### PR TITLE
Additional i18n-l10n for Welcome/Home/Chat/History + Spanish language translations

### DIFF
--- a/webview-ui/src/components/chat/Announcement.tsx
+++ b/webview-ui/src/components/chat/Announcement.tsx
@@ -114,8 +114,8 @@ const Announcement = ({ version, hideAnnouncement }: AnnouncementProps) => {
 				<Trans
 					i18nKey="announcement.joinOurCommunities"
 					components={{
-						DiscordLink: <VSCodeLink href="https://discord.gg/cline" />,
-						RedditLink: <VSCodeLink href="https://www.reddit.com/r/cline/" />,
+						DiscordLink: <VSCodeLink style={{ display: "inline" }} href="https://discord.gg/cline" />,
+						RedditLink: <VSCodeLink style={{ display: "inline" }} href="https://www.reddit.com/r/cline/" />,
 					}}
 				/>
 			</p>

--- a/webview-ui/src/components/chat/AutoApproveMenu.tsx
+++ b/webview-ui/src/components/chat/AutoApproveMenu.tsx
@@ -5,6 +5,7 @@ import { useExtensionState } from "../../context/ExtensionStateContext"
 import { AutoApprovalSettings } from "../../../../src/shared/AutoApprovalSettings"
 import { vscode } from "../../utils/vscode"
 import { getAsVar, VSC_FOREGROUND, VSC_TITLEBAR_INACTIVE_FOREGROUND, VSC_DESCRIPTION_FOREGROUND } from "../../utils/vscStyles"
+import { useTranslation } from "react-i18next"
 
 interface AutoApproveMenuProps {
 	style?: React.CSSProperties
@@ -50,6 +51,7 @@ const ACTION_METADATA: {
 ]
 
 const AutoApproveMenu = ({ style }: AutoApproveMenuProps) => {
+	const { t } = useTranslation("translation", { keyPrefix: "autoApproveMenu" })
 	const { autoApprovalSettings } = useExtensionState()
 	const [isExpanded, setIsExpanded] = useState(false)
 	const [isHoveringCollapsibleSection, setIsHoveringCollapsibleSection] = useState(false)
@@ -190,7 +192,7 @@ const AutoApproveMenu = ({ style }: AutoApproveMenuProps) => {
 							color: getAsVar(VSC_FOREGROUND),
 							whiteSpace: "nowrap",
 						}}>
-						Auto-approve:
+						{t("autoApprove")}
 					</span>
 					<span
 						style={{
@@ -198,7 +200,7 @@ const AutoApproveMenu = ({ style }: AutoApproveMenuProps) => {
 							overflow: "hidden",
 							textOverflow: "ellipsis",
 						}}>
-						{enabledActions.length === 0 ? "None" : enabledActionsList}
+						{enabledActions.length === 0 ? t("none") : enabledActionsList}
 					</span>
 					<span
 						className={`codicon codicon-chevron-${isExpanded ? "down" : "right"}`}
@@ -217,8 +219,7 @@ const AutoApproveMenu = ({ style }: AutoApproveMenuProps) => {
 							color: getAsVar(VSC_DESCRIPTION_FOREGROUND),
 							fontSize: "12px",
 						}}>
-						Auto-approve allows Cline to perform the following actions without asking for permission. Please use with
-						caution and only enable if you understand the risks.
+						{t("autoApproveDescription")}
 					</div>
 					{ACTION_METADATA.map((action) => (
 						<div key={action.id} style={{ margin: "6px 0" }}>
@@ -285,7 +286,7 @@ const AutoApproveMenu = ({ style }: AutoApproveMenuProps) => {
 							fontSize: "12px",
 							marginBottom: "10px",
 						}}>
-						Cline will automatically make this many API requests before asking for approval to proceed with the task.
+						{t("autoApproveMaxRequestsDescription")}
 					</div>
 					<div style={{ margin: "6px 0" }}>
 						<VSCodeCheckbox
@@ -294,7 +295,7 @@ const AutoApproveMenu = ({ style }: AutoApproveMenuProps) => {
 								const checked = (e.target as HTMLInputElement).checked
 								updateNotifications(checked)
 							}}>
-							Enable Notifications
+							{t("enableNotifications")}
 						</VSCodeCheckbox>
 						<div
 							style={{
@@ -302,7 +303,7 @@ const AutoApproveMenu = ({ style }: AutoApproveMenuProps) => {
 								color: getAsVar(VSC_DESCRIPTION_FOREGROUND),
 								fontSize: "12px",
 							}}>
-							Receive system notifications when Cline requires approval to proceed or when a task is completed.
+							{t("enableNotificationsDescription")}
 						</div>
 					</div>
 				</div>

--- a/webview-ui/src/components/chat/ChatRow.tsx
+++ b/webview-ui/src/components/chat/ChatRow.tsx
@@ -2,6 +2,7 @@ import { VSCodeBadge, VSCodeProgressRing } from "@vscode/webview-ui-toolkit/reac
 import deepEqual from "fast-deep-equal"
 import React, { memo, useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { useEvent, useSize } from "react-use"
+import { useTranslation } from "react-i18next"
 import styled from "styled-components"
 import {
 	ClineApiReqInfo,
@@ -99,6 +100,7 @@ const ChatRow = memo(
 export default ChatRow
 
 export const ChatRowContent = ({ message, isExpanded, onToggleExpand, lastModifiedMessage, isLast }: ChatRowContentProps) => {
+	const { t } = useTranslation("translation", { keyPrefix: "chatRow" })
 	const { mcpServers } = useExtensionState()
 
 	const [seeNewChangesDisabled, setSeeNewChangesDisabled] = useState(false)
@@ -151,7 +153,7 @@ export const ChatRowContent = ({ message, isExpanded, onToggleExpand, lastModifi
 							color: errorColor,
 							marginBottom: "-1.5px",
 						}}></span>,
-					<span style={{ color: errorColor, fontWeight: "bold" }}>Error</span>,
+					<span style={{ color: errorColor, fontWeight: "bold" }}>{t("error")}</span>,
 				]
 			case "mistake_limit_reached":
 				return [
@@ -161,7 +163,7 @@ export const ChatRowContent = ({ message, isExpanded, onToggleExpand, lastModifi
 							color: errorColor,
 							marginBottom: "-1.5px",
 						}}></span>,
-					<span style={{ color: errorColor, fontWeight: "bold" }}>Cline is having trouble...</span>,
+					<span style={{ color: errorColor, fontWeight: "bold" }}>{t("mistakeLimitReached")}</span>,
 				]
 			case "auto_approval_max_req_reached":
 				return [
@@ -171,7 +173,7 @@ export const ChatRowContent = ({ message, isExpanded, onToggleExpand, lastModifi
 							color: errorColor,
 							marginBottom: "-1.5px",
 						}}></span>,
-					<span style={{ color: errorColor, fontWeight: "bold" }}>Maximum Requests Reached</span>,
+					<span style={{ color: errorColor, fontWeight: "bold" }}>{t("autoApprovalMaxReqReached")}</span>,
 				]
 			case "command":
 				return [
@@ -186,7 +188,7 @@ export const ChatRowContent = ({ message, isExpanded, onToggleExpand, lastModifi
 							}}></span>
 					),
 					<span style={{ color: normalColor, fontWeight: "bold" }}>
-						{message.type === "ask" ? "Cline wants to execute this command:" : "Cline executed this command:"}
+						{message.type === "ask" ? t("command.ask") : t("command.say")}
 					</span>,
 				]
 			case "use_mcp_server":
@@ -205,13 +207,23 @@ export const ChatRowContent = ({ message, isExpanded, onToggleExpand, lastModifi
 					<span style={{ color: normalColor, fontWeight: "bold" }}>
 						{message.type === "ask" ? (
 							<>
-								Cline wants to {mcpServerUse.type === "use_mcp_tool" ? "use a tool" : "access a resource"} on the{" "}
-								<code>{mcpServerUse.serverName}</code> MCP server:
+								{t("useMcpServer.ask", {
+									type:
+										mcpServerUse.type === "use_mcp_tool"
+											? t("useMcpServer.tool")
+											: t("useMcpServer.resource"),
+									serverName: mcpServerUse.serverName,
+								})}
 							</>
 						) : (
 							<>
-								Cline {mcpServerUse.type === "use_mcp_tool" ? "used a tool" : "accessed a resource"} on the{" "}
-								<code>{mcpServerUse.serverName}</code> MCP server:
+								{t("useMcpServer.say", {
+									type:
+										mcpServerUse.type === "use_mcp_tool"
+											? t("useMcpServer.tool")
+											: t("useMcpServer.resource"),
+									serverName: mcpServerUse.serverName,
+								})}
 							</>
 						)}
 					</span>,
@@ -224,7 +236,7 @@ export const ChatRowContent = ({ message, isExpanded, onToggleExpand, lastModifi
 							color: successColor,
 							marginBottom: "-1.5px",
 						}}></span>,
-					<span style={{ color: successColor, fontWeight: "bold" }}>Task Completed</span>,
+					<span style={{ color: successColor, fontWeight: "bold" }}>{t("completionResult")}</span>,
 				]
 			case "api_req_started":
 				const getIconSpan = (iconName: string, color: string) => (
@@ -266,7 +278,7 @@ export const ChatRowContent = ({ message, isExpanded, onToggleExpand, lastModifi
 									color: normalColor,
 									fontWeight: "bold",
 								}}>
-								API Request Cancelled
+								{t("apiReqCancelled")}
 							</span>
 						) : (
 							<span
@@ -274,15 +286,15 @@ export const ChatRowContent = ({ message, isExpanded, onToggleExpand, lastModifi
 									color: errorColor,
 									fontWeight: "bold",
 								}}>
-								API Streaming Failed
+								{t("apiStreamingFailed")}
 							</span>
 						)
 					) : cost != null ? (
-						<span style={{ color: normalColor, fontWeight: "bold" }}>API Request</span>
+						<span style={{ color: normalColor, fontWeight: "bold" }}>{t("apiRequest")}</span>
 					) : apiRequestFailedMessage ? (
-						<span style={{ color: errorColor, fontWeight: "bold" }}>API Request Failed</span>
+						<span style={{ color: errorColor, fontWeight: "bold" }}>{t("apiRequestFailed")}</span>
 					) : (
-						<span style={{ color: normalColor, fontWeight: "bold" }}>API Request...</span>
+						<span style={{ color: normalColor, fontWeight: "bold" }}>{t("apiRequestInProgress")}</span>
 					),
 				]
 			case "followup":
@@ -293,7 +305,7 @@ export const ChatRowContent = ({ message, isExpanded, onToggleExpand, lastModifi
 							color: normalColor,
 							marginBottom: "-1.5px",
 						}}></span>,
-					<span style={{ color: normalColor, fontWeight: "bold" }}>Cline has a question:</span>,
+					<span style={{ color: normalColor, fontWeight: "bold" }}>{t("followup")}</span>,
 				]
 			default:
 				return [null, null]
@@ -307,6 +319,7 @@ export const ChatRowContent = ({ message, isExpanded, onToggleExpand, lastModifi
 		isMcpServerResponding,
 		message.text,
 		message.type,
+		t,
 	])
 
 	const headerStyle: React.CSSProperties = {
@@ -347,7 +360,7 @@ export const ChatRowContent = ({ message, isExpanded, onToggleExpand, lastModifi
 						<div style={headerStyle}>
 							{toolIcon("edit")}
 							<span style={{ fontWeight: "bold" }}>
-								{message.type === "ask" ? "Cline wants to edit this file:" : "Cline is editing this file:"}
+								{message.type === "ask" ? t("tool.editedExistingFile.ask") : t("tool.editedExistingFile.say")}
 							</span>
 						</div>
 						<CodeAccordian
@@ -365,7 +378,7 @@ export const ChatRowContent = ({ message, isExpanded, onToggleExpand, lastModifi
 						<div style={headerStyle}>
 							{toolIcon("new-file")}
 							<span style={{ fontWeight: "bold" }}>
-								{message.type === "ask" ? "Cline wants to create a new file:" : "Cline is creating a new file:"}
+								{message.type === "ask" ? t("tool.createdNewFile.ask") : t("tool.createdNewFile.say")}
 							</span>
 						</div>
 						<CodeAccordian
@@ -383,7 +396,7 @@ export const ChatRowContent = ({ message, isExpanded, onToggleExpand, lastModifi
 						<div style={headerStyle}>
 							{toolIcon("file-code")}
 							<span style={{ fontWeight: "bold" }}>
-								{message.type === "ask" ? "Cline wants to read this file:" : "Cline read this file:"}
+								{message.type === "ask" ? t("tool.readExistingFile.ask") : t("tool.readExistingFile.say")}
 							</span>
 						</div>
 						{/* <CodeAccordian
@@ -773,52 +786,42 @@ export const ChatRowContent = ({ message, isExpanded, onToggleExpand, lastModifi
 											<>
 												<br />
 												<br />
-												It seems like you're having Windows PowerShell issues, please see this{" "}
-												<a
-													href="https://github.com/cline/cline/wiki/TroubleShooting-%E2%80%90-%22PowerShell-is-not-recognized-as-an-internal-or-external-command%22"
-													style={{
-														color: "inherit",
-														textDecoration: "underline",
-													}}>
-													troubleshooting guide
-												</a>
-												.
+												{t("troubleshootingGuide")}
 											</>
 										)}
 									</p>
-
 									{/* {apiProvider === "" && (
-											<div
+										<div
+											style={{
+												display: "flex",
+												alignItems: "center",
+												backgroundColor:
+													"color-mix(in srgb, var(--vscode-errorForeground) 20%, transparent)",
+												color: "var(--vscode-editor-foreground)",
+												padding: "6px 8px",
+												borderRadius: "3px",
+												margin: "10px 0 0 0",
+												fontSize: "12px",
+											}}>
+											<i
+												className="codicon codicon-warning"
 												style={{
-													display: "flex",
-													alignItems: "center",
-													backgroundColor:
-														"color-mix(in srgb, var(--vscode-errorForeground) 20%, transparent)",
-													color: "var(--vscode-editor-foreground)",
-													padding: "6px 8px",
-													borderRadius: "3px",
-													margin: "10px 0 0 0",
-													fontSize: "12px",
-												}}>
-												<i
-													className="codicon codicon-warning"
-													style={{
-														marginRight: 6,
-														fontSize: 16,
-														color: "var(--vscode-errorForeground)",
-													}}></i>
-												<span>
-													Uh-oh, this could be a problem on end. We've been alerted and
-													will resolve this ASAP. You can also{" "}
-													<a
-														href=""
-														style={{ color: "inherit", textDecoration: "underline" }}>
-														contact us
-													</a>
-													.
-												</span>
-											</div>
-										)} */}
+													marginRight: 6,
+													fontSize: 16,
+													color: "var(--vscode-errorForeground)",
+												}}></i>
+											<span>
+												Uh-oh, this could be a problem on end. We've been alerted and
+												will resolve this ASAP. You can also{" "}
+												<a
+													href=""
+													style={{ color: "inherit", textDecoration: "underline" }}>
+													contact us
+												</a>
+												.
+											</span>
+										</div>
+									)} */}
 								</>
 							)}
 
@@ -923,13 +926,10 @@ export const ChatRowContent = ({ message, isExpanded, onToggleExpand, lastModifi
 											fontWeight: 500,
 											color: "#FFA500",
 										}}>
-										Diff Edit Failed
+										{t("diffEditFailed")}
 									</span>
 								</div>
-								<div>
-									This usually happens when the model uses search patterns that don't match anything in the
-									file. Retrying...
-								</div>
+								<div>{t("diffEditFailedMessage")}</div>
 							</div>
 						</>
 					)
@@ -969,7 +969,7 @@ export const ChatRowContent = ({ message, isExpanded, onToggleExpand, lastModifi
 											cursor: seeNewChangesDisabled ? "wait" : "pointer",
 										}}>
 										<i className="codicon codicon-new-file" style={{ marginRight: 6 }} />
-										See new changes
+										{t("seeNewChanges")}
 									</SuccessButton>
 								</div>
 							)}
@@ -1005,23 +1005,10 @@ export const ChatRowContent = ({ message, isExpanded, onToggleExpand, lastModifi
 											fontWeight: 500,
 											color: "#FFA500",
 										}}>
-										Shell Integration Unavailable
+										{t("shellIntegrationUnavailable")}
 									</span>
 								</div>
-								<div>
-									Cline won't be able to view the command's output. Please update VSCode (
-									<code>CMD/CTRL + Shift + P</code> → "Update") and make sure you're using a supported shell:
-									zsh, bash, fish, or PowerShell (<code>CMD/CTRL + Shift + P</code> → "Terminal: Select Default
-									Profile").{" "}
-									<a
-										href="https://github.com/cline/cline/wiki/Troubleshooting-%E2%80%90-Shell-Integration-Unavailable"
-										style={{
-											color: "inherit",
-											textDecoration: "underline",
-										}}>
-										Still having trouble?
-									</a>
-								</div>
+								<div>{t("shellIntegrationUnavailableMessage")}</div>
 							</div>
 						</>
 					)
@@ -1036,14 +1023,15 @@ export const ChatRowContent = ({ message, isExpanded, onToggleExpand, lastModifi
 										fontSize: "12px",
 										textTransform: "uppercase",
 									}}>
-									Response
+									<a
+										href="https://github.com/cline/cline/wiki/Troubleshooting-%E2%80%90-Shell-Integration-Unavailable"
+										style={{
+											color: "inherit",
+											textDecoration: "underline",
+										}}>
+										{t("response")}
+									</a>
 								</div>
-								<CodeAccordian
-									code={message.text}
-									language="json"
-									isExpanded={true}
-									onToggleExpand={onToggleExpand}
-								/>
 							</div>
 						</>
 					)
