### PR TITLE
feat:Add custom context window for openai compatible endpoints

### DIFF
--- a/src/api/providers/openai.ts
+++ b/src/api/providers/openai.ts
@@ -59,7 +59,10 @@ export class OpenAiHandler implements ApiHandler {
 	getModel(): { id: string; info: ModelInfo } {
 		return {
 			id: this.options.openAiModelId ?? "",
-			info: openAiModelInfoSaneDefaults,
+			info: {
+				...openAiModelInfoSaneDefaults,
+				contextWindow: this.options.openAiContextWindow ?? openAiModelInfoSaneDefaults.contextWindow,
+			}
 		}
 	}
 }

--- a/src/api/providers/openai.ts
+++ b/src/api/providers/openai.ts
@@ -62,7 +62,7 @@ export class OpenAiHandler implements ApiHandler {
 			info: {
 				...openAiModelInfoSaneDefaults,
 				contextWindow: this.options.openAiContextWindow ?? openAiModelInfoSaneDefaults.contextWindow,
-			}
+			},
 		}
 	}
 }

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -59,6 +59,7 @@ type GlobalStateKey =
 	| "customInstructions"
 	| "taskHistory"
 	| "openAiBaseUrl"
+	| "openAiContextWindow"
 	| "openAiModelId"
 	| "ollamaModelId"
 	| "ollamaBaseUrl"
@@ -426,6 +427,7 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 								vertexProjectId,
 								vertexRegion,
 								openAiBaseUrl,
+								openAiContextWindow,
 								openAiApiKey,
 								openAiModelId,
 								ollamaModelId,
@@ -454,6 +456,7 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 							await this.updateGlobalState("vertexProjectId", vertexProjectId)
 							await this.updateGlobalState("vertexRegion", vertexRegion)
 							await this.updateGlobalState("openAiBaseUrl", openAiBaseUrl)
+							await this.updateGlobalState("openAiContextWindow", openAiContextWindow)
 							await this.storeSecret("openAiApiKey", openAiApiKey)
 							await this.updateGlobalState("openAiModelId", openAiModelId)
 							await this.updateGlobalState("ollamaModelId", ollamaModelId)
@@ -1238,6 +1241,7 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 			vertexProjectId,
 			vertexRegion,
 			openAiBaseUrl,
+			openAiContextWindow,
 			openAiApiKey,
 			openAiModelId,
 			ollamaModelId,
@@ -1274,6 +1278,7 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 			this.getGlobalState("vertexProjectId") as Promise<string | undefined>,
 			this.getGlobalState("vertexRegion") as Promise<string | undefined>,
 			this.getGlobalState("openAiBaseUrl") as Promise<string | undefined>,
+			this.getGlobalState("openAiContextWindow") as Promise<number | undefined>,
 			this.getSecret("openAiApiKey") as Promise<string | undefined>,
 			this.getGlobalState("openAiModelId") as Promise<string | undefined>,
 			this.getGlobalState("ollamaModelId") as Promise<string | undefined>,
@@ -1327,6 +1332,7 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 				vertexProjectId,
 				vertexRegion,
 				openAiBaseUrl,
+				openAiContextWindow,
 				openAiApiKey,
 				openAiModelId,
 				ollamaModelId,

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -29,6 +29,7 @@ export interface ApiHandlerOptions {
 	openAiBaseUrl?: string
 	openAiApiKey?: string
 	openAiModelId?: string
+	openAiContextWindow?: number
 	ollamaModelId?: string
 	ollamaBaseUrl?: string
 	lmStudioModelId?: string

--- a/webview-ui/src/components/settings/ApiOptions.tsx
+++ b/webview-ui/src/components/settings/ApiOptions.tsx
@@ -536,6 +536,13 @@ const ApiOptions = ({ showModelOptions, apiErrorMessage, modelIdErrorMessage, is
 					</VSCodeTextField>
 					<span style={{ fontWeight: 500 }}>{t("model")}</span>
 					<OpenAiModelPicker />
+					<VSCodeTextField
+						value={apiConfiguration?.openAiContextWindow ? apiConfiguration.openAiContextWindow.toString() : ""}
+						style={{ width: "100%" }}
+						onInput={handleInputChange("openAiContextWindow")}
+						placeholder={"Default: 128000"}>
+						<span style={{ fontWeight: 500 }}>Context Window Size</span>
+					</VSCodeTextField>
 					<VSCodeCheckbox
 						checked={azureApiVersionSelected}
 						onChange={(e: any) => {


### PR DESCRIPTION
### Description

This PR adds the ability to customize the context window size for OpenAI-compatible models while preserving the predefined settings for native OpenAI models.

Changes:

Added context window size input field in API options for OpenAI-compatible provider
Updated OpenAI provider to use custom context window size when specified
Maintained separation between OpenAI-compatible and native OpenAI implementations:
OpenAI-compatible models: Can use custom context window or fall back to 128k default
Native OpenAI models: Continue using their predefined context windows
The context window setting allows users to adjust the context size based on their specific OpenAI-compatible model's capabilities, while ensuring that native OpenAI models maintain their standard configurations.

Based on this PR [Add custom context window setting for OpenAI-compatible models #817](https://github.com/cline/cline/pull/817) from @bold84

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

![Capture d’écran 2025-01-27 121029](https://github.com/user-attachments/assets/dfd7f70f-e1c5-4a93-b60c-ea2f8f67fcbe)

### Additional Notes

<!-- Add any additional notes for reviewers -->
Merging this PR would allow use of cline in our organization (several thousand people)
