### PR TITLE
Cleanup: Remove unused property and param postMessage from ClineAccountService

### DIFF
--- a/src/core/controller/index.ts
+++ b/src/core/controller/index.ts
@@ -78,13 +78,10 @@ export class Controller {
 			(msg) => this.postMessageToWebview(msg),
 			this.context.extension?.packageJSON?.version ?? "1.0.0",
 		)
-		this.accountService = new ClineAccountService(
-			(msg) => this.postMessageToWebview(msg),
-			async () => {
-				const { apiConfiguration } = await this.getStateToPostToWebview()
-				return apiConfiguration?.clineApiKey
-			},
-		)
+		this.accountService = new ClineAccountService(async () => {
+			const { apiConfiguration } = await this.getStateToPostToWebview()
+			return apiConfiguration?.clineApiKey
+		})
 
 		// Clean up legacy checkpoints
 		cleanupLegacyCheckpoints(this.context.globalStorageUri.fsPath, this.outputChannel).catch((error) => {

--- a/src/services/account/ClineAccountService.ts
+++ b/src/services/account/ClineAccountService.ts
@@ -4,14 +4,9 @@ import { ExtensionMessage } from "@shared/ExtensionMessage"
 
 export class ClineAccountService {
 	private readonly baseUrl = "https://api.cline.bot/v1"
-	private postMessageToWebview: (message: ExtensionMessage) => Promise<void>
 	private getClineApiKey: () => Promise<string | undefined>
 
-	constructor(
-		postMessageToWebview: (message: ExtensionMessage) => Promise<void>,
-		getClineApiKey: () => Promise<string | undefined>,
-	) {
-		this.postMessageToWebview = postMessageToWebview
+	constructor(getClineApiKey: () => Promise<string | undefined>) {
 		this.getClineApiKey = getClineApiKey
 	}
 

--- a/src/services/test/TestMode.ts
+++ b/src/services/test/TestMode.ts
@@ -9,7 +9,6 @@ import * as path from "path"
 import { Logger } from "../logging/Logger"
 import { createTestServer, shutdownTestServer } from "./TestServer"
 import { getHostBridgeProvider } from "@/hosts/host-providers"
-import { GetWorkspacePathsRequest } from "@/shared/proto/index.host"
 
 // State variable
 let isTestMode = false


### PR DESCRIPTION
Remove unused property and param postMessage from ClineAccountService

Remove unused import.