### PR TITLE
Add simple backend logging service

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,6 +3,7 @@
 import delay from "delay"
 import * as vscode from "vscode"
 import { ClineProvider } from "./core/webview/ClineProvider"
+import { Logger } from "./services/logging/Logger"
 import { createClineAPI } from "./exports"
 import "./utils/path" // necessary to have access to String.prototype.toPosix
 import { DIFF_VIEW_URI_SCHEME } from "./integrations/editor/DiffViewProvider"
@@ -24,7 +25,8 @@ export function activate(context: vscode.ExtensionContext) {
 	outputChannel = vscode.window.createOutputChannel("Cline")
 	context.subscriptions.push(outputChannel)
 
-	outputChannel.appendLine("Cline extension activated")
+	Logger.initialize(outputChannel)
+	Logger.log("Cline extension activated")
 
 	const sidebarProvider = new ClineProvider(context, outputChannel)
 
@@ -36,7 +38,7 @@ export function activate(context: vscode.ExtensionContext) {
 
 	context.subscriptions.push(
 		vscode.commands.registerCommand("cline.plusButtonClicked", async () => {
-			outputChannel.appendLine("Plus button Clicked")
+			Logger.log("Plus button Clicked")
 			await sidebarProvider.clearTask()
 			await sidebarProvider.postStateToWebview()
 			await sidebarProvider.postMessageToWebview({
@@ -56,7 +58,7 @@ export function activate(context: vscode.ExtensionContext) {
 	)
 
 	const openClineInNewTab = async () => {
-		outputChannel.appendLine("Opening Cline in new tab")
+		Logger.log("Opening Cline in new tab")
 		// (this example uses webviewProvider activation event which is necessary to deserialize cached webview, but since we use retainContextWhenHidden, we don't need to use that event)
 		// https://github.com/microsoft/vscode-extension-samples/blob/main/webview-sample/src/extension.ts
 		const tabProvider = new ClineProvider(context, outputChannel)
@@ -186,5 +188,5 @@ export function activate(context: vscode.ExtensionContext) {
 
 // This method is called when your extension is deactivated
 export function deactivate() {
-	outputChannel.appendLine("Cline extension deactivated")
+	Logger.log("Cline extension deactivated")
 }

--- a/src/services/logging/Logger.ts
+++ b/src/services/logging/Logger.ts
@@ -1,4 +1,4 @@
-import * as vscode from "vscode"
+import type { OutputChannel } from "vscode"
 
 /**
  * Simple logging utility for the extension's backend code.
@@ -6,9 +6,9 @@ import * as vscode from "vscode"
  * to ensure proper registration with the extension context.
  */
 export class Logger {
-	private static outputChannel: vscode.OutputChannel
+	private static outputChannel: OutputChannel
 
-	static initialize(outputChannel: vscode.OutputChannel) {
+	static initialize(outputChannel: OutputChannel) {
 		Logger.outputChannel = outputChannel
 	}
 

--- a/src/services/logging/Logger.ts
+++ b/src/services/logging/Logger.ts
@@ -1,0 +1,21 @@
+import * as vscode from "vscode"
+
+/**
+ * Simple logging utility for the extension's backend code.
+ * Uses VS Code's OutputChannel which must be initialized from extension.ts
+ * to ensure proper registration with the extension context.
+ */
+export class Logger {
+	private static outputChannel: vscode.OutputChannel
+
+	static initialize(outputChannel: vscode.OutputChannel) {
+		Logger.outputChannel = outputChannel
+	}
+
+	static log(message: string) {
+		if (!Logger.outputChannel) {
+			throw new Error("Logger must be initialized first")
+		}
+		Logger.outputChannel.appendLine(message)
+	}
+}

--- a/src/services/logging/Logger.ts
+++ b/src/services/logging/Logger.ts
@@ -13,9 +13,6 @@ export class Logger {
 	}
 
 	static log(message: string) {
-		if (!Logger.outputChannel) {
-			throw new Error("Logger must be initialized first")
-		}
 		Logger.outputChannel.appendLine(message)
 	}
 }


### PR DESCRIPTION
### Description

This PR introduces a simple logging service for the VS Code Output for backend files.

Previously only the ClineProvider had access to the output channel allowing logging under the Output tab in VS Code. This meant that logging to the output was not available in other files, like Cline.ts, unless one added an explicit log method to the ClineProvider and called this from the other file. This service endeavors to make this accessible across the backend.

Key changes:
- Added `src/services/logging/Logger.ts`
- Updated extension.ts to initialize and use the Logger
- Maintained compatibility with existing OutputChannel usage

The Logger service is intentionally minimal but structured to allow for future enhancements while following VS Code's extension patterns. Another PR can handle the scope of switching OutputChannel dependency injection over to using the logger via import.

### Usage

The Logger provides a static interface for logging messages to VS Code's Output panel:

1. Import:
```typescript
import { Logger } from '../services/logging/Logger';
```

2. Log messages:
```typescript
Logger.log('Extension activated');
Logger.log('Processing request');
Logger.log('Operation completed');
Logger.log(
`System prompt length with MCP ${mcpHub.getMode() === "full" ? "enabled" : mcpHub.getMode() === "server-use-only" ? "servers only" : "disabled"}: ${systemPrompt.length} characters`
)
```
<img width="690" alt="Screenshot 2025-01-28 at 11 01 08 AM" src="https://github.com/user-attachments/assets/fc7a30d4-fc5e-41bf-898e-b64a140532de" />

Logs appear in VS Code's Output panel under the "Cline" channel.

### Test Procedure

To test the Logger implementation:

1. Basic Logging:
   - Start VS Code with the extension
   - Open the Output panel (View > Output)
   - Select "Cline" from the dropdown
   - Verify Logger.log() messages appear in the output

2. Frontend Separation:
   - Logger imports should not be allowed in a webview-ui/ file
   - However, this is currently not throwing any errors in the IDE
   - Either the tsconfig or the eslint rules need to be updated to disallow this. This can be the scope of a separate PR for 
   readability.

### Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update

### Pre-flight Checklist

- [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
- [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
- [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Additional Notes

#### Architecture & Implementation
- Static class pattern for simple, extension-wide logging
- Initialized in extension.ts for proper VS Code lifecycle management
- Located in services/ directory to maintain separation from webview code

#### Future Extensions
The Logger can be enhanced with:

1. Log Levels
- error(), warn(), info(), debug() methods with configurable minimum level
- Color coding for different levels

2. Advanced Features
- Timestamps and source location information

These enhancements can be added incrementally.

