### PR TITLE
Add terminal connection timeout

### DIFF
--- a/.changeset/nervous-dolphins-greet.md
+++ b/.changeset/nervous-dolphins-greet.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": minor
+---
+
+Add a timeout setting for the terminal connection, allowing users to adjust this if they are having timeout issues

--- a/src/core/storage/state-keys.ts
+++ b/src/core/storage/state-keys.ts
@@ -76,5 +76,6 @@ export type GlobalStateKey =
 	| "planActSeparateModelsSetting"
 	| "favoritedModelIds"
 	| "requestTimeoutMs"
+	| "shellIntegrationTimeout"
 
 export type LocalStateKey = "localClineRulesToggles"

--- a/src/core/storage/state.ts
+++ b/src/core/storage/state.ts
@@ -126,6 +126,7 @@ export async function getAllExtensionState(context: vscode.ExtensionContext) {
 		favoritedModelIds,
 		globalClineRulesToggles,
 		requestTimeoutMs,
+		shellIntegrationTimeout,
 	] = await Promise.all([
 		getGlobalState(context, "apiProvider") as Promise<ApiProvider | undefined>,
 		getGlobalState(context, "apiModelId") as Promise<string | undefined>,
@@ -200,6 +201,7 @@ export async function getAllExtensionState(context: vscode.ExtensionContext) {
 		getGlobalState(context, "favoritedModelIds") as Promise<string[] | undefined>,
 		getGlobalState(context, "globalClineRulesToggles") as Promise<ClineRulesToggles | undefined>,
 		getGlobalState(context, "requestTimeoutMs") as Promise<number | undefined>,
+		getGlobalState(context, "shellIntegrationTimeout") as Promise<number | undefined>,
 	])
 
 	let apiProvider: ApiProvider
@@ -319,6 +321,7 @@ export async function getAllExtensionState(context: vscode.ExtensionContext) {
 		mcpMarketplaceEnabled,
 		telemetrySetting: telemetrySetting || "unset",
 		planActSeparateModelsSetting,
+		shellIntegrationTimeout: shellIntegrationTimeout || 4000,
 	}
 }
 

--- a/src/core/task/index.ts
+++ b/src/core/task/index.ts
@@ -173,6 +173,7 @@ export class Task {
 		autoApprovalSettings: AutoApprovalSettings,
 		browserSettings: BrowserSettings,
 		chatSettings: ChatSettings,
+		shellIntegrationTimeout: number,
 		customInstructions?: string,
 		task?: string,
 		images?: string[],
@@ -191,6 +192,7 @@ export class Task {
 			console.error("Failed to initialize ClineIgnoreController:", error)
 		})
 		this.terminalManager = new TerminalManager()
+		this.terminalManager.setShellIntegrationTimeout(shellIntegrationTimeout)
 		this.urlContentFetcher = new UrlContentFetcher(context)
 		this.browserSession = new BrowserSession(context, browserSettings)
 		this.contextManager = new ContextManager()

