### PR TITLE
when the assistant says to act mode we render a custom highlight with hotkey suggestion

### DIFF
--- a/.changeset/beige-drinks-chew.md
+++ b/.changeset/beige-drinks-chew.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+when the assistant says to act mode we render a custom highlight with hotkey suggestion

--- a/webview-ui/src/components/common/MarkdownBlock.tsx
+++ b/webview-ui/src/components/common/MarkdownBlock.tsx
@@ -429,7 +429,6 @@ const MarkdownBlock = memo(({ markdown }: MarkdownBlockProps) => {
 					// This ensures we only style the exact "Act Mode" mentions with keyboard shortcut
 					// Using case-insensitive flag to catch all capitalization variations
 					if (/^act mode\s*\(⌘⇧A\)$/i.test(childrenText)) {
-						console.log("Found Act Mode text:", childrenText)
 						return <ActModeHighlight />
 					}
 

--- a/webview-ui/src/components/common/MarkdownBlock.tsx
+++ b/webview-ui/src/components/common/MarkdownBlock.tsx
@@ -10,6 +10,27 @@ import type { Node } from "unist"
 import { useExtensionState } from "@/context/ExtensionStateContext"
 import { CODE_BLOCK_BG_COLOR } from "@/components/common/CodeBlock"
 import MermaidBlock from "@/components/common/MermaidBlock"
+import { vscode } from "@/utils/vscode"
+
+// Styled component for Act Mode text with more specific styling
+const ActModeHighlight: React.FC = () => (
+	<span
+		onClick={() => {
+			vscode.postMessage({
+				type: "togglePlanActMode",
+				chatSettings: {
+					mode: "act",
+				},
+			})
+		}}
+		title="Click to toggle to Act Mode"
+		className="text-[var(--vscode-textLink-foreground)] hover:opacity-90 cursor-pointer inline-flex items-center gap-1">
+		<div className="p-1 rounded-[12px] bg-[var(--vscode-editor-background)] flex items-center justify-end w-4 border-[1px] border-[var(--vscode-input-border)]">
+			<div className="rounded-full bg-[var(--vscode-textLink-foreground)] w-2 h-2" />
+		</div>
+		Act Mode (⌘⇧A)
+	</span>
+)
 
 interface MarkdownBlockProps {
 	markdown?: string
@@ -48,6 +69,68 @@ const remarkUrlToLink = () => {
 			// Fix: Instead of converting the node to a paragraph (which broke things),
 			// we replace the original text node with our new nodes in the parent's children array.
 			// This preserves the document structure while adding our links.
+			if (parent) {
+				parent.children.splice(index, 1, ...children)
+			}
+		})
+	}
+}
+
+/**
+ * Custom remark plugin that highlights "to Act Mode" mentions and adds keyboard shortcut hint
+ */
+const remarkHighlightActMode = () => {
+	return (tree: Node) => {
+		visit(tree, "text", (node: any, index, parent) => {
+			// Case-insensitive regex to match "to Act Mode" in various capitalizations
+			// Using word boundaries to avoid matching within words
+			// Added negative lookahead to avoid matching if already followed by the shortcut
+			const actModeRegex = /\bto\s+Act\s+Mode\b(?!\s*\(⌘⇧A\))/i
+
+			if (!node.value.match(actModeRegex)) return
+
+			// Split the text by the matches
+			const parts = node.value.split(actModeRegex)
+			const matches = node.value.match(actModeRegex)
+
+			if (!matches || parts.length <= 1) return
+
+			const children: any[] = []
+
+			parts.forEach((part: string, i: number) => {
+				// Add the text before the match
+				if (part) children.push({ type: "text", value: part })
+
+				// Add the match, but only make "Act Mode" bold (not the "to" part)
+				if (matches[i]) {
+					// Extract "to" and "Act Mode" parts
+					const matchText = matches[i]
+					const toIndex = matchText.toLowerCase().indexOf("to")
+					const actModeIndex = matchText.toLowerCase().indexOf("act mode", toIndex + 2)
+
+					if (toIndex !== -1 && actModeIndex !== -1) {
+						// Add "to" as regular text
+						const toPart = matchText.substring(toIndex, actModeIndex).trim()
+						children.push({ type: "text", value: toPart + " " })
+
+						// Add "Act Mode" as bold with keyboard shortcut
+						const actModePart = matchText.substring(actModeIndex)
+						children.push({
+							type: "strong",
+							children: [{ type: "text", value: `${actModePart} (⌘⇧A)` }],
+						})
+					} else {
+						// Fallback if we can't parse it correctly
+						children.push({ type: "text", value: matchText + " " })
+						children.push({
+							type: "strong",
+							children: [{ type: "text", value: `(⌘⇧A)` }],
+						})
+					}
+				}
+			})
+
+			// Replace the original text node with our new nodes
 			if (parent) {
 				parent.children.splice(index, 1, ...children)
 			}
@@ -286,6 +369,7 @@ const MarkdownBlock = memo(({ markdown }: MarkdownBlockProps) => {
 		remarkPlugins: [
 			remarkPreventBoldFilenames,
 			remarkUrlToLink,
+			remarkHighlightActMode,
 			remarkMath,
 			() => {
 				return (tree) => {
@@ -328,6 +412,28 @@ const MarkdownBlock = memo(({ markdown }: MarkdownBlockProps) => {
 						return <MermaidBlock code={codeText} />
 					}
 					return <code {...props} />
+				},
+				strong: (props: ComponentProps<"strong">) => {
+					// Check if this is an "Act Mode" strong element by looking for the keyboard shortcut
+					// Handle both string children and array of children cases
+					const childrenText = React.Children.toArray(props.children)
+						.map((child) => {
+							if (typeof child === "string") return child
+							if (typeof child === "object" && "props" in child && child.props.children)
+								return String(child.props.children)
+							return ""
+						})
+						.join("")
+
+					// Case-insensitive check for "Act Mode (⌘⇧A)" pattern
+					// This ensures we only style the exact "Act Mode" mentions with keyboard shortcut
+					// Using case-insensitive flag to catch all capitalization variations
+					if (/^act mode\s*\(⌘⇧A\)$/i.test(childrenText)) {
+						console.log("Found Act Mode text:", childrenText)
+						return <ActModeHighlight />
+					}
+
+					return <strong {...props} />
 				},
 			},
 		},


### PR DESCRIPTION
### Description

![image](https://github.com/user-attachments/assets/01996048-2680-45d7-b96e-b6471fa26b0c)


### Test Procedure

<!-- How did you test this? Are you confident that it will not introduce bugs? If so, why? -->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds custom highlight and hotkey suggestion for 'Act Mode' mentions in markdown in `MarkdownBlock.tsx`.
> 
>   - **New Feature**:
>     - Adds `ActModeHighlight` component in `MarkdownBlock.tsx` to render 'Act Mode' text with a hotkey suggestion (⌘⇧A).
>     - Implements `remarkHighlightActMode` plugin to detect and transform 'to Act Mode' mentions in markdown.
>   - **Markdown Processing**:
>     - Updates `useRemark` in `MarkdownBlock.tsx` to include `remarkHighlightActMode` for processing markdown text.
>     - Modifies `strong` element rendering to replace 'Act Mode' mentions with `ActModeHighlight`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for b7e479f6d5a1d0e029872f1e0414dc9c90da83d3. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->