### PR TITLE
Add load_mcp_documentation tool

### DIFF
--- a/.changeset/fluffy-toys-punch.md
+++ b/.changeset/fluffy-toys-punch.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Reduce system prompt size by letting Cline dynamically load MCP documentation only when needed

--- a/package.json
+++ b/package.json
@@ -214,21 +214,6 @@
 					},
 					"description": "Settings for VSCode Language Model API"
 				},
-				"cline.mcp.mode": {
-					"type": "string",
-					"enum": [
-						"full",
-						"server-use-only",
-						"off"
-					],
-					"enumDescriptions": [
-						"Enable all MCP functionality (server use and build instructions)",
-						"Enable MCP server use only (excludes instructions about building MCP servers)",
-						"Disable all MCP functionality"
-					],
-					"default": "full",
-					"description": "Controls MCP inclusion in prompts, reduces token usage if you only need access to certain functionality."
-				},
 				"cline.enableCheckpoints": {
 					"type": "boolean",
 					"default": true,

--- a/src/core/assistant-message/index.ts
+++ b/src/core/assistant-message/index.ts
@@ -21,6 +21,7 @@ export const toolUseNames = [
 	"access_mcp_resource",
 	"ask_followup_question",
 	"plan_mode_respond",
+	"load_mcp_documentation",
 	"attempt_completion",
 ] as const
 

--- a/src/core/controller/index.ts
+++ b/src/core/controller/index.ts
@@ -472,14 +472,7 @@ export class Controller {
 						await this.togglePlanActModeWithChatSettings({ mode: "act" })
 					}
 
-					// 2. Enable MCP settings if disabled
-					// Enable MCP mode if disabled
-					const mcpConfig = vscode.workspace.getConfiguration("cline.mcp")
-					if (mcpConfig.get<string>("mode") !== "full") {
-						await mcpConfig.update("mode", "full", true)
-					}
-
-					// 3. download MCP
+					// 2. download MCP
 					await this.downloadMcp(message.mcpId)
 				}
 				break
