### PR TITLE
Add HTML entity replacing for \&amp; and \&apos; 

### DIFF
--- a/src/core/Cline.ts
+++ b/src/core/Cline.ts
@@ -1036,12 +1036,16 @@ export class Cline {
 						if (
 							newContent.includes("&gt;") ||
 							newContent.includes("&lt;") ||
-							newContent.includes("&quot;")
+							newContent.includes("&quot;") ||
+							newContent.includes("&amp;") ||
+							newContent.includes("&apos;")
 						) {
 							newContent = newContent
 								.replace(/&gt;/g, ">")
 								.replace(/&lt;/g, "<")
 								.replace(/&quot;/g, '"')
+								.replace(/&amp;/g, "&")
+								.replace(/&apos;/g, "'")
 						}
 
 						const sharedMessageProps: ClineSayTool = {

--- a/src/core/Cline.ts
+++ b/src/core/Cline.ts
@@ -1493,8 +1493,11 @@ export class Cline {
 						}
 					}
 					case "execute_command": {
-						const command: string | undefined = block.params.command
+						let command: string | undefined = block.params.command
+
 						try {
+
+
 							if (block.partial) {
 								await this.ask("command", removeClosingTag("command", command), block.partial).catch(
 									() => {}
@@ -1512,6 +1515,20 @@ export class Cline {
 								const didApprove = await askApproval("command", command)
 								if (!didApprove) {
 									break
+								}
+								if (
+									command.includes("&gt;") ||
+									command.includes("&lt;") ||
+									command.includes("&quot;") ||
+									command.includes("&amp;") ||
+									command.includes("&apos;")
+								) {
+									command = command
+										.replace(/&gt;/g, ">")
+										.replace(/&lt;/g, "<")
+										.replace(/&quot;/g, '"')
+										.replace(/&amp;/g, "&")
+										.replace(/&apos;/g, "'")
 								}
 								const [userRejected, result] = await this.executeCommandTool(command)
 								if (userRejected) {


### PR DESCRIPTION
It is observed that the character '&' is output by other LLMs as HTML entity ("&\amp;"), just like '\&lt;' and '\&gt;'. e.g. [here](https://discord.com/channels/1275535550845292637/1275535550845292640/1300811706850738307) and [here](https://github.com/cline/cline/issues/611)

This commit is to add "\&amp;" and possibily "\&apos;" (since \&quot; is there) to the workaround list.
