### PR TITLE
Fixing bug on accepting tool response

### DIFF
--- a/webview-ui/src/components/chat/chat-view/hooks/useMessageHandlers.ts
+++ b/webview-ui/src/components/chat/chat-view/hooks/useMessageHandlers.ts
@@ -120,7 +120,14 @@ export function useMessageHandlers(messages: ClineMessage[], chatState: ChatStat
 					// If there's no input content, just approve the action
 					if (trimmedInput || (images && images.length > 0) || (files && files.length > 0)) {
 						// Send as a regular message so it appears in the conversation
-						await handleSendMessage(trimmedInput || "", images || [], files || [])
+						await TaskServiceClient.askResponse(
+							AskResponseRequest.create({
+								responseType: "yesButtonClicked",
+								text: trimmedInput,
+								images: images,
+								files: files,
+							}),
+						)
 					} else {
 						// No input content, just approve the action
 						await TaskServiceClient.askResponse(


### PR DESCRIPTION


### Related Issue

Solve https://github.com/cline/cline/issues/4671 

### Description
Instead of just giving the text response we will also accept the tool call when the primary button is clicked. 



### Test Procedure
- Turn of auto accept
- Create a file using cline
- Before you press accept type some text in the text box(Notice another file is not created)

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [X] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [X] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [X] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [X] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [X] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes tool response acceptance bug by updating `handlePrimaryButtonClick` in `useMessageHandlers.ts` to send tool call with text response.
> 
>   - **Behavior**:
>     - Updates `handlePrimaryButtonClick` in `useMessageHandlers.ts` to send tool call with text response when primary button is clicked.
>     - Fixes issue where tool call was not accepted if input content was present.
>   - **Test Procedure**:
>     - Turn off auto accept, create a file using cline, type text before accepting, ensure no duplicate file creation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for c38cc068ca79be89096b83b990f8cc39b5369611. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->