### PR TITLE
Improve auth flow and state validation

### DIFF
--- a/src/core/controller/index.ts
+++ b/src/core/controller/index.ts
@@ -458,12 +458,7 @@ export class Controller {
 
 	// Auth
 	public async validateAuthState(state: string | null): Promise<boolean> {
-		const storedNonce = this.authService.authNonce
-		if (!state || state !== storedNonce) {
-			return false
-		}
-		this.authService.resetAuthNonce() // Clear the nonce after validation
-		return true
+		return state === this.authService.authNonce
 	}
 
 	async handleAuthCallback(customToken: string, provider: string | null = null) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -307,10 +307,18 @@ export async function activate(context: vscode.ExtensionContext) {
 					provider: provider,
 				})
 
-				// Validate state parameter
-				if (!(authService.authNonce === state)) {
-					vscode.window.showErrorMessage("Invalid auth state")
-					return
+				// Ask user to confirm on state mismatch. This enables signins initiated from
+				// outside the extension (e.g. Cline web) to be handled correctly.
+				if (authService.authNonce !== state) {
+					const userConfirmation = await vscode.window.showWarningMessage(
+						`Store token returned from ${uri.path}`,
+						"Store",
+						"Cancel",
+					)
+					if (userConfirmation === "Cancel") {
+						console.log("User declined to continue with auth callback due to state mismatch")
+						return
+					}
 				}
 
 				if (token) {

--- a/src/services/auth/AuthService.ts
+++ b/src/services/auth/AuthService.ts
@@ -30,7 +30,7 @@ export class AuthService {
 	private _authenticated: boolean = false
 	private _user: any = null
 	private _provider: any = null
-	private _authNonce: string | null = null
+	private readonly _authNonce = crypto.randomBytes(32).toString("hex")
 	private _activeAuthStatusUpdateSubscriptions = new Set<[Controller, StreamingResponseHandler]>()
 	private _context: vscode.ExtensionContext
 
@@ -136,7 +136,7 @@ export class AuthService {
 		this._setProvider(providerName)
 	}
 
-	get authNonce(): string | null {
+	get authNonce(): string {
 		return this._authNonce
 	}
 
@@ -170,33 +170,27 @@ export class AuthService {
 		})
 	}
 
-	/**
-	 * Resets the auth nonce to null.
-	 * This is typically called after a successful authentication.
-	 */
-	resetAuthNonce(): void {
-		this._authNonce = null
-	}
-
 	async createAuthRequest(): Promise<String> {
-		if (!this._authenticated) {
-			// Generate nonce for state validation
-			this._authNonce = crypto.randomBytes(32).toString("hex")
-
-			const uriScheme = vscode.env.uriScheme
-			const authUrl = vscode.Uri.parse(
-				`${this._config.URI}?state=${encodeURIComponent(this._authNonce)}&callback_url=${encodeURIComponent(`${uriScheme || "vscode"}://saoudrizwan.claude-dev/auth`)}`,
-			)
-			await vscode.env.openExternal(authUrl)
-			return String.create({
-				value: authUrl.toString(),
-			})
-		} else {
+		if (this._authenticated) {
 			this.sendAuthStatusUpdate()
-			return String.create({
-				value: "Already authenticated",
-			})
+			return String.create({ value: "Already authenticated" })
 		}
+
+		if (!this._config.URI) {
+			throw new Error("Authentication URI is not configured")
+		}
+
+		const callbackUrl = `${vscode.env.uriScheme || "vscode"}://saoudrizwan.claude-dev/auth`
+
+		// Use URL object for more graceful query construction
+		const authUrl = new URL(this._config.URI)
+		authUrl.searchParams.set("state", this._authNonce)
+		authUrl.searchParams.set("callback_url", callbackUrl)
+
+		const authUrlString = authUrl.toString()
+
+		await vscode.env.openExternal(vscode.Uri.parse(authUrlString))
+		return String.create({ value: authUrlString })
 	}
 
 	async handleDeauth(): Promise<void> {


### PR DESCRIPTION
<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- Opened an issue and discussed your proposed changes with the community / contributors
- Received approval from a core Cline contributor prior to proceeding with the implementation
- Link the associated issue in the "Related Issue" section

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly.

Why this requirement?
We deeply appreciate all community contributions - they are the core reason we're able to operate successfully and keep innovating! We welcome community input and want to make it as easy as possible for people to submit quality work. This process helps our core maintainers review new ideas faster and saves contributor time by ensuring you have the go-ahead before spending time on implementation.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** #4756

The cause of the issue is that the authNonce is being reset in the validateAuthState method in the Controller, but the extension.ts is directly accessing authService.authNonce without going through the validation method. This creates a race condition where:

1. User initiates auth, nonce is generated
2. Auth callback comes back with the state
3. If there are multiple auth attempts or the callback is processed multiple times, the nonce might be reset before the validation in extension.ts happens.
4. User gets "Invalid auth state" error

### Description

<!-- 
Help reviewers understand your changes by making this PR readable and well-organized:

- What problem does this PR solve?
- Why were these changes introduced and what purpose do they serve?
- For larger changes, provide context about your approach and reasoning

Small PRs may need minimal description, but larger changes benefit from explaining where you're coming from. Much of this context can be in the linked issue above, so feel free to reference it rather than repeating everything here.
-->

Improves the authentication flow and state validation process.  We no longer reset the auth nounce after each sign in as AuthService is a singleton and there is no risk of nonce collision between different users as only one user can be signed in at a time.

Changes:
    - The `authNonce` is now generated once during `AuthService` instantiation and stored as a read-only property. This ensures that the nonce remains consistent throughout the authentication process.
    - The `resetAuthNonce` method has been removed, as the nonce is no longer meant to be reset.
    - The `createAuthRequest` method now uses the URL object for more graceful query construction.
- **Controller:**
    - The `validateAuthState` method has been simplified to directly compare the provided state with the stored `authNonce`.
- **Extension:**
    - The extension now prompts the user for confirmation if the state parameter in the auth callback does not match the stored `authNonce`. This allows sign-ins initiated from outside the extension (e.g., Cline web) to be handled correctly.

### Test Procedure

<!-- 
Please walk us through your testing approach and thought process. This helps reviewers understand that you've thoroughly considered the impact of your changes:

- How did you test this change?
- What could potentially break and how did you verify it doesn't?
- What existing functionality might be affected and how did you check it still works?
- Why are you confident this is ready for merge?

We're not looking for exhaustive documentation - just evidence that you've thought through the implications of your changes and tested accordingly.
-->

Verify auth redirection is working as expected and the invalid auth state is no longer an issue on multiple login

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Improves auth flow by making `authNonce` consistent, simplifying state validation, and adding user prompts for state mismatches.
> 
>   - **AuthService**:
>     - `authNonce` is now a read-only property generated during instantiation.
>     - Removed `resetAuthNonce()` method.
>     - `createAuthRequest()` uses `URL` object for query construction.
>   - **Controller**:
>     - Simplified `validateAuthState()` to directly compare `state` with `authNonce`.
>   - **Extension**:
>     - Added user confirmation prompt for state mismatches in auth callback handling.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 2195a689b787a963bdacc35d348f4590c30a2692. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->