### PR TITLE
Detect and display chrome path as placeholder in settings

### DIFF
--- a/.changeset/serious-hornets-behave.md
+++ b/.changeset/serious-hornets-behave.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Added feature to detect installed versions of chromium and display them as a placeholder if not already explicitly configured by the user

--- a/package.json
+++ b/package.json
@@ -346,6 +346,7 @@
 		"axios": "^1.8.2",
 		"cheerio": "^1.0.0",
 		"chokidar": "^4.0.1",
+		"chrome-launcher": "^1.1.2",
 		"clone-deep": "^4.0.1",
 		"default-shell": "^2.2.0",
 		"diff": "^5.2.0",

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -1043,6 +1043,21 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 						this.postMessageToWebview({ type: "relinquishControl" })
 						break
 					}
+					case "getDetectedChromePath": {
+						try {
+							const { browserSettings } = await this.getState()
+							const browserSession = new BrowserSession(this.context, browserSettings)
+							const { path, isBundled } = await browserSession.getDetectedChromePath()
+							await this.postMessageToWebview({
+								type: "detectedChromePath",
+								text: path,
+								isBundled,
+							})
+						} catch (error) {
+							console.error("Error getting detected Chrome path:", error)
+						}
+						break
+					}
 					// Add more switch case statements here as more webview message commands
 					// are created within the webview context (i.e. inside media/main.js)
 				}

--- a/src/shared/ExtensionMessage.ts
+++ b/src/shared/ExtensionMessage.ts
@@ -41,6 +41,7 @@ export interface ExtensionMessage {
 		| "totalTasksSize"
 		| "addToInput"
 		| "browserConnectionResult"
+		| "detectedChromePath"
 	text?: string
 	action?:
 		| "chatButtonClicked"
@@ -83,6 +84,7 @@ export interface ExtensionMessage {
 	totalTasksSize?: number | null
 	success?: boolean
 	values?: Record<string, any>
+	isBundled?: boolean
 }
 
 export type Invoke = "sendMessage" | "primaryButtonClick" | "secondaryButtonClick"

--- a/src/shared/WebviewMessage.ts
+++ b/src/shared/WebviewMessage.ts
@@ -70,6 +70,8 @@ export interface WebviewMessage {
 		| "fetchUserCreditsData"
 		| "optionsResponse"
 		| "requestTotalTasksSize"
+		| "getDetectedChromePath"
+		| "detectedChromePath"
 	// | "relaunchChromeDebugMode"
 	text?: string
 	disabled?: boolean


### PR DESCRIPTION
### Description

This change adds a feature to detect and display the path to the chrome executable as a placeholder in the "Chrome Executable Path" setting. If Chrome is installed, the path will be displayed as the placeholder but not applied as the setting value. If Chrome is not installed, the placeholder will indicate that the bundled Chromium is being used instead.

### Test Procedure

Remove/uninstall Chrome and open Cline's settings, the placeholder should say "(Using bundled Chromium)". Install Chrome, the placeholder should now have the path to Chrome. Unless the path is actually entered by the user, it will continue to use the bundled version.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [X] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [X] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [X] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [X] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [X] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds feature to detect and display Chrome executable path as a placeholder in settings, using `chrome-launcher` and falling back to bundled Chromium if necessary.
> 
>   - **Behavior**:
>     - Detects Chrome executable path using `chrome-launcher` in `BrowserSession.ts`.
>     - Displays detected path as a placeholder in `BrowserSettingsSection.tsx`.
>     - Falls back to bundled Chromium if Chrome is not found.
>   - **Integration**:
>     - Adds `chrome-launcher` dependency in `package.json`.
>     - Handles `getDetectedChromePath` message in `ClineProvider.ts` to communicate with webview.
>   - **UI**:
>     - Updates `BrowserSettingsSection.tsx` to show placeholder based on detected path or bundled status.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for f915f2d26b36cf711797e6cd59db1ce65fa73c73. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->