### PR TITLE
[PROTOBUS] Move getRelativePaths to protobus 

### DIFF
--- a/.changeset/curly-fireants-work.md
+++ b/.changeset/curly-fireants-work.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+getRelativePaths protobus migration

--- a/proto/file.proto
+++ b/proto/file.proto
@@ -22,6 +22,20 @@ service FileService {
   
   // Search git commits in the workspace
   rpc searchCommits(StringRequest) returns (GitCommits);
+  
+  // Convert URIs to workspace-relative paths
+  rpc getRelativePaths(RelativePathsRequest) returns (RelativePaths);
+}
+
+// Request to convert a list of URIs to relative paths
+message RelativePathsRequest {
+  Metadata metadata = 1;
+  repeated string uris = 2;
+}
+
+// Response containing the converted relative paths
+message RelativePaths {
+  repeated string paths = 1;
 }
 
 // Response for searchCommits

--- a/src/core/controller/file/getRelativePaths.ts
+++ b/src/core/controller/file/getRelativePaths.ts
@@ -1,0 +1,50 @@
+import { Controller } from ".."
+import { RelativePathsRequest, RelativePaths } from "@shared/proto/file"
+import { FileMethodHandler } from "./index"
+import * as vscode from "vscode"
+import * as path from "path"
+
+/**
+ * Converts a list of URIs to workspace-relative paths
+ * @param controller The controller instance
+ * @param request The request containing URIs to convert
+ * @returns Response with resolved relative paths
+ */
+export const getRelativePaths: FileMethodHandler = async (
+	controller: Controller,
+	request: RelativePathsRequest,
+): Promise<RelativePaths> => {
+	const resolvedPaths = await Promise.all(
+		request.uris.map(async (uriString) => {
+			try {
+				const fileUri = vscode.Uri.parse(uriString, true)
+				const relativePathToGet = vscode.workspace.asRelativePath(fileUri, false)
+
+				// If the path is still absolute, it's outside the workspace
+				if (path.isAbsolute(relativePathToGet)) {
+					console.warn(`Dropped file ${relativePathToGet} is outside the workspace. Sending original path.`)
+					return fileUri.fsPath.replace(/\\/g, "/")
+				} else {
+					let finalPath = "/" + relativePathToGet.replace(/\\/g, "/")
+					try {
+						const stat = await vscode.workspace.fs.stat(fileUri)
+						if (stat.type === vscode.FileType.Directory) {
+							finalPath += "/"
+						}
+					} catch (statError) {
+						console.error(`Error stating file ${fileUri.fsPath}:`, statError)
+					}
+					return finalPath
+				}
+			} catch (error) {
+				console.error(`Error calculating relative path for ${uriString}:`, error)
+				return null
+			}
+		}),
+	)
+
+	// Filter out any null values from errors
+	const validPaths = resolvedPaths.filter((path): path is string => path !== null)
+
+	return RelativePaths.create({ paths: validPaths })
+}

--- a/src/core/controller/file/methods.ts
+++ b/src/core/controller/file/methods.ts
@@ -5,6 +5,7 @@
 import { registerMethod } from "./index"
 import { createRuleFile } from "./createRuleFile"
 import { deleteRuleFile } from "./deleteRuleFile"
+import { getRelativePaths } from "./getRelativePaths"
 import { openFile } from "./openFile"
 import { openImage } from "./openImage"
 import { searchCommits } from "./searchCommits"
