### PR TITLE
read_file tool context management

### DIFF
--- a/.changeset/cuddly-bulldogs-end.md
+++ b/.changeset/cuddly-bulldogs-end.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": minor
+---
+
+add context management of read_file duplicate file reads

--- a/src/core/prompts/responses.ts
+++ b/src/core/prompts/responses.ts
@@ -4,6 +4,9 @@ import * as path from "path"
 import { ClineIgnoreController, LOCK_TEXT_SYMBOL } from "../ignore/ClineIgnoreController"
 
 export const formatResponse = {
+	duplicateFileReadNotice: () =>
+		`[[NOTE] This file read has been removed to save space in the context window. Refer to the latest file read for the most up to date version of this file.]`,
+
 	contextTruncationNotice: () =>
 		`[NOTE] Some previous conversation history with the user has been removed to maintain optimal context window length. The initial user task and the most recent exchanges have been retained for continuity, while intermediate conversation history has been removed. Please keep this in mind as you continue assisting the user.`,
 


### PR DESCRIPTION
### Description

Removes duplicate file reads in stateful manner. To start this only covers dumped file content from the read_file tool call.

### Test Procedure

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

### Additional Notes

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds context management for duplicate file reads in `ContextManager.ts`, optimizing context by removing redundant reads and updating history.
> 
>   - **Behavior**:
>     - Adds context management for duplicate file reads in `ContextManager.ts`.
>     - Removes redundant file reads by tracking and updating context history.
>     - Updates context history to indicate duplicate file reads with a notice.
>   - **Functions**:
>     - Adds `applyContextOptimizations()`, `findAndPotentiallySaveFileReadContextHistoryUpdates()`, `getPossibleDuplicateFileReads()`, and `applyFileReadContextHistoryUpdates()` in `ContextManager.ts`.
>     - Updates `formatResponse` in `responses.ts` to include `duplicateFileReadNotice()`.
>   - **Misc**:
>     - Fixes typo in `ContextManager.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for c955e8ed06126caf373d6ff55048d7a8cf490296. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->