### PR TITLE
Fix Cline account logging out issues by saving Firebase refresh token instead of the short-lived credential key

### DIFF
--- a/src/services/account/ClineAccountService.ts
+++ b/src/services/account/ClineAccountService.ts
@@ -275,7 +275,7 @@ export class ClineAccountService {
 			throw error
 		} finally {
 			// Request a new authentication token
-			await this._authService.refreshAuth()
+			// await this._authService.refreshAuth()
 		}
 	}
 }

--- a/src/services/auth/AuthService.ts
+++ b/src/services/auth/AuthService.ts
@@ -220,7 +220,6 @@ export class AuthService {
 			this._authenticated = true
 
 			await this.sendAuthStatusUpdate()
-			this.setupAutoRefreshAuth()
 			return this._user
 		} catch (error) {
 			console.error("Error signing in with custom token:", error)
@@ -250,7 +249,6 @@ export class AuthService {
 			if (this._user) {
 				this._authenticated = true
 				await this.sendAuthStatusUpdate()
-				this.setupAutoRefreshAuth()
 				// Setup auto-refresh for the auth token
 			} else {
 				console.warn("No user found after restoring auth token")
@@ -263,34 +261,6 @@ export class AuthService {
 			this._user = null
 			return
 		}
-	}
-
-	/**
-	 * Refreshes the authentication status and sends an update to all subscribers.
-	 */
-	async refreshAuth(): Promise<void> {
-		if (!this._user) {
-			console.warn("No user is authenticated, skipping auth refresh")
-			return
-		}
-
-		await this._provider.provider.refreshAuthToken()
-		this.sendAuthStatusUpdate()
-	}
-
-	private setupAutoRefreshAuth(): void {
-		// Set timeoutDuration to refresh the auth token 5 minutes before it expires
-		const timeoutDuration = Math.floor(this._user.stsTokenManager.expirationTime - 5 * 60000 - Date.now()) // Milliseconds until 5 minutes before expiration
-		setTimeout(() => this._autoRefreshAuth(), timeoutDuration)
-	}
-
-	private async _autoRefreshAuth(): Promise<void> {
-		if (!this._user) {
-			console.warn("No user is authenticated, skipping auth refresh")
-			return
-		}
-		await this.refreshAuth()
-		this.setupAutoRefreshAuth() // Reschedule the next auto-refresh
 	}
 
 	/**

--- a/src/services/auth/providers/FirebaseAuthProvider.ts
+++ b/src/services/auth/providers/FirebaseAuthProvider.ts
@@ -39,16 +39,6 @@ export class FirebaseAuthProvider {
 	}
 
 	/**
-	 * Refreshes the authentication token of the current user.
-	 * @returns {Promise<string | null>} A promise that resolves to the refreshed authentication token of the current user, or null if no user is signed in.
-	 */
-	async refreshAuthToken(): Promise<string | null> {
-		const user = getAuth().currentUser
-		const idToken = user ? await user.getIdToken(true) : null
-		return idToken
-	}
-
-	/**
 	 * Converts Firebase User object to a generic user object.
 	 * @param user - The Firebase User object.
 	 * @returns {User} A generic user object.
@@ -111,11 +101,8 @@ export class FirebaseAuthProvider {
 
 			// Step 2: Exchange access token for custom token from our backend (backend has the admin key, which firebase requires to create a custom token)
 			const customTokenResponse = await axios.post(
-				"https://api.cline.bot/api/v1/users/getauthtoken",
-				{
-					user_id: "",
-					id_token: googleAccessIdToken,
-				},
+				"https://api.cline.bot/api/v1/custom-token",
+				{}, // Empty request body
 				{
 					headers: {
 						"Content-Type": "application/json",
@@ -124,7 +111,7 @@ export class FirebaseAuthProvider {
 				},
 			)
 
-			const customToken = customTokenResponse.data.token
+			const customToken = customTokenResponse.data.data.token
 
 			// Step 3: Use the custom token to sign in with Firebase and create a user object (we then use user.getIdToken() to refresh the access token periodically)
 			const firebaseConfig = Object.assign({}, this._config)


### PR DESCRIPTION
When the user logs in to cline account, and we receive the authcallback which includes a short-lived credential key from google or github, which we then use to sign in to firebase to create a Firebase.User object which contains a long-lived refresh token and short-lived id token (the id token authenticates requests to our backend). We were previously storing the first short-lived credential key from google/github in secret storage, when we should have been persisting the long-lived refresh token from firebase. Now we persist this firebase refresh token, and use it to re-construct the Firebase.User object when the short-lived id token expires. The firebase sdk has a restriction where an id token or refresh token by themselves cannot be used to construct a Firebase.User session for the node sdk, so we are required to make a call to our backend that uses the firebase admin sdk/admin key to take the user's id token and convert it into a "custom token" which CAN be used to construct a Firebase.User session that is then used throughout the extension to represent an active user session. (Side note, anywhere else we retrieve the latest id token used to authenticate requests, we use `user.getIdToken()` which will automatically refresh the id token if expired or close to expiration -- so we don't need to be using the timer to keep refreshing the id token since `user.getIdToken()` will just refresh if its expired anyways.).

Basically the SDK makes it hard for the developer to create a User object JUST from the refresh token alone, but once we go through the process of signing in with the custom token and the User object is created -- it then has a refresh token internally and can refresh the id token itself as needed with the `getIdToken` method. 

So at a high level, when the extension launches, we create a controller/index.ts instance whose constructor calls `this.authService.restoreAuthToken()` which calls `provider.restoreAuthCredential()` (the authService has a provider: FirebaseAuthProvider variable). `provider.restoreAuthCredential()` was previously using a short-lived credential key from google/github to sign the user into firebase for the Firebase.User session, but now we use the newly saved long-lived firebase refresh token to create a custom token to create a Firebase.User session, which then handles refreshing the short-lived id token (used to authenticate api requests) as needed. The reason we were running into authentication issues before was that the credential key from google/github being returned in the auth callback had a 1-8 hour expiration depending on the sign in method, and we actually needed to immediately use that to get a long-lived refresh token from firebase that doesn't expire (and that we can invalidate ie if the user's access is revoked).
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Switch from storing short-lived tokens to long-lived Firebase refresh tokens for persistent user sessions, removing unnecessary token refresh logic.
> 
>   - **Behavior**:
>     - Store Firebase refresh token instead of short-lived credential key in `FirebaseAuthProvider.ts`.
>     - Use refresh token to reconstruct `Firebase.User` object when ID token expires.
>     - Remove `refreshAuth()` and `setupAutoRefreshAuth()` from `AuthService.ts`.
>   - **Auth Flow**:
>     - `restoreAuthCredential()` in `FirebaseAuthProvider.ts` exchanges refresh token for access token, then for a custom token to sign in.
>     - `signIn()` in `FirebaseAuthProvider.ts` stores refresh token after signing in with Google/GitHub credentials.
>   - **Misc**:
>     - Comment out `refreshAuth()` call in `ClineAccountService.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 22ed9e90c474c06ac9b17a2c05cadbb29a69426a. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->