### PR TITLE
Keybinding to quick-add context to Cline chat

### DIFF
--- a/.changeset/many-sloths-fetch.md
+++ b/.changeset/many-sloths-fetch.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": minor
+---
+
+Add cmd+quote default keybinding to add selected context to Cline chat

--- a/.changeset/slimy-falcons-retire.md
+++ b/.changeset/slimy-falcons-retire.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": minor
+---
+
+Auto focus the text field when the user uses the 'add to Cline' command

--- a/package.json
+++ b/package.json
@@ -118,6 +118,16 @@
 				"category": "Cline"
 			}
 		],
+		"keybindings": [
+			{
+				"command": "cline.addToChat",
+				"key": "cmd+'",
+				"mac": "cmd+'",
+				"win": "ctrl+'",
+				"linux": "ctrl+'",
+				"when": "editorHasSelection"
+			}
+		],
 		"menus": {
 			"view/title": [
 				{

--- a/webview-ui/src/components/chat/ChatView.tsx
+++ b/webview-ui/src/components/chat/ChatView.tsx
@@ -457,7 +457,7 @@ const ChatView = ({ isHidden, showAnnouncement, hideAnnouncement, showHistoryVie
 				case "addToInput":
 					setInputValue((prevValue) => {
 						const newText = message.text ?? ""
-						const newTextWithNewline = newText + "\n\n"
+						const newTextWithNewline = newText + "\n"
 						return prevValue ? `${prevValue}\n${newTextWithNewline}` : newTextWithNewline
 					})
 					// Add scroll to bottom after state update

--- a/webview-ui/src/components/chat/ChatView.tsx
+++ b/webview-ui/src/components/chat/ChatView.tsx
@@ -457,12 +457,15 @@ const ChatView = ({ isHidden, showAnnouncement, hideAnnouncement, showHistoryVie
 				case "addToInput":
 					setInputValue((prevValue) => {
 						const newText = message.text ?? ""
-						return prevValue ? `${prevValue}\n${newText}` : newText
+						const newTextWithNewline = newText + "\n\n"
+						return prevValue ? `${prevValue}\n${newTextWithNewline}` : newTextWithNewline
 					})
 					// Add scroll to bottom after state update
+					// Auto focus the input and start the cursor on a new linefor easy typing
 					setTimeout(() => {
 						if (textAreaRef.current) {
 							textAreaRef.current.scrollTop = textAreaRef.current.scrollHeight
+							textAreaRef.current.focus()
 						}
 					}, 0)
 					break


### PR DESCRIPTION
### Description

- Add a command/control + quote keybinding to add selected context to the Cline chat.
- Auto focus the chat area for easy typing

- This keybinding should have low chance of conflicting with existing hotkeys.

- It makes sense intuitively - "command" plus "quote" to quote text



### Test Procedure

Tested that it triggered our existing "add to cline" command.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots



https://github.com/user-attachments/assets/63218cb1-7f7b-407e-a62e-15f73a6aa904





### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add `cmd+'`/`ctrl+'` keybinding to quickly add selected context to Cline chat and auto-focus input field.
> 
>   - **Keybinding**:
>     - Adds `cmd+'` (Mac) and `ctrl+'` (Windows/Linux) keybinding in `package.json` to trigger `cline.addToChat` when text is selected.
>   - **Behavior**:
>     - Modifies `ChatView.tsx` to auto-focus the text field when the 'add to Cline' command is used.
>     - Updates `addToInput` case to append selected text with newlines and focus the input field.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for b6de8ce9aa970c0482f00ed1135ba32f3c0ed8ad. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->