### PR TITLE
Use the host bridge to get the cwd in autoApprove.ts

### DIFF
--- a/src/core/task/ToolExecutor.ts
+++ b/src/core/task/ToolExecutor.ts
@@ -63,7 +63,10 @@ export class ToolExecutor {
 		return this.autoApprover.shouldAutoApproveTool(toolName)
 	}
 
-	private shouldAutoApproveToolWithPath(blockname: ToolUseName, autoApproveActionpath: string | undefined): boolean {
+	private async shouldAutoApproveToolWithPath(
+		blockname: ToolUseName,
+		autoApproveActionpath: string | undefined,
+	): Promise<boolean> {
 		return this.autoApprover.shouldAutoApproveToolWithPath(blockname, autoApproveActionpath)
 	}
 
@@ -573,7 +576,7 @@ export class ToolExecutor {
 						// update gui message
 						const partialMessage = JSON.stringify(sharedMessageProps)
 
-						if (this.shouldAutoApproveToolWithPath(block.name, relPath)) {
+						if (await this.shouldAutoApproveToolWithPath(block.name, relPath)) {
 							this.removeLastPartialMessageIfExistsWithType("ask", "tool") // in case the user changes auto-approval settings mid stream
 							await this.say("tool", partialMessage, undefined, undefined, block.partial)
 						} else {
@@ -645,7 +648,7 @@ export class ToolExecutor {
 							// 	)
 							// : undefined,
 						} satisfies ClineSayTool)
-						if (this.shouldAutoApproveToolWithPath(block.name, relPath)) {
+						if (await this.shouldAutoApproveToolWithPath(block.name, relPath)) {
 							this.removeLastPartialMessageIfExistsWithType("ask", "tool")
 							await this.say("tool", completeMessage, undefined, undefined, false)
 							this.taskState.consecutiveAutoApprovedRequestsCount++
@@ -782,7 +785,7 @@ export class ToolExecutor {
 							content: undefined,
 							operationIsLocatedInWorkspace: await isLocatedInWorkspace(relPath),
 						} satisfies ClineSayTool)
-						if (this.shouldAutoApproveToolWithPath(block.name, block.params.path)) {
+						if (await this.shouldAutoApproveToolWithPath(block.name, block.params.path)) {
 							this.removeLastPartialMessageIfExistsWithType("ask", "tool")
 							await this.say("tool", partialMessage, undefined, undefined, block.partial)
 						} else {
@@ -813,7 +816,7 @@ export class ToolExecutor {
 							content: absolutePath,
 							operationIsLocatedInWorkspace: await isLocatedInWorkspace(relPath),
 						} satisfies ClineSayTool)
-						if (this.shouldAutoApproveToolWithPath(block.name, block.params.path)) {
+						if (await this.shouldAutoApproveToolWithPath(block.name, block.params.path)) {
 							this.removeLastPartialMessageIfExistsWithType("ask", "tool")
 							await this.say("tool", completeMessage, undefined, undefined, false) // need to be sending partialValue bool, since undefined has its own purpose in that the message is treated neither as a partial or completion of a partial, but as a single complete message
 							this.taskState.consecutiveAutoApprovedRequestsCount++
@@ -864,7 +867,7 @@ export class ToolExecutor {
 							content: "",
 							operationIsLocatedInWorkspace: await isLocatedInWorkspace(block.params.path),
 						} satisfies ClineSayTool)
-						if (this.shouldAutoApproveToolWithPath(block.name, block.params.path)) {
+						if (await this.shouldAutoApproveToolWithPath(block.name, block.params.path)) {
 							this.removeLastPartialMessageIfExistsWithType("ask", "tool")
 							await this.say("tool", partialMessage, undefined, undefined, block.partial)
 						} else {
@@ -896,7 +899,7 @@ export class ToolExecutor {
 							content: result,
 							operationIsLocatedInWorkspace: await isLocatedInWorkspace(block.params.path),
 						} satisfies ClineSayTool)
-						if (this.shouldAutoApproveToolWithPath(block.name, block.params.path)) {
+						if (await this.shouldAutoApproveToolWithPath(block.name, block.params.path)) {
 							this.removeLastPartialMessageIfExistsWithType("ask", "tool")
 							await this.say("tool", completeMessage, undefined, undefined, false)
 							this.taskState.consecutiveAutoApprovedRequestsCount++
@@ -939,7 +942,7 @@ export class ToolExecutor {
 							content: "",
 							operationIsLocatedInWorkspace: await isLocatedInWorkspace(block.params.path),
 						} satisfies ClineSayTool)
-						if (this.shouldAutoApproveToolWithPath(block.name, block.params.path)) {
+						if (await this.shouldAutoApproveToolWithPath(block.name, block.params.path)) {
 							this.removeLastPartialMessageIfExistsWithType("ask", "tool")
 							await this.say("tool", partialMessage, undefined, undefined, block.partial)
 						} else {
@@ -968,7 +971,7 @@ export class ToolExecutor {
 							content: result,
 							operationIsLocatedInWorkspace: await isLocatedInWorkspace(block.params.path),
 						} satisfies ClineSayTool)
-						if (this.shouldAutoApproveToolWithPath(block.name, block.params.path)) {
+						if (await this.shouldAutoApproveToolWithPath(block.name, block.params.path)) {
 							this.removeLastPartialMessageIfExistsWithType("ask", "tool")
 							await this.say("tool", completeMessage, undefined, undefined, false)
 							this.taskState.consecutiveAutoApprovedRequestsCount++
@@ -1015,7 +1018,7 @@ export class ToolExecutor {
 							content: "",
 							operationIsLocatedInWorkspace: await isLocatedInWorkspace(block.params.path),
 						} satisfies ClineSayTool)
-						if (this.shouldAutoApproveToolWithPath(block.name, block.params.path)) {
+						if (await this.shouldAutoApproveToolWithPath(block.name, block.params.path)) {
 							this.removeLastPartialMessageIfExistsWithType("ask", "tool")
 							await this.say("tool", partialMessage, undefined, undefined, block.partial)
 						} else {
@@ -1052,7 +1055,7 @@ export class ToolExecutor {
 							content: results,
 							operationIsLocatedInWorkspace: await isLocatedInWorkspace(block.params.path),
 						} satisfies ClineSayTool)
-						if (this.shouldAutoApproveToolWithPath(block.name, block.params.path)) {
+						if (await this.shouldAutoApproveToolWithPath(block.name, block.params.path)) {
 							this.removeLastPartialMessageIfExistsWithType("ask", "tool")
 							await this.say("tool", completeMessage, undefined, undefined, false)
 							this.taskState.consecutiveAutoApprovedRequestsCount++

--- a/src/core/task/tools/autoApprove.ts
+++ b/src/core/task/tools/autoApprove.ts
@@ -1,11 +1,8 @@
 import { AutoApprovalSettings } from "@shared/AutoApprovalSettings"
 import { ToolUseName } from "@core/assistant-message"
 import * as path from "path"
-import * as vscode from "vscode"
 import os from "os"
-
-export const cwd =
-	vscode.workspace.workspaceFolders?.map((folder) => folder.uri.fsPath).at(0) ?? path.join(os.homedir(), "Desktop")
+import { getCwd } from "@/utils/path"
 
 export class AutoApprove {
 	autoApprovalSettings: AutoApprovalSettings
@@ -54,9 +51,10 @@ export class AutoApprove {
 	// Check if the tool should be auto-approved based on the settings
 	// and the path of the action. Returns true if the tool should be auto-approved
 	// based on the user's settings and the path of the action.
-	shouldAutoApproveToolWithPath(blockname: ToolUseName, autoApproveActionpath: string | undefined): boolean {
+	async shouldAutoApproveToolWithPath(blockname: ToolUseName, autoApproveActionpath: string | undefined): Promise<boolean> {
 		let isLocalRead: boolean = false
 		if (autoApproveActionpath) {
+			const cwd = await getCwd(path.join(os.homedir(), "Desktop"))
 			const absolutePath = path.resolve(cwd, autoApproveActionpath)
 			isLocalRead = absolutePath.startsWith(cwd)
 		} else {


### PR DESCRIPTION
Replaces uses of the vscode SDK with the host bridge.
Update the ToolExecutor to use await because the approval is now async.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> The PR updates `ToolExecutor` to handle async tool approval using `await` and modifies `autoApprove.ts` to use `getCwd()` for the current working directory.
> 
>   - **Behavior**:
>     - `ToolExecutor` now uses `await` for `shouldAutoApproveToolWithPath()` to handle async approval.
>     - Updates `autoApprove.ts` to use `getCwd()` for determining the current working directory.
>   - **Functions**:
>     - `shouldAutoApproveToolWithPath()` in `ToolExecutor.ts` and `autoApprove.ts` now return `Promise<boolean>`.
>   - **Misc**:
>     - Removed `vscode` dependency from `autoApprove.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 9e9a8faab9c704bd25529ad248417985350251d5. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->