### PR TITLE
feat: add workspace folder mapping for MCP configs

### DIFF
--- a/src/services/mcp/McpHub.ts
+++ b/src/services/mcp/McpHub.ts
@@ -142,9 +142,18 @@ export class McpHub {
 				},
 			)
 
+			const workspaceFolder = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath || "";
+			const workspaceFolderBasename = path.basename(workspaceFolder);
+
+			const replacePathVariables = (str: string) => {
+				return str
+					.replace("\${workspaceFolder}", workspaceFolder)
+					.replace("\${workspaceFolderBasename}", workspaceFolderBasename);
+			};
+
 			const transport = new StdioClientTransport({
-				command: config.command,
-				args: config.args,
+				command: replacePathVariables(config.command),
+				args: config.args?.map(replacePathVariables),
 				env: {
 					...config.env,
 					...(process.env.PATH ? { PATH: process.env.PATH } : {}),


### PR DESCRIPTION
### Description

This PR introduces the ability to use workspace-relative paths in MCP server configurations. It adds a `replacePathVariables` function that replaces `${workspaceFolder}` and `${workspaceFolderBasename}` variables in the `command` and `args` properties of the `StdioClientTransport` configuration with the actual workspace path and basename. This allows MCP servers to be configured with paths relative to the workspace, making them more portable and easier to share.

This is based on an experiment I've done with a forked version of [`mcp-client-cli`](https://github.com/monotykamary/mcp-client-cli) to essentially replicate aider/cline without the system prompt bulk using `filesystem` and `mcp-shell-server` using `{pwd}` and `{basename_pwd}`:
```json
    "filesystem": {
      "command": "docker",
      "args": [
        "run",
        "-i",
        "--rm",
        "--mount",
        "type=bind,src={pwd},dst=/projects/{basename_pwd}",
        "mcp/filesystem",
        "/projects"
      ]
    },
    "cli": {
      "command": "docker",
      "args": [
        "run",
        "-i",
        "--rm",
        "--mount",
        "type=bind,src={pwd},dst=/projects/{basename_pwd}",
        "--mount",
        "type=bind,src=/Users/monotykamary/.gitconfig,dst=/root/.gitconfig",
        "-e",
        "ALLOWED_COMMANDS=ls,cat,pwd,echo,git,touch,find,wc",
        "monotykamary/uv",
        "uvx",
        "mcp-shell-server"
      ]
    }
```

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

### Additional Notes

<!-- Add any additional notes for reviewers -->
This change does not introduce any UI changes.