### PR TITLE
refactor: Make reasoning effort setting model independent

### DIFF
--- a/package.json
+++ b/package.json
@@ -239,7 +239,7 @@
 					"default": false,
 					"description": "Disables extension from spawning browser session."
 				},
-				"cline.modelSettings.o3Mini.reasoningEffort": {
+				"cline.modelSettings.reasoningEffort": {
 					"type": "string",
 					"enum": [
 						"low",
@@ -247,7 +247,7 @@
 						"high"
 					],
 					"default": "medium",
-					"description": "Controls the reasoning effort when using the o3-mini model. Higher values may result in more thorough but slower responses."
+					"description": "Controls the reasoning effort for models that support this feature. Higher values may result in more thorough but slower responses."
 				},
 				"cline.chromeExecutablePath": {
 					"type": "string",

--- a/src/api/providers/cline.ts
+++ b/src/api/providers/cline.ts
@@ -33,7 +33,7 @@ export class ClineHandler implements ApiHandler {
 			systemPrompt,
 			messages,
 			this.getModel(),
-			this.options.o3MiniReasoningEffort,
+			this.options.reasoningEffort,
 			this.options.thinkingBudgetTokens,
 			this.options.openRouterProviderSorting,
 		)

--- a/src/api/providers/openai-native.ts
+++ b/src/api/providers/openai-native.ts
@@ -72,7 +72,9 @@ export class OpenAiNativeHandler implements ApiHandler {
 					messages: [{ role: "developer", content: systemPrompt }, ...convertToOpenAiMessages(messages)],
 					stream: true,
 					stream_options: { include_usage: true },
-					reasoning_effort: (this.options.o3MiniReasoningEffort as ChatCompletionReasoningEffort) || "medium",
+					...(model.info.supportsReasoningEffort
+						? { reasoning_effort: (this.options.reasoningEffort as ChatCompletionReasoningEffort) || "medium" }
+						: {}),
 				})
 				for await (const chunk of stream) {
 					const delta = chunk.choices[0]?.delta

--- a/src/api/providers/openai.ts
+++ b/src/api/providers/openai.ts
@@ -37,7 +37,7 @@ export class OpenAiHandler implements ApiHandler {
 		const modelId = this.options.openAiModelId ?? ""
 		const isDeepseekReasoner = modelId.includes("deepseek-reasoner")
 		const isR1FormatRequired = this.options.openAiModelInfo?.isR1FormatRequired ?? false
-		const isReasoningModelFamily = modelId.includes("o3") || modelId.includes("o4")
+		const supportsReasoningEffort = this.options.openAiModelInfo?.supportsReasoningEffort ?? false
 
 		let openAiMessages: OpenAI.Chat.ChatCompletionMessageParam[] = [
 			{ role: "system", content: systemPrompt },
@@ -57,10 +57,10 @@ export class OpenAiHandler implements ApiHandler {
 			openAiMessages = convertToR1Format([{ role: "user", content: systemPrompt }, ...messages])
 		}
 
-		if (isReasoningModelFamily) {
+		if (supportsReasoningEffort) {
 			openAiMessages = [{ role: "developer", content: systemPrompt }, ...convertToOpenAiMessages(messages)]
 			temperature = undefined // does not support temperature
-			reasoningEffort = (this.options.o3MiniReasoningEffort as ChatCompletionReasoningEffort) || "medium"
+			reasoningEffort = (this.options.reasoningEffort as ChatCompletionReasoningEffort) || "medium"
 		}
 
 		const stream = await this.client.chat.completions.create({

--- a/src/api/providers/openrouter.ts
+++ b/src/api/providers/openrouter.ts
@@ -35,7 +35,7 @@ export class OpenRouterHandler implements ApiHandler {
 			systemPrompt,
 			messages,
 			this.getModel(),
-			this.options.o3MiniReasoningEffort,
+			this.options.reasoningEffort,
 			this.options.thinkingBudgetTokens,
 			this.options.openRouterProviderSorting,
 		)

--- a/src/api/providers/requesty.ts
+++ b/src/api/providers/requesty.ts
@@ -32,9 +32,9 @@ export class RequestyHandler implements ApiHandler {
 			...convertToOpenAiMessages(messages),
 		]
 
-		const reasoningEffort = this.options.o3MiniReasoningEffort || "medium"
+		const reasoningEffort = this.options.reasoningEffort || "medium"
 		const reasoning = { reasoning_effort: reasoningEffort }
-		const reasoningArgs = model.id === "openai/o3-mini" ? reasoning : {}
+		const reasoningArgs = model.info.supportsReasoningEffort ? reasoning : {}
 
 		const thinkingBudget = this.options.thinkingBudgetTokens || 0
 		const thinking =

--- a/src/api/transform/openrouter-stream.ts
+++ b/src/api/transform/openrouter-stream.ts
@@ -11,7 +11,7 @@ export async function createOpenRouterStream(
 	systemPrompt: string,
 	messages: Anthropic.Messages.MessageParam[],
 	model: { id: string; info: ModelInfo },
-	o3MiniReasoningEffort?: string,
+	reasoningEffort?: string,
 	thinkingBudgetTokens?: number,
 	openRouterProviderSorting?: string,
 ) {
@@ -145,7 +145,7 @@ export async function createOpenRouterStream(
 		stream_options: { include_usage: true },
 		transforms: shouldApplyMiddleOutTransform ? ["middle-out"] : undefined,
 		include_reasoning: true,
-		...(model.id === "openai/o3-mini" ? { reasoning_effort: o3MiniReasoningEffort || "medium" } : {}),
+		...(model.info.supportsReasoningEffort ? { reasoning_effort: reasoningEffort || "medium" } : {}),
 		...(reasoning ? { reasoning } : {}),
 		...(openRouterProviderSorting ? { provider: { sort: openRouterProviderSorting } } : {}),
 	})

--- a/src/core/storage/state.ts
+++ b/src/core/storage/state.ts
@@ -119,7 +119,6 @@ export async function getAllExtensionState(context: vscode.ExtensionContext) {
 		asksageApiUrl,
 		xaiApiKey,
 		thinkingBudgetTokens,
-		reasoningEffort,
 		sambanovaApiKey,
 		planActSeparateModelsSettingRaw,
 		favoritedModelIds,
@@ -214,14 +213,14 @@ export async function getAllExtensionState(context: vscode.ExtensionContext) {
 
 	const localClineRulesToggles = (await getWorkspaceState(context, "localClineRulesToggles")) as ClineRulesToggles
 
-	const o3MiniReasoningEffort = vscode.workspace.getConfiguration("cline.modelSettings.o3Mini").get("reasoningEffort", "medium")
+	const reasoningEffort = vscode.workspace.getConfiguration("cline.modelSettings").get("reasoningEffort", "medium")
 
 	const mcpMarketplaceEnabled = vscode.workspace.getConfiguration("cline").get<boolean>("mcpMarketplace.enabled", true)
 
 	// Plan/Act separate models setting is a boolean indicating whether the user wants to use different models for plan and act. Existing users expect this to be enabled, while we want new users to opt in to this being disabled by default.
 	// On win11 state sometimes initializes as empty string instead of undefined
 	let planActSeparateModelsSetting: boolean | undefined = undefined
-	if (planActSeparateModelsSettingRaw === true || planActSeparateModelsSettingRaw === false) {
+	if (typeof planActSeparateModelsSettingRaw === "boolean") {
 		planActSeparateModelsSetting = planActSeparateModelsSettingRaw
 	} else {
 		// default to true for existing users
@@ -282,7 +281,6 @@ export async function getAllExtensionState(context: vscode.ExtensionContext) {
 			openRouterModelInfo,
 			openRouterProviderSorting,
 			vsCodeLmModelSelector,
-			o3MiniReasoningEffort,
 			thinkingBudgetTokens,
 			reasoningEffort,
 			liteLlmBaseUrl,

--- a/src/core/storage/state.ts
+++ b/src/core/storage/state.ts
@@ -119,6 +119,7 @@ export async function getAllExtensionState(context: vscode.ExtensionContext) {
 		asksageApiUrl,
 		xaiApiKey,
 		thinkingBudgetTokens,
+		reasoningEffort,
 		sambanovaApiKey,
 		planActSeparateModelsSettingRaw,
 		favoritedModelIds,
@@ -213,14 +214,12 @@ export async function getAllExtensionState(context: vscode.ExtensionContext) {
 
 	const localClineRulesToggles = (await getWorkspaceState(context, "localClineRulesToggles")) as ClineRulesToggles
 
-	const reasoningEffort = vscode.workspace.getConfiguration("cline.modelSettings").get("reasoningEffort", "medium")
-
 	const mcpMarketplaceEnabled = vscode.workspace.getConfiguration("cline").get<boolean>("mcpMarketplace.enabled", true)
 
 	// Plan/Act separate models setting is a boolean indicating whether the user wants to use different models for plan and act. Existing users expect this to be enabled, while we want new users to opt in to this being disabled by default.
 	// On win11 state sometimes initializes as empty string instead of undefined
 	let planActSeparateModelsSetting: boolean | undefined = undefined
-	if (typeof planActSeparateModelsSettingRaw === "boolean") {
+	if (planActSeparateModelsSettingRaw === true || planActSeparateModelsSettingRaw === false) {
 		planActSeparateModelsSetting = planActSeparateModelsSettingRaw
 	} else {
 		// default to true for existing users

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -71,7 +71,6 @@ export interface ApiHandlerOptions {
 	mistralApiKey?: string
 	azureApiVersion?: string
 	vsCodeLmModelSelector?: LanguageModelChatSelector
-	o3MiniReasoningEffort?: string
 	qwenApiLine?: string
 	asksageApiUrl?: string
 	asksageApiKey?: string
@@ -99,6 +98,7 @@ export interface ModelInfo {
 	supportsImages?: boolean
 	supportsComputerUse?: boolean
 	supportsPromptCache: boolean // this value is hardcoded for now
+	supportsReasoningEffort?: boolean
 	inputPrice?: number // Keep for non-tiered input models
 	inputPriceTiers?: PriceTier[] // Add for tiered input pricing
 	outputPrice?: number // Keep for non-tiered output models
@@ -111,6 +111,7 @@ export interface ModelInfo {
 export interface OpenAiCompatibleModelInfo extends ModelInfo {
 	temperature?: number
 	isR1FormatRequired?: boolean
+	supportsReasoningEffort?: boolean
 }
 
 // Anthropic
@@ -612,6 +613,7 @@ export const openAiNativeModels = {
 		contextWindow: 200_000,
 		supportsImages: true,
 		supportsPromptCache: true,
+		supportsReasoningEffort: true,
 		inputPrice: 10.0,
 		outputPrice: 40.0,
 		cacheReadsPrice: 2.5,
@@ -621,6 +623,7 @@ export const openAiNativeModels = {
 		contextWindow: 200_000,
 		supportsImages: true,
 		supportsPromptCache: true,
+		supportsReasoningEffort: true,
 		inputPrice: 1.1,
 		outputPrice: 4.4,
 		cacheReadsPrice: 0.275,
@@ -657,6 +660,7 @@ export const openAiNativeModels = {
 		contextWindow: 200_000,
 		supportsImages: false,
 		supportsPromptCache: true,
+		supportsReasoningEffort: true,
 		inputPrice: 1.1,
 		outputPrice: 4.4,
 		cacheReadsPrice: 0.55,
@@ -1415,6 +1419,7 @@ export const xaiModels = {
 		contextWindow: 131072,
 		supportsImages: false,
 		supportsPromptCache: false,
+		supportsReasoningEffort: true,
 		inputPrice: 0.3,
 		outputPrice: 0.5,
 		description: "X AI's Grok-3 mini beta model with 131K context window",
@@ -1424,6 +1429,7 @@ export const xaiModels = {
 		contextWindow: 131072,
 		supportsImages: false,
 		supportsPromptCache: false,
+		supportsReasoningEffort: true,
 		inputPrice: 0.6,
 		outputPrice: 4.0,
 		description: "X AI's Grok-3 mini fast beta model with 131K context window",

--- a/webview-ui/src/components/settings/ApiOptions.tsx
+++ b/webview-ui/src/components/settings/ApiOptions.tsx
@@ -1616,7 +1616,7 @@ const ApiOptions = ({ showModelOptions, apiErrorMessage, modelIdErrorMessage, is
 							<ThinkingBudgetSlider apiConfiguration={apiConfiguration} setApiConfiguration={setApiConfiguration} />
 						)}
 
-						{selectedProvider === "xai" && selectedModelId.includes("3-mini") && (
+						{selectedModelInfo.supportsReasoningEffort && (
 							<>
 								<VSCodeCheckbox
 									style={{ marginTop: 0 }}

--- a/webview-ui/src/components/settings/ApiOptions.tsx
+++ b/webview-ui/src/components/settings/ApiOptions.tsx
@@ -1651,6 +1651,7 @@ const ApiOptions = ({ showModelOptions, apiErrorMessage, modelIdErrorMessage, is
 													})
 												}}>
 												<VSCodeOption value="low">low</VSCodeOption>
+												<VSCodeOption value="medium">medium</VSCodeOption>
 												<VSCodeOption value="high">high</VSCodeOption>
 											</VSCodeDropdown>
 										</DropdownContainer>


### PR DESCRIPTION
### Description

Refactors the `o3MiniReasoningEffort` setting and related logic to be model-independent. Previously, this setting was specifically tied to OpenAI's o3-mini model, but the functionality was also being used for other o3/o4 models and in the OpenRouter and Requesty providers.

This change generalizes the concept of a 'reasoning effort' setting and allows it to be applied to any model that supports this feature by adding a `supportsReasoningEffort` flag to the `ModelInfo`.

Modified files:
- `package.json`: Renamed the configuration setting key from `cline.modelSettings.o3Mini.reasoningEffort` to `cline.modelSettings.reasoningEffort` and updated the description.
- `src/shared/api.ts`: Renamed `o3MiniReasoningEffort` to `reasoningEffort` in `ApiHandlerOptions` and added `supportsReasoningEffort?: boolean` to the `ModelInfo` interface. Updated `openAiNativeModels` and `xaiModels` to set `supportsReasoningEffort: true` for relevant models.
- `src/api/providers/openai.ts`: Updated to use `this.options.reasoningEffort` and check `model.info.supportsReasoningEffort`.
- `src/api/providers/cline.ts`: Updated to pass `this.options.reasoningEffort` to `createOpenRouterStream`.
- `src/api/providers/openai-native.ts`: Updated to use `this.options.reasoningEffort` and check `model.info.supportsReasoningEffort`.
- `src/api/providers/requesty.ts`: Updated to use `this.options.reasoningEffort` and check `model.info.supportsReasoningEffort`.
- `src/api/transform/openrouter-stream.ts`: Renamed the `o3MiniReasoningEffort` parameter to `reasoningEffort` and updated the logic to check `model.info.supportsReasoningEffort`.
- `src/core/storage/state.ts`: Updated to read the `cline.modelSettings.reasoningEffort` configuration setting.
- `webview-ui/src/components/settings/ApiOptions.tsx`: Updated the UI logic to use `selectedModelInfo.supportsReasoningEffing effort control.

### Test Procedure

1. Verified that the project builds without TypeScript or linting errors.
2. Checked the Settings UI to confirm that the 'Modify reasoning effort' checkbox and dropdown appear only when a model that supports reasoning effort (e.g., OpenAI Native o3/o4-mini, XAI Grok 3 mini) is selected.
3. Confirmed that selecting different reasoning effort options updates the setting value.
4. Reviewed the code changes in the API providers and stream transformation to ensure the `reasoning_effort` parameter is correctly included in API calls based on the `supportsReasoningEffort` flag.

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [x] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<img width="270" alt="image" src="https://github.com/user-attachments/assets/cbd56cff-6e67-4c12-a728-b5c0ca67cc47" />

<img width="660" alt="image" src="https://github.com/user-attachments/assets/c696ceef-1b10-4164-8ee5-880a84055980" />

<img width="619" alt="image" src="https://github.com/user-attachments/assets/2301104c-bebf-454b-9592-c4db65c9a0a1" />


### Additional Notes

This refactor makes the reasoning effort setting more flexible and easier to extend to other models in the future. Any new model that supports a similar reasoning effort parameter can now utilize this setting by simply adding `supportsReasoningEffort: true` to its `ModelInfo` definition in `src/shared/api.ts`.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Refactors reasoning effort setting to be model-independent, updating configurations and logic across multiple files and UI components.
> 
>   - **Behavior**:
>     - Generalizes `reasoningEffort` setting to be model-independent by adding `supportsReasoningEffort` flag to `ModelInfo` in `src/shared/api.ts`.
>     - Updates `ApiHandlerOptions` in `src/shared/api.ts` to include `reasoningEffort`.
>     - Modifies `src/api/providers/openai.ts`, `src/api/providers/cline.ts`, `src/api/providers/openai-native.ts`, and `src/api/providers/requesty.ts` to use `this.options.reasoningEffort` and check `model.info.supportsReasoningEffort`.
>   - **UI**:
>     - Updates `webview-ui/src/components/settings/ApiOptions.tsx` to show reasoning effort controls only for models that support it.
>   - **Misc**:
>     - Renames `o3MiniReasoningEffort` to `reasoningEffort` in `package.json` and `src/shared/api.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 99308665e1d930f72929064182924727caca6933. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->