### PR TITLE
Replace globby with fast-glob. Fix Cline ignoring entire workspace with just 1 folder no access permission

### DIFF
--- a/.changeset/red-terms-build.md
+++ b/.changeset/red-terms-build.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Replace globby with own glob implementation based on fast-glob

--- a/src/services/glob/list-files.ts
+++ b/src/services/glob/list-files.ts
@@ -43,7 +43,6 @@ export async function listFiles(dirPath: string, recursive: boolean, limit: numb
 
 		try {
 			const gitignoreContent = await fs.promises.readFile(gitignorePath, "utf8")
-			const ig = ignore().add(gitignoreContent)
 
 			// Convert .gitignore patterns to glob patterns
 			return gitignoreContent

--- a/src/services/glob/list-files.ts
+++ b/src/services/glob/list-files.ts
@@ -46,7 +46,8 @@ export async function listFiles(dirPath: string, recursive: boolean, limit: numb
 
 			// Convert .gitignore patterns to glob patterns
 			return gitignoreContent
-				.split("\n").map(line => line.trim())
+				.split("\n")
+				.map((line) => line.trim())
 				.filter((line) => line && !line.startsWith("#"))
 				.map(
 					(pattern) =>

--- a/src/services/glob/list-files.ts
+++ b/src/services/glob/list-files.ts
@@ -46,7 +46,7 @@ export async function listFiles(dirPath: string, recursive: boolean, limit: numb
 
 			// Convert .gitignore patterns to glob patterns
 			return gitignoreContent
-				.split("\n")
+				.split("\n").map(line => line.trim())
 				.filter((line) => line && !line.startsWith("#"))
 				.map(
 					(pattern) =>


### PR DESCRIPTION
### Description

Replace globby with fast-glob.
- Fast-glob does not have gitignore functionality so I added a function to translate the root `.gitignore` to glob patterns 
- This fix https://github.com/cline/cline/issues/1756

### Test Procedure

- I tested with extension development mode, the bug is not found anymore.
- fast-glob seems more permissive than globby so there's unlikely any breaking bug caused by replacing the library. 

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Replace `globby` with `fast-glob` in `list-files.ts`, fixing Cline's workspace ignore issue and adding `.gitignore` pattern conversion.
> 
>   - **Behavior**:
>     - Replace `globby` with `fast-glob` in `list-files.ts`.
>     - Add `getGitignorePatterns()` to convert `.gitignore` to glob patterns.
>     - Fix Cline ignoring entire workspace if one folder lacks access permission.
>   - **Functions**:
>     - Update `globbyLevelByLevel()` to use `fast-glob` and handle `EACCES` errors by logging and continuing.
>   - **Misc**:
>     - Remove `gitignore` option from `options` in `listFiles()` and replace with custom ignore patterns.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for cf67a9cca06ee8bf7cafe06f8eaa346addb146a4. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->