### PR TITLE
Fix/duplicate bom

### DIFF
--- a/.changeset/dry-donuts-develop.md
+++ b/.changeset/dry-donuts-develop.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+fix: Prevent duplicate BOM

--- a/src/integrations/editor/DiffViewProvider.ts
+++ b/src/integrations/editor/DiffViewProvider.ts
@@ -79,6 +79,15 @@ export class DiffViewProvider {
 		if (!this.relPath || !this.activeLineController || !this.fadedOverlayController) {
 			throw new Error("Required values not set")
 		}
+
+		// --- Fix to prevent duplicate BOM ---
+		// Strip potential BOM from incoming content. VS Code's `applyEdit` might implicitly handle the BOM
+		// when replacing from the start (0,0), and we want to avoid duplication.
+		// Final BOM is handled in `saveChanges`.
+		if (accumulatedContent.startsWith("\ufeff")) {
+			accumulatedContent = accumulatedContent.slice(1) // Remove the BOM character
+		}
+
 		this.newContent = accumulatedContent
 		const accumulatedLines = accumulatedContent.split("\n")
 		if (!isFinal) {


### PR DESCRIPTION
### Description

Fixes a bug in `DiffViewProvider` where editing a file with a Byte Order Mark (BOM) could result in a duplicate BOM being inserted into the document buffer during the streaming update process.

The issue occurred because:
1. Incoming content (`accumulatedContent`) contained a BOM when the original file has BOM.
2. `vscode.workspace.applyEdit`, when replacing content from the start of the file (0,0), might also implicitly preserve or add a BOM based on the original file's state.

This combination led to two BOMs (`\ufeff\ufeff`) appearing at the beginning of the buffer.

The fix involves unconditionally stripping any leading BOM from the `accumulatedContent` within the `update` method *before* it is passed to `applyEdit`. This prevents the duplication, relying on `applyEdit` and the later `saveChanges` method to correctly handle the final BOM state based on the original file's requirements.

**Related Issues:**
*   Fixes #947
*   Fixes #2463

### Test Procedure

The issue was identified and debugged through interactive testing and analysis of the `applyEdit` behavior with BOM files.

**Steps to reproduce the bug (before fix) and verify the fix:**

1.  Create a file named `temp.txt` with the following content:
    ```
    a
    b
    c
    ```
2.  In VS Code, change the file encoding to "UTF-8 with BOM". (Click on the encoding in the status bar, select "Save with Encoding", choose "UTF-8 with BOM").
3.  Ask Cline to perform an edit, for example: "replace c with d in temp.txt".

**Expected behavior:**
*   **Before fix:** During the streaming update in the diff view, a duplicate BOM (`\ufeff\ufeff`) might appear at the beginning of the file content in the editor buffer. The final saved file might also contain issues depending on subsequent save logic.
*   **After fix:** The streaming update proceeds without inserting a duplicate BOM. The final saved file correctly contains only a single BOM.

Manual testing confirmed that editing a BOM file no longer results in duplicate BOMs in the editor buffer during streaming updates, and the final saved file correctly retains the single BOM.


### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes duplicate BOM issue in `DiffViewProvider` by stripping BOM from `accumulatedContent` in `update()` method.
> 
>   - **Bug Fix**:
>     - In `DiffViewProvider`, `update()` method now strips leading BOM from `accumulatedContent` to prevent duplicate BOMs during streaming updates.
>     - Relies on `applyEdit` and `saveChanges` to handle BOM based on original file state.
>   - **Related Issues**:
>     - Fixes #947
>     - Fixes #2463
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 943a190f6b7b66012d5ebb6732b0cdabaeeaf0a2. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->