### PR TITLE
[PROTOBUS] Re-enable streaming state, fix the memory leak probably

### DIFF
--- a/src/core/controller/grpc-handler.ts
+++ b/src/core/controller/grpc-handler.ts
@@ -82,12 +82,6 @@ export class GrpcHandler {
 					sequence_number: sequenceNumber,
 				},
 			})
-			console.log("[PROTOBUS] streaming response (CHECK SEQ)", {
-				responseLength: response.length,
-				request_id: requestId,
-				is_streaming: !isLast,
-				sequence_number: sequenceNumber,
-			})
 		}
 
 		try {

--- a/src/core/controller/grpc-handler.ts
+++ b/src/core/controller/grpc-handler.ts
@@ -82,6 +82,12 @@ export class GrpcHandler {
 					sequence_number: sequenceNumber,
 				},
 			})
+			console.log("[PROTOBUS] streaming response (CHECK SEQ)", {
+				responseLength: response.length,
+				request_id: requestId,
+				is_streaming: !isLast,
+				sequence_number: sequenceNumber,
+			})
 		}
 
 		try {

--- a/src/core/controller/index.ts
+++ b/src/core/controller/index.ts
@@ -1228,10 +1228,7 @@ export class Controller {
 
 	async postStateToWebview() {
 		const state = await this.getStateToPostToWebview()
-		// For testing: Bypass gRPC stream and send state directly
-		console.log("[Controller Test Revert] Posting full state via direct 'state' message.")
-		await this.postMessageToWebview({ type: "state", state: state })
-		// await sendStateUpdate(state) // Original line for the GrPC stream
+		await sendStateUpdate(state)
 	}
 
 	async getStateToPostToWebview(): Promise<ExtensionState> {

--- a/webview-ui/src/context/ExtensionStateContext.tsx
+++ b/webview-ui/src/context/ExtensionStateContext.tsx
@@ -206,60 +206,6 @@ export const ExtensionStateContextProvider: React.FC<{
 				}
 				break
 			}
-			case "state": {
-				// Handler for direct state messages
-				if (message.state) {
-					const stateData = message.state as ExtensionState
-					console.log("[Webview Context Test Revert] Received direct 'state' message, updating state.")
-					setState((prevState) => {
-						// Versioning logic for autoApprovalSettings (copied from original onResponse)
-						const incomingVersion = stateData.autoApprovalSettings?.version ?? 1
-						const currentVersion = prevState.autoApprovalSettings?.version ?? 1
-						const shouldUpdateAutoApproval = incomingVersion > currentVersion
-
-						const newState = {
-							...stateData,
-							autoApprovalSettings: shouldUpdateAutoApproval
-								? stateData.autoApprovalSettings
-								: prevState.autoApprovalSettings,
-						}
-
-						// Update welcome screen state based on API configuration (copied from original onResponse)
-						const config = stateData.apiConfiguration
-						const hasKey = config
-							? [
-									config.apiKey,
-									config.openRouterApiKey,
-									config.awsRegion,
-									config.vertexProjectId,
-									config.openAiApiKey,
-									config.ollamaModelId,
-									config.lmStudioModelId,
-									config.liteLlmApiKey,
-									config.geminiApiKey,
-									config.openAiNativeApiKey,
-									config.deepSeekApiKey,
-									config.requestyApiKey,
-									config.togetherApiKey,
-									config.qwenApiKey,
-									config.doubaoApiKey,
-									config.mistralApiKey,
-									config.vsCodeLmModelSelector,
-									config.clineApiKey,
-									config.asksageApiKey,
-									config.xaiApiKey,
-									config.sambanovaApiKey,
-									config.nebiusApiKey,
-								].some((key) => key !== undefined)
-							: false
-
-						setShowWelcome(!hasKey)
-						setDidHydrateState(true)
-						return newState
-					})
-				}
-				break
-			}
 			case "theme": {
 				if (message.text) {
 					setTheme(convertTextMateToHljs(JSON.parse(message.text)))
@@ -329,33 +275,32 @@ export const ExtensionStateContextProvider: React.FC<{
 	const stateSubscriptionRef = useRef<(() => void) | null>(null)
 
 	// Subscribe to state updates using the new gRPC streaming API
-	/* // TEST REVERT: Commenting out gRPC state subscription
 	useEffect(() => {
 		// Set up state subscription
 		stateSubscriptionRef.current = StateServiceClient.subscribeToState(
 			{},
 			{
 				onResponse: (response) => {
-					console.log("[DEBUG] got state update via subscription", response);
+					console.log("[DEBUG] got state update via subscription", response)
 					if (response.stateJson) {
 						try {
-							const stateData = JSON.parse(response.stateJson) as ExtensionState;
-							console.log("[DEBUG] parsed state JSON, updating state");
+							const stateData = JSON.parse(response.stateJson) as ExtensionState
+							console.log("[DEBUG] parsed state JSON, updating state")
 							setState((prevState) => {
 								// Versioning logic for autoApprovalSettings
-								const incomingVersion = stateData.autoApprovalSettings?.version ?? 1;
-								const currentVersion = prevState.autoApprovalSettings?.version ?? 1;
-								const shouldUpdateAutoApproval = incomingVersion > currentVersion;
+								const incomingVersion = stateData.autoApprovalSettings?.version ?? 1
+								const currentVersion = prevState.autoApprovalSettings?.version ?? 1
+								const shouldUpdateAutoApproval = incomingVersion > currentVersion
 
 								const newState = {
 									...stateData,
 									autoApprovalSettings: shouldUpdateAutoApproval
 										? stateData.autoApprovalSettings
 										: prevState.autoApprovalSettings,
-								};
+								}
 
 								// Update welcome screen state based on API configuration
-								const config = stateData.apiConfiguration;
+								const config = stateData.apiConfiguration
 								const hasKey = config
 									? [
 											config.apiKey,
@@ -380,52 +325,41 @@ export const ExtensionStateContextProvider: React.FC<{
 											config.xaiApiKey,
 											config.sambanovaApiKey,
 										].some((key) => key !== undefined)
-									: false;
+									: false
 
-								setShowWelcome(!hasKey);
-								setDidHydrateState(true);
+								setShowWelcome(!hasKey)
+								setDidHydrateState(true)
 
-								console.log("[DEBUG] returning new state in ESC");
+								console.log("[DEBUG] returning new state in ESC")
 
-								return newState;
-							});
+								return newState
+							})
 						} catch (error) {
-							console.error("Error parsing state JSON:", error);
-							console.log("[DEBUG] ERR getting state", error);
+							console.error("Error parsing state JSON:", error)
+							console.log("[DEBUG] ERR getting state", error)
 						}
 					}
-					console.log('[DEBUG] ended "got subscribed state"');
+					console.log('[DEBUG] ended "got subscribed state"')
 				},
 				onError: (error) => {
-					console.error("Error in state subscription:", error);
+					console.error("Error in state subscription:", error)
 				},
 				onComplete: () => {
-					console.log("State subscription completed");
+					console.log("State subscription completed")
 				},
 			},
-		);
+		)
 
 		// Still send the webviewDidLaunch message for other initialization
-		vscode.postMessage({ type: "webviewDidLaunch" });
+		vscode.postMessage({ type: "webviewDidLaunch" })
 
 		// Clean up subscription when component unmounts
 		return () => {
 			if (stateSubscriptionRef.current) {
-				stateSubscriptionRef.current();
-				stateSubscriptionRef.current = null;
+				stateSubscriptionRef.current()
+				stateSubscriptionRef.current = null
 			}
-		};
-	}, []);
-	*/ // END TEST REVERT
-
-	// For the test revert, ensure webviewDidLaunch is still sent if not done by the above useEffect
-	useEffect(() => {
-		// This effect now only sends webviewDidLaunch if the gRPC subscription is commented out.
-		// If the gRPC subscription is active, it sends webviewDidLaunch.
-		// To avoid sending it twice if you uncomment the above, you might add a flag.
-		// For this specific test (gRPC sub commented out), this is fine.
-		console.log("[Webview Context Test Revert] Sending webviewDidLaunch from separate useEffect.")
-		vscode.postMessage({ type: "webviewDidLaunch" })
+		}
 	}, [])
 
 	const contextValue: ExtensionStateContextType = {

--- a/webview-ui/src/context/ExtensionStateContext.tsx
+++ b/webview-ui/src/context/ExtensionStateContext.tsx
@@ -115,7 +115,7 @@ export const ExtensionStateContextProvider: React.FC<{
 			}
 			setShowMcp(true)
 		},
-		[setShowMcp, setMcpTab, setShowSettings, setShowHistory, setShowAccount],
+		[setShowMcp, setMcpTab, setShowSettings, setShowHistory, setShowAccount]
 	)
 
 	const navigateToSettings = useCallback(() => {
@@ -281,7 +281,6 @@ export const ExtensionStateContextProvider: React.FC<{
 			{},
 			{
 				onResponse: (response) => {
-					console.log("[DEBUG] got state update via subscription", response)
 					if (response.stateJson) {
 						try {
 							const stateData = JSON.parse(response.stateJson) as ExtensionState
@@ -347,7 +346,7 @@ export const ExtensionStateContextProvider: React.FC<{
 				onComplete: () => {
 					console.log("State subscription completed")
 				},
-			},
+			}
 		)
 
 		// Still send the webviewDidLaunch message for other initialization

--- a/webview-ui/src/context/ExtensionStateContext.tsx
+++ b/webview-ui/src/context/ExtensionStateContext.tsx
@@ -115,7 +115,7 @@ export const ExtensionStateContextProvider: React.FC<{
 			}
 			setShowMcp(true)
 		},
-		[setShowMcp, setMcpTab, setShowSettings, setShowHistory, setShowAccount]
+		[setShowMcp, setMcpTab, setShowSettings, setShowHistory, setShowAccount],
 	)
 
 	const navigateToSettings = useCallback(() => {
@@ -346,7 +346,7 @@ export const ExtensionStateContextProvider: React.FC<{
 				onComplete: () => {
 					console.log("State subscription completed")
 				},
-			}
+			},
 		)
 
 		// Still send the webviewDidLaunch message for other initialization

--- a/webview-ui/src/services/grpc-client-base.ts
+++ b/webview-ui/src/services/grpc-client-base.ts
@@ -94,7 +94,6 @@ export function createGrpcClient<T extends ProtoService>(service: T): GrpcClient
 							if (message.grpc_response.message) {
 								const responseType = method.responseType
 								const response = responseType.fromJSON(message.grpc_response.message)
-								console.log("[DEBUG] Received streaming response:", message.grpc_response.message)
 								options.onResponse(response)
 							}
 						}
@@ -149,7 +148,6 @@ export function createGrpcClient<T extends ProtoService>(service: T): GrpcClient
 								// Convert JSON back to protobuf message
 								const responseType = method.responseType
 								const response = responseType.fromJSON(message.grpc_response.message)
-								console.log("[DEBUG] grpc-client sending response:", response)
 								resolve(response)
 							}
 						}


### PR DESCRIPTION
### Description

Previously, we had to revert streaming state because we found that the memory kept increasing. After substantial hair-pulling, I've come to the theory that it's console logs. What happened was, when I wrote the gRPC bridge originally, I decided to log all the objects going through it so that you could see the APIs working. However, state is a very big object, often megabytes in size, so the logging of it (in string form) causes the engine to keep a copy of it. Apparently this problem is substantially worse in node.js as compared to normal browser environments, logs are kept longer and references don't get cleaned up fast

### Test Procedure

1. Open your most expensive task
2. Ask cline to generate a bunch of poems to the display (not a file), to increase the amount of state

Note that the reason we use an expensive task is because it has the biggest state, and the theory is that we end up with multiple copies of it. This effect is much less pronounced in small tasks

#### Current main branch result:

https://github.com/user-attachments/assets/68fa88e9-bbc7-40a5-a884-3cc1f8f7d8c3

#### This PR branch result:

https://github.com/user-attachments/assets/75ffbd9e-8bd0-4822-9e08-e691ff4243b9

#### This PR but with the console.logs left in:

https://github.com/user-attachments/assets/ddf6fa0f-622a-463f-b5d2-02b03774e94a

Conclusion: this works at least as well as the current main & we should try enabling state again

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [x] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

