### PR TITLE
Raise Errors when users try to upload images larger than 7500x7500 pixels

### DIFF
--- a/.changeset/shiny-snakes-occur.md
+++ b/.changeset/shiny-snakes-occur.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Raise Errors when users try to upload images larger than 7500x7500 pixels

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,6 +42,7 @@
 				"globby": "^14.0.2",
 				"iconv-lite": "^0.6.3",
 				"ignore": "^7.0.3",
+				"image-size": "^2.0.2",
 				"isbinaryfile": "^5.0.2",
 				"jschardet": "^3.1.4",
 				"mammoth": "^1.8.0",
@@ -16577,6 +16578,18 @@
 			"integrity": "sha512-bAH5jbK/F3T3Jls4I0SO1hmPR0dKU0a7+SY6n1yzRtG54FLO8d6w/nxLFX2Nb7dBu6cCWXPaAME6cYqFUMmuCA==",
 			"engines": {
 				"node": ">= 4"
+			}
+		},
+		"node_modules/image-size": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/image-size/-/image-size-2.0.2.tgz",
+			"integrity": "sha512-IRqXKlaXwgSMAMtpNzZa1ZAe8m+Sa1770Dhk8VkSsP9LS+iHD62Zd8FQKs8fbPiagBE7BzoFX23cxFnwshpV6w==",
+			"license": "MIT",
+			"bin": {
+				"image-size": "bin/image-size.js"
+			},
+			"engines": {
+				"node": ">=16.x"
 			}
 		},
 		"node_modules/immediate": {
@@ -37429,6 +37442,11 @@
 			"version": "7.0.3",
 			"resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.3.tgz",
 			"integrity": "sha512-bAH5jbK/F3T3Jls4I0SO1hmPR0dKU0a7+SY6n1yzRtG54FLO8d6w/nxLFX2Nb7dBu6cCWXPaAME6cYqFUMmuCA=="
+		},
+		"image-size": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/image-size/-/image-size-2.0.2.tgz",
+			"integrity": "sha512-IRqXKlaXwgSMAMtpNzZa1ZAe8m+Sa1770Dhk8VkSsP9LS+iHD62Zd8FQKs8fbPiagBE7BzoFX23cxFnwshpV6w=="
 		},
 		"immediate": {
 			"version": "3.0.6",

--- a/package.json
+++ b/package.json
@@ -385,6 +385,7 @@
 		"globby": "^14.0.2",
 		"iconv-lite": "^0.6.3",
 		"ignore": "^7.0.3",
+		"image-size": "^2.0.2",
 		"isbinaryfile": "^5.0.2",
 		"jschardet": "^3.1.4",
 		"mammoth": "^1.8.0",

--- a/src/integrations/misc/process-images.ts
+++ b/src/integrations/misc/process-images.ts
@@ -27,20 +27,20 @@ export async function selectImages(): Promise<string[]> {
 			// Convert Node.js Buffer to Uint8Array
 			const uint8Array = new Uint8Array(buffer.buffer, buffer.byteOffset, buffer.byteLength)
 			const dimensions = sizeOf(uint8Array) // Get dimensions from Uint8Array
-			if (dimensions.width! > 200 || dimensions.height! > 200) {
+			if (dimensions.width! > 8000 || dimensions.height! > 8000) {
 				// Corrected to 8000px
 				console.warn(`Image dimensions exceed 8000px, skipping: ${imagePath}`)
 				// Notify user
 				vscode.window.showErrorMessage(
 					`Image too large: ${path.basename(imagePath)} was skipped (dimensions exceed 8000px).`,
 				)
-				return null // Mark for filtering
+				return null
 			}
 		} catch (error) {
 			console.error(`Error reading file or getting dimensions for ${imagePath}:`, error)
 			// Notify user
 			vscode.window.showErrorMessage(`Could not read dimensions for ${path.basename(imagePath)}, skipping.`)
-			return null // Mark for filtering
+			return null
 		}
 
 		// If dimensions are valid, proceed to convert the existing buffer to base64

--- a/src/integrations/misc/process-images.ts
+++ b/src/integrations/misc/process-images.ts
@@ -27,10 +27,10 @@ export async function selectImages(): Promise<string[]> {
 			// Convert Node.js Buffer to Uint8Array
 			const uint8Array = new Uint8Array(buffer.buffer, buffer.byteOffset, buffer.byteLength)
 			const dimensions = sizeOf(uint8Array) // Get dimensions from Uint8Array
-			if (dimensions.width! > 8000 || dimensions.height! > 8000) {
-				console.warn(`Image dimensions exceed 8000px, skipping: ${imagePath}`)
+			if (dimensions.width! > 7500 || dimensions.height! > 7500) {
+				console.warn(`Image dimensions exceed 7500px, skipping: ${imagePath}`)
 				vscode.window.showErrorMessage(
-					`Image too large: ${path.basename(imagePath)} was skipped (dimensions exceed 8000px).`,
+					`Image too large: ${path.basename(imagePath)} was skipped (dimensions exceed 7500px).`,
 				)
 				return null
 			}

--- a/src/integrations/misc/process-images.ts
+++ b/src/integrations/misc/process-images.ts
@@ -28,9 +28,7 @@ export async function selectImages(): Promise<string[]> {
 			const uint8Array = new Uint8Array(buffer.buffer, buffer.byteOffset, buffer.byteLength)
 			const dimensions = sizeOf(uint8Array) // Get dimensions from Uint8Array
 			if (dimensions.width! > 8000 || dimensions.height! > 8000) {
-				// Corrected to 8000px
 				console.warn(`Image dimensions exceed 8000px, skipping: ${imagePath}`)
-				// Notify user
 				vscode.window.showErrorMessage(
 					`Image too large: ${path.basename(imagePath)} was skipped (dimensions exceed 8000px).`,
 				)
@@ -38,14 +36,13 @@ export async function selectImages(): Promise<string[]> {
 			}
 		} catch (error) {
 			console.error(`Error reading file or getting dimensions for ${imagePath}:`, error)
-			// Notify user
 			vscode.window.showErrorMessage(`Could not read dimensions for ${path.basename(imagePath)}, skipping.`)
 			return null
 		}
 
 		// If dimensions are valid, proceed to convert the existing buffer to base64
 		const base64 = buffer.toString("base64")
-		const mimeType = getMimeType(imagePath) // Assuming getMimeType is defined in the file
+		const mimeType = getMimeType(imagePath)
 		return `data:${mimeType};base64,${base64}`
 	})
 

--- a/webview-ui/src/components/chat/ChatTextArea.tsx
+++ b/webview-ui/src/components/chat/ChatTextArea.tsx
@@ -39,19 +39,17 @@ import { ChatSettings } from "@shared/ChatSettings"
 import ServersToggleModal from "./ServersToggleModal"
 import ClineRulesToggleModal from "../cline-rules/ClineRulesToggleModal"
 
-// Helper function to check image dimensions
 const getImageDimensions = (dataUrl: string): Promise<{ width: number; height: number }> => {
 	return new Promise((resolve, reject) => {
 		const img = new Image()
 		img.onload = () => {
-			if (img.naturalWidth > 200 || img.naturalHeight > 200) {
+			if (img.naturalWidth > 8000 || img.naturalHeight > 8000) {
 				reject(new Error("Image dimensions exceed maximum allowed size of 200px."))
 			} else {
 				resolve({ width: img.naturalWidth, height: img.naturalHeight })
 			}
 		}
 		img.onerror = (err) => {
-			// Added error parameter
 			console.error("Failed to load image for dimension check:", err)
 			reject(new Error("Failed to load image to check dimensions."))
 		}
@@ -291,8 +289,8 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 		const shiftHoldTimerRef = useRef<NodeJS.Timeout | null>(null)
 		const [showUnsupportedFileError, setShowUnsupportedFileError] = useState(false)
 		const unsupportedFileTimerRef = useRef<NodeJS.Timeout | null>(null)
-		const [showDimensionError, setShowDimensionError] = useState(false) // New state for dimension error
-		const dimensionErrorTimerRef = useRef<NodeJS.Timeout | null>(null) // New timer ref for dimension error
+		const [showDimensionError, setShowDimensionError] = useState(false)
+		const dimensionErrorTimerRef = useRef<NodeJS.Timeout | null>(null)
 
 		const [fileSearchResults, setFileSearchResults] = useState<SearchResult[]>([])
 		const [searchLoading, setSearchLoading] = useState(false)
@@ -803,7 +801,6 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 							}
 							const reader = new FileReader()
 							reader.onloadend = async () => {
-								// Make async
 								if (reader.error) {
 									console.error("Error reading file:", reader.error)
 									resolve(null)
@@ -811,12 +808,12 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 									const result = reader.result
 									if (typeof result === "string") {
 										try {
-											await getImageDimensions(result) // Check dimensions
+											await getImageDimensions(result)
 											resolve(result)
 										} catch (error) {
 											console.warn((error as Error).message)
-											showDimensionErrorMessage() // Show error to user
-											resolve(null) // Don't add this image
+											showDimensionErrorMessage()
+											resolve(null)
 										}
 									} else {
 										resolve(null)
@@ -836,7 +833,7 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 					}
 				}
 			},
-			[shouldDisableImages, setSelectedImages, cursorPosition, setInputValue, inputValue, showDimensionErrorMessage], // Added showDimensionErrorMessage dependency
+			[shouldDisableImages, setSelectedImages, cursorPosition, setInputValue, inputValue, showDimensionErrorMessage],
 		)
 
 		const handleThumbnailsHeightChange = useCallback((height: number) => {
@@ -1300,7 +1297,7 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 					onDragOver={onDragOver}
 					onDragEnter={handleDragEnter}
 					onDragLeave={handleDragLeave}>
-					{showDimensionError && ( // New JSX for dimension error
+					{showDimensionError && (
 						<div
 							style={{
 								position: "absolute",
@@ -1319,7 +1316,7 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 									color: "var(--vscode-errorForeground)",
 									fontWeight: "bold",
 									fontSize: "12px",
-									textAlign: "center", // Center text if it wraps
+									textAlign: "center",
 								}}>
 								Image dimensions exceed 8000px
 							</span>
@@ -1443,7 +1440,7 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 							}
 							onHeightChange?.(height)
 						}}
-						placeholder={showUnsupportedFileError ? "" : placeholderText}
+						placeholder={showUnsupportedFileError || showDimensionError ? "" : placeholderText}
 						maxRows={10}
 						autoFocus={true}
 						style={{

--- a/webview-ui/src/components/chat/ChatTextArea.tsx
+++ b/webview-ui/src/components/chat/ChatTextArea.tsx
@@ -43,8 +43,8 @@ const getImageDimensions = (dataUrl: string): Promise<{ width: number; height: n
 	return new Promise((resolve, reject) => {
 		const img = new Image()
 		img.onload = () => {
-			if (img.naturalWidth > 8000 || img.naturalHeight > 8000) {
-				reject(new Error("Image dimensions exceed maximum allowed size of 200px."))
+			if (img.naturalWidth > 7500 || img.naturalHeight > 7500) {
+				reject(new Error("Image dimensions exceed maximum allowed size of 7500px."))
 			} else {
 				resolve({ width: img.naturalWidth, height: img.naturalHeight })
 			}
@@ -1318,7 +1318,7 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 									fontSize: "12px",
 									textAlign: "center",
 								}}>
-								Image dimensions exceed 8000px
+								Image dimensions exceed 7500px
 							</span>
 						</div>
 					)}

--- a/webview-ui/src/components/chat/ChatTextArea.tsx
+++ b/webview-ui/src/components/chat/ChatTextArea.tsx
@@ -39,6 +39,26 @@ import { ChatSettings } from "@shared/ChatSettings"
 import ServersToggleModal from "./ServersToggleModal"
 import ClineRulesToggleModal from "../cline-rules/ClineRulesToggleModal"
 
+// Helper function to check image dimensions
+const getImageDimensions = (dataUrl: string): Promise<{ width: number; height: number }> => {
+	return new Promise((resolve, reject) => {
+		const img = new Image()
+		img.onload = () => {
+			if (img.naturalWidth > 200 || img.naturalHeight > 200) {
+				reject(new Error("Image dimensions exceed maximum allowed size of 200px."))
+			} else {
+				resolve({ width: img.naturalWidth, height: img.naturalHeight })
+			}
+		}
+		img.onerror = (err) => {
+			// Added error parameter
+			console.error("Failed to load image for dimension check:", err)
+			reject(new Error("Failed to load image to check dimensions."))
+		}
+		img.src = dataUrl
+	})
+}
+
 interface ChatTextAreaProps {
 	inputValue: string
 	setInputValue: (value: string) => void
@@ -271,6 +291,8 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 		const shiftHoldTimerRef = useRef<NodeJS.Timeout | null>(null)
 		const [showUnsupportedFileError, setShowUnsupportedFileError] = useState(false)
 		const unsupportedFileTimerRef = useRef<NodeJS.Timeout | null>(null)
+		const [showDimensionError, setShowDimensionError] = useState(false) // New state for dimension error
+		const dimensionErrorTimerRef = useRef<NodeJS.Timeout | null>(null) // New timer ref for dimension error
 
 		const [fileSearchResults, setFileSearchResults] = useState<SearchResult[]>([])
 		const [searchLoading, setSearchLoading] = useState(false)
@@ -724,6 +746,17 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 			setIsTextAreaFocused(false)
 		}, [isMouseDownOnMenu])
 
+		const showDimensionErrorMessage = useCallback(() => {
+			setShowDimensionError(true)
+			if (dimensionErrorTimerRef.current) {
+				clearTimeout(dimensionErrorTimerRef.current)
+			}
+			dimensionErrorTimerRef.current = setTimeout(() => {
+				setShowDimensionError(false)
+				dimensionErrorTimerRef.current = null
+			}, 3000)
+		}, [])
+
 		const handlePaste = useCallback(
 			async (e: React.ClipboardEvent) => {
 				const items = e.clipboardData.items
@@ -769,13 +802,25 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 								return
 							}
 							const reader = new FileReader()
-							reader.onloadend = () => {
+							reader.onloadend = async () => {
+								// Make async
 								if (reader.error) {
 									console.error("Error reading file:", reader.error)
 									resolve(null)
 								} else {
 									const result = reader.result
-									resolve(typeof result === "string" ? result : null)
+									if (typeof result === "string") {
+										try {
+											await getImageDimensions(result) // Check dimensions
+											resolve(result)
+										} catch (error) {
+											console.warn((error as Error).message)
+											showDimensionErrorMessage() // Show error to user
+											resolve(null) // Don't add this image
+										}
+									} else {
+										resolve(null)
+									}
 								}
 							}
 							reader.readAsDataURL(blob)
@@ -791,7 +836,7 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 					}
 				}
 			},
-			[shouldDisableImages, setSelectedImages, cursorPosition, setInputValue, inputValue],
+			[shouldDisableImages, setSelectedImages, cursorPosition, setInputValue, inputValue, showDimensionErrorMessage], // Added showDimensionErrorMessage dependency
 		)
 
 		const handleThumbnailsHeightChange = useCallback((height: number) => {
@@ -1213,13 +1258,25 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 					(file) =>
 						new Promise<string | null>((resolve) => {
 							const reader = new FileReader()
-							reader.onloadend = () => {
+							reader.onloadend = async () => {
+								// Make async
 								if (reader.error) {
 									console.error("Error reading file:", reader.error)
 									resolve(null)
 								} else {
 									const result = reader.result
-									resolve(typeof result === "string" ? result : null)
+									if (typeof result === "string") {
+										try {
+											await getImageDimensions(result) // Check dimensions
+											resolve(result)
+										} catch (error) {
+											console.warn((error as Error).message)
+											showDimensionErrorMessage() // Show error to user
+											resolve(null) // Don't add this image
+										}
+									} else {
+										resolve(null)
+									}
 								}
 							}
 							reader.readAsDataURL(file)
@@ -1243,6 +1300,31 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 					onDragOver={onDragOver}
 					onDragEnter={handleDragEnter}
 					onDragLeave={handleDragLeave}>
+					{showDimensionError && ( // New JSX for dimension error
+						<div
+							style={{
+								position: "absolute",
+								inset: "10px 15px",
+								backgroundColor: "rgba(var(--vscode-errorForeground-rgb), 0.1)",
+								border: "2px solid var(--vscode-errorForeground)",
+								borderRadius: 2,
+								display: "flex",
+								alignItems: "center",
+								justifyContent: "center",
+								zIndex: 10, // Ensure it's above other elements
+								pointerEvents: "none",
+							}}>
+							<span
+								style={{
+									color: "var(--vscode-errorForeground)",
+									fontWeight: "bold",
+									fontSize: "12px",
+									textAlign: "center", // Center text if it wraps
+								}}>
+								Image dimensions exceed 8000px
+							</span>
+						</div>
+					)}
 					{showUnsupportedFileError && (
 						<div
 							style={{


### PR DESCRIPTION
Fixes https://github.com/cline/cline/issues/3308 

### Description
Add blockers to users to stop users from uploading images larger than 8000x8000 size as that is not supported in claude. 



### Test Procedure
You can test this in two ways
1.  First way is to do drag and drop test which will give you 

<img width="306" alt="image" src="https://github.com/user-attachments/assets/e0dc5273-a8ac-41f1-b550-3a899f865286" />

2. The second way is to upload an image using camera button and that should give you an upload error on vscode 
 <img width="471" alt="image" src="https://github.com/user-attachments/assets/c4fc6c14-a094-482b-87c9-9a5334a6dc2c" />



### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [ ] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Block image uploads larger than 7500x7500 pixels and provide user feedback in `process-images.ts` and `ChatTextArea.tsx`.
> 
>   - **Behavior**:
>     - Blocks image uploads larger than 7500x7500 pixels in `selectImages()` in `process-images.ts` and `ChatTextArea` in `ChatTextArea.tsx`.
>     - Displays error messages in VSCode and UI when images exceed size limits.
>   - **Dependencies**:
>     - Adds `image-size` package to `package.json` for dimension checking.
>   - **UI Changes**:
>     - Adds visual error feedback for oversized images in `ChatTextArea.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 555e72fde06a31b273e6dcd6232f92bfa26b345e. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->