### PR TITLE
Reading Shift key hold detection for file drop in ChatTextArea component

### DIFF
--- a/.changeset/strange-baboons-repeat.md
+++ b/.changeset/strange-baboons-repeat.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Readding Shift Key hold detection for file drop in ChatTextArea component

--- a/webview-ui/src/components/chat/ChatTextArea.tsx
+++ b/webview-ui/src/components/chat/ChatTextArea.tsx
@@ -1048,15 +1048,12 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 				}
 			}
 
-			// Add listeners
 			window.addEventListener("keydown", handleKeyDown)
 			window.addEventListener("keyup", handleKeyUp)
 
-			// Cleanup listeners on component unmount
 			return () => {
 				window.removeEventListener("keydown", handleKeyDown)
 				window.removeEventListener("keyup", handleKeyUp)
-				// Clear any running timer on unmount
 				if (shiftHoldTimerRef.current !== null) {
 					clearTimeout(shiftHoldTimerRef.current)
 				}
@@ -1509,7 +1506,6 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 							minWidth: 0,
 							height: "28px", // Fixed height to prevent container shrinking
 						}}>
-						{/* ButtonGroup - always in DOM but visibility controlled */}
 						<ButtonGroup
 							style={{
 								opacity: showShiftDragTip ? 0 : 1,

--- a/webview-ui/src/components/chat/ChatTextArea.tsx
+++ b/webview-ui/src/components/chat/ChatTextArea.tsx
@@ -268,6 +268,7 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 		const [menuPosition, setMenuPosition] = useState(0)
 		const [shownTooltipMode, setShownTooltipMode] = useState<ChatSettings["mode"] | null>(null)
 		const [pendingInsertions, setPendingInsertions] = useState<string[]>([])
+		const [showShiftDragTip, setShowShiftDragTip] = useState(false)
 		const shiftHoldTimerRef = useRef<NodeJS.Timeout | null>(null)
 		const [showUnsupportedFileError, setShowUnsupportedFileError] = useState(false)
 		const unsupportedFileTimerRef = useRef<NodeJS.Timeout | null>(null)
@@ -1023,6 +1024,45 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 			}
 		}, [showModelSelector])
 
+		// Effect for Shift key hold detection
+		useEffect(() => {
+			const handleKeyDown = (event: KeyboardEvent) => {
+				if (event.key === "Shift" && !event.repeat) {
+					// Start timer only if Shift is pressed and not already held down
+					if (shiftHoldTimerRef.current === null) {
+						shiftHoldTimerRef.current = setTimeout(() => {
+							setShowShiftDragTip(true)
+						}, 250) // 250ms delay
+					}
+				}
+			}
+
+			const handleKeyUp = (event: KeyboardEvent) => {
+				if (event.key === "Shift") {
+					// Clear timer and hide tip when Shift is released
+					if (shiftHoldTimerRef.current !== null) {
+						clearTimeout(shiftHoldTimerRef.current)
+						shiftHoldTimerRef.current = null
+					}
+					setShowShiftDragTip(false)
+				}
+			}
+
+			// Add listeners
+			window.addEventListener("keydown", handleKeyDown)
+			window.addEventListener("keyup", handleKeyUp)
+
+			// Cleanup listeners on component unmount
+			return () => {
+				window.removeEventListener("keydown", handleKeyDown)
+				window.removeEventListener("keyup", handleKeyUp)
+				// Clear any running timer on unmount
+				if (shiftHoldTimerRef.current !== null) {
+					clearTimeout(shiftHoldTimerRef.current)
+				}
+			}
+		}, []) // Empty dependency array ensures this runs only once on mount/unmount
+
 		// Function to show error message for unsupported files for drag and drop
 		const showUnsupportedFileErrorMessage = () => {
 			// Show error message for unsupported files
@@ -1472,14 +1512,17 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 						{/* ButtonGroup - always in DOM but visibility controlled */}
 						<ButtonGroup
 							style={{
+								opacity: showShiftDragTip ? 0 : 1,
+								pointerEvents: showShiftDragTip ? "none" : "auto",
 								position: "absolute",
 								top: 0,
 								left: 0,
 								right: 0,
 								transition: "opacity 0.3s ease-in-out",
+								transitionDelay: showShiftDragTip ? "0s" : "0.2s",
 								width: "100%",
 								height: "100%",
-								zIndex: 6,
+								zIndex: showShiftDragTip ? 0 : 6,
 							}}>
 							<Tooltip tipText="Add Context" style={{ left: 0 }}>
 								<VSCodeButton
@@ -1549,6 +1592,36 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 								)}
 							</ModelContainer>
 						</ButtonGroup>
+
+						{/* Shift Tip - always in DOM but visibility controlled */}
+						<div
+							style={{
+								display: "flex",
+								justifyContent: "flex-start", // Left align horizontally
+								alignItems: "center", // Center vertically
+								height: "100%", // Fill the container height
+								padding: "4px 0", // Add padding to match button group height
+								boxSizing: "border-box", // Include padding in height calculation
+								opacity: showShiftDragTip ? 1 : 0,
+								pointerEvents: showShiftDragTip ? "auto" : "none",
+								position: "absolute",
+								top: 0,
+								left: 0,
+								right: 0,
+								transition: "opacity 0.3s ease-in-out",
+								transitionDelay: showShiftDragTip ? "0.2s" : "0s",
+								width: "100%",
+								zIndex: showShiftDragTip ? 1 : 0,
+							}}>
+							<span
+								style={{
+									fontSize: "10px",
+									color: "var(--vscode-descriptionForeground)",
+									whiteSpace: "nowrap",
+								}}>
+								Hold Shift to Drop Files
+							</span>
+						</div>
 					</div>
 					{/* Tooltip for Plan/Act toggle remains outside the conditional rendering */}
 					<Tooltip


### PR DESCRIPTION
Fixes -> https://github.com/cline/cline/pull/3241 

### Description
Title says it all 

Previously we faced issues with showing the hint of shift key because of erroneous Z index but now I have fixed that 

### Test Procedure

Press shift key above type your task and you will see

<img width="436" alt="image" src="https://github.com/user-attachments/assets/b6776ff3-2abc-4eaf-a3d6-ddbd44dd0afe" />

Make sure that all the buttons below the text box work perfectly by clicking on them. 
<img width="333" alt="image" src="https://github.com/user-attachments/assets/c9d9cae1-af8a-49ac-a1ac-7ed20b2732e9" />



### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [X] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [X] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [X] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [X] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [X] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Reintroduces Shift key detection in `ChatTextArea.tsx` to show a file drop hint, with UI adjustments for smooth transitions.
> 
>   - **Behavior**:
>     - Reintroduces Shift key hold detection in `ChatTextArea.tsx` to show a hint for file drop.
>     - Adds `showShiftDragTip` state to manage hint visibility.
>     - Listens for `keydown` and `keyup` events to toggle hint visibility.
>   - **UI Changes**:
>     - Adjusts `ButtonGroup` and hint opacity and z-index for smooth transitions.
>     - Displays "Hold Shift to Drop Files" hint when Shift is held.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for d2fc589b4437211d6165ecadedbaa1ecd010d456. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->