### PR TITLE
Revert "re-enabling conversation observability"

### DIFF
--- a/.changeset/gold-beans-compare.md
+++ b/.changeset/gold-beans-compare.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Revert "re-enabling conversation observability"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "claude-dev",
-	"version": "3.8.2",
+	"version": "3.8.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "claude-dev",
-			"version": "3.8.2",
+			"version": "3.8.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@anthropic-ai/bedrock-sdk": "^0.12.4",

--- a/package.json
+++ b/package.json
@@ -261,11 +261,6 @@
 					"type": "boolean",
 					"default": true,
 					"description": "Controls whether the MCP Marketplace is enabled."
-				},
-				"cline.conversationObservability": {
-					"type": "boolean",
-					"default": false,
-					"markdownDescription": "Share message data, code, and more extensive observability. This data may be used to improve prompts used in Cline, train models, and understand failure states more accurately. [Learn more](https://docs.cline.bot/more-info/conversation-observability)"
 				}
 			}
 		}

--- a/src/core/Cline.ts
+++ b/src/core/Cline.ts
@@ -64,7 +64,7 @@ import { ClineHandler } from "../api/providers/cline"
 import { ClineProvider } from "./webview/ClineProvider"
 import { DEFAULT_LANGUAGE_SETTINGS, getLanguageKey, LanguageDisplay, LanguageKey } from "../shared/Languages"
 import { telemetryService } from "../services/telemetry/TelemetryService"
