### PR TITLE
replay evals

### DIFF
--- a/.changeset/blue-cobras-allow.md
+++ b/.changeset/blue-cobras-allow.md
@@ -1,5 +1,0 @@
----
-"claude-dev": patch
----
-
-Migrated updateSettings to protos, removed didUpdateSettings, altered Plan/Act toggling in settings menu

--- a/.changeset/eight-otters-grow.md
+++ b/.changeset/eight-otters-grow.md
@@ -1,5 +1,0 @@
----
-"claude-dev": patch
----
-
-Fixed issue where telemetry warning popup was created for every new Cline window

--- a/.changeset/eleven-monkeys-watch.md
+++ b/.changeset/eleven-monkeys-watch.md
@@ -1,5 +1,0 @@
----
-"claude-dev": minor
----
-
-Prioritize active files in file context menu

--- a/.changeset/giant-cycles-divide.md
+++ b/.changeset/giant-cycles-divide.md
@@ -1,5 +1,0 @@
----
-"claude-dev": patch
----
-
-toggleWorkflow protobus migration

--- a/.changeset/heavy-bananas-shave.md
+++ b/.changeset/heavy-bananas-shave.md
@@ -1,5 +1,0 @@
----
-"claude-dev": patch
----
-
-Added promise to task init to prevent race condition with checkpoints

--- a/.changeset/honest-boats-fix.md
+++ b/.changeset/honest-boats-fix.md
@@ -1,5 +1,0 @@
----
-"claude-dev": patch
----
-
-Spring cleaning

--- a/.changeset/khaki-cheetahs-tickle.md
+++ b/.changeset/khaki-cheetahs-tickle.md
@@ -1,5 +1,0 @@
----
-"claude-dev": patch
----
-
-Add free grok model

--- a/.changeset/purple-islands-move.md
+++ b/.changeset/purple-islands-move.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Remove ‘-beta’ from grok model id

--- a/.changeset/quick-rocks-guess.md
+++ b/.changeset/quick-rocks-guess.md
@@ -1,5 +1,0 @@
----
-"claude-dev": patch
----
-
-Fix bug where replace_in_file would not be able to handle for out-of-order SEARCH/REPLACE blocks

--- a/.changeset/rare-ducks-give.md
+++ b/.changeset/rare-ducks-give.md
@@ -1,5 +1,0 @@
----
-"claude-dev": minor
----
-
-Context menu is default to File option on start up

--- a/.changeset/six-rice-end.md
+++ b/.changeset/six-rice-end.md
@@ -1,5 +1,0 @@
----
-"claude-dev": minor
----
-
-Migrate fetchLatestServersFromHub to protobus

--- a/.changeset/smart-ladybugs-give.md
+++ b/.changeset/smart-ladybugs-give.md
@@ -1,5 +1,0 @@
----
-"claude-dev": minor
----
-
-the response of the mcps is displayed with a collapsible which allows to focus on the model responses.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [3.17.12]
+
+-   **Free Grok Model Available!** Access Grok 3 completely free through the Cline provider
+-   Add collapsible MCP response panels to keep conversations focused on the main AI responses while still allowing access to detailed MCP output (Thanks @valinha!)
+-   Prioritize active files (open tabs) at the top of the file context menu when using @ mentions (Thanks @abeatrix!)
+-   Fix context menu to properly default to "File" option instead of incorrectly selecting "Git Commits"
+-   Fix diff editing to handle out-of-order SEARCH/REPLACE blocks, improving reliability with models that don't follow strict ordering
+-   Fix telemetry warning popup appearing repeatedly for users who have telemetry disabled
+
 ## [3.17.11]
 
 -   Add support for Gemini 2.5 Pro Preview 06-05 model to Vertex AI and Google Gemini providers

