### PR TITLE
[PROTOBUS] Move refreshOpenAiModels to protobus

### DIFF
--- a/.changeset/sour-kiwis-smash.md
+++ b/.changeset/sour-kiwis-smash.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+refreshOpenAiModels protobus migration

--- a/proto/models.proto
+++ b/proto/models.proto
@@ -16,6 +16,8 @@ service ModelsService {
   rpc getVsCodeLmModels(EmptyRequest) returns (VsCodeLmModelsArray);
   // Refreshes and returns OpenRouter models
   rpc refreshOpenRouterModels(EmptyRequest) returns (OpenRouterModels);
+  // Refreshes and returns OpenAI models
+  rpc refreshOpenAiModels(OpenAiModelsRequest) returns (StringArray);
 }
 
 // List of VS Code LM models
@@ -47,5 +49,12 @@ message OpenRouterModelInfo {
 // Response message for OpenRouter models
 message OpenRouterModels {
   map<string, OpenRouterModelInfo> models = 1;
+}
+
+// Request for fetching OpenAI models
+message OpenAiModelsRequest {
+  Metadata metadata = 1;
+  string baseUrl = 2;
+  string apiKey = 3;
 }
 

--- a/src/core/controller/index.ts
+++ b/src/core/controller/index.ts
@@ -1,6 +1,5 @@
 import { Anthropic } from "@anthropic-ai/sdk"
 import axios from "axios"
-import type { AxiosRequestConfig } from "axios"
 
 import fs from "fs/promises"
 import { setTimeout as setTimeoutPromise } from "node:timers/promises"
@@ -334,11 +333,6 @@ export class Controller {
 				break
 			case "refreshRequestyModels":
 				await this.refreshRequestyModels()
-				break
-			case "refreshOpenAiModels":
-				const { apiConfiguration } = await getAllExtensionState(this.context)
-				const openAiModels = await this.getOpenAiModels(apiConfiguration.openAiBaseUrl, apiConfiguration.openAiApiKey)
-				this.postMessageToWebview({ type: "openAiModels", openAiModels })
 				break
 			case "refreshClineRules":
 				await refreshClineRulesToggles(this.context, cwd)
@@ -1114,32 +1108,6 @@ Here is the project's README to help you get started:\n\n${mcpDetails.readmeCont
 				type: "mcpDownloadDetails",
 				error: errorMessage,
 			})
-		}
-	}
-
-	// OpenAi
-
-	async getOpenAiModels(baseUrl?: string, apiKey?: string) {
-		try {
-			if (!baseUrl) {
-				return []
-			}
-
-			if (!URL.canParse(baseUrl)) {
-				return []
-			}
-
-			const config: AxiosRequestConfig = {}
-			if (apiKey) {
-				config["headers"] = { Authorization: `Bearer ${apiKey}` }
-			}
-
-			const response = await axios.get(`${baseUrl}/models`, config)
-			const modelsArray = response.data?.data?.map((model: any) => model.id) || []
-			const models = [...new Set<string>(modelsArray)]
-			return models
-		} catch (error) {
-			return []
 		}
 	}
 

--- a/src/core/controller/models/methods.ts
+++ b/src/core/controller/models/methods.ts
@@ -6,6 +6,7 @@ import { registerMethod } from "./index"
 import { getLmStudioModels } from "./getLmStudioModels"
 import { getOllamaModels } from "./getOllamaModels"
 import { getVsCodeLmModels } from "./getVsCodeLmModels"
+import { refreshOpenAiModels } from "./refreshOpenAiModels"
 import { refreshOpenRouterModels } from "./refreshOpenRouterModels"
 
 // Register all models service methods
@@ -14,5 +15,6 @@ export function registerAllMethods(): void {
 	registerMethod("getLmStudioModels", getLmStudioModels)
 	registerMethod("getOllamaModels", getOllamaModels)
 	registerMethod("getVsCodeLmModels", getVsCodeLmModels)
+	registerMethod("refreshOpenAiModels", refreshOpenAiModels)
 	registerMethod("refreshOpenRouterModels", refreshOpenRouterModels)
 }

