### PR TITLE
Feat/change reset state colors

### DIFF
--- a/.changeset/cyan-pears-battle.md
+++ b/.changeset/cyan-pears-battle.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Update Reset Button color to Red

--- a/webview-ui/src/components/settings/SettingsView.tsx
+++ b/webview-ui/src/components/settings/SettingsView.tsx
@@ -252,7 +252,10 @@ const SettingsView = ({ onDone }: SettingsViewProps) => {
 				{IS_DEV && (
 					<>
 						<div className="mt-[10px] mb-1">Debug</div>
-						<VSCodeButton onClick={handleResetState} className="mt-[5px] w-auto">
+						<VSCodeButton
+							onClick={handleResetState}
+							className="mt-[5px] w-auto"
+							style={{ backgroundColor: "var(--vscode-errorForeground)", color: "black" }}>
 							Reset State
 						</VSCodeButton>
 						<p className="text-xs mt-[5px] text-[var(--vscode-descriptionForeground)]">


### PR DESCRIPTION
### Description

Change color of Reset State Button

### Test Procedure

Build extension in dev and check that color is red for the Reset State Button

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [X] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [X] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [X] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [X] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [X] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<img width="982" alt="image" src="https://github.com/user-attachments/assets/4c10870c-f3e9-4afd-840f-ad020c4e67e5" />

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Change Reset State button color to red in `SettingsView.tsx` using `vscode-errorForeground`.
> 
>   - **Cosmetic Change**:
>     - Change Reset State button color to red in `SettingsView.tsx` using `vscode-errorForeground` for background color and black for text color.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for c636ded206ea6bfdc3d8e8f35bb139e8b358bc5e. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->