### PR TITLE
feat: 128k outputs for claude 3.7

### DIFF
--- a/.changeset/eight-snakes-share.md
+++ b/.changeset/eight-snakes-share.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Updates the Claude 3.7 Sonnet model configuration to fully support its 128K token output.

--- a/src/api/providers/anthropic.ts
+++ b/src/api/providers/anthropic.ts
@@ -95,15 +95,21 @@ export class AnthropicHandler implements ApiHandler {
 						// prompt caching: https://x.com/alexalbert__/status/1823751995901272068
 						// https://github.com/anthropics/anthropic-sdk-typescript?tab=readme-ov-file#default-headers
 						// https://github.com/anthropics/anthropic-sdk-typescript/commit/c920b77fc67bd839bfeb6716ceab9d7c9bbe7393
+
+						const betas = []
+
 						switch (modelId) {
+							// @ts-ignore
 							case "claude-3-7-sonnet-20250219":
+								betas.push("output-128k-2025-02-19")
 							case "claude-3-5-sonnet-20241022":
 							case "claude-3-5-haiku-20241022":
 							case "claude-3-opus-20240229":
 							case "claude-3-haiku-20240307":
+								betas.push("prompt-caching-2024-07-31")
 								return {
 									headers: {
-										"anthropic-beta": "prompt-caching-2024-07-31",
+										"anthropic-beta": betas.join(","),
 									},
 								}
 							default:

--- a/src/api/providers/bedrock.ts
+++ b/src/api/providers/bedrock.ts
@@ -34,7 +34,7 @@ export class AwsBedrockHandler implements ApiHandler {
 
 		const stream = await client.messages.create({
 			model: modelId,
-			max_tokens: model.info.maxTokens || 8192,
+			max_tokens: reasoningOn ? 128_000 : model.info.maxTokens || 8192,
 			thinking: reasoningOn ? { type: "enabled", budget_tokens: budget_tokens } : undefined,
 			temperature: reasoningOn ? undefined : 0,
 			system: [

--- a/src/api/providers/openrouter.ts
+++ b/src/api/providers/openrouter.ts
@@ -132,6 +132,7 @@ export class OpenRouterHandler implements ApiHandler {
 				if (reasoningOn) {
 					temperature = undefined // extended thinking does not support non-1 temperature
 					reasoning = { max_tokens: budget_tokens }
+					maxTokens = 128_000 // Set max tokens to 128k when reasoning is enabled
 				}
 				break
 		}

--- a/src/api/providers/vertex.ts
+++ b/src/api/providers/vertex.ts
@@ -53,7 +53,7 @@ export class VertexHandler implements ApiHandler {
 					stream = await this.clientAnthropic.beta.messages.create(
 						{
 							model: modelId,
-							max_tokens: model.info.maxTokens || 8192,
+							max_tokens: reasoningOn ? 128_000 : model.info.maxTokens || 8192,
 							thinking: reasoningOn ? { type: "enabled", budget_tokens: budget_tokens } : undefined,
 							temperature: reasoningOn ? undefined : 0,
 							system: [

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -90,7 +90,7 @@ export type AnthropicModelId = keyof typeof anthropicModels
 export const anthropicDefaultModelId: AnthropicModelId = "claude-3-7-sonnet-20250219"
 export const anthropicModels = {
 	"claude-3-7-sonnet-20250219": {
-		maxTokens: 128_000,
+		maxTokens: 8192,
 		contextWindow: 200_000,
 		supportsImages: true,
 		supportsComputerUse: true,

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -90,7 +90,7 @@ export type AnthropicModelId = keyof typeof anthropicModels
 export const anthropicDefaultModelId: AnthropicModelId = "claude-3-7-sonnet-20250219"
 export const anthropicModels = {
 	"claude-3-7-sonnet-20250219": {
-		maxTokens: 8192,
+		maxTokens: 128_000,
 		contextWindow: 200_000,
 		supportsImages: true,
 		supportsComputerUse: true,


### PR DESCRIPTION
### Description

This PR updates the Claude 3.7 Sonnet model configuration to fully support its 128K token output capability along with enabling prompt caching for Anthropic models. The changes include:

1. Increasing the `maxTokens` value for Claude 3.7 Sonnet from 8,192 to 128,000 to match its actual capabilities
2. Adding the `output-128k-2025-02-19` beta flag specifically for Claude 3.7 Sonnet
3. Refactoring the Anthropic beta flags implementation to support multiple beta features simultaneously
4. Maintaining the existing prompt caching beta flag for all applicable Claude models

These changes will allow users to leverage Claude 3.7 Sonnet's full output capacity while preserving performance optimizations from prompt caching.

### Test Procedure

Tested by:
- Verifying that Claude 3.7 Sonnet properly accepts larger output token requests
- Confirming that the beta flags are correctly combined in the Anthropic API headers
- Ensuring other Claude models continue to use prompt caching as before
- Running a series of prompts that generate longer outputs to validate the 128K capability

### Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update

### Pre-flight Checklist

- [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
- [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
- [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
- [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Additional Notes

This change brings our Claude 3.7 Sonnet configuration fully in line with Anthropic's latest capabilities while maintaining performance optimizations from prompt caching. The refactoring of beta flags enables us to more easily add future beta features as Anthropic releases them.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update Claude 3.7 Sonnet to support 128K token outputs and refactor Anthropic beta flag handling.
> 
>   - **Behavior**:
>     - Increase `maxTokens` for `claude-3-7-sonnet-20250219` from 8,192 to 128,000 in `api.ts`.
>     - Add `output-128k-2025-02-19` beta flag for `claude-3-7-sonnet-20250219` in `anthropic.ts`.
>     - Refactor beta flags to support multiple features in `anthropic.ts`.
>     - Maintain prompt caching beta flag for all applicable Claude models.
>   - **Testing**:
>     - Verified larger output token requests for Claude 3.7 Sonnet.
>     - Confirmed correct combination of beta flags in API headers.
>     - Ensured prompt caching continues for other Claude models.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 4a34f8bb54660d39815a07c9327b7f4628fb2255. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->