### PR TITLE
custom instructions but with a little more discretion

### DIFF
--- a/.changeset/serious-dodos-kiss.md
+++ b/.changeset/serious-dodos-kiss.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": minor
+---
+
+Easily configurable and toggleable custom modes which replace the current custom instructions. Users can now easily manage a small set of custom instructions and manage them smoothly.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "claude-dev",
-	"version": "3.8.4",
+	"version": "3.8.6",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "claude-dev",
-			"version": "3.8.4",
+			"version": "3.8.6",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@anthropic-ai/bedrock-sdk": "^0.12.4",

--- a/src/core/prompts/system.ts
+++ b/src/core/prompts/system.ts
@@ -988,17 +988,41 @@ export function addUserInstructions(
 	clineRulesFileInstructions?: string,
 	clineIgnoreInstructions?: string,
 	preferredLanguageInstructions?: string,
+	customInstructionModes?: { id: string; title: string; content: string; isEnabled: boolean }[],
+	selectedModeIds?: string[],
 ) {
 	let customInstructions = ""
+
+	// Add language instructions first (if any)
 	if (preferredLanguageInstructions) {
 		customInstructions += preferredLanguageInstructions + "\n\n"
 	}
+
+	// Add old-style custom instructions for backward compatibility
 	if (settingsCustomInstructions) {
 		customInstructions += settingsCustomInstructions + "\n\n"
 	}
-	if (clineRulesFileInstructions) {
-		customInstructions += clineRulesFileInstructions + "\n\n"
+
+	// Add content from selected custom instruction modes
+	if (customInstructionModes && customInstructionModes.length > 0 && selectedModeIds && selectedModeIds.length > 0) {
+		const selectedModes = customInstructionModes.filter((mode) => selectedModeIds.includes(mode.id))
+		if (selectedModes.length > 0) {
+			customInstructions += "# Custom Instruction Modes\n\n"
+			// Add each selected mode with its title
+			selectedModes.forEach((mode) => {
+				if (mode.content && mode.content.trim()) {
+					customInstructions += `## ${mode.title}\n${mode.content.trim()}\n\n`
+				}
+			})
+		}
 	}
+
+	// Add clinerules file instructions
+	if (clineRulesFileInstructions) {
+		customInstructions += "# .clinerules\n\n" + clineRulesFileInstructions + "\n\n"
+	}
+
+	// Add clineignore instructions
 	if (clineIgnoreInstructions) {
 		customInstructions += clineIgnoreInstructions
 	}

--- a/src/core/storage/state-keys.ts
+++ b/src/core/storage/state-keys.ts
@@ -31,6 +31,8 @@ export type GlobalStateKey =
 	| "vertexRegion"
 	| "lastShownAnnouncementId"
 	| "customInstructions"
+	| "customInstructionModes"
+	| "selectedModeIds"
 	| "taskHistory"
 	| "openAiBaseUrl"
 	| "openAiModelId"

--- a/src/core/storage/state.ts
+++ b/src/core/storage/state.ts
@@ -10,6 +10,8 @@ import { BrowserSettings } from "../../shared/BrowserSettings"
 import { ChatSettings } from "../../shared/ChatSettings"
 import { TelemetrySetting } from "../../shared/TelemetrySetting"
 import { UserInfo } from "../../shared/UserInfo"
+import { CustomInstructionMode } from "../../shared/CustomInstructionMode" // Removed DEFAULT import
+import { getSavedCustomInstructionModes } from "./disk" // Import disk function
 /*
 	Storage
 	https://dev.to/kompotkot/how-to-use-secretstorage-in-your-vscode-extensions-2hco
@@ -93,6 +95,8 @@ export async function getAllExtensionState(context: vscode.ExtensionContext) {
 		openRouterProviderSorting,
 		lastShownAnnouncementId,
 		customInstructions,
+		customInstructionModes,
+		selectedModeIds,
 		taskHistory,
 		autoApprovalSettings,
 		browserSettings,
@@ -157,6 +161,8 @@ export async function getAllExtensionState(context: vscode.ExtensionContext) {
 		getGlobalState(context, "openRouterProviderSorting") as Promise<string | undefined>,
 		getGlobalState(context, "lastShownAnnouncementId") as Promise<string | undefined>,
 		getGlobalState(context, "customInstructions") as Promise<string | undefined>,
+		getSavedCustomInstructionModes(context), // Load modes from disk
+		getGlobalState(context, "selectedModeIds") as Promise<string[] | undefined>,
 		getGlobalState(context, "taskHistory") as Promise<HistoryItem[] | undefined>,
 		getGlobalState(context, "autoApprovalSettings") as Promise<AutoApprovalSettings | undefined>,
 		getGlobalState(context, "browserSettings") as Promise<BrowserSettings | undefined>,
@@ -272,6 +278,8 @@ export async function getAllExtensionState(context: vscode.ExtensionContext) {
 		},
 		lastShownAnnouncementId,
 		customInstructions,
+		customInstructionModes, // Already has default handling in getSavedCustomInstructionModes
+		selectedModeIds: selectedModeIds || [],
 		taskHistory,
 		autoApprovalSettings: autoApprovalSettings || DEFAULT_AUTO_APPROVAL_SETTINGS, // default value can be 0 or empty string
 		browserSettings: browserSettings || DEFAULT_BROWSER_SETTINGS,

--- a/src/core/storage/state.ts
+++ b/src/core/storage/state.ts
@@ -11,7 +11,7 @@ import { ChatSettings } from "../../shared/ChatSettings"
 import { TelemetrySetting } from "../../shared/TelemetrySetting"
 import { UserInfo } from "../../shared/UserInfo"
 import { CustomInstructionMode } from "../../shared/CustomInstructionMode" // Removed DEFAULT import
-import { getSavedCustomInstructionModes } from "./disk" // Import disk function
+import { getCustomInstructionModesFromState } from "./disk" // Import disk function (Updated import name)
 /*
 	Storage
 	https://dev.to/kompotkot/how-to-use-secretstorage-in-your-vscode-extensions-2hco
@@ -161,7 +161,7 @@ export async function getAllExtensionState(context: vscode.ExtensionContext) {
 		getGlobalState(context, "openRouterProviderSorting") as Promise<string | undefined>,
 		getGlobalState(context, "lastShownAnnouncementId") as Promise<string | undefined>,
 		getGlobalState(context, "customInstructions") as Promise<string | undefined>,
-		getSavedCustomInstructionModes(context), // Load modes from disk
+		getCustomInstructionModesFromState(context), // Load modes from state (Updated function call)
 		getGlobalState(context, "selectedModeIds") as Promise<string[] | undefined>,
 		getGlobalState(context, "taskHistory") as Promise<HistoryItem[] | undefined>,
 		getGlobalState(context, "autoApprovalSettings") as Promise<AutoApprovalSettings | undefined>,

--- a/src/shared/CustomInstructionMode.ts
+++ b/src/shared/CustomInstructionMode.ts
@@ -1,0 +1,8 @@
+export interface CustomInstructionMode {
+	id: string
+	title: string
+	content: string
+	isEnabled: boolean
+}
+
+export const DEFAULT_CUSTOM_INSTRUCTION_MODES: CustomInstructionMode[] = []

--- a/src/shared/ExtensionMessage.ts
+++ b/src/shared/ExtensionMessage.ts
@@ -5,6 +5,7 @@ import { ApiConfiguration, ModelInfo } from "./api"
 import { AutoApprovalSettings } from "./AutoApprovalSettings"
 import { BrowserSettings } from "./BrowserSettings"
 import { ChatSettings } from "./ChatSettings"
+import { CustomInstructionMode } from "./CustomInstructionMode"
 import { HistoryItem } from "./HistoryItem"
 import { McpServer, McpMarketplaceCatalog, McpMarketplaceItem, McpDownloadResponse } from "./mcp"
 import { TelemetrySetting } from "./TelemetrySetting"
@@ -103,6 +104,8 @@ export interface ExtensionState {
 	clineMessages: ClineMessage[]
 	currentTaskItem?: HistoryItem
 	customInstructions?: string
+	customInstructionModes: CustomInstructionMode[] // Added for multi-mode support
+	selectedModeIds: string[] // IDs of selected modes
 	mcpMarketplaceEnabled?: boolean
 	planActSeparateModelsSetting: boolean
 	platform: Platform

--- a/src/shared/WebviewMessage.ts
+++ b/src/shared/WebviewMessage.ts
@@ -5,6 +5,7 @@ import { ChatSettings } from "./ChatSettings"
 import { UserInfo } from "./UserInfo"
 import { ChatContent } from "./ChatContent"
 import { TelemetrySetting } from "./TelemetrySetting"
+import { CustomInstructionMode } from "./CustomInstructionMode" // Import added
 
 export interface WebviewMessage {
 	type:
@@ -67,6 +68,8 @@ export interface WebviewMessage {
 		| "optionsResponse"
 		| "requestTotalTasksSize"
 		| "taskFeedback"
+		| "updateCustomInstructionModes" // Added new type
+		| "updateSelectedModeIds" // Added new type
 	// | "relaunchChromeDebugMode"
 	text?: string
 	disabled?: boolean
@@ -95,6 +98,8 @@ export interface WebviewMessage {
 	planActSeparateModelsSetting?: boolean
 	telemetrySetting?: TelemetrySetting
 	customInstructionsSetting?: string
+	customInstructionModes?: CustomInstructionMode[] // Added for multi-mode support
+	selectedModeIds?: string[] // IDs of selected modes
 	// For task feedback
 	feedbackType?: TaskFeedbackType
 }

--- a/webview-ui/src/components/chat/ChatTextArea.tsx
+++ b/webview-ui/src/components/chat/ChatTextArea.tsx
@@ -22,6 +22,7 @@ import Tooltip from "../common/Tooltip"
 import ApiOptions, { normalizeApiConfiguration } from "../settings/ApiOptions"
 import { MAX_IMAGES_PER_MESSAGE } from "./ChatView"
 import ContextMenu from "./ContextMenu"
+import ModesSelector from "./ModesSelector"
 import { ChatSettings } from "../../../../src/shared/ChatSettings"
 
 interface ChatTextAreaProps {
@@ -1131,27 +1132,32 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 							)}
 						</ModelContainer>
 					</ButtonGroup>
-					<Tooltip
-						style={{ zIndex: 1000 }}
-						visible={shownTooltipMode !== null}
-						tipText={`In ${shownTooltipMode === "act" ? "Act" : "Plan"}  mode, Cline will ${shownTooltipMode === "act" ? "complete the task immediately" : "gather information to architect a plan"}`}
-						hintText={`Toggle w/ ${metaKeyChar}+Shift+A`}>
-						<SwitchContainer data-testid="mode-switch" disabled={false} onClick={onModeToggle}>
-							<Slider isAct={chatSettings.mode === "act"} isPlan={chatSettings.mode === "plan"} />
-							<SwitchOption
-								isActive={chatSettings.mode === "plan"}
-								onMouseOver={() => setShownTooltipMode("plan")}
-								onMouseLeave={() => setShownTooltipMode(null)}>
-								Plan
-							</SwitchOption>
-							<SwitchOption
-								isActive={chatSettings.mode === "act"}
-								onMouseOver={() => setShownTooltipMode("act")}
-								onMouseLeave={() => setShownTooltipMode(null)}>
-								Act
-							</SwitchOption>
-						</SwitchContainer>
-					</Tooltip>
+					<div style={{ display: "flex", alignItems: "center", gap: "6px" }}>
+						{/* Custom Instruction Modes Selector */}
+						<ModesSelector />
+
+						<Tooltip
+							style={{ zIndex: 1000 }}
+							visible={shownTooltipMode !== null}
+							tipText={`In ${shownTooltipMode === "act" ? "Act" : "Plan"}  mode, Cline will ${shownTooltipMode === "act" ? "complete the task immediately" : "gather information to architect a plan"}`}
+							hintText={`Toggle w/ ${metaKeyChar}+Shift+A`}>
+							<SwitchContainer data-testid="mode-switch" disabled={false} onClick={onModeToggle}>
+								<Slider isAct={chatSettings.mode === "act"} isPlan={chatSettings.mode === "plan"} />
+								<SwitchOption
+									isActive={chatSettings.mode === "plan"}
+									onMouseOver={() => setShownTooltipMode("plan")}
+									onMouseLeave={() => setShownTooltipMode(null)}>
+									Plan
+								</SwitchOption>
+								<SwitchOption
+									isActive={chatSettings.mode === "act"}
+									onMouseOver={() => setShownTooltipMode("act")}
+									onMouseLeave={() => setShownTooltipMode(null)}>
+									Act
+								</SwitchOption>
+							</SwitchContainer>
+						</Tooltip>
+					</div>
 				</ControlsContainer>
 			</div>
 		)

