### PR TITLE
fix: Remove redundant closing tag from MCP tool example

### DIFF
--- a/src/core/prompts/system.ts
+++ b/src/core/prompts/system.ts
@@ -196,7 +196,6 @@ Usage:
   "param2": "value2"
 }
 </arguments>
-</use_mcp_tool>
 
 ## access_mcp_resource
 Description: Request to access a resource provided by a connected MCP server. Resources represent data sources that can be used as context, such as files, API responses, or system information.
@@ -324,7 +323,6 @@ ${
   "days": 5
 }
 </arguments>
-</use_mcp_tool>
 
 ## Example 5: Requesting to access an MCP resource
 


### PR DESCRIPTION
## Description
This PR fixes an issue in the system prompt where a redundant closing tag `</use_mcp_tool>` was being added to the bottom of the MCP tool example. This extra tag was causing issues to use MCP tools. Causing errors.

## Changes Made
- Removed the redundant closing tag from the MCP tool example in `src/core/prompts/system.ts`
- The example now correctly shows the proper XML-style formatting without duplicate closing tags