### PR TITLE
Add a linter for proto files

### DIFF
--- a/buf.yaml
+++ b/buf.yaml
@@ -1,21 +1,21 @@
 version: v2
 modules:
-  - path: proto
-    name: cline/cline/lint
+    - path: proto
+      name: cline/cline/lint
 
 lint:
-  use:
-    - STANDARD
+    use:
+        - STANDARD
 
-  except: # Add exceptions for current patterns that contradict STANDARD settings
-    - RPC_PASCAL_CASE # rpcs are camel case (start with lowercase)
-    - PACKAGE_DIRECTORY_MATCH # the protos in the cline package are not in a dir named cline.
-    - RPC_REQUEST_RESPONSE_UNIQUE # request messages are not unique.
-    - RPC_REQUEST_STANDARD_NAME # request messages dont all end with Request
-    - RPC_RESPONSE_STANDARD_NAME # response messages dont all end with Response
-    - PACKAGE_VERSION_SUFFIX # package name does not contain version.
-    - ENUM_VALUE_PREFIX # enum values dont start with the enum name.
-    - ENUM_ZERO_VALUE_SUFFIX # first value does not have to be UNSPECIFIED.
+    except: # Add exceptions for current patterns that contradict STANDARD settings
+        - RPC_PASCAL_CASE # rpcs are camel case (start with lowercase)
+        - PACKAGE_DIRECTORY_MATCH # the protos in the cline package are not in a dir named cline.
+        - RPC_REQUEST_RESPONSE_UNIQUE # request messages are not unique.
+        - RPC_REQUEST_STANDARD_NAME # request messages dont all end with Request
+        - RPC_RESPONSE_STANDARD_NAME # response messages dont all end with Response
+        - PACKAGE_VERSION_SUFFIX # package name does not contain version.
+        - ENUM_VALUE_PREFIX # enum values dont start with the enum name.
+        - ENUM_ZERO_VALUE_SUFFIX # first value does not have to be UNSPECIFIED.
 
 # breaking:
 #   use:

--- a/buf.yaml
+++ b/buf.yaml
@@ -1,0 +1,22 @@
+version: v2
+modules:
+  - path: proto
+    name: cline/cline/lint
+
+lint:
+  use:
+    - STANDARD
+
+  except: # Add exceptions for current patterns that contradict STANDARD settings
+    - RPC_PASCAL_CASE # rpcs are camel case (start with lowercase)
+    - PACKAGE_DIRECTORY_MATCH # the protos in the cline package are not in a dir named cline.
+    - RPC_REQUEST_RESPONSE_UNIQUE # request messages are not unique.
+    - RPC_REQUEST_STANDARD_NAME # request messages dont all end with Request
+    - RPC_RESPONSE_STANDARD_NAME # response messages dont all end with Response
+    - PACKAGE_VERSION_SUFFIX # package name does not contain version.
+    - ENUM_VALUE_PREFIX # enum values dont start with the enum name.
+    - ENUM_ZERO_VALUE_SUFFIX # first value does not have to be UNSPECIFIED.
+
+# breaking:
+#   use:
+#     - WIRE_JSON # Detect changes that break the json wire format (this is the minimum recommended level.)

