### PR TITLE
Revert "Changeset version bump"

### DIFF
--- a/.changeset/eighty-pumas-fly.md
+++ b/.changeset/eighty-pumas-fly.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+taskFeedback protobus migration

--- a/.changeset/forty-singers-yawn.md
+++ b/.changeset/forty-singers-yawn.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+fix: Address memory leak by bypassing subscribeToState gRPC stream for state updates

--- a/.changeset/good-ducks-teach.md
+++ b/.changeset/good-ducks-teach.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+fetchOpenGraphData protobus migration

--- a/.changeset/hip-actors-do.md
+++ b/.changeset/hip-actors-do.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Changing UX and UI for gemini models attempts

--- a/.changeset/olive-bags-pump.md
+++ b/.changeset/olive-bags-pump.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+resetState protobus migration

--- a/.changeset/sixty-panthers-breathe.md
+++ b/.changeset/sixty-panthers-breathe.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Add Enable auto approve toggle

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,5 @@
 # Changelog
 
-## [3.16.1]
-
--   Add Enable auto approve toggle switch, allowing users to easily turn auto-approve functionality on or off without losing their action settings
--   Improve Gemini retry handling with better UI feedback, showing retry progress during API request attempts
--   Fix memory leak issue that could occur during long sessions with multiple tasks
--   Improve UI for Gemini model retry attempts with clearer status updates
--   Fix quick actions functionality in auto-approve settings
--   Update UI styling for auto-approve menu items to conserve space
-
 ## [3.16.0]
 
 -   Add new workflow feature allowing users to create and manage workflow files that can be injected into conversations via slash commands

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "claude-dev",
 	"displayName": "Cline",
 	"description": "Autonomous coding agent right in your IDE, capable of creating/editing files, running commands, using the browser, and more with your permission every step of the way.",
-	"version": "3.16.1",
+	"version": "3.16.0",
 	"icon": "assets/icons/icon.png",
 	"engines": {
 		"vscode": "^1.84.0"


### PR DESCRIPTION
Reverts cline/cline#3598
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Reverts changeset version bump from `3.16.1` to `3.16.0`, removing related `CHANGELOG.md` entries and adding back changeset files.
> 
>   - **Reversion**:
>     - Reverts changeset version bump from `3.16.1` to `3.16.0` in `package.json`.
>     - Removes entries related to version `3.16.1` from `CHANGELOG.md`.
>   - **Changeset Files**:
>     - Adds back changeset files: `eighty-pumas-fly.md`, `forty-singers-yawn.md`, `good-ducks-teach.md`, `hip-actors-do.md`, `olive-bags-pump.md`, `sixty-panthers-breathe.md`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 377bb26e38b860e0f1a795ac7b0e92069e9d108f. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->