### PR TITLE
Fix new rule button click

### DIFF
--- a/.changeset/mean-mangos-sell.md
+++ b/.changeset/mean-mangos-sell.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": minor
+---
+
+Fix add new rule file button not working


### PR DESCRIPTION
### Description

Fix the new rule button not adding a new rule file do to tricky event propogation.

### Test Procedure

Confirmed that rule files are now created when clicking the button.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes 'New Rule' button in `NewRuleRow.tsx` to correctly create rule files by handling form submission and managing component state.
> 
>   - **Behavior**:
>     - Fixes 'New Rule' button in `NewRuleRow.tsx` to correctly create rule files by handling form submission.
>     - Uses `useClickAway` to collapse input and reset state when clicking outside the component.
>   - **Functions**:
>     - Replaces `handleCreateRule` with `handleSubmit` to manage form submission.
>     - Removes `handleBlur` and integrates its functionality into `useClickAway`.
>     - Updates `handleKeyDown` to only handle 'Escape' key for collapsing input.
>   - **UI**:
>     - Wraps input and button in a `<form>` element to handle submission via button click or 'Enter' key.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 7b313aed1f5a64a28c4c95d4400a0eecb576d3db. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->