### PR TITLE
[PROTOBUS] gRPC-ized discoverBrowser

### DIFF
--- a/proto/browser.proto
+++ b/proto/browser.proto
@@ -7,6 +7,7 @@ import "common.proto";
 service BrowserService {
   rpc getBrowserConnectionInfo(EmptyRequest) returns (BrowserConnectionInfo);
   rpc testBrowserConnection(StringRequest) returns (BrowserConnection);
+  rpc discoverBrowser(EmptyRequest) returns (BrowserConnection);
 }
 
 message BrowserConnectionInfo {

--- a/src/core/controller/browser/discoverBrowser.ts
+++ b/src/core/controller/browser/discoverBrowser.ts
@@ -6,7 +6,7 @@ import { BrowserSession } from "../../../services/browser/BrowserSession"
 import { discoverChromeInstances } from "../../../services/browser/BrowserDiscovery"
 
 /**
- * Discover Chrome instances on the network
+ * Discover Chrome instances
  * @param controller The controller instance
  * @param request The request message
  * @returns The browser connection result
@@ -33,7 +33,7 @@ export async function discoverBrowser(controller: Controller, request: EmptyRequ
 			return {
 				success: false,
 				message:
-					"No Chrome instances found on the network. Make sure Chrome is running with remote debugging enabled (--remote-debugging-port=9222).",
+					"No Chrome instances found. Make sure Chrome is running with remote debugging enabled (--remote-debugging-port=9222).",
 				endpoint: "",
 			}
 		}

--- a/src/core/controller/browser/discoverBrowser.ts
+++ b/src/core/controller/browser/discoverBrowser.ts
@@ -1,0 +1,47 @@
+import { BrowserConnection } from "../../../shared/proto/browser"
+import { EmptyRequest } from "../../../shared/proto/common"
+import { Controller } from "../index"
+import { getAllExtensionState } from "../../storage/state"
+import { BrowserSession } from "../../../services/browser/BrowserSession"
+import { discoverChromeInstances } from "../../../services/browser/BrowserDiscovery"
+
+/**
+ * Discover Chrome instances on the network
+ * @param controller The controller instance
+ * @param request The request message
+ * @returns The browser connection result
+ */
+export async function discoverBrowser(controller: Controller, request: EmptyRequest): Promise<BrowserConnection> {
+	try {
+		const discoveredHost = await discoverChromeInstances()
+
+		if (discoveredHost) {
+			// Don't update the remoteBrowserHost state when auto-discovering
+			// This way we don't override the user's preference
+
+			// Test the connection to get the endpoint
+			const { browserSettings } = await getAllExtensionState(controller.context)
+			const browserSession = new BrowserSession(controller.context, browserSettings)
+			const result = await browserSession.testConnection(discoveredHost)
+
+			return {
+				success: true,
+				message: `Successfully discovered and connected to Chrome at ${discoveredHost}`,
+				endpoint: result.endpoint || "",
+			}
+		} else {
+			return {
+				success: false,
+				message:
+					"No Chrome instances found on the network. Make sure Chrome is running with remote debugging enabled (--remote-debugging-port=9222).",
+				endpoint: "",
+			}
+		}
+	} catch (error) {
+		return {
+			success: false,
+			message: `Error discovering browser: ${error instanceof Error ? error.message : String(error)}`,
+			endpoint: "",
+		}
+	}
+}

--- a/src/core/controller/browser/methods.ts
+++ b/src/core/controller/browser/methods.ts
@@ -3,12 +3,14 @@
 
 // Import all method implementations
 import { registerMethod } from "./index"
+import { discoverBrowser } from "./discoverBrowser"
 import { getBrowserConnectionInfo } from "./getBrowserConnectionInfo"
 import { testBrowserConnection } from "./testBrowserConnection"
 
 // Register all browser service methods
 export function registerAllMethods(): void {
 	// Register each method with the registry
+	registerMethod("discoverBrowser", discoverBrowser)
 	registerMethod("getBrowserConnectionInfo", getBrowserConnectionInfo)
 	registerMethod("testBrowserConnection", testBrowserConnection)
 }

--- a/src/core/controller/index.ts
+++ b/src/core/controller/index.ts
@@ -311,41 +311,6 @@ export class Controller {
 					await this.postStateToWebview()
 				}
 				break
-			case "discoverBrowser":
-				try {
-					const discoveredHost = await discoverChromeInstances()
-
-					if (discoveredHost) {
-						// Don't update the remoteBrowserHost state when auto-discovering
-						// This way we don't override the user's preference
-
-						// Test the connection to get the endpoint
-						const { browserSettings } = await getAllExtensionState(this.context)
-						const browserSession = new BrowserSession(this.context, browserSettings)
-						const result = await browserSession.testConnection(discoveredHost)
-
-						// Send the result back to the webview
-						await this.postMessageToWebview({
-							type: "browserConnectionResult",
-							success: true,
-							text: `Successfully discovered and connected to Chrome at ${discoveredHost}`,
-							endpoint: result.endpoint,
-						})
-					} else {
-						await this.postMessageToWebview({
-							type: "browserConnectionResult",
-							success: false,
-							text: "No Chrome instances found on the network. Make sure Chrome is running with remote debugging enabled (--remote-debugging-port=9222).",
-						})
-					}
-				} catch (error) {
-					await this.postMessageToWebview({
-						type: "browserConnectionResult",
-						success: false,
-						text: `Error discovering browser: ${error instanceof Error ? error.message : String(error)}`,
-					})
-				}
-				break
 			case "togglePlanActMode":
 				if (message.chatSettings) {
 					await this.togglePlanActModeWithChatSettings(message.chatSettings, message.chatContent)

--- a/src/shared/WebviewMessage.ts
+++ b/src/shared/WebviewMessage.ts
@@ -39,7 +39,6 @@ export interface WebviewMessage {
 		| "deleteMcpServer"
 		| "autoApprovalSettings"
 		| "browserSettings"
-		| "discoverBrowser"
 		| "browserRelaunchResult"
 		| "togglePlanActMode"
 		| "checkpointDiff"

--- a/src/shared/proto/browser.ts
+++ b/src/shared/proto/browser.ts
@@ -227,6 +227,14 @@ export const BrowserServiceDefinition = {
 			responseStream: false,
 			options: {},
 		},
+		discoverBrowser: {
+			name: "discoverBrowser",
+			requestType: EmptyRequest,
+			requestStream: false,
+			responseType: BrowserConnection,
+			responseStream: false,
+			options: {},
+		},
 	},
 } as const
 

--- a/webview-ui/src/components/settings/BrowserSettingsSection.tsx
+++ b/webview-ui/src/components/settings/BrowserSettingsSection.tsx
@@ -107,7 +107,6 @@ export const BrowserSettingsSection: React.FC = () => {
 							setIsCheckingConnection(false)
 						})
 				} else {
-					// Use gRPC for discoverBrowser
 					BrowserServiceClient.discoverBrowser({})
 						.then((result) => {
 							setConnectionStatus(result.success)
@@ -186,7 +185,6 @@ export const BrowserSettingsSection: React.FC = () => {
 					setConnectionStatus(false)
 				})
 		} else {
-			// Use gRPC for discoverBrowser
 			BrowserServiceClient.discoverBrowser({})
 				.then((result) => {
 					setConnectionStatus(result.success)

--- a/webview-ui/src/components/settings/BrowserSettingsSection.tsx
+++ b/webview-ui/src/components/settings/BrowserSettingsSection.tsx
@@ -107,10 +107,17 @@ export const BrowserSettingsSection: React.FC = () => {
 							setIsCheckingConnection(false)
 						})
 				} else {
-					// Use old message passing for discoverBrowser (not yet migrated)
-					vscode.postMessage({
-						type: "discoverBrowser",
-					})
+					// Use gRPC for discoverBrowser
+					BrowserServiceClient.discoverBrowser({})
+						.then((result) => {
+							setConnectionStatus(result.success)
+							setIsCheckingConnection(false)
+						})
+						.catch((error) => {
+							console.error("Error discovering browser:", error)
+							setConnectionStatus(false)
+							setIsCheckingConnection(false)
+						})
 				}
 			}
 		}, 1000),
