### PR TITLE
docs: enhance contributing guide with setup instructions for first time contributors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,7 @@ Anyone can contribute code to Cline, but we ask that you follow these guidelines
 2. **Code Quality**
 
     - Run `npm run lint` to check code style
-    - Run `npm run format` to automatically format code (includes prettier --write)
+    - Run `npm run format` to automatically format code
     - All PRs must pass CI checks which include both linting and formatting
     - Address any ESLint warnings or errors before submitting
     - Follow TypeScript best practices and maintain type safety

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,15 +19,15 @@ If you're planning to work on a bigger feature, please create an issue first so 
 ## Development Setup
 
 1. **VS Code Extensions**
-   - When opening the project, VS Code will prompt you to install recommended extensions
-   - These extensions are required for development - please accept all installation prompts
-   - If you dismissed the prompts, you can install them manually from the Extensions panel
+
+    - When opening the project, VS Code will prompt you to install recommended extensions
+    - These extensions are required for development - please accept all installation prompts
+    - If you dismissed the prompts, you can install them manually from the Extensions panel
 
 2. **Local Development**
-   - Run `npm install` to install dependencies
-   - Use `npm run watch` for development with hot reload
-   - Run `npm run test` to run tests locally
-   - Before submitting PR, run `npm run format` which includes prettier --write
+    - Run `npm install` to install dependencies
+    - Run `npm run test` to run tests locally
+    - Before submitting PR, run `npm run format` which includes prettier --write
 
 ## Writing and Submitting Code
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ If you're planning to work on a bigger feature, please create an issue first so 
 2. **Local Development**
     - Run `npm install` to install dependencies
     - Run `npm run test` to run tests locally
-    - Before submitting PR, run `npm run format` which includes prettier --write
+    - Before submitting PR, run `npm run format:fix` to format your code
 
 ## Writing and Submitting Code
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,6 +16,19 @@ Looking for a good first contribution? Check out issues labeled ["good first iss
 
 If you're planning to work on a bigger feature, please create an issue first so we can discuss whether it aligns with Cline's vision.
 
+## Development Setup
+
+1. **VS Code Extensions**
+   - When opening the project, VS Code will prompt you to install recommended extensions
+   - These extensions are required for development - please accept all installation prompts
+   - If you dismissed the prompts, you can install them manually from the Extensions panel
+
+2. **Local Development**
+   - Run `npm install` to install dependencies
+   - Use `npm run watch` for development with hot reload
+   - Run `npm run test` to run tests locally
+   - Before submitting PR, run `npm run format` which includes prettier --write
+
 ## Writing and Submitting Code
 
 Anyone can contribute code to Cline, but we ask that you follow these guidelines to ensure your contributions can be smoothly integrated:
@@ -28,8 +41,9 @@ Anyone can contribute code to Cline, but we ask that you follow these guidelines
 
 2. **Code Quality**
 
-    - Run `npm run lint` to ensure code follows our style guidelines
-    - Run `npm run format` to format your code with Prettier
+    - Run `npm run lint` to check code style
+    - Run `npm run format` to automatically format code (includes prettier --write)
+    - All PRs must pass CI checks which include both linting and formatting
     - Address any ESLint warnings or errors before submitting
     - Follow TypeScript best practices and maintain type safety
 


### PR DESCRIPTION
Description
This PR enhances the CONTRIBUTING.md guide based on feedback from first-time contributors to improve the developer experience. The changes add clarity around development setup, testing workflows, and code quality requirements.
Key updates include:

Added a new "Development Setup" section explaining VS Code extension requirements
Clarified local development workflow with explicit npm commands
Enhanced the code quality section with more detailed formatting instructions
Improved overall documentation structure for better readability

These changes address specific friction points reported by community members, particularly around VS Code extension setup and testing requirements.
Type of Change

 🐛 Bug fix (non-breaking change which fixes an issue)
 ✨ New feature (non-breaking change which adds functionality)
 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
 ✅**📚 Documentation update**

Pre-flight Checklist

 ✅Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
 ✅Tests are passing (npm test) and code is formatted and linted (npm run format && npm run lint)
 ✅ I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

Screenshots
Before:
![image](https://github.com/user-attachments/assets/acf1d0b5-84dc-4768-9fdf-f4a3eea202a4)

After:
[You would want to add a screenshot of your updated CONTRIBUTING.md]
![image](https://github.com/user-attachments/assets/f9de7313-cb4d-4005-ab35-df4ae1ad864c)

Additional Notes
This documentation update was inspired by feedback from @punkpeye in Discord, who highlighted several areas where our contributor documentation could be more explicit about development setup requirements and workflows.
The changes are focused on reducing friction for first-time contributors while maintaining our high standards for code quality and testing.