### PR TITLE
fix: respect chromeExecutablePath setting in UrlContentFetcher

### DIFF
--- a/src/services/browser/UrlContentFetcher.ts
+++ b/src/services/browser/UrlContentFetcher.ts
@@ -32,11 +32,18 @@ export class UrlContentFetcher {
 		if (!dirExists) {
 			await fs.mkdir(puppeteerDir, { recursive: true })
 		}
-		// if chromium doesn't exist, this will download it to path.join(puppeteerDir, ".chromium-browser-snapshots")
-		// if it does exist it will return the path to existing chromium
-		const stats: PCRStats = await PCR({
-			downloadPath: puppeteerDir,
-		})
+		
+		const chromeExecutablePath = vscode.workspace.getConfiguration("cline").get<string>("chromeExecutablePath")
+		if (chromeExecutablePath && !(await fileExistsAtPath(chromeExecutablePath))) {
+			throw new Error(`Chrome executable not found at path: ${chromeExecutablePath}`)
+		}
+		
+		const stats: PCRStats = chromeExecutablePath
+			? { puppeteer: require("puppeteer-core"), executablePath: chromeExecutablePath }
+			: // if chromium doesn't exist, this will download it to path.join(puppeteerDir, ".chromium-browser-snapshots")
+			  // if it does exist it will return the path to existing chromium
+			  await PCR({ downloadPath: puppeteerDir })
+		
 		return stats
 	}
 


### PR DESCRIPTION
### Description
<!-- Describe your changes in detail. What problem does this PR solve? -->
This PR fixes issue #2510 where the "@http://" command was failing to use the custom chrome executable path specified in settings, while the "Visit" command worked fine.

The root cause was that `BrowserSession.ts` (used by the "Visit" command) properly checked for and respected the `cline.chromeExecutablePath` configuration setting, while `UrlContentFetcher.ts` (used by the "@http://" command) did not include this check.

This change modifies the `ensureChromiumExists()` method in `UrlContentFetcher.ts` to mirror the same logic used in `BrowserSession.ts`, ensuring both commands use the same approach to determine the Chrome executable path.

### Test Procedure
<!-- How did you test this? Are you confident that it will not introduce bugs? If so, why? -->
1. Configure a custom Chrome executable path in VSCode settings with `cline.chromeExecutablePath`
2. Test the "Visit https://www.example.com" command to verify it works as expected
3. Test the "@http://www.example.com" command to verify it now uses the same executable path
4. Confirm the browser launches correctly in both cases

This change is minimal and only affects how the Chrome executable path is determined, mirroring existing well-tested logic from `BrowserSession.ts`. The fix doesn't modify any browser behavior or arguments, so it should not introduce new bugs.

### Type of Change
<!-- Put an 'x' in all boxes that apply -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update

### Pre-flight Checklist
<!-- Put an 'x' in all boxes that apply -->
- [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
- [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
- [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
- [x] I have reviewed [[contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots
<!-- For UI changes, add screenshots here -->
N/A

### Additional Notes
<!-- Add any additional notes for reviewers -->
This change essentially ports the Chrome executable path detection logic from `BrowserSession.ts` to `UrlContentFetcher.ts` to ensure consistent behavior across both browser-related features. The fix is particularly important for users running Cline in containerized environments where custom Chrome executables with specific flags are required.