### PR TITLE
fix(api): update cacheReadsPrice for OpenAI GPT-4.1 models

### DIFF
--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -613,6 +613,7 @@ export const openAiNativeModels = {
 		supportsPromptCache: true,
 		inputPrice: 2,
 		outputPrice: 8,
+		cacheReadsPrice: 0.5,
 	},
 	"gpt-4.1-mini": {
 		maxTokens: 32_768,
@@ -621,6 +622,7 @@ export const openAiNativeModels = {
 		supportsPromptCache: true,
 		inputPrice: 0.4,
 		outputPrice: 1.6,
+		cacheReadsPrice: 0.1,
 	},
 	"gpt-4.1-nano": {
 		maxTokens: 32_768,
@@ -629,6 +631,7 @@ export const openAiNativeModels = {
 		supportsPromptCache: true,
 		inputPrice: 0.1,
 		outputPrice: 0.4,
+		cacheReadsPrice: 0.025,
 	},
 	"o3-mini": {
 		maxTokens: 100_000,


### PR DESCRIPTION
### Description

This PR updates the cached input pricing (`cacheReadsPrice`) for the OpenAI GPT-4.1 model family in `src/shared/api.ts` to match the latest official OpenAI pricing:

- **GPT-4.1:** `cacheReadsPrice: 0.5` ($0.50 per 1M tokens)
- **GPT-4.1 mini:** `cacheReadsPrice: 0.1` ($0.10 per 1M tokens)
- **GPT-4.1 nano:** `cacheReadsPrice: 0.025` ($0.025 per 1M tokens)

No changes were made to `cacheWritesPrice`, as OpenAI does not currently specify a separate price for cache writes for these models.

### Test Procedure

- Verified that the correct `cacheReadsPrice` values are set for each model in `src/shared/api.ts`.
- Confirmed that the cost calculation logic in `src/utils/cost.ts` will now apply the correct cached input price for these models.
- No other files or logic were changed.

### Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

### Pre-flight Checklist

- [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
- [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
- [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
- [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<img width="1045" alt="image" src="https://github.com/user-attachments/assets/9c7acd94-e0c8-4809-adc0-806cef7d0446" />

<img width="613" alt="image" src="https://github.com/user-attachments/assets/900e1a50-6cb8-4756-87bb-d53dacb08913" />
<img width="613" alt="image" src="https://github.com/user-attachments/assets/19a4cd43-7b86-4520-a34c-2e6dcde93219" />
<img width="616" alt="image" src="https://github.com/user-attachments/assets/a7d42e58-3896-41a0-9a71-07533253c3f8" />


### Additional Notes

- This ensures prompt caching costs are accurately reflected in cost calculations for these models.
- The update aligns the extension's cost reporting and accounting with OpenAI's published pricing as of April 2025.
- If you have any questions or need further clarification, please let me know!
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `cacheReadsPrice` for OpenAI GPT-4.1, GPT-4.1-mini, and GPT-4.1-nano models in `src/shared/api.ts` to match latest OpenAI pricing.
> 
>   - **Pricing Update**:
>     - Set `cacheReadsPrice` for `gpt-4.1` to `0.5`, `gpt-4.1-mini` to `0.1`, and `gpt-4.1-nano` to `0.025` in `openAiNativeModels` in `src/shared/api.ts`.
>     - No changes to `cacheWritesPrice` or other model properties.
>   - **Effect**:
>     - Ensures cost calculations for cached input tokens use current OpenAI pricing for these models.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 884be420f16f557f740c71e748d488947d063c81. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->