### PR TITLE
Add warning when checkpoints takes too long to load

### DIFF
--- a/.changeset/smooth-dryers-happen.md
+++ b/.changeset/smooth-dryers-happen.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Add warning for when checkpoints takes too long to load

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,6 +42,7 @@
 				"open-graph-scraper": "^6.9.0",
 				"openai": "^4.83.0",
 				"os-name": "^6.0.0",
+				"p-timeout": "^6.1.4",
 				"p-wait-for": "^5.0.2",
 				"pdf-parse": "^1.1.1",
 				"posthog-node": "^4.8.1",
@@ -13208,9 +13209,9 @@
 			}
 		},
 		"node_modules/p-timeout": {
-			"version": "6.1.2",
-			"resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-6.1.2.tgz",
-			"integrity": "sha512-UbD77BuZ9Bc9aABo74gfXhNvzC9Tx7SxtHSh1fxvx3jTLLYvmVhiQZZrJzqqU0jKbN32kb5VOKiLEQI/3bIjgQ==",
+			"version": "6.1.4",
+			"resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-6.1.4.tgz",
+			"integrity": "sha512-MyIV3ZA/PmyBN/ud8vV9XzwTrNtR4jFrObymZYnZqMmW0zA8Z17vnT0rBgFE/TlohB+YCHqXMgZzb3Csp49vqg==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=14.16"

--- a/package.json
+++ b/package.json
@@ -160,7 +160,7 @@
 				"cline.enableCheckpoints": {
 					"type": "boolean",
 					"default": true,
-					"description": "Enables extension to save checkpoints of workspace throughout the task."
+					"description": "Enables extension to save checkpoints of workspace throughout the task. Uses git under the hood which may not work well with large workspaces."
 				},
 				"cline.disableBrowserTool": {
 					"type": "boolean",
@@ -297,6 +297,7 @@
 		"open-graph-scraper": "^6.9.0",
 		"openai": "^4.83.0",
 		"os-name": "^6.0.0",
+		"p-timeout": "^6.1.4",
 		"p-wait-for": "^5.0.2",
 		"pdf-parse": "^1.1.1",
 		"posthog-node": "^4.8.1",

--- a/webview-ui/src/components/chat/TaskHeader.tsx
+++ b/webview-ui/src/components/chat/TaskHeader.tsx
@@ -43,6 +43,15 @@ const TaskHeader: React.FC<TaskHeaderProps> = ({
 	const { selectedModelInfo } = useMemo(() => normalizeApiConfiguration(apiConfiguration), [apiConfiguration])
 	const contextWindow = selectedModelInfo?.contextWindow
 
+	// Open task header when checkpoint tracker error message is set
+	const prevErrorMessageRef = useRef(checkpointTrackerErrorMessage)
+	useEffect(() => {
+		if (checkpointTrackerErrorMessage !== prevErrorMessageRef.current) {
+			setIsTaskExpanded(true)
+			prevErrorMessageRef.current = checkpointTrackerErrorMessage
+		}
+	}, [checkpointTrackerErrorMessage])
+
 	/*
 	When dealing with event listeners in React components that depend on state variables, we face a challenge. We want our listener to always use the most up-to-date version of a callback function that relies on current state, but we don't want to constantly add and remove event listeners as that function updates. This scenario often arises with resize listeners or other window events. Simply adding the listener in a useEffect with an empty dependency array risks using stale state, while including the callback in the dependencies can lead to unnecessary re-registrations of the listener. There are react hook libraries that provide a elegant solution to this problem by utilizing the useRef hook to maintain a reference to the latest callback function without triggering re-renders or effect re-runs. This approach ensures that our event listener always has access to the most current state while minimizing performance overhead and potential memory leaks from multiple listener registrations. 
 	Sources
@@ -461,7 +470,25 @@ const TaskHeader: React.FC<TaskHeaderProps> = ({
 									}}>
 									<i className="codicon codicon-warning" />
 									<span>
-										{checkpointTrackerErrorMessage}
+										{checkpointTrackerErrorMessage.replace(/disabling checkpoints\.$/, "")}
+										{checkpointTrackerErrorMessage.endsWith("disabling checkpoints.") && (
+											<>
+												<a
+													onClick={() => {
+														vscode.postMessage({
+															type: "openExtensionSettings",
+															text: "enableCheckpoints",
+														})
+													}}
+													style={{
+														color: "inherit",
+														textDecoration: "underline",
+														cursor: "pointer",
+													}}>
+													disabling checkpoints.
+												</a>
+											</>
+										)}
 										{checkpointTrackerErrorMessage.includes("Git must be installed to use checkpoints.") && (
 											<>
 												{" "}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds a warning for long checkpoint loading times and updates UI to display related error messages.
> 
>   - **Behavior**:
>     - Adds a warning for long checkpoint loading times using `p-timeout` in `Cline.ts`.
>     - Sets a 15-second timeout for `CheckpointTracker.create()` with a custom error message.
>   - **UI**:
>     - Updates `TaskHeader.tsx` to display `checkpointTrackerErrorMessage` and provide a link to disable checkpoints.
>     - Expands task header when `checkpointTrackerErrorMessage` changes.
>   - **Dependencies**:
>     - Adds `p-timeout` to `package.json` dependencies.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for bd01465997fe7204ae67ae7493c9db72257e3809. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->