### PR TITLE
Revert "chore: prompt cache up to the third-to-last message in the conversation history for claude"

### DIFF
--- a/.changeset/ten-wasps-compete.md
+++ b/.changeset/ten-wasps-compete.md
@@ -1,5 +1,0 @@
----
-"claude-dev": patch
----
-
-Cache prompts up to third-to-last message in Claude conversation history

--- a/src/api/providers/anthropic.ts
+++ b/src/api/providers/anthropic.ts
@@ -34,7 +34,7 @@ export class AnthropicHandler implements ApiHandler {
 			case "claude-3-opus-20240229":
 			case "claude-3-haiku-20240307": {
 				/*
-				The latest message will be the new user message, one before will be the assistant message from a previous request, and the user message before that will be a previously cached user message. So we need to mark the latest user message as ephemeral to cache it for the next request, and mark the second and the third to last user message as ephemeral to let the server know the last message to retrieve from the cache for the current request..
+				The latest message will be the new user message, one before will be the assistant message from a previous request, and the user message before that will be a previously cached user message. So we need to mark the latest user message as ephemeral to cache it for the next request, and mark the second to last user message as ephemeral to let the server know the last message to retrieve from the cache for the current request..
 				*/
 				const userMsgIndices = messages.reduce(
 					(acc, msg, index) => (msg.role === "user" ? [...acc, index] : acc),
@@ -42,7 +42,6 @@ export class AnthropicHandler implements ApiHandler {
 				)
 				const lastUserMsgIndex = userMsgIndices[userMsgIndices.length - 1] ?? -1
 				const secondLastMsgUserIndex = userMsgIndices[userMsgIndices.length - 2] ?? -1
-				const thirdLastMsgUserIndex = userMsgIndices[userMsgIndices.length - 3] ?? -1
 				stream = await this.client.messages.create(
 					{
 						model: modelId,
@@ -59,11 +58,7 @@ export class AnthropicHandler implements ApiHandler {
 							},
 						], // setting cache breakpoint for system prompt so new tasks can reuse it
 						messages: messages.map((message, index) => {
-							if (
-								index === lastUserMsgIndex ||
-								index === secondLastMsgUserIndex ||
-								index === thirdLastMsgUserIndex
-							) {
+							if (index === lastUserMsgIndex || index === secondLastMsgUserIndex) {
 								return {
 									...message,
 									content:

--- a/src/api/providers/bedrock.ts
+++ b/src/api/providers/bedrock.ts
@@ -47,7 +47,6 @@ export class AwsBedrockHandler implements ApiHandler {
 		const userMsgIndices = messages.reduce((acc, msg, index) => (msg.role === "user" ? [...acc, index] : acc), [] as number[])
 		const lastUserMsgIndex = userMsgIndices[userMsgIndices.length - 1] ?? -1
 		const secondLastMsgUserIndex = userMsgIndices[userMsgIndices.length - 2] ?? -1
-		const thirdLastMsgUserIndex = userMsgIndices[userMsgIndices.length - 3] ?? -1
 
 		// Create anthropic client, using sessions created or renewed after this handler's
 		// initialization, and allowing for session renewal if necessary as well
@@ -68,7 +67,7 @@ export class AwsBedrockHandler implements ApiHandler {
 				},
 			],
 			messages: messages.map((message, index) => {
-				if (index === lastUserMsgIndex || index === secondLastMsgUserIndex || index === thirdLastMsgUserIndex) {
+				if (index === lastUserMsgIndex || index === secondLastMsgUserIndex) {
 					return {
 						...message,
 						content:


### PR DESCRIPTION
Reverts cline/cline#2847
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Reverts caching logic to only consider the last and second-to-last user messages in `anthropic.ts` and `bedrock.ts`, removing third-to-last message handling.
> 
>   - **Behavior**:
>     - Reverts caching logic to only consider the last and second-to-last user messages in `AnthropicHandler` in `anthropic.ts` and `AwsBedrockHandler` in `bedrock.ts`.
>     - Updates comments to reflect the reverted caching logic.
>   - **Misc**:
>     - Deletes `.changeset/ten-wasps-compete.md` as it is no longer relevant.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 644f91c1782d78d302fe1ba434bfc44491cf75e3. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->