### PR TITLE
Fix #2941 ollama timeout 

### DIFF
--- a/.changeset/red-yaks-call.md
+++ b/.changeset/red-yaks-call.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Fix Ollama provider timeout by increasing it from 30 sec to 120 seconds to accommodate model loading time

--- a/src/api/providers/__tests__/ollama.test.ts
+++ b/src/api/providers/__tests__/ollama.test.ts
@@ -96,7 +96,7 @@ describe("OllamaHandler", () => {
 				try {
 					// Create a promise that rejects after a short timeout
 					const timeoutPromise = new Promise<never>((_, reject) => {
-						setTimeout(() => reject(new Error("Ollama request timed out after 30 seconds")), 100)
+						setTimeout(() => reject(new Error("Ollama request timed out after 120 seconds")), 100)
 					})
 
 					// Create a promise that never resolves
@@ -125,7 +125,7 @@ describe("OllamaHandler", () => {
 			}
 
 			// Check the result
-			errorMessage.should.equal("Ollama request timed out after 30 seconds")
+			errorMessage.should.equal("Ollama request timed out after 120 seconds")
 
 			// Restore the fake timers for other tests
 			clock = sinon.useFakeTimers()

--- a/src/api/providers/ollama.ts
+++ b/src/api/providers/ollama.ts
@@ -22,7 +22,7 @@ export class OllamaHandler implements ApiHandler {
 		try {
 			// Create a promise that rejects after timeout
 			const timeoutPromise = new Promise<never>((_, reject) => {
-				setTimeout(() => reject(new Error("Ollama request timed out after 30 seconds")), 30000)
+				setTimeout(() => reject(new Error("Ollama request timed out after 120 seconds")), 120000)
 			})
 
 			// Create the actual API request promise
@@ -63,7 +63,7 @@ export class OllamaHandler implements ApiHandler {
 		} catch (error: any) {
 			// Check if it's a timeout error
 			if (error.message && error.message.includes("timed out")) {
-				throw new Error("Ollama request timed out after 30 seconds")
+				throw new Error("Ollama request timed out after 120 seconds")
 			}
 
 			// Enhance error reporting


### PR DESCRIPTION
### Description

This PR fixes the Ollama provider timeout issue reported in [#2941](https://github.com/cline/cline/issues/2941). The current timeout of 30 seconds is not sufficient for models to load in some cases, causing timeout errors. This PR increases the timeout from 30 seconds to 120 seconds (2 minutes) to give more time for models to load before timing out. More elegant ways for doing it is left for another PR.

### Test Procedure

The changes have been tested by:
- Verifying that the code compiles successfully
- Ensuring all tests pass with the updated timeout value
- The changes are minimal and focused on just the timeout value, reducing the risk of introducing new issues

### Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ♻️ Refactor Changes
- [ ] 💅 Cosmetic Changes
- [ ] 📚 Documentation update
- [ ] 🏃 Workflow Changes

### Pre-flight Checklist

- [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
- [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
- [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
- [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A

### Additional Notes

This change is minimal and focused on addressing the specific timeout issue. It doesn't change any other functionality of the Ollama provider, just extends the timeout period to accommodate model loading time.
