### PR TITLE
fix: ChatSettings being synced between VSCode windows

### DIFF
--- a/.changeset/lovely-jars-check.md
+++ b/.changeset/lovely-jars-check.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Fix unwanted synchronization of "Act|Plan" toggle state across all VSCode instances

--- a/.changeset/nine-feet-attack.md
+++ b/.changeset/nine-feet-attack.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+fixes an issue with Azure API version detection in the OpenAI provider

--- a/.changeset/olive-apricots-help.md
+++ b/.changeset/olive-apricots-help.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": minor
+---
+
+Add size calculation to "Delete all Tasks" button

--- a/.changeset/sharp-hats-hug.md
+++ b/.changeset/sharp-hats-hug.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+SuccessButton to Tailwind

--- a/src/core/prompts/system.ts
+++ b/src/core/prompts/system.ts
@@ -280,33 +280,16 @@ Usage:
 <replace_in_file>
 <path>src/components/App.tsx</path>
 <diff>
-<<<<<<< SEARCH
 import React from 'react';
-=======
-import React, { useState } from 'react';
->>>>>>> REPLACE
 
-<<<<<<< SEARCH
 function handleSubmit() {
   saveData();
   setLoading(false);
 }
 
-=======
->>>>>>> REPLACE
-
-<<<<<<< SEARCH
-return (
-  <div>
-=======
-function handleSubmit() {
-  saveData();
-  setLoading(false);
-}
 
 return (
   <div>
->>>>>>> REPLACE
 </diff>
 </replace_in_file>
 ${

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -91,7 +91,6 @@ type GlobalStateKey =
 	| "openRouterModelInfo"
 	| "autoApprovalSettings"
 	| "browserSettings"
-	| "chatSettings"
 	| "vsCodeLmModelSelector"
 	| "userInfo"
 	| "previousModeApiProvider"
@@ -112,6 +111,7 @@ type GlobalStateKey =
 export const GlobalFileNames = {
 	apiConversationHistory: "api_conversation_history.json",
 	uiMessages: "ui_messages.json",
+	chatSettings: "ui_chat_settings.json",
 	openRouterModels: "openrouter_models.json",
 	mcpSettings: "cline_mcp_settings.json",
 	clineRules: ".clinerules",
@@ -128,6 +128,8 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 	mcpHub?: McpHub
 	private latestAnnouncementId = "feb-19-2025" // update to some unique identifier when we add a new announcement
 
+	private globalChatSettings: ChatSettings = DEFAULT_CHAT_SETTINGS
+
 	constructor(
 		readonly context: vscode.ExtensionContext,
 		private readonly outputChannel: vscode.OutputChannel,
@@ -141,6 +143,12 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 		cleanupLegacyCheckpoints(this.context.globalStorageUri.fsPath, this.outputChannel).catch((error) => {
 			console.error("Failed to cleanup legacy checkpoints:", error)
 		})
+	}
+
+	private getInitialChatSettings(): ChatSettings {
+		return {
+			...this.globalChatSettings, // carry over the state of the plan/act toggle into the new Cline instance
+		}
 	}
 
 	/*
@@ -282,8 +290,9 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 
 	async initClineWithTask(task?: string, images?: string[]) {
 		await this.clearTask() // ensures that an existing task doesn't exist before starting a new one, although this shouldn't be possible since user must clear task before starting a new one
-		const { apiConfiguration, customInstructions, autoApprovalSettings, browserSettings, chatSettings } =
-			await this.getState()
+		const { apiConfiguration, customInstructions, autoApprovalSettings, browserSettings } = await this.getState()
+
+		const chatSettings = this.getInitialChatSettings()
 		this.cline = new Cline(
 			this,
 			apiConfiguration,
@@ -298,8 +307,9 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 
 	async initClineWithHistoryItem(historyItem: HistoryItem) {
 		await this.clearTask()
-		const { apiConfiguration, customInstructions, autoApprovalSettings, browserSettings, chatSettings } =
-			await this.getState()
+		const { apiConfiguration, customInstructions, autoApprovalSettings, browserSettings } = await this.getState()
+
+		const chatSettings = this.getInitialChatSettings()
 		this.cline = new Cline(
 			this,
 			apiConfiguration,
@@ -1035,7 +1045,6 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 			}
 		}
 
-		await this.updateGlobalState("chatSettings", chatSettings)
 		await this.postStateToWebview()
 
 		if (this.cline) {
@@ -1053,6 +1062,9 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 				this.cancelTask()
 			}
 		}
+
+		// Independent of the cline instance: Always toggle the "global" state
+		this.globalChatSettings = chatSettings
 	}
 
 	async cancelTask() {
@@ -1846,7 +1858,6 @@ Here is the project's README to help you get started:\n\n${mcpDetails.readmeCont
 			taskHistory,
 			autoApprovalSettings,
 			browserSettings,
-			chatSettings,
 			userInfo,
 			mcpMarketplaceEnabled,
 			telemetrySetting,
@@ -1869,7 +1880,7 @@ Here is the project's README to help you get started:\n\n${mcpDetails.readmeCont
 			platform: process.platform as Platform,
 			autoApprovalSettings,
 			browserSettings,
-			chatSettings,
+			chatSettings: this.cline ? this.cline.getChatSettings() : this.getInitialChatSettings(),
 			userInfo,
 			mcpMarketplaceEnabled,
 			telemetrySetting,
@@ -1974,7 +1985,6 @@ Here is the project's README to help you get started:\n\n${mcpDetails.readmeCont
 			taskHistory,
 			autoApprovalSettings,
 			browserSettings,
-			chatSettings,
 			vsCodeLmModelSelector,
 			liteLlmBaseUrl,
 			liteLlmModelId,
@@ -2036,7 +2046,6 @@ Here is the project's README to help you get started:\n\n${mcpDetails.readmeCont
 			this.getGlobalState("taskHistory") as Promise<HistoryItem[] | undefined>,
 			this.getGlobalState("autoApprovalSettings") as Promise<AutoApprovalSettings | undefined>,
 			this.getGlobalState("browserSettings") as Promise<BrowserSettings | undefined>,
-			this.getGlobalState("chatSettings") as Promise<ChatSettings | undefined>,
 			this.getGlobalState("vsCodeLmModelSelector") as Promise<vscode.LanguageModelChatSelector | undefined>,
 			this.getGlobalState("liteLlmBaseUrl") as Promise<string | undefined>,
 			this.getGlobalState("liteLlmModelId") as Promise<string | undefined>,
@@ -2151,7 +2160,6 @@ Here is the project's README to help you get started:\n\n${mcpDetails.readmeCont
 			taskHistory,
 			autoApprovalSettings: autoApprovalSettings || DEFAULT_AUTO_APPROVAL_SETTINGS, // default value can be 0 or empty string
 			browserSettings: browserSettings || DEFAULT_BROWSER_SETTINGS,
-			chatSettings: chatSettings || DEFAULT_CHAT_SETTINGS,
 			userInfo,
 			previousModeApiProvider,
 			previousModeModelId,


### PR DESCRIPTION
### Description
Fixes #2122, where the toggle state of the "ACT|PLAN" button is synced between all open VSCode instances, which wreaks havoc if you have multiple chats ongoing and suddenly all of then switch to "Act" state, while you are still reviewing the plan.

**Note:** This introduce persisting the `ChatSettings` shapealongside the message history. Why? IMO it belongs into the same persistence bucket - and helped get rid of the last few "surprise" cases when re-opening/-loading a workspace.

### Test Procedure

- install the extension from file. Either
   - a) download this `vsix` (and drop the `.zip` suffix)
[cline-test-pr-2234-variant-b.vsix.zip](https://github.com/user-attachments/files/19349666/cline-test-pr-2234-variant-b.vsix.zip)
   - b) OR run `npm install -g vsce ovsx && vsce package --out "cline-test-pr-2234-variant-b.vsix"`
- open two VSCode windows in parallel
- start `cline` in both, and start a chat in both. Repeadetly toggle the "Act|Plan" button
- observe how the state of the toggle stays local to the window :heavy_check_mark: 
  - verify that the state does not change without reflecting in the UI: (F1 -> Developer: Reload Window") :heavy_check_mark: 
  - verify that you can toggle back-and-forth without any unexpected impact on either chat :heavy_check_mark: 

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes `ChatSettings` synchronization issue across VSCode instances by persisting settings locally per instance.
> 
>   - **Behavior**:
>     - Fixes synchronization of `ChatSettings` across VSCode instances by persisting settings locally in `Cline.ts` and `ClineProvider.ts`.
>     - Introduces `persistChatHistory()` in `Cline.ts` to save both messages and chat settings.
>     - Updates `togglePlanActModeWithChatSettings()` in `ClineProvider.ts` to manage global and instance-specific chat settings.
>   - **Functions**:
>     - Adds `getChatSettings()` and `saveChatSettings()` in `Cline.ts` for handling chat settings.
>     - Modifies `initClineWithTask()` and `initClineWithHistoryItem()` in `ClineProvider.ts` to initialize with local chat settings.
>   - **Misc**:
>     - Removes `chatSettings` from `GlobalStateKey` in `ClineProvider.ts`.
>     - Updates `GlobalFileNames` in `ClineProvider.ts` to include `chatSettings` file.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 4d416d797a266ad2b77e6e04cf374e3a40b67bb0. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->