### PR TITLE
fix: prevent IME composition Enter from auto‑sending edited message

### DIFF
--- a/.changeset/tasty-parrots-applaud.md
+++ b/.changeset/tasty-parrots-applaud.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+prevent IME composition Enter from auto‑sending edited message

--- a/webview-ui/src/components/chat/UserMessage.tsx
+++ b/webview-ui/src/components/chat/UserMessage.tsx
@@ -75,7 +75,7 @@ const UserMessage: React.FC<UserMessageProps> = ({ text, images, messageTs, send
 			setIsEditing(false)
 		} else if (e.key === "Enter" && e.metaKey && !checkpointTrackerErrorMessage) {
 			handleRestoreWorkspace("taskAndWorkspace")
-		} else if (e.key === "Enter" && !e.shiftKey) {
+		} else if (e.key === "Enter" && !e.shiftKey && !e.nativeEvent.isComposing && e.keyCode !== 229) {
 			e.preventDefault()
 			handleRestoreWorkspace("task")
 		}

--- a/webview-ui/src/components/chat/__tests__/UserMessage.ime.test.tsx
+++ b/webview-ui/src/components/chat/__tests__/UserMessage.ime.test.tsx
@@ -1,0 +1,44 @@
+/**
+ * UserMessage – IME composition Enter test
+ * --------------------------------------------------
+ * Confirm that sendMessageFromChatRow is not called
+ * even if you confirm the IME conversion (Enter) in message re-edit mode.
+ */
+
+import React from "react"
+import { render, fireEvent } from "@testing-library/react"
+import { describe, it, expect, vi } from "vitest"
+
+vi.mock("@/context/ExtensionStateContext", () => ({
+	__esModule: true,
+	useExtensionState: () => ({
+		state: {},
+		dispatch: vi.fn(),
+	}),
+}))
+
+import UserMessage from "../UserMessage"
+
+describe("UserMessage – IME composition handling", () => {
+	it("does NOT send when IME composition Enter is pressed while editing", () => {
+		const sendMessageFromChatRow = vi.fn()
+
+		const { getByText } = render(
+			<UserMessage text="変換テスト" images={[]} messageTs={Date.now()} sendMessageFromChatRow={sendMessageFromChatRow} />,
+		)
+
+		const editable = getByText("変換テスト") as HTMLElement
+		editable.setAttribute("contenteditable", "true")
+		editable.focus()
+
+		fireEvent.compositionStart(editable)
+		fireEvent.keyDown(editable, {
+			key: "Enter",
+			keyCode: 13,
+			nativeEvent: { isComposing: true },
+		})
+		fireEvent.compositionEnd(editable)
+
+		expect(sendMessageFromChatRow).not.toHaveBeenCalled()
+	})
+})


### PR DESCRIPTION
### Description

<!-- Describe your changes in detail. What problem does this PR solve? -->

Closes #3475

Japanese / Chinese IME users reported that pressing **Enter** to *confirm* a
composition while **editing an existing message** immediately triggers
`cline.chat.send`.  
The textarea input is safe because IME Enter emits `keyCode 229 ("Process")`,
but the `contenteditable` editor emits a normal `keyCode 13` **after
`compositionend`**, so the current logic cannot distinguish it.

| File | Change |
|------|--------|
| `webview-ui/src/components/chat/UserMessage.tsx` | add `!e.nativeEvent.isComposing && e.keyCode !== 229` guard before calling `sendMessage()` |
| `webview-ui/src/components/chat/__tests__/UserMessage.ime.test.tsx` | unit test that ensures IME Enter does **not** call `onSend()` |

### Test Procedure

<!-- How did you test this? Are you confident that it will not introduce bugs? If so, why? -->
・Scope is minimal – one Guard (!e.nativeEvent.isComposing && e.keyCode !== 229) in handleKeyDown, no other logic touched.

・isComposing is a standard KeyboardEvent boolean; for browsers that don’t support it, the value is false, so behavior falls back to the original path.

・keyCode 229 fallback keeps legacy Edge/Chromium “Process key” behavior unchanged.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->
Before change
![20250513](https://github.com/user-attachments/assets/93a66436-c7c8-4deb-867f-4bcbd2d231cc)
After change
![20250512](https://github.com/user-attachments/assets/a906a707-a36f-433c-a5d0-d1c4d879afa2)


### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes issue where IME composition Enter auto-sends messages by adding a guard in `UserMessage.tsx` and tests in `UserMessage.ime.test.tsx`.
> 
>   - **Behavior**:
>     - Adds a guard `!e.nativeEvent.isComposing && e.keyCode !== 229` in `handleKeyDown` in `UserMessage.tsx` to prevent auto-sending messages when IME composition Enter is pressed.
>   - **Tests**:
>     - Adds `UserMessage.ime.test.tsx` to verify that `sendMessageFromChatRow` is not called when IME Enter is pressed during editing.
>   - **Misc**:
>     - Closes issue #3475.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for e234f76e13fb125fcb1b481181d563b7c3d5554c. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->