### PR TITLE
Fix warnings for protobuf object literals

### DIFF
--- a/src/core/controller/account/accountLoginClicked.ts
+++ b/src/core/controller/account/accountLoginClicked.ts
@@ -12,7 +12,7 @@ import { EmptyRequest, String } from "../../../shared/proto/common"
  * @param controller The controller instance.
  * @returns The login URL as a string.
  */
-export async function accountLoginClicked(controller: Controller, unused: EmptyRequest): Promise<String> {
+export async function accountLoginClicked(controller: Controller, _: EmptyRequest): Promise<String> {
 	// Generate nonce for state validation
 	const nonce = crypto.randomBytes(32).toString("hex")
 	await storeSecret(controller.context, "authNonce", nonce)
@@ -27,7 +27,7 @@ export async function accountLoginClicked(controller: Controller, unused: EmptyR
 		`https://app.cline.bot/auth?state=${encodeURIComponent(nonce)}&callback_url=${encodeURIComponent(`${uriScheme || "vscode"}://saoudrizwan.claude-dev/auth`)}`,
 	)
 	await vscode.env.openExternal(authUrl)
-	return {
+	return String.create({
 		value: authUrl.toString(),
-	}
+	})
 }

--- a/src/core/controller/account/accountLogoutClicked.ts
+++ b/src/core/controller/account/accountLogoutClicked.ts
@@ -1,4 +1,4 @@
-import type { Empty } from "../../../shared/proto/common"
+import { Empty } from "../../../shared/proto/common"
 import type { EmptyRequest } from "../../../shared/proto/common"
 import type { Controller } from "../index"
 
@@ -10,5 +10,5 @@ import type { Controller } from "../index"
  */
 export async function accountLogoutClicked(controller: Controller, _request: EmptyRequest): Promise<Empty> {
 	await controller.handleSignOut()
-	return {}
+	return Empty.create({})
 }

--- a/src/core/controller/browser/discoverBrowser.ts
+++ b/src/core/controller/browser/discoverBrowser.ts
@@ -24,24 +24,24 @@ export async function discoverBrowser(controller: Controller, request: EmptyRequ
 			const browserSession = new BrowserSession(controller.context, browserSettings)
 			const result = await browserSession.testConnection(discoveredHost)
 
-			return {
+			return BrowserConnection.create({
 				success: true,
 				message: `Successfully discovered and connected to Chrome at ${discoveredHost}`,
 				endpoint: result.endpoint || "",
-			}
+			})
 		} else {
-			return {
+			return BrowserConnection.create({
 				success: false,
 				message:
 					"No Chrome instances found. Make sure Chrome is running with remote debugging enabled (--remote-debugging-port=9222).",
 				endpoint: "",
-			}
+			})
 		}
 	} catch (error) {
-		return {
+		return BrowserConnection.create({
 			success: false,
 			message: `Error discovering browser: ${error instanceof Error ? error.message : String(error)}`,
 			endpoint: "",
-		}
+		})
 	}
 }

--- a/src/core/controller/browser/getBrowserConnectionInfo.ts
+++ b/src/core/controller/browser/getBrowserConnectionInfo.ts
@@ -9,7 +9,7 @@ import { getAllExtensionState } from "@core/storage/state"
  * @param request The request message
  * @returns The browser connection info
  */
