### PR TITLE
Everyone Gets a Timeout

### DIFF
--- a/src/api/providers/requesty.ts
+++ b/src/api/providers/requesty.ts
@@ -2,7 +2,13 @@ import { Anthropic } from "@anthropic-ai/sdk"
 import OpenAI from "openai"
 import { withRetry } from "../retry"
 import { calculateApiCostOpenAI } from "../../utils/cost"
-import { ApiHandlerOptions, ModelInfo, openAiModelInfoSaneDefaults, requestyDefaultModelId, requestyDefaultModelInfo  } from "../../shared/api"
+import {
+	ApiHandlerOptions,
+	ModelInfo,
+	openAiModelInfoSaneDefaults,
+	requestyDefaultModelId,
+	requestyDefaultModelInfo,
+} from "../../shared/api"
 import { ApiHandler } from "../index"
 import { convertToOpenAiMessages } from "../transform/openai-format"
 import { ApiStream } from "../transform/stream"

--- a/src/core/prompts/system.ts
+++ b/src/core/prompts/system.ts
@@ -3,6 +3,7 @@ import os from "os"
 import osName from "os-name"
 import { McpHub } from "../../services/mcp/McpHub"
 import { BrowserSettings } from "../../shared/BrowserSettings"
+import { DEFAULT_MCP_TIMEOUT_SECONDS } from "../../shared/mcp"
 
 export const SYSTEM_PROMPT = async (
 	cwd: string,
@@ -752,15 +753,16 @@ IMPORTANT: Regardless of what else you see in the MCP settings file, you must de
 
 \`\`\`json
 {
-  "mcpServers": {
+ "mcpServers": {
     ...,
     "weather": {
       "command": "node",
       "args": ["/path/to/weather-server/build/index.js"],
       "env": {
         "OPENWEATHER_API_KEY": "user-provided-api-key"
-      }
-    },
+      },
+      "timeout": ${DEFAULT_MCP_TIMEOUT_SECONDS}, // ${DEFAULT_MCP_TIMEOUT_SECONDS} seconds should be set as the default timeout for all MCP servers
+    }
   }
 }
 \`\`\`

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -542,7 +542,6 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 							telemetryService.updateTelemetryState(isOptedIn)
 						})
 
-            
 						// post last cached models in case the call to endpoint fails
 						this.readDynamicProviderModels(GlobalFileNames.requestyModels).then((requestyModels) => {
 							if (requestyModels) {
@@ -552,7 +551,7 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 								})
 							}
 						})
-            
+
 						// gui relies on model info to be up-to-date to provide the most accurate pricing, so we need to fetch the latest details on launch.
 						// we do this for all users since many users switch between api providers and if they were to switch back to openrouter it would be showing outdated model info if we hadn't retrieved the latest at this point
 						// (see normalizeApiConfiguration > openrouter)
@@ -569,7 +568,7 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 								}
 							}
 						})
-            
+
 						break
 					case "newTask":
 						// Code that should run in response to the hello message command
@@ -971,6 +970,16 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 							} catch (error) {
 								console.error(`Error searching commits: ${JSON.stringify(error)}`)
 							}
+						}
+						break
+					}
+					case "updateMcpTimeout": {
+						try {
+							if (message.serverName && message.timeout) {
+								await this.mcpHub?.updateServerTimeout(message.serverName, message.timeout)
+							}
+						} catch (error) {
+							console.error(`Failed to update timeout for server ${message.serverName}:`, error)
 						}
 						break
 					}

--- a/src/services/mcp/McpHub.ts
+++ b/src/services/mcp/McpHub.ts
@@ -16,6 +16,7 @@ import * as vscode from "vscode"
 import { z } from "zod"
 import { ClineProvider, GlobalFileNames } from "../../core/webview/ClineProvider"
 import {
+	DEFAULT_MCP_TIMEOUT_SECONDS,
 	McpMode,
 	McpResource,
 	McpResourceResponse,
@@ -23,10 +24,11 @@ import {
 	McpServer,
 	McpTool,
 	McpToolCallResponse,
+	MIN_MCP_TIMEOUT_SECONDS,
 } from "../../shared/mcp"
 import { fileExistsAtPath } from "../../utils/fs"
 import { arePathsEqual } from "../../utils/path"
-
+import { secondsToMs } from "../../utils/time"
 export type McpConnection = {
 	server: McpServer
 	client: Client
@@ -35,13 +37,13 @@ export type McpConnection = {
 
 const AutoApproveSchema = z.array(z.string()).default([])
 
-// StdioServerParameters
 const StdioConfigSchema = z.object({
 	command: z.string(),
 	args: z.array(z.string()).optional(),
 	env: z.record(z.string()).optional(),
 	autoApprove: AutoApproveSchema.optional(),
 	disabled: z.boolean().optional(),
+	timeout: z.number().min(MIN_MCP_TIMEOUT_SECONDS).optional().default(DEFAULT_MCP_TIMEOUT_SECONDS),
 })
 
 const McpSettingsSchema = z.object({
@@ -242,28 +244,6 @@ export class McpHub {
 			}
 			transport.start = async () => {} // No-op now, .connect() won't fail
 
-			// // Set up notification handlers
-			// client.setNotificationHandler(
-			// 	// @ts-ignore-next-line
-			// 	{ method: "notifications/tools/list_changed" },
-			// 	async () => {
-			// 		console.log(`Tools changed for server: ${name}`)
-			// 		connection.server.tools = await this.fetchTools(name)
-			// 		await this.notifyWebviewOfServerChanges()
-			// 	},
-			// )
-
-			// client.setNotificationHandler(
-			// 	// @ts-ignore-next-line
-			// 	{ method: "notifications/resources/list_changed" },
-			// 	async () => {
-			// 		console.log(`Resources changed for server: ${name}`)
-			// 		connection.server.resources = await this.fetchResources(name)
-			// 		connection.server.resourceTemplates = await this.fetchResourceTemplates(name)
-			// 		await this.notifyWebviewOfServerChanges()
-			// 	},
-			// )
-
 			// Connect
 			await client.connect(transport)
 			connection.server.status = "connected"
@@ -343,10 +323,6 @@ export class McpHub {
 		const connection = this.connections.find((conn) => conn.server.name === name)
 		if (connection) {
 			try {
-				// connection.client.removeNotificationHandler("notifications/tools/list_changed")
-				// connection.client.removeNotificationHandler("notifications/resources/list_changed")
-				// connection.client.removeNotificationHandler("notifications/stderr")
-				// connection.client.removeNotificationHandler("notifications/stderr")
 				await connection.transport.close()
 				await connection.client.close()
 			} catch (error) {
@@ -563,6 +539,7 @@ export class McpHub {
 		if (connection.server.disabled) {
 			throw new Error(`Server "${serverName}" is disabled`)
 		}
+
 		return await connection.client.request(
 			{
 				method: "resources/read",
@@ -586,6 +563,17 @@ export class McpHub {
 			throw new Error(`Server "${serverName}" is disabled and cannot be used`)
 		}
 
+		let timeout = secondsToMs(DEFAULT_MCP_TIMEOUT_SECONDS) // sdk expects ms
+
+		try {
+			const config = JSON.parse(connection.server.config)
+			const parsedConfig = StdioConfigSchema.parse(config)
+			timeout = secondsToMs(parsedConfig.timeout)
+		} catch (error) {
+			console.error(`Failed to parse timeout configuration for server ${serverName}: ${error}`)
+			// Continue with default timeout
+		}
+
 		return await connection.client.request(
 			{
 				method: "tools/call",
@@ -595,6 +583,9 @@ export class McpHub {
 				},
 			},
 			CallToolResultSchema,
+			{
+				timeout,
+			},
 		)
 	}
 
@@ -658,6 +649,47 @@ export class McpHub {
 		} catch (error) {
 			vscode.window.showErrorMessage(
 				`Failed to delete MCP server: ${error instanceof Error ? error.message : String(error)}`,
+			)
+			throw error
+		}
+	}
+
+	public async updateServerTimeout(serverName: string, timeout: number): Promise<void> {
+		try {
+			// Validate timeout against schema
+			const setConfigResult = StdioConfigSchema.shape.timeout.safeParse(timeout)
+			if (!setConfigResult.success) {
+				throw new Error(`Invalid timeout value: ${timeout}. Must be at minimum ${MIN_MCP_TIMEOUT_SECONDS} seconds.`)
+			}
+
+			const settingsPath = await this.getMcpSettingsFilePath()
+			const content = await fs.readFile(settingsPath, "utf-8")
+			const config = JSON.parse(content)
+
+			if (!config.mcpServers?.[serverName]) {
+				throw new Error(`Server "${serverName}" not found in settings`)
+			}
+
+			// Update the timeout in the config
+			config.mcpServers[serverName] = {
+				...config.mcpServers[serverName],
+				timeout,
+			}
+
+			// Write updated config back to file
+			await fs.writeFile(settingsPath, JSON.stringify(config, null, 2))
+
+			// Update server connections to apply the new timeout
+			await this.updateServerConnections(config.mcpServers)
+
+			vscode.window.showInformationMessage(`Updated timeout to ${timeout} seconds`)
+		} catch (error) {
+			console.error("Failed to update server timeout:", error)
+			if (error instanceof Error) {
+				console.error("Error details:", error.message, error.stack)
+			}
+			vscode.window.showErrorMessage(
+				`Failed to update server timeout: ${error instanceof Error ? error.message : String(error)}`,
 			)
 			throw error
 		}

--- a/src/shared/WebviewMessage.ts
+++ b/src/shared/WebviewMessage.ts
@@ -70,7 +70,7 @@ export interface WebviewMessage {
 	chatSettings?: ChatSettings
 	chatContent?: ChatContent
 	mcpId?: string
-
+	timeout?: number
 	// For toggleToolAutoApprove
 	serverName?: string
 	toolName?: string

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -897,4 +897,3 @@ export const xaiModels = {
 		description: "X AI's Grok Beta model (legacy) with 131K context window",
 	},
 } as const satisfies Record<string, ModelInfo>
-

--- a/src/shared/mcp.ts
+++ b/src/shared/mcp.ts
@@ -1,3 +1,5 @@
+export const DEFAULT_MCP_TIMEOUT_SECONDS = 60 // matches Anthropic's default timeout in their MCP SDK
+export const MIN_MCP_TIMEOUT_SECONDS = 1
 export type McpMode = "full" | "server-use-only" | "off"
 
 export type McpServer = {
@@ -9,6 +11,7 @@ export type McpServer = {
 	resources?: McpResource[]
 	resourceTemplates?: McpResourceTemplate[]
 	disabled?: boolean
+	timeout?: number
 }
 
 export type McpTool = {

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -1,0 +1,3 @@
+export function secondsToMs(seconds: number): number {
+	return seconds * 1000
+}

--- a/webview-ui/src/components/mcp/McpView.tsx
+++ b/webview-ui/src/components/mcp/McpView.tsx
@@ -1,7 +1,15 @@
-import { VSCodeButton, VSCodeLink, VSCodePanels, VSCodePanelTab, VSCodePanelView } from "@vscode/webview-ui-toolkit/react"
+import {
+	VSCodeButton,
+	VSCodeLink,
+	VSCodePanels,
+	VSCodePanelTab,
+	VSCodePanelView,
+	VSCodeDropdown,
+	VSCodeOption,
+} from "@vscode/webview-ui-toolkit/react"
 import { useEffect, useState } from "react"
 import styled from "styled-components"
-import { McpServer } from "../../../../src/shared/mcp"
+import { DEFAULT_MCP_TIMEOUT_SECONDS, McpServer } from "../../../../src/shared/mcp"
 import { useExtensionState } from "../../context/ExtensionStateContext"
 import { getMcpServerDisplayName } from "../../utils/mcp"
 import { vscode } from "../../utils/vscode"
@@ -210,6 +218,36 @@ const ServerRow = ({ server }: { server: McpServer }) => {
 		}
 	}
 
+	const [timeoutValue, setTimeoutValue] = useState<string>(() => {
+		try {
+			const config = JSON.parse(server.config)
+			return config.timeout?.toString() || DEFAULT_MCP_TIMEOUT_SECONDS.toString()
+		} catch {
+			return DEFAULT_MCP_TIMEOUT_SECONDS.toString()
+		}
+	})
+
+	const timeoutOptions = [
+		{ value: "30", label: "30 seconds" },
+		{ value: "60", label: "1 minute" },
+		{ value: "300", label: "5 minutes" },
+		{ value: "600", label: "10 minutes" },
+		{ value: "1800", label: "30 minutes" },
+		{ value: "3600", label: "1 hour" },
+	]
+
+	const handleTimeoutChange = (e: any) => {
+		const select = e.target as HTMLSelectElement
+		const value = select.value
+		const num = parseInt(value)
+		setTimeoutValue(value)
+		vscode.postMessage({
+			type: "updateMcpTimeout",
+			serverName: server.name,
+			timeout: num,
+		})
+	}
+
 	const handleRestart = () => {
 		vscode.postMessage({
 			type: "restartMcpServer",
@@ -410,6 +448,16 @@ const ServerRow = ({ server }: { server: McpServer }) => {
 							</VSCodePanelView>
 						</VSCodePanels>
 
+						<div style={{ margin: "10px 7px" }}>
+							<label style={{ display: "block", marginBottom: "4px", fontSize: "13px" }}>Request Timeout</label>
+							<VSCodeDropdown style={{ width: "100%" }} value={timeoutValue} onChange={handleTimeoutChange}>
+								{timeoutOptions.map((option) => (
+									<VSCodeOption key={option.value} value={option.value}>
+										{option.label}
+									</VSCodeOption>
+								))}
+							</VSCodeDropdown>
+						</div>
 						<VSCodeButton
 							appearance="secondary"
 							onClick={handleRestart}

--- a/webview-ui/src/components/settings/SettingsView.tsx
+++ b/webview-ui/src/components/settings/SettingsView.tsx
@@ -18,7 +18,7 @@ const SettingsView = ({ onDone }: SettingsViewProps) => {
 		customInstructions,
 		setCustomInstructions,
 		openRouterModels,
-    requestyModels,
+		requestyModels,
 		telemetrySetting,
 		setTelemetrySetting,
 	} = useExtensionState()


### PR DESCRIPTION
### Description

This PR adds configurable timeout settings for individual MCP servers, allowing fine-grained control over how long each server's tool calls can run before timing out. Key changes include:

- Default timeout of 60 seconds (matching Anthropic's MCP SDK default)
- Added UI controls in McpView for easy timeout configuration

### Test Procedure

1. UI Testing:
- Confirmed dropdown shows correct preset timeout options
- Verified timeout changes persist
- Tested that timeout updates are passed to the server
 
2. Backwards Compatability:
- Verified that configs with no timeout set still work fine
- Checked that setting the timeout on configs without correctly writes the value

4. Installing a new server:
- Tested that Cline correctly writes the new timeout field with the default of 60 for new servers.

### Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)

### Pre-flight Checklist

- [x] Changes are limited to a single feature (timeout configuration for MCP servers)
- [x] Tests are passing (`npm test`) and code is formatted and linted
- [x] I have created a changeset using `npm run changeset`
- [x] I have reviewed contributor guidelines

### Screenshots


<img width="434" alt="Screenshot 2025-02-20 at 6 32 55 PM" src="https://github.com/user-attachments/assets/dbb50434-42ba-49b2-a320-1e5a809b3bf8" />


<img width="427" alt="Screenshot 2025-02-20 at 6 33 03 PM" src="https://github.com/user-attachments/assets/16924c13-0986-42b7-b81e-41164a505afb" />

### Additional Notes

Default timeout of 60 seconds matches Anthropic's MCP SDK default timeout.

Added this to the system prompt so that Cline creates new MCP servers with this value for visibility.

Existing server configs without this value will function fine - they will have this value set when it is explicitly set by the user, otherwise they will simply default to the default value of 60 seconds as before.
