### PR TITLE
Lazily initialize provider SDKs

### DIFF
--- a/src/api/providers/__tests__/ollama.test.ts
+++ b/src/api/providers/__tests__/ollama.test.ts
@@ -45,8 +45,10 @@ describe("OllamaHandler", () => {
 				this.skip()
 			}
 			this.timeout(5000)
+			// Ensure client is initialized
+			const client = (handler as any).ensureClient()
 			// Mock the Ollama client's chat method
-			const chatStub = sinon.stub(handler["client"], "chat").resolves({
+			const chatStub = sinon.stub(client, "chat").resolves({
 				[Symbol.asyncIterator]: async function* () {
 					yield {
 						message: { content: "Hello, world!" },
@@ -139,8 +141,9 @@ describe("OllamaHandler", () => {
 			// Restore real timers for this test
 			clock.restore()
 
-			// Mock the Ollama client's chat method to fail on first call and succeed on second
-			const chatStub = sinon.stub(handler["client"], "chat")
+			// Ensure client is initialized and mock the Ollama client's chat method to fail on first call and succeed on second
+			const client = (handler as any).ensureClient()
+			const chatStub = sinon.stub(client, "chat")
 
 			// First call throws an error
 			chatStub.onFirstCall().rejects(new Error("API Error"))

--- a/src/api/providers/cerebras.ts
+++ b/src/api/providers/cerebras.ts
@@ -7,26 +7,37 @@ import { ApiStream } from "@api/transform/stream"
 
 export class CerebrasHandler implements ApiHandler {
 	private options: ApiHandlerOptions
-	private client: Cerebras
+	private client: Cerebras | undefined
 
 	constructor(options: ApiHandlerOptions) {
 		this.options = options
+	}
 
-		// Clean and validate the API key
-		const cleanApiKey = this.options.cerebrasApiKey?.trim()
+	private ensureClient(): Cerebras {
+		if (!this.client) {
+			// Clean and validate the API key
+			const cleanApiKey = this.options.cerebrasApiKey?.trim()
 
-		if (!cleanApiKey) {
-			throw new Error("Cerebras API key is required")
+			if (!cleanApiKey) {
+				throw new Error("Cerebras API key is required")
+			}
+
+			try {
+				this.client = new Cerebras({
+					apiKey: cleanApiKey,
+					timeout: 30000, // 30 second timeout
+				})
+			} catch (error) {
+				throw new Error(`Error creating Cerebras client: ${error.message}`)
+			}
 		}
-
-		this.client = new Cerebras({
-			apiKey: cleanApiKey,
-			timeout: 30000, // 30 second timeout
-		})
+		return this.client
 	}
 
 	@withRetry()
 	async *createMessage(systemPrompt: string, messages: Anthropic.Messages.MessageParam[]): ApiStream {
+		const client = this.ensureClient()
+
 		// Convert Anthropic messages to Cerebras format
 		const cerebrasMessages: Array<{
 			role: "system" | "user" | "assistant"
@@ -65,7 +76,7 @@ export class CerebrasHandler implements ApiHandler {
 		}
 
 		try {
-			const stream = await this.client.chat.completions.create({
+			const stream = await client.chat.completions.create({
 				model: this.getModel().id,
 				messages: cerebrasMessages,
 				temperature: 0,

--- a/src/api/providers/deepseek.ts
+++ b/src/api/providers/deepseek.ts
@@ -10,14 +10,27 @@ import { convertToR1Format } from "../transform/r1-format"
 
 export class DeepSeekHandler implements ApiHandler {
 	private options: ApiHandlerOptions
-	private client: OpenAI
+	private client: OpenAI | undefined
 
 	constructor(options: ApiHandlerOptions) {
 		this.options = options
-		this.client = new OpenAI({
-			baseURL: "https://api.deepseek.com/v1",
-			apiKey: this.options.deepSeekApiKey,
-		})
+	}
+
+	private ensureClient(): OpenAI {
+		if (!this.client) {
+			if (!this.options.deepSeekApiKey) {
+				throw new Error("DeepSeek API key is required")
+			}
+			try {
+				this.client = new OpenAI({
+					baseURL: "https://api.deepseek.com/v1",
+					apiKey: this.options.deepSeekApiKey,
+				})
+			} catch (error) {
+				throw new Error(`Error creating DeepSeek client: ${error.message}`)
+			}
+		}
+		return this.client
 	}
 
 	private async *yieldUsage(info: ModelInfo, usage: OpenAI.Completions.CompletionUsage | undefined): ApiStream {
@@ -54,6 +67,7 @@ export class DeepSeekHandler implements ApiHandler {
 
 	@withRetry()
 	async *createMessage(systemPrompt: string, messages: Anthropic.Messages.MessageParam[]): ApiStream {
+		const client = this.ensureClient()
 		const model = this.getModel()
 
 		const isDeepseekReasoner = model.id.includes("deepseek-reasoner")
@@ -67,7 +81,7 @@ export class DeepSeekHandler implements ApiHandler {
 			openAiMessages = convertToR1Format([{ role: "user", content: systemPrompt }, ...messages])
 		}
 
-		const stream = await this.client.chat.completions.create({
+		const stream = await client.chat.completions.create({
 			model: model.id,
 			max_completion_tokens: model.info.maxTokens,
 			messages: openAiMessages,

--- a/src/api/providers/doubao.ts
+++ b/src/api/providers/doubao.ts
@@ -8,13 +8,26 @@ import { withRetry } from "../retry"
 
 export class DoubaoHandler implements ApiHandler {
 	private options: ApiHandlerOptions
-	private client: OpenAI
+	private client: OpenAI | undefined
 	constructor(options: ApiHandlerOptions) {
 		this.options = options
-		this.client = new OpenAI({
-			baseURL: "https://ark.cn-beijing.volces.com/api/v3/",
-			apiKey: this.options.doubaoApiKey,
-		})
+	}
+
+	private ensureClient(): OpenAI {
+		if (!this.client) {
+			if (!this.options.doubaoApiKey) {
+				throw new Error("Doubao API key is required")
+			}
+			try {
+				this.client = new OpenAI({
+					baseURL: "https://ark.cn-beijing.volces.com/api/v3/",
+					apiKey: this.options.doubaoApiKey,
+				})
+			} catch (error) {
+				throw new Error(`Error creating Doubao client: ${error.message}`)
+			}
+		}
+		return this.client
 	}
 
 	getModel(): { id: DoubaoModelId; info: ModelInfo } {
@@ -31,12 +44,13 @@ export class DoubaoHandler implements ApiHandler {
 
 	@withRetry()
 	async *createMessage(systemPrompt: string, messages: Anthropic.Messages.MessageParam[]): ApiStream {
+		const client = this.ensureClient()
 		const model = this.getModel()
 		let openAiMessages: OpenAI.Chat.ChatCompletionMessageParam[] = [
 			{ role: "system", content: systemPrompt },
 			...convertToOpenAiMessages(messages),
 		]
-		const stream = await this.client.chat.completions.create({
+		const stream = await client.chat.completions.create({
 			model: model.id,
 			max_completion_tokens: model.info.maxTokens,
 			messages: openAiMessages,

--- a/src/api/providers/fireworks.ts
+++ b/src/api/providers/fireworks.ts
@@ -15,18 +15,32 @@ import { ApiStream } from "../transform/stream"
 
 export class FireworksHandler implements ApiHandler {
 	private options: ApiHandlerOptions
-	private client: OpenAI
+	private client: OpenAI | undefined
 
 	constructor(options: ApiHandlerOptions) {
 		this.options = options
-		this.client = new OpenAI({
-			baseURL: "https://api.fireworks.ai/inference/v1",
-			apiKey: this.options.fireworksApiKey,
-		})
+	}
+
+	private ensureClient(): OpenAI {
+		if (!this.client) {
+			if (!this.options.fireworksApiKey) {
+				throw new Error("Fireworks API key is required")
+			}
+			try {
+				this.client = new OpenAI({
+					baseURL: "https://api.fireworks.ai/inference/v1",
+					apiKey: this.options.fireworksApiKey,
+				})
+			} catch (error) {
+				throw new Error(`Error creating Fireworks client: ${error.message}`)
+			}
+		}
+		return this.client
 	}
 
 	@withRetry()
 	async *createMessage(systemPrompt: string, messages: Anthropic.Messages.MessageParam[]): ApiStream {
+		const client = this.ensureClient()
 		const modelId = this.options.fireworksModelId ?? ""
 
 		const openAiMessages: OpenAI.Chat.ChatCompletionMessageParam[] = [
@@ -34,7 +48,7 @@ export class FireworksHandler implements ApiHandler {
 			...convertToOpenAiMessages(messages),
 		]
 
-		const stream = await this.client.chat.completions.create({
+		const stream = await client.chat.completions.create({
 			model: modelId,
 			...(this.options.fireworksModelMaxCompletionTokens
 				? { max_completion_tokens: this.options.fireworksModelMaxCompletionTokens }

--- a/src/api/providers/lmstudio.ts
+++ b/src/api/providers/lmstudio.ts
@@ -8,25 +8,36 @@ import { withRetry } from "../retry"
 
 export class LmStudioHandler implements ApiHandler {
 	private options: ApiHandlerOptions
-	private client: OpenAI
+	private client: OpenAI | undefined
 
 	constructor(options: ApiHandlerOptions) {
 		this.options = options
-		this.client = new OpenAI({
-			baseURL: (this.options.lmStudioBaseUrl || "http://localhost:1234") + "/v1",
-			apiKey: "noop",
-		})
+	}
+
+	private ensureClient(): OpenAI {
+		if (!this.client) {
+			try {
+				this.client = new OpenAI({
+					baseURL: (this.options.lmStudioBaseUrl || "http://localhost:1234") + "/v1",
+					apiKey: "noop",
+				})
+			} catch (error) {
+				throw new Error(`Error creating LM Studio client: ${error.message}`)
+			}
+		}
+		return this.client
 	}
 
 	@withRetry({ retryAllErrors: true })
 	async *createMessage(systemPrompt: string, messages: Anthropic.Messages.MessageParam[]): ApiStream {
+		const client = this.ensureClient()
 		const openAiMessages: OpenAI.Chat.ChatCompletionMessageParam[] = [
 			{ role: "system", content: systemPrompt },
 			...convertToOpenAiMessages(messages),
 		]
 
 		try {
-			const stream = await this.client.chat.completions.create({
+			const stream = await client.chat.completions.create({
 				model: this.getModel().id,
 				messages: openAiMessages,
 				stream: true,

--- a/src/api/providers/nebius.ts
+++ b/src/api/providers/nebius.ts
@@ -8,24 +8,37 @@ import { convertToR1Format } from "../transform/r1-format"
 import { nebiusDefaultModelId, nebiusModels, type ModelInfo, type ApiHandlerOptions, type NebiusModelId } from "../../shared/api"
 
 export class NebiusHandler implements ApiHandler {
-	private client: OpenAI
+	private client: OpenAI | undefined
 
-	constructor(private readonly options: ApiHandlerOptions) {
-		this.client = new OpenAI({
-			baseURL: "https://api.studio.nebius.ai/v1",
-			apiKey: this.options.nebiusApiKey,
-		})
+	constructor(private readonly options: ApiHandlerOptions) {}
+
+	private ensureClient(): OpenAI {
+		if (!this.client) {
+			if (!this.options.nebiusApiKey) {
+				throw new Error("Nebius API key is required")
+			}
+			try {
+				this.client = new OpenAI({
+					baseURL: "https://api.studio.nebius.ai/v1",
+					apiKey: this.options.nebiusApiKey,
+				})
+			} catch (error) {
+				throw new Error(`Error creating Nebius client: ${error.message}`)
+			}
+		}
+		return this.client
 	}
 
 	@withRetry()
 	async *createMessage(systemPrompt: string, messages: Anthropic.Messages.MessageParam[]): ApiStream {
+		const client = this.ensureClient()
 		const model = this.getModel()
 
 		const openAiMessages: OpenAI.Chat.ChatCompletionMessageParam[] = model.id.includes("DeepSeek-R1")
 			? convertToR1Format([{ role: "user", content: systemPrompt }, ...messages])
 			: [{ role: "system", content: systemPrompt }, ...convertToOpenAiMessages(messages)]
 
-		const stream = await this.client.chat.completions.create({
+		const stream = await client.chat.completions.create({
 			model: model.id,
 			messages: openAiMessages,
 			temperature: 0,

--- a/src/api/providers/ollama.ts
+++ b/src/api/providers/ollama.ts
@@ -8,15 +8,26 @@ import { withRetry } from "../retry"
 
 export class OllamaHandler implements ApiHandler {
 	private options: ApiHandlerOptions
-	private client: Ollama
+	private client: Ollama | undefined
 
 	constructor(options: ApiHandlerOptions) {
 		this.options = options
-		this.client = new Ollama({ host: this.options.ollamaBaseUrl || "http://localhost:11434" })
+	}
+
+	private ensureClient(): Ollama {
+		if (!this.client) {
+			try {
+				this.client = new Ollama({ host: this.options.ollamaBaseUrl || "http://localhost:11434" })
+			} catch (error) {
+				throw new Error(`Error creating Ollama client: ${error.message}`)
+			}
+		}
+		return this.client
 	}
 
 	@withRetry({ retryAllErrors: true })
 	async *createMessage(systemPrompt: string, messages: Anthropic.Messages.MessageParam[]): ApiStream {
+		const client = this.ensureClient()
 		const ollamaMessages: Message[] = [{ role: "system", content: systemPrompt }, ...convertToOllamaMessages(messages)]
 
 		try {
@@ -27,7 +38,7 @@ export class OllamaHandler implements ApiHandler {
 			})
 
 			// Create the actual API request promise
-			const apiPromise = this.client.chat({
+			const apiPromise = client.chat({
 				model: this.getModel().id,
 				messages: ollamaMessages,
 				stream: true,

--- a/src/api/providers/openai-native.ts
+++ b/src/api/providers/openai-native.ts
@@ -10,13 +10,26 @@ import type { ChatCompletionReasoningEffort } from "openai/resources/chat/comple
 
 export class OpenAiNativeHandler implements ApiHandler {
 	private options: ApiHandlerOptions
-	private client: OpenAI
+	private client: OpenAI | undefined
 
 	constructor(options: ApiHandlerOptions) {
 		this.options = options
-		this.client = new OpenAI({
-			apiKey: this.options.openAiNativeApiKey,
-		})
+	}
+
+	private ensureClient(): OpenAI {
+		if (!this.client) {
+			if (!this.options.openAiNativeApiKey) {
+				throw new Error("OpenAI API key is required")
+			}
+			try {
+				this.client = new OpenAI({
+					apiKey: this.options.openAiNativeApiKey,
+				})
+			} catch (error: any) {
+				throw new Error(`Error creating OpenAI client: ${error.message}`)
+			}
+		}
+		return this.client
 	}
 
 	private async *yieldUsage(info: ModelInfo, usage: OpenAI.Completions.CompletionUsage | undefined): ApiStream {
@@ -38,6 +51,7 @@ export class OpenAiNativeHandler implements ApiHandler {
 
 	@withRetry()
 	async *createMessage(systemPrompt: string, messages: Anthropic.Messages.MessageParam[]): ApiStream {
+		const client = this.ensureClient()
 		const model = this.getModel()
 
 		switch (model.id) {
@@ -45,7 +59,7 @@ export class OpenAiNativeHandler implements ApiHandler {
 			case "o1-preview":
 			case "o1-mini": {
 				// o1 doesn't support streaming, non-1 temp, or system prompt
-				const response = await this.client.chat.completions.create({
+				const response = await client.chat.completions.create({
 					model: model.id,
 					messages: [{ role: "user", content: systemPrompt }, ...convertToOpenAiMessages(messages)],
 				})
@@ -61,7 +75,7 @@ export class OpenAiNativeHandler implements ApiHandler {
 			case "o4-mini":
 			case "o3":
 			case "o3-mini": {
-				const stream = await this.client.chat.completions.create({
+				const stream = await client.chat.completions.create({
 					model: model.id,
 					messages: [{ role: "developer", content: systemPrompt }, ...convertToOpenAiMessages(messages)],
 					stream: true,
@@ -85,7 +99,7 @@ export class OpenAiNativeHandler implements ApiHandler {
 				break
 			}
 			default: {
-				const stream = await this.client.chat.completions.create({
+				const stream = await client.chat.completions.create({
 					model: model.id,
 					// max_completion_tokens: this.getModel().info.maxTokens,
 					temperature: 0,

--- a/src/api/providers/openrouter.ts
+++ b/src/api/providers/openrouter.ts
@@ -11,27 +11,41 @@ import { OpenRouterErrorResponse } from "./types"
 
 export class OpenRouterHandler implements ApiHandler {
 	private options: ApiHandlerOptions
-	private client: OpenAI
+	private client: OpenAI | undefined
 	lastGenerationId?: string
 
 	constructor(options: ApiHandlerOptions) {
 		this.options = options
-		this.client = new OpenAI({
-			baseURL: "https://openrouter.ai/api/v1",
-			apiKey: this.options.openRouterApiKey,
-			defaultHeaders: {
-				"HTTP-Referer": "https://cline.bot", // Optional, for including your app on openrouter.ai rankings.
-				"X-Title": "Cline", // Optional. Shows in rankings on openrouter.ai.
-			},
-		})
+	}
+
+	private ensureClient(): OpenAI {
+		if (!this.client) {
+			if (!this.options.openRouterApiKey) {
+				throw new Error("OpenRouter API key is required")
+			}
+			try {
+				this.client = new OpenAI({
+					baseURL: "https://openrouter.ai/api/v1",
+					apiKey: this.options.openRouterApiKey,
+					defaultHeaders: {
+						"HTTP-Referer": "https://cline.bot", // Optional, for including your app on openrouter.ai rankings.
+						"X-Title": "Cline", // Optional. Shows in rankings on openrouter.ai.
+					},
+				})
+			} catch (error: any) {
+				throw new Error(`Error creating OpenRouter client: ${error.message}`)
+			}
+		}
+		return this.client
 	}
 
 	@withRetry()
 	async *createMessage(systemPrompt: string, messages: Anthropic.Messages.MessageParam[]): ApiStream {
+		const client = this.ensureClient()
 		this.lastGenerationId = undefined
 
 		const stream = await createOpenRouterStream(
-			this.client,
+			client,
 			systemPrompt,
 			messages,
 			this.getModel(),

--- a/src/api/providers/together.ts
+++ b/src/api/providers/together.ts
@@ -9,18 +9,32 @@ import { convertToR1Format } from "@api/transform/r1-format"
 
 export class TogetherHandler implements ApiHandler {
 	private options: ApiHandlerOptions
-	private client: OpenAI
+	private client: OpenAI | undefined
 
 	constructor(options: ApiHandlerOptions) {
 		this.options = options
-		this.client = new OpenAI({
-			baseURL: "https://api.together.xyz/v1",
-			apiKey: this.options.togetherApiKey,
-		})
+	}
+
+	private ensureClient(): OpenAI {
+		if (!this.client) {
+			if (!this.options.togetherApiKey) {
+				throw new Error("Together API key is required")
+			}
+			try {
+				this.client = new OpenAI({
+					baseURL: "https://api.together.xyz/v1",
+					apiKey: this.options.togetherApiKey,
+				})
+			} catch (error: any) {
+				throw new Error(`Error creating Together client: ${error.message}`)
+			}
+		}
+		return this.client
 	}
 
 	@withRetry()
 	async *createMessage(systemPrompt: string, messages: Anthropic.Messages.MessageParam[]): ApiStream {
+		const client = this.ensureClient()
 		const modelId = this.options.togetherModelId ?? ""
 		const isDeepseekReasoner = modelId.includes("deepseek-reasoner")
 
@@ -33,7 +47,7 @@ export class TogetherHandler implements ApiHandler {
 			openAiMessages = convertToR1Format([{ role: "user", content: systemPrompt }, ...messages])
 		}
 
-		const stream = await this.client.chat.completions.create({
+		const stream = await client.chat.completions.create({
 			model: modelId,
 			messages: openAiMessages,
 			temperature: 0,

--- a/src/api/providers/vertex.ts
+++ b/src/api/providers/vertex.ts
@@ -7,25 +7,49 @@ import { ApiStream } from "@api/transform/stream"
 import { GeminiHandler } from "./gemini"
 
 export class VertexHandler implements ApiHandler {
-	private geminiHandler: GeminiHandler
-	private clientAnthropic: AnthropicVertex
+	private geminiHandler: GeminiHandler | undefined
+	private clientAnthropic: AnthropicVertex | undefined
 	private options: ApiHandlerOptions
 
 	constructor(options: ApiHandlerOptions) {
 		this.options = options
+	}
 
-		// Create a GeminiHandler with isVertex flag for Gemini models
-		this.geminiHandler = new GeminiHandler({
-			...options,
-			isVertex: true,
-		})
+	private ensureGeminiHandler(): GeminiHandler {
+		if (!this.geminiHandler) {
+			try {
+				// Create a GeminiHandler with isVertex flag for Gemini models
+				this.geminiHandler = new GeminiHandler({
+					...this.options,
+					isVertex: true,
+				})
+			} catch (error: any) {
+				throw new Error(`Error creating Vertex AI Gemini handler: ${error.message}`)
+			}
+		}
+		return this.geminiHandler
+	}
 
-		// Initialize Anthropic client for Claude models
-		this.clientAnthropic = new AnthropicVertex({
-			projectId: this.options.vertexProjectId,
-			// https://cloud.google.com/vertex-ai/generative-ai/docs/partner-models/use-claude#regions
-			region: this.options.vertexRegion,
-		})
+	private ensureAnthropicClient(): AnthropicVertex {
+		if (!this.clientAnthropic) {
+			if (!this.options.vertexProjectId) {
+				throw new Error("Vertex AI project ID is required")
+			}
+			if (!this.options.vertexRegion) {
+				throw new Error("Vertex AI region is required")
+			}
+			try {
+				// Initialize Anthropic client for Claude models
+				this.clientAnthropic = new AnthropicVertex({
+					projectId: this.options.vertexProjectId,
+					// https://cloud.google.com/vertex-ai/generative-ai/docs/partner-models/use-claude#regions
+					region: this.options.vertexRegion,
+				})
+			} catch (error: any) {
+				throw new Error(`Error creating Vertex AI Anthropic client: ${error.message}`)
+			}
+		}
+		return this.clientAnthropic
 	}
 
 	@withRetry()
@@ -35,9 +59,12 @@ export class VertexHandler implements ApiHandler {
 
 		// For Gemini models, use the GeminiHandler
 		if (!modelId.includes("claude")) {
-			yield* this.geminiHandler.createMessage(systemPrompt, messages)
+			const geminiHandler = this.ensureGeminiHandler()
+			yield* geminiHandler.createMessage(systemPrompt, messages)
 			return
 		}
+
+		const clientAnthropic = this.ensureAnthropicClient()
 
 		// Claude implementation
 		let budget_tokens = this.options.thinkingBudgetTokens || 0
@@ -63,7 +90,7 @@ export class VertexHandler implements ApiHandler {
 				)
 				const lastUserMsgIndex = userMsgIndices[userMsgIndices.length - 1] ?? -1
 				const secondLastMsgUserIndex = userMsgIndices[userMsgIndices.length - 2] ?? -1
-				stream = await this.clientAnthropic.beta.messages.create(
+				stream = await clientAnthropic.beta.messages.create(
 					{
 						model: modelId,
 						max_tokens: model.info.maxTokens || 8192,
@@ -125,7 +152,7 @@ export class VertexHandler implements ApiHandler {
 				break
 			}
 			default: {
-				stream = await this.clientAnthropic.beta.messages.create({
+				stream = await clientAnthropic.beta.messages.create({
 					model: modelId,
 					max_tokens: model.info.maxTokens || 8192,
 					temperature: 0,


### PR DESCRIPTION


### Description

Only initialize the various API provider SDKs when creating a message. This allows for better error flow as it displays in the chat view. It also avoids obstructing the initTask() flow since Tasks call buildApiHandler() on initialization. Before, we had the problem where, if an API key was not set, users could not switch to that provider while in a task or open a task in the chat history view.

Now, clean errors are displayed when the user tries to send a message with a misconfigured provider. The user is able to select that provider and view tasks.

### Test Procedure

Tested the cases before to ensure they work correctly.

Clear the api key and credentials for providers like Gemini, Openrouter, Mistral, etc. and try to switch to them while in a Task, or while outside of a task, switch to them and open a task.

Previously, this would not work.

Confirm that message generation now correctly throws an error, which displays in the chat messages.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Lazily initialize provider SDKs to improve error handling and user experience when switching providers or viewing tasks.
> 
>   - **Behavior**:
>     - Lazily initialize provider SDKs in `anthropic.ts`, `cerebras.ts`, and `cline.ts` by adding `ensureClient()` method.
>     - Improves error handling by displaying errors in chat view when sending messages with misconfigured providers.
>     - Allows users to switch providers and view tasks even if API keys are not set.
>   - **Tests**:
>     - Update `ollama.test.ts` to ensure client initialization before mocking methods.
>     - Add tests for handling timeout errors, retry on errors, and stream processing errors.
>   - **Misc**:
>     - Minor refactoring in `ollama.ts` to use `ensureClient()` for client initialization.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 6ca086d7a14843c682fa927b24a269364cf5f6a7. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->