-export async function getBrowserConnectionInfo(controller: Controller, request: EmptyRequest): Promise<BrowserConnectionInfo> {
+export async function getBrowserConnectionInfo(controller: Controller, _: EmptyRequest): Promise<BrowserConnectionInfo> {
 	try {
 		// Get browser settings from extension state
 		const { browserSettings } = await getAllExtensionState(controller.context)
@@ -23,25 +23,25 @@ export async function getBrowserConnectionInfo(controller: Controller, request: 
 			const connectionInfo = browserSession.getConnectionInfo()
 
 			// Convert from BrowserSession.BrowserConnectionInfo to proto.BrowserConnectionInfo
-			return {
+			return BrowserConnectionInfo.create({
 				isConnected: connectionInfo.isConnected,
 				isRemote: connectionInfo.isRemote,
 				host: connectionInfo.host || "", // Ensure host is never undefined
-			}
+			})
 		}
 
 		// Fallback to browser settings if no active browser session
-		return {
+		return BrowserConnectionInfo.create({
 			isConnected: false,
 			isRemote: !!browserSettings.remoteBrowserEnabled,
 			host: browserSettings.remoteBrowserHost || "",
-		}
+		})
 	} catch (error: unknown) {
 		console.error("Error getting browser connection info:", error)
-		return {
+		return BrowserConnectionInfo.create({
 			isConnected: false,
 			isRemote: false,
 			host: "",
-		}
+		})
 	}
 }

--- a/src/core/controller/browser/getDetectedChromePath.ts
+++ b/src/core/controller/browser/getDetectedChromePath.ts
@@ -10,21 +10,21 @@ import { BrowserSession } from "../../../services/browser/BrowserSession"
  * @param request The empty request message
  * @returns The detected Chrome path and whether it's bundled
  */
-export async function getDetectedChromePath(controller: Controller, request: EmptyRequest): Promise<ChromePath> {
+export async function getDetectedChromePath(controller: Controller, _: EmptyRequest): Promise<ChromePath> {
 	try {
 		const { browserSettings } = await getAllExtensionState(controller.context)
 		const browserSession = new BrowserSession(controller.context, browserSettings)
 		const result = await browserSession.getDetectedChromePath()
 
-		return {
+		return ChromePath.create({
 			path: result.path,
 			isBundled: result.isBundled,
-		}
+		})
 	} catch (error) {
 		console.error("Error getting detected Chrome path:", error)
-		return {
+		return ChromePath.create({
 			path: "",
 			isBundled: false,
-		}
+		})
 	}
 }

--- a/src/core/controller/browser/relaunchChromeDebugMode.ts
+++ b/src/core/controller/browser/relaunchChromeDebugMode.ts
@@ -8,7 +8,7 @@ import { BrowserSession } from "../../../services/browser/BrowserSession"
  * @param request The empty request message
  * @returns The browser relaunch result as a string message
  */
-export async function relaunchChromeDebugMode(controller: Controller, request: EmptyRequest): Promise<StringMessage> {
+export async function relaunchChromeDebugMode(controller: Controller, _: EmptyRequest): Promise<StringMessage> {
 	try {
 		const { browserSettings } = await controller.getStateToPostToWebview()
 		const browserSession = new BrowserSession(controller.context, browserSettings)
@@ -18,9 +18,9 @@ export async function relaunchChromeDebugMode(controller: Controller, request: E
 
 		// The actual result will be sent via postMessageToWebview in the BrowserSession.relaunchChromeDebugMode method
 		// Here we just return a message as a placeholder
-		return {
+		return StringMessage.create({
 			value: "Chrome relaunch initiated",
-		}
+		})
 	} catch (error) {
 		throw new Error(`Error relaunching Chrome: ${error instanceof Error ? error.message : globalThis.String(error)}`)
 	}

--- a/src/core/controller/browser/testBrowserConnection.ts
+++ b/src/core/controller/browser/testBrowserConnection.ts
@@ -24,40 +24,40 @@ export async function testBrowserConnection(controller: Controller, request: Str
 				if (discoveredHost) {
 					// Test the connection to the discovered host
 					const result = await browserSession.testConnection(discoveredHost)
-					return {
+					return BrowserConnection.create({
 						success: result.success,
 						message: `Auto-discovered and tested connection to Chrome at ${discoveredHost}: ${result.message}`,
 						endpoint: result.endpoint || "",
-					}
+					})
 				} else {
-					return {
+					return BrowserConnection.create({
 						success: false,
 						message:
 							"No Chrome instances found on the network. Make sure Chrome is running with remote debugging enabled (--remote-debugging-port=9222).",
 						endpoint: "",
-					}
+					})
 				}
 			} catch (error) {
-				return {
+				return BrowserConnection.create({
 					success: false,
 					message: `Error during auto-discovery: ${error instanceof Error ? error.message : String(error)}`,
 					endpoint: "",
-				}
+				})
 			}
 		} else {
 			// Test the provided URL
 			const result = await browserSession.testConnection(text)
-			return {
+			return BrowserConnection.create({
 				success: result.success,
 				message: result.message,
 				endpoint: result.endpoint || "",
-			}
+			})
 		}
 	} catch (error) {
-		return {
+		return BrowserConnection.create({
 			success: false,
 			message: `Error testing connection: ${error instanceof Error ? error.message : String(error)}`,
 			endpoint: "",
-		}
+		})
 	}
 }

--- a/src/core/controller/browser/updateBrowserSettings.ts
+++ b/src/core/controller/browser/updateBrowserSettings.ts
@@ -50,13 +50,13 @@ export async function updateBrowserSettings(controller: Controller, request: Upd
 		// Post updated state to webview
 		await controller.postStateToWebview()
 
-		return {
+		return Boolean.create({
 			value: true,
-		}
+		})
 	} catch (error) {
 		console.error("Error updating browser settings:", error)
-		return {
+		return Boolean.create({
 			value: false,
-		}
+		})
 	}
 }

--- a/src/core/controller/checkpoints/checkpointRestore.ts
+++ b/src/core/controller/checkpoints/checkpointRestore.ts
@@ -18,5 +18,5 @@ export async function checkpointRestore(controller: Controller, request: Checkpo
 		// NOTE: cancelTask awaits abortTask, which awaits diffViewProvider.revertChanges, which reverts any edited files, allowing us to reset to a checkpoint rather than running into a state where the revertChanges function is called alongside or after the checkpoint reset
 		await controller.task?.restoreCheckpoint(request.number, request.restoreType as ClineCheckpointRestore, request.offset)
 	}
-	return {}
+	return Empty.create({})
 }

