### PR TITLE
Model 4 prep bedrock

### DIFF
--- a/.changeset/cool-trainers-cheer.md
+++ b/.changeset/cool-trainers-cheer.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": minor
+---
+
+Add Sonnet 4 to bedrock provider

--- a/src/api/providers/bedrock.ts
+++ b/src/api/providers/bedrock.ts
@@ -47,7 +47,7 @@ export class AwsBedrockHandler implements ApiHandler {
 		}
 
 		const budget_tokens = this.options.thinkingBudgetTokens || 0
-		const reasoningOn = baseModelId.includes("3-7") && budget_tokens !== 0 ? true : false
+		const reasoningOn = (baseModelId.includes("3-7") || baseModelId.includes("4-")) && budget_tokens !== 0 ? true : false
 
 		// Get model info and message indices for caching
 		const userMsgIndices = messages.reduce((acc, msg, index) => (msg.role === "user" ? [...acc, index] : acc), [] as number[])

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -197,8 +197,22 @@ export const anthropicModels = {
 // AWS Bedrock
 // https://docs.aws.amazon.com/bedrock/latest/userguide/conversation-inference.html
 export type BedrockModelId = keyof typeof bedrockModels
-export const bedrockDefaultModelId: BedrockModelId = "anthropic.claude-3-7-sonnet-20250219-v1:0"
+export const bedrockDefaultModelId: BedrockModelId = "anthropic.claude-4-sonnet-20250522-v1:0"
 export const bedrockModels = {
+	"anthropic.claude-4-sonnet-20250522-v1:0": {
+		maxTokens: 8192,
+		contextWindow: 200_000,
+		supportsImages: true,
+		supportsPromptCache: true,
+		inputPrice: 3.0,
+		outputPrice: 15.0,
+		cacheWritesPrice: 3.75,
+		cacheReadsPrice: 0.3,
+		thinkingConfig: {
+			maxBudget: 64000,
+			outputPrice: 15.0,
+		},
+	},
 	"amazon.nova-premier-v1:0": {
 		maxTokens: 10_000,
 		contextWindow: 1_000_000,

--- a/webview-ui/src/components/settings/ApiOptions.tsx
+++ b/webview-ui/src/components/settings/ApiOptions.tsx
@@ -894,8 +894,11 @@ const ApiOptions = ({
 						</div>
 					)}
 					{(selectedModelId === "anthropic.claude-3-7-sonnet-20250219-v1:0" ||
+						selectedModelId === "anthropic.claude-4-sonnet-20250522-v1:0" ||
 						(apiConfiguration?.awsBedrockCustomSelected &&
-							apiConfiguration?.awsBedrockCustomModelBaseId === "anthropic.claude-3-7-sonnet-20250219-v1:0")) && (
+							(apiConfiguration?.awsBedrockCustomModelBaseId === "anthropic.claude-3-7-sonnet-20250219-v1:0" ||
+								apiConfiguration?.awsBedrockCustomModelBaseId ===
+									"anthropic.claude-4-sonnet-20250522-v1:0"))) && (
 						<ThinkingBudgetSlider apiConfiguration={apiConfiguration} setApiConfiguration={setApiConfiguration} />
 					)}
 					<ModelInfoView


### PR DESCRIPTION
### Description

Add sonnet 4 bedrock

### Test Procedure

<!-- How did you test this? Are you confident that it will not introduce bugs? If so, why? -->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `Sonnet 4` model to Bedrock provider with UI support for model selection and configuration.
> 
>   - **Behavior**:
>     - Add `Sonnet 4` model to Bedrock provider in `bedrock.ts`.
>     - Update `reasoningOn` logic to include `4-` models in `bedrock.ts`.
>     - Change default Bedrock model ID to `anthropic.claude-4-sonnet-20250522-v1:0` in `api.ts`.
>   - **Models**:
>     - Add `anthropic.claude-4-sonnet-20250522-v1:0` to `bedrockModels` in `api.ts` with support for images, prompt caching, and reasoning.
>   - **UI**:
>     - Update `ApiOptions.tsx` to include `Sonnet 4` in model selection dropdowns.
>     - Add `ThinkingBudgetSlider` for `Sonnet 4` in `ApiOptions.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 6f797d2488d5d99a1bc42e12ebccd40828a377e3. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->