### PR TITLE
Support external webview 

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -50,10 +50,11 @@
 			"outFiles": ["${workspaceFolder}/dist-standalone/**/*.js"],
 			"preLaunchTask": "compile-standalone",
 			"env": {
-				"GRPC_TRACE": "all",
-				"GRPC_VERBOSITY": "DEBUG",
+				// Turns on grpc debug log.
+				//"GRPC_TRACE": "all",
+				//"GRPC_VERBOSITY": "DEBUG",
 				"NODE_PATH": "${workspaceFolder}/dist-standalone/node_modules",
-				"CLINE_DIR": "${userHome}/.cline-standalone",
+
 				"HOST_BRIDGE_ADDRESS": "localhost:50052"
 			},
 			"program": "standalone.js"

--- a/proto/ui.proto
+++ b/proto/ui.proto
@@ -262,4 +262,7 @@ service UiService {
   
   // Subscribe to webview visibility change events
   rpc subscribeToDidBecomeVisible(EmptyRequest) returns (stream Empty);
+
+  // Returns the HTML for the webview index page. This is only used by external clients, not by the vscode webview.
+  rpc getWebviewHtml(EmptyRequest) returns (String);
 }

--- a/scripts/package-standalone.mjs
+++ b/scripts/package-standalone.mjs
@@ -56,13 +56,24 @@ archive.glob("**/*", {
 
 // Add the whole cline directory under "extension"
 archive.directory(process.cwd(), "extension", (entry) => {
-	// Skip certain directories
-	if (
-		entry.name.startsWith(BUILD_DIR + "/") ||
-		entry.name.startsWith("node_modules/") || // node_modules nearly 1GB.
-		entry.name.startsWith("webview-ui/node_modules/") || // node_modules nearly 1GB.
-		entry.name.match(/(^|\/)\./) // exclude dot directories
-	) {
+	// Skip certain directories.
+	const exclude = [
+		BUILD_DIR + "/",
+		"node_modules/", // node_modules nearly 1GB.
+		"webview-ui/node_modules/", // node_modules nearly 1GB.
+	]
+	// These node modules are used at runtime as assets, they need to be included.
+	const include = ["node_modules/@vscode/", "webview-ui/node_modules/katex"]
+	const name = entry.name
+
+	if (include.some((prefix) => name.startsWith(prefix))) {
+		return entry
+	}
+	if (exclude.some((prefix) => name.startsWith(prefix))) {
+		return false
+	}
+	if (name.match(/(^|\/)\./)) {
+		// exclude dot directories
 		return false
 	}
 	return entry

--- a/src/core/controller/ui/getWebviewHtml.ts
+++ b/src/core/controller/ui/getWebviewHtml.ts
@@ -1,0 +1,16 @@
+import type { Controller } from "../index"
+import { EmptyRequest, Empty, String } from "@shared/proto/common"
+import * as hostProviders from "@hosts/host-providers"
+import { WebviewProviderType } from "@/shared/webview/types"
+
+/**
+ * Initialize webview when it launches
+ * @param controller The controller instance
+ * @param request The empty request
+ * @returns Empty response
+ */
+export async function getWebviewHtml(_controller: Controller, _: EmptyRequest): Promise<String> {
+	const webviewProvider = hostProviders.createWebviewProvider(WebviewProviderType.SIDEBAR)
+
+	return Promise.resolve(String.create({ value: webviewProvider.getHtmlContent() }))
+}

--- a/src/core/webview/VscodeWebviewProvider.ts
+++ b/src/core/webview/VscodeWebviewProvider.ts
@@ -15,14 +15,6 @@ https://github.com/KumarVariable/vscode-extension-sidebar-html/blob/master/src/c
 export class VscodeWebviewProvider extends WebviewProvider implements vscode.WebviewViewProvider {
 	public webview?: vscode.WebviewView | vscode.WebviewPanel
 
-	public static create(
-		context: vscode.ExtensionContext,
-		outputChannel: vscode.OutputChannel,
-		providerType: WebviewProviderType,
-	) {
-		return new VscodeWebviewProvider(context, outputChannel, providerType)
-	}
-
 	constructor(context: vscode.ExtensionContext, outputChannel: vscode.OutputChannel, providerType: WebviewProviderType) {
 		super(context, outputChannel, providerType)
 	}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -29,6 +29,7 @@ import { FileContextTracker } from "./core/context/context-tracking/FileContextT
 import * as hostProviders from "@hosts/host-providers"
 import { vscodeHostBridgeClient } from "@/hosts/vscode/client/host-grpc-client"
 import { VscodeWebviewProvider } from "./core/webview/VscodeWebviewProvider"
+import { ExtensionContext } from "vscode"
 
 /*
 Built using https://github.com/microsoft/vscode-webview-ui-toolkit
@@ -51,7 +52,7 @@ export async function activate(context: vscode.ExtensionContext) {
 	Logger.initialize(outputChannel)
 	Logger.log("Cline extension activated")
 
-	maybeSetupHostProviders()
+	maybeSetupHostProviders(context)
 
 	// Migrate global storage values to workspace storage (one-time cleanup)
 	await migratePlanActGlobalToWorkspaceStorage(context)
@@ -65,7 +66,7 @@ export async function activate(context: vscode.ExtensionContext) {
 	// Version checking for autoupdate notification
 	const currentVersion = context.extension.packageJSON.version
 	const previousVersion = context.globalState.get<string>("clineVersion")
-	const sidebarWebview = hostProviders.createWebviewProvider(context, outputChannel, WebviewProviderType.SIDEBAR)
+	const sidebarWebview = hostProviders.createWebviewProvider(WebviewProviderType.SIDEBAR)
 
 	// Initialize test mode and add disposables to context
 	context.subscriptions.push(...initializeTestMode(context, sidebarWebview))
@@ -154,7 +155,7 @@ export async function activate(context: vscode.ExtensionContext) {
 		Logger.log("Opening Cline in new tab")
 		// (this example uses webviewProvider activation event which is necessary to deserialize cached webview, but since we use retainContextWhenHidden, we don't need to use that event)
 		// https://github.com/microsoft/vscode-extension-samples/blob/main/webview-sample/src/extension.ts
-		const tabWebview = hostProviders.createWebviewProvider(context, outputChannel, WebviewProviderType.TAB)
+		const tabWebview = hostProviders.createWebviewProvider(WebviewProviderType.TAB)
 		//const column = vscode.window.activeTextEditor ? vscode.window.activeTextEditor.viewColumn : undefined
 		const lastCol = Math.max(...vscode.window.visibleTextEditors.map((editor) => editor.viewColumn || 0))
 
@@ -639,10 +640,13 @@ export async function activate(context: vscode.ExtensionContext) {
 	return createClineAPI(outputChannel, sidebarWebview.controller)
 }
 
-function maybeSetupHostProviders() {
+function maybeSetupHostProviders(context: ExtensionContext) {
 	if (!hostProviders.isSetup) {
 		console.log("Setting up vscode host providers...")
-		hostProviders.initializeHostProviders(VscodeWebviewProvider.create, vscodeHostBridgeClient)
+		const createWebview = function (type: WebviewProviderType) {
+			return new VscodeWebviewProvider(context, outputChannel, type)
+		}
+		hostProviders.initializeHostProviders(createWebview, vscodeHostBridgeClient)
 	}
 }
 

--- a/src/hosts/host-providers.ts
+++ b/src/hosts/host-providers.ts
@@ -6,11 +6,7 @@ import * as vscode from "vscode"
 /**
  * A function that creates WebviewProvider instances
  */
-export type WebviewProviderCreator = (
-	context: vscode.ExtensionContext,
-	outputChannel: vscode.OutputChannel,
-	providerType: WebviewProviderType,
-) => WebviewProvider
+export type WebviewProviderCreator = (providerType: WebviewProviderType) => WebviewProvider
 
 let _webviewProviderCreator: WebviewProviderCreator | undefined
 let _hostBridgeProvider: HostBridgeClientProvider | undefined
@@ -26,15 +22,11 @@ export function initializeHostProviders(
 	isSetup = true
 }
 
-export function createWebviewProvider(
-	context: vscode.ExtensionContext,
-	outputChannel: vscode.OutputChannel,
-	providerType: WebviewProviderType,
-): WebviewProvider {
+export function createWebviewProvider(providerType: WebviewProviderType): WebviewProvider {
 	if (!_webviewProviderCreator) {
 		throw Error("Host providers not initialized")
 	}
-	return _webviewProviderCreator(context, outputChannel, providerType)
+	return _webviewProviderCreator(providerType)
 }
 
 export function getHostBridgeProvider(): HostBridgeClientProvider {

--- a/src/standalone/ExternalWebviewProvider.ts
+++ b/src/standalone/ExternalWebviewProvider.ts
@@ -14,14 +14,6 @@ https://github.com/KumarVariable/vscode-extension-sidebar-html/blob/master/src/c
 export class ExternalWebviewProvider extends WebviewProvider {
 	public webview?: vscode.WebviewView | vscode.WebviewPanel
 
-	public static create(
-		context: vscode.ExtensionContext,
-		outputChannel: vscode.OutputChannel,
-		providerType: WebviewProviderType,
-	) {
-		return new ExternalWebviewProvider(context, outputChannel, providerType)
-	}
-
 	constructor(context: vscode.ExtensionContext, outputChannel: vscode.OutputChannel, providerType: WebviewProviderType) {
 		super(context, outputChannel, providerType)
 	}

--- a/src/standalone/ExternalWebviewProvider.ts
+++ b/src/standalone/ExternalWebviewProvider.ts
@@ -10,6 +10,7 @@ https://github.com/KumarVariable/vscode-extension-sidebar-html/blob/master/src/c
 */
 
 export class ExternalWebviewProvider extends WebviewProvider {
+	private RESOURCE_AUTHORITY: string = "file.resources"
 	constructor(context: vscode.ExtensionContext, outputChannel: vscode.OutputChannel, providerType: WebviewProviderType) {
 		super(context, outputChannel, providerType)
 	}
@@ -18,7 +19,7 @@ export class ExternalWebviewProvider extends WebviewProvider {
 		if (uri.scheme !== "file") {
 			return uri
 		}
-		return URI.from({ scheme: "https", authority: "file.resource", path: uri.fsPath })
+		return URI.from({ scheme: "https", authority: this.RESOURCE_AUTHORITY, path: uri.fsPath })
 	}
 	override getCspSource() {
 		return "csp-source"

--- a/src/standalone/ExternalWebviewProvider.ts
+++ b/src/standalone/ExternalWebviewProvider.ts
@@ -1,9 +1,7 @@
 import { ExtensionMessage } from "@/shared/ExtensionMessage"
 import { WebviewProviderType } from "@/shared/webview/types"
-import { sendThemeEvent } from "@core/controller/ui/subscribeToTheme"
-import { getTheme } from "@integrations/theme/getTheme"
 import * as vscode from "vscode"
-import { Uri } from "vscode"
+import { URI } from "vscode-uri"
 import { WebviewProvider } from "@core/webview"
 
 /*
@@ -12,17 +10,15 @@ https://github.com/KumarVariable/vscode-extension-sidebar-html/blob/master/src/c
 */
 
 export class ExternalWebviewProvider extends WebviewProvider {
-	public webview?: vscode.WebviewView | vscode.WebviewPanel
-
 	constructor(context: vscode.ExtensionContext, outputChannel: vscode.OutputChannel, providerType: WebviewProviderType) {
 		super(context, outputChannel, providerType)
 	}
 
-	override getWebviewUri(uri: Uri) {
-		return uri.with({
-			scheme: "http",
-			authority: "resources",
-		})
+	override getWebviewUri(uri: URI) {
+		if (uri.scheme !== "file") {
+			return uri
+		}
+		return URI.from({ scheme: "https", authority: "file.resource", path: uri.fsPath })
 	}
 	override getCspSource() {
 		return "csp-source"
@@ -38,7 +34,7 @@ export class ExternalWebviewProvider extends WebviewProvider {
 		return {}
 	}
 
-	override resolveWebviewView(_: vscode.WebviewView | vscode.WebviewPanel): Promise<void> {
+	override resolveWebviewView(_: any): Promise<void> {
 		return Promise.resolve()
 	}
 }

--- a/src/standalone/standalone.ts
+++ b/src/standalone/standalone.ts
@@ -11,11 +11,12 @@ import { addProtobusServices } from "@generated/standalone/server-setup"
 import { StreamingResponseHandler } from "@/core/controller/grpc-handler"
 import { ExternalHostBridgeClientManager } from "./host-bridge-client-manager"
 import { ExternalWebviewProvider } from "./ExternalWebviewProvider"
+import { WebviewProviderType } from "@/shared/webview/types"
 
 async function main() {
 	log("Starting standalone service...")
 
-	hostProviders.initializeHostProviders(ExternalWebviewProvider.create, new ExternalHostBridgeClientManager())
+	hostProviders.initializeHostProviders(createWebview, new ExternalHostBridgeClientManager())
 	activate(extensionContext)
 	const controller = new Controller(extensionContext, outputChannel, postMessage)
 	const server = new grpc.Server()
@@ -41,6 +42,10 @@ async function main() {
 		server.start()
 		log(`gRPC server listening on ${host}`)
 	})
+}
+
+const createWebview = () => {
+	return new ExternalWebviewProvider(extensionContext, outputChannel, WebviewProviderType.SIDEBAR)
 }
 
 /**

--- a/src/standalone/vscode-context.ts
+++ b/src/standalone/vscode-context.ts
@@ -1,5 +1,5 @@
 import { URI } from "vscode-uri"
-
+import os from "os"
 import { mkdirSync, readFileSync } from "fs"
 import path, { join } from "path"
 import type { Extension, ExtensionContext } from "vscode"
@@ -8,19 +8,15 @@ import { log } from "./utils"
 import { outputChannel, postMessage } from "./vscode-context-stubs"
 import { EnvironmentVariableCollection, MementoStore, readJson, SecretStore } from "./vscode-context-utils"
 
-if (!process.env.CLINE_DIR) {
-	console.warn("Environment variable CLINE_DIR was not set.")
-	process.exit(1)
-}
-
 const VERSION = getPackageVersion()
 log("Running standalone cline ", VERSION)
 
-const DATA_DIR = path.join(process.env.CLINE_DIR, "data")
+const CLINE_DIR = process.env.CLINE_DIR || `${os.homedir()}/.cline`
+const DATA_DIR = path.join(CLINE_DIR, "data")
 mkdirSync(DATA_DIR, { recursive: true })
 log("Using settings dir:", DATA_DIR)
 
-const EXTENSION_DIR = path.join(process.env.CLINE_DIR, "core", VERSION, "extension")
+const EXTENSION_DIR = path.join(CLINE_DIR, "core", VERSION, "extension")
 const EXTENSION_MODE = process.env.IS_DEV === "true" ? ExtensionMode.Development : ExtensionMode.Production
 
 const extension: Extension<void> = {


### PR DESCRIPTION
Add ui.getWebviewHtml to the protobus-this will return the HTML content for external clients.

- Include node modules used as assets in the standalone package.
- Change getUri to return URIs for files in an appropriate format for the external web view.
- Use URI from npm module in ExternalWebviewProvider.
- Use a default value for the cline dir, ~/.cline
- Turn off gRPC debugging, it is too spammy with the streaming host bridge clients.