### PR TITLE
Fix deepseek/openai pricing and token counting

### DIFF
--- a/.changeset/ten-zebras-tie.md
+++ b/.changeset/ten-zebras-tie.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Fix issue with DeepSeek API provider token counting + context management

--- a/src/api/providers/deepseek.ts
+++ b/src/api/providers/deepseek.ts
@@ -36,14 +36,15 @@ export class DeepSeekHandler implements ApiHandler {
 		}
 		const deepUsage = usage as DeepSeekUsage
 
-		const inputTokens = deepUsage?.prompt_tokens || 0
+		const inputTokens = deepUsage?.prompt_tokens || 0 // sum of cache hits and misses
 		const outputTokens = deepUsage?.completion_tokens || 0
 		const cacheReadTokens = deepUsage?.prompt_cache_hit_tokens || 0
 		const cacheWriteTokens = deepUsage?.prompt_cache_miss_tokens || 0
 		const totalCost = calculateApiCostOpenAI(info, inputTokens, outputTokens, cacheWriteTokens, cacheReadTokens)
+		const nonCachedInputTokens = Math.max(0, inputTokens - cacheReadTokens - cacheWriteTokens) // this will always be 0
 		yield {
 			type: "usage",
-			inputTokens: inputTokens,
+			inputTokens: nonCachedInputTokens,
 			outputTokens: outputTokens,
 			cacheWriteTokens: cacheWriteTokens,
 			cacheReadTokens: cacheReadTokens,

--- a/src/api/providers/openai-native.ts
+++ b/src/api/providers/openai-native.ts
@@ -26,14 +26,15 @@ export class OpenAiNativeHandler implements ApiHandler {
 	}
 
 	private async *yieldUsage(info: ModelInfo, usage: OpenAI.Completions.CompletionUsage | undefined): ApiStream {
-		const inputTokens = usage?.prompt_tokens || 0
+		const inputTokens = usage?.prompt_tokens || 0 // sum of cache hits and misses
 		const outputTokens = usage?.completion_tokens || 0
 		const cacheReadTokens = usage?.prompt_tokens_details?.cached_tokens || 0
 		const cacheWriteTokens = 0
 		const totalCost = calculateApiCostOpenAI(info, inputTokens, outputTokens, cacheWriteTokens, cacheReadTokens)
+		const nonCachedInputTokens = Math.max(0, inputTokens - cacheReadTokens - cacheWriteTokens)
 		yield {
 			type: "usage",
-			inputTokens: inputTokens,
+			inputTokens: nonCachedInputTokens,
 			outputTokens: outputTokens,
 			cacheWriteTokens: cacheWriteTokens,
 			cacheReadTokens: cacheReadTokens,

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -648,8 +648,8 @@ export const deepSeekModels = {
 		maxTokens: 8_000,
 		contextWindow: 64_000,
 		supportsImages: false,
-		supportsPromptCache: true,
-		inputPrice: 0.27,
+		supportsPromptCache: true, // supports context caching, but not in the way anthropic does it (deepseek reports input tokens and reads/writes in the same usage report) FIXME: we need to show users cache stats how deepseek does it
+		inputPrice: 0, // technically there is no input price, it's all either a cache hit or miss (ApiOptions will not show this). Input is the sum of cache reads and writes
 		outputPrice: 1.1,
 		cacheWritesPrice: 0.27,
 		cacheReadsPrice: 0.07,
@@ -658,8 +658,8 @@ export const deepSeekModels = {
 		maxTokens: 8_000,
 		contextWindow: 64_000,
 		supportsImages: false,
-		supportsPromptCache: true,
-		inputPrice: 0.55,
+		supportsPromptCache: true, // supports context caching, but not in the way anthropic does it (deepseek reports input tokens and reads/writes in the same usage report) FIXME: we need to show users cache stats how deepseek does it
+		inputPrice: 0, // technically there is no input price, it's all either a cache hit or miss (ApiOptions will not show this)
 		outputPrice: 2.19,
 		cacheWritesPrice: 0.55,
 		cacheReadsPrice: 0.14,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix token counting and pricing for DeepSeek and OpenAI by adjusting token calculations and updating pricing models.
> 
>   - **Token Counting**:
>     - In `deepseek.ts`, `inputTokens` now accounts for cache hits and misses, and `nonCachedInputTokens` is calculated but always zero.
>     - In `openai-native.ts`, `inputTokens` also accounts for cache hits and misses, with `nonCachedInputTokens` calculated accordingly.
>   - **Pricing Model**:
>     - In `api.ts`, `deepSeekModels` updated to set `inputPrice` to 0, reflecting that input is the sum of cache reads and writes.
>     - Comments added to clarify DeepSeek's unique cache reporting method.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 96f6397ae839c69552974395325047c8b09b06fb. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->