### PR TITLE
Safer check for xAI reasoning content

### DIFF
--- a/.changeset/rich-pens-buy.md
+++ b/.changeset/rich-pens-buy.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Safer check for xAI reasoning content

--- a/src/api/providers/xai.ts
+++ b/src/api/providers/xai.ts
@@ -47,7 +47,7 @@ export class XAIHandler implements ApiHandler {
 				}
 			}
 
-			if ("reasoning_content" in delta && delta.reasoning_content) {
+			if (delta && "reasoning_content" in delta && delta.reasoning_content) {
 				yield {
 					type: "reasoning",
 					// @ts-ignore-next-line


### PR DESCRIPTION
### Description

Fixes #2931 #2896

### Test Procedure

Not 100% sure how to repro, but when this was happening to me it stopped after this change.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix safer check for `reasoning_content` in `XAIHandler.createMessage()` in `xai.ts`.
> 
>   - **Bug Fix**:
>     - In `xai.ts`, updated the condition in `XAIHandler.createMessage()` to check if `delta` is defined before accessing `reasoning_content`. This prevents errors when `delta` is undefined.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 24f5c9d84f09aa17be652dbf3bf4f23d3fdec427. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->