### PR TITLE
Fix bug where replace_in_file would not be able to handle for out-of-order SEARCH/REPLACE blocks

### DIFF
--- a/src/core/assistant-message/diff.test.ts
+++ b/src/core/assistant-message/diff.test.ts
@@ -1,9 +1,9 @@
-import { constructNewFileContent as cnfc2 } from "./diff"
+import { constructNewFileContent as cnfc } from "./diff"
 import { describe, it } from "mocha"
 import { expect } from "chai"
 
-async function cnfc(diffContent: string, originalContent: string, isFinal: boolean): Promise<string> {
-	return cnfc2(diffContent, originalContent, isFinal, "v1")
+async function cnfc2(diffContent: string, originalContent: string, isFinal: boolean): Promise<string> {
+	return cnfc(diffContent, originalContent, isFinal, "v2")
 }
 
 describe("constructNewFileContent", () => {
@@ -173,6 +173,211 @@ replaced
 			expect.fail("Expected an error to be thrown")
 		} catch (err) {
 			expect(err).to.be.an("error")
+		}
+	})
+})
+
+// Test cases for out-of-order search/replace blocks
+
+describe("out-of-order search/replace blocks", () => {
+	it("should handle out-of-order replacements correctly", async () => {
+		const original = "First\nSecond\nThird\nFourth\nFifth"
+		const diff = `------- SEARCH
+  Fourth
+  =======
+  4th
+  +++++++ REPLACE
+  
+  ------- SEARCH
+  Second
+  =======
+  2nd
+  +++++++ REPLACE`
+		const expected = "First\n2nd\nThird\n4th\nFifth"
+
+		const result = await cnfc(diff, original, true)
+		expect(result).to.equal(expected)
+	})
+
+	it("should handle complex out-of-order replacements", async () => {
+		const original = `function test() {
+	const a = 1;
+	const b = 2;
+	const c = 3;
+	const d = 4;
+	return a + b + c + d;
+  }`
+
+		const diff = `------- SEARCH
+	const d = 4;
+  =======
+	const d = 40;
+  +++++++ REPLACE
+  
+  ------- SEARCH
+	const b = 2;
+  =======
+	const b = 20;
+  +++++++ REPLACE
+  
+  ------- SEARCH
+	const c = 3;
+  =======
+	const c = 30;
+  +++++++ REPLACE`
+
+		const expected = `function test() {
+	const a = 1;
+	const b = 20;
+	const c = 30;
+	const d = 40;
+	return a + b + c + d;
+  }`
+
+		const result = await cnfc(diff, original, true)
+		expect(result).to.equal(expected)
+	})
+
+	it("should handle out-of-order replacements with overlapping content", async () => {
+		const original = `class Example {
+	constructor() {
+	  this.value = 10;
+	}
+	
+	method1() {
+	  return this.value * 2;
+	}
+	
+	method2() {
+	  return this.value * 3;
+	}
+  }`
+
+		const diff = `------- SEARCH
+	method2() {
+	  return this.value * 3;
+	}
+  =======
+	method2() {
+	  return this.value * 4;
+	}
+	
+	method3() {
+	  return this.value * 5;
+	}
+  +++++++ REPLACE
+  
+  ------- SEARCH
+	constructor() {
+	  this.value = 10;
+	}
+  =======
+	constructor() {
+	  this.value = 100;
+	}
+  +++++++ REPLACE`
+
+		const expected = `class Example {
+	constructor() {
+	  this.value = 100;
+	}
+	
+	method1() {
+	  return this.value * 2;
+	}
+	
+	method2() {
+	  return this.value * 4;
+	}
+	
+	method3() {
+	  return this.value * 5;
+	}
+  }`
+
+		const result = await cnfc(diff, original, true)
+		expect(result).to.equal(expected)
+	})
+
+	it("should handle out-of-order replacements with deletions", async () => {
+		const original = "Line1\nLine2\nLine3\nLine4\nLine5"
+		const diff = `------- SEARCH
+  Line4
+  =======
+  +++++++ REPLACE
+  
+  ------- SEARCH
+  Line2
+  =======
+  Line2-Modified
+  +++++++ REPLACE`
+
+		const expected = "Line1\nLine2-Modified\nLine3\n\nLine5"
+
+		const result = await cnfc(diff, original, true)
+		expect(result).to.equal(expected)
+	})
+
+	it("should handle many out-of-order replacements", async () => {
+		const original = "A\nB\nC\nD\nE\nF\nG\nH\nI\nJ"
+		const diff = `------- SEARCH
+  I
+  =======
+  I-Modified
+  +++++++ REPLACE
+  
+  ------- SEARCH
+  C
+  =======
+  C-Modified
+  +++++++ REPLACE
+  
+  ------- SEARCH
+  G
+  =======
+  G-Modified
+  +++++++ REPLACE
+  
+  ------- SEARCH
+  A
+  =======
+  A-Modified
+  +++++++ REPLACE
+  
+  ------- SEARCH
+  E
+  =======
+  E-Modified
+  +++++++ REPLACE`
+
+		const expected = "A-Modified\nB\nC-Modified\nD\nE-Modified\nF\nG-Modified\nH\nI-Modified\nJ"
+
+		const result = await cnfc(diff, original, true)
+		expect(result).to.equal(expected)
+	})
+
+	it("should correctly identify the error type for truly missing content", async () => {
+		const original = "Line1\nLine2\nLine3"
+		const diff = `------- SEARCH
+  Line2
+  =======
+  Line2-Modified
+  +++++++ REPLACE
+  
+  ------- SEARCH
+  NonExistentLine
+  =======
+  Something
+  +++++++ REPLACE`
+
+		try {
+			await cnfc(diff, original, true)
+			expect.fail("Expected an error to be thrown")
+		} catch (err) {
+			expect(err).to.be.an("error")
+			expect(err.message).to.include("does not match anything in the file")
+			// The error message should no longer include "or was searched out of order"
+			expect(err.message).to.not.include("out of order")
 		}
 	})
 })


