### PR TITLE
Hugelung/rich mcp response

### DIFF
--- a/.changeset/old-dancers-smell.md
+++ b/.changeset/old-dancers-smell.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": minor
+---
+
+Add rich MCP responses with images and link previews

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "claude-dev",
-	"version": "3.4.3",
+	"version": "3.4.6",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "claude-dev",
-			"version": "3.4.3",
+			"version": "3.4.6",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@anthropic-ai/bedrock-sdk": "^0.10.2",
@@ -36,6 +36,7 @@
 				"isbinaryfile": "^5.0.2",
 				"mammoth": "^1.8.0",
 				"monaco-vscode-textmate-theme-converter": "^0.1.7",
+				"open-graph-scraper": "^6.9.0",
 				"openai": "^4.83.0",
 				"os-name": "^6.0.0",
 				"p-wait-for": "^5.0.2",
@@ -11046,6 +11047,27 @@
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
+		},
+		"node_modules/open-graph-scraper": {
+			"version": "6.9.0",
+			"resolved": "https://registry.npmjs.org/open-graph-scraper/-/open-graph-scraper-6.9.0.tgz",
+			"integrity": "sha512-1KoV5v6GT0/MqlryrVGQROhEAD4u8wC3VjYOxsnhj3mWeGJ6N6nF/rbrcZREFr+kiYm9I5LMrzdK9t9hBMbL2Q==",
+			"license": "MIT",
+			"dependencies": {
+				"chardet": "^2.0.0",
+				"cheerio": "^1.0.0-rc.12",
+				"iconv-lite": "^0.6.3",
+				"undici": "^6.21.0"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/open-graph-scraper/node_modules/chardet": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/chardet/-/chardet-2.0.0.tgz",
+			"integrity": "sha512-xVgPpulCooDjY6zH4m9YW3jbkaBe3FKIAvF5sj5t7aBNsVl2ljIE+xwJ4iNgiDZHFQvNIpjdKdVOQvvk5ZfxbQ==",
+			"license": "MIT"
 		},
 		"node_modules/openai": {
 			"version": "4.83.0",

--- a/package.json
+++ b/package.json
@@ -264,6 +264,7 @@
 		"isbinaryfile": "^5.0.2",
 		"mammoth": "^1.8.0",
 		"monaco-vscode-textmate-theme-converter": "^0.1.7",
+		"open-graph-scraper": "^6.9.0",
 		"openai": "^4.83.0",
 		"os-name": "^6.0.0",
 		"p-wait-for": "^5.0.2",

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -1941,12 +1941,12 @@ Here is the project's README to help you get started:\n\n${mcpDetails.readmeCont
 		try {
 			// Use the fetchOpenGraphData function from link-preview.ts
 			const ogData = await fetchOpenGraphData(url)
-			
+
 			// Send the data back to the webview
 			await this.postMessageToWebview({
 				type: "openGraphData",
 				openGraphData: ogData,
-				url: url
+				url: url,
 			})
 		} catch (error) {
 			console.error(`Error fetching Open Graph data for ${url}:`, error)
@@ -1954,25 +1954,25 @@ Here is the project's README to help you get started:\n\n${mcpDetails.readmeCont
 			await this.postMessageToWebview({
 				type: "openGraphData",
 				error: `Failed to fetch Open Graph data: ${error}`,
-				url: url
+				url: url,
 			})
 		}
 	}
-	
+
 	// Check if a URL is an image
 	async checkIsImageUrl(url: string) {
 		try {
 			// Import the isImageUrl function from link-preview.ts
-			const { isImageUrl } = await import('../../integrations/misc/link-preview')
-			
+			const { isImageUrl } = await import("../../integrations/misc/link-preview")
+
 			// Check if the URL is an image
 			const isImage = await isImageUrl(url)
-			
+
 			// Send the result back to the webview
 			await this.postMessageToWebview({
 				type: "isImageUrlResult",
 				isImage,
-				url
+				url,
 			})
 		} catch (error) {
 			console.error(`Error checking if URL is an image: ${url}`, error)
@@ -1980,7 +1980,7 @@ Here is the project's README to help you get started:\n\n${mcpDetails.readmeCont
 			await this.postMessageToWebview({
 				type: "isImageUrlResult",
 				isImage: false,
-				url
+				url,
 			})
 		}
 	}

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -11,6 +11,7 @@ import { buildApiHandler } from "../../api"
 import { downloadTask } from "../../integrations/misc/export-markdown"
 import { openFile, openImage } from "../../integrations/misc/open-file"
 import { openImageInWebview } from "../../integrations/misc/open-image-webview"
+import { openLinkPreview, fetchOpenGraphData } from "../../integrations/misc/link-preview"
 import { selectImages } from "../../integrations/misc/process-images"
 import { getTheme } from "../../integrations/theme/getTheme"
 import WorkspaceTracker from "../../integrations/workspace/WorkspaceTracker"
@@ -638,6 +639,20 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 						break
 					case "openImageInWebview":
 						openImageInWebview(message.text!)
+						break
+					case "openLinkPreview":
+						openLinkPreview(message.text!)
+						break
+					case "openInBrowser":
+						if (message.url) {
+							vscode.env.openExternal(vscode.Uri.parse(message.url))
+						}
+						break
+					case "fetchOpenGraphData":
+						this.fetchOpenGraphData(message.text!)
+						break
+					case "checkIsImageUrl":
+						this.checkIsImageUrl(message.text!)
 						break
 					case "openFile":
 						openFile(message.text!)
@@ -1918,6 +1933,56 @@ Here is the project's README to help you get started:\n\n${mcpDetails.readmeCont
 
 	async getSecret(key: SecretKey) {
 		return await this.context.secrets.get(key)
+	}
+
+	// Open Graph Data
+
+	async fetchOpenGraphData(url: string) {
+		try {
+			// Use the fetchOpenGraphData function from link-preview.ts
+			const ogData = await fetchOpenGraphData(url)
+			
+			// Send the data back to the webview
+			await this.postMessageToWebview({
+				type: "openGraphData",
+				openGraphData: ogData,
+				url: url
+			})
+		} catch (error) {
+			console.error(`Error fetching Open Graph data for ${url}:`, error)
+			// Send an error response
+			await this.postMessageToWebview({
+				type: "openGraphData",
+				error: `Failed to fetch Open Graph data: ${error}`,
+				url: url
+			})
+		}
+	}
+	
+	// Check if a URL is an image
+	async checkIsImageUrl(url: string) {
+		try {
+			// Import the isImageUrl function from link-preview.ts
+			const { isImageUrl } = await import('../../integrations/misc/link-preview')
+			
+			// Check if the URL is an image
+			const isImage = await isImageUrl(url)
+			
+			// Send the result back to the webview
+			await this.postMessageToWebview({
+				type: "isImageUrlResult",
+				isImage,
+				url
+			})
+		} catch (error) {
+			console.error(`Error checking if URL is an image: ${url}`, error)
+			// Send an error response
+			await this.postMessageToWebview({
+				type: "isImageUrlResult",
+				isImage: false,
+				url
+			})
+		}
 	}
 
 	// dev

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -10,6 +10,7 @@ import * as vscode from "vscode"
 import { buildApiHandler } from "../../api"
 import { downloadTask } from "../../integrations/misc/export-markdown"
 import { openFile, openImage } from "../../integrations/misc/open-file"
+import { openImageInWebview } from "../../integrations/misc/open-image-webview"
 import { selectImages } from "../../integrations/misc/process-images"
 import { getTheme } from "../../integrations/theme/getTheme"
 import WorkspaceTracker from "../../integrations/workspace/WorkspaceTracker"
@@ -634,6 +635,9 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 						break
 					case "openImage":
 						openImage(message.text!)
+						break
+					case "openImageInWebview":
+						openImageInWebview(message.text!)
 						break
 					case "openFile":
 						openFile(message.text!)

--- a/src/integrations/misc/link-preview.ts
+++ b/src/integrations/misc/link-preview.ts
@@ -1,0 +1,348 @@
+import * as vscode from "vscode"
+import axios from "axios"
+import ogs from 'open-graph-scraper'
+
+interface OpenGraphData {
+  title?: string
+  description?: string
+  image?: string
+  url?: string
+  siteName?: string
+  type?: string
+}
+
+/**
+ * Fetches Open Graph metadata from a URL
+ * @param url The URL to fetch metadata from
+ * @returns Promise resolving to OpenGraphData
+ */
+export async function fetchOpenGraphData(url: string): Promise<OpenGraphData> {
+  try {
+    const options = {
+      url: url,
+      timeout: 5000,
+      headers: {
+        'user-agent': 'Mozilla/5.0 (compatible; VSCodeExtension/1.0; +https://cline.bot)'
+      },
+      onlyGetOpenGraphInfo: false, // Get all metadata, not just Open Graph
+      fetchOptions: {
+        redirect: 'follow' // Follow redirects
+      } as any
+    }
+    
+    const { result } = await ogs(options)
+    
+    // Use type assertion to avoid TypeScript errors
+    const data = result as any
+    
+    // Handle image URLs
+    let imageUrl = data.ogImage?.[0]?.url || data.twitterImage?.[0]?.url
+    
+    // If the image URL is relative, make it absolute
+    if (imageUrl && (imageUrl.startsWith('/') || imageUrl.startsWith('./'))) {
+      try {
+        // Extract the base URL and make the relative URL absolute
+        const urlObj = new URL(url)
+        const baseUrl = `${urlObj.protocol}//${urlObj.hostname}`
+        imageUrl = new URL(imageUrl, baseUrl).href
+      } catch (error) {
+        console.error(`Error converting relative URL to absolute: ${imageUrl}`, error)
+      }
+    }
+    
+    return {
+      title: data.ogTitle || data.twitterTitle || data.dcTitle || data.title || new URL(url).hostname,
+      description: data.ogDescription || data.twitterDescription || data.dcDescription || data.description || 'No description available',
+      image: imageUrl,
+      url: data.ogUrl || url,
+      siteName: data.ogSiteName || new URL(url).hostname,
+      type: data.ogType
+    }
+  } catch (error) {
+    console.error(`Error fetching Open Graph data for ${url}:`, error)
+    // Return basic information based on the URL
+    try {
+      const urlObj = new URL(url)
+      return {
+        title: urlObj.hostname,
+        description: url,
+        url: url,
+        siteName: urlObj.hostname
+      }
+    } catch {
+      return {
+        title: url,
+        description: url,
+        url: url
+      }
+    }
+  }
+}
+
+/**
+ * Checks if a URL is an image by making a HEAD request and checking the content type
+ * @param url The URL to check
+ * @returns Promise resolving to boolean indicating if the URL is an image
+ */
+export async function isImageUrl(url: string): Promise<boolean> {
+  try {
+    const response = await axios.head(url, {
+      headers: {
+        'User-Agent': 'Mozilla/5.0 (compatible; VSCodeExtension/1.0; +https://cline.bot)'
+      },
+      timeout: 3000
+    })
+    
+    const contentType = response.headers['content-type']
+    return contentType && contentType.startsWith('image/')
+  } catch (error) {
+    console.error(`Error checking if URL is an image: ${url}`, error)
+    // If we can't determine, fall back to checking the file extension
+    return /\.(jpg|jpeg|png|gif|webp|svg)$/i.test(url)
+  }
+}
+
+/**
+ * Opens a link preview in a VS Code webview panel
+ * @param url The URL to preview
+ */
+export async function openLinkPreview(url: string): Promise<void> {
+  // First check if it's an image
+  const isImage = await isImageUrl(url)
+  
+  if (isImage) {
+    // If it's an image, show it directly
+    openImagePreview(url)
+    return
+  }
+  
+  // Otherwise, fetch Open Graph data and show a rich preview
+  const ogData = await fetchOpenGraphData(url)
+  openRichLinkPreview(url, ogData)
+}
+
+/**
+ * Opens an image preview in a VS Code webview panel
+ * @param imageUrl The URL of the image to preview
+ */
+function openImagePreview(imageUrl: string): void {
+  const panel = vscode.window.createWebviewPanel(
+    'linkPreview',
+    'Image Preview',
+    vscode.ViewColumn.One,
+    {
+      enableScripts: true,
+      retainContextWhenHidden: true
+    }
+  )
+  
+  panel.webview.html = getImagePreviewHtml(imageUrl)
+}
+
+/**
+ * Opens a rich link preview in a VS Code webview panel
+ * @param url The URL to preview
+ * @param ogData The Open Graph data for the URL
+ */
+function openRichLinkPreview(url: string, ogData: OpenGraphData): void {
+  const panel = vscode.window.createWebviewPanel(
+    'linkPreview',
+    ogData.title || 'Link Preview',
+    vscode.ViewColumn.One,
+    {
+      enableScripts: true,
+      retainContextWhenHidden: true
+    }
+  )
+  
+  panel.webview.html = getRichLinkPreviewHtml(url, ogData)
+}
+
+/**
+ * Generates HTML for an image preview
+ * @param imageUrl The URL of the image to preview
+ * @returns HTML content as a string
+ */
+function getImagePreviewHtml(imageUrl: string): string {
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Image Preview</title>
+    <style>
+        body {
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            height: 100vh;
+            margin: 0;
+            padding: 20px;
+            box-sizing: border-box;
+            background-color: var(--vscode-editor-background);
+            color: var(--vscode-editor-foreground);
+            font-family: var(--vscode-font-family);
+        }
+        .image-container {
+            max-width: 100%;
+            max-height: 90vh;
+            overflow: auto;
+            margin-bottom: 10px;
+            text-align: center;
+        }
+        img {
+            max-width: 100%;
+            height: auto;
+            display: block;
+            margin: 0 auto;
+        }
+        .url-display {
+            margin-top: 10px;
+            word-break: break-all;
+            font-size: 12px;
+            color: var(--vscode-descriptionForeground);
+        }
+        .open-browser {
+            margin-top: 15px;
+            cursor: pointer;
+            background-color: var(--vscode-button-background);
+            color: var(--vscode-button-foreground);
+            border: none;
+            padding: 6px 12px;
+            border-radius: 2px;
+            font-family: var(--vscode-font-family);
+        }
+        .open-browser:hover {
+            background-color: var(--vscode-button-hoverBackground);
+        }
+    </style>
+</head>
+<body>
+    <div class="image-container">
+        <img src="${imageUrl}" alt="Image Preview" />
+    </div>
+    <div class="url-display">
+        Source: ${imageUrl}
+    </div>
+    <button class="open-browser" onclick="openInBrowser()">Open in Browser</button>
+    <script>
+        function openInBrowser() {
+            const vscode = acquireVsCodeApi();
+            vscode.postMessage({
+                type: 'openInBrowser',
+                url: '${imageUrl}'
+            });
+        }
+    </script>
+</body>
+</html>`
+}
+
+/**
+ * Generates HTML for a rich link preview
+ * @param url The URL to preview
+ * @param ogData The Open Graph data for the URL
+ * @returns HTML content as a string
+ */
+function getRichLinkPreviewHtml(url: string, ogData: OpenGraphData): string {
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>${ogData.title || 'Link Preview'}</title>
+    <style>
+        body {
+            display: flex;
+            flex-direction: column;
+            padding: 20px;
+            box-sizing: border-box;
+            background-color: var(--vscode-editor-background);
+            color: var(--vscode-editor-foreground);
+            font-family: var(--vscode-font-family);
+            line-height: 1.5;
+        }
+        .preview-container {
+            max-width: 800px;
+            margin: 0 auto;
+            width: 100%;
+        }
+        .preview-header {
+            margin-bottom: 20px;
+        }
+        .preview-title {
+            font-size: 24px;
+            font-weight: bold;
+            margin-bottom: 10px;
+        }
+        .preview-site {
+            font-size: 14px;
+            color: var(--vscode-descriptionForeground);
+            margin-bottom: 5px;
+        }
+        .preview-url {
+            font-size: 14px;
+            color: var(--vscode-textLink-foreground);
+            margin-bottom: 15px;
+            word-break: break-all;
+        }
+        .preview-image {
+            max-width: 100%;
+            max-height: 400px;
+            margin-bottom: 20px;
+            border-radius: 4px;
+        }
+        .preview-description {
+            font-size: 16px;
+            margin-bottom: 20px;
+            line-height: 1.6;
+        }
+        .open-browser {
+            cursor: pointer;
+            background-color: var(--vscode-button-background);
+            color: var(--vscode-button-foreground);
+            border: none;
+            padding: 8px 16px;
+            border-radius: 2px;
+            font-family: var(--vscode-font-family);
+            align-self: flex-start;
+        }
+        .open-browser:hover {
+            background-color: var(--vscode-button-hoverBackground);
+        }
+        .no-data {
+            font-style: italic;
+            color: var(--vscode-descriptionForeground);
+        }
+    </style>
+</head>
+<body>
+    <div class="preview-container">
+        <div class="preview-header">
+            <div class="preview-title">${ogData.title || 'No title available'}</div>
+            <div class="preview-site">${ogData.siteName || new URL(url).hostname}</div>
+            <div class="preview-url">${ogData.url || url}</div>
+        </div>
+        
+        ${ogData.image ? `<img class="preview-image" src="${ogData.image}" alt="Preview image" />` : ''}
+        
+        <div class="preview-description">
+            ${ogData.description || '<span class="no-data">No description available</span>'}
+        </div>
+        
+        <button class="open-browser" onclick="openInBrowser()">Open in Browser</button>
+    </div>
+    
+    <script>
+        function openInBrowser() {
+            const vscode = acquireVsCodeApi();
+            vscode.postMessage({
+                type: 'openInBrowser',
+                url: '${url}'
+            });
+        }
+    </script>
+</body>
+</html>`
+}

--- a/src/integrations/misc/link-preview.ts
+++ b/src/integrations/misc/link-preview.ts
@@ -1,14 +1,14 @@
 import * as vscode from "vscode"
 import axios from "axios"
-import ogs from 'open-graph-scraper'
+import ogs from "open-graph-scraper"
 
 interface OpenGraphData {
-  title?: string
-  description?: string
-  image?: string
-  url?: string
-  siteName?: string
-  type?: string
+	title?: string
+	description?: string
+	image?: string
+	url?: string
+	siteName?: string
+	type?: string
 }
 
 /**
@@ -17,66 +17,71 @@ interface OpenGraphData {
  * @returns Promise resolving to OpenGraphData
  */
 export async function fetchOpenGraphData(url: string): Promise<OpenGraphData> {
-  try {
-    const options = {
-      url: url,
-      timeout: 5000,
-      headers: {
-        'user-agent': 'Mozilla/5.0 (compatible; VSCodeExtension/1.0; +https://cline.bot)'
-      },
-      onlyGetOpenGraphInfo: false, // Get all metadata, not just Open Graph
-      fetchOptions: {
-        redirect: 'follow' // Follow redirects
-      } as any
-    }
-    
-    const { result } = await ogs(options)
-    
-    // Use type assertion to avoid TypeScript errors
-    const data = result as any
-    
-    // Handle image URLs
-    let imageUrl = data.ogImage?.[0]?.url || data.twitterImage?.[0]?.url
-    
-    // If the image URL is relative, make it absolute
-    if (imageUrl && (imageUrl.startsWith('/') || imageUrl.startsWith('./'))) {
-      try {
-        // Extract the base URL and make the relative URL absolute
-        const urlObj = new URL(url)
-        const baseUrl = `${urlObj.protocol}//${urlObj.hostname}`
-        imageUrl = new URL(imageUrl, baseUrl).href
-      } catch (error) {
-        console.error(`Error converting relative URL to absolute: ${imageUrl}`, error)
-      }
-    }
-    
-    return {
-      title: data.ogTitle || data.twitterTitle || data.dcTitle || data.title || new URL(url).hostname,
-      description: data.ogDescription || data.twitterDescription || data.dcDescription || data.description || 'No description available',
-      image: imageUrl,
-      url: data.ogUrl || url,
-      siteName: data.ogSiteName || new URL(url).hostname,
-      type: data.ogType
-    }
-  } catch (error) {
-    console.error(`Error fetching Open Graph data for ${url}:`, error)
-    // Return basic information based on the URL
-    try {
-      const urlObj = new URL(url)
-      return {
-        title: urlObj.hostname,
-        description: url,
-        url: url,
-        siteName: urlObj.hostname
-      }
-    } catch {
-      return {
-        title: url,
-        description: url,
-        url: url
-      }
-    }
-  }
+	try {
+		const options = {
+			url: url,
+			timeout: 5000,
+			headers: {
+				"user-agent": "Mozilla/5.0 (compatible; VSCodeExtension/1.0; +https://cline.bot)",
+			},
+			onlyGetOpenGraphInfo: false, // Get all metadata, not just Open Graph
+			fetchOptions: {
+				redirect: "follow", // Follow redirects
+			} as any,
+		}
+
+		const { result } = await ogs(options)
+
+		// Use type assertion to avoid TypeScript errors
+		const data = result as any
+
+		// Handle image URLs
+		let imageUrl = data.ogImage?.[0]?.url || data.twitterImage?.[0]?.url
+
+		// If the image URL is relative, make it absolute
+		if (imageUrl && (imageUrl.startsWith("/") || imageUrl.startsWith("./"))) {
+			try {
+				// Extract the base URL and make the relative URL absolute
+				const urlObj = new URL(url)
+				const baseUrl = `${urlObj.protocol}//${urlObj.hostname}`
+				imageUrl = new URL(imageUrl, baseUrl).href
+			} catch (error) {
+				console.error(`Error converting relative URL to absolute: ${imageUrl}`, error)
+			}
+		}
+
+		return {
+			title: data.ogTitle || data.twitterTitle || data.dcTitle || data.title || new URL(url).hostname,
+			description:
+				data.ogDescription ||
+				data.twitterDescription ||
+				data.dcDescription ||
+				data.description ||
+				"No description available",
+			image: imageUrl,
+			url: data.ogUrl || url,
+			siteName: data.ogSiteName || new URL(url).hostname,
+			type: data.ogType,
+		}
+	} catch (error) {
+		console.error(`Error fetching Open Graph data for ${url}:`, error)
+		// Return basic information based on the URL
+		try {
+			const urlObj = new URL(url)
+			return {
+				title: urlObj.hostname,
+				description: url,
+				url: url,
+				siteName: urlObj.hostname,
+			}
+		} catch {
+			return {
+				title: url,
+				description: url,
+				url: url,
+			}
+		}
+	}
 }
 
 /**
@@ -85,21 +90,21 @@ export async function fetchOpenGraphData(url: string): Promise<OpenGraphData> {
  * @returns Promise resolving to boolean indicating if the URL is an image
  */
 export async function isImageUrl(url: string): Promise<boolean> {
-  try {
-    const response = await axios.head(url, {
-      headers: {
-        'User-Agent': 'Mozilla/5.0 (compatible; VSCodeExtension/1.0; +https://cline.bot)'
-      },
-      timeout: 3000
-    })
-    
-    const contentType = response.headers['content-type']
-    return contentType && contentType.startsWith('image/')
-  } catch (error) {
-    console.error(`Error checking if URL is an image: ${url}`, error)
-    // If we can't determine, fall back to checking the file extension
-    return /\.(jpg|jpeg|png|gif|webp|svg)$/i.test(url)
-  }
+	try {
+		const response = await axios.head(url, {
+			headers: {
+				"User-Agent": "Mozilla/5.0 (compatible; VSCodeExtension/1.0; +https://cline.bot)",
+			},
+			timeout: 3000,
+		})
+
+		const contentType = response.headers["content-type"]
+		return contentType && contentType.startsWith("image/")
+	} catch (error) {
+		console.error(`Error checking if URL is an image: ${url}`, error)
+		// If we can't determine, fall back to checking the file extension
+		return /\.(jpg|jpeg|png|gif|webp|svg)$/i.test(url)
+	}
 }
 
 /**
@@ -107,18 +112,18 @@ export async function isImageUrl(url: string): Promise<boolean> {
  * @param url The URL to preview
  */
 export async function openLinkPreview(url: string): Promise<void> {
-  // First check if it's an image
-  const isImage = await isImageUrl(url)
-  
-  if (isImage) {
-    // If it's an image, show it directly
-    openImagePreview(url)
-    return
-  }
-  
-  // Otherwise, fetch Open Graph data and show a rich preview
-  const ogData = await fetchOpenGraphData(url)
-  openRichLinkPreview(url, ogData)
+	// First check if it's an image
+	const isImage = await isImageUrl(url)
+
+	if (isImage) {
+		// If it's an image, show it directly
+		openImagePreview(url)
+		return
+	}
+
+	// Otherwise, fetch Open Graph data and show a rich preview
+	const ogData = await fetchOpenGraphData(url)
+	openRichLinkPreview(url, ogData)
 }
 
 /**
@@ -126,17 +131,12 @@ export async function openLinkPreview(url: string): Promise<void> {
  * @param imageUrl The URL of the image to preview
  */
 function openImagePreview(imageUrl: string): void {
-  const panel = vscode.window.createWebviewPanel(
-    'linkPreview',
-    'Image Preview',
-    vscode.ViewColumn.One,
-    {
-      enableScripts: true,
-      retainContextWhenHidden: true
-    }
-  )
-  
-  panel.webview.html = getImagePreviewHtml(imageUrl)
+	const panel = vscode.window.createWebviewPanel("linkPreview", "Image Preview", vscode.ViewColumn.One, {
+		enableScripts: true,
+		retainContextWhenHidden: true,
+	})
+
+	panel.webview.html = getImagePreviewHtml(imageUrl)
 }
 
 /**
@@ -145,17 +145,12 @@ function openImagePreview(imageUrl: string): void {
  * @param ogData The Open Graph data for the URL
  */
 function openRichLinkPreview(url: string, ogData: OpenGraphData): void {
-  const panel = vscode.window.createWebviewPanel(
-    'linkPreview',
-    ogData.title || 'Link Preview',
-    vscode.ViewColumn.One,
-    {
-      enableScripts: true,
-      retainContextWhenHidden: true
-    }
-  )
-  
-  panel.webview.html = getRichLinkPreviewHtml(url, ogData)
+	const panel = vscode.window.createWebviewPanel("linkPreview", ogData.title || "Link Preview", vscode.ViewColumn.One, {
+		enableScripts: true,
+		retainContextWhenHidden: true,
+	})
+
+	panel.webview.html = getRichLinkPreviewHtml(url, ogData)
 }
 
 /**
@@ -164,7 +159,7 @@ function openRichLinkPreview(url: string, ogData: OpenGraphData): void {
  * @returns HTML content as a string
  */
 function getImagePreviewHtml(imageUrl: string): string {
-  return `<!DOCTYPE html>
+	return `<!DOCTYPE html>
 <html lang="en">
 <head>
     <meta charset="UTF-8">
@@ -246,12 +241,12 @@ function getImagePreviewHtml(imageUrl: string): string {
  * @returns HTML content as a string
  */
 function getRichLinkPreviewHtml(url: string, ogData: OpenGraphData): string {
-  return `<!DOCTYPE html>
+	return `<!DOCTYPE html>
 <html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>${ogData.title || 'Link Preview'}</title>
+    <title>${ogData.title || "Link Preview"}</title>
     <style>
         body {
             display: flex;
@@ -320,12 +315,12 @@ function getRichLinkPreviewHtml(url: string, ogData: OpenGraphData): string {
 <body>
     <div class="preview-container">
         <div class="preview-header">
-            <div class="preview-title">${ogData.title || 'No title available'}</div>
+            <div class="preview-title">${ogData.title || "No title available"}</div>
             <div class="preview-site">${ogData.siteName || new URL(url).hostname}</div>
             <div class="preview-url">${ogData.url || url}</div>
         </div>
         
-        ${ogData.image ? `<img class="preview-image" src="${ogData.image}" alt="Preview image" />` : ''}
+        ${ogData.image ? `<img class="preview-image" src="${ogData.image}" alt="Preview image" />` : ""}
         
         <div class="preview-description">
             ${ogData.description || '<span class="no-data">No description available</span>'}

--- a/src/integrations/misc/open-image-webview.ts
+++ b/src/integrations/misc/open-image-webview.ts
@@ -1,0 +1,80 @@
+import * as vscode from "vscode"
+
+/**
+ * Opens an image in a VS Code webview panel
+ * @param imageUrl The URL of the image to open
+ * @param title Optional title for the webview panel
+ */
+export function openImageInWebview(imageUrl: string, title: string = "Image Viewer") {
+  // Create and show panel
+  const panel = vscode.window.createWebviewPanel(
+    'imageViewer',
+    title,
+    vscode.ViewColumn.One,
+    {
+      enableScripts: true,
+      retainContextWhenHidden: true
+    }
+  )
+
+  // Set the webview's HTML content
+  panel.webview.html = getWebviewContent(imageUrl)
+}
+
+/**
+ * Generates the HTML content for the webview panel
+ * @param imageUrl The URL of the image to display
+ * @returns HTML content as a string
+ */
+function getWebviewContent(imageUrl: string) {
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Image Viewer</title>
+    <style>
+        body {
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            height: 100vh;
+            margin: 0;
+            padding: 20px;
+            box-sizing: border-box;
+            background-color: var(--vscode-editor-background);
+            color: var(--vscode-editor-foreground);
+            font-family: var(--vscode-font-family);
+        }
+        .image-container {
+            max-width: 100%;
+            max-height: 90vh;
+            overflow: auto;
+            margin-bottom: 10px;
+            text-align: center;
+        }
+        img {
+            max-width: 100%;
+            height: auto;
+            display: block;
+            margin: 0 auto;
+        }
+        .url-display {
+            margin-top: 10px;
+            word-break: break-all;
+            font-size: 12px;
+            color: var(--vscode-descriptionForeground);
+        }
+    </style>
+</head>
+<body>
+    <div class="image-container">
+        <img src="${imageUrl}" alt="Image" />
+    </div>
+    <div class="url-display">
+        Source: ${imageUrl}
+    </div>
+</body>
+</html>`
+}

--- a/src/integrations/misc/open-image-webview.ts
+++ b/src/integrations/misc/open-image-webview.ts
@@ -6,19 +6,14 @@ import * as vscode from "vscode"
  * @param title Optional title for the webview panel
  */
 export function openImageInWebview(imageUrl: string, title: string = "Image Viewer") {
-  // Create and show panel
-  const panel = vscode.window.createWebviewPanel(
-    'imageViewer',
-    title,
-    vscode.ViewColumn.One,
-    {
-      enableScripts: true,
-      retainContextWhenHidden: true
-    }
-  )
+	// Create and show panel
+	const panel = vscode.window.createWebviewPanel("imageViewer", title, vscode.ViewColumn.One, {
+		enableScripts: true,
+		retainContextWhenHidden: true,
+	})
 
-  // Set the webview's HTML content
-  panel.webview.html = getWebviewContent(imageUrl)
+	// Set the webview's HTML content
+	panel.webview.html = getWebviewContent(imageUrl)
 }
 
 /**
@@ -27,7 +22,7 @@ export function openImageInWebview(imageUrl: string, title: string = "Image View
  * @returns HTML content as a string
  */
 function getWebviewContent(imageUrl: string) {
-  return `<!DOCTYPE html>
+	return `<!DOCTYPE html>
 <html lang="en">
 <head>
     <meta charset="UTF-8">

--- a/src/shared/ExtensionMessage.ts
+++ b/src/shared/ExtensionMessage.ts
@@ -30,6 +30,8 @@ export interface ExtensionMessage {
 		| "mcpMarketplaceCatalog"
 		| "mcpDownloadDetails"
 		| "commitSearchResults"
+		| "openGraphData"
+		| "isImageUrlResult"
 	text?: string
 	action?:
 		| "chatButtonClicked"
@@ -54,6 +56,16 @@ export interface ExtensionMessage {
 	error?: string
 	mcpDownloadDetails?: McpDownloadResponse
 	commits?: GitCommit[]
+	openGraphData?: {
+		title?: string
+		description?: string
+		image?: string
+		url?: string
+		siteName?: string
+		type?: string
+	}
+	url?: string
+	isImage?: boolean
 }
 
 export type Platform = "aix" | "darwin" | "freebsd" | "linux" | "openbsd" | "sunos" | "win32" | "unknown"

--- a/src/shared/WebviewMessage.ts
+++ b/src/shared/WebviewMessage.ts
@@ -22,6 +22,7 @@ export interface WebviewMessage {
 		| "requestOllamaModels"
 		| "requestLmStudioModels"
 		| "openImage"
+		| "openImageInWebview"
 		| "openFile"
 		| "openMention"
 		| "cancelTask"

--- a/src/shared/WebviewMessage.ts
+++ b/src/shared/WebviewMessage.ts
@@ -75,7 +75,7 @@ export interface WebviewMessage {
 	serverName?: string
 	toolName?: string
 	autoApprove?: boolean
-	
+
 	// For openInBrowser
 	url?: string
 }

--- a/src/shared/WebviewMessage.ts
+++ b/src/shared/WebviewMessage.ts
@@ -23,6 +23,8 @@ export interface WebviewMessage {
 		| "requestLmStudioModels"
 		| "openImage"
 		| "openImageInWebview"
+		| "openLinkPreview"
+		| "openInBrowser"
 		| "openFile"
 		| "openMention"
 		| "cancelTask"
@@ -52,6 +54,8 @@ export interface WebviewMessage {
 		| "showMcpView"
 		| "fetchLatestMcpServersFromHub"
 		| "updateMcpTimeout"
+		| "fetchOpenGraphData"
+		| "checkIsImageUrl"
 	// | "relaunchChromeDebugMode"
 	text?: string
 	disabled?: boolean
@@ -71,6 +75,9 @@ export interface WebviewMessage {
 	serverName?: string
 	toolName?: string
 	autoApprove?: boolean
+	
+	// For openInBrowser
+	url?: string
 }
 
 export type ClineAskResponse = "yesButtonClicked" | "noButtonClicked" | "messageResponse"

--- a/webview-ui/src/components/chat/ChatRow.tsx
+++ b/webview-ui/src/components/chat/ChatRow.tsx
@@ -25,7 +25,7 @@ import McpResourceRow from "../mcp/McpResourceRow"
 import McpToolRow from "../mcp/McpToolRow"
 import { highlightMentions } from "./TaskHeader"
 import { CheckmarkControl } from "../common/CheckmarkControl"
-import McpResponseExtras from "../mcp/McpResponseExtras"
+import McpResponseDisplay from "../mcp/McpResponseDisplay"
 
 const ChatRowContainer = styled.div`
 	padding: 10px 6px 10px 15px;
@@ -755,30 +755,7 @@ export const ChatRowContent = ({ message, isExpanded, onToggleExpand, lastModifi
 				case "api_req_finished":
 					return null
 				case "mcp_server_response":
-					return (
-						<>
-							<div style={{ paddingTop: 0 }}>
-								<div
-									style={{
-										marginBottom: "4px",
-										opacity: 0.8,
-										fontSize: "12px",
-										textTransform: "uppercase",
-									}}>
-									Response
-								</div>
-								<CodeAccordian
-									code={message.text}
-									language="json"
-									isExpanded={true}
-									onToggleExpand={onToggleExpand}
-								/>
-								<div style={{ marginTop: "10px", padding: "10px", background: "#333" }}>
-									<McpResponseExtras responseText={message.text || ""} />
-								</div>
-							</div>
-						</>
-					)
+					return <McpResponseDisplay responseText={message.text || ""} />
 				case "text":
 					return (
 						<div>

--- a/webview-ui/src/components/mcp/LinkPreview.tsx
+++ b/webview-ui/src/components/mcp/LinkPreview.tsx
@@ -2,186 +2,186 @@ import React, { useEffect, useState } from "react"
 import { vscode } from "../../utils/vscode"
 
 interface OpenGraphData {
-  title?: string
-  description?: string
-  image?: string
-  url?: string
-  siteName?: string
-  type?: string
+	title?: string
+	description?: string
+	image?: string
+	url?: string
+	siteName?: string
+	type?: string
 }
 
 interface LinkPreviewProps {
-  url: string
+	url: string
 }
 
 const LinkPreview: React.FC<LinkPreviewProps> = ({ url }) => {
-  const [loading, setLoading] = useState(true)
-  const [error, setError] = useState<string | null>(null)
-  const [ogData, setOgData] = useState<OpenGraphData | null>(null)
-  
-  useEffect(() => {
-    const fetchOpenGraphData = async () => {
-      try {
-        setLoading(true)
-        
-        // Send a message to the extension to fetch Open Graph data
-        vscode.postMessage({
-          type: "fetchOpenGraphData",
-          text: url
-        })
-        
-        // Set up a listener for the response
-        const messageListener = (event: MessageEvent) => {
-          const message = event.data
-          if (message.type === "openGraphData" && message.url === url) {
-            setOgData(message.openGraphData)
-            setLoading(false)
-            window.removeEventListener('message', messageListener)
-          }
-        }
-        
-        window.addEventListener('message', messageListener)
-        
-        // Clean up the listener if the component unmounts
-        return () => {
-          window.removeEventListener('message', messageListener)
-        }
-      } catch (err) {
-        setError("Failed to fetch preview data")
-        setLoading(false)
-      }
-    }
-    
-    // Fetch Open Graph data immediately when component mounts
-    fetchOpenGraphData()
-  }, [url])
-  
-  // Fallback display while loading
-  if (loading) {
-    return (
-      <div className="link-preview-loading" style={{ 
-        padding: "12px", 
-        display: "flex", 
-        alignItems: "center", 
-        justifyContent: "center",
-        border: "1px solid var(--vscode-editorWidget-border, rgba(127, 127, 127, 0.3))",
-        borderRadius: "4px",
-      }}>
-        <div className="loading-spinner" style={{ 
-          marginRight: "8px", 
-          width: "16px", 
-          height: "16px", 
-          border: "2px solid rgba(127, 127, 127, 0.3)",
-          borderTopColor: "var(--vscode-textLink-foreground, #3794ff)",
-          borderRadius: "50%",
-          animation: "spin 1s linear infinite"
-        }} />
-        <style>
-          {`
+	const [loading, setLoading] = useState(true)
+	const [error, setError] = useState<string | null>(null)
+	const [ogData, setOgData] = useState<OpenGraphData | null>(null)
+
+	useEffect(() => {
+		const fetchOpenGraphData = async () => {
+			try {
+				setLoading(true)
+
+				// Send a message to the extension to fetch Open Graph data
+				vscode.postMessage({
+					type: "fetchOpenGraphData",
+					text: url,
+				})
+
+				// Set up a listener for the response
+				const messageListener = (event: MessageEvent) => {
+					const message = event.data
+					if (message.type === "openGraphData" && message.url === url) {
+						setOgData(message.openGraphData)
+						setLoading(false)
+						window.removeEventListener("message", messageListener)
+					}
+				}
+
+				window.addEventListener("message", messageListener)
+
+				// Clean up the listener if the component unmounts
+				return () => {
+					window.removeEventListener("message", messageListener)
+				}
+			} catch (err) {
+				setError("Failed to fetch preview data")
+				setLoading(false)
+			}
+		}
+
+		// Fetch Open Graph data immediately when component mounts
+		fetchOpenGraphData()
+	}, [url])
+
+	// Fallback display while loading
+	if (loading) {
+		return (
+			<div
+				className="link-preview-loading"
+				style={{
+					padding: "12px",
+					display: "flex",
+					alignItems: "center",
+					justifyContent: "center",
+					border: "1px solid var(--vscode-editorWidget-border, rgba(127, 127, 127, 0.3))",
+					borderRadius: "4px",
+				}}>
+				<div
+					className="loading-spinner"
+					style={{
+						marginRight: "8px",
+						width: "16px",
+						height: "16px",
+						border: "2px solid rgba(127, 127, 127, 0.3)",
+						borderTopColor: "var(--vscode-textLink-foreground, #3794ff)",
+						borderRadius: "50%",
+						animation: "spin 1s linear infinite",
+					}}
+				/>
+				<style>
+					{`
             @keyframes spin {
               to { transform: rotate(360deg); }
             }
           `}
-        </style>
-        Loading preview for {new URL(url).hostname}...
-      </div>
-    )
-  }
-  
-  // Create a fallback object if ogData is null
-  const data = ogData || {
-    title: new URL(url).hostname,
-    description: "No description available",
-    siteName: new URL(url).hostname,
-    url: url
-  }
-  
-  // Render the Open Graph preview
-  return (
-    <div 
-      className="link-preview"
-      style={{
-        display: "flex",
-        border: "1px solid var(--vscode-editorWidget-border, rgba(127, 127, 127, 0.3))",
-        borderRadius: "4px",
-        overflow: "hidden",
-        cursor: "pointer"
-      }}
-      onClick={() => {
-        vscode.postMessage({ 
-          type: "openInBrowser", 
-          url: url 
-        })
-      }}
-    >
-      {data.image && (
-        <div className="link-preview-image" style={{ width: "128px", height: "128px", flexShrink: 0 }}>
-          <img 
-            src={data.image} 
-            alt=""
-            style={{ 
-              width: "100%", 
-              height: "100%", 
-              objectFit: "cover" 
-            }} 
-          />
-        </div>
-      )}
-      
-      <div 
-        className="link-preview-content" 
-        style={{ 
-          flex: 1, 
-          padding: "12px",
-          display: "flex",
-          flexDirection: "column",
-          overflow: "hidden"
-        }}
-      >
-        <div 
-          className="link-preview-title" 
-          style={{ 
-            fontWeight: "bold", 
-            marginBottom: "4px",
-            whiteSpace: "nowrap",
-            overflow: "hidden",
-            textOverflow: "ellipsis"
-          }}
-        >
-          {data.title || "No title"}
-        </div>
-        
-        <div 
-          className="link-preview-url" 
-          style={{ 
-            fontSize: "12px", 
-            color: "var(--vscode-textLink-foreground, #3794ff)",
-            marginBottom: "8px",
-            whiteSpace: "nowrap",
-            overflow: "hidden",
-            textOverflow: "ellipsis"
-          }}
-        >
-          {data.siteName || new URL(url).hostname}
-        </div>
-        
-        <div 
-          className="link-preview-description" 
-          style={{ 
-            fontSize: "12px",
-            color: "var(--vscode-descriptionForeground, rgba(204, 204, 204, 0.7))",
-            overflow: "hidden",
-            display: "-webkit-box",
-            WebkitLineClamp: 3,
-            WebkitBoxOrient: "vertical",
-            textOverflow: "ellipsis"
-          }}
-        >
-          {data.description || "No description available"}
-        </div>
-      </div>
-    </div>
-  )
+				</style>
+				Loading preview for {new URL(url).hostname}...
+			</div>
+		)
+	}
+
+	// Create a fallback object if ogData is null
+	const data = ogData || {
+		title: new URL(url).hostname,
+		description: "No description available",
+		siteName: new URL(url).hostname,
+		url: url,
+	}
+
+	// Render the Open Graph preview
+	return (
+		<div
+			className="link-preview"
+			style={{
+				display: "flex",
+				border: "1px solid var(--vscode-editorWidget-border, rgba(127, 127, 127, 0.3))",
+				borderRadius: "4px",
+				overflow: "hidden",
+				cursor: "pointer",
+			}}
+			onClick={() => {
+				vscode.postMessage({
+					type: "openInBrowser",
+					url: url,
+				})
+			}}>
+			{data.image && (
+				<div className="link-preview-image" style={{ width: "128px", height: "128px", flexShrink: 0 }}>
+					<img
+						src={data.image}
+						alt=""
+						style={{
+							width: "100%",
+							height: "100%",
+							objectFit: "cover",
+						}}
+					/>
+				</div>
+			)}
+
+			<div
+				className="link-preview-content"
+				style={{
+					flex: 1,
+					padding: "12px",
+					display: "flex",
+					flexDirection: "column",
+					overflow: "hidden",
+				}}>
+				<div
+					className="link-preview-title"
+					style={{
+						fontWeight: "bold",
+						marginBottom: "4px",
+						whiteSpace: "nowrap",
+						overflow: "hidden",
+						textOverflow: "ellipsis",
+					}}>
+					{data.title || "No title"}
+				</div>
+
+				<div
+					className="link-preview-url"
+					style={{
+						fontSize: "12px",
+						color: "var(--vscode-textLink-foreground, #3794ff)",
+						marginBottom: "8px",
+						whiteSpace: "nowrap",
+						overflow: "hidden",
+						textOverflow: "ellipsis",
+					}}>
+					{data.siteName || new URL(url).hostname}
+				</div>
+
+				<div
+					className="link-preview-description"
+					style={{
+						fontSize: "12px",
+						color: "var(--vscode-descriptionForeground, rgba(204, 204, 204, 0.7))",
+						overflow: "hidden",
+						display: "-webkit-box",
+						WebkitLineClamp: 3,
+						WebkitBoxOrient: "vertical",
+						textOverflow: "ellipsis",
+					}}>
+					{data.description || "No description available"}
+				</div>
+			</div>
+		</div>
+	)
 }
 
 export default LinkPreview

--- a/webview-ui/src/components/mcp/LinkPreview.tsx
+++ b/webview-ui/src/components/mcp/LinkPreview.tsx
@@ -1,0 +1,187 @@
+import React, { useEffect, useState } from "react"
+import { vscode } from "../../utils/vscode"
+
+interface OpenGraphData {
+  title?: string
+  description?: string
+  image?: string
+  url?: string
+  siteName?: string
+  type?: string
+}
+
+interface LinkPreviewProps {
+  url: string
+}
+
+const LinkPreview: React.FC<LinkPreviewProps> = ({ url }) => {
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [ogData, setOgData] = useState<OpenGraphData | null>(null)
+  
+  useEffect(() => {
+    const fetchOpenGraphData = async () => {
+      try {
+        setLoading(true)
+        
+        // Send a message to the extension to fetch Open Graph data
+        vscode.postMessage({
+          type: "fetchOpenGraphData",
+          text: url
+        })
+        
+        // Set up a listener for the response
+        const messageListener = (event: MessageEvent) => {
+          const message = event.data
+          if (message.type === "openGraphData" && message.url === url) {
+            setOgData(message.openGraphData)
+            setLoading(false)
+            window.removeEventListener('message', messageListener)
+          }
+        }
+        
+        window.addEventListener('message', messageListener)
+        
+        // Clean up the listener if the component unmounts
+        return () => {
+          window.removeEventListener('message', messageListener)
+        }
+      } catch (err) {
+        setError("Failed to fetch preview data")
+        setLoading(false)
+      }
+    }
+    
+    // Fetch Open Graph data immediately when component mounts
+    fetchOpenGraphData()
+  }, [url])
+  
+  // Fallback display while loading
+  if (loading) {
+    return (
+      <div className="link-preview-loading" style={{ 
+        padding: "12px", 
+        display: "flex", 
+        alignItems: "center", 
+        justifyContent: "center",
+        border: "1px solid var(--vscode-editorWidget-border, rgba(127, 127, 127, 0.3))",
+        borderRadius: "4px",
+      }}>
+        <div className="loading-spinner" style={{ 
+          marginRight: "8px", 
+          width: "16px", 
+          height: "16px", 
+          border: "2px solid rgba(127, 127, 127, 0.3)",
+          borderTopColor: "var(--vscode-textLink-foreground, #3794ff)",
+          borderRadius: "50%",
+          animation: "spin 1s linear infinite"
+        }} />
+        <style>
+          {`
+            @keyframes spin {
+              to { transform: rotate(360deg); }
+            }
+          `}
+        </style>
+        Loading preview for {new URL(url).hostname}...
+      </div>
+    )
+  }
+  
+  // Create a fallback object if ogData is null
+  const data = ogData || {
+    title: new URL(url).hostname,
+    description: "No description available",
+    siteName: new URL(url).hostname,
+    url: url
+  }
+  
+  // Render the Open Graph preview
+  return (
+    <div 
+      className="link-preview"
+      style={{
+        display: "flex",
+        border: "1px solid var(--vscode-editorWidget-border, rgba(127, 127, 127, 0.3))",
+        borderRadius: "4px",
+        overflow: "hidden",
+        cursor: "pointer"
+      }}
+      onClick={() => {
+        vscode.postMessage({ 
+          type: "openInBrowser", 
+          url: url 
+        })
+      }}
+    >
+      {data.image && (
+        <div className="link-preview-image" style={{ width: "128px", height: "128px", flexShrink: 0 }}>
+          <img 
+            src={data.image} 
+            alt=""
+            style={{ 
+              width: "100%", 
+              height: "100%", 
+              objectFit: "cover" 
+            }} 
+          />
+        </div>
+      )}
+      
+      <div 
+        className="link-preview-content" 
+        style={{ 
+          flex: 1, 
+          padding: "12px",
+          display: "flex",
+          flexDirection: "column",
+          overflow: "hidden"
+        }}
+      >
+        <div 
+          className="link-preview-title" 
+          style={{ 
+            fontWeight: "bold", 
+            marginBottom: "4px",
+            whiteSpace: "nowrap",
+            overflow: "hidden",
+            textOverflow: "ellipsis"
+          }}
+        >
+          {data.title || "No title"}
+        </div>
+        
+        <div 
+          className="link-preview-url" 
+          style={{ 
+            fontSize: "12px", 
+            color: "var(--vscode-textLink-foreground, #3794ff)",
+            marginBottom: "8px",
+            whiteSpace: "nowrap",
+            overflow: "hidden",
+            textOverflow: "ellipsis"
+          }}
+        >
+          {data.siteName || new URL(url).hostname}
+        </div>
+        
+        <div 
+          className="link-preview-description" 
+          style={{ 
+            fontSize: "12px",
+            color: "var(--vscode-descriptionForeground, rgba(204, 204, 204, 0.7))",
+            overflow: "hidden",
+            display: "-webkit-box",
+            WebkitLineClamp: 3,
+            WebkitBoxOrient: "vertical",
+            textOverflow: "ellipsis"
+          }}
+        >
+          {data.description || "No description available"}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default LinkPreview

--- a/webview-ui/src/components/mcp/McpResponseDisplay.tsx
+++ b/webview-ui/src/components/mcp/McpResponseDisplay.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState, useCallback } from "react"
 import { vscode } from "../../utils/vscode"
 import LinkPreview from "./LinkPreview"
 import styled from "styled-components"
+import { CODE_BLOCK_BG_COLOR } from "../common/CodeBlock"
 
 // We'll use the backend isImageUrl function for HEAD requests
 // This is a client-side fallback for data URLs and obvious image extensions
@@ -176,14 +177,23 @@ const ResponseHeader = styled.div`
 	display: flex;
 	justify-content: space-between;
 	align-items: center;
-	padding: 8px;
-	border-bottom: 1px dashed var(--vscode-editorGroup-border, rgba(127, 127, 127, 0.3));
+	padding: 9px 10px;
+	color: var(--vscode-descriptionForeground);
+	cursor: pointer;
+	user-select: none;
+	WebkitUserSelect: none;
+	MozUserSelect: none;
+	msUserSelect: none;
+	border-bottom: 1px dashed var(--vscode-editorGroup-border);
 	margin-bottom: 8px;
 	
 	.header-title {
-		font-size: 12px;
-		text-transform: uppercase;
-		opacity: 0.8;
+		display: flex;
+		align-items: center;
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		margin-right: 8px;
 	}
 `
 
@@ -231,12 +241,17 @@ const ResponseContainer = styled.div`
 	position: relative;
 	font-family: var(--vscode-editor-font-family, monospace);
 	font-size: var(--vscode-editor-font-size, 12px);
-	background-color: var(--vscode-textCodeBlock-background, #1e1e1e);
+	background-color: ${CODE_BLOCK_BG_COLOR};
 	color: var(--vscode-editor-foreground, #d4d4d4);
 	border-radius: 3px;
+	border: 1px solid var(--vscode-editorGroup-border);
+	overflow: hidden;
 	
 	.response-content {
-		padding: 0 10px 10px 10px;
+		padding: 10px;
+		overflow-x: auto;
+		overflow-y: hidden;
+		max-width: 100%;
 	}
 `
 
@@ -381,7 +396,7 @@ const McpResponseDisplay: React.FC<McpResponseDisplayProps> = ({ responseText })
 									src={url}
 									alt={`Image for ${url}`}
 									style={{
-										width: "75%",
+										width: "85%",
 										height: "auto",
 										borderRadius: "4px",
 										cursor: "pointer"

--- a/webview-ui/src/components/mcp/McpResponseDisplay.tsx
+++ b/webview-ui/src/components/mcp/McpResponseDisplay.tsx
@@ -172,15 +172,26 @@ export const extractUrlsFromText = async (text: string): Promise<{ imageUrls: st
 	return { imageUrls, regularUrls }
 }
 
+const ResponseHeader = styled.div`
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	padding: 8px;
+	border-bottom: 1px dashed var(--vscode-editorGroup-border, rgba(127, 127, 127, 0.3));
+	margin-bottom: 8px;
+	
+	.header-title {
+		font-size: 12px;
+		text-transform: uppercase;
+		opacity: 0.8;
+	}
+`
+
 const ToggleSwitch = styled.div`
-	position: absolute;
-	top: 0;
-	right: 0;
 	display: flex;
 	align-items: center;
 	font-size: 12px;
 	color: var(--vscode-descriptionForeground);
-	margin-bottom: 10px;
 	
 	.toggle-label {
 		margin-right: 8px;
@@ -218,13 +229,15 @@ const ToggleSwitch = styled.div`
 
 const ResponseContainer = styled.div`
 	position: relative;
-	padding-top: 24px;
 	font-family: var(--vscode-editor-font-family, monospace);
 	font-size: var(--vscode-editor-font-size, 12px);
 	background-color: var(--vscode-textCodeBlock-background, #1e1e1e);
 	color: var(--vscode-editor-foreground, #d4d4d4);
 	border-radius: 3px;
-	padding: 10px;
+	
+	.response-content {
+		padding: 0 10px 10px 10px;
+	}
 `
 
 // Style for URL text to ensure proper wrapping
@@ -273,13 +286,10 @@ const McpResponseDisplay: React.FC<McpResponseDisplayProps> = ({ responseText })
 				const text = responseText || ""
 				const matches: UrlMatch[] = []
 				
-				// Find all URLs in the text (including at the end of the text)
-				// Add the text to a space at the end to ensure we catch URLs at the very end
-				const textWithSpace = text + " "
 				const urlRegex = /https?:\/\/[^\s]+/g
 				let urlMatch: RegExpExecArray | null
 				
-				while ((urlMatch = urlRegex.exec(textWithSpace)) !== null) {
+				while ((urlMatch = urlRegex.exec(text)) !== null) {
 					const url = urlMatch[0]
 					const fullMatch = url
 					
@@ -421,29 +431,39 @@ const McpResponseDisplay: React.FC<McpResponseDisplayProps> = ({ responseText })
 	try {
 		return (
 			<ResponseContainer>
-				<ToggleSwitch>
-					<span className="toggle-label">
-						{displayMode === 'rich' ? 'Rich Display' : 'Plain Text'}
-					</span>
-					<div 
-						className={`toggle-container ${displayMode === 'rich' ? 'active' : ''}`}
-						onClick={toggleDisplayMode}
-					>
-						<div className="toggle-handle"></div>
-					</div>
-				</ToggleSwitch>
+				<ResponseHeader>
+					<span className="header-title">Response</span>
+					<ToggleSwitch>
+						<span className="toggle-label">
+							{displayMode === 'rich' ? 'Rich Display' : 'Plain Text'}
+						</span>
+						<div 
+							className={`toggle-container ${displayMode === 'rich' ? 'active' : ''}`}
+							onClick={toggleDisplayMode}
+						>
+							<div className="toggle-handle"></div>
+						</div>
+					</ToggleSwitch>
+				</ResponseHeader>
 				
-				{renderContent()}
+				<div className="response-content">
+					{renderContent()}
+				</div>
 			</ResponseContainer>
 		)
 	} catch (error) {
 		console.error('Error parsing MCP response:', error);
 		return (
 			<ResponseContainer>
-				<div>Error parsing response:</div>
-				<UrlText>
-					{responseText}
-				</UrlText>
+				<ResponseHeader>
+					<span className="header-title">Response</span>
+				</ResponseHeader>
+				<div className="response-content">
+					<div>Error parsing response:</div>
+					<UrlText>
+						{responseText}
+					</UrlText>
+				</div>
 			</ResponseContainer>
 		)
 	}

--- a/webview-ui/src/components/mcp/McpResponseDisplay.tsx
+++ b/webview-ui/src/components/mcp/McpResponseDisplay.tsx
@@ -273,11 +273,13 @@ const McpResponseDisplay: React.FC<McpResponseDisplayProps> = ({ responseText })
 				const text = responseText || ""
 				const matches: UrlMatch[] = []
 				
-				// Find all URLs in the text
+				// Find all URLs in the text (including at the end of the text)
+				// Add the text to a space at the end to ensure we catch URLs at the very end
+				const textWithSpace = text + " "
 				const urlRegex = /https?:\/\/[^\s]+/g
 				let urlMatch: RegExpExecArray | null
 				
-				while ((urlMatch = urlRegex.exec(text)) !== null) {
+				while ((urlMatch = urlRegex.exec(textWithSpace)) !== null) {
 					const url = urlMatch[0]
 					const fullMatch = url
 					
@@ -369,7 +371,7 @@ const McpResponseDisplay: React.FC<McpResponseDisplayProps> = ({ responseText })
 									src={url}
 									alt={`Image for ${url}`}
 									style={{
-										width: "100%",
+										width: "75%",
 										height: "auto",
 										borderRadius: "4px",
 										cursor: "pointer"

--- a/webview-ui/src/components/mcp/McpResponseDisplay.tsx
+++ b/webview-ui/src/components/mcp/McpResponseDisplay.tsx
@@ -338,17 +338,13 @@ const McpResponseDisplay: React.FC<McpResponseDisplayProps> = ({ responseText })
 	
 	// Function to render content based on display mode
 	const renderContent = () => {
-		if (isLoading) {
-			return <div>Analyzing response content...</div>
-		}
-		
 		// For plain text mode, just show the text
-		if (displayMode === 'plain') {
+		if (displayMode === 'plain' || isLoading) {
 			return <UrlText>{responseText}</UrlText>
 		}
 		
 		// For rich display mode, show the text with embedded content
-		if (displayMode === 'rich') {
+		if (displayMode === 'rich' && !isLoading) {
 			// Create an array of text segments and embedded content
 			const segments: JSX.Element[] = []
 			let lastIndex = 0

--- a/webview-ui/src/components/mcp/McpResponseExtras.tsx
+++ b/webview-ui/src/components/mcp/McpResponseExtras.tsx
@@ -1,17 +1,76 @@
-import React from "react"
+import React, { useEffect, useState } from "react"
 import { vscode } from "../../utils/vscode"
+import LinkPreview from "./LinkPreview"
 
-// Image detection utilities
-export const isImageUrl = (str: string): boolean => {
+// We'll use the backend isImageUrl function for HEAD requests
+// This is a client-side fallback for data URLs and obvious image extensions
+const isImageUrlSync = (str: string): boolean => {
 	// Remove "image:" prefix if present
 	const cleanStr = str.replace(/^image:\s*/, '')
-	return cleanStr.match(/\.(jpg|jpeg|png|gif|webp)$/i) !== null || 
-		cleanStr.startsWith('data:image/') ||
-		(cleanStr.includes('wolframalpha.com') && cleanStr.includes('MSPStoreType=image'))
+	
+	// Check for data URLs which are definitely images
+	if (cleanStr.startsWith('data:image/')) {
+		return true
+	}
+	
+	// Check for common image file extensions
+	return cleanStr.match(/\.(jpg|jpeg|png|gif|webp)$/i) !== null
+}
+
+export const isUrl = (str: string): boolean => {
+	// Basic URL validation
+	const urlPattern = /^(https?:\/\/)?([a-zA-Z0-9-]+\.)+[a-zA-Z]{2,}(\/[^\s]*)?$/
+	return urlPattern.test(str)
+}
+
+// Function to check if a URL is an image using HEAD request
+export const checkIfImageUrl = async (url: string): Promise<boolean> => {
+	// For data URLs, we can check synchronously
+	if (url.startsWith('data:image/')) {
+		return true
+	}
+	
+	// For http/https URLs, we need to send a message to the extension
+	if (url.startsWith('http')) {
+		try {
+			// Create a promise that will resolve when we get a response
+			return new Promise((resolve) => {
+				// Set up a one-time listener for the response
+				const messageListener = (event: MessageEvent) => {
+					const message = event.data
+					if (message.type === "isImageUrlResult" && message.url === url) {
+						window.removeEventListener('message', messageListener)
+						resolve(message.isImage)
+					}
+				}
+				
+				window.addEventListener('message', messageListener)
+				
+				// Send the request to the extension
+				vscode.postMessage({
+					type: "checkIsImageUrl",
+					text: url
+				})
+				
+				// Set a timeout to avoid hanging indefinitely
+				setTimeout(() => {
+					window.removeEventListener('message', messageListener)
+					// Fall back to extension check
+					resolve(isImageUrlSync(url))
+				}, 3000)
+			})
+		} catch (error) {
+			console.error("Error checking if URL is an image:", error)
+			return isImageUrlSync(url)
+		}
+	}
+	
+	// Fall back to extension check for other URLs
+	return isImageUrlSync(url)
 }
 
 export const cleanUrl = (str: string): string => {
-	return str.replace(/^image:\s*/, '')
+	return str.replace(/^image:\s*/, '').replace(/^url:\s*/, '')
 }
 
 // Helper to ensure URL is in a format that can be opened
@@ -29,18 +88,88 @@ export const formatUrlForOpening = (url: string): string => {
 	return url
 }
 
-export const findImageUrls = (obj: any): string[] => {
-	const urls: string[] = []
+// Find all URLs (both image and regular) in an object
+export const findUrls = async (obj: any): Promise<{ imageUrls: string[], regularUrls: string[] }> => {
+	const imageUrls: string[] = []
+	const regularUrls: string[] = []
+	const pendingChecks: Promise<void>[] = []
+	
 	if (typeof obj === 'object' && obj !== null) {
-		Object.values(obj).forEach(value => {
-			if (typeof value === 'string' && isImageUrl(value)) {
-				urls.push(cleanUrl(value))
+		for (const value of Object.values(obj)) {
+			if (typeof value === 'string') {
+				const cleanedValue = cleanUrl(value)
+				
+				// First check with synchronous method
+				if (isImageUrlSync(value)) {
+					imageUrls.push(cleanedValue)
+				} else if (isUrl(cleanedValue)) {
+					// For URLs that don't obviously look like images, we'll check asynchronously
+					const checkPromise = checkIfImageUrl(cleanedValue).then(isImage => {
+						if (isImage) {
+							imageUrls.push(cleanedValue)
+						} else {
+							regularUrls.push(cleanedValue)
+						}
+					})
+					pendingChecks.push(checkPromise)
+				}
 			} else if (typeof value === 'object') {
-				urls.push(...findImageUrls(value))
+				const nestedUrlsPromise = findUrls(value).then(nestedUrls => {
+					imageUrls.push(...nestedUrls.imageUrls)
+					regularUrls.push(...nestedUrls.regularUrls)
+				})
+				pendingChecks.push(nestedUrlsPromise)
 			}
-		})
+		}
 	}
-	return urls
+	
+	// Wait for all async checks to complete
+	await Promise.all(pendingChecks)
+	
+	return { imageUrls, regularUrls }
+}
+
+// Extract URLs from text using regex
+export const extractUrlsFromText = async (text: string): Promise<{ imageUrls: string[], regularUrls: string[] }> => {
+	const imageUrls: string[] = []
+	const regularUrls: string[] = []
+	const pendingChecks: Promise<void>[] = []
+	
+	// Match image URLs (explicitly marked with image: prefix)
+	const imageMatches = text.match(/image:\s*(https?:\/\/[^\s]+)/g)
+	if (imageMatches) {
+		imageUrls.push(...imageMatches.map(match => match.replace(/^image:\s*/, '')))
+	}
+	
+	// Match regular URLs
+	const urlMatches = text.match(/https?:\/\/[^\s]+/g)
+	if (urlMatches) {
+		// Filter out URLs that are already in imageUrls
+		const filteredUrls = urlMatches.filter(url => !imageUrls.includes(url))
+		
+		// Check each URL to see if it's an image
+		for (const url of filteredUrls) {
+			// First check with synchronous method
+			if (isImageUrlSync(url)) {
+				imageUrls.push(url)
+			} else {
+				// For URLs that don't obviously look like images, we'll check asynchronously
+				const checkPromise = checkIfImageUrl(url).then(isImage => {
+					if (isImage) {
+						imageUrls.push(url)
+					} else {
+						regularUrls.push(url)
+					}
+				})
+				pendingChecks.push(checkPromise)
+			}
+		}
+	}
+	
+	// Wait for all async checks to complete
+	await Promise.all(pendingChecks)
+	
+	return { imageUrls, regularUrls }
 }
 
 interface McpResponseExtrasProps {
@@ -48,55 +177,94 @@ interface McpResponseExtrasProps {
 }
 
 const McpResponseExtras: React.FC<McpResponseExtrasProps> = ({ responseText }) => {
-	try {
-		let imageUrls: string[] = []
-		const text = responseText || ""
-		
-		// First try parsing as JSON
-		try {
-			const jsonResponse = JSON.parse(text)
-			imageUrls = findImageUrls(jsonResponse)
-		} catch {
-			// If not JSON, try parsing as formatted text
-			const matches = text.match(/image:\s*(https?:\/\/[^\s]+)/g)
-			if (matches) {
-				imageUrls = matches.map(match => match.replace(/^image:\s*/, ''))
+	const [imageUrls, setImageUrls] = useState<string[]>([])
+	const [regularUrls, setRegularUrls] = useState<string[]>([])
+	const [isLoading, setIsLoading] = useState(true)
+	
+	useEffect(() => {
+		const processResponse = async () => {
+			setIsLoading(true)
+			try {
+				let foundImageUrls: string[] = []
+				let foundRegularUrls: string[] = []
+				const text = responseText || ""
+				
+				// First try parsing as JSON
+				try {
+					const jsonResponse = JSON.parse(text)
+					const urls = await findUrls(jsonResponse)
+					foundImageUrls = urls.imageUrls
+					foundRegularUrls = urls.regularUrls
+				} catch {
+					// If not JSON, try parsing as formatted text
+					const urls = await extractUrlsFromText(text)
+					foundImageUrls = urls.imageUrls
+					foundRegularUrls = urls.regularUrls
+				}
+				
+				setImageUrls(foundImageUrls)
+				setRegularUrls(foundRegularUrls)
+			} catch (error) {
+				console.error('Error processing MCP response:', error)
+			} finally {
+				setIsLoading(false)
 			}
 		}
 		
-		return imageUrls.length > 0 ? (
+		processResponse()
+	}, [responseText])
+		
+	if (isLoading) {
+		return <div>Analyzing response content...</div>
+	}
+	
+	const hasContent = imageUrls.length > 0 || regularUrls.length > 0
+	
+	try {
+		return hasContent ? (
 			<>
-				<div>Found {imageUrls.length} image{imageUrls.length !== 1 ? 's' : ''} in response:</div>
-				<div style={{ display: "flex", gap: "10px", flexWrap: "wrap", marginTop: "10px" }}>
-					{imageUrls.map((url, index) => (
-						<img 
-							key={`response-${index}`}
-							src={url}
-							alt={`Response ${index + 1}`}
-							className="embed"
+				{imageUrls.length > 0 && (
+					<>
+						<div>Found {imageUrls.length} image{imageUrls.length !== 1 ? 's' : ''} in response:</div>
+						<div style={{ display: "flex", gap: "10px", flexWrap: "wrap", marginTop: "10px", marginBottom: "20px" }}>
+							{imageUrls.map((url, index) => (
+								<img 
+									key={`image-${index}`}
+									src={url}
+									alt={`Image ${index + 1}`}
+									className="embed"
 							style={{
 								width: "100%",
 								height: "auto",
 								borderRadius: "4px",
 								cursor: "pointer"
 							}}
-							onClick={() => {
-								// For data URIs, use openImage
-								if (url.startsWith('data:image/')) {
-									vscode.postMessage({ type: "openImage", text: url })
-								} else {
-									// For regular URLs, open in a webview panel
-									vscode.postMessage({ 
-										type: "openImageInWebview", 
-										text: url 
-									})
-								}
-							}}
-						/>
-					))}
-				</div>
+									onClick={() => {
+										// Open images directly in the browser
+										const formattedUrl = formatUrlForOpening(url)
+										vscode.postMessage({ 
+											type: "openInBrowser", 
+											url: formattedUrl 
+										})
+									}}
+								/>
+							))}
+						</div>
+					</>
+				)}
+				
+				{regularUrls.length > 0 && (
+					<>
+						<div>Found {regularUrls.length} link{regularUrls.length !== 1 ? 's' : ''} in response:</div>
+						<div style={{ marginTop: "10px", display: "flex", flexDirection: "column", gap: "16px" }}>
+							{regularUrls.map((url, index) => (
+								<LinkPreview key={`link-${index}`} url={formatUrlForOpening(url)} />
+							))}
+						</div>
+					</>
+				)}
 			</>
-		) : <div>No images found in response</div>
+		) : <div>No links or images found in response</div>
 	} catch (error) {
 		console.error('Error parsing MCP response:', error);
 		return (

--- a/webview-ui/src/components/mcp/McpResponseExtras.tsx
+++ b/webview-ui/src/components/mcp/McpResponseExtras.tsx
@@ -1,0 +1,118 @@
+import React from "react"
+import { vscode } from "../../utils/vscode"
+
+// Image detection utilities
+export const isImageUrl = (str: string): boolean => {
+	// Remove "image:" prefix if present
+	const cleanStr = str.replace(/^image:\s*/, '')
+	return cleanStr.match(/\.(jpg|jpeg|png|gif|webp)$/i) !== null || 
+		cleanStr.startsWith('data:image/') ||
+		(cleanStr.includes('wolframalpha.com') && cleanStr.includes('MSPStoreType=image'))
+}
+
+export const cleanUrl = (str: string): string => {
+	return str.replace(/^image:\s*/, '')
+}
+
+// Helper to ensure URL is in a format that can be opened
+export const formatUrlForOpening = (url: string): string => {
+	// If it's a data URI, return as is
+	if (url.startsWith('data:image/')) {
+		return url
+	}
+	
+	// If it's a regular URL but doesn't have a protocol, add https://
+	if (!url.startsWith('http://') && !url.startsWith('https://')) {
+		return `https://${url}`
+	}
+	
+	return url
+}
+
+export const findImageUrls = (obj: any): string[] => {
+	const urls: string[] = []
+	if (typeof obj === 'object' && obj !== null) {
+		Object.values(obj).forEach(value => {
+			if (typeof value === 'string' && isImageUrl(value)) {
+				urls.push(cleanUrl(value))
+			} else if (typeof value === 'object') {
+				urls.push(...findImageUrls(value))
+			}
+		})
+	}
+	return urls
+}
+
+interface McpResponseExtrasProps {
+	responseText: string
+}
+
+const McpResponseExtras: React.FC<McpResponseExtrasProps> = ({ responseText }) => {
+	try {
+		let imageUrls: string[] = []
+		const text = responseText || ""
+		
+		// First try parsing as JSON
+		try {
+			const jsonResponse = JSON.parse(text)
+			imageUrls = findImageUrls(jsonResponse)
+		} catch {
+			// If not JSON, try parsing as formatted text
+			const matches = text.match(/image:\s*(https?:\/\/[^\s]+)/g)
+			if (matches) {
+				imageUrls = matches.map(match => match.replace(/^image:\s*/, ''))
+			}
+		}
+		
+		return imageUrls.length > 0 ? (
+			<>
+				<div>Found {imageUrls.length} image{imageUrls.length !== 1 ? 's' : ''} in response:</div>
+				<div style={{ display: "flex", gap: "10px", flexWrap: "wrap", marginTop: "10px" }}>
+					{imageUrls.map((url, index) => (
+						<img 
+							key={`response-${index}`}
+							src={url}
+							alt={`Response ${index + 1}`}
+							className="embed"
+							style={{
+								width: "100%",
+								height: "auto",
+								borderRadius: "4px",
+								cursor: "pointer"
+							}}
+							onClick={() => {
+								// For data URIs, use openImage
+								if (url.startsWith('data:image/')) {
+									vscode.postMessage({ type: "openImage", text: url })
+								} else {
+									// For regular URLs, open in a webview panel
+									vscode.postMessage({ 
+										type: "openImageInWebview", 
+										text: url 
+									})
+								}
+							}}
+						/>
+					))}
+				</div>
+			</>
+		) : <div>No images found in response</div>
+	} catch (error) {
+		console.error('Error parsing MCP response:', error);
+		return (
+			<div>
+				<div>Error parsing response:</div>
+				<div style={{ 
+					fontFamily: "monospace",
+					fontSize: "12px",
+					marginTop: "5px",
+					opacity: 0.7
+				}}>
+					{responseText}
+				</div>
+			</div>
+		)
+	}
+}
+
+export default McpResponseExtras


### PR DESCRIPTION
### Description

This PR enhances the MCP (Model Context Protocol) response display with a rich content viewer that provides a more polished user experience. The implementation provides the McpResponseDisplay

#### Key improvements include:

- If we detect an image link (by sending a HEAD request and checking content type), display a clickable preview inline
- If we detect a web URL, we use the Open Graph standard to display an embed
- Toggle functionality between rich and plain text display modes

#### Test Procedure

- Getting various MCP replies with different types of content (plain text, URLs, images). Particularly the WolframAlpha MCP tools are useful for getting interesting responses
- Verifying the component renders correctly with the updated styling
- Confirming the toggle between rich and plain text modes works properly
- Verifying URL detection and preview functionality works as expected
- The changes are isolated to the styling and rendering logic of the McpResponseDisplay component, minimizing the risk of introducing bugs

### Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update

### Pre-flight Checklist

- [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
- [x] Tests are passing (npm test) and code is formatted and linted (npm run format && npm run lint)
- [x] I have created a changeset using npm run changeset (required for user-facing changes)
- [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

![Screenshot From 2025-02-24 14-43-29](https://github.com/user-attachments/assets/1865e040-39c6-41c9-979a-393024a8a89e)
![Screenshot From 2025-02-24 14-43-42](https://github.com/user-attachments/assets/e4710e74-03fe-4426-97bc-0f2535a83d37)