### PR TITLE
Fix linter warnings in the webview (part 2)

### DIFF
--- a/webview-ui/src/components/history/HistoryPreview.tsx
+++ b/webview-ui/src/components/history/HistoryPreview.tsx
@@ -1,9 +1,9 @@
-import { VSCodeButton } from "@vscode/webview-ui-toolkit/react"
 import { useExtensionState } from "@/context/ExtensionStateContext"
-import { vscode } from "@/utils/vscode"
-import { memo, useState } from "react"
 import { TaskServiceClient } from "@/services/grpc-client"
 import { formatLargeNumber } from "@/utils/format"
+import { StringRequest } from "@shared/proto/common"
+import { VSCodeButton } from "@vscode/webview-ui-toolkit/react"
+import { memo, useState } from "react"
 
 type HistoryPreviewProps = {
 	showHistoryView: () => void
@@ -14,7 +14,9 @@ const HistoryPreview = ({ showHistoryView }: HistoryPreviewProps) => {
 	const [isExpanded, setIsExpanded] = useState(true)
 
 	const handleHistorySelect = (id: string) => {
-		TaskServiceClient.showTaskWithId({ value: id }).catch((error) => console.error("Error showing task:", error))
+		TaskServiceClient.showTaskWithId(StringRequest.create({ value: id })).catch((error) =>
+			console.error("Error showing task:", error),
+		)
 	}
 
 	const toggleExpanded = () => {

--- a/webview-ui/src/components/history/HistoryView.tsx
+++ b/webview-ui/src/components/history/HistoryView.tsx
@@ -1,15 +1,16 @@
-import { VSCodeButton, VSCodeTextField, VSCodeRadioGroup, VSCodeRadio, VSCodeCheckbox } from "@vscode/webview-ui-toolkit/react"
-import { useExtensionState } from "@/context/ExtensionStateContext"
-import { vscode } from "@/utils/vscode"
-import { Virtuoso } from "react-virtuoso"
-import { memo, useMemo, useState, useEffect, useCallback } from "react"
-import Fuse, { FuseResult } from "fuse.js"
-import { TaskServiceClient } from "@/services/grpc-client"
-import { formatLargeNumber } from "@/utils/format"
-import { formatSize } from "@/utils/format"
-import { ExtensionMessage } from "@shared/ExtensionMessage"
-import { useEvent } from "react-use"
 import DangerButton from "@/components/common/DangerButton"
+import { useExtensionState } from "@/context/ExtensionStateContext"
+import { TaskServiceClient } from "@/services/grpc-client"
+import { formatLargeNumber, formatSize } from "@/utils/format"
+import { vscode } from "@/utils/vscode"
+import { ExtensionMessage } from "@shared/ExtensionMessage"
+import { EmptyRequest, StringArrayRequest, StringRequest } from "@shared/proto/common"
+import { GetTaskHistoryRequest, TaskFavoriteRequest } from "@shared/proto/task"
+import { VSCodeButton, VSCodeCheckbox, VSCodeRadio, VSCodeRadioGroup, VSCodeTextField } from "@vscode/webview-ui-toolkit/react"
+import Fuse, { FuseResult } from "fuse.js"
+import { memo, useCallback, useEffect, useMemo, useState } from "react"
+import { useEvent } from "react-use"
+import { Virtuoso } from "react-virtuoso"
 
 type HistoryViewProps = {
 	onDone: () => void
@@ -66,12 +67,14 @@ const HistoryView = ({ onDone }: HistoryViewProps) => {
 	// Load and refresh task history
 	const loadTaskHistory = useCallback(async () => {
 		try {
-			const response = await TaskServiceClient.getTaskHistory({
-				favoritesOnly: showFavoritesOnly,
-				searchQuery: searchQuery || undefined,
-				sortBy: sortOption,
-				currentWorkspaceOnly: showCurrentWorkspaceOnly,
-			})
+			const response = await TaskServiceClient.getTaskHistory(
+				GetTaskHistoryRequest.create({
+					favoritesOnly: showFavoritesOnly,
+					searchQuery: searchQuery || undefined,
+					sortBy: sortOption,
+					currentWorkspaceOnly: showCurrentWorkspaceOnly,
+				}),
+			)
 			setFilteredTasks(response.tasks || [])
 		} catch (error) {
 			console.error("Error loading task history:", error)
@@ -94,10 +97,12 @@ const HistoryView = ({ onDone }: HistoryViewProps) => {
 			setPendingFavoriteToggles((prev) => ({ ...prev, [taskId]: !currentValue }))
 
 			try {
-				await TaskServiceClient.toggleTaskFavorite({
-					taskId,
-					isFavorited: !currentValue,
-				})
+				await TaskServiceClient.toggleTaskFavorite(
+					TaskFavoriteRequest.create({
+						taskId,
+						isFavorited: !currentValue,
+					}),
+				)
 
 				// Refresh if either filter is active to ensure proper combined filtering
 				if (showFavoritesOnly || showCurrentWorkspaceOnly) {
@@ -136,7 +141,7 @@ const HistoryView = ({ onDone }: HistoryViewProps) => {
 
 	const fetchTotalTasksSize = useCallback(async () => {
 		try {
-			const response = await TaskServiceClient.getTotalTasksSize({})
+			const response = await TaskServiceClient.getTotalTasksSize(EmptyRequest.create({}))
 			if (response && typeof response.value === "number") {
 				setTotalTasksSize?.(response.value || 0)
 			}
@@ -161,7 +166,9 @@ const HistoryView = ({ onDone }: HistoryViewProps) => {
 	}, [searchQuery, sortOption, lastNonRelevantSort])
 
 	const handleShowTaskWithId = useCallback((id: string) => {
-		TaskServiceClient.showTaskWithId({ value: id }).catch((error) => console.error("Error showing task:", error))
+		TaskServiceClient.showTaskWithId(StringRequest.create({ value: id })).catch((error) =>
+			console.error("Error showing task:", error),
+		)
 	}, [])
 
 	const handleHistorySelect = useCallback((itemId: string, checked: boolean) => {
@@ -176,7 +183,7 @@ const HistoryView = ({ onDone }: HistoryViewProps) => {
 
 	const handleDeleteHistoryItem = useCallback(
 		(id: string) => {
-			TaskServiceClient.deleteTasksWithIds({ value: [id] })
+			TaskServiceClient.deleteTasksWithIds(StringArrayRequest.create({ value: [id] }))
 				.then(() => fetchTotalTasksSize())
 				.catch((error) => console.error("Error deleting task:", error))
 		},
@@ -186,7 +193,7 @@ const HistoryView = ({ onDone }: HistoryViewProps) => {
 	const handleDeleteSelectedHistoryItems = useCallback(
 		(ids: string[]) => {
 			if (ids.length > 0) {
-				TaskServiceClient.deleteTasksWithIds({ value: ids })
+				TaskServiceClient.deleteTasksWithIds(StringArrayRequest.create({ value: ids }))
 					.then(() => fetchTotalTasksSize())
 					.catch((error) => console.error("Error deleting tasks:", error))
 				setSelectedItems([])
@@ -737,7 +744,9 @@ const ExportButton = ({ itemId }: { itemId: string }) => (
 		appearance="icon"
 		onClick={(e) => {
 			e.stopPropagation()
-			TaskServiceClient.exportTaskWithId({ value: itemId }).catch((err) => console.error("Failed to export task:", err))
+			TaskServiceClient.exportTaskWithId(StringRequest.create({ value: itemId })).catch((err) =>
+				console.error("Failed to export task:", err),
+			)
 		}}>
 		<div style={{ fontSize: "11px", fontWeight: 500, opacity: 1 }}>EXPORT</div>
 	</VSCodeButton>

--- a/webview-ui/src/components/mcp/chat-display/ImagePreview.tsx
+++ b/webview-ui/src/components/mcp/chat-display/ImagePreview.tsx
@@ -1,9 +1,9 @@
-import React from "react"
-import { vscode } from "@/utils/vscode"
-import { WebServiceClient } from "@/services/grpc-client"
-import DOMPurify from "dompurify"
-import { getSafeHostname, formatUrlForOpening, checkIfImageUrl } from "./utils/mcpRichUtil"
 import ChatErrorBoundary from "@/components/chat/ChatErrorBoundary"
+import { WebServiceClient } from "@/services/grpc-client"
+import { StringRequest } from "@shared/proto/common"
+import DOMPurify from "dompurify"
+import React from "react"
+import { checkIfImageUrl, formatUrlForOpening, getSafeHostname } from "./utils/mcpRichUtil"
 
 interface ImagePreviewProps {
 	url: string
@@ -235,9 +235,11 @@ class ImagePreview extends React.Component<
 					}}
 					onClick={async () => {
 						try {
-							await WebServiceClient.openInBrowser({
-								value: DOMPurify.sanitize(url),
-							})
+							await WebServiceClient.openInBrowser(
+								StringRequest.create({
+									value: DOMPurify.sanitize(url),
+								}),
+							)
 						} catch (err) {
 							console.error("Error opening URL in browser:", err)
 						}
@@ -262,9 +264,11 @@ class ImagePreview extends React.Component<
 				}}
 				onClick={async () => {
 					try {
-						await WebServiceClient.openInBrowser({
-							value: DOMPurify.sanitize(formatUrlForOpening(url)),
-						})
+						await WebServiceClient.openInBrowser(
+							StringRequest.create({
+								value: DOMPurify.sanitize(formatUrlForOpening(url)),
+							}),
+						)
 					} catch (err) {
 						console.error("Error opening URL in browser:", err)
 					}

--- a/webview-ui/src/components/mcp/chat-display/LinkPreview.tsx
+++ b/webview-ui/src/components/mcp/chat-display/LinkPreview.tsx
@@ -285,7 +285,7 @@ class LinkPreview extends React.Component<LinkPreviewProps, LinkPreviewState> {
 				onClick={async () => {
 					try {
 						await WebServiceClient.openInBrowser(
-							StringRequestß.create({
+							StringRequest.create({
 								value: DOMPurify.sanitize(url),
 							}),
 						)
@@ -320,8 +320,8 @@ class LinkPreview extends React.Component<LinkPreviewProps, LinkPreviewState> {
 							}}
 							onError={(e) => {
 								console.log(`Image could not be loaded: ${data.image}`)
-								// Hide the broken image
-								;(e.target as HTMLImageElement).style.display = "none"
+									// Hide the broken image
+									; (e.target as HTMLImageElement).style.display = "none"
 							}}
 						/>
 					</div>

--- a/webview-ui/src/components/mcp/chat-display/LinkPreview.tsx
+++ b/webview-ui/src/components/mcp/chat-display/LinkPreview.tsx
@@ -320,8 +320,8 @@ class LinkPreview extends React.Component<LinkPreviewProps, LinkPreviewState> {
 							}}
 							onError={(e) => {
 								console.log(`Image could not be loaded: ${data.image}`)
-									// Hide the broken image
-									; (e.target as HTMLImageElement).style.display = "none"
+								// Hide the broken image
+								;(e.target as HTMLImageElement).style.display = "none"
 							}}
 						/>
 					</div>

--- a/webview-ui/src/components/mcp/chat-display/LinkPreview.tsx
+++ b/webview-ui/src/components/mcp/chat-display/LinkPreview.tsx
@@ -1,9 +1,9 @@
-import React from "react"
-import { vscode } from "@/utils/vscode"
-import DOMPurify from "dompurify"
-import { getSafeHostname, normalizeRelativeUrl } from "./utils/mcpRichUtil"
 import ChatErrorBoundary from "@/components/chat/ChatErrorBoundary"
 import { WebServiceClient } from "@/services/grpc-client"
+import { StringRequest } from "@shared/proto/common"
+import DOMPurify from "dompurify"
+import React from "react"
+import { getSafeHostname, normalizeRelativeUrl } from "./utils/mcpRichUtil"
 
 interface OpenGraphData {
 	title?: string
@@ -110,9 +110,11 @@ class LinkPreview extends React.Component<LinkPreviewProps, LinkPreviewState> {
 			this.setState({ fetchStartTime: startTime })
 
 			// Use the gRPC client to fetch Open Graph data
-			const response = await WebServiceClient.fetchOpenGraphData({
-				value: this.props.url,
-			})
+			const response = await WebServiceClient.fetchOpenGraphData(
+				StringRequest.create({
+					value: this.props.url,
+				}),
+			)
 
 			// Process the response
 			if (response) {
@@ -240,9 +242,11 @@ class LinkPreview extends React.Component<LinkPreviewProps, LinkPreviewState> {
 					}}
 					onClick={async () => {
 						try {
-							await WebServiceClient.openInBrowser({
-								value: DOMPurify.sanitize(url),
-							})
+							await WebServiceClient.openInBrowser(
+								StringRequest.create({
+									value: DOMPurify.sanitize(url),
+								}),
+							)
 						} catch (err) {
 							console.error("Error opening URL in browser:", err)
 						}
@@ -280,9 +284,11 @@ class LinkPreview extends React.Component<LinkPreviewProps, LinkPreviewState> {
 				}}
 				onClick={async () => {
 					try {
-						await WebServiceClient.openInBrowser({
-							value: DOMPurify.sanitize(url),
-						})
+						await WebServiceClient.openInBrowser(
+							StringRequestß.create({
+								value: DOMPurify.sanitize(url),
+							}),
+						)
 					} catch (err) {
 						console.error("Error opening URL in browser:", err)
 					}

--- a/webview-ui/src/components/mcp/chat-display/utils/mcpRichUtil.ts
+++ b/webview-ui/src/components/mcp/chat-display/utils/mcpRichUtil.ts
@@ -1,4 +1,5 @@
 import { WebServiceClient } from "@/services/grpc-client"
+import { StringRequest } from "@shared/proto/common"
 
 // Safely create a URL object with error handling and ensure HTTPS
 export const safeCreateUrl = (url: string): URL | null => {
@@ -145,7 +146,7 @@ export const checkIfImageUrl = async (url: string): Promise<boolean> => {
 			})
 
 			// Create the actual service call
-			const servicePromise = WebServiceClient.checkIsImageUrl({ value: url })
+			const servicePromise = WebServiceClient.checkIsImageUrl(StringRequest.create({ value: url }))
 				.then((result) => result.isImage)
 				.catch((error) => {
 					console.error("Error checking if URL is an image via gRPC:", error)

--- a/webview-ui/src/components/mcp/configuration/McpConfigurationView.tsx
+++ b/webview-ui/src/components/mcp/configuration/McpConfigurationView.tsx
@@ -1,13 +1,14 @@
+import { useExtensionState } from "@/context/ExtensionStateContext"
+import { McpServiceClient } from "@/services/grpc-client"
+import { vscode } from "@/utils/vscode"
+import { McpViewTab } from "@shared/mcp"
+import { EmptyRequest } from "@shared/proto/common"
 import { VSCodeButton } from "@vscode/webview-ui-toolkit/react"
 import { useEffect, useState } from "react"
 import styled from "styled-components"
-import { useExtensionState } from "@/context/ExtensionStateContext"
-import { vscode } from "@/utils/vscode"
-import { McpServiceClient } from "@/services/grpc-client"
 import AddRemoteServerForm from "./tabs/add-server/AddRemoteServerForm"
-import McpMarketplaceView from "./tabs/marketplace/McpMarketplaceView"
 import InstalledServersView from "./tabs/installed/InstalledServersView"
-import { McpViewTab } from "@shared/mcp"
+import McpMarketplaceView from "./tabs/marketplace/McpMarketplaceView"
 
 type McpViewProps = {
 	onDone: () => void
@@ -34,7 +35,7 @@ const McpConfigurationView = ({ onDone, initialTab }: McpViewProps) => {
 
 	useEffect(() => {
 		if (mcpMarketplaceEnabled) {
-			McpServiceClient.refreshMcpMarketplace({})
+			McpServiceClient.refreshMcpMarketplace(EmptyRequest.create({}))
 				.then((response) => {
 					// Types are structurally identical, use response directly
 					setMcpMarketplaceCatalog(response)

--- a/webview-ui/src/components/mcp/configuration/tabs/add-server/AddLocalServerForm.tsx
+++ b/webview-ui/src/components/mcp/configuration/tabs/add-server/AddLocalServerForm.tsx
@@ -1,7 +1,8 @@
-import { VSCodeButton, VSCodeLink } from "@vscode/webview-ui-toolkit/react"
-import styled from "styled-components"
 import { LINKS } from "@/constants"
 import { McpServiceClient } from "@/services/grpc-client"
+import { EmptyRequest } from "@shared/proto/common"
+import { VSCodeButton, VSCodeLink } from "@vscode/webview-ui-toolkit/react"
+import styled from "styled-components"
 
 type AddLocalServerFormProps = {
 	onServerAdded: () => void
@@ -22,7 +23,7 @@ const AddLocalServerForm = ({ onServerAdded }: AddLocalServerFormProps) => {
 				appearance="primary"
 				style={{ width: "100%", marginBottom: "5px", marginTop: 8 }}
 				onClick={() => {
-					McpServiceClient.openMcpSettings({}).catch((error) => {
+					McpServiceClient.openMcpSettings(EmptyRequest.create({})).catch((error) => {
 						console.error("Error opening MCP settings:", error)
 					})
 				}}>

--- a/webview-ui/src/components/mcp/configuration/tabs/add-server/AddRemoteServerForm.tsx
+++ b/webview-ui/src/components/mcp/configuration/tabs/add-server/AddRemoteServerForm.tsx
@@ -1,9 +1,11 @@
-import { useRef, useState } from "react"
-import { VSCodeButton, VSCodeLink, VSCodeTextField } from "@vscode/webview-ui-toolkit/react"
 import { LINKS } from "@/constants"
+import { useExtensionState } from "@/context/ExtensionStateContext"
 import { McpServiceClient } from "@/services/grpc-client"
 import { convertProtoMcpServersToMcpServers } from "@shared/proto-conversions/mcp/mcp-server-conversion"
-import { useExtensionState } from "@/context/ExtensionStateContext"
+import { EmptyRequest } from "@shared/proto/common"
+import { AddRemoteMcpServerRequest } from "@shared/proto/mcp"
+import { VSCodeButton, VSCodeLink, VSCodeTextField } from "@vscode/webview-ui-toolkit/react"
+import { useState } from "react"
 
 const AddRemoteServerForm = ({ onServerAdded }: { onServerAdded: () => void }) => {
 	const [serverName, setServerName] = useState("")
@@ -38,10 +40,12 @@ const AddRemoteServerForm = ({ onServerAdded }: { onServerAdded: () => void }) =
 		setShowConnectingMessage(true)
 
 		try {
-			const servers = await McpServiceClient.addRemoteMcpServer({
-				serverName: serverName.trim(),
-				serverUrl: serverUrl.trim(),
-			})
+			const servers = await McpServiceClient.addRemoteMcpServer(
+				AddRemoteMcpServerRequest.create({
+					serverName: serverName.trim(),
+					serverUrl: serverUrl.trim(),
+				}),
+			)
 
 			setIsSubmitting(false)
 
@@ -115,7 +119,7 @@ const AddRemoteServerForm = ({ onServerAdded }: { onServerAdded: () => void }) =
 					appearance="secondary"
 					style={{ width: "100%", marginBottom: "5px", marginTop: 15 }}
 					onClick={() => {
-						McpServiceClient.openMcpSettings({}).catch((error) => {
+						McpServiceClient.openMcpSettings(EmptyRequest.create({})).catch((error) => {
 							console.error("Error opening MCP settings:", error)
 						})
 					}}>

--- a/webview-ui/src/components/mcp/configuration/tabs/installed/InstalledServersView.tsx
+++ b/webview-ui/src/components/mcp/configuration/tabs/installed/InstalledServersView.tsx
@@ -1,8 +1,9 @@
-import { VSCodeButton, VSCodeLink } from "@vscode/webview-ui-toolkit/react"
 import { useExtensionState } from "@/context/ExtensionStateContext"
+import { VSCodeButton, VSCodeLink } from "@vscode/webview-ui-toolkit/react"
 
-import { UiServiceClient, McpServiceClient } from "@/services/grpc-client"
+import { McpServiceClient, UiServiceClient } from "@/services/grpc-client"
 
+import { EmptyRequest, StringRequest } from "@shared/proto/common"
 import ServersToggleList from "./ServersToggleList"
 const InstalledServersView = () => {
 	const { mcpServers: servers, navigateToSettings } = useExtensionState()
@@ -39,7 +40,7 @@ const InstalledServersView = () => {
 					appearance="secondary"
 					style={{ width: "100%", marginBottom: "5px" }}
 					onClick={() => {
-						McpServiceClient.openMcpSettings({}).catch((error) => {
+						McpServiceClient.openMcpSettings(EmptyRequest.create({})).catch((error) => {
 							console.error("Error opening MCP settings:", error)
 						})
 					}}>
@@ -56,7 +57,7 @@ const InstalledServersView = () => {
 							// After a short delay, send a message to scroll to browser settings
 							setTimeout(async () => {
 								try {
-									await UiServiceClient.scrollToSettings({ value: "features" })
+									await UiServiceClient.scrollToSettings(StringRequest.create({ value: "features" }))
 								} catch (error) {
 									console.error("Error scrolling to mcp settings:", error)
 								}

--- a/webview-ui/src/components/mcp/configuration/tabs/installed/server-row/McpToolRow.tsx
+++ b/webview-ui/src/components/mcp/configuration/tabs/installed/server-row/McpToolRow.tsx
@@ -1,8 +1,9 @@
-import { VSCodeCheckbox } from "@vscode/webview-ui-toolkit/react"
-import { McpTool } from "@shared/mcp"
 import { useExtensionState } from "@/context/ExtensionStateContext"
 import { McpServiceClient } from "@/services/grpc-client"
+import { McpTool } from "@shared/mcp"
 import { convertProtoMcpServersToMcpServers } from "@shared/proto-conversions/mcp/mcp-server-conversion"
+import { ToggleToolAutoApproveRequest } from "@shared/proto/mcp"
+import { VSCodeCheckbox } from "@vscode/webview-ui-toolkit/react"
 
 type McpToolRowProps = {
 	tool: McpTool
@@ -20,11 +21,13 @@ const McpToolRow = ({ tool, serverName }: McpToolRowProps) => {
 			return
 		}
 
-		McpServiceClient.toggleToolAutoApprove({
-			serverName,
-			toolNames: [tool.name],
-			autoApprove: !tool.autoApprove,
-		})
+		McpServiceClient.toggleToolAutoApprove(
+			ToggleToolAutoApproveRequest.create({
+				serverName,
+				toolNames: [tool.name],
+				autoApprove: !tool.autoApprove,
+			}),
+		)
 			.then((response) => {
 				const mcpServers = convertProtoMcpServersToMcpServers(response.mcpServers)
 				setMcpServers(mcpServers)

--- a/webview-ui/src/components/mcp/configuration/tabs/marketplace/McpMarketplaceCard.tsx
+++ b/webview-ui/src/components/mcp/configuration/tabs/marketplace/McpMarketplaceCard.tsx
@@ -1,8 +1,9 @@
-import { useCallback, useState, useRef, useMemo } from "react"
-import styled from "styled-components"
-import { McpMarketplaceItem, McpServer } from "@shared/mcp"
-import { useEvent } from "react-use"
 import { McpServiceClient } from "@/services/grpc-client"
+import { McpMarketplaceItem, McpServer } from "@shared/mcp"
+import { StringRequest } from "@shared/proto/common"
+import { useCallback, useMemo, useRef, useState } from "react"
+import { useEvent } from "react-use"
+import styled from "styled-components"
 
 interface McpMarketplaceCardProps {
 	item: McpMarketplaceItem
@@ -113,7 +114,7 @@ const McpMarketplaceCard = ({ item, installedServers }: McpMarketplaceCardProps)
 									if (!isInstalled && !isDownloading) {
 										setIsDownloading(true)
 										try {
-											await McpServiceClient.downloadMcp({ value: item.mcpId })
+											await McpServiceClient.downloadMcp(StringRequest.create({ value: item.mcpId }))
 										} catch (error) {
 											setIsDownloading(false)
 											console.error("Failed to download MCP:", error)

--- a/webview-ui/src/components/settings/ApiOptions.tsx
+++ b/webview-ui/src/components/settings/ApiOptions.tsx
@@ -1,3 +1,54 @@
+import VSCodeButtonLink from "@/components/common/VSCodeButtonLink"
+import { useExtensionState } from "@/context/ExtensionStateContext"
+import { ModelsServiceClient } from "@/services/grpc-client"
+import { vscode } from "@/utils/vscode"
+import { getAsVar, VSC_DESCRIPTION_FOREGROUND } from "@/utils/vscStyles"
+import {
+	anthropicDefaultModelId,
+	anthropicModels,
+	ApiConfiguration,
+	ApiProvider,
+	askSageDefaultModelId,
+	askSageDefaultURL,
+	askSageModels,
+	azureOpenAiDefaultApiVersion,
+	bedrockDefaultModelId,
+	bedrockModels,
+	cerebrasDefaultModelId,
+	cerebrasModels,
+	deepSeekDefaultModelId,
+	deepSeekModels,
+	doubaoDefaultModelId,
+	doubaoModels,
+	geminiDefaultModelId,
+	geminiModels,
+	internationalQwenDefaultModelId,
+	internationalQwenModels,
+	liteLlmModelInfoSaneDefaults,
+	mainlandQwenDefaultModelId,
+	mainlandQwenModels,
+	mistralDefaultModelId,
+	mistralModels,
+	ModelInfo,
+	nebiusDefaultModelId,
+	nebiusModels,
+	openAiModelInfoSaneDefaults,
+	openAiNativeDefaultModelId,
+	openAiNativeModels,
+	openRouterDefaultModelId,
+	openRouterDefaultModelInfo,
+	requestyDefaultModelId,
+	requestyDefaultModelInfo,
+	sambanovaDefaultModelId,
+	sambanovaModels,
+	vertexDefaultModelId,
+	vertexGlobalModels,
+	vertexModels,
+	xaiDefaultModelId,
+	xaiModels,
+} from "@shared/api"
+import { EmptyRequest, StringRequest } from "@shared/proto/common"
+import { OpenAiModelsRequest } from "@shared/proto/models"
 import {
 	VSCodeButton,
 	VSCodeCheckbox,
@@ -9,63 +60,14 @@ import {
 	VSCodeTextField,
 } from "@vscode/webview-ui-toolkit/react"
 import { Fragment, memo, useCallback, useEffect, useMemo, useRef, useState } from "react"
-import ThinkingBudgetSlider from "./ThinkingBudgetSlider"
-import { useEvent, useInterval } from "react-use"
+import { useInterval } from "react-use"
 import styled from "styled-components"
 import * as vscodemodels from "vscode"
-import {
-	anthropicDefaultModelId,
-	anthropicModels,
-	ApiConfiguration,
-	ApiProvider,
-	azureOpenAiDefaultApiVersion,
-	bedrockDefaultModelId,
-	bedrockModels,
-	deepSeekDefaultModelId,
-	deepSeekModels,
-	geminiDefaultModelId,
-	geminiModels,
-	mistralDefaultModelId,
-	mistralModels,
-	ModelInfo,
-	openAiModelInfoSaneDefaults,
-	openAiNativeDefaultModelId,
-	openAiNativeModels,
-	openRouterDefaultModelId,
-	openRouterDefaultModelInfo,
-	requestyDefaultModelId,
-	requestyDefaultModelInfo,
-	mainlandQwenModels,
-	internationalQwenModels,
-	mainlandQwenDefaultModelId,
-	internationalQwenDefaultModelId,
-	vertexDefaultModelId,
-	vertexModels,
-	vertexGlobalModels,
-	askSageModels,
-	askSageDefaultModelId,
-	askSageDefaultURL,
-	xaiDefaultModelId,
-	xaiModels,
-	nebiusModels,
-	nebiusDefaultModelId,
-	sambanovaModels,
-	sambanovaDefaultModelId,
-	cerebrasModels,
-	cerebrasDefaultModelId,
-	doubaoModels,
-	doubaoDefaultModelId,
-	liteLlmModelInfoSaneDefaults,
-} from "@shared/api"
-import { useExtensionState } from "@/context/ExtensionStateContext"
-import { vscode } from "@/utils/vscode"
-import { ModelsServiceClient } from "@/services/grpc-client"
-import { getAsVar, VSC_DESCRIPTION_FOREGROUND } from "@/utils/vscStyles"
-import VSCodeButtonLink from "@/components/common/VSCodeButtonLink"
-import OpenRouterModelPicker, { ModelDescriptionMarkdown, OPENROUTER_MODEL_PICKER_Z_INDEX } from "./OpenRouterModelPicker"
-import { ClineAccountInfoCard } from "./ClineAccountInfoCard"
-import RequestyModelPicker from "./RequestyModelPicker"
 import { useOpenRouterKeyInfo } from "../ui/hooks/useOpenRouterKeyInfo"
+import { ClineAccountInfoCard } from "./ClineAccountInfoCard"
+import OpenRouterModelPicker, { ModelDescriptionMarkdown, OPENROUTER_MODEL_PICKER_Z_INDEX } from "./OpenRouterModelPicker"
+import RequestyModelPicker from "./RequestyModelPicker"
+import ThinkingBudgetSlider from "./ThinkingBudgetSlider"
 
 interface ApiOptionsProps {
 	showModelOptions: boolean
@@ -190,9 +192,11 @@ const ApiOptions = ({
 	const requestLocalModels = useCallback(async () => {
 		if (selectedProvider === "ollama") {
 			try {
-				const response = await ModelsServiceClient.getOllamaModels({
-					value: apiConfiguration?.ollamaBaseUrl || "",
-				})
+				const response = await ModelsServiceClient.getOllamaModels(
+					StringRequest.create({
+						value: apiConfiguration?.ollamaBaseUrl || "",
+					}),
+				)
 				if (response && response.values) {
 					setOllamaModels(response.values)
 				}
@@ -202,9 +206,11 @@ const ApiOptions = ({
 			}
 		} else if (selectedProvider === "lmstudio") {
 			try {
-				const response = await ModelsServiceClient.getLmStudioModels({
-					value: apiConfiguration?.lmStudioBaseUrl || "",
-				})
+				const response = await ModelsServiceClient.getLmStudioModels(
+					StringRequest.create({
+						value: apiConfiguration?.lmStudioBaseUrl || "",
+					}),
+				)
 				if (response && response.values) {
 					setLmStudioModels(response.values)
 				}
@@ -214,7 +220,7 @@ const ApiOptions = ({
 			}
 		} else if (selectedProvider === "vscode-lm") {
 			try {
-				const response = await ModelsServiceClient.getVsCodeLmModels({})
+				const response = await ModelsServiceClient.getVsCodeLmModels(EmptyRequest.create({}))
 				if (response && response.models) {
 					setVsCodeLmModels(response.models)
 				}
@@ -284,10 +290,12 @@ const ApiOptions = ({
 
 		if (baseUrl && apiKey) {
 			debounceTimerRef.current = setTimeout(() => {
-				ModelsServiceClient.refreshOpenAiModels({
-					baseUrl,
-					apiKey,
-				}).catch((error) => {
+				ModelsServiceClient.refreshOpenAiModels(
+					OpenAiModelsRequest.create({
+						baseUrl,
+						apiKey,
+					}),
+				).catch((error) => {
 					console.error("Failed to refresh OpenAI models:", error)
 				})
 			}, 500)

--- a/webview-ui/src/components/settings/BrowserSettingsSection.tsx
+++ b/webview-ui/src/components/settings/BrowserSettingsSection.tsx
@@ -1,9 +1,11 @@
-import React, { useState, useEffect, useCallback } from "react"
+import { UpdateBrowserSettingsRequest } from "@shared/proto/browser"
+import { EmptyRequest, StringRequest } from "@shared/proto/common"
 import { VSCodeButton, VSCodeCheckbox, VSCodeDropdown, VSCodeOption, VSCodeTextField } from "@vscode/webview-ui-toolkit/react"
 import debounce from "debounce"
+import React, { useCallback, useEffect, useState } from "react"
+import styled from "styled-components"
 import { BROWSER_VIEWPORT_PRESETS } from "../../../../src/shared/BrowserSettings"
 import { useExtensionState } from "../../context/ExtensionStateContext"
-import styled from "styled-components"
 import { BrowserServiceClient } from "../../services/grpc-client"
 
 const ConnectionStatusIndicator = ({
@@ -74,7 +76,7 @@ export const BrowserSettingsSection: React.FC = () => {
 	// Request detected Chrome path on mount
 	useEffect(() => {
 		// Use gRPC for getDetectedChromePath
-		BrowserServiceClient.getDetectedChromePath({})
+		BrowserServiceClient.getDetectedChromePath(EmptyRequest.create({}))
 			.then((result) => {
 				setDetectedChromePath(result.path)
 				setIsBundled(result.isBundled)
@@ -100,7 +102,7 @@ export const BrowserSettingsSection: React.FC = () => {
 				setConnectionStatus(null)
 				if (browserSettings.remoteBrowserHost) {
 					// Use gRPC for testBrowserConnection
-					BrowserServiceClient.testBrowserConnection({ value: browserSettings.remoteBrowserHost })
+					BrowserServiceClient.testBrowserConnection(StringRequest.create({ value: browserSettings.remoteBrowserHost }))
 						.then((result) => {
 							setConnectionStatus(result.success)
 							setIsCheckingConnection(false)
@@ -111,7 +113,7 @@ export const BrowserSettingsSection: React.FC = () => {
 							setIsCheckingConnection(false)
 						})
 				} else {
-					BrowserServiceClient.discoverBrowser({})
+					BrowserServiceClient.discoverBrowser(EmptyRequest.create({}))
 						.then((result) => {
 							setConnectionStatus(result.success)
 							setIsCheckingConnection(false)
@@ -140,17 +142,19 @@ export const BrowserSettingsSection: React.FC = () => {
 		const target = event.target as HTMLSelectElement
 		const selectedSize = BROWSER_VIEWPORT_PRESETS[target.value as keyof typeof BROWSER_VIEWPORT_PRESETS]
 		if (selectedSize) {
-			BrowserServiceClient.updateBrowserSettings({
-				metadata: {},
-				viewport: {
-					width: selectedSize.width,
-					height: selectedSize.height,
-				},
-				remoteBrowserEnabled: browserSettings.remoteBrowserEnabled,
-				remoteBrowserHost: browserSettings.remoteBrowserHost,
-				chromeExecutablePath: browserSettings.chromeExecutablePath,
-				disableToolUse: browserSettings.disableToolUse,
-			})
+			BrowserServiceClient.updateBrowserSettings(
+				UpdateBrowserSettingsRequest.create({
+					metadata: {},
+					viewport: {
+						width: selectedSize.width,
+						height: selectedSize.height,
+					},
+					remoteBrowserEnabled: browserSettings.remoteBrowserEnabled,
+					remoteBrowserHost: browserSettings.remoteBrowserHost,
+					chromeExecutablePath: browserSettings.chromeExecutablePath,
+					disableToolUse: browserSettings.disableToolUse,
+				}),
+			)
 				.then((response) => {
 					if (!response.value) {
 						console.error("Failed to update browser settings")
@@ -163,18 +167,20 @@ export const BrowserSettingsSection: React.FC = () => {
 	}
 
 	const updateRemoteBrowserEnabled = (enabled: boolean) => {
-		BrowserServiceClient.updateBrowserSettings({
-			metadata: {},
-			viewport: {
-				width: browserSettings.viewport.width,
-				height: browserSettings.viewport.height,
-			},
-			remoteBrowserEnabled: enabled,
-			// If disabling, also clear the host
-			remoteBrowserHost: enabled ? browserSettings.remoteBrowserHost : undefined,
-			chromeExecutablePath: browserSettings.chromeExecutablePath,
-			disableToolUse: browserSettings.disableToolUse,
-		})
+		BrowserServiceClient.updateBrowserSettings(
+			UpdateBrowserSettingsRequest.create({
+				metadata: {},
+				viewport: {
+					width: browserSettings.viewport.width,
+					height: browserSettings.viewport.height,
+				},
+				remoteBrowserEnabled: enabled,
+				// If disabling, also clear the host
+				remoteBrowserHost: enabled ? browserSettings.remoteBrowserHost : undefined,
+				chromeExecutablePath: browserSettings.chromeExecutablePath,
+				disableToolUse: browserSettings.disableToolUse,
+			}),
+		)
 			.then((response) => {
 				if (!response.value) {
 					console.error("Failed to update browser settings")
@@ -186,17 +192,19 @@ export const BrowserSettingsSection: React.FC = () => {
 	}
 
 	const updateRemoteBrowserHost = (host: string | undefined) => {
-		BrowserServiceClient.updateBrowserSettings({
-			metadata: {},
-			viewport: {
-				width: browserSettings.viewport.width,
-				height: browserSettings.viewport.height,
-			},
-			remoteBrowserEnabled: browserSettings.remoteBrowserEnabled,
-			remoteBrowserHost: host,
-			chromeExecutablePath: browserSettings.chromeExecutablePath,
-			disableToolUse: browserSettings.disableToolUse,
-		})
+		BrowserServiceClient.updateBrowserSettings(
+			UpdateBrowserSettingsRequest.create({
+				metadata: {},
+				viewport: {
+					width: browserSettings.viewport.width,
+					height: browserSettings.viewport.height,
+				},
+				remoteBrowserEnabled: browserSettings.remoteBrowserEnabled,
+				remoteBrowserHost: host,
+				chromeExecutablePath: browserSettings.chromeExecutablePath,
+				disableToolUse: browserSettings.disableToolUse,
+			}),
+		)
 			.then((response) => {
 				if (!response.value) {
 					console.error("Failed to update browser settings")
@@ -209,17 +217,19 @@ export const BrowserSettingsSection: React.FC = () => {
 
 	const debouncedUpdateChromePath = useCallback(
 		debounce((newPath: string | undefined) => {
-			BrowserServiceClient.updateBrowserSettings({
-				metadata: {},
-				viewport: {
-					width: browserSettings.viewport.width,
-					height: browserSettings.viewport.height,
-				},
-				remoteBrowserEnabled: browserSettings.remoteBrowserEnabled,
-				remoteBrowserHost: browserSettings.remoteBrowserHost,
-				chromeExecutablePath: newPath,
-				disableToolUse: browserSettings.disableToolUse,
-			})
+			BrowserServiceClient.updateBrowserSettings(
+				UpdateBrowserSettingsRequest.create({
+					metadata: {},
+					viewport: {
+						width: browserSettings.viewport.width,
+						height: browserSettings.viewport.height,
+					},
+					remoteBrowserEnabled: browserSettings.remoteBrowserEnabled,
+					remoteBrowserHost: browserSettings.remoteBrowserHost,
+					chromeExecutablePath: newPath,
+					disableToolUse: browserSettings.disableToolUse,
+				}),
+			)
 				.then((response) => {
 					if (!response.value) {
 						console.error("Failed to update browser settings for chromeExecutablePath")
@@ -233,17 +243,19 @@ export const BrowserSettingsSection: React.FC = () => {
 	)
 
 	const updateChromeExecutablePath = (path: string | undefined) => {
-		BrowserServiceClient.updateBrowserSettings({
-			metadata: {},
-			viewport: {
-				width: browserSettings.viewport.width,
-				height: browserSettings.viewport.height,
-			},
-			remoteBrowserEnabled: browserSettings.remoteBrowserEnabled,
-			remoteBrowserHost: browserSettings.remoteBrowserHost,
-			chromeExecutablePath: path,
-			disableToolUse: browserSettings.disableToolUse,
-		})
+		BrowserServiceClient.updateBrowserSettings(
+			UpdateBrowserSettingsRequest.create({
+				metadata: {},
+				viewport: {
+					width: browserSettings.viewport.width,
+					height: browserSettings.viewport.height,
+				},
+				remoteBrowserEnabled: browserSettings.remoteBrowserEnabled,
+				remoteBrowserHost: browserSettings.remoteBrowserHost,
+				chromeExecutablePath: path,
+				disableToolUse: browserSettings.disableToolUse,
+			}),
+		)
 			.then((response) => {
 				if (!response.value) {
 					console.error("Failed to update browser settings")
@@ -260,7 +272,7 @@ export const BrowserSettingsSection: React.FC = () => {
 		// We'll rely on the response to update the connectionStatus
 		if (browserSettings.remoteBrowserHost) {
 			// Use gRPC for testBrowserConnection
-			BrowserServiceClient.testBrowserConnection({ value: browserSettings.remoteBrowserHost })
+			BrowserServiceClient.testBrowserConnection(StringRequest.create({ value: browserSettings.remoteBrowserHost }))
 				.then((result) => {
 					setConnectionStatus(result.success)
 				})
@@ -269,7 +281,7 @@ export const BrowserSettingsSection: React.FC = () => {
 					setConnectionStatus(false)
 				})
 		} else {
-			BrowserServiceClient.discoverBrowser({})
+			BrowserServiceClient.discoverBrowser(EmptyRequest.create({}))
 				.then((result) => {
 					setConnectionStatus(result.success)
 				})
@@ -302,17 +314,19 @@ export const BrowserSettingsSection: React.FC = () => {
 	}, [browserSettings.remoteBrowserEnabled, checkConnectionOnce])
 
 	const updateDisableToolUse = (disabled: boolean) => {
-		BrowserServiceClient.updateBrowserSettings({
-			metadata: {},
-			viewport: {
-				width: browserSettings.viewport.width,
-				height: browserSettings.viewport.height,
-			},
-			remoteBrowserEnabled: browserSettings.remoteBrowserEnabled,
-			remoteBrowserHost: browserSettings.remoteBrowserHost,
-			chromeExecutablePath: browserSettings.chromeExecutablePath,
-			disableToolUse: disabled,
-		})
+		BrowserServiceClient.updateBrowserSettings(
+			UpdateBrowserSettingsRequest.create({
+				metadata: {},
+				viewport: {
+					width: browserSettings.viewport.width,
+					height: browserSettings.viewport.height,
+				},
+				remoteBrowserEnabled: browserSettings.remoteBrowserEnabled,
+				remoteBrowserHost: browserSettings.remoteBrowserHost,
+				chromeExecutablePath: browserSettings.chromeExecutablePath,
+				disableToolUse: disabled,
+			}),
+		)
 			.then((response) => {
 				if (!response.value) {
 					console.error("Failed to update disableToolUse setting")
@@ -328,7 +342,7 @@ export const BrowserSettingsSection: React.FC = () => {
 		setRelaunchResult(null)
 		// The connection status will be automatically updated by our polling
 
-		BrowserServiceClient.relaunchChromeDebugMode({})
+		BrowserServiceClient.relaunchChromeDebugMode(EmptyRequest.create({}))
 			.then((result) => {
 				setRelaunchResult({
 					success: result.success,

--- a/webview-ui/src/components/settings/OpenRouterModelPicker.tsx
+++ b/webview-ui/src/components/settings/OpenRouterModelPicker.tsx
@@ -1,17 +1,18 @@
+import { CODE_BLOCK_BG_COLOR } from "@/components/common/CodeBlock"
+import { useExtensionState } from "@/context/ExtensionStateContext"
+import { StateServiceClient } from "@/services/grpc-client"
+import { openRouterDefaultModelId } from "@shared/api"
+import { StringRequest } from "@shared/proto/common"
 import { VSCodeLink, VSCodeTextField } from "@vscode/webview-ui-toolkit/react"
 import Fuse from "fuse.js"
 import React, { KeyboardEvent, memo, useEffect, useMemo, useRef, useState } from "react"
 import { useRemark } from "react-remark"
 import { useMount } from "react-use"
 import styled from "styled-components"
-import { openRouterDefaultModelId } from "@shared/api"
-import { useExtensionState } from "@/context/ExtensionStateContext"
-import { StateServiceClient } from "@/services/grpc-client"
 import { highlight } from "../history/HistoryView"
 import { ModelInfoView, normalizeApiConfiguration } from "./ApiOptions"
-import { CODE_BLOCK_BG_COLOR } from "@/components/common/CodeBlock"
-import ThinkingBudgetSlider from "./ThinkingBudgetSlider"
 import FeaturedModelCard from "./FeaturedModelCard"
+import ThinkingBudgetSlider from "./ThinkingBudgetSlider"
 
 // Star icon for favorites
 const StarIcon = ({ isFavorite, onClick }: { isFavorite: boolean; onClick: (e: React.MouseEvent) => void }) => {
@@ -289,9 +290,9 @@ const OpenRouterModelPicker: React.FC<OpenRouterModelPickerProps> = ({ isPopup }
 												isFavorite={isFavorite}
 												onClick={(e) => {
 													e.stopPropagation()
-													StateServiceClient.toggleFavoriteModel({ value: item.id }).catch((error) =>
-														console.error("Failed to toggle favorite model:", error),
-													)
+													StateServiceClient.toggleFavoriteModel(
+														StringRequest.create({ value: item.id }),
+													).catch((error) => console.error("Failed to toggle favorite model:", error))
 												}}
 											/>
 										</div>

--- a/webview-ui/src/components/settings/RequestyModelPicker.tsx
+++ b/webview-ui/src/components/settings/RequestyModelPicker.tsx
@@ -1,3 +1,4 @@
+import { EmptyRequest } from "@shared/proto/common"
 import { VSCodeLink, VSCodeTextField } from "@vscode/webview-ui-toolkit/react"
 import Fuse from "fuse.js"
 import React, { KeyboardEvent, memo, useEffect, useMemo, useRef, useState } from "react"
@@ -7,9 +8,9 @@ import styled from "styled-components"
 import { requestyDefaultModelId } from "../../../../src/shared/api"
 import { useExtensionState } from "../../context/ExtensionStateContext"
 import { ModelsServiceClient } from "../../services/grpc-client"
+import { CODE_BLOCK_BG_COLOR } from "../common/CodeBlock"
 import { highlight } from "../history/HistoryView"
 import { ModelInfoView, normalizeApiConfiguration } from "./ApiOptions"
-import { CODE_BLOCK_BG_COLOR } from "../common/CodeBlock"
 import ThinkingBudgetSlider from "./ThinkingBudgetSlider"
 
 export interface RequestyModelPickerProps {
@@ -43,7 +44,7 @@ const RequestyModelPicker: React.FC<RequestyModelPickerProps> = ({ isPopup }) =>
 	}, [apiConfiguration])
 
 	useMount(() => {
-		ModelsServiceClient.refreshRequestyModels({}).catch((err) => {
+		ModelsServiceClient.refreshRequestyModels(EmptyRequest.create({})).catch((err) => {
 			console.error("Failed to refresh Requesty models:", err)
 		})
 	})

--- a/webview-ui/src/components/settings/SettingsView.tsx
+++ b/webview-ui/src/components/settings/SettingsView.tsx
@@ -1,48 +1,26 @@
-import {
-	VSCodeButton,
-	VSCodeCheckbox,
-	VSCodeDropdown,
-	VSCodeLink,
-	VSCodeOption,
-	VSCodeTextArea,
-} from "@vscode/webview-ui-toolkit/react"
-import { memo, useCallback, useEffect, useState, useRef } from "react"
-import {
-	Settings,
-	Webhook,
-	CheckCheck,
-	SquareMousePointer,
-	GitBranch,
-	Bell,
-	Database,
-	SquareTerminal,
-	FlaskConical,
-	Globe,
-	Info,
-	LucideIcon,
-} from "lucide-react"
-import HeroTooltip from "@/components/common/HeroTooltip"
 import { UnsavedChangesDialog } from "@/components/common/AlertDialog"
-import SectionHeader from "./SectionHeader"
-import Section from "./Section"
-import PreferredLanguageSetting from "./PreferredLanguageSetting" // Added import
-import { OpenAIReasoningEffort } from "@shared/ChatSettings"
+import HeroTooltip from "@/components/common/HeroTooltip"
 import { useExtensionState } from "@/context/ExtensionStateContext"
+import { StateServiceClient } from "@/services/grpc-client"
+import { cn } from "@/utils/cn"
 import { validateApiConfiguration, validateModelId } from "@/utils/validate"
 import { vscode } from "@/utils/vscode"
-import SettingsButton from "@/components/common/SettingsButton"
-import ApiOptions from "./ApiOptions"
-import { TabButton } from "../mcp/configuration/McpConfigurationView"
-import { useEvent } from "react-use"
 import { ExtensionMessage } from "@shared/ExtensionMessage"
-import { StateServiceClient } from "@/services/grpc-client"
-import FeatureSettingsSection from "./FeatureSettingsSection"
-import BrowserSettingsSection from "./BrowserSettingsSection"
-import TerminalSettingsSection from "./TerminalSettingsSection"
-import { FEATURE_FLAGS } from "@shared/services/feature-flags/feature-flags"
+import { EmptyRequest } from "@shared/proto/common"
+import { PlanActMode, TogglePlanActModeRequest } from "@shared/proto/state"
+import { VSCodeButton, VSCodeCheckbox, VSCodeLink, VSCodeTextArea } from "@vscode/webview-ui-toolkit/react"
+import { CheckCheck, FlaskConical, Info, LucideIcon, Settings, SquareMousePointer, SquareTerminal, Webhook } from "lucide-react"
+import { memo, useCallback, useEffect, useRef, useState } from "react"
+import { useEvent } from "react-use"
 import { Tab, TabContent, TabHeader, TabList, TabTrigger } from "../common/Tab"
-import { cn } from "@/utils/cn"
-import { PlanActMode } from "@shared/proto/state"
+import { TabButton } from "../mcp/configuration/McpConfigurationView"
+import ApiOptions from "./ApiOptions"
+import BrowserSettingsSection from "./BrowserSettingsSection"
+import FeatureSettingsSection from "./FeatureSettingsSection"
+import PreferredLanguageSetting from "./PreferredLanguageSetting" // Added import
+import Section from "./Section"
+import SectionHeader from "./SectionHeader"
+import TerminalSettingsSection from "./TerminalSettingsSection"
 const { IS_DEV } = process.env
 
 // Styles for the tab system
@@ -315,13 +293,15 @@ const SettingsView = ({ onDone, targetSection }: SettingsViewProps) => {
 			switch (message.type) {
 				case "didUpdateSettings":
 					if (pendingTabChange) {
-						StateServiceClient.togglePlanActMode({
-							chatSettings: {
-								mode: pendingTabChange === "plan" ? PlanActMode.PLAN : PlanActMode.ACT,
-								preferredLanguage: chatSettings.preferredLanguage,
-								openAIReasoningEffort: chatSettings.openAIReasoningEffort,
-							},
-						})
+						StateServiceClient.togglePlanActMode(
+							TogglePlanActModeRequest.create({
+								chatSettings: {
+									mode: pendingTabChange === "plan" ? PlanActMode.PLAN : PlanActMode.ACT,
+									preferredLanguage: chatSettings.preferredLanguage,
+									openAiReasoningEffort: chatSettings.openAIReasoningEffort,
+								},
+							}),
+						)
 						setPendingTabChange(null)
 					}
 					break
@@ -365,7 +345,7 @@ const SettingsView = ({ onDone, targetSection }: SettingsViewProps) => {
 
 	const handleResetState = async () => {
 		try {
-			await StateServiceClient.resetState({})
+			await StateServiceClient.resetState(EmptyRequest.create({}))
 		} catch (error) {
 			console.error("Failed to reset state:", error)
 		}

--- a/webview-ui/src/components/welcome/SuggestedTasks.tsx
+++ b/webview-ui/src/components/welcome/SuggestedTasks.tsx
@@ -1,11 +1,12 @@
-import React from "react"
 import { TaskServiceClient } from "@/services/grpc-client"
+import { NewTaskRequest } from "@shared/proto/task"
+import React from "react"
 import QuickWinCard from "./QuickWinCard"
 import { QuickWinTask, quickWinTasks } from "./quickWinTasks"
 
 export const SuggestedTasks: React.FC<{ shouldShowQuickWins: boolean }> = ({ shouldShowQuickWins }) => {
 	const handleExecuteQuickWin = async (prompt: string) => {
-		await TaskServiceClient.newTask({ text: prompt, images: [] })
+		await TaskServiceClient.newTask(NewTaskRequest.create({ text: prompt, images: [] }))
 	}
 
 	if (shouldShowQuickWins) {

--- a/webview-ui/src/context/ExtensionStateContext.tsx
+++ b/webview-ui/src/context/ExtensionStateContext.tsx
@@ -1,8 +1,12 @@
-import React, { createContext, useCallback, useContext, useEffect, useState, useRef } from "react"
-import { useEvent } from "react-use"
-import { ModelsServiceClient, StateServiceClient } from "../services/grpc-client"
 import { DEFAULT_AUTO_APPROVAL_SETTINGS } from "@shared/AutoApprovalSettings"
-import { ExtensionMessage, ExtensionState, DEFAULT_PLATFORM } from "@shared/ExtensionMessage"
+import { DEFAULT_BROWSER_SETTINGS } from "@shared/BrowserSettings"
+import { ChatSettings, DEFAULT_CHAT_SETTINGS } from "@shared/ChatSettings"
+import { DEFAULT_PLATFORM, ExtensionMessage, ExtensionState } from "@shared/ExtensionMessage"
+import { TelemetrySetting } from "@shared/TelemetrySetting"
+import { findLastIndex } from "@shared/array"
+import { EmptyRequest } from "@shared/proto/common"
+import React, { createContext, useCallback, useContext, useEffect, useRef, useState } from "react"
+import { useEvent } from "react-use"
 import {
 	ApiConfiguration,
 	ModelInfo,
@@ -11,13 +15,10 @@ import {
 	requestyDefaultModelId,
 	requestyDefaultModelInfo,
 } from "../../../src/shared/api"
-import { findLastIndex } from "@shared/array"
 import { McpMarketplaceCatalog, McpServer, McpViewTab } from "../../../src/shared/mcp"
+import { ModelsServiceClient, StateServiceClient } from "../services/grpc-client"
 import { convertTextMateToHljs } from "../utils/textMateToHljs"
 import { vscode } from "../utils/vscode"
-import { DEFAULT_BROWSER_SETTINGS } from "@shared/BrowserSettings"
-import { ChatSettings, DEFAULT_CHAT_SETTINGS } from "@shared/ChatSettings"
-import { TelemetrySetting } from "@shared/TelemetrySetting"
 
 interface ExtensionStateContextType extends ExtensionState {
 	didHydrateState: boolean
@@ -276,77 +277,74 @@ export const ExtensionStateContextProvider: React.FC<{
 	// Subscribe to state updates using the new gRPC streaming API
 	useEffect(() => {
 		// Set up state subscription
-		stateSubscriptionRef.current = StateServiceClient.subscribeToState(
-			{},
-			{
-				onResponse: (response) => {
-					if (response.stateJson) {
-						try {
-							const stateData = JSON.parse(response.stateJson) as ExtensionState
-							console.log("[DEBUG] parsed state JSON, updating state")
-							setState((prevState) => {
-								// Versioning logic for autoApprovalSettings
-								const incomingVersion = stateData.autoApprovalSettings?.version ?? 1
-								const currentVersion = prevState.autoApprovalSettings?.version ?? 1
-								const shouldUpdateAutoApproval = incomingVersion > currentVersion
+		stateSubscriptionRef.current = StateServiceClient.subscribeToState(EmptyRequest.create({}), {
+			onResponse: (response) => {
+				if (response.stateJson) {
+					try {
+						const stateData = JSON.parse(response.stateJson) as ExtensionState
+						console.log("[DEBUG] parsed state JSON, updating state")
+						setState((prevState) => {
+							// Versioning logic for autoApprovalSettings
+							const incomingVersion = stateData.autoApprovalSettings?.version ?? 1
+							const currentVersion = prevState.autoApprovalSettings?.version ?? 1
+							const shouldUpdateAutoApproval = incomingVersion > currentVersion
 
-								const newState = {
-									...stateData,
-									autoApprovalSettings: shouldUpdateAutoApproval
-										? stateData.autoApprovalSettings
-										: prevState.autoApprovalSettings,
-								}
+							const newState = {
+								...stateData,
+								autoApprovalSettings: shouldUpdateAutoApproval
+									? stateData.autoApprovalSettings
+									: prevState.autoApprovalSettings,
+							}
 
-								// Update welcome screen state based on API configuration
-								const config = stateData.apiConfiguration
-								const hasKey = config
-									? [
-											config.apiKey,
-											config.openRouterApiKey,
-											config.awsRegion,
-											config.vertexProjectId,
-											config.openAiApiKey,
-											config.ollamaModelId,
-											config.lmStudioModelId,
-											config.liteLlmApiKey,
-											config.geminiApiKey,
-											config.openAiNativeApiKey,
-											config.deepSeekApiKey,
-											config.requestyApiKey,
-											config.togetherApiKey,
-											config.qwenApiKey,
-											config.doubaoApiKey,
-											config.mistralApiKey,
-											config.vsCodeLmModelSelector,
-											config.clineApiKey,
-											config.asksageApiKey,
-											config.xaiApiKey,
-											config.sambanovaApiKey,
-										].some((key) => key !== undefined)
-									: false
+							// Update welcome screen state based on API configuration
+							const config = stateData.apiConfiguration
+							const hasKey = config
+								? [
+										config.apiKey,
+										config.openRouterApiKey,
+										config.awsRegion,
+										config.vertexProjectId,
+										config.openAiApiKey,
+										config.ollamaModelId,
+										config.lmStudioModelId,
+										config.liteLlmApiKey,
+										config.geminiApiKey,
+										config.openAiNativeApiKey,
+										config.deepSeekApiKey,
+										config.requestyApiKey,
+										config.togetherApiKey,
+										config.qwenApiKey,
+										config.doubaoApiKey,
+										config.mistralApiKey,
+										config.vsCodeLmModelSelector,
+										config.clineApiKey,
+										config.asksageApiKey,
+										config.xaiApiKey,
+										config.sambanovaApiKey,
+									].some((key) => key !== undefined)
+								: false
 
-								setShowWelcome(!hasKey)
-								setDidHydrateState(true)
+							setShowWelcome(!hasKey)
+							setDidHydrateState(true)
 
-								console.log("[DEBUG] returning new state in ESC")
+							console.log("[DEBUG] returning new state in ESC")
 
-								return newState
-							})
-						} catch (error) {
-							console.error("Error parsing state JSON:", error)
-							console.log("[DEBUG] ERR getting state", error)
-						}
+							return newState
+						})
+					} catch (error) {
+						console.error("Error parsing state JSON:", error)
+						console.log("[DEBUG] ERR getting state", error)
 					}
-					console.log('[DEBUG] ended "got subscribed state"')
-				},
-				onError: (error) => {
-					console.error("Error in state subscription:", error)
-				},
-				onComplete: () => {
-					console.log("State subscription completed")
-				},
+				}
+				console.log('[DEBUG] ended "got subscribed state"')
 			},
-		)
+			onError: (error) => {
+				console.error("Error in state subscription:", error)
+			},
+			onComplete: () => {
+				console.log("State subscription completed")
+			},
+		})
 
 		// Still send the webviewDidLaunch message for other initialization
 		vscode.postMessage({ type: "webviewDidLaunch" })
@@ -361,7 +359,7 @@ export const ExtensionStateContextProvider: React.FC<{
 	}, [])
 
 	const refreshOpenRouterModels = useCallback(() => {
-		ModelsServiceClient.refreshOpenRouterModels({})
+		ModelsServiceClient.refreshOpenRouterModels(EmptyRequest.create({}))
 			.then((res) => {
 				setOpenRouterModels({
 					[openRouterDefaultModelId]: openRouterDefaultModelInfo, // in case the extension sent a model list without the default model

--- a/webview-ui/src/context/FirebaseAuthContext.tsx
+++ b/webview-ui/src/context/FirebaseAuthContext.tsx
@@ -1,8 +1,9 @@
-import { User, getAuth, signInWithCustomToken, signOut } from "firebase/auth"
-import { initializeApp } from "firebase/app"
-import React, { createContext, useCallback, useContext, useEffect, useState } from "react"
-import { vscode } from "@/utils/vscode"
 import { AccountServiceClient } from "@/services/grpc-client"
+import { vscode } from "@/utils/vscode"
+import { EmptyRequest } from "@shared/proto/common"
+import { initializeApp } from "firebase/app"
+import { User, getAuth, signInWithCustomToken, signOut } from "firebase/auth"
+import React, { createContext, useCallback, useContext, useEffect, useState } from "react"
 
 // Firebase configuration from extension
 const firebaseConfig = {
@@ -74,20 +75,17 @@ export const FirebaseAuthProvider: React.FC<{ children: React.ReactNode }> = ({ 
 
 	// Set up authCallback subscription
 	useEffect(() => {
-		const cleanup = AccountServiceClient.subscribeToAuthCallback(
-			{},
-			{
-				onResponse: (event) => {
-					if (event.value) {
-						signInWithToken(event.value)
-					}
-				},
-				onError: (error) => {
-					console.error("Error in authCallback subscription:", error)
-				},
-				onComplete: () => {},
+		const cleanup = AccountServiceClient.subscribeToAuthCallback(EmptyRequest.create({}), {
+			onResponse: (event) => {
+				if (event.value) {
+					signInWithToken(event.value)
+				}
 			},
-		)
+			onError: (error) => {
+				console.error("Error in authCallback subscription:", error)
+			},
+			onComplete: () => {},
+		})
 
 		return cleanup
 	}, [signInWithToken])


### PR DESCRIPTION
Replace protobus calls using object literals to use Message.create({...})

Fix incorrect property name detected after this change in webview-ui/src/components/settings/SettingsView.tsx

Optimised imports in vscode.

### Test Procedure

`npm run test`
Tested manually in the vscode extension host.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

NA

### Additional Notes

NA
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fix linter warnings by using `Message.create({...})` for protobuf calls and optimize imports.
> 
>   - **Behavior**:
>     - Replace object literals with `Message.create({...})` for protobuf calls in `HistoryView.tsx`, `ImagePreview.tsx`, and `LinkPreview.tsx`.
>     - Fix incorrect property name in `SettingsView.tsx`.
>   - **Imports**:
>     - Optimize imports in `HistoryPreview.tsx`, `HistoryView.tsx`, and `ImagePreview.tsx`.
>   - **Testing**:
>     - Manual testing in VSCode extension host.
>     - Automated tests with `npm run test`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 47d4cdd1e3233437b242e675be48269196a6897e. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->