### PR TITLE
Add workspace service to the host bridge.

### DIFF
--- a/proto/host/workspace.proto
+++ b/proto/host/workspace.proto
@@ -1,0 +1,24 @@
+syntax = "proto3";
+
+package host;
+option java_package = "bot.cline.host.proto";
+option java_multiple_files = true;
+
+// Provides methods for working with workspaces/projects.
+service WorkspaceService {
+  // Returns a list of the top level directories of the workspace.
+  rpc getWorkspacePaths(GetWorkspacePathsRequest) returns (GetWorkspacePathsResponse);
+}
+
+message GetWorkspacePathsRequest {
+  // The unique ID for the workspace/project.
+  // This is currently optional in vscode. It is required in other environments where cline is running at
+  // the application level, and the user can open multiple projects.
+  optional string id = 1;
+}
+
+message GetWorkspacePathsResponse {
+  // The unique ID for the workspace/project.
+  optional string id = 1;
+  repeated string paths = 2;
+}

--- a/src/hosts/host-provider-types.ts
+++ b/src/hosts/host-provider-types.ts
@@ -1,4 +1,8 @@
-import { UriServiceClientInterface, WatchServiceClientInterface } from "@generated/hosts/host-bridge-client-types"
+import {
+	UriServiceClientInterface,
+	WatchServiceClientInterface,
+	WorkspaceServiceClientInterface,
+} from "@generated/hosts/host-bridge-client-types"
 
 /**
  * Interface for host bridge client providers
@@ -6,6 +10,7 @@ import { UriServiceClientInterface, WatchServiceClientInterface } from "@generat
 export interface HostBridgeClientProvider {
 	uriServiceClient: UriServiceClientInterface
 	watchServiceClient: WatchServiceClientInterface
+	workspaceClient: WorkspaceServiceClientInterface
 }
 
 /**

--- a/src/hosts/vscode/client/host-grpc-client.ts
+++ b/src/hosts/vscode/client/host-grpc-client.ts
@@ -5,4 +5,5 @@ import * as host from "@shared/proto/index.host"
 export const vscodeHostBridgeClient: HostBridgeClientProvider = {
 	uriServiceClient: createGrpcClient(host.UriServiceDefinition),
 	watchServiceClient: createGrpcClient(host.WatchServiceDefinition),
+	workspaceClient: createGrpcClient(host.WorkspaceServiceDefinition),
 }

--- a/src/standalone/host-bridge-client-manager.ts
+++ b/src/standalone/host-bridge-client-manager.ts
@@ -1,16 +1,25 @@
 import { Channel, createChannel } from "nice-grpc"
-import { UriServiceClientImpl, WatchServiceClientImpl } from "@generated/standalone/host-bridge-clients"
-import { UriServiceClientInterface, WatchServiceClientInterface } from "@generated/hosts/host-bridge-client-types"
+import {
+	UriServiceClientImpl,
+	WatchServiceClientImpl,
+	WorkspaceServiceClientImpl,
+} from "@generated/standalone/host-bridge-clients"
+import {
+	UriServiceClientInterface,
+	WatchServiceClientInterface,
+	WorkspaceServiceClientInterface,
+} from "@generated/hosts/host-bridge-client-types"
 import { HostBridgeClientProvider } from "@/hosts/host-provider-types"
 
 /**
- * Singleton class to hold the gRPC clients for the host bridge. The clients should be re-used to avoid
+ * Manager to hold the gRPC clients for the host bridge. The clients should be re-used to avoid
  * creating a new TCP connection every time a rpc is made.
  */
 export class ExternalHostBridgeClientManager implements HostBridgeClientProvider {
 	private channel: Channel
 	uriServiceClient: UriServiceClientInterface
 	watchServiceClient: WatchServiceClientInterface
+	workspaceClient: WorkspaceServiceClientInterface
 
 	constructor() {
 		const address = process.env.HOST_BRIDGE_ADDRESS || "localhost:50052"
@@ -18,6 +27,7 @@ export class ExternalHostBridgeClientManager implements HostBridgeClientProvider
 
 		this.uriServiceClient = new UriServiceClientImpl(this.channel)
 		this.watchServiceClient = new WatchServiceClientImpl(this.channel)
+		this.workspaceClient = new WorkspaceServiceClientImpl(this.channel)
 	}
 
 	public close(): void {


### PR DESCRIPTION
### Description
Add a service for workspaces to the host bridge.
The service has one rpc getWorkspacePaths that will replace vscode.workspace.workspaceFolders.

### Test Procedure

Tested manually in the vscode extension host

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

NA

### Additional Notes

NA