--- a/evals/cli/src/commands/runDiffEval.ts
+++ b/evals/cli/src/commands/runDiffEval.ts
@@ -13,6 +13,7 @@ interface RunDiffEvalOptions {
 	verbose: boolean
 	testPath: string
 	outputPath: string
+	replay: boolean
 }
 
 export async function runDiffEvalHandler(options: RunDiffEvalOptions) {
@@ -48,6 +49,10 @@ export async function runDiffEvalHandler(options: RunDiffEvalOptions) {
 
 	if (options.parallel) {
 		args.push("--parallel")
+	}
+
+	if (options.replay) {
+		args.push("--replay")
 	}
 
 	if (options.verbose) {

--- a/evals/cli/src/index.ts
+++ b/evals/cli/src/index.ts
@@ -91,6 +91,7 @@ program
 	.option("--diff-edit-function <name>", "The diff editing function to use", "constructNewFileContentV2")
 	.option("--thinking-budget <tokens>", "Set the thinking tokens budget", "0")
 	.option("--parallel", "Run tests in parallel", false)
+	.option("--replay", "Run evaluation from a pre-recorded LLM output, skipping the API call", false)
 	.option("-v, --verbose", "Enable verbose logging", false)
 	.action(async (options) => {
 		try {

--- a/evals/diff_editing/types.ts
+++ b/evals/diff_editing/types.ts
@@ -13,6 +13,7 @@ export interface ProcessedTestCase {
 	file_contents: string
 	file_path: string
 	system_prompt_details: SystemPromptDetails
+	original_diff_edit_tool_call_message: string
 }
 
 export interface TestCase {
@@ -21,6 +22,7 @@ export interface TestCase {
 	file_contents: string
 	file_path: string
 	system_prompt_details: SystemPromptDetails
+	original_diff_edit_tool_call_message: string
 }
 
 export interface TestConfig {
@@ -30,6 +32,7 @@ export interface TestConfig {
 	parsing_function: string
 	diff_edit_function: string
 	thinking_tokens_budget: number
+	replay: boolean
 }
 
 export interface SystemPromptDetails {
@@ -72,7 +75,7 @@ export interface ExtractedToolCall {
 }
 
 export interface TestInput {
-	apiKey: string
+	apiKey?: string
 	systemPrompt: string
 	messages: Anthropic.Messages.MessageParam[]
 	modelId: string
@@ -81,4 +84,5 @@ export interface TestInput {
 	parsingFunction: string
 	diffEditFunction: string
 	thinkingBudgetTokens: number
+	originalDiffEditToolCallMessage?: string
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "claude-dev",
-	"version": "3.17.11",
+	"version": "3.17.12",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "claude-dev",
-			"version": "3.17.11",
+			"version": "3.17.12",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@anthropic-ai/bedrock-sdk": "^0.12.4",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "claude-dev",
 	"displayName": "Cline",
 	"description": "Autonomous coding agent right in your IDE, capable of creating/editing files, running commands, using the browser, and more with your permission every step of the way.",
-	"version": "3.17.11",
+	"version": "3.17.12",
 	"icon": "assets/icons/icon.png",
 	"engines": {
 		"vscode": "^1.84.0"

--- a/src/api/providers/cline.ts
+++ b/src/api/providers/cline.ts
@@ -134,7 +134,10 @@ export class ClineHandler implements ApiHandler {
 	}
 
 	getModel(): { id: string; info: ModelInfo } {
-		const modelId = this.options.openRouterModelId
+		let modelId = this.options.openRouterModelId
+		if (modelId === "x-ai/grok-3") {
+			modelId = "x-ai/grok-3-beta"
+		}
 		const modelInfo = this.options.openRouterModelInfo
 		if (modelId && modelInfo) {
 			return { id: modelId, info: modelInfo }

--- a/src/api/providers/openrouter.ts
+++ b/src/api/providers/openrouter.ts
@@ -139,7 +139,10 @@ export class OpenRouterHandler implements ApiHandler {
 	}
 
 	getModel(): { id: string; info: ModelInfo } {
-		const modelId = this.options.openRouterModelId
+		let modelId = this.options.openRouterModelId
+		if (modelId === "x-ai/grok-3") {
+			modelId = "x-ai/grok-3-beta"
+		}
 		const modelInfo = this.options.openRouterModelInfo
 		if (modelId && modelInfo) {
 			return { id: modelId, info: modelInfo }

--- a/src/core/controller/models/refreshOpenRouterModels.ts
+++ b/src/core/controller/models/refreshOpenRouterModels.ts
@@ -117,6 +117,11 @@ export async function refreshOpenRouterModels(
 						break
 				}
 
+				// add new model id
+				if (rawModel.id === "x-ai/grok-3-beta") {
+					models["x-ai/grok-3"] = modelInfo
+				}
+
 				models[rawModel.id] = modelInfo
 			}
 		} else {

--- a/webview-ui/src/components/settings/ApiOptions.tsx
+++ b/webview-ui/src/components/settings/ApiOptions.tsx
@@ -2577,7 +2577,7 @@ export function normalizeApiConfiguration(apiConfiguration?: ApiConfiguration): 
 				// TODO: remove this once we have a better way to handle free models on Cline
 				// Free grok 3 promotion
 				selectedModelInfo:
-					openRouterModelId === "x-ai/grok-3-beta"
+					openRouterModelId === "x-ai/grok-3"
 						? { ...openRouterModelInfo, inputPrice: 0, outputPrice: 0 }
 						: openRouterModelInfo,
 			}

--- a/webview-ui/src/components/settings/OpenRouterModelPicker.tsx
+++ b/webview-ui/src/components/settings/OpenRouterModelPicker.tsx
@@ -52,7 +52,7 @@ const featuredModels = [
 		label: "Trending",
 	},
 	{
-		id: "x-ai/grok-3-beta",
+		id: "x-ai/grok-3",
 		description: "Latest flagship model from xAI, free for now!",
 		label: "Free",
 	},


### PR DESCRIPTION
### Description

Diff edit evals to replay tasks for diff-edit algorithms

### Test Procedure

<!-- How did you test this? Are you confident that it will not introduce bugs? If so, why? -->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add replay mode for evaluations using pre-recorded LLM outputs and update Grok model ID.
> 
>   - **New Feature**:
>     - Add `--replay` option to `runDiffEval.ts`, `index.ts`, and `TestRunner.ts` to enable replaying evaluations from pre-recorded LLM outputs.
>     - Modify `runSingleEvaluation()` in `ClineWrapper.ts` to handle replay mode by mocking stream results.
>     - Update `NodeTestRunner` constructor in `TestRunner.ts` to handle replay mode without requiring an API key.
>   - **Model ID Update**:
>     - Remove '-beta' from Grok model ID in `cline.ts`, `openrouter.ts`, and `refreshOpenRouterModels.ts`.
>     - Update model selection logic in `ApiOptions.tsx` and `OpenRouterModelPicker.tsx` to reflect the new Grok model ID.
>   - **Miscellaneous**:
>     - Update `CHANGELOG.md` to document the availability of the free Grok model and other minor fixes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 40da2d6d0c05fd75f0362c268de5060d1a5d108b. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->