### PR TITLE
feat: Add deep link for starting new task

### DIFF
--- a/.changeset/forty-dingos-reply.md
+++ b/.changeset/forty-dingos-reply.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": minor
+---
+
+Add ability to start task via URI

--- a/README.md
+++ b/README.md
@@ -137,6 +137,33 @@ For example, when working with a local web server, you can use 'Restore Workspac
 
 <img width="2000" height="0" src="https://github.com/user-attachments/assets/ee14e6f7-20b8-4391-9091-8e8e25561929"><br>
 
+## Deep Linking
+
+Cline supports a custom URI scheme (`vscode://saoudrizwan.claude-dev/task`) to open the extension and optionally start a new task with a pre-filled message and mode.
+
+**Scheme:** `vscode://saoudrizwan.claude-dev/task?parameters`
+
+**Parameters:**
+
+*   `message` (string, URL-encoded): The initial message for the new task.
+*   `message64` (string, base64-encoded): Alternative to `message` for longer or special character-heavy content. If both `message` and `message64` are provided, `message64` takes precedence.
+*   `mode` (string, optional): Set the initial mode for the task.
+    *   `act` (default): Start in Act Mode.
+    *   `plan`: Start in Plan Mode.
+
+**Examples:**
+
+*   Open Cline with a simple message:
+    ```
+    vscode://saoudrizwan.claude-dev/task?message=Hello%20Cline
+    ```
+*   Open in Plan Mode with a base64 encoded message:
+    ```
+    vscode://saoudrizwan.claude-dev/task?mode=plan&message64=SGVsbG8gV29ybGQ=
+    ```
+
+This feature allows for integration with other tools or scripts that can generate these URIs to automate or streamline workflows involving Cline.
+
 ## Contributing
 
 To contribute to the project, start with our [Contributing Guide](CONTRIBUTING.md) to learn the basics. You can also join our [Discord](https://discord.gg/cline) to chat with other contributors in the `#contributors` channel. If you're looking for full-time work, check out our open positions on our [careers page](https://cline.bot/join-us)!

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "claude-dev",
-	"version": "3.17.2",
+	"version": "3.18.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "claude-dev",
-			"version": "3.17.2",
+			"version": "3.18.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@anthropic-ai/bedrock-sdk": "^0.12.4",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
 		"llama"
 	],
 	"activationEvents": [
+		"onUri",
 		"onLanguage",
 		"onStartupFinished",
 		"workspaceContains:evals.env"


### PR DESCRIPTION
### Description

Allow opening a task with context via a link, like `vscode://saoudrizwan.claude-dev/task?message=Hello%20World`. Makes it easier to integrate with other tools like CI. 

As a follow up, I'd like to figure out the right way to pass the desired workspace as a param and have that work as expected. It's messier than I'd like so I'll keep this as a simple start.

### Test Procedure

These work as expected
```
open "vscode://saoudrizwan.claude-dev/task?message=hello%20from%20deep%20link&mode=plan"
open "vscode://saoudrizwan.claude-dev/task?message=hello%20from%20deep%20link&mode=act"
open "vscode://saoudrizwan.claude-dev/task?message64=aGVsbG8gd29ybGQ=&mode=plan"
```

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes


### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

I wanted to write a simple test for this change, but there were persistent, confusing errors with `ERR_UNKNOWN_FILE_EXTENSION` that I see mentioned in other PRs like #3630 and #3246, so I went with simple manual verification for now.

### Screenshots
<img width="275" alt="Screenshot 2025-05-23 at 2 22 19 PM" src="https://github.com/user-attachments/assets/dda00446-7eb2-4b40-9ec4-b07b9925c65a" />
<img width="406" alt="Screenshot 2025-05-23 at 2 22 24 PM" src="https://github.com/user-attachments/assets/a18308c1-0512-4fcc-9b8c-737b94f5ed10" />


### Additional Notes


<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add deep linking feature to start tasks via URI with parameters for message and mode, including tests and documentation.
> 
>   - **Feature**:
>     - Add `handleDeepLink` method in `Controller` to start tasks via URI with parameters `message`, `message64`, and `mode`.
>     - Update `README.md` to document the new deep linking feature with examples.
>     - Add `onUri` to `activationEvents` in `package.json`.
>   - **Misc**:
>     - Log errors and warnings in `handleDeepLink` for invalid base64 messages and missing workspace folders.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for e11f678ddebd1e47a97a6aba282d57a0e640021a. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add deep linking feature to start tasks via URI with parameters for message and mode, including tests and documentation.
> 
>   - **Feature**:
>     - Add `handleDeepLink` method in `Controller` to start tasks via URI with parameters `message`, `message64`, and `mode`.
>     - Update `README.md` to document the new deep linking feature with examples.
>     - Add `onUri` to `activationEvents` in `package.json`.
>   - **Tests**:
>     - Add `deepLink.test.ts` to test various scenarios for the `handleDeepLink` method, including valid and invalid URIs.
>   - **Misc**:
>     - Log errors and warnings in `handleDeepLink` for invalid base64 messages and missing workspace folders.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for e6aa0a252c3599a58233ded6ea767dd34c3ec21b. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>
