### PR TITLE
Create a vscode specific webview provider, and an a generic webview provider class for the standalone service.

### DIFF
--- a/src/core/webview/VscodeWebviewProvider.ts
+++ b/src/core/webview/VscodeWebviewProvider.ts
@@ -15,11 +15,15 @@ https://github.com/KumarVariable/vscode-extension-sidebar-html/blob/master/src/c
 export class VscodeWebviewProvider extends WebviewProvider implements vscode.WebviewViewProvider {
 	public webview?: vscode.WebviewView | vscode.WebviewPanel
 
-	constructor(
+	public static create(
 		context: vscode.ExtensionContext,
 		outputChannel: vscode.OutputChannel,
-		providerType: WebviewProviderType = WebviewProviderType.TAB, // Default to tab provider
+		providerType: WebviewProviderType,
 	) {
+		return new VscodeWebviewProvider(context, outputChannel, providerType)
+	}
+
+	constructor(context: vscode.ExtensionContext, outputChannel: vscode.OutputChannel, providerType: WebviewProviderType) {
 		super(context, outputChannel, providerType)
 	}
 

--- a/src/core/webview/VscodeWebviewProvider.ts
+++ b/src/core/webview/VscodeWebviewProvider.ts
@@ -1,0 +1,177 @@
+import { ExtensionMessage } from "@/shared/ExtensionMessage"
+import { WebviewProviderType } from "@/shared/webview/types"
+import { sendThemeEvent } from "@core/controller/ui/subscribeToTheme"
+import { getTheme } from "@integrations/theme/getTheme"
+import * as vscode from "vscode"
+import { Uri } from "vscode"
+import { WebviewProvider } from "."
+import { sendDidBecomeVisibleEvent } from "../controller/ui/subscribeToDidBecomeVisible"
+
+/*
+https://github.com/microsoft/vscode-webview-ui-toolkit-samples/blob/main/default/weather-webview/src/providers/WeatherViewProvider.ts
+https://github.com/KumarVariable/vscode-extension-sidebar-html/blob/master/src/customSidebarViewProvider.ts
+*/
+
+export class VscodeWebviewProvider extends WebviewProvider implements vscode.WebviewViewProvider {
+	public webview?: vscode.WebviewView | vscode.WebviewPanel
+
+	constructor(
+		context: vscode.ExtensionContext,
+		outputChannel: vscode.OutputChannel,
+		providerType: WebviewProviderType = WebviewProviderType.TAB, // Default to tab provider
+	) {
+		super(context, outputChannel, providerType)
+	}
+
+	override getWebviewUri(uri: Uri) {
+		if (!this.webview) {
+			throw new Error("Webview not initialized")
+		}
+		return this.webview.webview.asWebviewUri(uri)
+	}
+	override getCspSource() {
+		if (!this.webview) {
+			throw new Error("Webview not initialized")
+		}
+		return this.webview.webview.cspSource
+	}
+	override postMessageToWebview(message: ExtensionMessage) {
+		return this.webview?.webview.postMessage(message)
+	}
+	override isVisible() {
+		return this.webview?.visible || false
+	}
+	override getWebview() {
+		return this.webview
+	}
+
+	override async resolveWebviewView(webviewView: vscode.WebviewView | vscode.WebviewPanel) {
+		this.webview = webviewView
+
+		webviewView.webview.options = {
+			// Allow scripts in the webview
+			enableScripts: true,
+			localResourceRoots: [this.context.extensionUri],
+		}
+
+		webviewView.webview.html =
+			this.context.extensionMode === vscode.ExtensionMode.Development
+				? await this.getHMRHtmlContent()
+				: this.getHtmlContent()
+
+		// Sets up an event listener to listen for messages passed from the webview view context
+		// and executes code based on the message that is received
+		this.setWebviewMessageListener(webviewView.webview)
+
+		// Logs show up in bottom panel > Debug Console
+		//console.log("registering listener")
+
+		// Listen for when the panel becomes visible
+		// https://github.com/microsoft/vscode-discussions/discussions/840
+		if ("onDidChangeViewState" in webviewView) {
+			// WebviewView and WebviewPanel have all the same properties except for this visibility listener
+			// panel
+			webviewView.onDidChangeViewState(
+				async () => {
+					if (this.webview?.visible) {
+						await sendDidBecomeVisibleEvent(this.controller.id)
+					}
+				},
+				null,
+				this.disposables,
+			)
+		} else if ("onDidChangeVisibility" in webviewView) {
+			// sidebar
+			webviewView.onDidChangeVisibility(
+				async () => {
+					if (this.webview?.visible) {
+						await sendDidBecomeVisibleEvent(this.controller.id)
+					}
+				},
+				null,
+				this.disposables,
+			)
+		}
+
+		// Listen for when the view is disposed
+		// This happens when the user closes the view or when the view is closed programmatically
+		webviewView.onDidDispose(
+			async () => {
+				await this.dispose()
+			},
+			null,
+			this.disposables,
+		)
+
+		// // if the extension is starting a new session, clear previous task state
+		// this.clearTask()
+		{
+			// Listen for configuration changes
+			vscode.workspace.onDidChangeConfiguration(
+				async (e) => {
+					if (e && e.affectsConfiguration("workbench.colorTheme")) {
+						// Send theme update via gRPC subscription
+						const theme = await getTheme()
+						if (theme) {
+							await sendThemeEvent(JSON.stringify(theme))
+						}
+					}
+					if (e && e.affectsConfiguration("cline.mcpMarketplace.enabled")) {
+						// Update state when marketplace tab setting changes
+						await this.controller.postStateToWebview()
+					}
+				},
+				null,
+				this.disposables,
+			)
+
+			// if the extension is starting a new session, clear previous task state
+			this.controller.clearTask()
+
+			this.outputChannel.appendLine("Webview view resolved")
+
+			// Title setting logic removed to allow VSCode to use the container title primarily.
+		}
+	}
+
+	/**
+	 * Sets up an event listener to listen for messages passed from the webview context and
+	 * executes code based on the message that is received.
+	 *
+	 * IMPORTANT: When passing methods as callbacks in JavaScript/TypeScript, the method's
+	 * 'this' context can be lost. This happens because the method is passed as a
+	 * standalone function reference, detached from its original object.
+	 *
+	 * The Problem:
+	 * Doing: webview.onDidReceiveMessage(this.controller.handleWebviewMessage)
+	 * Would cause 'this' inside handleWebviewMessage to be undefined or wrong,
+	 * leading to "TypeError: this.setUserInfo is not a function"
+	 *
+	 * The Solution:
+	 * We wrap the method call in an arrow function, which:
+	 * 1. Preserves the lexical scope's 'this' binding
+	 * 2. Ensures handleWebviewMessage is called as a method on the controller instance
+	 * 3. Maintains access to all controller methods and properties
+	 *
+	 * Alternative solutions could use .bind() or making handleWebviewMessage an arrow
+	 * function property, but this approach is clean and explicit.
+	 *
+	 * @param webview The webview instance to attach the message listener to
+	 */
+	private setWebviewMessageListener(webview: vscode.Webview) {
+		webview.onDidReceiveMessage(
+			(message) => {
+				this.controller.handleWebviewMessage(message)
+			},
+			null,
+			this.disposables,
+		)
+	}
+
+	override async dispose() {
+		if (this.webview && "dispose" in this.webview) {
+			this.webview.dispose()
+		}
+		super.dispose()
+	}
+}

--- a/src/core/webview/index.ts
+++ b/src/core/webview/index.ts
@@ -1,41 +1,34 @@
 import axios from "axios"
 import * as vscode from "vscode"
 import { getNonce } from "./getNonce"
-import { getTheme } from "@integrations/theme/getTheme"
+
+import { WebviewProviderType } from "@/shared/webview/types"
 import { Controller } from "@core/controller/index"
 import { findLast } from "@shared/array"
 import { readFile } from "fs/promises"
 import path from "node:path"
-import { WebviewProviderType } from "@/shared/webview/types"
-import { sendThemeEvent } from "@core/controller/ui/subscribeToTheme"
 import { v4 as uuidv4 } from "uuid"
-import { sendDidBecomeVisibleEvent } from "../controller/ui/subscribeToDidBecomeVisible"
 import { Uri } from "vscode"
+import { ExtensionMessage } from "@/shared/ExtensionMessage"
 
-/*
-https://github.com/microsoft/vscode-webview-ui-toolkit-samples/blob/main/default/weather-webview/src/providers/WeatherViewProvider.ts
-https://github.com/KumarVariable/vscode-extension-sidebar-html/blob/master/src/customSidebarViewProvider.ts
-*/
-
-export class WebviewProvider implements vscode.WebviewViewProvider {
+export abstract class WebviewProvider {
 	public static readonly sideBarId = "claude-dev.SidebarProvider" // used in package.json as the view's id. This value cannot be changed due to how vscode caches views based on their id, and updating the id would break existing instances of the extension.
 	public static readonly tabPanelId = "claude-dev.TabPanelProvider"
 	private static activeInstances: Set<WebviewProvider> = new Set()
 	private static clientIdMap = new Map<WebviewProvider, string>()
-	public view?: vscode.WebviewView | vscode.WebviewPanel
-	private disposables: vscode.Disposable[] = []
+	protected disposables: vscode.Disposable[] = []
 	controller: Controller
 	private clientId: string
 
 	constructor(
 		readonly context: vscode.ExtensionContext,
-		private readonly outputChannel: vscode.OutputChannel,
-		private readonly providerType: WebviewProviderType = WebviewProviderType.TAB, // Default to tab provider
+		protected readonly outputChannel: vscode.OutputChannel,
+		private readonly providerType: WebviewProviderType,
 	) {
 		WebviewProvider.activeInstances.add(this)
 		this.clientId = uuidv4()
 		WebviewProvider.clientIdMap.set(this, this.clientId)
-		this.controller = new Controller(context, outputChannel, (message) => this.view?.webview.postMessage(message))
+		this.controller = new Controller(context, outputChannel, (message) => this.postMessageToWebview(message))
 	}
 
 	// Add a method to get the client ID
@@ -49,9 +42,6 @@ export class WebviewProvider implements vscode.WebviewViewProvider {
 	}
 
 	async dispose() {
-		if (this.view && "dispose" in this.view) {
-			this.view.dispose()
-		}
 		while (this.disposables.length) {
 			const x = this.disposables.pop()
 			if (x) {
@@ -65,7 +55,7 @@ export class WebviewProvider implements vscode.WebviewViewProvider {
 	}
 
 	public static getVisibleInstance(): WebviewProvider | undefined {
-		return findLast(Array.from(this.activeInstances), (instance) => instance.view?.visible === true)
+		return findLast(Array.from(this.activeInstances), (instance) => instance.isVisible() === true)
 	}
 
 	public static getAllInstances(): WebviewProvider[] {
@@ -73,11 +63,15 @@ export class WebviewProvider implements vscode.WebviewViewProvider {
 	}
 
 	public static getSidebarInstance() {
-		return Array.from(this.activeInstances).find((instance) => instance.view && "onDidChangeVisibility" in instance.view)
+		return Array.from(this.activeInstances).find(
+			(instance) => instance.getWebview() && "onDidChangeVisibility" in instance.getWebview(),
+		)
 	}
 
 	public static getTabInstances(): WebviewProvider[] {
-		return Array.from(this.activeInstances).filter((instance) => instance.view && "onDidChangeViewState" in instance.view)
+		return Array.from(this.activeInstances).filter(
+			(instance) => instance.getWebview() && "onDidChangeViewState" in instance.getWebview(),
+		)
 	}
 
 	public static async disposeAllInstances() {
@@ -87,94 +81,13 @@ export class WebviewProvider implements vscode.WebviewViewProvider {
 		}
 	}
 
-	async resolveWebviewView(webviewView: vscode.WebviewView | vscode.WebviewPanel) {
-		this.view = webviewView
+	abstract resolveWebviewView(webviewView: vscode.WebviewView | vscode.WebviewPanel): Promise<void>
+	abstract postMessageToWebview(message: ExtensionMessage): Thenable<boolean> | undefined
+	abstract getWebview(): any
 
-		webviewView.webview.options = {
-			// Allow scripts in the webview
-			enableScripts: true,
-			localResourceRoots: [this.context.extensionUri],
-		}
-
-		webviewView.webview.html =
-			this.context.extensionMode === vscode.ExtensionMode.Development
-				? await this.getHMRHtmlContent(webviewView.webview)
-				: this.getHtmlContent(webviewView.webview)
-
-		// Sets up an event listener to listen for messages passed from the webview view context
-		// and executes code based on the message that is received
-		this.setWebviewMessageListener(webviewView.webview)
-
-		// Logs show up in bottom panel > Debug Console
-		//console.log("registering listener")
-
-		// Listen for when the panel becomes visible
-		// https://github.com/microsoft/vscode-discussions/discussions/840
-		if ("onDidChangeViewState" in webviewView) {
-			// WebviewView and WebviewPanel have all the same properties except for this visibility listener
-			// panel
-			webviewView.onDidChangeViewState(
-				async () => {
-					if (this.view?.visible) {
-						await sendDidBecomeVisibleEvent(this.controller.id)
-					}
-				},
-				null,
-				this.disposables,
-			)
-		} else if ("onDidChangeVisibility" in webviewView) {
-			// sidebar
-			webviewView.onDidChangeVisibility(
-				async () => {
-					if (this.view?.visible) {
-						await sendDidBecomeVisibleEvent(this.controller.id)
-					}
-				},
-				null,
-				this.disposables,
-			)
-		}
-
-		// Listen for when the view is disposed
-		// This happens when the user closes the view or when the view is closed programmatically
-		webviewView.onDidDispose(
-			async () => {
-				await this.dispose()
-			},
-			null,
-			this.disposables,
-		)
-
-		// // if the extension is starting a new session, clear previous task state
-		// this.clearTask()
-		{
-			// Listen for configuration changes
-			vscode.workspace.onDidChangeConfiguration(
-				async (e) => {
-					if (e && e.affectsConfiguration("workbench.colorTheme")) {
-						// Send theme update via gRPC subscription
-						const theme = await getTheme()
-						if (theme) {
-							await sendThemeEvent(JSON.stringify(theme))
-						}
-					}
-					if (e && e.affectsConfiguration("cline.mcpMarketplace.enabled")) {
-						// Update state when marketplace tab setting changes
-						await this.controller.postStateToWebview()
-					}
-				},
-				null,
-				this.disposables,
-			)
-
-			// if the extension is starting a new session, clear previous task state
-			this.controller.clearTask()
-
-			this.outputChannel.appendLine("Webview view resolved")
-
-			// Title setting logic removed to allow VSCode to use the container title primarily.
-		}
-	}
+	abstract getWebviewUri(uri: Uri): Uri
+	abstract getCspSource(): string
+	abstract isVisible(): boolean
 
 	/**
 	 * Defines and returns the HTML that should be rendered within the webview panel.
@@ -187,7 +100,7 @@ export class WebviewProvider implements vscode.WebviewViewProvider {
 	 * @returns A template string literal containing the HTML that should be
 	 * rendered within the webview panel
 	 */
-	private getHtmlContent(webview: vscode.Webview): string {
+	public getHtmlContent(): string {
 		// Get the local path to main script run in the webview,
 		// then convert it to a uri we can use in the webview.
 
@@ -236,7 +149,12 @@ export class WebviewProvider implements vscode.WebviewViewProvider {
 				<link rel="stylesheet" type="text/css" href="${stylesUri}">
 				<link href="${codiconsUri}" rel="stylesheet" />
 				<link href="${katexCssUri}" rel="stylesheet" />
-				<meta http-equiv="Content-Security-Policy" content="default-src 'none'; connect-src https://*.posthog.com https://*.firebaseauth.com https://*.firebaseio.com https://*.googleapis.com https://*.firebase.com; font-src ${webview.cspSource} data:; style-src ${webview.cspSource} 'unsafe-inline'; img-src ${webview.cspSource} https: data:; script-src 'nonce-${nonce}' 'unsafe-eval';">
+				<meta http-equiv="Content-Security-Policy" content="default-src 'none';
+					connect-src https://*.posthog.com https://*.firebaseauth.com https://*.firebaseio.com https://*.googleapis.com https://*.firebase.com; 
+					font-src ${this.getCspSource()} data:; 
+					style-src ${this.getCspSource()} 'unsafe-inline'; 
+					img-src ${this.getCspSource()} https: data:; 
+					script-src 'nonce-${nonce}' 'unsafe-eval';">
 				<title>Cline</title>
 			</head>
 			<body>
@@ -287,7 +205,7 @@ export class WebviewProvider implements vscode.WebviewViewProvider {
 	 * @returns A template string literal containing the HTML that should be
 	 * rendered within the webview panel
 	 */
-	private async getHMRHtmlContent(webview: vscode.Webview): Promise<string> {
+	protected async getHMRHtmlContent(): Promise<string> {
 		const localPort = await this.getDevServerPort()
 		const localServerUrl = `localhost:${localPort}`
 
@@ -299,7 +217,7 @@ export class WebviewProvider implements vscode.WebviewViewProvider {
 				"Cline: Local webview dev server is not running, HMR will not work. Please run 'npm run dev:webview' before launching the extension to enable HMR. Using bundled assets.",
 			)
 
-			return this.getHtmlContent(webview)
+			return this.getHtmlContent()
 		}
 
 		const nonce = getNonce()
@@ -324,9 +242,9 @@ export class WebviewProvider implements vscode.WebviewViewProvider {
 
 		const csp = [
 			"default-src 'none'",
-			`font-src ${webview.cspSource} data:`,
-			`style-src ${webview.cspSource} 'unsafe-inline' https://* http://${localServerUrl} http://0.0.0.0:${localPort}`,
-			`img-src ${webview.cspSource} https: data:`,
+			`font-src ${this.getCspSource()} data:`,
+			`style-src ${this.getCspSource()} 'unsafe-inline' https://* http://${localServerUrl} http://0.0.0.0:${localPort}`,
+			`img-src ${this.getCspSource()} https: data:`,
 			`script-src 'unsafe-eval' https://* http://${localServerUrl} http://0.0.0.0:${localPort} 'nonce-${nonce}'`,
 			`connect-src https://* ws://${localServerUrl} ws://0.0.0.0:${localPort} http://${localServerUrl} http://0.0.0.0:${localPort}`,
 		]
@@ -359,40 +277,6 @@ export class WebviewProvider implements vscode.WebviewViewProvider {
 			</html>
 		`
 	}
-
-	/**
-	 * Sets up an event listener to listen for messages passed from the webview context and
-	 * executes code based on the message that is received.
-	 *
-	 * IMPORTANT: When passing methods as callbacks in JavaScript/TypeScript, the method's
-	 * 'this' context can be lost. This happens because the method is passed as a
-	 * standalone function reference, detached from its original object.
-	 *
-	 * The Problem:
-	 * Doing: webview.onDidReceiveMessage(this.controller.handleWebviewMessage)
-	 * Would cause 'this' inside handleWebviewMessage to be undefined or wrong,
-	 * leading to "TypeError: this.setUserInfo is not a function"
-	 *
-	 * The Solution:
-	 * We wrap the method call in an arrow function, which:
-	 * 1. Preserves the lexical scope's 'this' binding
-	 * 2. Ensures handleWebviewMessage is called as a method on the controller instance
-	 * 3. Maintains access to all controller methods and properties
-	 *
-	 * Alternative solutions could use .bind() or making handleWebviewMessage an arrow
-	 * function property, but this approach is clean and explicit.
-	 *
-	 * @param webview The webview instance to attach the message listener to
-	 */
-	private setWebviewMessageListener(webview: vscode.Webview) {
-		webview.onDidReceiveMessage(
-			(message) => {
-				this.controller.handleWebviewMessage(message)
-			},
-			null,
-			this.disposables,
-		)
-	}
 	/**
 	 * A helper function which will get the webview URI of a given file or resource in the extension directory.
 	 *
@@ -403,9 +287,9 @@ export class WebviewProvider implements vscode.WebviewViewProvider {
 	 * @returns A URI pointing to the file/resource
 	 */
 	private getExtensionUri(...pathList: string[]): Uri {
-		if (!this.view) {
+		if (!this.getWebview()) {
 			throw Error("webview is not initialized.")
 		}
-		return this.view.webview.asWebviewUri(Uri.joinPath(this.context.extensionUri, ...pathList))
+		return this.getWebviewUri(Uri.joinPath(this.context.extensionUri, ...pathList))
 	}
 }

--- a/src/core/webview/index.ts
+++ b/src/core/webview/index.ts
@@ -81,12 +81,49 @@ export abstract class WebviewProvider {
 		}
 	}
 
+	/**
+	 * Initializes and sets up the webview when it's first created.
+	 *
+	 * @param webviewView - The webview view or panel instance to be resolved
+	 * @returns A promise that resolves when the webview has been fully initialized
+	 */
 	abstract resolveWebviewView(webviewView: vscode.WebviewView | vscode.WebviewPanel): Promise<void>
+
+	/**
+	 * Sends a message from the extension to the webview.
+	 *
+	 * @param message - The message to send to the webview
+	 * @returns A thenable that resolves to a boolean indicating success, or undefined if the webview is not available
+	 */
 	abstract postMessageToWebview(message: ExtensionMessage): Thenable<boolean> | undefined
+
+	/**
+	 * Gets the current webview instance.
+	 *
+	 * @returns The webview instance (WebviewView, WebviewPanel, or similar)
+	 */
 	abstract getWebview(): any
 
+	/**
+	 * Converts a local URI to a webview URI that can be used within the webview.
+	 *
+	 * @param uri - The local URI to convert
+	 * @returns A URI that can be used within the webview
+	 */
 	abstract getWebviewUri(uri: Uri): Uri
+
+	/**
+	 * Gets the Content Security Policy source for the webview.
+	 *
+	 * @returns The CSP source string to be used in the webview's Content-Security-Policy
+	 */
 	abstract getCspSource(): string
+
+	/**
+	 * Checks if the webview is currently visible to the user.
+	 *
+	 * @returns True if the webview is visible, false otherwise
+	 */
 	abstract isVisible(): boolean
 
 	/**

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -642,12 +642,7 @@ export async function activate(context: vscode.ExtensionContext) {
 function maybeSetupHostProviders() {
 	if (!hostProviders.isSetup) {
 		console.log("Setting up vscode host providers...")
-		const webviewCreator = (
-			context: vscode.ExtensionContext,
-			outputChannel: vscode.OutputChannel,
-			type: WebviewProviderType | undefined,
-		) => new VscodeWebviewProvider(context, outputChannel, type)
-		hostProviders.initializeHostProviders(webviewCreator, vscodeHostBridgeClient)
+		hostProviders.initializeHostProviders(VscodeWebviewProvider.create, vscodeHostBridgeClient)
 	}
 }
 

--- a/src/hosts/host-providers.ts
+++ b/src/hosts/host-providers.ts
@@ -1,12 +1,40 @@
+import { WebviewProvider } from "@core/webview"
 import { HostBridgeClientProvider } from "./host-provider-types"
+import { WebviewProviderType } from "@/shared/webview/types"
+import * as vscode from "vscode"
 
+/**
+ * A function that creates WebviewProvider instances
+ */
+export type WebviewProviderCreator = (
+	context: vscode.ExtensionContext,
+	outputChannel: vscode.OutputChannel,
+	providerType: WebviewProviderType,
+) => WebviewProvider
+
+let _webviewProviderCreator: WebviewProviderCreator | undefined
 let _hostBridgeProvider: HostBridgeClientProvider | undefined
 
 export var isSetup: boolean = false
 
-export function initializeHostProviders(hostBridgeProvider: HostBridgeClientProvider) {
+export function initializeHostProviders(
+	webviewProviderCreator: WebviewProviderCreator,
+	hostBridgeProvider: HostBridgeClientProvider,
+) {
+	_webviewProviderCreator = webviewProviderCreator
 	_hostBridgeProvider = hostBridgeProvider
 	isSetup = true
+}
+
+export function createWebviewProvider(
+	context: vscode.ExtensionContext,
+	outputChannel: vscode.OutputChannel,
+	providerType: WebviewProviderType,
+): WebviewProvider {
+	if (!_webviewProviderCreator) {
+		throw Error("Host providers not initialized")
+	}
+	return _webviewProviderCreator(context, outputChannel, providerType)
 }
 
 export function getHostBridgeProvider(): HostBridgeClientProvider {

--- a/src/standalone/ExternalWebviewProvider.ts
+++ b/src/standalone/ExternalWebviewProvider.ts
@@ -1,0 +1,52 @@
+import { ExtensionMessage } from "@/shared/ExtensionMessage"
+import { WebviewProviderType } from "@/shared/webview/types"
+import { sendThemeEvent } from "@core/controller/ui/subscribeToTheme"
+import { getTheme } from "@integrations/theme/getTheme"
+import * as vscode from "vscode"
+import { Uri } from "vscode"
+import { WebviewProvider } from "@core/webview"
+
+/*
+https://github.com/microsoft/vscode-webview-ui-toolkit-samples/blob/main/default/weather-webview/src/providers/WeatherViewProvider.ts
+https://github.com/KumarVariable/vscode-extension-sidebar-html/blob/master/src/customSidebarViewProvider.ts
+*/
+
+export class ExternalWebviewProvider extends WebviewProvider {
+	public webview?: vscode.WebviewView | vscode.WebviewPanel
+
+	public static create(
+		context: vscode.ExtensionContext,
+		outputChannel: vscode.OutputChannel,
+		providerType: WebviewProviderType,
+	) {
+		return new ExternalWebviewProvider(context, outputChannel, providerType)
+	}
+
+	constructor(context: vscode.ExtensionContext, outputChannel: vscode.OutputChannel, providerType: WebviewProviderType) {
+		super(context, outputChannel, providerType)
+	}
+
+	override getWebviewUri(uri: Uri) {
+		return uri.with({
+			scheme: "http",
+			authority: "resources",
+		})
+	}
+	override getCspSource() {
+		return "csp-source"
+	}
+	override postMessageToWebview(message: ExtensionMessage) {
+		console.log(`postMessageToWebview: ${message}`)
+		return undefined
+	}
+	override isVisible() {
+		return true
+	}
+	override getWebview() {
+		return {}
+	}
+
+	override resolveWebviewView(_: vscode.WebviewView | vscode.WebviewPanel): Promise<void> {
+		return Promise.resolve()
+	}
+}

--- a/src/standalone/standalone.ts
+++ b/src/standalone/standalone.ts
@@ -10,10 +10,12 @@ import { GrpcHandler, GrpcStreamingResponseHandler } from "./grpc-types"
 import { addProtobusServices } from "@generated/standalone/server-setup"
 import { StreamingResponseHandler } from "@/core/controller/grpc-handler"
 import { ExternalHostBridgeClientManager } from "./host-bridge-client-manager"
+import { ExternalWebviewProvider } from "./ExternalWebviewProvider"
 
 async function main() {
-	log("Starting service...")
-	hostProviders.initializeHostProviders(new ExternalHostBridgeClientManager())
+	log("Starting standalone service...")
+
+	hostProviders.initializeHostProviders(ExternalWebviewProvider.create, new ExternalHostBridgeClientManager())
 	activate(extensionContext)
 	const controller = new Controller(extensionContext, outputChannel, postMessage)
 	const server = new grpc.Server()


### PR DESCRIPTION
Add a generic WebviewProvider class that is not tied to the vscode SDK.
Move all the vscode specific parts of the webview provider into the VscodeWebviewProvider.
Update extension.ts to use the generic webview provider class.

Create an ExternalWebviewProvider for the standalone service.
The external webview provider will be used to generate html for external clients.

### Test Procedure

Tested manually in the vscode extension host and the standalone app.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

NA

### Additional Notes

NA

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Introduce a generic `WebviewProvider` class with specific implementations for VSCode and standalone services, updating webview handling across the codebase.
> 
>   - **Webview Providers**:
>     - Introduce `WebviewProvider` abstract class in `index.ts` for generic webview handling.
>     - Create `VscodeWebviewProvider` in `VscodeWebviewProvider.ts` for VSCode-specific webview logic.
>     - Create `ExternalWebviewProvider` in `ExternalWebviewProvider.ts` for standalone service webview logic.
>   - **Extension Changes**:
>     - Update `extension.ts` to use `hostProviders.createWebviewProvider()` for webview creation.
>     - Modify `maybeSetupHostProviders()` to initialize with `VscodeWebviewProvider.create`.
>   - **Standalone Service**:
>     - Update `standalone.ts` to initialize with `ExternalWebviewProvider.create` for webview handling.
>   - **Host Providers**:
>     - Add `WebviewProviderCreator` type and `createWebviewProvider()` function in `host-providers.ts` for dynamic webview provider creation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 2e038c399720ab63b88d55af33198f51ffc8f922. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->