### PR TITLE
Make intro note at top of chat view closeable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-dev",
-  "version": "1.6.4",
+  "version": "1.6.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-dev",
-      "version": "1.6.4",
+      "version": "1.6.8",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/bedrock-sdk": "^0.10.2",

--- a/webview-ui/src/App.tsx
+++ b/webview-ui/src/App.tsx
@@ -1,5 +1,5 @@
-import { useCallback, useEffect, useState } from "react"
-import { useEvent } from "react-use"
+import { useCallback, useEffect } from "react"
+import { useEvent, useToggle } from "react-use"
 import { ExtensionMessage } from "../../src/shared/ExtensionMessage"
 import ChatView from "./components/ChatView"
 import HistoryView from "./components/HistoryView"
@@ -7,12 +7,14 @@ import SettingsView from "./components/SettingsView"
 import WelcomeView from "./components/WelcomeView"
 import { ExtensionStateContextProvider, useExtensionState } from "./context/ExtensionStateContext"
 import { vscode } from "./utils/vscode"
+import { useHideable } from "./hooks/useHideable"
 
 const AppContent = () => {
 	const { didHydrateState, showWelcome, shouldShowAnnouncement } = useExtensionState()
-	const [showSettings, setShowSettings] = useState(false)
-	const [showHistory, setShowHistory] = useState(false)
-	const [showAnnouncement, setShowAnnouncement] = useState(false)
+	const [showSettings, setShowSettings] = useToggle(false)
+	const [showHistory, setShowHistory] = useToggle(false)
+	const [isShowAnnouncement, hideAnnouncement, showAnnouncement] = useHideable(false)
+	const [isShowIntroNote, hideIntroNote] = useHideable(true)
 
 	const handleMessage = useCallback((e: MessageEvent) => {
 		const message: ExtensionMessage = e.data
@@ -34,16 +36,16 @@ const AppContent = () => {
 				}
 				break
 		}
-	}, [])
+	}, [setShowSettings, setShowHistory])
 
 	useEvent("message", handleMessage)
 
 	useEffect(() => {
 		if (shouldShowAnnouncement) {
-			setShowAnnouncement(true)
+			showAnnouncement()
 			vscode.postMessage({ type: "didShowAnnouncement" })
 		}
-	}, [shouldShowAnnouncement])
+	}, [shouldShowAnnouncement, showAnnouncement])
 
 	if (!didHydrateState) {
 		return null
@@ -64,10 +66,10 @@ const AppContent = () => {
 							setShowHistory(true)
 						}}
 						isHidden={showSettings || showHistory}
-						showAnnouncement={showAnnouncement}
-						hideAnnouncement={() => {
-							setShowAnnouncement(false)
-						}}
+						isShowAnnouncement={isShowAnnouncement}
+						hideAnnouncement={hideAnnouncement}
+						isShowIntroNote={isShowIntroNote}
+						hideIntroNote={hideIntroNote}
 					/>
 				</>
 			)}

--- a/webview-ui/src/components/Announcement.tsx
+++ b/webview-ui/src/components/Announcement.tsx
@@ -1,5 +1,6 @@
-import { VSCodeButton, VSCodeLink } from "@vscode/webview-ui-toolkit/react"
+import { VSCodeLink } from "@vscode/webview-ui-toolkit/react"
 import { memo } from "react"
+import CloseableNote from "./common/CloseableNote"
 // import VSCodeButtonLink from "./VSCodeButtonLink"
 // import { getOpenRouterAuthUrl } from "./ApiOptions"
 // import { vscode } from "../utils/vscode"
