### PR TITLE
Correct Calculation of Quarter Truncation

### DIFF
--- a/src/core/context-management/ContextManager.ts
+++ b/src/core/context-management/ContextManager.ts
@@ -12,11 +12,17 @@ export class ContextManager {
 
 		let messagesToRemove: number
 		if (keep === "half") {
-			// Remove half of user-assistant pairs
+			// Remove half of remaining user-assistant pairs
+			// We first calculate half of the messages then divide by 2 to get the number of pairs.
+			// After flooring, we multiply by 2 to get the number of messages.
+			// Note that this will also always be an even number.
 			messagesToRemove = Math.floor((messages.length - startOfRest) / 4) * 2 // Keep even number
 		} else {
-			// Remove 3/4 of user-assistant pairs
-			messagesToRemove = Math.floor((messages.length - startOfRest) / 8) * 3 * 2
+			// Remove 3/4 of remaining user-assistant pairs
+			// We calculate 3/4ths of the messages then divide by 2 to get the number of pairs.
+			// After flooring, we multiply by 2 to get the number of messages.
+			// Note that this will also always be an even number.
+			messagesToRemove = Math.floor(((messages.length - startOfRest) * 3) / 4 / 2) * 2
 		}
 
 		let rangeEndIndex = startOfRest + messagesToRemove - 1


### PR DESCRIPTION
### Description

Correct the calculation of getNextTruncationRange when the "quarter" option is passed.

Before it would incorrectly round messagesToRemove to zero when the messages.length was less than 8.

This is because of the premature flooring.

### Test Procedure

Logged [rangeStartIndex, rangeEndIndex] for message arrays with quarter truncation enabled. Before, this number wouldn't change when the messages were 5 or 7 in length. (Message arrays of 3 can't be truncated due to the limitation of keeping the first message and the need to remove user/assistant pairs).

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

### Additional Notes

<!-- Add any additional notes for reviewers -->
