### PR TITLE
fix: fix claude_3_7_sonnet support on bedrock

### DIFF
--- a/.changeset/dull-flies-flash.md
+++ b/.changeset/dull-flies-flash.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+fix claude 3.7 sonnet access for amazon bedrock

--- a/src/api/providers/bedrock.ts
+++ b/src/api/providers/bedrock.ts
@@ -119,7 +119,14 @@ export class AwsBedrockHandler implements ApiHandler {
 	}
 
 	private async getModelId(): Promise<string> {
-		if (this.options.awsUseCrossRegionInference) {
+
+	// Automatically enable cross-region inference for Claude 3.7 Sonnet
+	if (this.getModel().id === "anthropic.claude-3-7-sonnet-20250219-v1:0") {
+		this.options.awsUseCrossRegionInference = true;
+		return `us.${this.getModel().id}`
+	}
+	// Handle cross-region inference if enabled
+	if (this.options.awsUseCrossRegionInference) {
 			let regionPrefix = (this.options.awsRegion || "").slice(0, 3)
 			switch (regionPrefix) {
 				case "us-":

--- a/src/api/providers/bedrock.ts
+++ b/src/api/providers/bedrock.ts
@@ -119,13 +119,12 @@ export class AwsBedrockHandler implements ApiHandler {
 	}
 
 	private async getModelId(): Promise<string> {
-
-	// Automatically enable cross-region inference for Claude 3.7 Sonnet
-	if (this.getModel().id === "anthropic.claude-3-7-sonnet-20250219-v1:0") {
-		this.options.awsUseCrossRegionInference = true;
-	}
-	// Handle cross-region inference if enabled
-	if (this.options.awsUseCrossRegionInference) {
+		// Automatically enable cross-region inference for Claude 3.7 Sonnet
+		if (this.getModel().id === "anthropic.claude-3-7-sonnet-20250219-v1:0") {
+			this.options.awsUseCrossRegionInference = true
+		}
+		// Handle cross-region inference if enabled
+		if (this.options.awsUseCrossRegionInference) {
 			let regionPrefix = (this.options.awsRegion || "").slice(0, 3)
 			switch (regionPrefix) {
 				case "us-":

--- a/src/api/providers/bedrock.ts
+++ b/src/api/providers/bedrock.ts
@@ -132,11 +132,11 @@ export class AwsBedrockHandler implements ApiHandler {
 					return `us.${this.getModel().id}`
 				case "eu-":
 					return `eu.${this.getModel().id}`
-					break
+				case "ap-":
+					return `apac.${this.getModel().id}`
 				default:
 					// cross region inference is not supported in this region, falling back to default model
 					return this.getModel().id
-					break
 			}
 		}
 		return this.getModel().id

--- a/src/api/providers/bedrock.ts
+++ b/src/api/providers/bedrock.ts
@@ -123,7 +123,6 @@ export class AwsBedrockHandler implements ApiHandler {
 	// Automatically enable cross-region inference for Claude 3.7 Sonnet
 	if (this.getModel().id === "anthropic.claude-3-7-sonnet-20250219-v1:0") {
 		this.options.awsUseCrossRegionInference = true;
-		return `us.${this.getModel().id}`
 	}
 	// Handle cross-region inference if enabled
 	if (this.options.awsUseCrossRegionInference) {


### PR DESCRIPTION
### Description
Fix claude 3.7 sonnet support for bedrock. Sonnet is only available cross-region at the moment. Also add case for apac cross-region. 

### Test Procedure

<!-- How did you test this? Are you confident that it will not introduce bugs? If so, why? -->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Automatically enables cross-region inference for Claude 3.7 Sonnet in `AwsBedrockHandler` by prefixing model ID with `us.`.
> 
>   - **Behavior**:
>     - Automatically enables cross-region inference for `anthropic.claude-3-7-sonnet-20250219-v1:0` in `getModelId()` in `bedrock.ts`.
>     - Returns model ID prefixed with `us.` for this model.
>   - **Cross-Region Handling**:
>     - If `awsUseCrossRegionInference` is enabled, prefixes model ID with region code (`us.` or `eu.`) based on `awsRegion`.
>     - Falls back to default model ID if region is unsupported.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 771ddda98d4c8cf7d29d4c801e22641560d24d2e. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->