### PR TITLE
feat: Allow to configure computer use for openapi compatible provider

### DIFF
--- a/.changeset/violet-socks-obey.md
+++ b/.changeset/violet-socks-obey.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": minor
+---
+
+Allow to set computerUse for OpenAI Compatible provider

--- a/webview-ui/src/components/settings/ApiOptions.tsx
+++ b/webview-ui/src/components/settings/ApiOptions.tsx
@@ -742,7 +742,7 @@ const ApiOptions = ({ showModelOptions, apiErrorMessage, modelIdErrorMessage, is
 									let modelInfo = apiConfiguration?.openAiModelInfo
 										? apiConfiguration.openAiModelInfo
 										: { ...openAiModelInfoSaneDefaults }
-									modelInfo.supportsComputerUse = isChecked
+									modelInfo = { ...modelInfo, supportsComputerUse: isChecked }
 									setApiConfiguration({
 										...apiConfiguration,
 										openAiModelInfo: modelInfo,

--- a/webview-ui/src/components/settings/ApiOptions.tsx
+++ b/webview-ui/src/components/settings/ApiOptions.tsx
@@ -735,6 +735,21 @@ const ApiOptions = ({ showModelOptions, apiErrorMessage, modelIdErrorMessage, is
 								}}>
 								Supports Images
 							</VSCodeCheckbox>
+							<VSCodeCheckbox
+								checked={!!apiConfiguration?.openAiModelInfo?.supportsComputerUse}
+								onChange={(e: any) => {
+									const isChecked = e.target.checked === true
+									let modelInfo = apiConfiguration?.openAiModelInfo
+										? apiConfiguration.openAiModelInfo
+										: { ...openAiModelInfoSaneDefaults }
+									modelInfo.supportsComputerUse = isChecked
+									setApiConfiguration({
+										...apiConfiguration,
+										openAiModelInfo: modelInfo,
+									})
+								}}>
+								Supports Computer Use
+							</VSCodeCheckbox>
 							<div style={{ display: "flex", gap: 10, marginTop: "5px" }}>
 								<VSCodeTextField
 									value={


### PR DESCRIPTION
### Description

Sorry for reopening the PR, but there is an open question from @saoudrizwan to @brownrw8 in the original PR: https://github.com/cline/cline/pull/1923

The PR was closed without any reason (workflow issue?) and I don't get any answers anymore (probably because it is closed). Merging this should be straightforward and it's important to us.
(I'm working for [https://internetcomputer.org](https://internetcomputer.org) )

I suggest to reopen the other PR and close this one.

Thanks for your attention
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add configuration option for 'computer use' in OpenAI compatible providers in `ApiOptions.tsx`.
> 
>   - **Feature Addition**:
>     - Adds `VSCodeCheckbox` for `supportsComputerUse` in `ApiOptions.tsx` to allow configuration of computer use for OpenAI compatible providers.
>     - Updates `apiConfiguration` to include `supportsComputerUse` in `openAiModelInfo`.
>   - **Documentation**:
>     - Adds a changeset file `violet-socks-obey.md` to document the new feature.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 607674acfc2127188d441187f7d0a2b637a417f6. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->