### PR TITLE
Trevhud/eng 279

### DIFF
--- a/.changeset/mighty-pants-sort.md
+++ b/.changeset/mighty-pants-sort.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Move the MCP Restart and Delete buttons and add an auto-approve all toggle

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -823,9 +823,20 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 					}
 					case "toggleToolAutoApprove": {
 						try {
-							await this.mcpHub?.toggleToolAutoApprove(message.serverName!, message.toolName!, message.autoApprove!)
+							await this.mcpHub?.toggleToolAutoApprove(
+								message.serverName!,
+								message.toolNames!,
+								message.autoApprove!,
+							)
 						} catch (error) {
-							console.error(`Failed to toggle auto-approve for tool ${message.toolName}:`, error)
+							if (message.toolNames?.length === 1) {
+								console.error(
+									`Failed to toggle auto-approve for server ${message.serverName} with tool ${message.toolNames[0]}:`,
+									error,
+								)
+							} else {
+								console.error(`Failed to toggle auto-approve tools for server ${message.serverName}:`, error)
+							}
 						}
 						break
 					}

--- a/src/services/mcp/McpHub.ts
+++ b/src/services/mcp/McpHub.ts
@@ -634,7 +634,7 @@ export class McpHub {
 		)
 	}
 
-	async toggleToolAutoApprove(serverName: string, toolName: string, shouldAllow: boolean): Promise<void> {
+	async toggleToolAutoApprove(serverName: string, toolNames: string[], shouldAllow: boolean): Promise<void> {
 		try {
 			const settingsPath = await this.getMcpSettingsFilePath()
 			const content = await fs.readFile(settingsPath, "utf-8")
@@ -646,14 +646,16 @@ export class McpHub {
 			}
 
 			const autoApprove = config.mcpServers[serverName].autoApprove
-			const toolIndex = autoApprove.indexOf(toolName)
+			for (const toolName of toolNames) {
+				const toolIndex = autoApprove.indexOf(toolName)
 
-			if (shouldAllow && toolIndex === -1) {
-				// Add tool to autoApprove list
-				autoApprove.push(toolName)
-			} else if (!shouldAllow && toolIndex !== -1) {
-				// Remove tool from autoApprove list
-				autoApprove.splice(toolIndex, 1)
+				if (shouldAllow && toolIndex === -1) {
+					// Add tool to autoApprove list
+					autoApprove.push(toolName)
+				} else if (!shouldAllow && toolIndex !== -1) {
+					// Remove tool from autoApprove list
+					autoApprove.splice(toolIndex, 1)
+				}
 			}
 
 			await fs.writeFile(settingsPath, JSON.stringify(config, null, 2))

--- a/src/shared/WebviewMessage.ts
+++ b/src/shared/WebviewMessage.ts
@@ -81,7 +81,7 @@ export interface WebviewMessage {
 	timeout?: number
 	// For toggleToolAutoApprove
 	serverName?: string
-	toolName?: string
+	toolNames?: string[]
 	autoApprove?: boolean
 
 	// For auth

--- a/webview-ui/src/components/mcp/McpToolRow.tsx
+++ b/webview-ui/src/components/mcp/McpToolRow.tsx
@@ -11,13 +11,15 @@ type McpToolRowProps = {
 const McpToolRow = ({ tool, serverName }: McpToolRowProps) => {
 	const { autoApprovalSettings } = useExtensionState()
 
-	const handleAutoApproveChange = () => {
-		if (!serverName) return
+	// Accept the event object
+	const handleAutoApproveChange = (event: any) => {
+		// Only proceed if the event was triggered by a direct user interaction
+		if (!serverName || !event.isTrusted) return
 
 		vscode.postMessage({
 			type: "toggleToolAutoApprove",
 			serverName,
-			toolName: tool.name,
+			toolNames: [tool.name],
 			autoApprove: !tool.autoApprove,
 		})
 	}

--- a/webview-ui/src/components/mcp/McpView.tsx
+++ b/webview-ui/src/components/mcp/McpView.tsx
@@ -205,7 +205,7 @@ export const TabButton = ({
 
 // Server Row Component
 const ServerRow = ({ server }: { server: McpServer }) => {
-	const { mcpMarketplaceCatalog } = useExtensionState()
+	const { mcpMarketplaceCatalog, autoApprovalSettings } = useExtensionState()
 
 	const [isExpanded, setIsExpanded] = useState(false)
 	const [isDeleting, setIsDeleting] = useState(false)
@@ -457,13 +457,15 @@ const ServerRow = ({ server }: { server: McpServer }) => {
 											gap: "8px",
 											width: "100%",
 										}}>
-										<VSCodeCheckbox
-											style={{ alignSelf: "center" }}
-											checked={server.tools.every((tool) => tool.autoApprove)}
-											onChange={handleAutoApproveChange}
-											data-tool="all-tools">
-											Auto-approve all tools
-										</VSCodeCheckbox>
+										{server.name && autoApprovalSettings.enabled && autoApprovalSettings.actions.useMcp && (
+											<VSCodeCheckbox
+												style={{ alignSelf: "center" }}
+												checked={server.tools.every((tool) => tool.autoApprove)}
+												onChange={handleAutoApproveChange}
+												data-tool="all-tools">
+												Auto-approve all tools
+											</VSCodeCheckbox>
+										)}
 										{server.tools.map((tool) => (
 											<McpToolRow key={tool.name} tool={tool} serverName={server.name} />
 										))}

--- a/webview-ui/src/components/mcp/McpView.tsx
+++ b/webview-ui/src/components/mcp/McpView.tsx
@@ -312,7 +312,7 @@ const ServerRow = ({ server }: { server: McpServer }) => {
 					{getMcpServerDisplayName(server.name, mcpMarketplaceCatalog)}
 				</span>
 				{/* Collapsed view controls */}
-				{!isExpanded && !server.error && (
+				{!server.error && (
 					<div style={{ display: "flex", alignItems: "center", gap: "4px", marginLeft: "8px" }}>
 						<VSCodeButton
 							appearance="icon"
@@ -442,19 +442,6 @@ const ServerRow = ({ server }: { server: McpServer }) => {
 							fontSize: "13px",
 							borderRadius: "0 0 4px 4px",
 						}}>
-						<div style={{ display: "flex", gap: "8px", margin: "0 7px 3px 7px" }}>
-							<VSCodeButton
-								appearance="secondary"
-								onClick={handleRestart}
-								disabled={server.status === "connecting"}
-								style={{ flex: 1 }}>
-								{server.status === "connecting" ? "Restarting..." : "Restart Server"}
-							</VSCodeButton>
-
-							<DangerButton style={{ flex: 1 }} disabled={isDeleting} onClick={handleDelete}>
-								{isDeleting ? "Deleting..." : "Delete Server"}
-							</DangerButton>
-						</div>
 						<VSCodePanels>
 							<VSCodePanelTab id="tools">Tools ({server.tools?.length || 0})</VSCodePanelTab>
 							<VSCodePanelTab id="resources">
@@ -531,6 +518,23 @@ const ServerRow = ({ server }: { server: McpServer }) => {
 								))}
 							</VSCodeDropdown>
 						</div>
+						<VSCodeButton
+							appearance="secondary"
+							onClick={handleRestart}
+							disabled={server.status === "connecting"}
+							style={{
+								width: "calc(100% - 14px)",
+								margin: "0 7px 3px 7px",
+							}}>
+							{server.status === "connecting" ? "Restarting..." : "Restart Server"}
+						</VSCodeButton>
+
+						<DangerButton
+							style={{ width: "calc(100% - 14px)", margin: "5px 7px 3px 7px" }}
+							disabled={isDeleting}
+							onClick={handleDelete}>
+							{isDeleting ? "Deleting..." : "Delete Server"}
+						</DangerButton>
 					</div>
 				)
 			)}

--- a/webview-ui/src/components/mcp/McpView.tsx
+++ b/webview-ui/src/components/mcp/McpView.tsx
@@ -457,18 +457,18 @@ const ServerRow = ({ server }: { server: McpServer }) => {
 											gap: "8px",
 											width: "100%",
 										}}>
+										{server.tools.map((tool) => (
+											<McpToolRow key={tool.name} tool={tool} serverName={server.name} />
+										))}
 										{server.name && autoApprovalSettings.enabled && autoApprovalSettings.actions.useMcp && (
 											<VSCodeCheckbox
-												style={{ alignSelf: "center" }}
+												style={{ marginBottom: -10 }}
 												checked={server.tools.every((tool) => tool.autoApprove)}
 												onChange={handleAutoApproveChange}
 												data-tool="all-tools">
 												Auto-approve all tools
 											</VSCodeCheckbox>
 										)}
-										{server.tools.map((tool) => (
-											<McpToolRow key={tool.name} tool={tool} serverName={server.name} />
-										))}
 									</div>
 								) : (
 									<div


### PR DESCRIPTION
### Description

Add restart/delete icons on server list items and add auto approve all

### Test Procedure

Test that it marks all tools as auto approve or non-auto approve

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<img width="576" alt="Screenshot 2025-03-27 at 10 11 14 PM" src="https://github.com/user-attachments/assets/bae2a475-f1b4-4818-b94d-b9eb9fa309d4" />

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add UI controls for restarting/deleting MCP servers and auto-approving all tools, with backend support for handling multiple tool names.
> 
>   - **UI Enhancements**:
>     - Add restart and delete buttons for MCP servers in `McpView.tsx` and `ServerRow` component.
>     - Add "Auto-approve all tools" checkbox in `McpToolRow.tsx` and `ServerRow` component.
>   - **Functionality**:
>     - Modify `toggleToolAutoApprove` in `ClineProvider.ts` and `McpHub.ts` to handle multiple tool names.
>     - Update `WebviewMessage.ts` to support multiple tool names for auto-approval.
>   - **Error Handling**:
>     - Improve error logging for auto-approve failures in `ClineProvider.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 3eb0d8a701035ace6ff467f2f398a647ca434ce7. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->