### PR TITLE
add openrouter / cline provider caching metrics to ui

### DIFF
--- a/.changeset/shy-buckets-itch.md
+++ b/.changeset/shy-buckets-itch.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": minor
+---
+
+add cache ui for open router and cline provider

--- a/src/api/providers/cline.ts
+++ b/src/api/providers/cline.ts
@@ -74,6 +74,8 @@ export class ClineHandler implements ApiHandler {
 			if (!didOutputUsage && chunk.usage) {
 				yield {
 					type: "usage",
+					cacheWriteTokens: 0,
+					cacheReadTokens: chunk.usage.prompt_tokens_details?.cached_tokens || 0,
 					inputTokens: chunk.usage.prompt_tokens || 0,
 					outputTokens: chunk.usage.completion_tokens || 0,
 					// @ts-ignore-next-line
@@ -105,6 +107,9 @@ export class ClineHandler implements ApiHandler {
 				const generation = response.data
 				return {
 					type: "usage",
+					// at this time there's no support for gatting cached_tokens from generation endpoint
+					cacheWriteTokens: 0,
+					cacheReadTokens: 0,
 					inputTokens: generation?.native_tokens_prompt || 0,
 					outputTokens: generation?.native_tokens_completion || 0,
 					totalCost: generation?.total_cost || 0,

--- a/src/api/providers/openrouter.ts
+++ b/src/api/providers/openrouter.ts
@@ -76,6 +76,8 @@ export class OpenRouterHandler implements ApiHandler {
 			if (!didOutputUsage && chunk.usage) {
 				yield {
 					type: "usage",
+					cacheWriteTokens: 0,
+					cacheReadTokens: chunk.usage.prompt_tokens_details?.cached_tokens || 0,
 					inputTokens: chunk.usage.prompt_tokens || 0,
 					outputTokens: chunk.usage.completion_tokens || 0,
 					// @ts-ignore-next-line
@@ -103,8 +105,9 @@ export class OpenRouterHandler implements ApiHandler {
 				// console.log("OpenRouter generation details:", generation)
 				return {
 					type: "usage",
-					// cacheWriteTokens: 0,
-					// cacheReadTokens: 0,
+					// at this time there's no support for gatting cached_tokens from generation endpoint
+					cacheWriteTokens: 0,
+					cacheReadTokens: 0,
 					// openrouter generation endpoint fails often
 					inputTokens: generation?.native_tokens_prompt || 0,
 					outputTokens: generation?.native_tokens_completion || 0,

--- a/webview-ui/src/components/chat/TaskHeader.tsx
+++ b/webview-ui/src/components/chat/TaskHeader.tsx
@@ -138,6 +138,10 @@ const TaskHeader: React.FC<TaskHeaderProps> = ({
 	const shouldShowPromptCacheInfo =
 		doesModelSupportPromptCache && apiConfiguration?.apiProvider !== "openrouter" && apiConfiguration?.apiProvider !== "cline"
 
+	const shouldShowPromptCacheInfoClineOR =
+		doesModelSupportPromptCache &&
+		(apiConfiguration?.apiProvider === "openrouter" || apiConfiguration?.apiProvider === "cline")
+
 	const ContextWindowComponent = (
 		<>
 			{isTaskExpanded && contextWindow && (
@@ -406,6 +410,33 @@ const TaskHeader: React.FC<TaskHeaderProps> = ({
 								)}
 							</div>
 
+							{shouldShowPromptCacheInfoClineOR && cacheReads !== undefined && (
+								<div
+									style={{
+										display: "flex",
+										alignItems: "center",
+										gap: "4px",
+										flexWrap: "wrap",
+									}}>
+									<span style={{ fontWeight: "bold" }}>Cache:</span>
+									<span
+										style={{
+											display: "flex",
+											alignItems: "center",
+											gap: "3px",
+										}}>
+										<i
+											className="codicon codicon-arrow-right"
+											style={{
+												fontSize: "12px",
+												fontWeight: "bold",
+												marginBottom: 0,
+											}}
+										/>
+										{formatLargeNumber(cacheReads || 0)}
+									</span>
+								</div>
+							)}
 							{shouldShowPromptCacheInfo &&
 								(cacheReads !== undefined ||
 									cacheWrites !== undefined ||


### PR DESCRIPTION
### Description

For models which have caching enabled for openrouter / cline provider, we record the streamed cache usage (reads) and add to ui, similar to existing caching ui, but we don't have writes

reference issue: https://github.com/cline/cline/issues/3162

### Test Procedure

Select sonnet-3.5 for openrouter and cline provider. For both, go through a short conversation and check if the Cache: <value> is being updated and is non-zero

Note: some models don't seem to be working properly in terms of receiving the cache info from the endpoint, such as 3.5-haiku and 3-opus

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<img width="415" alt="cached" src="https://github.com/user-attachments/assets/f99bf681-e207-42db-b97a-a9b9095a78f3" />

### Additional Notes

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add cache read metrics for openrouter and cline providers to UI, updating `ClineHandler`, `OpenRouterHandler`, and `TaskHeader`.
> 
>   - **Behavior**:
>     - Adds cache read metrics for `openrouter` and `cline` providers in `ClineHandler` and `OpenRouterHandler` classes.
>     - Cache write metrics are not supported.
>   - **UI**:
>     - Updates `TaskHeader` component to display cache reads for `openrouter` and `cline` providers.
>     - Uses `shouldShowPromptCacheInfoClineOR` to conditionally render cache information.
>   - **Misc**:
>     - Adds changeset `shy-buckets-itch.md` for versioning.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 204963a4ed27c7693fac35f0190bef124a1a8710. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->