### PR TITLE
enable mentions on hidden folders

### DIFF
--- a/.changeset/sour-boats-nail.md
+++ b/.changeset/sour-boats-nail.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Enable mentions on hidden directories

--- a/src/services/glob/list-files.ts
+++ b/src/services/glob/list-files.ts
@@ -33,7 +33,7 @@ export async function listFiles(dirPath: string, recursive: boolean, limit: numb
 		"deps",
 		"pkg",
 		"Pods",
-		".*", // '!**/.*' excludes hidden directories, while '!**/.*/**' excludes only their contents. This way we are at least aware of the existence of hidden directories.
+		// '!**/.*' excludes hidden directories, while '!**/.*/**' excludes only their contents. This way we are at least aware of the existence of hidden directories.
 	].map((dir) => `**/${dir}/**`)
 
 	const options: Options = {


### PR DESCRIPTION
### Description

enable mentions on hidden folders

### Test Procedure

"@" a hidden folder the in the webview

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<img width="427" alt="Screenshot 2025-03-15 at 4 42 35 PM" src="https://github.com/user-attachments/assets/26884b51-1070-4d19-acc4-5313fae43606" />

### Additional Notes

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Enables mentions on hidden directories by updating comment in `listFiles` in `list-files.ts`.
> 
>   - **Behavior**:
>     - Enables mentions on hidden directories by updating comment in `listFiles` in `list-files.ts`.
>   - **Code**:
>     - Removes exclusion of hidden directories in `listFiles` by commenting out the exclusion pattern.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for e8cfc0e024c7cfedff7356043992668953150b35. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->