### PR TITLE
[PROTOBUS] Move taskFeedback to protobus

### DIFF
--- a/.changeset/eighty-pumas-fly.md
+++ b/.changeset/eighty-pumas-fly.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+taskFeedback protobus migration

--- a/proto/task.proto
+++ b/proto/task.proto
@@ -27,6 +27,8 @@ service TaskService {
   rpc getTaskHistory(GetTaskHistoryRequest) returns (TaskHistoryArray);
   // Sends a response to a previous ask operation
   rpc askResponse(AskResponseRequest) returns (Empty);
+  // Records task feedback (thumbs up/down)
+  rpc taskFeedback(StringRequest) returns (Empty);
 }
 
 // Request message for creating a new task

--- a/src/core/controller/index.ts
+++ b/src/core/controller/index.ts
@@ -380,11 +380,6 @@ export class Controller {
 				await this.silentlyRefreshMcpMarketplace()
 				break
 			}
-			case "taskFeedback":
-				if (message.feedbackType && this.task?.taskId) {
-					telemetryService.captureTaskFeedback(this.task.taskId, message.feedbackType)
-				}
-				break
 			// case "openMcpMarketplaceServerDetails": {
 			// 	if (message.text) {
 			// 		const response = await fetch(`https://api.cline.bot/v1/mcp/marketplace/item?mcpId=${message.mcpId}`)

--- a/src/core/controller/task/methods.ts
+++ b/src/core/controller/task/methods.ts
@@ -12,6 +12,7 @@ import { exportTaskWithId } from "./exportTaskWithId"
 import { getTaskHistory } from "./getTaskHistory"
 import { newTask } from "./newTask"
 import { showTaskWithId } from "./showTaskWithId"
+import { taskFeedback } from "./taskFeedback"
 import { toggleTaskFavorite } from "./toggleTaskFavorite"
 
 // Register all task service methods
@@ -26,5 +27,6 @@ export function registerAllMethods(): void {
 	registerMethod("getTaskHistory", getTaskHistory)
 	registerMethod("newTask", newTask)
 	registerMethod("showTaskWithId", showTaskWithId)
+	registerMethod("taskFeedback", taskFeedback)
 	registerMethod("toggleTaskFavorite", toggleTaskFavorite)
 }

--- a/src/core/controller/task/taskFeedback.ts
+++ b/src/core/controller/task/taskFeedback.ts
@@ -1,0 +1,28 @@
+import { Controller } from ".."
+import { Empty, StringRequest } from "../../../shared/proto/common"
+import { telemetryService } from "@/services/posthog/telemetry/TelemetryService"
+
+/**
+ * Handles task feedback submission (thumbs up/down)
+ * @param controller The controller instance
+ * @param request The StringRequest containing the feedback type ("thumbs_up" or "thumbs_down") in the value field
+ * @returns Empty response
+ */
+export async function taskFeedback(controller: Controller, request: StringRequest): Promise<Empty> {
+	if (!request.value) {
+		console.warn("taskFeedback: Missing feedback type value")
+		return Empty.create()
+	}
+
+	try {
+		if (controller.task?.taskId) {
+			telemetryService.captureTaskFeedback(controller.task.taskId, request.value as any)
+		} else {
+			console.warn("taskFeedback: No active task to receive feedback")
+		}
+	} catch (error) {
+		console.error("Error in taskFeedback handler:", error)
+	}
+
+	return Empty.create()
+}

