### PR TITLE
Remind VS code users of clines existence(Open Cline on AutoUpdate+KeyboardShortcuts+Lightbulb icons)

### DIFF
--- a/.changeset/tame-windows-compete.md
+++ b/.changeset/tame-windows-compete.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Remind VS code users of clines existence(Open Cline on AutoUpdate+KeyboardShortcuts+Lightbulb icons)

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "claude-dev",
 	"displayName": "Cline",
 	"description": "Autonomous coding agent right in your IDE, capable of creating/editing files, running commands, using the browser, and more with your permission every step of the way.",
-	"version": "3.16.1",
+	"version": "3.16.2",
 	"icon": "assets/icons/icon.png",
 	"engines": {
 		"vscode": "^1.84.0"

--- a/package.json
+++ b/package.json
@@ -126,6 +126,16 @@
 				"title": "Generate Commit Message with Cline",
 				"category": "Cline",
 				"icon": "$(robot)"
+			},
+			{
+				"command": "cline.explainCode",
+				"title": "Explain with Cline",
+				"category": "Cline"
+			},
+			{
+				"command": "cline.improveCode",
+				"title": "Improve with Cline",
+				"category": "Cline"
 			}
 		],
 		"keybindings": [
@@ -140,6 +150,12 @@
 			{
 				"command": "cline.generateGitCommitMessage",
 				"when": "scmProvider == git"
+			},
+			{
+				"command": "cline.focusChatInput",
+				"key": "ctrl+shift+l",
+				"mac": "cmd+shift+l",
+				"when": "true"
 			}
 		],
 		"menus": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "claude-dev",
 	"displayName": "Cline",
 	"description": "Autonomous coding agent right in your IDE, capable of creating/editing files, running commands, using the browser, and more with your permission every step of the way.",
-	"version": "3.16.1",
+	"version": "3.16.5",
 	"icon": "assets/icons/icon.png",
 	"engines": {
 		"vscode": "^1.84.0"

--- a/package.json
+++ b/package.json
@@ -153,9 +153,11 @@
 			},
 			{
 				"command": "cline.focusChatInput",
-				"key": "ctrl+shift+l",
-				"mac": "cmd+shift+l",
-				"when": "true"
+				"key": "cmd+'",
+				"mac": "cmd+'",
+				"win": "ctrl+'",
+				"linux": "ctrl+'",
+				"when": "!editorHasSelection"
 			}
 		],
 		"menus": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "claude-dev",
 	"displayName": "Cline",
 	"description": "Autonomous coding agent right in your IDE, capable of creating/editing files, running commands, using the browser, and more with your permission every step of the way.",
