### PR TITLE
Add viewport setting to Cline

### DIFF
--- a/src/services/browser/BrowserSession.ts
+++ b/src/services/browser/BrowserSession.ts
@@ -19,6 +19,7 @@ export class BrowserSession {
 	private browser?: Browser
 	private page?: Page
 	private currentMousePosition?: string
+	private defaultViewport = { width: 1280, height: 720 }
 
 	constructor(context: vscode.ExtensionContext) {
 		this.context = context
@@ -58,10 +59,7 @@ export class BrowserSession {
 				"--user-agent=Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/128.0.0.0 Safari/537.36",
 			],
 			executablePath: stats.executablePath,
-			defaultViewport: {
-				width: 900,
-				height: 600,
-			},
+			defaultViewport: this.defaultViewport,
 			// headless: false,
 		})
 		// (latest version of puppeteer does not add headless to user agent)
@@ -266,5 +264,12 @@ export class BrowserSession {
 			})
 			await delay(300)
 		})
+	}
+
+	async changeViewport(width: number, height: number): Promise<void> {
+		this.defaultViewport = { width, height }
+		if (this.page) {
+			await this.page.setViewport(this.defaultViewport)
+		}
 	}
 }

--- a/webview-ui/src/components/settings/ApiOptions.tsx
+++ b/webview-ui/src/components/settings/ApiOptions.tsx
@@ -49,6 +49,7 @@ const ApiOptions = ({ showModelOptions, apiErrorMessage, modelIdErrorMessage }: 
 	const [anthropicBaseUrlSelected, setAnthropicBaseUrlSelected] = useState(!!apiConfiguration?.anthropicBaseUrl)
 	const [azureApiVersionSelected, setAzureApiVersionSelected] = useState(!!apiConfiguration?.azureApiVersion)
 	const [isDescriptionExpanded, setIsDescriptionExpanded] = useState(false)
+	const [viewportResolution, setViewportResolution] = useState<string>("1280x720")
 
 	const handleInputChange = (field: keyof ApiConfiguration) => (event: any) => {
 		setApiConfiguration({ ...apiConfiguration, [field]: event.target.value })
@@ -650,7 +651,36 @@ const ApiOptions = ({ showModelOptions, apiErrorMessage, modelIdErrorMessage }: 
 					}}>
 					{modelIdErrorMessage}
 				</p>
-			)}
+				)}
+
+				<div style={{ marginBottom: 5 }}>
+					<label htmlFor="viewport-resolution">
+						<span style={{ fontWeight: 500 }}>Viewport Resolution</span>
+					</label>
+					<VSCodeDropdown
+						id="viewport-resolution"
+						value={viewportResolution}
+						onChange={(e: any) => setViewportResolution(e.target.value)}
+						style={{ width: "100%" }}>
+						<VSCodeOption value="1280x720">1280x720 (HD)</VSCodeOption>
+						<VSCodeOption value="1920x1080">1920x1080 (Full HD)</VSCodeOption>
+						<VSCodeOption value="1366x768">1366x768 (WXGA)</VSCodeOption>
+						<VSCodeOption value="1440x900">1440x900 (WXGA+)</VSCodeOption>
+						<VSCodeOption value="1536x864">1536x864 (HD+)</VSCodeOption>
+						<VSCodeOption value="1600x900">1600x900 (HD+)</VSCodeOption>
+						<VSCodeOption value="1680x1050">1680x1050 (WSXGA+)</VSCodeOption>
+						<VSCodeOption value="2560x1440">2560x1440 (QHD)</VSCodeOption>
+						<VSCodeOption value="3840x2160">3840x2160 (4K UHD)</VSCodeOption>
+					</VSCodeDropdown>
+					<p
+						style={{
+							fontSize: "12px",
+							marginTop: "5px",
+							color: "var(--vscode-descriptionForeground)",
+						}}>
+						Select a common resolution for the viewport while the extension is running.
+					</p>
+				</div>
 		</div>
 	)
 }

