### PR TITLE
Fetch context window size from Ollama server

### DIFF
--- a/src/api/providers/ollama.ts
+++ b/src/api/providers/ollama.ts
@@ -1,5 +1,6 @@
 import { Anthropic } from "@anthropic-ai/sdk"
 import OpenAI from "openai"
+import axios from "axios"
 import { ApiHandler } from "../"
 import { ApiHandlerOptions, ModelInfo, openAiModelInfoSaneDefaults } from "../../shared/api"
 import { convertToOpenAiMessages } from "../transform/openai-format"
@@ -8,6 +9,8 @@ import { ApiStream } from "../transform/stream"
 export class OllamaHandler implements ApiHandler {
 	private options: ApiHandlerOptions
 	private client: OpenAI
+	private modelInfo: ModelInfo = openAiModelInfoSaneDefaults
+	private modelInfoPromise: Promise<void> | null = null
 
 	constructor(options: ApiHandlerOptions) {
 		this.options = options
@@ -15,9 +18,52 @@ export class OllamaHandler implements ApiHandler {
 			baseURL: (this.options.ollamaBaseUrl || "http://localhost:11434") + "/v1",
 			apiKey: "ollama",
 		})
+		// Start fetching model info immediately
+		this.modelInfoPromise = this.fetchModelInfo()
+	}
+
+	private async fetchModelInfo(): Promise<void> {
+		try {
+			const modelId = this.options.ollamaModelId || ""
+			const baseUrl = this.options.ollamaBaseUrl || "http://localhost:11434"
+			const response = await axios.post(`${baseUrl}/api/show`, {
+				name: modelId
+			})
+			
+			const modelInfo = response.data?.model_info
+			let contextLength = openAiModelInfoSaneDefaults.contextWindow
+
+			// Find any property that ends with .context_length
+			if (modelInfo) {
+				const contextLengthKey = Object.keys(modelInfo).find(key => key.endsWith('.context_length'))
+				if (contextLengthKey) {
+					contextLength = modelInfo[contextLengthKey]
+				}
+			}
+
+			// Get max tokens from num_ctx parameter
+			const maxTokens = response.data?.parameters?.num_ctx ? 
+				parseInt(response.data.parameters.num_ctx) : 
+				openAiModelInfoSaneDefaults.maxTokens
+
+			this.modelInfo = {
+				...openAiModelInfoSaneDefaults,
+				contextWindow: contextLength,
+				maxTokens,
+			}
+		} catch (error) {
+			console.error("Error fetching Ollama model info:", error)
+			this.modelInfo = openAiModelInfoSaneDefaults
+		}
 	}
 
 	async *createMessage(systemPrompt: string, messages: Anthropic.Messages.MessageParam[]): ApiStream {
+		// Wait for model info to be fetched before creating message
+		if (this.modelInfoPromise) {
+			await this.modelInfoPromise
+			this.modelInfoPromise = null
+		}
+
 		const openAiMessages: OpenAI.Chat.ChatCompletionMessageParam[] = [
 			{ role: "system", content: systemPrompt },
 			...convertToOpenAiMessages(messages),
@@ -43,7 +89,7 @@ export class OllamaHandler implements ApiHandler {
 	getModel(): { id: string; info: ModelInfo } {
 		return {
 			id: this.options.ollamaModelId || "",
-			info: openAiModelInfoSaneDefaults,
+			info: this.modelInfo,
 		}
 	}
 }


### PR DESCRIPTION
This PR adds automatic context window size detection for Ollama models by fetching the information directly from the Ollama server.

Implementation details:

- Added context window size retrieval from Ollama's /api/show endpoint
- Dynamically detects the context length property by finding keys that end with .context_length
- Falls back to sane defaults if the server request fails
- Context window size is fetched when initializing the OllamaHandler and when switching models

This change improves the extension's compatibility with different Ollama models by automatically adapting to their specific context window sizes rather than using hardcoded values.