### PR TITLE
Update the vscode usages script to include commands used by vscode.commands.executeCommand

### DIFF
--- a/scripts/get-vscode-usages.sh
+++ b/scripts/get-vscode-usages.sh
@@ -5,17 +5,31 @@ DIR=${1:-src/}
 DEST_DIR=dist-standalone
 SDK_DEST=$DEST_DIR/vscode-sdk-uses.txt
 CSS_DEST=$DEST_DIR/vscode-css-uses.txt
+TMP=/tmp/vscode-sdk-uses.txt.tmp
 mkdir -p $DEST_DIR
 
 {
 git grep -h 'vscode\.' $DIR |
 grep -Ev '//.*vscode' | # remove commented out code
+grep -v vscode.commands.executeCommand | # executeCommand is handled separately
+grep -Ev '"vscode' | # remove command strings that get included because they start with vscode
 sed 's|.*vscode\.|vscode.|'| # remove everything before vscode.
 sed 's/[^a-zA-Z0-9_.].*$//' | # remove everything after last identifier
 grep -E '\.[a-z][^.]+$' | # remove types (last part of identifier should be lowercase)
-sort | uniq -c | sort -n | # Count occurrences
-cat > $SDK_DEST
+cat > $TMP
 }
+{
+  grep -rh vscode.commands.executeCommand $DIR |
+  perl -ne 'print if /["\x27"]/'  | # Remove occurrences where the command is not on the same line (line doesnt contain quote chars) :(
+  sed -n 's|.*\(vscode.commands.executeCommand[^,]*\).*|\1|p'| # Remove all params after the first one
+  sed 's|\(".*"\).*|\1)|'| # Close the parantheses
+  cat >> $TMP
+}
+
+# Count occurrences
+cat $TMP | sort | uniq -c | sort -n > $SDK_DEST
+rm $TMP
+
 echo Wrote uses of the vscode SDK to $(realpath $SDK_DEST)
 
 {


### PR DESCRIPTION

`vscode.commands.executeCommand` runs other vscode commands, so we need to include the actual command being run in the output.

