### PR TITLE
fix the eternal loading state when the last message is a checkpoint

### DIFF
--- a/.changeset/beige-pets-type.md
+++ b/.changeset/beige-pets-type.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+fix eternal loading states when the last message is a checkpoint

--- a/webview-ui/src/components/chat/ChatView.tsx
+++ b/webview-ui/src/components/chat/ChatView.tsx
@@ -976,6 +976,14 @@ const ChatView = ({ isHidden, showAnnouncement, hideAnnouncement, showHistoryVie
 				)
 			}
 
+			// We display certain statuses for the last message only
+			// If the last message is a checkpoint, we want to show the status of the previous message
+			const nextMessage = index < groupedMessages.length - 1 && groupedMessages[index + 1]
+			const isNextCheckpoint = !Array.isArray(nextMessage) && nextMessage && nextMessage?.say === "checkpoint_created"
+			const isLastMessageGroup = isNextCheckpoint && index === groupedMessages.length - 2
+
+			const isLast = index === groupedMessages.length - 1 || isLastMessageGroup
+
 			// regular message
 			return (
 				<ChatRow
@@ -984,7 +992,7 @@ const ChatView = ({ isHidden, showAnnouncement, hideAnnouncement, showHistoryVie
 					isExpanded={expandedRows[messageOrGroup.ts] || false}
 					onToggleExpand={() => toggleRowExpansion(messageOrGroup.ts)}
 					lastModifiedMessage={modifiedMessages.at(-1)}
-					isLast={index === groupedMessages.length - 1}
+					isLast={isLast}
 					onHeightChange={handleRowHeightChange}
 					inputValue={inputValue}
 					sendMessageFromChatRow={handleSendMessage}


### PR DESCRIPTION
### Description

We create a checkpoint before the task succeeds, which leads to the failed message to not be considered last and because it failed and we don't have `cost`, a loading state to be shown despite the message not being loading.
This PR checks if the last message is a checkpoint and, if it is, considers the previous message as the last.
<img width="243" alt="image" src="https://github.com/user-attachments/assets/93fff29d-c4cb-4c21-b3d2-06491c89d5b8" />

We should create checkpoints once it succeeds/get rid of them if the task fails, but this is a quick workaround before diving into checkpoint creation.

### Test Procedure

I tested this changes locally. Check the image attached above.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes eternal loading state in `ChatView` when the last message is a checkpoint by adjusting the last message logic.
> 
>   - **Behavior**:
>     - Fixes eternal loading state when the last message is a checkpoint in `ChatView` component.
>     - Checks if the last message is a checkpoint and considers the previous message as the last.
>   - **Code Changes**:
>     - Modifies `isLast` logic in `ChatView.tsx` to handle checkpoint messages.
>     - Adds logic to determine `isLastMessageGroup` based on checkpoint status.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 8669695e6c7e01225e943ebd1bd0346e2cd97279. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->