### PR TITLE
feat: add QwQ-32B model to SambaNova provider

### DIFF
--- a/.changeset/serious-spoons-knock.md
+++ b/.changeset/serious-spoons-knock.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": minor
+---
+
+Added support for SambaNova QwQ-32B model

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -1364,4 +1364,12 @@ export const sambanovaModels = {
 		inputPrice: 0,
 		outputPrice: 0,
 	},
+	"QwQ-32B": {
+		maxTokens: 4096,
+		contextWindow: 16_000,
+		supportsImages: false,
+		supportsPromptCache: false,
+		inputPrice: 0.5,
+		outputPrice: 1.0,
+	},
 } as const satisfies Record<string, ModelInfo>


### PR DESCRIPTION
### Description
- Added support for the QwQ-32B model to the SambaNova provider with appropriate pricing.

### Test Procedure
1. Select the SambaNova provider in the settings
2. Verify that QwQ-32B model appears in the model dropdown
3. Test connection to the model with a valid API key

This is an addition of a model to an already working provider, it's a small change that was easy to test with my SambaNova API Key (screenshot below)

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Changes
- Added QwQ-32B model to sambanovaModels in `src/shared/api.ts`
- Created changeset for minor version update

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots
![Code 2025-03-22 19 20 47](https://github.com/user-attachments/assets/afad38b2-fd6c-4c3d-bfb0-8de10d946b43)

### Additional Notes
None

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add QwQ-32B model to SambaNova provider with specific token limits and pricing in `src/shared/api.ts`.
> 
>   - **Behavior**:
>     - Added QwQ-32B model to `sambanovaModels` in `src/shared/api.ts` with max tokens 4096, context window 16000, input price 0.5, and output price 1.0.
>   - **Versioning**:
>     - Created changeset for minor version update in `.changeset/serious-spoons-knock.md`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 2ff87e53a9e106487418a80d857a57cc05ff9195. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->