### PR TITLE
fixing parsing v2 thanks to @cte

### DIFF
--- a/src/core/assistant-message/parse-assistant-message.ts
+++ b/src/core/assistant-message/parse-assistant-message.ts
@@ -264,32 +264,28 @@ export function parseAssistantMessageV1(assistantMessage: string): AssistantMess
  */
 export function parseAssistantMessageV2(assistantMessage: string): AssistantMessageContent[] {
 	const contentBlocks: AssistantMessageContent[] = []
-
-	let currentTextContentStart = 0 // Index where the current text block started.
+	let currentTextContentStart = 0 // Index where the current text block started
 	let currentTextContent: TextContent | undefined = undefined
-	let currentToolUseStart = 0 // Index *after* the opening tag of the current tool use.
+	let currentToolUseStart = 0 // Index *after* the opening tag of the current tool use
 	let currentToolUse: ToolUse | undefined = undefined
-	let currentParamValueStart = 0 // Index *after* the opening tag of the current param.
+	let currentParamValueStart = 0 // Index *after* the opening tag of the current param
 	let currentParamName: ToolParamName | undefined = undefined
 
-	// Precompute tags for faster lookups.
+	// Precompute tags for faster lookups
 	const toolUseOpenTags = new Map<string, ToolUseName>()
 	const toolParamOpenTags = new Map<string, ToolParamName>()
-
 	for (const name of toolUseNames) {
 		toolUseOpenTags.set(`<${name}>`, name)
 	}
-
 	for (const name of toolParamNames) {
 		toolParamOpenTags.set(`<${name}>`, name)
 	}
 
 	const len = assistantMessage.length
-
 	for (let i = 0; i < len; i++) {
 		const currentCharIndex = i
 
-		// Parsing a tool parameter
+		// --- State: Parsing a Tool Parameter ---
 		if (currentToolUse && currentParamName) {
 			const closeTag = `</${currentParamName}>`
 			// Check if the string *ending* at index `i` matches the closing tag
@@ -297,127 +293,111 @@ export function parseAssistantMessageV2(assistantMessage: string): AssistantMess
 				currentCharIndex >= closeTag.length - 1 &&
 				assistantMessage.startsWith(
 					closeTag,
-					currentCharIndex - closeTag.length + 1, // Start checking from potential start of tag.
+					currentCharIndex - closeTag.length + 1, // Start checking from potential start of tag
 				)
 			) {
-				// Found the closing tag for the parameter.
+				// Found the closing tag for the parameter
 				const value = assistantMessage
 					.slice(
-						currentParamValueStart, // Start after the opening tag.
-						currentCharIndex - closeTag.length + 1, // End before the closing tag.
+						currentParamValueStart, // Start after the opening tag
+						currentCharIndex - closeTag.length + 1, // End before the closing tag
 					)
 					.trim()
 				currentToolUse.params[currentParamName] = value
-				currentParamName = undefined // Go back to parsing tool content.
-				// We don't continue loop here, need to check for tool close or other params at index i.
+				currentParamName = undefined // Go back to parsing tool content
+				// We don't continue loop here, need to check for tool close or other params at index i
 			} else {
-				continue // Still inside param value, move to next char.
+				continue // Still inside param value, move to next char
 			}
 		}
 
-		// Parsing a tool use (but not a specific parameter).
+		// --- State: Parsing a Tool Use (but not a specific parameter) ---
 		if (currentToolUse && !currentParamName) {
-			// Ensure we are not inside a parameter already.
-			// Check if starting a new parameter.
+			// Ensure we are not inside a parameter already
+			// Check if starting a new parameter
 			let startedNewParam = false
-
 			for (const [tag, paramName] of toolParamOpenTags.entries()) {
 				if (currentCharIndex >= tag.length - 1 && assistantMessage.startsWith(tag, currentCharIndex - tag.length + 1)) {
 					currentParamName = paramName
-					currentParamValueStart = currentCharIndex + 1 // Value starts after the tag.
+					currentParamValueStart = currentCharIndex + 1 // Value starts after the tag
 					startedNewParam = true
 					break
 				}
 			}
-
 			if (startedNewParam) {
-				continue // Handled start of param, move to next char.
+				continue // Handled start of param, move to next char
 			}
 
-			// Check if closing the current tool use.
+			// Check if closing the current tool use
 			const toolCloseTag = `</${currentToolUse.name}>`
-
 			if (
 				currentCharIndex >= toolCloseTag.length - 1 &&
 				assistantMessage.startsWith(toolCloseTag, currentCharIndex - toolCloseTag.length + 1)
 			) {
-				// End of the tool use found.
-				// Special handling for content params *before* finalizing the
-				// tool.
+				// End of the tool use found
+				// Special handling for content params *before* finalizing the tool
 				const toolContentSlice = assistantMessage.slice(
-					currentToolUseStart, // From after the tool opening tag.
-					currentCharIndex - toolCloseTag.length + 1, // To before the tool closing tag.
+					currentToolUseStart, // From after the tool opening tag
+					currentCharIndex - toolCloseTag.length + 1, // To before the tool closing tag
 				)
 
-				// Check if content parameter needs special handling
-				// (write_to_file/new_rule).
-				// This check is important if the closing </content> tag was
-				// missed by the parameter parsing logic (e.g., if content is
-				// empty or parsing logic prioritizes tool close).
+				// Check if content parameter needs special handling (write_to_file/new_rule)
+				// This check is important if the closing </content> tag was missed by the parameter parsing logic
+				// (e.g., if content is empty or parsing logic prioritizes tool close)
 				const contentParamName: ToolParamName = "content"
 				if (
 					currentToolUse.name === "write_to_file" /* || currentToolUse.name === "new_rule" */ &&
-					// !(contentParamName in currentToolUse.params) && // Only if not already parsed.
-					toolContentSlice.includes(`<${contentParamName}>`) // Check if tag exists.
+					toolContentSlice.includes(`<${contentParamName}>`)
 				) {
 					const contentStartTag = `<${contentParamName}>`
 					const contentEndTag = `</${contentParamName}>`
 					const contentStart = toolContentSlice.indexOf(contentStartTag)
-
-					// Use `lastIndexOf` for robustness against nested tags.
+					// Use lastIndexOf for robustness against nested tags
 					const contentEnd = toolContentSlice.lastIndexOf(contentEndTag)
 
 					if (contentStart !== -1 && contentEnd !== -1 && contentEnd > contentStart) {
 						const contentValue = toolContentSlice.slice(contentStart + contentStartTag.length, contentEnd).trim()
-
 						currentToolUse.params[contentParamName] = contentValue
 					}
 				}
 
-				currentToolUse.partial = false // Mark as complete.
+				currentToolUse.partial = false // Mark as complete
 				contentBlocks.push(currentToolUse)
-				currentToolUse = undefined // Reset state.
-				currentTextContentStart = currentCharIndex + 1 // Potential text starts after this tag.
-				continue // Move to next char.
+				currentToolUse = undefined // Reset state
+				currentTextContentStart = currentCharIndex + 1 // Potential text starts after this tag
+				continue // Move to next char
 			}
-
-			// If not starting a param and not closing the tool, continue
-			// accumulating tool content implicitly.
+			// If not starting a param and not closing the tool, continue accumulating tool content implicitly
 			continue
 		}
 
-		// Parsing text / looking for tool start.
+		// --- State: Parsing Text / Looking for Tool Start ---
 		if (!currentToolUse) {
-			// Check if starting a new tool use.
+			// Check if starting a new tool use
 			let startedNewTool = false
-
 			for (const [tag, toolName] of toolUseOpenTags.entries()) {
 				if (currentCharIndex >= tag.length - 1 && assistantMessage.startsWith(tag, currentCharIndex - tag.length + 1)) {
-					// End current text block if one was active.
+					// End current text block if one was active
 					if (currentTextContent) {
 						currentTextContent.content = assistantMessage
 							.slice(
-								currentTextContentStart, // From where text started.
-								currentCharIndex - tag.length + 1, // To before the tool tag starts.
+								currentTextContentStart, // From where text started
+								currentCharIndex - tag.length + 1, // To before the tool tag starts
 							)
 							.trim()
-
-						currentTextContent.partial = false // Ended because tool started.
-
+						currentTextContent.partial = false // Ended because tool started
 						if (currentTextContent.content.length > 0) {
 							contentBlocks.push(currentTextContent)
 						}
-
 						currentTextContent = undefined
 					} else {
-						// Check for any text between the last block and this tag.
+						// Check for any text between the last block and this tag
 						const potentialText = assistantMessage
 							.slice(
-								currentTextContentStart, // From where text *might* have started.
-								currentCharIndex - tag.length + 1, // To before the tool tag starts.
+								currentTextContentStart, // From where text *might* have started
+								currentCharIndex - tag.length + 1, // To before the tool tag starts
 							)
 							.trim()
-
 						if (potentialText.length > 0) {
 							contentBlocks.push({
 								type: "text",
@@ -427,35 +407,33 @@ export function parseAssistantMessageV2(assistantMessage: string): AssistantMess
 						}
 					}
 
-					// Start the new tool use.
+					// Start the new tool use
 					currentToolUse = {
 						type: "tool_use",
 						name: toolName,
 						params: {},
-						partial: true, // Assume partial until closing tag is found.
+						partial: true, // Assume partial until closing tag is found
 					}
-
-					currentToolUseStart = currentCharIndex + 1 // Tool content starts after the opening tag.
+					currentToolUseStart = currentCharIndex + 1 // Tool content starts after the opening tag
 					startedNewTool = true
-
 					break
 				}
 			}
 
 			if (startedNewTool) {
-				continue // Handled start of tool, move to next char.
+				continue // Handled start of tool, move to next char
 			}
 
-			// If not starting a tool, it must be text content.
+			// If not starting a tool, it must be text content
 			if (!currentTextContent) {
-				// Start a new text block if we aren't already in one.
-				currentTextContentStart = currentCharIndex // Text starts at the current character.
-
-				// Check if the current char is the start of potential text *immediately* after a tag.
+				// Start a new text block if we aren't already in one
+				currentTextContentStart = currentCharIndex // Text starts at the current character
+				// Check if the current char is the start of potential text *immediately* after a tag
 				// This needs the previous state - simpler to let slicing handle it later.
 				// Resetting start index accurately is key.
 				// It should be the index *after* the last processed tag.
 				// The logic managing currentTextContentStart after closing tags handles this.
+
 				currentTextContent = {
 					type: "text",
 					content: "", // Will be determined by slicing at the end or when a tool starts
@@ -464,29 +442,30 @@ export function parseAssistantMessageV2(assistantMessage: string): AssistantMess
 			}
 			// Continue accumulating text implicitly; content is extracted later.
 		}
-	}
+	} // End of loop
 
-	// Finalize any open parameter within an open tool use.
+	// --- Finalization after loop ---
+
+	// Finalize any open parameter within an open tool use
 	if (currentToolUse && currentParamName) {
 		currentToolUse.params[currentParamName] = assistantMessage
-			.slice(currentParamValueStart) // From param start to end of string.
+			.slice(currentParamValueStart) // From param start to end of string
 			.trim()
-		// Tool use remains partial.
+		// Tool use remains partial
 	}
 
-	// Finalize any open tool use (which might contain the finalized partial param).
+	// Finalize any open tool use (which might contain the finalized partial param)
 	if (currentToolUse) {
-		// Tool use is partial because the loop finished before its closing tag.
+		// Tool use is partial because the loop finished before its closing tag
 		contentBlocks.push(currentToolUse)
 	}
-	// Finalize any trailing text content.
-	// Only possible if a tool use wasn't open at the very end.
+	// Finalize any trailing text content
+	// Only possible if a tool use wasn't open at the very end
 	else if (currentTextContent) {
 		currentTextContent.content = assistantMessage
-			.slice(currentTextContentStart) // From text start to end of string.
+			.slice(currentTextContentStart) // From text start to end of string
 			.trim()
-
-		// Text is partial because the loop finished.
+		// Text is partial because the loop finished
 		if (currentTextContent.content.length > 0) {
 			contentBlocks.push(currentTextContent)
 		}

--- a/src/core/assistant-message/parse-assistant-message.ts
+++ b/src/core/assistant-message/parse-assistant-message.ts
@@ -322,10 +322,7 @@ export function parseAssistantMessageV2(assistantMessage: string): AssistantMess
 			let startedNewParam = false
 
 			for (const [tag, paramName] of toolParamOpenTags.entries()) {
-				if (
-					currentCharIndex >= tag.length - 1 &&
-					assistantMessage.startsWith(tag, currentCharIndex - tag.length + 1)
-				) {
+				if (currentCharIndex >= tag.length - 1 && assistantMessage.startsWith(tag, currentCharIndex - tag.length + 1)) {
 					currentParamName = paramName
 					currentParamValueStart = currentCharIndex + 1 // Value starts after the tag.
 					startedNewParam = true
@@ -371,9 +368,7 @@ export function parseAssistantMessageV2(assistantMessage: string): AssistantMess
 					const contentEnd = toolContentSlice.lastIndexOf(contentEndTag)
 
 					if (contentStart !== -1 && contentEnd !== -1 && contentEnd > contentStart) {
-						const contentValue = toolContentSlice
-							.slice(contentStart + contentStartTag.length, contentEnd)
-							.trim()
+						const contentValue = toolContentSlice.slice(contentStart + contentStartTag.length, contentEnd).trim()
 
 						currentToolUse.params[contentParamName] = contentValue
 					}
@@ -397,10 +392,7 @@ export function parseAssistantMessageV2(assistantMessage: string): AssistantMess
 			let startedNewTool = false
 
 			for (const [tag, toolName] of toolUseOpenTags.entries()) {
-				if (
-					currentCharIndex >= tag.length - 1 &&
-					assistantMessage.startsWith(tag, currentCharIndex - tag.length + 1)
-				) {
+				if (currentCharIndex >= tag.length - 1 && assistantMessage.startsWith(tag, currentCharIndex - tag.length + 1)) {
 					// End current text block if one was active.
 					if (currentTextContent) {
 						currentTextContent.content = assistantMessage

--- a/src/core/assistant-message/parse-assistant-message.ts
+++ b/src/core/assistant-message/parse-assistant-message.ts
@@ -264,28 +264,32 @@ export function parseAssistantMessageV1(assistantMessage: string): AssistantMess
  */
 export function parseAssistantMessageV2(assistantMessage: string): AssistantMessageContent[] {
 	const contentBlocks: AssistantMessageContent[] = []
-	let currentTextContentStart = 0 // Index where the current text block started
+
+	let currentTextContentStart = 0 // Index where the current text block started.
 	let currentTextContent: TextContent | undefined = undefined
-	let currentToolUseStart = 0 // Index *after* the opening tag of the current tool use
+	let currentToolUseStart = 0 // Index *after* the opening tag of the current tool use.
 	let currentToolUse: ToolUse | undefined = undefined
-	let currentParamValueStart = 0 // Index *after* the opening tag of the current param
+	let currentParamValueStart = 0 // Index *after* the opening tag of the current param.
 	let currentParamName: ToolParamName | undefined = undefined
 
-	// Precompute tags for faster lookups
+	// Precompute tags for faster lookups.
 	const toolUseOpenTags = new Map<string, ToolUseName>()
 	const toolParamOpenTags = new Map<string, ToolParamName>()
+
 	for (const name of toolUseNames) {
 		toolUseOpenTags.set(`<${name}>`, name)
 	}
+
 	for (const name of toolParamNames) {
 		toolParamOpenTags.set(`<${name}>`, name)
 	}
 
 	const len = assistantMessage.length
+
 	for (let i = 0; i < len; i++) {
 		const currentCharIndex = i
 
-		// --- State: Parsing a Tool Parameter ---
+		// Parsing a tool parameter
 		if (currentToolUse && currentParamName) {
 			const closeTag = `</${currentParamName}>`
 			// Check if the string *ending* at index `i` matches the closing tag
@@ -293,112 +297,135 @@ export function parseAssistantMessageV2(assistantMessage: string): AssistantMess
 				currentCharIndex >= closeTag.length - 1 &&
 				assistantMessage.startsWith(
 					closeTag,
-					currentCharIndex - closeTag.length + 1, // Start checking from potential start of tag
+					currentCharIndex - closeTag.length + 1, // Start checking from potential start of tag.
 				)
 			) {
-				// Found the closing tag for the parameter
+				// Found the closing tag for the parameter.
 				const value = assistantMessage
 					.slice(
-						currentParamValueStart, // Start after the opening tag
-						currentCharIndex - closeTag.length + 1, // End before the closing tag
+						currentParamValueStart, // Start after the opening tag.
+						currentCharIndex - closeTag.length + 1, // End before the closing tag.
 					)
 					.trim()
 				currentToolUse.params[currentParamName] = value
-				currentParamName = undefined // Go back to parsing tool content
-				// We don't continue loop here, need to check for tool close or other params at index i
+				currentParamName = undefined // Go back to parsing tool content.
+				// We don't continue loop here, need to check for tool close or other params at index i.
 			} else {
-				continue // Still inside param value, move to next char
+				continue // Still inside param value, move to next char.
 			}
 		}
 
-		// --- State: Parsing a Tool Use (but not a specific parameter) ---
+		// Parsing a tool use (but not a specific parameter).
 		if (currentToolUse && !currentParamName) {
-			// Ensure we are not inside a parameter already
-			// Check if starting a new parameter
+			// Ensure we are not inside a parameter already.
+			// Check if starting a new parameter.
 			let startedNewParam = false
+
 			for (const [tag, paramName] of toolParamOpenTags.entries()) {
-				if (currentCharIndex >= tag.length - 1 && assistantMessage.startsWith(tag, currentCharIndex - tag.length + 1)) {
+				if (
+					currentCharIndex >= tag.length - 1 &&
+					assistantMessage.startsWith(tag, currentCharIndex - tag.length + 1)
+				) {
 					currentParamName = paramName
-					currentParamValueStart = currentCharIndex + 1 // Value starts after the tag
+					currentParamValueStart = currentCharIndex + 1 // Value starts after the tag.
 					startedNewParam = true
 					break
 				}
 			}
+
 			if (startedNewParam) {
-				continue // Handled start of param, move to next char
+				continue // Handled start of param, move to next char.
 			}
 
-			// Check if closing the current tool use
+			// Check if closing the current tool use.
 			const toolCloseTag = `</${currentToolUse.name}>`
+
 			if (
 				currentCharIndex >= toolCloseTag.length - 1 &&
 				assistantMessage.startsWith(toolCloseTag, currentCharIndex - toolCloseTag.length + 1)
 			) {
-				// End of the tool use found
-				// Special handling for content params *before* finalizing the tool
+				// End of the tool use found.
+				// Special handling for content params *before* finalizing the
+				// tool.
 				const toolContentSlice = assistantMessage.slice(
-					currentToolUseStart, // From after the tool opening tag
-					currentCharIndex - toolCloseTag.length + 1, // To before the tool closing tag
+					currentToolUseStart, // From after the tool opening tag.
+					currentCharIndex - toolCloseTag.length + 1, // To before the tool closing tag.
 				)
 
-				// Check if content parameter needs special handling (write_to_file/new_rule)
-				// This check is important if the closing </content> tag was missed by the parameter parsing logic
-				// (e.g., if content is empty or parsing logic prioritizes tool close)
+				// Check if content parameter needs special handling
+				// (write_to_file/new_rule).
+				// This check is important if the closing </content> tag was
+				// missed by the parameter parsing logic (e.g., if content is
+				// empty or parsing logic prioritizes tool close).
 				const contentParamName: ToolParamName = "content"
 				if (
-					(currentToolUse.name === "write_to_file" || currentToolUse.name === "new_rule") &&
-					!(contentParamName in currentToolUse.params) && // Only if not already parsed
-					toolContentSlice.includes(`<${contentParamName}>`) // Check if tag exists
+					currentToolUse.name === "write_to_file" /* || currentToolUse.name === "new_rule" */ &&
+					// !(contentParamName in currentToolUse.params) && // Only if not already parsed.
+					toolContentSlice.includes(`<${contentParamName}>`) // Check if tag exists.
 				) {
 					const contentStartTag = `<${contentParamName}>`
 					const contentEndTag = `</${contentParamName}>`
 					const contentStart = toolContentSlice.indexOf(contentStartTag)
-					// Use lastIndexOf for robustness against nested tags
+
+					// Use `lastIndexOf` for robustness against nested tags.
 					const contentEnd = toolContentSlice.lastIndexOf(contentEndTag)
 
 					if (contentStart !== -1 && contentEnd !== -1 && contentEnd > contentStart) {
-						const contentValue = toolContentSlice.slice(contentStart + contentStartTag.length, contentEnd).trim()
+						const contentValue = toolContentSlice
+							.slice(contentStart + contentStartTag.length, contentEnd)
+							.trim()
+
 						currentToolUse.params[contentParamName] = contentValue
 					}
 				}
 
-				currentToolUse.partial = false // Mark as complete
+				currentToolUse.partial = false // Mark as complete.
 				contentBlocks.push(currentToolUse)
-				currentToolUse = undefined // Reset state
-				currentTextContentStart = currentCharIndex + 1 // Potential text starts after this tag
-				continue // Move to next char
+				currentToolUse = undefined // Reset state.
+				currentTextContentStart = currentCharIndex + 1 // Potential text starts after this tag.
+				continue // Move to next char.
 			}
-			// If not starting a param and not closing the tool, continue accumulating tool content implicitly
+
+			// If not starting a param and not closing the tool, continue
+			// accumulating tool content implicitly.
 			continue
 		}
 
-		// --- State: Parsing Text / Looking for Tool Start ---
+		// Parsing text / looking for tool start.
 		if (!currentToolUse) {
-			// Check if starting a new tool use
+			// Check if starting a new tool use.
 			let startedNewTool = false
+
 			for (const [tag, toolName] of toolUseOpenTags.entries()) {
-				if (currentCharIndex >= tag.length - 1 && assistantMessage.startsWith(tag, currentCharIndex - tag.length + 1)) {
-					// End current text block if one was active
+				if (
+					currentCharIndex >= tag.length - 1 &&
+					assistantMessage.startsWith(tag, currentCharIndex - tag.length + 1)
+				) {
+					// End current text block if one was active.
 					if (currentTextContent) {
 						currentTextContent.content = assistantMessage
 							.slice(
-								currentTextContentStart, // From where text started
-								currentCharIndex - tag.length + 1, // To before the tool tag starts
+								currentTextContentStart, // From where text started.
+								currentCharIndex - tag.length + 1, // To before the tool tag starts.
 							)
 							.trim()
-						currentTextContent.partial = false // Ended because tool started
+
+						currentTextContent.partial = false // Ended because tool started.
+
 						if (currentTextContent.content.length > 0) {
 							contentBlocks.push(currentTextContent)
 						}
+
 						currentTextContent = undefined
 					} else {
-						// Check for any text between the last block and this tag
+						// Check for any text between the last block and this tag.
 						const potentialText = assistantMessage
 							.slice(
-								currentTextContentStart, // From where text *might* have started
-								currentCharIndex - tag.length + 1, // To before the tool tag starts
+								currentTextContentStart, // From where text *might* have started.
+								currentCharIndex - tag.length + 1, // To before the tool tag starts.
 							)
 							.trim()
+
 						if (potentialText.length > 0) {
 							contentBlocks.push({
 								type: "text",
@@ -408,33 +435,35 @@ export function parseAssistantMessageV2(assistantMessage: string): AssistantMess
 						}
 					}
 
-					// Start the new tool use
+					// Start the new tool use.
 					currentToolUse = {
 						type: "tool_use",
 						name: toolName,
 						params: {},
-						partial: true, // Assume partial until closing tag is found
+						partial: true, // Assume partial until closing tag is found.
 					}
-					currentToolUseStart = currentCharIndex + 1 // Tool content starts after the opening tag
+
+					currentToolUseStart = currentCharIndex + 1 // Tool content starts after the opening tag.
 					startedNewTool = true
+
 					break
 				}
 			}
 
 			if (startedNewTool) {
-				continue // Handled start of tool, move to next char
+				continue // Handled start of tool, move to next char.
 			}
 
-			// If not starting a tool, it must be text content
+			// If not starting a tool, it must be text content.
 			if (!currentTextContent) {
-				// Start a new text block if we aren't already in one
-				currentTextContentStart = currentCharIndex // Text starts at the current character
-				// Check if the current char is the start of potential text *immediately* after a tag
+				// Start a new text block if we aren't already in one.
+				currentTextContentStart = currentCharIndex // Text starts at the current character.
+
+				// Check if the current char is the start of potential text *immediately* after a tag.
 				// This needs the previous state - simpler to let slicing handle it later.
 				// Resetting start index accurately is key.
 				// It should be the index *after* the last processed tag.
 				// The logic managing currentTextContentStart after closing tags handles this.
-
 				currentTextContent = {
 					type: "text",
 					content: "", // Will be determined by slicing at the end or when a tool starts
@@ -443,30 +472,29 @@ export function parseAssistantMessageV2(assistantMessage: string): AssistantMess
 			}
 			// Continue accumulating text implicitly; content is extracted later.
 		}
-	} // End of loop
+	}
 
-	// --- Finalization after loop ---
-
-	// Finalize any open parameter within an open tool use
+	// Finalize any open parameter within an open tool use.
 	if (currentToolUse && currentParamName) {
 		currentToolUse.params[currentParamName] = assistantMessage
-			.slice(currentParamValueStart) // From param start to end of string
+			.slice(currentParamValueStart) // From param start to end of string.
 			.trim()
-		// Tool use remains partial
+		// Tool use remains partial.
 	}
 
-	// Finalize any open tool use (which might contain the finalized partial param)
+	// Finalize any open tool use (which might contain the finalized partial param).
 	if (currentToolUse) {
-		// Tool use is partial because the loop finished before its closing tag
+		// Tool use is partial because the loop finished before its closing tag.
 		contentBlocks.push(currentToolUse)
 	}
-	// Finalize any trailing text content
-	// Only possible if a tool use wasn't open at the very end
+	// Finalize any trailing text content.
+	// Only possible if a tool use wasn't open at the very end.
 	else if (currentTextContent) {
 		currentTextContent.content = assistantMessage
-			.slice(currentTextContentStart) // From text start to end of string
+			.slice(currentTextContentStart) // From text start to end of string.
 			.trim()
-		// Text is partial because the loop finished
+
+		// Text is partial because the loop finished.
 		if (currentTextContent.content.length > 0) {
 			contentBlocks.push(currentTextContent)
 		}


### PR DESCRIPTION
### Description

As per https://github.com/RooVetGit/Roo-Code/pull/3538

### Test Procedure

<!-- How did you test this? Are you confident that it will not introduce bugs? If so, why? -->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Refines `parseAssistantMessageV2` in `parse-assistant-message.ts` to improve tool parameter and text content parsing, with enhanced handling of special cases.
> 
>   - **Behavior**:
>     - Refines `parseAssistantMessageV2` in `parse-assistant-message.ts` to improve parsing of tool parameters and text content.
>     - Enhances handling of special cases like `write_to_file` and `new_rule` by using `indexOf` and `lastIndexOf` for nested tags.
>     - Ensures partial blocks are correctly marked when input ends mid-block.
>   - **Misc**:
>     - Adds comments for clarity and consistency in `parse-assistant-message.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for a2f46cb989e19f73f7c6975a602550556d0713bb. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->