### PR TITLE
ENG-516 Slash commands

### DIFF
--- a/.changeset/clean-birds-count.md
+++ b/.changeset/clean-birds-count.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": minor
+---
+
+menu fix for slash commands

--- a/webview-ui/src/components/chat/ChatTextArea.tsx
+++ b/webview-ui/src/components/chat/ChatTextArea.tsx
@@ -566,6 +566,10 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 				justDeletedSpaceAfterMention,
 				queryItems,
 				fileSearchResults,
+				showSlashCommandsMenu,
+				selectedSlashCommandsIndex,
+				slashCommandsQuery,
+				handleSlashCommandsSelect,
 			],
 		)
 

--- a/webview-ui/src/components/chat/ChatTextArea.tsx
+++ b/webview-ui/src/components/chat/ChatTextArea.tsx
@@ -534,7 +534,7 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 						charBeforeIsWhitespace &&
 						inputValue.slice(0, cursorPosition - 1).match(new RegExp(mentionRegex.source + "$"))
 					) {
-						// File mention handling (existing code)
+						// File mention handling
 						const newCursorPosition = cursorPosition - 1
 						if (!charAfterIsWhitespace) {
 							event.preventDefault()
@@ -543,7 +543,7 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 						}
 						setCursorPosition(newCursorPosition)
 						setJustDeletedSpaceAfterMention(true)
-						setJustDeletedSpaceAfterSlashCommand(false) // Reset the other flag
+						setJustDeletedSpaceAfterSlashCommand(false)
 					} else if (charBeforeIsWhitespace && inputValue.slice(0, cursorPosition - 1).match(slashCommandDeleteRegex)) {
 						// New slash command handling
 						const newCursorPosition = cursorPosition - 1
@@ -554,11 +554,10 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 						}
 						setCursorPosition(newCursorPosition)
 						setJustDeletedSpaceAfterSlashCommand(true)
-						setJustDeletedSpaceAfterMention(false) // Reset the other flag
+						setJustDeletedSpaceAfterMention(false)
 					}
 					// Handle the second backspace press for mentions or slash commands
 					else if (justDeletedSpaceAfterMention) {
-						// Existing mention deletion code
 						const { newText, newPosition } = removeMention(inputValue, cursorPosition)
 						if (newText !== inputValue) {
 							event.preventDefault()
@@ -578,7 +577,7 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 						setJustDeletedSpaceAfterSlashCommand(false)
 						setShowSlashCommandsMenu(false)
 					}
-					// STEP 3: Default case - reset flags if none of the above apply
+					// Default case - reset flags if none of the above apply
 					else {
 						setJustDeletedSpaceAfterMention(false)
 						setJustDeletedSpaceAfterSlashCommand(false)

--- a/webview-ui/src/utils/slash-commands.ts
+++ b/webview-ui/src/utils/slash-commands.ts
@@ -13,6 +13,28 @@ export const SUPPORTED_SLASH_COMMANDS: SlashCommand[] = [
 // Regex for detecting slash commands in text
 export const slashCommandRegex = /\/([a-zA-Z0-9_-]+)(\s|$)/
 export const slashCommandRegexGlobal = new RegExp(slashCommandRegex.source, "g")
+export const slashCommandDeleteRegex = /^\s*\/([a-zA-Z0-9_-]+)$/
+
+/**
+ * Removes a slash command at the cursor position
+ */
+export function removeSlashCommand(text: string, position: number): { newText: string; newPosition: number } {
+	const beforeCursor = text.slice(0, position)
+	const afterCursor = text.slice(position)
+
+	// Check if we're at the end of a slash command
+	const matchEnd = beforeCursor.match(slashCommandDeleteRegex)
+
+	if (matchEnd) {
+		// If we're at the end of a slash command, remove it
+		const newText = text.slice(0, position - matchEnd[0].length) + afterCursor.replace(" ", "") // removes the first space after the command
+		const newPosition = position - matchEnd[0].length
+		return { newText, newPosition }
+	}
+
+	// If we're not at the end of a slash command, just return the original text and position
+	return { newText: text, newPosition: position }
+}
 
 /**
  * Determines whether the slash command menu should be displayed based on text input


### PR DESCRIPTION
### Description

Fix slash command menu

### Test Procedure

Select command from slash-commands dropdown and mention(s) from the mentions menu, and test the delete functionality. If deleting starting from the space prior to the command/mention, it should delete the entire command/mention.

[recording](https://github.com/user-attachments/assets/f300b7c5-c28d-4445-8768-1a5f906e8e12)

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

### Additional Notes

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes slash command menu in `ChatTextArea.tsx` to handle deletion of slash commands and mentions correctly.
> 
>   - **Behavior**:
>     - Fixes slash command menu in `ChatTextArea.tsx` to handle deletion of slash commands and mentions correctly.
>     - Updates backspace handling to delete entire slash command or mention when deleting from space before it.
>   - **Functions**:
>     - Adds `slashCommandDeleteRegex` and `removeSlashCommand()` in `slash-commands.ts` for handling slash command deletion.
>   - **Misc**:
>     - Updates changeset file `clean-birds-count.md` to reflect menu fix for slash commands.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 9025e33fed32a257494eeb79d7887a6f9b30d06f. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->