### PR TITLE
Fix bug when shell profile is not found

### DIFF
--- a/src/test/shell.test.ts
+++ b/src/test/shell.test.ts
@@ -78,6 +78,11 @@ describe("Shell Detection Tests", () => {
 			expect(getShell()).to.equal("C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe")
 		})
 
+		it("handles undefined shell profile gracefully", () => {
+			mockVsCodeConfig("windows", "NonExistentProfile", {})
+			expect(getShell()).to.equal("C:\\Windows\\System32\\cmd.exe")
+		})
+
 		it("uses WSL bash when profile indicates WSL source", () => {
 			mockVsCodeConfig("windows", "WSL", {
 				WSL: { source: "WSL" },

--- a/src/utils/shell.ts
+++ b/src/utils/shell.ts
@@ -105,7 +105,7 @@ function getWindowsShellFromVSCode(): string | null {
 	}
 
 	// If there's a specific path, return that immediately
-	if (profile.path) {
+	if (profile?.path) {
 		return profile.path
 	}
 


### PR DESCRIPTION
### Description

Someone flagged to me that they kept getting a "Cannot read properties of undefined (reading 'path')" error, and this seemed to fix it for them.

### Test Procedure

I wrote a test, and it matches the surrounding code.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes bug in `getWindowsShellFromVSCode()` to handle undefined shell profiles gracefully, with added test case.
> 
>   - **Bug Fix**:
>     - Fixes bug in `getWindowsShellFromVSCode()` in `shell.ts` where accessing `profile.path` could cause an error if `profile` is undefined.
>     - Adds optional chaining to `profile?.path` to prevent error.
>   - **Tests**:
>     - Adds test case in `shell.test.ts` to verify handling of undefined shell profiles, expecting fallback to `cmd.exe`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 7a5add6534950bd584a837b20855355c4d9a4031. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->