### PR TITLE
Enhances visual feedback during drag-and-drop with dashed outline and transition effects.

### DIFF
--- a/.changeset/fair-papayas-learn.md
+++ b/.changeset/fair-papayas-learn.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Minor UX improvement to drag and drop ux

--- a/webview-ui/src/components/chat/ChatTextArea.tsx
+++ b/webview-ui/src/components/chat/ChatTextArea.tsx
@@ -1066,6 +1066,23 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 		 *
 		 * @param {React.DragEvent} e - The drag event.
 		 */
+		// Function to show error message for unsupported files
+		const showUnsupportedFileErrorMessage = () => {
+			// Show error message for unsupported files
+			setShowUnsupportedFileError(true)
+
+			// Clear any existing timer
+			if (unsupportedFileTimerRef.current) {
+				clearTimeout(unsupportedFileTimerRef.current)
+			}
+
+			// Set timer to hide error after 3 seconds
+			unsupportedFileTimerRef.current = setTimeout(() => {
+				setShowUnsupportedFileError(false)
+				unsupportedFileTimerRef.current = null
+			}, 3000)
+		}
+
 		const handleDragEnter = (e: React.DragEvent) => {
 			e.preventDefault()
 			setIsDraggingOver(true)
@@ -1083,19 +1100,7 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 				})
 
 				if (hasNonImageFile) {
-					// Show error message for unsupported files
-					setShowUnsupportedFileError(true)
-
-					// Clear any existing timer
-					if (unsupportedFileTimerRef.current) {
-						clearTimeout(unsupportedFileTimerRef.current)
-					}
-
-					// Set timer to hide error after 3 seconds
-					unsupportedFileTimerRef.current = setTimeout(() => {
-						setShowUnsupportedFileError(false)
-						unsupportedFileTimerRef.current = null
-					}, 3000)
+					showUnsupportedFileErrorMessage()
 				}
 			}
 		}
@@ -1117,6 +1122,21 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 				// Don't clear the error message here, let it time out naturally
 			}
 		}
