### PR TITLE
MCP image response handling

### DIFF
--- a/src/core/Cline.ts
+++ b/src/core/Cline.ts
@@ -1909,29 +1909,9 @@ export class Cline {
 									}
 								}
 
-								// TODO: add progress indicator and ability to parse images and non-text responses
-								// const toolResultImages: string[] = []
-								// const toolResultPretty =
-								// 	(toolResult?.isError ? "Error:\n" : "") +
-								// 		toolResult?.content
-								// 			.map((item) => {
-								// 				if (item.type === "text") {
-								// 					return item.text
-								// 				}
-								// 				if (item.type === "resource") {
-								// 					const { blob, ...rest } = item.resource
-								// 					return JSON.stringify(rest, null, 2)
-								// 				}
-								// 				if (item.type === "image") {
-								// 					toolResultImages.push(`data:${item.mimeType};base64,${item.data}`)
-								// 				}
-								// 				return ""
-								// 			})
-								// 			.filter(Boolean)
-								// 			.join("\n\n") || "(No response)"
-	
 								// In order to return response text & images in correct order, we fragment message content
 								// TODO: Make it so we can "say" array of Anthropic messages to avoid this complex logic
+								// TODO: add progress indicator and ability to parse images and non-text responses
 								var img_acc = []
 								var text_acc = [toolResult?.isError ? "Error:\n" : ""]
 								async function forwardResponseBlock(
@@ -1972,9 +1952,6 @@ export class Cline {
 								if (img_acc.length > 0 || text_acc.length > 0) {
 									await forwardResponseBlock(this, text_acc, img_acc)
 								}
-
-								// await this.say("mcp_server_response", toolResultPretty, toolResultImages)
-								// pushToolResult(formatResponse.toolResult(toolResultPretty, toolResultImages))
 								break
 							}
 						} catch (error) {

--- a/webview-ui/src/components/chat/ChatRow.tsx
+++ b/webview-ui/src/components/chat/ChatRow.tsx
@@ -894,6 +894,9 @@ export const ChatRowContent = ({
 									isExpanded={true}
 									onToggleExpand={onToggleExpand}
 								/>
+								{message.images && message.images.length > 0 && (
+									<Thumbnails images={message.images} style={{ marginTop: "8px" }} />
+								)}
 							</div>
 						</>
 					)


### PR DESCRIPTION
### Description

Solves issue  #1033 

Contributions:
- Reworked MCP server response handler. Rather than joining everything into a single string, the MCP server response is broken into a minimum number of Cline messages that respects the original ordering of the messages. 
- Added thumbnails to the mcp_server_response type of ChatRow

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

![image](https://github.com/user-attachments/assets/9158441e-0365-4bd5-a50d-c89db5cadef6)

### Additional Notes

Encountered issues running tests, needed to upgrade @vscode/test-cli from version ^0.0.9 to ^0.0.10 and @vscode/test-electron from version ^2.4.0 to ^2.4.1
