### PR TITLE
Adds telemetry to record the usage of keyboard  and lightbulb icon shortcuts in Cline

### DIFF
--- a/.changeset/five-bikes-impress.md
+++ b/.changeset/five-bikes-impress.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Fix edge case of changing language in settings

--- a/.changeset/five-bikes-impress.md
+++ b/.changeset/five-bikes-impress.md
@@ -2,4 +2,4 @@
 "claude-dev": patch
 ---
 
-Fix edge case of changing language in settings
+Adding Telemetry for button clicks

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -310,8 +310,8 @@ export async function activate(context: vscode.ExtensionContext) {
 				languageId,
 				Array.isArray(diagnostics) ? diagnostics : undefined,
 			)
-			const taskId = visibleWebview?.controller.task?.taskId // Corrected to use .task?.taskId
-			telemetryService.captureButtonClick("codeAction_addToChat", taskId) // taskId added
+			const taskId = visibleWebview?.controller.task?.taskId
+			telemetryService.captureButtonClick("codeAction_addToChat", taskId)
 		}),
 	)
 
@@ -484,7 +484,7 @@ export async function activate(context: vscode.ExtensionContext) {
 			const visibleWebview = WebviewProvider.getVisibleInstance()
 			await visibleWebview?.controller.fixWithCline(selectedText, filePath, languageId, diagnostics)
 			const taskId = visibleWebview?.controller.task?.taskId
-			telemetryService.captureButtonClick("codeAction_fixWithCline", taskId) // taskId added
+			telemetryService.captureButtonClick("codeAction_fixWithCline", taskId)
 		}),
 	)
 
@@ -507,7 +507,7 @@ export async function activate(context: vscode.ExtensionContext) {
 			const prompt = `Explain the following code from ${fileMention}:\n\`\`\`${editor.document.languageId}\n${selectedText}\n\`\`\``
 			await visibleWebview?.controller.initTask(prompt)
 			const taskId = visibleWebview?.controller.task?.taskId
-			telemetryService.captureButtonClick("codeAction_explainCode", taskId) // taskId added
+			telemetryService.captureButtonClick("codeAction_explainCode", taskId)
 		}),
 	)
 
@@ -530,7 +530,7 @@ export async function activate(context: vscode.ExtensionContext) {
 			const prompt = `Improve the following code from ${fileMention} (e.g., suggest refactorings, optimizations, or better practices):\n\`\`\`${editor.document.languageId}\n${selectedText}\n\`\`\``
 			await visibleWebview?.controller.initTask(prompt)
 			const taskId = visibleWebview?.controller.task?.taskId
-			telemetryService.captureButtonClick("codeAction_improveCode", taskId) // taskId added
+			telemetryService.captureButtonClick("codeAction_improveCode", taskId)
 		}),
 	)
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -14,6 +14,8 @@ import { Controller } from "./core/controller"
 import { ErrorService } from "./services/error/ErrorService"
 import { initializeTestMode, cleanupTestMode } from "./services/test/TestMode"
 import { telemetryService } from "./services/posthog/telemetry/TelemetryService"
