### PR TITLE
Fix hardcoded context menu index for File option selection

### DIFF
--- a/webview-ui/src/components/chat/ChatTextArea.tsx
+++ b/webview-ui/src/components/chat/ChatTextArea.tsx
@@ -10,6 +10,7 @@ import { FileServiceClient, StateServiceClient } from "@/services/grpc-client"
 import {
 	ContextMenuOptionType,
 	getContextMenuOptions,
+	getContextMenuOptionIndex,
 	insertMention,
 	insertMentionDirectly,
 	removeMention,
@@ -59,6 +60,9 @@ const getImageDimensions = (dataUrl: string): Promise<{ width: number; height: n
 		img.src = dataUrl
 	})
 }
+
+// Set to "File" option by default
+const DEFAULT_CONTEXT_MENU_OPTION = getContextMenuOptionIndex(ContextMenuOptionType.File)
 
 interface ChatTextAreaProps {
 	inputValue: string
@@ -530,7 +534,7 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 					if (event.key === "Escape") {
 						// event.preventDefault()
 						setSelectedType(null)
-						setSelectedMenuIndex(3) // File by default
+						setSelectedMenuIndex(DEFAULT_CONTEXT_MENU_OPTION)
 						return
 					}
 
@@ -770,7 +774,7 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 								})
 						}, 200) // 200ms debounce
 					} else {
-						setSelectedMenuIndex(3) // Set to "File" option by default
+						setSelectedMenuIndex(DEFAULT_CONTEXT_MENU_OPTION)
 					}
 				} else {
 					setSearchQuery("")

--- a/webview-ui/src/utils/context-mentions.ts
+++ b/webview-ui/src/utils/context-mentions.ts
@@ -75,6 +75,19 @@ export interface ContextMenuQueryItem {
 	description?: string
 }
 
+const DEFAULT_CONTEXT_MENU_OPTIONS = [
+	ContextMenuOptionType.URL,
+	ContextMenuOptionType.Problems,
+	ContextMenuOptionType.Terminal,
+	ContextMenuOptionType.Git,
+	ContextMenuOptionType.Folder,
+	ContextMenuOptionType.File,
+]
+
+export function getContextMenuOptionIndex(option: ContextMenuOptionType) {
+	return DEFAULT_CONTEXT_MENU_OPTIONS.findIndex((item) => item === option)
+}
+
 export function getContextMenuOptions(
 	query: string,
 	selectedType: ContextMenuOptionType | null = null,
@@ -114,14 +127,7 @@ export function getContextMenuOptions(
 			return commits.length > 0 ? [workingChanges, ...commits] : [workingChanges]
 		}
 
-		return [
-			{ type: ContextMenuOptionType.URL },
-			{ type: ContextMenuOptionType.Problems },
-			{ type: ContextMenuOptionType.Terminal },
-			{ type: ContextMenuOptionType.Git },
-			{ type: ContextMenuOptionType.Folder },
-			{ type: ContextMenuOptionType.File },
-		]
+		return DEFAULT_CONTEXT_MENU_OPTIONS.map((type) => ({ type }))
 	}
 
 	const lowerQuery = query.toLowerCase()


### PR DESCRIPTION
### Description

<!-- Describe your changes in detail. What problem does this PR solve? -->

Based on the comments in the code, the `File` option should be selected by default when Context Menu is opened:

```ts
setSelectedMenuIndex(3) // File by default

setSelectedMenuIndex(3) // Set to "File" option by default
```


In the code the ChatTextArea component was using a hardcoded index 3 to select the "File" option by default in the context menu when  the File option is actually at index 5 in the menu options array. This caused the wrong option (Git Commits) to be selected by default or on reset.

Additionally, the hardcoded approach was fragile and would break if the context menu order changed in the future.

Key Changes:

- Added `DEFAULT_CONTEXT_MENU_OPTIONS` array in context-mentions.ts to define the canonical menu order
- Added helper function `getDefaultContextMenuOptionIndex()` dynamically finds the correct index for any option type
- Updated ChatTextArea to use `DEFAULT_CONTEXT_MENU_OPTION` constant instead of hardcoded 3
- Updated `getContextMenuOptions()` to use the new centralized array

### Test Procedure

<!-- How did you test this? Are you confident that it will not introduce bugs? If so, why? -->

1. Open the context menu
2. Verify the "Add File" is selected instead of "Git Commits"

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

Context menu is opened with the `Add File` option selected

<img width="631" alt="image" src="https://github.com/user-attachments/assets/4cf4b974-792e-43c7-96d3-12fbffef2b1e" />

Before: Context menu is opened with the `Git Commits` option selected

<img width="646" alt="image" src="https://github.com/user-attachments/assets/4f16ab6e-4ca3-4eb6-afc0-883d46e0de0d" />

### Additional Notes

<!-- Add any additional notes for reviewers -->
