### PR TITLE
refactor & perf of file `ThinkingBudgetSlider.tsx`

### DIFF
--- a/.changeset/tasty-plums-laugh.md
+++ b/.changeset/tasty-plums-laugh.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+refactor & perf of file `ThinkingBudgetSlider.tsx`

--- a/webview-ui/src/components/settings/ThinkingBudgetSlider.tsx
+++ b/webview-ui/src/components/settings/ThinkingBudgetSlider.tsx
@@ -1,4 +1,4 @@
-import { memo, useState } from "react"
+import { memo, useCallback, useState } from "react"
 import { anthropicModels, ApiConfiguration } from "@shared/api"
 import { VSCodeCheckbox } from "@vscode/webview-ui-toolkit/react"
 import styled from "styled-components"
@@ -92,10 +92,10 @@ const ThinkingBudgetSlider = ({ apiConfiguration, setApiConfiguration }: Thinkin
 	// Add local state for the slider value
 	const [localValue, setLocalValue] = useState(apiConfiguration?.thinkingBudgetTokens || 0)
 
-	const handleSliderChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+	const handleSliderChange = useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
 		const value = parseInt(event.target.value, 10)
 		setLocalValue(value)
-	}
+	}, [])
 
 	const handleSliderComplete = () => {
 		setApiConfiguration({


### PR DESCRIPTION
### Description

refactor & perf of file `ThinkingBudgetSlider.tsx`

### Test Procedure

Test with `Fn + F5` => Settings => Enabled extended thinking => check slider works fine

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [x] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Refactor `ThinkingBudgetSlider.tsx` to use `useCallback` for performance optimization without changing behavior.
> 
>   - **Refactor & Performance**:
>     - Use `useCallback` for `handleSliderChange` in `ThinkingBudgetSlider.tsx` to optimize rendering.
>   - **Behavior**:
>     - No changes in behavior; slider functionality remains the same.
>   - **Misc**:
>     - Minor import change: added `useCallback` to imports.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 0b13f958c1b4cb9b497f10583666f9afed7e8325. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->