### PR TITLE
Add ability to customize Git commit message instructions

### DIFF
--- a/.changeset/poor-panthers-wink.md
+++ b/.changeset/poor-panthers-wink.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": minor
+---
+
+Add ability to customize Git commit message instructions

--- a/src/core/storage/state-keys.ts
+++ b/src/core/storage/state-keys.ts
@@ -56,6 +56,7 @@ export type GlobalStateKey =
 	| "globalClineRulesToggles"
 	| "browserSettings"
 	| "chatSettings"
+	| "gitSettings"
 	| "vsCodeLmModelSelector"
 	| "userInfo"
 	| "previousModeApiProvider"

--- a/src/core/storage/state.ts
+++ b/src/core/storage/state.ts
@@ -2,12 +2,14 @@ import * as vscode from "vscode"
 import { DEFAULT_CHAT_SETTINGS, OpenAIReasoningEffort } from "@shared/ChatSettings"
 import { DEFAULT_BROWSER_SETTINGS } from "@shared/BrowserSettings"
 import { DEFAULT_AUTO_APPROVAL_SETTINGS } from "@shared/AutoApprovalSettings"
+import { DEFAULT_GIT_SETTINGS } from "@shared/GitSettings"
 import { GlobalStateKey, SecretKey } from "./state-keys"
 import { ApiConfiguration, ApiProvider, BedrockModelId, ModelInfo } from "@shared/api"
 import { HistoryItem } from "@shared/HistoryItem"
 import { AutoApprovalSettings } from "@shared/AutoApprovalSettings"
 import { BrowserSettings } from "@shared/BrowserSettings"
 import { ChatSettings } from "@shared/ChatSettings"
+import { GitSettings } from "@shared/GitSettings"
 import { TelemetrySetting } from "@shared/TelemetrySetting"
 import { UserInfo } from "@shared/UserInfo"
 import { ClineRulesToggles } from "@shared/cline-rules"
