### PR TITLE
Formatting read file tool

### DIFF
--- a/.changeset/yellow-bikes-yell.md
+++ b/.changeset/yellow-bikes-yell.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": minor
+---
+
+formatted read files tool


### PR DESCRIPTION
### Description

Properly maintains XML structure for read file tool, including file read errors.

#### Example 1: Reading a file with content

Scenario: Reading src/utils/string.ts containing export const capitalize = (s: string) => s.charAt(0).toUpperCase() + s.slice(1);

Expected XML Output:

```
<file><path>src/utils/string.ts</path><content>
export const capitalize = (s: string) => s.charAt(0).toUpperCase() + s.slice(1);
</content></file>

```
Note: Demonstrates the standard format with content wrapped in <content> tags, including the leading/trailing newlines.

#### Example 2: Reading an empty file

Scenario: Reading docs/empty-example.md which is an empty file.
Expected XML Output:

```
<file><path>docs/empty-example.md</path><content/><notice>File is empty</notice></file>
```

Note: Shows the self-closing <content/> tag and the specific <notice> for empty files.

#### Example 3: Error reading a non-existent file

Scenario: Attempting to read src/nonexistent-component.tsx.
Expected XML Output:

```
<file><path>src/nonexistent-component.tsx</path><error>File not found: /Users/pash/Documents/Melden/cline/src/nonexistent-component.tsx</error></file>
```

Note: Illustrates the error format, omitting the <content> tag and including the specific error message within <error> tags. The exact path in the error message will depend on the user's system.

#### Example 4: Error reading a file that's too large (based on current extractTextFromFile limit)

Scenario: Attempting to read assets/large-log-file.log which exceeds the size limit (e.g., > 300KB).
Expected XML Output:

```
<file><path>assets/large-log-file.log</path><error>File is too large to read: assets/large-log-file.log</error></file>
```

Note: Shows another error case handled by the <error> tag.


### Test Procedure

<!-- How did you test this? Are you confident that it will not introduce bugs? If so, why? -->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Enhances `read_file` tool in `Task` class to format results and errors as XML, ensuring consistent structure for file content and error messages.
> 
>   - **Behavior**:
>     - Enhances `read_file` tool in `Task` class to format results as XML, including handling empty files and errors.
>     - On successful read, wraps content in `<file><path>...</path><content>...</content></file>`.
>     - On error, wraps error message in `<file><path>...</path><error>...</error></file>`.
>   - **Error Handling**:
>     - Catches file read errors and formats them as XML, ensuring `relPath` is always included.
>     - Logs error messages to UI using `say()` method.
>   - **Misc**:
>     - Adds a changeset file `yellow-bikes-yell.md` to document the feature addition.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 4443f3e9331930215225015b98db525246ac84e5. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->