### PR TITLE
Auto-run command after cline save a file, and send the context back to cline. 

### DIFF
--- a/.changeset/silly-beds-applaud.md
+++ b/.changeset/silly-beds-applaud.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": minor
+---
+
+Auto-run terminal command feature, after cline has saved a file. This is ideal for test-driven development, where you first make the tests, and then make the code. The ai then gets fast response if the test passes or not.

--- a/src/core/Cline.ts
+++ b/src/core/Cline.ts
@@ -1900,10 +1900,10 @@ export class Cline {
 
 								const { newProblemsMessage, userEdits, autoFormattingEdits, finalContent, autoRunOutput } =
 									await this.diffViewProvider.saveChanges(this.providerRef.deref())
-								
+
 								// If auto-run output is available, send it to the AI
 								if (autoRunOutput) {
-									await this.say("auto_run_output", autoRunOutput);
+									await this.say("auto_run_output", autoRunOutput)
 								}
 								this.didEditFile = true // used to determine if we should wait for busy terminal to update before sending api request
 								if (userEdits) {
@@ -3443,8 +3443,8 @@ export class Cline {
 
 	async loadContext(userContent: UserContent, includeFileDetails: boolean = false) {
 		// Check for auto-run output in the clineMessages
-		const autoRunOutput = findLast(this.clineMessages, (m) => m.say === "auto_run_output")?.text;
-		
+		const autoRunOutput = findLast(this.clineMessages, (m) => m.say === "auto_run_output")?.text
+
 		return await Promise.all([
 			// This is a temporary solution to dynamically load context mentions from tool results. It checks for the presence of tags that indicate that the tool was rejected and feedback was provided (see formatToolDeniedFeedback, attemptCompletion, executeCommand, and consecutiveMistakeCount >= 3) or "<answer>" (see askFollowupQuestion), we place all user generated content in these tags so they can effectively be used as markers for when we should parse mentions). However if we allow multiple tools responses in the future, we will need to parse mentions specifically within the user content tags.
 			// (Note: this caused the @/ import alias bug where file contents were being parsed as well, since v2 converted tool results to text blocks)
@@ -3642,7 +3642,7 @@ export class Cline {
 		// This is what is being sent to cline
 		// autoRunOutput = `# Auto-Run Command\nThe following command was automatically executed after your last file edit:\n$ ${autoRunResult.command}\n\nOutput:\n${autoRunResult.output}`;
 		if (autoRunOutput) {
-			details += autoRunOutput;
+			details += autoRunOutput
 		}
 
 		return `<environment_details>\n${details.trim()}\n</environment_details>`

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -157,7 +157,7 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 		cleanupLegacyCheckpoints(this.context.globalStorageUri.fsPath, this.outputChannel).catch((error) => {
 			console.error("Failed to cleanup legacy checkpoints:", error)
 		})
-		
+
 		// Setup auto-run file watcher
 		this.setupAutoRunWatcher()
 	}

--- a/src/integrations/editor/DiffViewProvider.ts
+++ b/src/integrations/editor/DiffViewProvider.ts
@@ -134,61 +134,61 @@ export class DiffViewProvider {
 		}
 	}
 
-	async runAutoRunCommand(clineProvider: any): Promise<{ command: string, output: string } | undefined> {
+	async runAutoRunCommand(clineProvider: any): Promise<{ command: string; output: string } | undefined> {
 		if (!clineProvider) {
-			return undefined;
+			return undefined
 		}
 
 		try {
 			// Get auto-run settings
-			const { autoRunSettings } = await clineProvider.getState();
-			
+			const { autoRunSettings } = await clineProvider.getState()
+
 			// If auto-run is enabled and a command is specified, run it
 			if (autoRunSettings.enabled && autoRunSettings.command) {
 				// Mark that we're running the auto-run command
-				clineProvider.isAutoRunning = true;
-				
+				clineProvider.isAutoRunning = true
+
 				// Use the terminal manager to run the command and capture output
-				const terminalManager = clineProvider.cline?.terminalManager;
+				const terminalManager = clineProvider.cline?.terminalManager
 				if (!terminalManager) {
-					return undefined;
+					return undefined
 				}
-				
+
 				// Create a terminal
-				const terminalInfo = await terminalManager.getOrCreateTerminal(this.cwd);
-				terminalInfo.terminal.show();
-				
+				const terminalInfo = await terminalManager.getOrCreateTerminal(this.cwd)
+				terminalInfo.terminal.show()
+
 				// Run the command and capture output
-				const process = terminalManager.runCommand(terminalInfo, autoRunSettings.command);
-				
+				const process = terminalManager.runCommand(terminalInfo, autoRunSettings.command)
+
 				// Collect output
-				let result = "";
+				let result = ""
 				process.on("line", (line: string) => {
-					result += line + "\n";
-				});
-				
+					result += line + "\n"
+				})
+
 				// Wait for the command to complete
-				let completed = false;
+				let completed = false
 				process.once("completed", () => {
-					completed = true;
-				});
-				
-				await process;
-				
+					completed = true
+				})
+
+				await process
+
 				// Mark that we're done running the auto-run command
-				clineProvider.isAutoRunning = false;
-				
+				clineProvider.isAutoRunning = false
+
 				return {
 					command: autoRunSettings.command,
-					output: result.trim()
-				};
+					output: result.trim(),
+				}
 			}
 		} catch (error) {
-			console.error('Error running auto-run command:', error);
-			clineProvider.isAutoRunning = false;
+			console.error("Error running auto-run command:", error)
+			clineProvider.isAutoRunning = false
 		}
-		
-		return undefined;
+
+		return undefined
 	}
 
 	async saveChanges(clineProvider?: any): Promise<{
@@ -281,11 +281,11 @@ export class DiffViewProvider {
 		}
 
 		// Run auto-run command if enabled
-		let autoRunOutput: string | undefined;
+		let autoRunOutput: string | undefined
 		if (clineProvider) {
-			const autoRunResult = await this.runAutoRunCommand(clineProvider);
+			const autoRunResult = await this.runAutoRunCommand(clineProvider)
 			if (autoRunResult) {
-				autoRunOutput = `# Auto-Run Command\nThe following command was automatically executed after your last file edit:\n$ ${autoRunResult.command}\n\nOutput:\n${autoRunResult.output}`;
+				autoRunOutput = `# Auto-Run Command\nThe following command was automatically executed after your last file edit:\n$ ${autoRunResult.command}\n\nOutput:\n${autoRunResult.output}`
 			}
 		}
 

--- a/src/shared/AutoRunSettings.ts
+++ b/src/shared/AutoRunSettings.ts
@@ -1,9 +1,9 @@
 export interface AutoRunSettings {
-	enabled: boolean;
-	command: string;
+	enabled: boolean
+	command: string
 }
 
 export const DEFAULT_AUTO_RUN_SETTINGS: AutoRunSettings = {
 	enabled: false,
-	command: '',
-};
+	command: "",
+}

--- a/src/shared/AutoRunSettings.ts
+++ b/src/shared/AutoRunSettings.ts
@@ -1,0 +1,9 @@
+export interface AutoRunSettings {
+	enabled: boolean;
+	command: string;
+}
+
+export const DEFAULT_AUTO_RUN_SETTINGS: AutoRunSettings = {
+	enabled: false,
+	command: '',
+};

--- a/src/shared/ExtensionMessage.ts
+++ b/src/shared/ExtensionMessage.ts
@@ -3,11 +3,14 @@
 import { GitCommit } from "../utils/git"
 import { ApiConfiguration, ModelInfo } from "./api"
 import { AutoApprovalSettings } from "./AutoApprovalSettings"
+import { AutoRunSettings } from "./AutoRunSettings"
 import { BrowserSettings } from "./BrowserSettings"
+import { ChatContent } from "./ChatContent"
 import { ChatSettings } from "./ChatSettings"
 import { HistoryItem } from "./HistoryItem"
 import { McpServer, McpMarketplaceCatalog, McpMarketplaceItem, McpDownloadResponse } from "./mcp"
 import { TelemetrySetting } from "./TelemetrySetting"
+import { UserInfo } from "./UserInfo"
 
 // webview will hold state
 export interface ExtensionMessage {
@@ -88,6 +91,7 @@ export interface ExtensionState {
 	taskHistory: HistoryItem[]
 	shouldShowAnnouncement: boolean
 	autoApprovalSettings: AutoApprovalSettings
+	autoRunSettings: AutoRunSettings
 	browserSettings: BrowserSettings
 	chatSettings: ChatSettings
 	platform: Platform
@@ -157,6 +161,7 @@ export type ClineSay =
 	| "deleted_api_reqs"
 	| "clineignore_error"
 	| "checkpoint_created"
+	| "auto_run_output"
 
 export interface ClineSayTool {
 	tool:
@@ -225,3 +230,7 @@ export interface ClineApiReqInfo {
 export type ClineApiReqCancelReason = "streaming_failed" | "user_cancelled"
 
 export const COMPLETION_RESULT_CHANGES_FLAG = "HAS_CHANGES"
+
+export type ClineAskResponse = "yesButtonClicked" | "noButtonClicked" | "messageResponse"
+
+export type ClineCheckpointRestore = "task" | "workspace" | "taskAndWorkspace"

--- a/src/shared/WebviewMessage.ts
+++ b/src/shared/WebviewMessage.ts
@@ -1,5 +1,6 @@
 import { ApiConfiguration } from "./api"
 import { AutoApprovalSettings } from "./AutoApprovalSettings"
+import { AutoRunSettings } from "./AutoRunSettings"
 import { BrowserSettings } from "./BrowserSettings"
 import { ChatSettings } from "./ChatSettings"
 import { UserInfo } from "./UserInfo"
@@ -33,6 +34,7 @@ export interface WebviewMessage {
 		| "restartMcpServer"
 		| "deleteMcpServer"
 		| "autoApprovalSettings"
+		| "autoRunSettings"
 		| "browserSettings"
 		| "togglePlanActMode"
 		| "checkpointDiff"
@@ -71,6 +73,7 @@ export interface WebviewMessage {
 	bool?: boolean
 	number?: number
 	autoApprovalSettings?: AutoApprovalSettings
+	autoRunSettings?: AutoRunSettings
 	browserSettings?: BrowserSettings
 	chatSettings?: ChatSettings
 	chatContent?: ChatContent

--- a/webview-ui/src/components/chat/AutoRunMenu.tsx
+++ b/webview-ui/src/components/chat/AutoRunMenu.tsx
@@ -88,7 +88,7 @@ const AutoRunMenu = ({ style }: AutoRunMenuProps) => {
 							overflow: "hidden",
 							textOverflow: "ellipsis",
 						}}>
-						{autoRunSettings.enabled ? (autoRunSettings.command || "No command") : "Disabled"}
+						{autoRunSettings.enabled ? autoRunSettings.command || "No command" : "Disabled"}
 					</span>
 					<span
 						className={`codicon codicon-chevron-${isExpanded ? "down" : "right"}`}
@@ -107,7 +107,9 @@ const AutoRunMenu = ({ style }: AutoRunMenuProps) => {
 							color: getAsVar(VSC_DESCRIPTION_FOREGROUND),
 							fontSize: "12px",
 						}}>
-						Auto-run automatically executes your specified command whenever Cline saves a file. The output is sent directly to Cline for context, making it ideal for running tests, linters, or other processes that should trigger on save.
+						Auto-run automatically executes your specified command whenever Cline saves a file. The output is sent
+						directly to Cline for context, making it ideal for running tests, linters, or other processes that should
+						trigger on save.
 					</div>
 					<div
 						style={{

--- a/webview-ui/src/components/chat/AutoRunMenu.tsx
+++ b/webview-ui/src/components/chat/AutoRunMenu.tsx
@@ -1,0 +1,152 @@
+import { VSCodeCheckbox, VSCodeTextField } from "@vscode/webview-ui-toolkit/react"
+import { useCallback, useState } from "react"
+import styled from "styled-components"
+import { useExtensionState } from "../../context/ExtensionStateContext"
+import { AutoRunSettings } from "../../../../src/shared/AutoRunSettings"
+import { vscode } from "../../utils/vscode"
+import { getAsVar, VSC_FOREGROUND, VSC_TITLEBAR_INACTIVE_FOREGROUND, VSC_DESCRIPTION_FOREGROUND } from "../../utils/vscStyles"
+
+interface AutoRunMenuProps {
+	style?: React.CSSProperties
+}
+
+const AutoRunMenu = ({ style }: AutoRunMenuProps) => {
+	const { autoRunSettings } = useExtensionState()
+	const [isExpanded, setIsExpanded] = useState(false)
+	const [isHoveringCollapsibleSection, setIsHoveringCollapsibleSection] = useState(false)
+
+	const updateEnabled = useCallback(
+		(enabled: boolean) => {
+			vscode.postMessage({
+				type: "autoRunSettings",
+				autoRunSettings: {
+					...autoRunSettings,
+					enabled,
+				},
+			})
+		},
+		[autoRunSettings],
+	)
+
+	const updateCommand = useCallback(
+		(command: string) => {
+			vscode.postMessage({
+				type: "autoRunSettings",
+				autoRunSettings: {
+					...autoRunSettings,
+					command,
+				},
+			})
+		},
+		[autoRunSettings],
+	)
+
+	return (
+		<div
+			style={{
+				padding: "0 15px",
+				userSelect: "none",
+				borderTop: `0.5px solid color-mix(in srgb, ${getAsVar(VSC_TITLEBAR_INACTIVE_FOREGROUND)} 20%, transparent)`,
+				overflowY: "auto",
+				...style,
+			}}>
+			<div
+				style={{
+					display: "flex",
+					alignItems: "center",
+					gap: "8px",
+					padding: isExpanded ? "8px 0" : "8px 0 0 0",
+					cursor: "pointer",
+				}}
+				onMouseEnter={() => {
+					setIsHoveringCollapsibleSection(true)
+				}}
+				onMouseLeave={() => {
+					setIsHoveringCollapsibleSection(false)
+				}}
+				onClick={() => {
+					setIsExpanded((prev) => !prev)
+				}}>
+				<VSCodeCheckbox
+					checked={autoRunSettings.enabled}
+					onClick={(e) => {
+						e.stopPropagation() // stops click from bubbling up to the parent
+						updateEnabled(!autoRunSettings.enabled)
+					}}
+				/>
+				<CollapsibleSection isHovered={isHoveringCollapsibleSection} style={{ cursor: "pointer" }}>
+					<span
+						style={{
+							color: getAsVar(VSC_FOREGROUND),
+							whiteSpace: "nowrap",
+						}}>
+						Auto-run:
+					</span>
+					<span
+						style={{
+							whiteSpace: "nowrap",
+							overflow: "hidden",
+							textOverflow: "ellipsis",
+						}}>
+						{autoRunSettings.enabled ? (autoRunSettings.command || "No command") : "Disabled"}
+					</span>
+					<span
+						className={`codicon codicon-chevron-${isExpanded ? "down" : "right"}`}
+						style={{
+							flexShrink: 0,
+							marginLeft: isExpanded ? "2px" : "-2px",
+						}}
+					/>
+				</CollapsibleSection>
+			</div>
+			{isExpanded && (
+				<div style={{ padding: "0" }}>
+					<div
+						style={{
+							marginBottom: "10px",
+							color: getAsVar(VSC_DESCRIPTION_FOREGROUND),
+							fontSize: "12px",
+						}}>
+						Auto-run automatically executes your specified command whenever Cline saves a file. The output is sent directly to Cline for context, making it ideal for running tests, linters, or other processes that should trigger on save.
+					</div>
+					<div
+						style={{
+							display: "flex",
+							alignItems: "center",
+							gap: "8px",
+							marginTop: "10px",
+							marginBottom: "8px",
+							color: getAsVar(VSC_FOREGROUND),
+						}}>
+						<span style={{ flexShrink: 1, minWidth: 0 }}>Command:</span>
+						<VSCodeTextField
+							placeholder="Enter command to run after file save"
+							value={autoRunSettings.command}
+							onInput={(e) => {
+								const input = e.target as HTMLInputElement
+								updateCommand(input.value)
+							}}
+							style={{ flex: 1 }}
+							disabled={!autoRunSettings.enabled}
+						/>
+					</div>
+				</div>
+			)}
+		</div>
+	)
+}
+
+const CollapsibleSection = styled.div<{ isHovered?: boolean }>`
+	display: flex;
+	align-items: center;
+	gap: 4px;
+	color: ${(props) => (props.isHovered ? getAsVar(VSC_FOREGROUND) : getAsVar(VSC_DESCRIPTION_FOREGROUND))};
+	flex: 1;
+	min-width: 0;
+
+	&:hover {
+		color: ${getAsVar(VSC_FOREGROUND)};
+	}
+`
+
+export default AutoRunMenu

--- a/webview-ui/src/components/chat/ChatRow.tsx
+++ b/webview-ui/src/components/chat/ChatRow.tsx
@@ -911,6 +911,21 @@ export const ChatRowContent = ({ message, isExpanded, onToggleExpand, lastModifi
 							/>
 						</div>
 					)
+				case "auto_run_output":
+					return (
+						<div
+							style={{
+								marginTop: -10,
+								width: "100%",
+							}}>
+							<CodeAccordian
+								code={message.text}
+								isAutoRunOutput={true}
+								isExpanded={isExpanded}
+								onToggleExpand={onToggleExpand}
+							/>
+						</div>
+					)
 				case "error":
 					return (
 						<>

--- a/webview-ui/src/components/chat/ChatView.tsx
+++ b/webview-ui/src/components/chat/ChatView.tsx
@@ -22,6 +22,7 @@ import HistoryPreview from "../history/HistoryPreview"
 import { normalizeApiConfiguration } from "../settings/ApiOptions"
 import Announcement from "./Announcement"
 import AutoApproveMenu from "./AutoApproveMenu"
+import AutoRunMenu from "./AutoRunMenu"
 import BrowserSessionRow from "./BrowserSessionRow"
 import ChatRow from "./ChatRow"
 import ChatTextArea from "./ChatTextArea"
@@ -827,13 +828,16 @@ const ChatView = ({ isHidden, showAnnouncement, hideAnnouncement, showHistoryVie
 			//    but becomes scrollable when the viewport is too small
 			*/}
 			{!task && (
-				<AutoApproveMenu
-					style={{
-						marginBottom: -2,
-						flex: "0 1 auto", // flex-grow: 0, flex-shrink: 1, flex-basis: auto
-						minHeight: 0,
-					}}
-				/>
+				<>
+					<AutoRunMenu />
+					<AutoApproveMenu
+						style={{
+							marginBottom: -2,
+							flex: "0 1 auto", // flex-grow: 0, flex-shrink: 1, flex-basis: auto
+							minHeight: 0,
+						}}
+					/>
+				</>
 			)}
 
 			{task && (
@@ -868,6 +872,7 @@ const ChatView = ({ isHidden, showAnnouncement, hideAnnouncement, showHistoryVie
 							initialTopMostItemIndex={groupedMessages.length - 1}
 						/>
 					</div>
+					<AutoRunMenu />
 					<AutoApproveMenu />
 					{showScrollToBottom ? (
 						<div

--- a/webview-ui/src/components/common/CodeAccordian.tsx
+++ b/webview-ui/src/components/common/CodeAccordian.tsx
@@ -9,6 +9,7 @@ interface CodeAccordianProps {
 	path?: string
 	isFeedback?: boolean
 	isConsoleLogs?: boolean
+	isAutoRunOutput?: boolean
 	isExpanded: boolean
 	onToggleExpand: () => void
 	isLoading?: boolean
@@ -29,6 +30,7 @@ const CodeAccordian = ({
 	path,
 	isFeedback,
 	isConsoleLogs,
+	isAutoRunOutput,
 	isExpanded,
 	onToggleExpand,
 	isLoading,
@@ -46,7 +48,7 @@ const CodeAccordian = ({
 				overflow: "hidden", // This ensures the inner scrollable area doesn't overflow the rounded corners
 				border: "1px solid var(--vscode-editorGroup-border)",
 			}}>
-			{(path || isFeedback || isConsoleLogs) && (
+			{(path || isFeedback || isConsoleLogs || isAutoRunOutput) && (
 				<div
 					style={{
 						color: "var(--vscode-descriptionForeground)",
@@ -62,10 +64,10 @@ const CodeAccordian = ({
 						msUserSelect: "none",
 					}}
 					onClick={isLoading ? undefined : onToggleExpand}>
-					{isFeedback || isConsoleLogs ? (
+					{isFeedback || isConsoleLogs || isAutoRunOutput ? (
 						<div style={{ display: "flex", alignItems: "center" }}>
 							<span
-								className={`codicon codicon-${isFeedback ? "feedback" : "output"}`}
+								className={`codicon codicon-${isFeedback ? "feedback" : isAutoRunOutput ? "run" : "output"}`}
 								style={{ marginRight: "6px" }}></span>
 							<span
 								style={{
@@ -74,7 +76,7 @@ const CodeAccordian = ({
 									textOverflow: "ellipsis",
 									marginRight: "8px",
 								}}>
-								{isFeedback ? "User Edits" : "Console Logs"}
+								{isFeedback ? "User Edits" : isAutoRunOutput ? "Auto-Run Output" : "Console Logs"}
 							</span>
 						</div>
 					) : (
@@ -98,7 +100,7 @@ const CodeAccordian = ({
 					<span className={`codicon codicon-chevron-${isExpanded ? "up" : "down"}`}></span>
 				</div>
 			)}
-			{(!(path || isFeedback || isConsoleLogs) || isExpanded) && (
+			{(!(path || isFeedback || isConsoleLogs || isAutoRunOutput) || isExpanded) && (
 				<div
 					//className="code-block-scrollable" this doesn't seem to be necessary anymore, on silicon macs it shows the native mac scrollbar instead of the vscode styled one
 					style={{

--- a/webview-ui/src/context/ExtensionStateContext.tsx
+++ b/webview-ui/src/context/ExtensionStateContext.tsx
@@ -1,6 +1,7 @@
 import React, { createContext, useCallback, useContext, useEffect, useState } from "react"
 import { useEvent } from "react-use"
 import { DEFAULT_AUTO_APPROVAL_SETTINGS } from "../../../src/shared/AutoApprovalSettings"
+import { DEFAULT_AUTO_RUN_SETTINGS } from "../../../src/shared/AutoRunSettings"
 import { ExtensionMessage, ExtensionState, DEFAULT_PLATFORM } from "../../../src/shared/ExtensionMessage"
 import { ApiConfiguration, ModelInfo, openRouterDefaultModelId, openRouterDefaultModelInfo } from "../../../src/shared/api"
 import { findLastIndex } from "../../../src/shared/array"
@@ -25,6 +26,7 @@ interface ExtensionStateContextType extends ExtensionState {
 	setTelemetrySetting: (value: TelemetrySetting) => void
 	setShowAnnouncement: (value: boolean) => void
 	setPlanActSeparateModelsSetting: (value: boolean) => void
+	setAutoRunSettings: (value: typeof DEFAULT_AUTO_RUN_SETTINGS) => void
 }
 
 const ExtensionStateContext = createContext<ExtensionStateContextType | undefined>(undefined)
@@ -38,6 +40,7 @@ export const ExtensionStateContextProvider: React.FC<{
 		taskHistory: [],
 		shouldShowAnnouncement: false,
 		autoApprovalSettings: DEFAULT_AUTO_APPROVAL_SETTINGS,
+		autoRunSettings: DEFAULT_AUTO_RUN_SETTINGS,
 		browserSettings: DEFAULT_BROWSER_SETTINGS,
 		chatSettings: DEFAULT_CHAT_SETTINGS,
 		platform: DEFAULT_PLATFORM,
@@ -180,6 +183,11 @@ export const ExtensionStateContextProvider: React.FC<{
 			setState((prevState) => ({
 				...prevState,
 				shouldShowAnnouncement: value,
+			})),
+		setAutoRunSettings: (value) =>
+			setState((prevState) => ({
+				...prevState,
+				autoRunSettings: value,
 			})),
 	}
 


### PR DESCRIPTION
### Description

This PR adds a new Auto-Run feature to Cline, enhancing the development workflow by automatically executing commands when files are saved. The feature allows users to configure commands that run in the terminal after file saves, with the output displayed in a dedicated CodeAccordian component in the chat view.

This is great for test driven development, where cline gets response right away from the work it is doing during fixing tests/code. 

Key components of this implementation:

Added a new input field in the chat view UI just above the Auto-Approve row
Created file watcher functionality to detect when files are saved
Implemented command execution in the terminal with output capture
Added a new CodeAccordian component to display auto-run command output
Ensured the auto-run output is sent to the AI as context for better assistance
This feature is particularly useful for automatically running tests, linters, or build scripts after making changes, providing immediate feedback and saving developers time by eliminating manual command execution.


### Test Procedure

The feature was tested by:

Enabling auto-run and setting various commands
Saving files to trigger the auto-run functionality
Verifying command execution in the terminal
Confirming output appears in the CodeAccordian component
Checking that the AI receives the auto-run output as context
Tests were conducted across different file types and with various commands to ensure reliability and proper error handling.

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<img width="359" alt="Screenshot 2025-03-17 at 12 19 22" src="https://github.com/user-attachments/assets/9fe1d51e-876d-4aed-89bb-8c1e9f6324da" />
<img width="359" alt="Screenshot 2025-03-17 at 12 22 57" src="https://github.com/user-attachments/assets/a1c7a40b-6fd4-462a-96dd-64d78fab8446" />
<img width="357" alt="Screenshot 2025-03-17 at 12 21 34" src="https://github.com/user-attachments/assets/c6677c20-810e-476a-935d-c3de5ad526e5" />
<img width="351" alt="Screenshot 2025-03-17 at 12 22 05" src="https://github.com/user-attachments/assets/494274bc-2943-49ed-873e-7fa41b4f9c89" />


### Additional Notes

This feature lays the groundwork for future enhancements such as:

Predefined command templates (e.g., "Run Tests", "Lint Code")
File pattern matching to run specific commands for specific file types
Command history and favorites for quick selection
The implementation ensures that commands complete execution before sending output to the AI, preventing partial or incomplete information from being used as context.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds an auto-run feature to execute terminal commands on file save, with output displayed in the chat view and sent to AI for context.
> 
>   - **Behavior**:
>     - Adds auto-run feature to execute terminal commands on file save, displaying output in `CodeAccordian` in chat view.
>     - Sends auto-run output to AI for context.
>   - **UI Components**:
>     - Adds `AutoRunMenu` in `ChatView.tsx` for configuring auto-run settings.
>     - Displays auto-run output in `ChatRow.tsx` using `CodeAccordian`.
>   - **State Management**:
>     - Introduces `AutoRunSettings` in `ExtensionStateContext.tsx` and `ExtensionMessage.ts`.
>     - Updates state handling in `ClineProvider.ts` and `WebviewMessage.ts` for auto-run settings.
>   - **Command Execution**:
>     - Implements `runAutoRunCommand()` in `DiffViewProvider.ts` to execute commands and capture output.
>     - Integrates command execution in `saveChanges()` in `DiffViewProvider.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 1947c3acf822872e059fc2311a3cee4b2567c806. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->