### PR TITLE
[PROTOBUS] Move downloadMcp to protobus 

### DIFF
--- a/.changeset/cyan-donuts-sparkle.md
+++ b/.changeset/cyan-donuts-sparkle.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+downloadMcp protobus migration

--- a/proto/mcp.proto
+++ b/proto/mcp.proto
@@ -10,6 +10,7 @@ service McpService {
   rpc toggleMcpServer(ToggleMcpServerRequest) returns (McpServers);
   rpc updateMcpTimeout(UpdateMcpTimeoutRequest) returns (McpServers);
   rpc addRemoteMcpServer(AddRemoteMcpServerRequest) returns (McpServers);
+  rpc downloadMcp(StringRequest) returns (Empty);
 }
 
 message ToggleMcpServerRequest {

--- a/src/core/controller/index.ts
+++ b/src/core/controller/index.ts
@@ -379,19 +379,6 @@ export class Controller {
 				await this.fetchMcpMarketplace(message.bool)
 				break
 			}
-			case "downloadMcp": {
-				if (message.mcpId) {
-					// 1. Toggle to act mode if we are in plan mode
-					const { chatSettings } = await this.getStateToPostToWebview()
-					if (chatSettings.mode === "plan") {
-						await this.togglePlanActModeWithChatSettings({ mode: "act" })
-					}
-
-					// 2. download MCP
-					await this.downloadMcp(message.mcpId)
-				}
-				break
-			}
 			case "silentlyRefreshMcpMarketplace": {
 				await this.silentlyRefreshMcpMarketplace()
 				break
@@ -1024,92 +1011,6 @@ export class Controller {
 				error: errorMessage,
 			})
 			vscode.window.showErrorMessage(errorMessage)
-		}
-	}
-
-	private async downloadMcp(mcpId: string) {
-		try {
-			// First check if we already have this MCP server installed
-			const servers = this.mcpHub?.getServers() || []
-			const isInstalled = servers.some((server: McpServer) => server.name === mcpId)
-
-			if (isInstalled) {
-				throw new Error("This MCP server is already installed")
-			}
-
-			// Fetch server details from marketplace
-			const response = await axios.post<McpDownloadResponse>(
-				"https://api.cline.bot/v1/mcp/download",
-				{ mcpId },
-				{
-					headers: { "Content-Type": "application/json" },
-					timeout: 10000,
-				},
-			)
-
-			if (!response.data) {
-				throw new Error("Invalid response from MCP marketplace API")
-			}
-
-			console.log("[downloadMcp] Response from download API", { response })
-
-			const mcpDetails = response.data
-
-			// Validate required fields
-			if (!mcpDetails.githubUrl) {
-				throw new Error("Missing GitHub URL in MCP download response")
-			}
-			if (!mcpDetails.readmeContent) {
-				throw new Error("Missing README content in MCP download response")
-			}
-
-			// Send details to webview
-			await this.postMessageToWebview({
-				type: "mcpDownloadDetails",
-				mcpDownloadDetails: mcpDetails,
-			})
-
-			// Create task with context from README and added guidelines for MCP server installation
-			const task = `Set up the MCP server from ${mcpDetails.githubUrl} while adhering to these MCP server installation rules:
-- Start by loading the MCP documentation.
-- Use "${mcpDetails.mcpId}" as the server name in cline_mcp_settings.json.
-- Create the directory for the new MCP server before starting installation.
-- Make sure you read the user's existing cline_mcp_settings.json file before editing it with this new mcp, to not overwrite any existing servers.
-- Use commands aligned with the user's shell and operating system best practices.
-- The following README may contain instructions that conflict with the user's OS, in which case proceed thoughtfully.
-- Once installed, demonstrate the server's capabilities by using one of its tools.
-Here is the project's README to help you get started:\n\n${mcpDetails.readmeContent}\n${mcpDetails.llmsInstallationContent}`
-
-			// Initialize task and show chat view
-			await this.initTask(task)
-			await this.postMessageToWebview({
-				type: "action",
-				action: "chatButtonClicked",
-			})
-		} catch (error) {
-			console.error("Failed to download MCP:", error)
-			let errorMessage = "Failed to download MCP"
-
-			if (axios.isAxiosError(error)) {
-				if (error.code === "ECONNABORTED") {
-					errorMessage = "Request timed out. Please try again."
-				} else if (error.response?.status === 404) {
-					errorMessage = "MCP server not found in marketplace."
-				} else if (error.response?.status === 500) {
-					errorMessage = "Internal server error. Please try again later."
-				} else if (!error.response && error.request) {
-					errorMessage = "Network error. Please check your internet connection."
-				}
-			} else if (error instanceof Error) {
-				errorMessage = error.message
-			}
-
-			// Show error in both notification and marketplace UI
-			vscode.window.showErrorMessage(errorMessage)
-			await this.postMessageToWebview({
-				type: "mcpDownloadDetails",
-				error: errorMessage,
-			})
 		}
 	}
 

