### PR TITLE
In the reflection output the standalone service should only show the Protobus services

### DIFF
--- a/src/standalone/standalone.ts
+++ b/src/standalone/standalone.ts
@@ -20,6 +20,10 @@ async function main() {
 	hostProviders.initializeHostProviders(createWebview, new ExternalHostBridgeClientManager())
 	activate(extensionContext)
 	const controller = new Controller(extensionContext, outputChannel, postMessage, uuidv4())
+	startProtobusService(controller)
+}
+
+function startProtobusService(controller: Controller) {
 	const server = new grpc.Server()
 
 	// Set up health check.
@@ -29,12 +33,15 @@ async function main() {
 	// Add all the handlers for the ProtoBus services to the server.
 	addProtobusServices(server, controller, wrapHandler, wrapStreamingResponseHandler)
 
-	// Set up reflection.
-	const reflection = new ReflectionService(getPackageDefinition())
+	// Create reflection service with protobus service names
+	const packageDefinition = getPackageDefinition()
+	const reflection = new ReflectionService(packageDefinition, {
+		services: getProtobusServiceNames(packageDefinition),
+	})
 	reflection.addToServer(server)
 
 	// Start the server.
-	const host = "127.0.0.1:50051"
+	const host = process.env.PROTOBUS_ADDRESS || "127.0.0.1:50051"
 	server.bindAsync(host, grpc.ServerCredentials.createInsecure(), (err) => {
 		if (err) {
 			log(`Error: Failed to bind to ${host}, port may be unavailable. ${err.message}`)
@@ -43,6 +50,14 @@ async function main() {
 		server.start()
 		log(`gRPC server listening on ${host}`)
 	})
+}
+
+function getProtobusServiceNames(packageDefinition: { [x: string]: any }): string[] {
+	// Filter service names to only include cline services
+	const clineServiceNames = Object.keys(packageDefinition).filter(
+		(name) => name.startsWith("cline.") || name.startsWith("grpc.health"),
+	)
+	return clineServiceNames
 }
 
 const createWebview = () => {

--- a/src/standalone/standalone.ts
+++ b/src/standalone/standalone.ts
@@ -54,10 +54,10 @@ function startProtobusService(controller: Controller) {
 
 function getProtobusServiceNames(packageDefinition: { [x: string]: any }): string[] {
 	// Filter service names to only include cline services
-	const clineServiceNames = Object.keys(packageDefinition).filter(
+	const protobusServiceNames = Object.keys(packageDefinition).filter(
 		(name) => name.startsWith("cline.") || name.startsWith("grpc.health"),
 	)
-	return clineServiceNames
+	return protobusServiceNames
 }
 
 const createWebview = () => {

--- a/src/standalone/utils.ts
+++ b/src/standalone/utils.ts
@@ -11,9 +11,28 @@ const log = (...args: unknown[]) => {
 function getPackageDefinition() {
 	// Load service definitions.
 	const descriptorSet = fs.readFileSync("proto/descriptor_set.pb")
-	const clineDef = protoLoader.loadFileDescriptorSetFromBuffer(descriptorSet)
+	const allDefs = protoLoader.loadFileDescriptorSetFromBuffer(descriptorSet)
+
+	// Log all keys to see what's in the descriptor set
+	console.log("All keys in descriptor set:", Object.keys(allDefs).join(", "))
+
+	// Filter to only include entries from the cline package
+	const clineDef: Record<string, any> = {}
+	for (const [key, value] of Object.entries(allDefs)) {
+		if (key.startsWith("cline.")) {
+			clineDef[key] = value
+		}
+	}
+
+	// Log the filtered keys
+	console.log("Filtered keys:", Object.keys(clineDef).join(", "))
+
 	const healthDef = protoLoader.loadSync(health.protoPath)
 	const packageDefinition = { ...clineDef, ...healthDef }
+
+	// Log the final package definition keys
+	console.log("Final package definition keys:", Object.keys(packageDefinition).join(", "))
+
 	return packageDefinition
 }
 

--- a/src/standalone/utils.ts
+++ b/src/standalone/utils.ts
@@ -11,28 +11,9 @@ const log = (...args: unknown[]) => {
 function getPackageDefinition() {
 	// Load service definitions.
 	const descriptorSet = fs.readFileSync("proto/descriptor_set.pb")
-	const allDefs = protoLoader.loadFileDescriptorSetFromBuffer(descriptorSet)
-
-	// Log all keys to see what's in the descriptor set
-	console.log("All keys in descriptor set:", Object.keys(allDefs).join(", "))
-
-	// Filter to only include entries from the cline package
-	const clineDef: Record<string, any> = {}
-	for (const [key, value] of Object.entries(allDefs)) {
-		if (key.startsWith("cline.")) {
-			clineDef[key] = value
-		}
-	}
-
-	// Log the filtered keys
-	console.log("Filtered keys:", Object.keys(clineDef).join(", "))
-
+	const descriptorDefs = protoLoader.loadFileDescriptorSetFromBuffer(descriptorSet)
 	const healthDef = protoLoader.loadSync(health.protoPath)
-	const packageDefinition = { ...clineDef, ...healthDef }
-
-	// Log the final package definition keys
-	console.log("Final package definition keys:", Object.keys(packageDefinition).join(", "))
-
+	const packageDefinition = { ...descriptorDefs, ...healthDef }
 	return packageDefinition
 }
 


### PR DESCRIPTION
The proto descriptor set includes all the proto services- the protobus and host bridge services.
The standalone service only provides the protobus service. When adding reflection to the service allowlist the cline and health packages.

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Filter reflection in standalone service to only include Protobus services and update server binding address handling.
> 
>   - **Behavior**:
>     - `startProtobusService()` in `standalone.ts` now filters reflection to only include Protobus services using `getProtobusServiceNames()`.
>     - Server binding address in `standalone.ts` now uses `process.env.PROTOBUS_ADDRESS` if available.
>   - **Functions**:
>     - New `getProtobusServiceNames()` in `standalone.ts` filters service names to include only `cline.` and `grpc.health` services.
>   - **Misc**:
>     - Renamed `clineDef` to `descriptorDefs` in `getPackageDefinition()` in `utils.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 719b2381ec59e226720dceb07fe73b1739dd409b. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->