### PR TITLE
fix(bedrock): add missing sonnet model to bedrock, fixes #632

### DIFF
--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -115,6 +115,14 @@ export const bedrockModels = {
 		inputPrice: 15.0,
 		outputPrice: 75.0,
 	},
+	"anthropic.claude-3-sonnet-20240229-v1:0": {
+		maxTokens: 4096,
+		contextWindow: 200_000,
+		supportsImages: true,
+		supportsPromptCache: false,
+		inputPrice: 3.0,
+		outputPrice: 15.0,
+	},
 	"anthropic.claude-3-haiku-20240307-v1:0": {
 		maxTokens: 4096,
 		contextWindow: 200_000,


### PR DESCRIPTION
- Add missing sonnet 3 model to bedrock (this is the "best" available model in the ap-southeast-2 region)

Fixes https://github.com/cline/cline/issues/632