### PR TITLE
Message catching added to test server

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -399,7 +399,7 @@ export function activate(context: vscode.ExtensionContext) {
 
 	// Set up test server if in test mode
 	if (IS_TEST && IS_TEST === "true") {
-		createTestServer()
+		createTestServer(sidebarWebview)
 	}
 
 	return createClineAPI(outputChannel, sidebarWebview.controller)

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -398,7 +398,7 @@ export function activate(context: vscode.ExtensionContext) {
 	)
 
 	// Set up test server if in test mode
-	if (IS_TEST && IS_TEST === "true") {
+	if (IS_TEST === "true") {
 		createTestServer(sidebarWebview)
 	}
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -397,6 +397,11 @@ export function activate(context: vscode.ExtensionContext) {
 		}),
 	)
 
+	// Set up test server if in test mode
+	if (IS_TEST && IS_TEST === "true") {
+		createTestServer()
+	}
+
 	return createClineAPI(outputChannel, sidebarWebview.controller)
 }
 
@@ -427,9 +432,4 @@ if (IS_DEV && IS_DEV !== "false") {
 
 		vscode.commands.executeCommand("workbench.action.reloadWindow")
 	})
-}
-
-// Set up test server if in test mode
-if (IS_TEST && IS_TEST === "true") {
-	createTestServer()
 }

--- a/src/services/test/TestServer.ts
+++ b/src/services/test/TestServer.ts
@@ -117,9 +117,9 @@ export function createTestServer(): http.Server {
  */
 export function createMessageCatcher(webviewProvider: WebviewProvider): vscode.Disposable {
 	Logger.log("Cline message catcher registered")
-	
+
 	if (webviewProvider && webviewProvider.controller) {
-		const originalPostMessageToWebview = webviewProvider.controller.postMessageToWebview;
+		const originalPostMessageToWebview = webviewProvider.controller.postMessageToWebview
 		webviewProvider.controller.postMessageToWebview = async (message) => {
 			console.log("Cline message received:", message)
 			return originalPostMessageToWebview.call(webviewProvider.controller, message)
@@ -143,7 +143,7 @@ export function shutdownTestServer() {
 		Logger.log("Test server shut down")
 		testServer = undefined
 	}
-	
+
 	// Dispose of the message catcher if it exists
 	if (messageCatcherDisposable) {
 		messageCatcherDisposable.dispose()

--- a/src/services/test/TestServer.ts
+++ b/src/services/test/TestServer.ts
@@ -126,7 +126,7 @@ export function createMessageCatcher(webviewProvider: WebviewProvider): vscode.D
 	if (webviewProvider && webviewProvider.controller) {
 		const originalPostMessageToWebview = webviewProvider.controller.postMessageToWebview
 		webviewProvider.controller.postMessageToWebview = async (message) => {
-			console.log("Cline message received:", message)
+			Logger.log("Cline message received: " + message.type)
 			return originalPostMessageToWebview.call(webviewProvider.controller, message)
 		}
 	} else {

--- a/src/services/test/TestServer.ts
+++ b/src/services/test/TestServer.ts
@@ -8,9 +8,10 @@ let messageCatcherDisposable: vscode.Disposable | undefined
 
 /**
  * Creates and starts an HTTP server for test automation
+ * @param webviewProvider The webview provider instance to use for message catching
  * @returns The created HTTP server instance
  */
-export function createTestServer(): http.Server {
+export function createTestServer(webviewProvider?: WebviewProvider): http.Server {
 	const PORT = 9876
 
 	testServer = http.createServer((req, res) => {
@@ -99,12 +100,16 @@ export function createTestServer(): http.Server {
 		Logger.log(`Test server error: ${error}`)
 	})
 
-	// Set up message catcher for the visible webview instance
-	const visibleWebview = WebviewProvider.getVisibleInstance()
-	if (visibleWebview) {
-		messageCatcherDisposable = createMessageCatcher(visibleWebview)
+	// Set up message catcher for the provided webview instance or try to get the visible one
+	if (webviewProvider) {
+		messageCatcherDisposable = createMessageCatcher(webviewProvider)
 	} else {
-		Logger.log("No visible webview instance found for message catcher")
+		const visibleWebview = WebviewProvider.getVisibleInstance()
+		if (visibleWebview) {
+			messageCatcherDisposable = createMessageCatcher(visibleWebview)
+		} else {
+			Logger.log("No visible webview instance found for message catcher")
+		}
 	}
 
 	return testServer


### PR DESCRIPTION
### Description

So that we can listen for any webview messages (e.g. task completed messages) on our test server

### Test Procedure

<!-- How did you test this? Are you confident that it will not introduce bugs? If so, why? -->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds message catching to the test server by modifying `createTestServer` to accept a `WebviewProvider` and introducing `createMessageCatcher` for logging webview messages.
> 
>   - **New Feature**:
>     - Adds message catching to the test server in `TestServer.ts` by modifying `createTestServer()` to accept a `WebviewProvider` and setting up a message catcher.
>     - Introduces `createMessageCatcher()` in `TestServer.ts` to log messages sent to the webview.
>   - **Behavior**:
>     - In `extension.ts`, the test server is set up with `createTestServer(sidebarWebview)` if `IS_TEST` is "true".
>     - Removes redundant test server setup code in `extension.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for a428665874a847d001888adc1bb400264c511c53. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->