### PR TITLE
Fixed the path of cline_mcp_settings.json files in Windows

### DIFF
--- a/src/core/controller/index.ts
+++ b/src/core/controller/index.ts
@@ -1362,7 +1362,7 @@ export class Controller {
 			// Create task with context from README and added guidelines for MCP server installation
 			const task = `Set up the MCP server from ${mcpDetails.githubUrl} while adhering to these MCP server installation rules:
 - Start by loading the MCP documentation.
-- Use "${mcpDetails.mcpId}" as the server name in cline_mcp_settings.json.
+- Use "${mcpDetails.mcpId}" as the server name in ${process.platform === "win32" ? await ensureSettingsDirectoryExists(this.context) + '\\' : ''}cline_mcp_settings.json.
 - Create the directory for the new MCP server before starting installation.
 - Make sure you read the user's existing cline_mcp_settings.json file before editing it with this new mcp, to not overwrite any existing servers.
 - Use commands aligned with the user's shell and operating system best practices.

--- a/src/core/controller/index.ts
+++ b/src/core/controller/index.ts
@@ -1358,11 +1358,17 @@ export class Controller {
 				type: "mcpDownloadDetails",
 				mcpDownloadDetails: mcpDetails,
 			})
+			// fix mcpSettings path for windows
+			let mcpSettingsPath = GlobalFileNames.mcpSettings
+			if (process.platform === "win32") {
+				const settingsDir = await ensureSettingsDirectoryExists(this.context)
+				mcpSettingsPath = path.join(settingsDir, GlobalFileNames.mcpSettings)
+			}
 
 			// Create task with context from README and added guidelines for MCP server installation
 			const task = `Set up the MCP server from ${mcpDetails.githubUrl} while adhering to these MCP server installation rules:
 - Start by loading the MCP documentation.
-- Use "${mcpDetails.mcpId}" as the server name in ${process.platform === "win32" ? (await ensureSettingsDirectoryExists(this.context)) + "\\" : ""}cline_mcp_settings.json.
+- Use "${mcpDetails.mcpId}" as the server name in ${mcpSettingsPath}.
 - Create the directory for the new MCP server before starting installation.
 - Make sure you read the user's existing cline_mcp_settings.json file before editing it with this new mcp, to not overwrite any existing servers.
 - Use commands aligned with the user's shell and operating system best practices.

--- a/src/core/controller/index.ts
+++ b/src/core/controller/index.ts
@@ -1362,7 +1362,7 @@ export class Controller {
 			// Create task with context from README and added guidelines for MCP server installation
 			const task = `Set up the MCP server from ${mcpDetails.githubUrl} while adhering to these MCP server installation rules:
 - Start by loading the MCP documentation.
-- Use "${mcpDetails.mcpId}" as the server name in ${process.platform === "win32" ? await ensureSettingsDirectoryExists(this.context) + '\\' : ''}cline_mcp_settings.json.
+- Use "${mcpDetails.mcpId}" as the server name in ${process.platform === "win32" ? (await ensureSettingsDirectoryExists(this.context)) + "\\" : ""}cline_mcp_settings.json.
 - Create the directory for the new MCP server before starting installation.
 - Make sure you read the user's existing cline_mcp_settings.json file before editing it with this new mcp, to not overwrite any existing servers.
 - Use commands aligned with the user's shell and operating system best practices.


### PR DESCRIPTION
Relative paths are used in the project directory in Windows, not in the settings directory

### Description

Relative paths for "cline_mcp_settings.json" are used in the project directory in Windows, not in the settings directory.
so in the Windows environment, the path for "cline_mcp_settings.json" should be fixed to full path.

### Test Procedure

Installing the MCP service from the MCP Service Marketplace will no longer cause errors due to path problems in the Windows environment.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x ] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes path handling for `cline_mcp_settings.json` in Windows within the `Controller` class.
> 
>   - **Behavior**:
>     - Fixes path for `cline_mcp_settings.json` in Windows by using full path in `Controller` class.
>     - Ensures `cline_mcp_settings.json` is accessed correctly during MCP server setup.
>   - **Misc**:
>     - Adjusts path handling logic in `index.ts` for Windows environments.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 033365ad6ed22a32a516571902bf8da587c374ff. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->