### PR TITLE
Fix: Telemetry warning popup bug

### DIFF
--- a/.changeset/eight-otters-grow.md
+++ b/.changeset/eight-otters-grow.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Fixed issue where telemetry warning popup was created for every new Cline window

--- a/src/services/posthog/telemetry/TelemetryService.ts
+++ b/src/services/posthog/telemetry/TelemetryService.ts
@@ -138,17 +138,20 @@ class TelemetryService {
 		if (globalTelemetryEnabled) {
 			this.telemetryEnabled = didUserOptIn
 		} else {
-			// Show warning to user that global telemetry is disabled
-			void vscode.window
-				.showWarningMessage(
-					"VSCode telemetry is disabled. To enable telemetry for this extension, first enable VSCode telemetry in settings.",
-					"Open Settings",
-				)
-				.then((selection) => {
-					if (selection === "Open Settings") {
-						void vscode.commands.executeCommand("workbench.action.openSettings", "telemetry.telemetryLevel")
-					}
-				})
+			// Only show warning if user has opted in to Cline telemetry but VS Code telemetry is disabled
+			if (didUserOptIn) {
+				void vscode.window
+					.showWarningMessage(
+						"Anonymous Cline error and usage reporting is enabled, but VSCode telemetry is disabled. To enable error and usage reporting for this extension, enable VSCode telemetry in settings.",
+						"Open Settings",
+					)
+					.then((selection) => {
+						if (selection === "Open Settings") {
+							void vscode.commands.executeCommand("workbench.action.openSettings", "telemetry.telemetryLevel")
+						}
+					})
+			}
+			this.telemetryEnabled = false
 		}
 
 		// Update PostHog client state based on telemetry preference


### PR DESCRIPTION
### Description

This change fixes a bug where users were getting a popup every time they created a new Cline window if they had telemetry disabled in Cline & in VS Code. With this change, they will only get this popup if they have telemetry enabled in Cline and disabled in VS Code. A future improvement could make this only appear once per session.

Fixes #4066 

### Test Procedure

Open Cline with telemetry enabled in the extension, and telemetry disabled in VS Code settings. Create new Cline windows, you should get the warning. Now disable telemetry in the extension, create new Cline windows, the popups should no longer occur.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [X] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [X] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [X] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [X] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [X] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes telemetry warning popup bug in `TelemetryService.ts` to only show when Cline telemetry is enabled and VS Code telemetry is disabled.
> 
>   - **Behavior**:
>     - Fixes bug in `TelemetryService.ts` where telemetry warning popup appeared for every new Cline window.
>     - Popup now only appears if telemetry is enabled in Cline and disabled in VS Code.
>   - **Misc**:
>     - Adds changeset `eight-otters-grow.md` to document the fix.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for ee4e1a0bf0af11e0a6c0aad3b71447fb26c07abb. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->