### PR TITLE
start of info panel popover

### DIFF
--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -592,6 +592,39 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 						}
 						await this.postStateToWebview()
 						break
+					case "getBrowserConnectionInfo":
+						try {
+							// Get the current browser session from Cline if it exists
+							if (this.cline?.browserSession) {
+								const connectionInfo = this.cline.browserSession.getConnectionInfo();
+								await this.postMessageToWebview({
+									type: "browserConnectionInfo",
+									isConnected: connectionInfo.isConnected,
+									isRemote: connectionInfo.isRemote,
+									host: connectionInfo.host,
+									isHeadless: connectionInfo.isHeadless
+								});
+							} else {
+								// If no active browser session, just return the settings
+								const { browserSettings } = await this.getState();
+								await this.postMessageToWebview({
+									type: "browserConnectionInfo",
+									isConnected: false,
+									isRemote: !!browserSettings.remoteBrowserEnabled,
+									host: browserSettings.remoteBrowserHost,
+									isHeadless: !!browserSettings.headless
+								});
+							}
+						} catch (error) {
+							console.error("Error getting browser connection info:", error);
+							await this.postMessageToWebview({
+								type: "browserConnectionInfo",
+								isConnected: false,
+								isRemote: false,
+								isHeadless: true
+							});
+						}
+						break;
 					case "testBrowserConnection":
 						try {
 							const { browserSettings } = await this.getState()
@@ -1049,6 +1082,40 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 						this.refreshTotalTasksSize()
 						this.postMessageToWebview({ type: "relinquishControl" })
 						break
+					}
+					case "getBrowserConnectionInfo": {
+						try {
+							// Get the current browser session from Cline if it exists
+							if (this.cline?.browserSession) {
+								const connectionInfo = this.cline.browserSession.getConnectionInfo();
+								await this.postMessageToWebview({
+									type: "browserConnectionInfo",
+									isConnected: connectionInfo.isConnected,
+									isRemote: connectionInfo.isRemote,
+									host: connectionInfo.host,
+									isHeadless: connectionInfo.isHeadless
+								});
+							} else {
+								// If no active browser session, just return the settings
+								const { browserSettings } = await this.getState();
+								await this.postMessageToWebview({
+									type: "browserConnectionInfo",
+									isConnected: false,
+									isRemote: !!browserSettings.remoteBrowserEnabled,
+									host: browserSettings.remoteBrowserHost,
+									isHeadless: !!browserSettings.headless
+								});
+							}
+						} catch (error) {
+							console.error("Error getting browser connection info:", error);
+							await this.postMessageToWebview({
+								type: "browserConnectionInfo",
+								isConnected: false,
+								isRemote: false,
+								isHeadless: true
+							});
+						}
+						break;
 					}
 					case "getDetectedChromePath": {
 						try {

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -596,35 +596,35 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 						try {
 							// Get the current browser session from Cline if it exists
 							if (this.cline?.browserSession) {
-								const connectionInfo = this.cline.browserSession.getConnectionInfo();
+								const connectionInfo = this.cline.browserSession.getConnectionInfo()
 								await this.postMessageToWebview({
 									type: "browserConnectionInfo",
 									isConnected: connectionInfo.isConnected,
 									isRemote: connectionInfo.isRemote,
 									host: connectionInfo.host,
-									isHeadless: connectionInfo.isHeadless
-								});
+									isHeadless: connectionInfo.isHeadless,
+								})
 							} else {
 								// If no active browser session, just return the settings
-								const { browserSettings } = await this.getState();
+								const { browserSettings } = await this.getState()
 								await this.postMessageToWebview({
 									type: "browserConnectionInfo",
 									isConnected: false,
 									isRemote: !!browserSettings.remoteBrowserEnabled,
 									host: browserSettings.remoteBrowserHost,
-									isHeadless: !!browserSettings.headless
-								});
+									isHeadless: !!browserSettings.headless,
+								})
 							}
 						} catch (error) {
-							console.error("Error getting browser connection info:", error);
+							console.error("Error getting browser connection info:", error)
 							await this.postMessageToWebview({
 								type: "browserConnectionInfo",
 								isConnected: false,
 								isRemote: false,
-								isHeadless: true
-							});
+								isHeadless: true,
+							})
 						}
