### PR TITLE
[Chatview] Simplify isPartial

### DIFF
--- a/webview-ui/src/components/chat/ChatView.tsx
+++ b/webview-ui/src/components/chat/ChatView.tsx
@@ -414,28 +414,8 @@ const ChatView = ({ isHidden, showAnnouncement, hideAnnouncement, showHistoryVie
 	}, [task?.ts])
 
 	const isStreaming = useMemo(() => {
-		const isLastAsk = !!modifiedMessages.at(-1)?.ask // checking clineAsk isn't enough since messages effect may be called again for a tool for example, set clineAsk to its value, and if the next message is not an ask then it doesn't reset. This is likely due to how much more often we're updating messages as compared to before, and should be resolved with optimizations as it's likely a rendering bug. but as a final guard for now, the cancel button will show if the last message is not an ask
-		const isToolCurrentlyAsking = isLastAsk && clineAsk !== undefined && enableButtons && primaryButtonText !== undefined
-		if (isToolCurrentlyAsking) {
-			return false
-		}
-
-		const isLastMessagePartial = modifiedMessages.at(-1)?.partial === true
-		if (isLastMessagePartial) {
-			return true
-		} else {
-			const lastApiReqStarted = findLast(modifiedMessages, (message) => message.say === "api_req_started")
-			if (lastApiReqStarted && lastApiReqStarted.text != null && lastApiReqStarted.say === "api_req_started") {
-				const cost = JSON.parse(lastApiReqStarted.text).cost
-				if (cost === undefined) {
-					// api request has not finished yet
-					return true
-				}
-			}
-		}
-
-		return false
-	}, [modifiedMessages, clineAsk, enableButtons, primaryButtonText])
+		return modifiedMessages.at(-1)?.partial === true
+	}, [modifiedMessages])
 
 	const handleSendMessage = useCallback(
 		async (text: string, images: string[], files: string[]) => {


### PR DESCRIPTION


### Description

### __Refactor: Simplify `isStreaming` Logic in ChatView__

__Description:__

This PR simplifies the `isStreaming` logic in `ChatView.tsx` to improve clarity and remove a potential circular dependency.

The previous implementation was overly complex, checking for UI button states and an asynchronously updated `cost` field. These checks were redundant, as the `partial` flag on the last message is the definitive source of truth for whether the API is actively streaming.

The new logic relies solely on `modifiedMessages.at(-1)?.partial === true`. This change eliminates the circular dependency between `isStreaming` and button states, making the component more robust and easier to maintain.


### Test Procedure

The "Cancel" button's behavior was manually verified across all tool calls. Task cancellation and rapid UI interactions were also tested.

Typing in the chat field while streaming was also checked.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [x] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Simplifies `isStreaming` logic in `ChatView.tsx` by relying solely on the `partial` flag of the last message, removing redundant checks and potential circular dependencies.
> 
>   - **Behavior**:
>     - Simplifies `isStreaming` logic in `ChatView.tsx` by relying solely on `modifiedMessages.at(-1)?.partial === true`.
>     - Removes redundant checks for UI button states and `cost` field.
>   - **Misc**:
>     - Eliminates potential circular dependency between `isStreaming` and button states.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 4b399189ca28424a31d9cba250cbc0dd199575dd. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->