### PR TITLE
Class into cline file

### DIFF
--- a/src/core/Cline.ts
+++ b/src/core/Cline.ts
@@ -60,7 +60,6 @@ import { SYSTEM_PROMPT } from "./prompts/system"
 import { addUserInstructions } from "./prompts/system"
 import { OpenAiHandler } from "../api/providers/openai"
 import { ApiStream } from "../api/transform/stream"
-import { Logger } from "../services/logging/Logger"
 
 const cwd = vscode.workspace.workspaceFolders?.map((folder) => folder.uri.fsPath).at(0) ?? path.join(os.homedir(), "Desktop") // may or may not exist but fs checking existence would immediately ask for permission which would be bad UX, need to come up with a better solution
 
@@ -126,14 +125,10 @@ export class Cline {
 		images?: string[],
 		historyItem?: HistoryItem,
 	) {
-		Logger.log("initializing LLMAC")
 		this.llmAccessController = new LLMFileAccessController(cwd)
-		this.llmAccessController
-			.initialize()
-			.then(() => Logger.log("initialized"))
-			.catch((error) => {
-				console.error("Failed to initialize LLMFileAccessController:", error)
-			})
+		this.llmAccessController.initialize().catch((error) => {
+			console.error("Failed to initialize LLMFileAccessController:", error)
+		})
 		this.providerRef = new WeakRef(provider)
 		this.api = buildApiHandler(apiConfiguration)
 		this.terminalManager = new TerminalManager()

--- a/src/services/llm-access-control/LLMFileAccessController.test.ts
+++ b/src/services/llm-access-control/LLMFileAccessController.test.ts
@@ -224,52 +224,6 @@ describe("LLMFileAccessController", () => {
 		})
 	})
 