@@ -1183,6 +1176,7 @@ export class Controller {
 
 			// Create task with context from README and added guidelines for MCP server installation
 			const task = `Set up the MCP server from ${mcpDetails.githubUrl} while adhering to these MCP server installation rules:
+- Start by loading the MCP documentation.
 - Use "${mcpDetails.mcpId}" as the server name in cline_mcp_settings.json.
 - Create the directory for the new MCP server before starting installation.
 - Use commands aligned with the user's shell and operating system best practices.

--- a/src/core/prompts/loadMcpDocumentation.ts
+++ b/src/core/prompts/loadMcpDocumentation.ts
@@ -1,0 +1,361 @@
+import { McpHub } from "../../services/mcp/McpHub"
+
+export async function loadMcpDocumentation(mcpHub: McpHub) {
+	return `## Creating an MCP Server
+
+When creating MCP servers, it's important to understand that they operate in a non-interactive environment. The server cannot initiate OAuth flows, open browser windows, or prompt for user input during runtime. All credentials and authentication tokens must be provided upfront through environment variables in the MCP settings configuration. For example, Spotify's API uses OAuth to get a refresh token for the user, but the MCP server cannot initiate this flow. While you can walk the user through obtaining an application client ID and secret, you may have to create a separate one-time setup script (like get-refresh-token.js) that captures and logs the final piece of the puzzle: the user's refresh token (i.e. you might run the script using execute_command which would open a browser for authentication, and then log the refresh token so that you can see it in the command output for you to use in the MCP settings configuration).
+
+Unless the user specifies otherwise, new MCP servers should be created in: ${await mcpHub.getMcpServersPath()}
+
+### Example MCP Server
+
+For example, if the user wanted to give you the ability to retrieve weather information, you could create an MCP server that uses the OpenWeather API to get weather information, add it to the MCP settings configuration file, and then notice that you now have access to new tools and resources in the system prompt that you might use to show the user your new capabilities.
+
+The following example demonstrates how to build an MCP server that provides weather data functionality. While this example shows how to implement resources, resource templates, and tools, in practice you should prefer using tools since they are more flexible and can handle dynamic parameters. The resource and resource template implementations are included here mainly for demonstration purposes of the different MCP capabilities, but a real weather server would likely just expose tools for fetching weather data. (The following steps are for macOS)
+
+1. Use the \`create-typescript-server\` tool to bootstrap a new project in the default MCP servers directory:
+
+\`\`\`bash
+cd ${await mcpHub.getMcpServersPath()}
+npx @modelcontextprotocol/create-server weather-server
+cd weather-server
+# Install dependencies
+npm install axios
+\`\`\`
+
+This will create a new project with the following structure:
+
+\`\`\`
+weather-server/
+  ├── package.json
+      {
+        ...
+        "type": "module", // added by default, uses ES module syntax (import/export) rather than CommonJS (require/module.exports) (Important to know if you create additional scripts in this server repository like a get-refresh-token.js script)
+        "scripts": {
+          "build": "tsc && node -e \"require('fs').chmodSync('build/index.js', '755')\"",
+          ...
+        }
+        ...
+      }
+  ├── tsconfig.json
+  └── src/
+      └── weather-server/
+          └── index.ts      # Main server implementation
+\`\`\`
+
+2. Replace \`src/index.ts\` with the following:
+
+\`\`\`typescript
+#!/usr/bin/env node
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import {
+  CallToolRequestSchema,
+  ErrorCode,
+  ListResourcesRequestSchema,
+  ListResourceTemplatesRequestSchema,
+  ListToolsRequestSchema,
+  McpError,
+  ReadResourceRequestSchema,
+} from '@modelcontextprotocol/sdk/types.js';
+import axios from 'axios';
+
+const API_KEY = process.env.OPENWEATHER_API_KEY; // provided by MCP config
+if (!API_KEY) {
+  throw new Error('OPENWEATHER_API_KEY environment variable is required');
+}
+
+interface OpenWeatherResponse {
+  main: {
+    temp: number;
+    humidity: number;
+  };
+  weather: [{ description: string }];
+  wind: { speed: number };
+  dt_txt?: string;
+}
+
+const isValidForecastArgs = (
+  args: any
+): args is { city: string; days?: number } =>
+  typeof args === 'object' &&
+  args !== null &&
+  typeof args.city === 'string' &&
+  (args.days === undefined || typeof args.days === 'number');
+
+class WeatherServer {
+  private server: Server;
+  private axiosInstance;
+
+  constructor() {
+    this.server = new Server(
+      {
+        name: 'example-weather-server',
+        version: '0.1.0',
+      },
+      {
+        capabilities: {
+          resources: {},
+          tools: {},
+        },
+      }
+    );
+
+    this.axiosInstance = axios.create({
+      baseURL: 'http://api.openweathermap.org/data/2.5',
+      params: {
+        appid: API_KEY,
+        units: 'metric',
+      },
+    });
+
+    this.setupResourceHandlers();
+    this.setupToolHandlers();
+    
+    // Error handling
+    this.server.onerror = (error) => console.error('[MCP Error]', error);
+    process.on('SIGINT', async () => {
+      await this.server.close();
+      process.exit(0);
+    });
+  }
+
+  // MCP Resources represent any kind of UTF-8 encoded data that an MCP server wants to make available to clients, such as database records, API responses, log files, and more. Servers define direct resources with a static URI or dynamic resources with a URI template that follows the format \`[protocol]://[host]/[path]\`.
+  private setupResourceHandlers() {
+    // For static resources, servers can expose a list of resources:
+    this.server.setRequestHandler(ListResourcesRequestSchema, async () => ({
+      resources: [
+        // This is a poor example since you could use the resource template to get the same information but this demonstrates how to define a static resource
+        {
+          uri: \`weather://San Francisco/current\`, // Unique identifier for San Francisco weather resource
+          name: \`Current weather in San Francisco\`, // Human-readable name
+          mimeType: 'application/json', // Optional MIME type
+          // Optional description
+          description:
+            'Real-time weather data for San Francisco including temperature, conditions, humidity, and wind speed',
+        },
+      ],
+    }));
+
+    // For dynamic resources, servers can expose resource templates:
+    this.server.setRequestHandler(
+      ListResourceTemplatesRequestSchema,
+      async () => ({
+        resourceTemplates: [
+          {
+            uriTemplate: 'weather://{city}/current', // URI template (RFC 6570)
+            name: 'Current weather for a given city', // Human-readable name
+            mimeType: 'application/json', // Optional MIME type
+            description: 'Real-time weather data for a specified city', // Optional description
+          },
+        ],
+      })
+    );
+
+    // ReadResourceRequestSchema is used for both static resources and dynamic resource templates
+    this.server.setRequestHandler(
+      ReadResourceRequestSchema,
+      async (request) => {
+        const match = request.params.uri.match(
+          /^weather:\/\/([^/]+)\/current$/
+        );
+        if (!match) {
+          throw new McpError(
+            ErrorCode.InvalidRequest,
+            \`Invalid URI format: \${request.params.uri}\`
+          );
+        }
+        const city = decodeURIComponent(match[1]);
+
+        try {
+          const response = await this.axiosInstance.get(
+            'weather', // current weather
+            {
+              params: { q: city },
+            }
+          );
+
+          return {
+            contents: [
+              {
+                uri: request.params.uri,
+                mimeType: 'application/json',
+                text: JSON.stringify(
+                  {
+                    temperature: response.data.main.temp,
+                    conditions: response.data.weather[0].description,
+                    humidity: response.data.main.humidity,
+                    wind_speed: response.data.wind.speed,
+                    timestamp: new Date().toISOString(),
+                  },
+                  null,
+                  2
+                ),
+              },
+            ],
+          };
+        } catch (error) {
+          if (axios.isAxiosError(error)) {
+            throw new McpError(
+              ErrorCode.InternalError,
+              \`Weather API error: \${
+                error.response?.data.message ?? error.message
+              }\`
+            );
+          }
+          throw error;
+        }
+      }
+    );
+  }
+
+  /* MCP Tools enable servers to expose executable functionality to the system. Through these tools, you can interact with external systems, perform computations, and take actions in the real world.
+   * - Like resources, tools are identified by unique names and can include descriptions to guide their usage. However, unlike resources, tools represent dynamic operations that can modify state or interact with external systems.
+   * - While resources and tools are similar, you should prefer to create tools over resources when possible as they provide more flexibility.
+   */
+  private setupToolHandlers() {
+    this.server.setRequestHandler(ListToolsRequestSchema, async () => ({
+      tools: [
+        {
+          name: 'get_forecast', // Unique identifier
+          description: 'Get weather forecast for a city', // Human-readable description
+          inputSchema: {
+            // JSON Schema for parameters
+            type: 'object',
+            properties: {
+              city: {
+                type: 'string',
+                description: 'City name',
+              },
+              days: {
+                type: 'number',
+                description: 'Number of days (1-5)',
+                minimum: 1,
+                maximum: 5,
+              },
+            },
+            required: ['city'], // Array of required property names
+          },
+        },
+      ],
+    }));
+
+    this.server.setRequestHandler(CallToolRequestSchema, async (request) => {
+      if (request.params.name !== 'get_forecast') {
+        throw new McpError(
+          ErrorCode.MethodNotFound,
+          \`Unknown tool: \${request.params.name}\`
+        );
+      }
+
+      if (!isValidForecastArgs(request.params.arguments)) {
+        throw new McpError(
+          ErrorCode.InvalidParams,
+          'Invalid forecast arguments'
+        );
+      }
+
+      const city = request.params.arguments.city;
+      const days = Math.min(request.params.arguments.days || 3, 5);
+
+      try {
+        const response = await this.axiosInstance.get<{
+          list: OpenWeatherResponse[];
+        }>('forecast', {
+          params: {
+            q: city,
+            cnt: days * 8,
+          },
+        });
+
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify(response.data.list, null, 2),
+            },
+          ],
+        };
+      } catch (error) {
+        if (axios.isAxiosError(error)) {
+          return {
+            content: [
+              {
+                type: 'text',
+                text: \`Weather API error: \${
+                  error.response?.data.message ?? error.message
+                }\`,
+              },
+            ],
+            isError: true,
+          };
+        }
+        throw error;
+      }
+    });
+  }
+
+  async run() {
+    const transport = new StdioServerTransport();
+    await this.server.connect(transport);
+    console.error('Weather MCP server running on stdio');
+  }
+}
+
+const server = new WeatherServer();
+server.run().catch(console.error);
+\`\`\`
+
+(Remember: This is just an example–you may use different dependencies, break the implementation up into multiple files, etc.)
+
+3. Build and compile the executable JavaScript file
+
+\`\`\`bash
+npm run build
+\`\`\`
+
+4. Whenever you need an environment variable such as an API key to configure the MCP server, walk the user through the process of getting the key. For example, they may need to create an account and go to a developer dashboard to generate the key. Provide step-by-step instructions and URLs to make it easy for the user to retrieve the necessary information. Then use the ask_followup_question tool to ask the user for the key, in this case the OpenWeather API key.
+
+5. Install the MCP Server by adding the MCP server configuration to the settings file located at '${await mcpHub.getMcpSettingsFilePath()}'. The settings file may have other MCP servers already configured, so you would read it first and then add your new server to the existing \`mcpServers\` object.
+
+IMPORTANT: Regardless of what else you see in the MCP settings file, you must default any new MCP servers you create to disabled=false and autoApprove=[].
+
+\`\`\`json
+{
+  "mcpServers": {
+    ...,
+    "weather": {
+      "command": "node",
+      "args": ["/path/to/weather-server/build/index.js"],
+      "env": {
+        "OPENWEATHER_API_KEY": "user-provided-api-key"
+      }
+    },
+  }
+}
+\`\`\`
+
+(Note: the user may also ask you to install the MCP server to the Claude desktop app, in which case you would read then modify \`~/Library/Application\ Support/Claude/claude_desktop_config.json\` on macOS for example. It follows the same format of a top level \`mcpServers\` object.)
+
+6. After you have edited the MCP settings configuration file, the system will automatically run all the servers and expose the available tools and resources in the 'Connected MCP Servers' section. (Note: If you encounter a 'not connected' error when testing a newly installed mcp server, a common cause is an incorrect build path in your MCP settings configuration. Since compiled JavaScript files are commonly output to either 'dist/' or 'build/' directories, double-check that the build path in your MCP settings matches where your files are actually being compiled. E.g. If you assumed 'build' as the folder, check tsconfig.json to see if it's using 'dist' instead.)
+
+7. Now that you have access to these new tools and resources, you may suggest ways the user can command you to invoke them - for example, with this new weather tool now available, you can invite the user to ask "what's the weather in San Francisco?"
+
+## Editing MCP Servers
+
+The user may ask to add tools or resources that may make sense to add to an existing MCP server (listed under 'Connected MCP Servers' below: ${
+		mcpHub
+			.getServers()
+			.filter((server) => server.status === "connected")
+			.map((server) => server.name)
+			.join(", ") || "(None running currently)"
+	}, e.g. if it would use the same API. This would be possible if you can locate the MCP server repository on the user's system by looking at the server arguments for a filepath. You might then use list_files and read_file to explore the files in the repository, and use replace_in_file to make changes to the files.
+
+However some MCP servers may be running from installed packages rather than a local repository, in which case it may make more sense to create a new MCP server.
+
+# MCP Servers Are Not Always Necessary
+
+The user may not always request the use or creation of MCP servers. Instead, they might provide tasks that can be completed with existing tools. While using the MCP SDK to extend your capabilities can be useful, it's important to understand that this is just one specialized type of task you can accomplish. You should only implement MCP servers when the user explicitly requests it (e.g., "add a tool that...").
+
+Remember: The MCP documentation and example provided above are to help you understand and work with existing MCP servers or create new ones when requested by the user. You already have access to tools and capabilities that can be used to accomplish a wide range of tasks.`
+}

