### PR TITLE
fix(bedrock) Sonnet 3.7's Prompt Cache is false

### DIFF
--- a/.changeset/spicy-snakes-fail.md
+++ b/.changeset/spicy-snakes-fail.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+fix(bedrock) Prompt Cache is false

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -146,7 +146,7 @@ export const bedrockModels = {
 		contextWindow: 200_000,
 		supportsImages: true,
 		supportsComputerUse: true,
-		supportsPromptCache: true,
+		supportsPromptCache: false,
 		inputPrice: 3.0,
 		outputPrice: 15.0,
 		cacheWritesPrice: 3.75,


### PR DESCRIPTION
### Description

Set supportsPromptCache to false for anthropic.claude-3-7-sonnet-20250219-v1:0 Align with other Bedrock models' configuration

This fixes the issue of abnormally high token usage when using Claude 3.7 through Bedrock by preventing unnecessary cache-related cost calculations.

### Test Procedure

Done.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

None.

### Additional Notes

None.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Set `supportsPromptCache` to `false` for `anthropic.claude-3-7-sonnet-20250219-v1:0` in `bedrockModels` to fix high token usage.
> 
>   - **Behavior**:
>     - Set `supportsPromptCache` to `false` for `anthropic.claude-3-7-sonnet-20250219-v1:0` in `bedrockModels`.
>     - Aligns with other Bedrock models to prevent high token usage due to cache calculations.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for d77df4d00300331755cda89185409b732b3e929d. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->