### PR TITLE
Disable language dropdown until i18n fully integrated

### DIFF
--- a/webview-ui/src/components/settings/SettingsView.tsx
+++ b/webview-ui/src/components/settings/SettingsView.tsx
@@ -5,7 +5,7 @@ import { useExtensionState } from "../../context/ExtensionStateContext"
 import { validateApiConfiguration, validateModelId } from "../../utils/validate"
 import { vscode } from "../../utils/vscode"
 import ApiOptions from "./ApiOptions"
-import LanguageOptions from "./LanguageOptions"
+//import LanguageOptions from "./LanguageOptions"
 import SettingsButton from "../common/SettingsButton"
 
 const IS_DEV = false // FIXME: use flags when packaging
@@ -117,9 +117,9 @@ const SettingsView = ({ onDone }: SettingsViewProps) => {
 						{t("customInstructionsDescription")}
 					</p>
 				</div>
-				<div style={{ marginBottom: 5 }}>
+				{/*<div style={{ marginBottom: 5 }}>
 					<LanguageOptions />
-				</div>
+				</div>*/}
 
 				{IS_DEV && (
 					<>

--- a/webview-ui/src/i18n.ts
+++ b/webview-ui/src/i18n.ts
@@ -2,10 +2,10 @@ import i18n from "i18next"
 import { initReactI18next } from "react-i18next"
 
 import translationEN from "./locales/en/translation.json"
-import translationDE from "./locales/de/translation.json"
-import translationZHCN from "./locales/zh-cn/translation.json"
-import translationZHTW from "./locales/zh-tw/translation.json"
-import translationJA from "./locales/ja/translation.json"
+//import translationDE from "./locales/de/translation.json"
+//import translationZHCN from "./locales/zh-cn/translation.json"
+//import translationZHTW from "./locales/zh-tw/translation.json"
+//import translationJA from "./locales/ja/translation.json"
 
 i18n.use(initReactI18next) // passes i18n down to react-i18next
 	.init({
@@ -18,10 +18,10 @@ i18n.use(initReactI18next) // passes i18n down to react-i18next
 		},
 	})
 
-i18n.addResourceBundle("de", "translation", translationDE)
 i18n.addResourceBundle("en", "translation", translationEN)
-i18n.addResourceBundle("zh-CN", "translation", translationZHCN)
-i18n.addResourceBundle("zh-TW", "translation", translationZHTW)
-i18n.addResourceBundle("ja", "translation", translationJA)
+//i18n.addResourceBundle("de", "translation", translationDE)
+//i18n.addResourceBundle("zh-CN", "translation", translationZHCN)
+//i18n.addResourceBundle("zh-TW", "translation", translationZHTW)
+//i18n.addResourceBundle("ja", "translation", translationJA)
 
 export default i18n


### PR DESCRIPTION
### Description

<!-- Describe your changes in detail. What problem does this PR solve? -->
Disable language dropdown && automatic switching of VSCode Display Language until `react-i18next` is fully integrated.  

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

### Additional Notes

<!-- Add any additional notes for reviewers -->
Language will always default to `en` (english).
