### PR TITLE
Prevent file editing tools in PLAN mode

### DIFF
--- a/.changeset/lovely-schools-marry.md
+++ b/.changeset/lovely-schools-marry.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Prevent file editing tools in PLAN mode to ensure consistency with mode's intended purpose

--- a/src/core/prompts/responses.ts
+++ b/src/core/prompts/responses.ts
@@ -31,9 +31,9 @@ ${toolUseInstructionsReminder}
 
 # Next Steps
 
-If you have completed the user's task, use the attempt_completion tool.
-If you require additional information from the user, use the ask_followup_question tool.
-Otherwise, if you have not completed the task and do not need additional information, then proceed with the next step of the task.
+If you have completed the user's task, use the attempt_completion tool. 
+If you require additional information from the user, use the ask_followup_question tool. 
+Otherwise, if you have not completed the task and do not need additional information, then proceed with the next step of the task. 
 (This is an automated message, so do not respond to it conversationally.)`,
 
 	tooManyMistakes: (feedback?: string) =>

--- a/src/core/prompts/responses.ts
+++ b/src/core/prompts/responses.ts
@@ -17,6 +17,13 @@ export const formatResponse = {
 	clineIgnoreError: (path: string) =>
 		`Access to ${path} is blocked by the .clineignore file settings. You must try to continue in the task without using this file, or ask the user to update the .clineignore file.`,
 
+	planModeEditToolError: () =>
+		`This tool cannot be used in PLAN MODE. File editing tools (write_to_file and replace_in_file) are only available in ACT MODE.
+
+Please ask the user to switch to ACT MODE using the toggle button or the keyboard shortcut (Meta+Shift+A) if you need to edit files.
+
+In PLAN MODE, you should focus on information gathering, asking questions, and architecting a solution. Once you have a plan, use the plan_mode_response tool to engage in a conversational back and forth with the user.`,
+
 	noToolsUsed: () =>
 		`[ERROR] You did not use a tool in your previous response! Please retry with a tool use.
 
@@ -24,9 +31,9 @@ ${toolUseInstructionsReminder}
 
 # Next Steps
 
