### PR TITLE
feat: add cline user agent in Axios requests

### DIFF
--- a/src/api/providers/openrouter.ts
+++ b/src/api/providers/openrouter.ts
@@ -151,6 +151,7 @@ export class OpenRouterHandler implements ApiHandler {
 			const response = await axios.get(`https://openrouter.ai/api/v1/generation?id=${genId}`, {
 				headers: {
 					Authorization: `Bearer ${this.options.openRouterApiKey}`,
+					"User-Agent": "Cline",
 				},
 				timeout: 5_000, // this request hangs sometimes
 			})

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -81,6 +81,12 @@ export const GlobalFileNames = {
 	clineRules: ".clinerules",
 }
 
+const headers = {
+	headers: {
+		"User-Agent": "Cline",
+	},
+}
+
 export class ClineProvider implements vscode.WebviewViewProvider {
 	public static readonly sideBarId = "claude-dev.SidebarProvider" // used in package.json as the view's id. This value cannot be changed due to how vscode caches views based on their id, and updating the id would break existing instances of the extension.
 	public static readonly tabPanelId = "claude-dev.TabPanelProvider"
@@ -763,7 +769,7 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 			if (!URL.canParse(baseUrl)) {
 				return []
 			}
-			const response = await axios.get(`${baseUrl}/api/tags`)
+			const response = await axios.get(`${baseUrl}/api/tags`, headers)
 			const modelsArray = response.data?.models?.map((model: any) => model.name) || []
 			const models = [...new Set<string>(modelsArray)]
 			return models
@@ -782,7 +788,7 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 			if (!URL.canParse(baseUrl)) {
 				return []
 			}
-			const response = await axios.get(`${baseUrl}/v1/models`)
+			const response = await axios.get(`${baseUrl}/v1/models`, headers)
 			const modelsArray = response.data?.data?.map((model: any) => model.id) || []
 			const models = [...new Set<string>(modelsArray)]
 			return models
@@ -867,7 +873,7 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 
 		let models: Record<string, ModelInfo> = {}
 		try {
-			const response = await axios.get("https://openrouter.ai/api/v1/models")
+			const response = await axios.get("https://openrouter.ai/api/v1/models", headers)
 			/*
 			{
 				"id": "anthropic/claude-3.5-sonnet",


### PR DESCRIPTION
### Description

Propagate user agent as Cline, so the original tool gets identified properly when tracking requests

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

### Additional Notes

<!-- Add any additional notes for reviewers -->
