### PR TITLE
[PROTOBUS] Move resetState to protobus 

### DIFF
--- a/.changeset/olive-bags-pump.md
+++ b/.changeset/olive-bags-pump.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+resetState protobus migration

--- a/proto/state.proto
+++ b/proto/state.proto
@@ -7,6 +7,7 @@ service StateService {
   rpc getLatestState(EmptyRequest) returns (State);
   rpc subscribeToState(EmptyRequest) returns (stream State);
   rpc toggleFavoriteModel(StringRequest) returns (Empty);
+  rpc resetState(EmptyRequest) returns (Empty);
 }
 
 message State {

--- a/src/core/controller/index.ts
+++ b/src/core/controller/index.ts
@@ -319,9 +319,6 @@ export class Controller {
 				await updateGlobalState(this.context, "lastShownAnnouncementId", this.latestAnnouncementId)
 				await this.postStateToWebview()
 				break
-			case "resetState":
-				await this.resetState()
-				break
 			case "refreshClineRules":
 				await refreshClineRulesToggles(this.context, cwd)
 				await refreshExternalRulesToggles(this.context, cwd)
@@ -1587,19 +1584,4 @@ Commit message:`
 	}
 
 	// dev
-
-	async resetState() {
-		vscode.window.showInformationMessage("Resetting state...")
-		await resetExtensionState(this.context)
-		if (this.task) {
-			this.task.abortTask()
-			this.task = undefined
-		}
-		vscode.window.showInformationMessage("State reset")
-		await this.postStateToWebview()
-		await this.postMessageToWebview({
-			type: "action",
-			action: "chatButtonClicked",
-		})
-	}
 }

--- a/src/core/controller/state/methods.ts
+++ b/src/core/controller/state/methods.ts
@@ -4,6 +4,7 @@
 // Import all method implementations
 import { registerMethod } from "./index"
 import { getLatestState } from "./getLatestState"
+import { resetState } from "./resetState"
 import { subscribeToState } from "./subscribeToState"
 import { toggleFavoriteModel } from "./toggleFavoriteModel"
 
@@ -14,6 +15,7 @@ export const streamingMethods = ["subscribeToState"]
 export function registerAllMethods(): void {
 	// Register each method with the registry
 	registerMethod("getLatestState", getLatestState)
+	registerMethod("resetState", resetState)
 	registerMethod("subscribeToState", subscribeToState, { isStreaming: true })
 	registerMethod("toggleFavoriteModel", toggleFavoriteModel)
 }

--- a/src/core/controller/state/resetState.ts
+++ b/src/core/controller/state/resetState.ts
@@ -1,0 +1,36 @@
+import { Controller } from ".."
+import { Empty, EmptyRequest } from "../../../shared/proto/common"
+import { resetExtensionState } from "../../../core/storage/state"
+import * as vscode from "vscode"
+
+/**
+ * Resets the extension state to its defaults
+ * @param controller The controller instance
+ * @param request An empty request (no parameters needed)
+ * @returns An empty response
+ */
+export async function resetState(controller: Controller, request: EmptyRequest): Promise<Empty> {
+	try {
+		vscode.window.showInformationMessage("Resetting state...")
+		await resetExtensionState(controller.context)
+
+		if (controller.task) {
+			controller.task.abortTask()
+			controller.task = undefined
+		}
+
+		vscode.window.showInformationMessage("State reset")
+		await controller.postStateToWebview()
+
+		await controller.postMessageToWebview({
+			type: "action",
+			action: "chatButtonClicked",
+		})
+
+		return Empty.create()
+	} catch (error) {
+		console.error("Error resetting state:", error)
+		vscode.window.showErrorMessage(`Failed to reset state: ${error instanceof Error ? error.message : String(error)}`)
+		throw error
+	}
+}

--- a/src/shared/WebviewMessage.ts
+++ b/src/shared/WebviewMessage.ts
@@ -16,7 +16,6 @@ export interface WebviewMessage {
 		| "reportBug"
 		| "askResponse"
 		| "didShowAnnouncement"
-		| "resetState"
 		| "openInBrowser"
 		| "openMention"
 		| "showChatView"

--- a/src/shared/proto/state.ts
+++ b/src/shared/proto/state.ts
@@ -101,6 +101,14 @@ export const StateServiceDefinition = {
 			responseStream: false,
 			options: {},
 		},
+		resetState: {
+			name: "resetState",
+			requestType: EmptyRequest,
+			requestStream: false,
+			responseType: Empty,
+			responseStream: false,
+			options: {},
+		},
 	},
 } as const
 

--- a/src/standalone/server-setup.ts
+++ b/src/standalone/server-setup.ts
@@ -50,6 +50,7 @@ import { condense } from "../core/controller/slash/condense"
 import { getLatestState } from "../core/controller/state/getLatestState"
 import { subscribeToState } from "../core/controller/state/subscribeToState"
 import { toggleFavoriteModel } from "../core/controller/state/toggleFavoriteModel"
+import { resetState } from "../core/controller/state/resetState"
 
 // Task Service
 import { cancelTask } from "../core/controller/task/cancelTask"
@@ -133,6 +134,7 @@ export function addServices(
 		getLatestState: wrapper(getLatestState, controller),
 		subscribeToState: wrapStreamingResponse(subscribeToState, controller),
 		toggleFavoriteModel: wrapper(toggleFavoriteModel, controller),
+		resetState: wrapper(resetState, controller),
 	})
 
 	// Task Service

--- a/webview-ui/src/components/settings/SettingsView.tsx
+++ b/webview-ui/src/components/settings/SettingsView.tsx
@@ -17,6 +17,7 @@ import ApiOptions from "./ApiOptions"
 import { TabButton } from "../mcp/configuration/McpConfigurationView"
 import { useEvent } from "react-use"
 import { ExtensionMessage } from "@shared/ExtensionMessage"
+import { StateServiceClient } from "@/services/grpc-client"
 import FeatureSettingsSection from "./FeatureSettingsSection"
 import BrowserSettingsSection from "./BrowserSettingsSection"
 import TerminalSettingsSection from "./TerminalSettingsSection"
@@ -148,8 +149,12 @@ const SettingsView = ({ onDone }: SettingsViewProps) => {
 
 	useEvent("message", handleMessage)
 
-	const handleResetState = () => {
-		vscode.postMessage({ type: "resetState" })
+	const handleResetState = async () => {
+		try {
+			await StateServiceClient.resetState({})
+		} catch (error) {
+			console.error("Failed to reset state:", error)
+		}
 	}
 
 	const handleTabChange = (tab: "plan" | "act") => {


### PR DESCRIPTION
### Description

This PR migrates the resetState message to the gRPC/Protobuf system. It converts the legacy VSCode message passing mechanism to a gRPC method in the StateService. The client can now call StateServiceClient.resetState() to pass resetState messages.

### Test Procedure

This message is used by the state reset button, available under settings when running the extension with IS_DEV set to true. **_Testing this will delete all settings, API configurations, the kitchen sink, everything._**

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [x] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Migrates `resetState` functionality to gRPC/Protobuf system, updating client and server-side implementations.
> 
>   - **Behavior**:
>     - Migrates `resetState` to gRPC in `proto/state.proto` by adding `rpc resetState(EmptyRequest) returns (Empty);`.
>     - Removes legacy `resetState` handling from `Controller` in `index.ts`.
>     - Updates `SettingsView.tsx` to use `StateServiceClient.resetState()`.
>   - **Methods**:
>     - Adds `resetState` method in `resetState.ts` to reset extension state and notify webview.
>     - Registers `resetState` in `methods.ts` and `server-setup.ts`.
>   - **Misc**:
>     - Removes `resetState` from `WebviewMessage.ts` type definitions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 09e6e6cf777a103495daae5840a5bc1697a0b64f. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->