### PR TITLE
Make previous updates a dropdown

### DIFF
--- a/.changeset/shy-goats-deliver.md
+++ b/.changeset/shy-goats-deliver.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Make Previous Updates in the Announcement a dropdown

--- a/webview-ui/src/components/chat/Announcement.tsx
+++ b/webview-ui/src/components/chat/Announcement.tsx
@@ -1,6 +1,7 @@
 import { VSCodeButton, VSCodeLink } from "@vscode/webview-ui-toolkit/react"
 import { CSSProperties, memo } from "react"
 import { getAsVar, VSC_DESCRIPTION_FOREGROUND, VSC_INACTIVE_SELECTION_BACKGROUND } from "@/utils/vscStyles"
+import { Accordion, AccordionItem } from "@heroui/react"
 
 interface AnnouncementProps {
 	version: string
@@ -60,24 +61,38 @@ const Announcement = ({ version, hideAnnouncement }: AnnouncementProps) => {
 				<li>Added more checkpoints across the task, allowing you to restore from more than just file changes.</li>
 				<li>Added support for rendering LaTeX in message responses. (Try asking Cline to show the quadratic formula)</li>
 			</ul>
-			{/* <h4 style={{ margin: "5px 0 5px" }}>Previous Updates:</h4>
-			<ul style={ulStyle}>
-				<li>
-					<b>Global Cline Rules:</b> store multiple rules files in Documents/Cline/Rules to share between projects.
-				</li>
-				<li>
-					<b>Cline Rules Popup:</b> New button in the chat area to view workspace and global cline rules files to plug
-					and play specific rules for the task
-				</li>
-				<li>
-					<b>Slash Commands:</b> Type <code>/</code> in chat to see the list of quick actions, like starting a new task
-					(more coming soon!)
-				</li>
-				<li>
-					<b>Edit Messages:</b> You can now edit a message you sent previously by clicking on it. Optionally restore
-					your project when the message was sent!
-				</li>
-			</ul> */}
+			<Accordion isCompact className="pl-0">
+				<AccordionItem
+					key="1"
+					aria-label="Previous Updates"
+					title="Previous Updates:"
+					classNames={{
+						trigger: "bg-transparent border-0 pl-0 pb-0 w-fit",
+						title: "font-bold text-[var(--vscode-foreground)]",
+						indicator:
+							"text-[var(--vscode-foreground)] mb-0.5 -rotate-180 data-[open=true]:-rotate-90 rtl:rotate-0 rtl:data-[open=true]:-rotate-90",
+					}}>
+					<ul style={ulStyle}>
+						<li>
+							<b>Global Cline Rules:</b> store multiple rules files in Documents/Cline/Rules to share between
+							projects.
+						</li>
+						<li>
+							<b>Cline Rules Popup:</b> New button in the chat area to view workspace and global cline rules files
+							to plug and play specific rules for the task
+						</li>
+						<li>
+							<b>Slash Commands:</b> Type <code>/</code> in chat to see the list of quick actions, like starting a
+							new task (more coming soon!)
+						</li>
+						<li>
+							<b>Edit Messages:</b> You can now edit a message you sent previously by clicking on it. Optionally
+							restore your project when the message was sent!
+						</li>
+					</ul>
+				</AccordionItem>
+			</Accordion>
+
 			{/*
 			// Leave this here for an example of how to structure the announcement
 			<ul style={{ margin: "0 0 8px", paddingLeft: "12px" }}>


### PR DESCRIPTION
### Description

<!-- Describe your changes in detail. What problem does this PR solve? -->

Previous updates was too big, this uses a HeroUI dropdown to hide the previous updates and allow you to read them if need be

### Test Procedure

<!-- How did you test this? Are you confident that it will not introduce bugs? If so, why? -->

Go to webview-ui/src/components/chat/ChatView.tsx:917 and replace `showAnnouncement &&` with `true &&`
Verify that dropdown works correctly

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [x] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

<img width="494" alt="Screenshot 2025-05-02 at 9 14 57 PM" src="https://github.com/user-attachments/assets/abb50d20-6e5f-4360-bb06-e9407d8b4e81" />
<img width="489" alt="Screenshot 2025-05-02 at 9 15 11 PM" src="https://github.com/user-attachments/assets/4900bab7-f696-4cd6-9c1d-b540956d4183" />

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Replaced static previous updates list with a dropdown in `Announcement.tsx` using `HeroUI` accordion.
> 
>   - **UI Update**:
>     - In `Announcement.tsx`, replaced static list of previous updates with a `HeroUI` `Accordion` to create a dropdown for previous updates.
>     - Dropdown is compact and styled to match existing UI.
>   - **Misc**:
>     - Added import for `Accordion` and `AccordionItem` from `@heroui/react` in `Announcement.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 27e384f1809e26c967f66f9b34b372b34932f560. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->