### PR TITLE
Remove cancelReason when retrying request to show the proper animation in ChatRow

### DIFF
--- a/src/core/task/index.ts
+++ b/src/core/task/index.ts
@@ -1723,7 +1723,7 @@ export class Task {
 					await this.messageStateHandler.updateClineMessage(lastApiReqStartedIndex, {
 						text: JSON.stringify({
 							...currentApiReqInfo, // Spread the modified info (with retryStatus removed)
-							cancelReason: "retries_exhausted", // Indicate that automatic retries failed
+							// cancelReason: "retries_exhausted", // Indicate that automatic retries failed
 							streamingFailedMessage: errorMessage,
 						} satisfies ClineApiReqInfo),
 					})


### PR DESCRIPTION
When retrying a request we want to show the progress indicator, and ChatRow will show this when cancelReason is undefined.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Comment out `cancelReason` setting in `Task` class to ensure progress indicator shows during request retries.
> 
>   - **Behavior**:
>     - In `Task` class in `index.ts`, comment out setting `cancelReason` to "retries_exhausted" in `onRetryAttempt` method.
>     - Ensures `cancelReason` is undefined when retrying, allowing progress indicator to display in `ChatRow`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for f6ac583edec53065774f19cd65c6d00ecee0699c. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->