### PR TITLE
Improve terminal state management and error handling

### DIFF
--- a/src/integrations/terminal/TerminalManager.ts
+++ b/src/integrations/terminal/TerminalManager.ts
@@ -116,7 +116,10 @@ export class TerminalManager {
 		this.processes.set(terminalInfo.id, process)
 
 		process.once("completed", () => {
-			terminalInfo.busy = false
+			// Reset terminal state completely
+			TerminalRegistry.resetTerminalState(terminalInfo.id)
+			// Remove the process from tracking to prevent stale state
+			this.processes.delete(terminalInfo.id)
 		})
 
 		// if shell integration is not available, remove terminal so it does not get reused as it may be running a long-running process

--- a/src/integrations/terminal/TerminalProcess.ts
+++ b/src/integrations/terminal/TerminalProcess.ts
@@ -30,19 +30,35 @@ export class TerminalProcess extends EventEmitter<TerminalProcessEvents> {
 		if (terminal.shellIntegration && terminal.shellIntegration.executeCommand) {
 			const execution = terminal.shellIntegration.executeCommand(command)
 			const stream = execution.read()
-			// todo: need to handle errors
 			let isFirstChunk = true
+			let exitCode: number | null = null
 			let didOutputNonCommand = false
 			let didEmitEmptyLine = false
-			for await (let data of stream) {
-				// 1. Process chunk and remove artifacts
-				if (isFirstChunk) {
-					/*
+			let hasProcessedAnyData = false
+
+			// Start a timeout to handle commands that complete without any output
+			const noOutputTimeout = setTimeout(() => {
+				if (!hasProcessedAnyData) {
+					this.isHot = false
+					this.emit("line", "")
+					this.emit("completed")
+					this.emit("continue")
+				}
+			}, 100) // Short timeout for no-output commands
+			try {
+				for await (let data of stream) {
+					// Clear the no-output timeout since we got data
+					clearTimeout(noOutputTimeout)
+					hasProcessedAnyData = true
+
+					// 1. Process chunk and remove artifacts
+					if (isFirstChunk) {
+						/*
 					The first chunk we get from this stream needs to be processed to be more human readable, ie remove vscode's custom escape sequences and identifiers, removing duplicate first char bug, etc.
 					*/
 
-					// bug where sometimes the command output makes its way into vscode shell integration metadata
-					/*
+						// bug where sometimes the command output makes its way into vscode shell integration metadata
+						/*
 					]633 is a custom sequence number used by VSCode shell integration:
 					- OSC 633 ; A ST - Mark prompt start
 					- OSC 633 ; B ST - Mark prompt end
@@ -50,124 +66,156 @@ export class TerminalProcess extends EventEmitter<TerminalProcessEvents> {
 					- OSC 633 ; D [; <exitcode>] ST - Mark execution finished with optional exit code
 					- OSC 633 ; E ; <commandline> [; <nonce>] ST - Explicitly set command line with optional nonce
 					*/
-					// if you print this data you might see something like "eecho hello worldo hello world;5ba85d14-e92a-40c4-b2fd-71525581eeb0]633;C" but this is actually just a bunch of escape sequences, ignore up to the first ;C
-					/* ddateb15026-6a64-40db-b21f-2a621a9830f0]633;CTue Sep 17 06:37:04 EDT 2024 % ]633;D;0]633;P;Cwd=/Users/saoud/Repositories/test */
-					// Gets output between ]633;C (command start) and ]633;D (command end)
-					const outputBetweenSequences = this.removeLastLineArtifacts(
-						data.match(/\]633;C([\s\S]*?)\]633;D/)?.[1] || "",
-					).trim()
-
-					// Once we've retrieved any potential output between sequences, we can remove everything up to end of the last sequence
-					// https://code.visualstudio.com/docs/terminal/shell-integration#_vs-code-custom-sequences-osc-633-st
-					const vscodeSequenceRegex = /\x1b\]633;.[^\x07]*\x07/g
-					const lastMatch = [...data.matchAll(vscodeSequenceRegex)].pop()
-					if (lastMatch && lastMatch.index !== undefined) {
-						data = data.slice(lastMatch.index + lastMatch[0].length)
-					}
-					// Place output back after removing vscode sequences
-					if (outputBetweenSequences) {
-						data = outputBetweenSequences + "\n" + data
-					}
-					// remove ansi
-					data = stripAnsi(data)
-					// Split data by newlines
-					let lines = data ? data.split("\n") : []
-					// Remove non-human readable characters from the first line
-					if (lines.length > 0) {
-						lines[0] = lines[0].replace(/[^\x20-\x7E]/g, "")
-					}
-					// Check if first two characters are the same, if so remove the first character
-					if (lines.length > 0 && lines[0].length >= 2 && lines[0][0] === lines[0][1]) {
-						lines[0] = lines[0].slice(1)
-					}
-					// Remove everything up to the first alphanumeric character for first two lines
-					if (lines.length > 0) {
-						lines[0] = lines[0].replace(/^[^a-zA-Z0-9]*/, "")
-					}
-					if (lines.length > 1) {
-						lines[1] = lines[1].replace(/^[^a-zA-Z0-9]*/, "")
-					}
-					// Join lines back
-					data = lines.join("\n")
-					isFirstChunk = false
-				} else {
-					data = stripAnsi(data)
-				}
-
-				// first few chunks could be the command being echoed back, so we must ignore
-				// note this means that 'echo' commands wont work
-				if (!didOutputNonCommand) {
-					const lines = data.split("\n")
-					for (let i = 0; i < lines.length; i++) {
-						if (command.includes(lines[i].trim())) {
-							lines.splice(i, 1)
-							i-- // Adjust index after removal
-						} else {
-							didOutputNonCommand = true
-							break
+						// if you print this data you might see something like "eecho hello worldo hello world;5ba85d14-e92a-40c4-b2fd-71525581eeb0]633;C" but this is actually just a bunch of escape sequences, ignore up to the first ;C
+						/* ddateb15026-6a64-40db-b21f-2a621a9830f0]633;CTue Sep 17 06:37:04 EDT 2024 % ]633;D;0]633;P;Cwd=/Users/saoud/Repositories/test */
+						// Gets output between ]633;C (command start) and ]633;D (command end)
+						const exitCodeMatch = data.match(/\]633;D;(\d+)/)
+						if (exitCodeMatch) {
+							exitCode = parseInt(exitCodeMatch[1])
 						}
+
+						const outputBetweenSequences = this.removeLastLineArtifacts(
+							data.match(/\]633;C([\s\S]*?)\]633;D/)?.[1] || "",
+						).trim()
+
+						// Once we've retrieved any potential output between sequences, we can remove everything up to end of the last sequence
+						// https://code.visualstudio.com/docs/terminal/shell-integration#_vs-code-custom-sequences-osc-633-st
+						const vscodeSequenceRegex = /\x1b\]633;.[^\x07]*\x07/g
+						const lastMatch = [...data.matchAll(vscodeSequenceRegex)].pop()
+						if (lastMatch && lastMatch.index !== undefined) {
+							data = data.slice(lastMatch.index + lastMatch[0].length)
+						}
+						// Place output back after removing vscode sequences
+						if (outputBetweenSequences) {
+							data = outputBetweenSequences + "\n" + data
+						}
+						// remove ansi
+						data = stripAnsi(data)
+						// Split data by newlines
+						let lines = data ? data.split("\n") : []
+						// Remove non-human readable characters from the first line
+						if (lines.length > 0) {
+							lines[0] = lines[0].replace(/[^\x20-\x7E]/g, "")
+						}
+						// Check if first two characters are the same, if so remove the first character
+						if (lines.length > 0 && lines[0].length >= 2 && lines[0][0] === lines[0][1]) {
+							lines[0] = lines[0].slice(1)
+						}
+						// Remove everything up to the first alphanumeric character for first two lines
+						if (lines.length > 0) {
+							lines[0] = lines[0].replace(/^[^a-zA-Z0-9]*/, "")
+						}
+						if (lines.length > 1) {
+							lines[1] = lines[1].replace(/^[^a-zA-Z0-9]*/, "")
+						}
+						// Join lines back
+						data = lines.join("\n")
+						isFirstChunk = false
+					} else {
+						data = stripAnsi(data)
 					}
