### PR TITLE
add approved commands to run in auto mode

### DIFF
--- a/.changeset/stale-shoes-heal.md
+++ b/.changeset/stale-shoes-heal.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": minor
+---
+
+Add list of commands considered safe to run in auto mode

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [3.9.0]
+
+-   Add command auto-approve feature, allowing you to specify which commands should be automatically approved based on string or regex patterns
+-   Read command auto-approve rules from VS Code settings
+-   Improve command approval behavior with rule-based pattern matching
+-   Add detailed documentation for pattern types and best practices
+
 ## [3.8.6]
  
 -   Add UI for adding remote servers

--- a/docs/command-auto-approve.md
+++ b/docs/command-auto-approve.md
@@ -1,0 +1,101 @@
+# Command Auto-Approve Feature
+
+The Command Auto-Approve feature allows you to specify commands that should be automatically approved without prompting. This is useful for repetitive commands that you frequently use and trust.
+
+## Configuration
+
+Configure command auto-approval rules in your VS Code settings. You can define rules in your `settings.json` file:
+
+```json
+"cline.commandAutoApproveRules": [
+  {
+    "pattern": "npm install",
+    "action": "auto-approve"
+  },
+  {
+    "pattern": "/^git (status|pull|push)/",
+    "action": "auto-approve"
+  },
+  {
+    "pattern": "rm -rf node_modules",
+    "action": "require-approval"
+  }
+]
+```
+
+## How It Works
+
+1. Each rule consists of a `pattern` and an `action`
+2. When Cline asks to execute a command, it checks against these rules
+3. If a rule matches, the specified action is taken
+4. If multiple rules match, the last matching rule wins
+5. If no rules match, the global auto-approval setting for commands is used
+
+## Pattern Types
+
+You can use two types of patterns:
+
+### String Pattern
+
+A simple string pattern will match if it's contained anywhere in the command:
+
+```json
+{
+  "pattern": "npm start",
+  "action": "auto-approve"
+}
+```
+
+This will match any command containing "npm start", such as "npm start", "npm start --port=3000", etc.
+
+### Regex Pattern
+
+For more complex matching, use regex patterns by enclosing them in forward slashes:
+
+```json
+{
+  "pattern": "/^npm (start|run dev)( --.*)?$/",
+  "action": "auto-approve"
+}
+```
+
+This will match commands that start with "npm start" or "npm run dev", optionally followed by arguments.
+
+You can also use regex flags after the closing slash:
+
+```json
+{
+  "pattern": "/docker/i",
+  "action": "require-approval"
+}
+```
+
+This will match any command containing "docker" (case-insensitive) and explicitly require approval.
+
+## Actions
+
+Two possible actions can be specified:
+
+- `auto-approve`: Automatically approve the command without prompting
+- `require-approval`: Always require manual approval for the command
+
+## Best Practices
+
+1. Start with a conservative set of rules and add more as you become comfortable
+2. Use `require-approval` for potentially destructive commands
+3. Use regex patterns for precise control
+4. Place more specific patterns after more general ones
+5. Test your rules to ensure they match as expected
+
+## Command Execution Flow
+
+1. Cline detects a command to run
+2. Auto-approval for commands is checked:
+   - If disabled, prompt for approval
+   - If enabled, continue to rule checking
+3. Rules are checked from top to bottom:
+   - If a matching rule is found with `auto-approve`, execute without prompting
+   - If a matching rule is found with `require-approval`, prompt for approval
+4. If no matching rules are found, defer to the global "Auto-approve commands" setting
+
+This feature works in conjunction with the global "Auto-approve commands" setting, allowing for more fine-grained control over which commands require approval.

--- a/src/core/controller/index.ts
+++ b/src/core/controller/index.ts
@@ -1616,27 +1616,27 @@ Here is the project's README to help you get started:\n\n${mcpDetails.readmeCont
 			// Read the command auto-approve rules from VSCode settings
 			const config = vscode.workspace.getConfiguration("cline")
 			const commandAutoApproveRules = config.get<CommandAutoApproveRule[]>("commandAutoApproveRules") || []
-			
+
 			// Get current autoApprovalSettings
 			const { autoApprovalSettings } = await getAllExtensionState(this.context)
