### PR TITLE
Editor selection

### DIFF
--- a/.changeset/itchy-rules-shake.md
+++ b/.changeset/itchy-rules-shake.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": minor
+---
+
+add @editorSelection context mention

--- a/src/core/mentions/index.ts
+++ b/src/core/mentions/index.ts
@@ -46,6 +46,8 @@ export async function parseMentions(text: string, cwd: string, urlContentFetcher
 				: `'${mentionPath}' (see below for file content)`
 		} else if (mention === "problems") {
 			return `Workspace Problems (see below for diagnostics)`
+		} else if (mention === "editorSelection") {
+			return `Editor Selection (see below for editor selection content)`
 		}
 		return match
 	})
@@ -98,6 +100,15 @@ export async function parseMentions(text: string, cwd: string, urlContentFetcher
 				parsedText += `\n\n<workspace_diagnostics>\n${problems}\n</workspace_diagnostics>`
 			} catch (error) {
 				parsedText += `\n\n<workspace_diagnostics>\nError fetching diagnostics: ${error.message}\n</workspace_diagnostics>`
+			}
+		} else if (mention === "editorSelection") {
+			const editor = vscode.window.activeTextEditor
+			if (editor) {
+				const selection = editor.selection
+				const selectedText = editor.document.getText(selection)
+				parsedText += `\n\n<editor_selection_content>\n${selectedText}\n</editor_selection_content>`
+			} else {
+				parsedText += `\n\n<editor_selection_content>\nNo editor is active.\n</editor_selection_content>`
 			}
 		}
 	}

--- a/src/services/browser/BrowserSession.ts
+++ b/src/services/browser/BrowserSession.ts
@@ -43,8 +43,10 @@ export class BrowserSession {
 		}
 
 		const chromeExecutablePath = vscode.workspace.getConfiguration("cline").get<string>("chromeExecutablePath")
-		if (chromeExecutablePath && !(await fileExistsAtPath(chromeExecutablePath)))
+		if (chromeExecutablePath && !(await fileExistsAtPath(chromeExecutablePath))) {
 			throw new Error(`Chrome executable not found at path: ${chromeExecutablePath}`)
+		}
+
 		const stats: PCRStats = chromeExecutablePath
 			? { puppeteer: require("puppeteer-core"), executablePath: chromeExecutablePath }
 			: // if chromium doesn't exist, this will download it to path.join(puppeteerDir, ".chromium-browser-snapshots")

--- a/src/shared/context-mentions.ts
+++ b/src/shared/context-mentions.ts
@@ -44,5 +44,5 @@ Mention regex:
   - `mentionRegexGlobal`: Creates a global version of the `mentionRegex` to find all matches within a given string.
 
 */
-export const mentionRegex = /@((?:\/|\w+:\/\/)[^\s]+?|problems\b)(?=[.,;:!?]?(?=[\s\r\n]|$))/
+export const mentionRegex = /@((?:\/|\w+:\/\/)[^\s]+?|problems\b|editorSelection\b)(?=[.,;:!?]?(?=[\s\r\n]|$))/
 export const mentionRegexGlobal = new RegExp(mentionRegex.source, "g")

