### PR TITLE
Add a new local rule file when there is already a .clinerules file.

### DIFF
--- a/.changeset/strong-paws-crash.md
+++ b/.changeset/strong-paws-crash.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": minor
+---
+
+Successfully create a new rule file locally when there is an existing .clinerules file

--- a/src/core/context/instructions/user-instructions/cline-rules.ts
+++ b/src/core/context/instructions/user-instructions/cline-rules.ts
@@ -192,7 +192,7 @@ export const createRuleFile = async (isGlobal: boolean, filename: string, cwd: s
 				try {
 					const content = await fs.readFile(localClineRulesFilePath, "utf8")
 
-					const tempDirPath = path.resolve(cwd, ".clinerules_temp")
+					const tempDirPath = await fs.mkdtemp(path.join(cwd, ".clinerules_temp_"))
 					await fs.mkdir(tempDirPath, { recursive: true })
 
 					await fs.writeFile(path.join(tempDirPath, "old_clinerules_file.md"), content, "utf8")


### PR DESCRIPTION
### Description

We migrate the existing .clinerules file to a .clinerules folder so that new rules files can be added.

### Test Procedure

Tested that it works with an existing .clinerules file locally.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Migrate existing `.clinerules` file to a directory in `createRuleFile()` to allow multiple rule files.
> 
>   - **Behavior**:
>     - Migrate existing `.clinerules` file to a directory in `createRuleFile()` in `cline-rules.ts`.
>     - If `.clinerules` file exists and is not a directory, read its content, create a temporary directory, move content, and rename it.
>     - Create new rule file in the migrated directory.
>   - **Error Handling**:
>     - Logs error and throws if migration fails in `createRuleFile()`.
>   - **Misc**:
>     - Adds changeset `strong-paws-crash.md` for versioning.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 83926836efd579afdc51dad466d2b7eb5647548c. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->