### PR TITLE
Remove Claude Tool Use Code

### DIFF
--- a/src/integrations/misc/export-markdown.ts
+++ b/src/integrations/misc/export-markdown.ts
@@ -47,10 +47,7 @@ export async function downloadTask(dateTs: number, conversationHistory: Anthropi
 	}
 }
 
-export function formatContentBlockToMarkdown(
-	block: Anthropic.ContentBlockParam,
-	// messages: Anthropic.MessageParam[]
-): string {
+export function formatContentBlockToMarkdown(block: Anthropic.ContentBlockParam): string {
 	switch (block.type) {
 		case "text":
 			return block.text
@@ -69,32 +66,16 @@ export function formatContentBlockToMarkdown(
 			}
 			return `[Tool Use: ${block.name}]\n${input}`
 		case "tool_result":
-			// For now we're not doing tool name lookup since we don't use tools anymore
-			// const toolName = findToolName(block.tool_use_id, messages)
-			const toolName = "Tool"
 			if (typeof block.content === "string") {
-				return `[${toolName}${block.is_error ? " (Error)" : ""}]\n${block.content}`
+				return `[Tool${block.is_error ? " (Error)" : ""}]\n${block.content}`
 			} else if (Array.isArray(block.content)) {
-				return `[${toolName}${block.is_error ? " (Error)" : ""}]\n${block.content
+				return `[Tool${block.is_error ? " (Error)" : ""}]\n${block.content
 					.map((contentBlock) => formatContentBlockToMarkdown(contentBlock))
 					.join("\n")}`
 			} else {
-				return `[${toolName}${block.is_error ? " (Error)" : ""}]`
+				return `[Tool${block.is_error ? " (Error)" : ""}]`
 			}
 		default:
 			return "[Unexpected content type]"
 	}
-}
-
-export function findToolName(toolCallId: string, messages: Anthropic.MessageParam[]): string {
-	for (const message of messages) {
-		if (Array.isArray(message.content)) {
-			for (const block of message.content) {
-				if (block.type === "tool_use" && block.id === toolCallId) {
-					return block.name
-				}
-			}
-		}
-	}
-	return "Unknown Tool"
 }


### PR DESCRIPTION
### Description

This PR removes the old backward compatibility code for Claude tool use. Since we've been using XML tags for tool invocation for a significant time now, we no longer need to maintain the conversion logic that translated between the old format and the current XML-based format.

### Test Procedure

Tested by verifying that normal tool usage with the current XML tag format continues to work correctly. Since this is removing compatibility code that is no longer needed, the changes don't affect current functionality. I've also verified that task history export still works properly with the simplified tool result formatting.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [x] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

### Additional Notes

This is technically marked as a breaking change because it removes backward compatibility with a legacy format. However, this format has been deprecated for some time, and all active users should already be using the XML tag format for tool invocation.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Removes backward compatibility code for Claude tool use, focusing on XML-based tool invocation in `Cline.ts` and `export-markdown.ts`.
> 
>   - **Behavior**:
>     - Removes backward compatibility code for Claude tool use in `Cline.ts`, focusing on XML-based tool invocation.
>     - Ensures normal tool usage with XML tags continues to work correctly.
>   - **Functions**:
>     - Removes `findToolName()` from `export-markdown.ts` and updates `formatContentBlockToMarkdown()` to reflect the removal of tool name lookup.
>   - **Misc**:
>     - Simplifies tool result formatting in task history export.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 5b537f80448be7faba956d408506bb24a4ea60e3. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->