### PR TITLE
re-enabling conversation observability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "claude-dev",
-	"version": "3.8.0",
+	"version": "3.8.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "claude-dev",
-			"version": "3.8.0",
+			"version": "3.8.2",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@anthropic-ai/bedrock-sdk": "^0.12.4",

--- a/package.json
+++ b/package.json
@@ -262,7 +262,7 @@
 					"default": true,
 					"description": "Controls whether the MCP Marketplace is enabled."
 				},
-				"cline.conversationTelemetry": {
+				"cline.conversationObservability": {
 					"type": "boolean",
 					"default": false,
 					"markdownDescription": "Share message data, code, and more extensive telemetry. This data may be used to improve prompts used in Cline, train models, and understand failure states more accurately. [Learn more](https://docs.cline.bot/more-info/llm-observability)"

--- a/package.json
+++ b/package.json
@@ -265,7 +265,7 @@
 				"cline.conversationObservability": {
 					"type": "boolean",
 					"default": false,
-					"markdownDescription": "Share message data, code, and more extensive observability. This data may be used to improve prompts used in Cline, train models, and understand failure states more accurately. [Learn more](https://docs.cline.bot/more-info/llm-observability)"
+					"markdownDescription": "Share message data, code, and more extensive observability. This data may be used to improve prompts used in Cline, train models, and understand failure states more accurately. [Learn more](https://docs.cline.bot/more-info/conversation-observability)"
 				}
 			}
 		}

--- a/package.json
+++ b/package.json
@@ -265,7 +265,7 @@
 				"cline.conversationObservability": {
 					"type": "boolean",
 					"default": false,
-					"markdownDescription": "Share message data, code, and more extensive telemetry. This data may be used to improve prompts used in Cline, train models, and understand failure states more accurately. [Learn more](https://docs.cline.bot/more-info/llm-observability)"
+					"markdownDescription": "Share message data, code, and more extensive observability. This data may be used to improve prompts used in Cline, train models, and understand failure states more accurately. [Learn more](https://docs.cline.bot/more-info/llm-observability)"
 				}
 			}
 		}

--- a/package.json
+++ b/package.json
@@ -261,6 +261,11 @@
 					"type": "boolean",
 					"default": true,
 					"description": "Controls whether the MCP Marketplace is enabled."
+				},
+				"cline.conversationTelemetry": {
+					"type": "boolean",
+					"default": false,
+					"markdownDescription": "Share message data, code, and more extensive telemetry. This data may be used to improve prompts used in Cline, train models, and understand failure states more accurately. [Learn more](https://docs.cline.bot/more-info/llm-observability)"
 				}
 			}
 		}

--- a/src/core/Cline.ts
+++ b/src/core/Cline.ts
@@ -64,7 +64,7 @@ import { ClineHandler } from "../api/providers/cline"
 import { ClineProvider } from "./webview/ClineProvider"
 import { DEFAULT_LANGUAGE_SETTINGS, getLanguageKey, LanguageDisplay, LanguageKey } from "../shared/Languages"
 import { telemetryService } from "../services/telemetry/TelemetryService"
