### PR TITLE
fetch cache details from OR/Cline provider generation endpoint

### DIFF
--- a/.changeset/hungry-rules-relax.md
+++ b/.changeset/hungry-rules-relax.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": minor
+---
+
+fetch cache details from generation endpoint

--- a/src/api/providers/cline.ts
+++ b/src/api/providers/cline.ts
@@ -107,9 +107,8 @@ export class ClineHandler implements ApiHandler {
 				const generation = response.data
 				return {
 					type: "usage",
-					// at this time there's no support for gatting cached_tokens from generation endpoint
 					cacheWriteTokens: 0,
-					cacheReadTokens: 0,
+					cacheReadTokens: generation?.native_tokens_cached || 0,
 					inputTokens: generation?.native_tokens_prompt || 0,
 					outputTokens: generation?.native_tokens_completion || 0,
 					totalCost: generation?.total_cost || 0,

--- a/src/api/providers/openrouter.ts
+++ b/src/api/providers/openrouter.ts
@@ -105,9 +105,8 @@ export class OpenRouterHandler implements ApiHandler {
 				// console.log("OpenRouter generation details:", generation)
 				return {
 					type: "usage",
-					// at this time there's no support for gatting cached_tokens from generation endpoint
 					cacheWriteTokens: 0,
-					cacheReadTokens: 0,
+					cacheReadTokens: generation?.native_tokens_cached || 0,
 					// openrouter generation endpoint fails often
 					inputTokens: generation?.native_tokens_prompt || 0,
 					outputTokens: generation?.native_tokens_completion || 0,


### PR DESCRIPTION
### Description

Fetch cache details from OR/Cline provider generation endpoint

### Test Procedure

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

### Additional Notes

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fetch cache details from generation endpoint in `ClineHandler` and `OpenRouterHandler`, updating `getApiStreamUsage()` to include `cacheReadTokens`.
> 
>   - **Behavior**:
>     - Fetch cache details from generation endpoint in `ClineHandler` and `OpenRouterHandler`.
>     - Update `getApiStreamUsage()` in `cline.ts` and `openrouter.ts` to include `cacheReadTokens` from `native_tokens_cached`.
>   - **Misc**:
>     - Remove comments about lack of support for cached tokens in `cline.ts` and `openrouter.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 3a4f014619d9c4f230b20e28653f7d1bcebe8dbc. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->