### PR TITLE
Fix `reasoning_content` that may not exist on grok-3-beta streaming r…

### DIFF
--- a/.changeset/big-ladybugs-unite.md
+++ b/.changeset/big-ladybugs-unite.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Fix `reasoning_content` that may not exist on grok-3-beta streaming response

--- a/src/api/providers/xai.ts
+++ b/src/api/providers/xai.ts
@@ -39,7 +39,7 @@ export class XAIHandler implements ApiHandler {
 		})
 
 		for await (const chunk of stream) {
-			const delta = chunk.choices[0]?.delta
+			const delta = chunk.choices[0]?.delta as { content?: string; reasoning_content?: string }
 			if (delta?.content) {
 				yield {
 					type: "text",
@@ -47,7 +47,7 @@ export class XAIHandler implements ApiHandler {
 				}
 			}
 
-			if ("reasoning_content" in delta && delta.reasoning_content) {
+			if (delta?.reasoning_content) {
 				yield {
 					type: "reasoning",
 					// @ts-ignore-next-line


### PR DESCRIPTION
### Description

`grok-3-beta` model doesn't have `reasoning_content` in the streaming response

### Test Procedure

1. Build the the extension package with
```
$ npm run package
$ npx vsce package

2. Load the VSIX extension to my vscode
3. Send a query to grok-3-beta with xAI provider
4. It no longer failed with the reasoning content error

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) -> I couldn't run the test locally
-   [x] Code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Additional Notes

Running `npm run test` results in the following error
```
> claude-dev@3.12.3 pretest
> npm run compile-tests && npm run compile && npm run lint

> claude-dev@3.12.3 compile-tests
> tsc -p ./tsconfig.test.json --outDir out

src/api/providers/xai.ts:7:47 - error TS7016: Could not find a declaration file for module 'openai/resources/chat/completions.mjs'. '/Users/jeesearmand/Develop/cline/node_modules/openai/resources/chat/completions.mjs' implicitly has an 'any' type.
  There are types at '/Users/jeesearmand/Develop/cline/node_modules/openai/resources/chat/completions.d.ts', but this result could not be resolved under your current 'moduleResolution' setting. Consider updating to 'node16', 'nodenext', or 'bundler'.

7 import { ChatCompletionReasoningEffort } from "openai/resources/chat/completions.mjs"
                                                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

Found 1 error in src/api/providers/xai.ts:7
```
