### PR TITLE
feat: pipe into STDIN support for `<execute_command>`

### DIFF
--- a/src/core/Cline.ts
+++ b/src/core/Cline.ts
@@ -673,10 +673,10 @@ export class Cline {
 
 	// Tools
 
-	async executeCommandTool(command: string): Promise<[boolean, ToolResponse]> {
+	async executeCommandTool(command: string, pipein?: string): Promise<[boolean, ToolResponse]> {
 		const terminalInfo = await this.terminalManager.getOrCreateTerminal(cwd)
 		terminalInfo.terminal.show() // weird visual bug when creating new terminals (even manually) where there's an empty space at the top.
-		const process = this.terminalManager.runCommand(terminalInfo, command)
+		const process = this.terminalManager.runCommand(terminalInfo, command, pipein)
 
 		let userFeedback: { text?: string; images?: string[] } | undefined
 		let didContinue = false
@@ -1507,6 +1507,7 @@ export class Cline {
 					}
 					case "execute_command": {
 						const command: string | undefined = block.params.command
+						const pipein: string | undefined = block.params.pipein
 						try {
 							if (block.partial) {
 								await this.ask("command", removeClosingTag("command", command), block.partial).catch(
@@ -1526,7 +1527,7 @@ export class Cline {
 								if (!didApprove) {
 									break
 								}
-								const [userRejected, result] = await this.executeCommandTool(command)
+								const [userRejected, result] = await this.executeCommandTool(command, pipein)
 								if (userRejected) {
 									this.didRejectTool = true
 								}
@@ -1589,6 +1590,8 @@ export class Cline {
 						*/
 						const result: string | undefined = block.params.result
 						const command: string | undefined = block.params.command
+						const pipein: string | undefined = block.params.pipein
+
 						try {
 							const lastMessage = this.clineMessages.at(-1)
 							if (block.partial) {
@@ -1651,7 +1654,7 @@ export class Cline {
 									if (!didApprove) {
 										break
 									}
-									const [userRejected, execCommandResult] = await this.executeCommandTool(command!)
+									const [userRejected, execCommandResult] = await this.executeCommandTool(command!, pipein)
 									if (userRejected) {
 										this.didRejectTool = true
 										pushToolResult(execCommandResult)

--- a/src/core/assistant-message/index.ts
+++ b/src/core/assistant-message/index.ts
@@ -25,6 +25,7 @@ export type ToolUseName = (typeof toolUseNames)[number]
 
 export const toolParamNames = [
 	"command",
+	"pipein",
 	"path",
 	"content",
 	"regex",
@@ -51,7 +52,7 @@ export interface ToolUse {
 export interface ExecuteCommandToolUse extends ToolUse {
 	name: "execute_command"
 	// Pick<Record<ToolParamName, string>, "command"> makes "command" required, but Partial<> makes it optional
-	params: Partial<Pick<Record<ToolParamName, string>, "command">>
+	params: Partial<Pick<Record<ToolParamName, string>, "command" | "pipein">>
 }
 
 export interface ReadFileToolUse extends ToolUse {

--- a/src/core/prompts/system.ts
+++ b/src/core/prompts/system.ts
@@ -37,9 +37,11 @@ Always adhere to this format for the tool use to ensure proper parsing and execu
 Description: Request to execute a CLI command on the system. Use this when you need to perform system operations or run specific commands to accomplish any step in the user's task. You must tailor your command to the user's system and provide a clear explanation of what the command does. Prefer to execute complex CLI commands over creating executable scripts, as they are more flexible and easier to run. Commands will be executed in the current working directory: ${cwd.toPosix()}
 Parameters:
 - command: (required) The CLI command to execute. This should be valid for the current operating system. Ensure the command is properly formatted and does not contain any harmful instructions.
+- pipein: (optional) Text piped into the command's standard input which can be used for multi-line input in place of \`echo\` and "heredoc" content.
 Usage:
 <execute_command>
 <command>Your command here</command>
+<pipein>Optional standard input to the command</pipein>
 </execute_command>
 
 ## read_file
@@ -160,10 +162,20 @@ Your final result description here
 
 # Tool Use Examples
 
-## Example 1: Requesting to execute a command
+## Example 1a: Requesting to execute a command
 
 <execute_command>
 <command>npm run dev</command>
+</execute_command>
+
+## Example 1b: Using \`execute_command\` with \`pipein\` to write into the standard input of a program
+
+<execute_command>
+<command>cat -n</command>
+<pipein>line1
+line2
+line3
+</pipein>
 </execute_command>
 
 ## Example 2: Requesting to write to a file

--- a/src/integrations/terminal/TerminalManager.ts
+++ b/src/integrations/terminal/TerminalManager.ts
@@ -109,7 +109,7 @@ export class TerminalManager {
 		}
 	}
 
-	runCommand(terminalInfo: TerminalInfo, command: string): TerminalProcessResultPromise {
+	runCommand(terminalInfo: TerminalInfo, command: string, pipein?: string): TerminalProcessResultPromise {
 		terminalInfo.busy = true
 		terminalInfo.lastCommand = command
 		const process = new TerminalProcess()
@@ -141,7 +141,7 @@ export class TerminalManager {
 		// if shell integration is already active, run the command immediately
 		if (terminalInfo.terminal.shellIntegration) {
 			process.waitForShellIntegration = false
-			process.run(terminalInfo.terminal, command)
+			process.run(terminalInfo.terminal, command, pipein)
 		} else {
 			// docs recommend waiting 3s for shell integration to activate
 			pWaitFor(() => terminalInfo.terminal.shellIntegration !== undefined, { timeout: 4000 }).finally(() => {


### PR DESCRIPTION
Add optional `pipein` parameter to `execute_command` to pipe into stdin. 

    - Updates Cline.ts to support piping input into terminal commands
    - Update type definitions and system prompt documentation
    - Example usage showing pipein with cat -n command
    
        <execute_command>
        <command>cat -n</command>
        <pipein>line1
        line2
        line3
        </pipein>
        </execute_command>
    
This patch series also fixes #274, because I was working with pipes that need to preserve commas in the output while developing this feature. See the commit serious and comments for specific details.