### PR TITLE
Add Shell Integration Timeout made configurable from fixed 4000ms

### DIFF
--- a/docs/tools/cline-tools-guide.md
+++ b/docs/tools/cline-tools-guide.md
@@ -40,6 +40,8 @@ Cline is your AI assistant that can:
     - Run npm commands
     - Start development servers
     - Install dependencies
+    - Advanced Configuration:
+      - `cline.terminal.shellIntegrationTimeout`: Timeout in milliseconds to wait for shell integration to activate (default: 4000)
 
 3. **Code Analysis**
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "claude-dev",
-	"version": "3.8.0",
+	"version": "3.8.3",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "claude-dev",
-			"version": "3.8.0",
+			"version": "3.8.3",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@anthropic-ai/bedrock-sdk": "^0.12.4",

--- a/package.json
+++ b/package.json
@@ -217,6 +217,11 @@
 					"default": false,
 					"description": "Disables extension from spawning browser session."
 				},
+				"cline.terminal.shellIntegrationTimeout": {
+					"type": "number",
+					"default": 4000,
+					"description": "Maximum timeout in milliseconds to wait for shell integration to activate"
+				},
 				"cline.modelSettings.o3Mini.reasoningEffort": {
 					"type": "string",
 					"enum": [

--- a/src/integrations/terminal/TerminalManager.ts
+++ b/src/integrations/terminal/TerminalManager.ts
@@ -144,7 +144,8 @@ export class TerminalManager {
 			process.run(terminalInfo.terminal, command)
 		} else {
 			// docs recommend waiting 3s for shell integration to activate
-			pWaitFor(() => terminalInfo.terminal.shellIntegration !== undefined, { timeout: 4000 }).finally(() => {
+			const timeout = vscode.workspace.getConfiguration("terminal").get("shellIntegration.timeout", 4000) as number
+			pWaitFor(() => terminalInfo.terminal.shellIntegration !== undefined, { timeout: timeout }).finally(() => {
 				const existingProcess = this.processes.get(terminalInfo.id)
 				if (existingProcess && existingProcess.waitForShellIntegration) {
 					existingProcess.waitForShellIntegration = false


### PR DESCRIPTION
### Description

This change addresses reliability issues in terminal integration due to short timeout across diverse environments. The previous hardcoded 4-second timeout proved insufficient for:
- Older systems with slower I/O subsystems
- Custom shell configurations (zsh/fish) with complex initialization routines
- Resource-constrained environments (ARM devices, virtualized systems)
- Enterprise setups with security tooling impacting shell startup

### Test Procedure

- The timeout was earlier hardcoded and not working my machine. After making the changes and increasing the timeout to 40s from the advance settings the integration is now working fine. So this was manually test
- Automated tests were not written a simulating a slow shell was not something I could achieve

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [X] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [X] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [X] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [X] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [X] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [X] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->
<img width="1090" alt="ClineTimeout" src="https://github.com/user-attachments/assets/a3bc1c25-9d82-4546-ba19-736172c33793" />

### Additional Notes

<!-- Add any additional notes for reviewers -->
