### PR TITLE
[PROTOBUS] Move autoApprovalSettings to protobus

### DIFF
--- a/.changeset/mean-wolves-sleep.md
+++ b/.changeset/mean-wolves-sleep.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+autoApprovalSettings protobus migration

--- a/proto/state.proto
+++ b/proto/state.proto
@@ -42,7 +42,7 @@ message ChatContent {
 // Message for auto approval settings
 message AutoApprovalSettingsRequest {
   Metadata metadata = 1;
-  
+
   message Actions {
     bool read_files = 1;
     bool read_files_externally = 2;

--- a/proto/state.proto
+++ b/proto/state.proto
@@ -10,6 +10,7 @@ service StateService {
   rpc resetState(EmptyRequest) returns (Empty);
   rpc togglePlanActMode(TogglePlanActModeRequest) returns (Empty);
   rpc updateTerminalConnectionTimeout(Int64Request) returns (Int64);
+  rpc updateAutoApprovalSettings(AutoApprovalSettingsRequest) returns (Empty);
 }
 
 message State {
@@ -36,4 +37,27 @@ message ChatSettings {
 message ChatContent {
   optional string message = 1;
   repeated string images = 2;
+}
+
+// Message for auto approval settings
+message AutoApprovalSettingsRequest {
+  Metadata metadata = 1;
+  
+  message Actions {
+    bool read_files = 1;
+    bool read_files_externally = 2;
+    bool edit_files = 3;
+    bool edit_files_externally = 4;
+    bool execute_safe_commands = 5;
+    bool execute_all_commands = 6;
+    bool use_browser = 7;
+    bool use_mcp = 8;
+  }
+
+  int32 version = 2;
+  bool enabled = 3;
+  Actions actions = 4;
+  int32 max_requests = 5;
+  bool enable_notifications = 6;
+  repeated string favorites = 7;
 }

--- a/src/core/controller/index.ts
+++ b/src/core/controller/index.ts
@@ -291,25 +291,6 @@ export class Controller {
 				}
 				await this.postStateToWebview()
 				break
-			case "autoApprovalSettings":
-				if (message.autoApprovalSettings) {
-					const currentSettings = (await getAllExtensionState(this.context)).autoApprovalSettings
-					const incomingVersion = message.autoApprovalSettings.version ?? 1
-					const currentVersion = currentSettings?.version ?? 1
-					if (incomingVersion > currentVersion) {
-						await updateGlobalState(this.context, "autoApprovalSettings", message.autoApprovalSettings)
-						if (this.task) {
-							this.task.autoApprovalSettings = message.autoApprovalSettings
-						}
-						await this.postStateToWebview()
-					}
-				}
-				break
-			case "togglePlanActMode":
-				if (message.chatSettings) {
-					await this.togglePlanActModeWithChatSettings(message.chatSettings, message.chatContent)
-				}
-				break
 			case "optionsResponse":
 				await this.postMessageToWebview({
 					type: "invoke",

--- a/src/core/controller/state/updateAutoApprovalSettings.ts
+++ b/src/core/controller/state/updateAutoApprovalSettings.ts
@@ -1,0 +1,32 @@
+import { Controller } from ".."
+import { AutoApprovalSettingsRequest } from "../../../shared/proto/state"
+import { Empty } from "../../../shared/proto/common"
+import { convertProtoToAutoApprovalSettings } from "../../../shared/proto-conversions/models/auto-approval-settings-conversion"
+import { updateGlobalState } from "../../../core/storage/state"
+
+/**
+ * Updates the auto approval settings
+ * @param controller The controller instance
+ * @param request The auto approval settings request
+ * @returns Empty response
+ */
+export async function updateAutoApprovalSettings(controller: Controller, request: AutoApprovalSettingsRequest): Promise<Empty> {
+	const currentSettings = (await controller.getStateToPostToWebview()).autoApprovalSettings
+	const incomingVersion = request.version
+	const currentVersion = currentSettings?.version ?? 1
+
+	// Only update if incoming version is higher
+	if (incomingVersion > currentVersion) {
+		const settings = convertProtoToAutoApprovalSettings(request)
+
+		await updateGlobalState(controller.context, "autoApprovalSettings", settings)
+
+		if (controller.task) {
+			controller.task.autoApprovalSettings = settings
+		}
+
+		await controller.postStateToWebview()
+	}
+
+	return Empty.create()
+}

--- a/src/shared/WebviewMessage.ts
+++ b/src/shared/WebviewMessage.ts
@@ -1,5 +1,4 @@
 import { ApiConfiguration } from "./api"
-import { AutoApprovalSettings } from "./AutoApprovalSettings"
 import { BrowserSettings } from "./BrowserSettings"
 import { ChatSettings } from "./ChatSettings"
 import { UserInfo } from "./UserInfo"
@@ -18,7 +17,6 @@ export interface WebviewMessage {
 		| "openInBrowser"
 		| "showChatView"
 		| "openMcpSettings"
-		| "autoApprovalSettings"
 		| "togglePlanActMode"
 		| "openExtensionSettings"
 		| "requestVsCodeLmModels"
@@ -46,7 +44,6 @@ export interface WebviewMessage {
 	images?: string[]
 	bool?: boolean
 	number?: number
-	autoApprovalSettings?: AutoApprovalSettings
 	browserSettings?: BrowserSettings
 	chatSettings?: ChatSettings
 	chatContent?: ChatContent

--- a/src/shared/proto-conversions/models/auto-approval-settings-conversion.ts
+++ b/src/shared/proto-conversions/models/auto-approval-settings-conversion.ts
@@ -1,0 +1,45 @@
+import { AutoApprovalSettings } from "../../AutoApprovalSettings"
+import { AutoApprovalSettingsRequest } from "../../proto/state"
+
+// Converts domain AutoApprovalSettings to proto AutoApprovalSettingsRequest
+export function convertAutoApprovalSettingsToProto(settings: AutoApprovalSettings): AutoApprovalSettingsRequest {
+	return {
+		metadata: {},
+		version: settings.version,
+		enabled: settings.enabled,
+		actions: {
+			readFiles: settings.actions.readFiles || false,
+			readFilesExternally: settings.actions.readFilesExternally || false,
+			editFiles: settings.actions.editFiles || false,
+			editFilesExternally: settings.actions.editFilesExternally || false,
+			executeSafeCommands: settings.actions.executeSafeCommands || false,
+			executeAllCommands: settings.actions.executeAllCommands || false,
+			useBrowser: settings.actions.useBrowser || false,
+			useMcp: settings.actions.useMcp || false,
+		},
+		maxRequests: settings.maxRequests || 20,
+		enableNotifications: settings.enableNotifications || false,
+		favorites: settings.favorites || [],
+	}
+}
+
+// Converts proto AutoApprovalSettingsRequest to domain AutoApprovalSettings
+export function convertProtoToAutoApprovalSettings(protoSettings: AutoApprovalSettingsRequest): AutoApprovalSettings {
+	return {
+		version: protoSettings.version,
+		enabled: protoSettings.enabled,
+		actions: {
+			readFiles: protoSettings.actions?.readFiles || false,
+			readFilesExternally: protoSettings.actions?.readFilesExternally || false,
+			editFiles: protoSettings.actions?.editFiles || false,
+			editFilesExternally: protoSettings.actions?.editFilesExternally || false,
+			executeSafeCommands: protoSettings.actions?.executeSafeCommands || false,
+			executeAllCommands: protoSettings.actions?.executeAllCommands || false,
+			useBrowser: protoSettings.actions?.useBrowser || false,
+			useMcp: protoSettings.actions?.useMcp || false,
+		},
+		maxRequests: protoSettings.maxRequests || 20,
+		enableNotifications: protoSettings.enableNotifications || false,
+		favorites: protoSettings.favorites || [],
+	}
+}

--- a/webview-ui/src/components/chat/auto-approve-menu/AutoApproveMenuItem.tsx
+++ b/webview-ui/src/components/chat/auto-approve-menu/AutoApproveMenuItem.tsx
@@ -8,8 +8,8 @@ interface AutoApproveMenuItemProps {
 	action: ActionMetadata
 	isChecked: (action: ActionMetadata) => boolean
 	isFavorited?: (action: ActionMetadata) => boolean
-	onToggle: (action: ActionMetadata, checked: boolean) => void
-	onToggleFavorite?: (actionId: string) => void
+	onToggle: (action: ActionMetadata, checked: boolean) => Promise<void>
+	onToggleFavorite?: (actionId: string) => Promise<void>
 	condensed?: boolean
 	showIcon?: boolean
 }
@@ -83,9 +83,9 @@ const AutoApproveMenuItem = ({
 	const checked = isChecked(action)
 	const favorited = isFavorited?.(action)
 
-	const onChange = (e: Event) => {
+	const onChange = async (e: Event) => {
 		e.stopPropagation()
-		onToggle(action, !checked)
+		await onToggle(action, !checked)
 	}
 
 	const content = (
@@ -107,9 +107,10 @@ const AutoApproveMenuItem = ({
 									style={{
 										cursor: "pointer",
 									}}
-									onClick={(e) => {
+									onClick={async (e) => {
 										e.stopPropagation()
-										onToggleFavorite?.(action.id)
+										if (action.id === "enableAll") return
+										await onToggleFavorite?.(action.id)
 									}}
 								/>
 							</HeroTooltip>

--- a/webview-ui/src/components/chat/auto-approve-menu/AutoApproveModal.tsx
+++ b/webview-ui/src/components/chat/auto-approve-menu/AutoApproveModal.tsx
@@ -170,13 +170,13 @@ const AutoApproveModal: React.FC<AutoApproveModalProps> = ({
 						<VSCodeTextField
 							className="flex-1 w-full pr-[35px] ml-4"
 							value={autoApprovalSettings.maxRequests.toString()}
-							onInput={(e) => {
+							onInput={async (e) => {
 								const input = e.target as HTMLInputElement
 								// Remove any non-numeric characters
 								input.value = input.value.replace(/[^0-9]/g, "")
 								const value = parseInt(input.value)
 								if (!isNaN(value) && value > 0) {
-									updateMaxRequests(value)
+									await updateMaxRequests(value)
 								}
 							}}
 							onKeyDown={(e) => {

--- a/webview-ui/src/components/chat/auto-approve-menu/AutoApproveSettingsAPI.ts
+++ b/webview-ui/src/components/chat/auto-approve-menu/AutoApproveSettingsAPI.ts
@@ -1,0 +1,18 @@
+import { StateServiceClient } from "@/services/grpc-client"
+import { AutoApprovalSettings } from "@shared/AutoApprovalSettings"
+import { convertAutoApprovalSettingsToProto } from "@shared/proto-conversions/models/auto-approval-settings-conversion"
+
+/**
+ * Updates auto approval settings using the gRPC/Protobus client
+ * @param settings The auto approval settings to update
+ * @throws Error if the update fails
+ */
+export async function updateAutoApproveSettings(settings: AutoApprovalSettings) {
+	try {
+		const protoSettings = convertAutoApprovalSettingsToProto(settings)
+		await StateServiceClient.updateAutoApprovalSettings(protoSettings)
+	} catch (error) {
+		console.error("Failed to update auto approval settings:", error)
+		throw error
+	}
+}

--- a/webview-ui/src/hooks/useAutoApproveActions.ts
+++ b/webview-ui/src/hooks/useAutoApproveActions.ts
@@ -1,7 +1,7 @@
 import { useCallback } from "react"
 import { useExtensionState } from "@/context/ExtensionStateContext"
-import { vscode } from "@/utils/vscode"
 import { AutoApprovalSettings } from "@shared/AutoApprovalSettings"
+import { updateAutoApproveSettings } from "@/components/chat/auto-approve-menu/AutoApproveSettingsAPI"
 import { ActionMetadata } from "@/components/chat/auto-approve-menu/types"
 
 export function useAutoApproveActions() {
@@ -35,7 +35,7 @@ export function useAutoApproveActions() {
 
 	// Toggle favorite status
 	const toggleFavorite = useCallback(
-		(actionId: string) => {
+		async (actionId: string) => {
 			const currentFavorites = autoApprovalSettings.favorites || []
 			let newFavorites: string[]
 
@@ -45,13 +45,10 @@ export function useAutoApproveActions() {
 				newFavorites = [...currentFavorites, actionId]
 			}
 
-			vscode.postMessage({
-				type: "autoApprovalSettings",
-				autoApprovalSettings: {
-					...autoApprovalSettings,
-					version: (autoApprovalSettings.version ?? 1) + 1,
-					favorites: newFavorites,
-				},
+			await updateAutoApproveSettings({
+				...autoApprovalSettings,
+				version: (autoApprovalSettings.version ?? 1) + 1,
+				favorites: newFavorites,
 			})
 		},
 		[autoApprovalSettings],
@@ -59,22 +56,22 @@ export function useAutoApproveActions() {
 
 	// Update action state
 	const updateAction = useCallback(
-		(action: ActionMetadata, value: boolean) => {
+		async (action: ActionMetadata, value: boolean) => {
 			const actionId = action.id
 			const subActionId = action.subAction?.id
 
 			if (actionId === "enableAutoApprove") {
-				updateAutoApproveEnabled(value)
+				await updateAutoApproveEnabled(value)
 				return
 			}
 
 			if (actionId === "enableAll" || subActionId === "enableAll") {
-				toggleAll(action, value)
+				await toggleAll(action, value)
 				return
 			}
 
 			if (actionId === "enableNotifications" || subActionId === "enableNotifications") {
-				updateNotifications(action, value)
+				await updateNotifications(action, value)
 				return
 			}
 
@@ -95,14 +92,11 @@ export function useAutoApproveActions() {
 			// Check if this will result in any enabled actions
 			const willHaveEnabledActions = Object.values(newActions).some(Boolean)
 
-			vscode.postMessage({
-				type: "autoApprovalSettings",
-				autoApprovalSettings: {
-					...autoApprovalSettings,
-					version: (autoApprovalSettings.version ?? 1) + 1,
-					actions: newActions,
-					enabled: willHaveEnabledActions,
-				},
+			await updateAutoApproveSettings({
+				...autoApprovalSettings,
+				version: (autoApprovalSettings.version ?? 1) + 1,
+				actions: newActions,
+				enabled: willHaveEnabledActions,
 			})
 		},
 		[autoApprovalSettings],
@@ -110,14 +104,11 @@ export function useAutoApproveActions() {
 
 	// Update max requests
 	const updateMaxRequests = useCallback(
-		(maxRequests: number) => {
-			vscode.postMessage({
-				type: "autoApprovalSettings",
-				autoApprovalSettings: {
-					...autoApprovalSettings,
-					version: (autoApprovalSettings.version ?? 1) + 1,
-					maxRequests,
-				},
+		async (maxRequests: number) => {
+			await updateAutoApproveSettings({
+				...autoApprovalSettings,
+				version: (autoApprovalSettings.version ?? 1) + 1,
+				maxRequests,
 			})
 		},
 		[autoApprovalSettings],
@@ -125,14 +116,11 @@ export function useAutoApproveActions() {
 
 	// Update auto-approve enabled state
 	const updateAutoApproveEnabled = useCallback(
-		(checked: boolean) => {
-			vscode.postMessage({
-				type: "autoApprovalSettings",
-				autoApprovalSettings: {
-					...autoApprovalSettings,
-					version: (autoApprovalSettings.version ?? 1) + 1,
-					enabled: checked,
-				},
+		async (checked: boolean) => {
+			await updateAutoApproveSettings({
+				...autoApprovalSettings,
+				version: (autoApprovalSettings.version ?? 1) + 1,
+				enabled: checked,
 			})
 		},
 		[autoApprovalSettings],
@@ -140,21 +128,18 @@ export function useAutoApproveActions() {
 
 	// Toggle all actions
 	const toggleAll = useCallback(
-		(action: ActionMetadata, checked: boolean) => {
+		async (action: ActionMetadata, checked: boolean) => {
 			let actions = { ...autoApprovalSettings.actions }
 
 			for (const action of Object.keys(actions)) {
 				actions[action as keyof AutoApprovalSettings["actions"]] = checked
 			}
 
-			vscode.postMessage({
-				type: "autoApprovalSettings",
-				autoApprovalSettings: {
-					...autoApprovalSettings,
-					version: (autoApprovalSettings.version ?? 1) + 1,
-					actions,
-					enabled: checked,
-				},
+			await updateAutoApproveSettings({
+				...autoApprovalSettings,
+				version: (autoApprovalSettings.version ?? 1) + 1,
+				actions,
+				enabled: checked,
 			})
 		},
 		[autoApprovalSettings],
@@ -162,15 +147,12 @@ export function useAutoApproveActions() {
 
 	// Update notifications setting
 	const updateNotifications = useCallback(
-		(action: ActionMetadata, checked: boolean) => {
+		async (action: ActionMetadata, checked: boolean) => {
 			if (action.id === "enableNotifications") {
-				vscode.postMessage({
-					type: "autoApprovalSettings",
-					autoApprovalSettings: {
-						...autoApprovalSettings,
-						version: (autoApprovalSettings.version ?? 1) + 1,
-						enableNotifications: checked,
-					},
+				await updateAutoApproveSettings({
+					...autoApprovalSettings,
+					version: (autoApprovalSettings.version ?? 1) + 1,
+					enableNotifications: checked,
 				})
 			}
 		},


### PR DESCRIPTION
### Description

This PR migrates the autoApprovalSettings message to the gRPC/Protobuf system. It converts the legacy VSCode message passing mechanism to a gRPC method in the ModelsService. The client can now call StateServiceClient.updateAutoApprovalSettings() to update the Auto Approve settings.

### Test Procedure

To test this change, launch Cline and start a new task. Test the Auto Approve menu:
- Enable and disable auto approve options
- Confirm menus for nested items collapse and expand as expected
- Confirm favorites display in the collapsed view when toggled
- Confirm settings changes are retained between task turns
- Confirm settings changes are retained when toggled in the middle of a turn
- Confirm settings changes are retained when creating new tasks

All changes should be visible in GRPC state debug logging.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [X] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [X] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [X] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [X] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [X] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Migrates `autoApprovalSettings` to gRPC/Protobuf, adding a new RPC method and updating client-side logic and UI components.
> 
>   - **Behavior**:
>     - Migrates `autoApprovalSettings` to gRPC/Protobuf system.
>     - Adds `updateAutoApprovalSettings` RPC method in `state.proto`.
>     - Removes legacy message handling for `autoApprovalSettings` in `Controller`.
>   - **Methods**:
>     - Implements `updateAutoApprovalSettings()` in `updateAutoApprovalSettings.ts` to update settings if the incoming version is higher.
>     - Registers `updateAutoApprovalSettings` in `methods.ts` and `server-setup.ts`.
>   - **UI**:
>     - Updates `AutoApproveMenuItem.tsx` and `AutoApproveModal.tsx` to use async `onToggle` and `onToggleFavorite`.
>     - Updates `useAutoApproveActions.ts` to handle settings updates via gRPC.
>   - **Conversions**:
>     - Adds conversion functions in `auto-approval-settings-conversion.ts` for domain to proto and vice versa.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 5599c1f0b93def21e0cad2b40b1505794622fa98. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->