### PR TITLE
Set user-agent to Cline for Anthropic and OpenAI providers

### DIFF
--- a/src/api/providers/anthropic.ts
+++ b/src/api/providers/anthropic.ts
@@ -3,6 +3,7 @@ import { Stream as AnthropicStream } from "@anthropic-ai/sdk/streaming"
 import { anthropicDefaultModelId, AnthropicModelId, anthropicModels, ApiHandlerOptions, ModelInfo } from "../../shared/api"
 import { ApiHandler } from "../index"
 import { ApiStream } from "../transform/stream"
+import { version } from "../../../package.json"
 
 export class AnthropicHandler implements ApiHandler {
 	private options: ApiHandlerOptions
@@ -13,6 +14,9 @@ export class AnthropicHandler implements ApiHandler {
 		this.client = new Anthropic({
 			apiKey: this.options.apiKey,
 			baseURL: this.options.anthropicBaseUrl || undefined,
+			defaultHeaders: {
+				"User-Agent": `Cline/${version}`,
+			},
 		})
 	}
 

--- a/src/api/providers/lmstudio.ts
+++ b/src/api/providers/lmstudio.ts
@@ -4,6 +4,7 @@ import { ApiHandler } from "../"
 import { ApiHandlerOptions, ModelInfo, openAiModelInfoSaneDefaults } from "../../shared/api"
 import { convertToOpenAiMessages } from "../transform/openai-format"
 import { ApiStream } from "../transform/stream"
+import { version } from "../../../package.json"
 
 export class LmStudioHandler implements ApiHandler {
 	private options: ApiHandlerOptions
@@ -14,6 +15,9 @@ export class LmStudioHandler implements ApiHandler {
 		this.client = new OpenAI({
 			baseURL: (this.options.lmStudioBaseUrl || "http://localhost:1234") + "/v1",
 			apiKey: "noop",
+			defaultHeaders: {
+				"User-Agent": `Cline/${version}`,
+			},
 		})
 	}
 

--- a/src/api/providers/ollama.ts
+++ b/src/api/providers/ollama.ts
@@ -4,6 +4,7 @@ import { ApiHandler } from "../"
 import { ApiHandlerOptions, ModelInfo, openAiModelInfoSaneDefaults } from "../../shared/api"
 import { convertToOpenAiMessages } from "../transform/openai-format"
 import { ApiStream } from "../transform/stream"
+import { version } from "../../../package.json"
 
 export class OllamaHandler implements ApiHandler {
 	private options: ApiHandlerOptions
@@ -14,6 +15,9 @@ export class OllamaHandler implements ApiHandler {
 		this.client = new OpenAI({
 			baseURL: (this.options.ollamaBaseUrl || "http://localhost:11434") + "/v1",
 			apiKey: "ollama",
+			defaultHeaders: {
+				"User-Agent": `Cline/${version}`,
+			},
 		})
 	}
 

--- a/src/api/providers/openai.ts
+++ b/src/api/providers/openai.ts
@@ -5,6 +5,7 @@ import { ApiHandler } from "../index"
 import { convertToOpenAiMessages } from "../transform/openai-format"
 import { ApiStream } from "../transform/stream"
 import { convertToR1Format } from "../transform/r1-format"
+import { version } from "../../../package.json"
 
 export class OpenAiHandler implements ApiHandler {
 	private options: ApiHandlerOptions
@@ -18,11 +19,17 @@ export class OpenAiHandler implements ApiHandler {
 				baseURL: this.options.openAiBaseUrl,
 				apiKey: this.options.openAiApiKey,
 				apiVersion: this.options.azureApiVersion || azureOpenAiDefaultApiVersion,
+				defaultHeaders: {
+					"User-Agent": `Cline/${version}`,
+				},
 			})
 		} else {
 			this.client = new OpenAI({
 				baseURL: this.options.openAiBaseUrl,
 				apiKey: this.options.openAiApiKey,
+				defaultHeaders: {
+					"User-Agent": `Cline/${version}`,
+				},
 			})
 		}
 	}


### PR DESCRIPTION

### Description

When cline is used behind a proxy such as
[codegate](https://github.com/stacklok/codegate) it is useful to know
what kind of client is the proxy talking to.

This patch adds User-Agent headers to the calls that talk to LLMs that
allow the base API to be set, which are IIRC OpenAPI-like, Anthropic,
LMStudio and Ollama.

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A

### Additional Notes

N/A