--- a/src/core/prompts/system.ts
+++ b/src/core/prompts/system.ts
@@ -177,9 +177,6 @@ Usage:
 		: ""
 }
 
-${
-	mcpHub.getMode() !== "off"
-		? `
 ## use_mcp_tool
 Description: Request to use a tool provided by a connected MCP server. Each MCP server can provide multiple tools with different capabilities. Tools have defined input schemas that specify required and optional parameters.
 Parameters:
@@ -208,9 +205,6 @@ Usage:
 <server_name>server name here</server_name>
 <uri>resource URI here</uri>
 </access_mcp_resource>
-`
-		: ""
-}
 
 ## ask_followup_question
 Description: Ask the user a question to gather additional information needed to complete the task. This tool should be used when you encounter ambiguities, need clarification, or require more details to proceed effectively. It allows for interactive problem-solving by enabling direct communication with the user. Use this tool judiciously to maintain a balance between gathering necessary information and avoiding excessive back-and-forth.
@@ -251,6 +245,13 @@ Usage:
 Array of options here (optional), e.g. ["Option 1", "Option 2", "Option 3"]
 </options>
 </plan_mode_respond>
+
+## load_mcp_documentation
+Description: Load documentation about creating MCP servers. This tool should be used when the user requests to create or install an MCP server (the user may ask you something along the lines of "add a tool" that does some function, in other words to create an MCP server that provides tools and resources that may connect to external APIs for example. You have the ability to create an MCP server and add it to a configuration file that will then expose the tools and resources for you to use with \`use_mcp_tool\` and \`access_mcp_resource\`). The documentation provides detailed information about the MCP server creation process, including setup instructions, best practices, and examples.
+Parameters: None
+Usage:
+<load_mcp_documentation>
+</load_mcp_documentation>
 
 # Tool Use Examples
 
@@ -317,9 +318,6 @@ return (
 >>>>>>> REPLACE
 </diff>
 </replace_in_file>
-${
-	mcpHub.getMode() !== "off"
-		? `
 
 ## Example 4: Requesting to use an MCP tool
 
@@ -334,14 +332,7 @@ ${
 </arguments>
 </use_mcp_tool>
 
-## Example 5: Requesting to access an MCP resource
-
-<access_mcp_resource>
-<server_name>weather-server</server_name>
-<uri>weather://san-francisco/current</uri>
-</access_mcp_resource>
-
-## Example 6: Another example of using an MCP tool (where the server name is a unique identifier such as a URL)
+## Example 5: Another example of using an MCP tool (where the server name is a unique identifier such as a URL)
 
 <use_mcp_tool>
 <server_name>github.com/modelcontextprotocol/servers/tree/main/src/github</server_name>
@@ -356,9 +347,7 @@ ${
   "assignees": ["octocat"]
 }
 </arguments>
-</use_mcp_tool>`
-		: ""
-}
+</use_mcp_tool>
 
 # Tool Use Guidelines
 
@@ -381,9 +370,6 @@ It is crucial to proceed step-by-step, waiting for the user's message after each
 
 By waiting for and carefully considering the user's response after each tool use, you can react accordingly and make informed decisions about how to proceed with the task. This iterative process helps ensure the overall success and accuracy of your work.
 
-${
-	mcpHub.getMode() !== "off"
-		? `
 ====
 
 MCP SERVERS
@@ -430,374 +416,6 @@ ${
 				})
 				.join("\n\n")}`
 		: "(No MCP servers currently connected)"
-}`
-		: ""
-}
-
-${
-	mcpHub.getMode() === "full"
-		? `
-## Creating an MCP Server
-
-The user may ask you something along the lines of "add a tool" that does some function, in other words to create an MCP server that provides tools and resources that may connect to external APIs for example. You have the ability to create an MCP server and add it to a configuration file that will then expose the tools and resources for you to use with \`use_mcp_tool\` and \`access_mcp_resource\`.
-
-When creating MCP servers, it's important to understand that they operate in a non-interactive environment. The server cannot initiate OAuth flows, open browser windows, or prompt for user input during runtime. All credentials and authentication tokens must be provided upfront through environment variables in the MCP settings configuration. For example, Spotify's API uses OAuth to get a refresh token for the user, but the MCP server cannot initiate this flow. While you can walk the user through obtaining an application client ID and secret, you may have to create a separate one-time setup script (like get-refresh-token.js) that captures and logs the final piece of the puzzle: the user's refresh token (i.e. you might run the script using execute_command which would open a browser for authentication, and then log the refresh token so that you can see it in the command output for you to use in the MCP settings configuration).
-
-Unless the user specifies otherwise, new MCP servers should be created in: ${await mcpHub.getMcpServersPath()}
-
-### Example MCP Server
-
-For example, if the user wanted to give you the ability to retrieve weather information, you could create an MCP server that uses the OpenWeather API to get weather information, add it to the MCP settings configuration file, and then notice that you now have access to new tools and resources in the system prompt that you might use to show the user your new capabilities.
-
-The following example demonstrates how to build an MCP server that provides weather data functionality. While this example shows how to implement resources, resource templates, and tools, in practice you should prefer using tools since they are more flexible and can handle dynamic parameters. The resource and resource template implementations are included here mainly for demonstration purposes of the different MCP capabilities, but a real weather server would likely just expose tools for fetching weather data. (The following steps are for macOS)
-
-1. Use the \`create-typescript-server\` tool to bootstrap a new project in the default MCP servers directory:
-
-\`\`\`bash
-cd ${await mcpHub.getMcpServersPath()}
-npx @modelcontextprotocol/create-server weather-server
-cd weather-server
-# Install dependencies
-npm install axios
-\`\`\`
-
-This will create a new project with the following structure:
-
-\`\`\`
-weather-server/
-  ├── package.json
-      {
-        ...
-        "type": "module", // added by default, uses ES module syntax (import/export) rather than CommonJS (require/module.exports) (Important to know if you create additional scripts in this server repository like a get-refresh-token.js script)
-        "scripts": {
-          "build": "tsc && node -e \"require('fs').chmodSync('build/index.js', '755')\"",
-          ...
-        }
-        ...
-      }
-  ├── tsconfig.json
-  └── src/
-      └── weather-server/
-          └── index.ts      # Main server implementation
-\`\`\`
-
-2. Replace \`src/index.ts\` with the following:
-
-\`\`\`typescript
-#!/usr/bin/env node
-import { Server } from '@modelcontextprotocol/sdk/server/index.js';
-import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
-import {
-  CallToolRequestSchema,
-  ErrorCode,
-  ListResourcesRequestSchema,
-  ListResourceTemplatesRequestSchema,
-  ListToolsRequestSchema,
-  McpError,
-  ReadResourceRequestSchema,
-} from '@modelcontextprotocol/sdk/types.js';
-import axios from 'axios';
-
-const API_KEY = process.env.OPENWEATHER_API_KEY; // provided by MCP config
-if (!API_KEY) {
-  throw new Error('OPENWEATHER_API_KEY environment variable is required');
-}
-
-interface OpenWeatherResponse {
-  main: {
-    temp: number;
-    humidity: number;
-  };
-  weather: [{ description: string }];
-  wind: { speed: number };
-  dt_txt?: string;
-}
-
-const isValidForecastArgs = (
-  args: any
-): args is { city: string; days?: number } =>
-  typeof args === 'object' &&
-  args !== null &&
-  typeof args.city === 'string' &&
-  (args.days === undefined || typeof args.days === 'number');
-
-class WeatherServer {
-  private server: Server;
-  private axiosInstance;
-
-  constructor() {
-    this.server = new Server(
-      {
-        name: 'example-weather-server',
-        version: '0.1.0',
-      },
-      {
-        capabilities: {
-          resources: {},
-          tools: {},
-        },
-      }
-    );
-
-    this.axiosInstance = axios.create({
-      baseURL: 'http://api.openweathermap.org/data/2.5',
-      params: {
-        appid: API_KEY,
-        units: 'metric',
-      },
-    });
-
-    this.setupResourceHandlers();
-    this.setupToolHandlers();
-    
-    // Error handling
-    this.server.onerror = (error) => console.error('[MCP Error]', error);
-    process.on('SIGINT', async () => {
-      await this.server.close();
-      process.exit(0);
-    });
-  }
-
-  // MCP Resources represent any kind of UTF-8 encoded data that an MCP server wants to make available to clients, such as database records, API responses, log files, and more. Servers define direct resources with a static URI or dynamic resources with a URI template that follows the format \`[protocol]://[host]/[path]\`.
-  private setupResourceHandlers() {
-    // For static resources, servers can expose a list of resources:
-    this.server.setRequestHandler(ListResourcesRequestSchema, async () => ({
-      resources: [
-        // This is a poor example since you could use the resource template to get the same information but this demonstrates how to define a static resource
-        {
-          uri: \`weather://San Francisco/current\`, // Unique identifier for San Francisco weather resource
-          name: \`Current weather in San Francisco\`, // Human-readable name
-          mimeType: 'application/json', // Optional MIME type
-          // Optional description
-          description:
-            'Real-time weather data for San Francisco including temperature, conditions, humidity, and wind speed',
-        },
-      ],
-    }));
-
-    // For dynamic resources, servers can expose resource templates:
-    this.server.setRequestHandler(
-      ListResourceTemplatesRequestSchema,
-      async () => ({
-        resourceTemplates: [
-          {
-            uriTemplate: 'weather://{city}/current', // URI template (RFC 6570)
-            name: 'Current weather for a given city', // Human-readable name
-            mimeType: 'application/json', // Optional MIME type
-            description: 'Real-time weather data for a specified city', // Optional description
-          },
-        ],
-      })
-    );
-
-    // ReadResourceRequestSchema is used for both static resources and dynamic resource templates
-    this.server.setRequestHandler(
-      ReadResourceRequestSchema,
-      async (request) => {
-        const match = request.params.uri.match(
-          /^weather:\/\/([^/]+)\/current$/
-        );
-        if (!match) {
-          throw new McpError(
-            ErrorCode.InvalidRequest,
-            \`Invalid URI format: \${request.params.uri}\`
-          );
-        }
-        const city = decodeURIComponent(match[1]);
-
-        try {
-          const response = await this.axiosInstance.get(
-            'weather', // current weather
-            {
-              params: { q: city },
-            }
-          );
-
-          return {
-            contents: [
-              {
-                uri: request.params.uri,
-                mimeType: 'application/json',
-                text: JSON.stringify(
-                  {
-                    temperature: response.data.main.temp,
-                    conditions: response.data.weather[0].description,
-                    humidity: response.data.main.humidity,
-                    wind_speed: response.data.wind.speed,
-                    timestamp: new Date().toISOString(),
-                  },
-                  null,
-                  2
-                ),
-              },
-            ],
-          };
-        } catch (error) {
-          if (axios.isAxiosError(error)) {
-            throw new McpError(
-              ErrorCode.InternalError,
-              \`Weather API error: \${
-                error.response?.data.message ?? error.message
-              }\`
-            );
-          }
-          throw error;
-        }
-      }
-    );
-  }
-
-  /* MCP Tools enable servers to expose executable functionality to the system. Through these tools, you can interact with external systems, perform computations, and take actions in the real world.
-   * - Like resources, tools are identified by unique names and can include descriptions to guide their usage. However, unlike resources, tools represent dynamic operations that can modify state or interact with external systems.
-   * - While resources and tools are similar, you should prefer to create tools over resources when possible as they provide more flexibility.
-   */
-  private setupToolHandlers() {
-    this.server.setRequestHandler(ListToolsRequestSchema, async () => ({
-      tools: [
-        {
-          name: 'get_forecast', // Unique identifier
-          description: 'Get weather forecast for a city', // Human-readable description
-          inputSchema: {
-            // JSON Schema for parameters
-            type: 'object',
-            properties: {
-              city: {
-                type: 'string',
-                description: 'City name',
-              },
-              days: {
-                type: 'number',
-                description: 'Number of days (1-5)',
-                minimum: 1,
-                maximum: 5,
-              },
-            },
-            required: ['city'], // Array of required property names
-          },
-        },
-      ],
-    }));
-
-    this.server.setRequestHandler(CallToolRequestSchema, async (request) => {
-      if (request.params.name !== 'get_forecast') {
-        throw new McpError(
-          ErrorCode.MethodNotFound,
-          \`Unknown tool: \${request.params.name}\`
-        );
-      }
-
-      if (!isValidForecastArgs(request.params.arguments)) {
-        throw new McpError(
-          ErrorCode.InvalidParams,
-          'Invalid forecast arguments'
-        );
-      }
-
-      const city = request.params.arguments.city;
-      const days = Math.min(request.params.arguments.days || 3, 5);
-
-      try {
-        const response = await this.axiosInstance.get<{
-          list: OpenWeatherResponse[];
-        }>('forecast', {
-          params: {
-            q: city,
-            cnt: days * 8,
-          },
-        });
-
-        return {
-          content: [
-            {
-              type: 'text',
-              text: JSON.stringify(response.data.list, null, 2),
-            },
-          ],
-        };
-      } catch (error) {
-        if (axios.isAxiosError(error)) {
-          return {
-            content: [
-              {
-                type: 'text',
-                text: \`Weather API error: \${
-                  error.response?.data.message ?? error.message
-                }\`,
-              },
-            ],
-            isError: true,
-          };
-        }
-        throw error;
-      }
-    });
-  }
-
-  async run() {
-    const transport = new StdioServerTransport();
-    await this.server.connect(transport);
-    console.error('Weather MCP server running on stdio');
-  }
-}
-
-const server = new WeatherServer();
-server.run().catch(console.error);
-\`\`\`
-
-(Remember: This is just an example–you may use different dependencies, break the implementation up into multiple files, etc.)
-
-3. Build and compile the executable JavaScript file
-
-\`\`\`bash
-npm run build
-\`\`\`
-
-4. Whenever you need an environment variable such as an API key to configure the MCP server, walk the user through the process of getting the key. For example, they may need to create an account and go to a developer dashboard to generate the key. Provide step-by-step instructions and URLs to make it easy for the user to retrieve the necessary information. Then use the ask_followup_question tool to ask the user for the key, in this case the OpenWeather API key.
-
-5. Install the MCP Server by adding the MCP server configuration to the settings file located at '${await mcpHub.getMcpSettingsFilePath()}'. The settings file may have other MCP servers already configured, so you would read it first and then add your new server to the existing \`mcpServers\` object.
-
-IMPORTANT: Regardless of what else you see in the MCP settings file, you must default any new MCP servers you create to disabled=false and autoApprove=[].
-
-\`\`\`json
-{
-  "mcpServers": {
-    ...,
-    "weather": {
-      "command": "node",
-      "args": ["/path/to/weather-server/build/index.js"],
-      "env": {
-        "OPENWEATHER_API_KEY": "user-provided-api-key"
-      }
-    },
-  }
-}
-\`\`\`
-
-(Note: the user may also ask you to install the MCP server to the Claude desktop app, in which case you would read then modify \`~/Library/Application\ Support/Claude/claude_desktop_config.json\` on macOS for example. It follows the same format of a top level \`mcpServers\` object.)
-
-6. After you have edited the MCP settings configuration file, the system will automatically run all the servers and expose the available tools and resources in the 'Connected MCP Servers' section. (Note: If you encounter a 'not connected' error when testing a newly installed mcp server, a common cause is an incorrect build path in your MCP settings configuration. Since compiled JavaScript files are commonly output to either 'dist/' or 'build/' directories, double-check that the build path in your MCP settings matches where your files are actually being compiled. E.g. If you assumed 'build' as the folder, check tsconfig.json to see if it's using 'dist' instead.)
-
-7. Now that you have access to these new tools and resources, you may suggest ways the user can command you to invoke them - for example, with this new weather tool now available, you can invite the user to ask "what's the weather in San Francisco?"
-
-## Editing MCP Servers
-
-The user may ask to add tools or resources that may make sense to add to an existing MCP server (listed under 'Connected MCP Servers' below: ${
-				mcpHub
-					.getServers()
-					.filter((server) => server.status === "connected")
-					.map((server) => server.name)
-					.join(", ") || "(None running currently)"
-			}, e.g. if it would use the same API. This would be possible if you can locate the MCP server repository on the user's system by looking at the server arguments for a filepath. You might then use list_files and read_file to explore the files in the repository, and use replace_in_file to make changes to the files.
-
-However some MCP servers may be running from installed packages rather than a local repository, in which case it may make more sense to create a new MCP server.
-
-# MCP Servers Are Not Always Necessary
-
-The user may not always request the use or creation of MCP servers. Instead, they might provide tasks that can be completed with existing tools. While using the MCP SDK to extend your capabilities can be useful, it's important to understand that this is just one specialized type of task you can accomplish. You should only implement MCP servers when the user explicitly requests it (e.g., "add a tool that...").
-
-Remember: The MCP documentation and example provided above are to help you understand and work with existing MCP servers or create new ones when requested by the user. You already have access to tools and capabilities that can be used to accomplish a wide range of tasks.
-`
-		: ""
 }
 
 ====
