### PR TITLE
Let's reason together

### DIFF
--- a/.changeset/little-pianos-juggle.md
+++ b/.changeset/little-pianos-juggle.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": minor
+---
+
+Adding reasoning_effort support for openrouter and openai-native

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "claude-dev",
-	"version": "3.2.12",
+	"version": "3.2.13",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "claude-dev",
-			"version": "3.2.12",
+			"version": "3.2.13",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@anthropic-ai/bedrock-sdk": "^0.10.2",
@@ -36,7 +36,7 @@
 				"isbinaryfile": "^5.0.2",
 				"mammoth": "^1.8.0",
 				"monaco-vscode-textmate-theme-converter": "^0.1.7",
-				"openai": "^4.82.0",
+				"openai": "^4.83.0",
 				"os-name": "^6.0.0",
 				"p-wait-for": "^5.0.2",
 				"pdf-parse": "^1.1.1",
@@ -10617,9 +10617,9 @@
 			}
 		},
 		"node_modules/openai": {
-			"version": "4.82.0",
-			"resolved": "https://registry.npmjs.org/openai/-/openai-4.82.0.tgz",
-			"integrity": "sha512-1bTxOVGZuVGsKKUWbh3BEwX1QxIXUftJv+9COhhGGVDTFwiaOd4gWsMynF2ewj1mg6by3/O+U8+EEHpWRdPaJg==",
+			"version": "4.83.0",
+			"resolved": "https://registry.npmjs.org/openai/-/openai-4.83.0.tgz",
+			"integrity": "sha512-fmTsqud0uTtRKsPC7L8Lu55dkaTwYucqncDHzVvO64DKOpNTuiYwjbR/nVgpapXuYy8xSnhQQPUm+3jQaxICgw==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@types/node": "^18.11.18",

--- a/package.json
+++ b/package.json
@@ -161,6 +161,16 @@
 					"type": "boolean",
 					"default": true,
 					"description": "Enables extension to save checkpoints of workspace throughout the task."
+				},
+				"cline.modelSettings.o3Mini.reasoningEffort": {
+					"type": "string",
+					"enum": [
+						"low",
+						"medium",
+						"high"
+					],
+					"default": "medium",
+					"description": "Controls the reasoning effort when using the o3-mini model. Higher values may result in more thorough but slower responses."
 				}
 			}
 		}

--- a/package.json
+++ b/package.json
@@ -249,7 +249,7 @@
 		"isbinaryfile": "^5.0.2",
 		"mammoth": "^1.8.0",
 		"monaco-vscode-textmate-theme-converter": "^0.1.7",
-		"openai": "^4.82.0",
+		"openai": "^4.83.0",
 		"os-name": "^6.0.0",
 		"p-wait-for": "^5.0.2",
 		"pdf-parse": "^1.1.1",

--- a/src/api/providers/openai-native.ts
+++ b/src/api/providers/openai-native.ts
@@ -51,6 +51,7 @@ export class OpenAiNativeHandler implements ApiHandler {
 					messages: [{ role: "developer", content: systemPrompt }, ...convertToOpenAiMessages(messages)],
 					stream: true,
 					stream_options: { include_usage: true },
+					reasoning_effort: this.options.o3MiniReasoningEffort || "medium",
 				})
 				for await (const chunk of stream) {
 					const delta = chunk.choices[0]?.delta

--- a/src/api/providers/openai-native.ts
+++ b/src/api/providers/openai-native.ts
@@ -11,6 +11,7 @@ import {
 } from "../../shared/api"
 import { convertToOpenAiMessages } from "../transform/openai-format"
 import { ApiStream } from "../transform/stream"
+import { ChatCompletionReasoningEffort } from "openai/resources/chat/completions.mjs"
 
 export class OpenAiNativeHandler implements ApiHandler {
 	private options: ApiHandlerOptions
@@ -51,7 +52,7 @@ export class OpenAiNativeHandler implements ApiHandler {
 					messages: [{ role: "developer", content: systemPrompt }, ...convertToOpenAiMessages(messages)],
 					stream: true,
 					stream_options: { include_usage: true },
-					reasoning_effort: this.options.o3MiniReasoningEffort || "medium",
+					reasoning_effort: (this.options.o3MiniReasoningEffort as ChatCompletionReasoningEffort) || "medium",
 				})
 				for await (const chunk of stream) {
 					const delta = chunk.choices[0]?.delta

--- a/src/api/providers/openrouter.ts
+++ b/src/api/providers/openrouter.ts
@@ -128,6 +128,7 @@ export class OpenRouterHandler implements ApiHandler {
 			stream: true,
 			transforms: shouldApplyMiddleOutTransform ? ["middle-out"] : undefined,
 			include_reasoning: true,
+			...(model.id === "openai/o3-mini" ? { reasoning_effort: this.options.o3MiniReasoningEffort || "medium" } : {}),
 		})
 
 		let genId: string | undefined

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -1424,6 +1424,8 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 			}
 		}
 
