### PR TITLE
feat: code block copy button

### DIFF
--- a/.changeset/code-block-copy-button.md
+++ b/.changeset/code-block-copy-button.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": minor
+---
+
+Add code block copy button

--- a/.changeset/yellow-paws-chew.md
+++ b/.changeset/yellow-paws-chew.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": minor
+---
+
+ADD IS_DEV and Hot Reloading to debug

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,7 +11,11 @@
 			"request": "launch",
 			"args": ["--extensionDevelopmentPath=${workspaceFolder}"],
 			"outFiles": ["${workspaceFolder}/dist/**/*.js"],
-			"preLaunchTask": "${defaultBuildTask}"
+			"preLaunchTask": "${defaultBuildTask}",
+			"env": {
+				"IS_DEV": "true",
+				"DEV_WORKSPACE_FOLDER": "${workspaceFolder}"
+			}
 		}
 	]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -24,6 +24,11 @@
 			"presentation": {
 				"group": "watch",
 				"reveal": "never"
+			},
+			"options": {
+				"env": {
+					"IS_DEV": "true"
+				}
 			}
 		},
 		{

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [3.4.9]
+
+-   Add toggle to let users opt-in to anonymous telemetry and error reporting
+
 ## [3.4.6]
 
 -   Add support for Claude 3.7 Sonnet

--- a/docs/PRIVACY.md
+++ b/docs/PRIVACY.md
@@ -42,8 +42,8 @@ Cline functions solely as a client-side VS Code extension that facilitates commu
 1. **Local-Only Processing**:
 
     - All operations happen on your local machine
-    - No central servers or data collection
-    - No telemetry or usage statistics gathered
+    - No central servers or data collection by default
+    - Anonymous telemetry and usage statistics are only collected if you explicitly opt in
     - No account creation required
 
 2. **API Key Security**:
@@ -73,7 +73,8 @@ When you request assistance:
 
 -   Error logs are processed locally
 -   No automatic error reporting to Cline
--   You control what information to include when reporting issues
+    - Optional anonymous telemetry and error reporting via PostHog if you opt in
+-   You control what information to include when manually reporting issues
 
 ## Children's Privacy
 
@@ -89,6 +90,22 @@ We will post any changes to this policy on our GitHub repository. Significant ch
 -   Our client-side architecture ensures no central point of data collection
 -   You can inspect exactly what data is being sent to AI providers
 -   Enterprise users can implement additional access controls through VS Code
+
+## Telemetry & Usage Statistics
+
+If you choose to opt in to anonymous telemetry:
+
+-   Basic usage statistics and error reports are collected via PostHog
+-   A stable, anonymous identifier (VS Code's `machineId`) is used to understand unique usage patterns
+    - This identifier is not linked to any personal information
+    - It helps us understand how features are used across sessions
+    - It cannot be used to identify you personally
+-   All data is anonymized and cannot be linked to individual users
+-   No code content or sensitive information is ever included
+-   You can opt out at any time through:
+    - VS Code Settings > Cline > Enable Telemetry
+    - VS Code Settings > Telemetry > Telemetry Level (setting this to anything other than "all" will disable Cline's telemetry)
+-   Collected data helps us improve the extension's functionality and stability
 
 ## Contact Us
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "claude-dev",
-	"version": "3.4.6",
+	"version": "3.4.8",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "claude-dev",
-			"version": "3.4.6",
+			"version": "3.4.8",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@anthropic-ai/bedrock-sdk": "^0.10.2",
@@ -40,6 +40,7 @@
 				"os-name": "^6.0.0",
 				"p-wait-for": "^5.0.2",
 				"pdf-parse": "^1.1.1",
+				"posthog-node": "^4.7.0",
 				"puppeteer-chromium-resolver": "^23.0.0",
 				"puppeteer-core": "^23.4.0",
 				"serialize-error": "^11.0.3",
@@ -11604,6 +11605,18 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.4"
+			}
+		},
+		"node_modules/posthog-node": {
+			"version": "4.7.0",
+			"resolved": "https://registry.npmjs.org/posthog-node/-/posthog-node-4.7.0.tgz",
+			"integrity": "sha512-RgdUKSW8MfMOkjUa8cYVqWndNjPePNuuxlGbrZC6z1WRBsVc6TdGl8caidmC10RW8mu/BOfmrGbP4cRTo2jARg==",
+			"license": "MIT",
+			"dependencies": {
+				"axios": "^1.7.4"
+			},
+			"engines": {
+				"node": ">=15.0.0"
 			}
 		},
 		"node_modules/prelude-ls": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "claude-dev",
 	"displayName": "Cline",
 	"description": "Autonomous coding agent right in your IDE, capable of creating/editing files, running commands, using the browser, and more with your permission every step of the way.",
-	"version": "3.4.7",
+	"version": "3.4.8",
 	"icon": "assets/icons/icon.png",
 	"galleryBanner": {
 		"color": "#617A91",

--- a/package.json
+++ b/package.json
@@ -186,11 +186,6 @@
 					"type": "boolean",
 					"default": true,
 					"description": "Controls whether the MCP Marketplace is enabled."
-				},
-				"cline.enableTelemetry": {
-					"type": "boolean",
-					"default": null,
-					"markdownDescription": "Allow anonymous usage and error reporting to help improve Cline. No code, prompts, or personal information is ever sent. See our [privacy policy](https://github.com/cline/cline/blob/main/docs/PRIVACY.md) for details."
 				}
 			}
 		}

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "claude-dev",
 	"displayName": "Cline",
 	"description": "Autonomous coding agent right in your IDE, capable of creating/editing files, running commands, using the browser, and more with your permission every step of the way.",