-If you have completed the user's task, use the attempt_completion tool. 
-If you require additional information from the user, use the ask_followup_question tool. 
-Otherwise, if you have not completed the task and do not need additional information, then proceed with the next step of the task. 
+If you have completed the user's task, use the attempt_completion tool.
+If you require additional information from the user, use the ask_followup_question tool.
+Otherwise, if you have not completed the task and do not need additional information, then proceed with the next step of the task.
 (This is an automated message, so do not respond to it conversationally.)`,
 
 	tooManyMistakes: (feedback?: string) =>

--- a/src/core/prompts/system.ts
+++ b/src/core/prompts/system.ts
@@ -460,14 +460,14 @@ You have access to two tools for working with files: **write_to_file** and **rep
 
 ## When to Use
 
-- Initial file creation, such as when scaffolding a new project.
+- Initial file creation, such as when scaffolding a new project.  
 - Overwriting large boilerplate files where you want to replace the entire content at once.
 - When the complexity or number of changes would make replace_in_file unwieldy or error-prone.
 - When you need to completely restructure a file's content or change its fundamental organization.
 
 ## Important Considerations
 
-- Using write_to_file requires providing the file's complete final content.
+- Using write_to_file requires providing the file’s complete final content.  
 - If you only need to make small changes to an existing file, consider using replace_in_file instead to avoid unnecessarily rewriting the entire file.
 - While write_to_file should not be your default choice, don't hesitate to use it when the situation truly calls for it.
 
@@ -480,12 +480,12 @@ You have access to two tools for working with files: **write_to_file** and **rep
 ## When to Use
 
 - Small, localized changes like updating a few lines, function implementations, changing variable names, modifying a section of text, etc.
-- Targeted improvements where only specific portions of the file's content needs to be altered.
+- Targeted improvements where only specific portions of the file’s content needs to be altered.
 - Especially useful for long files where much of the file will remain unchanged.
 
 ## Advantages
 
-- More efficient for minor edits, since you don't need to supply the entire file content.  
+- More efficient for minor edits, since you don’t need to supply the entire file content.  
 - Reduces the chance of errors that can occur when overwriting large files.
 
 # Choosing the Appropriate Tool
@@ -522,7 +522,7 @@ You have access to two tools for working with files: **write_to_file** and **rep
 By thoughtfully selecting between write_to_file and replace_in_file, you can make your file editing process smoother, safer, and more efficient.
 
 ====
-
+ 
 ACT MODE V.S. PLAN MODE
 
 In each user message, the environment_details will specify the current mode. There are two modes:
@@ -536,7 +536,7 @@ In each user message, the environment_details will specify the current mode. The
 
 ## What is PLAN MODE?
 
-- While you are usually in ACT MODE, the user may switch to PLAN MODE in order to have a back and forth with you to plan how to best accomplish the task.
+- While you are usually in ACT MODE, the user may switch to PLAN MODE in order to have a back and forth with you to plan how to best accomplish the task. 
 - When starting in PLAN MODE, depending on the user's request, you may need to do some information gathering e.g. using read_file or search_files to get more context about the task. You may also ask the user clarifying questions to get a better understanding of the task. You may return mermaid diagrams to visually display your understanding.
 - Once you've gained more context about the user's request, you should architect a detailed plan for how you will accomplish the task. Returning mermaid diagrams may be helpful here as well.
 - Then you might ask the user if they are pleased with this plan, or if they would like to make any changes. Think of this as a brainstorming session where you can discuss the task and plan the best way to accomplish it.
@@ -544,7 +544,7 @@ In each user message, the environment_details will specify the current mode. The
 - Finally once it seems like you've reached a good plan, ask the user to switch you back to ACT MODE to implement the solution.
 
 ====
-
+ 
 CAPABILITIES
 
 - You have access to tools that let you execute CLI commands on the user's computer, list files, view source code definitions, regex search${

--- a/src/core/prompts/system.ts
+++ b/src/core/prompts/system.ts
@@ -460,14 +460,14 @@ You have access to two tools for working with files: **write_to_file** and **rep
 
 ## When to Use
 
-- Initial file creation, such as when scaffolding a new project.  
+- Initial file creation, such as when scaffolding a new project.
 - Overwriting large boilerplate files where you want to replace the entire content at once.
 - When the complexity or number of changes would make replace_in_file unwieldy or error-prone.
 - When you need to completely restructure a file's content or change its fundamental organization.
 
 ## Important Considerations
 
-- Using write_to_file requires providing the file's complete final content.  
+- Using write_to_file requires providing the file's complete final content.
 - If you only need to make small changes to an existing file, consider using replace_in_file instead to avoid unnecessarily rewriting the entire file.
 - While write_to_file should not be your default choice, don't hesitate to use it when the situation truly calls for it.
 
@@ -522,7 +522,7 @@ You have access to two tools for working with files: **write_to_file** and **rep
 By thoughtfully selecting between write_to_file and replace_in_file, you can make your file editing process smoother, safer, and more efficient.
 
 ====
- 
+
 ACT MODE V.S. PLAN MODE
 
 In each user message, the environment_details will specify the current mode. There are two modes:
@@ -531,11 +531,12 @@ In each user message, the environment_details will specify the current mode. The
  - In ACT MODE, you use tools to accomplish the user's task. Once you've completed the user's task, you use the attempt_completion tool to present the result of the task to the user.
 - PLAN MODE: In this special mode, you have access to the plan_mode_respond tool.
  - In PLAN MODE, the goal is to gather information and get context to create a detailed plan for accomplishing the task, which the user will review and approve before they switch you to ACT MODE to implement the solution.
- - In PLAN MODE, when you need to converse with the user or present a plan, you should use the plan_mode_respond tool to deliver your response directly, rather than using <thinking> tags to analyze when to respond. Do not talk about using plan_mode_respond - just use it directly to share your thoughts and provide helpful answers.
+ - In PLAN MODE, when you need to converse with the user or present a plan, you should use the plan_mode_response tool to deliver your response directly, rather than using <thinking> tags to analyze when to respond. Do not talk about using plan_mode_response - just use it directly to share your thoughts and provide helpful answers.
+ - In PLAN MODE, file editing tools (write_to_file and replace_in_file) cannot be used. If you need to edit a file, please request the user to switch to ACT MODE.
 
 ## What is PLAN MODE?
 
-- While you are usually in ACT MODE, the user may switch to PLAN MODE in order to have a back and forth with you to plan how to best accomplish the task. 
+- While you are usually in ACT MODE, the user may switch to PLAN MODE in order to have a back and forth with you to plan how to best accomplish the task.
 - When starting in PLAN MODE, depending on the user's request, you may need to do some information gathering e.g. using read_file or search_files to get more context about the task. You may also ask the user clarifying questions to get a better understanding of the task. You may return mermaid diagrams to visually display your understanding.
 - Once you've gained more context about the user's request, you should architect a detailed plan for how you will accomplish the task. Returning mermaid diagrams may be helpful here as well.
 - Then you might ask the user if they are pleased with this plan, or if they would like to make any changes. Think of this as a brainstorming session where you can discuss the task and plan the best way to accomplish it.
@@ -543,7 +544,7 @@ In each user message, the environment_details will specify the current mode. The
 - Finally once it seems like you've reached a good plan, ask the user to switch you back to ACT MODE to implement the solution.
 
 ====
- 
+
 CAPABILITIES
 
 - You have access to tools that let you execute CLI commands on the user's computer, list files, view source code definitions, regex search${

--- a/src/core/prompts/system.ts
+++ b/src/core/prompts/system.ts
@@ -467,7 +467,7 @@ You have access to two tools for working with files: **write_to_file** and **rep
 
 ## Important Considerations
 
-- Using write_to_file requires providing the file’s complete final content.  
+- Using write_to_file requires providing the file's complete final content.  
 - If you only need to make small changes to an existing file, consider using replace_in_file instead to avoid unnecessarily rewriting the entire file.
 - While write_to_file should not be your default choice, don't hesitate to use it when the situation truly calls for it.
 
@@ -480,12 +480,12 @@ You have access to two tools for working with files: **write_to_file** and **rep
 ## When to Use
 
 - Small, localized changes like updating a few lines, function implementations, changing variable names, modifying a section of text, etc.
-- Targeted improvements where only specific portions of the file’s content needs to be altered.
+- Targeted improvements where only specific portions of the file's content needs to be altered.
 - Especially useful for long files where much of the file will remain unchanged.
 
 ## Advantages
 
-- More efficient for minor edits, since you don’t need to supply the entire file content.  
+- More efficient for minor edits, since you don't need to supply the entire file content.  
 - Reduces the chance of errors that can occur when overwriting large files.
 
 # Choosing the Appropriate Tool
@@ -531,7 +531,7 @@ In each user message, the environment_details will specify the current mode. The
  - In ACT MODE, you use tools to accomplish the user's task. Once you've completed the user's task, you use the attempt_completion tool to present the result of the task to the user.
 - PLAN MODE: In this special mode, you have access to the plan_mode_respond tool.
  - In PLAN MODE, the goal is to gather information and get context to create a detailed plan for accomplishing the task, which the user will review and approve before they switch you to ACT MODE to implement the solution.
- - In PLAN MODE, when you need to converse with the user or present a plan, you should use the plan_mode_response tool to deliver your response directly, rather than using <thinking> tags to analyze when to respond. Do not talk about using plan_mode_response - just use it directly to share your thoughts and provide helpful answers.
+ - In PLAN MODE, when you need to converse with the user or present a plan, you should use the plan_mode_respond tool to deliver your response directly, rather than using <thinking> tags to analyze when to respond. Do not talk about using plan_mode_respond - just use it directly to share your thoughts and provide helpful answers.
  - In PLAN MODE, file editing tools (write_to_file and replace_in_file) cannot be used. If you need to edit a file, please request the user to switch to ACT MODE.
 
 ## What is PLAN MODE?

--- a/src/core/task/index.ts
+++ b/src/core/task/index.ts
@@ -1653,6 +1653,13 @@ export class Task {
 					await this.browserSession.closeBrowser()
 				}
 
+				// Check if tool is allowed in current mode
+				if (this.chatSettings.mode === "plan" && (block.name === "write_to_file" || block.name === "replace_in_file")) {
+					this.consecutiveMistakeCount++
+					pushToolResult(formatResponse.toolError(formatResponse.planModeEditToolError()))
+					break
+				}
+
 				switch (block.name) {
 					case "write_to_file":
 					case "replace_in_file": {
@@ -3098,7 +3105,7 @@ export class Task {
 		}
 
 		/*
-		Seeing out of bounds is fine, it means that the next too call is being built up and ready to add to assistantMessageContent to present. 
+		Seeing out of bounds is fine, it means that the next too call is being built up and ready to add to assistantMessageContent to present.
 		When you see the UI inactive during this, it means that a tool is breaking without presenting any UI. For example the write_to_file tool was breaking when relpath was undefined, and for invalid relpath it never presented UI.
 		*/
 		this.presentAssistantMessageLocked = false // this needs to be placed here, if not then calling this.presentAssistantMessage below would fail (sometimes) since it's locked

--- a/src/core/task/index.ts
+++ b/src/core/task/index.ts
@@ -3105,7 +3105,7 @@ export class Task {
 		}
 
 		/*
-		Seeing out of bounds is fine, it means that the next too call is being built up and ready to add to assistantMessageContent to present.
+		Seeing out of bounds is fine, it means that the next too call is being built up and ready to add to assistantMessageContent to present. 
 		When you see the UI inactive during this, it means that a tool is breaking without presenting any UI. For example the write_to_file tool was breaking when relpath was undefined, and for invalid relpath it never presented UI.
 		*/
 		this.presentAssistantMessageLocked = false // this needs to be placed here, if not then calling this.presentAssistantMessage below would fail (sometimes) since it's locked


### PR DESCRIPTION

### Description

<!-- Describe your changes in detail. What problem does this PR solve? -->

This PR prevents file editing tools (`write_to_file` and `replace_in_file`) from being used in PLAN mode.

I understand that PLAN mode is intended for information gathering and planning purposes, while actual execution like file editing should be done in ACT mode. This is because PLAN mode is specifically designed for "planning" as opposed to "acting" in ACT mode, with clear role separation between the two.

In the current implementation, file editing tools can still be used in PLAN mode, which is inconsistent with the mode's intended purpose. I noticed this issue, and after seeing that other users had mentioned similar concerns in #1621 #2024, I decided to implement this fix.

This PR adds the necessary checks to enforce this restriction and updates the system prompt to explicitly state this limitation, ensuring that the system behavior matches the intended purpose of PLAN mode.

### Test Procedure

<!-- How did you test this? Are you confident that it will not introduce bugs? If so, why? -->

I tested this by:
1. Switching to PLAN mode
2. Attempting to use file editing tools
3. Verifying that the appropriate error message is displayed
![image](https://github.com/user-attachments/assets/e6f344c8-cbbc-45e3-961e-9704558964f1)


This change is minimal and focused on a specific condition check, so the risk of introducing bugs is low. The implementation simply checks the current mode before allowing file editing tools to be used.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

- [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
- [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
- [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
- [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

N/A

### Additional Notes

<!-- Add any additional notes for reviewers -->

This is my first contribution to the Cline project. I encountered this issue while using the application and noticed that PLAN mode was allowing file edits, which seemed inconsistent with its purpose as a planning/information gathering mode. If my understanding of PLAN mode's purpose is incorrect, please feel free to close this PR.

The fix is straightforward and ensures that the user experience is consistent with the intended mode behavior.v
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Restricts file editing tools in PLAN mode and updates system prompt to reflect this limitation.
> 
>   - **Behavior**:
>     - Restricts `write_to_file` and `replace_in_file` tools in PLAN mode in `Cline.ts`.
>     - Updates system prompt in `system.ts` to state that file editing tools are not available in PLAN mode.
>   - **Error Handling**:
>     - Adds `planModeEditToolError` in `responses.ts` to provide error message when file editing tools are used in PLAN mode.
>   - **Misc**:
>     - Adds a changeset file `lovely-schools-marry.md` to document the patch.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 9edd6058f62b0a2bf6ff15939be8ec775f12803d. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->