### PR TITLE
stateful context management

### DIFF
--- a/.changeset/silly-toys-tell.md
+++ b/.changeset/silly-toys-tell.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": minor
+---
+
+stateful context management

--- a/src/core/Cline.ts
+++ b/src/core/Cline.ts
@@ -1381,7 +1381,7 @@ export class Cline {
 			this.api,
 			this.conversationHistoryDeletedRange,
 			previousApiReqIndex,
-			await this.ensureTaskDirectoryExists()
+			await this.ensureTaskDirectoryExists(),
 		)
 
 		if (contextManagementMetadata.updatedConversationHistoryDeletedRange) {

--- a/src/core/Cline.ts
+++ b/src/core/Cline.ts
@@ -1375,6 +1375,7 @@ export class Cline {
 			this.api,
 			this.conversationHistoryDeletedRange,
 			previousApiReqIndex,
+			await this.ensureTaskDirectoryExists()
 		)
 
 		if (contextManagementMetadata.updatedConversationHistoryDeletedRange) {

--- a/src/core/Cline.ts
+++ b/src/core/Cline.ts
@@ -340,6 +340,9 @@ export class Cline {
 					) // +1 since this index corresponds to the last user message, and another +1 since slice end index is exclusive
 					await this.overwriteApiConversationHistory(newConversationHistory)
 
+					// update the context history state
+					await this.contextManager.truncateContextHistory(message.ts, await this.ensureTaskDirectoryExists())
+
 					// aggregate deleted api reqs info so we don't lose costs/tokens
 					const deletedMessages = this.clineMessages.slice(messageIndex + 1)
 					const deletedApiReqsMetrics = getApiMetrics(combineApiRequests(combineCommandSequences(deletedMessages)))
@@ -873,6 +876,9 @@ export class Cline {
 		// Now present the cline messages to the user and ask if they want to resume (NOTE: we ran into a bug before where the apiconversationhistory wouldnt be initialized when opening a old task, and it was because we were waiting for resume)
 		// This is important in case the user deletes messages without resuming the task first
 		this.apiConversationHistory = await this.getSavedApiConversationHistory()
+
+		// load the context history state
+		await this.contextManager.initializeContextHistory(await this.ensureTaskDirectoryExists())
 
 		const lastClineMessage = this.clineMessages
 			.slice()

--- a/src/core/Cline.ts
+++ b/src/core/Cline.ts
@@ -1369,7 +1369,7 @@ export class Cline {
 			})
 		}
 
-		const contextManagementMetadata = this.contextManager.getNewContextMessagesAndMetadata(
+		const contextManagementMetadata = await this.contextManager.getNewContextMessagesAndMetadata(
 			this.apiConversationHistory,
 			this.clineMessages,
 			this.api,

--- a/src/core/context-management/ContextManager.ts
+++ b/src/core/context-management/ContextManager.ts
@@ -304,7 +304,7 @@ export class ContextManager {
 		timestamp: number,
 	): void {
 		for (const [messageIndex, innerMap] of contextHistory) {
-			// rrack which blockIndices to delete
+			// track which blockIndices to delete
 			const blockIndicesToDelete: number[] = []
 
 			for (const [blockIndex, updates] of innerMap) {
@@ -339,7 +339,7 @@ export class ContextManager {
 	}
 
 	/**
-	 * if there is any truncation, and there is no other alteration already set, alter the assistant message to indicate this occured
+	 * if there is any truncation, and there is no other alteration already set, alter the assistant message to indicate this occurred
 	 */
 	private applyStandardContextTruncationNoticeChange(timestamp: number): boolean {
 		if (!this.contextHistoryUpdates.has(1)) {

--- a/src/core/context-management/ContextManager.ts
+++ b/src/core/context-management/ContextManager.ts
@@ -9,20 +9,24 @@ import * as path from "path"
 import fs from "fs/promises"
 import cloneDeep from "clone-deep"
 
-// string used for text blocks, string[] used for image blocks
-export type MessageContent = string | string[]
+// array of string values allows us to cover all changes currently
+export type MessageContent = string[]
 
 // Type for a single context update
 type ContextUpdate = [number, string, MessageContent] // [timestamp, updateType, update]
 
 // Type for the serialized format of our nested maps
-type SerializedContextHistory = Array<[
-    number, // messageIndex
-    Array<[
-        number, // blockIndex
-        ContextUpdate[] // updates array
-    ]>
-]>
+type SerializedContextHistory = Array<
+	[
+		number, // messageIndex
+		Array<
+			[
+				number, // blockIndex
+				ContextUpdate[], // updates array
+			]
+		>,
+	]
+>
 
 export class ContextManager {
 	// mapping from the apiMessages outer index to the inner message index to a list of actual changes, ordered by timestamp
@@ -34,9 +38,9 @@ export class ContextManager {
 	// the above example would be how we update the first assistant message to indicate we truncated text
 	private contextHistoryUpdates: Map<number, Map<number, ContextUpdate[]>>
 
-    constructor() {
+	constructor() {
 		this.contextHistoryUpdates = new Map()
-    }
+	}
 
 	/**
 	 * public function for loading contextHistory from memory, if it exists
@@ -52,15 +56,10 @@ export class ContextManager {
 		try {
 			const filePath = path.join(taskDirectory, GlobalFileNames.contextHistory)
 			if (await fileExistsAtPath(filePath)) {
-				const data = await fs.readFile(filePath, 'utf8')
+				const data = await fs.readFile(filePath, "utf8")
 				const serializedUpdates = JSON.parse(data) as SerializedContextHistory
-				
-				return new Map(
-					serializedUpdates.map(([messageIndex, innerMapArray]) => [
-						messageIndex,
-						new Map(innerMapArray)
-					])
-				)
+
+				return new Map(serializedUpdates.map(([messageIndex, innerMapArray]) => [messageIndex, new Map(innerMapArray)]))
 			}
 		} catch (error) {
 			console.error("Failed to load context history:", error)
@@ -74,17 +73,14 @@ export class ContextManager {
 	private async saveContextHistory(taskDirectory: string) {
 		try {
 			// Convert Map to our defined serialized format
-			const serializedUpdates: SerializedContextHistory = Array.from(
-				this.contextHistoryUpdates.entries()
-			).map(([messageIndex, innerMap]) => [
-				messageIndex,
-				Array.from(innerMap.entries())
-			])
-			
+			const serializedUpdates: SerializedContextHistory = Array.from(this.contextHistoryUpdates.entries()).map(
+				([messageIndex, innerMap]) => [messageIndex, Array.from(innerMap.entries())],
+			)
+
 			await fs.writeFile(
 				path.join(taskDirectory, GlobalFileNames.contextHistory),
 				JSON.stringify(serializedUpdates),
-				'utf8'
+				"utf8",
 			)
 		} catch (error) {
 			console.error("Failed to save context history:", error)
@@ -100,7 +96,7 @@ export class ContextManager {
 		api: ApiHandler,
 		conversationHistoryDeletedRange: [number, number] | undefined,
 		previousApiReqIndex: number,
-		taskDirectory: string
+		taskDirectory: string,
 	) {
 		let updatedConversationHistoryDeletedRange = false
 
@@ -150,7 +146,7 @@ export class ContextManager {
 					conversationHistoryDeletedRange = this.getNextTruncationRange(
 						apiConversationHistory,
 						conversationHistoryDeletedRange,
-						keep
+						keep,
 					)
 
 					updatedConversationHistoryDeletedRange = true
@@ -176,7 +172,7 @@ export class ContextManager {
 	public getNextTruncationRange(
 		apiMessages: Anthropic.Messages.MessageParam[],
 		currentDeletedRange: [number, number] | undefined,
-		keep: "half" | "quarter"
+		keep: "half" | "quarter",
 	): [number, number] {
 		// We always keep the first user-assistant pairing, and truncate an even number of messages from there
 		const rangeStartIndex = 2 // index 0 and 1 are kept
@@ -222,72 +218,82 @@ export class ContextManager {
 	/**
 	 * apply all required truncation methods to the messages in context
 	 */
-    private getAndAlterTruncatedMessages(
-        messages: Anthropic.Messages.MessageParam[],
-        deletedRange: [number, number] | undefined,
-    ): Anthropic.Messages.MessageParam[] {
-        if (messages.length <= 1) return messages
+	private getAndAlterTruncatedMessages(
+		messages: Anthropic.Messages.MessageParam[],
+		deletedRange: [number, number] | undefined,
+	): Anthropic.Messages.MessageParam[] {
+		if (messages.length <= 1) {
+			return messages
+		}
 
 		const updatedMessages = this.applyContextHistoryUpdates(messages, deletedRange ? deletedRange[1] + 1 : 2)
 
 		// OLD NOTE: if you try to console log these, don't forget that logging a reference to an array may not provide the same result as logging a slice() snapshot of that array at that exact moment. The following DOES in fact include the latest assistant message.
 		return updatedMessages
-    }
+	}
 
 	/**
 	 * applies deletedRange truncation and other alterations based on changes in this.contextHistoryUpdates
 	 */
-    private applyContextHistoryUpdates(
-        messages: Anthropic.Messages.MessageParam[],
-        startFromIndex: number,
-    ): Anthropic.Messages.MessageParam[] {
+	private applyContextHistoryUpdates(
+		messages: Anthropic.Messages.MessageParam[],
+		startFromIndex: number,
+	): Anthropic.Messages.MessageParam[] {
 		// runtime is linear in length of user messages, if expecting a limited number of alterations, could be more optimal to loop over alterations
 
-        const firstChunk = messages.slice(0, 2)  // get first user-assistant pair
-        const secondChunk = messages.slice(startFromIndex) // get remaining messages within context
-        const messagesToUpdate = [...firstChunk, ...secondChunk]
+		const firstChunk = messages.slice(0, 2) // get first user-assistant pair
+		const secondChunk = messages.slice(startFromIndex) // get remaining messages within context
+		const messagesToUpdate = [...firstChunk, ...secondChunk]
 
 		// we need the mapping from the local indices in messagesToUpdate to the global array of updates in this.contextHistoryUpdates
-        const originalIndices = [...Array(2).keys(), ...Array(secondChunk.length).fill(0).map((_, i) => i + startFromIndex)]
-        
-        for (let arrayIndex = 0; arrayIndex < messagesToUpdate.length; arrayIndex++) {
-            const messageIndex = originalIndices[arrayIndex]
-            
-            const innerMap = this.contextHistoryUpdates.get(messageIndex)
-            if (!innerMap) continue
+		const originalIndices = [
+			...Array(2).keys(),
+			...Array(secondChunk.length)
+				.fill(0)
+				.map((_, i) => i + startFromIndex),
+		]
+
+		for (let arrayIndex = 0; arrayIndex < messagesToUpdate.length; arrayIndex++) {
+			const messageIndex = originalIndices[arrayIndex]
+
+			const innerMap = this.contextHistoryUpdates.get(messageIndex)
+			if (!innerMap) {
+				continue
+			}
 
 			// because we are altering this, we need a deep copy
 			messagesToUpdate[arrayIndex] = cloneDeep(messagesToUpdate[arrayIndex])
-            
-            for (const [blockIndex, changes] of innerMap) {
-                // apply the latest change among n changes - [timestamp, updateType, update]
-                const latestChange = changes[changes.length - 1]
-                
-                if (latestChange[1] === "text") { // only altering text for now
-                    const message = messagesToUpdate[arrayIndex]
-                    
-                    if (Array.isArray(message.content)) {
-                        const block = message.content[blockIndex]
-                        if (block && block.type === "text") {
-                            block.text = latestChange[2]
-                        }
-                    }
-                }
-            }
-        }
-        
-        return messagesToUpdate
-    }
+
+			for (const [blockIndex, changes] of innerMap) {
+				// apply the latest change among n changes - [timestamp, updateType, update]
+				const latestChange = changes[changes.length - 1]
+
+				if (latestChange[1] === "text") {
+					// only altering text for now
+					const message = messagesToUpdate[arrayIndex]
+
+					if (Array.isArray(message.content)) {
+						const block = message.content[blockIndex]
+						if (block && block.type === "text") {
+							block.text = latestChange[2][0]
+						}
+					}
+				}
+			}
+		}
+
+		return messagesToUpdate
+	}
 
 	/**
 	 * removes all context history updates that occurred after the specified timestamp and saves to disk
 	 */
 	async truncateContextHistory(timestamp: number, taskDirectory: string): Promise<void> {
 		this.truncateContextHistoryAtTimestamp(this.contextHistoryUpdates, timestamp)
-		
+
 		// save the modified context history to disk
 		await this.saveContextHistory(taskDirectory)
-	}	
+	}
 
 	/**
 	 * alters the context history to remove all alterations after a given timestamp
@@ -295,36 +301,36 @@ export class ContextManager {
 	 */
 	private truncateContextHistoryAtTimestamp(
 		contextHistory: Map<number, Map<number, ContextUpdate[]>>,
-		timestamp: number
+		timestamp: number,
 	): void {
 		for (const [messageIndex, innerMap] of contextHistory) {
 			// rrack which blockIndices to delete
 			const blockIndicesToDelete: number[] = []
-			
+
 			for (const [blockIndex, updates] of innerMap) {
 				// updates ordered by timestamp, so find cutoff point by interating from right to left
 				let cutoffIndex = updates.length - 1
 				while (cutoffIndex >= 0 && updates[cutoffIndex][0] > timestamp) {
 					cutoffIndex--
 				}
-				
+
 				// If we found updates to remove
 				if (cutoffIndex < updates.length - 1) {
 					// Modify the array in place to keep only updates up to cutoffIndex
 					updates.length = cutoffIndex + 1
-					
+
 					// If no updates left after truncation, mark this block for deletion
 					if (updates.length === 0) {
 						blockIndicesToDelete.push(blockIndex)
 					}
 				}
 			}
-			
+
 			// Remove empty blocks from inner map
 			for (const blockIndex of blockIndicesToDelete) {
 				innerMap.delete(blockIndex)
 			}
-			
+
 			// If inner map is now empty, remove the message index from outer map
 			if (innerMap.size === 0) {
 				contextHistory.delete(messageIndex)
@@ -335,13 +341,14 @@ export class ContextManager {
 	/**
 	 * if there is any truncation, and there is no other alteration already set, alter the assistant message to indicate this occured
 	 */
-    private applyStandardContextTruncationNoticeChange(timestamp: number): boolean {
-        if (!this.contextHistoryUpdates.has(1)) { // first assistant message always at index 1
-            const innerMap = new Map<number, ContextUpdate[]>()
-            innerMap.set(0, [[timestamp, "text", formatResponse.contextTruncationNotice()]]) // alter message text at index 0
-            this.contextHistoryUpdates.set(1, innerMap)
+	private applyStandardContextTruncationNoticeChange(timestamp: number): boolean {
+		if (!this.contextHistoryUpdates.has(1)) {
+			// first assistant message always at index 1
+			const innerMap = new Map<number, ContextUpdate[]>()
+			innerMap.set(0, [[timestamp, "text", [formatResponse.contextTruncationNotice()]]]) // alter message text at index 0
+			this.contextHistoryUpdates.set(1, innerMap)
 			return true
-        }
+		}
 		return false
-    }	
+	}
 }

--- a/src/global-constants.ts
+++ b/src/global-constants.ts
@@ -2,6 +2,7 @@
 export const GlobalFileNames = {
 	apiConversationHistory: "api_conversation_history.json",
 	uiMessages: "ui_messages.json",
+	contextHistory: "context_history.json",
 	openRouterModels: "openrouter_models.json",
 	mcpSettings: "cline_mcp_settings.json",
 	clineRules: ".clinerules",


### PR DESCRIPTION
### Description

Stateful implementation of context management - initially just adjusts the first assistant message to indicate we have truncated context when applicable. Includes logic to restore the context history state during checkpoint task restores & `resumeTaskFromHistory`.

### Test Procedure

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

### Additional Notes

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Introduce stateful context management to handle conversation history with context state restoration and truncation notices.
> 
>   - **Behavior**:
>     - Implements stateful context management in `Cline.ts` and `ContextManager.ts`.
>     - Updates first assistant message to indicate truncated context when applicable.
>     - Restores context history state during checkpoint task restores and `resumeTaskFromHistory`.
>   - **Context Management**:
>     - Adds `initializeContextHistory()` and `truncateContextHistory()` in `ContextManager.ts` to manage context state.
>     - Saves and loads context history from `context_history.json`.
>     - Applies truncation notices using `applyStandardContextTruncationNoticeChange()`.
>   - **Misc**:
>     - Adds `contextHistory` to `GlobalFileNames` in `global-constants.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 721aa32dacc1078607e25cf1dde11054c5620854. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->