### PR TITLE
refactor: type improvements of multi files that doesn't modify functionality

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -381,7 +381,7 @@ export function activate(context: vscode.ExtensionContext) {
 
 	// Register the command handler
 	context.subscriptions.push(
-		vscode.commands.registerCommand("cline.fixWithCline", async (range: vscode.Range, diagnostics: any[]) => {
+		vscode.commands.registerCommand("cline.fixWithCline", async (range: vscode.Range, diagnostics: vscode.Diagnostic[]) => {
 			const editor = vscode.window.activeTextEditor
 			if (!editor) {
 				return

--- a/src/services/telemetry/TelemetryService.ts
+++ b/src/services/telemetry/TelemetryService.ts
@@ -3,6 +3,7 @@ import * as vscode from "vscode"
 import { version as extensionVersion } from "../../../package.json"
 
 import type { TaskFeedbackType } from "../../shared/WebviewMessage"
+import type { BrowserSettings } from "../../shared/BrowserSettings"
 
 /**
  * PostHogClient handles telemetry event tracking for the Cline extension
@@ -474,7 +475,7 @@ class PostHogClient {
 	 * @param taskId Unique identifier for the task
 	 * @param browserSettings The browser settings being used
 	 */
-	public captureBrowserToolStart(taskId: string, browserSettings: any) {
+	public captureBrowserToolStart(taskId: string, browserSettings: BrowserSettings) {
 		this.capture({
 			event: PostHogClient.EVENTS.TASK.BROWSER_TOOL_START,
 			properties: {

--- a/webview-ui/src/components/common/MarkdownBlock.tsx
+++ b/webview-ui/src/components/common/MarkdownBlock.tsx
@@ -4,6 +4,7 @@ import { useRemark } from "react-remark"
 import rehypeHighlight, { Options } from "rehype-highlight"
 import styled from "styled-components"
 import { visit } from "unist-util-visit"
+import type { Node } from "unist"
 import { useExtensionState } from "@/context/ExtensionStateContext"
 import { CODE_BLOCK_BG_COLOR } from "@/components/common/CodeBlock"
 import MermaidBlock from "@/components/common/MermaidBlock"
@@ -21,7 +22,7 @@ interface MarkdownBlockProps {
  * This caused the entire content to disappear because the structure became invalid.
  */
 const remarkUrlToLink = () => {
-	return (tree: any) => {
+	return (tree: Node) => {
 		// Visit all "text" nodes in the markdown AST (Abstract Syntax Tree)
 		visit(tree, "text", (node: any, index, parent) => {
 			const urlRegex = /https?:\/\/[^\s<>)"]+/g

--- a/webview-ui/src/context/ExtensionStateContext.tsx
+++ b/webview-ui/src/context/ExtensionStateContext.tsx
@@ -21,7 +21,7 @@ import { TelemetrySetting } from "@shared/TelemetrySetting"
 interface ExtensionStateContextType extends ExtensionState {
 	didHydrateState: boolean
 	showWelcome: boolean
-	theme: any
+	theme: Record<string, string> | undefined
 	openRouterModels: Record<string, ModelInfo>
 	openAiModels: string[]
 	requestyModels: Record<string, ModelInfo>
@@ -56,7 +56,7 @@ export const ExtensionStateContextProvider: React.FC<{
 	})
 	const [didHydrateState, setDidHydrateState] = useState(false)
 	const [showWelcome, setShowWelcome] = useState(false)
-	const [theme, setTheme] = useState<any>(undefined)
+	const [theme, setTheme] = useState<Record<string, string>>()
 	const [filePaths, setFilePaths] = useState<string[]>([])
 	const [openRouterModels, setOpenRouterModels] = useState<Record<string, ModelInfo>>({
 		[openRouterDefaultModelId]: openRouterDefaultModelInfo,

--- a/webview-ui/src/utils/useDebounceEffect.ts
+++ b/webview-ui/src/utils/useDebounceEffect.ts
@@ -1,4 +1,5 @@
 import { useEffect, useRef } from "react"
+import type { DependencyList } from "react"
 
 type VoidFn = () => void
 
@@ -6,7 +7,7 @@ type VoidFn = () => void
  * Runs `effectRef.current()` after `delay` ms whenever any of the `deps` change,
  * but cancels/re-schedules if they change again before the delay.
  */
-export function useDebounceEffect(effect: VoidFn, delay: number, deps: any[]) {
+export function useDebounceEffect(effect: VoidFn, delay: number, deps: DependencyList) {
 	const callbackRef = useRef<VoidFn>(effect)
 	const timeoutRef = useRef<NodeJS.Timeout | null>(null)
 


### PR DESCRIPTION
### Description

refactor: type improvements of multi files that doesn't modify functionality

### Test Procedure

`npm run test`

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [x] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Refactor to improve type definitions across multiple files without altering functionality.
> 
>   - **Type Improvements**:
>     - Change `diagnostics` type from `any[]` to `vscode.Diagnostic[]` in `registerCommand` in `extension.ts`.
>     - Change `browserSettings` type from `any` to `BrowserSettings` in `captureBrowserToolStart()` in `TelemetryService.ts`.
>     - Change `tree` type from `any` to `Node` in `remarkUrlToLink()` in `MarkdownBlock.tsx`.
>     - Change `theme` type from `any` to `Record<string, string> | undefined` in `ExtensionStateContext.tsx`.
>     - Change `deps` type from `any[]` to `DependencyList` in `useDebounceEffect()` in `useDebounceEffect.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for e27aa22e5d385e51fcc04fed3cacd0d3a1822efe. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->