### PR TITLE
fix (workspace tracker): Replace the workspace events with a FileSystemWatcher

### DIFF
--- a/.changeset/kind-carrots-breathe.md
+++ b/.changeset/kind-carrots-breathe.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Replace the WorkspaceTracker with a FileSystemWatcher

--- a/src/integrations/workspace/WorkspaceTracker.test.ts
+++ b/src/integrations/workspace/WorkspaceTracker.test.ts
@@ -1,0 +1,191 @@
+import path from "path"
+import os from "os"
+import fs from "fs/promises"
+
+import { after, describe, it, beforeEach, before } from "mocha"
+import { expect } from "chai"
+import sinon from "sinon"
+
+import * as vscode from "vscode"
+import WorkspaceTracker from "./WorkspaceTracker"
+import { shouldTrackFile } from "../../services/glob/list-files"
+
+const timeout = () => {
+	return new Promise((_, reject) => setTimeout(() => reject(new Error("Timeout")), 1000))
+}
+
+describe("WorkspaceTracker", () => {
+	describe("file system watcher", () => {
+		const tmpDir = path.join(os.tmpdir(), "cline-test-" + Math.random().toString(36).slice(2))
+
+		let filePaths: string[] = []
+		let workspaceTracker: WorkspaceTracker
+		let sandbox: sinon.SinonSandbox
+
+		// Wait for the fileSystemWatcher event trigger
+		let fileSystemWatcherWaiter: Array<() => void> = []
+
+		const waitForFileChange = async (operation?: () => Promise<unknown> | Thenable<void>) => {
+			const promise = new Promise<void>((res) => {
+				fileSystemWatcherWaiter.push(res)
+			})
+
+			if (operation) {
+				await operation()
+			}
+
+			return Promise.race([promise, timeout()])
+		}
+
+		before(async () => {
+			await fs.mkdir(tmpDir, { recursive: true })
+			// If we don't wait for the directory to be created,
+			// the fileSystemWatcher might send the event while we are waiting for another file operation
+			// which will resolve the promise before we intend and fail the tests.
+			await new Promise((res) => setTimeout(res, 500))
+		})
+
+		beforeEach(() => {
+			sandbox = sinon.createSandbox()
+
+			sandbox.stub(vscode.workspace, "workspaceFolders").value([
+				{
+					name: "Test Workspace",
+					uri: vscode.Uri.from({
+						scheme: "file",
+						path: tmpDir,
+					}),
+				},
+			])
+
+			filePaths = []
+			workspaceTracker = new WorkspaceTracker(async (message) => {
+				filePaths = message.filePaths || []
+
+				if (fileSystemWatcherWaiter.length > 0) {
+					const resolve = fileSystemWatcherWaiter.shift()
+					resolve?.()
+				}
+			})
+		})
+
+		afterEach(() => {
+			workspaceTracker.dispose()
+			sandbox.restore()
+		})
+
+		// Clean up after tests
+		after(async () => {
+			try {
+				await fs.rm(tmpDir, { recursive: true, force: true })
+			} catch {
+				// Ignore cleanup errors
+			}
+		})
+
+		it("should keep the filePaths updated", async () => {
+			const testFile = path.join(tmpDir, "test.txt")
+			const fileThroughVSActions = path.join(tmpDir, "test2.txt")
+
+			await waitForFileChange(() => fs.writeFile(testFile, "test"))
+			await waitForFileChange(() =>
+				vscode.workspace.fs.writeFile(vscode.Uri.file(fileThroughVSActions), new TextEncoder().encode("test")),
+			)
+
+			expect(filePaths).to.contain("test.txt")
+			expect(filePaths).to.contain("test2.txt")
+
+			await waitForFileChange(() => fs.unlink(testFile))
+
+			expect(filePaths).to.not.contain("test.txt")
+			expect(filePaths).to.contain("test2.txt")
+		})
+
+		describe("when it has subdirectories", () => {
+			it("should remove all files when deleting a directory", async () => {
+				const subDir = path.join(tmpDir, "test")
+				const testFile = path.join(subDir, "test.txt")
+				const similarlyNamedFile = path.join(tmpDir, "test.js")
+
+				await waitForFileChange(() => fs.mkdir(subDir))
+				await waitForFileChange(() => fs.writeFile(testFile, "test"))
+				await waitForFileChange(() => fs.writeFile(similarlyNamedFile, "test"))
+
+				expect(filePaths).to.contain("test/test.txt")
+				expect(filePaths).to.contain("test/")
+				expect(filePaths).to.contain("test.js")
+
+				await waitForFileChange(() => fs.rm(subDir, { recursive: true, force: true }))
+
+				expect(filePaths).to.not.contain("test/test.txt")
+				expect(filePaths).to.not.contain("test/")
+				expect(filePaths).to.contain("test.js")
+			})
+		})
+
+		describe("when renaming", () => {
+			const renameOperation = async (oldPath: string, newPath: string) => {
+				// Renames trigger a deletion and a creation event. This will ensure we wait for both.
+				const createOperation = waitForFileChange()
+				const deleteOperation = waitForFileChange(() => fs.rename(oldPath, newPath))
+				return Promise.all([createOperation, deleteOperation])
+			}
+
+			it("should update file paths", async () => {
+				const testFile = path.join(tmpDir, "test.txt")
+				const renamedFile = path.join(tmpDir, "renamed.txt")
+
+				await waitForFileChange(() => fs.writeFile(testFile, "test"))
+				await renameOperation(testFile, renamedFile)
+
+				expect(filePaths).to.contain("renamed.txt")
+				expect(filePaths).to.not.contain("test.txt")
+			})
+
+			it("should update all files within a directory when renaming it", async () => {
+				const subDir = path.join(tmpDir, "test_rename")
+				const testFile = path.join(subDir, "test.txt")
+				const renamedDir = path.join(tmpDir, "renamed")
+
+				await waitForFileChange(() => fs.mkdir(subDir))
+				await waitForFileChange(() => fs.writeFile(testFile, "test"))
+				await renameOperation(subDir, renamedDir)
+
+				expect(filePaths).to.contain("renamed/")
+				expect(filePaths).to.contain("renamed/test.txt")
+				expect(filePaths).to.not.contain("test_rename/test.txt")
+			})
+		})
+	})
+
+	describe("should ignore files", () => {
+		const directories = ["node_modules", "__pycache__", "env"]
+		it("ignores directories in the root of the workspace", () => {
+			directories.forEach((dir) => {
+				expect(shouldTrackFile(dir)).to.be.false
+			})
+		})
+
+		it("ignores files within those directories", () => {
+			directories.forEach((dir) => {
+				expect(shouldTrackFile(`${dir}/test.txt`)).to.be.false
+			})
+		})
+
+		it("ignores nested ignored directories", () => {
+			expect(shouldTrackFile("test")).to.be.true
+
+			directories.forEach((dir) => {
+				expect(shouldTrackFile("test/" + dir)).to.be.false
+			})
+		})
+
+		it("ignores files in hidden directories", () => {
+			const directories = [".git", ".vscode", ".env"]
+
+			directories.forEach((dir) => {
+				expect(shouldTrackFile(`${dir}/test.txt`)).to.be.false
+			})
+		})
+	})
+})

