### PR TITLE
feat: add optional API Key setting for Ollama

### DIFF
--- a/src/api/providers/ollama.ts
+++ b/src/api/providers/ollama.ts
@@ -13,7 +13,7 @@ export class OllamaHandler implements ApiHandler {
 		this.options = options
 		this.client = new OpenAI({
 			baseURL: (this.options.ollamaBaseUrl || "http://localhost:11434") + "/v1",
-			apiKey: "ollama",
+			apiKey: this.options.ollamaApiKey || "ollama",
 		})
 	}
 

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -39,6 +39,7 @@ type SecretKey =
 	| "openAiApiKey"
 	| "geminiApiKey"
 	| "openAiNativeApiKey"
+	| "ollamaApiKey"
 type GlobalStateKey =
 	| "apiProvider"
 	| "apiModelId"
@@ -373,6 +374,7 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 								openAiModelId,
 								ollamaModelId,
 								ollamaBaseUrl,
+								ollamaApiKey,
 								lmStudioModelId,
 								lmStudioBaseUrl,
 								anthropicBaseUrl,
@@ -398,6 +400,7 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 							await this.updateGlobalState("openAiModelId", openAiModelId)
 							await this.updateGlobalState("ollamaModelId", ollamaModelId)
 							await this.updateGlobalState("ollamaBaseUrl", ollamaBaseUrl)
+							await this.storeSecret("ollamaApiKey", ollamaApiKey)
 							await this.updateGlobalState("lmStudioModelId", lmStudioModelId)
 							await this.updateGlobalState("lmStudioBaseUrl", lmStudioBaseUrl)
 							await this.updateGlobalState("anthropicBaseUrl", anthropicBaseUrl)
@@ -1074,6 +1077,7 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 			"openAiApiKey",
 			"geminiApiKey",
 			"openAiNativeApiKey",
+			"ollamaApiKey",
 		]
 		for (const key of secretKeys) {
 			await this.storeSecret(key, undefined)

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -28,6 +28,7 @@ export interface ApiHandlerOptions {
 	openAiModelId?: string
 	ollamaModelId?: string
 	ollamaBaseUrl?: string
+	ollamaApiKey?: string
 	lmStudioModelId?: string
 	lmStudioBaseUrl?: string
 	geminiApiKey?: string

--- a/webview-ui/src/components/settings/ApiOptions.tsx
+++ b/webview-ui/src/components/settings/ApiOptions.tsx
@@ -549,6 +549,22 @@ const ApiOptions = ({ showModelOptions, apiErrorMessage, modelIdErrorMessage }: 
 						<span style={{ fontWeight: 500 }}>Base URL (optional)</span>
 					</VSCodeTextField>
 					<VSCodeTextField
+						value={apiConfiguration?.ollamaApiKey || ""}
+						style={{ width: "100%" }}
+						type="password"
+						onInput={handleInputChange("ollamaApiKey")}
+						placeholder="Enter API Key...">
+						<span style={{ fontWeight: 500 }}>(optional) API Key</span>
+					</VSCodeTextField>
+					<p
+						style={{
+							fontSize: "12px",
+							marginTop: "5px",
+							color: "var(--vscode-descriptionForeground)",
+						}}>
+						This key is stored locally and only used to make API requests from this extension.{" "}
+					</p>
+					<VSCodeTextField
 						value={apiConfiguration?.ollamaModelId || ""}
 						style={{ width: "100%" }}
 						onInput={handleInputChange("ollamaModelId")}

--- a/webview-ui/src/context/ExtensionStateContext.tsx
+++ b/webview-ui/src/context/ExtensionStateContext.tsx
@@ -57,6 +57,7 @@ export const ExtensionStateContextProvider: React.FC<{ children: React.ReactNode
 							config.awsRegion,
 							config.vertexProjectId,
 							config.openAiApiKey,
+							config.ollamaApiKey,
 							config.ollamaModelId,
 							config.lmStudioModelId,
 							config.geminiApiKey,


### PR DESCRIPTION
### Description
I have my ollama instance behind a reverse proxy that accepts auth in the same manor that OpenAI js library sends. This adds an optional field to allow for customization of the key that is sent.

### Type of Change
<!-- Put an 'x' in all boxes that apply -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update

### Pre-flight Checklist

- [x] Changes are limited to a single feature, bugfix or chore (split larger changes into seperate PRs)
- [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
- [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots
<!-- For UI changes, add screenshots here -->

