### PR TITLE
fix: Non-error logs from the MCP server are also output as error logs, causing abnormal server display.

### DIFF
--- a/src/services/mcp/McpHub.ts
+++ b/src/services/mcp/McpHub.ts
@@ -255,7 +255,7 @@ export class McpHub {
 					stderrStream.on("data", async (data: Buffer) => {
 						const output = data.toString()
 						// Check if output contains INFO level log
-						const isInfoLog = !(/^.*\berror\b/.test(output) || /^.*\bERROR\b/.test(output))
+						const isInfoLog = !(/\berror\b/i.test(output))
 
 						if (isInfoLog) {
 							// Log normal informational messages

--- a/src/services/mcp/McpHub.ts
+++ b/src/services/mcp/McpHub.ts
@@ -255,7 +255,7 @@ export class McpHub {
 					stderrStream.on("data", async (data: Buffer) => {
 						const output = data.toString()
 						// Check if output contains INFO level log
-						const isInfoLog = !(/\berror\b/i.test(output))
+						const isInfoLog = !/\berror\b/i.test(output)
 
 						if (isInfoLog) {
 							// Log normal informational messages

--- a/src/services/mcp/McpHub.ts
+++ b/src/services/mcp/McpHub.ts
@@ -255,7 +255,7 @@ export class McpHub {
 					stderrStream.on("data", async (data: Buffer) => {
 						const output = data.toString()
 						// Check if output contains INFO level log
-						const isInfoLog = /^\s*INFO\b/.test(output)
+						const isInfoLog = !(/^.*\berror\b/.test(output) || /^.*\bERROR\b/.test(output))
 
 						if (isInfoLog) {
 							// Log normal informational messages


### PR DESCRIPTION
### Description
Non-error logs from the MCP server are also output as error logs, causing abnormal server display.
especially for servers built with @mcp.tool, the normal logs (such as tool list retrieval) are printed to stderr. 
Many normal log entries are being incorrectly identified as error logs by the current regex pattern (^\s*INFO\b) because they lack the "INFO" keyword.
and the server will be displayed with these logs, actually it is normal.

### Test Procedure
After modifying the regular expression to identify logs containing the "error" keyword as error logs, local tests showed that dozens of servers are now displaying normally.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots
<!-- For UI changes, add screenshots here -->
Before the changes
<img width="356" alt="image" src="https://github.com/user-attachments/assets/8811cfac-a105-4464-a0eb-ce2305bb5be4" />

After the changes
<img width="785" alt="image" src="https://github.com/user-attachments/assets/994d3462-7cf5-4262-8ea0-0d4b6875350d" />



### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes log classification in `McpHub` by updating regex to correctly identify error logs.
> 
>   - **Behavior**:
>     - Fixes log classification in `McpHub` by updating regex in `connectToServer` to correctly identify error logs by checking for 'error' keyword.
>   - **Misc**:
>     - Updates regex pattern in `McpHub.ts` to prevent non-error logs from being misclassified as error logs.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for ef0b8dde8e989683555a2b9f98bb94e0c2740ca3. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->