### PR TITLE
fix: revert ServerConfigSchema to union.

### DIFF
--- a/.changeset/eleven-dragons-sell.md
+++ b/.changeset/eleven-dragons-sell.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+no longer requires `transportType` property to be set in MCP Server configuration.

--- a/src/services/mcp/McpHub.ts
+++ b/src/services/mcp/McpHub.ts
@@ -55,23 +55,30 @@ const BaseConfigSchema = z.object({
 })
 
 const SseConfigSchema = BaseConfigSchema.extend({
-	transportType: z.literal("sse"),
 	url: z.string().url(),
-})
+}).transform((config) => ({
+	...config,
+	transportType: "sse" as const,
+}))
 
 const StdioConfigSchema = BaseConfigSchema.extend({
-	transportType: z.literal("stdio"),
 	command: z.string(),
 	args: z.array(z.string()).optional(),
 	env: z.record(z.string()).optional(),
-})
+}).transform((config) => ({
+	...config,
+	transportType: "stdio" as const,
+}))
 
 const StreamableHTTPConfigSchema = BaseConfigSchema.extend({
 	transportType: z.literal("http"),
 	url: z.string().url(),
-})
+}).transform((config) => ({
+	...config,
+	transportType: "http" as const,
+}))
 
-const ServerConfigSchema = z.discriminatedUnion("transportType", [StdioConfigSchema, SseConfigSchema, StreamableHTTPConfigSchema])
+const ServerConfigSchema = z.union([StdioConfigSchema, SseConfigSchema, StreamableHTTPConfigSchema])
 
 const McpSettingsSchema = z.object({
 	mcpServers: z.record(ServerConfigSchema),


### PR DESCRIPTION
This type was changed from a union to a discriminated union based on transportType. It seems like this is an internal implementation detail that end users shouldn't really care about. This change reverts that type back to a union.

Fixes #3714 #3705 #2459 

Thank you to @stampcli for reporting a specific version number that worked for them. It made this issue much easier to debug.

### Description

<!-- Describe your changes in detail. What problem does this PR solve? -->

### Test Procedure

<!-- How did you test this? Are you confident that it will not introduce bugs? If so, why? -->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

### Additional Notes

<!-- Add any additional notes for reviewers -->
