### PR TITLE
Updated feedback to model when diff edit fails

### DIFF
--- a/.changeset/breezy-items-bake.md
+++ b/.changeset/breezy-items-bake.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": minor
+---
+
+improving search and replace edit failure behaviors

--- a/src/core/Cline.ts
+++ b/src/core/Cline.ts
@@ -1754,7 +1754,9 @@ export class Cline {
 												`This is likely because the SEARCH block content doesn't match exactly with what's in the file, or if you used multiple SEARCH/REPLACE blocks they may not have been in the order they appear in the file.\n\n` +
 												`The file was reverted to its original state:\n\n` +
 												`<file_content path="${relPath.toPosix()}">\n${this.diffViewProvider.originalContent}\n</file_content>\n\n` +
-												`Try again with fewer/more precise SEARCH blocks.\n(If you run into this error two times in a row, you may use the write_to_file tool as a fallback.)`,
+												`First, make sure you call the read_file tool and re-read the file again in case any changes were made, to get its latest state. Then, make a proper, TARGETED search and replace edit using the write_to_file tool.` +
+												`You can play around with fewer/more precise SEARCH blocks.\n(If you run into this error three times in a row, you may use the write_to_file tool as a fallback. ` +
+												`Keep in mind, the write_to_file fallback is far from ideal, as this means you'll be re-writing the entire contents of the file just to meake a few edits, which takes time and money.)`,
 										),
 									)
 									await this.diffViewProvider.revertChanges()

--- a/src/core/Cline.ts
+++ b/src/core/Cline.ts
@@ -1755,7 +1755,7 @@ export class Cline {
 												`The file was reverted to its original state:\n\n` +
 												`<file_content path="${relPath.toPosix()}">\n${this.diffViewProvider.originalContent}\n</file_content>\n\n` +
 												`First, make sure you call the read_file tool and re-read the file again in case any changes were made, to get its latest state. Then, make a proper, TARGETED search and replace edit using the write_to_file tool.` +
-												`You can play around with fewer/more precise SEARCH blocks.\n(If you run into this error three times in a row, you may use the write_to_file tool as a fallback. ` +
+												`You may want to try fewer/more precise SEARCH blocks.\n(If you run into this error three times in a row, you may use the write_to_file tool as a fallback. ` +
 												`Keep in mind, the write_to_file fallback is far from ideal, as this means you'll be re-writing the entire contents of the file just to make a few edits, which takes time and money. So let's bias towards using replace_in_file as effectively as possible)`,
 										),
 									)

--- a/src/core/Cline.ts
+++ b/src/core/Cline.ts
@@ -1756,7 +1756,7 @@ export class Cline {
 												`<file_content path="${relPath.toPosix()}">\n${this.diffViewProvider.originalContent}\n</file_content>\n\n` +
 												`First, make sure you call the read_file tool and re-read the file again in case any changes were made, to get its latest state. Then, make a proper, TARGETED search and replace edit using the write_to_file tool.` +
 												`You can play around with fewer/more precise SEARCH blocks.\n(If you run into this error three times in a row, you may use the write_to_file tool as a fallback. ` +
-												`Keep in mind, the write_to_file fallback is far from ideal, as this means you'll be re-writing the entire contents of the file just to meake a few edits, which takes time and money. So let's bias towards using replace_in_file as effectively as possible)`,
+												`Keep in mind, the write_to_file fallback is far from ideal, as this means you'll be re-writing the entire contents of the file just to make a few edits, which takes time and money. So let's bias towards using replace_in_file as effectively as possible)`,
 										),
 									)
 									await this.diffViewProvider.revertChanges()

--- a/src/core/Cline.ts
+++ b/src/core/Cline.ts
@@ -1756,7 +1756,7 @@ export class Cline {
 												`<file_content path="${relPath.toPosix()}">\n${this.diffViewProvider.originalContent}\n</file_content>\n\n` +
 												`First, make sure you call the read_file tool and re-read the file again in case any changes were made, to get its latest state. Then, make a proper, TARGETED search and replace edit using the write_to_file tool.` +
 												`You can play around with fewer/more precise SEARCH blocks.\n(If you run into this error three times in a row, you may use the write_to_file tool as a fallback. ` +
-												`Keep in mind, the write_to_file fallback is far from ideal, as this means you'll be re-writing the entire contents of the file just to meake a few edits, which takes time and money.)`,
+												`Keep in mind, the write_to_file fallback is far from ideal, as this means you'll be re-writing the entire contents of the file just to meake a few edits, which takes time and money. So let's bias towards using replace_in_file as effectively as possible)`,
 										),
 									)
 									await this.diffViewProvider.revertChanges()


### PR DESCRIPTION
### Description

Everyone experiences Cline messing up a targeted search & replace edit and then immediately jumping to write an entire file. This is pretty painful to watch, and leaves a bad taste in your mouth. 

In my experience working with cline, telling him to "Please re-read the contents of the entire file, then make a proper, TARGETED search & replace diff edit" works every time, and gets me back on track. 

So I'd like to 
1. Include these instructions that I usually type manually in the automated diff_error feedback the model gets. 
2. Bias cline towards being more persistent with the <replace_in_file> tool. Imo, trying to use <write_to_file> is almost ALWAYS a mistake after a failed <replace_in_file>. 

I am aware we already send `this.diffViewProvider.originalContent` -- but clearly it's not enough if my manual instructions to re-read the file and make a proper search and replace diff edit consistently works to get Cline back on track. I'm torn between removing that altogether and just asking cline to re-read, or keeping it, and asking cline to re-read on top of having `originalContent`, as an opportunity for cline to read, take a breather, and think about what a proper targeted diff edit should look like. 

### Test Procedure

<!-- How did you test this? Are you confident that it will not introduce bugs? If so, why? -->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [ ] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Improves feedback for failed search and replace operations in `Cline.ts` to encourage re-reading files and retrying targeted edits.
> 
>   - **Behavior**:
>     - Updates feedback in `Cline.ts` for failed search and replace operations to instruct re-reading the file and retrying a targeted edit.
>     - Suggests using `replace_in_file` over `write_to_file` to avoid unnecessary full file writes.
>   - **Misc**:
>     - Adds a changeset file `breezy-items-bake.md` for version tracking.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for d366ff3744f2f63024e52e64f93615b66f94d146. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->