### PR TITLE
refactor & perf of file `BrowserSettingsMenu.tsx`

### DIFF
--- a/.changeset/silver-rice-sleep.md
+++ b/.changeset/silver-rice-sleep.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+refactor & perf of file BrowserSettingsMenu.tsx


### PR DESCRIPTION
### Description

- declare const outside the component for inline style object
- declare const outside the component for `DropdownOptions`
- replace unnecessary `useState` to `useRef`
- add `useMemo` for dropdownValue

### Test Procedure

Test with `Fn + F5` => Open Cline in Editor => enter `browser_action_launch github`

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<img width="1280" alt="截圖 2025-04-01 晚上10 26 10" src="https://github.com/user-attachments/assets/d33c7d4d-98b7-4453-9ea9-181aa4ff7c51" />

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Refactor and optimize `BrowserSettingsMenu.tsx` by moving constants outside the component, replacing `useState` with `useRef`, and using `useMemo` for dropdown values.
> 
>   - **Refactoring**:
>     - Move constant inline styles (`containerStyle`, `codiconStyle`, `VSCodeCheckboxStyle`, `VSCodeDropdownStyle`) outside the component.
>     - Move `DropdownOptions` JSX elements outside the component.
>   - **Performance**:
>     - Replace `useState` with `useRef` for `hasMouseEntered` to avoid unnecessary re-renders.
>     - Use `useMemo` for `dropdownValue` to memoize the computed value based on `browserSettings`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for feb0615842b55ceda7044e6e98eefca2c03d6dd8. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->