### PR TITLE
settings cancel

### DIFF
--- a/.changeset/wise-ants-remain.md
+++ b/.changeset/wise-ants-remain.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+added cancel button with alert dialogue popup to settings view

--- a/webview-ui/src/components/common/AlertDialog.tsx
+++ b/webview-ui/src/components/common/AlertDialog.tsx
@@ -1,0 +1,111 @@
+import React, { ReactNode } from "react"
+import { cn } from "@/utils/cn"
+import { VSCodeButton } from "@vscode/webview-ui-toolkit/react"
+import { AlertTriangle } from "lucide-react"
+import { OPENROUTER_MODEL_PICKER_Z_INDEX } from "../settings/OpenRouterModelPicker"
+
+interface AlertDialogProps {
+	open: boolean
+	onOpenChange: (open: boolean) => void
+	children: ReactNode
+}
+
+export function AlertDialog({ open, onOpenChange, children }: AlertDialogProps) {
+	if (!open) return null
+
+	// Close the dialog when clicking on the backdrop
+	const handleBackdropClick = (e: React.MouseEvent) => {
+		if (e.target === e.currentTarget) {
+			onOpenChange(false)
+		}
+	}
+
+	return (
+		<div
+			className={cn(`fixed inset-0 bg-black/50 flex items-center justify-center`)}
+			onClick={handleBackdropClick}
+			style={{ zIndex: OPENROUTER_MODEL_PICKER_Z_INDEX + 50 }}>
+			{children}
+		</div>
+	)
+}
+
+export function AlertDialogContent({ className, children, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+	return (
+		<div
+			className={cn(
+				`fixed top-[50%] left-[50%] grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%]`,
+				className,
+			)}
+			onClick={(e) => e.stopPropagation()}
+			{...props}>
+			<div className="bg-[var(--vscode-editor-background)] rounded-sm  gap-3 border border-[var(--vscode-panel-border)] p-4 shadow-lg sm:max-w-md">
+				{children}
+			</div>
+		</div>
+	)
+}
+
+export function AlertDialogHeader({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+	return <div className={cn("flex flex-col gap-1 text-left", className)} {...props} />
+}
+
+export function AlertDialogFooter({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+	return <div className={cn("flex flex-row justify-end gap-2 mt-4", className)} {...props} />
+}
+
+export function AlertDialogTitle({ className, ...props }: React.HTMLAttributes<HTMLHeadingElement>) {
+	return (
+		<h2
+			className={cn(
+				"text-base font-medium text-[var(--vscode-editor-foreground)] flex items-center gap-2 text-left",
+				className,
+			)}
+			{...props}
+		/>
+	)
+}
+
+export function AlertDialogDescription({ className, ...props }: React.HTMLAttributes<HTMLParagraphElement>) {
+	return <p className={cn("text-[var(--vscode-descriptionForeground)] text-sm text-left", className)} {...props} />
+}
+
+export function AlertDialogAction({ className, ...props }: React.ComponentProps<typeof VSCodeButton>) {
+	return <VSCodeButton appearance="primary" {...props} />
+}
+
+export function AlertDialogCancel({ className, ...props }: React.ComponentProps<typeof VSCodeButton>) {
+	return <VSCodeButton appearance="secondary" {...props} />
+}
+
+export function UnsavedChangesDialog({
+	open,
+	onOpenChange,
+	onConfirm,
+	onCancel,
+}: {
+	open: boolean
+	onOpenChange: (open: boolean) => void
+	onConfirm: () => void
+	onCancel: () => void
+}) {
+	return (
+		<AlertDialog open={open} onOpenChange={onOpenChange}>
+			<AlertDialogContent>
+				<AlertDialogHeader>
+					<AlertDialogTitle>
+						<AlertTriangle className="w-5 h-5 text-[var(--vscode-errorForeground)]" />
+						Unsaved Changes
+					</AlertDialogTitle>
+					<AlertDialogDescription>
+						You have unsaved changes. Are you sure you want to discard them?
+					</AlertDialogDescription>
+				</AlertDialogHeader>
+				<AlertDialogFooter>
+					<AlertDialogCancel onClick={onCancel}>Cancel</AlertDialogCancel>
+					<AlertDialogAction onClick={onConfirm}>Discard Changes</AlertDialogAction>
+				</AlertDialogFooter>
+			</AlertDialogContent>
+		</AlertDialog>
+	)
+}

--- a/webview-ui/src/components/settings/SettingsView.tsx
+++ b/webview-ui/src/components/settings/SettingsView.tsx
@@ -22,6 +22,7 @@ import {
 	LucideIcon,
 } from "lucide-react"
 import HeroTooltip from "@/components/common/HeroTooltip"
+import { UnsavedChangesDialog } from "@/components/common/AlertDialog"
 import SectionHeader from "./SectionHeader"
 import Section from "./Section"
 import PreferredLanguageSetting from "./PreferredLanguageSetting" // Added import
@@ -124,6 +125,12 @@ type SettingsViewProps = {
 }
 
 const SettingsView = ({ onDone, targetSection }: SettingsViewProps) => {
+	// Track if there are unsaved changes
+	const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false)
+	// State for the unsaved changes dialog
+	const [isUnsavedChangesDialogOpen, setIsUnsavedChangesDialogOpen] = useState(false)
+	// Store the action to perform after confirmation
+	const pendingAction = useRef<() => void>()
 	const {
 		apiConfiguration,
 		version,
@@ -139,6 +146,17 @@ const SettingsView = ({ onDone, targetSection }: SettingsViewProps) => {
 		enableCheckpointsSetting,
 		mcpMarketplaceEnabled,
 	} = useExtensionState()
+
+	// Store the original state to detect changes
+	const originalState = useRef({
+		apiConfiguration,
+		customInstructions,
+		telemetrySetting,
+		planActSeparateModelsSetting,
+		enableCheckpointsSetting,
+		mcpMarketplaceEnabled,
+		chatSettings,
+	})
 	const [apiErrorMessage, setApiErrorMessage] = useState<string | undefined>(undefined)
 	const [modelIdErrorMessage, setModelIdErrorMessage] = useState<string | undefined>(undefined)
 	const [pendingTabChange, setPendingTabChange] = useState<"plan" | "act" | null>(null)
@@ -190,6 +208,61 @@ const SettingsView = ({ onDone, targetSection }: SettingsViewProps) => {
 		setApiErrorMessage(undefined)
 		setModelIdErrorMessage(undefined)
 	}, [apiConfiguration])
+
+	// Check for unsaved changes by comparing current state with original state
+	useEffect(() => {
+		const hasChanges =
+			JSON.stringify(apiConfiguration) !== JSON.stringify(originalState.current.apiConfiguration) ||
+			customInstructions !== originalState.current.customInstructions ||
+			telemetrySetting !== originalState.current.telemetrySetting ||
+			planActSeparateModelsSetting !== originalState.current.planActSeparateModelsSetting ||
+			enableCheckpointsSetting !== originalState.current.enableCheckpointsSetting ||
+			mcpMarketplaceEnabled !== originalState.current.mcpMarketplaceEnabled ||
+			JSON.stringify(chatSettings) !== JSON.stringify(originalState.current.chatSettings)
+
+		setHasUnsavedChanges(hasChanges)
+	}, [
+		apiConfiguration,
+		customInstructions,
+		telemetrySetting,
+		planActSeparateModelsSetting,
+		enableCheckpointsSetting,
+		mcpMarketplaceEnabled,
+		chatSettings,
+	])
+
+	// Handle cancel button click
+	const handleCancel = useCallback(() => {
+		if (hasUnsavedChanges) {
+			// Show confirmation dialog
+			setIsUnsavedChangesDialogOpen(true)
+			pendingAction.current = () => {
+				// Reset to original state
+				setCustomInstructions(originalState.current.customInstructions)
+				setTelemetrySetting(originalState.current.telemetrySetting)
+				setPlanActSeparateModelsSetting(originalState.current.planActSeparateModelsSetting)
+				// Close settings view
+				onDone()
+			}
+		} else {
+			// No changes, just close
+			onDone()
+		}
+	}, [hasUnsavedChanges, onDone, setCustomInstructions, setTelemetrySetting, setPlanActSeparateModelsSetting])
+
+	// Handle confirmation dialog actions
+	const handleConfirmDiscard = useCallback(() => {
+		setIsUnsavedChangesDialogOpen(false)
+		if (pendingAction.current) {
+			pendingAction.current()
+			pendingAction.current = undefined
+		}
+	}, [])
+
+	const handleCancelDiscard = useCallback(() => {
+		setIsUnsavedChangesDialogOpen(false)
+		pendingAction.current = undefined
+	}, [])
 
 	// validate as soon as the component is mounted
 	/*
@@ -328,7 +401,12 @@ const SettingsView = ({ onDone, targetSection }: SettingsViewProps) => {
 					<h3 className="text-[var(--vscode-foreground)] m-0">Settings</h3>
 				</div>
 				<div className="flex gap-2">
-					<VSCodeButton onClick={() => handleSubmit(false)}>Save</VSCodeButton>
+					<VSCodeButton appearance="secondary" onClick={handleCancel}>
+						Cancel
+					</VSCodeButton>
+					<VSCodeButton onClick={() => handleSubmit(false)} disabled={!hasUnsavedChanges}>
+						Save
+					</VSCodeButton>
 				</div>
 			</TabHeader>
 
@@ -593,6 +671,14 @@ const SettingsView = ({ onDone, targetSection }: SettingsViewProps) => {
 					)
 				})()}
 			</div>
+
+			{/* Unsaved Changes Dialog */}
+			<UnsavedChangesDialog
+				open={isUnsavedChangesDialogOpen}
+				onOpenChange={setIsUnsavedChangesDialogOpen}
+				onConfirm={handleConfirmDiscard}
+				onCancel={handleCancelDiscard}
+			/>
 		</Tab>
 	)
 }

