### PR TITLE
fix: Checking "Support Images" had no effect on first click

### DIFF
--- a/.changeset/rare-pigs-divide.md
+++ b/.changeset/rare-pigs-divide.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Fix checking "Support Images" setting had no effect on first click

--- a/webview-ui/src/components/settings/ApiOptions.tsx
+++ b/webview-ui/src/components/settings/ApiOptions.tsx
@@ -721,7 +721,7 @@ const ApiOptions = ({ showModelOptions, apiErrorMessage, modelIdErrorMessage, is
 					{modelConfigurationSelected && (
 						<>
 							<VSCodeCheckbox
-								checked={apiConfiguration?.openAiModelInfo?.supportsImages}
+								checked={!!apiConfiguration?.openAiModelInfo?.supportsImages}
 								onChange={(e: any) => {
 									const isChecked = e.target.checked === true
 									let modelInfo = apiConfiguration?.openAiModelInfo


### PR DESCRIPTION
### Description

Bugfix: If you checked "Support Images" the first time, it had no effect

### Test Procedure

* Reset State
* Select "OpenAI Compatible" provider
* Model Provider -> Check "Supports Images"
* Configure the Provider
* Click "Let's Go"
* Goto Configuration -> "Supports Images" is checked (which was not before)
### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->


### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes initial click behavior of "Supports Images" checkbox in `ApiOptions.tsx` by ensuring boolean value.
> 
>   - **Bug Fix**:
>     - Fixes initial click behavior of "Supports Images" checkbox in `ApiOptions.tsx` by using `!!` to ensure boolean value.
>     - Affects `VSCodeCheckbox` for `openAiModelInfo.supportsImages`.
>   - **Changeset**:
>     - Adds changeset `rare-pigs-divide.md` to document the bug fix.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for c255af43bad016b0f83766773151f73edeaec17b. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->