### PR TITLE
fix(mcp): fix error loading config when running MCP Server with npx and bunx

### DIFF
--- a/src/services/mcp/McpHub.ts
+++ b/src/services/mcp/McpHub.ts
@@ -222,6 +222,7 @@ export class McpHub {
 					env: {
 						...config.env,
 						...(process.env.PATH ? { PATH: process.env.PATH } : {}),
+						...(process.env.HOME ? { HOME: process.env.HOME } : {}),
 						// ...(process.env.NODE_PATH ? { NODE_PATH: process.env.NODE_PATH } : {}),
 					},
 					stderr: "pipe", // necessary for stderr to be available
@@ -338,6 +339,7 @@ export class McpHub {
 					env: {
 						...config.env,
 						...(process.env.PATH ? { PATH: process.env.PATH } : {}),
+						...(process.env.HOME ? { HOME: process.env.HOME } : {}),
 						// ...(process.env.NODE_PATH ? { NODE_PATH: process.env.NODE_PATH } : {}),
 					},
 					stderr: "pipe", // necessary for stderr to be available


### PR DESCRIPTION
### Description

The MCP Server was throwing an error 'error loading config: $HOME is not defined' when run using npx and bunx. This was due to the HOME environment variable not being set in the environment. The fix involves setting the HOME environment variable if it is available in the process environment.

### Test Procedure

Issue: #3794

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes missing `$HOME` environment variable in `McpHub` class when running MCP Server with `npx` and `bunx`.
> 
>   - **Behavior**:
>     - Fixes error in `McpHub` class in `McpHub.ts` where `$HOME` environment variable was not set when running MCP Server with `npx` and `bunx`.
>     - Adds check and sets `HOME` environment variable if available in `process.env` in two places within `McpHub.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for b83ee167a4d87df20bbd2e145e9ed7ebcaf0bdfc. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->