### PR TITLE
feat: Introduce Thinking Budget customization for Claude Code

### DIFF
--- a/.changeset/shy-fishes-check.md
+++ b/.changeset/shy-fishes-check.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+feat: Introduce Thinking Budget customization for Claude Code

--- a/src/api/providers/claude-code.ts
+++ b/src/api/providers/claude-code.ts
@@ -27,6 +27,7 @@ export class ClaudeCodeHandler implements ApiHandler {
 			messages: filteredMessages,
 			path: this.options.claudeCodePath,
 			modelId: this.getModel().id,
+			thinkingBudgetTokens: this.options.thinkingBudgetTokens,
 		})
 
 		// Usage is included with assistant messages,

--- a/src/integrations/claude-code/run.ts
+++ b/src/integrations/claude-code/run.ts
@@ -11,6 +11,7 @@ type ClaudeCodeOptions = {
 	messages: Anthropic.Messages.MessageParam[]
 	path?: string
 	modelId?: string
+	thinkingBudgetTokens?: number
 }
 
 type ProcessState = {
@@ -107,7 +108,7 @@ const claudeCodeTools = [
 
 const CLAUDE_CODE_TIMEOUT = 600000 // 10 minutes
 
-function runProcess({ systemPrompt, messages, path, modelId }: ClaudeCodeOptions) {
+function runProcess({ systemPrompt, messages, path, modelId, thinkingBudgetTokens }: ClaudeCodeOptions) {
 	const claudePath = path || "claude"
 
 	const args = [
@@ -132,6 +133,7 @@ function runProcess({ systemPrompt, messages, path, modelId }: ClaudeCodeOptions
 		...process.env,
 		// The default is 32000. However, I've gotten larger responses, so we increase it unless the user specified it.
 		CLAUDE_CODE_MAX_OUTPUT_TOKENS: process.env.CLAUDE_CODE_MAX_OUTPUT_TOKENS || "64000",
+		MAX_THINKING_TOKENS: (thinkingBudgetTokens || 0).toString(),
 	}
 
 	// We don't want to consume the user's ANTHROPIC_API_KEY,

--- a/webview-ui/src/components/settings/providers/AnthropicProvider.tsx
+++ b/webview-ui/src/components/settings/providers/AnthropicProvider.tsx
@@ -9,7 +9,11 @@ import { useExtensionState } from "@/context/ExtensionStateContext"
 import { useApiConfigurationHandlers } from "../utils/useApiConfigurationHandlers"
 
 // Anthropic models that support thinking/reasoning mode
-const SUPPORTED_THINKING_MODELS = ["claude-3-7-sonnet-20250219", "claude-sonnet-4-20250514", "claude-opus-4-20250514"]
+export const SUPPORTED_ANTHROPIC_THINKING_MODELS = [
+	"claude-3-7-sonnet-20250219",
+	"claude-sonnet-4-20250514",
+	"claude-opus-4-20250514",
+]
 
 /**
  * Props for the AnthropicProvider component
@@ -54,7 +58,7 @@ export const AnthropicProvider = ({ showModelOptions, isPopup }: AnthropicProvid
 						label="Model"
 					/>
 
-					{SUPPORTED_THINKING_MODELS.includes(selectedModelId) && (
+					{SUPPORTED_ANTHROPIC_THINKING_MODELS.includes(selectedModelId) && (
 						<ThinkingBudgetSlider maxBudget={selectedModelInfo.thinkingConfig?.maxBudget} />
 					)}
 

--- a/webview-ui/src/components/settings/providers/ClaudeCodeProvider.tsx
+++ b/webview-ui/src/components/settings/providers/ClaudeCodeProvider.tsx
@@ -5,6 +5,8 @@ import { ModelInfoView } from "../common/ModelInfoView"
 import { normalizeApiConfiguration } from "../utils/providerUtils"
 import { useApiConfigurationHandlers } from "../utils/useApiConfigurationHandlers"
 import { useExtensionState } from "@/context/ExtensionStateContext"
+import { SUPPORTED_ANTHROPIC_THINKING_MODELS } from "./AnthropicProvider"
+import ThinkingBudgetSlider from "../ThinkingBudgetSlider"
 
 /**
  * Props for the ClaudeCodeProvider component
@@ -52,6 +54,10 @@ export const ClaudeCodeProvider = ({ showModelOptions, isPopup }: ClaudeCodeProv
 						onChange={(e: any) => handleFieldChange("apiModelId", e.target.value)}
 						label="Model"
 					/>
+
+					{SUPPORTED_ANTHROPIC_THINKING_MODELS.includes(selectedModelId) && (
+						<ThinkingBudgetSlider maxBudget={selectedModelInfo.thinkingConfig?.maxBudget} />
+					)}
 
 					<ModelInfoView selectedModelId={selectedModelId} modelInfo={selectedModelInfo} isPopup={isPopup} />
 				</>


### PR DESCRIPTION
### Description

This PR integrates the exiting thinking budget configuration into Claude Code.

### Test Procedure

I enabled the option, prompted Claude for a prompt that would make it think, made a request and verified it thought. Disabled it, made the same request twice and verified it didn't think. Enabled it again, made the same request, and verified it thought again.

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

With thinking enabled:
<img width="211" alt="image" src="https://github.com/user-attachments/assets/7cea1370-7ae4-419c-94d0-5cf5d06b76aa" />
<img width="207" alt="image" src="https://github.com/user-attachments/assets/53d69038-34a2-42a7-a476-13b8905fef4c" />

With thinking disabled:
<img width="212" alt="image" src="https://github.com/user-attachments/assets/d123ca31-7a51-47ce-b429-6bb6d24320d8" />
<img width="214" alt="image" src="https://github.com/user-attachments/assets/b04e861c-d578-4c55-9d67-a56370cf1aa7" />


The options:
With a model that supports thinking:
<img width="200" alt="image" src="https://github.com/user-attachments/assets/6f500886-5485-4c3f-9642-3fe4f5070ce8" />

With a model that doesn't support thinking:
<img width="194" alt="image" src="https://github.com/user-attachments/assets/e2b5f944-53e2-4ef1-8c9b-f48b498d14ed" />

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Introduce thinking budget customization for Claude Code with UI and API updates.
> 
>   - **Behavior**:
>     - Adds `thinkingBudgetTokens` option to `ClaudeCodeHandler` in `claude-code.ts` and `runProcess` in `run.ts`.
>     - Updates `runClaudeCode` to handle `thinkingBudgetTokens`.
>   - **UI Components**:
>     - Adds `ThinkingBudgetSlider` to `ClaudeCodeProvider` and `AnthropicProvider` in `ClaudeCodeProvider.tsx` and `AnthropicProvider.tsx`.
>     - Updates `ApiOptions` in `ApiOptions.tsx` to pass `setApiConfiguration` to providers.
>   - **Constants**:
>     - Renames `SUPPORTED_THINKING_MODELS` to `SUPPORTED_ANTHROPIC_THINKING_MODELS` in `AnthropicProvider.tsx` and uses it in `ClaudeCodeProvider.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for c33b4514e757770f08fb816eb954f4690a8c4465. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->