### PR TITLE
Remove max width on account view

### DIFF
--- a/webview-ui/src/components/account/AccountView.tsx
+++ b/webview-ui/src/components/account/AccountView.tsx
@@ -147,7 +147,7 @@ export const ClineAccountView = () => {
 					</div>
 				</div>
 			) : (
-				<div className="flex flex-col items-center pr-3 max-w-[400px]">
+				<div className="flex flex-col items-center pr-3">
 					<ClineLogoWhite className="size-16 mb-4" />
 
 					<p style={{}}>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove `max-w-[400px]` constraint from `ClineAccountView` div for unauthenticated users.
> 
>   - **Layout**:
>     - Removed `max-w-[400px]` from the div in `ClineAccountView` when user is not logged in, allowing it to expand fully.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 0ac55ea6800556cfab2a7d82094c3156100fe329. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->