### PR TITLE
Fall back to getting current terminal content when shell integration API fails to return output

### DIFF
--- a/src/integrations/terminal/TerminalProcess.test.ts
+++ b/src/integrations/terminal/TerminalProcess.test.ts
@@ -60,7 +60,14 @@ describe("TerminalProcess (Integration Tests)", () => {
 			const emitSpy = sandbox.spy(process, "emit")
 
 			// Run a simple command
-			await process.run(terminal, "echo test")
+			const runPromise = process.run(terminal, "echo test")
+
+			// If terminal doesn't have shell integration, advance timer
+			if (!terminal.shellIntegration) {
+				await sandbox.clock.tickAsync(3000)
+			}
+
+			await runPromise
 
 			// Verify that the continue event was emitted
 			;(emitSpy as sinon.SinonSpy).calledWith("continue").should.be.true()
@@ -76,7 +83,14 @@ describe("TerminalProcess (Integration Tests)", () => {
 			const emitSpy = sandbox.spy(process, "emit")
 
 			// Run a command that produces predictable output
-			await process.run(terminal, "echo 'Line 1' && echo 'Line 2'")
+			const runPromise = process.run(terminal, "echo 'Line 1' && echo 'Line 2'")
+
+			// If terminal doesn't have shell integration, advance timer
+			if (!terminal.shellIntegration) {
+				await sandbox.clock.tickAsync(3000)
+			}
+
+			await runPromise
 
 			// Check that the events were emitted
 			;(emitSpy as sinon.SinonSpy).calledWith("completed").should.be.true()
@@ -92,7 +106,14 @@ describe("TerminalProcess (Integration Tests)", () => {
 			const emitSpy = sandbox.spy(process, "emit")
 
 			// Run a command that lists files
-			await process.run(terminal, "ls -la")
+			const runPromise = process.run(terminal, "ls -la")
+
+			// If terminal doesn't have shell integration, advance timer
+			if (!terminal.shellIntegration) {
+				await sandbox.clock.tickAsync(3000)
+			}
+
+			await runPromise
 
 			// Verify that the continue event was emitted
 			;(emitSpy as sinon.SinonSpy).calledWith("continue").should.be.true()
@@ -130,7 +151,14 @@ describe("TerminalProcess (Integration Tests)", () => {
 			const emitSpy = sandbox.spy(process, "emit")
 
 			// Run a command that produces predictable output
-			await process.run(terminal, "echo 'Line 1' 'Line 2'")
+			const runPromise = process.run(terminal, "echo 'Line 1' 'Line 2'")
+
+			// If terminal doesn't have shell integration, advance timer
+			if (!terminal.shellIntegration) {
+				await sandbox.clock.tickAsync(3000)
+			}
+
+			await runPromise
 
 			// Check that the events were emitted
 			;(emitSpy as sinon.SinonSpy).calledWith("completed").should.be.true()
@@ -146,7 +174,14 @@ describe("TerminalProcess (Integration Tests)", () => {
 			const emitSpy = sandbox.spy(process, "emit")
 
 			// Run a command that produces predictable output
-			await process.run(terminal, "echo \"Line 1\" && echo 'Line 2'")
+			const runPromise = process.run(terminal, "echo \"Line 1\" && echo 'Line 2'")
+
+			// If terminal doesn't have shell integration, advance timer
+			if (!terminal.shellIntegration) {
+				await sandbox.clock.tickAsync(3000)
+			}
+
+			await runPromise
 
 			// Check that the events were emitted
 			;(emitSpy as sinon.SinonSpy).calledWith("completed").should.be.true()
@@ -169,8 +204,14 @@ describe("TerminalProcess (Integration Tests)", () => {
 		// Spy on the emit function to verify events
 		const emitSpy = sandbox.spy(process, "emit")
 
-		// Run the command
-		await process.run(terminal, "test-command")
+		// Run the command - this returns a promise
+		const runPromise = process.run(terminal, "test-command")
+
+		// Advance the fake timer by 3 seconds to trigger the setTimeout
+		await sandbox.clock.tickAsync(3000)
+
+		// Now wait for the promise to resolve
+		await runPromise
 
 		// Check that the correct methods were called and events emitted
 		sendTextStub.calledWith("test-command", true).should.be.true()

--- a/src/integrations/terminal/TerminalProcess.ts
+++ b/src/integrations/terminal/TerminalProcess.ts
@@ -1,7 +1,6 @@
 import { EventEmitter } from "events"
 import { stripAnsi } from "./ansiUtils"
 import * as vscode from "vscode"
-import { Logger } from "@services/logging/Logger"
 
 export interface TerminalProcessEvents {
 	line: [line: string]
@@ -23,84 +22,19 @@ export class TerminalProcess extends EventEmitter<TerminalProcessEvents> {
 	private lastRetrievedIndex: number = 0
 	isHot: boolean = false
 	private hotTimer: NodeJS.Timeout | null = null
-	private command: string = ""
-	private gracePeriodTimer: NodeJS.Timeout | null = null
-	private hasEmittedCompleted: boolean = false
 
 	// constructor() {
 	// 	super()
 
 	async run(terminal: vscode.Terminal, command: string) {
-		// Clear any existing grace period timer from previous commands
-		if (this.gracePeriodTimer) {
-			clearTimeout(this.gracePeriodTimer)
-			this.gracePeriodTimer = null
-			console.log(`[TerminalProcess] Cleared existing grace period timer before starting new command`)
-		}
-
-		// Clear any existing hot timer
-		if (this.hotTimer) {
-			clearTimeout(this.hotTimer)
-			this.hotTimer = null
-		}
-
-		// Reset state for new command
-		this.hasEmittedCompleted = false
-		this.buffer = ""
-		this.fullOutput = ""
-		this.lastRetrievedIndex = 0
-		this.isListening = true
-		this.isHot = false
-
-		this.command = command
-		console.log(`[TerminalProcess] Starting command: "${command}"`)
-		console.log(`[TerminalProcess] Shell integration available: ${!!terminal.shellIntegration?.executeCommand}`)
-		console.log(`[TerminalProcess] Terminal ID: ${terminal.name}`)
 		if (terminal.shellIntegration && terminal.shellIntegration.executeCommand) {
-			let execution
-			let stream
-
-			try {
-				execution = terminal.shellIntegration.executeCommand(command)
-				stream = execution.read()
-			} catch (error) {
-				console.error(`[TerminalProcess] Failed to execute command: ${error}`)
-				this.emit("error", error as Error)
-				return
-			}
-
+			const execution = terminal.shellIntegration.executeCommand(command)
+			const stream = execution.read()
 			// todo: need to handle errors
 			let isFirstChunk = true
 			let didOutputNonCommand = false
 			let didEmitEmptyLine = false
-			let receivedFirstChunk = false
-
-			// Set up a timeout to emit empty line if no output is received within 3 seconds
-			// This ensures the "proceed while running" button appears even for commands with no/delayed output
-			const firstChunkTimeout = setTimeout(() => {
-				if (!receivedFirstChunk && !didEmitEmptyLine) {
-					console.log(`[TerminalProcess] First chunk timeout fired - no output received within 3s for: "${command}"`)
-					this.emit("line", "") // empty line to show proceed button
-					didEmitEmptyLine = true
-
-					// Also emit a message indicating the command might be running without output
-					this.emit("line", "[Command is running but producing no output]")
-				}
-			}, 3000) // 3 second timeout
-
 			for await (let data of stream) {
-				// Clear the timeout since we received output
-				if (!receivedFirstChunk) {
-					clearTimeout(firstChunkTimeout)
-					receivedFirstChunk = true
-					console.log(`[TerminalProcess] First chunk received for command: "${command}"`)
-				}
-
-				// Log raw data length
-				console.log(`[TerminalProcess] Raw data chunk received: ${data.length} chars`)
-				if (!data || data.trim() === "") {
-					console.log(`[TerminalProcess] WARNING: Received empty or whitespace-only chunk`)
-				}
 				// 1. Process chunk and remove artifacts
 				if (isFirstChunk) {
 					/*
@@ -240,79 +174,14 @@ export class TerminalProcess extends EventEmitter<TerminalProcessEvents> {
 
 			this.emitRemainingBufferIfListening()
 
-			// Clean up the first chunk timeout if it's still active
-			if (!receivedFirstChunk) {
-				clearTimeout(firstChunkTimeout)
-				console.log(`[TerminalProcess] WARNING: Stream ended without receiving any chunks for command: "${command}"`)
-
-				// If we never received any chunks and haven't emitted anything yet, emit now
-				if (!didEmitEmptyLine) {
-					console.log(`[TerminalProcess] Emitting fallback empty line for no-output command`)
-					this.emit("line", "") // empty line to show proceed button
-					this.emit("line", "[Command completed with no output]")
-					didEmitEmptyLine = true
-				}
-			}
-
 			// for now we don't want this delaying requests since we don't send diagnostics automatically anymore (previous: "even though the command is finished, we still want to consider it 'hot' in case so that api request stalls to let diagnostics catch up")
 			if (this.hotTimer) {
 				clearTimeout(this.hotTimer)
 			}
 			this.isHot = false
 
-			console.log(`[TerminalProcess] Stream ended for command: "${command}"`)
-			console.log(`[TerminalProcess] Final output length: ${this.fullOutput.length} characters`)
-
-			// Check if this looks like a command that completed vs one that's still running
-			const quickCommands = ["cd ", "pwd", "ls ", "echo ", "mkdir ", "touch ", "rm ", "cp ", "mv "]
-			const isQuickCommand = quickCommands.some((cmd) => command.startsWith(cmd) || command.includes(" && " + cmd))
-
-			// Check if output suggests a long-running process
-			const longRunningIndicators = [
-				"listening on",
-				"server running",
-				"started on",
-				"watching for",
-				"compiled successfully",
-				"webpack",
-				"vite",
-				"nodemon",
-				"dev server",
-				"press ctrl",
-				"to quit",
-				"to exit",
-				"to stop",
-			]
-			const hasLongRunningOutput = longRunningIndicators.some((indicator) =>
-				this.fullOutput.toLowerCase().includes(indicator),
-			)
-
-			// Check if this is likely a command that starts a server or long-running process
-			const longRunningCommands = ["npm run", "npm start", "yarn", "node ", "python ", "serve", "dev", "watch"]
-			const isLongRunningCommand = longRunningCommands.some((cmd) => command.includes(cmd))
-
-			if (this.fullOutput.length === 0) {
-				console.log(`[TerminalProcess] WARNING: Process completed but no output was captured`)
-				// Ensure we emit at least one line for UI feedback
-				if (!didEmitEmptyLine) {
-					this.emit("line", "[Command completed silently]")
-				}
-			}
-
-			// Only skip grace period for truly quick commands that have no output or are known to complete instantly
-			if ((this.fullOutput.length === 0 || isQuickCommand) && !isLongRunningCommand && !hasLongRunningOutput) {
-				console.log(`[TerminalProcess] Command appears to have completed immediately, skipping grace period`)
-				this.emit("completed")
-				this.emit("continue")
-			} else {
-				console.log(
-					`[TerminalProcess] Command may still be running (longRunningCommand: ${isLongRunningCommand}, longRunningOutput: ${hasLongRunningOutput})`,
-				)
-				console.log(`[TerminalProcess] Starting grace period to detect true completion...`)
-				// Start grace period - wait 2.5 seconds to see if more output comes
-				// This prevents premature "proceed while running" for commands that clearly finished
-				this.startGracePeriod()
-			}
+			this.emit("completed")
+			this.emit("continue")
 		} else {
 			terminal.sendText(command, true)
 			// For terminals without shell integration, we can't know when the command completes
@@ -331,24 +200,14 @@ export class TerminalProcess extends EventEmitter<TerminalProcessEvents> {
 	private emitIfEol(chunk: string) {
 		this.buffer += chunk
 		let lineEndIndex: number
-		let lineCount = 0
 		while ((lineEndIndex = this.buffer.indexOf("\n")) !== -1) {
 			let line = this.buffer.slice(0, lineEndIndex).trimEnd() // removes trailing \r
 			// Remove \r if present (for Windows-style line endings)
 			// if (line.endsWith("\r")) {
 			// 	line = line.slice(0, -1)
 			// }
-			if (!line || line.trim() === "") {
-				console.log(`[TerminalProcess] Emitting empty line`)
-			} else {
-				console.log(`[TerminalProcess] Emitting line: ${line.substring(0, 100)}${line.length > 100 ? "..." : ""}`)
-			}
 			this.emit("line", line)
 			this.buffer = this.buffer.slice(lineEndIndex + 1)
-			lineCount++
-		}
-		if (lineCount === 0 && chunk.length > 0) {
-			console.log(`[TerminalProcess] Buffering partial line, buffer size: ${this.buffer.length}`)
 		}
 	}
 
@@ -363,41 +222,7 @@ export class TerminalProcess extends EventEmitter<TerminalProcessEvents> {
 		}
 	}
 
-	private startGracePeriod() {
-		// Clear any existing grace period timer
-		if (this.gracePeriodTimer) {
-			clearTimeout(this.gracePeriodTimer)
-		}
-
-		// Emit completed event for UI to show "proceed while running" button
-		console.log(`[TerminalProcess] Emitting completed event for UI (grace period active)`)
-		this.emit("completed")
-
-		// Wait 2.5 seconds to see if the command is truly finished
-		this.gracePeriodTimer = setTimeout(() => {
-			// Double-check the timer hasn't been cleared
-			if (this.gracePeriodTimer && !this.hasEmittedCompleted) {
-				console.log(`[TerminalProcess] Grace period completed - command appears truly finished: "${this.command}"`)
-				console.log(`[TerminalProcess] Auto-continuing without user intervention`)
-				this.hasEmittedCompleted = true
-				this.gracePeriodTimer = null
-				// Only emit continue after the grace period, not immediately
-				this.emit("continue")
-			}
-		}, 2500) // 2.5 second grace period
-	}
-
 	continue() {
-		console.log(`[TerminalProcess] Manual continue() called for: "${this.command}"`)
-
-		// Clear grace period since user manually continued
-		if (this.gracePeriodTimer) {
-			console.log(`[TerminalProcess] Clearing grace period timer due to manual continue`)
-			clearTimeout(this.gracePeriodTimer)
-			this.gracePeriodTimer = null
-		}
-
-		this.hasEmittedCompleted = true
 		this.emitRemainingBufferIfListening()
 		this.isListening = false
 		this.removeAllListeners("line")

--- a/src/integrations/terminal/TerminalProcess.ts
+++ b/src/integrations/terminal/TerminalProcess.ts
@@ -1,6 +1,7 @@
 import { EventEmitter } from "events"
 import { stripAnsi } from "./ansiUtils"
 import * as vscode from "vscode"
+import { Logger } from "@services/logging/Logger"
 import { getLatestTerminalOutput } from "./get-latest-output"
 
 export interface TerminalProcessEvents {
@@ -23,33 +24,98 @@ export class TerminalProcess extends EventEmitter<TerminalProcessEvents> {
 	private lastRetrievedIndex: number = 0
 	isHot: boolean = false
 	private hotTimer: NodeJS.Timeout | null = null
+	private command: string = ""
+	private gracePeriodTimer: NodeJS.Timeout | null = null
+	private hasEmittedCompleted: boolean = false
 
 	// constructor() {
 	// 	super()
 
 	async run(terminal: vscode.Terminal, command: string) {
 		// When command does not produce any output, we can assume the shell integration API failed and as a fallback return the current terminal contents
-		const returnCurrentTerminalContents = async () => {
+		const emitCurrentTerminalContents = async () => {
 			try {
 				const terminalSnapshot = await getLatestTerminalOutput()
 				if (terminalSnapshot && terminalSnapshot.trim()) {
 					const fallbackMessage = `The command's output could not be captured due to some technical issue, however it has been executed successfully. Here's the current terminal's content to help you get the command's output:\n\n${terminalSnapshot}`
 					this.emit("line", fallbackMessage)
-					this.fullOutput += fallbackMessage
 				}
 			} catch (error) {
-				console.error("Error capturing terminal output:", error);
+				console.error("Error capturing terminal output:", error)
 			}
 		}
 
+		// Clear any existing grace period timer from previous commands
+		if (this.gracePeriodTimer) {
+			clearTimeout(this.gracePeriodTimer)
+			this.gracePeriodTimer = null
+			console.log(`[TerminalProcess] Cleared existing grace period timer before starting new command`)
+		}
+
+		// Clear any existing hot timer
+		if (this.hotTimer) {
+			clearTimeout(this.hotTimer)
+			this.hotTimer = null
+		}
+
+		// Reset state for new command
+		this.hasEmittedCompleted = false
+		this.buffer = ""
+		this.fullOutput = ""
+		this.lastRetrievedIndex = 0
+		this.isListening = true
+		this.isHot = false
+
+		this.command = command
+		console.log(`[TerminalProcess] Starting command: "${command}"`)
+		console.log(`[TerminalProcess] Shell integration available: ${!!terminal.shellIntegration?.executeCommand}`)
+		console.log(`[TerminalProcess] Terminal ID: ${terminal.name}`)
 		if (terminal.shellIntegration && terminal.shellIntegration.executeCommand) {
-			const execution = terminal.shellIntegration.executeCommand(command)
-			const stream = execution.read()
+			let execution
+			let stream
+
+			try {
+				execution = terminal.shellIntegration.executeCommand(command)
+				stream = execution.read()
+			} catch (error) {
+				console.error(`[TerminalProcess] Failed to execute command: ${error}`)
+				this.emit("error", error as Error)
+				return
+			}
+
 			// todo: need to handle errors
 			let isFirstChunk = true
 			let didOutputNonCommand = false
 			let didEmitEmptyLine = false
+			let receivedFirstChunk = false
+
+			// Set up a timeout to emit empty line if no output is received within 3 seconds
+			// This ensures the "proceed while running" button appears even for commands with no/delayed output
+			const firstChunkTimeout = setTimeout(() => {
+				if (!receivedFirstChunk && !didEmitEmptyLine) {
+					console.log(`[TerminalProcess] First chunk timeout fired - no output received within 3s for: "${command}"`)
+					this.emit("line", "") // empty line to show proceed button
+					didEmitEmptyLine = true
+
+					// Also emit a message indicating the command might be running without output
+					// this.emit("line", "[Command is running but producing no output]")
+					emitCurrentTerminalContents()
+				}
+			}, 3000) // 3 second timeout
+
 			for await (let data of stream) {
+				// Clear the timeout since we received output
+				if (!receivedFirstChunk) {
+					clearTimeout(firstChunkTimeout)
+					receivedFirstChunk = true
+					console.log(`[TerminalProcess] First chunk received for command: "${command}"`)
+				}
+
+				// Log raw data length
+				console.log(`[TerminalProcess] Raw data chunk received: ${data.length} chars`)
+				if (!data || data.trim() === "") {
+					console.log(`[TerminalProcess] WARNING: Received empty or whitespace-only chunk`)
+				}
 				// 1. Process chunk and remove artifacts
 				if (isFirstChunk) {
 					/*
@@ -189,10 +255,19 @@ export class TerminalProcess extends EventEmitter<TerminalProcessEvents> {
 
 			this.emitRemainingBufferIfListening()
 
-			// console.log("fullOutput", this.fullOutput.trim())
-			// Check if command produced no meaningful output and capture terminal snapshot
-			if (!this.fullOutput.trim()) {
-				await returnCurrentTerminalContents()
+			// Clean up the first chunk timeout if it's still active
+			if (!receivedFirstChunk) {
+				clearTimeout(firstChunkTimeout)
+				console.log(`[TerminalProcess] WARNING: Stream ended without receiving any chunks for command: "${command}"`)
+
+				// If we never received any chunks and haven't emitted anything yet, emit now
+				if (!didEmitEmptyLine) {
+					console.log(`[TerminalProcess] Emitting fallback empty line for no-output command`)
+					this.emit("line", "") // empty line to show proceed button
+					// this.emit("line", "[Command completed with no output]")
+					await emitCurrentTerminalContents()
+					didEmitEmptyLine = true
+				}
 			}
 
 			// for now we don't want this delaying requests since we don't send diagnostics automatically anymore (previous: "even though the command is finished, we still want to consider it 'hot' in case so that api request stalls to let diagnostics catch up")
@@ -201,8 +276,59 @@ export class TerminalProcess extends EventEmitter<TerminalProcessEvents> {
 			}
 			this.isHot = false
 
-			this.emit("completed")
-			this.emit("continue")
+			console.log(`[TerminalProcess] Stream ended for command: "${command}"`)
+			console.log(`[TerminalProcess] Final output length: ${this.fullOutput.length} characters`)
+
+			// Check if this looks like a command that completed vs one that's still running
+			const quickCommands = ["cd ", "pwd", "ls ", "echo ", "mkdir ", "touch ", "rm ", "cp ", "mv "]
+			const isQuickCommand = quickCommands.some((cmd) => command.startsWith(cmd) || command.includes(" && " + cmd))
+
+			// Check if output suggests a long-running process
+			const longRunningIndicators = [
+				"listening on",
+				"server running",
+				"started on",
+				"watching for",
+				"compiled successfully",
+				"webpack",
+				"vite",
+				"nodemon",
+				"dev server",
+				"press ctrl",
+				"to quit",
+				"to exit",
+				"to stop",
+			]
+			const hasLongRunningOutput = longRunningIndicators.some((indicator) =>
+				this.fullOutput.toLowerCase().includes(indicator),
+			)
+
+			// Check if this is likely a command that starts a server or long-running process
+			const longRunningCommands = ["npm run", "npm start", "yarn", "node ", "python ", "serve", "dev", "watch"]
+			const isLongRunningCommand = longRunningCommands.some((cmd) => command.includes(cmd))
+
+			if (this.fullOutput.length === 0) {
+				console.log(`[TerminalProcess] WARNING: Process completed but no output was captured`)
+				// Ensure we emit at least one line for UI feedback
+				if (!didEmitEmptyLine) {
+					this.emit("line", "[Command completed silently]")
+				}
+			}
+
+			// Only skip grace period for truly quick commands that have no output or are known to complete instantly
+			if ((this.fullOutput.length === 0 || isQuickCommand) && !isLongRunningCommand && !hasLongRunningOutput) {
+				console.log(`[TerminalProcess] Command appears to have completed immediately, skipping grace period`)
+				this.emit("completed")
+				this.emit("continue")
+			} else {
+				console.log(
+					`[TerminalProcess] Command may still be running (longRunningCommand: ${isLongRunningCommand}, longRunningOutput: ${hasLongRunningOutput})`,
+				)
+				console.log(`[TerminalProcess] Starting grace period to detect true completion...`)
+				// Start grace period - wait 2.5 seconds to see if more output comes
+				// This prevents premature "proceed while running" for commands that clearly finished
+				this.startGracePeriod()
+			}
 		} else {
 			// no shell integration detected, we'll fallback to running the command and capturing the terminal's output after some time
 			terminal.sendText(command, true)
@@ -211,8 +337,7 @@ export class TerminalProcess extends EventEmitter<TerminalProcessEvents> {
 			await new Promise((resolve) => setTimeout(resolve, 3000))
 
 			// For terminals without shell integration, also try to capture terminal content
-			await returnCurrentTerminalContents()
-
+			await emitCurrentTerminalContents()
 			// For terminals without shell integration, we can't know when the command completes
 			// So we'll just emit the continue event after a delay
 			this.emit("completed")
@@ -229,14 +354,24 @@ export class TerminalProcess extends EventEmitter<TerminalProcessEvents> {
 	private emitIfEol(chunk: string) {
 		this.buffer += chunk
 		let lineEndIndex: number
+		let lineCount = 0
 		while ((lineEndIndex = this.buffer.indexOf("\n")) !== -1) {
 			let line = this.buffer.slice(0, lineEndIndex).trimEnd() // removes trailing \r
 			// Remove \r if present (for Windows-style line endings)
 			// if (line.endsWith("\r")) {
 			// 	line = line.slice(0, -1)
 			// }
+			if (!line || line.trim() === "") {
+				console.log(`[TerminalProcess] Emitting empty line`)
+			} else {
+				console.log(`[TerminalProcess] Emitting line: ${line.substring(0, 100)}${line.length > 100 ? "..." : ""}`)
+			}
 			this.emit("line", line)
 			this.buffer = this.buffer.slice(lineEndIndex + 1)
+			lineCount++
+		}
+		if (lineCount === 0 && chunk.length > 0) {
+			console.log(`[TerminalProcess] Buffering partial line, buffer size: ${this.buffer.length}`)
 		}
 	}
 
@@ -251,7 +386,41 @@ export class TerminalProcess extends EventEmitter<TerminalProcessEvents> {
 		}
 	}
 
+	private startGracePeriod() {
+		// Clear any existing grace period timer
+		if (this.gracePeriodTimer) {
+			clearTimeout(this.gracePeriodTimer)
+		}
+
+		// Emit completed event for UI to show "proceed while running" button
+		console.log(`[TerminalProcess] Emitting completed event for UI (grace period active)`)
+		this.emit("completed")
+
+		// Wait 2.5 seconds to see if the command is truly finished
+		this.gracePeriodTimer = setTimeout(() => {
+			// Double-check the timer hasn't been cleared
+			if (this.gracePeriodTimer && !this.hasEmittedCompleted) {
+				console.log(`[TerminalProcess] Grace period completed - command appears truly finished: "${this.command}"`)
+				console.log(`[TerminalProcess] Auto-continuing without user intervention`)
+				this.hasEmittedCompleted = true
+				this.gracePeriodTimer = null
+				// Only emit continue after the grace period, not immediately
+				this.emit("continue")
+			}
+		}, 2500) // 2.5 second grace period
+	}
+
 	continue() {
+		console.log(`[TerminalProcess] Manual continue() called for: "${this.command}"`)
+
+		// Clear grace period since user manually continued
+		if (this.gracePeriodTimer) {
+			console.log(`[TerminalProcess] Clearing grace period timer due to manual continue`)
+			clearTimeout(this.gracePeriodTimer)
+			this.gracePeriodTimer = null
+		}
+
+		this.hasEmittedCompleted = true
 		this.emitRemainingBufferIfListening()
 		this.isListening = false
 		this.removeAllListeners("line")

--- a/src/integrations/terminal/TerminalProcess.ts
+++ b/src/integrations/terminal/TerminalProcess.ts
@@ -311,7 +311,8 @@ export class TerminalProcess extends EventEmitter<TerminalProcessEvents> {
 				console.log(`[TerminalProcess] WARNING: Process completed but no output was captured`)
 				// Ensure we emit at least one line for UI feedback
 				if (!didEmitEmptyLine) {
-					this.emit("line", "[Command completed silently]")
+					// this.emit("line", "[Command completed silently]")
+					await emitCurrentTerminalContents()
 				}
 			}
 

--- a/src/integrations/terminal/TerminalProcess.ts
+++ b/src/integrations/terminal/TerminalProcess.ts
@@ -202,7 +202,11 @@ export class TerminalProcess extends EventEmitter<TerminalProcessEvents> {
 			this.emit("completed")
 			this.emit("continue")
 		} else {
+			// no shell integration detected, we'll fallback to running the command and capturing the terminal's output after some time
 			terminal.sendText(command, true)
+
+			// wait 3 seconds for the command to run
+			await new Promise((resolve) => setTimeout(resolve, 3000))
 
 			// For terminals without shell integration, also try to capture terminal content
 			await returnCurrentTerminalContents()

--- a/src/integrations/terminal/TerminalProcess.ts
+++ b/src/integrations/terminal/TerminalProcess.ts
@@ -28,7 +28,7 @@ export class TerminalProcess extends EventEmitter<TerminalProcessEvents> {
 	// 	super()
 
 	async run(terminal: vscode.Terminal, command: string) {
-		// When command does not product any output, we can assume the shell integration API failed and as a fallback return the current terminal contents
+		// When command does not produce any output, we can assume the shell integration API failed and as a fallback return the current terminal contents
 		const returnCurrentTerminalContents = async () => {
 			try {
 				const terminalSnapshot = await getLatestTerminalOutput()
@@ -37,7 +37,9 @@ export class TerminalProcess extends EventEmitter<TerminalProcessEvents> {
 					this.emit("line", fallbackMessage)
 					this.fullOutput += fallbackMessage
 				}
-			} catch {}
+			} catch (error) {
+				console.error("Error capturing terminal output:", error);
+			}
 		}
 
 		if (terminal.shellIntegration && terminal.shellIntegration.executeCommand) {

--- a/src/integrations/terminal/TerminalProcess.ts
+++ b/src/integrations/terminal/TerminalProcess.ts
@@ -98,8 +98,7 @@ export class TerminalProcess extends EventEmitter<TerminalProcessEvents> {
 					didEmitEmptyLine = true
 
 					// Also emit a message indicating the command might be running without output
-					// this.emit("line", "[Command is running but producing no output]")
-					emitCurrentTerminalContents()
+					this.emit("line", "[Command is running but producing no output]")
 				}
 			}, 3000) // 3 second timeout
 

--- a/webview-ui/src/components/chat/ChatRow.tsx
+++ b/webview-ui/src/components/chat/ChatRow.tsx
@@ -1376,7 +1376,7 @@ export const ChatRowContent = memo(
 												fontWeight: 500,
 												color: "var(--vscode-foreground)",
 											}}>
-											Shell Integration Error
+											Shell Integration Unavailable
 										</span>
 									</div>
 									<div style={{ color: "var(--vscode-foreground)", opacity: 0.8 }}>

--- a/webview-ui/src/components/chat/ChatRow.tsx
+++ b/webview-ui/src/components/chat/ChatRow.tsx
@@ -1353,7 +1353,7 @@ export const ChatRowContent = memo(
 									style={{
 										display: "flex",
 										flexDirection: "column",
-										backgroundColor: "rgba(255, 191, 0, 0.1)",
+										backgroundColor: "var(--vscode-textBlockQuote-background)",
 										padding: 8,
 										borderRadius: 3,
 										fontSize: 12,
@@ -1368,19 +1368,19 @@ export const ChatRowContent = memo(
 											className="codicon codicon-warning"
 											style={{
 												marginRight: 8,
-												fontSize: 18,
-												color: "#FFA500",
+												fontSize: 14,
+												color: "var(--vscode-descriptionForeground)",
 											}}></i>
 										<span
 											style={{
 												fontWeight: 500,
-												color: "#FFA500",
+												color: "var(--vscode-foreground)",
 											}}>
-											Shell Integration Unavailable
+											Shell Integration Error
 										</span>
 									</div>
-									<div>
-										Cline won't be able to view the command's output. Please update VSCode (
+									<div style={{ color: "var(--vscode-foreground)", opacity: 0.8 }}>
+										Cline may have trouble viewing the command's output. Please update VSCode (
 										<code>CMD/CTRL + Shift + P</code> → "Update") and make sure you're using a supported
 										shell: zsh, bash, fish, or PowerShell (<code>CMD/CTRL + Shift + P</code> → "Terminal:
 										Select Default Profile").{" "}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> `TerminalProcess` now captures terminal content as a fallback when shell integration fails, with updated tests and UI warnings.
> 
>   - **Behavior**:
>     - `TerminalProcess` in `TerminalProcess.ts` now falls back to capturing terminal content if shell integration fails.
>     - Emits "no_shell_integration" event when shell integration is unavailable.
>     - Updates `run()` to handle cases without shell integration by waiting 3 seconds and capturing terminal output.
>   - **Tests**:
>     - `TerminalProcess.test.ts` updated to test fallback behavior when shell integration is unavailable.
>     - Adds checks for "no_shell_integration" event emission.
>   - **UI**:
>     - `ChatRow.tsx` updates warning message style and content for shell integration unavailability.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 75a311f3452287443d69bec4878498e824c0dd09. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->