### PR TITLE
Chore: Add OVSX to the pre-release

### DIFF
--- a/.github/workflows/prerelease-publish.yml
+++ b/.github/workflows/prerelease-publish.yml
@@ -72,9 +72,8 @@ jobs:
                   OVSX_PAT: ${{ secrets.OVSX_PAT }}
               run: |
                   current_package_version=$(node -p "require('./package.json').version")
-                  vsce package
-                  vsce publish --pre-release -p ${{ secrets.VSCE_PAT }}
-                  echo "Successfully published pre-release version $current_package_version to VS Code Marketplace"
+                  npm run publish:marketplace:prerelease
+                  echo "Successfully published pre-release version $current_package_version to VS Code Marketplace and Open VSX Registry"
 
             - name: Create GitHub Pre-release
               uses: softprops/action-gh-release@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,7 +72,7 @@ jobs:
               run: |
                   current_package_version=$(node -p "require('./package.json').version")
                   npm run publish:marketplace
-                  echo "Successfully published version $current_package_version to VS Code Marketplace"
+                  echo "Successfully published version $current_package_version to VS Code Marketplace and Open VSX Registry"
 
             - name: Create GitHub Release
               uses: softprops/action-gh-release@v1

--- a/package.json
+++ b/package.json
@@ -185,6 +185,7 @@
 		"build:webview": "cd webview-ui && npm run build",
 		"test:webview": "cd webview-ui && npm run test",
 		"publish:marketplace": "vsce publish && ovsx publish",
+		"publish:marketplace:prerelease": "vsce publish --pre-release && ovsx publish --pre-release",
 		"prepare": "husky"
 	},
 	"devDependencies": {


### PR DESCRIPTION
### Description

Just make sure to push pre-release to OVSX as well as the MSFT marketplace. Standardize on `npm run` for the publishing of both.

### Test Procedure

<!-- How did you test this? Are you confident that it will not introduce bugs? If so, why? -->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

### Additional Notes

<!-- Add any additional notes for reviewers -->
