### PR TITLE
[PROTOBUS] Move selectImages to protobus

### DIFF
--- a/.changeset/funny-ties-sleep.md
+++ b/.changeset/funny-ties-sleep.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+selectImages protos migration

--- a/proto/file.proto
+++ b/proto/file.proto
@@ -22,6 +22,9 @@ service FileService {
   
   // Search git commits in the workspace
   rpc searchCommits(StringRequest) returns (GitCommits);
+
+  // Select images from the file system and return as data URLs
+  rpc selectImages(EmptyRequest) returns (StringArray);
   
   // Convert URIs to workspace-relative paths
   rpc getRelativePaths(RelativePathsRequest) returns (RelativePaths);

--- a/src/core/controller/file/methods.ts
+++ b/src/core/controller/file/methods.ts
@@ -10,6 +10,7 @@ import { openFile } from "./openFile"
 import { openImage } from "./openImage"
 import { searchCommits } from "./searchCommits"
 import { searchFiles } from "./searchFiles"
+import { selectImages } from "./selectImages"
 
 // Register all file service methods
 export function registerAllMethods(): void {
@@ -21,4 +22,5 @@ export function registerAllMethods(): void {
 	registerMethod("openImage", openImage)
 	registerMethod("searchCommits", searchCommits)
 	registerMethod("searchFiles", searchFiles)
+	registerMethod("selectImages", selectImages)
 }

--- a/src/core/controller/file/selectImages.ts
+++ b/src/core/controller/file/selectImages.ts
@@ -1,0 +1,21 @@
+import { Controller } from ".."
+import { EmptyRequest, StringArray } from "@shared/proto/common"
+import { selectImages as selectImagesIntegration } from "@integrations/misc/process-images"
+import { FileMethodHandler } from "./index"
+
+/**
+ * Prompts the user to select images from the file system and returns them as data URLs
+ * @param controller The controller instance
+ * @param request Empty request, no parameters needed
+ * @returns Array of image data URLs
+ */
+export const selectImages: FileMethodHandler = async (controller: Controller, request: EmptyRequest): Promise<StringArray> => {
+	try {
+		const images = await selectImagesIntegration()
+		return StringArray.create({ values: images })
+	} catch (error) {
+		console.error("Error selecting images:", error)
+		// Return empty array on error
+		return StringArray.create({ values: [] })
+	}
+}

--- a/src/core/controller/index.ts
+++ b/src/core/controller/index.ts
@@ -14,7 +14,6 @@ import { cleanupLegacyCheckpoints } from "@integrations/checkpoints/CheckpointMi
 import { downloadTask } from "@integrations/misc/export-markdown"
 import { fetchOpenGraphData } from "@integrations/misc/link-preview"
 import { handleFileServiceRequest } from "./file"
-import { selectImages } from "@integrations/misc/process-images"
 import { getTheme } from "@integrations/theme/getTheme"
 import WorkspaceTracker from "@integrations/workspace/WorkspaceTracker"
 import { ClineAccountService } from "@services/account/ClineAccountService"
@@ -319,13 +318,6 @@ export class Controller {
 			case "didShowAnnouncement":
 				await updateGlobalState(this.context, "lastShownAnnouncementId", this.latestAnnouncementId)
 				await this.postStateToWebview()
-				break
-			case "selectImages":
-				const images = await selectImages()
-				await this.postMessageToWebview({
-					type: "selectedImages",
-					images,
-				})
 				break
 			case "resetState":
 				await this.resetState()

--- a/src/shared/WebviewMessage.ts
+++ b/src/shared/WebviewMessage.ts
@@ -16,7 +16,6 @@ export interface WebviewMessage {
 		| "reportBug"
 		| "askResponse"
 		| "didShowAnnouncement"
-		| "selectImages"
 		| "resetState"
 		| "openInBrowser"
 		| "openMention"

--- a/src/shared/proto/file.ts
+++ b/src/shared/proto/file.ts
@@ -6,7 +6,7 @@
 
 /* eslint-disable */
 import { BinaryReader, BinaryWriter } from "@bufbuild/protobuf/wire"
-import { Empty, Metadata, StringRequest } from "./common"
+import { Empty, EmptyRequest, Metadata, StringArray, StringRequest } from "./common"
 
 export const protobufPackage = "cline"
 
@@ -894,6 +894,15 @@ export const FileServiceDefinition = {
 			requestType: StringRequest,
 			requestStream: false,
 			responseType: Empty,
+			responseStream: false,
+			options: {},
+		},
+		/** Select images from the file system and return as data URLs */
+		selectImages: {
+			name: "selectImages",
+			requestType: EmptyRequest,
+			requestStream: false,
+			responseType: StringArray,
 			responseStream: false,
 			options: {},
 		},

--- a/src/standalone/server-setup.ts
+++ b/src/standalone/server-setup.ts
@@ -20,6 +20,7 @@ import { checkpointRestore } from "../core/controller/checkpoints/checkpointRest
 
 // File Service
 import { openFile } from "../core/controller/file/openFile"
+import { selectImages } from "../core/controller/file/selectImages"
 import { openImage } from "../core/controller/file/openImage"
 import { deleteRuleFile } from "../core/controller/file/deleteRuleFile"
 import { createRuleFile } from "../core/controller/file/createRuleFile"
@@ -94,6 +95,7 @@ export function addServices(
 	// File Service
 	server.addService(proto.cline.FileService.service, {
 		openFile: wrapper(openFile, controller),
+		selectImages: wrapper(selectImages, controller),
 		openImage: wrapper(openImage, controller),
 		deleteRuleFile: wrapper(deleteRuleFile, controller),
 		createRuleFile: wrapper(createRuleFile, controller),


### PR DESCRIPTION
### Description

This PR migrates the selectImages message to the gRPC/Protobuf system. It converts the legacy VSCode message passing mechanism to a gRPC method in the FileService. The client can now call FileServiceClient.selectImages() to pass selectImages messages.

### Test Procedure

This message is used when submitting multiple images to Cline. To do this, click the camera icon below the text input field in the task view. Select multiple images, and confirm this selection. The images should be added to the chat, and an array of these images should be recorded by the GRPC logging.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [x] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Migrates `selectImages` functionality to gRPC/Protobuf system, adding a new method to `FileService` and updating client-side usage.
> 
>   - **Behavior**:
>     - Migrates `selectImages` functionality to gRPC/Protobuf system.
>     - Adds `selectImages` method to `FileService` in `proto/file.proto`.
>     - Updates `ChatView.tsx` to use `FileServiceClient.selectImages()`.
>   - **Controller**:
>     - Implements `selectImages` in `selectImages.ts` to return image data URLs.
>     - Registers `selectImages` method in `methods.ts` and `server-setup.ts`.
>   - **Legacy Removal**:
>     - Removes `selectImages` handling from `Controller` class in `index.ts`.
>     - Deletes `selectImages` from `WebviewMessage` type in `WebviewMessage.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 8b93038e54e0ea21db1cfff7acd7c9f8fb6b083f. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->