### PR TITLE
Change default OpenRouter model to non-moderated

### DIFF
--- a/.changeset/breezy-bobcats-change.md
+++ b/.changeset/breezy-bobcats-change.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Change default OpenRouter model to anthropic/claude-3.5-sonnet

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -172,7 +172,7 @@ export const bedrockModels = {
 
 // OpenRouter
 // https://openrouter.ai/models?order=newest&supported_parameters=tools
-export const openRouterDefaultModelId = "anthropic/claude-3.5-sonnet:beta" // will always exist in openRouterModels
+export const openRouterDefaultModelId = "anthropic/claude-3.5-sonnet" // will always exist in openRouterModels
 export const openRouterDefaultModelInfo: ModelInfo = {
 	maxTokens: 8192,
 	contextWindow: 200_000,
@@ -184,7 +184,7 @@ export const openRouterDefaultModelInfo: ModelInfo = {
 	cacheWritesPrice: 3.75,
 	cacheReadsPrice: 0.3,
 	description:
-		"The new Claude 3.5 Sonnet delivers better-than-Opus capabilities, faster-than-Sonnet speeds, at the same Sonnet prices. Sonnet is particularly good at:\n\n- Coding: New Sonnet scores ~49% on SWE-Bench Verified, higher than the last best score, and without any fancy prompt scaffolding\n- Data science: Augments human data science expertise; navigates unstructured data while using multiple tools for insights\n- Visual processing: excelling at interpreting charts, graphs, and images, accurately transcribing text to derive insights beyond just the text alone\n- Agentic tasks: exceptional tool use, making it great at agentic tasks (i.e. complex, multi-step problem solving tasks that require engaging with other systems)\n\n#multimodal\n\n_This is a faster endpoint, made available in collaboration with Anthropic, that is self-moderated: response moderation happens on the provider's side instead of OpenRouter's. For requests that pass moderation, it's identical to the [Standard](/anthropic/claude-3.5-sonnet) variant._",
+		"The new Claude 3.5 Sonnet delivers better-than-Opus capabilities, faster-than-Sonnet speeds, at the same Sonnet prices. Sonnet is particularly good at:\n\n- Coding: New Sonnet scores ~49% on SWE-Bench Verified, higher than the last best score, and without any fancy prompt scaffolding\n- Data science: Augments human data science expertise; navigates unstructured data while using multiple tools for insights\n- Visual processing: excelling at interpreting charts, graphs, and images, accurately transcribing text to derive insights beyond just the text alone\n- Agentic tasks: exceptional tool use, making it great at agentic tasks (i.e. complex, multi-step problem solving tasks that require engaging with other systems)\n\n#multimodal",
 }
 
 // Vertex AI

--- a/webview-ui/src/components/settings/OpenRouterModelPicker.tsx
+++ b/webview-ui/src/components/settings/OpenRouterModelPicker.tsx
@@ -228,8 +228,8 @@ const OpenRouterModelPicker: React.FC<OpenRouterModelPickerProps> = ({ isPopup }
 						If you're unsure which model to choose, Cline works best with{" "}
 						<VSCodeLink
 							style={{ display: "inline", fontSize: "inherit" }}
-							onClick={() => handleModelChange("anthropic/claude-3.5-sonnet:beta")}>
-							anthropic/claude-3.5-sonnet:beta.
+							onClick={() => handleModelChange("anthropic/claude-3.5-sonnet")}>
+							anthropic/claude-3.5-sonnet.
 						</VSCodeLink>
 						You can also try searching "free" for no-cost options currently available.
 					</>


### PR DESCRIPTION
### Description

Changes the default OpenRouter model from `anthropic/claude-3.5-sonnet` to the standard endpoint based on OpenRouter team's recommendation for better scalability and reduced compute load on Anthropic's systems.

### Test Procedure

- Verified that the default model switch works correctly in local development
- Tested basic conversation flows with the standard endpoint
- Confirmed response quality remains consistent
- Checked that existing tests pass with the new default model

### Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update

### Pre-flight Checklist

- [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
- [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
- [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
- [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Additional Notes

This change was made based on direct feedback from the OpenRouter team to help with Anthropic's current compute constraints and ensure better scalability for all users. The standard endpoint provides comparable performance while distributing the load more effectively.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Change default OpenRouter model to `anthropic/claude-3.5-sonnet` for better scalability and reduced compute load.
> 
>   - **Behavior**:
>     - Change default OpenRouter model from `anthropic/claude-3.5-sonnet:beta` to `anthropic/claude-3.5-sonnet` in `api.ts` and `OpenRouterModelPicker.tsx`.
>     - Aimed at improving scalability and reducing compute load on Anthropic's systems.
>   - **Testing**:
>     - Verified model switch in local development.
>     - Tested conversation flows and confirmed response quality.
>     - Ensured existing tests pass with new default model.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for c7b92b3bcee5d6dc7a8f87f04f80162468a54dfe. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->