### PR TITLE
Update copyright for Readme Files

### DIFF
--- a/.changeset/poor-zoos-jump.md
+++ b/.changeset/poor-zoos-jump.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Update copyright for Readme Files

--- a/locales/de/README.md
+++ b/locales/de/README.md
@@ -158,5 +158,5 @@ Um zum Projekt beizutragen, beginnen Sie mit unserem [Beitragsleitfaden](CONTRIB
 
 ## Lizenz
 
-[Apache 2.0 © 2024 Cline Bot Inc.](./LICENSE)
+[Apache 2.0 © 2025 Cline Bot Inc.](./LICENSE)
 

--- a/locales/es/README.md
+++ b/locales/es/README.md
@@ -158,4 +158,4 @@ Para contribuir al proyecto, comience con nuestra [guía de contribución](CONTR
 
 ## Licencia
 
-[Apache 2.0 © 2024 Cline Bot Inc.](./LICENSE)
+[Apache 2.0 © 2025 Cline Bot Inc.](./LICENSE)

--- a/locales/ja/README.md
+++ b/locales/ja/README.md
@@ -158,4 +158,4 @@ Clineがタスクを進める中で、拡張機能は各ステップでワーク
 
 ## ライセンス
 
-[Apache 2.0 © 2024 Cline Bot Inc.](./LICENSE)
+[Apache 2.0 © 2025 Cline Bot Inc.](./LICENSE)

--- a/locales/pt-BR/README.md
+++ b/locales/pt-BR/README.md
@@ -158,4 +158,4 @@ Para contribuir com o projeto, comece com nosso [Guia de Contribuição](CONTRIB
 
 ## Licença
 
-[Apache 2.0 © 2024 Cline Bot Inc.](./LICENSE)
+[Apache 2.0 © 2025 Cline Bot Inc.](./LICENSE)

--- a/locales/zh-cn/README.md
+++ b/locales/zh-cn/README.md
@@ -158,5 +158,5 @@ Cline 所做的所有更改都会记录在你的文件时间轴中，提供了�
 
 ## 许可证
 
-[Apache 2.0 © 2024 Cline Bot Inc.](./LICENSE)
+[Apache 2.0 © 2025 Cline Bot Inc.](./LICENSE)
 

--- a/locales/zh-tw/README.md
+++ b/locales/zh-tw/README.md
@@ -158,4 +158,4 @@ Cline 所做的所有更改都會記錄在你的文件時間軸中，提供了�
 
 ## 許可證
 
-[Apache 2.0 © 2024 Cline Bot Inc.](./LICENSE)
+[Apache 2.0 © 2025 Cline Bot Inc.](./LICENSE)


### PR DESCRIPTION
### Description

Update Copyright in README files for other languages.

### Test Procedure

README Updates, check the readme files in locales for the updated 2025 copyright.

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [X] 📚 Documentation update

### Pre-flight Checklist

-   [X] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [X] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [X] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [X] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update copyright year in multiple locale-specific README files from 2024 to 2025.
> 
>   - **Documentation**:
>     - Update copyright year from 2024 to 2025 in `README.md` files for `de`, `es`, `ja`, `pt-BR`, `zh-cn`, and `zh-tw` locales.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for cc28851ba8069705af969da2415392e002966344. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->