### PR TITLE
Trevhud/eng 1817

### DIFF
--- a/.changeset/honest-scissors-smile.md
+++ b/.changeset/honest-scissors-smile.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Loads the theme variables into the webview so they are available in css

--- a/src/integrations/theme/default-themes/hc_black.json
+++ b/src/integrations/theme/default-themes/hc_black.json
@@ -12,7 +12,9 @@
 		"statusBarItem.remoteBackground": "#00000000",
 		"ports.iconRunningProcessForeground": "#FFFFFF",
 		"editorWhitespace.foreground": "#7c7c7c",
-		"actionBar.toggledBackground": "#383a49"
+		"actionBar.toggledBackground": "#383a49",
+		"textCodeBlock.background": "#21ACFF",
+		"textPreformat.foreground": "#000000"
 	},
 	"tokenColors": [
 		{

--- a/src/integrations/theme/default-themes/hc_light.json
+++ b/src/integrations/theme/default-themes/hc_light.json
@@ -3,11 +3,7 @@
 	"name": "Light High Contrast",
 	"tokenColors": [
 		{
-			"scope": [
-				"meta.embedded",
-				"source.groovy.embedded",
-				"variable.legacy.builtin.python"
-			],
+			"scope": ["meta.embedded", "source.groovy.embedded", "variable.legacy.builtin.python"],
 			"settings": {
 				"foreground": "#292929"
 			}
@@ -150,10 +146,7 @@
 			}
 		},
 		{
-			"scope": [
-				"punctuation.definition.quote.begin.markdown",
-				"punctuation.definition.list.begin.markdown"
-			],
+			"scope": ["punctuation.definition.quote.begin.markdown", "punctuation.definition.list.begin.markdown"],
 			"settings": {
 				"foreground": "#0451A5"
 			}
@@ -171,10 +164,7 @@
 			}
 		},
 		{
-			"scope": [
-				"meta.preprocessor",
-				"entity.name.function.preprocessor"
-			],
+			"scope": ["meta.preprocessor", "entity.name.function.preprocessor"],
 			"settings": {
 				"foreground": "#0F4A85"
 			}
@@ -210,19 +200,13 @@
 			}
 		},
 		{
-			"scope": [
-				"storage.modifier",
-				"keyword.operator.noexcept"
-			],
+			"scope": ["storage.modifier", "keyword.operator.noexcept"],
 			"settings": {
 				"foreground": "#0F4A85"
 			}
 		},
 		{
-			"scope": [
-				"string",
-				"meta.embedded.assembly"
-			],
+			"scope": ["string", "meta.embedded.assembly"],
 			"settings": {
 				"foreground": "#0F4A85"
 			}
@@ -266,9 +250,7 @@
 			}
 		},
 		{
-			"scope": [
-				"meta.template.expression"
-			],
+			"scope": ["meta.template.expression"],
 			"settings": {
 				"foreground": "#000000"
 			}
@@ -299,9 +281,7 @@
 			}
 		},
 		{
-			"scope": [
-				"support.type.property-name.json"
-			],
+			"scope": ["support.type.property-name.json"],
 			"settings": {
 				"foreground": "#0451A5"
 			}
@@ -348,10 +328,7 @@
 			}
 		},
 		{
-			"scope": [
-				"punctuation.section.embedded.begin.php",
-				"punctuation.section.embedded.end.php"
-			],
+			"scope": ["punctuation.section.embedded.begin.php", "punctuation.section.embedded.end.php"],
 			"settings": {
 				"foreground": "#0F4A85"
 			}
@@ -369,11 +346,7 @@
 			}
 		},
 		{
-			"scope": [
-				"storage.modifier.import.java",
-				"variable.language.wildcard.java",
-				"storage.modifier.package.java"
-			],
+			"scope": ["storage.modifier.import.java", "variable.language.wildcard.java", "storage.modifier.package.java"],
 			"settings": {
 				"foreground": "#000000"
 			}
@@ -475,18 +448,13 @@
 			}
 		},
 		{
-			"scope": [
-				"variable.other.constant",
-				"variable.other.enummember"
-			],
+			"scope": ["variable.other.constant", "variable.other.enummember"],
 			"settings": {
 				"foreground": "#02715D"
 			}
 		},
 		{
-			"scope": [
-				"meta.object-literal.key"
-			],
+			"scope": ["meta.object-literal.key"],
 			"settings": {
 				"foreground": "#001080"
 			}
@@ -537,10 +505,7 @@
 			}
 		},
 		{
-			"scope": [
-				"keyword.operator.or.regexp",
-				"keyword.control.anchor.regexp"
-			],
+			"scope": ["keyword.operator.or.regexp", "keyword.control.anchor.regexp"],
 			"settings": {
 				"foreground": "#EE0000"
 			}

--- a/src/integrations/theme/default-themes/hc_light.json
+++ b/src/integrations/theme/default-themes/hc_light.json
@@ -3,7 +3,11 @@
 	"name": "Light High Contrast",
 	"tokenColors": [
 		{
-			"scope": ["meta.embedded", "source.groovy.embedded", "variable.legacy.builtin.python"],
+			"scope": [
+				"meta.embedded",
+				"source.groovy.embedded",
+				"variable.legacy.builtin.python"
+			],
 			"settings": {
 				"foreground": "#292929"
 			}
@@ -146,7 +150,10 @@
 			}
 		},
 		{
-			"scope": ["punctuation.definition.quote.begin.markdown", "punctuation.definition.list.begin.markdown"],
+			"scope": [
+				"punctuation.definition.quote.begin.markdown",
+				"punctuation.definition.list.begin.markdown"
+			],
 			"settings": {
 				"foreground": "#0451A5"
 			}
@@ -164,7 +171,10 @@
 			}
 		},
 		{
-			"scope": ["meta.preprocessor", "entity.name.function.preprocessor"],
+			"scope": [
+				"meta.preprocessor",
+				"entity.name.function.preprocessor"
+			],
 			"settings": {
 				"foreground": "#0F4A85"
 			}
@@ -200,13 +210,19 @@
 			}
 		},
 		{
-			"scope": ["storage.modifier", "keyword.operator.noexcept"],
+			"scope": [
+				"storage.modifier",
+				"keyword.operator.noexcept"
+			],
 			"settings": {
 				"foreground": "#0F4A85"
 			}
 		},
 		{
-			"scope": ["string", "meta.embedded.assembly"],
+			"scope": [
+				"string",
+				"meta.embedded.assembly"
+			],
 			"settings": {
 				"foreground": "#0F4A85"
 			}
@@ -250,7 +266,9 @@
 			}
 		},
 		{
-			"scope": ["meta.template.expression"],
+			"scope": [
+				"meta.template.expression"
+			],
 			"settings": {
 				"foreground": "#000000"
 			}
@@ -281,7 +299,9 @@
 			}
 		},
 		{
-			"scope": ["support.type.property-name.json"],
+			"scope": [
+				"support.type.property-name.json"
+			],
 			"settings": {
 				"foreground": "#0451A5"
 			}
@@ -328,7 +348,10 @@
 			}
 		},
 		{
-			"scope": ["punctuation.section.embedded.begin.php", "punctuation.section.embedded.end.php"],
+			"scope": [
+				"punctuation.section.embedded.begin.php",
+				"punctuation.section.embedded.end.php"
+			],
 			"settings": {
 				"foreground": "#0F4A85"
 			}
@@ -346,7 +369,11 @@
 			}
 		},
 		{
-			"scope": ["storage.modifier.import.java", "variable.language.wildcard.java", "storage.modifier.package.java"],
+			"scope": [
+				"storage.modifier.import.java",
+				"variable.language.wildcard.java",
+				"storage.modifier.package.java"
+			],
 			"settings": {
 				"foreground": "#000000"
 			}
@@ -448,13 +475,18 @@
 			}
 		},
 		{
-			"scope": ["variable.other.constant", "variable.other.enummember"],
+			"scope": [
+				"variable.other.constant",
+				"variable.other.enummember"
+			],
 			"settings": {
 				"foreground": "#02715D"
 			}
 		},
 		{
-			"scope": ["meta.object-literal.key"],
+			"scope": [
+				"meta.object-literal.key"
+			],
 			"settings": {
 				"foreground": "#001080"
 			}
@@ -505,7 +537,10 @@
 			}
 		},
 		{
-			"scope": ["keyword.operator.or.regexp", "keyword.control.anchor.regexp"],
+			"scope": [
+				"keyword.operator.or.regexp",
+				"keyword.control.anchor.regexp"
+			],
 			"settings": {
 				"foreground": "#EE0000"
 			}
@@ -554,6 +589,8 @@
 		}
 	],
 	"colors": {
-		"actionBar.toggledBackground": "#dddddd"
+		"actionBar.toggledBackground": "#dddddd",
+		"textCodeBlock.background": "#0F4A85",
+		"textPreformat.foreground": "#FFFFFF"
 	}
 }

