### PR TITLE
Replace firebase user object session logic with google endpoint to get id token and custom jwt validation

### DIFF
--- a/.changeset/green-drinks-rest.md
+++ b/.changeset/green-drinks-rest.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Fix authentication issue where Cline accounts users would keep getting logged out or seeing 'Unexpected API response' errors

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,6 +51,7 @@
 				"image-size": "^2.0.2",
 				"isbinaryfile": "^5.0.2",
 				"jschardet": "^3.1.4",
+				"jwt-decode": "^4.0.0",
 				"mammoth": "^1.8.0",
 				"monaco-vscode-textmate-theme-converter": "^0.1.7",
 				"nice-grpc": "^2.1.12",
@@ -15783,6 +15784,15 @@
 			"dependencies": {
 				"jwa": "^2.0.0",
 				"safe-buffer": "^5.0.1"
+			}
+		},
+		"node_modules/jwt-decode": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
+			"integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
 			}
 		},
 		"node_modules/katex": {
@@ -35227,6 +35237,11 @@
 				"jwa": "^2.0.0",
 				"safe-buffer": "^5.0.1"
 			}
+		},
+		"jwt-decode": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
+			"integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA=="
 		},
 		"katex": {
 			"version": "0.16.22",

--- a/package.json
+++ b/package.json
@@ -449,6 +449,7 @@
 		"image-size": "^2.0.2",
 		"isbinaryfile": "^5.0.2",
 		"jschardet": "^3.1.4",
+		"jwt-decode": "^4.0.0",
 		"mammoth": "^1.8.0",
 		"monaco-vscode-textmate-theme-converter": "^0.1.7",
 		"nice-grpc": "^2.1.12",

--- a/src/core/controller/index.ts
+++ b/src/core/controller/index.ts
@@ -74,7 +74,7 @@ export class Controller {
 		)
 		this.accountService = ClineAccountService.getInstance()
 		this.authService = AuthService.getInstance(context)
-		this.authService.restoreAuthToken()
+		this.authService.restoreRefreshTokenAndRetrieveAuthInfo()
 
 		// Clean up legacy checkpoints
 		cleanupLegacyCheckpoints(this.context.globalStorageUri.fsPath, this.outputChannel).catch((error) => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -715,7 +715,7 @@ export async function activate(context: vscode.ExtensionContext) {
 	context.subscriptions.push(
 		context.secrets.onDidChange((event) => {
 			if (event.key === "clineAccountId") {
-				AuthService.getInstance(context)?.restoreAuthToken()
+				AuthService.getInstance(context)?.restoreRefreshTokenAndRetrieveAuthInfo()
 			}
 		}),
 	)

--- a/src/services/account/ClineAccountService.ts
+++ b/src/services/account/ClineAccountService.ts
@@ -275,7 +275,6 @@ export class ClineAccountService {
 			throw error
 		} finally {
 			// Request a new authentication token
-			// await this._authService.refreshAuth()
 		}
 	}
 }

--- a/src/services/account/ClineAccountService.ts
+++ b/src/services/account/ClineAccountService.ts
@@ -274,7 +274,8 @@ export class ClineAccountService {
 			console.error("Error switching account:", error)
 			throw error
 		} finally {
-			// Request a new authentication token
+			// After user switches account, we will force a refresh of the id token by calling this function that restores the refresh token and retrieves new auth info
+			await this._authService.restoreRefreshTokenAndRetrieveAuthInfo()
 		}
 	}
 }

--- a/src/services/account/ClineAccountService.ts
+++ b/src/services/account/ClineAccountService.ts
@@ -275,7 +275,7 @@ export class ClineAccountService {
 			throw error
 		} finally {
 			// Request a new authentication token
-			await this._authService.refreshAuth()
+			// await this._authService.refreshAuth()
 		}
 	}
 }

--- a/src/services/auth/AuthService.ts
+++ b/src/services/auth/AuthService.ts
@@ -1,7 +1,7 @@
 import vscode from "vscode"
 import crypto from "crypto"
 import { EmptyRequest, String } from "../../shared/proto/common"
