### PR TITLE
Add configurable viewport settings for screenshots

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,25 @@
   "activationEvents": [],
   "main": "./dist/extension.js",
   "contributes": {
+    "configuration": {
+      "title": "Cline",
+      "properties": {
+        "cline.viewport.width": {
+          "type": "number",
+          "default": 1280,
+          "minimum": 320,
+          "maximum": 7680,
+          "description": "Width of the browser viewport for screenshots (in pixels)"
+        },
+        "cline.viewport.height": {
+          "type": "number",
+          "default": 720,
+          "minimum": 240,
+          "maximum": 4320,
+          "description": "Height of the browser viewport for screenshots (in pixels)"
+        }
+      }
+    },
     "viewsContainers": {
       "activitybar": [
         {

--- a/src/services/browser/UrlContentFetcher.ts
+++ b/src/services/browser/UrlContentFetcher.ts
@@ -50,6 +50,10 @@ export class UrlContentFetcher {
 			return
 		}
 		const stats = await this.ensureChromiumExists()
+		const config = vscode.workspace.getConfiguration('cline')
+		const viewportWidth = config.get<number>('viewport.width') || 1280
+		const viewportHeight = config.get<number>('viewport.height') || 720
+
 		this.browser = await stats.puppeteer.launch({
 			args: [
 				"--user-agent=Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/128.0.0.0 Safari/537.36",
@@ -58,6 +62,10 @@ export class UrlContentFetcher {
 		})
 		// (latest version of puppeteer does not add headless to user agent)
 		this.page = await this.browser?.newPage()
+		await this.page?.setViewport({
+			width: viewportWidth,
+			height: viewportHeight,
+		})
 	}
 
 	async closeBrowser(): Promise<void> {


### PR DESCRIPTION
Add VS Code configuration options to customize the browser viewport size used for taking screenshots. This allows users to capture screenshots at their preferred resolution.

- Add cline.viewport.width and cline.viewport.height settings
- Update UrlContentFetcher to read viewport settings from VS Code config
- Set reasonable defaults (1280x720) and limits for viewport dimensions
- Maintain 8000px maximum height limit for screenshots

The viewport settings can be adjusted through VS Code's settings UI under Extensions > Cline.