### PR TITLE
Diable auto track

### DIFF
--- a/.changeset/chilly-oranges-play.md
+++ b/.changeset/chilly-oranges-play.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+disable autocapture

--- a/webview-ui/src/App.tsx
+++ b/webview-ui/src/App.tsx
@@ -74,15 +74,6 @@ const AppContent = () => {
 
 	useEvent("message", handleMessage)
 
-	// useEffect(() => {
-	// 	if (telemetrySetting === "enabled") {
-	// 		posthog.identify(vscMachineId)
-	// 		posthog.opt_in_capturing()
-	// 	} else {
-	// 		posthog.opt_out_capturing()
-	// 	}
-	// }, [telemetrySetting, vscMachineId])
-
 	useEffect(() => {
 		if (shouldShowAnnouncement) {
 			setShowAnnouncement(true)

--- a/webview-ui/src/Providers.tsx
+++ b/webview-ui/src/Providers.tsx
@@ -9,6 +9,7 @@ import posthog from "posthog-js"
 
 posthog.init(posthogConfig.apiKey, {
 	api_host: posthogConfig.host,
+	autocapture: false,
 })
 
 export function Providers({ children }: { children: ReactNode }) {


### PR DESCRIPTION
### Description

Disables autocatpure

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Disables PostHog autocapture and removes unused telemetry settings code in `App.tsx`.
> 
>   - **Behavior**:
>     - Disables PostHog autocapture by setting `autocapture: false` in `posthog.init` in `Providers.tsx`.
>     - Removes commented-out telemetry settings code in `App.tsx` that handled `posthog` identification and capture opt-in/out based on `telemetrySetting`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for b8b0279e042c92e39561538fdb41d7da9cfaf373. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->