### PR TITLE
SSE Schema and Types

### DIFF
--- a/.changeset/odd-feet-battle.md
+++ b/.changeset/odd-feet-battle.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": minor
+---
+
+Added types and schemas for SSE transport MCP connections


### PR DESCRIPTION
### Description

Adding types and zod schema for 

### Test Procedure

Tested that existing MCP server connections still work by calling the sequential thinking server with the new build.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add types and schemas for SSE transport in MCP connections, updating `McpHub.ts` to support and validate new configurations.
> 
>   - **Types and Schemas**:
>     - Add `McpTransportType` and `McpServerConfig` types in `McpHub.ts` to support "stdio" and "sse" transport types.
>     - Define `SseConfigSchema` using `zod` for SSE-specific configurations, including `url`, `headers`, and `withCredentials`.
>     - Update `ServerConfigSchema` to use a discriminated union for "stdio" and "sse" configurations.
>   - **Integration**:
>     - Modify `McpSettingsSchema` to use `ServerConfigSchema` for `mcpServers`.
>     - Ensure existing MCP server connections remain functional with new configurations.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for f7b6d378a15982c474139ac87cddae0bdeca8eb5. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->