### PR TITLE
Fix temperature param for o3mini and o1mini when using LiteLLM

### DIFF
--- a/src/api/providers/litellm.ts
+++ b/src/api/providers/litellm.ts
@@ -23,11 +23,18 @@ export class LiteLlmHandler implements ApiHandler {
 			role: "system",
 			content: systemPrompt,
 		}
+		const modelId = this.options.liteLlmModelId || liteLlmDefaultModelId
+		const isO3Mini = modelId.includes("o3-mini")
+		let temperature: number | undefined = 0
+
+		if (isO3Mini) {
+			temperature = undefined // does not support temperature
+		}
 
 		const stream = await this.client.chat.completions.create({
 			model: this.options.liteLlmModelId || liteLlmDefaultModelId,
 			messages: [systemMessage, ...formattedMessages],
-			temperature: 0,
+			temperature,
 			stream: true,
 			stream_options: { include_usage: true },
 		})

--- a/src/api/providers/litellm.ts
+++ b/src/api/providers/litellm.ts
@@ -24,10 +24,10 @@ export class LiteLlmHandler implements ApiHandler {
 			content: systemPrompt,
 		}
 		const modelId = this.options.liteLlmModelId || liteLlmDefaultModelId
-		const isO3Mini = modelId.includes("o3-mini")
+		const isOminiModel = modelId.includes("o1-mini") || modelId.includes("o3-mini")
 		let temperature: number | undefined = 0
 
-		if (isO3Mini) {
+		if (isOminiModel) {
 			temperature = undefined // does not support temperature
 		}
 


### PR DESCRIPTION
### Description
This PR fixes an issue where OpenAI O-series models (o1-mini and o3-mini) reject API calls with temperature=0 parameter when using LiteLLM, causing request failures.

When using o1-mini or o3-mini models, the following error was occurring:
```
400 litellm.UnsupportedParamsError: O-series models don't support temperature=0. Only temperature=1 is supported. To drop unsupported openai params from the call, set `litellm.drop_params = True`No fallback model group found for original model_group=openai/o1-mini-2024-09-12. Fallbacks=[]. Received Model Group=openai/o1-mini-2024-09-12
Available Model Group Fallbacks=None
Error doing the fallback: litellm.UnsupportedParamsError: O-series models don't support temperature=0. Only temperature=1 is supported. To drop unsupported openai params from the call, set `litellm.drop_params = True`No fallback model group found for original model_group=openai/o1-mini-2024-09-12. Fallbacks=[] LiteLLM Retried: 1 times, LiteLLM Max Retries: 2
```
### Test Procedure

Verified successful API calls using o1-mini and o3-mini and other model.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist
-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes temperature parameter handling for `o1-mini` and `o3-mini` models in `LiteLlmHandler` to prevent API call failures.
> 
>   - **Behavior**:
>     - Fixes issue in `LiteLlmHandler` in `litellm.ts` where `o1-mini` and `o3-mini` models reject `temperature=0`.
>     - Sets `temperature` to `undefined` for `o1-mini` and `o3-mini` models to prevent API call failures.
>   - **Files**:
>     - Modifies `createMessage()` in `litellm.ts` to handle temperature parameter correctly.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for e21c4d76e24ed66b5546a6284c74a16f0de06834. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->