### PR TITLE
Update sentry in extension to add traceability and version 

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -9,7 +9,6 @@ import { DIFF_VIEW_URI_SCHEME } from "./integrations/editor/DiffViewProvider"
 import assert from "node:assert"
 import { telemetryService } from "./services/telemetry/TelemetryService"
 import { WebviewProvider } from "./core/webview"
-import * as Sentry from "@sentry/browser"
 
 /*
 Built using https://github.com/microsoft/vscode-webview-ui-toolkit
@@ -27,11 +26,6 @@ let outputChannel: vscode.OutputChannel
 export function activate(context: vscode.ExtensionContext) {
 	outputChannel = vscode.window.createOutputChannel("Cline")
 	context.subscriptions.push(outputChannel)
-
-	// Initialize sentry
-	Sentry.init({
-		dsn: "https://7936780e3f0f0290fcf8d4a395c249b7@o4509028819664896.ingest.us.sentry.io/4509052955983872",
-	})
 
 	Logger.initialize(outputChannel)
 	Logger.log("Cline extension activated")

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -9,6 +9,7 @@ import { DIFF_VIEW_URI_SCHEME } from "./integrations/editor/DiffViewProvider"
 import assert from "node:assert"
 import { telemetryService } from "./services/telemetry/TelemetryService"
 import { WebviewProvider } from "./core/webview"
+import * as Sentry from "@sentry/browser"
 
 /*
 Built using https://github.com/microsoft/vscode-webview-ui-toolkit
@@ -26,6 +27,11 @@ let outputChannel: vscode.OutputChannel
 export function activate(context: vscode.ExtensionContext) {
 	outputChannel = vscode.window.createOutputChannel("Cline")
 	context.subscriptions.push(outputChannel)
+
+	// Initialize sentry
+	Sentry.init({
+		dsn: "https://7936780e3f0f0290fcf8d4a395c249b7@o4509028819664896.ingest.us.sentry.io/4509052955983872",
+	})
 
 	Logger.initialize(outputChannel)
 	Logger.log("Cline extension activated")

--- a/src/services/error/ErrorService.ts
+++ b/src/services/error/ErrorService.ts
@@ -1,8 +1,12 @@
 import * as Sentry from "@sentry/browser"
+import * as pkg from "../../../package.json"
 
 // Initialize sentry
 Sentry.init({
 	dsn: "https://7936780e3f0f0290fcf8d4a395c249b7@o4509028819664896.ingest.us.sentry.io/4509052955983872",
+	environment: process.env.NODE_ENV,
+	release: `cline@${pkg.version}`,
+	integrations: [Sentry.browserTracingIntegration(), Sentry.replayIntegration()],
 })
 
 export class ErrorService {


### PR DESCRIPTION
### Description

Add Release number and traceability to Sentry

### Test Procedure

Manually update `extension.ts` to throw an error and check that version and traceability is enabled in sentry for the new messages.

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [X] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [X] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [X] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [X] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [X] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<img width="558" alt="image" src="https://github.com/user-attachments/assets/d7cc9197-c58e-4260-aec2-4aeff5c6b0b7" />

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add Sentry release and environment configuration to `ErrorService.ts` for enhanced error tracking.
> 
>   - **Sentry Configuration**:
>     - Adds `release` and `environment` to Sentry initialization in `ErrorService.ts`.
>     - Uses `pkg.version` for release version and `process.env.NODE_ENV` for environment.
>     - Integrates `Sentry.browserTracingIntegration()` and `Sentry.replayIntegration()` for enhanced tracing.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 07fb8284512d78170850f73c41c8f0e8752159da. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->