### PR TITLE
Bump ollama from 0.5.13 to 0.5.15: To support proxy/Basic auth

### DIFF
--- a/.changeset/lazy-dolls-smell.md
+++ b/.changeset/lazy-dolls-smell.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Bump ollama from 0.5.13 to 0.5.15

--- a/package-lock.json
+++ b/package-lock.json
@@ -20252,10 +20252,9 @@
 			}
 		},
 		"node_modules/ollama": {
-			"version": "0.5.13",
-			"resolved": "https://registry.npmjs.org/ollama/-/ollama-0.5.13.tgz",
-			"integrity": "sha512-qK3eE2GjMYjCiTknEJfAHjbUzUqgVtf9qtzjxWrkwBZgBG7kOB6Z4+Ov4fbvDjmKKHv+rpuTsWFg4jZvVjNBtQ==",
-			"license": "MIT",
+			"version": "0.5.15",
+			"resolved": "https://registry.npmjs.org/ollama/-/ollama-0.5.15.tgz",
+			"integrity": "sha512-TSaZSJyP7MQJFjSmmNsoJiriwa3U+/UJRw6+M8aucs5dTsaWNZsBIGpDb5rXnW6nXxJBB/z79gZY8IaiIQgelQ==",
 			"dependencies": {
 				"whatwg-fetch": "^3.6.20"
 			}
@@ -39896,9 +39895,9 @@
 			}
 		},
 		"ollama": {
-			"version": "0.5.13",
-			"resolved": "https://registry.npmjs.org/ollama/-/ollama-0.5.13.tgz",
-			"integrity": "sha512-qK3eE2GjMYjCiTknEJfAHjbUzUqgVtf9qtzjxWrkwBZgBG7kOB6Z4+Ov4fbvDjmKKHv+rpuTsWFg4jZvVjNBtQ==",
+			"version": "0.5.15",
+			"resolved": "https://registry.npmjs.org/ollama/-/ollama-0.5.15.tgz",
+			"integrity": "sha512-TSaZSJyP7MQJFjSmmNsoJiriwa3U+/UJRw6+M8aucs5dTsaWNZsBIGpDb5rXnW6nXxJBB/z79gZY8IaiIQgelQ==",
 			"requires": {
 				"whatwg-fetch": "^3.6.20"
 			}


### PR DESCRIPTION
### Description
Upgrade ollama-js library to 0.5.15 that now has proxy support.

fix #2255 

### Test Procedure

<!-- How did you test this? Are you confident that it will not introduce bugs? If so, why? -->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)


### Additional Notes

This change will allow all people using ollama with proxy/basic auth use cline. 
Which is a common and simple way that many people use ollama in their environment.
