### PR TITLE
feat: add llama.cpp provider w/ native tool calls

### DIFF
--- a/.changeset/friendly-icons-press.md
+++ b/.changeset/friendly-icons-press.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": minor
+---
+
+Add llama.cpp provider (llama-server w/ tool use)

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -21,6 +21,7 @@ import { LiteLlmHandler } from "./providers/litellm"
 export interface ApiHandler {
 	createMessage(systemPrompt: string, messages: Anthropic.Messages.MessageParam[], tools?: Anthropic.Tool[]): ApiStream
 	getModel(): { id: string; info: ModelInfo }
+	formatToolCalls?: (toolCalls: { name: string; args: unknown }[]) => Promise<string>
 }
 
 export interface SingleCompletionHandler {

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -19,7 +19,7 @@ import { VsCodeLmHandler } from "./providers/vscode-lm"
 import { LiteLlmHandler } from "./providers/litellm"
 
 export interface ApiHandler {
-	createMessage(systemPrompt: string, messages: Anthropic.Messages.MessageParam[]): ApiStream
+	createMessage(systemPrompt: string, messages: Anthropic.Messages.MessageParam[], tools?: Anthropic.Tool[]): ApiStream
 	getModel(): { id: string; info: ModelInfo }
 }
 

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -17,6 +17,7 @@ import { QwenHandler } from "./providers/qwen"
 import { MistralHandler } from "./providers/mistral"
 import { VsCodeLmHandler } from "./providers/vscode-lm"
 import { LiteLlmHandler } from "./providers/litellm"
+import { LlamaCppHandler } from "./providers/llama.cpp"
 
 export interface ApiHandler {
 	createMessage(systemPrompt: string, messages: Anthropic.Messages.MessageParam[], tools?: Anthropic.Tool[]): ApiStream
@@ -43,6 +44,8 @@ export function buildApiHandler(configuration: ApiConfiguration): ApiHandler {
 			return new OpenAiHandler(options)
 		case "ollama":
 			return new OllamaHandler(options)
+		case "llama.cpp":
+			return new LlamaCppHandler(options)
 		case "lmstudio":
 			return new LmStudioHandler(options)
 		case "gemini":

--- a/src/api/providers/anthropic.ts
+++ b/src/api/providers/anthropic.ts
@@ -18,7 +18,7 @@ export class AnthropicHandler implements ApiHandler {
 	}
 
 	@withRetry()
-	async *createMessage(systemPrompt: string, messages: Anthropic.Messages.MessageParam[]): ApiStream {
+	async *createMessage(systemPrompt: string, messages: Anthropic.Messages.MessageParam[], tools?: Anthropic.Tool[]): ApiStream {
 		const model = this.getModel()
 		let stream: AnthropicStream<Anthropic.Beta.PromptCaching.Messages.RawPromptCachingBetaMessageStreamEvent>
 		const modelId = model.id

--- a/src/api/providers/bedrock.ts
+++ b/src/api/providers/bedrock.ts
@@ -13,7 +13,7 @@ export class AwsBedrockHandler implements ApiHandler {
 		this.options = options
 	}
 
-	async *createMessage(systemPrompt: string, messages: Anthropic.Messages.MessageParam[]): ApiStream {
+	async *createMessage(systemPrompt: string, messages: Anthropic.Messages.MessageParam[], tools?: Anthropic.Tool[]): ApiStream {
 		// cross region inference requires prefixing the model id with the region
 		let modelId = await this.getModelId()
 

--- a/src/api/providers/deepseek.ts
+++ b/src/api/providers/deepseek.ts
@@ -20,7 +20,7 @@ export class DeepSeekHandler implements ApiHandler {
 	}
 
 	@withRetry()
-	async *createMessage(systemPrompt: string, messages: Anthropic.Messages.MessageParam[]): ApiStream {
+	async *createMessage(systemPrompt: string, messages: Anthropic.Messages.MessageParam[], tools?: Anthropic.Tool[]): ApiStream {
 		const model = this.getModel()
 
 		const isDeepseekReasoner = model.id.includes("deepseek-reasoner")

--- a/src/api/providers/gemini.ts
+++ b/src/api/providers/gemini.ts
@@ -19,7 +19,7 @@ export class GeminiHandler implements ApiHandler {
 	}
 
 	@withRetry()
-	async *createMessage(systemPrompt: string, messages: Anthropic.Messages.MessageParam[]): ApiStream {
+	async *createMessage(systemPrompt: string, messages: Anthropic.Messages.MessageParam[], tools?: Anthropic.Tool[]): ApiStream {
 		const model = this.client.getGenerativeModel({
 			model: this.getModel().id,
 			systemInstruction: systemPrompt,

--- a/src/api/providers/litellm.ts
+++ b/src/api/providers/litellm.ts
@@ -17,7 +17,7 @@ export class LiteLlmHandler implements ApiHandler {
 		})
 	}
 
-	async *createMessage(systemPrompt: string, messages: Anthropic.Messages.MessageParam[]): ApiStream {
+	async *createMessage(systemPrompt: string, messages: Anthropic.Messages.MessageParam[], tools?: Anthropic.Tool[]): ApiStream {
 		const formattedMessages = convertToOpenAiMessages(messages)
 		const systemMessage: OpenAI.Chat.ChatCompletionSystemMessageParam = {
 			role: "system",

--- a/src/api/providers/llama.cpp.ts
+++ b/src/api/providers/llama.cpp.ts
@@ -1,0 +1,167 @@
+import { Anthropic } from "@anthropic-ai/sdk"
+import OpenAI from "openai"
+import { ApiHandler } from "../"
+import { ApiHandlerOptions, llamaCppModelInfoSaneDefaults, ModelInfo, openAiModelInfoSaneDefaults } from "../../shared/api"
+import { convertToClineToolCalls, convertToOpenAiMessages, convertToOpenAiTools } from "../transform/openai-format"
+import { ApiStream } from "../transform/stream"
+
+type LlamaCppProps = {
+	default_generation_settings: {
+		n_ctx: number
+		params: {
+			n_predict: number
+		}
+	}
+	total_slots: number
+	model_path: string
+	chat_template: string
+	chat_template_tool_use?: string
+	build_info: string
+	bos_token: string
+	eos_token: string
+}
+
+export class LlamaCppHandler implements ApiHandler {
+	private options: ApiHandlerOptions
+	private client: OpenAI
+	private props?: Promise<LlamaCppProps> | LlamaCppProps
+	private baseUrl: string
+	private formattedToolCallsCache = new Map<string, string>()
+	private lastModelId?: string
+
+	constructor(options: ApiHandlerOptions) {
+		this.options = options
+		this.baseUrl = this.options.llamaCppBaseUrl || "http://localhost:8080"
+		this.client = new OpenAI({
+			baseURL: this.baseUrl + "/v1",
+			apiKey: this.options.llamaCppApiKey ?? "",
+		})
+
+		this.props = fetch(this.baseUrl + "/props").then((res) => (this.props = res.json().then((props) => (this.props = props))))
+		this.formatToolCalls = this.formatToolCalls.bind(this)
+	}
+
+	async *createMessage(systemPrompt: string, messages: Anthropic.Messages.MessageParam[], tools?: Anthropic.Tool[]): ApiStream {
+		const response = await this.client.chat.completions.create({
+			model: this.getModel().id,
+			messages: [{ role: "system", content: systemPrompt }, ...convertToOpenAiMessages(messages)],
+			tools: tools && convertToOpenAiTools(tools),
+		})
+		const message = response.choices[0]?.message
+		const texts: string[] = []
+		if ("reasoning_content" in message) {
+			texts.push(`<thinking>${message["reasoning_content"]}</thinking>`)
+		}
+		if (message.content !== null && message.content !== "") {
+			texts.push(message.content)
+		}
+		if (message.tool_calls) {
+			texts.push(...convertToClineToolCalls(message.tool_calls))
+		}
+		yield {
+			type: "text",
+			text: texts.join("\n"),
+		}
+		yield {
+			type: "usage",
+			inputTokens: response.usage?.prompt_tokens || 0,
+			outputTokens: response.usage?.completion_tokens || 0,
+		}
+	}
+
+	// Formats tool calls using llama-server's /apply-template endpoint
+	async formatToolCalls(toolCalls: { name: string; args: unknown }[]): Promise<string> {
+		const key = JSON.stringify(toolCalls)
+		const cached = this.formattedToolCallsCache.get(key)
+		if (cached) {
+			return cached
+		}
+		const props = await this.props!
+
+		const userMsg = {
+			role: "user",
+			content: "hey",
+		}
+		const assistantMsg = {
+			role: "assistant",
+			content: null,
+			tool_calls: toolCalls.map(({ name, args }) => ({
+				// Dummy id... that doesn't make Mistral Nemo's template to explode.
+				id: "0123456789",
+				type: "function",
+				function: {
+					name,
+					arguments: JSON.stringify(args),
+				},
+			})),
+		}
+		const tools = [
+			{
+				type: "function",
+				function: {
+					description: "phony",
+					name: "phony",
+					parameters: {
+						type: "object",
+						properties: {},
+					},
+				},
+			},
+		]
+		const method = "POST"
+		const headers = new Headers([["Authorization", `Bearer ${this.options.llamaCppApiKey ?? ""}`]])
+		const [{ prompt: prefix }, { prompt: full }] = await Promise.all(
+			(
+				await Promise.all([
+					fetch(
+						new Request(this.baseUrl + "/apply-template", {
+							headers,
+							method,
+							body: JSON.stringify({ tools, messages: [userMsg] }),
+						}),
+					),
+					fetch(
+						new Request(this.baseUrl + "/apply-template", {
+							headers,
+							method,
+							body: JSON.stringify({ tools, messages: [userMsg, assistantMsg], add_generation_prompt: false }),
+						}),
+					),
+				])
+			).map((res) => res.json()),
+		)
+
+		let toolCallsStr = full.slice(prefix.length).trim()
+		if (toolCallsStr.endsWith(props.eos_token)) {
+			toolCallsStr = toolCallsStr.slice(0, -props.eos_token.length).trim()
+		}
+		this.formattedToolCallsCache.set(key, toolCallsStr)
+		return toolCallsStr
+	}
+
+	getModel(): { id: string; info: ModelInfo } {
+		let id = "undefined"
+		let n_ctx = 128 * 1024
+		let n_predict = -1
+		if (this.props instanceof Promise) {
+			console.warn("getModel() called before props are loaded. Returning default values.")
+		} else if (this.props) {
+			id = this.props.model_path.split("/").pop() ?? "undefined"
+			n_ctx = this.props.default_generation_settings.n_ctx
+			n_predict = this.props.default_generation_settings.params.n_predict
+		}
+		if (this.lastModelId !== id) {
+			// If the model has changed, clear the cache.
+			this.formattedToolCallsCache.clear()
+			this.lastModelId = id
+		}
+		return {
+			id,
+			info: {
+				...llamaCppModelInfoSaneDefaults,
+				maxTokens: n_predict,
+				contextWindow: n_ctx,
+			},
+		}
+	}
+}

--- a/src/api/providers/lmstudio.ts
+++ b/src/api/providers/lmstudio.ts
@@ -17,7 +17,7 @@ export class LmStudioHandler implements ApiHandler {
 		})
 	}
 
-	async *createMessage(systemPrompt: string, messages: Anthropic.Messages.MessageParam[]): ApiStream {
+	async *createMessage(systemPrompt: string, messages: Anthropic.Messages.MessageParam[], tools?: Anthropic.Tool[]): ApiStream {
 		const openAiMessages: OpenAI.Chat.ChatCompletionMessageParam[] = [
 			{ role: "system", content: systemPrompt },
 			...convertToOpenAiMessages(messages),

--- a/src/api/providers/mistral.ts
+++ b/src/api/providers/mistral.ts
@@ -27,7 +27,7 @@ export class MistralHandler implements ApiHandler {
 	}
 
 	@withRetry()
-	async *createMessage(systemPrompt: string, messages: Anthropic.Messages.MessageParam[]): ApiStream {
+	async *createMessage(systemPrompt: string, messages: Anthropic.Messages.MessageParam[], tools?: Anthropic.Tool[]): ApiStream {
 		const stream = await this.client.chat.stream({
 			model: this.getModel().id,
 			// max_completion_tokens: this.getModel().info.maxTokens,

--- a/src/api/providers/ollama.ts
+++ b/src/api/providers/ollama.ts
@@ -17,7 +17,7 @@ export class OllamaHandler implements ApiHandler {
 		})
 	}
 
-	async *createMessage(systemPrompt: string, messages: Anthropic.Messages.MessageParam[]): ApiStream {
+	async *createMessage(systemPrompt: string, messages: Anthropic.Messages.MessageParam[], tools?: Anthropic.Tool[]): ApiStream {
 		const openAiMessages: OpenAI.Chat.ChatCompletionMessageParam[] = [
 			{ role: "system", content: systemPrompt },
 			...convertToOpenAiMessages(messages),

--- a/src/api/providers/openai-native.ts
+++ b/src/api/providers/openai-native.ts
@@ -25,7 +25,7 @@ export class OpenAiNativeHandler implements ApiHandler {
 	}
 
 	@withRetry()
-	async *createMessage(systemPrompt: string, messages: Anthropic.Messages.MessageParam[]): ApiStream {
+	async *createMessage(systemPrompt: string, messages: Anthropic.Messages.MessageParam[], tools?: Anthropic.Tool[]): ApiStream {
 		switch (this.getModel().id) {
 			case "o1":
 			case "o1-preview":

--- a/src/api/providers/openai.ts
+++ b/src/api/providers/openai.ts
@@ -29,7 +29,7 @@ export class OpenAiHandler implements ApiHandler {
 	}
 
 	@withRetry()
-	async *createMessage(systemPrompt: string, messages: Anthropic.Messages.MessageParam[]): ApiStream {
+	async *createMessage(systemPrompt: string, messages: Anthropic.Messages.MessageParam[], tools?: Anthropic.Tool[]): ApiStream {
 		const modelId = this.options.openAiModelId ?? ""
 		const isDeepseekReasoner = modelId.includes("deepseek-reasoner")
 

--- a/src/api/providers/openrouter.ts
+++ b/src/api/providers/openrouter.ts
@@ -26,7 +26,7 @@ export class OpenRouterHandler implements ApiHandler {
 	}
 
 	@withRetry()
-	async *createMessage(systemPrompt: string, messages: Anthropic.Messages.MessageParam[]): ApiStream {
+	async *createMessage(systemPrompt: string, messages: Anthropic.Messages.MessageParam[], tools?: Anthropic.Tool[]): ApiStream {
 		const model = this.getModel()
 
 		// Convert Anthropic messages to OpenAI format

--- a/src/api/providers/qwen.ts
+++ b/src/api/providers/qwen.ts
@@ -33,7 +33,7 @@ export class QwenHandler implements ApiHandler {
 		}
 	}
 
-	async *createMessage(systemPrompt: string, messages: Anthropic.Messages.MessageParam[]): ApiStream {
+	async *createMessage(systemPrompt: string, messages: Anthropic.Messages.MessageParam[], tools?: Anthropic.Tool[]): ApiStream {
 		const model = this.getModel()
 		const isDeepseekReasoner = model.id.includes("deepseek-r1")
 		let openAiMessages: OpenAI.Chat.ChatCompletionMessageParam[] = [

--- a/src/api/providers/requesty.ts
+++ b/src/api/providers/requesty.ts
@@ -23,7 +23,7 @@ export class RequestyHandler implements ApiHandler {
 	}
 
 	@withRetry()
-	async *createMessage(systemPrompt: string, messages: Anthropic.Messages.MessageParam[]): ApiStream {
+	async *createMessage(systemPrompt: string, messages: Anthropic.Messages.MessageParam[], tools?: Anthropic.Tool[]): ApiStream {
 		const modelId = this.options.requestyModelId ?? ""
 
 		let openAiMessages: OpenAI.Chat.ChatCompletionMessageParam[] = [

--- a/src/api/providers/together.ts
+++ b/src/api/providers/together.ts
@@ -20,7 +20,7 @@ export class TogetherHandler implements ApiHandler {
 	}
 
 	@withRetry()
-	async *createMessage(systemPrompt: string, messages: Anthropic.Messages.MessageParam[]): ApiStream {
+	async *createMessage(systemPrompt: string, messages: Anthropic.Messages.MessageParam[], tools?: Anthropic.Tool[]): ApiStream {
 		const modelId = this.options.togetherModelId ?? ""
 		const isDeepseekReasoner = modelId.includes("deepseek-reasoner")
 

--- a/src/api/providers/vertex.ts
+++ b/src/api/providers/vertex.ts
@@ -20,7 +20,7 @@ export class VertexHandler implements ApiHandler {
 	}
 
 	@withRetry()
-	async *createMessage(systemPrompt: string, messages: Anthropic.Messages.MessageParam[]): ApiStream {
+	async *createMessage(systemPrompt: string, messages: Anthropic.Messages.MessageParam[], tools?: Anthropic.Tool[]): ApiStream {
 		const stream = await this.client.messages.create({
 			model: this.getModel().id,
 			max_tokens: this.getModel().info.maxTokens || 8192,

--- a/src/api/providers/vscode-lm.ts
+++ b/src/api/providers/vscode-lm.ts
@@ -410,7 +410,7 @@ export class VsCodeLmHandler implements ApiHandler, SingleCompletionHandler {
 		return content
 	}
 
-	async *createMessage(systemPrompt: string, messages: Anthropic.Messages.MessageParam[]): ApiStream {
+	async *createMessage(systemPrompt: string, messages: Anthropic.Messages.MessageParam[], tools?: Anthropic.Tool[]): ApiStream {
 		// Ensure clean state before starting a new request
 		this.ensureCleanState()
 		const client: vscode.LanguageModelChat = await this.getClient()

--- a/src/api/transform/openai-format.ts
+++ b/src/api/transform/openai-format.ts
@@ -1,6 +1,30 @@
 import { Anthropic } from "@anthropic-ai/sdk"
 import OpenAI from "openai"
 
+export function convertToOpenAiTools(tools: Anthropic.Tool[]): OpenAI.Chat.ChatCompletionTool[] {
+	return tools.map((tool) => ({
+		type: "function",
+		function: {
+			name: tool.name,
+			description: tool.description,
+			parameters: tool.input_schema,
+		},
+	}))
+}
+
+export function convertToClineToolCalls(tool_calls: OpenAI.Chat.ChatCompletionMessageToolCall[]): string[] {
+	return tool_calls.map((tool_call) =>
+		[
+			`<${tool_call.function.name}>`,
+			...Object.entries(JSON.parse(tool_call.function.arguments)).map(
+				([key, value]) =>
+					`<${key}>${typeof value === "string" && value.includes("\n") ? `\n${value}\n` : value}</${key}>`,
+			),
+			`</${tool_call.function.name}>`,
+		].join("\n"),
+	)
+}
+
 export function convertToOpenAiMessages(
 	anthropicMessages: Anthropic.Messages.MessageParam[],
 ): OpenAI.Chat.ChatCompletionMessageParam[] {

--- a/src/core/prompts/system.ts
+++ b/src/core/prompts/system.ts
@@ -3,21 +3,430 @@ import os from "os"
 import osName from "os-name"
 import { McpHub } from "../../services/mcp/McpHub"
 import { BrowserSettings } from "../../shared/BrowserSettings"
+import Anthropic from "@anthropic-ai/sdk"
 
-export const SYSTEM_PROMPT = async (
-	cwd: string,
-	supportsComputerUse: boolean,
-	mcpHub: McpHub,
-	browserSettings: BrowserSettings,
-) => `You are Cline, a highly skilled software engineer with extensive knowledge in many programming languages, frameworks, design patterns, and best practices.
+type ToolCall = { name: string; args: unknown }
+type ToolCallFormatter = (toolCalls: ToolCall[]) => Promise<string>
 
-====
+/*
+	Example: `formatToolCallsClineXml([{ name: "execute_command", args: { command: "npm run dev", requires_approval: false }])` gives:
 
-TOOL USE
+	<execute_command>
+	<command>npm run dev</command>
+	<requires_approval>false</requires_approval>
+	</execute_command>
+*/
+export const formatToolCallsClineXml: ToolCallFormatter = async (toolCalls) => {
+	return toolCalls
+		.flatMap(({ name, args }) => [
+			`<${name}>`,
+			...Object.entries(args as object).map(([n, v]) => {
+				const multiline = (typeof v === "string" && v.indexOf("\n") >= 0) || ["diff", "result", "content"].includes(n)
+				return `<${n}>${multiline ? `\n${v}\n` : v}</${n}>`
+			}),
+			`</${name}>`,
+		])
+		.join("\n")
+}
 
-You have access to a set of tools that are executed upon the user's approval. You can use one tool per message, and will receive the result of that tool use in the user's response. You use tools step-by-step to accomplish a given task, with each tool use informed by the result of the previous tool use.
+async function formatToolSchema(tool: Anthropic.Tool, exampleArgs: any, toolCallFormatter: ToolCallFormatter) {
+	const lines = [
+		`## ${tool.name}`,
+		`Description: ${tool.description}`,
+		`Parameters:`,
+		...Object.entries(tool.input_schema.properties ?? {}).map(
+			([n, s]) =>
+				`- ${n}: ${(tool.input_schema["required"] as string[]).includes(n) ? "(required)" : "(optional)"} ${s.description.replace(/\n/g, "\n  ")}`,
+		),
+		...(exampleArgs ? [`Usage:`, await toolCallFormatter([{ name: tool.name, args: exampleArgs }])] : []),
+	]
+	return lines.join("\n")
+}
 
-# Tool Use Formatting
+export type SystemPromptOptions = {
+	cwd: string
+	supportsComputerUse: boolean
+	mcpHub: McpHub
+	browserSettings: BrowserSettings
+	supportsTools?: boolean
+	formatToolCalls: ToolCallFormatter
+}
+
+export async function SYSTEM_PROMPT({
+	cwd,
+	supportsComputerUse,
+	mcpHub,
+	browserSettings,
+	supportsTools,
+	formatToolCalls,
+}: SystemPromptOptions): Promise<{ systemPrompt: string; tools?: Anthropic.Tool[] }> {
+	const formatToolCall = (name: string, args: unknown) => formatToolCalls([{ name, args }])
+
+	const toolsAndExamples: [Anthropic.Tool, any][] = []
+	toolsAndExamples.push([
+		{
+			name: "execute_command",
+			description: `Request to execute a CLI command on the system. Use this when you need to perform system operations or run specific commands to accomplish any step in the user's task. You must tailor your command to the user's system and provide a clear explanation of what the command does. For command chaining, use the appropriate chaining syntax for the user's shell. Prefer to execute complex CLI commands over creating executable scripts, as they are more flexible and easier to run. Commands will be executed in the current working directory: ${cwd.toPosix()}`,
+			input_schema: {
+				type: "object",
+				properties: {
+					command: {
+						type: "string",
+						description:
+							"The CLI command to execute. This should be valid for the current operating system. Ensure the command is properly formatted and does not contain any harmful instructions.",
+					},
+					requires_approval: {
+						type: "boolean",
+						description:
+							"A boolean indicating whether this command requires explicit user approval before execution in case the user has auto-approve mode enabled. Set to 'true' for potentially impactful operations like installing/uninstalling packages, deleting/overwriting files, system configuration changes, network operations, or any commands that could have unintended side effects. Set to 'false' for safe operations like reading files/directories, running development servers, building projects, and other non-destructive operations.",
+					},
+				},
+				required: ["command", "requires_approval"],
+			},
+		},
+		{
+			command: "Your command here",
+			requires_approval: "true or false",
+		},
+	])
+
+	toolsAndExamples.push([
+		{
+			name: "read_file",
+			description:
+				"Request to read the contents of a file at the specified path. Use this when you need to examine the contents of an existing file you do not know the contents of, for example to analyze code, review text files, or extract information from configuration files. Automatically extracts raw text from PDF and DOCX files. May not be suitable for other types of binary files, as it returns the raw content as a string.",
+			input_schema: {
+				type: "object",
+				properties: {
+					path: {
+						type: "string",
+						description: `The path of the file to read (relative to the current working directory ${cwd.toPosix()})`,
+					},
+				},
+				required: ["path"],
+			},
+		},
+		{
+			path: "File path here",
+		},
+	])
+
+	toolsAndExamples.push([
+		{
+			name: "write_to_file",
+			description:
+				"Request to write content to a file at the specified path. If the file exists, it will be overwritten with the provided content. If the file doesn't exist, it will be created. This tool will automatically create any directories needed to write the file.",
+			input_schema: {
+				type: "object",
+				properties: {
+					path: {
+						type: "string",
+						description: `The path of the file to write to (relative to the current working directory ${cwd.toPosix()})`,
+					},
+					content: {
+						type: "string",
+						description:
+							"The content to write to the file. ALWAYS provide the COMPLETE intended content of the file, without any truncation or omissions. You MUST include ALL parts of the file, even if they haven't been modified.",
+					},
+				},
+				required: ["path", "content"],
+			},
+		},
+		{
+			path: "File path here",
+			content: "Your file content here",
+		},
+	])
+
+	toolsAndExamples.push([
+		{
+			name: "replace_in_file",
+			description:
+				"Request to replace sections of content in an existing file using SEARCH/REPLACE blocks that define exact changes to specific parts of the file. This tool should be used when you need to make targeted changes to specific parts of a file.",
+			input_schema: {
+				type: "object",
+				properties: {
+					path: {
+						type: "string",
+						description: `The path of the file to modify (relative to the current working directory ${cwd.toPosix()})`,
+					},
+					diff: {
+						type: "string",
+						description:
+							"One or more SEARCH/REPLACE blocks following this exact format:\n```\n<<<<<<< SEARCH\n[exact content to find]\n=======\n[new content to replace with]\n>>>>>>> REPLACE\n```\nCritical rules:\n1. SEARCH content must match the associated file section to find EXACTLY:\n   * Match character-for-character including whitespace, indentation, line endings\n   * Include all comments, docstrings, etc.\n2. SEARCH/REPLACE blocks will ONLY replace the first match occurrence.\n   * Including multiple unique SEARCH/REPLACE blocks if you need to make multiple changes.\n   * Include *just* enough lines in each SEARCH section to uniquely match each set of lines that need to change.\n   * When using multiple SEARCH/REPLACE blocks, list them in the order they appear in the file.\n3. Keep SEARCH/REPLACE blocks concise:\n   * Break large SEARCH/REPLACE blocks into a series of smaller blocks that each change a small portion of the file.\n   * Include just the changing lines, and a few surrounding lines if needed for uniqueness.\n   * Do not include long runs of unchanging lines in SEARCH/REPLACE blocks.\n   * Each line must be complete. Never truncate lines mid-way through as this can cause matching failures.\n4. Special operations:\n   * To move code: Use two SEARCH/REPLACE blocks (one to delete from original + one to insert at new location)\n   * To delete code: Use empty REPLACE section",
+					},
+				},
+				required: ["path", "diff"],
+			},
+		},
+		{
+			path: "File path here",
+			diff: "Search and replace blocks here",
+		},
+	])
+
+	toolsAndExamples.push([
+		{
+			name: "search_files",
+			description:
+				"Request to perform a regex search across files in a specified directory, providing context-rich results. This tool searches for patterns or specific content across multiple files, displaying each match with encapsulating context.",
+			input_schema: {
+				type: "object",
+				properties: {
+					path: {
+						type: "string",
+						description: `The path of the directory to search in (relative to the current working directory ${cwd.toPosix()}). This directory will be recursively searched.`,
+					},
+					regex: {
+						type: "string",
+						description: "The regular expression pattern to search for. Uses Rust regex syntax.",
+					},
+					file_pattern: {
+						type: "string",
+						description:
+							"Glob pattern to filter files (e.g., '*.ts' for TypeScript files). If not provided, it will search all files (*).",
+					},
+				},
+				required: ["path", "regex"],
+			},
+		},
+		{
+			path: "Directory path here",
+			regex: "Your regex pattern here",
+			file_pattern: "file pattern here (optional)",
+		},
+	])
+
+	toolsAndExamples.push([
+		{
+			name: "list_files",
+			description:
+				"Request to list files and directories within the specified directory. If recursive is true, it will list all files and directories recursively. If recursive is false or not provided, it will only list the top-level contents. Do not use this tool to confirm the existence of files you may have created, as the user will let you know if the files were created successfully or not.",
+			input_schema: {
+				type: "object",
+				properties: {
+					path: {
+						type: "string",
+						description: `The path of the directory to list contents for (relative to the current working directory ${cwd.toPosix()})`,
+					},
+					recursive: {
+						type: "boolean",
+						description:
+							"Whether to list files recursively. Use true for recursive listing, false or omit for top-level only.",
+					},
+				},
+				required: ["path"],
+			},
+		},
+		{
+			path: "Directory path here",
+			recursive: "true or false (optional)",
+		},
+	])
+
+	toolsAndExamples.push([
+		{
+			name: "list_code_definition_names",
+			description:
+				"Request to list definition names (classes, functions, methods, etc.) used in source code files at the top level of the specified directory. This tool provides insights into the codebase structure and important constructs, encapsulating high-level concepts and relationships that are crucial for understanding the overall architecture.",
+			input_schema: {
+				type: "object",
+				properties: {
+					path: {
+						type: "string",
+						description: `The path of the directory (relative to the current working directory ${cwd.toPosix()}) to list top level source code definitions for.`,
+					},
+				},
+				required: ["path"],
+			},
+		},
+		{
+			path: "Directory path here",
+		},
+	])
+
+	if (supportsComputerUse) {
+		toolsAndExamples.push([
+			{
+				name: "browser_action",
+				description:
+					"Request to interact with a Puppeteer-controlled browser. Every action, except `close`, will be responded to with a screenshot of the browser's current state, along with any new console logs. You may only perform one browser action per message, and wait for the user's response including a screenshot and logs to determine the next action.\n" +
+					"- The sequence of actions **must always start with** launching the browser at a URL, and **must always end with** closing the browser. If you need to visit a new URL that is not possible to navigate to from the current webpage, you must first close the browser, then launch again at the new URL.\n" +
+					"- While the browser is active, only the `browser_action` tool can be used. No other tools should be called during this time. You may proceed to use other tools only after closing the browser. For example if you run into an error and need to fix a file, you must close the browser, then use other tools to make the necessary changes, then re-launch the browser to verify the result.\n" +
+					"- The browser window has a resolution of **900x600** pixels. When performing any click actions, ensure the coordinates are within this resolution range.\n" +
+					"- Before clicking on any elements such as icons, links, or buttons, you must consult the provided screenshot of the page to determine the coordinates of the element. The click should be targeted at the **center of the element**, not on its edges.",
+				input_schema: {
+					type: "object",
+					properties: {
+						action: {
+							type: "string",
+							description:
+								"The action to perform. The available actions are:\n  * launch: Launch a new Puppeteer-controlled browser instance at the specified URL. This **must always be the first action**.\n      - Use with the `url` parameter to provide the URL.\n      - Ensure the URL is valid and includes the appropriate protocol (e.g. http://localhost:3000/page, file:///path/to/file.html, etc.)\n  * click: Click at a specific x,y coordinate.\n      - Use with the `coordinate` parameter to specify the location.\n      - Always click in the center of an element (icon, button, link, etc.) based on coordinates derived from a screenshot.\n  * type: Type a string of text on the keyboard. You might use this after clicking on a text field to input text.\n      - Use with the `text` parameter to provide the string to type.\n  * scroll_down: Scroll down the page by one page height.\n  * scroll_up: Scroll up the page by one page height.\n  * close: Close the Puppeteer-controlled browser instance. This **must always be the final browser action**.\n      - Example: `<action>close</action>`",
+						},
+						url: {
+							type: "string",
+							description:
+								"Use this for providing the URL for the `launch` action.\n  * Example: <url>https://example.com</url>",
+						},
+						coordinate: {
+							type: "string",
+							description: `The X and Y coordinates for the \`click\` action. Coordinates should be within the **${browserSettings.viewport.width}x${browserSettings.viewport.height}** resolution.\n  * Example: <coordinate>450,300</coordinate>`,
+						},
+						text: {
+							type: "string",
+							description:
+								"Use this for providing the text for the `type` action.\n  * Example: <text>Hello, world!</text>",
+						},
+					},
+					required: ["action"],
+				},
+			},
+			{
+				action: "Action to perform (e.g., launch, click, type, scroll_down, scroll_up, close)",
+				url: "URL to launch the browser at (optional)",
+				coordinate: "x,y coordinates (optional)",
+				text: "Text to type (optional)",
+			},
+		])
+	}
+
+	if (mcpHub.getMode() !== "off") {
+		toolsAndExamples.push([
+			{
+				name: "use_mcp_tool",
+				description:
+					"Request to use a tool provided by a connected MCP server. Each MCP server can provide multiple tools with different capabilities. Tools have defined input schemas that specify required and optional parameters.",
+				input_schema: {
+					type: "object",
+					properties: {
+						server_name: {
+							type: "string",
+							description: "The name of the MCP server providing the tool",
+						},
+						tool_name: {
+							type: "string",
+							description: "The name of the tool to execute",
+						},
+						arguments: {
+							type: "string",
+							description:
+								"A JSON object containing the tool's input parameters, following the tool's input schema",
+						},
+					},
+					required: ["server_name", "tool_name", "arguments"],
+				},
+			},
+			{
+				server_name: "server name here",
+				tool_name: "tool name here",
+				arguments: '{\n  "param1": "value1",\n  "param2": "value2"\n}',
+			},
+		])
+
+		toolsAndExamples.push([
+			{
+				name: "access_mcp_resource",
+				description:
+					"Request to access a resource provided by a connected MCP server. Resources represent data sources that can be used as context, such as files, API responses, or system information.",
+				input_schema: {
+					type: "object",
+					properties: {
+						server_name: {
+							type: "string",
+							description: "The name of the MCP server providing the resource",
+						},
+						uri: {
+							type: "string",
+							description: "The URI identifying the specific resource to access",
+						},
+					},
+					required: ["server_name", "uri"],
+				},
+			},
+			{
+				server_name: "server name here",
+				uri: "resource URI here",
+			},
+		])
+	}
+
+	toolsAndExamples.push([
+		{
+			name: "ask_followup_question",
+			description:
+				"Ask the user a question to gather additional information needed to complete the task. This tool should be used when you encounter ambiguities, need clarification, or require more details to proceed effectively. It allows for interactive problem-solving by enabling direct communication with the user. Use this tool judiciously to maintain a balance between gathering necessary information and avoiding excessive back-and-forth.",
+			input_schema: {
+				type: "object",
+				properties: {
+					question: {
+						type: "string",
+						description:
+							"The question to ask the user. This should be a clear, specific question that addresses the information you need.",
+					},
+				},
+				required: ["question"],
+			},
+		},
+		{
+			question: "Your question here",
+		},
+	])
+
+	toolsAndExamples.push([
+		{
+			name: "attempt_completion",
+			description:
+				"After each tool use, the user will respond with the result of that tool use, i.e. if it succeeded or failed, along with any reasons for failure. Once you've received the results of tool uses and can confirm that the task is complete, use this tool to present the result of your work to the user. Optionally you may provide a CLI command to showcase the result of your work. The user may respond with feedback if they are not satisfied with the result, which you can use to make improvements and try again.\n" +
+				"IMPORTANT NOTE: This tool CANNOT be used until you've confirmed from the user that any previous tool uses were successful. Failure to do so will result in code corruption and system failure. Before using this tool, you must ask yourself in <thinking></thinking> tags if you've confirmed from the user that any previous tool uses were successful. If not, then DO NOT use this tool.",
+			input_schema: {
+				type: "object",
+				properties: {
+					result: {
+						type: "string",
+						description:
+							"The result of the task. Formulate this result in a way that is final and does not require further input from the user. Don't end your result with questions or offers for further assistance.",
+					},
+					command: {
+						type: "string",
+						description:
+							"A CLI command to execute to show a live demo of the result to the user. For example, use `open index.html` to display a created html website, or `open localhost:3000` to display a locally running development server. But DO NOT use commands like `echo` or `cat` that merely print text. This command should be valid for the current operating system. Ensure the command is properly formatted and does not contain any harmful instructions.",
+					},
+				},
+				required: ["result"],
+			},
+		},
+		{
+			result: "Your final result description here",
+			command: "Command to demonstrate result (optional)",
+		},
+	])
+
+	toolsAndExamples.push([
+		{
+			name: "plan_mode_response",
+			description:
+				"Respond to the user's inquiry in an effort to plan a solution to the user's task. This tool should be used when you need to provide a response to a question or statement from the user about how you plan to accomplish the task. This tool is only available in PLAN MODE. The environment_details will specify the current mode, if it is not PLAN MODE then you should not use this tool. Depending on the user's message, you may ask questions to get clarification about the user's request, architect a solution to the task, and to brainstorm ideas with the user. For example, if the user's task is to create a website, you may start by asking some clarifying questions, then present a detailed plan for how you will accomplish the task given the context, and perhaps engage in a back and forth to finalize the details before the user switches you to ACT MODE to implement the solution.",
+			input_schema: {
+				type: "object",
+				properties: {
+					response: {
+						type: "string",
+						description:
+							"The response to provide to the user. Do not try to use tools in this parameter, this is simply a chat response.",
+					},
+				},
+				required: ["response"],
+			},
+		},
+		{
+			response: "Your response here",
+		},
+	])
+
+	let toolsPreamble = ""
+	if (!supportsTools) {
+		toolsPreamble =
+			`# Tool Use Formatting
 
 Tool use is formatted using XML-style tags. The tool name is enclosed in opening and closing tags, and each parameter is similarly enclosed within its own set of tags. Here's the structure:
 
@@ -37,250 +446,55 @@ Always adhere to this format for the tool use to ensure proper parsing and execu
 
 # Tools
 
-## execute_command
-Description: Request to execute a CLI command on the system. Use this when you need to perform system operations or run specific commands to accomplish any step in the user's task. You must tailor your command to the user's system and provide a clear explanation of what the command does. For command chaining, use the appropriate chaining syntax for the user's shell. Prefer to execute complex CLI commands over creating executable scripts, as they are more flexible and easier to run. Commands will be executed in the current working directory: ${cwd.toPosix()}
-Parameters:
-- command: (required) The CLI command to execute. This should be valid for the current operating system. Ensure the command is properly formatted and does not contain any harmful instructions.
-- requires_approval: (required) A boolean indicating whether this command requires explicit user approval before execution in case the user has auto-approve mode enabled. Set to 'true' for potentially impactful operations like installing/uninstalling packages, deleting/overwriting files, system configuration changes, network operations, or any commands that could have unintended side effects. Set to 'false' for safe operations like reading files/directories, running development servers, building projects, and other non-destructive operations.
-Usage:
-<execute_command>
-<command>Your command here</command>
-<requires_approval>true or false</requires_approval>
-</execute_command>
+` +
+			(
+				await Promise.all(
+					toolsAndExamples.map(([tool, exampleArgs]) => formatToolSchema(tool, exampleArgs, formatToolCalls)),
+				)
+			).join("\n\n") +
+			"\n\n"
+	}
 
-## read_file
-Description: Request to read the contents of a file at the specified path. Use this when you need to examine the contents of an existing file you do not know the contents of, for example to analyze code, review text files, or extract information from configuration files. Automatically extracts raw text from PDF and DOCX files. May not be suitable for other types of binary files, as it returns the raw content as a string.
-Parameters:
-- path: (required) The path of the file to read (relative to the current working directory ${cwd.toPosix()})
-Usage:
-<read_file>
-<path>File path here</path>
-</read_file>
-
-## write_to_file
-Description: Request to write content to a file at the specified path. If the file exists, it will be overwritten with the provided content. If the file doesn't exist, it will be created. This tool will automatically create any directories needed to write the file.
-Parameters:
-- path: (required) The path of the file to write to (relative to the current working directory ${cwd.toPosix()})
-- content: (required) The content to write to the file. ALWAYS provide the COMPLETE intended content of the file, without any truncation or omissions. You MUST include ALL parts of the file, even if they haven't been modified.
-Usage:
-<write_to_file>
-<path>File path here</path>
-<content>
-Your file content here
-</content>
-</write_to_file>
-
-## replace_in_file
-Description: Request to replace sections of content in an existing file using SEARCH/REPLACE blocks that define exact changes to specific parts of the file. This tool should be used when you need to make targeted changes to specific parts of a file.
-Parameters:
-- path: (required) The path of the file to modify (relative to the current working directory ${cwd.toPosix()})
-- diff: (required) One or more SEARCH/REPLACE blocks following this exact format:
-  \`\`\`
-  <<<<<<< SEARCH
-  [exact content to find]
-  =======
-  [new content to replace with]
-  >>>>>>> REPLACE
-  \`\`\`
-  Critical rules:
-  1. SEARCH content must match the associated file section to find EXACTLY:
-     * Match character-for-character including whitespace, indentation, line endings
-     * Include all comments, docstrings, etc.
-  2. SEARCH/REPLACE blocks will ONLY replace the first match occurrence.
-     * Including multiple unique SEARCH/REPLACE blocks if you need to make multiple changes.
-     * Include *just* enough lines in each SEARCH section to uniquely match each set of lines that need to change.
-     * When using multiple SEARCH/REPLACE blocks, list them in the order they appear in the file.
-  3. Keep SEARCH/REPLACE blocks concise:
-     * Break large SEARCH/REPLACE blocks into a series of smaller blocks that each change a small portion of the file.
-     * Include just the changing lines, and a few surrounding lines if needed for uniqueness.
-     * Do not include long runs of unchanging lines in SEARCH/REPLACE blocks.
-     * Each line must be complete. Never truncate lines mid-way through as this can cause matching failures.
-  4. Special operations:
-     * To move code: Use two SEARCH/REPLACE blocks (one to delete from original + one to insert at new location)
-     * To delete code: Use empty REPLACE section
-Usage:
-<replace_in_file>
-<path>File path here</path>
-<diff>
-Search and replace blocks here
-</diff>
-</replace_in_file>
-
-## search_files
-Description: Request to perform a regex search across files in a specified directory, providing context-rich results. This tool searches for patterns or specific content across multiple files, displaying each match with encapsulating context.
-Parameters:
-- path: (required) The path of the directory to search in (relative to the current working directory ${cwd.toPosix()}). This directory will be recursively searched.
-- regex: (required) The regular expression pattern to search for. Uses Rust regex syntax.
-- file_pattern: (optional) Glob pattern to filter files (e.g., '*.ts' for TypeScript files). If not provided, it will search all files (*).
-Usage:
-<search_files>
-<path>Directory path here</path>
-<regex>Your regex pattern here</regex>
-<file_pattern>file pattern here (optional)</file_pattern>
-</search_files>
-
-## list_files
-Description: Request to list files and directories within the specified directory. If recursive is true, it will list all files and directories recursively. If recursive is false or not provided, it will only list the top-level contents. Do not use this tool to confirm the existence of files you may have created, as the user will let you know if the files were created successfully or not.
-Parameters:
-- path: (required) The path of the directory to list contents for (relative to the current working directory ${cwd.toPosix()})
-- recursive: (optional) Whether to list files recursively. Use true for recursive listing, false or omit for top-level only.
-Usage:
-<list_files>
-<path>Directory path here</path>
-<recursive>true or false (optional)</recursive>
-</list_files>
-
-## list_code_definition_names
-Description: Request to list definition names (classes, functions, methods, etc.) used in source code files at the top level of the specified directory. This tool provides insights into the codebase structure and important constructs, encapsulating high-level concepts and relationships that are crucial for understanding the overall architecture.
-Parameters:
-- path: (required) The path of the directory (relative to the current working directory ${cwd.toPosix()}) to list top level source code definitions for.
-Usage:
-<list_code_definition_names>
-<path>Directory path here</path>
-</list_code_definition_names>${
-	supportsComputerUse
-		? `
-
-## browser_action
-Description: Request to interact with a Puppeteer-controlled browser. Every action, except \`close\`, will be responded to with a screenshot of the browser's current state, along with any new console logs. You may only perform one browser action per message, and wait for the user's response including a screenshot and logs to determine the next action.
-- The sequence of actions **must always start with** launching the browser at a URL, and **must always end with** closing the browser. If you need to visit a new URL that is not possible to navigate to from the current webpage, you must first close the browser, then launch again at the new URL.
-- While the browser is active, only the \`browser_action\` tool can be used. No other tools should be called during this time. You may proceed to use other tools only after closing the browser. For example if you run into an error and need to fix a file, you must close the browser, then use other tools to make the necessary changes, then re-launch the browser to verify the result.
-- The browser window has a resolution of **${browserSettings.viewport.width}x${browserSettings.viewport.height}** pixels. When performing any click actions, ensure the coordinates are within this resolution range.
-- Before clicking on any elements such as icons, links, or buttons, you must consult the provided screenshot of the page to determine the coordinates of the element. The click should be targeted at the **center of the element**, not on its edges.
-Parameters:
-- action: (required) The action to perform. The available actions are:
-    * launch: Launch a new Puppeteer-controlled browser instance at the specified URL. This **must always be the first action**.
-        - Use with the \`url\` parameter to provide the URL.
-        - Ensure the URL is valid and includes the appropriate protocol (e.g. http://localhost:3000/page, file:///path/to/file.html, etc.)
-    * click: Click at a specific x,y coordinate.
-        - Use with the \`coordinate\` parameter to specify the location.
-        - Always click in the center of an element (icon, button, link, etc.) based on coordinates derived from a screenshot.
-    * type: Type a string of text on the keyboard. You might use this after clicking on a text field to input text.
-        - Use with the \`text\` parameter to provide the string to type.
-    * scroll_down: Scroll down the page by one page height.
-    * scroll_up: Scroll up the page by one page height.
-    * close: Close the Puppeteer-controlled browser instance. This **must always be the final browser action**.
-        - Example: \`<action>close</action>\`
-- url: (optional) Use this for providing the URL for the \`launch\` action.
-    * Example: <url>https://example.com</url>
-- coordinate: (optional) The X and Y coordinates for the \`click\` action. Coordinates should be within the **${browserSettings.viewport.width}x${browserSettings.viewport.height}** resolution.
-    * Example: <coordinate>450,300</coordinate>
-- text: (optional) Use this for providing the text for the \`type\` action.
-    * Example: <text>Hello, world!</text>
-Usage:
-<browser_action>
-<action>Action to perform (e.g., launch, click, type, scroll_down, scroll_up, close)</action>
-<url>URL to launch the browser at (optional)</url>
-<coordinate>x,y coordinates (optional)</coordinate>
-<text>Text to type (optional)</text>
-</browser_action>`
-		: ""
-}
-
-${
-	mcpHub.getMode() !== "off"
-		? `
-## use_mcp_tool
-Description: Request to use a tool provided by a connected MCP server. Each MCP server can provide multiple tools with different capabilities. Tools have defined input schemas that specify required and optional parameters.
-Parameters:
-- server_name: (required) The name of the MCP server providing the tool
-- tool_name: (required) The name of the tool to execute
-- arguments: (required) A JSON object containing the tool's input parameters, following the tool's input schema
-Usage:
-<use_mcp_tool>
-<server_name>server name here</server_name>
-<tool_name>tool name here</tool_name>
-<arguments>
-{
-  "param1": "value1",
-  "param2": "value2"
-}
-</arguments>
-</use_mcp_tool>
-
-## access_mcp_resource
-Description: Request to access a resource provided by a connected MCP server. Resources represent data sources that can be used as context, such as files, API responses, or system information.
-Parameters:
-- server_name: (required) The name of the MCP server providing the resource
-- uri: (required) The URI identifying the specific resource to access
-Usage:
-<access_mcp_resource>
-<server_name>server name here</server_name>
-<uri>resource URI here</uri>
-</access_mcp_resource>
-`
-		: ""
-}
-
-## ask_followup_question
-Description: Ask the user a question to gather additional information needed to complete the task. This tool should be used when you encounter ambiguities, need clarification, or require more details to proceed effectively. It allows for interactive problem-solving by enabling direct communication with the user. Use this tool judiciously to maintain a balance between gathering necessary information and avoiding excessive back-and-forth.
-Parameters:
-- question: (required) The question to ask the user. This should be a clear, specific question that addresses the information you need.
-Usage:
-<ask_followup_question>
-<question>Your question here</question>
-</ask_followup_question>
-
-## attempt_completion
-Description: After each tool use, the user will respond with the result of that tool use, i.e. if it succeeded or failed, along with any reasons for failure. Once you've received the results of tool uses and can confirm that the task is complete, use this tool to present the result of your work to the user. Optionally you may provide a CLI command to showcase the result of your work. The user may respond with feedback if they are not satisfied with the result, which you can use to make improvements and try again.
-IMPORTANT NOTE: This tool CANNOT be used until you've confirmed from the user that any previous tool uses were successful. Failure to do so will result in code corruption and system failure. Before using this tool, you must ask yourself in <thinking></thinking> tags if you've confirmed from the user that any previous tool uses were successful. If not, then DO NOT use this tool.
-Parameters:
-- result: (required) The result of the task. Formulate this result in a way that is final and does not require further input from the user. Don't end your result with questions or offers for further assistance.
-- command: (optional) A CLI command to execute to show a live demo of the result to the user. For example, use \`open index.html\` to display a created html website, or \`open localhost:3000\` to display a locally running development server. But DO NOT use commands like \`echo\` or \`cat\` that merely print text. This command should be valid for the current operating system. Ensure the command is properly formatted and does not contain any harmful instructions.
-Usage:
-<attempt_completion>
-<result>
-Your final result description here
-</result>
-<command>Command to demonstrate result (optional)</command>
-</attempt_completion>
-
-## plan_mode_response
-Description: Respond to the user's inquiry in an effort to plan a solution to the user's task. This tool should be used when you need to provide a response to a question or statement from the user about how you plan to accomplish the task. This tool is only available in PLAN MODE. The environment_details will specify the current mode, if it is not PLAN MODE then you should not use this tool. Depending on the user's message, you may ask questions to get clarification about the user's request, architect a solution to the task, and to brainstorm ideas with the user. For example, if the user's task is to create a website, you may start by asking some clarifying questions, then present a detailed plan for how you will accomplish the task given the context, and perhaps engage in a back and forth to finalize the details before the user switches you to ACT MODE to implement the solution.
-Parameters:
-- response: (required) The response to provide to the user. Do not try to use tools in this parameter, this is simply a chat response.
-Usage:
-<plan_mode_response>
-<response>Your response here</response>
-</plan_mode_response>
-
-# Tool Use Examples
-
-## Example 1: Requesting to execute a command
-
-<execute_command>
-<command>npm run dev</command>
-<requires_approval>false</requires_approval>
-</execute_command>
-
-## Example 2: Requesting to create a new file
-
-<write_to_file>
-<path>src/frontend-config.json</path>
-<content>
-{
-  "apiEndpoint": "https://api.example.com",
-  "theme": {
-    "primaryColor": "#007bff",
-    "secondaryColor": "#6c757d",
-    "fontFamily": "Arial, sans-serif"
-  },
-  "features": {
-    "darkMode": true,
-    "notifications": true,
-    "analytics": false
-  },
-  "version": "1.0.0"
-}
-</content>
-</write_to_file>
-
-## Example 3: Requesting to make targeted edits to a file
-
-<replace_in_file>
-<path>src/components/App.tsx</path>
-<diff>
-<<<<<<< SEARCH
+	const toolExamples: ({ title: string } & ToolCall)[] = [
+		{
+			title: "Requesting to execute a command",
+			name: "execute_command",
+			args: {
+				command: "npm run dev",
+				requires_approval: false,
+			},
+		},
+		{
+			title: "Requesting to create a new file",
+			name: "write_to_file",
+			args: {
+				path: "src/frontend-config.json",
+				content: JSON.stringify(
+					{
+						apiEndpoint: "https://api.example.com",
+						theme: {
+							primaryColor: "#007bff",
+							secondaryColor: "#6c757d",
+							fontFamily: "Arial, sans-serif",
+						},
+						features: {
+							darkMode: true,
+							notifications: true,
+							analytics: false,
+						},
+						version: "1.0.0",
+					},
+					null,
+					2,
+				),
+			},
+		},
+		{
+			title: "Requesting to make targeted edits to a file",
+			name: "replace_in_file",
+			args: {
+				path: "src/components/App.tsx",
+				diff: `<<<<<<< SEARCH
 import React from 'react';
 =======
 import React, { useState } from 'react';
@@ -306,51 +520,70 @@ function handleSubmit() {
 
 return (
   <div>
->>>>>>> REPLACE
-</diff>
-</replace_in_file>
-${
-	mcpHub.getMode() !== "off"
-		? `
+>>>>>>> REPLACE`,
+			},
+		},
+	]
 
-## Example 4: Requesting to use an MCP tool
+	if (mcpHub.getMode() !== "off") {
+		toolExamples.push({
+			title: "Requesting to use an MCP tool",
+			name: "use_mcp_tool",
+			args: {
+				server_name: "weather-server",
+				tool_name: "get_forecast",
+				arguments: JSON.stringify(
+					{
+						city: "San Francisco",
+						days: 5,
+					},
+					null,
+					2,
+				),
+			},
+		})
+		toolExamples.push({
+			title: "Requesting to access an MCP resource",
+			name: "access_mcp_resource",
+			args: {
+				server_name: "weather-server",
+				uri: "weather://san-francisco/current",
+			},
+		})
 
-<use_mcp_tool>
-<server_name>weather-server</server_name>
-<tool_name>get_forecast</tool_name>
-<arguments>
-{
-  "city": "San Francisco",
-  "days": 5
-}
-</arguments>
-</use_mcp_tool>
+		toolExamples.push({
+			title: "Another example of using an MCP tool (where the server name is a unique identifier such as a URL)",
+			name: "use_mcp_tool",
+			args: {
+				server_name: "github.com/modelcontextprotocol/servers/tree/main/src/github",
+				tool_name: "create_issue",
+				arguments: JSON.stringify(
+					{
+						owner: "octocat",
+						repo: "hello-world",
+						title: "Found a bug",
+						body: "I'm having a problem with this.",
+						labels: ["bug", "help wanted"],
+						assignees: ["octocat"],
+					},
+					null,
+					2,
+				),
+			},
+		})
+	}
 
-## Example 5: Requesting to access an MCP resource
+	const systemPrompt = `You are Cline, a highly skilled software engineer with extensive knowledge in many programming languages, frameworks, design patterns, and best practices.
 
-<access_mcp_resource>
-<server_name>weather-server</server_name>
-<uri>weather://san-francisco/current</uri>
-</access_mcp_resource>
+====
 
-## Example 6: Another example of using an MCP tool (where the server name is a unique identifier such as a URL)
+TOOL USE
 
-<use_mcp_tool>
-<server_name>github.com/modelcontextprotocol/servers/tree/main/src/github</server_name>
-<tool_name>create_issue</tool_name>
-<arguments>
-{
-  "owner": "octocat",
-  "repo": "hello-world",
-  "title": "Found a bug",
-  "body": "I'm having a problem with this.",
-  "labels": ["bug", "help wanted"],
-  "assignees": ["octocat"]
-}
-</arguments>
-</use_mcp_tool>`
-		: ""
-}
+You have access to a set of tools that are executed upon the user's approval. You can use one tool per message, and will receive the result of that tool use in the user's response. You use tools step-by-step to accomplish a given task, with each tool use informed by the result of the previous tool use.
+
+${toolsPreamble}# Tool Use Examples
+
+${(await Promise.all(toolExamples.map(async ({ title, name, args }, i) => `## Example ${i + 1}: ${title}\n\n${await formatToolCall(name, args)}`))).join("\n\n")}
 
 # Tool Use Guidelines
 
@@ -893,17 +1126,17 @@ In each user message, the environment_details will specify the current mode. The
 CAPABILITIES
 
 - You have access to tools that let you execute CLI commands on the user's computer, list files, view source code definitions, regex search${
-	supportsComputerUse ? ", use the browser" : ""
-}, read and edit files, and ask follow-up questions. These tools help you effectively accomplish a wide range of tasks, such as writing code, making edits or improvements to existing files, understanding the current state of a project, performing system operations, and much more.
+		supportsComputerUse ? ", use the browser" : ""
+	}, read and edit files, and ask follow-up questions. These tools help you effectively accomplish a wide range of tasks, such as writing code, making edits or improvements to existing files, understanding the current state of a project, performing system operations, and much more.
 - When the user initially gives you a task, a recursive list of all filepaths in the current working directory ('${cwd.toPosix()}') will be included in environment_details. This provides an overview of the project's file structure, offering key insights into the project from directory/file names (how developers conceptualize and organize their code) and file extensions (the language used). This can also guide decision-making on which files to explore further. If you need to further explore directories such as outside the current working directory, you can use the list_files tool. If you pass 'true' for the recursive parameter, it will list files recursively. Otherwise, it will list files at the top level, which is better suited for generic directories where you don't necessarily need the nested structure, like the Desktop.
 - You can use search_files to perform regex searches across files in a specified directory, outputting context-rich results that include surrounding lines. This is particularly useful for understanding code patterns, finding specific implementations, or identifying areas that need refactoring.
 - You can use the list_code_definition_names tool to get an overview of source code definitions for all files at the top level of a specified directory. This can be particularly useful when you need to understand the broader context and relationships between certain parts of the code. You may need to call this tool multiple times to understand various parts of the codebase related to the task.
 	- For example, when asked to make edits or improvements you might analyze the file structure in the initial environment_details to get an overview of the project, then use list_code_definition_names to get further insight using source code definitions for files located in relevant directories, then read_file to examine the contents of relevant files, analyze the code and suggest improvements or make necessary edits, then use the replace_in_file tool to implement changes. If you refactored code that could affect other parts of the codebase, you could use search_files to ensure you update other files as needed.
 - You can use the execute_command tool to run commands on the user's computer whenever you feel it can help accomplish the user's task. When you need to execute a CLI command, you must provide a clear explanation of what the command does. Prefer to execute complex CLI commands over creating executable scripts, since they are more flexible and easier to run. Interactive and long-running commands are allowed, since the commands are run in the user's VSCode terminal. The user may keep commands running in the background and you will be kept updated on their status along the way. Each command you execute is run in a new terminal instance.${
-	supportsComputerUse
-		? "\n- You can use the browser_action tool to interact with websites (including html files and locally running development servers) through a Puppeteer-controlled browser when you feel it is necessary in accomplishing the user's task. This tool is particularly useful for web development tasks as it allows you to launch a browser, navigate to pages, interact with elements through clicks and keyboard input, and capture the results through screenshots and console logs. This tool may be useful at key stages of web development tasks-such as after implementing new features, making substantial changes, when troubleshooting issues, or to verify the result of your work. You can analyze the provided screenshots to ensure correct rendering or identify errors, and review console logs for runtime issues.\n	- For example, if asked to add a component to a react website, you might create the necessary files, use execute_command to run the site locally, then use browser_action to launch the browser, navigate to the local server, and verify the component renders & functions correctly before closing the browser."
-		: ""
-}
+		supportsComputerUse
+			? "\n- You can use the browser_action tool to interact with websites (including html files and locally running development servers) through a Puppeteer-controlled browser when you feel it is necessary in accomplishing the user's task. This tool is particularly useful for web development tasks as it allows you to launch a browser, navigate to pages, interact with elements through clicks and keyboard input, and capture the results through screenshots and console logs. This tool may be useful at key stages of web development tasks-such as after implementing new features, making substantial changes, when troubleshooting issues, or to verify the result of your work. You can analyze the provided screenshots to ensure correct rendering or identify errors, and review console logs for runtime issues.\n	- For example, if asked to add a component to a react website, you might create the necessary files, use execute_command to run the site locally, then use browser_action to launch the browser, navigate to the local server, and verify the component renders & functions correctly before closing the browser."
+			: ""
+	}
 ${
 	mcpHub.getMode() !== "off"
 		? `
@@ -930,10 +1163,10 @@ RULES
 - When executing commands, if you don't see the expected output, assume the terminal executed the command successfully and proceed with the task. The user's terminal may be unable to stream the output back properly. If you absolutely need to see the actual terminal output, use the ask_followup_question tool to request the user to copy and paste it back to you.
 - The user may provide a file's contents directly in their message, in which case you shouldn't use the read_file tool to get the file contents again since you already have it.
 - Your goal is to try to accomplish the user's task, NOT engage in a back and forth conversation.${
-	supportsComputerUse
-		? `\n- The user may ask generic non-development tasks, such as "what\'s the latest news" or "look up the weather in San Diego", in which case you might use the browser_action tool to complete the task if it makes sense to do so, rather than trying to create a website or using curl to answer the question.${mcpHub.getMode() !== "off" ? "However, if an available MCP server tool or resource can be used instead, you should prefer to use it over browser_action." : ""}`
-		: ""
-}
+		supportsComputerUse
+			? `\n- The user may ask generic non-development tasks, such as "what\'s the latest news" or "look up the weather in San Diego", in which case you might use the browser_action tool to complete the task if it makes sense to do so, rather than trying to create a website or using curl to answer the question.${mcpHub.getMode() !== "off" ? "However, if an available MCP server tool or resource can be used instead, you should prefer to use it over browser_action." : ""}`
+			: ""
+	}
 - NEVER end attempt_completion result with a question or request to engage in further conversation! Formulate the end of your result in a way that is final and does not require further input from the user.
 - You are STRICTLY FORBIDDEN from starting your messages with "Great", "Certainly", "Okay", "Sure". You should NOT be conversational in your responses, but rather direct and to the point. For example you should NOT say "Great, I've updated the CSS" but instead something like "I've updated the CSS". It is important you be clear and technical in your messages.
 - When presented with images, utilize your vision capabilities to thoroughly examine them and extract meaningful information. Incorporate these insights into your thought process as you accomplish the user's task.
@@ -942,10 +1175,10 @@ RULES
 - When using the replace_in_file tool, you must include complete lines in your SEARCH blocks, not partial lines. The system requires exact line matches and cannot match partial lines. For example, if you want to match a line containing "const x = 5;", your SEARCH block must include the entire line, not just "x = 5" or other fragments.
 - When using the replace_in_file tool, if you use multiple SEARCH/REPLACE blocks, list them in the order they appear in the file. For example if you need to make changes to both line 10 and line 50, first include the SEARCH/REPLACE block for line 10, followed by the SEARCH/REPLACE block for line 50.
 - It is critical you wait for the user's response after each tool use, in order to confirm the success of the tool use. For example, if asked to make a todo app, you would create a file, wait for the user's response it was created successfully, then create another file if needed, wait for the user's response it was created successfully, etc.${
-	supportsComputerUse
-		? " Then if you want to test your work, you might use browser_action to launch the site, wait for the user's response confirming the site was launched along with a screenshot, then perhaps e.g., click a button to test functionality if needed, wait for the user's response confirming the button was clicked along with a screenshot of the new state, before finally closing the browser."
-		: ""
-}
+		supportsComputerUse
+			? " Then if you want to test your work, you might use browser_action to launch the site, wait for the user's response confirming the site was launched along with a screenshot, then perhaps e.g., click a button to test functionality if needed, wait for the user's response confirming the button was clicked along with a screenshot of the new state, before finally closing the browser."
+			: ""
+	}
 ${
 	mcpHub.getMode() !== "off"
 		? `
@@ -974,6 +1207,13 @@ You accomplish a given task iteratively, breaking it down into clear steps and w
 3. Remember, you have extensive capabilities with access to a wide range of tools that can be used in powerful and clever ways as necessary to accomplish each goal. Before calling a tool, do some analysis within <thinking></thinking> tags. First, analyze the file structure provided in environment_details to gain context and insights for proceeding effectively. Then, think about which of the provided tools is the most relevant tool to accomplish the user's task. Next, go through each of the required parameters of the relevant tool and determine if the user has directly provided or given enough information to infer a value. When deciding if the parameter can be inferred, carefully consider all the context to see if it supports a specific value. If all of the required parameters are present or can be reasonably inferred, close the thinking tag and proceed with the tool use. BUT, if one of the values for a required parameter is missing, DO NOT invoke the tool (not even with fillers for the missing params) and instead, ask the user to provide the missing parameters using the ask_followup_question tool. DO NOT ask for more information on optional parameters if it is not provided.
 4. Once you've completed the user's task, you must use the attempt_completion tool to present the result of the task to the user. You may also provide a CLI command to showcase the result of your task; this can be particularly useful for web development tasks, where you can run e.g. \`open index.html\` to show the website you've built.
 5. The user may provide feedback, which you can use to make improvements and try again. But DO NOT continue in pointless back and forth conversations, i.e. don't end your responses with questions or offers for further assistance.`
+
+	if (supportsTools) {
+		return { systemPrompt, tools: toolsAndExamples.map(([t, e]) => t) }
+	} else {
+		return { systemPrompt }
+	}
+}
 
 export function addUserInstructions(
 	settingsCustomInstructions?: string,

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -48,6 +48,7 @@ type SecretKey =
 	| "openAiApiKey"
 	| "geminiApiKey"
 	| "openAiNativeApiKey"
+	| "llamaCppApiKey"
 	| "deepSeekApiKey"
 	| "requestyApiKey"
 	| "togetherApiKey"
@@ -73,6 +74,7 @@ type GlobalStateKey =
 	| "openAiModelInfo"
 	| "ollamaModelId"
 	| "ollamaBaseUrl"
+	| "llamaCppBaseUrl"
 	| "lmStudioModelId"
 	| "lmStudioBaseUrl"
 	| "anthropicBaseUrl"
@@ -468,6 +470,8 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 								openAiModelInfo,
 								ollamaModelId,
 								ollamaBaseUrl,
+								llamaCppBaseUrl,
+								llamaCppApiKey,
 								lmStudioModelId,
 								lmStudioBaseUrl,
 								anthropicBaseUrl,
@@ -508,6 +512,7 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 							await this.updateGlobalState("openAiModelInfo", openAiModelInfo)
 							await this.updateGlobalState("ollamaModelId", ollamaModelId)
 							await this.updateGlobalState("ollamaBaseUrl", ollamaBaseUrl)
+							await this.updateGlobalState("llamaCppBaseUrl", llamaCppBaseUrl)
 							await this.updateGlobalState("lmStudioModelId", lmStudioModelId)
 							await this.updateGlobalState("lmStudioBaseUrl", lmStudioBaseUrl)
 							await this.updateGlobalState("anthropicBaseUrl", anthropicBaseUrl)
@@ -519,6 +524,7 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 							await this.storeSecret("qwenApiKey", qwenApiKey)
 							await this.storeSecret("mistralApiKey", mistralApiKey)
 							await this.storeSecret("liteLlmApiKey", liteLlmApiKey)
+							await this.storeSecret("llamaCppApiKey", llamaCppApiKey)
 							await this.updateGlobalState("azureApiVersion", azureApiVersion)
 							await this.updateGlobalState("openRouterModelId", openRouterModelId)
 							await this.updateGlobalState("openRouterModelInfo", openRouterModelInfo)
@@ -1680,6 +1686,8 @@ Here is the project's README to help you get started:\n\n${mcpDetails.readmeCont
 			openAiModelInfo,
 			ollamaModelId,
 			ollamaBaseUrl,
+			llamaCppBaseUrl,
+			llamaCppApiKey,
 			lmStudioModelId,
 			lmStudioBaseUrl,
 			anthropicBaseUrl,
@@ -1731,6 +1739,8 @@ Here is the project's README to help you get started:\n\n${mcpDetails.readmeCont
 			this.getGlobalState("openAiModelInfo") as Promise<ModelInfo | undefined>,
 			this.getGlobalState("ollamaModelId") as Promise<string | undefined>,
 			this.getGlobalState("ollamaBaseUrl") as Promise<string | undefined>,
+			this.getGlobalState("llamaCppBaseUrl") as Promise<string | undefined>,
+			this.getSecret("llamaCppApiKey") as Promise<string | undefined>,
 			this.getGlobalState("lmStudioModelId") as Promise<string | undefined>,
 			this.getGlobalState("lmStudioBaseUrl") as Promise<string | undefined>,
 			this.getGlobalState("anthropicBaseUrl") as Promise<string | undefined>,
@@ -1805,6 +1815,8 @@ Here is the project's README to help you get started:\n\n${mcpDetails.readmeCont
 				openAiModelInfo,
 				ollamaModelId,
 				ollamaBaseUrl,
+				llamaCppBaseUrl,
+				llamaCppApiKey,
 				lmStudioModelId,
 				lmStudioBaseUrl,
 				anthropicBaseUrl,

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -5,6 +5,7 @@ export type ApiProvider =
 	| "vertex"
 	| "openai"
 	| "ollama"
+	| "llama.cpp"
 	| "lmstudio"
 	| "gemini"
 	| "openai-native"
@@ -41,6 +42,8 @@ export interface ApiHandlerOptions {
 	openAiModelInfo?: ModelInfo
 	ollamaModelId?: string
 	ollamaBaseUrl?: string
+	llamaCppBaseUrl?: string
+	llamaCppApiKey?: string
 	lmStudioModelId?: string
 	lmStudioBaseUrl?: string
 	geminiApiKey?: string
@@ -252,6 +255,15 @@ export const openAiModelInfoSaneDefaults: ModelInfo = {
 	contextWindow: 128_000,
 	supportsImages: true,
 	supportsPromptCache: false,
+	inputPrice: 0,
+	outputPrice: 0,
+}
+
+export const llamaCppModelInfoSaneDefaults: ModelInfo = {
+	maxTokens: -1,
+	supportsImages: false,
+	supportsPromptCache: true,
+	supportsTools: true,
 	inputPrice: 0,
 	outputPrice: 0,
 }

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -70,6 +70,7 @@ export interface ModelInfo {
 	supportsImages?: boolean
 	supportsComputerUse?: boolean
 	supportsPromptCache: boolean // this value is hardcoded for now
+	supportsTools?: boolean
 	inputPrice?: number
 	outputPrice?: number
 	cacheWritesPrice?: number

--- a/webview-ui/src/components/chat/ChatTextArea.tsx
+++ b/webview-ui/src/components/chat/ChatTextArea.tsx
@@ -755,6 +755,8 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 					return `${selectedProvider}:${apiConfiguration.lmStudioModelId}`
 				case "ollama":
 					return `${selectedProvider}:${apiConfiguration.ollamaModelId}`
+				case "llama.cpp":
+					return "undefined"
 				case "litellm":
 					return `${selectedProvider}:${apiConfiguration.liteLlmModelId}`
 				case "requesty":

--- a/webview-ui/src/components/settings/ApiOptions.tsx
+++ b/webview-ui/src/components/settings/ApiOptions.tsx
@@ -33,6 +33,7 @@ import {
 	openRouterDefaultModelInfo,
 	vertexDefaultModelId,
 	vertexModels,
+	llamaCppModelInfoSaneDefaults,
 } from "../../../../src/shared/api"
 import { ExtensionMessage } from "../../../../src/shared/ExtensionMessage"
 import { useExtensionState } from "../../context/ExtensionStateContext"
@@ -194,6 +195,7 @@ const ApiOptions = ({ showModelOptions, apiErrorMessage, modelIdErrorMessage, is
 					<VSCodeOption value="qwen">Alibaba Qwen</VSCodeOption>
 					<VSCodeOption value="lmstudio">LM Studio</VSCodeOption>
 					<VSCodeOption value="ollama">Ollama</VSCodeOption>
+					<VSCodeOption value="llama.cpp">llama.cpp</VSCodeOption>
 					<VSCodeOption value="litellm">LiteLLM</VSCodeOption>
 				</VSCodeDropdown>
 			</DropdownContainer>
@@ -1122,6 +1124,66 @@ const ApiOptions = ({ showModelOptions, apiErrorMessage, modelIdErrorMessage, is
 				</div>
 			)}
 
+			{selectedProvider === "llama.cpp" && (
+				<div>
+					<VSCodeTextField
+						value={apiConfiguration?.llamaCppBaseUrl || ""}
+						style={{ width: "100%" }}
+						type="url"
+						onInput={handleInputChange("llamaCppBaseUrl")}
+						placeholder={"Default: http://localhost:8080"}>
+						<span style={{ fontWeight: 500 }}>Base URL</span>
+					</VSCodeTextField>
+					<VSCodeTextField
+						value={apiConfiguration?.llamaCppApiKey || ""}
+						style={{ width: "100%" }}
+						type="password"
+						onInput={handleInputChange("llamaCppApiKey")}
+						placeholder="Default: unset">
+						<span style={{ fontWeight: 500 }}>
+							API Key (if <code>--api-key*</code> set)
+						</span>
+					</VSCodeTextField>
+					<p
+						style={{
+							fontSize: "12px",
+							marginTop: "5px",
+							color: "var(--vscode-descriptionForeground)",
+						}}>
+						llama.cpp allows you to run GGUF models locally on your computer. Their documentation explains
+						<VSCodeLink
+							href="https://github.com/ggml-org/llama.cpp?tab=readme-ov-file#building-the-project"
+							style={{ display: "inline", fontSize: "inherit" }}>
+							how to install / build
+						</VSCodeLink>
+						and which options
+						<VSCodeLink
+							href="https://github.com/ggerganov/llama.cpp/blob/master/examples/server/README.md"
+							style={{ display: "inline", fontSize: "inherit" }}>
+							llama-server
+						</VSCodeLink>
+						supports.
+						<br />
+						<span style={{ color: "var(--vscode-errorForeground)" }}>
+							<span style={{ fontWeight: 500 }}>Note:</span> Cline uses complex prompts and works best with Claude
+							models. Less capable models may not work as expected: for a given model family, try the largest, least
+							quantized model you can fit in your VRAM / RAM for the best results. Also, please only use models that
+							support long context windows (e.g. 128k tokens). Here are configurations known to work (YMMV):
+							<pre>
+								<code>
+									llama-server -hf unsloth/phi-4-GGUF:Q6_K -c 131072 --jinja -fa -ngl 999
+									<br />
+									llama-server -hf unsloth/Qwen2.5-Coder-32B-Instruct-128K-GGUF -c 0 --jinja -fa -ngl 999
+									<br />
+									llama-server -hf bartowski/Mistral-Nemo-Instruct-2407-GGUF:Q6_K_L -c 0 --jinja -fa -ngl 999
+								</code>
+							</pre>
+							<p></p>
+						</span>
+					</p>
+				</div>
+			)}
+
 			{apiErrorMessage && (
 				<p
 					style={{
@@ -1379,6 +1441,12 @@ export function normalizeApiConfiguration(apiConfiguration?: ApiConfiguration): 
 				selectedProvider: provider,
 				selectedModelId: apiConfiguration?.ollamaModelId || "",
 				selectedModelInfo: openAiModelInfoSaneDefaults,
+			}
+		case "llama.cpp":
+			return {
+				selectedProvider: provider,
+				selectedModelId: "",
+				selectedModelInfo: llamaCppModelInfoSaneDefaults,
 			}
 		case "lmstudio":
 			return {


### PR DESCRIPTION
### Description

This adds a provider for [llama.cpp](https://github.com/ggml-org/llama.cpp)'s `llama-server`, leveraging its recently introduced [grammar-constrained, universal tool call support](https://github.com/ggml-org/llama.cpp/pull/9639).

Structural changes:
- Refactored `system.ts`:
  - Optionally return tool definitions to pass to `ApiHandler.createMessage` (if `ModelInfo.supportsTools`)
  - Add provider-specific formatting of tool call examples (implemented w/ llama.cpp api calls - cached)

Limitations:
- No streaming yet, so you may wanna launch `llama-server` with the `--verbose` flag to see what's happening (especially when the KV cache isn't hot yet on first call)
  - `llama-server` doesn't support tool calls in streaming mode yet
  - I'm translating the tool_calls output back to the XML-ish format Cline expects, so this would also need a revamp to support streaming
- Calling llama-server's `/apply-template` endpoint w/ + [fresh new add_generation_prompt param](https://github.com/ggml-org/llama.cpp/pull/12062) to compute tool call deltas. This is used in the system prompt to express the few-shot tool use examples with the call syntax native to the model, which helps it tremendously (esp. when small).
- Need an async call to know the model's max tokens, which makes the code slightly awkward (getModel may return default values before props are fetched; may want to make getModel async as follow up?)
- Qwen 2.5 Coder support needs https://github.com/ggml-org/llama.cpp/pull/12034 (under review / not merged yet)

TODOs / follow ups:
- [x] Merge https://github.com/ggml-org/llama.cpp/pull/12062
- [ ] Fix Context Window gauge
- [ ] Nicer error messages when llama-server is down (currently cryptic `fetch failed`)
- [ ] Update help text to heavily suggest disabling MCP to save context
- [ ] Merge https://github.com/ggml-org/llama.cpp/pull/12034 (non-blocker)

Note that switching to native tool use for other providers should be possible (even for Claude, assuming it doesn't mess with its caching), but one would need to find a nice syntax to format tool call examples.

### Test Procedure

I haven't tested this thoroughly yet, but did check that the system prompt didn't budge (only diff is in `Example 6` where JSON arguments are now fully indented - incl. labels & assignees)

Mostly had to disabled MCP to save prompt, tested successfully w/ long context window models (128k tokens):

```shell
git clone https://github.com/ggerganov/llama.cpp
cd llama.cpp
git remote add ochafik https://github.com/ochafik/llama.cpp
git fetch ochafik
git checkout ochafik/tool-bench-prod
cmake -B build -DLLAMA_CURL=1
cmake --build build -t llama-server --parallel --config Release
alias llama-server=./build/bin/llama-server

llama-server --jinja -fa -hf unsloth/phi-4-GGUF:Q6_K -c 131072 -ngl 999
llama-server --jinja -fa -hf bartowski/Mistral-Nemo-Instruct-2407-GGUF:Q6_K_L -c 0 -ngl 999
llama-server --jinja -fa -hf unsloth/Qwen2.5-Coder-32B-Instruct-128K-GGUF -c 0 -ngl 999
```

Some notes:
- [Qwen 2.5 Coder 32B 128k](https://huggingface.co/unsloth/Qwen2.5-Coder-32B-Instruct-128K-GGUF) works best but requires this PR: https://github.com/ggml-org/llama.cpp/pull/12034
- `unsloth/phi-4-GGUF` supports 128k context window but it's not set in its properties (the other models support `-c 0` to mean "use the model's maximum")

Random prompts tested:
- write a web app that creates qr codes
- write a lisp parser in c++
- write a trie in c++
- build a todo list web app that persists in local storage

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
  - happy to split this 
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<img width="471" alt="image" src="https://github.com/user-attachments/assets/6a65a452-b7a1-49c4-ba3a-81ffe5873f4b" />

### Additional Notes

Still some todos but could be done as follow ups.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds llama.cpp provider with tool call support, updating API handling, configuration, and UI components to integrate llama-server.
> 
>   - **Behavior**:
>     - Adds `LlamaCppHandler` in `llama.cpp.ts` to support llama.cpp's `llama-server` with tool call functionality.
>     - Updates `createMessage` function across multiple providers to include `tools` parameter.
>     - Implements provider-specific tool call formatting in `system.ts`.
>   - **Configuration**:
>     - Adds `llama.cpp` as a new `ApiProvider` in `api.ts`.
>     - Updates `ApiOptions` component to include llama.cpp configuration fields.
>     - Adds `llamaCppBaseUrl` and `llamaCppApiKey` to `ApiHandlerOptions`.
>   - **UI**:
>     - Updates `ChatTextArea.tsx` and `ApiOptions.tsx` to support llama.cpp in the UI.
>     - Adds llama.cpp specific fields in the settings UI for base URL and API key.
>   - **Misc**:
>     - Adds `llamaCppModelInfoSaneDefaults` in `api.ts` for default model info.
>     - Updates `ClineProvider.ts` to handle llama.cpp specific configurations.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 6760db3b5d2e8a3d0d8c4b3c72747ce626a26a8d. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->