### PR TITLE
add eslint rule banning postMessage in webview

### DIFF
--- a/eslint-rules/__tests__/no-vscode-postmessage.test.ts
+++ b/eslint-rules/__tests__/no-vscode-postmessage.test.ts
@@ -1,0 +1,74 @@
+const { RuleTester: VscodeRuleTester } = require("eslint")
+const vscodePostmessageRule = require("../no-vscode-postmessage")
+
+const vscodeRuleTester = new VscodeRuleTester({
+	parser: require.resolve("@typescript-eslint/parser"),
+	parserOptions: {
+		ecmaVersion: 2020,
+		sourceType: "module",
+		ecmaFeatures: {
+			jsx: true,
+		},
+	},
+})
+
+vscodeRuleTester.run("no-vscode-postmessage", vscodePostmessageRule, {
+	valid: [
+		// Should allow vscode.postMessage in grpc-client-base.ts
+		{
+			code: `vscode.postMessage({ type: "grpc_request", data: {} })`,
+			filename: "grpc-client-base.ts",
+		},
+		{
+			code: `vscode.postMessage({ type: "grpc_request_cancel" })`,
+			filename: "/path/to/grpc-client-base.ts",
+		},
+		// Should allow other vscode API calls
+		{
+			code: `vscode.window.showInformationMessage("Hello")`,
+			filename: "test.ts",
+		},
+		// Should allow postMessage calls on other objects
+		{
+			code: `window.postMessage({ type: "test" }, "*")`,
+			filename: "test.ts",
+		},
+		// Should allow variables named vscode but not calling postMessage
+		{
+			code: `const vscode = { other: "method" }; vscode.other()`,
+			filename: "test.ts",
+		},
+	],
+	invalid: [
+		// Should ban vscode.postMessage in regular files
+		{
+			code: `vscode.postMessage({ type: "test", data: {} })`,
+			filename: "test.ts",
+			errors: [
+				{
+					messageId: "useGrpcClient",
+				},
+			],
+		},
+		// Should ban vscode.postMessage in components
+		{
+			code: `vscode.postMessage({ type: "apiConfiguration", apiConfiguration })`,
+			filename: "ApiOptions.tsx",
+			errors: [
+				{
+					messageId: "useGrpcClient",
+				},
+			],
+		},
+		// Should ban vscode.postMessage in test files
+		{
+			code: `vscode.postMessage({ type: "newTask", text: message.text })`,
+			filename: "test.test.ts",
+			errors: [
+				{
+					messageId: "useGrpcClient",
+				},
+			],
+		},
+	],
+})

--- a/eslint-rules/index.js
+++ b/eslint-rules/index.js
@@ -1,11 +1,13 @@
 // eslint-rules/index.js
 const noProtobufObjectLiterals = require("./no-protobuf-object-literals")
 const noGrpcClientObjectLiterals = require("./no-grpc-client-object-literals")
+const noVscodePostmessage = require("./no-vscode-postmessage")
 
 module.exports = {
 	rules: {
 		"no-protobuf-object-literals": noProtobufObjectLiterals,
 		"no-grpc-client-object-literals": noGrpcClientObjectLiterals,
+		"no-vscode-postmessage": noVscodePostmessage,
 	},
 	configs: {
 		recommended: {
@@ -13,6 +15,7 @@ module.exports = {
 			rules: {
 				"local/no-protobuf-object-literals": "error",
 				"local/no-grpc-client-object-literals": "error",
+				"local/no-vscode-postmessage": "error",
 			},
 		},
 	},

--- a/eslint-rules/no-vscode-postmessage.js
+++ b/eslint-rules/no-vscode-postmessage.js
@@ -1,0 +1,61 @@
+const { ESLintUtils } = require("@typescript-eslint/utils")
+const path = require("path")
+
+const createRule = ESLintUtils.RuleCreator((name) => `https://cline.bot/eslint-rules/${name}`)
+
+module.exports = createRule({
+	name: "no-vscode-postmessage",
+	meta: {
+		type: "problem",
+		docs: {
+			description: "Ban vscode.postMessage() calls in favor of gRPC service clients, except in grpc-client-base.ts",
+			recommended: "error",
+		},
+		messages: {
+			useGrpcClient:
+				"Use gRPC service clients instead of vscode.postMessage().\n" +
+				"Example: AccountServiceClient.methodName(RequestType.create({...})) instead of vscode.postMessage({type: '...'}).\n" +
+				"Found: {{code}}",
+		},
+		schema: [],
+	},
+	defaultOptions: [],
+
+	create(context) {
+		// Check if current file is grpc-client-base.ts (exception case)
+		const filename = context.filename
+		const isGrpcClientBase = path.basename(filename) === "grpc-client-base.ts"
+
+		return {
+			// Detect vscode.postMessage calls
+			"CallExpression[callee.type='MemberExpression']"(node) {
+				// Skip if this is grpc-client-base.ts
+				if (isGrpcClientBase) {
+					return
+				}
+
+				const callee = node.callee
+
+				// Check for vscode.postMessage pattern
+				if (
+					callee.object &&
+					callee.object.type === "Identifier" &&
+					callee.object.name === "vscode" &&
+					callee.property &&
+					callee.property.name === "postMessage"
+				) {
+					const sourceCode = context.sourceCode
+					const callText = sourceCode.getText(node).trim()
+
+					context.report({
+						node,
+						messageId: "useGrpcClient",
+						data: {
+							code: callText,
+						},
+					})
+				}
+			},
+		}
+	},
+})

--- a/webview-ui/.eslintrc.json
+++ b/webview-ui/.eslintrc.json
@@ -28,6 +28,7 @@
 		"no-extra-semi": "off",
 		"eslint-rules/no-protobuf-object-literals": "error",
 		"eslint-rules/no-grpc-client-object-literals": "error",
+		"eslint-rules/no-vscode-postmessage": "warn",
 		"no-restricted-syntax": [
 			"error",
 			{


### PR DESCRIPTION




### Description

Warn on postMessage calls in webview for now, while there are still some around.

Later will move to error. It bypasses the grpc-client-base.ts

Runs on commit hook.

### Test Procedure

Tested commiting. Tested on the grpc-client-base to confirm no warnings thrown.

<img width="770" alt="Screenshot 2025-06-24 at 10 35 48 AM" src="https://github.com/user-attachments/assets/5a652e6a-baca-4e7c-ab92-82d0859277a1" />


### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [x] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add ESLint rule to ban `vscode.postMessage` in favor of gRPC clients, with tests and configuration updates.
> 
>   - **ESLint Rule**:
>     - Adds `no-vscode-postmessage` rule in `eslint-rules/no-vscode-postmessage.js` to ban `vscode.postMessage` calls, except in `grpc-client-base.ts`.
>     - Rule suggests using gRPC service clients instead.
>   - **Testing**:
>     - Adds tests in `eslint-rules/__tests__/no-vscode-postmessage.test.ts` to validate rule behavior.
>     - Tests cover valid cases (e.g., `grpc-client-base.ts`, other API calls) and invalid cases (e.g., regular files, components).
>   - **Configuration**:
>     - Updates `eslint-rules/index.js` to include the new rule.
>     - Sets `no-vscode-postmessage` to "warn" in `webview-ui/.eslintrc.json`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 992bebc8b491d4d47c26a7b8f44bea7a7703b8da. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->