### PR TITLE
Add groq to kimi providers

### DIFF
--- a/.changeset/fair-glasses-lick.md
+++ b/.changeset/fair-glasses-lick.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Add groq to kimi providers

--- a/src/api/transform/openrouter-stream.ts
+++ b/src/api/transform/openrouter-stream.ts
@@ -158,7 +158,7 @@ export async function createOpenRouterStream(
 		...(reasoning ? { reasoning } : {}),
 		...(openRouterProviderSorting ? { provider: { sort: openRouterProviderSorting } } : {}),
 		// limit providers to only those that support the 131k context window
-		...(isKimiK2 ? { provider: { order: ["together"], allow_fallbacks: false } } : {}),
+		...(isKimiK2 ? { provider: { order: ["groq", "together"], allow_fallbacks: false } } : {}),
 	})
 
 	return stream


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds 'groq' to the provider order for Kimi K2 models in `createOpenRouterStream`.
> 
>   - **Behavior**:
>     - In `createOpenRouterStream` in `openrouter-stream.ts`, adds 'groq' to the provider order for Kimi K2 models.
>     - Affects provider selection when model ID starts with 'moonshotai/kimi-k2'.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 2a054ef6a580d92fd91c91cc8fcf6b6296b0767c. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->