-					data = lines.join("\n")
+
+					// first few chunks could be the command being echoed back, so we must ignore
+					// note this means that 'echo' commands wont work
+					if (!didOutputNonCommand) {
+						const lines = data.split("\n")
+						for (let i = 0; i < lines.length; i++) {
+							if (command.includes(lines[i].trim())) {
+								lines.splice(i, 1)
+								i-- // Adjust index after removal
+							} else {
+								didOutputNonCommand = true
+								break
+							}
+						}
+						data = lines.join("\n")
+					}
+
+					// FIXME: right now it seems that data chunks returned to us from the shell integration stream contains random commas, which from what I can tell is not the expected behavior. There has to be a better solution here than just removing all commas.
+					data = data.replace(/,/g, "")
+					// 2. Set isHot depending on the command
+					// Set to hot to stall API requests until terminal is cool again
+					this.isHot = true
+					if (this.hotTimer) {
+						clearTimeout(this.hotTimer)
+					}
+					// these markers indicate the command is some kind of local dev server recompiling the app, which we want to wait for output of before sending request to cline
+					const compilingMarkers = [
+						"compiling",
+						"building",
+						"bundling",
+						"transpiling",
+						"generating",
+						"starting",
+					]
+					const markerNullifiers = [
+						"compiled",
+						"success",
+						"finish",
+						"complete",
+						"succeed",
+						"done",
+						"end",
+						"stop",
+						"exit",
+						"terminate",
+						"error",
+						"fail",
+					]
+					const isCompiling =
+						compilingMarkers.some((marker) => data.toLowerCase().includes(marker.toLowerCase())) &&
+						!markerNullifiers.some((nullifier) => data.toLowerCase().includes(nullifier.toLowerCase()))
+
+					this.hotTimer = setTimeout(
+						() => {
+							this.isHot = false
+						},
+						isCompiling ? PROCESS_HOT_TIMEOUT_COMPILING : PROCESS_HOT_TIMEOUT_NORMAL,
+					)
+
+					// For non-immediately returning commands we want to show loading spinner right away but this wouldnt happen until it emits a line break, so as soon as we get any output we emit "" to let webview know to show spinner
+					if (!didEmitEmptyLine && !this.fullOutput && data) {
+						this.emit("line", "")
+						didEmitEmptyLine = true
+					}
+
+					this.fullOutput += data
+					if (this.isListening) {
+						this.emitIfEol(data)
+						this.lastRetrievedIndex = this.fullOutput.length - this.buffer.length
+					}
 				}
 
