### PR TITLE
Feature/ENG_107 Send input on mode switch

### DIFF
--- a/.changeset/silly-cats-appear.md
+++ b/.changeset/silly-cats-appear.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": minor
+---
+
+Add new ability to send message that is in Input field during Plan/Act Mode Change to Act.

--- a/src/core/Cline.ts
+++ b/src/core/Cline.ts
@@ -2707,14 +2707,15 @@ export class Cline {
 								this.isAwaitingPlanResponse = false
 
 								if (this.didRespondToPlanAskBySwitchingMode) {
-									// await this.say("user_feedback", text ?? "", images)
 									pushToolResult(
 										formatResponse.toolResult(
 											`[The user has switched to ACT MODE, so you may now proceed with the task.]`,
 											images,
 										),
 									)
-								} else {
+								}
+
+								if (text) {
 									await this.say("user_feedback", text ?? "", images)
 									pushToolResult(formatResponse.toolResult(`<user_message>\n${text}\n</user_message>`, images))
 								}

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -618,7 +618,8 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 									await this.postMessageToWebview({
 										type: "invoke",
 										invoke: "sendMessage",
-										text: "[Proceeding with the task...]",
+										text: message.chatContent?.message || "[Proceeding with the task...]",
+										images: message.chatContent?.images,
 									})
 								} else {
 									this.cancelTask()

--- a/src/services/browser/BrowserSession.ts
+++ b/src/services/browser/BrowserSession.ts
@@ -43,8 +43,9 @@ export class BrowserSession {
 		}
 
 		const chromeExecutablePath = vscode.workspace.getConfiguration("cline").get<string>("chromeExecutablePath")
-		if (chromeExecutablePath && !(await fileExistsAtPath(chromeExecutablePath)))
+		if (chromeExecutablePath && !(await fileExistsAtPath(chromeExecutablePath))) {
 			throw new Error(`Chrome executable not found at path: ${chromeExecutablePath}`)
+		}
 		const stats: PCRStats = chromeExecutablePath
 			? { puppeteer: require("puppeteer-core"), executablePath: chromeExecutablePath }
 			: // if chromium doesn't exist, this will download it to path.join(puppeteerDir, ".chromium-browser-snapshots")

--- a/src/shared/ChatContent.ts
+++ b/src/shared/ChatContent.ts
@@ -1,0 +1,4 @@
+export interface ChatContent {
+	message?: string
+	images?: string[]
+}

--- a/src/shared/WebviewMessage.ts
+++ b/src/shared/WebviewMessage.ts
@@ -2,6 +2,7 @@ import { ApiConfiguration } from "./api"
 import { AutoApprovalSettings } from "./AutoApprovalSettings"
 import { BrowserSettings } from "./BrowserSettings"
 import { ChatSettings } from "./ChatSettings"
+import { ChatContent } from "./ChatContent"
 
 export interface WebviewMessage {
 	type:
@@ -53,6 +54,7 @@ export interface WebviewMessage {
 	autoApprovalSettings?: AutoApprovalSettings
 	browserSettings?: BrowserSettings
 	chatSettings?: ChatSettings
+	chatContent?: ChatContent
 
 	// For toggleToolAutoApprove
 	serverName?: string

--- a/src/test/webview/chat-native.test.ts
+++ b/src/test/webview/chat-native.test.ts
@@ -28,7 +28,13 @@ describe("Chat Integration Tests", () => {
                                     vscode.postMessage({ type: 'newTask', text: message.text });
                                     break;
                                 case 'toggleMode':
-                                    vscode.postMessage({ type: 'chatSettings', chatSettings: { mode: 'act' } });
+                                    vscode.postMessage({
+                                        type: 'chatSettings',
+                                        chatSettings: { mode: 'act' }, 
+                                        chatContent: {
+                                            message: "message test",
+                                        }
+                                    });
                                     break;
                                 case 'invoke':
                                     if (message.invoke === 'primaryButtonClick') {
@@ -90,6 +96,25 @@ describe("Chat Integration Tests", () => {
 		// Verify mode changed
 		const stateChange = await stateChangePromise
 		assert.equal(stateChange.chatSettings.mode, "act")
+	})
+
+	it("should toggle between plan and act modes with messages", async () => {
+		// Set up state change listener
+		const stateChangePromise = new Promise<any>((resolve) => {
+			panel.webview.onDidReceiveMessage((message) => {
+				if (message.type === "chatSettings") {
+					resolve(message)
+				}
+			})
+		})
+
+		// Trigger mode toggle
+		await panel.webview.postMessage({ type: "toggleMode" })
+
+		// Verify mode changed
+		const stateChange = await stateChangePromise
+		assert.equal(stateChange.chatSettings.mode, "act")
+		assert.equal(stateChange.chatContent.message, "message test")
 	})
 
 	it("should handle tool approval flow", async () => {

--- a/webview-ui/src/components/chat/ChatTextArea.tsx
+++ b/webview-ui/src/components/chat/ChatTextArea.tsx
@@ -616,13 +616,17 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 					chatSettings: {
 						mode: newMode,
 					},
+					chatContent: {
+						message: inputValue.trim() ? inputValue : undefined,
+						images: selectedImages.length > 0 ? selectedImages : undefined,
+					},
 				})
 				// Focus the textarea after mode toggle with slight delay
 				setTimeout(() => {
 					textAreaRef.current?.focus()
 				}, 100)
 			}, changeModeDelay)
-		}, [chatSettings.mode, showModelSelector, submitApiConfig])
+		}, [chatSettings.mode, showModelSelector, submitApiConfig, inputValue, selectedImages])
 
 		useShortcut("Meta+Shift+a", onModeToggle, { disableTextInputs: false }) // important that we don't disable the text input here
 


### PR DESCRIPTION
### Description

Add the ability to send the message typed into the Message field when Plan/Act toggle is switched to Act.  This allows end-users to send a message while switching into Act mode, for the Model to act against in addition to the previous conversation.

### Test Procedure

Automated tests were added to ensure that Cline switches to ACT Mode when a message is in the box.  It verifies that the message was sent along with the toggle.

Manual testing was does to ensure that the message is sent along to the model with the switch.  The message is sent to the Model under the ACT profile.  Regression testing was manually done to verify that when toggling the toggle with a message in the box at any point that is not part of a Plan Conversation does not break existing functionality.  I'm confident that this will not introduce bugs.

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [X] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

-   [X] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [X] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [X] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [X] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

![image](https://github.com/user-attachments/assets/09212782-11d9-49b0-b7d2-56207b3be927)


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds feature to send input message when switching from Plan to Act mode, with updates to `Cline`, `ClineProvider`, and `ChatTextArea`, and new tests.
> 
>   - **Behavior**:
>     - On switching from Plan to Act mode, the message in the input field is sent to the model (`Cline.ts`, `ClineProvider.ts`).
>     - If a message is present, it is sent under the ACT profile (`ClineProvider.ts`).
>   - **Components**:
>     - `ChatTextArea.tsx`: Captures input message and images, sends them on mode toggle.
>   - **Tests**:
>     - Added test in `chat-native.test.ts` to verify message sending on mode toggle.
>   - **Misc**:
>     - Added `ChatContent` interface in `ChatContent.ts` to structure message and images.
>     - Updated `WebviewMessage` in `WebviewMessage.ts` to include `chatContent`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 2a894d8cf14b1702765e4ce4d884ed084b502a51. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->