### PR TITLE
Add more granular settings filtering

### DIFF
--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -683,7 +683,11 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 						break
 					}
 					case "openExtensionSettings": {
-						await vscode.commands.executeCommand("workbench.action.openSettings", "@ext:saoudrizwan.claude-dev")
+						const settingsFilter = message.text || ""
+						await vscode.commands.executeCommand(
+							"workbench.action.openSettings",
+							`@ext:saoudrizwan.claude-dev ${settingsFilter}`.trim(), // trim whitespace if no settings filter
+						)
 						break
 					}
 					// Add more switch case statements here as more webview message commands


### PR DESCRIPTION
### Description

This PR adds more granular settings filters for the MCP settings view. Instead of just showing all extension settings when clicking "Advanced MCP Settings", we now filter down to just the MCP-related ones. The approach is flexible enough to be used anywhere in the extension where we need to narrow down settings to specific groups, while still keeping the option to show everything when needed.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

- [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
- [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
- [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots
**No filtering - General advanced settings button**
<img width="1367" alt="Screenshot 2025-01-26 at 3 50 06 PM" src="https://github.com/user-attachments/assets/07e5655e-bbe1-4824-8844-cb951444db00" />

**Granular filtering - MCP settings link**
<img width="1371" alt="Screenshot 2025-01-26 at 3 53 43 PM" src="https://github.com/user-attachments/assets/b9f7ac91-93b1-4acc-aa94-9397f8a42524" />



### Additional Notes
