### PR TITLE
Increase the number of retries for Bedrock. Refs #213

### DIFF
--- a/src/api/providers/bedrock.ts
+++ b/src/api/providers/bedrock.ts
@@ -22,7 +22,10 @@ export class AwsBedrockHandler implements ApiHandler {
 		this.options = options
 	}
 
-	@withRetry()
+	@withRetry({maxRetries: 4000000,
+		baseDelay: 2000,
+		maxDelay: 15000000,
+	})
 	async *createMessage(systemPrompt: string, messages: Anthropic.Messages.MessageParam[]): ApiStream {
 		// cross region inference requires prefixing the model id with the region
 		const modelId = await this.getModelId()


### PR DESCRIPTION
### Description

This solves the insanely low default retry count for Bedrock.  I think I added enough... but let me know if you want me to increase the number.

References #213

### Test Procedure

I didn't test it - but I'm pretty sure it will work.  Mostly just copied from Gemini.

### Type of Change


-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A

### Additional Notes

I think I added enough.  But I could understand if you want to add more retries.