+
+		// Effect to detect when drag operation ends outside the component
+		useEffect(() => {
+			const handleGlobalDragEnd = () => {
+				// This will be triggered when the drag operation ends anywhere
+				setIsDraggingOver(false)
+				// Don't clear error message, let it time out naturally
+			}
+
+			document.addEventListener("dragend", handleGlobalDragEnd)
+
+			return () => {
+				document.removeEventListener("dragend", handleGlobalDragEnd)
+			}
+		}, [])
 
 		/**
 		 * Handles the drop event for files and text.

--- a/webview-ui/src/components/chat/ChatTextArea.tsx
+++ b/webview-ui/src/components/chat/ChatTextArea.tsx
@@ -1412,12 +1412,13 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 							cursor: textAreaDisabled ? "not-allowed" : undefined,
 							flex: 1,
 							zIndex: 1,
-							outline: isDraggingOver // Add drag-over outline here
-								? "2px dashed var(--vscode-focusBorder)" // Changed from dotted to dashed
-								: isTextAreaFocused
-									? `1px solid ${chatSettings.mode === "plan" ? PLAN_MODE_COLOR : "var(--vscode-focusBorder)"}`
-									: "none",
-							outlineOffset: isDraggingOver ? "1px" : "0px", // Add offset for drag-over outline
+							outline:
+								isDraggingOver && !showUnsupportedFileError // Only show drag outline if not showing error
+									? "2px dashed var(--vscode-focusBorder)" // Changed from dotted to dashed
+									: isTextAreaFocused
+										? `1px solid ${chatSettings.mode === "plan" ? PLAN_MODE_COLOR : "var(--vscode-focusBorder)"}`
+										: "none",
+							outlineOffset: isDraggingOver && !showUnsupportedFileError ? "1px" : "0px", // Add offset for drag-over outline
 						}}
 						onScroll={() => updateHighlights()}
 					/>

--- a/webview-ui/src/components/chat/ChatTextArea.tsx
+++ b/webview-ui/src/components/chat/ChatTextArea.tsx
@@ -1029,7 +1029,7 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 					if (shiftHoldTimerRef.current === null) {
 						shiftHoldTimerRef.current = setTimeout(() => {
 							setShowShiftDragTip(true)
-						}, 250) // 500ms delay
+						}, 250) // 250ms delay
 					}
 				}
 			}
@@ -1510,11 +1510,16 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 						<ButtonGroup
 							style={{
 								opacity: showShiftDragTip ? 0 : 1,
-								visibility: showShiftDragTip ? "hidden" : "visible",
-								position: showShiftDragTip ? "absolute" : "relative",
-								transition: "opacity 0.2s ease-in-out",
+								pointerEvents: showShiftDragTip ? "none" : "auto",
+								position: "absolute",
+								top: 0,
+								left: 0,
+								right: 0,
+								transition: "opacity 0.3s ease-in-out",
+								transitionDelay: showShiftDragTip ? "0s" : "0.2s",
 								width: "100%",
 								height: "100%",
+								zIndex: showShiftDragTip ? 0 : 1,
 							}}>
 							<Tooltip tipText="Add Context" style={{ left: 0 }}>
 								<VSCodeButton
@@ -1595,10 +1600,15 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 								padding: "4px 0", // Add padding to match button group height
 								boxSizing: "border-box", // Include padding in height calculation
 								opacity: showShiftDragTip ? 1 : 0,
-								visibility: showShiftDragTip ? "visible" : "hidden",
-								position: showShiftDragTip ? "relative" : "absolute",
-								transition: "opacity 0.2s ease-in-out",
+								pointerEvents: showShiftDragTip ? "auto" : "none",
+								position: "absolute",
+								top: 0,
+								left: 0,
+								right: 0,
+								transition: "opacity 0.3s ease-in-out",
+								transitionDelay: showShiftDragTip ? "0.2s" : "0s",
 								width: "100%",
+								zIndex: showShiftDragTip ? 1 : 0,
 							}}>
 							<span
 								style={{

--- a/webview-ui/src/components/chat/ChatTextArea.tsx
+++ b/webview-ui/src/components/chat/ChatTextArea.tsx
@@ -1380,7 +1380,7 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 							}
 							onHeightChange?.(height)
 						}}
-						placeholder={placeholderText}
+						placeholder={showUnsupportedFileError ? "" : placeholderText}
 						maxRows={10}
 						autoFocus={true}
 						style={{

--- a/webview-ui/src/components/chat/ChatTextArea.tsx
+++ b/webview-ui/src/components/chat/ChatTextArea.tsx
@@ -1029,7 +1029,7 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 					if (shiftHoldTimerRef.current === null) {
 						shiftHoldTimerRef.current = setTimeout(() => {
 							setShowShiftDragTip(true)
-						}, 500) // 500ms delay
+						}, 100) // 500ms delay
 					}
 				}
 			}

--- a/webview-ui/src/components/chat/ChatTextArea.tsx
+++ b/webview-ui/src/components/chat/ChatTextArea.tsx
@@ -1415,9 +1415,24 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 				</div>
 
 				<ControlsContainer>
-					{/* Conditionally render ButtonGroup or Shift Tip */}
-					{!showShiftDragTip ? (
-						<ButtonGroup>
+					{/* Always render both components, but control visibility with CSS */}
+					<div
+						style={{
+							position: "relative",
+							flex: 1,
+							minWidth: 0,
+							height: "28px", // Fixed height to prevent container shrinking
+						}}>
+						{/* ButtonGroup - always in DOM but visibility controlled */}
+						<ButtonGroup
+							style={{
+								opacity: showShiftDragTip ? 0 : 1,
+								visibility: showShiftDragTip ? "hidden" : "visible",
+								position: showShiftDragTip ? "absolute" : "relative",
+								transition: "opacity 0.2s ease-in-out",
+								width: "100%",
+								height: "100%", // Fill the container height
+							}}>
 							<Tooltip tipText="Add Context" style={{ left: 0 }}>
 								<VSCodeButton
 									data-testid="context-button"
@@ -1430,7 +1445,6 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 										<span className="flex items-center" style={{ fontSize: "13px", marginBottom: 1 }}>
 											@
 										</span>
-										{/* {showButtonText && <span style={{ fontSize: "10px" }}>Context</span>} */}
 									</ButtonContainer>
 								</VSCodeButton>
 							</Tooltip>
@@ -1452,7 +1466,6 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 											className="codicon codicon-device-camera flex items-center"
 											style={{ fontSize: "14px", marginBottom: -3 }}
 										/>
-										{/* {showButtonText && <span style={{ fontSize: "10px" }}>Images</span>} */}
 									</ButtonContainer>
 								</VSCodeButton>
 							</Tooltip>
@@ -1466,12 +1479,6 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 										disabled={false}
 										title="Select Model / API Provider"
 										onClick={handleModelButtonClick}
-										// onKeyDown={(e) => {
-										// 	if (e.key === "Enter" || e.key === " ") {
-										// 		e.preventDefault()
-										// 		handleModelButtonClick()
-										// 	}
-										// }}
 										tabIndex={0}>
 										<ModelButtonContent>{modelDisplayName}</ModelButtonContent>
 									</ModelDisplayButton>
@@ -1494,15 +1501,21 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 								)}
 							</ModelContainer>
 						</ButtonGroup>
