### PR TITLE
added gemini exp 1121 and 1206 to api.ts

### DIFF
--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -277,6 +277,16 @@ export const geminiModels = {
 		inputPrice: 0,
 		outputPrice: 0,
 	},
+
+        "gemini-exp-1121": {
+		maxTokens: 8192,
+                contextWindow: 32_768,
+                supportsImages: true,
+		supportsPromptCache: false,
+		inputPrice: 0,
+		outputPrice: 0,
+        },
+	
 } as const satisfies Record<string, ModelInfo>
 
 // OpenAI Native

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -286,7 +286,6 @@ export const geminiModels = {
 		inputPrice: 0,
 		outputPrice: 0,
         },
-	
 } as const satisfies Record<string, ModelInfo>
 
 // OpenAI Native

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -286,6 +286,14 @@ export const geminiModels = {
 		inputPrice: 0,
 		outputPrice: 0,
         },
+	"gemini-exp-1206": {
+		maxTokens: 8192,
+                contextWindow: 2_097_152,
+                supportsImages: true,
+		supportsPromptCache: false,
+		inputPrice: 0,
+		outputPrice: 0,
+        },
 } as const satisfies Record<string, ModelInfo>
 
 // OpenAI Native


### PR DESCRIPTION
I added gemini exp 1121 to the api.ts 
according to/based on the original data provided by the google api:

{
      "name": "models/gemini-exp-1121",
      "version": "exp-1121",
      "displayName": "Gemini Experimental 1121",
      "description": "Experimental release (November 21st, 2024) of Gemini.",
      "inputTokenLimit": 32768,
      "outputTokenLimit": 8192,
      "supportedGenerationMethods": [
        "generateContent",
        "countTokens"
      ],
      "temperature": 1,
      "topP": 0.95,
      "topK": 64,
      "maxTemperature": 2
    },

