### PR TITLE
Fix tooltip layer bug

### DIFF
--- a/.changeset/fifty-foxes-brake.md
+++ b/.changeset/fifty-foxes-brake.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Fix tooltip css layer bug

--- a/webview-ui/src/components/chat/ChatTextArea.tsx
+++ b/webview-ui/src/components/chat/ChatTextArea.tsx
@@ -1132,6 +1132,7 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 						</ModelContainer>
 					</ButtonGroup>
 					<Tooltip
+						style={{ zIndex: 1000 }}
 						visible={shownTooltipMode !== null}
 						tipText={`In ${shownTooltipMode === "act" ? "Act" : "Plan"}  mode, Cline will ${shownTooltipMode === "act" ? "complete the task immediately" : "gather information to architect a plan"}`}
 						hintText={`Toggle w/ ${metaKeyChar}+Shift+A`}>

--- a/webview-ui/src/components/common/Tooltip.tsx
+++ b/webview-ui/src/components/common/Tooltip.tsx
@@ -13,10 +13,11 @@ interface TooltipProps {
 	hintText: string
 	tipText: string
 	children: React.ReactNode
+	style?: React.CSSProperties
 }
 
 // add styled component for tooltip
-const TooltipBody = styled.div`
+const TooltipBody = styled.div<Pick<TooltipProps, "style">>`
 	position: absolute;
 	background-color: ${getAsVar(VSC_SIDEBAR_BACKGROUND)};
 	color: ${getAsVar(VSC_DESCRIPTION_FOREGROUND)};
@@ -24,7 +25,7 @@ const TooltipBody = styled.div`
 	border-radius: 5px;
 	bottom: 100%;
 	left: -180%;
-	z-index: 10;
+	z-index: ${(props) => props.style?.zIndex ?? 10};
 	white-space: wrap;
 	max-width: 200px;
 	border: 1px solid ${getAsVar(VSC_INPUT_BORDER)};
@@ -39,12 +40,12 @@ const Hint = styled.div`
 	margin-top: 2px;
 `
 
-const Tooltip: React.FC<TooltipProps> = ({ visible, tipText, hintText, children }) => {
+const Tooltip: React.FC<TooltipProps> = ({ visible, tipText, hintText, children, style }) => {
 	return (
 		<div style={{ position: "relative", display: "inline-block" }}>
 			{children}
 			{visible && (
-				<TooltipBody>
+				<TooltipBody style={style}>
 					{tipText}
 					{hintText && <Hint>{hintText}</Hint>}
 				</TooltipBody>


### PR DESCRIPTION
### Description
Fix tooltip css layer bug.

<!-- Describe your changes in detail. What problem does this PR solve? -->

### Test Procedure
- `npm run test`
- use `extension-test-runner` to test manually
<!-- How did you test this? Are you confident that it will not introduce bugs? If so, why? -->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Before:
![image](https://github.com/user-attachments/assets/072f64b1-9b1e-43e7-bce0-e957031017ea)


After:
![image](https://github.com/user-attachments/assets/895b0800-95d4-4226-9e5f-9867b45d2abb)

<!-- For UI changes, add screenshots here -->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes tooltip CSS layering issue by setting `zIndex` to 1000 in `ChatTextArea.tsx` and `Tooltip.tsx`.
> 
>   - **Behavior**:
>     - Fixes tooltip CSS layering issue by setting `zIndex` to 1000 in `ChatTextArea.tsx` and `Tooltip.tsx`.
>   - **Components**:
>     - Adds `style` prop to `Tooltip` component in `Tooltip.tsx` to allow custom styling, including `zIndex`.
>     - Updates `TooltipBody` styled component to use `zIndex` from `style` prop in `Tooltip.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 278b8a6d6cbf49d2227952f23d4b8bd445499028. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->