### PR TITLE
fix: overcoming Windows issue with npx command of MCP servers (issue: 2886)

### DIFF
--- a/.changeset/shiny-sloths-fail.md
+++ b/.changeset/shiny-sloths-fail.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Fixing how `npx` is invoked by MCP hub on Windows systems

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "claude-dev",
-	"version": "3.13.1",
+	"version": "3.13.3",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "claude-dev",
-			"version": "3.13.1",
+			"version": "3.13.3",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@anthropic-ai/bedrock-sdk": "^0.12.4",

--- a/src/services/mcp/McpHub.ts
+++ b/src/services/mcp/McpHub.ts
@@ -1,4 +1,6 @@
+import { GlobalFileNames } from "@core/storage/disk"
 import { Client } from "@modelcontextprotocol/sdk/client/index.js"
+import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js"
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js"
 import {
 	CallToolResultSchema,
@@ -7,16 +9,9 @@ import {
 	ListToolsResultSchema,
 	ReadResourceResultSchema,
 } from "@modelcontextprotocol/sdk/types.js"
-import chokidar, { FSWatcher } from "chokidar"
-import { setTimeout as setTimeoutPromise } from "node:timers/promises"
-import deepEqual from "fast-deep-equal"
-import * as fs from "fs/promises"
-import * as path from "path"
-import * as vscode from "vscode"
-import { z } from "zod"
+import { ExtensionMessage } from "@shared/ExtensionMessage"
 import {
 	DEFAULT_MCP_TIMEOUT_SECONDS,
-	McpMode,
 	McpResource,
 	McpResourceResponse,
 	McpResourceTemplate,
@@ -28,9 +23,14 @@ import {
 import { fileExistsAtPath } from "@utils/fs"
 import { arePathsEqual } from "@utils/path"
 import { secondsToMs } from "@utils/time"
-import { GlobalFileNames } from "@core/storage/disk"
-import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js"
-import { ExtensionMessage } from "@shared/ExtensionMessage"
+import chokidar, { FSWatcher } from "chokidar"
+import deepEqual from "fast-deep-equal"
+import * as fs from "fs/promises"
+import { setTimeout as setTimeoutPromise } from "node:timers/promises"
+import * as os from "os"
+import * as path from "path"
+import * as vscode from "vscode"
+import { z } from "zod"
 
 // Default timeout for internal MCP data requests in milliseconds; is not the same as the user facing timeout stored as DEFAULT_MCP_TIMEOUT_SECONDS
 const DEFAULT_REQUEST_TIMEOUT_MS = 5000
@@ -204,9 +204,10 @@ export class McpHub {
 			if (config.transportType === "sse") {
 				transport = new SSEClientTransport(new URL(config.url), {})
 			} else {
+				const { command, args } = transformNpxCommand(config.command, config.args)
 				transport = new StdioClientTransport({
-					command: config.command,
-					args: config.args,
+					command,
+					args,
 					env: {
 						...config.env,
 						...(process.env.PATH ? { PATH: process.env.PATH } : {}),
@@ -827,4 +828,22 @@ export class McpHub {
 		}
 		this.disposables.forEach((d) => d.dispose())
 	}
+}
+
+interface TransformedCommand {
+	command: string
+	args: string[]
+}
+
+function transformNpxCommand(command: string, args: string[] = []): TransformedCommand {
+	const isWindows = os.platform() === "win32"
+
+	if (isWindows && command === "npx") {
+		return {
+			command: "cmd",
+			args: ["/c", "npx", ...args],
+		}
+	}
+
+	return { command, args }
 }

--- a/src/test/services/mcp/McpHub.test.ts
+++ b/src/test/services/mcp/McpHub.test.ts
@@ -1,0 +1,113 @@
+import { ExtensionMessage } from "@shared/ExtensionMessage"
+import { DEFAULT_MCP_TIMEOUT_SECONDS } from "@shared/mcp"
+import { describe, it } from "mocha"
+import proxyquire from "proxyquire"
+import "should"
+
+describe("McpHub Command Transformation", () => {
+	let mcpHub: any
+	let lastTransportOptions: any
+	let currentPlatform = "darwin"
+
+	// Setup test doubles
+	const StdioTransportDouble = function (options: any) {
+		lastTransportOptions = options
+		return {
+			onerror: null,
+			onclose: null,
+			close: async () => {},
+			start: async () => {},
+			stderr: { on: () => {} },
+		}
+	}
+
+	// Helper to create McpHub instance
+	const createMcpHub = () => {
+		const getMcpServersPath = () => Promise.resolve("/test/path")
+		const getSettingsDirectoryPath = () => Promise.resolve("/test/settings")
+		const postMessageToWebview = async (_: ExtensionMessage) => {}
+		const clientVersion = "1.0.0"
+
+		// Mock dependencies
+		const McpHubModule = proxyquire("../../../services/mcp/McpHub", {
+			os: {
+				platform: () => currentPlatform,
+			},
+			"@modelcontextprotocol/sdk/client/stdio.js": {
+				StdioClientTransport: StdioTransportDouble,
+			},
+		}).McpHub
+
+		return new McpHubModule(getMcpServersPath, getSettingsDirectoryPath, postMessageToWebview, clientVersion)
+	}
+
+	beforeEach(() => {
+		lastTransportOptions = null
+		mcpHub = createMcpHub()
+	})
+
+	describe("npx command handling", () => {
+		it("transforms npx command on Windows", async () => {
+			currentPlatform = "win32"
+			const config = {
+				command: "npx",
+				args: ["-y", "kusto-mcp"],
+				transportType: "stdio" as const,
+				timeout: DEFAULT_MCP_TIMEOUT_SECONDS,
+			}
+
+			await mcpHub.connectToServer("test-server", config)
+
+			lastTransportOptions.command.should.equal("cmd")
+			lastTransportOptions.args.should.deepEqual(["/c", "npx", "-y", "kusto-mcp"])
+			lastTransportOptions.should.have.property("stderr", "pipe")
+		})
+
+		it("leaves npx command unchanged on non-Windows", async () => {
+			currentPlatform = "darwin"
+			const config = {
+				command: "npx",
+				args: ["-y", "kusto-mcp"],
+				transportType: "stdio" as const,
+				timeout: DEFAULT_MCP_TIMEOUT_SECONDS,
+			}
+
+			await mcpHub.connectToServer("test-server", config)
+
+			lastTransportOptions.command.should.equal("npx")
+			lastTransportOptions.args.should.deepEqual(["-y", "kusto-mcp"])
+			lastTransportOptions.should.have.property("stderr", "pipe")
+		})
+
+		it("handles undefined args on Windows", async () => {
+			currentPlatform = "win32"
+			const config = {
+				command: "npx",
+				transportType: "stdio" as const,
+				timeout: DEFAULT_MCP_TIMEOUT_SECONDS,
+			}
+
+			await mcpHub.connectToServer("test-server", config)
+
+			lastTransportOptions.command.should.equal("cmd")
+			lastTransportOptions.args.should.deepEqual(["/c", "npx"])
+			lastTransportOptions.should.have.property("stderr", "pipe")
+		})
+
+		it("preserves non-npx commands on Windows", async () => {
+			currentPlatform = "win32"
+			const config = {
+				command: "other-command",
+				args: ["arg1", "arg2"],
+				transportType: "stdio" as const,
+				timeout: DEFAULT_MCP_TIMEOUT_SECONDS,
+			}
+
+			await mcpHub.connectToServer("test-server", config)
+
+			lastTransportOptions.command.should.equal("other-command")
+			lastTransportOptions.args.should.deepEqual(["arg1", "arg2"])
+			lastTransportOptions.should.have.property("stderr", "pipe")
+		})
+	})
+})


### PR DESCRIPTION
### Description

Implemented Windows compatibility for npx commands in MCP servers by adding automatic command transformation. When running on Windows, npx commands are wrapped with `cmd /c` to ensure proper execution. This fixes issues where npx commands would fail to execute correctly on Windows systems.

Fixes this issue: #2886 

### Test Procedure

Covered by unit tests that make sure only MCP servers with `npx` as their command running on Windows systems are transformed.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

This is what Windows users have to do now, in order to use `npx` to have MCP servers be installed easily:

```json
{
  "mcpServers": {
    "github.com/johnib/ado-mcp": {
      "disabled": false,
      "timeout": 60,
      "command": "cmd",
      "args": [
        "/c",
        "npx",
        "-y",
        "ado-mcp"
      ],
      "env": {
        "AZURE_DEVOPS_AUTH_METHOD": "azure-cli",
        "AZURE_DEVOPS_ORG": "<ado org>",
        "AZURE_DEVOPS_ORG_URL": "https://dev.azure.com/<ado org>",
        "AZURE_DEVOPS_PROJECT": "<ado project>",
        "LOG_LEVEL": "info"
      },
      "transportType": "stdio"
    }
  }
}
```

And with this PR, they will no longer need to adjust the configuration to use `cmd /c`:

```json
{
  "mcpServers": {
    "github.com/johnib/ado-mcp": {
      "disabled": false,
      "timeout": 60,
      "command": "npx",
      "args": [
        "-y",
        "ado-mcp"
      ],
      "env": {
        "AZURE_DEVOPS_AUTH_METHOD": "azure-cli",
        "AZURE_DEVOPS_ORG": "<ado org>",
        "AZURE_DEVOPS_ORG_URL": "https://dev.azure.com/<ado org>",
        "AZURE_DEVOPS_PROJECT": "<ado project>",
        "LOG_LEVEL": "info"
      },
      "transportType": "stdio"
    }
  }
}
```
### Additional Notes

<!-- Add any additional notes for reviewers -->
