### PR TITLE
Custom Gateway API Provider

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -9,6 +9,7 @@ import { OllamaHandler } from "./providers/ollama"
 import { LmStudioHandler } from "./providers/lmstudio"
 import { GeminiHandler } from "./providers/gemini"
 import { OpenAiNativeHandler } from "./providers/openai-native"
+import { CustomGatewayHandler } from "./providers/custom-gateway"
 import { ApiStream } from "./transform/stream"
 import { DeepSeekHandler } from "./providers/deepseek"
 import { MistralHandler } from "./providers/mistral"
@@ -53,6 +54,8 @@ export function buildApiHandler(configuration: ApiConfiguration): ApiHandler {
 			return new VsCodeLmHandler(options)
 		case "litellm":
 			return new LiteLlmHandler(options)
+		case "custom-gateway":
+			return new CustomGatewayHandler(options)
 		default:
 			return new AnthropicHandler(options)
 	}

--- a/src/api/providers/custom-gateway.ts
+++ b/src/api/providers/custom-gateway.ts
@@ -1,0 +1,390 @@
+import { Anthropic } from "@anthropic-ai/sdk"
+import axios, { AxiosInstance } from "axios"
+import { ApiHandler } from "../"
+import {
+	ApiHandlerOptions,
+	CustomGatewayConfig,
+	CustomGatewayModel,
+	HealthCheckConfig,
+	ModelInfo,
+} from "../../shared/api"
+import { convertMessages, validateMessageFormat } from "../transform/custom-gateway-format"
+import { ApiStream, ApiStreamChunk } from "../transform/stream"
+
+interface HealthCheckRequest {
+	type: "ping"
+	timestamp?: number
+}
+
+interface HealthCheckResponse {
+	type: "pong"
+	status: "healthy" | "degraded" | "unhealthy"
+	timestamp?: number
+	message?: string
+}
+
+interface HealthStatusMessage {
+	type: "customGatewayHealthStatus"
+	healthStatus: {
+		status: "healthy" | "degraded" | "unhealthy"
+		message?: string
+		timestamp?: number
+	}
+}
+
+export class CustomGatewayHandler implements ApiHandler {
+	private options: ApiHandlerOptions
+	private config: CustomGatewayConfig
+	private client: AxiosInstance
+	private modelListCache?: CustomGatewayModel[]
+	private modelListLastFetched?: number
+	private cachedModel?: { id: string; info: ModelInfo }
+
+	private debugLog(message: string, data?: any) {
+		if (this.config.debug) {
+			const timestamp = new Date().toISOString();
+			const logMessage = `[Custom Gateway Debug] ${timestamp} - ${message}`;
+			this.options.outputChannel?.appendLine(logMessage);
+			if (data) {
+				this.options.outputChannel?.appendLine(JSON.stringify(data, null, 2));
+			}
+			console.log(logMessage, data);
+		}
+	}
+
+	constructor(options: ApiHandlerOptions) {
+		if (!options.customGatewayConfig) {
+			throw new Error("Custom gateway configuration is required")
+		}
+
+		this.options = options
+		this.config = options.customGatewayConfig
+
+		// Validate required configuration
+		if (!this.config.baseUrl) {
+			throw new Error("Base URL is required")
+		}
+		if (!this.config.compatibilityMode) {
+			throw new Error("Compatibility mode is required")
+		}
+
+		// Create axios client with base configuration
+		this.client = axios.create({
+			baseURL: this.getFullBaseUrl(),
+			headers: this.buildHeaders(),
+		})
+	}
+
+	private getFullBaseUrl(): string {
+		const baseUrl = this.config.baseUrl.endsWith("/")
+			? this.config.baseUrl.slice(0, -1)
+			: this.config.baseUrl
+		const pathPrefix = this.config.pathPrefix
+			? this.config.pathPrefix.startsWith("/")
+				? this.config.pathPrefix
+				: `/${this.config.pathPrefix}`
+			: ""
+		return `${baseUrl}${pathPrefix}`
+	}
+
+	private buildHeaders(): Record<string, string> {
+		const headers: Record<string, string> = {
+			"Content-Type": "application/json",
+		}
+		for (const header of this.config.headers) {
+			headers[header.key] = header.value
+		}
+		return headers
+	}
+
+	private sendHealthStatus(response: HealthCheckResponse) {
+		// Send health status to webview
+		this.options.webview?.postMessage({
+			type: "customGatewayHealthStatus",
+			healthStatus: {
+				status: response.status,
+				message: response.message,
+				timestamp: response.timestamp,
+			},
+		} as HealthStatusMessage)
+	}
+
+	async performHealthCheck() {
+		try {
+			const model = await this.getModel()
+			const endpoint = "/chat/completions"
+			const requestData = {
+				model: model.id,
+				messages: [
+					{
+						role: "user",
+						content: "If you are working correctly, please respond to this with ONLY PONG!",
+					},
+				],
+			}
+			
+			let isValidResponse = false
+			
+			try {
+				const timeout = this.config.healthCheck?.timeout ?? 10000;
+				this.debugLog("Sending health check request", {
+					endpoint,
+					timeout,
+					model: model.id,
+					requestData
+				});
+				const response = await this.client.post(
+					endpoint,
+					requestData,
+					{
+						timeout: timeout,
+					}
+				)
+				this.debugLog("Received health check response", {
+					status: response.status,
+					headers: response.headers,
+					data: response.data
+				});
+				
+				// Validate response based on compatibility mode
+				switch (this.config.compatibilityMode) {
+					case "openai":
+						// Check for OpenAI response format
+						if (
+							response.data.choices?.[0]?.message?.role === "assistant" &&
+							typeof response.data.choices[0].message.content === "string"
+						) {
+							isValidResponse = true
+						}
+						break
+					case "anthropic":
+						// Check for Anthropic response format
+						if (
+							response.data.content?.[0]?.text ||
+							(response.data.choices?.[0]?.message?.content &&
+								!response.data.choices[0].message.role)
+						) {
+							isValidResponse = true
+						}
+						break
+					case "bedrock":
+						// Check for Bedrock response format (which follows AWS Bedrock's format)
+						if (
+							response.data.completion ||
+							response.data.results?.[0]?.outputText ||
+							(response.data.choices?.[0]?.message?.content &&
+								response.data.requestId)
+						) {
+							isValidResponse = true
+						}
+						break
+					default: // Fallback for unknown compatibility modes
+						// For unknown compatibility modes, check for any reasonable response format
+						if (
+							response.data.choices?.[0]?.message?.content ||
+							response.data.content?.[0]?.text ||
+							response.data.response ||
+							response.data.output ||
+							response.data.generated_text
+						) {
+							isValidResponse = true
+						}
+				}
+			} catch (requestError) {
+				this.debugLog("Request failed", requestError)
+				throw requestError
+			}
+
+			if (isValidResponse) {
+				this.sendHealthStatus({
+					type: "pong",
+					status: "healthy",
+					message: "Connection successful",
+					timestamp: Date.now(),
+				})
+			} else {
+				this.sendHealthStatus({
+					type: "pong",
+					status: "unhealthy",
+					message: "Invalid response from model",
+					timestamp: Date.now(),
+				})
+			}
+		} catch (error) {
+			this.debugLog("Health check failed", error)
+			this.sendHealthStatus({
+				type: "pong",
+				status: "unhealthy",
+				message: error instanceof Error ? error.message : String(error),
+				timestamp: Date.now(),
+			})
+		}
+	}
+
+	async fetchModelList(): Promise<CustomGatewayModel[]> {
+		if (!this.config.modelListSource) {
+			if (!this.config.defaultModel) {
+				throw new Error("Either modelListSource or defaultModel must be provided")
+			}
+			return [this.config.defaultModel]
+		}
+
+		// Check cache
+		const cacheExpiry = 5 * 60 * 1000 // 5 minutes
+		if (
+			this.modelListCache &&
+			this.modelListLastFetched &&
+			Date.now() - this.modelListLastFetched < cacheExpiry
+		) {
+			return this.modelListCache
+		}
+
+		try {
+			const response = await this.client.get(this.config.modelListSource)
+			const models = response.data.models as CustomGatewayModel[]
+			this.modelListCache = models
+			this.modelListLastFetched = Date.now()
+			return models
+		} catch (error) {
+			this.options.outputChannel?.appendLine(`Failed to fetch model list: ${error instanceof Error ? error.message : String(error)}`)
+			if (this.config.defaultModel) {
+				return [this.config.defaultModel]
+			}
+			throw error
+		}
+	}
+
+	async *createMessage(systemPrompt: string, messages: Anthropic.Messages.MessageParam[]): ApiStream {
+		this.debugLog("Starting Message Creation")
+		const model = await this.getModel()
+		const endpoint = "/chat/completions"
+		const requestMessages = convertMessages(this.config.compatibilityMode, systemPrompt, messages)
+		validateMessageFormat(this.config.compatibilityMode, requestMessages)
+		
+		const requestData = {
+			model: model.id,
+			messages: requestMessages,
+			stream: true,
+		}
+
+		this.debugLog("Request details", {
+			endpoint,
+			baseUrl: this.getFullBaseUrl(),
+			headers: this.buildHeaders(),
+			requestData
+		})
+		
+		try {
+			this.debugLog("Sending streaming request")
+			const response = await this.client.post(
+				endpoint,
+				requestData,
+				{
+					responseType: "stream",
+				}
+			)
+			
+			this.debugLog("Received streaming response", {
+				status: response.status,
+				statusText: response.statusText,
+				headers: response.headers
+			})
+
+			for await (const chunk of response.data) {
+				const lines = chunk.toString().split('\n')
+				for (const line of lines) {
+					if (line.startsWith('data: ')) {
+						// Skip empty lines or "[DONE]" message
+						if (line === 'data: ' || line === 'data: [DONE]') {
+							continue
+						}
+						
+						this.debugLog("Received SSE data", { line })
+						
+						let content: string | undefined
+						
+						try {
+							// Parse the JSON data after the "data: " prefix
+							const jsonStr = line.substring(6) // length of "data: "
+							
+							// Skip incomplete JSON
+							if (!jsonStr.trim() || jsonStr.trim().length < 2) {
+								this.debugLog("Skipping empty or incomplete JSON", { jsonStr })
+								continue
+							}
+							
+							try {
+                            const data = JSON.parse(jsonStr)
+                            
+                            if (data.error) {
+                                throw new Error(`Gateway API Error: ${data.error.message}`)
+                            }
+
+                            const delta = data.choices?.[0]?.delta
+                            // Skip if this is just the initial message structure with empty content
+                            if (delta?.role === "assistant" && !delta.content) {
+                                continue
+                            }
+                            
+                            // Only yield when we have actual content
+                            if (delta?.content) {
+                                yield {
+                                    type: "text",
+                                    text: delta.content,
+                                } as ApiStreamChunk
+                            }
+							} catch (parseError) {
+								// Log the error but don't throw it - allow the stream to continue
+								this.debugLog("JSON parse warning", { error: parseError, jsonStr })
+								continue
+							}
+						} catch (streamError) {
+							this.debugLog("Stream processing error", { error: streamError, line })
+							throw streamError
+						}
+					}
+				}
+			}
+
+			// Final usage info if available
+			if (response.headers["x-usage"]) {
+				try {
+					const usage = JSON.parse(response.headers["x-usage"])
+					yield {
+						type: "usage",
+						inputTokens: usage.prompt_tokens || 0,
+						outputTokens: usage.completion_tokens || 0,
+						totalCost: usage.total_cost || 0,
+					} as ApiStreamChunk
+				} catch (error) {
+					this.debugLog("Failed to parse usage info", error)
+				}
+			}
+		} catch (error) {
+			this.debugLog("Error in message creation", error)
+			throw error
+		}
+	}
+
+	getModel(): { id: string; info: ModelInfo } {
+		this.debugLog("Getting model")
+		if (!this.cachedModel) {
+			// Initialize with default model if available
+			if (this.config.defaultModel) {
+				this.cachedModel = this.config.defaultModel
+			} else {
+				throw new Error("No model available. Configure defaultModel or fetch from modelListSource.")
+			}
+			
+			// Fetch model list in background to update cache
+			this.fetchModelList().then(models => {
+				if (models.length > 0) {
+					this.cachedModel = models[0]
+				}
+			}).catch(error => {
+				this.debugLog("Failed to update model cache", error)
+			})
+		}
+		return this.cachedModel
+	}
+}

