### PR TITLE
Stop doomscrolling

### DIFF
--- a/.changeset/stupid-hotels-brush.md
+++ b/.changeset/stupid-hotels-brush.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": minor
+---
+
+Allow the user to scroll when Cline is editing a file by disabling auto-scroll when the user scrolls up

--- a/src/integrations/editor/DiffViewProvider.ts
+++ b/src/integrations/editor/DiffViewProvider.ts
@@ -26,6 +26,9 @@ export class DiffViewProvider {
 	private streamedLines: string[] = []
 	private preDiagnostics: [vscode.Uri, vscode.Diagnostic[]][] = []
 	private fileEncoding: string = "utf8"
+	private lastFirstVisibleLine: number = 0
+	private shouldAutoScroll: boolean = true
+	private scrollListener?: vscode.Disposable
 
 	constructor(private cwd: string) {}
 
@@ -34,6 +37,8 @@ export class DiffViewProvider {
 		const fileExists = this.editType === "modify"
 		const absolutePath = path.resolve(this.cwd, relPath)
 		this.isEditing = true
+		this.shouldAutoScroll = true
+		this.lastFirstVisibleLine = 0
 		// if the file is already open, ensure it's not dirty before getting its contents
 		if (fileExists) {
 			const existingDocument = vscode.workspace.textDocuments.find((doc) => arePathsEqual(doc.uri.fsPath, absolutePath))
@@ -79,6 +84,21 @@ export class DiffViewProvider {
 		this.fadedOverlayController.addLines(0, this.activeDiffEditor.document.lineCount)
 		this.scrollEditorToLine(0) // will this crash for new files?
 		this.streamedLines = []
+
+		// Add scroll detection to disable auto-scrolling when user scrolls up
+		this.scrollListener = vscode.window.onDidChangeTextEditorVisibleRanges((e: vscode.TextEditorVisibleRangesChangeEvent) => {
+			if (e.textEditor === this.activeDiffEditor) {
+				const currentFirstVisibleLine = e.visibleRanges[0]?.start.line || 0
+
+				// If the first visible line moved upward, user scrolled up
+				if (currentFirstVisibleLine < this.lastFirstVisibleLine) {
+					this.shouldAutoScroll = false
+				}
+
+				// Always update our tracking variable
+				this.lastFirstVisibleLine = currentFirstVisibleLine
+			}
+		})
 	}
 
 	async update(accumulatedContent: string, isFinal: boolean) {
@@ -128,25 +148,30 @@ export class DiffViewProvider {
 			this.activeLineController.setActiveLine(currentLine)
 			this.fadedOverlayController.updateOverlayAfterLine(currentLine, document.lineCount)
 
-			// Scroll to the last changed line
-			if (diffLines.length <= 5) {
-				// For small changes, just jump directly to the line
-				this.scrollEditorToLine(currentLine)
-			} else {
-				// For larger changes, create a quick scrolling animation
-				const startLine = this.streamedLines.length
-				const endLine = currentLine
-				const totalLines = endLine - startLine
-				const numSteps = 10 // Adjust this number to control animation speed
-				const stepSize = Math.max(1, Math.floor(totalLines / numSteps))
+			// Scroll to the last changed line only if the user hasn't scrolled up
+			if (this.shouldAutoScroll) {
+				if (diffLines.length <= 5) {
+					// For small changes, just jump directly to the line
+					this.scrollEditorToLine(currentLine)
+				} else {
+					// For larger changes, create a quick scrolling animation
+					const startLine = this.streamedLines.length
+					const endLine = currentLine
+					const totalLines = endLine - startLine
+					const numSteps = 10 // Adjust this number to control animation speed
+					const stepSize = Math.max(1, Math.floor(totalLines / numSteps))
 
-				// Create and await the smooth scrolling animation
-				for (let line = startLine; line <= endLine; line += stepSize) {
-					this.activeDiffEditor?.revealRange(new vscode.Range(line, 0, line, 0), vscode.TextEditorRevealType.InCenter)
-					await new Promise((resolve) => setTimeout(resolve, 16)) // ~60fps
+					// Create and await the smooth scrolling animation
+					for (let line = startLine; line <= endLine; line += stepSize) {
+						this.activeDiffEditor?.revealRange(
+							new vscode.Range(line, 0, line, 0),
+							vscode.TextEditorRevealType.InCenter,
+						)
+						await new Promise((resolve) => setTimeout(resolve, 16)) // ~60fps
+					}
+					// Ensure we end at the final line
+					this.scrollEditorToLine(currentLine)
 				}
-				// Ensure we end at the final line
-				this.scrollEditorToLine(currentLine)
 			}
 		}
 
@@ -418,5 +443,15 @@ export class DiffViewProvider {
 		this.activeLineController = undefined
 		this.streamedLines = []
 		this.preDiagnostics = []
+
+		// Clean up the scroll listener
+		if (this.scrollListener) {
+			this.scrollListener.dispose()
+			this.scrollListener = undefined
+		}
+
+		// Reset auto-scroll state
+		this.shouldAutoScroll = true
+		this.lastFirstVisibleLine = 0
 	}
 }


### PR DESCRIPTION
## Description

This PR disables auto-scrolling in the DiffViewProvider when a user scrolls up, allowing them to focus on specific code sections while Cline is streaming edits. Key improvements:

- Detects upward scrolling as user intent to focus on a specific section
- Disables auto-scroll for the remainder of the edit session when detected
- Properly resets auto-scroll state for new edit sessions
- Maintains expected behavior across edit operations

## Test Procedure

1. Initiated a file edit with Cline that would produce multi-line changes (e.g., asked Cline to refactor a function)
2. Observed that the editor auto-scrolled to follow new edits as they came in
3. Manually scrolled up to an earlier part of the file during the edit process
4. Verified that auto-scrolling stopped, allowing me to continue reviewing the earlier section
5. Confirmed that when the edit completed and I started a new edit, auto-scrolling was re-enabled
6. Tested edge cases:
   - Cancelling an edit and starting a new one (auto-scroll resets properly)
   - Rejecting changes (cleanup happens correctly)
   - Accepting changes (cleanup happens correctly)
   - Rapidly scrolling up and down during edits (behaves as expected)

All test scenarios worked correctly, with the editor respecting user scroll actions while maintaining expected behavior for new edit sessions.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Disables auto-scrolling in `DiffViewProvider` when user scrolls up, allowing focus on specific code sections during streaming edits.
> 
>   - **Behavior**:
>     - Disables auto-scrolling in `DiffViewProvider` when user scrolls up, allowing focus on specific code sections during streaming edits.
>     - Auto-scroll state resets at new edit session start or diff view disposal.
>   - **Implementation**:
>     - Adds `lastFirstVisibleLine` and `shouldAutoScroll` to track scroll state in `DiffViewProvider`.
>     - Implements scroll detection using `vscode.window.onDidChangeTextEditorVisibleRanges` to update scroll state.
>     - Updates `update()` and `reset()` methods to handle new scroll behavior.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 7f4d08f4a5ffc07f7de06cc889003444dc36f561. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->