### PR TITLE
Support loading by directory in .clinerules/

### DIFF
--- a/.changeset/honest-deers-add.md
+++ b/.changeset/honest-deers-add.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": minor
+---
+
+Support for Loading Files from the `.clinerules/` Directory

--- a/docs/prompting/README.md
+++ b/docs/prompting/README.md
@@ -128,6 +128,27 @@ Cline's system prompt, on the other hand, is not user-editable ([here's where yo
 -   Focus on Desired Outcomes: Describe the results you want, not the specific steps.
 -   Test and Iterate: Experiment to find what works best for your workflow.
 
+
+### Support for Loading Files from the `.clinerules/` Directory
+All files under the `.clinerules/` directory are recursively loaded, and their contents are merged into clineRulesFileInstructions.
+
+#### Example 1:
+```
+.clinerules/
+├── .local-clinerules
+└── .project-clinerules
+```
+
+#### Example 2:
+```
+.clinerules/
+├── .clinerules-nextjs
+├── .clinerules-serverside
+└── tests/
+    ├── .pytest-clinerules
+    └── .jest-clinerules
+```
+
 ## Prompting Cline 💬
 
 **Prompting is how you communicate your needs for a given task in the back-and-forth chat with Cline.** Cline understands natural language, so write conversationally.

--- a/src/core/Cline.ts
+++ b/src/core/Cline.ts
@@ -1306,7 +1306,8 @@ export class Cline {
 					const ruleFileContent = await Promise.all(
 						ruleFiles.map(async (file) => {
 							const ruleFilePath = path.resolve(clineRulesFilePath, file)
-							return `${ruleFilePath}\n` + (await fs.readFile(ruleFilePath, "utf8")).trim()
+							const ruleFilePathRelative = path.relative(cwd, ruleFilePath)
+							return `${ruleFilePathRelative}\n` + (await fs.readFile(ruleFilePath, "utf8")).trim()
 						}),
 					).then((contents) => contents.join("\n\n"))
 					clineRulesFileInstructions = `# .clinerules/\n\nThe following is provided by a root-level .clinerules/ directory where the user has specified instructions for this working directory (${cwd.toPosix()})\n\n${ruleFileContent}`
@@ -1330,6 +1331,8 @@ export class Cline {
 		if (clineIgnoreContent) {
 			clineIgnoreInstructions = `# .clineignore\n\n(The following is provided by a root-level .clineignore file where the user has specified files and directories that should not be accessed. When using list_files, you'll notice a ${LOCK_TEXT_SYMBOL} next to files that are blocked. Attempting to access the file's contents e.g. through read_file will result in an error.)\n\n${clineIgnoreContent}\n.clineignore`
 		}
+
+		console.log("clineRulesFileInstructions", clineRulesFileInstructions)
 
 		if (
 			settingsCustomInstructions ||

--- a/src/core/Cline.ts
+++ b/src/core/Cline.ts
@@ -1332,8 +1332,6 @@ export class Cline {
 			clineIgnoreInstructions = `# .clineignore\n\n(The following is provided by a root-level .clineignore file where the user has specified files and directories that should not be accessed. When using list_files, you'll notice a ${LOCK_TEXT_SYMBOL} next to files that are blocked. Attempting to access the file's contents e.g. through read_file will result in an error.)\n\n${clineIgnoreContent}\n.clineignore`
 		}
 
-		console.log("clineRulesFileInstructions", clineRulesFileInstructions)
-
 		if (
 			settingsCustomInstructions ||
 			clineRulesFileInstructions ||

--- a/src/core/Cline.ts
+++ b/src/core/Cline.ts
@@ -46,7 +46,7 @@ import { getApiMetrics } from "../shared/getApiMetrics"
 import { HistoryItem } from "../shared/HistoryItem"
 import { ClineAskResponse, ClineCheckpointRestore } from "../shared/WebviewMessage"
 import { calculateApiCostAnthropic } from "../utils/cost"
-import { fileExistsAtPath } from "../utils/fs"
+import { fileExistsAtPath, isDirectory } from "../utils/fs"
 import { arePathsEqual, getReadablePath } from "../utils/path"
 import { fixModelHtmlEscaping, removeInvalidChars } from "../utils/string"
 import { AssistantMessageContent, parseAssistantMessage, ToolParamName, ToolUseName } from "./assistant-message"
@@ -1296,13 +1296,32 @@ export class Cline {
 		const clineRulesFilePath = path.resolve(cwd, GlobalFileNames.clineRules)
 		let clineRulesFileInstructions: string | undefined
 		if (await fileExistsAtPath(clineRulesFilePath)) {
-			try {
-				const ruleFileContent = (await fs.readFile(clineRulesFilePath, "utf8")).trim()
-				if (ruleFileContent) {
-					clineRulesFileInstructions = `# .clinerules\n\nThe following is provided by a root-level .clinerules file where the user has specified instructions for this working directory (${cwd.toPosix()})\n\n${ruleFileContent}`
+			if (await isDirectory(clineRulesFilePath)) {
+				try {
+					// Read all files in the .clinerules/ directory.
+					const ruleFiles = await fs
+						.readdir(clineRulesFilePath, { withFileTypes: true, recursive: true })
+						.then((files) => files.filter((file) => file.isFile()))
+						.then((files) => files.map((file) => path.resolve(file.parentPath, file.name)))
+					const ruleFileContent = await Promise.all(
+						ruleFiles.map(async (file) => {
+							const ruleFilePath = path.resolve(clineRulesFilePath, file)
+							return `${ruleFilePath}\n` + (await fs.readFile(ruleFilePath, "utf8")).trim()
+						}),
+					).then((contents) => contents.join("\n\n"))
+					clineRulesFileInstructions = `# .clinerules/\n\nThe following is provided by a root-level .clinerules/ directory where the user has specified instructions for this working directory (${cwd.toPosix()})\n\n${ruleFileContent}`
+				} catch {
+					console.error(`Failed to read .clinerules directory at ${clineRulesFilePath}`)
 				}
-			} catch {
-				console.error(`Failed to read .clinerules file at ${clineRulesFilePath}`)
+			} else {
+				try {
+					const ruleFileContent = (await fs.readFile(clineRulesFilePath, "utf8")).trim()
+					if (ruleFileContent) {
+						clineRulesFileInstructions = `# .clinerules\n\nThe following is provided by a root-level .clinerules file where the user has specified instructions for this working directory (${cwd.toPosix()})\n\n${ruleFileContent}`
+					}
+				} catch {
+					console.error(`Failed to read .clinerules file at ${clineRulesFilePath}`)
+				}
 			}
 		}
 

--- a/src/utils/fs.test.ts
+++ b/src/utils/fs.test.ts
@@ -3,7 +3,7 @@ import { after, describe, it } from "mocha"
 import * as os from "os"
 import * as path from "path"
 import "should"
-import { createDirectoriesForFile, fileExistsAtPath } from "./fs"
+import { createDirectoriesForFile, fileExistsAtPath, isDirectory } from "./fs"
 
 describe("Filesystem Utilities", () => {
 	const tmpDir = path.join(os.tmpdir(), "cline-test-" + Math.random().toString(36).slice(2))
@@ -66,6 +66,26 @@ describe("Filesystem Utilities", () => {
 			createdDirs.length.should.equal(1)
 			const exists = await fileExistsAtPath(path.join(tmpDir, "b"))
 			exists.should.be.true()
+		})
+	})
+	describe("isDirectory", () => {
+		it("should return true for directories", async () => {
+			await fs.mkdir(tmpDir, { recursive: true })
+			const isDir = await isDirectory(tmpDir)
+			isDir.should.be.true()
+		})
+
+		it("should return false for files", async () => {
+			const testFile = path.join(tmpDir, "test.txt")
+			await fs.writeFile(testFile, "test")
+			const isDir = await isDirectory(testFile)
+			isDir.should.be.false()
+		})
+
+		it("should return false for non-existent paths", async () => {
+			const nonExistentPath = path.join(tmpDir, "does-not-exist")
+			const isDir = await isDirectory(nonExistentPath)
+			isDir.should.be.false()
 		})
 	})
 })

--- a/src/utils/fs.ts
+++ b/src/utils/fs.ts
@@ -47,7 +47,7 @@ export async function fileExistsAtPath(filePath: string): Promise<boolean> {
 }
 
 /**
- * Check path is a directory
+ * Checks if the path is a directory
  * @param filePath - The path to check.
  * @returns A promise that resolves to true if the path is a directory, false otherwise.
  */

--- a/src/utils/fs.ts
+++ b/src/utils/fs.ts
@@ -45,3 +45,17 @@ export async function fileExistsAtPath(filePath: string): Promise<boolean> {
 		return false
 	}
 }
+
+/**
+ * Check path is a directory
+ * @param filePath - The path to check.
+ * @returns A promise that resolves to true if the path is a directory, false otherwise.
+ */
+export async function isDirectory(filePath: string): Promise<boolean> {
+	try {
+		const stats = await fs.stat(filePath)
+		return stats.isDirectory()
+	} catch {
+		return false
+	}
+}


### PR DESCRIPTION
### Description


Related to the following discussion:
https://github.com/cline/cline/discussions/1703
https://github.com/cline/cline/discussions/1807

This PR is a more flexible feature than the PR below.
https://github.com/cline/cline/pull/1803

---

### Support for loading `clinerules` files from the `.clinerules/` directory

Files in the `.clinerules/` directory are also supported for loading.  
This enables the separation of `.clinerules` files.

***This feature allows pluggable loading of `.clinerules`, and separate `.clinerules` can be reused.***

Also, if `.clinerules` is a file, `.clinerules` will be loaded as before.

There is a need for this in cases such as:

#### Example 1:
```
.clinerules/
├── .local-clinerules
└── .project-clinerules
```

#### Example 2:
```
.clinerules/
├── .clinerules-nextjs
├── .clinerules-serverside
└── tests/
    ├── .pytest-clinerules
    └── .jest-clinerules
```
---

All files under the `.clinerules/` directory are recursively loaded, and their contents are merged into `clineRulesFileInstructions`.

Below is the contents of `clineRulesFileInstructions`.

```
# .clinerules/

The following is provided by a root-level .clinerules/ directory where the user has specified instructions for this working directory (/Users/xxxx/cline)

/Users/xxxx/cline/.clinerules/.local-clinerules
# my .clinerules
this is a local .clinerules

/Users/xxxx/cline/.clinerules/.project-clinerules
# Project .clinerules
This is project .clinerules

/Users/xxxx/cline/.clinerules/test/.test-clinerules
# Test .clinerules
This is a test .clinerules
```

### Test Procedure

I built it and confirmed that it works by injecting Logger.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality not to work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

### Additional Notes


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add support for loading `.clinerules` from a directory, enhancing rule management flexibility.
> 
>   - **Behavior**:
>     - Support loading `.clinerules` from `.clinerules/` directory in `Cline.ts`.
>     - Recursively loads and merges contents of all files in `.clinerules/` into `clineRulesFileInstructions`.
>   - **Functions**:
>     - Add `isDirectory()` in `fs.ts` to check if a path is a directory.
>     - Update `Cline.ts` to use `isDirectory()` for directory handling.
>   - **Misc**:
>     - Update error handling in `Cline.ts` for reading `.clinerules` directory or file.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for a67dbb13382352730b08d4b9855f078d506d149a. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->