### PR TITLE
fix(bedrock): application inference profile is not work

### DIFF
--- a/.changeset/tricky-grapes-accept.md
+++ b/.changeset/tricky-grapes-accept.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Fixed an issue where loading never finished when using an application inference profile for the model ID

--- a/src/api/providers/bedrock.ts
+++ b/src/api/providers/bedrock.ts
@@ -272,9 +272,13 @@ export class AwsBedrockHandler implements ApiHandler {
 	}
 
 	/**
-	 * Gets the appropriate model ID, accounting for cross-region inference if enabled
+	 * Gets the appropriate model ID, accounting for cross-region inference if enabled.
+	 * If an ARN is specified to model ID, the URL encoded ARN is retrieved.
 	 */
 	async getModelId(): Promise<string> {
+		if (this.options.awsBedrockCustomSelected && this.getModel().id.startsWith("arn:")) {
+			return encodeURIComponent(this.getModel().id)
+		}
 		if (this.options.awsUseCrossRegionInference) {
 			const regionPrefix = this.getRegion().slice(0, 3)
 			switch (regionPrefix) {

--- a/src/api/providers/bedrock.ts
+++ b/src/api/providers/bedrock.ts
@@ -273,13 +273,13 @@ export class AwsBedrockHandler implements ApiHandler {
 
 	/**
 	 * Gets the appropriate model ID, accounting for cross-region inference if enabled.
-	 * If an ARN is specified to model ID, the URL encoded ARN is retrieved.
+	 * If the model ID is an ARN that contains a slash, you will get the URL encoded ARN.
 	 */
 	async getModelId(): Promise<string> {
-		if (this.options.awsBedrockCustomSelected && this.getModel().id.startsWith("arn:")) {
+		if (this.options.awsBedrockCustomSelected && this.getModel().id.includes("/")) {
 			return encodeURIComponent(this.getModel().id)
 		}
-		if (this.options.awsUseCrossRegionInference) {
+		if (!this.options.awsBedrockCustomSelected && this.options.awsUseCrossRegionInference) {
 			const regionPrefix = this.getRegion().slice(0, 3)
 			switch (regionPrefix) {
 				case "us-":

--- a/webview-ui/src/components/settings/ApiOptions.tsx
+++ b/webview-ui/src/components/settings/ApiOptions.tsx
@@ -822,10 +822,7 @@ const ApiOptions = ({
 									color: "var(--vscode-descriptionForeground)",
 								}}>
 								Select "Custom" when using the Application Inference Profile in Bedrock. Enter the Application
-								Inference Profile ID in the Model ID field. However, be sure to encode the / in the ARN as %2F.
-								<br />
-								Example: arn:aws:bedrock:us-west-2:&lt;AWS Account
-								ID&gt;:application-inference-profile%2Fxxxxxxxxxxxx
+								Inference Profile ARN in the Model ID field.
 							</p>
 							<label htmlFor="bedrock-model-input">
 								<span style={{ fontWeight: 500 }}>Model ID</span>


### PR DESCRIPTION
### Description

Addresses an issue where application inference profiles with cross region inference are not available on Amazon Bedrock. This feature was introduced in #2078, but it has been reported that it doesn't work with #3302.
When using an application inference profile and cross-region inference is enabled, a prefix such as us. is added before the ARN, causing it to be treated as an invalid ID.

There was also a misconfiguration due to encoding requirements, so the following will fix this issue.

- Encode if the model ID contains a slash
  - This will in turn improve UX
- Do not add the cross-region inference prefix when specifying a custom model ID
<!-- Describe your changes in detail. What problem does this PR solve? -->

### Test Procedure

- `npm run test` 
- `npm run format:fix`
- Debug run in VS Code.
<!-- How did you test this? Are you confident that it will not introduce bugs? If so, why? -->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
  -  It works until the unit test, but test:integration fails to start because my environment seems bad. Could someone please check it out?
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

![image](https://github.com/user-attachments/assets/d49e2cc9-10a3-44a0-b82c-58c8b5b6376d)

![image](https://github.com/user-attachments/assets/41694c79-4f96-4e43-8134-ef1fb61510f6)

<!-- For UI changes, add screenshots here -->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes Amazon Bedrock application inference profile handling by URL encoding ARNs and updates UI instructions.
> 
>   - **Behavior**:
>     - Fixes application inference profile handling in Amazon Bedrock by URL encoding ARNs in `getModelId()` in `bedrock.ts`.
>     - Updates UI instructions in `ApiOptions.tsx` to reflect the change in ARN encoding requirements.
>   - **Misc**:
>     - Removes outdated instruction about encoding slashes in ARNs in `ApiOptions.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 0aec4e977f97dc4120fd42890304993f01f2750d. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->