### PR TITLE
Fix localized README links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <div align="center"><sub>
-English | <a href="./locales/es/README.md" target="_blank">Español</a> | <a href="./locales/de/README.md" target="_blank">Deutsch</a> | <a href="./locales/ja/README.md" target="_blank">日本語</a> | <a href="./locales/zh-cn/README.md" target="_blank">简体中文</a> | <a href="./locales/zh-tw/README.md" target="_blank">繁體中文</a>
+English | <a href="https://github.com/cline/cline/blob/main/locales/es/README.md" target="_blank">Español</a> | <a href="https://github.com/cline/cline/blob/main/locales/de/README.md" target="_blank">Deutsch</a> | <a href="https://github.com/cline/cline/blob/main/locales/ja/README.md" target="_blank">日本語</a> | <a href="https://github.com/cline/cline/blob/main/locales/zh-cn/README.md" target="_blank">简体中文</a> | <a href="https://github.com/cline/cline/blob/main/locales/zh-tw/README.md" target="_blank">繁體中文</a>
 </sub></div>
 
 # Cline – \#1 on OpenRouter


### PR DESCRIPTION
### Description

Fixed broken localization links in README.md files to ensure proper navigation between translated documentation.

### Test Procedure

Manually verified all localization links in README files across different language versions to confirm they now correctly redirect to their respective translations.

### Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📚 Documentation update

### Pre-flight Checklist

- [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
- [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
- [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A - Documentation change only
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes broken localization links in `README.md` by updating them to absolute URLs.
> 
>   - **Documentation**:
>     - Fixes broken localization links in `README.md` by updating them to absolute URLs for proper navigation to translated documentation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for c218cd659cb724435e5f0c41f011663cc1e42ac0. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->