### PR TITLE
Add prompt caching indicator to grok 3

### DIFF
--- a/.changeset/seven-insects-shop.md
+++ b/.changeset/seven-insects-shop.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Add prompt caching indicator to grok 3

--- a/src/core/controller/models/refreshOpenRouterModels.ts
+++ b/src/core/controller/models/refreshOpenRouterModels.ts
@@ -99,6 +99,11 @@ export async function refreshOpenRouterModels(
 						modelInfo.cacheWritesPrice = 0.14
 						modelInfo.cacheReadsPrice = 0.014
 						break
+					case "x-ai/grok-3-beta":
+						modelInfo.supportsPromptCache = true
+						modelInfo.cacheWritesPrice = 0
+						modelInfo.cacheReadsPrice = 0
+						break
 					default:
 						if (rawModel.id.startsWith("openai/")) {
 							modelInfo.cacheReadsPrice = parsePrice(rawModel.pricing?.input_cache_read)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds support for `x-ai/grok-3-beta` in `refreshOpenRouterModels` with prompt caching enabled and zero pricing.
> 
>   - **Behavior**:
>     - Adds support for `x-ai/grok-3-beta` in `refreshOpenRouterModels`.
>     - Sets `supportsPromptCache` to `true` and both `cacheWritesPrice` and `cacheReadsPrice` to `0` for `x-ai/grok-3-beta`.
>   - **Misc**:
>     - Adds `x-ai/grok-3` to models list with the same configuration as `x-ai/grok-3-beta`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 3ec4771f75cecfb977e519e3b8708063599466b3. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->