### PR TITLE
add ark provider which is from volcengine

### DIFF
--- a/.changeset/popular-trains-deliver.md
+++ b/.changeset/popular-trains-deliver.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": minor
+---
+
+add ark provider which is from volcengine

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -21,6 +21,7 @@ import { LiteLlmHandler } from "./providers/litellm"
 import { AskSageHandler } from "./providers/asksage"
 import { XAIHandler } from "./providers/xai"
 import { SambanovaHandler } from "./providers/sambanova"
+import { ArkHandler } from "./providers/ark"
 
 export interface ApiHandler {
 	createMessage(systemPrompt: string, messages: Anthropic.Messages.MessageParam[]): ApiStream
@@ -75,6 +76,8 @@ export function buildApiHandler(configuration: ApiConfiguration): ApiHandler {
 			return new XAIHandler(options)
 		case "sambanova":
 			return new SambanovaHandler(options)
+		case "ark":
+			return new ArkHandler(options)
 		default:
 			return new AnthropicHandler(options)
 	}

--- a/src/api/providers/ark.ts
+++ b/src/api/providers/ark.ts
@@ -1,0 +1,89 @@
+import { Anthropic } from "@anthropic-ai/sdk"
+import { withRetry } from "../retry"
+import OpenAI from "openai"
+import { ApiHandlerOptions, ModelInfo, arkModels, openAiModelInfoSaneDefaults } from "../../shared/api"
+import { ApiHandler } from "../index"
+import { ApiStream } from "../transform/stream"
+import { convertToR1Format } from "../transform/r1-format"
+
+interface ArkModel {
+	id: string
+	max_tokens: number
+	context_window: number
+	supports_images: boolean
+	supports_computer_use: boolean
+	supports_prompt_cache: boolean
+	input_price: number
+	output_price: number
+	description: string
+}
+
+interface ArkModelsResponse {
+	models: ArkModel[]
+}
+
+export class ArkHandler implements ApiHandler {
+	private options: ApiHandlerOptions
+	private client: OpenAI
+	private models: Record<string, ModelInfo> = {}
+
+	constructor(options: ApiHandlerOptions) {
+		this.options = options
+		this.client = new OpenAI({
+			baseURL: this.options.arkEndpoint || "https://ark.cn-beijing.volces.com/api/v3",
+			apiKey: this.options.arkApiKey,
+		})
+	}
+
+	@withRetry()
+	async *createMessage(systemPrompt: string, messages: Anthropic.Messages.MessageParam[]): ApiStream {
+		const r1Messages = convertToR1Format([{ role: "user", content: systemPrompt }, ...messages])
+
+		const stream = await this.client.chat.completions.create({
+			model: this.options.apiModelId || "",
+			messages: r1Messages,
+			temperature: 0,
+			stream: true,
+			stream_options: { include_usage: true },
+		})
+		for await (const chunk of stream) {
+			const delta = chunk.choices[0]?.delta
+			if (delta?.content) {
+				yield {
+					type: "text",
+					text: delta.content,
+				}
+			}
+
+			if (delta && "reasoning_content" in delta && delta.reasoning_content) {
+				yield {
+					type: "reasoning",
+					reasoning: (delta.reasoning_content as string | undefined) || "",
+				}
+			}
+
+			if (chunk.usage) {
+				yield {
+					type: "usage",
+					inputTokens: chunk.usage.prompt_tokens || 0,
+					outputTokens: chunk.usage.completion_tokens || 0,
+				}
+			}
+		}
+	}
+
+	getModel(): { id: string; info: ModelInfo } {
+		console.log("Getting Ark model:", this.options.apiModelId)
+		this.models = arkModels
+
+		const modelId = this.options.apiModelId || ""
+		const model = modelId in arkModels ? arkModels[modelId as keyof typeof arkModels] : openAiModelInfoSaneDefaults
+
+		return {
+			id: modelId,
+			info: {
+				...model,
+			},
+		}
+	}
+}

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -68,6 +68,7 @@ type SecretKey =
 	| "asksageApiKey"
 	| "xaiApiKey"
 	| "sambanovaApiKey"
+	| "arkApiKey"
 type GlobalStateKey =
 	| "apiProvider"
 	| "apiModelId"
@@ -115,6 +116,7 @@ type GlobalStateKey =
 	| "asksageApiUrl"
 	| "thinkingBudgetTokens"
 	| "planActSeparateModelsSetting"
+	| "arkEndpoint"
 
 export class ClineProvider implements vscode.WebviewViewProvider {
 	public static readonly sideBarId = "claude-dev.SidebarProvider" // used in package.json as the view's id. This value cannot be changed due to how vscode caches views based on their id, and updating the id would break existing instances of the extension.
@@ -1170,6 +1172,8 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 			thinkingBudgetTokens,
 			clineApiKey,
 			sambanovaApiKey,
+			arkEndpoint,
+			arkApiKey,
 		} = apiConfiguration
 		await this.updateGlobalState("apiProvider", apiProvider)
 		await this.updateGlobalState("apiModelId", apiModelId)
@@ -1220,6 +1224,8 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 		await this.updateGlobalState("thinkingBudgetTokens", thinkingBudgetTokens)
 		await this.storeSecret("clineApiKey", clineApiKey)
 		await this.storeSecret("sambanovaApiKey", sambanovaApiKey)
+		await this.updateGlobalState("arkEndpoint", arkEndpoint)
+		await this.storeSecret("arkApiKey", arkApiKey)
 		if (this.cline) {
 			this.cline.api = buildApiHandler(apiConfiguration)
 		}
@@ -2147,6 +2153,8 @@ Here is the project's README to help you get started:\n\n${mcpDetails.readmeCont
 			thinkingBudgetTokens,
 			sambanovaApiKey,
 			planActSeparateModelsSettingRaw,
+			arkEndpoint,
+			arkApiKey,
 		] = await Promise.all([
 			this.getGlobalState("apiProvider") as Promise<ApiProvider | undefined>,
 			this.getGlobalState("apiModelId") as Promise<string | undefined>,
@@ -2211,6 +2219,8 @@ Here is the project's README to help you get started:\n\n${mcpDetails.readmeCont
 			this.getGlobalState("thinkingBudgetTokens") as Promise<number | undefined>,
 			this.getSecret("sambanovaApiKey") as Promise<string | undefined>,
 			this.getGlobalState("planActSeparateModelsSetting") as Promise<boolean | undefined>,
+			this.getGlobalState("arkEndpoint") as Promise<string | undefined>,
+			this.getSecret("arkApiKey") as Promise<string | undefined>,
 		])
 
 		let apiProvider: ApiProvider
