### PR TITLE
Re-enable tests in workflow

### DIFF
--- a/.changeset/nasty-taxis-trade.md
+++ b/.changeset/nasty-taxis-trade.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Re-enable tests in workflow

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,7 +23,7 @@ jobs:
         uses: ./.github/workflows/test.yml
 
     publish:
-        # needs: test
+        needs: test
         name: Publish Extension
         runs-on: ubuntu-latest
         environment: publish


### PR DESCRIPTION
### Description

Reverts change from a recent community PR.

### Test Procedure

<!-- How did you test this? Are you confident that it will not introduce bugs? If so, why? -->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [X] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [X] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [X] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [X] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [X] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Re-enables tests in the GitHub Actions workflow before publishing by uncommenting `needs: test`.
> 
>   - **Workflow**:
>     - Re-enables `test` job as a prerequisite for `publish` job in `.github/workflows/publish.yml` by uncommenting `needs: test`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for cf455f39db91e3b89bc9376642dec0a913473435. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->