### PR TITLE
Fix/chrome remote debugging user data dir

### DIFF
--- a/.changeset/new-pots-walk.md
+++ b/.changeset/new-pots-walk.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+This fix adds the --user-data-dir flag when launching Chrome with the remote debugging port, which resolves the 'Chrome was launched but debug port is not responding' error.

--- a/src/services/browser/BrowserSession.ts
+++ b/src/services/browser/BrowserSession.ts
@@ -124,29 +124,7 @@ export class BrowserSession {
 	}
 
 	async relaunchChromeDebugMode(controller: Controller) {
-		const result = await vscode.window.showWarningMessage(
-			"This will close your existing Chrome tabs and relaunch Chrome in debug mode. Are you sure?",
-			{ modal: true },
-			"Yes",
-		)
-
-		if (result !== "Yes") {
-			controller?.postMessageToWebview({
-				type: "browserRelaunchResult",
-				success: false,
-				text: "Operation cancelled by user",
-			})
-			return
-		}
-
 		try {
-			// Chrome-launcher's killAll only kills instances it launched
-			// We need to handle system Chrome processes separately
-			await this.killAllChromeBrowsers()
-
-			// Wait a moment for Chrome to fully shut down
-			await new Promise((resolve) => setTimeout(resolve, 500))
-
 			const userDataDir = path.join(os.tmpdir(), "chrome-debug-profile")
 			const installation = chromeLauncher.Launcher.getFirstInstallation()
 			if (!installation) {

--- a/src/services/browser/BrowserSession.ts
+++ b/src/services/browser/BrowserSession.ts
@@ -149,7 +149,6 @@ export class BrowserSession {
 			// Instead of using any default flags, use a minimal set to ensure session persistence
 			// This closely mimics running "google-chrome-stable --remote-debugging-port=9222 --user-data-dir=/path/to/profile" from the CLI
 			const userDataDir = path.join(require("os").tmpdir(), "chrome-debug-profile")
-			const chromeFlags = [
 				"--remote-debugging-port=" + DEBUG_PORT,
 				`--user-data-dir=${userDataDir}`,
 				"--disable-notifications",

--- a/src/services/browser/BrowserSession.ts
+++ b/src/services/browser/BrowserSession.ts
@@ -149,6 +149,7 @@ export class BrowserSession {
 			// Instead of using any default flags, use a minimal set to ensure session persistence
 			// This closely mimics running "google-chrome-stable --remote-debugging-port=9222 --user-data-dir=/path/to/profile" from the CLI
 			const userDataDir = path.join(require("os").tmpdir(), "chrome-debug-profile")
+			const chromeFlags = [
 				"--remote-debugging-port=" + DEBUG_PORT,
 				`--user-data-dir=${userDataDir}`,
 				"--disable-notifications",

--- a/src/services/browser/BrowserSession.ts
+++ b/src/services/browser/BrowserSession.ts
@@ -147,9 +147,11 @@ export class BrowserSession {
 			await new Promise((resolve) => setTimeout(resolve, 500))
 
 			// Instead of using any default flags, use a minimal set to ensure session persistence
-			// This closely mimics running "google-chrome-stable --remote-debugging-port=9222" from the CLI
+			// This closely mimics running "google-chrome-stable --remote-debugging-port=9222 --user-data-dir=/path/to/profile" from the CLI
+			const userDataDir = path.join(require('os').tmpdir(), "chrome-debug-profile")
 			const chromeFlags = [
 				"--remote-debugging-port=" + DEBUG_PORT,
+				`--user-data-dir=${userDataDir}`,
 				"--disable-notifications",
 				// Do not add any flags that might interfere with profile data
 			]
@@ -160,8 +162,13 @@ export class BrowserSession {
 			}
 			console.info("chrome installation", installation)
 
-			// Prepare the command arguments
-			const args = [`--remote-debugging-port=${DEBUG_PORT}`, "--disable-notifications", "chrome://newtab"]
+			// Prepare the command arguments using the same userDataDir
+			const args = [
+				`--remote-debugging-port=${DEBUG_PORT}`,
+				`--user-data-dir=${userDataDir}`,
+				"--disable-notifications",
+				"chrome://newtab"
+			]
 
 			// Spawn Chrome as a detached process
 			const chromeProcess = spawn(installation, args, {

--- a/src/services/browser/BrowserSession.ts
+++ b/src/services/browser/BrowserSession.ts
@@ -16,6 +16,7 @@ import { discoverChromeInstances, testBrowserConnection, isPortOpen } from "./Br
 import * as chromeLauncher from "chrome-launcher"
 import { Controller } from "@core/controller"
 import { telemetryService } from "@/services/posthog/telemetry/TelemetryService"
+import os from "os"
 
 interface PCRStats {
 	puppeteer: { launch: typeof launch }
@@ -146,26 +147,16 @@ export class BrowserSession {
 			// Wait a moment for Chrome to fully shut down
 			await new Promise((resolve) => setTimeout(resolve, 500))
 
-			// Instead of using any default flags, use a minimal set to ensure session persistence
-			// This closely mimics running "google-chrome-stable --remote-debugging-port=9222 --user-data-dir=/path/to/profile" from the CLI
-			const userDataDir = path.join(require("os").tmpdir(), "chrome-debug-profile")
-			const chromeFlags = [
-				"--remote-debugging-port=" + DEBUG_PORT,
-				`--user-data-dir=${userDataDir}`,
-				"--disable-notifications",
-				// Do not add any flags that might interfere with profile data
-			]
-
+			const userDataDir = path.join(os.tmpdir(), "chrome-debug-profile")
 			const installation = chromeLauncher.Launcher.getFirstInstallation()
 			if (!installation) {
 				throw new Error("Could not find Chrome installation on this system")
 			}
 			console.info("chrome installation", installation)
 
-			// Prepare the command arguments using the same userDataDir
 			const args = [
 				`--remote-debugging-port=${DEBUG_PORT}`,
-				`--user-data-dir=${userDataDir}`,
+				`--user-data-dir="${userDataDir}"`,
 				"--disable-notifications",
 				"chrome://newtab",
 			]

--- a/src/services/browser/BrowserSession.ts
+++ b/src/services/browser/BrowserSession.ts
@@ -156,7 +156,7 @@ export class BrowserSession {
 
 			const args = [
 				`--remote-debugging-port=${DEBUG_PORT}`,
-				`--user-data-dir="${userDataDir}"`,
+				`--user-data-dir=${userDataDir}`,
 				"--disable-notifications",
 				"chrome://newtab",
 			]

--- a/src/services/browser/BrowserSession.ts
+++ b/src/services/browser/BrowserSession.ts
@@ -148,7 +148,7 @@ export class BrowserSession {
 
 			// Instead of using any default flags, use a minimal set to ensure session persistence
 			// This closely mimics running "google-chrome-stable --remote-debugging-port=9222 --user-data-dir=/path/to/profile" from the CLI
-			const userDataDir = path.join(require('os').tmpdir(), "chrome-debug-profile")
+			const userDataDir = path.join(require("os").tmpdir(), "chrome-debug-profile")
 			const chromeFlags = [
 				"--remote-debugging-port=" + DEBUG_PORT,
 				`--user-data-dir=${userDataDir}`,
@@ -167,7 +167,7 @@ export class BrowserSession {
 				`--remote-debugging-port=${DEBUG_PORT}`,
 				`--user-data-dir=${userDataDir}`,
 				"--disable-notifications",
-				"chrome://newtab"
+				"chrome://newtab",
 			]
 
 			// Spawn Chrome as a detached process

--- a/webview-ui/src/components/settings/BrowserSettingsSection.tsx
+++ b/webview-ui/src/components/settings/BrowserSettingsSection.tsx
@@ -462,7 +462,7 @@ export const BrowserSettingsSection: React.FC = () => {
 							{shouldShowRelaunchButton && (
 								<div style={{ display: "flex", gap: "10px", marginBottom: 8, justifyContent: "center" }}>
 									<VSCodeButton style={{ flex: 1 }} disabled={debugMode} onClick={relaunchChromeDebugMode}>
-										{debugMode ? "Relaunching Browser..." : "Relaunch Browser with Debug Mode"}
+										{debugMode ? "Launching Browser..." : "Launch Browser with Debug Mode"}
 									</VSCodeButton>
 								</div>
 							)}


### PR DESCRIPTION
### Description

(edit by Garoth) explanation of security issue, Chrome just did this: https://developer.chrome.com/blog/remote-debugging-port

- I identified a bug in the Chrome remote debugging functionality in Cline, where Chrome requires a `--user-data-dir` flag when using the `--remote-debugging-port` flag.

- I fixed the issue by modifying the `BrowserSession.ts` file to include the `--user-data-dir` flag when launching Chrome with the remote debugging port.

- I adjusted both arrays, as well as updated the comments above them, to include the updated flag

### Test Procedure

<!-- How did you test this? Are you confident that it will not introduce bugs? If so, why? -->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes Chrome remote debugging by adding `--user-data-dir` flag in `BrowserSession.ts` and updates button text in `BrowserSettingsSection.tsx`.
> 
>   - **Behavior**:
>     - Adds `--user-data-dir` flag in `relaunchChromeDebugMode()` in `BrowserSession.ts` to fix Chrome remote debugging issue.
>     - Updates button text in `BrowserSettingsSection.tsx` from "Relaunch Browser with Debug Mode" to "Launch Browser with Debug Mode".
>   - **Misc**:
>     - Adds import for `os` in `BrowserSession.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 6ad5430dca73b94e2c4b42d18cc4a65907d4745a. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->