-				// FIXME: right now it seems that data chunks returned to us from the shell integration stream contains random commas, which from what I can tell is not the expected behavior. There has to be a better solution here than just removing all commas.
-				data = data.replace(/,/g, "")
+				// Handle command completion
+				this.emitRemainingBufferIfListening()
 
-				// 2. Set isHot depending on the command
-				// Set to hot to stall API requests until terminal is cool again
-				this.isHot = true
 				if (this.hotTimer) {
 					clearTimeout(this.hotTimer)
 				}
-				// these markers indicate the command is some kind of local dev server recompiling the app, which we want to wait for output of before sending request to cline
-				const compilingMarkers = ["compiling", "building", "bundling", "transpiling", "generating", "starting"]
-				const markerNullifiers = [
-					"compiled",
-					"success",
-					"finish",
-					"complete",
-					"succeed",
-					"done",
-					"end",
-					"stop",
-					"exit",
-					"terminate",
-					"error",
-					"fail",
-				]
-				const isCompiling =
-					compilingMarkers.some((marker) => data.toLowerCase().includes(marker.toLowerCase())) &&
-					!markerNullifiers.some((nullifier) => data.toLowerCase().includes(nullifier.toLowerCase()))
-				this.hotTimer = setTimeout(
-					() => {
-						this.isHot = false
-					},
-					isCompiling ? PROCESS_HOT_TIMEOUT_COMPILING : PROCESS_HOT_TIMEOUT_NORMAL,
-				)
+				this.isHot = false
 
