### PR TITLE
Alias paths on integration tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,8 +70,8 @@ jobs:
               run: npm run format
 
             # Build the extension before running tests
-            - name: Build Extension
-              run: npm run compile
+            - name: Build Tests and Extension
+              run: npm run pretest
 
             - name: Unit Tests
               run: npm run test:unit

--- a/.vscode-test.mjs
+++ b/.vscode-test.mjs
@@ -6,6 +6,10 @@ export default defineConfig({
 	mocha: {
 		ui: "bdd",
 		timeout: 20000, // Maximum time (in ms) that a test can run before failing
+		/** Set up alias path resolution during tests
+		 * @See {@link file://./test-setup.js}
+		 */
+		require: ["./test-setup.js"],
 	},
 	workspaceFolder: "test-workspace",
 	version: "stable",

--- a/test-setup.js
+++ b/test-setup.js
@@ -1,0 +1,22 @@
+const tsConfigPaths = require("tsconfig-paths")
+const fs = require("fs")
+
+const tsConfig = JSON.parse(fs.readFileSync("./tsconfig.json", "utf-8"))
+
+/**
+ * The aliases point towards the `src` directory.
+ * However, `tsc` doesn't compile paths by itself
+ * (https://www.typescriptlang.org/docs/handbook/modules/reference.html#paths-does-not-affect-emit)
+ * So we need to use tsconfig-paths to resolve the aliases when running tests,
+ * but pointing to `out` instead.
+ */
+const outPaths = {}
+Object.keys(tsConfig.compilerOptions.paths).forEach((key) => {
+	const value = tsConfig.compilerOptions.paths[key]
+	outPaths[key] = value.map((path) => path.replace("src", "out"))
+})
+
+tsConfigPaths.register({
+	baseUrl: ".",
+	paths: outPaths,
+})


### PR DESCRIPTION
### Description

This is a continuation of #2930. They are separate PRs against main to list them on the Cline repo.
If you want to see the proper diff against the previous branch, feel free to check out [this PR](https://github.com/BarreiroT/cline/pull/1) on the fork instead.

This PR adds a setup script that will alias the paths we have on the application since `tsc` [doesn't compile paths by itself](https://www.typescriptlang.org/docs/handbook/modules/reference.html#paths-does-not-affect-emit), and we can't use the existing aliases because they point towards `src` instead of `out`.

As [mentioned in the original PR](https://github.com/cline/cline/pull/2930#issuecomment-2810403649), I expect tests to continue failing because of the ES modules, but I will [follow up with a fix for that](https://github.com/cline/cline/pull/3030).

### Test Procedure

You can run `pretest` and `test:integration` or see the test workflow output. The current failure is:
```
Error [ERR_REQUIRE_ESM]: require() of ES Module /home/runner/work/cline/cline/node_modules/execa/index.js from /home/runner/work/cline/cline/out/core/storage/disk.js not supported.
```

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [x] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `test-setup.js` to alias paths for integration tests, updating test configuration and workflow to support path resolution from `src` to `out`.
> 
>   - **Setup Script**:
>     - Adds `test-setup.js` to alias paths from `src` to `out` using `tsconfig-paths`.
>     - Parses `tsconfig.json` to adjust paths for test execution.
>   - **Test Configuration**:
>     - Updates `.vscode-test.mjs` to require `test-setup.js` for path resolution during tests.
>   - **Workflow Changes**:
>     - Modifies `.github/workflows/test.yml` to use `npm run pretest` instead of `npm run compile` for building tests and extension.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 8e28c6364241705e4f0d3d5b427d3b87425dc292. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->