### PR TITLE
Add support for qwq32b to OpenRouter.

### DIFF
--- a/src/api/transform/openrouter-stream.ts
+++ b/src/api/transform/openrouter-stream.ts
@@ -98,7 +98,12 @@ export async function* streamOpenRouterFormatRequest(
 
 	let temperature: number | undefined = 0
 	let topP: number | undefined = undefined
-	if (model.id.startsWith("deepseek/deepseek-r1") || model.id === "perplexity/sonar-reasoning") {
+	if (
+		model.id.startsWith("deepseek/deepseek-r1") ||
+		model.id === "perplexity/sonar-reasoning" ||
+		model.id === "qwen/qwq-32b:free" ||
+		model.id === "qwen/qwq-32b"
+	) {
 		// Recommended values from DeepSeek
 		temperature = 0.7
 		topP = 0.95


### PR DESCRIPTION
### Description

<!-- Describe your changes in detail. What problem does this PR solve? -->

### Test Procedure

<!-- How did you test this? Are you confident that it will not introduce bugs? If so, why? -->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add support for `qwen/qwq-32b` models in `streamOpenRouterFormatRequest()` with specific `temperature` and `topP` settings.
> 
>   - **Behavior**:
>     - Adds support for `qwen/qwq-32b` and `qwen/qwq-32b:free` models in `streamOpenRouterFormatRequest()` in `openrouter-stream.ts`.
>     - Sets `temperature` to 0.7 and `topP` to 0.95 for these models.
>     - Converts messages to R1 format for these models.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for e4a47f7107e50ba65853b5858036fb2da814ebee. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->