### PR TITLE
[ISSUE-3707] Fix issue with process env

### DIFF
--- a/.changeset/sour-boxes-hang.md
+++ b/.changeset/sour-boxes-hang.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Fix issue with process.env for bedrock

--- a/src/api/providers/__tests__/bedrock.test.ts
+++ b/src/api/providers/__tests__/bedrock.test.ts
@@ -1,0 +1,145 @@
+import "should"
+import { AwsBedrockHandler } from "../bedrock"
+import { ApiHandlerOptions } from "@shared/api"
+
+describe("AwsBedrockHandler", () => {
+	describe("withTempEnv", () => {
+		// Store original env vars for cleanup
+		const originalEnv: Record<string, string | undefined> = {}
+
+		beforeEach(() => {
+			// Store original values before each test
+			originalEnv.TEST_VAR = process.env.TEST_VAR
+			originalEnv.ANOTHER_VAR = process.env.ANOTHER_VAR
+			originalEnv.VAR1 = process.env.VAR1
+			originalEnv.VAR2 = process.env.VAR2
+			originalEnv.VAR3 = process.env.VAR3
+			originalEnv.UNDEFINED_VAR = process.env.UNDEFINED_VAR
+		})
+
+		afterEach(() => {
+			// Restore original values after each test
+			Object.entries(originalEnv).forEach(([key, value]) => {
+				if (value === undefined) {
+					delete process.env[key]
+				} else {
+					process.env[key] = value
+				}
+			})
+		})
+
+		it("should restore original environment variables after operation", async () => {
+			// Set initial environment
+			process.env.TEST_VAR = "original"
+			process.env.ANOTHER_VAR = "another"
+
+			// Store original values
+			const originalTestVar = process.env.TEST_VAR
+			const originalAnotherVar = process.env.ANOTHER_VAR
+
+			await AwsBedrockHandler["withTempEnv"](
+				() => {
+					process.env.TEST_VAR = "modified"
+					delete process.env.ANOTHER_VAR
+				},
+				async () => {
+					// Verify environment is modified
+					process.env.TEST_VAR!.should.equal("modified")
+					should.not.exist(process.env.ANOTHER_VAR)
+					return "test"
+				},
+			)
+
+			// Verify environment is restored
+			process.env.TEST_VAR!.should.equal(originalTestVar)
+			process.env.ANOTHER_VAR!.should.equal(originalAnotherVar)
+		})
+
+		it("should handle undefined environment variables", async () => {
+			await AwsBedrockHandler["withTempEnv"](
+				() => {
+					delete process.env.UNDEFINED_VAR
+				},
+				async () => {
+					should.not.exist(process.env.UNDEFINED_VAR)
+					return "test"
+				},
+			)
+
+			// Verify undefined variable is not present
+			should.not.exist(process.env.UNDEFINED_VAR)
+		})
+
+		it("should handle errors and still restore environment", async () => {
+			// Set initial environment
+			process.env.TEST_VAR = "original"
+
+			try {
+				await AwsBedrockHandler["withTempEnv"](
+					() => {
+						process.env.TEST_VAR = "modified"
+					},
+					async () => {
+						throw new Error("Test error")
+					},
+				)
+				should.fail(null, null, "Expected error was not thrown", "throw")
+			} catch (error) {
+				;(error as Error).message.should.equal("Test error")
+			}
+
+			// Verify environment is restored even after error
+			process.env.TEST_VAR!.should.equal("original")
+		})
+
+		it("should handle multiple environment variable changes", async () => {
+			// Set initial environment
+			process.env.VAR1 = "original1"
+			process.env.VAR2 = "original2"
+			process.env.VAR3 = "original3"
+
+			// Store original values
+			const originalVar1 = process.env.VAR1
+			const originalVar2 = process.env.VAR2
+			const originalVar3 = process.env.VAR3
+
+			await AwsBedrockHandler["withTempEnv"](
+				() => {
+					process.env.VAR1 = "modified1"
+					process.env.VAR2 = "modified2"
+					delete process.env.VAR3
+				},
+				async () => {
+					// Verify environment is modified
+					process.env.VAR1!.should.equal("modified1")
+					process.env.VAR2!.should.equal("modified2")
+					should.not.exist(process.env.VAR3)
+					return "test"
+				},
+			)
+
+			// Verify environment is restored
+			process.env.VAR1!.should.equal(originalVar1)
+			process.env.VAR2!.should.equal(originalVar2)
+			process.env.VAR3!.should.equal(originalVar3)
+		})
+
+		it("should work with AWS_PROFILE", async () => {
+			process.env["AWS_PROFILE"] = "test-profile"
+
+			const preAWSProfile = process.env["AWS_PROFILE"]
+
+			await AwsBedrockHandler["withTempEnv"](
+				() => {
+					delete process.env["AWS_PROFILE"]
+				},
+				async () => {
+					should.not.exist(process.env["AWS_PROFILE"])
+					return "test"
+				},
+			)
+
+			process.env["AWS_PROFILE"]!.should.equal(preAWSProfile)
+		})
+	})
+})

