### PR TITLE
added anthropic to list of retrying providers when api call fails

### DIFF
--- a/.changeset/sixty-mayflies-exercise.md
+++ b/.changeset/sixty-mayflies-exercise.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": minor
+---
+
+Added anthropic to the list of providers we retry failed api requests for

--- a/src/core/task/index.ts
+++ b/src/core/task/index.ts
@@ -1403,8 +1403,8 @@ export class Task {
 				await this.saveClineMessages()
 
 				this.didAutomaticallyRetryFailedApiRequest = true
-			} else if (isOpenRouter && !this.didAutomaticallyRetryFailedApiRequest) {
-				if (isOpenRouterContextWindowError) {
+			} else if ((isOpenRouter || isAnthropic) && !this.didAutomaticallyRetryFailedApiRequest) {
+				if (isOpenRouterContextWindowError || (isAnthropic && isAnthropicContextWindowError)) {
 					this.conversationHistoryDeletedRange = this.contextManager.getNextTruncationRange(
 						this.apiConversationHistory,
 						this.conversationHistoryDeletedRange,


### PR DESCRIPTION
### Description

In response to https://www.reddit.com/r/CLine/comments/1jnepck/a_very_annoying_cline_design_oversight/

It appears this guy was frustrated because we don't automatically retry api requests when they fail for the anthropic provider, like we do with openrouter/cline providers. I think in the past this wasn't needed because anthropic was very stable, but guess it's an issue now. 

### Test Procedure

Note: i tested this by throwing an error in the actual request code, and it appears to work successfully:
<img width="518" alt="Screenshot 2025-03-30 at 7 18 26 PM" src="https://github.com/user-attachments/assets/c7728a47-d750-48ec-a75c-d7cfb2b25517" />


### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots


### Additional Notes


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `anthropic` to retry logic for failed API requests in `Task` class in `index.ts`.
> 
>   - **Behavior**:
>     - Add `anthropic` to retry logic for failed API requests in `Task` class in `index.ts`.
>     - Modify condition in `attemptApiRequest` to include `isAnthropic` alongside `isOpenRouter` for retrying requests.
>   - **Misc**:
>     - Add changeset `sixty-mayflies-exercise.md` to document the addition of `anthropic` to retry logic.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for b132fe719bdf54695904423df64b428df48530e0. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->