### PR TITLE
Feat: automatic retry for Gemini 2.5 Pro 503 Server Busy error (#2471)

### DIFF
--- a/.changeset/proud-pumas-brush.md
+++ b/.changeset/proud-pumas-brush.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Automatically but respectfully retries Gemini Pro 2.5 API calls

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "claude-dev",
-	"version": "3.8.0",
+	"version": "3.8.3",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "claude-dev",
-			"version": "3.8.0",
+			"version": "3.8.3",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@anthropic-ai/bedrock-sdk": "^0.12.4",

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -938,6 +938,15 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 						this.postMessageToWebview({ type: "relinquishControl" })
 						break
 					}
+					case "retryApiRequest": {
+						if (message.ts && this.cline) {
+							console.log(`Received retry request for message ts: ${message.ts}`)
+							// Call a method on the Cline instance to handle the retry
+							// We'll need to implement this method in Cline.ts
+							await this.cline.retryFailedRequest(message.ts)
+						}
+						break
+					}
 					// Add more switch case statements here as more webview message commands
 					// are created within the webview context (i.e. inside media/main.js)
 				}

--- a/src/shared/ExtensionMessage.ts
+++ b/src/shared/ExtensionMessage.ts
@@ -40,6 +40,7 @@ export interface ExtensionMessage {
 		| "userCreditsPayments"
 		| "totalTasksSize"
 		| "addToInput"
+		| "retryApiRequest" // Added for automatic retry
 	text?: string
 	action?:
 		| "chatButtonClicked"

--- a/src/shared/WebviewMessage.ts
+++ b/src/shared/WebviewMessage.ts
@@ -65,8 +65,10 @@ export interface WebviewMessage {
 		| "fetchUserCreditsData"
 		| "optionsResponse"
 		| "requestTotalTasksSize"
+		| "retryApiRequest" // Added for automatic retry
 	// | "relaunchChromeDebugMode"
 	text?: string
+	ts?: number // Added for retryApiRequest
 	disabled?: boolean
 	askResponse?: ClineAskResponse
 	apiConfiguration?: ApiConfiguration


### PR DESCRIPTION
### Description

This PR introduces an automatic retry mechanism for API calls made to Gemini models (specifically targeting Gemini 2.5 Pro, but potentially applicable to others) when the API responds with a 503 "Server Busy" status code.

Currently, these transient errors interrupt the workflow and require manual intervention. This change implements a respectful retry strategy within `src/core/Cline.ts`  to handle these specific 503 errors automatically, improving the reliability and user experience when interacting with Gemini. Modifications were also made to `src/shared/ExtensionMessage.ts`, `src/shared/WebviewMessage.ts`, and `webview-ui/src/components/chat/ChatRow.tsx`. The retry mechanism is invisible to the user.


### Test Procedure

Used it in prod all day

I am confident that this change will not introduce bugs because the retry logic is specifically scoped to 503 errors in general and also those with the specific wording used by Gemini 503 responses. Existing error handling for other statuses remains unchanged.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

No UI changes.

### Additional Notes

Considered adding configuration options for retry behavior but opted for a default implementation first.


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds automatic retry mechanism for Gemini 2.5 Pro API calls on 503 errors, with retry logic implemented in `Cline.ts` and `ChatRow.tsx`.
> 
>   - **Behavior**:
>     - Adds automatic retry for Gemini 2.5 Pro API calls on 503 errors in `Cline.ts`.
>     - Retry logic in `ChatRow.tsx` triggers on specific error messages ("503 Service Unavailable" or "model is overloaded").
>     - Retries are delayed randomly between 3-7 seconds.
>   - **Message Handling**:
>     - Adds `retryApiRequest` type to `ExtensionMessage` and `WebviewMessage`.
>     - Implements retry logic in `ClineProvider.ts` for handling `retryApiRequest` messages.
>   - **Misc**:
>     - Removes incorrect import for `getRandomInt` in `Cline.ts` and defines it locally in `ChatRow.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 433c9498506b1e154e0c4f321fde09c99b93d0b9. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->