### PR TITLE
Fix: Bedrock Profiles

### DIFF
--- a/.changeset/orange-eels-unite.md
+++ b/.changeset/orange-eels-unite.md
@@ -2,4 +2,4 @@
 "claude-dev": patch
 ---
 
-Fix AWS Bedrock Profiles
+Fix AWS Bedrock Profiles. When configuring the AnthropicBedrock Client you must pass AWS credentials in a specific way, otherwise the client will default to reading credentials from the default AWS profile.

--- a/.changeset/orange-eels-unite.md
+++ b/.changeset/orange-eels-unite.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Fix AWS Bedrock Profiles

--- a/src/api/providers/bedrock.ts
+++ b/src/api/providers/bedrock.ts
@@ -31,15 +31,15 @@ export class AwsBedrockHandler implements ApiHandler {
 					credentials = await fromIni({
 						profile: this.options.awsProfile,
 						ignoreCache: true,
-					}) ()
+					})()
 				} else {
 					credentials = await fromIni({
 						ignoreCache: true,
-					}) ()
+					})()
 				}
-				clientConfig.awsAccessKey = credentials.accessKeyId;
-				clientConfig.awsSecretKey = credentials.secretAccessKey;
-				clientConfig.awsSessionToken = credentials.sessionToken;
+				clientConfig.awsAccessKey = credentials.accessKeyId
+				clientConfig.awsSecretKey = credentials.secretAccessKey
+				clientConfig.awsSessionToken = credentials.sessionToken
 			} else if (this.options.awsAccessKey && this.options.awsSecretKey) {
 				// Use direct credentials if provided
 				clientConfig.awsAccessKey = this.options.awsAccessKey

--- a/src/api/providers/bedrock.ts
+++ b/src/api/providers/bedrock.ts
@@ -4,39 +4,56 @@ import { ApiHandler } from "../"
 import { ApiHandlerOptions, bedrockDefaultModelId, BedrockModelId, bedrockModels, ModelInfo } from "../../shared/api"
 import { ApiStream } from "../transform/stream"
 import { fromIni } from "@aws-sdk/credential-providers"
+import { access } from "fs"
 
 // https://docs.anthropic.com/en/api/claude-on-amazon-bedrock
 export class AwsBedrockHandler implements ApiHandler {
 	private options: ApiHandlerOptions
-	private client: AnthropicBedrock
+	private client: AnthropicBedrock | any
+	private initializationPromise: Promise<void>
 
 	constructor(options: ApiHandlerOptions) {
 		this.options = options
+		this.initializationPromise = this.initializeClient()
+	}
 
-		const clientConfig: any = {
-			awsRegion: this.options.awsRegion || "us-east-1",
-		}
-
-		if (this.options.awsUseProfile) {
-			// Use profile-based credentials if enabled
-			if (this.options.awsProfile) {
-				clientConfig.credentials = fromIni({
-					profile: this.options.awsProfile,
-				})
-			} else {
-				// Use default profile if no specific profile is set
-				clientConfig.credentials = fromIni()
+	private async initializeClient() {
+		try {
+			var clientConfig: any = {
+				awsRegion: this.options.awsRegion || "us-east-1",
 			}
-		} else if (this.options.awsAccessKey && this.options.awsSecretKey) {
-			// Use direct credentials if provided
-			clientConfig.awsAccessKey = this.options.awsAccessKey
-			clientConfig.awsSecretKey = this.options.awsSecretKey
-			if (this.options.awsSessionToken) {
-				clientConfig.awsSessionToken = this.options.awsSessionToken
-			}
-		}
 
-		this.client = new AnthropicBedrock(clientConfig)
+			if (this.options.awsUseProfile) {
+				// Use profile-based credentials if enabled
+				// Use named profile, defaulting to 'default' if not specified
+				var credentials: any
+				if (this.options.awsProfile) {
+					credentials = await fromIni({
+						profile: this.options.awsProfile,
+						ignoreCache: true,
+					}) ()
+				} else {
+					credentials = await fromIni({
+						ignoreCache: true,
+					}) ()
+				}
+				clientConfig.awsAccessKey = credentials.accessKeyId;
+				clientConfig.awsSecretKey = credentials.secretAccessKey;
+				clientConfig.awsSessionToken = credentials.sessionToken;
+			} else if (this.options.awsAccessKey && this.options.awsSecretKey) {
+				// Use direct credentials if provided
+				clientConfig.awsAccessKey = this.options.awsAccessKey
+				clientConfig.awsSecretKey = this.options.awsSecretKey
+				if (this.options.awsSessionToken) {
+					clientConfig.awsSessionToken = this.options.awsSessionToken
+				}
+			}
+		} catch (error) {
+			console.error("Failed to initialize Bedrock client:", error)
+			throw error
+		} finally {
+			this.client = new AnthropicBedrock(clientConfig)
+		}
 	}
 
 	async *createMessage(systemPrompt: string, messages: Anthropic.Messages.MessageParam[]): ApiStream {

--- a/src/api/providers/bedrock.ts
+++ b/src/api/providers/bedrock.ts
@@ -17,11 +17,10 @@ export class AwsBedrockHandler implements ApiHandler {
 	}
 
 	private async initializeClient() {
+		let clientConfig: any = {
+			awsRegion: this.options.awsRegion || "us-east-1",
+		}
 		try {
-			var clientConfig: any = {
-				awsRegion: this.options.awsRegion || "us-east-1",
-			}
-
 			if (this.options.awsUseProfile) {
 				// Use profile-based credentials if enabled
 				// Use named profile, defaulting to 'default' if not specified

--- a/src/api/providers/bedrock.ts
+++ b/src/api/providers/bedrock.ts
@@ -4,7 +4,6 @@ import { ApiHandler } from "../"
 import { ApiHandlerOptions, bedrockDefaultModelId, BedrockModelId, bedrockModels, ModelInfo } from "../../shared/api"
 import { ApiStream } from "../transform/stream"
 import { fromIni } from "@aws-sdk/credential-providers"
-import { access } from "fs"
 
 // https://docs.anthropic.com/en/api/claude-on-amazon-bedrock
 export class AwsBedrockHandler implements ApiHandler {

--- a/src/services/browser/BrowserSession.ts
+++ b/src/services/browser/BrowserSession.ts
@@ -43,8 +43,9 @@ export class BrowserSession {
 		}
 
 		const chromeExecutablePath = vscode.workspace.getConfiguration("cline").get<string>("chromeExecutablePath")
-		if (chromeExecutablePath && !(await fileExistsAtPath(chromeExecutablePath)))
+		if (chromeExecutablePath && !(await fileExistsAtPath(chromeExecutablePath))) {
 			throw new Error(`Chrome executable not found at path: ${chromeExecutablePath}`)
+		}
 		const stats: PCRStats = chromeExecutablePath
 			? { puppeteer: require("puppeteer-core"), executablePath: chromeExecutablePath }
 			: // if chromium doesn't exist, this will download it to path.join(puppeteerDir, ".chromium-browser-snapshots")


### PR DESCRIPTION
### Description

This is a fix to https://github.com/cline/cline/pull/1667

The implementation is incorrectly passing aws credentials to the AnthropicBedrock client when a profile is used. This is causing the AnthropicBedrock client to fall back to using credentials from the "default" profile in all cases.

Also fixed a linting issues in BrowserSession.tx which was inherited from main.

### Test Procedure

* Setup two AWS profiles:
* default, with an invalid role.
* bedrock, with a valid role, and logged in using SSO.

Test 1:
* Set AWS credentials manually and validated I can obtain results.

Test 2:
* Set the AWS profile to "default" and validated that I receive and expected error.

Test 3:
* Set the AWS profile to "bedrock" and vaidated that I can obtain results.

Test 4:
* Fixed the default profile and logged in.
* Set the AWS profile to blank "default" and validated I can obtain results.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [X] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [X] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [X] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [X] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [X] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes AWS credential handling in `AwsBedrockHandler` to correctly use specified profiles or direct credentials for `AnthropicBedrock` client.
> 
>   - **Behavior**:
>     - Fixes incorrect AWS credential handling in `AwsBedrockHandler` when using profiles.
>     - Ensures `AnthropicBedrock` client uses correct credentials from specified profile or direct credentials.
>   - **Implementation**:
>     - Refactors `initializeClient()` to correctly fetch and assign credentials using `fromIni`.
>     - Adds error handling and logging for client initialization failures.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 393b39cc5875b6d4f8a6b1ce2f75697ca0a0a60d. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->