### PR TITLE
fix the display from filename if type is windows in RuleRow.tsx

### DIFF
--- a/webview-ui/src/components/cline-rules/RuleRow.tsx
+++ b/webview-ui/src/components/cline-rules/RuleRow.tsx
@@ -9,8 +9,10 @@ const RuleRow: React.FC<{
 	ruleType: string
 	toggleRule: (rulePath: string, enabled: boolean) => void
 }> = ({ rulePath, enabled, isGlobal, toggleRule, ruleType }) => {
+	// Check if the path type is Windows
+	const win32Path = /^[a-zA-Z]:\\/.test(rulePath)
 	// Get the filename from the path for display
-	const displayName = rulePath.split("/").pop() || rulePath
+	const displayName = rulePath.split(win32Path ? "\\" : "/").pop() || rulePath
 
 	const getRuleTypeIcon = () => {
 		switch (ruleType) {


### PR DESCRIPTION
### Description

The original code only worked for extracting filenames from Linux - style paths. It failed in Windows environments. So, I added a precondition to check if it's a Windows path.

### Test Procedure

After testing on macOS, Windows 10, and Windows 11, the issue has been fixed to allow and correctly extract the filename.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist


-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)



<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes filename extraction in `RuleRow.tsx` for Windows-style paths by checking path type and adjusting delimiter.
> 
>   - **Behavior**:
>     - Fixes filename extraction in `RuleRow.tsx` for Windows-style paths by checking if the path is Windows and using `\\` as the delimiter.
>   - **Testing**:
>     - Verified on macOS, Windows 10, and Windows 11 to ensure correct filename extraction.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 65918c9861057d6ae18fb634207165c3197f248b. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->