--- a/webview-ui/src/components/chat/ModesSelector.tsx
+++ b/webview-ui/src/components/chat/ModesSelector.tsx
@@ -1,0 +1,176 @@
+import React, { useState, useRef, useEffect } from "react"
+import { useExtensionState } from "../../context/ExtensionStateContext"
+import { CustomInstructionMode } from "../../../../src/shared/CustomInstructionMode"
+import { VSCodeButton, VSCodeCheckbox } from "@vscode/webview-ui-toolkit/react"
+import { vscode } from "../../utils/vscode"
+
+const ModesSelector: React.FC = () => {
+	const { customInstructionModes, selectedModeIds, toggleModeSelection } = useExtensionState()
+	const [isOpen, setIsOpen] = useState(false)
+	const [showTooltip, setShowTooltip] = useState(false) // State for custom tooltip
+	const dropdownRef = useRef<HTMLDivElement>(null)
+	const buttonRef = useRef<HTMLDivElement>(null) // Ref for button positioning
+
+	useEffect(() => {
+		const handleClickOutside = (event: MouseEvent) => {
+			// Close dropdown if clicking outside
+			if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
+				// Also ensure click wasn't on the button itself
+				if (buttonRef.current && !buttonRef.current.contains(event.target as Node)) {
+					setIsOpen(false)
+				}
+			}
+		}
+		document.addEventListener("mousedown", handleClickOutside)
+		return () => {
+			document.removeEventListener("mousedown", handleClickOutside)
+		}
+	}, [])
+
+	const selectedCount = selectedModeIds.length
+	const totalCount = customInstructionModes.length
+
+	// If there are no modes defined at all, don't render the selector
+	if (totalCount === 0) {
+		return null
+	}
+
+	// Determine tooltip content based on selection
+	let tooltipContent = "Select Modes" // Default tooltip text
+	if (selectedCount > 0) {
+		const selectedModes = customInstructionModes.filter((m) => selectedModeIds.includes(m.id)).map((m) => m.title)
+
+		// Just list the mode names, truncated if necessary
+		const maxListed = 5
+		tooltipContent =
+			selectedModes.length > maxListed ? selectedModes.slice(0, maxListed).join(", ") + ", ..." : selectedModes.join(", ")
+	}
+
+	// Handler to open dropdown and hide tooltip
+	const handleButtonClick = () => {
+		setShowTooltip(false) // Hide tooltip immediately on click
+		setIsOpen(!isOpen) // Toggle dropdown
+	}
+
+	return (
+		// Icon-only button container
+		<div style={{ position: "relative", display: "inline-block" }} ref={dropdownRef}>
+			{/* Custom Tooltip - Hide if dropdown is open */}
+			{showTooltip && !isOpen && (
+				<div
+					style={{
+						position: "absolute",
+						bottom: "calc(100% + 6px)", // Position above the button
+						left: "50%", // Center horizontally relative to the button container
+						transform: "translateX(-50%)", // Adjust centering
+						zIndex: 1010, // Above dropdown
+						padding: "4px 8px",
+						backgroundColor: "var(--vscode-editorWidget-background)",
+						border: "1px solid var(--vscode-editorWidget-border, var(--vscode-contrastBorder))",
+						borderRadius: "4px",
+						fontSize: "0.9em",
+						color: "var(--vscode-editor-foreground)",
+						whiteSpace: "nowrap",
+						boxShadow: "0 2px 8px rgba(0, 0, 0, 0.15)",
+					}}>
+					{tooltipContent}
+				</div>
+			)}
+
+			{/* Button */}
+			<div ref={buttonRef}>
+				{" "}
+				{/* Added ref wrapper for positioning */}
+				<VSCodeButton
+					appearance="icon" // Minimal appearance
+					onClick={handleButtonClick} // Use handler to hide tooltip on click
+					// Remove native title attribute
+					onMouseEnter={() => {
+						if (!isOpen) setShowTooltip(true)
+					}} // Show tooltip only if dropdown is closed
+					onMouseLeave={() => setShowTooltip(false)} // Hide custom tooltip
+					style={{
+						marginLeft: "4px",
+						position: "relative", // Needed for positioning the dot
+					}}>
+					{/* Always show the icon */}
+					<span className="codicon codicon-layers"></span>
+					{/* Blue bubble indicator when modes are active */}
+					{selectedCount > 0 && (
+						<span
+							style={{
+								position: "absolute",
+								top: "1px",
+								right: "1px",
+								width: "7px",
+								height: "7px",
+								borderRadius: "50%",
+								backgroundColor: "var(--vscode-notifications-infoBackground, var(--vscode-focusBorder))",
+								border: "1px solid var(--vscode-contrastBorder, var(--vscode-editorWidget-background))",
+							}}></span>
+					)}
+				</VSCodeButton>
+			</div>
+
+			{/* Minimal Dropdown */}
+			{isOpen && (
+				<div
+					style={{
+						position: "absolute",
+						bottom: "calc(100% + 4px)", // Open upwards
+						right: 0, // Align to the right edge of the container div
+						zIndex: 1000,
+						minWidth: "150px",
+						backgroundColor: "var(--vscode-editorWidget-background)",
+						border: "1px solid var(--vscode-editorWidget-border)",
+						borderRadius: "4px",
+						boxShadow: "0 2px 8px rgba(0, 0, 0, 0.15)",
+						padding: "4px 0",
+					}}>
+					{/* Items Container - No Header/Footer */}
+					<div style={{ maxHeight: "200px", overflowY: "auto" }}>
+						{customInstructionModes.map((mode) => (
+							<div
+								key={mode.id}
+								style={{
+									padding: "4px 10px",
+									display: "flex",
+									alignItems: "center",
+									cursor: "pointer",
+									borderBottom: "none",
+								}}
+								onClick={() => {
+									toggleModeSelection(mode.id)
+									const nextSelectedIds = selectedModeIds.includes(mode.id)
+										? selectedModeIds.filter((id) => id !== mode.id)
+										: [...selectedModeIds, mode.id]
+									vscode.postMessage({
+										type: "updateSelectedModeIds",
+										selectedModeIds: nextSelectedIds,
+									})
+									// Optionally close dropdown after selection
+									// setIsOpen(false);
+								}}>
+								<VSCodeCheckbox
+									checked={selectedModeIds.includes(mode.id)}
+									style={{ marginRight: "8px", pointerEvents: "none" }}
+									readOnly
+								/>
+								<div>
+									<div>{mode.title}</div>
+								</div>
+							</div>
+						))}
+					</div>
+					{customInstructionModes.length === 0 && (
+						<div style={{ padding: "4px 10px", fontStyle: "italic", color: "var(--vscode-disabledForeground)" }}>
+							No modes defined
+						</div>
+					)}
+				</div>
+			)}
+		</div>
+	)
+}
+
+export default ModesSelector

