### PR TITLE
refactor & perf of file `BrowserSettingsMenu.tsx`

### DIFF
--- a/.changeset/short-donuts-search.md
+++ b/.changeset/short-donuts-search.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+refactor & perf of file `BrowserSettingsMenu.tsx`

--- a/webview-ui/src/components/browser/BrowserSettingsMenu.style.ts
+++ b/webview-ui/src/components/browser/BrowserSettingsMenu.style.ts
@@ -1,0 +1,70 @@
+import { CSSProperties } from "react"
+import styled from "styled-components"
+import { CODE_BLOCK_BG_COLOR } from "../common/CodeBlock"
+
+export const containerStyle: CSSProperties = { position: "relative", marginTop: "-1px" }
+
+export const codiconStyle: CSSProperties = { fontSize: "14.5px" }
+
+export const VSCodeCheckboxStyle: CSSProperties = { marginBottom: "8px", marginTop: -1 }
+
+export const VSCodeDropdownStyle: CSSProperties = { width: "100%" }
+
+export const SettingsMenu = styled.div<{ maxWidth?: number }>`
+	position: absolute;
+	top: calc(100% + 8px);
+	right: -2px;
+	background: ${CODE_BLOCK_BG_COLOR};
+	border: 1px solid var(--vscode-editorGroup-border);
+	padding: 8px;
+	border-radius: 3px;
+	z-index: 1000;
+	width: calc(100vw - 57px);
+	min-width: 0px;
+	max-width: ${(props) => (props.maxWidth ? `${props.maxWidth - 23}px` : "100vw")};
+
+	// Add invisible padding to create a safe hover zone
+	&::before {
+		content: "";
+		position: absolute;
+		top: -14px; // Same as margin-top in the parent's top property
+		left: 0;
+		right: -6px;
+		height: 14px;
+	}
+
+	&::after {
+		content: "";
+		position: absolute;
+		top: -6px;
+		right: 6px;
+		width: 10px;
+		height: 10px;
+		background: ${CODE_BLOCK_BG_COLOR};
+		border-left: 1px solid var(--vscode-editorGroup-border);
+		border-top: 1px solid var(--vscode-editorGroup-border);
+		transform: rotate(45deg);
+		z-index: 1; // Ensure arrow stays above the padding
+	}
+`
+
+export const SettingsGroup = styled.div`
+	&:not(:last-child) {
+		margin-bottom: 8px;
+		// padding-bottom: 8px;
+		border-bottom: 1px solid var(--vscode-editorGroup-border);
+	}
+`
+
+export const SettingsHeader = styled.div`
+	font-size: 11px;
+	font-weight: 600;
+	margin-bottom: 6px;
+	color: var(--vscode-foreground);
+`
+
+export const SettingsDescription = styled.div<{ isLast?: boolean }>`
+	font-size: 11px;
+	color: var(--vscode-descriptionForeground);
+	margin-bottom: ${(props) => (props.isLast ? "0" : "8px")};
+`

--- a/webview-ui/src/components/browser/BrowserSettingsMenu.tsx
+++ b/webview-ui/src/components/browser/BrowserSettingsMenu.tsx
@@ -1,39 +1,61 @@
 import { VSCodeButton, VSCodeCheckbox, VSCodeDropdown, VSCodeOption } from "@vscode/webview-ui-toolkit/react"
-import React, { useRef, useState } from "react"
+import React, { useRef, useState, useMemo } from "react"
 import { useClickAway } from "react-use"
-import styled from "styled-components"
 import { BROWSER_VIEWPORT_PRESETS } from "../../../../src/shared/BrowserSettings"
 import { useExtensionState } from "../../context/ExtensionStateContext"
 import { vscode } from "../../utils/vscode"
-import { CODE_BLOCK_BG_COLOR } from "../common/CodeBlock"
+import {
+	containerStyle,
+	codiconStyle,
+	VSCodeCheckboxStyle,
+	VSCodeDropdownStyle,
+	SettingsMenu,
+	SettingsGroup,
+	SettingsHeader,
+	SettingsDescription,
+} from "./BrowserSettingsMenu.style"
 
 interface BrowserSettingsMenuProps {
 	disabled?: boolean
 	maxWidth?: number
 }
 