-			
+
 			// Update autoApprovalSettings with the rules
 			const updatedSettings = {
 				...autoApprovalSettings,
-				commandAutoApproveRules: Array.isArray(commandAutoApproveRules) ? commandAutoApproveRules : []
+				commandAutoApproveRules: Array.isArray(commandAutoApproveRules) ? commandAutoApproveRules : [],
 			}
-			
+
 			// Save the updated settings
 			await updateGlobalState(this.context, "autoApprovalSettings", updatedSettings)
-			
+
 			// Update the task if it exists
 			if (this.task) {
 				this.task.autoApprovalSettings = updatedSettings
 			}
-			
+
 			// Log that rules were loaded
 			console.log(`Loaded ${commandAutoApproveRules.length} command auto-approve rules from settings`)
-			
+
 			// Post updated state to webview
 			await this.postStateToWebview()
 		} catch (error) {
@@ -1647,7 +1647,7 @@ Here is the project's README to help you get started:\n\n${mcpDetails.readmeCont
 	async getStateToPostToWebview(): Promise<ExtensionState> {
 		// Read the latest command auto-approve rules before getting state
 		await this.readCommandAutoApproveRules()
-		
+
 		const {
 			apiConfiguration,
 			lastShownAnnouncementId,

--- a/src/core/task/index.ts
+++ b/src/core/task/index.ts
@@ -2377,7 +2377,7 @@ export class Task {
 									await this.say("command", command, undefined, false)
 									this.consecutiveAutoApprovedRequestsCount++
 									didAutoApprove = true
-									
+
 									// Log auto-approved command
 									console.log(`Auto-approved command based on rules: ${command}`)
 								} else {

--- a/src/shared/AutoApprovalSettings.ts
+++ b/src/shared/AutoApprovalSettings.ts
@@ -1,4 +1,4 @@
-import { CommandAutoApproveRule } from './CommandAutoApproveRule'
+import { CommandAutoApproveRule } from "./CommandAutoApproveRule"
 
 export interface AutoApprovalSettings {
 	// Whether auto-approval is enabled

--- a/src/shared/AutoApprovalSettings.ts
+++ b/src/shared/AutoApprovalSettings.ts
@@ -1,3 +1,5 @@
+import { CommandAutoApproveRule } from './CommandAutoApproveRule'
+
 export interface AutoApprovalSettings {
 	// Whether auto-approval is enabled
 	enabled: boolean
@@ -12,6 +14,8 @@ export interface AutoApprovalSettings {
 	// Global settings
 	maxRequests: number // Maximum number of auto-approved requests
 	enableNotifications: boolean // Show notifications for approval and task completion
+	// Command auto-approve rules
+	commandAutoApproveRules?: CommandAutoApproveRule[] // Rules for command auto-approval
 }
 
 export const DEFAULT_AUTO_APPROVAL_SETTINGS: AutoApprovalSettings = {
@@ -25,4 +29,5 @@ export const DEFAULT_AUTO_APPROVAL_SETTINGS: AutoApprovalSettings = {
 	},
 	maxRequests: 20,
 	enableNotifications: false,
+	commandAutoApproveRules: [],
 }

--- a/src/shared/CommandAutoApproveRule.ts
+++ b/src/shared/CommandAutoApproveRule.ts
@@ -2,42 +2,42 @@
  * Represents a rule for command auto-approval
  */
 export interface CommandAutoApproveRule {
-  /**
-   * The pattern to match against commands
-   */
-  pattern: string
+	/**
+	 * The pattern to match against commands
+	 */
+	pattern: string
 
-  /**
-   * The action to take when the pattern matches
-   */
-  action: 'auto-approve' | 'require-approval'
+	/**
+	 * The action to take when the pattern matches
+	 */
+	action: "auto-approve" | "require-approval"
 }
 
 /**
  * Auto-approval actions
  */
-export type CommandAutoApproveAction = 'auto-approve' | 'require-approval'
+export type CommandAutoApproveAction = "auto-approve" | "require-approval"
 
 /**
  * Utility function to determine if a command should be auto-approved based on rules
  */
 export function shouldAutoApproveCommand(command: string, rules: CommandAutoApproveRule[]): boolean {
-  if (!rules || rules.length === 0) {
-    return false
-  }
+	if (!rules || rules.length === 0) {
+		return false
+	}
 
-  // Check rules in reverse order (last matching rule wins)
-  for (let i = rules.length - 1; i >= 0; i--) {
-    const rule = rules[i]
-    
-    // Check if rule matches the command
-    if (matchesRule(command, rule.pattern)) {
-      return rule.action === 'auto-approve'
-    }
-  }
+	// Check rules in reverse order (last matching rule wins)
+	for (let i = rules.length - 1; i >= 0; i--) {
+		const rule = rules[i]
 
-  // Default: require approval
-  return false
+		// Check if rule matches the command
+		if (matchesRule(command, rule.pattern)) {
+			return rule.action === "auto-approve"
+		}
+	}
+
+	// Default: require approval
+	return false
 }
 
 /**
@@ -45,22 +45,22 @@ export function shouldAutoApproveCommand(command: string, rules: CommandAutoAppr
  * Supports simple string contains matching and regex patterns
  */
 function matchesRule(command: string, pattern: string): boolean {
-  // Check if pattern is a regex
-  if (pattern.startsWith('/') && pattern.lastIndexOf('/') > 0) {
-    try {
-      // Extract regex and flags
-      const lastSlashIndex = pattern.lastIndexOf('/')
-      const regexPattern = pattern.substring(1, lastSlashIndex)
-      const flags = pattern.substring(lastSlashIndex + 1)
-      
-      const regex = new RegExp(regexPattern, flags)
-      return regex.test(command)
-    } catch (error) {
-      console.error('Invalid regex pattern:', error)
-      return false
-    }
-  }
-  
-  // Default to simple contains matching
-  return command.includes(pattern)
+	// Check if pattern is a regex
+	if (pattern.startsWith("/") && pattern.lastIndexOf("/") > 0) {
+		try {
+			// Extract regex and flags
+			const lastSlashIndex = pattern.lastIndexOf("/")
+			const regexPattern = pattern.substring(1, lastSlashIndex)
+			const flags = pattern.substring(lastSlashIndex + 1)
+
+			const regex = new RegExp(regexPattern, flags)
+			return regex.test(command)
+		} catch (error) {
+			console.error("Invalid regex pattern:", error)
+			return false
+		}
+	}
+
+	// Default to simple contains matching
+	return command.includes(pattern)
 }

--- a/src/shared/CommandAutoApproveRule.ts
+++ b/src/shared/CommandAutoApproveRule.ts
@@ -1,0 +1,66 @@
+/**
+ * Represents a rule for command auto-approval
+ */
+export interface CommandAutoApproveRule {
+  /**
+   * The pattern to match against commands
+   */
+  pattern: string
+
+  /**
+   * The action to take when the pattern matches
+   */
+  action: 'auto-approve' | 'require-approval'
+}
+
+/**
+ * Auto-approval actions
+ */
+export type CommandAutoApproveAction = 'auto-approve' | 'require-approval'
+
+/**
+ * Utility function to determine if a command should be auto-approved based on rules
+ */
+export function shouldAutoApproveCommand(command: string, rules: CommandAutoApproveRule[]): boolean {
+  if (!rules || rules.length === 0) {
+    return false
+  }
+
+  // Check rules in reverse order (last matching rule wins)
+  for (let i = rules.length - 1; i >= 0; i--) {
+    const rule = rules[i]
+    
+    // Check if rule matches the command
+    if (matchesRule(command, rule.pattern)) {
+      return rule.action === 'auto-approve'
+    }
+  }
+
+  // Default: require approval
+  return false
+}
+
+/**
+ * Check if a command matches a rule pattern
+ * Supports simple string contains matching and regex patterns
+ */
+function matchesRule(command: string, pattern: string): boolean {
+  // Check if pattern is a regex
+  if (pattern.startsWith('/') && pattern.lastIndexOf('/') > 0) {
+    try {
+      // Extract regex and flags
+      const lastSlashIndex = pattern.lastIndexOf('/')
+      const regexPattern = pattern.substring(1, lastSlashIndex)
+      const flags = pattern.substring(lastSlashIndex + 1)
+      
+      const regex = new RegExp(regexPattern, flags)
+      return regex.test(command)
+    } catch (error) {
+      console.error('Invalid regex pattern:', error)
+      return false
+    }
+  }
+  
+  // Default to simple contains matching
+  return command.includes(pattern)
+}

--- a/src/test/command-auto-approve.test.ts
+++ b/src/test/command-auto-approve.test.ts
@@ -1,88 +1,82 @@
-import * as assert from 'assert';
-import { describe, it } from 'mocha';
-import { shouldAutoApproveCommand, CommandAutoApproveRule } from '../shared/CommandAutoApproveRule';
+import * as assert from "assert"
+import { describe, it } from "mocha"
+import { shouldAutoApproveCommand, CommandAutoApproveRule } from "../shared/CommandAutoApproveRule"
 
-describe('Command Auto Approve Rules', () => {
-  describe('shouldAutoApproveCommand', () => {
-    it('should return false when no rules are provided', () => {
-      const result = shouldAutoApproveCommand('npm install', []);
-      assert.strictEqual(result, false);
-    });
+describe("Command Auto Approve Rules", () => {
+	describe("shouldAutoApproveCommand", () => {
+		it("should return false when no rules are provided", () => {
+			const result = shouldAutoApproveCommand("npm install", [])
+			assert.strictEqual(result, false)
+		})
 
-    it('should return false when rules is undefined', () => {
-      const result = shouldAutoApproveCommand('npm install', undefined as unknown as CommandAutoApproveRule[]);
-      assert.strictEqual(result, false);
-    });
+		it("should return false when rules is undefined", () => {
+			const result = shouldAutoApproveCommand("npm install", undefined as unknown as CommandAutoApproveRule[])
+			assert.strictEqual(result, false)
+		})
 
-    it('should match simple string patterns', () => {
-      const rules: CommandAutoApproveRule[] = [
-        { pattern: 'npm install', action: 'auto-approve' }
-      ];
-      const result = shouldAutoApproveCommand('npm install express', rules);
-      assert.strictEqual(result, true);
-    });
+		it("should match simple string patterns", () => {
+			const rules: CommandAutoApproveRule[] = [{ pattern: "npm install", action: "auto-approve" }]
+			const result = shouldAutoApproveCommand("npm install express", rules)
+			assert.strictEqual(result, true)
+		})
 
-    it('should follow the "last rule wins" principle', () => {
-      const rules: CommandAutoApproveRule[] = [
-        { pattern: 'npm', action: 'auto-approve' },
-        { pattern: 'install', action: 'require-approval' }
-      ];
-      const result = shouldAutoApproveCommand('npm install express', rules);
-      assert.strictEqual(result, false);
+		it('should follow the "last rule wins" principle', () => {
+			const rules: CommandAutoApproveRule[] = [
+				{ pattern: "npm", action: "auto-approve" },
+				{ pattern: "install", action: "require-approval" },
+			]
+			const result = shouldAutoApproveCommand("npm install express", rules)
+			assert.strictEqual(result, false)
 
-      const reversedRules: CommandAutoApproveRule[] = [
-        { pattern: 'install', action: 'require-approval' },
-        { pattern: 'npm', action: 'auto-approve' }
-      ];
-      const reversedResult = shouldAutoApproveCommand('npm install express', reversedRules);
-      assert.strictEqual(reversedResult, true);
-    });
+			const reversedRules: CommandAutoApproveRule[] = [
+				{ pattern: "install", action: "require-approval" },
+				{ pattern: "npm", action: "auto-approve" },
+			]
+			const reversedResult = shouldAutoApproveCommand("npm install express", reversedRules)
+			assert.strictEqual(reversedResult, true)
+		})
 
-    it('should handle regex patterns correctly', () => {
-      const rules: CommandAutoApproveRule[] = [
-        { pattern: '/^npm (install|list)/', action: 'auto-approve' }
-      ];
-      
-      // Should match
-      assert.strictEqual(shouldAutoApproveCommand('npm install express', rules), true);
-      assert.strictEqual(shouldAutoApproveCommand('npm list', rules), true);
-      
-      // Should not match
-      assert.strictEqual(shouldAutoApproveCommand('npm uninstall express', rules), false);
-      assert.strictEqual(shouldAutoApproveCommand('yarn install', rules), false);
-    });
+		it("should handle regex patterns correctly", () => {
+			const rules: CommandAutoApproveRule[] = [{ pattern: "/^npm (install|list)/", action: "auto-approve" }]
 
-    it('should handle regex patterns with flags', () => {
-      const rules: CommandAutoApproveRule[] = [
-        { pattern: '/npm/i', action: 'auto-approve' }
-      ];
-      
-      // Should match case-insensitively
-      assert.strictEqual(shouldAutoApproveCommand('NPM install express', rules), true);
-      assert.strictEqual(shouldAutoApproveCommand('npm Install', rules), true);
-    });
+			// Should match
+			assert.strictEqual(shouldAutoApproveCommand("npm install express", rules), true)
+			assert.strictEqual(shouldAutoApproveCommand("npm list", rules), true)
 
-    it('should handle invalid regex patterns gracefully', () => {
-      const rules: CommandAutoApproveRule[] = [
-        { pattern: '/npm(/i', action: 'auto-approve' } // Invalid regex
-      ];
-      
-      // Should not throw and should not match
-      assert.strictEqual(shouldAutoApproveCommand('npm install express', rules), false);
-    });
+			// Should not match
+			assert.strictEqual(shouldAutoApproveCommand("npm uninstall express", rules), false)
+			assert.strictEqual(shouldAutoApproveCommand("yarn install", rules), false)
+		})
 
-    it('should handle multiple matching rules correctly', () => {
-      const rules: CommandAutoApproveRule[] = [
-        { pattern: 'npm', action: 'auto-approve' },
-        { pattern: 'install', action: 'auto-approve' },
-        { pattern: 'express', action: 'require-approval' }
-      ];
-      
-      // Last matching rule (express) requires approval
-      assert.strictEqual(shouldAutoApproveCommand('npm install express', rules), false);
-      
-      // Only npm and install match, so auto-approve
-      assert.strictEqual(shouldAutoApproveCommand('npm install react', rules), true);
-    });
-  });
-});
+		it("should handle regex patterns with flags", () => {
+			const rules: CommandAutoApproveRule[] = [{ pattern: "/npm/i", action: "auto-approve" }]
+
+			// Should match case-insensitively
+			assert.strictEqual(shouldAutoApproveCommand("NPM install express", rules), true)
+			assert.strictEqual(shouldAutoApproveCommand("npm Install", rules), true)
+		})
+
+		it("should handle invalid regex patterns gracefully", () => {
+			const rules: CommandAutoApproveRule[] = [
+				{ pattern: "/npm(/i", action: "auto-approve" }, // Invalid regex
+			]
+
+			// Should not throw and should not match
+			assert.strictEqual(shouldAutoApproveCommand("npm install express", rules), false)
+		})
+
+		it("should handle multiple matching rules correctly", () => {
+			const rules: CommandAutoApproveRule[] = [
+				{ pattern: "npm", action: "auto-approve" },
+				{ pattern: "install", action: "auto-approve" },
+				{ pattern: "express", action: "require-approval" },
+			]
+
+			// Last matching rule (express) requires approval
+			assert.strictEqual(shouldAutoApproveCommand("npm install express", rules), false)
+
+			// Only npm and install match, so auto-approve
+			assert.strictEqual(shouldAutoApproveCommand("npm install react", rules), true)
+		})
+	})
+})

--- a/src/test/command-auto-approve.test.ts
+++ b/src/test/command-auto-approve.test.ts
@@ -1,0 +1,88 @@
+import * as assert from 'assert';
+import { describe, it } from 'mocha';
+import { shouldAutoApproveCommand, CommandAutoApproveRule } from '../shared/CommandAutoApproveRule';
+
+describe('Command Auto Approve Rules', () => {
+  describe('shouldAutoApproveCommand', () => {
+    it('should return false when no rules are provided', () => {
+      const result = shouldAutoApproveCommand('npm install', []);
+      assert.strictEqual(result, false);
+    });
+
+    it('should return false when rules is undefined', () => {
+      const result = shouldAutoApproveCommand('npm install', undefined as unknown as CommandAutoApproveRule[]);
+      assert.strictEqual(result, false);
+    });
+
+    it('should match simple string patterns', () => {
+      const rules: CommandAutoApproveRule[] = [
+        { pattern: 'npm install', action: 'auto-approve' }
+      ];
+      const result = shouldAutoApproveCommand('npm install express', rules);
+      assert.strictEqual(result, true);
+    });
+
+    it('should follow the "last rule wins" principle', () => {
+      const rules: CommandAutoApproveRule[] = [
+        { pattern: 'npm', action: 'auto-approve' },
+        { pattern: 'install', action: 'require-approval' }
+      ];
+      const result = shouldAutoApproveCommand('npm install express', rules);
+      assert.strictEqual(result, false);
+
+      const reversedRules: CommandAutoApproveRule[] = [
+        { pattern: 'install', action: 'require-approval' },
+        { pattern: 'npm', action: 'auto-approve' }
+      ];
+      const reversedResult = shouldAutoApproveCommand('npm install express', reversedRules);
+      assert.strictEqual(reversedResult, true);
+    });
+
+    it('should handle regex patterns correctly', () => {
+      const rules: CommandAutoApproveRule[] = [
+        { pattern: '/^npm (install|list)/', action: 'auto-approve' }
+      ];
+      
+      // Should match
+      assert.strictEqual(shouldAutoApproveCommand('npm install express', rules), true);
+      assert.strictEqual(shouldAutoApproveCommand('npm list', rules), true);
+      
+      // Should not match
+      assert.strictEqual(shouldAutoApproveCommand('npm uninstall express', rules), false);
+      assert.strictEqual(shouldAutoApproveCommand('yarn install', rules), false);
+    });
+
+    it('should handle regex patterns with flags', () => {
+      const rules: CommandAutoApproveRule[] = [
+        { pattern: '/npm/i', action: 'auto-approve' }
+      ];
+      
+      // Should match case-insensitively
+      assert.strictEqual(shouldAutoApproveCommand('NPM install express', rules), true);
+      assert.strictEqual(shouldAutoApproveCommand('npm Install', rules), true);
+    });
+
+    it('should handle invalid regex patterns gracefully', () => {
+      const rules: CommandAutoApproveRule[] = [
+        { pattern: '/npm(/i', action: 'auto-approve' } // Invalid regex
+      ];
+      
+      // Should not throw and should not match
+      assert.strictEqual(shouldAutoApproveCommand('npm install express', rules), false);
+    });
+
+    it('should handle multiple matching rules correctly', () => {
+      const rules: CommandAutoApproveRule[] = [
+        { pattern: 'npm', action: 'auto-approve' },
+        { pattern: 'install', action: 'auto-approve' },
+        { pattern: 'express', action: 'require-approval' }
+      ];
+      
+      // Last matching rule (express) requires approval
+      assert.strictEqual(shouldAutoApproveCommand('npm install express', rules), false);
+      
+      // Only npm and install match, so auto-approve
+      assert.strictEqual(shouldAutoApproveCommand('npm install react', rules), true);
+    });
+  });
+});


### PR DESCRIPTION
### Description

Allow user to define commands that are considered safe to run without explicit approval.

### Test Procedure

Tests included.

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ X] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ X] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [ X] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ X] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add command auto-approve feature to auto-approve commands based on user-defined string or regex patterns, with configuration via VS Code settings.
> 
>   - **Feature**:
>     - Add command auto-approve feature allowing specification of commands to auto-approve based on string or regex patterns.
>     - Implement `CommandAutoApproveRule` interface and `shouldAutoApproveCommand()` function in `CommandAutoApproveRule.ts`.
>     - Update `AutoApprovalSettings` in `AutoApprovalSettings.ts` to include `commandAutoApproveRules`.
>   - **Implementation**:
>     - Add `readCommandAutoApproveRules()` in `index.ts` of `controller` to read rules from VS Code settings.
>     - Modify `shouldAutoApproveTool()` in `index.ts` of `task` to use command-specific rules.
>   - **Testing**:
>     - Add `command-auto-approve.test.ts` to test various scenarios for command auto-approval.
>   - **Documentation**:
>     - Add `command-auto-approve.md` detailing configuration and usage of the feature.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for ddee6b14d836f82157d1210b2e8bd6fc1bdb2f14. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->