### PR TITLE
replay evals

### DIFF
--- a/evals/cli/src/commands/runDiffEval.ts
+++ b/evals/cli/src/commands/runDiffEval.ts
@@ -13,6 +13,7 @@ interface RunDiffEvalOptions {
 	verbose: boolean
 	testPath: string
 	outputPath: string
+	replay: boolean
 }
 
 export async function runDiffEvalHandler(options: RunDiffEvalOptions) {
@@ -48,6 +49,10 @@ export async function runDiffEvalHandler(options: RunDiffEvalOptions) {
 
 	if (options.parallel) {
 		args.push("--parallel")
+	}
+
+	if (options.replay) {
+		args.push("--replay")
 	}
 
 	if (options.verbose) {

--- a/evals/cli/src/index.ts
+++ b/evals/cli/src/index.ts
@@ -91,6 +91,7 @@ program
 	.option("--diff-edit-function <name>", "The diff editing function to use", "constructNewFileContentV2")
 	.option("--thinking-budget <tokens>", "Set the thinking tokens budget", "0")
 	.option("--parallel", "Run tests in parallel", false)
+	.option("--replay", "Run evaluation from a pre-recorded LLM output, skipping the API call", false)
 	.option("-v, --verbose", "Enable verbose logging", false)
 	.action(async (options) => {
 		try {

--- a/evals/diff_editing/diff-apply/diff-06-06-25.ts
+++ b/evals/diff_editing/diff-apply/diff-06-06-25.ts
@@ -211,7 +211,7 @@ export async function constructNewFileContent(
 	diffContent: string,
 	originalContent: string,
 	isFinal: boolean,
-	version: "v1" | "v2" = "v2",
+	version: "v1" | "v2" = "v1",
 ): Promise<string> {
 	const constructor = constructNewFileContentVersionMapping[version]
 	if (!constructor) {

--- a/evals/diff_editing/types.ts
+++ b/evals/diff_editing/types.ts
@@ -13,6 +13,7 @@ export interface ProcessedTestCase {
 	file_contents: string
 	file_path: string
 	system_prompt_details: SystemPromptDetails
+	original_diff_edit_tool_call_message: string
 }
 
 export interface TestCase {
@@ -21,6 +22,7 @@ export interface TestCase {
 	file_contents: string
 	file_path: string
 	system_prompt_details: SystemPromptDetails
+	original_diff_edit_tool_call_message: string
 }
 
 export interface TestConfig {
@@ -30,6 +32,7 @@ export interface TestConfig {
 	parsing_function: string
 	diff_edit_function: string
 	thinking_tokens_budget: number
+	replay: boolean
 }
 
 export interface SystemPromptDetails {
@@ -72,7 +75,7 @@ export interface ExtractedToolCall {
 }
 
 export interface TestInput {
-	apiKey: string
+	apiKey?: string
 	systemPrompt: string
 	messages: Anthropic.Messages.MessageParam[]
 	modelId: string
@@ -81,4 +84,5 @@ export interface TestInput {
 	parsingFunction: string
 	diffEditFunction: string
 	thinkingBudgetTokens: number
+	originalDiffEditToolCallMessage?: string
 }


### PR DESCRIPTION
### Description

Replay evals for testing diff apply algorithms. this does not touch the core codebase

### Test Procedure

<!-- How did you test this? Are you confident that it will not introduce bugs? If so, why? -->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds replay mode to diff evaluation, allowing tests to run using pre-recorded outputs without API calls.
> 
>   - **Behavior**:
>     - Adds `--replay` option to `runDiffEvalHandler` in `runDiffEval.ts` and `program` in `index.ts` to run evaluations using pre-recorded outputs.
>     - In `ClineWrapper.ts`, modifies `runSingleEvaluation()` to handle replay mode by using `originalDiffEditToolCallMessage` instead of making API calls.
>     - In `TestRunner.ts`, `NodeTestRunner` constructor checks for `OPENROUTER_API_KEY` only if not in replay mode.
>   - **Functions**:
>     - Updates `constructNewFileContent()` in `diff-06-06-25.ts` to default to version "v1".
>     - Adds `originalDiffEditToolCallMessage` handling in `runSingleTest()` in `TestRunner.ts`.
>   - **Types**:
>     - Adds `replay` boolean to `RunDiffEvalOptions`, `TestConfig`, and `TestInput` in `types.ts`.
>     - Adds `originalDiffEditToolCallMessage` to `ProcessedTestCase` and `TestCase` in `types.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for b8721805aca169f1822f6a0a5eaf5ea0a54088df. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->