### PR TITLE
Unused message - browserConnectionResult removal/cleanup

### DIFF
--- a/.changeset/clean-kiwis-fly.md
+++ b/.changeset/clean-kiwis-fly.md
@@ -1,0 +1,6 @@
+---
+"claude-dev": patch
+---
+
+browserConnectionResult protobus migration/removal
+

--- a/src/shared/ExtensionMessage.ts
+++ b/src/shared/ExtensionMessage.ts
@@ -35,7 +35,6 @@ export interface ExtensionMessage {
 		| "userCreditsBalance"
 		| "userCreditsUsage"
 		| "userCreditsPayments"
-		| "browserConnectionResult"
 		| "fileSearchResults"
 		| "grpc_response" // New type for gRPC responses
 	text?: string

--- a/webview-ui/src/components/settings/BrowserSettingsSection.tsx
+++ b/webview-ui/src/components/settings/BrowserSettingsSection.tsx
@@ -59,20 +59,6 @@ export const BrowserSettingsSection: React.FC = () => {
 	const [isBundled, setIsBundled] = useState(false)
 	const [detectedChromePath, setDetectedChromePath] = useState<string | null>(null)
 
-	// Listen for browser connection test results
-	useEffect(() => {
-		const handleMessage = (event: MessageEvent) => {
-			const message = event.data
-			if (message.type === "browserConnectionResult") {
-				setConnectionStatus(message.success)
-				setIsCheckingConnection(false)
-			}
-		}
-
-		window.addEventListener("message", handleMessage)
-		return () => window.removeEventListener("message", handleMessage)
-	}, [])
-
 	// Auto-clear relaunch result message after 15 seconds
 	useEffect(() => {
 		if (relaunchResult) {


### PR DESCRIPTION
### Description

browserConnectionResult was not being used, this PR removes it from BrowserSettings and ExtensionMessage.

### Test Procedure

Confirm browser connection attempts/successes still work. To do this, open the browser settings tab with Chrome closed and confirm connection attempts are made (check debug logging). Then open Chrome, confirm Cline connects,  and that connection attempt cease.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [X] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [X] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [X] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [X] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [X] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove unused `browserConnectionResult` from `ExtensionMessage` and related cleanup in `BrowserSettingsSection.tsx`.
> 
>   - **Removal**:
>     - Remove `browserConnectionResult` from `ExtensionMessage` in `ExtensionMessage.ts`.
>     - Remove `useEffect` handling `browserConnectionResult` in `BrowserSettingsSection.tsx`.
>   - **Behavior**:
>     - Confirm browser connection attempts and successes still function correctly without `browserConnectionResult`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 95bc44c77d1102ffdc7d0a08b3f7eb274c6aa900. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->