### PR TITLE
support for partial reads of large files

### DIFF
--- a/src/core/Cline.ts
+++ b/src/core/Cline.ts
@@ -65,6 +65,9 @@ export class Cline {
 	private didEditFile: boolean = false
 	customInstructions?: string
 	alwaysAllowReadOnly: boolean
+	enableLargeFileCheck: boolean
+	largeFileCheckMaxSize: number
+	largeFileCheckChunkSize: number
 	apiConversationHistory: Anthropic.MessageParam[] = []
 	clineMessages: ClineMessage[] = []
 	private askResponse?: ClineAskResponse
@@ -94,6 +97,9 @@ export class Cline {
 		apiConfiguration: ApiConfiguration,
 		customInstructions?: string,
 		alwaysAllowReadOnly?: boolean,
+		enableLargeFileCheck?: boolean,
+		largeFileCheckMaxSize?: number,
+		largeFileCheckChunkSize?: number,
 		task?: string,
 		images?: string[],
 		historyItem?: HistoryItem,
@@ -106,6 +112,9 @@ export class Cline {
 		this.diffViewProvider = new DiffViewProvider(cwd)
 		this.customInstructions = customInstructions
 		this.alwaysAllowReadOnly = alwaysAllowReadOnly ?? false
+		this.enableLargeFileCheck = enableLargeFileCheck ?? false
+		this.largeFileCheckMaxSize = largeFileCheckMaxSize ?? 128
+		this.largeFileCheckChunkSize = largeFileCheckChunkSize ?? 10
 
 		if (historyItem) {
 			this.taskId = historyItem.id
@@ -1195,7 +1204,7 @@ export class Cline {
 									}
 								}
 								// now execute the tool like normal
-								const content = await extractTextFromFile(absolutePath)
+								const content = await extractTextFromFile(absolutePath, this.enableLargeFileCheck, this.largeFileCheckMaxSize, this.largeFileCheckChunkSize)
 								pushToolResult(content)
 								break
 							}

--- a/src/core/assistant-message/index.ts
+++ b/src/core/assistant-message/index.ts
@@ -18,6 +18,7 @@ export const toolUseNames = [
 	"browser_action",
 	"ask_followup_question",
 	"attempt_completion",
+	"read_next_chunk",
 ] as const
 
 // Converts array of tool call names into a union type ("execute_command" | "read_file" | ...)
@@ -36,6 +37,7 @@ export const toolParamNames = [
 	"text",
 	"question",
 	"result",
+	"offset",
 ] as const
 
 export type ToolParamName = (typeof toolParamNames)[number]
@@ -92,4 +94,9 @@ export interface AskFollowupQuestionToolUse extends ToolUse {
 export interface AttemptCompletionToolUse extends ToolUse {
 	name: "attempt_completion"
 	params: Partial<Pick<Record<ToolParamName, string>, "result" | "command">>
+}
+
+export interface ReadNextChunkToolUse extends ToolUse {
+	name: "read_next_chunk"
+	params: Partial<Pick<Record<ToolParamName, string>, "path" | "offset">>
 }

--- a/src/core/prompts/system.ts
+++ b/src/core/prompts/system.ts
@@ -5,6 +5,7 @@ import os from "os"
 export const SYSTEM_PROMPT = async (
 	cwd: string,
 	supportsComputerUse: boolean,
+	enableLargeFileCheck: boolean = false,
 ) => `You are Cline, a highly skilled software engineer with extensive knowledge in many programming languages, frameworks, design patterns, and best practices.
 
 ====
@@ -43,13 +44,25 @@ Usage:
 </execute_command>
 
 ## read_file
-Description: Request to read the contents of a file at the specified path. Use this when you need to examine the contents of an existing file you do not know the contents of, for example to analyze code, review text files, or extract information from configuration files. Automatically extracts raw text from PDF and DOCX files. May not be suitable for other types of binary files, as it returns the raw content as a string.
+Description: Request to read the contents of a file at the specified path. Use this when you need to examine the contents of an existing file you do not know the contents of, for example to analyze code, review text files, or extract information from configuration files. Automatically extracts raw text from PDF and DOCX files. May not be suitable for other types of binary files, as it returns the raw content as a string.${enableLargeFileCheck ? " For large files, only the first chunk will be returned, and you can use read_next_chunk to request additional chunks if you need more information." : ""}
 Parameters:
 - path: (required) The path of the file to read (relative to the current working directory ${cwd.toPosix()})
 Usage:
 <read_file>
 <path>File path here</path>
 </read_file>
+${enableLargeFileCheck ? `
+
+## read_next_chunk
+Description: Request to read the next chunk of a large file starting from a specific offset. Use this when read_file returns a partial content and you need to read more of the file. The response will indicate if there is more content available and provide the next offset to use.
+Parameters:
+- path: (required) The path of the file to read (relative to the current working directory ${cwd.toPosix()})
+- offset: (required) The byte offset to start reading from, provided in the previous read_file or read_next_chunk result
+Usage:
+<read_next_chunk>
+<path>File path here</path>
+<offset>Offset number here</offset>
+</read_next_chunk>` : ""}
 
 ## write_to_file
 Description: Request to write content to a file at the specified path. If the file exists, it will be overwritten with the provided content. If the file doesn't exist, it will be created. This tool will automatically create any directories needed to write the file.

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -880,11 +880,11 @@ private setWebviewMessageListener(webview: vscode.Webview) {
 	https://www.eliostruyf.com/devhack-code-extension-storage-options/
 	*/
 
-async getState() {
-	const [
-		storedApiProvider,
-		apiModelId,
-		apiKey,
+	async getState() {
+		const [
+			storedApiProvider,
+			apiModelId,
+			apiKey,
 			openRouterApiKey,
 			awsAccessKey,
 			awsSecretKey,
@@ -906,17 +906,17 @@ async getState() {
 			azureApiVersion,
 			openRouterModelId,
 			openRouterModelInfo,
-		lastShownAnnouncementId,
-		customInstructions,
-		alwaysAllowReadOnly,
-		enableLargeFileCheck,
-		largeFileCheckMaxSize,
-		largeFileCheckChunkSize,
-		taskHistory,
-	] = await Promise.all([
-		this.getGlobalState("apiProvider") as Promise<ApiProvider | undefined>,
-		this.getGlobalState("apiModelId") as Promise<string | undefined>,
-		this.getSecret("apiKey") as Promise<string | undefined>,
+			lastShownAnnouncementId,
+			customInstructions,
+			alwaysAllowReadOnly,
+			enableLargeFileCheck,
+			largeFileCheckMaxSize,
+			largeFileCheckChunkSize,
+			taskHistory,
+		] = await Promise.all([
+			this.getGlobalState("apiProvider") as Promise<ApiProvider | undefined>,
+			this.getGlobalState("apiModelId") as Promise<string | undefined>,
+			this.getSecret("apiKey") as Promise<string | undefined>,
 			this.getSecret("openRouterApiKey") as Promise<string | undefined>,
 			this.getSecret("awsAccessKey") as Promise<string | undefined>,
 			this.getSecret("awsSecretKey") as Promise<string | undefined>,
@@ -938,67 +938,65 @@ async getState() {
 			this.getGlobalState("azureApiVersion") as Promise<string | undefined>,
 			this.getGlobalState("openRouterModelId") as Promise<string | undefined>,
 			this.getGlobalState("openRouterModelInfo") as Promise<ModelInfo | undefined>,
-		this.getGlobalState("lastShownAnnouncementId") as Promise<string | undefined>,
-		this.getGlobalState("customInstructions") as Promise<string | undefined>,
-		this.getGlobalState("alwaysAllowReadOnly") as Promise<boolean | undefined>,
-		this.getGlobalState("enableLargeFileCheck") as Promise<boolean | undefined>,
-		this.getGlobalState("largeFileCheckMaxSize") as Promise<number | undefined>,
-		this.getGlobalState("largeFileCheckChunkSize") as Promise<number | undefined>,
+			this.getGlobalState("lastShownAnnouncementId") as Promise<string | undefined>,
+			this.getGlobalState("customInstructions") as Promise<string | undefined>,
+			this.getGlobalState("alwaysAllowReadOnly") as Promise<boolean | undefined>,
+			this.getGlobalState("enableLargeFileCheck") as Promise<boolean | undefined>,
+			this.getGlobalState("largeFileCheckMaxSize") as Promise<number | undefined>,
+			this.getGlobalState("largeFileCheckChunkSize") as Promise<number | undefined>,
+			this.getGlobalState("taskHistory") as Promise<HistoryItem[] | undefined>,
+		])
 
-
-		this.getGlobalState("taskHistory") as Promise<HistoryItem[] | undefined>,
-	])
-
-	let apiProvider: ApiProvider
-	if (storedApiProvider) {
-		apiProvider = storedApiProvider
-	} else {
-			// Either new user or legacy user that doesn't have the apiProvider stored in state
-			// (If they're using OpenRouter or Bedrock, then apiProvider state will exist)
-		if (apiKey) {
-			apiProvider = "anthropic"
+		let apiProvider: ApiProvider
+		if (storedApiProvider) {
+			apiProvider = storedApiProvider
 		} else {
-				// New users should default to openrouter
-			apiProvider = "openrouter"
+				// Either new user or legacy user that doesn't have the apiProvider stored in state
+				// (If they're using OpenRouter or Bedrock, then apiProvider state will exist)
+			if (apiKey) {
+				apiProvider = "anthropic"
+			} else {
+					// New users should default to openrouter
+				apiProvider = "openrouter"
+			}
+		}
+
+		return {
+			apiConfiguration: {
+					apiProvider,
+					apiModelId,
+					apiKey,
+					openRouterApiKey,
+					awsAccessKey,
+					awsSecretKey,
+					awsSessionToken,
+					awsRegion,
+					awsUseCrossRegionInference,
+					vertexProjectId,
+					vertexRegion,
+					openAiBaseUrl,
+					openAiApiKey,
+					openAiModelId,
+					ollamaModelId,
+					ollamaBaseUrl,
+					lmStudioModelId,
+					lmStudioBaseUrl,
+					anthropicBaseUrl,
+					geminiApiKey,
+					openAiNativeApiKey,
+					azureApiVersion,
+					openRouterModelId,
+					openRouterModelInfo,
+			},
+			lastShownAnnouncementId,
+			customInstructions,
+			alwaysAllowReadOnly: alwaysAllowReadOnly ?? false,
+			enableLargeFileCheck: enableLargeFileCheck ?? false,
+			largeFileCheckMaxSize: largeFileCheckMaxSize ?? 128,
+			largeFileCheckChunkSize: largeFileCheckChunkSize ?? 10,
+			taskHistory,
 		}
 	}
-
-	return {
-		apiConfiguration: {
-				apiProvider,
-				apiModelId,
-				apiKey,
-				openRouterApiKey,
-				awsAccessKey,
-				awsSecretKey,
-				awsSessionToken,
-				awsRegion,
-				awsUseCrossRegionInference,
-				vertexProjectId,
-				vertexRegion,
-				openAiBaseUrl,
-				openAiApiKey,
-				openAiModelId,
-				ollamaModelId,
-				ollamaBaseUrl,
-				lmStudioModelId,
-				lmStudioBaseUrl,
-				anthropicBaseUrl,
-				geminiApiKey,
-				openAiNativeApiKey,
-				azureApiVersion,
-				openRouterModelId,
-				openRouterModelInfo,
-		},
-		lastShownAnnouncementId,
-		customInstructions,
-		alwaysAllowReadOnly: alwaysAllowReadOnly ?? false,
-		enableLargeFileCheck: enableLargeFileCheck ?? false,
-		largeFileCheckMaxSize: largeFileCheckMaxSize ?? 128,
-		largeFileCheckChunkSize: largeFileCheckChunkSize ?? 10,
-		taskHistory,
-	}
-}
 
 	async updateTaskHistory(item: HistoryItem): Promise<HistoryItem[]> {
 		const history = ((await this.getGlobalState("taskHistory")) as HistoryItem[]) || []

--- a/src/integrations/misc/extract-text.ts
+++ b/src/integrations/misc/extract-text.ts
@@ -4,52 +4,60 @@ import pdf from "pdf-parse/lib/pdf-parse"
 import mammoth from "mammoth"
 import fs from "fs/promises"
 import { isBinaryFile } from "isbinaryfile"
+import { readFileWithSizeCheck } from "../../utils/large-file"
 
-export async function extractTextFromFile(filePath: string): Promise<string> {
-	try {
-		await fs.access(filePath)
-	} catch (error) {
-		throw new Error(`File not found: ${filePath}`)
-	}
-	const fileExtension = path.extname(filePath).toLowerCase()
-	switch (fileExtension) {
-		case ".pdf":
-			return extractTextFromPDF(filePath)
-		case ".docx":
-			return extractTextFromDOCX(filePath)
-		case ".ipynb":
-			return extractTextFromIPYNB(filePath)
-		default:
-			const isBinary = await isBinaryFile(filePath).catch(() => false)
-			if (!isBinary) {
-				return await fs.readFile(filePath, "utf8")
-			} else {
-				throw new Error(`Cannot read text for file type: ${fileExtension}`)
-			}
-	}
+export async function extractTextFromFile(filePath: string, enableLargeFileCheck: boolean = false, largeFileCheckMaxSize: number = Number.MAX_VALUE, largeFileCheckChunkSize: number = Number.MAX_VALUE): Promise<string> {
+    try {
+        await fs.access(filePath)
+    } catch (error) {
+        throw new Error(`File not found: ${filePath}`)
+    }
+    const fileExtension = path.extname(filePath).toLowerCase()
+    switch (fileExtension) {
+        case ".pdf":
+            return extractTextFromPDF(filePath)
+        case ".docx":
+            return extractTextFromDOCX(filePath)
+        case ".ipynb":
+            return extractTextFromIPYNB(filePath)
+        default:
+            const isBinary = await isBinaryFile(filePath).catch(() => false)
+            if (!isBinary) {
+                if (enableLargeFileCheck) {
+                    const result = await readFileWithSizeCheck(filePath, largeFileCheckMaxSize, largeFileCheckChunkSize)
+                    if (result.isPartial) {
+                        return `${result.content}\n\n[Note: This is a partial content (${(result.loadedSize / 1024).toFixed(1)}KB of ${(result.totalSize / 1024).toFixed(1)}KB). The file is large, so only the first part is shown. You can request more content if needed.]`
+                    }
+                    return result.content
+                }
+                return await fs.readFile(filePath, "utf8")
+            } else {
+                throw new Error(`Cannot read text for file type: ${fileExtension}`)
+            }
+    }
 }
 
 async function extractTextFromPDF(filePath: string): Promise<string> {
-	const dataBuffer = await fs.readFile(filePath)
-	const data = await pdf(dataBuffer)
-	return data.text
+    const dataBuffer = await fs.readFile(filePath)
+    const data = await pdf(dataBuffer)
+    return data.text
 }
 
 async function extractTextFromDOCX(filePath: string): Promise<string> {
-	const result = await mammoth.extractRawText({ path: filePath })
-	return result.value
+    const result = await mammoth.extractRawText({ path: filePath })
+    return result.value
 }
 
 async function extractTextFromIPYNB(filePath: string): Promise<string> {
-	const data = await fs.readFile(filePath, "utf8")
-	const notebook = JSON.parse(data)
-	let extractedText = ""
+    const data = await fs.readFile(filePath, "utf8")
+    const notebook = JSON.parse(data)
+    let extractedText = ""
 
-	for (const cell of notebook.cells) {
-		if ((cell.cell_type === "markdown" || cell.cell_type === "code") && cell.source) {
-			extractedText += cell.source.join("\n") + "\n"
-		}
-	}
+    for (const cell of notebook.cells) {
+        if ((cell.cell_type === "markdown" || cell.cell_type === "code") && cell.source) {
+            extractedText += cell.source.join("\n") + "\n"
+        }
+    }
 
-	return extractedText
+    return extractedText
 }

--- a/src/shared/ExtensionMessage.ts
+++ b/src/shared/ExtensionMessage.ts
@@ -85,6 +85,7 @@ export interface ClineSayTool {
 		| "editedExistingFile"
 		| "newFileCreated"
 		| "readFile"
+		| "readNextChunk"
 		| "listFilesTopLevel"
 		| "listFilesRecursive"
 		| "listCodeDefinitionNames"
@@ -94,6 +95,7 @@ export interface ClineSayTool {
 	content?: string
 	regex?: string
 	filePattern?: string
+	offset?: number
 }
 
 // must keep in sync with system prompt

--- a/src/shared/ExtensionMessage.ts
+++ b/src/shared/ExtensionMessage.ts
@@ -33,6 +33,9 @@ export interface ExtensionState {
 	apiConfiguration?: ApiConfiguration
 	customInstructions?: string
 	alwaysAllowReadOnly?: boolean
+	enableLargeFileCheck?: boolean
+	largeFileCheckMaxSize?: number
+	largeFileCheckChunkSize?: number
 	uriScheme?: string
 	clineMessages: ClineMessage[]
 	taskHistory: HistoryItem[]

--- a/src/shared/WebviewMessage.ts
+++ b/src/shared/WebviewMessage.ts
@@ -5,6 +5,9 @@ export interface WebviewMessage {
 		| "apiConfiguration"
 		| "customInstructions"
 		| "alwaysAllowReadOnly"
+		| "enableLargeFileCheck"
+		| "largeFileCheckMaxSize"
+		| "largeFileCheckChunkSize"
 		| "webviewDidLaunch"
 		| "newTask"
 		| "askResponse"
@@ -24,6 +27,7 @@ export interface WebviewMessage {
 		| "cancelTask"
 		| "refreshOpenRouterModels"
 	text?: string
+	number?: number
 	askResponse?: ClineAskResponse
 	apiConfiguration?: ApiConfiguration
 	images?: string[]

--- a/src/utils/large-file.ts
+++ b/src/utils/large-file.ts
@@ -1,0 +1,73 @@
+import fs from "fs/promises"
+import { stat } from "fs/promises"
+
+
+
+export interface LargeFileResult {
+    content: string
+    isPartial: boolean
+    totalSize: number
+    loadedSize: number
+}
+
+export async function readFileWithSizeCheck(filePath: string, maxFileSize: number, chunkSize: number): Promise<LargeFileResult> {
+    const MAX_FILE_SIZE = maxFileSize * 1024
+    const CHUNK_SIZE = chunkSize * 10
+
+    const stats = await stat(filePath)
+    const fileSize = stats.size
+
+    if (fileSize <= MAX_FILE_SIZE) {
+        // If file is small enough, read it entirely
+        const content = await fs.readFile(filePath, "utf8")
+        return {
+            content,
+            isPartial: false,
+            totalSize: fileSize,
+            loadedSize: fileSize
+        }
+    }
+
+    // If file is too large, read only the first chunk
+    const fileHandle = await fs.open(filePath, "r")
+    const buffer = Buffer.alloc(CHUNK_SIZE)
+    
+    try {
+        const { bytesRead } = await fileHandle.read(buffer, 0, CHUNK_SIZE, 0)
+        const content = buffer.toString("utf8", 0, bytesRead)
+        
+        return {
+            content,
+            isPartial: true,
+            totalSize: fileSize,
+            loadedSize: bytesRead
+        }
+    } finally {
+        await fileHandle.close()
+    }
+}
+
+export async function readNextChunk(filePath: string, offset: number, maxFileSize: number, chunkSize: number): Promise<LargeFileResult> {
+    const MAX_FILE_SIZE = maxFileSize * 1024
+    const CHUNK_SIZE = chunkSize * 10
+
+    const stats = await stat(filePath)
+    const fileSize = stats.size
+    
+    const fileHandle = await fs.open(filePath, "r")
+    const buffer = Buffer.alloc(CHUNK_SIZE)
+    
+    try {
+        const { bytesRead } = await fileHandle.read(buffer, 0, CHUNK_SIZE, offset)
+        const content = buffer.toString("utf8", 0, bytesRead)
+        
+        return {
+            content,
+            isPartial: offset + bytesRead < fileSize,
+            totalSize: fileSize,
+            loadedSize: offset + bytesRead
+        }
+    } finally {
+        await fileHandle.close()
+    }
+}

--- a/webview-ui/src/components/settings/SettingsView.tsx
+++ b/webview-ui/src/components/settings/SettingsView.tsx
@@ -1,4 +1,4 @@
-import { VSCodeButton, VSCodeCheckbox, VSCodeLink, VSCodeTextArea } from "@vscode/webview-ui-toolkit/react"
+import { VSCodeButton, VSCodeCheckbox, VSCodeLink, VSCodeTextArea, VSCodeTextField } from "@vscode/webview-ui-toolkit/react"
 import { memo, useEffect, useState } from "react"
 import { useExtensionState } from "../../context/ExtensionStateContext"
 import { validateApiConfiguration, validateModelId } from "../../utils/validate"
@@ -19,6 +19,12 @@ const SettingsView = ({ onDone }: SettingsViewProps) => {
 		setCustomInstructions,
 		alwaysAllowReadOnly,
 		setAlwaysAllowReadOnly,
+		enableLargeFileCheck,
+		setEnableLargeFileCheck,
+		largeFileCheckMaxSize,
+		setLargeFileCheckMaxSize,
+		largeFileCheckChunkSize,
+		setLargeFileCheckChunkSize,
 		openRouterModels,
 	} = useExtensionState()
 	const [apiErrorMessage, setApiErrorMessage] = useState<string | undefined>(undefined)
@@ -33,6 +39,9 @@ const SettingsView = ({ onDone }: SettingsViewProps) => {
 			vscode.postMessage({ type: "apiConfiguration", apiConfiguration })
 			vscode.postMessage({ type: "customInstructions", text: customInstructions })
 			vscode.postMessage({ type: "alwaysAllowReadOnly", bool: alwaysAllowReadOnly })
+			vscode.postMessage({ type: "enableLargeFileCheck", bool: enableLargeFileCheck })
+			vscode.postMessage({ type: "largeFileCheckMaxSize", number: largeFileCheckMaxSize })
+			vscode.postMessage({ type: "largeFileCheckChunkSize", number: largeFileCheckChunkSize })
 			onDone()
 		}
 	}
@@ -128,6 +137,59 @@ const SettingsView = ({ onDone }: SettingsViewProps) => {
 						When enabled, Cline will automatically view directory contents and read files without requiring
 						you to click the Approve button.
 					</p>
+				</div>
+
+				<div style={{ marginBottom: 5 }}>
+					<VSCodeCheckbox
+						checked={enableLargeFileCheck}
+						onChange={(e: any) => setEnableLargeFileCheck(e.target.checked)}>
+						<span style={{ fontWeight: "500" }}>Enable large file handling</span>
+					</VSCodeCheckbox>
+					<p
+						style={{
+							fontSize: "12px",
+							marginTop: "5px",
+							color: "var(--vscode-descriptionForeground)",
+						}}>
+						When enabled, files larger than {largeFileCheckMaxSize}KB will be read in chunks of {largeFileCheckChunkSize}KB to prevent memory issues.
+						The LLM can request more content if needed.
+					</p>
+					{enableLargeFileCheck && (
+						<div style={{ marginLeft: "20px", marginTop: "10px" }}>
+							<div style={{ marginBottom: "10px" }}>
+								<VSCodeTextField
+									value={largeFileCheckMaxSize?.toString() ?? "128"}
+									style={{ width: "100%" }}
+									onChange={(e: any) => setLargeFileCheckMaxSize(Number(e.target.value))}>
+									<span style={{ fontWeight: "500" }}>Maximum File Size (KB)</span>
+								</VSCodeTextField>
+								<p
+									style={{
+										fontSize: "12px",
+										marginTop: "5px",
+										color: "var(--vscode-descriptionForeground)",
+									}}>
+									Files larger than this size will be read in chunks.
+								</p>
+							</div>
+							<div>
+								<VSCodeTextField
+									value={largeFileCheckChunkSize?.toString() ?? "10"}
+									style={{ width: "100%" }}
+									onChange={(e: any) => setLargeFileCheckChunkSize(Number(e.target.value))}>
+									<span style={{ fontWeight: "500" }}>Chunk Size (KB)</span>
+								</VSCodeTextField>
+								<p
+									style={{
+										fontSize: "12px",
+										marginTop: "5px",
+										color: "var(--vscode-descriptionForeground)",
+									}}>
+									The size of each chunk when reading large files.
+								</p>
+							</div>
+						</div>
+					)}
 				</div>
 
 				{IS_DEV && (

--- a/webview-ui/src/components/settings/SettingsView.tsx
+++ b/webview-ui/src/components/settings/SettingsView.tsx
@@ -151,8 +151,7 @@ const SettingsView = ({ onDone }: SettingsViewProps) => {
 							marginTop: "5px",
 							color: "var(--vscode-descriptionForeground)",
 						}}>
-						When enabled, files larger than {largeFileCheckMaxSize}KB will be read in chunks of {largeFileCheckChunkSize}KB to prevent memory issues.
-						The LLM can request more content if needed.
+						When enabled, files larger than {largeFileCheckMaxSize}KB will be initially read up to the first {largeFileCheckChunkSize}KB. The LLM can request additional chunks if it determines it needs more information.
 					</p>
 					{enableLargeFileCheck && (
 						<div style={{ marginLeft: "20px", marginTop: "10px" }}>

--- a/webview-ui/src/components/settings/SettingsView.tsx
+++ b/webview-ui/src/components/settings/SettingsView.tsx
@@ -151,7 +151,7 @@ const SettingsView = ({ onDone }: SettingsViewProps) => {
 							marginTop: "5px",
 							color: "var(--vscode-descriptionForeground)",
 						}}>
-						When enabled, files larger than {largeFileCheckMaxSize}KB will be initially read up to the first {largeFileCheckChunkSize}KB. The LLM can request additional chunks if it determines it needs more information.
+						When enabled, files larger than {largeFileCheckMaxSize}KB will be initially read up to {largeFileCheckMaxSize}KB. If needed, additional chunks of {largeFileCheckChunkSize}KB can be requested.
 					</p>
 					{enableLargeFileCheck && (
 						<div style={{ marginLeft: "20px", marginTop: "10px" }}>
@@ -184,7 +184,7 @@ const SettingsView = ({ onDone }: SettingsViewProps) => {
 										marginTop: "5px",
 										color: "var(--vscode-descriptionForeground)",
 									}}>
-									The size of each chunk when reading large files.
+									The size of each additional chunk when reading large files.
 								</p>
 							</div>
 						</div>

--- a/webview-ui/src/context/ExtensionStateContext.tsx
+++ b/webview-ui/src/context/ExtensionStateContext.tsx
@@ -20,6 +20,9 @@ interface ExtensionStateContextType extends ExtensionState {
 	setApiConfiguration: (config: ApiConfiguration) => void
 	setCustomInstructions: (value?: string) => void
 	setAlwaysAllowReadOnly: (value: boolean) => void
+	setEnableLargeFileCheck: (value: boolean) => void
+	setLargeFileCheckMaxSize: (value: number) => void
+	setLargeFileCheckChunkSize: (value: number) => void
 	setShowAnnouncement: (value: boolean) => void
 }
 
@@ -114,6 +117,9 @@ export const ExtensionStateContextProvider: React.FC<{ children: React.ReactNode
 		setApiConfiguration: (value) => setState((prevState) => ({ ...prevState, apiConfiguration: value })),
 		setCustomInstructions: (value) => setState((prevState) => ({ ...prevState, customInstructions: value })),
 		setAlwaysAllowReadOnly: (value) => setState((prevState) => ({ ...prevState, alwaysAllowReadOnly: value })),
+		setEnableLargeFileCheck: (value) => setState((prevState) => ({ ...prevState, enableLargeFileCheck: value })),
+		setLargeFileCheckMaxSize: (value) => setState((prevState) => ({ ...prevState, largeFileCheckMaxSize: value })),
+		setLargeFileCheckChunkSize: (value) => setState((prevState) => ({ ...prevState, largeFileCheckChunkSize: value })),
 		setShowAnnouncement: (value) => setState((prevState) => ({ ...prevState, shouldShowAnnouncement: value })),
 	}
 


### PR DESCRIPTION
I currently have the problem that I am not the most patient guy, so I let clide read all the files it wants automatically. However, this results in crashes, huge context windows and context limit error messages.

So I added a new setting.

![grafik](https://github.com/user-attachments/assets/d2ea6e8e-8d27-4604-aa0b-825ec5b4cb18)

This works insanely well, even in this alpha state. I am thinking about implementing the same for huge terminal command outputs.

The description should speak for itself. Funny enough, under Linux the LLM tries to read the rest of the file by using tail, which is even better than what I wanted to implement.

This could be merged as it is behind a configuration switch. Maybe I will keep polishing it but for now, I do not have any issues.