### PR TITLE
Use buyCreditsURL returns by server in CreditLimitError component

### DIFF
--- a/webview-ui/src/components/chat/ChatRow.tsx
+++ b/webview-ui/src/components/chat/ChatRow.tsx
@@ -956,6 +956,7 @@ export const ChatRowContent = memo(
 															totalSpent={errorData.total_spent}
 															totalPromotions={errorData.total_promotions}
 															message={errorData.message}
+															buyCreditsURL={errorData.buy_credits_url}
 														/>
 													)
 												}

--- a/webview-ui/src/components/chat/CreditLimitError.tsx
+++ b/webview-ui/src/components/chat/CreditLimitError.tsx
@@ -9,6 +9,7 @@ interface CreditLimitErrorProps {
 	totalSpent?: number
 	totalPromotions?: number
 	message: string
+	buyCreditsURL?: string
 }
 
 const CreditLimitError: React.FC<CreditLimitErrorProps> = ({
@@ -16,6 +17,7 @@ const CreditLimitError: React.FC<CreditLimitErrorProps> = ({
 	totalSpent = 0,
 	totalPromotions = 0,
 	message = "You have run out of credit.",
+	buyCreditsURL = "https://app.cline.bot/dashboard/account?tab=credits",
 }) => {
 	// We have to divide because the balance is stored in microcredits
 	return (
@@ -28,7 +30,7 @@ const CreditLimitError: React.FC<CreditLimitErrorProps> = ({
 			</div>
 
 			<VSCodeButtonLink
-				href="https://app.cline.bot/"
+				href={buyCreditsURL}
 				style={{
 					width: "100%",
 					marginBottom: "8px",


### PR DESCRIPTION
Adds the `buyCreditsURL` prop to the `CreditLimitError` component WHEN the value is returned by the server added in https://github.com/cline/core-platform/pull/444. This allows users to navigate directly to the Cline credits purchase page directly to the url sent by the server when they encounter a credit limit error.

<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- Opened an issue and discussed your proposed changes with the community / contributors
- Received approval from a core Cline contributor prior to proceeding with the implementation
- Link the associated issue in the "Related Issue" section

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly.

Why this requirement?
We deeply appreciate all community contributions - they are the core reason we're able to operate successfully and keep innovating! We welcome community input and want to make it as easy as possible for people to submit quality work. This process helps our core maintainers review new ideas faster and saves contributor time by ensuring you have the go-ahead before spending time on implementation.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** #XXXX

### Description

<!-- 
Help reviewers understand your changes by making this PR readable and well-organized:

- What problem does this PR solve?
- Why were these changes introduced and what purpose do they serve?
- For larger changes, provide context about your approach and reasoning

Small PRs may need minimal description, but larger changes benefit from explaining where you're coming from. Much of this context can be in the linked issue above, so feel free to reference it rather than repeating everything here.
-->

Adds the `buyCreditsURL` prop to the `CreditLimitError` component  where the value is returned by the server added in https://github.com/cline/core-platform/pull/444. This allows users to navigate directly to the Cline credits purchase page directly to the url sent by the server when they encounter a credit limit error.

The `buyCreditsURL` prop is now used in the `CreditLimitError` component to dynamically set the `href` attribute of the VSCodeButtonLink, ensuring users are directed to the correct page for purchasing more credits. The default value is set to use the user account one.


### Test Procedure

<!-- 
Please walk us through your testing approach and thought process. This helps reviewers understand that you've thoroughly considered the impact of your changes:

- How did you test this change?
- What could potentially break and how did you verify it doesn't?
- What existing functionality might be affected and how did you check it still works?
- Why are you confident this is ready for merge?

We're not looking for exhaustive documentation - just evidence that you've thought through the implications of your changes and tested accordingly.
-->

Once https://github.com/cline/core-platform/pull/444 is deployed, you can reproduce the credit limit error and verify if the "Buy Credit" button takes you to the corrected url with credit tab opened. Before this change, the buy credit button always takes you to the https://app.cline.bot

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [x] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `buyCreditsURL` prop to `CreditLimitError` for dynamic credit purchase URL setting.
> 
>   - **Behavior**:
>     - Adds `buyCreditsURL` prop to `CreditLimitError` component in `CreditLimitError.tsx`.
>     - Uses `buyCreditsURL` in `CreditLimitError` to set `href` of `VSCodeButtonLink`.
>     - Default `buyCreditsURL` set to `https://app.cline.bot/dashboard/account?tab=credits`.
>   - **Integration**:
>     - Passes `buyCreditsURL` from `ChatRow.tsx` to `CreditLimitError` when server returns the value.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 0224fdebe20b8f6db4954e6cc5152b7a7630fe60. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->