### PR TITLE
feat: support git context #3556

### DIFF
--- a/.changeset/eight-fireants-rule.md
+++ b/.changeset/eight-fireants-rule.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": minor
+---
+
+Add git repositories information to Cline environment context


### PR DESCRIPTION
### Description

This pull request enhances Cline by adding detailed Git repository information to the environment details provided to the AI as described in #3556

This includes:

- The relative path to each active repository.
- The current branch of each repository.
- The remote URL (fetch or push) for the 'origin' remote, or the first available remote.

This information allows Cline to have better context about the user's project structure and version control status, potentially leading to more relevant and accurate assistance.


### Test Procedure

Manual testing with the following scenarios.

- No folder open
- Folder open without git repositories
- A git repository opened
- Multiple git repositories opened

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Folder not opened - no information about git
<img width="1728" alt="FolderNotOpened" src="https://github.com/user-attachments/assets/f8d4e60c-7e79-44ad-bdcd-7d152c7677db" />

Folder With No Git Repository - no information about git
<img width="1722" alt="FolderWithNoGitRepository" src="https://github.com/user-attachments/assets/40fe5430-2bf5-47aa-a985-9cddca98c2a8" />

One Git Repository - a single git repository in the prompt
<img width="1722" alt="OneGitRepository" src="https://github.com/user-attachments/assets/20157663-e31c-4891-836d-c2009e192387" />

Multiple Folders And Remotes - list of all git repositories
<img width="1727" alt="MultipleFoldersAndRemotes" src="https://github.com/user-attachments/assets/6b2691ea-ff43-4290-9ab4-c4ec86689cf0" />


