### PR TITLE
Feat MCP ImageContent as tool result

### DIFF
--- a/.changeset/slimy-jeans-dance.md
+++ b/.changeset/slimy-jeans-dance.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+MCP ImageContent as tool result

--- a/src/core/Cline.ts
+++ b/src/core/Cline.ts
@@ -2575,6 +2575,9 @@ export class Cline {
 												if (item.type === "text") {
 													return item.text
 												}
+												if (item.type === "image") {
+													return ` data:${item.mimeType};base64,${item.data} `
+												}
 												if (item.type === "resource") {
 													const { blob, ...rest } = item.resource
 													return JSON.stringify(rest, null, 2)
@@ -2584,7 +2587,12 @@ export class Cline {
 											.filter(Boolean)
 											.join("\n\n") || "(No response)"
 								await this.say("mcp_server_response", toolResultPretty)
-								pushToolResult(formatResponse.toolResult(toolResultPretty))
+								if (toolResult?.isError) {
+									pushToolResult(formatResponse.toolResult(toolResultPretty))
+								} else {
+									const supportsImages = this.api.getModel().info.supportsImages ?? true
+									pushToolResult(formatResponse.mcpToolResult(toolResult, supportsImages))
+								}
 
 								await this.saveCheckpoint()
 

--- a/src/core/Cline.ts
+++ b/src/core/Cline.ts
@@ -2568,6 +2568,7 @@ export class Cline {
 									?.mcpHub?.callTool(server_name, tool_name, parsedArguments)
 
 								// TODO: add progress indicator and ability to parse images and non-text responses
+								const supportsImages = this.api.getModel().info.supportsImages ?? false
 								const toolResultPretty =
 									(toolResult?.isError ? "Error:\n" : "") +
 										toolResult?.content
@@ -2575,8 +2576,11 @@ export class Cline {
 												if (item.type === "text") {
 													return item.text
 												}
-												if (item.type === "image") {
+												if (item.type === "image" && supportsImages) {
 													return ` data:${item.mimeType};base64,${item.data} `
+												}
+												if (item.type === "image" && !supportsImages) {
+													return "[Image placeholder (images not supported)]"
 												}
 												if (item.type === "resource") {
 													const { blob, ...rest } = item.resource
@@ -2590,7 +2594,6 @@ export class Cline {
 								if (toolResult?.isError) {
 									pushToolResult(formatResponse.toolResult(toolResultPretty))
 								} else {
-									const supportsImages = this.api.getModel().info.supportsImages ?? true
 									pushToolResult(formatResponse.mcpToolResult(toolResult, supportsImages))
 								}
 

--- a/src/core/prompts/responses.ts
+++ b/src/core/prompts/responses.ts
@@ -2,6 +2,7 @@ import { Anthropic } from "@anthropic-ai/sdk"
 import * as diff from "diff"
 import * as path from "path"
 import { ClineIgnoreController, LOCK_TEXT_SYMBOL } from "../ignore/ClineIgnoreController"
+import { McpToolCallResponse } from "../../shared/mcp"
 
 export const formatResponse = {
 	toolDenied: () => `The user denied this operation.`,
@@ -41,6 +42,49 @@ Otherwise, if you have not completed the task and do not need additional informa
 		} else {
 			return text
 		}
+	},
+
+	mcpToolResult: (
+		result?: McpToolCallResponse,
+		supportsImages: boolean = true,
+	): Array<Anthropic.TextBlockParam | Anthropic.ImageBlockParam> => {
+		return (
+			result?.content
+				.map((item) => {
+					if (item.type === "text") {
+						return item as Anthropic.TextBlockParam
+					}
+					if (item.type === "resource") {
+						const { blob, ...rest } = item.resource
+						return {
+							type: "text",
+							text: JSON.stringify(rest, null, 2),
+						} as Anthropic.TextBlockParam
+					}
+					if (item.type === "image") {
+						if (supportsImages) {
+							return {
+								source: {
+									data: item.data,
+									media_type: item.mimeType,
+									type: "base64",
+								},
+								type: "image",
+							} as Anthropic.ImageBlockParam
+						} else {
+							return {
+								type: "text",
+								text: "[image]",
+							} as Anthropic.TextBlockParam
+						}
+					}
+					return { type: "text", text: "" } as Anthropic.TextBlockParam
+				})
+				.filter((item) => item.type !== "text" || item.text !== "") || [
+				// Remove empty text blocks
+				{ type: "text", text: "" } as Anthropic.TextBlockParam,
+			]
+		)
 	},
 
 	imageBlocks: (images?: string[]): Anthropic.ImageBlockParam[] => {

--- a/src/core/prompts/responses.ts
+++ b/src/core/prompts/responses.ts
@@ -74,7 +74,7 @@ Otherwise, if you have not completed the task and do not need additional informa
 						} else {
 							return {
 								type: "text",
-								text: "[image]",
+								text: "[Image placeholder (images not supported)]",
 							} as Anthropic.TextBlockParam
 						}
 					}

--- a/webview-ui/src/components/mcp/McpResponseDisplay.tsx
+++ b/webview-ui/src/components/mcp/McpResponseDisplay.tsx
@@ -301,7 +301,7 @@ const McpResponseDisplay: React.FC<McpResponseDisplayProps> = ({ responseText })
 				const text = responseText || ""
 				const matches: UrlMatch[] = []
 
-				const urlRegex = /https?:\/\/[^\s]+/g
+				const urlRegex = /(?:https?:\/\/|data:image\/)[^\s]+/g
 				let urlMatch: RegExpExecArray | null
 
 				while ((urlMatch = urlRegex.exec(text)) !== null) {
@@ -369,7 +369,11 @@ const McpResponseDisplay: React.FC<McpResponseDisplayProps> = ({ responseText })
 					}
 
 					// Add the URL text itself
-					segments.push(<UrlText key={`url-${segmentIndex++}`}>{fullMatch}</UrlText>)
+					if (url.startsWith("data:image/")) {
+						segments.push(<UrlText key={`url-${segmentIndex++}`}>[base64 image]</UrlText>)
+					} else {
+						segments.push(<UrlText key={`url-${segmentIndex++}`}>{fullMatch}</UrlText>)
+					}
 
 					// Calculate the end position of this URL in the text
 					const urlEndIndex = index + fullMatch.length


### PR DESCRIPTION
### Description

<!-- Describe your changes in detail. What problem does this PR solve? -->
I'd like to propose support for the MCP ImageContent type as a tool result. This would allow adding image content to the LLM's context and displaying it in the frontend. I noticed that issues #1865 and #1033 raise similar problem. I actually implemented this functionality a few weeks ago and have been using it, but I wasn't satisfied with the frontend display, so I didn't submit a pull request.

However, I recently saw the improvements made to the display of MCP tool results. Much of that code already accounts for compatibility with base64-encoded images. With only minor modifications, we can achieve full compatibility. 

Therefore, I've adapted the new frontend code, added a check for whether the model supports images (as requested in #1033), and arrived at the current version.

Finally, I can provide a testable MCP server implementation for this feature: [https://github.com/w1zirn/mcp-image-return-demo](https://github.com/w1zirn/mcp-image-return-demo)

### Test Procedure

<!-- How did you test this? Are you confident that it will not introduce bugs? If so, why? -->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

### Additional Notes

<!-- Add any additional notes for reviewers -->
test with plain text result
<img width="460" alt="Screenshot 2025-03-08 at 09 24 35" src="https://github.com/user-attachments/assets/53afa611-54f8-4219-a4f6-08eb55425a27" />

rich display
<img width="341" alt="Screenshot 2025-03-08 at 09 25 04" src="https://github.com/user-attachments/assets/6598505d-b0b9-4e09-9898-a22f844cf498" />

test with deepseek-r1 (Does not support images)
<img width="508" alt="Screenshot 2025-03-08 at 09 36 59" src="https://github.com/user-attachments/assets/b76b9431-a6fd-429b-aff8-71d1a3035e13" />
