### PR TITLE
Update `xaiModels` object and `xaiDefaultModelId` in `src/shared/api.ts`

### DIFF
--- a/.changeset/beige-lizards-cry.md
+++ b/.changeset/beige-lizards-cry.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": minor
+---
+
+Update `xaiModels` object and `xaiDefaultModelId` in `src/shared/api.ts`

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -1713,7 +1713,7 @@ export const nebiusDefaultModelId = "Qwen/Qwen2.5-32B-Instruct-fast" satisfies N
 // X AI
 // https://docs.x.ai/docs/api-reference
 export type XAIModelId = keyof typeof xaiModels
-export const xaiDefaultModelId: XAIModelId = "grok-3-beta"
+export const xaiDefaultModelId: XAIModelId = "grok-3"
 export const xaiModels = {
 	"grok-3-beta": {
 		maxTokens: 8192,
@@ -1750,6 +1750,42 @@ export const xaiModels = {
 		inputPrice: 0.6,
 		outputPrice: 4.0,
 		description: "X AI's Grok-3 mini fast beta model with 131K context window",
+	},
+	"grok-3": {
+		maxTokens: 8192,
+		contextWindow: 131072,
+		supportsImages: false,
+		supportsPromptCache: false,
+		inputPrice: 3.0,
+		outputPrice: 15.0,
+		description: "X AI's Grok-3 model with 131K context window",
+	},
+	"grok-3-fast": {
+		maxTokens: 8192,
+		contextWindow: 131072,
+		supportsImages: false,
+		supportsPromptCache: false,
+		inputPrice: 5.0,
+		outputPrice: 25.0,
+		description: "X AI's Grok-3 fast model with 131K context window",
+	},
+	"grok-3-mini": {
+		maxTokens: 8192,
+		contextWindow: 131072,
+		supportsImages: false,
+		supportsPromptCache: false,
+		inputPrice: 0.3,
+		outputPrice: 0.5,
+		description: "X AI's Grok-3 mini model with 131K context window",
+	},
+	"grok-3-mini-fast": {
+		maxTokens: 8192,
+		contextWindow: 131072,
+		supportsImages: false,
+		supportsPromptCache: false,
+		inputPrice: 0.6,
+		outputPrice: 4.0,
+		description: "X AI's Grok-3 mini fast model with 131K context window",
 	},
 	"grok-2-latest": {
 		maxTokens: 8192,


### PR DESCRIPTION
### Description

This PR adds non-beta versions of Grok-3 models to the X AI API configuration and updates the default model from `grok-3-beta` to the stable `grok-3` release.

**Changes:**
- Added four new stable Grok-3 model variants: `grok-3`, `grok-3-fast`, `grok-3-mini`, and `grok-3-mini-fast`
- Updated `xaiDefaultModelId` from `grok-3-beta` to `grok-3`
- All new models maintain the same 131K context window and pricing structure as their beta counterparts

### Test Procedure

This change is configuration-only and adds new model options without removing existing ones. No functional testing is required as:
- The change only extends the available model list
- The default model update uses the same API structure
- Existing beta models remain available for backward compatibility

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [[contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A - Configuration changes only

### Additional Notes

This update aligns with X AI's release of stable Grok-3 models, providing users with production-ready alternatives to the beta versions while maintaining full backward compatibility.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add stable Grok-3 models to `xaiModels` and update `xaiDefaultModelId` to `grok-3` in `src/shared/api.ts`.
> 
>   - **Models**:
>     - Added stable Grok-3 models: `grok-3`, `grok-3-fast`, `grok-3-mini`, `grok-3-mini-fast` to `xaiModels` in `src/shared/api.ts`.
>     - Updated `xaiDefaultModelId` from `grok-3-beta` to `grok-3` in `src/shared/api.ts`.
>   - **Behavior**:
>     - New models have the same 131K context window and pricing as beta versions.
>     - Configuration-only change; no functional testing required.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for b8b365a555a1221be4a08bb7851e9ea4f6d6b2ab. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->