### PR TITLE
feat: add x-title and http-referer header to all openai providers

### DIFF
--- a/.changeset/shaggy-frogs-shop.md
+++ b/.changeset/shaggy-frogs-shop.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Improved observability of openai compatible APIs, by sending x-title and http-referer headers, as per Open Router standard.

--- a/src/api/providers/openai.ts
+++ b/src/api/providers/openai.ts
@@ -8,6 +8,11 @@ import { ApiStream } from "../transform/stream"
 import { convertToR1Format } from "../transform/r1-format"
 import { ChatCompletionReasoningEffort } from "openai/resources/chat/completions.mjs"
 
+export const defaultHeaders = {
+	"HTTP-Referer": "https://cline.bot", // Optional, for including your app on openrouter.ai rankings.
+	"X-Title": "Cline", // Optional. Shows in rankings on openrouter.ai.
+}
+
 export class OpenAiHandler implements ApiHandler {
 	private options: ApiHandlerOptions
 	private client: OpenAI
@@ -20,11 +25,13 @@ export class OpenAiHandler implements ApiHandler {
 				baseURL: this.options.openAiBaseUrl,
 				apiKey: this.options.openAiApiKey,
 				apiVersion: this.options.azureApiVersion || azureOpenAiDefaultApiVersion,
+				defaultHeaders,
 			})
 		} else {
 			this.client = new OpenAI({
 				baseURL: this.options.openAiBaseUrl,
 				apiKey: this.options.openAiApiKey,
+				defaultHeaders,
 			})
 		}
 	}

--- a/src/api/providers/openrouter.ts
+++ b/src/api/providers/openrouter.ts
@@ -8,6 +8,7 @@ import { ApiHandlerOptions, ModelInfo, openRouterDefaultModelId, openRouterDefau
 import { convertToOpenAiMessages } from "../transform/openai-format"
 import { ApiStream } from "../transform/stream"
 import { convertToR1Format } from "../transform/r1-format"
+import { defaultHeaders } from "./openai"
 
 export class OpenRouterHandler implements ApiHandler {
 	private options: ApiHandlerOptions
@@ -18,10 +19,7 @@ export class OpenRouterHandler implements ApiHandler {
 		this.client = new OpenAI({
 			baseURL: "https://openrouter.ai/api/v1",
 			apiKey: this.options.openRouterApiKey,
-			defaultHeaders: {
-				"HTTP-Referer": "https://cline.bot", // Optional, for including your app on openrouter.ai rankings.
-				"X-Title": "Cline", // Optional. Shows in rankings on openrouter.ai.
-			},
+			defaultHeaders,
 		})
 	}
 

--- a/src/api/providers/requesty.ts
+++ b/src/api/providers/requesty.ts
@@ -5,6 +5,7 @@ import { ApiHandler } from "../index"
 import { withRetry } from "../retry"
 import { convertToOpenAiMessages } from "../transform/openai-format"
 import { ApiStream } from "../transform/stream"
+import { defaultHeaders } from "./openai"
 
 export class RequestyHandler implements ApiHandler {
 	private options: ApiHandlerOptions
@@ -15,10 +16,7 @@ export class RequestyHandler implements ApiHandler {
 		this.client = new OpenAI({
 			baseURL: "https://router.requesty.ai/v1",
 			apiKey: this.options.requestyApiKey,
-			defaultHeaders: {
-				"HTTP-Referer": "https://cline.bot",
-				"X-Title": "Cline",
-			},
+			defaultHeaders,
 		})
 	}
 


### PR DESCRIPTION
### Description

<!-- Describe your changes in detail. What problem does this PR solve? -->

feat: add x-title and http-referer header to all openai providers

 - Provides the ability for Open AI compatible gateways, such as LiteLLM, Open Router, Requesty to determine originating app.
 - Uses standard set by Open Router.

### Test Procedure

1. Enable proxy on system
2. Run Roo in debug mode and view headers in proxy
3. Headers should be set for any "Open AI Compatible", "Requesty", or "Open Router" provider.

 - I have tested this locally using the above approach using an "Open AI Compatible" provider
 - I have also regression tested Requesty and Open Router providers.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

I marked as patch considering it's a small change.

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Previously headers were not sent for Open AI Compatbile gateways like LiteLLM.

Now headers are sent:
![Screenshot 2025-03-02 at 5 55 08 PM](https://github.com/user-attachments/assets/633ca169-d314-4e7f-bb14-c8ab3bbf8b7d)


### Additional Notes
