### PR TITLE
feat(bedrock): #1723 Add prompt caching support for Anthropic Claude on AWS Bedrock

### DIFF
--- a/.changeset/cool-apes-rescue.md
+++ b/.changeset/cool-apes-rescue.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": minor
+---
+
+feat(bedrock): Add prompt caching support for Anthropic Claude on AWS Bedrock

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "3.4.3",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@anthropic-ai/bedrock-sdk": "^0.10.2",
+				"@anthropic-ai/bedrock-sdk": "^v0.12.4",
 				"@anthropic-ai/sdk": "^0.26.0",
 				"@anthropic-ai/vertex-sdk": "^0.4.1",
 				"@google/generative-ai": "^0.18.0",
@@ -76,11 +76,12 @@
 			}
 		},
 		"node_modules/@anthropic-ai/bedrock-sdk": {
-			"version": "0.10.2",
-			"resolved": "https://registry.npmjs.org/@anthropic-ai/bedrock-sdk/-/bedrock-sdk-0.10.2.tgz",
-			"integrity": "sha512-sGmTzKJQHVwfXexe+yfzPU3rJmUMCygC+GNPkmMsPX/Jr+WKtJ0M71nGyHONr6vcHwUpUWA6o0MRH/oHaE54KA==",
+			"version": "0.12.4",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/bedrock-sdk/-/bedrock-sdk-0.12.4.tgz",
+			"integrity": "sha512-kraOgWWyVO/Wef3wYbpws77pCZubg/hCzXQ7RGrLRJsRpbTIT+ms+MigGu/0b1qn3o5WuIrumlT3Qtu3esHpzw==",
+			"license": "MIT",
 			"dependencies": {
-				"@anthropic-ai/sdk": "^0",
+				"@anthropic-ai/sdk": ">=0.36 <1",
 				"@aws-crypto/sha256-js": "^4.0.0",
 				"@aws-sdk/client-bedrock-runtime": "^3.423.0",
 				"@aws-sdk/credential-providers": "^3.341.0",
@@ -91,6 +92,30 @@
 				"@smithy/smithy-client": "^2.1.9",
 				"@smithy/types": "^2.3.4",
 				"@smithy/util-base64": "^2.0.0"
+			}
+		},
+		"node_modules/@anthropic-ai/bedrock-sdk/node_modules/@anthropic-ai/sdk": {
+			"version": "0.36.3",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.36.3.tgz",
+			"integrity": "sha512-+c0mMLxL/17yFZ4P5+U6bTWiCSFZUKJddrv01ud2aFBWnTPLdRncYV76D3q1tqfnL7aCnhRtykFnoCFzvr4U3Q==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/node": "^18.11.18",
+				"@types/node-fetch": "^2.6.4",
+				"abort-controller": "^3.0.0",
+				"agentkeepalive": "^4.2.1",
+				"form-data-encoder": "1.7.2",
+				"formdata-node": "^4.3.2",
+				"node-fetch": "^2.6.7"
+			}
+		},
+		"node_modules/@anthropic-ai/bedrock-sdk/node_modules/@types/node": {
+			"version": "18.19.76",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.76.tgz",
+			"integrity": "sha512-yvR7Q9LdPz2vGpmpJX5LolrgRdWvB67MJKDPSgIIzpFbaf9a1j/f5DnLp5VDyHGMR0QZHlTr1afsD87QCXFHKw==",
+			"license": "MIT",
+			"dependencies": {
+				"undici-types": "~5.26.4"
 			}
 		},
 		"node_modules/@anthropic-ai/sdk": {

--- a/package.json
+++ b/package.json
@@ -237,7 +237,7 @@
 		"typescript": "^5.4.5"
 	},
 	"dependencies": {
-		"@anthropic-ai/bedrock-sdk": "^0.10.2",
+		"@anthropic-ai/bedrock-sdk": "^v0.12.4",
 		"@anthropic-ai/sdk": "^0.26.0",
 		"@anthropic-ai/vertex-sdk": "^0.4.1",
 		"@google/generative-ai": "^0.18.0",

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -127,6 +127,7 @@ export const anthropicModels = {
 
 // AWS Bedrock
 // https://docs.aws.amazon.com/bedrock/latest/userguide/conversation-inference.html
+// https://aws.amazon.com/bedrock/pricing/
 export type BedrockModelId = keyof typeof bedrockModels
 export const bedrockDefaultModelId: BedrockModelId = "anthropic.claude-3-5-sonnet-20241022-v2:0"
 export const bedrockModels = {
@@ -135,23 +136,27 @@ export const bedrockModels = {
 		contextWindow: 200_000,
 		supportsImages: true,
 		supportsComputerUse: true,
-		supportsPromptCache: false,
+		supportsPromptCache: true,
 		inputPrice: 3.0,
 		outputPrice: 15.0,
+		cacheWritesPrice: 3.75, // $3.75 per million tokens
+		cacheReadsPrice: 0.3, // $0.30 per million tokens
 	},
 	"anthropic.claude-3-5-haiku-20241022-v1:0": {
 		maxTokens: 8192,
 		contextWindow: 200_000,
 		supportsImages: false,
-		supportsPromptCache: false,
+		supportsPromptCache: true,
 		inputPrice: 1.0,
 		outputPrice: 5.0,
+		cacheWritesPrice: 1.0,
+		cacheReadsPrice: 0.08,
 	},
 	"anthropic.claude-3-5-sonnet-20240620-v1:0": {
 		maxTokens: 8192,
 		contextWindow: 200_000,
 		supportsImages: true,
-		supportsPromptCache: false,
+		supportsPromptCache: true,
 		inputPrice: 3.0,
 		outputPrice: 15.0,
 	},
@@ -159,15 +164,17 @@ export const bedrockModels = {
 		maxTokens: 4096,
 		contextWindow: 200_000,
 		supportsImages: true,
-		supportsPromptCache: false,
+		supportsPromptCache: true,
 		inputPrice: 15.0,
 		outputPrice: 75.0,
+		cacheWritesPrice: 18.75,
+		cacheReadsPrice: 1.5,
 	},
 	"anthropic.claude-3-sonnet-20240229-v1:0": {
 		maxTokens: 4096,
 		contextWindow: 200_000,
 		supportsImages: true,
-		supportsPromptCache: false,
+		supportsPromptCache: true,
 		inputPrice: 3.0,
 		outputPrice: 15.0,
 	},
@@ -175,9 +182,11 @@ export const bedrockModels = {
 		maxTokens: 4096,
 		contextWindow: 200_000,
 		supportsImages: true,
-		supportsPromptCache: false,
+		supportsPromptCache: true,
 		inputPrice: 0.25,
 		outputPrice: 1.25,
+		cacheWritesPrice: 0.3,
+		cacheReadsPrice: 0.03,
 	},
 } as const satisfies Record<string, ModelInfo>
 


### PR DESCRIPTION
Closes #1723

### Description

This PR adds prompt caching support to the AWS Bedrock handler for Claude 3 models, similar to the existing implementation in the Vertex handler.

Changes:

- Upgraded anthropid/bedrock-sdk 
- Implemented prompt caching in AWS Bedrock for Anthropic models



### Test Procedure

<!-- How did you test this? Are you confident that it will not introduce bugs? If so, why? -->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds prompt caching support for Anthropic Claude models in AWS Bedrock and Vertex handlers, updating SDKs and model pricing.
> 
>   - **Behavior**:
>     - Adds prompt caching support for Anthropic Claude models in `AwsBedrockHandler` 
>     - Handles specific models like `claude-3-sonnet-20240229-v1:0` and `claude-3-haiku-20240307-v1:0` in `bedrock.ts`.
>   - **Dependencies**:
>     - Upgrades `@anthropic-ai/bedrock-sdk` to `^v0.12.4` and `@anthropic-ai/vertex-sdk` to `^0.6.4` in `package.json`.
>   - **Models**:
>     - Updates `ModelInfo` in `api.ts` to include `cacheWritesPrice` and `cacheReadsPrice` for Bedrock models.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 361ec9682c1476f6a7da95fad2f8420d37270a20. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->