### PR TITLE
Fix: Store correct commitHash value

### DIFF
--- a/src/integrations/checkpoints/CheckpointTracker.ts
+++ b/src/integrations/checkpoints/CheckpointTracker.ts
@@ -166,8 +166,8 @@ class CheckpointTracker {
 				"--allow-empty": null,
 				"--no-verify": null,
 			})
-			const commitHash = result.commit || ""
-			console.warn(`Checkpoint commit created.`)
+			const commitHash = (result.commit || "").replace(/^HEAD\s+/, "")
+			console.warn(`Checkpoint commit created: `, commitHash)
 
 			const durationMs = Math.round(performance.now() - startTime)
 			telemetryService.captureCheckpointUsage(this.taskId, "commit_created", durationMs)


### PR DESCRIPTION
### Description

This PR fixes an issue where the commit hashes were checkpoints could be stored in ui_messages.json with an incorrect value that contained a "HEAD" prefix. This was occurring when the checkpoints shadow git was in a detached head state on some devices. This change simply removes the HEAD prefix when storing the commit hash.

### Test Procedure

On a workspace where checkpoints were not restoring due to this issue, it should be resolved in new tasks that are created.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [X] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [X] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [X] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [X] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [X] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix incorrect commit hash storage in `CheckpointTracker.ts` by removing "HEAD" prefix in `commit()` method.
> 
>   - **Bug Fix**:
>     - In `CheckpointTracker.ts`, fix incorrect commit hash storage by removing "HEAD" prefix in `commit()` method.
>     - Affects commit creation when shadow git is in a detached head state.
>   - **Logging**:
>     - Update log message in `commit()` to include the corrected commit hash.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 9744afcabf68f57abce68bfc46cb6b1ab526ae67. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->