@@ -912,13 +530,7 @@ CAPABILITIES
 		? "\n- You can use the browser_action tool to interact with websites (including html files and locally running development servers) through a Puppeteer-controlled browser when you feel it is necessary in accomplishing the user's task. This tool is particularly useful for web development tasks as it allows you to launch a browser, navigate to pages, interact with elements through clicks and keyboard input, and capture the results through screenshots and console logs. This tool may be useful at key stages of web development tasks-such as after implementing new features, making substantial changes, when troubleshooting issues, or to verify the result of your work. You can analyze the provided screenshots to ensure correct rendering or identify errors, and review console logs for runtime issues.\n	- For example, if asked to add a component to a react website, you might create the necessary files, use execute_command to run the site locally, then use browser_action to launch the browser, navigate to the local server, and verify the component renders & functions correctly before closing the browser."
 		: ""
 }
-${
-	mcpHub.getMode() !== "off"
-		? `
 - You have access to MCP servers that may provide additional tools and resources. Each server may provide different capabilities that you can use to accomplish tasks more effectively.
-`
-		: ""
-}
 
 ====
 
@@ -939,7 +551,7 @@ RULES
 - The user may provide a file's contents directly in their message, in which case you shouldn't use the read_file tool to get the file contents again since you already have it.
 - Your goal is to try to accomplish the user's task, NOT engage in a back and forth conversation.${
 	supportsComputerUse
