### PR TITLE
Check character savings from context management before deciding on additional truncation

### DIFF
--- a/.changeset/tiny-peaches-grow.md
+++ b/.changeset/tiny-peaches-grow.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": minor
+---
+
+char counting to determine whether context management is sufficient to skip truncation

--- a/src/core/context-management/ContextManager.ts
+++ b/src/core/context-management/ContextManager.ts
@@ -553,7 +553,7 @@ export class ContextManager {
 
 			// `hasExistingAlterations` will also include the alterations we just made
 			const hasExistingAlterations = this.contextHistoryUpdates.has(i)
-			const hasNewAlterations = uniqueFileReadIndices.has(i) // we don't consider changes to the first assistant message for now
+			const hasNewAlterations = uniqueFileReadIndices.has(i)
 
 			if (Array.isArray(message.content)) {
 				for (let blockIndex = 0; blockIndex < message.content.length; blockIndex++) {
@@ -561,8 +561,8 @@ export class ContextManager {
 					const block = message.content[blockIndex]
 
 					if (block.type === "text" && block.text) {
+						// true if we just altered it, or it was altered before
 						if (hasExistingAlterations) {
-							// true if we just altered it, or it was altered before
 							const innerMap = this.contextHistoryUpdates.get(i)
 							const updates = innerMap?.get(blockIndex)
 
@@ -585,7 +585,7 @@ export class ContextManager {
 								totalCharCount += block.text.length
 							}
 						} else {
-							// reach here if there's no alterations for this outer block
+							// reach here if there's no alterations for this outer index
 							totalCharCount += block.text.length
 						}
 					} else if (block.type === "image" && block.source) {

--- a/src/core/context-management/ContextManager.ts
+++ b/src/core/context-management/ContextManager.ts
@@ -547,7 +547,9 @@ export class ContextManager {
 			// looping over the outer indicies of messages
 			const message = apiMessages[i]
 
-			if (!message.content) continue
+			if (!message.content) {
+				continue
+			}
 
 			// `hasExistingAlterations` will also include the alterations we just made
 			const hasExistingAlterations = this.contextHistoryUpdates.has(i)

--- a/src/core/context-management/ContextManager.ts
+++ b/src/core/context-management/ContextManager.ts
@@ -134,13 +134,26 @@ export class ContextManager {
 					const keep = totalTokens / 2 > maxAllowedSize ? "quarter" : "half"
 
 					// currently if we are able to trim context we will optimistically continue
-					let anyContextUpdates = this.applyContextOptimizations(
+					let [anyContextUpdates, uniqueFileReadIndices] = this.applyContextOptimizations(
 						apiConversationHistory,
 						conversationHistoryDeletedRange ? conversationHistoryDeletedRange[1] + 1 : 2,
 						timestamp,
 					)
 
-					if (!anyContextUpdates) {
+					let needToTruncate = true
+					if (anyContextUpdates) {
+						// determine whether we've saved enough chars to not truncate
+						const charactersSavedPercentage = this.calculateContextOptimizationMetrics(
+							apiConversationHistory,
+							conversationHistoryDeletedRange,
+							uniqueFileReadIndices,
+						)
+						if (charactersSavedPercentage >= 0.3) {
+							needToTruncate = false
+						}
+					}
+
+					if (needToTruncate) {
 						// go ahead with truncation
 						anyContextUpdates = anyContextUpdates || this.applyStandardContextTruncationNoticeChange(timestamp)
 
@@ -353,8 +366,8 @@ export class ContextManager {
 		apiMessages: Anthropic.Messages.MessageParam[],
 		startFromIndex: number,
 		timestamp: number,
-	): boolean {
-		const fileReadUpdatesBool = this.findAndPotentiallySaveFileReadContextHistoryUpdates(
+	): [boolean, Set<number>] {
+		const [fileReadUpdatesBool, uniqueFileReadIndices] = this.findAndPotentiallySaveFileReadContextHistoryUpdates(
 			apiMessages,
 			startFromIndex,
 			timestamp,
@@ -363,7 +376,7 @@ export class ContextManager {
 		// true if any context optimization steps alter state
 		const contextHistoryUpdated = fileReadUpdatesBool
 
-		return contextHistoryUpdated
+		return [contextHistoryUpdated, uniqueFileReadIndices]
 	}
 
 	/**
@@ -387,7 +400,7 @@ export class ContextManager {
 		apiMessages: Anthropic.Messages.MessageParam[],
 		startFromIndex: number,
 		timestamp: number,
-	): boolean {
+	): [boolean, Set<number>] {
 		const fileReadIndices = this.getPossibleDuplicateFileReads(apiMessages, startFromIndex)
 		return this.applyFileReadContextHistoryUpdates(fileReadIndices, timestamp)
 	}
@@ -476,10 +489,15 @@ export class ContextManager {
 	}
 
 	/**
-	 * alter all occurrences of file read operations to indicate they occurred, and latest should be referenced
+	 * alter all occurrences of file read operations and track which messages were updated
+	 * returns the outer index of messages we alter, to count number of changes
 	 */
-	private applyFileReadContextHistoryUpdates(fileReadIndices: Map<string, [number, string][]>, timestamp: number): boolean {
+	private applyFileReadContextHistoryUpdates(
+		fileReadIndices: Map<string, [number, string][]>,
+		timestamp: number,
+	): [boolean, Set<number>] {
 		let didUpdate = false
+		const updatedMessageIndices = new Set<number>() // track which messages we update on this round
 
 		for (const indices of fileReadIndices.values()) {
 			// Only process if there are multiple reads of the same file
@@ -505,10 +523,105 @@ export class ContextManager {
 					innerMap.set(blockIndex, updates)
 
 					didUpdate = true
+					updatedMessageIndices.add(messageIndex)
 				}
 			}
 		}
 
-		return didUpdate
+		return [didUpdate, updatedMessageIndices]
+	}
+
+	/**
+	 * count total characters in messages and total savings within this range
+	 */
+	private countCharactersAndSavingsInRange(
+		apiMessages: Anthropic.Messages.MessageParam[],
+		startIndex: number,
+		endIndex: number,
+		uniqueFileReadIndices: Set<number>,
+	): { totalCharacters: number; charactersSaved: number } {
+		let totalCharCount = 0
+		let totalCharactersSaved = 0
+
+		for (let i = startIndex; i < endIndex; i++) {
+			// looping over the outer indicies of messages
+			const message = apiMessages[i]
+
+			if (!message.content) continue
+
+			// `hasExistingAlterations` will also include the alterations we just made
+			const hasExistingAlterations = this.contextHistoryUpdates.has(i)
+			const hasNewAlterations = uniqueFileReadIndices.has(i) // we don't consider changes to the first assistant message for now
+
+			if (Array.isArray(message.content)) {
+				for (let blockIndex = 0; blockIndex < message.content.length; blockIndex++) {
+					// looping over inner indices of messages
+					const block = message.content[blockIndex]
+
+					if (block.type === "text" && block.text) {
+						if (hasExistingAlterations) {
+							// true if we just altered it, or it was altered before
+							const innerMap = this.contextHistoryUpdates.get(i)
+							const updates = innerMap?.get(blockIndex)
+
+							if (updates && updates.length > 0) {
+								// exists if we have an update for the message at this index
+								const latestUpdate = updates[updates.length - 1]
+
+								// if block was just altered, then calculate savings
+								if (hasNewAlterations) {
+									const originalTextLength = block.text.length
+									const newTextLength = latestUpdate[2][0].length // replacement text
+									totalCharactersSaved += originalTextLength - newTextLength
+
+									totalCharCount += originalTextLength
+								} else {
+									totalCharCount += latestUpdate[2][0].length
+								}
+							} else {
+								// reach here if there was one inner index with an update, but now we are at a different index, so updates is not defined
+								totalCharCount += block.text.length
+							}
+						} else {
+							// reach here if there's no alterations for this outer block
+							totalCharCount += block.text.length
+						}
+					} else if (block.type === "image" && block.source) {
+						if (block.source.type === "base64" && block.source.data) {
+							totalCharCount += block.source.data.length
+						}
+					}
+				}
+			}
+		}
+
+		return { totalCharacters: totalCharCount, charactersSaved: totalCharactersSaved }
+	}
+
+	/**
+	 * count total percentage character savings across in-range conversation
+	 */
+	private calculateContextOptimizationMetrics(
+		apiMessages: Anthropic.Messages.MessageParam[],
+		conversationHistoryDeletedRange: [number, number] | undefined,
+		uniqueFileReadIndices: Set<number>,
+	): number {
+		// count for first user-assistant message pair
+		const firstChunkResult = this.countCharactersAndSavingsInRange(apiMessages, 0, 2, uniqueFileReadIndices)
+
+		// count for the remaining in-range messages
+		const secondChunkResult = this.countCharactersAndSavingsInRange(
+			apiMessages,
+			conversationHistoryDeletedRange ? conversationHistoryDeletedRange[1] + 1 : 2,
+			apiMessages.length,
+			uniqueFileReadIndices,
+		)
+
+		const totalCharacters = firstChunkResult.totalCharacters + secondChunkResult.totalCharacters
+		const totalCharactersSaved = firstChunkResult.charactersSaved + secondChunkResult.charactersSaved
+
+		const percentCharactersSaved = totalCharacters === 0 ? 0 : totalCharactersSaved / totalCharacters
+
+		return percentCharactersSaved
 	}
 }


### PR DESCRIPTION
### Description

Add logic to check for character savings to decide whether we should truncate history even after context management.

### Test Procedure

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

### Additional Notes

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds character savings check in `ContextManager.ts` to decide on truncation, skipping it if savings are 30% or more.
> 
>   - **Behavior**:
>     - Adds logic in `ContextManager.ts` to check character savings before deciding on truncation.
>     - Introduces `calculateContextOptimizationMetrics()` to compute percentage of characters saved.
>     - Skips truncation if character savings are 30% or more.
>   - **Functions**:
>     - Modifies `applyContextOptimizations()` to return indices of updated messages.
>     - Adds `countCharactersAndSavingsInRange()` to calculate character savings in a message range.
>     - Updates `applyFileReadContextHistoryUpdates()` to track updated message indices.
>   - **Misc**:
>     - Updates logic in `getNewContextMessagesAndMetadata()` to incorporate character savings check.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 1fba329505406b2ab56565175303296fa1d45991. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->