--- a/webview-ui/src/components/chat/ChatTextArea.tsx
+++ b/webview-ui/src/components/chat/ChatTextArea.tsx
@@ -242,6 +242,7 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 
 		const queryItems = useMemo(() => {
 			return [
+				{ type: ContextMenuOptionType.EditorSelection, value: "editorSelection" },
 				{ type: ContextMenuOptionType.Problems, value: "problems" },
 				...filePaths
 					.map((file) => "/" + file)

--- a/webview-ui/src/components/chat/ContextMenu.tsx
+++ b/webview-ui/src/components/chat/ContextMenu.tsx
@@ -48,6 +48,8 @@ const ContextMenu: React.FC<ContextMenuProps> = ({
 		switch (option.type) {
 			case ContextMenuOptionType.Problems:
 				return <span>Problems</span>
+			case ContextMenuOptionType.EditorSelection:
+				return <span>Editor Selection</span>
 			case ContextMenuOptionType.URL:
 				return <span>Paste URL to fetch contents</span>
 			case ContextMenuOptionType.NoResults:
@@ -79,6 +81,8 @@ const ContextMenu: React.FC<ContextMenuProps> = ({
 
 	const getIconForOption = (option: ContextMenuQueryItem): string => {
 		switch (option.type) {
+			case ContextMenuOptionType.EditorSelection:
+				return "list-selection"
 			case ContextMenuOptionType.File:
 				return "file"
 			case ContextMenuOptionType.Folder:

--- a/webview-ui/src/components/chat/__tests__/ContextMenu.spec.tsx
+++ b/webview-ui/src/components/chat/__tests__/ContextMenu.spec.tsx
@@ -1,0 +1,35 @@
+import { render, screen, fireEvent } from "@testing-library/react"
+import { describe, it, expect, vi } from "vitest"
+import ContextMenu from "../ContextMenu"
+import { ContextMenuOptionType, ContextMenuQueryItem } from "../../../utils/context-mentions"
+
+describe("ContextMenu", () => {
+	const onSelect = vi.fn()
+	const onMouseDown = vi.fn()
+	const setSelectedIndex = vi.fn()
+
+	const defaultProps = {
+		onSelect,
+		searchQuery: "",
+		onMouseDown,
+		selectedIndex: 0,
+		setSelectedIndex,
+		selectedType: null,
+		queryItems: [],
+	}
+
+	it("renders Editor Selection option correctly", () => {
+		const queryItems: ContextMenuQueryItem[] = [{ type: ContextMenuOptionType.EditorSelection, value: "editorSelection" }]
+		render(<ContextMenu {...defaultProps} queryItems={queryItems} />)
+
+		expect(screen.getByText("Editor Selection")).toBeInTheDocument()
+	})
+
+	it("calls onSelect when Editor Selection is clicked", () => {
+		const queryItems: ContextMenuQueryItem[] = [{ type: ContextMenuOptionType.EditorSelection, value: "editorSelection" }]
+		render(<ContextMenu {...defaultProps} queryItems={queryItems} />)
+
+		fireEvent.click(screen.getByText("Editor Selection"))
+		expect(onSelect).toHaveBeenCalledWith(ContextMenuOptionType.EditorSelection, "editorSelection")
+	})
+})

--- a/webview-ui/src/utils/context-mentions.ts
+++ b/webview-ui/src/utils/context-mentions.ts
@@ -46,6 +46,7 @@ export enum ContextMenuOptionType {
 	File = "file",
 	Folder = "folder",
 	Problems = "problems",
+	EditorSelection = "editorSelection",
 	URL = "url",
 	NoResults = "noResults",
 }
@@ -82,6 +83,7 @@ export function getContextMenuOptions(
 		}
 
 		return [
+			{ type: ContextMenuOptionType.EditorSelection, value: "editorSelection" },
 			{ type: ContextMenuOptionType.URL },
 			{ type: ContextMenuOptionType.Problems },
 			{ type: ContextMenuOptionType.Folder },


### PR DESCRIPTION
### Description

<!-- Describe your changes in detail. What problem does this PR solve? -->
This PR adds a new context mention, `@editorSelection`, which allows the user to include the currently selected text from the active editor in the prompt to the AI.

### Test Procedure

<!-- How did you test this? Are you confident that it will not introduce bugs? If so, why? -->
**Manual Testing**:
    *   Opened VS Code with the extension loaded.
    *   Created a new file with some sample code (e.g., JavaScript, Python).
    *   Selected a portion of the code.
    *   Started a chat with the AI.
    *   Typed `@` in the chat input area. Verified that "Editor Selection" appeared as an option in the context menu.
    *   Selected "Editor Selection".  Verified that `@editorSelection` was inserted into the input.
    *   Sent the message to the AI (e.g., "Explain this code: @editorSelection").
    *   Verified that the AI's response included the selected code within `<editor_selection_content>` tags, and that the response correctly addressed the selected code.
    *   Tested with no active editor, and verified get the string  `<editor_selection_content>\nNo editor is active.\n</editor_selection_content>`.
    *   Tested with the active editor, without no code selected, and verified, in the  `<editor_selection_content>` tag, there should be an empty string.
    *	Tested by typing "@edi" + tab, expecting there is editorSelection hint.


### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->
![ss](https://github.com/user-attachments/assets/549b9c27-c8d9-46f6-a711-1bc27e2cd40b)


### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `@editorSelection` context mention to include selected text from the active editor in AI prompts, with updates to regex, context menu, and parsing logic.
> 
>   - **New Feature**:
>     - Adds `@editorSelection` context mention to include selected text from the active editor in AI prompts.
>     - Updates `parseMentions()` in `index.ts` to handle `@editorSelection`, fetching selected text or indicating no active editor.
>   - **Regex and Context Menu**:
>     - Updates `mentionRegex` in `context-mentions.ts` to include `editorSelection`.
>     - Adds `EditorSelection` option to context menu in `ChatTextArea.tsx` and `ContextMenu.tsx`.
>   - **Misc**:
>     - Adds `EditorSelection` to `ContextMenuOptionType` in `context-mentions.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 017d21064b9308dedfa4668266f7750b63b39c14. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->