--- a/webview-ui/src/components/settings/CustomModesEditor.tsx
+++ b/webview-ui/src/components/settings/CustomModesEditor.tsx
@@ -1,0 +1,223 @@
+import React, { useState, useEffect, useRef } from "react" // Added useEffect, useRef
+import {
+	VSCodeButton,
+	VSCodeDivider,
+	VSCodeTextField,
+	VSCodeTextArea,
+	// Removed VSCodePanels, VSCodePanelTab, VSCodePanelView
+} from "@vscode/webview-ui-toolkit/react"
+import { useExtensionState } from "../../context/ExtensionStateContext"
+import { CustomInstructionMode } from "../../../../src/shared/CustomInstructionMode"
+import { vscode } from "../../utils/vscode" // Added vscode import
+
+const CustomModesEditor: React.FC = () => {
+	// Destructure all settings needed for the updateSettings message
+	const {
+		customInstructionModes,
+		addCustomInstructionMode,
+		updateCustomInstructionMode,
+		removeCustomInstructionMode,
+		customInstructions,
+		setCustomInstructions,
+		// Get other settings needed for the message
+		apiConfiguration,
+		selectedModeIds,
+		telemetrySetting,
+		planActSeparateModelsSetting,
+	} = useExtensionState()
+
+	const [showAddMode, setShowAddMode] = useState(false)
+	const [newModeTitle, setNewModeTitle] = useState("")
+	const [newModeContent, setNewModeContent] = useState("")
+	const [expandedModeId, setExpandedModeId] = useState<string | null>(null) // State for expanded mode
+	// Removed debounceTimeoutRef
+
+	// Convert existing custom instructions to a mode if needed
+	useEffect(() => {
+		if (customInstructions && customInstructionModes.length === 0) {
+			// Only do this if we have custom instructions but no modes yet
+			addCustomInstructionMode({
+				title: "Default Mode",
+				content: customInstructions,
+				isEnabled: true,
+			})
+			// Clear the old custom instructions since they're now in a mode
+			setCustomInstructions("")
+		}
+		// Intentionally not including addCustomInstructionMode/setCustomInstructions in deps
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [customInstructions, customInstructionModes.length])
+
+	// Removed debounced useEffect hook
+
+	const handleAddMode = () => {
+		if (newModeTitle.trim() === "") return
+
+		addCustomInstructionMode({
+			title: newModeTitle,
+			content: newModeContent,
+			isEnabled: false,
+		})
+
+		// Reset form
+		setNewModeTitle("")
+		setNewModeContent("")
+		setShowAddMode(false)
+	}
+
+	const handleCancelAdd = () => {
+		setNewModeTitle("")
+		setNewModeContent("")
+		setShowAddMode(false)
+	}
+
+	return (
+		<div style={{ marginBottom: 20 }}>
+			<div style={{ marginBottom: 8 }}>
+				<span style={{ fontWeight: "500" }}>Custom Instruction Modes</span>
+			</div>
+
+			{/* List of existing modes - Collapsible List */}
+			{customInstructionModes.length > 0 ? (
+				<div style={{ marginBottom: 12 }}>
+					{customInstructionModes.map((mode) => {
+						const isExpanded = expandedModeId === mode.id
+						return (
+							<div
+								key={mode.id}
+								style={{
+									border: "1px solid var(--vscode-panel-border)",
+									borderRadius: 4,
+									marginBottom: 8,
+									overflow: "hidden", // Ensures content doesn't overflow when collapsed
+								}}>
+								{/* Header */}
+								<div
+									style={{
+										display: "flex",
+										alignItems: "center",
+										padding: "8px 12px",
+										cursor: "pointer",
+										backgroundColor: "var(--vscode-sideBar-background)", // Subtle background
+									}}
+									onClick={() => setExpandedModeId(isExpanded ? null : mode.id)}>
+									<span
+										className={`codicon codicon-chevron-${isExpanded ? "down" : "right"}`}
+										style={{ marginRight: 8 }}></span>
+									<span style={{ flexGrow: 1, fontWeight: "500" }}>{mode.title || "Untitled Mode"}</span>
+								</div>
+
+								{/* Collapsible Content */}
+								{isExpanded && (
+									<div
+										style={{
+											padding: "8px 12px 12px 12px",
+											borderTop: "1px solid var(--vscode-panel-border)",
+										}}>
+										<VSCodeTextField
+											value={mode.title}
+											style={{ width: "100%", marginBottom: 8 }}
+											placeholder="Mode Title"
+											onInput={(e: any) =>
+												updateCustomInstructionMode(mode.id, { title: e.target?.value })
+											}>
+											<span>Title</span>
+										</VSCodeTextField>
+
+										<VSCodeTextArea
+											value={mode.content}
+											style={{ width: "100%" }}
+											resize="vertical"
+											rows={4}
+											placeholder={'e.g. "Run unit tests at the end", "Use TypeScript with async/await"'}
+											onInput={(e: any) =>
+												updateCustomInstructionMode(mode.id, { content: e.target?.value })
+											}>
+											<span>Instructions</span>
+										</VSCodeTextArea>
+
+										<div style={{ marginTop: 12, display: "flex", justifyContent: "flex-end" }}>
+											<VSCodeButton
+												appearance="secondary"
+												onClick={() => removeCustomInstructionMode(mode.id)}
+												style={{ marginRight: 8 }}>
+												Delete Mode
+											</VSCodeButton>
+										</div>
+									</div>
+								)}
+							</div>
+						)
+					})}
+				</div>
+			) : (
+				<div
+					style={{
+						padding: 12,
+						border: "1px solid var(--vscode-panel-border)",
+						borderRadius: 4,
+						marginBottom: 12,
+						fontStyle: "italic",
+						color: "var(--vscode-descriptionForeground)",
+					}}>
+					No custom instruction modes. Add one to get started.
+				</div>
+			)}
+
+			{/* Add new mode form */}
+			{showAddMode ? (
+				<div
+					style={{
+						padding: 12,
+						border: "1px solid var(--vscode-panel-border)",
+						borderRadius: 4,
+						marginBottom: 12,
+					}}>
+					<VSCodeTextField
+						value={newModeTitle}
+						style={{ width: "100%", marginBottom: 8 }}
+						placeholder="e.g. Python Expert, Document Writer"
+						onInput={(e: any) => setNewModeTitle(e.target?.value ?? "")}>
+						<span>Mode Title</span>
+					</VSCodeTextField>
+
+					<VSCodeTextArea
+						value={newModeContent}
+						style={{ width: "100%" }}
+						resize="vertical"
+						rows={4}
+						placeholder={'e.g. "Use Python with type hints", "Format output as markdown"'}
+						onInput={(e: any) => setNewModeContent(e.target?.value ?? "")}>
+						<span>Instructions</span>
+					</VSCodeTextArea>
+
+					<div style={{ marginTop: 12, display: "flex", justifyContent: "flex-end" }}>
+						<VSCodeButton appearance="secondary" onClick={handleCancelAdd} style={{ marginRight: 8 }}>
+							Cancel
+						</VSCodeButton>
+						<VSCodeButton onClick={handleAddMode} disabled={newModeTitle.trim() === ""}>
+							Add Mode
+						</VSCodeButton>
+					</div>
+				</div>
+			) : (
+				<VSCodeButton appearance="secondary" onClick={() => setShowAddMode(true)}>
+					<span slot="start" className="codicon codicon-add"></span>
+					Add a Mode
+				</VSCodeButton>
+			)}
+
+			<p
+				style={{
+					fontSize: "12px",
+					marginTop: "5px",
+					color: "var(--vscode-descriptionForeground)",
+				}}>
+				Create multiple instruction modes that can be toggled on/off using the selector next to the Plan/Act toggle.
+				Selected modes will be added to the system prompt.
+			</p>
+		</div>
+	)
+}
+
+export default CustomModesEditor

--- a/webview-ui/src/context/ExtensionStateContext.tsx
+++ b/webview-ui/src/context/ExtensionStateContext.tsx
@@ -201,37 +201,49 @@ export const ExtensionStateContextProvider: React.FC<{
 
 		// Add Mode
 		addCustomInstructionMode: (mode) => {
+			let newModes: CustomInstructionMode[] = []
 			setState((prevState) => {
 				const id = crypto.randomUUID() // Use crypto for better uniqueness
-				const newModes = [...prevState.customInstructionModes, { id, ...mode }]
-				// ONLY update local state
+				newModes = [...prevState.customInstructionModes, { id, ...mode }]
 				return {
 					...prevState,
 					customInstructionModes: newModes,
 				}
 			})
+			// Post update back to extension host
+			vscode.postMessage({ type: "updateCustomInstructionModes", customInstructionModes: newModes })
 		},
 
 		// Update Mode
 		updateCustomInstructionMode: (id, mode) => {
-			setState((prevState) => ({
-				...prevState,
-				customInstructionModes: prevState.customInstructionModes.map((m) => (m.id === id ? { ...m, ...mode } : m)),
-			}))
+			let updatedModes: CustomInstructionMode[] = []
+			setState((prevState) => {
+				updatedModes = prevState.customInstructionModes.map((m) => (m.id === id ? { ...m, ...mode } : m))
+				return {
+					...prevState,
+					customInstructionModes: updatedModes,
+				}
+			})
+			// Post update back to extension host
+			vscode.postMessage({ type: "updateCustomInstructionModes", customInstructionModes: updatedModes })
 		},
 
 		// Remove Mode
 		removeCustomInstructionMode: (id) => {
+			let newModes: CustomInstructionMode[] = []
+			let newSelectedIds: string[] = []
 			setState((prevState) => {
-				const newModes = prevState.customInstructionModes.filter((m) => m.id !== id)
-				const newSelectedIds = prevState.selectedModeIds.filter((modeId) => modeId !== id)
-				// ONLY update local state
+				newModes = prevState.customInstructionModes.filter((m) => m.id !== id)
+				newSelectedIds = prevState.selectedModeIds.filter((modeId) => modeId !== id)
 				return {
 					...prevState,
 					customInstructionModes: newModes,
 					selectedModeIds: newSelectedIds,
 				}
 			})
+			// Post updates back to extension host
+			vscode.postMessage({ type: "updateCustomInstructionModes", customInstructionModes: newModes })
+			vscode.postMessage({ type: "updateSelectedModeIds", selectedModeIds: newSelectedIds })
 		},
 
 		// Set Selected Modes
@@ -240,21 +252,25 @@ export const ExtensionStateContextProvider: React.FC<{
 				...prevState,
 				selectedModeIds: ids,
 			}))
