### PR TITLE
Remove options from plan mode tool + improve plan mode prompt

### DIFF
--- a/src/core/prompts/responses.ts
+++ b/src/core/prompts/responses.ts
@@ -137,7 +137,7 @@ Otherwise, if you have not completed the task and do not need additional informa
 			responseText
 				? `\n\n${mode === "plan" ? "New message to respond to with plan_mode_respond tool (be sure to provide your response in the <response> parameter)" : "New instructions for task continuation"}:\n<user_message>\n${responseText}\n</user_message>`
 				: mode === "plan"
-					? "(The user did not provide a new message. Consider asking them how they'd like you to proceed, or to switch to Act mode to continue with the task.)"
+					? "(The user did not provide a new message. Consider asking them how they'd like you to proceed, or suggest to them to switch to Act mode to continue with the task.)"
 					: ""
 		}`
 	},

--- a/src/core/prompts/system.ts
+++ b/src/core/prompts/system.ts
@@ -243,13 +243,9 @@ Your final result description here
 Description: Respond to the user's inquiry in an effort to plan a solution to the user's task. This tool should be used when you need to provide a response to a question or statement from the user about how you plan to accomplish the task. This tool is only available in PLAN MODE. The environment_details will specify the current mode, if it is not PLAN MODE then you should not use this tool. Depending on the user's message, you may ask questions to get clarification about the user's request, architect a solution to the task, and to brainstorm ideas with the user. For example, if the user's task is to create a website, you may start by asking some clarifying questions, then present a detailed plan for how you will accomplish the task given the context, and perhaps engage in a back and forth to finalize the details before the user switches you to ACT MODE to implement the solution.
 Parameters:
 - response: (required) The response to provide to the user. Do not try to use tools in this parameter, this is simply a chat response. (You MUST use the response parameter, do not simply place the response text directly within <plan_mode_respond> tags.)
-- options: (optional) An array of 2-5 options for the user to choose from. Each option should be a string describing a possible choice or path forward in the planning process. This can help guide the discussion and make it easier for the user to provide input on key decisions. You may not always need to provide options, but it may be helpful in many cases where it can save the user from having to type out a response manually. Do NOT present an option to toggle to Act mode, as this will be something you need to direct the user to do manually themselves.
 Usage:
 <plan_mode_respond>
 <response>Your response here</response>
-<options>
-Array of options here (optional), e.g. ["Option 1", "Option 2", "Option 3"]
-</options>
 </plan_mode_respond>
 
 # Tool Use Examples


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove 'options' parameter from 'plan_mode_respond' tool and update related documentation.
> 
>   - **Behavior**:
>     - Removed `options` parameter from `plan_mode_respond` tool in `system.ts`.
>     - Updated `taskResumption` function in `responses.ts` to suggest switching to Act mode.
>   - **Documentation**:
>     - Removed `options` parameter description from `plan_mode_respond` usage in `system.ts`.
>     - Removed `options` parameter from `ask_followup_question` tool in `system.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 53cd8ad9e4367e4306d02b36c2495758e27ba8d1. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->