### PR TITLE
add boostrap

### DIFF
--- a/.changeset/angry-meals-perform.md
+++ b/.changeset/angry-meals-perform.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+add distinct id bootstrap

--- a/webview-ui/src/CustomPostHogProvider.tsx
+++ b/webview-ui/src/CustomPostHogProvider.tsx
@@ -3,9 +3,10 @@ import { PostHogProvider } from "posthog-js/react"
 import posthog from "posthog-js"
 import { posthogConfig } from "@shared/services/config/posthog-config"
 import { useExtensionState } from "./context/ExtensionStateContext"
+import { vscode } from "./utils/vscode"
 
 export function CustomPostHogProvider({ children }: { children: ReactNode }) {
-	const { telemetrySetting } = useExtensionState()
+	const { telemetrySetting, vscMachineId } = useExtensionState()
 	const isTelemetryEnabled = telemetrySetting !== "disabled"
 
 	useEffect(() => {
@@ -16,6 +17,9 @@ export function CustomPostHogProvider({ children }: { children: ReactNode }) {
 			disable_session_recording: true,
 			capture_pageview: false,
 			capture_dead_clicks: true,
+			bootstrap: {
+				distinctID: vscMachineId,
+			},
 		})
 
 		if (isTelemetryEnabled) {

--- a/webview-ui/src/CustomPostHogProvider.tsx
+++ b/webview-ui/src/CustomPostHogProvider.tsx
@@ -3,13 +3,16 @@ import { PostHogProvider } from "posthog-js/react"
 import posthog from "posthog-js"
 import { posthogConfig } from "@shared/services/config/posthog-config"
 import { useExtensionState } from "./context/ExtensionStateContext"
-import { vscode } from "./utils/vscode"
 
 export function CustomPostHogProvider({ children }: { children: ReactNode }) {
 	const { telemetrySetting, vscMachineId } = useExtensionState()
 	const isTelemetryEnabled = telemetrySetting !== "disabled"
 
 	useEffect(() => {
+		if (vscMachineId.length === 0) {
+			return
+		}
+
 		posthog.init(posthogConfig.apiKey, {
 			api_host: posthogConfig.host,
 			ui_host: posthogConfig.uiHost,
@@ -27,7 +30,7 @@ export function CustomPostHogProvider({ children }: { children: ReactNode }) {
 		} else {
 			posthog.opt_out_capturing()
 		}
-	}, [isTelemetryEnabled])
+	}, [isTelemetryEnabled, vscMachineId])
 
 	return <PostHogProvider client={posthog}>{children}</PostHogProvider>
 }


### PR DESCRIPTION
### Description

Bootstrap distinct id at init

### Test Procedure

posthog

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add distinct ID bootstrap to PostHog initialization in `CustomPostHogProvider.tsx`.
> 
>   - **Behavior**:
>     - Add `bootstrap` with `distinctID` set to `vscMachineId` in `posthog.init()` in `CustomPostHogProvider.tsx`.
>     - Skip PostHog initialization if `vscMachineId` is empty.
>   - **Effects**:
>     - Ensures distinct ID is set during PostHog initialization for telemetry tracking.
>     - Updates `useEffect` dependencies to include `vscMachineId`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 732c604b90ab5ea28319c5298b6e27714949bf66. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->