### PR TITLE
Checkpoints documentation cleanup

### DIFF
--- a/.changeset/sweet-jokes-run.md
+++ b/.changeset/sweet-jokes-run.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Checkpoints documentation cleanup

--- a/src/integrations/checkpoints/CheckpointGitOperations.ts
+++ b/src/integrations/checkpoints/CheckpointGitOperations.ts
@@ -18,7 +18,6 @@ interface CheckpointAddResult {
  * - Git repository initialization and configuration
  * - Git settings management (user, LFS, etc.)
  * - Worktree configuration and management
- * - Task-specific branch management (creation, switching, deletion)
  * - Managing nested git repositories during checkpoint operations
  * - File staging and checkpoint creation
  * - Shadow git repository maintenance and cleanup
@@ -89,7 +88,6 @@ export class GitOperations {
 		const lfsPatterns = await getLfsPatterns(cwd)
 		await writeExcludesFile(gitPath, lfsPatterns)
 
-		// Stage all files for initial commit (important so main branch is created with all files in initial commit, and branches created from it will take up less space)
 		await this.addCheckpointFiles(git)
 
 		// Initial commit only on first repo creation

--- a/src/integrations/checkpoints/CheckpointTracker.ts
+++ b/src/integrations/checkpoints/CheckpointTracker.ts
@@ -34,7 +34,7 @@ import { getShadowGitPath, getWorkingDirectory, hashWorkingDir } from "./Checkpo
  *
  * Checkpoint Architecture:
  * - Unique shadow git repository for each workspace
- * - Workspaces are idenfied by name, and hashed to a unique number
+ * - Workspaces are identified by name, and hashed to a unique number
  * - All commits for a workspace are stored in one shadow git, under a single branch
  */
 

--- a/src/integrations/checkpoints/CheckpointTracker.ts
+++ b/src/integrations/checkpoints/CheckpointTracker.ts
@@ -33,9 +33,9 @@ import { getShadowGitPath, getWorkingDirectory, hashWorkingDir } from "./Checkpo
  * - Handles cleanup and resource disposal
  *
  * Checkpoint Architecture:
- * - Uses a branch-per-task model to consolidate shadow git repositories
- * - Each task gets its own branch within a single shadow git per workspace
- * - Automatically cleans up by deleting task branches when tasks are removed
+ * - Unique shadow git repository for each workspace
+ * - Workspaces are idenfied by name, and hashed to a unique number
+ * - All commits for a workspace are stored in one shadow git, under a single branch
  */
 
 class CheckpointTracker {
@@ -64,7 +64,7 @@ class CheckpointTracker {
 
 	/**
 	 * Creates a new CheckpointTracker instance for tracking changes in a task.
-	 * Handles initialization of the shadow git repository and branch setup.
+	 * Handles initialization of the shadow git repository.
 	 *
 	 * @param taskId - Unique identifier for the task to track
 	 * @param globalStoragePath - the globalStorage path
@@ -78,11 +78,9 @@ class CheckpointTracker {
 	 * Key operations:
 	 * - Validates git installation and settings
 	 * - Creates/initializes shadow git repository
-	 * - Sets up task-specific branch for new checkpoints
 	 *
 	 * Configuration:
 	 * - Respects 'cline.enableCheckpoints' VS Code setting
-	 * - Uses branch-per-task architecture for new checkpoints
 	 */
 	public static async create(taskId: string, globalStoragePath: string | undefined): Promise<CheckpointTracker | undefined> {
 		if (!globalStoragePath) {
@@ -110,7 +108,6 @@ class CheckpointTracker {
 
 			const newTracker = new CheckpointTracker(globalStoragePath, taskId, workingDir, cwdHash)
 
-			// Branch-per-task structure
 			const gitPath = await getShadowGitPath(newTracker.globalStoragePath, newTracker.taskId, newTracker.cwdHash)
 			await newTracker.gitOperations.initShadowGit(gitPath, workingDir)
 
@@ -128,28 +125,24 @@ class CheckpointTracker {
 	 *
 	 * Key behaviors:
 	 * - Creates commit with checkpoint files in shadow git repo
-	 * - For new tasks, switches to task-specific branch first
 	 * - Caches the created commit hash
 	 *
 	 * Commit structure:
-	 * - Branch-per-task: "checkpoint-{cwdHash}-{taskId}"
+	 * - Commit message: "checkpoint-{cwdHash}-{taskId}"
 	 * - Always allows empty commits
 	 *
 	 * Dependencies:
 	 * - Requires initialized shadow git (getShadowGitPath)
-	 * - For new checkpoints, requires task branch setup
 	 * - Uses addCheckpointFiles to stage changes using 'git add .'
 	 * - Relies on git's native exclusion handling via the exclude file
 	 *
 	 * @returns Promise<string | undefined> The created commit hash, or undefined if:
 	 * - Shadow git access fails
-	 * - Branch switch fails
 	 * - Staging files fails
 	 * - Commit creation fails
 	 * @throws Error if unable to:
 	 * - Access shadow git path
 	 * - Initialize simple-git
-	 * - Switch branches
 	 * - Stage or commit files
 	 */
 	public async commit(): Promise<string | undefined> {
@@ -225,7 +218,6 @@ class CheckpointTracker {
 	 *
 	 * Dependencies:
 	 * - Requires initialized shadow git (getShadowGitPath)
-	 * - For new checkpoints, requires task branch setup
 	 * - Must be called with a valid commit hash from this task's history
 	 *
 	 * @param commitHash - The hash of the checkpoint commit to reset to
@@ -233,7 +225,6 @@ class CheckpointTracker {
 	 * @throws Error if unable to:
 	 * - Access shadow git path
 	 * - Initialize simple-git
-	 * - Switch to task branch
 	 * - Reset to target commit
 	 */
 	public async resetHead(commitHash: string): Promise<void> {

--- a/src/integrations/checkpoints/CheckpointUtils.ts
+++ b/src/integrations/checkpoints/CheckpointUtils.ts
@@ -5,9 +5,8 @@ import os from "os"
 
 /**
  * Gets the path to the shadow Git repository in globalStorage.
- * For new checkpoints, uses the consolidated branch-per-task structure.
  *
- * Branch-per-task path structure:
+ * Checkpoints path structure:
  * globalStorage/
  *   checkpoints/
  *     {cwdHash}/


### PR DESCRIPTION
### Description

Documentation cleanup for checkpoints after BPT removal.

### Test Procedure

<!-- How did you test this? Are you confident that it will not introduce bugs? If so, why? -->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [X] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [X] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [X] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [X] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [X] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Documentation updated to reflect removal of branch-per-task model in checkpoints system.
> 
>   - **Documentation Updates**:
>     - Removed references to branch-per-task model in `CheckpointGitOperations.ts`, `CheckpointTracker.ts`, and `CheckpointUtils.ts`.
>     - Updated comments to reflect the use of a single shadow git repository per workspace.
>     - Clarified commit structure and operations in `CheckpointTracker.ts`.
>   - **Misc**:
>     - Removed outdated comments related to task-specific branches in `CheckpointGitOperations.ts` and `CheckpointTracker.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for ecdeddb8a5081ecbbe1c755727b8f9698b4edced. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->