### PR TITLE
Conditionally initialize posthog webview

### DIFF
--- a/.changeset/modern-weeks-knock.md
+++ b/.changeset/modern-weeks-knock.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": minor
+---
+
+Only initialize posthog in the webview if the user has opted into telemetry

--- a/webview-ui/src/CustomPostHogProvider.tsx
+++ b/webview-ui/src/CustomPostHogProvider.tsx
@@ -1,0 +1,24 @@
+import { useEffect, type ReactNode } from "react"
+import { PostHogProvider } from "posthog-js/react"
+import posthog from "posthog-js"
+import { posthogConfig } from "@shared/services/config/posthog-config"
+import { useExtensionState } from "./context/ExtensionStateContext"
+
+export function CustomPostHogProvider({ children }: { children: ReactNode }) {
+	const { telemetrySetting } = useExtensionState()
+	const isTelemetryEnabled = telemetrySetting === "enabled"
+
+	useEffect(() => {
+		if (isTelemetryEnabled) {
+			posthog.init(posthogConfig.apiKey, {
+				api_host: posthogConfig.host,
+				autocapture: false,
+				disable_session_recording: true,
+			})
+		} else {
+			posthog.opt_out_capturing()
+		}
+	}, [isTelemetryEnabled])
+
+	return <PostHogProvider client={posthog}>{children}</PostHogProvider>
+}

--- a/webview-ui/src/Providers.tsx
+++ b/webview-ui/src/Providers.tsx
@@ -1,25 +1,18 @@
-import type { ReactNode } from "react"
+import { type ReactNode } from "react"
 
 import { ExtensionStateContextProvider } from "./context/ExtensionStateContext"
 import { FirebaseAuthProvider } from "./context/FirebaseAuthContext"
 import { HeroUIProvider } from "@heroui/react"
-import { PostHogProvider } from "posthog-js/react"
-import { posthogConfig } from "@shared/services/config/posthog-config"
-import posthog from "posthog-js"
-
-posthog.init(posthogConfig.apiKey, {
-	api_host: posthogConfig.host,
-	autocapture: false,
-})
+import { CustomPostHogProvider } from "./CustomPostHogProvider"
 
 export function Providers({ children }: { children: ReactNode }) {
 	return (
 		<ExtensionStateContextProvider>
-			<PostHogProvider client={posthog}>
+			<CustomPostHogProvider>
 				<FirebaseAuthProvider>
 					<HeroUIProvider>{children}</HeroUIProvider>
 				</FirebaseAuthProvider>
-			</PostHogProvider>
+			</CustomPostHogProvider>
 		</ExtensionStateContextProvider>
 	)
 }

--- a/webview-ui/src/components/settings/SettingsView.tsx
+++ b/webview-ui/src/components/settings/SettingsView.tsx
@@ -10,7 +10,6 @@ import { useEvent } from "react-use"
 import { ExtensionMessage } from "@shared/ExtensionMessage"
 import BrowserSettingsSection from "./BrowserSettingsSection"
 import TerminalSettingsSection from "./TerminalSettingsSection"
-import { useFeatureFlag } from "@/hooks/useFeatureFlag"
 import { FEATURE_FLAGS } from "@shared/services/feature-flags/feature-flags"
 const { IS_DEV } = process.env
 
@@ -146,8 +145,6 @@ const SettingsView = ({ onDone }: SettingsViewProps) => {
 		handleSubmit(true)
 	}
 
-	const showCustomInstructions = useFeatureFlag(FEATURE_FLAGS.CUSTOM_INSTRUCTIONS)
-
 	return (
 		<div className="fixed top-0 left-0 right-0 bottom-0 pt-[10px] pr-0 pb-0 pl-5 flex flex-col overflow-hidden">
 			<div className="flex justify-between items-center mb-[13px] pr-[17px]">
@@ -186,24 +183,20 @@ const SettingsView = ({ onDone }: SettingsViewProps) => {
 					/>
 				)}
 
