### PR TITLE
fix: use exact match for kimi-k2 model check to resolve "404 No endpoints found for moonshotai/kimi-k2:free" (#4940)

### DIFF
--- a/src/api/transform/openrouter-stream.ts
+++ b/src/api/transform/openrouter-stream.ts
@@ -140,7 +140,7 @@ export async function createOpenRouterStream(
 	}
 
 	// hardcoded provider sorting for kimi-k2
-	const isKimiK2 = model.id.startsWith("moonshotai/kimi-k2")
+	const isKimiK2 = model.id === "moonshotai/kimi-k2"
 	openRouterProviderSorting = isKimiK2 ? undefined : openRouterProviderSorting
 
 	// @ts-ignore-next-line


### PR DESCRIPTION
### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** #4940

### Description
fix: use exact match for kimi-k2 model check to resolve "404 No endpoints found for moonshotai/kimi-k2:free" 

### Test Procedure

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes exact model ID match for `moonshotai/kimi-k2` in `createOpenRouterStream` to resolve 404 error.
> 
>   - **Behavior**:
>     - Fixes model ID check in `createOpenRouterStream` in `openrouter-stream.ts` to use exact match for `moonshotai/kimi-k2`.
>     - Resolves "404 No endpoints found" error for `moonshotai/kimi-k2:free` by ensuring correct provider sorting logic.
>   - **Misc**:
>     - No changes to other files or functions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 5c7d888857e8fdab94af5df5386a94baffc37d3e. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->