### PR TITLE
fix: Address memory leak by bypassing subscribeToState gRPC stream for state updates

### DIFF
--- a/.changeset/forty-singers-yawn.md
+++ b/.changeset/forty-singers-yawn.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+fix: Address memory leak by bypassing subscribeToState gRPC stream for state updates

--- a/.changeset/kind-bears-sort.md
+++ b/.changeset/kind-bears-sort.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+fix: Address memory leak by bypassing subscribeToState gRPC stream for state updates

--- a/.changeset/kind-bears-sort.md
+++ b/.changeset/kind-bears-sort.md
@@ -1,5 +1,0 @@
----
-"claude-dev": patch
----
-
-fix: Address memory leak by bypassing subscribeToState gRPC stream for state updates

--- a/src/core/controller/index.ts
+++ b/src/core/controller/index.ts
@@ -1345,7 +1345,10 @@ export class Controller {
 
 	async postStateToWebview() {
 		const state = await this.getStateToPostToWebview()
-		await sendStateUpdate(state)
+		// For testing: Bypass gRPC stream and send state directly
+		console.log("[Controller Test Revert] Posting full state via direct 'state' message.")
+		await this.postMessageToWebview({ type: "state", state: state })
+		// await sendStateUpdate(state) // Original line
 	}
 
 	async getStateToPostToWebview(): Promise<ExtensionState> {

--- a/src/core/controller/index.ts
+++ b/src/core/controller/index.ts
@@ -1348,7 +1348,7 @@ export class Controller {
 		// For testing: Bypass gRPC stream and send state directly
 		console.log("[Controller Test Revert] Posting full state via direct 'state' message.")
 		await this.postMessageToWebview({ type: "state", state: state })
-		// await sendStateUpdate(state) // Original line
+		// await sendStateUpdate(state) // Original line for the GrPC stream
 	}
 
 	async getStateToPostToWebview(): Promise<ExtensionState> {

--- a/src/shared/proto/file.ts
+++ b/src/shared/proto/file.ts
@@ -915,15 +915,6 @@ export const FileServiceDefinition = {
 			responseStream: false,
 			options: {},
 		},
-		/** Select images from the file system and return as data URLs */
-		selectImages: {
-			name: "selectImages",
-			requestType: EmptyRequest,
-			requestStream: false,
-			responseType: StringArray,
-			responseStream: false,
-			options: {},
-		},
 		/** Opens an image in the system viewer */
 		openImage: {
 			name: "openImage",
@@ -957,6 +948,15 @@ export const FileServiceDefinition = {
 			requestType: StringRequest,
 			requestStream: false,
 			responseType: GitCommits,
+			responseStream: false,
+			options: {},
+		},
+		/** Select images from the file system and return as data URLs */
+		selectImages: {
+			name: "selectImages",
+			requestType: EmptyRequest,
+			requestStream: false,
+			responseType: StringArray,
 			responseStream: false,
 			options: {},
 		},

--- a/src/standalone/server-setup.ts
+++ b/src/standalone/server-setup.ts
@@ -20,11 +20,11 @@ import { checkpointRestore } from "../core/controller/checkpoints/checkpointRest
 
 // File Service
 import { openFile } from "../core/controller/file/openFile"
-import { selectImages } from "../core/controller/file/selectImages"
 import { openImage } from "../core/controller/file/openImage"
 import { deleteRuleFile } from "../core/controller/file/deleteRuleFile"
 import { createRuleFile } from "../core/controller/file/createRuleFile"
 import { searchCommits } from "../core/controller/file/searchCommits"
+import { selectImages } from "../core/controller/file/selectImages"
 import { getRelativePaths } from "../core/controller/file/getRelativePaths"
 import { searchFiles } from "../core/controller/file/searchFiles"
 
@@ -96,11 +96,11 @@ export function addServices(
 	// File Service
 	server.addService(proto.cline.FileService.service, {
 		openFile: wrapper(openFile, controller),
-		selectImages: wrapper(selectImages, controller),
 		openImage: wrapper(openImage, controller),
 		deleteRuleFile: wrapper(deleteRuleFile, controller),
 		createRuleFile: wrapper(createRuleFile, controller),
 		searchCommits: wrapper(searchCommits, controller),
+		selectImages: wrapper(selectImages, controller),
 		getRelativePaths: wrapper(getRelativePaths, controller),
 		searchFiles: wrapper(searchFiles, controller),
 	})

--- a/webview-ui/src/context/ExtensionStateContext.tsx
+++ b/webview-ui/src/context/ExtensionStateContext.tsx
@@ -100,6 +100,59 @@ export const ExtensionStateContextProvider: React.FC<{
 	const handleMessage = useCallback((event: MessageEvent) => {
 		const message: ExtensionMessage = event.data
 		switch (message.type) {
+			case "state": {
+				// Handler for direct state messages
+				if (message.state) {
+					const stateData = message.state as ExtensionState
+					console.log("[Webview Context Test Revert] Received direct 'state' message, updating state.")
+					setState((prevState) => {
+						// Versioning logic for autoApprovalSettings (copied from original onResponse)
+						const incomingVersion = stateData.autoApprovalSettings?.version ?? 1
+						const currentVersion = prevState.autoApprovalSettings?.version ?? 1
+						const shouldUpdateAutoApproval = incomingVersion > currentVersion
+
+						const newState = {
+							...stateData,
+							autoApprovalSettings: shouldUpdateAutoApproval
+								? stateData.autoApprovalSettings
+								: prevState.autoApprovalSettings,
+						}
+
+						// Update welcome screen state based on API configuration (copied from original onResponse)
+						const config = stateData.apiConfiguration
+						const hasKey = config
+							? [
+									config.apiKey,
+									config.openRouterApiKey,
+									config.awsRegion,
+									config.vertexProjectId,
+									config.openAiApiKey,
+									config.ollamaModelId,
+									config.lmStudioModelId,
+									config.liteLlmApiKey,
+									config.geminiApiKey,
+									config.openAiNativeApiKey,
+									config.deepSeekApiKey,
+									config.requestyApiKey,
+									config.togetherApiKey,
+									config.qwenApiKey,
+									config.doubaoApiKey,
+									config.mistralApiKey,
+									config.vsCodeLmModelSelector,
+									config.clineApiKey,
+									config.asksageApiKey,
+									config.xaiApiKey,
+									config.sambanovaApiKey,
+								].some((key) => key !== undefined)
+							: false
+
+						setShowWelcome(!hasKey)
+						setDidHydrateState(true)
+						return newState
+					})
+				}
+				break
+			}
 			case "theme": {
 				if (message.text) {
 					setTheme(convertTextMateToHljs(JSON.parse(message.text)))
@@ -169,32 +222,33 @@ export const ExtensionStateContextProvider: React.FC<{
 	const stateSubscriptionRef = useRef<(() => void) | null>(null)
 
 	// Subscribe to state updates using the new gRPC streaming API
+	/* // TEST REVERT: Commenting out gRPC state subscription
 	useEffect(() => {
 		// Set up state subscription
 		stateSubscriptionRef.current = StateServiceClient.subscribeToState(
 			{},
 			{
 				onResponse: (response) => {
-					console.log("[DEBUG] got state update via subscription", response)
+					console.log("[DEBUG] got state update via subscription", response);
 					if (response.stateJson) {
 						try {
-							const stateData = JSON.parse(response.stateJson) as ExtensionState
-							console.log("[DEBUG] parsed state JSON, updating state")
+							const stateData = JSON.parse(response.stateJson) as ExtensionState;
+							console.log("[DEBUG] parsed state JSON, updating state");
 							setState((prevState) => {
 								// Versioning logic for autoApprovalSettings
-								const incomingVersion = stateData.autoApprovalSettings?.version ?? 1
-								const currentVersion = prevState.autoApprovalSettings?.version ?? 1
-								const shouldUpdateAutoApproval = incomingVersion > currentVersion
+								const incomingVersion = stateData.autoApprovalSettings?.version ?? 1;
+								const currentVersion = prevState.autoApprovalSettings?.version ?? 1;
+								const shouldUpdateAutoApproval = incomingVersion > currentVersion;
 
 								const newState = {
 									...stateData,
 									autoApprovalSettings: shouldUpdateAutoApproval
 										? stateData.autoApprovalSettings
 										: prevState.autoApprovalSettings,
-								}
+								};
 
 								// Update welcome screen state based on API configuration
-								const config = stateData.apiConfiguration
+								const config = stateData.apiConfiguration;
 								const hasKey = config
 									? [
 											config.apiKey,
@@ -219,41 +273,52 @@ export const ExtensionStateContextProvider: React.FC<{
 											config.xaiApiKey,
 											config.sambanovaApiKey,
 										].some((key) => key !== undefined)
-									: false
+									: false;
 
-								setShowWelcome(!hasKey)
-								setDidHydrateState(true)
+								setShowWelcome(!hasKey);
+								setDidHydrateState(true);
 
-								console.log("[DEBUG] returning new state in ESC")
+								console.log("[DEBUG] returning new state in ESC");
 
-								return newState
-							})
+								return newState;
+							});
 						} catch (error) {
-							console.error("Error parsing state JSON:", error)
-							console.log("[DEBUG] ERR getting state", error)
+							console.error("Error parsing state JSON:", error);
+							console.log("[DEBUG] ERR getting state", error);
 						}
 					}
-					console.log('[DEBUG] ended "got subscribed state"')
+					console.log('[DEBUG] ended "got subscribed state"');
 				},
 				onError: (error) => {
-					console.error("Error in state subscription:", error)
+					console.error("Error in state subscription:", error);
 				},
 				onComplete: () => {
-					console.log("State subscription completed")
+					console.log("State subscription completed");
 				},
 			},
-		)
+		);
 
 		// Still send the webviewDidLaunch message for other initialization
-		vscode.postMessage({ type: "webviewDidLaunch" })
+		vscode.postMessage({ type: "webviewDidLaunch" });
 
 		// Clean up subscription when component unmounts
 		return () => {
 			if (stateSubscriptionRef.current) {
-				stateSubscriptionRef.current()
-				stateSubscriptionRef.current = null
+				stateSubscriptionRef.current();
+				stateSubscriptionRef.current = null;
 			}
-		}
+		};
+	}, []);
+	*/ // END TEST REVERT
+
+	// For the test revert, ensure webviewDidLaunch is still sent if not done by the above useEffect
+	useEffect(() => {
+		// This effect now only sends webviewDidLaunch if the gRPC subscription is commented out.
+		// If the gRPC subscription is active, it sends webviewDidLaunch.
+		// To avoid sending it twice if you uncomment the above, you might add a flag.
+		// For this specific test (gRPC sub commented out), this is fine.
+		console.log("[Webview Context Test Revert] Sending webviewDidLaunch from separate useEffect.")
+		vscode.postMessage({ type: "webviewDidLaunch" })
 	}, [])
 
 	const contextValue: ExtensionStateContextType = {


### PR DESCRIPTION
## NOTE ON Testing
The way to test this PR is as follows: - You make one task converse for a while. - You observe a lot of gain in memory - You start a new task. Once that new start is completed, the memory of the previous task is going to go away We are not fully confident if this is the best GC solution, but it's better than what we have right now in main.

- This PR helps in the sense that if you start a new task, then if you type something in the new task, the held-up memory of the previous task is cleared up. But if a previous conversation is still going on, then the held-up memory is not cleared up. 


### Description


This PR addresses a memory leak on the extension host that was primarily caused by the lifecycle management of the `subscribeToState` gRPC stream, introduced in PR #3253.

**The Problem:**
The `subscribeToState` gRPC stream, used for pushing full state updates to the webview, was not being reliably cancelled by the webview client. This was due to the webview's "never unmounts" behavior, which prevented the standard React `useEffect` cleanup (responsible for triggering the gRPC stream cancellation) from executing.

On the extension host, this resulted in:
1.  The `GrpcRequestRegistry` retaining `RequestInfo` objects for these uncancelled `subscribeToState` streams.
2.  These `RequestInfo` objects held references to `responseStream` callback closures.
3.  The `responseStream` closures captured the main `Controller` instance.
4.  Consequently, the `Controller` (and the active `Task` instance with all its data, including chat history) was pinned in memory, leading to a persistent memory leak.

**The Solution (Temporary/Diagnostic Fix Implemented in this PR):**
To diagnose and confirm the causality, this PR implements a temporary change that bypasses the `subscribeToState` gRPC stream for full state updates:

1.  **In `src/core/controller/index.ts`:** The `Controller.postStateToWebview()` method has been modified to send the `ExtensionState` directly to the webview using a standard `ExtensionMessage` of type `"state"` via `this.postMessageToWebview()`. It no longer uses `sendStateUpdate()` which relied on the `subscribeToState` gRPC infrastructure.
2.  **In `webview-ui/src/context/ExtensionStateContext.tsx`:** The `useEffect` hook that initiated the `StateServiceClient.subscribeToState()` gRPC call has been commented out. The context now handles incoming direct `"state"` messages to update its React state.

This change effectively reverts the mechanism for full state updates to a simpler, stateless `postMessage` approach, thereby avoiding the problematic gRPC stream lifecycle issue for this specific data path. Testing has shown that this resolves the observed memory leak.

**Note:** This is considered a temporary solution to confirm the problem's source. A more permanent solution would involve making the gRPC `subscribeToState` stream lifecycle robust (e.g., by implementing reliable client-side cancellation even if the webview doesn't unmount, or by server-side stale stream detection with appropriate timeouts that don't disrupt active sessions).

### Test Procedure
1.  Build and run the extension with these changes.
2.  Monitor the memory usage of the VS Code Extension Host process using profiling tools.
3.  Engage in chat sessions, start new tasks, etc.
4.  Observe that the previously identified memory leak (where memory would grow and not be reclaimed, especially after gRPC streams were established) is no longer present or is significantly mitigated.
5.  Verify that the webview still receives state updates correctly and chat functionality remains intact (though now via direct `"state"` messages instead of the `subscribeToState` gRPC stream).


### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [X] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [X] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [X] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [X] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [X] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [X] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Bypasses `subscribeToState` gRPC stream for state updates to address memory leak, using direct messaging instead.
> 
>   - **Behavior**:
>     - Bypasses `subscribeToState` gRPC stream for state updates, using direct messaging instead in `src/core/controller/index.ts` and `webview-ui/src/context/ExtensionStateContext.tsx`.
>     - Comments out gRPC stream setup in `ExtensionStateContext.tsx`.
>   - **Files**:
>     - `index.ts`: Modifies `Controller.postStateToWebview()` to use direct messaging.
>     - `ExtensionStateContext.tsx`: Handles direct state messages and comments out gRPC subscription.
>     - `server-setup.ts`: No changes directly related to the main fix, but relevant to gRPC setup.
>   - **Misc**:
>     - Adjusts `FileServiceDefinition` in `file.ts` for consistency.
>     - Updates `selectImages` import order in `server-setup.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 04014541a8420dec8fe6648b73bbdba9a79bb548. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->