### PR TITLE
Add ability to send context with an options selection

### DIFF
--- a/.changeset/rare-starfishes-design.md
+++ b/.changeset/rare-starfishes-design.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Allow user to send context with an option selection

--- a/webview-ui/src/components/chat/ChatRow.tsx
+++ b/webview-ui/src/components/chat/ChatRow.tsx
@@ -49,6 +49,7 @@ interface ChatRowProps {
 	lastModifiedMessage?: ClineMessage
 	isLast: boolean
 	onHeightChange: (isTaller: boolean) => void
+	inputValue?: string
 }
 
 interface ChatRowContentProps extends Omit<ChatRowProps, "onHeightChange"> {}
@@ -84,7 +85,7 @@ const Markdown = memo(({ markdown }: { markdown?: string }) => {
 
 const ChatRow = memo(
 	(props: ChatRowProps) => {
-		const { isLast, onHeightChange, message, lastModifiedMessage } = props
+		const { isLast, onHeightChange, message, lastModifiedMessage, inputValue } = props
 		// Store the previous height to compare with the current height
 		// This allows us to detect changes without causing re-renders
 		const prevHeightRef = useRef(0)
@@ -117,7 +118,14 @@ const ChatRow = memo(
 
 export default ChatRow
 
-export const ChatRowContent = ({ message, isExpanded, onToggleExpand, lastModifiedMessage, isLast }: ChatRowContentProps) => {
+export const ChatRowContent = ({
+	message,
+	isExpanded,
+	onToggleExpand,
+	lastModifiedMessage,
+	isLast,
+	inputValue,
+}: ChatRowContentProps) => {
 	const { mcpServers, mcpMarketplaceCatalog } = useExtensionState()
 	const [seeNewChangesDisabled, setSeeNewChangesDisabled] = useState(false)
 
@@ -1248,6 +1256,7 @@ export const ChatRowContent = ({ message, isExpanded, onToggleExpand, lastModifi
 									options={options}
 									selected={selected}
 									isActive={isLast && lastModifiedMessage?.ask === "followup"}
+									inputValue={inputValue}
 								/>
 							</div>
 						</>
@@ -1286,7 +1295,12 @@ export const ChatRowContent = ({ message, isExpanded, onToggleExpand, lastModifi
 							<OptionsButtons
 								options={options}
 								selected={selected}
+<<<<<<< HEAD
 								isActive={isLast && lastModifiedMessage?.ask === "plan_mode_respond"}
+=======
+								isActive={isLast && lastModifiedMessage?.ask === "plan_mode_response"}
+								inputValue={inputValue}
+>>>>>>> 31f8a323 (- add ability to send context with an options selection)
 							/>
 						</div>
 					)

--- a/webview-ui/src/components/chat/ChatRow.tsx
+++ b/webview-ui/src/components/chat/ChatRow.tsx
@@ -1295,12 +1295,8 @@ export const ChatRowContent = ({
 							<OptionsButtons
 								options={options}
 								selected={selected}
-<<<<<<< HEAD
 								isActive={isLast && lastModifiedMessage?.ask === "plan_mode_respond"}
-=======
-								isActive={isLast && lastModifiedMessage?.ask === "plan_mode_response"}
 								inputValue={inputValue}
->>>>>>> 31f8a323 (- add ability to send context with an options selection)
 							/>
 						</div>
 					)

--- a/webview-ui/src/components/chat/ChatView.tsx
+++ b/webview-ui/src/components/chat/ChatView.tsx
@@ -789,10 +789,11 @@ const ChatView = ({ isHidden, showAnnouncement, hideAnnouncement, showHistoryVie
 					lastModifiedMessage={modifiedMessages.at(-1)}
 					isLast={index === groupedMessages.length - 1}
 					onHeightChange={handleRowHeightChange}
+					inputValue={inputValue}
 				/>
 			)
 		},
-		[expandedRows, modifiedMessages, groupedMessages.length, toggleRowExpansion, handleRowHeightChange],
+		[expandedRows, modifiedMessages, groupedMessages.length, toggleRowExpansion, handleRowHeightChange, inputValue],
 	)
 
 	return (

--- a/webview-ui/src/components/chat/OptionsButtons.tsx
+++ b/webview-ui/src/components/chat/OptionsButtons.tsx
@@ -60,7 +60,7 @@ export const OptionsButtons = ({
 						}
 						vscode.postMessage({
 							type: "optionsResponse",
-							text: `${option}: ${inputValue?.trim()}`,
+							text: option + (inputValue ? `: ${inputValue?.trim()}` : ""),
 						})
 					}}>
 					{option}

--- a/webview-ui/src/components/chat/OptionsButtons.tsx
+++ b/webview-ui/src/components/chat/OptionsButtons.tsx
@@ -26,10 +26,12 @@ export const OptionsButtons = ({
 	options,
 	selected,
 	isActive,
+	inputValue,
 }: {
 	options?: string[]
 	selected?: string
 	isActive?: boolean
+	inputValue?: string
 }) => {
 	if (!options?.length) return null
 
@@ -58,7 +60,7 @@ export const OptionsButtons = ({
 						}
 						vscode.postMessage({
 							type: "optionsResponse",
-							text: option,
+							text: `${option}: ${inputValue?.trim()}`,
 						})
 					}}>
 					{option}

--- a/webview-ui/vite.config.ts
+++ b/webview-ui/vite.config.ts
@@ -18,7 +18,6 @@ export default defineConfig({
 	},
 	build: {
 		outDir: "build",
-		sourcemap: true,
 		rollupOptions: {
 			output: {
 				inlineDynamicImports: true,

--- a/webview-ui/vite.config.ts
+++ b/webview-ui/vite.config.ts
@@ -18,6 +18,7 @@ export default defineConfig({
 	},
 	build: {
 		outDir: "build",
+		sourcemap: true,
 		rollupOptions: {
 			output: {
 				inlineDynamicImports: true,


### PR DESCRIPTION
### Description

- Add ability to send context with an options selection
- Add sourcemaps for debugging in the webview

### Test Procedure

Test options selection with and without extra context

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [X] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [X] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [X] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [X] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [X] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<img width="579" alt="Screenshot 2025-03-21 at 5 20 57 PM" src="https://github.com/user-attachments/assets/0eed5e1e-51ae-4034-a7e3-8fc717f11787" />

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add `inputValue` prop to send context with options selection and enable sourcemaps for debugging.
> 
>   - **Feature**:
>     - Add `inputValue` prop to `ChatRow`, `ChatRowContent`, and `OptionsButtons` to send context with options selection.
>     - Modify `OptionsButtons` to append `inputValue` to selected option text in `OptionsButtons.tsx`.
>   - **Debugging**:
>     - Enable sourcemaps in `vite.config.ts` for better debugging in the webview.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for a25e384956d346a0a55d71cdb55ef3f8dd885e9e. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->