### PR TITLE
feat: add retry decorator with rate limit handling

### DIFF
--- a/.changeset/modern-knives-tan.md
+++ b/.changeset/modern-knives-tan.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Add automatic retry for rate limited requests

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "claude-dev",
-	"version": "3.2.10",
+	"version": "3.2.12",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "claude-dev",
-			"version": "3.2.10",
+			"version": "3.2.12",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@anthropic-ai/bedrock-sdk": "^0.10.2",

--- a/src/api/providers/anthropic.ts
+++ b/src/api/providers/anthropic.ts
@@ -1,5 +1,6 @@
 import { Anthropic } from "@anthropic-ai/sdk"
 import { Stream as AnthropicStream } from "@anthropic-ai/sdk/streaming"
+import { withRetry } from "../retry"
 import { anthropicDefaultModelId, AnthropicModelId, anthropicModels, ApiHandlerOptions, ModelInfo } from "../../shared/api"
 import { ApiHandler } from "../index"
 import { ApiStream } from "../transform/stream"
@@ -16,6 +17,7 @@ export class AnthropicHandler implements ApiHandler {
 		})
 	}
 
+	@withRetry()
 	async *createMessage(systemPrompt: string, messages: Anthropic.Messages.MessageParam[]): ApiStream {
 		const model = this.getModel()
 		let stream: AnthropicStream<Anthropic.Beta.PromptCaching.Messages.RawPromptCachingBetaMessageStreamEvent>

--- a/src/api/providers/deepseek.ts
+++ b/src/api/providers/deepseek.ts
@@ -1,5 +1,6 @@
 import { Anthropic } from "@anthropic-ai/sdk"
 import OpenAI from "openai"
+import { withRetry } from "../retry"
 import { ApiHandler } from "../"
 import { ApiHandlerOptions, DeepSeekModelId, ModelInfo, deepSeekDefaultModelId, deepSeekModels } from "../../shared/api"
 import { convertToOpenAiMessages } from "../transform/openai-format"
@@ -18,6 +19,7 @@ export class DeepSeekHandler implements ApiHandler {
 		})
 	}
 