-		? `\n- The user may ask generic non-development tasks, such as "what\'s the latest news" or "look up the weather in San Diego", in which case you might use the browser_action tool to complete the task if it makes sense to do so, rather than trying to create a website or using curl to answer the question.${mcpHub.getMode() !== "off" ? "However, if an available MCP server tool or resource can be used instead, you should prefer to use it over browser_action." : ""}`
+		? `\n- The user may ask generic non-development tasks, such as "what\'s the latest news" or "look up the weather in San Diego", in which case you might use the browser_action tool to complete the task if it makes sense to do so, rather than trying to create a website or using curl to answer the question. However, if an available MCP server tool or resource can be used instead, you should prefer to use it over browser_action.`
 		: ""
 }
 - NEVER end attempt_completion result with a question or request to engage in further conversation! Formulate the end of your result in a way that is final and does not require further input from the user.
@@ -954,13 +566,7 @@ RULES
 		? " Then if you want to test your work, you might use browser_action to launch the site, wait for the user's response confirming the site was launched along with a screenshot, then perhaps e.g., click a button to test functionality if needed, wait for the user's response confirming the button was clicked along with a screenshot of the new state, before finally closing the browser."
 		: ""
 }
-${
-	mcpHub.getMode() !== "off"
-		? `
 - MCP operations should be used one at a time, similar to other tool usage. Wait for confirmation of success before proceeding with additional operations.
-`
-		: ""
-}
 
 ====
 