--- a/src/integrations/workspace/WorkspaceTracker.ts
+++ b/src/integrations/workspace/WorkspaceTracker.ts
@@ -1,14 +1,15 @@
 import * as vscode from "vscode"
 import * as path from "path"
-import { listFiles } from "@services/glob/list-files"
+import { listFiles, shouldTrackFile } from "@services/glob/list-files"
 import { ExtensionMessage } from "@shared/ExtensionMessage"
-
-const cwd = vscode.workspace.workspaceFolders?.map((folder) => folder.uri.fsPath).at(0)
 
 // Note: this is not a drop-in replacement for listFiles at the start of tasks, since that will be done for Desktops when there is no workspace selected
 class WorkspaceTracker {
 	private disposables: vscode.Disposable[] = []
 	private filePaths: Set<string> = new Set()
+
+	private readonly workspaceFolder = vscode.workspace.workspaceFolders?.[0]
+	private readonly cwd = this.workspaceFolder?.uri.fsPath
 
 	constructor(private readonly postMessageToWebview: (message: ExtensionMessage) => Promise<void>) {
 		this.postMessageToWebview = postMessageToWebview
@@ -17,24 +18,45 @@ class WorkspaceTracker {
 
 	async populateFilePaths() {
 		// should not auto get filepaths for desktop since it would immediately show permission popup before cline ever creates a file
-		if (!cwd) {
+		if (!this.cwd) {
 			return
 		}
-		const [files, _] = await listFiles(cwd, true, 1_000)
+		const [files, _] = await listFiles(this.cwd, true, 1_000)
 		files.forEach((file) => this.filePaths.add(this.normalizeFilePath(file)))
 		this.workspaceDidUpdate()
 	}
 
 	private registerListeners() {
-		// Listen for file creation
-		// .bind(this) ensures the callback refers to class instance when using this, not necessary when using arrow function
-		this.disposables.push(vscode.workspace.onDidCreateFiles(this.onFilesCreated.bind(this)))
+		if (!this.workspaceFolder) {
+			return
+		}
 
-		// Listen for file deletion
-		this.disposables.push(vscode.workspace.onDidDeleteFiles(this.onFilesDeleted.bind(this)))
+		/*
+		  Watch for new and deleted files within the workspace. 
+ 		  We are not concerned about the contents of the files here, 
+ 		  but about files that should be listed to the user.
+		  
+		  We use a globstar because the vscode glob pattern is somewhat particular:
+		  https://code.visualstudio.com/api/references/vscode-api#GlobPattern
+		  And they don't support ignore patterns yet:
+		  https://github.com/microsoft/vscode/issues/169724#issuecomment-2530442986
+		*/
+		const watcher = vscode.workspace.createFileSystemWatcher(
+			new vscode.RelativePattern(this.workspaceFolder, "**"),
+			// Do not ignore create events
+			false,
+			// Ignore update events
+			true,
+			// Do not ignore delete events
+			false,
+		)
 
-		// Listen for file renaming
-		this.disposables.push(vscode.workspace.onDidRenameFiles(this.onFilesRenamed.bind(this)))
+		this.disposables.push(
+			watcher,
+			// .bind(this) ensures the callback refers to class instance when using this, not necessary when using arrow function
+			watcher.onDidCreate(this.onFileCreated.bind(this)),
+			watcher.onDidDelete(this.onFileDeleted.bind(this)),
+		)
 
 		/*
 		 An event that is emitted when a workspace folder is added or removed.
@@ -47,43 +69,24 @@ class WorkspaceTracker {
 		// this.disposables.push(vscode.workspace.onDidChangeWorkspaceFolders(this.onWorkspaceFoldersChanged.bind(this)))
 	}
 
-	private async onFilesCreated(event: vscode.FileCreateEvent) {
-		await Promise.all(
-			event.files.map(async (file) => {
-				await this.addFilePath(file.fsPath)
-			}),
-		)
-		this.workspaceDidUpdate()
-	}
-
-	private async onFilesDeleted(event: vscode.FileDeleteEvent) {
-		let updated = false
-		await Promise.all(
-			event.files.map(async (file) => {
-				if (await this.removeFilePath(file.fsPath)) {
-					updated = true
-				}
-			}),
-		)
-		if (updated) {
+	private async onFileCreated(uri: vscode.Uri) {
+		if (await this.addFilePath(uri.fsPath)) {
 			this.workspaceDidUpdate()
 		}
 	}
 
-	private async onFilesRenamed(event: vscode.FileRenameEvent) {
-		await Promise.all(
-			event.files.map(async (file) => {
-				await this.removeFilePath(file.oldUri.fsPath)
-				await this.addFilePath(file.newUri.fsPath)
-			}),
-		)
-		this.workspaceDidUpdate()
+	private async onFileDeleted(uri: vscode.Uri) {
+		if (await this.removeFilePath(uri.fsPath)) {
+			this.workspaceDidUpdate()
+		}
 	}
 
 	private workspaceDidUpdate() {
+		const cwd = this.cwd
 		if (!cwd) {
 			return
 		}
+
 		this.postMessageToWebview({
 			type: "workspaceUpdated",
 			filePaths: Array.from(this.filePaths).map((file) => {
@@ -94,15 +97,28 @@ class WorkspaceTracker {
 	}
 
 	private normalizeFilePath(filePath: string): string {
-		const resolvedPath = cwd ? path.resolve(cwd, filePath) : path.resolve(filePath)
+		const resolvedPath = this.cwd ? path.resolve(this.cwd, filePath) : path.resolve(filePath)
 		return filePath.endsWith("/") ? resolvedPath + "/" : resolvedPath
 	}
 
-	private async addFilePath(filePath: string): Promise<string> {
+	private async addFilePath(filePath: string): Promise<string | boolean> {
 		const normalizedPath = this.normalizeFilePath(filePath)
+
+		if (!this.cwd || !shouldTrackFile(path.relative(this.cwd, normalizedPath))) {
+			return false
+		}
+
 		try {
 			const stat = await vscode.workspace.fs.stat(vscode.Uri.file(normalizedPath))
 			const isDirectory = (stat.type & vscode.FileType.Directory) !== 0
+
+			if (isDirectory) {
+				// Renaming a directory doesn't trigger events for files within it
+				// If it has files, we need to add them to the list
+				const [files, _] = await listFiles(normalizedPath, true, 1_000)
+				files.forEach((file) => this.filePaths.add(this.normalizeFilePath(file)))
+			}
+
 			const pathWithSlash = isDirectory && !normalizedPath.endsWith("/") ? normalizedPath + "/" : normalizedPath
 			this.filePaths.add(pathWithSlash)
 			return pathWithSlash
@@ -115,6 +131,24 @@ class WorkspaceTracker {
 
 	private async removeFilePath(filePath: string): Promise<boolean> {
 		const normalizedPath = this.normalizeFilePath(filePath)
+
+		/* 
+		  When deleting a directory recursively, we will receive a single event for the directory itself.
+		  Consequently, we need to remove files from that directory manually.
+		  We can't check the stats to determine if it was a directory because it no longer exists.
+		  However, since we store the directory paths with a slash,
+		  we can check for that instead.
+		*/
+		if (this.filePaths.has(normalizedPath + "/")) {
+			this.filePaths.forEach((filePath) => {
+				if (filePath.startsWith(normalizedPath + "/")) {
+					this.filePaths.delete(filePath)
+				}
+			})
+
+			return true
+		}
+
 		return this.filePaths.delete(normalizedPath) || this.filePaths.delete(normalizedPath + "/")
 	}
 

--- a/src/packages/globby.ts
+++ b/src/packages/globby.ts
@@ -1,0 +1,1 @@
+export { globby } from "globby"

--- a/src/services/glob/list-files.ts
+++ b/src/services/glob/list-files.ts
@@ -1,7 +1,8 @@
-import { globby, Options } from "globby"
+import { type Options } from "globby"
 import os from "os"
 import * as path from "path"
 import ignore from "ignore"
+import { globby } from "@packages/globby"
 import { arePathsEqual } from "@utils/path"
 
 const dirsToIgnore = [

--- a/src/services/glob/list-files.ts
+++ b/src/services/glob/list-files.ts
@@ -16,7 +16,6 @@ const dirsToIgnore = [
 	"out",
 	"bundle",
 	"vendor",
-	"temp",
 	"deps",
 	"pkg",
 	"Pods",

--- a/src/services/glob/list-files.ts
+++ b/src/services/glob/list-files.ts
@@ -16,7 +16,6 @@ const dirsToIgnore = [
 	"out",
 	"bundle",
 	"vendor",
-	"tmp",
 	"temp",
 	"deps",
 	"pkg",

--- a/src/services/glob/list-files.ts
+++ b/src/services/glob/list-files.ts
@@ -1,7 +1,34 @@
 import { globby, Options } from "globby"
 import os from "os"
 import * as path from "path"
+import ignore from "ignore"
 import { arePathsEqual } from "@utils/path"
+
+const dirsToIgnore = [
+	"node_modules",
+	"__pycache__",
+	"env",
+	"venv",
+	"target/dependency",
+	"build/dependencies",
+	"dist",
+	"out",
+	"bundle",
+	"vendor",
+	"tmp",
+	"temp",
+	"deps",
+	"pkg",
+	"Pods",
+	".*", // '!**/.*' excludes hidden directories, while '!**/.*/**' excludes only their contents. This way we are at least aware of the existence of hidden directories.
+]
+
+const ignoreInstance = ignore().add(dirsToIgnore)
+
+// TODO: Consider .clineignore (ClineIgnoreController) and .gitignore
+export const shouldTrackFile = (filePath: string): boolean => {
+	return !ignoreInstance.ignores(filePath)
+}
 
 export async function listFiles(dirPath: string, recursive: boolean, limit: number): Promise<[string[], boolean]> {
 	// First resolve the path normally - path.resolve doesn't care about glob special characters
@@ -18,32 +45,13 @@ export async function listFiles(dirPath: string, recursive: boolean, limit: numb
 		return [[homeDir], false]
 	}
 
-	const dirsToIgnore = [
-		"node_modules",
-		"__pycache__",
-		"env",
-		"venv",
-		"target/dependency",
-		"build/dependencies",
-		"dist",
-		"out",
-		"bundle",
-		"vendor",
-		"tmp",
-		"temp",
-		"deps",
-		"pkg",
-		"Pods",
-		".*", // '!**/.*' excludes hidden directories, while '!**/.*/**' excludes only their contents. This way we are at least aware of the existence of hidden directories.
-	].map((dir) => `**/${dir}/**`)
-
 	const options: Options = {
 		cwd: dirPath,
 		dot: true, // do not ignore hidden files/directories
 		absolute: true,
 		markDirectories: true, // Append a / on any directories matched (/ is used on windows as well, so dont use path.sep)
 		gitignore: recursive, // globby ignores any files that are gitignored
-		ignore: recursive ? dirsToIgnore : undefined, // just in case there is no gitignore, we ignore sensible defaults
+		ignore: recursive ? dirsToIgnore.map((dir) => `**/${dir}/**`) : undefined, // just in case there is no gitignore, we ignore sensible defaults
 		onlyFiles: false, // true by default, false means it will list directories on their own too
 		suppressErrors: true,
 	}


### PR DESCRIPTION
### Description

This is a fix for #1340. Following @albemala's [idea](https://github.com/cline/cline/issues/1340#issuecomment-2788491117), I am replacing the workspace events used in the `WorkspaceTracker` with a `FileSystemWatcher` which reacts to any events within the workspace instead of only user actions.
The `FileSystemWatcher` is somewhat particular, so I am using `ignore` to ignore the files not returned by `listItems`. I want to use the `ClineIgnoreController` but it requires reorganizing things a bit, so I preferred to limit this PR and follow up with the replacement.

### Test Procedure

I added integration tests for the changes. I also tested the changes locally, creating files using a `node` and `bash`, and making sure the webview got the updates.
If you want to change these changes by yourself, you can run the extension locally and play around with the mentions menu while modifying files outside of VSCode. For example:
1. `mkdir test`
2. Type `@` and navigate to the `Add Folder` section
3. Verify `/test/` is there
4. `touch test/test.txt`
5. Type `@` and navigate to the `Add File` section
6. Verify `test/test.txt` is there.

You can then verify the file and directory are removed when deleting `test` through VSCode or the terminal.


### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [x] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Additional Notes

~I've noticed certain flakiness in the tests, which seems to be related with the timing requirements. It's infrequent enough where I am confident on the tests, but I will fix it soon.~
[Fixed](https://github.com/cline/cline/pull/2869/commits/0c2a4a370b46df5f870f601303cd45d89e285f0b)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Replaces `WorkspaceTracker` with `FileSystemWatcher` to handle workspace file events and adds tests for new functionality.
> 
>   - **Behavior**:
>     - Replaces `WorkspaceTracker` with `FileSystemWatcher` in `WorkspaceTracker.ts` to handle all file events in the workspace.
>     - Uses `shouldTrackFile` to ignore specific directories and files, such as `node_modules` and hidden directories.
>   - **Tests**:
>     - Adds `WorkspaceTracker.test.ts` to test file creation, deletion, and ignored files.
>     - Tests ensure `filePaths` are updated correctly and ignored directories are not tracked.
>   - **Misc**:
>     - Refactors `list-files.ts` to include `shouldTrackFile` function for file ignoring logic.
>     - Removes old event listeners for file creation, deletion, and renaming in `WorkspaceTracker.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 0a0681d21e79e09094d5eff510804819093b40f5. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->