### PR TITLE
bugfix: AWS credentials overridden by env variables in shell init scripts

### DIFF
--- a/src/api/providers/bedrock.ts
+++ b/src/api/providers/bedrock.ts
@@ -52,6 +52,10 @@ export class AwsBedrockHandler implements ApiHandler {
 		// initialization, and allowing for session renewal if necessary as well
 		const client = await this.getAnthropicClient()
 
+		// AWS SDK prioritizes AWS_PROFILE over AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY pair
+		// If this is set as an env variable already (ie. from ~/.zshrc) it will override credentials configured by Cline
+		const previousEnv = process.env
+		delete process.env["AWS_PROFILE"]
 		const stream = await client.messages.create({
 			model: modelId,
 			max_tokens: model.info.maxTokens || 8192,
@@ -97,6 +101,7 @@ export class AwsBedrockHandler implements ApiHandler {
 			}),
 			stream: true,
 		})
+		process.env = previousEnv
 
 		for await (const chunk of stream) {
 			switch (chunk.type) {
@@ -196,10 +201,14 @@ export class AwsBedrockHandler implements ApiHandler {
 		return await AwsBedrockHandler.withTempEnv(
 			() => {
 				AwsBedrockHandler.setEnv("AWS_REGION", this.options.awsRegion)
-				AwsBedrockHandler.setEnv("AWS_ACCESS_KEY_ID", this.options.awsAccessKey)
-				AwsBedrockHandler.setEnv("AWS_SECRET_ACCESS_KEY", this.options.awsSecretKey)
-				AwsBedrockHandler.setEnv("AWS_SESSION_TOKEN", this.options.awsSessionToken)
-				AwsBedrockHandler.setEnv("AWS_PROFILE", this.options.awsProfile)
+				if (this.options.awsUseProfile) {
+					AwsBedrockHandler.setEnv("AWS_PROFILE", this.options.awsProfile)
+				} else {
+					delete process.env["AWS_PROFILE"]
+					AwsBedrockHandler.setEnv("AWS_ACCESS_KEY_ID", this.options.awsAccessKey)
+					AwsBedrockHandler.setEnv("AWS_SECRET_ACCESS_KEY", this.options.awsSecretKey)
+					AwsBedrockHandler.setEnv("AWS_SESSION_TOKEN", this.options.awsSessionToken)
+				}
 			},
 			() => providerChain(),
 		)


### PR DESCRIPTION
### Description

If a user is setting the `AWS_PROFILE` environment variable in a shell init script (~/.zshrc, ~/.bashrc, etc.) then this profile will always be used instead of any Cline settings. This is due to two factors:

1. `AWS_PROFILE` will always be used over `AWS_ACCESS_KEY` pairs by the AWS SDK. See additional notes for more details.
2. The `AWS_PROFILE` environment variable is only set temporarily when the credential provider is invoked. After, it is restored to the value it was previously.

To reproduce, add `export AWS_PROFILE="fake-aws-profile"` to your shell init script. Reload VS Code, use Bedrock authentication, and all API requests will fail.

### Test Procedure

1. `AWS_PROFILE` set to non-existent profile name in ~/.zshrc
2. AWS Profile set to `bedrock` in Cline
3. API calls succeed

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Error message when `AWS_PROFILE` is set to an account without Bedrock access via shell init script:

![image](https://github.com/user-attachments/assets/fe0b4118-c163-4c4a-87f0-545e38376b6b)

### Additional Notes

There is debug output that describes the AWS SDK behavior regarding prioritization of `AWS_PROFILE`:
```
@aws-sdk/credential-provider-node - defaultProvider::fromEnv WARNING:
    Multiple credential sources detected: 
    Both AWS_PROFILE and the pair AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY static credentials are set.
    This SDK will proceed with the AWS_PROFILE value.
    
    However, a future version may change this behavior to prefer the ENV static credentials.
    Please ensure that your environment only sets either the AWS_PROFILE or the
    AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY pair.
```

I don't see an open issue for this, but internally we have seen multiple users with this issue, and it seems it was mentioned here: https://github.com/cline/cline/issues/852#issuecomment-2627567364


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Prevents shell-initialized `AWS_PROFILE` from overriding Cline's AWS credential settings in `AwsBedrockHandler.getAwsCredentials()`.
> 
>   - **Bugfix (AWS credentials):**
>     - In `AwsBedrockHandler.getAwsCredentials()` in `bedrock.ts`, deletes `process.env["AWS_PROFILE"]` if `awsUseProfile` is set and `AWS_PROFILE` is present, preventing shell-initialized `AWS_PROFILE` from overriding Cline's AWS credential settings.
>     - Ensures AWS SDK uses credentials/profile as configured in Cline, not from shell environment variables.
>   - **Release notes:**
>     - Adds changeset documenting the fix for AWS_PROFILE override issue.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 23f0e7c1df62eda3d009c59ff1919392f70b0f10. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->