+// テレメトリサービスをインポート
+import { telemetryService as clineTelemetryService } from "./services/posthog/telemetry/TelemetryService"
 
 /*
 Built using https://github.com/microsoft/vscode-webview-ui-toolkit
@@ -310,6 +312,8 @@ export async function activate(context: vscode.ExtensionContext) {
 				languageId,
 				Array.isArray(diagnostics) ? diagnostics : undefined,
 			)
+			const taskId = visibleWebview?.controller.task?.taskId // Corrected to use .task?.taskId
+			clineTelemetryService.captureButtonClick("codeAction_addToChat", taskId) // taskId added
 		}),
 	)
 
@@ -481,6 +485,8 @@ export async function activate(context: vscode.ExtensionContext) {
 			// Send to sidebar provider with diagnostics
 			const visibleWebview = WebviewProvider.getVisibleInstance()
 			await visibleWebview?.controller.fixWithCline(selectedText, filePath, languageId, diagnostics)
+			const taskId = visibleWebview?.controller.task?.taskId
+			clineTelemetryService.captureButtonClick("codeAction_fixWithCline", taskId) // taskId added
 		}),
 	)
 
@@ -502,6 +508,8 @@ export async function activate(context: vscode.ExtensionContext) {
 			const fileMention = visibleWebview?.controller.getFileMentionFromPath(filePath) || filePath
 			const prompt = `Explain the following code from ${fileMention}:\n\`\`\`${editor.document.languageId}\n${selectedText}\n\`\`\``
 			await visibleWebview?.controller.initTask(prompt)
+			const taskId = visibleWebview?.controller.task?.taskId
+			clineTelemetryService.captureButtonClick("codeAction_explainCode", taskId) // taskId added
 		}),
 	)
 
@@ -523,6 +531,8 @@ export async function activate(context: vscode.ExtensionContext) {
 			const fileMention = visibleWebview?.controller.getFileMentionFromPath(filePath) || filePath
 			const prompt = `Improve the following code from ${fileMention} (e.g., suggest refactorings, optimizations, or better practices):\n\`\`\`${editor.document.languageId}\n${selectedText}\n\`\`\``
 			await visibleWebview?.controller.initTask(prompt)
+			const taskId = visibleWebview?.controller.task?.taskId
+			clineTelemetryService.captureButtonClick("codeAction_improveCode", taskId) // taskId added
 		}),
 	)
 
@@ -584,6 +594,8 @@ export async function activate(context: vscode.ExtensionContext) {
 					"Could not activate Cline view. Please try opening it manually from the Activity Bar.",
 				)
 			}
+			const taskId = activeWebviewProvider?.controller.task?.taskId
+			clineTelemetryService.captureButtonClick("command_focusChatInput", taskId)
 		}),
 	)
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -310,8 +310,7 @@ export async function activate(context: vscode.ExtensionContext) {
 				languageId,
 				Array.isArray(diagnostics) ? diagnostics : undefined,
 			)
-			const taskId = visibleWebview?.controller.task?.taskId
-			telemetryService.captureButtonClick("codeAction_addToChat", taskId)
+			telemetryService.captureButtonClick("codeAction_addToChat", visibleWebview?.controller.task?.taskId, true)
 		}),
 	)
 
@@ -483,8 +482,7 @@ export async function activate(context: vscode.ExtensionContext) {
 			// Send to sidebar provider with diagnostics
 			const visibleWebview = WebviewProvider.getVisibleInstance()
 			await visibleWebview?.controller.fixWithCline(selectedText, filePath, languageId, diagnostics)
-			const taskId = visibleWebview?.controller.task?.taskId
-			telemetryService.captureButtonClick("codeAction_fixWithCline", taskId)
+			telemetryService.captureButtonClick("codeAction_fixWithCline", visibleWebview?.controller.task?.taskId, true)
 		}),
 	)
 
@@ -506,8 +504,7 @@ export async function activate(context: vscode.ExtensionContext) {
 			const fileMention = visibleWebview?.controller.getFileMentionFromPath(filePath) || filePath
 			const prompt = `Explain the following code from ${fileMention}:\n\`\`\`${editor.document.languageId}\n${selectedText}\n\`\`\``
 			await visibleWebview?.controller.initTask(prompt)
-			const taskId = visibleWebview?.controller.task?.taskId
-			telemetryService.captureButtonClick("codeAction_explainCode", taskId)
+			telemetryService.captureButtonClick("codeAction_explainCode", visibleWebview?.controller.task?.taskId, true)
 		}),
 	)
 
@@ -529,8 +526,7 @@ export async function activate(context: vscode.ExtensionContext) {
 			const fileMention = visibleWebview?.controller.getFileMentionFromPath(filePath) || filePath
 			const prompt = `Improve the following code from ${fileMention} (e.g., suggest refactorings, optimizations, or better practices):\n\`\`\`${editor.document.languageId}\n${selectedText}\n\`\`\``
 			await visibleWebview?.controller.initTask(prompt)
-			const taskId = visibleWebview?.controller.task?.taskId
-			telemetryService.captureButtonClick("codeAction_improveCode", taskId)
+			telemetryService.captureButtonClick("codeAction_improveCode", visibleWebview?.controller.task?.taskId, true)
 		}),
 	)
 
@@ -592,8 +588,7 @@ export async function activate(context: vscode.ExtensionContext) {
 					"Could not activate Cline view. Please try opening it manually from the Activity Bar.",
 				)
 			}
-			const taskId = activeWebviewProvider?.controller.task?.taskId
-			telemetryService.captureButtonClick("command_focusChatInput", taskId)
+			telemetryService.captureButtonClick("command_focusChatInput", activeWebviewProvider?.controller.task?.taskId, true)
 		}),
 	)
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -14,8 +14,6 @@ import { Controller } from "./core/controller"
 import { ErrorService } from "./services/error/ErrorService"
 import { initializeTestMode, cleanupTestMode } from "./services/test/TestMode"
 import { telemetryService } from "./services/posthog/telemetry/TelemetryService"
-// テレメトリサービスをインポート
-import { telemetryService as clineTelemetryService } from "./services/posthog/telemetry/TelemetryService"
 
 /*
 Built using https://github.com/microsoft/vscode-webview-ui-toolkit
@@ -313,7 +311,7 @@ export async function activate(context: vscode.ExtensionContext) {
 				Array.isArray(diagnostics) ? diagnostics : undefined,
 			)
 			const taskId = visibleWebview?.controller.task?.taskId // Corrected to use .task?.taskId
-			clineTelemetryService.captureButtonClick("codeAction_addToChat", taskId) // taskId added
+			telemetryService.captureButtonClick("codeAction_addToChat", taskId) // taskId added
 		}),
 	)
 
@@ -486,7 +484,7 @@ export async function activate(context: vscode.ExtensionContext) {
 			const visibleWebview = WebviewProvider.getVisibleInstance()
 			await visibleWebview?.controller.fixWithCline(selectedText, filePath, languageId, diagnostics)
 			const taskId = visibleWebview?.controller.task?.taskId
-			clineTelemetryService.captureButtonClick("codeAction_fixWithCline", taskId) // taskId added
+			telemetryService.captureButtonClick("codeAction_fixWithCline", taskId) // taskId added
 		}),
 	)
 
@@ -509,7 +507,7 @@ export async function activate(context: vscode.ExtensionContext) {
 			const prompt = `Explain the following code from ${fileMention}:\n\`\`\`${editor.document.languageId}\n${selectedText}\n\`\`\``
 			await visibleWebview?.controller.initTask(prompt)
 			const taskId = visibleWebview?.controller.task?.taskId
-			clineTelemetryService.captureButtonClick("codeAction_explainCode", taskId) // taskId added
+			telemetryService.captureButtonClick("codeAction_explainCode", taskId) // taskId added
 		}),
 	)
 
@@ -532,7 +530,7 @@ export async function activate(context: vscode.ExtensionContext) {
 			const prompt = `Improve the following code from ${fileMention} (e.g., suggest refactorings, optimizations, or better practices):\n\`\`\`${editor.document.languageId}\n${selectedText}\n\`\`\``
 			await visibleWebview?.controller.initTask(prompt)
 			const taskId = visibleWebview?.controller.task?.taskId
-			clineTelemetryService.captureButtonClick("codeAction_improveCode", taskId) // taskId added
+			telemetryService.captureButtonClick("codeAction_improveCode", taskId) // taskId added
 		}),
 	)
 
@@ -595,7 +593,7 @@ export async function activate(context: vscode.ExtensionContext) {
 				)
 			}
 			const taskId = activeWebviewProvider?.controller.task?.taskId
-			clineTelemetryService.captureButtonClick("command_focusChatInput", taskId)
+			telemetryService.captureButtonClick("command_focusChatInput", taskId)
 		}),
 	)
 


### PR DESCRIPTION
### Description
Adds telemetry to record the usage of Short cuts and lightbulb icon in Cline

### Test Procedure
- Use the debugger with breakpoints in these places

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [X] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [X] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [X] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [X] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [X] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds telemetry for button clicks in Cline extension to capture usage of code actions and commands.
> 
>   - **Telemetry**:
>     - Adds `telemetryService.captureButtonClick()` to `cline.addToChat`, `cline.fixWithCline`, `cline.explainCode`, `cline.improveCode`, and `cline.focusChatInput` commands in `extension.ts`.
>     - Captures button click events with specific action names and task IDs.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for b8d7601a370612d7cf1e628df5856e558fb0a27f. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->