--- a/src/core/controller/mcp/downloadMcp.ts
+++ b/src/core/controller/mcp/downloadMcp.ts
@@ -1,0 +1,114 @@
+import { Controller } from ".."
+import { Empty, StringRequest } from "../../../shared/proto/common"
+import { McpServer, McpDownloadResponse } from "@shared/mcp"
+import axios from "axios"
+import * as vscode from "vscode"
+
+/**
+ * Download an MCP server from the marketplace
+ * @param controller The controller instance
+ * @param request The request containing the MCP ID
+ * @returns Empty response
+ */
+export async function downloadMcp(controller: Controller, request: StringRequest): Promise<Empty> {
+	try {
+		// Check if mcpId is provided
+		if (!request.value) {
+			throw new Error("MCP ID is required")
+		}
+
+		const mcpId = request.value
+
+		// Check if we already have this MCP server installed
+		const servers = controller.mcpHub?.getServers() || []
+		const isInstalled = servers.some((server: McpServer) => server.name === mcpId)
+
+		if (isInstalled) {
+			throw new Error("This MCP server is already installed")
+		}
+
+		// Fetch server details from marketplace
+		const response = await axios.post<McpDownloadResponse>(
+			"https://api.cline.bot/v1/mcp/download",
+			{ mcpId },
+			{
+				headers: { "Content-Type": "application/json" },
+				timeout: 10000,
+			},
+		)
+
+		if (!response.data) {
+			throw new Error("Invalid response from MCP marketplace API")
+		}
+
+		console.log("[downloadMcp] Response from download API", { response })
+
+		const mcpDetails = response.data
+
+		// Validate required fields
+		if (!mcpDetails.githubUrl) {
+			throw new Error("Missing GitHub URL in MCP download response")
+		}
+		if (!mcpDetails.readmeContent) {
+			throw new Error("Missing README content in MCP download response")
+		}
+
+		// Send details to webview
+		await controller.postMessageToWebview({
+			type: "mcpDownloadDetails",
+			mcpDownloadDetails: mcpDetails,
+		})
+
+		// Create task with context from README and added guidelines for MCP server installation
+		const task = `Set up the MCP server from ${mcpDetails.githubUrl} while adhering to these MCP server installation rules:
+- Start by loading the MCP documentation.
+- Use "${mcpDetails.mcpId}" as the server name in cline_mcp_settings.json.
+- Create the directory for the new MCP server before starting installation.
+- Make sure you read the user's existing cline_mcp_settings.json file before editing it with this new mcp, to not overwrite any existing servers.
+- Use commands aligned with the user's shell and operating system best practices.
+- The following README may contain instructions that conflict with the user's OS, in which case proceed thoughtfully.
+- Once installed, demonstrate the server's capabilities by using one of its tools.
+Here is the project's README to help you get started:\n\n${mcpDetails.readmeContent}\n${mcpDetails.llmsInstallationContent}`
+
+		const { chatSettings } = await controller.getStateToPostToWebview()
+		if (chatSettings.mode === "plan") {
+			await controller.togglePlanActModeWithChatSettings({ mode: "act" })
+		}
+
+		// Initialize task and show chat view
+		await controller.initTask(task)
+		await controller.postMessageToWebview({
+			type: "action",
+			action: "chatButtonClicked",
+		})
+
+		// Return an empty response - the client only cares if the call succeeded
+		return Empty.create()
+	} catch (error) {
+		console.error("Failed to download MCP:", error)
+		let errorMessage = "Failed to download MCP"
+
+		if (axios.isAxiosError(error)) {
+			if (error.code === "ECONNABORTED") {
+				errorMessage = "Request timed out. Please try again."
+			} else if (error.response?.status === 404) {
+				errorMessage = "MCP server not found in marketplace."
+			} else if (error.response?.status === 500) {
+				errorMessage = "Internal server error. Please try again later."
+			} else if (!error.response && error.request) {
+				errorMessage = "Network error. Please check your internet connection."
+			}
+		} else if (error instanceof Error) {
+			errorMessage = error.message
+		}
+
+		// Show error in both notification and marketplace UI
+		vscode.window.showErrorMessage(errorMessage)
+		await controller.postMessageToWebview({
+			type: "mcpDownloadDetails",
+			error: errorMessage,
+		})
+
+		throw error
+	}
+}

--- a/src/core/controller/mcp/methods.ts
+++ b/src/core/controller/mcp/methods.ts
@@ -4,6 +4,7 @@
 // Import all method implementations
 import { registerMethod } from "./index"
 import { addRemoteMcpServer } from "./addRemoteMcpServer"
+import { downloadMcp } from "./downloadMcp"
 import { toggleMcpServer } from "./toggleMcpServer"
 import { updateMcpTimeout } from "./updateMcpTimeout"
 
