### PR TITLE
Add checkpoints between all messages

### DIFF
--- a/.changeset/nine-rings-shout.md
+++ b/.changeset/nine-rings-shout.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": minor
+---
+
+add checkpoints after more messages


### PR DESCRIPTION
### Description

Add checkpoints between all messages. There is no UI change wrt the current checkpoints - this should be included in the overhaul

reference #3167 

### Test Procedure

Go through the normal conversation flow testing different tools. Periodically test `compare` / `restore` functionality and check if the checkpoints logic works as expected. As part of this you should test restoring the first checkpoint, as there was an early issue with more than one checkpoint message occurring next to each other, which should now be resolved - you would see this visually as two dashed lines next to each other

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

![checkpoints ui](https://github.com/user-attachments/assets/42133f02-fb8d-4385-8c4d-22e9085ac111)

### Additional Notes

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds frequent checkpoints in `Task` class in `index.ts` for improved state restoration and comparison, without UI changes.
> 
>   - **Behavior**:
>     - Adds `saveCheckpoint()` calls after various actions in `Task` class in `index.ts`, including user feedback, tool usage, and error handling.
>     - Ensures checkpoints are created more frequently for better state restoration and comparison.
>   - **Misc**:
>     - Fixes early issue with multiple checkpoint messages occurring consecutively.
>     - No UI changes introduced.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for f1624aaf712e7803d4053be8de1be728cea24764. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->