### PR TITLE
Enhance DiffViewProvider to preserve cursor focus when opening text documents

### DIFF
--- a/src/integrations/editor/DiffViewProvider.ts
+++ b/src/integrations/editor/DiffViewProvider.ts
@@ -202,6 +202,7 @@ export class DiffViewProvider {
 
 		await vscode.window.showTextDocument(vscode.Uri.file(absolutePath), {
 			preview: false,
+			preserveFocus: true,
 		})
 		await this.closeAllDiffViews()
 
@@ -302,6 +303,7 @@ export class DiffViewProvider {
 			if (this.documentWasOpen) {
 				await vscode.window.showTextDocument(vscode.Uri.file(absolutePath), {
 					preview: false,
+					preserveFocus: true,
 				})
 			}
 			await this.closeAllDiffViews()
@@ -338,7 +340,9 @@ export class DiffViewProvider {
 					arePathsEqual(tab.input.modified.fsPath, uri.fsPath),
 			)
 		if (diffTab && diffTab.input instanceof vscode.TabInputTextDiff) {
-			const editor = await vscode.window.showTextDocument(diffTab.input.modified)
+			const editor = await vscode.window.showTextDocument(diffTab.input.modified, {
+				preserveFocus: true,
+			})
 			return editor
 		}
 		// Open new diff editor
@@ -358,6 +362,9 @@ export class DiffViewProvider {
 				}),
 				uri,
 				`${fileName}: ${fileExists ? "Original ↔ Cline's Changes" : "New File"} (Editable)`,
+				{
+					preserveFocus: true,
+				},
 			)
 			// This may happen on very slow machines ie project idx
 			setTimeout(() => {


### PR DESCRIPTION
### Description
Vscode Steals the cursor when editing document when its opening files to show in the diff view and in a few other steps. This change ensures that Vscode does not do that in specifically while diff editing. 
NOTE: This doesn't make the focus get to the first line of the new file but it does take the focus away from the cline text box if you are using that. 

### Test Procedure
- Run this code in a debugger
- Do something in chat that makes a file edit
- Keep typing randomly in the terminal until the entire edit is finished and you will notice that the cursor was not stolen by the cline to edit files etc 


### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [X] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [X] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [X] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [X] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [X] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Enhances `DiffViewProvider` to preserve cursor focus during diff editing by adding `preserveFocus: true` to relevant `vscode.window.showTextDocument` calls.
> 
>   - **Behavior**:
>     - Adds `preserveFocus: true` to `vscode.window.showTextDocument` calls in `DiffViewProvider` to prevent cursor focus loss during diff editing.
>     - Affects `open()`, `saveChanges()`, `revertChanges()`, and `openDiffEditor()` methods.
>   - **Misc**:
>     - No changes to logic or functionality beyond focus preservation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for b1080a8e8528fb3b3762db3b80a874d149727b0a. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->