### PR TITLE
[PROTOBUS] optionsResponse migration/removal

### DIFF
--- a/.changeset/rare-students-appear.md
+++ b/.changeset/rare-students-appear.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+optionsResponse protobus migration

--- a/src/core/controller/index.ts
+++ b/src/core/controller/index.ts
@@ -290,11 +290,6 @@ export class Controller {
 				}
 				await this.postStateToWebview()
 				break
-			case "optionsResponse":
-				if (this.task) {
-					await this.task.handleWebviewAskResponse("messageResponse", message.text || "", [])
-				}
-				break
 			case "fetchUserCreditsData": {
 				await this.fetchUserCreditsData()
 				break

--- a/src/shared/WebviewMessage.ts
+++ b/src/shared/WebviewMessage.ts
@@ -23,7 +23,6 @@ export interface WebviewMessage {
 		| "updateSettings"
 		| "clearAllTaskHistory"
 		| "fetchUserCreditsData"
-		| "optionsResponse"
 		| "searchFiles"
 		| "grpc_request"
 		| "grpc_request_cancel"

--- a/webview-ui/src/components/chat/OptionsButtons.tsx
+++ b/webview-ui/src/components/chat/OptionsButtons.tsx
@@ -1,6 +1,6 @@
 import styled from "styled-components"
 import { CODE_BLOCK_BG_COLOR } from "@/components/common/CodeBlock"
-import { vscode } from "@/utils/vscode"
+import { TaskServiceClient } from "@/services/grpc-client"
 
 const OptionButton = styled.button<{ isSelected?: boolean; isNotSelectable?: boolean }>`
 	padding: 8px 12px;
@@ -56,14 +56,19 @@ export const OptionsButtons = ({
 					key={index}
 					isSelected={option === selected}
 					isNotSelectable={hasSelected || !isActive}
-					onClick={() => {
+					onClick={async () => {
 						if (hasSelected || !isActive) {
 							return
 						}
-						vscode.postMessage({
-							type: "optionsResponse",
-							text: option + (inputValue ? `: ${inputValue?.trim()}` : ""),
-						})
+						try {
+							await TaskServiceClient.askResponse({
+								responseType: "messageResponse",
+								text: option + (inputValue ? `: ${inputValue?.trim()}` : ""),
+								images: [],
+							})
+						} catch (error) {
+							console.error("Error sending option response:", error)
+						}
 					}}>
 					<span className="ph-no-capture">{option}</span>
 				</OptionButton>


### PR DESCRIPTION
### Description

This PR removes the optionsResponse message, replacing it with TaskServiceClient.askResponse.

### Test Procedure

This message is used when users select an option from provided feedback questions. Ask Cline to return feedback questions, choose one, and confirm Cline receives the response.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [X] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [X] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [X] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [X] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [X] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove `optionsResponse` and replace with `TaskServiceClient.askResponse` for handling feedback options.
> 
>   - **Behavior**:
>     - Remove `optionsResponse` handling in `Controller.handleWebviewMessage()` in `index.ts`.
>     - Replace `vscode.postMessage` with `TaskServiceClient.askResponse` in `OptionsButtons.tsx` for sending option responses.
>   - **Webview Message**:
>     - Remove `optionsResponse` from `WebviewMessage` type in `WebviewMessage.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 701789d5cd7a341010639fcd8aec21684f7727cd. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->