### PR TITLE
Cline.ts - Factor out get saved cline messages [3/8]

### DIFF
--- a/.changeset/calm-owls-jam.md
+++ b/.changeset/calm-owls-jam.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+refactor

--- a/src/core/messages-io.ts
+++ b/src/core/messages-io.ts
@@ -3,6 +3,7 @@ import path from "path"
 import { GlobalFileNames } from "../global-constants"
 import Anthropic from "@anthropic-ai/sdk"
 import { fileExistsAtPath } from "../utils/fs"
+import { ClineMessage } from "../shared/ExtensionMessage"
 
 export async function ensureTaskDirectoryExists(globalStoragePath: string | undefined, taskId: string): Promise<string> {
 	if (!globalStoragePath) {
@@ -38,6 +39,22 @@ export async function getSavedApiConversationHistory(
 	const fileExists = await fileExistsAtPath(filePath)
 	if (fileExists) {
 		return JSON.parse(await fs.readFile(filePath, "utf8"))
+	}
+	return []
+}
+
+export async function getSavedClineMessages(globalStoragePath: string | undefined, taskId: string): Promise<ClineMessage[]> {
+	const filePath = path.join(await ensureTaskDirectoryExists(globalStoragePath, taskId), GlobalFileNames.uiMessages)
+	if (await fileExistsAtPath(filePath)) {
+		return JSON.parse(await fs.readFile(filePath, "utf8"))
+	} else {
+		// check old location
+		const oldPath = path.join(await ensureTaskDirectoryExists(globalStoragePath, taskId), "claude_messages.json")
+		if (await fileExistsAtPath(oldPath)) {
+			const data = JSON.parse(await fs.readFile(oldPath, "utf8"))
+			await fs.unlink(oldPath) // remove old file
+			return data
+		}
 	}
 	return []
 }


### PR DESCRIPTION
### Description

Factor out get saved cline messages

### Test Procedure

<!-- How did you test this? Are you confident that it will not introduce bugs? If so, why? -->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [ ] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Refactor `Cline.ts` by moving message I/O functions to `messages-io.ts` for better code organization.
> 
>   - **Refactor**:
>     - Move `ensureTaskDirectoryExists`, `getSavedApiConversationHistory`, `getSavedClineMessages`, and `saveApiConversationHistory` from `Cline.ts` to `messages-io.ts`.
>     - Update `Cline` class in `Cline.ts` to use the refactored functions from `messages-io.ts`.
>   - **Misc**:
>     - Add three changeset files for patch updates.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for b3c71b0bd0624e56dce12a243ec374aed14576d7. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->