### PR TITLE
specific or/cline caching for evals

### DIFF
--- a/src/api/providers/cline.ts
+++ b/src/api/providers/cline.ts
@@ -27,7 +27,11 @@ export class ClineHandler implements ApiHandler {
 	}
 
 	@withRetry()
-	async *createMessage(systemPrompt: string, messages: Anthropic.Messages.MessageParam[]): ApiStream {
+	async *createMessage(
+		systemPrompt: string,
+		messages: Anthropic.Messages.MessageParam[],
+		systemPromptCacheOnly: boolean = false,
+	): ApiStream {
 		this.lastGenerationId = undefined
 
 		const stream = await createOpenRouterStream(
@@ -35,6 +39,7 @@ export class ClineHandler implements ApiHandler {
 			systemPrompt,
 			messages,
 			this.getModel(),
+			systemPromptCacheOnly,
 			this.options.reasoningEffort,
 			this.options.thinkingBudgetTokens,
 			this.options.openRouterProviderSorting,

--- a/src/api/providers/openrouter.ts
+++ b/src/api/providers/openrouter.ts
@@ -27,7 +27,11 @@ export class OpenRouterHandler implements ApiHandler {
 	}
 
 	@withRetry()
-	async *createMessage(systemPrompt: string, messages: Anthropic.Messages.MessageParam[]): ApiStream {
+	async *createMessage(
+		systemPrompt: string,
+		messages: Anthropic.Messages.MessageParam[],
+		systemPromptCacheOnly: boolean = false,
+	): ApiStream {
 		this.lastGenerationId = undefined
 
 		const stream = await createOpenRouterStream(
@@ -35,6 +39,7 @@ export class OpenRouterHandler implements ApiHandler {
 			systemPrompt,
 			messages,
 			this.getModel(),
+			systemPromptCacheOnly,
 			this.options.reasoningEffort,
 			this.options.thinkingBudgetTokens,
 			this.options.openRouterProviderSorting,


### PR DESCRIPTION
### Description

<!-- Describe your changes in detail. What problem does this PR solve? -->

### Test Procedure

<!-- How did you test this? Are you confident that it will not introduce bugs? If so, why? -->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `systemPromptCacheOnly` parameter to control caching in `createMessage` and `createOpenRouterStream` functions.
> 
>   - **Behavior**:
>     - Add `systemPromptCacheOnly` parameter to `createMessage()` in `ClineHandler` and `OpenRouterHandler` to control caching behavior.
>     - Modify `createOpenRouterStream()` to handle `systemPromptCacheOnly`, affecting caching of user messages.
>   - **Caching Logic**:
>     - In `openrouter-stream.ts`, update logic to skip caching user messages if `systemPromptCacheOnly` is true.
>     - Adjust `shouldApplyMiddleOutTransform` to consider `systemPromptCacheOnly` in `openrouter-stream.ts`.
>   - **Misc**:
>     - No changes to existing tests or documentation noted.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for d5b5cc18d9ea5cab082a47feeb28fe9e33037a5d. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->