### PR TITLE
Fail the workflow on webview test errors

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -92,7 +92,7 @@ jobs:
                   cd webview-ui
                   # Ensure coverage dependency is installed
                   npm install --no-save @vitest/coverage-v8
-                  npm run test:coverage > webview_coverage.txt 2>&1 || true
+                  npm run test:coverage > webview_coverage.txt 2>&1
                   cd ..
                   PYTHONPATH=.github/scripts python -m coverage_check extract-coverage webview-ui/webview_coverage.txt --type=webview --github-output --verbose
 

--- a/webview-ui/src/components/chat/Announcement.tsx
+++ b/webview-ui/src/components/chat/Announcement.tsx
@@ -36,7 +36,7 @@ const Announcement = ({ version, hideAnnouncement }: AnnouncementProps) => {
 	const minorVersion = version.split(".").slice(0, 2).join(".") // 2.0.0 -> 2.0
 	return (
 		<div style={containerStyle}>
-			<VSCodeButton appearance="icon" onClick={hideAnnouncement} style={closeIconStyle}>
+			<VSCodeButton data-testid="close-button" appearance="icon" onClick={hideAnnouncement} style={closeIconStyle}>
 				<span className="codicon codicon-close"></span>
 			</VSCodeButton>
 			<h3 style={h3TitleStyle}>

--- a/webview-ui/src/components/chat/__tests__/Announcement.spec.tsx
+++ b/webview-ui/src/components/chat/__tests__/Announcement.spec.tsx
@@ -23,10 +23,4 @@ describe("Announcement", () => {
 		fireEvent.click(screen.getByRole("button"))
 		expect(hideAnnouncement).toHaveBeenCalled()
 	})
-
-	it("renders the enhanced MCP support announcement", () => {
-		render(<Announcement version="2.0.0" hideAnnouncement={hideAnnouncement} />)
-		// Updated text based on actual component output
-		expect(screen.getByText(/Enhanced MCP Support:/)).toBeInTheDocument()
-	})
 })

--- a/webview-ui/src/components/chat/__tests__/Announcement.spec.tsx
+++ b/webview-ui/src/components/chat/__tests__/Announcement.spec.tsx
@@ -20,7 +20,7 @@ describe("Announcement", () => {
 
 	it("calls hideAnnouncement when close button is clicked", () => {
 		render(<Announcement version="2.0.0" hideAnnouncement={hideAnnouncement} />)
-		fireEvent.click(screen.getByRole("button"))
+		fireEvent.click(screen.getByTestId("close-button"))
 		expect(hideAnnouncement).toHaveBeenCalled()
 	})
 })

--- a/webview-ui/src/components/settings/__tests__/APIOptions.spec.tsx
+++ b/webview-ui/src/components/settings/__tests__/APIOptions.spec.tsx
@@ -1,7 +1,8 @@
 import { render, screen, fireEvent } from "@testing-library/react"
 import { describe, it, expect, vi } from "vitest"
 import ApiOptions from "../ApiOptions"
-import { ExtensionStateContextProvider } from "@/context/ExtensionStateContext"
+import { ExtensionStateContextProvider, useExtensionState } from "@/context/ExtensionStateContext"
+import { ApiConfiguration } from "@shared/api"
 
 vi.mock("../../../context/ExtensionStateContext", async (importOriginal) => {
 	const actual = await importOriginal()
@@ -16,9 +17,19 @@ vi.mock("../../../context/ExtensionStateContext", async (importOriginal) => {
 			},
 			setApiConfiguration: vi.fn(),
 			uriScheme: "vscode",
+			requestyModels: {},
 		})),
 	}
 })