-						break;
+						break
 					case "testBrowserConnection":
 						try {
 							const { browserSettings } = await this.getState()
@@ -1082,40 +1082,6 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 						this.refreshTotalTasksSize()
 						this.postMessageToWebview({ type: "relinquishControl" })
 						break
-					}
-					case "getBrowserConnectionInfo": {
-						try {
-							// Get the current browser session from Cline if it exists
-							if (this.cline?.browserSession) {
-								const connectionInfo = this.cline.browserSession.getConnectionInfo();
-								await this.postMessageToWebview({
-									type: "browserConnectionInfo",
-									isConnected: connectionInfo.isConnected,
-									isRemote: connectionInfo.isRemote,
-									host: connectionInfo.host,
-									isHeadless: connectionInfo.isHeadless
-								});
-							} else {
-								// If no active browser session, just return the settings
-								const { browserSettings } = await this.getState();
-								await this.postMessageToWebview({
-									type: "browserConnectionInfo",
-									isConnected: false,
-									isRemote: !!browserSettings.remoteBrowserEnabled,
-									host: browserSettings.remoteBrowserHost,
-									isHeadless: !!browserSettings.headless
-								});
-							}
-						} catch (error) {
-							console.error("Error getting browser connection info:", error);
-							await this.postMessageToWebview({
-								type: "browserConnectionInfo",
-								isConnected: false,
-								isRemote: false,
-								isHeadless: true
-							});
-						}
-						break;
 					}
 					case "getDetectedChromePath": {
 						try {

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -596,35 +596,35 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 						try {
 							// Get the current browser session from Cline if it exists
 							if (this.cline?.browserSession) {
-								const connectionInfo = this.cline.browserSession.getConnectionInfo()
+								const connectionInfo = this.cline.browserSession.getConnectionInfo();
 								await this.postMessageToWebview({
 									type: "browserConnectionInfo",
 									isConnected: connectionInfo.isConnected,
 									isRemote: connectionInfo.isRemote,
 									host: connectionInfo.host,
-									isHeadless: connectionInfo.isHeadless,
-								})
+									isHeadless: connectionInfo.isHeadless
+								});
 							} else {
 								// If no active browser session, just return the settings
-								const { browserSettings } = await this.getState()
+								const { browserSettings } = await this.getState();
 								await this.postMessageToWebview({
 									type: "browserConnectionInfo",
 									isConnected: false,
 									isRemote: !!browserSettings.remoteBrowserEnabled,
 									host: browserSettings.remoteBrowserHost,
-									isHeadless: !!browserSettings.headless,
-								})
+									isHeadless: !!browserSettings.headless
+								});
 							}
 						} catch (error) {
-							console.error("Error getting browser connection info:", error)
+							console.error("Error getting browser connection info:", error);
 							await this.postMessageToWebview({
 								type: "browserConnectionInfo",
 								isConnected: false,
 								isRemote: false,
-								isHeadless: true,
-							})
+								isHeadless: true
+							});
 						}
