### PR TITLE
Update star icon alignment within Auto-approve settings, to avoid confusion from double-column format 

### DIFF
--- a/webview-ui/src/components/chat/auto-approve-menu/AutoApproveMenuItem.tsx
+++ b/webview-ui/src/components/chat/auto-approve-menu/AutoApproveMenuItem.tsx
@@ -94,27 +94,27 @@ const AutoApproveMenuItem = ({
 				<HeroTooltip content={action.description} delay={500}>
 					<CheckboxContainer isFavorited={favorited} onClick={onChange}>
 						<div className="left-content">
+							{onToggleFavorite && !condensed && (
+								<HeroTooltip
+									delay={500}
+									content={favorited ? "Remove from quick-access menu" : "Add to quick-access menu"}>
+									<span
+										className={`p-0.5 codicon codicon-${favorited ? "star-full" : "star-empty"} star`}
+										style={{
+											cursor: "pointer",
+										}}
+										onClick={async (e) => {
+											e.stopPropagation()
+											if (action.id === "enableAll") return
+											await onToggleFavorite?.(action.id)
+										}}
+									/>
+								</HeroTooltip>
+							)}
 							<VSCodeCheckbox checked={checked} />
 							{showIcon && <span className={`codicon ${action.icon} icon`}></span>}
 							<span className="label">{condensed ? action.shortName : action.label}</span>
 						</div>
-						{onToggleFavorite && !condensed && (
-							<HeroTooltip
-								delay={500}
-								content={favorited ? "Remove from quick-access menu" : "Add to quick-access menu"}>
-								<span
-									className={`p-0.5 codicon codicon-${favorited ? "star-full" : "star-empty"} star`}
-									style={{
-										cursor: "pointer",
-									}}
-									onClick={async (e) => {
-										e.stopPropagation()
-										if (action.id === "enableAll") return
-										await onToggleFavorite?.(action.id)
-									}}
-								/>
-							</HeroTooltip>
-						)}
 					</CheckboxContainer>
 				</HeroTooltip>
 			</ActionButtonContainer>


### PR DESCRIPTION
### Description

Fix for #3916 
Update star icon alignment within Auto-approve settings, to avoid confusion from double-column format.

Before:
![image](https://github.com/user-attachments/assets/37b32441-7dd3-442a-ae44-9496031adc4e)

After:
![image](https://github.com/user-attachments/assets/3eb806af-ba7e-43db-a312-44f0f6c22a42)


### Test Procedure

This is an icon alignment change and does not impact any other functionalities. Like there is no functionality change as such.

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [X] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [X] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [X] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [X] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Added above

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adjusts star icon alignment in `AutoApproveMenuItem` for improved visual clarity.
> 
>   - **UI Update**:
>     - Adjusts star icon alignment in `AutoApproveMenuItem` to improve visual clarity.
>     - Moves star icon inside `.left-content` div for better alignment.
>   - **Code Changes**:
>     - Reorders JSX elements in `AutoApproveMenuItem` to place the star icon before the checkbox.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 7d6f03650a20bc334bc7ed3ea1c9744e39c925ef. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->