### PR TITLE
Add disable checkpoints setting 

### DIFF
--- a/package.json
+++ b/package.json
@@ -146,6 +146,11 @@
 					"type": "boolean",
 					"default": true,
 					"description": "Include MCP server functionality in AI prompts. When disabled, the AI will not be aware of MCP capabilities. This saves context window tokens."
+				},
+				"cline.disableCheckpoints": {
+					"type": "boolean",
+					"default": false,
+					"description": "Disable checkpoint creation during task execution"
 				}
 			}
 		}

--- a/package.json
+++ b/package.json
@@ -147,10 +147,10 @@
 					"default": true,
 					"description": "Include MCP server functionality in AI prompts. When disabled, the AI will not be aware of MCP capabilities. This saves context window tokens."
 				},
-				"cline.disableCheckpoints": {
+				"cline.enableCheckpoints": {
 					"type": "boolean",
-					"default": false,
-					"description": "Disable checkpoint creation during task execution"
+					"default": true,
+					"description": "Enable checkpoint creation during task execution"
 				}
 			}
 		}

--- a/src/integrations/checkpoints/CheckpointTracker.ts
+++ b/src/integrations/checkpoints/CheckpointTracker.ts
@@ -21,10 +21,16 @@ class CheckpointTracker {
 		this.cwd = cwd
 	}
 
-	public static async create(taskId: string, provider?: ClineProvider): Promise<CheckpointTracker> {
+	public static async create(taskId: string, provider?: ClineProvider): Promise<CheckpointTracker | undefined> {
 		try {
 			if (!provider) {
 				throw new Error("Provider is required to create a checkpoint tracker")
+			}
+
+			// Check if checkpoints are disabled in VS Code settings
+			const disableCheckpoints = vscode.workspace.getConfiguration("cline").get<boolean>("disableCheckpoints") ?? false
+			if (disableCheckpoints) {
+				return undefined // Don't create tracker when disabled
 			}
 
 			// Check if git is installed by attempting to get version

--- a/src/integrations/checkpoints/CheckpointTracker.ts
+++ b/src/integrations/checkpoints/CheckpointTracker.ts
@@ -28,8 +28,8 @@ class CheckpointTracker {
 			}
 
 			// Check if checkpoints are disabled in VS Code settings
-			const disableCheckpoints = vscode.workspace.getConfiguration("cline").get<boolean>("disableCheckpoints") ?? false
-			if (disableCheckpoints) {
+			const enableCheckpoints = vscode.workspace.getConfiguration("cline").get<boolean>("enableCheckpoints") ?? true
+			if (!enableCheckpoints) {
 				return undefined // Don't create tracker when disabled
 			}
 


### PR DESCRIPTION
### Description

This PR adds the ability to control checkpoint creation through VS Code settings. Some users experience issues with the shadow git repo used for checkpoints, so this change allows them to disable the checkpoint feature when needed.

The implementation adds a new VS Code setting `cline.enableCheckpoints` that controls checkpoint creation. When the setting is disabled, it prevents the creation of shadow git repositories and hides checkpoint controls from the UI. The setting defaults to enabled to maintain existing behavior. The change is minimal and leverages existing null-safety patterns in the codebase.

The implementation creates an intentionally asymmetric behavior around mid-task toggling: disabling mid-task has no effect (preserving existing functionality) while enabling mid-task allows checkpoints from that point forward. This is by design - we never destroy an existing CheckpointTracker instance when the setting is disabled, but we do attempt to create one when needed if none exists. This approach prioritizes safety (never losing existing checkpoints) while still allowing users to enable the feature when needed.

Key behaviors:

1. When disabled:
   - No shadow git repo is created
   - No checkpoint controls appear in UI
   - Tasks proceed normally without checkpoint functionality

2. When enabled:
   - Functions exactly as before
   - Creates shadow git repo
   - Shows checkpoint controls
   - All checkpoint operations work normally

3. Toggling behavior:
   - **Disabled → Enabled**:
     - New tasks will have checkpoints
     - Existing tasks without checkpoints remain without them
     - No retroactive checkpoint creation for existing tasks
   
   - **Enabled → Disabled**:
     - New tasks will not have checkpoints
     - Existing tasks retain their checkpoints
     - Can still access/restore existing checkpoints
     - No new checkpoints can be created

4. Mid-task behavior:
   - Tasks started with checkpoints enabled:
     - Continue creating checkpoints even if setting is disabled mid-task
     - Can restore previous checkpoints
     - UI controls remain visible
   
   - Tasks started with checkpoints disabled:
     - Start without checkpoint functionality
     - If setting is enabled mid-task, checkpoints will begin working from that point forward
     - Only actions after enabling will have checkpoint controls
     - Cannot create checkpoints for actions taken while disabled

### Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)

### Pre-flight Checklist

- [x] Changes are limited to a single feature (adds checkpoint disable capability)
- [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
- [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

### Additional Notes

The implementation is intentionally minimal, adding just a single check in CheckpointTracker.create() that prevents shadow git repo creation when disabled. This approach:

1. Leverages existing null-safety patterns in the UI
2. Maintains all error handling paths
3. Preserves existing checkpoint functionality when enabled
4. Provides clean transitions when toggling the setting

#### Testing Done
* Tested the above cases described under "key behavior"
* Verified that .git files were not created in the cases where checkpoints should be disabled

Testing notes:
- Checkpoints can only be created in proper workspaces (not in Desktop/Documents/Downloads/Home directories)
- Checkpoints are stored for each task at the following path:

      - Windows: %APPDATA%/Code/User/globalStorage/saoudrizwan.claude-dev
      - macOS: ~/Library/Application Support/Code/User/globalStorage/saoudrizwan.claude-dev
      - Linux: ~/.config/Code/User/globalStorage/saoudrizwan.claude-dev)