### PR TITLE
fix: always sanitize trailing slashes

### DIFF
--- a/.changeset/little-stingrays-walk.md
+++ b/.changeset/little-stingrays-walk.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+SAP AI Core: Ignore trailing slashes in URLs.

--- a/src/core/api/providers/sapaicore.ts
+++ b/src/core/api/providers/sapaicore.ts
@@ -355,7 +355,11 @@ export class SapAiCoreHandler implements ApiHandler {
 	private isAiCoreEnvSetup: boolean = false
 
 	constructor(options: SapAiCoreHandlerOptions) {
-		this.options = options
+		this.options = {
+			...options,
+			sapAiCoreTokenUrl: options.sapAiCoreTokenUrl?.replace(/\/+$/, ""),
+			sapAiCoreBaseUrl: options.sapAiCoreBaseUrl?.replace(/\/+$/, ""),
+		}
 	}
 
 	private validateCredentials(): void {
@@ -378,7 +382,7 @@ export class SapAiCoreHandler implements ApiHandler {
 			client_secret: this.options.sapAiCoreClientSecret,
 		}
 
-		const tokenUrl = this.options.sapAiCoreTokenUrl!.replace(/\/+$/, "") + "/oauth/token"
+		const tokenUrl = this.options.sapAiCoreTokenUrl! + "/oauth/token"
 		const response = await axios.post(tokenUrl, payload, {
 			headers: { "Content-Type": "application/x-www-form-urlencoded" },
 		})


### PR DESCRIPTION
### Related Issue

Minor fix, no issue.

### Description

When providing trailing slashes in the AI Core base URL API requests will fail. This commit removes trailing slashes from both, auth and base URL to prevent this from happening independent of how the user provides the URLs.

### Test Procedure

Ensured trailing slashes are now removed from URLs before using them.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

n/a

### Additional Notes

~I'm getting test failures but not sure if they are related? Might also be something on my local setup as I'm not frequently contributing to node projects.~

CI seems happy.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Normalize URLs by removing trailing slashes in `SapAiCoreHandler` to prevent request failures.
> 
>   - **Behavior**:
>     - Normalize URLs by removing trailing slashes in `SapAiCoreHandler` constructor in `sapaicore.ts`.
>     - Affects `sapAiCoreTokenUrl` and `sapAiCoreBaseUrl` to prevent request failures.
>   - **Misc**:
>     - Adds changeset `little-stingrays-walk.md` to document the patch.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 8126a10e584ec0c9a35a93ceb0d8874a2c8f176b. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->