### PR TITLE
chore: prompt cache up to the third-to-last message in the conversation history for claude

### DIFF
--- a/.changeset/ten-wasps-compete.md
+++ b/.changeset/ten-wasps-compete.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Cache prompts up to third-to-last message in Claude conversation history

--- a/src/api/providers/anthropic.ts
+++ b/src/api/providers/anthropic.ts
@@ -34,7 +34,7 @@ export class AnthropicHandler implements ApiHandler {
 			case "claude-3-opus-20240229":
 			case "claude-3-haiku-20240307": {
 				/*
-				The latest message will be the new user message, one before will be the assistant message from a previous request, and the user message before that will be a previously cached user message. So we need to mark the latest user message as ephemeral to cache it for the next request, and mark the second ant the third to last user message as ephemeral to let the server know the last message to retrieve from the cache for the current request..
+				The latest message will be the new user message, one before will be the assistant message from a previous request, and the user message before that will be a previously cached user message. So we need to mark the latest user message as ephemeral to cache it for the next request, and mark the second and the third to last user message as ephemeral to let the server know the last message to retrieve from the cache for the current request..
 				*/
 				const userMsgIndices = messages.reduce(
 					(acc, msg, index) => (msg.role === "user" ? [...acc, index] : acc),

--- a/src/api/providers/anthropic.ts
+++ b/src/api/providers/anthropic.ts
@@ -59,7 +59,11 @@ export class AnthropicHandler implements ApiHandler {
 							},
 						], // setting cache breakpoint for system prompt so new tasks can reuse it
 						messages: messages.map((message, index) => {
-							if (index === lastUserMsgIndex || index === secondLastMsgUserIndex || index === thirdLastMsgUserIndex) {
+							if (
+								index === lastUserMsgIndex ||
+								index === secondLastMsgUserIndex ||
+								index === thirdLastMsgUserIndex
+							) {
 								return {
 									...message,
 									content:

--- a/src/api/providers/anthropic.ts
+++ b/src/api/providers/anthropic.ts
@@ -34,7 +34,7 @@ export class AnthropicHandler implements ApiHandler {
 			case "claude-3-opus-20240229":
 			case "claude-3-haiku-20240307": {
 				/*
-				The latest message will be the new user message, one before will be the assistant message from a previous request, and the user message before that will be a previously cached user message. So we need to mark the latest user message as ephemeral to cache it for the next request, and mark the second to last user message as ephemeral to let the server know the last message to retrieve from the cache for the current request..
+				The latest message will be the new user message, one before will be the assistant message from a previous request, and the user message before that will be a previously cached user message. So we need to mark the latest user message as ephemeral to cache it for the next request, and mark the second ant the third to last user message as ephemeral to let the server know the last message to retrieve from the cache for the current request..
 				*/
 				const userMsgIndices = messages.reduce(
 					(acc, msg, index) => (msg.role === "user" ? [...acc, index] : acc),
@@ -42,6 +42,7 @@ export class AnthropicHandler implements ApiHandler {
 				)
 				const lastUserMsgIndex = userMsgIndices[userMsgIndices.length - 1] ?? -1
 				const secondLastMsgUserIndex = userMsgIndices[userMsgIndices.length - 2] ?? -1
+				const thirdLastMsgUserIndex = userMsgIndices[userMsgIndices.length - 3] ?? -1
 				stream = await this.client.messages.create(
 					{
 						model: modelId,
@@ -58,7 +59,7 @@ export class AnthropicHandler implements ApiHandler {
 							},
 						], // setting cache breakpoint for system prompt so new tasks can reuse it
 						messages: messages.map((message, index) => {
-							if (index === lastUserMsgIndex || index === secondLastMsgUserIndex) {
+							if (index === lastUserMsgIndex || index === secondLastMsgUserIndex || index === thirdLastMsgUserIndex) {
 								return {
 									...message,
 									content:

--- a/src/api/providers/bedrock.ts
+++ b/src/api/providers/bedrock.ts
@@ -47,6 +47,7 @@ export class AwsBedrockHandler implements ApiHandler {
 		const userMsgIndices = messages.reduce((acc, msg, index) => (msg.role === "user" ? [...acc, index] : acc), [] as number[])
 		const lastUserMsgIndex = userMsgIndices[userMsgIndices.length - 1] ?? -1
 		const secondLastMsgUserIndex = userMsgIndices[userMsgIndices.length - 2] ?? -1
+		const thirdLastMsgUserIndex = userMsgIndices[userMsgIndices.length - 3] ?? -1
 
 		// Create anthropic client, using sessions created or renewed after this handler's
 		// initialization, and allowing for session renewal if necessary as well
@@ -67,7 +68,7 @@ export class AwsBedrockHandler implements ApiHandler {
 				},
 			],
 			messages: messages.map((message, index) => {
-				if (index === lastUserMsgIndex || index === secondLastMsgUserIndex) {
+				if (index === lastUserMsgIndex || index === secondLastMsgUserIndex || index === thirdLastMsgUserIndex) {
 					return {
 						...message,
 						content:


### PR DESCRIPTION
### Description

<!-- Describe your changes in detail. What problem does this PR solve? -->

According to [the documentation](https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching), cache_control can be set for up to 4. Currently, we are caching the system prompt and the last 2 messages. If I understand correctly, since we're not using tools, we can cache up to the last 3 messages in the conversation history.

>Using the cache_control parameter, you can define up to 4 cache breakpoints,

### Test Procedure

<!-- How did you test this? Are you confident that it will not introduce bugs? If so, why? -->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [x] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update caching logic in `anthropic.ts` and `bedrock.ts` to cache up to the third-to-last user message for specific model IDs.
> 
>   - **Behavior**:
>     - Update caching logic in `createMessage()` in `anthropic.ts` and `bedrock.ts` to cache up to the third-to-last user message.
>     - Applies to model IDs: `claude-3-opus-20240229`, `claude-3-haiku-20240307`, and others.
>   - **Implementation**:
>     - Add `thirdLastMsgUserIndex` to track third-to-last user message.
>     - Modify message mapping to include `thirdLastMsgUserIndex` in ephemeral cache control logic.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 676df137361d9425bb3db054c1f4a5fa07ba2dbe. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->