@@ -1136,7 +1124,7 @@ export const ChatRowContent = ({ message, isExpanded, onToggleExpand, lastModifi
 														cursor: seeNewChangesDisabled ? "wait" : "pointer",
 													}}
 												/>
-												See new changes
+												{t("seeNewChanges")}
 											</SuccessButton>
 										</div>
 									)}

--- a/webview-ui/src/components/chat/ChatRow.tsx
+++ b/webview-ui/src/components/chat/ChatRow.tsx
@@ -3,6 +3,7 @@ import deepEqual from "fast-deep-equal"
 import React, { memo, useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { useEvent, useSize } from "react-use"
 import { useTranslation } from "react-i18next"
+import { Trans } from "react-i18next"
 import styled from "styled-components"
 import {
 	ClineApiReqInfo,
@@ -786,7 +787,21 @@ export const ChatRowContent = ({ message, isExpanded, onToggleExpand, lastModifi
 											<>
 												<br />
 												<br />
-												{t("troubleshootingGuide")}
+												<Trans
+													i18nKey="chatRow.troubleshootingGuide"
+													components={{
+														Link: (
+															<a
+																href="https://github.com/cline/cline/wiki/TroubleShooting-%E2%80%90-%22PowerShell-is-not-recognized-as-an-internal-or-external-command%22"
+																style={{
+																	color: "inherit",
+																	textDecoration: "underline",
+																}}>
+																PowerShell
+															</a>
+														),
+													}}
+												/>
 											</>
 										)}
 									</p>
@@ -1032,6 +1047,12 @@ export const ChatRowContent = ({ message, isExpanded, onToggleExpand, lastModifi
 										{t("response")}
 									</a>
 								</div>
+								<CodeAccordian
+									code={message.text}
+									language="json"
+									isExpanded={true}
+									onToggleExpand={onToggleExpand}
+								/>
 							</div>
 						</>
 					)

--- a/webview-ui/src/components/chat/ChatTextArea.tsx
+++ b/webview-ui/src/components/chat/ChatTextArea.tsx
@@ -4,7 +4,7 @@ import DynamicTextArea from "react-textarea-autosize"
 import { useClickAway, useWindowSize } from "react-use"
 import styled from "styled-components"
 import { mentionRegex, mentionRegexGlobal } from "../../../../src/shared/context-mentions"
-import { ExtensionMessage } from "../../../../src/shared/ExtensionMessage"
+import { useTranslation } from "react-i18next"
 import { useExtensionState } from "../../context/ExtensionStateContext"
 import {
 	ContextMenuOptionType,
@@ -211,6 +211,7 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 		},
 		ref,
 	) => {
+		const { t } = useTranslation("translation", { keyPrefix: "chatTextArea" })
 		const { filePaths, chatSettings, apiConfiguration, openRouterModels } = useExtensionState()
 		const [isTextAreaFocused, setIsTextAreaFocused] = useState(false)
 		const [thumbnailsHeight, setThumbnailsHeight] = useState(0)
@@ -1063,8 +1064,8 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 
 					<SwitchContainer data-testid="mode-switch" disabled={textAreaDisabled} onClick={onModeToggle}>
 						<Slider isAct={chatSettings.mode === "act"} isPlan={chatSettings.mode === "plan"} />
-						<SwitchOption isActive={chatSettings.mode === "plan"}>Plan</SwitchOption>
-						<SwitchOption isActive={chatSettings.mode === "act"}>Act</SwitchOption>
+						<SwitchOption isActive={chatSettings.mode === "plan"}>{t("plan")}</SwitchOption>
+						<SwitchOption isActive={chatSettings.mode === "act"}>{t("act")}</SwitchOption>
 					</SwitchContainer>
 				</ControlsContainer>
 			</div>

--- a/webview-ui/src/components/chat/ChatView.tsx
+++ b/webview-ui/src/components/chat/ChatView.tsx
@@ -3,6 +3,8 @@ import debounce from "debounce"
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { useDeepCompareEffect, useEvent, useMount } from "react-use"
 import { Virtuoso, type VirtuosoHandle } from "react-virtuoso"
+import { useTranslation } from "react-i18next"
+import { Trans } from "react-i18next"
 import styled from "styled-components"
 import {
 	ClineAsk,
@@ -36,6 +38,7 @@ interface ChatViewProps {
 export const MAX_IMAGES_PER_MESSAGE = 20 // Anthropic limits to 20 images
 
 const ChatView = ({ isHidden, showAnnouncement, hideAnnouncement, showHistoryView }: ChatViewProps) => {
+	const { t } = useTranslation("translation", { keyPrefix: "chatView" })
 	const { version, clineMessages: messages, taskHistory, apiConfiguration } = useExtensionState()
 
 	//const task = messages.length > 0 ? (messages[0].say === "task" ? messages[0] : undefined) : undefined) : undefined
@@ -666,9 +669,8 @@ const ChatView = ({ isHidden, showAnnouncement, hideAnnouncement, showHistoryVie
 	useEvent("wheel", handleWheel, window, { passive: true }) // passive improves scrolling performance
 
 	const placeholderText = useMemo(() => {
-		const text = task ? "Type a message..." : "Type your task here..."
-		return text
-	}, [task])
+		return task ? t("typeMessage") : t("typeTask")
+	}, [task, t])
 
 	const itemContent = useCallback(
 		(index: number, messageOrGroup: ClineMessage | ClineMessage[]) => {
@@ -743,18 +745,19 @@ const ChatView = ({ isHidden, showAnnouncement, hideAnnouncement, showHistoryVie
 					}}>
 					{showAnnouncement && <Announcement version={version} hideAnnouncement={hideAnnouncement} />}
 					<div style={{ padding: "0 20px", flexShrink: 0 }}>
-						<h2>What can I do for you?</h2>
+						<h2>{t("whatCanIDoForYou")}</h2>
 						<p>
-							Thanks to{" "}
-							<VSCodeLink
-								href="https://www-cdn.anthropic.com/fed9cc193a14b84131812372d8d5857f8f304c52/Model_Card_Claude_3_Addendum.pdf"
-								style={{ display: "inline" }}>
-								Claude 3.5 Sonnet's agentic coding capabilities,
-							</VSCodeLink>{" "}
-							I can handle complex software development tasks step-by-step. With tools that let me create & edit
-							files, explore complex projects, use the browser, and execute terminal commands (after you grant
-							permission), I can assist you in ways that go beyond code completion or tech support. I can even use
-							MCP to create new tools and extend my own capabilities.
+							<Trans
+								i18nKey="chatView.thanksTo"
+								components={{
+									ClaudeLink: (
+										<VSCodeLink
+											href="https://www-cdn.anthropic.com/fed9cc193a14b84131812372d8d5857f8f304c52/Model_Card_Claude_3_Addendum.pdf"
+											style={{ display: "inline" }}
+										/>
+									),
+								}}
+							/>
 						</p>
 					</div>
 					{taskHistory.length > 0 && <HistoryPreview showHistoryView={showHistoryView} />}

--- a/webview-ui/src/components/history/HistoryPreview.tsx
+++ b/webview-ui/src/components/history/HistoryPreview.tsx
@@ -3,12 +3,14 @@ import { useExtensionState } from "../../context/ExtensionStateContext"
 import { vscode } from "../../utils/vscode"
 import { memo } from "react"
 import { formatLargeNumber } from "../../utils/format"
+import { useTranslation } from "react-i18next"
 
 type HistoryPreviewProps = {
 	showHistoryView: () => void
 }
 
 const HistoryPreview = ({ showHistoryView }: HistoryPreviewProps) => {
+	const { t } = useTranslation("translation", { keyPrefix: "historyPreview" })
 	const { taskHistory } = useExtensionState()
 	const handleHistorySelect = (id: string) => {
 		vscode.postMessage({ type: "showTaskWithId", text: id })
@@ -69,7 +71,7 @@ const HistoryPreview = ({ showHistoryView }: HistoryPreviewProps) => {
 						fontSize: "0.85em",
 						textTransform: "uppercase",
 					}}>
-					Recent Tasks
+					{t("recentTasks")}
 				</span>
 			</div>
 
@@ -112,13 +114,14 @@ const HistoryPreview = ({ showHistoryView }: HistoryPreviewProps) => {
 										color: "var(--vscode-descriptionForeground)",
 									}}>
 									<span>
-										Tokens: ↑{formatLargeNumber(item.tokensIn || 0)} ↓{formatLargeNumber(item.tokensOut || 0)}
+										{t("tokens")}: ↑{formatLargeNumber(item.tokensIn || 0)} ↓
+										{formatLargeNumber(item.tokensOut || 0)}
 									</span>
 									{!!item.cacheWrites && (
 										<>
 											{" • "}
 											<span>
-												Cache: +{formatLargeNumber(item.cacheWrites || 0)} →{" "}
+												{t("cache")}: +{formatLargeNumber(item.cacheWrites || 0)} →{" "}
 												{formatLargeNumber(item.cacheReads || 0)}
 											</span>
 										</>
@@ -126,7 +129,9 @@ const HistoryPreview = ({ showHistoryView }: HistoryPreviewProps) => {
 									{!!item.totalCost && (
 										<>
 											{" • "}
-											<span>API Cost: ${item.totalCost?.toFixed(4)}</span>
+											<span>
+												{t("apiCost")}: ${item.totalCost?.toFixed(4)}
+											</span>
 										</>
 									)}
 								</div>
@@ -150,7 +155,7 @@ const HistoryPreview = ({ showHistoryView }: HistoryPreviewProps) => {
 								fontSize: "var(--vscode-font-size)",
 								color: "var(--vscode-descriptionForeground)",
 							}}>
-							View all history
+							{t("viewAllHistory")}
 						</div>
 					</VSCodeButton>
 				</div>

--- a/webview-ui/src/components/history/HistoryView.tsx
+++ b/webview-ui/src/components/history/HistoryView.tsx
@@ -6,6 +6,7 @@ import { memo, useMemo, useState, useEffect } from "react"
 import Fuse, { FuseResult } from "fuse.js"
 import { formatLargeNumber } from "../../utils/format"
 import { formatSize } from "../../utils/size"
+import { useTranslation } from "react-i18next"
 
 type HistoryViewProps = {
 	onDone: () => void
@@ -14,6 +15,7 @@ type HistoryViewProps = {
 type SortOption = "newest" | "oldest" | "mostExpensive" | "mostTokens" | "mostRelevant"
 
 const HistoryView = ({ onDone }: HistoryViewProps) => {
+	const { t } = useTranslation("translation", { keyPrefix: "historyView" })
 	const { taskHistory } = useExtensionState()
 	const [searchQuery, setSearchQuery] = useState("")
 	const [sortOption, setSortOption] = useState<SortOption>("newest")
@@ -142,9 +144,9 @@ const HistoryView = ({ onDone }: HistoryViewProps) => {
 							color: "var(--vscode-foreground)",
 							margin: 0,
 						}}>
-						History
+						{t("history")}
 					</h3>
-					<VSCodeButton onClick={onDone}>Done</VSCodeButton>
+					<VSCodeButton onClick={onDone}>{t("done")}</VSCodeButton>
 				</div>
 				<div style={{ padding: "5px 17px 6px 17px" }}>
 					<div
@@ -155,7 +157,7 @@ const HistoryView = ({ onDone }: HistoryViewProps) => {
 						}}>
 						<VSCodeTextField
 							style={{ width: "100%" }}
-							placeholder="Fuzzy search history..."
+							placeholder={t("fuzzySearchHistory")}
 							value={searchQuery}
 							onInput={(e) => {
 								const newValue = (e.target as HTMLInputElement)?.value
@@ -192,12 +194,12 @@ const HistoryView = ({ onDone }: HistoryViewProps) => {
 							style={{ display: "flex", flexWrap: "wrap" }}
 							value={sortOption}
 							onChange={(e) => setSortOption((e.target as HTMLInputElement).value as SortOption)}>
-							<VSCodeRadio value="newest">Newest</VSCodeRadio>
-							<VSCodeRadio value="oldest">Oldest</VSCodeRadio>
-							<VSCodeRadio value="mostExpensive">Most Expensive</VSCodeRadio>
-							<VSCodeRadio value="mostTokens">Most Tokens</VSCodeRadio>
+							<VSCodeRadio value="newest">{t("newest")}</VSCodeRadio>
+							<VSCodeRadio value="oldest">{t("oldest")}</VSCodeRadio>
+							<VSCodeRadio value="mostExpensive">{t("mostExpensive")}</VSCodeRadio>
+							<VSCodeRadio value="mostTokens">{t("mostTokens")}</VSCodeRadio>
 							<VSCodeRadio value="mostRelevant" disabled={!searchQuery} style={{ opacity: searchQuery ? 1 : 0.5 }}>
-								Most Relevant
+								{t("mostRelevant")}
 							</VSCodeRadio>
 						</VSCodeRadioGroup>
 					</div>
@@ -319,7 +321,7 @@ const HistoryView = ({ onDone }: HistoryViewProps) => {
 														fontWeight: 500,
 														color: "var(--vscode-descriptionForeground)",
 													}}>
-													Tokens:
+													{t("tokens")}
 												</span>
 												<span
 													style={{
@@ -372,7 +374,7 @@ const HistoryView = ({ onDone }: HistoryViewProps) => {
 														fontWeight: 500,
 														color: "var(--vscode-descriptionForeground)",
 													}}>
-													Cache:
+													{t("cache")}
 												</span>
 												<span
 													style={{
@@ -429,7 +431,7 @@ const HistoryView = ({ onDone }: HistoryViewProps) => {
 															fontWeight: 500,
 															color: "var(--vscode-descriptionForeground)",
 														}}>
-														API Cost:
+														{t("apiCost")}
 													</span>
 													<span
 														style={{
@@ -452,17 +454,20 @@ const HistoryView = ({ onDone }: HistoryViewProps) => {
 	)
 }
 
-const ExportButton = ({ itemId }: { itemId: string }) => (
-	<VSCodeButton
-		className="export-button"
-		appearance="icon"
-		onClick={(e) => {
-			e.stopPropagation()
-			vscode.postMessage({ type: "exportTaskWithId", text: itemId })
-		}}>
-		<div style={{ fontSize: "11px", fontWeight: 500, opacity: 1 }}>EXPORT</div>
-	</VSCodeButton>
-)
+const ExportButton = ({ itemId }: { itemId: string }) => {
+	const { t } = useTranslation("translation", { keyPrefix: "historyView" })
+	return (
+		<VSCodeButton
+			className="export-button"
+			appearance="icon"
+			onClick={(e) => {
+				e.stopPropagation()
+				vscode.postMessage({ type: "exportTaskWithId", text: itemId })
+			}}>
+			<div style={{ fontSize: "11px", fontWeight: 500, opacity: 1 }}>{t("export")}</div>
+		</VSCodeButton>
+	)
+}
 
 // https://gist.github.com/evenfrost/1ba123656ded32fb7a0cd4651efd4db0
 export const highlight = (fuseSearchResult: FuseResult<any>[], highlightClassName: string = "history-item-highlight") => {

--- a/webview-ui/src/components/settings/ApiOptions.tsx
+++ b/webview-ui/src/components/settings/ApiOptions.tsx
@@ -75,7 +75,7 @@ declare module "vscode" {
 }
 
 const ApiOptions = ({ showModelOptions, apiErrorMessage, modelIdErrorMessage, isPopup }: ApiOptionsProps) => {
-	const { t, ready } = useTranslation("translation", { keyPrefix: "apiOptions", useSuspense: false })
+	const { t } = useTranslation("translation", { keyPrefix: "apiOptions" })
 	const { apiConfiguration, setApiConfiguration, uriScheme } = useExtensionState()
 	const [ollamaModels, setOllamaModels] = useState<string[]>([])
 	const [lmStudioModels, setLmStudioModels] = useState<string[]>([])
@@ -831,7 +831,7 @@ export const ModelInfoView = ({
 	isPopup?: boolean
 }) => {
 	const isGemini = Object.keys(geminiModels).includes(selectedModelId)
-	const { t, ready } = useTranslation("translation", { keyPrefix: "apiOptions", useSuspense: false })
+	const { t } = useTranslation("translation", { keyPrefix: "apiOptions" })
 
 	const infoItems = [
 		modelInfo.description && (

--- a/webview-ui/src/components/settings/LanguageOptions.tsx
+++ b/webview-ui/src/components/settings/LanguageOptions.tsx
@@ -22,6 +22,7 @@ const LanguageOptions = () => {
 					style={{ width: "100%" }}
 					onChange={changeLanguage}>
 					<VSCodeOption value="en">English</VSCodeOption>
+					<VSCodeOption value="es">Español</VSCodeOption>
 					<VSCodeOption value="de">Deutsch</VSCodeOption>
 					<VSCodeOption value="zh-CN">中文(简体)</VSCodeOption>
 					<VSCodeOption value="zh-TW">中文(繁體)</VSCodeOption>

--- a/webview-ui/src/components/welcome/WelcomeView.tsx
+++ b/webview-ui/src/components/welcome/WelcomeView.tsx
@@ -4,8 +4,12 @@ import { useExtensionState } from "../../context/ExtensionStateContext"
 import { validateApiConfiguration } from "../../utils/validate"
 import { vscode } from "../../utils/vscode"
 import ApiOptions from "../settings/ApiOptions"
+import { useTranslation } from "react-i18next"
+import { Trans } from "react-i18next"
 
 const WelcomeView = () => {
+	const { t } = useTranslation("translation", { keyPrefix: "welcomeView" })
+
 	const { apiConfiguration } = useExtensionState()
 
 	const [apiErrorMessage, setApiErrorMessage] = useState<string | undefined>(undefined)
@@ -30,25 +34,27 @@ const WelcomeView = () => {
 				bottom: 0,
 				padding: "0 20px",
 			}}>
-			<h2>Hi, I'm Cline</h2>
+			<h2>{t("greeting")}</h2>
 			<p>
-				I can do all kinds of tasks thanks to the latest breakthroughs in{" "}
-				<VSCodeLink
-					href="https://www-cdn.anthropic.com/fed9cc193a14b84131812372d8d5857f8f304c52/Model_Card_Claude_3_Addendum.pdf"
-					style={{ display: "inline" }}>
-					Claude 3.5 Sonnet's agentic coding capabilities
-				</VSCodeLink>{" "}
-				and access to tools that let me create & edit files, explore complex projects, use the browser, and execute
-				terminal commands (with your permission, of course). I can even use MCP to create new tools and extend my own
-				capabilities.
+				<Trans
+					i18nKey="welcomeView.description"
+					components={{
+						ClaudeLink: (
+							<VSCodeLink
+								href="https://www-cdn.anthropic.com/fed9cc193a14b84131812372d8d5857f8f304c52/Model_Card_Claude_3_Addendum.pdf"
+								style={{ display: "inline" }}
+							/>
+						),
+					}}
+				/>
 			</p>
 
-			<b>To get started, this extension needs an API provider for Claude 3.5 Sonnet.</b>
+			<b>{t("getStarted")}</b>
 
 			<div style={{ marginTop: "10px" }}>
 				<ApiOptions showModelOptions={false} />
 				<VSCodeButton onClick={handleSubmit} disabled={disableLetsGoButton} style={{ marginTop: "3px" }}>
-					Let's go!
+					{t("letsGo")}
 				</VSCodeButton>
 			</div>
 		</div>

--- a/webview-ui/src/i18n.ts
+++ b/webview-ui/src/i18n.ts
@@ -2,6 +2,7 @@ import i18n from "i18next"
 import { initReactI18next } from "react-i18next"
 
 import translationEN from "./locales/en/translation.json"
+//import translationES from "./locales/es/translation.json"
 //import translationDE from "./locales/de/translation.json"
 //import translationZHCN from "./locales/zh-cn/translation.json"
 //import translationZHTW from "./locales/zh-tw/translation.json"
@@ -19,6 +20,7 @@ i18n.use(initReactI18next) // passes i18n down to react-i18next
 	})
 
 i18n.addResourceBundle("en", "translation", translationEN)
+//i18n.addResourceBundle("es", "translation", translationES)
 //i18n.addResourceBundle("de", "translation", translationDE)
 //i18n.addResourceBundle("zh-CN", "translation", translationZHCN)
 //i18n.addResourceBundle("zh-TW", "translation", translationZHTW)

--- a/webview-ui/src/locales/de/translation.json
+++ b/webview-ui/src/locales/de/translation.json
@@ -68,5 +68,108 @@
 		"geminiInfo": "* Kostenlos bis zu {{selectedModelId}} Anfragen pro Minute. Danach hängt die Abrechnung von der Prompt-Größe ab.",
 		"pricingDetails": "Weitere Informationen finden Sie in den Preisdaten.",
 		"languageModel": "Sprachmodell"
+	},
+	"welcomeView": {
+		"greeting": "Hallo! Ich bin Cline, dein KI-Assistent.",
+		"description": "Ich kann alle möglichen Aufgaben dank der neuesten Durchbrüche in <ClaudeLink>Claude 3.5 Sonnets agentischen Codierungsfähigkeiten</ClaudeLink> und dem Zugriff auf Werkzeuge, die es mir ermöglichen, Dateien zu erstellen und zu bearbeiten, komplexe Projekte zu erkunden, den Browser zu verwenden und Terminalbefehle auszuführen (natürlich mit deiner Erlaubnis). Ich kann sogar MCP verwenden, um neue Werkzeuge zu erstellen und meine eigenen Fähigkeiten zu erweitern.",
+		"getStarted": "Um loszulegen, benötigt diese Erweiterung einen API-Anbieter für Claude 3.5 Sonnet.",
+		"letsGo": "Los geht's!"
+	},
+	"chatView": {
+		"typeMessage": "Nachricht eingeben...",
+		"typeTask": "Aufgabe eingeben...",
+		"whatCanIDoForYou": "Was kann ich für dich tun?",
+		"thanksTo": "Dank <ClaudeLink>Claude 3.5 Sonnets agentischen Codierungsfähigkeiten</ClaudeLink> kann ich komplexe Softwareentwicklungsaufgaben Schritt für Schritt bewältigen. Mit Werkzeugen, die es mir ermöglichen, Dateien zu erstellen und zu bearbeiten, komplexe Projekte zu erkunden, den Browser zu verwenden und Terminalbefehle auszuführen (nachdem du die Erlaubnis erteilt hast), kann ich dir auf eine Weise helfen, die über die Codevervollständigung oder den technischen Support hinausgeht. Ich kann sogar MCP verwenden, um neue Werkzeuge zu erstellen und meine eigenen Fähigkeiten zu erweitern."
+	},
+	"chatTextArea": {
+		"plan": "Planen",
+		"act": "Handeln"
+	},
+	"chatRow": {
+		"error": "Fehler",
+		"mistakeLimitReached": "Fehlergrenze erreicht",
+		"autoApprovalMaxReqReached": "Maximale Anzahl automatischer Genehmigungen erreicht",
+		"command": {
+			"ask": "Cline möchte diesen Befehl ausführen:",
+			"say": "Cline hat diesen Befehl ausgeführt:"
+		},
+		"useMcpServer": {
+			"ask": "Cline möchte dieses {type} auf {serverName} verwenden:",
+			"say": "Cline hat dieses {type} auf {serverName} verwendet:",
+			"tool": "Werkzeug",
+			"resource": "Ressource"
+		},
+		"completionResult": "Abschlussergebnis",
+		"apiReqCancelled": "API-Anfrage abgebrochen",
+		"apiStreamingFailed": "API-Streaming fehlgeschlagen",
+		"apiRequest": "API-Anfrage",
+		"apiRequestFailed": "API-Anfrage fehlgeschlagen",
+		"apiRequestInProgress": "API-Anfrage in Bearbeitung",
+		"followup": "Nachverfolgung",
+		"tool": {
+			"editedExistingFile": {
+				"ask": "Cline möchte diese Datei bearbeiten:",
+				"say": "Cline bearbeitet diese Datei:"
+			},
+			"createdNewFile": {
+				"ask": "Cline möchte diese Datei erstellen:",
+				"say": "Cline hat diese Datei erstellt:"
+			},
+			"readExistingFile": {
+				"ask": "Cline möchte diese Datei lesen:",
+				"say": "Cline hat diese Datei gelesen:"
+			}
+		},
+		"apiReqStarted": "API-Anfrage gestartet",
+		"userFeedback": "Benutzer-Feedback",
+		"userFeedbackDiff": "Benutzer-Feedback-Diff",
+		"diffEditFailed": "Diff-Bearbeitung fehlgeschlagen",
+		"shellIntegrationUnavailable": "Shell-Integration nicht verfügbar",
+		"mcpServerResponse": "MCP-Server-Antwort",
+		"planModeResponse": "Planmodus-Antwort",
+		"seeNewChanges": "Neue Änderungen anzeigen",
+		"commandRequiresApproval": "Das Modell hat bestimmt, dass dieser Befehl eine ausdrückliche Genehmigung erfordert.",
+		"troubleshootingGuide": "Fehlerbehebungshandbuch",
+		"clineWantsToViewTopLevelFiles": "Cline möchte die obersten Dateien in diesem Verzeichnis anzeigen:",
+		"clineViewedTopLevelFiles": "Cline hat die obersten Dateien in diesem Verzeichnis angezeigt:",
+		"clineWantsToRecursivelyViewFiles": "Cline möchte alle Dateien in diesem Verzeichnis rekursiv anzeigen:",
+		"clineRecursivelyViewedFiles": "Cline hat alle Dateien in diesem Verzeichnis rekursiv angezeigt:",
+		"clineWantsToViewSourceCodeDefinitions": "Cline möchte die in diesem Verzeichnis verwendeten Quellcode-Definitionsnamen anzeigen:",
+		"clineViewedSourceCodeDefinitions": "Cline hat die in diesem Verzeichnis verwendeten Quellcode-Definitionsnamen angezeigt:",
+		"clineWantsToSearchDirectory": "Cline möchte dieses Verzeichnis nach {{regex}} durchsuchen:",
+		"clineSearchedDirectory": "Cline hat dieses Verzeichnis nach {{regex}} durchsucht:",
+		"diffEditFailedMessage": "Dies passiert normalerweise, wenn das Modell Suchmuster verwendet, die nichts in der Datei finden. Erneut versuchen...",
+		"shellIntegrationUnavailableMessage": "Cline kann die Ausgabe des Befehls nicht anzeigen. Bitte aktualisiere VSCode (CMD/CTRL + Shift + P → \"Update\") und stelle sicher, dass du eine unterstützte Shell verwendest: zsh, bash, fish oder PowerShell (CMD/CTRL + Shift + P → \"Terminal: Standardprofil auswählen\"). Immer noch Probleme?",
+		"response": "Antwort",
+		"stillHavingTrouble": "Immer noch Probleme?"
+	},
+	"autoApproveMenu": {
+		"none": "Keine",
+		"autoApprove": "Automatische Genehmigung:",
+		"autoApproveDescription": "Die automatische Genehmigung ermöglicht es Cline, die folgenden Aktionen ohne Erlaubnis auszuführen. Bitte mit Vorsicht verwenden und nur aktivieren, wenn Sie die Risiken verstehen.",
+		"autoApproveMaxRequestsDescription": "Cline wird automatisch so viele API-Anfragen stellen, bevor eine Genehmigung zur Fortsetzung der Aufgabe erforderlich ist.",
+		"enableNotifications": "Benachrichtigungen aktivieren",
+		"enableNotificationsDescription": "Erhalte Systembenachrichtigungen, wenn Cline eine Genehmigung zur Fortsetzung benötigt oder wenn eine Aufgabe abgeschlossen ist."
+	},
+	"historyPreview": {
+		"recentTasks": "Kürzliche Aufgaben",
+		"tokens": "Tokens",
+		"cache": "Cache",
+		"apiCost": "API-Kosten",
+		"viewAllHistory": "Alle Verlauf anzeigen"
+	},
+	"historyView": {
+		"history": "Verlauf",
+		"done": "Fertig",
+		"fuzzySearchHistory": "Verlauf unscharf durchsuchen...",
+		"newest": "Neueste",
+		"oldest": "Älteste",
+		"mostExpensive": "Teuerste",
+		"mostTokens": "Meiste Tokens",
+		"mostRelevant": "Relevanteste",
+		"tokens": "Tokens:",
+		"cache": "Cache:",
+		"apiCost": "API-Kosten:",
+		"export": "EXPORTIEREN"
 	}
 }

--- a/webview-ui/src/locales/de/translation.json
+++ b/webview-ui/src/locales/de/translation.json
@@ -129,7 +129,7 @@
 		"planModeResponse": "Planmodus-Antwort",
 		"seeNewChanges": "Neue Änderungen anzeigen",
 		"commandRequiresApproval": "Das Modell hat bestimmt, dass dieser Befehl eine ausdrückliche Genehmigung erfordert.",
-		"troubleshootingGuide": "Fehlerbehebungshandbuch",
+		"troubleshootingGuide": "Es scheint, dass Sie Probleme mit Windows PowerShell haben. Bitte sehen Sie sich diesen <Link>Fehlerbehebungsleitfaden</Link> an.",
 		"clineWantsToViewTopLevelFiles": "Cline möchte die obersten Dateien in diesem Verzeichnis anzeigen:",
 		"clineViewedTopLevelFiles": "Cline hat die obersten Dateien in diesem Verzeichnis angezeigt:",
 		"clineWantsToRecursivelyViewFiles": "Cline möchte alle Dateien in diesem Verzeichnis rekursiv anzeigen:",

--- a/webview-ui/src/locales/en/translation.json
+++ b/webview-ui/src/locales/en/translation.json
@@ -87,8 +87,8 @@
 	},
 	"chatRow": {
 		"error": "Error",
-		"mistakeLimitReached": "Mistake limit reached",
-		"autoApprovalMaxReqReached": "Auto approval max request reached",
+		"mistakeLimitReached": "Cline is having trouble...",
+		"autoApprovalMaxReqReached": "Maximum Requests Reached",
 		"command": {
 			"ask": "Cline wants to execute this command:",
 			"say": "Cline executed this command:"
@@ -99,13 +99,13 @@
 			"tool": "tool",
 			"resource": "resource"
 		},
-		"completionResult": "Completion result",
-		"apiReqCancelled": "API request cancelled",
-		"apiStreamingFailed": "API streaming failed",
-		"apiRequest": "API request",
-		"apiRequestFailed": "API request failed",
-		"apiRequestInProgress": "API request in progress",
-		"followup": "Follow-up",
+		"completionResult": "Task Completed",
+		"apiReqCancelled": "API Request Cancelled",
+		"apiStreamingFailed": "API Streaming Failed",
+		"apiRequest": "API Request",
+		"apiRequestFailed": "API Request Failed",
+		"apiRequestInProgress": "API Request...",
+		"followup": "Cline has a question:",
 		"tool": {
 			"editedExistingFile": {
 				"ask": "Cline wants to edit this file:",
@@ -129,7 +129,7 @@
 		"planModeResponse": "Plan Mode Response",
 		"seeNewChanges": "See new changes",
 		"commandRequiresApproval": "The model has determined this command requires explicit approval.",
-		"troubleshootingGuide": "troubleshooting guide",
+		"troubleshootingGuide": "It seems like you're having Windows PowerShell issues, please see this <Link>troubleshooting guide</Link>",
 		"clineWantsToViewTopLevelFiles": "Cline wants to view the top level files in this directory:",
 		"clineViewedTopLevelFiles": "Cline viewed the top level files in this directory:",
 		"clineWantsToRecursivelyViewFiles": "Cline wants to recursively view all files in this directory:",

--- a/webview-ui/src/locales/en/translation.json
+++ b/webview-ui/src/locales/en/translation.json
@@ -68,5 +68,108 @@
 		"geminiInfo": "* Free up to {{selectedModelId}} requests per minute. After that, billing depends on prompt size.",
 		"pricingDetails": "For more info, see pricing details.",
 		"languageModel": "Language Model"
+	},
+	"welcomeView": {
+		"greeting": "Hello! I'm Cline, your AI assistant.",
+		"description": "I can do all kinds of tasks thanks to the latest breakthroughs in <ClaudeLink>Claude 3.5 Sonnet's agentic coding capabilities</ClaudeLink> and access to tools that let me create & edit files, explore complex projects, use the browser, and execute terminal commands (with your permission, of course). I can even use MCP to create new tools and extend my own capabilities.",
+		"getStarted": "To get started, this extension needs an API provider for Claude 3.5 Sonnet.",
+		"letsGo": "Let's go!"
+	},
+	"chatView": {
+		"typeMessage": "Type a message...",
+		"typeTask": "Type a task...",
+		"whatCanIDoForYou": "What can I do for you?",
+		"thanksTo": "Thanks to <ClaudeLink>Claude 3.5 Sonnet's agentic coding capabilities,</ClaudeLink> I can handle complex software development tasks step-by-step. With tools that let me create & edit files, explore complex projects, use the browser, and execute terminal commands (after you grant permission), I can assist you in ways that go beyond code completion or tech support. I can even use MCP to create new tools and extend my own capabilities."
+	},
+	"chatTextArea": {
+		"plan": "Plan",
+		"act": "Act"
+	},
+	"chatRow": {
+		"error": "Error",
+		"mistakeLimitReached": "Mistake limit reached",
+		"autoApprovalMaxReqReached": "Auto approval max request reached",
+		"command": {
+			"ask": "Cline wants to execute this command:",
+			"say": "Cline executed this command:"
+		},
+		"useMcpServer": {
+			"ask": "Cline wants to use this {type} on {serverName}:",
+			"say": "Cline used this {type} on {serverName}:",
+			"tool": "tool",
+			"resource": "resource"
+		},
+		"completionResult": "Completion result",
+		"apiReqCancelled": "API request cancelled",
+		"apiStreamingFailed": "API streaming failed",
+		"apiRequest": "API request",
+		"apiRequestFailed": "API request failed",
+		"apiRequestInProgress": "API request in progress",
+		"followup": "Follow-up",
+		"tool": {
+			"editedExistingFile": {
+				"ask": "Cline wants to edit this file:",
+				"say": "Cline is editing this file:"
+			},
+			"createdNewFile": {
+				"ask": "Cline wants to create this file:",
+				"say": "Cline created this file:"
+			},
+			"readExistingFile": {
+				"ask": "Cline wants to read this file:",
+				"say": "Cline read this file:"
+			}
+		},
+		"apiReqStarted": "API Request Started",
+		"userFeedback": "User Feedback",
+		"userFeedbackDiff": "User Feedback Diff",
+		"diffEditFailed": "Diff Edit Failed",
+		"shellIntegrationUnavailable": "Shell Integration Unavailable",
+		"mcpServerResponse": "MCP Server Response",
+		"planModeResponse": "Plan Mode Response",
+		"seeNewChanges": "See new changes",
+		"commandRequiresApproval": "The model has determined this command requires explicit approval.",
+		"troubleshootingGuide": "troubleshooting guide",
+		"clineWantsToViewTopLevelFiles": "Cline wants to view the top level files in this directory:",
+		"clineViewedTopLevelFiles": "Cline viewed the top level files in this directory:",
+		"clineWantsToRecursivelyViewFiles": "Cline wants to recursively view all files in this directory:",
+		"clineRecursivelyViewedFiles": "Cline recursively viewed all files in this directory:",
+		"clineWantsToViewSourceCodeDefinitions": "Cline wants to view source code definition names used in this directory:",
+		"clineViewedSourceCodeDefinitions": "Cline viewed source code definition names used in this directory:",
+		"clineWantsToSearchDirectory": "Cline wants to search this directory for {{regex}}:",
+		"clineSearchedDirectory": "Cline searched this directory for {{regex}}:",
+		"diffEditFailedMessage": "This usually happens when the model uses search patterns that don't match anything in the file. Retrying...",
+		"shellIntegrationUnavailableMessage": "Cline won't be able to view the command's output. Please update VSCode (CMD/CTRL + Shift + P → \"Update\") and make sure you're using a supported shell: zsh, bash, fish, or PowerShell (CMD/CTRL + Shift + P → \"Terminal: Select Default Profile\"). Still having trouble?",
+		"response": "Response",
+		"stillHavingTrouble": "Still having trouble?"
+	},
+	"autoApproveMenu": {
+		"none": "None",
+		"autoApprove": "Auto Approve:",
+		"autoApproveDescription": "Auto-approve allows Cline to perform the following actions without asking for permission. Please use with caution and only enable if you understand the risks.",
+		"autoApproveMaxRequestsDescription": "Cline will automatically make this many API requests before asking for approval to proceed with the task.",
+		"enableNotifications": "Enable Notifications",
+		"enableNotificationsDescription": "Receive system notifications when Cline requires approval to proceed or when a task is completed."
+	},
+	"historyPreview": {
+		"recentTasks": "Recent Tasks",
+		"tokens": "Tokens",
+		"cache": "Cache",
+		"apiCost": "API Cost",
+		"viewAllHistory": "View all history"
+	},
+	"historyView": {
+		"history": "History",
+		"done": "Done",
+		"fuzzySearchHistory": "Fuzzy search history...",
+		"newest": "Newest",
+		"oldest": "Oldest",
+		"mostExpensive": "Most Expensive",
+		"mostTokens": "Most Tokens",
+		"mostRelevant": "Most Relevant",
+		"tokens": "Tokens:",
+		"cache": "Cache:",
+		"apiCost": "API Cost:",
+		"export": "EXPORT"
 	}
 }

--- a/webview-ui/src/locales/es/translation.json
+++ b/webview-ui/src/locales/es/translation.json
@@ -1,0 +1,175 @@
+{
+	"announcement": {
+		"newInVersion": "Nuevo en la versión {{version}}",
+		"joinOurCommunities": "Únete a nuestro <DiscordLink>Discord</DiscordLink> o <RedditLink>Reddit</RedditLink> para más actualizaciones!"
+	},
+	"settingsView": {
+		"settings": "Configuraciones",
+		"done": "Hecho",
+		"language": "Idioma",
+		"customInstructions": "Instrucciones personalizadas",
+		"customInstructionsPlaceholder": "por ejemplo, \"Realiza pruebas unitarias al final\", \"Usa TypeScript con async/await\", \"Habla en japonés\"",
+		"customInstructionsDescription": "Estas instrucciones se agregarán al final del prompt del sistema que se envía con cada solicitud.",
+		"debug": "Depurar",
+		"resetState": "Restablecer estado",
+		"resetStateDescription": "Esto restablecerá todo el estado global y el almacenamiento secreto en la extensión.",
+		"feedback": "Si tienes preguntas o comentarios, no dudes en abrir un issue en",
+		"version": "v"
+	},
+	"apiOptions": {
+		"selectModel": "Seleccionar modelo...",
+		"model": "Modelo",
+		"apiProvider": "Proveedor de API",
+		"enterApiKey": "Ingresar clave API...",
+		"apiKey": "Clave API",
+		"enterBaseUrl": "Ingresar URL base...",
+		"baseUrl": "URL base",
+		"optionalBaseUrl": "URL base (opcional)",
+		"enterModelId": "Ingresar ID del modelo...",
+		"modelId": "ID del modelo",
+		"useCustomBaseUrl": "Usar URL base personalizada",
+		"apiKeyInfo": "Esta clave se almacena localmente y solo se usa para realizar solicitudes API desde esta extensión.",
+		"getDefault": "Predeterminado: {{defaultValue}}",
+		"getApiKeyMessage": "Puedes obtener una clave API de {{vendor}} registrándote aquí.",
+		"getApiVendorKey": "Clave API de {{vendor}}",
+		"getCompatibleVendor": "Compatible con {{vendor}}",
+		"lmStudioInfo": "LM Studio te permite ejecutar modelos localmente en tu computadora. Encuentra instrucciones para comenzar en su <Link href=\"https://lmstudio.ai/docs\">Guía de inicio rápido.</Link> También debes iniciar la función de <Link href=\"https://lmstudio.ai/docs/basics/server\">servidor local</Link> de LM Studio para usarla con esta extensión. <ErrSpan>(<b>Nota:</b> Cline usa prompts complejos y funciona mejor con modelos Claude. Los modelos menos potentes pueden no funcionar como se espera.)</ErrSpan>",
+		"ollamaInfo": "Ollama te permite ejecutar modelos localmente en tu computadora. Encuentra instrucciones para comenzar en su <Link href=\"https://github.com/ollama/ollama/blob/main/README.md\">Guía de inicio rápido.</Link> <ErrorSpan>(<b>Nota:</b> Cline usa prompts complejos y funciona mejor con modelos Claude. Los modelos menos potentes pueden no funcionar como se espera.)</ErrorSpan>",
+		"azureInfo": "<ErrSpan>(<b>Nota:</b> Cline usa prompts complejos y funciona mejor con modelos Claude. Los modelos menos potentes pueden no funcionar como se espera.)</ErrSpan>",
+		"setAzureApiVersion": "Establecer versión de API de Azure",
+		"enterGcpProjectId": "Ingresar ID del proyecto...",
+		"gcpProjectId": "ID del proyecto de Google Cloud",
+		"gcpLinks": "Para usar Google Cloud Vertex AI, debes <Link href=\"https://cloud.google.com/vertex-ai/generative-ai/docs/partner-models/use-claude#before_you_begin\"> 1) crear una cuenta de Google Cloud › habilitar la API de Vertex AI › habilitar los modelos Claude deseados, </Link><br /> <Link href=\"https://cloud.google.com/docs/authentication/provide-credentials-adc#google-idp\"> 2) instalar la CLI de Google Cloud › configurar credenciales predeterminadas de la aplicación. </Link>",
+		"enterAwsAccessKey": "Ingresar clave de acceso...",
+		"awsAccessKey": "Clave de acceso de AWS",
+		"enterAwsSecretKey": "Ingresar clave secreta...",
+		"awsSecretKey": "Clave secreta de AWS",
+		"enterAwsSessionToken": "Ingresar token de sesión...",
+		"awsSessionToken": "Token de sesión de AWS",
+		"getRegion": "Región de {{vendor}}",
+		"selectRegion": "Seleccionar región...",
+		"useCrossRegionInference": "Usar inferencia entre regiones",
+		"awsInfo": "Autentícate proporcionando las claves mencionadas arriba o usando las credenciales predeterminadas de AWS, es decir, ~/.aws/credentials o variables de entorno. Estas credenciales solo se usan localmente para realizar solicitudes API desde esta extensión.",
+		"vscodeLanguageModelsInfo": "La API de Modelos de Lenguaje de VS Code te permite usar modelos proporcionados por otras extensiones de VS Code (incluyendo, pero no limitado a GitHub Copilot). La forma más fácil de comenzar es instalar la extensión Copilot desde el VS Marketplace y habilitar Claude 3.5 Sonnet.",
+		"experimentalFeature": "Nota: Esta es una integración muy experimental y puede no funcionar como se espera.",
+		"supportsImages": "Soporta imágenes",
+		"doesNotSupportImages": "No soporta imágenes",
+		"supportsComputerUse": "Soporta uso de computadora",
+		"doesNotSupportComputerUse": "No soporta uso de computadora",
+		"supportsPromptCache": "Soporta caché de prompts",
+		"doesNotSupportPromptCache": "No soporta caché de prompts",
+		"maxOutput": "Salida máxima",
+		"tokens": "Tokens",
+		"inputPrice": "Precio de entrada",
+		"millionTokens": "Millones de tokens",
+		"cacheWritesPrice": "Precio de escritura en caché",
+		"cacheReadsPrice": "Precio de lectura en caché",
+		"outputPrice": "Precio de salida",
+		"geminiInfo": "* Gratis hasta {{selectedModelId}} solicitudes por minuto. Después, la facturación depende del tamaño del prompt.",
+		"pricingDetails": "Para más información, consulta los detalles de precios.",
+		"languageModel": "Modelo de lenguaje"
+	},
+	"welcomeView": {
+		"greeting": "¡Hola! Soy Cline, tu asistente de IA.",
+		"description": "Puedo realizar todo tipo de tareas gracias a los últimos avances en <ClaudeLink>las habilidades de codificación agencial de Claude 3.5 Sonnet</ClaudeLink> y el acceso a herramientas que me permiten crear y editar archivos, explorar proyectos complejos, usar el navegador y ejecutar comandos de terminal (por supuesto, con tu permiso). Incluso puedo usar MCP para crear nuevas herramientas y expandir mis propias habilidades.",
+		"getStarted": "Para comenzar, esta extensión necesita un proveedor de API para Claude 3.5 Sonnet.",
+		"letsGo": "¡Vamos allá!"
+	},
+	"chatView": {
+		"typeMessage": "Escribir mensaje...",
+		"typeTask": "Escribir tarea...",
+		"whatCanIDoForYou": "¿Qué puedo hacer por ti?",
+		"thanksTo": "Gracias a <ClaudeLink>las habilidades de codificación agencial de Claude 3.5 Sonnet</ClaudeLink>, puedo manejar tareas complejas de desarrollo de software paso a paso. Con herramientas que me permiten crear y editar archivos, explorar proyectos complejos, usar el navegador y ejecutar comandos de terminal (después de que hayas dado permiso), puedo ayudarte de una manera que va más allá de la autocompletación de código o el soporte técnico. Incluso puedo usar MCP para crear nuevas herramientas y expandir mis propias habilidades."
+	},
+	"chatTextArea": {
+		"plan": "Planificar",
+		"act": "Actuar"
+	},
+	"chatRow": {
+		"error": "Error",
+		"mistakeLimitReached": "Límite de errores alcanzado",
+		"autoApprovalMaxReqReached": "Número máximo de aprobaciones automáticas alcanzado",
+		"command": {
+			"ask": "Cline quiere ejecutar este comando:",
+			"say": "Cline ha ejecutado este comando:"
+		},
+		"useMcpServer": {
+			"ask": "Cline quiere usar este {type} en {serverName}:",
+			"say": "Cline ha usado este {type} en {serverName}:",
+			"tool": "Herramienta",
+			"resource": "Recurso"
+		},
+		"completionResult": "Resultado de la finalización",
+		"apiReqCancelled": "Solicitud API cancelada",
+		"apiStreamingFailed": "Transmisión API fallida",
+		"apiRequest": "Solicitud API",
+		"apiRequestFailed": "Solicitud API fallida",
+		"apiRequestInProgress": "Solicitud API en progreso",
+		"followup": "Seguimiento",
+		"tool": {
+			"editedExistingFile": {
+				"ask": "Cline quiere editar este archivo:",
+				"say": "Cline está editando este archivo:"
+			},
+			"createdNewFile": {
+				"ask": "Cline quiere crear este archivo:",
+				"say": "Cline ha creado este archivo:"
+			},
+			"readExistingFile": {
+				"ask": "Cline quiere leer este archivo:",
+				"say": "Cline ha leído este archivo:"
+			}
+		},
+		"apiReqStarted": "Solicitud API iniciada",
+		"userFeedback": "Comentarios del usuario",
+		"userFeedbackDiff": "Diferencia de comentarios del usuario",
+		"diffEditFailed": "Edición de diferencia fallida",
+		"shellIntegrationUnavailable": "Integración de shell no disponible",
+		"mcpServerResponse": "Respuesta del servidor MCP",
+		"planModeResponse": "Respuesta del modo plan",
+		"seeNewChanges": "Ver nuevos cambios",
+		"commandRequiresApproval": "El modelo ha determinado que este comando requiere aprobación explícita.",
+		"troubleshootingGuide": "Guía de solución de problemas",
+		"clineWantsToViewTopLevelFiles": "Cline quiere ver los archivos principales en este directorio:",
+		"clineViewedTopLevelFiles": "Cline ha visto los archivos principales en este directorio:",
+		"clineWantsToRecursivelyViewFiles": "Cline quiere ver todos los archivos en este directorio de forma recursiva:",
+		"clineRecursivelyViewedFiles": "Cline ha visto todos los archivos en este directorio de forma recursiva:",
+		"clineWantsToViewSourceCodeDefinitions": "Cline quiere ver los nombres de las definiciones de código fuente usadas en este directorio:",
+		"clineViewedSourceCodeDefinitions": "Cline ha visto los nombres de las definiciones de código fuente usadas en este directorio:",
+		"clineWantsToSearchDirectory": "Cline quiere buscar en este directorio por {{regex}}:",
+		"clineSearchedDirectory": "Cline ha buscado en este directorio por {{regex}}:",
+		"diffEditFailedMessage": "Esto generalmente ocurre cuando el modelo usa patrones de búsqueda que no encuentran nada en el archivo. Intentar de nuevo...",
+		"shellIntegrationUnavailableMessage": "Cline no puede mostrar la salida del comando. Por favor, actualiza VSCode (CMD/CTRL + Shift + P → \"Update\") y asegúrate de estar usando una shell compatible: zsh, bash, fish o PowerShell (CMD/CTRL + Shift + P → \"Terminal: Seleccionar perfil predeterminado\"). ¿Sigues teniendo problemas?",
+		"response": "Respuesta",
+		"stillHavingTrouble": "¿Sigues teniendo problemas?"
+	},
+	"autoApproveMenu": {
+		"none": "Ninguno",
+		"autoApprove": "Aprobación automática:",
+		"autoApproveDescription": "La aprobación automática permite a Cline realizar las siguientes acciones sin pedir permiso. Por favor, úsalo con precaución y solo habilítalo si entiendes los riesgos.",
+		"autoApproveMaxRequestsDescription": "Cline realizará automáticamente tantas solicitudes API antes de que se requiera una aprobación para continuar con la tarea.",
+		"enableNotifications": "Habilitar notificaciones",
+		"enableNotificationsDescription": "Recibe notificaciones del sistema cuando Cline necesita aprobación para continuar o cuando una tarea se ha completado."
+	},
+	"historyPreview": {
+		"recentTasks": "Tareas recientes",
+		"tokens": "Tokens",
+		"cache": "Caché",
+		"apiCost": "Costo de API",
+		"viewAllHistory": "Ver todo el historial"
+	},
+	"historyView": {
+		"history": "Historial",
+		"done": "Hecho",
+		"fuzzySearchHistory": "Búsqueda difusa en el historial...",
+		"newest": "Más reciente",
+		"oldest": "Más antiguo",
+		"mostExpensive": "Más caro",
+		"mostTokens": "Más tokens",
+		"mostRelevant": "Más relevante",
+		"tokens": "Tokens:",
+		"cache": "Caché:",
+		"apiCost": "Costo de API:",
+		"export": "EXPORTAR"
+	}
+}

--- a/webview-ui/src/locales/ja/translation.json
+++ b/webview-ui/src/locales/ja/translation.json
@@ -129,7 +129,7 @@
 		"planModeResponse": "計画モード応答",
 		"seeNewChanges": "新しい変更を見る",
 		"commandRequiresApproval": "このコマンドは明示的な承認が必要です。",
-		"troubleshootingGuide": "トラブルシューティングガイド",
+		"troubleshootingGuide": "Windows PowerShellの問題が発生しているようです。この<Link>トラブルシューティングガイド</Link>をご覧ください。",
 		"clineWantsToViewTopLevelFiles": "クラインがこのディレクトリのトップレベルファイルを表示したいと考えています：",
 		"clineViewedTopLevelFiles": "クラインがこのディレクトリのトップレベルファイルを表示しました：",
 		"clineWantsToRecursivelyViewFiles": "クラインがこのディレクトリのすべてのファイルを再帰的に表示したいと考えています：",

--- a/webview-ui/src/locales/ja/translation.json
+++ b/webview-ui/src/locales/ja/translation.json
@@ -68,5 +68,108 @@
 		"geminiInfo": "* {{selectedModelId}} リクエスト毎分まで無料。その後、料金はプロンプトサイズに基づいて計算されます。",
 		"pricingDetails": "詳細については料金情報をご確認ください。",
 		"languageModel": "言語モデル"
+	},
+	"welcomeView": {
+		"greeting": "こんにちは！私はあなたのAIアシスタント、クラインです。",
+		"description": "最新の<ClaudeLink>Claude 3.5 Sonnetのエージェントコーディング機能</ClaudeLink>と、ファイルの作成や編集、複雑なプロジェクトの探索、ブラウザの使用、ターミナルコマンドの実行（もちろん、あなたの許可が必要です）を可能にするツールのおかげで、あらゆるタスクをこなすことができます。さらに、MCPを使用して新しいツールを作成し、自分の能力を拡張することもできます。",
+		"getStarted": "始めるには、この拡張機能にClaude 3.5 SonnetのAPIプロバイダーが必要です。",
+		"letsGo": "さあ、始めましょう！"
+	},
+	"chatView": {
+		"typeMessage": "メッセージを入力...",
+		"typeTask": "タスクを入力...",
+		"whatCanIDoForYou": "何をお手伝いしましょうか？",
+		"thanksTo": "<ClaudeLink>Claude 3.5 Sonnetのエージェントコーディング機能</ClaudeLink>のおかげで、複雑なソフトウェア開発タスクをステップバイステップで処理できます。ファイルの作成や編集、複雑なプロジェクトの探索、ブラウザの使用、ターミナルコマンドの実行（許可をいただいた後）を可能にするツールを使用して、コードの補完や技術サポートを超えた支援を提供できます。さらに、MCPを使用して新しいツールを作成し、自分の能力を拡張することもできます。"
+	},
+	"chatTextArea": {
+		"plan": "計画",
+		"act": "実行"
+	},
+	"chatRow": {
+		"error": "エラー",
+		"mistakeLimitReached": "ミスの限界に達しました",
+		"autoApprovalMaxReqReached": "自動承認の最大リクエストに達しました",
+		"command": {
+			"ask": "クラインがこのコマンドを実行したいと考えています：",
+			"say": "クラインがこのコマンドを実行しました："
+		},
+		"useMcpServer": {
+			"ask": "クラインがこの{type}を{serverName}で使用したいと考えています：",
+			"say": "クラインがこの{type}を{serverName}で使用しました：",
+			"tool": "ツール",
+			"resource": "リソース"
+		},
+		"completionResult": "完了結果",
+		"apiReqCancelled": "APIリクエストがキャンセルされました",
+		"apiStreamingFailed": "APIストリーミングに失敗しました",
+		"apiRequest": "APIリクエスト",
+		"apiRequestFailed": "APIリクエストに失敗しました",
+		"apiRequestInProgress": "APIリクエスト進行中",
+		"followup": "フォローアップ",
+		"tool": {
+			"editedExistingFile": {
+				"ask": "クラインがこのファイルを編集したいと考えています：",
+				"say": "クラインがこのファイルを編集しています："
+			},
+			"createdNewFile": {
+				"ask": "クラインがこのファイルを作成したいと考えています：",
+				"say": "クラインがこのファイルを作成しました："
+			},
+			"readExistingFile": {
+				"ask": "クラインがこのファイルを読みたいと考えています：",
+				"say": "クラインがこのファイルを読みました："
+			}
+		},
+		"apiReqStarted": "APIリクエスト開始",
+		"userFeedback": "ユーザーフィードバック",
+		"userFeedbackDiff": "ユーザーフィードバック差分",
+		"diffEditFailed": "差分編集に失敗しました",
+		"shellIntegrationUnavailable": "シェル統合が利用できません",
+		"mcpServerResponse": "MCPサーバー応答",
+		"planModeResponse": "計画モード応答",
+		"seeNewChanges": "新しい変更を見る",
+		"commandRequiresApproval": "このコマンドは明示的な承認が必要です。",
+		"troubleshootingGuide": "トラブルシューティングガイド",
+		"clineWantsToViewTopLevelFiles": "クラインがこのディレクトリのトップレベルファイルを表示したいと考えています：",
+		"clineViewedTopLevelFiles": "クラインがこのディレクトリのトップレベルファイルを表示しました：",
+		"clineWantsToRecursivelyViewFiles": "クラインがこのディレクトリのすべてのファイルを再帰的に表示したいと考えています：",
+		"clineRecursivelyViewedFiles": "クラインがこのディレクトリのすべてのファイルを再帰的に表示しました：",
+		"clineWantsToViewSourceCodeDefinitions": "クラインがこのディレクトリで使用されているソースコード定義名を表示したいと考えています：",
+		"clineViewedSourceCodeDefinitions": "クラインがこのディレクトリで使用されているソースコード定義名を表示しました：",
+		"clineWantsToSearchDirectory": "クラインがこのディレクトリで{{regex}}を検索したいと考えています：",
+		"clineSearchedDirectory": "クラインがこのディレクトリで{{regex}}を検索しました：",
+		"diffEditFailedMessage": "これは通常、モデルがファイル内で一致しない検索パターンを使用した場合に発生します。再試行中...",
+		"shellIntegrationUnavailableMessage": "クラインはコマンドの出力を表示できません。VSCodeを更新し（CMD/CTRL + Shift + P → \"Update\"）、サポートされているシェルを使用していることを確認してください：zsh、bash、fish、またはPowerShell（CMD/CTRL + Shift + P → \"Terminal: Select Default Profile\"）。まだ問題がありますか？",
+		"response": "応答",
+		"stillHavingTrouble": "まだ問題がありますか？"
+	},
+	"autoApproveMenu": {
+		"none": "なし",
+		"autoApprove": "自動承認:",
+		"autoApproveDescription": "自動承認を有効にすると、クラインが以下のアクションを許可を求めずに実行できるようになります。リスクを理解した上で、慎重に使用してください。",
+		"autoApproveMaxRequestsDescription": "クラインは、このタスクを進めるために承認を求める前に、この数のAPIリクエストを自動的に行います。",
+		"enableNotifications": "通知を有効にする",
+		"enableNotificationsDescription": "クラインがタスクを進めるために承認を求めるとき、またはタスクが完了したときにシステム通知を受け取ります。"
+	},
+	"historyPreview": {
+		"recentTasks": "最近のタスク",
+		"tokens": "トークン",
+		"cache": "キャッシュ",
+		"apiCost": "APIコスト",
+		"viewAllHistory": "すべての履歴を見る"
+	},
+	"historyView": {
+		"history": "履歴",
+		"done": "完了",
+		"fuzzySearchHistory": "履歴をあいまい検索...",
+		"newest": "最新",
+		"oldest": "最古",
+		"mostExpensive": "最も高価",
+		"mostTokens": "最も多いトークン",
+		"mostRelevant": "最も関連性が高い",
+		"tokens": "トークン:",
+		"cache": "キャッシュ:",
+		"apiCost": "APIコスト:",
+		"export": "エクスポート"
 	}
 }

--- a/webview-ui/src/locales/zh-cn/translation.json
+++ b/webview-ui/src/locales/zh-cn/translation.json
@@ -63,5 +63,108 @@
 		"geminiInfo": "* 每分钟最多 {{selectedModelId}} 次请求免费。之后，费用取决于提示大小。",
 		"pricingDetails": "有关更多信息，请参阅定价详情。",
 		"languageModel": "语言模型"
+	},
+	"welcomeView": {
+		"greeting": "你好！我是 Cline，你的 AI 助手。",
+		"description": "感谢 <ClaudeLink>Claude 3.5 Sonnet 的代理编码能力</ClaudeLink> 和访问工具，我可以执行各种任务，这些工具让我可以创建和编辑文件、探索复杂项目、使用浏览器和执行终端命令（当然，需要你的许可）。我甚至可以使用 MCP 创建新工具并扩展我自己的能力。",
+		"getStarted": "要开始使用，此扩展需要 Claude 3.5 Sonnet 的 API 提供商。",
+		"letsGo": "开始吧！"
+	},
+	"chatView": {
+		"typeMessage": "输入消息...",
+		"typeTask": "输入任务...",
+		"whatCanIDoForYou": "我能为你做什么？",
+		"thanksTo": "感谢 <ClaudeLink>Claude 3.5 Sonnet 的代理编码能力，</ClaudeLink> 我可以一步步处理复杂的软件开发任务。通过允许我创建和编辑文件、探索复杂项目、使用浏览器和执行终端命令的工具（在你授予权限后），我可以以超越代码完成或技术支持的方式帮助你。我甚至可以使用 MCP 创建新工具并扩展我自己的能力。"
+	},
+	"chatTextArea": {
+		"plan": "计划",
+		"act": "行动"
+	},
+	"chatRow": {
+		"error": "错误",
+		"mistakeLimitReached": "错误次数达到上限",
+		"autoApprovalMaxReqReached": "自动批准请求次数达到上限",
+		"command": {
+			"ask": "Cline 想执行此命令：",
+			"say": "Cline 执行了此命令："
+		},
+		"useMcpServer": {
+			"ask": "Cline 想在 {serverName} 上使用此 {type}：",
+			"say": "Cline 在 {serverName} 上使用了此 {type}：",
+			"tool": "工具",
+			"resource": "资源"
+		},
+		"completionResult": "完成结果",
+		"apiReqCancelled": "API 请求已取消",
+		"apiStreamingFailed": "API 流式传输失败",
+		"apiRequest": "API 请求",
+		"apiRequestFailed": "API 请求失败",
+		"apiRequestInProgress": "API 请求进行中",
+		"followup": "跟进",
+		"tool": {
+			"editedExistingFile": {
+				"ask": "Cline 想编辑此文件：",
+				"say": "Cline 正在编辑此文件："
+			},
+			"createdNewFile": {
+				"ask": "Cline 想创建此文件：",
+				"say": "Cline 创建了此文件："
+			},
+			"readExistingFile": {
+				"ask": "Cline 想读取此文件：",
+				"say": "Cline 读取了此文件："
+			}
+		},
+		"apiReqStarted": "API 请求已启动",
+		"userFeedback": "用户反馈",
+		"userFeedbackDiff": "用户反馈差异",
+		"diffEditFailed": "差异编辑失败",
+		"shellIntegrationUnavailable": "Shell 集成不可用",
+		"mcpServerResponse": "MCP 服务器响应",
+		"planModeResponse": "计划模式响应",
+		"seeNewChanges": "查看新更改",
+		"commandRequiresApproval": "模型已确定此命令需要明确批准。",
+		"troubleshootingGuide": "故障排除指南",
+		"clineWantsToViewTopLevelFiles": "Cline 想查看此目录中的顶级文件：",
+		"clineViewedTopLevelFiles": "Cline 查看了此目录中的顶级文件：",
+		"clineWantsToRecursivelyViewFiles": "Cline 想递归查看此目录中的所有文件：",
+		"clineRecursivelyViewedFiles": "Cline 递归查看了此目录中的所有文件：",
+		"clineWantsToViewSourceCodeDefinitions": "Cline 想查看此目录中使用的源代码定义名称：",
+		"clineViewedSourceCodeDefinitions": "Cline 查看了此目录中使用的源代码定义名称：",
+		"clineWantsToSearchDirectory": "Cline 想在此目录中搜索 {{regex}}：",
+		"clineSearchedDirectory": "Cline 在此目录中搜索了 {{regex}}：",
+		"diffEditFailedMessage": "这通常发生在模型使用的搜索模式与文件中的任何内容不匹配时。重试中...",
+		"shellIntegrationUnavailableMessage": "Cline 将无法查看命令的输出。请更新 VSCode（CMD/CTRL + Shift + P → \"Update\"）并确保你使用的是受支持的 shell：zsh、bash、fish 或 PowerShell（CMD/CTRL + Shift + P → \"Terminal: Select Default Profile\"）。仍有问题？",
+		"response": "响应",
+		"stillHavingTrouble": "仍有问题？"
+	},
+	"autoApproveMenu": {
+		"none": "无",
+		"autoApprove": "自动批准：",
+		"autoApproveDescription": "自动批准允许 Cline 在不请求许可的情况下执行以下操作。请谨慎使用，并仅在了解风险的情况下启用。",
+		"autoApproveMaxRequestsDescription": "Cline 将自动发出此数量的 API 请求，然后再请求批准以继续任务。",
+		"enableNotifications": "启用通知",
+		"enableNotificationsDescription": "当 Cline 需要批准以继续或任务完成时接收系统通知。"
+	},
+	"historyPreview": {
+		"recentTasks": "最近任务",
+		"tokens": "令牌",
+		"cache": "缓存",
+		"apiCost": "API 成本",
+		"viewAllHistory": "查看所有历史记录"
+	},
+	"historyView": {
+		"history": "历史",
+		"done": "完成",
+		"fuzzySearchHistory": "模糊搜索历史...",
+		"newest": "最新",
+		"oldest": "最旧",
+		"mostExpensive": "最昂贵",
+		"mostTokens": "最多令牌",
+		"mostRelevant": "最相关",
+		"tokens": "令牌：",
+		"cache": "缓存：",
+		"apiCost": "API 成本：",
+		"export": "导出"
 	}
 }

--- a/webview-ui/src/locales/zh-cn/translation.json
+++ b/webview-ui/src/locales/zh-cn/translation.json
@@ -124,7 +124,7 @@
 		"planModeResponse": "计划模式响应",
 		"seeNewChanges": "查看新更改",
 		"commandRequiresApproval": "模型已确定此命令需要明确批准。",
-		"troubleshootingGuide": "故障排除指南",
+		"troubleshootingGuide": "看起来你遇到了 Windows PowerShell 问题，请参阅此 <Link>故障排除指南</Link>",
 		"clineWantsToViewTopLevelFiles": "Cline 想查看此目录中的顶级文件：",
 		"clineViewedTopLevelFiles": "Cline 查看了此目录中的顶级文件：",
 		"clineWantsToRecursivelyViewFiles": "Cline 想递归查看此目录中的所有文件：",

--- a/webview-ui/src/locales/zh-tw/translation.json
+++ b/webview-ui/src/locales/zh-tw/translation.json
@@ -124,7 +124,7 @@
 		"planModeResponse": "計劃模式響應",
 		"seeNewChanges": "查看新變更",
 		"commandRequiresApproval": "模型已確定此命令需要明確批准。",
-		"troubleshootingGuide": "故障排除指南",
+		"troubleshootingGuide": "看起來您遇到了 Windows PowerShell 問題，請參閱此 <Link>故障排除指南</Link>",
 		"clineWantsToViewTopLevelFiles": "Cline 想要查看此目錄中的頂層文件：",
 		"clineViewedTopLevelFiles": "Cline 查看了此目錄中的頂層文件：",
 		"clineWantsToRecursivelyViewFiles": "Cline 想要遞歸查看此目錄中的所有文件：",

--- a/webview-ui/src/locales/zh-tw/translation.json
+++ b/webview-ui/src/locales/zh-tw/translation.json
@@ -63,5 +63,108 @@
 		"geminiInfo": "* 每分鐘最多免費 {{selectedModelId}} 次請求。之後，計費取決於提示大小。",
 		"pricingDetails": "更多信息，請參見定價詳情。",
 		"languageModel": "語言模型"
+	},
+	"welcomeView": {
+		"greeting": "您好！我是 Cline，您的 AI 助手。",
+		"description": "得益於 <ClaudeLink>Claude 3.5 Sonnet 的代理編碼能力</ClaudeLink> 和訪問各種工具，我可以執行各種任務，這些工具讓我能夠創建和編輯文件、探索複雜項目、使用瀏覽器和執行終端命令（當然是在您的許可下）。我甚至可以使用 MCP 創建新工具並擴展我自己的能力。",
+		"getStarted": "要開始使用，這個擴展需要 Claude 3.5 Sonnet 的 API 提供者。",
+		"letsGo": "讓我們開始吧！"
+	},
+	"chatView": {
+		"typeMessage": "輸入消息...",
+		"typeTask": "輸入任務...",
+		"whatCanIDoForYou": "我能為您做什麼？",
+		"thanksTo": "感謝 <ClaudeLink>Claude 3.5 Sonnet 的代理編碼能力，</ClaudeLink> 我可以逐步處理複雜的軟件開發任務。通過這些工具，我可以創建和編輯文件、探索複雜項目、使用瀏覽器和執行終端命令（在您授權後），我可以幫助您完成超越代碼補全或技術支持的任務。我甚至可以使用 MCP 創建新工具並擴展我自己的能力。"
+	},
+	"chatTextArea": {
+		"plan": "計劃",
+		"act": "行動"
+	},
+	"chatRow": {
+		"error": "錯誤",
+		"mistakeLimitReached": "錯誤次數達到上限",
+		"autoApprovalMaxReqReached": "自動批准請求次數達到上限",
+		"command": {
+			"ask": "Cline 想要執行此命令：",
+			"say": "Cline 執行了此命令："
+		},
+		"useMcpServer": {
+			"ask": "Cline 想要在 {serverName} 上使用此 {type}：",
+			"say": "Cline 在 {serverName} 上使用了此 {type}：",
+			"tool": "工具",
+			"resource": "資源"
+		},
+		"completionResult": "完成結果",
+		"apiReqCancelled": "API 請求已取消",
+		"apiStreamingFailed": "API 流式傳輸失敗",
+		"apiRequest": "API 請求",
+		"apiRequestFailed": "API 請求失敗",
+		"apiRequestInProgress": "API 請求進行中",
+		"followup": "後續",
+		"tool": {
+			"editedExistingFile": {
+				"ask": "Cline 想要編輯此文件：",
+				"say": "Cline 正在編輯此文件："
+			},
+			"createdNewFile": {
+				"ask": "Cline 想要創建此文件：",
+				"say": "Cline 創建了此文件："
+			},
+			"readExistingFile": {
+				"ask": "Cline 想要閱讀此文件：",
+				"say": "Cline 閱讀了此文件："
+			}
+		},
+		"apiReqStarted": "API 請求已開始",
+		"userFeedback": "用戶反饋",
+		"userFeedbackDiff": "用戶反饋差異",
+		"diffEditFailed": "差異編輯失敗",
+		"shellIntegrationUnavailable": "Shell 集成不可用",
+		"mcpServerResponse": "MCP 服務器響應",
+		"planModeResponse": "計劃模式響應",
+		"seeNewChanges": "查看新變更",
+		"commandRequiresApproval": "模型已確定此命令需要明確批准。",
+		"troubleshootingGuide": "故障排除指南",
+		"clineWantsToViewTopLevelFiles": "Cline 想要查看此目錄中的頂層文件：",
+		"clineViewedTopLevelFiles": "Cline 查看了此目錄中的頂層文件：",
+		"clineWantsToRecursivelyViewFiles": "Cline 想要遞歸查看此目錄中的所有文件：",
+		"clineRecursivelyViewedFiles": "Cline 遞歸查看了此目錄中的所有文件：",
+		"clineWantsToViewSourceCodeDefinitions": "Cline 想要查看此目錄中使用的源代碼定義名稱：",
+		"clineViewedSourceCodeDefinitions": "Cline 查看了此目錄中使用的源代碼定義名稱：",
+		"clineWantsToSearchDirectory": "Cline 想要在此目錄中搜索 {{regex}}：",
+		"clineSearchedDirectory": "Cline 在此目錄中搜索了 {{regex}}：",
+		"diffEditFailedMessage": "這通常發生在模型使用的搜索模式與文件中的任何內容不匹配時。重試中...",
+		"shellIntegrationUnavailableMessage": "Cline 將無法查看命令的輸出。請更新 VSCode（CMD/CTRL + Shift + P → \"Update\"）並確保您使用的是受支持的 shell：zsh、bash、fish 或 PowerShell（CMD/CTRL + Shift + P → \"Terminal: Select Default Profile\"）。仍有問題？",
+		"response": "響應",
+		"stillHavingTrouble": "仍有問題？"
+	},
+	"autoApproveMenu": {
+		"none": "無",
+		"autoApprove": "自動批准：",
+		"autoApproveDescription": "自動批准允許 Cline 執行以下操作而無需請求許可。請謹慎使用，僅在您了解風險的情況下啟用。",
+		"autoApproveMaxRequestsDescription": "Cline 將自動發出這麼多 API 請求，然後再請求批准以繼續任務。",
+		"enableNotifications": "啟用通知",
+		"enableNotificationsDescription": "當 Cline 需要批准以繼續或任務完成時接收系統通知。"
+	},
+	"historyPreview": {
+		"recentTasks": "最近任務",
+		"tokens": "標記",
+		"cache": "緩存",
+		"apiCost": "API 成本",
+		"viewAllHistory": "查看所有歷史記錄"
+	},
+	"historyView": {
+		"history": "歷史",
+		"done": "完成",
+		"fuzzySearchHistory": "模糊搜索歷史...",
+		"newest": "最新",
+		"oldest": "最舊",
+		"mostExpensive": "最昂貴",
+		"mostTokens": "最多標記",
+		"mostRelevant": "最相關",
+		"tokens": "標記：",
+		"cache": "緩存：",
+		"apiCost": "API 成本：",
+		"export": "導出"
 	}
 }


### PR DESCRIPTION
### Description

<!-- Describe your changes in detail. What problem does this PR solve? -->
Includes i18n-l10n for following:
- Welcome (WelcomeView.tsx)
- Chat/Home View (ChatView.tsx. ChatTextArea.tsx, ChatRow.tsx)
- History (HistoryView.tsx, HistoryPreview.tsx)

In additional, I've added Spanish (`es`) translations.

### Test Procedure

<!-- How did you test this? Are you confident that it will not introduce bugs? If so, why? -->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

### Additional Notes

<!-- Add any additional notes for reviewers -->
