### PR TITLE
Add Remote Server Function

### DIFF
--- a/.changeset/hot-socks-watch.md
+++ b/.changeset/hot-socks-watch.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": minor
+---
+
+Add remote server programatically

--- a/src/services/mcp/McpHub.ts
+++ b/src/services/mcp/McpHub.ts
@@ -652,6 +652,10 @@ export class McpHub {
 				autoApprove: [],
 			}
 
+			// TS expects the server config to be a McpServerConfig, but we know it's valid
+			// The issue is that the type is not having the transportType field added to it
+
+			// ToDo: Add input types reflecting the non-transformed version
 			settings.mcpServers[serverName] = serverConfig as unknown as McpServerConfig
 			const settingsPath = await this.getMcpSettingsFilePath()
 			await fs.writeFile(settingsPath, JSON.stringify(settings, null, 2))

--- a/src/services/mcp/McpHub.ts
+++ b/src/services/mcp/McpHub.ts
@@ -31,7 +31,6 @@ import { arePathsEqual } from "../../utils/path"
 import { secondsToMs } from "../../utils/time"
 import { GlobalFileNames } from "../../core/storage/disk"
 import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js"
-import { Logger } from "../logging/Logger"
 
 // Default timeout for internal MCP data requests in milliseconds; is not the same as the user facing timeout stored as DEFAULT_MCP_TIMEOUT_SECONDS
 const DEFAULT_REQUEST_TIMEOUT_MS = 5000

--- a/src/services/mcp/McpHub.ts
+++ b/src/services/mcp/McpHub.ts
@@ -31,6 +31,7 @@ import { arePathsEqual } from "../../utils/path"
 import { secondsToMs } from "../../utils/time"
 import { GlobalFileNames } from "../../core/storage/disk"
 import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js"
+import { Logger } from "../logging/Logger"
 
 // Default timeout for internal MCP data requests in milliseconds; is not the same as the user facing timeout stored as DEFAULT_MCP_TIMEOUT_SECONDS
 const DEFAULT_REQUEST_TIMEOUT_MS = 5000
@@ -278,6 +279,7 @@ export class McpHub {
 
 			// Connect
 			await client.connect(transport)
+
 			connection.server.status = "connected"
 			connection.server.error = ""
 
@@ -625,6 +627,46 @@ export class McpHub {
 			console.error("Failed to update autoApprove settings:", error)
 			vscode.window.showErrorMessage("Failed to update autoApprove settings")
 			throw error // Re-throw to ensure the error is properly handled
+		}
+	}
+
+	public async addRemoteServer(serverName: string, serverUrl: string) {
+		try {
+			const settings = await this.readAndValidateMcpSettingsFile()
+			if (!settings) {
+				throw new Error("Failed to read MCP settings")
+			}
+
+			if (settings.mcpServers[serverName]) {
+				throw new Error(`An MCP server with the name "${serverName}" already exists`)
+			}
+
+			const urlValidation = z.string().url().safeParse(serverUrl)
+			if (!urlValidation.success) {
+				throw new Error(`Invalid server URL: ${serverUrl}. Please provide a valid URL.`)
+			}
+
+			const serverConfig = {
+				url: serverUrl,
+				disabled: false,
+				autoApprove: [],
+			}
+
+			settings.mcpServers[serverName] = serverConfig as unknown as McpServerConfig
+			const settingsPath = await this.getMcpSettingsFilePath()
+			await fs.writeFile(settingsPath, JSON.stringify(settings, null, 2))
+
+			await this.updateServerConnections(settings.mcpServers)
+
+			vscode.window.showInformationMessage(`Added and connected to ${serverName} MCP server`)
+		} catch (error) {
+			console.error("Failed to add remote MCP server:", error)
+
+			vscode.window.showErrorMessage(
+				`Failed to add remote MCP server: ${error instanceof Error ? error.message : String(error)}`,
+			)
+
+			throw error
 		}
 	}
 


### PR DESCRIPTION
### Description

Add a function to the McpHub to add a remote server to the config programmatically

### Test Procedure

Tests will be done when hooking it up to the UI

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add `addRemoteServer()` to `McpHub` for programmatically adding remote servers with validation and connection handling.
> 
>   - **New Feature**:
>     - Adds `addRemoteServer()` method to `McpHub` class in `McpHub.ts` to programmatically add remote servers.
>     - Validates server name uniqueness and URL format before adding.
>     - Updates MCP settings file and connects to the new server.
>     - Displays success or error messages via `vscode.window` notifications.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 5e96b1dbde9ce3760ef92ca25b1a56c836f79c90. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->