### PR TITLE
[ISSUE-3145] Fix Windows path issue: Correct handling of import.meta.url to avoid leading slash in pathname

### DIFF
--- a/.changeset/tall-cups-fly.md
+++ b/.changeset/tall-cups-fly.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": minor
+---
+
+Fix Windows path issue: Correct handling of import.meta.url to avoid leading slash in pathname

--- a/proto/build-proto.js
+++ b/proto/build-proto.js
@@ -2,6 +2,7 @@
 
 import * as fs from "fs/promises"
 import * as path from "path"
+import { fileURLToPath } from "url"
 import { execSync } from "child_process"
 import { globby } from "globby"
 import chalk from "chalk"
@@ -12,7 +13,8 @@ const protoc = path.join(require.resolve("grpc-tools"), "../bin/protoc")
 const tsProtoPlugin = require.resolve("ts-proto/protoc-gen-ts_proto")
 
 // Get script directory and root directory
-const SCRIPT_DIR = path.dirname(new URL(import.meta.url).pathname)
+const __filename = fileURLToPath(import.meta.url)
+const SCRIPT_DIR = path.dirname(__filename)
 const ROOT_DIR = path.resolve(SCRIPT_DIR, "..")
 
 async function main() {


### PR DESCRIPTION
### Description

This resolves issue https://github.com/cline/cline/issues/3145 with running `build-proto` on Windows machine.

What happened: 
On Windows, `new URL(import.meta.url).pathname` returns a pathname that starts with a leading slash (e.g., /C:/path/to/file.js), which is not a valid Windows path and will cause issues with path.dirname.

### Test Procedure

1. Run `npm run protos` on windows machine.

I've used VMware Fusion to test it manually.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes Windows path issue in `build-proto.js` by using `fileURLToPath(import.meta.url)` to avoid leading slash in pathname.
> 
>   - **Behavior**:
>     - Fixes Windows path issue in `build-proto.js` by using `fileURLToPath(import.meta.url)` to avoid leading slash in pathname.
>     - Ensures compatibility of `build-proto` script on Windows by correcting path handling.
>   - **Imports**:
>     - Adds `fileURLToPath` import from `url` module in `build-proto.js`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for c2d51f4183713176996b8b918c1c3198b76f9d22. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->