### PR TITLE
chore: prettier fixed `mcp-quickstart.md` to fix workflow approval errors

### DIFF
--- a/docs/mcp/mcp-quickstart.md
+++ b/docs/mcp/mcp-quickstart.md
@@ -35,7 +35,7 @@ STOP! Before proceeding, you MUST verify these requirements:
 1. From the Cline extension, click the `MCP Server` tab
 1. Click the `Edit MCP Settings` button
 
-    <img src="https://github.com/user-attachments/assets/abf908b1-be98-4894-8dc7-ef3d27943a47" alt="MCP Server Panel" width="400" />
+ <img src="https://github.com/user-attachments/assets/abf908b1-be98-4894-8dc7-ef3d27943a47" alt="MCP Server Panel" width="400" />
 
 1. The MCP settings files should be display in a tab in VS Code.
 1. Replce the file's contents with this code:


### PR DESCRIPTION
### Description

Some unrelated PRs were having workflow approval errors because `mcp-quickstart.md` wasn't formatted properly. This change prettier fixed that file.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [x] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

### Additional Notes

<!-- Add any additional notes for reviewers -->
