### PR TITLE
Add baseUrl configuration for gemini api requests

### DIFF
--- a/.changeset/rich-bees-talk.md
+++ b/.changeset/rich-bees-talk.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Support baseURL for Google Gemini provider

--- a/src/api/providers/gemini.ts
+++ b/src/api/providers/gemini.ts
@@ -20,10 +20,13 @@ export class GeminiHandler implements ApiHandler {
 
 	@withRetry()
 	async *createMessage(systemPrompt: string, messages: Anthropic.Messages.MessageParam[]): ApiStream {
-		const model = this.client.getGenerativeModel({
+		const modelOptions = {
 			model: this.getModel().id,
 			systemInstruction: systemPrompt,
-		})
+		}
+
+		const clientOptions = this.options.geminiBaseUrl ? { baseUrl: this.options.geminiBaseUrl } : undefined
+		const model = this.client.getGenerativeModel(modelOptions, clientOptions)
 		const result = await model.generateContentStream({
 			contents: messages.map(convertAnthropicMessageToGemini),
 			generationConfig: {

--- a/src/core/storage/state-keys.ts
+++ b/src/core/storage/state-keys.ts
@@ -42,6 +42,7 @@ export type GlobalStateKey =
 	| "lmStudioModelId"
 	| "lmStudioBaseUrl"
 	| "anthropicBaseUrl"
+	| "geminiBaseUrl"
 	| "azureApiVersion"
 	| "openRouterModelId"
 	| "openRouterModelInfo"

--- a/src/core/storage/state.ts
+++ b/src/core/storage/state.ts
@@ -79,6 +79,7 @@ export async function getAllExtensionState(context: vscode.ExtensionContext) {
 		lmStudioBaseUrl,
 		anthropicBaseUrl,
 		geminiApiKey,
+		geminiBaseUrl,
 		openAiNativeApiKey,
 		deepSeekApiKey,
 		requestyApiKey,
@@ -149,6 +150,7 @@ export async function getAllExtensionState(context: vscode.ExtensionContext) {
 		getGlobalState(context, "lmStudioBaseUrl") as Promise<string | undefined>,
 		getGlobalState(context, "anthropicBaseUrl") as Promise<string | undefined>,
 		getSecret(context, "geminiApiKey") as Promise<string | undefined>,
+		getGlobalState(context, "geminiBaseUrl") as Promise<string | undefined>,
 		getSecret(context, "openAiNativeApiKey") as Promise<string | undefined>,
 		getSecret(context, "deepSeekApiKey") as Promise<string | undefined>,
 		getSecret(context, "requestyApiKey") as Promise<string | undefined>,
@@ -258,6 +260,7 @@ export async function getAllExtensionState(context: vscode.ExtensionContext) {
 			lmStudioBaseUrl,
 			anthropicBaseUrl,
 			geminiApiKey,
+			geminiBaseUrl,
 			openAiNativeApiKey,
 			deepSeekApiKey,
 			requestyApiKey,
@@ -334,6 +337,7 @@ export async function updateApiConfiguration(context: vscode.ExtensionContext, a
 		lmStudioBaseUrl,
 		anthropicBaseUrl,
 		geminiApiKey,
+		geminiBaseUrl,
 		openAiNativeApiKey,
 		deepSeekApiKey,
 		requestyApiKey,
@@ -389,6 +393,7 @@ export async function updateApiConfiguration(context: vscode.ExtensionContext, a
 	await updateGlobalState(context, "lmStudioBaseUrl", lmStudioBaseUrl)
 	await updateGlobalState(context, "anthropicBaseUrl", anthropicBaseUrl)
 	await storeSecret(context, "geminiApiKey", geminiApiKey)
+	await updateGlobalState(context, "geminiBaseUrl", geminiBaseUrl)
 	await storeSecret(context, "openAiNativeApiKey", openAiNativeApiKey)
 	await storeSecret(context, "deepSeekApiKey", deepSeekApiKey)
 	await storeSecret(context, "requestyApiKey", requestyApiKey)

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -56,6 +56,7 @@ export interface ApiHandlerOptions {
 	lmStudioModelId?: string
 	lmStudioBaseUrl?: string
 	geminiApiKey?: string
+	geminiBaseUrl?: string
 	openAiNativeApiKey?: string
 	deepSeekApiKey?: string
 	requestyApiKey?: string

--- a/webview-ui/src/components/settings/ApiOptions.tsx
+++ b/webview-ui/src/components/settings/ApiOptions.tsx
@@ -97,6 +97,7 @@ const ApiOptions = ({ showModelOptions, apiErrorMessage, modelIdErrorMessage, is
 	const [lmStudioModels, setLmStudioModels] = useState<string[]>([])
 	const [vsCodeLmModels, setVsCodeLmModels] = useState<vscodemodels.LanguageModelChatSelector[]>([])
 	const [anthropicBaseUrlSelected, setAnthropicBaseUrlSelected] = useState(!!apiConfiguration?.anthropicBaseUrl)
+	const [geminiBaseUrlSelected, setGeminiBaseUrlSelected] = useState(!!apiConfiguration?.geminiBaseUrl)
 	const [azureApiVersionSelected, setAzureApiVersionSelected] = useState(!!apiConfiguration?.azureApiVersion)
 	const [awsEndpointSelected, setAwsEndpointSelected] = useState(!!apiConfiguration?.awsBedrockEndpoint)
 	const [modelConfigurationSelected, setModelConfigurationSelected] = useState(false)
@@ -778,6 +779,32 @@ const ApiOptions = ({ showModelOptions, apiErrorMessage, modelIdErrorMessage, is
 						placeholder="Enter API Key...">
 						<span style={{ fontWeight: 500 }}>Gemini API Key</span>
 					</VSCodeTextField>
+
+					<VSCodeCheckbox
+						checked={geminiBaseUrlSelected}
+						onChange={(e: any) => {
+							const isChecked = e.target.checked === true
+							setGeminiBaseUrlSelected(isChecked)
+							if (!isChecked) {
+								setApiConfiguration({
+									...apiConfiguration,
+									geminiBaseUrl: "",
+								})
+							}
+						}}>
+						Use custom base URL
+					</VSCodeCheckbox>
+
+					{geminiBaseUrlSelected && (
+						<VSCodeTextField
+							value={apiConfiguration?.geminiBaseUrl || ""}
+							style={{ width: "100%", marginTop: 3 }}
+							type="url"
+							onInput={handleInputChange("geminiBaseUrl")}
+							placeholder="Default: https://generativelanguage.googleapis.com"
+						/>
+					)}
+
 					<p
 						style={{
 							fontSize: "12px",


### PR DESCRIPTION
### Description

The patch allows to configure a baseURL for gemini

https://github.com/cline/cline/discussions/1389
### Test Procedure

I tested Cline with a gemini provider with and without the baseURL option activated and checked it worked thru an internal proxy when used and directly to google api when not.

When the option is not enabled the behavior will be 100% as before, and when it's activated it's using the the GenerativeAI api support of the baseURL.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

![image](https://github.com/user-attachments/assets/19e1a6cf-8a28-458a-8084-7aa4d87876e3)

### Additional Notes

When running tests I have this error, but I also have it on the main branch, so the patch did not bring any regression

```

  1 failing
  1) ModelContextTracker
       should throw an error when controller is dereferenced:

      AssertionError: expected 'Expected an error to be thrown' to equal 'Unable to access extension context'
      + expected - actual

      -Expected an error to be thrown
      +Unable to access extension context
      
        at Context.<anonymous> (out/core/context/context-tracking/ModelContextTracker.test.js:102:50)

1 test failed.
```

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add support for configuring a custom `baseUrl` for Gemini API requests, with UI and state management updates.
> 
>   - **Behavior**:
>     - Adds support for configuring a `baseUrl` for Gemini API requests in `gemini.ts`.
>     - When `geminiBaseUrl` is set, requests use the custom URL; otherwise, default behavior is maintained.
>   - **Configuration**:
>     - Updates `ApiHandlerOptions` in `api.ts` to include `geminiBaseUrl`.
>     - Adds `geminiBaseUrl` to global state management in `state.ts` and `state-keys.ts`.
>   - **UI**:
>     - Adds UI elements in `ApiOptions.tsx` to enable/disable and set a custom `baseUrl` for Gemini.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for f9ea279fe268bcb0b51d1f2c3eec1dedb312c1db. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->