### PR TITLE
Add telemetry enable/disable controls by category to TelemetryService

### DIFF
--- a/.changeset/nice-baboons-suffer.md
+++ b/.changeset/nice-baboons-suffer.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Adds switch to enabler/disable telemtry categories

--- a/src/services/posthog/telemetry/TelemetryService.ts
+++ b/src/services/posthog/telemetry/TelemetryService.ts
@@ -27,12 +27,13 @@ interface Collection {
  * When adding a new category, add it both here and to the initial values in telemetryCategoryEnabled
  * Ensure `if (!this.isCategoryEnabled('<category_name>')` is added to the capture method
  */
-type TelemetryCategory = "checkpoints"
+type TelemetryCategory = "checkpoints" | "browser"
 
 class PostHogClient {
 	// Map to control specific telemetry categories (event types)
 	private telemetryCategoryEnabled: Map<TelemetryCategory, boolean> = new Map([
 		["checkpoints", false], // Checkpoints telemetry disabled
+		["browser", true], // Browser telemetry enabled
 	])
 
 	// Stores events when collect=true
@@ -599,6 +600,10 @@ class PostHogClient {
 	 * @param browserSettings The browser settings being used
 	 */
 	public captureBrowserToolStart(taskId: string, browserSettings: BrowserSettings, collect: boolean = false) {
+		if (!this.isCategoryEnabled("browser")) {
+			return
+		}
+
 		this.capture(
 			{
 				event: PostHogClient.EVENTS.TASK.BROWSER_TOOL_START,
@@ -628,6 +633,10 @@ class PostHogClient {
 		},
 		collect: boolean = false,
 	) {
+		if (!this.isCategoryEnabled("browser")) {
+			return
+		}
+
 		this.capture(
 			{
 				event: PostHogClient.EVENTS.TASK.BROWSER_TOOL_END,
@@ -662,6 +671,10 @@ class PostHogClient {
 		},
 		collect: boolean = false,
 	) {
+		if (!this.isCategoryEnabled("browser")) {
+			return
+		}
+
 		this.capture(
 			{
 				event: PostHogClient.EVENTS.TASK.BROWSER_ERROR,


### PR DESCRIPTION
### Description

This PR introduces category-level controls for the telemetry service. This can be expanded to enable/disable additional categories of telemetry, and introduces these changes to the checkpoints category with a disabled configuration. The browser category has been included and set to enabled, this does not change any telemetry for browser actions and purely serves as an example for future category additions.

### Test Procedure

Use Cline, and confirm telemetry for the checkpoints category is not transmitted. Also confirm that browser telemetry is still being sent.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [X] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [X] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [X] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [X] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [X] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [X] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds category-level telemetry controls in `TelemetryService.ts`, disabling `checkpoints` and enabling `browser` telemetry.
> 
>   - **Behavior**:
>     - Adds category-level telemetry controls in `TelemetryService.ts`.
>     - `checkpoints` category telemetry is disabled; `browser` category telemetry is enabled.
>   - **Implementation**:
>     - Introduces `telemetryCategoryEnabled` map in `PostHogClient` to manage category states.
>     - Adds `isCategoryEnabled()` to check category state.
>     - Updates `captureCheckpointUsage`, `captureBrowserToolStart`, `captureBrowserToolEnd`, and `captureBrowserError` to respect category settings.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 3f71aec5dce40c040fb26283c8e171df04675de6. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->