### PR TITLE
fix: Update Google Gemini API key link

### DIFF
--- a/.changeset/chatty-scissors-rescue.md
+++ b/.changeset/chatty-scissors-rescue.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Update Google Gemini API key link

--- a/webview-ui/src/components/settings/ApiOptions.tsx
+++ b/webview-ui/src/components/settings/ApiOptions.tsx
@@ -733,7 +733,7 @@ const ApiOptions = ({ showModelOptions, apiErrorMessage, modelIdErrorMessage, is
 						This key is stored locally and only used to make API requests from this extension.
 						{!apiConfiguration?.geminiApiKey && (
 							<VSCodeLink
-								href="https://ai.google.dev/"
+								href="https://aistudio.google.com/apikey"
 								style={{
 									display: "inline",
 									fontSize: "inherit",


### PR DESCRIPTION
### Description

Google updated where you can sign up for API keys. This is the new link that will take people closer to where they can generate an API key.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update Google Gemini API key link in `ApiOptions.tsx` to direct users to the correct page for key generation.
> 
>   - **Behavior**:
>     - Update Google Gemini API key link in `ApiOptions.tsx` from `https://ai.google.dev/` to `https://aistudio.google.com/apikey`.
>   - **Misc**:
>     - This change ensures users are directed to the correct page for generating a Google Gemini API key.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 65128edf1a3ff29a0371a9bf0d7d96b87441082a. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->