### PR TITLE
Multi providers for "OpenAI Compatible"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-dev",
-  "version": "2.0.7",
+  "version": "2.0.19",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-dev",
-      "version": "2.0.7",
+      "version": "2.0.19",
       "license": "Apache-2.0",
       "dependencies": {
         "@anthropic-ai/bedrock-sdk": "^0.10.2",

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -28,6 +28,18 @@ export function buildApiHandler(configuration: ApiConfiguration): ApiHandler {
 			return new VertexHandler(options)
 		case "openai":
 			return new OpenAiHandler(options)
+		case "openai_alt_1":
+			options.openAiBaseUrl = options.openAiBaseUrl_1;
+			options.openAiApiKey = options.openAiApiKey_1;
+			options.openAiModelId = options.openAiModelId_1;
+			options.azureApiVersion = options.azureApiVersion_1;
+			return new OpenAiHandler(options)
+		case "openai_alt_2":
+			options.openAiBaseUrl = options.openAiBaseUrl_2;
+			options.openAiApiKey = options.openAiApiKey_2;
+			options.openAiModelId = options.openAiModelId_2;
+			options.azureApiVersion = options.azureApiVersion_2;
+			return new OpenAiHandler(options)
 		case "ollama":
 			return new OllamaHandler(options)
 		case "gemini":

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -34,6 +34,8 @@ type SecretKey =
 	| "awsSecretKey"
 	| "awsSessionToken"
 	| "openAiApiKey"
+	| "openAiApiKey_1"
+	| "openAiApiKey_2"
 	| "geminiApiKey"
 	| "openAiNativeApiKey"
 type GlobalStateKey =
@@ -48,10 +50,16 @@ type GlobalStateKey =
 	| "taskHistory"
 	| "openAiBaseUrl"
 	| "openAiModelId"
+	| "openAiBaseUrl_1"
+	| "openAiModelId_1"
+	| "openAiBaseUrl_2"
+	| "openAiModelId_2"
 	| "ollamaModelId"
 	| "ollamaBaseUrl"
 	| "anthropicBaseUrl"
 	| "azureApiVersion"
+	| "azureApiVersion_1"
+	| "azureApiVersion_2"
 	| "openRouterModelId"
 	| "openRouterModelInfo"
 
@@ -256,15 +264,15 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 
 		// Use a nonce to only allow a specific script to be run.
 		/*
-        content security policy of your webview to only allow scripts that have a specific nonce
-        create a content security policy meta tag so that only loading scripts with a nonce is allowed
-        As your extension grows you will likely want to add custom styles, fonts, and/or images to your webview. If you do, you will need to update the content security policy meta tag to explicity allow for these resources. E.g.
-                <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src ${webview.cspSource}; font-src ${webview.cspSource}; img-src ${webview.cspSource} https:; script-src 'nonce-${nonce}';">
+		content security policy of your webview to only allow scripts that have a specific nonce
+		create a content security policy meta tag so that only loading scripts with a nonce is allowed
+		As your extension grows you will likely want to add custom styles, fonts, and/or images to your webview. If you do, you will need to update the content security policy meta tag to explicity allow for these resources. E.g.
+				<meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src ${webview.cspSource}; font-src ${webview.cspSource}; img-src ${webview.cspSource} https:; script-src 'nonce-${nonce}';">
 		- 'unsafe-inline' is required for styles due to vscode-webview-toolkit's dynamic style injection
 		- since we pass base64 images to the webview, we need to specify img-src ${webview.cspSource} data:;
 
-        in meta tag we add nonce attribute: A cryptographic nonce (only used once) to allow scripts. The server must generate a unique nonce value each time it transmits a policy. It is critical to provide a nonce that cannot be guessed as bypassing a resource's policy is otherwise trivial.
-        */
+		in meta tag we add nonce attribute: A cryptographic nonce (only used once) to allow scripts. The server must generate a unique nonce value each time it transmits a policy. It is critical to provide a nonce that cannot be guessed as bypassing a resource's policy is otherwise trivial.
+		*/
 		const nonce = getNonce()
 
 		// Tip: Install the es6-string-html VS Code extension to enable code highlighting below
@@ -341,12 +349,20 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 								openAiBaseUrl,
 								openAiApiKey,
 								openAiModelId,
+								openAiBaseUrl_1,
+								openAiApiKey_1,
+								openAiModelId_1,
+								openAiBaseUrl_2,
+								openAiApiKey_2,
+								openAiModelId_2,
 								ollamaModelId,
 								ollamaBaseUrl,
 								anthropicBaseUrl,
 								geminiApiKey,
 								openAiNativeApiKey,
 								azureApiVersion,
+								azureApiVersion_1,
+								azureApiVersion_2,
 								openRouterModelId,
 								openRouterModelInfo,
 							} = message.apiConfiguration
@@ -363,12 +379,20 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 							await this.updateGlobalState("openAiBaseUrl", openAiBaseUrl)
 							await this.storeSecret("openAiApiKey", openAiApiKey)
 							await this.updateGlobalState("openAiModelId", openAiModelId)
+							await this.updateGlobalState("openAiBaseUrl_1", openAiBaseUrl_1)
+							await this.storeSecret("openAiApiKey_1", openAiApiKey_1)
+							await this.updateGlobalState("openAiModelId_1", openAiModelId_1)
+							await this.updateGlobalState("openAiBaseUrl_2", openAiBaseUrl_2)
+							await this.storeSecret("openAiApiKey_2", openAiApiKey_2)
+							await this.updateGlobalState("openAiModelId_2", openAiModelId_2)
 							await this.updateGlobalState("ollamaModelId", ollamaModelId)
 							await this.updateGlobalState("ollamaBaseUrl", ollamaBaseUrl)
 							await this.updateGlobalState("anthropicBaseUrl", anthropicBaseUrl)
 							await this.storeSecret("geminiApiKey", geminiApiKey)
 							await this.storeSecret("openAiNativeApiKey", openAiNativeApiKey)
 							await this.updateGlobalState("azureApiVersion", azureApiVersion)
+							await this.updateGlobalState("azureApiVersion_1", azureApiVersion_1)
+							await this.updateGlobalState("azureApiVersion_2", azureApiVersion_2)
 							await this.updateGlobalState("openRouterModelId", openRouterModelId)
 							await this.updateGlobalState("openRouterModelInfo", openRouterModelInfo)
 							if (this.cline) {
@@ -796,12 +820,20 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 			openAiBaseUrl,
 			openAiApiKey,
 			openAiModelId,
+			openAiBaseUrl_1,
+			openAiApiKey_1,
+			openAiModelId_1,
+			openAiBaseUrl_2,
+			openAiApiKey_2,
+			openAiModelId_2,
 			ollamaModelId,
 			ollamaBaseUrl,
 			anthropicBaseUrl,
 			geminiApiKey,
 			openAiNativeApiKey,
 			azureApiVersion,
+			azureApiVersion_1,
+			azureApiVersion_2,
 			openRouterModelId,
 			openRouterModelInfo,
 			lastShownAnnouncementId,
@@ -822,12 +854,20 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 			this.getGlobalState("openAiBaseUrl") as Promise<string | undefined>,
 			this.getSecret("openAiApiKey") as Promise<string | undefined>,
 			this.getGlobalState("openAiModelId") as Promise<string | undefined>,
+			this.getGlobalState("openAiBaseUrl_1") as Promise<string | undefined>,
+			this.getSecret("openAiApiKey_1") as Promise<string | undefined>,
+			this.getGlobalState("openAiModelId_1") as Promise<string | undefined>,
+			this.getGlobalState("openAiBaseUrl_2") as Promise<string | undefined>,
+			this.getSecret("openAiApiKey_2") as Promise<string | undefined>,
+			this.getGlobalState("openAiModelId_2") as Promise<string | undefined>,
 			this.getGlobalState("ollamaModelId") as Promise<string | undefined>,
 			this.getGlobalState("ollamaBaseUrl") as Promise<string | undefined>,
 			this.getGlobalState("anthropicBaseUrl") as Promise<string | undefined>,
 			this.getSecret("geminiApiKey") as Promise<string | undefined>,
 			this.getSecret("openAiNativeApiKey") as Promise<string | undefined>,
 			this.getGlobalState("azureApiVersion") as Promise<string | undefined>,
+			this.getGlobalState("azureApiVersion_1") as Promise<string | undefined>,
+			this.getGlobalState("azureApiVersion_2") as Promise<string | undefined>,
 			this.getGlobalState("openRouterModelId") as Promise<string | undefined>,
 			this.getGlobalState("openRouterModelInfo") as Promise<ModelInfo | undefined>,
 			this.getGlobalState("lastShownAnnouncementId") as Promise<string | undefined>,
@@ -865,12 +905,20 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 				openAiBaseUrl,
 				openAiApiKey,
 				openAiModelId,
+				openAiBaseUrl_1,
+				openAiApiKey_1,
+				openAiModelId_1,
+				openAiBaseUrl_2,
+				openAiApiKey_2,
+				openAiModelId_2,
 				ollamaModelId,
 				ollamaBaseUrl,
 				anthropicBaseUrl,
 				geminiApiKey,
 				openAiNativeApiKey,
 				azureApiVersion,
+				azureApiVersion_1,
+				azureApiVersion_2,
 				openRouterModelId,
 				openRouterModelInfo,
 			},
@@ -951,6 +999,8 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 			"awsSecretKey",
 			"awsSessionToken",
 			"openAiApiKey",
+			"openAiApiKey_1",
+			"openAiApiKey_2",
 			"geminiApiKey",
 			"openAiNativeApiKey",
 		]

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -4,6 +4,8 @@ export type ApiProvider =
 	| "bedrock"
 	| "vertex"
 	| "openai"
