### PR TITLE
Remove legacy tool use code from gemini-format.ts

### DIFF
--- a/src/api/transform/gemini-format.ts
+++ b/src/api/transform/gemini-format.ts
@@ -1,15 +1,5 @@
 import { Anthropic } from "@anthropic-ai/sdk"
-import {
-	Content,
-	EnhancedGenerateContentResponse,
-	FunctionCallPart,
-	FunctionDeclaration,
-	FunctionResponsePart,
-	InlineDataPart,
-	Part,
-	SchemaType,
-	TextPart,
-} from "@google/generative-ai"
+import { Content, EnhancedGenerateContentResponse, InlineDataPart, Part, TextPart } from "@google/generative-ai"
 
 export function convertAnthropicContentToGemini(content: string | Anthropic.ContentBlockParam[]): Part[] {
 	if (typeof content === "string") {

--- a/src/api/transform/gemini-format.ts
+++ b/src/api/transform/gemini-format.ts
@@ -29,55 +29,6 @@ export function convertAnthropicContentToGemini(content: string | Anthropic.Cont
 						mimeType: block.source.media_type,
 					},
 				} as InlineDataPart
-			case "tool_use":
-				return {
-					functionCall: {
-						name: block.name,
-						args: block.input,
-					},
-				} as FunctionCallPart
-			case "tool_result":
-				const name = block.tool_use_id.split("-")[0]
-				if (!block.content) {
-					return []
-				}
-				if (typeof block.content === "string") {
-					return {
-						functionResponse: {
-							name,
-							response: {
-								name,
-								content: block.content,
-							},
-						},
-					} as FunctionResponsePart
-				} else {
-					// The only case when tool_result could be array is when the tool failed and we're providing ie user feedback potentially with images
-					const textParts = block.content.filter((part) => part.type === "text")
-					const imageParts = block.content.filter((part) => part.type === "image")
-					const text = textParts.length > 0 ? textParts.map((part) => part.text).join("\n\n") : ""
-					const imageText = imageParts.length > 0 ? "\n\n(See next part for image)" : ""
-					return [
-						{
-							functionResponse: {
-								name,
-								response: {
-									name,
-									content: text + imageText,
-								},
-							},
-						} as FunctionResponsePart,
-						...imageParts.map(
-							(part) =>
-								({
-									inlineData: {
-										data: part.source.data,
-										mimeType: part.source.media_type,
-									},
-								}) as InlineDataPart,
-						),
-					]
-				}
 			default:
 				throw new Error(`Unsupported content block type: ${(block as any).type}`)
 		}
@@ -88,26 +39,6 @@ export function convertAnthropicMessageToGemini(message: Anthropic.Messages.Mess
 	return {
 		role: message.role === "assistant" ? "model" : "user",
 		parts: convertAnthropicContentToGemini(message.content),
-	}
-}
-
-export function convertAnthropicToolToGemini(tool: Anthropic.Messages.Tool): FunctionDeclaration {
-	return {
-		name: tool.name,
-		description: tool.description || "",
-		parameters: {
-			type: SchemaType.OBJECT,
-			properties: Object.fromEntries(
-				Object.entries(tool.input_schema.properties || {}).map(([key, value]) => [
-					key,
-					{
-						type: (value as any).type.toUpperCase(),
-						description: (value as any).description || "",
-					},
-				]),
-			),
-			required: (tool.input_schema.required as string[]) || [],
-		},
 	}
 }
 
@@ -125,22 +56,6 @@ export function convertGeminiResponseToAnthropic(response: EnhancedGenerateConte
 	const text = response.text()
 	if (text) {
 		content.push({ type: "text", text, citations: null })
-	}
-
-	// Add function calls as tool_use blocks
-	const functionCalls = response.functionCalls()
-	if (functionCalls) {
-		functionCalls.forEach((call, index) => {
-			if ("content" in call.args && typeof call.args.content === "string") {
-				call.args.content = unescapeGeminiContent(call.args.content)
-			}
-			content.push({
-				type: "tool_use",
-				id: `${call.name}-${index}-${Date.now()}`,
-				name: call.name,
-				input: call.args,
-			})
-		})
 	}
 
 	// Determine stop reason


### PR DESCRIPTION
### Description

Remove old tool use conversion code.

### Test Procedure

Got a Gemini API key and tested that interaction works fine.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Remove legacy tool use conversion code from `gemini-format.ts`, simplifying content conversion functions.
> 
>   - **Code Removal**:
>     - Remove `tool_use` and `tool_result` cases from `convertAnthropicContentToGemini` in `gemini-format.ts`.
>     - Remove `convertAnthropicToolToGemini` function from `gemini-format.ts`.
>     - Remove handling of `functionCalls` in `convertGeminiResponseToAnthropic` in `gemini-format.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for c66407e9678fcdfcf3970745b1a145cb383396f8. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->