### PR TITLE
Nighttrek/bedrock credential manager

### DIFF
--- a/.changeset/tasty-readers-move.md
+++ b/.changeset/tasty-readers-move.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": minor
+---
+
+Added support for AWS provider profiles using the AWS CLI to make the profile. enabling long lived connections to AWS bedrock

--- a/src/api/providers/bedrock.ts
+++ b/src/api/providers/bedrock.ts
@@ -3,6 +3,7 @@ import { Anthropic } from "@anthropic-ai/sdk"
 import { ApiHandler } from "../"
 import { ApiHandlerOptions, bedrockDefaultModelId, BedrockModelId, bedrockModels, ModelInfo } from "../../shared/api"
 import { ApiStream } from "../transform/stream"
+import { fromIni } from "@aws-sdk/credential-providers"
 
 // https://docs.anthropic.com/en/api/claude-on-amazon-bedrock
 export class AwsBedrockHandler implements ApiHandler {
@@ -11,17 +12,31 @@ export class AwsBedrockHandler implements ApiHandler {
 
 	constructor(options: ApiHandlerOptions) {
 		this.options = options
-		this.client = new AnthropicBedrock({
-			// Authenticate by either providing the keys below or use the default AWS credential providers, such as
-			// using ~/.aws/credentials or the "AWS_SECRET_ACCESS_KEY" and "AWS_ACCESS_KEY_ID" environment variables.
-			...(this.options.awsAccessKey ? { awsAccessKey: this.options.awsAccessKey } : {}),
-			...(this.options.awsSecretKey ? { awsSecretKey: this.options.awsSecretKey } : {}),
-			...(this.options.awsSessionToken ? { awsSessionToken: this.options.awsSessionToken } : {}),
 
-			// awsRegion changes the aws region to which the request is made. By default, we read AWS_REGION,
-			// and if that's not present, we default to us-east-1. Note that we do not read ~/.aws/config for the region.
-			awsRegion: this.options.awsRegion,
-		})
+		const clientConfig: any = {
+			awsRegion: this.options.awsRegion || "us-east-1",
+		}
+
+		if (this.options.awsUseProfile) {
+			// Use profile-based credentials if enabled
+			if (this.options.awsProfile) {
+				clientConfig.credentials = fromIni({
+					profile: this.options.awsProfile,
+				})
+			} else {
+				// Use default profile if no specific profile is set
+				clientConfig.credentials = fromIni()
+			}
+		} else if (this.options.awsAccessKey && this.options.awsSecretKey) {
+			// Use direct credentials if provided
+			clientConfig.awsAccessKey = this.options.awsAccessKey
+			clientConfig.awsSecretKey = this.options.awsSecretKey
+			if (this.options.awsSessionToken) {
+				clientConfig.awsSessionToken = this.options.awsSessionToken
+			}
+		}
+
+		this.client = new AnthropicBedrock(clientConfig)
 	}
 
 	async *createMessage(systemPrompt: string, messages: Anthropic.Messages.MessageParam[]): ApiStream {

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -429,6 +429,8 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 								awsSessionToken,
 								awsRegion,
 								awsUseCrossRegionInference,
+								awsProfile,
+								awsUseProfile,
 								vertexProjectId,
 								vertexRegion,
 								openAiBaseUrl,
@@ -459,6 +461,8 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 							await this.storeSecret("awsSessionToken", awsSessionToken)
 							await this.updateGlobalState("awsRegion", awsRegion)
 							await this.updateGlobalState("awsUseCrossRegionInference", awsUseCrossRegionInference)
+							await this.updateGlobalState("awsProfile", awsProfile)
+							await this.updateGlobalState("awsUseProfile", awsUseProfile)
 							await this.updateGlobalState("vertexProjectId", vertexProjectId)
 							await this.updateGlobalState("vertexRegion", vertexRegion)
 							await this.updateGlobalState("openAiBaseUrl", openAiBaseUrl)

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -53,6 +53,8 @@ type GlobalStateKey =
 	| "apiModelId"
 	| "awsRegion"
 	| "awsUseCrossRegionInference"
+	| "awsProfile"
+	| "awsUseProfile"
 	| "vertexProjectId"
 	| "vertexRegion"
 	| "lastShownAnnouncementId"
@@ -1352,6 +1354,8 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 			awsSessionToken,
 			awsRegion,
 			awsUseCrossRegionInference,
+			awsProfile,
+			awsUseProfile,
 			vertexProjectId,
 			vertexRegion,
 			openAiBaseUrl,
@@ -1393,6 +1397,8 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 			this.getSecret("awsSessionToken") as Promise<string | undefined>,
 			this.getGlobalState("awsRegion") as Promise<string | undefined>,
 			this.getGlobalState("awsUseCrossRegionInference") as Promise<boolean | undefined>,
+			this.getGlobalState("awsProfile") as Promise<string | undefined>,
+			this.getGlobalState("awsUseProfile") as Promise<boolean | undefined>,
 			this.getGlobalState("vertexProjectId") as Promise<string | undefined>,
 			this.getGlobalState("vertexRegion") as Promise<string | undefined>,
 			this.getGlobalState("openAiBaseUrl") as Promise<string | undefined>,
@@ -1451,6 +1457,8 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 				awsSessionToken,
 				awsRegion,
 				awsUseCrossRegionInference,
+				awsProfile,
+				awsUseProfile,
 				vertexProjectId,
 				vertexRegion,
 				openAiBaseUrl,

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -27,6 +27,8 @@ export interface ApiHandlerOptions {
 	awsSessionToken?: string
 	awsRegion?: string
 	awsUseCrossRegionInference?: boolean
+	awsUseProfile?: boolean
+	awsProfile?: string
 	vertexProjectId?: string
 	vertexRegion?: string
 	openAiBaseUrl?: string

--- a/webview-ui/src/components/settings/ApiOptions.tsx
+++ b/webview-ui/src/components/settings/ApiOptions.tsx
@@ -489,14 +489,14 @@ const ApiOptions = ({ showModelOptions, apiErrorMessage, modelIdErrorMessage, is
 						}}>
 						{apiConfiguration?.awsUseProfile ? (
 							<>
-								Using AWS Profile credentials from ~/.aws/credentials. Leave profile name empty to use the default profile.
-								These credentials are only used locally to make API requests from this extension.
+								Using AWS Profile credentials from ~/.aws/credentials. Leave profile name empty to use the default
+								profile. These credentials are only used locally to make API requests from this extension.
 							</>
 						) : (
 							<>
 								Authenticate by either providing the keys above or use the default AWS credential providers, i.e.
-								~/.aws/credentials or environment variables. These credentials are only used locally to make API requests
-								from this extension.
+								~/.aws/credentials or environment variables. These credentials are only used locally to make API
+								requests from this extension.
 							</>
 						)}
 					</p>

--- a/webview-ui/src/components/settings/ApiOptions.tsx
+++ b/webview-ui/src/components/settings/ApiOptions.tsx
@@ -383,30 +383,56 @@ const ApiOptions = ({ showModelOptions, apiErrorMessage, modelIdErrorMessage, is
 						flexDirection: "column",
 						gap: 5,
 					}}>
-					<VSCodeTextField
-						value={apiConfiguration?.awsAccessKey || ""}
-						style={{ width: "100%" }}
-						type="password"
-						onInput={handleInputChange("awsAccessKey")}
-						placeholder="Enter Access Key...">
-						<span style={{ fontWeight: 500 }}>AWS Access Key</span>
-					</VSCodeTextField>
-					<VSCodeTextField
-						value={apiConfiguration?.awsSecretKey || ""}
-						style={{ width: "100%" }}
-						type="password"
-						onInput={handleInputChange("awsSecretKey")}
-						placeholder="Enter Secret Key...">
-						<span style={{ fontWeight: 500 }}>AWS Secret Key</span>
-					</VSCodeTextField>
-					<VSCodeTextField
-						value={apiConfiguration?.awsSessionToken || ""}
-						style={{ width: "100%" }}
-						type="password"
-						onInput={handleInputChange("awsSessionToken")}
-						placeholder="Enter Session Token...">
-						<span style={{ fontWeight: 500 }}>AWS Session Token</span>
-					</VSCodeTextField>
+					<VSCodeRadioGroup
+						value={apiConfiguration?.awsUseProfile ? "profile" : "credentials"}
+						onChange={(e) => {
+							const value = (e.target as HTMLInputElement)?.value
+							const useProfile = value === "profile"
+							setApiConfiguration({
+								...apiConfiguration,
+								awsUseProfile: useProfile,
+							})
+						}}>
+						<VSCodeRadio value="credentials">AWS Credentials</VSCodeRadio>
+						<VSCodeRadio value="profile">AWS Profile</VSCodeRadio>
+					</VSCodeRadioGroup>
+
+					{apiConfiguration?.awsUseProfile ? (
+						<VSCodeTextField
+							value={apiConfiguration?.awsProfile || ""}
+							style={{ width: "100%" }}
+							onInput={handleInputChange("awsProfile")}
+							placeholder="Enter profile name (default if empty)">
+							<span style={{ fontWeight: 500 }}>AWS Profile Name</span>
+						</VSCodeTextField>
+					) : (
+						<>
+							<VSCodeTextField
+								value={apiConfiguration?.awsAccessKey || ""}
+								style={{ width: "100%" }}
+								type="password"
+								onInput={handleInputChange("awsAccessKey")}
+								placeholder="Enter Access Key...">
+								<span style={{ fontWeight: 500 }}>AWS Access Key</span>
+							</VSCodeTextField>
+							<VSCodeTextField
+								value={apiConfiguration?.awsSecretKey || ""}
+								style={{ width: "100%" }}
+								type="password"
+								onInput={handleInputChange("awsSecretKey")}
+								placeholder="Enter Secret Key...">
+								<span style={{ fontWeight: 500 }}>AWS Secret Key</span>
+							</VSCodeTextField>
+							<VSCodeTextField
+								value={apiConfiguration?.awsSessionToken || ""}
+								style={{ width: "100%" }}
+								type="password"
+								onInput={handleInputChange("awsSessionToken")}
+								placeholder="Enter Session Token...">
+								<span style={{ fontWeight: 500 }}>AWS Session Token</span>
+							</VSCodeTextField>
+						</>
+					)}
 					<DropdownContainer zIndex={DROPDOWN_Z_INDEX - 1} className="dropdown-container">
 						<label htmlFor="aws-region-dropdown">
 							<span style={{ fontWeight: 500 }}>AWS Region</span>
@@ -461,9 +487,18 @@ const ApiOptions = ({ showModelOptions, apiErrorMessage, modelIdErrorMessage, is
 							marginTop: "5px",
 							color: "var(--vscode-descriptionForeground)",
 						}}>
-						Authenticate by either providing the keys above or use the default AWS credential providers, i.e.
-						~/.aws/credentials or environment variables. These credentials are only used locally to make API requests
-						from this extension.
+						{apiConfiguration?.awsUseProfile ? (
+							<>
+								Using AWS Profile credentials from ~/.aws/credentials. Leave profile name empty to use the default profile.
+								These credentials are only used locally to make API requests from this extension.
+							</>
+						) : (
+							<>
+								Authenticate by either providing the keys above or use the default AWS credential providers, i.e.
+								~/.aws/credentials or environment variables. These credentials are only used locally to make API requests
+								from this extension.
+							</>
+						)}
 					</p>
 				</div>
 			)}


### PR DESCRIPTION
### Description

This PR adds support for AWS Credential Manager profiles in has been tested to work with AWS SSO credentials via the AWS CLI. It does require that the provider is supported on the same region. 


### Test Procedure

<!-- How did you test this? Are you confident that it will not introduce bugs? If so, why? -->

Use the AWS SSO. Start right from the beginning. Use the AWS CLI to log in to your SSO user account and create a profile. Set the profile to be your default or specify the name of the profile. Then you can use the default profile and make requests, and Cline should work as normal with Bedrock.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->



### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds AWS Credential Manager profile support, allowing authentication via AWS profiles in `bedrock.ts`, with UI updates in `ApiOptions.tsx`.
> 
>   - **Behavior**:
>     - Adds support for AWS Credential Manager profiles in `bedrock.ts` using `fromIni` for profile-based authentication.
>     - Updates `ClineProvider.ts` to handle new AWS profile options `awsUseProfile` and `awsProfile`.
>     - Modifies `ApiOptions.tsx` to include UI elements for selecting AWS profiles or credentials.
>   - **Configuration**:
>     - Adds `awsUseProfile` and `awsProfile` to `ApiHandlerOptions` in `api.ts`.
>   - **UI**:
>     - Updates `ApiOptions.tsx` to allow users to choose between AWS credentials and profiles.
>     - Adds radio buttons for selecting AWS authentication method in `ApiOptions.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 69cc6e2e3f797833986db55b42c2764070839503. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->