### PR TITLE
fix: can't open as image diagrams with non-Latin1 characters

### DIFF
--- a/.changeset/rich-stingrays-clean.md
+++ b/.changeset/rich-stingrays-clean.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+fix: open diagrams with non-Latin characters (Hebrew, Arabic etc.)

--- a/webview-ui/src/components/common/MermaidBlock.tsx
+++ b/webview-ui/src/components/common/MermaidBlock.tsx
@@ -174,7 +174,10 @@ async function svgToPng(svgEl: SVGElement): Promise<string> {
 
 	const serializer = new XMLSerializer()
 	const svgString = serializer.serializeToString(svgClone)
-	const svgDataUrl = "data:image/svg+xml;base64," + btoa(decodeURIComponent(encodeURIComponent(svgString)))
+	const encoder = new TextEncoder()
+	const bytes = encoder.encode(svgString)
+	const base64 = btoa(Array.from(bytes, (byte) => String.fromCharCode(byte)).join(""))
+	const svgDataUrl = `data:image/svg+xml;base64,${base64}`
 
 	return new Promise((resolve, reject) => {
 		const img = new Image()


### PR DESCRIPTION
### Description

<!-- Describe your changes in detail. What problem does this PR solve? -->
Currently, if the diagram contains text in a non-Latin1 language (such as Hebrew, Arabic, etc.), you cannot open the diagram, and the following error occurs:

```
Error converting SVG to PNG: InvalidCharacterError: Failed to execute 'btoa' on 'Window': The string to be encoded contains characters outside of the Latin1 range.
```

### Test Procedure

<!-- How did you test this? Are you confident that it will not introduce bugs? If so, why? -->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

https://github.com/user-attachments/assets/3946e08a-300f-46d2-aa67-5f9ae1199559

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes encoding issue in `MermaidBlock.tsx` to support diagrams with non-Latin1 characters.
> 
>   - **Bug Fix**:
>     - Fixes issue with opening diagrams containing non-Latin1 characters (e.g., Hebrew, Arabic) in `MermaidBlock.tsx`.
>     - Changes encoding method in `svgToPng()` to use `TextEncoder` for proper handling of non-Latin1 characters.
>   - **Misc**:
>     - Adds a changeset file `rich-stingrays-clean.md` to document the patch.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 45f2eb881574f7a77b4079d335698cb674a79fe5. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->