--- a/src/integrations/theme/getTheme.ts
+++ b/src/integrations/theme/getTheme.ts
@@ -71,6 +71,11 @@ export async function getTheme() {
 			parsed = mergeJson(parsed, includeTheme)
 		}
 
+		// Push the merged, parsed colors to the global configuration so the variables are available in the webview
+		vscode.workspace
+			.getConfiguration()
+			.update("workbench.colorCustomizations", parsed.colors, vscode.ConfigurationTarget.Global)
+
 		const converted = convertTheme(parsed)
 
 		converted.base = (


### PR DESCRIPTION
### Description

This PR fixes the variables loading into the webview and allows them to be available in CSS. It resolves an issue where text cannot be seen when using a high contrast theme.
Fixes https://github.com/cline/cline/issues/1817

### Test Procedure

I tested VS Code themes and verified that variables are now being passed through.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<img width="381" alt="Screenshot 2025-03-09 at 8 02 31 PM" src="https://github.com/user-attachments/assets/92f86951-d03c-45ed-8247-2ddd4a18f01e" />

### Additional Notes



<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes theme variable loading into webview to improve text visibility in high contrast themes.
> 
>   - **Behavior**:
>     - Fixes issue with theme variables not loading into webview, affecting text visibility in high contrast themes.
>     - Updates `getTheme.ts` to push parsed theme colors to global configuration for webview availability.
>   - **Themes**:
>     - Adds `textCodeBlock.background` and `textPreformat.foreground` to `hc_black.json` and `hc_light.json`.
>   - **Misc**:
>     - Adds changeset `honest-scissors-smile.md` to document the patch.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 98b05fc0ecdd4523ed50ddab14ca840cf911ec0d. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->