### PR TITLE
sreamable "http" transport config fix

### DIFF
--- a/src/services/mcp/McpHub.ts
+++ b/src/services/mcp/McpHub.ts
@@ -55,6 +55,7 @@ const BaseConfigSchema = z.object({
 })
 
 const SseConfigSchema = BaseConfigSchema.extend({
+	transportType: z.literal("sse").optional(),
 	url: z.string().url(),
 }).transform((config) => ({
 	...config,
@@ -62,6 +63,7 @@ const SseConfigSchema = BaseConfigSchema.extend({
 }))
 
 const StdioConfigSchema = BaseConfigSchema.extend({
+	transportType: z.literal("stdio").optional(),
 	command: z.string(),
 	args: z.array(z.string()).optional(),
 	env: z.record(z.string()).optional(),
@@ -71,14 +73,14 @@ const StdioConfigSchema = BaseConfigSchema.extend({
 }))
 
 const StreamableHTTPConfigSchema = BaseConfigSchema.extend({
-	transportType: z.literal("http"),
+	transportType: z.literal("http").optional(),
 	url: z.string().url(),
 }).transform((config) => ({
 	...config,
 	transportType: "http" as const,
 }))
 
-const ServerConfigSchema = z.union([StdioConfigSchema, SseConfigSchema, StreamableHTTPConfigSchema])
+export const ServerConfigSchema = z.union([StdioConfigSchema, SseConfigSchema, StreamableHTTPConfigSchema])
 
 const McpSettingsSchema = z.object({
 	mcpServers: z.record(ServerConfigSchema),

--- a/src/test/services/mcp/McpHub.schema.test.ts
+++ b/src/test/services/mcp/McpHub.schema.test.ts
@@ -1,0 +1,104 @@
+import { describe, it } from "mocha"
+import { expect } from "chai"
+import { z } from "zod"
+import { ServerConfigSchema } from "@services/mcp/McpHub"
+
+describe("McpHub Schema Validation Tests", () => {
+	it("should correctly parse HTTP config when transportType is explicit", () => {
+		// Config with explicit HTTP transportType
+		const httpConfig = {
+			url: "http://localhost:3000/mcp",
+			transportType: "http",
+			disabled: false,
+			timeout: 60,
+			autoApprove: [],
+		}
+
+		const result = ServerConfigSchema.safeParse(httpConfig)
+
+		// It should succeed and parse correctly
+		expect(result.success).to.be.true
+
+		if (result.success) {
+			// It should be parsed as HTTP with the fix
+			expect(result.data.transportType).to.equal("http")
+		}
+	})
+
+	it("should work with configs that omit transportType to fallback to sse", () => {
+		// Without explicit transportType, using URL implies it's a remote server
+		const httpConfig = {
+			url: "http://localhost:3000/mcp",
+			disabled: false,
+			timeout: 60,
+			autoApprove: [],
+		}
+
+		const result = ServerConfigSchema.safeParse(httpConfig)
+
+		expect(result.success).to.be.true
+
+		if (result.success) {
+			// With our fix, URLs should be treated as HTTP when transportType is not specified
+			expect(result.data.transportType).to.equal("sse")
+		}
+	})
+
+	it("should correctly parse stdio config when transportType is explicit", () => {
+		const stdioConfig = {
+			command: "node",
+			args: ["server.js"],
+			transportType: "stdio",
+			disabled: false,
+			timeout: 60,
+			autoApprove: [],
+		}
+
+		const result = ServerConfigSchema.safeParse(stdioConfig)
+
+		expect(result.success).to.be.true
+
+		if (result.success) {
+			expect(result.data.transportType).to.equal("stdio")
+		}
+	})
+
+	describe("Validation with incorrect schema", () => {
+		it("should reject configs with invalid transportType", () => {
+			const invalidConfig = {
+				url: "http://localhost:3000/mcp",
+				transportType: "invalid", // Not one of the allowed transportTypes
+				disabled: false,
+				timeout: 60,
+				autoApprove: [],
+			}
+
+			const result = ServerConfigSchema.safeParse(invalidConfig)
+			expect(result.success).to.be.false
+		})
+
+		it("should reject configs with missing required fields", () => {
+			// Missing both url and command, which means it matches neither HTTP/SSE nor stdio
+			const invalidConfig = {
+				disabled: false,
+				timeout: 60,
+				autoApprove: [],
+			}
+
+			const result = ServerConfigSchema.safeParse(invalidConfig)
+			expect(result.success).to.be.false
+		})
+
+		it("should reject configs with invalid field types", () => {
+			const invalidConfig = {
+				url: "not-a-valid-url", // Invalid URL format
+				disabled: false,
+				timeout: 60,
+				autoApprove: [],
+			}
+
+			const result = ServerConfigSchema.safeParse(invalidConfig)
+			expect(result.success).to.be.false
+		})
+	})
+})


### PR DESCRIPTION
The fix ensures that when you pass a config with transportType: "http", it will be correctly parsed as HTTP rather than sse, while maintaining backward compatibility with all other config formats.

### Description

<!-- Describe your changes in detail. What problem does this PR solve? -->

### Test Procedure

<!-- How did you test this? Are you confident that it will not introduce bugs? If so, why? -->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes parsing of `transportType: "http"` in `McpHub.ts` and adds tests to validate configuration parsing.
> 
>   - **Behavior**:
>     - Fixes parsing of `transportType: "http"` in `StreamableHTTPConfigSchema` in `McpHub.ts` to ensure it is recognized as HTTP.
>     - Maintains backward compatibility for configurations without explicit `transportType`, defaulting to SSE.
>   - **Tests**:
>     - Adds `McpHub.schema.test.ts` to test parsing of HTTP, SSE, and stdio configurations.
>     - Validates correct parsing of explicit and implicit transport types.
>     - Ensures invalid configurations are rejected.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 18fb1640b12daae0fafcf27b66f1a4e835407763. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->