### PR TITLE
Fix: Context mentions menu is not legible with light+ theme (#745)

### DIFF
--- a/webview-ui/src/components/chat/ContextMenu.tsx
+++ b/webview-ui/src/components/chat/ContextMenu.tsx
@@ -129,14 +129,17 @@ const ContextMenu: React.FC<ContextMenuProps> = ({
 						style={{
 							padding: "8px 12px",
 							cursor: isOptionSelectable(option) ? "pointer" : "default",
-							color: "var(--vscode-dropdown-foreground)",
+							color: 
+								index === selectedIndex && isOptionSelectable(option)
+									? "var(--vscode-quickInputList-focusForeground)"
+									: "",
 							borderBottom: "1px solid var(--vscode-editorGroup-border)",
 							display: "flex",
 							alignItems: "center",
 							justifyContent: "space-between",
 							backgroundColor:
 								index === selectedIndex && isOptionSelectable(option)
-									? "var(--vscode-list-activeSelectionBackground)"
+									? "var(--vscode-quickInputList-focusBackground)"
 									: "",
 						}}
 						onMouseEnter={() => isOptionSelectable(option) && setSelectedIndex(index)}>


### PR DESCRIPTION
I inspected the dropdowns in VSCode settings and found [`quickInputList` CSS variables](https://code.visualstudio.com/api/references/theme-color#quick-picker-colors) are used.