### PR TITLE
fixing ripgrep overload - tool should not return more than 0.25mb max…

### DIFF
--- a/.changeset/healthy-ties-kneel.md
+++ b/.changeset/healthy-ties-kneel.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Fixed search tool overloading conversation with massive outputs by setting a maximum overall byte limit for search tool responses


### PR DESCRIPTION
…, but it can easily return more than 9mb in some cases

<img width="460" alt="Screenshot 2025-05-31 at 4 48 53 PM" src="https://github.com/user-attachments/assets/75dc8813-8703-4626-b46f-591cdca77b7a" />

previously, you could get a grep result that was massive, and it would brick your task (retry button shown, doesn't do anything because the api conversation history is so massive)

Now:

<img width="467" alt="Screenshot 2025-05-31 at 4 48 30 PM" src="https://github.com/user-attachments/assets/690e8cfd-22a4-4d20-8995-044a4f3c60d3" />


I set the limit arbitrarily to 0.25mb as that seems reasonable for a simple search tool. 

<!-- Describe your changes in detail. What problem does this PR solve? -->

### Test Procedure

<!-- How did you test this? Are you confident that it will not introduce bugs? If so, why? -->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Limits ripgrep output to 0.25MB in `index.ts` to prevent overloads, adding a truncation message if exceeded.
> 
>   - **Behavior**:
>     - Limits ripgrep output to 0.25MB in `formatResults()` in `index.ts` to prevent system overloads.
>     - Adds truncation message if output exceeds limit, suggesting more specific search patterns.
>   - **Constants**:
>     - Introduces `MAX_RIPGREP_MB` and `MAX_BYTE_SIZE` to define the output size limit.
>   - **Logic**:
>     - Checks byte size before adding file paths and lines to output in `formatResults()`.
>     - Stops processing when byte limit is reached, ensuring output remains within bounds.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 9829ef938b923cf01762776752ba0f9684ad8ee1. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->