### PR TITLE
[cline.ts] Refactor out ensureTaskDirectoryExists [1/8]

### DIFF
--- a/.changeset/real-kings-guess.md
+++ b/.changeset/real-kings-guess.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+refactor

--- a/src/core/messages-io.ts
+++ b/src/core/messages-io.ts
@@ -1,0 +1,11 @@
+import fs from "fs/promises"
+import path from "path"
+
+export async function ensureTaskDirectoryExists(globalStoragePath: string | undefined, taskId: string): Promise<string> {
+	if (!globalStoragePath) {
+		throw new Error("Global storage uri is invalid")
+	}
+	const taskDir = path.join(globalStoragePath, "tasks", taskId)
+	await fs.mkdir(taskDir, { recursive: true })
+	return taskDir
+}


### PR DESCRIPTION
### Description

Refactor out ensureTaskDirectoryExists

### Test Procedure



### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Refactor `ensureTaskDirectoryExists` from `Cline.ts` to `messages-io.ts` without changing functionality.
> 
>   - **Refactor**:
>     - Move `ensureTaskDirectoryExists` from `Cline.ts` to `messages-io.ts`.
>     - Update `Cline.ts` to import `ensureTaskDirectoryExists` from `messages-io.ts`.
>   - **Behavior**:
>     - No change in functionality; `ensureTaskDirectoryExists` still ensures the task directory exists for a given `taskId`.
>   - **Misc**:
>     - Add changeset file `real-kings-guess.md` for patch release.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for eea2c9783526ed5dbebd69f7421d43f452baaaab. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->