### PR TITLE
Add dispatch trigger and restrictions to changeset converter.

### DIFF
--- a/.github/workflows/changeset-converter.yml
+++ b/.github/workflows/changeset-converter.yml
@@ -30,7 +30,7 @@ jobs:
             - name: Check user for team affiliation
               id: team_check
               if: github.event_name == 'workflow_dispatch'
-              uses: morfien101/actions-authorized-user@v3
+              uses: morfien101/actions-authorized-user@4a3cfbf0bcb3cafe4a71710a278920c5d94bb38b
               with:
                 username: ${{ github.actor }}
                 team: "deployer"

--- a/.github/workflows/changeset-converter.yml
+++ b/.github/workflows/changeset-converter.yml
@@ -22,7 +22,7 @@ jobs:
                 github.event.pull_request.base.ref == 'main' &&
                 github.actor != 'github-actions'
             )
-        runs-on: ubuntu-latestx`
+        runs-on: ubuntu-latest`
         permissions:
             contents: write
             pull-requests: write

--- a/.github/workflows/changeset-converter.yml
+++ b/.github/workflows/changeset-converter.yml
@@ -2,6 +2,7 @@ name: Changeset Converter
 run-name: Changeset Conversion
 
 on:
+    workflow_dispatch:
     pull_request:
         types: [closed]
 
@@ -13,16 +14,36 @@ env:
 jobs:
     # Job 1: Create version bump PR when changesets are merged to main
     changeset-pr-version-bump:
-        if: >
-            github.event_name == 'pull_request' &&
-            github.event.pull_request.merged == true &&
-            github.event.pull_request.base.ref == 'main' &&
-            github.actor != 'github-actions'
-        runs-on: ubuntu-latest
+        if: |
+            github.event_name == 'workflow_dispatch' ||
+            (
+                github.event_name == 'pull_request' &&
+                github.event.pull_request.merged == true &&
+                github.event.pull_request.base.ref == 'main' &&
+                github.actor != 'github-actions'
+            )
+        runs-on: ubuntu-latestx`
         permissions:
             contents: write
             pull-requests: write
         steps:
+            - name: Check user for team affiliation
+              id: team_check
+              if: github.event_name == 'workflow_dispatch'
+              uses: morfien101/actions-authorized-user@v3
+              with:
+                username: ${{ github.actor }}
+                team: "deployer"
+                github_token: ${{ secrets.GITHUB_TOKEN }}
+
+            - name: Check if user is authorized
+              if: github.event_name == 'workflow_dispatch'
+              run: |
+                  if [ "${{ steps.team_check.outputs.authorized }}" != "true" ]; then
+                      echo "User is not authorized to run this workflow."
+                      exit 1
+                  fi
+
             - name: Git Checkout
               uses: actions/checkout@v4
               with:

--- a/.github/workflows/changeset-converter.yml
+++ b/.github/workflows/changeset-converter.yml
@@ -32,9 +32,9 @@ jobs:
               if: github.event_name == 'workflow_dispatch'
               uses: morfien101/actions-authorized-user@4a3cfbf0bcb3cafe4a71710a278920c5d94bb38b
               with:
-                username: ${{ github.actor }}
-                team: "deployer"
-                github_token: ${{ secrets.GITHUB_TOKEN }}
+                  username: ${{ github.actor }}
+                  team: "deployer"
+                  github_token: ${{ secrets.GITHUB_TOKEN }}
 
             - name: Check if user is authorized
               if: github.event_name == 'workflow_dispatch'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "claude-dev",
-	"version": "3.9.1",
+	"version": "3.9.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "claude-dev",
-			"version": "3.9.1",
+			"version": "3.9.2",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@anthropic-ai/bedrock-sdk": "^0.12.4",


### PR DESCRIPTION
### Description

Add dispatch trigger and restrictions to changeset converter.  This will allow anyone that is listed as a "deployer" team member to manually update the changeset PR using the workflow.

### Test Procedure

Manually trigger workflow as an authorized and non-authorized user to test happy and sad paths respectively

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update
-   [X] 🏃 Workflow update

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds manual trigger and authorization checks to changeset converter workflow for deployer team members.
> 
>   - **Workflow Dispatch**:
>     - Adds `workflow_dispatch` trigger to `.github/workflows/changeset-converter.yml`.
>     - Allows manual triggering of the workflow.
>   - **Authorization**:
>     - Checks if the user is part of the 'deployer' team using `morfien101/actions-authorized-user`.
>     - Fails the workflow if the user is not authorized.
>   - **Job Execution**:
>     - Modifies `if` condition in `changeset-pr-version-bump` to include `workflow_dispatch`.
>     - Ensures only authorized users can manually trigger the changeset conversion.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 710612f165777bef82a7426aed4a4760f70c5740. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->