### PR TITLE
Eng-134 / Added checkpoint telemetry

### DIFF
--- a/.changeset/quick-rings-eat.md
+++ b/.changeset/quick-rings-eat.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Checkpoints Telemetry

--- a/src/services/telemetry/TelemetryService.ts
+++ b/src/services/telemetry/TelemetryService.ts
@@ -23,7 +23,7 @@ class PostHogClient {
 			TOKEN_USAGE: "task.tokens",
 			// Tracks switches between plan and act modes
 			MODE_SWITCH: "task.mode",
-			// Tracks usage of the git-based checkpoint system (shadow_git_initialized, commit_created, branch_created, branch_deleted_active, ranch_deleted_inactive, restored)
+			// Tracks usage of the git-based checkpoint system (shadow_git_initialized, commit_created, branch_created, branch_deleted_active, branch_deleted_inactive, restored)
 			CHECKPOINT_USED: "task.checkpoint_used",
 			// Tracks when tools (like file operations, commands) are used
 			TOOL_USED: "task.tool_used",

--- a/src/services/telemetry/TelemetryService.ts
+++ b/src/services/telemetry/TelemetryService.ts
@@ -23,7 +23,7 @@ class PostHogClient {
 			TOKEN_USAGE: "task.tokens",
 			// Tracks switches between plan and act modes
 			MODE_SWITCH: "task.mode",
-			// Tracks usage of the git-based checkpoint system (create/restore/delete)
+			// Tracks usage of the git-based checkpoint system (shadow_git_initialized, commit_created, branch_created, branch_deleted_active, ranch_deleted_inactive, restored)
 			CHECKPOINT_USED: "task.checkpoint_used",
 			// Tracks when tools (like file operations, commands) are used
 			TOOL_USED: "task.tool_used",
@@ -249,9 +249,18 @@ class PostHogClient {
 	/**
 	 * Records interactions with the git-based checkpoint system
 	 * @param taskId Unique identifier for the task
-	 * @param action The type of checkpoint action (created/restored/deleted)
+	 * @param action The type of checkpoint action
 	 */
-	public captureCheckpointUsage(taskId: string, action: "created" | "restored" | "deleted") {
+	public captureCheckpointUsage(
+		taskId: string,
+		action:
+			| "shadow_git_initialized"
+			| "commit_created"
+			| "branch_created"
+			| "branch_deleted_active"
+			| "branch_deleted_inactive"
+			| "restored",
+	) {
 		this.capture({
 			event: PostHogClient.EVENTS.TASK.CHECKPOINT_USED,
 			properties: {


### PR DESCRIPTION
### Description

This PR implements comprehensive telemetry tracking for the checkpoint system in Cline. This PR adds the necessary telemetry calls to track key checkpoint events throughout the system. The implementation tracks six specific checkpoint actions:

- Shadow git initialization (when a new checkpoint repository is created)
- Commit creation (when a new checkpoint is saved)
- Branch creation (when a new task branch is created)
- Branch deletion for active tasks
- Branch deletion for inactive tasks
- Checkpoint restoration (when a user reverts to a previous checkpoint)

Importantly, this telemetry implementation only collects non-sensitive, anonymous usage data. We track only the action type and the taskID, which is simply a numeric identifier for the task on the user's local machine. No personal information, file contents, or workspace details are collected. This data helps us understand how users interact with the checkpoint system, allowing us to prioritize improvements to the most-used features while maintaining user privacy.

### Test Procedure

- Create new tasks to test shadow git initialization and branch creation
- Create multiple checkpoints to test commit creation
- Restore/Revert Cline's changes using checkpoints to test the restore functionality
- Delete tasks (both active and inactive) to test branch deletion

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [X] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [X] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [X] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [X] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [X] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add telemetry tracking for checkpoint actions in Cline, logging non-sensitive data on key events.
> 
>   - **Telemetry Tracking**:
>     - Added telemetry for checkpoint actions: `shadow_git_initialized`, `commit_created`, `branch_created`, `branch_deleted_active`, `branch_deleted_inactive`, `restored` in `CheckpointGitOperations.ts` and `CheckpointTracker.ts`.
>     - `captureCheckpointUsage()` in `TelemetryService.ts` logs these actions with task ID.
>   - **Behavior**:
>     - Tracks shadow git initialization, commit creation, branch creation/deletion, and checkpoint restoration.
>     - Only non-sensitive, anonymous data is collected (action type and task ID).
>   - **Misc**:
>     - Updated `PostHogClient.EVENTS.TASK.CHECKPOINT_USED` to include new action types.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 04be5da2858744f393d2879c411e1904254d6d26. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->