### PR TITLE
Add a new configuration property cline.commitMessageInstructions 

### DIFF
--- a/.changeset/eleven-ducks-brake.md
+++ b/.changeset/eleven-ducks-brake.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": minor
+---
+
+Added a new configuration property `cline.commitMessageInstructions` to package.json to allow users to customize the commit message format through VSCode settings.

--- a/package.json
+++ b/package.json
@@ -303,6 +303,19 @@
 					"type": "boolean",
 					"default": true,
 					"description": "Controls whether the MCP Marketplace is enabled."
+				},
+				"cline.commitMessageInstructions": {
+					"type": "array",
+					"items": {
+						"type": "string"
+					},
+					"default": [
+						"Start with a short summary (50-72 characters)",
+						"Use the imperative mood (e.g., \"Add feature\" not \"Added feature\")",
+						"Describe what was changed and why",
+						"Be clear and descriptive"
+					],
+					"description": "Instructions for generating commit messages. Each item will be numbered in the prompt sent to the AI."
 				}
 			}
 		}

--- a/src/core/controller/index.ts
+++ b/src/core/controller/index.ts
@@ -31,7 +31,7 @@ import { TelemetrySetting } from "@shared/TelemetrySetting"
 import { WebviewMessage } from "@shared/WebviewMessage"
 import { fileExistsAtPath } from "@utils/fs"
 import { getWorkingState } from "@utils/git"
-import { extractCommitMessage } from "@integrations/git/commit-message-generator"
+import { extractCommitMessage, formatGitDiffPrompt } from "@integrations/git/commit-message-generator"
 import { getTotalTasksSize } from "@utils/storage"
 import { openMention } from "../mentions"
 import { ensureMcpServersDirectoryExists, ensureSettingsDirectoryExists, GlobalFileNames } from "../storage/disk"
@@ -1622,18 +1622,8 @@ Here is the project's README to help you get started:\n\n${mcpDetails.readmeCont
 				},
 				async (progress, token) => {
 					try {
-						// Format the git diff into a prompt
-						const prompt = `Based on the following git diff, generate a concise and descriptive commit message:
-
-${gitDiff.length > 5000 ? gitDiff.substring(0, 5000) + "\n\n[Diff truncated due to size]" : gitDiff}
-
-The commit message should:
-1. Start with a short summary (50-72 characters)
-2. Use the imperative mood (e.g., "Add feature" not "Added feature")
-3. Describe what was changed and why
-4. Be clear and descriptive
-
-Commit message:`
+						// Format the git diff into a prompt using the formatGitDiffPrompt function
+						const prompt = formatGitDiffPrompt(gitDiff)
 
 						// Get the current API configuration
 						const { apiConfiguration } = await getAllExtensionState(this.context)

--- a/src/integrations/git/commit-message-generator.ts
+++ b/src/integrations/git/commit-message-generator.ts
@@ -6,7 +6,19 @@ import { getWorkingState } from "@utils/git"
  * @param gitDiff The git diff to format
  * @returns A formatted prompt for the AI
  */
-function formatGitDiffPrompt(gitDiff: string): string {
+export function formatGitDiffPrompt(gitDiff: string): string {
+	// Get commit message instructions from settings
+	const config = vscode.workspace.getConfiguration("cline")
+	const instructions = config.get<string[]>("commitMessageInstructions") || [
+		"Start with a short summary (50-72 characters)",
+		'Use the imperative mood (e.g., "Add feature" not "Added feature")',
+		"Describe what was changed and why",
+		"Be clear and descriptive",
+	]
+
+	// Format instructions as numbered list
+	const instructionsText = instructions.map((instruction: string, index: number) => `${index + 1}. ${instruction}`).join("\n")
+
 	// Limit the diff size to avoid token limits
 	const maxDiffLength = 5000
 	let truncatedDiff = gitDiff
@@ -20,10 +32,7 @@ function formatGitDiffPrompt(gitDiff: string): string {
 ${truncatedDiff}
 
 The commit message should:
-1. Start with a short summary (50-72 characters)
-2. Use the imperative mood (e.g., "Add feature" not "Added feature")
-3. Describe what was changed and why
-4. Be clear and descriptive
+${instructionsText}
 
 Commit message:`
 }


### PR DESCRIPTION
Add a new configuration property cline.commitMessageInstructions to package.json to allow users to customize the commit message format through VSCode settings. 

### Description

This PR adds the ability for users to customize the instructions used for generating Git commit messages through VSCode user settings. Based on #3318 

The implementation:
1. Adds a new configuration property `cline.commitMessageInstructions` in package.json
2. Modifies the `formatGitDiffPrompt` function to read from this configuration
3. Exports the function and uses it in the controller to eliminate code duplication

This change maintains backward compatibility by providing the same default instructions that were previously hardcoded.

### Test Procedure

Tested by:
1. Adding the configuration to package.json and verifying it appears in VSCode settings
2. Modifying the commit message instructions in settings and verifying they are used when generating a commit message
3. Ensuring the default instructions are used when no custom instructions are provided
4. Verifying that both the commit-message-generator.ts and controller/index.ts use the same configuration

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [x] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Additional Notes

This change eliminates code duplication between the commit message generator and the controller, making future maintenance easier. Users can now customize the commit message format to match their team's specific requirements or preferences.

Example user configuration in settings.json:
```json
"cline.commitMessageInstructions": [
  "Start with a short summary (50-72 characters)",
  "Use the imperative mood (e.g., \"Add feature\" not \"Added feature\")",
  "Describe what was changed and why",
  "Be clear and descriptive",
  "Include ticket number in format [TICKET-123]"
]
```
