### PR TITLE
Fix reset buttons when message say completion_result

### DIFF
--- a/webview-ui/src/components/chat/ChatView.tsx
+++ b/webview-ui/src/components/chat/ChatView.tsx
@@ -235,9 +235,9 @@ const ChatView = ({ isHidden, showAnnouncement, hideAnnouncement, showHistoryVie
 		// if user finished a task, then start a new task with a new conversation history since in this moment that the extension is waiting for user response, the user could close the extension and the conversation history would be lost.
 		// basically as long as a task is active, the conversation history will be persisted
 		if (lastMessage) {
+			const isPartial = lastMessage.partial === true
 			switch (lastMessage.type) {
 				case "ask":
-					const isPartial = lastMessage.partial === true
 					switch (lastMessage.ask) {
 						case "api_req_failed":
 							setSendingDisabled(true)
@@ -392,9 +392,15 @@ const ChatView = ({ isHidden, showAnnouncement, hideAnnouncement, showHistoryVie
 						case "command_output":
 						case "mcp_server_request_started":
 						case "mcp_server_response":
-						case "completion_result":
 						case "tool":
 						case "load_mcp_documentation":
+							break
+						case "completion_result":
+							setSendingDisabled(isPartial)
+							setClineAsk("completion_result")
+							setEnableButtons(!isPartial)
+							setPrimaryButtonText("Start New Task")
+							setSecondaryButtonText(undefined)
 							break
 					}
 					break


### PR DESCRIPTION
### Description

<!-- Describe your changes in detail. What problem does this PR solve? -->
When RPC message `say` `completion_result`, the buttons are not reseted, also disabled.

### Test Procedure

<!-- How did you test this? Are you confident that it will not introduce bugs? If so, why? -->
1. ask cline to update code
2. when the task completed, the buttons are disabled like this:
![Screenshot 2025-06-09 at 23 55 35](https://github.com/user-attachments/assets/21f9c88b-c7a1-432c-93ea-a8334042b6f9)


### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes button reset and disablement for `completion_result` messages in `ChatView.tsx`.
> 
>   - **Behavior**:
>     - Fixes button reset and disablement for `completion_result` messages in `ChatView.tsx`.
>     - Sets `sendingDisabled` to `isPartial` and updates button states and text when `completion_result` is received.
>   - **Functions**:
>     - Updates `useDeepCompareEffect` in `ChatView.tsx` to handle `completion_result` by setting `setSendingDisabled`, `setClineAsk`, `setEnableButtons`, `setPrimaryButtonText`, and `setSecondaryButtonText`.
>   - **Misc**:
>     - Moves `isPartial` declaration outside of the `ask` switch case in `ChatView.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 1423a7c999371a2ff80621195f6543570d5f3045. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->