### PR TITLE
Adding Caching to gemini provider

### DIFF
--- a/src/api/providers/gemini.ts
+++ b/src/api/providers/gemini.ts
@@ -1,21 +1,23 @@
 import type { Anthropic } from "@anthropic-ai/sdk"
 // Restore GenerateContentConfig import and add GenerateContentResponseUsageMetadata
-import {
-	GoogleGenAI,
-	type GenerationConfig,
-	type Content,
-	type GenerateContentConfig,
-	type GenerateContentResponseUsageMetadata,
-} from "@google/genai"
+import { GoogleGenAI, type Content, type GenerateContentConfig, type GenerateContentResponseUsageMetadata } from "@google/genai"
 import { withRetry } from "../retry"
 import { ApiHandler } from "../"
 import { ApiHandlerOptions, geminiDefaultModelId, GeminiModelId, geminiModels, ModelInfo } from "@shared/api"
 import { convertAnthropicMessageToGemini } from "../transform/gemini-format"
 import { ApiStream } from "../transform/stream"
 
+// Define a default TTL for the cache (e.g., 1 hour in seconds)
+const DEFAULT_CACHE_TTL_SECONDS = 3600
+
 export class GeminiHandler implements ApiHandler {
 	private options: ApiHandlerOptions
 	private client: GoogleGenAI // Updated client type
+
+	// Internal state for caching
+	private cacheName: string | null = null
+	private cacheExpireTime: number | null = null
+	private isFirstApiCall = true
 
 	constructor(options: ApiHandlerOptions) {
 		if (!options.geminiApiKey) {
@@ -30,6 +32,32 @@ export class GeminiHandler implements ApiHandler {
 	async *createMessage(systemPrompt: string, messages: Anthropic.Messages.MessageParam[]): ApiStream {
 		const { id: modelId, info: modelInfo } = this.getModel()
 
+		// --- Cache Handling Logic ---
+		const isCacheValid = this.cacheName && this.cacheExpireTime && Date.now() < this.cacheExpireTime
+		let useCache = !this.isFirstApiCall && isCacheValid
+
+		if (this.isFirstApiCall && !isCacheValid && systemPrompt) {
+			// It's the first call, no valid cache exists, and we have a system prompt. Attempt cache creation.
+			this.isFirstApiCall = false
+
+			// Minimum token check heuristic (simple length check for now, could be improved)
+			// Gemini requires minimum 4096 tokens. A simple length check isn't accurate but avoids complex token counting here.
+			// Let's assume a generous average of 4 chars/token. 4096 tokens * 4 chars/token = 16384 chars.
+			const MIN_SYSTEM_PROMPT_LENGTH_FOR_CACHE = 16384
+			if (systemPrompt.length >= MIN_SYSTEM_PROMPT_LENGTH_FOR_CACHE) {
+				// Start cache creation asynchronously, don't block the main request
+				this.createCacheInBackground(modelId, systemPrompt)
+			}
+			// Proceed with the first request *without* using the cache, as it's being created.
+			useCache = false
+		} else if (!isCacheValid && this.cacheName) {
+			// Cache exists but has expired
+			this.cacheName = null
+			this.cacheExpireTime = null
+			useCache = false
+		}
+		// --- End Cache Handling Logic ---
+
 		// Re-implement thinking budget logic based on new SDK structure
 		const thinkingBudget = this.options.thinkingBudgetTokens ?? 0
 		const maxBudget = modelInfo.thinkingConfig?.maxBudget ?? 0
@@ -37,11 +65,12 @@ export class GeminiHandler implements ApiHandler {
 		// port add baseUrl configuration for gemini api requests (#2843)
 		const httpOptions = this.options.geminiBaseUrl ? { baseUrl: this.options.geminiBaseUrl } : undefined
 
-		// Base generation config - Restore type and systemInstruction
+		// Base generation config - Conditionally include systemInstruction based on cache usage
 		const generationConfig: GenerateContentConfig = {
 			httpOptions,
 			temperature: 0, // Default temperature
-			systemInstruction: systemPrompt, // System prompt belongs here
+			// Only include systemInstruction if NOT using the cache
+			...(useCache ? {} : { systemInstruction: systemPrompt }),
 		}
 
 		// Convert messages to the format expected by @google/genai
@@ -64,7 +93,11 @@ export class GeminiHandler implements ApiHandler {
 		const result = await this.client.models.generateContentStream({
 			model: modelId, // Pass model ID directly
 			contents,
-			config: requestConfig, // Pass the combined config (which includes systemInstruction)
+			// Add cachedContent if using the cache
+			config: {
+				...requestConfig,
+				...(useCache ? { cachedContent: this.cacheName! } : {}),
+			},
 		})
 
 		// Declare variable to hold the last usage metadata found
@@ -88,7 +121,34 @@ export class GeminiHandler implements ApiHandler {
 				type: "usage",
 				inputTokens: lastUsageMetadata.promptTokenCount ?? 0,
 				outputTokens: lastUsageMetadata.candidatesTokenCount ?? 0,
+				cacheWriteTokens: lastUsageMetadata.cachedContentTokenCount ?? 0,
+				cacheReadTokens: useCache ? (lastUsageMetadata.promptTokenCount ?? 0) : 0, // If cache used, prompt tokens are read from cache
 			}
+		}
+	}
+
+	private async createCacheInBackground(modelId: string, systemInstruction: string): Promise<void> {
+		try {
+			const cache = await this.client.caches.create({
+				model: modelId,
+				config: {
+					systemInstruction: systemInstruction,
+					ttl: `${DEFAULT_CACHE_TTL_SECONDS}s`,
+				},
+			})
+
+			if (cache?.name) {
+				this.cacheName = cache.name
+				// Calculate expiry timestamp using the default TTL, as the response object might not contain it directly.
+				this.cacheExpireTime = Date.now() + DEFAULT_CACHE_TTL_SECONDS * 1000
+			} else {
+				console.warn("Gemini cache creation call succeeded but returned no cache name.")
+			}
+		} catch (error) {
+			console.error("Failed to create Gemini cache in background:", error)
+			// Reset state if creation failed definitively
+			this.cacheName = null
+			this.cacheExpireTime = null
 		}
 	}
 


### PR DESCRIPTION
### Description

This PR implements context caching for the Google Gemini API provider (`src/api/providers/gemini.ts`) to optimize performance and reduce costs for tasks involving large, repetitive system prompts.

**Problem:** Currently, the full system prompt (which can be large, especially with custom instructions and rules) is sent with every API request to Gemini within a task.
**Solution:** This change introduces task-scoped [context caching](https://ai.google.dev/gemini-api/docs/caching?lang=node#generate-content) directly within the `GeminiHandler`.
    - On the first API call within a task, if the system prompt meets a minimum length heuristic (approximating the Gemini API's 4096 token minimum), the handler attempts to create a Gemini cache for the prompt asynchronously.
    - On subsequent calls within the same task, if a valid (non-expired) cache exists for that handler instance, it's used (`cachedContent` parameter), and the `systemInstruction` is omitted from the request. 
    - Cache TTL defaults to 1 hour.

Files Changed:
- `src/api/providers/gemini.ts`: Implemented caching logic, state, creation, usage

### Test Procedure
Test locally with the debugger and notice how our 10K token system prompt is cached. 

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [X] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [X] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [X] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [X] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [X] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots
Proof of cache hit 
<img width="1114" alt="image" src="https://github.com/user-attachments/assets/f14bbda1-a514-4ee5-ac0c-2ef3ca7a7e25" />



### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds task-scoped context caching to `GeminiHandler` in `gemini.ts` to optimize API calls by reducing redundant `systemPrompt` transmissions.
> 
>   - **Caching Logic**:
>     - Implements task-scoped context caching in `GeminiHandler` in `gemini.ts`.
>     - On first API call, attempts to create cache if `systemPrompt` exceeds 16384 characters.
>     - Uses cache for subsequent calls if valid, omitting `systemInstruction`.
>     - Cache TTL set to 1 hour.
>   - **Functions**:
>     - Adds `createCacheInBackground()` to handle asynchronous cache creation.
>     - Modifies `createMessage()` to include cache logic and conditional `systemInstruction` inclusion.
>   - **Misc**:
>     - Introduces `DEFAULT_CACHE_TTL_SECONDS` constant for cache TTL.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 2a9d3862ab6eae0696aafa6fedd5acac3075c2ba. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->