### PR TITLE
Running Commands Old-School + Living on the Edge with the Latest VSIX

### DIFF
--- a/src/services/test/TestServer.ts
+++ b/src/services/test/TestServer.ts
@@ -503,8 +503,6 @@ export function createMessageCatcher(webviewProvider: WebviewProvider): vscode.D
 
 		// Intercept outgoing messages from extension to webview
 		webviewProvider.controller.postMessageToWebview = async (message: ExtensionMessage) => {
-			Logger.log("Cline message received: " + JSON.stringify(message))
-
 			// Check for completion_result message
 			if (message.type === "partialMessage" && message.partialMessage?.say === "completion_result") {
 				// Complete the current task


### PR DESCRIPTION
### Description

We had a problem with evals getting confused as to what VSIX to use, so now we use whichever VSIX was the last one to be generated.

Also, we had a problem with flaky VS code terminal commands, so we're using node shell environment instead to run commands for guaranteed outputs.

### Test Procedure

<!-- How did you test this? Are you confident that it will not introduce bugs? If so, why? -->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> This PR improves VSIX selection by using the most recent file and enhances command execution reliability by using Node.js for command execution in test mode.
> 
>   - **Behavior**:
>     - In `vscode.ts`, selects the most recent VSIX file by modification time if multiple are found, logging all found VSIX files.
>     - In `index.ts`, adds `executeCommandInNode()` to run commands in Node.js for reliable output, especially in test mode.
>   - **Logging**:
>     - Removes redundant logging in `TestServer.ts` for received messages.
>   - **Misc**:
>     - Adjusts command execution logic to handle timeouts and output collection in `index.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 18f0e510600d822c2e86710179832b468ed87e72. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->