### PR TITLE
feat: Select model info for OpenAI Compatible models

### DIFF
--- a/src/api/providers/openai.ts
+++ b/src/api/providers/openai.ts
@@ -1,6 +1,17 @@
 import { Anthropic } from "@anthropic-ai/sdk"
 import OpenAI, { AzureOpenAI } from "openai"
-import { ApiHandlerOptions, azureOpenAiDefaultApiVersion, ModelInfo, openAiModelInfoSaneDefaults } from "../../shared/api"
+import {
+	ApiHandlerOptions,
+	azureOpenAiDefaultApiVersion,
+	ModelInfo,
+	openAiModelInfoSaneDefaults,
+	anthropicModels,
+	bedrockModels,
+	vertexModels,
+	openAiNativeModels,
+	deepSeekModels,
+	mistralModels,
+} from "../../shared/api"
 import { ApiHandler } from "../index"
 import { convertToOpenAiMessages } from "../transform/openai-format"
 import { ApiStream } from "../transform/stream"
@@ -59,7 +70,7 @@ export class OpenAiHandler implements ApiHandler {
 	getModel(): { id: string; info: ModelInfo } {
 		return {
 			id: this.options.openAiModelId ?? "",
-			info: openAiModelInfoSaneDefaults,
+			info: this.options.openAiModelInfo ?? openAiModelInfoSaneDefaults,
 		}
 	}
 }

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -60,6 +60,7 @@ type GlobalStateKey =
 	| "taskHistory"
 	| "openAiBaseUrl"
 	| "openAiModelId"
+	| "openAiModelInfo"
 	| "ollamaModelId"
 	| "ollamaBaseUrl"
 	| "lmStudioModelId"
@@ -430,6 +431,7 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 								openAiBaseUrl,
 								openAiApiKey,
 								openAiModelId,
+								openAiModelInfo,
 								ollamaModelId,
 								ollamaBaseUrl,
 								lmStudioModelId,
@@ -458,6 +460,7 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 							await this.updateGlobalState("openAiBaseUrl", openAiBaseUrl)
 							await this.storeSecret("openAiApiKey", openAiApiKey)
 							await this.updateGlobalState("openAiModelId", openAiModelId)
+							await this.updateGlobalState("openAiModelInfo", openAiModelInfo)
 							await this.updateGlobalState("ollamaModelId", ollamaModelId)
 							await this.updateGlobalState("ollamaBaseUrl", ollamaBaseUrl)
 							await this.updateGlobalState("lmStudioModelId", lmStudioModelId)
@@ -528,6 +531,7 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 									break
 								case "openai":
 									await this.updateGlobalState("previousModeModelId", apiConfiguration.openAiModelId)
+									await this.updateGlobalState("previousModeModelInfo", apiConfiguration.openAiModelInfo)
 									break
 								case "ollama":
 									await this.updateGlobalState("previousModeModelId", apiConfiguration.ollamaModelId)
@@ -1339,6 +1343,7 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 			openAiBaseUrl,
 			openAiApiKey,
 			openAiModelId,
+			openAiModelInfo,
 			ollamaModelId,
 			ollamaBaseUrl,
 			lmStudioModelId,
@@ -1378,6 +1383,7 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 			this.getGlobalState("openAiBaseUrl") as Promise<string | undefined>,
 			this.getSecret("openAiApiKey") as Promise<string | undefined>,
 			this.getGlobalState("openAiModelId") as Promise<string | undefined>,
+			this.getGlobalState("openAiModelInfo") as Promise<ModelInfo | undefined>,
 			this.getGlobalState("ollamaModelId") as Promise<string | undefined>,
 			this.getGlobalState("ollamaBaseUrl") as Promise<string | undefined>,
 			this.getGlobalState("lmStudioModelId") as Promise<string | undefined>,
@@ -1434,6 +1440,7 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 				openAiBaseUrl,
 				openAiApiKey,
 				openAiModelId,
