### PR TITLE
Fix build-protos script on windows

### DIFF
--- a/proto/build-proto.js
+++ b/proto/build-proto.js
@@ -55,7 +55,7 @@ async function main() {
 
 	// Process all proto files
 	console.log(chalk.cyan("Processing proto files from"), SCRIPT_DIR)
-	const protoFiles = await globby("*.proto", { cwd: SCRIPT_DIR, absolute: true })
+	const protoFiles = await globby("*.proto", { cwd: SCRIPT_DIR, realpath: true })
 
 	// Build the protoc command with proper path handling for cross-platform
 	const tsProtocCommand = [

--- a/proto/build-proto.js
+++ b/proto/build-proto.js
@@ -10,11 +10,15 @@ import chalk from "chalk"
 import { createRequire } from "module"
 const require = createRequire(import.meta.url)
 const protoc = path.join(require.resolve("grpc-tools"), "../bin/protoc")
-const tsProtoPlugin = require.resolve("ts-proto/protoc-gen-ts_proto")
 
 const __filename = fileURLToPath(import.meta.url)
 const SCRIPT_DIR = path.dirname(__filename)
 const ROOT_DIR = path.resolve(SCRIPT_DIR, "..")
+
+const isWindows = process.platform === "win32"
+const tsProtoPlugin = isWindows
+	? path.join(ROOT_DIR, "node_modules", ".bin", "protoc-gen-ts_proto.cmd") // Use the .bin directory path for Windows
+	: require.resolve("ts-proto/protoc-gen-ts_proto")
 
 // List of gRPC services
 // To add a new service, simply add it to this map and run this script


### PR DESCRIPTION
### Description

Use correct ts plugin path on windows. The plugin is in a different location on windows, see https://github.com/stephenh/ts-proto/issues/93

`glob` will always return forward slashes with `absolute: true`, use `realpath: true` instead which returns native slashes.
The forward slashes causes protoc to fail because it needs the protopath be an exact string prefix of the proto file(s).

Fixes #3595

### Test Procedure

Testing with `npm run protos` on windows server 2022.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

 NA

### Additional Notes

 NA
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix Windows compatibility in `build-proto.js` by adjusting `tsProtoPlugin` path and using `realpath` in `globby`.
> 
>   - **Bug Fix**:
>     - Adjust `tsProtoPlugin` path in `build-proto.js` for Windows compatibility by using `.bin/protoc-gen-ts_proto.cmd`.
>     - Change `globby` option from `absolute: true` to `realpath: true` to ensure native path separators are used.
>   - **Testing**:
>     - Verified on Windows Server 2022 using `npm run protos`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 4db00e801127f327d04c0f0990131f1426d32ff3. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->