### PR TITLE
Improve Mode Tooltip

### DIFF
--- a/.changeset/chilly-pandas-retire.md
+++ b/.changeset/chilly-pandas-retire.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": minor
+---
+
+tooltip for each mode can be shown no matter what the current mode is

--- a/webview-ui/src/components/chat/ChatTextArea.tsx
+++ b/webview-ui/src/components/chat/ChatTextArea.tsx
@@ -237,7 +237,7 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 		const buttonRef = useRef<HTMLDivElement>(null)
 		const [arrowPosition, setArrowPosition] = useState(0)
 		const [menuPosition, setMenuPosition] = useState(0)
-		const [shownTooltipMode, setShownToolipMode] = useState<ChatSettings["mode"] | null>(null)
+		const [shownTooltipMode, setShownTooltipMode] = useState<ChatSettings["mode"] | null>(null)
 
 		const [, metaKeyChar] = useMetaKeyDetection(platform)
 

--- a/webview-ui/src/components/chat/ChatTextArea.tsx
+++ b/webview-ui/src/components/chat/ChatTextArea.tsx
@@ -22,6 +22,7 @@ import Tooltip from "../common/Tooltip"
 import ApiOptions, { normalizeApiConfiguration } from "../settings/ApiOptions"
 import { MAX_IMAGES_PER_MESSAGE } from "./ChatView"
 import ContextMenu from "./ContextMenu"
+import { ChatSettings } from "../../../../src/shared/ChatSettings"
 
 interface ChatTextAreaProps {
 	inputValue: string
@@ -236,6 +237,7 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 		const buttonRef = useRef<HTMLDivElement>(null)
 		const [arrowPosition, setArrowPosition] = useState(0)
 		const [menuPosition, setMenuPosition] = useState(0)
+		const [shownTooltipMode, setShownToolipMode] = useState<ChatSettings["mode"] | null>(null)
 
 		const [, metaKeyChar] = useMetaKeyDetection(platform)
 
@@ -1130,12 +1132,23 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 						</ModelContainer>
 					</ButtonGroup>
 					<Tooltip
-						tipText={`In ${chatSettings.mode === "act" ? "Act" : "Plan"}  mode, Cline will ${chatSettings.mode === "act" ? "complete the task immediately" : "gather information to architect a plan"}`}
+						visible={shownTooltipMode !== null}
+						tipText={`In ${shownTooltipMode === "act" ? "Act" : "Plan"}  mode, Cline will ${shownTooltipMode === "act" ? "complete the task immediately" : "gather information to architect a plan"}`}
 						hintText={`Toggle w/ ${metaKeyChar}+Shift+A`}>
 						<SwitchContainer data-testid="mode-switch" disabled={false} onClick={onModeToggle}>
 							<Slider isAct={chatSettings.mode === "act"} isPlan={chatSettings.mode === "plan"} />
-							<SwitchOption isActive={chatSettings.mode === "plan"}>Plan</SwitchOption>
-							<SwitchOption isActive={chatSettings.mode === "act"}>Act</SwitchOption>
+							<SwitchOption
+								isActive={chatSettings.mode === "plan"}
+								onMouseOver={() => setShownToolipMode("plan")}
+								onMouseLeave={() => setShownToolipMode(null)}>
+								Plan
+							</SwitchOption>
+							<SwitchOption
+								isActive={chatSettings.mode === "act"}
+								onMouseOver={() => setShownToolipMode("act")}
+								onMouseLeave={() => setShownToolipMode(null)}>
+								Act
+							</SwitchOption>
 						</SwitchContainer>
 					</Tooltip>
 				</ControlsContainer>

--- a/webview-ui/src/components/chat/ChatTextArea.tsx
+++ b/webview-ui/src/components/chat/ChatTextArea.tsx
@@ -1139,14 +1139,14 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 							<Slider isAct={chatSettings.mode === "act"} isPlan={chatSettings.mode === "plan"} />
 							<SwitchOption
 								isActive={chatSettings.mode === "plan"}
-								onMouseOver={() => setShownToolipMode("plan")}
-								onMouseLeave={() => setShownToolipMode(null)}>
+								onMouseOver={() => setShownTooltipMode("plan")}
+								onMouseLeave={() => setShownTooltipMode(null)}>
 								Plan
 							</SwitchOption>
 							<SwitchOption
 								isActive={chatSettings.mode === "act"}
-								onMouseOver={() => setShownToolipMode("act")}
-								onMouseLeave={() => setShownToolipMode(null)}>
+								onMouseOver={() => setShownTooltipMode("act")}
+								onMouseLeave={() => setShownTooltipMode(null)}>
 								Act
 							</SwitchOption>
 						</SwitchContainer>

--- a/webview-ui/src/components/common/Tooltip.tsx
+++ b/webview-ui/src/components/common/Tooltip.tsx
@@ -9,6 +9,7 @@ import {
 } from "../../utils/vscStyles"
 
 interface TooltipProps {
+	visible: boolean
 	hintText: string
 	tipText: string
 	children: React.ReactNode
@@ -38,14 +39,9 @@ const Hint = styled.div`
 	margin-top: 2px;
 `
 
-const Tooltip: React.FC<TooltipProps> = ({ tipText, hintText, children }) => {
-	const [visible, setVisible] = useState(false)
-
-	const showTooltip = () => setVisible(true)
-	const hideTooltip = () => setVisible(false)
-
+const Tooltip: React.FC<TooltipProps> = ({ visible, tipText, hintText, children }) => {
 	return (
-		<div style={{ position: "relative", display: "inline-block" }} onMouseEnter={showTooltip} onMouseLeave={hideTooltip}>
+		<div style={{ position: "relative", display: "inline-block" }}>
 			{children}
 			{visible && (
 				<TooltipBody>


### PR DESCRIPTION
### Description
Previously, when we hover to the Chat Mode switch option, it will only show tooltip of current selected mode, no matter whether we hover on which mode

Now, no matter what the current selected mode is
- when we hover on Plan mode, it will shows tooltip of Plan mode
- when we hover on Act mode, it will shows tooltip of Act mode.

### Test Procedure
I've tested it by hover to each of the mode and it works fine

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots
<img width="319" alt="Screenshot 2025-02-18 at 10 05 54" src="https://github.com/user-attachments/assets/3dd0bbb1-1df8-4749-8d77-0a040eefdf57" />


### Additional Notes
- Actually there is no UI changes
- What's there is behavior changes. In the screenshot above, my cursor (which is not captured unfortunately) hovers on Act mode so it shows tooltip of Act mode

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Improves tooltip behavior in `ChatTextArea.tsx` to show tooltips for hovered mode, not just the current mode.
> 
>   - **Behavior**:
>     - Tooltips now show for the hovered mode in `ChatTextArea.tsx`, regardless of the current mode.
>     - `shownTooltipMode` state added to track hovered mode.
>   - **Components**:
>     - `Tooltip` in `Tooltip.tsx` updated to accept `visible` prop for conditional rendering.
>   - **Misc**:
>     - Added changeset `chilly-pandas-retire.md` to document the feature addition.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for f44d95da124ed1d8c0878fcf5235ab5e8064c455. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->