### PR TITLE
Webpack Single Bundle

### DIFF
--- a/.changeset/smart-cycles-promise.md
+++ b/.changeset/smart-cycles-promise.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Force all JS code into a single bundle for better VS Code compatability

--- a/webview-ui/scripts/build-react-no-split.js
+++ b/webview-ui/scripts/build-react-no-split.js
@@ -98,18 +98,26 @@ config.module.rules[1].oneOf.forEach((rule) => {
 	}
 })
 
-// Disable code splitting
-config.optimization.splitChunks = {
-	cacheGroups: {
-		default: false,
+// Force all code into a single bundle for VS Code webview compatibility.
+// This is necessary for:
+// 1. Mermaid.js to work properly (prevents async chunk loading)
+// 2. Consistent CSP nonce handling (single bundle = single nonce)
+config.optimization = {
+	...config.optimization,
+	splitChunks: {
+		cacheGroups: {
+			default: false,
+		},
+		name: "main", // Forces all chunks (dynamic import() calls, for example those used by Mermaid) into one bundle - this is what actually prevents code splitting
 	},
+	runtimeChunk: false,
 }
 
-// Disable code chunks
-config.optimization.runtimeChunk = false
-
-// Rename main.{hash}.js to main.js
-config.output.filename = "static/js/[name].js"
+// Ensure all chunks are named 'main' to match our CSP nonce setup
+config.output = {
+	...config.output,
+	filename: "static/js/[name].js",
+}
 
 // Rename main.{hash}.css to main.css
 config.plugins[5].options.filename = "static/css/[name].css"


### PR DESCRIPTION
### Description

Force webpack to put everything in one bundle. This was the intention with the previous code, but it wasn't catching all code splitting.

### Test Procedure

Compiled and ran in development mode to make sure things still work as before.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Additional Notes


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Modify Webpack to bundle all JS into a single file for VS Code webview compatibility, preventing code splitting issues.
> 
>   - **Webpack Configuration**:
>     - Modify `build-react-no-split.js` to force all JS code into a single bundle for VS Code webview compatibility.
>     - Disable `splitChunks` and set `runtimeChunk` to `false` to prevent code splitting.
>     - Set `config.output.filename` to `static/js/[name].js` to ensure consistent file naming.
>   - **Purpose**:
>     - Ensures Mermaid.js works properly by preventing async chunk loading.
>     - Maintains consistent CSP nonce handling with a single bundle.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 8dfb2621bacc692e2ea95168e8cf687afdd0ea81. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->