### PR TITLE
add syntax highlighting for code blocks

### DIFF
--- a/.changeset/calm-ads-drive.md
+++ b/.changeset/calm-ads-drive.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Add syntax highlighting for code blocks

--- a/webview-ui/src/components/common/MarkdownBlock.tsx
+++ b/webview-ui/src/components/common/MarkdownBlock.tsx
@@ -11,6 +11,8 @@ import { useExtensionState } from "@/context/ExtensionStateContext"
 import { CODE_BLOCK_BG_COLOR } from "@/components/common/CodeBlock"
 import MermaidBlock from "@/components/common/MermaidBlock"
 
+import "highlight.js/styles/github-dark.css"
+
 interface MarkdownBlockProps {
 	markdown?: string
 }


### PR DESCRIPTION
### Description

Issue: #3337 - no syntax highlighting provided in code blocks

### Test Procedure

Manual testing, see screenshots below

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

**Plan mode**
![image](https://github.com/user-attachments/assets/177af4aa-1395-43c5-843c-cc1f73c8187f)

**Act mode**
![image](https://github.com/user-attachments/assets/f625301d-f895-4780-806a-b8495ebeb284)

### Additional Notes

n/a
