### PR TITLE
[PROTOBUS] Move copyToClipboard to protobus 

### DIFF
--- a/.changeset/long-zebras-yawn.md
+++ b/.changeset/long-zebras-yawn.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+copyToClipboard protobus migration

--- a/proto/file.proto
+++ b/proto/file.proto
@@ -8,6 +8,9 @@ import "common.proto";
 
 // Service for file-related operations
 service FileService {
+  // Copies text to clipboard
+  rpc copyToClipboard(StringRequest) returns (Empty);
+
   // Opens a file in the editor
   rpc openFile(StringRequest) returns (Empty);
  

--- a/src/core/controller/file/copyToClipboard.ts
+++ b/src/core/controller/file/copyToClipboard.ts
@@ -1,0 +1,20 @@
+import * as vscode from "vscode"
+import { Controller } from ".."
+import { Empty, StringRequest } from "../../../shared/proto/common"
+
+/**
+ * Copies text to the system clipboard
+ * @param controller The controller instance
+ * @param request The request containing the text to copy
+ * @returns Empty response
+ */
+export async function copyToClipboard(controller: Controller, request: StringRequest): Promise<Empty> {
+	try {
+		if (request.value) {
+			await vscode.env.clipboard.writeText(request.value)
+		}
+	} catch (error) {
+		console.error("Error copying to clipboard:", error)
+	}
+	return Empty.create()
+}

--- a/src/core/controller/index.ts
+++ b/src/core/controller/index.ts
@@ -621,14 +621,6 @@ export class Controller {
 				break
 			}
 
-			case "copyToClipboard": {
-				try {
-					await vscode.env.clipboard.writeText(message.text || "")
-				} catch (error) {
-					console.error("Error copying to clipboard:", error)
-				}
-				break
-			}
 			case "updateTerminalConnectionTimeout": {
 				if (message.shellIntegrationTimeout !== undefined) {
 					const timeout = message.shellIntegrationTimeout

--- a/src/shared/WebviewMessage.ts
+++ b/src/shared/WebviewMessage.ts
@@ -55,7 +55,6 @@ export interface WebviewMessage {
 		| "toggleWindsurfRule"
 		| "toggleWorkflow"
 		| "deleteClineRule"
-		| "copyToClipboard"
 		| "updateTerminalConnectionTimeout"
 		| "setActiveQuote"
 

--- a/src/shared/proto/file.ts
+++ b/src/shared/proto/file.ts
@@ -906,6 +906,15 @@ export const FileServiceDefinition = {
 	name: "FileService",
 	fullName: "cline.FileService",
 	methods: {
+		/** Copies text to clipboard */
+		copyToClipboard: {
+			name: "copyToClipboard",
+			requestType: StringRequest,
+			requestStream: false,
+			responseType: Empty,
+			responseStream: false,
+			options: {},
+		},
 		/** Opens a file in the editor */
 		openFile: {
 			name: "openFile",

--- a/src/standalone/server-setup.ts
+++ b/src/standalone/server-setup.ts
@@ -19,6 +19,7 @@ import { checkpointDiff } from "../core/controller/checkpoints/checkpointDiff"
 import { checkpointRestore } from "../core/controller/checkpoints/checkpointRestore"
 
 // File Service
+import { copyToClipboard } from "../core/controller/file/copyToClipboard"
 import { openFile } from "../core/controller/file/openFile"
 import { openImage } from "../core/controller/file/openImage"
 import { deleteRuleFile } from "../core/controller/file/deleteRuleFile"
@@ -98,6 +99,7 @@ export function addServices(
 
 	// File Service
 	server.addService(proto.cline.FileService.service, {
+		copyToClipboard: wrapper(copyToClipboard, controller),
 		openFile: wrapper(openFile, controller),
 		openImage: wrapper(openImage, controller),
 		deleteRuleFile: wrapper(deleteRuleFile, controller),

--- a/webview-ui/src/components/chat/ChatView.tsx
+++ b/webview-ui/src/components/chat/ChatView.tsx
@@ -199,8 +199,14 @@ const ChatView = ({ isHidden, showAnnouncement, hideAnnouncement, showHistoryVie
 					}
 
 					if (textToCopy !== null) {
-						vscode.postMessage({ type: "copyToClipboard", text: textToCopy })
-						e.preventDefault()
+						try {
+							FileServiceClient.copyToClipboard({ value: textToCopy }).catch((err) => {
+								console.error("Error copying to clipboard:", err)
+							})
+							e.preventDefault()
+						} catch (error) {
+							console.error("Error copying to clipboard:", error)
+						}
 					}
 				}
 			}


### PR DESCRIPTION
### Description

This PR migrates the copyToClipboard message to the gRPC/Protobuf system. It converts the legacy VSCode message passing mechanism to a gRPC method in the FileService. The client can now call FileServiceClient.copyToClipboard() to pass copyToClipboard messages.

### Test Procedure

This message is used when copying selected text to the clipboard. Start a new task, select some of the text in Cline's response, and use the copy command or right click method. Confirm the text is copied and GRPC logging is recorded.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [X] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [ ] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Migrate `copyToClipboard` functionality to gRPC/Protobuf system, updating client and server code accordingly.
> 
>   - **Behavior**:
>     - Migrate `copyToClipboard` to gRPC in `proto/file.proto` and `src/core/controller/file/copyToClipboard.ts`.
>     - Update `ChatView.tsx` to use `FileServiceClient.copyToClipboard()` for copying text.
>   - **Legacy Removal**:
>     - Remove `copyToClipboard` handling from `src/core/controller/index.ts` and `src/shared/WebviewMessage.ts`.
>   - **Server Setup**:
>     - Add `copyToClipboard` to `FileService` in `server-setup.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for e2d58f82b55b158efe946da0a26a05eb5e6cf5f6. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->