### PR TITLE
docs/typo: remove extra bullet point on `installing-cline.mdx`

### DIFF
--- a/docs/getting-started/installing-cline.mdx
+++ b/docs/getting-started/installing-cline.mdx
@@ -60,7 +60,6 @@ Now that you have Cline installed, let's get you set up with your account:
     - DeepSeek Chat (cost-effective alternative)
     - Google Gemini 2.0 Flash
     - And more — all through your Cline account.
-4.  -
 
 ### 💻 Your First Interaction with Cline
 


### PR DESCRIPTION
### Description

Thanks for making this awesome project! I noticed there's an extra bullet point in the docs at https://docs.cline.bot/getting-started/installing-cline. See this screenshot from the current docs:

<img width="609" alt="Screenshot 2025-06-02 at 2 40 13 PM" src="https://github.com/user-attachments/assets/36649ed1-16f7-44d1-8987-bab54235bf9d" />

This PR removes this extra/hanging 🚀 

### Test Procedure

This should not break anything, just a teeny docs typo fix.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [X] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [X] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [X] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [X] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots



### Additional Notes


