### PR TITLE
feat: add volcengine ark api provider

### DIFF
--- a/.changeset/shaggy-shrimps-give.md
+++ b/.changeset/shaggy-shrimps-give.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": minor
+---
+
+Add Ark(VolcEngine) model provider

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -20,6 +20,7 @@ import { ClineHandler } from "./providers/cline"
 import { LiteLlmHandler } from "./providers/litellm"
 import { AskSageHandler } from "./providers/asksage"
 import { XAIHandler } from "./providers/xai"
+import { VolcArkHandler } from "./providers/ark"
 
 export interface ApiHandler {
 	createMessage(systemPrompt: string, messages: Anthropic.Messages.MessageParam[]): ApiStream
@@ -71,6 +72,8 @@ export function buildApiHandler(configuration: ApiConfiguration): ApiHandler {
 			return new AskSageHandler(options)
 		case "xai":
 			return new XAIHandler(options)
+		case "ark":
+			return new VolcArkHandler(options)
 		default:
 			return new AnthropicHandler(options)
 	}

--- a/src/api/providers/ark.ts
+++ b/src/api/providers/ark.ts
@@ -24,6 +24,7 @@ export class VolcArkHandler implements ApiHandler {
 	@withRetry()
 	async *createMessage(systemPrompt: string, messages: Anthropic.Messages.MessageParam[]): ApiStream {
 		const epId = this.options.arkEpId || ""
+		const modelId = this.options.apiModelId || ""
 
 		const preConvertMessages = this.prevConvertMessages(messages)
 
@@ -33,7 +34,7 @@ export class VolcArkHandler implements ApiHandler {
 		]
 
 		const stream = await this.client.chat.completions.create({
-			model: epId,
+			model: epId || modelId,
 			messages: openAiMessages,
 			temperature: 0,
 			stream: true,

--- a/src/api/providers/ark.ts
+++ b/src/api/providers/ark.ts
@@ -1,0 +1,118 @@
+import { Anthropic } from "@anthropic-ai/sdk"
+import OpenAI from "openai"
+import { withRetry } from "../retry"
+import { ApiHandlerOptions, arkDefaultModelId, ArkModelId, arkModels, ModelInfo } from "../../shared/api"
+import { ApiHandler } from "../index"
+import { convertToOpenAiMessages } from "../transform/openai-format"
+import { ApiStream } from "../transform/stream"
+
+type ContentPartText = OpenAI.Chat.ChatCompletionContentPartText
+type ContentPartImage = Anthropic.Messages.ImageBlockParam
+
+export class VolcArkHandler implements ApiHandler {
+	private options: ApiHandlerOptions
+	private client: OpenAI
+
+	constructor(options: ApiHandlerOptions) {
+		this.options = options
+		this.client = new OpenAI({
+			baseURL: this.options.arkBaseUrl,
+			apiKey: this.options.arkApiKey,
+		})
+	}
+
+	@withRetry()
+	async *createMessage(systemPrompt: string, messages: Anthropic.Messages.MessageParam[]): ApiStream {
+		const epId = this.options.arkEpId || ""
+
+		const preConvertMessages = this.prevConvertMessages(messages)
+
+		let openAiMessages: OpenAI.Chat.ChatCompletionMessageParam[] = [
+			{ role: "system", content: systemPrompt },
+			...convertToOpenAiMessages(preConvertMessages),
+		]
+
+		const stream = await this.client.chat.completions.create({
+			model: epId,
+			messages: openAiMessages,
+			temperature: 0,
+			stream: true,
+			stream_options: { include_usage: true },
+		})
+
+		for await (const chunk of stream) {
+			const delta = chunk.choices[0]?.delta
+			if (delta?.content) {
+				yield {
+					type: "text",
+					text: delta.content,
+				}
+			}
+
+			if (delta && "reasoning_content" in delta && delta.reasoning_content) {
+				yield {
+					type: "reasoning",
+					reasoning: (delta.reasoning_content as string | undefined) || "",
+				}
+			}
+
+			if (chunk.usage) {
+				yield {
+					type: "usage",
+					inputTokens: chunk.usage.prompt_tokens || 0,
+					outputTokens: chunk.usage.completion_tokens || 0,
+				}
+			}
+		}
+	}
+
+	// merge part text message to string and convert image_url
+	prevConvertMessages(anthropicMessages: Anthropic.Messages.MessageParam[]) {
+		for (const anthropicMessage of anthropicMessages) {
+			let messageContent = anthropicMessage.content
+			// Convert content to appropriate format
+			if (Array.isArray(anthropicMessage.content)) {
+				const textParts: string[] = []
+				const imageParts: ContentPartImage[] = []
+				let hasImages = false
+
+				anthropicMessage.content.forEach((part) => {
+					if (part.type === "text") {
+						textParts.push(part.text)
+					}
+					if (part.type === "image") {
+						hasImages = true
+						imageParts.push(part)
+					}
+				})
+
+				if (hasImages) {
+					const parts: (ContentPartText | ContentPartImage)[] = []
+					if (textParts.length > 0) {
+						parts.push({ type: "text", text: textParts.join("\n") })
+					}
+					parts.push(...imageParts)
+					messageContent = parts
+				} else {
+					messageContent = textParts.join("\n")
+				}
+			} else {
+				messageContent = anthropicMessage.content
+			}
+			anthropicMessage.content = messageContent
+		}
+		return anthropicMessages
+	}
+
+	getModel(): { id: ArkModelId; info: ModelInfo } {
+		const modelId = this.options.apiModelId
+		if (modelId && modelId in arkModels) {
+			const id = modelId as ArkModelId
+			return { id, info: arkModels[id] }
+		}
+		return {
+			id: arkDefaultModelId,
+			info: arkModels[arkDefaultModelId],
+		}
+	}
+}

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -62,6 +62,7 @@ type SecretKey =
 	| "authNonce"
 	| "asksageApiKey"
 	| "xaiApiKey"
+	| "arkApiKey"
 type GlobalStateKey =
 	| "apiProvider"
 	| "apiModelId"
@@ -106,6 +107,8 @@ type GlobalStateKey =
 	| "asksageApiUrl"
 	| "thinkingBudgetTokens"
 	| "planActSeparateModelsSetting"
+	| "arkBaseUrl"
+	| "arkEpId"
 
 export const GlobalFileNames = {
 	apiConversationHistory: "api_conversation_history.json",
@@ -955,6 +958,7 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 				case "gemini":
 				case "asksage":
 				case "openai-native":
+				case "ark":
 					await this.updateGlobalState("previousModeModelId", apiConfiguration.apiModelId)
 					break
 				case "openrouter":
@@ -994,6 +998,7 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 					case "gemini":
 					case "asksage":
 					case "openai-native":
+					case "ark":
 						await this.updateGlobalState("apiModelId", newModelId)
 						break
 					case "openrouter":
@@ -1134,6 +1139,9 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 			xaiApiKey,
 			thinkingBudgetTokens,
 			clineApiKey,
+			arkApiKey,
+			arkBaseUrl,
+			arkEpId,
 		} = apiConfiguration
 		await this.updateGlobalState("apiProvider", apiProvider)
 		await this.updateGlobalState("apiModelId", apiModelId)
@@ -1181,6 +1189,9 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 		await this.updateGlobalState("asksageApiUrl", asksageApiUrl)
 		await this.updateGlobalState("thinkingBudgetTokens", thinkingBudgetTokens)
 		await this.storeSecret("clineApiKey", clineApiKey)
+		await this.updateGlobalState("arkBaseUrl", arkBaseUrl)
+		await this.updateGlobalState("arkEpId", arkEpId)
+		await this.storeSecret("arkApiKey", arkApiKey)
 		if (this.cline) {
 			this.cline.api = buildApiHandler(apiConfiguration)
 		}
@@ -1980,6 +1991,9 @@ Here is the project's README to help you get started:\n\n${mcpDetails.readmeCont
 			xaiApiKey,
 			thinkingBudgetTokens,
 			planActSeparateModelsSettingRaw,
+			arkBaseUrl,
+			arkApiKey,
+			arkEpId,
 		] = await Promise.all([
 			this.getGlobalState("apiProvider") as Promise<ApiProvider | undefined>,
 			this.getGlobalState("apiModelId") as Promise<string | undefined>,
@@ -2040,6 +2054,9 @@ Here is the project's README to help you get started:\n\n${mcpDetails.readmeCont
 			this.getSecret("xaiApiKey") as Promise<string | undefined>,
 			this.getGlobalState("thinkingBudgetTokens") as Promise<number | undefined>,
 			this.getGlobalState("planActSeparateModelsSetting") as Promise<boolean | undefined>,
+			this.getGlobalState("arkBaseUrl") as Promise<string | undefined>,
+			this.getSecret("arkApiKey") as Promise<string | undefined>,
+			this.getGlobalState("arkEpId") as Promise<string | undefined>,
 		])
 
 		let apiProvider: ApiProvider
@@ -2129,6 +2146,9 @@ Here is the project's README to help you get started:\n\n${mcpDetails.readmeCont
 				asksageApiKey,
 				asksageApiUrl,
 				xaiApiKey,
+				arkBaseUrl,
+				arkApiKey,
+				arkEpId,
 			},
 			lastShownAnnouncementId,
 			customInstructions,
@@ -2275,6 +2295,7 @@ Here is the project's README to help you get started:\n\n${mcpDetails.readmeCont
 			"liteLlmApiKey",
 			"asksageApiKey",
 			"xaiApiKey",
+			"arkApiKey",
 		]
 		for (const key of secretKeys) {
 			await this.storeSecret(key, undefined)

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -18,6 +18,7 @@ export type ApiProvider =
 	| "litellm"
 	| "asksage"
 	| "xai"
+	| "ark"
 
 export interface ApiHandlerOptions {
 	apiModelId?: string
@@ -66,6 +67,9 @@ export interface ApiHandlerOptions {
 	asksageApiKey?: string
 	xaiApiKey?: string
 	thinkingBudgetTokens?: number
+	arkApiKey?: string
+	arkBaseUrl?: string
+	arkEpId?: string
 }
 
 export type ApiConfiguration = ApiHandlerOptions & {
@@ -1258,3 +1262,51 @@ export const xaiModels = {
 		description: "X AI's Grok Beta model (legacy) with 131K context window",
 	},
 } as const satisfies Record<string, ModelInfo>
+// Ark
+// https://www.volcengine.com/docs/82379/1302004
+export type ArkModelId = keyof typeof arkModels
+export const arkDefaultModelId: ArkModelId = "doubao-1.5-pro-32k"
+export const arkModels = {
+	"doubao-1.5-pro-256k": {
+		maxTokens: 12_288,
+		contextWindow: 131_072,
+		supportsImages: false,
+		supportsPromptCache: false,
+		inputPrice: 0.68,
+		outputPrice: 1.23,
+		// tool
+	},
+	"doubao-1.5-pro-32k": {
+		maxTokens: 12_288,
+		contextWindow: 32_768,
+		supportsImages: false,
+		supportsPromptCache: false,
+		inputPrice: 0.11,
+		outputPrice: 0.27,
+		// tool
+	},
+	"doubao-1.5-vision-pro-32k": {
+		maxTokens: 12_288,
+		contextWindow: 32_768,
+		supportsImages: true,
+		supportsPromptCache: false,
+		inputPrice: 0.41,
+		outputPrice: 1.23,
+	},
+	"deepseek-r1": {
+		maxTokens: 8192,
+		contextWindow: 64_000,
+		supportsImages: false,
+		supportsPromptCache: false,
+		inputPrice: 0.54,
+		outputPrice: 2.19,
+	},
+	"deepseek-v3": {
+		maxTokens: 8192,
+		contextWindow: 64_000,
+		supportsImages: false,
+		supportsPromptCache: false,
+		inputPrice: 0.27,
+		outputPrice: 1.1,
+	},
+}

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -1265,27 +1265,33 @@ export const xaiModels = {
 // Ark
 // https://www.volcengine.com/docs/82379/1302004
 export type ArkModelId = keyof typeof arkModels
-export const arkDefaultModelId: ArkModelId = "doubao-1.5-pro-32k"
+export const arkDefaultModelId: ArkModelId = "doubao-1.5-pro"
 export const arkModels = {
-	"doubao-1.5-pro-256k": {
+	"doubao-1-5-pro-256k-250115": {
 		maxTokens: 12_288,
 		contextWindow: 131_072,
 		supportsImages: false,
 		supportsPromptCache: false,
 		inputPrice: 0.68,
 		outputPrice: 1.23,
-		// tool
 	},
-	"doubao-1.5-pro-32k": {
+	"doubao-1.5-pro-32k-250115": {
 		maxTokens: 12_288,
 		contextWindow: 32_768,
 		supportsImages: false,
 		supportsPromptCache: false,
 		inputPrice: 0.11,
 		outputPrice: 0.27,
-		// tool
 	},
-	"doubao-1.5-vision-pro-32k": {
+	"doubao-1.5-pro": {
+		maxTokens: 12_288,
+		contextWindow: 32_768,
+		supportsImages: false,
+		supportsPromptCache: false,
+		inputPrice: 0.11,
+		outputPrice: 0.27,
+	},
+	"doubao-1-5-vision-pro-32k-250115": {
 		maxTokens: 12_288,
 		contextWindow: 32_768,
 		supportsImages: true,
@@ -1293,7 +1299,7 @@ export const arkModels = {
 		inputPrice: 0.41,
 		outputPrice: 1.23,
 	},
-	"deepseek-r1": {
+	"deepseek-r1-250120": {
 		maxTokens: 8192,
 		contextWindow: 64_000,
 		supportsImages: false,
@@ -1301,7 +1307,7 @@ export const arkModels = {
 		inputPrice: 0.54,
 		outputPrice: 2.19,
 	},
-	"deepseek-v3": {
+	"deepseek-v3-241226": {
 		maxTokens: 8192,
 		contextWindow: 64_000,
 		supportsImages: false,

--- a/webview-ui/src/components/settings/ApiOptions.tsx
+++ b/webview-ui/src/components/settings/ApiOptions.tsx
@@ -1290,7 +1290,7 @@ const ApiOptions = ({ showModelOptions, apiErrorMessage, modelIdErrorMessage, is
 						style={{ width: "100%" }}
 						onInput={handleInputChange("arkEpId")}
 						placeholder={"Enter Endpoint ID..."}>
-						<span style={{ fontWeight: 500 }}>Endpoint Id</span>
+						<span style={{ fontWeight: 500 }}>Endpoint ID</span>
 					</VSCodeTextField>
 					<p
 						style={{

--- a/webview-ui/src/components/settings/ApiOptions.tsx
+++ b/webview-ui/src/components/settings/ApiOptions.tsx
@@ -1245,7 +1245,7 @@ const ApiOptions = ({ showModelOptions, apiErrorMessage, modelIdErrorMessage, is
 							marginTop: 3,
 							color: "var(--vscode-descriptionForeground)",
 						}}>
-					<span style={{ color: "var(--vscode-errorForeground)" }}>
+						<span style={{ color: "var(--vscode-errorForeground)" }}>
 							(<span style={{ fontWeight: 500 }}>Note:</span> Cline uses complex prompts and works best with Claude
 							models. Less capable models may not work as expected.)
 						</span>
@@ -1266,7 +1266,7 @@ const ApiOptions = ({ showModelOptions, apiErrorMessage, modelIdErrorMessage, is
 					)} */}
 				</div>
 			)}
-			
+
 			{selectedProvider === "ark" && (
 				<div>
 					<VSCodeTextField

--- a/webview-ui/src/components/settings/ApiOptions.tsx
+++ b/webview-ui/src/components/settings/ApiOptions.tsx
@@ -1290,7 +1290,7 @@ const ApiOptions = ({ showModelOptions, apiErrorMessage, modelIdErrorMessage, is
 						style={{ width: "100%" }}
 						onInput={handleInputChange("arkEpId")}
 						placeholder={"Enter Endpoint ID..."}>
-						<span style={{ fontWeight: 500 }}>Endpoint ID</span>
+						<span style={{ fontWeight: 500 }}>Endpoint ID(optional)</span>
 					</VSCodeTextField>
 					<p
 						style={{

--- a/webview-ui/src/components/settings/ApiOptions.tsx
+++ b/webview-ui/src/components/settings/ApiOptions.tsx
@@ -43,6 +43,8 @@ import {
 	askSageDefaultURL,
 	xaiDefaultModelId,
 	xaiModels,
+	arkModels,
+	arkDefaultModelId,
 } from "../../../../src/shared/api"
 import { ExtensionMessage } from "../../../../src/shared/ExtensionMessage"
 import { useExtensionState } from "../../context/ExtensionStateContext"
@@ -207,6 +209,7 @@ const ApiOptions = ({ showModelOptions, apiErrorMessage, modelIdErrorMessage, is
 					<VSCodeOption value="litellm">LiteLLM</VSCodeOption>
 					<VSCodeOption value="asksage">AskSage</VSCodeOption>
 					<VSCodeOption value="xai">X AI</VSCodeOption>
+					<VSCodeOption value="ark">Volcengine Ark</VSCodeOption>
 				</VSCodeDropdown>
 			</DropdownContainer>
 
@@ -1242,12 +1245,10 @@ const ApiOptions = ({ showModelOptions, apiErrorMessage, modelIdErrorMessage, is
 							marginTop: 3,
 							color: "var(--vscode-descriptionForeground)",
 						}}>
-						This key is stored locally and only used to make API requests from this extension.
-						{!apiConfiguration?.xaiApiKey && (
-							<VSCodeLink href="https://x.ai" style={{ display: "inline", fontSize: "inherit" }}>
-								You can get an X AI API key by signing up here.
-							</VSCodeLink>
-						)}
+					<span style={{ color: "var(--vscode-errorForeground)" }}>
+							(<span style={{ fontWeight: 500 }}>Note:</span> Cline uses complex prompts and works best with Claude
+							models. Less capable models may not work as expected.)
+						</span>
 					</p>
 					{/* Note: To fully implement this, you would need to add a handler in ClineProvider.ts */}
 					{/* {apiConfiguration?.xaiApiKey && (
@@ -1263,6 +1264,47 @@ const ApiOptions = ({ showModelOptions, apiErrorMessage, modelIdErrorMessage, is
 							Fetch Available Models
 						</button>
 					)} */}
+				</div>
+			)}
+			
+			{selectedProvider === "ark" && (
+				<div>
+					<VSCodeTextField
+						value={apiConfiguration?.arkBaseUrl || ""}
+						style={{ width: "100%" }}
+						type="url"
+						onInput={handleInputChange("arkBaseUrl")}
+						placeholder={"Enter base URL..."}>
+						<span style={{ fontWeight: 500 }}>Base URL</span>
+					</VSCodeTextField>
+					<VSCodeTextField
+						value={apiConfiguration?.arkApiKey || ""}
+						style={{ width: "100%" }}
+						type="password"
+						onInput={handleInputChange("arkApiKey")}
+						placeholder="Enter API Key...">
+						<span style={{ fontWeight: 500 }}>API Key</span>
+					</VSCodeTextField>
+					<VSCodeTextField
+						value={apiConfiguration?.arkEpId || ""}
+						style={{ width: "100%" }}
+						onInput={handleInputChange("arkEpId")}
+						placeholder={"Enter Endpoint ID..."}>
+						<span style={{ fontWeight: 500 }}>Endpoint Id</span>
+					</VSCodeTextField>
+					<p
+						style={{
+							fontSize: "12px",
+							marginTop: 3,
+							color: "var(--vscode-descriptionForeground)",
+						}}>
+						This key is stored locally and only used to make API requests from this extension.
+						{!apiConfiguration?.xaiApiKey && (
+							<VSCodeLink href="https://x.ai" style={{ display: "inline", fontSize: "inherit" }}>
+								You can get an X AI API key by signing up here.
+							</VSCodeLink>
+						)}
+					</p>
 				</div>
 			)}
 
@@ -1304,6 +1346,7 @@ const ApiOptions = ({ showModelOptions, apiErrorMessage, modelIdErrorMessage, is
 							{selectedProvider === "mistral" && createDropdown(mistralModels)}
 							{selectedProvider === "asksage" && createDropdown(askSageModels)}
 							{selectedProvider === "xai" && createDropdown(xaiModels)}
+							{selectedProvider === "ark" && createDropdown(arkModels)}
 						</DropdownContainer>
 
 						{((selectedProvider === "anthropic" && selectedModelId === "claude-3-7-sonnet-20250219") ||
@@ -1527,6 +1570,8 @@ export function normalizeApiConfiguration(apiConfiguration?: ApiConfiguration): 
 			return getProviderData(mistralModels, mistralDefaultModelId)
 		case "asksage":
 			return getProviderData(askSageModels, askSageDefaultModelId)
+		case "ark":
+			return getProviderData(arkModels, arkDefaultModelId)
 		case "openrouter":
 			return {
 				selectedProvider: provider,

--- a/webview-ui/src/context/ExtensionStateContext.tsx
+++ b/webview-ui/src/context/ExtensionStateContext.tsx
@@ -83,6 +83,7 @@ export const ExtensionStateContextProvider: React.FC<{
 							config.clineApiKey,
 							config.asksageApiKey,
 							config.xaiApiKey,
+							config.arkApiKey,
 						].some((key) => key !== undefined)
 					: false
 				setShowWelcome(!hasKey)

--- a/webview-ui/src/utils/validate.ts
+++ b/webview-ui/src/utils/validate.ts
@@ -94,8 +94,8 @@ export function validateApiConfiguration(apiConfiguration?: ApiConfiguration): s
 				}
 				break;
 			case "ark":
-				if (!apiConfiguration.arkBaseUrl || !apiConfiguration.arkApiKey || !apiConfiguration.arkEpId) {
-					return "You must provide a valid base URL, API key, EP ID."
+				if (!apiConfiguration.arkBaseUrl || !apiConfiguration.arkApiKey) {
+					return "You must provide a valid base URL, API key."
 				}
 				break
 		}

--- a/webview-ui/src/utils/validate.ts
+++ b/webview-ui/src/utils/validate.ts
@@ -92,6 +92,11 @@ export function validateApiConfiguration(apiConfiguration?: ApiConfiguration): s
 				if (!apiConfiguration.asksageApiKey) {
 					return "You must provide a valid API key or choose a different provider."
 				}
+				break;
+			case "ark":
+				if (!apiConfiguration.arkBaseUrl || !apiConfiguration.arkApiKey || !apiConfiguration.arkEpId) {
+					return "You must provide a valid base URL, API key, EP ID, and model."
+				}
 				break
 		}
 	}

--- a/webview-ui/src/utils/validate.ts
+++ b/webview-ui/src/utils/validate.ts
@@ -95,7 +95,7 @@ export function validateApiConfiguration(apiConfiguration?: ApiConfiguration): s
 				break;
 			case "ark":
 				if (!apiConfiguration.arkBaseUrl || !apiConfiguration.arkApiKey || !apiConfiguration.arkEpId) {
-					return "You must provide a valid base URL, API key, EP ID, and model."
+					return "You must provide a valid base URL, API key, EP ID."
 				}
 				break
 		}

--- a/webview-ui/src/utils/validate.ts
+++ b/webview-ui/src/utils/validate.ts
@@ -92,7 +92,7 @@ export function validateApiConfiguration(apiConfiguration?: ApiConfiguration): s
 				if (!apiConfiguration.asksageApiKey) {
 					return "You must provide a valid API key or choose a different provider."
 				}
-				break;
+				break
 			case "ark":
 				if (!apiConfiguration.arkBaseUrl || !apiConfiguration.arkApiKey) {
 					return "You must provide a valid base URL, API key."


### PR DESCRIPTION
### Description

This PR adds Ark(火山方舟) as model provider.

### Test Procedure

- Test UI by selecting Ark as Provider
- Integration test no issue
- No changes on other providers logic

### Type of Change


-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [X] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist


-   [X] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [X] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [X] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [X] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<img width="402" alt="image" src="https://github.com/user-attachments/assets/70da9c25-6aac-4387-9d91-79e68bb8e119" />

<!-- For UI changes, add screenshots here -->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds Volcengine Ark as a new API provider with corresponding handler, UI updates, and state management changes.
> 
>   - **Behavior**:
>     - Adds `VolcArkHandler` in `src/api/providers/ark.ts` to handle Ark API interactions.
>     - Updates `buildApiHandler()` in `index.ts` to include "ark" as a case for `VolcArkHandler`.
>     - Adds Ark-specific configuration fields (`arkBaseUrl`, `arkApiKey`, `arkEpId`) in `ApiConfiguration`.
>   - **UI**:
>     - Updates `ApiOptions.tsx` to include Ark as a selectable provider with input fields for `arkBaseUrl`, `arkApiKey`, and `arkEpId`.
>     - Adds validation for Ark configuration in `validate.ts`.
>   - **State Management**:
>     - Updates `ClineProvider.ts` to handle Ark-specific state keys and secrets.
>     - Modifies `ExtensionStateContext.tsx` to include Ark API key in state hydration logic.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for ac5fe92d84f82a013e00ed031a8ea2fd038e8223. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->