### PR TITLE
feat: Add support for all available Mistral API models

### DIFF
--- a/src/api/providers/mistral.ts
+++ b/src/api/providers/mistral.ts
@@ -21,7 +21,7 @@ export class MistralHandler implements ApiHandler {
 	constructor(options: ApiHandlerOptions) {
 		this.options = options
 		this.client = new Mistral({
-			serverURL: "https://api.mistral.ai/v1",
+			serverURL: "https://api.mistral.ai",
 			apiKey: this.options.mistralApiKey,
 		})
 	}

--- a/src/api/providers/mistral.ts
+++ b/src/api/providers/mistral.ts
@@ -21,7 +21,7 @@ export class MistralHandler implements ApiHandler {
 	constructor(options: ApiHandlerOptions) {
 		this.options = options
 		this.client = new Mistral({
-			serverURL: "https://codestral.mistral.ai",
+			serverURL: "https://api.mistral.ai/v1",
 			apiKey: this.options.mistralApiKey,
 		})
 	}

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -408,10 +408,90 @@ export const deepSeekModels = {
 // Mistral
 // https://docs.mistral.ai/getting-started/models/models_overview/
 export type MistralModelId = keyof typeof mistralModels
-export const mistralDefaultModelId: MistralModelId = "codestral-latest"
+export const mistralDefaultModelId: MistralModelId = "codestral-2501"
 export const mistralModels = {
-	"codestral-latest": {
-		maxTokens: 32_768,
+	"mistral-large-2411": {
+		maxTokens: 131_000,
+		contextWindow: 131_000,
+		supportsImages: false,
+		supportsPromptCache: false,
+		inputPrice: 2.0,
+		outputPrice: 6.0,
+	},
+	"pixtral-large-2411": {
+		maxTokens: 131_000,
+		contextWindow: 131_000,
+		supportsImages: true,
+		supportsPromptCache: false,
+		inputPrice: 2.0,
+		outputPrice: 6.0,
+	},
+	"ministral-3b-2410": {
+		maxTokens: 131_000,
+		contextWindow: 131_000,
+		supportsImages: false,
+		supportsPromptCache: false,
+		inputPrice: 0.04,
+		outputPrice: 0.04,
+	},
+	"ministral-8b-2410": {
+		maxTokens: 131_000,
+		contextWindow: 131_000,
+		supportsImages: false,
+		supportsPromptCache: false,
+		inputPrice: 0.1,
+		outputPrice: 0.1,
+	},
+	"mistral-embed": {
+		maxTokens: 8_000,
+		contextWindow: 8_000,
+		supportsImages: false,
+		supportsPromptCache: false,
+		inputPrice: 0.1,
+		outputPrice: 0.1,
+	},
+	"mistral-moderation-2411": {
+		maxTokens: 8_000,
+		contextWindow: 8_000,
+		supportsImages: false,
+		supportsPromptCache: false,
+		inputPrice: 0.1,
+		outputPrice: 0.1,
+	},
+	"mistral-small-2501": {
+		maxTokens: 32_000,
+		contextWindow: 32_000,
+		supportsImages: false,
+		supportsPromptCache: false,
+		inputPrice: 0.1,
+		outputPrice: 0.3,
+	},
+	"pixtral-12b-2409": {
+		maxTokens: 131_000,
+		contextWindow: 131_000,
+		supportsImages: true,
+		supportsPromptCache: false,
+		inputPrice: 0.15,
+		outputPrice: 0.15,
+	},
+	"open-mistral-nemo-2407": {
+		maxTokens: 131_000,
+		contextWindow: 131_000,
+		supportsImages: false,
+		supportsPromptCache: false,
+		inputPrice: 0.15,
+		outputPrice: 0.15,
+	},
+	"open-codestral-mamba": {
+		maxTokens: 256_000,
+		contextWindow: 256_000,
+		supportsImages: false,
+		supportsPromptCache: false,
+		inputPrice: 0.15,
+		outputPrice: 0.15,
+	},
+	"codestral-2501": {
+		maxTokens: 256_000,
 		contextWindow: 256_000,
 		supportsImages: false,
 		supportsPromptCache: false,


### PR DESCRIPTION
- Add all available Mistral models with specific version numbers
- Include Premier models (Mistral Large, Pixtral, Ministral, etc.)
- Include Free models (Mistral Small, Pixtral 12B, etc.)
- Set correct token limits and pricing for each model

Fixes #1609

### Description

Add support for all available Mistral API models with their specific version numbers, replacing the single codestral-latest model. This includes proper configuration of token limits, pricing, and image support capabilities for each model. Users with "-latest" selections will gracefully fall back to the corresponding versioned model.

### Test Procedure

- Verified all model endpoints match official Mistral documentation
- Confirmed pricing and token limits are accurate
- Tested fallback behavior for "-latest" model selections
- Pre-commit checks (ESLint, Prettier) passing

### Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update

### Pre-flight Checklist

- [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
- [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
- [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A

### Additional Notes

Existing users with "-latest" model selections will automatically use the corresponding versioned model through the fallback mechanism in MistralHandler.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds support for multiple Mistral API models with specific configurations and fallback for '-latest' selections in `src/shared/api.ts`.
> 
>   - **Behavior**:
>     - Adds support for multiple Mistral API models in `src/shared/api.ts`, replacing `codestral-latest` with specific models like `mistral-large-2411`, `pixtral-large-2411`, etc.
>     - Sets token limits and pricing for each model.
>     - Implements fallback for '-latest' model selections to corresponding versioned models.
>   - **Models**:
>     - Includes Premier models (e.g., `Mistral Large`, `Pixtral`) and Free models (e.g., `Mistral Small`, `Pixtral 12B`).
>   - **Misc**:
>     - Updates `mistralDefaultModelId` to `codestral-2501`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 466b1982f26f63e74a290b633433870b2cea4a63. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->