### PR TITLE
Fix for headless browser option

### DIFF
--- a/.changeset/swift-frogs-learn.md
+++ b/.changeset/swift-frogs-learn.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Fix for headless browser mode

--- a/src/services/browser/BrowserSession.ts
+++ b/src/services/browser/BrowserSession.ts
@@ -96,10 +96,16 @@ export class BrowserSession {
 			// Kill any existing Chrome instances
 			await chromeLauncher.killAll()
 
+			const chromeFlags = ["--remote-debugging-port=" + DEBUG_PORT, "--no-first-run", "--no-default-browser-check"]
+
+			if (this.browserSettings.headless) {
+				chromeFlags.push("--headless")
+			}
+
 			// Launch Chrome with debug port
 			const launcher = new chromeLauncher.Launcher({
 				port: DEBUG_PORT,
-				chromeFlags: ["--remote-debugging-port=" + DEBUG_PORT, "--no-first-run", "--no-default-browser-check"],
+				chromeFlags: chromeFlags,
 			})
 
 			await launcher.launch()
@@ -112,7 +118,7 @@ export class BrowserSession {
 			webview?.postMessage({
 				type: "browserRelaunchResult",
 				success: true,
-				text: "Browser successfully launched in debug mode",
+				text: `Browser successfully launched in debug mode${this.browserSettings.headless ? " (headless)" : ""}`,
 			})
 		} catch (error) {
 			webview?.postMessage({
@@ -154,7 +160,7 @@ export class BrowserSession {
 			],
 			executablePath: path,
 			defaultViewport: this.browserSettings.viewport,
-			headless: this.browserSettings.headless,
+			headless: this.browserSettings.headless ? "shell" : false,
 		})
 	}
 


### PR DESCRIPTION
### Description

This change corrects an issue with the headless option in the browser feature.

For local browser launches with Puppeteer, we changed to use the newer Puppeteer v23+ method which requires 'shell' instead of 'true' for the more performant headless implementation.

For remote browser launches with chrome-launcher, we changed --headless=new to the standard --headless flag which is more widely supported by the chrome-launcher library and ensures Chrome properly launches in headless mode when that setting is enabled.

### Test Procedure

Launch the browser using the test button with headless mode enabled and confirm it launches headless. Test the browser tool call to ensure functionality in headless mode for both local and remote launches.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [X] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [X] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [X] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [X] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [X] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes headless browser mode for local and remote launches in `BrowserSession.ts` by updating Puppeteer and chrome-launcher configurations.
> 
>   - **Behavior**:
>     - Fixes headless mode for local launches in `launchLocalBrowser()` by using Puppeteer's 'shell' option.
>     - Fixes headless mode for remote launches in `relaunchChromeDebugMode()` by using `--headless` flag.
>   - **Code Changes**:
>     - Updates `launchLocalBrowser()` to set `headless: 'shell'`.
>     - Updates `relaunchChromeDebugMode()` to include `--headless` in `chromeFlags` if headless is enabled.
>     - Updates success message in `relaunchChromeDebugMode()` to indicate headless mode.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 5733c13247eb3431fe26ac2a8b7cffa3d61280d2. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->