### PR TITLE
fix:  partial support virtual workspaces (e.g., GitHub Remote)

### DIFF
--- a/src/integrations/misc/process-images.ts
+++ b/src/integrations/misc/process-images.ts
@@ -20,7 +20,7 @@ export async function selectImages(): Promise<string[]> {
 	return await Promise.all(
 		fileUris.map(async (uri) => {
 			const imagePath = uri.fsPath
-			const buffer = await fs.readFile(imagePath)
+			const buffer = Buffer.from(await vscode.workspace.fs.readFile(uri))
 			const base64 = buffer.toString("base64")
 			const mimeType = getMimeType(imagePath)
 			const dataUrl = `data:${mimeType};base64,${base64}`

--- a/src/utils/fs.ts
+++ b/src/utils/fs.ts
@@ -1,5 +1,6 @@
-import fs from "fs/promises"
 import * as path from "path"
+import * as vscode from "vscode"
+import { isBinaryFile as isBinaryFileImpl } from "isbinaryfile"
 
 /**
  * Asynchronously creates all non-existing subdirectories for a given file path
@@ -8,24 +9,25 @@ import * as path from "path"
  * @param filePath - The full path to a file.
  * @returns A promise that resolves to an array of newly created directories.
  */
-export async function createDirectoriesForFile(filePath: string): Promise<string[]> {
+export async function createDirectoriesForFile(filePath: string | vscode.Uri): Promise<string[]> {
+	let uri = filePath instanceof vscode.Uri ? filePath : vscode.Uri.parse(filePath)
 	const newDirectories: string[] = []
-	const normalizedFilePath = path.normalize(filePath) // Normalize path for cross-platform compatibility
+	const normalizedFilePath = path.normalize(uri.fsPath) // Normalize path for cross-platform compatibility
 	const directoryPath = path.dirname(normalizedFilePath)
 
-	let currentPath = directoryPath
-	const dirsToCreate: string[] = []
+	let currentPath = uri.with({ path: directoryPath })
+	const dirsToCreate: vscode.Uri[] = []
 
 	// Traverse up the directory tree and collect missing directories
 	while (!(await fileExistsAtPath(currentPath))) {
 		dirsToCreate.push(currentPath)
-		currentPath = path.dirname(currentPath)
+		currentPath = uri.with({ path: path.dirname(currentPath.fsPath) })
 	}
 
 	// Create directories from the topmost missing one down to the target directory
 	for (let i = dirsToCreate.length - 1; i >= 0; i--) {
-		await fs.mkdir(dirsToCreate[i])
-		newDirectories.push(dirsToCreate[i])
+		await vscode.workspace.fs.createDirectory(dirsToCreate[i])
+		newDirectories.push(dirsToCreate[i].fsPath)
 	}
 
 	return newDirectories
@@ -37,9 +39,10 @@ export async function createDirectoriesForFile(filePath: string): Promise<string
  * @param path - The path to check.
  * @returns A promise that resolves to true if the path exists, false otherwise.
  */
-export async function fileExistsAtPath(filePath: string): Promise<boolean> {
+export async function fileExistsAtPath(filePath: string | vscode.Uri): Promise<boolean> {
 	try {
-		await fs.access(filePath)
+		filePath = filePath instanceof vscode.Uri ? filePath : vscode.Uri.parse(filePath)
+		await vscode.workspace.fs.stat(filePath)
 		return true
 	} catch {
 		return false
@@ -51,10 +54,11 @@ export async function fileExistsAtPath(filePath: string): Promise<boolean> {
  * @param filePath - The path to check.
  * @returns A promise that resolves to true if the path is a directory, false otherwise.
  */
-export async function isDirectory(filePath: string): Promise<boolean> {
+export async function isDirectory(filePath: string | vscode.Uri): Promise<boolean> {
 	try {
-		const stats = await fs.stat(filePath)
-		return stats.isDirectory()
+		filePath = filePath instanceof vscode.Uri ? filePath : vscode.Uri.parse(filePath)
+		const stats = await vscode.workspace.fs.stat(filePath)
+		return stats.type === vscode.FileType.Directory
 	} catch {
 		return false
 	}
@@ -65,12 +69,32 @@ export async function isDirectory(filePath: string): Promise<boolean> {
  * @param filePath - Path to the file to check
  * @returns Promise<number> - Size of the file in KB, or 0 if file doesn't exist
  */
-export async function getFileSizeInKB(filePath: string): Promise<number> {
+export async function getFileSizeInKB(filePath: string | vscode.Uri): Promise<number> {
 	try {
-		const stats = await fs.stat(filePath)
+		filePath = filePath instanceof vscode.Uri ? filePath : vscode.Uri.parse(filePath)
+		const stats = await vscode.workspace.fs.stat(filePath)
 		const fileSizeInKB = stats.size / 1000 // Convert bytes to KB (decimal) - matches OS file size display
 		return fileSizeInKB
 	} catch {
 		return 0
+	}
+}
+
+/**
+ * Get the file is Binary file
+ * note: When operating in a virtual file system, since the interface does not support limiting the size of files being read, files considered to be larger than 1MB are deemed to be binary files.
+ * @param filePath - Path to the file to check
+ * @returns Promise<boolean> - A promise that resolves to true if the file is binary file, false otherwise.
+ */
+export async function isBinaryFile(filePath: string | vscode.Uri): Promise<boolean> {
+	let uri = filePath instanceof vscode.Uri ? filePath : vscode.Uri.parse(filePath)
+	if (uri.scheme === "file") {
+		return await isBinaryFileImpl(uri.fsPath)
+	} else {
+		if ((await getFileSizeInKB(uri)) > 10000) {
+			return true
+		} else {
+			return await isBinaryFileImpl(Buffer.from(await vscode.workspace.fs.readFile(uri)))
+		}
 	}
 }


### PR DESCRIPTION
### Description

Replace parts of Node fs with vscode.workspace.fs to improve compatibility with virtual workspaces (e.g., GitHub Remote)


### Test Procedure


### Type of Change

-   [X] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

-   [ ] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

### Additional Notes

The following changes only affected read_file, list_file, write_file, and mention. 

Possible impacted areas include:
- Inability to access local files within the virtual workspace.
