### PR TITLE
Fix url no trim

### DIFF
--- a/.changeset/tiny-pants-train.md
+++ b/.changeset/tiny-pants-train.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+trim input value for URL fields

--- a/webview-ui/src/components/settings/common/BaseUrlField.tsx
+++ b/webview-ui/src/components/settings/common/BaseUrlField.tsx
@@ -44,7 +44,7 @@ export const BaseUrlField = ({
 					value={localValue}
 					style={{ width: "100%", marginTop: 3 }}
 					type="url"
-					onInput={(e: any) => setLocalValue(e.target.value)}
+					onInput={(e: any) => setLocalValue(e.target.value.trim())}
 					placeholder={placeholder}
 				/>
 			)}

--- a/webview-ui/src/components/settings/common/DebouncedTextField.tsx
+++ b/webview-ui/src/components/settings/common/DebouncedTextField.tsx
@@ -22,11 +22,18 @@ interface DebouncedTextFieldProps {
  * A wrapper around VSCodeTextField that automatically handles debounced input
  * to prevent excessive API calls while typing
  */
-export const DebouncedTextField = ({ initialValue, onChange, children, ...otherProps }: DebouncedTextFieldProps) => {
+export const DebouncedTextField = ({ initialValue, onChange, children, type, ...otherProps }: DebouncedTextFieldProps) => {
 	const [localValue, setLocalValue] = useDebouncedInput(initialValue, onChange)
 
 	return (
-		<VSCodeTextField {...otherProps} value={localValue} onInput={(e: any) => setLocalValue(e.target.value)}>
+		<VSCodeTextField
+			{...otherProps}
+			type={type}
+			value={localValue}
+			onInput={(e: any) => {
+				const value = e.target.value
+				setLocalValue(type === "url" ? value.trim() : value)
+			}}>
 			{children}
 		</VSCodeTextField>
 	)


### PR DESCRIPTION

### Related Issue

https://github.com/cline/cline/issues/4051

### Description

#### Current Status

When users enter a custom URL in cline, if there are spaces before or after the URL, cline's interface will not display the spaces at the beginning and end, but the URL actually used internally by cline still contains the spaces. The display does not match the actual, which can cause request errors and make troubleshooting difficult.

This issue occurs when using the `VSCodeTextField `component with type set to `URL`. The involved base components are: [BaseUrlField](https://github.com/cline/cline/blob/6c2c0780eea9a37ec408ebee8c1371ec8bdd9c6f/webview-ui/src/components/settings/common/BaseUrlField.tsx#L46) and [DebouncedTextField](https://github.com/cline/cline/blob/6c2c0780eea9a37ec408ebee8c1371ec8bdd9c6f/webview-ui/src/components/settings/common/DebouncedTextField.tsx#L25). The affected providers include: [AskSageProvider](https://github.com/cline/cline/blob/6c2c0780eea9a37ec408ebee8c1371ec8bdd9c6f/webview-ui/src/components/settings/providers/AskSageProvider.tsx#L41), [BedrockProvider](https://github.com/cline/cline/blob/6c2c0780eea9a37ec408ebee8c1371ec8bdd9c6f/webview-ui/src/components/settings/providers/BedrockProvider.tsx#L141), [LiteLlmProvider](https://github.com/cline/cline/blob/6c2c0780eea9a37ec408ebee8c1371ec8bdd9c6f/webview-ui/src/components/settings/providers/LiteLlmProvider.tsx#L39), [OpenAICompatibleProvider](https://github.com/cline/cline/blob/6c2c0780eea9a37ec408ebee8c1371ec8bdd9c6f/webview-ui/src/components/settings/providers/OpenAICompatible.tsx#L74), [AnthropicProvider](https://github.com/cline/cline/blob/6c2c0780eea9a37ec408ebee8c1371ec8bdd9c6f/webview-ui/src/components/settings/providers/AnthropicProvider.tsx#L45), [GeminiProvider](https://github.com/cline/cline/blob/6c2c0780eea9a37ec408ebee8c1371ec8bdd9c6f/webview-ui/src/components/settings/providers/GeminiProvider.tsx#L41), [LMStudioProvider](https://github.com/cline/cline/blob/6c2c0780eea9a37ec408ebee8c1371ec8bdd9c6f/webview-ui/src/components/settings/providers/LMStudioProvider.tsx#L53), and [OllamaProvider](https://github.com/cline/cline/blob/6c2c0780eea9a37ec408ebee8c1371ec8bdd9c6f/webview-ui/src/components/settings/providers/OllamaProvider.tsx#L54).

![image](https://github.com/user-attachments/assets/4dd11a4e-d727-453e-896f-71ab95f98a07)
![image](https://github.com/user-attachments/assets/e76feaf2-cda1-4c2e-8f6b-bfe46f80cf73)


#### Reason

The reason for this issue is very interesting.
The `VSCodeTextField` component actually uses `@microsoft/fast-foundation's` [TextField](https://github.com/microsoft/fast/blob/fd9068b94e4aa8d2282f0cce613f58436fae955d/packages/web-components/fast-foundation/src/text-field/text-field.ts#L34). The underlying implementation of the TextField is a [web-component with two-way binding](https://github.com/microsoft/fast/blob/fd9068b94e4aa8d2282f0cce613f58436fae955d/packages/web-components/fast-foundation/src/text-field/text-field.template.ts#L52) functionality. During the actual execution of value binding, it directly [assigns the value](https://github.com/microsoft/fast/blob/fd9068b94e4aa8d2282f0cce613f58436fae955d/packages/web-components/fast-element/src/templating/binding.ts#L143) to the shadow element.
If the type of this element is `url`, the browser environment will apply the [sanitization algorithm](https://html.spec.whatwg.org/multipage/input.html#url-state-(type=url)) to the value, removing spaces on both sides of the value. This is the default behavior of the browser and will only occur when the value is assigned via JavaScript. If the user enters the value directly into the input, it will not happen.

#### Changes

Since the package of the VSCodeTextField component is [no longer maintained](https://github.com/microsoft/vscode-webview-ui-toolkit/issues/561), this change only performs a trim operation on the value when the type is url, so that the actual value matches the displayed value, and also avoids request errors caused by spaces.

### Test Procedure

1. Verified that pasting a URL with spaces correctly sends the request.
2. Verified that when the user deletes input, value.trim does not cause an error.

### Type of Change


-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

No changes on the interface

### Additional Notes

In the long term, it would be more reasonable to migrate the UI components to another component library and implement input validation.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Trim spaces from URL input values in `BaseUrlField` and `DebouncedTextField` to ensure consistency and prevent errors.
> 
>   - **Behavior**:
>     - Trim spaces from URL input values in `BaseUrlField` and `DebouncedTextField` to ensure consistency between displayed and actual values.
>     - Prevents request errors caused by leading or trailing spaces in URLs.
>   - **Components**:
>     - Modify `onInput` handler in `BaseUrlField` to trim URL values.
>     - Modify `onInput` handler in `DebouncedTextField` to conditionally trim URL values based on type.
>   - **Misc**:
>     - Add changeset `tiny-pants-train.md` to document the patch.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for d97a48ab3abfc2eca37415827fe7bd5ebb18fdd5. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->