### PR TITLE
feat:show api error status code

### DIFF
--- a/src/core/Cline.ts
+++ b/src/core/Cline.ts
@@ -1194,6 +1194,13 @@ export class Cline {
 		return false
 	}
 
+	private formatErrorWithStatusCode(error: any): string {
+		const statusCode = error.status || error.statusCode || (error.response && error.response.status)
+		const message = error.message ?? JSON.stringify(serializeError(error), null, 2)
+
+		return statusCode ? `API Request Error (${statusCode}): ${message}` : `API Request Error: ${message}`
+	}
+
 	async *attemptApiRequest(previousApiReqIndex: number): ApiStream {
 		// Wait for MCP servers to be connected before generating system prompt
 		await pWaitFor(() => this.providerRef.deref()?.mcpHub?.isConnecting !== true, { timeout: 10_000 }).catch(() => {
@@ -1302,10 +1309,7 @@ export class Cline {
 				// request failed after retrying automatically once, ask user if they want to retry again
 				// note that this api_req_failed ask is unique in that we only present this option if the api hasn't streamed any content yet (ie it fails on the first chunk due), as it would allow them to hit a retry button. However if the api failed mid-stream, it could be in any arbitrary state where some tools may have executed, so that error is handled differently and requires cancelling the task entirely.
 				// Extract status code if available in error object
-				const statusCode = error.status || error.statusCode || (error.response && error.response.status)
-				const errorMessage = statusCode
-					? `API Request Error (${statusCode}): ${error.message ?? JSON.stringify(serializeError(error), null, 2)}`
-					: `API Request Error: ${error.message ?? JSON.stringify(serializeError(error), null, 2)}`
+				const errorMessage = this.formatErrorWithStatusCode(error)
 
 				const { response } = await this.ask("api_req_failed", errorMessage)
 				if (response !== "yesButtonClicked") {
@@ -3055,11 +3059,7 @@ export class Cline {
 				// abandoned happens when extension is no longer waiting for the cline instance to finish aborting (error is thrown here when any function in the for loop throws due to this.abort)
 				if (!this.abandoned) {
 					this.abortTask() // if the stream failed, there's various states the task could be in (i.e. could have streamed some tools the user may have executed), so we just resort to replicating a cancel task
-					// Extract status code if available in error object
-					const statusCode = error.status || error.statusCode || (error.response && error.response.status)
-					const errorMessage = statusCode
-						? `API Request Error (${statusCode}): ${error.message ?? JSON.stringify(serializeError(error), null, 2)}`
-						: `API Request Error: ${error.message ?? JSON.stringify(serializeError(error), null, 2)}`
+					const errorMessage = this.formatErrorWithStatusCode(error)
 
 					await abortStream("streaming_failed", errorMessage)
 					const history = await this.providerRef.deref()?.getTaskWithId(this.taskId)

--- a/src/core/Cline.ts
+++ b/src/core/Cline.ts
@@ -1198,7 +1198,8 @@ export class Cline {
 		const statusCode = error.status || error.statusCode || (error.response && error.response.status)
 		const message = error.message ?? JSON.stringify(serializeError(error), null, 2)
 
-		return statusCode ? `API Request Error (${statusCode}): ${message}` : `API Request Error: ${message}`
+		// Only prepend the statusCode if it's not already part of the message
+		return statusCode && !message.includes(statusCode.toString()) ? `${statusCode} - ${message}` : message
 	}
 
 	async *attemptApiRequest(previousApiReqIndex: number): ApiStream {

--- a/src/core/Cline.ts
+++ b/src/core/Cline.ts
@@ -1309,7 +1309,6 @@ export class Cline {
 			} else {
 				// request failed after retrying automatically once, ask user if they want to retry again
 				// note that this api_req_failed ask is unique in that we only present this option if the api hasn't streamed any content yet (ie it fails on the first chunk due), as it would allow them to hit a retry button. However if the api failed mid-stream, it could be in any arbitrary state where some tools may have executed, so that error is handled differently and requires cancelling the task entirely.
-				// Extract status code if available in error object
 				const errorMessage = this.formatErrorWithStatusCode(error)
 
 				const { response } = await this.ask("api_req_failed", errorMessage)


### PR DESCRIPTION
### Description

Show status code when available in error message.
Not too fancy, but atleast should help differentiate between problems somewhat, to prevent 100x the same issue's being created while the issue might not be the same. [Open in discussion.](https://github.com/cline/cline/discussions/1615)
### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [  ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [  ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [  ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [ x ] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ x ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ x ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds functionality to display API error status codes in error messages in `Cline.ts` for better error differentiation.
> 
>   - **Behavior**:
>     - Adds `formatErrorWithStatusCode()` in `Cline.ts` to prepend status code to error messages if not already included.
>     - Updates error handling in `attemptApiRequest()` and `recursivelyMakeClineRequests()` to use `formatErrorWithStatusCode()`.
>   - **Functions**:
>     - Modifies `attemptApiRequest()` to format error messages with status codes.
>     - Modifies `recursivelyMakeClineRequests()` to handle formatted error messages.
>   - **Misc**:
>     - Improves error differentiation by including status codes in error messages.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for d2bea2f7bd7ad431774d485d7a09979d3d351b71. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->