### PR TITLE
Fix: Focus is stolen when switching tabs in "Open in Editor" mode

### DIFF
--- a/.changeset/hungry-singers-beam.md
+++ b/.changeset/hungry-singers-beam.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Focus Stealing Fix for Cline Editor Tab

--- a/src/hosts/vscode/VscodeWebviewProvider.ts
+++ b/src/hosts/vscode/VscodeWebviewProvider.ts
@@ -66,16 +66,10 @@ export class VscodeWebviewProvider extends WebviewProvider implements vscode.Web
 		// https://github.com/microsoft/vscode-discussions/discussions/840
 		if ("onDidChangeViewState" in webviewView) {
 			// WebviewView and WebviewPanel have all the same properties except for this visibility listener
-			// panel
-			webviewView.onDidChangeViewState(
-				async () => {
-					if (this.webview?.visible) {
-						await sendDidBecomeVisibleEvent(this.controller.id)
-					}
-				},
-				null,
-				this.disposables,
-			)
+			// NOTE: We intentionally do NOT send didBecomeVisible events for editor tabs
+			// to prevent focus stealing when switching between tabs.
+			// The chat input will still be focused when needed via keyboard shortcuts (Cmd/Ctrl+')
+			// which use the focusChatInput event instead.
 		} else if ("onDidChangeVisibility" in webviewView) {
 			// sidebar
 			webviewView.onDidChangeVisibility(


### PR DESCRIPTION
<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- Opened an issue and discussed your proposed changes with the community / contributors
- Received approval from a core Cline contributor prior to proceeding with the implementation
- Link the associated issue in the "Related Issue" section

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly.

Why this requirement?
We deeply appreciate all community contributions - they are the core reason we're able to operate successfully and keep innovating! We welcome community input and want to make it as easy as possible for people to submit quality work. This process helps our core maintainers review new ideas faster and saves contributor time by ensuring you have the go-ahead before spending time on implementation.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** #4700

### Description
This PR fixes the focus stealing issue when using Cline in "Open in Editor" mode, where the chat input steals focus every time you switch between Cline and other code tabs.

__Problem details:__

- When Cline is opened as an editor tab, switching between Cline and other code tabs automatically focuses the chat input
- This makes it difficult to work with multiple files

__Solution:__

- Modified to not send `didBecomeVisible` event in `onDidChangeViewState` for editor tabs (WebviewPanel)
- Sidebar mode (WebviewView) behavior remains unchanged
- Keyboard shortcuts (Cmd/Ctrl+') continue to work properly

<!-- 
Help reviewers understand your changes by making this PR readable and well-organized:

- What problem does this PR solve?
- Why were these changes introduced and what purpose do they serve?
- For larger changes, provide context about your approach and reasoning

Small PRs may need minimal description, but larger changes benefit from explaining where you're coming from. Much of this context can be in the linked issue above, so feel free to reference it rather than repeating everything here.
-->

### Test Procedure

- Open Cline in the sidebar
- Click "Open in Editor" button
- Open any code file in another tab
- Switch between Cline tab and code tabs
- Verify focus remains on the clicked tab (not stolen by Cline)
- Verify Cmd/Ctrl+' still focuses the chat input

<!-- 
Please walk us through your testing approach and thought process. This helps reviewers understand that you've thoroughly considered the impact of your changes:

- How did you test this change?
- What could potentially break and how did you verify it doesn't?
- What existing functionality might be affected and how did you check it still works?
- Why are you confident this is ready for merge?

We're not looking for exhaustive documentation - just evidence that you've thought through the implications of your changes and tested accordingly.
-->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [x] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Prevents focus stealing in "Open in Editor" mode by modifying `onDidChangeViewState` in `VscodeWebviewProvider.ts` to not send `didBecomeVisible` events for editor tabs.
> 
>   - **Behavior**:
>     - Prevents focus stealing in "Open in Editor" mode by not sending `didBecomeVisible` event in `onDidChangeViewState` for editor tabs in `VscodeWebviewProvider.ts`.
>     - Sidebar mode behavior remains unchanged.
>     - Keyboard shortcuts (Cmd/Ctrl+') still focus the chat input as expected.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 13d25e8260ab52e50ede7dd2aa585ac04f207954. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->