### PR TITLE
[3093] Fix Handle @withRetry() SyntaxError when running extension locally issue

### DIFF
--- a/.changeset/itchy-ligers-give.md
+++ b/.changeset/itchy-ligers-give.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": minor
+---
+
+Fix Handle @withRetry() SyntaxError when running extension locally issue

--- a/esbuild.js
+++ b/esbuild.js
@@ -124,6 +124,7 @@ const extensionConfig = {
 	define: {
 		"process.env.IS_DEV": JSON.stringify(!production),
 	},
+	tsconfig: path.resolve(__dirname, "tsconfig.json"),
 	plugins: [
 		copyWasmFiles,
 		aliasResolverPlugin,


### PR DESCRIPTION
### Description

While developing I had issue described in https://github.com/cline/cline/issues/3093.

This issue is consistently reproducible with my setup:

* Laptop: MacBook Pro, macOS 23.3.0 (Darwin Kernel Version 23.3.0: Wed Dec 20 21:31:00 PST 2023; root:xnu-10002.81.5~7/RELEASE_ARM64_T6020 arm64)
* IDE: Cursor 0.49.6
* Node.js: v23.1.0

To enable the withRetry decorator, we added the `experimentalDecorators` flag in our `tsconfig.json`. However, we still encounter the following error:

> Invalid or unexpected token → @withRetry() when run extension

It appears that this flag is being lost during the build process, even though [esbuild is expected to respect it automatically](https://esbuild.github.io/content-types/#tsconfig-json).

The issue is resolved when we explicitly specify the path to `tsconfig.json` during the build.

Note: using `tsconfigRaw` param also will work.

Similar issue reported while back to esbuild: https://github.com/evanw/esbuild/issues/60


### Test Procedure

Since it's constantly reproducible in my setup I did manual testing after changes.

1. Open the project in VSCode:
    ```bash
    code cline
    ```
2. Install the necessary dependencies
    ```bash
    npm run install:all
    ```
3. Launch by pressing `F5` (or `Run`->`Start Debugging`)

It should no longer show `Invalid or unexpected token → @withRetry() when run extension`

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes SyntaxError for `@withRetry()` decorator by specifying `tsconfig` path in `esbuild.js`.
> 
>   - **Behavior**:
>     - Fixes SyntaxError for `@withRetry()` decorator by specifying `tsconfig` path in `esbuild.js`.
>     - Ensures `experimentalDecorators` flag is respected during build.
>   - **Misc**:
>     - Adds changeset file `itchy-ligers-give.md` for version tracking.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for f2e138fa220050fb1844c953e02851c29735876f. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->