### PR TITLE
Replace vscode workspaceFolders with getCwd which uses the host bridge.

### DIFF
--- a/src/integrations/workspace/get-python-env.ts
+++ b/src/integrations/workspace/get-python-env.ts
@@ -1,3 +1,4 @@
+import { getCwd } from "@/utils/path"
 import * as vscode from "vscode"
 
 /*
@@ -28,12 +29,12 @@ export async function getPythonEnvPath(): Promise<string | undefined> {
 	// Access the Python extension API
 	const pythonApi = pythonExtension.exports
 	// Get the active environment path for the current workspace
-	const workspaceFolder = vscode.workspace.workspaceFolders?.[0]
+	const workspaceFolder = await getCwd()
 	if (!workspaceFolder) {
 		return undefined
 	}
 	// Get the active python environment path for the current workspace
-	const pythonEnv = await pythonApi?.environments?.getActiveEnvironmentPath(workspaceFolder.uri)
+	const pythonEnv = await pythonApi?.environments?.getActiveEnvironmentPath(workspaceFolder)
 	if (pythonEnv && pythonEnv.path) {
 		return pythonEnv.path
 	} else {


### PR DESCRIPTION
Use getCwd in src/integrations/workspace/get-python-env.ts
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Replace `vscode.workspace.workspaceFolders` with `getCwd` in `getPythonEnvPath()` to determine the current workspace folder.
> 
>   - **Behavior**:
>     - Replaces `vscode.workspace.workspaceFolders` with `getCwd` in `getPythonEnvPath()` in `get-python-env.ts`.
>     - Uses `getCwd` to determine the current workspace folder for fetching the active Python environment path.
>   - **Imports**:
>     - Adds import for `getCwd` from `@/utils/path` in `get-python-env.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 177cfc753ba6926246ec2e026a34d16bf4b95f72. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->