### PR TITLE
fix: LiteLLM provider cost calculations

### DIFF
--- a/.changeset/small-readers-sip.md
+++ b/.changeset/small-readers-sip.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Fix LiteLLM Proxy Provider Cost Tracking

--- a/src/api/providers/litellm.ts
+++ b/src/api/providers/litellm.ts
@@ -16,9 +16,29 @@ interface LiteLlmHandlerOptions {
 	taskId?: string
 }
 
+interface LiteLlmModelInfoResponse {
+	data: Array<{
+		model_name: string
+		litellm_params: {
+			model: string
+			[key: string]: any
+		}
+		model_info: {
+			input_cost_per_token: number
+			output_cost_per_token: number
+			cache_creation_input_token_cost?: number
+			cache_read_input_token_cost?: number
+			[key: string]: any
+		}
+	}>
+}
+
 export class LiteLlmHandler implements ApiHandler {
 	private options: LiteLlmHandlerOptions
 	private client: OpenAI | undefined
+	private modelInfoCache: LiteLlmModelInfoResponse | undefined
+	private modelInfoCacheTimestamp: number = 0
+	private readonly MODEL_INFO_CACHE_TTL = 5 * 60 * 1000 // 5 minutes
 
 	constructor(options: LiteLlmHandlerOptions) {
 		this.options = options
@@ -41,35 +61,112 @@ export class LiteLlmHandler implements ApiHandler {
 		return this.client
 	}
 
-	async calculateCost(prompt_tokens: number, completion_tokens: number): Promise<number | undefined> {
-		// Reference: https://github.com/BerriAI/litellm/blob/122ee634f434014267af104814022af1d9a0882f/litellm/proxy/spend_tracking/spend_management_endpoints.py#L1473
+	private async fetchModelInfo(): Promise<LiteLlmModelInfoResponse | undefined> {
+		// Check if cache is still valid
+		const now = Date.now()
+		if (this.modelInfoCache && now - this.modelInfoCacheTimestamp < this.MODEL_INFO_CACHE_TTL) {
+			return this.modelInfoCache
+		}
+
 		const client = this.ensureClient()
-		const modelId = this.options.liteLlmModelId || liteLlmDefaultModelId
+		// Handle base URLs that already include /v1 to avoid double /v1/v1/
+		const baseUrl = client.baseURL.endsWith("/v1") ? client.baseURL : `${client.baseURL}/v1`
+		const url = `${baseUrl}/model/info`
+
 		try {
-			const response = await fetch(`${client.baseURL}/spend/calculate`, {
-				method: "POST",
+			const response = await fetch(url, {
+				method: "GET",
 				headers: {
-					"Content-Type": "application/json",
-					Authorization: `Bearer ${this.options.liteLlmApiKey}`,
+					accept: "application/json",
+					"x-litellm-api-key": this.options.liteLlmApiKey || "",
 				},
-				body: JSON.stringify({
-					completion_response: {
-						model: modelId,
-						usage: {
-							prompt_tokens,
-							completion_tokens,
-						},
-					},
-				}),
 			})
 
 			if (response.ok) {
-				const data: { cost: number } = await response.json()
-				return data.cost
+				const data: LiteLlmModelInfoResponse = await response.json()
+				this.modelInfoCache = data
+				this.modelInfoCacheTimestamp = now
+				return data
 			} else {
-				console.error("Error calculating spend:", response.statusText)
-				return undefined
+				console.warn("Failed to fetch LiteLLM model info:", response.statusText)
+				// Try with Authorization header instead
+				const retryResponse = await fetch(url, {
+					method: "GET",
+					headers: {
+						accept: "application/json",
+						Authorization: `Bearer ${this.options.liteLlmApiKey || ""}`,
+					},
+				})
+
+				if (retryResponse.ok) {
+					const data: LiteLlmModelInfoResponse = await retryResponse.json()
+					this.modelInfoCache = data
+					this.modelInfoCacheTimestamp = now
+					return data
+				} else {
+					console.warn("Failed to fetch LiteLLM model info with Authorization header:", retryResponse.statusText)
+					return undefined
+				}
 			}
+		} catch (error) {
+			console.warn("Error fetching LiteLLM model info:", error)
+			return undefined
+		}
+	}
+
+	private async getModelCostInfo(publicModelName: string): Promise<{
+		inputCostPerToken: number
+		outputCostPerToken: number
+		cacheCreationCostPerToken?: number
+		cacheReadCostPerToken?: number
+	}> {
+		try {
+			const modelInfo = await this.fetchModelInfo()
+
+			if (modelInfo?.data) {
+				// Find the model by public name
+				const matchingModel = modelInfo.data.find((model) => model.model_name === publicModelName)
+
+				if (matchingModel?.model_info) {
+					return {
+						inputCostPerToken: matchingModel.model_info.input_cost_per_token || 0,
+						outputCostPerToken: matchingModel.model_info.output_cost_per_token || 0,
+						cacheCreationCostPerToken: matchingModel.model_info.cache_creation_input_token_cost,
+						cacheReadCostPerToken: matchingModel.model_info.cache_read_input_token_cost,
+					}
+				}
+			}
+		} catch (error) {
+			console.warn("Error getting LiteLLM model cost info:", error)
+		}
+
+		// Fallback to zero costs if we can't get the information
+		return {
+			inputCostPerToken: 0,
+			outputCostPerToken: 0,
+		}
+	}
+
+	async calculateCost(
+		prompt_tokens: number,
+		completion_tokens: number,
+		cache_creation_tokens?: number,
+		cache_read_tokens?: number,
+	): Promise<number | undefined> {
+		const publicModelId = this.options.liteLlmModelId || liteLlmDefaultModelId
+
+		try {
+			const costInfo = await this.getModelCostInfo(publicModelId)
+
+			// Calculate costs for different token types
+			const inputCost = (prompt_tokens - (cache_read_tokens || 0)) * costInfo.inputCostPerToken
+			const outputCost = completion_tokens * costInfo.outputCostPerToken
+			const cacheCreationCost = (cache_creation_tokens || 0) * (costInfo.cacheCreationCostPerToken || 0)
+			const cacheReadCost = (cache_read_tokens || 0) * (costInfo.cacheReadCostPerToken || 0)
+
+			const totalCost = inputCost + outputCost + cacheCreationCost + cacheReadCost
+
+			return totalCost
 		} catch (error) {
 			console.error("Error calculating spend:", error)
 			return undefined
@@ -136,9 +233,6 @@ export class LiteLlmHandler implements ApiHandler {
 			...(this.options.taskId && { litellm_session_id: `cline-${this.options.taskId}` }), // Add session ID for LiteLLM tracking
 		})
 
-		const inputCost = (await this.calculateCost(1e6, 0)) || 0
-		const outputCost = (await this.calculateCost(0, 1e6)) || 0
-
 		for await (const chunk of stream) {
 			const delta = chunk.choices[0]?.delta
 
@@ -165,9 +259,6 @@ export class LiteLlmHandler implements ApiHandler {
 
 			// Handle token usage information
 			if (chunk.usage) {
-				const totalCost =
-					(inputCost * chunk.usage.prompt_tokens) / 1e6 + (outputCost * chunk.usage.completion_tokens) / 1e6
-
 				// Extract cache-related information if available
 				// Need to use type assertion since these properties are not in the standard OpenAI types
 				const usage = chunk.usage as {
@@ -181,6 +272,15 @@ export class LiteLlmHandler implements ApiHandler {
 
 				const cacheWriteTokens = usage.cache_creation_input_tokens || usage.prompt_cache_miss_tokens || 0
 				const cacheReadTokens = usage.cache_read_input_tokens || usage.prompt_cache_hit_tokens || 0
+
+				// Calculate cost using the actual token usage including cache tokens
+				const totalCost =
+					(await this.calculateCost(
+						usage.prompt_tokens || 0,
+						usage.completion_tokens || 0,
+						cacheWriteTokens > 0 ? cacheWriteTokens : undefined,
+						cacheReadTokens > 0 ? cacheReadTokens : undefined,
+					)) || 0
 
 				yield {
 					type: "usage",

--- a/src/api/providers/litellm.ts
+++ b/src/api/providers/litellm.ts
@@ -38,7 +38,7 @@ export class LiteLlmHandler implements ApiHandler {
 	private client: OpenAI | undefined
 	private modelInfoCache: LiteLlmModelInfoResponse | undefined
 	private modelInfoCacheTimestamp: number = 0
-	private readonly MODEL_INFO_CACHE_TTL = 5 * 60 * 1000 // 5 minutes
+	private readonly modelInfoCacheTTL = 5 * 60 * 1000 // 5 minutes
 
 	constructor(options: LiteLlmHandlerOptions) {
 		this.options = options
@@ -64,7 +64,7 @@ export class LiteLlmHandler implements ApiHandler {
 	private async fetchModelInfo(): Promise<LiteLlmModelInfoResponse | undefined> {
 		// Check if cache is still valid
 		const now = Date.now()
-		if (this.modelInfoCache && now - this.modelInfoCacheTimestamp < this.MODEL_INFO_CACHE_TTL) {
+		if (this.modelInfoCache && now - this.modelInfoCacheTimestamp < this.modelInfoCacheTTL) {
 			return this.modelInfoCache
 		}
 

--- a/src/api/providers/litellm.ts
+++ b/src/api/providers/litellm.ts
@@ -159,7 +159,7 @@ export class LiteLlmHandler implements ApiHandler {
 			const costInfo = await this.getModelCostInfo(publicModelId)
 
 			// Calculate costs for different token types
-			const inputCost = (prompt_tokens - (cache_read_tokens || 0)) * costInfo.inputCostPerToken
+			const inputCost = Math.max(0, prompt_tokens - (cache_read_tokens || 0)) * costInfo.inputCostPerToken
 			const outputCost = completion_tokens * costInfo.outputCostPerToken
 			const cacheCreationCost = (cache_creation_tokens || 0) * (costInfo.cacheCreationCostPerToken || 0)
 			const cacheReadCost = (cache_read_tokens || 0) * (costInfo.cacheReadCostPerToken || 0)


### PR DESCRIPTION
### Related Issue

**Issue:** #2106 and https://github.com/cline/cline/pull/2403

### Description

This PR fixes the LiteLLM provider showing $0 cost for all sessions.

This problem has been detailed in https://github.com/cline/cline/issues/2106#issuecomment-3081362000 and https://github.com/cline/cline/pull/2403#issuecomment-2769741941

#### Problem

LiteLLM users were experiencing cost calculation failures with "Bad Request" errors in the console. The issue occurred because:

- **Incorrect cost calculation approach**: Used the `/spend/calculate` endpoint with public model names instead of fetching actual pricing data
- **Public vs Internal model names**: LiteLLM's public model names (e.g., `global-claude-4.0-sonnet`) differ from internal model identifiers (e.g., `bedrock/us.anthropic.claude-sonnet-4-20250514-v1:0`) as per https://github.com/cline/cline/pull/2403#issuecomment-2769741941

#### Solution

- **Fixed URL construction**: Intelligently handles base URLs that already include `/v1` to prevent double paths
- **Switched to `/v1/model/info` endpoint**: Fetches actual model pricing data instead of using the problematic `/spend/calculate` approach which appears both unreliable in LiteLLM and from what I've seen the /spend path is not exposed on some LiteLLM proxy deployments.
- **Added dual authentication support**: Tries both `x-litellm-api-key` and `Authorization: Bearer` headers for maximum compatibility
- **Implemented caching**: 5-minute cache for model info to reduce API calls and improve performance
- **Enhanced cost calculation**: Supports cache tokens (`cache_creation_tokens`, `cache_read_tokens`) for advanced pricing scenarios

#### Changes
- Added `LiteLlmModelInfoResponse` interface for proper typing
- Replaced `/spend/calculate` logic with `/v1/model/info` fetching
- Added `fetchModelInfo()` and `getModelCostInfo()` methods
- Enhanced `calculateCost()` to support cache token pricing
- Removed inefficient 1M token test calls used for cost estimation

### Test Procedure

- `npm run test`
- Build and install extension locally
- Verified cost calculations now work correctly for LiteLLM configurations
- Tested fallback behaviour when model info is unavailable

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<img width="566" height="249" alt="image" src="https://github.com/user-attachments/assets/fdfb8340-af65-4463-b409-5b8c0da1de8f" />

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes LiteLLM cost calculation by switching to a reliable endpoint, adding caching, and supporting dual authentication.
> 
>   - **Behavior**:
>     - Fixes cost calculation for LiteLLM by switching from `/spend/calculate` to `/v1/model/info` endpoint in `litellm.ts`.
>     - Adds dual authentication support using `x-litellm-api-key` and `Authorization: Bearer` headers.
>     - Implements a 5-minute cache for model info to reduce API calls.
>     - Enhances `calculateCost()` to include cache tokens (`cache_creation_tokens`, `cache_read_tokens`).
>   - **Functions**:
>     - Adds `fetchModelInfo()` and `getModelCostInfo()` methods in `litellm.ts`.
>     - Removes inefficient 1M token test calls in `createMessage()` in `litellm.ts`.
>   - **Interfaces**:
>     - Adds `LiteLlmModelInfoResponse` interface for proper typing in `litellm.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 19576c6c240b7edc549f7f0c2e6f23bfede8a6a5. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->