--- a/src/api/transform/custom-gateway-format.ts
+++ b/src/api/transform/custom-gateway-format.ts
@@ -1,0 +1,227 @@
+import { Anthropic } from "@anthropic-ai/sdk"
+import OpenAI from "openai"
+import { CompatibilityMode } from "../../shared/api"
+import { convertToOpenAiMessages } from "./openai-format"
+
+// Convert Anthropic messages to OpenAI format
+export function convertToOpenAiFormat(
+    systemPrompt: string,
+    messages: Anthropic.Messages.MessageParam[]
+): OpenAI.Chat.ChatCompletionMessageParam[] {
+    return [
+        { role: "system", content: systemPrompt },
+        ...convertToOpenAiMessages(messages),
+    ]
+}
+
+// Convert Anthropic messages to Anthropic format (pass-through)
+export function convertToAnthropicFormat(
+    _systemPrompt: string,
+    messages: Anthropic.Messages.MessageParam[]
+): Anthropic.Messages.MessageParam[] {
+    return messages
+}
+
+// Convert Anthropic messages to Bedrock format
+export function convertToBedrockFormat(
+    systemPrompt: string,
+    messages: Anthropic.Messages.MessageParam[]
+): {
+    input: {
+        messages: Array<{
+            role: string
+            content: string | Array<{
+                type: "text" | "image"
+                text?: string
+                image?: { source: { type: "url"; url: string } }
+            }>
+        }>
+    }
+} {
+    return {
+        input: {
+            messages: [
+                { role: "system", content: systemPrompt },
+                ...messages.map((msg) => {
+                    if (typeof msg.content === "string") {
+                        return {
+                            role: msg.role,
+                            content: msg.content,
+                        }
+                    }
+
+                    // Handle array content with text and images
+                    const content = msg.content.reduce<Array<{
+                        type: "text" | "image";
+                        text?: string;
+                        image?: { source: { type: "url"; url: string } };
+                    }>>((acc, part) => {
+                        if (part.type === "text") {
+                            acc.push({
+                                type: "text",
+                                text: part.text,
+                            })
+                        } else if (part.type === "image") {
+                            acc.push({
+                                type: "image",
+                                image: {
+                                    source: {
+                                        type: "url",
+                                        url: `data:${part.source.media_type};base64,${part.source.data}`,
+                                    },
+                                },
+                            })
+                        }
+                        // Skip tool_use and tool_result blocks as they're not supported in Bedrock
+                        return acc
+                    }, [])
+
+                    return {
+                        role: msg.role,
+                        content,
+                    }
+                }),
+            ],
+        },
+    }
+}
+
+// Convert messages based on compatibility mode
+export function convertMessages(
+    mode: CompatibilityMode,
+    systemPrompt: string,
+    messages: Anthropic.Messages.MessageParam[]
+): unknown {
+    switch (mode) {
+        case "openai":
+            return convertToOpenAiFormat(systemPrompt, messages)
+        case "anthropic":
+            return convertToAnthropicFormat(systemPrompt, messages)
+        case "bedrock":
+            return convertToBedrockFormat(systemPrompt, messages)
+        default:
+            throw new Error(`Unsupported compatibility mode: ${mode}`)
+    }
+}
+
+// Validate message format based on compatibility mode
+export function validateMessageFormat(
+    mode: CompatibilityMode,
+    messages: unknown
+): void {
+    switch (mode) {
+        case "openai":
+            validateOpenAiFormat(messages)
+            break
+        case "anthropic":
+            validateAnthropicFormat(messages)
+            break
+        case "bedrock":
+            validateBedrockFormat(messages)
+            break
+        default:
+            throw new Error(`Unsupported compatibility mode: ${mode}`)
+    }
+}
+
+function validateOpenAiFormat(messages: unknown): void {
+    if (!Array.isArray(messages)) {
+        throw new Error("OpenAI format requires an array of messages")
+    }
+
+    for (const msg of messages) {
+        if (!msg || typeof msg !== "object") {
+            throw new Error("Each message must be an object")
+        }
+
+        if (!("role" in msg) || !["system", "user", "assistant", "tool"].includes(msg.role as string)) {
+            throw new Error("Invalid message role")
+        }
+
+        if (!("content" in msg)) {
+            throw new Error("Message content is required")
+        }
+
+        if (Array.isArray(msg.content)) {
+            for (const part of msg.content) {
+                if (!part || typeof part !== "object") {
+                    throw new Error("Content array must contain objects")
+                }
+                if (!("type" in part) || !["text", "image_url"].includes(part.type as string)) {
+                    throw new Error("Invalid content type")
+                }
+            }
+        }
+    }
+}
+
+function validateAnthropicFormat(messages: unknown): void {
+    if (!Array.isArray(messages)) {
+        throw new Error("Anthropic format requires an array of messages")
+    }
+
+    for (const msg of messages) {
+        if (!msg || typeof msg !== "object") {
+            throw new Error("Each message must be an object")
+        }
+
+        if (!("role" in msg) || !["user", "assistant"].includes(msg.role as string)) {
+            throw new Error("Invalid message role")
+        }
+
+        if (!("content" in msg)) {
+            throw new Error("Message content is required")
+        }
+
+        if (Array.isArray(msg.content)) {
+            for (const part of msg.content) {
+                if (!part || typeof part !== "object") {
+                    throw new Error("Content array must contain objects")
+                }
+                if (!("type" in part) || !["text", "image"].includes(part.type as string)) {
+                    throw new Error("Invalid content type")
+                }
+            }
+        }
+    }
+}
+
+function validateBedrockFormat(messages: unknown): void {
+    if (!messages || typeof messages !== "object") {
+        throw new Error("Bedrock format requires an object")
+    }
+
+    if (!("input" in messages) || !messages.input || typeof messages.input !== "object") {
+        throw new Error("Missing or invalid input object")
+    }
+
+    const input = messages.input as { messages?: unknown }
+    if (!input.messages || !Array.isArray(input.messages)) {
+        throw new Error("Input must contain an array of messages")
+    }
+
+    for (const msg of input.messages) {
+        if (!msg || typeof msg !== "object") {
+            throw new Error("Each message must be an object")
+        }
+
+        if (!("role" in msg) || !["system", "user", "assistant"].includes(msg.role as string)) {
+            throw new Error("Invalid message role")
+        }
+
+        if (!("content" in msg)) {
+            throw new Error("Message content is required")
+        }
+
+        if (Array.isArray(msg.content)) {
+            for (const part of msg.content) {
+                if (!part || typeof part !== "object") {
+                    throw new Error("Content array must contain objects")
+                }
+                if (!("type" in part) || !["text", "image"].includes(part.type as string)) {
+                    throw new Error("Invalid content type")
+                }
+            }
+        }
+    }
+}

--- a/src/api/transform/custom-gateway-format.ts
+++ b/src/api/transform/custom-gateway-format.ts
@@ -5,223 +5,221 @@ import { convertToOpenAiMessages } from "./openai-format"
 
 // Convert Anthropic messages to OpenAI format
 export function convertToOpenAiFormat(
-    systemPrompt: string,
-    messages: Anthropic.Messages.MessageParam[]
+	systemPrompt: string,
+	messages: Anthropic.Messages.MessageParam[],
 ): OpenAI.Chat.ChatCompletionMessageParam[] {
-    return [
-        { role: "system", content: systemPrompt },
-        ...convertToOpenAiMessages(messages),
-    ]
+	return [{ role: "system", content: systemPrompt }, ...convertToOpenAiMessages(messages)]
 }
 
 // Convert Anthropic messages to Anthropic format (pass-through)
 export function convertToAnthropicFormat(
-    _systemPrompt: string,
-    messages: Anthropic.Messages.MessageParam[]
+	_systemPrompt: string,
+	messages: Anthropic.Messages.MessageParam[],
 ): Anthropic.Messages.MessageParam[] {
-    return messages
+	return messages
 }
 
 // Convert Anthropic messages to Bedrock format
 export function convertToBedrockFormat(
-    systemPrompt: string,
-    messages: Anthropic.Messages.MessageParam[]
+	systemPrompt: string,
+	messages: Anthropic.Messages.MessageParam[],
 ): {
-    input: {
-        messages: Array<{
-            role: string
-            content: string | Array<{
-                type: "text" | "image"
-                text?: string
-                image?: { source: { type: "url"; url: string } }
-            }>
-        }>
-    }
+	input: {
+		messages: Array<{
+			role: string
+			content:
+				| string
+				| Array<{
+						type: "text" | "image"
+						text?: string
+						image?: { source: { type: "url"; url: string } }
+				  }>
+		}>
+	}
 } {
-    return {
-        input: {
-            messages: [
-                { role: "system", content: systemPrompt },
-                ...messages.map((msg) => {
-                    if (typeof msg.content === "string") {
-                        return {
-                            role: msg.role,
-                            content: msg.content,
-                        }
-                    }
+	return {
+		input: {
+			messages: [
+				{ role: "system", content: systemPrompt },
+				...messages.map((msg) => {
+					if (typeof msg.content === "string") {
+						return {
+							role: msg.role,
+							content: msg.content,
+						}
+					}
 
-                    // Handle array content with text and images
-                    const content = msg.content.reduce<Array<{
-                        type: "text" | "image";
-                        text?: string;
-                        image?: { source: { type: "url"; url: string } };
-                    }>>((acc, part) => {
-                        if (part.type === "text") {
-                            acc.push({
-                                type: "text",
-                                text: part.text,
-                            })
-                        } else if (part.type === "image") {
-                            acc.push({
-                                type: "image",
-                                image: {
-                                    source: {
-                                        type: "url",
-                                        url: `data:${part.source.media_type};base64,${part.source.data}`,
-                                    },
-                                },
-                            })
-                        }
-                        // Skip tool_use and tool_result blocks as they're not supported in Bedrock
-                        return acc
-                    }, [])
+					// Handle array content with text and images
+					const content = msg.content.reduce<
+						Array<{
+							type: "text" | "image"
+							text?: string
+							image?: { source: { type: "url"; url: string } }
+						}>
+					>((acc, part) => {
+						if (part.type === "text") {
+							acc.push({
+								type: "text",
+								text: part.text,
+							})
+						} else if (part.type === "image") {
+							acc.push({
+								type: "image",
+								image: {
+									source: {
+										type: "url",
+										url: `data:${part.source.media_type};base64,${part.source.data}`,
+									},
+								},
+							})
+						}
+						// Skip tool_use and tool_result blocks as they're not supported in Bedrock
+						return acc
+					}, [])
 
-                    return {
-                        role: msg.role,
-                        content,
-                    }
-                }),
-            ],
-        },
-    }
+					return {
+						role: msg.role,
+						content,
+					}
+				}),
+			],
+		},
+	}
 }
 
 // Convert messages based on compatibility mode
 export function convertMessages(
-    mode: CompatibilityMode,
-    systemPrompt: string,
-    messages: Anthropic.Messages.MessageParam[]
+	mode: CompatibilityMode,
+	systemPrompt: string,
+	messages: Anthropic.Messages.MessageParam[],
 ): unknown {
-    switch (mode) {
-        case "openai":
-            return convertToOpenAiFormat(systemPrompt, messages)
-        case "anthropic":
-            return convertToAnthropicFormat(systemPrompt, messages)
-        case "bedrock":
-            return convertToBedrockFormat(systemPrompt, messages)
-        default:
-            throw new Error(`Unsupported compatibility mode: ${mode}`)
-    }
+	switch (mode) {
+		case "openai":
+			return convertToOpenAiFormat(systemPrompt, messages)
+		case "anthropic":
+			return convertToAnthropicFormat(systemPrompt, messages)
+		case "bedrock":
+			return convertToBedrockFormat(systemPrompt, messages)
+		default:
+			throw new Error(`Unsupported compatibility mode: ${mode}`)
+	}
 }
 
 // Validate message format based on compatibility mode
