### PR TITLE
Fixed double underscores in filenames rendering as bold in markdown

### DIFF
--- a/webview-ui/src/components/common/MarkdownBlock.tsx
+++ b/webview-ui/src/components/common/MarkdownBlock.tsx
@@ -50,6 +50,43 @@ const remarkUrlToLink = () => {
 	}
 }
 
+/**
+ * Custom remark plugin that prevents filenames with extensions from being parsed as bold text
+ * For example: __init__.py should not be rendered as bold "init" followed by ".py"
+ */
+const remarkPreventBoldFilenames = () => {
+	return (tree: any) => {
+		visit(tree, "strong", (node: any, index: number | undefined, parent: any) => {
+			// Only process if there's a next node (potential file extension)
+			if (!parent || typeof index === "undefined" || index === parent.children.length - 1) return
+
+			const nextNode = parent.children[index + 1]
+
+			// Check if next node is text and starts with . followed by extension
+			if (nextNode.type !== "text" || !nextNode.value.match(/^\.[a-zA-Z0-9]+/)) return
+
+			// If the strong node has multiple children, something weird is happening
+			if (node.children?.length !== 1) return
+
+			// Get the text content from inside the strong node
+			const strongContent = node.children?.[0]?.value
+			if (!strongContent || typeof strongContent !== "string") return
+
+			// Validate that the strong content is a valid filename
+			if (!strongContent.match(/^[a-zA-Z0-9_-]+$/)) return
+
+			// Combine into a single text node
+			const newNode = {
+				type: "text",
+				value: `__${strongContent}__${nextNode.value}`,
+			}
+
+			// Replace both nodes with the combined text node
+			parent.children.splice(index, 2, newNode)
+		})
+	}
+}
+
 const StyledMarkdown = styled.div`
 	pre {
 		background-color: ${CODE_BLOCK_BG_COLOR};
@@ -160,6 +197,7 @@ const MarkdownBlock = memo(({ markdown }: MarkdownBlockProps) => {
 	const { theme } = useExtensionState()
 	const [reactContent, setMarkdown] = useRemark({
 		remarkPlugins: [
+			remarkPreventBoldFilenames,
 			remarkUrlToLink,
 			() => {
 				return (tree) => {

--- a/webview-ui/src/components/common/MarkdownBlock.tsx
+++ b/webview-ui/src/components/common/MarkdownBlock.tsx
@@ -53,6 +53,7 @@ const remarkUrlToLink = () => {
 /**
  * Custom remark plugin that prevents filenames with extensions from being parsed as bold text
  * For example: __init__.py should not be rendered as bold "init" followed by ".py"
+ * Solves https://github.com/cline/cline/issues/1028
  */
 const remarkPreventBoldFilenames = () => {
 	return (tree: any) => {


### PR DESCRIPTION
### Description

Solves #1028 

Adds a markdown plugin in `webview-ui/src/components/common/MarkdownBlock.tsx` that prevents filenames with extensions (e.g. `__init__.py`) from being incorrectly rendered with bold formatting. The plugin identifies patterns where a strong node is followed by a text node containing a file extension, validates the filename components, and combines them into a single text node.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

- [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
- [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
- [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

![Pasted image 20241228210203](https://github.com/user-attachments/assets/083b6d7d-dfa4-4b0a-bef4-60c82e3250c1)

### Additional Notes