+
+const mockExtensionState = (apiConfiguration: Partial<ApiConfiguration>) => {
+	vi.mocked(useExtensionState).mockReturnValue({
+		apiConfiguration,
+		setApiConfiguration: vi.fn(),
+		uriScheme: "vscode",
+		requestyModels: {},
+	} as any)
+}
 
 describe("ApiOptions Component", () => {
 	vi.clearAllMocks()
@@ -27,6 +38,9 @@ describe("ApiOptions Component", () => {
 	beforeEach(() => {
 		//@ts-expect-error - vscode is not defined in the global namespace in test environment
 		global.vscode = { postMessage: mockPostMessage }
+		mockExtensionState({
+			apiProvider: "requesty",
+		})
 	})
 
 	it("renders Requesty API Key input", () => {
@@ -45,26 +59,9 @@ describe("ApiOptions Component", () => {
 				<ApiOptions showModelOptions={true} />
 			</ExtensionStateContextProvider>,
 		)
-		const modelIdInput = screen.getByPlaceholderText("Enter Model ID...")
+		const modelIdInput = screen.getByPlaceholderText("Search and select a model...")
 		expect(modelIdInput).toBeInTheDocument()
 	})
-})
-
-vi.mock("../../../context/ExtensionStateContext", async (importOriginal) => {
-	const actual = await importOriginal()
-	return {
-		...(actual || {}),
-		// your mocked methods
-		useExtensionState: vi.fn(() => ({
-			apiConfiguration: {
-				apiProvider: "together",
-				requestyApiKey: "",
-				requestyModelId: "",
-			},
-			setApiConfiguration: vi.fn(),
-			uriScheme: "vscode",
-		})),
-	}
 })
 
 describe("ApiOptions Component", () => {
@@ -74,6 +71,9 @@ describe("ApiOptions Component", () => {
 	beforeEach(() => {
 		//@ts-expect-error - vscode is not defined in the global namespace in test environment
 		global.vscode = { postMessage: mockPostMessage }
+		mockExtensionState({
+			apiProvider: "together",
+		})
 	})
 
 	it("renders Together API Key input", () => {
@@ -97,24 +97,6 @@ describe("ApiOptions Component", () => {
 	})
 })
 
-vi.mock("../../../context/ExtensionStateContext", async (importOriginal) => {
-	const actual = await importOriginal()
-	return {
-		...(actual || {}),
-		useExtensionState: vi.fn(() => ({
-			apiConfiguration: {
-				apiProvider: "fireworks",
-				fireworksApiKey: "",
-				fireworksModelId: "",
-				fireworksModelMaxCompletionTokens: 2000,
-				fireworksModelMaxTokens: 4000,
-			},
-			setApiConfiguration: vi.fn(),
-			uriScheme: "vscode",
-		})),
-	}
-})
-
 describe("ApiOptions Component", () => {
 	vi.clearAllMocks()
 	const mockPostMessage = vi.fn()
@@ -122,6 +104,14 @@ describe("ApiOptions Component", () => {
 	beforeEach(() => {
 		//@ts-expect-error - vscode is not defined in the global namespace in test environment
 		global.vscode = { postMessage: mockPostMessage }
+
+		mockExtensionState({
+			apiProvider: "fireworks",
+			fireworksApiKey: "",
+			fireworksModelId: "",
+			fireworksModelMaxCompletionTokens: 2000,
+			fireworksModelMaxTokens: 4000,
+		})
 	})
 
 	it("renders Fireworks API Key input", () => {
@@ -165,23 +155,6 @@ describe("ApiOptions Component", () => {
 	})
 })
 
-vi.mock("../../../context/ExtensionStateContext", async (importOriginal) => {
-	const actual = await importOriginal()
-	return {
-		...(actual || {}),
-		// your mocked methods
-		useExtensionState: vi.fn(() => ({
-			apiConfiguration: {
-				apiProvider: "openai",
-				requestyApiKey: "",
-				requestyModelId: "",
-			},
-			setApiConfiguration: vi.fn(),
-			uriScheme: "vscode",
-		})),
-	}
-})
-
 describe("OpenApiInfoOptions", () => {
 	const mockPostMessage = vi.fn()
 
@@ -189,6 +162,9 @@ describe("OpenApiInfoOptions", () => {
 		vi.clearAllMocks()
 		//@ts-expect-error - vscode is not defined in the global namespace in test environment
 		global.vscode = { postMessage: mockPostMessage }
+		mockExtensionState({
+			apiProvider: "openai",
+		})
 	})
 
 	it("renders OpenAI Supports Images input", () => {


### PR DESCRIPTION
### Description

On a recent PR, we introduced failures for [integration tests](https://github.com/cline/cline/pull/3197). However, I missed webview issues.

Recently, working on running [tests on Windows](https://github.com/cline/cline/pull/3246) I noticed a webview test is failing. This PR removes the failing test because it's no longer relevant and removes the code to ignore the test failure.

### Test Procedure

You can see the pipeline is green despite removing the code ignoring the test failure.

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [x] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)
