### PR TITLE
eng-255/Add extension_version to all telemetry

### DIFF
--- a/.changeset/lazy-garlics-protect.md
+++ b/.changeset/lazy-garlics-protect.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Added extension version to all telemetry

--- a/src/services/telemetry/TelemetryService.ts
+++ b/src/services/telemetry/TelemetryService.ts
@@ -1,5 +1,6 @@
 import { PostHog } from "posthog-node"
 import * as vscode from "vscode"
+import { version as extensionVersion } from "../../../package.json"
 
 /**
  * PostHogClient handles telemetry event tracking for the Cline extension
@@ -65,6 +66,8 @@ class PostHogClient {
 	private distinctId: string = vscode.env.machineId
 	/** Whether telemetry is currently enabled based on user and VSCode settings */
 	private telemetryEnabled: boolean = false
+	/** Current version of the extension */
+	private readonly version: string = extensionVersion
 
 	/**
 	 * Private constructor to enforce singleton pattern
@@ -120,7 +123,12 @@ class PostHogClient {
 	public capture(event: { event: string; properties?: any }): void {
 		// Only send events if telemetry is enabled
 		if (this.telemetryEnabled) {
-			this.client.capture({ distinctId: this.distinctId, event: event.event, properties: event.properties })
+			// Include extension version in all event properties
+			const propertiesWithVersion = {
+				...event.properties,
+				extension_version: this.version,
+			}
+			this.client.capture({ distinctId: this.distinctId, event: event.event, properties: propertiesWithVersion })
 		}
 	}
 


### PR DESCRIPTION
### Description

This change adds the extension version to all telemetry. This is useful for tracking what versions are being used, but more importantly it will allow us to combine/merge events and properties that are renamed in different versions of the extension using **_actions_** in PostHog.

### Test Procedure

The extension was ran in debug mode, and I confirmed that telemetry received on the PostHog side included the new extension_version property.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [X] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [X] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [X] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [X] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [X] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `extension_version` to all telemetry events in `PostHogClient` to track extension usage across versions.
> 
>   - **Telemetry Enhancement**:
>     - Add `extension_version` to all telemetry events in `PostHogClient` in `TelemetryService.ts`.
>     - Uses `version` from `package.json` to populate `extension_version`.
>   - **Misc**:
>     - Add changeset `lazy-garlics-protect.md` to document the change.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 17a27844c34e29aae964965267b500bba3713971. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->