### PR TITLE
Eng-451 Fixing bugs in the provider name  when we switch models halfway between a chat

### DIFF
--- a/src/core/task/index.ts
+++ b/src/core/task/index.ts
@@ -223,8 +223,8 @@ export class Task {
 			this.startTask(task, images)
 		}
 
-		// Initialize provider and telemetry
-		this.initializeProviderAndTelemetry(historyItem)
+		// Initialize telemetry
+		this.initializeTelemetry(historyItem)
 	}
 
 	// Get the current provider from global state to ensure we're using the latest provider
@@ -232,7 +232,7 @@ export class Task {
 		return (await getGlobalState(this.getContext(), "apiProvider")) as string
 	}
 
-	private async initializeProviderAndTelemetry(historyItem?: HistoryItem) {
+	private async initializeTelemetry(historyItem?: HistoryItem) {
 		const currentProviderId = await this.getCurrentProviderId()
 		if (historyItem) {
 			// Open task from history

--- a/src/core/task/index.ts
+++ b/src/core/task/index.ts
@@ -223,12 +223,23 @@ export class Task {
 			this.startTask(task, images)
 		}
 
+		// Initialize provider and telemetry
+		this.initializeProviderAndTelemetry(historyItem)
+	}
+
+	// Get the current provider from global state to ensure we're using the latest provider
+	private async getCurrentProviderId(): Promise<string> {
+		return (await getGlobalState(this.getContext(), "apiProvider")) as string
+	}
+
+	private async initializeProviderAndTelemetry(historyItem?: HistoryItem) {
+		const currentProviderId = await this.getCurrentProviderId()
 		if (historyItem) {
 			// Open task from history
-			telemetryService.captureTaskRestarted(this.taskId, this.apiProvider)
+			telemetryService.captureTaskRestarted(this.taskId, currentProviderId)
 		} else {
 			// New task started
-			telemetryService.captureTaskCreated(this.taskId, this.apiProvider)
+			telemetryService.captureTaskCreated(this.taskId, currentProviderId)
 		}
 	}
 
@@ -3157,7 +3168,7 @@ export class Task {
 		// Used to know what models were used in the task if user wants to export metadata for error reporting purposes
 		// Get the current provider from global state to ensure we're using the latest provider
 		// This is needed because apiProvider is readonly and may not reflect provider changes during a chat
-		const currentProviderId = (await getGlobalState(this.getContext(), "apiProvider")) as string
+		const currentProviderId = await this.getCurrentProviderId()
 		if (currentProviderId && this.api.getModel().id) {
 			try {
 				await this.modelContextTracker.recordModelUsage(currentProviderId, this.api.getModel().id, this.chatSettings.mode)

--- a/src/core/task/index.ts
+++ b/src/core/task/index.ts
@@ -104,7 +104,6 @@ export class Task {
 	private cancelTask: () => Promise<void>
 
 	readonly taskId: string
-	readonly apiProvider?: string
 	api: ApiHandler
 	private terminalManager: TerminalManager
 	private urlContentFetcher: UrlContentFetcher
@@ -183,7 +182,6 @@ export class Task {
 		this.clineIgnoreController.initialize().catch((error) => {
 			console.error("Failed to initialize ClineIgnoreController:", error)
 		})
-		this.apiProvider = apiConfiguration.apiProvider
 		this.terminalManager = new TerminalManager()
 		this.urlContentFetcher = new UrlContentFetcher(context)
 		this.browserSession = new BrowserSession(context, browserSettings)

--- a/src/core/task/index.ts
+++ b/src/core/task/index.ts
@@ -3166,8 +3166,6 @@ export class Task {
 		}
 
 		// Used to know what models were used in the task if user wants to export metadata for error reporting purposes
-		// Get the current provider from global state to ensure we're using the latest provider
-		// This is needed because apiProvider is readonly and may not reflect provider changes during a chat
 		const currentProviderId = await this.getCurrentProviderId()
 		if (currentProviderId && this.api.getModel().id) {
 			try {

--- a/src/core/task/index.ts
+++ b/src/core/task/index.ts
@@ -85,6 +85,7 @@ import {
 } from "../storage/disk"
 import { McpHub } from "../../services/mcp/McpHub"
 import WorkspaceTracker from "../../integrations/workspace/WorkspaceTracker"
+import { getGlobalState } from "../storage/state"
 
 const cwd = vscode.workspace.workspaceFolders?.map((folder) => folder.uri.fsPath).at(0) ?? path.join(os.homedir(), "Desktop") // may or may not exist but fs checking existence would immediately ask for permission which would be bad UX, need to come up with a better solution
 
@@ -3154,9 +3155,11 @@ export class Task {
 		}
 
 		// Used to know what models were used in the task if user wants to export metadata for error reporting purposes
-		if (this.apiProvider && this.api.getModel().id) {
+		// --- START: Read current provider from global state with fallback ---
+		const currentProviderId = (await getGlobalState(this.getContext(), "apiProvider")) as string
+		if (currentProviderId && this.api.getModel().id) {
 			try {
-				await this.modelContextTracker.recordModelUsage(this.apiProvider, this.api.getModel().id, this.chatSettings.mode)
+				await this.modelContextTracker.recordModelUsage(currentProviderId, this.api.getModel().id, this.chatSettings.mode)
 			} catch {}
 		}
 
@@ -3263,7 +3266,7 @@ export class Task {
 			content: userContent,
 		})
 
-		telemetryService.captureConversationTurnEvent(this.taskId, this.apiProvider, this.api.getModel().id, "user")
+		telemetryService.captureConversationTurnEvent(this.taskId, currentProviderId, this.api.getModel().id, "user")
 
 		// since we sent off a placeholder api_req_started message to update the webview while waiting to actually start the API request (to load potential details for example), we need to update the text of that message
 		const lastApiReqIndex = findLastIndex(this.clineMessages, (m) => m.say === "api_req_started")
@@ -3340,7 +3343,7 @@ export class Task {
 				updateApiReqMsg(cancelReason, streamingFailedMessage)
 				await this.saveClineMessagesAndUpdateHistory()
 
-				telemetryService.captureConversationTurnEvent(this.taskId, this.apiProvider, this.api.getModel().id, "assistant")
+				telemetryService.captureConversationTurnEvent(this.taskId, currentProviderId, this.api.getModel().id, "assistant")
 
 				// signals to provider that it can retrieve the saved messages from disk, as abortTask can not be awaited on in nature
 				this.didFinishAbortingStream = true
@@ -3480,7 +3483,7 @@ export class Task {
 			// need to save assistant responses to file before proceeding to tool use since user can exit at any moment and we wouldn't be able to save the assistant's response
 			let didEndLoop = false
 			if (assistantMessage.length > 0) {
-				telemetryService.captureConversationTurnEvent(this.taskId, this.apiProvider, this.api.getModel().id, "assistant")
+				telemetryService.captureConversationTurnEvent(this.taskId, currentProviderId, this.api.getModel().id, "assistant")
 
 				await this.addToApiConversationHistory({
 					role: "assistant",

--- a/src/core/task/index.ts
+++ b/src/core/task/index.ts
@@ -3155,7 +3155,8 @@ export class Task {
 		}
 
 		// Used to know what models were used in the task if user wants to export metadata for error reporting purposes
-		// --- START: Read current provider from global state with fallback ---
+		// Get the current provider from global state to ensure we're using the latest provider
+		// This is needed because apiProvider is readonly and may not reflect provider changes during a chat
 		const currentProviderId = (await getGlobalState(this.getContext(), "apiProvider")) as string
 		if (currentProviderId && this.api.getModel().id) {
 			try {

--- a/src/core/task/index.ts
+++ b/src/core/task/index.ts
@@ -221,23 +221,13 @@ export class Task {
 			this.startTask(task, images)
 		}
 
-		// Initialize telemetry
-		this.initializeTelemetry(historyItem)
-	}
-
-	// Get the current provider from global state to ensure we're using the latest provider
-	private async getCurrentProviderId(): Promise<string> {
-		return (await getGlobalState(this.getContext(), "apiProvider")) as string
-	}
-
-	private async initializeTelemetry(historyItem?: HistoryItem) {
-		const currentProviderId = await this.getCurrentProviderId()
+		// initialize telemetry
 		if (historyItem) {
 			// Open task from history
-			telemetryService.captureTaskRestarted(this.taskId, currentProviderId)
+			telemetryService.captureTaskRestarted(this.taskId, apiConfiguration.apiProvider)
 		} else {
 			// New task started
-			telemetryService.captureTaskCreated(this.taskId, currentProviderId)
+			telemetryService.captureTaskCreated(this.taskId, apiConfiguration.apiProvider)
 		}
 	}
 
@@ -3164,7 +3154,7 @@ export class Task {
 		}
 
 		// Used to know what models were used in the task if user wants to export metadata for error reporting purposes
-		const currentProviderId = await this.getCurrentProviderId()
+		const currentProviderId = (await getGlobalState(this.getContext(), "apiProvider")) as string
 		if (currentProviderId && this.api.getModel().id) {
 			try {
 				await this.modelContextTracker.recordModelUsage(currentProviderId, this.api.getModel().id, this.chatSettings.mode)


### PR DESCRIPTION
[Linear Issue
](https://linear.app/cline-bot/issue/ENG-451/asymetry-between-provider-and-model-name-when-switching-providers)


### Description
The original code has an issue where the apiProvider variable is readonly so when we change the provider and the model halfway through a chat only the model gets changed but not the provider so this change uses the provider from the global state to fix that. There are other ways to solve this too but this seemed like the cleanest for this specific case. I don't want to mutate other variables as they might break other things so I found this to be the cleanest way to solve this problem. 


### Test Procedure

Tested locally with the debugger which makes this file 

#### Before
[task_metadata.json](https://github.com/user-attachments/files/19714769/task_metadata.json)


#### After
[task_metadata.json](https://github.com/user-attachments/files/19714767/task_metadata.json)



### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [X] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [X] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [X] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [] I have created a changeset using `npm run changeset` (required for user-facing changes) -> This is not a user facing change
-   [X] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes `apiProvider` update bug in `Task` class and adds auto-response to ask messages in `TestServer.ts`.
> 
>   - **Behavior**:
>     - Fixes bug in `Task` class in `index.ts` where `apiProvider` was not updated when switching models mid-chat by fetching from global state.
>     - Updates `TestServer.ts` to auto-respond to ask messages requiring user intervention, ensuring tasks continue without manual input.
>   - **Functions**:
>     - Modifies `recordModelUsage()` calls in `Task` class to use `currentProviderId` from global state.
>     - Adds `autoRespondToAsk()` in `TestServer.ts` to handle ask messages automatically.
>   - **Misc**:
>     - Minor logging changes in `TestServer.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for d05575d64ace380c81b40ae23508ff2bec4aa6e6. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->