### PR TITLE
Set org dropdown value when recreated

### DIFF
--- a/webview-ui/src/components/account/AccountView.tsx
+++ b/webview-ui/src/components/account/AccountView.tsx
@@ -189,6 +189,7 @@ export const ClineAccountView = () => {
 
 								{userOrganizations && (
 									<VSCodeDropdown
+										key={`dropdown-${activeOrganization?.organizationId || "Personal"}`}
 										currentValue={activeOrganization?.organizationId || ""}
 										onChange={handleOrganizationChange}
 										style={{ width: "100%", marginTop: "4px" }}>


### PR DESCRIPTION
<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- Opened an issue and discussed your proposed changes with the community / contributors
- Received approval from a core Cline contributor prior to proceeding with the implementation
- Link the associated issue in the "Related Issue" section

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly.

Why this requirement?
We deeply appreciate all community contributions - they are the core reason we're able to operate successfully and keep innovating! We welcome community input and want to make it as easy as possible for people to submit quality work. This process helps our core maintainers review new ideas faster and saves contributor time by ensuring you have the go-ahead before spending time on implementation.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** #XXXX

### Description

Ensures the dropdown value displays the selected organization when users open the account tab.

### Test Procedure

<!-- 
Please walk us through your testing approach and thought process. This helps reviewers understand that you've thoroughly considered the impact of your changes:

- How did you test this change?
- What could potentially break and how did you verify it doesn't?
- What existing functionality might be affected and how did you check it still works?
- Why are you confident this is ready for merge?

We're not looking for exhaustive documentation - just evidence that you've thought through the implications of your changes and tested accordingly.
-->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [X] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [ ] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `key` prop to `VSCodeDropdown` in `ClineAccountView` to ensure correct dropdown value when component is recreated.
> 
>   - **Behavior**:
>     - Adds `key` prop to `VSCodeDropdown` in `ClineAccountView` to ensure dropdown value is set correctly when component is recreated.
>     - Uses `activeOrganization?.organizationId` or "Personal" as the key value.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 2233ae93c0f007d22f967d0d870c99a1d79b1d5f. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->