### PR TITLE
Store ChatSettings in WorkspaceState instead of globalState (#2122)

### DIFF
--- a/.changeset/lovely-jars-check.md
+++ b/.changeset/lovely-jars-check.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Fix unwanted synchronization of "Act|Plan" toggle state across all VSCode instances

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -97,7 +97,6 @@ type GlobalStateKey =
 	| "openRouterProviderSorting"
 	| "autoApprovalSettings"
 	| "browserSettings"
-	| "chatSettings"
 	| "vsCodeLmModelSelector"
 	| "userInfo"
 	| "previousModeApiProvider"
@@ -115,6 +114,8 @@ type GlobalStateKey =
 	| "asksageApiUrl"
 	| "thinkingBudgetTokens"
 	| "planActSeparateModelsSetting"
+
+type WorkspaceStateKey = "chatSettings"
 
 export class ClineProvider implements vscode.WebviewViewProvider {
 	public static readonly sideBarId = "claude-dev.SidebarProvider" // used in package.json as the view's id. This value cannot be changed due to how vscode caches views based on their id, and updating the id would break existing instances of the extension.
@@ -1062,7 +1063,7 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 			}
 		}
 
-		await this.updateGlobalState("chatSettings", chatSettings)
+		await this.updateWorkspaceState("chatSettings", chatSettings)
 		await this.postStateToWebview()
 
 		if (this.cline) {
@@ -2192,7 +2193,7 @@ Here is the project's README to help you get started:\n\n${mcpDetails.readmeCont
 			this.getGlobalState("taskHistory") as Promise<HistoryItem[] | undefined>,
 			this.getGlobalState("autoApprovalSettings") as Promise<AutoApprovalSettings | undefined>,
 			this.getGlobalState("browserSettings") as Promise<BrowserSettings | undefined>,
-			this.getGlobalState("chatSettings") as Promise<ChatSettings | undefined>,
+			this.getWorkspaceState("chatSettings") as Promise<ChatSettings | undefined>,
 			this.getGlobalState("vsCodeLmModelSelector") as Promise<vscode.LanguageModelChatSelector | undefined>,
 			this.getGlobalState("liteLlmBaseUrl") as Promise<string | undefined>,
 			this.getGlobalState("liteLlmModelId") as Promise<string | undefined>,
@@ -2346,11 +2347,11 @@ Here is the project's README to help you get started:\n\n${mcpDetails.readmeCont
 
 	// workspace
 
-	private async updateWorkspaceState(key: string, value: any) {
+	private async updateWorkspaceState(key: WorkspaceStateKey, value: any) {
 		await this.context.workspaceState.update(key, value)
 	}
 
-	private async getWorkspaceState(key: string) {
+	private async getWorkspaceState(key: WorkspaceStateKey) {
 		return await this.context.workspaceState.get(key)
 	}
 


### PR DESCRIPTION
### Description
Fixes #2122, where the toggle state of the "ACT|PLAN" button is synced between all open VSCode instances, which wreaks havoc if you have multiple chats ongoing and suddenly all of then switch to "Act" state, while you are still reviewing the plan.

### Test Procedure

- install the extension from file. Either
   - a) download this `vsix` (and drop the `.zip` suffix)
[cline-test-pr-2234-variant-b.vsix.zip](https://github.com/user-attachments/files/19486348/cline-test-pr-2234-variant-b.vsix.zip)



   - b) OR run `npm install -g vsce ovsx && vsce package --out "cline-test-pr-2234-variant-b.vsix"`
- open two VSCode windows in parallel
- start `cline` in both, and start a chat in both. Repeadetly toggle the "Act|Plan" button
- observe how the state of the toggle stays local to the window :heavy_check_mark: 
  - verify that the state does not change without reflecting in the UI: (F1 -> Developer: Reload Window") :heavy_check_mark: 
  - verify that you can toggle back-and-forth without any unexpected impact on either chat :heavy_check_mark: 

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

### Additional Notes

 - there was a previous attempt at #2234 that got closed accidentally

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Store `ChatSettings` in `WorkspaceState` to prevent "ACT|PLAN" toggle synchronization across VSCode instances.
> 
>   - **Behavior**:
>     - Store `ChatSettings` in `WorkspaceState` instead of `globalState` to prevent unwanted synchronization of "ACT|PLAN" toggle across VSCode instances.
>     - `ChatSettings` are now persisted alongside message history in `Cline.ts`.
>   - **Classes and Functions**:
>     - `Cline` class: Added `getChatSettings()` and `saveChatSettings()` methods.
>     - `ClineProvider` class: Modified `initClineWithTask()` and `initClineWithHistoryItem()` to use `getInitialChatSettings()`.
>   - **Constants**:
>     - Added `chatSettings` to `GlobalFileNames` in `global-constants.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 9584f28ca972427fd79b0df10114dc816dcddac0. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->