### PR TITLE
Add symlink support for readDirectory

### DIFF
--- a/.changeset/soft-windows-melt.md
+++ b/.changeset/soft-windows-melt.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Symlink support for readDirectory

--- a/src/utils/fs.test.ts
+++ b/src/utils/fs.test.ts
@@ -3,7 +3,7 @@ import { after, describe, it } from "mocha"
 import * as os from "os"
 import * as path from "path"
 import "should"
-import { createDirectoriesForFile, fileExistsAtPath, isDirectory } from "./fs"
+import { createDirectoriesForFile, fileExistsAtPath, isDirectory, readDirectory } from "./fs"
 
 describe("Filesystem Utilities", () => {
 	const tmpDir = path.join(os.tmpdir(), "cline-test-" + Math.random().toString(36).slice(2))
@@ -86,6 +86,68 @@ describe("Filesystem Utilities", () => {
 			const nonExistentPath = path.join(tmpDir, "does-not-exist")
 			const isDir = await isDirectory(nonExistentPath)
 			isDir.should.be.false()
+		})
+	})
+
+	describe("readDirectory", () => {
+		it("should return a list of files in a directory", async () => {
+			const testDir = path.join(tmpDir, "read-test")
+			await fs.mkdir(testDir, { recursive: true })
+
+			const file1 = path.join(testDir, "file1.txt")
+			const file2 = path.join(testDir, "file2.txt")
+			await fs.writeFile(file1, "test1")
+			await fs.writeFile(file2, "test2")
+
+			const subDir = path.join(testDir, "subdir")
+			await fs.mkdir(subDir, { recursive: true })
+			const file3 = path.join(subDir, "file3.txt")
+			await fs.writeFile(file3, "test3")
+
+			const files = await readDirectory(testDir)
+			files.length.should.equal(3)
+			files.should.containDeep([path.resolve(file1), path.resolve(file2), path.resolve(file3)])
+		})
+
+		it("should handle symlinks to files", async () => {
+			const testDir = path.join(tmpDir, "symlink-test")
+			await fs.mkdir(testDir, { recursive: true })
+
+			const realFile = path.join(testDir, "real-file.txt")
+			const symlinkFile = path.join(testDir, "symlink-file.txt")
+			await fs.writeFile(realFile, "real file content")
+			await fs.symlink(realFile, symlinkFile)
+
+			const files = await readDirectory(testDir)
+			files.length.should.equal(2)
+			files.should.containDeep([path.resolve(realFile), path.resolve(symlinkFile)])
+		})
+
+		it("should handle symlinks to directories", async () => {
+			const testDir = path.join(tmpDir, "symlink-dir-test")
+			const targetDir = path.join(tmpDir, "target-dir")
+			const symlinkDir = path.join(testDir, "symlink-dir")
+
+			await fs.mkdir(testDir, { recursive: true })
+			await fs.mkdir(targetDir, { recursive: true })
+
+			const targetFile = path.join(targetDir, "target-file.txt")
+			await fs.writeFile(targetFile, "target file content")
+
+			await fs.symlink(targetDir, symlinkDir)
+
+			const files = await readDirectory(testDir)
+			files.length.should.equal(1)
+			files.should.containDeep([path.resolve(path.join(symlinkDir, "target-file.txt"))])
+		})
+
+		it("should throw an error for non-existent directories", async () => {
+			const nonExistentDir = path.join(tmpDir, "does-not-exist")
+			try {
+				await readDirectory(nonExistentDir)
+			} catch (error) {
+				error.should.be.an.instanceOf(Error)
+			}
 		})
 	})
 })


### PR DESCRIPTION
### Description

<!-- Describe your changes in detail. What problem does this PR solve? -->

**Issue**  
Since **v3.13.0**, the **Cline Rules pop‑over** does not load rule files delivered through **symbolic links**.  
`readDirectory()` was skipping entries where `Dirent.isSymbolicLink()` is `true`, so the pop‑over could not discover those rules.

**Fix**  
* Update `src/utils/fs.ts` so that `readDirectory()`  
  * Detects symlinks, resolves them with `fs.readlink()`, and inspects the target stats.  
  * Returns symlinked files and recursively traverses symlinked directories.  
* Add comprehensive unit tests in `src/utils/fs.test.ts`.  
* Add a changeset describing the bug‑fix.

### Test Procedure

<!-- How did you test this? Are you confident that it will not introduce bugs? If so, why? -->

1. `npm test` — new test cases cover:  
   * Standard directory traversal.  
   * Symlink → file.  
   * Symlink → directory (recursive).  
   * Graceful failure on missing directories.  
2. Manual QA: run Cline with a rules folder containing symlinks and confirm the pop‑over lists them.  
3. Regression: verify circular symlinks are safely ignored and performance remains unaffected.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

_N/A_

### Additional Notes

<!-- Add any additional notes for reviewers -->

* **Performance impact:** minimal — traversal is still depth‑first and filters OS artefacts before symlink resolution.  
* **Edge cases:** circular symlinks are not followed, preventing infinite loops.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add symlink support to `readDirectory()` in `fs.ts`, with tests in `fs.test.ts`.
> 
>   - **Behavior**:
>     - `readDirectory()` in `fs.ts` now resolves symlinks using `fs.readlink()` and inspects target stats.
>     - Supports symlinks to files and directories, recursively traversing symlinked directories.
>     - Safely ignores circular symlinks to prevent infinite loops.
>   - **Tests**:
>     - Added unit tests in `fs.test.ts` for symlink handling, including symlink to file, symlink to directory, and error handling for non-existent directories.
>   - **Misc**:
>     - Added a changeset `soft-windows-melt.md` describing the bug fix.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 13ce4b76a7317a5f78df6d001b8d155b70a1c490. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->