### PR TITLE
[PROTOBUS] Move fetchOpenGraphData to protobus 

### DIFF
--- a/.changeset/good-ducks-teach.md
+++ b/.changeset/good-ducks-teach.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+fetchOpenGraphData protobus migration

--- a/proto/web.proto
+++ b/proto/web.proto
@@ -8,9 +8,19 @@ import "common.proto";
 
 service WebService {
   rpc checkIsImageUrl(StringRequest) returns (IsImageUrl);
+  rpc fetchOpenGraphData(StringRequest) returns (OpenGraphData);
 }
 
 message IsImageUrl {
   bool is_image = 1;
   string url = 2;
+}
+
+message OpenGraphData {
+  string title = 1;
+  string description = 2;
+  string image = 3;
+  string url = 4;
+  string site_name = 5;
+  string type = 6;
 }

--- a/src/core/controller/index.ts
+++ b/src/core/controller/index.ts
@@ -340,9 +340,6 @@ export class Controller {
 					vscode.env.openExternal(vscode.Uri.parse(message.url))
 				}
 				break
-			case "fetchOpenGraphData":
-				this.fetchOpenGraphData(message.text!)
-				break
 			case "openMention":
 				openMention(message.text)
 				break
@@ -1466,30 +1463,6 @@ export class Controller {
 	// }
 
 	// secrets
-
-	// Open Graph Data
-
-	async fetchOpenGraphData(url: string) {
-		try {
-			// Use the fetchOpenGraphData function from link-preview.ts
-			const ogData = await fetchOpenGraphData(url)
-
-			// Send the data back to the webview
-			await this.postMessageToWebview({
-				type: "openGraphData",
-				openGraphData: ogData,
-				url: url,
-			})
-		} catch (error) {
-			console.error(`Error fetching Open Graph data for ${url}:`, error)
-			// Send an error response
-			await this.postMessageToWebview({
-				type: "openGraphData",
-				error: `Failed to fetch Open Graph data: ${error}`,
-				url: url,
-			})
-		}
-	}
 
 	// Git commit message generation
 

--- a/src/core/controller/web/fetchOpenGraphData.ts
+++ b/src/core/controller/web/fetchOpenGraphData.ts
@@ -1,0 +1,26 @@
+import { Controller } from ".."
+import { StringRequest } from "../../../shared/proto/common"
+import { OpenGraphData } from "../../../shared/proto/web"
+import { fetchOpenGraphData as fetchOGData } from "../../../integrations/misc/link-preview"
+import { convertDomainOpenGraphDataToProto } from "../../../shared/proto-conversions/web/open-graph-conversion"
+
+/**
+ * Fetches Open Graph metadata from a URL
+ * @param controller The controller instance
+ * @param request The request containing the URL to fetch metadata from
+ * @returns Promise resolving to OpenGraphData
+ */
+export async function fetchOpenGraphData(controller: Controller, request: StringRequest): Promise<OpenGraphData> {
+	try {
+		const url = request.value || ""
+		// Fetch open graph data using the existing utility
+		const ogData = await fetchOGData(url)
+
+		// Convert domain model to proto model
+		return convertDomainOpenGraphDataToProto(ogData)
+	} catch (error) {
+		console.error(`Error fetching Open Graph data: ${request.value}`, error)
+		// Return empty OpenGraphData object
+		return OpenGraphData.create({})
+	}
+}

--- a/src/core/controller/web/methods.ts
+++ b/src/core/controller/web/methods.ts
@@ -4,9 +4,11 @@
 // Import all method implementations
 import { registerMethod } from "./index"
 import { checkIsImageUrl } from "./checkIsImageUrl"
+import { fetchOpenGraphData } from "./fetchOpenGraphData"
 
 // Register all web service methods
 export function registerAllMethods(): void {
 	// Register each method with the registry
 	registerMethod("checkIsImageUrl", checkIsImageUrl)
+	registerMethod("fetchOpenGraphData", fetchOpenGraphData)
 }

--- a/src/shared/WebviewMessage.ts
+++ b/src/shared/WebviewMessage.ts
@@ -42,7 +42,6 @@ export interface WebviewMessage {
 		| "fetchLatestMcpServersFromHub"
 		| "telemetrySetting"
 		| "openSettings"
-		| "fetchOpenGraphData"
 		| "invoke"
 		| "updateSettings"
 		| "clearAllTaskHistory"

--- a/src/shared/proto-conversions/web/open-graph-conversion.ts
+++ b/src/shared/proto-conversions/web/open-graph-conversion.ts
@@ -1,0 +1,18 @@
+import { OpenGraphData as DomainOpenGraphData } from "@integrations/misc/link-preview"
+import { OpenGraphData as ProtoOpenGraphData } from "@shared/proto/web"
+
+/**
+ * Converts domain OpenGraphData objects to proto OpenGraphData objects
+ * @param ogData Domain OpenGraphData object
+ * @returns Proto OpenGraphData object
+ */
+export function convertDomainOpenGraphDataToProto(ogData: DomainOpenGraphData): ProtoOpenGraphData {
+	return ProtoOpenGraphData.create({
+		title: ogData.title || "",
+		description: ogData.description || "",
+		image: ogData.image || "",
+		url: ogData.url || "",
+		siteName: ogData.siteName || "",
+		type: ogData.type || "",
+	})
+}

--- a/src/shared/proto/web.ts
+++ b/src/shared/proto/web.ts
@@ -15,6 +15,15 @@ export interface IsImageUrl {
 	url: string
 }
 
+export interface OpenGraphData {
+	title: string
+	description: string
+	image: string
+	url: string
+	siteName: string
+	type: string
+}
+
 function createBaseIsImageUrl(): IsImageUrl {
 	return { isImage: false, url: "" }
 }
@@ -91,6 +100,146 @@ export const IsImageUrl: MessageFns<IsImageUrl> = {
 	},
 }
 
+function createBaseOpenGraphData(): OpenGraphData {
+	return { title: "", description: "", image: "", url: "", siteName: "", type: "" }
+}
+
+export const OpenGraphData: MessageFns<OpenGraphData> = {
+	encode(message: OpenGraphData, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+		if (message.title !== "") {
+			writer.uint32(10).string(message.title)
+		}
+		if (message.description !== "") {
+			writer.uint32(18).string(message.description)
+		}
+		if (message.image !== "") {
+			writer.uint32(26).string(message.image)
+		}
+		if (message.url !== "") {
+			writer.uint32(34).string(message.url)
+		}
+		if (message.siteName !== "") {
+			writer.uint32(42).string(message.siteName)
+		}
+		if (message.type !== "") {
+			writer.uint32(50).string(message.type)
+		}
+		return writer
+	},
+
+	decode(input: BinaryReader | Uint8Array, length?: number): OpenGraphData {
+		const reader = input instanceof BinaryReader ? input : new BinaryReader(input)
+		let end = length === undefined ? reader.len : reader.pos + length
+		const message = createBaseOpenGraphData()
+		while (reader.pos < end) {
+			const tag = reader.uint32()
+			switch (tag >>> 3) {
+				case 1: {
+					if (tag !== 10) {
+						break
+					}
+
+					message.title = reader.string()
+					continue
+				}
+				case 2: {
+					if (tag !== 18) {
+						break
+					}
+
+					message.description = reader.string()
+					continue
+				}
+				case 3: {
+					if (tag !== 26) {
+						break
+					}
+
+					message.image = reader.string()
+					continue
+				}
+				case 4: {
+					if (tag !== 34) {
+						break
+					}
+
+					message.url = reader.string()
+					continue
+				}
+				case 5: {
+					if (tag !== 42) {
+						break
+					}
+
+					message.siteName = reader.string()
+					continue
+				}
+				case 6: {
+					if (tag !== 50) {
+						break
+					}
+
+					message.type = reader.string()
+					continue
+				}
+			}
+			if ((tag & 7) === 4 || tag === 0) {
+				break
+			}
+			reader.skip(tag & 7)
+		}
+		return message
+	},
+
+	fromJSON(object: any): OpenGraphData {
+		return {
+			title: isSet(object.title) ? globalThis.String(object.title) : "",
+			description: isSet(object.description) ? globalThis.String(object.description) : "",
+			image: isSet(object.image) ? globalThis.String(object.image) : "",
+			url: isSet(object.url) ? globalThis.String(object.url) : "",
+			siteName: isSet(object.siteName) ? globalThis.String(object.siteName) : "",
+			type: isSet(object.type) ? globalThis.String(object.type) : "",
+		}
+	},
+
+	toJSON(message: OpenGraphData): unknown {
+		const obj: any = {}
+		if (message.title !== "") {
+			obj.title = message.title
+		}
+		if (message.description !== "") {
+			obj.description = message.description
+		}
+		if (message.image !== "") {
+			obj.image = message.image
+		}
+		if (message.url !== "") {
+			obj.url = message.url
+		}
+		if (message.siteName !== "") {
+			obj.siteName = message.siteName
+		}
+		if (message.type !== "") {
+			obj.type = message.type
+		}
+		return obj
+	},
+
+	create<I extends Exact<DeepPartial<OpenGraphData>, I>>(base?: I): OpenGraphData {
+		return OpenGraphData.fromPartial(base ?? ({} as any))
+	},
+	fromPartial<I extends Exact<DeepPartial<OpenGraphData>, I>>(object: I): OpenGraphData {
+		const message = createBaseOpenGraphData()
+		message.title = object.title ?? ""
+		message.description = object.description ?? ""
+		message.image = object.image ?? ""
+		message.url = object.url ?? ""
+		message.siteName = object.siteName ?? ""
+		message.type = object.type ?? ""
+		return message
+	},
+}
+
 export type WebServiceDefinition = typeof WebServiceDefinition
 export const WebServiceDefinition = {
 	name: "WebService",
@@ -101,6 +250,14 @@ export const WebServiceDefinition = {
 			requestType: StringRequest,
 			requestStream: false,
 			responseType: IsImageUrl,
+			responseStream: false,
+			options: {},
+		},
+		fetchOpenGraphData: {
+			name: "fetchOpenGraphData",
+			requestType: StringRequest,
+			requestStream: false,
+			responseType: OpenGraphData,
 			responseStream: false,
 			options: {},
 		},

--- a/src/standalone/server-setup.ts
+++ b/src/standalone/server-setup.ts
@@ -63,6 +63,7 @@ import { getTaskHistory } from "../core/controller/task/getTaskHistory"
 
 // Web Service
 import { checkIsImageUrl } from "../core/controller/web/checkIsImageUrl"
+import { fetchOpenGraphData } from "../core/controller/web/fetchOpenGraphData"
 
 export function addServices(
 	server: grpc.Server,
@@ -149,5 +150,6 @@ export function addServices(
 	// Web Service
 	server.addService(proto.cline.WebService.service, {
 		checkIsImageUrl: wrapper(checkIsImageUrl, controller),
+		fetchOpenGraphData: wrapper(fetchOpenGraphData, controller),
 	})
 }


### PR DESCRIPTION
### Description

This PR migrates the fetchOpenGraphData message to the gRPC/Protobuf system. It converts the legacy VSCode message passing mechanism to a gRPC method in the WebService. The client can now call WebServiceClient.fetchOpenGraphData() to pass askResponse messages.

### Test Procedure

To test, use an MCP server that returns a rich response with links and thumbnails (Serper search is good for this). Confirm the previews with titles, descriptions, and thumbnails are displayed. Logs should record GRPC traffic.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [ ] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Migrates `fetchOpenGraphData` to gRPC/Protobuf system, updating server and client-side implementations to use the new method.
> 
>   - **Behavior**:
>     - Migrates `fetchOpenGraphData` from legacy message passing to gRPC in `web.proto` and `server-setup.ts`.
>     - Updates `LinkPreview.tsx` to use `WebServiceClient.fetchOpenGraphData()` for fetching Open Graph data.
>   - **Protobuf**:
>     - Adds `fetchOpenGraphData` RPC method to `WebService` in `web.proto`.
>     - Defines `OpenGraphData` message in `web.proto` and `web.ts`.
>   - **Controller**:
>     - Removes legacy `fetchOpenGraphData` handling from `index.ts`.
>     - Adds `fetchOpenGraphData` function in `fetchOpenGraphData.ts`.
>     - Registers `fetchOpenGraphData` in `methods.ts`.
>   - **Misc**:
>     - Adds `convertDomainOpenGraphDataToProto` in `open-graph-conversion.ts` for data conversion.
>     - Removes `fetchOpenGraphData` from `WebviewMessage.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 8b27611438488793574deac3bbc1421bd4243a9e. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->