-						break
+						break;
 					case "testBrowserConnection":
 						try {
 							const { browserSettings } = await this.getState()
@@ -1082,6 +1082,40 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 						this.refreshTotalTasksSize()
 						this.postMessageToWebview({ type: "relinquishControl" })
 						break
+					}
+					case "getBrowserConnectionInfo": {
+						try {
+							// Get the current browser session from Cline if it exists
+							if (this.cline?.browserSession) {
+								const connectionInfo = this.cline.browserSession.getConnectionInfo();
+								await this.postMessageToWebview({
+									type: "browserConnectionInfo",
+									isConnected: connectionInfo.isConnected,
+									isRemote: connectionInfo.isRemote,
+									host: connectionInfo.host,
+									isHeadless: connectionInfo.isHeadless
+								});
+							} else {
+								// If no active browser session, just return the settings
+								const { browserSettings } = await this.getState();
+								await this.postMessageToWebview({
+									type: "browserConnectionInfo",
+									isConnected: false,
+									isRemote: !!browserSettings.remoteBrowserEnabled,
+									host: browserSettings.remoteBrowserHost,
+									isHeadless: !!browserSettings.headless
+								});
+							}
+						} catch (error) {
+							console.error("Error getting browser connection info:", error);
+							await this.postMessageToWebview({
+								type: "browserConnectionInfo",
+								isConnected: false,
+								isRemote: false,
+								isHeadless: true
+							});
+						}
+						break;
 					}
 					case "getDetectedChromePath": {
 						try {

--- a/src/services/browser/BrowserSession.ts
+++ b/src/services/browser/BrowserSession.ts
@@ -281,6 +281,11 @@ export class BrowserSession {
 	async closeBrowser(): Promise<BrowserActionResult> {
 		if (this.browser || this.page) {
 			if (this.isConnectedToRemote && this.browser) {
+				// Close the page/tab first if it exists
+				if (this.page) {
+					await this.page.close().catch(() => {})
+					console.log("closed remote browser tab...")
+				}
 				await this.browser.disconnect().catch(() => {})
 				console.log("disconnected from remote browser...")
 			} else {

--- a/src/services/browser/BrowserSession.ts
+++ b/src/services/browser/BrowserSession.ts
@@ -56,7 +56,7 @@ export class BrowserSession {
 			isConnected: !!this.browser,
 			isRemote: this.isConnectedToRemote,
 			host: this.isConnectedToRemote ? this.browserSettings.remoteBrowserHost : undefined,
-			isHeadless: this.browserSettings.headless,
+			isHeadless: this.browserSettings.headless
 		}
 	}
 

--- a/src/services/browser/BrowserSession.ts
+++ b/src/services/browser/BrowserSession.ts
@@ -56,7 +56,7 @@ export class BrowserSession {
 			isConnected: !!this.browser,
 			isRemote: this.isConnectedToRemote,
 			host: this.isConnectedToRemote ? this.browserSettings.remoteBrowserHost : undefined,
-			isHeadless: this.browserSettings.headless
+			isHeadless: this.browserSettings.headless,
 		}
 	}
 

--- a/src/shared/ExtensionMessage.ts
+++ b/src/shared/ExtensionMessage.ts
@@ -41,6 +41,7 @@ export interface ExtensionMessage {
 		| "totalTasksSize"
 		| "addToInput"
 		| "browserConnectionResult"
+		| "browserConnectionInfo"
 		| "detectedChromePath"
 		| "scrollToSettings"
 	text?: string
@@ -86,6 +87,10 @@ export interface ExtensionMessage {
 	success?: boolean
 	values?: Record<string, any>
 	isBundled?: boolean
+	isConnected?: boolean
+	isRemote?: boolean
+	host?: string
+	isHeadless?: boolean
 }
 
 export type Invoke = "sendMessage" | "primaryButtonClick" | "secondaryButtonClick"
@@ -207,6 +212,13 @@ export type BrowserActionResult = {
 	logs?: string
 	currentUrl?: string
 	currentMousePosition?: string
+}
+
+export interface BrowserConnectionInfo {
+	isConnected: boolean
+	isRemote: boolean
+	host?: string
+	isHeadless: boolean
 }
 
 export interface ClineAskUseMcpServer {

--- a/src/shared/WebviewMessage.ts
+++ b/src/shared/WebviewMessage.ts
@@ -72,6 +72,7 @@ export interface WebviewMessage {
 		| "optionsResponse"
 		| "requestTotalTasksSize"
 		| "relaunchChromeDebugMode"
+		| "getBrowserConnectionInfo"
 		| "getDetectedChromePath"
 		| "detectedChromePath"
 		| "scrollToSettings"

--- a/webview-ui/src/components/browser/BrowserSettingsMenu.tsx
+++ b/webview-ui/src/components/browser/BrowserSettingsMenu.tsx
@@ -23,7 +23,7 @@ export const BrowserSettingsMenu: React.FC<BrowserSettingsMenuProps> = ({ maxWid
 		isConnected: false,
 		isRemote: !!browserSettings.remoteBrowserEnabled,
 		host: browserSettings.remoteBrowserHost,
-		isHeadless: !!browserSettings.headless
+		isHeadless: !!browserSettings.headless,
 	})
 	const popoverRef = useRef<HTMLDivElement>(null)
 
@@ -31,7 +31,7 @@ export const BrowserSettingsMenu: React.FC<BrowserSettingsMenuProps> = ({ maxWid
 	useEffect(() => {
 		// Request connection info when component mounts
 		vscode.postMessage({
-			type: "getBrowserConnectionInfo"
+			type: "getBrowserConnectionInfo",
 		})
 
 		// Listen for connection info updates
@@ -42,31 +42,34 @@ export const BrowserSettingsMenu: React.FC<BrowserSettingsMenuProps> = ({ maxWid
 					isConnected: message.isConnected,
 					isRemote: message.isRemote,
 					host: message.host,
-					isHeadless: message.isHeadless
+					isHeadless: message.isHeadless,
 				})
 			}
 		}
 
-		window.addEventListener('message', handleMessage)
+		window.addEventListener("message", handleMessage)
 		return () => {
-			window.removeEventListener('message', handleMessage)
+			window.removeEventListener("message", handleMessage)
 		}
 	}, [browserSettings.remoteBrowserHost, browserSettings.remoteBrowserEnabled, browserSettings.headless])
 
 	// Close popover when clicking outside
 	useEffect(() => {
 		const handleClickOutside = (event: MouseEvent) => {
-			if (popoverRef.current && !popoverRef.current.contains(event.target as Node) && 
-				!event.composedPath().some(el => (el as HTMLElement).classList?.contains('browser-info-icon'))) {
+			if (
+				popoverRef.current &&
+				!popoverRef.current.contains(event.target as Node) &&
+				!event.composedPath().some((el) => (el as HTMLElement).classList?.contains("browser-info-icon"))
+			) {
 				setShowInfoPopover(false)
 			}
 		}
 
 		if (showInfoPopover) {
-			document.addEventListener('mousedown', handleClickOutside)
+			document.addEventListener("mousedown", handleClickOutside)
 		}
 		return () => {
-			document.removeEventListener('mousedown', handleClickOutside)
+			document.removeEventListener("mousedown", handleClickOutside)
 		}
 	}, [showInfoPopover])
 
@@ -87,82 +90,87 @@ export const BrowserSettingsMenu: React.FC<BrowserSettingsMenuProps> = ({ maxWid
 
 	const toggleInfoPopover = () => {
 		setShowInfoPopover(!showInfoPopover)
-		
+
 		// Request updated connection info when opening the popover
 		if (!showInfoPopover) {
 			vscode.postMessage({
-				type: "getBrowserConnectionInfo"
+				type: "getBrowserConnectionInfo",
 			})
 		}
 	}
-	
+
 	// Refresh connection info periodically when popover is open
 	useEffect(() => {
-		if (!showInfoPopover) return;
-		
+		if (!showInfoPopover) return
+
 		// Request connection info immediately
 		vscode.postMessage({
-			type: "getBrowserConnectionInfo"
-		});
-		
+			type: "getBrowserConnectionInfo",
+		})
+
 		// Set up interval to refresh every 2 seconds
 		const intervalId = setInterval(() => {
 			vscode.postMessage({
-				type: "getBrowserConnectionInfo"
-			});
-		}, 2000);
-		
-		return () => clearInterval(intervalId);
-	}, [showInfoPopover]);
+				type: "getBrowserConnectionInfo",
+			})
+		}, 2000)
+
+		return () => clearInterval(intervalId)
+	}, [showInfoPopover])
 
 	// Determine icon based on connection state
 	const getIconClass = () => {
 		if (connectionInfo.isConnected) {
-			return connectionInfo.isRemote ? 'codicon-remote' : 'codicon-vm-running';
+			return connectionInfo.isRemote ? "codicon-remote" : "codicon-vm-running"
 		} else {
-			return connectionInfo.isRemote ? 'codicon-remote' : 'codicon-info';
+			return connectionInfo.isRemote ? "codicon-remote" : "codicon-info"
 		}
 	}
 
 	// Determine icon color based on connection state
 	const getIconColor = () => {
 		if (connectionInfo.isConnected) {
-			return 'var(--vscode-charts-green)';
+			return "var(--vscode-charts-green)"
 		} else if (connectionInfo.isRemote) {
-			return 'var(--vscode-charts-blue)';
+			return "var(--vscode-charts-blue)"
 		} else {
-			return 'var(--vscode-foreground)';
+			return "var(--vscode-foreground)"
 		}
 	}
 
 	return (
 		<div ref={containerRef} style={{ position: "relative", marginTop: "-1px", display: "flex" }}>
-			<VSCodeButton 
-				appearance="icon" 
+			<VSCodeButton
+				appearance="icon"
 				className="browser-info-icon"
 				onClick={toggleInfoPopover}
 				title="Browser connection info">
-				<i 
-					className={`codicon ${getIconClass()}`} 
-					style={{ 
-						fontSize: "14.5px", 
-						color: getIconColor()
-					}} 
+				<i
+					className={`codicon ${getIconClass()}`}
+					style={{
+						fontSize: "14.5px",
+						color: getIconColor(),
+					}}
 				/>
 			</VSCodeButton>
-			
+
 			{showInfoPopover && (
 				<InfoPopover ref={popoverRef}>
 					<h4 style={{ margin: "0 0 8px 0" }}>Browser Connection</h4>
 					<InfoRow>
 						<InfoLabel>Status:</InfoLabel>
-						<InfoValue style={{ color: connectionInfo.isConnected ? 'var(--vscode-charts-green)' : 'var(--vscode-errorForeground)' }}>
-							{connectionInfo.isConnected ? 'Connected' : 'Disconnected'}
+						<InfoValue
+							style={{
+								color: connectionInfo.isConnected
+									? "var(--vscode-charts-green)"
+									: "var(--vscode-errorForeground)",
+							}}>
+							{connectionInfo.isConnected ? "Connected" : "Disconnected"}
 						</InfoValue>
 					</InfoRow>
 					<InfoRow>
 						<InfoLabel>Type:</InfoLabel>
-						<InfoValue>{connectionInfo.isRemote ? 'Remote' : 'Local'}</InfoValue>
+						<InfoValue>{connectionInfo.isRemote ? "Remote" : "Local"}</InfoValue>
 					</InfoRow>
 					{connectionInfo.isRemote && connectionInfo.host && (
 						<InfoRow>
@@ -172,11 +180,11 @@ export const BrowserSettingsMenu: React.FC<BrowserSettingsMenuProps> = ({ maxWid
 					)}
 					<InfoRow>
 						<InfoLabel>Headless:</InfoLabel>
-						<InfoValue>{connectionInfo.isHeadless ? 'Yes' : 'No'}</InfoValue>
+						<InfoValue>{connectionInfo.isHeadless ? "Yes" : "No"}</InfoValue>
 					</InfoRow>
 				</InfoPopover>
 			)}
-			
+
 			<VSCodeButton appearance="icon" onClick={openBrowserSettings}>
 				<i className="codicon codicon-settings-gear" style={{ fontSize: "14.5px" }} />
 			</VSCodeButton>

--- a/webview-ui/src/components/browser/BrowserSettingsMenu.tsx
+++ b/webview-ui/src/components/browser/BrowserSettingsMenu.tsx
@@ -23,7 +23,7 @@ export const BrowserSettingsMenu: React.FC<BrowserSettingsMenuProps> = ({ maxWid
 		isConnected: false,
 		isRemote: !!browserSettings.remoteBrowserEnabled,
 		host: browserSettings.remoteBrowserHost,
-		isHeadless: !!browserSettings.headless,
+		isHeadless: !!browserSettings.headless
 	})
 	const popoverRef = useRef<HTMLDivElement>(null)
 
@@ -31,7 +31,7 @@ export const BrowserSettingsMenu: React.FC<BrowserSettingsMenuProps> = ({ maxWid
 	useEffect(() => {
 		// Request connection info when component mounts
 		vscode.postMessage({
-			type: "getBrowserConnectionInfo",
+			type: "getBrowserConnectionInfo"
 		})
 
 		// Listen for connection info updates
@@ -42,34 +42,31 @@ export const BrowserSettingsMenu: React.FC<BrowserSettingsMenuProps> = ({ maxWid
 					isConnected: message.isConnected,
 					isRemote: message.isRemote,
 					host: message.host,
-					isHeadless: message.isHeadless,
+					isHeadless: message.isHeadless
 				})
 			}
 		}
 
-		window.addEventListener("message", handleMessage)
+		window.addEventListener('message', handleMessage)
 		return () => {
-			window.removeEventListener("message", handleMessage)
+			window.removeEventListener('message', handleMessage)
 		}
 	}, [browserSettings.remoteBrowserHost, browserSettings.remoteBrowserEnabled, browserSettings.headless])
 
 	// Close popover when clicking outside
 	useEffect(() => {
 		const handleClickOutside = (event: MouseEvent) => {
-			if (
-				popoverRef.current &&
-				!popoverRef.current.contains(event.target as Node) &&
-				!event.composedPath().some((el) => (el as HTMLElement).classList?.contains("browser-info-icon"))
-			) {
+			if (popoverRef.current && !popoverRef.current.contains(event.target as Node) && 
+				!event.composedPath().some(el => (el as HTMLElement).classList?.contains('browser-info-icon'))) {
 				setShowInfoPopover(false)
 			}
 		}
 
 		if (showInfoPopover) {
-			document.addEventListener("mousedown", handleClickOutside)
+			document.addEventListener('mousedown', handleClickOutside)
 		}
 		return () => {
-			document.removeEventListener("mousedown", handleClickOutside)
+			document.removeEventListener('mousedown', handleClickOutside)
 		}
 	}, [showInfoPopover])
 
@@ -90,87 +87,82 @@ export const BrowserSettingsMenu: React.FC<BrowserSettingsMenuProps> = ({ maxWid
 
 	const toggleInfoPopover = () => {
 		setShowInfoPopover(!showInfoPopover)
-
+		
 		// Request updated connection info when opening the popover
 		if (!showInfoPopover) {
 			vscode.postMessage({
-				type: "getBrowserConnectionInfo",
+				type: "getBrowserConnectionInfo"
 			})
 		}
 	}
-
+	
 	// Refresh connection info periodically when popover is open
 	useEffect(() => {
-		if (!showInfoPopover) return
-
+		if (!showInfoPopover) return;
+		
 		// Request connection info immediately
 		vscode.postMessage({
-			type: "getBrowserConnectionInfo",
-		})
-
+			type: "getBrowserConnectionInfo"
+		});
+		
 		// Set up interval to refresh every 2 seconds
 		const intervalId = setInterval(() => {
 			vscode.postMessage({
-				type: "getBrowserConnectionInfo",
-			})
-		}, 2000)
-
-		return () => clearInterval(intervalId)
-	}, [showInfoPopover])
+				type: "getBrowserConnectionInfo"
+			});
+		}, 2000);
+		
+		return () => clearInterval(intervalId);
+	}, [showInfoPopover]);
 
 	// Determine icon based on connection state
 	const getIconClass = () => {
 		if (connectionInfo.isConnected) {
-			return connectionInfo.isRemote ? "codicon-remote" : "codicon-vm-running"
+			return connectionInfo.isRemote ? 'codicon-remote' : 'codicon-vm-running';
 		} else {
-			return connectionInfo.isRemote ? "codicon-remote" : "codicon-info"
+			return connectionInfo.isRemote ? 'codicon-remote' : 'codicon-info';
 		}
 	}
 
 	// Determine icon color based on connection state
 	const getIconColor = () => {
 		if (connectionInfo.isConnected) {
-			return "var(--vscode-charts-green)"
+			return 'var(--vscode-charts-green)';
 		} else if (connectionInfo.isRemote) {
-			return "var(--vscode-charts-blue)"
+			return 'var(--vscode-charts-blue)';
 		} else {
-			return "var(--vscode-foreground)"
+			return 'var(--vscode-foreground)';
 		}
 	}
 
 	return (
 		<div ref={containerRef} style={{ position: "relative", marginTop: "-1px", display: "flex" }}>
-			<VSCodeButton
-				appearance="icon"
+			<VSCodeButton 
+				appearance="icon" 
 				className="browser-info-icon"
 				onClick={toggleInfoPopover}
 				title="Browser connection info">
-				<i
-					className={`codicon ${getIconClass()}`}
-					style={{
-						fontSize: "14.5px",
-						color: getIconColor(),
-					}}
+				<i 
+					className={`codicon ${getIconClass()}`} 
+					style={{ 
+						fontSize: "14.5px", 
+						color: getIconColor()
+					}} 
 				/>
 			</VSCodeButton>
-
+			
 			{showInfoPopover && (
 				<InfoPopover ref={popoverRef}>
 					<h4 style={{ margin: "0 0 8px 0" }}>Browser Connection</h4>
 					<InfoRow>
 						<InfoLabel>Status:</InfoLabel>
-						<InfoValue
-							style={{
-								color: connectionInfo.isConnected
-									? "var(--vscode-charts-green)"
-									: "var(--vscode-errorForeground)",
-							}}>
-							{connectionInfo.isConnected ? "Connected" : "Disconnected"}
+						<InfoValue style={{ color: connectionInfo.isConnected ? 'var(--vscode-charts-green)' : 'var(--vscode-errorForeground)' }}>
+							{connectionInfo.isConnected ? 'Connected' : 'Disconnected'}
 						</InfoValue>
 					</InfoRow>
 					<InfoRow>
 						<InfoLabel>Type:</InfoLabel>
-						<InfoValue>{connectionInfo.isRemote ? "Remote" : "Local"}</InfoValue>
+						<InfoValue>{connectionInfo.isRemote ? 'Remote' : 'Local'}</InfoValue>
 					</InfoRow>
 					{connectionInfo.isRemote && connectionInfo.host && (
 						<InfoRow>
@@ -180,11 +172,11 @@ export const BrowserSettingsMenu: React.FC<BrowserSettingsMenuProps> = ({ maxWid
 					)}
 					<InfoRow>
 						<InfoLabel>Headless:</InfoLabel>
-						<InfoValue>{connectionInfo.isHeadless ? "Yes" : "No"}</InfoValue>
+						<InfoValue>{connectionInfo.isHeadless ? 'Yes' : 'No'}</InfoValue>
 					</InfoRow>
 				</InfoPopover>
 			)}
-
+			
 			<VSCodeButton appearance="icon" onClick={openBrowserSettings}>
 				<i className="codicon codicon-settings-gear" style={{ fontSize: "14.5px" }} />
 			</VSCodeButton>

--- a/webview-ui/src/components/browser/BrowserSettingsMenu.tsx
+++ b/webview-ui/src/components/browser/BrowserSettingsMenu.tsx
@@ -117,23 +117,40 @@ export const BrowserSettingsMenu: React.FC<BrowserSettingsMenuProps> = ({ maxWid
 
 	// Determine icon based on connection state
 	const getIconClass = () => {
-		if (connectionInfo.isConnected) {
-			return connectionInfo.isRemote ? 'codicon-remote' : 'codicon-vm-running';
+		if (connectionInfo.isRemote) {
+			return 'codicon-remote';
 		} else {
-			return connectionInfo.isRemote ? 'codicon-remote' : 'codicon-info';
+			return connectionInfo.isConnected ? 'codicon-vm-running' : 'codicon-info';
 		}
 	}
 
 	// Determine icon color based on connection state
 	const getIconColor = () => {
-		if (connectionInfo.isConnected) {
+		if (connectionInfo.isRemote) {
+			return connectionInfo.isConnected ? 'var(--vscode-charts-blue)' : 'var(--vscode-foreground)';
+		} else if (connectionInfo.isConnected) {
 			return 'var(--vscode-charts-green)';
-		} else if (connectionInfo.isRemote) {
-			return 'var(--vscode-charts-blue)';
 		} else {
 			return 'var(--vscode-foreground)';
 		}
 	}
+	
+	// Check connection status every second to keep icon in sync
+	useEffect(() => {
+		// Request connection info immediately
+		vscode.postMessage({
+			type: "getBrowserConnectionInfo"
+		});
+		
+		// Set up interval to refresh every second
+		const intervalId = setInterval(() => {
+			vscode.postMessage({
+				type: "getBrowserConnectionInfo"
+			});
+		}, 1000);
+		
+		return () => clearInterval(intervalId);
+	}, []);
 
 	return (
 		<div ref={containerRef} style={{ position: "relative", marginTop: "-1px", display: "flex" }}>
@@ -141,7 +158,8 @@ export const BrowserSettingsMenu: React.FC<BrowserSettingsMenuProps> = ({ maxWid
 				appearance="icon" 
 				className="browser-info-icon"
 				onClick={toggleInfoPopover}
-				title="Browser connection info">
+				title="Browser connection info"
+				style={{ marginRight: "4px" }}>
 				<i 
 					className={`codicon ${getIconClass()}`} 
 					style={{ 
@@ -170,10 +188,6 @@ export const BrowserSettingsMenu: React.FC<BrowserSettingsMenuProps> = ({ maxWid
 							<InfoValue>{connectionInfo.host}</InfoValue>
 						</InfoRow>
 					)}
-					<InfoRow>
-						<InfoLabel>Headless:</InfoLabel>
-						<InfoValue>{connectionInfo.isHeadless ? 'Yes' : 'No'}</InfoValue>
-					</InfoRow>
 				</InfoPopover>
 			)}
 			

--- a/webview-ui/src/components/browser/BrowserSettingsMenu.tsx
+++ b/webview-ui/src/components/browser/BrowserSettingsMenu.tsx
@@ -1,15 +1,74 @@
 import { VSCodeButton } from "@vscode/webview-ui-toolkit/react"
-import React, { useRef } from "react"
+import React, { useEffect, useRef, useState } from "react"
 import { useExtensionState } from "../../context/ExtensionStateContext"
 import { vscode } from "../../utils/vscode"
+import styled from "styled-components"
 
 interface BrowserSettingsMenuProps {
 	maxWidth?: number
 }
 
+interface ConnectionInfo {
+	isConnected: boolean
+	isRemote: boolean
+	host?: string
+	isHeadless: boolean
+}
+
 export const BrowserSettingsMenu: React.FC<BrowserSettingsMenuProps> = ({ maxWidth }) => {
 	const { browserSettings } = useExtensionState()
 	const containerRef = useRef<HTMLDivElement>(null)
+	const [showInfoPopover, setShowInfoPopover] = useState(false)
+	const [connectionInfo, setConnectionInfo] = useState<ConnectionInfo>({
+		isConnected: false,
+		isRemote: !!browserSettings.remoteBrowserEnabled,
+		host: browserSettings.remoteBrowserHost,
+		isHeadless: !!browserSettings.headless
+	})
+	const popoverRef = useRef<HTMLDivElement>(null)
+
+	// Get actual connection info from the browser session
+	useEffect(() => {
+		// Request connection info when component mounts
+		vscode.postMessage({
+			type: "getBrowserConnectionInfo"
+		})
+
+		// Listen for connection info updates
+		const handleMessage = (event: MessageEvent) => {
+			const message = event.data
+			if (message.type === "browserConnectionInfo") {
+				setConnectionInfo({
+					isConnected: message.isConnected,
+					isRemote: message.isRemote,
+					host: message.host,
+					isHeadless: message.isHeadless
+				})
+			}
+		}
+
+		window.addEventListener('message', handleMessage)
+		return () => {
+			window.removeEventListener('message', handleMessage)
+		}
+	}, [browserSettings.remoteBrowserHost, browserSettings.remoteBrowserEnabled, browserSettings.headless])
+
+	// Close popover when clicking outside
+	useEffect(() => {
+		const handleClickOutside = (event: MouseEvent) => {
+			if (popoverRef.current && !popoverRef.current.contains(event.target as Node) && 
+				!event.composedPath().some(el => (el as HTMLElement).classList?.contains('browser-info-icon'))) {
+				setShowInfoPopover(false)
+			}
+		}
+
+		if (showInfoPopover) {
+			document.addEventListener('mousedown', handleClickOutside)
+		}
+		return () => {
+			document.removeEventListener('mousedown', handleClickOutside)
+		}
+	}, [showInfoPopover])
 
 	const openBrowserSettings = () => {
 		// First open the settings panel
@@ -26,13 +85,131 @@ export const BrowserSettingsMenu: React.FC<BrowserSettingsMenuProps> = ({ maxWid
 		}, 300) // Give the settings panel time to open
 	}
 
+	const toggleInfoPopover = () => {
+		setShowInfoPopover(!showInfoPopover)
+		
+		// Request updated connection info when opening the popover
+		if (!showInfoPopover) {
+			vscode.postMessage({
+				type: "getBrowserConnectionInfo"
+			})
+		}
+	}
+	
+	// Refresh connection info periodically when popover is open
+	useEffect(() => {
+		if (!showInfoPopover) return;
+		
+		// Request connection info immediately
+		vscode.postMessage({
+			type: "getBrowserConnectionInfo"
+		});
+		
+		// Set up interval to refresh every 2 seconds
+		const intervalId = setInterval(() => {
+			vscode.postMessage({
+				type: "getBrowserConnectionInfo"
+			});
+		}, 2000);
+		
+		return () => clearInterval(intervalId);
+	}, [showInfoPopover]);
+
+	// Determine icon based on connection state
+	const getIconClass = () => {
+		if (connectionInfo.isConnected) {
+			return connectionInfo.isRemote ? 'codicon-remote' : 'codicon-vm-running';
+		} else {
+			return connectionInfo.isRemote ? 'codicon-remote' : 'codicon-info';
+		}
+	}
+
+	// Determine icon color based on connection state
+	const getIconColor = () => {
+		if (connectionInfo.isConnected) {
+			return 'var(--vscode-charts-green)';
+		} else if (connectionInfo.isRemote) {
+			return 'var(--vscode-charts-blue)';
+		} else {
+			return 'var(--vscode-foreground)';
+		}
+	}
+
 	return (
-		<div ref={containerRef} style={{ position: "relative", marginTop: "-1px" }}>
+		<div ref={containerRef} style={{ position: "relative", marginTop: "-1px", display: "flex" }}>
+			<VSCodeButton 
+				appearance="icon" 
+				className="browser-info-icon"
+				onClick={toggleInfoPopover}
+				title="Browser connection info">
+				<i 
+					className={`codicon ${getIconClass()}`} 
+					style={{ 
+						fontSize: "14.5px", 
+						color: getIconColor()
+					}} 
+				/>
+			</VSCodeButton>
+			
+			{showInfoPopover && (
+				<InfoPopover ref={popoverRef}>
+					<h4 style={{ margin: "0 0 8px 0" }}>Browser Connection</h4>
+					<InfoRow>
+						<InfoLabel>Status:</InfoLabel>
+						<InfoValue style={{ color: connectionInfo.isConnected ? 'var(--vscode-charts-green)' : 'var(--vscode-errorForeground)' }}>
+							{connectionInfo.isConnected ? 'Connected' : 'Disconnected'}
+						</InfoValue>
+					</InfoRow>
+					<InfoRow>
+						<InfoLabel>Type:</InfoLabel>
+						<InfoValue>{connectionInfo.isRemote ? 'Remote' : 'Local'}</InfoValue>
+					</InfoRow>
+					{connectionInfo.isRemote && connectionInfo.host && (
+						<InfoRow>
+							<InfoLabel>Remote Host:</InfoLabel>
+							<InfoValue>{connectionInfo.host}</InfoValue>
+						</InfoRow>
+					)}
+					<InfoRow>
+						<InfoLabel>Headless:</InfoLabel>
+						<InfoValue>{connectionInfo.isHeadless ? 'Yes' : 'No'}</InfoValue>
+					</InfoRow>
+				</InfoPopover>
+			)}
+			
 			<VSCodeButton appearance="icon" onClick={openBrowserSettings}>
 				<i className="codicon codicon-settings-gear" style={{ fontSize: "14.5px" }} />
 			</VSCodeButton>
 		</div>
 	)
 }
+
+const InfoPopover = styled.div`
+	position: absolute;
+	top: 30px;
+	right: 0;
+	background-color: var(--vscode-editorWidget-background);
+	border: 1px solid var(--vscode-widget-border);
+	border-radius: 4px;
+	padding: 10px;
+	z-index: 100;
+	width: 250px;
+	box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+`
+
+const InfoRow = styled.div`
+	display: flex;
+	margin-bottom: 4px;
+`
+
+const InfoLabel = styled.div`
+	flex: 0 0 90px;
+	font-weight: 500;
+`
+
+const InfoValue = styled.div`
+	flex: 1;
+	word-break: break-word;
+`
 
 export default BrowserSettingsMenu


### PR DESCRIPTION
### Description

Info icon by browser tool gear icon, providing a popover that specifies which kind of connection we have -- local vs remote, the ip/port, headless

### Test Procedure

<!-- How did you test this? Are you confident that it will not introduce bugs? If so, why? -->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [ ] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

### Additional Notes

<!-- Add any additional notes for reviewers -->
