### PR TITLE
feat: add gemini-2.5-pro-preview-05-06 model

### DIFF
--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -449,26 +449,6 @@ export const vertexModels = {
 			},
 		],
 	},
-	"gemini-2.5-pro-preview-03-25": {
-		maxTokens: 65536,
-		contextWindow: 1_048_576,
-		supportsImages: true,
-		supportsPromptCache: true,
-		inputPrice: 2.5,
-		outputPrice: 15,
-		tiers: [
-			{
-				contextWindow: 200000,
-				inputPrice: 1.25,
-				outputPrice: 10,
-			},
-			{
-				contextWindow: Infinity,
-				inputPrice: 2.5,
-				outputPrice: 15,
-			},
-		],
-	},
 	"gemini-2.5-flash-preview-04-17": {
 		maxTokens: 65536,
 		contextWindow: 1_048_576,
@@ -596,30 +576,6 @@ export const geminiModels = {
 				contextWindow: Infinity,
 				inputPrice: 2.5,
 				outputPrice: 15,
-			},
-		],
-	},
-	"gemini-2.5-pro-preview-03-25": {
-		maxTokens: 65536,
-		contextWindow: 1_048_576,
-		supportsImages: true,
-		supportsPromptCache: true,
-		inputPrice: 2.5, // Default price (highest tier)
-		outputPrice: 15, // Default price (highest tier)
-		cacheReadsPrice: 0.625,
-		cacheWritesPrice: 4.5,
-		tiers: [
-			{
-				contextWindow: 200000,
-				inputPrice: 1.25,
-				outputPrice: 10,
-				cacheReadsPrice: 0.31,
-			},
-			{
-				contextWindow: Infinity,
-				inputPrice: 2.5,
-				outputPrice: 15,
-				cacheReadsPrice: 0.625,
 			},
 		],
 	},

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -429,6 +429,26 @@ export const vertexModels = {
 		inputPrice: 0,
 		outputPrice: 0,
 	},
+	"gemini-2.5-pro-preview-05-06": {
+		maxTokens: 65536,
+		contextWindow: 1_048_576,
+		supportsImages: true,
+		supportsPromptCache: true,
+		inputPrice: 2.5,
+		outputPrice: 15,
+		tiers: [
+			{
+				contextWindow: 200000,
+				inputPrice: 1.25,
+				outputPrice: 10,
+			},
+			{
+				contextWindow: Infinity,
+				inputPrice: 2.5,
+				outputPrice: 15,
+			},
+		],
+	},
 	"gemini-2.5-pro-preview-03-25": {
 		maxTokens: 65536,
 		contextWindow: 1_048_576,
@@ -558,6 +578,26 @@ export const geminiModels = {
 		supportsPromptCache: false,
 		inputPrice: 0,
 		outputPrice: 0,
+	},
+	"gemini-2.5-pro-preview-05-06": {
+		maxTokens: 65536,
+		contextWindow: 1_048_576,
+		supportsImages: true,
+		supportsPromptCache: true,
+		inputPrice: 2.5,
+		outputPrice: 15,
+		tiers: [
+			{
+				contextWindow: 200000,
+				inputPrice: 1.25,
+				outputPrice: 10,
+			},
+			{
+				contextWindow: Infinity,
+				inputPrice: 2.5,
+				outputPrice: 15,
+			},
+		],
 	},
 	"gemini-2.5-pro-preview-03-25": {
 		maxTokens: 65536,


### PR DESCRIPTION
### Description

Adds the new `gemini-2.5-pro-preview-05-06` and removes the `gemini-2.5-pro-preview-03-25` model to the `vertexModels` and `geminiModels` objects in `src/shared/api.ts`. This includes the model's `maxTokens`, `contextWindow`, `supportsImages`, `supportsPromptCache`, `inputPrice`, `outputPrice`, and tiered pricing information.

### Test Procedure

Manually verified that the new model is present in the `src/shared/api.ts` file after applying the changes. The pre-commit hooks for linting and formatting passed successfully.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update)
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->
N/A (No UI changes)

### Additional Notes

<!-- Add any additional notes for reviewers -->
This PR adds support for the latest Gemini preview model.