### PR TITLE
Fix matching errors in the blockAnchorFallbackMatch method of diff.ts caused by using some special line matching in extreme cases; for example, using '/**' as the starting line and '}' as the ending line.

### DIFF
--- a/src/core/assistant-message/diff_edge_cases3.test.ts
+++ b/src/core/assistant-message/diff_edge_cases3.test.ts
@@ -1,0 +1,165 @@
+import { constructNewFileContent as cnfc2 } from "./diff"
+import { describe, it } from "mocha"
+import { expect } from "chai"
+
+describe("constructNewFileContent", () => {
+	it("should use the most similar block when multiple matches are found", async () => {
+		const original = `/** 
+ * comment1-1
+ * comment1-2
+ * comment1-3
+ */
+function foo(){
+    // foo
+}
+
+/**
+ * comment2-1
+ * comment2-2
+ * comment2-3
+ */
+function bar(){
+    // bar
+}`
+		const diff = `<<<<<<< SEARCH
+/**
+ * comment2-1.diff
+ * comment2-2
+ * comment2-3
+ */
+function bar(){
+    // bar
+}
+=======
+/**
+ * comment2-1
+ * comment2-2
+ * comment2-3
+ */
+function bar(){
+    // new bar
+}
+>>>>>>> REPLACE
+`
+		const result1 = await cnfc2(diff, original, true)
+		expect(result1).to.equal(`/** 
+ * comment1-1
+ * comment1-2
+ * comment1-3
+ */
+function foo(){
+    // foo
+}
+
+/**
+ * comment2-1
+ * comment2-2
+ * comment2-3
+ */
+function bar(){
+    // new bar
+}
+`)
+	})
+
+	it("should use the single matched block when only one is found", async () => {
+		const original = `/** 
+ * comment1-1
+ * comment1-2
+ * comment1-3
+ */
+function foo(){
+    // foo
+}
+
+/**
+ * comment2-1
+ * comment2-2
+ */
+function bar(){
+    // bar
+}`
+		const diff = `<<<<<<< SEARCH
+/**
+ * comment2-1.diff
+ * comment2-2
+ */
+function bar(){
+    // bar
+}
+=======
+/**
+ * comment2-1
+ * comment2-2
+ */
+function bar(){
+    // new bar
+}
+>>>>>>> REPLACE
+`
+		const result1 = await cnfc2(diff, original, true)
+		expect(result1).to.equal(`/** 
+ * comment1-1
+ * comment1-2
+ * comment1-3
+ */
+function foo(){
+    // foo
+}
+
+/**
+ * comment2-1
+ * comment2-2
+ */
+function bar(){
+    // new bar
+}
+`)
+	})
+
+	it("should match blocks with only 3 lines", async () => {
+		const original = `/** 
+ * comment1-1
+ * comment1-2
+ * comment1-3
+ */
+function foo(){
+    // foo
+}
+
+/**
+ * comment2-1
+ */
+`
+		const diff = `<<<<<<< SEARCH
+/**
+ * comment2-1.diff
+ */
+=======
+/**
+ * comment2-1
+ */
+function bar(){
+    // new bar
+}
+>>>>>>> REPLACE
+`
+		const result1 = await cnfc2(diff, original, true)
+		expect(result1).to.equal(`/** 
+ * comment1-1
+ * comment1-2
+ * comment1-3
+ */
+function foo(){
+    // foo
+}
+
+/**
+ * comment2-1
+ */
+function bar(){
+    // new bar
+}
+`)
+	})
+})


### PR DESCRIPTION
### Description

In the blockAnchorFallbackMatch method, when a block is matched using the first and last lines;
1. If only one block is matched; then calculate the average similarity and pass if it exceeds 0.5; otherwise, consider the match as failed
2. If multiple blocks are matched, sort them based on average similarity and select the highest one; if the similarity exceeds 0.7, it passes; otherwise, it is considered a failed match.

### Test Procedure

![image](https://github.com/user-attachments/assets/4482826d-3cdb-40be-a799-f30ccc9616ed)


### Type of Change

-   [X] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [X] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [X] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [X] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [X] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots


### Additional Notes

If time allows; please take a look at another [PR 2334](https://github.com/cline/cline/pull/2334); this issue has been around for some time, the following SEARCH-REPLACE block causes the 'replace_in_file' tool to perform incorrect replacements; resulting in the need for manual edits to the diff editor content.
If you have any better suggestions for a fix or follow-up plans, please let me know.

```
<<< SEARCH
content
=======
new content
>>>>>>> REPLACE
```
```
<<<<<<< SEARCH
content
=======
new content
```