-				// For non-immediately returning commands we want to show loading spinner right away but this wouldnt happen until it emits a line break, so as soon as we get any output we emit "" to let webview know to show spinner
-				if (!didEmitEmptyLine && !this.fullOutput && data) {
-					this.emit("line", "") // empty line to indicate start of command output stream
-					didEmitEmptyLine = true
+				if (exitCode === null) {
+					exitCode = 0
 				}
 
-				this.fullOutput += data
-				if (this.isListening) {
-					this.emitIfEol(data)
-					this.lastRetrievedIndex = this.fullOutput.length - this.buffer.length
+				if (exitCode !== 0) {
+					this.emit("error", new Error(`Command failed with exit code ${exitCode}`))
 				}
+
+				this.emit("completed")
+				this.emit("continue")
+			} catch (error) {
+				// Ensure cleanup in error cases
+				clearTimeout(noOutputTimeout)
+				if (this.hotTimer) {
+					clearTimeout(this.hotTimer)
+				}
+				this.isHot = false
+
+				this.emit("error", error instanceof Error ? error : new Error(String(error)))
+				this.emit("completed")
+				this.emit("continue")
 			}
-
-			this.emitRemainingBufferIfListening()
-
-			// for now we don't want this delaying requests since we don't send diagnostics automatically anymore (previous: "even though the command is finished, we still want to consider it 'hot' in case so that api request stalls to let diagnostics catch up")
-			if (this.hotTimer) {
-				clearTimeout(this.hotTimer)
-			}
-			this.isHot = false
-
-			this.emit("completed")
-			this.emit("continue")
 		} else {
 			terminal.sendText(command, true)
 			// For terminals without shell integration, we can't know when the command completes

--- a/src/integrations/terminal/TerminalRegistry.ts
+++ b/src/integrations/terminal/TerminalRegistry.ts
@@ -42,6 +42,18 @@ export class TerminalRegistry {
 		const terminal = this.getTerminal(id)
 		if (terminal) {
 			Object.assign(terminal, updates)
+			// If terminal is being marked as not busy, ensure it's in a clean state
+			if (updates.busy === false) {
+				terminal.lastCommand = ""
+			}
+		}
+	}
+
+	static resetTerminalState(id: number) {
+		const terminal = this.getTerminal(id)
+		if (terminal) {
+			terminal.busy = false
+			terminal.lastCommand = ""
 		}
 	}
 


### PR DESCRIPTION
### Description
This PR improves terminal state management and error handling, fixing issues where the UI could become unresponsive after command execution, particularly on macOS. 

Key improvements:
- Adds proper terminal state cleanup on process completion
- Implements handling for commands that complete without output (with 100ms timeout)
- Adds exit code tracking and proper error handling for failed commands
- Ensures cleanup of resources and timers in error cases
- Maintains VSCode shell integration documentation
- Prevents stale terminal state by properly resetting state and cleaning up processes

The changes particularly address a an issue on macOS where the UI would become unresponsive after executing commands, caused by incomplete terminal state cleanup.

### Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update

### Pre-flight Checklist
- [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
- [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
- [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots
N/A - No UI changes, only terminal handling improvements

### Additional Notes
The changes improve reliability by:
- Adding timeouts for no-output commands
- Better error propagation with exit code tracking
- More thorough cleanup of terminal state
- Preventing process tracking leaks