+	@withRetry()
 	async *createMessage(systemPrompt: string, messages: Anthropic.Messages.MessageParam[]): ApiStream {
 		const model = this.getModel()
 

--- a/src/api/providers/gemini.ts
+++ b/src/api/providers/gemini.ts
@@ -1,5 +1,6 @@
 import { Anthropic } from "@anthropic-ai/sdk"
 import { GoogleGenerativeAI } from "@google/generative-ai"
+import { withRetry } from "../retry"
 import { ApiHandler } from "../"
 import { ApiHandlerOptions, geminiDefaultModelId, GeminiModelId, geminiModels, ModelInfo } from "../../shared/api"
 import { convertAnthropicMessageToGemini } from "../transform/gemini-format"
@@ -17,6 +18,7 @@ export class GeminiHandler implements ApiHandler {
 		this.client = new GoogleGenerativeAI(options.geminiApiKey)
 	}
 
+	@withRetry()
 	async *createMessage(systemPrompt: string, messages: Anthropic.Messages.MessageParam[]): ApiStream {
 		const model = this.client.getGenerativeModel({
 			model: this.getModel().id,

--- a/src/api/providers/mistral.ts
+++ b/src/api/providers/mistral.ts
@@ -1,5 +1,6 @@
 import { Anthropic } from "@anthropic-ai/sdk"
 import { Mistral } from "@mistralai/mistralai"
+import { withRetry } from "../retry"
 import { ApiHandler } from "../"
 import {
 	ApiHandlerOptions,
@@ -26,6 +27,7 @@ export class MistralHandler implements ApiHandler {
 		})
 	}
 
+	@withRetry()
 	async *createMessage(systemPrompt: string, messages: Anthropic.Messages.MessageParam[]): ApiStream {
 		const stream = await this.client.chat.stream({
 			model: this.getModel().id,

--- a/src/api/providers/openai-native.ts
+++ b/src/api/providers/openai-native.ts
@@ -1,5 +1,6 @@
 import { Anthropic } from "@anthropic-ai/sdk"
 import OpenAI from "openai"
+import { withRetry } from "../retry"
 import { ApiHandler } from "../"
 import {
 	ApiHandlerOptions,
@@ -22,6 +23,7 @@ export class OpenAiNativeHandler implements ApiHandler {
 		})
 	}
 
+	@withRetry()
 	async *createMessage(systemPrompt: string, messages: Anthropic.Messages.MessageParam[]): ApiStream {
 		switch (this.getModel().id) {
 			case "o1":

--- a/src/api/providers/openai.ts
+++ b/src/api/providers/openai.ts
@@ -1,5 +1,6 @@
 import { Anthropic } from "@anthropic-ai/sdk"
 import OpenAI, { AzureOpenAI } from "openai"
+import { withRetry } from "../retry"
 import { ApiHandlerOptions, azureOpenAiDefaultApiVersion, ModelInfo, openAiModelInfoSaneDefaults } from "../../shared/api"
 import { ApiHandler } from "../index"
 import { convertToOpenAiMessages } from "../transform/openai-format"
@@ -27,6 +28,7 @@ export class OpenAiHandler implements ApiHandler {
 		}
 	}
 
+	@withRetry()
 	async *createMessage(systemPrompt: string, messages: Anthropic.Messages.MessageParam[]): ApiStream {
 		const modelId = this.options.openAiModelId ?? ""
 		const isDeepseekReasoner = modelId.includes("deepseek-reasoner")

--- a/src/api/providers/openrouter.ts
+++ b/src/api/providers/openrouter.ts
@@ -2,6 +2,7 @@ import { Anthropic } from "@anthropic-ai/sdk"
 import axios from "axios"
 import delay from "delay"
 import OpenAI from "openai"
+import { withRetry } from "../retry"
 import { ApiHandler } from "../"
 import { ApiHandlerOptions, ModelInfo, openRouterDefaultModelId, openRouterDefaultModelInfo } from "../../shared/api"
 import { convertToOpenAiMessages } from "../transform/openai-format"
@@ -24,6 +25,7 @@ export class OpenRouterHandler implements ApiHandler {
 		})
 	}
 
+	@withRetry()
 	async *createMessage(systemPrompt: string, messages: Anthropic.Messages.MessageParam[]): ApiStream {
 		const model = this.getModel()
 

--- a/src/api/providers/vertex.ts
+++ b/src/api/providers/vertex.ts
@@ -1,5 +1,6 @@
 import { Anthropic } from "@anthropic-ai/sdk"
 import { AnthropicVertex } from "@anthropic-ai/vertex-sdk"
+import { withRetry } from "../retry"
 import { ApiHandler } from "../"
 import { ApiHandlerOptions, ModelInfo, vertexDefaultModelId, VertexModelId, vertexModels } from "../../shared/api"
 import { ApiStream } from "../transform/stream"
@@ -18,6 +19,7 @@ export class VertexHandler implements ApiHandler {
 		})
 	}
 
+	@withRetry()
 	async *createMessage(systemPrompt: string, messages: Anthropic.Messages.MessageParam[]): ApiStream {
 		const stream = await this.client.messages.create({
 			model: this.getModel().id,

--- a/src/api/retry.test.ts
+++ b/src/api/retry.test.ts
@@ -1,0 +1,216 @@
+import { describe, it } from "mocha"
+import "should"
+import { withRetry } from "./retry"
+
+describe("Retry Decorator", () => {
+	describe("withRetry", () => {
+		it("should not retry on success", async () => {
+			let callCount = 0
+			class TestClass {
+				@withRetry()
+				async *successMethod() {
+					callCount++
+					yield "success"
+				}
+			}
+
+			const test = new TestClass()
+			const result = []
+			for await (const value of test.successMethod()) {
+				result.push(value)
+			}
+
+			callCount.should.equal(1)
+			result.should.deepEqual(["success"])
+		})
+
+		it("should retry on rate limit (429) error", async () => {
+			let callCount = 0
+			class TestClass {
+				@withRetry({ maxRetries: 2, baseDelay: 10, maxDelay: 100 })
+				async *failMethod() {
+					callCount++
+					if (callCount === 1) {
+						const error: any = new Error("Rate limit exceeded")
+						error.status = 429
+						throw error
+					}
+					yield "success after retry"
+				}
+			}
+
+			const test = new TestClass()
+			const result = []
+			for await (const value of test.failMethod()) {
+				result.push(value)
+			}
+
+			callCount.should.equal(2)
+			result.should.deepEqual(["success after retry"])
+		})
+
+		it("should not retry on non-rate-limit errors", async () => {
+			let callCount = 0
+			class TestClass {
+				@withRetry()
+				async *failMethod() {
+					callCount++
+					throw new Error("Regular error")
+				}
+			}
+
+			const test = new TestClass()
+			try {
+				for await (const _ of test.failMethod()) {
+					// Should not reach here
+				}
+				throw new Error("Should have thrown")
+			} catch (error: any) {
+				error.message.should.equal("Regular error")
+				callCount.should.equal(1)
+			}
+		})
+
+		it("should respect retry-after header with delta seconds", async () => {
+			let callCount = 0
+			const startTime = Date.now()
+			class TestClass {
+				@withRetry({ maxRetries: 2, baseDelay: 1000 }) // Use large baseDelay to ensure header takes precedence
+				async *failMethod() {
+					callCount++
+					if (callCount === 1) {
+						const error: any = new Error("Rate limit exceeded")
+						error.status = 429
+						error.headers = { "retry-after": "0.01" } // 10ms delay
+						throw error
+					}
+					yield "success after retry"
+				}
+			}
+
+			const test = new TestClass()
+			const result = []
+			for await (const value of test.failMethod()) {
+				result.push(value)
+			}
+
+			const duration = Date.now() - startTime
+			duration.should.be.approximately(10, 10) // Allow 10ms variance
+			callCount.should.equal(2)
+			result.should.deepEqual(["success after retry"])
+		})
+
+		it("should respect retry-after header with Unix timestamp", async () => {
+			let callCount = 0
+			const startTime = Date.now()
+			const retryTimestamp = Math.floor(Date.now() / 1000) + 0.01 // 10ms in the future
+
+			class TestClass {
+				@withRetry({ maxRetries: 2, baseDelay: 1000 }) // Use large baseDelay to ensure header takes precedence
+				async *failMethod() {
+					callCount++
+					if (callCount === 1) {
+						const error: any = new Error("Rate limit exceeded")
+						error.status = 429
+						error.headers = { "retry-after": retryTimestamp.toString() }
+						throw error
+					}
+					yield "success after retry"
+				}
+			}
+
+			const test = new TestClass()
+			const result = []
+			for await (const value of test.failMethod()) {
+				result.push(value)
+			}
+
+			const duration = Date.now() - startTime
+			duration.should.be.approximately(10, 10) // Allow 10ms variance
+			callCount.should.equal(2)
+			result.should.deepEqual(["success after retry"])
+		})
+
+		it("should use exponential backoff when no retry-after header", async () => {
+			let callCount = 0
+			const startTime = Date.now()
+			class TestClass {
+				@withRetry({ maxRetries: 2, baseDelay: 10, maxDelay: 100 })
+				async *failMethod() {
+					callCount++
+					if (callCount === 1) {
+						const error: any = new Error("Rate limit exceeded")
+						error.status = 429
+						throw error
+					}
+					yield "success after retry"
+				}
+			}
+
+			const test = new TestClass()
+			const result = []
+			for await (const value of test.failMethod()) {
+				result.push(value)
+			}
+
+			const duration = Date.now() - startTime
+			// First retry should be after baseDelay (10ms)
+			duration.should.be.approximately(10, 10)
+			callCount.should.equal(2)
+			result.should.deepEqual(["success after retry"])
+		})
+
+		it("should respect maxDelay", async () => {
+			let callCount = 0
+			const startTime = Date.now()
+			class TestClass {
+				@withRetry({ maxRetries: 3, baseDelay: 50, maxDelay: 10 })
+				async *failMethod() {
+					callCount++
+					if (callCount < 3) {
+						const error: any = new Error("Rate limit exceeded")
+						error.status = 429
+						throw error
+					}
+					yield "success after retries"
+				}
+			}
+
+			const test = new TestClass()
+			const result = []
+			for await (const value of test.failMethod()) {
+				result.push(value)
+			}
+
+			const duration = Date.now() - startTime
+			// Both retries should be capped at maxDelay (10ms each)
+			duration.should.be.approximately(20, 20)
+			callCount.should.equal(3)
+			result.should.deepEqual(["success after retries"])
+		})
+
+		it("should throw after maxRetries attempts", async () => {
+			let callCount = 0
+			class TestClass {
+				@withRetry({ maxRetries: 2, baseDelay: 10 })
+				async *failMethod() {
+					callCount++
+					const error: any = new Error("Rate limit exceeded")
+					error.status = 429
+					throw error
+				}
+			}
+
+			const test = new TestClass()
+			try {
+				for await (const _ of test.failMethod()) {
+					// Should not reach here
+				}
+				throw new Error("Should have thrown")
+			} catch (error: any) {
+				error.message.should.equal("Rate limit exceeded")
+				callCount.should.equal(2) // Initial attempt + 1 retry
+			}
+		})
+	})
+})

--- a/src/api/retry.ts
+++ b/src/api/retry.ts
@@ -1,0 +1,62 @@
+interface RetryOptions {
+	maxRetries?: number
+	baseDelay?: number
+	maxDelay?: number
+}
+
+const DEFAULT_OPTIONS: Required<RetryOptions> = {
+	maxRetries: 3,
+	baseDelay: 1000,
+	maxDelay: 10000,
+}
+
+export function withRetry(options: RetryOptions = {}) {
+	const { maxRetries, baseDelay, maxDelay } = { ...DEFAULT_OPTIONS, ...options }
+
+	return function (_target: any, _propertyKey: string, descriptor: PropertyDescriptor) {
+		const originalMethod = descriptor.value
+
+		descriptor.value = async function* (...args: any[]) {
+			for (let attempt = 0; attempt < maxRetries; attempt++) {
+				try {
+					yield* originalMethod.apply(this, args)
+					return
+				} catch (error: any) {
+					const isRateLimit = error?.status === 429
+					const isLastAttempt = attempt === maxRetries - 1
+
+					if (!isRateLimit || isLastAttempt) {
+						throw error
+					}
+
+					// Get retry delay from header or calculate exponential backoff
+					// Check various rate limit headers
+					const retryAfter =
+						error.headers?.["retry-after"] ||
+						error.headers?.["x-ratelimit-reset"] ||
+						error.headers?.["ratelimit-reset"]
+
+					let delay: number
+					if (retryAfter) {
+						// Handle both delta-seconds and Unix timestamp formats
+						const retryValue = parseInt(retryAfter, 10)
+						if (retryValue > Date.now() / 1000) {
+							// Unix timestamp
+							delay = retryValue * 1000 - Date.now()
+						} else {
+							// Delta seconds
+							delay = retryValue * 1000
+						}
+					} else {
+						// Use exponential backoff if no header
+						delay = Math.min(maxDelay, baseDelay * Math.pow(2, attempt))
+					}
+
+					await new Promise((resolve) => setTimeout(resolve, delay))
+				}
+			}
+		}
+
+		return descriptor
+	}
+}

--- a/src/api/retry.ts
+++ b/src/api/retry.ts
@@ -6,8 +6,8 @@ interface RetryOptions {
 
 const DEFAULT_OPTIONS: Required<RetryOptions> = {
 	maxRetries: 3,
-	baseDelay: 1000,
-	maxDelay: 10000,
+	baseDelay: 1_000,
+	maxDelay: 10_000,
 }
 
 export function withRetry(options: RetryOptions = {}) {


### PR DESCRIPTION
- Add handling of rate limit (429) errors
- Implement retry timing based on response headers
- Add exponential backoff when no headers present
- Add a few unit tests

Fixes #713

### Description

This PR introduces a robust retry mechanism for API requests across all providers to handle rate limiting more gracefully. Key improvements include:

1. Smart Rate Limit Handling:
   - Added a new `@withRetry` decorator that automatically handles 429 (rate limit) errors
   - Implemented in all API providers (Anthropic, DeepSeek, Gemini, Mistral, OpenAI, etc.)
   - Only retries on rate limit errors, other errors are passed through unchanged

2. Intelligent Retry Timing:
   - Primary: Uses server-provided retry timing from response headers
   - Supports both delta-seconds and Unix timestamp formats in retry-after headers
   - Checks multiple common rate limit header variations:
     - retry-after
     - x-ratelimit-reset
     - ratelimit-reset

3. Fallback Exponential Backoff:
   - When no retry timing headers are present, uses exponential backoff
   - Configurable base delay (default: 1000ms)
   - Configurable maximum delay (default: 10000ms)
   - Prevents retry storms while maintaining responsiveness

4. Configurable Retry Behavior:
   - Customizable through RetryOptions interface:
     - maxRetries (default: 3)
     - baseDelay (default: 1000ms)
     - maxDelay (default: 10000ms)

### Test Procedure

Added comprehensive unit tests that verify:
- Basic success case (no retry needed)
- Rate limit error handling with retry
- Non-rate-limit error passthrough
- Retry timing from delta-seconds headers
- Retry timing from Unix timestamp headers
- Exponential backoff when no headers present
- Maximum delay enforcement
- Maximum retries enforcement

All tests are passing and demonstrate the expected behavior for each scenario.

### Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update

### Pre-flight Checklist

- [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
- [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
- [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Additional Notes

This improvement makes the API interaction more resilient by:
1. Respecting server-provided rate limits
2. Implementing best practices for retry behavior
3. Providing a consistent retry mechanism across all providers
4. Adding proper test coverage for the retry functionality

The implementation is non-breaking and transparent to existing code - it simply wraps the existing functionality with smart retry behavior.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `@withRetry` decorator for smart retry handling of 429 errors across multiple API providers, with comprehensive unit tests.
> 
>   - **Behavior**:
>     - Introduces `@withRetry` decorator in `retry.ts` to handle 429 errors with retry logic.
>     - Applies `@withRetry` to `createMessage()` in `anthropic.ts`, `deepseek.ts`, `gemini.ts`, `mistral.ts`, `openai-native.ts`, `openai.ts`, `openrouter.ts`, and `vertex.ts`.
>     - Retries based on `retry-after`, `x-ratelimit-reset`, and `ratelimit-reset` headers or uses exponential backoff.
>   - **Testing**:
>     - Adds `retry.test.ts` with tests for success, rate limit handling, non-rate-limit errors, retry timing, exponential backoff, and retry limits.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 93e5eb6d5c5e557978ea11b266c84cef55c028ae. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->