### PR TITLE
Improve time display and filter out resume_task in Task Timeline

### DIFF
--- a/.changeset/smart-otters-admire.md
+++ b/.changeset/smart-otters-admire.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+timestamp visualization

--- a/webview-ui/src/components/chat/TaskHeader.tsx
+++ b/webview-ui/src/components/chat/TaskHeader.tsx
@@ -353,7 +353,7 @@ const TaskHeader: React.FC<TaskHeaderProps> = ({
 							style={{
 								display: "flex",
 								flexDirection: "column",
-								gap: "4px",
+								gap: "2px",
 							}}>
 							<div
 								style={{

--- a/webview-ui/src/components/chat/TaskHeader.tsx
+++ b/webview-ui/src/components/chat/TaskHeader.tsx
@@ -399,18 +399,18 @@ const TaskHeader: React.FC<TaskHeaderProps> = ({
 										</span>
 									</HeroTooltip>
 								</div>
+								{!shouldShowPromptCacheInfo() && (
+									<DeleteButton taskSize={formatSize(currentTaskItem?.size)} taskId={currentTaskItem?.id} />
+								)}
 							</div>
-							<div
-								style={{
-									display: "flex",
-									justifyContent: "space-between",
-									alignItems: "center",
-									flexWrap: "wrap",
-								}}>
-								{
-									!shouldShowPromptCacheInfo() && <div /> // Placeholder for spacing}
-								}
-								{shouldShowPromptCacheInfo() && (
+							{shouldShowPromptCacheInfo() && (
+								<div
+									style={{
+										display: "flex",
+										justifyContent: "space-between",
+										alignItems: "center",
+										flexWrap: "wrap",
+									}}>
 									<div
 										style={{
 											display: "flex",
@@ -452,9 +452,9 @@ const TaskHeader: React.FC<TaskHeaderProps> = ({
 											</HeroTooltip>
 										)}
 									</div>
-								)}
-								<DeleteButton taskSize={formatSize(currentTaskItem?.size)} taskId={currentTaskItem?.id} />
-							</div>
+									<DeleteButton taskSize={formatSize(currentTaskItem?.size)} taskId={currentTaskItem?.id} />
+								</div>
+							)}
 							<div className="flex flex-col">
 								<TaskTimeline messages={clineMessages} />
 								{ContextWindowComponent}

--- a/webview-ui/src/components/chat/TaskHeader.tsx
+++ b/webview-ui/src/components/chat/TaskHeader.tsx
@@ -156,18 +156,6 @@ const TaskHeader: React.FC<TaskHeaderProps> = ({
 						style={{
 							display: "flex",
 							alignItems: "center",
-							gap: "4px",
-							flexShrink: 0, // Prevents shrinking
-						}}>
-						<span style={{ fontWeight: "bold" }}>
-							{/* {windowWidth > 280 && windowWidth < 310 ? "Context:" : "Context Window:"} */}
-							Context Window:
-						</span>
-					</div>
-					<div
-						style={{
-							display: "flex",
-							alignItems: "center",
 							gap: "3px",
 							flex: 1,
 							whiteSpace: "nowrap",
@@ -413,8 +401,6 @@ const TaskHeader: React.FC<TaskHeaderProps> = ({
 								)}
 							</div>
 
-							<TaskTimeline messages={clineMessages} />
-
 							{shouldShowPromptCacheInfoClineOR && cacheReads !== undefined && (
 								<div
 									style={{
@@ -488,7 +474,6 @@ const TaskHeader: React.FC<TaskHeaderProps> = ({
 										</span>
 									</div>
 								)}
-							{ContextWindowComponent}
 							{isCostAvailable && (
 								<div
 									style={{
@@ -509,6 +494,10 @@ const TaskHeader: React.FC<TaskHeaderProps> = ({
 									<DeleteButton taskSize={formatSize(currentTaskItem?.size)} taskId={currentTaskItem?.id} />
 								</div>
 							)}
+							<div className="flex flex-col gap-0">
+								<TaskTimeline messages={clineMessages} />
+								{ContextWindowComponent}
+							</div>
 							{checkpointTrackerErrorMessage && (
 								<div
 									style={{

--- a/webview-ui/src/components/chat/TaskHeader.tsx
+++ b/webview-ui/src/components/chat/TaskHeader.tsx
@@ -162,7 +162,7 @@ const TaskHeader: React.FC<TaskHeaderProps> = ({
 							whiteSpace: "nowrap",
 						}}>
 						<HeroTooltip content="Current tokens used in this request">
-							<span>{formatLargeNumber(lastApiReqTotalTokens || 0)}</span>
+							<span className="cursor-pointer">{formatLargeNumber(lastApiReqTotalTokens || 0)}</span>
 						</HeroTooltip>
 						<div
 							style={{
@@ -171,25 +171,28 @@ const TaskHeader: React.FC<TaskHeaderProps> = ({
 								gap: "3px",
 								flex: 1,
 							}}>
-							<div
-								style={{
-									flex: 1,
-									height: "4px",
-									backgroundColor: "color-mix(in srgb, var(--vscode-badge-foreground) 20%, transparent)",
-									borderRadius: "2px",
-									overflow: "hidden",
-								}}>
+							<HeroTooltip content="Context window usage">
 								<div
 									style={{
-										width: `${((lastApiReqTotalTokens || 0) / contextWindow) * 100}%`,
-										height: "100%",
-										backgroundColor: "var(--vscode-badge-foreground)",
+										flex: 1,
+										height: "4px",
+										backgroundColor: "color-mix(in srgb, var(--vscode-badge-foreground) 20%, transparent)",
 										borderRadius: "2px",
+										overflow: "hidden",
 									}}
-								/>
-							</div>
+									className="cursor-pointer">
+									<div
+										style={{
+											width: `${((lastApiReqTotalTokens || 0) / contextWindow) * 100}%`,
+											height: "100%",
+											backgroundColor: "var(--vscode-badge-foreground)",
+											borderRadius: "2px",
+										}}
+									/>
+								</div>
+							</HeroTooltip>
 							<HeroTooltip content="Maximum context window size for this model">
-								<span>{formatLargeNumber(contextWindow)}</span>
+								<span className="cursor-pointer">{formatLargeNumber(contextWindow)}</span>
 							</HeroTooltip>
 						</div>
 					</div>
@@ -292,7 +295,7 @@ const TaskHeader: React.FC<TaskHeaderProps> = ({
 								ref={textRef}
 								style={{
 									display: "-webkit-box",
-									WebkitLineClamp: isTextExpanded ? "unset" : 3,
+									WebkitLineClamp: isTextExpanded ? "unset" : 2,
 									WebkitBoxOrient: "vertical",
 									overflow: "hidden",
 									whiteSpace: "pre-wrap",
@@ -357,7 +360,7 @@ const TaskHeader: React.FC<TaskHeaderProps> = ({
 									display: "flex",
 									justifyContent: "space-between",
 									alignItems: "center",
-									height: 17,
+									flexWrap: "wrap",
 								}}>
 								<div
 									style={{
@@ -366,6 +369,9 @@ const TaskHeader: React.FC<TaskHeaderProps> = ({
 										gap: "4px",
 										flexWrap: "wrap",
 									}}>
+									<div style={{ display: "flex", alignItems: "center" }}>
+										<span style={{ fontWeight: "bold" }}>Tokens:</span>
+									</div>
 									<HeroTooltip content="Prompt Tokens">
 										<span className="flex items-center gap-[3px] cursor-pointer">
 											<i
@@ -399,8 +405,11 @@ const TaskHeader: React.FC<TaskHeaderProps> = ({
 									display: "flex",
 									justifyContent: "space-between",
 									alignItems: "center",
-									height: 17,
+									flexWrap: "wrap",
 								}}>
+								{
+									!shouldShowPromptCacheInfo() && <div /> // Placeholder for spacing}
+								}
 								{shouldShowPromptCacheInfo() && (
 									<div
 										style={{
@@ -409,6 +418,9 @@ const TaskHeader: React.FC<TaskHeaderProps> = ({
 											gap: "4px",
 											flexWrap: "wrap",
 										}}>
+										<div style={{ display: "flex", alignItems: "center" }}>
+											<span style={{ fontWeight: "bold" }}>Cache:</span>
+										</div>
 										{cacheWrites !== undefined && cacheWrites > 0 && (
 											<HeroTooltip content="Tokens written to cache">
 												<span className="flex items-center gap-[3px] cursor-pointer">
@@ -611,23 +623,25 @@ const DeleteButton: React.FC<{
 	taskSize: string
 	taskId?: string
 }> = ({ taskSize, taskId }) => (
-	<VSCodeButton
-		appearance="icon"
-		onClick={() => taskId && TaskServiceClient.deleteTasksWithIds({ value: [taskId] })}
-		style={{ padding: "0px 0px" }}>
-		<div
-			style={{
-				display: "flex",
-				alignItems: "center",
-				gap: "3px",
-				fontSize: "10px",
-				fontWeight: "bold",
-				opacity: 0.6,
-			}}>
-			<i className={`codicon codicon-trash`} />
-			{taskSize}
-		</div>
-	</VSCodeButton>
+	<HeroTooltip content="Delete Task & Checkpoints">
+		<VSCodeButton
+			appearance="icon"
+			onClick={() => taskId && TaskServiceClient.deleteTasksWithIds({ value: [taskId] })}
+			style={{ padding: "0px 0px" }}>
+			<div
+				style={{
+					display: "flex",
+					alignItems: "center",
+					gap: "3px",
+					fontSize: "10px",
+					fontWeight: "bold",
+					opacity: 0.6,
+				}}>
+				<i className={`codicon codicon-trash`} />
+				{taskSize}
+			</div>
+		</VSCodeButton>
+	</HeroTooltip>
 )
 
 // const ExportButton = () => (

--- a/webview-ui/src/components/chat/TaskTimeline.tsx
+++ b/webview-ui/src/components/chat/TaskTimeline.tsx
@@ -140,8 +140,6 @@ const TaskTimeline: React.FC<TaskTimelineProps> = ({ messages }) => {
 		return null
 	}
 
-	console.log("TaskTimeline messages", { taskTimelinePropsMessages })
-
 	const handleMouseEnter = (message: ClineMessage, event: React.MouseEvent<HTMLDivElement>) => {
 		setHoveredMessage(message)
 

--- a/webview-ui/src/components/chat/TaskTimeline.tsx
+++ b/webview-ui/src/components/chat/TaskTimeline.tsx
@@ -6,9 +6,9 @@ import TaskTimelineTooltip from "./TaskTimelineTooltip"
 import { COLOR_WHITE, COLOR_GRAY, COLOR_DARK_GRAY, COLOR_BEIGE, COLOR_BLUE, COLOR_RED, COLOR_PURPLE, COLOR_GREEN } from "./colors"
 
 // Timeline dimensions and spacing
-const TIMELINE_HEIGHT = "12px"
-const BLOCK_WIDTH = "6px"
-const BLOCK_GAP = "2px"
+const TIMELINE_HEIGHT = "18px"
+const BLOCK_WIDTH = "9px"
+const BLOCK_GAP = "3px"
 const TOOLTIP_MARGIN = 32 // 32px margin on each side
 
 interface TaskTimelineProps {

--- a/webview-ui/src/components/chat/TaskTimeline.tsx
+++ b/webview-ui/src/components/chat/TaskTimeline.tsx
@@ -3,6 +3,13 @@ import { ClineMessage } from "@shared/ExtensionMessage"
 import { combineApiRequests } from "@shared/combineApiRequests"
 import { combineCommandSequences } from "@shared/combineCommandSequences"
 import TaskTimelineTooltip from "./TaskTimelineTooltip"
+import { COLOR_WHITE, COLOR_GRAY, COLOR_DARK_GRAY, COLOR_BEIGE, COLOR_BLUE, COLOR_RED, COLOR_PURPLE, COLOR_GREEN } from "./colors"
+
+// Timeline dimensions and spacing
+const TIMELINE_HEIGHT = "12px"
+const BLOCK_WIDTH = "6px"
+const BLOCK_GAP = "2px"
+const TOOLTIP_MARGIN = 32 // 32px margin on each side
 
 interface TaskTimelineProps {
 	messages: ClineMessage[]
@@ -12,9 +19,11 @@ const getBlockColor = (message: ClineMessage): string => {
 	if (message.type === "say") {
 		switch (message.say) {
 			case "task":
-				return "#FFFFFF" // White for system prompt
+				return COLOR_WHITE // White for system prompt
+			case "user_feedback":
+				return COLOR_WHITE // White for user feedback
 			case "text":
-				return "#AAAAAA" // Gray for assistant responses
+				return COLOR_GRAY // Gray for assistant responses
 			case "tool":
 				if (message.text) {
 					try {
@@ -26,43 +35,62 @@ const getBlockColor = (message: ClineMessage): string => {
 							toolData.tool === "listCodeDefinitionNames" ||
 							toolData.tool === "searchFiles"
 						) {
-							return "#F5F5DC" // Beige for file read operations
+							return COLOR_BEIGE // Beige for file read operations
 						} else if (toolData.tool === "editedExistingFile" || toolData.tool === "newFileCreated") {
-							return "#3B82F6" // Blue for file edit/create operations
+							return COLOR_BLUE // Blue for file edit/create operations
 						}
 					} catch (e) {
 						// JSON parse error here
 					}
 				}
-				return "#F5F5DC" // Default beige for tool use
+				return COLOR_BEIGE // Default beige for tool use
 			case "command":
 			case "command_output":
-				return "#EF4444" // Red for terminal commands
+				return COLOR_PURPLE // Red for terminal commands
 			case "browser_action":
 			case "browser_action_result":
-				return "#8B5CF6" // Purple for browser actions
+				return COLOR_PURPLE // Purple for browser actions
 			case "completion_result":
-				return "#10B981" // Green for task success
+				return COLOR_GREEN // Green for task success
 			default:
-				return "#9E9E9E" // Grey for unknown
+				return COLOR_DARK_GRAY // Dark gray for unknown
 		}
 	} else if (message.type === "ask") {
 		switch (message.ask) {
 			case "followup":
-				return "#AAAAAA" // Gray for user messages
+				return COLOR_GRAY // Gray for user messages
 			case "plan_mode_respond":
-				return "#AAAAAA" // Gray for planning responses
+				return COLOR_GRAY // Gray for planning responses
 			case "tool":
-				return "#9E9E9E" // Gray for tool approvals
+				// Match the color of the tool approval with the tool type
+				if (message.text) {
+					try {
+						const toolData = JSON.parse(message.text)
+						if (
+							toolData.tool === "readFile" ||
+							toolData.tool === "listFilesTopLevel" ||
+							toolData.tool === "listFilesRecursive" ||
+							toolData.tool === "listCodeDefinitionNames" ||
+							toolData.tool === "searchFiles"
+						) {
+							return COLOR_BEIGE // Beige for file read operations
+						} else if (toolData.tool === "editedExistingFile" || toolData.tool === "newFileCreated") {
+							return COLOR_BLUE // Blue for file edit/create operations
+						}
+					} catch (e) {
+						// JSON parse error here
+					}
+				}
+				return COLOR_BEIGE // Default beige for tool approvals
 			case "command":
-				return "#9E9E9E" // Gray for command approvals
+				return COLOR_PURPLE // Red for command approvals (same as terminal commands)
 			case "browser_action_launch":
-				return "#9E9E9E" // Gray for browser launch approvals
+				return COLOR_PURPLE // Purple for browser launch approvals (same as browser actions)
 			default:
-				return "#9E9E9E" // Grey for unknown
+				return COLOR_DARK_GRAY // Dark gray for unknown
 		}
 	}
-	return "#9E9E9E" // Default grey
+	return COLOR_WHITE // Default color
 }
 
 const TaskTimeline: React.FC<TaskTimelineProps> = ({ messages }) => {
@@ -77,19 +105,27 @@ const TaskTimeline: React.FC<TaskTimelineProps> = ({ messages }) => {
 		const processed = combineApiRequests(combineCommandSequences(messages.slice(1)))
 
 		return processed.filter((msg) => {
+			// Filter out standard "say" events we don't want to show
 			if (
 				msg.type === "say" &&
 				(msg.say === "api_req_started" ||
 					msg.say === "api_req_finished" ||
 					msg.say === "api_req_retried" ||
 					msg.say === "deleted_api_reqs" ||
+					msg.say === "checkpoint_created" ||
 					(msg.say === "text" && (!msg.text || msg.text.trim() === "")))
 			) {
 				return false
 			}
-			if (msg.type === "ask" && (msg.ask === "resume_task" || msg.ask === "resume_completed_task")) {
+
+			// Filter out "ask" events we don't want to show, including the duplicate completion_result
+			if (
+				msg.type === "ask" &&
+				(msg.ask === "resume_task" || msg.ask === "resume_completed_task" || msg.ask === "completion_result") // Filter out the duplicate completion_result "ask" message
+			) {
 				return false
 			}
+
 			return true
 		})
 	}, [messages])
@@ -104,7 +140,7 @@ const TaskTimeline: React.FC<TaskTimelineProps> = ({ messages }) => {
 		return null
 	}
 
-	const TOOLTIP_MARGIN = 32 // 32px margin on each side
+	console.log("TaskTimeline messages", { taskTimelinePropsMessages })
 
 	const handleMouseEnter = (message: ClineMessage, event: React.MouseEvent<HTMLDivElement>) => {
 		setHoveredMessage(message)
@@ -137,12 +173,13 @@ const TaskTimeline: React.FC<TaskTimelineProps> = ({ messages }) => {
 				ref={scrollableRef}
 				style={{
 					display: "flex",
-					height: "10px",
+					height: TIMELINE_HEIGHT,
 					overflowX: "auto",
 					scrollbarWidth: "none",
 					msOverflowStyle: "none",
 					width: "100%",
 					WebkitOverflowScrolling: "touch",
+					gap: BLOCK_GAP, // Using flexbox gap instead of marginRight
 				}}>
 				<style>
 					{`
@@ -156,10 +193,9 @@ const TaskTimeline: React.FC<TaskTimelineProps> = ({ messages }) => {
 					<div
 						key={index}
 						style={{
-							width: "5px",
+							width: BLOCK_WIDTH,
 							height: "100%",
 							backgroundColor: getBlockColor(message),
-							marginRight: "1px",
 							flexShrink: 0,
 							cursor: "pointer",
 						}}

--- a/webview-ui/src/components/chat/TaskTimeline.tsx
+++ b/webview-ui/src/components/chat/TaskTimeline.tsx
@@ -87,6 +87,9 @@ const TaskTimeline: React.FC<TaskTimelineProps> = ({ messages }) => {
 			) {
 				return false
 			}
+			if (msg.type === "ask" && (msg.ask === "resume_task" || msg.ask === "resume_completed_task")) {
+				return false
+			}
 			return true
 		})
 	}, [messages])

--- a/webview-ui/src/components/chat/TaskTimelineTooltip.tsx
+++ b/webview-ui/src/components/chat/TaskTimelineTooltip.tsx
@@ -1,5 +1,6 @@
 import React from "react"
 import { ClineMessage } from "@shared/ExtensionMessage"
+import { COLOR_WHITE, COLOR_GRAY, COLOR_DARK_GRAY, COLOR_BEIGE, COLOR_BLUE, COLOR_RED, COLOR_PURPLE, COLOR_GREEN } from "./colors"
 
 // Color mapping for different message types
 
@@ -14,6 +15,8 @@ const TaskTimelineTooltip: React.FC<TaskTimelineTooltipProps> = ({ message }) =>
 				// TODO: Need to confirm these classifcations with design
 				case "task":
 					return "Task Message"
+				case "user_feedback":
+					return "User Message"
 				case "text":
 					return "Assistant Response"
 				case "tool":
@@ -49,6 +52,8 @@ const TaskTimelineTooltip: React.FC<TaskTimelineTooltipProps> = ({ message }) =>
 					return "Browser Result"
 				case "completion_result":
 					return "Task Completed"
+				case "checkpoint_created":
+					return "Checkpoint Created"
 				default:
 					return message.say || "Unknown"
 			}
@@ -59,11 +64,32 @@ const TaskTimelineTooltip: React.FC<TaskTimelineTooltipProps> = ({ message }) =>
 				case "plan_mode_respond":
 					return "Planning Response"
 				case "tool":
+					if (message.text) {
+						try {
+							const toolData = JSON.parse(message.text)
+							if (
+								toolData.tool === "readFile" ||
+								toolData.tool === "listFilesTopLevel" ||
+								toolData.tool === "listFilesRecursive" ||
+								toolData.tool === "listCodeDefinitionNames" ||
+								toolData.tool === "searchFiles"
+							) {
+								return `File Read Approval: ${toolData.tool}`
+							} else if (toolData.tool === "editedExistingFile") {
+								return `File Edit Approval: ${toolData.path || "Unknown file"}`
+							} else if (toolData.tool === "newFileCreated") {
+								return `New File Approval: ${toolData.path || "Unknown file"}`
+							}
+							return `Tool Approval: ${toolData.tool}`
+						} catch (e) {
+							return "Tool Approval"
+						}
+					}
 					return "Tool Approval"
 				case "command":
-					return "Command Approval"
+					return "Terminal Command Approval"
 				case "browser_action_launch":
-					return "Browser Launch"
+					return "Browser Action Approval"
 				default:
 					return message.ask || "Unknown"
 			}
@@ -126,9 +152,11 @@ const TaskTimelineTooltip: React.FC<TaskTimelineTooltipProps> = ({ message }) =>
 		if (message.type === "say") {
 			switch (message.say) {
 				case "task":
-					return "#FFFFFF" // White for system prompt
+					return COLOR_WHITE // White for system prompt
+				case "user_feedback":
+					return COLOR_WHITE // White for user feedback
 				case "text":
-					return "#AAAAAA" // Gray for assistant responses
+					return COLOR_GRAY // Gray for assistant responses
 				case "tool":
 					if (message.text) {
 						try {
@@ -140,43 +168,62 @@ const TaskTimelineTooltip: React.FC<TaskTimelineTooltipProps> = ({ message }) =>
 								toolData.tool === "listCodeDefinitionNames" ||
 								toolData.tool === "searchFiles"
 							) {
-								return "#F5F5DC" // Beige for file read operations
+								return COLOR_BEIGE // Beige for file read operations
 							} else if (toolData.tool === "editedExistingFile" || toolData.tool === "newFileCreated") {
-								return "#3B82F6" // Blue for file edit/create operations
+								return COLOR_BLUE // Blue for file edit/create operations
 							}
 						} catch (e) {
 							// JSON parse error here
 						}
 					}
-					return "#F5F5DC" // Default beige for tool use
+					return COLOR_BEIGE // Default beige for tool use
 				case "command":
 				case "command_output":
-					return "#EF4444" // Red for terminal commands
+					return COLOR_PURPLE // Red for terminal commands
 				case "browser_action":
 				case "browser_action_result":
-					return "#8B5CF6" // Purple for browser actions
+					return COLOR_PURPLE // Purple for browser actions
 				case "completion_result":
-					return "#10B981" // Green for task success
+					return COLOR_GREEN // Green for task success
 				default:
-					return "#9E9E9E" // Grey for unknown
+					return COLOR_DARK_GRAY // Dark gray for unknown
 			}
 		} else if (message.type === "ask") {
 			switch (message.ask) {
 				case "followup":
-					return "#AAAAAA" // Gray for user messages
+					return COLOR_GRAY // Gray for user messages
 				case "plan_mode_respond":
-					return "#AAAAAA" // Gray for planning responses
+					return COLOR_GRAY // Gray for planning responses
 				case "tool":
-					return "#9E9E9E" // Gray for tool approvals
+					// Match the color of the tool approval with the tool type
+					if (message.text) {
+						try {
+							const toolData = JSON.parse(message.text)
+							if (
+								toolData.tool === "readFile" ||
+								toolData.tool === "listFilesTopLevel" ||
+								toolData.tool === "listFilesRecursive" ||
+								toolData.tool === "listCodeDefinitionNames" ||
+								toolData.tool === "searchFiles"
+							) {
+								return COLOR_BEIGE // Beige for file read operations
+							} else if (toolData.tool === "editedExistingFile" || toolData.tool === "newFileCreated") {
+								return COLOR_BLUE // Blue for file edit/create operations
+							}
+						} catch (e) {
+							// JSON parse error here
+						}
+					}
+					return COLOR_BEIGE // Default beige for tool approvals
 				case "command":
-					return "#9E9E9E" // Gray for command approvals
+					return COLOR_PURPLE // Red for command approvals (same as terminal commands)
 				case "browser_action_launch":
-					return "#9E9E9E" // Gray for browser launch approvals
+					return COLOR_PURPLE // Purple for browser launch approvals (same as browser actions)
 				default:
-					return "#9E9E9E" // Grey for unknown
+					return COLOR_DARK_GRAY // Dark gray for unknown
 			}
 		}
-		return "#9E9E9E" // Default grey
+		return COLOR_DARK_GRAY // Default dark gray
 	}
 
 	return (

--- a/webview-ui/src/components/chat/TaskTimelineTooltip.tsx
+++ b/webview-ui/src/components/chat/TaskTimelineTooltip.tsx
@@ -99,8 +99,24 @@ const TaskTimelineTooltip: React.FC<TaskTimelineTooltipProps> = ({ message }) =>
 
 	const getTimestamp = (message: ClineMessage): string => {
 		if (message.ts) {
-			const date = new Date(message.ts)
-			return date.toLocaleTimeString()
+			const messageDate = new Date(message.ts)
+			const today = new Date()
+
+			const todayDate = new Date(today.getFullYear(), today.getMonth(), today.getDate())
+			const messageDateOnly = new Date(messageDate.getFullYear(), messageDate.getMonth(), messageDate.getDate())
+
+			const time = messageDate.toLocaleTimeString([], { hour: "numeric", minute: "2-digit", hour12: true })
+
+			const monthNames = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"]
+			const monthName = monthNames[messageDate.getMonth()]
+
+			if (messageDateOnly.getTime() === todayDate.getTime()) {
+				return `${time}`
+			} else if (messageDate.getFullYear() === today.getFullYear()) {
+				return `${monthName} ${messageDate.getDate()} ${time}`
+			} else {
+				return `${monthName} ${messageDate.getDate()}, ${messageDate.getFullYear()} ${time}`
+			}
 		}
 		return ""
 	}

--- a/webview-ui/src/components/chat/colors.ts
+++ b/webview-ui/src/components/chat/colors.ts
@@ -1,0 +1,9 @@
+// Color constants for timeline and tooltips
+export const COLOR_WHITE = "#FFFFFF" // White for system prompt and user feedback
+export const COLOR_GRAY = "#AAAAAA" // Gray for assistant responses and user messages
+export const COLOR_DARK_GRAY = "#9E9E9E" // Dark gray for unknown types
+export const COLOR_BEIGE = "#FFFF54" // Beige for file read operations
+export const COLOR_BLUE = "#3B82F6" // Blue for file edit/create operations
+export const COLOR_RED = "#EF4444" // Red for terminal commands
+export const COLOR_PURPLE = "#9E59FA" // Purple for browser actions
+export const COLOR_GREEN = "#10B981" // Green for task success

--- a/webview-ui/src/components/common/HeroTooltip.tsx
+++ b/webview-ui/src/components/common/HeroTooltip.tsx
@@ -30,7 +30,7 @@ const HeroTooltip: React.FC<HeroTooltipProps> = ({
       border border-[var(--vscode-widget-border)] rounded p-2 w-full shadow-md text-xs max-w-[250px] ${className}`}>
 				<div
 					className="whitespace-pre-wrap break-words max-h-[150px] overflow-y-auto text-[11px] 
-        font-[var(--vscode-editor-font-family)] bg-[var(--vscode-textBlockQuote-background)] p-1 rounded">
+        font-[var(--vscode-editor-font-family)]  p-1 rounded">
 					{content}
 				</div>
 			</div>

--- a/webview-ui/src/components/common/HeroTooltip.tsx
+++ b/webview-ui/src/components/common/HeroTooltip.tsx
@@ -1,0 +1,59 @@
+import React from "react"
+import { Tooltip } from "@heroui/react"
+
+interface HeroTooltipProps {
+	content: React.ReactNode
+	children: React.ReactNode
+	className?: string
+	delay?: number
+	closeDelay?: number
+	placement?: "top" | "bottom" | "left" | "right"
+}
+
+/**
+ * HeroTooltip component that wraps the HeroUI tooltip with styling
+ * similar to TaskTimelineTooltip
+ */
+const HeroTooltip: React.FC<HeroTooltipProps> = ({
+	content,
+	children,
+	className,
+	delay = 0,
+	closeDelay = 500,
+	placement = "top",
+}) => {
+	// If content is a simple string, wrap it in the tailwind styled divs
+	const formattedContent =
+		typeof content === "string" ? (
+			<div
+				className={`bg-[var(--vscode-editor-background)] text-[var(--vscode-editor-foreground)] 
+      border border-[var(--vscode-widget-border)] rounded p-2 w-full shadow-md text-xs max-w-[250px] ${className}`}>
+				<div
+					className="whitespace-pre-wrap break-words max-h-[150px] overflow-y-auto text-[11px] 
+        font-[var(--vscode-editor-font-family)] bg-[var(--vscode-textBlockQuote-background)] p-1 rounded">
+					{content}
+				</div>
+			</div>
+		) : (
+			// If content is already a React node, assume it's pre-formatted
+			content
+		)
+
+	return (
+		<Tooltip
+			content={formattedContent}
+			delay={delay}
+			closeDelay={0} // Immediate close when cursor moves away
+			placement={placement}
+			isDisabled={false}
+			showArrow={false}
+			disableAnimation={true} // Disable animation for immediate appearance/disappearance
+			classNames={{
+				content: "hero-tooltip-content pointer-events-none", // Prevent hovering over tooltip
+			}}>
+			{children}
+		</Tooltip>
+	)
+}
+
+export default HeroTooltip


### PR DESCRIPTION
### Description
Adding some stability around the task timeline feature by adding date format on tasks that are older than today's date, and removing the "resume_task" block that is added at the end for chat that has ended in cancellation.

### Test Procedure
Reviewing all old chat messages and visually confirming them

### Type of Change
-   [] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [X] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist
-   [X] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [X] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [X] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [X] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots
![image](https://github.com/user-attachments/assets/f1a85e55-a96e-4fbd-949e-719423aab433)

### Additional Notes
N/A
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Enhances task timeline by filtering specific tasks and improving timestamp display for older messages.
> 
>   - **Behavior**:
>     - Filters out `resume_task` and `resume_completed_task` messages in `TaskTimeline.tsx`.
>     - Updates timestamp display in `TaskTimelineTooltip.tsx` to include date for messages older than today.
>   - **Functions**:
>     - Modifies `getTimestamp()` in `TaskTimelineTooltip.tsx` to format timestamps with month and year for older messages.
>   - **Misc**:
>     - Adds changeset `smart-otters-admire.md` for timestamp visualization.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 6217b2a75118bf13e82756ddb72d5a718aa76a28. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->