### PR TITLE
feat: Added Claude 4 models to Bedrock

### DIFF
--- a/src/api/providers/bedrock.ts
+++ b/src/api/providers/bedrock.ts
@@ -47,7 +47,7 @@ export class AwsBedrockHandler implements ApiHandler {
 		}
 
 		const budget_tokens = this.options.thinkingBudgetTokens || 0
-		const reasoningOn = baseModelId.includes("3-7") && budget_tokens !== 0 ? true : false
+		const reasoningOn = (baseModelId.includes("3-7") || baseModelId.includes("4-")) && budget_tokens !== 0 ? true : false
 
 		// Get model info and message indices for caching
 		const userMsgIndices = messages.reduce((acc, msg, index) => (msg.role === "user" ? [...acc, index] : acc), [] as number[])

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -262,6 +262,28 @@ export const bedrockModels = {
 		// cacheWritesPrice: 0.14, // not written
 		cacheReadsPrice: 0.00875,
 	},
+	"anthropic.claude-sonnet-4-20250514-v1:0": {
+		maxTokens: 64_000,
+		contextWindow: 200_000,
+		supportsImages: true,
+
+		supportsPromptCache: true,
+		inputPrice: 3.0,
+		outputPrice: 15.0,
+		cacheWritesPrice: 3.75,
+		cacheReadsPrice: 0.3,
+	},
+	"anthropic.claude-opus-4-20250514-v1:0": {
+		maxTokens: 32_000,
+		contextWindow: 200_000,
+		supportsImages: true,
+		
+		supportsPromptCache: true,
+		inputPrice: 15.0,
+		outputPrice: 75.0,
+		cacheWritesPrice: 18.75,
+		cacheReadsPrice: 1.5,
+	},
 	"anthropic.claude-3-7-sonnet-20250219-v1:0": {
 		maxTokens: 8192,
 		contextWindow: 200_000,

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -277,7 +277,7 @@ export const bedrockModels = {
 		maxTokens: 32_000,
 		contextWindow: 200_000,
 		supportsImages: true,
-		
+
 		supportsPromptCache: true,
 		inputPrice: 15.0,
 		outputPrice: 75.0,


### PR DESCRIPTION
### Description

Added Claude 4 models to Bedrock.

### Test Procedure

<!-- How did you test this? Are you confident that it will not introduce bugs? If so, why? -->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

### Additional Notes

Used AWS console to verify the model names and limits
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Added Claude 4 models `anthropic.claude-sonnet-4-20250514-v1:0` and `anthropic.claude-opus-4-20250514-v1:0` to Bedrock in `src/shared/api.ts`.
> 
>   - **Models**:
>     - Added `anthropic.claude-sonnet-4-20250514-v1:0` and `anthropic.claude-opus-4-20250514-v1:0` to `bedrockModels` in `src/shared/api.ts`.
>     - `anthropic.claude-sonnet-4-20250514-v1:0` supports 64,000 max tokens, 200,000 context window, images, prompt cache, with input price 3.0, output price 15.0, cache writes price 3.75, cache reads price 0.3.
>     - `anthropic.claude-opus-4-20250514-v1:0` supports 32,000 max tokens, 200,000 context window, images, prompt cache, with input price 15.0, output price 75.0, cache writes price 18.75, cache reads price 1.5.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for c763f2249f29198d9777ad695a3775e5fbb768d5. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->