### PR TITLE
feat: add tiered pricing for gemini-2.5-pro

### DIFF
--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -489,8 +489,6 @@ export const geminiModels = {
 		contextWindow: 1_048_576,
 		supportsImages: true,
 		supportsPromptCache: false,
-		// inputPrice: 1.25, // Removed
-		// outputPrice: 10, // Removed
 		inputPriceTiers: [
 			{ tokenLimit: 200000, price: 1.25 }, // Input price for <= 200k input tokens
 			{ tokenLimit: Infinity, price: 2.5 }, // Input price for > 200k input tokens

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -82,14 +82,21 @@ export type ApiConfiguration = ApiHandlerOptions & {
 
 // Models
 
+interface PriceTier {
+	tokenLimit: number // Upper limit (inclusive) of *input* tokens for this price. Use Infinity for the highest tier.
+	price: number // Price per million tokens for this tier.
+}
+
 export interface ModelInfo {
 	maxTokens?: number
 	contextWindow?: number
 	supportsImages?: boolean
 	supportsComputerUse?: boolean
 	supportsPromptCache: boolean // this value is hardcoded for now
-	inputPrice?: number
-	outputPrice?: number
+	inputPrice?: number // Keep for non-tiered input models
+	inputPriceTiers?: PriceTier[] // Add for tiered input pricing
+	outputPrice?: number // Keep for non-tiered output models
+	outputPriceTiers?: PriceTier[] // Add for tiered output pricing
 	cacheWritesPrice?: number
 	cacheReadsPrice?: number
 	description?: string
@@ -384,8 +391,16 @@ export const vertexModels = {
 		contextWindow: 1_048_576,
 		supportsImages: true,
 		supportsPromptCache: false,
-		inputPrice: 1.25,
-		outputPrice: 10,
+		// inputPrice: 1.25, // Removed
+		// outputPrice: 10, // Removed
+		inputPriceTiers: [
+			{ tokenLimit: 200000, price: 1.25 }, // Input price for <= 200k input tokens
+			{ tokenLimit: Infinity, price: 2.5 }, // Input price for > 200k input tokens
+		],
+		outputPriceTiers: [
+			{ tokenLimit: 200000, price: 10.0 }, // Output price for <= 200k input tokens
+			{ tokenLimit: Infinity, price: 15.0 }, // Output price for > 200k input tokens
+		],
 	},
 	"gemini-2.0-flash-thinking-exp-01-21": {
 		maxTokens: 65_536,
@@ -474,8 +489,16 @@ export const geminiModels = {
 		contextWindow: 1_048_576,
 		supportsImages: true,
 		supportsPromptCache: false,
-		inputPrice: 1.25,
-		outputPrice: 10,
+		// inputPrice: 1.25, // Removed
+		// outputPrice: 10, // Removed
+		inputPriceTiers: [
+			{ tokenLimit: 200000, price: 1.25 }, // Input price for <= 200k input tokens
+			{ tokenLimit: Infinity, price: 2.5 }, // Input price for > 200k input tokens
+		],
+		outputPriceTiers: [
+			{ tokenLimit: 200000, price: 10.0 }, // Output price for <= 200k input tokens
+			{ tokenLimit: Infinity, price: 15.0 }, // Output price for > 200k input tokens
+		],
 	},
 	"gemini-2.0-flash-001": {
 		maxTokens: 8192,

--- a/src/utils/cost.ts
+++ b/src/utils/cost.ts
@@ -10,25 +10,30 @@ function calculateApiCostInternal(
 ): number {
 	// Determine effective input price
 	let effectiveInputPrice = modelInfo.inputPrice || 0
-	if (modelInfo.inputPriceTiers && totalInputTokensForPricing !== undefined) {
+	if (modelInfo.inputPriceTiers && modelInfo.inputPriceTiers.length > 0 && totalInputTokensForPricing !== undefined) {
+		// Ensure tiers are sorted by tokenLimit ascending before finding
+		const sortedInputTiers = [...modelInfo.inputPriceTiers].sort((a, b) => a.tokenLimit - b.tokenLimit)
 		// Find the first tier where the total input tokens are less than or equal to the limit
-		const tier = modelInfo.inputPriceTiers.find((t) => totalInputTokensForPricing! <= t.tokenLimit)
+		const tier = sortedInputTiers.find((t) => totalInputTokensForPricing! <= t.tokenLimit)
 		if (tier) {
 			effectiveInputPrice = tier.price
 		} else {
 			// Should ideally not happen if Infinity is used for the last tier, but fallback just in case
-			effectiveInputPrice = modelInfo.inputPriceTiers[modelInfo.inputPriceTiers.length - 1]?.price || 0
+			effectiveInputPrice = sortedInputTiers[sortedInputTiers.length - 1]?.price || 0
 		}
 	}
 
 	// Determine effective output price (based on total *input* tokens for pricing)
 	let effectiveOutputPrice = modelInfo.outputPrice || 0
-	if (modelInfo.outputPriceTiers && totalInputTokensForPricing !== undefined) {
-		const tier = modelInfo.outputPriceTiers.find((t) => totalInputTokensForPricing! <= t.tokenLimit)
+	if (modelInfo.outputPriceTiers && modelInfo.outputPriceTiers.length > 0 && totalInputTokensForPricing !== undefined) {
+		// Ensure tiers are sorted by tokenLimit ascending before finding
+		const sortedOutputTiers = [...modelInfo.outputPriceTiers].sort((a, b) => a.tokenLimit - b.tokenLimit)
+		const tier = sortedOutputTiers.find((t) => totalInputTokensForPricing! <= t.tokenLimit)
 		if (tier) {
 			effectiveOutputPrice = tier.price
 		} else {
-			effectiveOutputPrice = modelInfo.outputPriceTiers[modelInfo.outputPriceTiers.length - 1]?.price || 0
+			// Should ideally not happen if Infinity is used for the last tier, but fallback just in case
+			effectiveOutputPrice = sortedOutputTiers[sortedOutputTiers.length - 1]?.price || 0
 		}
 	}
 

--- a/src/utils/cost.ts
+++ b/src/utils/cost.ts
@@ -2,15 +2,43 @@ import { ModelInfo } from "../shared/api"
 
 function calculateApiCostInternal(
 	modelInfo: ModelInfo,
-	inputTokens: number,
+	inputTokens: number, // Note: For OpenAI-style, this is non-cached tokens. For Anthropic-style, this is total input tokens.
 	outputTokens: number,
 	cacheCreationInputTokens: number,
 	cacheReadInputTokens: number,
+	totalInputTokensForPricing?: number, // The *total* input tokens, used for tiered pricing lookup
 ): number {
+	// Determine effective input price
+	let effectiveInputPrice = modelInfo.inputPrice || 0
+	if (modelInfo.inputPriceTiers && totalInputTokensForPricing !== undefined) {
+		// Find the first tier where the total input tokens are less than or equal to the limit
+		const tier = modelInfo.inputPriceTiers.find((t) => totalInputTokensForPricing! <= t.tokenLimit)
+		if (tier) {
+			effectiveInputPrice = tier.price
+		} else {
+			// Should ideally not happen if Infinity is used for the last tier, but fallback just in case
+			effectiveInputPrice = modelInfo.inputPriceTiers[modelInfo.inputPriceTiers.length - 1]?.price || 0
+		}
+	}
+
+	// Determine effective output price (based on total *input* tokens for pricing)
+	let effectiveOutputPrice = modelInfo.outputPrice || 0
+	if (modelInfo.outputPriceTiers && totalInputTokensForPricing !== undefined) {
+		const tier = modelInfo.outputPriceTiers.find((t) => totalInputTokensForPricing! <= t.tokenLimit)
+		if (tier) {
+			effectiveOutputPrice = tier.price
+		} else {
+			effectiveOutputPrice = modelInfo.outputPriceTiers[modelInfo.outputPriceTiers.length - 1]?.price || 0
+		}
+	}
+
 	const cacheWritesCost = ((modelInfo.cacheWritesPrice || 0) / 1_000_000) * cacheCreationInputTokens
 	const cacheReadsCost = ((modelInfo.cacheReadsPrice || 0) / 1_000_000) * cacheReadInputTokens
-	const baseInputCost = ((modelInfo.inputPrice || 0) / 1_000_000) * inputTokens
-	const outputCost = ((modelInfo.outputPrice || 0) / 1_000_000) * outputTokens
+	// Use effectiveInputPrice for baseInputCost. Note: 'inputTokens' here is the potentially adjusted count (e.g., non-cached for OpenAI)
+	const baseInputCost = (effectiveInputPrice / 1_000_000) * inputTokens
+	// Use effectiveOutputPrice for outputCost
+	const outputCost = (effectiveOutputPrice / 1_000_000) * outputTokens
+
 	const totalCost = cacheWritesCost + cacheReadsCost + baseInputCost + outputCost
 	return totalCost
 }
@@ -25,7 +53,15 @@ export function calculateApiCostAnthropic(
 ): number {
 	const cacheCreationInputTokensNum = cacheCreationInputTokens || 0
 	const cacheReadInputTokensNum = cacheReadInputTokens || 0
-	return calculateApiCostInternal(modelInfo, inputTokens, outputTokens, cacheCreationInputTokensNum, cacheReadInputTokensNum)
+	// Anthropic style doesn't need totalInputTokensForPricing as its inputTokens already represents the total
+	return calculateApiCostInternal(
+		modelInfo,
+		inputTokens,
+		outputTokens,
+		cacheCreationInputTokensNum,
+		cacheReadInputTokensNum,
+		undefined, // Pass undefined for totalInputTokensForPricing
+	)
 }
 
 // For OpenAI compliant usage, the input tokens count INCLUDES the cached tokens
@@ -38,12 +74,15 @@ export function calculateApiCostOpenAI(
 ): number {
 	const cacheCreationInputTokensNum = cacheCreationInputTokens || 0
 	const cacheReadInputTokensNum = cacheReadInputTokens || 0
+	// Calculate non-cached tokens for the internal function's 'inputTokens' parameter
 	const nonCachedInputTokens = Math.max(0, inputTokens - cacheCreationInputTokensNum - cacheReadInputTokensNum)
+	// Pass the original 'inputTokens' as 'totalInputTokensForPricing' for tier lookup
 	return calculateApiCostInternal(
 		modelInfo,
-		nonCachedInputTokens,
+		nonCachedInputTokens, // Pass the adjusted token count here
 		outputTokens,
 		cacheCreationInputTokensNum,
 		cacheReadInputTokensNum,
+		inputTokens, // Pass the original total input tokens for pricing tier lookup
 	)
 }

--- a/webview-ui/src/components/settings/ApiOptions.tsx
+++ b/webview-ui/src/components/settings/ApiOptions.tsx
@@ -1583,9 +1583,9 @@ const formatTiers = (tiers: ModelInfo["inputPriceTiers"]): string[] => {
 		const prevLimit = index > 0 ? arr[index - 1].tokenLimit : 0
 		const limitText =
 			tier.tokenLimit === Infinity
-				? `> ${(prevLimit / 1000).toLocaleString()}k` // Assumes sorted and Infinity is last
-				: `<= ${(tier.tokenLimit / 1000).toLocaleString()}k`
-		return `${formatPrice(tier.price)}/M (${limitText} tokens)`
+				? `> ${prevLimit.toLocaleString()}` // Assumes sorted and Infinity is last
+				: `<= ${tier.tokenLimit.toLocaleString()}`
+		return `${formatPrice(tier.price)}/million tokens (${limitText} tokens)`
 	})
 }
 

--- a/webview-ui/src/components/settings/ApiOptions.tsx
+++ b/webview-ui/src/components/settings/ApiOptions.tsx
@@ -1574,6 +1574,21 @@ export const formatPrice = (price: number) => {
 	}).format(price)
 }
 
+// Returns an array of formatted tier strings
+const formatTiers = (tiers: ModelInfo["inputPriceTiers"]): string[] => {
+	if (!tiers || tiers.length === 0) {
+		return []
+	}
+	return tiers.map((tier, index, arr) => {
+		const prevLimit = index > 0 ? arr[index - 1].tokenLimit : 0
+		const limitText =
+			tier.tokenLimit === Infinity
+				? `> ${(prevLimit / 1000).toLocaleString()}k` // Assumes sorted and Infinity is last
+				: `<= ${(tier.tokenLimit / 1000).toLocaleString()}k`
+		return `${formatPrice(tier.price)}/M (${limitText} tokens)`
+	})
+}
+
 export const ModelInfoView = ({
 	selectedModelId,
 	modelInfo,
@@ -1588,6 +1603,42 @@ export const ModelInfoView = ({
 	isPopup?: boolean
 }) => {
 	const isGemini = Object.keys(geminiModels).includes(selectedModelId)
+
+	// Create elements for tiered pricing separately
+	const inputPriceElement = modelInfo.inputPriceTiers ? (
+		<Fragment key="inputPriceTiers">
+			<span style={{ fontWeight: 500 }}>Input price:</span>
+			<br />
+			{formatTiers(modelInfo.inputPriceTiers).map((tierString, i, arr) => (
+				<Fragment key={`inputTierFrag${i}`}>
+					<span style={{ paddingLeft: "15px" }}>{tierString}</span>
+					{i < arr.length - 1 && <br />}
+				</Fragment>
+			))}
+		</Fragment>
+	) : modelInfo.inputPrice !== undefined && modelInfo.inputPrice > 0 ? (
+		<span key="inputPrice">
+			<span style={{ fontWeight: 500 }}>Input price:</span> {formatPrice(modelInfo.inputPrice)}/million tokens
+		</span>
+	) : null
+
+	const outputPriceElement = modelInfo.outputPriceTiers ? (
+		<Fragment key="outputPriceTiers">
+			<span style={{ fontWeight: 500 }}>Output price:</span>
+			<span style={{ fontStyle: "italic" }}> (based on input tokens)</span>
+			<br />
+			{formatTiers(modelInfo.outputPriceTiers).map((tierString, i, arr) => (
+				<Fragment key={`outputTierFrag${i}`}>
+					<span style={{ paddingLeft: "15px" }}>{tierString}</span>
+					{i < arr.length - 1 && <br />}
+				</Fragment>
+			))}
+		</Fragment>
+	) : modelInfo.outputPrice !== undefined && modelInfo.outputPrice > 0 ? (
+		<span key="outputPrice">
+			<span style={{ fontWeight: 500 }}>Output price:</span> {formatPrice(modelInfo.outputPrice)}/million tokens
+		</span>
+	) : null
 
 	const infoItems = [
 		modelInfo.description && (
@@ -1624,11 +1675,7 @@ export const ModelInfoView = ({
 				<span style={{ fontWeight: 500 }}>Max output:</span> {modelInfo.maxTokens?.toLocaleString()} tokens
 			</span>
 		),
-		modelInfo.inputPrice !== undefined && modelInfo.inputPrice > 0 && (
-			<span key="inputPrice">
-				<span style={{ fontWeight: 500 }}>Input price:</span> {formatPrice(modelInfo.inputPrice)}/million tokens
-			</span>
-		),
+		inputPriceElement, // Add the generated input price block
 		modelInfo.supportsPromptCache && modelInfo.cacheWritesPrice && (
 			<span key="cacheWritesPrice">
 				<span style={{ fontWeight: 500 }}>Cache writes price:</span> {formatPrice(modelInfo.cacheWritesPrice || 0)}
@@ -1641,11 +1688,7 @@ export const ModelInfoView = ({
 				tokens
 			</span>
 		),
-		modelInfo.outputPrice !== undefined && modelInfo.outputPrice > 0 && (
-			<span key="outputPrice">
-				<span style={{ fontWeight: 500 }}>Output price:</span> {formatPrice(modelInfo.outputPrice)}/million tokens
-			</span>
-		),
+		outputPriceElement, // Add the generated output price block
 		isGemini && (
 			<span key="geminiInfo" style={{ fontStyle: "italic" }}>
 				* Free up to {selectedModelId && selectedModelId.includes("flash") ? "15" : "2"} requests per minute. After that,


### PR DESCRIPTION
### Description

This PR introduces tiered pricing calculation and display for the `gemini-2.5-pro-preview-03-25` model based on input token count.

**Changes:**

-   **`src/shared/api.ts`**:
    -   Added a `PriceTier` interface.
    -   Updated `ModelInfo` to include optional `inputPriceTiers` and `outputPriceTiers` arrays.
    -   Modified the `gemini-2.5-pro-preview-03-25` definition to use these tiers, reflecting the $1.25/$2.50 input and $10.00/$15.00 output pricing based on a 200k input token threshold.
-   **`src/utils/cost.ts`**:
    -   Refactored `calculateApiCostInternal` to determine effective input/output prices based on tiers if available, using a new `totalInputTokensForPricing` parameter.
    -   Updated `calculateApiCostOpenAI` to pass the total input tokens for tier lookup.
-   **`webview-ui/src/components/settings/ApiOptions.tsx`**:
    -   Updated `ModelInfoView` to display tiered pricing clearly, with each tier on a new indented line.
    -   Refactored rendering logic to use `<span>` and `Fragment` for better layout and spacing control.

### Test Procedure

1.  Select "Google Gemini" as the API Provider in settings.
2.  Choose the `gemini-2.5-pro-preview-03-25` model.
3.  Observe the "Model Info" section below the dropdown.
4.  Verify that the Input and Output prices are displayed with two tiers each:
    *   Input: <= 200k tokens ($1.25/M) and > 200k tokens ($2.50/M)
    *   Output: <= 200k tokens ($10.00/M) and > 200k tokens ($15.00/M) (based on input tokens)
5.  Verify the formatting matches the final screenshot (compact spacing).
6.  (Optional) If possible, trigger API calls with prompts below and above 200k tokens and verify the cost calculation reflects the correct tier pricing in any relevant logs or usage tracking.

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`) (Based on pre-commit hook success)
-   [ ] I have created a changeset using `npm run changeset` (Required for user-facing changes - *Please run this if needed*)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

*Final UI showing tiered pricing for Gemini model in settings.*
<img width="615" alt="image" src="https://github.com/user-attachments/assets/489cd11a-ec6e-4e2c-b079-0a41faad4f3b" />

### Additional Notes

This change generalizes the pricing structure to support future models with tiered costs.