### PR TITLE
fixed new task test

### DIFF
--- a/src/test/new-task-tool.test.ts
+++ b/src/test/new-task-tool.test.ts
@@ -1,19 +1,20 @@
 import * as assert from "assert"
+import { describe, it } from "mocha"
 import { ClineMessage } from "../shared/ExtensionMessage"
 import { formatResponse } from "../core/prompts/responses"
 
-suite("New Task Tool Tests", () => {
-	test("formatResponse.newTaskContext formats context correctly", () => {
+describe("New Task Tool Tests", () => {
+	it("formatResponse.newTaskContext formats context correctly", () => {
 		const context = "This is a test context for a new task"
 		const result = formatResponse.newTaskContext(context)
 
 		assert.strictEqual(
 			result,
-			`Cline wants to create a new task with the following context:\n\nThis is a test context for a new task\n\nClick "Create New Task" to start a new task with this context preloaded in Plan Mode.`,
+			`Cline wants to start a new task with the following context:\n\nThis is a test context for a new task\n\nClick "Start New Task" to start a new task with this context preloaded.`,
 		)
 	})
 
-	test("ClineAskNewTask interface exists", () => {
+	it("ClineAskNewTask interface exists", () => {
 		// This is a type check test, it will fail at compile time if the interface doesn't exist
 		const message: ClineMessage = {
 			ts: Date.now(),


### PR DESCRIPTION
### Description

fixing new task test
### Test Procedure

<!-- How did you test this? Are you confident that it will not introduce bugs? If so, why? -->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes test structure and updates assertions in `new-task-tool.test.ts` for Mocha compatibility and correct message format.
> 
>   - **Test Structure**:
>     - Replaces `suite` with `describe` and `test` with `it` in `new-task-tool.test.ts` for Mocha compatibility.
>   - **Assertions**:
>     - Updates expected string in `formatResponse.newTaskContext` test to match new task initiation message format.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for b5b04233c42fec198419ad6582ad074a7b395c08. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->