### PR TITLE
Fix: clineMessages not storing all checkpoints commitHashes

### DIFF
--- a/.changeset/sour-peaches-float.md
+++ b/.changeset/sour-peaches-float.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Fix where clineMessages were not saving checkpoint commitHash on some messages

--- a/src/core/task/index.ts
+++ b/src/core/task/index.ts
@@ -429,6 +429,18 @@ export class Task {
 						vscode.window.showErrorMessage("Failed to restore offsetcheckpoint: " + errorMessage)
 						didWorkspaceRestoreFail = true
 					}
+				} else if (!offset && lastMessageWithHash.lastCheckpointHash && this.checkpointTracker) {
+					// Fallback: restore to most recent checkpoint when target message has no checkpoint hash
+					console.warn(`Message ${messageTs} has no checkpoint hash, falling back to previous checkpoint`)
+					try {
+						await this.checkpointTracker.resetHead(lastMessageWithHash.lastCheckpointHash)
+					} catch (error) {
+						const errorMessage = error instanceof Error ? error.message : "Unknown error"
+						vscode.window.showErrorMessage("Failed to restore checkpoint: " + errorMessage)
+						didWorkspaceRestoreFail = true
+					}
+				} else {
+					vscode.window.showErrorMessage("Failed to restore checkpoint")
 				}
 				break
 		}
@@ -1002,7 +1014,7 @@ export class Task {
 			}
 		}
 
