### PR TITLE
chore(openai): update o1-mini pricing based on current model pricing

### DIFF
--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -344,8 +344,8 @@ export const openAiNativeModels = {
 		contextWindow: 128_000,
 		supportsImages: true,
 		supportsPromptCache: false,
-		inputPrice: 3,
-		outputPrice: 12,
+		inputPrice: 1.1,
+		outputPrice: 4.4,
 	},
 	"gpt-4o": {
 		maxTokens: 4_096,


### PR DESCRIPTION
### Description

Update o1-mini pricing to match OpenAI's current model pricing of $1.1/M input tokens and $4.4/M output tokens. This aligns the pricing with OpenAI's latest pricing structure.

### Test Procedure

- Verified pricing values in src/shared/api.ts match OpenAI's current model pricing
- Ran format and lint checks which passed successfully
- No functional changes, only pricing updates

### Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update

### Pre-flight Checklist

- [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
- [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
- [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `o1-mini` model pricing in `src/shared/api.ts` to align with OpenAI's current pricing structure.
> 
>   - **Pricing Update**:
>     - Update `o1-mini` model pricing in `src/shared/api.ts` to $1.1/M input tokens and $4.4/M output tokens.
>   - **Verification**:
>     - Verified pricing values match OpenAI's current model pricing.
>     - Ran format and lint checks successfully.
>   - **No Functional Changes**:
>     - Only pricing updates, no changes to functionality.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 72e04cb30266c7e137ae4e596b106495331562a8. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->