-				{showCustomInstructions && (
-					<div className="mb-[5px]">
-						<VSCodeTextArea
-							value={customInstructions ?? ""}
-							className="w-full"
-							resize="vertical"
-							rows={4}
-							placeholder={
-								'e.g. "Run unit tests at the end", "Use TypeScript with async/await", "Speak in Spanish"'
-							}
-							onInput={(e: any) => setCustomInstructions(e.target?.value ?? "")}>
-							<span className="font-medium">Custom Instructions</span>
-						</VSCodeTextArea>
-						<p className="text-xs mt-[5px] text-[var(--vscode-descriptionForeground)]">
-							These instructions are added to the end of the system prompt sent with every request.
-						</p>
-					</div>
-				)}
+				<div className="mb-[5px]">
+					<VSCodeTextArea
+						value={customInstructions ?? ""}
+						className="w-full"
+						resize="vertical"
+						rows={4}
+						placeholder={'e.g. "Run unit tests at the end", "Use TypeScript with async/await", "Speak in Spanish"'}
+						onInput={(e: any) => setCustomInstructions(e.target?.value ?? "")}>
+						<span className="font-medium">Custom Instructions</span>
+					</VSCodeTextArea>
+					<p className="text-xs mt-[5px] text-[var(--vscode-descriptionForeground)]">
+						These instructions are added to the end of the system prompt sent with every request.
+					</p>
+				</div>
 
 				<div className="mb-[5px]">
 					<VSCodeCheckbox

--- a/webview-ui/src/hooks/useFeatureFlag.ts
+++ b/webview-ui/src/hooks/useFeatureFlag.ts
@@ -1,10 +1,23 @@
+import { useExtensionState } from "@/context/ExtensionStateContext"
 import { useFeatureFlagPayload } from "posthog-js/react"
 
 export const useFeatureFlag = (flagName: string): boolean => {
-	const payload = useFeatureFlagPayload(flagName) as { enabled: boolean }
-	if (payload && payload.enabled) {
-		return payload.enabled
+	const { telemetrySetting } = useExtensionState()
+
+	try {
+		const payload = useFeatureFlagPayload(flagName) as { enabled: boolean }
+		if (payload && typeof payload === "object") {
+			// Check if the enabled property exists and is a boolean
+			if ("enabled" in payload && typeof payload.enabled === "boolean") {
+				return payload.enabled
+			}
+		}
+
+		if (telemetrySetting === "enabled") {
+			console.warn(`Feature flag ${flagName} not found or missing enabled property.`)
+		}
+	} catch (error) {
+		console.error(`Error retrieving feature flag "${flagName}":`, error)
 	}
-	console.warn(`Feature flag ${flagName} not found or missing enabled property.`)
 	return false
 }


### PR DESCRIPTION
### Description

This PR implements conditional initialization of the PostHog client based on the user's telemetry preferences. Now, the PostHog client is only fully initialized when telemetry is explicitly enabled by the user, respecting their privacy choices. When telemetry is disabled, we call `posthog.opt_out_capturing()` as a redundancy to ensure no data is collected.

Key changes:
- Created a new `CustomPostHogProvider` component that initializes PostHog only when telemetry is enabled
- Disabled session recording and autocapture features for additional privacy when telemetry is enabled

### Test Procedure

Testing was performed by:
1. Verifying that PostHog initialization only occurs when telemetry is set to "enabled"
2. Confirming that `posthog.opt_out_capturing()` is called when telemetry is disabled
3. Testing the CustomPostHogProvider with different telemetry settings

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Conditionally initialize PostHog client based on telemetry settings, enhancing privacy by disabling session recording and autocapture.
> 
>   - **Behavior**:
>     - `CustomPostHogProvider` initializes PostHog only if telemetry is enabled, using `posthog.init()` with `autocapture` and `disable_session_recording` set to false and true, respectively.
>     - Calls `posthog.opt_out_capturing()` when telemetry is disabled.
>   - **Components**:
>     - Replaces `PostHogProvider` with `CustomPostHogProvider` in `Providers.tsx`.
>   - **Hooks**:
>     - Updates `useFeatureFlag` in `useFeatureFlag.ts` to log warnings only if telemetry is enabled and handle errors gracefully.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for cf9fc9f2f56bdaece6b18242997799a7c1476d4b. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->