### PR TITLE
ENG-318 feat: Show openrouter balance next to provider

### DIFF
--- a/.changeset/thirty-feet-rule.md
+++ b/.changeset/thirty-feet-rule.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Adding UI to show openrouter balance next to provider

--- a/webview-ui/src/components/ui/hooks/useOpenRouterKeyInfo.ts
+++ b/webview-ui/src/components/ui/hooks/useOpenRouterKeyInfo.ts
@@ -92,7 +92,6 @@ export const useOpenRouterKeyInfo = (apiKey?: string) => {
 
 		// Use cached data immediately if available
 		if (hasCache) {
-			console.log("[useOpenRouterKeyInfo] Cache hit: true")
 			// Ensure local state matches module cache if it hasn't updated yet
 			// This handles cases where the hook re-renders before the effect runs
 			if (data !== moduleCachedData) {
@@ -100,7 +99,6 @@ export const useOpenRouterKeyInfo = (apiKey?: string) => {
 			}
 			setIsLoading(false)
 		} else {
-			console.log("[useOpenRouterKeyInfo] Cache hit: false")
 			setIsLoading(true)
 			setError(null)
 		}

--- a/webview-ui/src/components/ui/hooks/useOpenRouterKeyInfo.ts
+++ b/webview-ui/src/components/ui/hooks/useOpenRouterKeyInfo.ts
@@ -1,0 +1,150 @@
+import { z } from "zod"
+import { useState, useEffect } from "react"
+
+const CACHE_DURATION_MS = 30 * 1000 // 30 seconds
+const OpenRouterBaseURL = "https://openrouter.ai/api/v1"
+
+// Define schema for OpenRouter key response
+const openRouterKeyInfoSchema = z.object({
+	data: z.object({
+		label: z.string().nullable(),
+		usage: z.number(),
+		is_free_tier: z.boolean(),
+		is_provisioning_key: z.boolean(),
+		rate_limit: z.object({
+			requests: z.number(),
+			interval: z.string(),
+		}),
+		limit: z.number().nullable(),
+	}),
+})
+export type OpenRouterKeyInfo = z.infer<typeof openRouterKeyInfoSchema>["data"]
+
+// Module-level cache variables
+let moduleCachedData: OpenRouterKeyInfo | null = null
+let moduleLastFetchTime: number | null = null
+
+async function getOpenRouterKeyInfo(apiKey: string, signal: AbortSignal): Promise<OpenRouterKeyInfo | null> {
+	try {
+		const keyEndpoint = `${OpenRouterBaseURL}/key`
+		const response = await fetch(keyEndpoint, {
+			headers: {
+				Authorization: `Bearer ${apiKey}`,
+			},
+			signal,
+		})
+
+		if (!response.ok) {
+			if (response.status === 401) {
+				console.warn("OpenRouter API key is invalid or unauthorized.")
+			} else {
+				console.error(`Error fetching OpenRouter key info: HTTP ${response.status}`)
+			}
+			return null
+		}
+
+		const responseData = await response.json()
+		const result = openRouterKeyInfoSchema.safeParse(responseData)
+		if (!result.success) {
+			console.error("OpenRouter API key info validation failed:", result.error.flatten().fieldErrors)
+			return null
+		}
+		return result.data.data
+	} catch (error: any) {
+		if (error.name !== "AbortError") {
+			console.error("Error fetching OpenRouter key info:", error)
+		}
+		return null
+	}
+}
+
+/**
+ * Custom hook to fetch OpenRouter API key information.
+ * Implements stale-while-revalidate caching using module-level variables.
+ * @param apiKey The OpenRouter API key.
+ * @returns An object containing the key info data, loading state, and error state.
+ */
+export const useOpenRouterKeyInfo = (apiKey?: string) => {
+	// State reflects the currently displayed data, initialized from cache
+	const [data, setData] = useState<OpenRouterKeyInfo | null>(moduleCachedData)
+	// Loading is true only if there's no initial cache and a key is provided
+	const [isLoading, setIsLoading] = useState<boolean>(!moduleCachedData && !!apiKey)
+	const [error, setError] = useState<Error | null>(null)
+
+	useEffect(() => {
+		const controller = new AbortController()
+		const signal = controller.signal
+
+		if (!apiKey) {
+			// Clear state and cache if API key is removed
+			setData(null)
+			moduleCachedData = null
+			moduleLastFetchTime = null
+			setIsLoading(false)
+			setError(null)
+			return () => controller.abort()
+		}
+
+		const now = Date.now()
+		const cacheAge = moduleLastFetchTime ? now - moduleLastFetchTime : Infinity
+		const isCacheStale = cacheAge >= CACHE_DURATION_MS
+		const hasCache = !!moduleCachedData
+
+		// Use cached data immediately if available
+		if (hasCache) {
+			console.log("[useOpenRouterKeyInfo] Cache hit: true")
+			// Ensure local state matches module cache if it hasn't updated yet
+			// This handles cases where the hook re-renders before the effect runs
+			if (data !== moduleCachedData) {
+				setData(moduleCachedData)
+			}
+			setIsLoading(false)
+		} else {
+			console.log("[useOpenRouterKeyInfo] Cache hit: false")
+			setIsLoading(true)
+			setError(null)
+		}
+
+		// Fetch if cache is stale or doesn't exist
+		if (isCacheStale || !hasCache) {
+			const isBackgroundFetch = hasCache && isCacheStale // Fetching while showing stale data
+
+			// Don't set loading true for background fetches
+			if (!isBackgroundFetch) {
+				setIsLoading(true)
+			}
+
+			getOpenRouterKeyInfo(apiKey, signal)
+				.then((result) => {
+					if (!signal.aborted) {
+						moduleCachedData = result // Update module cache
+						moduleLastFetchTime = Date.now() // Update module fetch time
+						setData(result) // Update state
+						setError(null) // Clear error on success
+					}
+				})
+				.catch((err) => {
+					if (!signal.aborted) {
+						console.error("[useOpenRouterKeyInfo] Fetch error:", err)
+						setError(err instanceof Error ? err : new Error("An unknown error occurred"))
+						if (!isBackgroundFetch) {
+							setData(null)
+							moduleCachedData = null
+							moduleLastFetchTime = null
+						}
+					}
+				})
+				.finally(() => {
+					if (!signal.aborted) {
+						setIsLoading(false) // Stop loading indicator
+					}
+				})
+		}
+
+		return () => {
+			controller.abort()
+		}
+	}, [apiKey]) // Re-run effect only when apiKey changes
+
+	return { data, isLoading, error }
+}


### PR DESCRIPTION
[Linear](https://linear.app/cline-bot/issue/ENG-318/show-openrouter-balance-next-to-provider 
)

### Description

This PR introduces two main enhancements related to OpenRouter integration:

1.  **OpenRouter Base URL Configuration**: Adds an optional `openRouterBaseUrl` field to the `ApiHandlerOptions` interface in `src/shared/api.ts`. This allows specifying a custom base URL for OpenRouter API requests, useful for proxies or self-hosted instances.
2.  **OpenRouter Balance Display**:
    *   Implements a new React hook `useOpenRouterKeyInfo` (`webview-ui/src/components/ui/hooks/useOpenRouterKeyInfo.ts`) to fetch key details (usage, credit limits) from the OpenRouter API (`/key` endpoint). It includes error handling and a 5-second timeout.
    *   Introduces the `OpenRouterBalanceDisplay` component (`webview-ui/src/components/settings/ApiOptions.tsx`) which uses the hook to show the remaining balance.
    *   Updates the `ApiOptions` component to display the remaining OpenRouter API key balance directly next to the API key input field. The balance is formatted as currency and links to the OpenRouter keys settings page, providing users immediate visibility into their credit status.


NOTE:  A balance can only be displayed if the user has manually set both a usage limit for that key in the Open Router console. If the user hasn't done this, no balance will be shown.
The recommendation is to only display the balance for users who have intentionally configured it, as they are the ones who would expect and need to see it. If a balance hasn't been set up for the key, nothing related to balance will be displayed.

### Test Procedure

<!-- How did you test this? Are you confident that it will not introduce bugs? If so, why? -->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [X] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [X] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [X] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [X] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [X] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

For cases when you have setup the key with the balance
<img width="406" alt="image" src="https://github.com/user-attachments/assets/b7e2e8ff-94e0-4291-b1ae-60ba24685645" />


### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds OpenRouter API key balance display and custom base URL configuration to the UI.
> 
>   - **Behavior**:
>     - Adds `openRouterBaseUrl` to `ApiHandlerOptions` in `api.ts` for custom OpenRouter API requests.
>     - Displays OpenRouter API key balance next to the input field in `ApiOptions.tsx` using `OpenRouterBalanceDisplay`.
>   - **Hooks**:
>     - Introduces `useOpenRouterKeyInfo` in `useOpenRouterKeyInfo.ts` to fetch API key details with error handling and a 5-second timeout.
>   - **UI Components**:
>     - Adds `OpenRouterBalanceDisplay` component in `ApiOptions.tsx` to show remaining balance formatted as currency.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for fe58862f607a85fa777bdb2b407f1c98a50353c6. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->