### PR TITLE
Update gemini caching for open router and cline provider

### DIFF
--- a/.changeset/quiet-cups-tie.md
+++ b/.changeset/quiet-cups-tie.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": minor
+---
+
+updated gemini caching for OR and cline provider

--- a/src/api/transform/openrouter-stream.ts
+++ b/src/api/transform/openrouter-stream.ts
@@ -21,7 +21,7 @@ export async function createOpenRouterStream(
 
 	// prompt caching: https://openrouter.ai/docs/prompt-caching
 	// this was initially specifically for claude models (some models may 'support prompt caching' automatically without this)
-	// gemini models only use the last breakpoint for caching, so the others will be ignored
+	// includes custom support for gemini which does not have iterative caching
 	switch (model.id) {
 		case "anthropic/claude-3.7-sonnet":
 		case "anthropic/claude-3.7-sonnet:beta":
@@ -40,10 +40,6 @@ export async function createOpenRouterStream(
 		case "anthropic/claude-3-haiku:beta":
 		case "anthropic/claude-3-opus":
 		case "anthropic/claude-3-opus:beta":
-		case "google/gemini-2.5-pro-preview-03-25":
-		case "google/gemini-2.0-flash-001":
-		case "google/gemini-flash-1.5":
-		case "google/gemini-pro-1.5":
 			openAiMessages[0] = {
 				role: "system",
 				content: [
@@ -74,6 +70,52 @@ export async function createOpenRouterStream(
 					lastTextPart["cache_control"] = { type: "ephemeral" }
 				}
 			})
+			break
+		case "google/gemini-2.5-pro-preview-03-25":
+		case "google/gemini-2.0-flash-001":
+		case "google/gemini-flash-1.5":
+		case "google/gemini-pro-1.5":
+			// gemini only uses the last breakpoint for caching, so the others will be ignored
+			openAiMessages[0] = {
+				role: "system",
+				content: [
+					{
+						type: "text",
+						text: systemPrompt,
+						// @ts-ignore-next-line
+						cache_control: { type: "ephemeral" },
+					},
+				],
+			}
+
+			const GEMINI_CACHE_USER_MESSAGE_INTERVAL = 4 // add new breakpoint every 4 turns
+			const userMessages = openAiMessages.filter((msg) => msg.role === "user")
+
+			const userMessageCount = userMessages.length
+			const targetUserMessageNumber =
+				Math.floor(userMessageCount / GEMINI_CACHE_USER_MESSAGE_INTERVAL) * GEMINI_CACHE_USER_MESSAGE_INTERVAL
+
+			if (targetUserMessageNumber > 0) {
+				// otherwise dont need to add a breakpoint
+				const msg = userMessages[targetUserMessageNumber - 1]
+
+				if (msg) {
+					if (typeof msg.content === "string") {
+						msg.content = [{ type: "text", text: msg.content }]
+					}
+					if (Array.isArray(msg.content)) {
+						// NOTE: this is fine since env details will always be added at the end. but if it weren't there, and the user added a image_url type message, it would pop a text part before it and then move it after to the end.
+						let lastTextPart = msg.content.filter((part) => part.type === "text").pop()
+
+						if (!lastTextPart) {
+							lastTextPart = { type: "text", text: "..." }
+							msg.content.push(lastTextPart)
+						}
+						// @ts-ignore-next-line
+						lastTextPart["cache_control"] = { type: "ephemeral" }
+					}
+				}
+			}
 			break
 		default:
 			break


### PR DESCRIPTION
### Description

We space out the cache breakpoints, such that we only write to the cache once every 4 conversational turns. This better utilizes how the gemini cache works

### Test Procedure

Use a cache-enabled gemini model using open router. If you look at the cache metrics in the UI you will notice the increase in cache reads (diff) prior to the 4th conversation turn will be the same. Then it will increase by the number of tokens you included in those 4 conversation turns (its easier to see if you do some big file reads here).

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

### Additional Notes

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update Gemini model caching in `createOpenRouterStream` to add cache breakpoints every 4 user messages.
> 
>   - **Behavior**:
>     - Updates caching for Gemini models in `createOpenRouterStream` to add a cache breakpoint every 4 user messages.
>     - Affects models: `google/gemini-2.5-pro-preview-03-25`, `google/gemini-2.0-flash-001`, `google/gemini-flash-1.5`, `google/gemini-pro-1.5`.
>   - **Implementation**:
>     - Adds logic to calculate and apply cache control to the appropriate user message based on the new interval.
>     - Ensures only the last breakpoint is used for caching in Gemini models.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 9e8ebd33bbb9681f6edf63475dde10dd275e0a59. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->