### PR TITLE
Add gemini model back to vertex provider

### DIFF
--- a/.changeset/chilly-balloons-unite.md
+++ b/.changeset/chilly-balloons-unite.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Add gemini model back to vertex provider

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -433,6 +433,14 @@ export const vertexModels = {
 		inputPrice: 0,
 		outputPrice: 0,
 	},
+	"gemini-2.5-pro-exp-03-25": {
+		maxTokens: 65536,
+		contextWindow: 1_048_576,
+		supportsImages: true,
+		supportsPromptCache: false,
+		inputPrice: 0,
+		outputPrice: 0,
+	},
 	"gemini-2.5-pro-preview-05-06": {
 		maxTokens: 65536,
 		contextWindow: 1_048_576,


### PR DESCRIPTION
### Description

Add gemini model back to vertex provider.

### Type of Change

-   [X] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [X] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [X] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [X] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [X] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Re-adds `gemini-2.5-pro-exp-03-25` model to `vertexModels` in `api.ts` with specific configurations.
> 
>   - **Behavior**:
>     - Re-adds `gemini-2.5-pro-exp-03-25` model to `vertexModels` in `api.ts`.
>     - Model supports 65536 max tokens, 1,048,576 context window, supports images, and does not support prompt cache.
>     - Input and output prices are set to 0.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for f05fc3c14d767a57c1302d9c6c28a3b3ffd8170c. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->