### PR TITLE
feat: Integrate Claude Code

### DIFF
--- a/.changeset/stupid-eyes-perform.md
+++ b/.changeset/stupid-eyes-perform.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Integrate Claude Code

--- a/proto/models.proto
+++ b/proto/models.proto
@@ -122,6 +122,7 @@ enum ApiProvider {
   SAMBANOVA = 22;
   CEREBRAS = 23;
   SAPAICORE = 24;
+  CLAUDE_CODE = 25;
 }
 
 // Model info for OpenAI-compatible models
@@ -234,4 +235,5 @@ message ModelsApiConfiguration {
   optional string sap_ai_resource_group = 70;
   optional string sap_ai_core_token_url = 71;
   optional string sap_ai_core_base_url = 72;
+  optional string claude_code_path = 73;
 }

--- a/proto/state.proto
+++ b/proto/state.proto
@@ -219,5 +219,5 @@ message ApiConfiguration {
   optional string sap_ai_resource_group = 76;
 
   // Claude Code specific
-  optional string claudeCodePath = 77;
+  optional string claude_code_path = 77;
 }

--- a/proto/state.proto
+++ b/proto/state.proto
@@ -217,4 +217,7 @@ message ApiConfiguration {
   optional string sap_ai_core_base_url = 74;
   optional string sap_ai_core_token_url = 75;
   optional string sap_ai_resource_group = 76;
+
+  // Claude Code specific
+  optional string claudeCodePath = 77;
 }

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -26,6 +26,7 @@ import { XAIHandler } from "./providers/xai"
 import { SambanovaHandler } from "./providers/sambanova"
 import { CerebrasHandler } from "./providers/cerebras"
 import { SapAiCoreHandler } from "./providers/sapaicore"
