### PR TITLE
feat. support anthropic--claude-4-sonnet in SAP AI Core provider

### DIFF
--- a/.changeset/sharp-singers-tie.md
+++ b/.changeset/sharp-singers-tie.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": minor
+---
+
+Support Sonnet-4 in SAP AI Core provider

--- a/src/api/providers/sapaicore.ts
+++ b/src/api/providers/sapaicore.ts
@@ -122,6 +122,7 @@ export class SapAiCoreHandler implements ApiHandler {
 		const deploymentId = await this.getDeploymentForModel(model.id)
 
 		const anthropicModels = [
+			"anthropic--claude-4-sonnet",
 			"anthropic--claude-3.7-sonnet",
 			"anthropic--claude-3.5-sonnet",
 			"anthropic--claude-3-sonnet",
@@ -136,7 +137,7 @@ export class SapAiCoreHandler implements ApiHandler {
 		if (anthropicModels.includes(model.id)) {
 			url = `${this.options.sapAiCoreBaseUrl}/v2/inference/deployments/${deploymentId}/invoke-with-response-stream`
 
-			if (model.id === "anthropic--claude-3.7-sonnet") {
+			if (model.id === "anthropic--claude-3.7-sonnet" || model.id === "anthropic--claude-4-sonnet") {
 				url = `${this.options.sapAiCoreBaseUrl}/v2/inference/deployments/${deploymentId}/converse-stream`
 				payload = {
 					inferenceConfig: {
@@ -221,7 +222,7 @@ export class SapAiCoreHandler implements ApiHandler {
 				}
 			} else if (openAIModels.includes(model.id)) {
 				yield* this.streamCompletionGPT(response.data, model)
-			} else if (model.id === "anthropic--claude-3.7-sonnet") {
+			} else if (model.id === "anthropic--claude-3.7-sonnet" || model.id === "anthropic--claude-4-sonnet") {
 				yield* this.streamCompletionSonnet37(response.data, model)
 			} else {
 				yield* this.streamCompletion(response.data, model)

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -2374,6 +2374,14 @@ export const requestyDefaultModelInfo: ModelInfo = {
 export type SapAiCoreModelId = keyof typeof sapAiCoreModels
 export const sapAiCoreDefaultModelId: SapAiCoreModelId = "anthropic--claude-3.5-sonnet"
 export const sapAiCoreModels = {
+	"anthropic--claude-4-sonnet": {
+		maxTokens: 8192,
+		contextWindow: 200_000,
+		supportsImages: true,
+		supportsPromptCache: false,
+		inputPrice: 3.0,
+		outputPrice: 15.0,
+	},
 	"anthropic--claude-3.7-sonnet": {
 		maxTokens: 64_000,
 		contextWindow: 200_000,


### PR DESCRIPTION
<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- Opened an issue and discussed your proposed changes with the community / contributors
- Received approval from a core Cline contributor prior to proceeding with the implementation
- Link the associated issue in the "Related Issue" section

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly.

Why this requirement?
We deeply appreciate all community contributions - they are the core reason we're able to operate successfully and keep innovating! We welcome community input and want to make it as easy as possible for people to submit quality work. This process helps our core maintainers review new ideas faster and saves contributor time by ensuring you have the go-ahead before spending time on implementation.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** #XXXX

### Description

<!-- 
Help reviewers understand your changes by making this PR readable and well-organized:

- What problem does this PR solve?
   A: add a new option 'anthropic--claude-4-sonnet' in SAP AI Core provider.
 
- Why were these changes introduced and what purpose do they serve?
   A: The current SAP AI Core provider supports up to Sonnet-3.7. Since Sonnet-4 is already available in SAP AI Core, I would like to use Sonnet-4 of SAP AI Core in Cline.

- For larger changes, provide context about your approach and reasoning
Small PRs may need minimal description, but larger changes benefit from explaining where you're coming from. Much of this context can be in the linked issue above, so feel free to reference it rather than repeating everything here.
-->

### Test Procedure

Testing approach:
1. switch to 'SAP AI Core' provider.
2. switch the model to 'anthropic--claude-4-sonnet'
3. send message in both plan and act, it shall return message.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots
![image](https://github.com/user-attachments/assets/81fddfe9-8d5f-4d08-8ddb-d88858351d34)



### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add support for `anthropic--claude-4-sonnet` in SAP AI Core provider with specific streaming logic and model attributes.
> 
>   - **Behavior**:
>     - Add support for `anthropic--claude-4-sonnet` in `SapAiCoreHandler` in `sapaicore.ts`.
>     - Update streaming logic to handle `anthropic--claude-4-sonnet` similarly to `anthropic--claude-3.7-sonnet`.
>   - **Models**:
>     - Add `anthropic--claude-4-sonnet` to `sapAiCoreModels` in `api.ts` with specific attributes like `maxTokens`, `contextWindow`, and pricing.
>   - **Misc**:
>     - Add changeset file `sharp-singers-tie.md` to document the addition of Sonnet-4 support.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 5c7f9879b5ab6d6e67258386c2d464cc3973770b. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->