### PR TITLE
Fix safari does not support isComposing of input event

### DIFF
--- a/webview-ui/src/components/chat/ChatTextArea.tsx
+++ b/webview-ui/src/components/chat/ChatTextArea.tsx
@@ -44,6 +44,7 @@ import { validateApiConfiguration, validateModelId } from "@/utils/validate"
 import ClineRulesToggleModal from "../cline-rules/ClineRulesToggleModal"
 import ServersToggleModal from "./ServersToggleModal"
 import { Mode } from "@shared/storage/types"
+import { isSafari } from "@/utils/platformUtils"
 
 const { MAX_IMAGES_AND_FILES_PER_MESSAGE } = CHAT_CONSTANTS
 
@@ -567,7 +568,8 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 					}
 				}
 
-				const isComposing = event.nativeEvent?.isComposing ?? false
+				// Safari does not support InputEvent.isComposing (always false), so we need to fallback to keyCode === 229 for it
+				const isComposing = isSafari ? event.nativeEvent.keyCode === 229 : (event.nativeEvent?.isComposing ?? false)
 				if (event.key === "Enter" && !event.shiftKey && !isComposing) {
 					event.preventDefault()
 

--- a/webview-ui/src/utils/platformUtils.ts
+++ b/webview-ui/src/utils/platformUtils.ts
@@ -34,3 +34,9 @@ export const detectMetaKeyChar = (platform: string) => {
 		return "CMD"
 	}
 }
+
+const userAgent = navigator?.userAgent || ''
+
+export const isChrome = userAgent.indexOf("Chrome") >= 0
+
+export const isSafari = !isChrome && userAgent.indexOf("Safari") >= 0

--- a/webview-ui/src/utils/platformUtils.ts
+++ b/webview-ui/src/utils/platformUtils.ts
@@ -35,7 +35,7 @@ export const detectMetaKeyChar = (platform: string) => {
 	}
 }
 
-const userAgent = navigator?.userAgent || ''
+const userAgent = navigator?.userAgent || ""
 
 export const isChrome = userAgent.indexOf("Chrome") >= 0
 


### PR DESCRIPTION
### Description

<!-- Describe your changes in detail. What problem does this PR solve? -->

Safari does not support InputEvent.isComposing.

before: 
1. Activate Chinese IME
2. Type “hello” and press “Enter”
3. “hello” is sent immediately

https://github.com/user-attachments/assets/395e94b9-5e48-4ceb-8d40-0949848c63cb


after:
1. Activate Chinese IME
2. Type “hello” and press “Enter”
3. “hello” is entered into the input box, and you can continue typing

https://github.com/user-attachments/assets/df452387-e6a1-4625-be37-444a8aa1ada9




### Test Procedure

<!-- How did you test this? Are you confident that it will not introduce bugs? If so, why? -->
* Use **code-server** or **vscode.dev**
* Switch the input method to Chinese
* Type some keys (pinyin) and press **Enter**
* The text gets submitted (It should insert the selected Chinese characters, not trigger an HTTP request)


### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes Safari bug in `ChatTextArea.tsx` by using `keyCode === 229` as a fallback for `InputEvent.isComposing`, with `isSafari` detection added in `platformUtils.ts`.
> 
>   - **Behavior**:
>     - Fixes Safari bug in `ChatTextArea.tsx` by using `keyCode === 229` as a fallback for `InputEvent.isComposing`.
>   - **Utilities**:
>     - Adds `isSafari` function in `platformUtils.ts` to detect Safari browser.
>   - **Misc**:
>     - Minor import reordering in `ChatTextArea.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for d4d3b61202f0e5fbe9e0bc274d4f76a4e93f8a4e. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->