### PR TITLE
c’est magnifique! 🫰 

### DIFF
--- a/.changeset/two-wolves-think.md
+++ b/.changeset/two-wolves-think.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": minor
+---
+
+Add new welcome header to home view

--- a/webview-ui/src/components/chat/ChatView.tsx
+++ b/webview-ui/src/components/chat/ChatView.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { useDeepCompareEffect, useEvent, useMount } from "react-use"
 import { Virtuoso, type VirtuosoHandle } from "react-virtuoso"
 import styled from "styled-components"
+import HomeHeader from "@/components/welcome/HomeHeader"
 import {
 	ClineApiReqInfo,
 	ClineAsk,
@@ -916,19 +917,7 @@ const ChatView = ({ isHidden, showAnnouncement, hideAnnouncement, showHistoryVie
 
 					{showAnnouncement && <Announcement version={version} hideAnnouncement={hideAnnouncement} />}
 
-					<div style={{ padding: "0 20px", flexShrink: 0 }}>
-						<h2>What can I do for you?</h2>
-						<p>
-							Thanks to{" "}
-							<VSCodeLink href="https://www.anthropic.com/claude/sonnet" style={{ display: "inline" }}>
-								Claude 3.7 Sonnet's
-							</VSCodeLink>
-							agentic coding capabilities, I can handle complex software development tasks step-by-step. With tools
-							that let me create & edit files, explore complex projects, use a browser, and execute terminal
-							commands (after you grant permission), I can assist you in ways that go beyond code completion or tech
-							support. I can even use MCP to create new tools and extend my own capabilities.
-						</p>
-					</div>
+					<HomeHeader />
 					{taskHistory.length > 0 && <HistoryPreview showHistoryView={showHistoryView} />}
 				</div>
 			)}

--- a/webview-ui/src/components/welcome/HomeHeader.tsx
+++ b/webview-ui/src/components/welcome/HomeHeader.tsx
@@ -1,0 +1,56 @@
+import { useFirebaseAuth } from "@/context/FirebaseAuthContext"
+import ClineLogoWhite from "@/assets/ClineLogoWhite"
+
+const getTimeOfDay = () => {
+	const hour = new Date().getHours()
+
+	if (hour >= 5 && hour < 12) return "Morning"
+	if (hour >= 12 && hour < 18) return "Afternoon"
+	if (hour >= 18 && hour < 24) return "Evening"
+	return "Late Night"
+}
+
+const getSecondaryMessage = (timeOfDay: string) => {
+	switch (timeOfDay) {
+		case "Morning":
+			return "Grab coffee and let's get to work."
+		case "Afternoon":
+			return "Let's keep the momentum going."
+		case "Evening":
+			return "Still going strong!"
+		case "Late Night":
+			return "Burning the midnight oil?"
+		default:
+			return "Let's get to work."
+	}
+}
+
+const getFirstName = (displayName: string | null | undefined) => {
+	if (!displayName) return ""
+	return displayName.split(" ")[0]
+}
+
+const HomeHeader = () => {
+	const { user } = useFirebaseAuth()
+	const timeOfDay = getTimeOfDay()
+	const firstName = getFirstName(user?.displayName)
+
+	return (
+		<div className="flex flex-col items-center mb-5">
+			<div className="my-5">
+				<ClineLogoWhite className="size-16" />
+			</div>
+			<div className="text-center">
+				<h2 className="m-0 text-[var(--vscode-font-size)]">
+					{timeOfDay}
+					{firstName ? ` ${firstName}` : ""}!
+				</h2>
+				<div className="text-[var(--vscode-descriptionForeground)] text-sm font-normal mt-1">
+					{getSecondaryMessage(timeOfDay)}
+				</div>
+			</div>
+		</div>
+	)
+}
+
+export default HomeHeader

--- a/webview-ui/src/components/welcome/HomeHeader.tsx
+++ b/webview-ui/src/components/welcome/HomeHeader.tsx
@@ -13,20 +13,24 @@ const getTimeOfDay = (): TimeOfDay => {
 }
 
 const secondaryMessages: Record<TimeOfDay, string[]> = {
-	morning: ["Grab coffee and let's get to work."],
-	afternoon: ["Let's keep the momentum going."],
-	evening: ["Still going strong!"],
+	morning: ["Grab coffee and let's get to work.", "Ready for a productive day?", "What are we building today?"],
+	afternoon: ["Let's keep the momentum going.", "Time for the next task."],
+	evening: ["Still going strong!", "Let's get those final touches in."],
 	night: ["Burning the midnight oil?"],
 }
-const defaultSecondaryMessages = ["Let's get to work."]
+
+// Should never hit default, just built in for redundancy
+const defaultSecondaryMessages = ["Let's get to work.", "Ready when you are.", "How can I assist?"]
 
 const primaryGreetings: Record<TimeOfDay, string[]> = {
-	morning: ["Good Morning"],
-	afternoon: ["Good Afternoon"],
-	evening: ["Good Evening"],
-	night: ["Good Night"],
+	morning: ["Good Morning", "Morning", "Top o' the mornin'"],
+	afternoon: ["Good Afternoon", "Afternoon", "Howdy"],
+	evening: ["Good Evening", "Evening"],
+	night: ["Good Evening", "Evening"],
 }
-const defaultPrimaryGreetings = ["Hello"]
+
+// Should never hit default, just built in for redundancy
+const defaultPrimaryGreetings = ["Hello", "Hi", "Hey!", "Yo!"]
 
 const getSecondaryMessage = (timeOfDay: TimeOfDay): string => {
 	const messages = secondaryMessages[timeOfDay] || defaultSecondaryMessages

--- a/webview-ui/src/components/welcome/HomeHeader.tsx
+++ b/webview-ui/src/components/welcome/HomeHeader.tsx
@@ -1,28 +1,43 @@
 import { useFirebaseAuth } from "@/context/FirebaseAuthContext"
 import ClineLogoWhite from "@/assets/ClineLogoWhite"
 
-const getTimeOfDay = () => {
+type TimeOfDay = "morning" | "afternoon" | "evening" | "night"
+
+const getTimeOfDay = (): TimeOfDay => {
 	const hour = new Date().getHours()
 
-	if (hour >= 5 && hour < 12) return "Morning"
-	if (hour >= 12 && hour < 18) return "Afternoon"
-	if (hour >= 18 && hour < 24) return "Evening"
-	return "Late Night"
+	if (hour >= 5 && hour < 12) return "morning"
+	if (hour >= 12 && hour < 18) return "afternoon"
+	if (hour >= 18 && hour < 24) return "evening"
+	return "night"
 }
 
-const getSecondaryMessage = (timeOfDay: string) => {
-	switch (timeOfDay) {
-		case "Morning":
-			return "Grab coffee and let's get to work."
-		case "Afternoon":
-			return "Let's keep the momentum going."
-		case "Evening":
-			return "Still going strong!"
-		case "Late Night":
-			return "Burning the midnight oil?"
-		default:
-			return "Let's get to work."
-	}
+const secondaryMessages: Record<TimeOfDay, string[]> = {
+	morning: ["Grab coffee and let's get to work."],
+	afternoon: ["Let's keep the momentum going."],
+	evening: ["Still going strong!"],
+	night: ["Burning the midnight oil?"],
+}
+const defaultSecondaryMessages = ["Let's get to work."]
+
+const primaryGreetings: Record<TimeOfDay, string[]> = {
+	morning: ["Good Morning"],
+	afternoon: ["Good Afternoon"],
+	evening: ["Good Evening"],
+	night: ["Good Night"],
+}
+const defaultPrimaryGreetings = ["Hello"]
+
+const getSecondaryMessage = (timeOfDay: TimeOfDay): string => {
+	const messages = secondaryMessages[timeOfDay] || defaultSecondaryMessages
+	const randomIndex = Math.floor(Math.random() * messages.length)
+	return messages[randomIndex]
+}
+
+const getPrimaryGreeting = (timeOfDay: TimeOfDay): string => {
+	const greetings = primaryGreetings[timeOfDay] || defaultPrimaryGreetings
+	const randomIndex = Math.floor(Math.random() * greetings.length)
+	return greetings[randomIndex]
 }
 
 const getFirstName = (displayName: string | null | undefined) => {
@@ -34,6 +49,7 @@ const HomeHeader = () => {
 	const { user } = useFirebaseAuth()
 	const timeOfDay = getTimeOfDay()
 	const firstName = getFirstName(user?.displayName)
+	const greeting = getPrimaryGreeting(timeOfDay)
 
 	return (
 		<div className="flex flex-col items-center mb-5">
@@ -42,8 +58,8 @@ const HomeHeader = () => {
 			</div>
 			<div className="text-center">
 				<h2 className="m-0 text-[var(--vscode-font-size)]">
-					{timeOfDay}
-					{firstName ? ` ${firstName}` : ""}!
+					{greeting}
+					{firstName ? `, ${firstName}` : ""}!
 				</h2>
 				<div className="text-[var(--vscode-descriptionForeground)] text-sm font-normal mt-1">
 					{getSecondaryMessage(timeOfDay)}


### PR DESCRIPTION
### Description

# `HomeHeader` Component

Displays a welcoming header for the Cline home screen.

*   Shows the Cline logo.
*   Provides a personalized greeting (e.g., "Good Morning, Cline!") based on the time of day and the logged-in user's first name.
*   Includes a secondary contextual message (e.g., "Ready for a productive day?").
*   Messages are easily changeable and can be hooked up to remote config

### Test Procedure

Tested:
- Logged in case
- logged out case
- different color themes (will need a different logo for the few white background themes)

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [x] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots
#### Logged out
<img width="540" alt="Screenshot 2025-05-02 at 5 35 27 PM" src="https://github.com/user-attachments/assets/b27d6898-46a3-4cb6-84fa-9a2addbce2a8" />

#### Logged in
<img width="509" alt="Screenshot 2025-05-02 at 5 49 20 PM" src="https://github.com/user-attachments/assets/897da543-7680-4687-8309-0e73d4e63691" />

<!-- For UI changes, add screenshots here -->

### Additional Notes

<!-- Add any additional notes for reviewers -->
