### PR TITLE
Move alwaysAllowReadOnly into VS Code settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ node_modules
 *.vsix
 
 .DS_Store
+.tool-versions

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-dev",
-  "version": "2.0.0",
+  "version": "2.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-dev",
-      "version": "2.0.0",
+      "version": "2.0.6",
       "license": "Apache-2.0",
       "dependencies": {
         "@anthropic-ai/bedrock-sdk": "^0.10.2",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "claude-dev",
   "displayName": "Cline (prev. Claude Dev)",
   "description": "Autonomous coding agent right in your IDE, capable of creating/editing files, executing commands, and more with your permission every step of the way.",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "icon": "assets/icons/icon.png",
   "galleryBanner": {
     "color": "#556C80",
@@ -88,6 +88,11 @@
         "command": "cline.openInNewTab",
         "title": "Open In New Tab",
         "category": "Cline"
+      },
+      {
+        "command": "cline.openVSCodeSettings",
+        "title": "Open VSCode Settings",
+        "category": "Cline"
       }
     ],
     "menus": {
@@ -112,7 +117,23 @@
           "group": "navigation@4",
           "when": "view == claude-dev.SidebarProvider"
         }
+      ],
+      "commandPalette": [
+        {
+          "command": "cline.openVSCodeSettings",
+          "group": "Cline"
+        }
       ]