-export function validateMessageFormat(
-    mode: CompatibilityMode,
-    messages: unknown
-): void {
-    switch (mode) {
-        case "openai":
-            validateOpenAiFormat(messages)
-            break
-        case "anthropic":
-            validateAnthropicFormat(messages)
-            break
-        case "bedrock":
-            validateBedrockFormat(messages)
-            break
-        default:
-            throw new Error(`Unsupported compatibility mode: ${mode}`)
-    }
+export function validateMessageFormat(mode: CompatibilityMode, messages: unknown): void {
+	switch (mode) {
+		case "openai":
+			validateOpenAiFormat(messages)
+			break
+		case "anthropic":
+			validateAnthropicFormat(messages)
+			break
+		case "bedrock":
+			validateBedrockFormat(messages)
+			break
+		default:
+			throw new Error(`Unsupported compatibility mode: ${mode}`)
+	}
 }
 
 function validateOpenAiFormat(messages: unknown): void {
-    if (!Array.isArray(messages)) {
-        throw new Error("OpenAI format requires an array of messages")
-    }
+	if (!Array.isArray(messages)) {
+		throw new Error("OpenAI format requires an array of messages")
+	}
 
-    for (const msg of messages) {
-        if (!msg || typeof msg !== "object") {
-            throw new Error("Each message must be an object")
-        }
+	for (const msg of messages) {
+		if (!msg || typeof msg !== "object") {
+			throw new Error("Each message must be an object")
+		}
 
-        if (!("role" in msg) || !["system", "user", "assistant", "tool"].includes(msg.role as string)) {
-            throw new Error("Invalid message role")
-        }
+		if (!("role" in msg) || !["system", "user", "assistant", "tool"].includes(msg.role as string)) {
+			throw new Error("Invalid message role")
+		}
 
-        if (!("content" in msg)) {
-            throw new Error("Message content is required")
-        }
+		if (!("content" in msg)) {
+			throw new Error("Message content is required")
+		}
 
-        if (Array.isArray(msg.content)) {
-            for (const part of msg.content) {
-                if (!part || typeof part !== "object") {
-                    throw new Error("Content array must contain objects")
-                }
-                if (!("type" in part) || !["text", "image_url"].includes(part.type as string)) {
-                    throw new Error("Invalid content type")
-                }
-            }
-        }
-    }
+		if (Array.isArray(msg.content)) {
+			for (const part of msg.content) {
+				if (!part || typeof part !== "object") {
+					throw new Error("Content array must contain objects")
+				}
+				if (!("type" in part) || !["text", "image_url"].includes(part.type as string)) {
+					throw new Error("Invalid content type")
+				}
+			}
+		}
+	}
 }
 
 function validateAnthropicFormat(messages: unknown): void {
-    if (!Array.isArray(messages)) {
-        throw new Error("Anthropic format requires an array of messages")
-    }
+	if (!Array.isArray(messages)) {
+		throw new Error("Anthropic format requires an array of messages")
+	}
 
-    for (const msg of messages) {
-        if (!msg || typeof msg !== "object") {
-            throw new Error("Each message must be an object")
-        }
+	for (const msg of messages) {
+		if (!msg || typeof msg !== "object") {
+			throw new Error("Each message must be an object")
+		}
 
-        if (!("role" in msg) || !["user", "assistant"].includes(msg.role as string)) {
-            throw new Error("Invalid message role")
-        }
+		if (!("role" in msg) || !["user", "assistant"].includes(msg.role as string)) {
+			throw new Error("Invalid message role")
+		}
 
-        if (!("content" in msg)) {
-            throw new Error("Message content is required")
-        }
+		if (!("content" in msg)) {
+			throw new Error("Message content is required")
+		}
 
-        if (Array.isArray(msg.content)) {
-            for (const part of msg.content) {
-                if (!part || typeof part !== "object") {
-                    throw new Error("Content array must contain objects")
-                }
-                if (!("type" in part) || !["text", "image"].includes(part.type as string)) {
-                    throw new Error("Invalid content type")
-                }
-            }
-        }
-    }
+		if (Array.isArray(msg.content)) {
+			for (const part of msg.content) {
+				if (!part || typeof part !== "object") {
+					throw new Error("Content array must contain objects")
+				}
+				if (!("type" in part) || !["text", "image"].includes(part.type as string)) {
+					throw new Error("Invalid content type")
+				}
+			}
+		}
+	}
 }
 
 function validateBedrockFormat(messages: unknown): void {
-    if (!messages || typeof messages !== "object") {
-        throw new Error("Bedrock format requires an object")
-    }
+	if (!messages || typeof messages !== "object") {
+		throw new Error("Bedrock format requires an object")
+	}
 
-    if (!("input" in messages) || !messages.input || typeof messages.input !== "object") {
-        throw new Error("Missing or invalid input object")
-    }
+	if (!("input" in messages) || !messages.input || typeof messages.input !== "object") {
+		throw new Error("Missing or invalid input object")
+	}
 
-    const input = messages.input as { messages?: unknown }
-    if (!input.messages || !Array.isArray(input.messages)) {
-        throw new Error("Input must contain an array of messages")
-    }
+	const input = messages.input as { messages?: unknown }
+	if (!input.messages || !Array.isArray(input.messages)) {
+		throw new Error("Input must contain an array of messages")
+	}
 
-    for (const msg of input.messages) {
-        if (!msg || typeof msg !== "object") {
-            throw new Error("Each message must be an object")
-        }
+	for (const msg of input.messages) {
+		if (!msg || typeof msg !== "object") {
+			throw new Error("Each message must be an object")
+		}
 
-        if (!("role" in msg) || !["system", "user", "assistant"].includes(msg.role as string)) {
-            throw new Error("Invalid message role")
-        }
+		if (!("role" in msg) || !["system", "user", "assistant"].includes(msg.role as string)) {
+			throw new Error("Invalid message role")
+		}
 
-        if (!("content" in msg)) {
-            throw new Error("Message content is required")
-        }
+		if (!("content" in msg)) {
+			throw new Error("Message content is required")
+		}
 
-        if (Array.isArray(msg.content)) {
-            for (const part of msg.content) {
-                if (!part || typeof part !== "object") {
-                    throw new Error("Content array must contain objects")
-                }
-                if (!("type" in part) || !["text", "image"].includes(part.type as string)) {
-                    throw new Error("Invalid content type")
-                }
-            }
-        }
-    }
+		if (Array.isArray(msg.content)) {
+			for (const part of msg.content) {
+				if (!part || typeof part !== "object") {
+					throw new Error("Content array must contain objects")
+				}
+				if (!("type" in part) || !["text", "image"].includes(part.type as string)) {
+					throw new Error("Invalid content type")
+				}
+			}
+		}
+	}
 }

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -494,7 +494,7 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 								this.cline.api = buildApiHandler({
 									...message.apiConfiguration,
 									outputChannel: this.outputChannel,
-									webview: this.view?.webview
+									webview: this.view?.webview,
 								})
 							}
 						}
