### PR TITLE
Fix scroll jumping during query/search (#3789)

### DIFF
--- a/webview-ui/src/components/chat/ChatView.tsx
+++ b/webview-ui/src/components/chat/ChatView.tsx
@@ -130,6 +130,7 @@ const ChatView = ({ isHidden, showAnnouncement, hideAnnouncement, showHistoryVie
 	const disableAutoScrollRef = useRef(false)
 	const [showScrollToBottom, setShowScrollToBottom] = useState(false)
 	const [isAtBottom, setIsAtBottom] = useState(false)
+	const userHasManuallyScrolledRef = useRef(false)
 
 	useEffect(() => {
 		const handleCopy = async (e: ClipboardEvent) => {
@@ -501,6 +502,7 @@ const ChatView = ({ isHidden, showAnnouncement, hideAnnouncement, showHistoryVie
 				// setPrimaryButtonText(undefined)
 				// setSecondaryButtonText(undefined)
 				disableAutoScrollRef.current = false
+				userHasManuallyScrolledRef.current = false // Reset manual scroll tracking
 			}
 		},
 		[messages.length, clineAsk, activeQuote],
@@ -568,6 +570,7 @@ const ChatView = ({ isHidden, showAnnouncement, hideAnnouncement, showHistoryVie
 			// setPrimaryButtonText(undefined)
 			// setSecondaryButtonText(undefined)
 			disableAutoScrollRef.current = false
+			userHasManuallyScrolledRef.current = false // Reset manual scroll tracking
 		},
 		[clineAsk, startNewTask, lastMessage],
 	)
@@ -605,8 +608,7 @@ const ChatView = ({ isHidden, showAnnouncement, hideAnnouncement, showHistoryVie
 					}
 					// Clear input state after sending
 					setInputValue("")
-					setActiveQuote(null) // Clear quote when using secondary button
-					setSelectedImages([])
+					setActiveQuote(null) // Clear quote when using secondary button				setSelectedImages([])
 					break
 			}
 			setSendingDisabled(true)
@@ -615,6 +617,7 @@ const ChatView = ({ isHidden, showAnnouncement, hideAnnouncement, showHistoryVie
 			// setPrimaryButtonText(undefined)
 			// setSecondaryButtonText(undefined)
 			disableAutoScrollRef.current = false
+			userHasManuallyScrolledRef.current = false // Reset manual scroll tracking
 		},
 		[clineAsk, startNewTask, isStreaming],
 	)
@@ -947,8 +950,9 @@ const ChatView = ({ isHidden, showAnnouncement, hideAnnouncement, showHistoryVie
 		const wheelEvent = event as WheelEvent
 		if (wheelEvent.deltaY && wheelEvent.deltaY < 0) {
 			if (scrollContainerRef.current?.contains(wheelEvent.target as Node)) {
-				// user scrolled up
+				// user scrolled up - mark as manually scrolled
 				disableAutoScrollRef.current = true
+				userHasManuallyScrolledRef.current = true
 			}
 		}
 	}, [])
@@ -1085,7 +1089,9 @@ const ChatView = ({ isHidden, showAnnouncement, hideAnnouncement, showHistoryVie
 							itemContent={itemContent}
 							atBottomStateChange={(isAtBottom) => {
 								setIsAtBottom(isAtBottom)
-								if (isAtBottom) {
+								if (isAtBottom && !userHasManuallyScrolledRef.current) {
+									// Only re-enable auto-scroll if user hasn't manually scrolled away
+									// This prevents interrupting user navigation during streaming
 									disableAutoScrollRef.current = false
 								}
 								setShowScrollToBottom(disableAutoScrollRef.current && !isAtBottom)


### PR DESCRIPTION
### Description

This PR prevents the chat view from auto-scrolling when a query is running and the user is manually browsing older messages. It solves issue #3789 by locking the scroll until the user scrolls back to the bottom.

---

### Test Procedure

* Ran a query and scrolled up while results streamed in.
* Verified scroll position stayed fixed until manually scrolled to bottom.
* Retested normal streaming to ensure auto-scroll still works when user hasn’t interacted.

---

### Type of Change

* [x] 🐛 Bug fix (non-breaking change which fixes an issue)

---

### Pre-flight Checklist

* [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
* [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
* [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
* [x] I have reviewed [[contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

---

### Screenshots

*Not a UI-visible change.*

---

### Additional Notes

None. Simple fix, smooth UX now.