### PR TITLE
fix: Supporting multiple cline windows

### DIFF
--- a/.changeset/sour-goats-fry.md
+++ b/.changeset/sour-goats-fry.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Fixing support for multiple Cline chat windows in the same VSCode workspace

--- a/src/core/controller/state/subscribeToState.ts
+++ b/src/core/controller/state/subscribeToState.ts
@@ -1,10 +1,9 @@
-import * as vscode from "vscode"
-import { Controller } from "../index"
 import { EmptyRequest } from "../../../shared/proto/common"
 import { StreamingResponseHandler, getRequestRegistry } from "../grpc-handler"
+import { Controller } from "../index"
 
-// Keep track of active state subscriptions
-const activeStateSubscriptions = new Set<StreamingResponseHandler>()
+// Replace global Set with Map grouped by controller ID
+const controllerSubscriptions = new Map<string, Set<StreamingResponseHandler>>()
 
 /**
  * Subscribe to state updates
@@ -19,23 +18,35 @@ export async function subscribeToState(
 	responseStream: StreamingResponseHandler,
 	requestId?: string,
 ): Promise<void> {
+	const controllerId = controller.id
+
+	// Get or create subscription set for this controller
+	if (!controllerSubscriptions.has(controllerId)) {
+		controllerSubscriptions.set(controllerId, new Set())
+	}
+	const subscriptions = controllerSubscriptions.get(controllerId)!
+
 	// Send the initial state
 	const initialState = await controller.getStateToPostToWebview()
 	const initialStateJson = JSON.stringify(initialState)
 
-	console.log("[DEBUG] set up state subscription")
+	console.log(`[DEBUG] set up state subscription for controller ${controllerId}`)
 
 	await responseStream({
 		stateJson: initialStateJson,
 	})
 
-	// Add this subscription to the active subscriptions
-	activeStateSubscriptions.add(responseStream)
+	// Add this subscription to THIS controller's subscriptions
+	subscriptions.add(responseStream)
 
 	// Register cleanup when the connection is closed
 	const cleanup = () => {
-		activeStateSubscriptions.delete(responseStream)
-		console.log("[DEBUG] Cleaned up state subscription")
+		subscriptions.delete(responseStream)
+		// Clean up empty sets
+		if (subscriptions.size === 0) {
+			controllerSubscriptions.delete(controllerId)
+		}
+		console.log(`[DEBUG] Cleaned up state subscription for controller ${controllerId}`)
 	}
 
 	// Register the cleanup function with the request registry if we have a requestId
@@ -45,29 +56,49 @@ export async function subscribeToState(
 }
 
 /**
- * Send a state update to all active subscribers
+ * Send a state update to subscribers of a specific controller
+ * @param controllerId The ID of the controller whose subscribers should receive the update
  * @param state The state to send
  */
-export async function sendStateUpdate(state: any): Promise<void> {
+export async function sendStateUpdateForController(controllerId: string, state: any): Promise<void> {
+	const subscriptions = controllerSubscriptions.get(controllerId)
+	if (!subscriptions || subscriptions.size === 0) {
+		return // No subscribers for this controller
+	}
+
 	const stateJson = JSON.stringify(state)
 
-	// Send the update to all active subscribers
-	const promises = Array.from(activeStateSubscriptions).map(async (responseStream) => {
+	// Send the update to this controller's subscribers only
+	const promises = Array.from(subscriptions).map(async (responseStream) => {
 		try {
-			// The issue might be that we're not properly formatting the response
-			// Let's ensure we're sending a properly formatted State message
 			await responseStream(
 				{
 					stateJson,
 				},
 				false, // Not the last message
 			)
-			console.log("[DEBUG] sending followup state", stateJson.length, "chars")
+			console.log(`[DEBUG] sending followup state to controller ${controllerId}`, stateJson.length, "chars")
 		} catch (error) {
-			console.error("Error sending state update:", error)
+			console.error(`Error sending state update to controller ${controllerId}:`, error)
 			// Remove the subscription if there was an error
-			activeStateSubscriptions.delete(responseStream)
+			subscriptions.delete(responseStream)
 		}
+	})
+
+	await Promise.all(promises)
+}
+
+/**
+ * @deprecated Use sendStateUpdateForController instead
+ * Legacy function - will broadcast to ALL controllers (the bug!)
+ */
+export async function sendStateUpdate(state: any): Promise<void> {
+	console.warn("[DEPRECATED] sendStateUpdate called - this broadcasts to all controllers!")
+
+	// For now, broadcast to all controllers to maintain backward compatibility
+	// TODO: Remove this function once all calls are updated
+	const promises = Array.from(controllerSubscriptions.entries()).map(async ([controllerId, subscriptions]) => {
+		await sendStateUpdateForController(controllerId, state)
 	})
 
 	await Promise.all(promises)


### PR DESCRIPTION
### Description

Multiple Cline chats stopped working independently in the same workspace

This relates to the following:

> Each Controller calls `sendStateUpdate()` thinking it's only updating its own webview, but the __global__ `activeStateSubscriptions` broadcasts to ALL controllers.

### Test Procedure

I run CLINE in local and tested it manually.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes independent functionality of multiple Cline chat windows by sending state updates to specific controller subscribers using a new map-based approach.
> 
>   - **Behavior**:
>     - Fixes issue with multiple Cline chat windows not working independently by ensuring state updates are sent only to relevant controller's subscribers.
>     - Replaces global `activeStateSubscriptions` with `controllerSubscriptions` map in `subscribeToState.ts`.
>     - Updates `postStateToWebview()` in `index.ts` to use `sendStateUpdateForController()`.
>   - **Functions**:
>     - Adds `sendStateUpdateForController()` in `subscribeToState.ts` to send updates to specific controller subscribers.
>     - Deprecates `sendStateUpdate()` in `subscribeToState.ts`, which broadcasts to all controllers, with a warning for usage.
>   - **Imports**:
>     - Reorders imports in `index.ts` for better organization.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for f3cfea17392c2d6e19de49462ffe5a07ca35bf72. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->