### PR TITLE
Display Sonnet Thinking - Bedrock

### DIFF
--- a/.changeset/itchy-masks-cheat.md
+++ b/.changeset/itchy-masks-cheat.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": minor
+---
+
+Display thinking chunks from Sonnet 3.7 in Bedrock

--- a/src/api/providers/bedrock.ts
+++ b/src/api/providers/bedrock.ts
@@ -8,7 +8,6 @@ import { calculateApiCostOpenAI } from "../../utils/cost"
 import { ApiStream } from "../transform/stream"
 import { fromNodeProviderChain } from "@aws-sdk/credential-providers"
 import { BedrockRuntimeClient, InvokeModelWithResponseStreamCommand } from "@aws-sdk/client-bedrock-runtime"
-import { Logger } from "../../services/logging/Logger"
 
 // https://docs.anthropic.com/en/api/claude-on-amazon-bedrock
 export class AwsBedrockHandler implements ApiHandler {
@@ -89,8 +88,6 @@ export class AwsBedrockHandler implements ApiHandler {
 		})
 
 		for await (const chunk of stream) {
-			Logger.log(`chunk: ${JSON.stringify(chunk, null, 2)}`)
-
 			switch (chunk.type) {
 				case "message_start":
 					const usage = chunk.message.usage


### PR DESCRIPTION
### Description

Display Sonnet 3.7 thinking in Bedrock

Will do another PR for Deepseek

### Test Procedure

Checked that it's streamed correctly

<img width="360" alt="Screenshot 2025-03-12 at 10 28 48 PM" src="https://github.com/user-attachments/assets/6d0519f7-3a31-4353-aba3-5b0e17829a24" />


### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add support for displaying Sonnet 3.7 thinking in Bedrock by handling new content block types in `AwsBedrockHandler`.
> 
>   - **Behavior**:
>     - Display Sonnet 3.7 thinking in Bedrock by handling 'thinking' and 'redacted_thinking' content blocks in `AwsBedrockHandler`.
>     - Yields 'reasoning' type with content from 'thinking' blocks and '[Redacted thinking block]' for 'redacted_thinking'.
>   - **Files**:
>     - Modifications in `src/api/providers/bedrock.ts` to support new content block types.
>   - **Misc**:
>     - Adds a changeset file `itchy-masks-cheat.md` for versioning.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 16064796d8eea934433c38fb8ca4bc5b8f24afc1. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->