### PR TITLE
Saoudrizwan/show resignin button

### DIFF
--- a/src/api/providers/cline.ts
+++ b/src/api/providers/cline.ts
@@ -182,7 +182,7 @@ export class ClineHandler implements ApiHandler {
 			}
 		} catch (error) {
 			if (error.code === "ERR_BAD_REQUEST" || error.status === 401) {
-				throw new Error("Unauthorized: Please sign in to Cline before trying again.")
+				throw new Error("Unauthorized: Please sign in to Cline before trying again.") // match with webview-ui/src/components/chat/ChatRow.tsx
 			} else if (error.code === "insufficient_credits" || error.status === 402) {
 				throw new Error(error.error ? JSON.stringify(error.error) : "Insufficient credits or unknown error.")
 			}

--- a/webview-ui/src/components/chat/ChatRow.tsx
+++ b/webview-ui/src/components/chat/ChatRow.tsx
@@ -1009,7 +1009,7 @@ export const ChatRowContent = memo(
 														</>
 													)}
 													{apiRequestFailedMessage?.includes(
-														"Unauthorized: Please sign in to Cline before trying again.", // match with cline.ts
+														"Unauthorized: Please sign in to Cline before trying again.", // match with cline.ts (TODO: remove after some time)
 													) && (
 														<>
 															<br />

--- a/webview-ui/src/components/chat/ChatRow.tsx
+++ b/webview-ui/src/components/chat/ChatRow.tsx
@@ -1,4 +1,4 @@
-import { VSCodeBadge, VSCodeProgressRing } from "@vscode/webview-ui-toolkit/react"
+import { VSCodeBadge, VSCodeButton, VSCodeProgressRing } from "@vscode/webview-ui-toolkit/react"
 import deepEqual from "fast-deep-equal"
 import React, { memo, MouseEvent, useCallback, useEffect, useMemo, useRef, useState } from "react"
 import styled from "styled-components"
@@ -36,6 +36,7 @@ import NewTaskPreview from "./NewTaskPreview"
 import ReportBugPreview from "./ReportBugPreview"
 import UserMessage from "./UserMessage"
 import QuoteButton from "./QuoteButton"
+import { useClineAuth } from "@/context/ClineAuthContext"
 
 const normalColor = "var(--vscode-foreground)"
 const errorColor = "var(--vscode-errorForeground)"
@@ -184,6 +185,7 @@ export const ChatRowContent = memo(
 		sendMessageFromChatRow,
 		onSetQuote,
 	}: ChatRowContentProps) => {
+		const { handleSignIn } = useClineAuth()
 		const { mcpServers, mcpMarketplaceCatalog, onRelinquishControl, apiConfiguration } = useExtensionState()
 		const [seeNewChangesDisabled, setSeeNewChangesDisabled] = useState(false)
 		const [quoteButtonState, setQuoteButtonState] = useState<QuoteButtonState>({
@@ -1004,6 +1006,17 @@ export const ChatRowContent = memo(
 																troubleshooting guide
 															</a>
 															.
+														</>
+													)}
+													{apiRequestFailedMessage?.includes(
+														"Unauthorized: Please sign in to Cline before trying again.", // match with cline.ts
+													) && (
+														<>
+															<br />
+															<br />
+															<VSCodeButton onClick={handleSignIn} className="w-full mb-4">
+																Sign in to Cline
+															</VSCodeButton>
 														</>
 													)}
 												</p>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds a sign-in button to `ChatRow.tsx` for unauthorized errors and updates error message in `cline.ts` to match UI logic.
> 
>   - **UI Enhancement**:
>     - Adds `VSCodeButton` to `ChatRow.tsx` to prompt user sign-in when unauthorized error occurs.
>     - Checks for "Unauthorized: Please sign in to Cline before trying again." in `apiRequestFailedMessage`.
>   - **Error Handling**:
>     - Updates error message in `ClineHandler` in `cline.ts` to "Unauthorized: Please sign in to Cline before trying again." to match UI logic.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 4e842c118620f8b73d9bd15c861bbb07950e5d2a. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->