### PR TITLE
refactor: LM Studio improvements

### DIFF
--- a/.changeset/beige-dingos-heal.md
+++ b/.changeset/beige-dingos-heal.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Remove hard-coded temperature from LM Studio API requests and add support for `reasoning_content` in LM Studio API responses.

--- a/src/api/providers/lmstudio.ts
+++ b/src/api/providers/lmstudio.ts
@@ -27,7 +27,6 @@ export class LmStudioHandler implements ApiHandler {
 			const stream = await this.client.chat.completions.create({
 				model: this.getModel().id,
 				messages: openAiMessages,
-				temperature: 0,
 				stream: true,
 			})
 			for await (const chunk of stream) {
@@ -36,6 +35,12 @@ export class LmStudioHandler implements ApiHandler {
 					yield {
 						type: "text",
 						text: delta.content,
+					}
+				}
+				if (delta && "reasoning_content" in delta && delta.reasoning_content) {
+					yield {
+						type: "reasoning",
+						reasoning: (delta.reasoning_content as string | undefined) || "",
 					}
 				}
 			}


### PR DESCRIPTION
### Description

Remove hard-coded temperature from LM Studio API requests and add support for `reasoning_content` in LM Studio API responses.

### Test Procedure

Manually started a chat with a local LM Studio server instance.

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [x] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Additional Notes

A hard-coded temperature is unnecessary when running a local LM Studio instance with full control over sampler settings. In addition, greedy decoding is highly detrimental to models of the size most users will be running locally, especially those capable of reasoning.

This change also provides support for reasoning models that output `<think></think>` tags as long as `reasoning_content` in API responses is enabled via the option in the LM Studio developer settings.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Refactor `LmStudioHandler` to remove hard-coded temperature and support `reasoning_content` in API responses.
> 
>   - **Behavior**:
>     - Remove hard-coded `temperature` parameter from LM Studio API requests in `LmStudioHandler` class in `lmstudio.ts`.
>     - Add support for `reasoning_content` in LM Studio API responses, yielding reasoning data if present.
>   - **Misc**:
>     - Update changeset to reflect removal of hard-coded temperature and addition of `reasoning_content` support.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 8cb736c706716a6ceaa2af7b6451ae622180ddb6. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->