### PR TITLE
Add audio type to McpToolCallResponse

### DIFF
--- a/src/shared/mcp.ts
+++ b/src/shared/mcp.ts
@@ -58,6 +58,11 @@ export type McpToolCallResponse = {
 				mimeType: string
 		  }
 		| {
+				type: "audio"
+				data: string
+				mimeType: string
+		  }
+		| {
 				type: "resource"
 				resource: {
 					uri: string


### PR DESCRIPTION
### Description

This allows me to build the package against `@modelcontextprotocol/sdk` at version `1.11.0`. Note that the new version adds the `audio` type: https://github.com/modelcontextprotocol/modelcontextprotocol/blob/78bdd7befad9f329195138428ec22e81018ca6c7/schema/draft/schema.ts#L990

Without this, the code wouldn't compile, raising this error

```
src/services/mcp/McpHub.ts:636:3 - error TS2322: Type 'objectOutputType<{ _meta: ZodOptional<ZodObject<{}, "passthrough", ZodTypeAny, objectOutputType<{}, ZodTypeAny, "passthrough">, objectInputType<{}, ZodTypeAny, "passthrough">>>; } & { ...; }, ZodTypeAny, "passthrough">' is not assignable to type 'McpToolCallResponse'.
  Types of property 'content' are incompatible.
    Type '(objectOutputType<{ type: ZodLiteral<"text">; text: ZodString; }, ZodTypeAny, "passthrough"> | objectOutputType<{ type: ZodLiteral<"image">; data: ZodString; mimeType: ZodString; }, ZodTypeAny, "passthrough"> | objectOutputType<...> | objectOutputType<...>)[]' is not assignable to type '({ type: "text"; text: string; } | { type: "image"; data: string; mimeType: string; } | { type: "resource"; resource: { uri: string; mimeType?: string | undefined; text?: string | undefined; blob?: string | undefined; }; })[]'.
      Type 'objectOutputType<{ type: ZodLiteral<"text">; text: ZodString; }, ZodTypeAny, "passthrough"> | objectOutputType<{ type: ZodLiteral<"image">; data: ZodString; mimeType: ZodString; }, ZodTypeAny, "passthrough"> | objectOutputType<...> | objectOutputType<...>' is not assignable to type '{ type: "text"; text: string; } | { type: "image"; data: string; mimeType: string; } | { type: "resource"; resource: { uri: string; mimeType?: string | undefined; text?: string | undefined; blob?: string | undefined; }; }'.
        Type 'objectOutputType<{ type: ZodLiteral<"audio">; data: ZodString; mimeType: ZodString; }, ZodTypeAny, "passthrough">' is not assignable to type '{ type: "text"; text: string; } | { type: "image"; data: string; mimeType: string; } | { type: "resource"; resource: { uri: string; mimeType?: string | undefined; text?: string | undefined; blob?: string | undefined; }; }'.
          Type 'objectOutputType<{ type: ZodLiteral<"audio">; data: ZodString; mimeType: ZodString; }, ZodTypeAny, "passthrough">' is not assignable to type '{ type: "image"; data: string; mimeType: string; }'.
            Types of property 'type' are incompatible.
              Type '"audio"' is not assignable to type '"image"'.

636   return await connection.client.request(
      ~~~~~~
```

### Test Procedure

It builds on my machine and doesn't change the code functionality in any way, just the type declaration.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `audio` type to `McpToolCallResponse` in `src/shared/mcp.ts` for compatibility with `@modelcontextprotocol/sdk` v1.11.0.
> 
>   - **Type Definition**:
>     - Add `audio` type to `McpToolCallResponse` in `src/shared/mcp.ts` to support `audio` content type.
>   - **Compatibility**:
>     - Allows building against `@modelcontextprotocol/sdk` version `1.11.0` by resolving type mismatch errors.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for f419620c3dbe2e94685e34e62a66b5ea58499599. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->