### PR TITLE
Confirmation popup when deleting tasks

### DIFF
--- a/.changeset/afraid-experts-beg.md
+++ b/.changeset/afraid-experts-beg.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Add confirmation popup when deleting tasks

--- a/src/core/controller/task/deleteTasksWithIds.ts
+++ b/src/core/controller/task/deleteTasksWithIds.ts
@@ -1,5 +1,6 @@
 import path from "path"
 import fs from "fs/promises"
+import vscode from "vscode"
 import { Controller } from ".."
 import { Empty, StringArrayRequest, BooleanRequest } from "../../../shared/proto/common"
 import { TaskMethodHandler } from "./index"
@@ -18,6 +19,18 @@ export const deleteTasksWithIds: TaskMethodHandler = async (
 ): Promise<Empty> => {
 	if (!request.value || request.value.length === 0) {
 		throw new Error("Missing task IDs")
+	}
+
+	const taskCount = request.value.length
+	const message =
+		taskCount === 1
+			? "Are you sure you want to delete this task? This action cannot be undone."
+			: `Are you sure you want to delete these ${taskCount} tasks? This action cannot be undone.`
+
+	const userChoice = await vscode.window.showWarningMessage(message, { modal: true }, "Delete")
+
+	if (userChoice === undefined) {
+		return Empty.create()
 	}
 
 	for (const id of request.value) {

--- a/webview-ui/src/components/chat/task-header/buttons/DeleteTaskButton.tsx
+++ b/webview-ui/src/components/chat/task-header/buttons/DeleteTaskButton.tsx
@@ -7,7 +7,7 @@ const DeleteTaskButton: React.FC<{
 	taskSize: string
 	taskId?: string
 }> = ({ taskSize, taskId }) => (
-	<HeroTooltip content="Delete Task & Checkpoints">
+	<HeroTooltip content="Delete Task">
 		<VSCodeButton
 			appearance="icon"
 			onClick={() => taskId && TaskServiceClient.deleteTasksWithIds(StringArrayRequest.create({ value: [taskId] }))}


### PR DESCRIPTION
<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- Opened an issue and discussed your proposed changes with the community / contributors
- Received approval from a core Cline contributor prior to proceeding with the implementation
- Link the associated issue in the "Related Issue" section

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly.

Why this requirement?
We deeply appreciate all community contributions - they are the core reason we're able to operate successfully and keep innovating! We welcome community input and want to make it as easy as possible for people to submit quality work. This process helps our core maintainers review new ideas faster and saves contributor time by ensuring you have the go-ahead before spending time on implementation.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** #XXXX

### Description

Adds a simple confirmation popup when users attempt to delete a single task from the task header.

### Test Procedure

Delete a task using the trash can icon in the task header- it should confirm this with the user before deleting it.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [X] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [X] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [X] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [X] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [X] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [X] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

![image](https://github.com/user-attachments/assets/8fe445ae-24bc-46f7-bfeb-5db1c1e1750c)

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add confirmation popup for task deletion in `deleteTasksWithIds.ts` and update `DeleteTaskButton.tsx` tooltip.
> 
>   - **Behavior**:
>     - Adds confirmation popup in `deleteTasksWithIds.ts` using `vscode.window.showWarningMessage` before deleting tasks.
>     - Updates `DeleteTaskButton.tsx` tooltip text to "Delete Task".
>   - **UI**:
>     - `DeleteTaskButton.tsx` now triggers a confirmation before task deletion.
>   - **Misc**:
>     - Adds changeset `afraid-experts-beg.md` for patch release.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 76ebef7d3af65ca398b7708e638a7d6f3269730c. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->