### PR TITLE
feat: provide UI to allow auto retrying failed API requests

### DIFF
--- a/.changeset/few-files-accept.md
+++ b/.changeset/few-files-accept.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": minor
+---
+
+Added a retry option to the auto-approve settings

--- a/proto/state.proto
+++ b/proto/state.proto
@@ -60,4 +60,5 @@ message AutoApprovalSettingsRequest {
   int32 max_requests = 5;
   bool enable_notifications = 6;
   repeated string favorites = 7;
+  bool enable_auto_retry = 8;
 }

--- a/src/core/task/index.ts
+++ b/src/core/task/index.ts
@@ -232,6 +232,9 @@ export class Task {
 		let effectiveApiConfiguration: ApiConfiguration = {
 			...apiConfiguration,
 			taskId: this.taskId,
+			retryOptions: {
+				retryAllErrors: this.autoApprovalSettings.enabled && this.autoApprovalSettings.enableAutoRetry,
+			},
 			onRetryAttempt: (attempt: number, maxRetries: number, delay: number, error: any) => {
 				const lastApiReqStartedIndex = findLastIndex(this.clineMessages, (m) => m.say === "api_req_started")
 				if (lastApiReqStartedIndex !== -1) {

--- a/src/shared/AutoApprovalSettings.ts
+++ b/src/shared/AutoApprovalSettings.ts
@@ -17,6 +17,7 @@ export interface AutoApprovalSettings {
 	// Global settings
 	maxRequests: number // Maximum number of auto-approved requests
 	enableNotifications: boolean // Show notifications for approval and task completion
+	enableAutoRetry: boolean // Automatic retries for failed requests
 	favorites: string[] // IDs of actions favorited by the user for quick access
 }
 
@@ -35,5 +36,6 @@ export const DEFAULT_AUTO_APPROVAL_SETTINGS: AutoApprovalSettings = {
 	},
 	maxRequests: 20,
 	enableNotifications: false,
+	enableAutoRetry: true,
 	favorites: ["enableAutoApprove", "readFiles", "editFiles"],
 }

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -1,3 +1,4 @@
+import { RetryOptions } from "../api/retry"
 import type { LanguageModelChatSelector } from "../api/providers/types"
 
 export type ApiProvider =
@@ -90,6 +91,7 @@ export interface ApiHandlerOptions {
 	reasoningEffort?: string
 	sambanovaApiKey?: string
 	requestTimeoutMs?: number
+	retryOptions?: RetryOptions
 	onRetryAttempt?: (attempt: number, maxRetries: number, delay: number, error: any) => void
 }
 

--- a/src/shared/proto-conversions/models/auto-approval-settings-conversion.ts
+++ b/src/shared/proto-conversions/models/auto-approval-settings-conversion.ts
@@ -19,6 +19,7 @@ export function convertAutoApprovalSettingsToProto(settings: AutoApprovalSetting
 		},
 		maxRequests: settings.maxRequests || 20,
 		enableNotifications: settings.enableNotifications || false,
+		enableAutoRetry: settings.enableAutoRetry || false,
 		favorites: settings.favorites || [],
 	}
 }
@@ -40,6 +41,7 @@ export function convertProtoToAutoApprovalSettings(protoSettings: AutoApprovalSe
 		},
 		maxRequests: protoSettings.maxRequests || 20,
 		enableNotifications: protoSettings.enableNotifications || false,
+		enableAutoRetry: protoSettings.enableAutoRetry || false,
 		favorites: protoSettings.favorites || [],
 	}
 }

--- a/src/shared/proto/state.ts
+++ b/src/shared/proto/state.ts
@@ -73,6 +73,7 @@ export interface AutoApprovalSettingsRequest {
 	maxRequests: number
 	enableNotifications: boolean
 	favorites: string[]
+	enableAutoRetry: boolean
 }
 
 export interface AutoApprovalSettingsRequest_Actions {
@@ -422,6 +423,7 @@ function createBaseAutoApprovalSettingsRequest(): AutoApprovalSettingsRequest {
 		maxRequests: 0,
 		enableNotifications: false,
 		favorites: [],
+		enableAutoRetry: false,
 	}
 }
 
