### PR TITLE
Configure Computer Use Openai Compatible

### DIFF
--- a/.changeset/violet-socks-obey.md
+++ b/.changeset/violet-socks-obey.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": minor
+---
+
+Allow to set computerUse for OpenAI Compatible provider

--- a/webview-ui/src/components/settings/ApiOptions.tsx
+++ b/webview-ui/src/components/settings/ApiOptions.tsx
@@ -800,6 +800,21 @@ const ApiOptions = ({ showModelOptions, apiErrorMessage, modelIdErrorMessage, is
 								}}>
 								Supports Images
 							</VSCodeCheckbox>
+							<VSCodeCheckbox
+								checked={!!apiConfiguration?.openAiModelInfo?.supportsComputerUse}
+								onChange={(e: any) => {
+									const isChecked = e.target.checked === true
+									let modelInfo = apiConfiguration?.openAiModelInfo
+										? apiConfiguration.openAiModelInfo
+										: { ...openAiModelInfoSaneDefaults }
+									modelInfo = { ...modelInfo, supportsComputerUse: isChecked }
+									setApiConfiguration({
+										...apiConfiguration,
+										openAiModelInfo: modelInfo,
+									})
+								}}>
+								Supports Computer Use
+							</VSCodeCheckbox>
 							<div style={{ display: "flex", gap: 10, marginTop: "5px" }}>
 								<VSCodeTextField
 									value={


### PR DESCRIPTION
### Description

This PR adds support for configuring computer use capability for OpenAI-compatible providers. It introduces a new checkbox in the API settings UI that allows users to specify whether their OpenAI-compatible model supports computer use functionality.

### Test Procedure

The changes were tested by:
- Verifying the new checkbox appears correctly in the API settings UI
- Confirming the `supportsComputerUse` flag is properly saved in the model configuration
- Testing that the flag correctly affects the system prompt
<img width="251" alt="Screenshot 2025-03-12 at 3 22 57 PM" src="https://github.com/user-attachments/assets/fd93d765-f8d1-4f57-ad05-70c258e3b530" />



### Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)

### Pre-flight Checklist

- [x] Changes are limited to a single feature (adds computer use configuration)
- [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
- [x] I have created a changeset using `npm run changeset` (see violet-socks-obey.md)
- [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<img width="351" alt="Screenshot 2025-03-12 at 3 28 30 PM" src="https://github.com/user-attachments/assets/990705ce-285e-4e44-9522-07c85db7851e" />


### Additional Notes


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add support for configuring computer use capability for OpenAI-compatible models via a new checkbox in the API settings UI.
> 
>   - **UI Changes**:
>     - Add `VSCodeCheckbox` for `supportsComputerUse` in `ApiOptions.tsx`.
>     - Checkbox appears under OpenAI-compatible model settings.
>   - **Configuration**:
>     - Updates `apiConfiguration` to include `supportsComputerUse` flag.
>     - Logic added to save and update this flag in model configuration.
>   - **Model Info**:
>     - `ModelInfoView` updated to display support for computer use.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 66f2e4f8b8677200dfa0469fd2844c88048e8e0f. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->