-import { AuthState } from "../../shared/proto/account"
+import { AuthState, UserInfo } from "../../shared/proto/account"
 import { StreamingResponseHandler, getRequestRegistry } from "@/core/controller/grpc-handler"
 import { FirebaseAuthProvider } from "./providers/FirebaseAuthProvider"
 import { Controller } from "@/core/controller"
@@ -22,13 +22,34 @@ const availableAuthProviders = {
 	// Add other providers here as needed
 }
 
+export interface ClineAuthInfo {
+	idToken: string
+	userInfo: ClineAccountUserInfo
+}
+
+export interface ClineAccountUserInfo {
+	createdAt: string
+	displayName: string
+	email: string
+	id: string
+	organizations: ClineAccountOrganization[]
+}
+
+export interface ClineAccountOrganization {
+	active: boolean
+	memberId: string
+	name: string
+	organizationId: string
+	roles: string[]
+}
+
 // TODO: Add logic to handle multiple webviews getting auth updates.
 
 export class AuthService {
 	private static instance: AuthService | null = null
 	private _config: ServiceConfig
 	private _authenticated: boolean = false
-	private _user: any = null
+	private _clineAuthInfo: ClineAuthInfo | null = null
 	private _provider: any = null
 	private readonly _authNonce = crypto.randomBytes(32).toString("hex")
 	private _activeAuthStatusUpdateSubscriptions = new Set<[Controller, StreamingResponseHandler]>()
@@ -142,13 +163,19 @@ export class AuthService {
 	}
 
 	async getAuthToken(): Promise<string | null> {
-		if (!this._user) {
+		if (!this._clineAuthInfo) {
 			return null
 		}
-
-		// TODO: This may need to be dependant on the auth provider
-		// Return the ID token from the user object
-		return this._provider.provider.getAuthToken(this._user)
+		const idToken = this._clineAuthInfo.idToken
+		const shouldRefreshIdToken = await this._provider.provider.shouldRefreshIdToken(idToken)
+		if (shouldRefreshIdToken) {
+			// Retrieves the stored id token and refreshes it, then updates this._clineAuthInfo
+			await this.restoreAuthToken()
+			if (!this._clineAuthInfo) {
+				return null
+			}
+		}
+		return this._clineAuthInfo.idToken
 	}
 
 	private _setProvider(providerName: string): void {
@@ -161,13 +188,20 @@ export class AuthService {
 	}
 
 	getInfo(): AuthState {
-		let user = null
-		if (this._user && this._authenticated) {
-			user = this._provider.provider.convertUserData(this._user)
+		let userInfo = null
+		if (this._clineAuthInfo && this._authenticated) {
+			userInfo = this._clineAuthInfo.userInfo
 		}
 
+		// TODO: create proto for new user info type
+
 		return AuthState.create({
-			user: user,
+			user: UserInfo.create({
+				uid: userInfo?.id,
+				displayName: userInfo?.displayName,
+				email: userInfo?.email,
+				photoUrl: undefined,
+			}),
 		})
 	}
 
@@ -201,7 +235,7 @@ export class AuthService {
 
 		try {
 			await this._provider.provider.signOut()
-			this._user = null
+			this._clineAuthInfo = null
 			this._authenticated = false
 			this.sendAuthStatusUpdate()
 		} catch (error) {
@@ -216,12 +250,11 @@ export class AuthService {
 		}
 
 		try {
-			this._user = await this._provider.provider.signIn(this._context, token, provider)
+			this._clineAuthInfo = await this._provider.provider.signIn(this._context, token, provider)
 			this._authenticated = true
 
 			await this.sendAuthStatusUpdate()
-			this.setupAutoRefreshAuth()
-			return this._user
+			// return this._clineAuthInfo
 		} catch (error) {
 			console.error("Error signing in with custom token:", error)
 			throw error
@@ -246,51 +279,21 @@ export class AuthService {
 		}
 
 		try {
-			this._user = await this._provider.provider.restoreAuthCredential(this._context)
-			if (this._user) {
+			this._clineAuthInfo = await this._provider.provider.retrieveClineAuthInfo(this._context)
+			if (this._clineAuthInfo) {
 				this._authenticated = true
 				await this.sendAuthStatusUpdate()
-				this.setupAutoRefreshAuth()
-				// Setup auto-refresh for the auth token
 			} else {
 				console.warn("No user found after restoring auth token")
 				this._authenticated = false
-				this._user = null
+				this._clineAuthInfo = null
 			}
 		} catch (error) {
 			console.error("Error restoring auth token:", error)
 			this._authenticated = false
-			this._user = null
+			this._clineAuthInfo = null
 			return
 		}
-	}
-
-	/**
-	 * Refreshes the authentication status and sends an update to all subscribers.
-	 */
-	async refreshAuth(): Promise<void> {
-		if (!this._user) {
-			console.warn("No user is authenticated, skipping auth refresh")
-			return
-		}
-
-		await this._provider.provider.refreshAuthToken()
-		this.sendAuthStatusUpdate()
-	}
-
-	private setupAutoRefreshAuth(): void {
-		// Set timeoutDuration to refresh the auth token 5 minutes before it expires
-		const timeoutDuration = Math.floor(this._user.stsTokenManager.expirationTime - 5 * 60000 - Date.now()) // Milliseconds until 5 minutes before expiration
-		setTimeout(() => this._autoRefreshAuth(), timeoutDuration)
-	}
-
-	private async _autoRefreshAuth(): Promise<void> {
-		if (!this._user) {
-			console.warn("No user is authenticated, skipping auth refresh")
-			return
-		}
-		await this.refreshAuth()
-		this.setupAutoRefreshAuth() // Reschedule the next auto-refresh
 	}
 
 	/**

--- a/src/services/auth/AuthService.ts
+++ b/src/services/auth/AuthService.ts
@@ -50,7 +50,7 @@ export class AuthService {
 	private _config: ServiceConfig
 	private _authenticated: boolean = false
 	private _clineAuthInfo: ClineAuthInfo | null = null
-	private _provider: any = null
+	private _provider: { provider: FirebaseAuthProvider } | null = null
 	private readonly _authNonce = crypto.randomBytes(32).toString("hex")
 	private _activeAuthStatusUpdateSubscriptions = new Set<[Controller, StreamingResponseHandler]>()
 	private _context: vscode.ExtensionContext
@@ -167,7 +167,7 @@ export class AuthService {
 			return null
 		}
 		const idToken = this._clineAuthInfo.idToken
-		const shouldRefreshIdToken = await this._provider.provider.shouldRefreshIdToken(idToken)
+		const shouldRefreshIdToken = await this._provider?.provider.shouldRefreshIdToken(idToken)
 		if (shouldRefreshIdToken) {
 			// Retrieves the stored id token and refreshes it, then updates this._clineAuthInfo
 			await this.restoreAuthToken()
@@ -234,7 +234,6 @@ export class AuthService {
 		}
 
 		try {
-			await this._provider.provider.signOut()
 			this._clineAuthInfo = null
 			this._authenticated = false
 			this.sendAuthStatusUpdate()

--- a/src/services/auth/AuthService.ts
+++ b/src/services/auth/AuthService.ts
@@ -170,7 +170,7 @@ export class AuthService {
 		const shouldRefreshIdToken = await this._provider?.provider.shouldRefreshIdToken(idToken)
 		if (shouldRefreshIdToken) {
 			// Retrieves the stored id token and refreshes it, then updates this._clineAuthInfo
-			await this.restoreAuthToken()
+			await this.restoreRefreshTokenAndRetrieveAuthInfo()
 			if (!this._clineAuthInfo) {
 				return null
 			}
@@ -272,7 +272,7 @@ export class AuthService {
 	 * Restores the authentication token from the extension's storage.
 	 * This is typically called when the extension is activated.
 	 */
-	async restoreAuthToken(): Promise<void> {
+	async restoreRefreshTokenAndRetrieveAuthInfo(): Promise<void> {
 		if (!this._provider || !this._provider.provider) {
 			throw new Error("Auth provider is not set")
 		}

--- a/src/services/auth/providers/FirebaseAuthProvider.ts
+++ b/src/services/auth/providers/FirebaseAuthProvider.ts
@@ -47,7 +47,8 @@ export class FirebaseAuthProvider {
 			return null
 		}
 		try {
-			// Step 1: Exchange refresh token for new access token using Firebase's secure token endpoint
+			// Exchange refresh token for new access token using Firebase's secure token endpoint
+			// https://stackoverflow.com/questions/38233687/how-to-use-the-firebase-refreshtoken-to-reauthenticate/57119131#57119131
 			const firebaseApiKey = this._config.apiKey
 			const googleAccessTokenResponse = await axios.post(
 				`https://securetoken.googleapis.com/v1/token?key=${firebaseApiKey}`,
@@ -59,12 +60,13 @@ export class FirebaseAuthProvider {
 				},
 			)
 
-			console.log("googleAccessTokenResponse", googleAccessTokenResponse)
+			// console.log("googleAccessTokenResponse", googleAccessTokenResponse)
 
+			// This returns an object with access_token, expires_in (3600), id_token (can be used as bearer token to authenticate requests, we'll use this in the future instead of firebase but need to be aware of how we use firebase sdk for e.g. user info like the profile image), project_id, refresh_token, token_type (always Bearer), and user_id
 			const idToken = googleAccessTokenResponse.data.id_token
 			// const idTokenExpirationDate = new Date(Date.now() + googleAccessTokenResponse.data.expires_in * 1000)
 
-			// Now retrieve the user info from the backend
+			// Now retrieve the user info from the backend (this was an easy solution to keep providing user profile details like name and email, but we should move to using the fetchMe() function instead)
 			// Fetch user info from Cline API
 			// TODO: consolidate with fetchMe() instead of making the call directly here
 			const userResponse = await axios.get("https://api.cline.bot/api/v1/users/me", {

--- a/src/services/auth/providers/FirebaseAuthProvider.ts
+++ b/src/services/auth/providers/FirebaseAuthProvider.ts
@@ -1,18 +1,11 @@
 import { getSecret, storeSecret } from "@/core/storage/state"
 import { ErrorService } from "@/services/error/ErrorService"
+import axios from "axios"
 import { initializeApp } from "firebase/app"
-import {
-	AuthCredential,
-	GoogleAuthProvider,
-	GithubAuthProvider,
-	OAuthCredential,
-	User,
-	UserCredential,
-	getAuth,
-	signInWithCredential,
-	signOut,
-} from "firebase/auth"
+import { GithubAuthProvider, GoogleAuthProvider, User, getAuth, signInWithCredential } from "firebase/auth"
 import { ExtensionContext } from "vscode"
+import { ClineAccountUserInfo, ClineAuthInfo } from "../AuthService"
+import { jwtDecode } from "jwt-decode"
 
 export class FirebaseAuthProvider {
 	private _config: any
@@ -29,80 +22,16 @@ export class FirebaseAuthProvider {
 		this._config = value
 	}
 
-	/**
-	 * Gets the authentication token of the current user.
-	 * @returns {Promise<string | null>} A promise that resolves to the authentication token of the current user, or null if no user is signed in.
-	 */
-	async getAuthToken(): Promise<string | null> {
-		const user = getAuth().currentUser
-		const idToken = user ? await user.getIdToken() : null
-		return idToken
-	}
-
-	/**
-	 * Gets the refresh token of the current user.
-	 * @returns {Promise<string | null>} A promise that resolves to the refresh token of the current user, or null if no user is signed in.
-	 */
-	async getRefreshToken(): Promise<string | null> {
-		const user = getAuth().currentUser
-		const refreshToken = user ? user.refreshToken : null
-		return refreshToken
-	}
-
-	/**
-	 * Refreshes the authentication token of the current user.
-	 * @returns {Promise<string | null>} A promise that resolves to the refreshed authentication token of the current user, or null if no user is signed in.
-	 */
-	async refreshAuthToken(): Promise<string | null> {
-		const user = getAuth().currentUser
-		const idToken = user ? await user.getIdToken(true) : null
-		return idToken
-	}
-
-	/**
-	 * Converts Firebase User object to a generic user object.
-	 * @param user - The Firebase User object.
-	 * @returns {User} A generic user object.
-	 */
-	convertUserData(user: User) {
-		return {
-			uid: user.uid,
-			email: user.email,
-			displayName: user.displayName,
-			photoUrl: user.photoURL,
+	async shouldRefreshIdToken(existingIdToken: string): Promise<boolean> {
+		const decodedToken = jwtDecode(existingIdToken)
+		const exp = decodedToken.exp || 0 // 1752297633
+		const expirationTime = exp * 1000
+		const currentTime = Date.now()
+		const fiveMinutesInMs = 5 * 60 * 1000
+		if (currentTime > expirationTime - fiveMinutesInMs) {
+			return true // id token is expired or about to be expired
 		}
-	}
-
-	/**
-	 * Signs out the current user from Firebase.
-	 * @returns {Promise<void>} A promise that resolves when the user is signed out.
-	 */
-	async signOut(): Promise<void> {
-		signOut(getAuth(initializeApp(Object.assign({}, this._config))))
-			.then(() => {
-				console.log("User signed out successfully.")
-			})
-			.catch((error) => {
-				ErrorService.logMessage("Firebase sign-out error", "error")
-				ErrorService.logException(error)
-				throw error
-			})
-	}
-
-	/**
-	 * Stores the authentication token using a provided token.
-	 * @param token - The authentication token to store.
-	 * @returns {Promise<User>} A promise that resolves with the authenticated user.
-	 * @throws {Error} Throws an error if the storage fails.
-	 */
-	private async _storeAuthCredential(context: ExtensionContext, credential: AuthCredential): Promise<void> {
-		try {
-			await storeSecret(context, "clineAccountId", JSON.stringify(credential.toJSON()))
-		} catch (error) {
-			ErrorService.logMessage("Firebase store token error", "error")
-			ErrorService.logException(error)
-			throw error
-		}
+		return false
 	}
 
 	/**
@@ -111,31 +40,53 @@ export class FirebaseAuthProvider {
 	 * @returns {Promise<User>} A promise that resolves with the authenticated user.
 	 * @throws {Error} Throws an error if the restoration fails.
 	 */
-	async restoreAuthCredential(context: ExtensionContext): Promise<User | null> {
-		const credentialJSON = await getSecret(context, "clineAccountId")
-		if (!credentialJSON) {
+	async retrieveClineAuthInfo(context: ExtensionContext): Promise<ClineAuthInfo | null> {
+		const userRefreshToken = await getSecret(context, "clineAccountId")
+		if (!userRefreshToken) {
 			console.error("No stored authentication credential found.")
 			return null
 		}
 		try {
-			const credentialData: AuthCredential = OAuthCredential.fromJSON(credentialJSON) as AuthCredential
-			const userCredential = await this._signInWithCredential(credentialData)
-			return userCredential.user
-		} catch (error) {
-			ErrorService.logMessage("Firebase restore token error", "error")
-			ErrorService.logException(error)
-			throw error
-		}
-	}
+			// Step 1: Exchange refresh token for new access token using Firebase's secure token endpoint
+			const firebaseApiKey = this._config.apiKey
+			const googleAccessTokenResponse = await axios.post(
+				`https://securetoken.googleapis.com/v1/token?key=${firebaseApiKey}`,
+				`grant_type=refresh_token&refresh_token=${userRefreshToken}`,
+				{
+					headers: {
+						"Content-Type": "application/x-www-form-urlencoded",
+					},
+				},
+			)
 
-	async _signInWithCredential(credential: AuthCredential): Promise<UserCredential> {
-		const firebaseConfig = Object.assign({}, this._config)
-		const app = initializeApp(firebaseConfig)
-		const auth = getAuth(app)
-		try {
-			return await signInWithCredential(auth, credential)
+			console.log("googleAccessTokenResponse", googleAccessTokenResponse)
+
+			const idToken = googleAccessTokenResponse.data.id_token
+			// const idTokenExpirationDate = new Date(Date.now() + googleAccessTokenResponse.data.expires_in * 1000)
+
+			// Now retrieve the user info from the backend
+			// Fetch user info from Cline API
+			// TODO: consolidate with fetchMe() instead of making the call directly here
+			const userResponse = await axios.get("https://api.cline.bot/api/v1/users/me", {
+				headers: {
+					Authorization: `Bearer ${idToken}`,
+				},
+			})
+
+			// Store user data
+			const userInfo: ClineAccountUserInfo = userResponse.data.data
+
+			return { idToken, userInfo }
+
+			// let userObject = JSON.parse(credentialJSON)
+			// let user = User.
+			// userObject = User.constructor._fromJSON(auth, user2);
+			// const credentialData: AuthCredential = OAuthCredential.fromJSON(credentialJSON) as AuthCredential
+			// const userCredential = await this._signInWithCredential(context, credentialData)
+			// return userCredential.user
 		} catch (error) {
-			ErrorService.logMessage("Firebase sign-in with credential error", "error")
+			console.error("Firebase restore token error", error)
+			ErrorService.logMessage("Firebase restore token error", "error")
 			ErrorService.logException(error)
 			throw error
 		}
@@ -146,10 +97,9 @@ export class FirebaseAuthProvider {
 	 * @returns {Promise<User>} A promise that resolves with the authenticated user.
 	 * @throws {Error} Throws an error if the sign-in fails.
 	 */
-	async signIn(context: ExtensionContext, token: string, provider: string): Promise<User> {
+	async signIn(context: ExtensionContext, token: string, provider: string): Promise<ClineAuthInfo | null> {
 		try {
 			let credential
-			let userCredential
 			switch (provider) {
 				case "google":
 					credential = GoogleAuthProvider.credential(token)
@@ -160,9 +110,25 @@ export class FirebaseAuthProvider {
 				default:
 					throw new Error(`Unsupported provider: ${provider}`)
 			}
-			this._storeAuthCredential(context, credential)
-			userCredential = await this._signInWithCredential(credential)
-			return userCredential.user
+			// we've received the short-lived tokens from google/github, now we need to sign in to firebase with them
+			const firebaseConfig = Object.assign({}, this._config)
+			const app = initializeApp(firebaseConfig)
+			const auth = getAuth(app)
+			// this signs the user into firebase sdk internally
+			const userCredential = (await signInWithCredential(auth, credential)).user
+			// const userRefreshToken = await userCredential.getIdToken()
+
+			// store the long-lived refresh token in secret storage
+			try {
+				await storeSecret(context, "clineAccountId", userCredential.refreshToken)
+			} catch (error) {
+				ErrorService.logMessage("Firebase store token error", "error")
+				ErrorService.logException(error)
+				throw error
+			}
+
+			// userCredential = await this._signInWithCredential(context, credential)
+			return await this.retrieveClineAuthInfo(context)
 		} catch (error) {
 			ErrorService.logMessage("Firebase sign-in error", "error")
 			ErrorService.logException(error)

--- a/src/services/auth/providers/FirebaseAuthProvider.ts
+++ b/src/services/auth/providers/FirebaseAuthProvider.ts
@@ -52,7 +52,7 @@ export class FirebaseAuthProvider {
 			const firebaseApiKey = this._config.apiKey
 			const googleAccessTokenResponse = await axios.post(
 				`https://securetoken.googleapis.com/v1/token?key=${firebaseApiKey}`,
-				`grant_type=refresh_token&refresh_token=${userRefreshToken}`,
+				`grant_type=refresh_token&refresh_token=${encodeURIComponent(userRefreshToken)}`,
 				{
 					headers: {
 						"Content-Type": "application/x-www-form-urlencoded",

--- a/webview-ui/src/components/account/AccountView.tsx
+++ b/webview-ui/src/components/account/AccountView.tsx
@@ -146,13 +146,13 @@ export const ClineAccountView = () => {
 				<div className="flex flex-col pr-3 h-full">
 					<div className="flex flex-col w-full">
 						<div className="flex items-center mb-6 flex-wrap gap-y-4">
-							{user.photoUrl ? (
+							{/* {user.photoUrl ? (
 								<img src={user.photoUrl} alt="Profile" className="size-16 rounded-full mr-4" />
-							) : (
-								<div className="size-16 rounded-full bg-[var(--vscode-button-background)] flex items-center justify-center text-2xl text-[var(--vscode-button-foreground)] mr-4">
-									{user.displayName?.[0] || user.email?.[0] || "?"}
-								</div>
-							)}
+							) : ( */}
+							<div className="size-16 rounded-full bg-[var(--vscode-button-background)] flex items-center justify-center text-2xl text-[var(--vscode-button-foreground)] mr-4">
+								{user.displayName?.[0] || user.email?.[0] || "?"}
+							</div>
+							{/* )} */}
 
 							<div className="flex flex-col">
 								{user.displayName && (


### PR DESCRIPTION
Closing https://github.com/cline/cline/pull/4850 in favor of this solution. This PR reduces our dependency on the firebase sdk, and gives us more control over the refresh logic. Although now we miss out on benefits the firebase sdk provided like the Firebase.User object giving us access to a profile image.

While before we relied on the firebase sdk to refresh the short-lived id token (incorrectly using the short-lived google/github credential token, which caused all the auth issues) -- we now just use firebase sdk to get the long-lived refresh token and store this in secret storage instead. This will log all existing users out, but this is the corret token to be storing in long term storage as it doesn't expire, and can be invalidated by server side i.e. to revoke user access. 

This refresh token is then used with google's `https://securetoken.googleapis.com` endpoint to retrieve an id token (short-lived access token), that we can then use as the bearer token to authenticate our API requests to our backend.

This id token is a JWT that when decoded has a variable `exp` that we can check to ensure if the id token is expired or not, and if it is about to expire (within 5 minutes) we use the stored refresh token to get a new id token. (When the extension is launched for the first time and we don't have an id token in memory, we do this anyways) 

<details>
<summary>Including notes from previous PR about the altnerative solution where we used the refresh token to reconstruct the Firebase.User object and let the sdk manage refreshing the token itself</summary>
<br>
When the user logs in to cline account, and we receive the authcallback which includes a short-lived credential key from google or github, which we then use to sign in to firebase to create a Firebase.User object which contains a long-lived refresh token and short-lived id token (the id token authenticates requests to our backend). We were previously storing the first short-lived credential key from google/github in secret storage, when we should have been persisting the long-lived refresh token from firebase. Now we persist this firebase refresh token, and use it to re-construct the Firebase.User object when the short-lived id token expires. The firebase sdk has a restriction where an id token or refresh token by themselves cannot be used to construct a Firebase.User session for the node sdk, so we are required to make a call to our backend that uses the firebase admin sdk/admin key to take the user's id token and convert it into a "custom token" which CAN be used to construct a Firebase.User session that is then used throughout the extension to represent an active user session. (Side note, anywhere else we retrieve the latest id token used to authenticate requests, we use user.getIdToken() which will automatically refresh the id token if expired or close to expiration -- so we don't need to be using the timer to keep refreshing the id token since user.getIdToken() will just refresh if its expired anyways.).

Basically the SDK makes it hard for the developer to create a User object JUST from the refresh token alone, but once we go through the process of signing in with the custom token and the User object is created -- it then has a refresh token internally and can refresh the id token itself as needed with the getIdToken method.

So at a high level, when the extension launches, we create a controller/index.ts instance whose constructor calls this.authService.restoreAuthToken() which calls provider.restoreAuthCredential() (the authService has a provider: FirebaseAuthProvider variable). provider.restoreAuthCredential() was previously using a short-lived credential key from google/github to sign the user into firebase for the Firebase.User session, but now we use the newly saved long-lived firebase refresh token to create a custom token to create a Firebase.User session, which then handles refreshing the short-lived id token (used to authenticate api requests) as needed. The reason we were running into authentication issues before was that the credential key from google/github being returned in the auth callback had a 1-8 hour expiration depending on the sign in method, and we actually needed to immediately use that to get a long-lived refresh token from firebase that doesn't expire (and that we can invalidate ie if the user's access is revoked).
</details>
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Replace Firebase SDK session logic with custom JWT validation using Google's endpoint for improved token management.
> 
>   - **Authentication Logic**:
>     - Replace Firebase SDK session logic with custom JWT validation using Google's `https://securetoken.googleapis.com` endpoint in `AuthService.ts` and `FirebaseAuthProvider.ts`.
>     - Introduce `restoreRefreshTokenAndRetrieveAuthInfo()` in `AuthService.ts` to handle token restoration and refresh.
>     - Use `jwt-decode` to check token expiration in `FirebaseAuthProvider.ts`.
>   - **Token Management**:
>     - Store long-lived refresh token in secret storage instead of short-lived credential token.
>     - Use refresh token to obtain new ID token when needed.
>   - **Dependency Changes**:
>     - Add `jwt-decode` to `package.json` dependencies.
>   - **UI Changes**:
>     - Update `AccountView.tsx` to remove Firebase user profile image handling.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 8a729199d3b27b584a5141d5794b6cdbd86fb22a. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->