### PR TITLE
Add extension setting for chromium executable path

### DIFF
--- a/.changeset/poor-cobras-destroy.md
+++ b/.changeset/poor-cobras-destroy.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": minor
+---
+
+Add extension setting for chromium executable path

--- a/package.json
+++ b/package.json
@@ -171,6 +171,11 @@
 					],
 					"default": "medium",
 					"description": "Controls the reasoning effort when using the o3-mini model. Higher values may result in more thorough but slower responses."
+				},
+				"cline.chromeExecutablePath": {
+					"type": "string",
+					"default": null,
+					"description": "Path to Chrome executable for browser use functionality. If not set, the extension will attempt to find or download it automatically."
 				}
 			}
 		}

--- a/src/services/browser/BrowserSession.ts
+++ b/src/services/browser/BrowserSession.ts
@@ -42,7 +42,7 @@ export class BrowserSession {
 			await fs.mkdir(puppeteerDir, { recursive: true })
 		}
 
-		const chromeExecutablePath = vscode.workspace.getConfiguration("cline").get<string>("chromeExecutablePath")
+		const chromeExecutablePath = vscode.workspace.getConfiguration("cline").get<string>("chromeExecutablePath"); if (chromeExecutablePath && !(await fileExistsAtPath(chromeExecutablePath))) throw new Error(`Chrome executable not found at path: ${chromeExecutablePath}`);
 		const stats: PCRStats = chromeExecutablePath
 			? { puppeteer: require("puppeteer-core"), executablePath: chromeExecutablePath }
 			: // if chromium doesn't exist, this will download it to path.join(puppeteerDir, ".chromium-browser-snapshots")

--- a/src/services/browser/BrowserSession.ts
+++ b/src/services/browser/BrowserSession.ts
@@ -42,11 +42,12 @@ export class BrowserSession {
 			await fs.mkdir(puppeteerDir, { recursive: true })
 		}
 
-		// if chromium doesn't exist, this will download it to path.join(puppeteerDir, ".chromium-browser-snapshots")
-		// if it does exist it will return the path to existing chromium
-		const stats: PCRStats = await PCR({
-			downloadPath: puppeteerDir,
-		})
+		const chromeExecutablePath = vscode.workspace.getConfiguration("cline").get<string>("chromeExecutablePath")
+		const stats: PCRStats = chromeExecutablePath
+			? { puppeteer: require("puppeteer-core"), executablePath: chromeExecutablePath }
+			: // if chromium doesn't exist, this will download it to path.join(puppeteerDir, ".chromium-browser-snapshots")
+				// if it does exist it will return the path to existing chromium
+				await PCR({ downloadPath: puppeteerDir })
 
 		return stats
 	}

--- a/src/services/browser/BrowserSession.ts
+++ b/src/services/browser/BrowserSession.ts
@@ -42,7 +42,9 @@ export class BrowserSession {
 			await fs.mkdir(puppeteerDir, { recursive: true })
 		}
 
-		const chromeExecutablePath = vscode.workspace.getConfiguration("cline").get<string>("chromeExecutablePath"); if (chromeExecutablePath && !(await fileExistsAtPath(chromeExecutablePath))) throw new Error(`Chrome executable not found at path: ${chromeExecutablePath}`);
+		const chromeExecutablePath = vscode.workspace.getConfiguration("cline").get<string>("chromeExecutablePath")
+		if (chromeExecutablePath && !(await fileExistsAtPath(chromeExecutablePath)))
+			throw new Error(`Chrome executable not found at path: ${chromeExecutablePath}`)
 		const stats: PCRStats = chromeExecutablePath
 			? { puppeteer: require("puppeteer-core"), executablePath: chromeExecutablePath }
 			: // if chromium doesn't exist, this will download it to path.join(puppeteerDir, ".chromium-browser-snapshots")


### PR DESCRIPTION
### Description

Currently, pre-built Chrome binaries for ARM Linux are not distributed. As a result, on Linux machines, Puppeteer assumes that the CPU architecture is x86_64 when downloading binaries. Due to this, Cline's Browser Use does not function on ARM Linux machines.

This pull request adds a setting to Cline that allows users to specify their own built and installed Chrome or Chromium binaries.

For example, on Debian, Chromium can be installed at `/usr/bin/chromium` using the following command:

```sh
sudo apt update && sudo apt install chromium -y
```

By setting `cline.chromeExecutablePath` to `/usr/bin/chromium`, Cline will be able to use this binary.

This PR closes #1673.

<!-- Describe your changes in detail. What problem does this PR solve? -->

### Test Procedure

<!-- How did you test this? Are you confident that it will not introduce bugs? If so, why? -->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `cline.chromeExecutablePath` setting to allow specifying a custom Chrome executable path, enhancing ARM Linux compatibility.
> 
>   - **New Feature**:
>     - Adds `cline.chromeExecutablePath` setting in `package.json` to specify custom Chrome executable path.
>     - In `BrowserSession.ts`, modifies `ensureChromiumExists()` to use `cline.chromeExecutablePath` if set, otherwise defaults to downloading Chromium.
>   - **Misc**:
>     - Adds changeset file `poor-cobras-destroy.md` for version tracking.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 75ea0a59ccf201feaa98cf2835b8b8b43e9efb23. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->