### PR TITLE
[PROTOBUS] Move toggleFavoriteModel to protobus

### DIFF
--- a/.changeset/nice-pears-hope.md
+++ b/.changeset/nice-pears-hope.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+toggleFavoriteModel protobus migration

--- a/proto/state.proto
+++ b/proto/state.proto
@@ -6,6 +6,7 @@ import "common.proto";
 service StateService {
   rpc getLatestState(EmptyRequest) returns (State);
   rpc subscribeToState(EmptyRequest) returns (stream State);
+  rpc toggleFavoriteModel(StringRequest) returns (Empty);
 }
 
 message State {

--- a/src/core/controller/index.ts
+++ b/src/core/controller/index.ts
@@ -609,27 +609,6 @@ export class Controller {
 				this.postMessageToWebview({ type: "relinquishControl" })
 				break
 			}
-			case "toggleFavoriteModel": {
-				if (message.modelId) {
-					const { apiConfiguration } = await getAllExtensionState(this.context)
-					const favoritedModelIds = apiConfiguration.favoritedModelIds || []
-
-					// Toggle favorite status
-					const updatedFavorites = favoritedModelIds.includes(message.modelId)
-						? favoritedModelIds.filter((id) => id !== message.modelId)
-						: [...favoritedModelIds, message.modelId]
-
-					await updateGlobalState(this.context, "favoritedModelIds", updatedFavorites)
-
-					// Capture telemetry for model favorite toggle
-					const isFavorited = !favoritedModelIds.includes(message.modelId)
-					telemetryService.captureModelFavoritesUsage(message.modelId, isFavorited)
-
-					// Post state to webview without changing any other configuration
-					await this.postStateToWebview()
-				}
-				break
-			}
 			case "grpc_request": {
 				if (message.grpc_request) {
 					await handleGrpcRequest(this, message.grpc_request)

--- a/src/core/controller/state/methods.ts
+++ b/src/core/controller/state/methods.ts
@@ -5,6 +5,7 @@
 import { registerMethod } from "./index"
 import { getLatestState } from "./getLatestState"
 import { subscribeToState } from "./subscribeToState"
+import { toggleFavoriteModel } from "./toggleFavoriteModel"
 
 // Streaming methods for this service
 export const streamingMethods = ["subscribeToState"]
@@ -14,4 +15,5 @@ export function registerAllMethods(): void {
 	// Register each method with the registry
 	registerMethod("getLatestState", getLatestState)
 	registerMethod("subscribeToState", subscribeToState, { isStreaming: true })
+	registerMethod("toggleFavoriteModel", toggleFavoriteModel)
 }

--- a/src/core/controller/state/toggleFavoriteModel.ts
+++ b/src/core/controller/state/toggleFavoriteModel.ts
@@ -1,0 +1,46 @@
+import { telemetryService } from "@/services/posthog/telemetry/TelemetryService"
+import { Controller } from ".."
+import { Empty, StringRequest } from "../../../shared/proto/common"
+import { updateGlobalState } from "@/core/storage/state"
+
+/**
+ * Toggles a model's favorite status
+ * @param controller The controller instance
+ * @param request The request containing the model ID to toggle
+ * @returns An empty response
+ */
+export async function toggleFavoriteModel(controller: Controller, request: StringRequest): Promise<Empty> {
+	try {
+		if (!request.value) {
+			throw new Error("Model ID is required")
+		}
+
+		const modelId = request.value
+		const { apiConfiguration } = await controller.getStateToPostToWebview()
+
+		if (!apiConfiguration) {
+			throw new Error("API configuration not found")
+		}
+
+		const favoritedModelIds = apiConfiguration.favoritedModelIds || []
+
+		// Toggle favorite status
+		const updatedFavorites = favoritedModelIds.includes(modelId)
+			? favoritedModelIds.filter((id) => id !== modelId)
+			: [...favoritedModelIds, modelId]
+
+		await updateGlobalState(controller.context, "favoritedModelIds", updatedFavorites)
+
+		// Capture telemetry for model favorite toggle
+		const isFavorited = !favoritedModelIds.includes(modelId)
+		telemetryService.captureModelFavoritesUsage(modelId, isFavorited)
+
+		// Post state to webview without changing any other configuration
+		await controller.postStateToWebview()
+
+		return Empty.create()
+	} catch (error) {
+		console.error(`Failed to toggle favorite status for model ${request.value}:`, error)
+		throw error
+	}
+}

--- a/src/shared/WebviewMessage.ts
+++ b/src/shared/WebviewMessage.ts
@@ -54,7 +54,6 @@ export interface WebviewMessage {
 		| "taskFeedback"
 		| "scrollToSettings"
 		| "searchFiles"
-		| "toggleFavoriteModel"
 		| "grpc_request"
 		| "grpc_request_cancel"
 		| "toggleClineRule"

--- a/src/shared/proto/state.ts
+++ b/src/shared/proto/state.ts
@@ -6,7 +6,7 @@
 
 /* eslint-disable */
 import { BinaryReader, BinaryWriter } from "@bufbuild/protobuf/wire"
-import { EmptyRequest } from "./common"
+import { Empty, EmptyRequest, StringRequest } from "./common"
 
 export const protobufPackage = "cline"
 
@@ -91,6 +91,14 @@ export const StateServiceDefinition = {
 			requestStream: false,
 			responseType: State,
 			responseStream: true,
+			options: {},
+		},
+		toggleFavoriteModel: {
+			name: "toggleFavoriteModel",
+			requestType: StringRequest,
+			requestStream: false,
+			responseType: Empty,
+			responseStream: false,
 			options: {},
 		},
 	},

--- a/webview-ui/src/components/settings/OpenRouterModelPicker.tsx
+++ b/webview-ui/src/components/settings/OpenRouterModelPicker.tsx
@@ -6,7 +6,7 @@ import { useMount } from "react-use"
 import styled from "styled-components"
 import { openRouterDefaultModelId } from "@shared/api"
 import { useExtensionState } from "@/context/ExtensionStateContext"
-import { ModelsServiceClient } from "@/services/grpc-client"
+import { ModelsServiceClient, StateServiceClient } from "@/services/grpc-client"
 import { vscode } from "@/utils/vscode"
 import { highlight } from "../history/HistoryView"
 import { ModelInfoView, normalizeApiConfiguration } from "./ApiOptions"
@@ -292,10 +292,9 @@ const OpenRouterModelPicker: React.FC<OpenRouterModelPickerProps> = ({ isPopup }
 												isFavorite={isFavorite}
 												onClick={(e) => {
 													e.stopPropagation()
-													vscode.postMessage({
-														type: "toggleFavoriteModel",
-														modelId: item.id,
-													})
+													StateServiceClient.toggleFavoriteModel({ value: item.id }).catch((error) =>
+														console.error("Failed to toggle favorite model:", error),
+													)
 												}}
 											/>
 										</div>


### PR DESCRIPTION
### Description

This PR migrates the toggleFavoriteModel message to the gRPC/Protobuf system. It converts the legacy VSCode message passing mechanism to a gRPC method in the State service.

### Test Procedure

Open the provider settings, select Cline/OpenRouter and hit save (model favoriting causes a state update, so the provider must be set before favoriting. Known issue). Favorite some models, and confirm these preferences are retained.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [X] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [X] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [X] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [X] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [X] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Migrates `toggleFavoriteModel` to gRPC/Protobuf, updating client-side handling and removing legacy message passing.
> 
>   - **Behavior**:
>     - Migrates `toggleFavoriteModel` to gRPC in `proto/state.proto` by adding `rpc toggleFavoriteModel(StringRequest) returns (Empty)`.
>     - Removes legacy `toggleFavoriteModel` handling from `handleWebviewMessage()` in `index.ts`.
>     - Updates `OpenRouterModelPicker.tsx` to use `StateServiceClient.toggleFavoriteModel()`.
>   - **Methods**:
>     - Adds `toggleFavoriteModel` function in `toggleFavoriteModel.ts` to handle gRPC requests.
>     - Registers `toggleFavoriteModel` in `methods.ts`.
>   - **Misc**:
>     - Removes `toggleFavoriteModel` from `WebviewMessage` type in `WebviewMessage.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 05ea977e4b6953e01cf5cb7e6431d33f853dd7d9. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->