--- a/src/core/task/index.ts
+++ b/src/core/task/index.ts
@@ -78,6 +78,7 @@ import {
 	saveClineMessages,
 	GlobalFileNames,
 } from "../storage/disk"
+import { loadMcpDocumentation } from "../prompts/loadMcpDocumentation"
 
 const cwd = vscode.workspace.workspaceFolders?.map((folder) => folder.uri.fsPath).at(0) ?? path.join(os.homedir(), "Desktop") // may or may not exist but fs checking existence would immediately ask for permission which would be bad UX, need to come up with a better solution
 
@@ -1453,6 +1454,8 @@ export class Task {
 							return `[${block.name} for '${block.params.question}']`
 						case "plan_mode_respond":
 							return `[${block.name}]`
+						case "load_mcp_documentation":
+							return `[${block.name}]`
 						case "attempt_completion":
 							return `[${block.name}]`
 					}
@@ -2786,6 +2789,28 @@ export class Task {
 						} catch (error) {
 							await handleError("responding to inquiry", error)
 							//
+							break
+						}
+					}
+					case "load_mcp_documentation": {
+						try {
+							if (block.partial) {
+								// shouldn't happen
+								break
+							} else {
+								await this.say("load_mcp_documentation", "", undefined, false)
+
+								const mcpHub = this.controllerRef.deref()?.mcpHub
+								if (!mcpHub) {
+									throw new Error("MCP hub not available")
+								}
+
+								pushToolResult(await loadMcpDocumentation(mcpHub))
+
+								break
+							}
+						} catch (error) {
+							await handleError("loading MCP documentation", error)
 							break
 						}
 					}

