### PR TITLE
fix(bedrock): Support VPC Endpoint options for Deepseek

### DIFF
--- a/.changeset/clever-suits-smoke.md
+++ b/.changeset/clever-suits-smoke.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Support VPC Endpoint options for Deepseek

--- a/src/api/providers/bedrock.ts
+++ b/src/api/providers/bedrock.ts
@@ -194,6 +194,7 @@ export class AwsBedrockHandler implements ApiHandler {
 				secretAccessKey: credentials.secretAccessKey,
 				sessionToken: credentials.sessionToken,
 			},
+			...(this.options.awsBedrockEndpoint && { endpoint: this.options.awsBedrockEndpoint }),
 		})
 	}
 


### PR DESCRIPTION
### Description

Adapt modification https://github.com/cline/cline/pull/2214 to https://github.com/cline/cline/pull/2185 as well.

### Test Procedure

Existing tests pass.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

None.

### Additional Notes

None.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add support for VPC Endpoint options in `AwsBedrockHandler` by conditionally including `endpoint` in client instances.
> 
>   - **Behavior**:
>     - Add support for VPC Endpoint options in `AwsBedrockHandler` by conditionally including `endpoint` in `BedrockRuntimeClient` and `AnthropicBedrock` instances.
>   - **Misc**:
>     - Add changeset file `clever-suits-smoke.md` to document the patch.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 6f69a531a0174b73fe0398509dc151acd716028d. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->