### PR TITLE
docs: Update Claude Code documentation to include Pro plans alongside Max plans

### DIFF
--- a/docs/provider-config/claude-code.mdx
+++ b/docs/provider-config/claude-code.mdx
@@ -1,11 +1,11 @@
 ---
 title: "Claude Code"
-description: "Use your Claude Max subscription with Cline instead of paying per token. Learn how to set up and configure the Claude Code provider."
+description: "Use your Claude Max or Pro subscription with Cline instead of paying per token. Learn how to set up and configure the Claude Code provider."
 ---
 
 **Website:** [https://docs.anthropic.com/en/docs/claude-code/setup](https://docs.anthropic.com/en/docs/claude-code/setup)
 
-The Claude Code provider lets you use your existing Claude subscription with Cline. If you have Claude Max, this means you can use Claude in Cline without paying extra API costs.
+The Claude Code provider lets you use your existing Claude subscription with Cline. If you have Claude Max or Pro, this means you can use Claude in Cline without paying extra API costs.
 
 <Frame>
 	<img


### PR DESCRIPTION
Updated Claude Code Provider Docs to include Pro plans, not just Max

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [x] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Additional Notes

Just added 4 words
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `claude-code.mdx` to include Pro plans alongside Max plans in the documentation.
> 
>   - **Documentation**:
>     - Update `description` in `claude-code.mdx` to include "Pro" alongside "Max" for subscription options.
>     - Modify text in `claude-code.mdx` to mention "Claude Max or Pro" instead of just "Claude Max".
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 4d7e24c3c94d20b8e14976479b5c7df88a580a54. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->