### PR TITLE
fix: LiteLLM provider setting persistence

### DIFF
--- a/.changeset/tasty-avocados-shake.md
+++ b/.changeset/tasty-avocados-shake.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Fix LiteLLM Provider Settings


### PR DESCRIPTION
<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- Opened an issue and discussed your proposed changes with the community / contributors
- Received approval from a core Cline contributor prior to proceeding with the implementation
- Link the associated issue in the "Related Issue" section

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly.

Why this requirement?
We deeply appreciate all community contributions - they are the core reason we're able to operate successfully and keep innovating! We welcome community input and want to make it as easy as possible for people to submit quality work. This process helps our core maintainers review new ideas faster and saves contributor time by ensuring you have the go-ahead before spending time on implementation.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** #4442

### Description

<!-- 
Help reviewers understand your changes by making this PR readable and well-organized:

- What problem does this PR solve?
- Why were these changes introduced and what purpose do they serve?
- For larger changes, provide context about your approach and reasoning

Small PRs may need minimal description, but larger changes benefit from explaining where you're coming from. Much of this context can be in the linked issue above, so feel free to reference it rather than repeating everything here.
-->

My attempt at a fix for LiteLLM provider settings (e.g. model name and context size) not persisting when VSCode is restarted.


### Test Procedure

<!-- 
Please walk us through your testing approach and thought process. This helps reviewers understand that you've thoroughly considered the impact of your changes:

- How did you test this change?
- What could potentially break and how did you verify it doesn't?
- What existing functionality might be affected and how did you check it still works?
- Why are you confident this is ready for merge?

We're not looking for exhaustive documentation - just evidence that you've thought through the implications of your changes and tested accordingly.
-->

1. Lint (`npm run lint`)
2. Format (`npm run format`)
3. Build (`npm run install:all; npm run compile`)
4. Test (`npm run test`)
5. Create visx and install (`rm -rf *.vsix ; npm run vscode:prepublish && npx vsce package && code --install-extension claude-dev-*.vsix`)
6. Select LiteLLM provider
7. Configure API url, model name and context size
8. Close all VSCode sessions
9. Open VSCode and check the provider
10. Note that the model name and context size remain configured as expected

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->

- Fixes #4442
- 100% of this fix was written by Cline with Claude Sonnet 4.0

---

## Cline Generated Change Description

Fix: LiteLLM provider settings not persisting across VSCode restarts

### Problem
LiteLLM provider settings (model ID, model configuration, API key, base URL, prompt cache settings) were being lost when VSCode restarted. This affected both the main settings panel and the quick popup settings in the chat interface, forcing users to reconfigure their LiteLLM setup repeatedly.

### Root Cause
The `setApiConfiguration` function in `ExtensionStateContext.tsx` only updated the local React state but never called the backend to persist changes to VSCode's storage. Unlike other settings like `setChatSettings`, API configuration changes were not being automatically saved.

### Solution
Modified `setApiConfiguration` in `webview-ui/src/context/ExtensionStateContext.tsx` to automatically persist API configuration changes to the backend storage, following the same pattern as `setChatSettings`.

### Changes
- **File**: `webview-ui/src/context/ExtensionStateContext.tsx`
- **Function**: `setApiConfiguration` now:
  1. Updates local React state immediately (preserves UI responsiveness)
  2. Automatically calls `StateServiceClient.updateSettings()` to persist changes
  3. Includes proper error handling with console logging
  4. Uses existing proto conversion functions for type safety

### Testing
- ✅ Linting and formatting passed
- ✅ All webview tests pass (36/36)
- ✅ Code compiles successfully
- ✅ No breaking changes to existing functionality
- ✅ Follows established codebase patterns

### Impact
- LiteLLM settings now persist correctly across VSCode restarts
- Works consistently with both main settings interface and popup settings
- Improves user experience by eliminating need to reconfigure LiteLLM repeatedly
- Maintains compatibility with all existing LiteLLM functionality

This fix ensures LiteLLM provider settings work as expected and match the behaviour of other API providers in the extension.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes persistence of LiteLLM provider settings across VSCode restarts by updating `setApiConfiguration` to persist changes to backend storage.
> 
>   - **Behavior**:
>     - Fixes persistence of LiteLLM provider settings (model ID, configuration, API key, etc.) across VSCode restarts.
>     - Updates `setApiConfiguration` in `ExtensionStateContext.tsx` to persist changes to backend storage.
>   - **Functionality**:
>     - `setApiConfiguration` now updates local state and calls `StateServiceClient.updateSettings()`.
>     - Includes error handling and uses proto conversion functions for type safety.
>   - **Testing**:
>     - Linting, formatting, and all tests pass.
>     - No breaking changes to existing functionality.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 29142fd0c4d71d1ac298529b1c8623a8cad609a1. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->