### PR TITLE
Disable breaking out of diff auto scroll

### DIFF
--- a/.changeset/forty-spiders-repair.md
+++ b/.changeset/forty-spiders-repair.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Disable breaking out of diff auto scroll while it's reworked

--- a/src/integrations/editor/DiffViewProvider.ts
+++ b/src/integrations/editor/DiffViewProvider.ts
@@ -91,9 +91,9 @@ export class DiffViewProvider {
 				const currentFirstVisibleLine = e.visibleRanges[0]?.start.line || 0
 
 				// If the first visible line moved upward, user scrolled up
-				if (currentFirstVisibleLine < this.lastFirstVisibleLine) {
-					this.shouldAutoScroll = false
-				}
+				// if (currentFirstVisibleLine < this.lastFirstVisibleLine) {
+				// 	this.shouldAutoScroll = false
+				// }
 
 				// Always update our tracking variable
 				this.lastFirstVisibleLine = currentFirstVisibleLine


### PR DESCRIPTION
### Description

Disabling breaking out of diff auto scrolled while it's reworked due to it sometimes breaking out unexpectedly.

### Test Procedure

Ensure that scrolling is mandatory as before.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [ ] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

### Additional Notes

<!-- Add any additional notes for reviewers -->
