### PR TITLE
Fix vs code lm plan/act toggle issue #2400

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [3.8.1]
+
+-   Fix bug where switching to plan/act would result in VS Code LM provider model ID being reset
+
 ## [3.8.0]
 
 -   Add 'Add to Cline' as an option when you right-click in a file or the terminal, making it easier to add context to your current task

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "claude-dev",
 	"displayName": "Cline",
 	"description": "Autonomous coding agent right in your IDE, capable of creating/editing files, running commands, using the browser, and more with your permission every step of the way.",
-	"version": "3.8.0",
+	"version": "3.8.1",
 	"icon": "assets/icons/icon.png",
 	"engines": {
 		"vscode": "^1.84.0"

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -2285,8 +2285,7 @@ Here is the project's README to help you get started:\n\n${mcpDetails.readmeCont
 				qwenApiLine,
 				mistralApiKey,
 				azureApiVersion,
-				// Fixes bug where switching to plan/act would result in setting this model id to previousModeModelId which may have been a non-string value by default, causing a type error in the webview when calling .toLowerCase() on it.
-				openRouterModelId: openRouterModelId ? String(openRouterModelId) : undefined,
+				openRouterModelId,
 				openRouterModelInfo,
 				openRouterProviderSorting,
 				vsCodeLmModelSelector,
@@ -2308,7 +2307,7 @@ Here is the project's README to help you get started:\n\n${mcpDetails.readmeCont
 			chatSettings: chatSettings || DEFAULT_CHAT_SETTINGS,
 			userInfo,
 			previousModeApiProvider,
-			previousModeModelId: previousModeModelId ? String(previousModeModelId) : undefined,
+			previousModeModelId,
 			previousModeModelInfo,
 			previousModeThinkingBudgetTokens,
 			mcpMarketplaceEnabled,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes VS Code LM provider model ID reset issue when toggling plan/act modes in `ClineProvider.ts`.
> 
>   - **Behavior**:
>     - Fixes bug in `ClineProvider.ts` where switching to plan/act mode reset VS Code LM provider model ID.
>     - Removes unnecessary `String()` conversion for `openRouterModelId` and `previousModeModelId`.
>   - **Versioning**:
>     - Updates version to 3.8.1 in `package.json`.
>     - Adds changelog entry for version 3.8.1 in `CHANGELOG.md`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 9d4a1874099ffdf088c7b9ab2098f7167a52a494. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->