### PR TITLE
Replace vscode.workspace.getWorkspaceFolder() with the host bridge

### DIFF
--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -1,8 +1,7 @@
-import * as path from "path"
-import os from "os"
-import * as vscode from "vscode"
 import { getHostBridgeProvider } from "@/hosts/host-providers"
-import { A } from "ollama/dist/shared/ollama.e009de91.mjs"
+import os from "os"
+import * as path from "path"
+import * as vscode from "vscode"
 
 /*
 The Node.js 'path' module resolves and normalizes paths differently depending on the platform:


### PR DESCRIPTION
- Replace vscode.workspace.getWorkspaceFolder() with the host bridge
  Use the existing hostbridge RPC getWorkspacePaths() to replace vscode.workspace.getWorkspaceFolder() 
- Update isLocatedInWorkspace() to check all the workspace directories, not just the first.

- Add utility function to check if a path is inside a directory instead of duplicating the logic in `isLocatedInWorkspace` and `getWorkspacePath`.

### Test Procedure

Tested manually in the vscode extension host **because the unit tests are still broken!!!**.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

NA

### Additional Notes

NA
