### PR TITLE
Update developer reset to allow for resetting workspace settings.

### DIFF
--- a/.changeset/grumpy-cars-report.md
+++ b/.changeset/grumpy-cars-report.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Update developer reset to allow for resetting workspace settings.

--- a/proto/state.proto
+++ b/proto/state.proto
@@ -13,7 +13,7 @@ service StateService {
   rpc getAvailableTerminalProfiles(EmptyRequest) returns (TerminalProfiles);
   rpc subscribeToState(EmptyRequest) returns (stream State);
   rpc toggleFavoriteModel(StringRequest) returns (Empty);
-  rpc resetState(EmptyRequest) returns (Empty);
+  rpc resetState(ResetStateRequest) returns (Empty);
   rpc togglePlanActMode(TogglePlanActModeRequest) returns (Empty);
   rpc updateAutoApprovalSettings(AutoApprovalSettingsRequest) returns (Empty);
   rpc updateSettings(UpdateSettingsRequest) returns (Empty);
@@ -61,6 +61,10 @@ message ChatContent {
   optional string message = 1;
   repeated string images = 2;
   repeated string files = 3;
+}
+
+message ResetStateRequest {
+  optional bool global = 1;
 }
 
 message AutoApprovalSettingsRequest {

--- a/proto/state.proto
+++ b/proto/state.proto
@@ -64,7 +64,8 @@ message ChatContent {
 }
 
 message ResetStateRequest {
-  optional bool global = 1;
+  Metadata metadata = 1;
+  optional bool global = 2;
 }
 
 message AutoApprovalSettingsRequest {

--- a/src/core/controller/state/resetState.ts
+++ b/src/core/controller/state/resetState.ts
@@ -1,19 +1,25 @@
 import { Controller } from ".."
-import { Empty, EmptyRequest } from "../../../shared/proto/common"
-import { resetExtensionState } from "../../../core/storage/state"
+import { Empty } from "../../../shared/proto/common"
+import { ResetStateRequest } from "../../../shared/proto/state"
+import { resetGlobalState, resetWorkspaceState } from "../../../core/storage/state"
 import * as vscode from "vscode"
 import { sendChatButtonClickedEvent } from "../ui/subscribeToChatButtonClicked"
 
 /**
  * Resets the extension state to its defaults
  * @param controller The controller instance
- * @param request An empty request (no parameters needed)
+ * @param request The reset state request containing the global flag
  * @returns An empty response
  */
-export async function resetState(controller: Controller, request: EmptyRequest): Promise<Empty> {
+export async function resetState(controller: Controller, request: ResetStateRequest): Promise<Empty> {
 	try {
-		vscode.window.showInformationMessage("Resetting state...")
-		await resetExtensionState(controller.context)
+		if (request.global) {
+			vscode.window.showInformationMessage("Resetting global state...")
+			await resetGlobalState(controller.context)
+		} else {
+			vscode.window.showInformationMessage("Resetting workspace state...")
+			await resetWorkspaceState(controller.context)
+		}
 
 		if (controller.task) {
 			controller.task.abortTask()

--- a/src/core/storage/state.ts
+++ b/src/core/storage/state.ts
@@ -650,7 +650,14 @@ export async function updateApiConfiguration(context: vscode.ExtensionContext, a
 	await storeSecret(context, "nebiusApiKey", nebiusApiKey)
 }
 
-export async function resetExtensionState(context: vscode.ExtensionContext) {
+export async function resetWorkspaceState(context: vscode.ExtensionContext) {
+	for (const key of context.workspaceState.keys()) {
+		await context.workspaceState.update(key, undefined)
+	}
+}
+
+export async function resetGlobalState(context: vscode.ExtensionContext) {
+	// TODO: Reset all workspace states?
 	for (const key of context.globalState.keys()) {
 		await context.globalState.update(key, undefined)
 	}

--- a/webview-ui/src/components/settings/SettingsView.tsx
+++ b/webview-ui/src/components/settings/SettingsView.tsx
@@ -7,7 +7,7 @@ import { validateApiConfiguration, validateModelId } from "@/utils/validate"
 import { vscode } from "@/utils/vscode"
 import { ExtensionMessage } from "@shared/ExtensionMessage"
 import { EmptyRequest, StringRequest } from "@shared/proto/common"
-import { PlanActMode, TogglePlanActModeRequest, UpdateSettingsRequest } from "@shared/proto/state"
+import { PlanActMode, ResetStateRequest, TogglePlanActModeRequest, UpdateSettingsRequest } from "@shared/proto/state"
 import { VSCodeButton, VSCodeCheckbox, VSCodeLink, VSCodeTextArea } from "@vscode/webview-ui-toolkit/react"
 import { CheckCheck, FlaskConical, Info, LucideIcon, Settings, SquareMousePointer, SquareTerminal, Webhook } from "lucide-react"
 import { memo, useCallback, useEffect, useRef, useState } from "react"
@@ -406,9 +406,13 @@ const SettingsView = ({ onDone, targetSection }: SettingsViewProps) => {
 
 	useEvent("message", handleMessage)
 
-	const handleResetState = async () => {
+	const handleResetState = async (resetGlobalState?: boolean) => {
 		try {
-			await StateServiceClient.resetState(EmptyRequest.create({}))
+			await StateServiceClient.resetState(
+				ResetStateRequest.create({
+					global: resetGlobalState,
+				}),
+			)
 		} catch (error) {
 			console.error("Failed to reset state:", error)
 		}
@@ -709,10 +713,16 @@ const SettingsView = ({ onDone, targetSection }: SettingsViewProps) => {
 									{renderSectionHeader("debug")}
 									<Section>
 										<VSCodeButton
-											onClick={handleResetState}
+											onClick={() => handleResetState()}
 											className="mt-[5px] w-auto"
 											style={{ backgroundColor: "var(--vscode-errorForeground)", color: "black" }}>
-											Reset State
+											Reset Workspace State
+										</VSCodeButton>
+										<VSCodeButton
+											onClick={() => handleResetState(true)}
+											className="mt-[5px] w-auto"
+											style={{ backgroundColor: "var(--vscode-errorForeground)", color: "black" }}>
+											Reset Global State
 										</VSCodeButton>
 										<p className="text-xs mt-[5px] text-[var(--vscode-descriptionForeground)]">
 											This will reset all global state and secret storage in the extension.


### PR DESCRIPTION
<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- Opened an issue and discussed your proposed changes with the community / contributors
- Received approval from a core Cline contributor prior to proceeding with the implementation
- Link the associated issue in the "Related Issue" section

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly.

Why this requirement?
We deeply appreciate all community contributions - they are the core reason we're able to operate successfully and keep innovating! We welcome community input and want to make it as easy as possible for people to submit quality work. This process helps our core maintainers review new ideas faster and saves contributor time by ensuring you have the go-ahead before spending time on implementation.
-->

### Description

This adds a button to the "developer" settings when running in development mode.  This adds functionality to reset settings for workspace and global settings stores.

### Test Procedure

Build extension in dev mode (run with debugger) and observe that the developer settings has two buttons now for resetting state.  Each should respectively reset the correct state.  Resetting the workspace state will still let you use Cline but the settings specific to the workspace are now cleared.  Resetting the global state will bring you back to the initial screen to sign in for setup your first API Key.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [X] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [X] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [X] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [-] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [X] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [X] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Old Settings:
![image](https://github.com/user-attachments/assets/ed03a1d0-b62c-4373-bdea-324dbb965daa)

New Settings:
![image](https://github.com/user-attachments/assets/611d7ca4-ced4-43ef-927d-0d6332f392b7)

Existing Test Error:
<img width="900" alt="image" src="https://github.com/user-attachments/assets/e471627b-1fbb-44ec-ac40-3f0815413c38" />

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add functionality to reset workspace and global settings separately in developer settings with UI buttons and updated state management.
> 
>   - **Behavior**:
>     - Adds buttons in `SettingsView.tsx` for resetting workspace and global states in developer settings.
>     - `resetState` RPC in `proto/state.proto` now accepts `ResetStateRequest` with a `global` flag.
>     - `resetState.ts` updated to handle `ResetStateRequest` and reset logic for workspace and global states.
>   - **State Management**:
>     - Adds `resetWorkspaceState()` and `resetGlobalState()` functions in `state.ts` to clear respective states.
>   - **UI**:
>     - `SettingsView.tsx` updated to include buttons for resetting workspace and global states in debug mode.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for e4523c1c405704827b9b890b4555e01bb87387dc. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->