### PR TITLE
Fix context window size setting on OpenAI compatible provider

### DIFF
--- a/.changeset/bright-adults-lie.md
+++ b/.changeset/bright-adults-lie.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Fix context window size setting on OpenAI compatible provider

--- a/webview-ui/src/components/settings/ApiOptions.tsx
+++ b/webview-ui/src/components/settings/ApiOptions.tsx
@@ -1543,7 +1543,7 @@ export function normalizeApiConfiguration(apiConfiguration?: ApiConfiguration): 
 			return {
 				selectedProvider: provider,
 				selectedModelId: apiConfiguration?.openAiModelId || "",
-				selectedModelInfo: openAiModelInfoSaneDefaults,
+				selectedModelInfo: apiConfiguration?.openAiModelInfo || openAiModelInfoSaneDefaults,
 			}
 		case "ollama":
 			return {


### PR DESCRIPTION
### Description

Fix context window size setting on OpenAI compatible provider

### Test Procedure

Set Provider to OpenAI Compatible
Configure Context window size to something other than 128000
Before Fix:
Observe that task header still shows 128k
After Fix:
Observe that task header shows correct amount

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [X] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [X] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [X] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [X] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [X] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Before Fix:

<img width="359" alt="image" src="https://github.com/user-attachments/assets/dcaee86a-fbae-4913-adc6-8b1a816a8e88" />
<img width="362" alt="image" src="https://github.com/user-attachments/assets/d6ff2342-5bfc-425a-b365-d6542dbd99c6" />

After Fix:

<img width="359" alt="image" src="https://github.com/user-attachments/assets/dcaee86a-fbae-4913-adc6-8b1a816a8e88" />
<img width="361" alt="image" src="https://github.com/user-attachments/assets/56d04249-0e36-489f-b9ec-2304f327f24f" />


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes context window size setting for OpenAI compatible provider in `ApiOptions.tsx`.
> 
>   - **Bug Fix**:
>     - Fixes context window size setting for OpenAI compatible provider in `normalizeApiConfiguration` function in `ApiOptions.tsx`.
>     - Ensures `selectedModelInfo` uses `apiConfiguration?.openAiModelInfo` instead of `openAiModelInfoSaneDefaults`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 3eab51ca2f02551227b3d89153ec002fc1a7616e. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->