+// constant JSX.Elements
+const DropdownOptions = Object.entries(BROWSER_VIEWPORT_PRESETS).map(([name]) => (
+	<VSCodeOption key={name} value={name}>
+		{name}
+	</VSCodeOption>
+))
+
 export const BrowserSettingsMenu: React.FC<BrowserSettingsMenuProps> = ({ disabled = false, maxWidth }) => {
 	const { browserSettings } = useExtensionState()
 	const [showMenu, setShowMenu] = useState(false)
-	const [hasMouseEntered, setHasMouseEntered] = useState(false)
+	const hasMouseEnteredRef = useRef(false)
 	const containerRef = useRef<HTMLDivElement>(null)
 	const menuRef = useRef<HTMLDivElement>(null)
+	const dropdownValue = useMemo(
+		() =>
+			Object.entries(BROWSER_VIEWPORT_PRESETS).find(
+				([_, size]) => size.width === browserSettings.viewport.width && size.height === browserSettings.viewport.height,
+			)?.[0],
+		[browserSettings],
+	)
 
 	useClickAway(containerRef, () => {
 		if (showMenu) {
 			setShowMenu(false)
-			setHasMouseEntered(false)
+			hasMouseEnteredRef.current = false
 		}
 	})
 
 	const handleMouseEnter = () => {
-		setHasMouseEntered(true)
+		hasMouseEnteredRef.current = true
 	}
 
 	const handleMouseLeave = () => {
-		if (hasMouseEntered) {
+		if (hasMouseEnteredRef.current) {
 			setShowMenu(false)
-			setHasMouseEntered(false)
+			hasMouseEnteredRef.current = false
 		}
 	}
 
@@ -55,7 +77,7 @@ export const BrowserSettingsMenu: React.FC<BrowserSettingsMenuProps> = ({ disabl
 		}
 
 		setShowMenu(false)
-		setHasMouseEntered(false)
+		hasMouseEnteredRef.current = false
 	}
 
 	const handleViewportChange = (event: Event) => {
@@ -99,16 +121,16 @@ export const BrowserSettingsMenu: React.FC<BrowserSettingsMenuProps> = ({ disabl
 	// }
 
 	return (
-		<div ref={containerRef} style={{ position: "relative", marginTop: "-1px" }} onMouseLeave={handleControlsMouseLeave}>
+		<div ref={containerRef} style={containerStyle} onMouseLeave={handleControlsMouseLeave}>
 			<VSCodeButton appearance="icon" onClick={() => setShowMenu(!showMenu)} disabled={disabled}>
-				<i className="codicon codicon-settings-gear" style={{ fontSize: "14.5px" }} />
+				<i className="codicon codicon-settings-gear" style={codiconStyle} />
 			</VSCodeButton>
 			{showMenu && (
 				<SettingsMenu ref={menuRef} maxWidth={maxWidth} onMouseEnter={handleMouseEnter} onMouseLeave={handleMouseLeave}>
 					<SettingsGroup>
 						{/* <SettingsHeader>Headless Mode</SettingsHeader> */}
 						<VSCodeCheckbox
-							style={{ marginBottom: "8px", marginTop: -1 }}
+							style={VSCodeCheckboxStyle}
 							checked={browserSettings.headless}
 							onChange={(e) => updateHeadless((e.target as HTMLInputElement).checked)}>
 							Run in headless mode
@@ -151,20 +173,10 @@ export const BrowserSettingsMenu: React.FC<BrowserSettingsMenuProps> = ({ disabl
 					<SettingsGroup>
 						<SettingsHeader>Viewport Size</SettingsHeader>
 						<VSCodeDropdown
-							style={{ width: "100%" }}
-							value={
-								Object.entries(BROWSER_VIEWPORT_PRESETS).find(
-									([_, size]) =>
-										size.width === browserSettings.viewport.width &&
-										size.height === browserSettings.viewport.height,
-								)?.[0]
-							}
+							style={VSCodeDropdownStyle}
+							value={dropdownValue}
 							onChange={(event) => handleViewportChange(event as Event)}>
-							{Object.entries(BROWSER_VIEWPORT_PRESETS).map(([name]) => (
-								<VSCodeOption key={name} value={name}>
-									{name}
-								</VSCodeOption>
-							))}
+							{DropdownOptions}
 						</VSCodeDropdown>
 					</SettingsGroup>
 				</SettingsMenu>
@@ -172,64 +184,5 @@ export const BrowserSettingsMenu: React.FC<BrowserSettingsMenuProps> = ({ disabl
 		</div>
 	)
 }
-
-const SettingsMenu = styled.div<{ maxWidth?: number }>`
-	position: absolute;
-	top: calc(100% + 8px);
-	right: -2px;
-	background: ${CODE_BLOCK_BG_COLOR};
-	border: 1px solid var(--vscode-editorGroup-border);
-	padding: 8px;
-	border-radius: 3px;
-	z-index: 1000;
-	width: calc(100vw - 57px);
-	min-width: 0px;
-	max-width: ${(props) => (props.maxWidth ? `${props.maxWidth - 23}px` : "100vw")};
-
-	// Add invisible padding to create a safe hover zone
-	&::before {
-		content: "";
-		position: absolute;
-		top: -14px; // Same as margin-top in the parent's top property
-		left: 0;
-		right: -6px;
-		height: 14px;
-	}
-
-	&::after {
-		content: "";
-		position: absolute;
-		top: -6px;
-		right: 6px;
-		width: 10px;
-		height: 10px;
-		background: ${CODE_BLOCK_BG_COLOR};
-		border-left: 1px solid var(--vscode-editorGroup-border);
-		border-top: 1px solid var(--vscode-editorGroup-border);
-		transform: rotate(45deg);
-		z-index: 1; // Ensure arrow stays above the padding
-	}
-`
-
-const SettingsGroup = styled.div`
-	&:not(:last-child) {
-		margin-bottom: 8px;
-		// padding-bottom: 8px;
-		border-bottom: 1px solid var(--vscode-editorGroup-border);
-	}
-`
-
-const SettingsHeader = styled.div`
-	font-size: 11px;
-	font-weight: 600;
-	margin-bottom: 6px;
-	color: var(--vscode-foreground);
-`
-
-const SettingsDescription = styled.div<{ isLast?: boolean }>`
-	font-size: 11px;
-	color: var(--vscode-descriptionForeground);
-	margin-bottom: ${(props) => (props.isLast ? "0" : "8px")};
-`
 
 export default BrowserSettingsMenu


### PR DESCRIPTION
### Description

refactor & perf of file `BrowserSettingsMenu.tsx`

### Test Procedure

Test with Fn + F5 => tell cline to open browser

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<img width="1280" alt="BrowserSettingsMenu" src="https://github.com/user-attachments/assets/f55a65f6-8cfb-4b62-a405-86ddd381f69a" />

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Refactor `BrowserSettingsMenu.tsx` for performance by using refs, `useMemo`, and extracting constants for styles and JSX elements.
> 
>   - **Refactor & Performance**:
>     - Replace `useState` with `useRef` for `hasMouseEntered` in `BrowserSettingsMenu.tsx` to avoid unnecessary re-renders.
>     - Use `useMemo` for `dropdownValue` calculation to optimize performance.
>     - Extract inline styles into `CSSProperties` constants: `containerStyle`, `codiconStyle`, `VSCodeCheckboxStyle`, `VSCodeDropdownStyle`.
>     - Extract `DropdownOptions` JSX elements into a constant for better readability and performance.
>   - **Behavior**:
>     - No changes in functionality; refactor focuses on performance and code clarity.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for e6767df461757fc956d79edfd4628778d557a53d. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->