### PR TITLE
Pashpashpash/rules links

### DIFF
--- a/.changeset/fast-days-poke.md
+++ b/.changeset/fast-days-poke.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Added documentation links to rules & workflows UI

--- a/webview-ui/src/components/cline-rules/ClineRulesToggleModal.tsx
+++ b/webview-ui/src/components/cline-rules/ClineRulesToggleModal.tsx
@@ -4,7 +4,7 @@ import { useExtensionState } from "@/context/ExtensionStateContext"
 import { CODE_BLOCK_BG_COLOR } from "@/components/common/CodeBlock"
 import { vscode } from "@/utils/vscode"
 import { FileServiceClient } from "@/services/grpc-client"
-import { VSCodeButton } from "@vscode/webview-ui-toolkit/react"
+import { VSCodeButton, VSCodeLink } from "@vscode/webview-ui-toolkit/react"
 import RulesToggleList from "./RulesToggleList"
 import Tooltip from "@/components/common/Tooltip"
 import styled from "styled-components"
@@ -222,7 +222,13 @@ const ClineRulesToggleModal: React.FC = () => {
 						{currentView === "rules" ? (
 							<p>
 								Rules allow you to provide Cline with system-level guidance. Think of them as a persistent way to
-								include context and preferences for your projects or globally for every conversation.
+								include context and preferences for your projects or globally for every conversation.{" "}
+								<VSCodeLink
+									href="https://docs.cline.bot/features/cline-rules"
+									style={{ display: "inline" }}
+									className="text-xs">
+									Docs
+								</VSCodeLink>
 							</p>
 						) : (
 							<p>
@@ -233,7 +239,13 @@ const ClineRulesToggleModal: React.FC = () => {
 								text-[var(--vscode-foreground)] font-bold">
 									/workflow-name
 								</span>{" "}
-								in the chat.
+								in the chat.{" "}
+								<VSCodeLink
+									href="https://docs.cline.bot/features/slash-commands/workflows"
+									style={{ display: "inline" }}
+									className="text-xs">
+									Docs
+								</VSCodeLink>
 							</p>
 						)}
 					</div>


### PR DESCRIPTION
### Description

<img width="437" alt="Screenshot 2025-05-21 at 1 07 37 PM" src="https://github.com/user-attachments/assets/3ed7e497-5f39-4add-99b8-ad234d0d3177" />

<img width="441" alt="Screenshot 2025-05-21 at 1 08 10 PM" src="https://github.com/user-attachments/assets/2ce7b775-77b4-456f-a1a1-ee45fad22474" />


### Test Procedure

<!-- How did you test this? Are you confident that it will not introduce bugs? If so, why? -->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [sx] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add documentation links to rules and workflows UI in `ClineRulesToggleModal.tsx`.
> 
>   - **UI Enhancements**:
>     - Added `VSCodeLink` to `ClineRulesToggleModal.tsx` for rules and workflows documentation.
>     - Links point to `https://docs.cline.bot/features/cline-rules` and `https://docs.cline.bot/features/slash-commands/workflows` respectively.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 4af7b2afc363a3b958a1cb137cdc121547ae8082. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->