### PR TITLE
ENG-449/Checkpoint UI hover debounce

### DIFF
--- a/.changeset/gorgeous-bees-talk.md
+++ b/.changeset/gorgeous-bees-talk.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Added debounce for checkmark expanded ui

--- a/webview-ui/src/components/common/CheckmarkControl.tsx
+++ b/webview-ui/src/components/common/CheckmarkControl.tsx
@@ -270,7 +270,7 @@ export const CheckmarkControl = ({ messageTs, isCheckpointCheckedOut, isLastRow 
 										color: isCheckpointCheckedOut
 											? "var(--vscode-textLink-foreground)"
 											: "var(--vscode-descriptionForeground)",
-										fontSize: "2px",
+										fontSize: "12px",
 										marginRight: "6px",
 									}}
 								/>

--- a/webview-ui/src/components/common/CheckmarkControl.tsx
+++ b/webview-ui/src/components/common/CheckmarkControl.tsx
@@ -8,6 +8,13 @@ import { VSCodeButton } from "@vscode/webview-ui-toolkit/react"
 import { createPortal } from "react-dom"
 import { useFloating, offset, flip, shift } from "@floating-ui/react"
 
+interface CheckmarkControlProps {
+	messageTs?: number
+	isCheckpointCheckedOut?: boolean
+	/** Whether this is the last row in the chat */
+	isLastRow?: boolean
+}
+
 export const CheckmarkControl = ({ messageTs, isCheckpointCheckedOut, isLastRow = false }: CheckmarkControlProps) => {
 	const [compareDisabled, setCompareDisabled] = useState(false)
 	const [restoreTaskDisabled, setRestoreTaskDisabled] = useState(false)

--- a/webview-ui/src/components/common/CheckmarkControl.tsx
+++ b/webview-ui/src/components/common/CheckmarkControl.tsx
@@ -8,13 +8,6 @@ import { VSCodeButton } from "@vscode/webview-ui-toolkit/react"
 import { createPortal } from "react-dom"
 import { useFloating, offset, flip, shift } from "@floating-ui/react"
 
-interface CheckmarkControlProps {
-	messageTs?: number
-	isCheckpointCheckedOut?: boolean
-	/** Whether this is the last row in the chat */
-	isLastRow?: boolean
-}
-
 export const CheckmarkControl = ({ messageTs, isCheckpointCheckedOut, isLastRow = false }: CheckmarkControlProps) => {
 	const [compareDisabled, setCompareDisabled] = useState(false)
 	const [restoreTaskDisabled, setRestoreTaskDisabled] = useState(false)

--- a/webview-ui/src/components/common/CheckmarkControl.tsx
+++ b/webview-ui/src/components/common/CheckmarkControl.tsx
@@ -27,15 +27,6 @@ export const CheckmarkControl = ({ messageTs, isCheckpointCheckedOut, isLastRow 
 	const [isLineHovered, setIsLineHovered] = useState(false)
 	const hideTimerRef = useRef<NodeJS.Timeout | null>(null)
 
-	// Cleanup timer on unmount
-	useEffect(() => {
-		return () => {
-			if (hideTimerRef.current) {
-				clearTimeout(hideTimerRef.current)
-			}
-		}
-	}, [])
-
 	const { refs, floatingStyles, update, placement } = useFloating({
 		placement: "bottom-end",
 		middleware: [


### PR DESCRIPTION
### Description

Adds a debounce to the expanded ui for checkpoints.

### Test Procedure

Hover over the checkpoints expanded ui and confirm it is not disappearing too quickly when moving the mouse to compare/restore buttons.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [X] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [X] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [X] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [X] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [X] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

https://github.com/user-attachments/assets/cad6a32f-ad9a-4b43-8ff5-056da28303ad

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds debounce to `CheckmarkControl` to delay hiding of expanded UI, improving hover experience.
> 
>   - **Behavior**:
>     - Adds debounce to `CheckmarkControl` in `CheckmarkControl.tsx` to delay hiding of expanded UI on mouse leave.
>     - Introduces `handleDebounceMouseLeave` function to manage hover state with a 400ms delay.
>   - **UI Changes**:
>     - Updates `CheckpointIndicator` width and height for better visibility.
>     - Adjusts border radius and opacity transitions for smoother UI.
>   - **Code Maintenance**:
>     - Cleans up timer on component unmount using `useEffect`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 7c22373f4d896b8632113f2cd856f86c6fdae067. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->