### PR TITLE
Use createFileSystemWatcher to more reliably watch for file system changes

### DIFF
--- a/src/integrations/workspace/WorkspaceTracker.ts
+++ b/src/integrations/workspace/WorkspaceTracker.ts
@@ -27,58 +27,36 @@ class WorkspaceTracker {
 	}
 
 	private registerListeners() {
+		// Create a file system watcher for all files
+		const watcher = vscode.workspace.createFileSystemWatcher('**')
+
 		// Listen for file creation
-		// .bind(this) ensures the callback refers to class instance when using this, not necessary when using arrow function
-		this.disposables.push(vscode.workspace.onDidCreateFiles(this.onFilesCreated.bind(this)))
+		this.disposables.push(
+			watcher.onDidCreate(async (uri) => {
+				await this.addFilePath(uri.fsPath)
+				this.workspaceDidUpdate()
+			})
+		)
 
 		// Listen for file deletion
-		this.disposables.push(vscode.workspace.onDidDeleteFiles(this.onFilesDeleted.bind(this)))
-
-		// Listen for file renaming
-		this.disposables.push(vscode.workspace.onDidRenameFiles(this.onFilesRenamed.bind(this)))
-
-		/*
-		 An event that is emitted when a workspace folder is added or removed.
-		 **Note:** this event will not fire if the first workspace folder is added, removed or changed,
-		 because in that case the currently executing extensions (including the one that listens to this
-		 event) will be terminated and restarted so that the (deprecated) `rootPath` property is updated
-		 to point to the first workspace folder.
-		 */
-		// In other words, we don't have to worry about the root workspace folder ([0]) changing since the extension will be restarted and our cwd will be updated to reflect the new workspace folder. (We don't care about non root workspace folders, since cline will only be working within the root folder cwd)
-		// this.disposables.push(vscode.workspace.onDidChangeWorkspaceFolders(this.onWorkspaceFoldersChanged.bind(this)))
-	}
-
-	private async onFilesCreated(event: vscode.FileCreateEvent) {
-		await Promise.all(
-			event.files.map(async (file) => {
-				await this.addFilePath(file.fsPath)
-			}),
-		)
-		this.workspaceDidUpdate()
-	}
-
-	private async onFilesDeleted(event: vscode.FileDeleteEvent) {
-		let updated = false
-		await Promise.all(
-			event.files.map(async (file) => {
-				if (await this.removeFilePath(file.fsPath)) {
-					updated = true
+		this.disposables.push(
+			watcher.onDidDelete(async (uri) => {
+				if (await this.removeFilePath(uri.fsPath)) {
+					this.workspaceDidUpdate()
 				}
-			}),
+			})
 		)
-		if (updated) {
-			this.workspaceDidUpdate()
-		}
-	}
 
-	private async onFilesRenamed(event: vscode.FileRenameEvent) {
-		await Promise.all(
-			event.files.map(async (file) => {
-				await this.removeFilePath(file.oldUri.fsPath)
-				await this.addFilePath(file.newUri.fsPath)
-			}),
+		// Listen for file changes (which could include renames)
+		this.disposables.push(
+			watcher.onDidChange(async (uri) => {
+				await this.addFilePath(uri.fsPath)
+				this.workspaceDidUpdate()
+			})
 		)
-		this.workspaceDidUpdate()
+
+		// Add the watcher itself to disposables
+		this.disposables.push(watcher)
 	}
 
 	private workspaceDidUpdate() {


### PR DESCRIPTION
### Description
This is an attempt to fix https://github.com/cline/cline/issues/772 by using a file system watcher.

### Type of Change
<!-- Put an 'x' in all boxes that apply -->

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update

### Pre-flight Checklist
<!-- Put an 'x' in all boxes that apply -->

- [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
- [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
- [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)
