### PR TITLE
Fix context window progress bar spacing

### DIFF
--- a/webview-ui/src/components/chat/TaskHeader.tsx
+++ b/webview-ui/src/components/chat/TaskHeader.tsx
@@ -117,7 +117,7 @@ const TaskHeader: React.FC<TaskHeaderProps> = ({
 				<div
 					style={{
 						display: "flex",
-						flexDirection: windowWidth < 320 ? "column" : "row",
+						flexDirection: windowWidth < 270 ? "column" : "row",
 						gap: "4px",
 					}}>
 					<div
@@ -136,19 +136,16 @@ const TaskHeader: React.FC<TaskHeaderProps> = ({
 						style={{
 							display: "flex",
 							alignItems: "center",
-							gap: "8px",
+							gap: "3px",
 							flex: 1,
 							whiteSpace: "nowrap",
 						}}>
-						<span>
-							{formatLargeNumber(lastApiReqTotalTokens)} (
-							{Math.round((lastApiReqTotalTokens / contextWindow) * 100)}%)
-						</span>
+						<span>{formatLargeNumber(lastApiReqTotalTokens)}</span>
 						<div
 							style={{
 								display: "flex",
 								alignItems: "center",
-								gap: "8px",
+								gap: "3px",
 								flex: 1,
 							}}>
 							<div


### PR DESCRIPTION
### Description

<!-- Describe your changes in detail. What problem does this PR solve? -->

### Test Procedure

<!-- How did you test this? Are you confident that it will not introduce bugs? If so, why? -->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [ ] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adjust `TaskHeader` layout and spacing for better alignment and compactness, especially for smaller window widths.
> 
>   - **Layout Adjustments**:
>     - In `TaskHeader.tsx`, change `flexDirection` threshold from 320 to 270 for column layout.
>     - Adjust `gap` from 8px to 3px for elements within the progress bar.
>   - **Progress Bar**:
>     - Remove percentage display next to `lastApiReqTotalTokens`.
>     - Adjust spacing for better alignment and compactness.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for f08f29081bb474929544b3106f29aef0b964eaba. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->