+import { ClaudeCodeHandler } from "./providers/claude-code"
 
 export interface ApiHandler {
 	createMessage(systemPrompt: string, messages: Anthropic.Messages.MessageParam[]): ApiStream
@@ -90,6 +91,8 @@ export function buildApiHandler(configuration: ApiConfiguration): ApiHandler {
 			return new CerebrasHandler(options)
 		case "sapaicore":
 			return new SapAiCoreHandler(options)
+		case "claude-code":
+			return new ClaudeCodeHandler(options)
 		default:
 			return new AnthropicHandler(options)
 	}

--- a/src/api/providers/claude-code.ts
+++ b/src/api/providers/claude-code.ts
@@ -1,0 +1,151 @@
+import type { Anthropic } from "@anthropic-ai/sdk"
+import { anthropicDefaultModelId, anthropicModels, type ApiHandlerOptions } from "@/shared/api"
+import { type ApiHandler } from ".."
+import { ApiStreamUsageChunk, type ApiStream } from "../transform/stream"
+import { withRetry } from "../retry"
+import { runClaudeCode } from "@/integrations/claude-code/run"
+import { ClaudeCodeMessage } from "@/integrations/claude-code/types"
+
+export class ClaudeCodeHandler implements ApiHandler {
+	private options: ApiHandlerOptions
+
+	constructor(options: ApiHandlerOptions) {
+		this.options = options
+	}
+
+	@withRetry({
+		maxRetries: 4,
+		baseDelay: 2000,
+		maxDelay: 15000,
+	})
+	async *createMessage(systemPrompt: string, messages: Anthropic.Messages.MessageParam[]): ApiStream {
+		// TODO: Extract the path from the options
+		const claudeProcess = runClaudeCode({
+			systemPrompt,
+			messages,
+		})
+
+		const dataQueue: string[] = []
+		let isProcessComplete = false
+		let processError = null
+
+		let errorOutput = ""
+
+		claudeProcess.stdout.on("data", (data) => {
+			const output = data.toString()
+			const lines = output.split("\n").filter((line: string) => line.trim() !== "")
+
+			for (const line of lines) {
+				console.log("Received line:", line)
+				dataQueue.push(line)
+			}
+		})
+
+		claudeProcess.stderr.on("data", (data) => {
+			errorOutput += data.toString()
+		})
+
+		claudeProcess.on("close", () => {
+			if (errorOutput) {
+				throw new Error(`ripgrep process error: ${errorOutput}`)
+			}
+
+			isProcessComplete = true
+		})
+
+		claudeProcess.on("error", (error) => {
+			processError = error
+		})
+
+		// Usage is included with assistant messages,
+		// but cost is included in the result chunk
+		let usage: ApiStreamUsageChunk = {
+			type: "usage",
+			inputTokens: 0,
+			outputTokens: 0,
+			cacheReadTokens: 0,
+			cacheWriteTokens: 0,
+		}
+
+		while (!isProcessComplete || dataQueue.length > 0) {
+			if (dataQueue.length === 0) {
+				await new Promise((resolve) => setImmediate(resolve))
+			}
+
+			const data = dataQueue.shift()
+			if (!data) {
+				continue
+			}
+
+			const chunk = this.attemptParseChunk(data)
+
+			if (!chunk) {
+				yield {
+					type: "text",
+					text: data || "",
+				}
+
+				continue
+			}
+
+			if (chunk.type === "system" && chunk.subtype === "init") {
+				continue
+			}
+
+			if (chunk.type === "assistant" && "message" in chunk) {
+				const message = chunk.message
+
+				if (message.stop_reason !== null) {
+					const errorMessage = message.content[0]?.text || `Claude Code stopped with reason: ${message.stop_reason}`
+
+					throw new Error(errorMessage)
+				}
+
+				for (const content of message.content) {
+					if (content.type === "text") {
+						yield {
+							type: "text",
+							text: content.text,
+						}
+					} else {
+						console.warn("Unsupported content type:", content.type)
+					}
+				}
+
+				usage.inputTokens += message.usage.input_tokens
+				usage.outputTokens += message.usage.output_tokens
+				usage.cacheReadTokens = (usage.cacheReadTokens || 0) + (message.usage.cache_read_input_tokens || 0)
+				usage.cacheWriteTokens = (usage.cacheWriteTokens || 0) + (message.usage.cache_creation_input_tokens || 0)
+
+				continue
+			}
+
+			if (chunk.type === "result" && "result" in chunk) {
+				usage.totalCost = chunk.cost_usd || 0
+
+				yield usage
+			}
+
+			if (processError) {
+				throw processError
+			}
+		}
+	}
+
+	getModel() {
+		return {
+			id: anthropicDefaultModelId,
+			info: anthropicModels[anthropicDefaultModelId],
+		}
+	}
+
+	// TOOD: Validate instead of parsing
+	private attemptParseChunk(data: string): ClaudeCodeMessage | null {
+		try {
+			return JSON.parse(data)
+		} catch (error) {
+			console.error("Error parsing chunk:", error)
+			return null
+		}
+	}
+}

--- a/src/api/providers/claude-code.ts
+++ b/src/api/providers/claude-code.ts
@@ -1,5 +1,5 @@
 import type { Anthropic } from "@anthropic-ai/sdk"
-import { anthropicDefaultModelId, AnthropicModelId, anthropicModels, type ApiHandlerOptions } from "@/shared/api"
+import { claudeCodeDefaultModelId, ClaudeCodeModelId, claudeCodeModels, type ApiHandlerOptions } from "@/shared/api"
 import { type ApiHandler } from ".."
 import { ApiStreamUsageChunk, type ApiStream } from "../transform/stream"
 import { withRetry } from "../retry"
@@ -100,6 +100,13 @@ export class ClaudeCodeHandler implements ApiHandler {
 				if (message.stop_reason !== null && message.stop_reason !== "tool_use") {
 					const errorMessage = message.content[0]?.text || `Claude Code stopped with reason: ${message.stop_reason}`
 
+					if (errorMessage.includes("Invalid model name")) {
+						throw new Error(
+							errorMessage +
+								`\n\nAPI keys and subscription plans allow different models. Make sure the selected model is included in your plan.`,
+						)
+					}
+
 					throw new Error(errorMessage)
 				}
 
@@ -136,14 +143,14 @@ export class ClaudeCodeHandler implements ApiHandler {
 
 	getModel() {
 		const modelId = this.options.apiModelId
-		if (modelId && modelId in anthropicModels) {
-			const id = modelId as AnthropicModelId
-			return { id, info: anthropicModels[id] }
+		if (modelId && modelId in claudeCodeModels) {
+			const id = modelId as ClaudeCodeModelId
+			return { id, info: claudeCodeModels[id] }
 		}
 
 		return {
-			id: anthropicDefaultModelId,
-			info: anthropicModels[anthropicDefaultModelId],
+			id: claudeCodeDefaultModelId,
+			info: claudeCodeModels[claudeCodeDefaultModelId],
 		}
 	}
 

--- a/src/api/providers/claude-code.ts
+++ b/src/api/providers/claude-code.ts
@@ -36,7 +36,6 @@ export class ClaudeCodeHandler implements ApiHandler {
 			const lines = output.split("\n").filter((line: string) => line.trim() !== "")
 
 			for (const line of lines) {
-				console.log("Received line:", line)
 				dataQueue.push(line)
 			}
 		})

--- a/src/core/storage/state-keys.ts
+++ b/src/core/storage/state-keys.ts
@@ -79,6 +79,7 @@ export type GlobalStateKey =
 	| "sapAiCoreClientId"
 	| "sapAiCoreClientSecret"
 	| "sapAiCoreModelId"
+	| "claudeCodePath"
 
 export type LocalStateKey =
 	| "localClineRulesToggles"

--- a/src/core/storage/state.ts
+++ b/src/core/storage/state.ts
@@ -246,6 +246,7 @@ export async function getAllExtensionState(context: vscode.ExtensionContext) {
 		sapAiCoreTokenUrl,
 		sapAiResourceGroup,
 		sapAiCoreModelId,
+		claudeCodePath,
 	] = await Promise.all([
 		getGlobalState(context, "isNewUser") as Promise<boolean | undefined>,
 		getSecret(context, "apiKey") as Promise<string | undefined>,
@@ -318,6 +319,7 @@ export async function getAllExtensionState(context: vscode.ExtensionContext) {
 		getGlobalState(context, "sapAiCoreTokenUrl") as Promise<string | undefined>,
 		getGlobalState(context, "sapAiResourceGroup") as Promise<string | undefined>,
 		getGlobalState(context, "sapAiCoreModelId") as Promise<string | undefined>,
+		getGlobalState(context, "claudeCodePath") as Promise<string | undefined>,
 	])
 
 	const localClineRulesToggles = (await getWorkspaceState(context, "localClineRulesToggles")) as ClineRulesToggles
@@ -437,6 +439,7 @@ export async function getAllExtensionState(context: vscode.ExtensionContext) {
 			apiKey,
 			openRouterApiKey,
 			clineApiKey,
+			claudeCodePath,
 			awsAccessKey,
 			awsSecretKey,
 			awsSessionToken,
@@ -618,6 +621,7 @@ export async function updateApiConfiguration(context: vscode.ExtensionContext, a
 		sapAiCoreTokenUrl,
 		sapAiResourceGroup,
 		sapAiCoreModelId,
+		claudeCodePath,
 	} = apiConfiguration
 	// Workspace state updates
 	await updateWorkspaceState(context, "apiProvider", apiProvider)
@@ -672,6 +676,7 @@ export async function updateApiConfiguration(context: vscode.ExtensionContext, a
 	await updateGlobalState(context, "sapAiCoreTokenUrl", sapAiCoreTokenUrl)
 	await updateGlobalState(context, "sapAiResourceGroup", sapAiResourceGroup)
 	await updateGlobalState(context, "sapAiCoreModelId", sapAiCoreModelId)
+	await updateGlobalState(context, "claudeCodePath", claudeCodePath)
 
 	// Secret updates
 	await storeSecret(context, "apiKey", apiKey)

--- a/src/integrations/claude-code/run.ts
+++ b/src/integrations/claude-code/run.ts
@@ -8,15 +8,32 @@ export function runClaudeCode({
 	systemPrompt,
 	messages,
 	path,
+	modelId,
 }: {
 	systemPrompt: string
 	messages: Anthropic.Messages.MessageParam[]
 	path?: string
+	modelId?: string
 }) {
 	const claudePath = path || "claude"
 
 	// TODO: Is it worh using sessions? Where do we store the session ID?
-	const args = ["-p", JSON.stringify(messages), "--system-prompt", systemPrompt, "--verbose", "--output-format", "stream-json"]
+	const args = [
+		"-p",
+		JSON.stringify(messages),
+		"--system-prompt",
+		systemPrompt,
+		"--verbose",
+		"--output-format",
+		"stream-json",
+		// Cline will handle recursive calls
+		"--max-turns",
+		"1",
+	]
+
+	if (modelId) {
+		args.push("--model", modelId)
+	}
 
 	return execa(claudePath, args, {
 		stdin: "ignore",

--- a/src/integrations/claude-code/run.ts
+++ b/src/integrations/claude-code/run.ts
@@ -1,0 +1,28 @@
+import * as vscode from "vscode"
+import Anthropic from "@anthropic-ai/sdk"
+import { execa } from "execa"
+
+const cwd = vscode.workspace.workspaceFolders?.map((folder) => folder.uri.fsPath).at(0)
+
+export function runClaudeCode({
+	systemPrompt,
+	messages,
+	path,
+}: {
+	systemPrompt: string
+	messages: Anthropic.Messages.MessageParam[]
+	path?: string
+}) {
+	const claudePath = path || "claude"
+
+	// TODO: Is it worh using sessions? Where do we store the session ID?
+	const args = ["-p", JSON.stringify(messages), "--system-prompt", systemPrompt, "--verbose", "--output-format", "stream-json"]
+
+	return execa(claudePath, args, {
+		stdin: "ignore",
+		stdout: "pipe",
+		stderr: "pipe",
+		env: process.env,
+		cwd,
+	})
+}

--- a/src/integrations/claude-code/types.ts
+++ b/src/integrations/claude-code/types.ts
@@ -1,0 +1,52 @@
+type InitMessage = {
+	type: "system"
+	subtype: "init"
+	session_id: string
+	tools: string[]
+	mcp_servers: string[]
+}
+
+type ClaudeCodeContent = {
+	type: "text"
+	text: string
+}
+
+type AssistantMessage = {
+	type: "assistant"
+	message: {
+		id: string
+		type: "message"
+		role: "assistant"
+		model: string
+		content: ClaudeCodeContent[]
+		stop_reason: null
+		stop_sequence: null
+		usage: {
+			input_tokens: number
+			cache_creation_input_tokens?: number
+			cache_read_input_tokens?: number
+			output_tokens: number
+			service_tier: "standard"
+		}
+	}
+	session_id: string
+}
+
+type ErrorMessage = {
+	type: "error"
+}
+
+type ResultMessage = {
+	type: "result"
+	subtype: "success"
+	cost_usd: number
+	is_error: boolean
+	duration_ms: number
+	duration_api_ms: number
+	num_turns: number
+	result: string
+	total_cost: number
+	session_id: string
+}
+
+export type ClaudeCodeMessage = InitMessage | AssistantMessage | ErrorMessage | ResultMessage

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -2,6 +2,7 @@ import type { LanguageModelChatSelector } from "../api/providers/types"
 
 export type ApiProvider =
 	| "anthropic"
+	| "claude-code"
 	| "openrouter"
 	| "bedrock"
 	| "vertex"

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -226,6 +226,17 @@ export const anthropicModels = {
 	},
 } as const satisfies Record<string, ModelInfo> // as const assertion makes the object deeply readonly
 
+// Claude Code
+export type ClaudeCodeModelId = keyof typeof claudeCodeModels
+export const claudeCodeDefaultModelId: ClaudeCodeModelId = "claude-sonnet-4-20250514"
+export const claudeCodeModels = {
+	"claude-sonnet-4-20250514": anthropicModels["claude-sonnet-4-20250514"],
+	"claude-opus-4-20250514": anthropicModels["claude-opus-4-20250514"],
+	"claude-3-7-sonnet-20250219": anthropicModels["claude-3-7-sonnet-20250219"],
+	"claude-3-5-sonnet-20241022": anthropicModels["claude-3-5-sonnet-20241022"],
+	"claude-3-5-haiku-20241022": anthropicModels["claude-3-5-haiku-20241022"],
+} as const satisfies Record<string, ModelInfo>
+
 // AWS Bedrock
 // https://docs.aws.amazon.com/bedrock/latest/userguide/conversation-inference.html
 export type BedrockModelId = keyof typeof bedrockModels

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -55,6 +55,7 @@ export interface ApiHandlerOptions {
 	awsBedrockEndpoint?: string
 	awsBedrockCustomSelected?: boolean
 	awsBedrockCustomModelBaseId?: BedrockModelId
+	claudeCodePath?: string
 	vertexProjectId?: string
 	vertexRegion?: string
 	openAiBaseUrl?: string

--- a/src/shared/proto-conversions/models/api-configuration-conversion.ts
+++ b/src/shared/proto-conversions/models/api-configuration-conversion.ts
@@ -236,6 +236,8 @@ function convertApiProviderToProto(provider: string | undefined): ProtoApiProvid
 			return ProtoApiProvider.CEREBRAS
 		case "sapaicore":
 			return ProtoApiProvider.SAPAICORE
+		case "claude-code":
+			return ProtoApiProvider.CLAUDE_CODE
 		default:
 			return ProtoApiProvider.ANTHROPIC
 	}
@@ -294,6 +296,8 @@ function convertProtoToApiProvider(provider: ProtoApiProvider): ApiProvider {
 			return "cerebras"
 		case ProtoApiProvider.SAPAICORE:
 			return "sapaicore"
+		case ProtoApiProvider.CLAUDE_CODE:
+			return "claude-code"
 		default:
 			return "anthropic"
 	}
@@ -374,6 +378,7 @@ export function convertApiConfigurationToProto(config: ApiConfiguration): ProtoA
 		sapAiResourceGroup: config.sapAiResourceGroup,
 		sapAiCoreTokenUrl: config.sapAiCoreTokenUrl,
 		sapAiCoreBaseUrl: config.sapAiCoreBaseUrl,
+		claudeCodePath: config.claudeCodePath,
 	}
 }
 
@@ -452,5 +457,6 @@ export function convertProtoToApiConfiguration(protoConfig: ProtoApiConfiguratio
 		sapAiResourceGroup: protoConfig.sapAiResourceGroup,
 		sapAiCoreTokenUrl: protoConfig.sapAiCoreTokenUrl,
 		sapAiCoreBaseUrl: protoConfig.sapAiCoreBaseUrl,
+		claudeCodePath: protoConfig.claudeCodePath,
 	}
 }

--- a/src/shared/proto-conversions/state/settings-conversion.ts
+++ b/src/shared/proto-conversions/state/settings-conversion.ts
@@ -117,6 +117,9 @@ export function convertApiConfigurationToProtoApiConfiguration(config: ApiConfig
 		litellmModelInfo: config.liteLlmModelInfo ? JSON.stringify(config.liteLlmModelInfo) : undefined,
 		openaiHeaders: config.openAiHeaders ? JSON.stringify(config.openAiHeaders) : undefined,
 
+		// Claude Code specific
+		claudeCodePath: config.claudeCodePath,
+
 		// Arrays
 		favoritedModelIds: config.favoritedModelIds || [],
 	})
@@ -221,6 +224,9 @@ export function convertProtoApiConfigurationToApiConfiguration(protoConfig: Prot
 		sapAiCoreBaseUrl: protoConfig.sapAiCoreBaseUrl,
 		sapAiCoreTokenUrl: protoConfig.sapAiCoreTokenUrl,
 		sapAiResourceGroup: protoConfig.sapAiResourceGroup,
+
+		// Claude Code specific
+		claudeCodePath: protoConfig.claudeCodePath,
 
 		// Arrays
 		favoritedModelIds: protoConfig.favoritedModelIds || [],

--- a/webview-ui/src/components/settings/ApiOptions.tsx
+++ b/webview-ui/src/components/settings/ApiOptions.tsx
@@ -16,6 +16,8 @@ import {
 	bedrockModels,
 	cerebrasDefaultModelId,
 	cerebrasModels,
+	claudeCodeDefaultModelId,
+	claudeCodeModels,
 	deepSeekDefaultModelId,
 	deepSeekModels,
 	doubaoDefaultModelId,
@@ -490,8 +492,7 @@ const ApiOptions = ({
 							marginTop: 3,
 							color: "var(--vscode-descriptionForeground)",
 						}}>
-						Path to the Claude Code CLI executable. Use `which claude` to find the path on Linux or macOS, or `where
-						claude` on Windows.
+						Path to the Claude Code CLI.
 					</p>
 				</div>
 			)}
@@ -2275,8 +2276,8 @@ const ApiOptions = ({
 							<label htmlFor="model-id">
 								<span style={{ fontWeight: 500 }}>Model</span>
 							</label>
-							{(selectedProvider === "anthropic" || selectedProvider === "claude-code") &&
-								createDropdown(anthropicModels)}
+							{selectedProvider === "anthropic" && createDropdown(anthropicModels)}
+							{selectedProvider === "claude-code" && createDropdown(claudeCodeModels)}
 							{selectedProvider === "vertex" &&
 								createDropdown(apiConfiguration?.vertexRegion === "global" ? vertexGlobalModels : vertexModels)}
 							{selectedProvider === "gemini" && createDropdown(geminiModels)}
@@ -2627,8 +2628,9 @@ export function normalizeApiConfiguration(apiConfiguration?: ApiConfiguration): 
 	}
 	switch (provider) {
 		case "anthropic":
-		case "claude-code":
 			return getProviderData(anthropicModels, anthropicDefaultModelId)
+		case "claude-code":
+			return getProviderData(claudeCodeModels, claudeCodeDefaultModelId)
 		case "bedrock":
 			if (apiConfiguration?.awsBedrockCustomSelected) {
 				const baseModelId = apiConfiguration.awsBedrockCustomModelBaseId

--- a/webview-ui/src/components/settings/ApiOptions.tsx
+++ b/webview-ui/src/components/settings/ApiOptions.tsx
@@ -474,6 +474,28 @@ const ApiOptions = ({
 				</div>
 			)}
 
+			{selectedProvider === "claude-code" && (
+				<div>
+					<VSCodeTextField
+						value={apiConfiguration?.claudeCodePath || ""}
+						style={{ width: "100%", marginTop: 3 }}
+						type="text"
+						onInput={handleInputChange("claudeCodePath")}
+						placeholder="Default: claude"
+					/>
+
+					<p
+						style={{
+							fontSize: "12px",
+							marginTop: 3,
+							color: "var(--vscode-descriptionForeground)",
+						}}>
+						Path to the Claude Code CLI executable. Use `which claude` to find the path on Linux or macOS, or `where
+						claude` on Windows.
+					</p>
+				</div>
+			)}
+
 			{selectedProvider === "openai-native" && (
 				<div>
 					<VSCodeTextField
@@ -2253,7 +2275,8 @@ const ApiOptions = ({
 							<label htmlFor="model-id">
 								<span style={{ fontWeight: 500 }}>Model</span>
 							</label>
-							{selectedProvider === "anthropic" && createDropdown(anthropicModels)}
+							{(selectedProvider === "anthropic" || selectedProvider === "claude-code") &&
+								createDropdown(anthropicModels)}
 							{selectedProvider === "vertex" &&
 								createDropdown(apiConfiguration?.vertexRegion === "global" ? vertexGlobalModels : vertexModels)}
 							{selectedProvider === "gemini" && createDropdown(geminiModels)}
@@ -2604,6 +2627,7 @@ export function normalizeApiConfiguration(apiConfiguration?: ApiConfiguration): 
 	}
 	switch (provider) {
 		case "anthropic":
+		case "claude-code":
 			return getProviderData(anthropicModels, anthropicDefaultModelId)
 		case "bedrock":
 			if (apiConfiguration?.awsBedrockCustomSelected) {

--- a/webview-ui/src/components/settings/ApiOptions.tsx
+++ b/webview-ui/src/components/settings/ApiOptions.tsx
@@ -356,6 +356,7 @@ const ApiOptions = ({
 					<VSCodeOption value="cline">Cline</VSCodeOption>
 					<VSCodeOption value="openrouter">OpenRouter</VSCodeOption>
 					<VSCodeOption value="anthropic">Anthropic</VSCodeOption>
+					<VSCodeOption value="claude-code">Claude Code</VSCodeOption>
 					<VSCodeOption value="bedrock">Amazon Bedrock</VSCodeOption>
 					<VSCodeOption value="openai">OpenAI Compatible</VSCodeOption>
 					<VSCodeOption value="vertex">GCP Vertex AI</VSCodeOption>


### PR DESCRIPTION
### Description

This PR introduces Claude Code as a provider using the non-interactive mode of the SDK.

### Test Procedure

I tested myself locally. Example simple task:

https://github.com/user-attachments/assets/5cddbfb0-b1cd-479f-acc1-2e20fcc32151

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Integrates Claude Code as a new provider, adding necessary configurations, handlers, and UI support for its integration.
> 
>   - **Behavior**:
>     - Integrates Claude Code as a provider using non-interactive mode in `src/api/index.ts` and `src/api/providers/claude-code.ts`.
>     - Adds `claudeCodePath` configuration in `proto/state.proto` and `src/core/storage/state.ts`.
>   - **Handlers**:
>     - Implements `ClaudeCodeHandler` in `src/api/providers/claude-code.ts` to manage Claude Code API interactions.
>     - Uses `runClaudeCode` function in `src/integrations/claude-code/run.ts` to execute Claude Code CLI.
>   - **UI**:
>     - Updates `ApiOptions.tsx` to include Claude Code in provider dropdown and handle `claudeCodePath` input.
>   - **Models**:
>     - Defines Claude Code models in `src/shared/api.ts`.
>   - **State Management**:
>     - Updates state handling for `claudeCodePath` in `src/core/storage/state.ts` and `state-keys.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for ccdd226d84c91a526691e0d09268014549f07378. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->