### PR TITLE
context management: cover additional tools for file reads

### DIFF
--- a/.changeset/sour-laws-approve.md
+++ b/.changeset/sour-laws-approve.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": minor
+---
+
+handle other tools which paste updated file

--- a/.changeset/tiny-peaches-grow.md
+++ b/.changeset/tiny-peaches-grow.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": minor
+---
+
+char counting to determine whether context management is sufficient to skip truncation

--- a/src/core/context-management/ContextManager.ts
+++ b/src/core/context-management/ContextManager.ts
@@ -393,7 +393,7 @@ export class ContextManager {
 	}
 
 	/**
-	 * generate a mapping from unique files reads from multiple tool calls to their outer index position(s)
+	 * generate a mapping from unique file reads from multiple tool calls to their outer index position(s)
 	 */
 	private getPossibleDuplicateFileReads(
 		apiMessages: Anthropic.Messages.MessageParam[],
@@ -416,9 +416,11 @@ export class ContextManager {
 						if (matchTup[0] === "read_file") {
 							this.handleReadFileToolCall(i, matchTup[1], fileReadIndices)
 						} else if (matchTup[0] === "replace_in_file" || matchTup[0] === "write_to_file") {
-							const secondBlock = message.content[1]
-							if (secondBlock.type === "text") {
-								this.handlePotentialFileChangeToolCalls(i, matchTup[1], secondBlock.text, fileReadIndices)
+							if (message.content.length > 1) {
+								const secondBlock = message.content[1]
+								if (secondBlock.type === "text") {
+									this.handlePotentialFileChangeToolCalls(i, matchTup[1], secondBlock.text, fileReadIndices)
+								}
 							}
 						}
 


### PR DESCRIPTION
### Description

We are now covering write_to_file and replace_in_file file reads.

### Test Procedure

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

### Additional Notes

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Extend `ContextManager` to handle file reads from `write_to_file` and `replace_in_file` tools, ensuring correct management of duplicate file operations.
> 
>   - **Behavior**:
>     - Extend file read handling to include `write_to_file` and `replace_in_file` tools in `ContextManager.ts`.
>     - Updates `getPossibleDuplicateFileReads()` to track file reads from multiple tools.
>     - Adds `handleReadFileToolCall()` and `handlePotentialFileChangeToolCalls()` to manage file read and change operations.
>   - **Functions**:
>     - `parsePotentialToolCall()` added to parse tool call formats.
>     - `applyFileReadContextHistoryUpdates()` updated to handle new tool outputs.
>   - **Misc**:
>     - Fix typo in comment in `ContextManager.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 81404c49f2d697edb143cdc915fbc74549445062. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->