### PR TITLE
Continuous Delivery | Pre Release Build and Publish

### DIFF
--- a/.github/workflows/prerelease-publish.yml
+++ b/.github/workflows/prerelease-publish.yml
@@ -6,32 +6,30 @@ on:
 
 jobs:
     publish-prerelease:
-        runs-on: ubuntu-latest
-        environment: staging
+    runs-on: ubuntu-latest
+    steps:
+        - name: Checkout code
+          uses: actions/checkout@v4
 
-        steps:
-            - name: Checkout code
-              uses: actions/checkout@v4
+        - name: Setup Node.js
+          uses: actions/setup-node@v4
+          with:
+              node-version: "20.15.1"
+              cache: "npm"
 
-            - name: Setup Node.js
-              uses: actions/setup-node@v4
-              with:
-                  node-version: "20.15.1"
-                  cache: "npm"
+        - name: Install dependencies
+          run: |
+              npm ci
+              cd webview-ui && npm ci
+              cd ..
 
-            - name: Install dependencies
-              run: |
-                  npm ci
-                  cd webview-ui && npm ci
-                  cd ..
+        - name: Install vsce
+          run: npm install -g @vscode/vsce
 
-            - name: Install vsce
-              run: npm install -g @vscode/vsce
+        - name: Build VSIX
+          run: vsce package
 
-            - name: Build VSIX
-              run: vsce package
-
-            - name: Publish Pre-release to Marketplace
-              run: vsce publish --pre-release -p ${{ secrets.VSCE_PAT }}
-              env:
-                  VSCE_PAT: ${{ secrets.VSCE_PAT }}
+        - name: Publish Pre-release to Marketplace
+          run: vsce publish --pre-release -p ${{ secrets.VSCE_PAT }}
+          env:
+              VSCE_PAT: ${{ secrets.VSCE_PAT }}

--- a/.github/workflows/prerelease-publish.yml
+++ b/.github/workflows/prerelease-publish.yml
@@ -1,0 +1,37 @@
+name: Pre-release Publisher
+
+on:
+    release:
+        types: [prereleased]
+
+jobs:
+    publish-prerelease:
+        runs-on: ubuntu-latest
+        environment: staging
+
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v4
+
+            - name: Setup Node.js
+              uses: actions/setup-node@v4
+              with:
+                  node-version: "20.15.1"
+                  cache: "npm"
+
+            - name: Install dependencies
+              run: |
+                  npm ci
+                  cd webview-ui && npm ci
+                  cd ..
+
+            - name: Install vsce
+              run: npm install -g @vscode/vsce
+
+            - name: Build VSIX
+              run: vsce package
+
+            - name: Publish Pre-release to Marketplace
+              run: vsce publish --pre-release -p ${{ secrets.VSCE_PAT }}
+              env:
+                  VSCE_PAT: ${{ secrets.VSCE_PAT }}

--- a/.github/workflows/prerelease-publish.yml
+++ b/.github/workflows/prerelease-publish.yml
@@ -5,6 +5,20 @@ on:
         types: [prereleased]
     workflow_dispatch:
 
+permissions:
+    contents: write
+    packages: write
+    actions: read
+    checks: read
+    deployments: read
+    discussions: read
+    issues: read
+    pages: read
+    pull-requests: read
+    repository-projects: read
+    security-events: read
+    statuses: read
+
 jobs:
     test:
         uses: ./.github/workflows/test.yml

--- a/.github/workflows/prerelease-publish.yml
+++ b/.github/workflows/prerelease-publish.yml
@@ -3,33 +3,70 @@ name: Pre-release Publisher
 on:
     release:
         types: [prereleased]
+    workflow_dispatch:
 
 jobs:
+    test:
+        uses: ./.github/workflows/test.yml
+
     publish-prerelease:
-    runs-on: ubuntu-latest
-    steps:
-        - name: Checkout code
-          uses: actions/checkout@v4
+        needs: test
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v4
 
-        - name: Setup Node.js
-          uses: actions/setup-node@v4
-          with:
-              node-version: "20.15.1"
-              cache: "npm"
+            - name: Setup Node.js
+              uses: actions/setup-node@v4
+              with:
+                  node-version: "20.15.1"
+                  cache: "npm"
 
-        - name: Install dependencies
-          run: |
-              npm ci
-              cd webview-ui && npm ci
-              cd ..
+            # Cache root dependencies
+            - name: Cache root dependencies
+              uses: actions/cache@v4
+              id: root-cache
+              with:
+                  path: node_modules
+                  key: ${{ runner.os }}-npm-${{ hashFiles('package-lock.json') }}
 
-        - name: Install vsce
-          run: npm install -g @vscode/vsce
+            # Cache webview-ui dependencies
+            - name: Cache webview-ui dependencies
+              uses: actions/cache@v4
+              id: webview-cache
+              with:
+                  path: webview-ui/node_modules
+                  key: ${{ runner.os }}-npm-webview-${{ hashFiles('webview-ui/package-lock.json') }}
 
-        - name: Build VSIX
-          run: vsce package
+            - name: Install root dependencies
+              if: steps.root-cache.outputs.cache-hit != 'true'
+              run: npm ci
 
-        - name: Publish Pre-release to Marketplace
-          run: vsce publish --pre-release -p ${{ secrets.VSCE_PAT }}
-          env:
-              VSCE_PAT: ${{ secrets.VSCE_PAT }}
+            - name: Install webview-ui dependencies
+              if: steps.webview-cache.outputs.cache-hit != 'true'
+              run: cd webview-ui && npm ci
+
+            - name: Build Extension
+              run: npm run build
+
+            - name: Install Publishing Tools
+              run: npm install -g vsce ovsx
+
+            - name: Package and Publish Pre-release
+              env:
+                  VSCE_PAT: ${{ secrets.VSCE_PAT }}
+                  OVSX_PAT: ${{ secrets.OVSX_PAT }}
+              run: |
+                  current_package_version=$(node -p "require('./package.json').version")
+                  vsce package
+                  vsce publish --pre-release -p ${{ secrets.VSCE_PAT }}
+                  echo "Successfully published pre-release version $current_package_version to VS Code Marketplace"
+
+            - name: Create GitHub Pre-release
+              uses: softprops/action-gh-release@v1
+              with:
+                  files: "*.vsix"
+                  generate_release_notes: true
+                  prerelease: true
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Description

This PR implements automated pre-release publishing for the VS Code extension. When a pre-release is created on GitHub, the workflow automatically builds a VSIX package and publishes it as a pre-release version to the VS Code marketplace.

Key features:
- Automated VSIX build on pre-release creation
- Pre-release publishing to VS Code marketplace using --pre-release flag
- Uses same VSCE_PAT secret as main release workflow
- Allows users to test new versions before stable release

### Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update

### Pre-flight Checklist

- [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
- [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
- [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A - Infrastructure change only

### Additional Notes

This workflow complements the existing release-publish.yml workflow by adding pre-release support. When publishing with the --pre-release flag, the extension is marked as a preview version in the marketplace, allowing users to explicitly opt-in to testing new features before they reach the stable channel.

Required setup:
- VSCE_PAT secret must be configured in GitHub repository settings

Usage:
1. Create a pre-release in GitHub
2. Workflow automatically triggers
3. VSIX is built and published as pre-release to marketplace
