### PR TITLE
Revert package version to 3.17.2 in package.json

### DIFF
--- a/.changeset/red-pears-do.md
+++ b/.changeset/red-pears-do.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Revert package version to 3.17.2 in package.json

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "claude-dev",
 	"displayName": "Cline",
 	"description": "Autonomous coding agent right in your IDE, capable of creating/editing files, running commands, using the browser, and more with your permission every step of the way.",
-	"version": "3.17.3",
+	"version": "3.17.2",
 	"icon": "assets/icons/icon.png",
 	"engines": {
 		"vscode": "^1.84.0"


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Revert package version from `3.17.3` to `3.17.2` in `package.json`.
> 
>   - **Version Change**:
>     - Revert package version from `3.17.3` to `3.17.2` in `package.json`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for fff3c7925ac169967667c58695ffe69235bc987a. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->