### PR TITLE
Revert "Added option for skipping diff animation. Useful when diff animation …"

### DIFF
--- a/.changeset/moody-rules-repeat.md
+++ b/.changeset/moody-rules-repeat.md
@@ -1,5 +1,0 @@
----
-"claude-dev": minor
----
-
-Added option for skipping diff animation. Useful when diff animation is slow.

--- a/README.md
+++ b/README.md
@@ -137,14 +137,6 @@ For example, when working with a local web server, you can use 'Restore Workspac
 
 <img width="2000" height="0" src="https://github.com/user-attachments/assets/ee14e6f7-20b8-4391-9091-8e8e25561929"><br>
 
-## Settings
-
-Cline provides several settings to customize its behavior:
-
-### Editor Settings
-
-- `cline.editor.skipDiffAnimation`: Disable the animated diff view when Cline makes changes to files. This can significantly speed up file modifications, especially when working with remote repositories. Default: `false`
-
 ## Contributing
 
 To contribute to the project, start with our [Contributing Guide](CONTRIBUTING.md) to learn the basics. You can also join our [Discord](https://discord.gg/cline) to chat with other contributors in the `#contributors` channel. If you're looking for full-time work, check out our open positions on our [careers page](https://cline.bot/join-us)!

--- a/package.json
+++ b/package.json
@@ -182,11 +182,6 @@
 					"default": null,
 					"description": "Path to Chrome executable for browser use functionality. If not set, the extension will attempt to find or download it automatically."
 				},
-				"cline.editor.skipDiffAnimation": {
-					"type": "boolean",
-					"default": false,
-					"description": "Skip the animation when applying diffs in the editor. Useful for faster updates, especially with remote repositories."
-        },
 				"cline.preferredLanguage": {
 					"type": "string",
 					"enum": [

--- a/src/shared/EditorSettings.ts
+++ b/src/shared/EditorSettings.ts
@@ -1,7 +1,0 @@
-export interface EditorSettings {
-	skipDiffAnimation: boolean
-}
-
-export const DEFAULT_EDITOR_SETTINGS: EditorSettings = {
-	skipDiffAnimation: false,
-}


### PR DESCRIPTION
Reverts cline/cline#1765

Reverting this PR as after testing, this does not improve performance.  
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Reverts the addition of the `skipDiffAnimation` feature in Cline due to lack of performance improvement.
> 
>   - **Reversion**:
>     - Reverts the addition of `cline.editor.skipDiffAnimation` setting from `package.json` and `README.md`.
>     - Removes `skipAnimation` logic from `DiffViewProvider` class in `DiffViewProvider.ts`.
>   - **File Deletions**:
>     - Deletes `EditorSettings.ts` which defined `skipDiffAnimation`.
>     - Deletes `.changeset/moody-rules-repeat.md` related to the original change.
>   - **Misc**:
>     - Removes related documentation from `README.md`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 0c377c7d0ac0a35f0b2e42f576f09b13549e3855. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->