### PR TITLE
feat: add claude-3-5-sonnet-20240620 model support

### DIFF
--- a/src/api/providers/anthropic.ts
+++ b/src/api/providers/anthropic.ts
@@ -28,6 +28,7 @@ export class AnthropicHandler implements ApiHandler {
 		switch (modelId) {
 			// 'latest' alias does not support cache_control
 			case "claude-3-5-sonnet-20241022":
+			case "claude-3-5-sonnet-20240620":
 			case "claude-3-5-haiku-20241022":
 			case "claude-3-opus-20240229":
 			case "claude-3-haiku-20240307": {

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -70,6 +70,17 @@ export const anthropicModels = {
 		cacheWritesPrice: 3.75, // $3.75 per million tokens
 		cacheReadsPrice: 0.3, // $0.30 per million tokens
 	},
+	"claude-3-5-sonnet-20240620": {
+		maxTokens: 8192,
+		contextWindow: 200_000,
+		supportsImages: true,
+		supportsComputerUse: true,
+		supportsPromptCache: true,
+		inputPrice: 3.0, // $3 per million input tokens
+		outputPrice: 15.0, // $15 per million output tokens
+		cacheWritesPrice: 3.75, // $3.75 per million tokens
+		cacheReadsPrice: 0.3, // $0.30 per million tokens
+	},
 	"claude-3-5-haiku-20241022": {
 		maxTokens: 8192,
 		contextWindow: 200_000,


### PR DESCRIPTION
Currently Anthropic supports two Sonnet 3.5 models, so include them both for available use by Cline users. Token accounting at Anthropic is different between the two models, so if you run out of tokens on one, you can switch to the other.

Related issues:
- #602 
- #677 