--- a/src/core/controller/file/refreshRules.ts
+++ b/src/core/controller/file/refreshRules.ts
@@ -18,14 +18,14 @@ export async function refreshRules(controller: Controller, _request: EmptyReques
 		const { cursorLocalToggles, windsurfLocalToggles } = await refreshExternalRulesToggles(controller.context, cwd)
 		const { localWorkflowToggles, globalWorkflowToggles } = await refreshWorkflowToggles(controller.context, cwd)
 
-		return {
+		return RefreshedRules.create({
 			globalClineRulesToggles: { toggles: globalToggles },
 			localClineRulesToggles: { toggles: localToggles },
 			localCursorRulesToggles: { toggles: cursorLocalToggles },
 			localWindsurfRulesToggles: { toggles: windsurfLocalToggles },
 			localWorkflowToggles: { toggles: localWorkflowToggles },
 			globalWorkflowToggles: { toggles: globalWorkflowToggles },
-		}
+		})
 	} catch (error) {
 		console.error("Failed to refresh rules:", error)
 		throw error

--- a/src/core/controller/file/toggleClineRule.ts
+++ b/src/core/controller/file/toggleClineRule.ts
@@ -1,4 +1,5 @@
-import type { ToggleClineRuleRequest, ClineRulesToggles, ToggleClineRules } from "../../../shared/proto/file"
+import { ToggleClineRules } from "../../../shared/proto/file"
+import type { ToggleClineRuleRequest } from "../../../shared/proto/file"
 import type { Controller } from "../index"
 import { getGlobalState, getWorkspaceState, updateGlobalState, updateWorkspaceState } from "../../../core/storage/state"
 import { ClineRulesToggles as AppClineRulesToggles } from "@shared/cline-rules"
@@ -36,8 +37,8 @@ export async function toggleClineRule(controller: Controller, request: ToggleCli
 	const globalToggles = ((await getGlobalState(controller.context, "globalClineRulesToggles")) as AppClineRulesToggles) || {}
 	const localToggles = ((await getWorkspaceState(controller.context, "localClineRulesToggles")) as AppClineRulesToggles) || {}
 
-	return {
+	return ToggleClineRules.create({
 		globalClineRulesToggles: { toggles: globalToggles },
 		localClineRulesToggles: { toggles: localToggles },
-	}
+	})
 }

--- a/src/core/controller/file/toggleCursorRule.ts
+++ b/src/core/controller/file/toggleCursorRule.ts
@@ -1,4 +1,5 @@
-import type { ToggleCursorRuleRequest, ClineRulesToggles } from "../../../shared/proto/file"
+import type { ToggleCursorRuleRequest } from "../../../shared/proto/file"
+import { ClineRulesToggles } from "../../../shared/proto/file"
 import type { Controller } from "../index"
 import { getWorkspaceState, updateWorkspaceState } from "../../../core/storage/state"
 import { ClineRulesToggles as AppClineRulesToggles } from "@shared/cline-rules"
@@ -28,7 +29,7 @@ export async function toggleCursorRule(controller: Controller, request: ToggleCu
 	// Get the current state to return in the response
 	const cursorToggles = ((await getWorkspaceState(controller.context, "localCursorRulesToggles")) as AppClineRulesToggles) || {}
 
-	return {
+	return ClineRulesToggles.create({
 		toggles: cursorToggles,
-	}
+	})
 }

--- a/src/core/controller/file/toggleWindsurfRule.ts
+++ b/src/core/controller/file/toggleWindsurfRule.ts
@@ -1,4 +1,5 @@
-import type { ToggleWindsurfRuleRequest, ClineRulesToggles } from "../../../shared/proto/file"
+import type { ToggleWindsurfRuleRequest } from "../../../shared/proto/file"
+import { ClineRulesToggles } from "../../../shared/proto/file"
 import type { Controller } from "../index"
 import { getWorkspaceState, updateWorkspaceState } from "../../../core/storage/state"
 import { ClineRulesToggles as AppClineRulesToggles } from "@shared/cline-rules"
@@ -26,5 +27,5 @@ export async function toggleWindsurfRule(controller: Controller, request: Toggle
 	await updateWorkspaceState(controller.context, "localWindsurfRulesToggles", toggles)
 
 	// Return the toggles directly
-	return { toggles: toggles }
+	return ClineRulesToggles.create({ toggles: toggles })
 }

--- a/src/core/controller/mcp/addRemoteMcpServer.ts
+++ b/src/core/controller/mcp/addRemoteMcpServer.ts
@@ -1,5 +1,6 @@
 import { convertMcpServersToProtoMcpServers } from "@/shared/proto-conversions/mcp/mcp-server-conversion"
-import type { AddRemoteMcpServerRequest, McpServers } from "../../../shared/proto/mcp"
+import type { AddRemoteMcpServerRequest } from "../../../shared/proto/mcp"
+import { McpServers } from "../../../shared/proto/mcp"
 import type { Controller } from "../index"
 
 /**
@@ -23,7 +24,7 @@ export async function addRemoteMcpServer(controller: Controller, request: AddRem
 
 		const protoServers = convertMcpServersToProtoMcpServers(servers)
 
-		return { mcpServers: protoServers }
+		return McpServers.create({ mcpServers: protoServers })
 	} catch (error) {
 		console.error(`Failed to add remote MCP server ${request.serverName}:`, error)
 

--- a/src/core/controller/mcp/deleteMcpServer.ts
+++ b/src/core/controller/mcp/deleteMcpServer.ts
@@ -1,5 +1,5 @@
 import type { Controller } from "../index"
-import type { McpServers } from "../../../shared/proto/mcp"
+import { McpServers } from "../../../shared/proto/mcp"
 import { convertMcpServersToProtoMcpServers } from "../../../shared/proto-conversions/mcp/mcp-server-conversion"
 import { StringRequest } from "@/shared/proto/common"
 
@@ -17,7 +17,7 @@ export async function deleteMcpServer(controller: Controller, request: StringReq
 		// Convert application types to protobuf types
 		const protoServers = convertMcpServersToProtoMcpServers(mcpServers)
 
-		return { mcpServers: protoServers }
+		return McpServers.create({ mcpServers: protoServers })
 	} catch (error) {
 		console.error(`Failed to delete MCP server: ${error}`)
 		throw error

--- a/src/core/controller/mcp/refreshMcpMarketplace.ts
+++ b/src/core/controller/mcp/refreshMcpMarketplace.ts
@@ -1,5 +1,5 @@
 import type { EmptyRequest } from "../../../shared/proto/common"
-import type { McpMarketplaceCatalog } from "../../../shared/proto/mcp"
+import { McpMarketplaceCatalog } from "../../../shared/proto/mcp"
 import type { Controller } from "../index"
 
 /**
@@ -19,9 +19,9 @@ export async function refreshMcpMarketplace(controller: Controller, _request: Em
 		}
 
 		// Return empty catalog if nothing was fetched
-		return { items: [] }
+		return McpMarketplaceCatalog.create({ items: [] })
 	} catch (error) {
 		console.error("Failed to refresh MCP marketplace:", error)
-		return { items: [] }
+		return McpMarketplaceCatalog.create({ items: [] })
 	}
 }

--- a/src/core/controller/mcp/restartMcpServer.ts
+++ b/src/core/controller/mcp/restartMcpServer.ts
@@ -1,4 +1,4 @@
-import type { McpServers } from "@shared/proto/mcp"
+import { McpServers } from "@shared/proto/mcp"
 import type { Controller } from "../index"
 import { convertMcpServersToProtoMcpServers } from "@shared/proto-conversions/mcp/mcp-server-conversion"
 import { StringRequest } from "@/shared/proto/common"
@@ -16,7 +16,7 @@ export async function restartMcpServer(controller: Controller, request: StringRe
 		// Convert from McpServer[] to ProtoMcpServer[] ensuring all required fields are set
 		const protoServers = convertMcpServersToProtoMcpServers(mcpServers)
 
-		return { mcpServers: protoServers }
+		return McpServers.create({ mcpServers: protoServers })
 	} catch (error) {
 		console.error(`Failed to restart MCP server ${request.value}:`, error)
 		throw error

--- a/src/core/controller/mcp/toggleMcpServer.ts
+++ b/src/core/controller/mcp/toggleMcpServer.ts
@@ -1,4 +1,5 @@
-import type { ToggleMcpServerRequest, McpServers } from "../../../shared/proto/mcp"
+import type { ToggleMcpServerRequest } from "../../../shared/proto/mcp"
+import { McpServers } from "../../../shared/proto/mcp"
 import type { Controller } from "../index"
 import { convertMcpServersToProtoMcpServers } from "../../../shared/proto-conversions/mcp/mcp-server-conversion"
 
@@ -15,7 +16,7 @@ export async function toggleMcpServer(controller: Controller, request: ToggleMcp
 		// Convert from McpServer[] to ProtoMcpServer[] ensuring all required fields are set
 		const protoServers = convertMcpServersToProtoMcpServers(mcpServers)
 
-		return { mcpServers: protoServers }
+		return McpServers.create({ mcpServers: protoServers })
 	} catch (error) {
 		console.error(`Failed to toggle MCP server ${request.serverName}:`, error)
 		throw error

--- a/src/core/controller/mcp/toggleToolAutoApprove.ts
+++ b/src/core/controller/mcp/toggleToolAutoApprove.ts
@@ -1,4 +1,5 @@
-import type { ToggleToolAutoApproveRequest, McpServers } from "@shared/proto/mcp"
+import type { ToggleToolAutoApproveRequest } from "@shared/proto/mcp"
+import { McpServers } from "@shared/proto/mcp"
 import type { Controller } from "../index"
 import { convertMcpServersToProtoMcpServers } from "@shared/proto-conversions/mcp/mcp-server-conversion"
 
@@ -15,7 +16,7 @@ export async function toggleToolAutoApprove(controller: Controller, request: Tog
 			(await controller.mcpHub?.toggleToolAutoApproveRPC(request.serverName, request.toolNames, request.autoApprove)) || []
 
 		// Convert application types to proto types
-		return { mcpServers: convertMcpServersToProtoMcpServers(mcpServers) }
+		return McpServers.create({ mcpServers: convertMcpServersToProtoMcpServers(mcpServers) })
 	} catch (error) {
 		console.error(`Failed to toggle tool auto-approve for ${request.serverName}:`, error)
 		throw error

--- a/src/core/controller/mcp/updateMcpTimeout.ts
+++ b/src/core/controller/mcp/updateMcpTimeout.ts
@@ -15,7 +15,7 @@ export async function updateMcpTimeout(controller: Controller, request: UpdateMc
 			console.log("mcpServers", mcpServers)
 			const convertedMcpServers = convertMcpServersToProtoMcpServers(mcpServers)
 			console.log("convertedMcpServers", convertedMcpServers)
-			return { mcpServers: convertedMcpServers }
+			return McpServers.create({ mcpServers: convertedMcpServers })
 		} else {
 			console.error("Server name and timeout are required")
 			throw new Error("Server name and timeout are required")

--- a/src/core/controller/models/refreshRequestyModels.ts
+++ b/src/core/controller/models/refreshRequestyModels.ts
@@ -10,10 +10,7 @@ import { getSecret } from "@core/storage/state"
  * @param request Empty request object
  * @returns Response containing the Requesty models
  */
-export async function refreshRequestyModels(
-	controller: Controller,
-	request: EmptyRequest,
-): Promise<OpenRouterCompatibleModelInfo> {
+export async function refreshRequestyModels(controller: Controller, _: EmptyRequest): Promise<OpenRouterCompatibleModelInfo> {
 	const parsePrice = (price: any) => {
 		if (price) {
 			return parseFloat(price) * 1_000_000
@@ -30,7 +27,7 @@ export async function refreshRequestyModels(
 		const response = await axios.get("https://router.requesty.ai/v1/models", { headers })
 		if (response.data?.data) {
 			for (const model of response.data.data) {
-				const modelInfo: OpenRouterModelInfo = {
+				const modelInfo: OpenRouterModelInfo = OpenRouterModelInfo.create({
 					maxTokens: model.max_output_tokens || undefined,
 					contextWindow: model.context_window,
 					supportsImages: model.supports_vision || undefined,
@@ -40,7 +37,7 @@ export async function refreshRequestyModels(
 					cacheWritesPrice: parsePrice(model.caching_price) || 0,
 					cacheReadsPrice: parsePrice(model.cached_price) || 0,
 					description: model.description,
-				}
+				})
 				models[model.id] = modelInfo
 			}
 			console.log("Requesty models fetched", models)

--- a/src/core/controller/state/getLatestState.ts
+++ b/src/core/controller/state/getLatestState.ts
@@ -2,7 +2,6 @@ import * as vscode from "vscode"
 import { Controller } from "../index"
 import { EmptyRequest } from "../../../shared/proto/common"
 import { State } from "../../../shared/proto/state"
-import { ExtensionState } from "../../../shared/ExtensionMessage"
 
 /**
  * Get the latest extension state
@@ -10,7 +9,7 @@ import { ExtensionState } from "../../../shared/ExtensionMessage"
  * @param request The empty request
  * @returns The current extension state
  */
-export async function getLatestState(controller: Controller, request: EmptyRequest): Promise<State> {
+export async function getLatestState(controller: Controller, _: EmptyRequest): Promise<State> {
 	// Get the state using the existing method
 	const state = await controller.getStateToPostToWebview()
 
@@ -18,7 +17,7 @@ export async function getLatestState(controller: Controller, request: EmptyReque
 	const stateJson = JSON.stringify(state)
 
 	// Return the state as a JSON string
-	return {
+	return State.create({
 		stateJson,
-	}
+	})
 }

--- a/src/core/controller/state/updateTerminalConnectionTimeout.ts
+++ b/src/core/controller/state/updateTerminalConnectionTimeout.ts
@@ -15,7 +15,7 @@ export async function updateTerminalConnectionTimeout(controller: Controller, re
 		if (typeof timeout === "number" && !isNaN(timeout) && timeout > 0) {
 			// Update the global state directly
 			await updateGlobalState(controller.context, "shellIntegrationTimeout", timeout)
-			return { value: timeout }
+			return Int64.create({ value: timeout })
 		} else {
 			console.warn(`Invalid shell integration timeout value received: ${timeout}. Expected a positive number.`)
 			throw new Error("Invalid timeout value. Expected a positive number.")

--- a/src/core/controller/task/deleteNonFavoritedTasks.ts
+++ b/src/core/controller/task/deleteNonFavoritedTasks.ts
@@ -47,10 +47,10 @@ export async function deleteNonFavoritedTasks(
 			console.error("Error posting to webview:", webviewErr)
 		}
 
-		return {
+		return DeleteNonFavoritedTasksResults.create({
 			tasksPreserved: favoritedTasks.length,
 			tasksDeleted: deletedCount,
-		}
+		})
 	} catch (error) {
 		console.error("Error in deleteNonFavoritedTasks:", error)
 		throw error

--- a/src/core/controller/task/getTaskHistory.ts
+++ b/src/core/controller/task/getTaskHistory.ts
@@ -106,10 +106,10 @@ export async function getTaskHistory(controller: Controller, request: GetTaskHis
 			cacheReads: item.cacheReads || 0,
 		}))
 
-		return {
+		return TaskHistoryArray.create({
 			tasks,
 			totalCount,
-		}
+		})
 	} catch (error) {
 		console.error("Error in getTaskHistory:", error)
 		throw error

--- a/src/core/controller/task/showTaskWithId.ts
+++ b/src/core/controller/task/showTaskWithId.ts
@@ -28,7 +28,7 @@ export async function showTaskWithId(controller: Controller, request: StringRequ
 			})
 
 			// Return task data for gRPC response
-			return {
+			return TaskResponse.create({
 				id: historyItem.id,
 				task: historyItem.task || "",
 				ts: historyItem.ts || 0,
@@ -39,7 +39,7 @@ export async function showTaskWithId(controller: Controller, request: StringRequ
 				tokensOut: historyItem.tokensOut || 0,
 				cacheWrites: historyItem.cacheWrites || 0,
 				cacheReads: historyItem.cacheReads || 0,
-			}
+			})
 		}
 
 		// If not in global state, fetch from storage
@@ -54,7 +54,7 @@ export async function showTaskWithId(controller: Controller, request: StringRequ
 			action: "chatButtonClicked",
 		})
 
-		return {
+		return TaskResponse.create({
 			id: fetchedItem.id,
 			task: fetchedItem.task || "",
 			ts: fetchedItem.ts || 0,
@@ -65,7 +65,7 @@ export async function showTaskWithId(controller: Controller, request: StringRequ
 			tokensOut: fetchedItem.tokensOut || 0,
 			cacheWrites: fetchedItem.cacheWrites || 0,
 			cacheReads: fetchedItem.cacheReads || 0,
-		}
+		})
 	} catch (error) {
 		console.error("Error in showTaskWithId:", error)
 		throw error

--- a/src/core/controller/task/toggleTaskFavorite.ts
+++ b/src/core/controller/task/toggleTaskFavorite.ts
@@ -6,7 +6,7 @@ export async function toggleTaskFavorite(controller: Controller, request: TaskFa
 	if (!request.taskId || request.isFavorited === undefined) {
 		const errorMsg = `[toggleTaskFavorite] Invalid request: taskId or isFavorited missing`
 		console.error(errorMsg)
-		return {}
+		return Empty.create({})
 	}
 
 	try {
@@ -47,5 +47,5 @@ export async function toggleTaskFavorite(controller: Controller, request: TaskFa
 		console.error("Error in toggleTaskFavorite:", error)
 	}
 
-	return {}
+	return Empty.create({})
 }

--- a/src/core/controller/ui/onDidShowAnnouncement.ts
+++ b/src/core/controller/ui/onDidShowAnnouncement.ts
@@ -1,4 +1,5 @@
-import type { EmptyRequest, Boolean } from "../../../shared/proto/common"
+import type { EmptyRequest } from "../../../shared/proto/common"
+import { Boolean } from "../../../shared/proto/common"
 import type { Controller } from "../index"
 import { getGlobalState, updateGlobalState } from "../../storage/state"
 
@@ -21,9 +22,9 @@ export async function onDidShowAnnouncement(controller: Controller, _request: Em
 		// This replicates the same logic used in getStateToPostToWebview()
 		const shouldShowAnnouncement = lastShownAnnouncementId !== controller.latestAnnouncementId
 
-		return { value: shouldShowAnnouncement }
+		return Boolean.create({ value: shouldShowAnnouncement })
 	} catch (error) {
 		console.error("Failed to acknowledge announcement:", error)
-		return { value: false }
+		return Boolean.create({ value: false })
 	}
 }

--- a/src/core/controller/web/checkIsImageUrl.ts
+++ b/src/core/controller/web/checkIsImageUrl.ts
@@ -9,21 +9,21 @@ import { detectImageUrl } from "@integrations/misc/link-preview"
  * @param request The request containing the URL to check
  * @returns A result indicating if the URL is an image and the URL that was checked
  */
-export async function checkIsImageUrl(controller: Controller, request: StringRequest): Promise<IsImageUrl> {
+export async function checkIsImageUrl(_: Controller, request: StringRequest): Promise<IsImageUrl> {
 	try {
 		const url = request.value || ""
 		// Check if the URL is an image
 		const isImage = await detectImageUrl(url)
 
-		return {
+		return IsImageUrl.create({
 			isImage,
 			url,
-		}
+		})
 	} catch (error) {
 		console.error(`Error checking if URL is an image: ${request.value}`, error)
-		return {
+		return IsImageUrl.create({
 			isImage: false,
 			url: request.value || "",
-		}
+		})
 	}
 }

--- a/src/shared/proto-conversions/state/chat-settings-conversion.ts
+++ b/src/shared/proto-conversions/state/chat-settings-conversion.ts
@@ -6,11 +6,11 @@ import { ChatContent as ProtoChatContent, ChatSettings as ProtoChatSettings, Pla
  * Converts domain ChatSettings objects to proto ChatSettings objects
  */
 export function convertChatSettingsToProtoChatSettings(chatSettings: ChatSettings): ProtoChatSettings {
-	return {
+	return ProtoChatSettings.create({
 		mode: chatSettings.mode === "plan" ? PlanActMode.PLAN : PlanActMode.ACT,
 		preferredLanguage: chatSettings.preferredLanguage,
 		openAiReasoningEffort: chatSettings.openAIReasoningEffort,
-	}
+	})
 }
 
 /**


### PR DESCRIPTION
Create protobuf objects with .create()

### Test Procedure

`npm run test`
Tested manually in the vscode extension host.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

NA

### Additional Notes

NA

<!-- For UI changes, add screenshots here -->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix warnings by using `.create()` for protobuf object instantiation across multiple files.
> 
>   - **Behavior**:
>     - Replace direct object creation with `.create()` method for protobuf objects in functions like `accountLoginClicked`, `accountLogoutClicked`, `discoverBrowser`, `getBrowserConnectionInfo`, `getDetectedChromePath`, `relaunchChromeDebugMode`, `testBrowserConnection`, `updateBrowserSettings`, `checkpointRestore`, `refreshRules`, `toggleClineRule`, `toggleCursorRule`, `toggleWindsurfRule`, `addRemoteMcpServer`, `deleteMcpServer`, `refreshMcpMarketplace`, `restartMcpServer`, `toggleMcpServer`, `toggleToolAutoApprove`, `updateMcpTimeout`, `refreshRequestyModels`, `getLatestState`, `updateTerminalConnectionTimeout`, `deleteNonFavoritedTasks`, `getTaskHistory`, `showTaskWithId`, `toggleTaskFavorite`, `onDidShowAnnouncement`, `checkIsImageUrl`, and `convertChatSettingsToProtoChatSettings`.
>   - **Imports**:
>     - Change import statements to import non-type protobuf objects directly in `accountLogoutClicked.ts`, `toggleClineRule.ts`, `toggleCursorRule.ts`, `toggleWindsurfRule.ts`, `addRemoteMcpServer.ts`, `deleteMcpServer.ts`, `refreshMcpMarketplace.ts`, `restartMcpServer.ts`, `toggleMcpServer.ts`, `toggleToolAutoApprove.ts`, `updateMcpTimeout.ts`, `onDidShowAnnouncement.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 7ab2a99911b63c173d33dd6b0dfe04ae71268618. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->