--- a/webview-ui/src/components/settings/SettingsView.tsx
+++ b/webview-ui/src/components/settings/SettingsView.tsx
@@ -1,4 +1,4 @@
-import { VSCodeButton, VSCodeCheckbox, VSCodeLink, VSCodeTextArea } from "@vscode/webview-ui-toolkit/react"
+import { VSCodeButton, VSCodeCheckbox, VSCodeDropdown, VSCodeLink, VSCodeOption, VSCodeTextArea } from "@vscode/webview-ui-toolkit/react"
 import { memo, useEffect, useState } from "react"
 import { useExtensionState } from "../../context/ExtensionStateContext"
 import { validateApiConfiguration, validateModelId } from "../../utils/validate"
@@ -23,6 +23,7 @@ const SettingsView = ({ onDone }: SettingsViewProps) => {
 	} = useExtensionState()
 	const [apiErrorMessage, setApiErrorMessage] = useState<string | undefined>(undefined)
 	const [modelIdErrorMessage, setModelIdErrorMessage] = useState<string | undefined>(undefined)
+	const [viewportResolution, setViewportResolution] = useState<string>("1280x720")
 	const handleSubmit = () => {
 		const apiValidationResult = validateApiConfiguration(apiConfiguration)
 		const modelIdValidationResult = validateModelId(apiConfiguration, openRouterModels)
@@ -33,6 +34,7 @@ const SettingsView = ({ onDone }: SettingsViewProps) => {
 			vscode.postMessage({ type: "apiConfiguration", apiConfiguration })
 			vscode.postMessage({ type: "customInstructions", text: customInstructions })
 			vscode.postMessage({ type: "alwaysAllowReadOnly", bool: alwaysAllowReadOnly })
+			vscode.postMessage({ type: "viewportResolution", resolution: viewportResolution })
 			onDone()
 		}
 	}
@@ -127,6 +129,35 @@ const SettingsView = ({ onDone }: SettingsViewProps) => {
 						}}>
 						When enabled, Cline will automatically view directory contents and read files without requiring
 						you to click the Approve button.
+					</p>
+				</div>
+
+				<div style={{ marginBottom: 5 }}>
+					<label htmlFor="viewport-resolution">
+						<span style={{ fontWeight: 500 }}>Viewport Resolution</span>
+					</label>
+					<VSCodeDropdown
+						id="viewport-resolution"
+						value={viewportResolution}
+						onChange={(e: any) => setViewportResolution(e.target.value)}
+						style={{ width: "100%" }}>
+						<VSCodeOption value="1280x720">1280x720 (HD)</VSCodeOption>
+						<VSCodeOption value="1920x1080">1920x1080 (Full HD)</VSCodeOption>
+						<VSCodeOption value="1366x768">1366x768 (WXGA)</VSCodeOption>
+						<VSCodeOption value="1440x900">1440x900 (WXGA+)</VSCodeOption>
+						<VSCodeOption value="1536x864">1536x864 (HD+)</VSCodeOption>
+						<VSCodeOption value="1600x900">1600x900 (HD+)</VSCodeOption>
+						<VSCodeOption value="1680x1050">1680x1050 (WSXGA+)</VSCodeOption>
+						<VSCodeOption value="2560x1440">2560x1440 (QHD)</VSCodeOption>
+						<VSCodeOption value="3840x2160">3840x2160 (4K UHD)</VSCodeOption>
+					</VSCodeDropdown>
+					<p
+						style={{
+							fontSize: "12px",
+							marginTop: "5px",
+							color: "var(--vscode-descriptionForeground)",
+						}}>
+						Select a common resolution for the viewport while the extension is running.
 					</p>
 				</div>
 


### PR DESCRIPTION
Add a setting to change the default viewport resolution for the computer use to common resolutions and device types.

* Update `src/services/browser/BrowserSession.ts` to set the default viewport to 1280x720 and add a method to change the viewport resolution while Cline is running.
* Add a dropdown menu in `webview-ui/src/components/settings/SettingsView.tsx` to select common resolutions and device types, and update the state to store the selected resolution.
* Add options for changing the viewport resolution in `webview-ui/src/components/settings/ApiOptions.tsx` and update the state to store the selected resolution.
* Add settings for changing the viewport resolution in `src/core/webview/ClineProvider.ts`, update the state to store the selected resolution, and ensure the option only appears if the model supports computer use.

