### PR TITLE
Improve Gemini Retry Handling UI and UX

### DIFF
--- a/.changeset/hip-actors-do.md
+++ b/.changeset/hip-actors-do.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Changing UX and UI for gemini models attempts

--- a/src/api/providers/gemini.ts
+++ b/src/api/providers/gemini.ts
@@ -79,19 +79,6 @@ export class GeminiHandler implements ApiHandler {
 		maxDelay: 15000,
 	})
 	async *createMessage(systemPrompt: string, messages: Anthropic.Messages.MessageParam[]): ApiStream {
-		// --- Cline: Modified for testing 429 error (50% chance) ---
-		const shouldThrowFakeError = Math.random() < 1
-		if (shouldThrowFakeError && systemPrompt.length > 100) {
-			// systemPrompt.length > 100 was auto-added, can be removed if not the desired condition
-			const fakeError: any = new Error("Fake 429 Too Many Requests for testing (50% chance).")
-			fakeError.status = 429
-			fakeError.name = "ClientError" // Mimicking Gemini's error structure
-			// fakeError.headers = { "retry-after": "5" }; // Optional: to test retry-after header
-			console.warn("GEMINI_HANDLER: INTENTIONALLY THROWING FAKE 429 ERROR FOR TESTING (50% chance)")
-			throw fakeError
-		}
-		// --- End Cline: Modified for testing 429 error ---
-
 		const { id: modelId, info } = this.getModel()
 		const contents = messages.map(convertAnthropicMessageToGemini)
 

--- a/src/api/providers/gemini.ts
+++ b/src/api/providers/gemini.ts
@@ -73,8 +73,25 @@ export class GeminiHandler implements ApiHandler {
 	 * @param messages The conversation history to include in the message
 	 * @returns An async generator that yields chunks of the response with accurate immediate costs
 	 */
-	@withRetry()
+	@withRetry({
+		maxRetries: 4,
+		baseDelay: 2000,
+		maxDelay: 15000,
+	})
 	async *createMessage(systemPrompt: string, messages: Anthropic.Messages.MessageParam[]): ApiStream {
+		// --- Cline: Modified for testing 429 error (50% chance) ---
+		const shouldThrowFakeError = Math.random() < 1
+		if (shouldThrowFakeError && systemPrompt.length > 100) {
+			// systemPrompt.length > 100 was auto-added, can be removed if not the desired condition
+			const fakeError: any = new Error("Fake 429 Too Many Requests for testing (50% chance).")
+			fakeError.status = 429
+			fakeError.name = "ClientError" // Mimicking Gemini's error structure
+			// fakeError.headers = { "retry-after": "5" }; // Optional: to test retry-after header
+			console.warn("GEMINI_HANDLER: INTENTIONALLY THROWING FAKE 429 ERROR FOR TESTING (50% chance)")
+			throw fakeError
+		}
+		// --- End Cline: Modified for testing 429 error ---
+
 		const { id: modelId, info } = this.getModel()
 		const contents = messages.map(convertAnthropicMessageToGemini)
 

--- a/src/api/retry.ts
+++ b/src/api/retry.ts
@@ -54,6 +54,15 @@ export function withRetry(options: RetryOptions = {}) {
 						delay = Math.min(maxDelay, baseDelay * Math.pow(2, attempt))
 					}
 
+					const handlerInstance = this as any
+					if (handlerInstance.options?.onRetryAttempt) {
+						try {
+							handlerInstance.options.onRetryAttempt(attempt + 1, maxRetries, delay, error)
+						} catch (e) {
+							console.error("Error in onRetryAttempt callback:", e)
+						}
+					}
+
 					await new Promise((resolve) => setTimeout(resolve, delay))
 				}
 			}

--- a/src/core/task/index.ts
+++ b/src/core/task/index.ts
@@ -232,6 +232,37 @@ export class Task {
 		let effectiveApiConfiguration: ApiConfiguration = {
 			...apiConfiguration,
 			taskId: this.taskId,
+			onRetryAttempt: (attempt: number, maxRetries: number, delay: number, error: any) => {
+				const lastApiReqStartedIndex = findLastIndex(this.clineMessages, (m) => m.say === "api_req_started")
+				if (lastApiReqStartedIndex !== -1) {
+					try {
+						const currentApiReqInfo: ClineApiReqInfo = JSON.parse(
+							this.clineMessages[lastApiReqStartedIndex].text || "{}",
+						)
+						currentApiReqInfo.retryStatus = {
+							attempt: attempt, // attempt is already 1-indexed from retry.ts
+							maxAttempts: maxRetries, // total attempts
+							delaySec: Math.round(delay / 1000),
+							errorSnippet: error?.message ? `${String(error.message).substring(0, 50)}...` : undefined,
+						}
+						// Clear previous cancelReason and streamingFailedMessage if we are retrying
+						delete currentApiReqInfo.cancelReason
+						delete currentApiReqInfo.streamingFailedMessage
+						this.clineMessages[lastApiReqStartedIndex].text = JSON.stringify(currentApiReqInfo)
+
+						// Post the updated state to the webview so the UI reflects the retry attempt
+						this.postStateToWebview().catch((e) =>
+							console.error("Error posting state to webview in onRetryAttempt:", e),
+						)
+
+						console.log(
+							`[Task ${this.taskId}] API Auto-Retry Status Update: Attempt ${attempt}/${maxRetries}, Delay: ${delay}ms`,
+						)
+					} catch (e) {
+						console.error("[Task ${this.taskId}] Error updating api_req_started with retryStatus:", e)
+					}
+				}
+			},
 		}
 
 		if (apiConfiguration.apiProvider === "openai" || apiConfiguration.apiProvider === "openai-native") {
@@ -1655,6 +1686,20 @@ export class Task {
 				}
 
 				const errorMessage = this.formatErrorWithStatusCode(error)
+
+				// Update the 'api_req_started' message to reflect final failure before asking user to manually retry
+				const lastApiReqStartedIndex = findLastIndex(this.clineMessages, (m) => m.say === "api_req_started")
+				if (lastApiReqStartedIndex !== -1) {
+					const currentApiReqInfo: ClineApiReqInfo = JSON.parse(this.clineMessages[lastApiReqStartedIndex].text || "{}")
+					delete currentApiReqInfo.retryStatus
+
+					this.clineMessages[lastApiReqStartedIndex].text = JSON.stringify({
+						...currentApiReqInfo, // Spread the modified info (with retryStatus removed)
+						cancelReason: "retries_exhausted", // Indicate that automatic retries failed
+						streamingFailedMessage: errorMessage,
+					} satisfies ClineApiReqInfo)
+					// this.ask will trigger postStateToWebview, so this change should be picked up.
+				}
 
 				const { response } = await this.ask("api_req_failed", errorMessage)
 
@@ -3799,8 +3844,11 @@ export class Task {
 			// fortunately api_req_finished was always parsed out for the gui anyways, so it remains solely for legacy purposes to keep track of prices in tasks from history
 			// (it's worth removing a few months from now)
 			const updateApiReqMsg = (cancelReason?: ClineApiReqCancelReason, streamingFailedMessage?: string) => {
+				const currentApiReqInfo: ClineApiReqInfo = JSON.parse(this.clineMessages[lastApiReqIndex].text || "{}")
+				delete currentApiReqInfo.retryStatus // Clear retry status when request is finalized
+
 				this.clineMessages[lastApiReqIndex].text = JSON.stringify({
-					...JSON.parse(this.clineMessages[lastApiReqIndex].text || "{}"),
+					...currentApiReqInfo, // Spread the modified info (with retryStatus removed)
 					tokensIn: inputTokens,
 					tokensOut: outputTokens,
 					cacheWrites: cacheWriteTokens,

--- a/src/core/task/index.ts
+++ b/src/core/task/index.ts
@@ -259,7 +259,7 @@ export class Task {
 							`[Task ${this.taskId}] API Auto-Retry Status Update: Attempt ${attempt}/${maxRetries}, Delay: ${delay}ms`,
 						)
 					} catch (e) {
-						console.error("[Task ${this.taskId}] Error updating api_req_started with retryStatus:", e)
+						console.error(`[Task ${this.taskId}] Error updating api_req_started with retryStatus:`, e)
 					}
 				}
 			},

--- a/src/shared/ExtensionMessage.ts
+++ b/src/shared/ExtensionMessage.ts
@@ -208,6 +208,7 @@ export type ClineSay =
 	| "clineignore_error"
 	| "checkpoint_created"
 	| "load_mcp_documentation"
+	| "info" // Added for general informational messages like retry status
 
 export interface ClineSayTool {
 	tool:
@@ -276,8 +277,14 @@ export interface ClineApiReqInfo {
 	cost?: number
 	cancelReason?: ClineApiReqCancelReason
 	streamingFailedMessage?: string
+	retryStatus?: {
+		attempt: number
+		maxAttempts: number
+		delaySec: number
+		errorSnippet?: string
+	}
 }
 
-export type ClineApiReqCancelReason = "streaming_failed" | "user_cancelled"
+export type ClineApiReqCancelReason = "streaming_failed" | "user_cancelled" | "retries_exhausted"
 
 export const COMPLETION_RESULT_CHANGES_FLAG = "HAS_CHANGES"

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -88,6 +88,7 @@ export interface ApiHandlerOptions {
 	reasoningEffort?: string
 	sambanovaApiKey?: string
 	requestTimeoutMs?: number
+	onRetryAttempt?: (attempt: number, maxRetries: number, delay: number, error: any) => void
 }
 
 export type ApiConfiguration = ApiHandlerOptions & {

--- a/src/shared/proto/file.ts
+++ b/src/shared/proto/file.ts
@@ -915,15 +915,6 @@ export const FileServiceDefinition = {
 			responseStream: false,
 			options: {},
 		},
-		/** Select images from the file system and return as data URLs */
-		selectImages: {
-			name: "selectImages",
-			requestType: EmptyRequest,
-			requestStream: false,
-			responseType: StringArray,
-			responseStream: false,
-			options: {},
-		},
 		/** Opens an image in the system viewer */
 		openImage: {
 			name: "openImage",
@@ -957,6 +948,15 @@ export const FileServiceDefinition = {
 			requestType: StringRequest,
 			requestStream: false,
 			responseType: GitCommits,
+			responseStream: false,
+			options: {},
+		},
+		/** Select images from the file system and return as data URLs */
+		selectImages: {
+			name: "selectImages",
+			requestType: EmptyRequest,
+			requestStream: false,
+			responseType: StringArray,
 			responseStream: false,
 			options: {},
 		},

--- a/src/standalone/server-setup.ts
+++ b/src/standalone/server-setup.ts
@@ -20,11 +20,11 @@ import { checkpointRestore } from "../core/controller/checkpoints/checkpointRest
 
 // File Service
 import { openFile } from "../core/controller/file/openFile"
-import { selectImages } from "../core/controller/file/selectImages"
 import { openImage } from "../core/controller/file/openImage"
 import { deleteRuleFile } from "../core/controller/file/deleteRuleFile"
 import { createRuleFile } from "../core/controller/file/createRuleFile"
 import { searchCommits } from "../core/controller/file/searchCommits"
+import { selectImages } from "../core/controller/file/selectImages"
 import { getRelativePaths } from "../core/controller/file/getRelativePaths"
 import { searchFiles } from "../core/controller/file/searchFiles"
 
@@ -96,11 +96,11 @@ export function addServices(
 	// File Service
 	server.addService(proto.cline.FileService.service, {
 		openFile: wrapper(openFile, controller),
-		selectImages: wrapper(selectImages, controller),
 		openImage: wrapper(openImage, controller),
 		deleteRuleFile: wrapper(deleteRuleFile, controller),
 		createRuleFile: wrapper(createRuleFile, controller),
 		searchCommits: wrapper(searchCommits, controller),
+		selectImages: wrapper(selectImages, controller),
 		getRelativePaths: wrapper(getRelativePaths, controller),
 		searchFiles: wrapper(searchFiles, controller),
 	})

--- a/webview-ui/src/components/chat/ChatRow.tsx
+++ b/webview-ui/src/components/chat/ChatRow.tsx
@@ -208,12 +208,12 @@ export const ChatRowContent = ({
 		selectedText: "",
 	})
 	const contentRef = useRef<HTMLDivElement>(null)
-	const [cost, apiReqCancelReason, apiReqStreamingFailedMessage] = useMemo(() => {
+	const [cost, apiReqCancelReason, apiReqStreamingFailedMessage, retryStatus] = useMemo(() => {
 		if (message.text != null && message.say === "api_req_started") {
 			const info: ClineApiReqInfo = JSON.parse(message.text)
-			return [info.cost, info.cancelReason, info.streamingFailedMessage]
+			return [info.cost, info.cancelReason, info.streamingFailedMessage, info.retryStatus]
 		}
-		return [undefined, undefined, undefined]
+		return [undefined, undefined, undefined, undefined]
 	}, [message.text, message.say])
 
 	// when resuming task last won't be api_req_failed but a resume_task message so api_req_started will show loading spinner. that's why we just remove the last api_req_started that failed without streaming anything
@@ -444,6 +444,17 @@ export const ChatRowContent = ({
 
 						if (apiRequestFailedMessage) {
 							return <span style={{ color: errorColor, fontWeight: "bold" }}>API Request Failed</span>
+						}
+						// New: Check for retryStatus to modify the title
+						if (retryStatus && cost == null && !apiReqCancelReason) {
+							const retryOperations = retryStatus.maxAttempts > 0 ? retryStatus.maxAttempts - 1 : 0
+							return (
+								<span
+									style={{
+										color: normalColor,
+										fontWeight: "bold",
+									}}>{`API Request (Retrying failed attempt ${retryStatus.attempt}/${retryOperations})...`}</span>
+							)
 						}
 
 						return <span style={{ color: normalColor, fontWeight: "bold" }}>API Request...</span>


### PR DESCRIPTION
### Description
This PR enhances the user experience during API request retries by providing clearer, more integrated feedback in the UI.

Previously, when an API request encountered a retriable error (e.g., rate limiting), the retry attempts were silent until a final failure or success. This change introduces two main improvements:
1.  **Inline Retry Status:** During automatic retries, the "API Request..." title in the chat UI now dynamically updates to show the retry progress (e.g., "API Request (Retrying failed attempt 1/2)..."). This provides immediate visibility into the retry process.
2.  **Correct Final State Update:** Ensures that if all automatic retries are exhausted, the "API Request..." row correctly transitions to a final failed state (e.g., "API Streaming Failed") *before* the user is prompted with manual retry options. This addresses a previous issue where a loading spinner might persist incorrectly.

These changes are achieved by:
*   Introducing an `onRetryAttempt` callback in the API handling options.
*   Modifying the generic `withRetry` decorator to invoke this callback.
*   Implementing the callback in `Task.ts` to update a new `retryStatus` field within the "api\_req\_started" `ClineMessage`.
*   Updating the frontend component `ChatRow.tsx` to parse and display this `retryStatus` directly in the API request title.
*   Ensuring `retryStatus` is cleared when the API request is definitively finalized.
*   A fake 429 error in `GeminiHandler` was also modified to trigger with a 50% chance for easier testing of this feature.

### Test Procedure

You can use branch [arafatkatze/gemini-retry-ui-fake](https://github.com/cline/cline/tree/arafatkatze/gemini-retry-ui-fake)  for making fake errors
1.  **Trigger Fake 429 Error:** Use an API provider configured to use the `GeminiHandler` (or modify an existing one temporarily). Ensure the `systemPrompt.length > 100` condition (or remove it) in `GeminiHandler`'s `createMessage` method is met to trigger the fake 429 error (which has a 50% chance). The `GeminiHandler` is also configured with `maxRetries: 4` (meaning 1 initial attempt + 3 retries).
2.  **Observe UI During Retries:**
    *   When the fake 429 error occurs, the "API Request..." title in the chat UI should change to "API Request (Retrying failed attempt 1/3)...".
    *   It should then update to "API Request (Retrying failed attempt 2/3)..." and "API Request (Retrying failed attempt 3/3)..." after respective delays.
    *   The progress ring (spinner) should remain active next to this title.
3.  **Observe UI on Final Failure:**
    *   After the third retry attempt fails, the title should change to "API Streaming Failed" (or similar, with an error icon), and the specific error message ("Fake 429 Too Many Requests for testing (50% chance).") should be displayed below it (when the row is expanded). The spinner should disappear.
    *   Only *after* this title change should the manual "Retry" / "Start New Task" buttons appear at the bottom of the chat.
4.  **Test Normal Request:** Ensure that for successful API requests (when the 50% chance for the fake error doesn't trigger), the "API Request..." title behaves normally (shows spinner, then updates to "API Request" with cost upon success) without any retry messages.
5.  **Test Other API Handlers:** Briefly test with another API handler (e.g., Anthropic) to ensure the `onRetryAttempt` callback mechanism (which is now part of the generic `withRetry`) doesn't negatively impact handlers that don't define this callback. They should continue to retry silently as before.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [X] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [X] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [X] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [X] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [X] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

## Attempt 1
<img width="501" alt="image" src="https://github.com/user-attachments/assets/1809fcb4-2257-4965-ba87-321418939136" />

## Attempt 3
<img width="428" alt="image" src="https://github.com/user-attachments/assets/049e2c7b-9cf3-4834-90b7-babebfbfd3bf" />


### Failure
<img width="445" alt="image" src="https://github.com/user-attachments/assets/9ed52cdb-eb55-45d9-b3af-641c66c379cd" />

<!-- For UI changes, add screenshots here -->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Enhances retry handling in the UI by adding retry status updates and improving feedback during API request retries.
> 
>   - **Behavior**:
>     - Adds `onRetryAttempt` callback in `Task.ts` to update `retryStatus` in `ClineMessage`.
>     - Updates `withRetry` decorator in `retry.ts` to invoke `onRetryAttempt`.
>     - Modifies `ChatRow.tsx` to display retry status in the UI.
>     - Ensures `retryStatus` is cleared when API request is finalized.
>     - Adjusts fake 429 error in `GeminiHandler` for testing.
>   - **UI**:
>     - `ChatRow.tsx` now shows retry progress in the API request title.
>     - Displays "API Streaming Failed" before manual retry options if retries are exhausted.
>   - **Testing**:
>     - Test procedure includes triggering fake 429 error and observing UI changes during retries and final failure.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 1abcd5d460c54a776ecf0bc8e2cbae7701549061. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->