### PR TITLE
fix: Api configuration error not display on Welcome Screen

### DIFF
--- a/.changeset/perfect-bikes-punch.md
+++ b/.changeset/perfect-bikes-punch.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Fix api configuration error not display on Welcome Screen

--- a/webview-ui/src/components/welcome/WelcomeView.tsx
+++ b/webview-ui/src/components/welcome/WelcomeView.tsx
@@ -107,7 +107,7 @@ const WelcomeView = () => {
 				</div>
 
 				<div style={{ marginTop: "15px" }}>
-					<ApiOptions showModelOptions={false} />
+					<ApiOptions showModelOptions={false} apiErrorMessage={apiErrorMessage} />
 					<VSCodeButton onClick={handleSubmit} disabled={disableLetsGoButton} style={{ marginTop: "3px" }}>
 						Let's go!
 					</VSCodeButton>


### PR DESCRIPTION
### Description

Fixes a bug when a provider was not correct configured on the Welcome Screen, the error was not visible

### Test Procedure

* Reset State
* Then you see the error message (it was missing before)
 
### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots
Before:
![bugbefore](https://github.com/user-attachments/assets/fda12c08-3c34-40c4-8fe6-ea76c6525663)

After:
![bugafter](https://github.com/user-attachments/assets/5c19c0c5-1b4a-4a47-abe0-8220b98878e2)

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes missing error message display on Welcome Screen by passing `apiErrorMessage` to `ApiOptions` in `WelcomeView.tsx`.
> 
>   - **Behavior**:
>     - Fixes missing error message display on the Welcome Screen when API provider is not configured correctly.
>     - Passes `apiErrorMessage` to `ApiOptions` in `WelcomeView.tsx` to show the error.
>   - **UI**:
>     - Updates `WelcomeView.tsx` to include `apiErrorMessage` in `ApiOptions` component.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 56381e743434ec4a131491f890c3c36bf25846c8. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->