### PR TITLE
[PROTOBUS] Move askResponse to protobus

### DIFF
--- a/.changeset/nervous-jokes-leave.md
+++ b/.changeset/nervous-jokes-leave.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+askResponse protobus migration

--- a/proto/task.proto
+++ b/proto/task.proto
@@ -25,6 +25,8 @@ service TaskService {
   rpc deleteNonFavoritedTasks(EmptyRequest) returns (DeleteNonFavoritedTasksResults);
   // Gets filtered task history
   rpc getTaskHistory(GetTaskHistoryRequest) returns (TaskHistoryArray);
+  // Sends a response to a previous ask operation
+  rpc askResponse(AskResponseRequest) returns (Empty);
 }
 
 // Request message for creating a new task
@@ -88,4 +90,12 @@ message TaskItem {
   int32 tokens_out = 8;
   int32 cache_writes = 9;
   int32 cache_reads = 10;
+}
+
+// Request for ask response operation
+message AskResponseRequest {
+  Metadata metadata = 1;
+  string response_type = 2; 
+  string text = 3;
+  repeated string images = 4;
 }

--- a/src/core/controller/index.ts
+++ b/src/core/controller/index.ts
@@ -313,9 +313,6 @@ export class Controller {
 				const browserSession = new BrowserSession(this.context, browserSettings)
 				await browserSession.relaunchChromeDebugMode(this)
 				break
-			case "askResponse":
-				this.task?.handleWebviewAskResponse(message.askResponse!, message.text, message.images)
-				break
 			case "didShowAnnouncement":
 				await updateGlobalState(this.context, "lastShownAnnouncementId", this.latestAnnouncementId)
 				await this.postStateToWebview()

--- a/src/core/controller/task/askResponse.ts
+++ b/src/core/controller/task/askResponse.ts
@@ -1,0 +1,45 @@
+import { Controller } from ".."
+import { Empty } from "../../../shared/proto/common"
+import { AskResponseRequest } from "../../../shared/proto/task"
+import { ClineAskResponse } from "../../../shared/WebviewMessage"
+
+/**
+ * Handles a response from the webview for a previous ask operation
+ *
+ * @param controller The controller instance
+ * @param request The request containing response type, optional text and optional images
+ * @returns Empty response
+ */
+export async function askResponse(controller: Controller, request: AskResponseRequest): Promise<Empty> {
+	try {
+		if (!controller.task) {
+			console.warn("askResponse: No active task to receive response")
+			return Empty.create()
+		}
+
+		// Map the string responseType to the ClineAskResponse enum
+		let responseType: ClineAskResponse
+		switch (request.responseType) {
+			case "yesButtonClicked":
+				responseType = "yesButtonClicked"
+				break
+			case "noButtonClicked":
+				responseType = "noButtonClicked"
+				break
+			case "messageResponse":
+				responseType = "messageResponse"
+				break
+			default:
+				console.warn(`askResponse: Unknown response type: ${request.responseType}`)
+				return Empty.create()
+		}
+
+		// Call the task's handler for webview responses
+		await controller.task.handleWebviewAskResponse(responseType, request.text, request.images)
+
+		return Empty.create()
+	} catch (error) {
+		console.error("Error in askResponse handler:", error)
+		throw error
+	}
+}

--- a/src/core/controller/task/methods.ts
+++ b/src/core/controller/task/methods.ts
@@ -3,6 +3,7 @@
 
 // Import all method implementations
 import { registerMethod } from "./index"
+import { askResponse } from "./askResponse"
 import { cancelTask } from "./cancelTask"
 import { clearTask } from "./clearTask"
 import { deleteNonFavoritedTasks } from "./deleteNonFavoritedTasks"
@@ -16,6 +17,7 @@ import { toggleTaskFavorite } from "./toggleTaskFavorite"
 // Register all task service methods
 export function registerAllMethods(): void {
 	// Register each method with the registry
+	registerMethod("askResponse", askResponse)
 	registerMethod("cancelTask", cancelTask)
 	registerMethod("clearTask", clearTask)
 	registerMethod("deleteNonFavoritedTasks", deleteNonFavoritedTasks)

--- a/src/services/test/TestServer.ts
+++ b/src/services/test/TestServer.ts
@@ -5,6 +5,7 @@ import { execa } from "execa"
 import { Logger } from "@services/logging/Logger"
 import { WebviewProvider } from "@core/webview"
 import { AutoApprovalSettings } from "@shared/AutoApprovalSettings"
+import { TaskServiceClient } from "webview-ui/src/services/grpc-client"
 import {
 	getWorkspacePath,
 	validateWorkspacePath,
@@ -15,7 +16,6 @@ import {
 import { updateGlobalState, getAllExtensionState, updateApiConfiguration, storeSecret } from "@core/storage/state"
 import { ClineAsk, ExtensionMessage } from "@shared/ExtensionMessage"
 import { ApiProvider } from "@shared/api"
-import { WebviewMessage } from "@shared/WebviewMessage"
 import { HistoryItem } from "@shared/HistoryItem"
 import { getSavedClineMessages, getSavedApiConversationHistory } from "@core/storage/disk"
 
@@ -515,8 +515,8 @@ export function createMessageCatcher(webviewProvider: WebviewProvider): vscode.D
 				const askText = message.partialMessage.text
 
 				// Automatically respond to different types of asks
-				setTimeout(() => {
-					autoRespondToAsk(webviewProvider, askType, askText)
+				setTimeout(async () => {
+					await autoRespondToAsk(webviewProvider, askType, askText)
 				}, 100) // Small delay to ensure the message is processed first
 			}
 
@@ -538,65 +538,64 @@ export function createMessageCatcher(webviewProvider: WebviewProvider): vscode.D
  * @param askType The type of ask message
  * @param askText The text content of the ask message
  */
-function autoRespondToAsk(webviewProvider: WebviewProvider, askType: ClineAsk, askText?: string): void {
+async function autoRespondToAsk(webviewProvider: WebviewProvider, askType: ClineAsk, askText?: string): Promise<void> {
 	if (!webviewProvider.controller) {
 		return
 	}
 
 	Logger.log(`Auto-responding to ask type: ${askType}`)
 
-	// Create a response message based on the ask type
-	const response: WebviewMessage = {
-		type: "askResponse",
-		askResponse: "yesButtonClicked", // Default to approving most actions
-	}
+	// Default to approving most actions
+	let responseType = "yesButtonClicked"
+	let responseText: string | undefined
+	let responseImages: string[] | undefined
 
 	// Handle specific ask types differently if needed
 	switch (askType) {
 		case "followup":
 			// For follow-up questions, provide a generic response
-			response.askResponse = "messageResponse"
-			response.text = "I can't answer any questions right now, use your best judgment."
+			responseType = "messageResponse"
+			responseText = "I can't answer any questions right now, use your best judgment."
 			break
 
 		case "api_req_failed":
 			// Always retry API requests
-			response.askResponse = "yesButtonClicked" // "Retry" button
+			responseType = "yesButtonClicked" // "Retry" button
 			break
 
 		case "completion_result":
 			// Accept the completion
-			response.askResponse = "messageResponse"
-			response.text = "Task completed successfully."
+			responseType = "messageResponse"
+			responseText = "Task completed successfully."
 			break
 
 		case "mistake_limit_reached":
 			// Provide guidance to continue
-			response.askResponse = "messageResponse"
-			response.text = "Try breaking down the task into smaller steps."
+			responseType = "messageResponse"
+			responseText = "Try breaking down the task into smaller steps."
 			break
 
 		case "auto_approval_max_req_reached":
 			// Reset the count to continue
-			response.askResponse = "yesButtonClicked" // "Reset and continue" button
+			responseType = "yesButtonClicked" // "Reset and continue" button
 			break
 
 		case "resume_task":
 		case "resume_completed_task":
 			// Resume the task
-			response.askResponse = "messageResponse"
+			responseType = "messageResponse"
 			break
 
 		case "new_task":
 			// Decline creating a new task to keep the current task running
-			response.askResponse = "messageResponse"
-			response.text = "Continue with the current task."
+			responseType = "messageResponse"
+			responseText = "Continue with the current task."
 			break
 
 		case "plan_mode_respond":
 			// Respond to plan mode with a message to toggle to Act mode
-			response.askResponse = "messageResponse"
-			response.text = "PLAN_MODE_TOGGLE_RESPONSE" // Special marker to toggle to Act mode
+			responseType = "messageResponse"
+			responseText = "PLAN_MODE_TOGGLE_RESPONSE" // Special marker to toggle to Act mode
 
 			// Automatically toggle to Act mode after responding
 			setTimeout(async () => {
@@ -616,8 +615,16 @@ function autoRespondToAsk(webviewProvider: WebviewProvider, askType: ClineAsk, a
 	}
 
 	// Send the response message
-	webviewProvider.controller.handleWebviewMessage(response)
-	Logger.log(`Auto-responded to ${askType} with ${response.askResponse}`)
+	try {
+		await TaskServiceClient.askResponse({
+			responseType,
+			text: responseText,
+			images: responseImages,
+		})
+		Logger.log(`Auto-responded to ${askType} with ${responseType}`)
+	} catch (error) {
+		Logger.log(`Error sending askResponse: ${error}`)
+	}
 }
 
 /**

--- a/src/shared/WebviewMessage.ts
+++ b/src/shared/WebviewMessage.ts
@@ -14,7 +14,6 @@ export interface WebviewMessage {
 		| "newTask"
 		| "condense"
 		| "reportBug"
-		| "askResponse"
 		| "didShowAnnouncement"
 		| "selectImages"
 		| "resetState"
@@ -66,7 +65,6 @@ export interface WebviewMessage {
 	// | "relaunchChromeDebugMode"
 	text?: string
 	disabled?: boolean
-	askResponse?: ClineAskResponse
 	apiConfiguration?: ApiConfiguration
 	images?: string[]
 	bool?: boolean

--- a/src/standalone/server-setup.ts
+++ b/src/standalone/server-setup.ts
@@ -60,6 +60,7 @@ import { exportTaskWithId } from "../core/controller/task/exportTaskWithId"
 import { toggleTaskFavorite } from "../core/controller/task/toggleTaskFavorite"
 import { deleteNonFavoritedTasks } from "../core/controller/task/deleteNonFavoritedTasks"
 import { getTaskHistory } from "../core/controller/task/getTaskHistory"
+import { askResponse } from "../core/controller/task/askResponse"
 
 // Web Service
 import { checkIsImageUrl } from "../core/controller/web/checkIsImageUrl"
@@ -144,6 +145,7 @@ export function addServices(
 		toggleTaskFavorite: wrapper(toggleTaskFavorite, controller),
 		deleteNonFavoritedTasks: wrapper(deleteNonFavoritedTasks, controller),
 		getTaskHistory: wrapper(getTaskHistory, controller),
+		askResponse: wrapper(askResponse, controller),
 	})
 
 	// Web Service

--- a/webview-ui/src/components/chat/ChatView.tsx
+++ b/webview-ui/src/components/chat/ChatView.tsx
@@ -463,25 +463,22 @@ const ChatView = ({ isHidden, showAnnouncement, hideAnnouncement, showHistoryVie
 						case "resume_completed_task":
 						case "mistake_limit_reached":
 						case "new_task": // user can provide feedback or reject the new task suggestion
-							vscode.postMessage({
-								type: "askResponse",
-								askResponse: "messageResponse",
+							await TaskServiceClient.askResponse({
+								responseType: "messageResponse",
 								text: messageToSend,
 								images,
 							})
 							break
 						case "condense":
-							vscode.postMessage({
-								type: "askResponse",
-								askResponse: "messageResponse",
+							await TaskServiceClient.askResponse({
+								responseType: "messageResponse",
 								text: messageToSend,
 								images,
 							})
 							break
 						case "report_bug":
-							vscode.postMessage({
-								type: "askResponse",
-								askResponse: "messageResponse",
+							await TaskServiceClient.askResponse({
+								responseType: "messageResponse",
 								text: messageToSend,
 								images,
 							})
@@ -525,16 +522,14 @@ const ChatView = ({ isHidden, showAnnouncement, hideAnnouncement, showHistoryVie
 				case "mistake_limit_reached":
 				case "auto_approval_max_req_reached":
 					if (trimmedInput || (images && images.length > 0)) {
-						vscode.postMessage({
-							type: "askResponse",
-							askResponse: "yesButtonClicked",
+						await TaskServiceClient.askResponse({
+							responseType: "yesButtonClicked",
 							text: trimmedInput,
 							images: images,
 						})
 					} else {
-						vscode.postMessage({
-							type: "askResponse",
-							askResponse: "yesButtonClicked",
+						await TaskServiceClient.askResponse({
+							responseType: "yesButtonClicked",
 						})
 					}
 					// Clear input state after sending
@@ -591,17 +586,15 @@ const ChatView = ({ isHidden, showAnnouncement, hideAnnouncement, showHistoryVie
 				case "browser_action_launch":
 				case "use_mcp_server":
 					if (trimmedInput || (images && images.length > 0)) {
-						vscode.postMessage({
-							type: "askResponse",
-							askResponse: "noButtonClicked",
+						await TaskServiceClient.askResponse({
+							responseType: "noButtonClicked",
 							text: trimmedInput,
 							images: images,
 						})
 					} else {
 						// responds to the API with a "This operation failed" and lets it try again
-						vscode.postMessage({
-							type: "askResponse",
-							askResponse: "noButtonClicked",
+						await TaskServiceClient.askResponse({
+							responseType: "noButtonClicked",
 						})
 					}
 					// Clear input state after sending


### PR DESCRIPTION
### Description

This PR migrates the askResponse message to the gRPC/Protobuf system. It converts the legacy VSCode message passing mechanism to a gRPC method in the ModelsService. The client can now call TaskServiceClient.askResponse() to pass askResponse messages.

### Test Procedure

<!-- How did you test this? Are you confident that it will not introduce bugs? If so, why? -->

Start a new task and request that Cline use the followup questions tool, confirm questions are returned and work when selected. GRPC traffic should be recorded in the console.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [x] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Migrates `askResponse` functionality to gRPC/Protobuf, updating message handling and tests accordingly.
> 
>   - **Behavior**:
>     - Migrates `askResponse` to gRPC/Protobuf in `task.proto`, adding `rpc askResponse(AskResponseRequest) returns (Empty)`.
>     - Updates `Controller` in `index.ts` to remove legacy `askResponse` handling.
>     - Implements `askResponse()` in `askResponse.ts` to handle gRPC requests.
>   - **Tests**:
>     - Updates `chat-native.test.ts` to test gRPC `askResponse` requests.
>     - Modifies `TestServer.ts` to use `TaskServiceClient.askResponse()` for auto-responses.
>   - **Misc**:
>     - Registers `askResponse` in `methods.ts` and `server-setup.ts`.
>     - Removes `askResponse` from `WebviewMessage.ts` type definitions.
>     - Updates `ChatView.tsx` to use `TaskServiceClient.askResponse()` for message handling.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 26d214795c3bd4fad7fd858e982aa784cf34ac93. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->