### PR TITLE
fix: Also skip html escaping fix for gemini-2.x models

### DIFF
--- a/.changeset/fresh-melons-scream.md
+++ b/.changeset/fresh-melons-scream.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Also bypass HTML escaping for gemini-2.0 models

--- a/src/core/Cline.ts
+++ b/src/core/Cline.ts
@@ -50,7 +50,7 @@ import { ClineAskResponse, ClineCheckpointRestore } from "../shared/WebviewMessa
 import { calculateApiCostAnthropic } from "../utils/cost"
 import { fileExistsAtPath, isDirectory } from "../utils/fs"
 import { arePathsEqual, getReadablePath } from "../utils/path"
-import { fixModelHtmlEscaping, removeInvalidChars } from "../utils/string"
+import { fixModelHtmlEscaping, removeInvalidChars, shouldFixModelHtmlEscaping } from "../utils/string"
 import { AssistantMessageContent, parseAssistantMessage, ToolParamName, ToolUseName } from "./assistant-message"
 import { constructNewFileContent } from "./assistant-message/diff"
 import { ClineIgnoreController, LOCK_TEXT_SYMBOL } from "./ignore/ClineIgnoreController"
@@ -1748,10 +1748,7 @@ export class Cline {
 							// Construct newContent from diff
 							let newContent: string
 							if (diff) {
-								if (
-									!this.api.getModel().id.includes("claude") &&
-									!this.api.getModel().id.includes("gemini-2.0")
-								) {
+								if (shouldFixModelHtmlEscaping(this.api.getModel())) {
 									// deepseek models tend to use unescaped html entities in diffs
 									diff = fixModelHtmlEscaping(diff)
 									diff = removeInvalidChars(diff)
@@ -1796,10 +1793,7 @@ export class Cline {
 									newContent = newContent.split("\n").slice(0, -1).join("\n").trim()
 								}
 
-								if (
-									!this.api.getModel().id.includes("claude") &&
-									!this.api.getModel().id.includes("gemini-2.0")
-								) {
+								if (shouldFixModelHtmlEscaping(this.api.getModel())) {
 									// it seems not just llama models are doing this, but also gemini and potentially others
 									newContent = fixModelHtmlEscaping(newContent)
 									newContent = removeInvalidChars(newContent)

--- a/src/core/Cline.ts
+++ b/src/core/Cline.ts
@@ -1748,7 +1748,10 @@ export class Cline {
 							// Construct newContent from diff
 							let newContent: string
 							if (diff) {
-								if (!this.api.getModel().id.includes("claude")) {
+								if (
+									!this.api.getModel().id.includes("claude") &&
+									!this.api.getModel().id.includes("gemini-2.0")
+								) {
 									// deepseek models tend to use unescaped html entities in diffs
 									diff = fixModelHtmlEscaping(diff)
 									diff = removeInvalidChars(diff)
@@ -1793,7 +1796,10 @@ export class Cline {
 									newContent = newContent.split("\n").slice(0, -1).join("\n").trim()
 								}
 
-								if (!this.api.getModel().id.includes("claude")) {
+								if (
+									!this.api.getModel().id.includes("claude") &&
+									!this.api.getModel().id.includes("gemini-2.0")
+								) {
 									// it seems not just llama models are doing this, but also gemini and potentially others
 									newContent = fixModelHtmlEscaping(newContent)
 									newContent = removeInvalidChars(newContent)

--- a/src/utils/string.ts
+++ b/src/utils/string.ts
@@ -20,3 +20,13 @@ export function fixModelHtmlEscaping(text: string): string {
 export function removeInvalidChars(text: string): string {
 	return text.replace(/\uFFFD/g, "")
 }
+
+/**
+ * Determines if a model's output should be fixed for HTML escaping issues
+ * @param model Model object containing the model ID
+ * @returns Boolean indicating if the model's output should be fixed
+ */
+export function shouldFixModelHtmlEscaping(model: { id: string }): boolean {
+	const id = model.id.toLowerCase()
+	return id.includes("claude") || id.includes("gemini-2.")
+}


### PR DESCRIPTION
### Description
Rel: https://github.com/cline/cline/issues/611

When working with gemini in ``xml`` files (in my case wix toolset) code like this:
```xml
<Launch Condition="Installed OR NETCORESTATUS=&quot;0&quot;"
	Message="[ProductName] requires Microsoft .NET Core - 8.0.0 or greater." />
```
constantly gets escaped to this:
```xml
<Launch Condition="Installed OR NETCORESTATUS="0""
	Message="[ProductName] requires Microsoft .NET Core - 8.0.0 or greater." />
```

The model is aware of this, as soon as it reloads the document it just saved but it really cant do much (other than be frustrated - lol)


### Test Procedure
I have tested it for my use case in editing two Xml files successfully which Gemini was unable to edit before the change.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [X] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [X] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [X] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`) ([Here](https://github.com/JKamsker/cline/actions/runs/14066221657))
-   [X] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [X] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots
None

### Additional Notes

<!-- Add any additional notes for reviewers -->
This pull request includes changes to handle HTML escaping for the `gemini-2.0` model in addition to the existing `claude` model. The changes involve code updates.

### Handling HTML escaping for `gemini-2.0` model:

* [`.changeset/fresh-melons-scream.md`](diffhunk://#diff-a4af4929b73e2b0b80c6d9b61208a3d005ceb799a4048b07d64408592b5de750R1-R5): Added a patch note to document the bypassing of HTML escaping for `gemini-2.0` models.

* [`src/core/Cline.ts`](diffhunk://#diff-b44efde712fc6775a6ce117b0de8ef3c0c3376689c98f7a9fca7ea91d40fe0f5L1751-R1754): Updated the conditions to include `gemini-2.0` models along with `claude` models for bypassing HTML escaping and removing invalid characters. [[1]](diffhunk://#diff-b44efde712fc6775a6ce117b0de8ef3c0c3376689c98f7a9fca7ea91d40fe0f5L1751-R1754) [[2]](diffhunk://#diff-b44efde712fc6775a6ce117b0de8ef3c0c3376689c98f7a9fca7ea91d40fe0f5L1796-R1802)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update HTML escaping logic to include 'gemini-2.0' models in `Cline.ts`.
> 
>   - **Behavior**:
>     - Update HTML escaping logic in `Cline.ts` to include `gemini-2.0` models alongside `claude` models for bypassing HTML escaping and removing invalid characters.
>   - **Documentation**:
>     - Add patch note in `.changeset/fresh-melons-scream.md` to document the bypassing of HTML escaping for `gemini-2.0` models.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 2513f53fcafc71872be23691b502d1dff28d90c3. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->