### PR TITLE
Fix MCP Schema support 

### DIFF
--- a/src/services/mcp/schemas.ts
+++ b/src/services/mcp/schemas.ts
@@ -16,49 +16,71 @@ const createServerTypeSchema = () => {
 		// Stdio config (has command field)
 		BaseConfigSchema.extend({
 			type: z.literal("stdio").optional(),
+			transportType: z.string().optional(), // Support legacy field
 			command: z.string(),
 			args: z.array(z.string()).optional(),
 			cwd: z.string().optional(),
 			env: z.record(z.string()).optional(),
-			// Explicitly disallow other types' fields
-			url: z.undefined().optional(),
-			headers: z.undefined().optional(),
+			// Allow other fields for backward compatibility
+			url: z.string().optional(),
+			headers: z.record(z.string()).optional(),
 		})
-			.transform((data) => ({
-				...data,
-				type: "stdio" as const,
-			}))
-			.refine((data) => data.type === undefined || data.type === "stdio", { message: TYPE_ERROR_MESSAGE }),
+			.transform((data) => {
+				// Support both type and transportType fields
+				const finalType = data.type || (data.transportType === "stdio" ? "stdio" : undefined) || "stdio"
+				return {
+					...data,
+					type: finalType as "stdio",
+					// Remove the legacy field after transformation
+					transportType: undefined,
+				}
+			})
+			.refine((data) => data.type === "stdio", { message: TYPE_ERROR_MESSAGE }),
 		// SSE config (has url field)
 		BaseConfigSchema.extend({
 			type: z.literal("sse").optional(),
+			transportType: z.string().optional(), // Support legacy field
 			url: z.string().url("URL must be a valid URL format"),
 			headers: z.record(z.string()).optional(),
-			// Explicitly disallow other types' fields
-			command: z.undefined().optional(),
-			args: z.undefined().optional(),
-			env: z.undefined().optional(),
+			// Allow other fields for backward compatibility
+			command: z.string().optional(),
+			args: z.array(z.string()).optional(),
+			env: z.record(z.string()).optional(),
 		})
-			.transform((data) => ({
-				...data,
-				type: "sse" as const,
-			}))
-			.refine((data) => data.type === undefined || data.type === "sse", { message: TYPE_ERROR_MESSAGE }),
+			.transform((data) => {
+				// Support both type and transportType fields
+				const finalType = data.type || (data.transportType === "sse" ? "sse" : undefined) || "sse"
+				return {
+					...data,
+					type: finalType as "sse",
+					// Remove the legacy field after transformation
+					transportType: undefined,
+				}
+			})
+			.refine((data) => data.type === "sse", { message: TYPE_ERROR_MESSAGE }),
 		// Streamable HTTP config (has url field)
 		BaseConfigSchema.extend({
 			type: z.literal("streamableHttp").optional(),
+			transportType: z.string().optional(), // Support legacy field
 			url: z.string().url("URL must be a valid URL format"),
 			headers: z.record(z.string()).optional(),
-			// Explicitly disallow other types' fields
-			command: z.undefined().optional(),
-			args: z.undefined().optional(),
-			env: z.undefined().optional(),
+			// Allow other fields for backward compatibility
+			command: z.string().optional(),
+			args: z.array(z.string()).optional(),
+			env: z.record(z.string()).optional(),
 		})
-			.transform((data) => ({
-				...data,
-				type: "streamableHttp" as const,
-			}))
-			.refine((data) => data.type === undefined || data.type === "streamableHttp", {
+			.transform((data) => {
+				// Support both type and transportType fields
+				// Note: legacy transportType was "http" not "streamableHttp"
+				const finalType = data.type || (data.transportType === "http" ? "streamableHttp" : undefined) || "streamableHttp"
+				return {
+					...data,
+					type: finalType as "streamableHttp",
+					// Remove the legacy field after transformation
+					transportType: undefined,
+				}
+			})
+			.refine((data) => data.type === "streamableHttp", {
 				message: TYPE_ERROR_MESSAGE,
 			}),
 	])


### PR DESCRIPTION
### Description
Attempt at solving type issues for #4057 



### Test Procedure
- I have NOT tested this on the specific MCP if @wjdavis5 could give me a test MCP i would be happy to do it.
- I have tested this on existing MCPs and it works okay

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [X] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [X] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [X] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [X] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [X] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Enhance `schemas.ts` to support legacy `transportType` field and ensure backward compatibility in MCP configurations.
> 
>   - **Behavior**:
>     - Support legacy `transportType` field in `createServerTypeSchema()` for `stdio`, `sse`, and `streamableHttp` configurations.
>     - Allow backward compatibility by permitting fields from other types in `BaseConfigSchema` extensions.
>     - Transformations now remove `transportType` after determining `type`.
>   - **Refinements**:
>     - Refine schemas to ensure `type` matches expected values (`stdio`, `sse`, `streamableHttp`) in `createServerTypeSchema()`.
>   - **Misc**:
>     - Update `schemas.ts` to handle legacy field support and backward compatibility.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for c20a1813667fb622a86acd3f47d178a11a7353c2. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->