### PR TITLE
fix: can't reference files under directories in parentheses

### DIFF
--- a/.changeset/silly-buses-count.md
+++ b/.changeset/silly-buses-count.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Fix can't reference files under directories in parentheses

--- a/src/services/glob/list-files.ts
+++ b/src/services/glob/list-files.ts
@@ -3,6 +3,10 @@ import os from "os"
 import * as path from "path"
 import { arePathsEqual } from "../../utils/path"
 
+function escapeGlobPattern(pattern: string): string {
+	return pattern.replace(/[(){}[\]]/g, "\\$&")
+}
+
 export async function listFiles(dirPath: string, recursive: boolean, limit: number): Promise<[string[], boolean]> {
 	const absolutePath = path.resolve(dirPath)
 	// Do not allow listing files in root or home directory, which cline tends to want to do when the user's prompt is vague.
@@ -47,7 +51,8 @@ export async function listFiles(dirPath: string, recursive: boolean, limit: numb
 	}
 
 	// * globs all files in one dir, ** globs files in nested directories
-	const filePaths = recursive ? await globbyLevelByLevel(limit, options) : (await globby("*", options)).slice(0, limit)
+	const pattern = escapeGlobPattern("*")
+	const filePaths = recursive ? await globbyLevelByLevel(limit, options) : (await globby(pattern, options)).slice(0, limit)
 
 	return [filePaths, filePaths.length >= limit]
 }
@@ -66,7 +71,7 @@ Breadth-first traversal of directory structure level by level up to a limit:
 */
 async function globbyLevelByLevel(limit: number, options?: Options) {
 	let results: Set<string> = new Set()
-	let queue: string[] = ["*"]
+	let queue: string[] = [escapeGlobPattern("*")]
 
 	const globbingProcess = async () => {
 		while (queue.length > 0 && results.size < limit) {
@@ -79,7 +84,7 @@ async function globbyLevelByLevel(limit: number, options?: Options) {
 				}
 				results.add(file)
 				if (file.endsWith("/")) {
-					queue.push(`${file}*`)
+					queue.push(escapeGlobPattern(`${file}*`))
 				}
 			}
 		}

--- a/webview-ui/src/components/chat/ContextMenu.tsx
+++ b/webview-ui/src/components/chat/ContextMenu.tsx
@@ -64,7 +64,6 @@ const ContextMenu: React.FC<ContextMenuProps> = ({
 									whiteSpace: "nowrap",
 									overflow: "hidden",
 									textOverflow: "ellipsis",
-									direction: "rtl",
 									textAlign: "left",
 								}}>
 								{cleanPathPrefix(option.value || "") + "\u200E"}

--- a/webview-ui/src/components/common/CodeAccordian.tsx
+++ b/webview-ui/src/components/common/CodeAccordian.tsx
@@ -15,12 +15,15 @@ interface CodeAccordianProps {
 }
 
 /*
-We need to remove leading non-alphanumeric characters from the path in order for our leading ellipses trick to work.
+We need to remove leading non-alphanumeric and non-special characters from the path in order for our leading ellipses trick to work.
 ^: Anchors the match to the start of the string.
-[^a-zA-Z0-9]+: Matches one or more characters that are not alphanumeric.
-The replace method removes these matched characters, effectively trimming the string up to the first alphanumeric character.
+[^\u4e00-\u9fa5a-zA-Z0-9()[\]{}]+: Matches one or more characters that are not:
+- Chinese characters (\u4e00-\u9fa5)
+- Alphanumeric characters (a-zA-Z0-9)
+- Common path characters: parentheses (), square brackets [], curly braces {}
+The replace method removes these matched characters, effectively trimming the string up to the first valid character.
 */
-export const cleanPathPrefix = (path: string): string => path.replace(/^[^\u4e00-\u9fa5a-zA-Z0-9]+/, "")
+export const cleanPathPrefix = (path: string): string => path.replace(/^[^\u4e00-\u9fa5a-zA-Z0-9()[\]{}]+/, "")
 
 const CodeAccordian = ({
 	code,


### PR DESCRIPTION
### Description

<!-- Describe your changes in detail. What problem does this PR solve? -->
This PR introduces several changes to fix #1164 improve the handling of file paths and directory listings in the application:

1. **Escape Glob Patterns**: Added a utility function `escapeGlobPattern` to escape special characters in glob patterns, ensuring that paths containing characters like `(){}[]` are correctly handled during directory traversal.

2. **Path Prefix Cleaning**: Updated the `cleanPathPrefix` function to handle `(){}[]` correctly.

3. **UI Adjustment**: Removed the `direction: "rtl"` CSS property from the `ContextMenu.tsx` component to make sure the path with `(){}[]` displays properly.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->
Add File:
![CleanShot 2025-01-26 at 20 31 45@2x](https://github.com/user-attachments/assets/77d89d14-c39b-4347-bae9-d90e832a250f)

Add Folder:
![CleanShot 2025-01-26 at 20 32 24@2x](https://github.com/user-attachments/assets/dbe66d5e-dd46-49df-b5ff-24e28b02a86b)


### Additional Notes

<!-- Add any additional notes for reviewers -->
- **Removing `rtl` Direction**: I am unsure if removing the `rtl` (right-to-left) direction property is acceptable. This change was made to improve text alignment and readability, but it may have unintended consequences for certain languages or paths. Feedback from reviewers on this change would be appreciated.

- **Allowing `[]` and `{}` in Paths**: I am also unsure if allowing square brackets `[]` and curly braces `{}` in paths is appropriate. While these characters are now included in the `cleanPathPrefix` function to handle special cases, there may be scenarios where this could cause issues. Reviewers, please let me know if this change aligns with the intended behavior or if further adjustments are needed.