### PR TITLE
feat: Add `taskId`as metadata to use from LiteLLM

### DIFF
--- a/.changeset/strange-paws-relate.md
+++ b/.changeset/strange-paws-relate.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Add taskId as metadata to use from LiteLLM

--- a/src/api/providers/litellm.ts
+++ b/src/api/providers/litellm.ts
@@ -110,7 +110,6 @@ export class LiteLlmHandler implements ApiHandler {
 
 		if (this.options.taskId) {
 			// LiteLLM expects metadata as an additional field in the payload.
-			// Using 'as any' if the OpenAI SDK type doesn't directly include 'metadata'.
 			;(requestPayload as any).metadata = {
 				cline_task_id: this.options.taskId,
 			}

--- a/src/api/providers/litellm.ts
+++ b/src/api/providers/litellm.ts
@@ -109,8 +109,8 @@ export class LiteLlmHandler implements ApiHandler {
 			stream_options: { include_usage: true },
 			...(thinkingConfig && { thinking: thinkingConfig }), // Add thinking configuration when applicable
 			...(this.options.taskId && {
-				metadata: { cline_task_id: this.options.taskId }
-			})
+				metadata: { cline_task_id: this.options.taskId },
+			}),
 		}
 
 		const stream = await this.client.chat.completions.create(requestPayload)

--- a/src/api/providers/litellm.ts
+++ b/src/api/providers/litellm.ts
@@ -99,20 +99,18 @@ export class LiteLlmHandler implements ApiHandler {
 			return message
 		})
 
-		const requestPayload: OpenAI.Chat.Completions.ChatCompletionCreateParamsStreaming = {
+		const requestPayload: OpenAI.Chat.Completions.ChatCompletionCreateParamsStreaming & {
+			metadata?: { cline_task_id: string }
+		} = {
 			model: this.options.liteLlmModelId || liteLlmDefaultModelId,
 			messages: [enhancedSystemMessage, ...enhancedMessages],
 			temperature,
 			stream: true,
 			stream_options: { include_usage: true },
 			...(thinkingConfig && { thinking: thinkingConfig }), // Add thinking configuration when applicable
-		}
-
-		if (this.options.taskId) {
-			// LiteLLM expects metadata as an additional field in the payload.
-			;(requestPayload as any).metadata = {
-				cline_task_id: this.options.taskId,
-			}
+			...(this.options.taskId && {
+				metadata: { cline_task_id: this.options.taskId }
+			})
 		}
 
 		const stream = await this.client.chat.completions.create(requestPayload)


### PR DESCRIPTION
### Description

Add taskId as metadata to use from LiteLLM. This feature allows to send the task ID (chat ID) for every API Request that Cline makes and the LiteLLM users can trace the number of request per task.

### Test Procedure

I tried that in my local development environment by sending several api requests to LiteLLM provider.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

![image](https://github.com/user-attachments/assets/aa0f708a-0d4a-49eb-b16b-e39ea9c40aa3)

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `taskId` as metadata in API requests to LiteLLM for request tracing by task.
> 
>   - **Behavior**:
>     - Add `taskId` as metadata in API requests to LiteLLM in `createMessage()` in `litellm.ts`.
>     - Allows tracing of requests by task ID.
>   - **Misc**:
>     - Add changeset `strange-paws-relate.md` documenting the feature as a patch.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for eb8ade5eb79110f0218baba7936c49ff29178145. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->