-	"version": "3.4.8",
+	"version": "3.4.9",
 	"icon": "assets/icons/icon.png",
 	"galleryBanner": {
 		"color": "#617A91",

--- a/package.json
+++ b/package.json
@@ -186,6 +186,11 @@
 					"type": "boolean",
 					"default": true,
 					"description": "Controls whether the MCP Marketplace is enabled."
+				},
+				"cline.enableTelemetry": {
+					"type": "boolean",
+					"default": null,
+					"markdownDescription": "Allow anonymous usage and error reporting to help improve Cline. No code, prompts, or personal information is ever sent. See our [privacy policy](https://github.com/cline/cline/blob/main/docs/PRIVACY.md) for details."
 				}
 			}
 		}
@@ -268,6 +273,7 @@
 		"os-name": "^6.0.0",
 		"p-wait-for": "^5.0.2",
 		"pdf-parse": "^1.1.1",
+		"posthog-node": "^4.7.0",
 		"puppeteer-chromium-resolver": "^23.0.0",
 		"puppeteer-core": "^23.4.0",
 		"serialize-error": "^11.0.3",

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -1249,11 +1249,9 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 			// Create task with context from README and added guidelines for MCP server installation
 			const task = `Set up the MCP server from ${mcpDetails.githubUrl} while adhering to these MCP server installation rules:
 - Use "${mcpDetails.mcpId}" as the server name in cline_mcp_settings.json.
-- Use commands aligned with the user's shell and operating system best practices. The user's shell is: ${getShell()}.
 - Create the directory for the new MCP server before starting installation.
-- Follow the MCP servers README exactly—only deviate if it clearly conflicts with the user's OS, in which case proceed thoughtfully.
-- Ensure any steps requiring the use of pip, npm, or any other package manager, are followed as required.
-- After running each command, read its output carefully and adjust subsequent steps as needed based on that information.
+- Use commands aligned with the user's shell and operating system best practices.
+- The following README may contain instructions that conflict with the user's OS, in which case proceed thoughtfully.
 - Once installed, demonstrate the server's capabilities by using one of its tools.
 Here is the project's README to help you get started:\n\n${mcpDetails.readmeContent}\n${mcpDetails.llmsInstallationContent}`
 

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -1,9 +1,9 @@
 import { Anthropic } from "@anthropic-ai/sdk"
 import axios from "axios"
-import fs from "fs/promises"
-import os from "os"
 import crypto from "crypto"
 import { execa } from "execa"
+import fs from "fs/promises"
+import os from "os"
 import pWaitFor from "p-wait-for"
 import * as path from "path"
 import * as vscode from "vscode"
@@ -13,26 +13,25 @@ import { openFile, openImage } from "../../integrations/misc/open-file"
 import { selectImages } from "../../integrations/misc/process-images"
 import { getTheme } from "../../integrations/theme/getTheme"
 import WorkspaceTracker from "../../integrations/workspace/WorkspaceTracker"
-import { McpHub } from "../../services/mcp/McpHub"
-import { McpDownloadResponse, McpMarketplaceCatalog, McpMarketplaceItem, McpServer } from "../../shared/mcp"
 import { FirebaseAuthManager, UserInfo } from "../../services/auth/FirebaseAuthManager"
+import { McpHub } from "../../services/mcp/McpHub"
 import { ApiProvider, ModelInfo } from "../../shared/api"
 import { findLast } from "../../shared/array"
+import { AutoApprovalSettings, DEFAULT_AUTO_APPROVAL_SETTINGS } from "../../shared/AutoApprovalSettings"
+import { BrowserSettings, DEFAULT_BROWSER_SETTINGS } from "../../shared/BrowserSettings"
+import { ChatContent } from "../../shared/ChatContent"
+import { ChatSettings, DEFAULT_CHAT_SETTINGS } from "../../shared/ChatSettings"
 import { ExtensionMessage, ExtensionState, Platform } from "../../shared/ExtensionMessage"
 import { HistoryItem } from "../../shared/HistoryItem"
+import { McpDownloadResponse, McpMarketplaceCatalog, McpServer } from "../../shared/mcp"
 import { ClineCheckpointRestore, WebviewMessage } from "../../shared/WebviewMessage"
 import { fileExistsAtPath } from "../../utils/fs"
+import { searchCommits } from "../../utils/git"
 import { Cline } from "../Cline"
 import { openMention } from "../mentions"
 import { getNonce } from "./getNonce"
 import { getUri } from "./getUri"
