### PR TITLE
Trevor/eng 416 add editing ability to older user messages in chat

### DIFF
--- a/.changeset/nasty-gifts-look.md
+++ b/.changeset/nasty-gifts-look.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Allow user to modify a previous message to continue chat

--- a/src/core/controller/index.ts
+++ b/src/core/controller/index.ts
@@ -522,7 +522,7 @@ export class Controller {
 						console.error("Failed to init new cline instance")
 					})
 					// NOTE: cancelTask awaits abortTask, which awaits diffViewProvider.revertChanges, which reverts any edited files, allowing us to reset to a checkpoint rather than running into a state where the revertChanges function is called alongside or after the checkpoint reset
-					await this.task?.restoreCheckpoint(message.number, message.text! as ClineCheckpointRestore)
+					await this.task?.restoreCheckpoint(message.number, message.text! as ClineCheckpointRestore, message.offset)
 				}
 				break
 			}

--- a/src/core/task/index.ts
+++ b/src/core/task/index.ts
@@ -307,8 +307,8 @@ export class Task {
 		}
 	}
 
-	async restoreCheckpoint(messageTs: number, restoreType: ClineCheckpointRestore) {
-		const messageIndex = this.clineMessages.findIndex((m) => m.ts === messageTs)
+	async restoreCheckpoint(messageTs: number, restoreType: ClineCheckpointRestore, offset?: number) {
+		const messageIndex = this.clineMessages.findIndex((m) => m.ts === messageTs) - (offset || 0)
 		const message = this.clineMessages[messageIndex]
 		if (!message) {
 			console.error("Message not found", this.clineMessages)

--- a/src/shared/WebviewMessage.ts
+++ b/src/shared/WebviewMessage.ts
@@ -121,6 +121,7 @@ export interface WebviewMessage {
 	query?: string
 	// For toggleFavoriteModel
 	modelId?: string
+<<<<<<< HEAD
 	grpc_request?: {
 		service: string
 		method: string
@@ -131,6 +132,9 @@ export interface WebviewMessage {
 	isGlobal?: boolean
 	rulePath?: string
 	enabled?: boolean
+=======
+	offset?: number
+>>>>>>> e0fd93b7 (restore and send)
 }
 
 export type ClineAskResponse = "yesButtonClicked" | "noButtonClicked" | "messageResponse"

--- a/src/shared/WebviewMessage.ts
+++ b/src/shared/WebviewMessage.ts
@@ -121,7 +121,6 @@ export interface WebviewMessage {
 	query?: string
 	// For toggleFavoriteModel
 	modelId?: string
-<<<<<<< HEAD
 	grpc_request?: {
 		service: string
 		method: string
@@ -132,9 +131,7 @@ export interface WebviewMessage {
 	isGlobal?: boolean
 	rulePath?: string
 	enabled?: boolean
-=======
 	offset?: number
->>>>>>> e0fd93b7 (restore and send)
 }
 
 export type ClineAskResponse = "yesButtonClicked" | "noButtonClicked" | "messageResponse"

--- a/webview-ui/src/components/chat/ChatRow.tsx
+++ b/webview-ui/src/components/chat/ChatRow.tsx
@@ -50,11 +50,8 @@ interface ChatRowProps {
 	lastModifiedMessage?: ClineMessage
 	isLast: boolean
 	onHeightChange: (isTaller: boolean) => void
-<<<<<<< HEAD
 	inputValue?: string
-=======
 	sendMessageFromChatRow?: (text: string, images: string[]) => void
->>>>>>> 3b3f7848 (User message editing)
 }
 
 interface ChatRowContentProps extends Omit<ChatRowProps, "onHeightChange"> {}
@@ -129,11 +126,8 @@ export const ChatRowContent = ({
 	onToggleExpand,
 	lastModifiedMessage,
 	isLast,
-<<<<<<< HEAD
 	inputValue,
-=======
 	sendMessageFromChatRow,
->>>>>>> 3b3f7848 (User message editing)
 }: ChatRowContentProps) => {
 	const { mcpServers, mcpMarketplaceCatalog } = useExtensionState()
 	const [seeNewChangesDisabled, setSeeNewChangesDisabled] = useState(false)

--- a/webview-ui/src/components/chat/ChatRow.tsx
+++ b/webview-ui/src/components/chat/ChatRow.tsx
@@ -32,6 +32,7 @@ import SuccessButton from "@/components/common/SuccessButton"
 import TaskFeedbackButtons from "@/components/chat/TaskFeedbackButtons"
 import NewTaskPreview from "./NewTaskPreview"
 import McpResourceRow from "@/components/mcp/configuration/tabs/installed/server-row/McpResourceRow"
+import UserMessage from "./UserMessage"
 
 const ChatRowContainer = styled.div`
 	padding: 10px 6px 10px 15px;
@@ -49,7 +50,11 @@ interface ChatRowProps {
 	lastModifiedMessage?: ClineMessage
 	isLast: boolean
 	onHeightChange: (isTaller: boolean) => void
+<<<<<<< HEAD
 	inputValue?: string
+=======
+	sendMessageFromChatRow?: (text: string, images: string[]) => void
+>>>>>>> 3b3f7848 (User message editing)
 }
 
 interface ChatRowContentProps extends Omit<ChatRowProps, "onHeightChange"> {}
@@ -124,7 +129,11 @@ export const ChatRowContent = ({
 	onToggleExpand,
 	lastModifiedMessage,
 	isLast,
+<<<<<<< HEAD
 	inputValue,
+=======
+	sendMessageFromChatRow,
+>>>>>>> 3b3f7848 (User message editing)
 }: ChatRowContentProps) => {
 	const { mcpServers, mcpMarketplaceCatalog } = useExtensionState()
 	const [seeNewChangesDisabled, setSeeNewChangesDisabled] = useState(false)
@@ -872,20 +881,12 @@ export const ChatRowContent = ({
 					)
 				case "user_feedback":
 					return (
-						<div
-							style={{
-								backgroundColor: "var(--vscode-badge-background)",
-								color: "var(--vscode-badge-foreground)",
-								borderRadius: "3px",
-								padding: "9px",
-								whiteSpace: "pre-line",
-								wordWrap: "break-word",
-							}}>
-							<span style={{ display: "block" }}>{highlightMentions(message.text)}</span>
-							{message.images && message.images.length > 0 && (
-								<Thumbnails images={message.images} style={{ marginTop: "8px" }} />
-							)}
-						</div>
+						<UserMessage
+							text={message.text}
+							images={message.images}
+							messageTs={message.ts}
+							sendMessageFromChatRow={sendMessageFromChatRow}
+						/>
 					)
 				case "user_feedback_diff":
 					const tool = JSON.parse(message.text || "{}") as ClineSayTool

--- a/webview-ui/src/components/chat/ChatView.tsx
+++ b/webview-ui/src/components/chat/ChatView.tsx
@@ -796,7 +796,11 @@ const ChatView = ({ isHidden, showAnnouncement, hideAnnouncement, showHistoryVie
 					lastModifiedMessage={modifiedMessages.at(-1)}
 					isLast={index === groupedMessages.length - 1}
 					onHeightChange={handleRowHeightChange}
+<<<<<<< HEAD
 					inputValue={inputValue}
+=======
+					sendMessageFromChatRow={handleSendMessage}
+>>>>>>> 3b3f7848 (User message editing)
 				/>
 			)
 		},

--- a/webview-ui/src/components/chat/ChatView.tsx
+++ b/webview-ui/src/components/chat/ChatView.tsx
@@ -796,11 +796,8 @@ const ChatView = ({ isHidden, showAnnouncement, hideAnnouncement, showHistoryVie
 					lastModifiedMessage={modifiedMessages.at(-1)}
 					isLast={index === groupedMessages.length - 1}
 					onHeightChange={handleRowHeightChange}
-<<<<<<< HEAD
 					inputValue={inputValue}
-=======
 					sendMessageFromChatRow={handleSendMessage}
->>>>>>> 3b3f7848 (User message editing)
 				/>
 			)
 		},

--- a/webview-ui/src/components/chat/UserMessage.tsx
+++ b/webview-ui/src/components/chat/UserMessage.tsx
@@ -34,6 +34,7 @@ const UserMessage: React.FC<UserMessageProps> = ({ text, images, messageTs, send
 	}, [isEditing])
 
 	const handleRestoreWorkspace = (type: string) => {
+		const delay = type === "task" ? 500 : 1000 // Delay for task and workspace restore
 		setIsEditing(false)
 
 		if (text === editedText) {
@@ -49,7 +50,7 @@ const UserMessage: React.FC<UserMessageProps> = ({ text, images, messageTs, send
 
 		setTimeout(() => {
 			sendMessageFromChatRow?.(editedText, images || [])
-		}, 500)
+		}, delay)
 	}
 
 	const handleBlur = (e: React.FocusEvent<HTMLTextAreaElement>) => {

--- a/webview-ui/src/components/chat/UserMessage.tsx
+++ b/webview-ui/src/components/chat/UserMessage.tsx
@@ -3,6 +3,7 @@ import Thumbnails from "@/components/common/Thumbnails"
 import { highlightMentions } from "./TaskHeader"
 import { vscode } from "@/utils/vscode"
 import DynamicTextArea from "react-textarea-autosize"
+import { useExtensionState } from "@/context/ExtensionStateContext"
 
 interface UserMessageProps {
 	text?: string
@@ -15,6 +16,7 @@ const UserMessage: React.FC<UserMessageProps> = ({ text, images, messageTs, send
 	const [isEditing, setIsEditing] = useState(false)
 	const [editedText, setEditedText] = useState(text || "")
 	const textAreaRef = useRef<HTMLTextAreaElement>(null)
+	const { checkpointTrackerErrorMessage } = useExtensionState()
 
 	// Create refs for the buttons to check in the blur handler
 	const restoreAllButtonRef = useRef<HTMLButtonElement>(null)
@@ -68,9 +70,9 @@ const UserMessage: React.FC<UserMessageProps> = ({ text, images, messageTs, send
 		if (e.key === "Escape") {
 			setIsEditing(false)
 		} else if (e.key === "Enter" && e.metaKey) {
-			handleRestoreWorkspace("task")
-		} else if (e.key === "Enter") {
 			handleRestoreWorkspace("taskAndWorkspace")
+		} else if (e.key === "Enter" && !checkpointTrackerErrorMessage) {
+			handleRestoreWorkspace("task")
 		}
 	}
 
@@ -113,21 +115,23 @@ const UserMessage: React.FC<UserMessageProps> = ({ text, images, messageTs, send
 						}}
 					/>
 					<div style={{ display: "flex", gap: "8px", marginTop: "8px", justifyContent: "flex-end" }}>
+						{!checkpointTrackerErrorMessage && (
+							<RestoreButton
+								ref={restoreAllButtonRef}
+								type="taskAndWorkspace"
+								label="Restore All"
+								isPrimary={false}
+								onClick={handleRestoreWorkspace}
+								title="Restore both the chat and workspace files to this checkpoint and send your message"
+							/>
+						)}
 						<RestoreButton
 							ref={restoreChatButtonRef}
 							type="task"
 							label="Restore Chat"
-							isPrimary={false}
-							onClick={handleRestoreWorkspace}
-							title="Restore just the chat to this checkpoint and send your message"
-						/>
-						<RestoreButton
-							ref={restoreAllButtonRef}
-							type="taskAndWorkspace"
-							label="Restore All"
 							isPrimary={true}
 							onClick={handleRestoreWorkspace}
-							title="Restore both the chat and workspace files to this checkpoint and send your message"
+							title="Restore just the chat to this checkpoint and send your message"
 						/>
 					</div>
 				</>

--- a/webview-ui/src/components/chat/UserMessage.tsx
+++ b/webview-ui/src/components/chat/UserMessage.tsx
@@ -26,13 +26,18 @@ const UserMessage: React.FC<UserMessageProps> = ({ text, images, messageTs, send
 	}
 
 	const handleRestoreWorkspace = (type: string) => {
+		setIsEditing(false)
+
+		if (text === editedText) {
+			return
+		}
+
 		vscode.postMessage({
 			type: "checkpointRestore",
 			number: messageTs,
 			text: type,
 			offset: 1,
 		})
-		setIsEditing(false)
 
 		setTimeout(() => {
 			sendMessageFromChatRow?.(editedText, images || [])
@@ -53,7 +58,7 @@ const UserMessage: React.FC<UserMessageProps> = ({ text, images, messageTs, send
 	const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
 		if (e.key === "Escape") {
 			setIsEditing(false)
-		} else if (e.key === "Enter" && e.ctrlKey) {
+		} else if (e.key === "Enter" && e.metaKey) {
 			handleRestoreWorkspace("task")
 		} else if (e.key === "Enter") {
 			handleRestoreWorkspace("taskAndWorkspace")
@@ -99,17 +104,17 @@ const UserMessage: React.FC<UserMessageProps> = ({ text, images, messageTs, send
 					/>
 					<div style={{ display: "flex", gap: "8px", marginTop: "8px", justifyContent: "flex-end" }}>
 						<RestoreButton
-							ref={restoreAllButtonRef}
-							type="taskAndWorkspace"
-							label="Restore All"
-							isPrimary={true}
-							onClick={handleRestoreWorkspace}
-						/>
-						<RestoreButton
 							ref={restoreChatButtonRef}
 							type="task"
 							label="Restore Chat"
 							isPrimary={false}
+							onClick={handleRestoreWorkspace}
+						/>
+						<RestoreButton
+							ref={restoreAllButtonRef}
+							type="taskAndWorkspace"
+							label="Restore All"
+							isPrimary={true}
 							onClick={handleRestoreWorkspace}
 						/>
 					</div>

--- a/webview-ui/src/components/chat/UserMessage.tsx
+++ b/webview-ui/src/components/chat/UserMessage.tsx
@@ -14,6 +14,7 @@ interface UserMessageProps {
 const UserMessage: React.FC<UserMessageProps> = ({ text, images, messageTs, sendMessageFromChatRow }) => {
 	const [isEditing, setIsEditing] = useState(false)
 	const [editedText, setEditedText] = useState(text || "")
+	const textAreaRef = useRef<HTMLTextAreaElement>(null)
 
 	// Create refs for the buttons to check in the blur handler
 	const restoreAllButtonRef = useRef<HTMLButtonElement>(null)
@@ -24,6 +25,13 @@ const UserMessage: React.FC<UserMessageProps> = ({ text, images, messageTs, send
 			setIsEditing(true)
 		}
 	}
+
+	// Select all text when entering edit mode
+	React.useEffect(() => {
+		if (isEditing && textAreaRef.current) {
+			textAreaRef.current.select()
+		}
+	}, [isEditing])
 
 	const handleRestoreWorkspace = (type: string) => {
 		setIsEditing(false)
@@ -79,6 +87,7 @@ const UserMessage: React.FC<UserMessageProps> = ({ text, images, messageTs, send
 			{isEditing ? (
 				<>
 					<DynamicTextArea
+						ref={textAreaRef}
 						value={editedText}
 						onChange={(e) => setEditedText(e.target.value)}
 						onBlur={(e) => handleBlur(e)}

--- a/webview-ui/src/components/chat/UserMessage.tsx
+++ b/webview-ui/src/components/chat/UserMessage.tsx
@@ -123,7 +123,7 @@ const UserMessage: React.FC<UserMessageProps> = ({ text, images, messageTs, send
 								label="Restore All"
 								isPrimary={false}
 								onClick={handleRestoreWorkspace}
-								title="Restore both the chat and workspace files to this checkpoint and send your editedmessage"
+								title="Restore both the chat and workspace files to this checkpoint and send your edited message"
 							/>
 						)}
 						<RestoreButton

--- a/webview-ui/src/components/chat/UserMessage.tsx
+++ b/webview-ui/src/components/chat/UserMessage.tsx
@@ -3,8 +3,7 @@ import Thumbnails from "@/components/common/Thumbnails"
 import { highlightMentions } from "./TaskHeader"
 import { vscode } from "@/utils/vscode"
 import DynamicTextArea from "react-textarea-autosize"
-import { useEvent } from "react-use"
-import type { ExtensionMessage } from "@shared/ExtensionMessage"
+
 interface UserMessageProps {
 	text?: string
 	images?: any[] // Using any[] for now, but you might want to specify the correct type from your codebase
@@ -31,8 +30,13 @@ const UserMessage: React.FC<UserMessageProps> = ({ text, images, messageTs, send
 			type: "checkpointRestore",
 			number: messageTs,
 			text: type,
+			offset: 1,
 		})
 		setIsEditing(false)
+
+		setTimeout(() => {
+			sendMessageFromChatRow?.(editedText, images || [])
+		}, 500)
 	}
 
 	const handleBlur = (e: React.FocusEvent<HTMLTextAreaElement>) => {
@@ -55,17 +59,6 @@ const UserMessage: React.FC<UserMessageProps> = ({ text, images, messageTs, send
 			handleRestoreWorkspace("taskAndWorkspace")
 		}
 	}
-
-	const handleMessage = useCallback(
-		(event: MessageEvent<ExtensionMessage>) => {
-			if (event.data.type === "relinquishControl" && editedText != text && sendMessageFromChatRow) {
-				sendMessageFromChatRow(editedText, images || [])
-			}
-		},
-		[editedText],
-	)
-
-	useEvent("message", handleMessage)
 
 	return (
 		<div

--- a/webview-ui/src/components/chat/UserMessage.tsx
+++ b/webview-ui/src/components/chat/UserMessage.tsx
@@ -123,7 +123,7 @@ const UserMessage: React.FC<UserMessageProps> = ({ text, images, messageTs, send
 								label="Restore All"
 								isPrimary={false}
 								onClick={handleRestoreWorkspace}
-								title="Restore both the chat and workspace files to this checkpoint and send your message"
+								title="Restore both the chat and workspace files to this checkpoint and send your editedmessage"
 							/>
 						)}
 						<RestoreButton
@@ -132,7 +132,7 @@ const UserMessage: React.FC<UserMessageProps> = ({ text, images, messageTs, send
 							label="Restore Chat"
 							isPrimary={true}
 							onClick={handleRestoreWorkspace}
-							title="Restore just the chat to this checkpoint and send your message"
+							title="Restore just the chat to this checkpoint and send your edited message"
 						/>
 					</div>
 				</>

--- a/webview-ui/src/components/chat/UserMessage.tsx
+++ b/webview-ui/src/components/chat/UserMessage.tsx
@@ -1,0 +1,168 @@
+import React, { useState, useRef, forwardRef, useCallback } from "react"
+import Thumbnails from "@/components/common/Thumbnails"
+import { highlightMentions } from "./TaskHeader"
+import { vscode } from "@/utils/vscode"
+import DynamicTextArea from "react-textarea-autosize"
+import { useEvent } from "react-use"
+import type { ExtensionMessage } from "@shared/ExtensionMessage"
+interface UserMessageProps {
+	text?: string
+	images?: any[] // Using any[] for now, but you might want to specify the correct type from your codebase
+	messageTs?: number // Timestamp for the message, needed for checkpoint restore
+	sendMessageFromChatRow?: (text: string, images: string[]) => void
+}
+
+const UserMessage: React.FC<UserMessageProps> = ({ text, images, messageTs, sendMessageFromChatRow }) => {
+	const [isEditing, setIsEditing] = useState(false)
+	const [editedText, setEditedText] = useState(text || "")
+
+	// Create refs for the buttons to check in the blur handler
+	const restoreAllButtonRef = useRef<HTMLButtonElement>(null)
+	const restoreChatButtonRef = useRef<HTMLButtonElement>(null)
+
+	const handleClick = () => {
+		if (!isEditing) {
+			setIsEditing(true)
+		}
+	}
+
+	const handleRestoreWorkspace = (type: string) => {
+		vscode.postMessage({
+			type: "checkpointRestore",
+			number: messageTs,
+			text: type,
+		})
+		setIsEditing(false)
+	}
+
+	const handleBlur = (e: React.FocusEvent<HTMLTextAreaElement>) => {
+		// Check if focus is moving to one of our button elements
+		if (e.relatedTarget === restoreAllButtonRef.current || e.relatedTarget === restoreChatButtonRef.current) {
+			// Don't close edit mode if focus is moving to one of our buttons
+			return
+		}
+
+		// Otherwise, close edit mode
+		setIsEditing(false)
+	}
+
+	const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+		if (e.key === "Escape") {
+			setIsEditing(false)
+		} else if (e.key === "Enter" && e.ctrlKey) {
+			handleRestoreWorkspace("task")
+		} else if (e.key === "Enter") {
+			handleRestoreWorkspace("taskAndWorkspace")
+		}
+	}
+
+	const handleMessage = useCallback(
+		(event: MessageEvent<ExtensionMessage>) => {
+			if (event.data.type === "relinquishControl" && editedText != text && sendMessageFromChatRow) {
+				sendMessageFromChatRow(editedText, images || [])
+			}
+		},
+		[editedText],
+	)
+
+	useEvent("message", handleMessage)
+
+	return (
+		<div
+			style={{
+				backgroundColor: isEditing ? "unset" : "var(--vscode-badge-background)",
+				color: "var(--vscode-badge-foreground)",
+				borderRadius: "3px",
+				padding: "9px",
+				whiteSpace: "pre-line",
+				wordWrap: "break-word",
+			}}
+			onClick={handleClick}>
+			{isEditing ? (
+				<>
+					<DynamicTextArea
+						value={editedText}
+						onChange={(e) => setEditedText(e.target.value)}
+						onBlur={(e) => handleBlur(e)}
+						onKeyDown={handleKeyDown}
+						autoFocus
+						style={{
+							width: "100%",
+							backgroundColor: "var(--vscode-input-background)",
+							color: "var(--vscode-input-foreground)",
+							borderColor: "var(--vscode-input-border)",
+							border: "1px solid",
+							borderRadius: "2px",
+							padding: "6px",
+							fontFamily: "inherit",
+							fontSize: "inherit",
+							lineHeight: "inherit",
+							boxSizing: "border-box",
+							resize: "none",
+							overflowX: "hidden",
+							overflowY: "scroll",
+							scrollbarWidth: "none",
+						}}
+					/>
+					<div style={{ display: "flex", gap: "8px", marginTop: "8px", justifyContent: "flex-end" }}>
+						<RestoreButton
+							ref={restoreAllButtonRef}
+							type="taskAndWorkspace"
+							label="Restore All"
+							isPrimary={true}
+							onClick={handleRestoreWorkspace}
+						/>
+						<RestoreButton
+							ref={restoreChatButtonRef}
+							type="task"
+							label="Restore Chat"
+							isPrimary={false}
+							onClick={handleRestoreWorkspace}
+						/>
+					</div>
+				</>
+			) : (
+				<span style={{ display: "block" }}>{highlightMentions(editedText || text)}</span>
+			)}
+			{images && images.length > 0 && <Thumbnails images={images} style={{ marginTop: "8px" }} />}
+		</div>
+	)
+}
+
+// Reusable button component for restore actions
+interface RestoreButtonProps {
+	type: string
+	label: string
+	isPrimary: boolean
+	onClick: (type: string) => void
+}
+
+const RestoreButton = forwardRef<HTMLButtonElement, RestoreButtonProps>(({ type, label, isPrimary, onClick }, ref) => {
+	const handleClick = (e: React.MouseEvent<HTMLButtonElement>) => {
+		e.stopPropagation()
+		onClick(type)
+	}
+
+	return (
+		<button
+			ref={ref}
+			onClick={handleClick}
+			style={{
+				backgroundColor: isPrimary
+					? "var(--vscode-button-background)"
+					: "var(--vscode-button-secondaryBackground, var(--vscode-descriptionForeground))",
+				color: isPrimary
+					? "var(--vscode-button-foreground)"
+					: "var(--vscode-button-secondaryForeground, var(--vscode-foreground))",
+				border: "none",
+				padding: "4px 8px",
+				borderRadius: "2px",
+				fontSize: "9px",
+				cursor: "pointer",
+			}}>
+			{label}
+		</button>
+	)
+})
+
+export default UserMessage

--- a/webview-ui/src/components/chat/UserMessage.tsx
+++ b/webview-ui/src/components/chat/UserMessage.tsx
@@ -119,6 +119,7 @@ const UserMessage: React.FC<UserMessageProps> = ({ text, images, messageTs, send
 							label="Restore Chat"
 							isPrimary={false}
 							onClick={handleRestoreWorkspace}
+							title="Restore just the chat to this checkpoint and send your message"
 						/>
 						<RestoreButton
 							ref={restoreAllButtonRef}
@@ -126,6 +127,7 @@ const UserMessage: React.FC<UserMessageProps> = ({ text, images, messageTs, send
 							label="Restore All"
 							isPrimary={true}
 							onClick={handleRestoreWorkspace}
+							title="Restore both the chat and workspace files to this checkpoint and send your message"
 						/>
 					</div>
 				</>
@@ -143,9 +145,10 @@ interface RestoreButtonProps {
 	label: string
 	isPrimary: boolean
 	onClick: (type: string) => void
+	title?: string
 }
 
-const RestoreButton = forwardRef<HTMLButtonElement, RestoreButtonProps>(({ type, label, isPrimary, onClick }, ref) => {
+const RestoreButton = forwardRef<HTMLButtonElement, RestoreButtonProps>(({ type, label, isPrimary, onClick, title }, ref) => {
 	const handleClick = (e: React.MouseEvent<HTMLButtonElement>) => {
 		e.stopPropagation()
 		onClick(type)
@@ -155,6 +158,7 @@ const RestoreButton = forwardRef<HTMLButtonElement, RestoreButtonProps>(({ type,
 		<button
 			ref={ref}
 			onClick={handleClick}
+			title={title}
 			style={{
 				backgroundColor: isPrimary
 					? "var(--vscode-button-background)"

--- a/webview-ui/src/components/chat/UserMessage.tsx
+++ b/webview-ui/src/components/chat/UserMessage.tsx
@@ -69,9 +69,10 @@ const UserMessage: React.FC<UserMessageProps> = ({ text, images, messageTs, send
 	const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
 		if (e.key === "Escape") {
 			setIsEditing(false)
-		} else if (e.key === "Enter" && e.metaKey) {
+		} else if (e.key === "Enter" && e.metaKey && !checkpointTrackerErrorMessage) {
 			handleRestoreWorkspace("taskAndWorkspace")
-		} else if (e.key === "Enter" && !checkpointTrackerErrorMessage) {
+		} else if (e.key === "Enter" && !e.shiftKey) {
+			e.preventDefault()
 			handleRestoreWorkspace("task")
 		}
 	}

--- a/webview-ui/src/components/chat/UserMessage.tsx
+++ b/webview-ui/src/components/chat/UserMessage.tsx
@@ -7,7 +7,7 @@ import { useExtensionState } from "@/context/ExtensionStateContext"
 
 interface UserMessageProps {
 	text?: string
-	images?: any[] // Using any[] for now, but you might want to specify the correct type from your codebase
+	images?: string[]
 	messageTs?: number // Timestamp for the message, needed for checkpoint restore
 	sendMessageFromChatRow?: (text: string, images: string[]) => void
 }


### PR DESCRIPTION
### Description

Tap on a message to select the text and edit it to start the conversation from that point

### Test Procedure

I tested both buttons, restoring a workspace and just a task

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<img width="555" alt="Screenshot 2025-04-17 at 11 38 40 AM" src="https://github.com/user-attachments/assets/7fea2594-3c52-45c5-9c46-4a7c4967b041" />

### Additional Notes

Please test restoring task and task + workspace in various workspace states

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add feature to edit and restore previous chat messages in `UserMessage` component, with updates to `restoreCheckpoint` and `WebviewMessage` for offset-based restoration.
> 
>   - **New Feature**:
>     - Users can edit previous chat messages and restore chat or workspace to a previous state.
>     - Implemented in `UserMessage` component with editing and restore buttons.
>   - **Functionality**:
>     - `restoreCheckpoint` in `Task` class updated to support offset-based restoration.
>     - `WebviewMessage` interface updated to include `offset` property.
>   - **UI Components**:
>     - `UserMessage` component allows editing and restoring messages with `DynamicTextArea` and `RestoreButton`.
>     - `ChatRow` and `ChatView` components updated to handle message editing and restoration.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for ef5c7697a8f911b50669439a8387a42c8f3bd6d3. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->