### PR TITLE
Improve chat row with UI grouping

### DIFF
--- a/.changeset/serious-weeks-know.md
+++ b/.changeset/serious-weeks-know.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+UIUX for ChatRow

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "claude-dev",
-	"version": "3.13.1",
+	"version": "3.13.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "claude-dev",
-			"version": "3.13.1",
+			"version": "3.13.2",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@anthropic-ai/bedrock-sdk": "^0.12.4",

--- a/webview-ui/src/components/chat/ChatRow.tsx
+++ b/webview-ui/src/components/chat/ChatRow.tsx
@@ -38,9 +38,18 @@ import UserMessage from "./UserMessage"
 const ChatRowContainer = styled.div`
 	padding: 10px 6px 10px 15px;
 	position: relative;
+	margin: 3px 9px;
 
 	&:hover ${CheckpointControls} {
 		opacity: 1;
+	}
+
+	& > div {
+		position: relative;
+		background-color: transparent;
+		border-radius: 12px;
+		padding: 12px 16px;
+		box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
 	}
 `
 
@@ -813,7 +822,13 @@ export const ChatRowContent = ({
 					return <McpResponseDisplay responseText={message.text || ""} />
 				case "text":
 					return (
-						<div>
+						<div
+							style={{
+								backgroundColor: "rgba(180, 180, 180, 0.1)",
+								borderRadius: "12px",
+								padding: "12px 16px",
+								boxShadow: "0 1px 2px rgba(0, 0, 0, 0.1)",
+							}}>
 							<Markdown markdown={message.text} />
 						</div>
 					)
@@ -875,12 +890,29 @@ export const ChatRowContent = ({
 					)
 				case "user_feedback":
 					return (
-						<UserMessage
-							text={message.text}
-							images={message.images}
-							messageTs={message.ts}
-							sendMessageFromChatRow={sendMessageFromChatRow}
-						/>
+						<>
+							<div
+								style={{
+									...headerStyle,
+									marginBottom: 0,
+								}}>
+								<span
+									className="codicon codicon-comment"
+									style={{
+										color: normalColor,
+										marginBottom: "-1.5px",
+									}}></span>
+								<span style={{ color: normalColor, fontWeight: "bold" }}>Your Request</span>
+							</div>
+							<div style={{ padding: "12px 16px", boxShadow: "0 1px 2px rgba(0, 0, 0, 0.1)" }}>
+								<UserMessage
+									text={message.text}
+									images={message.images}
+									messageTs={message.ts}
+									sendMessageFromChatRow={sendMessageFromChatRow}
+								/>
+							</div>
+						</>
 					)
 				case "user_feedback_diff":
 					const tool = JSON.parse(message.text || "{}") as ClineSayTool
@@ -1037,8 +1069,11 @@ export const ChatRowContent = ({
 							</div>
 							<div
 								style={{
+									backgroundColor: "rgba(180, 180, 180, 0.1)",
+									borderRadius: "12px",
+									padding: "12px 16px",
+									boxShadow: "0 1px 2px rgba(0, 0, 0, 0.1)",
 									color: "var(--vscode-charts-green)",
-									paddingTop: 10,
 								}}>
 								<Markdown markdown={text} />
 							</div>
@@ -1190,8 +1225,11 @@ export const ChatRowContent = ({
 								</div>
 								<div
 									style={{
+										backgroundColor: "rgba(180, 180, 180, 0.1)",
+										borderRadius: "12px",
+										padding: "12px 16px",
+										boxShadow: "0 1px 2px rgba(0, 0, 0, 0.1)",
 										color: "var(--vscode-charts-green)",
-										paddingTop: 10,
 									}}>
 									<Markdown markdown={text} />
 									{message.partial !== true && hasChanges && (

--- a/webview-ui/src/components/chat/UserMessage.tsx
+++ b/webview-ui/src/components/chat/UserMessage.tsx
@@ -86,8 +86,8 @@ const UserMessage: React.FC<UserMessageProps> = ({ text, images, messageTs, send
 			style={{
 				backgroundColor: isEditing ? "unset" : "var(--vscode-badge-background)",
 				color: "var(--vscode-badge-foreground)",
-				borderRadius: "3px",
-				padding: "9px",
+				borderRadius: "12px",
+				padding: "15px",
 				whiteSpace: "pre-line",
 				wordWrap: "break-word",
 			}}


### PR DESCRIPTION
### Description
UI/UX for how chat rows are separate is not visually clear. This PR addresses them by grouping each message into their own styling.

### Test Procedure
Locally running the extension on VS Code.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [X] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [X] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [X] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [X] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [X] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots
![image](https://github.com/user-attachments/assets/9ee22600-da98-4529-9013-cdebc95f7b7d)

### Additional Notes
N/A
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Improves chat row UI/UX by adding visual grouping and consistent styling to messages in `ChatRow.tsx` and `UserMessage.tsx`.
> 
>   - **UI/UX Improvements**:
>     - In `ChatRow.tsx`, added styling to group messages with background color, border radius, padding, and box shadow for better visual separation.
>     - In `UserMessage.tsx`, updated message container styling with increased border radius and padding.
>   - **Styling Details**:
>     - Applied consistent styling across different message types, including `text`, `user_feedback`, and `completion_result` in `ChatRow.tsx`.
>     - Enhanced hover effects and container margins in `ChatRowContainer` in `ChatRow.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 57a031cd20a50dda26464b0f6697f3359742c7f1. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->