### PR TITLE
Instead of getting the cwd from the workspaceFolders use the host bridge util getCwd()

### DIFF
--- a/src/core/context/context-tracking/FileContextTracker.ts
+++ b/src/core/context/context-tracking/FileContextTracker.ts
@@ -37,17 +37,6 @@ export class FileContextTracker {
 	}
 
 	/**
-	 * Gets the current working directory or returns undefined if it cannot be determined
-	 */
-	private async getCwd(): Promise<string | undefined> {
-		const cwd = await getCwd(undefined)
-		if (!cwd) {
-			console.info("No workspace folder available - cannot determine current working directory")
-		}
-		return cwd
-	}
-
-	/**
 	 * File watchers are set up for each file that is tracked in the task metadata.
 	 */
 	async setupFileWatcher(filePath: string) {
@@ -56,8 +45,9 @@ export class FileContextTracker {
 			return
 		}
 
-		const cwd = await this.getCwd()
+		const cwd = await getCwd()
 		if (!cwd) {
+			console.info("No workspace folder available - cannot determine current working directory")
 			return
 		}
 
@@ -87,8 +77,9 @@ export class FileContextTracker {
 	 */
 	async trackFileContext(filePath: string, operation: "read_tool" | "user_edited" | "cline_edited" | "file_mentioned") {
 		try {
-			const cwd = await this.getCwd()
+			const cwd = await getCwd()
 			if (!cwd) {
+				console.info("No workspace folder available - cannot determine current working directory")
 				return
 			}
 

--- a/src/core/controller/file/createRuleFile.ts
+++ b/src/core/controller/file/createRuleFile.ts
@@ -6,8 +6,8 @@ import { createRuleFile as createRuleFileImpl } from "@core/context/instructions
 import * as vscode from "vscode"
 import * as path from "path"
 import { handleFileServiceRequest } from "./index"
-import { cwd } from "@core/task"
 import { refreshWorkflowToggles } from "@/core/context/instructions/user-instructions/workflows"
+import { getCwd, getDesktopDir } from "@/utils/path"
 
 /**
  * Creates a rule file in either global or workspace rules directory
@@ -32,6 +32,7 @@ export const createRuleFile: FileMethodHandler = async (controller: Controller, 
 		throw new Error("Missing or invalid parameters")
 	}
 
+	const cwd = await getCwd(getDesktopDir())
 	const { filePath, fileExists } = await createRuleFileImpl(request.isGlobal, request.filename, cwd, request.type)
 
 	if (!filePath) {

--- a/src/core/controller/file/refreshRules.ts
+++ b/src/core/controller/file/refreshRules.ts
@@ -4,7 +4,7 @@ import type { Controller } from "../index"
 import { refreshClineRulesToggles } from "@core/context/instructions/user-instructions/cline-rules"
 import { refreshExternalRulesToggles } from "@core/context/instructions/user-instructions/external-rules"
 import { refreshWorkflowToggles } from "@core/context/instructions/user-instructions/workflows"
-import { cwd } from "@core/task"
+import { getCwd, getDesktopDir } from "@/utils/path"
 
 /**
  * Refreshes all rule toggles (Cline, External, and Workflows)
@@ -14,6 +14,7 @@ import { cwd } from "@core/task"
  */
 export async function refreshRules(controller: Controller, _request: EmptyRequest): Promise<RefreshedRules> {
 	try {
+		const cwd = await getCwd(getDesktopDir())
 		const { globalToggles, localToggles } = await refreshClineRulesToggles(controller.context, cwd)
 		const { cursorLocalToggles, windsurfLocalToggles } = await refreshExternalRulesToggles(controller.context, cwd)
 		const { localWorkflowToggles, globalWorkflowToggles } = await refreshWorkflowToggles(controller.context, cwd)

--- a/src/core/task/message-state.ts
+++ b/src/core/task/message-state.ts
@@ -12,7 +12,7 @@ import CheckpointTracker from "@integrations/checkpoints/CheckpointTracker"
 import { HistoryItem } from "@/shared/HistoryItem"
 import Anthropic from "@anthropic-ai/sdk"
 import { TaskState } from "./TaskState"
-import { getCwd } from "@/utils/path"
+import { getCwd, getDesktopDir } from "@/utils/path"
 
 interface MessageStateHandlerParams {
 	context: vscode.ExtensionContext
@@ -83,7 +83,7 @@ export class MessageStateHandler {
 			} catch (error) {
 				console.error("Failed to get task directory size:", taskDir, error)
 			}
-			const cwd = await getCwd(path.join(os.homedir(), "Desktop"))
+			const cwd = await getCwd(getDesktopDir())
 			await this.updateTaskHistory({
 				id: this.taskId,
 				ts: lastRelevantMessage.ts,

--- a/src/core/task/tools/autoApprove.ts
+++ b/src/core/task/tools/autoApprove.ts
@@ -2,7 +2,7 @@ import { AutoApprovalSettings } from "@shared/AutoApprovalSettings"
 import { ToolUseName } from "@core/assistant-message"
 import * as path from "path"
 import os from "os"
-import { getCwd } from "@/utils/path"
+import { getCwd, getDesktopDir } from "@/utils/path"
 
 export class AutoApprove {
 	autoApprovalSettings: AutoApprovalSettings
@@ -54,7 +54,7 @@ export class AutoApprove {
 	async shouldAutoApproveToolWithPath(blockname: ToolUseName, autoApproveActionpath: string | undefined): Promise<boolean> {
 		let isLocalRead: boolean = false
 		if (autoApproveActionpath) {
-			const cwd = await getCwd(path.join(os.homedir(), "Desktop"))
+			const cwd = await getCwd(getDesktopDir())
 			const absolutePath = path.resolve(cwd, autoApproveActionpath)
 			isLocalRead = absolutePath.startsWith(cwd)
 		} else {

--- a/src/integrations/checkpoints/CheckpointUtils.ts
+++ b/src/integrations/checkpoints/CheckpointUtils.ts
@@ -2,7 +2,7 @@ import { mkdir, access, constants } from "fs/promises"
 import * as path from "path"
 import * as vscode from "vscode"
 import os from "os"
-import { getCwd } from "@/utils/path"
+import { getCwd, getDesktopDir } from "@/utils/path"
 
 /**
  * Gets the path to the shadow Git repository in globalStorage.
@@ -61,7 +61,7 @@ export async function getWorkingDirectory(): Promise<string> {
 	}
 
 	const homedir = os.homedir()
-	const desktopPath = path.join(homedir, "Desktop")
+	const desktopPath = getDesktopDir()
 	const documentsPath = path.join(homedir, "Documents")
 	const downloadsPath = path.join(homedir, "Downloads")
 

--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -84,7 +84,7 @@ export function getReadablePath(cwd: string, relPath?: string): string {
 	relPath = relPath || ""
 	// path.resolve is flexible in that it will resolve relative paths like '../../' to the cwd and even ignore the cwd if the relPath is actually an absolute path
 	const absolutePath = path.resolve(cwd, relPath)
-	if (arePathsEqual(cwd, path.join(os.homedir(), "Desktop"))) {
+	if (arePathsEqual(cwd, getDesktopDir())) {
 		// User opened vscode without a workspace, so cwd is the Desktop. Show the full absolute path to keep the user aware of where files are being created
 		return absolutePath.toPosix()
 	}
@@ -106,6 +106,10 @@ export function getReadablePath(cwd: string, relPath?: string): string {
 export const getCwd = async (defaultCwdPath = ""): Promise<string> => {
 	const workspaceFolders = await getHostBridgeProvider().workspaceClient.getWorkspacePaths({})
 	return workspaceFolders.paths.shift() || defaultCwdPath
+}
+
+export function getDesktopDir() {
+	return path.join(os.homedir(), "Desktop")
 }
 
 // Returns the workspace path of the file in the current editor.


### PR DESCRIPTION
Don't export cwd from task/index.ts. This top-level property cwd will be removed in a following PR because `await` cannot be used at the top-level. 

Use the hostbridge util getCwd() in createRuleFile.ts and refreshRules.ts instead of import the cwd from `task`. 

Add a util function to get the desktop directory instead of constructing it multiple places, update uses with the new function getDesktopDir().

Replace function custom getCwd function in FileContextTracker.ts with just getCwd from paths.ts.

<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- Opened an issue and discussed your proposed changes with the community / contributors
- Received approval from a core Cline contributor prior to proceeding with the implementation
- Link the associated issue in the "Related Issue" section

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly.

Why this requirement?
We deeply appreciate all community contributions - they are the core reason we're able to operate successfully and keep innovating! We welcome community input and want to make it as easy as possible for people to submit quality work. This process helps our core maintainers review new ideas faster and saves contributor time by ensuring you have the go-ahead before spending time on implementation.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** #XXXX

### Description

<!-- 
Help reviewers understand your changes by making this PR readable and well-organized:

- What problem does this PR solve?
- Why were these changes introduced and what purpose do they serve?
- For larger changes, provide context about your approach and reasoning

Small PRs may need minimal description, but larger changes benefit from explaining where you're coming from. Much of this context can be in the linked issue above, so feel free to reference it rather than repeating everything here.
-->

### Test Procedure

<!-- 
Please walk us through your testing approach and thought process. This helps reviewers understand that you've thoroughly considered the impact of your changes:

- How did you test this change?
- What could potentially break and how did you verify it doesn't?
- What existing functionality might be affected and how did you check it still works?
- Why are you confident this is ready for merge?

We're not looking for exhaustive documentation - just evidence that you've thought through the implications of your changes and tested accordingly.
-->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [ ] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->
