### PR TITLE
Update pricing for O3 family models

### DIFF
--- a/.changeset/angry-terms-mate.md
+++ b/.changeset/angry-terms-mate.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+updating o3 model pricing

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -917,9 +917,9 @@ export const openAiNativeModels = {
 		contextWindow: 200_000,
 		supportsImages: true,
 		supportsPromptCache: true,
-		inputPrice: 10.0,
-		outputPrice: 40.0,
-		cacheReadsPrice: 2.5,
+		inputPrice: 2.0,
+		outputPrice: 8.0,
+		cacheReadsPrice: 0.5,
 	},
 	"o4-mini": {
 		maxTokens: 100_000,


### PR DESCRIPTION
### Description
Title says it all


### Test Procedure
<img width="537" alt="image" src="https://github.com/user-attachments/assets/2209d5bd-fa6b-4888-8056-9fc36591e1d3" />


### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [X] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [X] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [X] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [X] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [X] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Update pricing for the O3 model in `openAiNativeModels` in `api.ts`, reducing input, output, and cache read prices.
> 
>   - **Pricing Update**:
>     - Updated `inputPrice` from 10.0 to 2.0 for `o3` in `openAiNativeModels` in `api.ts`.
>     - Updated `outputPrice` from 40.0 to 8.0 for `o3` in `openAiNativeModels` in `api.ts`.
>     - Updated `cacheReadsPrice` from 2.5 to 0.5 for `o3` in `openAiNativeModels` in `api.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 129dd3e81dca65855150aa45996d308ae6030afe. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->