-import { ConversationObservabilityService, TelemetryChatMessage } from "../services/telemetry/ConversationObservabilityService"
+import { ConversationTelemetryService, TelemetryChatMessage } from "../services/telemetry/ConversationTelemetryService"
 import pTimeout from "p-timeout"
 import { GlobalFileNames } from "../global-constants"
 import {
@@ -1357,7 +1357,7 @@ export class Cline {
 
 		// Capture system prompt for telemetry,
 		// ONLY if user is opted in, in advanced settings
-		if (this.providerRef.deref()?.conversationObservabilityService.isOptedInToConversationObservability()) {
+		if (this.providerRef.deref()?.conversationTelemetryService.isOptedInToConversationTelemetry()) {
 			const systemMessage: TelemetryChatMessage = {
 				role: "system",
 				content: systemPrompt,
@@ -1365,7 +1365,7 @@ export class Cline {
 			}
 
 			// no need for timeout here, as there's no timestamp to compare to
-			this.providerRef.deref()?.conversationObservabilityService.captureMessage(this.taskId, systemMessage, {
+			this.providerRef.deref()?.conversationTelemetryService.captureMessage(this.taskId, systemMessage, {
 				apiProvider: this.apiProvider,
 				model: this.api.getModel().id,
 				tokensIn: 0,
@@ -3192,7 +3192,7 @@ export class Cline {
 
 		// Capture message data for telemetry,
 		// ONLY if user is opted in, in advanced settings
-		if (this.providerRef.deref()?.conversationObservabilityService.isOptedInToConversationObservability()) {
+		if (this.providerRef.deref()?.conversationTelemetryService.isOptedInToConversationTelemetry()) {
 			// Get the last message from apiConversationHistory
 			const lastMessage = this.apiConversationHistory[this.apiConversationHistory.length - 1]
 
@@ -3203,7 +3203,7 @@ export class Cline {
 			const ts = lastClineMessage.ts
 
 			// Send individual message to telemetry
-			this.providerRef.deref()?.conversationObservabilityService.captureMessage(
+			this.providerRef.deref()?.conversationTelemetryService.captureMessage(
 				this.taskId,
 				// Add the timestamp to the message object for telemetry
 				{
@@ -3220,7 +3220,7 @@ export class Cline {
 
 			// Send entire conversation history to cleanup endpoint
 			// This ensures deleted messages are properly handled in telemetry
-			this.providerRef.deref()?.conversationObservabilityService.cleanupTask(this.taskId, this.clineMessages)
+			this.providerRef.deref()?.conversationTelemetryService.cleanupTask(this.taskId, this.clineMessages)
 		}
 
 		// since we sent off a placeholder api_req_started message to update the webview while waiting to actually start the API request (to load potential details for example), we need to update the text of that message
@@ -3302,7 +3302,7 @@ export class Cline {
 
 				// Capture message data for telemetry after assistant response
 				// ONLY if user is opted in, in advanced settings
-				if (this.providerRef.deref()?.conversationObservabilityService.isOptedInToConversationObservability()) {
+				if (this.providerRef.deref()?.conversationTelemetryService.isOptedInToConversationTelemetry()) {
 					// Get the last message from apiConversationHistory
 					const lastMessage = this.apiConversationHistory[this.apiConversationHistory.length - 1]
 
@@ -3314,7 +3314,7 @@ export class Cline {
 					if (!lastTextMessage) {
 						console.error("No text message found in clineMessages")
 					} else {
-						this.providerRef.deref()?.conversationObservabilityService.captureMessage(
+						this.providerRef.deref()?.conversationTelemetryService.captureMessage(
 							this.taskId,
 							{
 								...lastMessage,
@@ -3481,7 +3481,7 @@ export class Cline {
 
 				// Capture message data for telemetry after assistant response,
 				// ONLY if user is opted in, in advanced settings
-				if (this.providerRef.deref()?.conversationObservabilityService.isOptedInToConversationObservability()) {
+				if (this.providerRef.deref()?.conversationTelemetryService.isOptedInToConversationTelemetry()) {
 					// Get the last message from apiConversationHistory
 					const lastMessage = this.apiConversationHistory[this.apiConversationHistory.length - 1]
 
@@ -3489,7 +3489,7 @@ export class Cline {
 					const lastClineMessage = this.clineMessages[this.clineMessages.length - 1]
 
 					if (lastClineMessage) {
-						this.providerRef.deref()?.conversationObservabilityService.captureMessage(
+						this.providerRef.deref()?.conversationTelemetryService.captureMessage(
 							this.taskId,
 							{
 								...lastMessage,

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -38,7 +38,7 @@ import { TelemetrySetting } from "../../shared/TelemetrySetting"
 import { cleanupLegacyCheckpoints } from "../../integrations/checkpoints/CheckpointMigration"
 import CheckpointTracker from "../../integrations/checkpoints/CheckpointTracker"
 import { getTotalTasksSize } from "../../utils/storage"
-import { ConversationObservabilityService } from "../../services/telemetry/ConversationObservabilityService"
+import { ConversationTelemetryService } from "../../services/telemetry/ConversationTelemetryService"
 import { GlobalFileNames } from "../../global-constants"
 import { setTimeout as setTimeoutPromise } from "node:timers/promises"
 
@@ -127,7 +127,7 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 	mcpHub?: McpHub
 	accountService?: ClineAccountService
 	private latestAnnouncementId = "march-22-2025" // update to some unique identifier when we add a new announcement
-	conversationObservabilityService: ConversationObservabilityService
+	conversationTelemetryService: ConversationTelemetryService
 
 	constructor(
 		readonly context: vscode.ExtensionContext,
@@ -138,7 +138,7 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 		this.workspaceTracker = new WorkspaceTracker(this)
 		this.mcpHub = new McpHub(this)
 		this.accountService = new ClineAccountService(this)
-		this.conversationObservabilityService = new ConversationObservabilityService(this)
+		this.conversationTelemetryService = new ConversationTelemetryService(this)
 
 		// Clean up legacy checkpoints
 		cleanupLegacyCheckpoints(this.context.globalStorageUri.fsPath, this.outputChannel).catch((error) => {
@@ -170,7 +170,7 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 		this.mcpHub?.dispose()
 		this.mcpHub = undefined
 		this.accountService = undefined
-		this.conversationObservabilityService.shutdown()
+		this.conversationTelemetryService.shutdown()
 		this.outputChannel.appendLine("Disposed all disposables")
 		ClineProvider.activeInstances.delete(this)
 	}


### PR DESCRIPTION
Reverts cline/cline#2448

Reverting due to shift in business priorities.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Reverts conversation observability feature and renames related services to telemetry due to business priority changes.
> 
>   - **Behavior**:
>     - Reverts conversation observability feature due to business priority changes.
>     - Removes `cline.conversationObservability` setting from `package.json`.
>   - **Renames**:
>     - Renames `ConversationObservabilityService` to `ConversationTelemetryService` in `Cline.ts` and `ClineProvider.ts`.
>     - Renames `isOptedInToConversationObservability()` to `isOptedInToConversationTelemetry()` in `ConversationTelemetryService.ts`.
>     - Renames `captureMessage()` and `cleanupTask()` methods to use `conversationTelemetryService` instead of `conversationObservabilityService` in `Cline.ts`.
>   - **Files**:
>     - `ConversationObservabilityService.ts` renamed to `ConversationTelemetryService.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 58287c08c2178f2fdcf7a0f0e8b7b29b022b79c7. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->