### PR TITLE
Disable recording webview click events

### DIFF
--- a/src/shared/services/config/posthog-config.ts
+++ b/src/shared/services/config/posthog-config.ts
@@ -1,6 +1,15 @@
 // Public PostHog key (safe for open source)
-export const posthogConfig = {
+const posthogProdConfig = {
 	apiKey: "phc_qfOAGxZw2TL5O8p9KYd9ak3bPBFzfjC8fy5L6jNWY7K",
 	host: "https://data.cline.bot",
 	uiHost: "https://us.posthog.com",
 }
+
+// Public PostHog key for Development Environment project
+const posthogDevEnvConfig = {
+	apiKey: "phc_uY24EJXNBcc9kwO1K8TJUl5hPQntGM6LL1Mtrz0CBD4",
+	host: "https://data.cline.bot",
+	uiHost: "https://us.i.posthog.com",
+}
+
+export const posthogConfig = process.env.isDev ? posthogDevEnvConfig : posthogProdConfig

--- a/webview-ui/src/CustomPostHogProvider.tsx
+++ b/webview-ui/src/CustomPostHogProvider.tsx
@@ -8,7 +8,15 @@ export function CustomPostHogProvider({ children }: { children: ReactNode }) {
 	const { telemetrySetting, distinctId, version } = useExtensionState()
 	const isTelemetryEnabled = telemetrySetting !== "disabled"
 
+	// NOTE: This is a hack to stop recording webview click events temporarily.
+	// Remove this to re-enable.
+	const temporaryDisabled = true
+
 	useEffect(() => {
+		if (temporaryDisabled) {
+			return
+		}
+
 		posthog.init(posthogConfig.apiKey, {
 			api_host: posthogConfig.host,
 			ui_host: posthogConfig.uiHost,
@@ -19,7 +27,7 @@ export function CustomPostHogProvider({ children }: { children: ReactNode }) {
 	}, [])
 
 	useEffect(() => {
-		if (distinctId.length === 0 || version.length === 0) {
+		if (temporaryDisabled || distinctId.length === 0 || version.length === 0) {
 			return
 		}
 


### PR DESCRIPTION
<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- Opened an issue and discussed your proposed changes with the community / contributors
- Received approval from a core Cline contributor prior to proceeding with the implementation
- Link the associated issue in the "Related Issue" section

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly.

Why this requirement?
We deeply appreciate all community contributions - they are the core reason we're able to operate successfully and keep innovating! We welcome community input and want to make it as easy as possible for people to submit quality work. This process helps our core maintainers review new ideas faster and saves contributor time by ensuring you have the go-ahead before spending time on implementation.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:**

### Description

<!-- 
Help reviewers understand your changes by making this PR readable and well-organized:

- What problem does this PR solve?
- Why were these changes introduced and what purpose do they serve?
- For larger changes, provide context about your approach and reasoning

Small PRs may need minimal description, but larger changes benefit from explaining where you're coming from. Much of this context can be in the linked issue above, so feel free to reference it rather than repeating everything here.
-->

Introduces a temporary measure to disable the recording of webview click events in PostHog. This is achieved by adding a `temporaryDisabled` flag that, when true, prevents the initialization of PostHog and stops the identification of users.
    
This change is intended to be temporary and should be reverted in a future commit by removing the `temporaryDisabled` flag.

This PR also introduces a separate PostHog project for the development environment. This allows us to track events in the development environment without polluting the production data.
    
The `posthogConfig` now uses `posthogDevEnvConfig` when `process.env.IS_DEV` is true, and `posthogProdConfig` otherwise.

### Test Procedure

<!-- 
Please walk us through your testing approach and thought process. This helps reviewers understand that you've thoroughly considered the impact of your changes:

- How did you test this change?
- What could potentially break and how did you verify it doesn't?
- What existing functionality might be affected and how did you check it still works?
- Why are you confident this is ready for merge?

We're not looking for exhaustive documentation - just evidence that you've thought through the implications of your changes and tested accordingly.
-->

1. Start cline in debugger
2. In debugger, switch mode, start a cline task, click around the UI while the task is in progress
3. Once the task is completed, check Posthog's Development Environment project to verify the task events were recorded excluding events from the `web library`.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [x] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

After: events from the web library are no longer being recorded

<img width="616" alt="Screenshot 2025-07-07 at 4 17 22 PM" src="https://github.com/user-attachments/assets/7cf0a10d-4e16-451c-a14b-1090c3bb9647" />

Before: web events were recorded on every clicks in UI

![Screenshot 2025-07-07 at 4 18 17 PM](https://github.com/user-attachments/assets/03a5a6b8-8ac3-4562-9cb4-1c396d5299a2)

### Additional Notes

<!-- Add any additional notes for reviewers -->
