### PR TITLE
feat: Enable VPC endpoint configuration for Amazon Bedrock in AWS Profile mode

### DIFF
--- a/.changeset/real-countries-burn.md
+++ b/.changeset/real-countries-burn.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": minor
+---
+
+Enable VPC endpoint configuration for Amazon Bedrock in AWS Profile mode.

--- a/src/api/providers/bedrock.ts
+++ b/src/api/providers/bedrock.ts
@@ -165,6 +165,7 @@ export class AwsBedrockHandler implements ApiHandler {
 			awsSecretKey: credentials.secretAccessKey,
 			awsSessionToken: credentials.sessionToken,
 			awsRegion: this.options.awsRegion || "us-east-1",
+			...(this.options.awsBedrockEndpoint && { endpoint: this.options.awsBedrockEndpoint }),
 		})
 	}
 

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -68,6 +68,7 @@ type GlobalStateKey =
 	| "awsRegion"
 	| "awsUseCrossRegionInference"
 	| "awsBedrockUsePromptCache"
+	| "awsBedrockEndpoint"
 	| "awsProfile"
 	| "awsUseProfile"
 	| "vertexProjectId"
@@ -1102,6 +1103,7 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 			awsRegion,
 			awsUseCrossRegionInference,
 			awsBedrockUsePromptCache,
+			awsBedrockEndpoint,
 			awsProfile,
 			awsUseProfile,
 			vertexProjectId,
@@ -1149,6 +1151,7 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 		await this.updateGlobalState("awsRegion", awsRegion)
 		await this.updateGlobalState("awsUseCrossRegionInference", awsUseCrossRegionInference)
 		await this.updateGlobalState("awsBedrockUsePromptCache", awsBedrockUsePromptCache)
+		await this.updateGlobalState("awsBedrockEndpoint", awsBedrockEndpoint)
 		await this.updateGlobalState("awsProfile", awsProfile)
 		await this.updateGlobalState("awsUseProfile", awsUseProfile)
 		await this.updateGlobalState("vertexProjectId", vertexProjectId)
@@ -1936,6 +1939,7 @@ Here is the project's README to help you get started:\n\n${mcpDetails.readmeCont
 			awsRegion,
 			awsUseCrossRegionInference,
 			awsBedrockUsePromptCache,
+			awsBedrockEndpoint,
 			awsProfile,
 			awsUseProfile,
 			vertexProjectId,
@@ -1996,6 +2000,7 @@ Here is the project's README to help you get started:\n\n${mcpDetails.readmeCont
 			this.getGlobalState("awsRegion") as Promise<string | undefined>,
 			this.getGlobalState("awsUseCrossRegionInference") as Promise<boolean | undefined>,
 			this.getGlobalState("awsBedrockUsePromptCache") as Promise<boolean | undefined>,
+			this.getGlobalState("awsBedrockEndpoint") as Promise<string | undefined>,
 			this.getGlobalState("awsProfile") as Promise<string | undefined>,
 			this.getGlobalState("awsUseProfile") as Promise<boolean | undefined>,
 			this.getGlobalState("vertexProjectId") as Promise<string | undefined>,
@@ -2097,6 +2102,7 @@ Here is the project's README to help you get started:\n\n${mcpDetails.readmeCont
 				awsRegion,
 				awsUseCrossRegionInference,
 				awsBedrockUsePromptCache,