@@ -447,6 +449,9 @@ export const AutoApprovalSettingsRequest: MessageFns<AutoApprovalSettingsRequest
 		}
 		for (const v of message.favorites) {
 			writer.uint32(58).string(v!)
+		}
+		if (message.enableAutoRetry !== false) {
+			writer.uint32(64).bool(message.enableAutoRetry)
 		}
 		return writer
 	},
@@ -514,6 +519,14 @@ export const AutoApprovalSettingsRequest: MessageFns<AutoApprovalSettingsRequest
 					message.favorites.push(reader.string())
 					continue
 				}
+				case 8: {
+					if (tag !== 64) {
+						break
+					}
+
+					message.enableAutoRetry = reader.bool()
+					continue
+				}
 			}
 			if ((tag & 7) === 4 || tag === 0) {
 				break
@@ -532,6 +545,7 @@ export const AutoApprovalSettingsRequest: MessageFns<AutoApprovalSettingsRequest
 			maxRequests: isSet(object.maxRequests) ? globalThis.Number(object.maxRequests) : 0,
 			enableNotifications: isSet(object.enableNotifications) ? globalThis.Boolean(object.enableNotifications) : false,
 			favorites: globalThis.Array.isArray(object?.favorites) ? object.favorites.map((e: any) => globalThis.String(e)) : [],
+			enableAutoRetry: isSet(object.enableAutoRetry) ? globalThis.Boolean(object.enableAutoRetry) : false,
 		}
 	},
 
@@ -558,6 +572,9 @@ export const AutoApprovalSettingsRequest: MessageFns<AutoApprovalSettingsRequest
 		if (message.favorites?.length) {
 			obj.favorites = message.favorites
 		}
+		if (message.enableAutoRetry !== false) {
+			obj.enableAutoRetry = message.enableAutoRetry
+		}
 		return obj
 	},
 
@@ -577,6 +594,7 @@ export const AutoApprovalSettingsRequest: MessageFns<AutoApprovalSettingsRequest
 		message.maxRequests = object.maxRequests ?? 0
 		message.enableNotifications = object.enableNotifications ?? false
 		message.favorites = object.favorites?.map((e) => e) || []
+		message.enableAutoRetry = object.enableAutoRetry ?? false
 		return message
 	},
 }

--- a/webview-ui/src/components/chat/auto-approve-menu/AutoApproveBar.tsx
+++ b/webview-ui/src/components/chat/auto-approve-menu/AutoApproveBar.tsx
@@ -5,7 +5,7 @@ import { CODE_BLOCK_BG_COLOR } from "@/components/common/CodeBlock"
 import { getAsVar, VSC_TITLEBAR_INACTIVE_FOREGROUND } from "@/utils/vscStyles"
 import AutoApproveMenuItem from "./AutoApproveMenuItem"
 import AutoApproveModal from "./AutoApproveModal"
