### PR TITLE
[PROTOBUS] Move getLmStudioModels to protobus

### DIFF
--- a/.changeset/serious-cameras-pretend.md
+++ b/.changeset/serious-cameras-pretend.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+getLmStudioModels protobus migration

--- a/proto/models.proto
+++ b/proto/models.proto
@@ -10,4 +10,7 @@ import "common.proto";
 service ModelsService {
   // Fetches available models from Ollama
   rpc getOllamaModels(StringRequest) returns (StringArray);
+  
+  // Fetches available models from LM Studio
+  rpc getLmStudioModels(StringRequest) returns (StringArray);
 }

--- a/src/core/controller/index.ts
+++ b/src/core/controller/index.ts
@@ -334,13 +334,6 @@ export class Controller {
 			case "resetState":
 				await this.resetState()
 				break
-			case "requestLmStudioModels":
-				const lmStudioModels = await this.getLmStudioModels(message.text)
-				this.postMessageToWebview({
-					type: "lmStudioModels",
-					lmStudioModels,
-				})
-				break
 			case "requestVsCodeLmModels":
 				const vsCodeLmModels = await this.getVsCodeLmModels()
 				this.postMessageToWebview({ type: "vsCodeLmModels", vsCodeLmModels })
@@ -901,25 +894,6 @@ export class Controller {
 			return models || []
 		} catch (error) {
 			console.error("Error fetching VS Code LM models:", error)
-			return []
-		}
-	}
-
-	// LM Studio
-
-	async getLmStudioModels(baseUrl?: string) {
-		try {
-			if (!baseUrl) {
-				baseUrl = "http://localhost:1234"
-			}
-			if (!URL.canParse(baseUrl)) {
-				return []
-			}
-			const response = await axios.get(`${baseUrl}/v1/models`)
-			const modelsArray = response.data?.data?.map((model: any) => model.id) || []
-			const models = [...new Set<string>(modelsArray)]
-			return models
-		} catch (error) {
 			return []
 		}
 	}

--- a/src/core/controller/models/getLmStudioModels.ts
+++ b/src/core/controller/models/getLmStudioModels.ts
@@ -1,0 +1,27 @@
+import { Controller } from ".."
+import { StringArray, StringRequest } from "../../../shared/proto/common"
+import axios from "axios"
+
+/**
+ * Fetches available models from LM Studio
+ * @param controller The controller instance
+ * @param request The request containing the base URL (optional)
+ * @returns Array of model names
+ */
+export async function getLmStudioModels(controller: Controller, request: StringRequest): Promise<StringArray> {
+	try {
+		let baseUrl = request.value || "http://localhost:1234"
+
+		if (!URL.canParse(baseUrl)) {
+			return StringArray.create({ values: [] })
+		}
+
+		const response = await axios.get(`${baseUrl}/v1/models`)
+		const modelsArray = response.data?.data?.map((model: any) => model.id) || []
+		const models = [...new Set<string>(modelsArray)]
+
+		return StringArray.create({ values: models })
+	} catch (error) {
+		return StringArray.create({ values: [] })
+	}
+}

--- a/src/core/controller/models/methods.ts
+++ b/src/core/controller/models/methods.ts
@@ -3,10 +3,12 @@
 
 // Import all method implementations
 import { registerMethod } from "./index"
+import { getLmStudioModels } from "./getLmStudioModels"
 import { getOllamaModels } from "./getOllamaModels"
 
 // Register all models service methods
 export function registerAllMethods(): void {
 	// Register each method with the registry
+	registerMethod("getLmStudioModels", getLmStudioModels)
 	registerMethod("getOllamaModels", getOllamaModels)
 }

--- a/src/shared/WebviewMessage.ts
+++ b/src/shared/WebviewMessage.ts
@@ -18,7 +18,6 @@ export interface WebviewMessage {
 		| "selectImages"
 		| "showTaskWithId"
 		| "resetState"
-		| "requestLmStudioModels"
 		| "openInBrowser"
 		| "openMention"
 		| "showChatView"

--- a/src/shared/proto/models.ts
+++ b/src/shared/proto/models.ts
@@ -24,5 +24,14 @@ export const ModelsServiceDefinition = {
 			responseStream: false,
 			options: {},
 		},
+		/** Fetches available models from LM Studio */
+		getLmStudioModels: {
+			name: "getLmStudioModels",
+			requestType: StringRequest,
+			requestStream: false,
+			responseType: StringArray,
+			responseStream: false,
+			options: {},
+		},
 	},
 } as const

--- a/webview-ui/src/components/settings/ApiOptions.tsx
+++ b/webview-ui/src/components/settings/ApiOptions.tsx
@@ -197,10 +197,17 @@ const ApiOptions = ({
 				setOllamaModels([])
 			}
 		} else if (selectedProvider === "lmstudio") {
-			vscode.postMessage({
-				type: "requestLmStudioModels",
-				text: apiConfiguration?.lmStudioBaseUrl,
-			})
+			try {
+				const response = await ModelsServiceClient.getLmStudioModels({
+					value: apiConfiguration?.lmStudioBaseUrl || "",
+				})
+				if (response && response.values) {
+					setLmStudioModels(response.values)
+				}
+			} catch (error) {
+				console.error("Failed to fetch LM Studio models:", error)
+				setLmStudioModels([])
+			}
 		} else if (selectedProvider === "vscode-lm") {
 			vscode.postMessage({ type: "requestVsCodeLmModels" })
 		}
@@ -217,9 +224,7 @@ const ApiOptions = ({
 
 	const handleMessage = useCallback((event: MessageEvent) => {
 		const message: ExtensionMessage = event.data
-		if (message.type === "lmStudioModels" && message.lmStudioModels) {
-			setLmStudioModels(message.lmStudioModels)
-		} else if (message.type === "vsCodeLmModels" && message.vsCodeLmModels) {
+		if (message.type === "vsCodeLmModels" && message.vsCodeLmModels) {
 			setVsCodeLmModels(message.vsCodeLmModels)
 		}
 	}, [])


### PR DESCRIPTION
### Description

This PR migrates the `getLmStudioModels` message to the gRPC/Protobuf system. It converts the legacy VSCode message passing mechanism to a gRPC method in the `ModelsService`. The client can now call `ModelsServiceClient.getLmStudioModels()` to obtain an array of LMStudio models that are available.

### Test Procedure

To test this change, launch Cline with LMStudio installed with at least one model installed. Confirm that the model is displayed with a radio button to select it.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [X] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [X] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [X] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [X] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [X] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Migrates `getLmStudioModels` to gRPC/Protobuf, updating `ModelsService` and removing legacy message handling.
> 
>   - **Behavior**:
>     - Migrates `getLmStudioModels` to gRPC/Protobuf in `ModelsService`.
>     - Removes legacy message handling for `requestLmStudioModels` in `index.ts`.
>     - Updates `ApiOptions.tsx` to use `ModelsServiceClient.getLmStudioModels()`.
>   - **Protobuf**:
>     - Adds `getLmStudioModels` RPC to `models.proto`.
>     - Updates `ModelsServiceDefinition` in `models.ts`.
>   - **Methods**:
>     - Implements `getLmStudioModels()` in `getLmStudioModels.ts`.
>     - Registers `getLmStudioModels` in `methods.ts`.
>   - **Misc**:
>     - Removes `requestLmStudioModels` from `WebviewMessage.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 725cf0aee07c8ac7331296a71357db9f804a4a0a. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->