### PR TITLE
Stream claude thinking vertex

### DIFF
--- a/.changeset/strange-rocks-rescue.md
+++ b/.changeset/strange-rocks-rescue.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": minor
+---
+
+Stream thinking from Vertex Claude

--- a/src/api/providers/vertex.ts
+++ b/src/api/providers/vertex.ts
@@ -162,6 +162,21 @@ export class VertexHandler implements ApiHandler {
 						break
 					case "content_block_start":
 						switch (chunk.content_block.type) {
+							case "thinking":
+								yield {
+									type: "reasoning",
+									reasoning: chunk.content_block.thinking || "",
+								}
+								break
+							case "redacted_thinking":
+								// Handle redacted thinking blocks - we still mark it as reasoning
+								// but note that the content is encrypted
+								yield {
+									type: "reasoning",
+									reasoning: "[Redacted thinking block]",
+								}
+								break
+
 							case "text":
 								if (chunk.index > 0) {
 									yield {
@@ -178,6 +193,12 @@ export class VertexHandler implements ApiHandler {
 						break
 					case "content_block_delta":
 						switch (chunk.delta.type) {
+							case "thinking_delta":
+								yield {
+									type: "reasoning",
+									reasoning: chunk.delta.thinking,
+								}
+								break
 							case "text_delta":
 								yield {
 									type: "text",


### PR DESCRIPTION
### Description

Stream thinking chunks from Claude

### Test Procedure

No tests, need to set up Vertex

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> `VertexHandler` in `vertex.ts` now processes `thinking` content blocks, yielding reasoning data.
> 
>   - **Behavior**:
>     - `VertexHandler` in `vertex.ts` now handles `thinking` and `redacted_thinking` content blocks, yielding reasoning data.
>     - Handles `thinking_delta` in `content_block_delta`, yielding reasoning updates.
>   - **Misc**:
>     - Adds a changeset file `strange-rocks-rescue.md` for versioning.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 9c15d9b07e90290dc21c37f34e74b8b63dd13687. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->