### PR TITLE
Add stale workflow

### DIFF
--- a/.changeset/eight-pears-grow.md
+++ b/.changeset/eight-pears-grow.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": minor
+---
+
+Add stale workflow

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -12,7 +12,7 @@ jobs:
             issues: write
             pull-requests: write
         steps:
-            - uses: actions/stale@v9
+            - uses: actions/stale@28ca103
               with:
                   days-before-issue-stale: 60
                   days-before-issue-close: 14

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,24 @@
+# This workflow will only label and/or close 30 issues at a time in order to avoid exceeding a rate limit.
+# More info: https://docs.github.com/en/actions/use-cases-and-examples/project-management/closing-inactive-issues
+name: Close inactive issues
+on:
+    schedule:
+        - cron: "30 1 * * *"
+
+jobs:
+    close-issues:
+        runs-on: ubuntu-latest
+        permissions:
+            issues: write
+            pull-requests: write
+        steps:
+            - uses: actions/stale@v9
+              with:
+                  days-before-issue-stale: 60
+                  days-before-issue-close: 14
+                  stale-issue-label: "stale"
+                  stale-issue-message: "This issue is stale because it has been open for 60 days with no activity."
+                  close-issue-message: "This issue was closed because it has been inactive for 14 days since being marked as stale."
+                  days-before-pr-stale: -1
+                  days-before-pr-close: -1
+                  repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -21,4 +21,5 @@ jobs:
                   close-issue-message: "This issue was closed because it has been inactive for 14 days since being marked as stale."
                   days-before-pr-stale: -1
                   days-before-pr-close: -1
+                  exempt-issue-labels: "pinned,security"
                   repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test-stale.yml
+++ b/.github/workflows/test-stale.yml
@@ -1,0 +1,32 @@
+name: Test Stale Issues Workflow
+on:
+    workflow_dispatch:
+        inputs:
+            days-before-stale:
+                description: "Days before an issue becomes stale"
+                required: true
+                default: "1"
+            days-before-close:
+                description: "Days before a stale issue is closed"
+                required: true
+                default: "1"
+
+jobs:
+    test-stale:
+        runs-on: ubuntu-latest
+        permissions:
+            issues: write
+            pull-requests: write
+        steps:
+            - uses: actions/stale@v9
+              with:
+                  days-before-issue-stale: ${{ github.event.inputs.days-before-stale }}
+                  days-before-issue-close: ${{ github.event.inputs.days-before-close }}
+                  stale-issue-label: "stale"
+                  stale-issue-message: "This issue is stale because it has been open for ${{ github.event.inputs.days-before-stale }} days with no activity."
+                  close-issue-message: "This issue was closed because it has been inactive for ${{ github.event.inputs.days-before-close }} days since being marked as stale."
+                  days-before-pr-stale: -1
+                  days-before-pr-close: -1
+                  exempt-issue-labels: "pinned,security"
+                  repo-token: ${{ secrets.GITHUB_TOKEN }}
+                  debug-only: true

--- a/.github/workflows/test-stale.yml
+++ b/.github/workflows/test-stale.yml
@@ -29,4 +29,3 @@ jobs:
                   days-before-pr-close: -1
                   exempt-issue-labels: "pinned,security"
                   repo-token: ${{ secrets.GITHUB_TOKEN }}
-                  debug-only: true

--- a/.github/workflows/test-stale.yml
+++ b/.github/workflows/test-stale.yml
@@ -18,7 +18,7 @@ jobs:
             issues: write
             pull-requests: write
         steps:
-            - uses: actions/stale@v9
+            - uses: actions/stale@28ca103
               with:
                   days-before-issue-stale: ${{ github.event.inputs.days-before-stale }}
                   days-before-issue-close: ${{ github.event.inputs.days-before-close }}

--- a/.github/workflows/test-stale.yml
+++ b/.github/workflows/test-stale.yml
@@ -29,3 +29,4 @@ jobs:
                   days-before-pr-close: -1
                   exempt-issue-labels: "pinned,security"
                   repo-token: ${{ secrets.GITHUB_TOKEN }}
+                  debug-only: true


### PR DESCRIPTION
### Description

This PR adds a GitHub Action (actions/stale) that automatically marks issues as stale after 60 days of inactivity and closes them 14 days later if no further activity occurs. This helps keep the issue tracker clean and focused on active tasks.

### Test Procedure

1. Trigger `test-stale` workflow manually. It will log something like [this](https://github.com/DaveFres/cline/actions/runs/15146597354/job/42583682953):
![Screenshot 2025-05-20 at 22 06 10](https://github.com/user-attachments/assets/7736caeb-3d65-4d8e-9d15-6b5c5cadf2a3)
2. Also you can remove `debug-only` on your fork and test it there by setting `days-before-stale` and `days-before-close` to 0.
Example: https://github.com/DaveFres/cline/issues/8.
Or other numbers: https://github.com/DaveFres/cline/issues/3.

My forks `test-stale` could be used for testing if needed: https://github.com/DaveFres/cline/actions/workflows/test-stale.yml.

![Screenshot 2025-05-20 at 22 23 34](https://github.com/user-attachments/assets/255a65ec-c6fe-4feb-b8f9-cc738cdcd50d)


<!-- How did you test this? Are you confident that it will not introduce bugs? If so, why? -->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [x] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add GitHub Action to mark issues as stale after 60 days and close them after 14 days of inactivity, with a test workflow for validation.
> 
>   - **New Workflow**:
>     - Adds `stale.yml` to automatically mark issues as stale after 60 days and close them after 14 more days of inactivity.
>     - Scheduled to run daily at 1:30 AM.
>     - Uses `actions/stale@v9` with specific messages for staling and closing issues.
>     - Exempts issues with labels `pinned` and `security`.
>   - **Test Workflow**:
>     - Adds `test-stale.yml` for testing the stale workflow with customizable days for staling and closing.
>     - Triggered manually via `workflow_dispatch`.
>     - Includes `debug-only: true` for testing purposes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for e31555174468025c4390a14123f659d532e61869. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->