### PR TITLE
feat: read_file support reading image directly as model input

### DIFF
--- a/src/core/prompts/system.ts
+++ b/src/core/prompts/system.ts
@@ -49,7 +49,7 @@ Usage:
 </execute_command>
 
 ## read_file
-Description: Request to read the contents of a file at the specified path. Use this when you need to examine the contents of an existing file you do not know the contents of, for example to analyze code, review text files, or extract information from configuration files. Automatically extracts raw text from PDF and DOCX files. May not be suitable for other types of binary files, as it returns the raw content as a string.
+Description: Request to read the contents of a file at the specified path. Use this when you need to examine the contents of an existing file you do not know the contents of, for example to analyze code, review text files, extract information from configuration files, or even process image files. Automatically extracts raw text from PDF and DOCX files. It can also read image files (png, jpg, jpeg, webp), returning them as base64 data URLs.
 Parameters:
 - path: (required) The path of the file to read (relative to the current working directory ${cwd.toPosix()})
 Usage:

--- a/src/core/prompts/system.ts
+++ b/src/core/prompts/system.ts
@@ -7,6 +7,7 @@ import { BrowserSettings } from "@shared/BrowserSettings"
 export const SYSTEM_PROMPT = async (
 	cwd: string,
 	supportsBrowserUse: boolean,
+	modelSupportsImages: boolean,
 	mcpHub: McpHub,
 	browserSettings: BrowserSettings,
 ) => `You are Cline, a highly skilled software engineer with extensive knowledge in many programming languages, frameworks, design patterns, and best practices.
@@ -49,7 +50,7 @@ Usage:
 </execute_command>
 
 ## read_file
-Description: Request to read the contents of a file at the specified path. Use this when you need to examine the contents of an existing file you do not know the contents of, for example to analyze code, review text files, extract information from configuration files, or even process image files. Automatically extracts raw text from PDF and DOCX files. It can also read image files (png, jpg, jpeg, webp), returning them as base64 data URLs.
+Description: Request to read the contents of a file at the specified path. Use this when you need to examine the contents of an existing file you do not know the contents of, for example to analyze code, review text files,${modelSupportsImages ? " process image files," : ""} or extract information from configuration files. Automatically extracts raw text from PDF and DOCX files.${modelSupportsImages ? " It can also read image files (png, jpg, jpeg, webp), returning them as base64 data URLs." : ""} May not be suitable for other types of binary files, as it returns the raw content as a string.
 Parameters:
 - path: (required) The path of the file to read (relative to the current working directory ${cwd.toPosix()})
 Usage:

--- a/src/core/task/index.ts
+++ b/src/core/task/index.ts
@@ -1428,10 +1428,10 @@ export class Task {
 		const disableBrowserTool = vscode.workspace.getConfiguration("cline").get<boolean>("disableBrowserTool") ?? false
 		// cline browser tool uses image recognition for navigation (requires model image support).
 		const modelSupportsBrowserUse = this.api.getModel().info.supportsImages ?? false
-
+		const modelSupportsImages = modelSupportsBrowserUse
 		const supportsBrowserUse = modelSupportsBrowserUse && !disableBrowserTool // only enable browser use if the model supports it and the user hasn't disabled it
 
-		let systemPrompt = await SYSTEM_PROMPT(cwd, supportsBrowserUse, this.mcpHub, this.browserSettings)
+		let systemPrompt = await SYSTEM_PROMPT(cwd, supportsBrowserUse, modelSupportsImages, this.mcpHub, this.browserSettings)
 
 		let settingsCustomInstructions = this.customInstructions?.trim()
 		const preferredLanguage = getLanguageKey(

--- a/src/integrations/misc/extract-text.ts
+++ b/src/integrations/misc/extract-text.ts
@@ -6,6 +6,7 @@ import fs from "fs/promises"
 import { isBinaryFile } from "isbinaryfile"
 import * as chardet from "jschardet"
 import * as iconv from "iconv-lite"
+import { getMimeType } from "./process-images"
 
 export async function detectEncoding(fileBuffer: Buffer, fileExtension?: string): Promise<string> {
 	const detected = chardet.detect(fileBuffer)
@@ -21,23 +22,6 @@ export async function detectEncoding(fileBuffer: Buffer, fileExtension?: string)
 			}
 		}
 		return "utf8"
-	}
-}
-
-// Function to get MIME type based on file extension
-function getMimeType(filePath: string): string {
-	const ext = path.extname(filePath).toLowerCase()
-	switch (ext) {
-		case ".png":
-			return "image/png"
-		case ".jpeg":
-		case ".jpg":
-			return "image/jpeg"
-		case ".webp":
-			return "image/webp"
-		default:
-			// Return a generic type or handle as needed for non-image files
-			return "application/octet-stream" // Or throw an error if only image types are expected
 	}
 }
 

--- a/src/integrations/misc/extract-text.ts
+++ b/src/integrations/misc/extract-text.ts
@@ -24,6 +24,23 @@ export async function detectEncoding(fileBuffer: Buffer, fileExtension?: string)
 	}
 }
 
+// Function to get MIME type based on file extension
+function getMimeType(filePath: string): string {
+	const ext = path.extname(filePath).toLowerCase()
+	switch (ext) {
+		case ".png":
+			return "image/png"
+		case ".jpeg":
+		case ".jpg":
+			return "image/jpeg"
+		case ".webp":
+			return "image/webp"
+		default:
+			// Return a generic type or handle as needed for non-image files
+			return "application/octet-stream" // Or throw an error if only image types are expected
+	}
+}
+
 export async function extractTextFromFile(filePath: string): Promise<string> {
 	try {
 		await fs.access(filePath)
@@ -38,6 +55,15 @@ export async function extractTextFromFile(filePath: string): Promise<string> {
 			return extractTextFromDOCX(filePath)
 		case ".ipynb":
 			return extractTextFromIPYNB(filePath)
+		// Add cases for image file types
+		case ".png":
+		case ".jpg":
+		case ".jpeg":
+		case ".webp":
+			const imageBuffer = await fs.readFile(filePath)
+			const base64 = imageBuffer.toString("base64")
+			const mimeType = getMimeType(filePath)
+			return `data:${mimeType};base64,${base64}`
 		default:
 			const fileBuffer = await fs.readFile(filePath)
 			if (fileBuffer.byteLength > 300 * 1024) {

--- a/src/integrations/misc/process-images.ts
+++ b/src/integrations/misc/process-images.ts
@@ -29,7 +29,7 @@ export async function selectImages(): Promise<string[]> {
 	)
 }
 
-function getMimeType(filePath: string): string {
+export function getMimeType(filePath: string): string {
 	const ext = path.extname(filePath).toLowerCase()
 	switch (ext) {
 		case ".png":


### PR DESCRIPTION
### Description

`read_file` supports reading image from fs directly as model input. This could complete image related action loops from model's perspective.

### Test Procedure

Ask model to read an image directly and give description of the image directly.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

![Screenshot from 2025-04-15 20-23-42](https://github.com/user-attachments/assets/9a5a9686-fbae-40e6-9b05-c398a816db18)

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> `read_file` now supports reading image files as base64 data URLs for model input, with updates in `extract-text.ts`, `index.ts`, and `system.ts`.
> 
>   - **Behavior**:
>     - `read_file` now supports reading image files (png, jpg, jpeg, webp) as base64 data URLs, allowing them to be used as model input.
>     - Updates `extractTextFromFile()` in `extract-text.ts` to handle image files by converting them to base64 data URLs.
>     - In `Task` class in `index.ts`, checks if `read_file` result is an image data URL and processes it accordingly.
>   - **Documentation**:
>     - Updates `read_file` tool description in `system.ts` to include image file processing capability.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for f10ae2d2b382570788842e5a3787f6c4cb9e8554. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->