### PR TITLE
Expanding task header by default

### DIFF
--- a/.changeset/six-hairs-rush.md
+++ b/.changeset/six-hairs-rush.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": minor
+---
+
+showing expanded task by default

--- a/webview-ui/src/components/chat/TaskHeader.tsx
+++ b/webview-ui/src/components/chat/TaskHeader.tsx
@@ -35,7 +35,7 @@ const TaskHeader: React.FC<TaskHeaderProps> = ({
 	onClose,
 }) => {
 	const { apiConfiguration, currentTaskItem, checkpointTrackerErrorMessage } = useExtensionState()
-	const [isTaskExpanded, setIsTaskExpanded] = useState(false)
+	const [isTaskExpanded, setIsTaskExpanded] = useState(true)
 	const [isTextExpanded, setIsTextExpanded] = useState(false)
 	const [showSeeMore, setShowSeeMore] = useState(false)
 	const textContainerRef = useRef<HTMLDivElement>(null)


### PR DESCRIPTION
### Description

A number of users were complaining about visibility into prompt caching. This will help with that, along with our next changes supporting cache stats view for openrouter & cline providers (among others)
<img width="474" alt="Screenshot 2025-04-28 at 4 21 45 PM" src="https://github.com/user-attachments/assets/c347b8b5-0b81-4675-8137-dabaef9ef574" />

### Test Procedure

start a new task

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Change default state of `isTaskExpanded` in `TaskHeader` to expand task header by default.
> 
>   - **Behavior**:
>     - Default state of `isTaskExpanded` in `TaskHeader` component in `TaskHeader.tsx` changed from `false` to `true`, expanding task header by default.
>   - **Misc**:
>     - Adds changeset `six-hairs-rush.md` to document the feature addition.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 1bbf21b92229318b36b1a85b25beb1e87bb4df12. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->