### PR TITLE
Add globalState to the standalone vscode extension context replacement.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -70,6 +70,7 @@
 				"tree-sitter-wasms": "^0.1.11",
 				"ts-morph": "^25.0.1",
 				"turndown": "^7.2.0",
+				"vscode-uri": "^3.1.0",
 				"web-tree-sitter": "^0.22.6",
 				"zod": "^3.24.2"
 			},
@@ -26065,6 +26066,12 @@
 				"url": "https://opencollective.com/unified"
 			}
 		},
+		"node_modules/vscode-uri": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
+			"integrity": "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==",
+			"license": "MIT"
+		},
 		"node_modules/wcwidth": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
@@ -45583,6 +45590,11 @@
 				"@types/unist": "^3.0.0",
 				"unist-util-stringify-position": "^4.0.0"
 			}
+		},
+		"vscode-uri": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
+			"integrity": "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ=="
 		},
 		"wcwidth": {
 			"version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -401,6 +401,7 @@
 		"tree-sitter-wasms": "^0.1.11",
 		"ts-morph": "^25.0.1",
 		"turndown": "^7.2.0",
+		"vscode-uri": "^3.1.0",
 		"web-tree-sitter": "^0.22.6",
 		"zod": "^3.24.2"
 	}

--- a/scripts/package-standalone.mjs
+++ b/scripts/package-standalone.mjs
@@ -39,7 +39,7 @@ const output = fs.createWriteStream(zipPath)
 const archive = archiver("zip", { zlib: { level: 9 } })
 
 output.on("close", () => {
-	console.log(`Created ${zipPath} (${archive.pointer()} bytes)`)
+	console.log(`Created ${zipPath} (${(archive.pointer() / 1024 / 1024).toFixed(1)} MB)`)
 })
 
 archive.on("error", (err) => {

--- a/src/standalone/vscode-context-stubs.ts
+++ b/src/standalone/vscode-context-stubs.ts
@@ -3,140 +3,9 @@ import * as vscode from "vscode"
 
 import { log } from "./utils"
 
-function stubUri(path: string): vscode.Uri {
-	console.log(`Using file path: ${path}`)
-	return {
-		fsPath: path,
-		scheme: "",
-		authority: "",
-		path: "",
-		query: "",
-		fragment: "",
-		with: function (change: {
-			scheme?: string
-			authority?: string
-			path?: string
-			query?: string
-			fragment?: string
-		}): vscode.Uri {
-			return stubUri(path)
-		},
-		toString: function (skipEncoding?: boolean): string {
-			return path
-		},
-		toJSON: function () {
-			return {}
-		},
-	}
-}
-
-function createMemento(): vscode.Memento {
-	const store = {}
-	return {
-		keys: function (): readonly string[] {
-			return Object.keys(store)
-		},
-		get: function <T>(key: string): T | undefined {
-			return key in store ? store[key] : undefined
-		},
-		update: function (key: string, value: any): Thenable<void> {
-			store[key] = value
-			return Promise.resolve()
-		},
-	}
-}
-
-const extensionContext: vscode.ExtensionContext = {
-	extensionPath: "/tmp/vscode/extension",
-	extensionUri: stubUri("/tmp/vscode/extension"),
-
-	globalStoragePath: "/tmp/vscode/global",
-	globalStorageUri: stubUri("/tmp/vscode/global"),
-
-	storagePath: "/tmp/vscode/storage",
-	storageUri: stubUri("/tmp/vscode/storage"),
-
-	logPath: "/tmp/vscode/log",
-	logUri: stubUri("/tmp/vscode/log"),
-
-	workspaceState: createMemento(),
-
-	environmentVariableCollection: {
-		getScoped: function (scope: vscode.EnvironmentVariableScope): vscode.EnvironmentVariableCollection {
-			return {
-				persistent: false,
-				description: undefined,
-				replace: function (variable: string, value: string, options?: vscode.EnvironmentVariableMutatorOptions): void {},
-				append: function (variable: string, value: string, options?: vscode.EnvironmentVariableMutatorOptions): void {},
-				prepend: function (variable: string, value: string, options?: vscode.EnvironmentVariableMutatorOptions): void {},
-				get: function (variable: string): vscode.EnvironmentVariableMutator | undefined {
-					return undefined
-				},
-				forEach: function (
-					callback: (
-						variable: string,
-						mutator: vscode.EnvironmentVariableMutator,
-						collection: vscode.EnvironmentVariableCollection,
-					) => any,
-					thisArg?: any,
-				): void {},
-				delete: function (variable: string): void {},
-				clear: function (): void {},
-				[Symbol.iterator]: function (): Iterator<
-					[variable: string, mutator: vscode.EnvironmentVariableMutator],
-					any,
-					any
-				> {
-					throw new Error("environmentVariableCollection.getScoped.Iterator not implemented")
-				},
-			}
-		},
-		persistent: false,
-		description: undefined,
-		replace: function (variable: string, value: string, options?: vscode.EnvironmentVariableMutatorOptions): void {},
-		append: function (variable: string, value: string, options?: vscode.EnvironmentVariableMutatorOptions): void {},
-		prepend: function (variable: string, value: string, options?: vscode.EnvironmentVariableMutatorOptions): void {},
-		get: function (variable: string): vscode.EnvironmentVariableMutator | undefined {
-			return undefined
-		},
-		forEach: function (
-			callback: (
-				variable: string,
-				mutator: vscode.EnvironmentVariableMutator,
-				collection: vscode.EnvironmentVariableCollection,
-			) => any,
-			thisArg?: any,
-		): void {
-			throw new Error("environmentVariableCollection.forEach not implemented")
-		},
-		delete: function (variable: string): void {},
-		clear: function (): void {},
-		[Symbol.iterator]: function (): Iterator<[variable: string, mutator: vscode.EnvironmentVariableMutator], any, any> {
-			throw new Error("environmentVariableCollection.Iterator not implemented")
-		},
-	},
-
-	extensionMode: 1, // Development
-
-	extension: {
-		id: "saoudrizwan.claude-dev",
-		isActive: true,
-		extensionPath: "/tmp/vscode/extension",
-		extensionUri: stubUri("/tmp/vscode/extension"),
-		packageJSON: {},
-		exports: {},
-		activate: async () => {},
-		extensionKind: vscode.ExtensionKind.UI,
-	},
-
-	subscriptions: [],
-
-	asAbsolutePath: (relPath) => `/tmp/vscode/extension/${relPath}`,
-}
-
 const outputChannel: vscode.OutputChannel = {
 	append: (text) => process.stdout.write(text),
-	appendLine: (line) => console.log(line),
+	appendLine: (line) => console.log(`OUTPUT_CHANNEL: ${line}`),
 	clear: () => {},
 	show: () => {},
 	hide: () => {},
@@ -150,4 +19,4 @@ function postMessage(message: ExtensionMessage): Promise<boolean> {
 	return Promise.resolve(true)
 }
 
-export { extensionContext, outputChannel, postMessage }
+export { outputChannel, postMessage }

--- a/src/standalone/vscode-context-utils.ts
+++ b/src/standalone/vscode-context-utils.ts
@@ -1,18 +1,53 @@
-import * as vscode from "vscode"
-import * as path from "path"
 import * as fs from "fs"
+import * as vscode from "vscode"
+import type { EnvironmentVariableMutatorOptions, EnvironmentVariableMutator, EnvironmentVariableScope } from "vscode"
+export class SecretStore implements vscode.SecretStorage {
+	private data: JsonKeyValueStore<string>
+	private readonly _onDidChange = new EventEmitter<vscode.SecretStorageChangeEvent>()
 
-// This is need to set properties on the extension context, because they are read-only in the vscode API.
-export function setContextProperty<K extends keyof vscode.ExtensionContext>(
-	context: any,
-	propertyName: K,
-	value: vscode.ExtensionContext[K],
-) {
-	Object.defineProperty(context, propertyName, {
-		value,
-		writable: true,
-		configurable: true,
-	})
+	constructor(filepath: string) {
+		this.data = new JsonKeyValueStore(filepath)
+	}
+
+	readonly onDidChange: vscode.Event<vscode.SecretStorageChangeEvent> = this._onDidChange.event
+
+	get(key: string): Thenable<string | undefined> {
+		return Promise.resolve(this.data.get(key))
+	}
+
+	store(key: string, value: string): Thenable<void> {
+		this.data.put(key, value)
+		this._onDidChange.fire({ key })
+		return Promise.resolve()
+	}
+
+	delete(key: string): Thenable<void> {
+		this.data.delete(key)
+		this._onDidChange.fire({ key })
+		return Promise.resolve()
+	}
+}
+
+// Create a class that implements Memento interface with the required setKeysForSync method
+export class MementoStore implements vscode.Memento {
+	private data: JsonKeyValueStore<any>
+
+	constructor(filepath: string) {
+		this.data = new JsonKeyValueStore(filepath)
+	}
+	keys(): readonly string[] {
+		return Array.from(this.data.keys())
+	}
+	get<T>(key: string): T | undefined {
+		return this.data.get(key) as T
+	}
+	update(key: string, value: any): Thenable<void> {
+		this.data.put(key, value)
+		return Promise.resolve()
+	}
+	setKeysForSync(_keys: readonly string[]): void {
+		throw new Error("Method not implemented.")
+	}
 }
 
 // Simple implementation of VSCode's EventEmitter
@@ -37,13 +72,13 @@ export class EventEmitter<T> {
 	}
 }
 
+/** A simple key-value store for secrets backed by a JSON file. This is not secure, and it is not thread-safe. */
 export class JsonKeyValueStore<T> {
-	// A simple key-value store for secrets backed by a JSON file. This is not secure, and it is not thread-safe.
 	private data = new Map<string, T>()
 	private filePath: string
 
-	constructor(dir: string, fileName: string) {
-		this.filePath = path.join(dir, fileName)
+	constructor(filePath: string) {
+		this.filePath = filePath
 		this.load()
 	}
 
@@ -74,4 +109,44 @@ export class JsonKeyValueStore<T> {
 	private save(): void {
 		fs.writeFileSync(this.filePath, JSON.stringify(Object.fromEntries(this.data), null, 2))
 	}
+}
+
+/** This is not used in cline, none of the methods are implemented. */
+export class EnvironmentVariableCollection implements EnvironmentVariableCollection {
+	persistent: boolean = false
+	description: string | undefined = undefined
+	replace(_variable: string, _value: string, _options?: EnvironmentVariableMutatorOptions): void {
+		throw new Error("Method not implemented.")
+	}
+	append(_variable: string, _value: string, _options?: EnvironmentVariableMutatorOptions): void {
+		throw new Error("Method not implemented.")
+	}
+	prepend(_variable: string, _value: string, _options?: EnvironmentVariableMutatorOptions): void {
+		throw new Error("Method not implemented.")
+	}
+	get(_variable: string): EnvironmentVariableMutator | undefined {
+		throw new Error("Method not implemented.")
+	}
+	forEach(
+		_callback: (variable: string, mutator: EnvironmentVariableMutator, collection: EnvironmentVariableCollection) => any,
+		_thisArg?: any,
+	): void {
+		throw new Error("Method not implemented.")
+	}
+	delete(_variable: string): void {
+		throw new Error("Method not implemented.")
+	}
+	clear(): void {
+		throw new Error("Method not implemented.")
+	}
+	[Symbol.iterator](): Iterator<[variable: string, mutator: EnvironmentVariableMutator], any, any> {
+		throw new Error("Method not implemented.")
+	}
+	getScoped(_scope: EnvironmentVariableScope): EnvironmentVariableCollection {
+		throw new Error("Method not implemented.")
+	}
+}
+
+export function readJson(filePath: string): any {
+	return JSON.parse(fs.readFileSync(filePath, "utf8"))
 }

--- a/standalone/runtime-files/package-lock.json
+++ b/standalone/runtime-files/package-lock.json
@@ -12,7 +12,7 @@
 				"@grpc/reflection": "^1.0.4",
 				"grpc-health-check": "^2.0.2",
 				"open": "^10.1.2",
-				"vscode": "file:./vscode"
+				"vscode-uri": "^3.1.0"
 			}
 		},
 		"node_modules/@grpc/grpc-js": {
@@ -450,9 +450,11 @@
 			"integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
 			"license": "MIT"
 		},
-		"node_modules/vscode": {
-			"resolved": "vscode",
-			"link": true
+		"node_modules/vscode-uri": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
+			"integrity": "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==",
+			"license": "MIT"
 		},
 		"node_modules/wrap-ansi": {
 			"version": "7.0.0",
@@ -508,7 +510,8 @@
 			}
 		},
 		"vscode": {
-			"version": "1.0.0"
+			"version": "1.0.0",
+			"extraneous": true
 		}
 	}
 }