-					) : (
-						// Display only the tip text when showShiftDragTip is true
+
+						{/* Shift Tip - always in DOM but visibility controlled */}
 						<div
 							style={{
 								display: "flex",
-								alignItems: "center",
-								flex: 1, // Take up available space like ButtonGroup
-								minWidth: 0,
-								height: "20px", // Match button height for alignment
+								justifyContent: "center", // Center horizontally
+								alignItems: "center", // Center vertically
+								height: "100%", // Fill the container height
+								padding: "4px 0", // Add padding to match button group height
+								boxSizing: "border-box", // Include padding in height calculation
+								opacity: showShiftDragTip ? 1 : 0,
+								visibility: showShiftDragTip ? "visible" : "hidden",
+								position: showShiftDragTip ? "relative" : "absolute",
+								transition: "opacity 0.2s ease-in-out",
+								width: "100%",
 							}}>
 							<span
 								style={{
@@ -1510,10 +1523,10 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 									color: "var(--vscode-descriptionForeground)",
 									whiteSpace: "nowrap",
 								}}>
-								Hold Shift to Drag
+								Drag, then Shift
 							</span>
 						</div>
-					)}
+					</div>
 					{/* Tooltip for Plan/Act toggle remains outside the conditional rendering */}
 					<Tooltip
 						style={{ zIndex: 1000 }}

--- a/webview-ui/src/components/chat/ChatTextArea.tsx
+++ b/webview-ui/src/components/chat/ChatTextArea.tsx
@@ -1029,7 +1029,7 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 					if (shiftHoldTimerRef.current === null) {
 						shiftHoldTimerRef.current = setTimeout(() => {
 							setShowShiftDragTip(true)
-						}, 100) // 500ms delay
+						}, 250) // 500ms delay
 					}
 				}
 			}
@@ -1606,7 +1606,7 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 									color: "var(--vscode-descriptionForeground)",
 									whiteSpace: "nowrap",
 								}}>
-								Hold Shift to Drag
+								Hold Shift to Drag Files
 							</span>
 						</div>
 					</div>

--- a/webview-ui/src/components/chat/ChatTextArea.tsx
+++ b/webview-ui/src/components/chat/ChatTextArea.tsx
@@ -1591,7 +1591,7 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 						<div
 							style={{
 								display: "flex",
-								justifyContent: "center", // Center horizontally
+								justifyContent: "flex-start", // Left align horizontally
 								alignItems: "center", // Center vertically
 								height: "100%", // Fill the container height
 								padding: "4px 0", // Add padding to match button group height
@@ -1608,7 +1608,7 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 									color: "var(--vscode-descriptionForeground)",
 									whiteSpace: "nowrap",
 								}}>
-								Drag, hold shift, then drop
+								Hold Shift to Drag
 							</span>
 						</div>
 					</div>

--- a/webview-ui/src/components/chat/ChatTextArea.tsx
+++ b/webview-ui/src/components/chat/ChatTextArea.tsx
@@ -237,7 +237,7 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 	) => {
 		const { filePaths, chatSettings, apiConfiguration, openRouterModels, platform } = useExtensionState()
 		const [isTextAreaFocused, setIsTextAreaFocused] = useState(false)
-		const [isDraggingOver, setIsDraggingOver] = useState(false) // State for drag feedback
+		const [isDraggingOver, setIsDraggingOver] = useState(false)
 		const [gitCommits, setGitCommits] = useState<GitCommit[]>([])
 
 		const [showSlashCommandsMenu, setShowSlashCommandsMenu] = useState(false)
@@ -267,10 +267,10 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 		const [menuPosition, setMenuPosition] = useState(0)
 		const [shownTooltipMode, setShownTooltipMode] = useState<ChatSettings["mode"] | null>(null)
 		const [pendingInsertions, setPendingInsertions] = useState<string[]>([])
-		const [showShiftDragTip, setShowShiftDragTip] = useState(false) // State for the shift drag tip
-		const shiftHoldTimerRef = useRef<NodeJS.Timeout | null>(null) // Ref for the timer
-		const [showUnsupportedFileError, setShowUnsupportedFileError] = useState(false) // State for unsupported file error
-		const unsupportedFileTimerRef = useRef<NodeJS.Timeout | null>(null) // Ref for the error timer
+		const [showShiftDragTip, setShowShiftDragTip] = useState(false)
+		const shiftHoldTimerRef = useRef<NodeJS.Timeout | null>(null)
+		const [showUnsupportedFileError, setShowUnsupportedFileError] = useState(false)
+		const unsupportedFileTimerRef = useRef<NodeJS.Timeout | null>(null)
 
 		const [fileSearchResults, setFileSearchResults] = useState<SearchResult[]>([])
 		const [searchLoading, setSearchLoading] = useState(false)
@@ -1060,13 +1060,7 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 			}
 		}, []) // Empty dependency array ensures this runs only once on mount/unmount
 
