### PR TITLE
Add org to team affiliation check

### DIFF
--- a/.changeset/flat-papayas-doubt.md
+++ b/.changeset/flat-papayas-doubt.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Add org to team affiliation check

--- a/.github/workflows/changeset-converter.yml
+++ b/.github/workflows/changeset-converter.yml
@@ -33,6 +33,7 @@ jobs:
               uses: morfien101/actions-authorized-user@4a3cfbf0bcb3cafe4a71710a278920c5d94bb38b
               with:
                   username: ${{ github.actor }}
+                  org: ${{ github.repo_owner }}
                   team: "deployer"
                   github_token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
### Description

Add org to team affiliation check

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [X] 🏃 Workflow Changes

### Pre-flight Checklist

-   [X] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [X] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [X] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [X] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `org` parameter to team affiliation check in `changeset-converter.yml` workflow.
> 
>   - **Workflow Changes**:
>     - Add `org` parameter to `actions-authorized-user` step in `changeset-converter.yml` to include organization in team affiliation check.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for d4ad6b1c2e69cf30b5b7c41099cb83167eb9fa12. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->