### PR TITLE
Remove misleading title

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 English | <a href="https://github.com/cline/cline/blob/main/locales/es/README.md" target="_blank">Español</a> | <a href="https://github.com/cline/cline/blob/main/locales/de/README.md" target="_blank">Deutsch</a> | <a href="https://github.com/cline/cline/blob/main/locales/ja/README.md" target="_blank">日本語</a> | <a href="https://github.com/cline/cline/blob/main/locales/zh-cn/README.md" target="_blank">简体中文</a> | <a href="https://github.com/cline/cline/blob/main/locales/zh-tw/README.md" target="_blank">繁體中文</a> | <a href="https://github.com/cline/cline/blob/main/locales/ko/README.md" target="_blank">한국어</a>
 </sub></div>
 
-# Cline – \#1 on OpenRouter
+# Cline
 
 <p align="center">
   <img src="https://media.githubusercontent.com/media/cline/cline/main/assets/docs/demo.gif" width="100%" />


### PR DESCRIPTION
That's just no longer the case.

<img width="512" alt="Screenshot 2025-04-12 at 8 43 54 AM" src="https://github.com/user-attachments/assets/9313d64f-63de-4387-82ae-2f7a32edea49" />

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove outdated "#1 on OpenRouter" from project title in `README.md`.
> 
>   - **README Update**:
>     - Removed "#1 on OpenRouter" from the project title in `README.md` to reflect current status.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 32263dcc84564eb2a96dac52a2e8b96b72278b75. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->