### PR TITLE
Fix kimi k2 provider sorting

### DIFF
--- a/.changeset/smart-flies-eat.md
+++ b/.changeset/smart-flies-eat.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Add additional Kimi K2 providers

--- a/src/api/transform/openrouter-stream.ts
+++ b/src/api/transform/openrouter-stream.ts
@@ -140,7 +140,7 @@ export async function createOpenRouterStream(
 	}
 
 	// hardcoded provider sorting for kimi-k2
-	const isKimiK2 = model.id.startsWith("moonshotai/kimi-k2")
+	const isKimiK2 = model.id === "moonshotai/kimi-k2"
 	openRouterProviderSorting = isKimiK2 ? undefined : openRouterProviderSorting
 
 	// @ts-ignore-next-line
@@ -158,7 +158,9 @@ export async function createOpenRouterStream(
 		...(reasoning ? { reasoning } : {}),
 		...(openRouterProviderSorting ? { provider: { sort: openRouterProviderSorting } } : {}),
 		// limit providers to only those that support the 131k context window
-		...(isKimiK2 ? { provider: { order: ["groq", "together"], allow_fallbacks: false } } : {}),
+		...(isKimiK2
+			? { provider: { order: ["groq", "together", "baseten", "parasail", "novita", "deepinfra"], allow_fallbacks: false } }
+			: {}),
 	})
 
 	return stream


### PR DESCRIPTION
Adds new kimi k2 providers and addresses https://github.com/cline/cline/issues/4940
<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix exact match condition and update provider order for `moonshotai/kimi-k2` in `createOpenRouterStream`.
> 
>   - **Behavior**:
>     - In `createOpenRouterStream`, change `isKimiK2` condition to check for exact match with `model.id === "moonshotai/kimi-k2"`.
>     - Update provider order for `isKimiK2` to include `"groq", "together", "baseten", "parasail", "novita", "deepinfra"` and disable fallbacks.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for ba0feaba5af37dc4544e9a90a7e23c27e5037346. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->