### PR TITLE
[PROTOBUS] showChatView protobus removal

### DIFF
--- a/.changeset/purple-rings-sit.md
+++ b/.changeset/purple-rings-sit.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+showChatView protobus migration

--- a/src/core/controller/index.ts
+++ b/src/core/controller/index.ts
@@ -263,13 +263,6 @@ export class Controller {
 					}
 				})
 				break
-			case "showChatView": {
-				this.postMessageToWebview({
-					type: "action",
-					action: "chatButtonClicked",
-				})
-				break
-			}
 			case "newTask":
 				// Code that should run in response to the hello message command
 				//vscode.window.showInformationMessage(message.text!)

--- a/src/shared/WebviewMessage.ts
+++ b/src/shared/WebviewMessage.ts
@@ -13,7 +13,6 @@ export interface WebviewMessage {
 		| "newTask"
 		| "condense"
 		| "reportBug"
-		| "showChatView"
 		| "requestVsCodeLmModels"
 		| "authStateChanged"
 		| "fetchMcpMarketplace"

--- a/webview-ui/src/components/chat/ChatView.tsx
+++ b/webview-ui/src/components/chat/ChatView.tsx
@@ -661,8 +661,7 @@ const ChatView = ({ isHidden, showAnnouncement, hideAnnouncement, showHistoryVie
 						case "focusChatInput":
 							textAreaRef.current?.focus()
 							if (isHidden) {
-								// Send message back to extension to show chat view
-								vscode.postMessage({ type: "showChatView" })
+								window.dispatchEvent(new CustomEvent("chatButtonClicked"))
 							}
 							break
 					}


### PR DESCRIPTION
### Description

This message was determined to be unnecessary as it was passing a request from the webview, to the extension, and back to the webview again.

### Test Procedure

Same test procedures as #3640 - Increment the version in package.json, rub in debug, and confirm Cline is brought into focus once it loads.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [X] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [X] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [X] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [X] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [X] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove `showChatView` protobus message handling and replace it with a custom event dispatch in `ChatView.tsx`.
> 
>   - **Behavior**:
>     - Remove `showChatView` message handling in `Controller` class in `index.ts`.
>     - Remove `showChatView` from `WebviewMessage` interface in `WebviewMessage.ts`.
>     - Replace `vscode.postMessage({ type: "showChatView" })` with `window.dispatchEvent(new CustomEvent("chatButtonClicked"))` in `ChatView.tsx`.
>   - **Misc**:
>     - Update changeset to reflect `showChatView` protobus migration.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 206cb48ea10babdfdd6021f5911c07bc500794b7. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->