### PR TITLE
Make change "at cursor" (@cursor) or "within selection" (@selection)

### DIFF
--- a/src/core/Cline.ts
+++ b/src/core/Cline.ts
@@ -42,7 +42,6 @@ import { addCustomInstructions, SYSTEM_PROMPT } from "./prompts/system"
 import { truncateHalfConversation } from "./sliding-window"
 import { ClineProvider, GlobalFileNames } from "./webview/ClineProvider"
 import { showOmissionWarning } from "../integrations/editor/detect-omission"
-import { first } from "puppeteer-core/lib/esm/third_party/rxjs/rxjs.js"
 
 const cwd =
 	vscode.workspace.workspaceFolders?.map((folder) => folder.uri.fsPath).at(0) ?? path.join(os.homedir(), "Desktop") // may or may not exist but fs checking existence would immediately ask for permission which would be bad UX, need to come up with a better solution


### PR DESCRIPTION
Feature request: https://github.com/cline/cline/discussions/473

# Feature
This PR add 2 new keywords to use in the prompt:
- `@cursor`: when used, the code generated by the prompt should be added at the cursor current position in the current file opened in editor.
- `@selection`: when used, the code generated by the prompt should replace the code in current selection in the current file opened in editor.
In both cases, the rest of the file should not be modified.

# Exemples
## `@cursor`
```
@cursor add a new paragraph that says "hello"
```
This should create a new paragraph exactly at the cursor position .

## `@selection`
Select a whole function in the current file
```
@position add a parameter "max_items" and limit the behavior of the function regarding.
```
This update only the selected function with a new parameter "max_item" and change the code accordingly.

# Additional info
When `@selection` is used and there is no selection in the code, fall back to `@cursor`.