### PR TITLE
#2272 fix 'see more' not showing up

### DIFF
--- a/.changeset/eleven-shirts-play.md
+++ b/.changeset/eleven-shirts-play.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Fix "See more" not showing up for tasks after task un-fold

--- a/webview-ui/src/components/chat/TaskHeader.tsx
+++ b/webview-ui/src/components/chat/TaskHeader.tsx
@@ -52,6 +52,13 @@ const TaskHeader: React.FC<TaskHeaderProps> = ({
 		}
 	}, [checkpointTrackerErrorMessage])
 
+	// Reset isTextExpanded when task is collapsed
+	useEffect(() => {
+		if (!isTaskExpanded) {
+			setIsTextExpanded(false)
+		}
+	}, [isTaskExpanded])
+
 	/*
 	When dealing with event listeners in React components that depend on state variables, we face a challenge. We want our listener to always use the most up-to-date version of a callback function that relies on current state, but we don't want to constantly add and remove event listeners as that function updates. This scenario often arises with resize listeners or other window events. Simply adding the listener in a useEffect with an empty dependency array risks using stale state, while including the callback in the dependencies can lead to unnecessary re-registrations of the listener. There are react hook libraries that provide a elegant solution to this problem by utilizing the useRef hook to maintain a reference to the latest callback function without triggering re-renders or effect re-runs. This approach ensures that our event listener always has access to the most current state while minimizing performance overhead and potential memory leaks from multiple listener registrations. 
 	Sources
@@ -95,17 +102,19 @@ const TaskHeader: React.FC<TaskHeaderProps> = ({
 
 	useEffect(() => {
 		if (isTaskExpanded && textRef.current && textContainerRef.current) {
-			let textContainerHeight = textContainerRef.current.clientHeight
-			if (!textContainerHeight) {
-				textContainerHeight = textContainerRef.current.getBoundingClientRect().height
-			}
-			const isOverflowing = textRef.current.scrollHeight > textContainerHeight
+			// Use requestAnimationFrame to ensure DOM is fully updated
+			requestAnimationFrame(() => {
+				// Check if refs are still valid
+				if (textRef.current && textContainerRef.current) {
+					let textContainerHeight = textContainerRef.current.clientHeight
+					if (!textContainerHeight) {
+						textContainerHeight = textContainerRef.current.getBoundingClientRect().height
+					}
+					const isOverflowing = textRef.current.scrollHeight > textContainerHeight
 
-			// necessary to show see more button again if user resizes window to expand and then back to collapse
-			if (!isOverflowing) {
-				setIsTextExpanded(false)
-			}
-			setShowSeeMore(isOverflowing)
+					setShowSeeMore(isOverflowing)
+				}
+			});
 		}
 	}, [task.text, windowWidth, isTaskExpanded])
 

--- a/webview-ui/src/components/chat/TaskHeader.tsx
+++ b/webview-ui/src/components/chat/TaskHeader.tsx
@@ -114,7 +114,7 @@ const TaskHeader: React.FC<TaskHeaderProps> = ({
 
 					setShowSeeMore(isOverflowing)
 				}
-			});
+			})
 		}
 	}, [task.text, windowWidth, isTaskExpanded])
 


### PR DESCRIPTION
### Description

Fixes bug #2273 

https://github.com/user-attachments/assets/87a9632a-00d9-4f05-b1d0-93f6edb5f51c

### Test Procedure

https://github.com/user-attachments/assets/8300599d-a046-43b6-aec9-139ad9966175

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes 'See more' button not showing after task expansion in `TaskHeader.tsx` by resetting `isTextExpanded` and using `requestAnimationFrame`.
> 
>   - **Behavior**:
>     - Fixes 'See more' button not showing after task expansion in `TaskHeader.tsx`.
>     - Resets `isTextExpanded` state when task is collapsed using `useEffect`.
>     - Uses `requestAnimationFrame` to ensure DOM updates before checking overflow.
>   - **Misc**:
>     - Adds changeset for patch release.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 0cf4fb59212b659a361297fd9eebeae75b1c5fc4. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->