### PR TITLE
Update the packaging script for the standalone app to include the same files as the extension in the zip

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,7 +1,7 @@
 # Default
 .vscode/**
 .vscode-test/**
-out/**
+out/
 dist-standalone/
 node_modules/**
 src/**
@@ -33,8 +33,8 @@ webview-ui/node_modules/**
 **/.gitignore
 
 # Ignore docs
-docs/**
-old_docs/**
+docs/
+old_docs/
 
 # Fix issue where codicons don't get packaged (https://github.com/microsoft/vscode-extension-samples/issues/692)
 !node_modules/@vscode/codicons/dist/codicon.css

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -2,6 +2,7 @@
 .vscode/**
 .vscode-test/**
 out/**
+dist-standalone/
 node_modules/**
 src/**
 .gitignore
@@ -13,6 +14,7 @@ vsc-extension-quickstart.md
 **/*.map
 **/*.ts
 **/.vscode-test.*
+eslint-rules/
 
 # Custom
 demo.gif
@@ -32,6 +34,7 @@ webview-ui/node_modules/**
 
 # Ignore docs
 docs/**
+old_docs/**
 
 # Fix issue where codicons don't get packaged (https://github.com/microsoft/vscode-extension-samples/issues/692)
 !node_modules/@vscode/codicons/dist/codicon.css

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,10 +1,11 @@
 # Default
 .vscode/**
 .vscode-test/**
-out/
-dist-standalone/
+out/**
+dist-standalone/**
 node_modules/**
 src/**
+standalone/**
 .gitignore
 .yarnrc
 esbuild.js
@@ -14,7 +15,7 @@ vsc-extension-quickstart.md
 **/*.map
 **/*.ts
 **/.vscode-test.*
-eslint-rules/
+eslint-rules/**
 
 # Custom
 demo.gif
@@ -33,8 +34,8 @@ webview-ui/node_modules/**
 **/.gitignore
 
 # Ignore docs
