### PR TITLE
Allow setting extra headers for openai compatible api

### DIFF
--- a/src/api/providers/openai.ts
+++ b/src/api/providers/openai.ts
@@ -21,11 +21,13 @@ export class OpenAiHandler implements ApiHandler {
 				baseURL: this.options.openAiBaseUrl,
 				apiKey: this.options.openAiApiKey,
 				apiVersion: this.options.azureApiVersion || azureOpenAiDefaultApiVersion,
+				defaultHeaders: this.options.openAiHeaders,
 			})
 		} else {
 			this.client = new OpenAI({
 				baseURL: this.options.openAiBaseUrl,
 				apiKey: this.options.openAiApiKey,
+				defaultHeaders: this.options.openAiHeaders,
 			})
 		}
 	}

--- a/src/core/storage/state-keys.ts
+++ b/src/core/storage/state-keys.ts
@@ -37,6 +37,7 @@ export type GlobalStateKey =
 	| "openAiBaseUrl"
 	| "openAiModelId"
 	| "openAiModelInfo"
+	| "openAiHeaders"
 	| "ollamaModelId"
 	| "ollamaBaseUrl"
 	| "ollamaApiOptionsCtxNum"

--- a/src/core/storage/state.ts
+++ b/src/core/storage/state.ts
@@ -73,6 +73,7 @@ export async function getAllExtensionState(context: vscode.ExtensionContext) {
 		openAiApiKey,
 		openAiModelId,
 		openAiModelInfo,
+		openAiHeaders,
 		ollamaModelId,
 		ollamaBaseUrl,
 		ollamaApiOptionsCtxNum,
@@ -144,6 +145,7 @@ export async function getAllExtensionState(context: vscode.ExtensionContext) {
 		getSecret(context, "openAiApiKey") as Promise<string | undefined>,
 		getGlobalState(context, "openAiModelId") as Promise<string | undefined>,
 		getGlobalState(context, "openAiModelInfo") as Promise<ModelInfo | undefined>,
+		getGlobalState(context, "openAiHeaders") as Promise<Record<string, string> | undefined>,
 		getGlobalState(context, "ollamaModelId") as Promise<string | undefined>,
 		getGlobalState(context, "ollamaBaseUrl") as Promise<string | undefined>,
 		getGlobalState(context, "ollamaApiOptionsCtxNum") as Promise<string | undefined>,
@@ -256,6 +258,7 @@ export async function getAllExtensionState(context: vscode.ExtensionContext) {
 			openAiApiKey,
 			openAiModelId,
 			openAiModelInfo,
+			openAiHeaders: openAiHeaders || {},
 			ollamaModelId,
 			ollamaBaseUrl,
 			ollamaApiOptionsCtxNum,
@@ -334,6 +337,7 @@ export async function updateApiConfiguration(context: vscode.ExtensionContext, a
 		openAiApiKey,
 		openAiModelId,
 		openAiModelInfo,
+		openAiHeaders,
 		ollamaModelId,
 		ollamaBaseUrl,
 		ollamaApiOptionsCtxNum,
@@ -389,6 +393,7 @@ export async function updateApiConfiguration(context: vscode.ExtensionContext, a
 	await storeSecret(context, "openAiApiKey", openAiApiKey)
 	await updateGlobalState(context, "openAiModelId", openAiModelId)
 	await updateGlobalState(context, "openAiModelInfo", openAiModelInfo)
+	await updateGlobalState(context, "openAiHeaders", openAiHeaders || {})
 	await updateGlobalState(context, "ollamaModelId", ollamaModelId)
 	await updateGlobalState(context, "ollamaBaseUrl", ollamaBaseUrl)
 	await updateGlobalState(context, "ollamaApiOptionsCtxNum", ollamaApiOptionsCtxNum)

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -32,6 +32,7 @@ export interface ApiHandlerOptions {
 	liteLlmModelId?: string
 	liteLlmApiKey?: string
 	liteLlmUsePromptCache?: boolean
+	openAiHeaders?: Record<string, string> // Custom headers for OpenAI requests
 	anthropicBaseUrl?: string
 	openRouterApiKey?: string
 	openRouterModelId?: string

--- a/webview-ui/src/components/settings/ApiOptions.tsx
+++ b/webview-ui/src/components/settings/ApiOptions.tsx
@@ -1,4 +1,5 @@
 import {
+	VSCodeButton,
 	VSCodeCheckbox,
 	VSCodeDropdown,
 	VSCodeLink,
@@ -827,7 +828,17 @@ const ApiOptions = ({ showModelOptions, apiErrorMessage, modelIdErrorMessage, is
 
 					{/* Custom Headers Section */}
 					<div style={{ marginTop: 10 }}>
-						<span style={{ fontWeight: 500 }}>Custom Headers</span>
+						<div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+							<span style={{ fontWeight: 500 }}>Custom Headers</span>
+							<VSCodeButton
+								onClick={() => {
+									const newHeaders = { ...apiConfiguration?.openAiHeaders ?? {} }
+									newHeaders[`header${Object.keys(newHeaders).length + 1}`] = ""
+									setApiConfiguration({ ...apiConfiguration, openAiHeaders: newHeaders })
+								}}>
+								Add Header
+							</VSCodeButton>
+						</div>
 						{Object.entries(apiConfiguration?.openAiHeaders || {}).map(([key, value], index) => (
 							<div key={index} style={{ display: "flex", gap: 5, marginTop: 5 }}>
 								<VSCodeTextField
@@ -835,7 +846,7 @@ const ApiOptions = ({ showModelOptions, apiErrorMessage, modelIdErrorMessage, is
 									style={{ width: "40%" }}
 									placeholder="Header name"
 									onInput={(e: any) => {
-										const newHeaders = { ...apiConfiguration?.openAiHeaders } || {}
+										const newHeaders = { ...apiConfiguration?.openAiHeaders }
 										const oldKey = key
 										delete newHeaders[oldKey]
 										newHeaders[e.target.value] = value
@@ -847,31 +858,22 @@ const ApiOptions = ({ showModelOptions, apiErrorMessage, modelIdErrorMessage, is
 									style={{ width: "40%" }}
 									placeholder="Header value"
 									onInput={(e: any) => {
-										const newHeaders = { ...apiConfiguration?.openAiHeaders } || {}
+										const newHeaders = { ...apiConfiguration?.openAiHeaders ?? {} }
 										newHeaders[key] = e.target.value
 										setApiConfiguration({ ...apiConfiguration, openAiHeaders: newHeaders })
 									}}
 								/>
-								<vscode-button
+								<VSCodeButton
 									appearance="secondary"
 									onClick={() => {
-										const newHeaders = { ...apiConfiguration?.openAiHeaders } || {}
+										const newHeaders = { ...apiConfiguration?.openAiHeaders ?? {} }
 										delete newHeaders[key]
 										setApiConfiguration({ ...apiConfiguration, openAiHeaders: newHeaders })
 									}}>
 									Remove
-								</vscode-button>
+								</VSCodeButton>
 							</div>
 						))}
-						<vscode-button
-							style={{ marginTop: 5 }}
-							onClick={() => {
-								const newHeaders = { ...apiConfiguration?.openAiHeaders } || {}
-								newHeaders[`header${Object.keys(newHeaders).length + 1}`] = ""
-								setApiConfiguration({ ...apiConfiguration, openAiHeaders: newHeaders })
-							}}>
-							Add Header
-						</vscode-button>
 					</div>
 
 					<VSCodeCheckbox

--- a/webview-ui/src/components/settings/ApiOptions.tsx
+++ b/webview-ui/src/components/settings/ApiOptions.tsx
@@ -828,21 +828,21 @@ const ApiOptions = ({ showModelOptions, apiErrorMessage, modelIdErrorMessage, is
 
 					{/* Custom Headers Section */}
 					{(() => {
-						const headerEntries = Object.entries(apiConfiguration?.openAiHeaders ?? {});
+						const headerEntries = Object.entries(apiConfiguration?.openAiHeaders ?? {})
 						return (
 							<div style={{ marginTop: 10 }}>
-								<div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+								<div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
 									<span style={{ fontWeight: 500 }}>Custom Headers</span>
 									<VSCodeButton
 										onClick={() => {
-											const currentHeaders = {...(apiConfiguration?.openAiHeaders || {})}
+											const currentHeaders = { ...(apiConfiguration?.openAiHeaders || {}) }
 											const headerCount = Object.keys(currentHeaders).length
 											const newKey = `header${headerCount + 1}`
 											currentHeaders[newKey] = ""
 											handleInputChange("openAiHeaders")({
 												target: {
-													value: currentHeaders
-												}
+													value: currentHeaders,
+												},
 											})
 										}}>
 										Add Header
@@ -850,59 +850,59 @@ const ApiOptions = ({ showModelOptions, apiErrorMessage, modelIdErrorMessage, is
 								</div>
 								<div>
 									{headerEntries.map(([key, value], index) => (
-							<div key={index} style={{ display: "flex", gap: 5, marginTop: 5 }}>
-								<VSCodeTextField
-									value={key}
-									style={{ width: "40%" }}
-									placeholder="Header name"
-									onInput={(e: any) => {
-										const currentHeaders = apiConfiguration?.openAiHeaders ?? {}
-										const newValue = e.target.value
-										if (newValue && newValue !== key) {
-											const { [key]: _, ...rest } = currentHeaders
-											handleInputChange("openAiHeaders")({
-												target: {
-													value: {
-														...rest,
-														[newValue]: value
+										<div key={index} style={{ display: "flex", gap: 5, marginTop: 5 }}>
+											<VSCodeTextField
+												value={key}
+												style={{ width: "40%" }}
+												placeholder="Header name"
+												onInput={(e: any) => {
+													const currentHeaders = apiConfiguration?.openAiHeaders ?? {}
+													const newValue = e.target.value
+													if (newValue && newValue !== key) {
+														const { [key]: _, ...rest } = currentHeaders
+														handleInputChange("openAiHeaders")({
+															target: {
+																value: {
+																	...rest,
+																	[newValue]: value,
+																},
+															},
+														})
 													}
-												}
-											})
-										}
-									}}
-								/>
-								<VSCodeTextField
-									value={value}
-									style={{ width: "40%" }}
-									placeholder="Header value"
-									onInput={(e: any) => {
-										handleInputChange("openAiHeaders")({
-											target: {
-												value: {
-													...apiConfiguration?.openAiHeaders ?? {},
-													[key]: e.target.value
-												}
-											}
-										})
-									}}
-								/>
-								<VSCodeButton
-									appearance="secondary"
-									onClick={() => {
-										const { [key]: _, ...rest } = apiConfiguration?.openAiHeaders ?? {}
-										handleInputChange("openAiHeaders")({
-											target: {
-												value: rest
-											}
-										})
-									}}>
-									Remove
-								</VSCodeButton>
-							</div>
-						))}
+												}}
+											/>
+											<VSCodeTextField
+												value={value}
+												style={{ width: "40%" }}
+												placeholder="Header value"
+												onInput={(e: any) => {
+													handleInputChange("openAiHeaders")({
+														target: {
+															value: {
+																...(apiConfiguration?.openAiHeaders ?? {}),
+																[key]: e.target.value,
+															},
+														},
+													})
+												}}
+											/>
+											<VSCodeButton
+												appearance="secondary"
+												onClick={() => {
+													const { [key]: _, ...rest } = apiConfiguration?.openAiHeaders ?? {}
+													handleInputChange("openAiHeaders")({
+														target: {
+															value: rest,
+														},
+													})
+												}}>
+												Remove
+											</VSCodeButton>
+										</div>
+									))}
 								</div>
 							</div>
-						);
+						)
 					})()}
 
 					<VSCodeCheckbox

--- a/webview-ui/src/components/settings/ApiOptions.tsx
+++ b/webview-ui/src/components/settings/ApiOptions.tsx
@@ -804,7 +804,7 @@ const ApiOptions = ({ showModelOptions, apiErrorMessage, modelIdErrorMessage, is
 				<div>
 					<VSCodeTextField
 						value={apiConfiguration?.openAiBaseUrl || ""}
-						style={{ width: "100%" }}
+						style={{ width: "100%", marginBottom: 10 }}
 						type="url"
 						onInput={handleInputChange("openAiBaseUrl")}
 						placeholder={"Enter base URL..."}>
@@ -812,7 +812,7 @@ const ApiOptions = ({ showModelOptions, apiErrorMessage, modelIdErrorMessage, is
 					</VSCodeTextField>
 					<VSCodeTextField
 						value={apiConfiguration?.openAiApiKey || ""}
-						style={{ width: "100%" }}
+						style={{ width: "100%", marginBottom: 10 }}
 						type="password"
 						onInput={handleInputChange("openAiApiKey")}
 						placeholder="Enter API Key...">
@@ -820,17 +820,17 @@ const ApiOptions = ({ showModelOptions, apiErrorMessage, modelIdErrorMessage, is
 					</VSCodeTextField>
 					<VSCodeTextField
 						value={apiConfiguration?.openAiModelId || ""}
-						style={{ width: "100%" }}
+						style={{ width: "100%", marginBottom: 10 }}
 						onInput={handleInputChange("openAiModelId")}
 						placeholder={"Enter Model ID..."}>
 						<span style={{ fontWeight: 500 }}>Model ID</span>
 					</VSCodeTextField>
 
-					{/* Custom Headers Section */}
+					{/* OpenAI Compatible Custom Headers */}
 					{(() => {
 						const headerEntries = Object.entries(apiConfiguration?.openAiHeaders ?? {})
 						return (
-							<div style={{ marginTop: 10 }}>
+							<div style={{ marginBottom: 10 }}>
 								<div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
 									<span style={{ fontWeight: 500 }}>Custom Headers</span>
 									<VSCodeButton

--- a/webview-ui/src/components/settings/ApiOptions.tsx
+++ b/webview-ui/src/components/settings/ApiOptions.tsx
@@ -824,6 +824,56 @@ const ApiOptions = ({ showModelOptions, apiErrorMessage, modelIdErrorMessage, is
 						placeholder={"Enter Model ID..."}>
 						<span style={{ fontWeight: 500 }}>Model ID</span>
 					</VSCodeTextField>
+
+					{/* Custom Headers Section */}
+					<div style={{ marginTop: 10 }}>
+						<span style={{ fontWeight: 500 }}>Custom Headers</span>
+						{Object.entries(apiConfiguration?.openAiHeaders || {}).map(([key, value], index) => (
+							<div key={index} style={{ display: "flex", gap: 5, marginTop: 5 }}>
+								<VSCodeTextField
+									value={key}
+									style={{ width: "40%" }}
+									placeholder="Header name"
+									onInput={(e: any) => {
+										const newHeaders = { ...apiConfiguration?.openAiHeaders } || {}
+										const oldKey = key
+										delete newHeaders[oldKey]
+										newHeaders[e.target.value] = value
+										setApiConfiguration({ ...apiConfiguration, openAiHeaders: newHeaders })
+									}}
+								/>
+								<VSCodeTextField
+									value={value}
+									style={{ width: "40%" }}
+									placeholder="Header value"
+									onInput={(e: any) => {
+										const newHeaders = { ...apiConfiguration?.openAiHeaders } || {}
+										newHeaders[key] = e.target.value
+										setApiConfiguration({ ...apiConfiguration, openAiHeaders: newHeaders })
+									}}
+								/>
+								<vscode-button
+									appearance="secondary"
+									onClick={() => {
+										const newHeaders = { ...apiConfiguration?.openAiHeaders } || {}
+										delete newHeaders[key]
+										setApiConfiguration({ ...apiConfiguration, openAiHeaders: newHeaders })
+									}}>
+									Remove
+								</vscode-button>
+							</div>
+						))}
+						<vscode-button
+							style={{ marginTop: 5 }}
+							onClick={() => {
+								const newHeaders = { ...apiConfiguration?.openAiHeaders } || {}
+								newHeaders[`header${Object.keys(newHeaders).length + 1}`] = ""
+								setApiConfiguration({ ...apiConfiguration, openAiHeaders: newHeaders })
+							}}>
+							Add Header
+						</vscode-button>
+					</div>
+
 					<VSCodeCheckbox
 						checked={azureApiVersionSelected}
 						onChange={(e: any) => {

--- a/webview-ui/src/components/settings/ApiOptions.tsx
+++ b/webview-ui/src/components/settings/ApiOptions.tsx
@@ -827,30 +827,48 @@ const ApiOptions = ({ showModelOptions, apiErrorMessage, modelIdErrorMessage, is
 					</VSCodeTextField>
 
 					{/* Custom Headers Section */}
-					<div style={{ marginTop: 10 }}>
-						<div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-							<span style={{ fontWeight: 500 }}>Custom Headers</span>
-							<VSCodeButton
-								onClick={() => {
-									const newHeaders = { ...apiConfiguration?.openAiHeaders ?? {} }
-									newHeaders[`header${Object.keys(newHeaders).length + 1}`] = ""
-									setApiConfiguration({ ...apiConfiguration, openAiHeaders: newHeaders })
-								}}>
-								Add Header
-							</VSCodeButton>
-						</div>
-						{Object.entries(apiConfiguration?.openAiHeaders || {}).map(([key, value], index) => (
+					{(() => {
+						const headerEntries = Object.entries(apiConfiguration?.openAiHeaders ?? {});
+						return (
+							<div style={{ marginTop: 10 }}>
+								<div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+									<span style={{ fontWeight: 500 }}>Custom Headers</span>
+									<VSCodeButton
+										onClick={() => {
+											const currentHeaders = {...(apiConfiguration?.openAiHeaders || {})}
+											const headerCount = Object.keys(currentHeaders).length
+											const newKey = `header${headerCount + 1}`
+											currentHeaders[newKey] = ""
+											handleInputChange("openAiHeaders")({
+												target: {
+													value: currentHeaders
+												}
+											})
+										}}>
+										Add Header
+									</VSCodeButton>
+								</div>
+								<div>
+									{headerEntries.map(([key, value], index) => (
 							<div key={index} style={{ display: "flex", gap: 5, marginTop: 5 }}>
 								<VSCodeTextField
 									value={key}
 									style={{ width: "40%" }}
 									placeholder="Header name"
 									onInput={(e: any) => {
-										const newHeaders = { ...apiConfiguration?.openAiHeaders }
-										const oldKey = key
-										delete newHeaders[oldKey]
-										newHeaders[e.target.value] = value
-										setApiConfiguration({ ...apiConfiguration, openAiHeaders: newHeaders })
+										const currentHeaders = apiConfiguration?.openAiHeaders ?? {}
+										const newValue = e.target.value
+										if (newValue && newValue !== key) {
+											const { [key]: _, ...rest } = currentHeaders
+											handleInputChange("openAiHeaders")({
+												target: {
+													value: {
+														...rest,
+														[newValue]: value
+													}
+												}
+											})
+										}
 									}}
 								/>
 								<VSCodeTextField
@@ -858,23 +876,34 @@ const ApiOptions = ({ showModelOptions, apiErrorMessage, modelIdErrorMessage, is
 									style={{ width: "40%" }}
 									placeholder="Header value"
 									onInput={(e: any) => {
-										const newHeaders = { ...apiConfiguration?.openAiHeaders ?? {} }
-										newHeaders[key] = e.target.value
-										setApiConfiguration({ ...apiConfiguration, openAiHeaders: newHeaders })
+										handleInputChange("openAiHeaders")({
+											target: {
+												value: {
+													...apiConfiguration?.openAiHeaders ?? {},
+													[key]: e.target.value
+												}
+											}
+										})
 									}}
 								/>
 								<VSCodeButton
 									appearance="secondary"
 									onClick={() => {
-										const newHeaders = { ...apiConfiguration?.openAiHeaders ?? {} }
-										delete newHeaders[key]
-										setApiConfiguration({ ...apiConfiguration, openAiHeaders: newHeaders })
+										const { [key]: _, ...rest } = apiConfiguration?.openAiHeaders ?? {}
+										handleInputChange("openAiHeaders")({
+											target: {
+												value: rest
+											}
+										})
 									}}>
 									Remove
 								</VSCodeButton>
 							</div>
 						))}
-					</div>
+								</div>
+							</div>
+						);
+					})()}
 
 					<VSCodeCheckbox
 						checked={azureApiVersionSelected}


### PR DESCRIPTION
### Description

My company requires using an internal custom LLM proxy to contact cloud LLM apis.  That proxy also requires added custom HTTP headers.  This change lets you set extra headers on that connection.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [X] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [X] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [X] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [X] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<img width="398" alt="Screenshot 2025-01-03 at 9 57 26 PM" src="https://github.com/user-attachments/assets/1cc89cd1-6a13-4ef3-8985-2424b031d13e" />

