### PR TITLE
FIX: Detect directory change when reusing active terminals

### DIFF
--- a/.changeset/funny-rivers-check.md
+++ b/.changeset/funny-rivers-check.md
@@ -2,4 +2,4 @@
 "claude-dev": patch
 ---
 
-Added confirmation of a successful cd to cwd before executing commaands in the active terminal
+Added confirmation of a successful cd to cwd before executing commands in the active terminal

--- a/.changeset/funny-rivers-check.md
+++ b/.changeset/funny-rivers-check.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Added confirmation of a successful cd to cwd before executing commaands in the active terminal

--- a/src/integrations/terminal/TerminalManager.ts
+++ b/src/integrations/terminal/TerminalManager.ts
@@ -253,7 +253,9 @@ export class TerminalManager {
 
 			// Either resolve immediately if CWD already updated or wait for event/timeout
 			if (this.isCwdMatchingExpected(availableTerminal)) {
-				availableTerminal.cwdResolved?.resolve()
+				if (availableTerminal.cwdResolved) {
+					availableTerminal.cwdResolved.resolve()
+				}
 				availableTerminal.pendingCwdChange = undefined
 				availableTerminal.cwdResolved = undefined
 			} else {
@@ -261,7 +263,9 @@ export class TerminalManager {
 					// Wait with a timeout for state change event to resolve
 					await Promise.race([
 						cwdPromise,
-						new Promise<void>((_, reject) => setTimeout(() => reject(new Error("CWD timeout")), 1000)),
+						new Promise<void>((_, reject) =>
+							setTimeout(() => reject(new Error(`CWD timeout: Failed to update to ${cwd}`)), 1000),
+						),
 					])
 				} catch (err) {
 					// Clear pending state on timeout

--- a/src/integrations/terminal/TerminalManager.ts
+++ b/src/integrations/terminal/TerminalManager.ts
@@ -87,11 +87,6 @@ declare module "vscode" {
 			disposables?: vscode.Disposable[],
 		) => vscode.Disposable
 	}
-
-	// Define TerminalStateChangeEvent interface
-	interface TerminalStateChangeEvent {
-		terminal: Terminal
-	}
 }
 
 export class TerminalManager {

--- a/src/integrations/terminal/TerminalRegistry.ts
+++ b/src/integrations/terminal/TerminalRegistry.ts
@@ -5,6 +5,11 @@ export interface TerminalInfo {
 	busy: boolean
 	lastCommand: string
 	id: number
+	pendingCwdChange?: string
+	cwdResolved?: {
+		resolve: () => void
+		reject: (error: Error) => void
+	}
 }
 
 // Although vscode.window.terminals provides a list of all open terminals, there's no way to know whether they're busy or not (exitStatus does not provide useful information for most commands). In order to prevent creating too many terminals, we need to keep track of terminals through the life of the extension, as well as session specific terminals for the life of a task (to get latest unretrieved output).


### PR DESCRIPTION
### Description

This PR implements a change to detect directory changes when reusing terminals. When Cline reuses an active terminal for commands, it executes a `cd` command to switch to the workspace's location (e.g., `cd /home/user/Documents/GitHub/myrepo/`). Previously, Cline would wait for this command to complete, but VSCode's terminal integration didn't reliably signal completion, causing the task to hang. Instead of using a timeout, this PR leverages VSCode's built-in event system to detect when the terminal's current working directory has successfully changed. The solution uses a promise-based pattern with `onDidChangeTerminalState` events that efficiently resolves when the shell integration reports the expected directory. This typically completes in 5-15ms.

### Test Procedure

Ask Cline to execute a command that requires switching directories before it can be run. For example, open VS Code in the parent directory of a node project, and ask Cline to build it. It will execute a command like `cd myrepo && npm run build`. This first command will execute successfully. Then, ask Cline to "Run it again". This time, Cline will re-use the active terminal, triggering code that will cd back to the parent directory first. Prior to this change, Cline would hang at this point waiting for the cd command to complete (when it had in fact completed, it did not detect this). With this change, Cline detects the directory change immediately when it happens, allowing it to proceed with executing the next command, reading its output, and continue the task.


### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [X] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [X] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [X] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [X] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [X] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes terminal UI hang by implementing promise-based directory change detection using VSCode events in `TerminalManager.ts`.
> 
>   - **Behavior**:
>     - Implements promise-based detection of directory changes in `TerminalManager.ts` using `onDidChangeTerminalState`.
>     - Replaces timeout-based approach with event-driven detection for terminal CWD changes.
>     - Handles CWD change confirmation before executing commands in reused terminals.
>   - **Terminal Management**:
>     - Adds `pendingCwdChange` and `cwdResolved` to `TerminalInfo` in `TerminalRegistry.ts`.
>     - Updates `getOrCreateTerminal()` in `TerminalManager.ts` to handle CWD change promises.
>   - **Error Handling**:
>     - Logs errors during terminal state change setup in `TerminalManager.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 6cec38ed0038db30d8d31ba278ecf4aa4f8d48a2. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->