### PR TITLE
Don't read that RTF nonsense

### DIFF
--- a/.changeset/short-nails-yawn.md
+++ b/.changeset/short-nails-yawn.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": minor
+---
+
+Filter out rtf files when reading cline rules files

--- a/src/core/context/instructions/user-instructions/cline-rules.ts
+++ b/src/core/context/instructions/user-instructions/cline-rules.ts
@@ -79,7 +79,17 @@ const getClineRulesFilesTotalContent = async (rulesFilePaths: string[], basePath
 				return null
 			}
 
-			return `${ruleFilePathRelative}\n` + (await fs.readFile(ruleFilePath, "utf8")).trim()
+			const content = await fs.readFile(ruleFilePath, "utf8")
+
+			// Check for RTF files which have weird formatting that outputs a bunch of mumbo jumbo into the context
+			if (content.trimStart().startsWith("{\\rtf")) {
+				console.warn(`Skipping RTF format file: ${ruleFilePath}`)
+				return null
+			}
+
+			const trimmedContent = content.trim()
+
+			return `${ruleFilePathRelative}\n${trimmedContent}`
 		}),
 	).then((contents) => contents.filter(Boolean).join("\n\n"))
 	return ruleFilesTotalContent


### PR DESCRIPTION
### Description

Filter out RTF files, which add a bunch of weird formatting, when reading clinerules files

These are sometimes created as the default file type when making a file without a file extension on Mac, like with TextEdit.

### Test Procedure

<!-- How did you test this? Are you confident that it will not introduce bugs? If so, why? -->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

### Additional Notes

<!-- Add any additional notes for reviewers -->
