### PR TITLE
fix: Support o1-mini and o1-preview in with OpenAi Compatible provider

### DIFF
--- a/src/api/providers/openai.ts
+++ b/src/api/providers/openai.ts
@@ -1,6 +1,11 @@
 import { Anthropic } from "@anthropic-ai/sdk"
 import OpenAI, { AzureOpenAI } from "openai"
-import { ApiHandlerOptions, azureOpenAiDefaultApiVersion, ModelInfo, openAiModelInfoSaneDefaults } from "../../shared/api"
+import {
+	ApiHandlerOptions,
+	ModelInfo,
+	azureOpenAiDefaultApiVersion,
+	openAiModelInfoSaneDefaults,
+} from "../../shared/api"
 import { ApiHandler } from "../index"
 import { convertToOpenAiMessages } from "../transform/openai-format"
 import { ApiStream } from "../transform/stream"
@@ -25,32 +30,53 @@ export class OpenAiHandler implements ApiHandler {
 			})
 		}
 	}
-
 	async *createMessage(systemPrompt: string, messages: Anthropic.Messages.MessageParam[]): ApiStream {
-		const openAiMessages: OpenAI.Chat.ChatCompletionMessageParam[] = [
-			{ role: "system", content: systemPrompt },
-			...convertToOpenAiMessages(messages),
-		]
-		const stream = await this.client.chat.completions.create({
-			model: this.options.openAiModelId ?? "",
-			messages: openAiMessages,
-			temperature: 0,
-			stream: true,
-			stream_options: { include_usage: true },
-		})
-		for await (const chunk of stream) {
-			const delta = chunk.choices[0]?.delta
-			if (delta?.content) {
+		switch (this.getModel().id) {
+			case "o1-preview":
+			case "o1-mini": {
+				// o1 doesnt support streaming, non-1 temp, or system prompt
+				const response = await this.client.chat.completions.create({
+					model: this.getModel().id,
+					messages: [{ role: "user", content: systemPrompt }, ...convertToOpenAiMessages(messages)],
+				})
 				yield {
 					type: "text",
-					text: delta.content,
+					text: response.choices[0]?.message.content || "",
 				}
-			}
-			if (chunk.usage) {
 				yield {
 					type: "usage",
-					inputTokens: chunk.usage.prompt_tokens || 0,
-					outputTokens: chunk.usage.completion_tokens || 0,
+					inputTokens: response.usage?.prompt_tokens || 0,
+					outputTokens: response.usage?.completion_tokens || 0,
+				}
+				break
+			}
+			default: {
+				const stream = await this.client.chat.completions.create({
+					model: this.getModel().id,
+					// max_completion_tokens: this.getModel().info.maxTokens,
+					temperature: 0,
+					messages: [{ role: "system", content: systemPrompt }, ...convertToOpenAiMessages(messages)],
+					stream: true,
+					stream_options: { include_usage: true },
+				})
+
+				for await (const chunk of stream) {
+					const delta = chunk.choices[0]?.delta
+					if (delta?.content) {
+						yield {
+							type: "text",
+							text: delta.content,
+						}
+					}
+
+					// contains a null value except for the last chunk which contains the token usage statistics for the entire request
+					if (chunk.usage) {
+						yield {
+							type: "usage",
+							inputTokens: chunk.usage.prompt_tokens || 0,
+							outputTokens: chunk.usage.completion_tokens || 0,
+						}
+					}
 				}
 			}
 		}


### PR DESCRIPTION
### Description

fix: Updating openai.ts to support o1-mini and o1-preview with openai compatible providers. #445 was closed but not fixed.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`) 
- - Blocked, potentially by #1050
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

### Additional Notes

Allows users to specify OpenAI Compatible as an API Provider and use o1-mini and o1-preview without error.
* npm tests fail before and after this change, I suspect #1050 is the cause.  Can hold until 1050 is resolved, but currently using Open AI Compatible provider locally without issues.
