### PR TITLE
fix: task cancellation during thinking stream would result in 'Cline aborted stream' error

### DIFF
--- a/.changeset/happy-lies-dress.md
+++ b/.changeset/happy-lies-dress.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+fix: task cancellation during thinking stream would result in 'Cline aborted stream' error

--- a/src/core/task/index.ts
+++ b/src/core/task/index.ts
@@ -3451,7 +3451,10 @@ export class Task {
 						case "reasoning":
 							// reasoning will always come before assistant message
 							reasoningMessage += chunk.reasoning
-							await this.say("reasoning", reasoningMessage, undefined, true)
+							// fixes bug where cancelling task > aborts task > for loop may be in middle of streaming reasoning > say function throws error before we get a chance to properly clean up and cancel the task.
+							if (!this.abort) {
+								await this.say("reasoning", reasoningMessage, undefined, true)
+							}
 							break
 						case "text":
 							if (reasoningMessage && assistantMessage.length === 0) {


### PR DESCRIPTION
When cancelling the task while claude 3.7 sonnet is streaming thinking, it would show 'Cline aborted task' instead of the usual API Request Cancelled. This PR fixes the issue by addressing an underlying race condition.

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix bug in `Task` class to prevent 'Cline aborted stream' error during task cancellation in reasoning stream.
> 
>   - **Bug Fix**:
>     - In `Task` class, fix bug in `src/core/task/index.ts` where cancelling a task during reasoning stream caused a 'Cline aborted stream' error.
>     - Added check for `this.abort` before calling `this.say()` in the reasoning case to prevent error during task cancellation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 30459086b731cca4ac9e1dd8c0018485d564abb4. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->