### PR TITLE
revering back to diff edit v1

### DIFF
--- a/src/core/assistant-message/diff.ts
+++ b/src/core/assistant-message/diff.ts
@@ -204,7 +204,7 @@ export async function constructNewFileContent(
 	diffContent: string,
 	originalContent: string,
 	isFinal: boolean,
-	version: "v1" | "v2" = "v2",
+	version: "v1" | "v2" = "v1",
 ): Promise<string> {
 	const constructor = constructNewFileContentVersionMapping[version]
 	if (!constructor) {


### PR DESCRIPTION
### Description

In posthog we saw more diff edit failures since we swapped to v2 (https://github.com/cline/cline/pull/2334). Let's swap back to v1 and monitor the situation cc @chi-cat 

![image](https://github.com/user-attachments/assets/94b03534-91cf-4692-989a-5eec76055add)

### Test Procedure

<!-- How did you test this? Are you confident that it will not introduce bugs? If so, why? -->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

### Additional Notes

<!-- Add any additional notes for reviewers -->
