### PR TITLE
Fix: edge case of changing language in settings

### DIFF
--- a/.changeset/five-bikes-impress.md
+++ b/.changeset/five-bikes-impress.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Fix edge case of changing language in settings

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "claude-dev",
-	"version": "3.16.0",
+	"version": "3.16.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "claude-dev",
-			"version": "3.16.0",
+			"version": "3.16.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@anthropic-ai/bedrock-sdk": "^0.12.4",

--- a/webview-ui/src/components/chat/ChatTextArea.tsx
+++ b/webview-ui/src/components/chat/ChatTextArea.tsx
@@ -970,6 +970,8 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 					type: "togglePlanActMode",
 					chatSettings: {
 						mode: newMode,
+						preferredLanguage: chatSettings.preferredLanguage,
+						openAIReasoningEffort: chatSettings.openAIReasoningEffort,
 					},
 					chatContent: {
 						message: inputValue.trim() ? inputValue : undefined,

--- a/webview-ui/src/components/settings/SettingsView.tsx
+++ b/webview-ui/src/components/settings/SettingsView.tsx
@@ -119,6 +119,8 @@ const SettingsView = ({ onDone }: SettingsViewProps) => {
 							type: "togglePlanActMode",
 							chatSettings: {
 								mode: pendingTabChange,
+								preferredLanguage: chatSettings.preferredLanguage,
+								openAIReasoningEffort: chatSettings.openAIReasoningEffort,
 							},
 						})
 						setPendingTabChange(null)


### PR DESCRIPTION
Fixes https://github.com/cline/cline/issues/3631 

### Description
Solves edge cases of language change settings 

### Test Procedure
- Change language in the language settings. 
- Try different chats

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [X] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [X] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [X] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [X] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [X] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes edge case in language settings by preserving `preferredLanguage` and `openAIReasoningEffort` during mode toggles in `ChatTextArea` and `SettingsView`.
> 
>   - **Behavior**:
>     - Fixes edge case in language settings by preserving `preferredLanguage` and `openAIReasoningEffort` during mode toggles in `ChatTextArea` and `SettingsView`.
>   - **Components**:
>     - Updates `ChatTextArea` to include `preferredLanguage` and `openAIReasoningEffort` in `togglePlanActMode` message.
>     - Updates `SettingsView` to include `preferredLanguage` and `openAIReasoningEffort` in `togglePlanActMode` message when settings are updated.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for ee6d74453234c35a8c754651cbb083834c6a8807. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->