### PR TITLE
migrate download MCP response to proto

### DIFF
--- a/proto/mcp.proto
+++ b/proto/mcp.proto
@@ -10,7 +10,7 @@ service McpService {
   rpc toggleMcpServer(ToggleMcpServerRequest) returns (McpServers);
   rpc updateMcpTimeout(UpdateMcpTimeoutRequest) returns (McpServers);
   rpc addRemoteMcpServer(AddRemoteMcpServerRequest) returns (McpServers);
-  rpc downloadMcp(StringRequest) returns (Empty);
+  rpc downloadMcp(StringRequest) returns (McpDownloadResponse);
   rpc restartMcpServer(StringRequest) returns (McpServers);
   rpc deleteMcpServer(StringRequest) returns (McpServers);
   rpc toggleToolAutoApprove(ToggleToolAutoApproveRequest) returns (McpServers);
@@ -118,4 +118,16 @@ message McpMarketplaceItem {
 
 message McpMarketplaceCatalog {
   repeated McpMarketplaceItem items = 1;
+}
+
+message McpDownloadResponse {
+  string mcp_id = 1;
+  string github_url = 2;
+  string name = 3;
+  string author = 4;
+  string description = 5;
+  string readme_content = 6;
+  string llms_installation_content = 7;
+  bool requires_api_key = 8;
+  optional string error = 9;
 }

--- a/src/shared/ExtensionMessage.ts
+++ b/src/shared/ExtensionMessage.ts
@@ -14,37 +14,8 @@ import { UserInfo } from "./UserInfo"
 
 // webview will hold state
 export interface ExtensionMessage {
-	type: "action" | "state" | "selectedImages" | "mcpDownloadDetails" | "grpc_response" // New type for gRPC responses
-	text?: string
-	action?: "accountLogoutClicked"
-	state?: ExtensionState
-	images?: string[]
-	files?: string[]
-	ollamaModels?: string[]
-	lmStudioModels?: string[]
-	vsCodeLmModels?: { vendor?: string; family?: string; version?: string; id?: string }[]
-	openAiModels?: string[]
-	mcpServers?: McpServer[]
-	customToken?: string
-	mcpMarketplaceCatalog?: McpMarketplaceCatalog
-	error?: string
-	mcpDownloadDetails?: McpDownloadResponse
-	commits?: GitCommit[]
-	url?: string
-	isImage?: boolean
-	success?: boolean
-	endpoint?: string
-	isBundled?: boolean
-	isConnected?: boolean
-	isRemote?: boolean
-	host?: string
-	mentionsRequestId?: string
-	results?: Array<{
-		path: string
-		type: "file" | "folder"
-		label?: string
-	}>
-	tab?: McpViewTab
+	type: "grpc_response" // New type for gRPC responses
+
 	grpc_response?: {
 		message?: any // JSON serialized protobuf message
 		request_id: string // Same ID as the request

--- a/webview-ui/src/components/mcp/configuration/tabs/marketplace/McpMarketplaceView.tsx
+++ b/webview-ui/src/components/mcp/configuration/tabs/marketplace/McpMarketplaceView.tsx
@@ -59,23 +59,8 @@ const McpMarketplaceView = () => {
 	}, [items, searchQuery, selectedCategory, sortBy])
 
 	useEffect(() => {
-		const handleMessage = (event: MessageEvent) => {
-			const message = event.data
-			if (message.type === "mcpDownloadDetails") {
-				if (message.error) {
-					setError(message.error)
-				}
-			}
-		}
-
-		window.addEventListener("message", handleMessage)
-
 		// Fetch marketplace catalog on initial load
 		fetchMarketplace()
-
-		return () => {
-			window.removeEventListener("message", handleMessage)
-		}
 	}, [])
 
 	useEffect(() => {
@@ -290,7 +275,9 @@ const McpMarketplaceView = () => {
 							: "No MCP servers found in the marketplace"}
 					</div>
 				) : (
-					filteredItems.map((item) => <McpMarketplaceCard key={item.mcpId} item={item} installedServers={mcpServers} />)
+					filteredItems.map((item) => (
+						<McpMarketplaceCard key={item.mcpId} item={item} installedServers={mcpServers} setError={setError} />
+					))
 				)}
 				<McpSubmitCard />
 			</div>


### PR DESCRIPTION


### Description

Migrate the download MCP response message to the existing proto function response.

### Test Procedure

Test that downloading an mcp works as before and that we see the console log.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [x] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Migrate download MCP response to use `McpDownloadResponse` proto message, updating controller logic and UI components accordingly.
> 
>   - **Proto Changes**:
>     - Change `downloadMcp` RPC in `mcp.proto` to return `McpDownloadResponse` instead of `Empty`.
>     - Add `McpDownloadResponse` message to `mcp.proto` with fields for MCP details and an optional error.
>   - **Controller Changes**:
>     - Update `downloadMcp()` in `downloadMcp.ts` to return `McpDownloadResponse` with MCP details or error.
>     - Remove webview message posting for MCP download details.
>   - **UI Changes**:
>     - Update `McpMarketplaceCard.tsx` to handle `McpDownloadResponse` and display errors using `setError`.
>     - Remove message event handling for `mcpDownloadDetails` in `McpMarketplaceView.tsx` and `McpMarketplaceCard.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 843ea45b9061bd270230f1993b0cf4f2d7509df2. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->