### PR TITLE
Fixing the UX bug for Requestly Provider's  model selection

### DIFF
--- a/.changeset/cold-terms-fail.md
+++ b/.changeset/cold-terms-fail.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+fix bug in Requestly UX for model selection

--- a/webview-ui/src/components/settings/ApiOptions.tsx
+++ b/webview-ui/src/components/settings/ApiOptions.tsx
@@ -1702,6 +1702,12 @@ export function normalizeApiConfiguration(apiConfiguration?: ApiConfiguration): 
 				selectedModelId: apiConfiguration?.lmStudioModelId || "",
 				selectedModelInfo: openAiModelInfoSaneDefaults,
 			}
+		case "requesty":
+			return {
+				selectedProvider: provider,
+				selectedModelId: apiConfiguration?.requestyModelId || "",
+				selectedModelInfo: openAiModelInfoSaneDefaults,
+			}
 		case "vscode-lm":
 			return {
 				selectedProvider: provider,


### PR DESCRIPTION
### Description
Solves the issue https://github.com/cline/cline/issues/2536 where Requesty API shows the same default model claude sonnet 3.7 in model selection. 

<details>
<summary>Explanation </summary>

## Core problem: 
The normalizeApiConfiguration function at the bottom of ApiOptions.tsx is responsible for figuring out the selectedProvider, selectedModelId, and selectedModelInfo based on your settings. It has specific case blocks for providers like "anthropic", "bedrock", "openrouter", etc., but was missing a case for "requesty": block.

## Fallback Behavior: 
Because there's no specific case for "requesty", the code falls through to the default: case at the end. The default case uses the settings for the "anthropic" provider (anthropicModels and anthropicDefaultModelId).
Result: This means that whenever "requesty" is selected as the provider, the UI incorrectly uses Anthropic's default model ID (which is likely claude-3-7-sonnet-20240715) and its corresponding info, leading to "Claude 3.7 Sonnet" always being displayed, even though the backend (RequestyHandler) is was using the correct requestyModelId you entered(I verified in the UX)


## Solution: 
I added a specific case "requesty": block within the switch (provider) statement in the normalizeApiConfiguration function in webview-ui/src/components/settings/ApiOptions.tsx.

This new case will correctly retrieve the requestyModelId from the apiConfiguration and use the right model info.

</details>


### Test Procedure
Tested this locally and verified the UX, its a small UX change. 


### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Before this bug fix:
<img width="373" alt="image" src="https://github.com/user-attachments/assets/5ed62c13-2869-4d78-999f-207724a377e1" />

After this bug fix:
<img width="373" alt="image" src="https://github.com/user-attachments/assets/66ceb18c-f592-4ae2-9967-d46bc36f3c90" />



<!-- For UI changes, add screenshots here -->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes UX bug in `ApiOptions.tsx` by adding a case for `requesty` provider to ensure correct model selection.
> 
>   - **Behavior**:
>     - Fixes UX bug in `normalizeApiConfiguration` in `ApiOptions.tsx` by adding a case for `requesty` provider.
>     - Ensures correct `requestyModelId` and model info are used instead of defaulting to Anthropic's settings.
>   - **Misc**:
>     - Adds a changeset `cold-terms-fail.md` to document the patch.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 395ace018363325c09aa1b87e95b0dd76c8d7078. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->