### PR TITLE
Migrate refreshClineRules protobus

### DIFF
--- a/.changeset/eight-sheep-remember.md
+++ b/.changeset/eight-sheep-remember.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": minor
+---
+
+Migrate refreshClineRules to protobus

--- a/proto/file.proto
+++ b/proto/file.proto
@@ -46,6 +46,18 @@ service FileService {
   
   // Toggle a Windsurf rule (enable or disable)
   rpc toggleWindsurfRule(ToggleWindsurfRuleRequest) returns (ClineRulesToggles);
+  
+  // Refreshes all rule toggles (Cline, External, and Workflows)
+  rpc refreshRules(EmptyRequest) returns (RefreshedRules);
+}
+
+// Response for refreshRules operation
+message RefreshedRules {
+  ClineRulesToggles global_cline_rules_toggles = 1;
+  ClineRulesToggles local_cline_rules_toggles = 2;
+  ClineRulesToggles local_cursor_rules_toggles = 3;
+  ClineRulesToggles local_windsurf_rules_toggles = 4;
+  ClineRulesToggles workflow_toggles = 5;
 }
 
 // Request to toggle a Windsurf rule

--- a/src/core/controller/file/methods.ts
+++ b/src/core/controller/file/methods.ts
@@ -10,6 +10,7 @@ import { getRelativePaths } from "./getRelativePaths"
 import { openFile } from "./openFile"
 import { openImage } from "./openImage"
 import { openMention } from "./openMention"
+import { refreshRules } from "./refreshRules"
 import { searchCommits } from "./searchCommits"
 import { searchFiles } from "./searchFiles"
 import { selectImages } from "./selectImages"
