### PR TITLE
Add retries to bedrock createMessage

### DIFF
--- a/.changeset/cool-rice-chew.md
+++ b/.changeset/cool-rice-chew.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Add retries to Bedrock createMessage

--- a/src/api/providers/bedrock.ts
+++ b/src/api/providers/bedrock.ts
@@ -1,5 +1,6 @@
 import AnthropicBedrock from "@anthropic-ai/bedrock-sdk"
 import { Anthropic } from "@anthropic-ai/sdk"
+import { withRetry } from "../retry"
 import { ApiHandler } from "../"
 import { ApiHandlerOptions, bedrockDefaultModelId, BedrockModelId, bedrockModels, ModelInfo } from "../../shared/api"
 import { ApiStream } from "../transform/stream"
@@ -13,6 +14,7 @@ export class AwsBedrockHandler implements ApiHandler {
 		this.options = options
 	}
 
+	@withRetry()
 	async *createMessage(systemPrompt: string, messages: Anthropic.Messages.MessageParam[]): ApiStream {
 		// cross region inference requires prefixing the model id with the region
 		let modelId = await this.getModelId()


### PR DESCRIPTION
### Description

Add retries to Bedrock's createMessage as indicated by [this](https://github.com/cline/cline/pull/1605#issuecomment-2665904349)

Similar to [this comment](https://github.com/cline/cline/pull/1605#issuecomment-2666290702) I am also experiencing a 429 every once in a while. Measuring a before/after, it's about a 90% improvement when there's no prompt caching. I'm going to add some logging and see if I can track it down further but honestly this is probably worth it as is.

### Test Procedure

I've gotten Cline to a bit under a 200k context window on Claude Sonnet 3.5 v2 through Bedrock 5 times now, each time exhibited 1-2 rate limits. Testing without this change, I'll hit about 10 by the time I get to 100k - so there is a marked improvement

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [X ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [X ] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [X ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ X] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [ X] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

### Additional Notes

<!-- Add any additional notes for reviewers -->
