### PR TITLE
Fix linter warning for Protobus ServiceClient calls using object literals

### DIFF
--- a/webview-ui/src/components/browser/BrowserSettingsMenu.tsx
+++ b/webview-ui/src/components/browser/BrowserSettingsMenu.tsx
@@ -1,9 +1,8 @@
+import { useExtensionState } from "@/context/ExtensionStateContext"
+import { EmptyRequest, StringRequest } from "@shared/proto/common"
 import { VSCodeButton } from "@vscode/webview-ui-toolkit/react"
 import { useEffect, useRef, useState } from "react"
 import styled from "styled-components"
-import { useExtensionState } from "@/context/ExtensionStateContext"
-import { vscode } from "@/utils/vscode"
-import { CODE_BLOCK_BG_COLOR } from "../common/CodeBlock"
 import { BrowserServiceClient, UiServiceClient } from "../../services/grpc-client"
 
 interface ConnectionInfo {
@@ -29,7 +28,7 @@ export const BrowserSettingsMenu = () => {
 		;(async () => {
 			try {
 				console.log("[DEBUG] SENDING BROWSER CONNECTION INFO REQUEST")
-				const info = await BrowserServiceClient.getBrowserConnectionInfo({})
+				const info = await BrowserServiceClient.getBrowserConnectionInfo(EmptyRequest.create({}))
 				console.log("[DEBUG] GOT BROWSER REPLY:", info, typeof info)
 				setConnectionInfo({
 					isConnected: info.isConnected,
@@ -71,7 +70,7 @@ export const BrowserSettingsMenu = () => {
 		// After a short delay, send a message to scroll to browser settings
 		setTimeout(async () => {
 			try {
-				await UiServiceClient.scrollToSettings({ value: "browser" })
+				await UiServiceClient.scrollToSettings(StringRequest.create({ value: "browser" }))
 			} catch (error) {
 				console.error("Error scrolling to browser settings:", error)
 			}
@@ -85,7 +84,7 @@ export const BrowserSettingsMenu = () => {
 		if (!showInfoPopover) {
 			const fetchConnectionInfo = async () => {
 				try {
-					const info = await BrowserServiceClient.getBrowserConnectionInfo({})
+					const info = await BrowserServiceClient.getBrowserConnectionInfo(EmptyRequest.create({}))
 					setConnectionInfo({
 						isConnected: info.isConnected,
 						isRemote: info.isRemote,
@@ -125,7 +124,7 @@ export const BrowserSettingsMenu = () => {
 		// Function to fetch connection info
 		const fetchConnectionInfo = async () => {
 			try {
-				const info = await BrowserServiceClient.getBrowserConnectionInfo({})
+				const info = await BrowserServiceClient.getBrowserConnectionInfo(EmptyRequest.create({}))
 				setConnectionInfo({
 					isConnected: info.isConnected,
 					isRemote: info.isRemote,

--- a/webview-ui/src/components/chat/BrowserSessionRow.tsx
+++ b/webview-ui/src/components/chat/BrowserSessionRow.tsx
@@ -1,16 +1,17 @@
+import { BrowserSettingsMenu } from "@/components/browser/BrowserSettingsMenu"
+import { ChatRowContent, ProgressIndicator } from "@/components/chat/ChatRow"
+import { CheckpointControls } from "@/components/common/CheckpointControls"
+import CodeBlock, { CODE_BLOCK_BG_COLOR } from "@/components/common/CodeBlock"
+import { useExtensionState } from "@/context/ExtensionStateContext"
+import { FileServiceClient } from "@/services/grpc-client"
+import { BROWSER_VIEWPORT_PRESETS } from "@shared/BrowserSettings"
+import { BrowserAction, BrowserActionResult, ClineMessage, ClineSayBrowserAction } from "@shared/ExtensionMessage"
+import { StringRequest } from "@shared/proto/common"
 import { VSCodeButton } from "@vscode/webview-ui-toolkit/react"
 import deepEqual from "fast-deep-equal"
 import React, { CSSProperties, memo, useEffect, useMemo, useRef, useState } from "react"
 import { useSize } from "react-use"
 import styled from "styled-components"
-import { BROWSER_VIEWPORT_PRESETS } from "@shared/BrowserSettings"
-import { BrowserAction, BrowserActionResult, ClineMessage, ClineSayBrowserAction } from "@shared/ExtensionMessage"
-import { useExtensionState } from "@/context/ExtensionStateContext"
-import { FileServiceClient } from "@/services/grpc-client"
-import { BrowserSettingsMenu } from "@/components/browser/BrowserSettingsMenu"
-import { CheckpointControls } from "@/components/common/CheckpointControls"
-import CodeBlock, { CODE_BLOCK_BG_COLOR } from "@/components/common/CodeBlock"
-import { ChatRowContent, ProgressIndicator } from "@/components/chat/ChatRow"
 
 interface BrowserSessionRowProps {
 	messages: ClineMessage[]
@@ -404,8 +405,8 @@ const BrowserSessionRow = memo((props: BrowserSessionRowProps) => {
 							alt="Browser screenshot"
 							style={imgScreenshotStyle}
 							onClick={() =>
-								FileServiceClient.openImage({ value: displayState.screenshot }).catch((err) =>
-									console.error("Failed to open image:", err),
+								FileServiceClient.openImage(StringRequest.create({ value: displayState.screenshot })).catch(
+									(err) => console.error("Failed to open image:", err),
 								)
 							}
 						/>

--- a/webview-ui/src/components/chat/ChatRow.tsx
+++ b/webview-ui/src/components/chat/ChatRow.tsx
@@ -1,9 +1,21 @@
-import { VSCodeBadge, VSCodeProgressRing, VSCodeButton } from "@vscode/webview-ui-toolkit/react"
+import { VSCodeBadge, VSCodeButton, VSCodeProgressRing } from "@vscode/webview-ui-toolkit/react"
 import deepEqual from "fast-deep-equal"
-import React, { memo, useCallback, useEffect, useMemo, useRef, useState, MouseEvent } from "react"
+import React, { memo, MouseEvent, useCallback, useEffect, useMemo, useRef, useState } from "react"
 
-import { useEvent, useSize } from "react-use"
-import styled from "styled-components"
+import CreditLimitError from "@/components/chat/CreditLimitError"
+import { OptionsButtons } from "@/components/chat/OptionsButtons"
+import TaskFeedbackButtons from "@/components/chat/TaskFeedbackButtons"
+import { CheckmarkControl } from "@/components/common/CheckmarkControl"
+import CodeBlock, { CODE_BLOCK_BG_COLOR } from "@/components/common/CodeBlock"
+import MarkdownBlock from "@/components/common/MarkdownBlock"
+import SuccessButton from "@/components/common/SuccessButton"
+import McpResponseDisplay from "@/components/mcp/chat-display/McpResponseDisplay"
+import McpResourceRow from "@/components/mcp/configuration/tabs/installed/server-row/McpResourceRow"
+import McpToolRow from "@/components/mcp/configuration/tabs/installed/server-row/McpToolRow"
+import { useExtensionState } from "@/context/ExtensionStateContext"
+import { FileServiceClient, TaskServiceClient } from "@/services/grpc-client"
+import { findMatchingResourceOrTemplate, getMcpServerDisplayName } from "@/utils/mcp"
+import { vscode } from "@/utils/vscode"
 import {
 	ClineApiReqInfo,
 	ClineAskQuestion,
@@ -15,11 +27,15 @@ import {
 	ExtensionMessage,
 } from "@shared/ExtensionMessage"
 import { COMMAND_OUTPUT_STRING, COMMAND_REQ_APP_STRING } from "@shared/combineCommandSequences"
-import { useExtensionState } from "@/context/ExtensionStateContext"
-import { findMatchingResourceOrTemplate, getMcpServerDisplayName } from "@/utils/mcp"
-import { vscode } from "@/utils/vscode"
-import { FileServiceClient, TaskServiceClient } from "@/services/grpc-client"
-import { CheckmarkControl } from "@/components/common/CheckmarkControl"
+import { Int64Request, StringRequest } from "@shared/proto/common"
+import { useEvent, useSize } from "react-use"
+import styled from "styled-components"
+import { CheckpointControls } from "../common/CheckpointControls"
+import CodeAccordian, { cleanPathPrefix } from "../common/CodeAccordian"
+import NewTaskPreview from "./NewTaskPreview"
+import QuoteButton from "./QuoteButton"
+import ReportBugPreview from "./ReportBugPreview"
+import UserMessage from "./UserMessage"
 
 interface CopyButtonProps {
 	textToCopy: string | undefined
@@ -76,23 +92,6 @@ const WithCopyButton = React.forwardRef<HTMLDivElement, WithCopyButtonProps>(
 		)
 	},
 )
-import { CheckpointControls, CheckpointOverlay } from "../common/CheckpointControls"
-import CodeAccordian, { cleanPathPrefix } from "../common/CodeAccordian"
-import CodeBlock, { CODE_BLOCK_BG_COLOR } from "@/components/common/CodeBlock"
-import MarkdownBlock from "@/components/common/MarkdownBlock"
-import Thumbnails from "@/components/common/Thumbnails"
-import McpToolRow from "@/components/mcp/configuration/tabs/installed/server-row/McpToolRow"
-import McpResponseDisplay from "@/components/mcp/chat-display/McpResponseDisplay"
-import CreditLimitError from "@/components/chat/CreditLimitError"
-import { OptionsButtons } from "@/components/chat/OptionsButtons"
-import { highlightText } from "./TaskHeader"
-import SuccessButton from "@/components/common/SuccessButton"
-import TaskFeedbackButtons from "@/components/chat/TaskFeedbackButtons"
-import NewTaskPreview from "./NewTaskPreview"
-import ReportBugPreview from "./ReportBugPreview"
-import McpResourceRow from "@/components/mcp/configuration/tabs/installed/server-row/McpResourceRow"
-import UserMessage from "./UserMessage"
-import QuoteButton from "./QuoteButton"
 
 const ChatRowContainer = styled.div`
 	padding: 10px 6px 10px 15px;
@@ -582,7 +581,7 @@ export const ChatRowContent = ({
 									msUserSelect: "none",
 								}}
 								onClick={() => {
-									FileServiceClient.openFile({ value: tool.content }).catch((err) =>
+									FileServiceClient.openFile(StringRequest.create({ value: tool.content })).catch((err) =>
 										console.error("Failed to open file:", err),
 									)
 								}}>
@@ -1284,9 +1283,11 @@ export const ChatRowContent = ({
 										disabled={seeNewChangesDisabled}
 										onClick={() => {
 											setSeeNewChangesDisabled(true)
-											TaskServiceClient.taskCompletionViewChanges({
-												value: message.ts,
-											}).catch((err) => console.error("Failed to show task completion view changes:", err))
+											TaskServiceClient.taskCompletionViewChanges(
+												Int64Request.create({
+													value: message.ts,
+												}),
+											).catch((err) => console.error("Failed to show task completion view changes:", err))
 										}}
 										style={{
 											cursor: seeNewChangesDisabled ? "wait" : "pointer",
@@ -1447,9 +1448,11 @@ export const ChatRowContent = ({
 											disabled={seeNewChangesDisabled}
 											onClick={() => {
 												setSeeNewChangesDisabled(true)
-												TaskServiceClient.taskCompletionViewChanges({
-													value: message.ts,
-												}).catch((err) =>
+												TaskServiceClient.taskCompletionViewChanges(
+													Int64Request.create({
+														value: message.ts,
+													}),
+												).catch((err) =>
 													console.error("Failed to show task completion view changes:", err),
 												)
 											}}>

--- a/webview-ui/src/components/chat/ChatView.tsx
+++ b/webview-ui/src/components/chat/ChatView.tsx
@@ -35,6 +35,8 @@ import rehypeParse from "rehype-parse"
 import HomeHeader from "../welcome/HomeHeader"
 import AutoApproveBar from "./auto-approve-menu/AutoApproveBar"
 import { SuggestedTasks } from "../welcome/SuggestedTasks"
+import { EmptyRequest, StringRequest } from "@shared/proto/common"
+import { AskResponseRequest, NewTaskRequest } from "@shared/proto/task"
 
 interface ChatViewProps {
 	isHidden: boolean
@@ -206,7 +208,7 @@ const ChatView = ({ isHidden, showAnnouncement, hideAnnouncement, showHistoryVie
 
 					if (textToCopy !== null) {
 						try {
-							FileServiceClient.copyToClipboard({ value: textToCopy }).catch((err) => {
+							FileServiceClient.copyToClipboard(StringRequest.create({ value: textToCopy })).catch((err) => {
 								console.error("Error copying to clipboard:", err)
 							})
 							e.preventDefault()
@@ -461,7 +463,7 @@ const ChatView = ({ isHidden, showAnnouncement, hideAnnouncement, showHistoryVie
 			if (hasContent) {
 				console.log("[ChatView] handleSendMessage - Sending message:", messageToSend)
 				if (messages.length === 0) {
-					await TaskServiceClient.newTask({ text: messageToSend, images, files })
+					await TaskServiceClient.newTask(NewTaskRequest.create({ text: messageToSend, images, files }))
 				} else if (clineAsk) {
 					switch (clineAsk) {
 						case "followup":
@@ -478,12 +480,14 @@ const ChatView = ({ isHidden, showAnnouncement, hideAnnouncement, showHistoryVie
 						case "new_task": // user can provide feedback or reject the new task suggestion
 						case "condense":
 						case "report_bug":
-							await TaskServiceClient.askResponse({
-								responseType: "messageResponse",
-								text: messageToSend,
-								images,
-								files,
-							})
+							await TaskServiceClient.askResponse(
+								AskResponseRequest.create({
+									responseType: "messageResponse",
+									text: messageToSend,
+									images,
+									files,
+								}),
+							)
 							break
 						// there is no other case that a textfield should be enabled
 					}
@@ -505,7 +509,7 @@ const ChatView = ({ isHidden, showAnnouncement, hideAnnouncement, showHistoryVie
 
 	const startNewTask = useCallback(async () => {
 		setActiveQuote(null) // Clear the active quote state
-		await TaskServiceClient.clearTask({})
+		await TaskServiceClient.clearTask(EmptyRequest.create({}))
 	}, [])
 
 	/*
@@ -525,16 +529,20 @@ const ChatView = ({ isHidden, showAnnouncement, hideAnnouncement, showHistoryVie
 				case "mistake_limit_reached":
 				case "auto_approval_max_req_reached":
 					if (trimmedInput || (images && images.length > 0) || (files && files.length > 0)) {
-						await TaskServiceClient.askResponse({
-							responseType: "yesButtonClicked",
-							text: trimmedInput,
-							images: images,
-							files: files,
-						})
+						await TaskServiceClient.askResponse(
+							AskResponseRequest.create({
+								responseType: "yesButtonClicked",
+								text: trimmedInput,
+								images: images,
+								files: files,
+							}),
+						)
 					} else {
-						await TaskServiceClient.askResponse({
-							responseType: "yesButtonClicked",
-						})
+						await TaskServiceClient.askResponse(
+							AskResponseRequest.create({
+								responseType: "yesButtonClicked",
+							}),
+						)
 					}
 					// Clear input state after sending
 					setInputValue("")
@@ -549,17 +557,23 @@ const ChatView = ({ isHidden, showAnnouncement, hideAnnouncement, showHistoryVie
 					break
 				case "new_task":
 					console.info("new task button clicked!", { lastMessage, messages, clineAsk, text })
-					await TaskServiceClient.newTask({
-						text: lastMessage?.text,
-						images: [],
-						files: [],
-					})
+					await TaskServiceClient.newTask(
+						NewTaskRequest.create({
+							text: lastMessage?.text,
+							images: [],
+							files: [],
+						}),
+					)
 					break
 				case "condense":
-					await SlashServiceClient.condense({ value: lastMessage?.text }).catch((err) => console.error(err))
+					await SlashServiceClient.condense(StringRequest.create({ value: lastMessage?.text })).catch((err) =>
+						console.error(err),
+					)
 					break
 				case "report_bug":
-					await SlashServiceClient.reportBug({ value: lastMessage?.text }).catch((err) => console.error(err))
+					await SlashServiceClient.reportBug(StringRequest.create({ value: lastMessage?.text })).catch((err) =>
+						console.error(err),
+					)
 					break
 			}
 			setSendingDisabled(true)
@@ -576,7 +590,7 @@ const ChatView = ({ isHidden, showAnnouncement, hideAnnouncement, showHistoryVie
 		async (text?: string, images?: string[], files?: string[]) => {
 			const trimmedInput = text?.trim()
 			if (isStreaming) {
-				await TaskServiceClient.cancelTask({})
+				await TaskServiceClient.cancelTask(EmptyRequest.create({}))
 				setDidClickCancel(true)
 				return
 			}
@@ -592,17 +606,21 @@ const ChatView = ({ isHidden, showAnnouncement, hideAnnouncement, showHistoryVie
 				case "browser_action_launch":
 				case "use_mcp_server":
 					if (trimmedInput || (images && images.length > 0) || (files && files.length > 0)) {
-						await TaskServiceClient.askResponse({
-							responseType: "noButtonClicked",
-							text: trimmedInput,
-							images: images,
-							files: files,
-						})
+						await TaskServiceClient.askResponse(
+							AskResponseRequest.create({
+								responseType: "noButtonClicked",
+								text: trimmedInput,
+								images: images,
+								files: files,
+							}),
+						)
 					} else {
 						// responds to the API with a "This operation failed" and lets it try again
-						await TaskServiceClient.askResponse({
-							responseType: "noButtonClicked",
-						})
+						await TaskServiceClient.askResponse(
+							AskResponseRequest.create({
+								responseType: "noButtonClicked",
+							}),
+						)
 					}
 					// Clear input state after sending
 					setInputValue("")
@@ -697,34 +715,31 @@ const ChatView = ({ isHidden, showAnnouncement, hideAnnouncement, showHistoryVie
 
 	// Set up addToInput subscription
 	useEffect(() => {
-		const cleanup = UiServiceClient.subscribeToAddToInput(
-			{},
-			{
-				onResponse: (event) => {
-					if (event.value) {
-						setInputValue((prevValue) => {
-							const newText = event.value
-							const newTextWithNewline = newText + "\n"
-							return prevValue ? `${prevValue}\n${newTextWithNewline}` : newTextWithNewline
-						})
-						// Add scroll to bottom after state update
-						// Auto focus the input and start the cursor on a new line for easy typing
-						setTimeout(() => {
-							if (textAreaRef.current) {
-								textAreaRef.current.scrollTop = textAreaRef.current.scrollHeight
-								textAreaRef.current.focus()
-							}
-						}, 0)
-					}
-				},
-				onError: (error) => {
-					console.error("Error in addToInput subscription:", error)
-				},
-				onComplete: () => {
-					console.log("addToInput subscription completed")
-				},
+		const cleanup = UiServiceClient.subscribeToAddToInput(EmptyRequest.create({}), {
+			onResponse: (event) => {
+				if (event.value) {
+					setInputValue((prevValue) => {
+						const newText = event.value
+						const newTextWithNewline = newText + "\n"
+						return prevValue ? `${prevValue}\n${newTextWithNewline}` : newTextWithNewline
+					})
+					// Add scroll to bottom after state update
+					// Auto focus the input and start the cursor on a new line for easy typing
+					setTimeout(() => {
+						if (textAreaRef.current) {
+							textAreaRef.current.scrollTop = textAreaRef.current.scrollHeight
+							textAreaRef.current.focus()
+						}
+					}, 0)
+				}
 			},
-		)
+			onError: (error) => {
+				console.error("Error in addToInput subscription:", error)
+			},
+			onComplete: () => {
+				console.log("addToInput subscription completed")
+			},
+		})
 
 		return cleanup
 	}, [])

--- a/webview-ui/src/components/chat/CreditLimitError.tsx
+++ b/webview-ui/src/components/chat/CreditLimitError.tsx
@@ -1,7 +1,8 @@
-import React from "react"
 import VSCodeButtonLink from "@/components/common/VSCodeButtonLink"
-import { VSCodeButton } from "@vscode/webview-ui-toolkit/react"
 import { TaskServiceClient } from "@/services/grpc-client"
+import { AskResponseRequest } from "@shared/proto/task"
+import { VSCodeButton } from "@vscode/webview-ui-toolkit/react"
+import React from "react"
 
 interface CreditLimitErrorProps {
 	currentBalance: number
@@ -41,11 +42,13 @@ const CreditLimitError: React.FC<CreditLimitErrorProps> = ({ currentBalance, tot
 			<VSCodeButton
 				onClick={async () => {
 					try {
-						await TaskServiceClient.askResponse({
-							responseType: "yesButtonClicked",
-							text: "",
-							images: [],
-						})
+						await TaskServiceClient.askResponse(
+							AskResponseRequest.create({
+								responseType: "yesButtonClicked",
+								text: "",
+								images: [],
+							}),
+						)
 					} catch (error) {
 						console.error("Error invoking action:", error)
 					}

--- a/webview-ui/src/components/chat/OptionsButtons.tsx
+++ b/webview-ui/src/components/chat/OptionsButtons.tsx
@@ -1,6 +1,7 @@
-import styled from "styled-components"
 import { CODE_BLOCK_BG_COLOR } from "@/components/common/CodeBlock"
 import { TaskServiceClient } from "@/services/grpc-client"
+import { AskResponseRequest } from "@shared/proto/task"
+import styled from "styled-components"
 
 const OptionButton = styled.button<{ isSelected?: boolean; isNotSelectable?: boolean }>`
 	padding: 8px 12px;
@@ -61,11 +62,13 @@ export const OptionsButtons = ({
 							return
 						}
 						try {
-							await TaskServiceClient.askResponse({
-								responseType: "messageResponse",
-								text: option + (inputValue ? `: ${inputValue?.trim()}` : ""),
-								images: [],
-							})
+							await TaskServiceClient.askResponse(
+								AskResponseRequest.create({
+									responseType: "messageResponse",
+									text: option + (inputValue ? `: ${inputValue?.trim()}` : ""),
+									images: [],
+								}),
+							)
 						} catch (error) {
 							console.error("Error sending option response:", error)
 						}

--- a/webview-ui/src/components/chat/TaskFeedbackButtons.tsx
+++ b/webview-ui/src/components/chat/TaskFeedbackButtons.tsx
@@ -1,8 +1,9 @@
-import React, { useState, useEffect } from "react"
-import styled from "styled-components"
 import { TaskServiceClient } from "@/services/grpc-client"
-import { VSCodeButton } from "@vscode/webview-ui-toolkit/react"
 import { TaskFeedbackType } from "@shared/WebviewMessage"
+import { StringRequest } from "@shared/proto/common"
+import { VSCodeButton } from "@vscode/webview-ui-toolkit/react"
+import React, { useEffect, useState } from "react"
+import styled from "styled-components"
 
 interface TaskFeedbackButtonsProps {
 	messageTs: number
@@ -47,9 +48,11 @@ const TaskFeedbackButtons: React.FC<TaskFeedbackButtonsProps> = ({ messageTs, is
 		setFeedback(type)
 
 		try {
-			await TaskServiceClient.taskFeedback({
-				value: type,
-			})
+			await TaskServiceClient.taskFeedback(
+				StringRequest.create({
+					value: type,
+				}),
+			)
 
 			// Store in localStorage that feedback was provided for this message
 			try {

--- a/webview-ui/src/components/chat/TaskHeader.tsx
+++ b/webview-ui/src/components/chat/TaskHeader.tsx
@@ -1,18 +1,17 @@
+import HeroTooltip from "@/components/common/HeroTooltip"
+import Thumbnails from "@/components/common/Thumbnails"
+import { normalizeApiConfiguration } from "@/components/settings/ApiOptions"
+import { useExtensionState } from "@/context/ExtensionStateContext"
+import { FileServiceClient, TaskServiceClient, UiServiceClient } from "@/services/grpc-client"
+import { formatLargeNumber, formatSize } from "@/utils/format"
+import { validateSlashCommand } from "@/utils/slash-commands"
+import { mentionRegexGlobal } from "@shared/context-mentions"
+import { ClineMessage } from "@shared/ExtensionMessage"
+import { StringArrayRequest, StringRequest } from "@shared/proto/common"
 import { VSCodeButton } from "@vscode/webview-ui-toolkit/react"
 import React, { memo, useEffect, useMemo, useRef, useState } from "react"
 import { useWindowSize } from "react-use"
-import { mentionRegexGlobal } from "@shared/context-mentions"
-import { ClineMessage } from "@shared/ExtensionMessage"
-import { useExtensionState } from "@/context/ExtensionStateContext"
-import { formatLargeNumber } from "@/utils/format"
-import { formatSize } from "@/utils/format"
-import { vscode } from "@/utils/vscode"
-import Thumbnails from "@/components/common/Thumbnails"
-import { normalizeApiConfiguration } from "@/components/settings/ApiOptions"
-import { validateSlashCommand } from "@/utils/slash-commands"
 import TaskTimeline from "./TaskTimeline"
-import { TaskServiceClient, FileServiceClient, UiServiceClient } from "@/services/grpc-client"
-import HeroTooltip from "@/components/common/HeroTooltip"
 const { IS_DEV } = process.env
 
 interface TaskHeaderProps {
@@ -501,7 +500,9 @@ const TaskHeader: React.FC<TaskHeaderProps> = ({
 														// After a short delay, send a message to scroll to settings
 														setTimeout(async () => {
 															try {
-																await UiServiceClient.scrollToSettings({ value: "features" })
+																await UiServiceClient.scrollToSettings(
+																	StringRequest.create({ value: "features" }),
+																)
 															} catch (error) {
 																console.error("Error scrolling to checkpoint settings:", error)
 															}
@@ -610,7 +611,7 @@ export const highlightMentions = (text: string, withShadow = true) => {
 					key={index}
 					className={withShadow ? "mention-context-highlight-with-shadow" : "mention-context-highlight"}
 					style={{ cursor: "pointer" }}
-					onClick={() => FileServiceClient.openMention({ value: part })}>
+					onClick={() => FileServiceClient.openMention(StringRequest.create({ value: part }))}>
 					@{part}
 				</span>
 			)
@@ -709,7 +710,7 @@ const DeleteButton: React.FC<{
 	<HeroTooltip content="Delete Task & Checkpoints">
 		<VSCodeButton
 			appearance="icon"
-			onClick={() => taskId && TaskServiceClient.deleteTasksWithIds({ value: [taskId] })}
+			onClick={() => taskId && TaskServiceClient.deleteTasksWithIds(StringArrayRequest.create({ value: [taskId] }))}
 			style={{ padding: "0px 0px" }}>
 			<div
 				style={{

--- a/webview-ui/src/components/chat/UserMessage.tsx
+++ b/webview-ui/src/components/chat/UserMessage.tsx
@@ -1,10 +1,11 @@
-import React, { useState, useRef, forwardRef, useCallback } from "react"
 import Thumbnails from "@/components/common/Thumbnails"
-import { highlightText } from "./TaskHeader"
-import DynamicTextArea from "react-textarea-autosize"
 import { useExtensionState } from "@/context/ExtensionStateContext"
 import { CheckpointsServiceClient } from "@/services/grpc-client"
 import { ClineCheckpointRestore } from "@shared/WebviewMessage"
+import { CheckpointRestoreRequest } from "@shared/proto/checkpoints"
+import React, { forwardRef, useRef, useState } from "react"
+import DynamicTextArea from "react-textarea-autosize"
+import { highlightText } from "./TaskHeader"
 
 interface UserMessageProps {
 	text?: string
@@ -46,11 +47,13 @@ const UserMessage: React.FC<UserMessageProps> = ({ text, images, files, messageT
 		}
 
 		try {
-			await CheckpointsServiceClient.checkpointRestore({
-				number: messageTs,
-				restoreType: type,
-				offset: 1,
-			})
+			await CheckpointsServiceClient.checkpointRestore(
+				CheckpointRestoreRequest.create({
+					number: messageTs,
+					restoreType: type,
+					offset: 1,
+				}),
+			)
 
 			setTimeout(() => {
 				sendMessageFromChatRow?.(editedText, images || [], files || [])

--- a/webview-ui/src/components/cline-rules/ClineRulesToggleModal.tsx
+++ b/webview-ui/src/components/cline-rules/ClineRulesToggleModal.tsx
@@ -1,15 +1,21 @@
-import React, { useRef, useState, useEffect } from "react"
-import { useClickAway, useWindowSize } from "react-use"
-import { useExtensionState } from "@/context/ExtensionStateContext"
 import { CODE_BLOCK_BG_COLOR } from "@/components/common/CodeBlock"
-import { vscode } from "@/utils/vscode"
-import { FileServiceClient } from "@/services/grpc-client"
-import { VSCodeButton, VSCodeLink } from "@vscode/webview-ui-toolkit/react"
-import RulesToggleList from "./RulesToggleList"
 import Tooltip from "@/components/common/Tooltip"
-import styled from "styled-components"
-import { ClineRulesToggles, RefreshedRules, ToggleWindsurfRuleRequest } from "@shared/proto/file"
+import { useExtensionState } from "@/context/ExtensionStateContext"
+import { FileServiceClient } from "@/services/grpc-client"
+import { vscode } from "@/utils/vscode"
 import { EmptyRequest } from "@shared/proto/common"
+import {
+	ClineRulesToggles,
+	RefreshedRules,
+	ToggleClineRuleRequest,
+	ToggleCursorRuleRequest,
+	ToggleWindsurfRuleRequest,
+} from "@shared/proto/file"
+import { VSCodeButton, VSCodeLink } from "@vscode/webview-ui-toolkit/react"
+import React, { useEffect, useRef, useState } from "react"
+import { useClickAway, useWindowSize } from "react-use"
+import styled from "styled-components"
+import RulesToggleList from "./RulesToggleList"
 
 const ClineRulesToggleModal: React.FC = () => {
 	const {
@@ -92,11 +98,13 @@ const ClineRulesToggleModal: React.FC = () => {
 
 	// Handle toggle rule using gRPC
 	const toggleRule = (isGlobal: boolean, rulePath: string, enabled: boolean) => {
-		FileServiceClient.toggleClineRule({
-			isGlobal,
-			rulePath,
-			enabled,
-		})
+		FileServiceClient.toggleClineRule(
+			ToggleClineRuleRequest.create({
+				isGlobal,
+				rulePath,
+				enabled,
+			}),
+		)
 			.then((response) => {
 				// Update the local state with the response
 				if (response.globalClineRulesToggles?.toggles) {
@@ -112,10 +120,12 @@ const ClineRulesToggleModal: React.FC = () => {
 	}
 
 	const toggleCursorRule = (rulePath: string, enabled: boolean) => {
-		FileServiceClient.toggleCursorRule({
-			rulePath,
-			enabled,
-		})
+		FileServiceClient.toggleCursorRule(
+			ToggleCursorRuleRequest.create({
+				rulePath,
+				enabled,
+			}),
+		)
 			.then((response) => {
 				// Update the local state with the response
 				if (response.toggles) {

--- a/webview-ui/src/components/cline-rules/RuleRow.tsx
+++ b/webview-ui/src/components/cline-rules/RuleRow.tsx
@@ -1,6 +1,7 @@
-import { VSCodeButton } from "@vscode/webview-ui-toolkit/react"
 import { FileServiceClient } from "@/services/grpc-client"
 import { DeleteRuleFileRequest } from "@shared/proto-conversions/file/rule-files-conversion"
+import { StringRequest } from "@shared/proto/common"
+import { VSCodeButton } from "@vscode/webview-ui-toolkit/react"
 
 const RuleRow: React.FC<{
 	rulePath: string
@@ -56,7 +57,9 @@ const RuleRow: React.FC<{
 	}
 
 	const handleEditClick = () => {
-		FileServiceClient.openFile({ value: rulePath }).catch((err) => console.error("Failed to open file:", err))
+		FileServiceClient.openFile(StringRequest.create({ value: rulePath })).catch((err) =>
+			console.error("Failed to open file:", err),
+		)
 	}
 
 	const handleDeleteClick = () => {

--- a/webview-ui/src/components/common/CheckmarkControl.tsx
+++ b/webview-ui/src/components/common/CheckmarkControl.tsx
@@ -1,14 +1,15 @@
-import { useCallback, useRef, useState, useEffect } from "react"
+import { CODE_BLOCK_BG_COLOR } from "@/components/common/CodeBlock"
+import { CheckpointsServiceClient } from "@/services/grpc-client"
+import { flip, offset, shift, useFloating } from "@floating-ui/react"
+import { ExtensionMessage } from "@shared/ExtensionMessage"
+import { CheckpointRestoreRequest } from "@shared/proto/checkpoints"
+import { Int64Request } from "@shared/proto/common"
+import { ClineCheckpointRestore } from "@shared/WebviewMessage"
+import { VSCodeButton } from "@vscode/webview-ui-toolkit/react"
+import { useCallback, useEffect, useRef, useState } from "react"
+import { createPortal } from "react-dom"
 import { useEvent } from "react-use"
 import styled from "styled-components"
-import { ExtensionMessage } from "@shared/ExtensionMessage"
-import { ClineCheckpointRestore } from "@shared/WebviewMessage"
-import { CheckpointsServiceClient } from "@/services/grpc-client"
-import { vscode } from "@/utils/vscode"
-import { CODE_BLOCK_BG_COLOR } from "@/components/common/CodeBlock"
-import { VSCodeButton } from "@vscode/webview-ui-toolkit/react"
-import { createPortal } from "react-dom"
-import { useFloating, offset, flip, shift } from "@floating-ui/react"
 
 interface CheckmarkControlProps {
 	messageTs?: number
@@ -65,10 +66,12 @@ export const CheckmarkControl = ({ messageTs, isCheckpointCheckedOut }: Checkmar
 		setRestoreTaskDisabled(true)
 		try {
 			const restoreType: ClineCheckpointRestore = "task"
-			await CheckpointsServiceClient.checkpointRestore({
-				number: messageTs,
-				restoreType,
-			})
+			await CheckpointsServiceClient.checkpointRestore(
+				CheckpointRestoreRequest.create({
+					number: messageTs,
+					restoreType,
+				}),
+			)
 		} catch (err) {
 			console.error("Checkpoint restore task error:", err)
 			setRestoreTaskDisabled(false)
@@ -79,10 +82,12 @@ export const CheckmarkControl = ({ messageTs, isCheckpointCheckedOut }: Checkmar
 		setRestoreWorkspaceDisabled(true)
 		try {
 			const restoreType: ClineCheckpointRestore = "workspace"
-			await CheckpointsServiceClient.checkpointRestore({
-				number: messageTs,
-				restoreType,
-			})
+			await CheckpointsServiceClient.checkpointRestore(
+				CheckpointRestoreRequest.create({
+					number: messageTs,
+					restoreType,
+				}),
+			)
 		} catch (err) {
 			console.error("Checkpoint restore workspace error:", err)
 			setRestoreWorkspaceDisabled(false)
@@ -93,10 +98,12 @@ export const CheckmarkControl = ({ messageTs, isCheckpointCheckedOut }: Checkmar
 		setRestoreBothDisabled(true)
 		try {
 			const restoreType: ClineCheckpointRestore = "taskAndWorkspace"
-			await CheckpointsServiceClient.checkpointRestore({
-				number: messageTs,
-				restoreType,
-			})
+			await CheckpointsServiceClient.checkpointRestore(
+				CheckpointRestoreRequest.create({
+					number: messageTs,
+					restoreType,
+				}),
+			)
 		} catch (err) {
 			console.error("Checkpoint restore both error:", err)
 			setRestoreBothDisabled(false)
@@ -158,9 +165,11 @@ export const CheckmarkControl = ({ messageTs, isCheckpointCheckedOut }: Checkmar
 					onClick={async () => {
 						setCompareDisabled(true)
 						try {
-							await CheckpointsServiceClient.checkpointDiff({
-								value: messageTs,
-							})
+							await CheckpointsServiceClient.checkpointDiff(
+								Int64Request.create({
+									value: messageTs,
+								}),
+							)
 						} catch (err) {
 							console.error("CheckpointDiff error:", err)
 						} finally {

--- a/webview-ui/src/components/common/CheckpointControls.tsx
+++ b/webview-ui/src/components/common/CheckpointControls.tsx
@@ -1,12 +1,12 @@
+import { CODE_BLOCK_BG_COLOR } from "@/components/common/CodeBlock"
+import { CheckpointsServiceClient } from "@/services/grpc-client"
+import { ExtensionMessage } from "@shared/ExtensionMessage"
+import { CheckpointRestoreRequest } from "@shared/proto/checkpoints"
+import { Int64Request } from "@shared/proto/common"
 import { VSCodeButton } from "@vscode/webview-ui-toolkit/react"
 import { useCallback, useRef, useState } from "react"
 import { useClickAway, useEvent } from "react-use"
 import styled from "styled-components"
-import { ExtensionMessage } from "@shared/ExtensionMessage"
-import { CheckpointsServiceClient } from "@/services/grpc-client"
-import { vscode } from "@/utils/vscode"
-import { CODE_BLOCK_BG_COLOR } from "@/components/common/CodeBlock"
-import { ClineCheckpointRestore } from "@shared/WebviewMessage"
 
 interface CheckpointOverlayProps {
 	messageTs?: number
@@ -48,10 +48,12 @@ export const CheckpointOverlay = ({ messageTs }: CheckpointOverlayProps) => {
 	const handleRestoreTask = async () => {
 		setRestoreTaskDisabled(true)
 		try {
-			await CheckpointsServiceClient.checkpointRestore({
-				number: messageTs,
-				restoreType: "task",
-			})
+			await CheckpointsServiceClient.checkpointRestore(
+				CheckpointRestoreRequest.create({
+					number: messageTs,
+					restoreType: "task",
+				}),
+			)
 		} catch (err) {
 			console.error("Checkpoint restore task error:", err)
 			setRestoreTaskDisabled(false)
@@ -61,10 +63,12 @@ export const CheckpointOverlay = ({ messageTs }: CheckpointOverlayProps) => {
 	const handleRestoreWorkspace = async () => {
 		setRestoreWorkspaceDisabled(true)
 		try {
-			await CheckpointsServiceClient.checkpointRestore({
-				number: messageTs,
-				restoreType: "workspace",
-			})
+			await CheckpointsServiceClient.checkpointRestore(
+				CheckpointRestoreRequest.create({
+					number: messageTs,
+					restoreType: "workspace",
+				}),
+			)
 		} catch (err) {
 			console.error("Checkpoint restore workspace error:", err)
 			setRestoreWorkspaceDisabled(false)
@@ -74,10 +78,12 @@ export const CheckpointOverlay = ({ messageTs }: CheckpointOverlayProps) => {
 	const handleRestoreBoth = async () => {
 		setRestoreBothDisabled(true)
 		try {
-			await CheckpointsServiceClient.checkpointRestore({
-				number: messageTs,
-				restoreType: "taskAndWorkspace",
-			})
+			await CheckpointsServiceClient.checkpointRestore(
+				CheckpointRestoreRequest.create({
+					number: messageTs,
+					restoreType: "taskAndWorkspace",
+				}),
+			)
 		} catch (err) {
 			console.error("Checkpoint restore both error:", err)
 			setRestoreBothDisabled(false)
@@ -126,9 +132,11 @@ export const CheckpointOverlay = ({ messageTs }: CheckpointOverlayProps) => {
 				onClick={async () => {
 					setCompareDisabled(true)
 					try {
-						await CheckpointsServiceClient.checkpointDiff({
-							value: messageTs,
-						})
+						await CheckpointsServiceClient.checkpointDiff(
+							Int64Request.create({
+								value: messageTs,
+							}),
+						)
 					} catch (err) {
 						console.error("CheckpointDiff error:", err)
 					} finally {

--- a/webview-ui/src/components/common/MarkdownBlock.tsx
+++ b/webview-ui/src/components/common/MarkdownBlock.tsx
@@ -1,27 +1,29 @@
-import React, { memo, useEffect, useRef, useState } from "react"
+import { CODE_BLOCK_BG_COLOR } from "@/components/common/CodeBlock"
+import MermaidBlock from "@/components/common/MermaidBlock"
+import { useExtensionState } from "@/context/ExtensionStateContext"
+import { StateServiceClient } from "@/services/grpc-client"
+import { PlanActMode, TogglePlanActModeRequest } from "@shared/proto/state"
 import type { ComponentProps } from "react"
+import React, { memo, useEffect, useRef, useState } from "react"
 import { useRemark } from "react-remark"
 import rehypeHighlight, { Options } from "rehype-highlight"
 import rehypeKatex from "rehype-katex"
 import remarkMath from "remark-math"
 import styled from "styled-components"
-import { visit } from "unist-util-visit"
 import type { Node } from "unist"
-import { useExtensionState } from "@/context/ExtensionStateContext"
-import { CODE_BLOCK_BG_COLOR } from "@/components/common/CodeBlock"
-import MermaidBlock from "@/components/common/MermaidBlock"
-import { StateServiceClient } from "@/services/grpc-client"
-import { PlanActMode } from "@shared/proto/state"
+import { visit } from "unist-util-visit"
 
 // Styled component for Act Mode text with more specific styling
 const ActModeHighlight: React.FC = () => (
 	<span
 		onClick={() => {
-			StateServiceClient.togglePlanActMode({
-				chatSettings: {
-					mode: PlanActMode.ACT,
-				},
-			})
+			StateServiceClient.togglePlanActMode(
+				TogglePlanActModeRequest.create({
+					chatSettings: {
+						mode: PlanActMode.ACT,
+					},
+				}),
+			)
 		}}
 		title="Click to toggle to Act Mode"
 		className="text-[var(--vscode-textLink-foreground)] hover:opacity-90 cursor-pointer inline-flex items-center gap-1">

--- a/webview-ui/src/components/common/MermaidBlock.tsx
+++ b/webview-ui/src/components/common/MermaidBlock.tsx
@@ -1,9 +1,10 @@
-import { useEffect, useRef, useState } from "react"
-import mermaid from "mermaid"
-import { useDebounceEffect } from "@/utils/useDebounceEffect"
-import styled from "styled-components"
 import { FileServiceClient } from "@/services/grpc-client"
+import { useDebounceEffect } from "@/utils/useDebounceEffect"
+import { StringRequest } from "@shared/proto/common"
 import { VSCodeButton } from "@vscode/webview-ui-toolkit/react"
+import mermaid from "mermaid"
+import { useEffect, useRef, useState } from "react"
+import styled from "styled-components"
 
 const MERMAID_THEME = {
 	background: "#1e1e1e", // VS Code dark theme background
@@ -131,7 +132,9 @@ export default function MermaidBlock({ code }: MermaidBlockProps) {
 
 		try {
 			const pngDataUrl = await svgToPng(svgEl)
-			FileServiceClient.openImage({ value: pngDataUrl }).catch((err) => console.error("Failed to open image:", err))
+			FileServiceClient.openImage(StringRequest.create({ value: pngDataUrl })).catch((err) =>
+				console.error("Failed to open image:", err),
+			)
 		} catch (err) {
 			console.error("Error converting SVG to PNG:", err)
 		}

--- a/webview-ui/src/components/common/Thumbnails.tsx
+++ b/webview-ui/src/components/common/Thumbnails.tsx
@@ -1,7 +1,7 @@
-import React, { useState, useRef, useLayoutEffect, memo } from "react"
-import { useWindowSize } from "react-use"
 import { FileServiceClient } from "@/services/grpc-client"
-import { vscode } from "@/utils/vscode"
+import { StringRequest } from "@shared/proto/common"
+import React, { memo, useLayoutEffect, useRef, useState } from "react"
+import { useWindowSize } from "react-use"
 
 interface ThumbnailsProps {
 	images: string[]
@@ -41,11 +41,15 @@ const Thumbnails = ({ images, files, style, setImages, setFiles, onHeightChange 
 	const isDeletableFiles = setFiles !== undefined
 
 	const handleImageClick = (image: string) => {
-		FileServiceClient.openImage({ value: image }).catch((err) => console.error("Failed to open image:", err))
+		FileServiceClient.openImage(StringRequest.create({ value: image })).catch((err) =>
+			console.error("Failed to open image:", err),
+		)
 	}
 
 	const handleFileClick = (filePath: string) => {
-		FileServiceClient.openFile({ value: filePath }).catch((err) => console.error("Failed to open file:", err))
+		FileServiceClient.openFile(StringRequest.create({ value: filePath })).catch((err) =>
+			console.error("Failed to open file:", err),
+		)
 	}
 
 	return (


### PR DESCRIPTION
Fix linter warnings in the first half of the webview.

### Test Procedure

`npm run test`
Tested manually in the vscode extension host.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

NA

### Additional Notes

NA