+			// Post update back to extension host
+			vscode.postMessage({ type: "updateSelectedModeIds", selectedModeIds: ids })
 		},
 
 		// Toggle Single Mode Selection
 		toggleModeSelection: (id) => {
+			let nextSelectedIds: string[] = []
 			setState((prevState) => {
 				const isSelected = prevState.selectedModeIds.includes(id)
-				const nextSelectedIds = isSelected
+				nextSelectedIds = isSelected
 					? prevState.selectedModeIds.filter((modeId) => modeId !== id)
 					: [...prevState.selectedModeIds, id]
-				// ONLY update local state
 				return {
 					...prevState,
 					selectedModeIds: nextSelectedIds,
 				}
 			})
+			// Post update back to extension host
+			vscode.postMessage({ type: "updateSelectedModeIds", selectedModeIds: nextSelectedIds })
 		},
 	}
 


### PR DESCRIPTION
Implement the ability to create, manage, and toggle multiple custom instruction modes. The content of active modes is appended to the system prompt, allowing for flexible prompt customization.

### Description

This PR enhances Cline's custom instructions functionality by replacing the single custom instruction with a flexible "modes" system. Users can now create multiple custom instruction modes, each with its own content, and toggle them on/off as needed through a new UI in the chat input area.

Key implementation details:
- New data model (`CustomInstructionMode.ts`) for representing instruction modes
- Extended state management in Controller and ExtensionStateContext
- Persistent storage of modes in JSON format and selected mode IDs in global state
- Modified system prompt generation to include content from active modes
- New UI components for managing modes in Settings and toggling in chat

