### PR TITLE
Strip thinking tokens from Cerebras reasoning model inputs

### DIFF
--- a/.changeset/chilly-sheep-rhyme.md
+++ b/.changeset/chilly-sheep-rhyme.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Strip thinking tokens from Cerebras reasoning model inputs

--- a/.changeset/chilly-sheep-rhyme.md
+++ b/.changeset/chilly-sheep-rhyme.md
@@ -2,4 +2,4 @@
 "claude-dev": patch
 ---
 
-Strip thinking tokens from Cerebras reasoning model inputs
+Improve cerebras Qwen model performance by removing thinking tokens from the model input


### PR DESCRIPTION
Filter out thinking tokens in message history

### Description

 - Remove thinking tags from Cerebras reasoning model inputs
 - Keep UI normal for the user

### Test Procedure

 - Console logging and end user testing

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds functionality to strip `<think>` tags from Cerebras reasoning model inputs in `cerebras.ts`.
> 
>   - **Behavior**:
>     - Adds `stripThinkingTags` function in `CerebrasHandler` to remove `<think>` tags from message content.
>     - Applies tag stripping to assistant messages for reasoning models (`qwen`, `deepseek-r1-distill`).
>   - **Implementation**:
>     - Checks model ID to determine if it's a reasoning model in `createMessage()`.
>     - Adjusts message processing to exclude `<think>` tags from conversation history.
>   - **Misc**:
>     - Removes redundant model ID check in streaming response handling.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for e83f6e0886df2df665410cc1c8930bc4bb205d91. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->