### PR TITLE
corrected "guard" typo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -203,7 +203,7 @@
 - Adds "Always allow read-only operations" setting to let Claude read files and view directories without needing approval (off by default)
 - Implement sliding window context management to keep tasks going past 200k tokens
 - Adds Google Cloud Vertex AI support and updates Claude 3.5 Sonnet max output to 8192 tokens for all providers.
-- Improves system prompt to gaurd against lazy edits (less "//rest of code here")
+- Improves system prompt to guard against lazy edits (less "//rest of code here")
 
 ## [1.3.0]
 

--- a/cspell.json
+++ b/cspell.json
@@ -1,0 +1,19 @@
+{
+    "version": "0.2",
+    "language": "en",
+    "words": [
+        "clinerules",
+        "Ollama",
+        "saoudrizwan",
+        "openrouter",
+        "popout",
+        "modelcontextprotocol",
+        "isbinaryfile",
+        "wasms"
+    ],
+    "ignorePaths": [
+        "node_modules/**",
+        "dist/**",
+        "*.lock"
+    ]
+}


### PR DESCRIPTION
### Description

This PR addresses spelling issues in the codebase:
1. Fixes the misspelling of "gaurd" to "guard" in CHANGELOG.md
2. Adds a cspell.json configuration file to whitelist valid technical terms used in the project

### Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update

### Pre-flight Checklist

- [x] Changes are limited to a single feature, bugfix or chore (spelling fixes only)
- [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
- [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Additional Notes

The following technical terms have been added to cspell.json to prevent false positives:
- clinerules (configuration file name)
- Ollama (API provider)
- saoudrizwan (publisher name)
- openrouter (package/service)
- popout (UI functionality)
- modelcontextprotocol (dependency)
- isbinaryfile (npm package)
- wasms (dependency)

These terms are valid within the context of this project and should not trigger spell check warnings.