### PR TITLE
Fixing task lockout after shell integration stream bug leading to terminal hang

### DIFF
--- a/.changeset/dry-paws-know.md
+++ b/.changeset/dry-paws-know.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": minor
+---
+
+fixed bug where certain terminal commands would lock you out of a task


### PR DESCRIPTION
Fixes https://github.com/cline/cline/issues/3187

### Description

This PR fixes a bug where certain commands (e.g. npm run build) would put the VS Code terminal's shell integration stream into a broken state. After this happens, any future commands in the same terminal would silently fail to produce output — the stream is created but never yields any chunks, effectively bricking the terminal.

The fix adds a 500ms timeout waiting for the first chunk from executeCommand().read(). If no chunk arrives, we assume the terminal is stuck and dispose it to force future commands to use a fresh shell. This ensures the app doesn't get stuck in a limbo state waiting for output that will never come.

<img width="466" alt="Screenshot 2025-05-08 at 7 44 43 PM" src="https://github.com/user-attachments/assets/bbde780f-fd52-467c-9863-16ff4cc9bb10" />

### Test Procedure

Open cline in cline repo. Ask it to run npm run build. Then after it successfully runs the command, ask it to run it again. 

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes terminal hang by adding a 500ms timeout in `TerminalProcess.run()` to detect and handle unresponsive states.
> 
>   - **Behavior**:
>     - Adds a 500ms timeout in `TerminalProcess.run()` to detect unresponsive terminal states.
>     - If no output is received within the timeout, the terminal is disposed to reset its state.
>     - Emits an error and `completed` and `continue` events to allow retrying in a new terminal.
>   - **Logging**:
>     - Logs debug messages when the timeout is hit and when terminal disposal fails.
>   - **Misc**:
>     - Adds import for `Logger` in `TerminalProcess.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 4658066a4a8dc18de08aa05df131380f9e018e13. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->