### PR TITLE
Add gpt-4.1

### DIFF
--- a/.changeset/eighty-carpets-attack.md
+++ b/.changeset/eighty-carpets-attack.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Add gpt-4.1

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -604,8 +604,32 @@ export const geminiModels = {
 // OpenAI Native
 // https://openai.com/api/pricing/
 export type OpenAiNativeModelId = keyof typeof openAiNativeModels
-export const openAiNativeDefaultModelId: OpenAiNativeModelId = "gpt-4o"
+export const openAiNativeDefaultModelId: OpenAiNativeModelId = "gpt-4.1"
 export const openAiNativeModels = {
+	"gpt-4.1": {
+		maxTokens: 32_768,
+		contextWindow: 1_047_576,
+		supportsImages: true,
+		supportsPromptCache: true,
+		inputPrice: 2,
+		outputPrice: 8,
+	},
+	"gpt-4.1-mini": {
+		maxTokens: 32_768,
+		contextWindow: 1_047_576,
+		supportsImages: true,
+		supportsPromptCache: true,
+		inputPrice: 0.4,
+		outputPrice: 1.6,
+	},
+	"gpt-4.1-nano": {
+		maxTokens: 32_768,
+		contextWindow: 1_047_576,
+		supportsImages: true,
+		supportsPromptCache: true,
+		inputPrice: 0.1,
+		outputPrice: 0.4,
+	},
 	"o3-mini": {
 		maxTokens: 100_000,
 		contextWindow: 200_000,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `gpt-4.1`, `gpt-4.1-mini`, and `gpt-4.1-nano` models to OpenAI Native and update default model ID to `gpt-4.1` in `api.ts`.
> 
>   - **Models**:
>     - Add `gpt-4.1`, `gpt-4.1-mini`, and `gpt-4.1-nano` to `openAiNativeModels` in `api.ts` with attributes: `maxTokens: 32,768`, `contextWindow: 1,047,576`, `supportsImages: true`, `supportsPromptCache: true`, and specific pricing.
>     - Update `openAiNativeDefaultModelId` from `gpt-4o` to `gpt-4.1` in `api.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 9c22bf0f2c5c69817445dca5cf1844e682fb9145. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->