-		await this.initiateTaskLoop(userContent)
+			await this.initiateTaskLoop(userContent)
 	}
 
 	private async resumeTaskFromHistory() {
@@ -1236,23 +1248,44 @@ export class Task {
 				return
 			}
 
-			// For non-attempt completion we just say checkpoints
-			await this.say("checkpoint_created")
-			this.checkpointTracker?.commit().then(async (commitHash) => {
-				const lastCheckpointMessage = findLast(this.clineMessages, (m) => m.say === "checkpoint_created")
-				if (lastCheckpointMessage) {
-					lastCheckpointMessage.lastCheckpointHash = commitHash
-					await saveClineMessagesAndUpdateHistory(
-						this.getContext(),
+			// Initialize checkpoint tracker if it doesn't exist
+			if (!this.checkpointTracker && !this.checkpointTrackerErrorMessage) {
+				try {
+					this.checkpointTracker = await CheckpointTracker.create(
 						this.taskId,
-						this.clineMessages,
-						this.taskIsFavorited ?? false,
-						this.conversationHistoryDeletedRange,
-						this.checkpointTracker,
-						this.updateTaskHistory,
+						this.context.globalStorageUri.fsPath,
+						this.enableCheckpoints,
 					)
+				} catch (error) {
+					const errorMessage = error instanceof Error ? error.message : "Unknown error"
+					console.error("Failed to initialize checkpoint tracker:", errorMessage)
+					this.checkpointTrackerErrorMessage = errorMessage
+					await this.postStateToWebview()
+					return
 				}
-			}) // silently fails for now
+			}
+
+			// Create a checkpoint commit and update clineMessages with a commitHash
+			if (this.checkpointTracker) {
+				const commitHash = await this.checkpointTracker.commit()
+				if (commitHash) {
+					await this.say("checkpoint_created")
+					const lastCheckpointMessage = findLast(this.clineMessages, (m) => m.say === "checkpoint_created")
+						if (lastCheckpointMessage) {
+							lastCheckpointMessage.lastCheckpointHash = commitHash
+							await saveClineMessagesAndUpdateHistory(
+								this.getContext(),
+								this.taskId,
+								this.clineMessages,
+								this.taskIsFavorited ?? false,
+								this.conversationHistoryDeletedRange,
+								this.checkpointTracker,
+								this.updateTaskHistory,
+							)
+						}
+					} 
+				} // silently fails for now
+
 
 			//
 		} else {
@@ -1714,7 +1747,6 @@ export class Task {
 				clineIgnoreInstructions,
 				preferredLanguageInstructions,
 			)
-			console.log("[INSTRUCTIONS] User instructions:", userInstructions)
 			systemPrompt += userInstructions
 		}
 		const contextManagementMetadata = await this.contextManager.getNewContextMessagesAndMetadata(
@@ -4416,8 +4448,8 @@ export class Task {
 		// Now, if it's the first request AND checkpoints are enabled AND tracker was successfully initialized,
 		// then say "checkpoint_created" and perform the commit.
 		if (isFirstRequest && this.enableCheckpoints && this.checkpointTracker) {
-			await this.say("checkpoint_created") // Now this is conditional
 			const commitHash = await this.checkpointTracker.commit() // Actual commit
+			await this.say("checkpoint_created") // Now this is conditional
 			const lastCheckpointMessage = findLast(this.clineMessages, (m) => m.say === "checkpoint_created")
 			if (lastCheckpointMessage) {
 				lastCheckpointMessage.lastCheckpointHash = commitHash

--- a/src/core/task/index.ts
+++ b/src/core/task/index.ts
@@ -1014,7 +1014,7 @@ export class Task {
 			}
 		}
 
-			await this.initiateTaskLoop(userContent)
+		await this.initiateTaskLoop(userContent)
 	}
 
 	private async resumeTaskFromHistory() {
@@ -1271,21 +1271,20 @@ export class Task {
 				if (commitHash) {
 					await this.say("checkpoint_created")
 					const lastCheckpointMessage = findLast(this.clineMessages, (m) => m.say === "checkpoint_created")
-						if (lastCheckpointMessage) {
-							lastCheckpointMessage.lastCheckpointHash = commitHash
-							await saveClineMessagesAndUpdateHistory(
-								this.getContext(),
-								this.taskId,
-								this.clineMessages,
-								this.taskIsFavorited ?? false,
-								this.conversationHistoryDeletedRange,
-								this.checkpointTracker,
-								this.updateTaskHistory,
-							)
-						}
-					} 
-				} // silently fails for now
-
+					if (lastCheckpointMessage) {
+						lastCheckpointMessage.lastCheckpointHash = commitHash
+						await saveClineMessagesAndUpdateHistory(
+							this.getContext(),
+							this.taskId,
+							this.clineMessages,
+							this.taskIsFavorited ?? false,
+							this.conversationHistoryDeletedRange,
+							this.checkpointTracker,
+							this.updateTaskHistory,
+						)
+					}
+				}
+			} // silently fails for now
 
 			//
 		} else {


### PR DESCRIPTION
<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- Opened an issue and discussed your proposed changes with the community / contributors
- Received approval from a core Cline contributor prior to proceeding with the implementation
- Link the associated issue in the "Related Issue" section

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly.

Why this requirement?
We deeply appreciate all community contributions - they are the core reason we're able to operate successfully and keep innovating! We welcome community input and want to make it as easy as possible for people to submit quality work. This process helps our core maintainers review new ideas faster and saves contributor time by ensuring you have the go-ahead before spending time on implementation.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** #XXXX

### Description

This PR fixes an issue where some `checkpoint_created` clineMessages were being saved without a commitHash value. This would result in checkpoint messages that displayed for the user, but when clicked would have no valid commitHash value to use for the resetHead function.

`await this.say("checkpoint_created")` was called before the commit hash was available, causing some checkpoint messages to be saved without their lastCheckpointHash property. The new code now awaits the commit operation first, then creates the checkpoint message with the hash already assigned, ensuring the hash is stored.

Example of what could occur before:
```
    {
        "ts": 1749927579208,
        "type": "say",
        "say": "checkpoint_created",
        "conversationHistoryIndex": 15,
        "isCheckpointCheckedOut": false
    },
    
    // Missing:
    "lastCheckpointHash": "315034cbcc0f095d4aa222cd471584102c542628"
```

This PR also adds an extra check to ensure CheckpointTracker is initialized before performing saveCheckpoint steps, which may be an issue for tasks that are resumed from history if the CheckpointTracker was not initialized for some reason.

### Test Procedure

<!-- 
Please walk us through your testing approach and thought process. This helps reviewers understand that you've thoroughly considered the impact of your changes:

- How did you test this change?
- What could potentially break and how did you verify it doesn't?
- What existing functionality might be affected and how did you check it still works?
- Why are you confident this is ready for merge?

We're not looking for exhaustive documentation - just evidence that you've thought through the implications of your changes and tested accordingly.
-->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [ ] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes missing `commitHash` in `clineMessages` for some checkpoints by ensuring commit operation is awaited before message creation in `Task` class.
> 
>   - **Behavior**:
>     - Fixes issue where `clineMessages` were missing `commitHash` for some `checkpoint_created` messages by awaiting commit operation before message creation in `Task` class.
>     - Adds check to ensure `CheckpointTracker` is initialized before saving checkpoints in `Task` class.
>   - **Misc**:
>     - Adds warning log for missing checkpoint hash and falls back to previous checkpoint in `restoreCheckpoint()` in `Task` class.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 3d3dc246e29607c1fd8eb9f24404d8545935a893. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->