### PR TITLE
ENG-377 Changing Checkpoint UI to take less real space on the chat interface

### DIFF
--- a/webview-ui/src/components/chat/BrowserSessionRow.tsx
+++ b/webview-ui/src/components/chat/BrowserSessionRow.tsx
@@ -275,11 +275,19 @@ const BrowserSessionRow = memo((props: BrowserSessionRowProps) => {
 				consoleLogs: currentPage?.currentState.consoleLogs,
 				screenshot: currentPage?.currentState.screenshot,
 			}
-
+	const [rowIndex, setRowIndex] = useState<number>(0)
+	const [hoveredRowIndex, setHoveredRowIndex] = useState<number | null>(null)
 	const [actionContent, { height: actionHeight }] = useSize(
 		<div>
 			{currentPage?.nextAction?.messages.map((message) => (
-				<BrowserSessionRowContent key={message.ts} {...props} message={message} setMaxActionHeight={setMaxActionHeight} />
+				<BrowserSessionRowContent
+					key={message.ts}
+					{...props}
+					message={message}
+					setMaxActionHeight={setMaxActionHeight}
+					rowIndex={rowIndex}
+					hoveredRowIndex={hoveredRowIndex}
+				/>
 			))}
 			{!isBrowsing && messages.some((m) => m.say === "browser_action_result") && currentPageIndex === 0 && (
 				<BrowserActionBox action={"launch"} text={initialUrl} />
@@ -473,6 +481,8 @@ const BrowserSessionRow = memo((props: BrowserSessionRowProps) => {
 interface BrowserSessionRowContentProps extends Omit<BrowserSessionRowProps, "messages"> {
 	message: ClineMessage
 	setMaxActionHeight: (height: number) => void
+	rowIndex: number
+	hoveredRowIndex: number | null
 }
 
 const BrowserSessionRowContent = ({
@@ -482,6 +492,8 @@ const BrowserSessionRowContent = ({
 	lastModifiedMessage,
 	isLast,
 	setMaxActionHeight,
+	rowIndex,
+	hoveredRowIndex,
 }: BrowserSessionRowContentProps) => {
 	if (message.ask === "browser_action_launch" || message.say === "browser_action_launch") {
 		return (
@@ -504,6 +516,8 @@ const BrowserSessionRowContent = ({
 					return (
 						<div style={chatRowContentContainerStyle}>
 							<ChatRowContent
+								rowIndex={rowIndex}
+								hoveredRowIndex={hoveredRowIndex}
 								message={message}
 								isExpanded={isExpanded(message.ts)}
 								onToggleExpand={() => {

--- a/webview-ui/src/components/chat/ChatRow.tsx
+++ b/webview-ui/src/components/chat/ChatRow.tsx
@@ -987,14 +987,15 @@ export const ChatRowContent = ({
 						</>
 					)
 				case "checkpoint_created":
-					const shouldShow = hoveredRowIndex === rowIndex - 1 || hoveredRowIndex === rowIndex
+					// Determine if the hover is near the checkpoint marker's visual position (either on the preceding row or the checkpoint row itself)
+					const isHoveredNearCheckpoint = hoveredRowIndex === rowIndex - 1 || hoveredRowIndex === rowIndex
 
 					return (
 						<>
 							<CheckmarkControl
 								messageTs={message.ts}
 								isCheckpointCheckedOut={message.isCheckpointCheckedOut}
-								shouldShow={shouldShow}
+								isHoveredNearCheckpoint={isHoveredNearCheckpoint}
 							/>
 						</>
 					)

--- a/webview-ui/src/components/chat/ChatRow.tsx
+++ b/webview-ui/src/components/chat/ChatRow.tsx
@@ -17,6 +17,7 @@ import { COMMAND_OUTPUT_STRING, COMMAND_REQ_APP_STRING } from "@shared/combineCo
 import { useExtensionState } from "@/context/ExtensionStateContext"
 import { findMatchingResourceOrTemplate, getMcpServerDisplayName } from "@/utils/mcp"
 import { vscode } from "@/utils/vscode"
+import { useChatRowStyles } from "@/hooks/useChatRowStyles"
 import { CheckmarkControl } from "@/components/common/CheckmarkControl"
 import { CheckpointControls, CheckpointOverlay } from "../common/CheckpointControls"
 import CodeAccordian, { cleanPathPrefix } from "../common/CodeAccordian"
@@ -94,16 +95,12 @@ const ChatRow = memo(
 		// Store the previous height to compare with the current height
 		// This allows us to detect changes without causing re-renders
 		const prevHeightRef = useRef(0)
-		const isCheckpointMessage = message.say === "checkpoint_created"
-		// Determine if the checkpoint marker *would* be shown based on hover state
-		const isHoverRelevant = hoveredRowIndex === rowIndex - 1 || hoveredRowIndex === rowIndex
+		// Calculate dynamic styles using the custom hook
+		const { padding, minHeight } = useChatRowStyles(message, hoveredRowIndex, rowIndex)
 
 		const [chatrow, { height }] = useSize(
 			<ChatRowContainer
-				style={{
-					padding: isCheckpointMessage && !message.isCheckpointCheckedOut && !isHoverRelevant ? 0 : undefined, // Reset padding if it's a checkpoint message and not hovered
-					minHeight: isCheckpointMessage && !message.isCheckpointCheckedOut && !isHoverRelevant ? 1 : undefined, // Ensure min height of 1px to prevent virtuoso error
-				}}
+				style={{ padding, minHeight }}
 				onMouseEnter={() => setHoveredRowIndex(rowIndex)}
 				onMouseLeave={() => setHoveredRowIndex(null)}>
 				<ChatRowContent {...props} rowIndex={rowIndex} hoveredRowIndex={hoveredRowIndex} />

--- a/webview-ui/src/components/chat/ChatView.tsx
+++ b/webview-ui/src/components/chat/ChatView.tsx
@@ -77,6 +77,7 @@ const ChatView = ({ isHidden, showAnnouncement, hideAnnouncement, showHistoryVie
 	const disableAutoScrollRef = useRef(false)
 	const [showScrollToBottom, setShowScrollToBottom] = useState(false)
 	const [isAtBottom, setIsAtBottom] = useState(false)
+	const [hoveredRowIndex, setHoveredRowIndex] = useState<number | null>(null)
 
 	// UI layout depends on the last 2 messages
 	// (since it relies on the content of these messages, we are deep comparing. i.e. the button state after hitting button sets enableButtons to false, and this effect otherwise would have to true again even if messages didn't change
@@ -763,10 +764,21 @@ const ChatView = ({ isHidden, showAnnouncement, hideAnnouncement, showHistoryVie
 					lastModifiedMessage={modifiedMessages.at(-1)}
 					isLast={index === groupedMessages.length - 1}
 					onHeightChange={handleRowHeightChange}
+					rowIndex={index}
+					hoveredRowIndex={hoveredRowIndex}
+					setHoveredRowIndex={setHoveredRowIndex}
 				/>
 			)
 		},
-		[expandedRows, modifiedMessages, groupedMessages.length, toggleRowExpansion, handleRowHeightChange],
+		[
+			expandedRows,
+			modifiedMessages,
+			groupedMessages.length,
+			toggleRowExpansion,
+			handleRowHeightChange,
+			hoveredRowIndex,
+			setHoveredRowIndex,
+		],
 	)
 
 	return (

--- a/webview-ui/src/components/common/CheckmarkControl.tsx
+++ b/webview-ui/src/components/common/CheckmarkControl.tsx
@@ -11,10 +11,11 @@ import { useFloating, offset, flip, shift } from "@floating-ui/react"
 interface CheckmarkControlProps {
 	messageTs?: number
 	isCheckpointCheckedOut?: boolean
-	shouldShow: boolean
+	/** Determines if the hover is near the checkpoint marker's visual position (either on the preceding row or the checkpoint row itself) */
+	isHoveredNearCheckpoint: boolean
 }
 
-export const CheckmarkControl = ({ messageTs, isCheckpointCheckedOut, shouldShow }: CheckmarkControlProps) => {
+export const CheckmarkControl = ({ messageTs, isCheckpointCheckedOut, isHoveredNearCheckpoint }: CheckmarkControlProps) => {
 	const [compareDisabled, setCompareDisabled] = useState(false)
 	const [restoreTaskDisabled, setRestoreTaskDisabled] = useState(false)
 	const [restoreWorkspaceDisabled, setRestoreWorkspaceDisabled] = useState(false)
@@ -120,7 +121,10 @@ export const CheckmarkControl = ({ messageTs, isCheckpointCheckedOut, shouldShow
 
 	useEvent("message", handleMessage)
 
-	if (!shouldShow && !isCheckpointCheckedOut) {
+	// Hide the control if the checkpoint is not the currently restored one AND the user is not hovering near it.
+	// This keeps the UI clean but ensures the controls appear on hover for interaction.
+	const shouldHideCheckpoint = !isCheckpointCheckedOut && !isHoveredNearCheckpoint
+	if (shouldHideCheckpoint) {
 		return null
 	}
 

--- a/webview-ui/src/components/common/CheckmarkControl.tsx
+++ b/webview-ui/src/components/common/CheckmarkControl.tsx
@@ -121,8 +121,8 @@ export const CheckmarkControl = ({ messageTs, isCheckpointCheckedOut, isHoveredN
 
 	useEvent("message", handleMessage)
 
-	// Hide the control if the checkpoint is not the currently restored one AND the user is not hovering near it.
-	// This keeps the UI clean but ensures the controls appear on hover for interaction.
+	// Hide checkpoint if it is not the currently restored one AND the user is not hovering near it.
+	// This keeps the UI clean but ensures the checkpoint appear on hover for interaction.
 	const shouldHideCheckpoint = !isCheckpointCheckedOut && !isHoveredNearCheckpoint
 	if (shouldHideCheckpoint) {
 		return null

--- a/webview-ui/src/components/common/CheckmarkControl.tsx
+++ b/webview-ui/src/components/common/CheckmarkControl.tsx
@@ -11,9 +11,10 @@ import { useFloating, offset, flip, shift } from "@floating-ui/react"
 interface CheckmarkControlProps {
 	messageTs?: number
 	isCheckpointCheckedOut?: boolean
+	shouldShow: boolean
 }
 
-export const CheckmarkControl = ({ messageTs, isCheckpointCheckedOut }: CheckmarkControlProps) => {
+export const CheckmarkControl = ({ messageTs, isCheckpointCheckedOut, shouldShow }: CheckmarkControlProps) => {
 	const [compareDisabled, setCompareDisabled] = useState(false)
 	const [restoreTaskDisabled, setRestoreTaskDisabled] = useState(false)
 	const [restoreWorkspaceDisabled, setRestoreWorkspaceDisabled] = useState(false)
@@ -118,6 +119,10 @@ export const CheckmarkControl = ({ messageTs, isCheckpointCheckedOut }: Checkmar
 	}
 
 	useEvent("message", handleMessage)
+
+	if (!shouldShow && !isCheckpointCheckedOut) {
+		return null
+	}
 
 	return (
 		<Container isMenuOpen={showRestoreConfirm} $isCheckedOut={isCheckpointCheckedOut} onMouseLeave={handleControlsMouseLeave}>

--- a/webview-ui/src/hooks/useChatRowStyles.ts
+++ b/webview-ui/src/hooks/useChatRowStyles.ts
@@ -1,0 +1,40 @@
+import { useMemo } from "react"
+import { ClineMessage } from "@shared/ExtensionMessage"
+
+/**
+ * Custom hook to determine the dynamic styles for a ChatRowContainer.
+ *
+ * This hook calculates the padding and minimum height for a chat row based on
+ * whether it represents a checkpoint message and its current hover state.
+ * The goal is to visually collapse checkpoint markers when they are not checked out
+ * and not being hovered over, while ensuring they remain interactable.
+ *
+ * @param message - The chat message object for the current row.
+ * @param hoveredRowIndex - The index of the currently hovered row, or null if none.
+ * @param rowIndex - The index of the current row being rendered.
+ * @returns An object containing the calculated style properties (padding and minHeight).
+ */
+export const useChatRowStyles = (
+	message: ClineMessage,
+	hoveredRowIndex: number | null,
+	rowIndex: number,
+): { padding: number | undefined; minHeight: number | undefined } => {
+	return useMemo(() => {
+		// Check if the current message is a checkpoint creation message.
+		const isCheckpointMessage = message.say === "checkpoint_created"
+
+		// Determine if the hover state is relevant to this row or the one immediately preceding it.
+		// This is because the checkpoint marker is visually associated with the row *before* the checkpoint message,
+		// but its visibility is controlled by the hover state of *both* the preceding row and the checkpoint message row itself.
+		const isHoverRelevant = hoveredRowIndex === rowIndex - 1 || hoveredRowIndex === rowIndex
+
+		// Calculate styles based on checkpoint status and hover relevance.
+		// If it's a checkpoint message, not currently checked out, and not relevantly hovered,
+		// reset padding to 0 and set minHeight to 1px to visually collapse it.
+		// Otherwise, use default styles (undefined, letting CSS handle it).
+		const padding = isCheckpointMessage && !message.isCheckpointCheckedOut && !isHoverRelevant ? 0 : undefined
+		const minHeight = isCheckpointMessage && !message.isCheckpointCheckedOut && !isHoverRelevant ? 1 : undefined
+
+		return { padding, minHeight }
+	}, [message.say, message.isCheckpointCheckedOut, hoveredRowIndex, rowIndex])
+}


### PR DESCRIPTION
### Description

[Linear Issue 
](https://linear.app/cline-bot/issue/ENG-377/revert-new-checkpoint-ui-to-older-checkpoint-ui)
<!-- Describe your changes in detail. What problem does this PR solve? -->

Related[ Linear Issue ](https://linear.app/cline-bot/issue/ENG-416/add-editing-ability-to-older-user-messages-in-chat)
This PR makes the Checkpoint UI invisible


### Test Procedure
- Tested locally using the local build 

#### Photos
- When Hovering 
<img width="374" alt="image" src="https://github.com/user-attachments/assets/1d7196d8-3607-4915-9a76-654772c677a2" />

- When not hovering 
<img width="382" alt="image" src="https://github.com/user-attachments/assets/50409e48-a366-49b6-9e09-4582aeb840fb" />



### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [X] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [X] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [X] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [X] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [X] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> UI update to collapse checkpoint markers in chat rows unless hovered or checked out, using a new `useChatRowStyles` hook for dynamic styling.
> 
>   - **Behavior**:
>     - Checkpoint markers in `ChatRow` and `BrowserSessionRow` now collapse when not hovered or checked out.
>     - Hovering over a row or its preceding row reveals the checkpoint marker.
>   - **Components**:
>     - `CheckmarkControl` updated to hide markers unless hovered or checked out.
>     - `ChatRow` and `BrowserSessionRow` updated to use `useChatRowStyles` for dynamic styling.
>   - **Hooks**:
>     - New `useChatRowStyles` hook calculates padding and minHeight for checkpoint messages based on hover state.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 98e3544b8293aa87e36615d00589a8f43fadfafb. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->