### PR TITLE
Fix bug where menu would open in sidebar and open tab

### DIFF
--- a/.changeset/nasty-spies-check.md
+++ b/.changeset/nasty-spies-check.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Fix bug where menu would open in sidebar and open tab

--- a/src/core/webview/index.ts
+++ b/src/core/webview/index.ts
@@ -48,6 +48,14 @@ export class WebviewProvider implements vscode.WebviewViewProvider {
 		return Array.from(this.activeInstances)
 	}
 
+	public static getSidebarInstance() {
+		return Array.from(this.activeInstances).find((instance) => instance.view && "onDidChangeVisibility" in instance.view)
+	}
+
+	public static getTabInstances(): WebviewProvider[] {
+		return Array.from(this.activeInstances).filter((instance) => instance.view && "onDidChangeViewState" in instance.view)
+	}
+
 	async resolveWebviewView(webviewView: vscode.WebviewView | vscode.WebviewPanel) {
 		this.view = webviewView
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -41,26 +41,37 @@ export function activate(context: vscode.ExtensionContext) {
 	)
 
 	context.subscriptions.push(
-		vscode.commands.registerCommand("cline.plusButtonClicked", async () => {
-			WebviewProvider.getAllInstances().forEach(async (instance) => {
-				await instance.controller.clearTask()
-				await instance.controller.postStateToWebview()
-				await instance.controller.postMessageToWebview({
+		vscode.commands.registerCommand("cline.plusButtonClicked", async (webview: any) => {
+			const openChat = async (instance?: WebviewProvider) => {
+				await instance?.controller.clearTask()
+				await instance?.controller.postStateToWebview()
+				await instance?.controller.postMessageToWebview({
 					type: "action",
 					action: "chatButtonClicked",
 				})
-			})
+			}
+			const isSidebar = !webview
+			if (isSidebar) {
+				openChat(WebviewProvider.getSidebarInstance())
+			} else {
+				WebviewProvider.getTabInstances().forEach(openChat)
+			}
 		}),
 	)
 
 	context.subscriptions.push(
-		vscode.commands.registerCommand("cline.mcpButtonClicked", () => {
-			WebviewProvider.getAllInstances().forEach((instance) => {
-				instance.controller.postMessageToWebview({
+		vscode.commands.registerCommand("cline.mcpButtonClicked", (webview: any) => {
+			const openMcp = (instance?: WebviewProvider) =>
+				instance?.controller.postMessageToWebview({
 					type: "action",
 					action: "mcpButtonClicked",
 				})
-			})
+			const isSidebar = !webview
+			if (isSidebar) {
+				openMcp(WebviewProvider.getSidebarInstance())
+			} else {
+				WebviewProvider.getTabInstances().forEach(openMcp)
+			}
 		}),
 	)
 
@@ -101,34 +112,58 @@ export function activate(context: vscode.ExtensionContext) {
 	context.subscriptions.push(vscode.commands.registerCommand("cline.openInNewTab", openClineInNewTab))
 
 	context.subscriptions.push(
-		vscode.commands.registerCommand("cline.settingsButtonClicked", () => {
+		vscode.commands.registerCommand("cline.settingsButtonClicked", (webview: any) => {
 			WebviewProvider.getAllInstances().forEach((instance) => {
-				instance.controller.postMessageToWebview({
-					type: "action",
-					action: "settingsButtonClicked",
-				})
+				const openSettings = async (instance?: WebviewProvider) => {
+					instance?.controller.postMessageToWebview({
+						type: "action",
+						action: "settingsButtonClicked",
+					})
+				}
+				const isSidebar = !webview
+				if (isSidebar) {
+					openSettings(WebviewProvider.getSidebarInstance())
+				} else {
+					WebviewProvider.getTabInstances().forEach(openSettings)
+				}
 			})
 		}),
 	)
 
 	context.subscriptions.push(
-		vscode.commands.registerCommand("cline.historyButtonClicked", () => {
+		vscode.commands.registerCommand("cline.historyButtonClicked", (webview: any) => {
 			WebviewProvider.getAllInstances().forEach((instance) => {
-				instance.controller.postMessageToWebview({
-					type: "action",
-					action: "historyButtonClicked",
-				})
+				const openHistory = async (instance?: WebviewProvider) => {
+					instance?.controller.postMessageToWebview({
+						type: "action",
+						action: "historyButtonClicked",
+					})
+				}
+				const isSidebar = !webview
+				if (isSidebar) {
+					openHistory(WebviewProvider.getSidebarInstance())
+				} else {
+					WebviewProvider.getTabInstances().forEach(openHistory)
+				}
 			})
 		}),
 	)
 
 	context.subscriptions.push(
-		vscode.commands.registerCommand("cline.accountButtonClicked", () => {
+		vscode.commands.registerCommand("cline.accountButtonClicked", (webview: any) => {
 			WebviewProvider.getAllInstances().forEach((instance) => {
-				instance.controller.postMessageToWebview({
-					type: "action",
-					action: "accountButtonClicked",
-				})
+				const openAccount = async (instance?: WebviewProvider) => {
+					instance?.controller.postMessageToWebview({
+						type: "action",
+						action: "accountButtonClicked",
+					})
+				}
+				const isSidebar = !webview
+				if (isSidebar) {
+					openAccount(WebviewProvider.getSidebarInstance())
+				} else {
+					WebviewProvider.getTabInstances().forEach(openAccount)
+				}
 			})
 		}),
 	)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes bug by differentiating sidebar and tab instances for menu actions in `extension.ts`.
> 
>   - **Behavior**:
>     - Fixes bug where menu actions triggered in both sidebar and open tab by differentiating instances in `extension.ts`.
>     - Commands like `cline.plusButtonClicked`, `cline.mcpButtonClicked`, etc., now check if the action is for sidebar or tab using `WebviewProvider.getSidebarInstance()` and `WebviewProvider.getTabInstances()`.
>   - **Functions**:
>     - Adds `getSidebarInstance()` and `getTabInstances()` to `WebviewProvider` in `index.ts` to filter instances based on view type.
>   - **Misc**:
>     - Updates command registration in `extension.ts` to use new instance methods for targeted action execution.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 996292d3f884ad44de7a74b7135d9bd20ff4e611. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->