@@ -179,10 +186,15 @@ export const BrowserSettingsSection: React.FC = () => {
 					setConnectionStatus(false)
 				})
 		} else {
-			// Use old message passing for discoverBrowser (not yet migrated)
-			vscode.postMessage({
-				type: "discoverBrowser",
-			})
+			// Use gRPC for discoverBrowser
+			BrowserServiceClient.discoverBrowser({})
+				.then((result) => {
+					setConnectionStatus(result.success)
+				})
+				.catch((error) => {
+					console.error("Error discovering browser:", error)
+					setConnectionStatus(false)
+				})
 		}
 	}, [browserSettings.remoteBrowserHost])
 


### PR DESCRIPTION
Note: reviewing this code, I think discoverBrowser may not be super necessary anymore. It came from a time where we might discover browsers on the network. Since it only ever looks at localhost currently (unless a host setting is available), it's probable that this code can be removed. But for the sake of keeping these refactors simple, I'm not going to change the logic at this point, and we can wait for another round of browser control improvements

### Test Procedure

Test remote browser with various settings, make sure it's discovered automatically

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [x] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Refactor `discoverBrowser` to use gRPC in `BrowserService`, moving logic to `discoverBrowser.ts` and updating UI to use gRPC.
> 
>   - **gRPC Integration**:
>     - Added `discoverBrowser` RPC method to `BrowserService` in `proto/browser.proto`.
>     - Implemented `discoverBrowser()` in `discoverBrowser.ts` to handle browser discovery using gRPC.
>   - **Refactoring**:
>     - Moved `discoverBrowser` logic from `Controller` to `discoverBrowser.ts`.
>     - Registered `discoverBrowser` method in `methods.ts`.
>   - **UI Updates**:
>     - Updated `BrowserSettingsSection.tsx` to use gRPC for `discoverBrowser` instead of message passing.
>   - **Miscellaneous**:
>     - Removed `discoverBrowser` from `WebviewMessage.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 33e4a0bce11ef4ea3bb15dfb5af169e68d5ff225. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->