### PR TITLE
Fix MCP Auto-Approve - State out of Sync [1/2]

### DIFF
--- a/.changeset/famous-snakes-deliver.md
+++ b/.changeset/famous-snakes-deliver.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Fix auto approve state out of sync

--- a/src/services/mcp/McpHub.ts
+++ b/src/services/mcp/McpHub.ts
@@ -627,7 +627,12 @@ export class McpHub {
 
 			// Update the tools list to reflect the change
 			const connection = this.connections.find((conn) => conn.server.name === serverName)
-			if (connection) {
+			if (connection && connection.server.tools) {
+				// Update the autoApprove property of each tool in the in-memory server object
+				connection.server.tools = connection.server.tools.map((tool) => ({
+					...tool,
+					autoApprove: autoApprove.includes(tool.name),
+				}))
 				await this.notifyWebviewOfServerChanges()
 			}
 		} catch (error) {


### PR DESCRIPTION
### Description

One of the auto approve all buttons was not updating the in-memory state properly before notifying the webview of the change.

### Test Procedure

<!-- How did you test this? Are you confident that it will not introduce bugs? If so, why? -->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix in-memory state update for `autoApprove` property in `McpHub.ts` to ensure consistency before notifying webview.
> 
>   - **Bug Fix**:
>     - In `McpHub.ts`, fix in-memory state update for `autoApprove` property of tools in `toggleToolAutoApprove()`.
>     - Ensures `autoApprove` property is updated before calling `notifyWebviewOfServerChanges()`.
>   - **Misc**:
>     - Add changeset file `famous-snakes-deliver.md` for patch release.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 94b87f967846f0fc919ef7cddca4b4ceb76704e2. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->