### PR TITLE
Fix reasoning_content check for openai & deepseek streams

### DIFF
--- a/src/api/providers/deepseek.ts
+++ b/src/api/providers/deepseek.ts
@@ -51,7 +51,7 @@ export class DeepSeekHandler implements ApiHandler {
 				}
 			}
 
-			if ("reasoning_content" in delta && delta.reasoning_content) {
+			if (delta && "reasoning_content" in delta && delta.reasoning_content) {
 				yield {
 					type: "reasoning",
 					reasoning: (delta.reasoning_content as string | undefined) || "",

--- a/src/api/providers/openai.ts
+++ b/src/api/providers/openai.ts
@@ -56,7 +56,7 @@ export class OpenAiHandler implements ApiHandler {
 				}
 			}
 
-			if ("reasoning_content" in delta && delta.reasoning_content) {
+			if (delta && "reasoning_content" in delta && delta.reasoning_content) {
 				yield {
 					type: "reasoning",
 					reasoning: (delta.reasoning_content as string | undefined) || "",


### PR DESCRIPTION
### Description

Scenario: Streaming with OpenAI or OpenAI-compliant provider.

To get the token count, you add to the request:
```
			stream_options: { include_usage: true },
```

When you do that, OpenAI adds to the stream a last chunk with the token usage.
That last chunk does NOT contain any choices.
Here is an actual recorded example (some fields values, e.g. id, abbreviated for brevity).
```
data: {"id":"chatcmpl-123","object":"chat.completion.chunk","created":1736259727,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_123","choices":[{"index":0,"delta":{"content":"Hello"},"logprobs":null,"finish_reason":null}]}

data: {"id":"chatcmpl-123","object":"chat.completion.chunk","created":1736259727,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_123","choices":[{"index":0,"delta":{"content":" World"},"logprobs":null,"finish_reason":null}]}

data: {"id":"chatcmpl-123","object":"chat.completion.chunk","created":1736259727,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_123","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}],"usage":null}

data: {"id":"chatcmpl-123","object":"chat.completion.chunk","created":1736259727,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_123","choices":[],"usage":{"prompt_tokens":10,"completion_tokens":20,"total_tokens":30}}

data: [DONE]

```

Commit `68ac266463a10a8aa1c988b03bf48bf1197a154c` introduced a check that breaks this behaviour.
It looks for a string inside `delta`, which is possibly `undefined` before checking if it is defined.

### Test Procedure

Use Cline with OpenAI compatible provider (e.g. Requesty).

This does not reproduce with OpenAI native, because the commit didn't change `openai-native.ts`, only `openai.ts`.

### Type of Change

-   [X] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

I do not have a Cline environment set up locally. I am hoping someone can take over this PR to fix this asap. Please forgive me for not following the checklist.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix `reasoning_content` check in `DeepSeekHandler` and `OpenAiHandler` to handle `undefined` `delta`.
> 
>   - **Bug Fix**:
>     - Fix `reasoning_content` check in `DeepSeekHandler` in `deepseek.ts` and `OpenAiHandler` in `openai.ts` by changing condition order to prevent errors when `delta` is `undefined`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for d2ab644811d67317f1473f8683f0312e18abb6f5. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->