### PR TITLE
return files if targeted directory is hidden

### DIFF
--- a/.changeset/beige-turtles-jump.md
+++ b/.changeset/beige-turtles-jump.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": minor
+---
+
+Fix list_files tool to return files if the targeted directory is a hidden directory

--- a/src/services/glob/list-files.ts
+++ b/src/services/glob/list-files.ts
@@ -1,55 +1,81 @@
 import { globby, Options } from "globby"
-import os from "os"
+import * as os from "os"
 import * as path from "path"
 import { arePathsEqual } from "@utils/path"
 
-export async function listFiles(dirPath: string, recursive: boolean, limit: number): Promise<[string[], boolean]> {
-	// First resolve the path normally - path.resolve doesn't care about glob special characters
-	const absolutePath = path.resolve(dirPath)
-	// Do not allow listing files in root or home directory, which cline tends to want to do when the user's prompt is vague.
+// Constants
+const DEFAULT_IGNORE_DIRECTORIES = [
+	"node_modules",
+	"__pycache__",
+	"env",
+	"venv",
+	"target/dependency",
+	"build/dependencies",
+	"dist",
+	"out",
+	"bundle",
+	"vendor",
+	"tmp",
+	"temp",
+	"deps",
+	"pkg",
+	"Pods",
+]
+
+// Helper functions
+function isRestrictedPath(absolutePath: string): boolean {
 	const root = process.platform === "win32" ? path.parse(absolutePath).root : "/"
 	const isRoot = arePathsEqual(absolutePath, root)
 	if (isRoot) {
-		return [[root], false]
+		return true
 	}
+
 	const homeDir = os.homedir()
 	const isHomeDir = arePathsEqual(absolutePath, homeDir)
 	if (isHomeDir) {
-		return [[homeDir], false]
+		return true
 	}
 
-	const dirsToIgnore = [
-		"node_modules",
-		"__pycache__",
-		"env",
-		"venv",
-		"target/dependency",
-		"build/dependencies",
-		"dist",
-		"out",
-		"bundle",
-		"vendor",
-		"tmp",
-		"temp",
-		"deps",
-		"pkg",
-		"Pods",
-		".*", // '!**/.*' excludes hidden directories, while '!**/.*/**' excludes only their contents. This way we are at least aware of the existence of hidden directories.
-	].map((dir) => `**/${dir}/**`)
+	return false
+}
+
+function isTargetingHiddenDirectory(absolutePath: string): boolean {
+	const dirName = path.basename(absolutePath)
+	return dirName.startsWith(".")
+}
+
+function buildIgnorePatterns(absolutePath: string): string[] {
+	const isTargetHidden = isTargetingHiddenDirectory(absolutePath)
+
+	const patterns = [...DEFAULT_IGNORE_DIRECTORIES]
+
+	// Only ignore hidden directories if we're not explicitly targeting a hidden directory
+	if (!isTargetHidden) {
+		patterns.push(".*")
+	}
+
+	return patterns.map((dir) => `**/${dir}/**`)
+}
+
+export async function listFiles(dirPath: string, recursive: boolean, limit: number): Promise<[string[], boolean]> {
+	const absolutePath = path.resolve(dirPath)
+
+	// Do not allow listing files in root or home directory
+	if (isRestrictedPath(absolutePath)) {
+		return [[], false]
+	}
 
 	const options: Options = {
 		cwd: dirPath,
 		dot: true, // do not ignore hidden files/directories
 		absolute: true,
-		markDirectories: true, // Append a / on any directories matched (/ is used on windows as well, so dont use path.sep)
+		markDirectories: true, // Append a / on any directories matched
 		gitignore: recursive, // globby ignores any files that are gitignored
-		ignore: recursive ? dirsToIgnore : undefined, // just in case there is no gitignore, we ignore sensible defaults
-		onlyFiles: false, // true by default, false means it will list directories on their own too
+		ignore: recursive ? buildIgnorePatterns(absolutePath) : undefined,
+		onlyFiles: false, // include directories in results
 		suppressErrors: true,
 	}
 
-	// * globs all files in one dir, ** globs files in nested directories
-	// For non-recursive listing, we still use a simple pattern
 	const filePaths = recursive ? await globbyLevelByLevel(limit, options) : (await globby("*", options)).slice(0, limit)
 
 	return [filePaths, filePaths.length >= limit]


### PR DESCRIPTION
<!-- ⚠️ Important: Discussion Required Before PR (Community Contributors) -->

**For community contributors, before submitting this PR, please ensure you have:**

- [ ] **Opened an issue** to discuss your proposed changes with the community
- [ ] **Received approval** from a core Cline contributor to proceed with the implementation
- [ ] **Linked the issue below** in the "Related Issue" section

**Exceptions:** Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly.

**Why this requirement?** We deeply appreciate all community contributions - they are the core reason we're able to operate successfully and keep innovating! We welcome community input and want to make it as easy as possible for people to submit quality work. This process helps our core maintainers review new ideas faster and saves contributor time by ensuring you have the go-ahead before spending time on implementation.

---

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** #4174 

### Description

Using the list file tool on a hidden (starting with a '.') directory with recursive = true was not returning any results. This is because we ignore '.' files recursively, but this should not be the behavior when the model explicitly targets such a directory.

This PR fixes that and cleans up the relevant code a bit.

### Test Procedure

Have normal cline call list_files recursively on a hidden directory and confirm that nothing is returned.

Ensure that this PR fixes that.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots
<img width="464" alt="Screenshot 2025-06-11 at 10 05 00 PM" src="https://github.com/user-attachments/assets/ac1b3d23-4541-4f40-8cb0-9e7a3ca2f2e4" />

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> `listFiles` in `list-files.ts` now returns files from hidden directories if explicitly targeted, with adjusted ignore patterns.
> 
>   - **Behavior**:
>     - `listFiles` in `list-files.ts` now returns files if the targeted directory is hidden.
>     - Adjusts ignore patterns to include hidden directories only if not explicitly targeted.
>   - **Functions**:
>     - Adds `isRestrictedPath` to check for root or home directory.
>     - Adds `isTargetingHiddenDirectory` to check if a directory is hidden.
>     - Adds `buildIgnorePatterns` to construct ignore patterns based on directory visibility.
>   - **Misc**:
>     - Refactors constants and helper functions for clarity in `list-files.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for f42c384be1fc6d1385c6525d7f6874bf8a896247. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->