### PR TITLE
split user text during task resumption

### DIFF
--- a/.changeset/khaki-cooks-walk.md
+++ b/.changeset/khaki-cooks-walk.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": minor
+---
+
+update ordering of messages during task restore

--- a/src/core/prompts/responses.ts
+++ b/src/core/prompts/responses.ts
@@ -124,8 +124,8 @@ Otherwise, if you have not completed the task and do not need additional informa
 		cwd: string,
 		wasRecent: boolean | 0 | undefined,
 		responseText?: string,
-	) => {
-		return `[TASK RESUMPTION] ${
+	): [string, string] => {
+		const taskResumptionMessage = `[TASK RESUMPTION] ${
 			mode === "plan"
 				? `This task was interrupted ${agoText}. The conversation may have been incomplete. Be aware that the project state may have changed since then. The current working directory is now '${cwd.toPosix()}'.\n\nNote: If you previously attempted a tool use that the user did not provide a result for, you should assume the tool use was not successful. However you are in PLAN MODE, so rather than continuing the task, you must respond to the user's message.`
 				: `This task was interrupted ${agoText}. It may or may not be complete, so please reassess the task context. Be aware that the project state may have changed since then. The current working directory is now '${cwd.toPosix()}'. If the task has not been completed, retry the last step before interruption and proceed with completing the task.\n\nNote: If you previously attempted a tool use that the user did not provide a result for, you should assume the tool use was not successful and assess whether you should retry. If the last tool was a browser_action, the browser has been closed and you must launch a new browser if needed.`
@@ -133,13 +133,17 @@ Otherwise, if you have not completed the task and do not need additional informa
 			wasRecent
 				? "\n\nIMPORTANT: If the last tool use was a replace_in_file or write_to_file that was interrupted, the file was reverted back to its original state before the interrupted edit, and you do NOT need to re-read the file as you already have its up-to-date contents."
 				: ""
-		}${
+		}`
+
+		const userResponseMessage = `${
 			responseText
-				? `\n\n${mode === "plan" ? "New message to respond to with plan_mode_respond tool (be sure to provide your response in the <response> parameter)" : "New instructions for task continuation"}:\n<user_message>\n${responseText}\n</user_message>`
+				? `${mode === "plan" ? "New message to respond to with plan_mode_respond tool (be sure to provide your response in the <response> parameter)" : "New instructions for task continuation"}:\n<user_message>\n${responseText}\n</user_message>`
 				: mode === "plan"
 					? "(The user did not provide a new message. Consider asking them how they'd like you to proceed, or to switch to Act mode to continue with the task.)"
 					: ""
 		}`
+
+		return [taskResumptionMessage, userResponseMessage]
 	},
 
 	planModeInstructions: () => {

--- a/src/core/task/index.ts
+++ b/src/core/task/index.ts
@@ -930,15 +930,22 @@ export class Task {
 
 		const wasRecent = lastClineMessage?.ts && Date.now() - lastClineMessage.ts < 30_000
 
+		const [taskResumptionMessage, userResponseMessage] = formatResponse.taskResumption(
+			this.chatSettings?.mode === "plan" ? "plan" : "act",
+			agoText,
+			cwd,
+			wasRecent,
+			responseText,
+		)
+
 		newUserContent.push({
 			type: "text",
-			text: formatResponse.taskResumption(
-				this.chatSettings?.mode === "plan" ? "plan" : "act",
-				agoText,
-				cwd,
-				wasRecent,
-				responseText,
-			),
+			text: taskResumptionMessage,
+		})
+
+		newUserContent.push({
+			type: "text",
+			text: userResponseMessage,
 		})
 
 		if (responseImages && responseImages.length > 0) {


### PR DESCRIPTION
### Description

Splits existing user text during task resumption. This means that the new task message ends up at the second index, rather than the first.

### Test Procedure

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

### Additional Notes

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Splits user text into two messages during task resumption, enhancing clarity in task resumption process.
> 
>   - **Behavior**:
>     - Splits user text into two messages during task resumption in `resumeTaskFromHistory()` in `index.ts`.
>     - `taskResumption()` in `responses.ts` now returns a tuple of two strings: task resumption message and user response message.
>   - **Functions**:
>     - Updates `taskResumption()` in `responses.ts` to return two separate messages.
>     - Modifies `resumeTaskFromHistory()` in `index.ts` to handle the two separate messages returned by `taskResumption()`.
>   - **Misc**:
>     - Adds a changeset file `khaki-cooks-walk.md` to document the update.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for fba80a0ffb57291a6f359005c265bf85d6d3850c. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->