### PR TITLE
feat: add support for Claude 3.7 Sonnet 128k output token beta feature

### DIFF
--- a/.changeset/soft-squids-sip.md
+++ b/.changeset/soft-squids-sip.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": minor
+---
+
+Add 128K output beta feature for Claude 3.7 Sonnet, increasing max output tokens from 8K to 128K. Includes API changes for Anthropic and Vertex providers, UI toggle in settings, and adaptive thinking budget slider that respects the new token limits.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "claude-dev",
-	"version": "3.10.1",
+	"version": "3.11.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "claude-dev",
-			"version": "3.10.1",
+			"version": "3.11.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@anthropic-ai/bedrock-sdk": "^0.12.4",

--- a/src/core/storage/state-keys.ts
+++ b/src/core/storage/state-keys.ts
@@ -42,6 +42,7 @@ export type GlobalStateKey =
 	| "lmStudioModelId"
 	| "lmStudioBaseUrl"
 	| "anthropicBaseUrl"
+	| "anthropicEnable128kOutputBeta"
 	| "azureApiVersion"
 	| "openRouterModelId"
 	| "openRouterModelInfo"

--- a/src/core/storage/state.ts
+++ b/src/core/storage/state.ts
@@ -119,6 +119,7 @@ export async function getAllExtensionState(context: vscode.ExtensionContext) {
 		sambanovaApiKey,
 		planActSeparateModelsSettingRaw,
 		favoritedModelIds,
+		anthropicEnable128kOutputBeta,
 	] = await Promise.all([
 		getGlobalState(context, "apiProvider") as Promise<ApiProvider | undefined>,
 		getGlobalState(context, "apiModelId") as Promise<string | undefined>,
@@ -187,6 +188,7 @@ export async function getAllExtensionState(context: vscode.ExtensionContext) {
 		getSecret(context, "sambanovaApiKey") as Promise<string | undefined>,
 		getGlobalState(context, "planActSeparateModelsSetting") as Promise<boolean | undefined>,
 		getGlobalState(context, "favoritedModelIds") as Promise<string[] | undefined>,
+		getGlobalState(context, "anthropicEnable128kOutputBeta") as Promise<boolean | undefined>,
 	])
 
 	let apiProvider: ApiProvider
@@ -281,6 +283,7 @@ export async function getAllExtensionState(context: vscode.ExtensionContext) {
 			xaiApiKey,
 			sambanovaApiKey,
 			favoritedModelIds,
+			anthropicEnable128kOutputBeta,
 		},
 		lastShownAnnouncementId,
 		customInstructions,
@@ -355,6 +358,7 @@ export async function updateApiConfiguration(context: vscode.ExtensionContext, a
 		clineApiKey,
 		sambanovaApiKey,
 		favoritedModelIds,
+		anthropicEnable128kOutputBeta,
 	} = apiConfiguration
 	await updateGlobalState(context, "apiProvider", apiProvider)
 	await updateGlobalState(context, "apiModelId", apiModelId)
@@ -409,6 +413,7 @@ export async function updateApiConfiguration(context: vscode.ExtensionContext, a
 	await storeSecret(context, "clineApiKey", clineApiKey)
 	await storeSecret(context, "sambanovaApiKey", sambanovaApiKey)
 	await updateGlobalState(context, "favoritedModelIds", favoritedModelIds)
+	await updateGlobalState(context, "anthropicEnable128kOutputBeta", anthropicEnable128kOutputBeta)
 }
 
 export async function resetExtensionState(context: vscode.ExtensionContext) {

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -74,6 +74,7 @@ export interface ApiHandlerOptions {
 	asksageApiKey?: string
 	xaiApiKey?: string
 	thinkingBudgetTokens?: number
+	anthropicEnable128kOutputBeta?: boolean
 	sambanovaApiKey?: string
 }
 

--- a/webview-ui/src/components/settings/ApiOptions.tsx
+++ b/webview-ui/src/components/settings/ApiOptions.tsx
@@ -1531,7 +1531,26 @@ const ApiOptions = ({ showModelOptions, apiErrorMessage, modelIdErrorMessage, is
 						{((selectedProvider === "anthropic" && selectedModelId === "claude-3-7-sonnet-20250219") ||
 							(selectedProvider === "bedrock" && selectedModelId === "anthropic.claude-3-7-sonnet-20250219-v1:0") ||
 							(selectedProvider === "vertex" && selectedModelId === "claude-3-7-sonnet@20250219")) && (
-							<ThinkingBudgetSlider apiConfiguration={apiConfiguration} setApiConfiguration={setApiConfiguration} />
+							<>
+								{/* 128k Beta Checkbox for providers with Claude 3.7 Sonnet */}
+								{(selectedProvider === "anthropic" || selectedProvider === "vertex") && (
+									<VSCodeCheckbox
+										checked={apiConfiguration?.anthropicEnable128kOutputBeta ?? false}
+										onChange={(e: any) => {
+											const isChecked = (e.target as HTMLInputElement).checked
+											setApiConfiguration({
+												...apiConfiguration,
+												anthropicEnable128kOutputBeta: isChecked,
+											})
+										}}>
+										Enable 128k Output (Beta)
+									</VSCodeCheckbox>
+								)}
+								<ThinkingBudgetSlider
+									apiConfiguration={apiConfiguration}
+									setApiConfiguration={setApiConfiguration}
+								/>
+							</>
 						)}
 
 						<ModelInfoView
@@ -1831,6 +1850,7 @@ export function normalizeApiConfiguration(apiConfiguration?: ApiConfiguration): 
 				selectedModelId: apiConfiguration?.lmStudioModelId || "",
 				selectedModelInfo: openAiModelInfoSaneDefaults,
 			}
+		// eslint-disable-next-line no-duplicate-case
 		case "requesty":
 			return {
 				selectedProvider: provider,


### PR DESCRIPTION
- Add checkbox in API settings UI to enable 128k output token beta feature for Claude 3.7 Sonnet
- Implement token limit adjustment in Anthropic and Vertex API handlers (from 4096 to 128k)
- Modify API request headers to include "output-128k-2025-02-19" beta flag when enabled
- Update ThinkingBudgetSlider to dynamically adjust max values based on selected output limit
- Add state management for the new anthropicEnable128kOutputBeta setting
- Bump version from 3.10.1 to 3.11.0

### Description

Add 128K output beta feature for Claude 3.7 Sonnet, increasing max output tokens from 8K to 128K. Includes API changes for Anthropic and Vertex providers, UI toggle in settings, and adaptive thinking budget slider that respects the new token limits.

### Test Procedure

- Select Anthropic or GCP Vertex AI as the API Provider
- Select Claude 3.7 as the model
- Verify that "Enable 128k Output (Beta)" is visible
- Check "Enable extended thinking"
- Verify that the max "Thinking Budget" is 6,524
- Check "Enable 128k Output (Beta)"
- Verify that the max "Thinking Budget" is 102,324 (80% of 128000)

- Uncheck "Enable 128k Output (Beta)" 
- Verify that the max "Thinking Budget" is moved back to 1024 (minimum)

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

![image](https://github.com/user-attachments/assets/f62b93c4-0b3e-4bb4-8d1a-e1d8f137419a)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds 128k output token beta feature for Claude 3.7 Sonnet, updating UI and API handlers to support increased token limits.
> 
>   - **Behavior**:
>     - Adds 128k output token beta feature for Claude 3.7 Sonnet, increasing max output tokens from 8K to 128K.
>     - Checkbox added in `ApiOptions.tsx` to enable 128k output token feature.
>     - Updates `ThinkingBudgetSlider.tsx` to adjust max values based on selected output limit.
>   - **API Handlers**:
>     - In `anthropic.ts`, adjusts `maxTokens` to 128k when `anthropicEnable128kOutputBeta` is enabled.
>     - In `vertex.ts`, similar adjustment for `maxTokens` and request headers.
>   - **State Management**:
>     - Adds `anthropicEnable128kOutputBeta` to state management in `state.ts` and `state-keys.ts`.
>   - **Misc**:
>     - Bumps version from 3.10.1 to 3.11.0.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 1b4de877c5a0266fd84c57657d34086ace78410a. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->