### PR TITLE
Fix: Telemetry

### DIFF
--- a/.changeset/wicked-suns-cry.md
+++ b/.changeset/wicked-suns-cry.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Telemetry fix

--- a/src/core/controller/index.ts
+++ b/src/core/controller/index.ts
@@ -261,6 +261,13 @@ export class Controller {
 						}
 					}
 				})
+
+				// Initialize telemetry service with user's current setting
+				this.getStateToPostToWebview().then((state) => {
+					const { telemetrySetting } = state
+					const isOptedIn = telemetrySetting !== "disabled"
+					telemetryService.updateTelemetryState(isOptedIn)
+				})
 				break
 			case "newTask":
 				// Code that should run in response to the hello message command


### PR DESCRIPTION
### Description

Reverts a change in #3765 that caused telemetry to be broken for all users. That PR removed the telemetry initialization code from webview launch, noting that it "uses the user's saved preference." However, there's no mechanism that automatically reads the user's preference - the service starts with telemetryEnabled = false and never gets updated, so all telemetry events are silently dropped for users who explicitly opted in. This fix restores the only code that reads the stored telemetry setting and properly configures the service, ensuring telemetry works while preserving privacy for those who have disabled telemetry.

- `TelemetryService` starts with `private telemetryEnabled: boolean = false`
- The only way to set `telemetryEnabled = true` is through `updateTelemetryState(didUserOptIn: boolean)`
- `updateTelemetryState()` is called in two places:
  - `updateTelemetrySetting()` - when user changes setting in UI
  - `webviewDidLaunch` - the code that was removed in #3765, which enables telemetry on startup if the user is opted in.

### Test Procedure

Start Cline, enable telemetry. Close and reopen Cline, and confirm telemetry events are received.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [X]  🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [X] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [X] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [X] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [X] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Restores telemetry initialization in `index.ts` to ensure events are processed for opted-in users.
> 
>   - **Behavior**:
>     - Restores telemetry initialization in `handleWebviewMessage()` in `index.ts` to respect user preferences.
>     - Ensures telemetry events are processed for users who opted in.
>   - **Misc**:
>     - Adds a changeset file `wicked-suns-cry.md` for the telemetry fix.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 64fe263dfdf92097cb68fb85020629a793efbef6. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->