### PR TITLE
Added "Approve All" checkbox to chat window to allow toggle-able autonomy

### DIFF
--- a/webview-ui/src/components/chat/ChatView.tsx
+++ b/webview-ui/src/components/chat/ChatView.tsx
@@ -1,4 +1,4 @@
-import { VSCodeButton, VSCodeLink } from "@vscode/webview-ui-toolkit/react"
+import { VSCodeButton, VSCodeLink, VSCodeCheckbox } from "@vscode/webview-ui-toolkit/react"
 import debounce from "debounce"
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { useDeepCompareEffect, useEvent, useMount } from "react-use"
@@ -60,6 +60,7 @@ const ChatView = ({ isHidden, showAnnouncement, hideAnnouncement, showHistoryVie
 	const disableAutoScrollRef = useRef(false)
 	const [showScrollToBottom, setShowScrollToBottom] = useState(false)
 	const [isAtBottom, setIsAtBottom] = useState(false)
+	const [approveAll, setApproveAll] = useState(false)
 
 	// UI layout depends on the last 2 messages
 	// (since it relies on the content of these messages, we are deep comparing. i.e. the button state after hitting button sets enableButtons to false, and this effect otherwise would have to true again even if messages didn't change
@@ -674,6 +675,15 @@ const ChatView = ({ isHidden, showAnnouncement, hideAnnouncement, showHistoryVie
 		[expandedRows, modifiedMessages, groupedMessages.length, toggleRowExpansion, handleRowHeightChange],
 	)
 
+	useEffect(() => {
+		if (approveAll && enableButtons && primaryButtonText) {
+			const autoApproveTexts = ["Run Command", "Proceed While Running", "Approve", "Save"]
+			if (autoApproveTexts.includes(primaryButtonText)) {
+				handlePrimaryButtonClick()
+			}
+		}
+	}, [approveAll, enableButtons, primaryButtonText, handlePrimaryButtonClick])
+
 	return (
 		<div
 			style={{
@@ -778,6 +788,7 @@ const ChatView = ({ isHidden, showAnnouncement, hideAnnouncement, showHistoryVie
 										: 0,
 								display: "flex",
 								padding: "10px 15px 0px 15px",
+								alignItems: "center",
 							}}>
 							{primaryButtonText && !isStreaming && (
 								<VSCodeButton
@@ -803,6 +814,12 @@ const ChatView = ({ isHidden, showAnnouncement, hideAnnouncement, showHistoryVie
 									{isStreaming ? "Cancel" : secondaryButtonText}
 								</VSCodeButton>
 							)}
+							<VSCodeCheckbox
+								style={{ marginLeft: "10px" }}
+								checked={approveAll}
+								onChange={(e) => setApproveAll((e.target as HTMLInputElement).checked)}>
+								Auto-approve
+							</VSCodeCheckbox>
 						</div>
 					)}
 				</>


### PR DESCRIPTION
Added "Approve All" checkbox and behavior to chat view to allow user to grant Cline autonomy (able to write files, run scripts, etc). Toggling the check off will restore normal operation once Cline finishes current task (if any). Will not override Cline requesting feedback or reporting errors. Very minor change but it entirely changes my usage of the extension. I have a seperate fork maintained primarily for this reason but would love it to be available in the core extension.

![image](https://github.com/user-attachments/assets/b64e292e-eec0-4d2b-902f-e56098bfe483)
