### PR TITLE
Fixes and refines MCP HTTP transport support

### DIFF
--- a/.changeset/short-moose-relax.md
+++ b/.changeset/short-moose-relax.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": minor
+---
+
+Fix streameable-http support for MCP

--- a/src/services/mcp/McpHub.ts
+++ b/src/services/mcp/McpHub.ts
@@ -142,6 +142,16 @@ export class McpHub {
 				return undefined
 			}
 
+			// Backward compatibility: default transportType to "stdio" if missing
+			if (config && config.mcpServers) {
+				for (const [name, server] of Object.entries(config.mcpServers)) {
+					const srv = server as Record<string, any>
+					if (!srv.transportType) {
+						srv.transportType = "stdio"
+					}
+				}
+			}
+
 			// Validate against schema
 			const result = McpSettingsSchema.safeParse(config)
 			if (!result.success) {

--- a/src/services/mcp/McpHub.ts
+++ b/src/services/mcp/McpHub.ts
@@ -55,30 +55,23 @@ const BaseConfigSchema = z.object({
 })
 
 const SseConfigSchema = BaseConfigSchema.extend({
+	transportType: z.literal("sse"),
 	url: z.string().url(),
-}).transform((config) => ({
-	...config,
-	transportType: "sse" as const,
-}))
+})
 
 const StdioConfigSchema = BaseConfigSchema.extend({
+	transportType: z.literal("stdio"),
 	command: z.string(),
 	args: z.array(z.string()).optional(),
 	env: z.record(z.string()).optional(),
-}).transform((config) => ({
-	...config,
-	transportType: "stdio" as const,
-}))
+})
 
 const StreamableHTTPConfigSchema = BaseConfigSchema.extend({
 	transportType: z.literal("http"),
 	url: z.string().url(),
-}).transform((config) => ({
-	...config,
-	transportType: "http" as const,
-}))
+})
 
-const ServerConfigSchema = z.union([StdioConfigSchema, SseConfigSchema, StreamableHTTPConfigSchema])
+const ServerConfigSchema = z.discriminatedUnion("transportType", [StdioConfigSchema, SseConfigSchema, StreamableHTTPConfigSchema])
 
 const McpSettingsSchema = z.object({
 	mcpServers: z.record(ServerConfigSchema),


### PR DESCRIPTION
### Description

<!-- Describe your changes in detail. What problem does this PR solve? -->

Fix MCP server on Streamable HTTP transport support.

### Test Procedure

<!-- How did you test this? Are you confident that it will not introduce bugs? If so, why? -->

locally tested with a sse server and HTTP server.

```json
{
  "mcpServers": {
    "mcp-sse": {
      "autoApprove": [],
      "disabled": false,
      "timeout": 60,
      "transportType": "sse",
      "url": "http://localhost:8081/v1/sse"
    },
    "mcp-http": {
      "autoApprove": [],
      "disabled": false,
      "timeout": 60,
      "transportType": "http",
      "url": "http://localhost:8080/v1/mcp/"
    }
  }
}
```

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [x] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

### Additional Notes

<!-- Add any additional notes for reviewers -->

previous PR https://github.com/cline/cline/pull/3413 seems like not working as expected. issue: https://github.com/cline/cline/issues/3315

Similar changes were done [here](https://github.com/cline/cline/pull/3716) but reverted due to backwards compatibility.
