### PR TITLE
feat(openai): add o3-mini model

### DIFF
--- a/src/api/providers/openai-native.ts
+++ b/src/api/providers/openai-native.ts
@@ -26,7 +26,8 @@ export class OpenAiNativeHandler implements ApiHandler {
 		switch (this.getModel().id) {
 			case "o1":
 			case "o1-preview":
-			case "o1-mini": {
+			case "o1-mini":
+			case "o3-mini": {
 				// o1 doesnt support streaming, non-1 temp, or system prompt
 				const response = await this.client.chat.completions.create({
 					model: this.getModel().id,

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -347,6 +347,14 @@ export const openAiNativeModels = {
 		inputPrice: 3,
 		outputPrice: 12,
 	},
+	"o3-mini": {
+		maxTokens: 100_000,
+		contextWindow: 200_000,
+		supportsImages: true,
+		supportsPromptCache: false,
+		inputPrice: 1.1,
+		outputPrice: 4.4,
+	},
 	"gpt-4o": {
 		maxTokens: 4_096,
 		contextWindow: 128_000,


### PR DESCRIPTION
### Description

Add support for OpenAI's o3-mini model, which offers a larger context window and token limit compared to o1-mini. This model provides:
- 100k max tokens capacity
- 200k context window
- Support for image input
- Pricing at $1.1/M input tokens and $4.4/M output tokens

The implementation includes both the model configuration and handler support for processing requests.

### Test Procedure

- Added o3-mini model configuration with appropriate token limits and context window
- Added o3-mini case to OpenAI native handler's switch statement for request processing
- Verified model configuration matches OpenAI's specifications
- Ran format and lint checks which passed successfully

### Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update

### Pre-flight Checklist

- [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
- [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
- [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Additional Notes

- This implementation was discussed and planned in #1578.
- Note, I do not have access to the model so someone who does needs to test.  Right now I get `404 The model `o3-mini` does not exist or you do not have access to it.`
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add support for OpenAI's `o3-mini` model with specific configurations and pricing in `openai-native.ts` and `api.ts`.
> 
>   - **Behavior**:
>     - Add support for `o3-mini` model in `OpenAiNativeHandler` in `openai-native.ts`.
>     - `o3-mini` supports 100k max tokens, 200k context window, and image input.
>     - Pricing set at $1.1/M input tokens and $4.4/M output tokens.
>   - **Configuration**:
>     - Add `o3-mini` model configuration in `api.ts` with specified token limits and context window.
>     - Include `o3-mini` in the switch statement for request processing in `openai-native.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for ed21c3e8e64be2cac701518a5220fb29e3c6c974. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->