### PR TITLE
vscode.workspace.openTextDocument migration to host bridge

### DIFF
--- a/proto/host/workspace.proto
+++ b/proto/host/workspace.proto
@@ -4,10 +4,15 @@ package host;
 option java_package = "bot.cline.host.proto";
 option java_multiple_files = true;
 
+import "common.proto";
+
 // Provides methods for working with workspaces/projects.
 service WorkspaceService {
   // Returns a list of the top level directories of the workspace.
   rpc getWorkspacePaths(GetWorkspacePathsRequest) returns (GetWorkspacePathsResponse);
+  
+  // Opens a text document and returns document information
+  rpc openTextDocument(OpenTextDocumentRequest) returns (OpenTextDocumentResponse);
 }
 
 message GetWorkspacePathsRequest {
@@ -21,4 +26,23 @@ message GetWorkspacePathsResponse {
   // The unique ID for the workspace/project.
   optional string id = 1;
   repeated string paths = 2;
+}
+
+message OpenTextDocumentRequest {
+  cline.Metadata metadata = 1;
+  // Path to the document to open
+  optional string path = 2;
+  // Content for new untitled document
+  optional string content = 3;
+  // Language identifier for untitled document
+  optional string language = 4;
+}
+
+message OpenTextDocumentResponse {
+  // Path to the opened document
+  string path = 1;
+  // Language identifier of the document
+  string language_id = 2;
+  // Whether the document is untitled
+  bool is_untitled = 3;
 }

--- a/src/hosts/vscode/workspace/openTextDocument.ts
+++ b/src/hosts/vscode/workspace/openTextDocument.ts
@@ -1,0 +1,28 @@
+import { OpenTextDocumentRequest, OpenTextDocumentResponse } from "@/shared/proto/index.host"
+import * as vscode from "vscode"
+
+export async function openTextDocument(request: OpenTextDocumentRequest): Promise<OpenTextDocumentResponse> {
+	let document: vscode.TextDocument
+
+	if (request.path) {
+		// Open existing file
+		const uri = vscode.Uri.file(request.path)
+		document = await vscode.workspace.openTextDocument(uri)
+	} else {
+		// Create untitled document
+		const options: { language?: string; content?: string } = {}
+		if (request.content) {
+			options.content = request.content
+		}
+		if (request.language) {
+			options.language = request.language
+		}
+		document = await vscode.workspace.openTextDocument(options)
+	}
+
+	return OpenTextDocumentResponse.create({
+		path: document.uri.fsPath,
+		languageId: document.languageId,
+		isUntitled: document.isUntitled,
+	})
+}

--- a/src/integrations/git/commit-message-generator.ts
+++ b/src/integrations/git/commit-message-generator.ts
@@ -151,14 +151,14 @@ async function applyCommitMessageToGitInput(message: string): Promise<void> {
  * @param message The commit message to edit
  */
 async function editCommitMessage(message: string): Promise<void> {
-	const document = await vscode.workspace.openTextDocument({
+	const document = await getHostBridgeProvider().workspaceClient.openTextDocument({
 		content: message,
 		language: "markdown",
 	})
 
 	await getHostBridgeProvider().windowClient.showTextDocument(
 		ShowTextDocumentRequest.create({
-			path: document.uri.fsPath,
+			path: document.path,
 		}),
 	)
 	getHostBridgeProvider().windowClient.showMessage(

--- a/src/integrations/misc/open-file.ts
+++ b/src/integrations/misc/open-file.ts
@@ -54,10 +54,12 @@ export async function openFile(absolutePath: string) {
 			}
 		} catch {} // not essential, sometimes tab operations fail
 
-		const document = await vscode.workspace.openTextDocument(uri)
+		const document = await getHostBridgeProvider().workspaceClient.openTextDocument({
+			path: uri.fsPath,
+		})
 		await getHostBridgeProvider().windowClient.showTextDocument(
 			ShowTextDocumentRequest.create({
-				path: document.uri.fsPath,
+				path: document.path,
 				options: ShowTextDocumentOptions.create({ preview: false }),
 			}),
 		)


### PR DESCRIPTION
- Add openTextDocument proto definitions to WorkspaceService
- Implement VSCode host handler for openTextDocument
- Replace vscode.workspace.openTextDocument calls with host bridge client

### Related Issue

**Issue:** #XXXX

### Description

This PR migrates `vscode.workspace.openTextDocument` calls to use the host bridge instead of direct VSCode API calls.

**Problem solved:**
-  replaced direct`vscode.workspace.openTextDocument` calls that would prevent Cline from running in non-VSCode environments

**Changes made:**
- Added `OpenTextDocumentRequest` and `OpenTextDocumentResponse` proto messages to WorkspaceService
- Implemented VSCode host handler supporting both file paths and untitled document creation
- Replaced `vscode.workspace.openTextDocument` calls in `open-file.ts` and `commit-message-generator.ts`

### Test Procedure

**Compilation testing:**
- `npm run compile` passes with no TypeScript errors
- All linting and formatting checks pass
- Proto generation successful with new service methods

**Manual testing approach:**
1. **File opening functionality**: Ask Cline to open existing files, verify files open correctly in VSCode

**What could break:**
...

**Confidence:** High - follows established patterns from completed migrations and maintains existing functionality.

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [x] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

...

### Additional Notes

...