### PR TITLE
Fix error handling for unary handler in the host bridge grpc handler for vscode

### DIFF
--- a/package.json
+++ b/package.json
@@ -331,7 +331,7 @@
 		"watch:tsc": "tsc --noEmit --watch --project tsconfig.json",
 		"package": "npm run check-types && npm run build:webview && npm run lint && node esbuild.js --production",
 		"protos": "node proto/build-proto.js && node scripts/generate-server-setup.mjs",
-		"postprotos": "prettier src/shared/proto src/core/controller src/hosts/ webview-ui/src/services src/standalone/server-setup.ts --write --log-level silent",
+		"postprotos": "prettier src/shared/proto src/core/controller src/hosts/ webview-ui/src/services src/generated --write --log-level warn",
 		"compile-tests": "node ./scripts/build-tests.js",
 		"watch-tests": "tsc -p . -w --outDir out",
 		"pretest": "npm run compile-tests && npm run compile && npm run compile-standalone && npm run lint",

--- a/src/hosts/vscode/client/host-grpc-client-base.ts
+++ b/src/hosts/vscode/client/host-grpc-client-base.ts
@@ -33,10 +33,11 @@ export function createGrpcClient<T extends ProtoService>(service: T): GrpcClient
 	const grpcHandler = new GrpcHandler()
 
 	Object.values(service.methods).forEach((method) => {
+		// Use lowercase method name as the key in the client object
+		const methodKey = method.name.charAt(0).toLowerCase() + method.name.slice(1)
+
 		// Streaming method implementation
 		if (method.responseStream) {
-			// Use lowercase method name as the key in the client object
-			const methodKey = method.name.charAt(0).toLowerCase() + method.name.slice(1)
 			client[methodKey as keyof GrpcClientType<T>] = ((
 				request: any,
 				options: StreamingCallbacks<InstanceType<typeof method.responseType>>,
@@ -75,7 +76,6 @@ export function createGrpcClient<T extends ProtoService>(service: T): GrpcClient
 			}) as any
 		} else {
 			// Unary method implementation
-			const methodKey = method.name.charAt(0).toLowerCase() + method.name.slice(1)
 			client[methodKey as keyof GrpcClientType<T>] = ((request: any) => {
 				return new Promise(async (resolve, reject) => {
 					const requestId = uuidv4()
@@ -84,15 +84,12 @@ export function createGrpcClient<T extends ProtoService>(service: T): GrpcClient
 						const response = await grpcHandler.handleRequest(service.fullName, methodKey, request, requestId)
 						console.log(`[DEBUG] gRPC host resp to ${service.fullName}.${methodKey} req:${requestId}`)
 
-						// Check if the response is a function (streaming) or an object (unary)
+						// Check if the response is a function (streaming)
 						if (typeof response === "function") {
 							// This shouldn't happen for unary requests
 							throw new Error("Received streaming response for unary request")
-						} else if (response && response.message) {
-							resolve(response.message)
-						} else {
-							throw new Error("gRPC response didn't have a message")
 						}
+						resolve(response)
 					} catch (e) {
 						console.log(`[DEBUG] gRPC host ERR to ${service.fullName}.${methodKey} req:${requestId} err:${e}`)
 						reject(e)
@@ -101,6 +98,5 @@ export function createGrpcClient<T extends ProtoService>(service: T): GrpcClient
 			}) as any
 		}
 	})
-
 	return client
 }

--- a/src/hosts/vscode/host-grpc-handler.ts
+++ b/src/hosts/vscode/host-grpc-handler.ts
@@ -1,5 +1,5 @@
 import { v4 as uuidv4 } from "uuid"
-import { hostServiceHandlers } from "./host-grpc-service-config"
+import { HostServiceHandlerConfig, hostServiceHandlers } from "./host-grpc-service-config"
 import { GrpcRequestRegistry } from "@core/controller/grpc-request-registry"
 
 /**
@@ -37,90 +37,71 @@ export class GrpcHandler {
 	async handleRequest<T = any>(
 		service: string,
 		method: string,
-		message: any,
+		request: any,
 		requestId: string,
 		streamingCallbacks?: StreamingCallbacks<T>,
-	): Promise<
-		| {
-				message?: any
-				error?: string
-				request_id: string
-		  }
-		| (() => void)
-	> {
+	): Promise<any | (() => void)> {
+		if (!streamingCallbacks) {
+			return this.handleUnaryRequest(service, method, request)
+		}
+
 		// If streaming callbacks are provided, handle as a streaming request
-		if (streamingCallbacks) {
-			let completionCalled = false
+		let completionCalled = false
 
-			// Create a response handler that will call the client's callbacks
-			const responseHandler: StreamingResponseHandler = async (response, isLast = false, sequenceNumber) => {
-				try {
-					// Call the client's onResponse callback with the response
-					streamingCallbacks.onResponse(response)
-
-					// If this is the last response, call the onComplete callback
-					if (isLast && streamingCallbacks.onComplete && !completionCalled) {
-						completionCalled = true
-						streamingCallbacks.onComplete()
-					}
-				} catch (error) {
-					// If there's an error in the callback, call the onError callback
-					if (streamingCallbacks.onError) {
-						streamingCallbacks.onError(error instanceof Error ? error : new Error(String(error)))
-					}
-				}
-			}
-
-			// Register the response handler with the registry
-			requestRegistry.registerRequest(
-				requestId,
-				() => {
-					console.log(`[DEBUG] Cleaning up streaming request: ${requestId}`)
-					if (streamingCallbacks.onComplete && !completionCalled) {
-						completionCalled = true
-						streamingCallbacks.onComplete()
-					}
-				},
-				{ type: "streaming_request", service, method },
-				responseHandler,
-			)
-
-			// Call the streaming handler directly
-			console.log(`[DEBUG] Streaming gRPC host call to ${service}.${method} req:${requestId}`)
+		// Create a response handler that will call the client's callbacks
+		const responseHandler: StreamingResponseHandler = async (response, isLast = false, sequenceNumber) => {
 			try {
-				await this.handleStreamingRequest(service, method, message, requestId)
+				// Call the client's onResponse callback with the response
+				streamingCallbacks.onResponse(response)
+
+				// If this is the last response, call the onComplete callback
+				if (isLast && streamingCallbacks.onComplete && !completionCalled) {
+					completionCalled = true
+					streamingCallbacks.onComplete()
+				}
 			} catch (error) {
+				// If there's an error in the callback, call the onError callback
 				if (streamingCallbacks.onError) {
 					streamingCallbacks.onError(error instanceof Error ? error : new Error(String(error)))
 				}
 			}
-
-			// Return a function to cancel the stream
-			return () => {
-				console.log(`[DEBUG] Cancelling streaming request: ${requestId}`)
-				this.cancelRequest(requestId)
-			}
 		}
 
-		// Handle as a unary request
+		// Register the response handler with the registry
+		requestRegistry.registerRequest(
+			requestId,
+			() => {
+				console.log(`[DEBUG] Cleaning up streaming request: ${requestId}`)
+				if (streamingCallbacks.onComplete && !completionCalled) {
+					completionCalled = true
+					streamingCallbacks.onComplete()
+				}
+			},
+			{ type: "streaming_request", service, method },
+			responseHandler,
+		)
+
+		// Call the streaming handler directly
+		console.log(`[DEBUG] Streaming gRPC host call to ${service}.${method} req:${requestId}`)
 		try {
-			// Get the service handler from the config
-			const serviceConfig = hostServiceHandlers[service]
-			if (!serviceConfig) {
-				throw new Error(`Unknown service: ${service}`)
-			}
-
-			// Handle unary request
-			return {
-				message: await serviceConfig.requestHandler(method, message),
-				request_id: requestId,
-			}
+			await this.handleStreamingRequest(service, method, request, requestId)
 		} catch (error) {
-			return {
-				error: error instanceof Error ? error.message : String(error),
-				request_id: requestId,
+			if (streamingCallbacks.onError) {
+				streamingCallbacks.onError(error instanceof Error ? error : new Error(String(error)))
 			}
 		}
+
+		// Return a function to cancel the stream
+		return () => {
+			console.log(`[DEBUG] Cancelling streaming request: ${requestId}`)
+			this.cancelRequest(requestId)
+		}
+	}
+
+	private async handleUnaryRequest(service: string, method: string, request: any): Promise<any> {
+		const serviceConfig = this.getServiceHandlerConfig(service)
+		const response = await serviceConfig.requestHandler(method, request)
+		return response
 	}
 
 	/**
@@ -160,11 +141,7 @@ export class GrpcHandler {
 	 * @param requestId The request ID for response correlation
 	 */
 	private async handleStreamingRequest(service: string, method: string, message: any, requestId: string): Promise<void> {
-		// Get the service handler from the config
-		const serviceConfig = hostServiceHandlers[service]
-		if (!serviceConfig) {
-			throw new Error(`Unknown service: ${service}`)
-		}
+		const serviceConfig = this.getServiceHandlerConfig(service)
 
 		// Check if the service supports streaming
 		if (!serviceConfig.streamingHandler) {
@@ -185,6 +162,13 @@ export class GrpcHandler {
 
 		// Don't send a final message here - the stream should stay open for future updates
 		// The stream will be closed when the client disconnects or when the service explicitly ends it
+	}
+
+	private getServiceHandlerConfig(serviceName: string): HostServiceHandlerConfig {
+		if (!(serviceName in hostServiceHandlers)) {
+			throw new Error(`Unknown service: ${serviceName}`)
+		}
+		return hostServiceHandlers[serviceName]
 	}
 }
 


### PR DESCRIPTION
The unary request handler was return a struct like {message: ..., error: ..., requestId: ...}. 

But the caller was only looking at the message field, not the error. 

Simplify the unary handler and just return the response message or throw if there was an error. 

The caller already has the request id, it doesn't need it to be returned from handler.

### Test Procedure

Tested manually in the standalone app and the vscode extension host.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

NA

### Additional Notes

NA