The implementation offers improved user experience by:
- Making custom instructions more visible and accessible
- Allowing quick toggling between different instruction sets
- Supporting multiple active modes simultaneously
- Providing clear visual feedback when modes are active

### Test Procedure

Testing was performed across the following areas:

1. **State Management**:
   - Verified proper saving and loading of custom modes

2. **UI Functionality**:
   - Created, edited, and deleted custom modes in Settings
   - Toggled modes on/off via the selector dropdown
   - Verified visual indicators (blue dot) appear correctly

3. **System Prompt Integration**:
   - Confirmed active modes content is correctly appended to system prompt
   - Tested with multiple active modes simultaneously

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<img width="218" alt="image" src="https://github.com/user-attachments/assets/9060a432-f54d-45ce-82b9-ad4ef8aa416e" />

<img width="260" alt="image" src="https://github.com/user-attachments/assets/de0102db-9f76-4b9a-8da2-b91fd96bdd17" />

<img width="398" alt="image" src="https://github.com/user-attachments/assets/1c7a9638-58be-47f6-a281-dd65f1c25767" />


### Additional Notes

This feature replaces the previous single custom instruction with a more flexible system, but maintains backward compatibility by migrating any existing custom instruction to a default mode during first load.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Introduces multiple custom instruction modes, allowing users to create, manage, and toggle modes, enhancing prompt customization and maintaining backward compatibility.
> 
>   - **Behavior**:
>     - Replaces single custom instruction with multiple custom instruction modes in `CustomInstructionMode.ts`.
>     - Modes can be toggled on/off and are appended to the system prompt.
>     - Backward compatibility maintained by migrating existing instructions to a default mode.
>   - **State Management**:
>     - Updates `Controller` and `ExtensionStateContext` to manage custom instruction modes and selected mode IDs.
>     - Persists modes in JSON format and selected mode IDs in global state.
>   - **UI Components**:
>     - Adds `ModesSelector` to `ChatTextArea.tsx` for toggling modes.
>     - Adds `CustomModesEditor` to `SettingsView.tsx` for creating and managing modes.
>   - **Storage**:
>     - Implements `getSavedCustomInstructionModes` and `saveCustomInstructionModes` in `disk.ts` for mode persistence.
>   - **Misc**:
>     - Updates `state.ts` and `state-keys.ts` to include new state keys for modes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 11b623ef5a60035efaf2a72568885553605cffcf. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->