@@ -128,6 +130,7 @@ export async function getAllExtensionState(context: vscode.ExtensionContext) {
 		autoApprovalSettings,
 		browserSettings,
 		chatSettings,
+		gitSettings,
 		vsCodeLmModelSelector,
 		liteLlmBaseUrl,
 		liteLlmModelId,
@@ -215,6 +218,7 @@ export async function getAllExtensionState(context: vscode.ExtensionContext) {
 		getGlobalState(context, "autoApprovalSettings") as Promise<AutoApprovalSettings | undefined>,
 		getGlobalState(context, "browserSettings") as Promise<BrowserSettings | undefined>,
 		getGlobalState(context, "chatSettings") as Promise<ChatSettings | undefined>,
+		getGlobalState(context, "gitSettings") as Promise<GitSettings | undefined>,
 		getGlobalState(context, "vsCodeLmModelSelector") as Promise<vscode.LanguageModelChatSelector | undefined>,
 		getGlobalState(context, "liteLlmBaseUrl") as Promise<string | undefined>,
 		getGlobalState(context, "liteLlmModelId") as Promise<string | undefined>,
@@ -367,6 +371,10 @@ export async function getAllExtensionState(context: vscode.ExtensionContext) {
 		chatSettings: {
 			...DEFAULT_CHAT_SETTINGS, // Apply defaults first
 			...(chatSettings || {}), // Spread fetched chatSettings, which includes preferredLanguage, and openAIReasoningEffort
+		},
+		gitSettings: {
+			...DEFAULT_GIT_SETTINGS, // Apply defaults first
+			...(gitSettings || {}), // Spread fetched gitSettings
 		},
 		userInfo,
 		previousModeApiProvider,

--- a/src/integrations/git/commit-message-generator.ts
+++ b/src/integrations/git/commit-message-generator.ts
@@ -4,9 +4,10 @@ import { getWorkingState } from "@utils/git"
 /**
  * Formats the git diff into a prompt for the AI
  * @param gitDiff The git diff to format
+ * @param instructions Optional custom instructions for the commit message format
  * @returns A formatted prompt for the AI
  */
-function formatGitDiffPrompt(gitDiff: string): string {
+export function formatGitDiffPrompt(gitDiff: string, instructions?: string): string {
 	// Limit the diff size to avoid token limits
 	const maxDiffLength = 5000
 	let truncatedDiff = gitDiff
@@ -15,15 +16,20 @@ function formatGitDiffPrompt(gitDiff: string): string {
 		truncatedDiff = gitDiff.substring(0, maxDiffLength) + "\n\n[Diff truncated due to size]"
 	}
 
+	// Use custom instructions if provided, otherwise use default
+	const commitInstructions =
+		instructions ||
+		`1. Start with a short summary (50-72 characters)
+2. Use the imperative mood (e.g., "Add feature" not "Added feature")
+3. Describe what was changed and why
+4. Be clear and descriptive`
+
 	return `Based on the following git diff, generate a concise and descriptive commit message:
 
 ${truncatedDiff}
 
 The commit message should:
-1. Start with a short summary (50-72 characters)
-2. Use the imperative mood (e.g., "Add feature" not "Added feature")
-3. Describe what was changed and why
-4. Be clear and descriptive
+${commitInstructions}
 
 Commit message:`
 }

--- a/src/shared/ExtensionMessage.ts
+++ b/src/shared/ExtensionMessage.ts
@@ -5,6 +5,7 @@ import { ApiConfiguration, ModelInfo } from "./api"
 import { AutoApprovalSettings } from "./AutoApprovalSettings"
 import { BrowserSettings } from "./BrowserSettings"
 import { ChatSettings } from "./ChatSettings"
+import { GitSettings } from "./GitSettings"
 import { HistoryItem } from "./HistoryItem"
 import { McpServer, McpMarketplaceCatalog, McpDownloadResponse, McpViewTab } from "./mcp"
 import { TelemetrySetting } from "./TelemetrySetting"
@@ -118,6 +119,7 @@ export interface ExtensionState {
 	browserSettings: BrowserSettings
 	remoteBrowserHost?: string
 	chatSettings: ChatSettings
+	gitSettings: GitSettings
 	checkpointTrackerErrorMessage?: string
 	clineMessages: ClineMessage[]
 	currentTaskItem?: HistoryItem

--- a/src/shared/GitSettings.ts
+++ b/src/shared/GitSettings.ts
@@ -1,0 +1,10 @@
+export interface GitSettings {
+	commitMessageInstructions: string
+}
+
+export const DEFAULT_GIT_SETTINGS: GitSettings = {
+	commitMessageInstructions: `1. Start with a short summary (50-72 characters)
+2. Use the imperative mood (e.g., "Add feature" not "Added feature")
+3. Describe what was changed and why
+4. Be clear and descriptive`,
+}

--- a/src/shared/WebviewMessage.ts
+++ b/src/shared/WebviewMessage.ts
@@ -2,6 +2,7 @@ import { ApiConfiguration } from "./api"
 import { AutoApprovalSettings } from "./AutoApprovalSettings"
 import { BrowserSettings } from "./BrowserSettings"
 import { ChatSettings } from "./ChatSettings"
+import { GitSettings } from "./GitSettings"
 import { UserInfo } from "./UserInfo"
 import { ChatContent } from "./ChatContent"
 import { TelemetrySetting } from "./TelemetrySetting"
@@ -49,6 +50,7 @@ export interface WebviewMessage {
 	autoApprovalSettings?: AutoApprovalSettings
 	browserSettings?: BrowserSettings
 	chatSettings?: ChatSettings
+	gitSettings?: GitSettings
 	chatContent?: ChatContent
 	mcpId?: string
 	timeout?: number

--- a/webview-ui/src/components/settings/GitSettingsSection.tsx
+++ b/webview-ui/src/components/settings/GitSettingsSection.tsx
@@ -1,0 +1,40 @@
+import React from "react"
+import { VSCodeTextArea } from "@vscode/webview-ui-toolkit/react"
+import { useExtensionState } from "../../context/ExtensionStateContext"
+import { memo } from "react"
+import { DEFAULT_GIT_SETTINGS } from "../../../../src/shared/GitSettings"
+
+const GitSettingsSection: React.FC = () => {
+	const { gitSettings, setGitSettings } = useExtensionState()
+
+	const handleInstructionsChange = (e: any) => {
+		setGitSettings({
+			...gitSettings,
+			commitMessageInstructions: e.target.value || DEFAULT_GIT_SETTINGS.commitMessageInstructions,
+		})
+	}
+
+	return (
+		<div style={{ marginBottom: 20, borderTop: "1px solid var(--vscode-panel-border)", paddingTop: 15 }}>
+			<h3 style={{ color: "var(--vscode-foreground)", margin: "0 0 10px 0", fontSize: "14px" }}>Git Settings</h3>
+
+			<div className="mb-[5px]">
+				<VSCodeTextArea
+					value={gitSettings?.commitMessageInstructions || DEFAULT_GIT_SETTINGS.commitMessageInstructions}
+					className="w-full"
+					resize="vertical"
+					rows={4}
+					placeholder={DEFAULT_GIT_SETTINGS.commitMessageInstructions}
+					onInput={handleInstructionsChange}>
+					<span className="font-medium">Commit Message Instructions</span>
+				</VSCodeTextArea>
+				<p className="text-xs mt-[5px] text-[var(--vscode-descriptionForeground)]">
+					These instructions are used when generating commit messages. They define the format and style of the commit
+					message.
+				</p>
+			</div>
+		</div>
+	)
+}
+
+export default memo(GitSettingsSection)

--- a/webview-ui/src/components/settings/SettingsView.tsx
+++ b/webview-ui/src/components/settings/SettingsView.tsx
@@ -21,6 +21,7 @@ import { StateServiceClient } from "@/services/grpc-client"
 import FeatureSettingsSection from "./FeatureSettingsSection"
 import BrowserSettingsSection from "./BrowserSettingsSection"
 import TerminalSettingsSection from "./TerminalSettingsSection"
+import GitSettingsSection from "./GitSettingsSection"
 import { FEATURE_FLAGS } from "@shared/services/feature-flags/feature-flags"
 const { IS_DEV } = process.env
 
@@ -102,7 +103,7 @@ const SettingsView = ({ onDone }: SettingsViewProps) => {
 	so trying to use useEffect with a dependency array of only one value for example will use any 
 	other variables' old values. In most cases you don't want this, and should opt to use react-use 
 	hooks.
-    
+	  
 		// uses someVar and anotherVar
 	// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [someVar])
@@ -272,6 +273,9 @@ const SettingsView = ({ onDone }: SettingsViewProps) => {
 
 				{/* Terminal Settings Section */}
 				<TerminalSettingsSection />
+
+				{/* Git Settings Section */}
+				<GitSettingsSection />
 
 				{IS_DEV && (
 					<>

--- a/webview-ui/src/context/ExtensionStateContext.tsx
+++ b/webview-ui/src/context/ExtensionStateContext.tsx
@@ -3,6 +3,7 @@ import { useEvent } from "react-use"
 import { StateServiceClient } from "../services/grpc-client"
 import { EmptyRequest } from "@shared/proto/common"
 import { DEFAULT_AUTO_APPROVAL_SETTINGS } from "@shared/AutoApprovalSettings"
+import { DEFAULT_GIT_SETTINGS, GitSettings } from "@shared/GitSettings"
 import { ExtensionMessage, ExtensionState, DEFAULT_PLATFORM } from "@shared/ExtensionMessage"
 import {
 	ApiConfiguration,
@@ -50,6 +51,7 @@ interface ExtensionStateContextType extends ExtensionState {
 	setMcpMarketplaceEnabled: (value: boolean) => void
 	setShellIntegrationTimeout: (value: number) => void
 	setChatSettings: (value: ChatSettings) => void
+	setGitSettings: (value: GitSettings) => void
 	setMcpServers: (value: McpServer[]) => void
 	setGlobalClineRulesToggles: (toggles: Record<string, boolean>) => void
 	setLocalClineRulesToggles: (toggles: Record<string, boolean>) => void
@@ -152,6 +154,7 @@ export const ExtensionStateContextProvider: React.FC<{
 		autoApprovalSettings: DEFAULT_AUTO_APPROVAL_SETTINGS,
 		browserSettings: DEFAULT_BROWSER_SETTINGS,
 		chatSettings: DEFAULT_CHAT_SETTINGS,
+		gitSettings: DEFAULT_GIT_SETTINGS,
 		platform: DEFAULT_PLATFORM,
 		telemetrySetting: "unset",
 		vscMachineId: "",
@@ -545,6 +548,11 @@ export const ExtensionStateContextProvider: React.FC<{
 			setState((prevState) => ({
 				...prevState,
 				workflowToggles: toggles,
+			})),
+		setGitSettings: (value) =>
+			setState((prevState) => ({
+				...prevState,
+				gitSettings: value,
 			})),
 		setMcpTab,
 	}


### PR DESCRIPTION

### Description

This PR adds the ability for users to customize the instructions used for generating Git commit messages through the Cline settings UI.

The implementation:

- Creates a new `GitSettings` interface with a `commitMessageInstructions` property
- Adds Git settings to the global state management system
- Modifies the `formatGitDiffPrompt` function to accept custom instructions
- Adds a new settings section in the UI for customizing commit message instructions
- Updates the controller to use these custom instructions when generating commit messages

This change maintains backward compatibility by providing the same default instructions that were previously hardcoded.

### Test Procedure

Tested by:

- Adding the Git settings section to the settings UI
- Modifying the commit message instructions in settings and verifying they are used when generating a commit message
- Ensuring the default instructions are used when no custom instructions are provided
- Verifying that both the commit-message-generator.ts and controller/index.ts use the same configuration


### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [x] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots
<img width="764" alt="스크린샷 2025-05-21 오후 7 17 10" src="https://github.com/user-attachments/assets/5d883e6b-4f6e-4827-bfbe-2b489b1b9027" />

### Additional Notes

This implementation is based on issues #3318  and #3468