### PR DESCRIPTION
### Description

# Support out-of-order search/replace blocks in diff processing

## Problem

Previously, our diff processing system required search/replace blocks to be provided in the exact order they appear in the file. This limitation caused failures when the LLM output search/replace blocks out of order. While we prompt the model to output them in order, we found models would find this difficult to adhere to when it realizes it needs to make an edit earlier in the file on the fly. 

### Example of the issue:

Given a file with content in this order:
1. `WINDOW_WIDTH = 800`
2. `RED = (255, 0, 0)`  
3. `self.clock.tick(10)`

If the LLM provided edits in this order:
```
------- SEARCH
WINDOW_WIDTH = 800
=======
WINDOW_WIDTH = 1000
+++++++ REPLACE

------- SEARCH
self.clock.tick(10)
=======
self.clock.tick(15) 
+++++++ REPLACE

------- SEARCH
RED = (255, 0, 0)
=======
RED = (255, 50, 50)
+++++++ REPLACE
```

The third edit would fail because it searches for content that appears earlier in the file than our current processing position.

## Solution

The fix introduces a new approach that collects all replacements and applies them in the correct order at the end:

### Key Changes:

1. **Replacement Tracking**: Instead of building the result incrementally, we now store all replacements in an array:
   ```typescript
   let replacements: Array<{ start: number; end: number; content: string }> = []
   ```

2. **Out-of-Order Detection**: When a search block matches content before our current position, we flag it as out-of-order and continue collecting the replacement without immediately applying it.

3. **Deferred Application**: For in-order replacements, we still output content immediately (for streaming). For out-of-order replacements, we just store them.

4. **Final Assembly**: When processing is complete (`isFinal=true`), we:
   - Sort all replacements by start position
   - Rebuild the entire result by applying replacements in order
   - This ensures all edits are applied correctly regardless of input order

### Benefits:
- ✅ Supports any order of search/replace blocks
- ✅ Maintains streaming output for in-order edits
- ✅ Handles mixed in-order and out-of-order edits

## Development Process

This fix was developed using an AI-assisted workflow that other developers might find helpful:

### 1. Problem Analysis
I provided Claude (Opus 4) with:
- The complete `diff.ts` file
- System instructions for the replace_in_file tool
- Concrete examples of working and failing cases
- Clear explanation of the desired behavior

### 2. Collaborative Solution Design
Working with Claude, we:
- Identified the root cause (forward-only searching from `lastProcessedIndex`)
- Explored multiple approaches (buffering vs. collecting replacements)
- Iterated on edge cases (like preserving already-applied edits)

### 3. Implementation Refinement
The initial solution had a bug where out-of-order replacements would undo previously applied edits. Through discussion with Claude, we refined the approach to collect all replacements and apply them in a single pass at the end.

### Key Takeaway for Developers:
When facing complex algorithmic challenges, providing an AI assistant with:
- Complete context and code
- Specific examples of failures
- Clear expected behavior
- Iterative refinement based on issues found

...can lead to robust solutions. The AI can help explore the solution space and catch edge cases you might miss.

## Technical Details

The algorithm now works as follows:

1. **During streaming**: Process search/replace blocks as they arrive
2. **For each match**: Determine if it's in-order or out-of-order
3. **In-order matches**: Apply immediately to maintain streaming behavior
4. **Out-of-order matches**: Store in replacements array
5. **On completion**: Sort and apply all replacements in correct order

This maintains backward compatibility while adding support for more flexible edit ordering.

## Testing

Tested with:
- ✅ In-order edits (existing behavior preserved)
- ✅ Out-of-order edits (now working)
- ✅ Mixed in-order and out-of-order edits
- ✅ Multiple out-of-order edits
- ✅ Streaming partial content updates

## Future Considerations

This implementation assumes non-overlapping search blocks. If overlapping edits become necessary, additional conflict resolution logic would be needed.

### Test Procedure

I added tests to diff.test.ts

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)
