### PR TITLE
Anthropic: Bump it up!

### DIFF
--- a/.changeset/silver-hotels-reflect.md
+++ b/.changeset/silver-hotels-reflect.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": minor
+---
+
+Update anthropic SDK to the latest version

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
 	"name": "claude-dev",
-	"version": "3.4.3",
+	"version": "3.4.6",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "claude-dev",
-			"version": "3.4.3",
+			"version": "3.4.6",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@anthropic-ai/bedrock-sdk": "^0.10.2",
-				"@anthropic-ai/sdk": "^0.26.0",
+				"@anthropic-ai/bedrock-sdk": "^0.12.4",
+				"@anthropic-ai/sdk": "^0.37.0",
 				"@anthropic-ai/vertex-sdk": "^0.4.1",
 				"@google/generative-ai": "^0.18.0",
 				"@mistralai/mistralai": "^1.5.0",
@@ -76,11 +76,12 @@
 			}
 		},
 		"node_modules/@anthropic-ai/bedrock-sdk": {
-			"version": "0.10.2",
-			"resolved": "https://registry.npmjs.org/@anthropic-ai/bedrock-sdk/-/bedrock-sdk-0.10.2.tgz",
-			"integrity": "sha512-sGmTzKJQHVwfXexe+yfzPU3rJmUMCygC+GNPkmMsPX/Jr+WKtJ0M71nGyHONr6vcHwUpUWA6o0MRH/oHaE54KA==",
+			"version": "0.12.4",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/bedrock-sdk/-/bedrock-sdk-0.12.4.tgz",
+			"integrity": "sha512-kraOgWWyVO/Wef3wYbpws77pCZubg/hCzXQ7RGrLRJsRpbTIT+ms+MigGu/0b1qn3o5WuIrumlT3Qtu3esHpzw==",
+			"license": "MIT",
 			"dependencies": {
-				"@anthropic-ai/sdk": "^0",
+				"@anthropic-ai/sdk": ">=0.36 <1",
 				"@aws-crypto/sha256-js": "^4.0.0",
 				"@aws-sdk/client-bedrock-runtime": "^3.423.0",
 				"@aws-sdk/credential-providers": "^3.341.0",
@@ -94,9 +95,10 @@
 			}
 		},
 		"node_modules/@anthropic-ai/sdk": {
-			"version": "0.26.0",
-			"resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.26.0.tgz",
-			"integrity": "sha512-vNbZ2rnnMfk8Bf4OdeVy6GA4EXao8tGC0tLEoSAl1NZrip9oOxnEGUkXl3FsPQgeBM5hmpGE1tSLuu9HEVJiHg==",
+			"version": "0.37.0",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.37.0.tgz",
+			"integrity": "sha512-tHjX2YbkUBwEgg0JZU3EFSSAQPoK4qQR/NFYa8Vtzd5UAyXzZksCw2In69Rml4R/TyHPBfRYaLK35XiOe33pjw==",
+			"license": "MIT",
 			"dependencies": {
 				"@types/node": "^18.11.18",
 				"@types/node-fetch": "^2.6.4",

--- a/package.json
+++ b/package.json
@@ -237,8 +237,8 @@
 		"typescript": "^5.4.5"
 	},
 	"dependencies": {
-		"@anthropic-ai/bedrock-sdk": "^0.10.2",
-		"@anthropic-ai/sdk": "^0.26.0",
+		"@anthropic-ai/bedrock-sdk": "^0.12.4",
+		"@anthropic-ai/sdk": "^0.37.0",
 		"@anthropic-ai/vertex-sdk": "^0.4.1",
 		"@google/generative-ai": "^0.18.0",
 		"@mistralai/mistralai": "^1.5.0",

--- a/src/api/providers/anthropic.ts
+++ b/src/api/providers/anthropic.ts
@@ -20,7 +20,7 @@ export class AnthropicHandler implements ApiHandler {
 	@withRetry()
 	async *createMessage(systemPrompt: string, messages: Anthropic.Messages.MessageParam[]): ApiStream {
 		const model = this.getModel()
-		let stream: AnthropicStream<Anthropic.Beta.PromptCaching.Messages.RawPromptCachingBetaMessageStreamEvent>
+		let stream: AnthropicStream<Anthropic.RawMessageStreamEvent>
 		const modelId = model.id
 		switch (modelId) {
 			// 'latest' alias does not support cache_control
@@ -38,7 +38,7 @@ export class AnthropicHandler implements ApiHandler {
 				)
 				const lastUserMsgIndex = userMsgIndices[userMsgIndices.length - 1] ?? -1
 				const secondLastMsgUserIndex = userMsgIndices[userMsgIndices.length - 2] ?? -1
-				stream = await this.client.beta.promptCaching.messages.create(
+				stream = await this.client.messages.create(
 					{
 						model: modelId,
 						max_tokens: model.info.maxTokens || 8192,

--- a/src/api/transform/gemini-format.ts
+++ b/src/api/transform/gemini-format.ts
@@ -11,16 +11,7 @@ import {
 	TextPart,
 } from "@google/generative-ai"
 
-export function convertAnthropicContentToGemini(
-	content:
-		| string
-		| Array<
-				| Anthropic.Messages.TextBlockParam
-				| Anthropic.Messages.ImageBlockParam
-				| Anthropic.Messages.ToolUseBlockParam
-				| Anthropic.Messages.ToolResultBlockParam
-		  >,
-): Part[] {
+export function convertAnthropicContentToGemini(content: string | Anthropic.ContentBlockParam[]): Part[] {
 	if (typeof content === "string") {
 		return [{ text: content } as TextPart]
 	}
@@ -133,7 +124,7 @@ export function convertGeminiResponseToAnthropic(response: EnhancedGenerateConte
 	// Add the main text response
 	const text = response.text()
 	if (text) {
-		content.push({ type: "text", text })
+		content.push({ type: "text", text, citations: null })
 	}
 
 	// Add function calls as tool_use blocks
@@ -183,6 +174,8 @@ export function convertGeminiResponseToAnthropic(response: EnhancedGenerateConte
 		usage: {
 			input_tokens: response.usageMetadata?.promptTokenCount ?? 0,
 			output_tokens: response.usageMetadata?.candidatesTokenCount ?? 0,
+			cache_creation_input_tokens: null,
+			cache_read_input_tokens: null,
 		},
 	}
 }

--- a/src/api/transform/o1-format.ts
+++ b/src/api/transform/o1-format.ts
@@ -376,6 +376,7 @@ export function convertO1ResponseToAnthropicMessage(
 			{
 				type: "text",
 				text: normalText,
+				citations: null,
 			},
 		],
 		model: completion.model,
@@ -396,6 +397,8 @@ export function convertO1ResponseToAnthropicMessage(
 		usage: {
 			input_tokens: completion.usage?.prompt_tokens || 0,
 			output_tokens: completion.usage?.completion_tokens || 0,
+			cache_creation_input_tokens: null,
+			cache_read_input_tokens: null,
 		},
 	}
 

--- a/src/api/transform/openai-format.ts
+++ b/src/api/transform/openai-format.ts
@@ -161,6 +161,7 @@ export function convertToAnthropicMessage(completion: OpenAI.Chat.Completions.Ch
 			{
 				type: "text",
 				text: openAiMessage.content || "",
+				citations: null,
 			},
 		],
 		model: completion.model,
@@ -181,6 +182,8 @@ export function convertToAnthropicMessage(completion: OpenAI.Chat.Completions.Ch
 		usage: {
 			input_tokens: completion.usage?.prompt_tokens || 0,
 			output_tokens: completion.usage?.completion_tokens || 0,
+			cache_creation_input_tokens: null,
+			cache_read_input_tokens: null,
 		},
 	}
 

--- a/src/api/transform/vscode-lm-format.ts
+++ b/src/api/transform/vscode-lm-format.ts
@@ -175,6 +175,7 @@ export async function convertToAnthropicMessage(
 					return {
 						type: "text",
 						text: part.value,
+						citations: null,
 					}
 				}
 
@@ -195,6 +196,8 @@ export async function convertToAnthropicMessage(
 		usage: {
 			input_tokens: 0,
 			output_tokens: 0,
+			cache_creation_input_tokens: null,
+			cache_read_input_tokens: null,
 		},
 	}
 }

--- a/src/core/Cline.ts
+++ b/src/core/Cline.ts
@@ -63,9 +63,7 @@ import { ClineProvider, GlobalFileNames } from "./webview/ClineProvider"
 const cwd = vscode.workspace.workspaceFolders?.map((folder) => folder.uri.fsPath).at(0) ?? path.join(os.homedir(), "Desktop") // may or may not exist but fs checking existence would immediately ask for permission which would be bad UX, need to come up with a better solution
 
 type ToolResponse = string | Array<Anthropic.TextBlockParam | Anthropic.ImageBlockParam>
-type UserContent = Array<
-	Anthropic.TextBlockParam | Anthropic.ImageBlockParam | Anthropic.ToolUseBlockParam | Anthropic.ToolResultBlockParam
->
+type UserContent = Array<Anthropic.ContentBlockParam>
 
 export class Cline {
 	readonly taskId: string

--- a/src/integrations/misc/export-markdown.ts
+++ b/src/integrations/misc/export-markdown.ts
@@ -35,9 +35,13 @@ export async function downloadTask(dateTs: number, conversationHistory: Anthropi
 	})
 
 	if (saveUri) {
-		// Write content to the selected location
-		await vscode.workspace.fs.writeFile(saveUri, new Uint8Array(Buffer.from(markdownContent)))
-		vscode.window.showTextDocument(saveUri, { preview: true })
+		try {
+			// Write content to the selected location
+			await vscode.workspace.fs.writeFile(saveUri, new TextEncoder().encode(markdownContent))
+			vscode.window.showTextDocument(saveUri, { preview: true })
+		} catch (error) {
+			vscode.window.showErrorMessage(`Failed to save markdown file: ${error instanceof Error ? error.message : String(error)}`)
+		}
 	}
 }
 

--- a/src/integrations/misc/export-markdown.ts
+++ b/src/integrations/misc/export-markdown.ts
@@ -36,13 +36,13 @@ export async function downloadTask(dateTs: number, conversationHistory: Anthropi
 
 	if (saveUri) {
 		// Write content to the selected location
-		await vscode.workspace.fs.writeFile(saveUri, Buffer.from(markdownContent))
+		await vscode.workspace.fs.writeFile(saveUri, new Uint8Array(Buffer.from(markdownContent)))
 		vscode.window.showTextDocument(saveUri, { preview: true })
 	}
 }
 
 export function formatContentBlockToMarkdown(
-	block: Anthropic.TextBlockParam | Anthropic.ImageBlockParam | Anthropic.ToolUseBlockParam | Anthropic.ToolResultBlockParam,
+	block: Anthropic.ContentBlockParam,
 	// messages: Anthropic.MessageParam[]
 ): string {
 	switch (block.type) {
@@ -50,6 +50,8 @@ export function formatContentBlockToMarkdown(
 			return block.text
 		case "image":
 			return `[Image]`
+		case "document":
+			return `[Document]`
 		case "tool_use":
 			let input: string
 			if (typeof block.input === "object" && block.input !== null) {

--- a/src/integrations/misc/export-markdown.ts
+++ b/src/integrations/misc/export-markdown.ts
@@ -40,7 +40,9 @@ export async function downloadTask(dateTs: number, conversationHistory: Anthropi
 			await vscode.workspace.fs.writeFile(saveUri, new TextEncoder().encode(markdownContent))
 			vscode.window.showTextDocument(saveUri, { preview: true })
 		} catch (error) {
-			vscode.window.showErrorMessage(`Failed to save markdown file: ${error instanceof Error ? error.message : String(error)}`)
+			vscode.window.showErrorMessage(
+				`Failed to save markdown file: ${error instanceof Error ? error.message : String(error)}`,
+			)
 		}
 	}
 }


### PR DESCRIPTION
### Description

This PR updates the Anthropic SDK dependencies to newer versions (@anthropic-ai/bedrock-sdk from ^0.10.2 to ^0.12.4 and @anthropic-ai/sdk from ^0.26.0 to ^0.37.0) and makes the necessary adjustments to maintain compatibility with the updated APIs.

While most changes are type-related, there are a few functional adjustments to maintain compatibility with the updated API structure:

1. Updated the API path for prompt caching (moved from beta to main API)
2. Modified buffer handling in export-markdown.ts for VSCode API compatibility
3. Added support for the new "document" content type

### Test Procedure

The changes have been verified by:
1. Ensuring that the extension builds and that things seem to be working as before.
2. Need to double check that prompt caching is working as expected (owing to the api path changing for this, as Anthropic moved this from beta to the main path a few months ago).

### Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update

### Pre-flight Checklist

- [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
- [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
- [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
- [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

### Additional Notes

This PR updates our integration with the Anthropic API to use the latest SDK versions. The changes are focused on maintaining compatibility with the updated API interfaces.


<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Update Anthropic SDK dependencies and adjust code for compatibility with new API paths, buffer handling, and content types.
> 
>   - **Dependencies**:
>     - Update `@anthropic-ai/bedrock-sdk` from `^0.10.2` to `^0.12.4` and `@anthropic-ai/sdk` from `^0.26.0` to `^0.37.0` in `package.json`.
>   - **API Adjustments**:
>     - Change API path for prompt caching in `anthropic.ts`.
>     - Modify buffer handling in `export-markdown.ts` for VSCode API compatibility.
>     - Add support for "document" content type in `export-markdown.ts` and `vscode-lm-format.ts`.
>   - **Type Changes**:
>     - Update type handling in `gemini-format.ts`, `o1-format.ts`, and `openai-format.ts` to align with new SDK versions.
>   - **Miscellaneous**:
>     - Add `cache_creation_input_tokens` and `cache_read_input_tokens` to usage metrics in `gemini-format.ts`, `o1-format.ts`, and `openai-format.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 56ff98ad2c89eb9ada711cc2e7b375b2dd262964. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->