### PR TITLE
ENG-323   Ara/diagnostics delay ux

### DIFF
--- a/.changeset/nasty-countries-grab.md
+++ b/.changeset/nasty-countries-grab.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Adding UI for changing the time spent on post edit diagnostics and linter checks

--- a/src/core/controller/index.ts
+++ b/src/core/controller/index.ts
@@ -1359,7 +1359,6 @@ Here is the project's README to help you get started:\n\n${mcpDetails.readmeCont
 				console.error("Invalid response from OpenRouter API")
 			}
 			await fs.writeFile(openRouterModelsFilePath, JSON.stringify(models))
-			console.log("OpenRouter models fetched and saved", models)
 		} catch (error) {
 			console.error("Error fetching OpenRouter models:", error)
 		}

--- a/src/core/task/index.ts
+++ b/src/core/task/index.ts
@@ -1764,7 +1764,8 @@ export class Task {
 									telemetryService.captureToolUsage(this.taskId, block.name, true, true)
 
 									// we need an artificial delay to let the diagnostics catch up to the changes
-									await setTimeoutPromise(3_500)
+									const diagnosticsDelay = this.autoApprovalSettings.diagnosticsDelayMs // Use delay from task's settings
+									await setTimeoutPromise(diagnosticsDelay)
 								} else {
 									// If auto-approval is enabled but this tool wasn't auto-approved, send notification
 									showNotificationForApprovalIfAutoApprovalEnabled(

--- a/src/shared/AutoApprovalSettings.ts
+++ b/src/shared/AutoApprovalSettings.ts
@@ -12,6 +12,8 @@ export interface AutoApprovalSettings {
 	// Global settings
 	maxRequests: number // Maximum number of auto-approved requests
 	enableNotifications: boolean // Show notifications for approval and task completion
+	/** Delay in milliseconds after file edits to wait for diagnostics. */
+	diagnosticsDelayMs: number
 }
 
 export const DEFAULT_AUTO_APPROVAL_SETTINGS: AutoApprovalSettings = {
@@ -25,4 +27,5 @@ export const DEFAULT_AUTO_APPROVAL_SETTINGS: AutoApprovalSettings = {
 	},
 	maxRequests: 20,
 	enableNotifications: false,
+	diagnosticsDelayMs: 1000, // Default delay
 }


### PR DESCRIPTION
[Solves Linear issue ](https://linear.app/cline-bot/issue/ENG-323/delay-after-editing-adjustment-set-a-pause-after-writes-for-diagnostic)

### Description

Introduce diagnostics delay setting for auto-approval
* Added diagnosticsDelayMs to AutoApprovalSettings for configurable delay after file edits.
* Updated AutoApproveMenu to include a slider for adjusting the diagnostics delay.
* Refactored task handling to utilize the new delay setting for improved error checking.

This enhancement allows users to customize the delay for diagnostics checks, improving the overall user experience so more details on the [linear issue]((https://linear.app/cline-bot/issue/ENG-323/delay-after-editing-adjustment-set-a-pause-after-writes-for-diagnostic))

UX examples
<img width="363" alt="image" src="https://github.com/user-attachments/assets/68925daf-8560-4b1a-82c8-bf80dfc1cc16" />
.
<img width="355" alt="image" src="https://github.com/user-attachments/assets/4806d4f2-d433-4179-b8d3-b3e2c0d636e0" />
.
<img width="356" alt="image" src="https://github.com/user-attachments/assets/220f8cce-2b47-41c4-8f5f-24ae7d216cc2" />
.

<img width="368" alt="image" src="https://github.com/user-attachments/assets/86743a15-9751-44e6-9b55-ea50f18e2333" />


UX Tooltip for explain the feature more
<img width="661" alt="image" src="https://github.com/user-attachments/assets/1567adde-7371-4942-8684-e84052d2892a" />


### Test Procedure
Tested this locally by adding adding a console log for the diagnostics check. 


### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [X] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [ ] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add diagnostics delay setting to auto-approval settings, allowing users to configure delay after file edits for improved diagnostics checks.
> 
>   - **Behavior**:
>     - Added `diagnosticsDelayMs` to `AutoApprovalSettings` for configurable delay after file edits.
>     - Updated `Task` class in `index.ts` to use `diagnosticsDelayMs` for delaying diagnostics checks after file edits.
>   - **UI**:
>     - Updated `AutoApproveMenu.tsx` to include a slider for adjusting `diagnosticsDelayMs`.
>     - Added qualitative feedback for diagnostics delay in `AutoApproveMenu.tsx`.
>   - **Misc**:
>     - Removed console log in `controller/index.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 39062a7135a43bf71b4983e04d177933af816bc1. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->