### PR TITLE
[PROTOBUS] browserSettings

### DIFF
--- a/proto/browser.proto
+++ b/proto/browser.proto
@@ -9,6 +9,7 @@ service BrowserService {
   rpc testBrowserConnection(StringRequest) returns (BrowserConnection);
   rpc discoverBrowser(EmptyRequest) returns (BrowserConnection);
   rpc getDetectedChromePath(EmptyRequest) returns (ChromePath);
+  rpc updateBrowserSettings(UpdateBrowserSettingsRequest) returns (Boolean);
 }
 
 message BrowserConnectionInfo {
@@ -26,4 +27,22 @@ message BrowserConnection {
 message ChromePath {
   string path = 1;
   bool is_bundled = 2;
+}
+
+message Viewport {
+  int32 width = 1;
+  int32 height = 2;
+}
+
+message BrowserSettings {
+  Viewport viewport = 1;
+  optional string remote_browser_host = 2;
+  optional bool remote_browser_enabled = 3;
+}
+
+message UpdateBrowserSettingsRequest {
+  Metadata metadata = 1;
+  Viewport viewport = 2;
+  optional string remote_browser_host = 3;
+  optional bool remote_browser_enabled = 4;
 }

--- a/proto/common.proto
+++ b/proto/common.proto
@@ -38,3 +38,12 @@ message BytesRequest {
 message Bytes {
   bytes value = 1;
 }
+
+message BooleanRequest {
+  Metadata metadata = 1;
+  bool value = 2;
+}
+
+message Boolean {
+  bool value = 1;
+}

--- a/src/core/controller/browser/methods.ts
+++ b/src/core/controller/browser/methods.ts
@@ -7,6 +7,7 @@ import { discoverBrowser } from "./discoverBrowser"
 import { getBrowserConnectionInfo } from "./getBrowserConnectionInfo"
 import { getDetectedChromePath } from "./getDetectedChromePath"
 import { testBrowserConnection } from "./testBrowserConnection"
+import { updateBrowserSettings } from "./updateBrowserSettings"
 
 // Register all browser service methods
 export function registerAllMethods(): void {
@@ -15,4 +16,5 @@ export function registerAllMethods(): void {
 	registerMethod("getBrowserConnectionInfo", getBrowserConnectionInfo)
 	registerMethod("getDetectedChromePath", getDetectedChromePath)
 	registerMethod("testBrowserConnection", testBrowserConnection)
+	registerMethod("updateBrowserSettings", updateBrowserSettings)
 }

--- a/src/core/controller/browser/updateBrowserSettings.ts
+++ b/src/core/controller/browser/updateBrowserSettings.ts
@@ -1,0 +1,46 @@
+import { UpdateBrowserSettingsRequest } from "../../../shared/proto/browser"
+import { Boolean } from "../../../shared/proto/common"
+import { Controller } from "../index"
+import { updateGlobalState } from "../../storage/state"
+import { BrowserSettings as SharedBrowserSettings } from "../../../shared/BrowserSettings"
+
+/**
+ * Update browser settings
+ * @param controller The controller instance
+ * @param request The browser settings request message
+ * @returns Success response
+ */
+export async function updateBrowserSettings(controller: Controller, request: UpdateBrowserSettingsRequest): Promise<Boolean> {
+	try {
+		// Convert from protobuf format to shared format
+		const browserSettings: SharedBrowserSettings = {
+			viewport: {
+				width: request.viewport?.width || 900,
+				height: request.viewport?.height || 600,
+			},
+			remoteBrowserEnabled: request.remoteBrowserEnabled || false,
+			remoteBrowserHost: request.remoteBrowserHost || undefined,
+		}
+
+		// Update global state with new settings
+		await updateGlobalState(controller.context, "browserSettings", browserSettings)
+
+		// Update task browser settings if task exists
+		if (controller.task) {
+			controller.task.browserSettings = browserSettings
+			controller.task.browserSession.browserSettings = browserSettings
+		}
+
+		// Post updated state to webview
+		await controller.postStateToWebview()
+
+		return {
+			value: true,
+		}
+	} catch (error) {
+		console.error("Error updating browser settings:", error)
+		return {
+			value: false,
+		}
+	}
+}

--- a/src/core/controller/index.ts
+++ b/src/core/controller/index.ts
@@ -295,8 +295,6 @@ export class Controller {
 					await this.postStateToWebview()
 				}
 				break
-			// browserSettings message has been migrated to gRPC
-			// Use BrowserServiceClient.updateBrowserSettings instead
 			case "togglePlanActMode":
 				if (message.chatSettings) {
 					await this.togglePlanActModeWithChatSettings(message.chatSettings, message.chatContent)

--- a/src/core/controller/index.ts
+++ b/src/core/controller/index.ts
@@ -295,22 +295,8 @@ export class Controller {
 					await this.postStateToWebview()
 				}
 				break
-			case "browserSettings":
-				if (message.browserSettings) {
-					// remoteBrowserEnabled now means "enable remote browser connection"
-					// commenting out since this is being done in BrowserSettingsSection updateRemoteBrowserEnabled
-					// if (!message.browserSettings.remoteBrowserEnabled) {
-					// 	// If disabling remote browser connection, clear the remoteBrowserHost
-					// 	message.browserSettings.remoteBrowserHost = undefined
-					// }
-					await updateGlobalState(this.context, "browserSettings", message.browserSettings)
-					if (this.task) {
-						this.task.browserSettings = message.browserSettings
-						this.task.browserSession.browserSettings = message.browserSettings
-					}
-					await this.postStateToWebview()
-				}
-				break
+			// browserSettings message has been migrated to gRPC
+			// Use BrowserServiceClient.updateBrowserSettings instead
 			case "togglePlanActMode":
 				if (message.chatSettings) {
 					await this.togglePlanActModeWithChatSettings(message.chatSettings, message.chatContent)

--- a/src/shared/WebviewMessage.ts
+++ b/src/shared/WebviewMessage.ts
@@ -39,7 +39,6 @@ export interface WebviewMessage {
 		| "restartMcpServer"
 		| "deleteMcpServer"
 		| "autoApprovalSettings"
-		| "browserSettings"
 		| "browserRelaunchResult"
 		| "togglePlanActMode"
 		| "checkpointRestore"

--- a/src/shared/proto/browser.ts
+++ b/src/shared/proto/browser.ts
@@ -6,7 +6,7 @@
 
 /* eslint-disable */
 import { BinaryReader, BinaryWriter } from "@bufbuild/protobuf/wire"
-import { EmptyRequest, StringRequest } from "./common"
+import { Boolean, EmptyRequest, Metadata, StringRequest } from "./common"
 
 export const protobufPackage = "cline"
 
@@ -25,6 +25,24 @@ export interface BrowserConnection {
 export interface ChromePath {
 	path: string
 	isBundled: boolean
+}
+
+export interface Viewport {
+	width: number
+	height: number
+}
+
+export interface BrowserSettings {
+	viewport?: Viewport | undefined
+	remoteBrowserHost?: string | undefined
+	remoteBrowserEnabled?: boolean | undefined
+}
+
+export interface UpdateBrowserSettingsRequest {
+	metadata?: Metadata | undefined
+	viewport?: Viewport | undefined
+	remoteBrowserHost?: string | undefined
+	remoteBrowserEnabled?: boolean | undefined
 }
 
 function createBaseBrowserConnectionInfo(): BrowserConnectionInfo {
@@ -287,6 +305,289 @@ export const ChromePath: MessageFns<ChromePath> = {
 	},
 }
 
+function createBaseViewport(): Viewport {
+	return { width: 0, height: 0 }
+}
+
+export const Viewport: MessageFns<Viewport> = {
+	encode(message: Viewport, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+		if (message.width !== 0) {
+			writer.uint32(8).int32(message.width)
+		}
+		if (message.height !== 0) {
+			writer.uint32(16).int32(message.height)
+		}
+		return writer
+	},
+
+	decode(input: BinaryReader | Uint8Array, length?: number): Viewport {
+		const reader = input instanceof BinaryReader ? input : new BinaryReader(input)
+		let end = length === undefined ? reader.len : reader.pos + length
+		const message = createBaseViewport()
+		while (reader.pos < end) {
+			const tag = reader.uint32()
+			switch (tag >>> 3) {
+				case 1: {
+					if (tag !== 8) {
+						break
+					}
+
+					message.width = reader.int32()
+					continue
+				}
+				case 2: {
+					if (tag !== 16) {
+						break
+					}
+
+					message.height = reader.int32()
+					continue
+				}
+			}
+			if ((tag & 7) === 4 || tag === 0) {
+				break
+			}
+			reader.skip(tag & 7)
+		}
+		return message
+	},
+
+	fromJSON(object: any): Viewport {
+		return {
+			width: isSet(object.width) ? globalThis.Number(object.width) : 0,
+			height: isSet(object.height) ? globalThis.Number(object.height) : 0,
+		}
+	},
+
+	toJSON(message: Viewport): unknown {
+		const obj: any = {}
+		if (message.width !== 0) {
+			obj.width = Math.round(message.width)
+		}
+		if (message.height !== 0) {
+			obj.height = Math.round(message.height)
+		}
+		return obj
+	},
+
+	create<I extends Exact<DeepPartial<Viewport>, I>>(base?: I): Viewport {
+		return Viewport.fromPartial(base ?? ({} as any))
+	},
+	fromPartial<I extends Exact<DeepPartial<Viewport>, I>>(object: I): Viewport {
+		const message = createBaseViewport()
+		message.width = object.width ?? 0
+		message.height = object.height ?? 0
+		return message
+	},
+}
+
+function createBaseBrowserSettings(): BrowserSettings {
+	return { viewport: undefined, remoteBrowserHost: undefined, remoteBrowserEnabled: undefined }
+}
+
+export const BrowserSettings: MessageFns<BrowserSettings> = {
+	encode(message: BrowserSettings, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+		if (message.viewport !== undefined) {
+			Viewport.encode(message.viewport, writer.uint32(10).fork()).join()
+		}
+		if (message.remoteBrowserHost !== undefined) {
+			writer.uint32(18).string(message.remoteBrowserHost)
+		}
+		if (message.remoteBrowserEnabled !== undefined) {
+			writer.uint32(24).bool(message.remoteBrowserEnabled)
+		}
+		return writer
+	},
+
+	decode(input: BinaryReader | Uint8Array, length?: number): BrowserSettings {
+		const reader = input instanceof BinaryReader ? input : new BinaryReader(input)
+		let end = length === undefined ? reader.len : reader.pos + length
+		const message = createBaseBrowserSettings()
+		while (reader.pos < end) {
+			const tag = reader.uint32()
+			switch (tag >>> 3) {
+				case 1: {
+					if (tag !== 10) {
+						break
+					}
+
+					message.viewport = Viewport.decode(reader, reader.uint32())
+					continue
+				}
+				case 2: {
+					if (tag !== 18) {
+						break
+					}
+
+					message.remoteBrowserHost = reader.string()
+					continue
+				}
+				case 3: {
+					if (tag !== 24) {
+						break
+					}
+
+					message.remoteBrowserEnabled = reader.bool()
+					continue
+				}
+			}
+			if ((tag & 7) === 4 || tag === 0) {
+				break
+			}
+			reader.skip(tag & 7)
+		}
+		return message
+	},
+
+	fromJSON(object: any): BrowserSettings {
+		return {
+			viewport: isSet(object.viewport) ? Viewport.fromJSON(object.viewport) : undefined,
+			remoteBrowserHost: isSet(object.remoteBrowserHost) ? globalThis.String(object.remoteBrowserHost) : undefined,
+			remoteBrowserEnabled: isSet(object.remoteBrowserEnabled)
+				? globalThis.Boolean(object.remoteBrowserEnabled)
+				: undefined,
+		}
+	},
+
+	toJSON(message: BrowserSettings): unknown {
+		const obj: any = {}
+		if (message.viewport !== undefined) {
+			obj.viewport = Viewport.toJSON(message.viewport)
+		}
+		if (message.remoteBrowserHost !== undefined) {
+			obj.remoteBrowserHost = message.remoteBrowserHost
+		}
+		if (message.remoteBrowserEnabled !== undefined) {
+			obj.remoteBrowserEnabled = message.remoteBrowserEnabled
+		}
+		return obj
+	},
+
+	create<I extends Exact<DeepPartial<BrowserSettings>, I>>(base?: I): BrowserSettings {
+		return BrowserSettings.fromPartial(base ?? ({} as any))
+	},
+	fromPartial<I extends Exact<DeepPartial<BrowserSettings>, I>>(object: I): BrowserSettings {
+		const message = createBaseBrowserSettings()
+		message.viewport =
+			object.viewport !== undefined && object.viewport !== null ? Viewport.fromPartial(object.viewport) : undefined
+		message.remoteBrowserHost = object.remoteBrowserHost ?? undefined
+		message.remoteBrowserEnabled = object.remoteBrowserEnabled ?? undefined
+		return message
+	},
+}
+
+function createBaseUpdateBrowserSettingsRequest(): UpdateBrowserSettingsRequest {
+	return { metadata: undefined, viewport: undefined, remoteBrowserHost: undefined, remoteBrowserEnabled: undefined }
+}
+
+export const UpdateBrowserSettingsRequest: MessageFns<UpdateBrowserSettingsRequest> = {
+	encode(message: UpdateBrowserSettingsRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+		if (message.metadata !== undefined) {
+			Metadata.encode(message.metadata, writer.uint32(10).fork()).join()
+		}
+		if (message.viewport !== undefined) {
+			Viewport.encode(message.viewport, writer.uint32(18).fork()).join()
+		}
+		if (message.remoteBrowserHost !== undefined) {
+			writer.uint32(26).string(message.remoteBrowserHost)
+		}
+		if (message.remoteBrowserEnabled !== undefined) {
+			writer.uint32(32).bool(message.remoteBrowserEnabled)
+		}
+		return writer
+	},
+
+	decode(input: BinaryReader | Uint8Array, length?: number): UpdateBrowserSettingsRequest {
+		const reader = input instanceof BinaryReader ? input : new BinaryReader(input)
+		let end = length === undefined ? reader.len : reader.pos + length
+		const message = createBaseUpdateBrowserSettingsRequest()
+		while (reader.pos < end) {
+			const tag = reader.uint32()
+			switch (tag >>> 3) {
+				case 1: {
+					if (tag !== 10) {
+						break
+					}
+
+					message.metadata = Metadata.decode(reader, reader.uint32())
+					continue
+				}
+				case 2: {
+					if (tag !== 18) {
+						break
+					}
+
+					message.viewport = Viewport.decode(reader, reader.uint32())
+					continue
+				}
+				case 3: {
+					if (tag !== 26) {
+						break
+					}
+
+					message.remoteBrowserHost = reader.string()
+					continue
+				}
+				case 4: {
+					if (tag !== 32) {
+						break
+					}
+
+					message.remoteBrowserEnabled = reader.bool()
+					continue
+				}
+			}
+			if ((tag & 7) === 4 || tag === 0) {
+				break
+			}
+			reader.skip(tag & 7)
+		}
+		return message
+	},
+
+	fromJSON(object: any): UpdateBrowserSettingsRequest {
+		return {
+			metadata: isSet(object.metadata) ? Metadata.fromJSON(object.metadata) : undefined,
+			viewport: isSet(object.viewport) ? Viewport.fromJSON(object.viewport) : undefined,
+			remoteBrowserHost: isSet(object.remoteBrowserHost) ? globalThis.String(object.remoteBrowserHost) : undefined,
+			remoteBrowserEnabled: isSet(object.remoteBrowserEnabled)
+				? globalThis.Boolean(object.remoteBrowserEnabled)
+				: undefined,
+		}
+	},
+
+	toJSON(message: UpdateBrowserSettingsRequest): unknown {
+		const obj: any = {}
+		if (message.metadata !== undefined) {
+			obj.metadata = Metadata.toJSON(message.metadata)
+		}
+		if (message.viewport !== undefined) {
+			obj.viewport = Viewport.toJSON(message.viewport)
+		}
+		if (message.remoteBrowserHost !== undefined) {
+			obj.remoteBrowserHost = message.remoteBrowserHost
+		}
+		if (message.remoteBrowserEnabled !== undefined) {
+			obj.remoteBrowserEnabled = message.remoteBrowserEnabled
+		}
+		return obj
+	},
+
+	create<I extends Exact<DeepPartial<UpdateBrowserSettingsRequest>, I>>(base?: I): UpdateBrowserSettingsRequest {
+		return UpdateBrowserSettingsRequest.fromPartial(base ?? ({} as any))
+	},
+	fromPartial<I extends Exact<DeepPartial<UpdateBrowserSettingsRequest>, I>>(object: I): UpdateBrowserSettingsRequest {
+		const message = createBaseUpdateBrowserSettingsRequest()
+		message.metadata =
+			object.metadata !== undefined && object.metadata !== null ? Metadata.fromPartial(object.metadata) : undefined
+		message.viewport =
+			object.viewport !== undefined && object.viewport !== null ? Viewport.fromPartial(object.viewport) : undefined
+		message.remoteBrowserHost = object.remoteBrowserHost ?? undefined
+		message.remoteBrowserEnabled = object.remoteBrowserEnabled ?? undefined
+		return message
+	},
+}
+
 export type BrowserServiceDefinition = typeof BrowserServiceDefinition
 export const BrowserServiceDefinition = {
 	name: "BrowserService",
@@ -321,6 +622,14 @@ export const BrowserServiceDefinition = {
 			requestType: EmptyRequest,
 			requestStream: false,
 			responseType: ChromePath,
+			responseStream: false,
+			options: {},
+		},
+		updateBrowserSettings: {
+			name: "updateBrowserSettings",
+			requestType: UpdateBrowserSettingsRequest,
+			requestStream: false,
+			responseType: Boolean,
 			responseStream: false,
 			options: {},
 		},

--- a/src/shared/proto/common.ts
+++ b/src/shared/proto/common.ts
@@ -44,6 +44,15 @@ export interface Bytes {
 	value: Buffer
 }
 
+export interface BooleanRequest {
+	metadata?: Metadata | undefined
+	value: boolean
+}
+
+export interface Boolean {
+	value: boolean
+}
+
 function createBaseMetadata(): Metadata {
 	return {}
 }
@@ -590,6 +599,141 @@ export const Bytes: MessageFns<Bytes> = {
 	fromPartial<I extends Exact<DeepPartial<Bytes>, I>>(object: I): Bytes {
 		const message = createBaseBytes()
 		message.value = object.value ?? Buffer.alloc(0)
+		return message
+	},
+}
+
+function createBaseBooleanRequest(): BooleanRequest {
+	return { metadata: undefined, value: false }
+}
+
+export const BooleanRequest: MessageFns<BooleanRequest> = {
+	encode(message: BooleanRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+		if (message.metadata !== undefined) {
+			Metadata.encode(message.metadata, writer.uint32(10).fork()).join()
+		}
+		if (message.value !== false) {
+			writer.uint32(16).bool(message.value)
+		}
+		return writer
+	},
+
+	decode(input: BinaryReader | Uint8Array, length?: number): BooleanRequest {
+		const reader = input instanceof BinaryReader ? input : new BinaryReader(input)
+		let end = length === undefined ? reader.len : reader.pos + length
+		const message = createBaseBooleanRequest()
+		while (reader.pos < end) {
+			const tag = reader.uint32()
+			switch (tag >>> 3) {
+				case 1: {
+					if (tag !== 10) {
+						break
+					}
+
+					message.metadata = Metadata.decode(reader, reader.uint32())
+					continue
+				}
+				case 2: {
+					if (tag !== 16) {
+						break
+					}
+
+					message.value = reader.bool()
+					continue
+				}
+			}
+			if ((tag & 7) === 4 || tag === 0) {
+				break
+			}
+			reader.skip(tag & 7)
+		}
+		return message
+	},
+
+	fromJSON(object: any): BooleanRequest {
+		return {
+			metadata: isSet(object.metadata) ? Metadata.fromJSON(object.metadata) : undefined,
+			value: isSet(object.value) ? globalThis.Boolean(object.value) : false,
+		}
+	},
+
+	toJSON(message: BooleanRequest): unknown {
+		const obj: any = {}
+		if (message.metadata !== undefined) {
+			obj.metadata = Metadata.toJSON(message.metadata)
+		}
+		if (message.value !== false) {
+			obj.value = message.value
+		}
+		return obj
+	},
+
+	create<I extends Exact<DeepPartial<BooleanRequest>, I>>(base?: I): BooleanRequest {
+		return BooleanRequest.fromPartial(base ?? ({} as any))
+	},
+	fromPartial<I extends Exact<DeepPartial<BooleanRequest>, I>>(object: I): BooleanRequest {
+		const message = createBaseBooleanRequest()
+		message.metadata =
+			object.metadata !== undefined && object.metadata !== null ? Metadata.fromPartial(object.metadata) : undefined
+		message.value = object.value ?? false
+		return message
+	},
+}
+
+function createBaseBoolean(): Boolean {
+	return { value: false }
+}
+
+export const Boolean: MessageFns<Boolean> = {
+	encode(message: Boolean, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+		if (message.value !== false) {
+			writer.uint32(8).bool(message.value)
+		}
+		return writer
+	},
+
+	decode(input: BinaryReader | Uint8Array, length?: number): Boolean {
+		const reader = input instanceof BinaryReader ? input : new BinaryReader(input)
+		let end = length === undefined ? reader.len : reader.pos + length
+		const message = createBaseBoolean()
+		while (reader.pos < end) {
+			const tag = reader.uint32()
+			switch (tag >>> 3) {
+				case 1: {
+					if (tag !== 8) {
+						break
+					}
+
+					message.value = reader.bool()
+					continue
+				}
+			}
+			if ((tag & 7) === 4 || tag === 0) {
+				break
+			}
+			reader.skip(tag & 7)
+		}
+		return message
+	},
+
+	fromJSON(object: any): Boolean {
+		return { value: isSet(object.value) ? globalThis.Boolean(object.value) : false }
+	},
+
+	toJSON(message: Boolean): unknown {
+		const obj: any = {}
+		if (message.value !== false) {
+			obj.value = message.value
+		}
+		return obj
+	},
+
+	create<I extends Exact<DeepPartial<Boolean>, I>>(base?: I): Boolean {
+		return Boolean.fromPartial(base ?? ({} as any))
+	},
+	fromPartial<I extends Exact<DeepPartial<Boolean>, I>>(object: I): Boolean {
+		const message = createBaseBoolean()
+		message.value = object.value ?? false
 		return message
 	},
 }

--- a/webview-ui/src/components/settings/BrowserSettingsSection.tsx
+++ b/webview-ui/src/components/settings/BrowserSettingsSection.tsx
@@ -139,38 +139,65 @@ export const BrowserSettingsSection: React.FC = () => {
 		const target = event.target as HTMLSelectElement
 		const selectedSize = BROWSER_VIEWPORT_PRESETS[target.value as keyof typeof BROWSER_VIEWPORT_PRESETS]
 		if (selectedSize) {
-			vscode.postMessage({
-				type: "browserSettings",
-				browserSettings: {
-					...browserSettings,
-					viewport: selectedSize,
+			BrowserServiceClient.updateBrowserSettings({
+				metadata: {},
+				viewport: {
+					width: selectedSize.width,
+					height: selectedSize.height,
 				},
+				remoteBrowserEnabled: browserSettings.remoteBrowserEnabled,
+				remoteBrowserHost: browserSettings.remoteBrowserHost,
 			})
+				.then((response) => {
+					if (!response.value) {
+						console.error("Failed to update browser settings")
+					}
+				})
+				.catch((error) => {
+					console.error("Error updating browser settings:", error)
+				})
 		}
 	}
 
 	const updateRemoteBrowserEnabled = (enabled: boolean) => {
-		// Also update browserSettings to ensure task settings are updated
-		vscode.postMessage({
-			type: "browserSettings",
-			browserSettings: {
-				...browserSettings,
-				remoteBrowserEnabled: enabled,
-				// If disabling, also clear the host in browserSettings
-				...(enabled ? {} : { remoteBrowserHost: undefined }),
+		BrowserServiceClient.updateBrowserSettings({
+			metadata: {},
+			viewport: {
+				width: browserSettings.viewport.width,
+				height: browserSettings.viewport.height,
 			},
+			remoteBrowserEnabled: enabled,
+			// If disabling, also clear the host
+			remoteBrowserHost: enabled ? browserSettings.remoteBrowserHost : undefined,
 		})
+			.then((response) => {
+				if (!response.value) {
+					console.error("Failed to update browser settings")
+				}
+			})
+			.catch((error) => {
+				console.error("Error updating browser settings:", error)
+			})
 	}
 
 	const updateRemoteBrowserHost = (host: string | undefined) => {
-		// Also update browserSettings to ensure task settings are updated
-		vscode.postMessage({
-			type: "browserSettings",
-			browserSettings: {
-				...browserSettings,
-				remoteBrowserHost: host,
+		BrowserServiceClient.updateBrowserSettings({
+			metadata: {},
+			viewport: {
+				width: browserSettings.viewport.width,
+				height: browserSettings.viewport.height,
 			},
+			remoteBrowserEnabled: browserSettings.remoteBrowserEnabled,
+			remoteBrowserHost: host,
 		})
+			.then((response) => {
+				if (!response.value) {
+					console.error("Failed to update browser settings")
+				}
+			})
+			.catch((error) => {
+				console.error("Error updating browser settings:", error)
+			})
 	}
 
 	// Function to check connection once without changing UI state immediately


### PR DESCRIPTION
### Test Procedure

Change the browser settings & make sure they persist and apply

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [x] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Refactor browser settings management to use gRPC, adding `updateBrowserSettings` method and updating UI components accordingly.
> 
>   - **Behavior**:
>     - Adds `updateBrowserSettings` gRPC method in `browser.proto` to update browser settings.
>     - Refactors `BrowserSettingsSection.tsx` to use `BrowserServiceClient.updateBrowserSettings` for updating settings.
>     - Removes direct message handling for `browserSettings` in `index.ts`.
>   - **Protobuf**:
>     - Adds `Viewport`, `BrowserSettings`, and `UpdateBrowserSettingsRequest` messages in `browser.proto`.
>     - Adds `Boolean` and `BooleanRequest` messages in `common.proto`.
>   - **Methods**:
>     - Registers `updateBrowserSettings` in `methods.ts`.
>     - Implements `updateBrowserSettings` function in `updateBrowserSettings.ts` to handle gRPC requests.
>   - **UI**:
>     - Updates `BrowserSettingsSection.tsx` to use gRPC for connection checks and settings updates.
>     - Adds connection status indicator and relaunch button logic in `BrowserSettingsSection.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for a70bc0fe0c4a7475c92742adf78eb4a925b75128. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->