### PR TITLE
Fixing the context window jump issue for gemini family of models

### DIFF
--- a/src/api/providers/gemini.ts
+++ b/src/api/providers/gemini.ts
@@ -185,7 +185,7 @@ export class GeminiHandler implements ApiHandler {
 				})
 				yield {
 					type: "usage",
-					inputTokens: promptTokens,
+					inputTokens: promptTokens - cacheReadTokens,
 					outputTokens,
 					thoughtsTokenCount,
 					cacheReadTokens,


### PR DESCRIPTION

### Related Issue
No github issue for this 

### Description
The context window for the model used to jump because the cacheread tokens would vary depending on whether the cache was hit or not. We were also doing some sort of double counting with that so this PR fixes it. 

### Test Procedure

Test locally with the debugger and notice that the context window raises incrementally and smoothly.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-    [X] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [X] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [X] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [X] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [X] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->
