### PR TITLE
Add api key for litellm api provider #1766

### DIFF
--- a/.changeset/slimy-toes-wait.md
+++ b/.changeset/slimy-toes-wait.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": minor
+---
+
+Added api key field for litellm api provider in settings

--- a/src/api/providers/litellm.ts
+++ b/src/api/providers/litellm.ts
@@ -13,7 +13,7 @@ export class LiteLlmHandler implements ApiHandler {
 		this.options = options
 		this.client = new OpenAI({
 			baseURL: this.options.liteLlmBaseUrl || "http://localhost:4000",
-			apiKey: "not-needed",
+			apiKey: this.options.liteLlmApiKey || "",
 		})
 	}
 

--- a/src/api/providers/litellm.ts
+++ b/src/api/providers/litellm.ts
@@ -13,7 +13,7 @@ export class LiteLlmHandler implements ApiHandler {
 		this.options = options
 		this.client = new OpenAI({
 			baseURL: this.options.liteLlmBaseUrl || "http://localhost:4000",
-			apiKey: this.options.liteLlmApiKey || "",
+			apiKey: this.options.liteLlmApiKey || "noop",
 		})
 	}
 

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -49,6 +49,7 @@ type SecretKey =
 	| "togetherApiKey"
 	| "qwenApiKey"
 	| "mistralApiKey"
+	| "liteLlmApiKey"
 	| "authToken"
 	| "authNonce"
 type GlobalStateKey =
@@ -334,15 +335,15 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 
 		// Use a nonce to only allow a specific script to be run.
 		/*
-        content security policy of your webview to only allow scripts that have a specific nonce
-        create a content security policy meta tag so that only loading scripts with a nonce is allowed
-        As your extension grows you will likely want to add custom styles, fonts, and/or images to your webview. If you do, you will need to update the content security policy meta tag to explicity allow for these resources. E.g.
-                <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src ${webview.cspSource}; font-src ${webview.cspSource}; img-src ${webview.cspSource} https:; script-src 'nonce-${nonce}';">
+				content security policy of your webview to only allow scripts that have a specific nonce
+				create a content security policy meta tag so that only loading scripts with a nonce is allowed
+				As your extension grows you will likely want to add custom styles, fonts, and/or images to your webview. If you do, you will need to update the content security policy meta tag to explicity allow for these resources. E.g.
+								<meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src ${webview.cspSource}; font-src ${webview.cspSource}; img-src ${webview.cspSource} https:; script-src 'nonce-${nonce}';">
 		- 'unsafe-inline' is required for styles due to vscode-webview-toolkit's dynamic style injection
 		- since we pass base64 images to the webview, we need to specify img-src ${webview.cspSource} data:;
 
-        in meta tag we add nonce attribute: A cryptographic nonce (only used once) to allow scripts. The server must generate a unique nonce value each time it transmits a policy. It is critical to provide a nonce that cannot be guessed as bypassing a resource's policy is otherwise trivial.
-        */
+				in meta tag we add nonce attribute: A cryptographic nonce (only used once) to allow scripts. The server must generate a unique nonce value each time it transmits a policy. It is critical to provide a nonce that cannot be guessed as bypassing a resource's policy is otherwise trivial.
+				*/
 		const nonce = getNonce()
 
 		// Tip: Install the es6-string-html VS Code extension to enable code highlighting below
@@ -462,6 +463,7 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 								vsCodeLmModelSelector,
 								liteLlmBaseUrl,
 								liteLlmModelId,
+								liteLlmApiKey,
 								qwenApiLine,
 							} = message.apiConfiguration
 							await this.updateGlobalState("apiProvider", apiProvider)
@@ -492,6 +494,7 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 							await this.storeSecret("togetherApiKey", togetherApiKey)
 							await this.storeSecret("qwenApiKey", qwenApiKey)
 							await this.storeSecret("mistralApiKey", mistralApiKey)
+							await this.storeSecret("liteLlmApiKey", liteLlmApiKey)
 							await this.updateGlobalState("azureApiVersion", azureApiVersion)
 							await this.updateGlobalState("openRouterModelId", openRouterModelId)
 							await this.updateGlobalState("openRouterModelInfo", openRouterModelInfo)
@@ -1416,6 +1419,7 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 			previousModeModelId,
 			previousModeModelInfo,
 			qwenApiLine,
