### PR TITLE
Fix cline ignoring entire tree while browsing files if encounter 1 file/folder without access

### DIFF
--- a/src/services/glob/list-files.ts
+++ b/src/services/glob/list-files.ts
@@ -36,7 +36,7 @@ export async function listFiles(dirPath: string, recursive: boolean, limit: numb
 		".*", // '!**/.*' excludes hidden directories, while '!**/.*/**' excludes only their contents. This way we are at least aware of the existence of hidden directories.
 	].map((dir) => `**/${dir}/**`)
 
-	const options = {
+	const options: Options = {
 		cwd: dirPath,
 		dot: true, // do not ignore hidden files/directories
 		absolute: true,
@@ -44,6 +44,7 @@ export async function listFiles(dirPath: string, recursive: boolean, limit: numb
 		gitignore: recursive, // globby ignores any files that are gitignored
 		ignore: recursive ? dirsToIgnore : undefined, // just in case there is no gitignore, we ignore sensible defaults
 		onlyFiles: false, // true by default, false means it will list directories on their own too
+		suppressErrors: true,
 	}
 
 	// * globs all files in one dir, ** globs files in nested directories


### PR DESCRIPTION
### Description
This has been discussed with @celestial-vault here: 
https://github.com/cline/cline/pull/1809#issuecomment-2699290295

### Test Procedure
Same test as old PR, works in my case

### Type of Change
-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist
-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

### Additional Notes

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `suppressErrors: true` to `listFiles()` in `list-files.ts` to handle inaccessible files/folders without failing.
> 
>   - **Behavior**:
>     - Adds `suppressErrors: true` to `options` in `listFiles()` in `list-files.ts` to handle inaccessible files/folders without failing.
>   - **Misc**:
>     - Ensures directory tree is not ignored if encountering an inaccessible file/folder.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for a30b0e6e52bec733a37d71e3a944f9bb68b95d1e. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->