--- a/package-lock.json
+++ b/package-lock.json
@@ -76,6 +76,7 @@
 				"zod": "^3.24.2"
 			},
 			"devDependencies": {
+				"@bufbuild/buf": "^1.54.0",
 				"@changesets/cli": "^2.27.12",
 				"@types/chai": "^5.0.1",
 				"@types/clone-deep": "^4.0.4",
@@ -4217,6 +4218,150 @@
 			"integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/@bufbuild/buf": {
+			"version": "1.54.0",
+			"resolved": "https://registry.npmjs.org/@bufbuild/buf/-/buf-1.54.0.tgz",
+			"integrity": "sha512-UkjZmVslA7YAxhUQVxE2O4HX4qD7aMspjkuG3vsjnvmAkiV6Jhz47z3focCuPI28e59H20TiQNhc9Y3fkffWPw==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "Apache-2.0",
+			"bin": {
+				"buf": "bin/buf",
+				"protoc-gen-buf-breaking": "bin/protoc-gen-buf-breaking",
+				"protoc-gen-buf-lint": "bin/protoc-gen-buf-lint"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"optionalDependencies": {
+				"@bufbuild/buf-darwin-arm64": "1.54.0",
+				"@bufbuild/buf-darwin-x64": "1.54.0",
+				"@bufbuild/buf-linux-aarch64": "1.54.0",
+				"@bufbuild/buf-linux-armv7": "1.54.0",
+				"@bufbuild/buf-linux-x64": "1.54.0",
+				"@bufbuild/buf-win32-arm64": "1.54.0",
+				"@bufbuild/buf-win32-x64": "1.54.0"
+			}
+		},
+		"node_modules/@bufbuild/buf-darwin-arm64": {
+			"version": "1.54.0",
+			"resolved": "https://registry.npmjs.org/@bufbuild/buf-darwin-arm64/-/buf-darwin-arm64-1.54.0.tgz",
+			"integrity": "sha512-MkwlxcuHH8YO2wyQ2nGAv5SwBRCR4PtA8zcQb7AR6q93Cgy314ac8blGjfpenprjI3kAAhxc9BQK4t+/hkIS/A==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@bufbuild/buf-darwin-x64": {
+			"version": "1.54.0",
+			"resolved": "https://registry.npmjs.org/@bufbuild/buf-darwin-x64/-/buf-darwin-x64-1.54.0.tgz",
+			"integrity": "sha512-59Z+6BxvVwBbcpLOAwD8TLobngb9YUvUZ1nnP1IyIJnay/tIY+yfmgAdgMwm3VUZlbaFlURGmD34UAwEsxodGQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@bufbuild/buf-linux-aarch64": {
+			"version": "1.54.0",
+			"resolved": "https://registry.npmjs.org/@bufbuild/buf-linux-aarch64/-/buf-linux-aarch64-1.54.0.tgz",
+			"integrity": "sha512-cUbvujfoAQGsnRH/+UfKxt0Hfe6PGHjM/gLiC2Kgv8fcoIWjPJMBBgdl/TLbq1QrVcCXSvMc16hW5ias7Jdyfw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@bufbuild/buf-linux-armv7": {
+			"version": "1.54.0",
+			"resolved": "https://registry.npmjs.org/@bufbuild/buf-linux-armv7/-/buf-linux-armv7-1.54.0.tgz",
+			"integrity": "sha512-xdKjzPsOo6E2eth3uGIRoVG9TpPVHOUucr0MeCRVhM2hb5gbM8KQLn6iDxVGbQFq6eL2qe+B0b8k9HfuwzirWA==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@bufbuild/buf-linux-x64": {
+			"version": "1.54.0",
+			"resolved": "https://registry.npmjs.org/@bufbuild/buf-linux-x64/-/buf-linux-x64-1.54.0.tgz",
+			"integrity": "sha512-ZnfaE5GLAhyvR/ponDgG+s6FbtMEm+RaS2f0EoBLORYC7sK/Elfmw2Q0XcjHyEl83u4hELCqej9T0eUxbgxtow==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@bufbuild/buf-win32-arm64": {
+			"version": "1.54.0",
+			"resolved": "https://registry.npmjs.org/@bufbuild/buf-win32-arm64/-/buf-win32-arm64-1.54.0.tgz",
+			"integrity": "sha512-N5YlX8c6p+KZIWYmx03viYF/FLuY5GyzHgor17nuJUYhF1xFyIJL8v4mhqcQ8Pq0xua9IyRwmSxHJKyrdNatcg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@bufbuild/buf-win32-x64": {
+			"version": "1.54.0",
+			"resolved": "https://registry.npmjs.org/@bufbuild/buf-win32-x64/-/buf-win32-x64-1.54.0.tgz",
+			"integrity": "sha512-PepTA9RcLCjukQhFPFBqKXF9mVwct+ZSBeuLjFuUVcHovdGUZXspNTb5LnuIDjWXx2fcALs0xb/FNUNd6pNjbA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=12"
+			}
 		},
 		"node_modules/@bufbuild/protobuf": {
 			"version": "2.2.5",
@@ -30080,6 +30225,70 @@
 			"resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
 			"integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
 			"dev": true
+		},
+		"@bufbuild/buf": {
+			"version": "1.54.0",
+			"resolved": "https://registry.npmjs.org/@bufbuild/buf/-/buf-1.54.0.tgz",
+			"integrity": "sha512-UkjZmVslA7YAxhUQVxE2O4HX4qD7aMspjkuG3vsjnvmAkiV6Jhz47z3focCuPI28e59H20TiQNhc9Y3fkffWPw==",
+			"dev": true,
+			"requires": {
+				"@bufbuild/buf-darwin-arm64": "1.54.0",
+				"@bufbuild/buf-darwin-x64": "1.54.0",
+				"@bufbuild/buf-linux-aarch64": "1.54.0",
+				"@bufbuild/buf-linux-armv7": "1.54.0",
+				"@bufbuild/buf-linux-x64": "1.54.0",
+				"@bufbuild/buf-win32-arm64": "1.54.0",
+				"@bufbuild/buf-win32-x64": "1.54.0"
+			}
+		},
+		"@bufbuild/buf-darwin-arm64": {
+			"version": "1.54.0",
+			"resolved": "https://registry.npmjs.org/@bufbuild/buf-darwin-arm64/-/buf-darwin-arm64-1.54.0.tgz",
+			"integrity": "sha512-MkwlxcuHH8YO2wyQ2nGAv5SwBRCR4PtA8zcQb7AR6q93Cgy314ac8blGjfpenprjI3kAAhxc9BQK4t+/hkIS/A==",
+			"dev": true,
+			"optional": true
+		},
+		"@bufbuild/buf-darwin-x64": {
+			"version": "1.54.0",
+			"resolved": "https://registry.npmjs.org/@bufbuild/buf-darwin-x64/-/buf-darwin-x64-1.54.0.tgz",
+			"integrity": "sha512-59Z+6BxvVwBbcpLOAwD8TLobngb9YUvUZ1nnP1IyIJnay/tIY+yfmgAdgMwm3VUZlbaFlURGmD34UAwEsxodGQ==",
+			"dev": true,
+			"optional": true
+		},
+		"@bufbuild/buf-linux-aarch64": {
+			"version": "1.54.0",
+			"resolved": "https://registry.npmjs.org/@bufbuild/buf-linux-aarch64/-/buf-linux-aarch64-1.54.0.tgz",
+			"integrity": "sha512-cUbvujfoAQGsnRH/+UfKxt0Hfe6PGHjM/gLiC2Kgv8fcoIWjPJMBBgdl/TLbq1QrVcCXSvMc16hW5ias7Jdyfw==",
+			"dev": true,
+			"optional": true
+		},
+		"@bufbuild/buf-linux-armv7": {
+			"version": "1.54.0",
+			"resolved": "https://registry.npmjs.org/@bufbuild/buf-linux-armv7/-/buf-linux-armv7-1.54.0.tgz",
+			"integrity": "sha512-xdKjzPsOo6E2eth3uGIRoVG9TpPVHOUucr0MeCRVhM2hb5gbM8KQLn6iDxVGbQFq6eL2qe+B0b8k9HfuwzirWA==",
+			"dev": true,
+			"optional": true
+		},
+		"@bufbuild/buf-linux-x64": {
+			"version": "1.54.0",
+			"resolved": "https://registry.npmjs.org/@bufbuild/buf-linux-x64/-/buf-linux-x64-1.54.0.tgz",
+			"integrity": "sha512-ZnfaE5GLAhyvR/ponDgG+s6FbtMEm+RaS2f0EoBLORYC7sK/Elfmw2Q0XcjHyEl83u4hELCqej9T0eUxbgxtow==",
+			"dev": true,
+			"optional": true
+		},
+		"@bufbuild/buf-win32-arm64": {
+			"version": "1.54.0",
+			"resolved": "https://registry.npmjs.org/@bufbuild/buf-win32-arm64/-/buf-win32-arm64-1.54.0.tgz",
+			"integrity": "sha512-N5YlX8c6p+KZIWYmx03viYF/FLuY5GyzHgor17nuJUYhF1xFyIJL8v4mhqcQ8Pq0xua9IyRwmSxHJKyrdNatcg==",
+			"dev": true,
+			"optional": true
+		},
+		"@bufbuild/buf-win32-x64": {
+			"version": "1.54.0",
+			"resolved": "https://registry.npmjs.org/@bufbuild/buf-win32-x64/-/buf-win32-x64-1.54.0.tgz",
+			"integrity": "sha512-PepTA9RcLCjukQhFPFBqKXF9mVwct+ZSBeuLjFuUVcHovdGUZXspNTb5LnuIDjWXx2fcALs0xb/FNUNd6pNjbA==",
+			"dev": true,
+			"optional": true
 		},
 		"@bufbuild/protobuf": {
 			"version": "2.2.5",

--- a/package.json
+++ b/package.json
@@ -336,7 +336,7 @@
 		"watch-tests": "tsc -p . -w --outDir out",
 		"pretest": "npm run compile-tests && npm run compile && npm run compile-standalone && npm run lint",
 		"check-types": "npm run protos && tsc --noEmit",
-		"lint": "eslint src --ext ts && eslint webview-ui/src --ext ts && cd webview-ui && npm run lint",
+		"lint": "eslint src --ext ts && eslint webview-ui/src --ext ts && buf lint && cd webview-ui && npm run lint",
 		"format": "prettier . --check",
 		"format:fix": "prettier . --write",
 		"test": "npm-run-all test:unit test:integration",
@@ -359,6 +359,7 @@
 		"report-issue": "node scripts/report-issue.js"
 	},
 	"devDependencies": {
+		"@bufbuild/buf": "^1.54.0",
 		"@changesets/cli": "^2.27.12",
 		"@types/chai": "^5.0.1",
 		"@types/clone-deep": "^4.0.4",

--- a/proto/host/uri.proto
+++ b/proto/host/uri.proto
@@ -25,12 +25,12 @@ message Uri {
   string path = 3;
   string query = 4;
   string fragment = 5;
-  string fsPath = 6;
+  string fs_path = 6;
 }
 
 // Request for joining path segments to a URI
 message JoinPathRequest {
   cline.Metadata metadata = 1;
   Uri base = 2;
-  repeated string pathSegments = 3;
+  repeated string path_segments = 3;
 }

--- a/proto/models.proto
+++ b/proto/models.proto
@@ -85,8 +85,8 @@ message OpenRouterCompatibleModelInfo {
 // Request for fetching OpenAI models
 message OpenAiModelsRequest {
   Metadata metadata = 1;
-  string baseUrl = 2;
-  string apiKey = 3;
+  string base_url = 2;
+  string api_key = 3;
 }
 
 // Request for updating API configuration

--- a/proto/ui.proto
+++ b/proto/ui.proto
@@ -15,7 +15,7 @@ enum WebviewProviderType {
 // Define a new message type for webview provider info
 message WebviewProviderTypeRequest {
   Metadata metadata = 1;
-  WebviewProviderType providerType = 2;
+  WebviewProviderType provider_type = 2;
 }
 
 // Enum for ClineMessage type


### PR DESCRIPTION
Use the standard lint rules for proto files: snake case field names, snake case file names, pascal case service names etc. 

The existing camel case fields names break the assumption in the standalone app gRPC server that the field names are all snake case: https://github.com/cline/cline/blob/9f605a1f6c925092cf6c2d2898af8f5342364c42/src/standalone/standalone.ts#L62

Add exceptions for the lint rules we are already not following.

Fix linter failures, this only affects the proto files. The generated TS types are the same, so the ts files don't need to be updated.

Linter rules enabled are documented here: https://buf.build/docs/lint/rules/#standard
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add a linter for proto files with standard rules and update proto fields to snake case.
> 
>   - **Linter Addition**:
>     - Adds `buf.yaml` to configure proto file linting with standard rules and specific exceptions.
>     - Integrates `buf lint` into the `lint` script in `package.json`.
>   - **Proto File Updates**:
>     - Renames camel case fields to snake case in `uri.proto`, `models.proto`, and `ui.proto` (e.g., `fsPath` to `fs_path`, `baseUrl` to `base_url`).
>   - **Dependencies**:
>     - Adds `@bufbuild/buf` to `devDependencies` in `package.json`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 518079b56d0d66b77f31d60c909f4eb211851812. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->