### PR TITLE
Make the protobuf object literal lint check an error instead of a warning

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -20,7 +20,7 @@
 		"no-throw-literal": "warn",
 		"semi": "off",
 		"react-hooks/exhaustive-deps": "off",
-		"eslint-rules/no-protobuf-object-literals": "warn",
+		"eslint-rules/no-protobuf-object-literals": "error",
 		"eslint-rules/no-grpc-client-object-literals": "error"
 	},
 	"ignorePatterns": ["out", "dist", "**/*.d.ts"]

--- a/src/core/controller/ui/subscribeToChatButtonClicked.ts
+++ b/src/core/controller/ui/subscribeToChatButtonClicked.ts
@@ -15,7 +15,7 @@ const activeChatButtonClickedSubscriptions = new Map<string, StreamingResponseHa
  */
 export async function subscribeToChatButtonClicked(
 	controller: Controller,
-	request: EmptyRequest,
+	_request: EmptyRequest,
 	responseStream: StreamingResponseHandler,
 	requestId?: string,
 ): Promise<void> {
@@ -50,7 +50,7 @@ export async function sendChatButtonClickedEvent(controllerId: string): Promise<
 	}
 
 	try {
-		const event: Empty = {}
+		const event: Empty = Empty.create({})
 		await responseStream(
 			event,
 			false, // Not the last message

--- a/src/core/controller/ui/subscribeToHistoryButtonClicked.ts
+++ b/src/core/controller/ui/subscribeToHistoryButtonClicked.ts
@@ -14,7 +14,7 @@ const activeHistoryButtonClickedSubscriptions = new Map<StreamingResponseHandler
  * @param requestId The ID of the request (passed by the gRPC handler)
  */
 export async function subscribeToHistoryButtonClicked(
-	controller: Controller,
+	_controller: Controller,
 	request: WebviewProviderTypeRequest,
 	responseStream: StreamingResponseHandler,
 	requestId?: string,
@@ -50,7 +50,7 @@ export async function sendHistoryButtonClickedEvent(webviewType?: WebviewProvide
 		}
 
 		try {
-			const event: Empty = {}
+			const event: Empty = Empty.create({})
 			await responseStream(
 				event,
 				false, // Not the last message

--- a/src/core/controller/ui/subscribeToMcpButtonClicked.ts
+++ b/src/core/controller/ui/subscribeToMcpButtonClicked.ts
@@ -14,7 +14,7 @@ const mcpButtonClickedSubscriptions = new Map<StreamingResponseHandler, WebviewP
  * @param requestId The ID of the request (passed by the gRPC handler)
  */
 export async function subscribeToMcpButtonClicked(
-	controller: Controller,
+	_controller: Controller,
 	request: WebviewProviderTypeRequest,
 	responseStream: StreamingResponseHandler,
 	requestId?: string,
@@ -41,7 +41,7 @@ export async function subscribeToMcpButtonClicked(
  * @param webviewType The type of webview that triggered the event (SIDEBAR or TAB)
  */
 export async function sendMcpButtonClickedEvent(webviewType?: WebviewProviderType): Promise<void> {
-	const event: Empty = {}
+	const event: Empty = Empty.create({})
 
 	// Process all subscriptions, filtering based on the source
 	const promises = Array.from(mcpButtonClickedSubscriptions.entries()).map(async ([responseStream, providerType]) => {


### PR DESCRIPTION
Make the protobuf object literal lint check an error instead of a warning.

Fix remaining occurrences of protobuf literals.

### Test Procedure

`npm run compile`

Unit tests are already failing.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

NA

### Additional Notes

NA

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Change protobuf object literal lint rule to error and fix occurrences in three files.
> 
>   - **Lint Rule Change**:
>     - Change `eslint-rules/no-protobuf-object-literals` from "warn" to "error" in `.eslintrc.json`.
>   - **Code Fixes**:
>     - Replace protobuf object literals `{}` with `Empty.create({})` in `subscribeToChatButtonClicked.ts`, `subscribeToHistoryButtonClicked.ts`, and `subscribeToMcpButtonClicked.ts`.
>   - **Misc**:
>     - Prefix unused parameters with `_` in `subscribeToChatButtonClicked()` and `subscribeToMcpButtonClicked()` functions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 4eab77aba8abf6f960afcf352ea8a2728ff2bf30. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->