### PR TITLE
feat: Allow to configure a watch argument in cline_mcp_settings.json

### DIFF
--- a/.changeset/tough-feet-roll.md
+++ b/.changeset/tough-feet-roll.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": minor
+---
+
+Allow to set a watch property in mcp configuration that allows to use any file to reload the mcp server

--- a/docs/mcp/mcp-quickstart.md
+++ b/docs/mcp/mcp-quickstart.md
@@ -75,6 +75,22 @@ After saving the file:
 
 <img src="https://github.com/user-attachments/assets/2abbb3de-e902-4ec2-a5e5-9418ed34684e" alt="MCP Server Panel with Installer" width="400" />
 
+## ⚡ Auto-Restart
+
+During local development, you can configure your MCP server to automatically restart when specific files change by adding a `watch` array to your configuration:
+
+```json
+{
+	"mcpServers": {
+		"my-server": {
+			"command": "node",
+			"args": ["server.js"],
+			"watch": ["server.js", "config.json"]
+		}
+	}
+}
+```
+
 ## 🤔 What Next?
 
 Now that you have the MCP installer, you can ask Cline to add more servers from:

--- a/src/services/mcp/McpHub.ts
+++ b/src/services/mcp/McpHub.ts
@@ -42,6 +42,7 @@ const StdioConfigSchema = z.object({
 	env: z.record(z.string()).optional(),
 	autoApprove: AutoApproveSchema.optional(),
 	disabled: z.boolean().optional(),
+	watch: z.array(z.string()).optional(),
 })
 
 const McpSettingsSchema = z.object({
@@ -400,7 +401,7 @@ export class McpHub {
 	}
 
 	private setupFileWatcher(name: string, config: any) {
-		const filePath = config.args?.find((arg: string) => arg.includes("build/index.js"))
+		const filePath = config.watch || config.args?.find((arg: string) => arg.includes("build/index.js"))
 		if (filePath) {
 			// we use chokidar instead of onDidSaveTextDocument because it doesn't require the file to be open in the editor. The settings config is better suited for onDidSave since that will be manually updated by the user or Cline (and we want to detect save events, not every file change)
 			const watcher = chokidar.watch(filePath, {


### PR DESCRIPTION
### Description

<!-- Describe your changes in detail. What problem does this PR solve? -->

### Test Procedure

<!-- How did you test this? Are you confident that it will not introduce bugs? If so, why? -->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [x] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

### Additional Notes

<!-- Add any additional notes for reviewers -->
I already filed a PR for this feature, but it was closed with a wrong statement and there was no further reply to it. I try again and I added a changeset too.

Previous PR was: https://github.com/cline/cline/pull/1382
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `watch` property to MCP settings for auto-restarting servers on file changes, with implementation in `McpHub.ts` and documentation updates.
> 
>   - **Feature**:
>     - Add `watch` property in `cline_mcp_settings.json` to auto-restart MCP server on file changes.
>     - Implemented in `setupFileWatcher()` in `McpHub.ts`.
>   - **Documentation**:
>     - Update `mcp-quickstart.md` to include instructions for using the `watch` property.
>   - **Changeset**:
>     - Add `tough-feet-roll.md` for minor version update.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for c342c9678af1ef80c109a75e4dbcf6ee4133c5e2. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->