### PR TITLE
fix: log error for attemptApiRequest and recursivelyMakeClineRequests

### DIFF
--- a/src/core/task/index.ts
+++ b/src/core/task/index.ts
@@ -3650,6 +3650,7 @@ export class Task {
 				}
 			} catch (error) {
 				// abandoned happens when extension is no longer waiting for the cline instance to finish aborting (error is thrown here when any function in the for loop throws due to this.abort)
+				console.error(error)
 				if (!this.abandoned) {
 					this.abortTask() // if the stream failed, there's various states the task could be in (i.e. could have streamed some tools the user may have executed), so we just resort to replicating a cancel task
 					const errorMessage = this.formatErrorWithStatusCode(error)
@@ -3754,6 +3755,7 @@ export class Task {
 
 			return didEndLoop // will always be false for now
 		} catch (error) {
+			console.error(error)
 			// this should never happen since the only thing that can throw an error is the attemptApiRequest, which is wrapped in a try catch that sends an ask where if noButtonClicked, will clear current task and destroy this instance. However to avoid unhandled promise rejection, we will end this loop which will end execution of this instance (see startTask)
 			return true // needs to be true so parent loop knows to end task
 		}

--- a/src/core/task/index.ts
+++ b/src/core/task/index.ts
@@ -3650,7 +3650,7 @@ export class Task {
 				}
 			} catch (error) {
 				// abandoned happens when extension is no longer waiting for the cline instance to finish aborting (error is thrown here when any function in the for loop throws due to this.abort)
-				console.error(error)
+				Logger.error(error)
 				if (!this.abandoned) {
 					this.abortTask() // if the stream failed, there's various states the task could be in (i.e. could have streamed some tools the user may have executed), so we just resort to replicating a cancel task
 					const errorMessage = this.formatErrorWithStatusCode(error)
@@ -3755,7 +3755,7 @@ export class Task {
 
 			return didEndLoop // will always be false for now
 		} catch (error) {
-			console.error(error)
+			Logger.error("Error in recursivelyMakeClineRequests:", error)
 			// this should never happen since the only thing that can throw an error is the attemptApiRequest, which is wrapped in a try catch that sends an ask where if noButtonClicked, will clear current task and destroy this instance. However to avoid unhandled promise rejection, we will end this loop which will end execution of this instance (see startTask)
 			return true // needs to be true so parent loop knows to end task
 		}


### PR DESCRIPTION
### Description

log error for attemptApiRequest and recursivelyMakeClineRequests

### Test Procedure

Api request response without any errror but nothing received in windows.
Due to the error is ignore while calling attemptApiRequest and calling recursivelyMakeClineRequests, we see nothing in the console in VSCode developer tool. Then we added some log in the source code, and find out the error caused by "powershell" executing.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
- Tests failed due to **Property 'toPosix' does not exist on type 'string'.**
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add error logging to `recursivelyMakeClineRequests()` and `attemptApiRequest()` in `Task` class for better error tracking.
> 
>   - **Error Logging**:
>     - Add `console.error(error)` in `recursivelyMakeClineRequests()` to log errors during recursive API requests.
>     - Add `console.error(error)` in `attemptApiRequest()` to log errors during API request attempts.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for f125baa246f6136d1fd3494a8947957943dbb753. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->