### PR TITLE
Expose reasoning

### DIFF
--- a/.changeset/metal-trees-care.md
+++ b/.changeset/metal-trees-care.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": minor
+---
+
+Expose the O3-mini reasoning settings in config.

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -3,5 +3,6 @@
 	"useTabs": true,
 	"printWidth": 130,
 	"semi": false,
-	"bracketSameLine": true
+	"bracketSameLine": true,
+	"endOfLine": "auto"
 }

--- a/webview-ui/src/components/settings/ApiOptions.tsx
+++ b/webview-ui/src/components/settings/ApiOptions.tsx
@@ -1030,6 +1030,24 @@ const ApiOptions = ({ showModelOptions, apiErrorMessage, modelIdErrorMessage, is
 							setIsDescriptionExpanded={setIsDescriptionExpanded}
 							isPopup={isPopup}
 						/>
+						{selectedProvider === "openai-native" && selectedModelId === "o3-mini" && (
+							<div style={{ marginTop: 5 }}>
+								<DropdownContainer zIndex={DROPDOWN_Z_INDEX - 2} className="dropdown-container">
+									<label htmlFor="o3-mini-reasoning-effort">
+										<span style={{ fontWeight: 500 }}>O3 Mini Reasoning Effort</span>
+									</label>
+									<VSCodeDropdown
+										id="o3-mini-reasoning-effort"
+										value={apiConfiguration?.o3MiniReasoningEffort || "medium"}
+										onChange={handleInputChange("o3MiniReasoningEffort")}
+										style={{ width: "100%" }}>
+										<VSCodeOption value="low">Low</VSCodeOption>
+										<VSCodeOption value="medium">Medium</VSCodeOption>
+										<VSCodeOption value="high">High</VSCodeOption>
+									</VSCodeDropdown>
+								</DropdownContainer>
+							</div>
+						)}
 					</>
 				)}
 


### PR DESCRIPTION
### Description

Expose the reasoning effort for o3 in settings.  Main plumbing was already in place.
Included is a minor change to allow pretty on Windows else every file would be updated.

### Test Procedure

I extended the getEnvironmentDetails to include these details so I can see the settings when executing.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [X ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [ X] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

![image](https://github.com/user-attachments/assets/da00203e-d16d-4629-b95a-158e7c335177)


### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds a dropdown in `ApiOptions.tsx` to expose `o3-mini` reasoning effort settings and updates Prettier config for line endings.
> 
>   - **New Feature**:
>     - Adds a dropdown in `ApiOptions.tsx` to expose `o3-mini` reasoning effort settings when `selectedProvider` is `openai-native` and `selectedModelId` is `o3-mini`.
>     - Options for reasoning effort are "Low", "Medium", and "High".
>   - **Configuration**:
>     - Updates `.prettierrc.json` to set `endOfLine` to `auto` to handle line endings across different OS.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 2b6d4fcccbdacd78f1ff31c814cfdaed58ebf3ac. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->