### PR TITLE
fix: use Uri.from to generate valid diff URI

### DIFF
--- a/src/integrations/editor/VscodeDiffViewProvider.ts
+++ b/src/integrations/editor/VscodeDiffViewProvider.ts
@@ -55,7 +55,9 @@ export class VscodeDiffViewProvider extends DiffViewProvider {
 				})
 				vscode.commands.executeCommand(
 					"vscode.diff",
-					vscode.Uri.parse(`${DIFF_VIEW_URI_SCHEME}:${fileName}`).with({
+					vscode.Uri.from({
+						scheme: DIFF_VIEW_URI_SCHEME,
+						path: fileName,
 						query: Buffer.from(this.originalContent ?? "").toString("base64"),
 					}),
 					uri,


### PR DESCRIPTION


### Related Issue

None – this is a minimal, non-breaking bug fix that aligns with the “small fixes may be submitted directly” exception in the contributing guidelines.

### Description

- **Problem**: When opening the left-hand virtual document in the diff view via `vscode.diff`, the URI was built with `Uri.parse(...).with(...)`. This produced an ill-formed URI (missing `//`) that violated RFC 3986 and caused VS Code to throw “Unable to open editor due to an unexpected error”.
- **Solution**: Replaced the URI construction with `Uri.from({ scheme: DIFF_VIEW_URI_SCHEME, path: fileName, query: base64Content })`, ensuring a valid URI with a proper path segment.
- **Impact**: Confined to the left-hand virtual document in the diff view; no functional changes and fully backward-compatible with the existing `TextDocumentContentProvider`.

### Test Procedure
1. Launch the extension in the development host.  
2. Trigger any Diff action and verify the diff editor opens without errors.  
3. Confirm that the Output panel (Log → Window) contains no URI-related warnings.

### Type of Change

-   [x ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots
Not applicable (no UI changes).

### Additional Notes
None.