-	describe("File Watcher", () => {
-		it("should update patterns when .clineignore is modified", async () => {
-			// Initial state
-			controller.validateAccess("test.log").should.be.true()
-
-			// Modify .clineignore
-			await fs.writeFile(path.join(tempDir, ".clineignore"), "*.log")
-
-			// Wait for the next event loop tick to ensure file watcher processes the change
-			await Promise.resolve()
-
-			// Check if the new pattern is applied
-			controller.validateAccess("test.log").should.be.false()
-		})
-
-		it("should reset to default patterns when .clineignore is deleted", async () => {
-			// Initial state with .clineignore containing a pattern
-			await fs.writeFile(path.join(tempDir, ".clineignore"), "*.log")
-			await new Promise((resolve) => setTimeout(resolve, 100))
-			controller.validateAccess("test.log").should.be.false()
-
-			// Delete .clineignore
-			await fs.unlink(path.join(tempDir, ".clineignore"))
-
-			// Wait for the next event loop tick to ensure file watcher processes the deletion
-			await Promise.resolve()
-
-			// Should now allow previously ignored files
-			controller.validateAccess("test.log").should.be.true()
-		})
-
-		it("should handle .clineignore being recreated", async () => {
-			// Delete existing .clineignore
-			await fs.unlink(path.join(tempDir, ".clineignore"))
-			await new Promise((resolve) => setTimeout(resolve, 100))
-
-			// Create new .clineignore with different patterns
-			await fs.writeFile(path.join(tempDir, ".clineignore"), "*.temp")
-			await new Promise((resolve) => setTimeout(resolve, 100))
-
-			// Check if new patterns are applied
-			controller.validateAccess("file.temp").should.be.false()
-			controller.validateAccess("test.log").should.be.true()
-		})
-	})
-
 	describe("Error Handling", () => {
 		it("should handle invalid paths", async () => {
 			// Test with an invalid path containing null byte

--- a/src/services/llm-access-control/LLMFileAccessController.test.ts
+++ b/src/services/llm-access-control/LLMFileAccessController.test.ts
@@ -33,44 +33,44 @@ describe("LLMFileAccessController", () => {
 
 	describe("Default Patterns", () => {
 		// it("should block access to common ignored files", async () => {
-		// 	const results = await Promise.all([
+		// 	const results = [
 		// 		controller.validateAccess(".env"),
 		// 		controller.validateAccess(".git/config"),
 		// 		controller.validateAccess("node_modules/package.json"),
-		// 	])
+		// 	]
 		// 	results.forEach((result) => result.should.be.false())
 		// })
 
 		it("should allow access to regular files", async () => {
-			const results = await Promise.all([
+			const results = [
 				controller.validateAccess("src/index.ts"),
 				controller.validateAccess("README.md"),
 				controller.validateAccess("package.json"),
-			])
+			]
 			results.forEach((result) => result.should.be.true())
 		})
 	})
 
 	describe("Custom Patterns", () => {
 		it("should block access to custom ignored patterns", async () => {
-			const results = await Promise.all([
+			const results = [
 				controller.validateAccess("config.secret"),
 				controller.validateAccess("private/data.txt"),
 				controller.validateAccess("temp.json"),
 				controller.validateAccess("nested/deep/file.secret"),
 				controller.validateAccess("private/nested/deep/file.txt"),
-			])
+			]
 			results.forEach((result) => result.should.be.false())
 		})
 
 		it("should allow access to non-ignored files", async () => {
-			const results = await Promise.all([
+			const results = [
 				controller.validateAccess("public/data.txt"),
 				controller.validateAccess("config.json"),
 				controller.validateAccess("src/temp/file.ts"),
 				controller.validateAccess("nested/deep/file.txt"),
 				controller.validateAccess("not-private/data.txt"),
-			])
+			]
 			results.forEach((result) => result.should.be.true())
 		})
 
@@ -83,11 +83,11 @@ describe("LLMFileAccessController", () => {
 			controller = new LLMFileAccessController(tempDir)
 			await controller.initialize()
 
-			const results = await Promise.all([
+			const results = [
 				controller.validateAccess("data-123.json"), // Should be false (wildcard)
 				controller.validateAccess("data.json"), // Should be true (doesn't match pattern)
 				controller.validateAccess("script.tmp"), // Should be false (extension match)
-			])
+			]
 
 			results[0].should.be.false() // data-123.json
 			results[1].should.be.true() // data.json
@@ -112,9 +112,8 @@ describe("LLMFileAccessController", () => {
 		// 	)
 
 		// 	controller = new LLMFileAccessController(tempDir)
-		// 	await controller.initialize()
 
-		// 	const results = await Promise.all([
+		// 	const results = [
 		// 		// Basic negation
 		// 		controller.validateAccess("temp/file.txt"), // Should be false (in temp/)
 		// 		controller.validateAccess("temp/allowed/file.txt"), // Should be true (negated)
@@ -130,7 +129,7 @@ describe("LLMFileAccessController", () => {
 		// 		controller.validateAccess("assets/logo.png"), // Should be false (in assets/)
 		// 		controller.validateAccess("assets/public/logo.png"), // Should be true (negated and matches *.png)
 		// 		controller.validateAccess("assets/public/data.json"), // Should be true (in negated public/)
-		// 	])
+		// 	]
 
 		// 	results[0].should.be.false() // temp/file.txt
 		// 	results[1].should.be.true() // temp/allowed/file.txt
@@ -154,7 +153,7 @@ describe("LLMFileAccessController", () => {
 			controller = new LLMFileAccessController(tempDir)
 			await controller.initialize()
 
-			const result = await controller.validateAccess("test.secret")
+			const result = controller.validateAccess("test.secret")
 			result.should.be.false()
 		})
 	})
@@ -163,55 +162,55 @@ describe("LLMFileAccessController", () => {
 		it("should handle absolute paths and match ignore patterns", async () => {
 			// Test absolute path that should be allowed
 			const allowedPath = path.join(tempDir, "src/file.ts")
-			const allowedResult = await controller.validateAccess(allowedPath)
+			const allowedResult = controller.validateAccess(allowedPath)
 			allowedResult.should.be.true()
 
 			// Test absolute path that matches an ignore pattern (*.secret)
 			const ignoredPath = path.join(tempDir, "config.secret")
-			const ignoredResult = await controller.validateAccess(ignoredPath)
+			const ignoredResult = controller.validateAccess(ignoredPath)
 			ignoredResult.should.be.false()
 
 			// Test absolute path in ignored directory (private/)
 			const ignoredDirPath = path.join(tempDir, "private/data.txt")
-			const ignoredDirResult = await controller.validateAccess(ignoredDirPath)
+			const ignoredDirResult = controller.validateAccess(ignoredDirPath)
 			ignoredDirResult.should.be.false()
 		})
 
 		it("should handle relative paths and match ignore patterns", async () => {
 			// Test relative path that should be allowed
-			const allowedResult = await controller.validateAccess("./src/file.ts")
+			const allowedResult = controller.validateAccess("./src/file.ts")
 			allowedResult.should.be.true()
 
 			// Test relative path that matches an ignore pattern (*.secret)
-			const ignoredResult = await controller.validateAccess("./config.secret")
+			const ignoredResult = controller.validateAccess("./config.secret")
 			ignoredResult.should.be.false()
 
 			// Test relative path in ignored directory (private/)
-			const ignoredDirResult = await controller.validateAccess("./private/data.txt")
+			const ignoredDirResult = controller.validateAccess("./private/data.txt")
 			ignoredDirResult.should.be.false()
 		})
 
 		it("should normalize paths with backslashes", async () => {
-			const result = await controller.validateAccess("src\\file.ts")
+			const result = controller.validateAccess("src\\file.ts")
 			result.should.be.true()
 		})
 
 		it("should handle paths outside cwd", async () => {
 			// Create a path that points to parent directory of cwd
 			const outsidePath = path.join(path.dirname(tempDir), "outside.txt")
-			const result = await controller.validateAccess(outsidePath)
+			const result = controller.validateAccess(outsidePath)
 
 			// Should return false for security since path is outside cwd
 			result.should.be.false()
 
 			// Test with a deeply nested path outside cwd
 			const deepOutsidePath = path.join(path.dirname(tempDir), "deep", "nested", "outside.secret")
-			const deepResult = await controller.validateAccess(deepOutsidePath)
+			const deepResult = controller.validateAccess(deepOutsidePath)
 			deepResult.should.be.false()
 
 			// Test with a path that tries to escape using ../
 			const escapeAttemptPath = path.join(tempDir, "..", "escape-attempt.txt")
-			const escapeResult = await controller.validateAccess(escapeAttemptPath)
+			const escapeResult = controller.validateAccess(escapeAttemptPath)
 			escapeResult.should.be.false()
 		})
 	})
@@ -225,10 +224,56 @@ describe("LLMFileAccessController", () => {
 		})
 	})
 
+	describe("File Watcher", () => {
+		it("should update patterns when .clineignore is modified", async () => {
+			// Initial state
+			controller.validateAccess("test.log").should.be.true()
+
+			// Modify .clineignore
+			await fs.writeFile(path.join(tempDir, ".clineignore"), "*.log")
+
+			// Wait for the next event loop tick to ensure file watcher processes the change
+			await Promise.resolve()
+
+			// Check if the new pattern is applied
+			controller.validateAccess("test.log").should.be.false()
+		})
+
+		it("should reset to default patterns when .clineignore is deleted", async () => {
+			// Initial state with .clineignore containing a pattern
+			await fs.writeFile(path.join(tempDir, ".clineignore"), "*.log")
+			await new Promise((resolve) => setTimeout(resolve, 100))
+			controller.validateAccess("test.log").should.be.false()
+
+			// Delete .clineignore
+			await fs.unlink(path.join(tempDir, ".clineignore"))
+
+			// Wait for the next event loop tick to ensure file watcher processes the deletion
+			await Promise.resolve()
+
+			// Should now allow previously ignored files
+			controller.validateAccess("test.log").should.be.true()
+		})
+
+		it("should handle .clineignore being recreated", async () => {
+			// Delete existing .clineignore
+			await fs.unlink(path.join(tempDir, ".clineignore"))
+			await new Promise((resolve) => setTimeout(resolve, 100))
+
+			// Create new .clineignore with different patterns
+			await fs.writeFile(path.join(tempDir, ".clineignore"), "*.temp")
+			await new Promise((resolve) => setTimeout(resolve, 100))
+
+			// Check if new patterns are applied
+			controller.validateAccess("file.temp").should.be.false()
+			controller.validateAccess("test.log").should.be.true()
+		})
+	})
+
 	describe("Error Handling", () => {
 		it("should handle invalid paths", async () => {
 			// Test with an invalid path containing null byte
-			const result = await controller.validateAccess("\0invalid")
+			const result = controller.validateAccess("\0invalid")
 			result.should.be.true()
 		})
 
@@ -240,7 +285,7 @@ describe("LLMFileAccessController", () => {
 			try {
 				const controller = new LLMFileAccessController(emptyDir)
 				await controller.initialize()
-				const result = await controller.validateAccess("file.txt")
+				const result = controller.validateAccess("file.txt")
 				result.should.be.true()
 			} finally {
 				await fs.rm(emptyDir, { recursive: true, force: true })
@@ -253,7 +298,7 @@ describe("LLMFileAccessController", () => {
 			controller = new LLMFileAccessController(tempDir)
 			await controller.initialize()
 
-			const result = await controller.validateAccess("regular-file.txt")
+			const result = controller.validateAccess("regular-file.txt")
 			result.should.be.true()
 		})
 	})

--- a/src/services/llm-access-control/LLMFileAccessController.ts
+++ b/src/services/llm-access-control/LLMFileAccessController.ts
@@ -40,6 +40,10 @@ export class LLMFileAccessController {
 		try {
 			const ignorePath = path.join(this.cwd, ".clineignore")
 			if (await fileExistsAtPath(ignorePath)) {
+				// We need to reset ignore. Otherwise we will be adding duplicate patterns from re-reading the .clineignore
+				// Will be switching to globby in next PR
+				this.ignoreInstance = ignore()
+				this.ignoreInstance.add(LLMFileAccessController.DEFAULT_PATTERNS)
 				const content = await fs.readFile(ignorePath, "utf8")
 				const customPatterns = content
 					.split("\n")

--- a/src/services/llm-access-control/LLMFileAccessController.ts
+++ b/src/services/llm-access-control/LLMFileAccessController.ts
@@ -32,7 +32,7 @@ export class LLMFileAccessController {
 
 	/**
 	 * Initialize the controller by loading custom patterns
-	 * Must be called after construction
+	 * Must be called after construction and before using the controller
 	 */
 	async initialize(): Promise<void> {
 		await this.loadCustomPatterns()

--- a/src/services/llm-access-control/LLMFileAccessController.ts
+++ b/src/services/llm-access-control/LLMFileAccessController.ts
@@ -48,10 +48,14 @@ export class LLMFileAccessController {
 		// Watch for changes and updates
 		this.disposables.push(
 			this.fileWatcher.onDidChange(() => {
-				this.loadCustomPatterns()
+				this.loadCustomPatterns().catch((error) => {
+					console.error("Failed to load updated .clineignore patterns:", error)
+				})
 			}),
 			this.fileWatcher.onDidCreate(() => {
-				this.loadCustomPatterns()
+				this.loadCustomPatterns().catch((error) => {
+					console.error("Failed to load new .clineignore patterns:", error)
+				})
 			}),
 			this.fileWatcher.onDidDelete(() => {
 				this.resetToDefaultPatterns()


### PR DESCRIPTION
### Description

This PR implements the `LLMFileAccessController` class into the `Cline.ts` file, where it will be instantiated and managed (see Additional Notes for thoughts on this). In addition, we have enhanced the `LLMFileAccessController` class by adding real-time monitoring of the `.clineignore` file. Previously, the controller would only load ignore patterns during initialization, meaning that changes made to the `.clineignore` during a task would not have been noticed until another task was started or renewed. The new implementation uses VSCode's `FileSystemWatcher` to automatically update ignore patterns whenever `.clineignore` is modified, created, or deleted.

Key improvements:
- Added file watching for `.clineignore` using VSCode's `FileSystemWatcher`
- Integrated with `Cline.ts` to for initialization and cleanup during task lifecycle

### Test Procedure

We have ensured that the existing `LLMFileAccessController` tests are passing.

In addition, logging was added to all of the relevant lifecycle events for the file watcher to ensure that the access controller is being updated properly.

https://github.com/user-attachments/assets/7bb7cb0f-4c3a-4129-a272-0173c1b535d3

Further unit tests covering the behavior of the file watcher in the `LLMFileAccessController` would be nice to have, but we need a way to either get the file watcher working in the VS Code test environment, or to effectively mock it. For now, manual verification via logging should be sufficient for this step.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

See video above.

### Additional Notes

- While logging it was discovered that the `abortTask()` function in `Cline.ts` is getting called twice when clicking the Cancel button while an API response is in process. This is something to fix, but doesn’t appear to affect behavior.
     - Upon further investigation, it is being called in `clearTask()` and `cancelTask()`, which together are duplicating the `abortTask()` call when pressing the "Cancel" button in the chat interface.

**Discussion Point:**

Currently, the behavior of initializing the `LLMFileAccessController` in the `Cline.ts` file is such that it will get initializing on every new chat / resumption of an old chat and destroyed when leaving a chat. This does not affect functionality, but is potentially wasteful. A recommendation is to move this up to a level where it is only initialized once on extension start. The filewatcher will take care of all subsequent `.clineignore` file changes.

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Integrates `LLMFileAccessController` into `Cline.ts` with real-time `.clineignore` monitoring using `FileSystemWatcher`.
> 
>   - **Behavior**:
>     - Integrates `LLMFileAccessController` into `Cline.ts` for task lifecycle management.
>     - Adds real-time monitoring of `.clineignore` using `FileSystemWatcher` to update ignore patterns dynamically.
>   - **Testing**:
>     - Ensures existing tests for `LLMFileAccessController` pass.
>     - Adds logging for lifecycle events to verify updates.
>   - **Misc**:
>     - Identifies duplicate `abortTask()` calls in `Cline.ts` during task cancellation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 989be56f4b1da0a37b7b1565bab35b39df5f3371. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->