### PR TITLE
Breakpoint just in first user message for gemini for OR and cline provider

### DIFF
--- a/.changeset/happy-radios-enjoy.md
+++ b/.changeset/happy-radios-enjoy.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": minor
+---
+
+breakpoint just in system prompt for gemini for OR and cline provider

--- a/src/api/transform/openrouter-stream.ts
+++ b/src/api/transform/openrouter-stream.ts
@@ -88,7 +88,8 @@ export async function createOpenRouterStream(
 				],
 			}
 
-			const GEMINI_CACHE_USER_MESSAGE_INTERVAL = 4 // add new breakpoint every 4 turns
+			// it doesn't make sense to alter breakpoints at all with the gemini cache implementation at this time
+			/*const GEMINI_CACHE_USER_MESSAGE_INTERVAL = 4 // add new breakpoint every 4 turns
 			const userMessages = openAiMessages.filter((msg) => msg.role === "user")
 
 			const userMessageCount = userMessages.length
@@ -115,7 +116,7 @@ export async function createOpenRouterStream(
 						lastTextPart["cache_control"] = { type: "ephemeral" }
 					}
 				}
-			}
+			}*/
 			break
 		default:
 			break

--- a/src/api/transform/openrouter-stream.ts
+++ b/src/api/transform/openrouter-stream.ts
@@ -88,6 +88,28 @@ export async function createOpenRouterStream(
 				],
 			}
 
+			// for safety, but this should always be the case
+			if (openAiMessages.length >= 2) {
+				const msg = openAiMessages[1]
+
+				if (msg) {
+					if (typeof msg.content === "string") {
+						msg.content = [{ type: "text", text: msg.content }]
+					}
+					if (Array.isArray(msg.content)) {
+						// NOTE: this is fine since env details will always be added at the end. but if it weren't there, and the user added a image_url type message, it would pop a text part before it and then move it after to the end.
+						let lastTextPart = msg.content.filter((part) => part.type === "text").pop()
+
+						if (!lastTextPart) {
+							lastTextPart = { type: "text", text: "..." }
+							msg.content.push(lastTextPart)
+						}
+						// @ts-ignore-next-line
+						lastTextPart["cache_control"] = { type: "ephemeral" }
+					}
+				}
+			}
+
 			// it doesn't make sense to alter breakpoints at all with the gemini cache implementation at this time
 			/*const GEMINI_CACHE_USER_MESSAGE_INTERVAL = 4 // add new breakpoint every 4 turns
 			const userMessages = openAiMessages.filter((msg) => msg.role === "user")


### PR DESCRIPTION
### Description

Breakpoint now just in first user message for gemini for OR and cline provider

### Test Procedure

Use a gemini model on OR/cline provider and compare the cost

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

### Additional Notes

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adjusts `createOpenRouterStream` to set breakpoints only in the system prompt for Gemini models on OR and cline providers.
> 
>   - **Behavior**:
>     - Adjusts `createOpenRouterStream` in `openrouter-stream.ts` to set breakpoints only in the system prompt for Gemini models on OR and cline providers.
>     - Removes logic for altering breakpoints during message processing for Gemini models.
>   - **Misc**:
>     - Adds a changeset file `happy-radios-enjoy.md` to document the change.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 4dd6f852b02a98ea9fb9f5cd9fae070b2e5ec027. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->