### PR TITLE
feat: optionally return html content with browser action response

### DIFF
--- a/.changeset/blue-feet-rhyme.md
+++ b/.changeset/blue-feet-rhyme.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": minor
+---
+
+Allow the browser tool to optionally return rendered HTML content for Cline to inspect, to supplement existing screenshots

--- a/docs/tools/cline-tools-guide.md
+++ b/docs/tools/cline-tools-guide.md
@@ -51,6 +51,7 @@ Cline is your AI assistant that can:
     - Test web pages
     - Capture screenshots
     - Inspect console logs
+    - Inspect rendered HTML content
 
 ## Available Tools
 

--- a/package.json
+++ b/package.json
@@ -167,6 +167,21 @@
 					"default": false,
 					"description": "Disables extension from spawning browser session."
 				},
+				"cline.browserToolEnableHTMLContent": {
+					"type": "boolean",
+					"default": false,
+					"description": "Enables extension to return HTML content during browser session. This can greatly increase the amount of tokens used."
+				},
+				"cline.browserToolMaxHTMLContentLength": {
+					"type": "integer",
+					"default": 20000,
+					"description": "Maximum length of HTML content that can be returned during a browser session. This truncates the content if it exceeds the limit, so might result in buggy behavior due to partial content."
+				},
+				"cline.browserToolStripHTMLContentStyleTags": {
+					"type": "boolean",
+					"default": false,
+					"description": "Strips <style> content from returned HTML content during browser session."
+				},
 				"cline.modelSettings.o3Mini.reasoningEffort": {
 					"type": "string",
 					"enum": [

--- a/src/core/prompts/system.ts
+++ b/src/core/prompts/system.ts
@@ -3,12 +3,14 @@ import os from "os"
 import osName from "os-name"
 import { McpHub } from "../../services/mcp/McpHub"
 import { BrowserSettings } from "../../shared/BrowserSettings"
+import { BrowserToolSettings } from "../../shared/BrowserToolSettings"
 
 export const SYSTEM_PROMPT = async (
 	cwd: string,
 	supportsComputerUse: boolean,
 	mcpHub: McpHub,
 	browserSettings: BrowserSettings,
+	browserToolSettings: BrowserToolSettings,
 ) => `You are Cline, a highly skilled software engineer with extensive knowledge in many programming languages, frameworks, design patterns, and best practices.
 
 ====
@@ -142,7 +144,8 @@ Usage:
 		? `
 
 ## browser_action
-Description: Request to interact with a Puppeteer-controlled browser. Every action, except \`close\`, will be responded to with a screenshot of the browser's current state, along with any new console logs. You may only perform one browser action per message, and wait for the user's response including a screenshot and logs to determine the next action.
+Description: Request to interact with a Puppeteer-controlled browser. Every action, except \`close\`, will be responded to with a screenshot of the browser's current state, along with any new console logs${browserToolSettings.enableHTMLContent ? `, and the HTML content for inspection, truncated to ${browserToolSettings.maxHTMLContentLength}.` : ""}. \
+${browserToolSettings.enableHTMLContent && browserToolSettings.stripHTMLContentStyleTags ? "The HTML content will be stripped of style tags." : ""} You may only perform one browser action per message, and wait for the user's response including a screenshot and logs to determine the next action.
 - The sequence of actions **must always start with** launching the browser at a URL, and **must always end with** closing the browser. If you need to visit a new URL that is not possible to navigate to from the current webpage, you must first close the browser, then launch again at the new URL.
 - While the browser is active, only the \`browser_action\` tool can be used. No other tools should be called during this time. You may proceed to use other tools only after closing the browser. For example if you run into an error and need to fix a file, you must close the browser, then use other tools to make the necessary changes, then re-launch the browser to verify the result.
 - The browser window has a resolution of **${browserSettings.viewport.width}x${browserSettings.viewport.height}** pixels. When performing any click actions, ensure the coordinates are within this resolution range.
@@ -549,7 +552,7 @@ class WeatherServer {
 
     this.setupResourceHandlers();
     this.setupToolHandlers();
-    
+
     // Error handling
     this.server.onerror = (error) => console.error('[MCP Error]', error);
     process.on('SIGINT', async () => {
@@ -814,14 +817,14 @@ You have access to two tools for working with files: **write_to_file** and **rep
 
 ## When to Use
 
-- Initial file creation, such as when scaffolding a new project.  
+- Initial file creation, such as when scaffolding a new project.
 - Overwriting large boilerplate files where you want to replace the entire content at once.
 - When the complexity or number of changes would make replace_in_file unwieldy or error-prone.
 - When you need to completely restructure a file's content or change its fundamental organization.
 
 ## Important Considerations
 
-- Using write_to_file requires providing the file's complete final content.  
+- Using write_to_file requires providing the file's complete final content.
 - If you only need to make small changes to an existing file, consider using replace_in_file instead to avoid unnecessarily rewriting the entire file.
 - While write_to_file should not be your default choice, don't hesitate to use it when the situation truly calls for it.
 
@@ -839,7 +842,7 @@ You have access to two tools for working with files: **write_to_file** and **rep
 
 ## Advantages
 
-- More efficient for minor edits, since you don't need to supply the entire file content.  
+- More efficient for minor edits, since you don't need to supply the entire file content.
 - Reduces the chance of errors that can occur when overwriting large files.
 
 # Choosing the Appropriate Tool
@@ -876,7 +879,7 @@ You have access to two tools for working with files: **write_to_file** and **rep
 By thoughtfully selecting between write_to_file and replace_in_file, you can make your file editing process smoother, safer, and more efficient.
 
 ====
- 
+
 ACT MODE V.S. PLAN MODE
 
 In each user message, the environment_details will specify the current mode. There are two modes:
@@ -889,7 +892,7 @@ In each user message, the environment_details will specify the current mode. The
 
 ## What is PLAN MODE?
 
-- While you are usually in ACT MODE, the user may switch to PLAN MODE in order to have a back and forth with you to plan how to best accomplish the task. 
+- While you are usually in ACT MODE, the user may switch to PLAN MODE in order to have a back and forth with you to plan how to best accomplish the task.
 - When starting in PLAN MODE, depending on the user's request, you may need to do some information gathering e.g. using read_file or search_files to get more context about the task. You may also ask the user clarifying questions to get a better understanding of the task. You may return mermaid diagrams to visually display your understanding.
 - Once you've gained more context about the user's request, you should architect a detailed plan for how you will accomplish the task. Returning mermaid diagrams may be helpful here as well.
 - Then you might ask the user if they are pleased with this plan, or if they would like to make any changes. Think of this as a brainstorming session where you can discuss the task and plan the best way to accomplish it.
@@ -897,7 +900,7 @@ In each user message, the environment_details will specify the current mode. The
 - Finally once it seems like you've reached a good plan, ask the user to switch you back to ACT MODE to implement the solution.
 
 ====
- 
+
 CAPABILITIES
 
 - You have access to tools that let you execute CLI commands on the user's computer, list files, view source code definitions, regex search${

--- a/src/shared/BrowserToolSettings.ts
+++ b/src/shared/BrowserToolSettings.ts
@@ -1,0 +1,5 @@
+export interface BrowserToolSettings {
+	enableHTMLContent: boolean
+	maxHTMLContentLength: number
+	stripHTMLContentStyleTags: boolean
+}

--- a/src/shared/ExtensionMessage.ts
+++ b/src/shared/ExtensionMessage.ts
@@ -191,6 +191,7 @@ export type BrowserActionResult = {
 	logs?: string
 	currentUrl?: string
 	currentMousePosition?: string
+	htmlContent?: string
 }
 
 export interface ClineAskUseMcpServer {

--- a/src/test/suite/extension.test.js
+++ b/src/test/suite/extension.test.js
@@ -57,8 +57,14 @@ describe("Extension Tests", function () {
 	it("should handle advanced settings configuration", async () => {
 		// Test browser session setting
 		await vscode.workspace.getConfiguration().update("cline.disableBrowserTool", true, true)
+		// Test browser tool settings
+		await vscode.workspace.getConfiguration().update("cline.browserToolEnableHTMLContent", true, true)
+		await vscode.workspace.getConfiguration().update("cline.browserToolStripHTMLContentStyleTags", true, true)
+
 		const updatedConfig = vscode.workspace.getConfiguration("cline")
 		expect(updatedConfig.get("disableBrowserTool")).to.be.true
+		expect(updatedConfig.get("browserToolEnableHTMLContent")).to.be.true
+		expect(updatedConfig.get("browserToolStripHTMLContentStyleTags")).to.be.true
 
 		// Reset settings
 		await vscode.workspace.getConfiguration().update("cline.disableBrowserTool", undefined, true)

--- a/webview-ui/src/components/chat/BrowserSessionRow.tsx
+++ b/webview-ui/src/components/chat/BrowserSessionRow.tsx
@@ -27,6 +27,7 @@ const BrowserSessionRow = memo((props: BrowserSessionRowProps) => {
 	const prevHeightRef = useRef(0)
 	const [maxActionHeight, setMaxActionHeight] = useState(0)
 	const [consoleLogsExpanded, setConsoleLogsExpanded] = useState(false)
+	const [htmlContentExpanded, setHTMLContentExpanded] = useState(false)
 
 	const isLastApiReqInterrupted = useMemo(() => {
 		// Check if last api_req_started is cancelled
@@ -56,6 +57,7 @@ const BrowserSessionRow = memo((props: BrowserSessionRowProps) => {
 				screenshot?: string
 				mousePosition?: string
 				consoleLogs?: string
+				htmlContent?: string
 				messages: ClineMessage[] // messages up to and including the result
 			}
 			nextAction?: {
@@ -86,6 +88,7 @@ const BrowserSessionRow = memo((props: BrowserSessionRowProps) => {
 						screenshot: resultData.screenshot,
 						mousePosition: resultData.currentMousePosition,
 						consoleLogs: resultData.logs,
+						htmlContent: resultData.htmlContent,
 						messages: [...currentStateMessages],
 					},
 					nextAction:
@@ -157,6 +160,7 @@ const BrowserSessionRow = memo((props: BrowserSessionRowProps) => {
 					url: page.currentState.url,
 					mousePosition: page.currentState.mousePosition,
 					consoleLogs: page.currentState.consoleLogs,
+					htmlContent: page.currentState.htmlContent,
 					screenshot: page.currentState.screenshot,
 				}
 			}
@@ -165,6 +169,7 @@ const BrowserSessionRow = memo((props: BrowserSessionRowProps) => {
 			url: undefined,
 			mousePosition: undefined,
 			consoleLogs: undefined,
+			htmlContent: undefined,
 			screenshot: undefined,
 		}
 	}, [pages])
@@ -180,12 +185,14 @@ const BrowserSessionRow = memo((props: BrowserSessionRowProps) => {
 				url: currentPage?.currentState.url || latestState.url || initialUrl,
 				mousePosition: currentPage?.currentState.mousePosition || latestState.mousePosition || defaultMousePosition,
 				consoleLogs: currentPage?.currentState.consoleLogs,
+				htmlContent: currentPage?.currentState.htmlContent,
 				screenshot: currentPage?.currentState.screenshot || latestState.screenshot,
 			}
 		: {
 				url: currentPage?.currentState.url || initialUrl,
 				mousePosition: currentPage?.currentState.mousePosition || defaultMousePosition,
 				consoleLogs: currentPage?.currentState.consoleLogs,
+				htmlContent: currentPage?.currentState.htmlContent,
 				screenshot: currentPage?.currentState.screenshot,
 			}
 
@@ -386,6 +393,29 @@ const BrowserSessionRow = memo((props: BrowserSessionRowProps) => {
 					</div>
 					{consoleLogsExpanded && (
 						<CodeBlock source={`${"```"}shell\n${displayState.consoleLogs || "(No new logs)"}\n${"```"}`} />
+					)}
+				</div>
+
+				<div style={{ width: "100%" }}>
+					<div
+						aria-label="View HTML Content"
+						onClick={() => {
+							setHTMLContentExpanded(!htmlContentExpanded)
+						}}
+						style={{
+							display: "flex",
+							alignItems: "center",
+							gap: "4px",
+							// width: "100%",
+							justifyContent: "flex-start",
+							cursor: "pointer",
+							padding: `9px 8px ${htmlContentExpanded ? 0 : 8}px 8px`,
+						}}>
+						<span className={`codicon codicon-chevron-${htmlContentExpanded ? "down" : "right"}`}></span>
+						<span style={{ fontSize: "0.8em" }}>HTML Content</span>
+					</div>
+					{htmlContentExpanded && (
+						<CodeBlock source={`${"```"}html\n${displayState.htmlContent || "(No HTML content)"}\n${"```"}`} />
 					)}
 				</div>
 			</div>


### PR DESCRIPTION
### Description

<!-- Describe your changes in detail. What problem does this PR solve? -->

Adds the ability to view loaded HTML page content to inspect things like attributes on HTML elements.

### Use Case

This came up while trying to generate end-to-end tests. Cline was able to suggest e2e test cases based on screenshots of the UI, but could not efficiently and reliably determine which `data-testid` attribute was on the HTML elements to use as selectors in the tests.

After making this change, we're now able to completely generate working e2e tests.

### Design Decisions

#### LLM Token Concerns

1. This has the potential to greatly increase tokens in the request, so the feature is disabled by default. It won't affect existing users.
2. This strategy has the potential to fail in many cases because the HTML content is too large to fit into an LLM prompt, so there are settings for max character limits.
3. It's becoming more popular in front-ends like React projects for style to be included inline with the JSX components, instead of using traditional .css files, which blows up the size of the returned HTML content. An option to strip out `<style>` tags was included for this case. Anecdotally, this brought a relatively small React page's returned HTML content down from **~270,000** tokens to **~4500**.

#### Settings UI Concerns

Sticking to the existing conventions around naming extension settings led to the configuration options for the browser tool being scattered across the settings page. I tried to lump those all into a group, but when I did that, you could no longer view or configure the available settings through the UI, and there was a "Configure these in a settings.json file" button in it's place. That felt bad for discovery, so I left these as individual settings but changed the naming convention to start with`browserTool` before anything else, so when VSCode orders them alphabetically, all the related configuration is in a single spot.

### Test Procedure

<!-- How did you test this? Are you confident that it will not introduce bugs? If so, why? -->

1. `npm run test` tests browser tool settings.
2. `Cline.ts` does not appear to have existing tests associated with it, so I relied on manually testing paths.
    * I manually tested this with a publicly available, basic static site.
    * I manually tested a private React site that needed the "remove style tags" setting enabled in order to succeed, due to inline styling.

Prompt:
```
use your browser tool to get the html content of https://example.com/ 

what is the content of the `@media` tag in the html content? return the full content.
```

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

#### Settings Page

<img width="1008" alt="Screenshot 2025-03-12 at 10 21 25 PM" src="https://github.com/user-attachments/assets/5d766d95-8013-4055-9f69-3834ac367435" />

#### Example HTML Source from Developer Tools and Cline Discovery of HTML Content

<img width="1224" alt="Screenshot 2025-03-12 at 6 20 23 PM" src="https://github.com/user-attachments/assets/1789449b-2e8b-4986-abea-3a9dea6bc75d" />

<img width="561" alt="Screenshot 2025-03-12 at 6 20 31 PM" src="https://github.com/user-attachments/assets/1c3b3b47-8aa3-4ab6-aa4a-2d3d5fea82a3" />


### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds optional HTML content return in browser action responses with configurable settings and UI updates.
> 
>   - **Behavior**:
>     - Adds optional HTML content return in browser action responses in `Cline.ts` and `BrowserSession.ts`.
>     - Controlled by new settings: `browserToolEnableHTMLContent`, `browserToolMaxHTMLContentLength`, and `browserToolStripHTMLContentStyleTags` in `package.json`.
>   - **Settings**:
>     - New settings added to `package.json` for enabling HTML content, setting max length, and stripping style tags.
>     - Settings are integrated into `Cline.ts` and `BrowserSession.ts` to control HTML content behavior.
>   - **UI**:
>     - Updates `BrowserSessionRow.tsx` to display HTML content in the UI.
>     - Adds toggle for HTML content visibility in the browser session view.
>   - **Tests**:
>     - Updates `extension.test.js` to test new settings for HTML content behavior.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 55362c7360db7f97d20aef3815e0a7c160b841fb. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->