### PR TITLE
Add better stubs for the workspace.

### DIFF
--- a/src/standalone/standalone.ts
+++ b/src/standalone/standalone.ts
@@ -32,12 +32,11 @@ function main() {
 	const host = "127.0.0.1:50051"
 	server.bindAsync(host, grpc.ServerCredentials.createInsecure(), (err) => {
 		if (err) {
-			log(`Error: Failed to bind to ${host}, port may be unavailable ${err.message}`)
+			log(`Error: Failed to bind to ${host}, port may be unavailable. ${err.message}`)
 			process.exit(1)
-		} else {
-			server.start()
-			log(`gRPC server listening on ${host}`)
 		}
+		server.start()
+		log(`gRPC server listening on ${host}`)
 	})
 }
 

--- a/standalone/runtime-files/package.json
+++ b/standalone/runtime-files/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "Cline standalone",
+	"name": "cline-standalone",
 	"version": "1.0.0",
 	"main": "standalone.js",
 	"dependencies": {

--- a/standalone/runtime-files/vscode/vscode-stubs.js
+++ b/standalone/runtime-files/vscode/vscode-stubs.js
@@ -816,7 +816,7 @@ vscode.TextDocumentSaveReason = { Manual: 0, AfterDelay: 0, FocusOut: 0 }
 vscode.workspace = {}
 vscode.workspace.fs = createStub("vscode.workspace.fs")
 vscode.workspace.rootPath = createStub("vscode.workspace.rootPath")
-vscode.workspace.workspaceFolders = createStub("vscode.workspace.workspaceFolders")
+vscode.workspace.workspaceFolders = []
 vscode.workspace.name = createStub("vscode.workspace.name")
 vscode.workspace.workspaceFile = createStub("vscode.workspace.workspaceFile")
 vscode.workspace.onDidChangeWorkspaceFolders = createStub("vscode.workspace.onDidChangeWorkspaceFolders")
@@ -894,10 +894,22 @@ vscode.workspace.onWillDeleteFiles = createStub("vscode.workspace.onWillDeleteFi
 vscode.workspace.onDidDeleteFiles = createStub("vscode.workspace.onDidDeleteFiles")
 vscode.workspace.onWillRenameFiles = createStub("vscode.workspace.onWillRenameFiles")
 vscode.workspace.onDidRenameFiles = createStub("vscode.workspace.onDidRenameFiles")
-vscode.workspace.getConfiguration = function (section, scope) {
-	console.log("Called stubbed function: vscode.workspace.getConfiguration")
-	return createStub("unknown")
+
+const workspaceConfigStore = {}
+vscode.workspace.getConfiguration = function (section) {
+	return {
+		get: (key, defaultValue) => {
+			return workspaceConfigStore[`${section}.${key}`] ?? defaultValue
+		},
+		update: (key, value, global) => {
+			workspaceConfigStore[`${section}.${key}`] = value
+		},
+		has: (key) => {
+			return `${section}.${key}` in workspaceConfigStore
+		},
+	}
 }
+
 vscode.workspace.onDidChangeConfiguration = createStub("vscode.workspace.onDidChangeConfiguration")
 vscode.workspace.registerTaskProvider = function (type, provider) {
 	console.log("Called stubbed function: vscode.workspace.registerTaskProvider")


### PR DESCRIPTION
The extension doesn't like it when the workspace/workspace config is undefined. Fix the warning about the name in package.json.
Change some logging in the gRPC server.

### Test Procedure

Test manually in the standalone app.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

NA

### Additional Notes

NA

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Improves workspace stubs, updates package name, and enhances gRPC server logging.
> 
>   - **Workspace Stubs**:
>     - In `vscode-stubs.js`, `vscode.workspace.workspaceFolders` is set to an empty array instead of a stub.
>     - `vscode.workspace.getConfiguration` now uses `workspaceConfigStore` to manage configuration settings.
>   - **Package Name**:
>     - Changed package name from `Cline standalone` to `cline-standalone` in `package.json`.
>   - **Logging**:
>     - Improved error logging in `standalone.ts` for gRPC server binding errors.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for bc94ccde829712bc2682a72936f0d7c0e6a56d93. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->