### PR TITLE
Revert "[Chatview] Simplify isPartial"

### DIFF
--- a/webview-ui/src/components/chat/ChatView.tsx
+++ b/webview-ui/src/components/chat/ChatView.tsx
@@ -414,8 +414,28 @@ const ChatView = ({ isHidden, showAnnouncement, hideAnnouncement, showHistoryVie
 	}, [task?.ts])
 
 	const isStreaming = useMemo(() => {
-		return modifiedMessages.at(-1)?.partial === true
-	}, [modifiedMessages])
+		const isLastAsk = !!modifiedMessages.at(-1)?.ask // checking clineAsk isn't enough since messages effect may be called again for a tool for example, set clineAsk to its value, and if the next message is not an ask then it doesn't reset. This is likely due to how much more often we're updating messages as compared to before, and should be resolved with optimizations as it's likely a rendering bug. but as a final guard for now, the cancel button will show if the last message is not an ask
+		const isToolCurrentlyAsking = isLastAsk && clineAsk !== undefined && enableButtons && primaryButtonText !== undefined
+		if (isToolCurrentlyAsking) {
+			return false
+		}
+
+		const isLastMessagePartial = modifiedMessages.at(-1)?.partial === true
+		if (isLastMessagePartial) {
+			return true
+		} else {
+			const lastApiReqStarted = findLast(modifiedMessages, (message) => message.say === "api_req_started")
+			if (lastApiReqStarted && lastApiReqStarted.text != null && lastApiReqStarted.say === "api_req_started") {
+				const cost = JSON.parse(lastApiReqStarted.text).cost
+				if (cost === undefined) {
+					// api request has not finished yet
+					return true
+				}
+			}
+		}
+
+		return false
+	}, [modifiedMessages, clineAsk, enableButtons, primaryButtonText])
 
 	const handleSendMessage = useCallback(
 		async (text: string, images: string[], files: string[]) => {


### PR DESCRIPTION
Reverts cline/cline#4404
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Reverts simplification of `isStreaming` logic in `ChatView.tsx`, restoring original complex checks for streaming state.
> 
>   - **Revert Change**:
>     - Reverts simplification of `isStreaming` logic in `ChatView.tsx`.
>     - Restores original logic with checks for `isLastAsk`, `isToolCurrentlyAsking`, and `isLastMessagePartial`.
>     - Includes additional conditions for `api_req_started` messages to determine streaming state.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for dcb2feff25cc760d2625db3297703d3eac196454. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->