### PR TITLE
Feat: MCP Marketplace Setting

### DIFF
--- a/.changeset/dry-ghosts-nail.md
+++ b/.changeset/dry-ghosts-nail.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+A new MCP Marketplace display setting has been added to VSCode settings. (It is defaulted to "true")

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "claude-dev",
-	"version": "3.4.1",
+	"version": "3.4.3",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "claude-dev",
-			"version": "3.4.1",
+			"version": "3.4.3",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@anthropic-ai/bedrock-sdk": "^0.10.2",

--- a/package.json
+++ b/package.json
@@ -181,6 +181,11 @@
 					"type": "string",
 					"default": null,
 					"description": "Path to Chrome executable for browser use functionality. If not set, the extension will attempt to find or download it automatically."
+				},
+				"cline.mcpMarketplace.enabled": {
+					"type": "boolean",
+					"default": true,
+					"description": "Controls whether the MCP Marketplace is enabled."
 				}
 			}
 		}

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -1585,6 +1585,7 @@ Here is the project's README to help you get started:\n\n${mcpDetails.readmeCont
 			chatSettings,
 			userInfo,
 			authToken,
+			mcpMarketplaceEnabled,
 		} = await this.getState()
 
 		return {
@@ -1603,7 +1604,7 @@ Here is the project's README to help you get started:\n\n${mcpDetails.readmeCont
 			chatSettings,
 			isLoggedIn: !!authToken,
 			userInfo,
-			mcpMarketplaceEnabled: vscode.workspace.getConfiguration("cline").get<boolean>("mcpMarketplace.enabled", true),
+			mcpMarketplaceEnabled,
 		}
 	}
 
@@ -1837,6 +1838,7 @@ Here is the project's README to help you get started:\n\n${mcpDetails.readmeCont
 			previousModeApiProvider,
 			previousModeModelId,
 			previousModeModelInfo,
+			mcpMarketplaceEnabled,
 		}
 	}
 

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -240,7 +240,7 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 			this.disposables,
 		)
 
-		// Listen for when color changes
+		// Listen for configuration changes
 		vscode.workspace.onDidChangeConfiguration(
 			async (e) => {
 				if (e && e.affectsConfiguration("workbench.colorTheme")) {
@@ -249,6 +249,10 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 						type: "theme",
 						text: JSON.stringify(await getTheme()),
 					})
+				}
+				if (e && e.affectsConfiguration("cline.mcpMarketplace.enabled")) {
+					// Update state when marketplace tab setting changes
+					await this.postStateToWebview()
 				}
 			},
 			null,
@@ -1599,6 +1603,7 @@ Here is the project's README to help you get started:\n\n${mcpDetails.readmeCont
 			chatSettings,
 			isLoggedIn: !!authToken,
 			userInfo,
+			mcpMarketplaceEnabled: vscode.workspace.getConfiguration("cline").get<boolean>("mcpMarketplace.enabled", true),
 		}
 	}
 
@@ -1775,6 +1780,8 @@ Here is the project's README to help you get started:\n\n${mcpDetails.readmeCont
 		const o3MiniReasoningEffort = vscode.workspace
 			.getConfiguration("cline.modelSettings.o3Mini")
 			.get("reasoningEffort", "medium")
