### PR TITLE
Security: Vulnerability alerts: Code scanning: Fix code scanning alert no. 2: Prototype-polluting function

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"

--- a/webview-ui/src/components/history/HistoryView.tsx
+++ b/webview-ui/src/components/history/HistoryView.tsx
@@ -437,10 +437,13 @@ export const highlight = (
 		let i: number
 
 		for (i = 0; i < pathValue.length - 1; i++) {
+			if (pathValue[i] === "__proto__" || pathValue[i] === "constructor") return
 			obj = obj[pathValue[i]] as Record<string, any>
 		}
 
-		obj[pathValue[i]] = value
+		if (pathValue[i] !== "__proto__" && pathValue[i] !== "constructor") {
+			obj[pathValue[i]] = value
+		}
 	}
 
 	// Function to merge overlapping regions


### PR DESCRIPTION
Relates to https://github.com/lloydchang/cline-cline-fka-saoudrizwan-claude-dev/pull/9

---

Fixes [https://github.com/lloydchang/cline-cline-fka-saoudrizwan-claude-dev/security/code-scanning/2](https://github.com/lloydchang/cline-cline-fka-saoudrizwan-claude-dev/security/code-scanning/2)

To fix the prototype pollution vulnerability, we need to ensure that the `set` function does not allow modification of the `__proto__` or `constructor` properties. This can be achieved by adding a check to block these property names before performing the assignment.

- Modify the `set` function to include a check that skips any property names that are `__proto__` or `constructor`.
- This change should be made in the `webview-ui/src/components/history/HistoryView.tsx` file, specifically within the `set` function.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
