### PR TITLE
Remove redundant sidebar focus when active webview exists

### DIFF
--- a/src/core/controller/index.ts
+++ b/src/core/controller/index.ts
@@ -22,7 +22,6 @@ import { fileExistsAtPath } from "@utils/fs"
 import { getWorkingState } from "@utils/git"
 import axios from "axios"
 import fs from "fs/promises"
-import { setTimeout as setTimeoutPromise } from "node:timers/promises"
 import pWaitFor from "p-wait-for"
 import * as path from "path"
 import * as vscode from "vscode"
@@ -681,10 +680,6 @@ export class Controller {
 
 	// 'Add to Cline' context menu in editor and code action
 	async addSelectedCodeToChat(code: string, filePath: string, languageId: string, diagnostics?: vscode.Diagnostic[]) {
-		// Ensure the sidebar view is visible
-		await vscode.commands.executeCommand("claude-dev.SidebarProvider.focus")
-		await setTimeoutPromise(100)
-
 		// Post message to webview with the selected code
 		const fileMention = await this.getFileMentionFromPath(filePath)
 
@@ -701,10 +696,6 @@ export class Controller {
 
 	// 'Add to Cline' context menu in Terminal
 	async addSelectedTerminalOutputToChat(output: string, terminalName: string) {
-		// Ensure the sidebar view is visible
-		await vscode.commands.executeCommand("claude-dev.SidebarProvider.focus")
-		await setTimeoutPromise(100)
-
 		// Post message to webview with the selected terminal output
 		// await this.postMessageToWebview({
 		//     type: "addSelectedTerminalOutput",
@@ -719,10 +710,6 @@ export class Controller {
 
 	// 'Fix with Cline' in code actions
 	async fixWithCline(code: string, filePath: string, languageId: string, diagnostics: vscode.Diagnostic[]) {
-		// Ensure the sidebar view is visible
-		await vscode.commands.executeCommand("claude-dev.SidebarProvider.focus")
-		await setTimeoutPromise(100)
-
 		const fileMention = await this.getFileMentionFromPath(filePath)
 		const problemsString = this.convertDiagnosticsToProblemsString(diagnostics)
 		await this.initTask(`Fix the following code in ${fileMention}\n\`\`\`\n${code}\n\`\`\`\n\nProblems:\n${problemsString}`)

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -369,6 +369,10 @@ export async function activate(context: vscode.ExtensionContext) {
 
 	context.subscriptions.push(
 		vscode.commands.registerCommand("cline.addTerminalOutputToChat", async () => {
+			// Ensure Cline is visible and input focused
+			await vscode.commands.executeCommand("cline.focusChatInput")
+			await pWaitFor(() => !!WebviewProvider.getVisibleInstance())
+
 			const terminal = vscode.window.activeTerminal
 			if (!terminal) {
 				return


### PR DESCRIPTION
<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- Opened an issue and discussed your proposed changes with the community / contributors
- Received approval from a core Cline contributor prior to proceeding with the implementation
- Link the associated issue in the "Related Issue" section

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly.

Why this requirement?
We deeply appreciate all community contributions - they are the core reason we're able to operate successfully and keep innovating! We welcome community input and want to make it as easy as possible for people to submit quality work. This process helps our core maintainers review new ideas faster and saves contributor time by ensuring you have the go-ahead before spending time on implementation.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** #4963

### Description

When pressing the `"Add to Cline"` and `"Fix with Cline"` buttons, the sidebar was always being opened. These commands already execute the `"cline.focusChatInput"` command beforehand, which focuses on the recently opened panel/sidebar (see [here](https://github.com/cline/cline/blob/5fba39f88609926f27c53084d12d1682268b6be2/src/extension.ts#L603) ), making this additional sidebar opening redundant. Therefore, these unnecessary operations were removed.

Conversely, the `"addTerminalOutputToChat"` command was not executing the `"cline.focusChatInput"` command, causing it to always open the sidebar (only when active). To maintain consistency with `"Add to Cline"` and `"Fix with Cline"`, this behavior was aligned to use the same processing pattern.

<!-- 
Help reviewers understand your changes by making this PR readable and well-organized:

- What problem does this PR solve?
- Why were these changes introduced and what purpose do they serve?
- For larger changes, provide context about your approach and reasoning

Small PRs may need minimal description, but larger changes benefit from explaining where you're coming from. Much of this context can be in the linked issue above, so feel free to reference it rather than repeating everything here.
-->

### Test Procedure

<!-- 
Please walk us through your testing approach and thought process. This helps reviewers understand that you've thoroughly considered the impact of your changes:

- How did you test this change?
- What could potentially break and how did you verify it doesn't?
- What existing functionality might be affected and how did you check it still works?
- Why are you confident this is ready for merge?

We're not looking for exhaustive documentation - just evidence that you've thought through the implications of your changes and tested accordingly.
-->

1. Open Cline in the sidebar
2. Select any texts in Editor
3. Click "Add to Cline" button
4. Verify chat input event only triggers on existing tab  
---
1. Close all cline tabs
2. Select any texts in Terminal
3. Click "Add to Cline" button
4. Verify chat input event triggers on new Sidebar

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

before changes:

https://github.com/user-attachments/assets/f0be3243-5275-4414-a6db-289cf09fe31a

after changes:

https://github.com/user-attachments/assets/2682f1fc-39ef-4059-bfc8-9c321ab83c21


### Additional Notes

<!-- Add any additional notes for reviewers -->
