### PR TITLE
Allow Claude to produce diff files directly when editing

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Claude Dev has access to the following capabilities:
 4. **`view_source_code_definitions_top_level`**: Parses all source code files at the top level of the specified directory to extract names of key elements like classes and functions (see more below)
 5. **`read_file`**: Read the contents of a file at the specified path
 6. **`write_to_file`**: Write content to a file at the specified path, automatically creating any necessary directories
+7. **`apply_diff`**: Apply a diff to file, more efficient that writing the whole content.
 7. **`ask_followup_question`**: Ask the user a question to gather additional information needed to complete a task (due to the autonomous nature of the program, this isn't a typical chatbot–Claude Dev must explicitly interrupt his task loop to ask for more information)
 8. **`attempt_completion`**: Present the result to the user after completing a task, potentially with a terminal command to kickoff a demonstration
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-dev",
-  "version": "1.1.15",
+  "version": "1.3.43",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-dev",
-      "version": "1.1.15",
+      "version": "1.3.43",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/bedrock-sdk": "^0.10.2",

--- a/src/shared/ExtensionMessage.ts
+++ b/src/shared/ExtensionMessage.ts
@@ -57,6 +57,7 @@ export type ClaudeSay =
 export interface ClaudeSayTool {
 	tool:
 		| "editedExistingFile"
+		| "appliedDiff"
 		| "newFileCreated"
 		| "readFile"
 		| "listFilesTopLevel"

--- a/src/shared/Tool.ts
+++ b/src/shared/Tool.ts
@@ -2,6 +2,7 @@ import { Anthropic } from "@anthropic-ai/sdk"
 
 export type ToolName =
 	| "write_to_file"
+	| "apply_diff"
 	| "read_file"
 	| "list_files_top_level"
 	| "list_files_recursive"

--- a/webview-ui/src/components/ChatRow.tsx
+++ b/webview-ui/src/components/ChatRow.tsx
@@ -350,11 +350,12 @@ const ChatRow: React.FC<ChatRowProps> = ({
 
 						switch (tool.tool) {
 							case "editedExistingFile":
+							case "appliedDiff":
 								return (
 									<>
 										<div style={headerStyle}>
 											{toolIcon("edit")}
-											<span style={{ fontWeight: "bold" }}>Claude wants to edit this file:</span>
+											<span style={{ fontWeight: "bold" }}>Claude wants to edit this file: {tool.tool}</span>
 										</div>
 										<CodeBlock
 											diff={tool.diff!}


### PR DESCRIPTION
Claude now responds with only the diff (when editing a file) and applies it, reducing token usage a lot.
The writeToFile is still there but its preferred when creating new files, while applyDiff when editing.