### PR TITLE
Add IS_DEV and Hot Reloading to debug.

### DIFF
--- a/.changeset/yellow-paws-chew.md
+++ b/.changeset/yellow-paws-chew.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": minor
+---
+
+ADD IS_DEV and Hot Reloading to debug

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,7 +11,11 @@
 			"request": "launch",
 			"args": ["--extensionDevelopmentPath=${workspaceFolder}"],
 			"outFiles": ["${workspaceFolder}/dist/**/*.js"],
-			"preLaunchTask": "${defaultBuildTask}"
+			"preLaunchTask": "${defaultBuildTask}",
+			"env": {
+				"IS_DEV": "true",
+				"DEV_WORKSPACE_FOLDER": "${workspaceFolder}"
+			}
 		}
 	]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -24,6 +24,11 @@
 			"presentation": {
 				"group": "watch",
 				"reveal": "never"
+			},
+			"options": {
+				"env": {
+					"IS_DEV": "true"
+				}
 			}
 		},
 		{

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,6 +7,7 @@ import { Logger } from "./services/logging/Logger"
 import { createClineAPI } from "./exports"
 import "./utils/path" // necessary to have access to String.prototype.toPosix
 import { DIFF_VIEW_URI_SCHEME } from "./integrations/editor/DiffViewProvider"
+import assert from "node:assert"
 
 /*
 Built using https://github.com/microsoft/vscode-webview-ui-toolkit
@@ -189,4 +190,21 @@ export function activate(context: vscode.ExtensionContext) {
 // This method is called when your extension is deactivated
 export function deactivate() {
 	Logger.log("Cline extension deactivated")
+}
+
+// TODO: remove this in production
+// This is a workaround to reload the extension when the source code changes
+// since vscode doesn't support hot reload for extensions
+const { IS_DEV, DEV_WORKSPACE_FOLDER } = process.env
+console.log("Is dev:", IS_DEV)
+console.log("Dev workspace folder:", DEV_WORKSPACE_FOLDER)
+if (IS_DEV) {
+	assert(DEV_WORKSPACE_FOLDER, "DEV_WORKSPACE_FOLDER must be set in development")
+	const watcher = vscode.workspace.createFileSystemWatcher(new vscode.RelativePattern(DEV_WORKSPACE_FOLDER, "src/**/*"))
+
+	watcher.onDidChange(({ scheme, path }) => {
+		console.info(`${scheme} ${path} changed. Reloading VSCode...`)
+
+		vscode.commands.executeCommand("workbench.action.reloadWindow")
+	})
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -196,8 +196,7 @@ export function deactivate() {
 // This is a workaround to reload the extension when the source code changes
 // since vscode doesn't support hot reload for extensions
 const { IS_DEV, DEV_WORKSPACE_FOLDER } = process.env
-console.log("Is dev:", IS_DEV)
-console.log("Dev workspace folder:", DEV_WORKSPACE_FOLDER)
+
 if (IS_DEV) {
 	assert(DEV_WORKSPACE_FOLDER, "DEV_WORKSPACE_FOLDER must be set in development")
 	const watcher = vscode.workspace.createFileSystemWatcher(new vscode.RelativePattern(DEV_WORKSPACE_FOLDER, "src/**/*"))

--- a/webview-ui/scripts/build-react-no-split.js
+++ b/webview-ui/scripts/build-react-no-split.js
@@ -12,6 +12,7 @@
 const rewire = require("rewire")
 const defaults = rewire("react-scripts/scripts/build.js")
 const config = defaults.__get__("config")
+const webpack = require("webpack")
 
 /* Modifying Webpack Configuration for 'shared' dir
 This section uses Rewire to modify Create React App's webpack configuration without ejecting. Rewire allows us to inject and alter the internal build scripts of CRA at runtime. This allows us to maintain a flexible project structure that keeps shared code outside the webview-ui/src directory, while still adhering to CRA's security model that typically restricts imports to within src/. 
@@ -118,6 +119,15 @@ config.output = {
 	...config.output,
 	filename: "static/js/[name].js",
 }
+
+// Adjust build environment variables for dev/debug builds.
+config.plugins[4] = new webpack.DefinePlugin({
+	"process.env": {
+		...config.plugins[4].definitions["process.env"],
+		NODE_ENV: JSON.stringify(process.env.IS_DEV ? "development" : "production"),
+		IS_DEV: JSON.stringify(process.env.IS_DEV),
+	},
+})
 
 // Rename main.{hash}.css to main.css
 config.plugins[5].options.filename = "static/css/[name].css"

--- a/webview-ui/src/components/settings/SettingsView.tsx
+++ b/webview-ui/src/components/settings/SettingsView.tsx
@@ -5,7 +5,7 @@ import { validateApiConfiguration, validateModelId } from "../../utils/validate"
 import { vscode } from "../../utils/vscode"
 import ApiOptions from "./ApiOptions"
 import SettingsButton from "../common/SettingsButton"
-const IS_DEV = false // FIXME: use flags when packaging
+const { IS_DEV } = process.env
 
 type SettingsViewProps = {
 	onDone: () => void


### PR DESCRIPTION
### Description

Add IS_DEV and Hot reloading to the debug tasks when run in VSCode.  This enhances the developer experience to allow for faster development without having to wait for the extension environment to rebuild.

### Test Procedure

Run the debugger in VSCode using (f5) and wait for the extension to load.  Make a change in src directory to see the extensionHost VSCode window reload.  IS_DEV is passed into the webview on build as well. Check Settings to make sure it's enabled.

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [X] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

-   [X] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [X] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [X] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [X] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `IS_DEV` and hot reloading for VSCode extension development, modifying build and settings view.
> 
>   - **Hot Reloading and Development Mode**:
>     - Adds `IS_DEV` and hot reloading support in `extension.ts` for VSCode extension development.
>     - Uses `vscode.workspace.createFileSystemWatcher` to reload the extension on source code changes.
>   - **Build Process**:
>     - Modifies `build-react-no-split.js` to adjust Webpack configuration for `IS_DEV` environment variable.
>     - Uses `webpack.DefinePlugin` to set `NODE_ENV` and `IS_DEV` for development builds.
>   - **Settings View**:
>     - Updates `SettingsView.tsx` to use `IS_DEV` for displaying debug options.
>     - Adds "Reset State" button in development mode.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 43abcf4681cc2836787a5aa604a6e7c18726362e. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->