### PR TITLE
Fixes types for webview building

### DIFF
--- a/webview-ui/src/components/settings/__tests__/APIOptions.spec.tsx
+++ b/webview-ui/src/components/settings/__tests__/APIOptions.spec.tsx
@@ -120,7 +120,7 @@ describe("ApiOptions Component", () => {
 	const mockPostMessage = vi.fn()
 
 	beforeEach(() => {
-		global.vscode = { postMessage: mockPostMessage } as any
+		;(global as any).vscode = { postMessage: mockPostMessage }
 	})
 
 	it("renders Fireworks API Key input", () => {
@@ -167,7 +167,7 @@ describe("ApiOptions Component", () => {
 vi.mock("../../../context/ExtensionStateContext", async (importOriginal) => {
 	const actual = await importOriginal()
 	return {
-		...actual,
+		...(actual || {}),
 		// your mocked methods
 		useExtensionState: vi.fn(() => ({
 			apiConfiguration: {

--- a/webview-ui/src/utils/context-mentions.ts
+++ b/webview-ui/src/utils/context-mentions.ts
@@ -1,6 +1,5 @@
 import { mentionRegex } from "@shared/context-mentions"
 import { Fzf } from "fzf"
-import * as path from "path"
 
 export interface SearchResult {
 	path: string
@@ -193,7 +192,7 @@ export function getContextMenuOptions(
 		const item = {
 			type: result.type === "folder" ? ContextMenuOptionType.Folder : ContextMenuOptionType.File,
 			value: formattedPath,
-			label: result.label || path.basename(result.path),
+			label: result.label || result.path.split("/").pop() || result.path,
 			description: formattedPath,
 		}
 		return item


### PR DESCRIPTION
### Description
This PR addresses several issues that were causing the `npm run build:webview` command to fail. The changes ensure that the webview UI builds correctly and that test mocks are more robust.

### Problem 1: TypeScript Error in Test Mock (`APIOptions.spec.tsx`)

-   **Error:** `TS7017: Element implicitly has an 'any' type because type 'typeof globalThis' has no index signature.`
-   **Cause:** Assigning `vscode` to the `global` object without TypeScript recognizing this property.
-   **Solution:** Cast `global` to `any` for this specific assignment (`(global as any).vscode = ...`) to inform TypeScript that this dynamic property addition is intentional for the test environment.

### Problem 2: TypeScript Error in Test Mock (`APIOptions.spec.tsx`)

-   **Error:** `TS2698: Spread types may only be created from object types.`
-   **Cause:** Attempting to spread the `actual` variable (from `await importOriginal()`) which could potentially be non-object (e.g., `undefined`).
-   **Solution:** Changed `...actual` to `...(actual || {})` to ensure that an empty object is spread if `actual` is falsy, making the spread operation type-safe.

### Problem 3: Vite Build Error due to Node.js `path` module (`context-mentions.ts`)

-   **Error:** `"basename" is not exported by "__vite-browser-external"`
-   **Cause:** The `path.basename()` function, imported from the Node.js `path` module, is not available in the browser environment where the webview UI code executes.
-   **Solution:**
    -   Removed the `import * as path from "path";` statement.
    -   Replaced the usage of `path.basename(result.path)` with a browser-compatible string manipulation: `result.path.split('/').pop() || result.path`. This achieves the same goal of extracting the filename/last segment of a path.

### Test Procedure

<!-- How did you test this? Are you confident that it will not introduce bugs? If so, why? -->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [X] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [X] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [X] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [X] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [X] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix TypeScript errors in `APIOptions.spec.tsx` and Vite build error in `context-mentions.ts` for webview UI build.
> 
>   - **TypeScript Errors in `APIOptions.spec.tsx`**:
>     - Cast `global` to `any` to fix `TS7017` error when assigning `vscode`.
>     - Use `...(actual || {})` to fix `TS2698` error when spreading `actual`.
>   - **Vite Build Error in `context-mentions.ts`**:
>     - Remove `import * as path from "path"`.
>     - Replace `path.basename(result.path)` with `result.path.split('/').pop() || result.path` for browser compatibility.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for f4e6c620d447e748c18c50c3fecbf03d910fc079. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->