### PR TITLE
fix: handle the Mistral SDK API errors

### DIFF
--- a/.changeset/slimy-bees-fail.md
+++ b/.changeset/slimy-bees-fail.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Handle Mistral SDK API errors


### PR DESCRIPTION
### Description

When testing the new [Mistral model](https://github.com/cline/cline/pull/3697), I noticed I would get rate limited and Cline wouldn't retry. Turns out the Mistral SDK throws errors without a `status` property, but with a statusCode one. Since we use `status` in the `withRetry` catch block, I am capturing them, setting the proper property and throwing them again. It might be worth checking both in the `withRetry` catch instead 🤔.

### Test Procedure

Checked locally the status code is present and the model now retries when it gets a 429 response.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Previous error:
<img width="251" alt="image" src="https://github.com/user-attachments/assets/a0a6a943-ba16-40fc-a4f4-f28032d9a7a1" />

Now:
<img width="245" alt="image" src="https://github.com/user-attachments/assets/d9a0dfef-78bc-4dd6-8123-90bc7f353512" />

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix error handling in `createMessage()` in `mistral.ts` by mapping `statusCode` to `status` for Mistral SDK errors.
> 
>   - **Error Handling**:
>     - In `createMessage()` in `mistral.ts`, catch block now checks for `statusCode` in errors and assigns it to `status` if `status` is absent.
>     - Ensures retry logic works when Mistral SDK errors occur.
>   - **Changeset**:
>     - Adds `slimy-bees-fail.md` to document the error handling fix.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 3aa6be212d8637534f073c259867b3473280c553. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->