--- a/webview-ui/src/components/settings/SettingsView.tsx
+++ b/webview-ui/src/components/settings/SettingsView.tsx
@@ -144,7 +144,10 @@ const SettingsView = ({ onDone, targetSection }: SettingsViewProps) => {
 		planActSeparateModelsSetting,
 		setPlanActSeparateModelsSetting,
 		enableCheckpointsSetting,
+		setEnableCheckpointsSetting,
 		mcpMarketplaceEnabled,
+		setMcpMarketplaceEnabled,
+		setApiConfiguration,
 	} = useExtensionState()
 
 	// Store the original state to detect changes
@@ -237,10 +240,28 @@ const SettingsView = ({ onDone, targetSection }: SettingsViewProps) => {
 			// Show confirmation dialog
 			setIsUnsavedChangesDialogOpen(true)
 			pendingAction.current = () => {
-				// Reset to original state
+				// Reset all tracked state to original values
 				setCustomInstructions(originalState.current.customInstructions)
 				setTelemetrySetting(originalState.current.telemetrySetting)
 				setPlanActSeparateModelsSetting(originalState.current.planActSeparateModelsSetting)
+				setChatSettings(originalState.current.chatSettings)
+				if (typeof setApiConfiguration === "function") {
+					setApiConfiguration(originalState.current.apiConfiguration ?? {})
+				}
+				if (typeof setEnableCheckpointsSetting === "function") {
+					setEnableCheckpointsSetting(
+						typeof originalState.current.enableCheckpointsSetting === "boolean"
+							? originalState.current.enableCheckpointsSetting
+							: false,
+					)
+				}
+				if (typeof setMcpMarketplaceEnabled === "function") {
+					setMcpMarketplaceEnabled(
+						typeof originalState.current.mcpMarketplaceEnabled === "boolean"
+							? originalState.current.mcpMarketplaceEnabled
+							: false,
+					)
+				}
 				// Close settings view
 				onDone()
 			}
@@ -248,7 +269,17 @@ const SettingsView = ({ onDone, targetSection }: SettingsViewProps) => {
 			// No changes, just close
 			onDone()
 		}
-	}, [hasUnsavedChanges, onDone, setCustomInstructions, setTelemetrySetting, setPlanActSeparateModelsSetting])
+	}, [
+		hasUnsavedChanges,
+		onDone,
+		setCustomInstructions,
+		setTelemetrySetting,
+		setPlanActSeparateModelsSetting,
+		setChatSettings,
+		setApiConfiguration,
+		setEnableCheckpointsSetting,
+		setMcpMarketplaceEnabled,
+	])
 
 	// Handle confirmation dialog actions
 	const handleConfirmDiscard = useCallback(() => {


### PR DESCRIPTION
### Description


https://github.com/user-attachments/assets/2afc0207-a1de-497c-987e-1ec4fcf18604


### Test Procedure

<!-- How did you test this? Are you confident that it will not introduce bugs? If so, why? -->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add cancel button with alert dialog to `SettingsView.tsx` for handling unsaved changes.
> 
>   - **New Feature**:
>     - Added `Cancel` button with alert dialog in `SettingsView.tsx` to handle unsaved changes.
>     - `AlertDialog.tsx` provides components for alert dialogs, including `AlertDialog`, `AlertDialogContent`, `AlertDialogHeader`, `AlertDialogFooter`, `AlertDialogTitle`, `AlertDialogDescription`, `AlertDialogAction`, and `AlertDialogCancel`.
>     - `UnsavedChangesDialog` component in `AlertDialog.tsx` prompts users to confirm discarding unsaved changes.
>   - **State Management**:
>     - `SettingsView.tsx` tracks unsaved changes using `useState` and `useRef`.
>     - `handleCancel` function in `SettingsView.tsx` opens the dialog if there are unsaved changes.
>     - `handleConfirmDiscard` and `handleCancelDiscard` manage dialog actions in `SettingsView.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 4fb61a4a147c7c413217f07abfd6acecb5d96651. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->