### PR TITLE
feat: set telemetry_enabled property on opt-in/out

### DIFF
--- a/src/services/posthog/telemetry/TelemetryService.ts
+++ b/src/services/posthog/telemetry/TelemetryService.ts
@@ -154,9 +154,9 @@ class TelemetryService {
 			this.client.capture({
 				distinctId: this.distinctId,
 				event: "$set",
-				properties: {
+				properties: this.addProperties({
 					$set: { telemetry_enabled: true },
-				},
+				}),
 			})
 		} else {
 			this.client.capture({

--- a/src/services/posthog/telemetry/TelemetryService.ts
+++ b/src/services/posthog/telemetry/TelemetryService.ts
@@ -149,7 +149,7 @@ class TelemetryService {
 
 		// Update PostHog client state based on telemetry preference
 		if (this.telemetryEnabled) {
-			this.client.optIn()
+			await this.client.optIn()
 			this.client.identify({ distinctId: this.distinctId })
 			this.client.capture({
 				distinctId: this.distinctId,
@@ -168,7 +168,7 @@ class TelemetryService {
 			})
 
 			await new Promise((resolve) => setTimeout(resolve, 1000)) // Delay 1 second before opting out
-			this.client.optOut()
+			await this.client.optOut()
 		}
 	}
 

--- a/src/services/posthog/telemetry/TelemetryService.ts
+++ b/src/services/posthog/telemetry/TelemetryService.ts
@@ -215,7 +215,11 @@ class TelemetryService {
 
 		if (this.telemetryEnabled) {
 			this.client.identify({ distinctId: this.distinctId })
-			this.client.capture({ distinctId: this.distinctId, event: TelemetryService.EVENTS.USER.EXTENSION_ACTIVATED })
+			this.client.capture({
+				distinctId: this.distinctId,
+				event: TelemetryService.EVENTS.USER.EXTENSION_ACTIVATED,
+				properties: this.addProperties({}),
+			})
 		}
 	}
 

--- a/src/services/posthog/telemetry/TelemetryService.ts
+++ b/src/services/posthog/telemetry/TelemetryService.ts
@@ -151,11 +151,20 @@ class TelemetryService {
 		if (this.telemetryEnabled) {
 			this.client.optIn()
 			this.client.identify({ distinctId: this.distinctId })
+			this.client.capture({
+				distinctId: this.distinctId,
+				event: "$set",
+				properties: {
+					$set: { telemetry_enabled: true },
+				},
+			})
 		} else {
 			this.client.capture({
 				distinctId: this.distinctId,
 				event: TelemetryService.EVENTS.USER.OPT_OUT,
-				properties: this.addProperties({}),
+				properties: this.addProperties({
+					$set: { telemetry_enabled: false },
+				}),
 			})
 
 			await new Promise((resolve) => setTimeout(resolve, 1000)) // Delay 1 second before opting out


### PR DESCRIPTION
<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- Opened an issue and discussed your proposed changes with the community / contributors
- Received approval from a core Cline contributor prior to proceeding with the implementation
- Link the associated issue in the "Related Issue" section

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly.

Why this requirement?
We deeply appreciate all community contributions - they are the core reason we're able to operate successfully and keep innovating! We welcome community input and want to make it as easy as possible for people to submit quality work. This process helps our core maintainers review new ideas faster and saves contributor time by ensuring you have the go-ahead before spending time on implementation.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** #XXXX

### Description

his PR updates the `TelemetryService` to accurately reflect a user's telemetry preference in their PostHog person profile.

__Changes:__

- When a user opts into telemetry, the `telemetry_enabled` person property is set to `true`.
- When a user opts out of telemetry, the `telemetry_enabled` person property is set to `false`.

This ensures that the user's telemetry status is explicitly recorded, allowing for more accurate filtering and analysis of user data based on their consent. Previously, the property was being unset, which did not reliably update the user's profile. This change guarantees that the property is always explicitly set to either `true` or `false`.


<!-- 
Help reviewers understand your changes by making this PR readable and well-organized:

- What problem does this PR solve?
- Why were these changes introduced and what purpose do they serve?
- For larger changes, provide context about your approach and reasoning

Small PRs may need minimal description, but larger changes benefit from explaining where you're coming from. Much of this context can be in the linked issue above, so feel free to reference it rather than repeating everything here.
-->

### Test Procedure

<!-- 
Please walk us through your testing approach and thought process. This helps reviewers understand that you've thoroughly considered the impact of your changes:

- How did you test this change?
- What could potentially break and how did you verify it doesn't?
- What existing functionality might be affected and how did you check it still works?
- Why are you confident this is ready for merge?

We're not looking for exhaustive documentation - just evidence that you've thought through the implications of your changes and tested accordingly.
-->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [x] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Updates `TelemetryService` to explicitly set `telemetry_enabled` property on user opt-in/out, improving data accuracy.
> 
>   - **Behavior**:
>     - Updates `TelemetryService` to set `telemetry_enabled` to `true` on opt-in and `false` on opt-out.
>     - Ensures `telemetry_enabled` is always explicitly set, improving data accuracy.
>   - **Functions**:
>     - Modifies `updateTelemetryState()` in `TelemetryService` to include `$set` event with `telemetry_enabled` property.
>     - Adds delay before opting out to ensure event capture.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for ced1845bbbd68601ada469836b8d23ea919230c6. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->