### PR TITLE
Fix multiple window splitting when opening Cline in new tab

### DIFF
--- a/.changeset/little-suns-deny.md
+++ b/.changeset/little-suns-deny.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Fixed Open in New Tab command causing multiple vscode window splitting


### PR DESCRIPTION
### Description

Prevent the "Open in New Tab" command from creating multiple VSCode window splits by checking for existing Cline tab instances and reusing their view column instead of always creating new editor groups.

#4093 

### Test Procedure

Tested it myself when running locally.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

### Additional Notes

<!-- Add any additional notes for reviewers -->
