### PR TITLE
Added the feature to configure multiple models in OpenAI Compatible

### DIFF
--- a/.changeset/shaggy-llamas-brush.md
+++ b/.changeset/shaggy-llamas-brush.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": minor
+---
+
+Added the feature to configure multiple models in OpenAI Compatible

--- a/src/api/providers/openai.ts
+++ b/src/api/providers/openai.ts
@@ -13,6 +13,15 @@ export class OpenAiHandler implements ApiHandler {
 	private client: OpenAI
 
 	constructor(options: ApiHandlerOptions) {
+		if (options.openAiConfigs && options.openAiConfigs.length > 0) {
+			const index = options.openAiSelectedConfigIndex ?? 0
+			const config = options.openAiConfigs[index]
+			options.openAiBaseUrl = config.openAiBaseUrl
+			options.openAiApiKey = config.openAiApiKey
+			options.openAiModelId = config.openAiModelId
+			options.openAiModelInfo = config.openAiModelInfo
+			options.azureApiVersion = config.azureApiVersion
+		}
 		this.options = options
 		// Azure API shape slightly differs from the core API shape: https://github.com/openai/openai-node?tab=readme-ov-file#microsoft-azure-openai
 		if (this.options.openAiBaseUrl?.toLowerCase().includes("azure.com")) {

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -69,6 +69,15 @@ export interface ApiHandlerOptions {
 	xaiApiKey?: string
 	thinkingBudgetTokens?: number
 	sambanovaApiKey?: string
+	openAiConfigs?: {
+		profileName: string
+		openAiBaseUrl: string
+		openAiApiKey: string
+		openAiModelId: string
+		openAiModelInfo: OpenAiCompatibleModelInfo
+		azureApiVersion: string
+	}[]
+	openAiSelectedConfigIndex?: number
 }
 
 export type ApiConfiguration = ApiHandlerOptions & {
@@ -412,6 +421,16 @@ export const openAiModelInfoSaneDefaults: OpenAiCompatibleModelInfo = {
 	inputPrice: 0,
 	outputPrice: 0,
 	temperature: 0,
+}
+
+// OpenAI
+export const openAiCompatibleDefaultConfig = {
+	profileName: "Default",
+	openAiBaseUrl: "",
+	openAiApiKey: "",
+	openAiModelId: "",
+	openAiModelInfo: openAiModelInfoSaneDefaults,
+	azureApiVersion: "",
 }
 
 // Gemini


### PR DESCRIPTION
### Description

This PR adds support for managing multiple profiles in the OpenAI Compatible provider.
Users can create, switch, and delete profiles, each with its own settings for Base URL,API Key, Model ID, Azure API Version, and model parameters.

### Test Procedure

- Verified that input fields (base URL, API key, model ID, Azure API version, etc.) accurately display the values of the selected profile.
- Confirmed that profile configurations are maintained correctly in both act and plan modes.
- Ensured that the dropdown, add, and delete buttons in the UI function as expected.

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

![profile](https://github.com/user-attachments/assets/627b12d7-6b2e-4180-972d-af4854940aa1)

![switching_profile](https://github.com/user-attachments/assets/d8642794-af5f-4beb-8fa3-5cccb1e4907a)

#### Add
![add](https://github.com/user-attachments/assets/793e96b2-7227-424c-aac9-9e03cf5e1b68)

#### Remove
![remove](https://github.com/user-attachments/assets/e1397ad3-2b79-46ae-8dd2-d41f6eb9ab50)

#### Switch Plan/Act
![switching_plan_act](https://github.com/user-attachments/assets/3c0556db-c1f8-4d6b-913e-1cbae34e50a7)