--- a/src/shared/WebviewMessage.ts
+++ b/src/shared/WebviewMessage.ts
@@ -48,7 +48,6 @@ export interface WebviewMessage {
 		| "optionsResponse"
 		| "requestTotalTasksSize"
 		| "relaunchChromeDebugMode"
-		| "taskFeedback"
 		| "scrollToSettings"
 		| "searchFiles"
 		| "grpc_request"
@@ -92,8 +91,6 @@ export interface WebviewMessage {
 	mcpMarketplaceEnabled?: boolean
 	telemetrySetting?: TelemetrySetting
 	customInstructionsSetting?: string
-	// For task feedback
-	feedbackType?: TaskFeedbackType
 	mentionsRequestId?: string
 	query?: string
 	// For toggleFavoriteModel

--- a/src/shared/proto/file.ts
+++ b/src/shared/proto/file.ts
@@ -915,15 +915,6 @@ export const FileServiceDefinition = {
 			responseStream: false,
 			options: {},
 		},
-		/** Select images from the file system and return as data URLs */
-		selectImages: {
-			name: "selectImages",
-			requestType: EmptyRequest,
-			requestStream: false,
-			responseType: StringArray,
-			responseStream: false,
-			options: {},
-		},
 		/** Opens an image in the system viewer */
 		openImage: {
 			name: "openImage",
@@ -957,6 +948,15 @@ export const FileServiceDefinition = {
 			requestType: StringRequest,
 			requestStream: false,
 			responseType: GitCommits,
+			responseStream: false,
+			options: {},
+		},
+		/** Select images from the file system and return as data URLs */
+		selectImages: {
+			name: "selectImages",
+			requestType: EmptyRequest,
+			requestStream: false,
+			responseType: StringArray,
 			responseStream: false,
 			options: {},
 		},

--- a/src/shared/proto/task.ts
+++ b/src/shared/proto/task.ts
@@ -1178,6 +1178,15 @@ export const TaskServiceDefinition = {
 			responseStream: false,
 			options: {},
 		},
+		/** Records task feedback (thumbs up/down) */
+		taskFeedback: {
+			name: "taskFeedback",
+			requestType: StringRequest,
+			requestStream: false,
+			responseType: Empty,
+			responseStream: false,
+			options: {},
+		},
 	},
 } as const
 

--- a/src/standalone/server-setup.ts
+++ b/src/standalone/server-setup.ts
@@ -20,11 +20,11 @@ import { checkpointRestore } from "../core/controller/checkpoints/checkpointRest
 
 // File Service
 import { openFile } from "../core/controller/file/openFile"
-import { selectImages } from "../core/controller/file/selectImages"
 import { openImage } from "../core/controller/file/openImage"
 import { deleteRuleFile } from "../core/controller/file/deleteRuleFile"
 import { createRuleFile } from "../core/controller/file/createRuleFile"
 import { searchCommits } from "../core/controller/file/searchCommits"
+import { selectImages } from "../core/controller/file/selectImages"
 import { getRelativePaths } from "../core/controller/file/getRelativePaths"
 import { searchFiles } from "../core/controller/file/searchFiles"
 
@@ -62,6 +62,7 @@ import { toggleTaskFavorite } from "../core/controller/task/toggleTaskFavorite"
 import { deleteNonFavoritedTasks } from "../core/controller/task/deleteNonFavoritedTasks"
 import { getTaskHistory } from "../core/controller/task/getTaskHistory"
 import { askResponse } from "../core/controller/task/askResponse"
+import { taskFeedback } from "../core/controller/task/taskFeedback"
 
 // Web Service
 import { checkIsImageUrl } from "../core/controller/web/checkIsImageUrl"
@@ -96,11 +97,11 @@ export function addServices(
 	// File Service
 	server.addService(proto.cline.FileService.service, {
 		openFile: wrapper(openFile, controller),
-		selectImages: wrapper(selectImages, controller),
 		openImage: wrapper(openImage, controller),
 		deleteRuleFile: wrapper(deleteRuleFile, controller),
 		createRuleFile: wrapper(createRuleFile, controller),
 		searchCommits: wrapper(searchCommits, controller),
+		selectImages: wrapper(selectImages, controller),
 		getRelativePaths: wrapper(getRelativePaths, controller),
 		searchFiles: wrapper(searchFiles, controller),
 	})
@@ -148,6 +149,7 @@ export function addServices(
 		deleteNonFavoritedTasks: wrapper(deleteNonFavoritedTasks, controller),
 		getTaskHistory: wrapper(getTaskHistory, controller),
 		askResponse: wrapper(askResponse, controller),
+		taskFeedback: wrapper(taskFeedback, controller),
 	})
 
 	// Web Service


### PR DESCRIPTION
### Description

This PR migrates the taskFeedback message to the gRPC/Protobuf system. It converts the legacy VSCode message passing mechanism to a gRPC method in the TaskService. The client can now call TaskServiceClient.taskFeedback() to pass taskFeedback messages.

### Test Procedure

The taskFeedback message is used to capture and record user satisfaction with task completions (thumbs up/down) if telemetry is enabled. To test it, complete any task with Cline and click either the thumbs up or thumbs down icon that appears in the top right of the final response, then verify in the console logs that the feedback was successfully sent.


### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [x] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Migrates `taskFeedback` to gRPC/Protobuf, updating client and server handling to use the new gRPC method.
> 
>   - **Behavior**:
>     - Migrates `taskFeedback` to gRPC/Protobuf in `task.proto`, adding `rpc taskFeedback(StringRequest) returns (Empty)`.
>     - Removes legacy `taskFeedback` handling from `Controller` in `index.ts`.
>     - Updates `TaskFeedbackButtons.tsx` to use `TaskServiceClient.taskFeedback()` for sending feedback.
>   - **Methods**:
>     - Adds `taskFeedback` method in `taskFeedback.ts` to handle feedback submission.
>     - Registers `taskFeedback` in `methods.ts` and `server-setup.ts`.
>   - **Misc**:
>     - Removes `taskFeedback` from `WebviewMessage.ts` type definitions.
>     - Adjusts `selectImages` method order in `server-setup.ts` for consistency.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 2ae13ece6d1f5e83fe198d608fdef10ad6d2a444. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->