### PR TITLE
Migrate openSettings protobus

### DIFF
--- a/.changeset/cold-rice-exist.md
+++ b/.changeset/cold-rice-exist.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": minor
+---
+
+Migrate openSettings message to use state navigation handlers

--- a/src/core/controller/index.ts
+++ b/src/core/controller/index.ts
@@ -423,13 +423,6 @@ export class Controller {
 				break
 			}
 			// telemetry
-			case "openSettings": {
-				await this.postMessageToWebview({
-					type: "action",
-					action: "settingsButtonClicked",
-				})
-				break
-			}
 			case "telemetrySetting": {
 				if (message.telemetrySetting) {
 					await this.updateTelemetrySetting(message.telemetrySetting)

--- a/src/shared/WebviewMessage.ts
+++ b/src/shared/WebviewMessage.ts
@@ -30,7 +30,6 @@ export interface WebviewMessage {
 		| "searchCommits"
 		| "fetchLatestMcpServersFromHub"
 		| "telemetrySetting"
-		| "openSettings"
 		| "invoke"
 		| "updateSettings"
 		| "clearAllTaskHistory"

--- a/webview-ui/src/components/browser/BrowserSettingsMenu.tsx
+++ b/webview-ui/src/components/browser/BrowserSettingsMenu.tsx
@@ -13,7 +13,7 @@ interface ConnectionInfo {
 }
 
 export const BrowserSettingsMenu = () => {
-	const { browserSettings } = useExtensionState()
+	const { browserSettings, navigateToSettings } = useExtensionState()
 	const containerRef = useRef<HTMLDivElement>(null)
 	const [showInfoPopover, setShowInfoPopover] = useState(false)
 	const [connectionInfo, setConnectionInfo] = useState<ConnectionInfo>({
@@ -65,10 +65,8 @@ export const BrowserSettingsMenu = () => {
 	}, [showInfoPopover])
 
 	const openBrowserSettings = () => {
-		// First open the settings panel
-		vscode.postMessage({
-			type: "openSettings",
-		})
+		// First open the settings panel using direct navigation
+		navigateToSettings()
 
 		// After a short delay, send a message to scroll to browser settings
 		setTimeout(async () => {

--- a/webview-ui/src/components/common/TelemetryBanner.tsx
+++ b/webview-ui/src/components/common/TelemetryBanner.tsx
@@ -1,6 +1,7 @@
 import { VSCodeButton, VSCodeLink } from "@vscode/webview-ui-toolkit/react"
 import { memo, useState } from "react"
 import styled from "styled-components"
+import { useExtensionState } from "@/context/ExtensionStateContext"
 import { vscode } from "@/utils/vscode"
 import { TelemetrySetting } from "@shared/TelemetrySetting"
 
@@ -45,9 +46,11 @@ const ButtonContainer = styled.div`
 `
 
 const TelemetryBanner = () => {
+	const { navigateToSettings } = useExtensionState()
+
 	const handleOpenSettings = () => {
 		handleClose()
-		vscode.postMessage({ type: "openSettings" })
+		navigateToSettings()
 	}
 
 	const handleClose = () => {


### PR DESCRIPTION
### Description

Use the state navigation handlers instead of passing the message to extension

### Test Procedure

Test that the navigation from browser tab and telemetry banner still works.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [x] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Migrate `openSettings` message handling to use state navigation handlers, updating `Controller`, `WebviewMessage`, and UI components.
> 
>   - **Behavior**:
>     - Migrates `openSettings` message handling to use state navigation handlers in `Controller` class.
>     - Removes `openSettings` case from `handleWebviewMessage()` in `index.ts`.
>     - Updates `WebviewMessage` interface to remove `openSettings` type.
>   - **Components**:
>     - Updates `BrowserSettingsMenu` and `TelemetryBanner` to use `navigateToSettings` from `useExtensionState`.
>   - **Misc**:
>     - Adds changeset `cold-rice-exist.md` to document migration.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 62463284d968f5baf539dc77ca9b9cb26a3a25b2. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->