### PR TITLE
Add support for custom OpenRouter API base URL

### DIFF
--- a/.changeset/silly-crabs-hide.md
+++ b/.changeset/silly-crabs-hide.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+add support for custom OpenRouter API base URL

--- a/package.json
+++ b/package.json
@@ -177,6 +177,11 @@
 					"default": "medium",
 					"description": "Controls the reasoning effort when using the o3-mini model. Higher values may result in more thorough but slower responses."
 				},
+				"cline.openRouterCustomBaseUrl": {
+					"type": "string",
+					"default": null,
+					"description": "Custom base URL for OpenRouter API calls. If not specified, defaults to https://openrouter.ai/api/v1"
+				},
 				"cline.chromeExecutablePath": {
 					"type": "string",
 					"default": null,

--- a/src/api/providers/openrouter.ts
+++ b/src/api/providers/openrouter.ts
@@ -16,7 +16,7 @@ export class OpenRouterHandler implements ApiHandler {
 	constructor(options: ApiHandlerOptions) {
 		this.options = options
 		this.client = new OpenAI({
-			baseURL: "https://openrouter.ai/api/v1",
+			baseURL: this.options.openRouterBaseUrl,
 			apiKey: this.options.openRouterApiKey,
 			defaultHeaders: {
 				"HTTP-Referer": "https://cline.bot", // Optional, for including your app on openrouter.ai rankings.
@@ -225,7 +225,8 @@ export class OpenRouterHandler implements ApiHandler {
 	async *fetchGenerationDetails(genId: string) {
 		// console.log("Fetching generation details for:", genId)
 		try {
-			const response = await axios.get(`https://openrouter.ai/api/v1/generation?id=${genId}`, {
+			const baseUrl = this.options.openRouterBaseUrl
+			const response = await axios.get(`${baseUrl}/generation?id=${genId}`, {
 				headers: {
 					Authorization: `Bearer ${this.options.openRouterApiKey}`,
 				},

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -1533,12 +1533,17 @@ Here is the project's README to help you get started:\n\n${mcpDetails.readmeCont
 		}
 	}
 
-	// OpenRouter
+	getOpenRouterBaseUrl() {
+		const openRouterCustomBaseUrl = vscode.workspace.getConfiguration("cline").get<string>("openRouterCustomBaseUrl")
+		return openRouterCustomBaseUrl || "https://openrouter.ai/api/v1"
+	}
 
+	// OpenRouter
 	async handleOpenRouterCallback(code: string) {
 		let apiKey: string
 		try {
-			const response = await axios.post("https://openrouter.ai/api/v1/auth/keys", { code })
+			const baseUrl = this.getOpenRouterBaseUrl()
+			const response = await axios.post(`${baseUrl}/auth/keys`, { code })
 			if (response.data && response.data.key) {
 				apiKey = response.data.key
 			} else {
@@ -1628,7 +1633,8 @@ Here is the project's README to help you get started:\n\n${mcpDetails.readmeCont
 
 		let models: Record<string, ModelInfo> = {}
 		try {
-			const response = await axios.get("https://openrouter.ai/api/v1/models")
+			const baseUrl = this.getOpenRouterBaseUrl()
+			const response = await axios.get(`${baseUrl}/models`)
 			/*
 			{
 				"id": "anthropic/claude-3.5-sonnet",
@@ -2061,6 +2067,8 @@ Here is the project's README to help you get started:\n\n${mcpDetails.readmeCont
 			}
 		}
 
+		const openRouterBaseUrl = this.getOpenRouterBaseUrl()
+
 		const o3MiniReasoningEffort = vscode.workspace
 			.getConfiguration("cline.modelSettings.o3Mini")
 			.get("reasoningEffort", "medium")
@@ -2076,6 +2084,7 @@ Here is the project's README to help you get started:\n\n${mcpDetails.readmeCont
 				apiProvider,
 				apiModelId,
 				apiKey,
+				openRouterBaseUrl,
 				openRouterApiKey,
 				awsAccessKey,
 				awsSecretKey,

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -24,6 +24,7 @@ export interface ApiHandlerOptions {
 	liteLlmModelId?: string
 	liteLlmApiKey?: string
 	anthropicBaseUrl?: string
+	openRouterBaseUrl?: string
 	openRouterApiKey?: string
 	openRouterModelId?: string
 	openRouterModelInfo?: ModelInfo


### PR DESCRIPTION
### Description

<!-- Describe your changes in detail. What problem does this PR solve? -->
Requests sent to OpenRouter may encounter errors (see #1336, possibly due to regional blocking), which can be avoided through Cloudflare AI Gateway, so support for custom base URL is needed.

Previous pr: #1397 

### Test Procedure

<!-- How did you test this? Are you confident that it will not introduce bugs? If so, why? -->
Use cline with/without this option, see if it works normally.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->
![image](https://github.com/user-attachments/assets/cf94adde-8cc6-4950-9f4f-b7e1a288c90c)


### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add support for custom OpenRouter API base URL, allowing users to specify a different endpoint for API calls.
> 
>   - **Feature**:
>     - Add support for custom OpenRouter API base URL in `openrouter.ts` and `ClineProvider.ts`.
>     - New configuration `cline.openRouterCustomBaseUrl` in `package.json` with default `https://openrouter.ai/api/v1`.
>   - **Implementation**:
>     - Modify `OpenRouterHandler` constructor in `openrouter.ts` to use `openRouterBaseUrl` from options.
>     - Add `getOpenRouterBaseUrl()` in `ClineProvider.ts` to fetch custom URL from configuration.
>     - Update API calls in `ClineProvider.ts` to use the custom base URL.
>   - **Misc**:
>     - Add changeset file `silly-crabs-hide.md` for version tracking.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 8fb37ee3a74d7f4e7b4c7d5cdb6d84690bbcb0c4. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->