### PR TITLE
fix: make AWS Bedrock authentication predictable

### DIFF
--- a/.changeset/cold-shirts-deny.md
+++ b/.changeset/cold-shirts-deny.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+fix: make AWS Bedrock authentication predictable


### PR DESCRIPTION
### Description

Anthropic's Bedrock SDK creates an AWS credential provider chain [1] for each request it needs to sign. By doing so right before actually having to sign the request, it can utilize any session created after VSCode launched (i.e. outside of the process), and it can renew the sessions every time necessary transparently for the user.

Cline, on the other hand, by transforming the provided AWS_PROFILE into a key / secret / session, as part of client initialization, completely short-circuits this, making it very difficult for users in companies where sessions are short-lived. Furthermore, Cline would silently ignore the provided AWS_PROFILE if there isn't a current/non-expired session at the time of initialization, pass null keys to the Bedrock SDK, which would then make use the default profile, which may not be configured or authorized to use AWS Bedrock (as most AWS SSO hub accounts would). From the perspective of the user, this would manifest itself as an "supported country" error or unhelpful errors that are basically impossible to debug without attaching a debugger to Cline.. and such developers may end up reaching out to their DevOps/IT teams for help, which also could turn into a waste of time.

This PR addresses the aforementioned issues by resolving the credentials at every invocation.

1: https://github.com/anthropics/anthropic-sdk-typescript/blob/61b55599d50d9c93840e4736cb756cb3a62b0696/packages/bedrock-sdk/src/auth.ts#L19

### Test Procedure

- Attach debugger to Cline 
- Witness null AWS keys being provided to the Bedrock SDK when a session isn't valid (e.g. expired) or isn't perfectly exposed to VSCode upon launch, resulting in the Bedrock SDK silently attempting to create a brand new session, without the expected AWS_PROFILE, causing permission/compliance failures for the users without any clue why
- After fix, successfully use Cline naturally, and have it refresh sessions transparently, and having it support AWS sessions created after VSCode was launched (e.g. new day's work, vscode stayed open overnight)

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Simplifies AWS Bedrock authentication by setting environment variables directly, removing complex credential handling logic in `bedrock.ts`.
> 
>   - **Behavior**:
>     - Simplifies AWS Bedrock authentication by setting environment variables `AWS_REGION`, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN`, and `AWS_PROFILE` in `initializeClient()` in `bedrock.ts`.
>     - Removes logic for handling AWS credentials via `fromIni` and direct key/secret/session token assignment.
>   - **Error Handling**:
>     - Eliminates potential silent failures when AWS_PROFILE is provided but no valid session exists at initialization.
>   - **Misc**:
>     - Removes complex credential handling logic, simplifying code flow in `initializeClient()` in `bedrock.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 735b8d041d93ba224600b4db4e625a7ed86b0ab4. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->