+		const o3MiniReasoningEffort = vscode.workspace.getConfiguration("cline.models.o3Mini").get("reasoningEffort", "medium")
+
 		return {
 			apiConfiguration: {
 				apiProvider,
@@ -1453,6 +1455,7 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 				openRouterModelId,
 				openRouterModelInfo,
 				vsCodeLmModelSelector,
+				o3MiniReasoningEffort,
 			},
 			lastShownAnnouncementId,
 			customInstructions,

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -1424,7 +1424,9 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 			}
 		}
 
-		const o3MiniReasoningEffort = vscode.workspace.getConfiguration("cline.models.o3Mini").get("reasoningEffort", "medium")
+		const o3MiniReasoningEffort = vscode.workspace
+			.getConfiguration("cline.modelSettings.o3Mini")
+			.get("reasoningEffort", "medium")
 
 		return {
 			apiConfiguration: {

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -39,6 +39,7 @@ export interface ApiHandlerOptions {
 	mistralApiKey?: string
 	azureApiVersion?: string
 	vsCodeLmModelSelector?: any
+	o3MiniReasoningEffort?: string
 }
 
 export type ApiConfiguration = ApiHandlerOptions & {


### PR DESCRIPTION
### Description

Adding the reasoning_effort parameter into openrouter provider when the model is o3_mini.

The setting in kept in advanced settings so there is no additional UI for it.

### Test Procedure

Logged that the correct param is being passed in openai-native. Checked on T3 openrouter key.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<img width="854" alt="Screenshot 2025-02-01 at 3 11 28 PM" src="https://github.com/user-attachments/assets/b4dca418-960a-4b27-9c93-ff7a72adae96" />

### Additional Notes

The API seems to always return an error when the level is set to "high".

The types ApiHandlerOptions could be refactored to host model specific params in a more organized way.

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add `reasoning_effort` parameter support for `o3-mini` model in `openrouter` and `openai-native` providers, configurable via advanced settings.
> 
>   - **Behavior**:
>     - Add `reasoning_effort` parameter for `o3-mini` model in `openrouter` and `openai-native` providers.
>     - Default `reasoning_effort` to "medium" if not specified.
>   - **Configuration**:
>     - Add `cline.modelSettings.o3Mini.reasoningEffort` to `package.json` with options "low", "medium", "high".
>     - Retrieve `reasoning_effort` from VSCode configuration in `ClineProvider.ts`.
>   - **Code Changes**:
>     - Update `createMessage()` in `openai-native.ts` and `openrouter.ts` to include `reasoning_effort`.
>     - Modify `ApiHandlerOptions` in `api.ts` to include `o3MiniReasoningEffort`.
>   - **Dependencies**:
>     - Update `openai` package version in `package.json` to `^4.83.0`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 78f29bc1af1bb90d56c60b7fe5c0361729890568. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->