### PR TITLE
Fix Webfetch link

### DIFF
--- a/proto/ui.proto
+++ b/proto/ui.proto
@@ -265,4 +265,7 @@ service UiService {
 
   // Returns the HTML for the webview index page. This is only used by external clients, not by the vscode webview.
   rpc getWebviewHtml(EmptyRequest) returns (String);
+  
+  // Opens a URL in the default browser
+  rpc openUrl(StringRequest) returns (Empty);
 }

--- a/src/core/controller/ui/openUrl.ts
+++ b/src/core/controller/ui/openUrl.ts
@@ -1,0 +1,20 @@
+import type { Controller } from "../index"
+import type { StringRequest } from "../../../shared/proto/common"
+import { Empty } from "../../../shared/proto/common"
+import { openUrlInBrowser } from "../../../utils/github-url-utils"
+
+/**
+ * Opens a URL in the default browser
+ * @param controller The controller instance
+ * @param request The URL to open
+ * @returns Empty response
+ */
+export async function openUrl(controller: Controller, request: StringRequest): Promise<Empty> {
+	try {
+		await openUrlInBrowser(request.value)
+		return Empty.create({})
+	} catch (error) {
+		console.error(`Failed to open URL: ${error}`)
+		throw error
+	}
+}

--- a/webview-ui/src/components/chat/ChatRow.tsx
+++ b/webview-ui/src/components/chat/ChatRow.tsx
@@ -17,7 +17,7 @@ import McpResponseDisplay from "@/components/mcp/chat-display/McpResponseDisplay
 import McpResourceRow from "@/components/mcp/configuration/tabs/installed/server-row/McpResourceRow"
 import McpToolRow from "@/components/mcp/configuration/tabs/installed/server-row/McpToolRow"
 import { useExtensionState } from "@/context/ExtensionStateContext"
-import { FileServiceClient, TaskServiceClient } from "@/services/grpc-client"
+import { FileServiceClient, TaskServiceClient, UiServiceClient } from "@/services/grpc-client"
 import { findMatchingResourceOrTemplate, getMcpServerDisplayName } from "@/utils/mcp"
 import { vscode } from "@/utils/vscode"
 import {
@@ -697,15 +697,13 @@ export const ChatRowContent = ({
 								msUserSelect: "none",
 							}}
 							onClick={() => {
-								// Attempt to open the URL in the default browser
+								// Open the URL in the default browser using gRPC
 								if (tool.path) {
-									// Assuming 'openUrl' is a valid action the extension can handle.
-									// If not, this might need adjustment based on how other external link openings are handled.
-									vscode.postMessage({
-										type: "action", // This should be a valid MessageType from WebviewMessage
-										action: "openUrl", // This should be a valid WebviewAction from WebviewMessage
-										url: tool.path,
-									} as any) // Using 'as any' for now if 'openUrl' isn't strictly typed yet
+									UiServiceClient.openUrl(StringRequest.create({ value: tool.path }))
+
+										.catch((err) => {
+											console.error("Failed to open URL:", err)
+										})
 								}
 							}}>
 							<span


### PR DESCRIPTION


### Description

Webfetch link wasn't working when clicked.

Now correctly calls the openUrlInBrowser function.

### Test Procedure

Confirmed it opened the url in my chrome browser.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes Webfetch link by adding `openUrl` gRPC method and updating `ChatRow.tsx` to use it.
> 
>   - **Behavior**:
>     - Fixes Webfetch link issue by using `UiServiceClient.openUrl` in `ChatRow.tsx` to open URLs in the default browser.
>   - **gRPC Service**:
>     - Adds `openUrl` method to `UiService` in `ui.proto`.
>   - **Implementation**:
>     - Implements `openUrl` function in `openUrl.ts` to call `openUrlInBrowser` utility.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for fed3c96c6a1c2e97c22532c5f7a2598d7a0783a9. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->