### PR TITLE
ChatErrorBoundary: a guard against evil react crashes

### DIFF
--- a/.changeset/popular-mirrors-rush.md
+++ b/.changeset/popular-mirrors-rush.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Start using ErrorBoundaries for chat widgets to handle crashes

--- a/webview-ui/src/components/chat/ChatErrorBoundary.tsx
+++ b/webview-ui/src/components/chat/ChatErrorBoundary.tsx
@@ -1,0 +1,108 @@
+import React from "react"
+
+interface ChatErrorBoundaryProps {
+  children: React.ReactNode
+  errorTitle?: string
+  errorBody?: string
+  height?: string
+}
+
+interface ChatErrorBoundaryState {
+  hasError: boolean
+  error: Error | null
+}
+
+/**
+ * A reusable error boundary component specifically designed for chat widgets.
+ * It provides a consistent error UI with customizable title and body text.
+ */
+export class ChatErrorBoundary extends React.Component<ChatErrorBoundaryProps, ChatErrorBoundaryState> {
+  constructor(props: ChatErrorBoundaryProps) {
+    super(props)
+    this.state = { hasError: false, error: null }
+  }
+
+  static getDerivedStateFromError(error: Error) {
+    return { hasError: true, error }
+  }
+
+  componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
+    console.error("Error in ChatErrorBoundary:", error.message)
+    console.error("Component stack:", errorInfo.componentStack)
+  }
+
+  render() {
+    const { errorTitle, errorBody, height } = this.props
+
+    if (this.state.hasError) {
+      return (
+        <div
+          style={{
+            padding: "10px",
+            color: "var(--vscode-errorForeground)",
+            height: height || "auto",
+            maxWidth: "512px",
+            overflow: "auto",
+            border: "1px solid var(--vscode-editorError-foreground)",
+            borderRadius: "4px",
+            backgroundColor: "var(--vscode-inputValidation-errorBackground, rgba(255, 0, 0, 0.1))",
+          }}>
+          <h3 style={{ margin: "0 0 8px 0" }}>
+            {errorTitle || "Something went wrong displaying this content"}
+          </h3>
+          <p style={{ margin: "0" }}>
+            {errorBody || `Error: ${this.state.error?.message || "Unknown error"}`}
+          </p>
+        </div>
+      )
+    }
+
+    return this.props.children
+  }
+}
+
+/**
+ * A demo component that throws an error after a delay.
+ * This is useful for testing error boundaries during development.
+ * It will be removed in production.
+ */
+export class ErrorAfterDelay extends React.Component {
+  private timeoutId: NodeJS.Timeout | null = null
+
+  componentDidMount() {
+    // Throw an error after 1 second (reduced from 5 seconds for faster testing)
+    this.timeoutId = setTimeout(() => {
+      // Using a more direct approach to trigger an error that will be caught by the boundary
+      this.setState(() => {
+        throw new Error("This is a demo error for testing the error boundary")
+      })
+    }, 1000)
+  }
+
+  componentWillUnmount() {
+    if (this.timeoutId) {
+      clearTimeout(this.timeoutId)
+    }
+  }
+
+  render() {
+    // Add a small visual indicator that this component will cause an error
+    return (
+      <div style={{ 
+        position: "absolute", 
+        top: 0, 
+        right: 0,
+        background: "rgba(255, 0, 0, 0.2)",
+        color: "var(--vscode-errorForeground)",
+        padding: "2px 5px",
+        fontSize: "10px",
+        borderRadius: "0 0 0 4px",
+        zIndex: 100
+      }}>
+        Error in 1s
+      </div>
+    )
+  }
+}
+
+export default ChatErrorBoundary

