### PR TITLE
Add activeTabGroup stub

### DIFF
--- a/standalone/runtime-files/vscode/vscode-impls.js
+++ b/standalone/runtime-files/vscode/vscode-impls.js
@@ -54,6 +54,7 @@ vscode.window = {
 		all: [],
 		close: async () => {},
 		onDidChangeTabs: createStub("vscode.env.tabGroups.onDidChangeTabs"),
+		activeTabGroup: { tabs: [] },
 	},
 	withProgress: async (_options, task) => {
 		console.log("Stubbed withProgress")


### PR DESCRIPTION
Add stub for activeTabGroup.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `activeTabGroup` stub to `vscode.window.tabGroups` in `vscode-impls.js`.
> 
>   - **Behavior**:
>     - Add `activeTabGroup` stub to `vscode.window.tabGroups` in `vscode-impls.js`, returning an empty `tabs` array.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for f0961623e639ea42620a13edc86d4bdaf58d3ab3. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->