### PR TITLE
docs: add getting started guide link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ English | <a href="https://github.com/cline/cline/blob/main/locales/es/README.md
 </table>
 </div>
 
+> 🚀 **New to Cline?** Check out our [Getting Started Guide](https://docs.cline.bot/getting-started/getting-started-new-coders) for a step-by-step walkthrough to help you get up and running quickly!
+
 Meet Cline, an AI assistant that can use your **CLI** a**N**d **E**ditor.
 
 Thanks to [Claude 3.5 Sonnet's agentic coding capabilities](https://www-cdn.anthropic.com/fed9cc193a14b84131812372d8d5857f8f304c52/Model_Card_Claude_3_Addendum.pdf), Cline can handle complex software development tasks step-by-step. With tools that let him create & edit files, explore large projects, use the browser, and execute terminal commands (after you grant permission), he can assist you in ways that go beyond code completion or tech support. Cline can even use the Model Context Protocol (MCP) to create new tools and extend his own capabilities. While autonomous AI scripts traditionally run in sandboxed environments, this extension provides a human-in-the-loop GUI to approve every file change and terminal command, providing a safe and accessible way to explore the potential of agentic AI.


### PR DESCRIPTION
### Description

Added link to getting started docs in README to help new users get rolling with Cline

### Test Procedure

Yes -- this is purely an update to the README

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [x] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [ ] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<img width="783" alt="image" src="https://github.com/user-attachments/assets/9d4cdf26-16f5-446d-936a-bb653a123276" />

### Additional Notes
