### PR TITLE
Cline.ts - Factor out saveApiConversationHistory [2/8]

### DIFF
--- a/.changeset/brave-bugs-ring.md
+++ b/.changeset/brave-bugs-ring.md
@@ -1,5 +1,0 @@
----
-"claude-dev": patch
----
-
-refactor

--- a/.changeset/brave-bugs-ring.md
+++ b/.changeset/brave-bugs-ring.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+refactor

--- a/.changeset/thin-socks-grin.md
+++ b/.changeset/thin-socks-grin.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+refactor

--- a/src/core/messages-io.ts
+++ b/src/core/messages-io.ts
@@ -1,5 +1,7 @@
 import fs from "fs/promises"
 import path from "path"
+import { GlobalFileNames } from "../global-constants"
+import Anthropic from "@anthropic-ai/sdk"
 
 export async function ensureTaskDirectoryExists(globalStoragePath: string | undefined, taskId: string): Promise<string> {
 	if (!globalStoragePath) {
@@ -8,4 +10,21 @@ export async function ensureTaskDirectoryExists(globalStoragePath: string | unde
 	const taskDir = path.join(globalStoragePath, "tasks", taskId)
 	await fs.mkdir(taskDir, { recursive: true })
 	return taskDir
+}
+
+export async function saveApiConversationHistory(
+	globalStoragePath: string | undefined,
+	taskId: string,
+	apiConversationHistory: Anthropic.MessageParam[],
+) {
+	try {
+		const filePath = path.join(
+			await ensureTaskDirectoryExists(globalStoragePath, taskId),
+			GlobalFileNames.apiConversationHistory,
+		)
+		await fs.writeFile(filePath, JSON.stringify(apiConversationHistory))
+	} catch (error) {
+		// in the off chance this fails, we don't want to stop the task
+		console.error("Failed to save API conversation history:", error)
+	}
 }

--- a/src/core/messages-io.ts
+++ b/src/core/messages-io.ts
@@ -2,6 +2,7 @@ import fs from "fs/promises"
 import path from "path"
 import { GlobalFileNames } from "../global-constants"
 import Anthropic from "@anthropic-ai/sdk"
+import { fileExistsAtPath } from "../utils/fs"
 
 export async function ensureTaskDirectoryExists(globalStoragePath: string | undefined, taskId: string): Promise<string> {
 	if (!globalStoragePath) {
@@ -27,4 +28,16 @@ export async function saveApiConversationHistory(
 		// in the off chance this fails, we don't want to stop the task
 		console.error("Failed to save API conversation history:", error)
 	}
+}
+
+export async function getSavedApiConversationHistory(
+	globalStoragePath: string | undefined,
+	taskId: string,
+): Promise<Anthropic.MessageParam[]> {
+	const filePath = path.join(await ensureTaskDirectoryExists(globalStoragePath, taskId), GlobalFileNames.apiConversationHistory)
+	const fileExists = await fileExistsAtPath(filePath)
+	if (fileExists) {
+		return JSON.parse(await fs.readFile(filePath, "utf8"))
+	}
+	return []
 }


### PR DESCRIPTION
### Description

Factor out saveApiConversationHistory

Factor out getSavedApiConversationHistory

### Test Procedure

<!-- How did you test this? Are you confident that it will not introduce bugs? If so, why? -->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Refactor `Cline.ts` by moving `saveApiConversationHistory` and `getSavedApiConversationHistory` to `messages-io.ts` for better code organization.
> 
>   - **Refactoring**:
>     - Move `saveApiConversationHistory` and `getSavedApiConversationHistory` from `Cline.ts` to `messages-io.ts`.
>     - Update imports in `Cline.ts` to use the moved functions from `messages-io.ts`.
>   - **Behavior**:
>     - No change in functionality; refactoring for better code organization.
>     - Handles API conversation history saving and retrieval without altering logic.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 754ee766d183b065e631d5f37b88838be723f51f. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->