### PR TITLE
fix output calculation by setting the default output cost

### DIFF
--- a/.changeset/twenty-comics-enjoy.md
+++ b/.changeset/twenty-comics-enjoy.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+fix cost calculation

--- a/src/utils/cost.ts
+++ b/src/utils/cost.ts
@@ -27,7 +27,7 @@ function calculateApiCostInternal(
 	}
 
 	// Determine effective output price
-	let effectiveOutputPrice = 0
+	let effectiveOutputPrice = modelInfo.outputPrice || 0
 	// Check if thinking budget was used and has a specific price
 	if (usedThinkingBudget && modelInfo.thinkingConfig?.outputPrice !== undefined) {
 		effectiveOutputPrice = modelInfo.thinkingConfig.outputPrice


### PR DESCRIPTION
### Description

[On a recent PR](https://github.com/cline/cline/pull/2964/files#diff-40bf6bcde2f72f02a58829a042ed7e0c9bbba5cfbff623e4b9df2db385b2a3f6R30), some improvements were made to calculate thinking costs and the default value was set to 0.
I noticed it when fixing the tests for my [other PR](https://github.com/cline/cline/actions/runs/14611325159/job/40989786850?pr=3030).
This PR returns the default to the model `outputPrice`.

### Test Procedure

I added the changes to [this branch](https://github.com/cline/cline/pull/3030) that has running tests (but the cost calculation is failing) and it went green.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes default output price in `calculateApiCostInternal` to use `modelInfo.outputPrice` for accurate cost calculation.
> 
>   - **Behavior**:
>     - Fixes default output price in `calculateApiCostInternal` in `cost.ts` to use `modelInfo.outputPrice` instead of 0.
>     - Ensures accurate cost calculation when thinking budget is not used.
>   - **Misc**:
>     - Adds changeset `twenty-comics-enjoy.md` for documentation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 76a8c02d6953fd5ba1f0325f4455064aa956e7e6. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->