+			liteLlmApiKey,
 		] = await Promise.all([
 			this.getGlobalState("apiProvider") as Promise<ApiProvider | undefined>,
 			this.getGlobalState("apiModelId") as Promise<string | undefined>,
@@ -1465,6 +1469,7 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 			this.getGlobalState("previousModeModelId") as Promise<string | undefined>,
 			this.getGlobalState("previousModeModelInfo") as Promise<ModelInfo | undefined>,
 			this.getGlobalState("qwenApiLine") as Promise<string | undefined>,
+			this.getSecret("liteLlmApiKey") as Promise<string | undefined>,
 		])
 
 		let apiProvider: ApiProvider
@@ -1525,6 +1530,7 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 				o3MiniReasoningEffort,
 				liteLlmBaseUrl,
 				liteLlmModelId,
+				liteLlmApiKey,
 			},
 			lastShownAnnouncementId,
 			customInstructions,
@@ -1617,6 +1623,7 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 			"togetherApiKey",
 			"qwenApiKey",
 			"mistralApiKey",
+			"liteLlmApiKey",
 			"authToken",
 		]
 		for (const key of secretKeys) {

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -21,6 +21,7 @@ export interface ApiHandlerOptions {
 	apiKey?: string // anthropic
 	liteLlmBaseUrl?: string
 	liteLlmModelId?: string
+	liteLlmApiKey?: string
 	anthropicBaseUrl?: string
 	openRouterApiKey?: string
 	openRouterModelId?: string

--- a/webview-ui/src/components/settings/ApiOptions.tsx
+++ b/webview-ui/src/components/settings/ApiOptions.tsx
@@ -905,7 +905,7 @@ const ApiOptions = ({ showModelOptions, apiErrorMessage, modelIdErrorMessage, is
 						style={{ width: "100%" }}
 						type="password"
 						onInput={handleInputChange("liteLlmApiKey")}
-						placeholder="Enter API Key...">
+						placeholder="Default: noop">
 						<span style={{ fontWeight: 500 }}>API Key</span>
 					</VSCodeTextField>
 					<VSCodeTextField

--- a/webview-ui/src/components/settings/ApiOptions.tsx
+++ b/webview-ui/src/components/settings/ApiOptions.tsx
@@ -901,6 +901,14 @@ const ApiOptions = ({ showModelOptions, apiErrorMessage, modelIdErrorMessage, is
 			{selectedProvider === "litellm" && (
 				<div>
 					<VSCodeTextField
+						value={apiConfiguration?.liteLlmApiKey || ""}
+						style={{ width: "100%" }}
+						type="password"
+						onInput={handleInputChange("liteLlmApiKey")}
+						placeholder="Enter API Key...">
+						<span style={{ fontWeight: 500 }}>API Key</span>
+					</VSCodeTextField>
+					<VSCodeTextField
 						value={apiConfiguration?.liteLlmBaseUrl || ""}
 						style={{ width: "100%" }}
 						type="url"

--- a/webview-ui/src/context/ExtensionStateContext.tsx
+++ b/webview-ui/src/context/ExtensionStateContext.tsx
@@ -65,6 +65,7 @@ export const ExtensionStateContextProvider: React.FC<{
 							config.openAiApiKey,
 							config.ollamaModelId,
 							config.lmStudioModelId,
+							config.liteLlmApiKey,
 							config.geminiApiKey,
 							config.openAiNativeApiKey,
 							config.deepSeekApiKey,


### PR DESCRIPTION
### Description

Problem:
Refer issue: #1766
The settings UI doesn't provide an API key input field when LiteLLM is selected as the API provider. As a result, API calls fail with authentication errors since no Virtual Key is being passed.

Changes:
First the key was hard coded as "not-needed in the litellm provider, so introduce an way to take in the key from user like the other providers.

### Test Procedure

It is an minor fix, since only the key has to be taken from the UI.
1. Tested the key being persisted and being masked.
2. API request is successful with the litellm calls.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<img width="498" alt="Screenshot 2025-02-12 at 10 00 40 PM" src="https://github.com/user-attachments/assets/57b5ce2c-194d-490c-adac-bc94caf83ffe" />


### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds support for LiteLLM API key input, storage, and usage across the application.
> 
>   - **Behavior**:
>     - Adds API key input for LiteLLM provider in `ApiOptions.tsx`.
>     - Updates `LiteLlmHandler` in `litellm.ts` to use `liteLlmApiKey` from options.
>     - Ensures API key is stored securely in `ClineProvider.ts`.
>   - **State Management**:
>     - Updates `ExtensionStateContext.tsx` to handle `liteLlmApiKey`.
>     - Modifies `ClineProvider.ts` to store and retrieve `liteLlmApiKey`.
>   - **Configuration**:
>     - Adds `liteLlmApiKey` to `ApiHandlerOptions` in `api.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 1f0a2534f84f086afee80516f4eb6979264a3e04. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->