### PR TITLE
Warn about rosetta on osx in build-protos

### DIFF
--- a/proto/build-proto.js
+++ b/proto/build-proto.js
@@ -6,11 +6,43 @@ import { fileURLToPath } from "url"
 import { execSync } from "child_process"
 import { globby } from "globby"
 import chalk from "chalk"
+import os from "os"
 
 import { createRequire } from "module"
 const require = createRequire(import.meta.url)
 const protoc = path.join(require.resolve("grpc-tools"), "../bin/protoc")
 const tsProtoPlugin = require.resolve("ts-proto/protoc-gen-ts_proto")
+
+// Check for Apple Silicon compatibility
+function checkAppleSiliconCompatibility() {
+  // Only run check on macOS
+  if (process.platform !== 'darwin') {
+    return;
+  }
+  
+  // Check if running on Apple Silicon
+  const cpuArchitecture = os.arch();
+  if (cpuArchitecture === 'arm64') {
+    console.log(chalk.yellow('Detected Apple Silicon (ARM64) architecture.'));
+    
+    try {
+      // Check if Rosetta is installed
+      const rosettaCheck = execSync('/usr/bin/pgrep oahd || echo "NOT_INSTALLED"').toString().trim();
+      
+      if (rosettaCheck === 'NOT_INSTALLED') {
+        console.log(chalk.red('Rosetta 2 is NOT installed. The npm version of protoc is not compatible with Apple Silicon.'));
+        console.log(chalk.cyan('Please install Rosetta 2 using the following command:'));
+        console.log(chalk.cyan('  softwareupdate --install-rosetta --agree-to-license'));
+        console.log(chalk.red('Aborting build process.'));
+        process.exit(1);
+      } else {
+        console.log(chalk.green('Rosetta 2 is installed. Continuing with build.'));
+      }
+    } catch (error) {
+      console.log(chalk.yellow('Could not determine Rosetta installation status. Proceeding anyway.'));
+    }
+  }
+}
 
 const __filename = fileURLToPath(import.meta.url)
 const SCRIPT_DIR = path.dirname(__filename)
@@ -35,6 +67,9 @@ const serviceDirs = Object.keys(serviceNameMap).map((serviceKey) => path.join(RO
 
 async function main() {
 	console.log(chalk.bold.blue("Starting Protocol Buffer code generation..."))
+	
+	// Check for Apple Silicon compatibility before proceeding
+	checkAppleSiliconCompatibility()
 
 	// Define output directories
 	const TS_OUT_DIR = path.join(ROOT_DIR, "src", "shared", "proto")


### PR DESCRIPTION
### Description

@celestial-vault warns that apple silicon fails to run the protoc that we install using npm, because it's compiled for intel and not arm. The solution he suggested is to detect the situation & provide rosetta install instructions to the developer

Alternative solution: find, or make our own, protoc npm package that supports apple silicon

### Test Procedure

Run `npm run protos` on apple silicon without rosetta installed. Follow the rosetta install instructions. Try again

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)