### PR TITLE
ENG 526/Fix: Versioned Auto Approve settings

### DIFF
--- a/.changeset/tidy-points-learn.md
+++ b/.changeset/tidy-points-learn.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Fixes auto approve settings becoming unset

--- a/src/core/controller/index.ts
+++ b/src/core/controller/index.ts
@@ -324,6 +324,41 @@ export class Controller {
 					await this.postStateToWebview()
 				}
 				break
+			case "discoverBrowser":
+				try {
+					const discoveredHost = await discoverChromeInstances()
+
+					if (discoveredHost) {
+						// Don't update the remoteBrowserHost state when auto-discovering
+						// This way we don't override the user's preference
+
+						// Test the connection to get the endpoint
+						const { browserSettings } = await getAllExtensionState(this.context)
+						const browserSession = new BrowserSession(this.context, browserSettings)
+						const result = await browserSession.testConnection(discoveredHost)
+
+						// Send the result back to the webview
+						await this.postMessageToWebview({
+							type: "browserConnectionResult",
+							success: true,
+							text: `Successfully discovered and connected to Chrome at ${discoveredHost}`,
+							endpoint: result.endpoint,
+						})
+					} else {
+						await this.postMessageToWebview({
+							type: "browserConnectionResult",
+							success: false,
+							text: "No Chrome instances found on the network. Make sure Chrome is running with remote debugging enabled (--remote-debugging-port=9222).",
+						})
+					}
+				} catch (error) {
+					await this.postMessageToWebview({
+						type: "browserConnectionResult",
+						success: false,
+						text: `Error discovering browser: ${error instanceof Error ? error.message : String(error)}`,
+					})
+				}
+				break
 			case "togglePlanActMode":
 				if (message.chatSettings) {
 					await this.togglePlanActModeWithChatSettings(message.chatSettings, message.chatContent)
@@ -461,6 +496,12 @@ export class Controller {
 			case "openMention":
 				openMention(message.text)
 				break
+			case "checkpointDiff": {
+				if (message.number) {
+					await this.task?.presentMultifileDiff(message.number, false)
+				}
+				break
+			}
 			case "checkpointRestore": {
 				await this.cancelTask() // we cannot alter message history say if the task is active, as it could be in the middle of editing a file or running a command, which expect the ask to be responded to rather than being superseded by a new message eg add deleted_api_reqs
 				// cancel task waits for any open editor to be reverted and starts a new cline instance

--- a/src/core/controller/index.ts
+++ b/src/core/controller/index.ts
@@ -324,41 +324,6 @@ export class Controller {
 					await this.postStateToWebview()
 				}
 				break
-			case "discoverBrowser":
-				try {
-					const discoveredHost = await discoverChromeInstances()
-
-					if (discoveredHost) {
-						// Don't update the remoteBrowserHost state when auto-discovering
-						// This way we don't override the user's preference
-
-						// Test the connection to get the endpoint
-						const { browserSettings } = await getAllExtensionState(this.context)
-						const browserSession = new BrowserSession(this.context, browserSettings)
-						const result = await browserSession.testConnection(discoveredHost)
-
-						// Send the result back to the webview
-						await this.postMessageToWebview({
-							type: "browserConnectionResult",
-							success: true,
-							text: `Successfully discovered and connected to Chrome at ${discoveredHost}`,
-							endpoint: result.endpoint,
-						})
-					} else {
-						await this.postMessageToWebview({
-							type: "browserConnectionResult",
-							success: false,
-							text: "No Chrome instances found on the network. Make sure Chrome is running with remote debugging enabled (--remote-debugging-port=9222).",
-						})
-					}
-				} catch (error) {
-					await this.postMessageToWebview({
-						type: "browserConnectionResult",
-						success: false,
-						text: `Error discovering browser: ${error instanceof Error ? error.message : String(error)}`,
-					})
-				}
-				break
 			case "togglePlanActMode":
 				if (message.chatSettings) {
 					await this.togglePlanActModeWithChatSettings(message.chatSettings, message.chatContent)
@@ -496,12 +461,6 @@ export class Controller {
 			case "openMention":
 				openMention(message.text)
 				break
-			case "checkpointDiff": {
-				if (message.number) {
-					await this.task?.presentMultifileDiff(message.number, false)
-				}
-				break
-			}
 			case "checkpointRestore": {
 				await this.cancelTask() // we cannot alter message history say if the task is active, as it could be in the middle of editing a file or running a command, which expect the ask to be responded to rather than being superseded by a new message eg add deleted_api_reqs
 				// cancel task waits for any open editor to be reverted and starts a new cline instance

--- a/src/shared/AutoApprovalSettings.ts
+++ b/src/shared/AutoApprovalSettings.ts
@@ -1,4 +1,6 @@
 export interface AutoApprovalSettings {
+	// Version for race condition prevention (incremented on every change)
+	version: number
 	// Whether auto-approval is enabled
 	enabled: boolean
 	// Individual action permissions
@@ -18,6 +20,7 @@ export interface AutoApprovalSettings {
 }
 
 export const DEFAULT_AUTO_APPROVAL_SETTINGS: AutoApprovalSettings = {
+	version: 1,
 	enabled: false,
 	actions: {
 		readFiles: false,

--- a/webview-ui/src/components/chat/AutoApproveMenu.tsx
+++ b/webview-ui/src/components/chat/AutoApproveMenu.tsx
@@ -168,7 +168,7 @@ const AutoApproveMenu = ({ style }: AutoApproveMenuProps) => {
 				},
 			})
 		},
-		[extensionState],
+		[extensionState.autoApprovalSettings],
 	)
 
 	const updateAction = useCallback(
@@ -194,7 +194,7 @@ const AutoApproveMenu = ({ style }: AutoApproveMenuProps) => {
 				},
 			})
 		},
-		[extensionState],
+		[extensionState.autoApprovalSettings],
 	)
 
 	const updateMaxRequests = useCallback(
@@ -209,7 +209,7 @@ const AutoApproveMenu = ({ style }: AutoApproveMenuProps) => {
 				},
 			})
 		},
