### PR TITLE
Context manager tests

### DIFF
--- a/src/core/context-management/ContextManager.test.ts
+++ b/src/core/context-management/ContextManager.test.ts
@@ -3,17 +3,14 @@ import { Anthropic } from "@anthropic-ai/sdk"
 import { expect } from "chai"
 
 describe("ContextManager", () => {
-	// Helper function to create an array of alternating user-assistant messages
 	function createMessages(count: number): Anthropic.Messages.MessageParam[] {
 		const messages: Anthropic.Messages.MessageParam[] = []
 
-		// First message is always system/user task message
 		messages.push({
 			role: "user",
 			content: "Initial task message",
 		})
 
-		// Create alternating user-assistant messages
 		let role: "user" | "assistant" = "assistant"
 		for (let i = 1; i < count; i++) {
 			messages.push({
@@ -37,7 +34,6 @@ describe("ContextManager", () => {
 			const messages = createMessages(11)
 			const result = contextManager.getNextTruncationRange(messages)
 
-			// Expected to remove indices 1-4
 			expect(result).to.deep.equal([1, 4])
 		})
 
@@ -45,7 +41,6 @@ describe("ContextManager", () => {
 			const messages = createMessages(11)
 			const result = contextManager.getNextTruncationRange(messages, undefined, "quarter")
 
-			// Expected to remove indices 1-6
 			expect(result).to.deep.equal([1, 6])
 		})
 
@@ -144,7 +139,6 @@ describe("ContextManager", () => {
 		it("correctly handles removing a range while preserving alternation pattern", () => {
 			const messages = createMessages(5)
 
-			// This preserves the user-assistant-user alternation
 			const range: [number, number] = [1, 2]
 			const result = contextManager.getTruncatedMessages(messages, range)
 
@@ -153,7 +147,6 @@ describe("ContextManager", () => {
 			expect(result[1]).to.deep.equal(messages[3])
 			expect(result[2]).to.deep.equal(messages[4])
 
-			// Verify alternating pattern is maintained
 			expect(result[0].role).to.equal("user")
 			expect(result[1].role).to.equal("assistant")
 			expect(result[2].role).to.equal("user")

--- a/src/core/context-management/ContextManager.test.ts
+++ b/src/core/context-management/ContextManager.test.ts
@@ -1,0 +1,162 @@
+import { ContextManager } from "./ContextManager"
+import { Anthropic } from "@anthropic-ai/sdk"
+import { expect } from "chai"
+
+describe("ContextManager", () => {
+	// Helper function to create an array of alternating user-assistant messages
+	function createMessages(count: number): Anthropic.Messages.MessageParam[] {
+		const messages: Anthropic.Messages.MessageParam[] = []
+
+		// First message is always system/user task message
+		messages.push({
+			role: "user",
+			content: "Initial task message",
+		})
+
+		// Create alternating user-assistant messages
+		let role: "user" | "assistant" = "assistant"
+		for (let i = 1; i < count; i++) {
+			messages.push({
+				role,
+				content: `Message ${i}`,
+			})
+			role = role === "user" ? "assistant" : "user"
+		}
+
+		return messages
+	}
+
+	describe("getNextTruncationRange", () => {
+		let contextManager: ContextManager
+
+		beforeEach(() => {
+			contextManager = new ContextManager()
+		})
+
+		it("first truncation with half keep", () => {
+			const messages = createMessages(11)
+			const result = contextManager.getNextTruncationRange(messages)
+
+			// Expected to remove indices 1-4
+			expect(result).to.deep.equal([1, 4])
+		})
+
+		it("first truncation with quarter keep", () => {
+			const messages = createMessages(11)
+			const result = contextManager.getNextTruncationRange(messages, undefined, "quarter")
+
+			// Expected to remove indices 1-6
+			expect(result).to.deep.equal([1, 6])
+		})
+
+		it("sequential truncation with half keep", () => {
+			const messages = createMessages(21)
+			const firstRange = contextManager.getNextTruncationRange(messages)
+			expect(firstRange).to.deep.equal([1, 10])
+
+			// Pass the previous range for sequential truncation
+			const secondRange = contextManager.getNextTruncationRange(messages, firstRange)
+			expect(secondRange).to.deep.equal([1, 14])
+		})
+
+		it("sequential truncation with quarter keep", () => {
+			const messages = createMessages(41)
+			const firstRange = contextManager.getNextTruncationRange(messages, undefined, "quarter")
+
+			const secondRange = contextManager.getNextTruncationRange(messages, firstRange, "quarter")
+
+			expect(secondRange[0]).to.equal(1)
+			expect(secondRange[1]).to.be.greaterThan(firstRange[1])
+		})
+
+		it("ensures the last message in range is a user message", () => {
+			const messages = createMessages(14)
+			const result = contextManager.getNextTruncationRange(messages)
+
+			// Check if the message at the end of range is a user message
+			const lastRemovedMessage = messages[result[1]]
+			expect(lastRemovedMessage.role).to.equal("user")
+
+			// Check if the next message after the range is an assistant message
+			const nextMessage = messages[result[1] + 1]
+			expect(nextMessage.role).to.equal("assistant")
+		})
+
+		it("handles small message arrays", () => {
+			const messages = createMessages(3)
+			const result = contextManager.getNextTruncationRange(messages)
+
+			expect(result).to.deep.equal([1, 0])
+		})
+
+		it("preserves the message structure when truncating", () => {
+			const messages = createMessages(20)
+			const result = contextManager.getNextTruncationRange(messages)
+
+			// Get messages after removing the range
+			const effectiveMessages = [...messages.slice(0, result[0]), ...messages.slice(result[1] + 1)]
+
+			// Check first message and alternating pattern
+			expect(effectiveMessages[0].role).to.equal("user")
+			for (let i = 1; i < effectiveMessages.length; i++) {
+				const expectedRole = i % 2 === 1 ? "assistant" : "user"
+				expect(effectiveMessages[i].role).to.equal(expectedRole)
+			}
+		})
+	})
+
+	describe("getTruncatedMessages", () => {
+		let contextManager: ContextManager
+
+		beforeEach(() => {
+			contextManager = new ContextManager()
+		})
+
+		it("returns original messages when no range is provided", () => {
+			const messages = createMessages(3)
+
+			const result = contextManager.getTruncatedMessages(messages, undefined)
+			expect(result).to.deep.equal(messages)
+		})
+
+		it("correctly removes messages in the specified range", () => {
+			const messages = createMessages(5)
+
+			const range: [number, number] = [1, 3]
+			const result = contextManager.getTruncatedMessages(messages, range)
+
+			expect(result).to.have.lengthOf(2)
+			expect(result[0]).to.deep.equal(messages[0])
+			expect(result[1]).to.deep.equal(messages[4])
+		})
+
+		it("works with a range that starts at the first message after task", () => {
+			const messages = createMessages(4)
+
+			const range: [number, number] = [1, 2]
+			const result = contextManager.getTruncatedMessages(messages, range)
+
+			expect(result).to.have.lengthOf(2)
+			expect(result[0]).to.deep.equal(messages[0])
+			expect(result[1]).to.deep.equal(messages[3])
+		})
+
+		it("correctly handles removing a range while preserving alternation pattern", () => {
+			const messages = createMessages(5)
+
+			// This preserves the user-assistant-user alternation
+			const range: [number, number] = [1, 2]
+			const result = contextManager.getTruncatedMessages(messages, range)
+
+			expect(result).to.have.lengthOf(3)
+			expect(result[0]).to.deep.equal(messages[0])
+			expect(result[1]).to.deep.equal(messages[3])
+			expect(result[2]).to.deep.equal(messages[4])
+
+			// Verify alternating pattern is maintained
+			expect(result[0].role).to.equal("user")
+			expect(result[1].role).to.equal("assistant")
+			expect(result[2].role).to.equal("user")
+		})
+	})
+})

--- a/src/core/context-management/ContextManager.test.ts
+++ b/src/core/context-management/ContextManager.test.ts
@@ -32,7 +32,7 @@ describe("ContextManager", () => {
 
 		it("first truncation with half keep", () => {
 			const messages = createMessages(11)
-			const result = contextManager.getNextTruncationRange(messages)
+			const result = contextManager.getNextTruncationRange(messages, undefined, "half")
 
 			expect(result).to.deep.equal([1, 4])
 		})
@@ -46,11 +46,11 @@ describe("ContextManager", () => {
 
 		it("sequential truncation with half keep", () => {
 			const messages = createMessages(21)
-			const firstRange = contextManager.getNextTruncationRange(messages)
+			const firstRange = contextManager.getNextTruncationRange(messages, undefined, "half")
 			expect(firstRange).to.deep.equal([1, 10])
 
 			// Pass the previous range for sequential truncation
-			const secondRange = contextManager.getNextTruncationRange(messages, firstRange)
+			const secondRange = contextManager.getNextTruncationRange(messages, firstRange, "half")
 			expect(secondRange).to.deep.equal([1, 14])
 		})
 
@@ -66,7 +66,7 @@ describe("ContextManager", () => {
 
 		it("ensures the last message in range is a user message", () => {
 			const messages = createMessages(14)
-			const result = contextManager.getNextTruncationRange(messages)
+			const result = contextManager.getNextTruncationRange(messages, undefined, "half")
 
 			// Check if the message at the end of range is a user message
 			const lastRemovedMessage = messages[result[1]]
@@ -79,14 +79,14 @@ describe("ContextManager", () => {
 
 		it("handles small message arrays", () => {
 			const messages = createMessages(3)
-			const result = contextManager.getNextTruncationRange(messages)
+			const result = contextManager.getNextTruncationRange(messages, undefined, "half")
 
 			expect(result).to.deep.equal([1, 0])
 		})
 
 		it("preserves the message structure when truncating", () => {
 			const messages = createMessages(20)
-			const result = contextManager.getNextTruncationRange(messages)
+			const result = contextManager.getNextTruncationRange(messages, undefined, "half")
 
 			// Get messages after removing the range
 			const effectiveMessages = [...messages.slice(0, result[0]), ...messages.slice(result[1] + 1)]


### PR DESCRIPTION
### Description

<!-- Describe your changes in detail. What problem does this PR solve? -->

### Test Procedure

<!-- How did you test this? Are you confident that it will not introduce bugs? If so, why? -->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [ ] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add tests for `ContextManager` class focusing on truncation methods and message handling.
> 
>   - **Tests**:
>     - Add `ContextManager.test.ts` to test `ContextManager` class.
>     - Test `getNextTruncationRange()` for first and sequential truncations with both "half" and "quarter" keep strategies.
>     - Ensure last message in truncation range is a user message and handle small message arrays.
>     - Test `getTruncatedMessages()` for correct message removal and preservation of alternation pattern.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 28fefa67ef2336d82d217594dae7d205b4c75362. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->