### PR TITLE
fix: Prevent reading env variables from the users environment

### DIFF
--- a/.changeset/lazy-cherries-search.md
+++ b/.changeset/lazy-cherries-search.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Prevent reading IS_DEV from the users environment

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -21,7 +21,14 @@
 		"semi": "off",
 		"react-hooks/exhaustive-deps": "off",
 		"eslint-rules/no-protobuf-object-literals": "error",
-		"eslint-rules/no-grpc-client-object-literals": "error"
+		"eslint-rules/no-grpc-client-object-literals": "error",
+		"no-restricted-syntax": [
+			"error",
+			{
+				"selector": "VariableDeclarator[id.type=\"ObjectPattern\"][init.object.name=\"process\"][init.property.name=\"env\"]",
+				"message": "Use process.env.VARIABLE_NAME directly instead of destructuring"
+			}
+		]
 	},
 	"ignorePatterns": ["out", "dist", "**/*.d.ts"]
 }

--- a/esbuild.js
+++ b/esbuild.js
@@ -125,9 +125,11 @@ const baseConfig = {
 	minify: production,
 	sourcemap: !production,
 	logLevel: "silent",
-	define: {
-		"process.env.IS_DEV": JSON.stringify(!production),
-	},
+	define: production
+		? {
+				"process.env.IS_DEV": JSON.stringify(!production),
+			}
+		: undefined,
 	tsconfig: path.resolve(__dirname, "tsconfig.json"),
 	plugins: [
 		copyWasmFiles,

--- a/scripts/build-tests.js
+++ b/scripts/build-tests.js
@@ -34,7 +34,6 @@ const srcConfig = {
 	format: "cjs",
 	platform: "node",
 	define: {
-		"process.env.IS_DEV": "true",
 		"process.env.IS_TEST": "true",
 	},
 	external: ["vscode"],

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -635,7 +635,8 @@ export async function activate(context: vscode.ExtensionContext) {
 //
 // This is a workaround to reload the extension when the source code changes
 // since vscode doesn't support hot reload for extensions
-const { IS_DEV, DEV_WORKSPACE_FOLDER } = process.env
+const IS_DEV = process.env.IS_DEV
+const DEV_WORKSPACE_FOLDER = process.env.DEV_WORKSPACE_FOLDER
 
 // This method is called when your extension is deactivated
 export async function deactivate() {

--- a/webview-ui/.eslintrc.json
+++ b/webview-ui/.eslintrc.json
@@ -27,7 +27,14 @@
 		"prefer-const": "off",
 		"no-extra-semi": "off",
 		"eslint-rules/no-protobuf-object-literals": "error",
-		"eslint-rules/no-grpc-client-object-literals": "error"
+		"eslint-rules/no-grpc-client-object-literals": "error",
+		"no-restricted-syntax": [
+			"error",
+			{
+				"selector": "VariableDeclarator[id.type=\"ObjectPattern\"][init.object.name=\"process\"][init.property.name=\"env\"]",
+				"message": "Use process.env.VARIABLE_NAME directly instead of destructuring"
+			}
+		]
 	},
 	"ignorePatterns": ["build"]
 }

--- a/webview-ui/src/components/chat/task-header/TaskHeader.tsx
+++ b/webview-ui/src/components/chat/task-header/TaskHeader.tsx
@@ -16,7 +16,7 @@ import DeleteTaskButton from "./buttons/DeleteTaskButton"
 import CopyTaskButton from "./buttons/CopyTaskButton"
 import OpenDiskTaskHistoryButton from "./buttons/OpenDiskTaskHistoryButton"
 
-const { IS_DEV } = process.env
+const IS_DEV = process.env.IS_DEV
 
 interface TaskHeaderProps {
 	task: ClineMessage

--- a/webview-ui/src/components/settings/SettingsView.tsx
+++ b/webview-ui/src/components/settings/SettingsView.tsx
@@ -23,7 +23,7 @@ import SectionHeader from "./SectionHeader"
 import TerminalSettingsSection from "./TerminalSettingsSection"
 import { convertApiConfigurationToProtoApiConfiguration } from "@shared/proto-conversions/state/settings-conversion"
 import { convertChatSettingsToProtoChatSettings } from "@shared/proto-conversions/state/chat-settings-conversion"
-const { IS_DEV } = process.env
+const IS_DEV = process.env.IS_DEV
 
 // Styles for the tab system
 const settingsTabsContainer = "flex flex-1 overflow-hidden [&.narrow_.tab-label]:hidden"


### PR DESCRIPTION
### Related Issue

**Issue:** #3888

### Description

We are defining variables using [`esbuild define`](https://esbuild.github.io/api/#define), but `esbuild` isn't replacing them in the output because we destructure them in the code. This PR replaces those definitions with a direct one, so it can be replaced.
Current build output:
```js
var { IS_DEV, DEV_WORKSPACE_FOLDER } = process.env;
async function deactivate() {
  await WebviewProvider.disposeAllInstances();
  await telemetryService.sendCollectedEvents();
  cleanupTestMode();
  await posthogClientProvider.shutdown();
  Logger.log("Cline extension deactivated");
}
if (IS_DEV && IS_DEV !== "false") {
  (0, import_node_assert.default)(DEV_WORKSPACE_FOLDER, "DEV_WORKSPACE_FOLDER must be set in development");
  const watcher = vscode52.workspace.createFileSystemWatcher(new vscode52.RelativePattern(DEV_WORKSPACE_FOLDER, "src/**/*"));
  watcher.onDidChange(({ scheme, path: path68 }) => {
    console.info(`${scheme} ${path68} changed. Reloading VSCode...`);
    vscode52.commands.executeCommand("workbench.action.reloadWindow");
  });
}
```

Build output after the changes:
```js
var IS_DEV = false;
var DEV_WORKSPACE_FOLDER = process.env.DEV_WORKSPACE_FOLDER;
async function deactivate() {
  await WebviewProvider.disposeAllInstances();
  await telemetryService.sendCollectedEvents();
  cleanupTestMode();
  await posthogClientProvider.shutdown();
  Logger.log("Cline extension deactivated");
}
if (IS_DEV && IS_DEV !== "false") {
  (0, import_node_assert.default)(DEV_WORKSPACE_FOLDER, "DEV_WORKSPACE_FOLDER must be set in development");
  const watcher = vscode52.workspace.createFileSystemWatcher(new vscode52.RelativePattern(DEV_WORKSPACE_FOLDER, "src/**/*"));
  watcher.onDidChange(({ scheme, path: path68 }) => {
    console.info(`${scheme} ${path68} changed. Reloading VSCode...`);
    vscode52.commands.executeCommand("workbench.action.reloadWindow");
  });
}
```

### Test Procedure

Compared the outputs and made sure the extension still builds and I can run tasks within it.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fix environment variable replacement by using direct access instead of destructuring and add ESLint rule to prevent destructuring `process.env`.
> 
>   - **Behavior**:
>     - Replace destructured environment variables with direct access in `extension.ts`, `TaskHeader.tsx`, and `SettingsView.tsx`.
>     - Modify `esbuild.js` to define `process.env.IS_DEV` as `false` in production.
>   - **ESLint**:
>     - Add `no-restricted-syntax` rule in `.eslintrc.json` and `webview-ui/.eslintrc.json` to prevent destructuring `process.env`.
>   - **Misc**:
>     - Remove `process.env.IS_DEV` definition from `build-tests.js`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 755cfd803fa259c560a3117428d33b41706d10e5. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->