### PR TITLE
fix: BrowserSessionRow to include 'reasoning' message type handling

### DIFF
--- a/webview-ui/src/components/chat/BrowserSessionRow.tsx
+++ b/webview-ui/src/components/chat/BrowserSessionRow.tsx
@@ -192,7 +192,12 @@ const BrowserSessionRow = memo((props: BrowserSessionRowProps) => {
 				// Reset for next page
 				currentStateMessages = []
 				nextActionMessages = []
-			} else if (message.say === "api_req_started" || message.say === "text" || message.say === "browser_action") {
+			} else if (
+				message.say === "api_req_started" ||
+				message.say === "text" ||
+				message.say === "reasoning" ||
+				message.say === "browser_action"
+			) {
 				// These messages lead to the next result, so they should always go in nextActionMessages
 				nextActionMessages.push(message)
 			} else {
@@ -511,6 +516,7 @@ const BrowserSessionRowContent = ({
 			switch (message.say) {
 				case "api_req_started":
 				case "text":
+				case "reasoning":
 					return (
 						<div style={chatRowContentContainerStyle}>
 							<ChatRowContent

--- a/webview-ui/src/components/chat/ChatView.tsx
+++ b/webview-ui/src/components/chat/ChatView.tsx
@@ -575,6 +575,7 @@ const ChatView = ({ isHidden, showAnnouncement, hideAnnouncement, showHistoryVie
 				"browser_action",
 				"browser_action_result",
 				"checkpoint_created",
+				"reasoning",
 			].includes(message.say!)
 		}
 		return false


### PR DESCRIPTION
Fixes bug where using a reasoning model (eg claude 3.7 sonnet) that outputs thinking blocks, would result in browser tool showing image blobs as text rather than being parsed correctly

![Slack 2025-04-17 10 59 31](https://github.com/user-attachments/assets/ebf46248-99d5-43bb-ad5c-26e68e8a6f82)

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add handling for 'reasoning' message type in `BrowserSessionRow.tsx` and `ChatView.tsx`.
> 
>   - **Behavior**:
>     - Add handling for 'reasoning' message type in `BrowserSessionRow.tsx` and `ChatView.tsx`.
>     - In `BrowserSessionRow.tsx`, include 'reasoning' in conditions for `nextActionMessages` and `BrowserSessionRowContent`.
>     - In `ChatView.tsx`, include 'reasoning' in `isBrowserSessionMessage` and `visibleMessages` filtering.
>   - **Misc**:
>     - No changes to existing functionality, only addition of 'reasoning' message type handling.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for ceb7a5fd64bc86f2235e58e1b73098da4ada6c3d. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->