### PR TITLE
⚙️ chore(glob): add globby config options to handle Next.js route gro…

### DIFF
--- a/src/services/glob/list-files.ts
+++ b/src/services/glob/list-files.ts
@@ -44,6 +44,9 @@ export async function listFiles(dirPath: string, recursive: boolean, limit: numb
 		gitignore: recursive, // globby ignores any files that are gitignored
 		ignore: recursive ? dirsToIgnore : undefined, // just in case there is no gitignore, we ignore sensible defaults
 		onlyFiles: false, // true by default, false means it will list directories on their own too
+		braceExpansion: false, // disable brace expansion to properly handle Next.js route groups
+		extglob: false, // disable extended glob patterns
+		expandDirectories: false // disable directory expansion to handle special characters in paths
 	}
 	// * globs all files in one dir, ** globs files in nested directories
 	const files = recursive ? await globbyLevelByLevel(limit, options) : (await globby("*", options)).slice(0, limit)


### PR DESCRIPTION
fix: support Next.js 13 route group folders in file listing

This PR fixes an issue where Next.js 13 route group folders (e.g., (dashboard)) were not visible when using @ to specify directories. The problem occurred because globby was treating parentheses as special characters for pattern matching.

Technical Details:

Next.js 13 uses parentheses in folder names for route grouping (e.g., (dashboard))
Previously, these folders were not properly listed due to globby's default pattern matching behavior
Special characters in folder names were being interpreted as glob syntax
Changes:

Disabled brace expansion to prevent parentheses from being treated as special characters
Turned off extended glob patterns to handle special characters in paths
Disabled directory expansion to ensure proper handling of route group folder names
Impact:

Next.js 13 route group folders are now properly visible and accessible
No changes to existing file listing behavior for regular folders
Maintains all other functionality (recursive search, directory ignoring, etc.)