### PR TITLE
Hugelung/gpt 4.5

### DIFF
--- a/.changeset/rare-cougars-look.md
+++ b/.changeset/rare-cougars-look.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": minor
+---
+
+GPT 4.5 Preview added

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -453,6 +453,14 @@ export const openAiNativeModels = {
 		inputPrice: 0.15,
 		outputPrice: 0.6,
 	},
+	"gpt-4.5-preview": {
+		maxTokens: 16_384,
+		contextWindow: 128_000,
+		supportsImages: true,
+		supportsPromptCache: false,
+		inputPrice: 75,
+		outputPrice: 150,
+	}
 } as const satisfies Record<string, ModelInfo>
 
 // Azure OpenAI


### PR DESCRIPTION
### Description

Adds chatgpt 4.5 preview

### Test Procedure

- Removed the system prompt
- Asked Cline what model is being used
- Confirmed that the model string is correct on the bottom of vscode
- Logged in the openai provider to make sure the code is being used

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

![Screenshot From 2025-02-27 13-25-59](https://github.com/user-attachments/assets/9f9891fa-d6f3-46da-97cd-3ca9cc4153aa)
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds `gpt-4.5-preview` model to `openAiNativeModels` in `api.ts`.
> 
>   - **New Feature**:
>     - Adds `gpt-4.5-preview` to `openAiNativeModels` in `api.ts` with specific attributes: `maxTokens`, `contextWindow`, `supportsImages`, `supportsPromptCache`, `inputPrice`, and `outputPrice`.
>   - **Changeset**:
>     - Adds a changeset `rare-cougars-look.md` to document the addition of GPT 4.5 Preview.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for a5a66da739d3fc4e73340b8bf2c6a20bd0ee8fea. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->