### PR TITLE
Fix Browser Settings saving mechanism

### DIFF
--- a/webview-ui/src/context/ExtensionStateContext.tsx
+++ b/webview-ui/src/context/ExtensionStateContext.tsx
@@ -14,7 +14,7 @@ import { TerminalProfile } from "@shared/proto/state"
 import { convertProtoToClineMessage } from "@shared/proto-conversions/cline-message"
 import { convertProtoMcpServersToMcpServers } from "@shared/proto-conversions/mcp/mcp-server-conversion"
 import { DEFAULT_AUTO_APPROVAL_SETTINGS } from "@shared/AutoApprovalSettings"
-import { DEFAULT_BROWSER_SETTINGS } from "@shared/BrowserSettings"
+import { DEFAULT_BROWSER_SETTINGS, BrowserSettings } from "@shared/BrowserSettings"
 import { ChatSettings, DEFAULT_CHAT_SETTINGS } from "@shared/ChatSettings"
 import { DEFAULT_PLATFORM, ExtensionMessage, ExtensionState } from "@shared/ExtensionMessage"
 import { TelemetrySetting } from "@shared/TelemetrySetting"
@@ -79,6 +79,7 @@ interface ExtensionStateContextType extends ExtensionState {
 	setMcpMarketplaceCatalog: (value: McpMarketplaceCatalog) => void
 	setTotalTasksSize: (value: number | null) => void
 	setAvailableTerminalProfiles: (profiles: TerminalProfile[]) => void // Setter for profiles
+	setBrowserSettings: (value: BrowserSettings) => void
 
 	// Refresh functions
 	refreshOpenRouterModels: () => void
@@ -838,6 +839,11 @@ export const ExtensionStateContextProvider: React.FC<{
 		refreshOpenRouterModels,
 		onRelinquishControl,
 		setUserInfo: (userInfo?: UserInfo) => setState((prevState) => ({ ...prevState, userInfo })),
+		setBrowserSettings: (value: BrowserSettings) =>
+			setState((prevState) => ({
+				...prevState,
+				browserSettings: value,
+			})),
 	}
 
 	return <ExtensionStateContext.Provider value={contextValue}>{children}</ExtensionStateContext.Provider>


### PR DESCRIPTION
### Description

This PR fixes an inconsistency in the Settings UI where browser settings were not showing Save/Discard buttons when changed, unlike other settings sections (Feature, Terminal, etc.). 

The issue was that browser settings were using an immediate update pattern - every change was directly calling gRPC to update the backend, bypassing the draft/commit pattern used by other settings. This meant:
- No Save/Discard buttons appeared when changing browser settings
- Changes were immediately persisted without user confirmation
- The UI behavior was inconsistent across different settings sections

### Test Procedure

**How I tested this change:**
1. Opened Settings and navigated to the Browser tab
2. Changed various browser settings:
   - Toggled "Disable browser tool usage"
   - Changed viewport size dropdown
   - Toggled "Use remote browser connection"
   - Modified Chrome executable path
3. Verified that the Save button becomes enabled after each change
4. Tested Cancel button to ensure changes are discarded
5. Tested Save button to ensure changes are persisted
6. Verified that switching between settings tabs preserves unsaved changes
7. Tested that the unsaved changes dialog appears when trying to close settings with unsaved browser settings


### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [x] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

### Additional Notes


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes browser settings UI inconsistency by implementing a draft/commit pattern with Save/Discard buttons.
> 
>   - **Behavior**:
>     - Implements draft/commit pattern for browser settings in `BrowserSettingsSection.tsx`, enabling Save/Discard buttons.
>     - Changes to browser settings are now locally stored and only persisted on Save.
>     - Unsaved changes dialog appears when closing settings with unsaved browser changes.
>   - **State Management**:
>     - Introduces `localBrowserSettings` state in `SettingsView.tsx` to track changes before saving.
>     - Adds `setBrowserSettings` function in `ExtensionStateContext.tsx` to update global state.
>   - **UI Components**:
>     - Updates `BrowserSettingsSection` to use `localBrowserSettings` and `onBrowserSettingsChange` for state updates.
>     - Ensures consistent UI behavior across different settings sections.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for b7bd6dbbea5f89515465de0eef50ea5c5468a447. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->