### PR TITLE
test server waits to respond until task completed

### DIFF
--- a/src/services/test/TestServer.ts
+++ b/src/services/test/TestServer.ts
@@ -5,6 +5,31 @@ import { WebviewProvider } from "../../core/webview"
 import { AutoApprovalSettings } from "../../shared/AutoApprovalSettings"
 import { updateGlobalState, getAllExtensionState } from "../../core/storage/state"
 
+// Task completion tracking
+let taskCompletionResolver: (() => void) | null = null
+let taskCompleted = false
+
+// Function to create a new task completion promise
+function createTaskCompletionTracker(): Promise<void> {
+	// Reset the completion state
+	taskCompleted = false
+
+	// Create a new promise that will resolve when the task is completed
+	return new Promise<void>((resolve) => {
+		taskCompletionResolver = resolve
+	})
+}
+
+// Function to mark the current task as completed
+function completeTask(): void {
+	if (taskCompletionResolver) {
+		taskCompleted = true
+		taskCompletionResolver()
+		taskCompletionResolver = null
+		Logger.log("Task marked as completed")
+	}
+}
+
 let testServer: http.Server | undefined
 let messageCatcherDisposable: vscode.Disposable | undefined
 
@@ -118,9 +143,39 @@ export function createTestServer(webviewProvider?: WebviewProvider): http.Server
 					// Initiate the new task
 					const taskId = await visibleWebview.controller.initTask(task)
 
-					// Return success response with the task ID
-					res.writeHead(200, { "Content-Type": "application/json" })
-					res.end(JSON.stringify({ success: true, taskId }))
+					// Create a completion tracker for this task
+					const completionPromise = createTaskCompletionTracker()
+
+					// Wait for the task to complete with a timeout
+					const timeoutPromise = new Promise<void>((_, reject) => {
+						setTimeout(() => reject(new Error("Task completion timeout")), 15 * 60 * 1000) // 15 minute timeout
+					})
+
+					try {
+						// Wait for either completion or timeout
+						await Promise.race([completionPromise, timeoutPromise])
+
+						// Return success response with the task ID
+						res.writeHead(200, { "Content-Type": "application/json" })
+						res.end(
+							JSON.stringify({
+								success: true,
+								taskId,
+								completed: true,
+							}),
+						)
+					} catch (timeoutError) {
+						// Task didn't complete within the timeout period
+						res.writeHead(200, { "Content-Type": "application/json" })
+						res.end(
+							JSON.stringify({
+								success: true,
+								taskId,
+								completed: false,
+								timeout: true,
+							}),
+						)
+					}
 				} catch (error) {
 					Logger.log(`Error initiating task: ${error}`)
 					res.writeHead(500)
@@ -169,6 +224,13 @@ export function createMessageCatcher(webviewProvider: WebviewProvider): vscode.D
 		const originalPostMessageToWebview = webviewProvider.controller.postMessageToWebview
 		webviewProvider.controller.postMessageToWebview = async (message) => {
 			Logger.log("Cline message received: " + JSON.stringify(message))
+
+			// Check for completion_result message
+			if (message.type === "partialMessage" && message.partialMessage?.say === "completion_result") {
+				// Complete the current task
+				completeTask()
+			}
+
 			return originalPostMessageToWebview.call(webviewProvider.controller, message)
 		}
 	} else {

--- a/src/services/test/TestServer.ts
+++ b/src/services/test/TestServer.ts
@@ -7,13 +7,9 @@ import { updateGlobalState, getAllExtensionState } from "../../core/storage/stat
 
 // Task completion tracking
 let taskCompletionResolver: (() => void) | null = null
-let taskCompleted = false
 
 // Function to create a new task completion promise
 function createTaskCompletionTracker(): Promise<void> {
-	// Reset the completion state
-	taskCompleted = false
-
 	// Create a new promise that will resolve when the task is completed
 	return new Promise<void>((resolve) => {
 		taskCompletionResolver = resolve
@@ -23,7 +19,6 @@ function createTaskCompletionTracker(): Promise<void> {
 // Function to mark the current task as completed
 function completeTask(): void {
 	if (taskCompletionResolver) {
-		taskCompleted = true
 		taskCompletionResolver()
 		taskCompletionResolver = null
 		Logger.log("Task marked as completed")


### PR DESCRIPTION
### Description


https://github.com/user-attachments/assets/41bf93b7-c5a3-4c30-9503-cdf678be855a



we can now start a task with 

```
pash|||cline: curl -X POST http://localhost:9876/task \
  -H "Content-Type: application/json" \
  -d '{"task": "Please say the word dog"}'
```

and it will wait until the task is completed:

```
{"success":true,"completed":true}%
```

### Test Procedure

pash|||cline: curl -X POST http://localhost:9876/task \
  -H "Content-Type: application/json" \
  -d '{"task": "Please say the word dog"}'

{"success":true,"completed":true}%

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Test server now waits for task completion before responding, with task completion tracking and timeout handling in `TestServer.ts`.
> 
>   - **Behavior**:
>     - Test server now waits for task completion before responding to POST requests to `/task` in `TestServer.ts`.
>     - Returns JSON response with `success`, `taskId`, and `completed` status.
>     - Handles task completion timeout (15 minutes) and returns `timeout` status if applicable.
>   - **Functions**:
>     - Adds `createTaskCompletionTracker()` and `completeTask()` for task completion tracking.
>     - Modifies `createTestServer()` to use task completion tracking and handle timeouts.
>     - Updates `createMessageCatcher()` to call `completeTask()` on receiving `completion_result` message.
>   - **Misc**:
>     - Logs task initiation and completion status using `Logger`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for f4d95e9e4d97ff580f80c6da2bb4b3bb0d70d54f. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->