### PR TITLE
Fix: Expand ${workspaceFolder} for MCP stdio transport cwd/env

### DIFF
--- a/.changeset/happy-lies-dress.md
+++ b/.changeset/happy-lies-dress.md
@@ -1,5 +1,0 @@
----
-"claude-dev": patch
----
-
-fix: task cancellation during thinking stream would result in 'Cline aborted stream' error

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [3.13.1]
+
+-   Fix bug where task cancellation during thinking stream would result in error state
+
 ## [3.13.0]
 
 -   Add Cline rules popover under the chat field, allowing you to easily add, enable & disable workspace level or global rule files
@@ -16,7 +20,6 @@
 -   Fix issue where some commands with large output would cause UI to freeze
 -   Fix token usage tracking issues with vertex provider (Thanks @mzsima!)
 -   Fix issue with xAI reasoning content not being parsed (Thanks @mrubens!)
-
 
 ## [3.12.3]
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "claude-dev",
 	"displayName": "Cline",
 	"description": "Autonomous coding agent right in your IDE, capable of creating/editing files, running commands, using the browser, and more with your permission every step of the way.",
-	"version": "3.13.0",
+	"version": "3.13.1",
 	"icon": "assets/icons/icon.png",
 	"engines": {
 		"vscode": "^1.84.0"


### PR DESCRIPTION
### Description

This PR addresses an issue where the `${workspaceFolder}` variable was not being expanded when used in the `cwd` (current working directory) or `env` (environment variables) fields for MCP servers configured with the `stdio` transport type.

**Problem:**

-   Servers launched via Cline would start in an incorrect directory (e.g., the VS Code installation directory) instead of the intended project workspace root specified by `${workspaceFolder}` in the `cwd` setting.
-   Environment variables defined using `${workspaceFolder}` (e.g., `PROJECT_ROOT`) would contain the literal string `${workspaceFolder}` instead of the resolved path.
-   This prevented servers from correctly resolving relative file paths based on the active workspace, leading to errors when accessing project files or writing output.

**Cause:**

The logic within `src/services/mcp/McpHub.ts` for initializing the `@modelcontextprotocol/sdk/client/stdio.js` `StdioClientTransport` did not include logic to explicitly expand the `${workspaceFolder}` variable for the `cwd` and `env` configuration options (as well as `command` and `args`) before spawning the server process.

**Solution:**

This PR modifies the `connectToServer` method in `src/services/mcp/McpHub.ts` to:
1.  Reliably determine the `workspaceRoot` path using the `vscode.workspace.workspaceFolders` API.
2.  Implement an `expand` function that replaces occurrences of the literal string `${workspaceFolder}` with the actual `workspaceRoot` path.
3.  Apply this `expand` function to the `command`, `args`, `env` values, and the `cwd` value obtained from the server configuration *before* constructing the `StdioClientTransport`.
4.  Provide a fallback for `cwd` to default to the determined `workspaceRoot` if `cwd` is not explicitly set in the server configuration.

This ensures that the server process is launched with the correct working directory and properly resolved environment variable paths when `${workspaceFolder}` is used in the configuration.

### Test Procedure

1.  Configured an MCP server (e.g., `FileDump`) using the `stdio` transport in settings (e.g., `cline_mcp_settings.json` or workspace `.vscode/settings.json`).
2.  Set `"cwd": "${workspaceFolder}"` in the server configuration.
3.  Set `"env": { "PROJECT_ROOT": "${workspaceFolder}" }` in the server configuration.
4.  Added debug logging at the start of the target server script (e.g., in Python using `os.getcwd()` and `os.getenv('PROJECT_ROOT')`) to print the CWD and relevant environment variable on startup.
5.  Launched VS Code in a specific project workspace.
6.  Started the configured MCP server via the Cline interface.
7.  **Verified:** Checked the MCP server's output logs. Confirmed that the logged `cwd` and the value of the `PROJECT_ROOT` environment variable correctly reflected the actual workspace path, not the VS Code installation directory or the literal string `${workspaceFolder}`.
8.  **Verified:** Confirmed that tool calls involving relative paths now correctly resolved paths relative to the workspace root.

### Type of Change

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation update
-   [ ] Other (please describe):