### PR TITLE
Patch/openai comp max tokens

### DIFF
--- a/.changeset/happy-seals-tickle.md
+++ b/.changeset/happy-seals-tickle.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Using Max Output Tokens that was set by the UI

--- a/src/api/providers/openai.ts
+++ b/src/api/providers/openai.ts
@@ -42,10 +42,11 @@ export class OpenAiHandler implements ApiHandler {
 		]
 		let temperature: number | undefined = this.options.openAiModelInfo?.temperature ?? openAiModelInfoSaneDefaults.temperature
 		let reasoningEffort: ChatCompletionReasoningEffort | undefined = undefined
-		let maxTokens: number | undefined =
-			Number(this.options.openAiModelInfo?.maxTokens) ?? openAiModelInfoSaneDefaults.maxTokens
+		let maxTokens: number | undefined
 
-		if (typeof maxTokens === "number" && maxTokens < 0) {
+		if (this.options.openAiModelInfo?.maxTokens && this.options.openAiModelInfo.maxTokens > 0) {
+			maxTokens = Number(this.options.openAiModelInfo.maxTokens)
+		} else {
 			maxTokens = undefined
 		}
 

--- a/src/api/providers/openai.ts
+++ b/src/api/providers/openai.ts
@@ -45,6 +45,10 @@ export class OpenAiHandler implements ApiHandler {
 		let maxTokens: number | undefined =
 			Number(this.options.openAiModelInfo?.maxTokens) ?? openAiModelInfoSaneDefaults.maxTokens
 
+		if (typeof maxTokens === "number" && maxTokens < 0) {
+			maxTokens = undefined
+		}
+
 		if (isDeepseekReasoner) {
 			openAiMessages = convertToR1Format([{ role: "user", content: systemPrompt }, ...messages])
 		}

--- a/src/api/providers/openai.ts
+++ b/src/api/providers/openai.ts
@@ -42,6 +42,8 @@ export class OpenAiHandler implements ApiHandler {
 		]
 		let temperature: number | undefined = this.options.openAiModelInfo?.temperature ?? openAiModelInfoSaneDefaults.temperature
 		let reasoningEffort: ChatCompletionReasoningEffort | undefined = undefined
+		let maxTokens: number | undefined =
+			Number(this.options.openAiModelInfo?.maxTokens) ?? openAiModelInfoSaneDefaults.maxTokens
 
 		if (isDeepseekReasoner) {
 			openAiMessages = convertToR1Format([{ role: "user", content: systemPrompt }, ...messages])
@@ -57,6 +59,7 @@ export class OpenAiHandler implements ApiHandler {
 			model: modelId,
 			messages: openAiMessages,
 			temperature,
+			max_tokens: maxTokens,
 			reasoning_effort: reasoningEffort,
 			stream: true,
 			stream_options: { include_usage: true },


### PR DESCRIPTION
### Description

This PR addresses the bug for OpenAI Compatible servers that was ignoring the `Max Ouput Tokens` that was set on UI.

### Test Procedure

Tested with on-prem LLM deployments and OpenAI-cloud endpoints.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes bug in `OpenAiHandler` to respect `Max Output Tokens` set in UI by setting `max_tokens` in API calls.
> 
>   - **Behavior**:
>     - Fixes bug in `OpenAiHandler` in `openai.ts` to respect `Max Output Tokens` set in UI.
>     - Sets `max_tokens` parameter in `createMessage()` based on `openAiModelInfo?.maxTokens`.
>     - Ignores negative `maxTokens` values by setting them to `undefined`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 8556545d52f15b4d0615ce45835787bcb520dbf5. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->