--- a/src/core/controller/models/refreshOpenAiModels.ts
+++ b/src/core/controller/models/refreshOpenAiModels.ts
@@ -1,0 +1,40 @@
+import { Controller } from ".."
+import { OpenAiModelsRequest } from "../../../shared/proto/models"
+import { StringArray } from "../../../shared/proto/common"
+import axios from "axios"
+import type { AxiosRequestConfig } from "axios"
+
+/**
+ * Fetches available models from the OpenAI API
+ * @param controller The controller instance
+ * @param request Request containing the base URL and API key
+ * @returns Array of model names
+ */
+export async function refreshOpenAiModels(controller: Controller, request: OpenAiModelsRequest): Promise<StringArray> {
+	try {
+		if (!request.baseUrl) {
+			return StringArray.create({ values: [] })
+		}
+
+		if (!URL.canParse(request.baseUrl)) {
+			return StringArray.create({ values: [] })
+		}
+
+		const config: AxiosRequestConfig = {}
+		if (request.apiKey) {
+			config["headers"] = { Authorization: `Bearer ${request.apiKey}` }
+		}
+
+		const response = await axios.get(`${request.baseUrl}/models`, config)
+		const modelsArray = response.data?.data?.map((model: any) => model.id) || []
+		const models = [...new Set<string>(modelsArray)]
+
+		// Send models to webview
+		controller.postMessageToWebview({ type: "openAiModels", openAiModels: models })
+
+		return StringArray.create({ values: models })
+	} catch (error) {
+		console.error("Error fetching OpenAI models:", error)
+		return StringArray.create({ values: [] })
+	}
+}

