### PR TITLE
Move platform specific code out of the DiffViewProvider and into the VscodeDiffViewProvider

### DIFF
--- a/src/hosts/vscode/VscodeDiffViewProvider.ts
+++ b/src/hosts/vscode/VscodeDiffViewProvider.ts
@@ -117,4 +117,11 @@ export class VscodeDiffViewProvider extends DiffViewProvider {
 			await new Promise((resolve) => setTimeout(resolve, 16)) // ~60fps
 		}
 	}
+
+	protected override async resetDiffView(): Promise<void> {
+		this.activeDiffEditor = undefined
+		this.fadedOverlayController = undefined
+		this.activeLineController = undefined
+		this.preDiagnostics = []
+	}
 }

--- a/src/hosts/vscode/VscodeDiffViewProvider.ts
+++ b/src/hosts/vscode/VscodeDiffViewProvider.ts
@@ -121,10 +121,6 @@ export class VscodeDiffViewProvider extends DiffViewProvider {
 		}
 	}
 
-	/**
-	 * Removes content from the specified line to the end of the document.
-	 * Called after the last update is recieved.
-	 */
 	override async truncateDocument(lineNumber: number): Promise<void> {
 		if (!this.activeDiffEditor) {
 			return

--- a/src/hosts/vscode/VscodeDiffViewProvider.ts
+++ b/src/hosts/vscode/VscodeDiffViewProvider.ts
@@ -118,6 +118,25 @@ export class VscodeDiffViewProvider extends DiffViewProvider {
 		}
 	}
 
+	/**
+	 * Removes content from the specified line to the end of the document.
+	 * Called after the last update is recieved.
+	 */
+	override async truncateDocument(lineNumber: number): Promise<void> {
+		if (!this.activeDiffEditor) {
+			return
+		}
+		const document = this.activeDiffEditor.document
+		if (lineNumber < document.lineCount) {
+			const edit = new vscode.WorkspaceEdit()
+			edit.delete(document.uri, new vscode.Range(lineNumber, 0, document.lineCount, 0))
+			await vscode.workspace.applyEdit(edit)
+		}
+		// Clear all decorations at the end (before applying final edit)
+		this.fadedOverlayController?.clear()
+		this.activeLineController?.clear()
+	}
+
 	protected override async resetDiffView(): Promise<void> {
 		this.activeDiffEditor = undefined
 		this.fadedOverlayController = undefined

--- a/src/integrations/editor/DiffViewProvider.ts
+++ b/src/integrations/editor/DiffViewProvider.ts
@@ -188,7 +188,7 @@ export abstract class DiffViewProvider {
 		this.streamedLines = accumulatedLines
 		if (isFinal) {
 			// Handle any remaining lines if the new content is shorter than the original
-			this.truncateDocument(this.streamedLines.length)
+			await this.truncateDocument(this.streamedLines.length)
 
 			// Add empty last line if original content had one
 			const hasEmptyLastLine = this.originalContent?.endsWith("\n")

--- a/src/integrations/editor/DiffViewProvider.ts
+++ b/src/integrations/editor/DiffViewProvider.ts
@@ -4,7 +4,6 @@ import * as fs from "fs/promises"
 import { createDirectoriesForFile } from "@utils/fs"
 import { arePathsEqual, getCwd } from "@utils/path"
 import { formatResponse } from "@core/prompts/responses"
-import { DecorationController } from "./DecorationController"
 import * as diff from "diff"
 import { diagnosticsToProblemsString, getNewDiagnostics } from "../diagnostics"
 import { detectEncoding } from "../misc/extract-text"
@@ -141,16 +140,6 @@ export abstract class DiffViewProvider {
 			accumulatedLines.pop() // remove the last partial line only if it's not the final update
 		}
 		const diffLines = accumulatedLines.slice(this.streamedLines.length)
-
-		const diffEditor = this.activeDiffEditor
-		const document = diffEditor?.document
-		if (!diffEditor || !document) {
-			throw new Error("User closed text editor, unable to edit file...")
-		}
-
-		// Place cursor at the beginning of the diff editor to keep it out of the way of the stream animation
-		const beginningOfDocument = new vscode.Position(0, 0)
-		diffEditor.selection = new vscode.Selection(beginningOfDocument, beginningOfDocument)
 
 		// Instead of animating each line, we'll update in larger chunks
 		const currentLine = this.streamedLines.length + diffLines.length - 1

--- a/src/integrations/editor/DiffViewProvider.ts
+++ b/src/integrations/editor/DiffViewProvider.ts
@@ -88,7 +88,6 @@ export abstract class DiffViewProvider {
 	 * streaming updates to keep the user's view focused on the changing content.
 	 *
 	 * @param line The 0-based line number to scroll to
-	 * @returns A promise that resolves when the scrolling operation is complete
 	 */
 	protected abstract scrollEditorToLine(line: number): Promise<void>
 
@@ -102,9 +101,13 @@ export abstract class DiffViewProvider {
 	 *
 	 * @param startLine The 0-based line number to begin the animation from
 	 * @param endLine The 0-based line number to animate to
-	 * @returns A promise that resolves when the animation is complete
 	 */
 	protected abstract scrollAnimation(startLine: number, endLine: number): Promise<void>
+
+	/**
+	 * Cleans up the diff view resources and resets internal state.
+	 */
+	protected abstract resetDiffView(): Promise<void>
 
 	async update(
 		accumulatedContent: string,
@@ -398,10 +401,8 @@ export abstract class DiffViewProvider {
 		this.originalContent = undefined
 		this.createdDirs = []
 		this.documentWasOpen = false
-		this.activeDiffEditor = undefined
-		this.fadedOverlayController = undefined
-		this.activeLineController = undefined
 		this.streamedLines = []
-		this.preDiagnostics = []
+
+		await this.resetDiffView()
 	}
 }

--- a/src/standalone/ExternalDiffviewProvider.ts
+++ b/src/standalone/ExternalDiffviewProvider.ts
@@ -27,6 +27,10 @@ export class ExternalDiffViewProvider extends DiffViewProvider {
 		})
 	}
 
+	protected override async truncateDocument(lineNumber: number): Promise<void> {
+		console.log(`Called ExternalDiffViewProvider.truncateDocument(${lineNumber}) stub`)
+	}
+
 	protected override async scrollEditorToLine(line: number): Promise<void> {
 		console.log(`Called ExternalDiffViewProvider.scrollEditorToLine(${line}) stub`)
 	}

--- a/src/standalone/ExternalDiffviewProvider.ts
+++ b/src/standalone/ExternalDiffviewProvider.ts
@@ -38,6 +38,9 @@ export class ExternalDiffViewProvider extends DiffViewProvider {
 	override async scrollAnimation(startLine: number, endLine: number): Promise<void> {
 		console.log(`Called ExternalDiffViewProvider.scrollAnimation(${startLine}, ${endLine}) stub`)
 	}
+	protected override async closeDiffView(): Promise<void> {
+		console.log(`Called ExternalDiffViewProvider.closeDiffView() stub`)
+	}
 
 	protected override async resetDiffView(): Promise<void> {
 		this.activeDiffEditorId = undefined

--- a/src/standalone/ExternalDiffviewProvider.ts
+++ b/src/standalone/ExternalDiffviewProvider.ts
@@ -34,4 +34,8 @@ export class ExternalDiffViewProvider extends DiffViewProvider {
 	override async scrollAnimation(startLine: number, endLine: number): Promise<void> {
 		console.log(`Called ExternalDiffViewProvider.scrollAnimation(${startLine}, ${endLine}) stub`)
 	}
+
+	protected override async resetDiffView(): Promise<void> {
+		this.activeDiffEditorId = undefined
+	}
 }


### PR DESCRIPTION
Move the platform specific logic out of the DiffViewProvider into the VscodeDiffProvider.

Add abstract methods to the DiffViewProvider for the functionality that was moved.

Move:

Truncating the diff document (on the last update)

Close the diff view tab.

Setting the cursor when replacing text into the platform specific code.

Move the DecorationControllers into the VscodeDiffViewProvider.

Resetting the state of the diff editor UI elements.

<!-- 
Help reviewers understand your changes by making this PR readable and well-organized:

- What problem does this PR solve?
- Why were these changes introduced and what purpose do they serve?
- For larger changes, provide context about your approach and reasoning

Small PRs may need minimal description, but larger changes benefit from explaining where you're coming from. Much of this context can be in the linked issue above, so feel free to reference it rather than repeating everything here.
-->

### Test Procedure

Tested manually in the vscode extension host.
<!-- 
Please walk us through your testing approach and thought process. This helps reviewers understand that you've thoroughly considered the impact of your changes:

- How did you test this change?
- What could potentially break and how did you verify it doesn't?
- What existing functionality might be affected and how did you check it still works?
- Why are you confident this is ready for merge?

We're not looking for exhaustive documentation - just evidence that you've thought through the implications of your changes and tested accordingly.
-->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [ ] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Refactor `DiffViewProvider` to move platform-specific logic to `VscodeDiffViewProvider` and `ExternalDiffViewProvider`, adding new methods for document truncation and view management.
> 
>   - **Behavior**:
>     - Adds `truncateDocument`, `closeDiffView`, and `resetDiffView` methods to `DiffViewProvider` and implements them in `VscodeDiffViewProvider` and `ExternalDiffViewProvider`.
>     - Moves cursor placement logic to `replaceText` in `VscodeDiffViewProvider`.
>     - Moves `DecorationController` initialization to `VscodeDiffViewProvider`.
>   - **Refactoring**:
>     - Removes `closeAllDiffViews` and `scrollEditorToLine` from `DiffViewProvider`.
>     - Adds stubs for new methods in `ExternalDiffViewProvider`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 148bdc96bf73ca5da64b96f8ccf21a61a8542ed3. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->