### PR TITLE
Revert "fix(ui): Remove blur hover effect from HistoryPreview"

### DIFF
--- a/webview-ui/src/components/history/HistoryPreview.tsx
+++ b/webview-ui/src/components/history/HistoryPreview.tsx
@@ -65,6 +65,7 @@ const HistoryPreview = ({ showHistoryView }: HistoryPreviewProps) => {
 											backgroundColor:
 												"color-mix(in srgb, var(--vscode-toolbar-hoverBackground) 30%, transparent)",
 											border: "1px solid color-mix(in srgb, var(--vscode-panel-border) 50%, transparent)",
+											backdropFilter: "blur(8px)",
 										}}
 										onClick={() => handleHistorySelect(item.id)}>
 										{/* Subtle gradient overlay for extra depth */}
@@ -152,6 +153,7 @@ const HistoryPreview = ({ showHistoryView }: HistoryPreviewProps) => {
 								fontSize: "var(--vscode-font-size)",
 								backgroundColor: "color-mix(in srgb, var(--vscode-toolbar-hoverBackground) 20%, transparent)",
 								border: "1px solid color-mix(in srgb, var(--vscode-panel-border) 30%, transparent)",
+								backdropFilter: "blur(8px)",
 							}}>
 							No recent tasks
 						</div>


### PR DESCRIPTION
Reverts cline/cline#4664

This PR causes a strange blur when you try to change model config 

<img width="807" alt="image" src="https://github.com/user-attachments/assets/9d781110-4e7f-4fac-9fbf-bd9a2a237824" />

Lets revert this and get a proper solution in
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Reverts removal of blur effect in `HistoryPreview.tsx` to fix visual issue when changing model config.
> 
>   - **Revert Changes**:
>     - Reintroduces `backdropFilter: "blur(8px)"` in `HistoryPreview.tsx` for hover effects on task items and the "No recent tasks" message.
>   - **Reason**:
>     - Reverts due to a visual issue caused by the previous removal of the blur effect when changing model config.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 8d4eccc4fc70edb18abc2daa4f3e313c485789ec. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->