### PR TITLE
Fix: Add support for existing bad commitHash values

### DIFF
--- a/.changeset/polite-mangos-report.md
+++ b/.changeset/polite-mangos-report.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Add support for bad commitHashes already stored in ui_messages.json

--- a/src/integrations/checkpoints/CheckpointTracker.ts
+++ b/src/integrations/checkpoints/CheckpointTracker.ts
@@ -355,7 +355,7 @@ class CheckpointTracker {
 		// Stage all changes so that untracked files appear in diff summary
 		await this.gitOperations.addCheckpointFiles(git)
 
-		const diffRange = rhsHash ? `${this.cleanCommitHash(lhsHash)}..${this.cleanCommitHash(rhsHash)}` : lhsHash
+		const diffRange = rhsHash ? `${this.cleanCommitHash(lhsHash)}..${this.cleanCommitHash(rhsHash)}` : this.cleanCommitHash(lhsHash)
 		const diffSummary = await git.diffSummary([diffRange])
 
 		const durationMs = Math.round(performance.now() - startTime)

--- a/src/integrations/checkpoints/CheckpointTracker.ts
+++ b/src/integrations/checkpoints/CheckpointTracker.ts
@@ -291,7 +291,8 @@ class CheckpointTracker {
 		// Stage all changes so that untracked files appear in diff summary
 		await this.gitOperations.addCheckpointFiles(git)
 
-		const diffRange = rhsHash ? `${this.cleanCommitHash(lhsHash)}..${this.cleanCommitHash(rhsHash)}` : lhsHash
+		const cleanRhs = rhsHash ? this.cleanCommitHash(rhsHash) : undefined
+		const diffRange = cleanRhs ? `${this.cleanCommitHash(lhsHash)}..${cleanRhs}` : this.cleanCommitHash(lhsHash)
 		console.info(`Diff range: ${diffRange}`)
 		const diffSummary = await git.diffSummary([diffRange])
 
@@ -355,7 +356,8 @@ class CheckpointTracker {
 		// Stage all changes so that untracked files appear in diff summary
 		await this.gitOperations.addCheckpointFiles(git)
 
-		const diffRange = rhsHash ? `${this.cleanCommitHash(lhsHash)}..${this.cleanCommitHash(rhsHash)}` : this.cleanCommitHash(lhsHash)
+		const cleanRhs = rhsHash ? this.cleanCommitHash(rhsHash) : undefined
+		const diffRange = cleanRhs ? `${this.cleanCommitHash(lhsHash)}..${cleanRhs}` : this.cleanCommitHash(lhsHash)
 		const diffSummary = await git.diffSummary([diffRange])
 
 		const durationMs = Math.round(performance.now() - startTime)

--- a/src/integrations/checkpoints/CheckpointTracker.ts
+++ b/src/integrations/checkpoints/CheckpointTracker.ts
@@ -47,6 +47,14 @@ class CheckpointTracker {
 	private gitOperations: GitOperations
 
 	/**
+	 * Helper method to clean commit hashes that might have a "HEAD " prefix.
+	 * Used for backward compatibility with old tasks that stored hashes with the prefix.
+	 */
+	private cleanCommitHash(hash: string): string {
+		return hash.startsWith("HEAD ") ? hash.slice(5) : hash
+	}
+
+	/**
 	 * Creates a new CheckpointTracker instance to manage checkpoints for a specific task.
 	 * The constructor is private - use the static create() method to instantiate.
 	 *
@@ -242,7 +250,7 @@ class CheckpointTracker {
 		const gitPath = await getShadowGitPath(this.globalStoragePath, this.taskId, this.cwdHash)
 		const git = simpleGit(path.dirname(gitPath))
 		console.debug(`Using shadow git at: ${gitPath}`)
-		await git.reset(["--hard", commitHash]) // Hard reset to target commit
+		await git.reset(["--hard", this.cleanCommitHash(commitHash)]) // Hard reset to target commit
 		console.debug(`Successfully reset to checkpoint: ${commitHash}`)
 
 		const durationMs = Math.round(performance.now() - startTime)
@@ -283,7 +291,7 @@ class CheckpointTracker {
 		// Stage all changes so that untracked files appear in diff summary
 		await this.gitOperations.addCheckpointFiles(git)
 
-		const diffRange = rhsHash ? `${lhsHash}..${rhsHash}` : lhsHash
+		const diffRange = rhsHash ? `${this.cleanCommitHash(lhsHash)}..${this.cleanCommitHash(rhsHash)}` : lhsHash
 		console.info(`Diff range: ${diffRange}`)
 		const diffSummary = await git.diffSummary([diffRange])
 
@@ -294,7 +302,7 @@ class CheckpointTracker {
 
 			let beforeContent = ""
 			try {
-				beforeContent = await git.show([`${lhsHash}:${filePath}`])
+				beforeContent = await git.show([`${this.cleanCommitHash(lhsHash)}:${filePath}`])
 			} catch (_) {
 				// file didn't exist in older commit => remains empty
 			}
@@ -302,7 +310,7 @@ class CheckpointTracker {
 			let afterContent = ""
 			if (rhsHash) {
 				try {
-					afterContent = await git.show([`${rhsHash}:${filePath}`])
+					afterContent = await git.show([`${this.cleanCommitHash(rhsHash)}:${filePath}`])
 				} catch (_) {
 					// file didn't exist in newer commit => remains empty
 				}
@@ -347,7 +355,7 @@ class CheckpointTracker {
 		// Stage all changes so that untracked files appear in diff summary
 		await this.gitOperations.addCheckpointFiles(git)
 
-		const diffRange = rhsHash ? `${lhsHash}..${rhsHash}` : lhsHash
+		const diffRange = rhsHash ? `${this.cleanCommitHash(lhsHash)}..${this.cleanCommitHash(rhsHash)}` : lhsHash
 		const diffSummary = await git.diffSummary([diffRange])
 
 		const durationMs = Math.round(performance.now() - startTime)


### PR DESCRIPTION
### Description

Companion PR to #2543. This change allows Cline to use checkpoints where the commitHash was stored incorrectly. If a bad hash is detected, the "HEAD " prefix will be removed before the value is passed into diff & reset git commands.

### Test Procedure

In a workspace where the HEAD prefix issue has occurred, attempt to restore/diff on checkpoints before and after running Cline with this code change. The diffs/restore should not work in older versions, but will work with these changes.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [X] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [X] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [X] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [X] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [X] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds `cleanCommitHash()` in `CheckpointTracker` to handle commit hashes with incorrect 'HEAD ' prefix, ensuring compatibility with older checkpoints.
> 
>   - **Behavior**:
>     - Adds `cleanCommitHash()` method in `CheckpointTracker` to remove "HEAD " prefix from commit hashes.
>     - Updates `resetHead()`, `getDiffSet()`, and `getDiffCount()` in `CheckpointTracker` to use `cleanCommitHash()` for commit hash processing.
>   - **Misc**:
>     - Adds changeset `polite-mangos-report.md` to document support for bad commit hashes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 013a391545ce3985ee5361a698ca6250615dee94. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->