### PR TITLE
Add .clinerules.local option to include local cline rules in addition to .clinerules

### DIFF
--- a/src/core/Cline.ts
+++ b/src/core/Cline.ts
@@ -1280,15 +1280,31 @@ export class Cline {
 			}
 		}
 
+		const clineRulesLocalFilePath = path.resolve(cwd, GlobalFileNames.clineRulesLocal)
+		let clineRulesLocalFileInstructions: string | undefined
+		if (await fileExistsAtPath(clineRulesLocalFilePath)) {
+			try {
+				const ruleFileContent = (await fs.readFile(clineRulesLocalFilePath, "utf8")).trim()
+				if (ruleFileContent) {
+					clineRulesLocalFileInstructions = `# .clinerules.local\n\nThe following is provided by a root-level .clinerules.local file where the user has specified local-only instructions for this working directory (${cwd.toPosix()})\n\n${ruleFileContent}`
+				}
+			} catch {
+				console.error(`Failed to read .clinerules.local file at ${clineRulesLocalFilePath}`)
+			}
+		}
+
 		const clineIgnoreContent = this.clineIgnoreController.clineIgnoreContent
 		let clineIgnoreInstructions: string | undefined
 		if (clineIgnoreContent) {
 			clineIgnoreInstructions = `# .clineignore\n\n(The following is provided by a root-level .clineignore file where the user has specified files and directories that should not be accessed. When using list_files, you'll notice a ${LOCK_TEXT_SYMBOL} next to files that are blocked. Attempting to access the file's contents e.g. through read_file will result in an error.)\n\n${clineIgnoreContent}\n.clineignore`
 		}
 
-		if (settingsCustomInstructions || clineRulesFileInstructions) {
+		if (settingsCustomInstructions || clineRulesFileInstructions || clineRulesLocalFileInstructions) {
 			// altering the system prompt mid-task will break the prompt cache, but in the grand scheme this will not change often so it's better to not pollute user messages with it the way we have to with <potentially relevant details>
-			systemPrompt += addUserInstructions(settingsCustomInstructions, clineRulesFileInstructions, clineIgnoreInstructions)
+			const combinedRulesInstructions = [clineRulesFileInstructions, clineRulesLocalFileInstructions]
+				.filter(Boolean)
+				.join('\n\n')
+			systemPrompt += addUserInstructions(settingsCustomInstructions, combinedRulesInstructions, clineIgnoreInstructions)
 		}
 
 		// If the previous API request's total token usage is close to the context window, truncate the conversation history to free up space for the new request
@@ -2902,7 +2918,7 @@ export class Cline {
 		}
 
 		/*
-		Seeing out of bounds is fine, it means that the next too call is being built up and ready to add to assistantMessageContent to present. 
+		Seeing out of bounds is fine, it means that the next too call is being built up and ready to add to assistantMessageContent to present.
 		When you see the UI inactive during this, it means that a tool is breaking without presenting any UI. For example the write_to_file tool was breaking when relpath was undefined, and for invalid relpath it never presented UI.
 		*/
 		this.presentAssistantMessageLocked = false // this needs to be placed here, if not then calling this.presentAssistantMessage below would fail (sometimes) since it's locked

--- a/src/core/Cline.ts
+++ b/src/core/Cline.ts
@@ -1303,7 +1303,7 @@ export class Cline {
 			// altering the system prompt mid-task will break the prompt cache, but in the grand scheme this will not change often so it's better to not pollute user messages with it the way we have to with <potentially relevant details>
 			const combinedRulesInstructions = [clineRulesFileInstructions, clineRulesLocalFileInstructions]
 				.filter(Boolean)
-				.join('\n\n')
+				.join("\n\n")
 			systemPrompt += addUserInstructions(settingsCustomInstructions, combinedRulesInstructions, clineIgnoreInstructions)
 		}
 

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -95,6 +95,7 @@ export const GlobalFileNames = {
 	openRouterModels: "openrouter_models.json",
 	mcpSettings: "cline_mcp_settings.json",
 	clineRules: ".clinerules",
+	clineRulesLocal: ".clinerules.local",
 }
 
 export class ClineProvider implements vscode.WebviewViewProvider {


### PR DESCRIPTION
### Description

When working with a team of developers, we want to allow developers to share a `.clinerules` files in the code base, but also include their own local `.clinerules.local` set of rules for cline.

### Test Procedure

1. Run cline with a `.clinerules.local` file that has very specific instructions.
2. Ask cline about the instructions.
3. Verify that local instructions are in cline's context.

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [X] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

-   [X] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [X] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [X] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [X] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add support for `.clinerules.local` in `Cline.ts` to allow local rule customization alongside shared `.clinerules`.
> 
>   - **Behavior**:
>     - Support for `.clinerules.local` added in `Cline.ts` to allow local rule customization.
>     - If `.clinerules.local` exists, its content is read and included in the system prompt.
>   - **Files**:
>     - `Cline.ts`: Implements reading and incorporating `.clinerules.local`.
>     - `ClineProvider.ts`: Updates `GlobalFileNames` to include `.clinerules.local`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for b5f3782e47e06158f0a5ce70e9694e1304ea68a7. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->