### PR TITLE
Fix/Correct VPC endpoint parameter for AnthropicBedrock

### DIFF
--- a/.changeset/hip-chefs-peel.md
+++ b/.changeset/hip-chefs-peel.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+fix: Correct VPC endpoint parameter for AnthropicBedrock

--- a/src/api/providers/bedrock.ts
+++ b/src/api/providers/bedrock.ts
@@ -230,7 +230,7 @@ export class AwsBedrockHandler implements ApiHandler {
 			awsSecretKey: credentials.secretAccessKey,
 			awsSessionToken: credentials.sessionToken,
 			awsRegion: this.getRegion(),
-			...(this.options.awsBedrockEndpoint && { endpoint: this.options.awsBedrockEndpoint }),
+			...(this.options.awsBedrockEndpoint && { baseURL: this.options.awsBedrockEndpoint }),
 		})
 	}
 


### PR DESCRIPTION
### Description

In PR #2214, we introduced the ability to configure a custom VPC endpoint to privatize communication between Cline and Amazon Bedrock.
However, when setting a VPC endpoint for AnthropicBedrock, `baseURL` must be used instead of `endpoint`. (If nothing is set, the AWS public endpoint is used by default.)
Since AnthropicBedrock does not have an `endpoint` parameter, it is simply ignored and has no effect.

This PR fixes this issue and ensures that the Bedrock client correctly applies the VPC endpoint configuration.

**Note:** The correct type of VPC endpoint to specify is `Bedrock-Runtime`. Do not mistakenly use `Bedrock`, `Bedrock-Agent`, or other similar VPC endpoints.

~~While setting the correct VPC endpoint on the Bedrock client privatizes communication between Cline and Amazon Bedrock, it also results in a failure to receive AI-generated replies.~~
~~According to AWS Support, real-time streaming is not supported when using a VPC endpoint.~~

~~As an alternative, this PR ensures that when a VPC endpoint is set, the non-streaming mode is used instead, allowing AI replies to be received correctly.~~
~~Although this means that real-time AI typing cannot be observed, the functionality remains intact.~~

Edit: There was actually no issue with streaming mode.

### Test Procedure

The following tests were conducted using a test build:

1. No VPC endpoint configured → Successfully communicates with Bedrock in streaming mode.
2. Set VPC endpoint to `https://example.com` → Returns an authentication error for example.com.
3. Set VPC endpoint to `https://vpce-${ExistingDomain}.bedrock-runtime.${MyRegion}.vpce.amazonaws.com` →  Successfully communicates with Bedrock in streaming mode.
4. Set VPC endpoint to `https://vpce-${FictitiousDomain}.bedrock-runtime.${MyRegion}.vpce.amazonaws.com` → Results in a connection error.

These results confirm that the VPC endpoint configuration behaves as expected.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

No UI changes.

### Additional Notes

In `src/api/providers/bedrock.ts` at line 287, the following code exists, written by @watany-dev （ありがとうございます！）:

```ts
return new BedrockRuntimeClient({
    region: this.getRegion(),
    credentials: {
        accessKeyId: credentials.accessKeyId,
        secretAccessKey: credentials.secretAccessKey,
        sessionToken: credentials.sessionToken,
    },
    ...(this.options.awsBedrockEndpoint && { endpoint: this.options.awsBedrockEndpoint }),
});
```

This should function correctly for AWS-SDK, not AnthropicBedrock, as it still uses `endpoint`.

Again, please ensure that the correct VPC endpoint specified is `Bedrock-Runtime`. Do not mistakenly configure similar endpoints such as `Bedrock`, `Bedrock-Agent`, or `Bedrock-Agent-Runtime`.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes VPC endpoint configuration for AnthropicBedrock by using `baseURL` and ensures non-streaming mode when a VPC endpoint is set.
> 
>   - **Behavior**:
>     - Fixes VPC endpoint configuration for AnthropicBedrock by using `baseURL` instead of `endpoint` in `getAnthropicClient()` in `bedrock.ts`.
>     - Ensures non-streaming mode is used when a VPC endpoint is set, as real-time streaming is unsupported.
>   - **Misc**:
>     - Adds changeset `hip-chefs-peel.md` documenting the fix.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for c1560f55fbd0e5788e621851ce3c3c74ca134175. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->