### PR TITLE
Feat/add gemini 2 flash thinking model 01 21

### DIFF
--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -241,9 +241,9 @@ export const openAiModelInfoSaneDefaults: ModelInfo = {
 // Gemini
 // https://ai.google.dev/gemini-api/docs/models/gemini
 export type GeminiModelId = keyof typeof geminiModels
-export const geminiDefaultModelId: GeminiModelId = "gemini-2.0-flash-thinking-exp-1219"
+export const geminiDefaultModelId: GeminiModelId = "gemini-2.0-flash-thinking-exp-01-21"
 export const geminiModels = {
-	"gemini-2.0-flash-thinking-exp-0121": {
+	"gemini-2.0-flash-thinking-exp-01-21": {
 		maxTokens: 65536,
 		contextWindow: 1_048_576,
 		supportsImages: true,

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -259,6 +259,14 @@ export const geminiModels = {
 		inputPrice: 0,
 		outputPrice: 0,
 	},
+	"gemini-2.0-flash-thinking-exp-01-21": {
+		maxTokens: 8192,
+		contextWindow: 1_048_576,
+		supportsImages: true,
+		supportsPromptCache: false,
+		inputPrice: 0,
+		outputPrice: 0,
+	},
 	"gemini-exp-1206": {
 		maxTokens: 8192,
 		contextWindow: 2_097_152,

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -241,7 +241,7 @@ export const openAiModelInfoSaneDefaults: ModelInfo = {
 // Gemini
 // https://ai.google.dev/gemini-api/docs/models/gemini
 export type GeminiModelId = keyof typeof geminiModels
-export const geminiDefaultModelId: GeminiModelId = "gemini-2.0-flash-thinking-exp-01-21"
+export const geminiDefaultModelId: GeminiModelId = "gemini-2.0-flash-thinking-exp-1219"
 export const geminiModels = {
 	"gemini-2.0-flash-thinking-exp-01-21": {
 		maxTokens: 65536,

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -259,8 +259,8 @@ export const geminiModels = {
 		inputPrice: 0,
 		outputPrice: 0,
 	},
-	"gemini-2.0-flash-thinking-exp-01-21": {
-		maxTokens: 8192,
+	"gemini-2.0-flash-thinking-exp-0121": {
+		maxTokens: 65536,
 		contextWindow: 1_048_576,
 		supportsImages: true,
 		supportsPromptCache: false,

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -243,6 +243,14 @@ export const openAiModelInfoSaneDefaults: ModelInfo = {
 export type GeminiModelId = keyof typeof geminiModels
 export const geminiDefaultModelId: GeminiModelId = "gemini-2.0-flash-thinking-exp-1219"
 export const geminiModels = {
+	"gemini-2.0-flash-thinking-exp-0121": {
+		maxTokens: 65536,
+		contextWindow: 1_048_576,
+		supportsImages: true,
+		supportsPromptCache: false,
+		inputPrice: 0,
+		outputPrice: 0,
+	},
 	"gemini-2.0-flash-thinking-exp-1219": {
 		maxTokens: 8192,
 		contextWindow: 32_767,
@@ -253,14 +261,6 @@ export const geminiModels = {
 	},
 	"gemini-2.0-flash-exp": {
 		maxTokens: 8192,
-		contextWindow: 1_048_576,
-		supportsImages: true,
-		supportsPromptCache: false,
-		inputPrice: 0,
-		outputPrice: 0,
-	},
-	"gemini-2.0-flash-thinking-exp-0121": {
-		maxTokens: 65536,
 		contextWindow: 1_048_576,
 		supportsImages: true,
 		supportsPromptCache: false,


### PR DESCRIPTION
### Description

This PR adds the new Gemini model "gemini-2.0-flash-thinking-exp-01-21" to the available models in src/shared/api.ts. The model is added to the geminiModels object with specifications matching Google's latest experimental model capabilities.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A - No UI changes in this PR

### Additional Notes

Model specifications:

"gemini-2.0-flash-thinking-exp-01-21": {
    maxTokens: 65536,
    contextWindow: 1_048_576,
    supportsImages: true,
    supportsPromptCache: false,
    inputPrice: 0,
    outputPrice: 0,
}
The model has been added before "gemini-2.0-flash-thinking-exp-1219" to maintain a logical ordering of models. All type safety is maintained through the existing TypeScript interfaces and type assertions.