--- a/src/services/mcp/McpHub.ts
+++ b/src/services/mcp/McpHub.ts
@@ -94,10 +94,6 @@ export class McpHub {
 		return this.connections.filter((conn) => !conn.server.disabled).map((conn) => conn.server)
 	}
 
-	getMode(): McpMode {
-		return vscode.workspace.getConfiguration("cline.mcp").get<McpMode>("mode", "full")
-	}
-
 	async getMcpServersPath(): Promise<string> {
 		const provider = this.controllerRef.deref()
 		if (!provider) {

--- a/src/shared/ExtensionMessage.ts
+++ b/src/shared/ExtensionMessage.ts
@@ -181,6 +181,7 @@ export type ClineSay =
 	| "deleted_api_reqs"
 	| "clineignore_error"
 	| "checkpoint_created"
+	| "load_mcp_documentation"
 
 export interface ClineSayTool {
 	tool:

--- a/webview-ui/src/components/chat/ChatRow.tsx
+++ b/webview-ui/src/components/chat/ChatRow.tsx
@@ -989,6 +989,21 @@ export const ChatRowContent = ({ message, isExpanded, onToggleExpand, lastModifi
 							<CheckmarkControl messageTs={message.ts} isCheckpointCheckedOut={message.isCheckpointCheckedOut} />
 						</>
 					)
+				case "load_mcp_documentation":
+					return (
+						<div
+							style={{
+								display: "flex",
+								alignItems: "center",
+								color: "var(--vscode-foreground)",
+								opacity: 0.7,
+								fontSize: 12,
+								padding: "4px 0",
+							}}>
+							<i className="codicon codicon-book" style={{ marginRight: 6 }} />
+							Loading MCP documentation
+						</div>
+					)
 				case "completion_result":
 					const hasChanges = message.text?.endsWith(COMPLETION_RESULT_CHANGES_FLAG) ?? false
 					const text = hasChanges ? message.text?.slice(0, -COMPLETION_RESULT_CHANGES_FLAG.length) : message.text

--- a/webview-ui/src/components/chat/ChatView.tsx
+++ b/webview-ui/src/components/chat/ChatView.tsx
@@ -224,6 +224,7 @@ const ChatView = ({ isHidden, showAnnouncement, hideAnnouncement, showHistoryVie
 						case "mcp_server_response":
 						case "completion_result":
 						case "tool":
+						case "load_mcp_documentation":
 							break
 					}
 					break


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `load_mcp_documentation` tool to load MCP server creation documentation and integrate it into the task execution and UI display.
> 
>   - **Behavior**:
>     - Adds `load_mcp_documentation` tool to `toolUseNames` in `index.ts`.
>     - Implements `loadMcpDocumentation()` in `loadMcpDocumentation.ts` to return MCP server creation documentation.
>     - Handles `load_mcp_documentation` in `Task` class in `index.ts` to execute the tool and push results.
>   - **UI**:
>     - Displays loading message for `load_mcp_documentation` in `ChatRow.tsx`.
>   - **Configuration**:
>     - Removes `cline.mcp.mode` setting from `package.json`.
>   - **Misc**:
>     - Removes `getMode()` from `McpHub.ts` as it's no longer needed.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for e899caf156d1f00f1d2ec69d302ae83c38790c69. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->