-import { AutoApprovalSettings, DEFAULT_AUTO_APPROVAL_SETTINGS } from "../../shared/AutoApprovalSettings"
-import { BrowserSettings, DEFAULT_BROWSER_SETTINGS } from "../../shared/BrowserSettings"
-import { ChatSettings, DEFAULT_CHAT_SETTINGS } from "../../shared/ChatSettings"
-import { DIFF_VIEW_URI_SCHEME } from "../../integrations/editor/DiffViewProvider"
-import { searchCommits } from "../../utils/git"
-import { ChatContent } from "../../shared/ChatContent"
-import { getShell } from "../../utils/shell"
+import { telemetryService } from "../../services/telemetry/TelemetryService"
 
 /*
 https://github.com/microsoft/vscode-webview-ui-toolkit-samples/blob/main/default/weather-webview/src/providers/WeatherViewProvider.ts
@@ -280,6 +279,16 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 			task,
 			images,
 		)
+
+		// New task started
+		if (telemetryService.isTelemetryEnabled()) {
+			telemetryService.capture({
+				event: "New task started",
+				properties: {
+					apiProvider: apiConfiguration.apiProvider,
+				},
+			})
+		}
 	}
 
 	async initClineWithHistoryItem(historyItem: HistoryItem) {
@@ -827,6 +836,21 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 							"workbench.action.openSettings",
 							`@ext:saoudrizwan.claude-dev ${settingsFilter}`.trim(), // trim whitespace if no settings filter
 						)
+						break
+					}
+					// telemetry
+					case "openTelemetrySettings": {
+						await vscode.commands.executeCommand(
+							"workbench.action.openSettings",
+							"@ext:saoudrizwan.claude-dev cline.telemetryOptIn",
+						)
+						break
+					}
+					case "telemetryOptIn": {
+						if (message.bool !== undefined) {
+							await vscode.workspace.getConfiguration("cline").update("enableTelemetry", message.bool, true)
+							await this.postStateToWebview()
+						}
 						break
 					}
 					// Add more switch case statements here as more webview message commands
@@ -1594,6 +1618,7 @@ Here is the project's README to help you get started:\n\n${mcpDetails.readmeCont
 			userInfo,
 			authToken,
 			mcpMarketplaceEnabled,
+			telemetryOptIn,
 		} = await this.getState()
 
 		return {
@@ -1613,6 +1638,7 @@ Here is the project's README to help you get started:\n\n${mcpDetails.readmeCont
 			isLoggedIn: !!authToken,
 			userInfo,
 			mcpMarketplaceEnabled,
+			telemetryOptIn,
 		}
 	}
 
@@ -1791,6 +1817,7 @@ Here is the project's README to help you get started:\n\n${mcpDetails.readmeCont
 			.get("reasoningEffort", "medium")
 
 		const mcpMarketplaceEnabled = vscode.workspace.getConfiguration("cline").get<boolean>("mcpMarketplace.enabled", true)
+		const telemetryOptIn = vscode.workspace.getConfiguration("cline").get<boolean | null>("enableTelemetry", null)
 
 		return {
 			apiConfiguration: {
@@ -1847,6 +1874,7 @@ Here is the project's README to help you get started:\n\n${mcpDetails.readmeCont
 			previousModeModelId,
 			previousModeModelInfo,
 			mcpMarketplaceEnabled,
+			telemetryOptIn,
 		}
 	}
 

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -306,6 +306,16 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 			undefined,
 			historyItem,
 		)
+
+		// Open task from history
+		if (telemetryService.isTelemetryEnabled()) {
+			telemetryService.capture({
+				event: "Open task from history",
+				properties: {
+					apiProvider: apiConfiguration.apiProvider,
+				},
+			})
+		}
 	}
 
 	// Send any JSON serializable data to the react app

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,6 +7,7 @@ import { Logger } from "./services/logging/Logger"
 import { createClineAPI } from "./exports"
 import "./utils/path" // necessary to have access to String.prototype.toPosix
 import { DIFF_VIEW_URI_SCHEME } from "./integrations/editor/DiffViewProvider"
+import assert from "node:assert"
 
 /*
 Built using https://github.com/microsoft/vscode-webview-ui-toolkit
@@ -189,4 +190,23 @@ export function activate(context: vscode.ExtensionContext) {
 // This method is called when your extension is deactivated
 export function deactivate() {
 	Logger.log("Cline extension deactivated")
+}
+
+// TODO: Find a solution for automatically removing DEV related content from production builds.
+//  This type of code is fine in production to keep. We just will want to remove it from production builds
+//  to bring down built asset sizes.
+//
+// This is a workaround to reload the extension when the source code changes
+// since vscode doesn't support hot reload for extensions
+const { IS_DEV, DEV_WORKSPACE_FOLDER } = process.env
+
+if (IS_DEV && IS_DEV !== "false") {
+	assert(DEV_WORKSPACE_FOLDER, "DEV_WORKSPACE_FOLDER must be set in development")
+	const watcher = vscode.workspace.createFileSystemWatcher(new vscode.RelativePattern(DEV_WORKSPACE_FOLDER, "src/**/*"))
+
+	watcher.onDidChange(({ scheme, path }) => {
+		console.info(`${scheme} ${path} changed. Reloading VSCode...`)
+
+		vscode.commands.executeCommand("workbench.action.reloadWindow")
+	})
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,6 +8,7 @@ import { createClineAPI } from "./exports"
 import "./utils/path" // necessary to have access to String.prototype.toPosix
 import { DIFF_VIEW_URI_SCHEME } from "./integrations/editor/DiffViewProvider"
 import assert from "node:assert"
