### PR TITLE
Remove docs link

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,11 +103,6 @@
 				"when": "cline.isDevMode"
 			},
 			{
-				"command": "cline.openDocumentation",
-				"title": "Documentation",
-				"icon": "$(book)"
-			},
-			{
 				"command": "cline.addToChat",
 				"title": "Add to Cline",
 				"category": "Cline"
@@ -146,18 +141,13 @@
 					"when": "view == claude-dev.SidebarProvider"
 				},
 				{
-					"command": "cline.openDocumentation",
+					"command": "cline.accountButtonClicked",
 					"group": "navigation@5",
 					"when": "view == claude-dev.SidebarProvider"
 				},
 				{
-					"command": "cline.accountButtonClicked",
-					"group": "navigation@6",
-					"when": "view == claude-dev.SidebarProvider"
-				},
-				{
 					"command": "cline.settingsButtonClicked",
-					"group": "navigation@7",
+					"group": "navigation@6",
 					"when": "view == claude-dev.SidebarProvider"
 				}
 			],
@@ -183,18 +173,13 @@
 					"when": "activeWebviewPanelId == claude-dev.TabPanelProvider"
 				},
 				{
-					"command": "cline.openDocumentation",
+					"command": "cline.accountButtonClicked",
 					"group": "navigation@5",
 					"when": "activeWebviewPanelId == claude-dev.TabPanelProvider"
 				},
 				{
-					"command": "cline.accountButtonClicked",
-					"group": "navigation@6",
-					"when": "activeWebviewPanelId == claude-dev.TabPanelProvider"
-				},
-				{
 					"command": "cline.settingsButtonClicked",
-					"group": "navigation@7",
+					"group": "navigation@6",
 					"when": "activeWebviewPanelId == claude-dev.TabPanelProvider"
 				}
 			],

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -155,12 +155,6 @@ export function activate(context: vscode.ExtensionContext) {
 		}),
 	)
 
-	context.subscriptions.push(
-		vscode.commands.registerCommand("cline.openDocumentation", () => {
-			vscode.env.openExternal(vscode.Uri.parse("https://docs.cline.bot/"))
-		}),
-	)
-
 	/*
 	We use the text document content provider API to show the left side for diff view by creating a virtual document for the original content. This makes it readonly so users know to edit the right side if they want to keep their changes.
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove `cline.openDocumentation` command and related menu entries from `package.json` and `extension.ts`.
> 
>   - **Commands**:
>     - Remove `cline.openDocumentation` command from `package.json` and `extension.ts`.
>   - **Menus**:
>     - Remove `cline.openDocumentation` from `view/title` and `editor/title` menus in `package.json`.
>     - Adjust `group` numbers for remaining commands in `package.json`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 66b54823f3ecbaeff96a168a9967b5a04a9a6fae. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->