### PR TITLE
chore(bedrock): Prompt cache is GA

### DIFF
--- a/.changeset/clean-carrots-dress.md
+++ b/.changeset/clean-carrots-dress.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+chore(bedrock): Prompt cache is GA

--- a/webview-ui/src/components/settings/ApiOptions.tsx
+++ b/webview-ui/src/components/settings/ApiOptions.tsx
@@ -635,7 +635,7 @@ const ApiOptions = ({ showModelOptions, apiErrorMessage, modelIdErrorMessage, is
 											awsBedrockUsePromptCache: isChecked,
 										})
 									}}>
-									Use prompt caching (Beta)
+									Use prompt caching
 								</VSCodeCheckbox>
 							</>
 						)}


### PR DESCRIPTION
### Description

Prompt cache has been GA'd! Should remove Beta notation as it is not already in Preview in the active model!

https://docs.aws.amazon.com/bedrock/latest/userguide/prompt-caching.html

### Test Procedure

none.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<img width="203" alt="スクリーンショット 2025-04-02 172339" src="https://github.com/user-attachments/assets/201c868f-018d-4b86-9f9f-66e41e30361f" />


### Additional Notes

None.