+				awsBedrockEndpoint,
 				awsProfile,
 				awsUseProfile,
 				vertexProjectId,

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -38,6 +38,7 @@ export interface ApiHandlerOptions {
 	awsBedrockUsePromptCache?: boolean
 	awsUseProfile?: boolean
 	awsProfile?: string
+	awsBedrockEndpoint?: string
 	vertexProjectId?: string
 	vertexRegion?: string
 	openAiBaseUrl?: string

--- a/webview-ui/src/components/settings/ApiOptions.tsx
+++ b/webview-ui/src/components/settings/ApiOptions.tsx
@@ -580,6 +580,13 @@ const ApiOptions = ({ showModelOptions, apiErrorMessage, modelIdErrorMessage, is
 							{/* <VSCodeOption value="us-gov-east-1">us-gov-east-1</VSCodeOption> */}
 						</VSCodeDropdown>
 					</DropdownContainer>
+					<VSCodeTextField
+						value={apiConfiguration?.awsBedrockEndpoint || ""}
+						style={{ width: "100%" }}
+						onInput={handleInputChange("awsBedrockEndpoint")}
+						placeholder="Enter VPC Endpoint URL (optional)">
+						<span style={{ fontWeight: 500 }}>AWS Bedrock VPC Endpoint</span>
+					</VSCodeTextField>
 					<div style={{ display: "flex", flexDirection: "column" }}>
 						<VSCodeCheckbox
 							checked={apiConfiguration?.awsUseCrossRegionInference || false}

--- a/webview-ui/src/components/settings/ApiOptions.tsx
+++ b/webview-ui/src/components/settings/ApiOptions.tsx
@@ -90,6 +90,7 @@ const ApiOptions = ({ showModelOptions, apiErrorMessage, modelIdErrorMessage, is
 	const [vsCodeLmModels, setVsCodeLmModels] = useState<vscodemodels.LanguageModelChatSelector[]>([])
 	const [anthropicBaseUrlSelected, setAnthropicBaseUrlSelected] = useState(!!apiConfiguration?.anthropicBaseUrl)
 	const [azureApiVersionSelected, setAzureApiVersionSelected] = useState(!!apiConfiguration?.azureApiVersion)
+	const [awsEndpointSelected, setAwsEndpointSelected] = useState(!!apiConfiguration?.awsBedrockEndpoint)
 	const [modelConfigurationSelected, setModelConfigurationSelected] = useState(false)
 	const [isDescriptionExpanded, setIsDescriptionExpanded] = useState(false)
 
@@ -580,14 +581,33 @@ const ApiOptions = ({ showModelOptions, apiErrorMessage, modelIdErrorMessage, is
 							{/* <VSCodeOption value="us-gov-east-1">us-gov-east-1</VSCodeOption> */}
 						</VSCodeDropdown>
 					</DropdownContainer>
-					<VSCodeTextField
-						value={apiConfiguration?.awsBedrockEndpoint || ""}
-						style={{ width: "100%" }}
-						onInput={handleInputChange("awsBedrockEndpoint")}
-						placeholder="Enter VPC Endpoint URL (optional)">
-						<span style={{ fontWeight: 500 }}>AWS Bedrock VPC Endpoint</span>
-					</VSCodeTextField>
+
 					<div style={{ display: "flex", flexDirection: "column" }}>
+						<VSCodeCheckbox
+							checked={awsEndpointSelected}
+							onChange={(e: any) => {
+								const isChecked = e.target.checked === true
+								setAwsEndpointSelected(isChecked)
+								if (!isChecked) {
+									setApiConfiguration({
+										...apiConfiguration,
+										awsBedrockEndpoint: "",
+									})
+								}
+							}}>
+							Use custom VPC endpoint
+						</VSCodeCheckbox>
+
+						{awsEndpointSelected && (
+							<VSCodeTextField
+								value={apiConfiguration?.awsBedrockEndpoint || ""}
+								style={{ width: "100%", marginTop: 3, marginBottom: 5 }}
+								type="url"
+								onInput={handleInputChange("awsBedrockEndpoint")}
+								placeholder="Enter VPC Endpoint URL (optional)"
+							/>
+						)}
+
 						<VSCodeCheckbox
 							checked={apiConfiguration?.awsUseCrossRegionInference || false}
 							onChange={(e: any) => {


### PR DESCRIPTION


### Description

Currently, the application does not support connecting to AWS Bedrock through VPC endpoints. This feature would be valuable for users who need to keep all API traffic within their private network for security and compliance reasons.
Organizations with strict security requirements often need to ensure that all cloud service communications remain on private networks without traversing the public internet. AWS PrivateLink and VPC endpoints provide this capability, but the current implementation doesn't support specifying custom endpoints when initializing the Bedrock client.
This update allows specifying a VPC endpoint when connecting to Amazon Bedrock using AWS Profile mode. It ensures that all API requests stay within a private network and do not traverse the public internet.

### Test Procedure

I've manually tested this functionality by adding the VPC endpoint configuration field to the UI and verifying that it's properly passed to the Bedrock client when connecting. I also verified that:

1. The field appears correctly in the UI when AWS Bedrock is selected as the provider
2. The endpoint value is properly saved in the configuration
3. The endpoint value is correctly loaded when reopening the settings
4. The endpoint configuration is correctly passed to the AnthropicBedrock client

The implementation changes are minimal and focused on a single feature, making the risk of introducing bugs very low.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

![tmp](https://github.com/user-attachments/assets/f9ef17ed-16c1-4c4b-8f89-74fd3df1d022)

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Enable VPC endpoint configuration for Amazon Bedrock in AWS Profile mode to keep API requests private.
> 
>   - **Behavior**:
>     - Adds support for specifying a VPC endpoint for Amazon Bedrock in AWS Profile mode in `bedrock.ts`.
>     - Ensures API requests stay within a private network.
>   - **Configuration**:
>     - Adds `awsBedrockEndpoint` to `ApiHandlerOptions` in `api.ts`.
>     - Updates `ClineProvider` in `ClineProvider.ts` to handle `awsBedrockEndpoint`.
>     - Adds input field for VPC Endpoint URL in `ApiOptions.tsx`.
>   - **Misc**:
>     - Adds changeset `real-countries-burn.md` for versioning.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 6ece72d123e08754ed26ebda921eb3cbb3dc7f63. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->