@@ -13,21 +14,7 @@ You must update the latestAnnouncementId in ClaudeDevProvider for new announceme
 */
 const Announcement = ({ version, hideAnnouncement }: AnnouncementProps) => {
 	return (
-		<div
-			style={{
-				backgroundColor: "var(--vscode-editor-inactiveSelectionBackground)",
-				borderRadius: "3px",
-				padding: "12px 16px",
-				margin: "5px 15px 5px 15px",
-				position: "relative",
-				flexShrink: 0,
-			}}>
-			<VSCodeButton
-				appearance="icon"
-				onClick={hideAnnouncement}
-				style={{ position: "absolute", top: "8px", right: "8px" }}>
-				<span className="codicon codicon-close"></span>
-			</VSCodeButton>
+		<CloseableNote onClose={hideAnnouncement} style={{ margin: '0px 20px 10px 20px' }}>
 			<h3 style={{ margin: "0 0 8px" }}>
 				🎉{"  "}New in v{version}
 			</h3>
@@ -40,7 +27,7 @@ const Announcement = ({ version, hideAnnouncement }: AnnouncementProps) => {
 				</VSCodeLink>
 			</p>
 			{/*<ul style={{ margin: "0 0 8px", paddingLeft: "12px" }}>
-				 <li>
+				<li>
 					OpenRouter now supports prompt caching! They also have much higher rate limits than other providers,
 					so I recommend trying them out.
 					<br />
@@ -92,7 +79,7 @@ const Announcement = ({ version, hideAnnouncement }: AnnouncementProps) => {
 					@sdrzn
 				</VSCodeLink>
 			</p>
-		</div>
+		</CloseableNote>
 	)
 }
 

--- a/webview-ui/src/components/ChatView.tsx
+++ b/webview-ui/src/components/ChatView.tsx
@@ -1,4 +1,4 @@
-import { VSCodeButton, VSCodeLink } from "@vscode/webview-ui-toolkit/react"
+import { VSCodeButton } from "@vscode/webview-ui-toolkit/react"
 import { KeyboardEvent, useCallback, useEffect, useMemo, useRef, useState } from "react"
 import DynamicTextArea from "react-textarea-autosize"
 import { useEvent, useMount } from "react-use"
@@ -15,17 +15,21 @@ import HistoryPreview from "./HistoryPreview"
 import TaskHeader from "./TaskHeader"
 import Thumbnails from "./Thumbnails"
 import { normalizeApiConfiguration } from "./ApiOptions"
+import IntroNote from "./IntroNote"
 
 interface ChatViewProps {
 	isHidden: boolean
-	showAnnouncement: boolean
+	isShowAnnouncement: boolean
 	hideAnnouncement: () => void
+	isShowIntroNote: boolean
+	hideIntroNote: () => void
 	showHistoryView: () => void
+
 }
 
 const MAX_IMAGES_PER_MESSAGE = 20 // Anthropic limits to 20 images
 
-const ChatView = ({ isHidden, showAnnouncement, hideAnnouncement, showHistoryView }: ChatViewProps) => {
+const ChatView = ({ isHidden, isShowAnnouncement, hideAnnouncement, isShowIntroNote, hideIntroNote, showHistoryView }: ChatViewProps) => {
 	const { version, claudeMessages: messages, taskHistory, apiConfiguration } = useExtensionState()
 
 	//const task = messages.length > 0 ? (messages[0].say === "task" ? messages[0] : undefined) : undefined) : undefined
@@ -521,21 +525,8 @@ const ChatView = ({ isHidden, showAnnouncement, hideAnnouncement, showHistoryVie
 						display: "flex",
 						flexDirection: "column",
 					}}>
-					{showAnnouncement && <Announcement version={version} hideAnnouncement={hideAnnouncement} />}
-					<div style={{ padding: "0 20px", flexShrink: 0 }}>
-						<h2>What can I do for you?</h2>
-						<p>
-							Thanks to{" "}
-							<VSCodeLink
-								href="https://www-cdn.anthropic.com/fed9cc193a14b84131812372d8d5857f8f304c52/Model_Card_Claude_3_Addendum.pdf"
-								style={{ display: "inline" }}>
-								Claude 3.5 Sonnet's agentic coding capabilities,
-							</VSCodeLink>{" "}
-							I can handle complex software development tasks step-by-step. With tools that let me create
-							& edit files, explore complex projects, and execute terminal commands (after you grant
-							permission), I can assist you in ways that go beyond simple code completion or tech support.
-						</p>
-					</div>
+					{isShowIntroNote && <IntroNote hideIntroNote={hideIntroNote} /> }
+					{isShowAnnouncement && <Announcement version={version} hideAnnouncement={hideAnnouncement} />}
 					{taskHistory.length > 0 && <HistoryPreview showHistoryView={showHistoryView} />}
 				</div>
 			)}

--- a/webview-ui/src/components/IntroNote.tsx
+++ b/webview-ui/src/components/IntroNote.tsx
@@ -1,0 +1,34 @@
+import { VSCodeLink } from "@vscode/webview-ui-toolkit/react"
+import CloseableNote from "./common/CloseableNote"
+
+type IntroNoteProps = {
+    hideIntroNote: () => void
+}
+
+const IntroNote = ({ hideIntroNote }: IntroNoteProps) => {
+    return (
+        <CloseableNote 
+            onClose={hideIntroNote}
+            style={{ 
+                flexShrink: 0,
+                margin: '20px 20px 10px 20px',
+                backgroundColor: 'color-mix(in srgb, var(--vscode-toolbar-hoverBackground) 65%, transparent)'
+            }}
+        >
+            <h2 style={{ margin: "0 0 8px" }}>What can I do for you?</h2>
+            <p>
+                Thanks to{" "}
+                <VSCodeLink
+                    href="https://www-cdn.anthropic.com/fed9cc193a14b84131812372d8d5857f8f304c52/Model_Card_Claude_3_Addendum.pdf"
+                    style={{ display: "inline" }}>
+                    Claude 3.5 Sonnet's agentic coding capabilities,
+                </VSCodeLink>{" "}
+                I can handle complex software development tasks step-by-step. With tools that let me create
+                & edit files, explore complex projects, and execute terminal commands (after you grant
+                permission), I can assist you in ways that go beyond simple code completion or tech support.
+            </p>
+        </CloseableNote>
+    )
+}
+
+export default IntroNote

--- a/webview-ui/src/components/common/CloseableNote.tsx
+++ b/webview-ui/src/components/common/CloseableNote.tsx
@@ -1,0 +1,31 @@
+import { VSCodeButton } from "@vscode/webview-ui-toolkit/react"
+
+type CloseableNoteProps = {
+    children: React.ReactNode
+    onClose: () => void
+    style?: React.CSSProperties
+}
+
+const CloseableNote = ({ children, onClose, style }: CloseableNoteProps) => {
+  return (
+    <div
+        style={{
+            backgroundColor: "var(--vscode-editor-inactiveSelectionBackground)",
+            borderRadius: "3px",
+            padding: "12px 12px",
+            position: "relative",
+            flexShrink: 0,
+            ...style,
+        }}>
+        <VSCodeButton
+            appearance="icon"
+            onClick={onClose}
+            style={{ position: "absolute", top: "8px", right: "8px" }}>
+            <span className="codicon codicon-close"></span>
+        </VSCodeButton>
+        {children}
+    </div>
+  )
+}
+
+export default CloseableNote

--- a/webview-ui/src/hooks/useHideable.ts
+++ b/webview-ui/src/hooks/useHideable.ts
@@ -1,0 +1,8 @@
+import { useToggle } from "react-use"
+
+export const useHideable = (defaultVisible: boolean = true) => {
+    const [visible, toggle] = useToggle(defaultVisible)
+    const hide = () => toggle(false)
+    const show = () => toggle(true)
+    return [ visible, hide, show ] as [boolean, () => void, () => void]
+}


### PR DESCRIPTION
This PR makes the intro note at the top closeable and shifts the announcement note below it. I've extracted out a common `CloseableNote` component.

Without announcement:

<img width="501" alt="image" src="https://github.com/user-attachments/assets/b589aef2-c4d0-49f9-93ba-f85c2e218d66">

With announcement:

<img width="499" alt="image" src="https://github.com/user-attachments/assets/fc72efbc-8028-451f-8a9c-cacebdb34fd7">

Both closed:

<img width="502" alt="image" src="https://github.com/user-attachments/assets/a021644f-2290-46b5-8a40-5eced9a05df6">
