### PR TITLE
Allow for multiple dev server instances

### DIFF
--- a/src/core/webview/index.ts
+++ b/src/core/webview/index.ts
@@ -249,7 +249,7 @@ export class WebviewProvider implements vscode.WebviewViewProvider {
 		return readFile(portFilePath, "utf8")
 			.then((portFile) => {
 				const port = parseInt(portFile.trim())
-				console.info(`[getDevServerPort] Using dev server port from file: ${port}`)
+				console.info(`[getDevServerPort] Using dev server port ${port} from .vite-port file`)
 
 				return port
 			})

--- a/src/core/webview/index.ts
+++ b/src/core/webview/index.ts
@@ -244,8 +244,7 @@ export class WebviewProvider implements vscode.WebviewViewProvider {
 	private getDevServerPort(): Promise<number> {
 		const DEFAULT_PORT = 25463
 
-		const projectRoot = path.resolve(__dirname, "../../..")
-		const portFilePath = path.join(projectRoot, "webview-ui", ".vite-port")
+		const portFilePath = path.join(__dirname, "..", "webview-ui", ".vite-port")
 
 		return readFile(portFilePath, "utf8")
 			.then((portFile) => {

--- a/src/core/webview/index.ts
+++ b/src/core/webview/index.ts
@@ -248,7 +248,7 @@ export class WebviewProvider implements vscode.WebviewViewProvider {
 
 		return readFile(portFilePath, "utf8")
 			.then((portFile) => {
-				const port = parseInt(portFile.trim())
+				const port = parseInt(portFile.trim()) || DEFAULT_PORT
 				console.info(`[getDevServerPort] Using dev server port ${port} from .vite-port file`)
 
 				return port

--- a/src/core/webview/index.ts
+++ b/src/core/webview/index.ts
@@ -5,6 +5,9 @@ import { getUri } from "./getUri"
 import { getTheme } from "@integrations/theme/getTheme"
 import { Controller } from "@core/controller/index"
 import { findLast } from "@shared/array"
+import { readFile } from "fs/promises"
+import path from "node:path"
+
 /*
 https://github.com/microsoft/vscode-webview-ui-toolkit-samples/blob/main/default/weather-webview/src/providers/WeatherViewProvider.ts
 https://github.com/KumarVariable/vscode-extension-sidebar-html/blob/master/src/customSidebarViewProvider.ts
@@ -234,6 +237,29 @@ export class WebviewProvider implements vscode.WebviewViewProvider {
 	}
 
 	/**
+	 * Reads the Vite dev server port from the generated port file to avoid conflicts
+	 * Returns a Promise that resolves to the port number
+	 * If the file doesn't exist or can't be read, it resolves to the default port
+	 */
+	private getDevServerPort(): Promise<number> {
+		const DEFAULT_PORT = 25463
+
+		const projectRoot = path.resolve(__dirname, "../../..")
+		const portFilePath = path.join(projectRoot, "webview-ui", ".vite-port")
+
+		return readFile(portFilePath, "utf8")
+			.then((portFile) => {
+				const port = parseInt(portFile.trim(), 10)
+				console.info(`[getDevServerPort] Using dev server port from file: ${port}`)
+				return port
+			})
+			.catch((err) => {
+				console.warn(`[getDevServerPort] Port file not found or couldn't be read, using default port: ${DEFAULT_PORT}`)
+				return DEFAULT_PORT
+			})
+	}
+
+	/**
 	 * Connects to the local Vite dev server to allow HMR, with fallback to the bundled assets
 	 *
 	 * @param webview A reference to the extension webview
@@ -241,7 +267,7 @@ export class WebviewProvider implements vscode.WebviewViewProvider {
 	 * rendered within the webview panel
 	 */
 	private async getHMRHtmlContent(webview: vscode.Webview): Promise<string> {
-		const localPort = 25463
+		const localPort = await this.getDevServerPort()
 		const localServerUrl = `localhost:${localPort}`
 
 		// Check if local dev server is running.

--- a/src/core/webview/index.ts
+++ b/src/core/webview/index.ts
@@ -249,12 +249,15 @@ export class WebviewProvider implements vscode.WebviewViewProvider {
 
 		return readFile(portFilePath, "utf8")
 			.then((portFile) => {
-				const port = parseInt(portFile.trim(), 10)
+				const port = parseInt(portFile.trim())
 				console.info(`[getDevServerPort] Using dev server port from file: ${port}`)
+
 				return port
 			})
 			.catch((err) => {
-				console.warn(`[getDevServerPort] Port file not found or couldn't be read, using default port: ${DEFAULT_PORT}`)
+				console.warn(
+					`[getDevServerPort] Port file not found or couldn't be read at ${portFilePath}, using default port: ${DEFAULT_PORT}`,
+				)
 				return DEFAULT_PORT
 			})
 	}

--- a/webview-ui/.gitignore
+++ b/webview-ui/.gitignore
@@ -13,6 +13,7 @@ dist-ssr
 build
 *.local
 coverage
+.vite-port
 
 # Environment
 .env

--- a/webview-ui/vite.config.ts
+++ b/webview-ui/vite.config.ts
@@ -1,12 +1,33 @@
 /// <reference types="vitest/config" />
 
-import { defineConfig } from "vite"
+import { defineConfig, ViteDevServer, type Plugin } from "vite"
 import tailwindcss from "@tailwindcss/vite"
 import react from "@vitejs/plugin-react-swc"
 import { resolve } from "path"
+import { writeFileSync } from "node:fs"
+
+// Custom plugin to write the server port to a file
+const writePortToFile = (): Plugin => {
+	return {
+		name: "write-port-to-file",
+		configureServer(server: ViteDevServer) {
+			server.httpServer?.once("listening", () => {
+				const address = server.httpServer?.address()
+				const port = typeof address === "object" && address ? address.port : null
+
+				if (port) {
+					const portFilePath = resolve(__dirname, ".vite-port")
+					writeFileSync(portFilePath, port.toString())
+				} else {
+					console.warn("[writePortToFile] Could not determine server port")
+				}
+			})
+		},
+	}
+}
 
 export default defineConfig({
-	plugins: [react(), tailwindcss()],
+	plugins: [react(), tailwindcss(), writePortToFile()],
 	test: {
 		environment: "jsdom",
 		globals: true,
@@ -18,6 +39,7 @@ export default defineConfig({
 	},
 	build: {
 		outDir: "build",
+		reportCompressedSize: false,
 		rollupOptions: {
 			output: {
 				inlineDynamicImports: true,


### PR DESCRIPTION
### Description

<!-- Describe your changes in detail. What problem does this PR solve? -->

This allows for running the Extension Development Host across multiple VSCode workspaces. I do this so I can keep my current task open, and test PRs in another workspace with the cline repo open without having to constantly stash and switch branches. 

This means when another vite instance says 
"Port 25463 is in use, trying another one..."
and uses 25464 instead, this will make it so it reliably detects that in the extension, and you don't have to shut down the first instance

### Test Procedure

<!-- How did you test this? Are you confident that it will not introduce bugs? If so, why? -->

Have Cline repo in setup two workspaces, and run the dev server on both of them, they should now no longer conflict and if you make a visible webview change in one of the instances, it should show up only in that instance

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Enable multiple dev server instances by dynamically determining Vite server port from a file, preventing conflicts across VSCode workspaces.
> 
>   - **Behavior**:
>     - `WebviewProvider` in `index.ts` now reads Vite dev server port from `.vite-port` file using `getDevServerPort()`.
>     - If `.vite-port` is missing or unreadable, defaults to port 25463.
>     - `vite.config.ts` includes a plugin `writePortToFile` to write the server port to `.vite-port`.
>   - **Configuration**:
>     - Adds `.vite-port` to `.gitignore` to prevent it from being tracked.
>   - **Misc**:
>     - Updates `vite.config.ts` to include `writePortToFile` plugin in the Vite configuration.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 6b86211279bda961ec34bb07f4f61fe24ec2c1b5. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->