### PR TITLE
Add Fireworks as an API Provider

### DIFF
--- a/.changeset/fuzzy-ducks-flow.md
+++ b/.changeset/fuzzy-ducks-flow.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": minor
+---
+
+Add Fireworks API Provider

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -17,7 +17,7 @@ import { QwenHandler } from "./providers/qwen"
 import { MistralHandler } from "./providers/mistral"
 import { VsCodeLmHandler } from "./providers/vscode-lm"
 import { LiteLlmHandler } from "./providers/litellm"
-
+import { FireworksHandler } from "./providers/fireworks"
 export interface ApiHandler {
 	createMessage(systemPrompt: string, messages: Anthropic.Messages.MessageParam[]): ApiStream
 	getModel(): { id: string; info: ModelInfo }
@@ -52,6 +52,8 @@ export function buildApiHandler(configuration: ApiConfiguration): ApiHandler {
 			return new DeepSeekHandler(options)
 		case "requesty":
 			return new RequestyHandler(options)
+		case "fireworks":
+			return new FireworksHandler(options)
 		case "together":
 			return new TogetherHandler(options)
 		case "qwen":

--- a/src/api/providers/fireworks.ts
+++ b/src/api/providers/fireworks.ts
@@ -20,7 +20,7 @@ export class FireworksHandler implements ApiHandler {
 	constructor(options: ApiHandlerOptions) {
 		this.options = options
 		this.client = new OpenAI({
-			baseURL: "https://api.fireworks.ai/v1",
+			baseURL: "https://api.fireworks.ai/inference/v1",
 			apiKey: this.options.fireworksApiKey,
 		})
 	}

--- a/src/api/providers/fireworks.ts
+++ b/src/api/providers/fireworks.ts
@@ -13,7 +13,7 @@ import {
 import { convertToOpenAiMessages } from "../transform/openai-format"
 import { ApiStream } from "../transform/stream"
 
-export class DeepSeekHandler implements ApiHandler {
+export class FireworksHandler implements ApiHandler {
 	private options: ApiHandlerOptions
 	private client: OpenAI
 

--- a/src/api/providers/fireworks.ts
+++ b/src/api/providers/fireworks.ts
@@ -1,0 +1,92 @@
+import { Anthropic } from "@anthropic-ai/sdk"
+import OpenAI from "openai"
+import { withRetry } from "../retry"
+import { ApiHandler } from ".."
+import {
+	ApiHandlerOptions,
+	DeepSeekModelId,
+	ModelInfo,
+	deepSeekDefaultModelId,
+	deepSeekModels,
+	openAiModelInfoSaneDefaults,
+} from "../../shared/api"
+import { convertToOpenAiMessages } from "../transform/openai-format"
+import { ApiStream } from "../transform/stream"
+
+export class DeepSeekHandler implements ApiHandler {
+	private options: ApiHandlerOptions
+	private client: OpenAI
+
+	constructor(options: ApiHandlerOptions) {
+		this.options = options
+		this.client = new OpenAI({
+			baseURL: "https://api.fireworks.ai/v1",
+			apiKey: this.options.fireworksApiKey,
+		})
+	}
+
+	@withRetry()
+	async *createMessage(systemPrompt: string, messages: Anthropic.Messages.MessageParam[]): ApiStream {
+		const modelId = this.options.fireworksModelId ?? ""
+
+		const openAiMessages: OpenAI.Chat.ChatCompletionMessageParam[] = [
+			{ role: "system", content: systemPrompt },
+			...convertToOpenAiMessages(messages),
+		]
+
+		const stream = await this.client.chat.completions.create({
+			model: modelId,
+			max_completion_tokens: this.options.fireworksModelMaxCompletionTokens ?? 2000,
+			max_tokens: this.options.fireworksModelMaxTokens ?? 4000,
+			messages: openAiMessages,
+			stream: true,
+			stream_options: { include_usage: true },
+			temperature: 0,
+		})
+
+		let reasoning: string | null = null
+		for await (const chunk of stream) {
+			const delta = chunk.choices[0]?.delta
+			if (reasoning || delta?.content?.includes("<think>")) {
+				reasoning = (reasoning || "") + (delta.content ?? "")
+			}
+
+			if (delta?.content && !reasoning) {
+				yield {
+					type: "text",
+					text: delta.content,
+				}
+			}
+
+			if (reasoning || ("reasoning_content" in delta && delta.reasoning_content)) {
+				yield {
+					type: "reasoning",
+					reasoning: delta.content || ((delta as any).reasoning_content as string | undefined) || "",
+				}
+				if (reasoning?.includes("</think>")) {
+					// Reset so the next chunk is regular content
+					reasoning = null
+				}
+			}
+
+			if (chunk.usage) {
+				yield {
+					type: "usage",
+					inputTokens: chunk.usage.prompt_tokens || 0, // (deepseek reports total input AND cache reads/writes, see context caching: https://api-docs.deepseek.com/guides/kv_cache) where the input tokens is the sum of the cache hits/misses, while anthropic reports them as separate tokens. This is important to know for 1) context management truncation algorithm, and 2) cost calculation (NOTE: we report both input and cache stats but for now set input price to 0 since all the cost calculation will be done using cache hits/misses)
+					outputTokens: chunk.usage.completion_tokens || 0,
+					// @ts-ignore-next-line
+					cacheReadTokens: chunk.usage.prompt_cache_hit_tokens || 0,
+					// @ts-ignore-next-line
+					cacheWriteTokens: chunk.usage.prompt_cache_miss_tokens || 0,
+				}
+			}
+		}
+	}
+
+	getModel(): { id: string; info: ModelInfo } {
+		return {
+			id: this.options.fireworksModelId ?? "",
+			info: openAiModelInfoSaneDefaults,
+		}
+	}
+}

--- a/src/api/providers/fireworks.ts
+++ b/src/api/providers/fireworks.ts
@@ -36,8 +36,10 @@ export class FireworksHandler implements ApiHandler {
 
 		const stream = await this.client.chat.completions.create({
 			model: modelId,
-			max_completion_tokens: this.options.fireworksModelMaxCompletionTokens ?? 2000,
-			max_tokens: this.options.fireworksModelMaxTokens ?? 4000,
+			...(this.options.fireworksModelMaxCompletionTokens
+				? { max_completion_tokens: this.options.fireworksModelMaxCompletionTokens }
+				: {}),
+			...(this.options.fireworksModelMaxTokens ? { max_tokens: this.options.fireworksModelMaxTokens } : {}),
 			messages: openAiMessages,
 			stream: true,
 			stream_options: { include_usage: true },

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -47,6 +47,7 @@ type SecretKey =
 	| "deepSeekApiKey"
 	| "requestyApiKey"
 	| "togetherApiKey"
+	| "fireworksApiKey"
 	| "qwenApiKey"
 	| "mistralApiKey"
 	| "authToken"
@@ -86,6 +87,9 @@ type GlobalStateKey =
 	| "qwenApiLine"
 	| "requestyModelId"
 	| "togetherModelId"
+	| "fireworksModelId"
+	| "fireworksModelMaxCompletionTokens"
+	| "fireworksModelMaxTokens"
 
 export const GlobalFileNames = {
 	apiConversationHistory: "api_conversation_history.json",
@@ -454,6 +458,10 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 								requestyModelId,
 								togetherApiKey,
 								togetherModelId,
+								fireworksApiKey,
+								fireworksModelId,
+								fireworksModelMaxCompletionTokens,
+								fireworksModelMaxTokens,
 								qwenApiKey,
 								mistralApiKey,
 								azureApiVersion,
@@ -490,6 +498,10 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 							await this.storeSecret("deepSeekApiKey", deepSeekApiKey)
 							await this.storeSecret("requestyApiKey", requestyApiKey)
 							await this.storeSecret("togetherApiKey", togetherApiKey)
+							await this.storeSecret("fireworksApiKey", fireworksApiKey)
+							await this.updateGlobalState("fireworksModelId", fireworksModelId)
+							await this.updateGlobalState("fireworksModelMaxCompletionTokens", fireworksModelMaxCompletionTokens)
+							await this.updateGlobalState("fireworksModelMaxTokens", fireworksModelMaxTokens)
 							await this.storeSecret("qwenApiKey", qwenApiKey)
 							await this.storeSecret("mistralApiKey", mistralApiKey)
 							await this.updateGlobalState("azureApiVersion", azureApiVersion)
@@ -1396,6 +1408,10 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 			requestyModelId,
 			togetherApiKey,
 			togetherModelId,
+			fireworksApiKey,
+			fireworksModelId,
+			fireworksModelMaxCompletionTokens,
+			fireworksModelMaxTokens,
 			qwenApiKey,
 			mistralApiKey,
 			azureApiVersion,
@@ -1445,6 +1461,10 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 			this.getGlobalState("requestyModelId") as Promise<string | undefined>,
 			this.getSecret("togetherApiKey") as Promise<string | undefined>,
 			this.getGlobalState("togetherModelId") as Promise<string | undefined>,
+			this.getSecret("fireworksApiKey") as Promise<string | undefined>,
+			this.getGlobalState("fireworksModelId") as Promise<string | undefined>,
+			this.getGlobalState("fireworksModelMaxCompletionTokens") as Promise<number | undefined>,
+			this.getGlobalState("fireworksModelMaxTokens") as Promise<number | undefined>,
 			this.getSecret("qwenApiKey") as Promise<string | undefined>,
 			this.getSecret("mistralApiKey") as Promise<string | undefined>,
 			this.getGlobalState("azureApiVersion") as Promise<string | undefined>,
@@ -1515,6 +1535,10 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 				requestyModelId,
 				togetherApiKey,
 				togetherModelId,
+				fireworksApiKey,
+				fireworksModelId,
+				fireworksModelMaxCompletionTokens,
+				fireworksModelMaxTokens,
 				qwenApiKey,
 				qwenApiLine,
 				mistralApiKey,
@@ -1615,6 +1639,7 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 			"deepSeekApiKey",
 			"requestyApiKey",
 			"togetherApiKey",
+			"fireworksApiKey",
 			"qwenApiKey",
 			"mistralApiKey",
 			"authToken",

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -15,6 +15,7 @@ export type ApiProvider =
 	| "mistral"
 	| "vscode-lm"
 	| "litellm"
+	| "fireworks"
 
 export interface ApiHandlerOptions {
 	apiModelId?: string
@@ -48,6 +49,10 @@ export interface ApiHandlerOptions {
 	requestyModelId?: string
 	togetherApiKey?: string
 	togetherModelId?: string
+	fireworksApiKey?: string
+	fireworksModelId?: string
+	fireworksModelMaxCompletionTokens?: number
+	fireworksModelMaxTokens?: number
 	qwenApiKey?: string
 	mistralApiKey?: string
 	azureApiVersion?: string

--- a/webview-ui/src/components/chat/ChatTextArea.tsx
+++ b/webview-ui/src/components/chat/ChatTextArea.tsx
@@ -702,8 +702,8 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 					return `openai-compat:${selectedModelId}`
 				case "vscode-lm":
 					return `vscode-lm:${apiConfiguration.vsCodeLmModelSelector ? `${apiConfiguration.vsCodeLmModelSelector.vendor ?? ""}/${apiConfiguration.vsCodeLmModelSelector.family ?? ""}` : unknownModel}`
-				case "together":
-					return `${selectedProvider}:${apiConfiguration.togetherModelId}`
+				case "fireworks":
+					return `fireworks:${apiConfiguration.fireworksModelId}`
 				case "lmstudio":
 					return `${selectedProvider}:${apiConfiguration.lmStudioModelId}`
 				case "ollama":

--- a/webview-ui/src/components/settings/ApiOptions.tsx
+++ b/webview-ui/src/components/settings/ApiOptions.tsx
@@ -188,6 +188,7 @@ const ApiOptions = ({ showModelOptions, apiErrorMessage, modelIdErrorMessage, is
 					<VSCodeOption value="openai-native">OpenAI</VSCodeOption>
 					<VSCodeOption value="vscode-lm">VS Code LM API</VSCodeOption>
 					<VSCodeOption value="requesty">Requesty</VSCodeOption>
+					<VSCodeOption value="fireworks">Fireworks</VSCodeOption>
 					<VSCodeOption value="together">Together</VSCodeOption>
 					<VSCodeOption value="qwen">Alibaba Qwen</VSCodeOption>
 					<VSCodeOption value="lmstudio">LM Studio</VSCodeOption>
@@ -725,31 +726,6 @@ const ApiOptions = ({ showModelOptions, apiErrorMessage, modelIdErrorMessage, is
 						placeholder={"Enter Model ID..."}>
 						<span style={{ fontWeight: 500 }}>Model ID</span>
 					</VSCodeTextField>
-					<p
-						style={{
-							fontSize: "12px",
-							marginTop: 3,
-							color: "var(--vscode-descriptionForeground)",
-						}}>
-						<span style={{ color: "var(--vscode-errorForeground)" }}>
-							(<span style={{ fontWeight: 500 }}>Note:</span> Cline uses complex prompts and works best with models
-							such as accounts/fireworks/models/deepseek-r1 or accounts/fireworks/models/deepseek-v3
-						</span>
-					</p>
-					<VSCodeTextField
-						value={apiConfiguration?.fireworksModelMaxCompletionTokens || ""}
-						style={{ width: "100%" }}
-						onInput={handleInputChange("fireworksModelMaxCompletionTokens")}
-						placeholder={"2000"}>
-						<span style={{ fontWeight: 500 }}>Max Completion Tokens</span>
-					</VSCodeTextField>
-					<VSCodeTextField
-						value={apiConfiguration?.fireworksModelMaxTokens || ""}
-						style={{ width: "100%" }}
-						onInput={handleInputChange("fireworksModelMaxTokens")}
-						placeholder={"4000"}>
-						<span style={{ fontWeight: 500 }}>Max Context Tokens</span>
-					</VSCodeTextField>
 				</div>
 			)}
 
@@ -763,6 +739,24 @@ const ApiOptions = ({ showModelOptions, apiErrorMessage, modelIdErrorMessage, is
 						placeholder="Enter API Key...">
 						<span style={{ fontWeight: 500 }}>API Key</span>
 					</VSCodeTextField>
+					<p
+						style={{
+							fontSize: "12px",
+							marginTop: 3,
+							color: "var(--vscode-descriptionForeground)",
+						}}>
+						This key is stored locally and only used to make API requests from this extension.
+						{!apiConfiguration?.fireworksApiKey && (
+							<VSCodeLink
+								href="https://fireworks.ai/account/api-keys"
+								style={{
+									display: "inline",
+									fontSize: "inherit",
+								}}>
+								You can get a Fireworks API key by signing up here.
+							</VSCodeLink>
+						)}
+					</p>
 					<VSCodeTextField
 						value={apiConfiguration?.fireworksModelId || ""}
 						style={{ width: "100%" }}
@@ -777,10 +771,52 @@ const ApiOptions = ({ showModelOptions, apiErrorMessage, modelIdErrorMessage, is
 							color: "var(--vscode-descriptionForeground)",
 						}}>
 						<span style={{ color: "var(--vscode-errorForeground)" }}>
-							(<span style={{ fontWeight: 500 }}>Note:</span> Cline uses complex prompts and works best with Claude
-							models. Less capable models may not work as expected.)
+							(<span style={{ fontWeight: 500 }}>Note:</span> Cline uses complex prompts and works best with models
+							such as accounts/fireworks/models/deepseek-r1 or accounts/fireworks/models/deepseek-v3
 						</span>
 					</p>
+					<VSCodeTextField
+						value={apiConfiguration?.fireworksModelMaxCompletionTokens?.toString() || ""}
+						style={{ width: "100%" }}
+						onInput={(e) => {
+							const value = (e.target as HTMLInputElement).value
+							if (!value) {
+								return
+							}
+							const num = parseInt(value)
+							if (isNaN(num)) {
+								return
+							}
+							handleInputChange("fireworksModelMaxCompletionTokens")({
+								target: {
+									value: num,
+								},
+							})
+						}}
+						placeholder={"2000"}>
+						<span style={{ fontWeight: 500 }}>Max Completion Tokens</span>
+					</VSCodeTextField>
+					<VSCodeTextField
+						value={apiConfiguration?.fireworksModelMaxTokens?.toString() || ""}
+						style={{ width: "100%" }}
+						onInput={(e) => {
+							const value = (e.target as HTMLInputElement).value
+							if (!value) {
+								return
+							}
+							const num = parseInt(value)
+							if (isNaN(num)) {
+								return
+							}
+							handleInputChange("fireworksModelMaxTokens")({
+								target: {
+									value: num,
+								},
+							})
+						}}
+						placeholder={"4000"}>
+						<span style={{ fontWeight: 500 }}>Max Context Tokens</span>
+					</VSCodeTextField>
 				</div>
 			)}
 

--- a/webview-ui/src/components/settings/ApiOptions.tsx
+++ b/webview-ui/src/components/settings/ApiOptions.tsx
@@ -783,7 +783,7 @@ const ApiOptions = ({ showModelOptions, apiErrorMessage, modelIdErrorMessage, is
 							if (!value) {
 								return
 							}
-							const num = parseInt(value)
+							const num = parseInt(value, 10)
 							if (isNaN(num)) {
 								return
 							}

--- a/webview-ui/src/components/settings/ApiOptions.tsx
+++ b/webview-ui/src/components/settings/ApiOptions.tsx
@@ -894,8 +894,8 @@ const ApiOptions = ({ showModelOptions, apiErrorMessage, modelIdErrorMessage, is
 							color: "var(--vscode-descriptionForeground)",
 						}}>
 						<span style={{ color: "var(--vscode-errorForeground)" }}>
-							(<span style={{ fontWeight: 500 }}>Note:</span> Cline uses complex prompts and works best with models
-							such as accounts/fireworks/models/deepseek-r1 or accounts/fireworks/models/deepseek-v3
+							(<span style={{ fontWeight: 500 }}>Note:</span> Cline uses complex prompts and works best with Claude
+							models. Less capable models may not work as expected.)
 						</span>
 					</p>
 					<VSCodeTextField

--- a/webview-ui/src/components/settings/ApiOptions.tsx
+++ b/webview-ui/src/components/settings/ApiOptions.tsx
@@ -732,6 +732,51 @@ const ApiOptions = ({ showModelOptions, apiErrorMessage, modelIdErrorMessage, is
 							color: "var(--vscode-descriptionForeground)",
 						}}>
 						<span style={{ color: "var(--vscode-errorForeground)" }}>
+							(<span style={{ fontWeight: 500 }}>Note:</span> Cline uses complex prompts and works best with models
+							such as accounts/fireworks/models/deepseek-r1 or accounts/fireworks/models/deepseek-v3
+						</span>
+					</p>
+					<VSCodeTextField
+						value={apiConfiguration?.fireworksModelMaxCompletionTokens || ""}
+						style={{ width: "100%" }}
+						onInput={handleInputChange("fireworksModelMaxCompletionTokens")}
+						placeholder={"2000"}>
+						<span style={{ fontWeight: 500 }}>Max Completion Tokens</span>
+					</VSCodeTextField>
+					<VSCodeTextField
+						value={apiConfiguration?.fireworksModelMaxTokens || ""}
+						style={{ width: "100%" }}
+						onInput={handleInputChange("fireworksModelMaxTokens")}
+						placeholder={"4000"}>
+						<span style={{ fontWeight: 500 }}>Max Context Tokens</span>
+					</VSCodeTextField>
+				</div>
+			)}
+
+			{selectedProvider === "fireworks" && (
+				<div>
+					<VSCodeTextField
+						value={apiConfiguration?.fireworksApiKey || ""}
+						style={{ width: "100%" }}
+						type="password"
+						onInput={handleInputChange("fireworksApiKey")}
+						placeholder="Enter API Key...">
+						<span style={{ fontWeight: 500 }}>API Key</span>
+					</VSCodeTextField>
+					<VSCodeTextField
+						value={apiConfiguration?.fireworksModelId || ""}
+						style={{ width: "100%" }}
+						onInput={handleInputChange("fireworksModelId")}
+						placeholder={"Enter Model ID..."}>
+						<span style={{ fontWeight: 500 }}>Model ID</span>
+					</VSCodeTextField>
+					<p
+						style={{
+							fontSize: "12px",
+							marginTop: 3,
+							color: "var(--vscode-descriptionForeground)",
+						}}>
+						<span style={{ color: "var(--vscode-errorForeground)" }}>
 							(<span style={{ fontWeight: 500 }}>Note:</span> Cline uses complex prompts and works best with Claude
 							models. Less capable models may not work as expected.)
 						</span>

--- a/webview-ui/src/components/settings/__tests__/APIOptions.spec.tsx
+++ b/webview-ui/src/components/settings/__tests__/APIOptions.spec.tsx
@@ -94,3 +94,71 @@ describe("ApiOptions Component", () => {
 		expect(modelIdInput).toBeInTheDocument()
 	})
 })
+
+vi.mock("../../../context/ExtensionStateContext", async (importOriginal) => {
+	const actual = await importOriginal()
+	return {
+		...actual,
+		// your mocked methods
+		useExtensionState: vi.fn(() => ({
+			apiConfiguration: {
+				apiProvider: "fireworks",
+				fireworksApiKey: "",
+				fireworksModelId: "",
+				fireworksModelMaxCompletionTokens: 2000,
+				fireworksModelMaxTokens: 4000,
+			},
+			setApiConfiguration: vi.fn(),
+			uriScheme: "vscode",
+		})),
+	}
+})
+
+describe("ApiOptions Component", () => {
+	vi.clearAllMocks()
+	const mockPostMessage = vi.fn()
+
+	beforeEach(() => {
+		global.vscode = { postMessage: mockPostMessage } as any
+	})
+
+	it("renders Fireworks API Key input", () => {
+		render(
+			<ExtensionStateContextProvider>
+				<ApiOptions showModelOptions={true} />
+			</ExtensionStateContextProvider>,
+		)
+		const apiKeyInput = screen.getByPlaceholderText("Enter API Key...")
+		expect(apiKeyInput).toBeInTheDocument()
+	})
+
+	it("renders Fireworks Model ID input", () => {
+		render(
+			<ExtensionStateContextProvider>
+				<ApiOptions showModelOptions={true} />
+			</ExtensionStateContextProvider>,
+		)
+		const modelIdInput = screen.getByPlaceholderText("Enter Model ID...")
+		expect(modelIdInput).toBeInTheDocument()
+	})
+
+	it("renders Fireworks Max Completion Tokens input", () => {
+		render(
+			<ExtensionStateContextProvider>
+				<ApiOptions showModelOptions={true} />
+			</ExtensionStateContextProvider>,
+		)
+		const maxCompletionTokensInput = screen.getByPlaceholderText("2000")
+		expect(maxCompletionTokensInput).toBeInTheDocument()
+	})
+
+	it("renders Fireworks Max Tokens input", () => {
+		render(
+			<ExtensionStateContextProvider>
+				<ApiOptions showModelOptions={true} />
+			</ExtensionStateContextProvider>,
+		)
+		const maxTokensInput = screen.getByPlaceholderText("4000")
+		expect(maxTokensInput).toBeInTheDocument()
+	})
+})

--- a/webview-ui/src/context/ExtensionStateContext.tsx
+++ b/webview-ui/src/context/ExtensionStateContext.tsx
@@ -70,6 +70,7 @@ export const ExtensionStateContextProvider: React.FC<{
 							config.deepSeekApiKey,
 							config.requestyApiKey,
 							config.togetherApiKey,
+							config.fireworksApiKey,
 							config.qwenApiKey,
 							config.mistralApiKey,
 							config.vsCodeLmModelSelector,

--- a/webview-ui/src/utils/validate.ts
+++ b/webview-ui/src/utils/validate.ts
@@ -59,7 +59,7 @@ export function validateApiConfiguration(apiConfiguration?: ApiConfiguration): s
 				}
 				break
 			case "fireworks":
-				if (!apiConfiguration.fireworksApiKey || !apiConfiguration.fireworksApiKey) {
+				if (!apiConfiguration.fireworksApiKey || !apiConfiguration.fireworksModelId) {
 					return "You must provide a valid API key or choose a different provider."
 				}
 				break

--- a/webview-ui/src/utils/validate.ts
+++ b/webview-ui/src/utils/validate.ts
@@ -58,6 +58,11 @@ export function validateApiConfiguration(apiConfiguration?: ApiConfiguration): s
 					return "You must provide a valid API key or choose a different provider."
 				}
 				break
+			case "fireworks":
+				if (!apiConfiguration.fireworksApiKey || !apiConfiguration.fireworksApiKey) {
+					return "You must provide a valid API key or choose a different provider."
+				}
+				break
 			case "together":
 				if (!apiConfiguration.togetherApiKey || !apiConfiguration.togetherModelId) {
 					return "You must provide a valid API key or choose a different provider."


### PR DESCRIPTION
### Description

Adding [Fireworks](https://fireworks.ai/) as an API provider in the settings menu.

### Test Procedure

Added unit tests runnable via npm run test:webview

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<img width="345" alt="Screenshot 2025-02-12 at 12 55 06 PM" src="https://github.com/user-attachments/assets/7468197a-de9c-4b02-8140-19695882e7cf" />


### Additional Notes

Fireworks is also OpenAI compatible.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add Fireworks as a new API provider with full integration into the system, including UI updates and validation.
> 
>   - **Behavior**:
>     - Add `Fireworks` as a new API provider in `api.ts` and `ClineProvider.ts`.
>     - Implement `DeepSeekHandler` in `fireworks.ts` to handle API requests to Fireworks.
>     - Update `validateApiConfiguration()` in `validate.ts` to include Fireworks API key validation.
>   - **UI**:
>     - Add Fireworks option to `ApiOptions.tsx` and `ChatTextArea.tsx` for user selection.
>     - Update `APIOptions.spec.tsx` to test Fireworks API key and model ID inputs.
>   - **Misc**:
>     - Add Fireworks-related fields to `ExtensionStateContext.tsx` for state management.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for c2b3cf3806f7556b5ee2de90dcffb7e0183c52d7. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->