+
+		const mcpMarketplaceEnabled = vscode.workspace.getConfiguration("cline").get<boolean>("mcpMarketplace.enabled", true)
 
 		return {
 			apiConfiguration: {

--- a/src/shared/ExtensionMessage.ts
+++ b/src/shared/ExtensionMessage.ts
@@ -80,6 +80,7 @@ export interface ExtensionState {
 		email: string | null
 		photoURL: string | null
 	}
+	mcpMarketplaceEnabled?: boolean
 }
 
 export interface ClineMessage {

--- a/webview-ui/src/components/mcp/McpView.tsx
+++ b/webview-ui/src/components/mcp/McpView.tsx
@@ -1,15 +1,14 @@
 import { VSCodeButton, VSCodeLink, VSCodePanels, VSCodePanelTab, VSCodePanelView } from "@vscode/webview-ui-toolkit/react"
-import { useState, useEffect } from "react"
-import { vscode } from "../../utils/vscode"
-import { useExtensionState } from "../../context/ExtensionStateContext"
-import { McpServer } from "../../../../src/shared/mcp"
-import { WebviewMessage } from "../../../../src/shared/WebviewMessage"
-import McpToolRow from "./McpToolRow"
-import McpResourceRow from "./McpResourceRow"
-import McpMarketplaceView from "./marketplace/McpMarketplaceView"
+import { useEffect, useState } from "react"
 import styled from "styled-components"
+import { McpServer } from "../../../../src/shared/mcp"
+import { useExtensionState } from "../../context/ExtensionStateContext"
 import { getMcpServerDisplayName } from "../../utils/mcp"
+import { vscode } from "../../utils/vscode"
 import DangerButton from "../common/DangerButton"
+import McpMarketplaceView from "./marketplace/McpMarketplaceView"
+import McpResourceRow from "./McpResourceRow"
+import McpToolRow from "./McpToolRow"
 
 type McpViewProps = {
 	onDone: () => void
@@ -24,14 +23,18 @@ const McpView = ({ onDone }: McpViewProps) => {
 	}
 
 	useEffect(() => {
-		if (mcpMarketplaceEnabled) {
-			vscode.postMessage({ type: "silentlyRefreshMcpMarketplace" } as WebviewMessage)
-			vscode.postMessage({ type: "fetchLatestMcpServersFromHub" } as WebviewMessage)
-		} else if (activeTab === "marketplace") {
+		if (!mcpMarketplaceEnabled && activeTab === "marketplace") {
 			// If marketplace is disabled and we're on marketplace tab, switch to installed
 			setActiveTab("installed")
 		}
 	}, [mcpMarketplaceEnabled, activeTab])
+
+	useEffect(() => {
+		if (mcpMarketplaceEnabled) {
+			vscode.postMessage({ type: "silentlyRefreshMcpMarketplace" })
+			vscode.postMessage({ type: "fetchLatestMcpServersFromHub" })
+		}
+	}, [mcpMarketplaceEnabled])
 
 	return (
 		<div
@@ -134,7 +137,7 @@ const McpView = ({ onDone }: McpViewProps) => {
 									appearance="secondary"
 									style={{ width: "100%", marginBottom: "5px" }}
 									onClick={() => {
-										vscode.postMessage({ type: "openMcpSettings" } as WebviewMessage)
+										vscode.postMessage({ type: "openMcpSettings" })
 									}}>
 									<span className="codicon codicon-server" style={{ marginRight: "6px" }}></span>
 									Configure MCP Servers
@@ -146,7 +149,7 @@ const McpView = ({ onDone }: McpViewProps) => {
 											vscode.postMessage({
 												type: "openExtensionSettings",
 												text: "cline.mcp",
-											} as WebviewMessage)
+											})
 										}}
 										style={{ fontSize: "12px" }}>
 										Advanced MCP Settings
@@ -211,7 +214,7 @@ const ServerRow = ({ server }: { server: McpServer }) => {
 		vscode.postMessage({
 			type: "restartMcpServer",
 			text: server.name,
-		} as WebviewMessage)
+		})
 	}
 
 	const handleDelete = () => {
@@ -219,7 +222,7 @@ const ServerRow = ({ server }: { server: McpServer }) => {
 		vscode.postMessage({
 			type: "deleteMcpServer",
 			serverName: server.name,
-		} as WebviewMessage)
+		})
 	}
 
 	return (
@@ -272,7 +275,7 @@ const ServerRow = ({ server }: { server: McpServer }) => {
 								type: "toggleMcpServer",
 								serverName: server.name,
 								disabled: !server.disabled,
-							} as WebviewMessage)
+							})
 						}}
 						onKeyDown={(e) => {
 							if (e.key === "Enter" || e.key === " ") {
@@ -281,7 +284,7 @@ const ServerRow = ({ server }: { server: McpServer }) => {
 									type: "toggleMcpServer",
 									serverName: server.name,
 									disabled: !server.disabled,
-								} as WebviewMessage)
+								})
 							}
 						}}>
 						<div


### PR DESCRIPTION
### Description

Resolves the Immedate Concerns of: https://github.com/cline/cline/issues/1870

For enterprise customers, policy may not allow the use of MCP servers from internet hosted locations, or for developers to install MCP servers from untrusted locations without detailed analysis. This provides an advanced setting which controls if the new MCP Marketplace is available.

The setting is defaulted to "true" to display the MarketPlace. For enterprise customers they can elect to deploy configuations to disable this setting to disable the MCP Marketplace.

At a future date, we might want to allow custom marketplace endpoints where enterprise customers could for example host a list of approved MCP servers using their own Git Repos or Artifact hosting locations. Until then, this can help enterprise custiomers continue using the Cline Extension without opening the door to inadvertant unapproved MCP usage.

### Test Procedure

I performed manual testing.

1. Launched the extension and noted that by default the MCP Marketplace setting is set to "true" and the tab is displayed.

2. Launched the extension with the MCP Marketplace setting set to "false" and observed the tab is not displayed.

3. With the MCP Servers tab open, I togged the MCP Marketplace setting to false and observed the tab is removed and the Installed Tab is selected and visiable.

4. With the MCP Servers tab open, and the MCP Marketplace setting to false, I note that the Market Place is not displayed and the Installed tab is active. When I toggle on the MCP Marketplace setting I can see the tab get displayed and the focus remains on the Installed tab until I move to the Market Place tab,

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [X] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [X] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [X] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [X] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [X] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

### Additional Notes

The new vscode setting is called: cline.mcpMarketplace.enabled (boolean)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds a setting to control MCP Marketplace visibility in the Cline extension, defaulting to visible, with UI updates in `McpView.tsx`.
> 
>   - **Behavior**:
>     - Adds `cline.mcpMarketplace.enabled` setting in `package.json` to control MCP Marketplace visibility.
>     - Default is `true`, showing the marketplace tab by default.
>     - In `ClineProvider.ts`, listens for changes to `cline.mcpMarketplace.enabled` and updates the webview state.
>     - In `McpView.tsx`, toggles the marketplace tab based on `mcpMarketplaceEnabled` state.
>   - **UI Changes**:
>     - In `McpView.tsx`, the marketplace tab is conditionally rendered based on `mcpMarketplaceEnabled`.
>     - Automatically switches to the "Installed" tab if the marketplace is disabled while active.
>   - **Misc**:
>     - Updates `ExtensionState` in `ExtensionMessage.ts` to include `mcpMarketplaceEnabled`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for a55ee99957c3361307c6cf274c79d2db72b63be8. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->