### PR TITLE
feat: support dynamic aws credentials

### DIFF
--- a/docs/mcp/mcp-quickstart.md
+++ b/docs/mcp/mcp-quickstart.md
@@ -35,7 +35,7 @@ STOP! Before proceeding, you MUST verify these requirements:
 1. From the Cline extension, click the `MCP Server` tab
 1. Click the `Edit MCP Settings` button
 
-    <img src="https://github.com/user-attachments/assets/abf908b1-be98-4894-8dc7-ef3d27943a47" alt="MCP Server Panel" width="400" />
+ <img src="https://github.com/user-attachments/assets/abf908b1-be98-4894-8dc7-ef3d27943a47" alt="MCP Server Panel" width="400" />
 
 1. The MCP settings files should be display in a tab in VS Code.
 1. Replce the file's contents with this code:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "claude-dev",
-	"version": "3.0.12",
+	"version": "3.1.6",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "claude-dev",
-			"version": "3.0.12",
+			"version": "3.1.6",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@anthropic-ai/bedrock-sdk": "^0.10.2",

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -44,6 +44,7 @@ type GlobalStateKey =
 	| "apiProvider"
 	| "apiModelId"
 	| "awsRegion"
+	| "awsProfile"
 	| "awsUseCrossRegionInference"
 	| "vertexProjectId"
 	| "vertexRegion"
@@ -375,6 +376,7 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 								awsSecretKey,
 								awsSessionToken,
 								awsRegion,
+								awsProfile,
 								awsUseCrossRegionInference,
 								vertexProjectId,
 								vertexRegion,
@@ -401,6 +403,7 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 							await this.storeSecret("awsSecretKey", awsSecretKey)
 							await this.storeSecret("awsSessionToken", awsSessionToken)
 							await this.updateGlobalState("awsRegion", awsRegion)
+							await this.updateGlobalState("awsProfile", awsProfile)
 							await this.updateGlobalState("awsUseCrossRegionInference", awsUseCrossRegionInference)
 							await this.updateGlobalState("vertexProjectId", vertexProjectId)
 							await this.updateGlobalState("vertexRegion", vertexRegion)
@@ -985,6 +988,7 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 			awsSecretKey,
 			awsSessionToken,
 			awsRegion,
+			awsProfile,
 			awsUseCrossRegionInference,
 			vertexProjectId,
 			vertexRegion,
@@ -1015,6 +1019,7 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 			this.getSecret("awsSecretKey") as Promise<string | undefined>,
 			this.getSecret("awsSessionToken") as Promise<string | undefined>,
 			this.getGlobalState("awsRegion") as Promise<string | undefined>,
+			this.getGlobalState("awsProfile") as Promise<string | undefined>,
 			this.getGlobalState("awsUseCrossRegionInference") as Promise<boolean | undefined>,
 			this.getGlobalState("vertexProjectId") as Promise<string | undefined>,
 			this.getGlobalState("vertexRegion") as Promise<string | undefined>,
@@ -1062,6 +1067,7 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 				awsSecretKey,
 				awsSessionToken,
 				awsRegion,
+				awsProfile,
 				awsUseCrossRegionInference,
 				vertexProjectId,
 				vertexRegion,

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -22,6 +22,7 @@ export interface ApiHandlerOptions {
 	awsSessionToken?: string
 	awsRegion?: string
 	awsUseCrossRegionInference?: boolean
+	awsProfile?: string
 	vertexProjectId?: string
 	vertexRegion?: string
 	openAiBaseUrl?: string

--- a/webview-ui/src/components/settings/ApiOptions.tsx
+++ b/webview-ui/src/components/settings/ApiOptions.tsx
@@ -373,6 +373,13 @@ const ApiOptions = ({ showModelOptions, apiErrorMessage, modelIdErrorMessage }: 
 							{/* <VSCodeOption value="us-gov-east-1">us-gov-east-1</VSCodeOption> */}
 						</VSCodeDropdown>
 					</div>
+					<VSCodeTextField
+						value={apiConfiguration?.awsProfile || ""}
+						style={{ width: "100%" }}
+						onInput={handleInputChange("awsProfile")}
+						placeholder="Default: bedrock">
+						<span style={{ fontWeight: 500 }}>AWS Profile (optional)</span>
+					</VSCodeTextField>
 					<VSCodeCheckbox
 						checked={apiConfiguration?.awsUseCrossRegionInference || false}
 						onChange={(e: any) => {

--- a/webview-ui/src/context/ExtensionStateContext.tsx
+++ b/webview-ui/src/context/ExtensionStateContext.tsx
@@ -52,6 +52,7 @@ export const ExtensionStateContextProvider: React.FC<{
 							config.apiKey,
 							config.openRouterApiKey,
 							config.awsRegion,
+							config.awsProfile,
 							config.vertexProjectId,
 							config.openAiApiKey,
 							config.ollamaModelId,


### PR DESCRIPTION
### Description

Fixes https://github.com/cline/cline/issues/852

* This PR introduces the support for automatically pulling AWS credentials using the credentials file (written using SSO), environment variables or the UI configuration.
* This PR solves for AWS credential expiration in that it reads the credentials each time, and disables caching to force a read from the AWS credential store. This way you don't have to restart the extension if your credentials expire.
* This PR intoduces the ability to set the AWS profile to be used in the AWS bedrock configuraiton UI and defaults it to "bedrock" vs "default". This offers the ability to have mutiple profiles and to have your VsCode cline profile pointing to a consistent profile not impacting default. Lets say if you have bedrock for developers configured in a separate AWS account, or under a separate IAM profile.

**Breaking Changes:**

* There is a potential breaking change in that this change doesn't support using raw ENV variables any longer as it relies on the AWS fromIni() function. This change requires an aws profile and aws credentails file to be created. If there is a desire to continue to support the use of raw AWS ENVs, I could enhance this PR to support this. It does however, support adding AWS credentials either via SSO to the sso cache or the credentials file directly.
* There is a breaking change in that the default AWS profile used is "bedrock" rather than "default". Again this could be reverted but it's easy to override in the config if you want to revert behavior.

**Observed Issues:**

* During testing it was noted if you start a task and it fails due to configuraiton, or lack of a valid configuration, and you fix it in settings, that settings changes isn't picked up until a new task is started. I recommend a separate PR to force a configuration settings reload on retry.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [X] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [X] ✨ New feature (non-breaking change which adds functionality)
-   [X] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [X] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [X] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [X] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<img width="733" alt="image" src="https://github.com/user-attachments/assets/96023dce-53fe-4f4b-905f-43666926d97f" />

### Additional Notes

<!-- Add any additional notes for reviewers -->
