### PR TITLE
fix: #2153 make sure isolated qwen model setting on switch mode settings

### DIFF
--- a/.changeset/stale-cats-hear.md
+++ b/.changeset/stale-cats-hear.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Fix issue with qwen model setting works incorrectly on switching Plan/Act mode settings

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -955,6 +955,7 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 				case "gemini":
 				case "asksage":
 				case "openai-native":
+				case "qwen":
 				case "deepseek":
 					await this.updateGlobalState("previousModeModelId", apiConfiguration.apiModelId)
 					break
@@ -994,7 +995,7 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 					case "vertex":
 					case "gemini":
 					case "asksage":
-					case "openai-native":
+					case "qwen":
 					case "deepseek":
 						await this.updateGlobalState("apiModelId", newModelId)
 						break


### PR DESCRIPTION
### Description

<!-- Describe your changes in detail. What problem does this PR solve? -->

Fix issue with qwen model setting works incorrectly on switching Plan/Act mode settings

### Test Procedure

<!-- How did you test this? Are you confident that it will not introduce bugs? If so, why? -->

1. Open Settings Panel of Cline
2. On Plan Mode Setting , set API Provider: Alibaba Qwen , Model: deepseek-r1
3. Switch to Act Mode Setting, set API Provider: Alibaba Qwen , Model: qwen-coder-plus
4. Switch back to Plan Mode Setting, Model remains deepseek-r1

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

### Additional Notes

<!-- Add any additional notes for reviewers -->
