### PR TITLE
Trevhud/auto approve

### DIFF
--- a/.changeset/olive-windows-yawn.md
+++ b/.changeset/olive-windows-yawn.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+ship with defaults

--- a/src/shared/AutoApprovalSettings.ts
+++ b/src/shared/AutoApprovalSettings.ts
@@ -22,18 +22,18 @@ export interface AutoApprovalSettings {
 
 export const DEFAULT_AUTO_APPROVAL_SETTINGS: AutoApprovalSettings = {
 	version: 1,
-	enabled: false,
+	enabled: true,
 	actions: {
-		readFiles: false,
+		readFiles: true,
 		readFilesExternally: false,
 		editFiles: false,
 		editFilesExternally: false,
-		executeSafeCommands: false,
+		executeSafeCommands: true,
 		executeAllCommands: false,
 		useBrowser: false,
 		useMcp: false,
 	},
 	maxRequests: 20,
 	enableNotifications: false,
-	favorites: [],
+	favorites: ["enableAll", "readFiles", "editFiles"],
 }

--- a/webview-ui/src/components/chat/auto-approve-menu/AutoApproveMenu.tsx
+++ b/webview-ui/src/components/chat/auto-approve-menu/AutoApproveMenu.tsx
@@ -381,7 +381,10 @@ const AutoApproveMenu = ({ style }: AutoApproveMenuProps) => {
 					maxHeight: isExpanded ? "1000px" : favorites.length > 0 ? "40px" : "22px", // Large enough to fit content
 					opacity: isExpanded ? 1 : 0,
 					overflow: "hidden",
-					transition: "max-height 0.3s ease-in-out, opacity 0.3s ease-in-out", // Removed padding to transition
+					transition: "max-height 0.3s ease-in-out, opacity 0.3s ease-in-out",
+					display: "flex",
+					flexDirection: "column",
+					gap: "4px",
 				}}>
 				{isExpanded && ( // Re-added conditional rendering for content
 					<>
@@ -469,7 +472,7 @@ const AutoApproveMenu = ({ style }: AutoApproveMenuProps) => {
 								<span className="codicon codicon-settings" style={{ color: "#CCCCCC", fontSize: "14px" }} />
 								<span style={{ color: "#CCCCCC", fontSize: "12px", fontWeight: 500 }}>Max Requests:</span>
 								<VSCodeTextField
-									style={{ flex: "1", width: "100%" }}
+									style={{ flex: "1", width: "100%", paddingRight: "35px" }}
 									value={autoApprovalSettings.maxRequests.toString()}
 									onInput={(e) => {
 										const input = e.target as HTMLInputElement
@@ -493,6 +496,13 @@ const AutoApproveMenu = ({ style }: AutoApproveMenuProps) => {
 							</div>
 						</HeroTooltip>
 					</>
+				)}
+				{isExpanded && (
+					<span
+						className="codicon codicon-chevron-up"
+						style={{ paddingBottom: "4px", marginLeft: "auto", marginTop: "-20px", cursor: "pointer" }}
+						onClick={() => setIsExpanded(false)}
+					/>
 				)}
 			</div>
 		</div>

--- a/webview-ui/src/components/chat/auto-approve-menu/AutoApproveMenu.tsx
+++ b/webview-ui/src/components/chat/auto-approve-menu/AutoApproveMenu.tsx
@@ -5,7 +5,7 @@ import { AutoApprovalSettings } from "@shared/AutoApprovalSettings"
 import { CODE_BLOCK_BG_COLOR } from "@/components/common/CodeBlock"
 import AutoApproveMenuItem from "./AutoApproveMenuItem"
 import { vscode } from "@/utils/vscode"
-import { getAsVar, VSC_FOREGROUND, VSC_TITLEBAR_INACTIVE_FOREGROUND, VSC_DESCRIPTION_FOREGROUND } from "@/utils/vscStyles"
+import { getAsVar, VSC_FOREGROUND, VSC_TITLEBAR_INACTIVE_FOREGROUND, VSC_FOREGROUND_MUTED } from "@/utils/vscStyles"
 import { useClickAway } from "react-use"
 import HeroTooltip from "@/components/common/HeroTooltip"
 
@@ -281,6 +281,43 @@ const AutoApproveMenu = ({ style }: AutoApproveMenuProps) => {
 		)
 	}
 
+	// Render a favorited item with a checkbox
+	const getQuickAccessItems = () => {
+		const notificationsEnabled = autoApprovalSettings.enableNotifications
+		const enabledActionsNames = Object.keys(autoApprovalSettings.actions).filter(
+			(key) => autoApprovalSettings.actions[key as keyof AutoApprovalSettings["actions"]],
+		)
+		const enabledActions = enabledActionsNames.map((action) => {
+			return ACTION_METADATA.flatMap((a) => [a, a.subAction]).find((a) => a?.id === action)
+		})
+
+		let minusFavorites = enabledActions.filter((action) => !favorites.includes(action?.id ?? "") && action?.shortName)
+
+		if (notificationsEnabled) {
+			minusFavorites.push(NOTIFICATIONS_SETTING)
+		}
+
+		return [
+			...favorites.map((favId) => renderFavoritedItem(favId)),
+			minusFavorites.length > 0 ? (
+				<span style={{ color: getAsVar(VSC_FOREGROUND_MUTED), paddingLeft: "10px", opacity: 0.6 }} key="separator">
+					✓
+				</span>
+			) : null,
+			...minusFavorites.map((action, index) => (
+				<span
+					style={{
+						color: getAsVar(VSC_FOREGROUND_MUTED),
+						opacity: 0.6,
+					}}
+					key={action?.id}>
+					{action?.shortName}
+					{index < minusFavorites.length - 1 && ","}
+				</span>
+			)),
+		]
+	}
+
 	const isChecked = (action: ActionMetadata): boolean => {
 		if (action.id === "enableNotifications") {
 			return autoApprovalSettings.enableNotifications
@@ -320,38 +357,20 @@ const AutoApproveMenu = ({ style }: AutoApproveMenuProps) => {
 						justifyContent: "space-between",
 						gap: "8px",
 					}}>
-					{favorites.length > 0 ? (
-						<div
-							style={{
-								display: "flex",
-								flexWrap: "nowrap",
-								alignItems: "center",
-								overflowX: "auto",
-								msOverflowStyle: "none",
-								scrollbarWidth: "none",
-								WebkitOverflowScrolling: "touch",
-								gap: "4px",
-								whiteSpace: "nowrap", // Prevent text wrapping
-							}}>
-							{favorites.map((favId) => renderFavoritedItem(favId))}
-						</div>
-					) : (
-						<div
-							style={{
-								display: "flex",
-								justifyContent: "space-between",
-								alignItems: "center",
-								cursor: "pointer",
-							}}>
-							<div style={{ display: "flex", alignItems: "center", gap: "8px" }}>
-								<HeroTooltip
-									content="Auto-approve allows Cline to perform the following actions without asking for permission. Please use with caution and only enable if you understand the risks."
-									placement="top">
-									<span style={{ color: getAsVar(VSC_FOREGROUND), left: "0" }}>Auto-approve</span>
-								</HeroTooltip>
-							</div>
-						</div>
-					)}
+					<div
+						style={{
+							display: "flex",
+							flexWrap: "nowrap",
+							alignItems: "center",
+							overflowX: "auto",
+							msOverflowStyle: "none",
+							scrollbarWidth: "none",
+							WebkitOverflowScrolling: "touch",
+							gap: "4px",
+							whiteSpace: "nowrap", // Prevent text wrapping
+						}}>
+						{getQuickAccessItems()}
+					</div>
 					<span className="codicon codicon-chevron-right" />
 				</div>
 			)}

--- a/webview-ui/src/components/chat/auto-approve-menu/AutoApproveMenuItem.tsx
+++ b/webview-ui/src/components/chat/auto-approve-menu/AutoApproveMenuItem.tsx
@@ -97,11 +97,22 @@ const AutoApproveMenuItem = ({
 							<span className="label">{condensed ? action.shortName : action.label}</span>
 						</div>
 						{onToggleFavorite && !condensed && (
-							<HeroTooltip content={favorited ? "Remove from quick-access menu" : "Add to quick-access menu"}>
+							<HeroTooltip
+								content={
+									action.id === "enableAll"
+										? "Required"
+										: favorited
+											? "Remove from quick-access menu"
+											: "Add to quick-access menu"
+								}>
 								<span
 									className={`codicon codicon-${favorited ? "star-full" : "star-empty"} star`}
+									style={{
+										cursor: action.id === "enableAll" ? "not-allowed" : "pointer",
+									}}
 									onClick={(e) => {
 										e.stopPropagation()
+										if (action.id === "enableAll") return
 										onToggleFavorite?.(action.id)
 									}}
 								/>

--- a/webview-ui/src/components/chat/auto-approve-menu/AutoApproveMenuItem.tsx
+++ b/webview-ui/src/components/chat/auto-approve-menu/AutoApproveMenuItem.tsx
@@ -98,6 +98,7 @@ const AutoApproveMenuItem = ({
 						</div>
 						{onToggleFavorite && !condensed && (
 							<HeroTooltip
+								delay={500}
 								content={
 									action.id === "enableAll"
 										? "Required"


### PR DESCRIPTION
### Description

Bring back parity with old system; ship with defaults
### Test Procedure

<!-- How did you test this? Are you confident that it will not introduce bugs? If so, why? -->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [x] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<img width="804" alt="Screenshot 2025-05-12 at 3 11 54 PM" src="https://github.com/user-attachments/assets/6875c83d-c3d5-4a11-b5bc-843e1ec87e01" />
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update default auto-approval settings and enhance UI for auto-approve menu.
> 
>   - **Behavior**:
>     - Change `enabled` to `true` in `DEFAULT_AUTO_APPROVAL_SETTINGS` in `AutoApprovalSettings.ts`.
>     - Set `readFiles` and `executeSafeCommands` to `true` by default.
>     - Add `"enableAll", "readFiles", "editFiles"` to `favorites`.
>   - **UI Enhancements**:
>     - Update `AutoApproveMenu.tsx` to render favorited items with checkboxes using `getQuickAccessItems()`.
>     - Add conditional rendering for expanded view in `AutoApproveMenu.tsx`.
>     - Modify `AutoApproveMenuItem.tsx` to prevent favoriting `enableAll` action.
>   - **Misc**:
>     - Update tooltip content and styles in `AutoApproveMenuItem.tsx`.
>     - Change `VSC_DESCRIPTION_FOREGROUND` to `VSC_FOREGROUND_MUTED` in `AutoApproveMenu.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 6ef153b957766a391abf437a826cd4dc4b657d8b. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->