### PR TITLE
Add cost calculation support for LiteLLM provider

### DIFF
--- a/.changeset/purple-queens-teach.md
+++ b/.changeset/purple-queens-teach.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": minor
+---
+
+Add cost calculation support for LiteLLM provider


### PR DESCRIPTION
### Description

Currently the LiteLLM provider always shows `$0.00` for the cost. This pull request addresses this by calling the `/spend/calculate` endpoint with the `prompt_tokens` and `completion_tokens` for every usage object.

### Test Procedure

Tested by hand, made sure to fall back to `0` if there is an error calculating the cost.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

### Additional Notes

Similar to the openrouter provider I first try to get `chunk.usage.cost` and avoid doing a POST request to calculate the cost. Currently this is not implemented in LiteLLM, but I plan to send a pull request to support this.

I was not entirely sure if this requires a minor version bump, but happy to adjust.