### PR TITLE
Fix: Temporary revert in protobus changes in toggle plan and act mode

### DIFF
--- a/.changeset/nice-cobras-pretend.md
+++ b/.changeset/nice-cobras-pretend.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Fixing bug in toggle plan and act

--- a/src/core/controller/index.ts
+++ b/src/core/controller/index.ts
@@ -305,6 +305,11 @@ export class Controller {
 					}
 				}
 				break
+			case "togglePlanActMode":
+				if (message.chatSettings) {
+					await this.togglePlanActModeWithChatSettings(message.chatSettings, message.chatContent)
+				}
+				break
 			case "optionsResponse":
 				await this.postMessageToWebview({
 					type: "invoke",

--- a/src/shared/WebviewMessage.ts
+++ b/src/shared/WebviewMessage.ts
@@ -20,6 +20,7 @@ export interface WebviewMessage {
 		| "refreshClineRules"
 		| "openMcpSettings"
 		| "autoApprovalSettings"
+		| "togglePlanActMode"
 		| "openExtensionSettings"
 		| "requestVsCodeLmModels"
 		| "showAccountViewClicked"

--- a/webview-ui/src/components/chat/ChatTextArea.tsx
+++ b/webview-ui/src/components/chat/ChatTextArea.tsx
@@ -966,7 +966,8 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 			}
 			setTimeout(() => {
 				const newMode = chatSettings.mode === "plan" ? "act" : "plan"
-				StateServiceClient.togglePlanActMode({
+				vscode.postMessage({
+					type: "togglePlanActMode",
 					chatSettings: {
 						mode: newMode,
 					},

--- a/webview-ui/src/components/settings/SettingsView.tsx
+++ b/webview-ui/src/components/settings/SettingsView.tsx
@@ -115,7 +115,8 @@ const SettingsView = ({ onDone }: SettingsViewProps) => {
 			switch (message.type) {
 				case "didUpdateSettings":
 					if (pendingTabChange) {
-						StateServiceClient.togglePlanActMode({
+						vscode.postMessage({
+							type: "togglePlanActMode",
 							chatSettings: {
 								mode: pendingTabChange,
 							},


### PR DESCRIPTION
Hot Fix for #3647 

### Description
<img width="680" alt="image" src="https://github.com/user-attachments/assets/42d2e176-0773-4e12-bf4e-d369af6a1b83" />


### Test Procedure
- Go in debugger
- Toggle between plan and act many times and it should work perfectly

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [X] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [X] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [X] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [X] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [X] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Reverts protobus changes for toggling 'plan' and 'act' modes, updating message handling and UI components to ensure correct functionality.
> 
>   - **Behavior**:
>     - Reverts protobus changes for toggling between 'plan' and 'act' modes.
>     - Adds `togglePlanActMode` case in `Controller.handleWebviewMessage()` in `index.ts`.
>     - Updates `ChatTextArea.tsx` to send `togglePlanActMode` message with `chatSettings` and `chatContent`.
>     - Updates `SettingsView.tsx` to handle `togglePlanActMode` message on settings update.
>   - **Message Types**:
>     - Adds `togglePlanActMode` to `WebviewMessage` type in `WebviewMessage.ts`.
>   - **UI Components**:
>     - Modifies `ChatTextArea.tsx` to handle mode toggle via UI interaction.
>     - Modifies `SettingsView.tsx` to handle mode toggle when settings are updated.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for c732fe948060eca6d6329a562f7ea5323312c091. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->