### PR TITLE
feat(extension): add access to history, mcp, and new task buttons in pop-out view

### DIFF
--- a/.changeset/fluffy-pants-jog.md
+++ b/.changeset/fluffy-pants-jog.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": minor
+---
+
+feat(extension): add access to history, mcp, and new task buttons in popout view

--- a/package.json
+++ b/package.json
@@ -161,6 +161,43 @@
 					"when": "view == claude-dev.SidebarProvider"
 				}
 			],
+			"editor/title": [
+				{
+					"command": "cline.plusButtonClicked",
+					"group": "navigation@1",
+					"when": "activeWebviewPanelId == claude-dev.TabPanelProvider"
+				},
+				{
+					"command": "cline.mcpButtonClicked",
+					"group": "navigation@2",
+					"when": "activeWebviewPanelId == claude-dev.TabPanelProvider"
+				},
+				{
+					"command": "cline.historyButtonClicked",
+					"group": "navigation@3",
+					"when": "activeWebviewPanelId == claude-dev.TabPanelProvider"
+				},
+				{
+					"command": "cline.popoutButtonClicked",
+					"group": "navigation@4",
+					"when": "activeWebviewPanelId == claude-dev.TabPanelProvider"
+				},
+				{
+					"command": "cline.openDocumentation",
+					"group": "navigation@5",
+					"when": "activeWebviewPanelId == claude-dev.TabPanelProvider"
+				},
+				{
+					"command": "cline.accountButtonClicked",
+					"group": "navigation@6",
+					"when": "activeWebviewPanelId == claude-dev.TabPanelProvider"
+				},
+				{
+					"command": "cline.settingsButtonClicked",
+					"group": "navigation@7",
+					"when": "activeWebviewPanelId == claude-dev.TabPanelProvider"
+				}
+			],
 			"editor/context": [
 				{
 					"command": "cline.addToChat",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -43,9 +43,15 @@ export function activate(context: vscode.ExtensionContext) {
 	context.subscriptions.push(
 		vscode.commands.registerCommand("cline.plusButtonClicked", async () => {
 			Logger.log("Plus button Clicked")
-			await sidebarProvider.clearTask()
-			await sidebarProvider.postStateToWebview()
-			await sidebarProvider.postMessageToWebview({
+			const visibleProvider = ClineProvider.getVisibleInstance()
+			if (!visibleProvider) {
+				Logger.log("Cannot find any visible Cline instances.")
+				return
+			}
+
+			await visibleProvider.clearTask()
+			await visibleProvider.postStateToWebview()
+			await visibleProvider.postMessageToWebview({
 				type: "action",
 				action: "chatButtonClicked",
 			})
@@ -54,7 +60,13 @@ export function activate(context: vscode.ExtensionContext) {
 
 	context.subscriptions.push(
 		vscode.commands.registerCommand("cline.mcpButtonClicked", () => {
-			sidebarProvider.postMessageToWebview({
+			const visibleProvider = ClineProvider.getVisibleInstance()
+			if (!visibleProvider) {
+				Logger.log("Cannot find any visible Cline instances.")
+				return
+			}
+
+			visibleProvider.postMessageToWebview({
 				type: "action",
 				action: "mcpButtonClicked",
 			})
@@ -100,7 +112,13 @@ export function activate(context: vscode.ExtensionContext) {
 	context.subscriptions.push(
 		vscode.commands.registerCommand("cline.settingsButtonClicked", () => {
 			//vscode.window.showInformationMessage(message)
-			sidebarProvider.postMessageToWebview({
+			const visibleClineProvider = ClineProvider.getVisibleInstance()
+			if (!visibleClineProvider) {
+				Logger.log("Cannot find any visible Cline instances.")
+				return
+			}
+
+			visibleClineProvider.postMessageToWebview({
 				type: "action",
 				action: "settingsButtonClicked",
 			})
@@ -109,7 +127,13 @@ export function activate(context: vscode.ExtensionContext) {
 
 	context.subscriptions.push(
 		vscode.commands.registerCommand("cline.historyButtonClicked", () => {
-			sidebarProvider.postMessageToWebview({
+			const visibleProvider = ClineProvider.getVisibleInstance()
+			if (!visibleProvider) {
+				Logger.log("Cannot find any visible Cline instances.")
+				return
+			}
+
+			visibleProvider.postMessageToWebview({
 				type: "action",
 				action: "historyButtonClicked",
 			})
@@ -118,7 +142,13 @@ export function activate(context: vscode.ExtensionContext) {
 
 	context.subscriptions.push(
 		vscode.commands.registerCommand("cline.accountButtonClicked", () => {
-			sidebarProvider.postMessageToWebview({
+			const visibleProvider = ClineProvider.getVisibleInstance()
+			if (!visibleProvider) {
+				Logger.log("Cannot find any visible Cline instances.")
+				return
+			}
+
+			visibleProvider.postMessageToWebview({
 				type: "action",
 				action: "accountButtonClicked",
 			})


### PR DESCRIPTION
### Description

<!-- Describe your changes in detail. What problem does this PR solve? -->

- Added new commands to the editor/title section in package.json to ensure buttons are available in the popped-out view.
- Updated command registrations in src/extension.ts to use `ClineProvider.getVisibleInstance()`

try resolves #1222 

### Test Procedure

<!-- How did you test this? Are you confident that it will not introduce bugs? If so, why? -->

Playing around in editor view with Cline for a while, and also in the sidebars.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

Demo:

https://github.com/user-attachments/assets/7addafe6-3a46-4220-8622-eed0e19df4ad


### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add access to history, MCP, and new task buttons in pop-out view by updating commands in `package.json` and `src/extension.ts`.
> 
>   - **Commands**:
>     - Added new commands to `editor/title` in `package.json` for `cline.plusButtonClicked`, `cline.mcpButtonClicked`, `cline.historyButtonClicked`, `cline.popoutButtonClicked`, `cline.openDocumentation`, `cline.accountButtonClicked`, and `cline.settingsButtonClicked`.
>   - **Command Registration**:
>     - Updated command registrations in `src/extension.ts` to use `ClineProvider.getVisibleInstance()` for `cline.plusButtonClicked`, `cline.mcpButtonClicked`, `cline.historyButtonClicked`, `cline.accountButtonClicked`, and `cline.settingsButtonClicked`.
>   - **Behavior**:
>     - Ensures buttons are available in the pop-out view, providing access to history, MCP, and new task functionalities.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 9b6d88e7aea928d872a53e3bf347fd81737dd6f3. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->