### PR TITLE
feat: Allow to configure computer use for openapi compatible provider

### DIFF
--- a/.changeset/violet-socks-obey.md
+++ b/.changeset/violet-socks-obey.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": minor
+---
+
+Allow to set computerUse for OpenAI Compatible provider

--- a/webview-ui/src/components/settings/ApiOptions.tsx
+++ b/webview-ui/src/components/settings/ApiOptions.tsx
@@ -742,7 +742,7 @@ const ApiOptions = ({ showModelOptions, apiErrorMessage, modelIdErrorMessage, is
 									let modelInfo = apiConfiguration?.openAiModelInfo
 										? apiConfiguration.openAiModelInfo
 										: { ...openAiModelInfoSaneDefaults }
-									modelInfo.supportsComputerUse = isChecked
+									modelInfo = { ...modelInfo, supportsComputerUse: isChecked }
 									setApiConfiguration({
 										...apiConfiguration,
 										openAiModelInfo: modelInfo,

--- a/webview-ui/src/components/settings/ApiOptions.tsx
+++ b/webview-ui/src/components/settings/ApiOptions.tsx
@@ -735,6 +735,21 @@ const ApiOptions = ({ showModelOptions, apiErrorMessage, modelIdErrorMessage, is
 								}}>
 								Supports Images
 							</VSCodeCheckbox>
+							<VSCodeCheckbox
+								checked={!!apiConfiguration?.openAiModelInfo?.supportsComputerUse}
+								onChange={(e: any) => {
+									const isChecked = e.target.checked === true
+									let modelInfo = apiConfiguration?.openAiModelInfo
+										? apiConfiguration.openAiModelInfo
+										: { ...openAiModelInfoSaneDefaults }
+									modelInfo.supportsComputerUse = isChecked
+									setApiConfiguration({
+										...apiConfiguration,
+										openAiModelInfo: modelInfo,
+									})
+								}}>
+								Supports Computer Use
+							</VSCodeCheckbox>
 							<div style={{ display: "flex", gap: 10, marginTop: "5px" }}>
 								<VSCodeTextField
 									value={


### PR DESCRIPTION
### Description

This feature enables configuration of computer use capabilities for OpenAI-compatible providers. This allows users to leverage Cline's full feature set when using custom endpoints, such as those accessed through a litellm proxy.

### Test Procedure

Computer Use setting:
* Goto configuration
* Select "OpenAI Compatible" provider
* Extend "Model Configuration"
* You can check/uncheck "Supports Computer Use"

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [X] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] x I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Before:
![before](https://github.com/user-attachments/assets/9a5813b2-6728-4293-b31e-bdfda62c852a)

After:
![after](https://github.com/user-attachments/assets/a9f94b7d-56b2-4cb5-8b80-517a69a1b0a4)

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `Supports Computer Use` configuration for OpenAI-compatible providers in `ApiOptions`.
> 
>   - **Feature**:
>     - Add `Supports Computer Use` checkbox in `ApiOptions` for OpenAI-compatible providers.
>     - Updates `apiConfiguration` to include `supportsComputerUse` setting.
>   - **Files**:
>     - Modify `ApiOptions.tsx` to handle new checkbox and update configuration.
>     - Add changeset `violet-socks-obey.md` to document the feature.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 0b6eb27e4d43bc83a78b43d1709784203b5d4487. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->