### PR TITLE
Handle Gemini Rate Limits

### DIFF
--- a/.changeset/chatty-emus-marry.md
+++ b/.changeset/chatty-emus-marry.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Handle Gemini Rate limiting


### PR DESCRIPTION
### Description

Gemini doesn't expose status codes in their API errors. While it should ideally be added on their side (and there are [PRs](https://github.com/googleapis/js-genai/pull/476/files#diff-55db69e02ff5714d444d8081ec6ecac5d9833fb29fda64d1e829e5766434fdc0) to do so), this PR handles the error message to rethrow them.

### Test Procedure

I tested this locally. As you can see here, it now includes it:
<img width="234" alt="image" src="https://github.com/user-attachments/assets/92f9e814-ba76-4417-b101-36979ea21b9f" />


### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Improves error handling in `GeminiHandler` to set status code 429 for rate limit errors in `gemini.ts`.
> 
>   - **Error Handling**:
>     - In `GeminiHandler` in `gemini.ts`, adds logic to handle rate limit errors by setting `status` to 429 when error message includes "429 Too Many Requests".
>   - **Imports**:
>     - Removes unused `Content` import from `@google/genai` in `gemini.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 9f3f7c898da2073c54e26ce4a148a8a796f93b8b. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->