### PR TITLE
 skip empty lines in the original content (when the corresponding line in the search content is non-empty)

### DIFF
--- a/src/core/assistant-message/diff.ts
+++ b/src/core/assistant-message/diff.ts
@@ -27,11 +27,19 @@ function lineTrimmedFallbackMatch(originalContent: string, searchContent: string
 	// For each possible starting position in original content
 	for (let i = startLineNum; i <= originalLines.length - searchLines.length; i++) {
 		let matches = true
+		let emptyLineCount = 0
 
 		// Try to match all search lines from this position
 		for (let j = 0; j < searchLines.length; j++) {
-			const originalTrimmed = originalLines[i + j].trim()
-			const searchTrimmed = searchLines[j].trim()
+			let originalTrimmed = originalLines[i + j].trim()
+			let searchTrimmed = searchLines[j].trim()
+
+			// skpi empty lines in the original content (when the corresponding line in the search content is non-empty)
+			while(searchTrimmed !=='' && originalTrimmed ==='' && i+j < originalLines.length - searchLines.length){
+				i++
+				emptyLineCount++
+				originalTrimmed = originalLines[i+j].trim()
+			}
 
 			if (originalTrimmed !== searchTrimmed) {
 				matches = false


### PR DESCRIPTION
 skpi empty lines in the original content (when the corresponding line in the search content is non-empty)

### Description

<!-- Describe your changes in detail. What problem does this PR solve? -->

### Test Procedure

<!-- How did you test this? Are you confident that it will not introduce bugs? If so, why? -->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [ ] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> In `lineTrimmedFallbackMatch`, skip empty lines in `originalContent` when the corresponding `searchContent` line is non-empty.
> 
>   - **Behavior**:
>     - In `lineTrimmedFallbackMatch` in `diff.ts`, skip empty lines in `originalContent` when the corresponding `searchContent` line is non-empty.
>     - Adjusts the loop to increment `i` and count skipped lines when encountering empty lines in `originalContent`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for a4ac0328d913284f1d631741c8c113c68fe9f390. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->