### PR TITLE
Fix tests: compile esmodules to cjs and bundle them

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,8 +70,8 @@ jobs:
               run: npm run format
 
             # Build the extension before running tests
-            - name: Build Extension
-              run: npm run compile
+            - name: Build Tests and Extension
+              run: npm run pretest
 
             - name: Unit Tests
               run: npm run test:unit

--- a/.vscode-test.mjs
+++ b/.vscode-test.mjs
@@ -6,6 +6,10 @@ export default defineConfig({
 	mocha: {
 		ui: "bdd",
 		timeout: 20000, // Maximum time (in ms) that a test can run before failing
+		/** Set up alias path resolution during tests
+		 * @See {@link file://./test-setup.js}
+		 */
+		require: ["./test-setup.js"],
 	},
 	workspaceFolder: "test-workspace",
 	version: "stable",

--- a/esbuild.js
+++ b/esbuild.js
@@ -19,6 +19,7 @@ const aliasResolverPlugin = {
 			"@services": path.resolve(__dirname, "src/services"),
 			"@shared": path.resolve(__dirname, "src/shared"),
 			"@utils": path.resolve(__dirname, "src/utils"),
+			"@packages": path.resolve(__dirname, "src/packages"),
 		}
 
 		// For each alias entry, create a resolver

--- a/package.json
+++ b/package.json
@@ -292,7 +292,7 @@
 		"watch:tsc": "tsc --noEmit --watch --project tsconfig.json",
 		"package": "npm run build:webview && npm run check-types && npm run lint && node esbuild.js --production",
 		"protos": "node proto/build-proto.js && prettier src/shared/proto --write && prettier src/core/controller --write",
-		"compile-tests": "tsc -p ./tsconfig.test.json --outDir out",
+		"compile-tests": "node ./scripts/build-tests.js",
 		"watch-tests": "tsc -p . -w --outDir out",
 		"pretest": "npm run compile-tests && npm run compile && npm run lint",
 		"check-types": "tsc --noEmit",

--- a/scripts/build-tests.js
+++ b/scripts/build-tests.js
@@ -1,0 +1,61 @@
+const { execSync } = require("child_process")
+const esbuild = require("esbuild")
+
+const watch = process.argv.includes("--watch")
+
+/**
+ * @type {import('esbuild').Plugin}
+ */
+const esbuildProblemMatcherPlugin = {
+	name: "esbuild-problem-matcher",
+
+	setup(build) {
+		build.onStart(() => {
+			console.log("[watch] build started")
+		})
+		build.onEnd((result) => {
+			result.errors.forEach(({ text, location }) => {
+				console.error(`✘ [ERROR] ${text}`)
+				console.error(`    ${location.file}:${location.line}:${location.column}:`)
+			})
+			console.log("[watch] build finished")
+		})
+	},
+}
+
+const srcConfig = {
+	bundle: true,
+	minify: false,
+	sourcemap: true,
+	sourcesContent: true,
+	logLevel: "silent",
+	entryPoints: ["src/packages/**/*.ts"],
+	outdir: "out/packages",
+	format: "cjs",
+	platform: "node",
+	define: {
+		"process.env.IS_DEV": "true",
+		"process.env.IS_TEST": "true",
+	},
+	external: ["vscode"],
+	plugins: [esbuildProblemMatcherPlugin],
+}
+
+async function main() {
+	const srcCtx = await esbuild.context(srcConfig)
+
+	if (watch) {
+		await srcCtx.watch()
+	} else {
+		await srcCtx.rebuild()
+
+		await srcCtx.dispose()
+	}
+}
+
+execSync("tsc -p ./tsconfig.test.json --outDir out", { encoding: "utf-8" })
+
+main().catch((e) => {
+	console.error(e)
+	process.exit(1)
+})

--- a/src/core/storage/disk.ts
+++ b/src/core/storage/disk.ts
@@ -6,7 +6,7 @@ import { fileExistsAtPath } from "@utils/fs"
 import { ClineMessage } from "@shared/ExtensionMessage"
 import { TaskMetadata } from "@core/context/context-tracking/ContextTrackerTypes"
 import os from "os"
-import { execa } from "execa"
+import { execa } from "../../packages/execa"
 
 export const GlobalFileNames = {
 	apiConversationHistory: "api_conversation_history.json",

--- a/src/core/storage/disk.ts
+++ b/src/core/storage/disk.ts
@@ -6,7 +6,7 @@ import { fileExistsAtPath } from "@utils/fs"
 import { ClineMessage } from "@shared/ExtensionMessage"
 import { TaskMetadata } from "@core/context/context-tracking/ContextTrackerTypes"
 import os from "os"
-import { execa } from "../../packages/execa"
+import { execa } from "@packages/execa"
 
 export const GlobalFileNames = {
 	apiConversationHistory: "api_conversation_history.json",

--- a/src/packages/execa.ts
+++ b/src/packages/execa.ts
@@ -1,0 +1,1 @@
+export { execa } from "execa"

--- a/test-setup.js
+++ b/test-setup.js
@@ -1,0 +1,22 @@
+const tsConfigPaths = require("tsconfig-paths")
+const fs = require("fs")
+
+const tsConfig = JSON.parse(fs.readFileSync("./tsconfig.json", "utf-8"))
+
+/**
+ * The aliases point towards the `src` directory.
+ * However, `tsc` doesn't compile paths by itself
+ * (https://www.typescriptlang.org/docs/handbook/modules/reference.html#paths-does-not-affect-emit)
+ * So we need to use tsconfig-paths to resolve the aliases when running tests,
+ * but pointing to `out` instead.
+ */
+const outPaths = {}
+Object.keys(tsConfig.compilerOptions.paths).forEach((key) => {
+	const value = tsConfig.compilerOptions.paths[key]
+	outPaths[key] = value.map((path) => path.replace("src", "out"))
+})
+
+tsConfigPaths.register({
+	baseUrl: ".",
+	paths: outPaths,
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -27,7 +27,8 @@
 			"@integrations/*": ["src/integrations/*"],
 			"@services/*": ["src/services/*"],
 			"@shared/*": ["src/shared/*"],
-			"@utils/*": ["src/utils/*"]
+			"@utils/*": ["src/utils/*"],
+			"@packages/*": ["src/packages/*"]
 		}
 	},
 	"include": ["src/**/*", "scripts/**/*"],


### PR DESCRIPTION
This is a continuation of #3196. They are separate PRs against main to list them on the Cline repo.
If you want to see the proper diff against the previous branch, feel free to check out [this PR](https://github.com/BarreiroT/cline/pull/2) on the fork instead.

---

We have recently seen broken pipelines because of attempts to `require` ES modules.
The extension works because we bundle modules using `esbuild` for it.
After looking into some alternatives that would allow imports without changes to the pipeline ([primarily dynamic imports](https://github.com/cline/cline/pull/2869/files#r2042853155)), I decided to take an approach closer to the one we have for the extension itself.

I tried moving to `esbuild` entirely, but:
- If we bundle all modules, the `out` size goes from 1.1M to 140M.
- If we only bundle ES modules into the src:
  - It goes to 6.2M.
  - Because esbuild doesn't [support splitting for `cjs`](https://esbuild.github.io/api/#splitting), we would have bundled modules in each `src` file that imports them.
  - We need to keep a list of all of our ES modules and which of their dependencies are also ES modules.
- Finally, `exports` (and namespace/default imports) are made non-configurable and non-writable, which means `Sinon` can't stub them.
   - So, a lot of tests don't pass on their current form.
 - You can see the attempt [here](https://github.com/cline/cline/compare/main...BarreiroT:refactor-test-build-to-use-esbuild)


I think the current solution provides a good balance. Instead of bundling all the src code, I am transpiling it with `tsc` but bundling ES Modules stored inside the `./src/packages` directory with `esbuild`. This results in imports from testing done to bundled versions of the files.

Consequently:
- We have to add ES modules to the `packages` directory,
- And have a bit more complexity in the compile-tests script,
- But tests work in their current form, and the `out` size goes to 1.8M.

~We could add aliases so imports don't need to be `../../../packages` but can be `@/packages/execa` or something of the sort.~ (Handled by @celestial-vault on a[ recent PR](https://github.com/cline/cline/pull/2982/files))
Ideally, we also make this more explicit in the errors or the codebase in general so future maintainers can find the solution faster.

I also gave transforming the extension to ESM a try, but it took quite a bit of time, and I didn't get it to a stable state, so I gave it up for now. [ESM NodeJS extensions are supported](https://github.com/microsoft/vscode/issues/130367#issuecomment-2768741248), but it [isn't super straightforward to get tests running](https://github.com/jrieken/vscode-esm-sample-extension).

@dcbartlett mentioned moving tests to the webview project itself. There is probably space to move many of the `integration` tests that don't require a VSCode instance into unit tests (in the main or the webview projects), but I haven't tried it yet since I suspect there are at least some that require vscode.

### Test Procedure

You can see the test script now runs properly, although it has a failing test and the exit code will be ignored. This will be addressed on a follow up PR.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [x] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [x] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Bundle ES modules with `esbuild` for testing, updating build scripts and imports accordingly.
> 
>   - **Build Process**:
>     - Introduced `scripts/build-tests.js` to bundle ES modules in `src/packages` using `esbuild`.
>     - Updated `package.json` scripts: `compile-tests` now uses `build-tests.js`.
>     - Changed `npm run compile` to `npm run pretest` in `.github/workflows/test.yml`.
>   - **Imports**:
>     - Updated `src/core/storage/disk.ts` to import `execa` from `../../packages/execa`.
>     - Added `src/packages/execa.ts` to re-export `execa` from `execa` package.
>   - **Misc**:
>     - Removed `continue-on-error: true` from `Extension Tests with Coverage` in `test.yml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for c7d51558c28d5f4f8844af3247130d6f59bdd053. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->