+    },
+    "configuration": {
+      "title": "Cline",
+      "properties": {
+        "cline.alwaysAllowReadOnly": {
+          "type": "boolean",
+          "default": false,
+          "description": "When enabled, Cline will automatically read files and view directories without requiring you to click the Allow button."
+        }
+      }
     }
   },
   "scripts": {

--- a/src/core/Cline.ts
+++ b/src/core/Cline.ts
@@ -57,7 +57,6 @@ export class Cline {
 	private urlContentFetcher: UrlContentFetcher
 	private didEditFile: boolean = false
 	customInstructions?: string
-	alwaysAllowReadOnly: boolean
 	apiConversationHistory: Anthropic.MessageParam[] = []
 	clineMessages: ClineMessage[] = []
 	private askResponse?: ClineAskResponse
@@ -84,7 +83,6 @@ export class Cline {
 		provider: ClineProvider,
 		apiConfiguration: ApiConfiguration,
 		customInstructions?: string,
-		alwaysAllowReadOnly?: boolean,
 		task?: string,
 		images?: string[],
 		historyItem?: HistoryItem
@@ -95,7 +93,6 @@ export class Cline {
 		this.urlContentFetcher = new UrlContentFetcher(provider.context)
 		this.diffViewProvider = new DiffViewProvider(cwd)
 		this.customInstructions = customInstructions
-		this.alwaysAllowReadOnly = alwaysAllowReadOnly ?? false
 
 		if (historyItem) {
 			this.taskId = historyItem.id
@@ -106,6 +103,10 @@ export class Cline {
 		} else {
 			throw new Error("Either historyItem or task/images must be provided")
 		}
+	}
+
+	private getAlwaysAllowReadOnly(): boolean {
+    return vscode.workspace.getConfiguration('cline').get('alwaysAllowReadOnly', false);
 	}
 
 	// Storing task to disk for history
@@ -1131,7 +1132,7 @@ export class Cline {
 									...sharedMessageProps,
 									content: undefined,
 								} satisfies ClineSayTool)
-								if (this.alwaysAllowReadOnly) {
+								if (this.getAlwaysAllowReadOnly()) {
 									await this.say("tool", partialMessage, undefined, block.partial)
 								} else {
 									await this.ask("tool", partialMessage, block.partial).catch(() => {})
@@ -1149,7 +1150,7 @@ export class Cline {
 									...sharedMessageProps,
 									content: absolutePath,
 								} satisfies ClineSayTool)
-								if (this.alwaysAllowReadOnly) {
+								if (this.getAlwaysAllowReadOnly()) {
 									await this.say("tool", completeMessage, undefined, false) // need to be sending partialValue bool, since undefined has its own purpose in that the message is treated neither as a partial or completion of a partial, but as a single complete message
 								} else {
 									const didApprove = await askApproval("tool", completeMessage)
@@ -1181,7 +1182,7 @@ export class Cline {
 									...sharedMessageProps,
 									content: "",
 								} satisfies ClineSayTool)
-								if (this.alwaysAllowReadOnly) {
+								if (this.getAlwaysAllowReadOnly()) {
 									await this.say("tool", partialMessage, undefined, block.partial)
 								} else {
 									await this.ask("tool", partialMessage, block.partial).catch(() => {})
@@ -1201,7 +1202,7 @@ export class Cline {
 									...sharedMessageProps,
 									content: result,
 								} satisfies ClineSayTool)
-								if (this.alwaysAllowReadOnly) {
+								if (this.getAlwaysAllowReadOnly()) {
 									await this.say("tool", completeMessage, undefined, false)
 								} else {
 									const didApprove = await askApproval("tool", completeMessage)
@@ -1229,7 +1230,7 @@ export class Cline {
 									...sharedMessageProps,
 									content: "",
 								} satisfies ClineSayTool)
-								if (this.alwaysAllowReadOnly) {
+								if (this.getAlwaysAllowReadOnly()) {
 									await this.say("tool", partialMessage, undefined, block.partial)
 								} else {
 									await this.ask("tool", partialMessage, block.partial).catch(() => {})
@@ -1250,7 +1251,7 @@ export class Cline {
 									...sharedMessageProps,
 									content: result,
 								} satisfies ClineSayTool)
-								if (this.alwaysAllowReadOnly) {
+								if (this.getAlwaysAllowReadOnly()) {
 									await this.say("tool", completeMessage, undefined, false)
 								} else {
 									const didApprove = await askApproval("tool", completeMessage)
@@ -1282,7 +1283,7 @@ export class Cline {
 									...sharedMessageProps,
 									content: "",
 								} satisfies ClineSayTool)
-								if (this.alwaysAllowReadOnly) {
+								if (this.getAlwaysAllowReadOnly()) {
 									await this.say("tool", partialMessage, undefined, block.partial)
 								} else {
 									await this.ask("tool", partialMessage, block.partial).catch(() => {})
@@ -1306,7 +1307,7 @@ export class Cline {
 									...sharedMessageProps,
 									content: results,
 								} satisfies ClineSayTool)
-								if (this.alwaysAllowReadOnly) {
+								if (this.getAlwaysAllowReadOnly()) {
 									await this.say("tool", completeMessage, undefined, false)
 								} else {
 									const didApprove = await askApproval("tool", completeMessage)
@@ -1331,7 +1332,7 @@ export class Cline {
 						try {
 							if (block.partial) {
 								const partialMessage = JSON.stringify(sharedMessageProps)
-								if (this.alwaysAllowReadOnly) {
+								if (this.getAlwaysAllowReadOnly()) {
 									await this.say("tool", partialMessage, undefined, block.partial)
 								} else {
 									await this.ask("tool", partialMessage, block.partial).catch(() => {})
@@ -1345,7 +1346,7 @@ export class Cline {
 								}
 								this.consecutiveMistakeCount = 0
 								const completeMessage = JSON.stringify(sharedMessageProps)
-								if (this.alwaysAllowReadOnly) {
+								if (this.getAlwaysAllowReadOnly()) {
 									await this.say("tool", completeMessage, undefined, false)
 								} else {
 									const didApprove = await askApproval("tool", completeMessage)

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -428,6 +428,9 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 					case "openMention":
 						openMention(message.text)
 						break
+					case "openVsCodeSettings":
+						vscode.commands.executeCommand('workbench.action.openSettings', 'cline')
+						break;
 					case "cancelTask":
 						if (this.cline) {
 							const { historyItem } = await this.getTaskWithId(this.cline.taskId)
@@ -708,7 +711,6 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 			version: this.context.extension?.packageJSON?.version ?? "",
 			apiConfiguration,
 			customInstructions,
-			alwaysAllowReadOnly: vscode.workspace.getConfiguration('cline').get('alwaysAllowReadOnly', false),
 			uriScheme: vscode.env.uriScheme,
 			clineMessages: this.cline?.clineMessages || [],
 			taskHistory: (taskHistory || []).filter((item) => item.ts && item.task).sort((a, b) => b.ts - a.ts),
@@ -792,7 +794,6 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 			openRouterModelInfo,
 			lastShownAnnouncementId,
 			customInstructions,
-			alwaysAllowReadOnly,
 			taskHistory,
 		] = await Promise.all([
 			this.getGlobalState("apiProvider") as Promise<ApiProvider | undefined>,
@@ -818,7 +819,6 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 			this.getGlobalState("openRouterModelInfo") as Promise<ModelInfo | undefined>,
 			this.getGlobalState("lastShownAnnouncementId") as Promise<string | undefined>,
 			this.getGlobalState("customInstructions") as Promise<string | undefined>,
-			vscode.workspace.getConfiguration('cline').get('alwaysAllowReadOnly', false),
 			this.getGlobalState("taskHistory") as Promise<HistoryItem[] | undefined>,
 		])
 
@@ -862,7 +862,6 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 			},
 			lastShownAnnouncementId,
 			customInstructions,
-			alwaysAllowReadOnly: alwaysAllowReadOnly ?? false,
 			taskHistory,
 		}
 	}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -92,6 +92,13 @@ export function activate(context: vscode.ExtensionContext) {
 		})
 	)
 
+	// New command to open VSCode settings
+	context.subscriptions.push(
+		vscode.commands.registerCommand("cline.openVSCodeSettings", () => {
+			vscode.commands.executeCommand("workbench.action.openSettings", "cline")
+		})
+	)
+
 	/*
 	We use the text document content provider API to show the left side for diff view by creating a virtual document for the original content. This makes it readonly so users know to edit the right side if they want to keep their changes.
 

--- a/src/shared/ExtensionMessage.ts
+++ b/src/shared/ExtensionMessage.ts
@@ -30,7 +30,6 @@ export interface ExtensionState {
 	version: string
 	apiConfiguration?: ApiConfiguration
 	customInstructions?: string
-	alwaysAllowReadOnly?: boolean
 	uriScheme?: string
 	clineMessages: ClineMessage[]
 	taskHistory: HistoryItem[]

--- a/src/shared/WebviewMessage.ts
+++ b/src/shared/WebviewMessage.ts
@@ -4,7 +4,6 @@ export interface WebviewMessage {
 	type:
 		| "apiConfiguration"
 		| "customInstructions"
-		| "alwaysAllowReadOnly"
 		| "webviewDidLaunch"
 		| "newTask"
 		| "askResponse"
@@ -20,6 +19,7 @@ export interface WebviewMessage {
 		| "openImage"
 		| "openFile"
 		| "openMention"
+		| "openVsCodeSettings"
 		| "cancelTask"
 		| "refreshOpenRouterModels"
 	text?: string

--- a/webview-ui/src/components/settings/SettingsView.tsx
+++ b/webview-ui/src/components/settings/SettingsView.tsx
@@ -1,4 +1,4 @@
-import { VSCodeButton, VSCodeCheckbox, VSCodeLink, VSCodeTextArea } from "@vscode/webview-ui-toolkit/react"
+import { VSCodeButton, VSCodeLink, VSCodeTextArea } from "@vscode/webview-ui-toolkit/react"
 import { memo, useEffect, useState } from "react"
 import { useExtensionState } from "../../context/ExtensionStateContext"
 import { validateApiConfiguration, validateModelId } from "../../utils/validate"
@@ -17,8 +17,6 @@ const SettingsView = ({ onDone }: SettingsViewProps) => {
 		version,
 		customInstructions,
 		setCustomInstructions,
-		alwaysAllowReadOnly,
-		setAlwaysAllowReadOnly,
 		openRouterModels,
 	} = useExtensionState()
 	const [apiErrorMessage, setApiErrorMessage] = useState<string | undefined>(undefined)
@@ -32,7 +30,6 @@ const SettingsView = ({ onDone }: SettingsViewProps) => {
 		if (!apiValidationResult && !modelIdValidationResult) {
 			vscode.postMessage({ type: "apiConfiguration", apiConfiguration })
 			vscode.postMessage({ type: "customInstructions", text: customInstructions })
-			vscode.postMessage({ type: "alwaysAllowReadOnly", bool: alwaysAllowReadOnly })
 			onDone()
 		}
 	}
@@ -56,6 +53,10 @@ const SettingsView = ({ onDone }: SettingsViewProps) => {
 
 	const handleResetState = () => {
 		vscode.postMessage({ type: "resetState" })
+	}
+
+	const openVSCodeSettings = () => {
+		vscode.postMessage({ type: "openVsCodeSettings" })
 	}
 
 	return (
@@ -114,19 +115,24 @@ const SettingsView = ({ onDone }: SettingsViewProps) => {
 				</div>
 
 				<div style={{ marginBottom: 5 }}>
-					<VSCodeCheckbox
-						checked={alwaysAllowReadOnly}
-						onChange={(e: any) => setAlwaysAllowReadOnly(e.target.checked)}>
-						<span style={{ fontWeight: "500" }}>Always allow read-only operations</span>
-					</VSCodeCheckbox>
+					<h4 style={{ color: "var(--vscode-foreground)", margin: 0 }}>Other Settings</h4>
 					<p
 						style={{
 							fontSize: "12px",
 							marginTop: "5px",
 							color: "var(--vscode-descriptionForeground)",
 						}}>
-						When enabled, Cline will automatically read files, view directories, and inspect sites without
-						requiring you to click the Allow button.
+						Modify via <VSCodeLink onClick={openVSCodeSettings}>VSCode Settings</VSCodeLink>.
+					</p>
+					<p
+						style={{
+							fontSize: "12px",
+							marginTop: "5px",
+							color: "var(--vscode-descriptionForeground)",
+						}}>
+						<span style={{ fontWeight: "bold" }}>AlwaysAllowReadOnly</span> - When enabled, Cline will
+						automatically read files, view directories, and inspect sites without requiring you to click the
+						Allow button.
 					</p>
 				</div>
 
@@ -142,7 +148,8 @@ const SettingsView = ({ onDone }: SettingsViewProps) => {
 								marginTop: "5px",
 								color: "var(--vscode-descriptionForeground)",
 							}}>
-							This will reset all global state and secret storage in the extension.
+							This will reset all global state and secret storage in the extension. It will not reset
+							anything stored in VS Code Settings.
 						</p>
 					</>
 				)}
@@ -162,6 +169,7 @@ const SettingsView = ({ onDone }: SettingsViewProps) => {
 							https://github.com/clinebot/cline
 						</VSCodeLink>
 					</p>
+
 					<p style={{ fontStyle: "italic", margin: "10px 0 0 0", padding: 0 }}>v{version}</p>
 				</div>
 			</div>

--- a/webview-ui/src/context/ExtensionStateContext.tsx
+++ b/webview-ui/src/context/ExtensionStateContext.tsx
@@ -19,7 +19,6 @@ interface ExtensionStateContextType extends ExtensionState {
 	filePaths: string[]
 	setApiConfiguration: (config: ApiConfiguration) => void
 	setCustomInstructions: (value?: string) => void
-	setAlwaysAllowReadOnly: (value: boolean) => void
 	setShowAnnouncement: (value: boolean) => void
 }
 
@@ -112,7 +111,6 @@ export const ExtensionStateContextProvider: React.FC<{ children: React.ReactNode
 		filePaths,
 		setApiConfiguration: (value) => setState((prevState) => ({ ...prevState, apiConfiguration: value })),
 		setCustomInstructions: (value) => setState((prevState) => ({ ...prevState, customInstructions: value })),
-		setAlwaysAllowReadOnly: (value) => setState((prevState) => ({ ...prevState, alwaysAllowReadOnly: value })),
 		setShowAnnouncement: (value) => setState((prevState) => ({ ...prevState, shouldShowAnnouncement: value })),
 	}
 


### PR DESCRIPTION
Move to using VSCode settings object for storing this attribute. That way it can be set differently for different projects and workspaces. This always makes the way for moving Custom Instructions into VS Code settings as well.

<img width="783" alt="image" src="https://github.com/user-attachments/assets/be60fabd-9779-419a-ad0a-6df553f65e94">

For the current settings panel, I've modified with a link and some text explanation so people will know where to look:
<img width="268" alt="image" src="https://github.com/user-attachments/assets/3e900833-bc13-4120-9f15-dea23fca953b">

Heavily inspired by https://github.com/clinebot/cline/pull/390 