@@ -27,6 +28,7 @@ export function registerAllMethods(): void {
 	registerMethod("openFile", openFile)
 	registerMethod("openImage", openImage)
 	registerMethod("openMention", openMention)
+	registerMethod("refreshRules", refreshRules)
 	registerMethod("searchCommits", searchCommits)
 	registerMethod("searchFiles", searchFiles)
 	registerMethod("selectImages", selectImages)

--- a/src/core/controller/file/refreshRules.ts
+++ b/src/core/controller/file/refreshRules.ts
@@ -1,0 +1,32 @@
+import { EmptyRequest } from "@shared/proto/common"
+import { RefreshedRules } from "@shared/proto/file"
+import type { Controller } from "../index"
+import { refreshClineRulesToggles } from "@core/context/instructions/user-instructions/cline-rules"
+import { refreshExternalRulesToggles } from "@core/context/instructions/user-instructions/external-rules"
+import { refreshWorkflowToggles } from "@core/context/instructions/user-instructions/workflows"
+import { cwd } from "@core/task"
+
+/**
+ * Refreshes all rule toggles (Cline, External, and Workflows)
+ * @param controller The controller instance
+ * @param _request The empty request
+ * @returns RefreshedRules containing updated toggles for all rule types
+ */
+export async function refreshRules(controller: Controller, _request: EmptyRequest): Promise<RefreshedRules> {
+	try {
+		const { globalToggles, localToggles } = await refreshClineRulesToggles(controller.context, cwd)
+		const { cursorLocalToggles, windsurfLocalToggles } = await refreshExternalRulesToggles(controller.context, cwd)
+		const workflowToggles = await refreshWorkflowToggles(controller.context, cwd)
+
+		return {
+			globalClineRulesToggles: { toggles: globalToggles },
+			localClineRulesToggles: { toggles: localToggles },
+			localCursorRulesToggles: { toggles: cursorLocalToggles },
+			localWindsurfRulesToggles: { toggles: windsurfLocalToggles },
+			workflowToggles: { toggles: workflowToggles },
+		}
+	} catch (error) {
+		console.error("Failed to refresh rules:", error)
+		throw error
+	}
+}

--- a/src/core/controller/index.ts
+++ b/src/core/controller/index.ts
@@ -321,12 +321,6 @@ export class Controller {
 				await updateGlobalState(this.context, "lastShownAnnouncementId", this.latestAnnouncementId)
 				await this.postStateToWebview()
 				break
-			case "refreshClineRules":
-				await refreshClineRulesToggles(this.context, cwd)
-				await refreshExternalRulesToggles(this.context, cwd)
-				await refreshWorkflowToggles(this.context, cwd)
-				await this.postStateToWebview()
-				break
 			case "openInBrowser":
 				if (message.url) {
 					vscode.env.openExternal(vscode.Uri.parse(message.url))

--- a/src/shared/WebviewMessage.ts
+++ b/src/shared/WebviewMessage.ts
@@ -17,7 +17,6 @@ export interface WebviewMessage {
 		| "didShowAnnouncement"
 		| "openInBrowser"
 		| "showChatView"
-		| "refreshClineRules"
 		| "openMcpSettings"
 		| "autoApprovalSettings"
 		| "togglePlanActMode"

--- a/src/shared/proto/file.ts
+++ b/src/shared/proto/file.ts
@@ -10,6 +10,15 @@ import { Empty, EmptyRequest, Metadata, StringArray, StringRequest } from "./com
 
 export const protobufPackage = "cline"
 
+/** Response for refreshRules operation */
+export interface RefreshedRules {
+	globalClineRulesToggles?: ClineRulesToggles | undefined
+	localClineRulesToggles?: ClineRulesToggles | undefined
+	localCursorRulesToggles?: ClineRulesToggles | undefined
+	localWindsurfRulesToggles?: ClineRulesToggles | undefined
+	workflowToggles?: ClineRulesToggles | undefined
+}
+
 /** Request to toggle a Windsurf rule */
 export interface ToggleWindsurfRuleRequest {
 	metadata?: Metadata | undefined
@@ -130,6 +139,159 @@ export interface ToggleCursorRuleRequest {
 	rulePath: string
 	/** Whether to enable or disable the rule */
 	enabled: boolean
+}
+
+function createBaseRefreshedRules(): RefreshedRules {
+	return {
+		globalClineRulesToggles: undefined,
+		localClineRulesToggles: undefined,
+		localCursorRulesToggles: undefined,
+		localWindsurfRulesToggles: undefined,
+		workflowToggles: undefined,
+	}
+}
+
+export const RefreshedRules: MessageFns<RefreshedRules> = {
+	encode(message: RefreshedRules, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+		if (message.globalClineRulesToggles !== undefined) {
+			ClineRulesToggles.encode(message.globalClineRulesToggles, writer.uint32(10).fork()).join()
+		}
+		if (message.localClineRulesToggles !== undefined) {
+			ClineRulesToggles.encode(message.localClineRulesToggles, writer.uint32(18).fork()).join()
+		}
+		if (message.localCursorRulesToggles !== undefined) {
+			ClineRulesToggles.encode(message.localCursorRulesToggles, writer.uint32(26).fork()).join()
+		}
+		if (message.localWindsurfRulesToggles !== undefined) {
+			ClineRulesToggles.encode(message.localWindsurfRulesToggles, writer.uint32(34).fork()).join()
+		}
+		if (message.workflowToggles !== undefined) {
+			ClineRulesToggles.encode(message.workflowToggles, writer.uint32(42).fork()).join()
+		}
+		return writer
+	},
+
+	decode(input: BinaryReader | Uint8Array, length?: number): RefreshedRules {
+		const reader = input instanceof BinaryReader ? input : new BinaryReader(input)
+		let end = length === undefined ? reader.len : reader.pos + length
+		const message = createBaseRefreshedRules()
+		while (reader.pos < end) {
+			const tag = reader.uint32()
+			switch (tag >>> 3) {
+				case 1: {
+					if (tag !== 10) {
+						break
+					}
+
+					message.globalClineRulesToggles = ClineRulesToggles.decode(reader, reader.uint32())
+					continue
+				}
+				case 2: {
+					if (tag !== 18) {
+						break
+					}
+
+					message.localClineRulesToggles = ClineRulesToggles.decode(reader, reader.uint32())
+					continue
+				}
+				case 3: {
+					if (tag !== 26) {
+						break
+					}
+
+					message.localCursorRulesToggles = ClineRulesToggles.decode(reader, reader.uint32())
+					continue
+				}
+				case 4: {
+					if (tag !== 34) {
+						break
+					}
+
+					message.localWindsurfRulesToggles = ClineRulesToggles.decode(reader, reader.uint32())
+					continue
+				}
+				case 5: {
+					if (tag !== 42) {
+						break
+					}
+
+					message.workflowToggles = ClineRulesToggles.decode(reader, reader.uint32())
+					continue
+				}
+			}
+			if ((tag & 7) === 4 || tag === 0) {
+				break
+			}
+			reader.skip(tag & 7)
+		}
+		return message
+	},
+
+	fromJSON(object: any): RefreshedRules {
+		return {
+			globalClineRulesToggles: isSet(object.globalClineRulesToggles)
+				? ClineRulesToggles.fromJSON(object.globalClineRulesToggles)
+				: undefined,
+			localClineRulesToggles: isSet(object.localClineRulesToggles)
+				? ClineRulesToggles.fromJSON(object.localClineRulesToggles)
+				: undefined,
+			localCursorRulesToggles: isSet(object.localCursorRulesToggles)
+				? ClineRulesToggles.fromJSON(object.localCursorRulesToggles)
+				: undefined,
+			localWindsurfRulesToggles: isSet(object.localWindsurfRulesToggles)
+				? ClineRulesToggles.fromJSON(object.localWindsurfRulesToggles)
+				: undefined,
+			workflowToggles: isSet(object.workflowToggles) ? ClineRulesToggles.fromJSON(object.workflowToggles) : undefined,
+		}
+	},
+
+	toJSON(message: RefreshedRules): unknown {
+		const obj: any = {}
+		if (message.globalClineRulesToggles !== undefined) {
+			obj.globalClineRulesToggles = ClineRulesToggles.toJSON(message.globalClineRulesToggles)
+		}
+		if (message.localClineRulesToggles !== undefined) {
+			obj.localClineRulesToggles = ClineRulesToggles.toJSON(message.localClineRulesToggles)
+		}
+		if (message.localCursorRulesToggles !== undefined) {
+			obj.localCursorRulesToggles = ClineRulesToggles.toJSON(message.localCursorRulesToggles)
+		}
+		if (message.localWindsurfRulesToggles !== undefined) {
+			obj.localWindsurfRulesToggles = ClineRulesToggles.toJSON(message.localWindsurfRulesToggles)
+		}
+		if (message.workflowToggles !== undefined) {
+			obj.workflowToggles = ClineRulesToggles.toJSON(message.workflowToggles)
+		}
+		return obj
+	},
+
+	create<I extends Exact<DeepPartial<RefreshedRules>, I>>(base?: I): RefreshedRules {
+		return RefreshedRules.fromPartial(base ?? ({} as any))
+	},
+	fromPartial<I extends Exact<DeepPartial<RefreshedRules>, I>>(object: I): RefreshedRules {
+		const message = createBaseRefreshedRules()
+		message.globalClineRulesToggles =
+			object.globalClineRulesToggles !== undefined && object.globalClineRulesToggles !== null
+				? ClineRulesToggles.fromPartial(object.globalClineRulesToggles)
+				: undefined
+		message.localClineRulesToggles =
+			object.localClineRulesToggles !== undefined && object.localClineRulesToggles !== null
+				? ClineRulesToggles.fromPartial(object.localClineRulesToggles)
+				: undefined
+		message.localCursorRulesToggles =
+			object.localCursorRulesToggles !== undefined && object.localCursorRulesToggles !== null
+				? ClineRulesToggles.fromPartial(object.localCursorRulesToggles)
+				: undefined
+		message.localWindsurfRulesToggles =
+			object.localWindsurfRulesToggles !== undefined && object.localWindsurfRulesToggles !== null
+				? ClineRulesToggles.fromPartial(object.localWindsurfRulesToggles)
+				: undefined
+		message.workflowToggles =
+			object.workflowToggles !== undefined && object.workflowToggles !== null
+				? ClineRulesToggles.fromPartial(object.workflowToggles)
+				: undefined
+		return message
+	},
 }
 
 function createBaseToggleWindsurfRuleRequest(): ToggleWindsurfRuleRequest {
@@ -1601,6 +1763,15 @@ export const FileServiceDefinition = {
 			requestType: ToggleWindsurfRuleRequest,
 			requestStream: false,
 			responseType: ClineRulesToggles,
+			responseStream: false,
+			options: {},
+		},
+		/** Refreshes all rule toggles (Cline, External, and Workflows) */
+		refreshRules: {
+			name: "refreshRules",
+			requestType: EmptyRequest,
+			requestStream: false,
+			responseType: RefreshedRules,
 			responseStream: false,
 			options: {},
 		},

--- a/src/standalone/server-setup.ts
+++ b/src/standalone/server-setup.ts
@@ -34,6 +34,7 @@ import { searchFiles } from "../core/controller/file/searchFiles"
 import { toggleClineRule } from "../core/controller/file/toggleClineRule"
 import { toggleCursorRule } from "../core/controller/file/toggleCursorRule"
 import { toggleWindsurfRule } from "../core/controller/file/toggleWindsurfRule"
+import { refreshRules } from "../core/controller/file/refreshRules"
 
 // Mcp Service
 import { toggleMcpServer } from "../core/controller/mcp/toggleMcpServer"
@@ -130,6 +131,7 @@ export function addServices(
 		toggleClineRule: wrapper(toggleClineRule, controller),
 		toggleCursorRule: wrapper(toggleCursorRule, controller),
 		toggleWindsurfRule: wrapper(toggleWindsurfRule, controller),
+		refreshRules: wrapper(refreshRules, controller),
 	})
 
 	// Mcp Service

--- a/webview-ui/src/components/cline-rules/ClineRulesToggleModal.tsx
+++ b/webview-ui/src/components/cline-rules/ClineRulesToggleModal.tsx
@@ -8,7 +8,8 @@ import { VSCodeButton } from "@vscode/webview-ui-toolkit/react"
 import RulesToggleList from "./RulesToggleList"
 import Tooltip from "@/components/common/Tooltip"
 import styled from "styled-components"
-import { ClineRulesToggles, ToggleWindsurfRuleRequest } from "@shared/proto/file"
+import { ClineRulesToggles, RefreshedRules, ToggleWindsurfRuleRequest } from "@shared/proto/file"
+import { EmptyRequest } from "@shared/proto/common"
 
 const ClineRulesToggleModal: React.FC = () => {
 	const {
@@ -21,6 +22,7 @@ const ClineRulesToggleModal: React.FC = () => {
 		setLocalClineRulesToggles,
 		setLocalCursorRulesToggles,
 		setLocalWindsurfRulesToggles,
+		setWorkflowToggles,
 	} = useExtensionState()
 	const [isVisible, setIsVisible] = useState(false)
 	const buttonRef = useRef<HTMLDivElement>(null)
@@ -32,7 +34,28 @@ const ClineRulesToggleModal: React.FC = () => {
 
 	useEffect(() => {
 		if (isVisible) {
-			vscode.postMessage({ type: "refreshClineRules" })
+			FileServiceClient.refreshRules({} as EmptyRequest)
+				.then((response: RefreshedRules) => {
+					// Update state with the response data using all available setters
+					if (response.globalClineRulesToggles?.toggles) {
+						setGlobalClineRulesToggles(response.globalClineRulesToggles.toggles)
+					}
+					if (response.localClineRulesToggles?.toggles) {
+						setLocalClineRulesToggles(response.localClineRulesToggles.toggles)
+					}
+					if (response.localCursorRulesToggles?.toggles) {
+						setLocalCursorRulesToggles(response.localCursorRulesToggles.toggles)
+					}
+					if (response.localWindsurfRulesToggles?.toggles) {
+						setLocalWindsurfRulesToggles(response.localWindsurfRulesToggles.toggles)
+					}
+					if (response.workflowToggles?.toggles) {
+						setWorkflowToggles(response.workflowToggles.toggles)
+					}
+				})
+				.catch((error) => {
+					console.error("Failed to refresh rules:", error)
+				})
 		}
 	}, [isVisible])
 

--- a/webview-ui/src/context/ExtensionStateContext.tsx
+++ b/webview-ui/src/context/ExtensionStateContext.tsx
@@ -55,6 +55,7 @@ interface ExtensionStateContextType extends ExtensionState {
 	setLocalClineRulesToggles: (toggles: Record<string, boolean>) => void
 	setLocalCursorRulesToggles: (toggles: Record<string, boolean>) => void
 	setLocalWindsurfRulesToggles: (toggles: Record<string, boolean>) => void
+	setWorkflowToggles: (toggles: Record<string, boolean>) => void
 	setMcpMarketplaceCatalog: (value: McpMarketplaceCatalog) => void
 
 	// Navigation state setters
@@ -539,6 +540,11 @@ export const ExtensionStateContextProvider: React.FC<{
 			setState((prevState) => ({
 				...prevState,
 				localWindsurfRulesToggles: toggles,
+			})),
+		setWorkflowToggles: (toggles) =>
+			setState((prevState) => ({
+				...prevState,
+				workflowToggles: toggles,
 			})),
 		setMcpTab,
 	}


### PR DESCRIPTION
### Description

Migrate refreshClineRules protobus

### Test Procedure

Tested that the message is being passed in the webview logs upon opening the cline rules modal

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [x] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Migrates `refreshClineRules` to `refreshRules` gRPC method, updating proto definitions, controller logic, and UI components to handle new response structure.
> 
>   - **Behavior**:
>     - Replaces `refreshClineRules` with `refreshRules` gRPC method in `file.proto` and `methods.ts`.
>     - Updates `ClineRulesToggleModal.tsx` to use `FileServiceClient.refreshRules()` and handle `RefreshedRules` response.
>   - **Proto Definitions**:
>     - Adds `refreshRules` RPC method to `FileService` in `file.proto`.
>     - Defines `RefreshedRules` message in `file.proto` and `file.ts`.
>   - **Controller**:
>     - Removes `refreshClineRules` case from `Controller.handleWebviewMessage()` in `index.ts`.
>     - Registers `refreshRules` method in `server-setup.ts`.
>   - **UI**:
>     - Updates `ClineRulesToggleModal.tsx` to handle new `RefreshedRules` response structure.
>     - Adds `setWorkflowToggles` to `ExtensionStateContext.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for b10f8549f556ee3083958febd2dfac1efc0f0211. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->