### PR TITLE
Unify error handling and display logic

### DIFF
--- a/src/api/providers/cline.ts
+++ b/src/api/providers/cline.ts
@@ -179,17 +179,7 @@ export class ClineHandler implements ApiHandler {
 			}
 		} catch (error) {
 			console.error("Cline API Error:", error)
-			const requestId = error?.request_id ? `\n | Request ID: ${error.request_id}` : ""
-			if (error.code === "ERR_BAD_REQUEST" || error.status === 401) {
-				throw new Error(CLINE_ACCOUNT_AUTH_ERROR_MESSAGE + requestId)
-			} else if (error.code === "insufficient_credits" || error.status === 402) {
-				if (error.error) {
-					throw new Error(JSON.stringify(error.error))
-				}
-			}
-			const _error = error instanceof Error ? error : new Error(String(error))
-			_error.message = _error.message + requestId
-			throw _error
+			throw error
 		}
 	}
 

--- a/src/core/task/index.ts
+++ b/src/core/task/index.ts
@@ -1657,12 +1657,13 @@ export class Task {
 			yield firstChunk.value
 			this.taskState.isWaitingForFirstChunk = false
 		} catch (error) {
+			const isCline = this.api instanceof ClineHandler
 			const isOpenRouter = this.api instanceof OpenRouterHandler || this.api instanceof ClineHandler
 			const isAnthropic = this.api instanceof AnthropicHandler
 			const isOpenRouterContextWindowError = checkIsOpenRouterContextWindowError(error) && isOpenRouter
 			const isAnthropicContextWindowError = checkIsAnthropicContextWindowError(error) && isAnthropic
 
-			const clineError = ErrorService.toClineError(error, modelInfo.id)
+			const clineError = ErrorService.toClineError(error, isCline ? "cline" : modelInfo.id)
 
 			// Capture provider failure telemetry using clineError
 			telemetryService.captureProviderApiError({

--- a/src/core/task/index.ts
+++ b/src/core/task/index.ts
@@ -83,7 +83,7 @@ import { TaskState } from "./TaskState"
 import { ToolExecutor } from "./ToolExecutor"
 import { updateApiReqMsg } from "./utils"
 import { createDiffViewProvider } from "@/hosts/host-providers"
-import { ErrorService } from "@services/error/ErrorService"
+import { ErrorService } from "@/services/error/ErrorService"
 export const USE_EXPERIMENTAL_CLAUDE4_FEATURES = false
 
 export type ToolResponse = string | Array<Anthropic.TextBlockParam | Anthropic.ImageBlockParam>

--- a/src/core/task/utils.ts
+++ b/src/core/task/utils.ts
@@ -1,24 +1,8 @@
 import { showSystemNotification } from "@/integrations/notifications"
 import { ClineApiReqCancelReason, ClineApiReqInfo } from "@/shared/ExtensionMessage"
-import { serializeError } from "serialize-error"
 import { MessageStateHandler } from "./message-state"
 import { calculateApiCostAnthropic } from "@/utils/cost"
 import { ApiHandler } from "@/api"
-
-export function formatErrorWithStatusCode(error: any): string {
-	const { statusCode, message } = extractErrorDetails(error)
-
-	// Only prepend the statusCode if it's not already part of the message
-	return statusCode && !message.includes(statusCode.toString()) ? `${statusCode} - ${message}` : message
-}
-
-export function extractErrorDetails(error: any): { message: string; statusCode?: number; requestId?: string } {
-	const statusCode = error.status || error.statusCode || (error.response && error.response?.status)
-	const message = error.message ?? JSON.stringify(serializeError(error), null, 2)
-	const requestId = error.request_id || error.response?.request_id || undefined
-
-	return { message, statusCode, requestId }
-}
 
 export const showNotificationForApprovalIfAutoApprovalEnabled = (
 	message: string,

--- a/src/services/error/ClineError.ts
+++ b/src/services/error/ClineError.ts
@@ -9,10 +9,32 @@ export enum ClineErrorType {
 }
 
 interface ErrorDetails {
+	/**
+	 * The HTTP status code of the error, if applicable.
+	 */
 	status?: number
+	/**
+	 * The request ID associated with the error, if available.
+	 * This can be useful for debugging and support.
+	 */
 	request_id?: string
+	/**
+	 * Specific error code provided by the API or service.
+	 */
 	code?: string
+	/**
+	 * The model ID associated with the error, if applicable.
+	 * This is useful for identifying which model the error relates to.
+	 */
 	modelId?: string
+	/**
+	 * The provider ID associated with the error, if applicable.
+	 * This is useful for identifying which provider the error relates to.
+	 */
+	providerId?: string
+	/**
+	 * The error message associated with the error, if applicable.
+	 */
 	message?: string
 	// Additional details that might be present in the error
 	// This can include things like current balance, error messages, etc.
@@ -46,6 +68,7 @@ export class ClineError extends Error {
 			request_id: error.request_id || error.response?.request_id,
 			code: error.code,
 			modelId,
+			providerId,
 			details: error.details || error.error, // Additional details provided by the server
 			...error,
 			stack: undefined, // Avoid serializing stack trace to keep the error object clean
@@ -62,6 +85,8 @@ export class ClineError extends Error {
 			status: this._error.status,
 			request_id: this._error.request_id,
 			code: this._error.code,
+			modelId: this.modelId,
+			providerId: this.providerId,
 			details: this._error.details,
 		})
 	}
@@ -76,6 +101,10 @@ export class ClineError extends Error {
 		return ClineError.transform(errorStr, modelId)
 	}
 
+	/**
+	 * Transforms any object into a ClineError instance.
+	 * Always returns a ClineError, even if the input is not a valid error object.
+	 */
 	static transform(error: any, modelId?: string, providerId?: string): ClineError {
 		try {
 			return new ClineError(JSON.parse(error), modelId, providerId)
@@ -88,6 +117,10 @@ export class ClineError extends Error {
 		return ClineError.getErrorType(this) === type
 	}
 
+	/**
+	 * Is known error type based on the error code, status, and details.
+	 * This is useful for determining how to handle the error in the UI or logic.
+	 */
 	static getErrorType(err: ClineError): ClineErrorType | undefined {
 		const { code, status, details } = err._error
 

--- a/src/services/error/ClineError.ts
+++ b/src/services/error/ClineError.ts
@@ -1,0 +1,112 @@
+import { CLINE_ACCOUNT_AUTH_ERROR_MESSAGE } from "../../shared/ClineAccount"
+import { serializeError } from "serialize-error"
+
+export enum ClineErrorType {
+	Auth = "auth",
+	Network = "network",
+	RateLimit = "rateLimit",
+	Balance = "balance",
+}
+
+interface ErrorDetails {
+	status?: number
+	request_id?: string
+	code?: string
+	modelId?: string
+	message?: string
+	// Additional details that might be present in the error
+	// This can include things like current balance, error messages, etc.
+	details?: any
+}
+
+const RATE_LIMIT_PATTERNS = [/status code 429/i, /rate limit/i, /too many requests/i, /quota exceeded/i, /resource exhausted/i]
+
+export class ClineError extends Error {
+	readonly title = "ClineError"
+	readonly _error: ErrorDetails
+
+	constructor(raw: any, modelId?: string) {
+		const error = serializeError(raw)
+
+		const message = error.message || String(error)
+		super(message)
+
+		// Extract status from multiple possible locations
+		const status = error.status || error.statusCode || error.response?.status
+
+		// Construct the error details object to includes relevant information
+		// And ensure it has a consistent structure
+		this._error = {
+			message: raw.message,
+			status,
+			request_id: error.request_id || error.response?.request_id,
+			code: error.code,
+			modelId,
+			details: error.details || error.error, // Additional details provided by the server
+			...error,
+			stack: undefined, // Avoid serializing stack trace to keep the error object clean
+		}
+	}
+
+	/**
+	 *  Serializes the error to a JSON string that allows for easy transmission and storage.
+	 *  This is useful for logging or sending error details to a webviews.
+	 */
+	public serialize(): string {
+		return JSON.stringify({
+			message: this.message,
+			status: this._error.status,
+			request_id: this._error.request_id,
+			code: this._error.code,
+			details: this._error.details,
+		})
+	}
+
+	/**
+	 * Parses a stringified error into a ClineError instance.
+	 */
+	static parse(errorStr?: string, modelId?: string): ClineError | undefined {
+		if (!errorStr || typeof errorStr !== "string") {
+			return undefined
+		}
+		try {
+			return new ClineError(JSON.parse(errorStr), modelId)
+		} catch {
+			return new ClineError(errorStr, modelId)
+		}
+	}
+
+	public isErrorType(type: ClineErrorType): boolean {
+		return ClineError.getErrorType(this) === type
+	}
+
+	static getErrorType(err: ClineError): ClineErrorType | undefined {
+		const { code, status, details } = err._error
+
+		// Check balance error first (most specific)
+		if (code === "insufficient_credits" && typeof details?.current_balance === "number") {
+			return ClineErrorType.Balance
+		}
+
+		// Check auth errors
+		if (code === "ERR_BAD_REQUEST" || status === 401) {
+			return ClineErrorType.Auth
+		}
+
+		// Check for auth message (only if message exists)
+		const message = err.message
+		if (message?.includes(CLINE_ACCOUNT_AUTH_ERROR_MESSAGE)) {
+			return ClineErrorType.Auth
+		}
+
+		// Check rate limit patterns
+		if (message) {
+			const lowerMessage = message.toLowerCase()
+			if (RATE_LIMIT_PATTERNS.some((pattern) => pattern.test(lowerMessage))) {
+				return ClineErrorType.RateLimit
+			}
+		}
+
+		return undefined
+	}
+}

--- a/src/services/error/ClineError.ts
+++ b/src/services/error/ClineError.ts
@@ -47,6 +47,10 @@ export class ClineError extends Error {
 	readonly title = "ClineError"
 	readonly _error: ErrorDetails
 
+	// Error details per providers:
+	// Cline: error?.error
+	// Ollama: error?.cause
+	// tbc
 	constructor(
 		raw: any,
 		public readonly modelId?: string,
@@ -54,7 +58,7 @@ export class ClineError extends Error {
 	) {
 		const error = serializeError(raw)
 
-		const message = error.message || String(error)
+		const message = error.message || String(error) || error?.cause?.means
 		super(message)
 
 		// Extract status from multiple possible locations
@@ -63,10 +67,10 @@ export class ClineError extends Error {
 		// Construct the error details object to includes relevant information
 		// And ensure it has a consistent structure
 		this._error = {
-			message: raw.message,
+			message: raw.message || message,
 			status,
 			request_id: error.request_id || error.response?.request_id,
-			code: error.code,
+			code: error.code || error?.cause?.code,
 			modelId,
 			providerId,
 			details: error.details || error.error, // Additional details provided by the server

--- a/src/services/error/ClineError.ts
+++ b/src/services/error/ClineError.ts
@@ -25,7 +25,11 @@ export class ClineError extends Error {
 	readonly title = "ClineError"
 	readonly _error: ErrorDetails
 
-	constructor(raw: any, modelId?: string) {
+	constructor(
+		raw: any,
+		public readonly modelId?: string,
+		public readonly providerId?: string,
+	) {
 		const error = serializeError(raw)
 
 		const message = error.message || String(error)
@@ -69,10 +73,14 @@ export class ClineError extends Error {
 		if (!errorStr || typeof errorStr !== "string") {
 			return undefined
 		}
+		return ClineError.transform(errorStr, modelId)
+	}
+
+	static transform(error: any, modelId?: string, providerId?: string): ClineError {
 		try {
-			return new ClineError(JSON.parse(errorStr), modelId)
+			return new ClineError(JSON.parse(error), modelId, providerId)
 		} catch {
-			return new ClineError(errorStr, modelId)
+			return new ClineError(error, modelId, providerId)
 		}
 	}
 

--- a/src/services/error/ErrorService.ts
+++ b/src/services/error/ErrorService.ts
@@ -1,7 +1,8 @@
 import * as Sentry from "@sentry/browser"
 import * as vscode from "vscode"
-import { telemetryService } from "@/services/posthog/telemetry/TelemetryService"
+import { telemetryService } from "../posthog/telemetry/TelemetryService"
 import * as pkg from "../../../package.json"
+import { ClineError } from "./ClineError"
 
 let telemetryLevel = vscode.workspace.getConfiguration("telemetry").get<string>("telemetryLevel", "all")
 let isTelemetryEnabled = ["all", "error"].includes(telemetryLevel)
@@ -14,6 +15,8 @@ vscode.workspace.onDidChangeConfiguration(() => {
 		ErrorService.setLevel(telemetryLevel as "error" | "all")
 	}
 })
+
+const isDev = process.env.IS_DEV === "true"
 
 export class ErrorService {
 	private static serviceEnabled: boolean
@@ -29,7 +32,7 @@ export class ErrorService {
 			beforeSend(event) {
 				// TelemetryService keeps track of whether the user has opted in to telemetry/error reporting
 				const isUserManuallyOptedIn = telemetryService.isTelemetryEnabled()
-				if (isUserManuallyOptedIn && ErrorService.isEnabled()) {
+				if (isUserManuallyOptedIn && ErrorService.isEnabled() && !isDev) {
 					return event
 				}
 				return null
@@ -65,7 +68,7 @@ export class ErrorService {
 		}
 	}
 
-	static logException(error: Error): void {
+	static logException(error: Error | ClineError): void {
 		// Don't log if telemetry is off
 		const isUserManuallyOptedIn = telemetryService.isTelemetryEnabled()
 		if (!isUserManuallyOptedIn || !ErrorService.isEnabled()) {
@@ -92,5 +95,10 @@ export class ErrorService {
 
 	static isEnabled(): boolean {
 		return ErrorService.serviceEnabled
+	}
+
+	static toClineError(rawError: any, modelId?: string): ClineError {
+		const clineError = ClineError.parse(rawError, modelId)
+		return clineError || new ClineError("Unknown error occurred", modelId)
 	}
 }

--- a/src/services/error/ErrorService.ts
+++ b/src/services/error/ErrorService.ts
@@ -97,8 +97,7 @@ export class ErrorService {
 		return ErrorService.serviceEnabled
 	}
 
-	static toClineError(rawError: any, modelId?: string): ClineError {
-		const clineError = ClineError.parse(rawError, modelId)
-		return clineError || new ClineError("Unknown error occurred", modelId)
+	static toClineError(rawError: any, modelId?: string, providerId?: string): ClineError {
+		return ClineError.transform(rawError, modelId, providerId)
 	}
 }

--- a/src/services/posthog/PostHogClientProvider.ts
+++ b/src/services/posthog/PostHogClientProvider.ts
@@ -1,5 +1,5 @@
 import { PostHog } from "posthog-node"
-import { posthogConfig } from "@/shared/services/config/posthog-config"
+import { posthogConfig } from "../../shared/services/config/posthog-config"
 
 class PostHogClientProvider {
 	private static instance: PostHogClientProvider

--- a/src/shared/ExtensionMessage.ts
+++ b/src/shared/ExtensionMessage.ts
@@ -7,7 +7,7 @@ import { HistoryItem } from "./HistoryItem"
 import { TelemetrySetting } from "./TelemetrySetting"
 import { ClineRulesToggles } from "./cline-rules"
 import { UserInfo } from "./UserInfo"
-import { McpDisplayMode, DEFAULT_MCP_DISPLAY_MODE } from "./McpDisplayMode"
+import { McpDisplayMode } from "./McpDisplayMode"
 
 // webview will hold state
 export interface ExtensionMessage {

--- a/webview-ui/src/components/chat/ErrorBlockTitle.tsx
+++ b/webview-ui/src/components/chat/ErrorBlockTitle.tsx
@@ -1,0 +1,106 @@
+import React from "react"
+import { ClineError, ClineErrorType } from "../../../../src/services/error/ClineError"
+import { ProgressIndicator } from "./ChatRow"
+
+const RetryMessage = React.memo(
+	({ seconds, attempt, retryOperations }: { retryOperations: number; attempt: number; seconds?: number }) => {
+		const [remainingSeconds, setRemainingSeconds] = React.useState(seconds || 0)
+
+		React.useEffect(() => {
+			if (seconds && seconds > 0) {
+				setRemainingSeconds(seconds)
+
+				const interval = setInterval(() => {
+					setRemainingSeconds((prev) => {
+						if (prev <= 1) {
+							clearInterval(interval)
+							return 0
+						}
+						return prev - 1
+					})
+				}, 1000)
+
+				return () => clearInterval(interval)
+			}
+		}, [seconds])
+
+		return (
+			<span className="font-bold text-[var(--vscode-foreground)]">
+				{`API Request (Retrying failed attempt ${attempt}/${retryOperations}`}
+				{remainingSeconds > 0 && ` in ${remainingSeconds} seconds`}
+				)...
+			</span>
+		)
+	},
+)
+
+interface ErrorBlockTitleProps {
+	cost?: number
+	apiReqCancelReason?: string
+	apiRequestFailedMessage?: string
+	retryStatus?: {
+		attempt: number
+		maxAttempts: number
+		delaySec?: number
+		errorSnippet?: string
+	}
+}
+
+export const ErrorBlockTitle = ({
+	cost,
+	apiReqCancelReason,
+	apiRequestFailedMessage,
+	retryStatus,
+}: ErrorBlockTitleProps): [React.ReactElement, React.ReactElement] => {
+	const getIconSpan = (iconName: string, colorClass: string) => (
+		<div className="w-4 h-4 flex items-center justify-center">
+			<span className={`codicon codicon-${iconName} text-base -mb-0.5 ${colorClass}`}></span>
+		</div>
+	)
+
+	const icon =
+		apiReqCancelReason != null ? (
+			apiReqCancelReason === "user_cancelled" ? (
+				getIconSpan("error", "text-[var(--vscode-descriptionForeground)]")
+			) : (
+				getIconSpan("error", "text-[var(--vscode-errorForeground)]")
+			)
+		) : cost != null ? (
+			getIconSpan("check", "text-[var(--vscode-charts-green)]")
+		) : apiRequestFailedMessage ? (
+			getIconSpan("error", "text-[var(--vscode-errorForeground)]")
+		) : (
+			<ProgressIndicator />
+		)
+
+	const title = (() => {
+		// Default loading state
+		const details = { title: "API Request...", classNames: ["font-bold"] }
+		// Handle cancellation states first
+		if (apiReqCancelReason === "user_cancelled") {
+			details.title = "API Request Cancelled"
+			details.classNames.push("text-[var(--vscode-foreground)]")
+		} else if (apiReqCancelReason) {
+			details.title = "API Streaming Failed"
+			details.classNames.push("text-[var(--vscode-errorForeground)]")
+		} else if (cost != null) {
+			// Handle completed request
+			details.title = "API Request"
+			details.classNames.push("text-[var(--vscode-foreground)]")
+		} else if (apiRequestFailedMessage) {
+			// Handle failed request
+			const clineError = ClineError.parse(apiRequestFailedMessage)
+			const titleText = clineError?.isErrorType(ClineErrorType.Balance) ? "Credit Limit Reached" : "API Request Failed"
+			details.title = titleText
+			details.classNames.push("font-bold text-[var(--vscode-errorForeground)]")
+		} else if (retryStatus) {
+			// Handle retry state
+			const retryOperations = Math.max(0, retryStatus.maxAttempts - 1)
+			return <RetryMessage seconds={retryStatus.delaySec} attempt={retryStatus.attempt} retryOperations={retryOperations} />
+		}
+
+		return <span className={details.classNames.join(" ")}>{details.title}</span>
+	})()
+
+	return [icon, title]
+}

--- a/webview-ui/src/components/chat/ErrorBlockTitle.tsx
+++ b/webview-ui/src/components/chat/ErrorBlockTitle.tsx
@@ -80,7 +80,7 @@ export const ErrorBlockTitle = ({
 		if (apiReqCancelReason === "user_cancelled") {
 			details.title = "API Request Cancelled"
 			details.classNames.push("text-[var(--vscode-foreground)]")
-		} else if (apiReqCancelReason) {
+		} else if (apiReqCancelReason != null) {
 			details.title = "API Streaming Failed"
 			details.classNames.push("text-[var(--vscode-errorForeground)]")
 		} else if (cost != null) {

--- a/webview-ui/src/components/chat/ErrorRow.test.tsx
+++ b/webview-ui/src/components/chat/ErrorRow.test.tsx
@@ -4,11 +4,29 @@ import ErrorRow from "./ErrorRow"
 import { ClineMessage } from "@shared/ExtensionMessage"
 
 // Mock the auth context
+const mockHandleSignIn = vi.fn()
 vi.mock("@/context/ClineAuthContext", () => ({
 	useClineAuth: () => ({
-		handleSignIn: vi.fn(),
+		handleSignIn: mockHandleSignIn,
 		clineUser: null,
 	}),
+}))
+
+// Mock CreditLimitError component
+vi.mock("@/components/chat/CreditLimitError", () => ({
+	default: ({ message }: { message: string }) => <div data-testid="credit-limit-error">{message}</div>,
+}))
+
+// Mock ClineError
+vi.mock("../../../../src/services/error/ClineError", () => ({
+	ClineError: {
+		parse: vi.fn(),
+	},
+	ClineErrorType: {
+		Balance: "balance",
+		RateLimit: "rateLimit",
+		Auth: "auth",
+	},
 }))
 
 describe("ErrorRow", () => {
@@ -19,10 +37,13 @@ describe("ErrorRow", () => {
 		text: "Test error message",
 	}
 
+	beforeEach(() => {
+		vi.clearAllMocks()
+	})
+
 	it("renders basic error message", () => {
 		render(<ErrorRow message={mockMessage} errorType="error" />)
 
-		expect(screen.getByText("Error")).toBeInTheDocument()
 		expect(screen.getByText("Test error message")).toBeInTheDocument()
 	})
 
@@ -30,7 +51,6 @@ describe("ErrorRow", () => {
 		const mistakeMessage = { ...mockMessage, text: "Mistake limit reached" }
 		render(<ErrorRow message={mistakeMessage} errorType="mistake_limit_reached" />)
 
-		expect(screen.getByText("Cline is having trouble...")).toBeInTheDocument()
 		expect(screen.getByText("Mistake limit reached")).toBeInTheDocument()
 	})
 
@@ -38,14 +58,12 @@ describe("ErrorRow", () => {
 		const maxReqMessage = { ...mockMessage, text: "Max requests reached" }
 		render(<ErrorRow message={maxReqMessage} errorType="auto_approval_max_req_reached" />)
 
-		expect(screen.getByText("Maximum Requests Reached")).toBeInTheDocument()
 		expect(screen.getByText("Max requests reached")).toBeInTheDocument()
 	})
 
 	it("renders diff error", () => {
 		render(<ErrorRow message={mockMessage} errorType="diff_error" />)
 
-		expect(screen.getByText("Diff Edit Mismatch")).toBeInTheDocument()
 		expect(
 			screen.getByText("The model used search patterns that don't match anything in the file. Retrying..."),
 		).toBeInTheDocument()
@@ -55,8 +73,128 @@ describe("ErrorRow", () => {
 		const clineignoreMessage = { ...mockMessage, text: "/path/to/file.txt" }
 		render(<ErrorRow message={clineignoreMessage} errorType="clineignore_error" />)
 
-		expect(screen.getByText("Access Denied")).toBeInTheDocument()
 		expect(screen.getByText(/Cline tried to access/)).toBeInTheDocument()
 		expect(screen.getByText("/path/to/file.txt")).toBeInTheDocument()
+	})
+
+	describe("API error handling", () => {
+		it("renders credit limit error when balance error is detected", async () => {
+			const mockClineError = {
+				message: "Insufficient credits",
+				isErrorType: vi.fn((type) => type === "balance"),
+				_error: {
+					details: {
+						current_balance: 0,
+						total_spent: 10.5,
+						total_promotions: 5.0,
+						message: "You have run out of credit.",
+						buy_credits_url: "https://app.cline.bot/dashboard",
+					},
+				},
+			}
+
+			const { ClineError } = await import("../../../../src/services/error/ClineError")
+			vi.mocked(ClineError.parse).mockReturnValue(mockClineError as any)
+
+			render(<ErrorRow message={mockMessage} errorType="error" apiRequestFailedMessage="Insufficient credits error" />)
+
+			expect(screen.getByTestId("credit-limit-error")).toBeInTheDocument()
+			expect(screen.getByText("You have run out of credit.")).toBeInTheDocument()
+		})
+
+		it("renders rate limit error with request ID", async () => {
+			const mockClineError = {
+				message: "Rate limit exceeded",
+				isErrorType: vi.fn((type) => type === "rateLimit"),
+				_error: {
+					request_id: "req_123456",
+				},
+			}
+
+			const { ClineError } = await import("../../../../src/services/error/ClineError")
+			vi.mocked(ClineError.parse).mockReturnValue(mockClineError as any)
+
+			render(<ErrorRow message={mockMessage} errorType="error" apiRequestFailedMessage="Rate limit exceeded" />)
+
+			expect(screen.getByText("Rate limit exceeded")).toBeInTheDocument()
+			expect(screen.getByText("Request ID: req_123456")).toBeInTheDocument()
+		})
+
+		it("renders auth error with sign in button when user is not signed in", async () => {
+			const mockClineError = {
+				message: "Authentication failed",
+				isErrorType: vi.fn((type) => type === "auth"),
+				providerId: "cline",
+				_error: {},
+			}
+
+			const { ClineError } = await import("../../../../src/services/error/ClineError")
+			vi.mocked(ClineError.parse).mockReturnValue(mockClineError as any)
+
+			render(<ErrorRow message={mockMessage} errorType="error" apiRequestFailedMessage="Authentication failed" />)
+
+			expect(screen.getByText("Authentication failed")).toBeInTheDocument()
+			expect(screen.getByText("Sign in to Cline")).toBeInTheDocument()
+		})
+
+		it("renders PowerShell troubleshooting link when error mentions PowerShell", async () => {
+			const mockClineError = {
+				message: "PowerShell is not recognized as an internal or external command",
+				isErrorType: vi.fn(() => false),
+				_error: {},
+			}
+
+			const { ClineError } = await import("../../../../src/services/error/ClineError")
+			vi.mocked(ClineError.parse).mockReturnValue(mockClineError as any)
+
+			render(
+				<ErrorRow
+					message={mockMessage}
+					errorType="error"
+					apiRequestFailedMessage="PowerShell is not recognized as an internal or external command"
+				/>,
+			)
+
+			expect(screen.getByText(/PowerShell is not recognized/)).toBeInTheDocument()
+			expect(screen.getByText("troubleshooting guide")).toBeInTheDocument()
+			expect(screen.getByRole("link", { name: "troubleshooting guide" })).toHaveAttribute(
+				"href",
+				"https://github.com/cline/cline/wiki/TroubleShooting-%E2%80%90-%22PowerShell-is-not-recognized-as-an-internal-or-external-command%22",
+			)
+		})
+
+		it("handles apiReqStreamingFailedMessage instead of apiRequestFailedMessage", async () => {
+			const mockClineError = {
+				message: "Streaming failed",
+				isErrorType: vi.fn(() => false),
+				_error: {},
+			}
+
+			const { ClineError } = await import("../../../../src/services/error/ClineError")
+			vi.mocked(ClineError.parse).mockReturnValue(mockClineError as any)
+
+			render(<ErrorRow message={mockMessage} errorType="error" apiReqStreamingFailedMessage="Streaming failed" />)
+
+			expect(screen.getByText("Streaming failed")).toBeInTheDocument()
+		})
+
+		it("falls back to regular error message when ClineError.parse returns null", async () => {
+			const { ClineError } = await import("../../../../src/services/error/ClineError")
+			vi.mocked(ClineError.parse).mockReturnValue(undefined)
+
+			render(<ErrorRow message={mockMessage} errorType="error" apiRequestFailedMessage="Some API error" />)
+
+			// When ClineError.parse returns null, clineErrorMessage is undefined, so it renders an empty paragraph
+			// The fallback to message.text only happens when there's no apiRequestFailedMessage at all
+			const paragraph = screen.getByRole("paragraph")
+			expect(paragraph).toBeInTheDocument()
+			expect(paragraph).toBeEmptyDOMElement()
+		})
+
+		it("renders regular error message when no API error messages are provided", () => {
+			render(<ErrorRow message={mockMessage} errorType="error" />)
+
+			expect(screen.getByText("Test error message")).toBeInTheDocument()
+		})
 	})
 })

--- a/webview-ui/src/components/chat/ErrorRow.test.tsx
+++ b/webview-ui/src/components/chat/ErrorRow.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen } from "@testing-library/react"
+import { describe, it, expect, vi } from "vitest"
+import ErrorRow from "./ErrorRow"
+import { ClineMessage } from "@shared/ExtensionMessage"
+
+// Mock the auth context
+vi.mock("@/context/ClineAuthContext", () => ({
+	useClineAuth: () => ({
+		handleSignIn: vi.fn(),
+		clineUser: null,
+	}),
+}))
+
+describe("ErrorRow", () => {
+	const mockMessage: ClineMessage = {
+		ts: 123456789,
+		type: "say",
+		say: "error",
+		text: "Test error message",
+	}
+
+	it("renders basic error message", () => {
+		render(<ErrorRow message={mockMessage} errorType="error" />)
+
+		expect(screen.getByText("Error")).toBeInTheDocument()
+		expect(screen.getByText("Test error message")).toBeInTheDocument()
+	})
+
+	it("renders mistake limit reached error", () => {
+		const mistakeMessage = { ...mockMessage, text: "Mistake limit reached" }
+		render(<ErrorRow message={mistakeMessage} errorType="mistake_limit_reached" />)
+
+		expect(screen.getByText("Cline is having trouble...")).toBeInTheDocument()
+		expect(screen.getByText("Mistake limit reached")).toBeInTheDocument()
+	})
+
+	it("renders auto approval max requests error", () => {
+		const maxReqMessage = { ...mockMessage, text: "Max requests reached" }
+		render(<ErrorRow message={maxReqMessage} errorType="auto_approval_max_req_reached" />)
+
+		expect(screen.getByText("Maximum Requests Reached")).toBeInTheDocument()
+		expect(screen.getByText("Max requests reached")).toBeInTheDocument()
+	})
+
+	it("renders diff error", () => {
+		render(<ErrorRow message={mockMessage} errorType="diff_error" />)
+
+		expect(screen.getByText("Diff Edit Mismatch")).toBeInTheDocument()
+		expect(
+			screen.getByText("The model used search patterns that don't match anything in the file. Retrying..."),
+		).toBeInTheDocument()
+	})
+
+	it("renders clineignore error", () => {
+		const clineignoreMessage = { ...mockMessage, text: "/path/to/file.txt" }
+		render(<ErrorRow message={clineignoreMessage} errorType="clineignore_error" />)
+
+		expect(screen.getByText("Access Denied")).toBeInTheDocument()
+		expect(screen.getByText(/Cline tried to access/)).toBeInTheDocument()
+		expect(screen.getByText("/path/to/file.txt")).toBeInTheDocument()
+	})
+})

--- a/webview-ui/src/components/chat/ErrorRow.tsx
+++ b/webview-ui/src/components/chat/ErrorRow.tsx
@@ -1,0 +1,126 @@
+import { memo } from "react"
+import { VSCodeButton } from "@vscode/webview-ui-toolkit/react"
+import { ClineMessage } from "@shared/ExtensionMessage"
+import { ClineError, ClineErrorType } from "../../../../src/services/error/ClineError"
+import CreditLimitError from "@/components/chat/CreditLimitError"
+import { useClineAuth } from "@/context/ClineAuthContext"
+
+const errorColor = "var(--vscode-errorForeground)"
+
+interface ErrorRowProps {
+	message: ClineMessage
+	errorType: "error" | "mistake_limit_reached" | "auto_approval_max_req_reached" | "diff_error" | "clineignore_error"
+	apiRequestFailedMessage?: string
+	apiReqStreamingFailedMessage?: string
+}
+
+const ErrorRow = memo(({ message, errorType, apiRequestFailedMessage, apiReqStreamingFailedMessage }: ErrorRowProps) => {
+	const { handleSignIn, clineUser } = useClineAuth()
+
+	const renderErrorContent = () => {
+		switch (errorType) {
+			case "error":
+			case "mistake_limit_reached":
+			case "auto_approval_max_req_reached":
+				// Handle API request errors with special error parsing
+				if (apiRequestFailedMessage || apiReqStreamingFailedMessage) {
+					const clineError = ClineError.parse(apiRequestFailedMessage || apiReqStreamingFailedMessage)
+					const clineErrorMessage = clineError?.message
+					const requestId = clineError?._error?.request_id
+
+					if (clineError) {
+						if (clineError.isErrorType(ClineErrorType.Balance)) {
+							const errorDetails = clineError._error?.details
+							return (
+								<CreditLimitError
+									currentBalance={errorDetails?.current_balance}
+									totalSpent={errorDetails?.total_spent}
+									totalPromotions={errorDetails?.total_promotions}
+									message={errorDetails?.message}
+									buyCreditsUrl={errorDetails?.buy_credits_url}
+								/>
+							)
+						}
+					}
+
+					if (clineError?.isErrorType(ClineErrorType.RateLimit)) {
+						return (
+							<p className="m-0 whitespace-pre-wrap text-[var(--vscode-errorForeground)] wrap-anywhere">
+								{clineErrorMessage}
+								{requestId && <div>Request ID: {requestId}</div>}
+							</p>
+						)
+					}
+
+					// Default error display
+					return (
+						<p className="m-0 whitespace-pre-wrap text-[var(--vscode-errorForeground)] wrap-anywhere">
+							{clineErrorMessage}
+							{requestId && <div>Request ID: {requestId}</div>}
+							{clineErrorMessage?.toLowerCase()?.includes("powershell") && (
+								<>
+									<br />
+									<br />
+									It seems like you're having Windows PowerShell issues, please see this{" "}
+									<a
+										href="https://github.com/cline/cline/wiki/TroubleShooting-%E2%80%90-%22PowerShell-is-not-recognized-as-an-internal-or-external-command%22"
+										className="underline text-inherit">
+										troubleshooting guide
+									</a>
+									.
+								</>
+							)}
+							{clineError?.isErrorType(ClineErrorType.Auth) && (
+								<>
+									<br />
+									<br />
+									{clineUser ? (
+										<span className="mb-4 text-[var(--vscode-descriptionForeground)]">
+											(Click "Retry" below)
+										</span>
+									) : (
+										<VSCodeButton onClick={handleSignIn} className="w-full mb-4">
+											Sign in to Cline
+										</VSCodeButton>
+									)}
+								</>
+							)}
+						</p>
+					)
+				}
+
+				// Regular error message
+				return <p className="m-0 whitespace-pre-wrap bg-[var(--vscode-errorForeground)] wrap-anywhere">{message.text}</p>
+
+			case "diff_error":
+				return (
+					<div className="flex flex-col p-2 rounded text-xs opacity-80 bg-[var(--vscode-textBlockQuote-background)] text-[var(--vscode-foreground)]">
+						<div>The model used search patterns that don't match anything in the file. Retrying...</div>
+					</div>
+				)
+
+			case "clineignore_error":
+				return (
+					<div className="flex flex-col p-2 rounded text-xs bg-[var(--vscode-textBlockQuote-background)] text-[var(--vscode-foreground)] opacity-80">
+						<div>
+							Cline tried to access <code>{message.text}</code> which is blocked by the <code>.clineignore</code>
+							file.
+						</div>
+					</div>
+				)
+
+			default:
+				return null
+		}
+	}
+
+	// For diff_error and clineignore_error, we don't show the header separately
+	if (errorType === "diff_error" || errorType === "clineignore_error") {
+		return <>{renderErrorContent()}</>
+	}
+
+	// For other error types, show header + content
+	return <>{renderErrorContent()}</>
+})
+
+export default ErrorRow

--- a/webview-ui/src/components/chat/ErrorRow.tsx
+++ b/webview-ui/src/components/chat/ErrorRow.tsx
@@ -27,6 +27,7 @@ const ErrorRow = memo(({ message, errorType, apiRequestFailedMessage, apiReqStre
 					const clineError = ClineError.parse(apiRequestFailedMessage || apiReqStreamingFailedMessage)
 					const clineErrorMessage = clineError?.message
 					const requestId = clineError?._error?.request_id
+					const isClineProvider = clineError?.providerId === "cline"
 
 					if (clineError) {
 						if (clineError.isErrorType(ClineErrorType.Balance)) {
@@ -74,7 +75,8 @@ const ErrorRow = memo(({ message, errorType, apiRequestFailedMessage, apiReqStre
 								<>
 									<br />
 									<br />
-									{clineUser ? (
+									{/* The user is signed in or not using cline provider */}
+									{clineUser && !isClineProvider ? (
 										<span className="mb-4 text-[var(--vscode-descriptionForeground)]">
 											(Click "Retry" below)
 										</span>

--- a/webview-ui/src/components/chat/ErrorRow.tsx
+++ b/webview-ui/src/components/chat/ErrorRow.tsx
@@ -92,7 +92,9 @@ const ErrorRow = memo(({ message, errorType, apiRequestFailedMessage, apiReqStre
 				}
 
 				// Regular error message
-				return <p className="m-0 whitespace-pre-wrap bg-[var(--vscode-errorForeground)] wrap-anywhere">{message.text}</p>
+				return (
+					<p className="m-0 whitespace-pre-wrap text-[var(--vscode-errorForeground)] wrap-anywhere">{message.text}</p>
+				)
 
 			case "diff_error":
 				return (

--- a/webview-ui/src/components/chat/__tests__/ErrorBlockTitle.spec.tsx
+++ b/webview-ui/src/components/chat/__tests__/ErrorBlockTitle.spec.tsx
@@ -1,0 +1,51 @@
+import { describe, it, expect } from "vitest"
+import { ErrorBlockTitle } from "../ErrorBlockTitle"
+
+describe("ErrorBlockTitle", () => {
+	it("should return icon and title for API request cancelled", () => {
+		const [icon, title] = ErrorBlockTitle({
+			apiReqCancelReason: "user_cancelled",
+		})
+
+		expect(icon).toBeDefined()
+		expect(title).toBeDefined()
+	})
+
+	it("should return icon and title for completed API request", () => {
+		const [icon, title] = ErrorBlockTitle({
+			cost: 0.001,
+		})
+
+		expect(icon).toBeDefined()
+		expect(title).toBeDefined()
+	})
+
+	it("should return icon and title for failed API request", () => {
+		const [icon, title] = ErrorBlockTitle({
+			apiRequestFailedMessage: "Request failed",
+		})
+
+		expect(icon).toBeDefined()
+		expect(title).toBeDefined()
+	})
+
+	it("should return icon and title for retry status", () => {
+		const [icon, title] = ErrorBlockTitle({
+			retryStatus: {
+				attempt: 2,
+				maxAttempts: 3,
+				delaySec: 5,
+			},
+		})
+
+		expect(icon).toBeDefined()
+		expect(title).toBeDefined()
+	})
+
+	it("should return icon and title for default API request", () => {
+		const [icon, title] = ErrorBlockTitle({})
+
+		expect(icon).toBeDefined()
+		expect(title).toBeDefined()
+	})
+})


### PR DESCRIPTION
<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- Opened an issue and discussed your proposed changes with the community / contributors
- Received approval from a core Cline contributor prior to proceeding with the implementation
- Link the associated issue in the "Related Issue" section

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly.

Why this requirement?
We deeply appreciate all community contributions - they are the core reason we're able to operate successfully and keep innovating! We welcome community input and want to make it as easy as possible for people to submit quality work. This process helps our core maintainers review new ideas faster and saves contributor time by ensuring you have the go-ahead before spending time on implementation.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** #XXXX

### Description

<!-- 
Help reviewers understand your changes by making this PR readable and well-organized:

- What problem does this PR solve?
- Why were these changes introduced and what purpose do they serve?
- For larger changes, provide context about your approach and reasoning

Small PRs may need minimal description, but larger changes benefit from explaining where you're coming from. Much of this context can be in the linked issue above, so feel free to reference it rather than repeating everything here.
-->

Several improvements to error handling and reporting within the Cline extension, focusing on providing more informative error messages to the user and exist early on empty response to avoid recent issues we had with grok where empty response led to more empty response due to retry. We now stop on empty assistant response or on auth error.
    
    - **Error Handling:**
      - Introduces a `ClineError` class to encapsulate Cline-specific errors, providing structured data about the error (status code, request ID, etc.).
      - The `ErrorService` now creates and logs `ClineError` instances, improving error reporting to Sentry and telemetry.
      - Removes redundant error formatting logic from `src/core/task/utils.ts`, relying on the `ClineError` class for consistent error representation.
      - The Cline API handler now throws the raw error, allowing the `ClineError` class to handle the error formatting.
    
    - **UI Improvements:**
      - Introduces new UI components (`ErrorRow`, `ErrorBlockTitle`) to display error messages in a more user-friendly format within the chat interface.
      - Displays credit limit errors with detailed information and a link to purchase credits.
      - Improves the display of rate limit errors and authentication errors.
      - Adds specific handling for PowerShell-related errors, providing a link to a troubleshooting guide.
    
    - **Telemetry:**
      - Captures provider API errors using `ClineError` data, providing more detailed information about the error in telemetry reports.
    
    - **Other Changes:**
      - Fixes an import path in `src/services/posthog/PostHogClientProvider.ts`.
      - Adds tests for the new UI components.
      - Adds `error` field to `ClineMessage` to transport `ClineError` instances to the webview.
    
    These changes aim to provide a better user experience by displaying more informative error messages and improving the overall reliability of the Cline extension.

### Test Procedure

<!-- 
Please walk us through your testing approach and thought process. This helps reviewers understand that you've thoroughly considered the impact of your changes:

- How did you test this change?
- What could potentially break and how did you verify it doesn't?
- What existing functionality might be affected and how did you check it still works?
- Why are you confident this is ready for merge?

We're not looking for exhaustive documentation - just evidence that you've thought through the implications of your changes and tested accordingly.
-->

1. Log out and send Cline a request to confirm you are seeing auth error with sign in button
2. Sign into an account with no balance and confirm you are seeing the credit error

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [ ] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

<img width="535" height="265" alt="image" src="https://github.com/user-attachments/assets/edab9c6c-e908-4e4e-83c9-9b21d3d30ef6" />

<img width="536" height="192" alt="image" src="https://github.com/user-attachments/assets/28f1f80c-963e-4402-ab16-17799a6ef955" />

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Unifies error handling and display in Cline extension with `ClineError` class and new UI components for improved user experience and telemetry.
> 
>   - **Error Handling**:
>     - Introduces `ClineError` class in `ClineError.ts` for structured error data.
>     - `ErrorService` logs `ClineError` instances, improving Sentry and telemetry reporting.
>     - Removes redundant error formatting in `utils.ts`, using `ClineError` for consistency.
>     - `ClineHandler` in `cline.ts` throws raw errors, handled by `ClineError`.
>   - **UI Improvements**:
>     - Adds `ErrorRow` and `ErrorBlockTitle` components in `ChatRow.tsx` for user-friendly error display.
>     - Displays credit limit errors with purchase link, rate limit, and auth errors with troubleshooting links.
>     - Handles PowerShell errors with a guide link.
>   - **Telemetry**:
>     - Captures API errors using `ClineError` data for detailed telemetry reports.
>   - **Other Changes**:
>     - Fixes import path in `PostHogClientProvider.ts`.
>     - Adds tests for new UI components in `ErrorRow.test.tsx` and `ErrorBlockTitle.spec.tsx`.
>     - Adds `error` field to `ClineMessage` in `ExtensionMessage.ts` for transporting `ClineError` instances.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for b9128b9005fedf8997f5da09730b99e986844335. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->