### PR TITLE
style: Move `Use different models for Plan and Act modes` checkbox to top, for better UIUX

### DIFF
--- a/.changeset/swift-kids-accept.md
+++ b/.changeset/swift-kids-accept.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Move `Use different models for Plan and Act modes` checkbox to top, for better UIUX

--- a/webview-ui/src/components/settings/SettingsView.tsx
+++ b/webview-ui/src/components/settings/SettingsView.tsx
@@ -155,6 +155,21 @@ const SettingsView = ({ onDone }: SettingsViewProps) => {
 				<VSCodeButton onClick={() => handleSubmit(false)}>Save</VSCodeButton>
 			</div>
 			<div className="grow overflow-y-scroll pr-2 flex flex-col">
+				<div className="mb-[5px]">
+					<VSCodeCheckbox
+						className="mb-[5px]"
+						checked={planActSeparateModelsSetting}
+						onChange={(e: any) => {
+							const checked = e.target.checked === true
+							setPlanActSeparateModelsSetting(checked)
+						}}>
+						Use different models for Plan and Act modes
+					</VSCodeCheckbox>
+					<p className="text-xs mt-[5px] text-[var(--vscode-descriptionForeground)]">
+						Switching between Plan and Act mode will persist the API and model used in the previous mode. This may be
+						helpful e.g. when using a strong reasoning model to architect a plan for a cheaper coding model to act on.
+					</p>
+				</div>
 				{/* Tabs container */}
 				{planActSeparateModelsSetting ? (
 					<div className="border border-solid border-[var(--vscode-panel-border)] rounded-md p-[10px] mb-5 bg-[var(--vscode-panel-background)]">
@@ -204,22 +219,6 @@ const SettingsView = ({ onDone }: SettingsViewProps) => {
 						</p>
 					</div>
 				)}
-
-				<div className="mb-[5px]">
-					<VSCodeCheckbox
-						className="mb-[5px]"
-						checked={planActSeparateModelsSetting}
-						onChange={(e: any) => {
-							const checked = e.target.checked === true
-							setPlanActSeparateModelsSetting(checked)
-						}}>
-						Use different models for Plan and Act modes
-					</VSCodeCheckbox>
-					<p className="text-xs mt-[5px] text-[var(--vscode-descriptionForeground)]">
-						Switching between Plan and Act mode will persist the API and model used in the previous mode. This may be
-						helpful e.g. when using a strong reasoning model to architect a plan for a cheaper coding model to act on.
-					</p>
-				</div>
 
 				<div className="mb-[5px]">
 					<VSCodeCheckbox


### PR DESCRIPTION
### Description

Move the `Use different models for Plan and Act modes` checkbox to the top, so that people won't confused about `Custom Instructions` can not be set separately for Plan and Act modes.

Solves https://github.com/cline/cline/issues/2753

### Test Procedure

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [x] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Before
![1746323235275](https://github.com/user-attachments/assets/6b79a1dc-3288-4b4e-a0d8-c1ef7d999fd6)

After
![After](https://github.com/user-attachments/assets/ced3ae5e-657c-4f81-a0a2-472135d152e4)

### Additional Notes

<!-- Add any additional notes for reviewers -->