--- a/src/shared/ExtensionMessage.ts
+++ b/src/shared/ExtensionMessage.ts
@@ -132,6 +132,7 @@ export interface ExtensionState {
 	shouldShowAnnouncement: boolean
 	taskHistory: HistoryItem[]
 	telemetrySetting: TelemetrySetting
+	shellIntegrationTimeout: number
 	uriScheme?: string
 	userInfo?: {
 		displayName: string | null

--- a/src/shared/WebviewMessage.ts
+++ b/src/shared/WebviewMessage.ts
@@ -71,6 +71,7 @@ export interface WebviewMessage {
 		| "toggleClineRule"
 		| "deleteClineRule"
 		| "copyToClipboard"
+		| "updateTerminalConnectionTimeout"
 
 	// | "relaunchChromeDebugMode"
 	text?: string
@@ -121,6 +122,7 @@ export interface WebviewMessage {
 	filename?: string
 
 	offset?: number
+	shellIntegrationTimeout?: number
 }
 
 export type ClineAskResponse = "yesButtonClicked" | "noButtonClicked" | "messageResponse"

--- a/webview-ui/src/components/settings/SettingsView.tsx
+++ b/webview-ui/src/components/settings/SettingsView.tsx
@@ -9,6 +9,7 @@ import { TabButton } from "../mcp/configuration/McpConfigurationView"
 import { useEvent } from "react-use"
 import { ExtensionMessage } from "@shared/ExtensionMessage"
 import BrowserSettingsSection from "./BrowserSettingsSection"
+import TerminalSettingsSection from "./TerminalSettingsSection"
 
 const { IS_DEV } = process.env
 
@@ -239,6 +240,9 @@ const SettingsView = ({ onDone }: SettingsViewProps) => {
 
 				{/* Browser Settings Section */}
 				<BrowserSettingsSection />
+
+				{/* Terminal Settings Section */}
+				<TerminalSettingsSection />
 
 				<div className="mt-auto pr-2 flex justify-center">
 					<SettingsButton

--- a/webview-ui/src/components/settings/TerminalSettingsSection.tsx
+++ b/webview-ui/src/components/settings/TerminalSettingsSection.tsx
@@ -1,0 +1,76 @@
+import React, { useState } from "react"
+import { VSCodeTextField } from "@vscode/webview-ui-toolkit/react"
+import { useExtensionState } from "@/context/ExtensionStateContext"
+import { vscode } from "@/utils/vscode"
+
+export const TerminalSettingsSection: React.FC = () => {
+	const { shellIntegrationTimeout, setShellIntegrationTimeout } = useExtensionState()
+	const [inputValue, setInputValue] = useState((shellIntegrationTimeout / 1000).toString())
+	const [inputError, setInputError] = useState<string | null>(null)
+
+	const handleTimeoutChange = (event: Event) => {
+		const target = event.target as HTMLInputElement
+		const value = target.value
+
+		setInputValue(value)
+
+		const seconds = parseFloat(value)
+		if (isNaN(seconds) || seconds <= 0) {
+			setInputError("Please enter a positive number")
+			return
+		}
+
+		setInputError(null)
+		const timeout = Math.round(seconds * 1000) // Convert to milliseconds
+
+		// Update local state
+		setShellIntegrationTimeout(timeout)
+
+		// Send to extension
+		vscode.postMessage({
+			type: "updateTerminalConnectionTimeout",
+			shellIntegrationTimeout: timeout,
+		})
+	}
+
+	const handleInputBlur = () => {
+		// If there was an error, reset the input to the current valid value
+		if (inputError) {
+			setInputValue((shellIntegrationTimeout / 1000).toString())
+			setInputError(null)
+		}
+	}
+
+	return (
+		<div
+			id="terminal-settings-section"
+			style={{ marginBottom: 20, borderTop: "1px solid var(--vscode-panel-border)", paddingTop: 15 }}>
+			<h3 style={{ color: "var(--vscode-foreground)", margin: "0 0 10px 0", fontSize: "14px" }}>Terminal Settings</h3>
+			<div style={{ marginBottom: 15 }}>
+				<div style={{ marginBottom: 8 }}>
+					<label style={{ fontWeight: "500", display: "block", marginBottom: 5 }}>
+						Shell integration timeout (seconds)
+					</label>
+					<div style={{ display: "flex", alignItems: "center" }}>
+						<VSCodeTextField
+							style={{ width: "100%" }}
+							value={inputValue}
+							placeholder="Enter timeout in seconds"
+							onChange={(event) => handleTimeoutChange(event as Event)}
+							onBlur={handleInputBlur}
+						/>
+					</div>
+					{inputError && (
+						<div style={{ color: "var(--vscode-errorForeground)", fontSize: "12px", marginTop: 5 }}>{inputError}</div>
+					)}
+				</div>
+				<p style={{ fontSize: "12px", color: "var(--vscode-descriptionForeground)", margin: 0 }}>
+					Set how long Cline waits for shell integration to activate before executing commands. Increase this value if
+					you experience terminal connection timeouts.
+				</p>
+			</div>
+		</div>
+	)
+}
+
+export default TerminalSettingsSection

--- a/webview-ui/src/context/ExtensionStateContext.tsx
+++ b/webview-ui/src/context/ExtensionStateContext.tsx
@@ -39,6 +39,7 @@ interface ExtensionStateContextType extends ExtensionState {
 	setTelemetrySetting: (value: TelemetrySetting) => void
 	setShowAnnouncement: (value: boolean) => void
 	setPlanActSeparateModelsSetting: (value: boolean) => void
+	setShellIntegrationTimeout: (value: number) => void
 	setMcpServers: (value: McpServer[]) => void
 
 	// Navigation
@@ -69,6 +70,7 @@ export const ExtensionStateContextProvider: React.FC<{
 		planActSeparateModelsSetting: true,
 		globalClineRulesToggles: {},
 		localClineRulesToggles: {},
+		shellIntegrationTimeout: 4000, // default timeout for shell integration
 	})
 	const [didHydrateState, setDidHydrateState] = useState(false)
 	const [showWelcome, setShowWelcome] = useState(false)
@@ -241,6 +243,11 @@ export const ExtensionStateContextProvider: React.FC<{
 			setState((prevState) => ({
 				...prevState,
 				shouldShowAnnouncement: value,
+			})),
+		setShellIntegrationTimeout: (value) =>
+			setState((prevState) => ({
+				...prevState,
+				shellIntegrationTimeout: value,
 			})),
 		setMcpServers: (mcpServers: McpServer[]) => setMcpServers(mcpServers),
 		setShowMcp,


### PR DESCRIPTION
### Description

Add a Terminal settings tab and a setting for adjusting the terminal connection timeout.
Solves https://github.com/cline/cline/issues/3166

### Test Procedure

## Setup

1.  **Temporary Logging:** Added `console.log` statements within the `pWaitFor` block in `src/integrations/terminal/TerminalManager.ts` to observe the waiting, success (activation), timeout, and proceeding states.
2.  **Simulated Delay:** Temporarily added a `sleep [N]` command (e.g., `sleep 10`) to the beginning of the user's `~/.zshrc` file. This forced new shell instances to take `N` seconds longer to initialize and activate shell integration.
3.  **VS Code Terminals:** Ensured all existing VS Code terminals were closed before each test run using "Terminal: Kill All Terminals".
4.  **Task Restart:** Restarted the Cline task between setting changes to ensure the `Task` instance picked up the latest `shellIntegrationTimeout` value from global state.

## Test Scenarios & Results

### Scenario 1: Timeout Occurs

*   **Configuration:**
    *   `shellIntegrationTimeout` set to a value *less* than the `sleep` duration (e.g., 2 seconds timeout vs. 5 seconds sleep).
*   **Procedure:** Executed a simple command (`echo "..."`) via Cline.
*   **Expected Logs:**
    1.  Waiting message (showing the short timeout value).
    2.  Timeout message (after the configured timeout duration).
    3.  Proceeding message.
    4.  Command output.
*   **Actual Result:** The logs confirmed this sequence, indicating the timeout triggered correctly when shell integration was delayed beyond the configured limit.

### Scenario 2: Timeout Avoided (Activation Succeeds)

*   **Configuration:**
    *   `shellIntegrationTimeout` set to a value *greater* than the `sleep` duration (e.g., 30 seconds timeout vs. 10 seconds sleep).
*   **Procedure:** Executed a simple command (`echo "..."`) via Cline.
*   **Expected Logs:**
    1.  Waiting message (showing the long timeout value).
    2.  Activation success message (after the `sleep` duration, but before the timeout).
    3.  Proceeding message.
    4.  Command output.
*   **Actual Result:** The logs confirmed this sequence, indicating the system correctly waited for shell integration to activate when it occurred within the configured timeout period.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [ ] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots
<img width="719" alt="Screenshot 2025-04-30 at 4 34 20 PM" src="https://github.com/user-attachments/assets/5a96041d-0688-405c-add7-fed7262d8c61" />

<!-- For UI changes, add screenshots here -->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add adjustable terminal connection timeout setting to handle shell integration delays.
> 
>   - **Behavior**:
>     - Adds `shellIntegrationTimeout` setting to control terminal connection timeout in `TerminalManager`.
>     - Default timeout set to 4000ms, adjustable via new UI in `TerminalSettingsSection.tsx`.
>   - **Backend**:
>     - Updates `TerminalManager` to use `shellIntegrationTimeout` for waiting on shell integration.
>     - Modifies `getAllExtensionState()` in `state.ts` to include `shellIntegrationTimeout`.
>     - Adds `shellIntegrationTimeout` to `ExtensionState` in `ExtensionMessage.ts` and `WebviewMessage.ts`.
>   - **Frontend**:
>     - Adds `TerminalSettingsSection.tsx` to `SettingsView.tsx` for user to adjust timeout.
>     - Updates `ExtensionStateContext.tsx` to manage `shellIntegrationTimeout` state.
>   - **Misc**:
>     - Adds `updateTerminalConnectionTimeout` message type to `WebviewMessage.ts` for communication between webview and extension.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 1e86882603692a76deb723635f5a293152e865f1. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->