--- a/src/shared/WebviewMessage.ts
+++ b/src/shared/WebviewMessage.ts
@@ -21,7 +21,6 @@ export interface WebviewMessage {
 		| "openMention"
 		| "showChatView"
 		| "refreshRequestyModels"
-		| "refreshOpenAiModels"
 		| "refreshClineRules"
 		| "openMcpSettings"
 		| "restartMcpServer"

--- a/src/shared/proto/models.ts
+++ b/src/shared/proto/models.ts
@@ -6,7 +6,7 @@
 
 /* eslint-disable */
 import { BinaryReader, BinaryWriter } from "@bufbuild/protobuf/wire"
-import { EmptyRequest, StringArray, StringRequest } from "./common"
+import { EmptyRequest, Metadata, StringArray, StringRequest } from "./common"
 
 export const protobufPackage = "cline"
 
@@ -44,6 +44,13 @@ export interface OpenRouterModels {
 export interface OpenRouterModels_ModelsEntry {
 	key: string
 	value?: OpenRouterModelInfo | undefined
+}
+
+/** Request for fetching OpenAI models */
+export interface OpenAiModelsRequest {
+	metadata?: Metadata | undefined
+	baseUrl: string
+	apiKey: string
 }
 
 function createBaseVsCodeLmModelsArray(): VsCodeLmModelsArray {
@@ -571,6 +578,99 @@ export const OpenRouterModels_ModelsEntry: MessageFns<OpenRouterModels_ModelsEnt
 	},
 }
 
+function createBaseOpenAiModelsRequest(): OpenAiModelsRequest {
+	return { metadata: undefined, baseUrl: "", apiKey: "" }
+}
+
+export const OpenAiModelsRequest: MessageFns<OpenAiModelsRequest> = {
+	encode(message: OpenAiModelsRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+		if (message.metadata !== undefined) {
+			Metadata.encode(message.metadata, writer.uint32(10).fork()).join()
+		}
+		if (message.baseUrl !== "") {
+			writer.uint32(18).string(message.baseUrl)
+		}
+		if (message.apiKey !== "") {
+			writer.uint32(26).string(message.apiKey)
+		}
+		return writer
+	},
+
+	decode(input: BinaryReader | Uint8Array, length?: number): OpenAiModelsRequest {
+		const reader = input instanceof BinaryReader ? input : new BinaryReader(input)
+		let end = length === undefined ? reader.len : reader.pos + length
+		const message = createBaseOpenAiModelsRequest()
+		while (reader.pos < end) {
+			const tag = reader.uint32()
+			switch (tag >>> 3) {
+				case 1: {
+					if (tag !== 10) {
+						break
+					}
+
+					message.metadata = Metadata.decode(reader, reader.uint32())
+					continue
+				}
+				case 2: {
+					if (tag !== 18) {
+						break
+					}
+
+					message.baseUrl = reader.string()
+					continue
+				}
+				case 3: {
+					if (tag !== 26) {
+						break
+					}
+
+					message.apiKey = reader.string()
+					continue
+				}
+			}
+			if ((tag & 7) === 4 || tag === 0) {
+				break
+			}
+			reader.skip(tag & 7)
+		}
+		return message
+	},
+
+	fromJSON(object: any): OpenAiModelsRequest {
+		return {
+			metadata: isSet(object.metadata) ? Metadata.fromJSON(object.metadata) : undefined,
+			baseUrl: isSet(object.baseUrl) ? globalThis.String(object.baseUrl) : "",
+			apiKey: isSet(object.apiKey) ? globalThis.String(object.apiKey) : "",
+		}
+	},
+
+	toJSON(message: OpenAiModelsRequest): unknown {
+		const obj: any = {}
+		if (message.metadata !== undefined) {
+			obj.metadata = Metadata.toJSON(message.metadata)
+		}
+		if (message.baseUrl !== "") {
+			obj.baseUrl = message.baseUrl
+		}
+		if (message.apiKey !== "") {
+			obj.apiKey = message.apiKey
+		}
+		return obj
+	},
+
+	create<I extends Exact<DeepPartial<OpenAiModelsRequest>, I>>(base?: I): OpenAiModelsRequest {
+		return OpenAiModelsRequest.fromPartial(base ?? ({} as any))
+	},
+	fromPartial<I extends Exact<DeepPartial<OpenAiModelsRequest>, I>>(object: I): OpenAiModelsRequest {
+		const message = createBaseOpenAiModelsRequest()
+		message.metadata =
+			object.metadata !== undefined && object.metadata !== null ? Metadata.fromPartial(object.metadata) : undefined
+		message.baseUrl = object.baseUrl ?? ""
+		message.apiKey = object.apiKey ?? ""
+		return message
+	},
+}
+
 /** Service for model-related operations */
 export type ModelsServiceDefinition = typeof ModelsServiceDefinition
 export const ModelsServiceDefinition = {
@@ -610,6 +710,15 @@ export const ModelsServiceDefinition = {
 			requestType: EmptyRequest,
 			requestStream: false,
 			responseType: OpenRouterModels,
+			responseStream: false,
+			options: {},
+		},
+		/** Refreshes and returns OpenAI models */
+		refreshOpenAiModels: {
+			name: "refreshOpenAiModels",
+			requestType: OpenAiModelsRequest,
+			requestStream: false,
+			responseType: StringArray,
 			responseStream: false,
 			options: {},
 		},

--- a/webview-ui/src/components/settings/ApiOptions.tsx
+++ b/webview-ui/src/components/settings/ApiOptions.tsx
@@ -999,7 +999,20 @@ const ApiOptions = ({
 						value={apiConfiguration?.openAiBaseUrl || ""}
 						style={{ width: "100%", marginBottom: 10 }}
 						type="url"
-						onInput={handleInputChange("openAiBaseUrl")}
+						onInput={(e: any) => {
+							const baseUrl = e.target.value
+							handleInputChange("openAiBaseUrl")({ target: { value: baseUrl } })
+
+							// Refresh models when baseUrl or apiKey changes and both have values
+							if (baseUrl && apiConfiguration?.openAiApiKey) {
+								ModelsServiceClient.refreshOpenAiModels({
+									baseUrl,
+									apiKey: apiConfiguration.openAiApiKey,
+								}).catch((error) => {
+									console.error("Failed to refresh OpenAI models:", error)
+								})
+							}
+						}}
 						placeholder={"Enter base URL..."}>
 						<span style={{ fontWeight: 500 }}>Base URL</span>
 					</VSCodeTextField>
@@ -1007,7 +1020,20 @@ const ApiOptions = ({
 						value={apiConfiguration?.openAiApiKey || ""}
 						style={{ width: "100%", marginBottom: 10 }}
 						type="password"
-						onInput={handleInputChange("openAiApiKey")}
+						onInput={(e: any) => {
+							const apiKey = e.target.value
+							handleInputChange("openAiApiKey")({ target: { value: apiKey } })
+
+							// Refresh models when baseUrl or apiKey changes and both have values
+							if (apiConfiguration?.openAiBaseUrl && apiKey) {
+								ModelsServiceClient.refreshOpenAiModels({
+									baseUrl: apiConfiguration.openAiBaseUrl,
+									apiKey,
+								}).catch((error) => {
+									console.error("Failed to refresh OpenAI models:", error)
+								})
+							}
+						}}
 						placeholder="Enter API Key...">
 						<span style={{ fontWeight: 500 }}>API Key</span>
 					</VSCodeTextField>

--- a/webview-ui/src/components/settings/ApiOptions.tsx
+++ b/webview-ui/src/components/settings/ApiOptions.tsx
@@ -264,6 +264,15 @@ const ApiOptions = ({
 
 	// Debounced function to refresh OpenAI models (prevents excessive API calls while typing)
 	const debounceTimerRef = useRef<NodeJS.Timeout | null>(null)
+
+	useEffect(() => {
+		return () => {
+			if (debounceTimerRef.current) {
+				clearTimeout(debounceTimerRef.current)
+			}
+		}
+	}, [])
+
 	const debouncedRefreshOpenAiModels = useCallback((baseUrl?: string, apiKey?: string) => {
 		if (debounceTimerRef.current) {
 			clearTimeout(debounceTimerRef.current)


### PR DESCRIPTION
### Description

This PR migrates the refreshOpenAiModels message to the gRPC/Protobuf system. It converts the legacy VSCode message passing mechanism to a gRPC method in the ModelsService. The client can now call ModelsServiceClient.refreshOpenAiModels() to obtain an array of Open AI models that are available. This PR also adds a debounced refresh so that the models are retrieved after users are done typing in the API key or Base URL fields.

### Test Procedure

To test this change, launch Cline with an OpenAI key configured, and confirm it is able to obtain a list of OpenAI that are available.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [X] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [X] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [X] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [X] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [X] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Migrates `refreshOpenAiModels` to gRPC/Protobuf, updating the method registration, implementation, and UI handling.
> 
>   - **Behavior**:
>     - Migrates `refreshOpenAiModels` to gRPC/Protobuf in `models.proto` and `refreshOpenAiModels.ts`.
>     - Adds `debouncedRefreshOpenAiModels` in `ApiOptions.tsx` to debounce API calls when typing in OpenAI settings.
>   - **Methods**:
>     - Registers `refreshOpenAiModels` in `methods.ts`.
>     - Implements `refreshOpenAiModels` in `refreshOpenAiModels.ts` to fetch models from OpenAI API.
>   - **UI**:
>     - Updates `ApiOptions.tsx` to use `debouncedRefreshOpenAiModels` for OpenAI settings.
>   - **Misc**:
>     - Removes legacy `refreshOpenAiModels` handling from `index.ts` and `WebviewMessage.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for a46e90991f0d38ded0ee9a27a7fbab9921d0f15b. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->