### PR TITLE
Add VSCode focusBorder colors to Action buttons (Approve/Save/Run Command & Reject buttons)

### DIFF
--- a/.changeset/brave-sheep-type.md
+++ b/.changeset/brave-sheep-type.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+added focusBorder coloring to Approve / Reject buttons

--- a/webview-ui/src/components/chat/chat-view/components/layout/ActionButtons.tsx
+++ b/webview-ui/src/components/chat/chat-view/components/layout/ActionButtons.tsx
@@ -1,4 +1,4 @@
-import React from "react"
+import React, { useState } from "react"
 import { VSCodeButton } from "@vscode/webview-ui-toolkit/react"
 import styled from "styled-components"
 import { ChatState, MessageHandlers } from "../../types/chatTypes"
@@ -20,6 +20,8 @@ interface ActionButtonsProps {
 export const ActionButtons: React.FC<ActionButtonsProps> = ({ chatState, messageHandlers, isStreaming, scrollBehavior }) => {
 	const { primaryButtonText, secondaryButtonText, enableButtons, didClickCancel, inputValue, selectedImages, selectedFiles } =
 		chatState
+	const [primaryFocused, setPrimaryFocused] = useState(false)
+	const [secondaryFocused, setSecondaryFocused] = useState(false)
 
 	const { showScrollToBottom, scrollToBottomSmooth, disableAutoScrollRef } = scrollBehavior
 
@@ -51,10 +53,20 @@ export const ActionButtons: React.FC<ActionButtonsProps> = ({ chatState, message
 				display: "flex",
 				padding: `${shouldShowButtons ? "10" : "0"}px 15px 0px 15px`,
 			}}>
+			<style>
+				{`
+          .focused {
+            outline: 1px solid var(--vscode-focusBorder);
+          }
+        `}
+			</style>
 			{primaryButtonText && !isStreaming && (
 				<VSCodeButton
 					appearance="primary"
 					disabled={!enableButtons}
+					className={primaryFocused ? "focused" : ""}
+					onFocus={() => setPrimaryFocused(true)}
+					onBlur={() => setPrimaryFocused(false)}
 					style={{
 						flex: secondaryButtonText ? 1 : 2,
 						marginRight: secondaryButtonText ? "6px" : "0",
@@ -67,6 +79,9 @@ export const ActionButtons: React.FC<ActionButtonsProps> = ({ chatState, message
 				<VSCodeButton
 					appearance="secondary"
 					disabled={!enableButtons && !(isStreaming && !didClickCancel)}
+					className={secondaryFocused ? "focused" : ""}
+					onFocus={() => setSecondaryFocused(true)}
+					onBlur={() => setSecondaryFocused(false)}
 					style={{
 						flex: isStreaming ? 2 : 1,
 						marginLeft: isStreaming ? 0 : "6px",


### PR DESCRIPTION
<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- Opened an issue and discussed your proposed changes with the community / contributors
- Received approval from a core Cline contributor prior to proceeding with the implementation
- Link the associated issue in the "Related Issue" section

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly.

Why this requirement?
We deeply appreciate all community contributions - they are the core reason we're able to operate successfully and keep innovating! We welcome community input and want to make it as easy as possible for people to submit quality work. This process helps our core maintainers review new ideas faster and saves contributor time by ensuring you have the go-ahead before spending time on implementation.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** #4650 

### Description

When using Shift + Tab to navigate to Approve or Reject, using the keyboard, they would not be highlighted. With this improvement, these 2 buttons highlight, taking on the colors set by the user. This allows users the ability to see which of the 2 buttons they've selected, before pressing "Enter".

<!-- 
Help reviewers understand your changes by making this PR readable and well-organized:

- What problem does this PR solve?
- Why were these changes introduced and what purpose do they serve?
- For larger changes, provide context about your approach and reasoning

Small PRs may need minimal description, but larger changes benefit from explaining where you're coming from. Much of this context can be in the linked issue above, so feel free to reference it rather than repeating everything here.
-->

### Test Procedure

Used the Debugger tool and tested that the buttons highlighted, and unhighlighted when passed over.

<!-- 
Please walk us through your testing approach and thought process. This helps reviewers understand that you've thoroughly considered the impact of your changes:

- How did you test this change?
- What could potentially break and how did you verify it doesn't?
- What existing functionality might be affected and how did you check it still works?
- Why are you confident this is ready for merge?

We're not looking for exhaustive documentation - just evidence that you've thought through the implications of your changes and tested accordingly.
-->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Before

https://github.com/user-attachments/assets/4bb3ee3d-634c-4826-8ff4-bd3548c60363

After

https://github.com/user-attachments/assets/dd893a09-43ea-41cc-b508-d860eae83cd6


<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add focus border styling to Approve and Reject buttons in `ActionButtons.tsx` for better keyboard navigation visibility.
> 
>   - **Behavior**:
>     - Adds focus border styling to Approve and Reject buttons in `ActionButtons.tsx` using `useState` to track focus.
>     - Applies `focused` class with `outline` style when buttons are focused.
>   - **Implementation**:
>     - Introduces `primaryFocused` and `secondaryFocused` state variables in `ActionButtons` component.
>     - Adds `onFocus` and `onBlur` handlers to update focus state for buttons.
>     - Defines `.focused` CSS class to apply `outline` using `--vscode-focusBorder`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 21da404f5b6679acd3ae372eb94a6eab6c101520. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->