--- a/src/api/providers/bedrock.ts
+++ b/src/api/providers/bedrock.ts
@@ -58,11 +58,11 @@ export class AwsBedrockHandler implements ApiHandler {
 		// initialization, and allowing for session renewal if necessary as well
 		const client = await this.getAnthropicClient()
 
-		// AWS SDK prioritizes AWS_PROFILE over AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY pair
-		// If this is set as an env variable already (ie. from ~/.zshrc) it will override credentials configured by Cline
 		// Use withTempEnv to ensure environment variables are properly restored
 		const stream = await AwsBedrockHandler.withTempEnv(
 			() => {
+				// AWS SDK prioritizes AWS_PROFILE over AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY pair
+				// If this is set as an env variable already (ie. from ~/.zshrc) it will override credentials configured by Cline
 				// Temporarily remove AWS_PROFILE to ensure our credentials are used
 				delete process.env["AWS_PROFILE"]
 			},

--- a/src/api/providers/bedrock.ts
+++ b/src/api/providers/bedrock.ts
@@ -60,54 +60,60 @@ export class AwsBedrockHandler implements ApiHandler {
 
 		// AWS SDK prioritizes AWS_PROFILE over AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY pair
 		// If this is set as an env variable already (ie. from ~/.zshrc) it will override credentials configured by Cline
-		const previousEnv = process.env
-		delete process.env["AWS_PROFILE"]
-		const stream = await client.messages.create({
-			model: modelId,
-			max_tokens: model.info.maxTokens || 8192,
-			thinking: reasoningOn ? { type: "enabled", budget_tokens: budget_tokens } : undefined,
-			temperature: reasoningOn ? undefined : 0,
-			system: [
-				{
-					text: systemPrompt,
-					type: "text",
-					...(this.options.awsBedrockUsePromptCache === true && {
-						cache_control: { type: "ephemeral" },
-					}),
-				},
-			],
-			messages: messages.map((message, index) => {
-				if (index === lastUserMsgIndex || index === secondLastMsgUserIndex) {
-					return {
-						...message,
-						content:
-							typeof message.content === "string"
-								? [
-										{
-											type: "text",
-											text: message.content,
-											...(this.options.awsBedrockUsePromptCache === true && {
-												cache_control: { type: "ephemeral" },
-											}),
-										},
-									]
-								: message.content.map((content, contentIndex) =>
-										contentIndex === message.content.length - 1
-											? {
-													...content,
+		// Use withTempEnv to ensure environment variables are properly restored
+		const stream = await AwsBedrockHandler.withTempEnv(
+			() => {
+				// Temporarily remove AWS_PROFILE to ensure our credentials are used
+				delete process.env["AWS_PROFILE"]
+			},
+			async () => {
+				return await client.messages.create({
+					model: modelId,
+					max_tokens: model.info.maxTokens || 8192,
+					thinking: reasoningOn ? { type: "enabled", budget_tokens: budget_tokens } : undefined,
+					temperature: reasoningOn ? undefined : 0,
+					system: [
+						{
+							text: systemPrompt,
+							type: "text",
+							...(this.options.awsBedrockUsePromptCache === true && {
+								cache_control: { type: "ephemeral" },
+							}),
+						},
+					],
+					messages: messages.map((message, index) => {
+						if (index === lastUserMsgIndex || index === secondLastMsgUserIndex) {
+							return {
+								...message,
+								content:
+									typeof message.content === "string"
+										? [
+												{
+													type: "text",
+													text: message.content,
 													...(this.options.awsBedrockUsePromptCache === true && {
 														cache_control: { type: "ephemeral" },
 													}),
-												}
-											: content,
-									),
-					}
-				}
-				return message
-			}),
-			stream: true,
-		})
-		process.env = previousEnv
+												},
+											]
+										: message.content.map((content, contentIndex) =>
+												contentIndex === message.content.length - 1
+													? {
+															...content,
+															...(this.options.awsBedrockUsePromptCache === true && {
+																cache_control: { type: "ephemeral" },
+															}),
+														}
+													: content,
+											),
+							}
+						}
+						return message
+					}),
+					stream: true,
+				})
+			},
+		)
 
 		for await (const chunk of stream) {
 			switch (chunk.type) {
@@ -297,13 +303,23 @@ export class AwsBedrockHandler implements ApiHandler {
 	}
 
 	private static async withTempEnv<R>(updateEnv: () => void, fn: () => Promise<R>): Promise<R> {
-		const previousEnv = { ...process.env }
+		const previousEnv = Object.assign({}, process.env)
 
 		try {
 			updateEnv()
 			return await fn()
 		} finally {
-			process.env = previousEnv
+			// Restore the previous environment
+			// First clear any new variables that might have been added
+			for (const key in process.env) {
+				if (!(key in previousEnv)) {
+					delete process.env[key]
+				}
+			}
+			// Then restore all previous values
+			for (const key in previousEnv) {
+				process.env[key] = previousEnv[key]
+			}
 		}
 	}
 


### PR DESCRIPTION
### Description

Should be fixing https://github.com/cline/cline/issues/3707.

Seems like this [PR](https://github.com/cline/cline/pull/2888) caused the issue.

### Test Procedure

Added unit test to check process.env correct restoration.

@arafatkatze, I saw that you were [manually testing bedrock fix](https://github.com/cline/cline/pull/2888#pullrequestreview-2794893716) before.
Could you please have a look at this one?

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes environment variable handling in `AwsBedrockHandler` by using `withTempEnv()` to temporarily modify and restore `process.env`.
> 
>   - **Behavior**:
>     - Fixes handling of `process.env` in `AwsBedrockHandler` to ensure `AWS_PROFILE` is temporarily removed and restored using `withTempEnv()`.
>     - Ensures environment variables are restored after API calls in `createMessage()` and `getAwsCredentials()`.
>   - **Functions**:
>     - Adds `withTempEnv()` to handle temporary environment variable changes.
>     - Modifies `createMessage()` and `getAwsCredentials()` to use `withTempEnv()` for environment management.
>   - **Misc**:
>     - Updates `.changeset/sour-boxes-hang.md` to document the patch fix.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for a21dd0f75e2517c7c2be28f1a37a8306ebf5b3c3. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->