### PR TITLE
chore: update stale action hash in workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -12,7 +12,7 @@ jobs:
             issues: write
             pull-requests: write
         steps:
-            - uses: actions/stale@28ca103
+            - uses: actions/stale@28ca1036281a5e5922ead5184a1bbf96e5fc984e
               with:
                   days-before-issue-stale: 60
                   days-before-issue-close: 14


### PR DESCRIPTION
Hope this change might help with cleanup of the issue tracker! 😄

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update stale action hash in GitHub workflow to a specific commit for stability.
> 
>   - **Workflow Update**:
>     - Update stale action hash in `.github/workflows/stale.yml` from `28ca103` to `28ca1036281a5e5922ead5184a1bbf96e5fc984e`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 60179dea3dad81b962f8c4294e627df636f1272b. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->