### PR TITLE
Add a postMessage handler for standalone cline app

### DIFF
--- a/src/core/controller/ui/subscribeToAccountButtonClicked.ts
+++ b/src/core/controller/ui/subscribeToAccountButtonClicked.ts
@@ -14,7 +14,7 @@ const activeSubscriptions = new Map<string, StreamingResponseHandler>()
  */
 export async function subscribeToAccountButtonClicked(
 	controller: Controller,
-	request: EmptyRequest,
+	_request: EmptyRequest,
 	responseStream: StreamingResponseHandler,
 	requestId?: string,
 ): Promise<void> {
@@ -46,7 +46,7 @@ export async function sendAccountButtonClickedEvent(controllerId: string): Promi
 	}
 
 	try {
-		const event: Empty = {}
+		const event: Empty = Empty.create({})
 		await responseStream(event, false)
 	} catch (error) {
 		console.error(`Error sending account button clicked event to controller ${controllerId}:`, error)

--- a/webview-ui/src/utils/vscode.ts
+++ b/webview-ui/src/utils/vscode.ts
@@ -41,11 +41,11 @@ class VSCodeAPIWrapper {
 			this.vsCodeApi.postMessage(message)
 		} else if (window.__is_standalone__) {
 			if (!window.standalonePostMessage) {
-				console.warn("Standalone event handler not found.")
+				console.warn("Standalone postMessage not found.")
 				return
 			}
 			const json = JSON.stringify(message)
-			console.log("Standalone event handler: " + json.slice(0, 200))
+			console.log("Standalone postMessage: " + json.slice(0, 200))
 			window.standalonePostMessage(json)
 		} else {
 			console.log("postMessage fallback: ", message)

--- a/webview-ui/src/utils/vscode.ts
+++ b/webview-ui/src/utils/vscode.ts
@@ -1,6 +1,5 @@
 import { WebviewMessage } from "@shared/WebviewMessage"
 import type { WebviewApi } from "vscode-webview"
-const { IS_DEV } = process.env
 
 /**
  * A utility wrapper around the acquireVsCodeApi() function, which enables
@@ -14,7 +13,7 @@ const { IS_DEV } = process.env
 declare global {
 	interface Window {
 		__is_standalone__?: boolean
-		standaloneEventHandler?: (event: any) => void
+		standalonePostMessage?: (event: any) => void
 	}
 }
 
@@ -41,13 +40,13 @@ class VSCodeAPIWrapper {
 		if (this.vsCodeApi) {
 			this.vsCodeApi.postMessage(message)
 		} else if (window.__is_standalone__) {
-			if (!window.standaloneEventHandler) {
+			if (!window.standalonePostMessage) {
 				console.warn("Standalone event handler not found.")
 				return
 			}
 			const json = JSON.stringify(message)
 			console.log("Standalone event handler: " + json.slice(0, 200))
-			window.standaloneEventHandler(json)
+			window.standalonePostMessage(json)
 		} else {
 			console.log("postMessage fallback: ", message)
 		}


### PR DESCRIPTION
In the webview-ui, If there is no vscode api defined, try to use the standalone postMessage handler.

Fix eslint error.

### Test Procedure

`npm run test` - the unit tests are already broken.

Tested manually in the vscode extension host.
Tested in the standalone app.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

NA

### Additional Notes

NA

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add standalone postMessage handler in `VSCodeAPIWrapper` and fix minor issues in `subscribeToAccountButtonClicked.ts`.
> 
>   - **Behavior**:
>     - In `VSCodeAPIWrapper` in `vscode.ts`, added a standalone postMessage handler for environments without VSCode API.
>     - Logs a warning if `standalonePostMessage` is not found.
>     - Uses `Empty.create({})` in `sendAccountButtonClickedEvent` in `subscribeToAccountButtonClicked.ts`.
>   - **Misc**:
>     - Fix eslint error by prefixing unused parameter with `_` in `subscribeToAccountButtonClicked.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for e2fd4409c63625820dd856693ef4510a2d0d01cb. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->