### PR TITLE
Fix bug where OpenRouter/Cline providers generation endpoint failed

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -9,7 +9,7 @@ import { OllamaHandler } from "./providers/ollama"
 import { LmStudioHandler } from "./providers/lmstudio"
 import { GeminiHandler } from "./providers/gemini"
 import { OpenAiNativeHandler } from "./providers/openai-native"
-import { ApiStream } from "./transform/stream"
+import { ApiStream, ApiStreamUsageChunk } from "./transform/stream"
 import { DeepSeekHandler } from "./providers/deepseek"
 import { RequestyHandler } from "./providers/requesty"
 import { TogetherHandler } from "./providers/together"
@@ -25,6 +25,7 @@ import { SambanovaHandler } from "./providers/sambanova"
 export interface ApiHandler {
 	createMessage(systemPrompt: string, messages: Anthropic.Messages.MessageParam[]): ApiStream
 	getModel(): { id: string; info: ModelInfo }
+	getApiStreamUsage?(): Promise<ApiStreamUsageChunk | undefined>
 }
 
 export interface SingleCompletionHandler {

--- a/src/api/providers/cline.ts
+++ b/src/api/providers/cline.ts
@@ -2,13 +2,15 @@ import { Anthropic } from "@anthropic-ai/sdk"
 import OpenAI from "openai"
 import { ApiHandler } from "../"
 import { ApiHandlerOptions, ModelInfo, openRouterDefaultModelId, openRouterDefaultModelInfo } from "../../shared/api"
-import { streamOpenRouterFormatRequest } from "../transform/openrouter-stream"
-import { ApiStream } from "../transform/stream"
+import { createOpenRouterStream } from "../transform/openrouter-stream"
+import { ApiStream, ApiStreamUsageChunk } from "../transform/stream"
 import axios from "axios"
+import { OpenRouterErrorResponse } from "./types"
 
 export class ClineHandler implements ApiHandler {
 	private options: ApiHandlerOptions
 	private client: OpenAI
+	lastGenerationId?: string
 
 	constructor(options: ApiHandlerOptions) {
 		this.options = options
@@ -19,36 +21,78 @@ export class ClineHandler implements ApiHandler {
 	}
 
 	async *createMessage(systemPrompt: string, messages: Anthropic.Messages.MessageParam[]): ApiStream {
-		const model = this.getModel()
-		const genId = yield* streamOpenRouterFormatRequest(
+		this.lastGenerationId = undefined
+
+		const stream = await createOpenRouterStream(
 			this.client,
 			systemPrompt,
 			messages,
-			model,
+			this.getModel(),
 			this.options.o3MiniReasoningEffort,
 			this.options.thinkingBudgetTokens,
 		)
 
-		try {
-			const response = await axios.get(`https://api.cline.bot/v1/generation?id=${genId}`, {
-				headers: {
-					Authorization: `Bearer ${this.options.clineApiKey}`,
-				},
-				timeout: 5_000, // this request hangs sometimes
-			})
-
-			const generation = response.data
-			console.log("cline generation details:", generation)
-			yield {
-				type: "usage",
-				inputTokens: generation?.native_tokens_prompt || 0,
-				outputTokens: generation?.native_tokens_completion || 0,
-				totalCost: generation?.total_cost || 0,
+		for await (const chunk of stream) {
+			// openrouter returns an error object instead of the openai sdk throwing an error
+			if ("error" in chunk) {
+				const error = chunk.error as OpenRouterErrorResponse["error"]
+				console.error(`Cline API Error: ${error?.code} - ${error?.message}`)
+				// Include metadata in the error message if available
+				const metadataStr = error.metadata ? `\nMetadata: ${JSON.stringify(error.metadata, null, 2)}` : ""
+				throw new Error(`Cline API Error ${error.code}: ${error.message}${metadataStr}`)
 			}
-		} catch (error) {
-			// ignore if fails
-			console.error("Error fetching cline generation details:", error)
+
+			if (!this.lastGenerationId && chunk.id) {
+				this.lastGenerationId = chunk.id
+			}
+
+			const delta = chunk.choices[0]?.delta
+			if (delta?.content) {
+				yield {
+					type: "text",
+					text: delta.content,
+				}
+			}
+
+			// Reasoning tokens are returned separately from the content
+			if ("reasoning" in delta && delta.reasoning) {
+				yield {
+					type: "reasoning",
+					// @ts-ignore-next-line
+					reasoning: delta.reasoning,
+				}
+			}
 		}
+
+		const apiStreamUsage = await this.getApiStreamUsage()
+		if (apiStreamUsage) {
+			yield apiStreamUsage
+		}
+	}
+
+	async getApiStreamUsage(): Promise<ApiStreamUsageChunk | undefined> {
+		if (this.lastGenerationId) {
+			try {
+				const response = await axios.get(`https://api.cline.bot/v1/generation?id=${this.lastGenerationId}`, {
+					headers: {
+						Authorization: `Bearer ${this.options.clineApiKey}`,
+					},
+					timeout: 10_000, // this request hangs sometimes
+				})
+
+				const generation = response.data
+				return {
+					type: "usage",
+					inputTokens: generation?.native_tokens_prompt || 0,
+					outputTokens: generation?.native_tokens_completion || 0,
+					totalCost: generation?.total_cost || 0,
+				}
+			} catch (error) {
+				// ignore if fails
+				console.error("Error fetching cline generation details:", error)
+			}
+		}
+		return undefined
 	}
 
 	getModel(): { id: string; info: ModelInfo } {

--- a/src/api/providers/cline.ts
+++ b/src/api/providers/cline.ts
@@ -77,7 +77,7 @@ export class ClineHandler implements ApiHandler {
 					headers: {
 						Authorization: `Bearer ${this.options.clineApiKey}`,
 					},
-					timeout: 10_000, // this request hangs sometimes
+					timeout: 15_000, // this request hangs sometimes
 				})
 
 				const generation = response.data

--- a/src/api/providers/openrouter.ts
+++ b/src/api/providers/openrouter.ts
@@ -2,17 +2,17 @@ import { Anthropic } from "@anthropic-ai/sdk"
 import axios from "axios"
 import delay from "delay"
 import OpenAI from "openai"
-import { withRetry } from "../retry"
 import { ApiHandler } from "../"
 import { ApiHandlerOptions, ModelInfo, openRouterDefaultModelId, openRouterDefaultModelInfo } from "../../shared/api"
-import { streamOpenRouterFormatRequest } from "../transform/openrouter-stream"
-import { ApiStream } from "../transform/stream"
-import { convertToR1Format } from "../transform/r1-format"
+import { withRetry } from "../retry"
+import { createOpenRouterStream } from "../transform/openrouter-stream"
+import { ApiStream, ApiStreamUsageChunk } from "../transform/stream"
 import { OpenRouterErrorResponse } from "./types"
 
 export class OpenRouterHandler implements ApiHandler {
 	private options: ApiHandlerOptions
 	private client: OpenAI
+	lastGenerationId?: string
 
 	constructor(options: ApiHandlerOptions) {
 		this.options = options
@@ -28,23 +28,63 @@ export class OpenRouterHandler implements ApiHandler {
 
 	@withRetry()
 	async *createMessage(systemPrompt: string, messages: Anthropic.Messages.MessageParam[]): ApiStream {
-		const model = this.getModel()
-		const genId = yield* streamOpenRouterFormatRequest(
+		this.lastGenerationId = undefined
+
+		const stream = await createOpenRouterStream(
 			this.client,
 			systemPrompt,
 			messages,
-			model,
+			this.getModel(),
 			this.options.o3MiniReasoningEffort,
 			this.options.thinkingBudgetTokens,
 		)
 
-		if (genId) {
+		for await (const chunk of stream) {
+			// openrouter returns an error object instead of the openai sdk throwing an error
+			if ("error" in chunk) {
+				const error = chunk.error as OpenRouterErrorResponse["error"]
+				console.error(`OpenRouter API Error: ${error?.code} - ${error?.message}`)
+				// Include metadata in the error message if available
+				const metadataStr = error.metadata ? `\nMetadata: ${JSON.stringify(error.metadata, null, 2)}` : ""
+				throw new Error(`OpenRouter API Error ${error.code}: ${error.message}${metadataStr}`)
+			}
+
+			if (!this.lastGenerationId && chunk.id) {
+				this.lastGenerationId = chunk.id
+			}
+
+			const delta = chunk.choices[0]?.delta
+			if (delta?.content) {
+				yield {
+					type: "text",
+					text: delta.content,
+				}
+			}
+
+			// Reasoning tokens are returned separately from the content
+			if ("reasoning" in delta && delta.reasoning) {
+				yield {
+					type: "reasoning",
+					// @ts-ignore-next-line
+					reasoning: delta.reasoning,
+				}
+			}
+		}
+
+		const apiStreamUsage = await this.getApiStreamUsage()
+		if (apiStreamUsage) {
+			yield apiStreamUsage
+		}
+	}
+
+	async getApiStreamUsage(): Promise<ApiStreamUsageChunk | undefined> {
+		if (this.lastGenerationId) {
 			await delay(500) // FIXME: necessary delay to ensure generation endpoint is ready
 			try {
-				const generationIterator = this.fetchGenerationDetails(genId)
+				const generationIterator = this.fetchGenerationDetails(this.lastGenerationId)
 				const generation = (await generationIterator.next()).value
 				// console.log("OpenRouter generation details:", generation)
-				yield {
+				return {
 					type: "usage",
 					// cacheWriteTokens: 0,
 					// cacheReadTokens: 0,
@@ -58,6 +98,7 @@ export class OpenRouterHandler implements ApiHandler {
 				console.error("Error fetching OpenRouter generation details:", error)
 			}
 		}
+		return undefined
 	}
 
 	@withRetry({ maxRetries: 4, baseDelay: 250, maxDelay: 1000, retryAllErrors: true })
@@ -68,7 +109,7 @@ export class OpenRouterHandler implements ApiHandler {
 				headers: {
 					Authorization: `Bearer ${this.options.openRouterApiKey}`,
 				},
-				timeout: 5_000, // this request hangs sometimes
+				timeout: 10_000, // this request hangs sometimes
 			})
 			yield response.data?.data
 		} catch (error) {

--- a/src/api/providers/openrouter.ts
+++ b/src/api/providers/openrouter.ts
@@ -109,7 +109,7 @@ export class OpenRouterHandler implements ApiHandler {
 				headers: {
 					Authorization: `Bearer ${this.options.openRouterApiKey}`,
 				},
-				timeout: 10_000, // this request hangs sometimes
+				timeout: 15_000, // this request hangs sometimes
 			})
 			yield response.data?.data
 		} catch (error) {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fixes OpenRouter/Cline providers' generation endpoint failure by refactoring streaming and error handling processes.
> 
>   - **Behavior**:
>     - Refactor `createMessage()` in `ClineHandler` and `OpenRouterHandler` to use `createOpenRouterStream()` for streaming.
>     - Handle error responses in `createMessage()` by checking for `error` in stream chunks and throwing detailed errors.
>     - Add `getApiStreamUsage()` to fetch usage data after streaming, updating the logic to handle cases where usage data is not part of the stream.
>   - **Functions**:
>     - Rename `streamOpenRouterFormatRequest()` to `createOpenRouterStream()` in `openrouter-stream.ts`.
>     - Remove generation ID return from `createOpenRouterStream()`; now returns the stream directly.
>   - **Misc**:
>     - Increase timeout for generation detail requests to 15 seconds in `ClineHandler` and `OpenRouterHandler`.
>     - Add `lastGenerationId` to track the last generation request ID for usage data retrieval.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 65a3e3cc54a292cde87bbc8fe2cc514431f7ee0e. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->