+	| "openai_alt_1"
+	| "openai_alt_2"
 	| "ollama"
 	| "gemini"
 	| "openai-native"
@@ -24,11 +26,19 @@ export interface ApiHandlerOptions {
 	openAiBaseUrl?: string
 	openAiApiKey?: string
 	openAiModelId?: string
+	openAiBaseUrl_1?: string
+	openAiApiKey_1?: string
+	openAiModelId_1?: string
+	openAiBaseUrl_2?: string
+	openAiApiKey_2?: string
+	openAiModelId_2?: string
 	ollamaModelId?: string
 	ollamaBaseUrl?: string
 	geminiApiKey?: string
 	openAiNativeApiKey?: string
 	azureApiVersion?: string
+	azureApiVersion_1?: string
+	azureApiVersion_2?: string
 }
 
 export type ApiConfiguration = ApiHandlerOptions & {

--- a/webview-ui/src/components/settings/ApiOptions.tsx
+++ b/webview-ui/src/components/settings/ApiOptions.tsx
@@ -47,6 +47,8 @@ const ApiOptions = ({ showModelOptions, apiErrorMessage, modelIdErrorMessage }: 
 	const [ollamaModels, setOllamaModels] = useState<string[]>([])
 	const [anthropicBaseUrlSelected, setAnthropicBaseUrlSelected] = useState(!!apiConfiguration?.anthropicBaseUrl)
 	const [azureApiVersionSelected, setAzureApiVersionSelected] = useState(!!apiConfiguration?.azureApiVersion)
+	const [azureApiVersionSelected_1, setAzureApiVersionSelected_1] = useState(!!apiConfiguration?.azureApiVersion_1)
+	const [azureApiVersionSelected_2, setAzureApiVersionSelected_2] = useState(!!apiConfiguration?.azureApiVersion_2)
 	const [isDescriptionExpanded, setIsDescriptionExpanded] = useState(false)
 
 	const handleInputChange = (field: keyof ApiConfiguration) => (event: any) => {
@@ -110,6 +112,12 @@ const ApiOptions = ({ showModelOptions, apiErrorMessage, modelIdErrorMessage }: 
 		)
 	}
 
+	const openAiSlots = [
+		"openai",
+		"openai_alt_1",
+		"openai_alt_2"
+	];
+
 	return (
 		<div style={{ display: "flex", flexDirection: "column", gap: 5 }}>
 			<div className="dropdown-container">
@@ -120,7 +128,7 @@ const ApiOptions = ({ showModelOptions, apiErrorMessage, modelIdErrorMessage }: 
 					id="api-provider"
 					value={selectedProvider}
 					onChange={handleInputChange("apiProvider")}
-					style={{ minWidth: 130, position: "relative", zIndex: OPENROUTER_MODEL_PICKER_Z_INDEX + 1 }}>
+					style={{ minWidth: 200, position: "relative", zIndex: OPENROUTER_MODEL_PICKER_Z_INDEX + 1 }}>
 					<VSCodeOption value="openrouter">OpenRouter</VSCodeOption>
 					<VSCodeOption value="anthropic">Anthropic</VSCodeOption>
 					<VSCodeOption value="gemini">Google Gemini</VSCodeOption>
@@ -128,6 +136,8 @@ const ApiOptions = ({ showModelOptions, apiErrorMessage, modelIdErrorMessage }: 
 					<VSCodeOption value="bedrock">AWS Bedrock</VSCodeOption>
 					<VSCodeOption value="openai-native">OpenAI</VSCodeOption>
 					<VSCodeOption value="openai">OpenAI Compatible</VSCodeOption>
+					<VSCodeOption value="openai_alt_1">OpenAI Compatible (alt. 1)</VSCodeOption>
+					<VSCodeOption value="openai_alt_2">OpenAI Compatible (alt. 2)</VSCodeOption>
 					<VSCodeOption value="ollama">Ollama</VSCodeOption>
 				</VSCodeDropdown>
 			</div>
@@ -395,63 +405,96 @@ const ApiOptions = ({ showModelOptions, apiErrorMessage, modelIdErrorMessage }: 
 				</div>
 			)}
 
-			{selectedProvider === "openai" && (
-				<div>
-					<VSCodeTextField
-						value={apiConfiguration?.openAiBaseUrl || ""}
-						style={{ width: "100%" }}
-						type="url"
-						onInput={handleInputChange("openAiBaseUrl")}
-						placeholder={"Enter base URL..."}>
-						<span style={{ fontWeight: 500 }}>Base URL</span>
-					</VSCodeTextField>
-					<VSCodeTextField
-						value={apiConfiguration?.openAiApiKey || ""}
-						style={{ width: "100%" }}
-						type="password"
-						onInput={handleInputChange("openAiApiKey")}
-						placeholder="Enter API Key...">
-						<span style={{ fontWeight: 500 }}>API Key</span>
-					</VSCodeTextField>
-					<VSCodeTextField
-						value={apiConfiguration?.openAiModelId || ""}
-						style={{ width: "100%" }}
-						onInput={handleInputChange("openAiModelId")}
-						placeholder={"Enter Model ID..."}>
-						<span style={{ fontWeight: 500 }}>Model ID</span>
-					</VSCodeTextField>
-					<VSCodeCheckbox
-						checked={azureApiVersionSelected}
-						onChange={(e: any) => {
-							const isChecked = e.target.checked === true
-							setAzureApiVersionSelected(isChecked)
-							if (!isChecked) {
-								setApiConfiguration({ ...apiConfiguration, azureApiVersion: "" })
-							}
-						}}>
-						Set Azure API version
-					</VSCodeCheckbox>
-					{azureApiVersionSelected && (
-						<VSCodeTextField
-							value={apiConfiguration?.azureApiVersion || ""}
-							style={{ width: "100%", marginTop: 3 }}
-							onInput={handleInputChange("azureApiVersion")}
-							placeholder={`Default: ${azureOpenAiDefaultApiVersion}`}
-						/>
-					)}
-					<p
-						style={{
-							fontSize: "12px",
-							marginTop: 3,
-							color: "var(--vscode-descriptionForeground)",
-						}}>
-						<span style={{ color: "var(--vscode-errorForeground)" }}>
-							(<span style={{ fontWeight: 500 }}>Note:</span> Cline uses complex prompts and works best
-							with Claude models. Less capable models may not work as expected.)
-						</span>
-					</p>
-				</div>
+
+			{openAiSlots.map((key) => {
+				let baseUrl: keyof ApiConfiguration = "openAiBaseUrl";
+				let openAiApiKey: keyof ApiConfiguration = "openAiApiKey";
+				let openAiModelId: keyof ApiConfiguration = "openAiModelId";
+				let azureApiVersionToUse: keyof ApiConfiguration = "azureApiVersion";
+				let azureApiVersionState = azureApiVersionSelected;
+				let setAzureApiVersion = setAzureApiVersionSelected;
+				switch (key) {
+					case "openai_alt_1":
+						baseUrl = "openAiBaseUrl_1";
+						openAiApiKey = "openAiApiKey_1";
+						openAiModelId = "openAiModelId_1";
+						azureApiVersionToUse = "azureApiVersion_1";
+						azureApiVersionState = azureApiVersionSelected_1;
+						setAzureApiVersion = setAzureApiVersionSelected_1;
+						break;
+					case "openai_alt_2":
+						baseUrl = "openAiBaseUrl_2";
+						openAiApiKey = "openAiApiKey_2";
+						openAiModelId = "openAiModelId_2";
+						azureApiVersionToUse = "azureApiVersion_2";
+						azureApiVersionState = azureApiVersionSelected_2;
+						setAzureApiVersion = setAzureApiVersionSelected_2;
+						break;
+				}
+
+				return (
+					selectedProvider === key && (
+						<div>
+							<VSCodeTextField
+								value={apiConfiguration?.[baseUrl] || ""}
+								style={{ width: "100%" }}
+								type="url"
+								onInput={handleInputChange(baseUrl)}
+								placeholder={"Enter base URL..."}>
+								<span style={{ fontWeight: 500 }}>Base URL</span>
+							</VSCodeTextField>
+							<VSCodeTextField
+								value={apiConfiguration?.[openAiApiKey] || ""}
+								style={{ width: "100%" }}
+								type="password"
+								onInput={handleInputChange(openAiApiKey)}
+								placeholder="Enter API Key...">
+								<span style={{ fontWeight: 500 }}>API Key</span>
+							</VSCodeTextField>
+							<VSCodeTextField
+								value={apiConfiguration?.[openAiModelId] || ""}
+								style={{ width: "100%" }}
+								onInput={handleInputChange(openAiModelId)}
+								placeholder={"Enter Model ID..."}>
+								<span style={{ fontWeight: 500 }}>Model ID</span>
+							</VSCodeTextField>
+							<VSCodeCheckbox
+								checked={azureApiVersionState}
+								onChange={(e: any) => {
+									const isChecked = e.target.checked === true
+									setAzureApiVersion(isChecked)
+									if (!isChecked) {
+										setApiConfiguration({ ...apiConfiguration, [azureApiVersionToUse]: "" })
+									}
+								}}>
+								Set Azure API version
+							</VSCodeCheckbox>
+							{azureApiVersionState && (
+								<VSCodeTextField
+									value={apiConfiguration?.[azureApiVersionToUse] || ""}
+									style={{ width: "100%", marginTop: 3 }}
+									onInput={handleInputChange(azureApiVersionToUse)}
+									placeholder={`Default: ${azureOpenAiDefaultApiVersion}`}
+								/>
+							)}
+							<p
+								style={{
+									fontSize: "12px",
+									marginTop: 3,
+									color: "var(--vscode-descriptionForeground)",
+								}}>
+								<span style={{ color: "var(--vscode-errorForeground)" }}>
+									(<span style={{ fontWeight: 500 }}>Note:</span> Cline uses complex prompts and works best
+									with Claude models. Less capable models may not work as expected.)
+								</span>
+							</p>
+						</div>
+					)
+				);
+			}
 			)}
+
+
 
 			{selectedProvider === "ollama" && (
 				<div>
@@ -531,7 +574,7 @@ const ApiOptions = ({ showModelOptions, apiErrorMessage, modelIdErrorMessage }: 
 			{selectedProvider === "openrouter" && showModelOptions && <OpenRouterModelPicker />}
 
 			{selectedProvider !== "openrouter" &&
-				selectedProvider !== "openai" &&
+				!openAiSlots.includes(selectedProvider) &&
 				selectedProvider !== "ollama" &&
 				showModelOptions && (
 					<>
@@ -734,6 +777,18 @@ export function normalizeApiConfiguration(apiConfiguration?: ApiConfiguration) {
 			return {
 				selectedProvider: provider,
 				selectedModelId: apiConfiguration?.openAiModelId || "",
+				selectedModelInfo: openAiModelInfoSaneDefaults,
+			}
+		case "openai_alt_1":
+			return {
+				selectedProvider: provider,
+				selectedModelId: apiConfiguration?.openAiModelId_1 || "",
+				selectedModelInfo: openAiModelInfoSaneDefaults,
+			}
+		case "openai_alt_2":
+			return {
+				selectedProvider: provider,
+				selectedModelId: apiConfiguration?.openAiModelId_2 || "",
 				selectedModelInfo: openAiModelInfoSaneDefaults,
 			}
 		case "ollama":

--- a/webview-ui/src/context/ExtensionStateContext.tsx
+++ b/webview-ui/src/context/ExtensionStateContext.tsx
@@ -48,15 +48,17 @@ export const ExtensionStateContextProvider: React.FC<{ children: React.ReactNode
 				const config = message.state?.apiConfiguration
 				const hasKey = config
 					? [
-							config.apiKey,
-							config.openRouterApiKey,
-							config.awsRegion,
-							config.vertexProjectId,
-							config.openAiApiKey,
-							config.ollamaModelId,
-							config.geminiApiKey,
-							config.openAiNativeApiKey,
-					  ].some((key) => key !== undefined)
+						config.apiKey,
+						config.openRouterApiKey,
+						config.awsRegion,
+						config.vertexProjectId,
+						config.openAiApiKey,
+						config.openAiApiKey_1,
+						config.openAiApiKey_2,
+						config.ollamaModelId,
+						config.geminiApiKey,
+						config.openAiNativeApiKey,
+					].some((key) => key !== undefined)
 					: false
 				setShowWelcome(!hasKey)
 				setDidHydrateState(true)

--- a/webview-ui/src/utils/validate.ts
+++ b/webview-ui/src/utils/validate.ts
@@ -42,6 +42,24 @@ export function validateApiConfiguration(apiConfiguration?: ApiConfiguration): s
 					return "You must provide a valid base URL, API key, and model ID."
 				}
 				break
+			case "openai_alt_1":
+				if (
+					!apiConfiguration.openAiBaseUrl_1 ||
+					!apiConfiguration.openAiApiKey_1 ||
+					!apiConfiguration.openAiModelId_1
+				) {
+					return "You must provide a valid base URL, API key, and model ID."
+				}
+				break
+			case "openai_alt_2":
+				if (
+					!apiConfiguration.openAiBaseUrl_2 ||
+					!apiConfiguration.openAiApiKey_2 ||
+					!apiConfiguration.openAiModelId_2
+				) {
+					return "You must provide a valid base URL, API key, and model ID."
+				}
+				break
 			case "ollama":
 				if (!apiConfiguration.ollamaModelId) {
 					return "You must provide a valid model ID."


### PR DESCRIPTION
Feature request: https://github.com/cline/cline/discussions/386

Now, there are 3 entries for "OpenAI Compatible" in the settings:
- OpenAI Compatible
- OpenAI Compatible (alt. 1)
- OpenAI Compatible (alt. 2)

We can now save up to 3 configs of different providers.