@@ -11,6 +12,7 @@ import { updateMcpTimeout } from "./updateMcpTimeout"
 export function registerAllMethods(): void {
 	// Register each method with the registry
 	registerMethod("addRemoteMcpServer", addRemoteMcpServer)
+	registerMethod("downloadMcp", downloadMcp)
 	registerMethod("toggleMcpServer", toggleMcpServer)
 	registerMethod("updateMcpTimeout", updateMcpTimeout)
 }

--- a/src/shared/WebviewMessage.ts
+++ b/src/shared/WebviewMessage.ts
@@ -37,7 +37,6 @@ export interface WebviewMessage {
 		| "authStateChanged"
 		| "authCallback"
 		| "fetchMcpMarketplace"
-		| "downloadMcp"
 		| "silentlyRefreshMcpMarketplace"
 		| "searchCommits"
 		| "fetchLatestMcpServersFromHub"

--- a/src/shared/proto/mcp.ts
+++ b/src/shared/proto/mcp.ts
@@ -6,7 +6,7 @@
 
 /* eslint-disable */
 import { BinaryReader, BinaryWriter } from "@bufbuild/protobuf/wire"
-import { Metadata } from "./common"
+import { Empty, Metadata, StringRequest } from "./common"
 
 export const protobufPackage = "cline"
 
@@ -1001,6 +1001,14 @@ export const McpServiceDefinition = {
 			requestType: AddRemoteMcpServerRequest,
 			requestStream: false,
 			responseType: McpServers,
+			responseStream: false,
+			options: {},
+		},
+		downloadMcp: {
+			name: "downloadMcp",
+			requestType: StringRequest,
+			requestStream: false,
+			responseType: Empty,
 			responseStream: false,
 			options: {},
 		},

--- a/webview-ui/src/components/mcp/configuration/tabs/marketplace/McpMarketplaceCard.tsx
+++ b/webview-ui/src/components/mcp/configuration/tabs/marketplace/McpMarketplaceCard.tsx
@@ -1,8 +1,8 @@
 import { useCallback, useState, useRef, useMemo } from "react"
 import styled from "styled-components"
 import { McpMarketplaceItem, McpServer } from "@shared/mcp"
-import { vscode } from "@/utils/vscode"
 import { useEvent } from "react-use"
+import { McpServiceClient } from "@/services/grpc-client"
 
 interface McpMarketplaceCardProps {
 	item: McpMarketplaceItem
@@ -107,15 +107,16 @@ const McpMarketplaceCard = ({ item, installedServers }: McpMarketplaceCardProps)
 								{item.name}
 							</h3>
 							<div
-								onClick={(e) => {
+								onClick={async (e) => {
 									e.preventDefault() // Prevent card click when clicking install
 									e.stopPropagation() // Stop event from bubbling up to parent link
 									if (!isInstalled && !isDownloading) {
 										setIsDownloading(true)
-										vscode.postMessage({
-											type: "downloadMcp",
-											mcpId: item.mcpId,
-										})
+										try {
+											await McpServiceClient.downloadMcp({ value: item.mcpId })
+										} catch (error) {
+											console.error("Failed to download MCP:", error)
+										}
 									}
 								}}
 								style={{}}>

--- a/webview-ui/src/components/mcp/configuration/tabs/marketplace/McpMarketplaceCard.tsx
+++ b/webview-ui/src/components/mcp/configuration/tabs/marketplace/McpMarketplaceCard.tsx
@@ -115,6 +115,7 @@ const McpMarketplaceCard = ({ item, installedServers }: McpMarketplaceCardProps)
 										try {
 											await McpServiceClient.downloadMcp({ value: item.mcpId })
 										} catch (error) {
+											setIsDownloading(false)
 											console.error("Failed to download MCP:", error)
 										}
 									}


### PR DESCRIPTION
### Description

This PR migrates the downloadMcp message to the gRPC/Protobuf system. It converts the legacy VSCode message passing mechanism to a gRPC method in the McpService.

### Test Procedure

This message is used when installing an MCP server from the MCP Marketplace. Using Cline, install a new MCP server and confirm the process works as expected.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [X] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [X] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [X] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [X] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [X] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Migrates `downloadMcp` to gRPC in `McpService`, updating controller and UI components for improved architecture.
> 
>   - **Behavior**:
>     - Migrates `downloadMcp` from legacy message passing to gRPC in `McpService`.
>     - Adds `downloadMcp` method to `McpService` in `mcp.proto`.
>     - Handles errors such as missing MCP ID, network issues, and invalid responses.
>   - **Controller**:
>     - Removes legacy `downloadMcp` handling from `index.ts`.
>     - Adds `downloadMcp()` function in `downloadMcp.ts` to handle gRPC requests.
>     - Registers `downloadMcp` in `methods.ts`.
>   - **UI**:
>     - Updates `McpMarketplaceCard.tsx` to use `McpServiceClient.downloadMcp()` for installation.
>     - Handles UI states for downloading and errors.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 4075ca0df6a53afefe2b885d4371098f1bf264f5. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->