### PR TITLE
Fix bug where menu buttons wouldn't open view in sidebar

### DIFF
--- a/src/core/webview/index.ts
+++ b/src/core/webview/index.ts
@@ -44,6 +44,10 @@ export class WebviewProvider implements vscode.WebviewViewProvider {
 		return findLast(Array.from(this.activeInstances), (instance) => instance.view?.visible === true)
 	}
 
+	public static getAllInstances(): WebviewProvider[] {
+		return Array.from(this.activeInstances)
+	}
+
 	async resolveWebviewView(webviewView: vscode.WebviewView | vscode.WebviewPanel) {
 		this.view = webviewView
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -42,33 +42,24 @@ export function activate(context: vscode.ExtensionContext) {
 
 	context.subscriptions.push(
 		vscode.commands.registerCommand("cline.plusButtonClicked", async () => {
-			Logger.log("Plus button Clicked")
-			const visibleWebview = WebviewProvider.getVisibleInstance()
-			if (!visibleWebview) {
-				Logger.log("Cannot find any visible Cline instances.")
-				return
-			}
-
-			await visibleWebview.controller.clearTask()
-			await visibleWebview.controller.postStateToWebview()
-			await visibleWebview.controller.postMessageToWebview({
-				type: "action",
-				action: "chatButtonClicked",
+			WebviewProvider.getAllInstances().forEach(async (instance) => {
+				await instance.controller.clearTask()
+				await instance.controller.postStateToWebview()
+				await instance.controller.postMessageToWebview({
+					type: "action",
+					action: "chatButtonClicked",
+				})
 			})
 		}),
 	)
 
 	context.subscriptions.push(
 		vscode.commands.registerCommand("cline.mcpButtonClicked", () => {
-			const visibleWebview = WebviewProvider.getVisibleInstance()
-			if (!visibleWebview) {
-				Logger.log("Cannot find any visible Cline instances.")
-				return
-			}
-
-			visibleWebview.controller.postMessageToWebview({
-				type: "action",
-				action: "mcpButtonClicked",
+			WebviewProvider.getAllInstances().forEach((instance) => {
+				instance.controller.postMessageToWebview({
+					type: "action",
+					action: "mcpButtonClicked",
+				})
 			})
 		}),
 	)
@@ -111,46 +102,33 @@ export function activate(context: vscode.ExtensionContext) {
 
 	context.subscriptions.push(
 		vscode.commands.registerCommand("cline.settingsButtonClicked", () => {
-			//vscode.window.showInformationMessage(message)
-			const visibleWebview = WebviewProvider.getVisibleInstance()
-			if (!visibleWebview) {
-				Logger.log("Cannot find any visible Cline instances.")
-				return
-			}
-
-			visibleWebview.controller.postMessageToWebview({
-				type: "action",
-				action: "settingsButtonClicked",
+			WebviewProvider.getAllInstances().forEach((instance) => {
+				instance.controller.postMessageToWebview({
+					type: "action",
+					action: "settingsButtonClicked",
+				})
 			})
 		}),
 	)
 
 	context.subscriptions.push(
 		vscode.commands.registerCommand("cline.historyButtonClicked", () => {
-			const visibleWebview = WebviewProvider.getVisibleInstance()
-			if (!visibleWebview) {
-				Logger.log("Cannot find any visible Cline instances.")
-				return
-			}
-
-			visibleWebview.controller.postMessageToWebview({
-				type: "action",
-				action: "historyButtonClicked",
+			WebviewProvider.getAllInstances().forEach((instance) => {
+				instance.controller.postMessageToWebview({
+					type: "action",
+					action: "historyButtonClicked",
+				})
 			})
 		}),
 	)
 
 	context.subscriptions.push(
 		vscode.commands.registerCommand("cline.accountButtonClicked", () => {
-			const visibleWebview = WebviewProvider.getVisibleInstance()
-			if (!visibleWebview) {
-				Logger.log("Cannot find any visible Cline instances.")
-				return
-			}
-
-			visibleWebview.controller.postMessageToWebview({
-				type: "action",
-				action: "accountButtonClicked",
+			WebviewProvider.getAllInstances().forEach((instance) => {
+				instance.controller.postMessageToWebview({
+					type: "action",
+					action: "accountButtonClicked",
+				})
 			})
 		}),
 	)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes bug where menu buttons wouldn't open views in the sidebar by iterating over all `WebviewProvider` instances.
> 
>   - **Behavior**:
>     - Fixes bug where menu buttons wouldn't open views in the sidebar by iterating over all `WebviewProvider` instances in `extension.ts`.
>     - Replaces `getVisibleInstance()` with `getAllInstances()` for commands `cline.plusButtonClicked`, `cline.mcpButtonClicked`, `cline.settingsButtonClicked`, `cline.historyButtonClicked`, and `cline.accountButtonClicked`.
>   - **Functions**:
>     - Adds `getAllInstances()` to `WebviewProvider` in `index.ts` to return all active instances.
>   - **Misc**:
>     - Removes logging and error handling for missing visible instances in `extension.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 34c1d8a58f0fdaa3f64b60617fba725f2d0ca061. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->