### PR TITLE
fixed: `Discard Changes` button in Settings

### DIFF
--- a/.changeset/forty-items-explode.md
+++ b/.changeset/forty-items-explode.md
@@ -1,0 +1,9 @@
+---
+"claude-dev": patch
+---
+
+fixed: "Discard Changes" button in UnsavedChangesDialog not working properly
+- Added proper event handlers to ensure dialog closes after executing callbacks
+- Fixed issue where clicking "Discard Changes" would call the callback but leave dialog open
+- Improved user experience by ensuring dialog dismisses correctly after all button actions
+This change ensures that when users click "Discard Changes" (or any other action button) in the unsaved changes dialog, the dialog properly closes after executing the intended action.

--- a/webview-ui/src/components/common/AlertDialog.tsx
+++ b/webview-ui/src/components/common/AlertDialog.tsx
@@ -94,6 +94,23 @@ export function UnsavedChangesDialog({
 	saveText?: string
 	showSaveOption?: boolean
 }) {
+	const handleConfirm = () => {
+		onConfirm()
+		onOpenChange(false)
+	}
+
+	const handleCancel = () => {
+		onCancel()
+		onOpenChange(false)
+	}
+
+	const handleSave = () => {
+		if (onSave) {
+			onSave()
+		}
+		onOpenChange(false)
+	}
+
 	return (
 		<AlertDialog open={open} onOpenChange={onOpenChange}>
 			<AlertDialogContent>
@@ -105,9 +122,9 @@ export function UnsavedChangesDialog({
 					<AlertDialogDescription>{description}</AlertDialogDescription>
 				</AlertDialogHeader>
 				<AlertDialogFooter>
-					<AlertDialogCancel onClick={onCancel}>Cancel</AlertDialogCancel>
-					{showSaveOption && onSave && <AlertDialogAction onClick={onSave}>{saveText}</AlertDialogAction>}
-					<AlertDialogAction onClick={onConfirm} appearance={showSaveOption ? "secondary" : "primary"}>
+					<AlertDialogCancel onClick={handleCancel}>Cancel</AlertDialogCancel>
+					{showSaveOption && onSave && <AlertDialogAction onClick={handleSave}>{saveText}</AlertDialogAction>}
+					<AlertDialogAction onClick={handleConfirm} appearance={showSaveOption ? "secondary" : "primary"}>
 						{confirmText}
 					</AlertDialogAction>
 				</AlertDialogFooter>


### PR DESCRIPTION
<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- Opened an issue and discussed your proposed changes with the community / contributors
- Received approval from a core Cline contributor prior to proceeding with the implementation
- Link the associated issue in the "Related Issue" section

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly.

Why this requirement?
We deeply appreciate all community contributions - they are the core reason we're able to operate successfully and keep innovating! We welcome community input and want to make it as easy as possible for people to submit quality work. This process helps our core maintainers review new ideas faster and saves contributor time by ensuring you have the go-ahead before spending time on implementation.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** #3955 

### Description
fixed: "Discard Changes" button in UnsavedChangesDialog not working properly
- Added proper event handlers to ensure dialog closes after executing callbacks
- Fixed issue where clicking "Discard Changes" would call the callback but leave dialog open
- Improved user experience by ensuring dialog dismisses correctly after all button actions

This change ensures that when users click "Discard Changes" (or any other action button) in the unsaved changes dialog, the dialog properly closes after executing the intended action.

<!-- 
Help reviewers understand your changes by making this PR readable and well-organized:

- What problem does this PR solve?
- Why were these changes introduced and what purpose do they serve?
- For larger changes, provide context about your approach and reasoning

Small PRs may need minimal description, but larger changes benefit from explaining where you're coming from. Much of this context can be in the linked issue above, so feel free to reference it rather than repeating everything here.
-->

### Test Procedure

<!-- 
Please walk us through your testing approach and thought process. This helps reviewers understand that you've thoroughly considered the impact of your changes:

- How did you test this change?
- What could potentially break and how did you verify it doesn't?
- What existing functionality might be affected and how did you check it still works?
- Why are you confident this is ready for merge?

We're not looking for exhaustive documentation - just evidence that you've thought through the implications of your changes and tested accordingly.
-->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes `UnsavedChangesDialog` to close properly after executing button actions by adding event handlers in `AlertDialog.tsx`.
> 
>   - **Behavior**:
>     - Fixes `UnsavedChangesDialog` to close after executing callbacks for "Discard Changes", "Cancel", and "Save & Continue".
>     - Adds `handleConfirm`, `handleCancel`, and `handleSave` functions to manage dialog state in `AlertDialog.tsx`.
>   - **Functions**:
>     - `handleConfirm`: Calls `onConfirm` and closes dialog.
>     - `handleCancel`: Calls `onCancel` and closes dialog.
>     - `handleSave`: Calls `onSave` (if defined) and closes dialog.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 2efa1081ecf571f5ace1e98ec55053f40a6cd572. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->