### PR TITLE
Fix bug where new files won't show up in files dropdown

### DIFF
--- a/.changeset/small-gifts-count.md
+++ b/.changeset/small-gifts-count.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Fix bug where new files won't show up in files dropdown

--- a/src/core/Cline.ts
+++ b/src/core/Cline.ts
@@ -1835,6 +1835,11 @@ export class Cline {
 											`${newProblemsMessage}`,
 									)
 								}
+
+								if (!fileExists) {
+									this.providerRef.deref()?.workspaceTracker?.populateFilePaths()
+								}
+
 								await this.diffViewProvider.reset()
 								await this.saveCheckpoint()
 								break
@@ -2387,6 +2392,10 @@ export class Cline {
 								if (userRejected) {
 									this.didRejectTool = true
 								}
+
+								// Re-populate file paths in case the command modified the workspace (vscode listeners do not trigger unless the user manually creates/deletes files)
+								this.providerRef.deref()?.workspaceTracker?.populateFilePaths()
+
 								pushToolResult(result)
 								await this.saveCheckpoint()
 								break

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -102,7 +102,7 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 	private disposables: vscode.Disposable[] = []
 	private view?: vscode.WebviewView | vscode.WebviewPanel
 	private cline?: Cline
-	private workspaceTracker?: WorkspaceTracker
+	workspaceTracker?: WorkspaceTracker
 	mcpHub?: McpHub
 	private authManager: FirebaseAuthManager
 	private latestAnnouncementId = "jan-20-2025" // update to some unique identifier when we add a new announcement
@@ -379,7 +379,7 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 				switch (message.type) {
 					case "webviewDidLaunch":
 						this.postStateToWebview()
-						this.workspaceTracker?.initializeFilePaths() // don't await
+						this.workspaceTracker?.populateFilePaths() // don't await
 						getTheme().then((theme) =>
 							this.postMessageToWebview({
 								type: "theme",

--- a/src/integrations/workspace/WorkspaceTracker.ts
+++ b/src/integrations/workspace/WorkspaceTracker.ts
@@ -16,7 +16,7 @@ class WorkspaceTracker {
 		this.registerListeners()
 	}
 
-	async initializeFilePaths() {
+	async populateFilePaths() {
 		// should not auto get filepaths for desktop since it would immediately show permission popup before cline ever creates a file
 		if (!cwd) {
 			return


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes bug where new files were not appearing in the files dropdown by ensuring file paths are re-populated in `Cline.ts` and `ClineProvider.ts`.
> 
>   - **Behavior**:
>     - Fixes bug where new files were not appearing in the files dropdown by calling `populateFilePaths()` in `Cline.ts` when a new file is created or a command modifies the workspace.
>     - Ensures `populateFilePaths()` is called in `ClineProvider.ts` on webview launch.
>   - **Refactoring**:
>     - Renames `initializeFilePaths()` to `populateFilePaths()` in `WorkspaceTracker.ts` to better reflect its functionality.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 7afccab3cc94668903ead6651f90835fe6496a56. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->