### PR TITLE
ENG-319/Add indicators when tools operate outside of workspace

### DIFF
--- a/src/core/task/index.ts
+++ b/src/core/task/index.ts
@@ -2282,7 +2282,7 @@ export class Task {
 						try {
 							if (block.partial) {
 								if (action === "launch") {
-									if (this.ShouldAutoApproveTool(block.name)) {
+									if (this.shouldAutoApproveTool(block.name)) {
 										this.removeLastPartialMessageIfExistsWithType("ask", "browser_action_launch")
 										await this.say(
 											"browser_action_launch",
@@ -2323,7 +2323,7 @@ export class Task {
 									}
 									this.consecutiveMistakeCount = 0
 
-									if (this.ShouldAutoApproveTool(block.name)) {
+									if (this.shouldAutoApproveTool(block.name)) {
 										this.removeLastPartialMessageIfExistsWithType("ask", "browser_action_launch")
 										await this.say("browser_action_launch", url, undefined, false)
 										this.consecutiveAutoApprovedRequestsCount++
@@ -2446,7 +2446,7 @@ export class Task {
 
 						try {
 							if (block.partial) {
-								if (this.ShouldAutoApproveTool(block.name)) {
+								if (this.shouldAutoApproveTool(block.name)) {
 									// since depending on an upcoming parameter, requiresApproval this may become an ask - we cant partially stream a say prematurely. So in this particular case we have to wait for the requiresApproval parameter to be completed before presenting it.
 									// await this.say(
 									// 	"command",
@@ -2495,7 +2495,7 @@ export class Task {
 
 								// If the model says this command is safe and auto aproval for safe commands is true, execute the command
 								// If the model says the command is risky, but *BOTH* auto approve settings are true, execute the command
-								const autoApproveResult = this.ShouldAutoApproveTool(block.name)
+								const autoApproveResult = this.shouldAutoApproveTool(block.name)
 								const [autoApproveSafe, autoApproveAll] = Array.isArray(autoApproveResult)
 									? autoApproveResult
 									: [autoApproveResult, false]
@@ -2516,7 +2516,7 @@ export class Task {
 									const didApprove = await askApproval(
 										"command",
 										command +
-											`${this.ShouldAutoApproveTool(block.name) && requiresApprovalPerLLM ? COMMAND_REQ_APP_STRING : ""}`, // ugly hack until we refactor combineCommandSequences
+											`${this.shouldAutoApproveTool(block.name) && requiresApprovalPerLLM ? COMMAND_REQ_APP_STRING : ""}`, // ugly hack until we refactor combineCommandSequences
 									)
 									if (!didApprove) {
 										await this.saveCheckpoint()
@@ -2572,7 +2572,7 @@ export class Task {
 									arguments: removeClosingTag("arguments", mcp_arguments),
 								} satisfies ClineAskUseMcpServer)
 
-								if (this.ShouldAutoApproveTool(block.name)) {
+								if (this.shouldAutoApproveTool(block.name)) {
 									this.removeLastPartialMessageIfExistsWithType("ask", "use_mcp_server")
 									await this.say("use_mcp_server", partialMessage, undefined, block.partial)
 								} else {
@@ -2631,7 +2631,7 @@ export class Task {
 									?.find((conn) => conn.server.name === server_name)
 									?.server.tools?.find((tool) => tool.name === tool_name)?.autoApprove
 
-								if (this.ShouldAutoApproveTool(block.name) && isToolAutoApproved) {
+								if (this.shouldAutoApproveTool(block.name) && isToolAutoApproved) {
 									this.removeLastPartialMessageIfExistsWithType("ask", "use_mcp_server")
 									await this.say("use_mcp_server", completeMessage, undefined, false)
 									this.consecutiveAutoApprovedRequestsCount++
@@ -2691,7 +2691,7 @@ export class Task {
 									uri: removeClosingTag("uri", uri),
 								} satisfies ClineAskUseMcpServer)
 
-								if (this.ShouldAutoApproveTool(block.name)) {
+								if (this.shouldAutoApproveTool(block.name)) {
 									this.removeLastPartialMessageIfExistsWithType("ask", "use_mcp_server")
 									await this.say("use_mcp_server", partialMessage, undefined, block.partial)
 								} else {
@@ -2720,7 +2720,7 @@ export class Task {
 									uri,
 								} satisfies ClineAskUseMcpServer)
 
-								if (this.ShouldAutoApproveTool(block.name)) {
+								if (this.shouldAutoApproveTool(block.name)) {
 									this.removeLastPartialMessageIfExistsWithType("ask", "use_mcp_server")
 									await this.say("use_mcp_server", completeMessage, undefined, false)
 									this.consecutiveAutoApprovedRequestsCount++


### PR DESCRIPTION
### Description

Adds visual indicators when Cline is operating on files outside the workspace boundary, with handling for long paths in Windows and symlinks. All file/directory tools (read_file, write_to_file, list_files, etc) now show a warning icon when operating outside workspace

### Test Procedure

Try operations inside workspace - no warning icon should appear
Try operations outside workspace (e.g. Desktop) - yellow warning icon should appear with tooltip
On Windows: Test with paths >260 characters
Test with symlinked directories

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [X] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [X] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [X] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [X] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [X] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

File is outside of the workspace:
![image](https://github.com/user-attachments/assets/c7bbadad-0f51-482f-95cd-f3016226aecd)


File is outside of the workspace (title/tooltip?):
![image](https://github.com/user-attachments/assets/b6947d9b-f2af-485e-83da-8c189582480e)


File is inside the workspace (no change):
![image](https://github.com/user-attachments/assets/b78d03f0-8d3b-4354-a6aa-34e226819394)


### Additional Notes

<!-- Add any additional notes for reviewers -->
