### PR TITLE
Migrate setActiveQuote message to protobus

### DIFF
--- a/.changeset/famous-shoes-beam.md
+++ b/.changeset/famous-shoes-beam.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": minor
+---
+
+Migrate setActiveQuote to protobus

--- a/src/shared/ExtensionMessage.ts
+++ b/src/shared/ExtensionMessage.ts
@@ -44,7 +44,6 @@ export interface ExtensionMessage {
 		| "browserRelaunchResult"
 		| "fileSearchResults"
 		| "grpc_response" // New type for gRPC responses
-		| "setActiveQuote"
 	text?: string
 	action?:
 		| "chatButtonClicked"

--- a/src/shared/WebviewMessage.ts
+++ b/src/shared/WebviewMessage.ts
@@ -51,7 +51,6 @@ export interface WebviewMessage {
 		| "toggleWorkflow"
 		| "deleteClineRule"
 		| "updateTerminalConnectionTimeout"
-		| "setActiveQuote"
 
 	// | "relaunchChromeDebugMode"
 	text?: string


### PR DESCRIPTION
### Description

Migrate setActiveQuote message to protobus

### Test Procedure

No type errors

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [x] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Migrate `setActiveQuote` message to protobus, removing it from `ExtensionMessage` and `WebviewMessage`.
> 
>   - **Behavior**:
>     - Remove `setActiveQuote` from `type` enum in `ExtensionMessage` and `WebviewMessage`.
>   - **Changeset**:
>     - Add changeset `famous-shoes-beam.md` to document migration of `setActiveQuote` to protobus.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 2c1fa304202cb8a2c89624702838c3be5030e676. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->