### PR TITLE
Solve Terminal running race conditions

### DIFF
--- a/src/integrations/terminal/TerminalManager.ts
+++ b/src/integrations/terminal/TerminalManager.ts
@@ -153,12 +153,16 @@ export class TerminalManager {
 	}
 
 	runCommand(terminalInfo: TerminalInfo, command: string): TerminalProcessResultPromise {
+		console.log(`[TerminalManager] Running command on terminal ${terminalInfo.id}: "${command}"`)
+		console.log(`[TerminalManager] Terminal ${terminalInfo.id} busy state before: ${terminalInfo.busy}`)
+
 		terminalInfo.busy = true
 		terminalInfo.lastCommand = command
 		const process = new TerminalProcess()
 		this.processes.set(terminalInfo.id, process)
 
 		process.once("completed", () => {
+			console.log(`[TerminalManager] Terminal ${terminalInfo.id} completed, setting busy to false`)
 			terminalInfo.busy = false
 		})
 
@@ -220,17 +224,25 @@ export class TerminalManager {
 		const terminals = TerminalRegistry.getAllTerminals()
 
 		// Find available terminal from our pool first (created for this task)
+		console.log(`[TerminalManager] Looking for terminal in cwd: ${cwd}`)
+		console.log(`[TerminalManager] Available terminals: ${terminals.length}`)
+
 		const matchingTerminal = terminals.find((t) => {
 			if (t.busy) {
+				console.log(`[TerminalManager] Terminal ${t.id} is busy, skipping`)
 				return false
 			}
 			const terminalCwd = t.terminal.shellIntegration?.cwd // one of cline's commands could have changed the cwd of the terminal
 			if (!terminalCwd) {
+				console.log(`[TerminalManager] Terminal ${t.id} has no cwd, skipping`)
 				return false
 			}
-			return arePathsEqual(vscode.Uri.file(cwd).fsPath, terminalCwd.fsPath)
+			const matches = arePathsEqual(vscode.Uri.file(cwd).fsPath, terminalCwd.fsPath)
+			console.log(`[TerminalManager] Terminal ${t.id} cwd: ${terminalCwd.fsPath}, matches: ${matches}`)
+			return matches
 		})
 		if (matchingTerminal) {
+			console.log(`[TerminalManager] Found matching terminal ${matchingTerminal.id} in correct cwd`)
 			this.terminalIds.add(matchingTerminal.id)
 			return matchingTerminal
 		}
@@ -246,7 +258,13 @@ export class TerminalManager {
 				})
 
 				// Navigate back to the desired directory
-				await this.runCommand(availableTerminal, `cd "${cwd}"`)
+				const cdProcess = this.runCommand(availableTerminal, `cd "${cwd}"`)
+
+				// Wait for the cd command to complete before proceeding
+				await cdProcess
+
+				// Add a small delay to ensure terminal is ready after cd
+				await new Promise((resolve) => setTimeout(resolve, 100))
 
 				// Either resolve immediately if CWD already updated or wait for event/timeout
 				if (this.isCwdMatchingExpected(availableTerminal)) {


### PR DESCRIPTION
### Related Issue

**Issue:** #3445

### Description

This PR fixes a critical race condition in the terminal process handling that was causing terminal output capture failures, particularly when multiple commands were executed in quick succession.

The main problems addressed:
- Grace period timers from previous commands (especially `cd` commands used for terminal reuse) were interfering with subsequent command executions
- Commands with expected output (like `node --verbose`) would timeout after 3 seconds with "Command is running but producing no output" errors
- Terminal state wasn't properly isolated between command executions
- No proper synchronization when reusing terminals for different working directories

The solution implements proper timer cleanup, state isolation, and synchronization to ensure each command runs without interference from previous executions.

### Test Procedure

**Testing approach:**
1. Tested rapid command execution sequences like:
   - `cd project && node index.js`
   - Followed immediately by `cd "/path/to/dir"` 
   - Then `cd project && node index.js --test-mode production --verbose`

2. Verified the following scenarios:
   - Quick commands (cd, ls, pwd) complete without grace period delays
   - Long-running commands (npm run start) properly use grace period
   - Terminal reuse with directory changes works without race conditions
   - Commands with verbose output are captured correctly
   - No premature auto-continuation from previous command timers

3. Checked edge cases:
   - Commands with no output
   - Commands that fail to execute
   - Rapid terminal reuse scenarios
   - Mixed quick and long-running command sequences

**Confidence:** The comprehensive logging added helps track command execution flow, and the fixes ensure proper isolation between commands. The race condition that was consistently reproducible is now resolved.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

**Before:** Grace period timers from `cd` commands would interfere with subsequent commands
```
[TerminalProcess] Grace period completed - command appears truly finished: "cd "/Users/arafatkhan/Desktop/fetch""
[TerminalProcess] Auto-continuing without user intervention
[TerminalProcess] First chunk timeout fired - no output received within 3s for: "cd project && node index.js --test-mode production --verbose"
```

**After:** Commands execute in isolation without timer interference
```
[TerminalProcess] Cleared existing grace period timer before starting new command
[TerminalProcess] Command appears to have completed immediately, skipping grace period
[TerminalProcess] Starting command: "cd project && node index.js --test-mode production --verbose"
[TerminalProcess] First chunk received for command: "cd project && node index.js --test-mode production --verbose"
```

### Additional Notes

This fix addresses the core race condition issue without implementing the configurable timeout suggested in the original issue. Instead, it uses smart command detection and proper synchronization to handle both quick commands and long-running processes appropriately. The solution is more robust than just increasing timeouts, as it eliminates the root cause of the race condition.

Key improvements:
- Timer cleanup prevents interference between commands
- State reset ensures clean execution environment
- Smart command detection optimizes execution flow
- Terminal synchronization prevents overlapping operations
- Enhanced error handling and logging for debugging
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes terminal command execution race conditions by implementing timer cleanup, state isolation, and synchronization in `TerminalManager.ts` and `TerminalProcess.ts`.
> 
>   - **Behavior**:
>     - Fixes race conditions in terminal command execution by implementing timer cleanup, state isolation, and synchronization in `TerminalManager.ts` and `TerminalProcess.ts`.
>     - Ensures commands run without interference from previous executions, handling quick commands, long-running processes, and terminal reuse.
>   - **Functions**:
>     - `runCommand()` in `TerminalManager.ts` now clears existing timers and resets terminal state before executing new commands.
>     - `run()` in `TerminalProcess.ts` clears grace period and hot timers, resets state, and handles command execution with proper output handling.
>     - `startGracePeriod()` in `TerminalProcess.ts` initiates a grace period to detect command completion.
>   - **Misc**:
>     - Adds logging for command execution flow and error handling in `TerminalProcess.ts`.
>     - Adjusts terminal reuse logic to ensure proper directory changes and command execution in `TerminalManager.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 7d91d39158d3b7e8ab4516441aa398e49ceac7a4. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->