### PR TITLE
Add edit cline rule button

### DIFF
--- a/.changeset/six-birds-move.md
+++ b/.changeset/six-birds-move.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": minor
+---
+
+Add an edit button to the Cline Rules toggle modal to open rule files

--- a/webview-ui/src/components/cline-rules/RuleRow.tsx
+++ b/webview-ui/src/components/cline-rules/RuleRow.tsx
@@ -1,3 +1,6 @@
+import { vscode } from "@/utils/vscode"
+import { VSCodeButton } from "@vscode/webview-ui-toolkit/react"
+
 const RuleRow: React.FC<{
 	rulePath: string
 	enabled: boolean
@@ -5,6 +8,13 @@ const RuleRow: React.FC<{
 }> = ({ rulePath, enabled, toggleRule }) => {
 	// Get the filename from the path for display
 	const displayName = rulePath.split("/").pop() || rulePath
+
+	const handleEditClick = () => {
+		vscode.postMessage({
+			type: "openFile",
+			text: rulePath,
+		})
+	}
 
 	return (
 		<div className="mb-2.5">
@@ -17,7 +27,7 @@ const RuleRow: React.FC<{
 				</span>
 
 				{/* Toggle Switch */}
-				<div className="flex items-center ml-2">
+				<div className="flex items-center ml-2 space-x-2">
 					<div
 						role="switch"
 						aria-checked={enabled}
@@ -40,6 +50,14 @@ const RuleRow: React.FC<{
 							}`}
 						/>
 					</div>
+					<VSCodeButton
+						appearance="icon"
+						aria-label="Edit rule file"
+						title="Edit rule file"
+						onClick={handleEditClick}
+						style={{ height: "20px" }}>
+						<span className="codicon codicon-edit" style={{ fontSize: "14px" }} />
+					</VSCodeButton>
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
### Description

Add an edit button to open the rule file.

### Test Procedure

Tested that it opens both global and local files.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots
<img width="609" alt="Screenshot 2025-04-17 at 1 21 49 PM" src="https://github.com/user-attachments/assets/1332deed-c0c5-4577-b507-98fb6fd7bcf6" />


### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add edit button in `RuleRow` component to open rule files via `vscode` API.
> 
>   - **New Feature**:
>     - Adds an edit button in `RuleRow` component to open rule files.
>     - `handleEditClick` function posts a message to open the file using `vscode` API.
>   - **UI Changes**:
>     - Introduces `VSCodeButton` with edit icon in `RuleRow.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 4dc458f1d2a00e34f7d11f51f2c53ecf8fec0fcc. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->