### PR TITLE
Update README.md to include Getting Started

### DIFF
--- a/.changeset/neat-apricots-search.md
+++ b/.changeset/neat-apricots-search.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Update README.md to include Getting Started

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ English | <a href="https://github.com/cline/cline/blob/main/locales/es/README.md
 <a href="https://github.com/cline/cline/discussions/categories/feature-requests?discussions_q=is%3Aopen+category%3A%22Feature+Requests%22+sort%3Atop" target="_blank"><strong>Feature Requests</strong></a>
 </td>
 <td align="center">
-<a href="https://cline.bot/join-us" target="_blank"><strong>We're Hiring!</strong></a>
+<a href="https://docs.cline.bot/getting-started/getting-started-new-coders" target="_blank"><strong>Getting Started</strong></a>
 </td>
 </tbody>
 </table>


### PR DESCRIPTION
### Description

Swapped "We're Hiring" with "Getting Started" link to getting started docs

### Test Procedure

I tested the link works

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [x ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [ ] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

![image](https://github.com/user-attachments/assets/e2f2aa07-9d47-42b5-a19f-d2f0aa62a829)

### Additional Notes


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Replace "We're Hiring" link with "Getting Started" link in `README.md`.
> 
>   - **Documentation**:
>     - In `README.md`, replaced "We're Hiring" link with "Getting Started" link to getting started docs.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 8c579365c56105334cb09381e3bac0067e36d5dd. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->