### PR TITLE
Add delete all task history button

### DIFF
--- a/.changeset/three-apples-add.md
+++ b/.changeset/three-apples-add.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Add delete all tasks button

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -915,6 +915,12 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 						await this.postMessageToWebview({ type: "didUpdateSettings" })
 						break
 					}
+					case "clearAllTaskHistory": {
+						await this.deleteAllTaskHistory()
+						await this.postStateToWebview()
+						this.postMessageToWebview({ type: "relinquishControl" })
+						break
+					}
 					// Add more switch case statements here as more webview message commands
 					// are created within the webview context (i.e. inside media/main.js)
 				}
@@ -1751,6 +1757,22 @@ Here is the project's README to help you get started:\n\n${mcpDetails.readmeCont
 		await downloadTask(historyItem.ts, apiConversationHistory)
 	}
 
+	async deleteAllTaskHistory() {
+		await this.clearTask()
+		await this.updateGlobalState("taskHistory", undefined)
+		// Remove all contents of tasks directory
+		const taskDirPath = path.join(this.context.globalStorageUri.fsPath, "tasks")
+		if (await fileExistsAtPath(taskDirPath)) {
+			await fs.rm(taskDirPath, { recursive: true, force: true })
+		}
+		// Remove checkpoints directory contents
+		const checkpointsDirPath = path.join(this.context.globalStorageUri.fsPath, "checkpoints")
+		if (await fileExistsAtPath(checkpointsDirPath)) {
+			await fs.rm(checkpointsDirPath, { recursive: true, force: true })
+		}
+		// await this.postStateToWebview()
+	}
+
 	async deleteTaskWithId(id: string) {
 		console.info("deleteTaskWithId: ", id)
 
@@ -1831,7 +1853,10 @@ Here is the project's README to help you get started:\n\n${mcpDetails.readmeCont
 			currentTaskItem: this.cline?.taskId ? (taskHistory || []).find((item) => item.id === this.cline?.taskId) : undefined,
 			checkpointTrackerErrorMessage: this.cline?.checkpointTrackerErrorMessage,
 			clineMessages: this.cline?.clineMessages || [],
-			taskHistory: (taskHistory || []).filter((item) => item.ts && item.task).sort((a, b) => b.ts - a.ts),
+			taskHistory: (taskHistory || [])
+				.filter((item) => item.ts && item.task)
+				.sort((a, b) => b.ts - a.ts)
+				.slice(0, 100), // for now we're only getting the latest 100 tasks, but a better solution here is to only pass in 3 for recent task history, and then get the full task history on demand when going to the task history view (maybe with pagination?)
 			shouldShowAnnouncement: lastShownAnnouncementId !== this.latestAnnouncementId,
 			platform: process.platform as Platform,
 			autoApprovalSettings,

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -1760,15 +1760,21 @@ Here is the project's README to help you get started:\n\n${mcpDetails.readmeCont
 	async deleteAllTaskHistory() {
 		await this.clearTask()
 		await this.updateGlobalState("taskHistory", undefined)
-		// Remove all contents of tasks directory
-		const taskDirPath = path.join(this.context.globalStorageUri.fsPath, "tasks")
-		if (await fileExistsAtPath(taskDirPath)) {
-			await fs.rm(taskDirPath, { recursive: true, force: true })
-		}
-		// Remove checkpoints directory contents
-		const checkpointsDirPath = path.join(this.context.globalStorageUri.fsPath, "checkpoints")
-		if (await fileExistsAtPath(checkpointsDirPath)) {
-			await fs.rm(checkpointsDirPath, { recursive: true, force: true })
+		try {
+			// Remove all contents of tasks directory
+			const taskDirPath = path.join(this.context.globalStorageUri.fsPath, "tasks")
+			if (await fileExistsAtPath(taskDirPath)) {
+				await fs.rm(taskDirPath, { recursive: true, force: true })
+			}
+			// Remove checkpoints directory contents
+			const checkpointsDirPath = path.join(this.context.globalStorageUri.fsPath, "checkpoints")
+			if (await fileExistsAtPath(checkpointsDirPath)) {
+				await fs.rm(checkpointsDirPath, { recursive: true, force: true })
+			}
+		} catch (error) {
+			vscode.window.showErrorMessage(
+				`Encountered error while deleting task history, there may be some files left behind. Error: ${error instanceof Error ? error.message : String(error)}`,
+			)
 		}
 		// await this.postStateToWebview()
 	}

--- a/src/shared/WebviewMessage.ts
+++ b/src/shared/WebviewMessage.ts
@@ -60,6 +60,7 @@ export interface WebviewMessage {
 		| "checkIsImageUrl"
 		| "invoke"
 		| "updateSettings"
+		| "clearAllTaskHistory"
 	// | "relaunchChromeDebugMode"
 	text?: string
 	disabled?: boolean

--- a/webview-ui/src/components/history/HistoryView.tsx
+++ b/webview-ui/src/components/history/HistoryView.tsx
@@ -2,10 +2,13 @@ import { VSCodeButton, VSCodeTextField, VSCodeRadioGroup, VSCodeRadio } from "@v
 import { useExtensionState } from "../../context/ExtensionStateContext"
 import { vscode } from "../../utils/vscode"
 import { Virtuoso } from "react-virtuoso"
-import { memo, useMemo, useState, useEffect } from "react"
+import { memo, useMemo, useState, useEffect, useCallback } from "react"
 import Fuse, { FuseResult } from "fuse.js"
 import { formatLargeNumber } from "../../utils/format"
 import { formatSize } from "../../utils/size"
+import DangerButton from "../common/DangerButton"
+import { ExtensionMessage } from "../../../../src/shared/ExtensionMessage"
+import { useEvent } from "react-use"
 
 type HistoryViewProps = {
 	onDone: () => void
@@ -18,6 +21,15 @@ const HistoryView = ({ onDone }: HistoryViewProps) => {
 	const [searchQuery, setSearchQuery] = useState("")
 	const [sortOption, setSortOption] = useState<SortOption>("newest")
 	const [lastNonRelevantSort, setLastNonRelevantSort] = useState<SortOption | null>("newest")
+	const [deleteAllDisabled, setDeleteAllDisabled] = useState(false)
+
+	const handleMessage = useCallback((event: MessageEvent<ExtensionMessage>) => {
+		if (event.data.type === "relinquishControl") {
+			setDeleteAllDisabled(false)
+		}
+	}, [])
+
+	useEvent("message", handleMessage)
 
 	useEffect(() => {
 		if (searchQuery && sortOption !== "mostRelevant" && !lastNonRelevantSort) {
@@ -446,6 +458,21 @@ const HistoryView = ({ onDone }: HistoryViewProps) => {
 							</div>
 						)}
 					/>
+				</div>
+				<div
+					style={{
+						padding: "10px 10px",
+						borderTop: "1px solid var(--vscode-panel-border)",
+					}}>
+					<DangerButton
+						style={{ width: "100%" }}
+						disabled={deleteAllDisabled}
+						onClick={() => {
+							setDeleteAllDisabled(true)
+							vscode.postMessage({ type: "clearAllTaskHistory" })
+						}}>
+						Delete All History
+					</DangerButton>
 				</div>
 			</div>
 		</>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add a feature to delete all task history with a button in the UI, implementing backend logic to handle the deletion and update the webview state.
> 
>   - **Feature Addition**:
>     - Add "Delete All History" button in `HistoryView.tsx`.
>     - Button triggers `clearAllTaskHistory` message to delete all task history.
>   - **Backend Logic**:
>     - Implement `deleteAllTaskHistory()` in `ClineProvider.ts` to clear task history and remove task and checkpoint directories.
>     - Handle `clearAllTaskHistory` message in `ClineProvider.ts` to invoke the deletion logic and update the webview state.
>   - **Message Handling**:
>     - Add `clearAllTaskHistory` to `WebviewMessage.ts` to define the new message type.
>     - Use `relinquishControl` message to re-enable the delete button after operation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 99a02bafd987a45143fa9b1907765d0b0b6fd8f2. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->