### PR TITLE
Fix fresh install mode launch config

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -18,14 +18,14 @@
 			}
 		},
 		{
-			"name": "Run Extension (Fresh Install Mode)",
+			"name": "Run Extension with Temp Profile (Fresh Install Mode)",
 			"type": "extensionHost",
 			"request": "launch",
 			"runtimeExecutable": "${execPath}",
 			"args": [
+				"--user-data-dir=/tmp/cline/user",
 				"--profile-temp",
-				"--sync",
-				"off",
+				"--sync=off",
 				"--disable-extensions",
 				"--extensionDevelopmentPath=${workspaceFolder}",
 				"${workspaceFolder}"

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -23,7 +23,7 @@
 			"request": "launch",
 			"runtimeExecutable": "${execPath}",
 			"args": [
-				"--user-data-dir=/tmp/cline-dev/ws${cwd}",
+				"--user-data-dir=${workspaceFolder}/dist/tmp/user",
 				"--profile-temp",
 				"--sync=off",
 				"--disable-extensions",
@@ -31,11 +31,12 @@
 				"${workspaceFolder}"
 			],
 			"outFiles": ["${workspaceFolder}/dist/**/*.js"],
-			"preLaunchTask": "clean-sandbox",
+			"preLaunchTask": "clean-tmp-user",
 			"internalConsoleOptions": "openOnSessionStart",
 			"postDebugTask": "stop",
 			"env": {
 				"IS_DEV": "true",
+				"TEMP_PROFILE": "true",
 				"DEV_WORKSPACE_FOLDER": "${workspaceFolder}"
 			}
 		},

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -18,7 +18,7 @@
 			}
 		},
 		{
-			"name": "Run Extension with Temp Profile (Fresh Install Mode)",
+			"name": "Run Extension (Fresh Install Mode)",
 			"type": "extensionHost",
 			"request": "launch",
 			"runtimeExecutable": "${execPath}",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -23,7 +23,7 @@
 			"request": "launch",
 			"runtimeExecutable": "${execPath}",
 			"args": [
-				"--user-data-dir=/tmp/cline/user",
+				"--user-data-dir=/tmp/cline-dev/ws${cwd}",
 				"--profile-temp",
 				"--sync=off",
 				"--disable-extensions",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -233,10 +233,10 @@
 			"type": "shell"
 		},
 		{
-			"label": "clean-sandbox",
+			"label": "clean-tmp-user",
 			"type": "shell",
 			"dependsOn": ["watch"],
-			"command": "rm -rf .vscode-dev"
+			"command": "rm -rf ${workspaceFolder}/dist/tmp/user && mkdir -p ${workspaceFolder}/dist/tmp/user"
 		}
 	],
 	"inputs": [

--- a/src/core/storage/state.ts
+++ b/src/core/storage/state.ts
@@ -18,23 +18,53 @@ import { migrateEnableCheckpointsSetting, migrateMcpMarketplaceEnableSetting } f
 	https://www.eliostruyf.com/devhack-code-extension-storage-options/
 	*/
 
+const isTemporaryProfile = process.env.TEMP_PROFILE === "true"
+
+// In-memory storage for temporary profiles
+const inMemoryGlobalState = new Map<string, any>()
+const inMemoryWorkspaceState = new Map<string, any>()
+const inMemorySecrets = new Map<string, string>()
+
 // global
 
 export async function updateGlobalState(context: vscode.ExtensionContext, key: GlobalStateKey, value: any) {
+	if (isTemporaryProfile) {
+		inMemoryGlobalState.set(key, value)
+		return
+	}
 	await context.globalState.update(key, value)
 }
 
 export async function getGlobalState(context: vscode.ExtensionContext, key: GlobalStateKey) {
+	if (isTemporaryProfile) {
+		return inMemoryGlobalState.get(key)
+	}
 	return await context.globalState.get(key)
 }
 
 // Batched operations for performance optimization
 export async function updateGlobalStateBatch(context: vscode.ExtensionContext, updates: Record<string, any>) {
+	if (isTemporaryProfile) {
+		Object.entries(updates).forEach(([key, value]) => {
+			inMemoryGlobalState.set(key, value)
+		})
+		return
+	}
 	// Use Promise.all to batch the updates
 	await Promise.all(Object.entries(updates).map(([key, value]) => context.globalState.update(key as GlobalStateKey, value)))
 }
 
 export async function updateSecretsBatch(context: vscode.ExtensionContext, updates: Record<string, string | undefined>) {
+	if (isTemporaryProfile) {
+		Object.entries(updates).forEach(([key, value]) => {
+			if (value) {
+				inMemorySecrets.set(key, value)
+			} else {
+				inMemorySecrets.delete(key)
+			}
+		})
+		return
+	}
 	// Use Promise.all to batch the secret updates
 	await Promise.all(Object.entries(updates).map(([key, value]) => storeSecret(context, key as SecretKey, value)))
 }
@@ -42,6 +72,14 @@ export async function updateSecretsBatch(context: vscode.ExtensionContext, updat
 // secrets
 
 export async function storeSecret(context: vscode.ExtensionContext, key: SecretKey, value?: string) {
+	if (isTemporaryProfile) {
+		if (value) {
+			inMemorySecrets.set(key, value)
+		} else {
+			inMemorySecrets.delete(key)
+		}
+		return
+	}
 	if (value) {
 		await context.secrets.store(key, value)
 	} else {
@@ -50,16 +88,26 @@ export async function storeSecret(context: vscode.ExtensionContext, key: SecretK
 }
 
 export async function getSecret(context: vscode.ExtensionContext, key: SecretKey) {
+	if (isTemporaryProfile) {
+		return inMemorySecrets.get(key)
+	}
 	return await context.secrets.get(key)
 }
 
 // workspace
 
 export async function updateWorkspaceState(context: vscode.ExtensionContext, key: LocalStateKey, value: any) {
+	if (isTemporaryProfile) {
+		inMemoryWorkspaceState.set(key, value)
+		return
+	}
 	await context.workspaceState.update(key, value)
 }
 
 export async function getWorkspaceState(context: vscode.ExtensionContext, key: LocalStateKey) {
+	if (isTemporaryProfile) {
+		return inMemoryWorkspaceState.get(key)
+	}
 	return await context.workspaceState.get(key)
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- Opened an issue and discussed your proposed changes with the community / contributors
- Received approval from a core Cline contributor prior to proceeding with the implementation
- Link the associated issue in the "Related Issue" section

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly.

Why this requirement?
We deeply appreciate all community contributions - they are the core reason we're able to operate successfully and keep innovating! We welcome community input and want to make it as easy as possible for people to submit quality work. This process helps our core maintainers review new ideas faster and saves contributor time by ensuring you have the go-ahead before spending time on implementation.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** #XXXX

### Description

<!-- 
Help reviewers understand your changes by making this PR readable and well-organized:

- What problem does this PR solve?
- Why were these changes introduced and what purpose do they serve?
- For larger changes, provide context about your approach and reasoning

Small PRs may need minimal description, but larger changes benefit from explaining where you're coming from. Much of this context can be in the linked issue above, so feel free to reference it rather than repeating everything here.
-->

Updates the launch configuration in `.vscode/launch.json` for `Run Extension (Fresh Install Mode)` to include a temporary profile and user data directory. This fixes the issue where the launch config does not start in fresh install mode for extension development. This change prevents  interference from existing settings and extensions. The `--user-data-dir=${workspaceFolder}/dist/tmp/user` argument specifies a temporary directory for user data for the current ws, while `--profile-temp` ensures a clean profile is used for each launch. Also, `--sync=off` is added to disable settings sync. Updated pre-launch task `clean-sandbox` to `clean-tmp-user` that reset the tmp directory.

Adds in-memory storage for global state, workspace state, and secrets when running in a temporary profile. This is determined by the `TEMP_PROFILE` environment variable being set to "true". 

### Test Procedure

<!-- 
Please walk us through your testing approach and thought process. This helps reviewers understand that you've thoroughly considered the impact of your changes:

- How did you test this change?
- What could potentially break and how did you verify it doesn't?
- What existing functionality might be affected and how did you check it still works?
- Why are you confident this is ready for merge?

We're not looking for exhaustive documentation - just evidence that you've thought through the implications of your changes and tested accordingly.
-->

1. Confirm you are currently signed in in Cline
2. In the RUN AND DEBUG tab, verify `Run Extension (Fresh Install Mode)` is showing up from the dropdown
3. Start the debugger with `Run Extension (Fresh Install Mode)` selected should open a new vs code dev env with Cline opened in auth page - this indicates no old states are being used by the new build.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

Run Extension (Fresh Install Mode) in debugger dropdown:

<img width="527" alt="image" src="https://github.com/user-attachments/assets/797881b1-9d04-416a-8eb5-3806a6ebf729" />

New VS Code Debugger opened with user not signed in:

<img width="1228" alt="image" src="https://github.com/user-attachments/assets/32bf57cb-9526-4da3-aebc-5ef9f8ec6717" />

### Additional Notes

<!-- Add any additional notes for reviewers -->