-	"version": "3.16.2",
+	"version": "3.16.1",
 	"icon": "assets/icons/icon.png",
 	"engines": {
 		"vscode": "^1.84.0"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "claude-dev",
 	"displayName": "Cline",
 	"description": "Autonomous coding agent right in your IDE, capable of creating/editing files, running commands, using the browser, and more with your permission every step of the way.",
-	"version": "3.16.5",
+	"version": "3.16.1",
 	"icon": "assets/icons/icon.png",
 	"engines": {
 		"vscode": "^1.84.0"

--- a/src/core/controller/file/methods.ts
+++ b/src/core/controller/file/methods.ts
@@ -3,6 +3,7 @@
 
 // Import all method implementations
 import { registerMethod } from "./index"
+import { copyToClipboard } from "./copyToClipboard"
 import { createRuleFile } from "./createRuleFile"
 import { deleteRuleFile } from "./deleteRuleFile"
 import { getRelativePaths } from "./getRelativePaths"
@@ -15,6 +16,7 @@ import { selectImages } from "./selectImages"
 // Register all file service methods
 export function registerAllMethods(): void {
 	// Register each method with the registry
+	registerMethod("copyToClipboard", copyToClipboard)
 	registerMethod("createRuleFile", createRuleFile)
 	registerMethod("deleteRuleFile", deleteRuleFile)
 	registerMethod("getRelativePaths", getRelativePaths)

--- a/src/core/webview/index.ts
+++ b/src/core/webview/index.ts
@@ -149,6 +149,28 @@ export class WebviewProvider implements vscode.WebviewViewProvider {
 			this.controller.clearTask()
 
 			this.outputChannel.appendLine("Webview view resolved")
+
+			// Set the title to include the keyboard shortcut
+			if (this.view && "title" in this.view) {
+				// Check if the view object has a title property
+				const isMac = process.platform === "darwin"
+				const shortcutDisplay = isMac ? " (⌘⇧L)" : " (Ctrl+Shift+L)"
+				const baseTitle = this.context.extension.packageJSON.displayName || "Cline"
+				const newTitleWithShortcut = `${baseTitle}${shortcutDisplay}`
+
+				const currentTitle = this.view.title
+
+				if (typeof currentTitle === "string") {
+					if (!currentTitle.includes(shortcutDisplay)) {
+						// Title exists and is a string, but doesn't have the shortcut
+						this.view.title = newTitleWithShortcut
+					}
+					// If it includes shortcutDisplay, do nothing
+				} else {
+					// Title is undefined or not a string (e.g., for sidebar initially)
+					this.view.title = newTitleWithShortcut
+				}
+			}
 		}
 	}
 

--- a/src/core/webview/index.ts
+++ b/src/core/webview/index.ts
@@ -154,7 +154,7 @@ export class WebviewProvider implements vscode.WebviewViewProvider {
 			if (this.view && "title" in this.view) {
 				// Check if the view object has a title property
 				const isMac = process.platform === "darwin"
-				const shortcutDisplay = isMac ? " (⌘⇧L)" : " (Ctrl+Shift+L)"
+				const shortcutDisplay = isMac ? " (⌘+')" : " (Ctrl+')"
 				const baseTitle = this.context.extension.packageJSON.displayName || "Cline"
 				const newTitleWithShortcut = `${baseTitle}${shortcutDisplay}`
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -58,7 +58,7 @@ export async function activate(context: vscode.ExtensionContext) {
 		const lastShownPopupNotificationVersion = context.globalState.get<string>("clineLastPopupNotificationVersion")
 
 		if (currentVersion !== lastShownPopupNotificationVersion && previousVersion) {
-			// Show VS Code popup notification as this version hasn't been notified yet.
+			// Show VS Code popup notification as this version hasn't been notified yet without doing it for fresh installs
 			const message = `Cline has been updated to v${currentVersion}`
 			await vscode.commands.executeCommand("claude-dev.SidebarProvider.focus")
 			await new Promise((resolve) => setTimeout(resolve, 200))

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -358,6 +358,10 @@ export async function activate(context: vscode.ExtensionContext) {
 		}),
 	)
 
+	const CONTEXT_LINES_TO_EXPAND = 3
+	const START_OF_LINE_CHAR_INDEX = 0
+	const LINE_COUNT_ADJUSTMENT_FOR_ZERO_INDEXING = 1
+
 	// Register code action provider
 	context.subscriptions.push(
 		vscode.languages.registerCodeActionsProvider(
@@ -386,10 +390,18 @@ export async function activate(context: vscode.ExtensionContext) {
 						expandedRange = selection
 					} else {
 						expandedRange = new vscode.Range(
-							Math.max(0, range.start.line - 3),
-							0,
-							Math.min(document.lineCount - 1, range.end.line + 3),
-							document.lineAt(Math.min(document.lineCount - 1, range.end.line + 3)).text.length,
+							Math.max(0, range.start.line - CONTEXT_LINES_TO_EXPAND),
+							START_OF_LINE_CHAR_INDEX,
+							Math.min(
+								document.lineCount - LINE_COUNT_ADJUSTMENT_FOR_ZERO_INDEXING,
+								range.end.line + CONTEXT_LINES_TO_EXPAND,
+							),
+							document.lineAt(
+								Math.min(
+									document.lineCount - LINE_COUNT_ADJUSTMENT_FOR_ZERO_INDEXING,
+									range.end.line + CONTEXT_LINES_TO_EXPAND,
+								),
+							).text.length,
 						)
 					}
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -291,10 +291,11 @@ export async function activate(context: vscode.ExtensionContext) {
 			}
 
 			// Use provided range if available, otherwise use current selection
+			// (vscode command passes an argument in the first param by default, so we need to ensure it's a Range object)
 			const textRange = range instanceof vscode.Range ? range : editor.selection
 			const selectedText = editor.document.getText(textRange)
 
-			if (!selectedText.trim()) {
+			if (!selectedText) {
 				return
 			}
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -59,31 +59,11 @@ export async function activate(context: vscode.ExtensionContext) {
 
 		if (currentVersion !== lastShownPopupNotificationVersion) {
 			// Show VS Code popup notification as this version hasn't been notified yet.
-			const message = `Cline has been updated to v${currentVersion}!`
+			const message = `Cline has been updated to v${currentVersion}`
 			Logger.log(`Showing update notification: ${message}`)
 			await vscode.commands.executeCommand("claude-dev.SidebarProvider.focus")
 			await new Promise((resolve) => setTimeout(resolve, 200))
-			let targetInstance = WebviewProvider.getVisibleInstance()
-			targetInstance = WebviewProvider.getSidebarInstance()
-			vscode.window.showInformationMessage(message, "Open Cline").then(async (selection) => {
-				if (selection === "Open Cline") {
-					Logger.log("User clicked 'Open Cline' from update notification.")
-					if (!targetInstance) {
-						await vscode.commands.executeCommand("claude-dev.SidebarProvider.focus")
-						await new Promise((resolve) => setTimeout(resolve, 200))
-						targetInstance = WebviewProvider.getSidebarInstance()
-					}
-					if (!targetInstance) {
-						const tabInstances = WebviewProvider.getTabInstances()
-						if (tabInstances.length > 0) {
-							const panelView = tabInstances[tabInstances.length - 1].view as vscode.WebviewPanel
-							panelView.reveal(panelView.viewColumn)
-						} else {
-							await vscode.commands.executeCommand("cline.openInNewTab")
-						}
-					}
-				}
-			})
+			vscode.window.showInformationMessage(message)
 			// Record that we've shown the popup for this version.
 			await context.globalState.update("clineLastPopupNotificationVersion", currentVersion)
 		}


### PR DESCRIPTION
Solves https://github.com/cline/cline/issues/3351 


### Description
This PR does a few things: 
1.  It opens Cline on auto-update 
2. It adds a shortcut to Cline(Cmd+Shift+L) to be able to focus on it whenever 
3. Any selected text gets a light bulb icon which lets you do "Add to Cline", "Explain with Cline" and "Improve with Cline" options.

### Test Procedure

Test 1:  It opens Cline on auto-update  
- Go to package.json and change the version of cline
- Restart the debugger(by clicking green button in photo) and you will see cline window as focused
<img width="244" alt="image" src="https://github.com/user-attachments/assets/cf957c52-0ae0-43f3-82b6-c15303e5f86d" />

- You will also see a popup
<img width="545" alt="image" src="https://github.com/user-attachments/assets/82a5e8c0-1aa2-40b4-be58-c8213b0a2a0e" />
- Note: If cline is out of focus this will automagically bring cline to focus


Test 2: Adding shortcut to cline 
- Do (Command + Shift + L ) at random place in vscode and it will bring cline to Focus
- This PR adds a shortcut name to the top of cline this is helpful and easy to understand
<img width="363" alt="image" src="https://github.com/user-attachments/assets/a452a507-65ac-43cd-8f59-f4398cdbc6a8" />



Test 3(add a lightbulb button):
- Select any random text
- click on the lightbulb icon
<img width="538" alt="image" src="https://github.com/user-attachments/assets/f7d62ec2-dda9-4c88-9944-0337203ed683" />


- Play with these
 





### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [X] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [X] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [X] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [X] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [X] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Enhances Cline extension with auto-update focus, keyboard shortcuts, and lightbulb actions for code interaction in VS Code.
> 
>   - **Behavior**:
>     - Opens Cline on auto-update by focusing the Cline window and showing a notification in `extension.ts`.
>     - Adds keyboard shortcut (Cmd+Shift+L) to focus Cline in `package.json` and `webview/index.ts`.
>     - Introduces lightbulb icon for selected text with options "Add to Cline", "Explain with Cline", and "Improve with Cline" in `extension.ts`.
>   - **Commands and Keybindings**:
>     - Adds `cline.explainCode` and `cline.improveCode` commands in `package.json`.
>     - Registers new commands and keybindings in `extension.ts`.
>   - **Webview Enhancements**:
>     - Updates `WebviewProvider` in `webview/index.ts` to include keyboard shortcut in the title.
>     - Ensures Cline webview is focused when executing commands in `extension.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for c458544e62a43279a03e711a88fbf7ce70265f24. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->