### PR TITLE
feat: Add delay information when retrying requests

### DIFF
--- a/.changeset/shaggy-seahorses-study.md
+++ b/.changeset/shaggy-seahorses-study.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Display delay information when retrying API calls

--- a/webview-ui/src/components/chat/ChatRow.tsx
+++ b/webview-ui/src/components/chat/ChatRow.tsx
@@ -189,6 +189,8 @@ const ChatRow = memo(
 
 export default ChatRow
 
+const formatDelay = (seconds: number) => (seconds ? ` ${seconds} seconds delay` : "")
+
 export const ChatRowContent = ({
 	message,
 	isExpanded,
@@ -453,7 +455,7 @@ export const ChatRowContent = ({
 									style={{
 										color: normalColor,
 										fontWeight: "bold",
-									}}>{`API Request (Retrying failed attempt ${retryStatus.attempt}/${retryOperations})...`}</span>
+									}}>{`API Request (Retrying failed attempt ${retryStatus.attempt}/${retryOperations}.${formatDelay(retryStatus.delaySec)})...`}</span>
 							)
 						}
 


### PR DESCRIPTION
### Description

Some users on Discord report long loading states. I am unsure if it's because the delay is long or because there is [another instance of status not being properly displayed](https://github.com/cline/cline/pull/3571).
Adding this information to the screen might shed some light on it.

### Test Procedure

Verified locally:
<img width="243" alt="image" src="https://github.com/user-attachments/assets/1ca296d6-5998-491e-8550-018753001b9e" />


### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

When there are seconds:
<img width="243" alt="image" src="https://github.com/user-attachments/assets/eb063064-435e-403e-a9d4-506b4aef1b6a" />

Once the countdown gets to 0 and we are waiting for a response:
<img width="247" alt="image" src="https://github.com/user-attachments/assets/b362cdd1-1fe5-4582-a1f4-b2b648b6b67f" />


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add delay information display for retrying API requests in `ChatRowContent`.
> 
>   - **Behavior**:
>     - Display delay information when retrying API requests in `ChatRowContent`.
>     - Uses `formatDelay()` to format delay in seconds.
>   - **Functions**:
>     - Adds `formatDelay(seconds: number)` to format delay message.
>     - Modifies retry message in `ChatRowContent` to include delay using `formatDelay()`.
>   - **Misc**:
>     - Adds changeset `shaggy-seahorses-study.md` to document the feature addition.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for b38224896fe832222dece6a0c033389220099d47. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->