### PR TITLE
Set default kimi provider to together

### DIFF
--- a/src/api/transform/openrouter-stream.ts
+++ b/src/api/transform/openrouter-stream.ts
@@ -139,6 +139,10 @@ export async function createOpenRouterStream(
 		shouldApplyMiddleOutTransform = true
 	}
 
+	// hardcoded provider sorting for kimi-k2
+	const isKimiK2 = model.id.startsWith("moonshotai/kimi-k2")
+	openRouterProviderSorting = isKimiK2 ? undefined : openRouterProviderSorting
+
 	// @ts-ignore-next-line
 	const stream = await client.chat.completions.create({
 		model: model.id,
@@ -153,6 +157,8 @@ export async function createOpenRouterStream(
 		...(model.id.startsWith("openai/o") ? { reasoning_effort: reasoningEffort || "medium" } : {}),
 		...(reasoning ? { reasoning } : {}),
 		...(openRouterProviderSorting ? { provider: { sort: openRouterProviderSorting } } : {}),
+		// limit providers to only those that support the 131k context window
+		...(isKimiK2 ? { provider: { order: ["together"], allow_fallbacks: false } } : {}),
 	})
 
 	return stream

--- a/src/core/controller/models/refreshOpenRouterModels.ts
+++ b/src/core/controller/models/refreshOpenRouterModels.ts
@@ -104,6 +104,12 @@ export async function refreshOpenRouterModels(
 						modelInfo.cacheWritesPrice = 0.75
 						modelInfo.cacheReadsPrice = 0
 						break
+					case "moonshotai/kimi-k2":
+						// forcing kimi-k2 to use the together provider for full context and best throughput
+						modelInfo.inputPrice = 1
+						modelInfo.outputPrice = 3
+						modelInfo.contextWindow = 131_000
+						break
 					default:
 						if (rawModel.id.startsWith("openai/")) {
 							modelInfo.cacheReadsPrice = parsePrice(rawModel.pricing?.input_cache_read)

--- a/webview-ui/src/components/settings/OpenRouterModelPicker.tsx
+++ b/webview-ui/src/components/settings/OpenRouterModelPicker.tsx
@@ -49,14 +49,14 @@ const featuredModels = [
 		label: "Best",
 	},
 	{
-		id: "moonshotai/kimi-k2",
-		description: "Latest open source model, trained for agentic tool calling.",
+		id: "google/gemini-2.5-pro",
+		description: "Large 1M context window, great value",
 		label: "Trending",
 	},
 	{
-		id: "x-ai/grok-4",
-		description: "Latest flagship model from xAI",
-		label: "Fast & Cheap",
+		id: "moonshotai/kimi-k2",
+		description: "Open source model topping coding benchmarks",
+		label: "New",
 	},
 ]
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Set `moonshotai/kimi-k2` model to use `together` provider by default, updating related configurations and UI elements.
> 
>   - **Behavior**:
>     - In `openrouter-stream.ts`, sets `moonshotai/kimi-k2` to use `together` provider exclusively, disabling fallbacks.
>     - Adjusts provider sorting logic to exclude `moonshotai/kimi-k2` from default sorting.
>   - **Models**:
>     - In `refreshOpenRouterModels.ts`, sets `moonshotai/kimi-k2` input price to 1, output price to 3, and context window to 131,000.
>   - **UI**:
>     - In `OpenRouterModelPicker.tsx`, updates `moonshotai/kimi-k2` description and label in featured models.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 024c979c5f5566e1a7251d63f30397314f355da8. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->