### PR TITLE
Only requesting requesty models if requesty api key is set

### DIFF
--- a/.changeset/thirty-hairs-sleep.md
+++ b/.changeset/thirty-hairs-sleep.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": minor
+---
+
+only fetching requesty models if api key set

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -540,32 +540,35 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 							const { telemetrySetting } = state
 							const isOptedIn = telemetrySetting === "enabled"
 							telemetryService.updateTelemetryState(isOptedIn)
-						})
 
-						// post last cached models in case the call to endpoint fails
-						this.readDynamicProviderModels(GlobalFileNames.requestyModels).then((requestyModels) => {
-							if (requestyModels) {
-								this.postMessageToWebview({
-									type: "requestyModels",
-									requestyModels,
+							// only fetch requesty api key if api key is set
+							if (state.apiConfiguration?.requestyApiKey) {
+								// post last cached models in case the call to endpoint fails
+								this.readDynamicProviderModels(GlobalFileNames.requestyModels).then((requestyModels) => {
+									if (requestyModels) {
+										this.postMessageToWebview({
+											type: "requestyModels",
+											requestyModels,
+										})
+									}
 								})
-							}
-						})
 
-						// gui relies on model info to be up-to-date to provide the most accurate pricing, so we need to fetch the latest details on launch.
-						// we do this for all users since many users switch between api providers and if they were to switch back to openrouter it would be showing outdated model info if we hadn't retrieved the latest at this point
-						// (see normalizeApiConfiguration > openrouter)
-						this.refreshRequestyModels().then(async (requestyModels) => {
-							if (requestyModels) {
-								// update model info in state (this needs to be done here since we don't want to update state while settings is open, and we may refresh models there)
-								const { apiConfiguration } = await this.getState()
-								if (apiConfiguration.requestyModelId) {
-									await this.updateGlobalState(
-										"requestyModelInfo",
-										requestyModels[apiConfiguration.requestyModelId],
-									)
-									await this.postStateToWebview()
-								}
+								// gui relies on model info to be up-to-date to provide the most accurate pricing, so we need to fetch the latest details on launch.
+								// we do this for all users since many users switch between api providers and if they were to switch back to openrouter it would be showing outdated model info if we hadn't retrieved the latest at this point
+								// (see normalizeApiConfiguration > openrouter)
+								this.refreshRequestyModels().then(async (requestyModels) => {
+									if (requestyModels) {
+										// update model info in state (this needs to be done here since we don't want to update state while settings is open, and we may refresh models there)
+										const { apiConfiguration } = await this.getState()
+										if (apiConfiguration.requestyModelId) {
+											await this.updateGlobalState(
+												"requestyModelInfo",
+												requestyModels[apiConfiguration.requestyModelId],
+											)
+											await this.postStateToWebview()
+										}
+									}
+								})
 							}
 						})
 


### PR DESCRIPTION
### Description

<!-- Describe your changes in detail. What problem does this PR solve? -->

### Test Procedure

<!-- How did you test this? Are you confident that it will not introduce bugs? If so, why? -->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fetch `requestyModels` in `ClineProvider` only if `requestyApiKey` is set, preventing unnecessary API calls.
> 
>   - **Behavior**:
>     - In `ClineProvider`, only fetch `requestyModels` if `requestyApiKey` is set in `state.apiConfiguration`.
>     - Prevents unnecessary API calls when `requestyApiKey` is not provided.
>   - **Misc**:
>     - Adds a changeset file `thirty-hairs-sleep.md` to document the change.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 49ddbe59b30d523a6a9fc135920e0ce3c21fc6c4. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->