### PR TITLE
Fix re-sign in flow

### DIFF
--- a/.changeset/stale-peas-give.md
+++ b/.changeset/stale-peas-give.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Fix bug where Cline account users logged in with invalid token would not be shown as logged out in webview presentation layer

--- a/src/services/auth/AuthService.ts
+++ b/src/services/auth/AuthService.ts
@@ -188,20 +188,23 @@ export class AuthService {
 	}
 
 	getInfo(): AuthState {
-		let userInfo = null
+		// TODO: this logic should be cleaner, but this will determine the authentication state for the webview -- if a user object is returned then the webview assumes authenticated, otherwise it assumes logged out (we previously returned a UserInfo object with empty fields, and this represented a broken logged in state)
+		let user: any = null
 		if (this._clineAuthInfo && this._authenticated) {
-			userInfo = this._clineAuthInfo.userInfo
-		}
-
-		// TODO: create proto for new user info type
-
-		return AuthState.create({
-			user: UserInfo.create({
+			const userInfo = this._clineAuthInfo.userInfo
+			user = UserInfo.create({
 				uid: userInfo?.id,
 				displayName: userInfo?.displayName,
 				email: userInfo?.email,
 				photoUrl: undefined,
-			}),
+			})
+		}
+
+		// TODO: create proto for new user info type
+
+		// If the user is logged out
+		return AuthState.create({
+			user: user,
 		})
 	}
 

--- a/src/services/auth/AuthService.ts
+++ b/src/services/auth/AuthService.ts
@@ -193,6 +193,7 @@ export class AuthService {
 		if (this._clineAuthInfo && this._authenticated) {
 			const userInfo = this._clineAuthInfo.userInfo
 			user = UserInfo.create({
+				// TODO: create proto for new user info type
 				uid: userInfo?.id,
 				displayName: userInfo?.displayName,
 				email: userInfo?.email,
@@ -200,9 +201,6 @@ export class AuthService {
 			})
 		}
 
-		// TODO: create proto for new user info type
-
-		// If the user is logged out
 		return AuthState.create({
 			user: user,
 		})

--- a/webview-ui/src/components/chat/ChatRow.tsx
+++ b/webview-ui/src/components/chat/ChatRow.tsx
@@ -185,7 +185,7 @@ export const ChatRowContent = memo(
 		sendMessageFromChatRow,
 		onSetQuote,
 	}: ChatRowContentProps) => {
-		const { handleSignIn } = useClineAuth()
+		const { handleSignIn, clineUser } = useClineAuth()
 		const { mcpServers, mcpMarketplaceCatalog, onRelinquishControl, apiConfiguration } = useExtensionState()
 		const [seeNewChangesDisabled, setSeeNewChangesDisabled] = useState(false)
 		const [quoteButtonState, setQuoteButtonState] = useState<QuoteButtonState>({
@@ -1014,9 +1014,15 @@ export const ChatRowContent = memo(
 														<>
 															<br />
 															<br />
-															<VSCodeButton onClick={handleSignIn} className="w-full mb-4">
-																Sign in to Cline
-															</VSCodeButton>
+															{clineUser ? (
+																<span style={{ color: "var(--vscode-descriptionForeground)" }}>
+																	(Click "Retry" below)
+																</span>
+															) : (
+																<VSCodeButton onClick={handleSignIn} className="w-full mb-4">
+																	Sign in to Cline
+																</VSCodeButton>
+															)}
 														</>
 													)}
 												</p>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fixes re-sign in flow by updating authentication logic in `AuthService.ts` and UI behavior in `ChatRow.tsx`.
> 
>   - **Behavior**:
>     - Fixes re-sign in flow in `AuthService.ts` by ensuring `getInfo()` returns `null` for unauthenticated users instead of an empty `UserInfo` object.
>     - Updates `ChatRow.tsx` to conditionally display a retry message or sign-in button based on `clineUser` state.
>   - **UI Changes**:
>     - In `ChatRow.tsx`, if `clineUser` is present, displays "(Click 'Retry' below)" instead of the sign-in button.
>     - If `clineUser` is not present, displays a "Sign in to Cline" button.
>   - **Misc**:
>     - Adds `clineUser` to `useClineAuth()` hook in `ChatRow.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 24f0656ce8540139e1a78b980b78cd087827dba4. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->