-import { ACTION_METADATA, NOTIFICATIONS_SETTING } from "./constants"
+import { ACTION_METADATA, AUTORETRY_SETTING, NOTIFICATIONS_SETTING } from "./constants"
 
 interface AutoApproveBarProps {
 	style?: React.CSSProperties
@@ -22,7 +22,7 @@ const AutoApproveBar = ({ style }: AutoApproveBarProps) => {
 
 	// Render a favorited item with a checkbox
 	const renderFavoritedItem = (favId: string) => {
-		const actions = [...ACTION_METADATA.flatMap((a) => [a, a.subAction]), NOTIFICATIONS_SETTING]
+		const actions = [...ACTION_METADATA.flatMap((a) => [a, a.subAction]), NOTIFICATIONS_SETTING, AUTORETRY_SETTING]
 		const action = actions.find((a) => a?.id === favId)
 		if (!action) return null
 
@@ -40,6 +40,7 @@ const AutoApproveBar = ({ style }: AutoApproveBarProps) => {
 
 	const getQuickAccessItems = () => {
 		const notificationsEnabled = autoApprovalSettings.enableNotifications
+		const autoRetryEnabled = autoApprovalSettings.enableAutoRetry
 		const enabledActionsNames = Object.keys(autoApprovalSettings.actions).filter(
 			(key) => autoApprovalSettings.actions[key as keyof typeof autoApprovalSettings.actions],
 		)
@@ -51,6 +52,10 @@ const AutoApproveBar = ({ style }: AutoApproveBarProps) => {
 
 		if (notificationsEnabled) {
 			minusFavorites.push(NOTIFICATIONS_SETTING)
+		}
+
+		if (autoRetryEnabled) {
+			minusFavorites.push(AUTORETRY_SETTING)
 		}
 
 		return [
@@ -107,6 +112,7 @@ const AutoApproveBar = ({ style }: AutoApproveBarProps) => {
 				buttonRef={buttonRef}
 				ACTION_METADATA={ACTION_METADATA}
 				NOTIFICATIONS_SETTING={NOTIFICATIONS_SETTING}
+				AUTORETRY_SETTING={AUTORETRY_SETTING}
 			/>
 		</div>
 	)

--- a/webview-ui/src/components/chat/auto-approve-menu/AutoApproveModal.tsx
+++ b/webview-ui/src/components/chat/auto-approve-menu/AutoApproveModal.tsx
@@ -8,6 +8,7 @@ import { getAsVar, VSC_TITLEBAR_INACTIVE_FOREGROUND } from "@/utils/vscStyles"
 import HeroTooltip from "@/components/common/HeroTooltip"
 import AutoApproveMenuItem from "./AutoApproveMenuItem"
 import { ActionMetadata } from "./types"
+import { TextFieldType } from "@vscode/webview-ui-toolkit"
 
 const breakpoint = 500
 
@@ -17,6 +18,7 @@ interface AutoApproveModalProps {
 	buttonRef: React.RefObject<HTMLDivElement>
 	ACTION_METADATA: ActionMetadata[]
 	NOTIFICATIONS_SETTING: ActionMetadata
+	AUTORETRY_SETTING: ActionMetadata
 }
 
 const AutoApproveModal: React.FC<AutoApproveModalProps> = ({
@@ -25,6 +27,7 @@ const AutoApproveModal: React.FC<AutoApproveModalProps> = ({
 	buttonRef,
 	ACTION_METADATA,
 	NOTIFICATIONS_SETTING,
+	AUTORETRY_SETTING,
 }) => {
 	const { autoApprovalSettings } = useExtensionState()
 	const { isChecked, isFavorited, toggleFavorite, updateAction, updateMaxRequests } = useAutoApproveActions()
@@ -155,6 +158,15 @@ const AutoApproveModal: React.FC<AutoApproveModalProps> = ({
 				<AutoApproveMenuItem
 					key={NOTIFICATIONS_SETTING.id}
 					action={NOTIFICATIONS_SETTING}
+					isChecked={isChecked}
+					isFavorited={isFavorited}
+					onToggle={updateAction}
+					onToggleFavorite={toggleFavorite}
+				/>
+
+				<AutoApproveMenuItem
+					key={AUTORETRY_SETTING.id}
+					action={AUTORETRY_SETTING}
 					isChecked={isChecked}
 					isFavorited={isFavorited}
 					onToggle={updateAction}

--- a/webview-ui/src/components/chat/auto-approve-menu/constants.ts
+++ b/webview-ui/src/components/chat/auto-approve-menu/constants.ts
@@ -84,3 +84,11 @@ export const NOTIFICATIONS_SETTING: ActionMetadata = {
 	description: "Receive system notifications when Cline requires approval to proceed or when a task is completed.",
 	icon: "codicon-bell",
 }
+
+export const AUTORETRY_SETTING: ActionMetadata = {
+	id: "enableAutoRetry",
+	label: "Retry failed requests",
+	shortName: "Retry",
+	description: "Allows Cline to automatically retry failed API requests.",
+	icon: "codicon-debug-restart",
+}

--- a/webview-ui/src/components/chat/auto-approve-menu/types.ts
+++ b/webview-ui/src/components/chat/auto-approve-menu/types.ts
@@ -1,7 +1,7 @@
 import { AutoApprovalSettings } from "@shared/AutoApprovalSettings"
 
 export interface ActionMetadata {
-	id: keyof AutoApprovalSettings["actions"] | "enableNotifications" | "enableAll" | "enableAutoApprove"
+	id: keyof AutoApprovalSettings["actions"] | "enableNotifications" | "enableAll" | "enableAutoApprove" | "enableAutoRetry"
 	label: string
 	shortName: string
 	description: string

--- a/webview-ui/src/hooks/useAutoApproveActions.ts
+++ b/webview-ui/src/hooks/useAutoApproveActions.ts
@@ -15,6 +15,8 @@ export function useAutoApproveActions() {
 					return Object.values(autoApprovalSettings.actions).every(Boolean)
 				case "enableNotifications":
 					return autoApprovalSettings.enableNotifications
+				case "enableAutoRetry":
+					return autoApprovalSettings.enableAutoRetry
 				case "enableAutoApprove":
 					return autoApprovalSettings.enabled
 				default:
@@ -72,6 +74,11 @@ export function useAutoApproveActions() {
 
 			if (actionId === "enableNotifications" || subActionId === "enableNotifications") {
 				await updateNotifications(action, value)
+				return
+			}
+
+			if (actionId === "enableAutoRetry" || subActionId === "enableAutoRetry") {
+				await updateAutoRetry(action, value)
 				return
 			}
 
@@ -159,6 +166,19 @@ export function useAutoApproveActions() {
 		[autoApprovalSettings],
 	)
 
+	const updateAutoRetry = useCallback(
+		async (action: ActionMetadata, checked: boolean) => {
+			if (action.id === "enableAutoRetry") {
+				await updateAutoApproveSettings({
+					...autoApprovalSettings,
+					version: (autoApprovalSettings.version ?? 1) + 1,
+					enableAutoRetry: checked,
+				})
+			}
+		},
+		[autoApprovalSettings],
+	)
+
 	return {
 		isChecked,
 		isFavorited,
@@ -168,5 +188,6 @@ export function useAutoApproveActions() {
 		updateAutoApproveEnabled,
 		toggleAll,
 		updateNotifications,
+		updateAutoRetry,
 	}
 }


### PR DESCRIPTION
### Description

This PR adds a new `Retry failed requests`/`enableAutoRetry` feature to the auto-approval settings. The feature allows Cline to automatically retry failed API requests when enabled. The implementation includes:

1. Adding the new field to the protocol buffer definition
2. Updating TypeScript interfaces and default settings
3. Adding UI components for toggling the feature in the auto-approve menu
4. Integrating the setting with the API retry mechanism
5. Setting the default value to `true` for this feature

### Test Procedure

The changes were tested by:
- Verifying the new field is properly serialized/deserialized in protocol buffers
- Ensuring the UI components correctly display and toggle the auto-retry setting
- Confirming the retry mechanism respects the user preference setting
- Testing that failed API requests are retried automatically when the feature is enabled

### Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ♻️ Refactor Changes
- [ ] 💅 Cosmetic Changes
- [ ] 📚 Documentation update
- [ ] 🏃 Workflow Changes

### Pre-flight Checklist

- [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
- [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
  - [ ] i have been unable to run the unit tests locally, the setup errors for me
- [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
- [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

![image](https://github.com/user-attachments/assets/dc495a51-2799-4ce9-aa31-3e37a729f68d)
![image](https://github.com/user-attachments/assets/79c5eb92-a7c4-488f-a718-38a7e4a03fb2)
![image](https://github.com/user-attachments/assets/4160516e-79dc-42c5-889e-d6c77372fe2c)