--- a/webview-ui/src/components/chat/ChatErrorBoundary.tsx
+++ b/webview-ui/src/components/chat/ChatErrorBoundary.tsx
@@ -1,15 +1,15 @@
 import React from "react"
 
 interface ChatErrorBoundaryProps {
-  children: React.ReactNode
-  errorTitle?: string
-  errorBody?: string
-  height?: string
+	children: React.ReactNode
+	errorTitle?: string
+	errorBody?: string
+	height?: string
 }
 
 interface ChatErrorBoundaryState {
-  hasError: boolean
-  error: Error | null
+	hasError: boolean
+	error: Error | null
 }
 
 /**
@@ -17,48 +17,44 @@ interface ChatErrorBoundaryState {
  * It provides a consistent error UI with customizable title and body text.
  */
 export class ChatErrorBoundary extends React.Component<ChatErrorBoundaryProps, ChatErrorBoundaryState> {
-  constructor(props: ChatErrorBoundaryProps) {
-    super(props)
-    this.state = { hasError: false, error: null }
-  }
+	constructor(props: ChatErrorBoundaryProps) {
+		super(props)
+		this.state = { hasError: false, error: null }
+	}
 
-  static getDerivedStateFromError(error: Error) {
-    return { hasError: true, error }
-  }
+	static getDerivedStateFromError(error: Error) {
+		return { hasError: true, error }
+	}
 
-  componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
-    console.error("Error in ChatErrorBoundary:", error.message)
-    console.error("Component stack:", errorInfo.componentStack)
-  }
+	componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
+		console.error("Error in ChatErrorBoundary:", error.message)
+		console.error("Component stack:", errorInfo.componentStack)
+	}
 
-  render() {
-    const { errorTitle, errorBody, height } = this.props
+	render() {
+		const { errorTitle, errorBody, height } = this.props
 
-    if (this.state.hasError) {
-      return (
-        <div
-          style={{
-            padding: "10px",
-            color: "var(--vscode-errorForeground)",
-            height: height || "auto",
-            maxWidth: "512px",
-            overflow: "auto",
-            border: "1px solid var(--vscode-editorError-foreground)",
-            borderRadius: "4px",
-            backgroundColor: "var(--vscode-inputValidation-errorBackground, rgba(255, 0, 0, 0.1))",
-          }}>
-          <h3 style={{ margin: "0 0 8px 0" }}>
-            {errorTitle || "Something went wrong displaying this content"}
-          </h3>
-          <p style={{ margin: "0" }}>
-            {errorBody || `Error: ${this.state.error?.message || "Unknown error"}`}
-          </p>
-        </div>
-      )
-    }
+		if (this.state.hasError) {
+			return (
+				<div
+					style={{
+						padding: "10px",
+						color: "var(--vscode-errorForeground)",
+						height: height || "auto",
+						maxWidth: "512px",
+						overflow: "auto",
+						border: "1px solid var(--vscode-editorError-foreground)",
+						borderRadius: "4px",
+						backgroundColor: "var(--vscode-inputValidation-errorBackground, rgba(255, 0, 0, 0.1))",
+					}}>
+					<h3 style={{ margin: "0 0 8px 0" }}>{errorTitle || "Something went wrong displaying this content"}</h3>
+					<p style={{ margin: "0" }}>{errorBody || `Error: ${this.state.error?.message || "Unknown error"}`}</p>
+				</div>
+			)
+		}
 
-    return this.props.children
-  }
+		return this.props.children
+	}
 }
 
 /**
@@ -66,68 +62,69 @@ export class ChatErrorBoundary extends React.Component<ChatErrorBoundaryProps, C
  * This is useful for testing error boundaries during development
  */
 interface ErrorAfterDelayProps {
-  numSecondsToWait?: number;
+	numSecondsToWait?: number
 }
 
 interface ErrorAfterDelayState {
-  tickCount: number;
+	tickCount: number
 }
 
 export class ErrorAfterDelay extends React.Component<ErrorAfterDelayProps, ErrorAfterDelayState> {
-  private intervalID: NodeJS.Timeout | null = null
+	private intervalID: NodeJS.Timeout | null = null
 
-  constructor(props: ErrorAfterDelayProps) {
-    super(props)
-    this.state = {
-      tickCount: 0,
-    }
-  }
+	constructor(props: ErrorAfterDelayProps) {
+		super(props)
+		this.state = {
+			tickCount: 0,
+		}
+	}
 
-  componentDidMount() {
-    const secondsToWait = this.props.numSecondsToWait ?? 5;
-    
-    this.intervalID = setInterval(() => {
-      if (this.state.tickCount >= secondsToWait) {
-        if (this.intervalID) {
-          clearInterval(this.intervalID)
-        }
-        // Error boundaries don't catch async code :(
-        // So this only works by throwing inside of a setState
-        this.setState(() => {
-          throw new Error("This is an error for testing the error boundary");
-        });
-      } else {
-        this.setState({
-          tickCount: this.state.tickCount + 1
-        });
-      }
-    }, 1000);
-  }
+	componentDidMount() {
+		const secondsToWait = this.props.numSecondsToWait ?? 5
 
-  componentWillUnmount() {
-    if (this.intervalID) {
-      clearInterval(this.intervalID)
-    }
-  }
+		this.intervalID = setInterval(() => {
+			if (this.state.tickCount >= secondsToWait) {
+				if (this.intervalID) {
+					clearInterval(this.intervalID)
+				}
+				// Error boundaries don't catch async code :(
+				// So this only works by throwing inside of a setState
+				this.setState(() => {
+					throw new Error("This is an error for testing the error boundary")
+				})
+			} else {
+				this.setState({
+					tickCount: this.state.tickCount + 1,
+				})
+			}
+		}, 1000)
+	}
 
-  render() {    
-    // Add a small visual indicator that this component will cause an error
-    return (
-      <div style={{ 
-        position: "absolute", 
-        top: 0, 
-        right: 0,
-        background: "rgba(255, 0, 0, 0.5)",
-        color: "var(--vscode-errorForeground)",
-        padding: "2px 5px",
-        fontSize: "12px",
-        borderRadius: "0 0 0 4px",
-        zIndex: 100
-      }}>
-        Error in {this.state.tickCount}/{this.props.numSecondsToWait ?? 5} seconds
-      </div>
-    )
-  }
+	componentWillUnmount() {
+		if (this.intervalID) {
+			clearInterval(this.intervalID)
+		}
+	}
+
+	render() {
+		// Add a small visual indicator that this component will cause an error
+		return (
+			<div
+				style={{
+					position: "absolute",
+					top: 0,
+					right: 0,
+					background: "rgba(255, 0, 0, 0.5)",
+					color: "var(--vscode-errorForeground)",
+					padding: "2px 5px",
+					fontSize: "12px",
+					borderRadius: "0 0 0 4px",
+					zIndex: 100,
+				}}>
+				Error in {this.state.tickCount}/{this.props.numSecondsToWait ?? 5} seconds
+			</div>
+		)
+	}
 }
 
 export default ChatErrorBoundary