@@ -14,6 +15,7 @@ export function registerAllMethods(): void {
 	// Register each method with the registry
 	registerMethod("createRuleFile", createRuleFile)
 	registerMethod("deleteRuleFile", deleteRuleFile)
+	registerMethod("getRelativePaths", getRelativePaths)
 	registerMethod("openFile", openFile)
 	registerMethod("openImage", openImage)
 	registerMethod("searchCommits", searchCommits)

--- a/src/core/controller/index.ts
+++ b/src/core/controller/index.ts
@@ -610,42 +610,6 @@ export class Controller {
 				this.postMessageToWebview({ type: "relinquishControl" })
 				break
 			}
-			case "getRelativePaths": {
-				if (message.uris && message.uris.length > 0) {
-					const resolvedPaths = await Promise.all(
-						message.uris.map(async (uriString) => {
-							try {
-								const fileUri = vscode.Uri.parse(uriString, true)
-								const relativePath = vscode.workspace.asRelativePath(fileUri, false)
-
-								if (path.isAbsolute(relativePath)) {
-									console.warn(`Dropped file ${relativePath} is outside the workspace. Sending original path.`)
-									return fileUri.fsPath.replace(/\\/g, "/")
-								} else {
-									let finalPath = "/" + relativePath.replace(/\\/g, "/")
-									try {
-										const stat = await vscode.workspace.fs.stat(fileUri)
-										if (stat.type === vscode.FileType.Directory) {
-											finalPath += "/"
-										}
-									} catch (statError) {
-										console.error(`Error stating file ${fileUri.fsPath}:`, statError)
-									}
-									return finalPath
-								}
-							} catch (error) {
-								console.error(`Error calculating relative path for ${uriString}:`, error)
-								return null
-							}
-						}),
-					)
-					await this.postMessageToWebview({
-						type: "relativePathsResponse",
-						paths: resolvedPaths,
-					})
-				}
-				break
-			}
 			case "searchFiles": {
 				const workspacePath = getWorkspacePath()
 

--- a/src/shared/ExtensionMessage.ts
+++ b/src/shared/ExtensionMessage.ts
@@ -44,11 +44,9 @@ export interface ExtensionMessage {
 		| "browserConnectionResult"
 		| "scrollToSettings"
 		| "browserRelaunchResult"
-		| "relativePathsResponse" // Handles single and multiple path responses
 		| "fileSearchResults"
 		| "grpc_response" // New type for gRPC responses
 	text?: string
-	paths?: (string | null)[] // Used for relativePathsResponse
 	action?:
 		| "chatButtonClicked"
 		| "mcpButtonClicked"

--- a/src/shared/WebviewMessage.ts
+++ b/src/shared/WebviewMessage.ts
@@ -62,7 +62,6 @@ export interface WebviewMessage {
 		| "relaunchChromeDebugMode"
 		| "taskFeedback"
 		| "scrollToSettings"
-		| "getRelativePaths" // Handles single and multiple URI resolution
 		| "searchFiles"
 		| "toggleFavoriteModel"
 		| "grpc_request"
@@ -73,7 +72,6 @@ export interface WebviewMessage {
 
 	// | "relaunchChromeDebugMode"
 	text?: string
-	uris?: string[] // Used for getRelativePaths
 	disabled?: boolean
 	askResponse?: ClineAskResponse
 	apiConfiguration?: ApiConfiguration

--- a/src/shared/proto/file.ts
+++ b/src/shared/proto/file.ts
@@ -10,6 +10,17 @@ import { Empty, Metadata, StringRequest } from "./common"
 
 export const protobufPackage = "cline"
 
+/** Request to convert a list of URIs to relative paths */
+export interface RelativePathsRequest {
+	metadata?: Metadata | undefined
+	uris: string[]
+}
+
+/** Response containing the converted relative paths */
+export interface RelativePaths {
+	paths: string[]
+}
+
 /** Response for searchCommits */
 export interface GitCommits {
 	commits: GitCommit[]
@@ -43,6 +54,141 @@ export interface RuleFile {
 	displayName: string
 	/** For createRuleFile, indicates if file already existed */
 	alreadyExists: boolean
+}
+
+function createBaseRelativePathsRequest(): RelativePathsRequest {
+	return { metadata: undefined, uris: [] }
+}
+
+export const RelativePathsRequest: MessageFns<RelativePathsRequest> = {
+	encode(message: RelativePathsRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+		if (message.metadata !== undefined) {
+			Metadata.encode(message.metadata, writer.uint32(10).fork()).join()
+		}
+		for (const v of message.uris) {
+			writer.uint32(18).string(v!)
+		}
+		return writer
+	},
+
+	decode(input: BinaryReader | Uint8Array, length?: number): RelativePathsRequest {
+		const reader = input instanceof BinaryReader ? input : new BinaryReader(input)
+		let end = length === undefined ? reader.len : reader.pos + length
+		const message = createBaseRelativePathsRequest()
+		while (reader.pos < end) {
+			const tag = reader.uint32()
+			switch (tag >>> 3) {
+				case 1: {
+					if (tag !== 10) {
+						break
+					}
+
+					message.metadata = Metadata.decode(reader, reader.uint32())
+					continue
+				}
+				case 2: {
+					if (tag !== 18) {
+						break
+					}
+
+					message.uris.push(reader.string())
+					continue
+				}
+			}
+			if ((tag & 7) === 4 || tag === 0) {
+				break
+			}
+			reader.skip(tag & 7)
+		}
+		return message
+	},
+
+	fromJSON(object: any): RelativePathsRequest {
+		return {
+			metadata: isSet(object.metadata) ? Metadata.fromJSON(object.metadata) : undefined,
+			uris: globalThis.Array.isArray(object?.uris) ? object.uris.map((e: any) => globalThis.String(e)) : [],
+		}
+	},
+
+	toJSON(message: RelativePathsRequest): unknown {
+		const obj: any = {}
+		if (message.metadata !== undefined) {
+			obj.metadata = Metadata.toJSON(message.metadata)
+		}
+		if (message.uris?.length) {
+			obj.uris = message.uris
+		}
+		return obj
+	},
+
+	create<I extends Exact<DeepPartial<RelativePathsRequest>, I>>(base?: I): RelativePathsRequest {
+		return RelativePathsRequest.fromPartial(base ?? ({} as any))
+	},
+	fromPartial<I extends Exact<DeepPartial<RelativePathsRequest>, I>>(object: I): RelativePathsRequest {
+		const message = createBaseRelativePathsRequest()
+		message.metadata =
+			object.metadata !== undefined && object.metadata !== null ? Metadata.fromPartial(object.metadata) : undefined
+		message.uris = object.uris?.map((e) => e) || []
+		return message
+	},
+}
+
+function createBaseRelativePaths(): RelativePaths {
+	return { paths: [] }
+}
+
+export const RelativePaths: MessageFns<RelativePaths> = {
+	encode(message: RelativePaths, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+		for (const v of message.paths) {
+			writer.uint32(10).string(v!)
+		}
+		return writer
+	},
+
+	decode(input: BinaryReader | Uint8Array, length?: number): RelativePaths {
+		const reader = input instanceof BinaryReader ? input : new BinaryReader(input)
+		let end = length === undefined ? reader.len : reader.pos + length
+		const message = createBaseRelativePaths()
+		while (reader.pos < end) {
+			const tag = reader.uint32()
+			switch (tag >>> 3) {
+				case 1: {
+					if (tag !== 10) {
+						break
+					}
+
+					message.paths.push(reader.string())
+					continue
+				}
+			}
+			if ((tag & 7) === 4 || tag === 0) {
+				break
+			}
+			reader.skip(tag & 7)
+		}
+		return message
+	},
+
+	fromJSON(object: any): RelativePaths {
+		return { paths: globalThis.Array.isArray(object?.paths) ? object.paths.map((e: any) => globalThis.String(e)) : [] }
+	},
+
+	toJSON(message: RelativePaths): unknown {
+		const obj: any = {}
+		if (message.paths?.length) {
+			obj.paths = message.paths
+		}
+		return obj
+	},
+
+	create<I extends Exact<DeepPartial<RelativePaths>, I>>(base?: I): RelativePaths {
+		return RelativePaths.fromPartial(base ?? ({} as any))
+	},
+	fromPartial<I extends Exact<DeepPartial<RelativePaths>, I>>(object: I): RelativePaths {
+		const message = createBaseRelativePaths()
+		message.paths = object.paths?.map((e) => e) || []
+		return message
+	},
 }
 
 function createBaseGitCommits(): GitCommits {
@@ -478,6 +624,15 @@ export const FileServiceDefinition = {
 			requestType: StringRequest,
 			requestStream: false,
 			responseType: GitCommits,
+			responseStream: false,
+			options: {},
+		},
+		/** Convert URIs to workspace-relative paths */
+		getRelativePaths: {
+			name: "getRelativePaths",
+			requestType: RelativePathsRequest,
+			requestStream: false,
+			responseType: RelativePaths,
 			responseStream: false,
 			options: {},
 		},

--- a/webview-ui/src/components/chat/ChatTextArea.tsx
+++ b/webview-ui/src/components/chat/ChatTextArea.tsx
@@ -305,15 +305,6 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 		const handleMessage = useCallback((event: MessageEvent) => {
 			const message: ExtensionMessage = event.data
 			switch (message.type) {
-				case "relativePathsResponse": {
-					// New case for batch response
-					const validPaths = message.paths?.filter((path): path is string => !!path) || []
-					if (validPaths.length > 0) {
-						setPendingInsertions((prev) => [...prev, ...validPaths])
-					}
-					break
-				}
-
 				case "fileSearchResults": {
 					// Only update results if they match the current query or if there's no mentionsRequestId - better UX
 					if (!message.mentionsRequestId || message.mentionsRequestId === currentSearchQueryRef.current) {
@@ -1150,10 +1141,15 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 				}
 				setIntendedCursorPosition(initialCursorPos)
 
-				vscode.postMessage({
-					type: "getRelativePaths",
-					uris: validUris,
-				})
+				FileServiceClient.getRelativePaths({ uris: validUris })
+					.then((response) => {
+						if (response.paths.length > 0) {
+							setPendingInsertions((prev) => [...prev, ...response.paths])
+						}
+					})
+					.catch((error) => {
+						console.error("Error getting relative paths:", error)
+					})
 				return
 			}
 


### PR DESCRIPTION
### Description

This PR migrates the `getRelativePaths` message to the gRPC/Protobuf system. It consolidates the previous two-step message flow (`getRelativePaths` request and `relativePathsResponse` response) into a single gRPC method in the FileService.

### Test Procedure

This message is used when files are dragged and dropped from the VS Code Explorer view into the chat in Cline. Drag and drop (with shift) single/multiple files into the chat. Confirm that files are loaded into the chat, and that logging records the GRPC activity. 

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [X] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [X] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [X] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [X] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [X] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Migrates `getRelativePaths` to gRPC/Protobuf, updating path conversion logic in `ChatTextArea.tsx` and adding a new handler in `getRelativePaths.ts`.
> 
>   - **Behavior**:
>     - Migrates `getRelativePaths` to gRPC/Protobuf in `proto/file.proto`, consolidating request and response into `getRelativePaths` method.
>     - Updates `ChatTextArea.tsx` to use `FileServiceClient.getRelativePaths()` for URI to path conversion.
>   - **Controller**:
>     - Adds `getRelativePaths` handler in `getRelativePaths.ts` to convert URIs to workspace-relative paths.
>     - Registers `getRelativePaths` in `methods.ts`.
>   - **Cleanup**:
>     - Removes `getRelativePaths` handling from `Controller` class in `index.ts`.
>     - Removes `relativePathsResponse` and `getRelativePaths` message types from `ExtensionMessage.ts` and `WebviewMessage.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 195964430a20ff2afce4d13b8ddac4f466341d03. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->