-		/**
-		 * Handles the drag over event to allow dropping.
-		 * Prevents the default behavior to enable drop.
-		 *
-		 * @param {React.DragEvent} e - The drag event.
-		 */
-		// Function to show error message for unsupported files
+		// Function to show error message for unsupported files for drag and drop
 		const showUnsupportedFileErrorMessage = () => {
 			// Show error message for unsupported files
 			setShowUnsupportedFileError(true)
@@ -1105,6 +1099,12 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 			}
 		}
 
+		/**
+		 * Handles the drag over event to allow dropping.
+		 * Prevents the default behavior to enable drop.
+		 *
+		 * @param {React.DragEvent} e - The drag event.
+		 */
 		const onDragOver = (e: React.DragEvent) => {
 			e.preventDefault()
 			// Ensure state remains true if dragging continues over the element
@@ -1278,10 +1278,8 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 					}}
 					onDrop={onDrop}
 					onDragOver={onDragOver}
-					onDragEnter={handleDragEnter} // Add handler
-					onDragLeave={handleDragLeave} // Add handler
-				>
-					{/* Error message for unsupported files */}
+					onDragEnter={handleDragEnter}
+					onDragLeave={handleDragLeave}>
 					{showUnsupportedFileError && (
 						<div
 							style={{
@@ -1434,7 +1432,7 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 							zIndex: 1,
 							outline:
 								isDraggingOver && !showUnsupportedFileError // Only show drag outline if not showing error
-									? "2px dashed var(--vscode-focusBorder)" // Changed from dotted to dashed
+									? "2px dashed var(--vscode-focusBorder)"
 									: isTextAreaFocused
 										? `1px solid ${chatSettings.mode === "plan" ? PLAN_MODE_COLOR : "var(--vscode-focusBorder)"}`
 										: "none",
@@ -1516,7 +1514,7 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 								position: showShiftDragTip ? "absolute" : "relative",
 								transition: "opacity 0.2s ease-in-out",
 								width: "100%",
-								height: "100%", // Fill the container height
+								height: "100%",
 							}}>
 							<Tooltip tipText="Add Context" style={{ left: 0 }}>
 								<VSCodeButton


### PR DESCRIPTION
### Description
This PR Enhances visual feedback during drag-and-drop with dashed outline and transition effects.


https://github.com/user-attachments/assets/1e7556de-7ceb-4efd-a528-096b35883c75


### Test Procedure
Tested locally with a debugger 

https://github.com/user-attachments/assets/767d0f53-cef4-44b2-ba82-d950442830e4



### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [X] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [X] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [X] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [X] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [X] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots
<img width="445" alt="image" src="https://github.com/user-attachments/assets/47e9915a-913e-4a88-a53c-bd864fd09ecb" />

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Enhances drag-and-drop UX in `ChatTextArea` with dashed outline and transition effects.
> 
>   - **Behavior**:
>     - Adds `isDraggingOver` state in `ChatTextArea` to manage drag-and-drop visual feedback.
>     - Implements `handleDragEnter`, `onDragOver`, and `handleDragLeave` to update `isDraggingOver` state.
>     - Updates `onDrop` to reset `isDraggingOver` state.
>   - **Styles**:
>     - Adds dashed outline and transition effects to `DynamicTextArea` during drag-and-drop in `ChatTextArea`.
>     - Adjusts `outlineOffset` for drag-over state.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 415c5c70cea515b1e41813b3f31009344fed4ff9. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->