@@ -1038,11 +1038,11 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 		await this.storeSecret("openRouterApiKey", apiKey)
 		await this.postStateToWebview()
 		if (this.cline) {
-			this.cline.api = buildApiHandler({ 
-				apiProvider: openrouter, 
+			this.cline.api = buildApiHandler({
+				apiProvider: openrouter,
 				openRouterApiKey: apiKey,
 				outputChannel: this.outputChannel,
-				webview: this.view?.webview
+				webview: this.view?.webview,
 			})
 		}
 		// await this.postMessageToWebview({ type: "action", action: "settingsButtonClicked" }) // bad ux if user is on welcome
@@ -1467,48 +1467,49 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 		}
 
 		return {
-				apiConfiguration: {
-					apiProvider,
-					apiModelId,
-					apiKey,
-					openRouterApiKey,
-					awsAccessKey,
-					awsSecretKey,
-					awsSessionToken,
-					awsRegion,
+			apiConfiguration: {
+				apiProvider,
+				apiModelId,
+				apiKey,
+				openRouterApiKey,
+				awsAccessKey,
+				awsSecretKey,
+				awsSessionToken,
+				awsRegion,
 				awsUseCrossRegionInference,
-					vertexProjectId,
-					vertexRegion,
-					openAiBaseUrl,
-					openAiApiKey,
-					openAiModelId,
-					ollamaModelId,
-					ollamaBaseUrl,
+				vertexProjectId,
+				vertexRegion,
+				openAiBaseUrl,
+				openAiApiKey,
+				openAiModelId,
+				ollamaModelId,
+				ollamaBaseUrl,
 				lmStudioModelId,
 				lmStudioBaseUrl,
-					anthropicBaseUrl,
-					geminiApiKey,
-					openAiNativeApiKey,
+				anthropicBaseUrl,
+				geminiApiKey,
+				openAiNativeApiKey,
 				deepSeekApiKey,
 				mistralApiKey,
-					azureApiVersion,
-					openRouterModelId,
-					openRouterModelInfo,
+				azureApiVersion,
+				openRouterModelId,
+				openRouterModelInfo,
 				vsCodeLmModelSelector,
 				liteLlmBaseUrl,
 				liteLlmModelId,
-					outputChannel: this.outputChannel,
-					webview: this.view?.webview,
-					customGatewayConfig: apiProvider === 'custom-gateway' ? 
-						customGatewayConfig || {
-							baseUrl: '',
-							compatibilityMode: 'openai' as CompatibilityMode,
-							headers: [],
-							pathPrefix: undefined,
-							modelListSource: undefined,
-							defaultModel: undefined,
-							healthCheck: undefined
-						}
+				outputChannel: this.outputChannel,
+				webview: this.view?.webview,
+				customGatewayConfig:
+					apiProvider === "custom-gateway"
+						? customGatewayConfig || {
+								baseUrl: "",
+								compatibilityMode: "openai" as CompatibilityMode,
+								headers: [],
+								pathPrefix: undefined,
+								modelListSource: undefined,
+								defaultModel: undefined,
+								healthCheck: undefined,
+							}
 						: undefined,
 			},
 			lastShownAnnouncementId,

--- a/src/shared/ExtensionMessage.ts
+++ b/src/shared/ExtensionMessage.ts
@@ -26,6 +26,9 @@ export interface ExtensionMessage {
 		| "vsCodeLmModels"
 		| "requestVsCodeLmModels"
 		| "emailSubscribed"
+		| "fetchCustomGatewayModels"
+		| "customGatewayModels"
+		| "customGatewayModelsError"
 	text?: string
 	action?:
 		| "chatButtonClicked"
@@ -46,6 +49,18 @@ export interface ExtensionMessage {
 	openRouterModels?: Record<string, ModelInfo>
 	openAiModels?: string[]
 	mcpServers?: McpServer[]
+	modelListSource?: string
+	models?: Array<{
+		id: string
+		name?: string
+		description?: string
+		maxTokens?: number
+		contextWindow?: number
+		supportsImages?: boolean
+		inputPrice?: number
+		outputPrice?: number
+	}>
+	error?: string
 }
 
 export interface ExtensionState {

--- a/src/shared/WebviewMessage.ts
+++ b/src/shared/WebviewMessage.ts
@@ -43,6 +43,9 @@ export interface WebviewMessage {
 		| "accountLogoutClicked"
 		| "subscribeEmail"
 	// | "relaunchChromeDebugMode"
+		| "fetchCustomGatewayModels"
+		| "customGatewayHealthCheck"
+		| "customGatewayHealthStatus"
 	text?: string
 	disabled?: boolean
 	askResponse?: ClineAskResponse
@@ -58,6 +61,12 @@ export interface WebviewMessage {
 	serverName?: string
 	toolName?: string
 	autoApprove?: boolean
+	modelListSource?: string
+	healthStatus?: {
+		status: "healthy" | "degraded" | "unhealthy"
+		message?: string
+		timestamp?: number
+	}
 }
 
 export type ClineAskResponse = "yesButtonClicked" | "noButtonClicked" | "messageResponse"

--- a/src/shared/WebviewMessage.ts
+++ b/src/shared/WebviewMessage.ts
@@ -42,7 +42,7 @@ export interface WebviewMessage {
 		| "accountLoginClicked"
 		| "accountLogoutClicked"
 		| "subscribeEmail"
-	// | "relaunchChromeDebugMode"
+		// | "relaunchChromeDebugMode"
 		| "fetchCustomGatewayModels"
 		| "customGatewayHealthCheck"
 		| "customGatewayHealthStatus"

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -58,7 +58,7 @@ export type ApiConfiguration = ApiHandlerOptions & {
 }
 
 // Custom Gateway Types
-export type CompatibilityMode = 'openai' | 'anthropic' | 'bedrock'
+export type CompatibilityMode = "openai" | "anthropic" | "bedrock"
 
 export interface CustomHeader {
 	key: string

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -12,9 +12,16 @@ export type ApiProvider =
 	| "mistral"
 	| "vscode-lm"
 	| "litellm"
+	| "custom-gateway"
+
+import * as vscode from "vscode"
 
 export interface ApiHandlerOptions {
+	outputChannel?: vscode.OutputChannel
 	apiModelId?: string
+	webview?: {
+		postMessage: (message: any) => void
+	}
 	apiKey?: string // anthropic
 	liteLlmBaseUrl?: string
 	liteLlmModelId?: string
@@ -42,10 +49,45 @@ export interface ApiHandlerOptions {
 	mistralApiKey?: string
 	azureApiVersion?: string
 	vsCodeLmModelSelector?: any
+	customGatewayConfig?: CustomGatewayConfig
 }
 
 export type ApiConfiguration = ApiHandlerOptions & {
 	apiProvider?: ApiProvider
+	customGatewayConfig?: CustomGatewayConfig
+}
+
+// Custom Gateway Types
+export type CompatibilityMode = 'openai' | 'anthropic' | 'bedrock'
+
+export interface CustomHeader {
+	key: string
+	value: string
+	description?: string
+	isSecret?: boolean
+}
+
+export interface CustomGatewayModel {
+	id: string
+	info: ModelInfo
+}
+
+export interface HealthCheckConfig {
+	enabled: boolean
+	endpoint?: string
+	interval?: number
+	timeout?: number // in milliseconds, defaults to 10000
+}
+
+export interface CustomGatewayConfig {
+	baseUrl: string
+	pathPrefix?: string
+	compatibilityMode: CompatibilityMode
+	modelListSource?: string
+	headers: CustomHeader[]
+	defaultModel?: CustomGatewayModel
+	healthCheck?: HealthCheckConfig
+	debug?: boolean // Enable debug logging for API connections
 }
 
 // Models

--- a/src/test/custom-gateway-handler.test.ts
+++ b/src/test/custom-gateway-handler.test.ts
@@ -1,395 +1,386 @@
-import * as assert from 'assert';
-import axios from 'axios';
-import { CustomGatewayHandler } from '../api/providers/custom-gateway';
-import { ApiHandlerOptions, CustomGatewayConfig } from '../shared/api';
+import * as assert from "assert"
+import axios from "axios"
+import { CustomGatewayHandler } from "../api/providers/custom-gateway"
+import { ApiHandlerOptions, CustomGatewayConfig } from "../shared/api"
 
 // Mock axios
 const mockAxios = {
-    create: () => ({
-        get: async () => ({}),
-        post: async () => ({})
-    })
-};
-(axios as any).create = mockAxios.create;
+	create: () => ({
+		get: async () => ({}),
+		post: async () => ({}),
+	}),
+}
+;(axios as any).create = mockAxios.create
 
-suite('CustomGatewayHandler', () => {
-    // Default test configuration
-    const defaultConfig: CustomGatewayConfig = {
-        baseUrl: 'https://api.example.com',
-        compatibilityMode: 'openai',
-        headers: [
-            { key: 'Authorization', value: 'Bearer test-token' }
-        ]
-    };
+suite("CustomGatewayHandler", () => {
+	// Default test configuration
+	const defaultConfig: CustomGatewayConfig = {
+		baseUrl: "https://api.example.com",
+		compatibilityMode: "openai",
+		headers: [{ key: "Authorization", value: "Bearer test-token" }],
+	}
 
-    const defaultOptions: ApiHandlerOptions = {
-        customGatewayConfig: defaultConfig,
-        webview: {
-            postMessage: () => {}
-        }
-    };
+	const defaultOptions: ApiHandlerOptions = {
+		customGatewayConfig: defaultConfig,
+		webview: {
+			postMessage: () => {},
+		},
+	}
 
-    setup(() => {
-        // Reset axios mock before each test
-        (axios as any).create = mockAxios.create;
-    });
+	setup(() => {
+		// Reset axios mock before each test
+		;(axios as any).create = mockAxios.create
+	})
 
-    teardown(() => {
-        // Clean up after each test
-        (axios as any).create = mockAxios.create;
-    });
+	teardown(() => {
+		// Clean up after each test
+		;(axios as any).create = mockAxios.create
+	})
 
-    suite('Constructor', () => {
-        test('should throw error if customGatewayConfig is missing', () => {
-            assert.throws(
-                () => new CustomGatewayHandler({} as ApiHandlerOptions),
-                /Custom gateway configuration is required/
-            );
-        });
+	suite("Constructor", () => {
+		test("should throw error if customGatewayConfig is missing", () => {
+			assert.throws(() => new CustomGatewayHandler({} as ApiHandlerOptions), /Custom gateway configuration is required/)
+		})
 
-        test('should throw error if baseUrl is missing', () => {
-            const options: ApiHandlerOptions = {
-                customGatewayConfig: {
-                    compatibilityMode: 'openai',
-                    headers: [],
-                    baseUrl: '', // Empty but present to satisfy type
-                }
-            };
+		test("should throw error if baseUrl is missing", () => {
+			const options: ApiHandlerOptions = {
+				customGatewayConfig: {
+					compatibilityMode: "openai",
+					headers: [],
+					baseUrl: "", // Empty but present to satisfy type
+				},
+			}
 
-            assert.throws(
-                () => new CustomGatewayHandler(options),
-                /Base URL is required/
-            );
-        });
+			assert.throws(() => new CustomGatewayHandler(options), /Base URL is required/)
+		})
 
-        test('should throw error if compatibilityMode is missing', () => {
-            const options: ApiHandlerOptions = {
-                customGatewayConfig: {
-                    baseUrl: 'https://api.example.com',
-                    headers: [],
-                    compatibilityMode: 'openai', // Added to satisfy type
-                }
-            };
+		test("should throw error if compatibilityMode is missing", () => {
+			const options: ApiHandlerOptions = {
+				customGatewayConfig: {
+					baseUrl: "https://api.example.com",
+					headers: [],
+					compatibilityMode: "openai", // Added to satisfy type
+				},
+			}
 
-            assert.throws(
-                () => new CustomGatewayHandler(options),
-                /Compatibility mode is required/
-            );
-        });
+			assert.throws(() => new CustomGatewayHandler(options), /Compatibility mode is required/)
+		})
 
-        test('should initialize with valid configuration', () => {
-            const handler = new CustomGatewayHandler(defaultOptions);
-            assert.ok(handler instanceof CustomGatewayHandler);
-        });
+		test("should initialize with valid configuration", () => {
+			const handler = new CustomGatewayHandler(defaultOptions)
+			assert.ok(handler instanceof CustomGatewayHandler)
+		})
 
-        test('should handle path prefix in baseUrl construction', () => {
-            const configWithPrefix: CustomGatewayConfig = {
-                ...defaultConfig,
-                pathPrefix: '/v1'
-            };
+		test("should handle path prefix in baseUrl construction", () => {
+			const configWithPrefix: CustomGatewayConfig = {
+				...defaultConfig,
+				pathPrefix: "/v1",
+			}
 
-            const createSpy = {
-                called: false,
-                args: null as any
-            };
+			const createSpy = {
+				called: false,
+				args: null as any,
+			}
 
-            (axios as any).create = (config: any) => {
-                createSpy.called = true;
-                createSpy.args = config;
-                return mockAxios.create();
-            };
+			;(axios as any).create = (config: any) => {
+				createSpy.called = true
+				createSpy.args = config
+				return mockAxios.create()
+			}
 
-            new CustomGatewayHandler({
-                ...defaultOptions,
-                customGatewayConfig: configWithPrefix
-            });
+			new CustomGatewayHandler({
+				...defaultOptions,
+				customGatewayConfig: configWithPrefix,
+			})
 
-            assert.ok(createSpy.called);
-            assert.strictEqual(createSpy.args.baseURL, 'https://api.example.com/v1');
-        });
+			assert.ok(createSpy.called)
+			assert.strictEqual(createSpy.args.baseURL, "https://api.example.com/v1")
+		})
 
-        test('should properly build headers', () => {
-            const configWithHeaders: CustomGatewayConfig = {
-                ...defaultConfig,
-                headers: [
-                    { key: 'Authorization', value: 'Bearer test-token' },
-                    { key: 'Custom-Header', value: 'test-value' }
-                ]
-            };
+		test("should properly build headers", () => {
+			const configWithHeaders: CustomGatewayConfig = {
+				...defaultConfig,
+				headers: [
+					{ key: "Authorization", value: "Bearer test-token" },
+					{ key: "Custom-Header", value: "test-value" },
+				],
+			}
 
-            const createSpy = {
-                called: false,
-                args: null as any
-            };
+			const createSpy = {
+				called: false,
+				args: null as any,
+			}
 
-            (axios as any).create = (config: any) => {
-                createSpy.called = true;
-                createSpy.args = config;
-                return mockAxios.create();
-            };
+			;(axios as any).create = (config: any) => {
+				createSpy.called = true
+				createSpy.args = config
+				return mockAxios.create()
+			}
 
-            new CustomGatewayHandler({
-                ...defaultOptions,
-                customGatewayConfig: configWithHeaders
-            });
+			new CustomGatewayHandler({
+				...defaultOptions,
+				customGatewayConfig: configWithHeaders,
+			})
 
-            assert.ok(createSpy.called);
-            assert.deepStrictEqual(createSpy.args.headers, {
-                'Content-Type': 'application/json',
-                'Authorization': 'Bearer test-token',
-                'Custom-Header': 'test-value'
-            });
-        });
-    });
+			assert.ok(createSpy.called)
+			assert.deepStrictEqual(createSpy.args.headers, {
+				"Content-Type": "application/json",
+				Authorization: "Bearer test-token",
+				"Custom-Header": "test-value",
+			})
+		})
+	})
 
-    suite('Health Check', () => {
-        test('should start health check when enabled', () => {
-            const configWithHealthCheck: CustomGatewayConfig = {
-                ...defaultConfig,
-                healthCheck: {
-                    enabled: true,
-                    interval: 5000,
-                    timeout: 2000
-                }
-            };
+	suite("Health Check", () => {
+		test("should start health check when enabled", () => {
+			const configWithHealthCheck: CustomGatewayConfig = {
+				...defaultConfig,
+				healthCheck: {
+					enabled: true,
+					interval: 5000,
+					timeout: 2000,
+				},
+			}
 
-            let healthCheckCalled = false;
-            const mockAxiosInstance = {
-                get: async (url: string) => {
-                    if (url === '/health') {
-                        healthCheckCalled = true;
-                    }
-                    return {
-                        data: {
-                            type: 'pong',
-                            status: 'healthy',
-                            timestamp: Date.now()
-                        }
-                    };
-                },
-                post: async () => ({})
-            };
+			let healthCheckCalled = false
+			const mockAxiosInstance = {
+				get: async (url: string) => {
+					if (url === "/health") {
+						healthCheckCalled = true
+					}
+					return {
+						data: {
+							type: "pong",
+							status: "healthy",
+							timestamp: Date.now(),
+						},
+					}
+				},
+				post: async () => ({}),
+			}
 
-            (axios as any).create = () => mockAxiosInstance;
+			;(axios as any).create = () => mockAxiosInstance
 
-            new CustomGatewayHandler({
-                ...defaultOptions,
-                customGatewayConfig: configWithHealthCheck
-            });
+			new CustomGatewayHandler({
+				...defaultOptions,
+				customGatewayConfig: configWithHealthCheck,
+			})
 
-            assert.ok(healthCheckCalled);
-        });
+			assert.ok(healthCheckCalled)
+		})
 
-        test('should handle health check errors', async () => {
-            const configWithHealthCheck: CustomGatewayConfig = {
-                ...defaultConfig,
-                healthCheck: {
-                    enabled: true
-                }
-            };
+		test("should handle health check errors", async () => {
+			const configWithHealthCheck: CustomGatewayConfig = {
+				...defaultConfig,
+				healthCheck: {
+					enabled: true,
+				},
+			}
 
-            let postedMessage: any = null;
-            const mockWebview = {
-                postMessage: (message: any) => {
-                    postedMessage = message;
-                }
-            };
+			let postedMessage: any = null
+			const mockWebview = {
+				postMessage: (message: any) => {
+					postedMessage = message
+				},
+			}
 
-            const mockAxiosInstance = {
-                get: async () => {
-                    throw new Error('Network error');
-                },
-                post: async () => ({})
-            };
+			const mockAxiosInstance = {
+				get: async () => {
+					throw new Error("Network error")
+				},
+				post: async () => ({}),
+			}
 
-            (axios as any).create = () => mockAxiosInstance;
+			;(axios as any).create = () => mockAxiosInstance
 
-            new CustomGatewayHandler({
-                ...defaultOptions,
-                customGatewayConfig: configWithHealthCheck,
-                webview: mockWebview
-            });
+			new CustomGatewayHandler({
+				...defaultOptions,
+				customGatewayConfig: configWithHealthCheck,
+				webview: mockWebview,
+			})
 
-            // Wait for next tick to allow health check to run
-            await new Promise(resolve => setTimeout(resolve, 0));
+			// Wait for next tick to allow health check to run
+			await new Promise((resolve) => setTimeout(resolve, 0))
 
-            assert.ok(postedMessage);
-            assert.strictEqual(postedMessage.type, 'customGatewayHealthStatus');
-            assert.strictEqual(postedMessage.healthStatus.status, 'unhealthy');
-            assert.strictEqual(postedMessage.healthStatus.message, 'Network error');
-        });
-    });
+			assert.ok(postedMessage)
+			assert.strictEqual(postedMessage.type, "customGatewayHealthStatus")
+			assert.strictEqual(postedMessage.healthStatus.status, "unhealthy")
+			assert.strictEqual(postedMessage.healthStatus.message, "Network error")
+		})
+	})
 
-    suite('Model Management', () => {
-        test('should use default model when no modelListSource', () => {
-            const configWithDefaultModel: CustomGatewayConfig = {
-                ...defaultConfig,
-                defaultModel: {
-                    id: 'test-model',
-                    info: {
-                        supportsPromptCache: false,
-                        description: 'A test model'
-                    }
-                }
-            };
+	suite("Model Management", () => {
+		test("should use default model when no modelListSource", () => {
+			const configWithDefaultModel: CustomGatewayConfig = {
+				...defaultConfig,
+				defaultModel: {
+					id: "test-model",
+					info: {
+						supportsPromptCache: false,
+						description: "A test model",
+					},
+				},
+			}
 
-            const handler = new CustomGatewayHandler({
-                ...defaultOptions,
-                customGatewayConfig: configWithDefaultModel
-            });
+			const handler = new CustomGatewayHandler({
+				...defaultOptions,
+				customGatewayConfig: configWithDefaultModel,
+			})
 
-            const model = handler.getModel();
-            assert.deepStrictEqual(model, configWithDefaultModel.defaultModel);
-        });
+			const model = handler.getModel()
+			assert.deepStrictEqual(model, configWithDefaultModel.defaultModel)
+		})
 
-        test('should fetch and cache model list', async () => {
-            const configWithModelList: CustomGatewayConfig = {
-                ...defaultConfig,
-                modelListSource: '/models'
-            };
+		test("should fetch and cache model list", async () => {
+			const configWithModelList: CustomGatewayConfig = {
+				...defaultConfig,
+				modelListSource: "/models",
+			}
 
-            const mockModels = {
-                models: [{
-                    id: 'model-1',
-                    info: {
-                        supportsPromptCache: false,
-                        description: 'First test model'
-                    }
-                }]
-            };
+			const mockModels = {
+				models: [
+					{
+						id: "model-1",
+						info: {
+							supportsPromptCache: false,
+							description: "First test model",
+						},
+					},
+				],
+			}
 
-            let getCallCount = 0;
-            const mockAxiosInstance = {
-                get: async (url: string) => {
-                    if (url === '/models') {
-                        getCallCount++;
-                        return { data: mockModels };
-                    }
-                    return {};
-                },
-                post: async () => ({})
-            };
+			let getCallCount = 0
+			const mockAxiosInstance = {
+				get: async (url: string) => {
+					if (url === "/models") {
+						getCallCount++
+						return { data: mockModels }
+					}
+					return {}
+				},
+				post: async () => ({}),
+			}
 
-            (axios as any).create = () => mockAxiosInstance;
+			;(axios as any).create = () => mockAxiosInstance
 
-            const handler = new CustomGatewayHandler({
-                ...defaultOptions,
-                customGatewayConfig: configWithModelList
-            });
+			const handler = new CustomGatewayHandler({
+				...defaultOptions,
+				customGatewayConfig: configWithModelList,
+			})
 
-            // Initial call should fetch from source
-            await handler.getModel();
-            assert.strictEqual(getCallCount, 1);
+			// Initial call should fetch from source
+			await handler.getModel()
+			assert.strictEqual(getCallCount, 1)
 
-            // Subsequent calls should use cache
-            await handler.getModel();
-            assert.strictEqual(getCallCount, 1);
-        });
-    });
+			// Subsequent calls should use cache
+			await handler.getModel()
+			assert.strictEqual(getCallCount, 1)
+		})
+	})
 
-    suite('Message Creation', () => {
-        test('should create message with proper format', async () => {
-            const mockAxiosInstance = {
-                get: async () => ({}),
-                post: async () => ({
-                    data: [
-                        Buffer.from(JSON.stringify({
-                            choices: [{
-                                delta: { content: 'Hello' }
-                            }]
-                        }))
-                    ],
-                    headers: {
-                        'x-usage': JSON.stringify({
-                            prompt_tokens: 10,
-                            completion_tokens: 5,
-                            total_cost: 0.001
-                        })
-                    }
-                })
-            };
+	suite("Message Creation", () => {
+		test("should create message with proper format", async () => {
+			const mockAxiosInstance = {
+				get: async () => ({}),
+				post: async () => ({
+					data: [
+						Buffer.from(
+							JSON.stringify({
+								choices: [
+									{
+										delta: { content: "Hello" },
+									},
+								],
+							}),
+						),
+					],
+					headers: {
+						"x-usage": JSON.stringify({
+							prompt_tokens: 10,
+							completion_tokens: 5,
+							total_cost: 0.001,
+						}),
+					},
+				}),
+			}
 
-            (axios as any).create = () => mockAxiosInstance;
+			;(axios as any).create = () => mockAxiosInstance
 
-            const handler = new CustomGatewayHandler({
-                ...defaultOptions,
-                customGatewayConfig: {
-                    ...defaultConfig,
-                    defaultModel: {
-                        id: 'test-model',
-                        info: {
-                            supportsPromptCache: false,
-                            description: 'Test Model'
-                        }
-                    }
-                }
-            });
+			const handler = new CustomGatewayHandler({
+				...defaultOptions,
+				customGatewayConfig: {
+					...defaultConfig,
+					defaultModel: {
+						id: "test-model",
+						info: {
+							supportsPromptCache: false,
+							description: "Test Model",
+						},
+					},
+				},
+			})
 
-            const messageIterator = handler.createMessage(
-                'You are a helpful assistant',
-                [{ role: 'user', content: 'Hello' }]
-            );
+			const messageIterator = handler.createMessage("You are a helpful assistant", [{ role: "user", content: "Hello" }])
 
-            const messages = [];
-            for await (const message of messageIterator) {
-                messages.push(message);
-            }
+			const messages = []
+			for await (const message of messageIterator) {
+				messages.push(message)
+			}
 
-            assert.deepStrictEqual(messages, [
-                { type: 'text', text: 'Hello' },
-                {
-                    type: 'usage',
-                    inputTokens: 10,
-                    outputTokens: 5,
-                    totalCost: 0.001
-                }
-            ]);
-        });
+			assert.deepStrictEqual(messages, [
+				{ type: "text", text: "Hello" },
+				{
+					type: "usage",
+					inputTokens: 10,
+					outputTokens: 5,
+					totalCost: 0.001,
+				},
+			])
+		})
 
-        test('should handle streaming errors', async () => {
-            const mockAxiosInstance = {
-                get: async () => ({}),
-                post: async () => ({
-                    data: [
-                        Buffer.from(JSON.stringify({
-                            error: {
-                                message: 'Test error'
-                            }
-                        }))
-                    ]
-                })
-            };
+		test("should handle streaming errors", async () => {
+			const mockAxiosInstance = {
+				get: async () => ({}),
+				post: async () => ({
+					data: [
+						Buffer.from(
+							JSON.stringify({
+								error: {
+									message: "Test error",
+								},
+							}),
+						),
+					],
+				}),
+			}
 
-            (axios as any).create = () => mockAxiosInstance;
+			;(axios as any).create = () => mockAxiosInstance
 
-            const handler = new CustomGatewayHandler({
-                ...defaultOptions,
-                customGatewayConfig: {
-                    ...defaultConfig,
-                    defaultModel: {
-                        id: 'test-model',
-                        info: {
-                            supportsPromptCache: false,
-                            description: 'Test Model'
-                        }
-                    }
-                }
-            });
+			const handler = new CustomGatewayHandler({
+				...defaultOptions,
+				customGatewayConfig: {
+					...defaultConfig,
+					defaultModel: {
+						id: "test-model",
+						info: {
+							supportsPromptCache: false,
+							description: "Test Model",
+						},
+					},
+				},
+			})
 
-            const messageIterator = handler.createMessage(
-                'You are a helpful assistant',
-                [{ role: 'user', content: 'Hello' }]
-            );
+			const messageIterator = handler.createMessage("You are a helpful assistant", [{ role: "user", content: "Hello" }])
 
-            try {
-                for await (const message of messageIterator) {
-                    // Consume iterator
-                }
-                assert.fail('Expected error was not thrown');
-            } catch (error) {
-                assert.ok(error instanceof Error);
-                assert.strictEqual(error.message, 'Gateway API Error: Test error');
-            }
-        });
-    });
-});
+			try {
+				for await (const message of messageIterator) {
+					// Consume iterator
+				}
+				assert.fail("Expected error was not thrown")
+			} catch (error) {
+				assert.ok(error instanceof Error)
+				assert.strictEqual(error.message, "Gateway API Error: Test error")
+			}
+		})
+	})
+})

--- a/src/test/custom-gateway-handler.test.ts
+++ b/src/test/custom-gateway-handler.test.ts
@@ -1,0 +1,395 @@
+import * as assert from 'assert';
+import axios from 'axios';
+import { CustomGatewayHandler } from '../api/providers/custom-gateway';
+import { ApiHandlerOptions, CustomGatewayConfig } from '../shared/api';
+
+// Mock axios
+const mockAxios = {
+    create: () => ({
+        get: async () => ({}),
+        post: async () => ({})
+    })
+};
+(axios as any).create = mockAxios.create;
+
+suite('CustomGatewayHandler', () => {
+    // Default test configuration
+    const defaultConfig: CustomGatewayConfig = {
+        baseUrl: 'https://api.example.com',
+        compatibilityMode: 'openai',
+        headers: [
+            { key: 'Authorization', value: 'Bearer test-token' }
+        ]
+    };
+
+    const defaultOptions: ApiHandlerOptions = {
+        customGatewayConfig: defaultConfig,
+        webview: {
+            postMessage: () => {}
+        }
+    };
+
+    setup(() => {
+        // Reset axios mock before each test
+        (axios as any).create = mockAxios.create;
+    });
+
+    teardown(() => {
+        // Clean up after each test
+        (axios as any).create = mockAxios.create;
+    });
+
+    suite('Constructor', () => {
+        test('should throw error if customGatewayConfig is missing', () => {
+            assert.throws(
+                () => new CustomGatewayHandler({} as ApiHandlerOptions),
+                /Custom gateway configuration is required/
+            );
+        });
+
+        test('should throw error if baseUrl is missing', () => {
+            const options: ApiHandlerOptions = {
+                customGatewayConfig: {
+                    compatibilityMode: 'openai',
+                    headers: [],
+                    baseUrl: '', // Empty but present to satisfy type
+                }
+            };
+
+            assert.throws(
+                () => new CustomGatewayHandler(options),
+                /Base URL is required/
+            );
+        });
+
+        test('should throw error if compatibilityMode is missing', () => {
+            const options: ApiHandlerOptions = {
+                customGatewayConfig: {
+                    baseUrl: 'https://api.example.com',
+                    headers: [],
+                    compatibilityMode: 'openai', // Added to satisfy type
+                }
+            };
+
+            assert.throws(
+                () => new CustomGatewayHandler(options),
+                /Compatibility mode is required/
+            );
+        });
+
+        test('should initialize with valid configuration', () => {
+            const handler = new CustomGatewayHandler(defaultOptions);
+            assert.ok(handler instanceof CustomGatewayHandler);
+        });
+
+        test('should handle path prefix in baseUrl construction', () => {
+            const configWithPrefix: CustomGatewayConfig = {
+                ...defaultConfig,
+                pathPrefix: '/v1'
+            };
+
+            const createSpy = {
+                called: false,
+                args: null as any
+            };
+
+            (axios as any).create = (config: any) => {
+                createSpy.called = true;
+                createSpy.args = config;
+                return mockAxios.create();
+            };
+
+            new CustomGatewayHandler({
+                ...defaultOptions,
+                customGatewayConfig: configWithPrefix
+            });
+
+            assert.ok(createSpy.called);
+            assert.strictEqual(createSpy.args.baseURL, 'https://api.example.com/v1');
+        });
+
+        test('should properly build headers', () => {
+            const configWithHeaders: CustomGatewayConfig = {
+                ...defaultConfig,
+                headers: [
+                    { key: 'Authorization', value: 'Bearer test-token' },
+                    { key: 'Custom-Header', value: 'test-value' }
+                ]
+            };
+
+            const createSpy = {
+                called: false,
+                args: null as any
+            };
+
+            (axios as any).create = (config: any) => {
+                createSpy.called = true;
+                createSpy.args = config;
+                return mockAxios.create();
+            };
+
+            new CustomGatewayHandler({
+                ...defaultOptions,
+                customGatewayConfig: configWithHeaders
+            });
+
+            assert.ok(createSpy.called);
+            assert.deepStrictEqual(createSpy.args.headers, {
+                'Content-Type': 'application/json',
+                'Authorization': 'Bearer test-token',
+                'Custom-Header': 'test-value'
+            });
+        });
+    });
+
+    suite('Health Check', () => {
+        test('should start health check when enabled', () => {
+            const configWithHealthCheck: CustomGatewayConfig = {
+                ...defaultConfig,
+                healthCheck: {
+                    enabled: true,
+                    interval: 5000,
+                    timeout: 2000
+                }
+            };
+
+            let healthCheckCalled = false;
+            const mockAxiosInstance = {
+                get: async (url: string) => {
+                    if (url === '/health') {
+                        healthCheckCalled = true;
+                    }
+                    return {
+                        data: {
+                            type: 'pong',
+                            status: 'healthy',
+                            timestamp: Date.now()
+                        }
+                    };
+                },
+                post: async () => ({})
+            };
+
+            (axios as any).create = () => mockAxiosInstance;
+
+            new CustomGatewayHandler({
+                ...defaultOptions,
+                customGatewayConfig: configWithHealthCheck
+            });
+
+            assert.ok(healthCheckCalled);
+        });
+
+        test('should handle health check errors', async () => {
+            const configWithHealthCheck: CustomGatewayConfig = {
+                ...defaultConfig,
+                healthCheck: {
+                    enabled: true
+                }
+            };
+
+            let postedMessage: any = null;
+            const mockWebview = {
+                postMessage: (message: any) => {
+                    postedMessage = message;
+                }
+            };
+
+            const mockAxiosInstance = {
+                get: async () => {
+                    throw new Error('Network error');
+                },
+                post: async () => ({})
+            };
+
+            (axios as any).create = () => mockAxiosInstance;
+
+            new CustomGatewayHandler({
+                ...defaultOptions,
+                customGatewayConfig: configWithHealthCheck,
+                webview: mockWebview
+            });
+
+            // Wait for next tick to allow health check to run
+            await new Promise(resolve => setTimeout(resolve, 0));
+
+            assert.ok(postedMessage);
+            assert.strictEqual(postedMessage.type, 'customGatewayHealthStatus');
+            assert.strictEqual(postedMessage.healthStatus.status, 'unhealthy');
+            assert.strictEqual(postedMessage.healthStatus.message, 'Network error');
+        });
+    });
+
+    suite('Model Management', () => {
+        test('should use default model when no modelListSource', () => {
+            const configWithDefaultModel: CustomGatewayConfig = {
+                ...defaultConfig,
+                defaultModel: {
+                    id: 'test-model',
+                    info: {
+                        supportsPromptCache: false,
+                        description: 'A test model'
+                    }
+                }
+            };
+
+            const handler = new CustomGatewayHandler({
+                ...defaultOptions,
+                customGatewayConfig: configWithDefaultModel
+            });
+
+            const model = handler.getModel();
+            assert.deepStrictEqual(model, configWithDefaultModel.defaultModel);
+        });
+
+        test('should fetch and cache model list', async () => {
+            const configWithModelList: CustomGatewayConfig = {
+                ...defaultConfig,
+                modelListSource: '/models'
+            };
+
+            const mockModels = {
+                models: [{
+                    id: 'model-1',
+                    info: {
+                        supportsPromptCache: false,
+                        description: 'First test model'
+                    }
+                }]
+            };
+
+            let getCallCount = 0;
+            const mockAxiosInstance = {
+                get: async (url: string) => {
+                    if (url === '/models') {
+                        getCallCount++;
+                        return { data: mockModels };
+                    }
+                    return {};
+                },
+                post: async () => ({})
+            };
+
+            (axios as any).create = () => mockAxiosInstance;
+
+            const handler = new CustomGatewayHandler({
+                ...defaultOptions,
+                customGatewayConfig: configWithModelList
+            });
+
+            // Initial call should fetch from source
+            await handler.getModel();
+            assert.strictEqual(getCallCount, 1);
+
+            // Subsequent calls should use cache
+            await handler.getModel();
+            assert.strictEqual(getCallCount, 1);
+        });
+    });
+
+    suite('Message Creation', () => {
+        test('should create message with proper format', async () => {
+            const mockAxiosInstance = {
+                get: async () => ({}),
+                post: async () => ({
+                    data: [
+                        Buffer.from(JSON.stringify({
+                            choices: [{
+                                delta: { content: 'Hello' }
+                            }]
+                        }))
+                    ],
+                    headers: {
+                        'x-usage': JSON.stringify({
+                            prompt_tokens: 10,
+                            completion_tokens: 5,
+                            total_cost: 0.001
+                        })
+                    }
+                })
+            };
+
+            (axios as any).create = () => mockAxiosInstance;
+
+            const handler = new CustomGatewayHandler({
+                ...defaultOptions,
+                customGatewayConfig: {
+                    ...defaultConfig,
+                    defaultModel: {
+                        id: 'test-model',
+                        info: {
+                            supportsPromptCache: false,
+                            description: 'Test Model'
+                        }
+                    }
+                }
+            });
+
+            const messageIterator = handler.createMessage(
+                'You are a helpful assistant',
+                [{ role: 'user', content: 'Hello' }]
+            );
+
+            const messages = [];
+            for await (const message of messageIterator) {
+                messages.push(message);
+            }
+
+            assert.deepStrictEqual(messages, [
+                { type: 'text', text: 'Hello' },
+                {
+                    type: 'usage',
+                    inputTokens: 10,
+                    outputTokens: 5,
+                    totalCost: 0.001
+                }
+            ]);
+        });
+
+        test('should handle streaming errors', async () => {
+            const mockAxiosInstance = {
+                get: async () => ({}),
+                post: async () => ({
+                    data: [
+                        Buffer.from(JSON.stringify({
+                            error: {
+                                message: 'Test error'
+                            }
+                        }))
+                    ]
+                })
+            };
+
+            (axios as any).create = () => mockAxiosInstance;
+
+            const handler = new CustomGatewayHandler({
+                ...defaultOptions,
+                customGatewayConfig: {
+                    ...defaultConfig,
+                    defaultModel: {
+                        id: 'test-model',
+                        info: {
+                            supportsPromptCache: false,
+                            description: 'Test Model'
+                        }
+                    }
+                }
+            });
+
+            const messageIterator = handler.createMessage(
+                'You are a helpful assistant',
+                [{ role: 'user', content: 'Hello' }]
+            );
+
+            try {
+                for await (const message of messageIterator) {
+                    // Consume iterator
+                }
+                assert.fail('Expected error was not thrown');
+            } catch (error) {
+                assert.ok(error instanceof Error);
+                assert.strictEqual(error.message, 'Gateway API Error: Test error');
+            }
+        });
+    });
+});

--- a/src/test/custom-gateway-handler.test.ts
+++ b/src/test/custom-gateway-handler.test.ts
@@ -1,7 +1,9 @@
-import * as assert from "assert"
-import axios from "axios"
-import { CustomGatewayHandler } from "../api/providers/custom-gateway"
-import { ApiHandlerOptions, CustomGatewayConfig } from "../shared/api"
+/// <reference types="mocha" />
+
+const assert = require("assert")
+const axios = require("axios")
+import type { CustomGatewayHandler } from "../api/providers/custom-gateway"
+import type { ApiHandlerOptions, CustomGatewayConfig } from "../shared/api"
 
 // Mock axios
 const mockAxios = {
@@ -12,38 +14,40 @@ const mockAxios = {
 }
 ;(axios as any).create = mockAxios.create
 
-suite("CustomGatewayHandler", () => {
+describe("CustomGatewayHandler", () => {
 	// Default test configuration
-	const defaultConfig: CustomGatewayConfig = {
+	const defaultConfig = {
 		baseUrl: "https://api.example.com",
 		compatibilityMode: "openai",
 		headers: [{ key: "Authorization", value: "Bearer test-token" }],
-	}
+	} as const
 
-	const defaultOptions: ApiHandlerOptions = {
+	const defaultOptions = {
 		customGatewayConfig: defaultConfig,
 		webview: {
 			postMessage: () => {},
 		},
 	}
 
-	setup(() => {
+	before(() => {
 		// Reset axios mock before each test
 		;(axios as any).create = mockAxios.create
 	})
 
-	teardown(() => {
+	after(() => {
 		// Clean up after each test
 		;(axios as any).create = mockAxios.create
 	})
 
-	suite("Constructor", () => {
-		test("should throw error if customGatewayConfig is missing", () => {
-			assert.throws(() => new CustomGatewayHandler({} as ApiHandlerOptions), /Custom gateway configuration is required/)
+	describe("Constructor", () => {
+		it("should throw error if customGatewayConfig is missing", () => {
+			const { CustomGatewayHandler } = require("../api/providers/custom-gateway")
+			assert.throws(() => new CustomGatewayHandler({}), /Custom gateway configuration is required/)
 		})
 
-		test("should throw error if baseUrl is missing", () => {
-			const options: ApiHandlerOptions = {
+		it("should throw error if baseUrl is missing", () => {
+			const { CustomGatewayHandler } = require("../api/providers/custom-gateway")
+			const options = {
 				customGatewayConfig: {
 					compatibilityMode: "openai",
 					headers: [],
@@ -54,8 +58,9 @@ suite("CustomGatewayHandler", () => {
 			assert.throws(() => new CustomGatewayHandler(options), /Base URL is required/)
 		})
 
-		test("should throw error if compatibilityMode is missing", () => {
-			const options: ApiHandlerOptions = {
+		it("should throw error if compatibilityMode is missing", () => {
+			const { CustomGatewayHandler } = require("../api/providers/custom-gateway")
+			const options = {
 				customGatewayConfig: {
 					baseUrl: "https://api.example.com",
 					headers: [],
@@ -66,13 +71,15 @@ suite("CustomGatewayHandler", () => {
 			assert.throws(() => new CustomGatewayHandler(options), /Compatibility mode is required/)
 		})
 
-		test("should initialize with valid configuration", () => {
+		it("should initialize with valid configuration", () => {
+			const { CustomGatewayHandler } = require("../api/providers/custom-gateway")
 			const handler = new CustomGatewayHandler(defaultOptions)
 			assert.ok(handler instanceof CustomGatewayHandler)
 		})
 
-		test("should handle path prefix in baseUrl construction", () => {
-			const configWithPrefix: CustomGatewayConfig = {
+		it("should handle path prefix in baseUrl construction", () => {
+			const { CustomGatewayHandler } = require("../api/providers/custom-gateway")
+			const configWithPrefix = {
 				...defaultConfig,
 				pathPrefix: "/v1",
 			}
@@ -97,8 +104,9 @@ suite("CustomGatewayHandler", () => {
 			assert.strictEqual(createSpy.args.baseURL, "https://api.example.com/v1")
 		})
 
-		test("should properly build headers", () => {
-			const configWithHeaders: CustomGatewayConfig = {
+		it("should properly build headers", () => {
+			const { CustomGatewayHandler } = require("../api/providers/custom-gateway")
+			const configWithHeaders = {
 				...defaultConfig,
 				headers: [
 					{ key: "Authorization", value: "Bearer test-token" },
@@ -131,9 +139,10 @@ suite("CustomGatewayHandler", () => {
 		})
 	})
 
-	suite("Health Check", () => {
-		test("should start health check when enabled", () => {
-			const configWithHealthCheck: CustomGatewayConfig = {
+	describe("Health Check", () => {
+		it("should start health check when enabled", () => {
+			const { CustomGatewayHandler } = require("../api/providers/custom-gateway")
+			const configWithHealthCheck = {
 				...defaultConfig,
 				healthCheck: {
 					enabled: true,
@@ -169,8 +178,9 @@ suite("CustomGatewayHandler", () => {
 			assert.ok(healthCheckCalled)
 		})
 
-		test("should handle health check errors", async () => {
-			const configWithHealthCheck: CustomGatewayConfig = {
+		it("should handle health check errors", async () => {
+			const { CustomGatewayHandler } = require("../api/providers/custom-gateway")
+			const configWithHealthCheck = {
 				...defaultConfig,
 				healthCheck: {
 					enabled: true,
@@ -209,9 +219,10 @@ suite("CustomGatewayHandler", () => {
 		})
 	})
 
-	suite("Model Management", () => {
-		test("should use default model when no modelListSource", () => {
-			const configWithDefaultModel: CustomGatewayConfig = {
+	describe("Model Management", () => {
+		it("should use default model when no modelListSource", () => {
+			const { CustomGatewayHandler } = require("../api/providers/custom-gateway")
+			const configWithDefaultModel = {
 				...defaultConfig,
 				defaultModel: {
 					id: "test-model",
@@ -231,8 +242,9 @@ suite("CustomGatewayHandler", () => {
 			assert.deepStrictEqual(model, configWithDefaultModel.defaultModel)
 		})
 
-		test("should fetch and cache model list", async () => {
-			const configWithModelList: CustomGatewayConfig = {
+		it("should fetch and cache model list", async () => {
+			const { CustomGatewayHandler } = require("../api/providers/custom-gateway")
+			const configWithModelList = {
 				...defaultConfig,
 				modelListSource: "/models",
 			}
@@ -278,8 +290,9 @@ suite("CustomGatewayHandler", () => {
 		})
 	})
 
-	suite("Message Creation", () => {
-		test("should create message with proper format", async () => {
+	describe("Message Creation", () => {
+		it("should create message with proper format", async () => {
+			const { CustomGatewayHandler } = require("../api/providers/custom-gateway")
 			const mockAxiosInstance = {
 				get: async () => ({}),
 				post: async () => ({
@@ -338,7 +351,8 @@ suite("CustomGatewayHandler", () => {
 			])
 		})
 
-		test("should handle streaming errors", async () => {
+		it("should handle streaming errors", async () => {
+			const { CustomGatewayHandler } = require("../api/providers/custom-gateway")
 			const mockAxiosInstance = {
 				get: async () => ({}),
 				post: async () => ({

--- a/webview-ui/src/components/settings/HeaderManager.tsx
+++ b/webview-ui/src/components/settings/HeaderManager.tsx
@@ -1,8 +1,4 @@
-import {
-	VSCodeButton,
-	VSCodeCheckbox,
-	VSCodeTextField,
-} from "@vscode/webview-ui-toolkit/react"
+import { VSCodeButton, VSCodeCheckbox, VSCodeTextField } from "@vscode/webview-ui-toolkit/react"
 import { useState } from "react"
 import { CustomHeader } from "../../../../src/shared/api"
 
@@ -33,9 +29,7 @@ export const HeaderManager = ({ headers, onChange }: HeaderManagerProps) => {
 		}
 
 		// Check for duplicates (case-insensitive)
-		const isDuplicate = headers.some(
-			(h) => h.key.toLowerCase() === header.key.toLowerCase()
-		)
+		const isDuplicate = headers.some((h) => h.key.toLowerCase() === header.key.toLowerCase())
 		if (isDuplicate) {
 			return "Header key already exists"
 		}
@@ -129,15 +123,10 @@ export const HeaderManager = ({ headers, onChange }: HeaderManagerProps) => {
 				</VSCodeCheckbox>
 
 				{validationError && (
-					<p style={{ color: "var(--vscode-errorForeground)", margin: 0, fontSize: 12 }}>
-						{validationError}
-					</p>
+					<p style={{ color: "var(--vscode-errorForeground)", margin: 0, fontSize: 12 }}>{validationError}</p>
 				)}
 
-				<VSCodeButton
-					appearance="secondary"
-					onClick={handleAddHeader}
-					style={{ alignSelf: "flex-start", marginTop: 5 }}>
+				<VSCodeButton appearance="secondary" onClick={handleAddHeader} style={{ alignSelf: "flex-start", marginTop: 5 }}>
 					Add Header
 				</VSCodeButton>
 			</div>
@@ -151,9 +140,7 @@ export const HeaderManager = ({ headers, onChange }: HeaderManagerProps) => {
 				/>
 				<span style={{ fontWeight: 500 }}>Current Headers</span>
 				{headers.length === 0 ? (
-					<div style={{ color: "var(--vscode-descriptionForeground)", fontSize: "12px" }}>
-						No headers added yet
-					</div>
+					<div style={{ color: "var(--vscode-descriptionForeground)", fontSize: "12px" }}>No headers added yet</div>
 				) : (
 					headers.map((header, index) => (
 						<div

--- a/webview-ui/src/components/settings/HeaderManager.tsx
+++ b/webview-ui/src/components/settings/HeaderManager.tsx
@@ -1,0 +1,203 @@
+import {
+	VSCodeButton,
+	VSCodeCheckbox,
+	VSCodeTextField,
+} from "@vscode/webview-ui-toolkit/react"
+import { useState } from "react"
+import { CustomHeader } from "../../../../src/shared/api"
+
+interface HeaderManagerProps {
+	headers: CustomHeader[]
+	onChange: (headers: CustomHeader[]) => void
+}
+
+export const HeaderManager = ({ headers, onChange }: HeaderManagerProps) => {
+	const [newHeader, setNewHeader] = useState<CustomHeader>({
+		key: "",
+		value: "",
+		description: "",
+		isSecret: false,
+	})
+	const [validationError, setValidationError] = useState<string>("")
+
+	const validateHeader = (header: CustomHeader): string | null => {
+		// Non-empty key validation
+		if (!header.key.trim()) {
+			return "Header key is required"
+		}
+
+		// Valid HTTP header name format (RFC 7230)
+		const headerNameRegex = /^[!#$%&'*+\-.^_`|~0-9a-zA-Z]+$/
+		if (!headerNameRegex.test(header.key)) {
+			return "Invalid header key format"
+		}
+
+		// Check for duplicates (case-insensitive)
+		const isDuplicate = headers.some(
+			(h) => h.key.toLowerCase() === header.key.toLowerCase()
+		)
+		if (isDuplicate) {
+			return "Header key already exists"
+		}
+
+		// Non-empty value validation
+		if (!header.value.trim()) {
+			return "Header value is required"
+		}
+
+		return null
+	}
+
+	const handleAddHeader = () => {
+		const error = validateHeader(newHeader)
+		if (error) {
+			setValidationError(error)
+			return
+		}
+
+		onChange([...headers, newHeader])
+		setNewHeader({
+			key: "",
+			value: "",
+			description: "",
+			isSecret: false,
+		})
+		setValidationError("")
+	}
+
+	const handleRemoveHeader = (index: number) => {
+		const newHeaders = [...headers]
+		newHeaders.splice(index, 1)
+		onChange(newHeaders)
+	}
+
+	const handleUpdateHeader = (index: number, field: keyof CustomHeader, value: string | boolean) => {
+		const newHeaders = [...headers]
+		newHeaders[index] = {
+			...newHeaders[index],
+			[field]: value,
+		}
+		onChange(newHeaders)
+	}
+
+	return (
+		<div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
+			<div style={{ display: "flex", flexDirection: "column", gap: 5 }}>
+				<VSCodeTextField
+					value={newHeader.key}
+					style={{ width: "100%" }}
+					onInput={(e) => {
+						const target = e.target as HTMLInputElement
+						setNewHeader({ ...newHeader, key: target.value })
+						setValidationError("")
+					}}
+					placeholder="Enter header key...">
+					<span style={{ fontWeight: 500 }}>New Header Key</span>
+				</VSCodeTextField>
+
+				<VSCodeTextField
+					value={newHeader.value}
+					style={{ width: "100%" }}
+					type={newHeader.isSecret ? "password" : "text"}
+					onInput={(e) => {
+						const target = e.target as HTMLInputElement
+						setNewHeader({ ...newHeader, value: target.value })
+						setValidationError("")
+					}}
+					placeholder="Enter header value...">
+					<span style={{ fontWeight: 500 }}>New Header Value</span>
+				</VSCodeTextField>
+
+				<VSCodeTextField
+					value={newHeader.description || ""}
+					style={{ width: "100%" }}
+					onInput={(e) => {
+						const target = e.target as HTMLInputElement
+						setNewHeader({ ...newHeader, description: target.value })
+					}}
+					placeholder="Optional description...">
+					<span style={{ fontWeight: 500 }}>Description (Optional)</span>
+				</VSCodeTextField>
+
+				<VSCodeCheckbox
+					checked={newHeader.isSecret}
+					onChange={(e) => {
+						const target = e.target as HTMLInputElement
+						setNewHeader({ ...newHeader, isSecret: target.checked })
+					}}>
+					Store as secret
+				</VSCodeCheckbox>
+
+				{validationError && (
+					<p style={{ color: "var(--vscode-errorForeground)", margin: 0, fontSize: 12 }}>
+						{validationError}
+					</p>
+				)}
+
+				<VSCodeButton
+					appearance="secondary"
+					onClick={handleAddHeader}
+					style={{ alignSelf: "flex-start", marginTop: 5 }}>
+					Add Header
+				</VSCodeButton>
+			</div>
+
+			<div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
+				<div
+					style={{
+						borderTop: "1px solid var(--vscode-textSeparator-foreground)",
+						margin: "5px 0",
+					}}
+				/>
+				<span style={{ fontWeight: 500 }}>Current Headers</span>
+				{headers.length === 0 ? (
+					<div style={{ color: "var(--vscode-descriptionForeground)", fontSize: "12px" }}>
+						No headers added yet
+					</div>
+				) : (
+					headers.map((header, index) => (
+						<div
+							key={index}
+							style={{
+								display: "flex",
+								alignItems: "center",
+								gap: 8,
+								padding: "4px 8px",
+								border: "1px solid var(--vscode-textSeparator-foreground)",
+								borderRadius: 4,
+								backgroundColor: "var(--vscode-editor-background)",
+							}}>
+							<div style={{ flex: 1 }}>
+								<div style={{ display: "flex", alignItems: "center", gap: 4 }}>
+									<span style={{ fontWeight: 500, color: "var(--vscode-editor-foreground)" }}>
+										{header.key}:
+									</span>
+									<span style={{ color: "var(--vscode-descriptionForeground)" }}>
+										{header.isSecret ? "••••••" : header.value}
+									</span>
+								</div>
+								{header.description && (
+									<div style={{ fontSize: "11px", color: "var(--vscode-descriptionForeground)" }}>
+										{header.description}
+									</div>
+								)}
+							</div>
+							<div style={{ display: "flex", gap: 4, alignItems: "center" }}>
+								<VSCodeButton
+									appearance="icon"
+									onClick={() => handleUpdateHeader(index, "isSecret", !header.isSecret)}>
+									<i className={`codicon codicon-${header.isSecret ? "eye" : "eye-closed"}`}></i>
+								</VSCodeButton>
+								<VSCodeButton appearance="icon" onClick={() => handleRemoveHeader(index)}>
+									<i className="codicon codicon-trash"></i>
+								</VSCodeButton>
+							</div>
+						</div>
+					))
+				)}
+			</div>
+		</div>
+	)
+}
+
+export default HeaderManager

--- a/webview-ui/src/components/settings/HealthCheckConfig.tsx
+++ b/webview-ui/src/components/settings/HealthCheckConfig.tsx
@@ -74,15 +74,11 @@ export const HealthCheckConfig = ({ config, onChange }: HealthCheckConfigProps) 
 					}}>
 					Health Check Timeout (ms)
 				</VSCodeTextField>
-				<span style={{ fontSize: 12, color: "var(--vscode-descriptionForeground)" }}>
-					Default: 10000ms (10 seconds)
-				</span>
+				<span style={{ fontSize: 12, color: "var(--vscode-descriptionForeground)" }}>Default: 10000ms (10 seconds)</span>
 			</div>
 			<div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
 				<div style={{ display: "flex", alignItems: "center", gap: 10 }}>
-					<VSCodeButton onClick={testConnection}>
-						Test Connection
-					</VSCodeButton>
+					<VSCodeButton onClick={testConnection}>Test Connection</VSCodeButton>
 					<span style={{ fontSize: 12, color: "var(--vscode-descriptionForeground)" }}>
 						View detailed logs in Output panel (Cmd+Shift+U) &gt; "Cline"
 					</span>
@@ -98,15 +94,13 @@ export const HealthCheckConfig = ({ config, onChange }: HealthCheckConfigProps) 
 								healthStatus.status === "healthy"
 									? "var(--vscode-testing-iconPassed)"
 									: healthStatus.status === "degraded"
-									? "var(--vscode-testing-iconSkipped)"
-									: "var(--vscode-testing-iconFailed)",
+										? "var(--vscode-testing-iconSkipped)"
+										: "var(--vscode-testing-iconFailed)",
 						}}>
 						<span style={{ fontWeight: 500 }}>Status:</span>
 						<span>{healthStatus.status}</span>
 						{healthStatus.message && (
-							<span style={{ color: "var(--vscode-descriptionForeground)" }}>
-								({healthStatus.message})
-							</span>
+							<span style={{ color: "var(--vscode-descriptionForeground)" }}>({healthStatus.message})</span>
 						)}
 					</div>
 				)}

--- a/webview-ui/src/components/settings/HealthCheckConfig.tsx
+++ b/webview-ui/src/components/settings/HealthCheckConfig.tsx
@@ -1,0 +1,118 @@
+import { VSCodeButton, VSCodeTextField } from "@vscode/webview-ui-toolkit/react"
+import { useCallback, useEffect, useState } from "react"
+import { CustomGatewayConfig } from "../../../../src/shared/api"
+import { vscode } from "../../utils/vscode"
+
+interface HealthCheckConfigProps {
+	config: CustomGatewayConfig
+	onChange: (config: CustomGatewayConfig) => void
+}
+
+export const HealthCheckConfig = ({ config, onChange }: HealthCheckConfigProps) => {
+	const [healthStatus, setHealthStatus] = useState<{
+		status: "healthy" | "degraded" | "unhealthy"
+		message?: string
+		timestamp?: number
+	}>()
+
+	// Listen for health status updates
+	useEffect(() => {
+		const handler = (event: MessageEvent) => {
+			const message = event.data
+			if (message.type === "customGatewayHealthStatus") {
+				setHealthStatus(message.healthStatus)
+			}
+		}
+
+		window.addEventListener("message", handler)
+		return () => window.removeEventListener("message", handler)
+	}, [])
+
+	// Request connection test
+	const testConnection = useCallback(() => {
+		// Validate minimum required settings
+		if (!config.baseUrl) {
+			setHealthStatus({
+				status: "unhealthy",
+				message: "Base URL is required",
+				timestamp: Date.now(),
+			})
+			return
+		}
+
+		if (!config.compatibilityMode) {
+			setHealthStatus({
+				status: "unhealthy",
+				message: "Compatibility mode is required",
+				timestamp: Date.now(),
+			})
+			return
+		}
+
+		vscode.postMessage({
+			type: "customGatewayHealthCheck",
+		})
+	}, [config])
+
+	return (
+		<div style={{ display: "flex", flexDirection: "column", gap: 15 }}>
+			<div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
+				<VSCodeTextField
+					type="text"
+					value={String(config.healthCheck?.timeout ?? 10000)}
+					style={{ width: 200 }}
+					onChange={(e) => {
+						const timeout = parseInt((e.target as HTMLInputElement).value)
+						onChange({
+							...config,
+							healthCheck: {
+								enabled: config.healthCheck?.enabled ?? true,
+								...config.healthCheck,
+								timeout: isNaN(timeout) ? 10000 : timeout,
+							},
+						})
+					}}>
+					Health Check Timeout (ms)
+				</VSCodeTextField>
+				<span style={{ fontSize: 12, color: "var(--vscode-descriptionForeground)" }}>
+					Default: 10000ms (10 seconds)
+				</span>
+			</div>
+			<div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
+				<div style={{ display: "flex", alignItems: "center", gap: 10 }}>
+					<VSCodeButton onClick={testConnection}>
+						Test Connection
+					</VSCodeButton>
+					<span style={{ fontSize: 12, color: "var(--vscode-descriptionForeground)" }}>
+						View detailed logs in Output panel (Cmd+Shift+U) &gt; "Cline"
+					</span>
+				</div>
+				{healthStatus && (
+					<div
+						style={{
+							display: "flex",
+							alignItems: "center",
+							gap: 5,
+							fontSize: 12,
+							color:
+								healthStatus.status === "healthy"
+									? "var(--vscode-testing-iconPassed)"
+									: healthStatus.status === "degraded"
+									? "var(--vscode-testing-iconSkipped)"
+									: "var(--vscode-testing-iconFailed)",
+						}}>
+						<span style={{ fontWeight: 500 }}>Status:</span>
+						<span>{healthStatus.status}</span>
+						{healthStatus.message && (
+							<span style={{ color: "var(--vscode-descriptionForeground)" }}>
+								({healthStatus.message})
+							</span>
+						)}
+					</div>
+				)}
+			</div>
+		</div>
+	)
+}
+
+export default HealthCheckConfig

--- a/webview-ui/src/components/settings/ModelSourceConfig.tsx
+++ b/webview-ui/src/components/settings/ModelSourceConfig.tsx
@@ -1,9 +1,4 @@
-import {
-	VSCodeButton,
-	VSCodeDropdown,
-	VSCodeOption,
-	VSCodeTextField,
-} from "@vscode/webview-ui-toolkit/react"
+import { VSCodeButton, VSCodeDropdown, VSCodeOption, VSCodeTextField } from "@vscode/webview-ui-toolkit/react"
 import { useCallback, useEffect, useState } from "react"
 import { CustomGatewayConfig, ModelInfo } from "../../../../src/shared/api"
 import { vscode } from "../../utils/vscode"
@@ -112,17 +107,12 @@ export const ModelSourceConfig = ({ config, onChange }: ModelSourceConfigProps) 
 					placeholder="Enter URL or file path for model list">
 					<span style={{ fontWeight: 500 }}>Model List Source</span>
 				</VSCodeTextField>
-				<VSCodeButton
-					appearance="secondary"
-					disabled={!config.modelListSource || isLoading}
-					onClick={fetchModels}>
+				<VSCodeButton appearance="secondary" disabled={!config.modelListSource || isLoading} onClick={fetchModels}>
 					{isLoading ? "Loading..." : "Refresh"}
 				</VSCodeButton>
 			</div>
 
-			{error && (
-				<p style={{ color: "var(--vscode-errorForeground)", fontSize: 12, margin: 0 }}>{error}</p>
-			)}
+			{error && <p style={{ color: "var(--vscode-errorForeground)", fontSize: 12, margin: 0 }}>{error}</p>}
 
 			<div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
 				{models.length > 0 && (
@@ -153,18 +143,20 @@ export const ModelSourceConfig = ({ config, onChange }: ModelSourceConfigProps) 
 							const target = e.target as HTMLInputElement
 							onChange({
 								...config,
-								defaultModel: target.value ? {
-									id: target.value,
-									info: {
-										maxTokens: undefined,
-										contextWindow: undefined,
-										supportsImages: false,
-										supportsPromptCache: false,
-										inputPrice: undefined,
-										outputPrice: undefined,
-										description: undefined,
-									}
-								} : undefined
+								defaultModel: target.value
+									? {
+											id: target.value,
+											info: {
+												maxTokens: undefined,
+												contextWindow: undefined,
+												supportsImages: false,
+												supportsPromptCache: false,
+												inputPrice: undefined,
+												outputPrice: undefined,
+												description: undefined,
+											},
+										}
+									: undefined,
 							})
 						}}
 						placeholder="Enter custom model identifier">
@@ -199,14 +191,14 @@ export const ModelSourceConfig = ({ config, onChange }: ModelSourceConfigProps) 
 					</div>
 					{config.defaultModel.info.inputPrice && (
 						<div>
-							<span style={{ fontWeight: 500 }}>Input Price:</span> $
-							{config.defaultModel.info.inputPrice}/million tokens
+							<span style={{ fontWeight: 500 }}>Input Price:</span> ${config.defaultModel.info.inputPrice}/million
+							tokens
 						</div>
 					)}
 					{config.defaultModel.info.outputPrice && (
 						<div>
-							<span style={{ fontWeight: 500 }}>Output Price:</span> $
-							{config.defaultModel.info.outputPrice}/million tokens
+							<span style={{ fontWeight: 500 }}>Output Price:</span> ${config.defaultModel.info.outputPrice}/million
+							tokens
 						</div>
 					)}
 				</div>

--- a/webview-ui/src/components/settings/ModelSourceConfig.tsx
+++ b/webview-ui/src/components/settings/ModelSourceConfig.tsx
@@ -1,0 +1,218 @@
+import {
+	VSCodeButton,
+	VSCodeDropdown,
+	VSCodeOption,
+	VSCodeTextField,
+} from "@vscode/webview-ui-toolkit/react"
+import { useCallback, useEffect, useState } from "react"
+import { CustomGatewayConfig, ModelInfo } from "../../../../src/shared/api"
+import { vscode } from "../../utils/vscode"
+
+interface ModelSourceConfigProps {
+	config: CustomGatewayConfig
+	onChange: (config: CustomGatewayConfig) => void
+}
+
+interface ModelListResponse {
+	models: Array<{
+		id: string
+		name?: string
+		description?: string
+		maxTokens?: number
+		contextWindow?: number
+		supportsImages?: boolean
+		inputPrice?: number
+		outputPrice?: number
+	}>
+}
+
+export const ModelSourceConfig = ({ config, onChange }: ModelSourceConfigProps) => {
+	const [models, setModels] = useState<ModelListResponse["models"]>([])
+	const [isLoading, setIsLoading] = useState(false)
+	const [error, setError] = useState<string>()
+
+	const fetchModels = useCallback(async () => {
+		if (!config.modelListSource) return
+
+		setIsLoading(true)
+		setError(undefined)
+
+		try {
+			// Request model list fetch through VSCode extension
+			vscode.postMessage({
+				type: "fetchCustomGatewayModels",
+				modelListSource: config.modelListSource,
+			})
+		} catch (err) {
+			setError("Failed to fetch models: " + (err instanceof Error ? err.message : String(err)))
+			setIsLoading(false)
+		}
+	}, [config.modelListSource])
+
+	// Listen for model list response from extension
+	useEffect(() => {
+		const handler = (event: MessageEvent) => {
+			const message = event.data
+			if (message.type === "customGatewayModels") {
+				setModels(message.models || [])
+				setIsLoading(false)
+			} else if (message.type === "customGatewayModelsError") {
+				setError(message.error)
+				setIsLoading(false)
+			}
+		}
+
+		window.addEventListener("message", handler)
+		return () => window.removeEventListener("message", handler)
+	}, [])
+
+	// Initial fetch when source is set
+	useEffect(() => {
+		if (config.modelListSource) {
+			fetchModels()
+		}
+	}, [config.modelListSource, fetchModels])
+
+	const handleModelSelect = (modelId: string) => {
+		const selectedModel = models.find((m) => m.id === modelId)
+		if (!selectedModel) return
+
+		const modelInfo: ModelInfo = {
+			maxTokens: selectedModel.maxTokens,
+			contextWindow: selectedModel.contextWindow,
+			supportsImages: selectedModel.supportsImages,
+			supportsPromptCache: false, // Custom gateways don't support prompt caching yet
+			inputPrice: selectedModel.inputPrice,
+			outputPrice: selectedModel.outputPrice,
+			description: selectedModel.description,
+		}
+
+		onChange({
+			...config,
+			defaultModel: {
+				id: modelId,
+				info: modelInfo,
+			},
+		})
+	}
+
+	return (
+		<div style={{ display: "flex", flexDirection: "column", gap: 5 }}>
+			<div style={{ display: "flex", gap: 5, alignItems: "flex-end" }}>
+				<VSCodeTextField
+					value={config.modelListSource || ""}
+					style={{ flex: 1 }}
+					onInput={(e) => {
+						const target = e.target as HTMLInputElement
+						onChange({
+							...config,
+							modelListSource: target.value,
+						})
+					}}
+					placeholder="Enter URL or file path for model list">
+					<span style={{ fontWeight: 500 }}>Model List Source</span>
+				</VSCodeTextField>
+				<VSCodeButton
+					appearance="secondary"
+					disabled={!config.modelListSource || isLoading}
+					onClick={fetchModels}>
+					{isLoading ? "Loading..." : "Refresh"}
+				</VSCodeButton>
+			</div>
+
+			{error && (
+				<p style={{ color: "var(--vscode-errorForeground)", fontSize: 12, margin: 0 }}>{error}</p>
+			)}
+
+			<div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
+				{models.length > 0 && (
+					<div className="dropdown-container">
+						<label htmlFor="model-select">
+							<span style={{ fontWeight: 500 }}>Model from List</span>
+						</label>
+						<VSCodeDropdown
+							id="model-select"
+							value={config.defaultModel?.id || ""}
+							style={{ width: "100%" }}
+							onChange={(e) => handleModelSelect((e.target as HTMLSelectElement).value)}>
+							<VSCodeOption value="">Select a model...</VSCodeOption>
+							{models.map((model) => (
+								<VSCodeOption key={model.id} value={model.id}>
+									{model.name || model.id}
+								</VSCodeOption>
+							))}
+						</VSCodeDropdown>
+					</div>
+				)}
+
+				<div>
+					<VSCodeTextField
+						value={config.defaultModel?.id || ""}
+						style={{ width: "100%" }}
+						onInput={(e) => {
+							const target = e.target as HTMLInputElement
+							onChange({
+								...config,
+								defaultModel: target.value ? {
+									id: target.value,
+									info: {
+										maxTokens: undefined,
+										contextWindow: undefined,
+										supportsImages: false,
+										supportsPromptCache: false,
+										inputPrice: undefined,
+										outputPrice: undefined,
+										description: undefined,
+									}
+								} : undefined
+							})
+						}}
+						placeholder="Enter custom model identifier">
+						<span style={{ fontWeight: 500 }}>Custom Model ID</span>
+					</VSCodeTextField>
+				</div>
+			</div>
+
+			{config.defaultModel && (
+				<div style={{ fontSize: 12, color: "var(--vscode-descriptionForeground)" }}>
+					<div>
+						<span style={{ fontWeight: 500 }}>Selected Model:</span> {config.defaultModel.id}
+					</div>
+					{config.defaultModel.info.description && (
+						<div style={{ marginTop: 3 }}>{config.defaultModel.info.description}</div>
+					)}
+					{config.defaultModel.info.maxTokens && (
+						<div>
+							<span style={{ fontWeight: 500 }}>Max Tokens:</span>{" "}
+							{config.defaultModel.info.maxTokens.toLocaleString()}
+						</div>
+					)}
+					{config.defaultModel.info.contextWindow && (
+						<div>
+							<span style={{ fontWeight: 500 }}>Context Window:</span>{" "}
+							{config.defaultModel.info.contextWindow.toLocaleString()}
+						</div>
+					)}
+					<div>
+						<span style={{ fontWeight: 500 }}>Supports Images:</span>{" "}
+						{config.defaultModel.info.supportsImages ? "Yes" : "No"}
+					</div>
+					{config.defaultModel.info.inputPrice && (
+						<div>
+							<span style={{ fontWeight: 500 }}>Input Price:</span> $
+							{config.defaultModel.info.inputPrice}/million tokens
+						</div>
+					)}
+					{config.defaultModel.info.outputPrice && (
+						<div>
+							<span style={{ fontWeight: 500 }}>Output Price:</span> $
+							{config.defaultModel.info.outputPrice}/million tokens
+						</div>
+					)}
+				</div>
+			)}
+		</div>
+	)
+}
+
+export default ModelSourceConfig

--- a/webview-ui/src/components/settings/OpenRouterModelPicker.tsx
+++ b/webview-ui/src/components/settings/OpenRouterModelPicker.tsx
@@ -4,7 +4,7 @@ import React, { KeyboardEvent, memo, useEffect, useMemo, useRef, useState } from
 import { useRemark } from "react-remark"
 import { useMount } from "react-use"
 import styled from "styled-components"
-import { openRouterDefaultModelId } from "../../../../src/shared/api"
+import { ModelInfo, openRouterDefaultModelId } from "../../../../src/shared/api"
 import { useExtensionState } from "../../context/ExtensionStateContext"
 import { vscode } from "../../utils/vscode"
 import { highlight } from "../history/HistoryView"
@@ -37,9 +37,8 @@ const OpenRouterModelPicker: React.FC<OpenRouterModelPickerProps> = ({ isPopup }
 		setSearchTerm(newModelId)
 	}
 
-	const { selectedModelId, selectedModelInfo } = useMemo(() => {
-		return normalizeApiConfiguration(apiConfiguration)
-	}, [apiConfiguration])
+	const selectedModelId = initialSelectedModelId
+	const selectedModelInfo = initialSelectedModelInfo
 
 	useMount(() => {
 		vscode.postMessage({ type: "refreshOpenRouterModels" })

--- a/webview-ui/src/components/settings/OpenRouterModelPicker.tsx
+++ b/webview-ui/src/components/settings/OpenRouterModelPicker.tsx
@@ -4,7 +4,7 @@ import React, { KeyboardEvent, memo, useEffect, useMemo, useRef, useState } from
 import { useRemark } from "react-remark"
 import { useMount } from "react-use"
 import styled from "styled-components"
-import { ModelInfo, openRouterDefaultModelId } from "../../../../src/shared/api"
+import { openRouterDefaultModelId } from "../../../../src/shared/api"
 import { useExtensionState } from "../../context/ExtensionStateContext"
 import { vscode } from "../../utils/vscode"
 import { highlight } from "../history/HistoryView"
@@ -37,8 +37,9 @@ const OpenRouterModelPicker: React.FC<OpenRouterModelPickerProps> = ({ isPopup }
 		setSearchTerm(newModelId)
 	}
 
-	const selectedModelId = initialSelectedModelId
-	const selectedModelInfo = initialSelectedModelInfo
+	const { selectedModelId, selectedModelInfo } = useMemo(() => {
+		return normalizeApiConfiguration(apiConfiguration)
+	}, [apiConfiguration])
 
 	useMount(() => {
 		vscode.postMessage({ type: "refreshOpenRouterModels" })


### PR DESCRIPTION
### Description

This PR shows a POC for adding a Custom Gateway API Provider to Cline to support situations where the connection to / through an AI Gateway might need to support more varied types of authentication, generally in the form of adding http headers.  It's designed to support a myriad of down stream provider compatibility (initial PR only has OpenAI functioning) while allowing for edge case requirements such as alternate authentication schemes via headers, alternative / extended information via headers and alternate/extended URI schemes. Also support for custom host and ports.

I have a specific use case in mind, but I have tried to implement in a way that is agnostic to my specific use case and able to hopefully support more generic use cases.

My use case looks like this.

Cline --> LocalAuthProxy --> AI Gateway/Proxy Service --> Varied Public and Private (Gemini, OpenAI, Anthropic, Bedrock, Sagemaker) AI Providers.

Cline to LocalAuthProxy requires headers that identify the user/system, and point to specific keys/auth methods to be used, and the proxy adds those to the request such as the authentication at the AI Proxy/Gateway is as expected and the request is allowed on to the provider.  The payloads in this specific situation are the same as general Provider payloads, so I have not written anything to handle translation of custom json payloads or adding of custom json payloads.

It also works for Cline --> AI Proxy/Gateway Service and adding the custom headers required directly and adjusting the host and port.

### Test Procedure

Testing was getting the addon to run by pressing F5, and then running some general tests through my gateway and ensuring that it worked.

I added a "enable debug mode" which is supposed to print information into the Ooutput tab --> Cline (in the drop down).  It only starts outputting that when you actually save the provider and load up a task with it. 

There are other bugs such as when you first load up the settings for the Custom Gateway provider, its blank.  But hit done, and reopen it, and all your settings are there. (By first load I mean when I am hitting F5 to test it and it opens a new window).  I havent gotten to solving that yet.

Only OpenAI works, and its only been tested with GPT4o so far.

`npm test` fails, but for reasons outside my test I added and I didnt want Cline to start running amok across the code creating and then fixing problems.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

![image](https://github.com/user-attachments/assets/53ef69cc-e810-4240-8882-bb59ff7eb8ec)


### Additional Notes

Adding this as requested by celestialvault in discord so you can have a look at my initial attempt to solve for my own feature request.  I don't code in javascript, so all awesome (and terrible) code is Clines ;)

This is strictly a POC, I am not looking to get this merged, i figure if this makes it beyond this then someone who knows how this code base works etc better than I can take my code and make it work better.  Or not, I dont mind doing it with feedback either, but it is simply to show the concept I was trying to discuss about.
