### PR TITLE
Make request timeout for tool use configurable in Cline MCP Settings

### DIFF
--- a/.changeset/long-maps-deny.md
+++ b/.changeset/long-maps-deny.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": minor
+---
+
+Add optional toolCallTimeoutMillis config parameter to StdioConfigSchema that will change the timeout of requests made by callTool for an MPC server

--- a/.changeset/mighty-clouds-chew.md
+++ b/.changeset/mighty-clouds-chew.md
@@ -1,5 +1,0 @@
----
-"claude-dev": minor
----
-
-Add MCP server config timeout setting for tool use

--- a/.changeset/mighty-clouds-chew.md
+++ b/.changeset/mighty-clouds-chew.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": minor
+---
+
+Add MCP server config timeout setting for tool use

--- a/src/services/mcp/McpHub.ts
+++ b/src/services/mcp/McpHub.ts
@@ -42,7 +42,7 @@ const StdioConfigSchema = z.object({
 	env: z.record(z.string()).optional(),
 	autoApprove: AutoApproveSchema.optional(),
 	disabled: z.boolean().optional(),
-	toolCallTimeoutMillis: z.number().optional(),
+	toolCallTimeoutMillis: z.number().int().nonnegative().optional(),
 })
 
 const McpSettingsSchema = z.object({

--- a/src/services/mcp/McpHub.ts
+++ b/src/services/mcp/McpHub.ts
@@ -42,7 +42,7 @@ const StdioConfigSchema = z.object({
 	env: z.record(z.string()).optional(),
 	autoApprove: AutoApproveSchema.optional(),
 	disabled: z.boolean().optional(),
-	timeout: z.number().optional(),
+	toolCallTimeoutMillis: z.number().optional(),
 })
 
 const McpSettingsSchema = z.object({
@@ -169,7 +169,6 @@ export class McpHub {
 					// ...(process.env.NODE_PATH ? { NODE_PATH: process.env.NODE_PATH } : {}),
 				},
 				stderr: "pipe", // necessary for stderr to be available
-				timeout: config.timeout,
 			})
 
 			transport.onerror = async (error) => {
@@ -215,7 +214,7 @@ export class McpHub {
 					config: JSON.stringify(config),
 					status: "connecting",
 					disabled: parsedConfig.disabled,
-					timeout: parsedConfig.timeout,
+					toolCallTimeoutMillis: parsedConfig.toolCallTimeoutMillis,
 				},
 				client,
 				transport,
@@ -598,7 +597,7 @@ export class McpHub {
 				},
 			},
 			CallToolResultSchema,
-			{ timeout: connection.server.timeout },
+			{ timeout: connection.server.toolCallTimeoutMillis },
 		)
 	}
 

--- a/src/services/mcp/McpHub.ts
+++ b/src/services/mcp/McpHub.ts
@@ -42,6 +42,7 @@ const StdioConfigSchema = z.object({
 	env: z.record(z.string()).optional(),
 	autoApprove: AutoApproveSchema.optional(),
 	disabled: z.boolean().optional(),
+	timeout: z.number().optional(),
 })
 
 const McpSettingsSchema = z.object({
@@ -168,6 +169,7 @@ export class McpHub {
 					// ...(process.env.NODE_PATH ? { NODE_PATH: process.env.NODE_PATH } : {}),
 				},
 				stderr: "pipe", // necessary for stderr to be available
+				timeout: config.timeout,
 			})
 
 			transport.onerror = async (error) => {
@@ -213,6 +215,7 @@ export class McpHub {
 					config: JSON.stringify(config),
 					status: "connecting",
 					disabled: parsedConfig.disabled,
+					timeout: parsedConfig.timeout
 				},
 				client,
 				transport,
@@ -595,6 +598,7 @@ export class McpHub {
 				},
 			},
 			CallToolResultSchema,
+			{ timeout: connection.server.timeout }
 		)
 	}
 

--- a/src/services/mcp/McpHub.ts
+++ b/src/services/mcp/McpHub.ts
@@ -215,7 +215,7 @@ export class McpHub {
 					config: JSON.stringify(config),
 					status: "connecting",
 					disabled: parsedConfig.disabled,
-					timeout: parsedConfig.timeout
+					timeout: parsedConfig.timeout,
 				},
 				client,
 				transport,
@@ -598,7 +598,7 @@ export class McpHub {
 				},
 			},
 			CallToolResultSchema,
-			{ timeout: connection.server.timeout }
+			{ timeout: connection.server.timeout },
 		)
 	}
 

