### PR TITLE
Arafatkatze/gemini caching

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
 				"@aws-sdk/client-bedrock-runtime": "^3.758.0",
 				"@bufbuild/protobuf": "^2.2.5",
 				"@google-cloud/vertexai": "^1.9.3",
-				"@google/generative-ai": "^0.18.0",
+				"@google/genai": "^0.9.0",
 				"@grpc/grpc-js": "^1.9.15",
 				"@mistralai/mistralai": "^1.5.0",
 				"@modelcontextprotocol/sdk": "^1.7.0",
@@ -5564,11 +5564,17 @@
 				"node": ">=18.0.0"
 			}
 		},
-		"node_modules/@google/generative-ai": {
-			"version": "0.18.0",
-			"resolved": "https://registry.npmjs.org/@google/generative-ai/-/generative-ai-0.18.0.tgz",
-			"integrity": "sha512-AhaIWSpk2tuhYHrBhUqC0xrWWznmYEja1/TRDIb+5kruBU5kUzMlFsXCQNO9PzyTZ4clUJ3CX/Rvy+Xm9x+w3g==",
+		"node_modules/@google/genai": {
+			"version": "0.9.0",
+			"resolved": "https://registry.npmjs.org/@google/genai/-/genai-0.9.0.tgz",
+			"integrity": "sha512-FD2RizYGInsvfjeaN6O+wQGpRnGVglS1XWrGQr8K7D04AfMmvPodDSw94U9KyFtsVLzWH9kmlPyFM+G4jbmkqg==",
 			"license": "Apache-2.0",
+			"dependencies": {
+				"google-auth-library": "^9.14.2",
+				"ws": "^8.18.0",
+				"zod": "^3.22.4",
+				"zod-to-json-schema": "^3.22.4"
+			},
 			"engines": {
 				"node": ">=18.0.0"
 			}
@@ -12495,9 +12501,10 @@
 			}
 		},
 		"node_modules/google-auth-library": {
-			"version": "9.14.0",
-			"resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.14.0.tgz",
-			"integrity": "sha512-Y/eq+RWVs55Io/anIsm24sDS8X79Tq948zVLGaa7+KlJYYqaGwp1YI37w48nzrNi12RgnzMrQD4NzdmCowT90g==",
+			"version": "9.15.1",
+			"resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.15.1.tgz",
+			"integrity": "sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==",
+			"license": "Apache-2.0",
 			"dependencies": {
 				"base64-js": "^1.3.0",
 				"ecdsa-sig-formatter": "^1.0.11",

--- a/package.json
+++ b/package.json
@@ -361,7 +361,7 @@
 		"@aws-sdk/client-bedrock-runtime": "^3.758.0",
 		"@bufbuild/protobuf": "^2.2.5",
 		"@google-cloud/vertexai": "^1.9.3",
-		"@google/generative-ai": "^0.18.0",
+		"@google/genai": "^0.9.0",
 		"@grpc/grpc-js": "^1.9.15",
 		"@mistralai/mistralai": "^1.5.0",
 		"@modelcontextprotocol/sdk": "^1.7.0",

--- a/src/api/providers/gemini.ts
+++ b/src/api/providers/gemini.ts
@@ -1,52 +1,100 @@
-import { Anthropic } from "@anthropic-ai/sdk"
-import { GoogleGenerativeAI } from "@google/generative-ai"
+import type { Anthropic } from "@anthropic-ai/sdk"
+// Restore GenerateContentConfig import and add GenerateContentResponseUsageMetadata
+import {
+	GoogleGenAI,
+	type GenerationConfig,
+	type Content,
+	type GenerateContentConfig,
+	type GenerateContentResponseUsageMetadata,
+} from "@google/genai"
 import { withRetry } from "../retry"
-import { ApiHandler } from "../"
-import { ApiHandlerOptions, geminiDefaultModelId, GeminiModelId, geminiModels, ModelInfo } from "../../shared/api"
-import { convertAnthropicMessageToGemini } from "../transform/gemini-format"
-import { ApiStream } from "../transform/stream"
+import type { ApiHandler } from "../"
+import type { ApiHandlerOptions, GeminiModelId, ModelInfo } from "../../shared/api"
+import { geminiDefaultModelId, geminiModels } from "../../shared/api"
+import { convertAnthropicMessageToGemini } from "../transform/gemini-format" // Note: This converter might need updates for @google/genai format
+import type { ApiStream } from "../transform/stream"
 
 export class GeminiHandler implements ApiHandler {
 	private options: ApiHandlerOptions
-	private client: GoogleGenerativeAI
+	private client: GoogleGenAI // Updated client type
 
 	constructor(options: ApiHandlerOptions) {
 		if (!options.geminiApiKey) {
 			throw new Error("API key is required for Google Gemini")
 		}
 		this.options = options
-		this.client = new GoogleGenerativeAI(options.geminiApiKey)
+		// Updated client initialization
+		this.client = new GoogleGenAI({ apiKey: options.geminiApiKey })
 	}
 
 	@withRetry()
 	async *createMessage(systemPrompt: string, messages: Anthropic.Messages.MessageParam[]): ApiStream {
-		const modelOptions = {
-			model: this.getModel().id,
-			systemInstruction: systemPrompt,
+		const { id: modelId, info: modelInfo } = this.getModel()
+
+		// Re-implement thinking budget logic based on new SDK structure
+		const thinkingBudget = this.options.thinkingBudgetTokens ?? 0
+		const maxBudget = modelInfo.thinkingConfig?.maxBudget ?? 0
+
+		// port add baseUrl configuration for gemini api requests (#2843)
+		const httpOptions = this.options.geminiBaseUrl ? { baseUrl: this.options.geminiBaseUrl } : undefined
+
+		// Base generation config - Restore type and systemInstruction
+		const generationConfig: GenerateContentConfig = {
+			httpOptions,
+			temperature: 0, // Default temperature
+			systemInstruction: systemPrompt, // System prompt belongs here
 		}
 
-		const clientOptions = this.options.geminiBaseUrl ? { baseUrl: this.options.geminiBaseUrl } : undefined
-		const model = this.client.getGenerativeModel(modelOptions, clientOptions)
-		const result = await model.generateContentStream({
-			contents: messages.map(convertAnthropicMessageToGemini),
-			generationConfig: {
-				// maxOutputTokens: this.getModel().info.maxTokens,
-				temperature: 0,
-			},
-		})
+		// Convert messages to the format expected by @google/genai
+		// Note: convertAnthropicMessageToGemini might need adjustments
+		const contents: Content[] = messages.map(convertAnthropicMessageToGemini)
 
-		for await (const chunk of result.stream) {
-			yield {
-				type: "text",
-				text: chunk.text(),
+		// Construct the main request config - Type as GenerateContentConfig
+		const requestConfig: GenerateContentConfig = {
+			...generationConfig,
+		}
+
+		// Add thinking config if the model supports it
+		if (modelInfo.thinkingConfig?.outputPrice !== undefined && maxBudget > 0) {
+			requestConfig.thinkingConfig = {
+				thinkingBudget: thinkingBudget,
 			}
 		}
 
-		const response = await result.response
-		yield {
-			type: "usage",
-			inputTokens: response.usageMetadata?.promptTokenCount ?? 0,
-			outputTokens: response.usageMetadata?.candidatesTokenCount ?? 0,
+		// Generate content using the new SDK structure via client.models
+		const result = await this.client.models.generateContentStream({
+			model: modelId, // Pass model ID directly
+			// Remove systemInstruction from here
+			contents,
+			config: requestConfig, // Pass the combined config (which includes systemInstruction)
+		})
+
+		// Declare variable to hold the last usage metadata found
+		let lastUsageMetadata: GenerateContentResponseUsageMetadata | undefined
+
+		// Iterate directly over the stream
+		for await (const chunk of result) {
+			// Access text directly as a property
+			if (chunk.text) {
+				// Check if text exists
+				yield {
+					type: "text",
+					text: chunk.text, // Access as property
+				}
+			}
+			// Capture usage metadata if present in the chunk
+			if (chunk.usageMetadata) {
+				lastUsageMetadata = chunk.usageMetadata
+			}
+		}
+
+		// Yield usage data from the last chunk that contained it
+		if (lastUsageMetadata) {
+			yield {
+				type: "usage",
+				inputTokens: lastUsageMetadata.promptTokenCount ?? 0,
+				outputTokens: lastUsageMetadata.candidatesTokenCount ?? 0,
+			}
 		}
 	}
 

--- a/src/api/transform/gemini-format.ts
+++ b/src/api/transform/gemini-format.ts
@@ -1,25 +1,31 @@
 import { Anthropic } from "@anthropic-ai/sdk"
-import { Content, EnhancedGenerateContentResponse, InlineDataPart, Part, TextPart } from "@google/generative-ai"
+// Update imports: Use GenerateContentResponse, remove InlineDataPart/TextPart, assume Part is available
+import { Content, GenerateContentResponse, Part } from "@google/genai"
 
 export function convertAnthropicContentToGemini(content: string | Anthropic.ContentBlockParam[]): Part[] {
 	if (typeof content === "string") {
-		return [{ text: content } as TextPart]
+		// Remove TextPart cast
+		return [{ text: content }]
 	}
-	return content.flatMap((block) => {
+	return content.flatMap((block): Part => {
+		// Add explicit Part return type for lambda
 		switch (block.type) {
 			case "text":
-				return { text: block.text } as TextPart
+				// Remove TextPart cast
+				return { text: block.text }
 			case "image":
 				if (block.source.type !== "base64") {
 					throw new Error("Unsupported image source type")
 				}
+				// Remove InlineDataPart cast, assume structure is correct for Part
 				return {
 					inlineData: {
 						data: block.source.data,
 						mimeType: block.source.media_type,
 					},
-				} as InlineDataPart
+				}
 			default:
+				// Ensure a Part is returned or error thrown
 				throw new Error(`Unsupported content block type: ${block.type}`)
 		}
 	})
@@ -39,11 +45,13 @@ export function unescapeGeminiContent(content: string) {
 	return content.replace(/\\n/g, "\n").replace(/\\'/g, "'").replace(/\\"/g, '"').replace(/\\r/g, "\r").replace(/\\t/g, "\t")
 }
 
-export function convertGeminiResponseToAnthropic(response: EnhancedGenerateContentResponse): Anthropic.Messages.Message {
+// Update response type to GenerateContentResponse
+export function convertGeminiResponseToAnthropic(response: GenerateContentResponse): Anthropic.Messages.Message {
 	const content: Anthropic.Messages.ContentBlock[] = []
 
-	// Add the main text response
-	const text = response.text()
+	// Add the main text response - check if response.text exists
+	// Assuming response.text is the correct accessor based on previous findings
+	const text = response.text
 	if (text) {
 		content.push({ type: "text", text, citations: null })
 	}

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -104,6 +104,11 @@ export interface ModelInfo {
 	inputPriceTiers?: PriceTier[] // Add for tiered input pricing
 	outputPrice?: number // Keep for non-tiered output models
 	outputPriceTiers?: PriceTier[] // Add for tiered output pricing
+	thinkingConfig?: {
+		maxBudget?: number // Max allowed thinking budget tokens
+		outputPrice?: number // Output price per million tokens when budget > 0
+		outputPriceTiers?: PriceTier[] // Optional: Tiered output price when budget > 0
+	}
 	cacheWritesPrice?: number
 	cacheReadsPrice?: number
 	description?: string
@@ -409,6 +414,18 @@ export const vertexModels = {
 			{ tokenLimit: Infinity, price: 15.0 }, // Output price for > 200k input tokens
 		],
 	},
+	"gemini-2.5-flash-preview-04-17": {
+		maxTokens: 65536,
+		contextWindow: 1_048_576,
+		supportsImages: true,
+		supportsPromptCache: false,
+		inputPrice: 0.15, // $0.15/million input tokens
+		outputPrice: 0.6, // $0.60/million output tokens (standard)
+		thinkingConfig: {
+			maxBudget: 24576, // Max thinking budget
+			outputPrice: 3.5, // $3.50/million output tokens (with thinking budget > 0)
+		},
+	},
 	"gemini-2.0-flash-thinking-exp-01-21": {
 		maxTokens: 65_536,
 		contextWindow: 1_048_576,
@@ -504,6 +521,18 @@ export const geminiModels = {
 			{ tokenLimit: 200000, price: 10.0 }, // Output price for <= 200k input tokens
 			{ tokenLimit: Infinity, price: 15.0 }, // Output price for > 200k input tokens
 		],
+	},
+	"gemini-2.5-flash-preview-04-17": {
+		maxTokens: 65536,
+		contextWindow: 1_048_576,
+		supportsImages: true,
+		supportsPromptCache: false,
+		inputPrice: 0.15, // $0.15/million input tokens
+		outputPrice: 0.6, // $0.60/million output tokens (standard)
+		thinkingConfig: {
+			maxBudget: 24576, // Max thinking budget
+			outputPrice: 3.5, // $3.50/million output tokens (with thinking budget > 0)
+		},
 	},
 	"gemini-2.0-flash-001": {
 		maxTokens: 8192,

--- a/webview-ui/src/components/settings/ApiOptions.tsx
+++ b/webview-ui/src/components/settings/ApiOptions.tsx
@@ -824,6 +824,15 @@ const ApiOptions = ({ showModelOptions, apiErrorMessage, modelIdErrorMessage, is
 							</VSCodeLink>
 						)}
 					</p>
+					{/* Add Thinking Budget Slider specifically for gemini-2.5-flash-preview-04-17 */}
+					{/* Add Thinking Budget Slider specifically for gemini-2.5-flash-preview-04-17 */}
+					{selectedProvider === "gemini" && selectedModelId === "gemini-2.5-flash-preview-04-17" && (
+						<ThinkingBudgetSlider
+							apiConfiguration={apiConfiguration}
+							setApiConfiguration={setApiConfiguration}
+							maxBudget={selectedModelInfo.thinkingConfig?.maxBudget}
+						/>
+					)}
 				</div>
 			)}
 
@@ -1738,17 +1747,30 @@ export const formatPrice = (price: number) => {
 }
 
 // Returns an array of formatted tier strings
-const formatTiers = (tiers: ModelInfo["inputPriceTiers"]): string[] => {
+const formatTiers = (tiers: ModelInfo["inputPriceTiers"]): JSX.Element[] => {
 	if (!tiers || tiers.length === 0) {
 		return []
 	}
 	return tiers.map((tier, index, arr) => {
 		const prevLimit = index > 0 ? arr[index - 1].tokenLimit : 0
-		const limitText =
-			tier.tokenLimit === Infinity
-				? `> ${prevLimit.toLocaleString()}` // Assumes sorted and Infinity is last
-				: `<= ${tier.tokenLimit.toLocaleString()}`
-		return `${formatPrice(tier.price)}/million tokens (${limitText} tokens)`
+		return (
+			<span style={{ paddingLeft: "15px" }} key={index}>
+				{formatPrice(tier.price)}/million tokens (
+				{tier.tokenLimit === Number.POSITIVE_INFINITY ? (
+					<span>
+						{"> "}
+						{prevLimit.toLocaleString()}
+					</span>
+				) : (
+					<span>
+						{"<= "}
+						{tier.tokenLimit.toLocaleString()}
+					</span>
+				)}
+				{" tokens)"}
+				{index < arr.length - 1 && <br />}
+			</span>
+		)
 	})
 }
 
@@ -1766,18 +1788,14 @@ export const ModelInfoView = ({
 	isPopup?: boolean
 }) => {
 	const isGemini = Object.keys(geminiModels).includes(selectedModelId)
+	const hasThinkingConfig = !!modelInfo.thinkingConfig
 
 	// Create elements for tiered pricing separately
 	const inputPriceElement = modelInfo.inputPriceTiers ? (
 		<Fragment key="inputPriceTiers">
 			<span style={{ fontWeight: 500 }}>Input price:</span>
 			<br />
-			{formatTiers(modelInfo.inputPriceTiers).map((tierString, i, arr) => (
-				<Fragment key={`inputTierFrag${i}`}>
-					<span style={{ paddingLeft: "15px" }}>{tierString}</span>
-					{i < arr.length - 1 && <br />}
-				</Fragment>
-			))}
+			{formatTiers(modelInfo.inputPriceTiers)}
 		</Fragment>
 	) : modelInfo.inputPrice !== undefined && modelInfo.inputPrice > 0 ? (
 		<span key="inputPrice">
@@ -1785,23 +1803,38 @@ export const ModelInfoView = ({
 		</span>
 	) : null
 
-	const outputPriceElement = modelInfo.outputPriceTiers ? (
-		<Fragment key="outputPriceTiers">
-			<span style={{ fontWeight: 500 }}>Output price:</span>
-			<span style={{ fontStyle: "italic" }}> (based on input tokens)</span>
-			<br />
-			{formatTiers(modelInfo.outputPriceTiers).map((tierString, i, arr) => (
-				<Fragment key={`outputTierFrag${i}`}>
-					<span style={{ paddingLeft: "15px" }}>{tierString}</span>
-					{i < arr.length - 1 && <br />}
-				</Fragment>
-			))}
-		</Fragment>
-	) : modelInfo.outputPrice !== undefined && modelInfo.outputPrice > 0 ? (
-		<span key="outputPrice">
-			<span style={{ fontWeight: 500 }}>Output price:</span> {formatPrice(modelInfo.outputPrice)}/million tokens
-		</span>
-	) : null
+	// --- Output Price Logic ---
+	let outputPriceElement = null
+	if (hasThinkingConfig && modelInfo.outputPrice !== undefined && modelInfo.thinkingConfig?.outputPrice !== undefined) {
+		// Display both standard and thinking budget prices
+		outputPriceElement = (
+			<Fragment key="outputPriceConditional">
+				<span style={{ fontWeight: 500 }}>Output price (Standard):</span> {formatPrice(modelInfo.outputPrice)}/million
+				tokens
+				<br />
+				<span style={{ fontWeight: 500 }}>Output price (Thinking Budget &gt; 0):</span>{" "}
+				{formatPrice(modelInfo.thinkingConfig.outputPrice)}/million tokens
+			</Fragment>
+		)
+	} else if (modelInfo.outputPriceTiers) {
+		// Display tiered output pricing
+		outputPriceElement = (
+			<Fragment key="outputPriceTiers">
+				<span style={{ fontWeight: 500 }}>Output price:</span>
+				<span style={{ fontStyle: "italic" }}> (based on input tokens)</span>
+				<br />
+				{formatTiers(modelInfo.outputPriceTiers)}
+			</Fragment>
+		)
+	} else if (modelInfo.outputPrice !== undefined && modelInfo.outputPrice > 0) {
+		// Display single standard output price
+		outputPriceElement = (
+			<span key="outputPrice">
+				<span style={{ fontWeight: 500 }}>Output price:</span> {formatPrice(modelInfo.outputPrice)}/million tokens
+			</span>
+		)
+	}
+	// --- End Output Price Logic ---
 
 	const infoItems = [
 		modelInfo.description && (


### PR DESCRIPTION
### Description

<!-- Describe your changes in detail. What problem does this PR solve? -->
This PR implements context caching for the Google Gemini API provider (`src/api/providers/gemini.ts`) to optimize performance and reduce costs for tasks involving large, repetitive system prompts.

**Problem:** Currently, the full system prompt (which can be large, especially with custom instructions and rules) is sent with every API request to Gemini within a task.
**Solution:** This change introduces task-scoped [context caching](https://ai.google.dev/gemini-api/docs/caching?lang=node#generate-content) directly within the GeminiHandler.
- On the first API call within a task, if the system prompt meets a minimum length heuristic (approximating the Gemini API's 4096 token minimum), the handler attempts to create a Gemini cache for the prompt asynchronously.
- On subsequent calls within the same task, if a valid (non-expired) cache exists for that handler instance, it's used (cachedContent parameter), and the systemInstruction is omitted from the request.
- Cache TTL defaults to 1 hour.

Files Changed:

- src/api/providers/gemini.ts: Implemented caching logic, state, creation, usage

### Test Procedure

<!-- How did you test this? Are you confident that it will not introduce bugs? If so, why? -->
Test locally with the debugger and notice how our 10K token system prompt is cached.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->
Proof of cache hit

![image](https://github.com/user-attachments/assets/963d9f8f-76da-458c-abb6-83ba6055a69e)

### Additional Notes

<!-- Add any additional notes for reviewers -->
