### PR TITLE
showSaveDialog host bridge implementation

### DIFF
--- a/proto/host/window.proto
+++ b/proto/host/window.proto
@@ -12,6 +12,8 @@ service WindowService {
   rpc showTextDocument(ShowTextDocumentRequest) returns (TextEditorInfo);
   rpc showOpenDialogue(ShowOpenDialogueRequest) returns (SelectedResources);
   rpc showMessage(ShowMessageRequest) returns (SelectedResponse);
+  // Shows a save dialog for file selection.
+  rpc showSaveDialog(ShowSaveDialogRequest) returns (ShowSaveDialogResponse);
 }
 
 message ShowTextDocumentRequest {
@@ -70,4 +72,27 @@ message ShowMessageRequestOptions {
 
 message SelectedResponse {
   optional string selected_option = 1;
+}
+
+message ShowSaveDialogRequest {
+  cline.Metadata metadata = 1;
+  optional ShowSaveDialogFilterOption filters = 2;
+  optional string default_uri = 3;
+  optional string save_label = 4;
+}
+
+message ShowSaveDialogFilterOption {
+  // A set of file filters used by the dialog. Each entry is a human-readable
+  // label (the key) and a list of file extensions (the value).
+  // For example, in JavaScript, this would be represented as:
+  // { 'Images': ['png', 'jpg'], 'TypeScript': ['ts', 'tsx'] }
+  map<string, FileExtensionList> filter_map = 1;
+}
+
+message FileExtensionList {
+  repeated string extensions = 1;
+}
+
+message ShowSaveDialogResponse {
+  optional string path = 1;
 }

--- a/src/hosts/vscode/window/showSaveDialog.ts
+++ b/src/hosts/vscode/window/showSaveDialog.ts
@@ -1,0 +1,28 @@
+import * as vscode from "vscode"
+import { ShowSaveDialogRequest, ShowSaveDialogResponse } from "@/shared/proto/host/window"
+
+export async function showSaveDialog(request: ShowSaveDialogRequest): Promise<ShowSaveDialogResponse> {
+	const options: vscode.SaveDialogOptions = {}
+
+	if (request.filters?.filterMap) {
+		const filters: Record<string, string[]> = {}
+		for (const [key, value] of Object.entries(request.filters.filterMap)) {
+			filters[key] = value.extensions || []
+		}
+		options.filters = filters
+	}
+
+	if (request.defaultUri) {
+		options.defaultUri = vscode.Uri.file(request.defaultUri)
+	}
+
+	if (request.saveLabel) {
+		options.saveLabel = request.saveLabel
+	}
+
+	const result = await vscode.window.showSaveDialog(options)
+
+	return ShowSaveDialogResponse.create({
+		path: result?.fsPath,
+	})
+}

--- a/src/integrations/misc/export-markdown.ts
+++ b/src/integrations/misc/export-markdown.ts
@@ -5,6 +5,7 @@ import * as vscode from "vscode"
 import { getHostBridgeProvider } from "@/hosts/host-providers"
 import { ShowTextDocumentRequest, ShowTextDocumentOptions, ShowMessageRequest, ShowMessageType } from "@/shared/proto/host/window"
 import { writeFile } from "@utils/fs"
+import { showSaveDialog } from "@/utils/dialog"
 
 export async function downloadTask(dateTs: number, conversationHistory: Anthropic.MessageParam[]) {
 	// File name
@@ -32,18 +33,15 @@ export async function downloadTask(dateTs: number, conversationHistory: Anthropi
 		.join("---\n\n")
 
 	// Prompt user for save location
-	const saveUri = await vscode.window.showSaveDialog({
-		filters: { Markdown: ["md"] },
-		defaultUri: vscode.Uri.file(path.join(os.homedir(), "Downloads", fileName)),
-	})
+	const savePath = await showSaveDialog({ Markdown: ["md"] }, path.join(os.homedir(), "Downloads", fileName))
 
-	if (saveUri) {
+	if (savePath) {
 		try {
 			// Write content to the selected location
-			await writeFile(saveUri.fsPath, markdownContent)
+			await writeFile(savePath, markdownContent)
 			await getHostBridgeProvider().windowClient.showTextDocument(
 				ShowTextDocumentRequest.create({
-					path: saveUri.fsPath,
+					path: savePath,
 					options: ShowTextDocumentOptions.create({ preview: true }),
 				}),
 			)

--- a/src/utils/dialog.ts
+++ b/src/utils/dialog.ts
@@ -1,0 +1,21 @@
+import { showSaveDialog as hostShowSaveDialog } from "@/hosts/vscode/window/showSaveDialog"
+import { ShowSaveDialogRequest, ShowSaveDialogResponse } from "@/shared/proto/host/window"
+
+export async function showSaveDialog(
+	filters?: Record<string, string[]>,
+	defaultPath?: string,
+	saveLabel?: string,
+): Promise<string> {
+	const request = ShowSaveDialogRequest.create({
+		filters: filters
+			? {
+					filterMap: Object.fromEntries(Object.entries(filters).map(([key, extensions]) => [key, { extensions }])),
+				}
+			: undefined,
+		defaultUri: defaultPath,
+		saveLabel,
+	})
+
+	const response = await hostShowSaveDialog(request)
+	return response.path || ""
+}


### PR DESCRIPTION
- Add showSaveDialog RPC to WindowService proto with proper filter map structure
- Create VSCode host implementation for showSaveDialog matching other host bridge files
- Add utility wrapper that matches VSCode API parameter order (filters first, defaultPath second)
- Replace vscode.window.showSaveDialog call in export-markdown.ts with host bridge utility
- Return file path instead of vscode.Uri


### Description

This PR migrates `vscode.window.showSaveDialog` to use the host bridge pattern.

The implementation follows the same pattern as other host bridge window methods and only migrates the single `showSaveDialog` call found in `export-markdown.ts`.

### Test Procedure

- Tested export functionality in VSCode extension development host
- Verified save dialog appears with correct filters and default path
- Confirmed file is saved to selected location
- Compilation and linting pass

### Type of Change

- [x] ♻️ Refactor Changes

### Pre-flight Checklist

- [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
- [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
- [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
- [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Additional Notes

This is a focused migration of just the showSaveDialog functionality, making it easier to test and review compared to migrating multiple APIs at once.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Migrate `showSaveDialog` to host bridge pattern with new RPC and VSCode implementation, updating `export-markdown.ts` to use this new utility.
> 
>   - **Behavior**:
>     - Add `showSaveDialog` RPC to `WindowService` in `window.proto` with a filter map structure.
>     - Implement `showSaveDialog` in `showSaveDialog.ts` to match VSCode API parameters.
>     - Replace `vscode.window.showSaveDialog` in `export-markdown.ts` with the new host bridge utility.
>     - Return file path as string instead of `vscode.Uri`.
>   - **Utilities**:
>     - Add utility wrapper `showSaveDialog` in `dialog.ts` to handle filters and default path.
>   - **Testing**:
>     - Verified export functionality, save dialog appearance, and file saving in VSCode extension development host.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for c7c623c471330834f405a6893ba9f900d1e4dae1. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->