### PR TITLE
Ignore package-lock files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 out
 dist
 node_modules
+package-lock.json
 tmp
 .vscode-test/
 *.vsix

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "claude-dev",
-	"version": "3.8.0",
+	"version": "3.8.3",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "claude-dev",
-			"version": "3.8.0",
+			"version": "3.8.3",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@anthropic-ai/bedrock-sdk": "^0.12.4",

--- a/webview-ui/.gitignore
+++ b/webview-ui/.gitignore
@@ -8,6 +8,7 @@ pnpm-debug.log*
 lerna-debug.log*
 
 node_modules
+package-lock.json
 dist
 dist-ssr
 build


### PR DESCRIPTION
### Description

Stop tracking changes to package-lock.json automatically.  This will allow us to Update it still manually, but won't be auto added to commits when `git add -u` is used.

### Test Procedure

Make a change in package-lock.json and run `git status` to verify it's not tracked.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [X] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [X] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [X] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [X] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [X] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)
