### PR TITLE
Create .clinerules directory when adding new cline rule in ui and .clinerules is currently a file

### DIFF
--- a/.changeset/blue-lobsters-sort.md
+++ b/.changeset/blue-lobsters-sort.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": minor
+---
+
+create clinerules folder if its currently a file and creating new rule

--- a/src/core/context/instructions/user-instructions/cline-rules.ts
+++ b/src/core/context/instructions/user-instructions/cline-rules.ts
@@ -221,7 +221,12 @@ export const createRuleFile = async (isGlobal: boolean, filename: string, cwd: s
 			filePath = path.join(globalClineRulesFilePath, filename)
 		} else {
 			const localClineRulesFilePath = path.resolve(cwd, GlobalFileNames.clineRules)
-			await fs.mkdir(localClineRulesFilePath, { recursive: true })
+
+			const hasError = await ensureLocalClinerulesDirExists(cwd)
+			if (hasError === true) {
+				return { filePath: null, fileExists: false }
+			}
+
 			filePath = path.join(localClineRulesFilePath, filename)
 		}
 

--- a/src/core/context/instructions/user-instructions/cline-rules.ts
+++ b/src/core/context/instructions/user-instructions/cline-rules.ts
@@ -14,7 +14,7 @@ import * as vscode from "vscode"
  */
 export async function ensureLocalClinerulesDirExists(cwd: string): Promise<boolean> {
 	const clinerulePath = path.resolve(cwd, GlobalFileNames.clineRules)
-	const defaultRuleFilename = "default-rules.md"
+	const defaultRuleFilename = "default-rules.txt"
 
 	try {
 		const exists = await fileExistsAtPath(clinerulePath)
@@ -226,6 +226,8 @@ export const createRuleFile = async (isGlobal: boolean, filename: string, cwd: s
 			if (hasError === true) {
 				return { filePath: null, fileExists: false }
 			}
+
+			await fs.mkdir(localClineRulesFilePath, { recursive: true })
 
 			filePath = path.join(localClineRulesFilePath, filename)
 		}

--- a/src/core/context/instructions/user-instructions/cline-rules.ts
+++ b/src/core/context/instructions/user-instructions/cline-rules.ts
@@ -14,7 +14,7 @@ import * as vscode from "vscode"
  */
 export async function ensureLocalClinerulesDirExists(cwd: string): Promise<boolean> {
 	const clinerulePath = path.resolve(cwd, GlobalFileNames.clineRules)
-	const defaultRuleFilename = "default-rules.txt"
+	const defaultRuleFilename = "default-rules.md"
 
 	try {
 		const exists = await fileExistsAtPath(clinerulePath)


### PR DESCRIPTION
### Description

Create `.clinerules` directory when adding new cline rule through ui and `.clinerules` is currently a file

Same functionality as #3013 but we are re-using logic already defined in `cline-rules.ts`

The expected behavior is that the old `.clinerules` file is converted into `.clinerules/default-rules.txt`

### Test Procedure

Start in a repo which has .clinerules as a file defining some rules, then try to add a new file. The old .clinerules should have been renamed as 'default-rules.txt' and placed inside of the newly created .clinerules directory

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<img width="480" alt="clinerules" src="https://github.com/user-attachments/assets/6732ed7f-0177-4122-8960-83af43f8723a" />

### Additional Notes

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Convert `.clinerules` file to a directory when adding a new rule, placing the old file as `default-rules.txt` inside the new directory.
> 
>   - **Behavior**:
>     - Converts `.clinerules` file to a directory when adding a new rule, placing the old file as `default-rules.txt` inside the new directory.
>     - Handles conversion errors by attempting to restore the original file.
>   - **Functions**:
>     - Adds `ensureLocalClinerulesDirExists()` in `cline-rules.ts` to manage the conversion of `.clinerules` from file to directory.
>     - Updates `createRuleFile()` in `cline-rules.ts` to call `ensureLocalClinerulesDirExists()` before creating a new rule file.
>   - **Misc**:
>     - Adds changeset `blue-lobsters-sort.md` to document the new feature.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 6ebc3eb825e673dd134080958f5e6382a64528e9. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->