### PR TITLE
narrative narrative narrative

### DIFF
--- a/.changeset/loud-spies-deny.md
+++ b/.changeset/loud-spies-deny.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": minor
+---
+
+add truncation notice when truncating manually

--- a/src/core/task/index.ts
+++ b/src/core/task/index.ts
@@ -1505,6 +1505,10 @@ export class Task {
 					"quarter", // Force aggressive truncation
 				)
 				await this.saveClineMessagesAndUpdateHistory()
+				await this.contextManager.triggerApplyStandardContextTruncationNoticeChange(
+					Date.now(),
+					await ensureTaskDirectoryExists(this.getContext(), this.taskId),
+				)
 
 				this.didAutomaticallyRetryFailedApiRequest = true
 			} else if (isOpenRouter && !this.didAutomaticallyRetryFailedApiRequest) {
@@ -1515,6 +1519,10 @@ export class Task {
 						"quarter", // Force aggressive truncation
 					)
 					await this.saveClineMessagesAndUpdateHistory()
+					await this.contextManager.triggerApplyStandardContextTruncationNoticeChange(
+						Date.now(),
+						await ensureTaskDirectoryExists(this.getContext(), this.taskId),
+					)
 				}
 
 				console.log("first chunk failed, waiting 1 second before retrying")


### PR DESCRIPTION
### Description

Add truncation notice when manually truncating context

### Test Procedure

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

### Additional Notes

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds a truncation notice when context is manually truncated in the `Task` class in `index.ts`.
> 
>   - **Behavior**:
>     - Adds a truncation notice when context is manually truncated in the `Task` class in `index.ts`.
>     - The notice is triggered by `triggerApplyStandardContextTruncationNoticeChange()` in two places within `attemptApiRequest()`.
>   - **Misc**:
>     - Adds a changeset file `loud-spies-deny.md` to document the new feature.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 988f2dd07134bb2d392e310ec9bb715d88237bfa. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->