### PR TITLE
fix: typo in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,9 +12,9 @@
 ### Pre-flight Checklist
 <!-- Put an 'x' in all boxes that apply -->
 
-- [ ] Changes are limited to a single feature, bugfix or chore (split larger changes into seperate PRs)
+- [ ] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
 - [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-- [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTOR.md)
+- [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)
 
 ### Screenshots
 <!-- For UI changes, add screenshots here -->


### PR DESCRIPTION
### Description
minor typos in the pull request template that I noticed when contributing my previous PR

### Type of Change
<!-- Put an 'x' in all boxes that apply -->

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] 📚 Documentation update

### Pre-flight Checklist
<!-- Put an 'x' in all boxes that apply -->

- [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
- [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
- [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTOR.md)

### Screenshots
<!-- For UI changes, add screenshots here -->

### Additional Notes
<!-- Add any additional notes for reviewers -->
