### PR TITLE
[PROTOBUS] Move taskCompletionViewChanges to protobus

### DIFF
--- a/.changeset/little-gifts-invite.md
+++ b/.changeset/little-gifts-invite.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+taskCompletionViewChanges protobus migration

--- a/proto/task.proto
+++ b/proto/task.proto
@@ -29,6 +29,8 @@ service TaskService {
   rpc askResponse(AskResponseRequest) returns (Empty);
   // Records task feedback (thumbs up/down)
   rpc taskFeedback(StringRequest) returns (Empty);
+  // Shows task completion changes diff in a view
+  rpc taskCompletionViewChanges(Int64Request) returns (Empty);
 }
 
 // Request message for creating a new task

--- a/src/core/controller/index.ts
+++ b/src/core/controller/index.ts
@@ -341,12 +341,6 @@ export class Controller {
 			case "openMention":
 				openMention(message.text)
 				break
-			case "taskCompletionViewChanges": {
-				if (message.number) {
-					await this.task?.presentMultifileDiff(message.number, true)
-				}
-				break
-			}
 			case "accountLogoutClicked": {
 				await this.handleSignOut()
 				break

--- a/src/core/controller/task/methods.ts
+++ b/src/core/controller/task/methods.ts
@@ -12,6 +12,7 @@ import { exportTaskWithId } from "./exportTaskWithId"
 import { getTaskHistory } from "./getTaskHistory"
 import { newTask } from "./newTask"
 import { showTaskWithId } from "./showTaskWithId"
+import { taskCompletionViewChanges } from "./taskCompletionViewChanges"
 import { taskFeedback } from "./taskFeedback"
 import { toggleTaskFavorite } from "./toggleTaskFavorite"
 
@@ -27,6 +28,7 @@ export function registerAllMethods(): void {
 	registerMethod("getTaskHistory", getTaskHistory)
 	registerMethod("newTask", newTask)
 	registerMethod("showTaskWithId", showTaskWithId)
+	registerMethod("taskCompletionViewChanges", taskCompletionViewChanges)
 	registerMethod("taskFeedback", taskFeedback)
 	registerMethod("toggleTaskFavorite", toggleTaskFavorite)
 }

--- a/src/core/controller/task/taskCompletionViewChanges.ts
+++ b/src/core/controller/task/taskCompletionViewChanges.ts
@@ -1,0 +1,21 @@
+import { Controller } from ".."
+import { Empty } from "../../../shared/proto/common"
+import { Int64Request } from "../../../shared/proto/common"
+
+/**
+ * Shows task completion changes in a diff view
+ * @param controller The controller instance
+ * @param request The request containing the timestamp of the message
+ * @returns Empty response
+ */
+export async function taskCompletionViewChanges(controller: Controller, request: Int64Request): Promise<Empty> {
+	try {
+		if (request.value && controller.task) {
+			await controller.task.presentMultifileDiff(request.value, true)
+		}
+		return Empty.create()
+	} catch (error) {
+		console.error("Error in taskCompletionViewChanges handler:", error)
+		throw error
+	}
+}

--- a/src/shared/WebviewMessage.ts
+++ b/src/shared/WebviewMessage.ts
@@ -25,7 +25,6 @@ export interface WebviewMessage {
 		| "autoApprovalSettings"
 		| "browserRelaunchResult"
 		| "togglePlanActMode"
-		| "taskCompletionViewChanges"
 		| "openExtensionSettings"
 		| "requestVsCodeLmModels"
 		| "toggleToolAutoApprove"

--- a/src/shared/proto/task.ts
+++ b/src/shared/proto/task.ts
@@ -6,7 +6,7 @@
 
 /* eslint-disable */
 import { BinaryReader, BinaryWriter } from "@bufbuild/protobuf/wire"
-import { Empty, EmptyRequest, Metadata, StringArrayRequest, StringRequest } from "./common"
+import { Empty, EmptyRequest, Int64Request, Metadata, StringArrayRequest, StringRequest } from "./common"
 
 export const protobufPackage = "cline"
 
@@ -1182,6 +1182,15 @@ export const TaskServiceDefinition = {
 		taskFeedback: {
 			name: "taskFeedback",
 			requestType: StringRequest,
+			requestStream: false,
+			responseType: Empty,
+			responseStream: false,
+			options: {},
+		},
+		/** Shows task completion changes diff in a view */
+		taskCompletionViewChanges: {
+			name: "taskCompletionViewChanges",
+			requestType: Int64Request,
 			requestStream: false,
 			responseType: Empty,
 			responseStream: false,

--- a/src/standalone/server-setup.ts
+++ b/src/standalone/server-setup.ts
@@ -64,6 +64,7 @@ import { deleteNonFavoritedTasks } from "../core/controller/task/deleteNonFavori
 import { getTaskHistory } from "../core/controller/task/getTaskHistory"
 import { askResponse } from "../core/controller/task/askResponse"
 import { taskFeedback } from "../core/controller/task/taskFeedback"
+import { taskCompletionViewChanges } from "../core/controller/task/taskCompletionViewChanges"
 
 // Web Service
 import { checkIsImageUrl } from "../core/controller/web/checkIsImageUrl"
@@ -153,6 +154,7 @@ export function addServices(
 		getTaskHistory: wrapper(getTaskHistory, controller),
 		askResponse: wrapper(askResponse, controller),
 		taskFeedback: wrapper(taskFeedback, controller),
+		taskCompletionViewChanges: wrapper(taskCompletionViewChanges, controller),
 	})
 
 	// Web Service

--- a/webview-ui/src/components/chat/ChatRow.tsx
+++ b/webview-ui/src/components/chat/ChatRow.tsx
@@ -18,7 +18,7 @@ import { COMMAND_OUTPUT_STRING, COMMAND_REQ_APP_STRING } from "@shared/combineCo
 import { useExtensionState } from "@/context/ExtensionStateContext"
 import { findMatchingResourceOrTemplate, getMcpServerDisplayName } from "@/utils/mcp"
 import { vscode } from "@/utils/vscode"
-import { FileServiceClient } from "@/services/grpc-client"
+import { FileServiceClient, TaskServiceClient } from "@/services/grpc-client"
 import { CheckmarkControl } from "@/components/common/CheckmarkControl"
 
 interface CopyButtonProps {
@@ -1226,10 +1226,9 @@ export const ChatRowContent = ({
 										disabled={seeNewChangesDisabled}
 										onClick={() => {
 											setSeeNewChangesDisabled(true)
-											vscode.postMessage({
-												type: "taskCompletionViewChanges",
-												number: message.ts,
-											})
+											TaskServiceClient.taskCompletionViewChanges({
+												value: message.ts,
+											}).catch((err) => console.error("Failed to show task completion view changes:", err))
 										}}
 										style={{
 											cursor: seeNewChangesDisabled ? "wait" : "pointer",
@@ -1390,10 +1389,11 @@ export const ChatRowContent = ({
 											disabled={seeNewChangesDisabled}
 											onClick={() => {
 												setSeeNewChangesDisabled(true)
-												vscode.postMessage({
-													type: "taskCompletionViewChanges",
-													number: message.ts,
-												})
+												TaskServiceClient.taskCompletionViewChanges({
+													value: message.ts,
+												}).catch((err) =>
+													console.error("Failed to show task completion view changes:", err),
+												)
 											}}>
 											<i
 												className="codicon codicon-new-file"


### PR DESCRIPTION
### Description

This PR migrates the taskCompletionViewChanges message to the gRPC/Protobuf system. It converts the legacy VSCode message passing mechanism to a gRPC method in the TaskService. The client can now call TaskServiceClient.taskCompletionViewChanges() to pass taskCompletionViewChanges messages.

### Test Procedure

The taskCompletionViewChanges message is used when a task is completed, and users click the "See New Changes" button to review a diff of changes that Cline has made.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [x] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Migrates `taskCompletionViewChanges` to gRPC/Protobuf, updating related files and removing legacy message handling.
> 
>   - **Behavior**:
>     - Migrates `taskCompletionViewChanges` to gRPC in `task.proto` and `server-setup.ts`.
>     - Removes legacy message handling for `taskCompletionViewChanges` in `index.ts` and `WebviewMessage.ts`.
>     - Updates `ChatRow.tsx` to use `TaskServiceClient.taskCompletionViewChanges()`.
>   - **Methods**:
>     - Adds `taskCompletionViewChanges` method in `taskCompletionViewChanges.ts`.
>     - Registers `taskCompletionViewChanges` in `methods.ts`.
>   - **Proto Definitions**:
>     - Adds `taskCompletionViewChanges` RPC definition in `task.proto` and `task.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 5874b7a9e32bd9d0b1ed48cfd328cf6665f77558. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->