### PR TITLE
fix: add instruction to use valid SEARCH/REPLACE markers when diff edit fails

### DIFF
--- a/.changeset/proud-trains-give.md
+++ b/.changeset/proud-trains-give.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+fix: add instruction to use valid SEARCH/REPLACE markers when diff edit fails

--- a/src/core/prompts/responses.ts
+++ b/src/core/prompts/responses.ts
@@ -196,7 +196,7 @@ Otherwise, if you have not completed the task and do not need additional informa
 		`${newProblemsMessage}`,
 
 	diffError: (relPath: string, originalContent: string | undefined) =>
-		`This is likely because the SEARCH block content doesn't match exactly with what's in the file, or if you used multiple SEARCH/REPLACE blocks they may not have been in the order they appear in the file.\n\n` +
+		`This is likely because the SEARCH block content doesn't match exactly with what's in the file, or if you used multiple SEARCH/REPLACE blocks they may not have been in the order they appear in the file. (Please also ensure that when using the replace_in_file tool, Do NOT add extra characters to the markers (e.g., <<<<<<< SEARCH> is INVALID). Do NOT forget to use the closing >>>>>>> REPLACE marker. Do NOT modify the marker format in any way. Malformed XML will cause complete tool failure and break the entire editing process.)\n\n` +
 		`The file was reverted to its original state:\n\n` +
 		`<file_content path="${relPath.toPosix()}">\n${originalContent}\n</file_content>\n\n` +
 		`Now that you have the latest state of the file, try the operation again with fewer, more precise SEARCH blocks. For large files especially, it may be prudent to try to limit yourself to <5 SEARCH/REPLACE blocks at a time, then wait for the user to respond with the result of the operation before following up with another replace_in_file call to make additional edits.\n(If you run into this error 3 times in a row, you may use the write_to_file tool as a fallback.)`,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds instructions in `diffError` to ensure valid SEARCH/REPLACE markers in `responses.ts`.
> 
>   - **Behavior**:
>     - Updates `diffError` in `responses.ts` to include instructions on using valid SEARCH/REPLACE markers.
>     - Warns against adding extra characters, forgetting closing markers, and modifying marker format.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 6b5813dd58d23d9f7691553dcc22f21c456c4cd9. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->