### PR TITLE
feat: add custom auth header support for Anthropic provider

### DIFF
--- a/.changeset/fair-colts-sleep.md
+++ b/.changeset/fair-colts-sleep.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": minor
+---
+
+Add ability to specify custom auth header for Anthropic

--- a/src/api/providers/anthropic.ts
+++ b/src/api/providers/anthropic.ts
@@ -14,6 +14,11 @@ export class AnthropicHandler implements ApiHandler {
 		this.client = new Anthropic({
 			apiKey: this.options.apiKey,
 			baseURL: this.options.anthropicBaseUrl || undefined,
+			defaultHeaders: this.options.anthropicCustomAuthHeader
+				? {
+						Authorization: this.options.anthropicCustomAuthHeader,
+					}
+				: undefined,
 		})
 	}
 

--- a/src/api/providers/anthropic.ts
+++ b/src/api/providers/anthropic.ts
@@ -15,9 +15,7 @@ export class AnthropicHandler implements ApiHandler {
 			apiKey: this.options.apiKey,
 			baseURL: this.options.anthropicBaseUrl || undefined,
 			defaultHeaders: this.options.anthropicCustomAuthHeader
-				? {
-						Authorization: this.options.anthropicCustomAuthHeader,
-					}
+				? { Authorization: this.options.anthropicCustomAuthHeader }
 				: undefined,
 		})
 	}

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -23,6 +23,7 @@ export interface ApiHandlerOptions {
 	liteLlmModelId?: string
 	liteLlmApiKey?: string
 	anthropicBaseUrl?: string
+	anthropicCustomAuthHeader?: string
 	openRouterApiKey?: string
 	openRouterModelId?: string
 	openRouterModelInfo?: ModelInfo

--- a/webview-ui/src/components/settings/ApiOptions.tsx
+++ b/webview-ui/src/components/settings/ApiOptions.tsx
@@ -218,6 +218,7 @@ const ApiOptions = ({ showModelOptions, apiErrorMessage, modelIdErrorMessage, is
 								setApiConfiguration({
 									...apiConfiguration,
 									anthropicBaseUrl: "",
+									anthropicCustomAuthHeader: "",
 								})
 							}
 						}}>
@@ -225,13 +226,23 @@ const ApiOptions = ({ showModelOptions, apiErrorMessage, modelIdErrorMessage, is
 					</VSCodeCheckbox>
 
 					{anthropicBaseUrlSelected && (
-						<VSCodeTextField
-							value={apiConfiguration?.anthropicBaseUrl || ""}
-							style={{ width: "100%", marginTop: 3 }}
-							type="url"
-							onInput={handleInputChange("anthropicBaseUrl")}
-							placeholder="Default: https://api.anthropic.com"
-						/>
+						<>
+							<VSCodeTextField
+								value={apiConfiguration?.anthropicBaseUrl || ""}
+								style={{ width: "100%", marginTop: 3 }}
+								type="url"
+								onInput={handleInputChange("anthropicBaseUrl")}
+								placeholder="Default: https://api.anthropic.com"
+							/>
+							<VSCodeTextField
+								value={apiConfiguration?.anthropicCustomAuthHeader || ""}
+								style={{ width: "100%", marginTop: 3 }}
+								type="text"
+								onInput={handleInputChange("anthropicCustomAuthHeader")}
+								placeholder="Custom Authorization header (optional)">
+								<span style={{ fontWeight: 500 }}>Custom Auth Header</span>
+							</VSCodeTextField>
+						</>
 					)}
 
 					<p


### PR DESCRIPTION
### Description

This PR adds the ability to specify a custom authorization header when using the Anthropic provider. This is particularly useful for users who are running self-hosted versions of Anthropic-like APIs that may require different authentication headers (my personal use-case, but pretty sure others might have it as well).

### Test Procedure

Please advise on testing this. I assumed it would work, but a dev loop on how to verify is needed.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds support for custom authorization headers for the Anthropic provider, including UI updates for configuration.
> 
>   - **Behavior**:
>     - Adds support for custom authorization headers in `AnthropicHandler` in `anthropic.ts`.
>     - Updates `ApiHandlerOptions` in `api.ts` to include `anthropicCustomAuthHeader`.
>   - **UI**:
>     - Updates `ApiOptions.tsx` to include a text field for `anthropicCustomAuthHeader` when Anthropic provider is selected.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 43e1e4c0dfb1ab2e9bd573d3d121e5fd26c79891. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->