--- a/src/shared/mcp.ts
+++ b/src/shared/mcp.ts
@@ -9,7 +9,7 @@ export type McpServer = {
 	resources?: McpResource[]
 	resourceTemplates?: McpResourceTemplate[]
 	disabled?: boolean
-	timeout?: number
+	toolCallTimeoutMillis?: number
 }
 
 export type McpTool = {

--- a/src/shared/mcp.ts
+++ b/src/shared/mcp.ts
@@ -9,6 +9,7 @@ export type McpServer = {
 	resources?: McpResource[]
 	resourceTemplates?: McpResourceTemplate[]
 	disabled?: boolean
+	timeout?: number
 }
 
 export type McpTool = {


### PR DESCRIPTION
### Description

When using MCP servers that make longer running requests, the default @modelcontextprotocol timeout of 60 seconds may not be sufficient. I experienced this while using a Perplexity Research MCP, which timed out quite regularly as Perplexity often takes more than 60 seconds to conduct detailed research. 
This is just one example, and there are likely other cases where it makes sense to extend (or shorten) the timeout of the tool call.

The MCP server request function accepts an optional `timeout` value in the `options` parameter, which this PR adds to the `request` call in `McpHub.callTool(...)`.  The value of the custom timeout is configurable for each individual MCP server through the Cline MCP settings JSON file.  A numeric value (in milliseconds) can be assigned to the `toolCallTimeoutMillis` field at the top level of the JSON object for any given server. 

Adding this value is optional; if it is not present the request call will submit `{ timeout: undefined }` as the `options` parameter of the `request` call, and the MCP Protocol class will still apply the `DEFAULT_REQUEST_TIMEOUT_MSEC` default (60 seconds), as it currently does.

Example of cline_mcp_settings.json with the optional timeout setting:

```JSON
{
  "mcpServers": {
    "perplexity-server": {
      "command": "node",
      "args": [
        "/Users/xyz/mcp/perplexity-mcp/build/index.js"
      ],
      "env": {
        "PERPLEXITY_API_KEY": "*****",
      },
      "disabled": false,
      "autoApprove": [
        "search"
      ],
      "toolCallTimeoutMillis": 120000
    }
  }
}
```

### Test Procedure

This feature affects (i) parsing the config file and (ii) submitting the optional value to a single MCP server request call. I manually tested both to ensure that it works as intended and the change didn't introduce any regression bugs.

MCP Server Settings JSON:
- Confirmed that a numeric timeout value is parsed correctly and added to the server connection.
- Tested schema validation with non-string values and confirmed that the `Invalid MCP Settings format` error is shown.
- Validated that the parameter is optional and settings without a `timeout` field are parsed as before.

Submitting a timeout value in the options parameter of the request call in `callTool`:
- Made tool calls after adding the timeout value and confirmed that the MCP Protocol applied this value. The request timed out, for example, after 5 seconds instead of the default 60 seconds.
- Confirmed that tool calls from MCP servers without the timeout field set are still processing and time out after 60 seconds (the default).

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [X] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [X] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [X] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [X] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [X] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

![cline_mcp_settings_timeout](https://github.com/user-attachments/assets/27fc46f8-b5e9-45b7-82d2-c299dcf85298)

### Additional Notes

- The timeout value is only submitted when making a request in `callTool`, as this is where it should matter. Other MCP server requests are unchanged.
- I mirrored the implementation of the `disabled` config setting, which also extends `StdioServerParameters` in the `StdioConfigSchema` definition in cline, and similarly gets added to the McpServer object when creating the connection.
- Resolves #1306

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add configurable request timeout for MCP servers via JSON settings in `McpHub.ts` and `mcp.ts`.
> 
>   - **New Feature**:
>     - Adds `toolCallTimeoutMillis` field to MCP server configuration in `McpHub.ts` and `mcp.ts`.
>     - Allows setting request timeout for tool call per server in `cline_mcp_settings.json`.
>     - Default timeout remains 60 seconds if not specified.
>   - **Behavior**:
>     - `callTool` in `McpHub.ts` uses `toolCallTimeoutMillis` from server config for requests.
>     - Validates `toolCallTimeoutMillis` as optional non-negative inetger in `StdioConfigSchema`.
>   - **Testing**:
>     - Manual tests confirm timeout setting is parsed and applied correctly.
>     - Validates schema with and without `toolCallTimeoutMillis` field.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 464f8989cd70070ee5fbaeb0c1fba428f23def70. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->