-docs/
-old_docs/
+docs/**
+old_docs/**
 
 # Fix issue where codicons don't get packaged (https://github.com/microsoft/vscode-extension-samples/issues/692)
 !node_modules/@vscode/codicons/dist/codicon.css

--- a/scripts/package-standalone.mjs
+++ b/scripts/package-standalone.mjs
@@ -70,6 +70,9 @@ async function zipDistribution() {
 		if (entry.name.startsWith(".git")) {
 			return false
 		}
+		if (entry.name.endsWith(".DS_Store")) {
+			return false
+		}
 		if (entry.name === "dist" || entry.name.startsWith("dist" + path.sep)) {
 			// Don't include the vscode extension build dir.
 			return false

--- a/scripts/package-standalone.mjs
+++ b/scripts/package-standalone.mjs
@@ -78,7 +78,7 @@ async function zipDistribution() {
 			return false
 		}
 		if (vscodeignore.ignores(entry.name)) {
-			// Exclude this entry
+			// Exclude entries also ignored by the vscode packager.
 			return false
 		}
 		return entry

--- a/scripts/package-standalone.mjs
+++ b/scripts/package-standalone.mjs
@@ -1,83 +1,97 @@
-import fs from "fs"
-import path from "path"
-import { glob } from "glob"
 import archiver from "archiver"
-import { cp } from "fs/promises"
 import { execSync } from "child_process"
-
+import fs from "fs"
+import { cp } from "fs/promises"
+import { glob } from "glob"
+import ignore from "ignore"
+import path from "path"
 const BUILD_DIR = "dist-standalone"
-const SOURCE_DIR = "standalone/runtime-files"
+const RUNTIME_DEPS_DIR = "standalone/runtime-files"
 
-await cp(SOURCE_DIR, BUILD_DIR, { recursive: true })
-
-// Run npm install in the distribution directory
-console.log("Running npm install in distribution directory...")
-const cwd = process.cwd()
-process.chdir(BUILD_DIR)
-try {
-	execSync("npm install", { stdio: "inherit" })
-	// Move the vscode directory into node_modules.
-	// It can't be installed using npm because it will create a symlink which is not portable.
-	fs.renameSync("vscode", path.join("node_modules", "vscode"))
-} catch (error) {
-	console.error("Error during setup:", error)
-	process.exit(1)
-} finally {
-	process.chdir(cwd)
+async function main() {
+	await installNodeDependencies()
+	await zipDistribution()
 }
 
-// Check for native .node modules.
-const nativeModules = await glob("**/*.node", { cwd: BUILD_DIR, nodir: true })
-if (nativeModules.length > 0) {
-	console.error("Native node modules cannot be included in the standalone distribution:\n", nativeModules.join("\n"))
-	process.exit(1)
+async function installNodeDependencies() {
+	await cpr(RUNTIME_DEPS_DIR, BUILD_DIR)
+
+	console.log("Running npm install in distribution directory...")
+	const cwd = process.cwd()
+	process.chdir(BUILD_DIR)
+
+	try {
+		execSync("npm install", { stdio: "inherit" })
+		// Move the vscode directory into node_modules.
+		// It can't be installed using npm because it will create a symlink which cannot be unzipped correctly on windows.
+		fs.renameSync("vscode", path.join("node_modules", "vscode"))
+	} catch (error) {
+		console.error("Error during setup:", error)
+		process.exit(1)
+	} finally {
+		process.chdir(cwd)
+	}
+
+	// Check for native .node modules.
+	const nativeModules = await glob("**/*.node", { cwd: BUILD_DIR, nodir: true })
+	if (nativeModules.length > 0) {
+		console.error("Native node modules cannot be included in the standalone distribution:\n", nativeModules.join("\n"))
+		process.exit(1)
+	}
 }
 
-// Zip the build directory (excluding any pre-existing output zip).
-const zipPath = path.join(BUILD_DIR, "standalone.zip")
-const output = fs.createWriteStream(zipPath)
-const archive = archiver("zip", { zlib: { level: 3 } })
+async function zipDistribution() {
+	// Zip the build directory (excluding any pre-existing output zip).
+	const zipPath = path.join(BUILD_DIR, "standalone.zip")
+	const output = fs.createWriteStream(zipPath)
+	const archive = archiver("zip", { zlib: { level: 3 } })
+	// Use the same ignore file that vscode uses when packaging the extension.
+	const vscodeignore = ignore().add(fs.readFileSync(".vscodeignore", "utf8"))
 
-output.on("close", () => {
-	console.log(`Created ${zipPath} (${(archive.pointer() / 1024 / 1024).toFixed(1)} MB)`)
-})
-archive.on("warning", (err) => {
-	console.warn(`Warning: ${err}`)
-})
-archive.on("error", (err) => {
-	throw err
-})
+	output.on("close", () => {
+		console.log(`Created ${zipPath} (${(archive.pointer() / 1024 / 1024).toFixed(1)} MB)`)
+	})
+	archive.on("warning", (err) => {
+		console.warn(`Warning: ${err}`)
+	})
+	archive.on("error", (err) => {
+		throw err
+	})
 
-archive.pipe(output)
-archive.glob("**/*", {
-	cwd: BUILD_DIR,
-	ignore: ["standalone.zip"],
-})
+	archive.pipe(output)
+	// Add all the files from the standalone build dir.
+	archive.glob("**/*", {
+		cwd: BUILD_DIR,
+		ignore: ["standalone.zip"],
+	})
 
-// Add the whole cline directory under "extension"
-archive.directory(process.cwd(), "extension", (entry) => {
-	// Skip certain directories.
-	const exclude = [
-		BUILD_DIR + "/",
-		"node_modules/", // node_modules nearly 1GB.
-		"webview-ui/node_modules/", // node_modules nearly 1GB.
-	]
-	// These node modules are used at runtime as assets, they need to be included.
-	const include = ["node_modules/@vscode/", "webview-ui/node_modules/katex"]
-	const name = entry.name
-
-	if (include.some((prefix) => name.startsWith(prefix))) {
+	// Add the whole cline directory under "extension"
+	archive.directory(process.cwd(), "extension", (entry) => {
+		if (entry.name.startsWith(".git")) {
+			return false
+		}
+		if (entry.name === "dist" || entry.name.startsWith("dist" + path.sep)) {
+			// Don't include the vscode extension build dir.
+			return false
+		}
+		if (vscodeignore.ignores(entry.name)) {
+			// Exclude this entry
+			return false
+		}
 		return entry
-	}
-	if (exclude.some((prefix) => name.startsWith(prefix))) {
-		return false
-	}
-	if (name.match(/(^|\/)\./)) {
-		// exclude dot directories
-		return false
-	}
-	return entry
-})
+	})
 
-console.log("Zipping package...")
-await archive.finalize()
+	console.log("Zipping package...")
+	await archive.finalize()
+}
+
+/* cp -r */
+async function cpr(source, dest) {
+	await cp(source, dest, {
+		recursive: true,
+		preserveTimestamps: true,
+		dereference: false, // preserve symlinks instead of following them
+	})
+}
+
+await main()


### PR DESCRIPTION
When packaging the standalone app use the same .vscodeignore that the vscode packager uses to decide which files to include. 

Exclude extra files from the vscode extension that aren't needed.

Split the script package-standalone.mjs into functions.

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Aligns packaging for standalone app and VSCode extension using `.vscodeignore` and refactors `package-standalone.mjs` for modularity.
> 
>   - **Packaging**:
>     - Use `.vscodeignore` for both standalone app and VSCode extension to determine included files.
>     - Exclude unnecessary files like `dist-standalone`, `standalone`, and `old_docs` from the extension.
>   - **Script Refactoring**:
>     - Split `package-standalone.mjs` into `installNodeDependencies()` and `zipDistribution()` functions for modularity.
>     - Use `ignore` package to apply `.vscodeignore` rules in `zipDistribution()`.
>     - Add `cpr()` function for recursive copy with symlink preservation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for bac9785c49981057c26eabb470f93e5962990576. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->