### PR TITLE
feat: add isOpenAIR1FormatEnabled option for DeepSeek compatibility

### DIFF
--- a/.changeset/itchy-ravens-attend.md
+++ b/.changeset/itchy-ravens-attend.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+feat: add isR1FormatRequired option for DeepSeek compatibility

--- a/src/api/providers/openai.ts
+++ b/src/api/providers/openai.ts
@@ -34,6 +34,7 @@ export class OpenAiHandler implements ApiHandler {
 	async *createMessage(systemPrompt: string, messages: Anthropic.Messages.MessageParam[]): ApiStream {
 		const modelId = this.options.openAiModelId ?? ""
 		const isDeepseekReasoner = modelId.includes("deepseek-reasoner")
+		const isR1FormatRequired = this.options.openAiModelInfo?.isR1FormatRequired ?? false
 		const isO3Mini = modelId.includes("o3-mini")
 
 		let openAiMessages: OpenAI.Chat.ChatCompletionMessageParam[] = [
@@ -43,7 +44,7 @@ export class OpenAiHandler implements ApiHandler {
 		let temperature: number | undefined = this.options.openAiModelInfo?.temperature ?? openAiModelInfoSaneDefaults.temperature
 		let reasoningEffort: ChatCompletionReasoningEffort | undefined = undefined
 
-		if (isDeepseekReasoner) {
+		if (isDeepseekReasoner || isR1FormatRequired) {
 			openAiMessages = convertToR1Format([{ role: "user", content: systemPrompt }, ...messages])
 		}
 

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -93,6 +93,7 @@ export interface ModelInfo {
 
 export interface OpenAiCompatibleModelInfo extends ModelInfo {
 	temperature?: number
+	isR1FormatRequired?: boolean
 }
 
 // Anthropic
@@ -437,6 +438,7 @@ export const openAiModelInfoSaneDefaults: OpenAiCompatibleModelInfo = {
 	contextWindow: 128_000,
 	supportsImages: true,
 	supportsPromptCache: false,
+	isR1FormatRequired: false,
 	inputPrice: 0,
 	outputPrice: 0,
 	temperature: 0,

--- a/webview-ui/src/components/settings/ApiOptions.tsx
+++ b/webview-ui/src/components/settings/ApiOptions.tsx
@@ -846,6 +846,22 @@ const ApiOptions = ({ showModelOptions, apiErrorMessage, modelIdErrorMessage, is
 								}}>
 								Supports Computer Use
 							</VSCodeCheckbox>
+							<VSCodeCheckbox
+								checked={!!apiConfiguration?.openAiModelInfo?.isR1FormatRequired}
+								onChange={(e: any) => {
+									const isChecked = e.target.checked === true
+									let modelInfo = apiConfiguration?.openAiModelInfo
+										? apiConfiguration.openAiModelInfo
+										: { ...openAiModelInfoSaneDefaults }
+									modelInfo = { ...modelInfo, isR1FormatRequired: isChecked }
+
+									setApiConfiguration({
+										...apiConfiguration,
+										openAiModelInfo: modelInfo,
+									})
+								}}>
+								Enable R1 messages format
+							</VSCodeCheckbox>
 							<div style={{ display: "flex", gap: 10, marginTop: "5px" }}>
 								<VSCodeTextField
 									value={


### PR DESCRIPTION
### Description

When using an OpenAI-compatible provider, if the model name does not match deepseek-reasoner (e.g., deepseek-r1), the system does not function correctly. This prevents proper interaction with DeepSeek models. Additionally, support for QWQ models is missing.

### Test Procedure
Tested with local open ai compatible provider. The existing tests pass.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

![image](https://github.com/user-attachments/assets/1b09632d-462c-4b9d-8a80-8d79a4f6be30)

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `isR1FormatEnabled` option for DeepSeek compatibility, updating message format handling and UI configuration.
> 
>   - **Behavior**:
>     - Adds `isR1FormatEnabled` option in `openai.ts` to support DeepSeek models by converting messages to R1 format.
>     - Updates `ClineProvider.ts` to handle `openAiR1FormatEnabled` in global state.
>   - **UI**:
>     - Adds checkbox in `ApiOptions.tsx` to enable R1 message format for OpenAI-compatible providers.
>   - **Configuration**:
>     - Updates `ApiHandlerOptions` in `api.ts` to include `openAiR1FormatEnabled`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for f38af4ab65f9cde4152a5c8b9a9ce8265e6db7cb. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->