+import { telemetryService } from "./services/telemetry/TelemetryService"
 
 /*
 Built using https://github.com/microsoft/vscode-webview-ui-toolkit
@@ -189,6 +190,7 @@ export function activate(context: vscode.ExtensionContext) {
 
 // This method is called when your extension is deactivated
 export function deactivate() {
+	telemetryService.shutdown()
 	Logger.log("Cline extension deactivated")
 }
 

--- a/src/services/telemetry/TelemetryService.ts
+++ b/src/services/telemetry/TelemetryService.ts
@@ -1,0 +1,73 @@
+import { PostHog } from "posthog-node"
+import * as vscode from "vscode"
+
+class PostHogClient {
+	private static instance: PostHogClient
+	private client: PostHog
+	private distinctId: string = vscode.env.machineId
+	private telemetryEnabled: boolean = false
+
+	private constructor() {
+		this.client = new PostHog("phc_qfOAGxZw2TL5O8p9KYd9ak3bPBFzfjC8fy5L6jNWY7K", {
+			host: "https://us.i.posthog.com",
+			enableExceptionAutocapture: false,
+		})
+
+		// Initialize telemetry state based on user settings
+		this.updateTelemetryState()
+
+		// Listen for settings changes
+		vscode.workspace.onDidChangeConfiguration((e) => {
+			if (e.affectsConfiguration("cline.enableTelemetry") || e.affectsConfiguration("telemetry.telemetryLevel")) {
+				this.updateTelemetryState()
+			}
+		})
+	}
+
+	private updateTelemetryState(): void {
+		// First check global telemetry level - telemetry should only be enabled when level is "all"
+		const telemetryLevel = vscode.workspace.getConfiguration("telemetry").get<string>("telemetryLevel", "all")
+		const globalTelemetryEnabled = telemetryLevel === "all"
+
+		// Only check Cline setting if global telemetry is enabled
+		if (globalTelemetryEnabled) {
+			const clineOptIn = vscode.workspace.getConfiguration("cline").get<boolean | null>("enableTelemetry", null)
+			this.telemetryEnabled = clineOptIn === true
+		}
+
+		// Update PostHog client state based on telemetry preference
+		if (this.telemetryEnabled) {
+			this.client.optIn()
+			// console.log("Telemetry enabled")
+		} else {
+			this.client.optOut()
+			// console.log("Telemetry disabled")
+		}
+	}
+
+	public static getInstance(): PostHogClient {
+		if (!PostHogClient.instance) {
+			PostHogClient.instance = new PostHogClient()
+		}
+		return PostHogClient.instance
+	}
+
+	public capture(event: { event: string; properties?: any }): void {
+		// Only send events if telemetry is enabled
+		if (this.telemetryEnabled) {
+			this.client.capture({ distinctId: this.distinctId, event: event.event, properties: event.properties })
+			// console.log("Captured event", { distinctId: this.distinctId, event: event.event, properties: event.properties })
+		}
+	}
+
+	public isTelemetryEnabled(): boolean {
+		return this.telemetryEnabled
+	}
+
+	public async shutdown(): Promise<void> {
+		await this.client.shutdown()
+	}
+}
+
+// Export a single instance
+export const telemetryService = PostHogClient.getInstance()

--- a/src/services/telemetry/TelemetryService.ts
+++ b/src/services/telemetry/TelemetryService.ts
@@ -25,6 +25,8 @@ class PostHogClient {
 	}
 
 	private updateTelemetryState(): void {
+		this.telemetryEnabled = false
+
 		// First check global telemetry level - telemetry should only be enabled when level is "all"
 		const telemetryLevel = vscode.workspace.getConfiguration("telemetry").get<string>("telemetryLevel", "all")
 		const globalTelemetryEnabled = telemetryLevel === "all"

--- a/src/services/telemetry/TelemetryService.ts
+++ b/src/services/telemetry/TelemetryService.ts
@@ -12,29 +12,18 @@ class PostHogClient {
 			host: "https://us.i.posthog.com",
 			enableExceptionAutocapture: false,
 		})
-
-		// Initialize telemetry state based on user settings
-		this.updateTelemetryState()
-
-		// Listen for settings changes
-		vscode.workspace.onDidChangeConfiguration((e) => {
-			if (e.affectsConfiguration("cline.enableTelemetry") || e.affectsConfiguration("telemetry.telemetryLevel")) {
-				this.updateTelemetryState()
-			}
-		})
 	}
 
-	private updateTelemetryState(): void {
+	public updateTelemetryState(didUserOptIn: boolean): void {
 		this.telemetryEnabled = false
 
 		// First check global telemetry level - telemetry should only be enabled when level is "all"
 		const telemetryLevel = vscode.workspace.getConfiguration("telemetry").get<string>("telemetryLevel", "all")
 		const globalTelemetryEnabled = telemetryLevel === "all"
 
-		// Only check Cline setting if global telemetry is enabled
+		// We only enable telemetry if global vscode telemetry is enabled
 		if (globalTelemetryEnabled) {
-			const clineOptIn = vscode.workspace.getConfiguration("cline").get<boolean | null>("enableTelemetry", null)
-			this.telemetryEnabled = clineOptIn === true
+			this.telemetryEnabled = didUserOptIn
 		}
 
 		// Update PostHog client state based on telemetry preference

--- a/src/shared/ExtensionMessage.ts
+++ b/src/shared/ExtensionMessage.ts
@@ -81,6 +81,7 @@ export interface ExtensionState {
 		photoURL: string | null
 	}
 	mcpMarketplaceEnabled?: boolean
+	telemetryOptIn: boolean | null
 }
 
 export interface ClineMessage {

--- a/src/shared/ExtensionMessage.ts
+++ b/src/shared/ExtensionMessage.ts
@@ -7,6 +7,7 @@ import { BrowserSettings } from "./BrowserSettings"
 import { ChatSettings } from "./ChatSettings"
 import { HistoryItem } from "./HistoryItem"
 import { McpServer, McpMarketplaceCatalog, McpMarketplaceItem, McpDownloadResponse } from "./mcp"
+import { TelemetrySetting } from "./TelemetrySetting"
 
 // webview will hold state
 export interface ExtensionMessage {
@@ -81,7 +82,7 @@ export interface ExtensionState {
 		photoURL: string | null
 	}
 	mcpMarketplaceEnabled?: boolean
-	telemetryOptIn: boolean | null
+	telemetrySetting: TelemetrySetting
 }
 
 export interface ClineMessage {

--- a/src/shared/TelemetrySetting.ts
+++ b/src/shared/TelemetrySetting.ts
@@ -1,0 +1,1 @@
+export type TelemetrySetting = "unset" | "enabled" | "disabled"

--- a/src/shared/WebviewMessage.ts
+++ b/src/shared/WebviewMessage.ts
@@ -50,8 +50,8 @@ export interface WebviewMessage {
 		| "searchCommits"
 		| "showMcpView"
 		| "fetchLatestMcpServersFromHub"
-		| "telemetryOptIn"
-		| "openTelemetrySettings"
+		| "telemetrySetting"
+		| "openSettings"
 	// | "relaunchChromeDebugMode"
 	text?: string
 	disabled?: boolean

--- a/src/shared/WebviewMessage.ts
+++ b/src/shared/WebviewMessage.ts
@@ -50,6 +50,8 @@ export interface WebviewMessage {
 		| "searchCommits"
 		| "showMcpView"
 		| "fetchLatestMcpServersFromHub"
+		| "telemetryOptIn"
+		| "openTelemetrySettings"
 	// | "relaunchChromeDebugMode"
 	text?: string
 	disabled?: boolean

--- a/webview-ui/scripts/build-react-no-split.js
+++ b/webview-ui/scripts/build-react-no-split.js
@@ -12,6 +12,7 @@
 const rewire = require("rewire")
 const defaults = rewire("react-scripts/scripts/build.js")
 const config = defaults.__get__("config")
+const webpack = require("webpack")
 
 /* Modifying Webpack Configuration for 'shared' dir
 This section uses Rewire to modify Create React App's webpack configuration without ejecting. Rewire allows us to inject and alter the internal build scripts of CRA at runtime. This allows us to maintain a flexible project structure that keeps shared code outside the webview-ui/src directory, while still adhering to CRA's security model that typically restricts imports to within src/. 
@@ -118,6 +119,15 @@ config.output = {
 	...config.output,
 	filename: "static/js/[name].js",
 }
+
+// Adjust build environment variables for dev/debug builds.
+config.plugins[4] = new webpack.DefinePlugin({
+	"process.env": {
+		...config.plugins[4].definitions["process.env"],
+		NODE_ENV: JSON.stringify(process.env.IS_DEV ? "development" : "production"),
+		IS_DEV: JSON.stringify(process.env.IS_DEV),
+	},
+})
 
 // Rename main.{hash}.css to main.css
 config.plugins[5].options.filename = "static/css/[name].css"

--- a/webview-ui/src/components/chat/BrowserSessionRow.tsx
+++ b/webview-ui/src/components/chat/BrowserSessionRow.tsx
@@ -473,7 +473,7 @@ const BrowserSessionRowContent = ({
 						overflow: "hidden",
 						backgroundColor: CODE_BLOCK_BG_COLOR,
 					}}>
-					<CodeBlock source={`${"```"}shell\n${message.text}\n${"```"}`} forceWrap={true} />
+					<CodeBlock source={`${"```"}shell\n${message.text}\n${"```"}`} />
 				</div>
 			</>
 		)

--- a/webview-ui/src/components/chat/ChatRow.tsx
+++ b/webview-ui/src/components/chat/ChatRow.tsx
@@ -581,7 +581,7 @@ export const ChatRowContent = ({ message, isExpanded, onToggleExpand, lastModifi
 						overflow: "hidden",
 						backgroundColor: CODE_BLOCK_BG_COLOR,
 					}}>
-					<CodeBlock source={`${"```"}shell\n${command}\n${"```"}`} forceWrap={true} />
+					<CodeBlock source={`${"```"}shell\n${command}\n${"```"}`} />
 					{output.length > 0 && (
 						<div style={{ width: "100%" }}>
 							<div

--- a/webview-ui/src/components/chat/ChatView.tsx
+++ b/webview-ui/src/components/chat/ChatView.tsx
@@ -38,7 +38,7 @@ interface ChatViewProps {
 export const MAX_IMAGES_PER_MESSAGE = 20 // Anthropic limits to 20 images
 
 const ChatView = ({ isHidden, showAnnouncement, hideAnnouncement, showHistoryView }: ChatViewProps) => {
-	const { version, clineMessages: messages, taskHistory, apiConfiguration, telemetryOptIn } = useExtensionState()
+	const { version, clineMessages: messages, taskHistory, apiConfiguration, telemetrySetting } = useExtensionState()
 
 	//const task = messages.length > 0 ? (messages[0].say === "task" ? messages[0] : undefined) : undefined) : undefined
 	const task = useMemo(() => messages.at(0), [messages]) // leaving this less safe version here since if the first message is not a task, then the extension is in a bad state and needs to be debugged (see Cline.abort)
@@ -790,7 +790,7 @@ const ChatView = ({ isHidden, showAnnouncement, hideAnnouncement, showHistoryVie
 						flexDirection: "column",
 						paddingBottom: "10px",
 					}}>
-					{telemetryOptIn === null && <TelemetryBanner />}
+					{telemetrySetting === "unset" && <TelemetryBanner />}
 
 					{showAnnouncement && <Announcement version={version} hideAnnouncement={hideAnnouncement} />}
 					<div style={{ padding: "0 20px", flexShrink: 0 }}>

--- a/webview-ui/src/components/chat/ChatView.tsx
+++ b/webview-ui/src/components/chat/ChatView.tsx
@@ -26,6 +26,7 @@ import BrowserSessionRow from "./BrowserSessionRow"
 import ChatRow from "./ChatRow"
 import ChatTextArea from "./ChatTextArea"
 import TaskHeader from "./TaskHeader"
+import TelemetryBanner from "../common/TelemetryBanner"
 
 interface ChatViewProps {
 	isHidden: boolean
@@ -37,7 +38,7 @@ interface ChatViewProps {
 export const MAX_IMAGES_PER_MESSAGE = 20 // Anthropic limits to 20 images
 
 const ChatView = ({ isHidden, showAnnouncement, hideAnnouncement, showHistoryView }: ChatViewProps) => {
-	const { version, clineMessages: messages, taskHistory, apiConfiguration } = useExtensionState()
+	const { version, clineMessages: messages, taskHistory, apiConfiguration, telemetryOptIn } = useExtensionState()
 
 	//const task = messages.length > 0 ? (messages[0].say === "task" ? messages[0] : undefined) : undefined) : undefined
 	const task = useMemo(() => messages.at(0), [messages]) // leaving this less safe version here since if the first message is not a task, then the extension is in a bad state and needs to be debugged (see Cline.abort)
@@ -789,6 +790,8 @@ const ChatView = ({ isHidden, showAnnouncement, hideAnnouncement, showHistoryVie
 						flexDirection: "column",
 						paddingBottom: "10px",
 					}}>
+					{telemetryOptIn === null && <TelemetryBanner />}
+
 					{showAnnouncement && <Announcement version={version} hideAnnouncement={hideAnnouncement} />}
 					<div style={{ padding: "0 20px", flexShrink: 0 }}>
 						<h2>What can I do for you?</h2>

--- a/webview-ui/src/components/common/CodeBlock.tsx
+++ b/webview-ui/src/components/common/CodeBlock.tsx
@@ -78,7 +78,7 @@ const CodeBlockContainer = styled.div`
 	}
 `
 
-const StyledMarkdown = styled.div<{ preStyle?: React.CSSProperties }>`
+const StyledMarkdown = styled.div<{ preStyle?: React.CSSProperties; wordwrap?: boolean }>`
 	overflow-x: auto;
 	width: 100%;
 
@@ -95,9 +95,9 @@ const StyledMarkdown = styled.div<{ preStyle?: React.CSSProperties }>`
 
 	pre,
 	code {
-		white-space: pre-wrap;
-		word-break: normal;
-		overflow-wrap: break-word;
+		white-space: ${({ wordwrap }) => (wordwrap === false ? "pre" : "pre-wrap")};
+		word-break: ${({ wordwrap }) => (wordwrap === false ? "normal" : "normal")};
+		overflow-wrap: ${({ wordwrap }) => (wordwrap === false ? "normal" : "break-word")};
 	}
 
 	pre > code {
@@ -274,7 +274,9 @@ const CodeBlock = memo(({ source, language, preStyle }: CodeBlockProps) => {
 
 	return (
 		<CodeBlockContainer ref={codeBlockRef}>
-			<StyledMarkdown preStyle={preStyle}>{reactContent}</StyledMarkdown>
+			<StyledMarkdown preStyle={preStyle} wordwrap={true}>
+				{reactContent}
+			</StyledMarkdown>
 			<CopyButtonWrapper
 				onMouseEnter={() => updateCopyButtonPosition(true)}
 				onMouseLeave={() => updateCopyButtonPosition()}>

--- a/webview-ui/src/components/common/TelemetryBanner.tsx
+++ b/webview-ui/src/components/common/TelemetryBanner.tsx
@@ -1,0 +1,70 @@
+import { VSCodeButton, VSCodeLink } from "@vscode/webview-ui-toolkit/react"
+import { memo, useState } from "react"
+import styled from "styled-components"
+import { vscode } from "../../utils/vscode"
+
+const BannerContainer = styled.div`
+	background-color: var(--vscode-banner-background);
+	padding: 12px 20px;
+	display: flex;
+	flex-direction: column;
+	gap: 10px;
+	flex-shrink: 0;
+`
+
+const ButtonContainer = styled.div`
+	display: flex;
+	gap: 8px;
+	width: 100%;
+
+	& > vscode-button {
+		flex: 1;
+	}
+`
+
+const TelemetryBanner = () => {
+	const [hasChosen, setHasChosen] = useState(false)
+
+	const handleAllow = () => {
+		setHasChosen(true)
+		vscode.postMessage({ type: "telemetryOptIn", bool: true })
+	}
+
+	const handleDeny = () => {
+		setHasChosen(true)
+		vscode.postMessage({ type: "telemetryOptIn", bool: false })
+	}
+
+	const handleOpenSettings = () => {
+		vscode.postMessage({ type: "openTelemetrySettings" })
+	}
+
+	return (
+		<BannerContainer>
+			<div>
+				<strong>Help Improve Cline</strong>
+				<div style={{ marginTop: 4 }}>
+					Send anonymous error and usage data to help us fix bugs and improve the extension. No code, prompts, or
+					personal information is ever sent.
+					<div style={{ marginTop: 4 }}>
+						You can always change this in{" "}
+						<VSCodeLink href="#" onClick={handleOpenSettings}>
+							settings
+						</VSCodeLink>
+						.
+					</div>
+				</div>
+			</div>
+			<ButtonContainer>
+				<VSCodeButton appearance="primary" onClick={handleAllow} disabled={hasChosen}>
+					Allow
+				</VSCodeButton>
+				<VSCodeButton appearance="secondary" onClick={handleDeny} disabled={hasChosen}>
+					Deny
+				</VSCodeButton>
+			</ButtonContainer>
+		</BannerContainer>
+	)
+}
+
+export default memo(TelemetryBanner)

--- a/webview-ui/src/components/common/TelemetryBanner.tsx
+++ b/webview-ui/src/components/common/TelemetryBanner.tsx
@@ -2,6 +2,7 @@ import { VSCodeButton, VSCodeLink } from "@vscode/webview-ui-toolkit/react"
 import { memo, useState } from "react"
 import styled from "styled-components"
 import { vscode } from "../../utils/vscode"
+import { TelemetrySetting } from "../../../../src/shared/TelemetrySetting"
 
 const BannerContainer = styled.div`
 	background-color: var(--vscode-banner-background);
@@ -10,6 +11,7 @@ const BannerContainer = styled.div`
 	flex-direction: column;
 	gap: 10px;
 	flex-shrink: 0;
+	margin-bottom: 6px;
 `
 
 const ButtonContainer = styled.div`
@@ -27,16 +29,16 @@ const TelemetryBanner = () => {
 
 	const handleAllow = () => {
 		setHasChosen(true)
-		vscode.postMessage({ type: "telemetryOptIn", bool: true })
+		vscode.postMessage({ type: "telemetrySetting", text: "enabled" satisfies TelemetrySetting })
 	}
 
 	const handleDeny = () => {
 		setHasChosen(true)
-		vscode.postMessage({ type: "telemetryOptIn", bool: false })
+		vscode.postMessage({ type: "telemetrySetting", text: "disabled" satisfies TelemetrySetting })
 	}
 
 	const handleOpenSettings = () => {
-		vscode.postMessage({ type: "openTelemetrySettings" })
+		vscode.postMessage({ type: "openSettings" })
 	}
 
 	return (

--- a/webview-ui/src/components/settings/SettingsView.tsx
+++ b/webview-ui/src/components/settings/SettingsView.tsx
@@ -5,7 +5,7 @@ import { validateApiConfiguration, validateModelId } from "../../utils/validate"
 import { vscode } from "../../utils/vscode"
 import ApiOptions from "./ApiOptions"
 import SettingsButton from "../common/SettingsButton"
-const IS_DEV = false // FIXME: use flags when packaging
+const { IS_DEV } = process.env
 
 type SettingsViewProps = {
 	onDone: () => void

--- a/webview-ui/src/components/settings/SettingsView.tsx
+++ b/webview-ui/src/components/settings/SettingsView.tsx
@@ -1,10 +1,10 @@
-import { VSCodeButton, VSCodeLink, VSCodeTextArea } from "@vscode/webview-ui-toolkit/react"
+import { VSCodeButton, VSCodeCheckbox, VSCodeLink, VSCodeTextArea } from "@vscode/webview-ui-toolkit/react"
 import { memo, useEffect, useState } from "react"
 import { useExtensionState } from "../../context/ExtensionStateContext"
 import { validateApiConfiguration, validateModelId } from "../../utils/validate"
 import { vscode } from "../../utils/vscode"
-import ApiOptions from "./ApiOptions"
 import SettingsButton from "../common/SettingsButton"
+import ApiOptions from "./ApiOptions"
 const { IS_DEV } = process.env
 
 type SettingsViewProps = {
@@ -12,7 +12,15 @@ type SettingsViewProps = {
 }
 
 const SettingsView = ({ onDone }: SettingsViewProps) => {
-	const { apiConfiguration, version, customInstructions, setCustomInstructions, openRouterModels } = useExtensionState()
+	const {
+		apiConfiguration,
+		version,
+		customInstructions,
+		setCustomInstructions,
+		openRouterModels,
+		telemetrySetting,
+		setTelemetrySetting,
+	} = useExtensionState()
 	const [apiErrorMessage, setApiErrorMessage] = useState<string | undefined>(undefined)
 	const [modelIdErrorMessage, setModelIdErrorMessage] = useState<string | undefined>(undefined)
 
@@ -28,6 +36,10 @@ const SettingsView = ({ onDone }: SettingsViewProps) => {
 			vscode.postMessage({
 				type: "customInstructions",
 				text: customInstructions,
+			})
+			vscode.postMessage({
+				type: "telemetrySetting",
+				text: telemetrySetting,
 			})
 			onDone()
 		}
@@ -111,6 +123,33 @@ const SettingsView = ({ onDone }: SettingsViewProps) => {
 							color: "var(--vscode-descriptionForeground)",
 						}}>
 						These instructions are added to the end of the system prompt sent with every request.
+					</p>
+				</div>
+
+				<div style={{ marginBottom: 5 }}>
+					<VSCodeCheckbox
+						style={{ marginBottom: "5px" }}
+						checked={telemetrySetting === "enabled"}
+						onChange={(e: any) => {
+							const checked = e.target.checked === true
+							setTelemetrySetting(checked ? "enabled" : "disabled")
+						}}>
+						Allow anonymous error and usage reporting
+					</VSCodeCheckbox>
+					<p
+						style={{
+							fontSize: "12px",
+							marginTop: "5px",
+							color: "var(--vscode-descriptionForeground)",
+						}}>
+						Help improve Cline by sending anonymous usage data and error reports. No code, prompts, or personal
+						information is ever sent. See our{" "}
+						<VSCodeLink
+							href="https://github.com/cline/cline/blob/main/docs/PRIVACY.md"
+							style={{ fontSize: "inherit" }}>
+							privacy policy
+						</VSCodeLink>{" "}
+						for more details.
 					</p>
 				</div>
 

--- a/webview-ui/src/context/ExtensionStateContext.tsx
+++ b/webview-ui/src/context/ExtensionStateContext.tsx
@@ -39,6 +39,7 @@ export const ExtensionStateContextProvider: React.FC<{
 		chatSettings: DEFAULT_CHAT_SETTINGS,
 		isLoggedIn: false,
 		platform: DEFAULT_PLATFORM,
+		telemetryOptIn: null,
 	})
 	const [didHydrateState, setDidHydrateState] = useState(false)
 	const [showWelcome, setShowWelcome] = useState(false)

--- a/webview-ui/src/context/ExtensionStateContext.tsx
+++ b/webview-ui/src/context/ExtensionStateContext.tsx
@@ -9,6 +9,7 @@ import { convertTextMateToHljs } from "../utils/textMateToHljs"
 import { vscode } from "../utils/vscode"
 import { DEFAULT_BROWSER_SETTINGS } from "../../../src/shared/BrowserSettings"
 import { DEFAULT_CHAT_SETTINGS } from "../../../src/shared/ChatSettings"
+import { TelemetrySetting } from "../../../src/shared/TelemetrySetting"
 
 interface ExtensionStateContextType extends ExtensionState {
 	didHydrateState: boolean
@@ -21,6 +22,7 @@ interface ExtensionStateContextType extends ExtensionState {
 	filePaths: string[]
 	setApiConfiguration: (config: ApiConfiguration) => void
 	setCustomInstructions: (value?: string) => void
+	setTelemetrySetting: (value: TelemetrySetting) => void
 	setShowAnnouncement: (value: boolean) => void
 }
 
@@ -39,7 +41,7 @@ export const ExtensionStateContextProvider: React.FC<{
 		chatSettings: DEFAULT_CHAT_SETTINGS,
 		isLoggedIn: false,
 		platform: DEFAULT_PLATFORM,
-		telemetryOptIn: null,
+		telemetrySetting: "unset",
 	})
 	const [didHydrateState, setDidHydrateState] = useState(false)
 	const [showWelcome, setShowWelcome] = useState(false)
@@ -157,6 +159,11 @@ export const ExtensionStateContextProvider: React.FC<{
 			setState((prevState) => ({
 				...prevState,
 				customInstructions: value,
+			})),
+		setTelemetrySetting: (value) =>
+			setState((prevState) => ({
+				...prevState,
+				telemetrySetting: value,
 			})),
 		setShowAnnouncement: (value) =>
 			setState((prevState) => ({


### PR DESCRIPTION
### Description

This pull request adds "copy" functionality for code blocks; this is implemented over three small changes:

1. Refactors code block rendering to use a single unified CodeBlock component, removing duplicate styling and ensuring consistent behavior between shell command output and markdown code blocks.
2. Add a "copy" button to all code blocks that allows users to easily copy code content with visual feedback (checkmark icon) when copied.
3. Make the copy button "sticky" while scrolling through long code blocks:
   - Button follows scroll position while staying within code block bounds
   - Smooth fade in/out transitions as blocks enter/exit view

### Test Procedure

Tested the following scenarios, test all cases with a task for Cline like this:

> 1. display a short python program within attempt response in ```...```
> 2. do the same thing outside of attempt response in a normal response
> 3. use execute command with a here document to display the same using cat

1. Code block rendering:
   - Verified consistent styling between shell commands and markdown code blocks
   - Confirmed syntax highlighting works correctly
2. Copy button functionality:
   - Tested copying code from both shell commands and markdown blocks, and also within attempt_completion
   - Copied content matches raw pre-html-rendered content
3. Scroll behavior:
   - Tested with code blocks that extend beyond viewport
   - Verified button is properly positioned while scrolling
   - Button remains within code block bounds

### Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update

### Pre-flight Checklist

- [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
- [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
- [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

#### Copy button in top-right
![image](https://github.com/user-attachments/assets/f25f8f92-3b88-488c-8132-7a674e890d61)

#### Copy button in top-right scrolls with window
![image](https://github.com/user-attachments/assets/cf7a7bfd-9a43-4949-a10f-72f1f9dd35bb)


### Additional Notes

none.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds a copy button to code blocks with sticky scrolling and refactors rendering for consistency.
> 
>   - **Behavior**:
>     - Adds a "copy" button to code blocks in `CodeBlock.tsx`, allowing users to copy code content with visual feedback (checkmark icon).
>     - Makes the copy button "sticky" while scrolling through long code blocks, ensuring it stays within bounds and fades in/out smoothly.
>   - **Refactoring**:
>     - Refactors code block rendering to use a unified `CodeBlock` component, ensuring consistent behavior and styling.
>     - Updates `MarkdownBlock.tsx` to utilize the new `CodeBlock` component for rendering code blocks.
>   - **Configuration**:
>     - Adds `cline.codeBlock.wordWrap` setting in `package.json` and `ClineProvider.ts` to control code block word wrapping.
>   - **Testing**:
>     - Verifies consistent styling and syntax highlighting for shell commands and markdown code blocks.
>     - Tests copy functionality and scroll behavior for code blocks extending beyond the viewport.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for c885b3f67ba5ea06f4ce31f40b63e2dc1952bf31. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->