+				openAiModelInfo,
 				ollamaModelId,
 				ollamaBaseUrl,
 				lmStudioModelId,

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -29,6 +29,7 @@ export interface ApiHandlerOptions {
 	openAiBaseUrl?: string
 	openAiApiKey?: string
 	openAiModelId?: string
+	openAiModelInfo?: ModelInfo
 	ollamaModelId?: string
 	ollamaBaseUrl?: string
 	lmStudioModelId?: string

--- a/webview-ui/src/components/settings/ApiOptions.tsx
+++ b/webview-ui/src/components/settings/ApiOptions.tsx
@@ -571,7 +571,39 @@ const ApiOptions = ({ showModelOptions, apiErrorMessage, modelIdErrorMessage, is
 					<VSCodeTextField
 						value={apiConfiguration?.openAiModelId || ""}
 						style={{ width: "100%" }}
-						onInput={handleInputChange("openAiModelId")}
+						onInput={(e: any) => {
+							const modelId = e.target.value
+							const allModels: Record<string, ModelInfo> = {
+								...anthropicModels,
+								...bedrockModels,
+								...vertexModels,
+								...openAiNativeModels,
+								...deepSeekModels,
+								...mistralModels,
+							}
+
+							// Try exact match first
+							let matchingModelId = Object.keys(allModels).find((id) => id === modelId)
+
+							if (!matchingModelId && modelId) {
+								// Try exact match with normalized ID (without prefix)
+								const normalizedModelId = modelId.includes("/") ? modelId.split("/").pop()! : modelId
+								matchingModelId = Object.keys(allModels).find((id) => id === normalizedModelId)
+							}
+
+							const modelInfo =
+								matchingModelId && allModels[matchingModelId]
+									? allModels[matchingModelId]
+									: openAiModelInfoSaneDefaults
+
+							setApiConfiguration({
+								...apiConfiguration,
+								...{
+									openAiModelId: modelId,
+									openAiModelInfo: modelInfo,
+								},
+							})
+						}}
 						placeholder={"Enter Model ID..."}>
 						<span style={{ fontWeight: 500 }}>Model ID</span>
 					</VSCodeTextField>
@@ -843,6 +875,16 @@ const ApiOptions = ({ showModelOptions, apiErrorMessage, modelIdErrorMessage, is
 
 			{selectedProvider === "openrouter" && showModelOptions && <OpenRouterModelPicker isPopup={isPopup} />}
 
+			{selectedProvider === "openai" && showModelOptions && selectedModelId && (
+				<ModelInfoView
+					selectedModelId={selectedModelId}
+					modelInfo={selectedModelInfo}
+					isDescriptionExpanded={isDescriptionExpanded}
+					setIsDescriptionExpanded={setIsDescriptionExpanded}
+					isPopup={isPopup}
+				/>
+			)}
+
 			{modelIdErrorMessage && (
 				<p
 					style={{
@@ -1043,12 +1085,13 @@ export function normalizeApiConfiguration(apiConfiguration?: ApiConfiguration): 
 				selectedModelId: apiConfiguration?.openRouterModelId || openRouterDefaultModelId,
 				selectedModelInfo: apiConfiguration?.openRouterModelInfo || openRouterDefaultModelInfo,
 			}
-		case "openai":
+		case "openai": {
 			return {
 				selectedProvider: provider,
 				selectedModelId: apiConfiguration?.openAiModelId || "",
-				selectedModelInfo: openAiModelInfoSaneDefaults,
+				selectedModelInfo: apiConfiguration?.openAiModelInfo || openAiModelInfoSaneDefaults,
 			}
+		}
 		case "ollama":
 			return {
 				selectedProvider: provider,


### PR DESCRIPTION
### Description
Currently when using OpenAI compatible the model is always treated as unknown/default capabilities.

OpenAI compatible endpoints (which aren't OpenRouter) can allow for selection of models such as claude 3.5 sonnet. e.g. the endpoint could be using LiteLLM.

Since we already know the model info for the majority of these models from the other providers we might as well try use that information in OpenAI compatible instead of treating it as unknown.

Some libraries like LiteLLM also allow usage of a prefix for disambiguating providers e.g. `bedrock/xxx`

### Test Procedure

In the extension I tried the following models:

* anthropic.claude-3-5-sonnet-20241022-v2:0
* * shows up with correct model info including computer use
* bedrock/anthropic.claude-3-5-sonnet-20241022-v2:0
* * shows up with correct model info
* foo
* * uses default model info

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<img width="456" alt="image" src="https://github.com/user-attachments/assets/93ff6eaf-2d36-400f-b45c-dc2a6defe93d" />

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Enhance OpenAI compatible model handling by using known model information instead of default defaults, with updates to state management and model selection logic.
> 
>   - **Behavior**:
>     - `OpenAiHandler` in `openai.ts` now uses `openAiModelInfo` from `ApiHandlerOptions` if available, instead of defaulting to `openAiModelInfoSaneDefaults`.
>     - `ApiOptions.tsx` updates `openAiModelInfo` based on user input for model ID, matching against known models.
>   - **State Management**:
>     - Adds `openAiModelInfo` to `GlobalStateKey` in `ClineProvider.ts` for state persistence.
>     - Updates `getState` and `updateGlobalState` methods in `ClineProvider.ts` to handle `openAiModelInfo`.
>   - **Models**:
>     - Imports additional model sets (`anthropicModels`, `bedrockModels`, etc.) in `openai.ts` and `ApiOptions.tsx` for model information retrieval.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for f5f4252d2411a0dcdb115071a26ab3c2a40e0063. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->