### PR TITLE
Cline Task Server

### DIFF
--- a/.changeset/green-moose-walk.md
+++ b/.changeset/green-moose-walk.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": minor
+---
+
+added cline server to take requests to make new tasks

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -406,9 +406,6 @@ export function activate(context: vscode.ExtensionContext) {
 // since vscode doesn't support hot reload for extensions
 const { IS_DEV, DEV_WORKSPACE_FOLDER, IS_TEST } = process.env
 
-// Reference to the test server
-let testServer: ReturnType<typeof createTestServer> | undefined
-
 // This method is called when your extension is deactivated
 export function deactivate() {
 	// Shutdown the test server if it exists
@@ -432,6 +429,5 @@ if (IS_DEV && IS_DEV !== "false") {
 
 // Set up test server if in test mode
 if (IS_TEST && IS_TEST === "true") {
-	// Create and start the test server
-	testServer = createTestServer()
+	createTestServer()
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -9,7 +9,7 @@ import { DIFF_VIEW_URI_SCHEME } from "./integrations/editor/DiffViewProvider"
 import assert from "node:assert"
 import { telemetryService } from "./services/telemetry/TelemetryService"
 import { WebviewProvider } from "./core/webview"
-import * as http from "http"
+import { createTestServer, shutdownTestServer } from "./services/test/TestServer"
 
 /*
 Built using https://github.com/microsoft/vscode-webview-ui-toolkit
@@ -406,16 +406,13 @@ export function activate(context: vscode.ExtensionContext) {
 // since vscode doesn't support hot reload for extensions
 const { IS_DEV, DEV_WORKSPACE_FOLDER, IS_TEST } = process.env
 
-// Create an HTTP server for test automation when in test mode
-let testServer: http.Server | undefined
+// Reference to the test server
+let testServer: ReturnType<typeof createTestServer> | undefined
 
 // This method is called when your extension is deactivated
 export function deactivate() {
 	// Shutdown the test server if it exists
-	if (testServer) {
-		testServer.close()
-		Logger.log("Test server shut down")
-	}
+	shutdownTestServer()
 
 	telemetryService.shutdown()
 	Logger.log("Cline extension deactivated")
@@ -435,84 +432,6 @@ if (IS_DEV && IS_DEV !== "false") {
 
 // Set up test server if in test mode
 if (IS_TEST && IS_TEST === "true") {
-	const PORT = 9876
-
-	testServer = http.createServer((req, res) => {
-		// Set CORS headers
-		res.setHeader("Access-Control-Allow-Origin", "*")
-		res.setHeader("Access-Control-Allow-Methods", "POST, OPTIONS")
-		res.setHeader("Access-Control-Allow-Headers", "Content-Type")
-
-		// Handle preflight requests
-		if (req.method === "OPTIONS") {
-			res.writeHead(204)
-			res.end()
-			return
-		}
-
-		// Only handle POST requests to /task
-		if (req.method !== "POST" || req.url !== "/task") {
-			res.writeHead(404)
-			res.end(JSON.stringify({ error: "Not found" }))
-			return
-		}
-
-		// Parse the request body
-		let body = ""
-		req.on("data", (chunk) => {
-			body += chunk.toString()
-		})
-
-		req.on("end", async () => {
-			try {
-				// Parse the JSON body
-				const { task } = JSON.parse(body)
-
-				if (!task) {
-					res.writeHead(400)
-					res.end(JSON.stringify({ error: "Missing task parameter" }))
-					return
-				}
-
-				// Get a visible webview instance
-				const visibleWebview = WebviewProvider.getVisibleInstance()
-				if (!visibleWebview || !visibleWebview.controller) {
-					res.writeHead(500)
-					res.end(JSON.stringify({ error: "No active Cline instance found" }))
-					return
-				}
-
-				// Initiate a new task
-				Logger.log(`Test server initiating task: ${task}`)
-
-				try {
-					// Clear any existing task
-					await visibleWebview.controller.clearTask()
-
-					// Initiate the new task
-					const taskId = await visibleWebview.controller.initClineWithTask(task)
-
-					// Return success response with the task ID
-					res.writeHead(200, { "Content-Type": "application/json" })
-					res.end(JSON.stringify({ success: true, taskId }))
-				} catch (error) {
-					Logger.log(`Error initiating task: ${error}`)
-					res.writeHead(500)
-					res.end(JSON.stringify({ error: `Failed to initiate task: ${error}` }))
-				}
-			} catch (error) {
-				res.writeHead(400)
-				res.end(JSON.stringify({ error: `Invalid JSON: ${error}` }))
-			}
-		})
-	})
-
-	testServer.listen(PORT, () => {
-		Logger.log(`Test server listening on port ${PORT}`)
-	})
-
-	// Handle server errors
-	testServer.on("error", (error) => {
-		Logger.log(`Test server error: ${error}`)
-	})
+	// Create and start the test server
+	testServer = createTestServer()
 }

--- a/src/services/test/TestServer.ts
+++ b/src/services/test/TestServer.ts
@@ -1,0 +1,105 @@
+import * as http from "http"
+import { Logger } from "../../services/logging/Logger"
+import { WebviewProvider } from "../../core/webview"
+
+let testServer: http.Server | undefined
+
+/**
+ * Creates and starts an HTTP server for test automation
+ * @returns The created HTTP server instance
+ */
+export function createTestServer(): http.Server {
+	const PORT = 9876
+
+	testServer = http.createServer((req, res) => {
+		// Set CORS headers
+		res.setHeader("Access-Control-Allow-Origin", "*")
+		res.setHeader("Access-Control-Allow-Methods", "POST, OPTIONS")
+		res.setHeader("Access-Control-Allow-Headers", "Content-Type")
+
+		// Handle preflight requests
+		if (req.method === "OPTIONS") {
+			res.writeHead(204)
+			res.end()
+			return
+		}
+
+		// Only handle POST requests to /task
+		if (req.method !== "POST" || req.url !== "/task") {
+			res.writeHead(404)
+			res.end(JSON.stringify({ error: "Not found" }))
+			return
+		}
+
+		// Parse the request body
+		let body = ""
+		req.on("data", (chunk) => {
+			body += chunk.toString()
+		})
+
+		req.on("end", async () => {
+			try {
+				// Parse the JSON body
+				const { task } = JSON.parse(body)
+
+				if (!task) {
+					res.writeHead(400)
+					res.end(JSON.stringify({ error: "Missing task parameter" }))
+					return
+				}
+
+				// Get a visible webview instance
+				const visibleWebview = WebviewProvider.getVisibleInstance()
+				if (!visibleWebview || !visibleWebview.controller) {
+					res.writeHead(500)
+					res.end(JSON.stringify({ error: "No active Cline instance found" }))
+					return
+				}
+
+				// Initiate a new task
+				Logger.log(`Test server initiating task: ${task}`)
+
+				try {
+					// Clear any existing task
+					await visibleWebview.controller.clearTask()
+
+					// Initiate the new task
+					const taskId = await visibleWebview.controller.initClineWithTask(task)
+
+					// Return success response with the task ID
+					res.writeHead(200, { "Content-Type": "application/json" })
+					res.end(JSON.stringify({ success: true, taskId }))
+				} catch (error) {
+					Logger.log(`Error initiating task: ${error}`)
+					res.writeHead(500)
+					res.end(JSON.stringify({ error: `Failed to initiate task: ${error}` }))
+				}
+			} catch (error) {
+				res.writeHead(400)
+				res.end(JSON.stringify({ error: `Invalid JSON: ${error}` }))
+			}
+		})
+	})
+
+	testServer.listen(PORT, () => {
+		Logger.log(`Test server listening on port ${PORT}`)
+	})
+
+	// Handle server errors
+	testServer.on("error", (error) => {
+		Logger.log(`Test server error: ${error}`)
+	})
+
+	return testServer
+}
+
+/**
+ * Shuts down the test server if it exists
+ */
+export function shutdownTestServer() {
+	if (testServer) {
+		testServer.close()
+		Logger.log("Test server shut down")
+		testServer = undefined
+	}
+}

--- a/src/services/test/TestServer.ts
+++ b/src/services/test/TestServer.ts
@@ -63,6 +63,13 @@ export function createTestServer(): http.Server {
 					// Clear any existing task
 					await visibleWebview.controller.clearTask()
 
+					// Ensure we're in Act mode before initiating the task
+					const { chatSettings } = await visibleWebview.controller.getStateToPostToWebview()
+					if (chatSettings.mode === "plan") {
+						// Switch to Act mode if currently in Plan mode
+						await visibleWebview.controller.togglePlanActModeWithChatSettings({ mode: "act" })
+					}
+
 					// Initiate the new task
 					const taskId = await visibleWebview.controller.initClineWithTask(task)
 


### PR DESCRIPTION
### Description

Adds a new server endpoint in IS_TEST mode that can create a new task in a remote way

### Test Procedure

1. Run in test mode:

<img width="612" alt="Screenshot 2025-04-09 at 3 35 16 PM" src="https://github.com/user-attachments/assets/365a5a20-b886-4a77-a209-2d7900e639e6" />

2. Open a terminal and run this:

```
curl -X POST http://localhost:9876/task \
  -H "Content-Type: application/json" \
  -d '{"task": "Create a simple React component"}'
```

3. Verify that a new task was started in your extension development host window

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds a test server in `TestServer.ts` for remote task creation in test mode, integrated with `extension.ts`.
> 
>   - **New Feature**:
>     - Adds `createTestServer()` and `shutdownTestServer()` in `TestServer.ts` to handle HTTP requests for task creation in test mode.
>     - Server listens on port 9876 and handles POST requests to `/task`.
>     - Validates JSON body and task parameter, initiates tasks via `WebviewProvider`.
>   - **Integration**:
>     - Modifies `extension.ts` to start the test server in IS_TEST mode and shut it down on deactivation.
>     - Ensures server is only active in test mode, using environment variable `IS_TEST`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for a09a42d00a8476a167411ad0dba61afa7394e1b1. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->