### PR TITLE
ENG-464 Fix Settings state issue with API provider reseting other settings.

### DIFF
--- a/.changeset/thirty-bugs-admire.md
+++ b/.changeset/thirty-bugs-admire.md
@@ -2,4 +2,4 @@
 "claude-dev": patch
 ---
 
-Fixed bug causing saved settings to get reset by changing providers"
+Fixed bug causing saved settings to get reset by changing providers

--- a/.changeset/thirty-bugs-admire.md
+++ b/.changeset/thirty-bugs-admire.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Fixed bug causing saved settings to get reset by changing providers"

--- a/webview-ui/src/components/chat/ChatTextArea.tsx
+++ b/webview-ui/src/components/chat/ChatTextArea.tsx
@@ -1378,6 +1378,7 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 										apiErrorMessage={undefined}
 										modelIdErrorMessage={undefined}
 										isPopup={true}
+										saveImmediately={true} // Ensure popup saves immediately
 									/>
 								</ModelSelectorTooltip>
 							)}

--- a/webview-ui/src/components/settings/SettingsView.tsx
+++ b/webview-ui/src/components/settings/SettingsView.tsx
@@ -148,7 +148,7 @@ const SettingsView = ({ onDone }: SettingsViewProps) => {
 		<div className="fixed top-0 left-0 right-0 bottom-0 pt-[10px] pr-0 pb-0 pl-5 flex flex-col overflow-hidden">
 			<div className="flex justify-between items-center mb-[13px] pr-[17px]">
 				<h3 className="text-[var(--vscode-foreground)] m-0">Settings</h3>
-				<VSCodeButton onClick={() => handleSubmit(false)}>Done</VSCodeButton>
+				<VSCodeButton onClick={() => handleSubmit(false)}>Save</VSCodeButton>
 			</div>
 			<div className="grow overflow-y-scroll pr-2 flex flex-col">
 				{/* Tabs container */}


### PR DESCRIPTION


### Description
When setting "Use different models for Plan and Act modes" then changing the provider (possibly other settings) for the modes, it will revert the checkbox and state of the settings view.  This happens if you start with separate or not.

Here is how it happens:

1. handleInputChange updates the local React state for apiProvider.
2. It immediately sends an "apiConfiguration" message to the core extension. The payload is based on the current local React state.
3. This local state might not reflect changes to other settings yet, or might still hold values related to the previous provider.
4. The core extension's updateApiConfiguration function (in src/core/storage/state.ts) receives this potentially incomplete/stale object.
5. Because updateApiConfiguration overwrites all API state keys based only on the received object, any fields missing from the message payload are effectively set to undefined in the persistent storage.
6. The core extension sends this modified state back to the webview.
7. The webview re-renders with the corrupted state, causing the UI elements (like the "Use different models" checkbox, model selections, etc.) to revert or display incorrectly.

### My solution
The challenge is that the API provider needs to support instant set for the roll up menu under the chatbox but it also needs to wait and only be set when the user hits done in the settings page. My solution is to support both options 
For the settings menu we rely on the react state and only update the core state when you hit done
for the roll up menue we set it instantly like before preserving the original behavior 

### Test Procedure

<!-- How did you test this? Are you confident that it will not introduce bugs? If so, why? -->

Test the rollup provider menu

1. switch to openrouter or cline provider
2. modify the favorite model
3. set the provider to something else
4. make sure the settings are saved and the favorite are saved

Test the settings menu

1. Do the same test as above 
2. change the use different models for plan and act 
3. change the provider after (this would have caused the bug)
4. hit done to save the provider.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [X] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes settings reset bug by ensuring API provider changes are saved only on confirmation, using `saveImmediately` prop for control.
> 
>   - **Behavior**:
>     - Fixes bug where changing API provider resets other settings by ensuring settings are saved only when confirmed.
>     - Introduces `saveImmediately` prop in `ApiOptions` to control immediate saving of settings.
>   - **Components**:
>     - Updates `ApiOptions` to use `saveImmediately` for immediate saving when changing providers.
>     - Modifies `ChatTextArea` to set `saveImmediately` to `true` for instant saving in popups.
>     - Changes `SettingsView` to save settings only on confirmation, not on every change.
>   - **Misc**:
>     - Renames "Done" button to "Save" in `SettingsView` for clarity.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 873a0b507edd688bc23e91e4ed4ee07fbf3c279b. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->