### PR TITLE
feat: Add extended thinking for LiteLLM provider

### DIFF
--- a/.changeset/clever-eggs-perform.md
+++ b/.changeset/clever-eggs-perform.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": minor
+---
+
+Add Enable extended thinking for LiteLLM provider

--- a/webview-ui/src/components/settings/ApiOptions.tsx
+++ b/webview-ui/src/components/settings/ApiOptions.tsx
@@ -1205,6 +1205,24 @@ const ApiOptions = ({ showModelOptions, apiErrorMessage, modelIdErrorMessage, is
 						placeholder={"e.g. gpt-4"}>
 						<span style={{ fontWeight: 500 }}>Model ID</span>
 					</VSCodeTextField>
+
+					<>
+						<ThinkingBudgetSlider apiConfiguration={apiConfiguration} setApiConfiguration={setApiConfiguration} />
+						<p
+							style={{
+								fontSize: "12px",
+								marginTop: "5px",
+								color: "var(--vscode-charts-green)",
+							}}>
+							Extended thinking is available for models as Sonnet-3-7, o3-mini, Deepseek R1, etc. More info on{" "}
+							<VSCodeLink
+								href="https://docs.litellm.ai/docs/reasoning_content"
+								style={{ display: "inline", fontSize: "inherit" }}>
+								thinking mode configuration
+							</VSCodeLink>
+						</p>
+					</>
+
 					<p
 						style={{
 							fontSize: "12px",

--- a/webview-ui/src/components/settings/ThinkingBudgetSlider.tsx
+++ b/webview-ui/src/components/settings/ThinkingBudgetSlider.tsx
@@ -123,11 +123,12 @@ const ThinkingBudgetSlider = ({ apiConfiguration, setApiConfiguration }: Thinkin
 			{isEnabled && (
 				<>
 					<LabelContainer>
-						<Label>
+						<Label htmlFor="thinking-budget-slider">
 							<strong>Budget:</strong> {localValue.toLocaleString()} tokens
 						</Label>
 					</LabelContainer>
 					<RangeInput
+						id="thinking-budget-slider"
 						type="range"
 						min={MIN_VALID_TOKENS}
 						max={maxSliderValue}
@@ -139,9 +140,16 @@ const ThinkingBudgetSlider = ({ apiConfiguration, setApiConfiguration }: Thinkin
 						$value={localValue}
 						$min={MIN_VALID_TOKENS}
 						$max={maxSliderValue}
+						aria-label={`Thinking budget: ${localValue.toLocaleString()} tokens`}
+						aria-valuemin={MIN_VALID_TOKENS}
+						aria-valuemax={maxSliderValue}
+						aria-valuenow={localValue}
+						aria-describedby="thinking-budget-description"
 					/>
 
-					<Description>Higher budgets may allow you to achieve more comprehensive and nuanced reasoning</Description>
+					<Description id="thinking-budget-description">
+						Higher budgets may allow you to achieve more comprehensive and nuanced reasoning
+					</Description>
 				</>
 			)}
 		</Container>


### PR DESCRIPTION
### Description

Relates to https://github.com/cline/cline/discussions/2605

### Test Procedure

- User can run models with support to thinking mode with or without reasoning enabled.
- If an user enables the thinking mode with a model not compatible, it returns a `400 litellm.UnsupportedParamsError`

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

**With extended thinking enabled**

![image](https://github.com/user-attachments/assets/ed785174-20e6-4d05-b629-04c177c7d07b)

**With extended thinking disabled**

![image](https://github.com/user-attachments/assets/96324352-4185-4a4d-863b-e5b8ea1ed93a)

**Error when an user enabled extended thinking with a model not compatible with that option**

![image](https://github.com/user-attachments/assets/df631955-c8e7-4b59-96c2-839e0ecc4a75)



<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds extended thinking mode to LiteLLM provider with UI configuration and error handling for unsupported models.
> 
>   - **Behavior**:
>     - Adds extended thinking mode to `LiteLlmHandler` in `litellm.ts`, configurable via `thinkingBudgetTokens`.
>     - Returns `400 litellm.UnsupportedParamsError` if thinking mode is enabled on incompatible models.
>   - **UI**:
>     - Updates `ApiOptions.tsx` to include `ThinkingBudgetSlider` for configuring thinking mode.
>     - Adds informational text and link for supported models and configuration in `ApiOptions.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for ec1c2f25d40859fd83102c3ca8942596a36189d1. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->