### PR TITLE
eng-250/ Added getDiffCount

### DIFF
--- a/.changeset/metal-chefs-dream.md
+++ b/.changeset/metal-chefs-dream.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Added a dedicated git getDiffCount function to reduce git operations

--- a/src/core/Cline.ts
+++ b/src/core/Cline.ts
@@ -562,9 +562,9 @@ export class Cline {
 				return false
 			}
 
-			// Get changed files between current state and commit
-			const changedFiles = await this.checkpointTracker?.getDiffSet(previousCheckpointHash, hash)
-			const changedFilesCount = changedFiles?.length || 0
+			// Get count of changed files between current state and commit
+			const changedFiles = await this.checkpointTracker?.getDiffCount(previousCheckpointHash, hash)
+			const changedFilesCount = changedFiles || 0
 			if (changedFilesCount > 0) {
 				return true
 			}

--- a/src/core/Cline.ts
+++ b/src/core/Cline.ts
@@ -563,8 +563,7 @@ export class Cline {
 			}
 
 			// Get count of changed files between current state and commit
-			const changedFiles = await this.checkpointTracker?.getDiffCount(previousCheckpointHash, hash)
-			const changedFilesCount = changedFiles || 0
+			const changedFilesCount = (await this.checkpointTracker?.getDiffCount(previousCheckpointHash, hash)) || 0
 			if (changedFilesCount > 0) {
 				return true
 			}

--- a/src/integrations/checkpoints/CheckpointTracker.ts
+++ b/src/integrations/checkpoints/CheckpointTracker.ts
@@ -310,6 +310,25 @@ class CheckpointTracker {
 
 		return result
 	}
+
+	/**
+	 * Returns the number of files changed between two commits.
+	 *
+	 * @param lhsHash - The commit to compare from (older commit)
+	 * @param rhsHash - The commit to compare to (newer commit)
+	 * @returns The number of files changed between the commits
+	 */
+	public async getDiffCount(lhsHash: string, rhsHash: string): Promise<number> {
+		const gitPath = await getShadowGitPath(this.globalStoragePath, this.taskId, this.cwdHash)
+		const git = simpleGit(path.dirname(gitPath))
+
+		console.info(`Getting commit diff file count: ${lhsHash} -> ${rhsHash}`)
+
+		const diffRange = `${lhsHash}..${rhsHash}`
+		const diffSummary = await git.diffSummary([diffRange])
+
+		return diffSummary.files.length
+	}
 }
 
 export default CheckpointTracker

--- a/src/integrations/checkpoints/CheckpointTracker.ts
+++ b/src/integrations/checkpoints/CheckpointTracker.ts
@@ -315,16 +315,20 @@ class CheckpointTracker {
 	 * Returns the number of files changed between two commits.
 	 *
 	 * @param lhsHash - The commit to compare from (older commit)
-	 * @param rhsHash - The commit to compare to (newer commit)
+	 * @param rhsHash - The commit to compare to (newer commit).
+	 *                  If omitted, we compare to the working directory.
 	 * @returns The number of files changed between the commits
 	 */
-	public async getDiffCount(lhsHash: string, rhsHash: string): Promise<number> {
+	public async getDiffCount(lhsHash: string, rhsHash?: string): Promise<number> {
 		const gitPath = await getShadowGitPath(this.globalStoragePath, this.taskId, this.cwdHash)
 		const git = simpleGit(path.dirname(gitPath))
 
-		console.info(`Getting commit diff file count: ${lhsHash} -> ${rhsHash}`)
+		console.info(`Getting diff count between commits: ${lhsHash || "initial"} -> ${rhsHash || "working directory"}`)
 
-		const diffRange = `${lhsHash}..${rhsHash}`
+		// Stage all changes so that untracked files appear in diff summary
+		await this.gitOperations.addCheckpointFiles(git)
+
+		const diffRange = rhsHash ? `${lhsHash}..${rhsHash}` : lhsHash
 		const diffSummary = await git.diffSummary([diffRange])
 
 		return diffSummary.files.length


### PR DESCRIPTION
### Description

This PR adds a dedicated git getDiffCount function to return the number of files changed between two commits. The existing getDiffSet function stages files and has logic for cases where only one hash has been provided, but in one case it is used to just get a count of the files. This function is simpler and serves the purpose of purely returning the changed file count without any other git operations and no need for single-hash handling. This need was identified when testing with extremely large workspaces, as the repeated staging of files was leading to lock errors (index.lock) in the shadow git.

### Test Procedure

This can be tested by enabling checkpoints and performing a task with file edits/creations to completion, then using the "See new changes" button. The getDiffCount() function is called to get the file count and determine whether the button should be displayed or not, and the existing getDiffSet() function is called to display the actual diff set when the button is clicked.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [X] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [X] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [X] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [X] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [X] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds `getDiffCount()` in `CheckpointTracker.ts` to efficiently count changed files between commits, optimizing performance in large workspaces.
> 
>   - **Behavior**:
>     - Adds `getDiffCount()` in `CheckpointTracker.ts` to return the number of files changed between two commits, without staging files.
>     - Replaces `getDiffSet()` with `getDiffCount()` in `Cline.ts` to check for changes without full diff set.
>   - **Performance**:
>     - Reduces git operations and potential lock errors in large workspaces by avoiding unnecessary file staging.
>   - **Logging**:
>     - Adds console logs in `getDiffCount()` for tracking operations.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 5769bafbb7d18d8bab36704db117f3db795ea5ed. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->