### PR TITLE
feat: Add devstrall-small-2505 to the Mistral model list

### DIFF
--- a/.changeset/strong-lizards-greet.md
+++ b/.changeset/strong-lizards-greet.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Add devstral-small to the Mistral model list

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -1457,6 +1457,14 @@ export const mistralModels = {
 		inputPrice: 0.3,
 		outputPrice: 0.9,
 	},
+	"devstral-small-2505": {
+		maxTokens: 128_000,
+		contextWindow: 128_000,
+		supportsImages: false,
+		supportsPromptCache: false,
+		inputPrice: 0.1,
+		outputPrice: 0.3,
+	},
 } as const satisfies Record<string, ModelInfo>
 
 // LiteLLM

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -1367,7 +1367,7 @@ export const doubaoModels = {
 // Mistral
 // https://docs.mistral.ai/getting-started/models/models_overview/
 export type MistralModelId = keyof typeof mistralModels
-export const mistralDefaultModelId: MistralModelId = "codestral-2501"
+export const mistralDefaultModelId: MistralModelId = "devstral-small-2505"
 export const mistralModels = {
 	"mistral-large-2411": {
 		maxTokens: 131_000,
@@ -1459,7 +1459,7 @@ export const mistralModels = {
 	},
 	"devstral-small-2505": {
 		maxTokens: 128_000,
-		contextWindow: 128_000,
+		contextWindow: 131_072,
 		supportsImages: false,
 		supportsPromptCache: false,
 		inputPrice: 0.1,


### PR DESCRIPTION
### Description

This PR adds the devstral-small-2505 model to the Mistral model list. You can find pricing information [here](https://mistral.ai/news/devstral).
> The model is also available on our API under the name devstral-small-2505 at the same price as Mistral Small 3.1: $0.1/M input tokens and $0.3/M output tokens. 

### Test Procedure

Checked the model is now there:
<img width="219" alt="image" src="https://github.com/user-attachments/assets/cd7dd4a3-30ec-4e29-9585-132917e5db8b" />

(Signed up to MIstral and checked the responses also work)
<img width="235" alt="image" src="https://github.com/user-attachments/assets/ed807a8e-1dbf-490d-94de-954ba332ac35" />


### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `devstral-small-2505` model to `mistralModels` in `api.ts` with specific attributes and pricing.
> 
>   - **Models**:
>     - Add `devstral-small-2505` to `mistralModels` in `api.ts` with `maxTokens` 128,000, `contextWindow` 128,000, `supportsImages` false, `supportsPromptCache` false, `inputPrice` 0.1, `outputPrice` 0.3.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 24eaa988e08f2a652592c568e943c94ea9d429c4. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->