### PR TITLE
Fix Token Count when API incorrectly returns token count per chunk.

### DIFF
--- a/.changeset/lovely-zoos-work.md
+++ b/.changeset/lovely-zoos-work.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Fix Token Count when API incorrectly returns token count per chunk

--- a/src/core/Cline.ts
+++ b/src/core/Cline.ts
@@ -3174,6 +3174,20 @@ export class Cline {
 			let assistantMessage = ""
 			let reasoningMessage = ""
 			this.isStreaming = true
+			let firstChunkTokenCount: {
+				inputTokens: number | undefined
+				outputTokens: number | undefined
+				cacheWriteTokens: number | undefined
+				cacheReadTokens: number | undefined
+				totalCost: number | undefined
+			} = {
+				inputTokens: undefined,
+				outputTokens: undefined,
+				cacheWriteTokens: undefined,
+				cacheReadTokens: undefined,
+				totalCost: undefined,
+			}
+			const inputTokenCounts = []
 			try {
 				for await (const chunk of stream) {
 					if (!chunk) {
@@ -3181,11 +3195,15 @@ export class Cline {
 					}
 					switch (chunk.type) {
 						case "usage":
+							inputTokenCounts.push(chunk.inputTokens)
 							inputTokens += chunk.inputTokens
 							outputTokens += chunk.outputTokens
 							cacheWriteTokens += chunk.cacheWriteTokens ?? 0
 							cacheReadTokens += chunk.cacheReadTokens ?? 0
-							totalCost = chunk.totalCost
+							totalCost = chunk.totalCost ?? 0
+							if (!firstChunkTokenCount.inputTokens) {
+								firstChunkTokenCount = { inputTokens, outputTokens, cacheWriteTokens, cacheReadTokens, totalCost }
+							}
 							break
 						case "reasoning":
 							// reasoning will always come before assistant message
@@ -3232,6 +3250,16 @@ export class Cline {
 							"\n\n[Response interrupted by a tool use result. Only one tool may be used at a time and should be placed at the end of the message.]"
 						break
 					}
+				}
+
+				// Naive check to see if all of the chunks have the same token count due to poor implementaiton of the API
+				const someTokenCountsAreDifferent = inputTokenCounts.some((tokens) => tokens !== firstChunkTokenCount.inputTokens)
+				if (!someTokenCountsAreDifferent) {
+					inputTokens = firstChunkTokenCount.inputTokens ?? 0
+					outputTokens = firstChunkTokenCount.outputTokens ?? 0
+					cacheWriteTokens = firstChunkTokenCount.cacheWriteTokens ?? 0
+					cacheReadTokens = firstChunkTokenCount.cacheReadTokens ?? 0
+					totalCost = firstChunkTokenCount.totalCost ?? 0
 				}
 			} catch (error) {
 				// abandoned happens when extension is no longer waiting for the cline instance to finish aborting (error is thrown here when any function in the for loop throws due to this.abort)

--- a/src/core/Cline.ts
+++ b/src/core/Cline.ts
@@ -3252,7 +3252,7 @@ export class Cline {
 					}
 				}
 
-				// Naive check to see if all of the chunks have the same token count due to poor implementaiton of the API
+				// Naive check to see if all of the chunks have the same token count due to poor implementation of the API
 				const someTokenCountsAreDifferent = inputTokenCounts.some((tokens) => tokens !== firstChunkTokenCount.inputTokens)
 				if (!someTokenCountsAreDifferent) {
 					inputTokens = firstChunkTokenCount.inputTokens ?? 0

--- a/src/core/Cline.ts
+++ b/src/core/Cline.ts
@@ -3201,7 +3201,7 @@ export class Cline {
 							cacheWriteTokens += chunk.cacheWriteTokens ?? 0
 							cacheReadTokens += chunk.cacheReadTokens ?? 0
 							totalCost = chunk.totalCost ?? 0
-							if (!firstChunkTokenCount.inputTokens) {
+							if (firstChunkTokenCount.inputTokens === undefined) {
 								firstChunkTokenCount = { inputTokens, outputTokens, cacheWriteTokens, cacheReadTokens, totalCost }
 							}
 							break


### PR DESCRIPTION
### Description

Fixes incorrect token calculation during stream because of upstream API incorrectly sending token counts in stream chunks, which causes the Token Count to visually be incorrect.  Checks through all chunks' counts and if they are all the same, uses that as the count for the message.

### Test Procedure

Interact with Cline using OpenAI Compatible Provider with Siliconflow as the API. (See screenshot below)
With a single message of "Hi" you'll notice an extremely high token count (200K+) before the fix.  After the Fix you'll notice a more reasonable 10-20K token count.

### Type of Change

-   [X] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

-   [X] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [X] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [X] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [X] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

![image](https://github.com/user-attachments/assets/55a8d65e-dc98-476f-b246-e2bd8615a97c)
![image](https://github.com/user-attachments/assets/17979806-8dc4-4389-bf89-ed2c4a71c77f)
![image](https://github.com/user-attachments/assets/9a1fedfc-5546-42cc-b79d-609a4a7d855f)

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes token count calculation in `Cline.ts` by checking if all stream chunks have the same token count and using that as the message count if true.
> 
>   - **Behavior**:
>     - Fixes token count calculation in `Cline` class in `Cline.ts` by checking if all stream chunks have the same token count and using that as the message count if true.
>   - **Misc**:
>     - Adds changeset file `lovely-zoos-work.md` for versioning.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 0af2b1bcaa287a131b13dd0a7b3ea3a4e0e9da10. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->