### PR TITLE
Don't scroll the editor window while changes are streaming

### DIFF
--- a/src/integrations/editor/DiffViewProvider.ts
+++ b/src/integrations/editor/DiffViewProvider.ts
@@ -306,13 +306,26 @@ export class DiffViewProvider {
 	}
 
 	private scrollEditorToLine(line: number) {
-		if (this.activeDiffEditor) {
+		if (this.activeDiffEditor && this.isScrolledToBottom()) {
 			const scrollLine = line + 4
 			this.activeDiffEditor.revealRange(
 				new vscode.Range(scrollLine, 0, scrollLine, 0),
 				vscode.TextEditorRevealType.InCenter
 			)
 		}
+	}
+
+	private isScrolledToBottom(): boolean {
+		if (!this.activeDiffEditor) {
+			return false
+		}
+		const visibleRanges = this.activeDiffEditor.visibleRanges
+		if (visibleRanges.length === 0) {
+			return false
+		}
+		const lastVisibleRange = visibleRanges[visibleRanges.length - 1]
+		const lastLine = this.activeDiffEditor.document.lineCount - 1
+		return lastVisibleRange.end.line >= lastLine
 	}
 
 	scrollToFirstDiff() {


### PR DESCRIPTION
NEEDS TESTING

Update `scrollEditorToLine` to preserve scroll position if not at the bottom.

* Add `isScrolledToBottom` method to check if the editor is scrolled to the bottom.
* Modify `scrollEditorToLine` to check if the user is scrolled to the bottom before scrolling.
* Ensure the user's scroll position is preserved if they are not at the bottom of the file.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/cline/cline?shareId=3386457c-f9e1-46fa-a19f-0e61fc365440).