--- a/webview-ui/src/components/chat/ChatRow.tsx
+++ b/webview-ui/src/components/chat/ChatRow.tsx
@@ -134,8 +134,6 @@ const ChatRow = memo(
 export default ChatRow
 
 export const ChatRowContent = ({ message, isExpanded, onToggleExpand, lastModifiedMessage, isLast }: ChatRowContentProps) => {
-	// Add demo error component at the top for review - will be removed later
-	const showDemoError = message.type === "say" && message.say === "text" && !message.partial
 	const { mcpServers, mcpMarketplaceCatalog } = useExtensionState()
 	const [seeNewChangesDisabled, setSeeNewChangesDisabled] = useState(false)
 
@@ -796,11 +794,7 @@ export const ChatRowContent = ({ message, isExpanded, onToggleExpand, lastModifi
 				case "api_req_finished":
 					return null // we should never see this message type
 				case "mcp_server_response":
-					return (
-						<div>
-							<McpResponseDisplay responseText={message.text || ""} />
-						</div>
-					)
+					return <McpResponseDisplay responseText={message.text || ""} />
 				case "text":
 					return (
 						<div>

--- a/webview-ui/src/components/chat/ChatRow.tsx
+++ b/webview-ui/src/components/chat/ChatRow.tsx
@@ -3,6 +3,7 @@ import deepEqual from "fast-deep-equal"
 import React, { memo, useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { useEvent, useSize } from "react-use"
 import styled from "styled-components"
+import { ErrorAfterDelay } from "./ChatErrorBoundary"
 import {
 	ClineApiReqInfo,
 	ClineAskQuestion,
@@ -134,6 +135,8 @@ const ChatRow = memo(
 export default ChatRow
 
 export const ChatRowContent = ({ message, isExpanded, onToggleExpand, lastModifiedMessage, isLast }: ChatRowContentProps) => {
+	// Add demo error component at the top for review - will be removed later
+	const showDemoError = message.type === "say" && message.say === "text" && !message.partial
 	const { mcpServers, mcpMarketplaceCatalog } = useExtensionState()
 	const [seeNewChangesDisabled, setSeeNewChangesDisabled] = useState(false)
 
@@ -794,7 +797,12 @@ export const ChatRowContent = ({ message, isExpanded, onToggleExpand, lastModifi
 				case "api_req_finished":
 					return null // we should never see this message type
 				case "mcp_server_response":
-					return <McpResponseDisplay responseText={message.text || ""} />
+					return (
+						<div>
+							{showDemoError && <ErrorAfterDelay />}
+							<McpResponseDisplay responseText={message.text || ""} />
+						</div>
+					)
 				case "text":
 					return (
 						<div>

--- a/webview-ui/src/components/chat/ChatRow.tsx
+++ b/webview-ui/src/components/chat/ChatRow.tsx
@@ -3,7 +3,6 @@ import deepEqual from "fast-deep-equal"
 import React, { memo, useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { useEvent, useSize } from "react-use"
 import styled from "styled-components"
-import { ErrorAfterDelay } from "./ChatErrorBoundary"
 import {
 	ClineApiReqInfo,
 	ClineAskQuestion,
@@ -799,7 +798,6 @@ export const ChatRowContent = ({ message, isExpanded, onToggleExpand, lastModifi
 				case "mcp_server_response":
 					return (
 						<div>
-							{showDemoError && <ErrorAfterDelay />}
 							<McpResponseDisplay responseText={message.text || ""} />
 						</div>
 					)

--- a/webview-ui/src/components/mcp/ImagePreview.tsx
+++ b/webview-ui/src/components/mcp/ImagePreview.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useRef } from "react"
 import { vscode } from "../../utils/vscode"
 import DOMPurify from "dompurify"
 import { getSafeHostname, formatUrlForOpening, checkIfImageUrl } from "./McpRichUtil"
-import ChatErrorBoundary, { ErrorAfterDelay } from "../chat/ChatErrorBoundary"
+import ChatErrorBoundary from "../chat/ChatErrorBoundary"
 
 interface ImagePreviewProps {
 	url: string
@@ -328,8 +328,6 @@ const MemoizedImagePreview = React.memo(
 const ImagePreviewWithErrorBoundary: React.FC<ImagePreviewProps> = (props) => {
 	return (
 		<ChatErrorBoundary errorTitle="Something went wrong displaying this image">
-			{/* Demo error component for review - will be removed later */}
-			<ErrorAfterDelay />
 			<MemoizedImagePreview {...props} />
 		</ChatErrorBoundary>
 	)

--- a/webview-ui/src/components/mcp/ImagePreview.tsx
+++ b/webview-ui/src/components/mcp/ImagePreview.tsx
@@ -2,35 +2,7 @@ import React, { useEffect, useRef } from "react"
 import { vscode } from "../../utils/vscode"
 import DOMPurify from "dompurify"
 import { getSafeHostname, formatUrlForOpening, checkIfImageUrl } from "./McpRichUtil"
-
-// Error boundary component to prevent crashes
-class ErrorBoundary extends React.Component<{ children: React.ReactNode }, { hasError: boolean; error: Error | null }> {
-	constructor(props: { children: React.ReactNode }) {
-		super(props)
-		this.state = { hasError: false, error: null }
-	}
-
-	static getDerivedStateFromError(error: Error) {
-		return { hasError: true, error }
-	}
-
-	componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
-		console.log("Error in ImagePreview component:", error.message)
-	}
-
-	render() {
-		if (this.state.hasError) {
-			return (
-				<div style={{ padding: "10px", color: "var(--vscode-errorForeground)" }}>
-					<h3>Something went wrong displaying this image</h3>
-					<p>Error: {this.state.error?.message || "Unknown error"}</p>
-				</div>
-			)
-		}
-
-		return this.props.children
-	}
-}
+import ChatErrorBoundary, { ErrorAfterDelay } from "../chat/ChatErrorBoundary"
 
 interface ImagePreviewProps {
 	url: string
@@ -355,9 +327,11 @@ const MemoizedImagePreview = React.memo(
 // Wrap the ImagePreview component with an error boundary
 const ImagePreviewWithErrorBoundary: React.FC<ImagePreviewProps> = (props) => {
 	return (
-		<ErrorBoundary>
+		<ChatErrorBoundary errorTitle="Something went wrong displaying this image">
+			{/* Demo error component for review - will be removed later */}
+			<ErrorAfterDelay />
 			<MemoizedImagePreview {...props} />
-		</ErrorBoundary>
+		</ChatErrorBoundary>
 	)
 }
 

--- a/webview-ui/src/components/mcp/LinkPreview.tsx
+++ b/webview-ui/src/components/mcp/LinkPreview.tsx
@@ -4,7 +4,6 @@ import DOMPurify from "dompurify"
 import { getSafeHostname, normalizeRelativeUrl } from "./McpRichUtil"
 import ChatErrorBoundary from "../chat/ChatErrorBoundary"
 
-
 interface OpenGraphData {
 	title?: string
 	description?: string
@@ -276,35 +275,35 @@ class LinkPreview extends React.Component<
 				}}>
 				{data.image && (
 					<div className="link-preview-image" style={{ width: "128px", height: "128px", flexShrink: 0 }}>
-                        <img
-                            src={DOMPurify.sanitize(normalizeRelativeUrl(data.image, url))}
-                            alt=""
-                            style={{
-                                width: "100%",
-                                height: "100%",
-                                objectFit: "contain", // Use contain for link preview thumbnails to handle logos
-                                objectPosition: "center", // Center the image
-                            }}
-                            onLoad={(e) => {
-                                // Check aspect ratio to determine if we should use contain or cover
-                                const img = e.currentTarget
-                                if (img.naturalWidth > 0 && img.naturalHeight > 0) {
-                                    const aspectRatio = img.naturalWidth / img.naturalHeight
+						<img
+							src={DOMPurify.sanitize(normalizeRelativeUrl(data.image, url))}
+							alt=""
+							style={{
+								width: "100%",
+								height: "100%",
+								objectFit: "contain", // Use contain for link preview thumbnails to handle logos
+								objectPosition: "center", // Center the image
+							}}
+							onLoad={(e) => {
+								// Check aspect ratio to determine if we should use contain or cover
+								const img = e.currentTarget
+								if (img.naturalWidth > 0 && img.naturalHeight > 0) {
+									const aspectRatio = img.naturalWidth / img.naturalHeight
 
-                                    // Use contain for extreme aspect ratios (logos), cover for photos
-                                    if (aspectRatio > 2.5 || aspectRatio < 0.4) {
-                                        img.style.objectFit = "contain"
-                                    } else {
-                                        img.style.objectFit = "cover"
-                                    }
-                                }
-                            }}
-                            onError={(e) => {
-                                console.log(`Image could not be loaded: ${data.image}`)
-                                // Hide the broken image
-                                ;(e.target as HTMLImageElement).style.display = "none"
-                            }}
-                        />
+									// Use contain for extreme aspect ratios (logos), cover for photos
+									if (aspectRatio > 2.5 || aspectRatio < 0.4) {
+										img.style.objectFit = "contain"
+									} else {
+										img.style.objectFit = "cover"
+									}
+								}
+							}}
+							onError={(e) => {
+								console.log(`Image could not be loaded: ${data.image}`)
+								// Hide the broken image
+								;(e.target as HTMLImageElement).style.display = "none"
+							}}
+						/>
 					</div>
 				)}
 

--- a/webview-ui/src/components/mcp/LinkPreview.tsx
+++ b/webview-ui/src/components/mcp/LinkPreview.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from "react"
 import { vscode } from "../../utils/vscode"
 import DOMPurify from "dompurify"
 import { getSafeHostname, normalizeRelativeUrl } from "./McpRichUtil"
-import ChatErrorBoundary, { ErrorAfterDelay } from "../chat/ChatErrorBoundary"
+import ChatErrorBoundary from "../chat/ChatErrorBoundary"
 
 
 interface OpenGraphData {
@@ -385,8 +385,6 @@ const MemoizedLinkPreview = React.memo(
 const LinkPreviewWithErrorBoundary: React.FC<LinkPreviewProps> = (props) => {
 	return (
 		<ChatErrorBoundary errorTitle="Something went wrong displaying this link preview">
-			{/* Demo error component for review - will be removed later */}
-			<ErrorAfterDelay />
 			<MemoizedLinkPreview {...props} />
 		</ChatErrorBoundary>
 	)

--- a/webview-ui/src/components/mcp/LinkPreview.tsx
+++ b/webview-ui/src/components/mcp/LinkPreview.tsx
@@ -276,37 +276,35 @@ class LinkPreview extends React.Component<
 				}}>
 				{data.image && (
 					<div className="link-preview-image" style={{ width: "128px", height: "128px", flexShrink: 0 }}>
-						<ChatErrorBoundary errorTitle="Image preview failed to load">
-							<img
-								src={DOMPurify.sanitize(normalizeRelativeUrl(data.image, url))}
-								alt=""
-								style={{
-									width: "100%",
-									height: "100%",
-									objectFit: "contain", // Use contain for link preview thumbnails to handle logos
-									objectPosition: "center", // Center the image
-								}}
-								onLoad={(e) => {
-									// Check aspect ratio to determine if we should use contain or cover
-									const img = e.currentTarget
-									if (img.naturalWidth > 0 && img.naturalHeight > 0) {
-										const aspectRatio = img.naturalWidth / img.naturalHeight
+                        <img
+                            src={DOMPurify.sanitize(normalizeRelativeUrl(data.image, url))}
+                            alt=""
+                            style={{
+                                width: "100%",
+                                height: "100%",
+                                objectFit: "contain", // Use contain for link preview thumbnails to handle logos
+                                objectPosition: "center", // Center the image
+                            }}
+                            onLoad={(e) => {
+                                // Check aspect ratio to determine if we should use contain or cover
+                                const img = e.currentTarget
+                                if (img.naturalWidth > 0 && img.naturalHeight > 0) {
+                                    const aspectRatio = img.naturalWidth / img.naturalHeight
 
-										// Use contain for extreme aspect ratios (logos), cover for photos
-										if (aspectRatio > 2.5 || aspectRatio < 0.4) {
-											img.style.objectFit = "contain"
-										} else {
-											img.style.objectFit = "cover"
-										}
-									}
-								}}
-								onError={(e) => {
-									console.log(`Image could not be loaded: ${data.image}`)
-									// Hide the broken image
-									;(e.target as HTMLImageElement).style.display = "none"
-								}}
-							/>
-						</ChatErrorBoundary>
+                                    // Use contain for extreme aspect ratios (logos), cover for photos
+                                    if (aspectRatio > 2.5 || aspectRatio < 0.4) {
+                                        img.style.objectFit = "contain"
+                                    } else {
+                                        img.style.objectFit = "cover"
+                                    }
+                                }
+                            }}
+                            onError={(e) => {
+                                console.log(`Image could not be loaded: ${data.image}`)
+                                // Hide the broken image
+                                ;(e.target as HTMLImageElement).style.display = "none"
+                            }}
+                        />
 					</div>
 				)}
 

--- a/webview-ui/src/components/mcp/LinkPreview.tsx
+++ b/webview-ui/src/components/mcp/LinkPreview.tsx
@@ -2,42 +2,8 @@ import React, { useEffect, useState } from "react"
 import { vscode } from "../../utils/vscode"
 import DOMPurify from "dompurify"
 import { getSafeHostname, normalizeRelativeUrl } from "./McpRichUtil"
+import ChatErrorBoundary, { ErrorAfterDelay } from "../chat/ChatErrorBoundary"
 
-// Error boundary component to prevent crashes
-class ErrorBoundary extends React.Component<{ children: React.ReactNode }, { hasError: boolean; error: Error | null }> {
-	constructor(props: { children: React.ReactNode }) {
-		super(props)
-		this.state = { hasError: false, error: null }
-	}
-
-	static getDerivedStateFromError(error: Error) {
-		return { hasError: true, error }
-	}
-
-	componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
-		console.log("Error in LinkPreview component:", error.message)
-	}
-
-	render() {
-		if (this.state.hasError) {
-			return (
-				<div
-					style={{
-						padding: "12px",
-						color: "var(--vscode-errorForeground)",
-						height: "128px",
-						maxWidth: "512px",
-						overflow: "auto",
-					}}>
-					<h3>Something went wrong displaying this link preview</h3>
-					<p>Error: {this.state.error?.message || "Unknown error"}</p>
-				</div>
-			)
-		}
-
-		return this.props.children
-	}
-}
 
 interface OpenGraphData {
 	title?: string
@@ -310,7 +276,7 @@ class LinkPreview extends React.Component<
 				}}>
 				{data.image && (
 					<div className="link-preview-image" style={{ width: "128px", height: "128px", flexShrink: 0 }}>
-						<ErrorBoundary>
+						<ChatErrorBoundary errorTitle="Image preview failed to load">
 							<img
 								src={DOMPurify.sanitize(normalizeRelativeUrl(data.image, url))}
 								alt=""
@@ -340,7 +306,7 @@ class LinkPreview extends React.Component<
 									;(e.target as HTMLImageElement).style.display = "none"
 								}}
 							/>
-						</ErrorBoundary>
+						</ChatErrorBoundary>
 					</div>
 				)}
 
@@ -420,9 +386,11 @@ const MemoizedLinkPreview = React.memo(
 // Wrap the LinkPreview component with an error boundary
 const LinkPreviewWithErrorBoundary: React.FC<LinkPreviewProps> = (props) => {
 	return (
-		<ErrorBoundary>
+		<ChatErrorBoundary errorTitle="Something went wrong displaying this link preview">
+			{/* Demo error component for review - will be removed later */}
+			<ErrorAfterDelay />
 			<MemoizedLinkPreview {...props} />
-		</ErrorBoundary>
+		</ChatErrorBoundary>
 	)
 }
 

--- a/webview-ui/src/components/mcp/McpResponseDisplay.tsx
+++ b/webview-ui/src/components/mcp/McpResponseDisplay.tsx
@@ -5,6 +5,7 @@ import { vscode } from "../../utils/vscode"
 import DOMPurify from "dompurify"
 import styled from "styled-components"
 import { CODE_BLOCK_BG_COLOR } from "../common/CodeBlock"
+import ChatErrorBoundary, { ErrorAfterDelay } from "../chat/ChatErrorBoundary"
 import {
 	safeCreateUrl,
 	isUrl,
@@ -119,41 +120,6 @@ interface UrlMatch {
 	isProcessed: boolean // Whether we've already processed this URL (to avoid duplicates)
 }
 
-// Error boundary component to prevent crashes from URL processing
-class ErrorBoundary extends React.Component<{ children: React.ReactNode }, { hasError: boolean; error: Error | null }> {
-	constructor(props: { children: React.ReactNode }) {
-		super(props)
-		this.state = { hasError: false, error: null }
-	}
-
-	static getDerivedStateFromError(error: Error) {
-		return { hasError: true, error }
-	}
-
-	componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
-		console.log("Error in component:", error.message)
-	}
-
-	render() {
-		if (this.state.hasError) {
-			return (
-				<div
-					style={{
-						padding: "10px",
-						color: "var(--vscode-errorForeground)",
-						height: "128px", // Fixed height
-						overflow: "auto", // Allow scrolling if content overflows
-					}}>
-					<h3>Something went wrong displaying this content</h3>
-					<p>Error: {this.state.error?.message || "Unknown error"}</p>
-					<p>Please switch to plain text mode to view the content safely.</p>
-				</div>
-			)
-		}
-
-		return this.props.children
-	}
-}
 
 const McpResponseDisplay: React.FC<McpResponseDisplayProps> = ({ responseText }) => {
 	const [isLoading, setIsLoading] = useState(true)
@@ -382,10 +348,8 @@ const McpResponseDisplay: React.FC<McpResponseDisplayProps> = ({ responseText })
 								// Use a unique key that includes the URL to ensure each preview is isolated
 								segments.push(
 									<div key={`embed-${url}-${segmentIndex++}`} style={{ margin: "10px 0" }}>
-										<ErrorBoundary>
-											{/* Already using formatUrlForOpening for link previews */}
-											<LinkPreview url={formatUrlForOpening(url)} />
-										</ErrorBoundary>
+                                        {/* Already using formatUrlForOpening for link previews */}
+                                        <LinkPreview url={formatUrlForOpening(url)} />
 									</div>,
 								)
 
@@ -464,9 +428,11 @@ const McpResponseDisplay: React.FC<McpResponseDisplayProps> = ({ responseText })
 // Wrap the entire McpResponseDisplay component with an error boundary
 const McpResponseDisplayWithErrorBoundary: React.FC<McpResponseDisplayProps> = (props) => {
 	return (
-		<ErrorBoundary>
+		<ChatErrorBoundary>
+			{/* Demo error component for review - will be removed later */}
+			<ErrorAfterDelay />
 			<McpResponseDisplay {...props} />
-		</ErrorBoundary>
+		</ChatErrorBoundary>
 	)
 }
 

--- a/webview-ui/src/components/mcp/McpResponseDisplay.tsx
+++ b/webview-ui/src/components/mcp/McpResponseDisplay.tsx
@@ -5,7 +5,7 @@ import { vscode } from "../../utils/vscode"
 import DOMPurify from "dompurify"
 import styled from "styled-components"
 import { CODE_BLOCK_BG_COLOR } from "../common/CodeBlock"
-import ChatErrorBoundary, { ErrorAfterDelay } from "../chat/ChatErrorBoundary"
+import ChatErrorBoundary from "../chat/ChatErrorBoundary"
 import {
 	safeCreateUrl,
 	isUrl,
@@ -429,8 +429,6 @@ const McpResponseDisplay: React.FC<McpResponseDisplayProps> = ({ responseText })
 const McpResponseDisplayWithErrorBoundary: React.FC<McpResponseDisplayProps> = (props) => {
 	return (
 		<ChatErrorBoundary>
-			{/* Demo error component for review - will be removed later */}
-			<ErrorAfterDelay />
 			<McpResponseDisplay {...props} />
 		</ChatErrorBoundary>
 	)

--- a/webview-ui/src/components/mcp/McpResponseDisplay.tsx
+++ b/webview-ui/src/components/mcp/McpResponseDisplay.tsx
@@ -120,7 +120,6 @@ interface UrlMatch {
 	isProcessed: boolean // Whether we've already processed this URL (to avoid duplicates)
 }
 
-
 const McpResponseDisplay: React.FC<McpResponseDisplayProps> = ({ responseText }) => {
 	const [isLoading, setIsLoading] = useState(true)
 	const [displayMode, setDisplayMode] = useState<"rich" | "plain">(() => {
@@ -348,8 +347,8 @@ const McpResponseDisplay: React.FC<McpResponseDisplayProps> = ({ responseText })
 								// Use a unique key that includes the URL to ensure each preview is isolated
 								segments.push(
 									<div key={`embed-${url}-${segmentIndex++}`} style={{ margin: "10px 0" }}>
-                                        {/* Already using formatUrlForOpening for link previews */}
-                                        <LinkPreview url={formatUrlForOpening(url)} />
+										{/* Already using formatUrlForOpening for link previews */}
+										<LinkPreview url={formatUrlForOpening(url)} />
 									</div>,
 								)
 


### PR DESCRIPTION
### Description

Adds a component in /chat/ that can catch crashes and produce a sensible UI instead. This is the last line of defense for a chat widget crashing

NOTE: this PR is based on https://github.com/cline/cline/pull/2177 NOT MAIN, as that other PR is needed to merge first

### Test Procedure

Edit some widget like ImagePreview to add an error throwing debug tool that's included:

```
		<ChatErrorBoundary errorTitle="Something went wrong displaying this image">
			<ErrorAfterDelay />
			<MemoizedImagePreview {...props} />
		</ChatErrorBoundary>
```

This ErrorAfterDelay widget will show a countdown and after 5 seconds, throw an uncaught error. The Error boundary will then step in to intercept it and render a niceish UI

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

https://github.com/user-attachments/assets/e1e2b6b1-ec0f-4c1f-8ef5-d035a6303463


<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds `ChatErrorBoundary` for consistent error handling in chat widgets, replacing existing boundaries in key components.
> 
>   - **New Feature**:
>     - Adds `ChatErrorBoundary` in `ChatErrorBoundary.tsx` to handle crashes in chat widgets with a consistent error UI.
>     - Includes `ErrorAfterDelay` for testing error boundaries.
>   - **Refactoring**:
>     - Replaces existing `ErrorBoundary` with `ChatErrorBoundary` in `ImagePreview.tsx`, `LinkPreview.tsx`, and `McpResponseDisplay.tsx`.
>   - **Behavior**:
>     - `ChatErrorBoundary` catches errors and displays a customizable error message.
>     - `ErrorAfterDelay` throws an error after a delay for testing purposes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for c2257d3bc13354039b8f06e0960251801dfe851e. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->