### PR TITLE
Error Service Respects Telemetry

### DIFF
--- a/.changeset/wet-avocados-kiss.md
+++ b/.changeset/wet-avocados-kiss.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Error Service Respects Telemetry

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -10,6 +10,7 @@ import assert from "node:assert"
 import { telemetryService } from "./services/telemetry/TelemetryService"
 import { WebviewProvider } from "./core/webview"
 import { createTestServer, shutdownTestServer } from "./services/test/TestServer"
+import { ErrorService } from "./services/error/ErrorService"
 
 /*
 Built using https://github.com/microsoft/vscode-webview-ui-toolkit
@@ -28,6 +29,7 @@ export function activate(context: vscode.ExtensionContext) {
 	outputChannel = vscode.window.createOutputChannel("Cline")
 	context.subscriptions.push(outputChannel)
 
+	ErrorService.initialize()
 	Logger.initialize(outputChannel)
 	Logger.log("Cline extension activated")
 

--- a/src/services/error/ErrorService.ts
+++ b/src/services/error/ErrorService.ts
@@ -1,12 +1,12 @@
 import * as Sentry from "@sentry/browser"
 import * as vscode from "vscode"
+import { telemetryService } from "../telemetry/TelemetryService"
 import * as pkg from "../../../package.json"
 
 let telemetryLevel = vscode.workspace.getConfiguration("telemetry").get<string>("telemetryLevel", "all")
 let isTelemetryEnabled = ["all", "error", "crash"].includes(telemetryLevel)
 
 vscode.workspace.onDidChangeConfiguration(() => {
-	console.log("Config Changed")
 	telemetryLevel = vscode.workspace.getConfiguration("telemetry").get<string>("telemetryLevel", "all")
 	isTelemetryEnabled = ["all", "error"].includes(telemetryLevel)
 	ErrorService.toggleEnabled(isTelemetryEnabled)
@@ -27,7 +27,7 @@ export class ErrorService {
 			release: `cline@${pkg.version}`,
 			integrations: [Sentry.browserTracingIntegration(), Sentry.replayIntegration()],
 			beforeSend(event) {
-				if (ErrorService.isEnabled()) {
+				if (ErrorService.isEnabled() && telemetryService.isTelemetryEnabled()) {
 					return event
 				}
 				return null

--- a/src/services/error/ErrorService.ts
+++ b/src/services/error/ErrorService.ts
@@ -4,7 +4,7 @@ import { telemetryService } from "../telemetry/TelemetryService"
 import * as pkg from "../../../package.json"
 
 let telemetryLevel = vscode.workspace.getConfiguration("telemetry").get<string>("telemetryLevel", "all")
-let isTelemetryEnabled = ["all", "error", "crash"].includes(telemetryLevel)
+let isTelemetryEnabled = ["all", "error"].includes(telemetryLevel)
 
 vscode.workspace.onDidChangeConfiguration(() => {
 	telemetryLevel = vscode.workspace.getConfiguration("telemetry").get<string>("telemetryLevel", "all")

--- a/src/services/error/ErrorService.ts
+++ b/src/services/error/ErrorService.ts
@@ -83,7 +83,6 @@ export class ErrorService {
 		}
 		// Log the message if allowed
 		Sentry.captureMessage(message, { level })
-		return
 	}
 
 	static isEnabled(): boolean {

--- a/src/services/error/ErrorService.ts
+++ b/src/services/error/ErrorService.ts
@@ -83,6 +83,7 @@ export class ErrorService {
 		}
 		// Log the message if allowed
 		Sentry.captureMessage(message, { level })
+		return
 	}
 
 	static isEnabled(): boolean {

--- a/src/services/error/ErrorService.ts
+++ b/src/services/error/ErrorService.ts
@@ -27,7 +27,9 @@ export class ErrorService {
 			release: `cline@${pkg.version}`,
 			integrations: [Sentry.browserTracingIntegration(), Sentry.replayIntegration()],
 			beforeSend(event) {
-				if (ErrorService.isEnabled() && telemetryService.isTelemetryEnabled()) {
+				// TelemetryService keeps track of whether the user has opted in to telemetry/error reporting
+				const isUserManuallyOptedIn = telemetryService.isTelemetryEnabled()
+				if (isUserManuallyOptedIn && ErrorService.isEnabled()) {
 					return event
 				}
 				return null

--- a/src/services/error/ErrorService.ts
+++ b/src/services/error/ErrorService.ts
@@ -1,22 +1,91 @@
 import * as Sentry from "@sentry/browser"
+import * as vscode from "vscode"
 import * as pkg from "../../../package.json"
 
-// Initialize sentry
-Sentry.init({
-	dsn: "https://7936780e3f0f0290fcf8d4a395c249b7@o4509028819664896.ingest.us.sentry.io/4509052955983872",
-	environment: process.env.NODE_ENV,
-	release: `cline@${pkg.version}`,
-	integrations: [Sentry.browserTracingIntegration(), Sentry.replayIntegration()],
+let telemetryLevel = vscode.workspace.getConfiguration("telemetry").get<string>("telemetryLevel", "all")
+let isTelemetryEnabled = ["all", "error", "crash"].includes(telemetryLevel)
+
+vscode.workspace.onDidChangeConfiguration(() => {
+	console.log("Config Changed")
+	telemetryLevel = vscode.workspace.getConfiguration("telemetry").get<string>("telemetryLevel", "all")
+	isTelemetryEnabled = ["all", "error"].includes(telemetryLevel)
+	ErrorService.toggleEnabled(isTelemetryEnabled)
+	if (isTelemetryEnabled) {
+		ErrorService.setLevel(telemetryLevel as "error" | "all")
+	}
 })
 
 export class ErrorService {
+	private static serviceEnabled: boolean
+	private static serviceLevel: string
+
+	static initialize() {
+		// Initialize sentry
+		Sentry.init({
+			dsn: "https://7936780e3f0f0290fcf8d4a395c249b7@o4509028819664896.ingest.us.sentry.io/4509052955983872",
+			environment: process.env.NODE_ENV,
+			release: `cline@${pkg.version}`,
+			integrations: [Sentry.browserTracingIntegration(), Sentry.replayIntegration()],
+			beforeSend(event) {
+				if (ErrorService.isEnabled()) {
+					return event
+				}
+				return null
+			},
+		})
+
+		ErrorService.toggleEnabled(true)
+		ErrorService.setLevel("error")
+	}
+
+	static toggleEnabled(state: boolean) {
+		if (state === false) {
+			ErrorService.serviceEnabled = false
+			return
+		}
+		// If we are trying to enable the service, check that we are allowed to.
+		if (isTelemetryEnabled) {
+			ErrorService.serviceEnabled = true
+		}
+	}
+
+	static setLevel(level: "error" | "all") {
+		switch (telemetryLevel) {
+			case "error": {
+				if (level === "error") {
+					ErrorService.serviceLevel = level
+				}
+				break
+			}
+			default: {
+				ErrorService.serviceLevel = level
+			}
+		}
+	}
+
 	static logException(error: Error): void {
+		// Don't log if telemetry is off
+		if (ErrorService.serviceLevel === "off") {
+			return
+		}
 		// Log the error to Sentry
 		Sentry.captureException(error)
 	}
 
 	static logMessage(message: string, level: "error" | "warning" | "log" | "debug" | "info" = "log"): void {
-		// Log a message to Sentry
+		// Don't log if telemetry is off
+		if (ErrorService.serviceLevel === "off") {
+			return
+		}
+		if (ErrorService.serviceLevel === "error" && level === "error") {
+			// Log the message if allowed
+			Sentry.captureMessage(message, { level })
+		}
+		// Log the message if allowed
 		Sentry.captureMessage(message, { level })
+	}
+
+	static isEnabled(): boolean {
+		return ErrorService.serviceEnabled
 	}
 }

--- a/src/services/error/ErrorService.ts
+++ b/src/services/error/ErrorService.ts
@@ -80,6 +80,7 @@ export class ErrorService {
 		if (ErrorService.serviceLevel === "error" && level === "error") {
 			// Log the message if allowed
 			Sentry.captureMessage(message, { level })
+			return
 		}
 		// Log the message if allowed
 		Sentry.captureMessage(message, { level })

--- a/src/services/error/ErrorService.ts
+++ b/src/services/error/ErrorService.ts
@@ -65,7 +65,7 @@ export class ErrorService {
 
 	static logException(error: Error): void {
 		// Don't log if telemetry is off
-		if (ErrorService.serviceLevel === "off") {
+		if (ErrorService. serviceEnabled) {
 			return
 		}
 		// Log the error to Sentry

--- a/src/services/error/ErrorService.ts
+++ b/src/services/error/ErrorService.ts
@@ -67,7 +67,8 @@ export class ErrorService {
 
 	static logException(error: Error): void {
 		// Don't log if telemetry is off
-		if (!ErrorService.serviceEnabled) {
+		const isUserManuallyOptedIn = telemetryService.isTelemetryEnabled()
+		if (!isUserManuallyOptedIn || !ErrorService.isEnabled()) {
 			return
 		}
 		// Log the error to Sentry
@@ -76,7 +77,8 @@ export class ErrorService {
 
 	static logMessage(message: string, level: "error" | "warning" | "log" | "debug" | "info" = "log"): void {
 		// Don't log if telemetry is off
-		if (!ErrorService.serviceEnabled) {
+		const isUserManuallyOptedIn = telemetryService.isTelemetryEnabled()
+		if (!isUserManuallyOptedIn || !ErrorService.serviceEnabled) {
 			return
 		}
 		if (ErrorService.serviceLevel === "error" && level === "error") {

--- a/src/services/error/ErrorService.ts
+++ b/src/services/error/ErrorService.ts
@@ -65,7 +65,7 @@ export class ErrorService {
 
 	static logException(error: Error): void {
 		// Don't log if telemetry is off
-		if (ErrorService. serviceEnabled) {
+		if (ErrorService.serviceEnabled) {
 			return
 		}
 		// Log the error to Sentry

--- a/src/services/error/ErrorService.ts
+++ b/src/services/error/ErrorService.ts
@@ -65,7 +65,7 @@ export class ErrorService {
 
 	static logException(error: Error): void {
 		// Don't log if telemetry is off
-		if (ErrorService.serviceEnabled) {
+		if (!ErrorService.serviceEnabled) {
 			return
 		}
 		// Log the error to Sentry
@@ -74,7 +74,7 @@ export class ErrorService {
 
 	static logMessage(message: string, level: "error" | "warning" | "log" | "debug" | "info" = "log"): void {
 		// Don't log if telemetry is off
-		if (ErrorService.serviceLevel === "off") {
+		if (!ErrorService.serviceEnabled) {
 			return
 		}
 		if (ErrorService.serviceLevel === "error" && level === "error") {


### PR DESCRIPTION
### Description

Refactor Error service so that it respects the users Telemetry settings in VSCode and Cline.

### Test Procedure

Manually add exception to `extension.ts`
Toggle through the telemetry settings in VSCode
Toggle telemetry on/off in Cline
Validate that Sentry only gets logs for Error or All settings in VSCode AND telemetry is on in Cline

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [X] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [X] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [X] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [X] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [X] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [X] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> `ErrorService` now respects telemetry settings, conditionally logging to Sentry based on user preferences in VSCode and Cline.
> 
>   - **Behavior**:
>     - `ErrorService` now respects telemetry settings in VSCode and Cline, only logging to Sentry if telemetry is enabled.
>     - `ErrorService.initialize()` in `ErrorService.ts` sets up Sentry with a `beforeSend` hook to check telemetry settings.
>     - Updates in `ErrorService.ts` to dynamically adjust logging based on telemetry configuration changes.
>   - **Functions**:
>     - Adds `ErrorService.toggleEnabled()` and `ErrorService.setLevel()` to manage service state and logging level.
>     - Modifies `ErrorService.logException()` and `ErrorService.logMessage()` to conditionally log based on telemetry settings.
>   - **Misc**:
>     - `extension.ts` updated to call `ErrorService.initialize()` during activation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for a4bfe3396e87da0637d44a02f70abfcc708f596f. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->