--- a/standalone/runtime-files/package.json
+++ b/standalone/runtime-files/package.json
@@ -6,6 +6,7 @@
 		"@grpc/grpc-js": "^1.13.3",
 		"@grpc/reflection": "^1.0.4",
 		"grpc-health-check": "^2.0.2",
-		"open": "^10.1.2"
+		"open": "^10.1.2",
+		"vscode-uri": "^3.1.0"
 	}
 }


### PR DESCRIPTION
Add a generic key-value store that can be used by different storages, and move this into vscode-context-utils file. 

Move the stubs/mocks of the extension context into a separate stubs file, (they have type checking turned off). 

Keep the actual implementations in vscode-context and turn on typechecking for this file.

### Test Procedure

Manually tested in the standalone cline app.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

NA

### Additional Notes

NA

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds `JsonKeyValueStore` for key-value storage, refactors context handling, and separates stubs with type checking adjustments.
> 
>   - **Behavior**:
>     - Introduces `JsonKeyValueStore` in `vscode-context-utils.ts` for key-value storage.
>     - Updates `SecretStore` and `MementoStore` in `vscode-context.ts` to use `JsonKeyValueStore`.
>     - Uses `setContextProperty` to set `globalState` and `secrets` on `extensionContext`.
>   - **Refactoring**:
>     - Moves stubs/mocks to `vscode-context-stubs.ts` with type checking off.
>     - Enables type checking in `vscode-context.ts`.
>   - **Misc**:
>     - Adds `EventEmitter` class in `vscode-context-utils.ts` for event handling.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for e21cc7be19d72a9e5e5642d6ebf6ccffc416a119. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->