### PR TITLE
Revert "Add IS_DEV and Hot Reloading to debug."

### DIFF
--- a/.changeset/yellow-paws-chew.md
+++ b/.changeset/yellow-paws-chew.md
@@ -1,5 +1,0 @@
----
-"claude-dev": minor
----
-
-ADD IS_DEV and Hot Reloading to debug

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,11 +11,7 @@
 			"request": "launch",
 			"args": ["--extensionDevelopmentPath=${workspaceFolder}"],
 			"outFiles": ["${workspaceFolder}/dist/**/*.js"],
-			"preLaunchTask": "${defaultBuildTask}",
-			"env": {
-				"IS_DEV": "true",
-				"DEV_WORKSPACE_FOLDER": "${workspaceFolder}"
-			}
+			"preLaunchTask": "${defaultBuildTask}"
 		}
 	]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -24,11 +24,6 @@
 			"presentation": {
 				"group": "watch",
 				"reveal": "never"
-			},
-			"options": {
-				"env": {
-					"IS_DEV": "true"
-				}
 			}
 		},
 		{

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,7 +7,6 @@ import { Logger } from "./services/logging/Logger"
 import { createClineAPI } from "./exports"
 import "./utils/path" // necessary to have access to String.prototype.toPosix
 import { DIFF_VIEW_URI_SCHEME } from "./integrations/editor/DiffViewProvider"
-import assert from "node:assert"
 
 /*
 Built using https://github.com/microsoft/vscode-webview-ui-toolkit
@@ -190,20 +189,4 @@ export function activate(context: vscode.ExtensionContext) {
 // This method is called when your extension is deactivated
 export function deactivate() {
 	Logger.log("Cline extension deactivated")
-}
-
-// TODO: remove this in production
-// This is a workaround to reload the extension when the source code changes
-// since vscode doesn't support hot reload for extensions
-const { IS_DEV, DEV_WORKSPACE_FOLDER } = process.env
-
-if (IS_DEV) {
-	assert(DEV_WORKSPACE_FOLDER, "DEV_WORKSPACE_FOLDER must be set in development")
-	const watcher = vscode.workspace.createFileSystemWatcher(new vscode.RelativePattern(DEV_WORKSPACE_FOLDER, "src/**/*"))
-
-	watcher.onDidChange(({ scheme, path }) => {
-		console.info(`${scheme} ${path} changed. Reloading VSCode...`)
-
-		vscode.commands.executeCommand("workbench.action.reloadWindow")
-	})
 }

--- a/webview-ui/scripts/build-react-no-split.js
+++ b/webview-ui/scripts/build-react-no-split.js
@@ -12,7 +12,6 @@
 const rewire = require("rewire")
 const defaults = rewire("react-scripts/scripts/build.js")
 const config = defaults.__get__("config")
-const webpack = require("webpack")
 
 /* Modifying Webpack Configuration for 'shared' dir
 This section uses Rewire to modify Create React App's webpack configuration without ejecting. Rewire allows us to inject and alter the internal build scripts of CRA at runtime. This allows us to maintain a flexible project structure that keeps shared code outside the webview-ui/src directory, while still adhering to CRA's security model that typically restricts imports to within src/. 
@@ -119,15 +118,6 @@ config.output = {
 	...config.output,
 	filename: "static/js/[name].js",
 }
-
-// Adjust build environment variables for dev/debug builds.
-config.plugins[4] = new webpack.DefinePlugin({
-	"process.env": {
-		...config.plugins[4].definitions["process.env"],
-		NODE_ENV: JSON.stringify(process.env.IS_DEV ? "development" : "production"),
-		IS_DEV: JSON.stringify(process.env.IS_DEV),
-	},
-})
 
 // Rename main.{hash}.css to main.css
 config.plugins[5].options.filename = "static/css/[name].css"

--- a/webview-ui/src/components/settings/SettingsView.tsx
+++ b/webview-ui/src/components/settings/SettingsView.tsx
@@ -5,7 +5,7 @@ import { validateApiConfiguration, validateModelId } from "../../utils/validate"
 import { vscode } from "../../utils/vscode"
 import ApiOptions from "./ApiOptions"
 import SettingsButton from "../common/SettingsButton"
-const { IS_DEV } = process.env
+const IS_DEV = false // FIXME: use flags when packaging
 
 type SettingsViewProps = {
 	onDone: () => void


### PR DESCRIPTION
Reverts cline/cline#1895
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Reverts hot reloading and `IS_DEV` environment variable changes, removing related code and configurations.
> 
>   - **Revert Changes**:
>     - Remove hot reloading and `IS_DEV` environment variable logic from `extension.ts`.
>     - Delete `yellow-paws-chew.md` changeset file.
>     - Remove `webpack` configuration for `IS_DEV` in `build-react-no-split.js`.
>     - Set `IS_DEV` to `false` in `SettingsView.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 8a2679fc30112d1ec4fde605eebc73c4e76965e3. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->