### PR TITLE
Fix gpt-4.5-preview's supportsPromptCache value to true

### DIFF
--- a/.changeset/fresh-falcons-hang.md
+++ b/.changeset/fresh-falcons-hang.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Fix gpt-4.5-preview's supportsPromptCache value to true

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -582,7 +582,7 @@ export const openAiNativeModels = {
 		maxTokens: 16_384,
 		contextWindow: 128_000,
 		supportsImages: true,
-		supportsPromptCache: false,
+		supportsPromptCache: true,
 		inputPrice: 75,
 		outputPrice: 150,
 	},


### PR DESCRIPTION
### Description

The `supportsPromptCache` config of `gpt-4.5-preview` was wrong.

Reference:
- https://platform.openai.com/docs/models/gpt-4.5-preview

### Test Procedure

Set `API Provider` to `OpenAI` in Cline Settings, select model to `gpt-4.5-preview`, and should see "Supports prompt caching" instead of "Does not support prompt caching"

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)
