### PR TITLE
Fix Prompt Caching for Anthropic Models in OpenRouter

### DIFF
--- a/src/api/providers/openrouter.ts
+++ b/src/api/providers/openrouter.ts
@@ -63,11 +63,6 @@ export class OpenRouterHandler implements ApiHandler {
 		this.isAnthropicModel = ANTHROPIC_MODELS.includes(options.openRouterModelId || openRouterDefaultModelId)
 		this.cacheBreakpointsUsed = 0
 
-		console.log("[OpenRouter] Initializing handler:", {
-			model: options.openRouterModelId || openRouterDefaultModelId,
-			isAnthropicModel: this.isAnthropicModel
-		})
-
 		const defaultHeaders: Record<string, string> = {
 			"HTTP-Referer": "https://cline.bot",
 			"X-Title": "Cline"
@@ -75,7 +70,6 @@ export class OpenRouterHandler implements ApiHandler {
 
 		if (this.isAnthropicModel) {
 			defaultHeaders["anthropic-beta"] = "prompt-caching-2024-07-31"
-			console.log("[OpenRouter] Added Anthropic beta header for caching")
 		}
 
 		this.client = new OpenAI({
@@ -92,11 +86,6 @@ export class OpenRouterHandler implements ApiHandler {
 	}
 
 	private convertToOpenRouterMessage(msg: OpenAI.Chat.ChatCompletionMessageParam): OpenRouterMessage {
-		console.log("[OpenRouter] Converting message:", {
-			role: msg.role,
-			contentType: typeof msg.content,
-			hasArray: Array.isArray(msg.content)
-		})
 
 		const role = msg.role as OpenRouterMessage["role"]
 		let content: OpenRouterMessage["content"]
@@ -109,18 +98,9 @@ export class OpenRouterHandler implements ApiHandler {
 					cache_control: { type: "ephemeral" }
 				}]
 				this.cacheBreakpointsUsed++
-				console.log("[OpenRouter] Added cache breakpoint:", {
-					textLength: msg.content.length,
-					breakpointsUsed: this.cacheBreakpointsUsed
-				})
 			} else {
 				content = msg.content
 			}
-			console.log("[OpenRouter] Converted string content:", {
-				original: msg.content.substring(0, 100) + "...",
-				transformed: typeof content === "string" ? content.substring(0, 100) + "..." : "array",
-				cached: Array.isArray(content)
-			})
 		} else if (Array.isArray(msg.content)) {
 			content = msg.content.map(part => {
 				if ("text" in part) {
@@ -132,51 +112,34 @@ export class OpenRouterHandler implements ApiHandler {
 					} as OpenRouterTextContent
 					if (shouldCacheThis) {
 						this.cacheBreakpointsUsed++
-						console.log("[OpenRouter] Added cache breakpoint:", {
-							textLength: part.text.length,
-							breakpointsUsed: this.cacheBreakpointsUsed
-						})
 					}
 					return transformed
 				} else if ("image_url" in part) {
-					console.log("[OpenRouter] Found image part")
 					return {
 						type: "image_url",
 						image_url: part.image_url
 					} as OpenRouterImageContent
 				}
-				console.warn("[OpenRouter] Unsupported content part:", part)
 				throw new Error(`Unsupported content part type: ${JSON.stringify(part)}`)
 			})
 		} else {
 			content = ""
-			console.log("[OpenRouter] Empty content")
 		}
 
 		const message: OpenRouterMessage = { role, content }
 
 		if ("name" in msg && msg.name) {
 			message.name = msg.name
-			console.log("[OpenRouter] Added name to message:", msg.name)
 		}
 
 		if (msg.role === "assistant" && "function_call" in msg && msg.function_call) {
 			message.function_call = msg.function_call
-			console.log("[OpenRouter] Added function call to message:", {
-				name: msg.function_call.name,
-				argsLength: msg.function_call.arguments?.length
-			})
 		}
 
 		return message
 	}
 
 	async *createMessage(systemPrompt: string, messages: Anthropic.Messages.MessageParam[]): ApiStream {
-		console.log("[OpenRouter] Creating message:", {
-			systemPromptLength: systemPrompt.length,
-			messagesCount: messages.length,
-			model: this.getModel().id
-		})
 
 		// Reset cache breakpoints counter
 		this.cacheBreakpointsUsed = 0
@@ -188,28 +151,15 @@ export class OpenRouterHandler implements ApiHandler {
 
 		// Convert and add other messages
 		const convertedMessages = convertToOpenAiMessages(messages)
-		console.log("[OpenRouter] Converted messages count:", convertedMessages.length)
 
 		// For non-Anthropic models, convert messages directly
 		openRouterMessages.push(...convertedMessages.map(msg => this.convertToOpenRouterMessage(msg)))
-
-		console.log("[OpenRouter] Final messages:", {
-			count: openRouterMessages.length,
-			cacheBreakpointsUsed: this.cacheBreakpointsUsed,
-			messages: openRouterMessages.map(msg => ({
-				role: msg.role,
-				contentType: typeof msg.content,
-				partsCount: Array.isArray(msg.content) ? msg.content.length : 'string',
-				hasCacheControl: Array.isArray(msg.content) && msg.content.some(part => 'cache_control' in part)
-			}))
-		})
 
 		// Set max tokens for specific models
 		let maxTokens: number | undefined
 		const modelId = this.getModel().id
 		if (modelId.includes("claude-3-sonnet") || modelId.includes("claude-3.5-sonnet")) {
 			maxTokens = 8_192
-			console.log("[OpenRouter] Set max tokens:", maxTokens)
 		}
 
 		const stream = await this.client.chat.completions.create({
@@ -227,25 +177,16 @@ export class OpenRouterHandler implements ApiHandler {
 			// openrouter returns an error object instead of the openai sdk throwing an error
 			if ("error" in chunk) {
 				const error = chunk.error as { message?: string; code?: number }
-				console.error("[OpenRouter] API Error:", {
-					code: error?.code,
-					message: error?.message
-				})
 				throw new Error(`OpenRouter API Error ${error?.code}: ${error?.message}`)
 			}
 
 			if (!genId && chunk.id) {
 				genId = chunk.id
-				console.log("[OpenRouter] Received generation ID:", genId)
 			}
 
 			const delta = chunk.choices[0]?.delta
 			if (delta?.content) {
 				totalContent += delta.content
-				console.log("[OpenRouter] Received content chunk:", {
-					length: delta.content.length,
-					totalLength: totalContent.length
-				})
 				yield {
 					type: "text",
 					text: delta.content,
@@ -253,15 +194,9 @@ export class OpenRouterHandler implements ApiHandler {
 			}
 		}
 
-		console.log("[OpenRouter] Stream completed:", {
-			totalContentLength: totalContent.length,
-			hasGenId: !!genId
-		})
-
 		await delay(500) // FIXME: necessary delay to ensure generation endpoint is ready
 
 		try {
-			console.log("[OpenRouter] Fetching generation details:", { genId })
 			const response = await axios.get(`https://openrouter.ai/api/v1/generation?id=${genId}`, {
 				headers: {
 					Authorization: `Bearer ${this.options.openRouterApiKey}`,
@@ -270,12 +205,6 @@ export class OpenRouterHandler implements ApiHandler {
 			})
 
 			const generation = response.data?.data
-			console.log("[OpenRouter] Generation details:", {
-				inputTokens: generation?.native_tokens_prompt || 0,
-				outputTokens: generation?.native_tokens_completion || 0,
-				totalCost: generation?.total_cost || 0,
-				rawResponse: response.data
-			})
 
 			yield {
 				type: "usage",

--- a/src/api/providers/openrouter.ts
+++ b/src/api/providers/openrouter.ts
@@ -7,119 +7,261 @@ import { convertToOpenAiMessages } from "../transform/openai-format"
 import { ApiStream } from "../transform/stream"
 import delay from "delay"
 
+// Custom types for OpenRouter's cache control
+type CacheControl = {
+	type: "ephemeral"
+}
+
+type OpenRouterTextContent = {
+	type: "text"
+	text: string
+	cache_control?: CacheControl
+}
+
+type OpenRouterImageContent = {
+	type: "image_url"
+	image_url: { url: string }
+}
+
+type OpenRouterContentPart = OpenRouterTextContent | OpenRouterImageContent
+
+type OpenRouterMessage = {
+	role: "system" | "user" | "assistant" | "function"
+	content: string | OpenRouterContentPart[]
+	name?: string
+	function_call?: OpenAI.Chat.ChatCompletionMessage["function_call"]
+}
+
+const ANTHROPIC_MODELS = [
+	"anthropic/claude-3-opus",
+	"anthropic/claude-3-sonnet",
+	"anthropic/claude-3.5-sonnet",
+	"anthropic/claude-3.5-sonnet-20240620",
+	"anthropic/claude-3-haiku",
+	"anthropic/claude-3-5-haiku",
+	"anthropic/claude-3-5-haiku-20241022",
+	"anthropic/claude-3-opus:beta",
+	"anthropic/claude-3-sonnet:beta",
+	"anthropic/claude-3.5-sonnet:beta",
+	"anthropic/claude-3.5-sonnet-20240620:beta",
+	"anthropic/claude-3-haiku:beta",
+	"anthropic/claude-3-5-haiku:beta",
+	"anthropic/claude-3-5-haiku-20241022:beta"
+]
+
+// Threshold for considering text "large" enough to cache (1000 characters)
+const CACHE_SIZE_THRESHOLD = 1000
+
 export class OpenRouterHandler implements ApiHandler {
 	private options: ApiHandlerOptions
 	private client: OpenAI
+	private isAnthropicModel: boolean
+	private cacheBreakpointsUsed: number
 
 	constructor(options: ApiHandlerOptions) {
 		this.options = options
+		this.isAnthropicModel = ANTHROPIC_MODELS.includes(options.openRouterModelId || openRouterDefaultModelId)
+		this.cacheBreakpointsUsed = 0
+
+		console.log("[OpenRouter] Initializing handler:", {
+			model: options.openRouterModelId || openRouterDefaultModelId,
+			isAnthropicModel: this.isAnthropicModel
+		})
+
+		const defaultHeaders: Record<string, string> = {
+			"HTTP-Referer": "https://cline.bot",
+			"X-Title": "Cline"
+		}
+
+		if (this.isAnthropicModel) {
+			defaultHeaders["anthropic-beta"] = "prompt-caching-2024-07-31"
+			console.log("[OpenRouter] Added Anthropic beta header for caching")
+		}
+
 		this.client = new OpenAI({
 			baseURL: "https://openrouter.ai/api/v1",
 			apiKey: this.options.openRouterApiKey,
-			defaultHeaders: {
-				"HTTP-Referer": "https://cline.bot", // Optional, for including your app on openrouter.ai rankings.
-				"X-Title": "Cline", // Optional. Shows in rankings on openrouter.ai.
-			},
+			defaultHeaders
 		})
 	}
 
+	private shouldCache(text: string): boolean {
+		return this.isAnthropicModel && 
+			   this.cacheBreakpointsUsed < 4 && 
+			   text.length >= CACHE_SIZE_THRESHOLD
+	}
+
+	private convertToOpenRouterMessage(msg: OpenAI.Chat.ChatCompletionMessageParam): OpenRouterMessage {
+		console.log("[OpenRouter] Converting message:", {
+			role: msg.role,
+			contentType: typeof msg.content,
+			hasArray: Array.isArray(msg.content)
+		})
+
+		const role = msg.role as OpenRouterMessage["role"]
+		let content: OpenRouterMessage["content"]
+
+		if (typeof msg.content === "string") {
+			if (this.shouldCache(msg.content)) {
+				content = [{
+					type: "text",
+					text: msg.content,
+					cache_control: { type: "ephemeral" }
+				}]
+				this.cacheBreakpointsUsed++
+				console.log("[OpenRouter] Added cache breakpoint:", {
+					textLength: msg.content.length,
+					breakpointsUsed: this.cacheBreakpointsUsed
+				})
+			} else {
+				content = msg.content
+			}
+			console.log("[OpenRouter] Converted string content:", {
+				original: msg.content.substring(0, 100) + "...",
+				transformed: typeof content === "string" ? content.substring(0, 100) + "..." : "array",
+				cached: Array.isArray(content)
+			})
+		} else if (Array.isArray(msg.content)) {
+			content = msg.content.map(part => {
+				if ("text" in part) {
+					const shouldCacheThis = this.shouldCache(part.text)
+					const transformed = {
+						type: "text",
+						text: part.text,
+						...(shouldCacheThis && { cache_control: { type: "ephemeral" } })
+					} as OpenRouterTextContent
+					if (shouldCacheThis) {
+						this.cacheBreakpointsUsed++
+						console.log("[OpenRouter] Added cache breakpoint:", {
+							textLength: part.text.length,
+							breakpointsUsed: this.cacheBreakpointsUsed
+						})
+					}
+					return transformed
+				} else if ("image_url" in part) {
+					console.log("[OpenRouter] Found image part")
+					return {
+						type: "image_url",
+						image_url: part.image_url
+					} as OpenRouterImageContent
+				}
+				console.warn("[OpenRouter] Unsupported content part:", part)
+				throw new Error(`Unsupported content part type: ${JSON.stringify(part)}`)
+			})
+		} else {
+			content = ""
+			console.log("[OpenRouter] Empty content")
+		}
+
+		const message: OpenRouterMessage = { role, content }
+
+		if ("name" in msg && msg.name) {
+			message.name = msg.name
+			console.log("[OpenRouter] Added name to message:", msg.name)
+		}
+
+		if (msg.role === "assistant" && "function_call" in msg && msg.function_call) {
+			message.function_call = msg.function_call
+			console.log("[OpenRouter] Added function call to message:", {
+				name: msg.function_call.name,
+				argsLength: msg.function_call.arguments?.length
+			})
+		}
+
+		return message
+	}
+
 	async *createMessage(systemPrompt: string, messages: Anthropic.Messages.MessageParam[]): ApiStream {
-		// Convert Anthropic messages to OpenAI format
-		const openAiMessages: OpenAI.Chat.ChatCompletionMessageParam[] = [
-			{ role: "system", content: systemPrompt },
-			...convertToOpenAiMessages(messages),
+		console.log("[OpenRouter] Creating message:", {
+			systemPromptLength: systemPrompt.length,
+			messagesCount: messages.length,
+			model: this.getModel().id
+		})
+
+		// Reset cache breakpoints counter
+		this.cacheBreakpointsUsed = 0
+
+		// Convert messages to OpenRouter format
+		const openRouterMessages: OpenRouterMessage[] = [
+			this.convertToOpenRouterMessage({ role: "system", content: systemPrompt })
 		]
 
-		// prompt caching: https://openrouter.ai/docs/prompt-caching
-		switch (this.getModel().id) {
-			case "anthropic/claude-3.5-sonnet:beta":
-			case "anthropic/claude-3-haiku:beta":
-			case "anthropic/claude-3-opus:beta":
-				openAiMessages[0] = {
-					role: "system",
-					content: [
-						{
-							type: "text",
-							text: systemPrompt,
-							// @ts-ignore-next-line
-							cache_control: { type: "ephemeral" },
-						},
-					],
-				}
-				// Add cache_control to the last two user messages
-				// (note: this works because we only ever add one user message at a time, but if we added multiple we'd need to mark the user message before the last assistant message)
-				const lastTwoUserMessages = openAiMessages.filter((msg) => msg.role === "user").slice(-2)
-				lastTwoUserMessages.forEach((msg) => {
-					if (typeof msg.content === "string") {
-						msg.content = [{ type: "text", text: msg.content }]
-					}
-					if (Array.isArray(msg.content)) {
-						// NOTE: this is fine since env details will always be added at the end. but if it weren't there, and the user added a image_url type message, it would pop a text part before it and then move it after to the end.
-						let lastTextPart = msg.content.filter((part) => part.type === "text").pop()
+		// Convert and add other messages
+		const convertedMessages = convertToOpenAiMessages(messages)
+		console.log("[OpenRouter] Converted messages count:", convertedMessages.length)
 
-						if (!lastTextPart) {
-							lastTextPart = { type: "text", text: "..." }
-							msg.content.push(lastTextPart)
-						}
-						// @ts-ignore-next-line
-						lastTextPart["cache_control"] = { type: "ephemeral" }
-					}
-				})
-				break
-			default:
-				break
-		}
+		// For non-Anthropic models, convert messages directly
+		openRouterMessages.push(...convertedMessages.map(msg => this.convertToOpenRouterMessage(msg)))
 
-		// Not sure how openrouter defaults max tokens when no value is provided, but the anthropic api requires this value and since they offer both 4096 and 8192 variants, we should ensure 8192.
-		// (models usually default to max tokens allowed)
+		console.log("[OpenRouter] Final messages:", {
+			count: openRouterMessages.length,
+			cacheBreakpointsUsed: this.cacheBreakpointsUsed,
+			messages: openRouterMessages.map(msg => ({
+				role: msg.role,
+				contentType: typeof msg.content,
+				partsCount: Array.isArray(msg.content) ? msg.content.length : 'string',
+				hasCacheControl: Array.isArray(msg.content) && msg.content.some(part => 'cache_control' in part)
+			}))
+		})
+
+		// Set max tokens for specific models
 		let maxTokens: number | undefined
-		switch (this.getModel().id) {
-			case "anthropic/claude-3.5-sonnet":
-			case "anthropic/claude-3.5-sonnet:beta":
-				maxTokens = 8_192
-				break
+		const modelId = this.getModel().id
+		if (modelId.includes("claude-3-sonnet") || modelId.includes("claude-3.5-sonnet")) {
+			maxTokens = 8_192
+			console.log("[OpenRouter] Set max tokens:", maxTokens)
 		}
+
 		const stream = await this.client.chat.completions.create({
 			model: this.getModel().id,
 			max_tokens: maxTokens,
 			temperature: 0,
-			messages: openAiMessages,
-			stream: true,
+			messages: openRouterMessages as any,
+			stream: true
 		})
 
 		let genId: string | undefined
+		let totalContent = ""
 
 		for await (const chunk of stream) {
 			// openrouter returns an error object instead of the openai sdk throwing an error
 			if ("error" in chunk) {
 				const error = chunk.error as { message?: string; code?: number }
-				console.error(`OpenRouter API Error: ${error?.code} - ${error?.message}`)
+				console.error("[OpenRouter] API Error:", {
+					code: error?.code,
+					message: error?.message
+				})
 				throw new Error(`OpenRouter API Error ${error?.code}: ${error?.message}`)
 			}
 
 			if (!genId && chunk.id) {
 				genId = chunk.id
+				console.log("[OpenRouter] Received generation ID:", genId)
 			}
 
 			const delta = chunk.choices[0]?.delta
 			if (delta?.content) {
+				totalContent += delta.content
+				console.log("[OpenRouter] Received content chunk:", {
+					length: delta.content.length,
+					totalLength: totalContent.length
+				})
 				yield {
 					type: "text",
 					text: delta.content,
 				}
 			}
-			// if (chunk.usage) {
-			// 	yield {
-			// 		type: "usage",
-			// 		inputTokens: chunk.usage.prompt_tokens || 0,
-			// 		outputTokens: chunk.usage.completion_tokens || 0,
-			// 	}
-			// }
 		}
+
+		console.log("[OpenRouter] Stream completed:", {
+			totalContentLength: totalContent.length,
+			hasGenId: !!genId
+		})
 
 		await delay(500) // FIXME: necessary delay to ensure generation endpoint is ready
 
 		try {
+			console.log("[OpenRouter] Fetching generation details:", { genId })
 			const response = await axios.get(`https://openrouter.ai/api/v1/generation?id=${genId}`, {
 				headers: {
 					Authorization: `Bearer ${this.options.openRouterApiKey}`,
@@ -128,19 +270,24 @@ export class OpenRouterHandler implements ApiHandler {
 			})
 
 			const generation = response.data?.data
-			console.log("OpenRouter generation details:", response.data)
+			console.log("[OpenRouter] Generation details:", {
+				inputTokens: generation?.native_tokens_prompt || 0,
+				outputTokens: generation?.native_tokens_completion || 0,
+				totalCost: generation?.total_cost || 0,
+				rawResponse: response.data
+			})
+
 			yield {
 				type: "usage",
-				// cacheWriteTokens: 0,
-				// cacheReadTokens: 0,
-				// openrouter generation endpoint fails often
 				inputTokens: generation?.native_tokens_prompt || 0,
 				outputTokens: generation?.native_tokens_completion || 0,
 				totalCost: generation?.total_cost || 0,
 			}
 		} catch (error) {
-			// ignore if fails
-			console.error("Error fetching OpenRouter generation details:", error)
+			console.error("[OpenRouter] Error fetching generation details:", {
+				error: error instanceof Error ? error.message : error,
+				genId
+			})
 		}
 	}
 


### PR DESCRIPTION
I noticed that prompt caching wasn't working properly for Anthropic models in OpenRouter, which was leading to higher token usage. This PR fixes that by updating the `openrouter.ts` to implement cache control correctly for these models.

100% written by Cline (but it took me 3 days and ~$100 OpenRouter credits :)

Please note: This will not update the caching info in the task header, as OpenRouter is not sharing caching statistics.