-		[extensionState],
+		[extensionState.autoApprovalSettings],
 	)
 
 	const updateNotifications = useCallback(
@@ -224,7 +224,7 @@ const AutoApproveMenu = ({ style }: AutoApproveMenuProps) => {
 				},
 			})
 		},
-		[extensionState],
+		[extensionState.autoApprovalSettings],
 	)
 
 	return (

--- a/webview-ui/src/components/chat/AutoApproveMenu.tsx
+++ b/webview-ui/src/components/chat/AutoApproveMenu.tsx
@@ -153,24 +153,30 @@ const AutoApproveMenu = ({ style }: AutoApproveMenuProps) => {
 		return enabledActionsCount > 0
 	}, [enabledActions, autoApprovalSettings.actions])
 
+	// Get the full extension state to ensure we have the most up-to-date settings
+	const extensionState = useExtensionState()
+
 	const updateEnabled = useCallback(
 		(enabled: boolean) => {
+			const currentSettings = extensionState.autoApprovalSettings
 			vscode.postMessage({
 				type: "autoApprovalSettings",
 				autoApprovalSettings: {
-					...autoApprovalSettings,
+					...currentSettings,
+					version: (currentSettings.version ?? 1) + 1,
 					enabled,
 				},
 			})
 		},
-		[autoApprovalSettings],
+		[extensionState],
 	)
 
 	const updateAction = useCallback(
 		(actionId: keyof AutoApprovalSettings["actions"], value: boolean) => {
+			const currentSettings = extensionState.autoApprovalSettings
 			// Calculate what the new actions state will be
 			const newActions = {
-				...autoApprovalSettings.actions,
+				...currentSettings.actions,
 				[actionId]: value,
 			}
 
@@ -180,40 +186,45 @@ const AutoApproveMenu = ({ style }: AutoApproveMenuProps) => {
 			vscode.postMessage({
 				type: "autoApprovalSettings",
 				autoApprovalSettings: {
-					...autoApprovalSettings,
+					...currentSettings,
+					version: (currentSettings.version ?? 1) + 1,
 					actions: newActions,
 					// If no actions will be enabled, ensure the main toggle is off
-					enabled: willHaveEnabledActions ? autoApprovalSettings.enabled : false,
+					enabled: willHaveEnabledActions ? currentSettings.enabled : false,
 				},
 			})
 		},
-		[autoApprovalSettings],
+		[extensionState],
 	)
 
 	const updateMaxRequests = useCallback(
 		(maxRequests: number) => {
+			const currentSettings = extensionState.autoApprovalSettings
 			vscode.postMessage({
 				type: "autoApprovalSettings",
 				autoApprovalSettings: {
-					...autoApprovalSettings,
+					...currentSettings,
+					version: (currentSettings.version ?? 1) + 1,
 					maxRequests,
 				},
 			})
 		},
-		[autoApprovalSettings],
+		[extensionState],
 	)
 
 	const updateNotifications = useCallback(
 		(enableNotifications: boolean) => {
+			const currentSettings = extensionState.autoApprovalSettings
 			vscode.postMessage({
 				type: "autoApprovalSettings",
 				autoApprovalSettings: {
-					...autoApprovalSettings,
+					...currentSettings,
+					version: (currentSettings.version ?? 1) + 1,
 					enableNotifications,
 				},
 			})
 		},
-		[autoApprovalSettings],
+		[extensionState],
 	)
 
 	return (

--- a/webview-ui/src/context/ExtensionStateContext.tsx
+++ b/webview-ui/src/context/ExtensionStateContext.tsx
@@ -75,7 +75,19 @@ export const ExtensionStateContextProvider: React.FC<{
 		const message: ExtensionMessage = event.data
 		switch (message.type) {
 			case "state": {
-				setState(message.state!)
+				setState((prevState) => {
+					const incoming = message.state!
+					// Versioning logic for autoApprovalSettings
+					const incomingVersion = incoming.autoApprovalSettings?.version ?? 1
+					const currentVersion = prevState.autoApprovalSettings?.version ?? 1
+					const shouldUpdateAutoApproval = incomingVersion > currentVersion
+					return {
+						...incoming,
+						autoApprovalSettings: shouldUpdateAutoApproval
+							? incoming.autoApprovalSettings
+							: prevState.autoApprovalSettings,
+					}
+				})
 				const config = message.state?.apiConfiguration
 				const hasKey = config
 					? [


### PR DESCRIPTION
### Description

This PR adds an incrementing version to auto approve settings messages to prevent race conditions.

### Test Procedure

While a task is running, toggle auto approve settings repeatedly mid-task. Confirm settings are as was desired.
While Cline is at rest, open the auto approve menu and change a setting. Close the menu, open it, confirm the settings have not changed.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [X] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [X] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [X] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [X] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Before:
https://github.com/user-attachments/assets/37ea5562-d831-4316-b977-67b22ad9e159

After:
https://github.com/user-attachments/assets/8110579f-cdb3-4338-bfb9-3315e3ad62cb


### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds versioning to auto-approve settings to prevent race conditions, ensuring only the latest settings are applied.
> 
>   - **Behavior**:
>     - Adds versioning to `autoApprovalSettings` in `index.ts` to prevent race conditions.
>     - Updates `autoApprovalSettings` only if the incoming version is newer.
>   - **Components**:
>     - In `AutoApproveMenu.tsx`, increments version on settings change and posts updated settings.
>     - Uses `useExtensionState` to ensure the latest settings are used.
>   - **Context**:
>     - In `ExtensionStateContext.tsx`, compares versions to decide if `autoApprovalSettings` should be updated.
>   - **Models**:
>     - Adds `version` field to `AutoApprovalSettings` interface in `AutoApprovalSettings.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for c86737a710a61e9ccc3c2aab77ea74e97bf2f1b1. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->