### PR TITLE
Push It to the Limit

### DIFF
--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -83,7 +83,7 @@ export type AnthropicModelId = keyof typeof anthropicModels
 export const anthropicDefaultModelId: AnthropicModelId = "claude-3-7-sonnet-20250219"
 export const anthropicModels = {
 	"claude-3-7-sonnet-20250219": {
-		maxTokens: 8192,
+		maxTokens: 64000,
 		contextWindow: 200_000,
 		supportsImages: true,
 		supportsComputerUse: true,


### PR DESCRIPTION
### Description

Sonnet 3.7 max tokens output is 64000, almost **8 times that of Sonnet 3.5**

<img width="389" alt="Screenshot 2025-02-24 at 1 04 45 PM" src="https://github.com/user-attachments/assets/037b5ff9-60f2-41d7-b83a-2bfb20d493e7" />

This is according the the anthropic developer console.

### Test Procedure

I logged that the correct max_tokens number is being passed to the API.

Sonnet seems unwilling to output anything much greater than even the previous max. However I was able to get it to output about 16k tokens in reasoning (which is set through the reasoning budget param). It seems that this large max_token size is mainly intended to be used for extended reasoning in the current version.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots



### Additional Notes



<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Increase `maxTokens` for `claude-3-7-sonnet-20250219` to 64000 in `api.ts` for extended reasoning capabilities.
> 
>   - **Behavior**:
>     - Increase `maxTokens` from 8192 to 64000 for `claude-3-7-sonnet-20250219` in `anthropicModels` in `api.ts`.
>     - Allows extended reasoning with larger token output, mainly for reasoning budget parameter.
>   - **Misc**:
>     - Update confirmed via logging to ensure correct `max_tokens` is passed to the API.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 3d7833d15f7fd45035432ef0bf09cc918e815e52. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->