### PR TITLE
feat: Allow to configure a watch argument in cline_mcp_settings.json

### DIFF
--- a/docs/mcp/mcp-quickstart.md
+++ b/docs/mcp/mcp-quickstart.md
@@ -75,6 +75,22 @@ After saving the file:
 
 <img src="https://github.com/user-attachments/assets/2abbb3de-e902-4ec2-a5e5-9418ed34684e" alt="MCP Server Panel with Installer" width="400" />
 
+## ⚡ Auto-Restart
+
+During local development, you can configure your MCP server to automatically restart when specific files change by adding a `watch` array to your configuration:
+
+```json
+{
+	"mcpServers": {
+		"my-server": {
+			"command": "node",
+			"args": ["server.js"],
+			"watch": ["server.js", "config.json"]
+		}
+	}
+}
+```
+
 ## 🤔 What Next?
 
 Now that you have the MCP installer, you can ask Cline to add more servers from:

--- a/src/services/mcp/McpHub.ts
+++ b/src/services/mcp/McpHub.ts
@@ -388,7 +388,7 @@ export class McpHub {
 	}
 
 	private setupFileWatcher(name: string, config: any) {
-		const filePath = config.args?.find((arg: string) => arg.includes("build/index.js"))
+		const filePath = config.watch || config.args?.find((arg: string) => arg.includes("build/index.js"))
 		if (filePath) {
 			// we use chokidar instead of onDidSaveTextDocument because it doesn't require the file to be open in the editor. The settings config is better suited for onDidSave since that will be manually updated by the user or Cline (and we want to detect save events, not every file change)
 			const watcher = chokidar.watch(filePath, {


### PR DESCRIPTION
### Description

It allows to configure the watch files for reloading an MCP server.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)
