### PR TITLE
eng-245 / More checkpoints git telemetry

### DIFF
--- a/.changeset/curvy-seahorses-behave.md
+++ b/.changeset/curvy-seahorses-behave.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Updated checkpoints telemetry to including timings, and better capture a true git init

--- a/src/services/telemetry/TelemetryService.ts
+++ b/src/services/telemetry/TelemetryService.ts
@@ -250,13 +250,19 @@ class PostHogClient {
 	 * Records interactions with the git-based checkpoint system
 	 * @param taskId Unique identifier for the task
 	 * @param action The type of checkpoint action
+	 * @param durationMs Optional duration of the operation in milliseconds
 	 */
-	public captureCheckpointUsage(taskId: string, action: "shadow_git_initialized" | "commit_created" | "restored") {
+	public captureCheckpointUsage(
+		taskId: string,
+		action: "shadow_git_initialized" | "commit_created" | "restored" | "diff_generated",
+		durationMs?: number,
+	) {
 		this.capture({
 			event: PostHogClient.EVENTS.TASK.CHECKPOINT_USED,
 			properties: {
 				taskId,
 				action,
+				durationMs,
 			},
 		})
 	}


### PR DESCRIPTION
### Description

This PR adds durationMs to checkpoints telemetry, allowing Cline to track how long checkpoints operations take to complete.

### Test Procedure

Create a new task that uses checkpoints with telemetry opted in, and confirm telemetry with durationMs properties reaches the PostHog servers.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [X] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [X] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [X] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [X] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [X] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add duration tracking to checkpoints telemetry in Cline for better performance analysis.
> 
>   - **Telemetry Enhancements**:
>     - Add `durationMs` to telemetry events in `CheckpointGitOperations.ts` and `CheckpointTracker.ts` for operations like `initShadowGit`, `commit`, `resetHead`, `getDiffSet`, and `getDiffCount`.
>     - Update `captureCheckpointUsage` in `TelemetryService.ts` to include `durationMs` parameter.
>   - **Function Modifications**:
>     - Modify `initShadowGit` in `CheckpointGitOperations.ts` to accept `taskId` and log duration.
>     - Modify `commit`, `resetHead`, `getDiffSet`, and `getDiffCount` in `CheckpointTracker.ts` to log operation duration.
>   - **Miscellaneous**:
>     - Add changeset `curvy-seahorses-behave.md` to document the update.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 3c0efaa88fceb931f059593731b2d1b60a375713. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->