-import { ConversationTelemetryService, TelemetryChatMessage } from "../services/telemetry/ConversationTelemetryService"
+import { ConversationObservabilityService, TelemetryChatMessage } from "../services/telemetry/ConversationObservabilityService"
 import pTimeout from "p-timeout"
 import { GlobalFileNames } from "../global-constants"
 import {
@@ -1357,7 +1357,7 @@ export class Cline {
 
 		// Capture system prompt for telemetry,
 		// ONLY if user is opted in, in advanced settings
-		if (this.providerRef.deref()?.conversationTelemetryService.isOptedInToConversationTelemetry()) {
+		if (this.providerRef.deref()?.conversationObservabilityService.isOptedInToConversationTelemetry()) {
 			const systemMessage: TelemetryChatMessage = {
 				role: "system",
 				content: systemPrompt,
@@ -1365,7 +1365,7 @@ export class Cline {
 			}
 
 			// no need for timeout here, as there's no timestamp to compare to
-			this.providerRef.deref()?.conversationTelemetryService.captureMessage(this.taskId, systemMessage, {
+			this.providerRef.deref()?.conversationObservabilityService.captureMessage(this.taskId, systemMessage, {
 				apiProvider: this.apiProvider,
 				model: this.api.getModel().id,
 				tokensIn: 0,
@@ -3192,7 +3192,7 @@ export class Cline {
 
 		// Capture message data for telemetry,
 		// ONLY if user is opted in, in advanced settings
-		if (this.providerRef.deref()?.conversationTelemetryService.isOptedInToConversationTelemetry()) {
+		if (this.providerRef.deref()?.conversationObservabilityService.isOptedInToConversationTelemetry()) {
 			// Get the last message from apiConversationHistory
 			const lastMessage = this.apiConversationHistory[this.apiConversationHistory.length - 1]
 
@@ -3203,7 +3203,7 @@ export class Cline {
 			const ts = lastClineMessage.ts
 
 			// Send individual message to telemetry
-			this.providerRef.deref()?.conversationTelemetryService.captureMessage(
+			this.providerRef.deref()?.conversationObservabilityService.captureMessage(
 				this.taskId,
 				// Add the timestamp to the message object for telemetry
 				{
@@ -3220,7 +3220,7 @@ export class Cline {
 
 			// Send entire conversation history to cleanup endpoint
 			// This ensures deleted messages are properly handled in telemetry
-			this.providerRef.deref()?.conversationTelemetryService.cleanupTask(this.taskId, this.clineMessages)
+			this.providerRef.deref()?.conversationObservabilityService.cleanupTask(this.taskId, this.clineMessages)
 		}
 
 		// since we sent off a placeholder api_req_started message to update the webview while waiting to actually start the API request (to load potential details for example), we need to update the text of that message
@@ -3302,7 +3302,7 @@ export class Cline {
 
 				// Capture message data for telemetry after assistant response
 				// ONLY if user is opted in, in advanced settings
-				if (this.providerRef.deref()?.conversationTelemetryService.isOptedInToConversationTelemetry()) {
+				if (this.providerRef.deref()?.conversationObservabilityService.isOptedInToConversationTelemetry()) {
 					// Get the last message from apiConversationHistory
 					const lastMessage = this.apiConversationHistory[this.apiConversationHistory.length - 1]
 
@@ -3314,7 +3314,7 @@ export class Cline {
 					if (!lastTextMessage) {
 						console.error("No text message found in clineMessages")
 					} else {
-						this.providerRef.deref()?.conversationTelemetryService.captureMessage(
+						this.providerRef.deref()?.conversationObservabilityService.captureMessage(
 							this.taskId,
 							{
 								...lastMessage,
@@ -3481,7 +3481,7 @@ export class Cline {
 
 				// Capture message data for telemetry after assistant response,
 				// ONLY if user is opted in, in advanced settings
-				if (this.providerRef.deref()?.conversationTelemetryService.isOptedInToConversationTelemetry()) {
+				if (this.providerRef.deref()?.conversationObservabilityService.isOptedInToConversationTelemetry()) {
 					// Get the last message from apiConversationHistory
 					const lastMessage = this.apiConversationHistory[this.apiConversationHistory.length - 1]
 
@@ -3489,7 +3489,7 @@ export class Cline {
 					const lastClineMessage = this.clineMessages[this.clineMessages.length - 1]
 
 					if (lastClineMessage) {
-						this.providerRef.deref()?.conversationTelemetryService.captureMessage(
+						this.providerRef.deref()?.conversationObservabilityService.captureMessage(
 							this.taskId,
 							{
 								...lastMessage,

--- a/src/core/Cline.ts
+++ b/src/core/Cline.ts
@@ -1357,7 +1357,7 @@ export class Cline {
 
 		// Capture system prompt for telemetry,
 		// ONLY if user is opted in, in advanced settings
-		if (this.providerRef.deref()?.conversationObservabilityService.isOptedInToConversationTelemetry()) {
+		if (this.providerRef.deref()?.conversationObservabilityService.isOptedInToConversationObservability()) {
 			const systemMessage: TelemetryChatMessage = {
 				role: "system",
 				content: systemPrompt,
@@ -3192,7 +3192,7 @@ export class Cline {
 
 		// Capture message data for telemetry,
 		// ONLY if user is opted in, in advanced settings
-		if (this.providerRef.deref()?.conversationObservabilityService.isOptedInToConversationTelemetry()) {
+		if (this.providerRef.deref()?.conversationObservabilityService.isOptedInToConversationObservability()) {
 			// Get the last message from apiConversationHistory
 			const lastMessage = this.apiConversationHistory[this.apiConversationHistory.length - 1]
 
@@ -3302,7 +3302,7 @@ export class Cline {
 
 				// Capture message data for telemetry after assistant response
 				// ONLY if user is opted in, in advanced settings
-				if (this.providerRef.deref()?.conversationObservabilityService.isOptedInToConversationTelemetry()) {
+				if (this.providerRef.deref()?.conversationObservabilityService.isOptedInToConversationObservability()) {
 					// Get the last message from apiConversationHistory
 					const lastMessage = this.apiConversationHistory[this.apiConversationHistory.length - 1]
 
@@ -3481,7 +3481,7 @@ export class Cline {
 
 				// Capture message data for telemetry after assistant response,
 				// ONLY if user is opted in, in advanced settings
-				if (this.providerRef.deref()?.conversationObservabilityService.isOptedInToConversationTelemetry()) {
+				if (this.providerRef.deref()?.conversationObservabilityService.isOptedInToConversationObservability()) {
 					// Get the last message from apiConversationHistory
 					const lastMessage = this.apiConversationHistory[this.apiConversationHistory.length - 1]
 

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -38,7 +38,7 @@ import { TelemetrySetting } from "../../shared/TelemetrySetting"
 import { cleanupLegacyCheckpoints } from "../../integrations/checkpoints/CheckpointMigration"
 import CheckpointTracker from "../../integrations/checkpoints/CheckpointTracker"
 import { getTotalTasksSize } from "../../utils/storage"
-import { ConversationTelemetryService } from "../../services/telemetry/ConversationTelemetryService"
+import { ConversationObservabilityService } from "../../services/telemetry/ConversationObservabilityService"
 import { GlobalFileNames } from "../../global-constants"
 import { setTimeout as setTimeoutPromise } from "node:timers/promises"
 
@@ -127,7 +127,7 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 	mcpHub?: McpHub
 	accountService?: ClineAccountService
 	private latestAnnouncementId = "march-22-2025" // update to some unique identifier when we add a new announcement
-	conversationTelemetryService: ConversationTelemetryService
+	conversationObservabilityService: ConversationObservabilityService
 
 	constructor(
 		readonly context: vscode.ExtensionContext,
@@ -138,7 +138,7 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 		this.workspaceTracker = new WorkspaceTracker(this)
 		this.mcpHub = new McpHub(this)
 		this.accountService = new ClineAccountService(this)
-		this.conversationTelemetryService = new ConversationTelemetryService(this)
+		this.conversationObservabilityService = new ConversationObservabilityService(this)
 
 		// Clean up legacy checkpoints
 		cleanupLegacyCheckpoints(this.context.globalStorageUri.fsPath, this.outputChannel).catch((error) => {
@@ -170,7 +170,7 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 		this.mcpHub?.dispose()
 		this.mcpHub = undefined
 		this.accountService = undefined
-		this.conversationTelemetryService.shutdown()
+		this.conversationObservabilityService.shutdown()
 		this.outputChannel.appendLine("Disposed all disposables")
 		ClineProvider.activeInstances.delete(this)
 	}

--- a/src/services/telemetry/ConversationObservabilityService.ts
+++ b/src/services/telemetry/ConversationObservabilityService.ts
@@ -26,14 +26,14 @@ Cline Telemetry (currently only available in DEV builds)
 
 Advanced Setting to opt-in to LLM observability, allowing you to share message data, code, and more extensive telemetry to help improve prompts used in Cline, train our models, and understand failure states more accurately.
 
-"cline.conversationTelemetry": {
+"cline.conversationObservability": {
 	"type": "boolean",
 	"default": false,
 	"markdownDescription": "Share message data, code, and more extensive telemetry. This data may be used to improve prompts used in Cline, train models, and understand failure states more accurately. [Learn more](https://docs.cline.bot/more-info/llm-observability)"
 }
  */
 
-export class ConversationTelemetryService {
+export class ConversationObservabilityService {
 	private providerRef: WeakRef<ClineProvider>
 	private distinctId: string = vscode.env.machineId
 	private apiEndpoint: string = "https://api.cline.bot/v1/traces"
@@ -61,7 +61,7 @@ export class ConversationTelemetryService {
 
 		// User has to manually opt in to conversation telemetry in Advanced Settings
 		const isConversationTelemetryEnabled =
-			vscode.workspace.getConfiguration("cline").get<boolean>("conversationTelemetry") ?? false
+			vscode.workspace.getConfiguration("cline").get<boolean>("conversationObservability") ?? false
 
 		return isGlobalTelemetryEnabled && isConversationTelemetryEnabled
 	}

--- a/src/services/telemetry/ConversationObservabilityService.ts
+++ b/src/services/telemetry/ConversationObservabilityService.ts
@@ -54,16 +54,12 @@ export class ConversationObservabilityService {
 		return apiConfiguration?.clineApiKey
 	}
 
-	public isOptedInToConversationTelemetry(): boolean {
-		// First check global telemetry level - telemetry should only be enabled when level is "all"
-		const telemetryLevel = vscode.workspace.getConfiguration("telemetry").get<string>("telemetryLevel", "all")
-		const isGlobalTelemetryEnabled = telemetryLevel === "all"
-
+	public isOptedInToConversationObservability(): boolean {
 		// User has to manually opt in to conversation telemetry in Advanced Settings
-		const isConversationTelemetryEnabled =
+		const isConversationObservabilityEnabled =
 			vscode.workspace.getConfiguration("cline").get<boolean>("conversationObservability") ?? false
 
-		return isGlobalTelemetryEnabled && isConversationTelemetryEnabled
+		return isConversationObservabilityEnabled
 	}
 
 	private async initializeTracer() {
@@ -76,7 +72,7 @@ export class ConversationObservabilityService {
 
 			const clineApiKey = await this.getClineApiKey()
 
-			console.log("[ConversationTelemetry] Initializing OpenTelemetry tracer...")
+			console.info("[ConversationObservability] Initializing OpenTelemetry tracer...")
 
 			// Configure the OTLP exporter
 			const headers: Record<string, string> = {
@@ -108,9 +104,9 @@ export class ConversationObservabilityService {
 			// Get a tracer
 			this.tracer = trace.getTracer("cline-conversation-tracer")
 
-			console.log("[ConversationTelemetry] OpenTelemetry tracer initialized successfully")
+			console.info("[ConversationObservability] OpenTelemetry tracer initialized successfully")
 		} catch (error) {
-			console.error("[ConversationTelemetry] Failed to initialize OpenTelemetry tracer:", error)
+			console.error("[ConversationObservability] Failed to initialize OpenTelemetry tracer:", error)
 		}
 	}
 
@@ -120,7 +116,7 @@ export class ConversationObservabilityService {
 	 */
 	public async captureMessage(taskId: string, message: TelemetryChatMessage, metadata: ConversationMetadata) {
 		// Do NOT capture message if user has not explicitly opted in
-		if (!this.isOptedInToConversationTelemetry()) {
+		if (!this.isOptedInToConversationObservability()) {
 			return
 		}
 
@@ -190,9 +186,9 @@ export class ConversationObservabilityService {
 			// End the span immediately since messages are discrete events
 			span.end(this.millisecondsToHrTime(timestamp)) // Convert to nanoseconds
 
-			console.log(`[ConversationTelemetry] Captured ${message.role} message for task ${taskId}`, { span })
+			console.info(`[ConversationObservability] Captured ${message.role} message for task ${taskId}`, { span })
 		} catch (error) {
-			console.error("[ConversationTelemetry] Error capturing message:", error)
+			console.error("[ConversationObservability] Error capturing message:", error)
 		}
 	}
 
@@ -254,7 +250,7 @@ export class ConversationObservabilityService {
 	 */
 	public async cleanupTask(taskId: string, conversationData: any): Promise<void> {
 		// Do NOT send data if user has not explicitly opted in
-		if (!this.isOptedInToConversationTelemetry()) {
+		if (!this.isOptedInToConversationObservability()) {
 			return
 		}
 
@@ -290,9 +286,9 @@ export class ConversationObservabilityService {
 				throw new Error(`Failed to send cleanup data: ${response.status} ${response.statusText}`)
 			}
 
-			console.log(`[ConversationTelemetry] Cleanup data sent for task ${taskId}`)
+			console.info(`[ConversationObservability] Cleanup data sent for task ${taskId}`)
 		} catch (error) {
-			console.error("[ConversationTelemetry] Error sending cleanup data:", error)
+			console.error("[ConversationObservability] Error sending cleanup data:", error)
 		}
 	}
 

--- a/src/services/telemetry/ConversationTelemetryService.ts
+++ b/src/services/telemetry/ConversationTelemetryService.ts
@@ -21,8 +21,6 @@ interface ConversationMetadata {
 	tokensOut: number
 }
 
-const { IS_DEV } = process.env
-
 /**
 Cline Telemetry (currently only available in DEV builds)
 
@@ -65,10 +63,7 @@ export class ConversationTelemetryService {
 		const isConversationTelemetryEnabled =
 			vscode.workspace.getConfiguration("cline").get<boolean>("conversationTelemetry") ?? false
 
-		// Currently only enabled in dev environment
-		const isDevEnvironment = !!IS_DEV
-
-		return isDevEnvironment && isGlobalTelemetryEnabled && isConversationTelemetryEnabled
+		return isGlobalTelemetryEnabled && isConversationTelemetryEnabled
 	}
 
 	private async initializeTracer() {


### PR DESCRIPTION
### Description

<!-- Describe your changes in detail. What problem does this PR solve? -->

### Test Procedure

<!-- How did you test this? Are you confident that it will not introduce bugs? If so, why? -->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Re-enables conversation observability by introducing `cline.conversationObservability` setting and updating telemetry services to `ConversationObservabilityService`.
> 
>   - **Behavior**:
>     - Introduces `cline.conversationObservability` setting in `package.json` to enable sharing of message data and telemetry.
>     - Updates `Cline.ts` to use `ConversationObservabilityService` for capturing and cleaning up telemetry data.
>   - **Services**:
>     - Renames `ConversationTelemetryService` to `ConversationObservabilityService`.
>     - Updates methods in `ConversationObservabilityService.ts` to handle telemetry data with OpenTelemetry.
>   - **Classes**:
>     - Updates `ClineProvider` to use `ConversationObservabilityService` for telemetry operations.
>   - **Misc**:
>     - Updates import paths and references from `ConversationTelemetryService` to `ConversationObservabilityService` in `Cline.ts` and `ClineProvider.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for c615d3eb5668cc1342dfa87c8ff768f0c427e2f9. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->