### PR TITLE
[PROTOBUS] Move commitSearch to protobus

### DIFF
--- a/.changeset/funny-numbers-trade.md
+++ b/.changeset/funny-numbers-trade.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+searchCommits protobus migration

--- a/proto/file.proto
+++ b/proto/file.proto
@@ -21,11 +21,11 @@ service FileService {
   rpc createRuleFile(RuleFileRequest) returns (RuleFile);
   
   // Search git commits in the workspace
-  rpc searchCommits(StringRequest) returns (GitCommitSearchResponse);
+  rpc searchCommits(StringRequest) returns (GitCommits);
 }
 
 // Response for searchCommits
-message GitCommitSearchResponse {
+message GitCommits {
   repeated GitCommit commits = 1;
 }
 

--- a/proto/file.proto
+++ b/proto/file.proto
@@ -10,7 +10,7 @@ import "common.proto";
 service FileService {
   // Opens a file in the editor
   rpc openFile(StringRequest) returns (Empty);
-  
+ 
   // Opens an image in the system viewer
   rpc openImage(StringRequest) returns (Empty);
 
@@ -19,6 +19,23 @@ service FileService {
 
   // Creates a rule file from either global or workspace rules directory
   rpc createRuleFile(RuleFileRequest) returns (RuleFile);
+  
+  // Search git commits in the workspace
+  rpc searchCommits(StringRequest) returns (GitCommitSearchResponse);
+}
+
+// Response for searchCommits
+message GitCommitSearchResponse {
+  repeated GitCommit commits = 1;
+}
+
+// Represents a Git commit
+message GitCommit {
+  string hash = 1;
+  string short_hash = 2;
+  string subject = 3;
+  string author = 4;
+  string date = 5;
 }
 
 // Unified request for all rule file operations

--- a/src/core/controller/file/methods.ts
+++ b/src/core/controller/file/methods.ts
@@ -7,6 +7,7 @@ import { createRuleFile } from "./createRuleFile"
 import { deleteRuleFile } from "./deleteRuleFile"
 import { openFile } from "./openFile"
 import { openImage } from "./openImage"
+import { searchCommits } from "./searchCommits"
 
 // Register all file service methods
 export function registerAllMethods(): void {
@@ -15,4 +16,5 @@ export function registerAllMethods(): void {
 	registerMethod("deleteRuleFile", deleteRuleFile)
 	registerMethod("openFile", openFile)
 	registerMethod("openImage", openImage)
+	registerMethod("searchCommits", searchCommits)
 }

--- a/src/core/controller/file/searchCommits.ts
+++ b/src/core/controller/file/searchCommits.ts
@@ -1,9 +1,10 @@
 import { Controller } from ".."
-import { GitCommits, GitCommit as ProtoGitCommit } from "@shared/proto/file"
+import { GitCommits } from "@shared/proto/file"
 import { StringRequest } from "@shared/proto/common"
 import { searchCommits as searchCommitsUtil } from "@utils/git"
 import { getWorkspacePath } from "@utils/path"
 import { FileMethodHandler } from "./index"
+import { convertGitCommitsToProtoGitCommits } from "@shared/proto-conversions/file/git-commit-conversion"
 
 /**
  * Searches for git commits in the workspace repository
@@ -20,14 +21,7 @@ export const searchCommits: FileMethodHandler = async (controller: Controller, r
 	try {
 		const commits = await searchCommitsUtil(request.value || "", cwd)
 
-		// Map the domain GitCommit type to the proto GitCommit type
-		const protoCommits: ProtoGitCommit[] = commits.map((commit) => ({
-			hash: commit.hash,
-			shortHash: commit.shortHash,
-			subject: commit.subject,
-			author: commit.author,
-			date: commit.date,
-		}))
+		const protoCommits = convertGitCommitsToProtoGitCommits(commits)
 
 		return GitCommits.create({ commits: protoCommits })
 	} catch (error) {

--- a/src/core/controller/file/searchCommits.ts
+++ b/src/core/controller/file/searchCommits.ts
@@ -9,7 +9,7 @@ import { FileMethodHandler } from "./index"
  * Searches for git commits in the workspace repository
  * @param controller The controller instance
  * @param request The request message containing the search query in the 'value' field
- * @returns GitCommitSearchResponse containing the matching commits
+ * @returns GitCommits containing the matching commits
  */
 export const searchCommits: FileMethodHandler = async (controller: Controller, request: StringRequest): Promise<GitCommits> => {
 	const cwd = getWorkspacePath()

--- a/src/core/controller/file/searchCommits.ts
+++ b/src/core/controller/file/searchCommits.ts
@@ -1,5 +1,5 @@
 import { Controller } from ".."
-import { GitCommitSearchResponse, GitCommit as ProtoGitCommit } from "@shared/proto/file"
+import { GitCommits, GitCommit as ProtoGitCommit } from "@shared/proto/file"
 import { StringRequest } from "@shared/proto/common"
 import { searchCommits as searchCommitsUtil } from "@utils/git"
 import { getWorkspacePath } from "@utils/path"
@@ -11,13 +11,10 @@ import { FileMethodHandler } from "./index"
  * @param request The request message containing the search query in the 'value' field
  * @returns GitCommitSearchResponse containing the matching commits
  */
-export const searchCommits: FileMethodHandler = async (
-	controller: Controller,
-	request: StringRequest,
-): Promise<GitCommitSearchResponse> => {
+export const searchCommits: FileMethodHandler = async (controller: Controller, request: StringRequest): Promise<GitCommits> => {
 	const cwd = getWorkspacePath()
 	if (!cwd) {
-		return GitCommitSearchResponse.create({ commits: [] })
+		return GitCommits.create({ commits: [] })
 	}
 
 	try {
@@ -32,9 +29,9 @@ export const searchCommits: FileMethodHandler = async (
 			date: commit.date,
 		}))
 
-		return GitCommitSearchResponse.create({ commits: protoCommits })
+		return GitCommits.create({ commits: protoCommits })
 	} catch (error) {
 		console.error(`Error searching commits: ${JSON.stringify(error)}`)
-		return GitCommitSearchResponse.create({ commits: [] })
+		return GitCommits.create({ commits: [] })
 	}
 }

--- a/src/core/controller/file/searchCommits.ts
+++ b/src/core/controller/file/searchCommits.ts
@@ -1,0 +1,40 @@
+import { Controller } from ".."
+import { GitCommitSearchResponse, GitCommit as ProtoGitCommit } from "@shared/proto/file"
+import { StringRequest } from "@shared/proto/common"
+import { searchCommits as searchCommitsUtil } from "@utils/git"
+import { getWorkspacePath } from "@utils/path"
+import { FileMethodHandler } from "./index"
+
+/**
+ * Searches for git commits in the workspace repository
+ * @param controller The controller instance
+ * @param request The request message containing the search query in the 'value' field
+ * @returns GitCommitSearchResponse containing the matching commits
+ */
+export const searchCommits: FileMethodHandler = async (
+	controller: Controller,
+	request: StringRequest,
+): Promise<GitCommitSearchResponse> => {
+	const cwd = getWorkspacePath()
+	if (!cwd) {
+		return GitCommitSearchResponse.create({ commits: [] })
+	}
+
+	try {
+		const commits = await searchCommitsUtil(request.value || "", cwd)
+
+		// Map the domain GitCommit type to the proto GitCommit type
+		const protoCommits: ProtoGitCommit[] = commits.map((commit) => ({
+			hash: commit.hash,
+			shortHash: commit.shortHash,
+			subject: commit.subject,
+			author: commit.author,
+			date: commit.date,
+		}))
+
+		return GitCommitSearchResponse.create({ commits: protoCommits })
+	} catch (error) {
+		console.error(`Error searching commits: ${JSON.stringify(error)}`)
+		return GitCommitSearchResponse.create({ commits: [] })
+	}
+}

--- a/src/core/controller/index.ts
+++ b/src/core/controller/index.ts
@@ -538,21 +538,6 @@ export class Controller {
 				this.mcpHub?.sendLatestMcpServers()
 				break
 			}
-			case "searchCommits": {
-				const cwd = vscode.workspace.workspaceFolders?.map((folder) => folder.uri.fsPath).at(0)
-				if (cwd) {
-					try {
-						const commits = await searchCommits(message.text || "", cwd)
-						await this.postMessageToWebview({
-							type: "commitSearchResults",
-							commits,
-						})
-					} catch (error) {
-						console.error(`Error searching commits: ${JSON.stringify(error)}`)
-					}
-				}
-				break
-			}
 			case "openExtensionSettings": {
 				const settingsFilter = message.text || ""
 				await vscode.commands.executeCommand(

--- a/src/shared/proto-conversions/file/git-commit-conversion.ts
+++ b/src/shared/proto-conversions/file/git-commit-conversion.ts
@@ -1,0 +1,28 @@
+import { GitCommit as ProtoGitCommit } from "@shared/proto/file"
+import { GitCommit } from "@utils/git"
+
+/**
+ * Converts domain GitCommit objects to proto GitCommit objects
+ */
+export function convertGitCommitsToProtoGitCommits(commits: GitCommit[]): ProtoGitCommit[] {
+	return commits.map((commit) => ({
+		hash: commit.hash,
+		shortHash: commit.shortHash,
+		subject: commit.subject,
+		author: commit.author,
+		date: commit.date,
+	}))
+}
+
+/**
+ * Converts proto GitCommit objects to domain GitCommit objects
+ */
+export function convertProtoGitCommitsToGitCommits(protoCommits: ProtoGitCommit[]): GitCommit[] {
+	return protoCommits.map((protoCommit) => ({
+		hash: protoCommit.hash,
+		shortHash: protoCommit.shortHash,
+		subject: protoCommit.subject,
+		author: protoCommit.author,
+		date: protoCommit.date,
+	}))
+}

--- a/src/shared/proto/file.ts
+++ b/src/shared/proto/file.ts
@@ -10,6 +10,20 @@ import { Empty, Metadata, StringRequest } from "./common"
 
 export const protobufPackage = "cline"
 
+/** Response for searchCommits */
+export interface GitCommitSearchResponse {
+	commits: GitCommit[]
+}
+
+/** Represents a Git commit */
+export interface GitCommit {
+	hash: string
+	shortHash: string
+	subject: string
+	author: string
+	date: string
+}
+
 /** Unified request for all rule file operations */
 export interface RuleFileRequest {
 	metadata?: Metadata | undefined
@@ -29,6 +43,190 @@ export interface RuleFile {
 	displayName: string
 	/** For createRuleFile, indicates if file already existed */
 	alreadyExists: boolean
+}
+
+function createBaseGitCommitSearchResponse(): GitCommitSearchResponse {
+	return { commits: [] }
+}
+
+export const GitCommitSearchResponse: MessageFns<GitCommitSearchResponse> = {
+	encode(message: GitCommitSearchResponse, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+		for (const v of message.commits) {
+			GitCommit.encode(v!, writer.uint32(10).fork()).join()
+		}
+		return writer
+	},
+
+	decode(input: BinaryReader | Uint8Array, length?: number): GitCommitSearchResponse {
+		const reader = input instanceof BinaryReader ? input : new BinaryReader(input)
+		let end = length === undefined ? reader.len : reader.pos + length
+		const message = createBaseGitCommitSearchResponse()
+		while (reader.pos < end) {
+			const tag = reader.uint32()
+			switch (tag >>> 3) {
+				case 1: {
+					if (tag !== 10) {
+						break
+					}
+
+					message.commits.push(GitCommit.decode(reader, reader.uint32()))
+					continue
+				}
+			}
+			if ((tag & 7) === 4 || tag === 0) {
+				break
+			}
+			reader.skip(tag & 7)
+		}
+		return message
+	},
+
+	fromJSON(object: any): GitCommitSearchResponse {
+		return {
+			commits: globalThis.Array.isArray(object?.commits) ? object.commits.map((e: any) => GitCommit.fromJSON(e)) : [],
+		}
+	},
+
+	toJSON(message: GitCommitSearchResponse): unknown {
+		const obj: any = {}
+		if (message.commits?.length) {
+			obj.commits = message.commits.map((e) => GitCommit.toJSON(e))
+		}
+		return obj
+	},
+
+	create<I extends Exact<DeepPartial<GitCommitSearchResponse>, I>>(base?: I): GitCommitSearchResponse {
+		return GitCommitSearchResponse.fromPartial(base ?? ({} as any))
+	},
+	fromPartial<I extends Exact<DeepPartial<GitCommitSearchResponse>, I>>(object: I): GitCommitSearchResponse {
+		const message = createBaseGitCommitSearchResponse()
+		message.commits = object.commits?.map((e) => GitCommit.fromPartial(e)) || []
+		return message
+	},
+}
+
+function createBaseGitCommit(): GitCommit {
+	return { hash: "", shortHash: "", subject: "", author: "", date: "" }
+}
+
+export const GitCommit: MessageFns<GitCommit> = {
+	encode(message: GitCommit, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+		if (message.hash !== "") {
+			writer.uint32(10).string(message.hash)
+		}
+		if (message.shortHash !== "") {
+			writer.uint32(18).string(message.shortHash)
+		}
+		if (message.subject !== "") {
+			writer.uint32(26).string(message.subject)
+		}
+		if (message.author !== "") {
+			writer.uint32(34).string(message.author)
+		}
+		if (message.date !== "") {
+			writer.uint32(42).string(message.date)
+		}
+		return writer
+	},
+
+	decode(input: BinaryReader | Uint8Array, length?: number): GitCommit {
+		const reader = input instanceof BinaryReader ? input : new BinaryReader(input)
+		let end = length === undefined ? reader.len : reader.pos + length
+		const message = createBaseGitCommit()
+		while (reader.pos < end) {
+			const tag = reader.uint32()
+			switch (tag >>> 3) {
+				case 1: {
+					if (tag !== 10) {
+						break
+					}
+
+					message.hash = reader.string()
+					continue
+				}
+				case 2: {
+					if (tag !== 18) {
+						break
+					}
+
+					message.shortHash = reader.string()
+					continue
+				}
+				case 3: {
+					if (tag !== 26) {
+						break
+					}
+
+					message.subject = reader.string()
+					continue
+				}
+				case 4: {
+					if (tag !== 34) {
+						break
+					}
+
+					message.author = reader.string()
+					continue
+				}
+				case 5: {
+					if (tag !== 42) {
+						break
+					}
+
+					message.date = reader.string()
+					continue
+				}
+			}
+			if ((tag & 7) === 4 || tag === 0) {
+				break
+			}
+			reader.skip(tag & 7)
+		}
+		return message
+	},
+
+	fromJSON(object: any): GitCommit {
+		return {
+			hash: isSet(object.hash) ? globalThis.String(object.hash) : "",
+			shortHash: isSet(object.shortHash) ? globalThis.String(object.shortHash) : "",
+			subject: isSet(object.subject) ? globalThis.String(object.subject) : "",
+			author: isSet(object.author) ? globalThis.String(object.author) : "",
+			date: isSet(object.date) ? globalThis.String(object.date) : "",
+		}
+	},
+
+	toJSON(message: GitCommit): unknown {
+		const obj: any = {}
+		if (message.hash !== "") {
+			obj.hash = message.hash
+		}
+		if (message.shortHash !== "") {
+			obj.shortHash = message.shortHash
+		}
+		if (message.subject !== "") {
+			obj.subject = message.subject
+		}
+		if (message.author !== "") {
+			obj.author = message.author
+		}
+		if (message.date !== "") {
+			obj.date = message.date
+		}
+		return obj
+	},
+
+	create<I extends Exact<DeepPartial<GitCommit>, I>>(base?: I): GitCommit {
+		return GitCommit.fromPartial(base ?? ({} as any))
+	},
+	fromPartial<I extends Exact<DeepPartial<GitCommit>, I>>(object: I): GitCommit {
+		const message = createBaseGitCommit()
+		message.hash = object.hash ?? ""
+		message.shortHash = object.shortHash ?? ""
+		message.subject = object.subject ?? ""
+		message.author = object.author ?? ""
+		message.date = object.date ?? ""
+		return message
+	},
 }
 
 function createBaseRuleFileRequest(): RuleFileRequest {
@@ -271,6 +469,15 @@ export const FileServiceDefinition = {
 			requestType: RuleFileRequest,
 			requestStream: false,
 			responseType: RuleFile,
+			responseStream: false,
+			options: {},
+		},
+		/** Search git commits in the workspace */
+		searchCommits: {
+			name: "searchCommits",
+			requestType: StringRequest,
+			requestStream: false,
+			responseType: GitCommitSearchResponse,
 			responseStream: false,
 			options: {},
 		},

--- a/src/shared/proto/file.ts
+++ b/src/shared/proto/file.ts
@@ -11,7 +11,7 @@ import { Empty, Metadata, StringRequest } from "./common"
 export const protobufPackage = "cline"
 
 /** Response for searchCommits */
-export interface GitCommitSearchResponse {
+export interface GitCommits {
 	commits: GitCommit[]
 }
 
@@ -45,22 +45,22 @@ export interface RuleFile {
 	alreadyExists: boolean
 }
 
-function createBaseGitCommitSearchResponse(): GitCommitSearchResponse {
+function createBaseGitCommits(): GitCommits {
 	return { commits: [] }
 }
 
-export const GitCommitSearchResponse: MessageFns<GitCommitSearchResponse> = {
-	encode(message: GitCommitSearchResponse, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+export const GitCommits: MessageFns<GitCommits> = {
+	encode(message: GitCommits, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
 		for (const v of message.commits) {
 			GitCommit.encode(v!, writer.uint32(10).fork()).join()
 		}
 		return writer
 	},
 
-	decode(input: BinaryReader | Uint8Array, length?: number): GitCommitSearchResponse {
+	decode(input: BinaryReader | Uint8Array, length?: number): GitCommits {
 		const reader = input instanceof BinaryReader ? input : new BinaryReader(input)
 		let end = length === undefined ? reader.len : reader.pos + length
-		const message = createBaseGitCommitSearchResponse()
+		const message = createBaseGitCommits()
 		while (reader.pos < end) {
 			const tag = reader.uint32()
 			switch (tag >>> 3) {
@@ -81,13 +81,13 @@ export const GitCommitSearchResponse: MessageFns<GitCommitSearchResponse> = {
 		return message
 	},
 
-	fromJSON(object: any): GitCommitSearchResponse {
+	fromJSON(object: any): GitCommits {
 		return {
 			commits: globalThis.Array.isArray(object?.commits) ? object.commits.map((e: any) => GitCommit.fromJSON(e)) : [],
 		}
 	},
 
-	toJSON(message: GitCommitSearchResponse): unknown {
+	toJSON(message: GitCommits): unknown {
 		const obj: any = {}
 		if (message.commits?.length) {
 			obj.commits = message.commits.map((e) => GitCommit.toJSON(e))
@@ -95,11 +95,11 @@ export const GitCommitSearchResponse: MessageFns<GitCommitSearchResponse> = {
 		return obj
 	},
 
-	create<I extends Exact<DeepPartial<GitCommitSearchResponse>, I>>(base?: I): GitCommitSearchResponse {
-		return GitCommitSearchResponse.fromPartial(base ?? ({} as any))
+	create<I extends Exact<DeepPartial<GitCommits>, I>>(base?: I): GitCommits {
+		return GitCommits.fromPartial(base ?? ({} as any))
 	},
-	fromPartial<I extends Exact<DeepPartial<GitCommitSearchResponse>, I>>(object: I): GitCommitSearchResponse {
-		const message = createBaseGitCommitSearchResponse()
+	fromPartial<I extends Exact<DeepPartial<GitCommits>, I>>(object: I): GitCommits {
+		const message = createBaseGitCommits()
 		message.commits = object.commits?.map((e) => GitCommit.fromPartial(e)) || []
 		return message
 	},
@@ -477,7 +477,7 @@ export const FileServiceDefinition = {
 			name: "searchCommits",
 			requestType: StringRequest,
 			requestStream: false,
-			responseType: GitCommitSearchResponse,
+			responseType: GitCommits,
 			responseStream: false,
 			options: {},
 		},


### PR DESCRIPTION
### Description

This PR migrates the `searchCommits` message to the gRPC/Protobuf system. It consolidates the previous two-step message flow (`searchCommits` request and `commitSearchResults` response) into a single gRPC method in the FileService. The client can call `FileServiceClient.searchCommits()` with a search query string and receive a typed `GitCommitSearchResponse` containing matching commits directly.

### Test Procedure

This message is used by the file mentions feature when searching for git commits a user wishes to add to context.

- Open a Git repository and launch the Cline chat interface
- Type "@" in the input field and select "Git" from the context menu
- Verify that recent commits appear in the dropdown with their subjects displayed as labels. A short hash, author, and date should also be displayed.
- Select a commit from the dropdown and verify it's correctly inserted into the chat input with proper formatting (full commit hash)
- Test with partial commit messages to confirm searching works with commit subjects. For example, type "@", arrow to the Git Commits option, then type "@fetching" when working on the Cline repo - this should (currently) return 3 git commit results.


### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [X] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [X] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [X] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [X] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [X] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Migrates `searchCommits` to gRPC/Protobuf, consolidating it into a single gRPC method in `FileService`, with updates to proto definitions, controller methods, and UI components.
> 
>   - **Behavior**:
>     - Migrates `searchCommits` to gRPC/Protobuf, consolidating request/response into `FileService.searchCommits()`.
>     - `searchCommits` now returns `GitCommits` directly, handling search queries for git commits.
>   - **Proto Definitions**:
>     - Adds `searchCommits` RPC to `FileService` in `file.proto`.
>     - Defines `GitCommits` and `GitCommit` messages in `file.proto`.
>   - **Controller Changes**:
>     - Implements `searchCommits` in `searchCommits.ts` using gRPC.
>     - Registers `searchCommits` in `methods.ts`.
>   - **UI Changes**:
>     - Updates `ChatTextArea.tsx` to use `FileServiceClient.searchCommits()` for fetching commits.
>     - Removes old message handling for `commitSearchResults`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 4f342934ce7cd730861405c68c343a43cad2ec81. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->