### PR TITLE
It depends...

### DIFF
--- a/.changeset/kind-pears-invent.md
+++ b/.changeset/kind-pears-invent.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Add dependsOn to more blocks in the tasks.json

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -20,9 +20,9 @@
 		},
 		{
 			"label": "watch",
-			"dependsOn": ["npm: protos", "npm: build:webview", "npm: dev:webview", "npm: watch:tsc", "npm: watch:esbuild"],
+			"dependsOn": ["npm: protos", "npm: dev:webview", "npm: watch:tsc", "npm: watch:esbuild"],
 			"presentation": {
-				"reveal": "never"
+				"reveal": "always"
 			},
 			"group": {
 				"kind": "build",
@@ -39,7 +39,7 @@
 				"npm: watch:esbuild:test"
 			],
 			"presentation": {
-				"reveal": "never"
+				"reveal": "always"
 			},
 			"group": "build"
 		},
@@ -53,8 +53,7 @@
 			"dependsOn": ["npm: protos"],
 			"presentation": {
 				"group": "watch",
-				"reveal": "never",
-				"close": true
+				"reveal": "always"
 			},
 			"options": {
 				"env": {
@@ -69,10 +68,10 @@
 			"problemMatcher": [],
 			"isBackground": true,
 			"label": "npm: build:webview:test",
+			"dependsOn": ["npm: protos"],
 			"presentation": {
 				"group": "watch",
-				"reveal": "never",
-				"close": true
+				"reveal": "always"
 			},
 			"options": {
 				"env": {
@@ -104,10 +103,10 @@
 			],
 			"isBackground": true,
 			"label": "npm: dev:webview",
+			"dependsOn": ["npm: protos"],
 			"presentation": {
 				"group": "watch",
-				"reveal": "never",
-				"close": true
+				"reveal": "always"
 			},
 			"options": {
 				"env": {
@@ -125,8 +124,7 @@
 			"dependsOn": ["npm: protos"],
 			"presentation": {
 				"group": "watch",
-				"reveal": "never",
-				"close": true
+				"reveal": "always"
 			},
 			"options": {
 				"env": {
@@ -144,8 +142,7 @@
 			"dependsOn": ["npm: protos"],
 			"presentation": {
 				"group": "watch",
-				"reveal": "never",
-				"close": true
+				"reveal": "always"
 			},
 			"options": {
 				"env": {
@@ -161,10 +158,10 @@
 			"problemMatcher": "$tsc-watch",
 			"isBackground": true,
 			"label": "npm: watch:tsc",
+			"dependsOn": ["npm: protos"],
 			"presentation": {
 				"group": "watch",
-				"reveal": "never",
-				"close": true
+				"reveal": "always"
 			}
 		},
 		{
@@ -172,8 +169,9 @@
 			"script": "watch-tests",
 			"problemMatcher": "$tsc-watch",
 			"isBackground": true,
+			"dependsOn": ["npm: protos"],
 			"presentation": {
-				"reveal": "never",
+				"reveal": "always",
 				"group": "watchers"
 			},
 			"group": "build"

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -20,7 +20,7 @@
 		},
 		{
 			"label": "watch",
-			"dependsOn": ["npm: protos", "npm: dev:webview", "npm: watch:tsc", "npm: watch:esbuild"],
+			"dependsOn": ["npm: protos", "npm: build:webview", "npm: dev:webview", "npm: watch:tsc", "npm: watch:esbuild"],
 			"presentation": {
 				"reveal": "always"
 			},


### PR DESCRIPTION
# Fix Extension Startup Script Ordering

### Description

This change addresses an issue where the Cline extension was failing to wait for the protos to build. build tasks were running in parallel without proper dependencies, causing TypeScript compilation, webview building, and other tasks to sometimes start before the Protocol Buffer files were generated.

Specific changes:
1. Added `"npm: protos"` dependency to all relevant build tasks to ensure protocol files are generated first
2. Changed terminal presentation settings to `"reveal": "always"` to make build output visible for debugging
3. Removed auto-closing terminal windows to preserve error logs

These changes ensure the extension's build process follows the correct order:
1. Protocol Buffer files are generated first (`npm: protos`)
2. All other build steps wait for protocol generation before starting
3. Terminal output remains visible to help debug any issues

### Test Procedure

Tested by:
- Running the full build process using the "watch" task
- Verifying all tasks run in the correct order
- Confirming protocol buffer files are generated before TypeScript compilation starts

### Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ♻️ Refactor Changes
- [ ] 💅 Cosmetic Changes
- [ ] 📚 Documentation update
- [ ] 🏃 Workflow Changes

### Pre-flight Checklist

- [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
- [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
- [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
- [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

### Additional Notes


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes build order in Cline extension by adding `"npm: protos"` dependency to tasks and adjusting terminal settings.
> 
>   - **Build Process**:
>     - Added `"npm: protos"` dependency to all relevant build tasks to ensure protocol files are generated first.
>     - Changed terminal presentation settings to `"reveal": "always"` to make build output visible for debugging.
>     - Removed auto-closing terminal windows to preserve error logs.
>   - **Testing**:
>     - Tested by running the full build process using the "watch" task.
>     - Verified all tasks run in the correct order and protocol files are generated before TypeScript compilation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 0e9d23b89172047ca188c03615e55e08a908383f. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->