### PR TITLE
fix(bedrock): Support application inference profile for non-Claude models on Amazon Bedrock

### DIFF
--- a/.changeset/rude-pumas-brake.md
+++ b/.changeset/rude-pumas-brake.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Support application inference profile for non-Claude models on Amazon Bedrock


### PR DESCRIPTION
### Description

<!-- Describe your changes in detail. What problem does this PR solve? -->

I fixed a bug in the application inference profile in #3388, but it didn't work with models other than Claude. This was because Claude and other models used different SDKs.

In this PR, we will fix it so that the contents of #3388 are applied only to the Claude model.

### Test Procedure

VSCode debug on following models.
- Claude 3.7 Sonnet
- Amazon Nova pro
- Deepseek.r1

<!-- How did you test this? Are you confident that it will not introduce bugs? If so, why? -->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
  -  It works until the unit test, but test:integration fails to start because my environment seems bad. Could someone please check it out?
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

### Additional Notes

<!-- Add any additional notes for reviewers -->
