### PR TITLE
fix: Reuse the previous command line

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "claude-dev",
-	"version": "2.2.2",
+	"version": "3.0.3",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "claude-dev",
-			"version": "2.2.2",
+			"version": "3.0.3",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@anthropic-ai/bedrock-sdk": "^0.10.2",

--- a/src/integrations/terminal/TerminalProcess.ts
+++ b/src/integrations/terminal/TerminalProcess.ts
@@ -170,15 +170,9 @@ export class TerminalProcess extends EventEmitter<TerminalProcessEvents> {
 			this.emit("continue")
 		} else {
 			terminal.sendText(command, true)
-			// For terminals without shell integration, we can't know when the command completes
-			// So we'll just emit the continue event after a delay
 			this.emit("completed")
 			this.emit("continue")
 			this.emit("no_shell_integration")
-			// setTimeout(() => {
-			// 	console.log(`Emitting continue after delay for terminal`)
-			// 	// can't emit completed since we don't if the command actually completed, it could still be running server
-			// }, 500) // Adjust this delay as needed
 		}
 	}
 

--- a/src/integrations/terminal/TerminalRegistry.ts
+++ b/src/integrations/terminal/TerminalRegistry.ts
@@ -14,6 +14,10 @@ export class TerminalRegistry {
 	private static nextTerminalId = 1
 
 	static createTerminal(cwd?: string | vscode.Uri | undefined): TerminalInfo {
+		const freeTerminal = this.getFreeTerminal(cwd?.toString() || "")
+		if (freeTerminal) {
+			return freeTerminal
+		}
 		const terminal = vscode.window.createTerminal({
 			cwd,
 			name: "Cline",
@@ -57,5 +61,14 @@ export class TerminalRegistry {
 	// The exit status of the terminal will be undefined while the terminal is active. (This value is set when onDidCloseTerminal is fired.)
 	private static isTerminalClosed(terminal: vscode.Terminal): boolean {
 		return terminal.exitStatus !== undefined
+	}
+
+	static getFreeTerminal(cwd: string): TerminalInfo | undefined {
+		return this.terminals.find((t) => {
+			const tmp = t.terminal.creationOptions
+			if (!tmp) {
+				return false
+			}
+			return !t.busy && (tmp as vscode.TerminalOptions).cwd === cwd})
 	}
 }


### PR DESCRIPTION
### Description
I change the three files in src/integrations/terminal. They will check if there is a free terminal. If so, we will use it instead of create a new one. Because there maybe some cd operations, which need to use the same terminal.

### Type of Change
- [ x ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update

### Pre-flight Checklist
<!-- Put an 'x' in all boxes that apply -->

- [ x ] Changes are limited to a single feature, bugfix or chore (split larger changes into seperate PRs)
- [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
- [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTOR.md)