@@ -2303,6 +2313,8 @@ Here is the project's README to help you get started:\n\n${mcpDetails.readmeCont
 				asksageApiUrl,
 				xaiApiKey,
 				sambanovaApiKey,
+				arkEndpoint,
+				arkApiKey,
 			},
 			lastShownAnnouncementId,
 			customInstructions,
@@ -2451,6 +2463,7 @@ Here is the project's README to help you get started:\n\n${mcpDetails.readmeCont
 			"asksageApiKey",
 			"xaiApiKey",
 			"sambanovaApiKey",
+			"arkApiKey",
 		]
 		for (const key of secretKeys) {
 			await this.storeSecret(key, undefined)

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -19,6 +19,7 @@ export type ApiProvider =
 	| "asksage"
 	| "xai"
 	| "sambanova"
+	| "ark"
 
 export interface ApiHandlerOptions {
 	apiModelId?: string
@@ -70,6 +71,8 @@ export interface ApiHandlerOptions {
 	xaiApiKey?: string
 	thinkingBudgetTokens?: number
 	sambanovaApiKey?: string
+	arkEndpoint?: string
+	arkApiKey?: string
 }
 
 export type ApiConfiguration = ApiHandlerOptions & {
@@ -1416,5 +1419,19 @@ export const sambanovaModels = {
 		supportsPromptCache: false,
 		inputPrice: 0.5,
 		outputPrice: 1.0,
+	},
+} as const satisfies Record<string, ModelInfo>
+
+// ARK
+// https://www.volcengine.com/product/ark
+export type ArkModelId = keyof typeof arkModels
+export const arkModels = {
+	"doubao-1-5-vision-pro-32k-250115": {
+		maxTokens: 4096,
+		contextWindow: 12_288,
+		supportsImages: true,
+		supportsPromptCache: false,
+		inputPrice: 0.25,
+		outputPrice: 0.65,
 	},
 } as const satisfies Record<string, ModelInfo>

--- a/webview-ui/src/components/settings/ApiOptions.tsx
+++ b/webview-ui/src/components/settings/ApiOptions.tsx
@@ -45,6 +45,7 @@ import {
 	xaiModels,
 	sambanovaModels,
 	sambanovaDefaultModelId,
+	arkModels,
 } from "../../../../src/shared/api"
 import { ExtensionMessage } from "../../../../src/shared/ExtensionMessage"
 import { useExtensionState } from "../../context/ExtensionStateContext"
@@ -212,6 +213,7 @@ const ApiOptions = ({ showModelOptions, apiErrorMessage, modelIdErrorMessage, is
 					<VSCodeOption value="asksage">AskSage</VSCodeOption>
 					<VSCodeOption value="xai">X AI</VSCodeOption>
 					<VSCodeOption value="sambanova">SambaNova</VSCodeOption>
+					<VSCodeOption value="ark">ARK</VSCodeOption>
 				</VSCodeDropdown>
 			</DropdownContainer>
 
@@ -1359,6 +1361,62 @@ const ApiOptions = ({ showModelOptions, apiErrorMessage, modelIdErrorMessage, is
 				</div>
 			)}
 
+			{selectedProvider === "ark" && (
+				<div>
+					<VSCodeTextField
+						value={apiConfiguration?.arkEndpoint || ""}
+						style={{ width: "100%" }}
+						type="url"
+						onInput={handleInputChange("arkEndpoint")}
+						placeholder="https://ark.cn-beijing.volces.com/api/v3">
+						<span style={{ fontWeight: 500 }}>Ark API Endpoint</span>
+					</VSCodeTextField>
+					<p
+						style={{
+							fontSize: "12px",
+							marginTop: 3,
+							color: "var(--vscode-descriptionForeground)",
+						}}>
+						<VSCodeLink href="https://console.volcengine.com/" style={{ display: "inline", fontSize: "inherit" }}>
+							Volcano
+						</VSCodeLink>{" "}
+						Ark is a large model development platform. Before using it, you need
+						<VSCodeLink
+							href="https://console.volcengine.com/ark/region:ark+cn-beijing/endpoint"
+							style={{ display: "inline", fontSize: "inherit" }}>
+							Create Inference Endpoint
+						</VSCodeLink>{" "}
+						or
+						<VSCodeLink
+							href="https://console.volcengine.com/ark/region:ark+cn-beijing/openManagement"
+							style={{ display: "inline", fontSize: "inherit" }}>
+							Active Model
+						</VSCodeLink>{" "}
+						and
+						<VSCodeLink
+							href="https://console.volcengine.com/ark/region:ark+cn-beijing/apiKey"
+							style={{ display: "inline", fontSize: "inherit" }}>
+							Get Api Key
+						</VSCodeLink>
+					</p>
+					<VSCodeTextField
+						value={apiConfiguration?.arkApiKey || ""}
+						style={{ width: "100%" }}
+						type="password"
+						onInput={handleInputChange("arkApiKey")}
+						placeholder="Enter API Key...">
+						<span style={{ fontWeight: 500 }}>Ark API Key</span>
+					</VSCodeTextField>
+					<VSCodeTextField
+						value={apiConfiguration?.apiModelId || ""}
+						style={{ width: "100%" }}
+						onInput={handleInputChange("apiModelId")}
+						placeholder={"Enter Model ID or Endpoint..."}>
+						<span style={{ fontWeight: 500 }}>Model ID or Endpoint</span>
+					</VSCodeTextField>
+				</div>
+			)}
+
 			{apiErrorMessage && (
 				<p
 					style={{
@@ -1449,6 +1507,7 @@ const ApiOptions = ({ showModelOptions, apiErrorMessage, modelIdErrorMessage, is
 							{selectedProvider === "asksage" && createDropdown(askSageModels)}
 							{selectedProvider === "xai" && createDropdown(xaiModels)}
 							{selectedProvider === "sambanova" && createDropdown(sambanovaModels)}
+							{selectedProvider === "ark" && createDropdown(arkModels)}
 						</DropdownContainer>
 
 						{((selectedProvider === "anthropic" && selectedModelId === "claude-3-7-sonnet-20250219") ||
@@ -1723,6 +1782,15 @@ export function normalizeApiConfiguration(apiConfiguration?: ApiConfiguration): 
 			return getProviderData(xaiModels, xaiDefaultModelId)
 		case "sambanova":
 			return getProviderData(sambanovaModels, sambanovaDefaultModelId)
+		case "ark":
+			return {
+				selectedProvider: provider,
+				selectedModelId: apiConfiguration?.apiModelId || "",
+				selectedModelInfo:
+					apiConfiguration?.apiModelId && apiConfiguration.apiModelId in arkModels
+						? arkModels[apiConfiguration.apiModelId as keyof typeof arkModels]
+						: openAiModelInfoSaneDefaults,
+			}
 		default:
 			return getProviderData(anthropicModels, anthropicDefaultModelId)
 	}

--- a/webview-ui/src/utils/validate.ts
+++ b/webview-ui/src/utils/validate.ts
@@ -98,6 +98,14 @@ export function validateApiConfiguration(apiConfiguration?: ApiConfiguration): s
 					return "You must provide a valid API key or choose a different provider."
 				}
 				break
+			case "ark":
+				if (!apiConfiguration.arkApiKey) {
+					return "You must provide a valid API key or choose a different provider."
+				}
+				if (!apiConfiguration.apiModelId) {
+					return "You must provide a valid model selector."
+				}
+				break
 		}
 	}
 	return undefined


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add Ark provider from Volcengine, including handler, configuration, UI support, and validation.
> 
>   - **Behavior**:
>     - Add `ArkHandler` in `src/api/providers/ark.ts` to handle Ark API interactions.
>     - Update `buildApiHandler()` in `index.ts` to include Ark as a case.
>     - Add Ark API configuration options in `ClineProvider.ts` and `ApiOptions.tsx`.
>   - **Models**:
>     - Define `ArkModel` and `ArkModelsResponse` interfaces in `ark.ts`.
>     - Add `arkModels` to `api.ts` with model details.
>   - **UI**:
>     - Add Ark as an option in the API provider dropdown in `ApiOptions.tsx`.
>     - Include fields for Ark API endpoint and key in `ApiOptions.tsx`.
>   - **Validation**:
>     - Update `validateApiConfiguration()` in `validate.ts` to include Ark API key and model ID checks.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 7bc21c7e4cd1b2b59bc67eac34eb6af5e9181efb. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->