### PR TITLE
Capturing telemetry events for write to file failures

### DIFF
--- a/.changeset/dirty-rice-film.md
+++ b/.changeset/dirty-rice-film.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": minor
+---
+
+added telemetry to track replace_in_file tool failures

--- a/src/core/Cline.ts
+++ b/src/core/Cline.ts
@@ -1748,6 +1748,16 @@ export class Cline {
 									)
 								} catch (error) {
 									await this.say("diff_error", relPath)
+
+									// Extract error type from error message if possible, or use a generic type
+									const errorType =
+										error instanceof Error && error.message.includes("does not match anything")
+											? "search_not_found"
+											: "other_diff_error"
+
+									// Add telemetry for diff edit failure
+									telemetryService.captureDiffEditFailure(this.taskId, errorType)
+
 									pushToolResult(
 										formatResponse.toolError(
 											`${(error as Error)?.message}\n\n` +

--- a/src/services/telemetry/TelemetryService.ts
+++ b/src/services/telemetry/TelemetryService.ts
@@ -32,6 +32,8 @@ class PostHogClient {
 			HISTORICAL_LOADED: "task.historical_loaded",
 			// Tracks when the retry button is clicked for failed operations
 			RETRY_CLICKED: "task.retry_clicked",
+			// Tracks when a diff edit (replace_in_file) operation fails
+			DIFF_EDIT_FAILED: "task.diff_edit_failed",
 		},
 		// UI interaction events for tracking user engagement
 		UI: {
@@ -373,6 +375,21 @@ class PostHogClient {
 			event: PostHogClient.EVENTS.UI.TASK_POPPED,
 			properties: {
 				taskId,
+			},
+		})
+	}
+
+	/**
+	 * Records when a diff edit (replace_in_file) operation fails
+	 * @param taskId Unique identifier for the task
+	 * @param errorType Type of error that occurred (e.g., "search_not_found", "invalid_format")
+	 */
+	public captureDiffEditFailure(taskId: string, errorType?: string) {
+		this.capture({
+			event: PostHogClient.EVENTS.TASK.DIFF_EDIT_FAILED,
+			properties: {
+				taskId,
+				errorType,
 			},
 		})
 	}


### PR DESCRIPTION
### Description

now capturing telemetry for failed write to file events

### Test Procedure

<!-- How did you test this? Are you confident that it will not introduce bugs? If so, why? -->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add telemetry tracking for `replace_in_file` tool failures in `Cline.ts` using new `DIFF_EDIT_FAILED` event in `TelemetryService.ts`.
> 
>   - **Telemetry**:
>     - Add `DIFF_EDIT_FAILED` event in `TelemetryService.ts` to track failed `replace_in_file` operations.
>     - Implement `captureDiffEditFailure()` in `TelemetryService.ts` to log failures with `taskId` and `errorType`.
>   - **Error Handling**:
>     - In `Cline.ts`, capture telemetry for diff edit failures in `replace_in_file` tool using `telemetryService.captureDiffEditFailure()`.
>     - Handle specific error types like `search_not_found` and `other_diff_error` in `Cline.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 3d9d823b0fe91dac9f36541efb76e2f1c7b1db10. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->