### PR TITLE
fix: ENAMETOOLONG on Claude Code - write to stdin instead of including the messages in the prompt

### DIFF
--- a/.changeset/chilled-paws-remain.md
+++ b/.changeset/chilled-paws-remain.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Fix ENAMETOOLONG when calling Claude Code

--- a/src/integrations/claude-code/run.ts
+++ b/src/integrations/claude-code/run.ts
@@ -112,7 +112,6 @@ function runProcess({ systemPrompt, messages, path, modelId }: ClaudeCodeOptions
 
 	const args = [
 		"-p",
-		JSON.stringify(messages),
 		"--system-prompt",
 		systemPrompt,
 		"--verbose",
@@ -129,8 +128,8 @@ function runProcess({ systemPrompt, messages, path, modelId }: ClaudeCodeOptions
 		args.push("--model", modelId)
 	}
 
-	return execa(claudePath, args, {
-		stdin: "ignore",
+	const claudeCodeProcess = execa(claudePath, args, {
+		stdin: "pipe",
 		stdout: "pipe",
 		stderr: "pipe",
 		env: {
@@ -142,6 +141,11 @@ function runProcess({ systemPrompt, messages, path, modelId }: ClaudeCodeOptions
 		maxBuffer: 1024 * 1024 * 1000,
 		timeout: CLAUDE_CODE_TIMEOUT,
 	})
+
+	claudeCodeProcess.stdin.write(JSON.stringify(messages))
+	claudeCodeProcess.stdin.end()
+
+	return claudeCodeProcess
 }
 
 function parseChunk(data: string, processState: ProcessState) {


### PR DESCRIPTION
### Related Issue

**Issue:** #4480

### Description

Users reported that, when using Claude Code on Windows, they would get ENAMETOOLONG. This PR refactors the Claude Code call to make use of the fact that they support writing to `stdin` to send the prompt that way instead of including it in the command itself.

### Test Procedure

Tested this locally in WSL and MacOS.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Refactor `runProcess` in `run.ts` to write `messages` to `stdin`, fixing ENAMETOOLONG error on Windows.
> 
>   - **Behavior**:
>     - Refactor `runProcess` in `run.ts` to write `messages` to `stdin` instead of including them in command arguments.
>     - Fixes ENAMETOOLONG error on Windows when using Claude Code.
>   - **Process Handling**:
>     - Change `stdin` option from `ignore` to `pipe` in `runProcess`.
>     - Write `messages` to `claudeCodeProcess.stdin` and end the stream.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 7c0c9648d779f7e0e6fbd80235511738cb1c3e3d. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->