### PR TITLE
Use the webview-ui linter during `npm run lint`

### DIFF
--- a/package.json
+++ b/package.json
@@ -279,7 +279,7 @@
 		"watch-tests": "tsc -p . -w --outDir out",
 		"pretest": "npm run compile-tests && npm run compile && npm run compile-standalone && npm run lint",
 		"check-types": "npm run protos && tsc --noEmit",
-		"lint": "eslint src --ext ts && eslint webview-ui/src --ext ts",
+		"lint": "eslint src --ext ts && eslint webview-ui/src --ext ts && cd webview-ui && npm run lint",
 		"format": "prettier . --check",
 		"format:fix": "prettier . --write",
 		"test": "npm-run-all test:unit test:integration",

--- a/webview-ui/src/utils/slash-commands.ts
+++ b/webview-ui/src/utils/slash-commands.ts
@@ -75,9 +75,9 @@ export function getWorkflowCommands(
 
 // Regex for detecting slash commands in text
 // currently doesn't allow whitespace inside of the filename
-export const slashCommandRegex = /\/([a-zA-Z0-9_\.-]+)(\s|$)/
+export const slashCommandRegex = /\/([a-zA-Z0-9_.-]+)(\s|$)/
 export const slashCommandRegexGlobal = new RegExp(slashCommandRegex.source, "g")
-export const slashCommandDeleteRegex = /^\s*\/([a-zA-Z0-9_\.-]+)$/
+export const slashCommandDeleteRegex = /^\s*\/([a-zA-Z0-9_.-]+)$/
 
 /**
  * Removes a slash command at the cursor position


### PR DESCRIPTION
The webview-ui has an existing eslint config, but it was not being run as part of the `npm run lint` command. 

Start running the webview specific linter (the top level linter doesn't run on tsx files, and webview linter has react specific checks). 

Fix lint errors in slash-commands file.

### Test Procedure

`npm run lint`

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

NA

### Additional Notes

NA


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add webview-ui linter to `npm run lint` and fix regex lint errors in `slash-commands.ts`.
> 
>   - **Linting**:
>     - Add webview-ui linter to `npm run lint` in `package.json`.
>     - Fix lint errors in `slash-commands.ts` by updating regex patterns to remove unnecessary escape characters.
>   - **Regex**:
>     - Update `slashCommandRegex` and `slashCommandDeleteRegex` in `slash-commands.ts` to `/([a-zA-Z0-9_.-]+)(\s|$)/` and `/^\s*\/([a-zA-Z0-9_.-]+)$/` respectively.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 517f5e30fa8f4e4a87ceb10a9881d0f38f389738. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->