### PR TITLE
fix: Restore native copy functionality in chat input text area

### DIFF
--- a/webview-ui/src/components/chat/ChatView.tsx
+++ b/webview-ui/src/components/chat/ChatView.tsx
@@ -133,11 +133,26 @@ const ChatView = ({ isHidden, showAnnouncement, hideAnnouncement, showHistoryVie
 
 	useEffect(() => {
 		const handleCopy = async (e: ClipboardEvent) => {
+			const targetElement = e.target as HTMLElement | null
+			// If the copy event originated from an input or textarea,
+			// let the default browser behavior handle it.
+			if (targetElement && (targetElement.tagName === 'INPUT' || targetElement.tagName === 'TEXTAREA' || targetElement.isContentEditable)) {
+				return
+			}
+
 			if (window.getSelection) {
 				const selection = window.getSelection()
-				if (selection && selection.rangeCount > 0) {
+				if (selection && selection.rangeCount > 0 && selection.toString().trim() !== "") {
 					// Get the selected HTML content
 					const range = selection.getRangeAt(0)
+
+					// Check if the selection is purely within a pre/code block that has its own copy button
+					// This is a heuristic: if the common ancestor is a PRE or CODE, and that element
+					// is inside something that might have a dedicated copy button (like our CodeBlockContainer)
+					// we might want to let that specific copy button's logic (if any) or default browser copy handle it.
+					// For now, we'll proceed with copy-as-markdown for any non-input/textarea selection.
+					// A more sophisticated check could be added here if needed.
+
 					const clonedSelection = range.cloneContents()
 					const div = document.createElement("div")
 					div.appendChild(clonedSelection)

--- a/webview-ui/src/components/chat/ChatView.tsx
+++ b/webview-ui/src/components/chat/ChatView.tsx
@@ -136,23 +136,18 @@ const ChatView = ({ isHidden, showAnnouncement, hideAnnouncement, showHistoryVie
 			const targetElement = e.target as HTMLElement | null
 			// If the copy event originated from an input or textarea,
 			// let the default browser behavior handle it.
-			if (targetElement && (targetElement.tagName === 'INPUT' || targetElement.tagName === 'TEXTAREA' || targetElement.isContentEditable)) {
+			if (
+				targetElement &&
+				(targetElement.tagName === "INPUT" || targetElement.tagName === "TEXTAREA" || targetElement.isContentEditable)
+			) {
 				return
 			}
 
 			if (window.getSelection) {
 				const selection = window.getSelection()
-				if (selection && selection.rangeCount > 0 && selection.toString().trim() !== "") {
+				if (selection && selection.rangeCount > 0) {
 					// Get the selected HTML content
 					const range = selection.getRangeAt(0)
-
-					// Check if the selection is purely within a pre/code block that has its own copy button
-					// This is a heuristic: if the common ancestor is a PRE or CODE, and that element
-					// is inside something that might have a dedicated copy button (like our CodeBlockContainer)
-					// we might want to let that specific copy button's logic (if any) or default browser copy handle it.
-					// For now, we'll proceed with copy-as-markdown for any non-input/textarea selection.
-					// A more sophisticated check could be added here if needed.
-
 					const clonedSelection = range.cloneContents()
 					const div = document.createElement("div")
 					div.appendChild(clonedSelection)


### PR DESCRIPTION
Resolves #3374

**Problem:**
Users were unable to copy text from the chat input field (`ChatTextArea`). Standard copy operations (Cmd+C/Ctrl+C) resulted in an empty clipboard or no action.

**Root Cause:**
A global `copy` event listener in `ChatView.tsx`, intended to provide "copy as Markdown" functionality for rendered chat messages, was unconditionally calling `event.preventDefault()`. This prevented the default copy behavior for all elements, including the `ChatTextArea` input field.

**Solution:**
The global `copy` handler in `ChatView.tsx` has been modified to check the `event.target`. If the copy event originates from an `HTMLInputElement`, `HTMLTextAreaElement`, or an element with `isContentEditable=true`, the handler now returns early, allowing the native browser copy mechanism (or the element's specific `onCopy` handler) to proceed. This restores standard copy functionality for input fields while preserving the "copy as Markdown" feature for other content.

**Changes Made:**
- Updated `webview-ui/src/components/chat/ChatView.tsx`:
    - The `useEffect` hook that adds the document-level `copy` event listener now includes a condition in its `handleCopy` function to bypass the custom logic and `preventDefault()` if `event.target` is an input, textarea, or contentEditable element.

**Testing:**
- Verified that text can be copied from the `ChatTextArea` using Cmd+C/Ctrl+C and pasted correctly.
- Verified that selecting text from rendered chat messages still triggers the "copy as Markdown" behavior (if applicable).

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [X] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [X] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [X] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [X] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [X] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Restores native copy functionality in `ChatTextArea` by modifying the global `copy` event listener in `ChatView.tsx`.
> 
>   - **Behavior**:
>     - Restores native copy functionality in `ChatTextArea` by modifying the global `copy` event listener in `ChatView.tsx`.
>     - The `handleCopy` function now checks if `event.target` is an `HTMLInputElement`, `HTMLTextAreaElement`, or contentEditable, and returns early to allow native copy behavior.
>   - **Testing**:
>     - Verified text can be copied from `ChatTextArea` using Cmd+C/Ctrl+C.
>     - Confirmed "copy as Markdown" still works for rendered chat messages.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 12b62a4e8a40ba2b178bd6f6464aad16801491be. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->