### PR TITLE
feat: add Full HD viewport preset and configurable browser settings

### DIFF
--- a/.changeset/stupid-bees-pretend.md
+++ b/.changeset/stupid-bees-pretend.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Added configurable browser viewport settings. Users can now select from predefined viewport presets including a new "Full HD (1920x1080)" option, or specify custom dimensions through VSCode settings.

--- a/package.json
+++ b/package.json
@@ -230,13 +230,15 @@
 					"default": 900,
 					"minimum": 320,
 					"maximum": 7680,
-					"description": "Custom width for browser viewport in pixels (only used when defaultBrowserViewport is set to 'Custom')."},
+					"description": "Custom width for browser viewport in pixels (only used when defaultBrowserViewport is set to 'Custom')."
+				},
 				"cline.defaultBrowserViewportHeight": {
 					"type": "number",
 					"default": 600,
 					"minimum": 240,
 					"maximum": 4320,
-					"description": "Custom height for browser viewport in pixels (only used when defaultBrowserViewport is set to 'Custom')."}
+					"description": "Custom height for browser viewport in pixels (only used when defaultBrowserViewport is set to 'Custom')."
+				}
 			}
 		}
 	},

--- a/package.json
+++ b/package.json
@@ -211,7 +211,32 @@
 					"type": "boolean",
 					"default": true,
 					"description": "Controls whether the MCP Marketplace is enabled."
-				}
+				},
+				"cline.defaultBrowserViewport": {
+					"type": "string",
+					"enum": [
+						"Full HD (1920x1080)",
+						"Large Desktop (1280x800)",
+						"Small Desktop (900x600)",
+						"Tablet (768x1024)",
+						"Mobile (360x640)",
+						"Custom"
+					],
+					"default": "Small Desktop (900x600)",
+					"description": "Default viewport size for browser sessions. Select 'Custom' to use custom dimensions."
+				},
+				"cline.defaultBrowserViewportWidth": {
+					"type": "number",
+					"default": 900,
+					"minimum": 320,
+					"maximum": 7680,
+					"description": "Custom width for browser viewport in pixels (only used when defaultBrowserViewport is set to 'Custom')."},
+				"cline.defaultBrowserViewportHeight": {
+					"type": "number",
+					"default": 600,
+					"minimum": 240,
+					"maximum": 4320,
+					"description": "Custom height for browser viewport in pixels (only used when defaultBrowserViewport is set to 'Custom')."}
 			}
 		}
 	},

--- a/src/shared/BrowserSettings.ts
+++ b/src/shared/BrowserSettings.ts
@@ -1,27 +1,89 @@
 export interface BrowserSettings {
-	// Viewport size settings
+	/**
+	 * Viewport size settings for the browser window
+	 */
 	viewport: {
 		width: number
 		height: number
 	}
-	// Browser mode settings
+	/**
+	 * Whether to run the browser in headless mode (no visible window)
+	 */
 	headless: boolean
-	// Chrome installation to use
-	// chromeType: "chromium" | "system"
 }
 
-export const DEFAULT_BROWSER_SETTINGS: BrowserSettings = {
-	viewport: {
-		width: 900,
-		height: 600,
-	},
-	headless: true,
-	// chromeType: "chromium",
-}
+// Import vscode to access configuration and the logger
+import * as vscode from "vscode"
+import { Logger } from "../services/logging/Logger"
 
+/**
+ * Available viewport size presets that users can select from settings
+ */
 export const BROWSER_VIEWPORT_PRESETS = {
+	"Full HD (1920x1080)": { width: 1920, height: 1080 },
 	"Large Desktop (1280x800)": { width: 1280, height: 800 },
 	"Small Desktop (900x600)": { width: 900, height: 600 },
 	"Tablet (768x1024)": { width: 768, height: 1024 },
 	"Mobile (360x640)": { width: 360, height: 640 },
 } as const
+
+/**
+ * Default viewport dimensions if no configuration is available
+ */
+const DEFAULT_VIEWPORT = { width: 900, height: 600 }
+
+/**
+ * Type guard to verify a string is a valid preset key
+ */
+export function isValidPreset(setting: string): setting is keyof typeof BROWSER_VIEWPORT_PRESETS {
+	return setting in BROWSER_VIEWPORT_PRESETS
+}
+
+/**
+ * Creates browser settings based on user configuration.
+ * Reads from VSCode configuration if available, otherwise uses defaults.
+ * @returns {BrowserSettings} Configured browser settings
+ */
+export function getConfiguredBrowserSettings(): BrowserSettings {
+	try {
+		const config = vscode.workspace.getConfiguration("cline")
+		const viewportSetting = config.get<string>("defaultBrowserViewport", "Small Desktop (900x600)")
+
+		let viewport = { ...DEFAULT_VIEWPORT }
+
+		if (viewportSetting === "Custom") {
+			// Use Custom dimensions from settings
+			viewport = {
+				width: config.get<number>("defaultBrowserViewportWidth", DEFAULT_VIEWPORT.width),
+				height: config.get<number>("defaultBrowserViewportHeight", DEFAULT_VIEWPORT.height),
+			}
+		} else if (viewportSetting && isValidPreset(viewportSetting)) {
+			// Use preset dimensions
+			const preset = BROWSER_VIEWPORT_PRESETS[viewportSetting]
+			viewport = {
+				width: preset.width,
+				height: preset.height,
+			}
+		}
+
+		return {
+			viewport,
+			headless: true,
+		}
+	} catch (e) {
+		// Log error to VSCode's output channel
+		Logger.log(`Failed to read browser settings from config: ${e instanceof Error ? e.message : String(e)}`)
+
+		// Fallback for tests or non-VSCode environments
+		return {
+			viewport: DEFAULT_VIEWPORT,
+			headless: true,
+		}
+	}
+}
+
+/**
+ * Browser settings initialized from configuration when the module is loaded.
+ * Used throughout the extension wherever browser settings are needed.
+ */
+export const DEFAULT_BROWSER_SETTINGS: BrowserSettings = getConfiguredBrowserSettings()


### PR DESCRIPTION
### Description
This PR enhances browser settings with user-configurable viewport options. It improves the existing browser configuration system by making viewport dimensions configurable through VSCode settings.

Key improvements:
- Added support for reading browser viewport settings from VSCode configuration
- Introduced a new "Full HD (1920x1080)" viewport preset
- Added custom viewport dimension support (users can specify exact width/height)
- Implemented validation and error handling for configuration values
- Added comprehensive JSDoc documentation to all browser settings components

These changes give users more control over browser sessions by allowing them to select from predefined viewport presets or set custom dimensions that better match their development needs.

### Test Procedure
I tested these changes by:
- Building out tests which are available at #2359

### Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📚 Documentation update

### Pre-flight Checklist
- [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
- [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`) - test failures observed are in the electron module, and occur with and without this change (addressed in #2351 )
- [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
- [x] I have reviewed [[contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots
N/A - Configuration enhancement

### Additional Notes
The changeset for this PR is:
```
Added configurable browser viewport settings. Users can now select from predefined viewport presets including a new "Full HD (1920x1080)" option, or specify custom dimensions through VSCode settings.
```

This enhancement makes browser sessions more flexible for users working on responsive designs or testing across different screen sizes.