### PR TITLE
fix excessive markdown format character escaping

### DIFF
--- a/.changeset/heavy-spoons-ring.md
+++ b/.changeset/heavy-spoons-ring.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Fix for markdown copy excessive escape characters

--- a/webview-ui/src/components/chat/ChatView.tsx
+++ b/webview-ui/src/components/chat/ChatView.tsx
@@ -41,6 +41,8 @@ interface ChatViewProps {
 	showHistoryView: () => void
 }
 
+const MD_FMT_ESCAPE_REGEX = /\w(\\[_*])\w/g
+
 async function convertHtmlToMarkdown(html: string) {
 	// Process the HTML to Markdown
 	const result = await unified()
@@ -58,7 +60,9 @@ async function convertHtmlToMarkdown(html: string) {
 		})
 		.process(html)
 
-	return String(result)
+	const md = String(result)
+	// transform snake\_case to snake_case or b\*p to b*p
+	return md.replace(MD_FMT_ESCAPE_REGEX, (v) => v.replace("\\", ""))
 }
 
 export const MAX_IMAGES_PER_MESSAGE = 20 // Anthropic limits to 20 images
@@ -120,7 +124,6 @@ const ChatView = ({ isHidden, showAnnouncement, hideAnnouncement, showHistoryVie
 
 					// Convert HTML to Markdown
 					const markdown = await convertHtmlToMarkdown(selectedHtml)
-
 					vscode.postMessage({ type: "copyToClipboard", text: markdown })
 					e.preventDefault()
 				}

--- a/webview-ui/src/components/chat/ChatView.tsx
+++ b/webview-ui/src/components/chat/ChatView.tsx
@@ -41,7 +41,26 @@ interface ChatViewProps {
 	showHistoryView: () => void
 }
 
-const MD_FMT_ESCAPE_REGEX = /\w(\\[_*])\w/g
+// Function to clean up markdown escape characters
+function cleanupMarkdownEscapes(markdown: string): string {
+	return (
+		markdown
+			// Handle underscores and asterisks (single or multiple)
+			.replace(/\\([_*]+)/g, "$1")
+
+			// Handle angle brackets (for generics and XML)
+			.replace(/\\([<>])/g, "$1")
+
+			// Handle backticks (for code)
+			.replace(/\\(`)/g, "$1")
+
+			// Handle other common markdown special characters
+			.replace(/\\([[\]()#.!])/g, "$1")
+
+			// Fix multiple consecutive backslashes
+			.replace(/\\{2,}([_*`<>[\]()#.!])/g, "$1")
+	)
+}
 
 async function convertHtmlToMarkdown(html: string) {
 	// Process the HTML to Markdown
@@ -57,12 +76,14 @@ async function convertHtmlToMarkdown(html: string) {
 			rule: "-", // Use - for horizontal rules
 			ruleSpaces: false, // No spaces in horizontal rules
 			fences: true,
+			escape: false,
+			entities: false,
 		})
 		.process(html)
 
 	const md = String(result)
-	// transform snake\_case to snake_case or b\*p to b*p
-	return md.replace(MD_FMT_ESCAPE_REGEX, (v) => v.replace("\\", ""))
+	// Apply comprehensive cleanup of escape characters
+	return cleanupMarkdownEscapes(md)
 }
 
 export const MAX_IMAGES_PER_MESSAGE = 20 // Anthropic limits to 20 images


### PR DESCRIPTION
### Description

<!-- Describe your changes in detail. What problem does this PR solve? -->

### Test Procedure

<!-- How did you test this? Are you confident that it will not introduce bugs? If so, why? -->

* Get some text in the chat view with some `_` and `*` characters
* Highlight the text just around those character if they're in the middle of a word
* See that the copied text doesn't have `\_` but `_` in it

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

### Additional Notes

Fix for issue https://github.com/cline/cline/issues/3326

The highlighted text:
<img width="332" alt="Screenshot 2025-05-06 at 10 43 39 PM" src="https://github.com/user-attachments/assets/99b4d317-a23c-41b5-a69b-b6251022bb51" />

Copies as:
```
mpt_com
```

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes excessive markdown escaping in `ChatView.tsx` by updating `convertHtmlToMarkdown()` with a regex to correct format characters.
> 
>   - **Behavior**:
>     - Fixes excessive escaping of markdown format characters in `convertHtmlToMarkdown()` in `ChatView.tsx`.
>     - Introduces `MD_FMT_ESCAPE_REGEX` to transform `snake\_case` to `snake_case` and `b\*p` to `b*p`.
>   - **Functions**:
>     - Updates `convertHtmlToMarkdown()` to use `MD_FMT_ESCAPE_REGEX` for post-processing markdown output.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 7eba1cba2f78ce3a8087dd7f8465b71fa11564e0. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->