### PR TITLE
Don't need to use `Message.create({...})` with the host bridge

### DIFF
--- a/src/core/controller/file/createRuleFile.ts
+++ b/src/core/controller/file/createRuleFile.ts
@@ -44,7 +44,7 @@ export const createRuleFile: FileMethodHandler = async (controller: Controller, 
 
 	if (fileExists) {
 		const message = `${fileTypeName} file "${request.filename}" already exists.`
-		await getHostBridgeProvider().windowClient.showMessage({
+		getHostBridgeProvider().windowClient.showMessage({
 			type: ShowMessageType.WARNING,
 			message,
 		})
@@ -61,7 +61,7 @@ export const createRuleFile: FileMethodHandler = async (controller: Controller, 
 		await handleFileServiceRequest(controller, "openFile", { value: filePath })
 
 		const message = `Created new ${request.isGlobal ? "global" : "workspace"} ${fileTypeName} file: ${request.filename}`
-		await getHostBridgeProvider().windowClient.showMessage({
+		getHostBridgeProvider().windowClient.showMessage({
 			type: ShowMessageType.INFORMATION,
 			message,
 		})

--- a/src/core/controller/file/createRuleFile.ts
+++ b/src/core/controller/file/createRuleFile.ts
@@ -44,12 +44,10 @@ export const createRuleFile: FileMethodHandler = async (controller: Controller, 
 
 	if (fileExists) {
 		const message = `${fileTypeName} file "${request.filename}" already exists.`
-		getHostBridgeProvider().windowClient.showMessage(
-			ShowMessageRequest.create({
-				type: ShowMessageType.WARNING,
-				message,
-			}),
-		)
+		await getHostBridgeProvider().windowClient.showMessage({
+			type: ShowMessageType.WARNING,
+			message,
+		})
 		// Still open it for editing
 		await handleFileServiceRequest(controller, "openFile", { value: filePath })
 	} else {
@@ -63,12 +61,10 @@ export const createRuleFile: FileMethodHandler = async (controller: Controller, 
 		await handleFileServiceRequest(controller, "openFile", { value: filePath })
 
 		const message = `Created new ${request.isGlobal ? "global" : "workspace"} ${fileTypeName} file: ${request.filename}`
-		getHostBridgeProvider().windowClient.showMessage(
-			ShowMessageRequest.create({
-				type: ShowMessageType.INFORMATION,
-				message,
-			}),
-		)
+		await getHostBridgeProvider().windowClient.showMessage({
+			type: ShowMessageType.INFORMATION,
+			message,
+		})
 	}
 
 	return RuleFile.create({

--- a/src/core/controller/file/deleteRuleFile.ts
+++ b/src/core/controller/file/deleteRuleFile.ts
@@ -46,7 +46,7 @@ export const deleteRuleFile: FileMethodHandler = async (controller: Controller, 
 	const fileTypeName = request.type === "workflow" ? "workflow" : "rule"
 
 	const message = `${fileTypeName} file "${fileName}" deleted successfully`
-	await getHostBridgeProvider().windowClient.showMessage({
+	getHostBridgeProvider().windowClient.showMessage({
 		type: ShowMessageType.INFORMATION,
 		message,
 	})

--- a/src/core/controller/file/deleteRuleFile.ts
+++ b/src/core/controller/file/deleteRuleFile.ts
@@ -46,12 +46,10 @@ export const deleteRuleFile: FileMethodHandler = async (controller: Controller, 
 	const fileTypeName = request.type === "workflow" ? "workflow" : "rule"
 
 	const message = `${fileTypeName} file "${fileName}" deleted successfully`
-	getHostBridgeProvider().windowClient.showMessage(
-		ShowMessageRequest.create({
-			type: ShowMessageType.INFORMATION,
-			message,
-		}),
-	)
+	await getHostBridgeProvider().windowClient.showMessage({
+		type: ShowMessageType.INFORMATION,
+		message,
+	})
 
 	return RuleFile.create({
 		filePath: request.rulePath,

--- a/src/core/controller/index.ts
+++ b/src/core/controller/index.ts
@@ -114,19 +114,15 @@ export class Controller {
 			await updateGlobalState(this.context, "userInfo", undefined)
 			await updateGlobalState(this.context, "apiProvider", "openrouter")
 			await this.postStateToWebview()
-			getHostBridgeProvider().windowClient.showMessage(
-				ShowMessageRequest.create({
-					type: ShowMessageType.INFORMATION,
-					message: "Successfully logged out of Cline",
-				}),
-			)
+			await getHostBridgeProvider().windowClient.showMessage({
+				type: ShowMessageType.INFORMATION,
+				message: "Successfully logged out of Cline",
+			})
 		} catch (error) {
-			getHostBridgeProvider().windowClient.showMessage(
-				ShowMessageRequest.create({
-					type: ShowMessageType.INFORMATION,
-					message: "Logout failed",
-				}),
-			)
+			await getHostBridgeProvider().windowClient.showMessage({
+				type: ShowMessageType.INFORMATION,
+				message: "Logout failed",
+			})
 		}
 	}
 
@@ -485,12 +481,10 @@ export class Controller {
 			await this.postStateToWebview()
 		} catch (error) {
 			console.error("Failed to handle auth callback:", error)
-			getHostBridgeProvider().windowClient.showMessage(
-				ShowMessageRequest.create({
-					type: ShowMessageType.ERROR,
-					message: "Failed to log in to Cline",
-				}),
-			)
+			await getHostBridgeProvider().windowClient.showMessage({
+				type: ShowMessageType.ERROR,
+				message: "Failed to log in to Cline",
+			})
 			// Even on login failure, we preserve any existing tokens
 			// Only clear tokens on explicit logout
 		}
@@ -525,12 +519,10 @@ export class Controller {
 			console.error("Failed to fetch MCP marketplace:", error)
 			if (!silent) {
 				const errorMessage = error instanceof Error ? error.message : "Failed to fetch MCP marketplace"
-				getHostBridgeProvider().windowClient.showMessage(
-					ShowMessageRequest.create({
-						type: ShowMessageType.ERROR,
-						message: errorMessage,
-					}),
-				)
+				await getHostBridgeProvider().windowClient.showMessage({
+					type: ShowMessageType.ERROR,
+					message: errorMessage,
+				})
 			}
 			return undefined
 		}
@@ -614,12 +606,10 @@ export class Controller {
 		} catch (error) {
 			console.error("Failed to handle cached MCP marketplace:", error)
 			const errorMessage = error instanceof Error ? error.message : "Failed to handle cached MCP marketplace"
-			getHostBridgeProvider().windowClient.showMessage(
-				ShowMessageRequest.create({
-					type: ShowMessageType.ERROR,
-					message: errorMessage,
-				}),
-			)
+			await getHostBridgeProvider().windowClient.showMessage({
+				type: ShowMessageType.ERROR,
+				message: errorMessage,
+			})
 		}
 	}
 
@@ -982,24 +972,20 @@ export class Controller {
 			// Check if there's a workspace folder open
 			const cwd = await getCwd()
 			if (!cwd) {
-				getHostBridgeProvider().windowClient.showMessage(
-					ShowMessageRequest.create({
-						type: ShowMessageType.ERROR,
-						message: "No workspace folder open",
-					}),
-				)
+				await getHostBridgeProvider().windowClient.showMessage({
+					type: ShowMessageType.ERROR,
+					message: "No workspace folder open",
+				})
 				return
 			}
 
 			// Get the git diff
 			const gitDiff = await getWorkingState(cwd)
 			if (gitDiff === "No changes in working directory") {
-				getHostBridgeProvider().windowClient.showMessage(
-					ShowMessageRequest.create({
-						type: ShowMessageType.INFORMATION,
-						message: "No changes in workspace for commit message",
-					}),
-				)
+				await getHostBridgeProvider().windowClient.showMessage({
+					type: ShowMessageType.INFORMATION,
+					message: "No changes in workspace for commit message",
+				})
 				return
 			}
 
@@ -1067,58 +1053,46 @@ Commit message:`
 									const repo = api.repositories[0]
 									repo.inputBox.value = commitMessage
 									const message = "Commit message generated and applied"
-									getHostBridgeProvider().windowClient.showMessage(
-										ShowMessageRequest.create({
-											type: ShowMessageType.INFORMATION,
-											message,
-										}),
-									)
+									await getHostBridgeProvider().windowClient.showMessage({
+										type: ShowMessageType.INFORMATION,
+										message,
+									})
 								} else {
 									const message = "No Git repositories found"
-									getHostBridgeProvider().windowClient.showMessage(
-										ShowMessageRequest.create({
-											type: ShowMessageType.ERROR,
-											message,
-										}),
-									)
+									await getHostBridgeProvider().windowClient.showMessage({
+										type: ShowMessageType.ERROR,
+										message,
+									})
 								}
 							} else {
 								const message = "Git extension not found"
-								getHostBridgeProvider().windowClient.showMessage(
-									ShowMessageRequest.create({
-										type: ShowMessageType.ERROR,
-										message,
-									}),
-								)
+								await getHostBridgeProvider().windowClient.showMessage({
+									type: ShowMessageType.ERROR,
+									message,
+								})
 							}
 						} else {
 							const message = "Failed to generate commit message"
-							getHostBridgeProvider().windowClient.showMessage(
-								ShowMessageRequest.create({
-									type: ShowMessageType.ERROR,
-									message,
-								}),
-							)
+							await getHostBridgeProvider().windowClient.showMessage({
+								type: ShowMessageType.ERROR,
+								message,
+							})
 						}
 					} catch (innerError) {
 						const innerErrorMessage = innerError instanceof Error ? innerError.message : String(innerError)
-						getHostBridgeProvider().windowClient.showMessage(
-							ShowMessageRequest.create({
-								type: ShowMessageType.ERROR,
-								message: `Failed to generate commit message: ${innerErrorMessage}`,
-							}),
-						)
+						await getHostBridgeProvider().windowClient.showMessage({
+							type: ShowMessageType.ERROR,
+							message: `Failed to generate commit message: ${innerErrorMessage}`,
+						})
 					}
 				},
 			)
 		} catch (error) {
 			const errorMessage = error instanceof Error ? error.message : String(error)
-			getHostBridgeProvider().windowClient.showMessage(
-				ShowMessageRequest.create({
-					type: ShowMessageType.ERROR,
-					message: `Failed to generate commit message: ${errorMessage}`,
-				}),
-			)
+			await getHostBridgeProvider().windowClient.showMessage({
+				type: ShowMessageType.ERROR,
+				message: `Failed to generate commit message: ${errorMessage}`,
+			})
 		}
 	}
 }

--- a/src/core/controller/index.ts
+++ b/src/core/controller/index.ts
@@ -114,12 +114,12 @@ export class Controller {
 			await updateGlobalState(this.context, "userInfo", undefined)
 			await updateGlobalState(this.context, "apiProvider", "openrouter")
 			await this.postStateToWebview()
-			await getHostBridgeProvider().windowClient.showMessage({
+			getHostBridgeProvider().windowClient.showMessage({
 				type: ShowMessageType.INFORMATION,
 				message: "Successfully logged out of Cline",
 			})
 		} catch (error) {
-			await getHostBridgeProvider().windowClient.showMessage({
+			getHostBridgeProvider().windowClient.showMessage({
 				type: ShowMessageType.INFORMATION,
 				message: "Logout failed",
 			})
@@ -481,7 +481,7 @@ export class Controller {
 			await this.postStateToWebview()
 		} catch (error) {
 			console.error("Failed to handle auth callback:", error)
-			await getHostBridgeProvider().windowClient.showMessage({
+			getHostBridgeProvider().windowClient.showMessage({
 				type: ShowMessageType.ERROR,
 				message: "Failed to log in to Cline",
 			})
@@ -519,7 +519,7 @@ export class Controller {
 			console.error("Failed to fetch MCP marketplace:", error)
 			if (!silent) {
 				const errorMessage = error instanceof Error ? error.message : "Failed to fetch MCP marketplace"
-				await getHostBridgeProvider().windowClient.showMessage({
+				getHostBridgeProvider().windowClient.showMessage({
 					type: ShowMessageType.ERROR,
 					message: errorMessage,
 				})
@@ -606,7 +606,7 @@ export class Controller {
 		} catch (error) {
 			console.error("Failed to handle cached MCP marketplace:", error)
 			const errorMessage = error instanceof Error ? error.message : "Failed to handle cached MCP marketplace"
-			await getHostBridgeProvider().windowClient.showMessage({
+			getHostBridgeProvider().windowClient.showMessage({
 				type: ShowMessageType.ERROR,
 				message: errorMessage,
 			})
@@ -972,7 +972,7 @@ export class Controller {
 			// Check if there's a workspace folder open
 			const cwd = await getCwd()
 			if (!cwd) {
-				await getHostBridgeProvider().windowClient.showMessage({
+				getHostBridgeProvider().windowClient.showMessage({
 					type: ShowMessageType.ERROR,
 					message: "No workspace folder open",
 				})
@@ -982,7 +982,7 @@ export class Controller {
 			// Get the git diff
 			const gitDiff = await getWorkingState(cwd)
 			if (gitDiff === "No changes in working directory") {
-				await getHostBridgeProvider().windowClient.showMessage({
+				getHostBridgeProvider().windowClient.showMessage({
 					type: ShowMessageType.INFORMATION,
 					message: "No changes in workspace for commit message",
 				})
@@ -1053,34 +1053,34 @@ Commit message:`
 									const repo = api.repositories[0]
 									repo.inputBox.value = commitMessage
 									const message = "Commit message generated and applied"
-									await getHostBridgeProvider().windowClient.showMessage({
+									getHostBridgeProvider().windowClient.showMessage({
 										type: ShowMessageType.INFORMATION,
 										message,
 									})
 								} else {
 									const message = "No Git repositories found"
-									await getHostBridgeProvider().windowClient.showMessage({
+									getHostBridgeProvider().windowClient.showMessage({
 										type: ShowMessageType.ERROR,
 										message,
 									})
 								}
 							} else {
 								const message = "Git extension not found"
-								await getHostBridgeProvider().windowClient.showMessage({
+								getHostBridgeProvider().windowClient.showMessage({
 									type: ShowMessageType.ERROR,
 									message,
 								})
 							}
 						} else {
 							const message = "Failed to generate commit message"
-							await getHostBridgeProvider().windowClient.showMessage({
+							getHostBridgeProvider().windowClient.showMessage({
 								type: ShowMessageType.ERROR,
 								message,
 							})
 						}
 					} catch (innerError) {
 						const innerErrorMessage = innerError instanceof Error ? innerError.message : String(innerError)
-						await getHostBridgeProvider().windowClient.showMessage({
+						getHostBridgeProvider().windowClient.showMessage({
 							type: ShowMessageType.ERROR,
 							message: `Failed to generate commit message: ${innerErrorMessage}`,
 						})
@@ -1089,7 +1089,7 @@ Commit message:`
 			)
 		} catch (error) {
 			const errorMessage = error instanceof Error ? error.message : String(error)
-			await getHostBridgeProvider().windowClient.showMessage({
+			getHostBridgeProvider().windowClient.showMessage({
 				type: ShowMessageType.ERROR,
 				message: `Failed to generate commit message: ${errorMessage}`,
 			})

--- a/src/core/controller/state/resetState.ts
+++ b/src/core/controller/state/resetState.ts
@@ -15,13 +15,13 @@ import { getHostBridgeProvider } from "@/hosts/host-providers"
 export async function resetState(controller: Controller, request: ResetStateRequest): Promise<Empty> {
 	try {
 		if (request.global) {
-			await getHostBridgeProvider().windowClient.showMessage({
+			getHostBridgeProvider().windowClient.showMessage({
 				type: ShowMessageType.INFORMATION,
 				message: "Resetting global state...",
 			})
 			await resetGlobalState(controller.context)
 		} else {
-			await getHostBridgeProvider().windowClient.showMessage({
+			getHostBridgeProvider().windowClient.showMessage({
 				type: ShowMessageType.INFORMATION,
 				message: "Resetting workspace state...",
 			})
@@ -33,7 +33,7 @@ export async function resetState(controller: Controller, request: ResetStateRequ
 			controller.task = undefined
 		}
 
-		await getHostBridgeProvider().windowClient.showMessage({
+		getHostBridgeProvider().windowClient.showMessage({
 			type: ShowMessageType.INFORMATION,
 			message: "State reset",
 		})
@@ -44,7 +44,7 @@ export async function resetState(controller: Controller, request: ResetStateRequ
 		return Empty.create()
 	} catch (error) {
 		console.error("Error resetting state:", error)
-		await getHostBridgeProvider().windowClient.showMessage({
+		getHostBridgeProvider().windowClient.showMessage({
 			type: ShowMessageType.ERROR,
 			message: `Failed to reset state: ${error instanceof Error ? error.message : String(error)}`,
 		})

--- a/src/core/controller/state/resetState.ts
+++ b/src/core/controller/state/resetState.ts
@@ -15,20 +15,16 @@ import { getHostBridgeProvider } from "@/hosts/host-providers"
 export async function resetState(controller: Controller, request: ResetStateRequest): Promise<Empty> {
 	try {
 		if (request.global) {
-			getHostBridgeProvider().windowClient.showMessage(
-				ShowMessageRequest.create({
-					type: ShowMessageType.INFORMATION,
-					message: "Resetting global state...",
-				}),
-			)
+			await getHostBridgeProvider().windowClient.showMessage({
+				type: ShowMessageType.INFORMATION,
+				message: "Resetting global state...",
+			})
 			await resetGlobalState(controller.context)
 		} else {
-			getHostBridgeProvider().windowClient.showMessage(
-				ShowMessageRequest.create({
-					type: ShowMessageType.INFORMATION,
-					message: "Resetting workspace state...",
-				}),
-			)
+			await getHostBridgeProvider().windowClient.showMessage({
+				type: ShowMessageType.INFORMATION,
+				message: "Resetting workspace state...",
+			})
 			await resetWorkspaceState(controller.context)
 		}
 
@@ -37,12 +33,10 @@ export async function resetState(controller: Controller, request: ResetStateRequ
 			controller.task = undefined
 		}
 
-		getHostBridgeProvider().windowClient.showMessage(
-			ShowMessageRequest.create({
-				type: ShowMessageType.INFORMATION,
-				message: "State reset",
-			}),
-		)
+		await getHostBridgeProvider().windowClient.showMessage({
+			type: ShowMessageType.INFORMATION,
+			message: "State reset",
+		})
 		await controller.postStateToWebview()
 
 		await sendChatButtonClickedEvent(controller.id)
@@ -50,12 +44,10 @@ export async function resetState(controller: Controller, request: ResetStateRequ
 		return Empty.create()
 	} catch (error) {
 		console.error("Error resetting state:", error)
-		getHostBridgeProvider().windowClient.showMessage(
-			ShowMessageRequest.create({
-				type: ShowMessageType.ERROR,
-				message: `Failed to reset state: ${error instanceof Error ? error.message : String(error)}`,
-			}),
-		)
+		await getHostBridgeProvider().windowClient.showMessage({
+			type: ShowMessageType.ERROR,
+			message: `Failed to reset state: ${error instanceof Error ? error.message : String(error)}`,
+		})
 		throw error
 	}
 }

--- a/src/core/controller/state/updateDefaultTerminalProfile.ts
+++ b/src/core/controller/state/updateDefaultTerminalProfile.ts
@@ -27,12 +27,10 @@ export async function updateDefaultTerminalProfile(
 		// Show information message if terminals were closed
 		if (closedCount > 0) {
 			const message = `Closed ${closedCount} ${closedCount === 1 ? "terminal" : "terminals"} with different profile.`
-			getHostBridgeProvider().windowClient.showMessage(
-				ShowMessageRequest.create({
-					type: ShowMessageType.INFORMATION,
-					message,
-				}),
-			)
+			await getHostBridgeProvider().windowClient.showMessage({
+				type: ShowMessageType.INFORMATION,
+				message,
+			})
 		}
 
 		// Show warning if there are busy terminals that couldn't be closed
@@ -40,12 +38,10 @@ export async function updateDefaultTerminalProfile(
 			const message =
 				`${busyTerminals.length} busy ${busyTerminals.length === 1 ? "terminal has" : "terminals have"} a different profile. ` +
 				`Close ${busyTerminals.length === 1 ? "it" : "them"} to use the new profile for all commands.`
-			getHostBridgeProvider().windowClient.showMessage(
-				ShowMessageRequest.create({
-					type: ShowMessageType.WARNING,
-					message,
-				}),
-			)
+			await getHostBridgeProvider().windowClient.showMessage({
+				type: ShowMessageType.WARNING,
+				message,
+			})
 		}
 	}
 

--- a/src/core/controller/state/updateDefaultTerminalProfile.ts
+++ b/src/core/controller/state/updateDefaultTerminalProfile.ts
@@ -27,7 +27,7 @@ export async function updateDefaultTerminalProfile(
 		// Show information message if terminals were closed
 		if (closedCount > 0) {
 			const message = `Closed ${closedCount} ${closedCount === 1 ? "terminal" : "terminals"} with different profile.`
-			await getHostBridgeProvider().windowClient.showMessage({
+			getHostBridgeProvider().windowClient.showMessage({
 				type: ShowMessageType.INFORMATION,
 				message,
 			})
@@ -38,7 +38,7 @@ export async function updateDefaultTerminalProfile(
 			const message =
 				`${busyTerminals.length} busy ${busyTerminals.length === 1 ? "terminal has" : "terminals have"} a different profile. ` +
 				`Close ${busyTerminals.length === 1 ? "it" : "them"} to use the new profile for all commands.`
-			await getHostBridgeProvider().windowClient.showMessage({
+			getHostBridgeProvider().windowClient.showMessage({
 				type: ShowMessageType.WARNING,
 				message,
 			})

--- a/src/core/controller/task/deleteAllTaskHistory.ts
+++ b/src/core/controller/task/deleteAllTaskHistory.ts
@@ -23,16 +23,14 @@ export async function deleteAllTaskHistory(controller: Controller): Promise<Dele
 		const totalTasks = taskHistory.length
 
 		const userChoice = (
-			await getHostBridgeProvider().windowClient.showMessage(
-				ShowMessageRequest.create({
-					type: ShowMessageType.WARNING,
-					message: "What would you like to delete?",
-					options: {
-						modal: true,
-						items: ["Delete All Except Favorites", "Delete Everything"],
-					},
-				}),
-			)
+			await getHostBridgeProvider().windowClient.showMessage({
+				type: ShowMessageType.WARNING,
+				message: "What would you like to delete?",
+				options: {
+					modal: true,
+					items: ["Delete All Except Favorites", "Delete Everything"],
+				},
+			})
 		)?.selectedOption
 
 		// Default VS Code Cancel button returns `undefined` - don't delete anything
@@ -67,16 +65,14 @@ export async function deleteAllTaskHistory(controller: Controller): Promise<Dele
 			} else {
 				// No favorited tasks found - show warning and ask user what to do
 				const answer = (
-					await getHostBridgeProvider().windowClient.showMessage(
-						ShowMessageRequest.create({
-							type: ShowMessageType.WARNING,
-							message: "No favorited tasks found. Would you like to delete all tasks anyway?",
-							options: {
-								modal: true,
-								items: ["Delete All Tasks"],
-							},
-						}),
-					)
+					await getHostBridgeProvider().windowClient.showMessage({
+						type: ShowMessageType.WARNING,
+						message: "No favorited tasks found. Would you like to delete all tasks anyway?",
+						options: {
+							modal: true,
+							items: ["Delete All Tasks"],
+						},
+					})
 				)?.selectedOption
 
 				// User cancelled - don't delete anything
@@ -105,12 +101,10 @@ export async function deleteAllTaskHistory(controller: Controller): Promise<Dele
 				await fs.rm(checkpointsDirPath, { recursive: true, force: true })
 			}
 		} catch (error) {
-			getHostBridgeProvider().windowClient.showMessage(
-				ShowMessageRequest.create({
-					type: ShowMessageType.ERROR,
-					message: `Encountered error while deleting task history, there may be some files left behind. Error: ${error instanceof Error ? error.message : String(error)}`,
-				}),
-			)
+			await getHostBridgeProvider().windowClient.showMessage({
+				type: ShowMessageType.ERROR,
+				message: `Encountered error while deleting task history, there may be some files left behind. Error: ${error instanceof Error ? error.message : String(error)}`,
+			})
 		}
 
 		// Update webview

--- a/src/core/controller/task/deleteAllTaskHistory.ts
+++ b/src/core/controller/task/deleteAllTaskHistory.ts
@@ -22,16 +22,14 @@ export async function deleteAllTaskHistory(controller: Controller): Promise<Dele
 		const taskHistory = ((await getGlobalState(controller.context, "taskHistory")) as any[]) || []
 		const totalTasks = taskHistory.length
 
-		const userChoice = (
-			await getHostBridgeProvider().windowClient.showMessage({
-				type: ShowMessageType.WARNING,
-				message: "What would you like to delete?",
-				options: {
-					modal: true,
-					items: ["Delete All Except Favorites", "Delete Everything"],
-				},
-			})
-		)?.selectedOption
+		const userChoice = getHostBridgeProvider().windowClient.showMessage({
+			type: ShowMessageType.WARNING,
+			message: "What would you like to delete?",
+			options: {
+				modal: true,
+				items: ["Delete All Except Favorites", "Delete Everything"],
+			},
+		})?.selectedOption
 
 		// Default VS Code Cancel button returns `undefined` - don't delete anything
 		if (userChoice === undefined) {
@@ -64,16 +62,14 @@ export async function deleteAllTaskHistory(controller: Controller): Promise<Dele
 				})
 			} else {
 				// No favorited tasks found - show warning and ask user what to do
-				const answer = (
-					await getHostBridgeProvider().windowClient.showMessage({
-						type: ShowMessageType.WARNING,
-						message: "No favorited tasks found. Would you like to delete all tasks anyway?",
-						options: {
-							modal: true,
-							items: ["Delete All Tasks"],
-						},
-					})
-				)?.selectedOption
+				const answer = getHostBridgeProvider().windowClient.showMessage({
+					type: ShowMessageType.WARNING,
+					message: "No favorited tasks found. Would you like to delete all tasks anyway?",
+					options: {
+						modal: true,
+						items: ["Delete All Tasks"],
+					},
+				})?.selectedOption
 
 				// User cancelled - don't delete anything
 				if (answer === undefined) {
@@ -101,7 +97,7 @@ export async function deleteAllTaskHistory(controller: Controller): Promise<Dele
 				await fs.rm(checkpointsDirPath, { recursive: true, force: true })
 			}
 		} catch (error) {
-			await getHostBridgeProvider().windowClient.showMessage({
+			getHostBridgeProvider().windowClient.showMessage({
 				type: ShowMessageType.ERROR,
 				message: `Encountered error while deleting task history, there may be some files left behind. Error: ${error instanceof Error ? error.message : String(error)}`,
 			})

--- a/src/core/controller/task/deleteAllTaskHistory.ts
+++ b/src/core/controller/task/deleteAllTaskHistory.ts
@@ -22,14 +22,18 @@ export async function deleteAllTaskHistory(controller: Controller): Promise<Dele
 		const taskHistory = ((await getGlobalState(controller.context, "taskHistory")) as any[]) || []
 		const totalTasks = taskHistory.length
 
-		const userChoice = getHostBridgeProvider().windowClient.showMessage({
-			type: ShowMessageType.WARNING,
-			message: "What would you like to delete?",
-			options: {
-				modal: true,
-				items: ["Delete All Except Favorites", "Delete Everything"],
-			},
-		})?.selectedOption
+		const userChoice = (
+			await getHostBridgeProvider().windowClient.showMessage(
+				ShowMessageRequest.create({
+					type: ShowMessageType.WARNING,
+					message: "What would you like to delete?",
+					options: {
+						modal: true,
+						items: ["Delete All Except Favorites", "Delete Everything"],
+					},
+				}),
+			)
+		).selectedOption
 
 		// Default VS Code Cancel button returns `undefined` - don't delete anything
 		if (userChoice === undefined) {
@@ -62,14 +66,16 @@ export async function deleteAllTaskHistory(controller: Controller): Promise<Dele
 				})
 			} else {
 				// No favorited tasks found - show warning and ask user what to do
-				const answer = getHostBridgeProvider().windowClient.showMessage({
-					type: ShowMessageType.WARNING,
-					message: "No favorited tasks found. Would you like to delete all tasks anyway?",
-					options: {
-						modal: true,
-						items: ["Delete All Tasks"],
-					},
-				})?.selectedOption
+				const answer = (
+					await getHostBridgeProvider().windowClient.showMessage({
+						type: ShowMessageType.WARNING,
+						message: "No favorited tasks found. Would you like to delete all tasks anyway?",
+						options: {
+							modal: true,
+							items: ["Delete All Tasks"],
+						},
+					})
+				).selectedOption
 
 				// User cancelled - don't delete anything
 				if (answer === undefined) {

--- a/src/core/controller/task/deleteTasksWithIds.ts
+++ b/src/core/controller/task/deleteTasksWithIds.ts
@@ -28,13 +28,11 @@ export const deleteTasksWithIds: TaskMethodHandler = async (
 			? "Are you sure you want to delete this task? This action cannot be undone."
 			: `Are you sure you want to delete these ${taskCount} tasks? This action cannot be undone.`
 
-	const userChoice = await getHostBridgeProvider().windowClient.showMessage(
-		ShowMessageRequest.create({
-			type: ShowMessageType.WARNING,
-			message,
-			options: { modal: true, items: ["Delete"] },
-		}),
-	)
+	const userChoice = await getHostBridgeProvider().windowClient.showMessage({
+		type: ShowMessageType.WARNING,
+		message,
+		options: { modal: true, items: ["Delete"] },
+	})
 
 	if (userChoice === undefined) {
 		return Empty.create()

--- a/src/core/mentions/index.ts
+++ b/src/core/mentions/index.ts
@@ -78,12 +78,10 @@ export async function parseMentions(
 			await urlContentFetcher.launchBrowser()
 		} catch (error) {
 			launchBrowserError = error
-			getHostBridgeProvider().windowClient.showMessage(
-				ShowMessageRequest.create({
-					type: ShowMessageType.ERROR,
-					message: `Error fetching content for ${urlMention}: ${error.message}`,
-				}),
-			)
+			await getHostBridgeProvider().windowClient.showMessage({
+				type: ShowMessageType.ERROR,
+				message: `Error fetching content for ${urlMention}: ${error.message}`,
+			})
 		}
 	}
 
@@ -100,12 +98,10 @@ export async function parseMentions(
 					const markdown = await urlContentFetcher.urlToMarkdown(mention)
 					result = markdown
 				} catch (error) {
-					getHostBridgeProvider().windowClient.showMessage(
-						ShowMessageRequest.create({
-							type: ShowMessageType.ERROR,
-							message: `Error fetching content for ${mention}: ${error.message}`,
-						}),
-					)
+					await getHostBridgeProvider().windowClient.showMessage({
+						type: ShowMessageType.ERROR,
+						message: `Error fetching content for ${mention}: ${error.message}`,
+					})
 					result = `Error fetching content: ${error.message}`
 				}
 			}

--- a/src/core/mentions/index.ts
+++ b/src/core/mentions/index.ts
@@ -78,7 +78,7 @@ export async function parseMentions(
 			await urlContentFetcher.launchBrowser()
 		} catch (error) {
 			launchBrowserError = error
-			await getHostBridgeProvider().windowClient.showMessage({
+			getHostBridgeProvider().windowClient.showMessage({
 				type: ShowMessageType.ERROR,
 				message: `Error fetching content for ${urlMention}: ${error.message}`,
 			})
@@ -98,7 +98,7 @@ export async function parseMentions(
 					const markdown = await urlContentFetcher.urlToMarkdown(mention)
 					result = markdown
 				} catch (error) {
-					await getHostBridgeProvider().windowClient.showMessage({
+					getHostBridgeProvider().windowClient.showMessage({
 						type: ShowMessageType.ERROR,
 						message: `Error fetching content for ${mention}: ${error.message}`,
 					})

--- a/src/core/webview/index.ts
+++ b/src/core/webview/index.ts
@@ -264,7 +264,7 @@ export abstract class WebviewProvider {
 		} catch (error) {
 			// Only show the error message if not in development mode.
 			if (!process.env.IS_DEV) {
-				await getHostBridgeProvider().windowClient.showMessage({
+				getHostBridgeProvider().windowClient.showMessage({
 					type: ShowMessageType.ERROR,
 					message:
 						"Cline: Local webview dev server is not running, HMR will not work. Please run 'npm run dev:webview' before launching the extension to enable HMR. Using bundled assets.",

--- a/src/core/webview/index.ts
+++ b/src/core/webview/index.ts
@@ -264,13 +264,11 @@ export abstract class WebviewProvider {
 		} catch (error) {
 			// Only show the error message if not in development mode.
 			if (!process.env.IS_DEV) {
-				getHostBridgeProvider().windowClient.showMessage(
-					ShowMessageRequest.create({
-						type: ShowMessageType.ERROR,
-						message:
-							"Cline: Local webview dev server is not running, HMR will not work. Please run 'npm run dev:webview' before launching the extension to enable HMR. Using bundled assets.",
-					}),
-				)
+				await getHostBridgeProvider().windowClient.showMessage({
+					type: ShowMessageType.ERROR,
+					message:
+						"Cline: Local webview dev server is not running, HMR will not work. Please run 'npm run dev:webview' before launching the extension to enable HMR. Using bundled assets.",
+				})
 			}
 
 			return this.getHtmlContent()

--- a/src/dev/commands/tasks.ts
+++ b/src/dev/commands/tasks.ts
@@ -99,12 +99,10 @@ export function registerTaskCommands(context: vscode.ExtensionContext, controlle
 					await controller.postStateToWebview()
 
 					const message = `Created ${tasksCount} test tasks`
-					getHostBridgeProvider().windowClient.showMessage(
-						ShowMessageRequest.create({
-							type: ShowMessageType.INFORMATION,
-							message,
-						}),
-					)
+					await getHostBridgeProvider().windowClient.showMessage({
+						type: ShowMessageType.INFORMATION,
+						message,
+					})
 				},
 			)
 		}),

--- a/src/dev/commands/tasks.ts
+++ b/src/dev/commands/tasks.ts
@@ -99,7 +99,7 @@ export function registerTaskCommands(context: vscode.ExtensionContext, controlle
 					await controller.postStateToWebview()
 
 					const message = `Created ${tasksCount} test tasks`
-					await getHostBridgeProvider().windowClient.showMessage({
+					getHostBridgeProvider().windowClient.showMessage({
 						type: ShowMessageType.INFORMATION,
 						message,
 					})

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -106,7 +106,7 @@ export async function activate(context: vscode.ExtensionContext) {
 				const message = `Cline has been updated to v${currentVersion}`
 				await vscode.commands.executeCommand("claude-dev.SidebarProvider.focus")
 				await new Promise((resolve) => setTimeout(resolve, 200))
-				await getHostBridgeProvider().windowClient.showMessage({
+				getHostBridgeProvider().windowClient.showMessage({
 					type: ShowMessageType.INFORMATION,
 					message,
 				})
@@ -411,7 +411,7 @@ export async function activate(context: vscode.ExtensionContext) {
 				// Ensure clipboard is restored even if an error occurs
 				await writeTextToClipboard(tempCopyBuffer)
 				console.error("Error getting terminal contents:", error)
-				await getHostBridgeProvider().windowClient.showMessage({
+				getHostBridgeProvider().windowClient.showMessage({
 					type: ShowMessageType.ERROR,
 					message: "Failed to get terminal contents",
 				})
@@ -550,7 +550,7 @@ export async function activate(context: vscode.ExtensionContext) {
 			}
 			const selectedText = editor.document.getText(range)
 			if (!selectedText.trim()) {
-				await getHostBridgeProvider().windowClient.showMessage({
+				getHostBridgeProvider().windowClient.showMessage({
 					type: ShowMessageType.INFORMATION,
 					message: "Please select some code to explain.",
 				})
@@ -575,7 +575,7 @@ export async function activate(context: vscode.ExtensionContext) {
 			}
 			const selectedText = editor.document.getText(range)
 			if (!selectedText.trim()) {
-				await getHostBridgeProvider().windowClient.showMessage({
+				getHostBridgeProvider().windowClient.showMessage({
 					type: ShowMessageType.INFORMATION,
 					message: "Please select some code to improve.",
 				})
@@ -643,7 +643,7 @@ export async function activate(context: vscode.ExtensionContext) {
 				sendFocusChatInputEvent(clientId)
 			} else {
 				console.error("FocusChatInput: Could not find or activate a Cline webview to focus.")
-				await getHostBridgeProvider().windowClient.showMessage({
+				getHostBridgeProvider().windowClient.showMessage({
 					type: ShowMessageType.ERROR,
 					message: "Could not activate Cline view. Please try opening it manually from the Activity Bar.",
 				})

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -106,12 +106,10 @@ export async function activate(context: vscode.ExtensionContext) {
 				const message = `Cline has been updated to v${currentVersion}`
 				await vscode.commands.executeCommand("claude-dev.SidebarProvider.focus")
 				await new Promise((resolve) => setTimeout(resolve, 200))
-				getHostBridgeProvider().windowClient.showMessage(
-					ShowMessageRequest.create({
-						type: ShowMessageType.INFORMATION,
-						message,
-					}),
-				)
+				await getHostBridgeProvider().windowClient.showMessage({
+					type: ShowMessageType.INFORMATION,
+					message,
+				})
 				// Record that we've shown the popup for this version.
 				await context.globalState.update("clineLastPopupNotificationVersion", currentVersion)
 			}
@@ -413,12 +411,10 @@ export async function activate(context: vscode.ExtensionContext) {
 				// Ensure clipboard is restored even if an error occurs
 				await writeTextToClipboard(tempCopyBuffer)
 				console.error("Error getting terminal contents:", error)
-				getHostBridgeProvider().windowClient.showMessage(
-					ShowMessageRequest.create({
-						type: ShowMessageType.ERROR,
-						message: "Failed to get terminal contents",
-					}),
-				)
+				await getHostBridgeProvider().windowClient.showMessage({
+					type: ShowMessageType.ERROR,
+					message: "Failed to get terminal contents",
+				})
 			}
 		}),
 	)
@@ -554,12 +550,10 @@ export async function activate(context: vscode.ExtensionContext) {
 			}
 			const selectedText = editor.document.getText(range)
 			if (!selectedText.trim()) {
-				getHostBridgeProvider().windowClient.showMessage(
-					ShowMessageRequest.create({
-						type: ShowMessageType.INFORMATION,
-						message: "Please select some code to explain.",
-					}),
-				)
+				await getHostBridgeProvider().windowClient.showMessage({
+					type: ShowMessageType.INFORMATION,
+					message: "Please select some code to explain.",
+				})
 				return
 			}
 			const filePath = editor.document.uri.fsPath
@@ -581,12 +575,10 @@ export async function activate(context: vscode.ExtensionContext) {
 			}
 			const selectedText = editor.document.getText(range)
 			if (!selectedText.trim()) {
-				getHostBridgeProvider().windowClient.showMessage(
-					ShowMessageRequest.create({
-						type: ShowMessageType.INFORMATION,
-						message: "Please select some code to improve.",
-					}),
-				)
+				await getHostBridgeProvider().windowClient.showMessage({
+					type: ShowMessageType.INFORMATION,
+					message: "Please select some code to improve.",
+				})
 				return
 			}
 			const filePath = editor.document.uri.fsPath
@@ -651,12 +643,10 @@ export async function activate(context: vscode.ExtensionContext) {
 				sendFocusChatInputEvent(clientId)
 			} else {
 				console.error("FocusChatInput: Could not find or activate a Cline webview to focus.")
-				getHostBridgeProvider().windowClient.showMessage(
-					ShowMessageRequest.create({
-						type: ShowMessageType.ERROR,
-						message: "Could not activate Cline view. Please try opening it manually from the Activity Bar.",
-					}),
-				)
+				await getHostBridgeProvider().windowClient.showMessage({
+					type: ShowMessageType.ERROR,
+					message: "Could not activate Cline view. Please try opening it manually from the Activity Bar.",
+				})
 			}
 			telemetryService.captureButtonClick("command_focusChatInput", activeWebviewProvider?.controller.task?.taskId)
 		}),

--- a/src/hosts/vscode/hostbridge/window/showMessage.ts
+++ b/src/hosts/vscode/hostbridge/window/showMessage.ts
@@ -3,7 +3,7 @@ import { SelectedResponse, ShowMessageRequest, ShowMessageType } from "@/shared/
 
 const DEFAULT_OPTIONS = { modal: false, items: [] } as const
 
-export async function showMessage(request: ShowMessageRequest): Promise<SelectedResponse | undefined> {
+export async function showMessage(request: ShowMessageRequest): Promise<SelectedResponse> {
 	const { message, type, options } = request
 	const { modal, detail, items } = { ...DEFAULT_OPTIONS, ...options }
 	const option = { modal, detail }

--- a/src/integrations/git/commit-message-generator.ts
+++ b/src/integrations/git/commit-message-generator.ts
@@ -84,7 +84,7 @@ export async function showCommitMessageOptions(message: string): Promise<void> {
 				items: [copyAction, applyAction, editAction],
 			},
 		})
-	)?.selectedOption
+	).selectedOption
 
 	// Handle user dismissing the dialog (selectedAction is undefined)
 	if (!selectedAction) {

--- a/src/integrations/git/commit-message-generator.ts
+++ b/src/integrations/git/commit-message-generator.ts
@@ -59,12 +59,10 @@ export function extractCommitMessage(aiResponse: string): string {
  */
 export async function copyCommitMessageToClipboard(message: string): Promise<void> {
 	await writeTextToClipboard(message)
-	getHostBridgeProvider().windowClient.showMessage(
-		ShowMessageRequest.create({
-			type: ShowMessageType.INFORMATION,
-			message: "Commit message copied to clipboard",
-		}),
-	)
+	await getHostBridgeProvider().windowClient.showMessage({
+		type: ShowMessageType.INFORMATION,
+		message: "Commit message copied to clipboard",
+	})
 }
 
 /**
@@ -77,17 +75,15 @@ export async function showCommitMessageOptions(message: string): Promise<void> {
 	const editAction = "Edit Message"
 
 	const selectedAction = (
-		await getHostBridgeProvider().windowClient.showMessage(
-			ShowMessageRequest.create({
-				type: ShowMessageType.INFORMATION,
-				message: "Commit message generated",
-				options: {
-					modal: false,
-					detail: message,
-					items: [copyAction, applyAction, editAction],
-				},
-			}),
-		)
+		await getHostBridgeProvider().windowClient.showMessage({
+			type: ShowMessageType.INFORMATION,
+			message: "Commit message generated",
+			options: {
+				modal: false,
+				detail: message,
+				items: [copyAction, applyAction, editAction],
+			},
+		})
 	)?.selectedOption
 
 	// Handle user dismissing the dialog (selectedAction is undefined)
@@ -120,28 +116,22 @@ async function applyCommitMessageToGitInput(message: string): Promise<void> {
 		if (api && api.repositories.length > 0) {
 			const repo = api.repositories[0]
 			repo.inputBox.value = message
-			getHostBridgeProvider().windowClient.showMessage(
-				ShowMessageRequest.create({
-					type: ShowMessageType.INFORMATION,
-					message: "Commit message applied to Git input",
-				}),
-			)
+			await getHostBridgeProvider().windowClient.showMessage({
+				type: ShowMessageType.INFORMATION,
+				message: "Commit message applied to Git input",
+			})
 		} else {
-			getHostBridgeProvider().windowClient.showMessage(
-				ShowMessageRequest.create({
-					type: ShowMessageType.ERROR,
-					message: "No Git repositories found",
-				}),
-			)
+			await getHostBridgeProvider().windowClient.showMessage({
+				type: ShowMessageType.ERROR,
+				message: "No Git repositories found",
+			})
 			await copyCommitMessageToClipboard(message)
 		}
 	} else {
-		getHostBridgeProvider().windowClient.showMessage(
-			ShowMessageRequest.create({
-				type: ShowMessageType.ERROR,
-				message: "Git extension not found",
-			}),
-		)
+		await getHostBridgeProvider().windowClient.showMessage({
+			type: ShowMessageType.ERROR,
+			message: "Git extension not found",
+		})
 		await copyCommitMessageToClipboard(message)
 	}
 }
@@ -161,10 +151,8 @@ async function editCommitMessage(message: string): Promise<void> {
 			path: document.uri.fsPath,
 		}),
 	)
-	getHostBridgeProvider().windowClient.showMessage(
-		ShowMessageRequest.create({
-			type: ShowMessageType.INFORMATION,
-			message: "Edit the commit message and copy when ready",
-		}),
-	)
+	await getHostBridgeProvider().windowClient.showMessage({
+		type: ShowMessageType.INFORMATION,
+		message: "Edit the commit message and copy when ready",
+	})
 }

--- a/src/integrations/git/commit-message-generator.ts
+++ b/src/integrations/git/commit-message-generator.ts
@@ -59,7 +59,7 @@ export function extractCommitMessage(aiResponse: string): string {
  */
 export async function copyCommitMessageToClipboard(message: string): Promise<void> {
 	await writeTextToClipboard(message)
-	await getHostBridgeProvider().windowClient.showMessage({
+	getHostBridgeProvider().windowClient.showMessage({
 		type: ShowMessageType.INFORMATION,
 		message: "Commit message copied to clipboard",
 	})
@@ -116,19 +116,19 @@ async function applyCommitMessageToGitInput(message: string): Promise<void> {
 		if (api && api.repositories.length > 0) {
 			const repo = api.repositories[0]
 			repo.inputBox.value = message
-			await getHostBridgeProvider().windowClient.showMessage({
+			getHostBridgeProvider().windowClient.showMessage({
 				type: ShowMessageType.INFORMATION,
 				message: "Commit message applied to Git input",
 			})
 		} else {
-			await getHostBridgeProvider().windowClient.showMessage({
+			getHostBridgeProvider().windowClient.showMessage({
 				type: ShowMessageType.ERROR,
 				message: "No Git repositories found",
 			})
 			await copyCommitMessageToClipboard(message)
 		}
 	} else {
-		await getHostBridgeProvider().windowClient.showMessage({
+		getHostBridgeProvider().windowClient.showMessage({
 			type: ShowMessageType.ERROR,
 			message: "Git extension not found",
 		})
@@ -151,7 +151,7 @@ async function editCommitMessage(message: string): Promise<void> {
 			path: document.uri.fsPath,
 		}),
 	)
-	await getHostBridgeProvider().windowClient.showMessage({
+	getHostBridgeProvider().windowClient.showMessage({
 		type: ShowMessageType.INFORMATION,
 		message: "Edit the commit message and copy when ready",
 	})

--- a/src/integrations/misc/export-markdown.ts
+++ b/src/integrations/misc/export-markdown.ts
@@ -48,12 +48,10 @@ export async function downloadTask(dateTs: number, conversationHistory: Anthropi
 				}),
 			)
 		} catch (error) {
-			getHostBridgeProvider().windowClient.showMessage(
-				ShowMessageRequest.create({
-					type: ShowMessageType.ERROR,
-					message: `Failed to save markdown file: ${error instanceof Error ? error.message : String(error)}`,
-				}),
-			)
+			await getHostBridgeProvider().windowClient.showMessage({
+				type: ShowMessageType.ERROR,
+				message: `Failed to save markdown file: ${error instanceof Error ? error.message : String(error)}`,
+			})
 		}
 	}
 }

--- a/src/integrations/misc/export-markdown.ts
+++ b/src/integrations/misc/export-markdown.ts
@@ -48,7 +48,7 @@ export async function downloadTask(dateTs: number, conversationHistory: Anthropi
 				}),
 			)
 		} catch (error) {
-			await getHostBridgeProvider().windowClient.showMessage({
+			getHostBridgeProvider().windowClient.showMessage({
 				type: ShowMessageType.ERROR,
 				message: `Failed to save markdown file: ${error instanceof Error ? error.message : String(error)}`,
 			})

--- a/src/integrations/misc/open-file.ts
+++ b/src/integrations/misc/open-file.ts
@@ -9,12 +9,10 @@ import { writeFile } from "@utils/fs"
 export async function openImage(dataUri: string) {
 	const matches = dataUri.match(/^data:image\/([a-zA-Z]+);base64,(.+)$/)
 	if (!matches) {
-		getHostBridgeProvider().windowClient.showMessage(
-			ShowMessageRequest.create({
-				type: ShowMessageType.ERROR,
-				message: "Invalid data URI format",
-			}),
-		)
+		await getHostBridgeProvider().windowClient.showMessage({
+			type: ShowMessageType.ERROR,
+			message: "Invalid data URI format",
+		})
 		return
 	}
 	const [, format, base64Data] = matches
@@ -24,12 +22,10 @@ export async function openImage(dataUri: string) {
 		await writeFile(tempFilePath, new Uint8Array(imageBuffer))
 		await vscode.commands.executeCommand("vscode.open", vscode.Uri.file(tempFilePath))
 	} catch (error) {
-		getHostBridgeProvider().windowClient.showMessage(
-			ShowMessageRequest.create({
-				type: ShowMessageType.ERROR,
-				message: `Error opening image: ${error}`,
-			}),
-		)
+		await getHostBridgeProvider().windowClient.showMessage({
+			type: ShowMessageType.ERROR,
+			message: `Error opening image: ${error}`,
+		})
 	}
 }
 
@@ -59,7 +55,7 @@ export async function openFile(absolutePath: string) {
 			options: { preview: false },
 		})
 	} catch (error) {
-		getHostBridgeProvider().windowClient.showMessage({
+		await getHostBridgeProvider().windowClient.showMessage({
 			type: ShowMessageType.ERROR,
 			message: `Could not open file!`,
 		})

--- a/src/integrations/misc/open-file.ts
+++ b/src/integrations/misc/open-file.ts
@@ -9,7 +9,7 @@ import { writeFile } from "@utils/fs"
 export async function openImage(dataUri: string) {
 	const matches = dataUri.match(/^data:image\/([a-zA-Z]+);base64,(.+)$/)
 	if (!matches) {
-		await getHostBridgeProvider().windowClient.showMessage({
+		getHostBridgeProvider().windowClient.showMessage({
 			type: ShowMessageType.ERROR,
 			message: "Invalid data URI format",
 		})
@@ -22,7 +22,7 @@ export async function openImage(dataUri: string) {
 		await writeFile(tempFilePath, new Uint8Array(imageBuffer))
 		await vscode.commands.executeCommand("vscode.open", vscode.Uri.file(tempFilePath))
 	} catch (error) {
-		await getHostBridgeProvider().windowClient.showMessage({
+		getHostBridgeProvider().windowClient.showMessage({
 			type: ShowMessageType.ERROR,
 			message: `Error opening image: ${error}`,
 		})
@@ -55,7 +55,7 @@ export async function openFile(absolutePath: string) {
 			options: { preview: false },
 		})
 	} catch (error) {
-		await getHostBridgeProvider().windowClient.showMessage({
+		getHostBridgeProvider().windowClient.showMessage({
 			type: ShowMessageType.ERROR,
 			message: `Could not open file!`,
 		})

--- a/src/integrations/misc/process-files.ts
+++ b/src/integrations/misc/process-files.ts
@@ -46,7 +46,7 @@ export async function selectFiles(imagesAllowed: boolean): Promise<{ images: str
 				const dimensions = sizeOf(uint8Array) // Get dimensions from Uint8Array
 				if (dimensions.width! > 7500 || dimensions.height! > 7500) {
 					console.warn(`Image dimensions exceed 7500px, skipping: ${filePath}`)
-					await getHostBridgeProvider().windowClient.showMessage({
+					getHostBridgeProvider().windowClient.showMessage({
 						type: ShowMessageType.ERROR,
 						message: `Image too large: ${path.basename(filePath)} was skipped (dimensions exceed 7500px).`,
 					})
@@ -54,7 +54,7 @@ export async function selectFiles(imagesAllowed: boolean): Promise<{ images: str
 				}
 			} catch (error) {
 				console.error(`Error reading file or getting dimensions for ${filePath}:`, error)
-				await getHostBridgeProvider().windowClient.showMessage({
+				getHostBridgeProvider().windowClient.showMessage({
 					type: ShowMessageType.ERROR,
 					message: `Could not read dimensions for ${path.basename(filePath)}, skipping.`,
 				})
@@ -72,7 +72,7 @@ export async function selectFiles(imagesAllowed: boolean): Promise<{ images: str
 				const stats = await fs.stat(filePath)
 				if (stats.size > 20 * 1000 * 1024) {
 					console.warn(`File too large, skipping: ${filePath}`)
-					await getHostBridgeProvider().windowClient.showMessage({
+					getHostBridgeProvider().windowClient.showMessage({
 						type: ShowMessageType.ERROR,
 						message: `File too large: ${path.basename(filePath)} was skipped (size exceeds 20MB).`,
 					})
@@ -80,7 +80,7 @@ export async function selectFiles(imagesAllowed: boolean): Promise<{ images: str
 				}
 			} catch (error) {
 				console.error(`Error checking file size for ${filePath}:`, error)
-				await getHostBridgeProvider().windowClient.showMessage({
+				getHostBridgeProvider().windowClient.showMessage({
 					type: ShowMessageType.ERROR,
 					message: `Could not check file size for ${path.basename(filePath)}, skipping.`,
 				})

--- a/src/integrations/misc/process-files.ts
+++ b/src/integrations/misc/process-files.ts
@@ -46,22 +46,18 @@ export async function selectFiles(imagesAllowed: boolean): Promise<{ images: str
 				const dimensions = sizeOf(uint8Array) // Get dimensions from Uint8Array
 				if (dimensions.width! > 7500 || dimensions.height! > 7500) {
 					console.warn(`Image dimensions exceed 7500px, skipping: ${filePath}`)
-					getHostBridgeProvider().windowClient.showMessage(
-						ShowMessageRequest.create({
-							type: ShowMessageType.ERROR,
-							message: `Image too large: ${path.basename(filePath)} was skipped (dimensions exceed 7500px).`,
-						}),
-					)
+					await getHostBridgeProvider().windowClient.showMessage({
+						type: ShowMessageType.ERROR,
+						message: `Image too large: ${path.basename(filePath)} was skipped (dimensions exceed 7500px).`,
+					})
 					return null
 				}
 			} catch (error) {
 				console.error(`Error reading file or getting dimensions for ${filePath}:`, error)
-				getHostBridgeProvider().windowClient.showMessage(
-					ShowMessageRequest.create({
-						type: ShowMessageType.ERROR,
-						message: `Could not read dimensions for ${path.basename(filePath)}, skipping.`,
-					}),
-				)
+				await getHostBridgeProvider().windowClient.showMessage({
+					type: ShowMessageType.ERROR,
+					message: `Could not read dimensions for ${path.basename(filePath)}, skipping.`,
+				})
 				return null
 			}
 
@@ -76,22 +72,18 @@ export async function selectFiles(imagesAllowed: boolean): Promise<{ images: str
 				const stats = await fs.stat(filePath)
 				if (stats.size > 20 * 1000 * 1024) {
 					console.warn(`File too large, skipping: ${filePath}`)
-					getHostBridgeProvider().windowClient.showMessage(
-						ShowMessageRequest.create({
-							type: ShowMessageType.ERROR,
-							message: `File too large: ${path.basename(filePath)} was skipped (size exceeds 20MB).`,
-						}),
-					)
+					await getHostBridgeProvider().windowClient.showMessage({
+						type: ShowMessageType.ERROR,
+						message: `File too large: ${path.basename(filePath)} was skipped (size exceeds 20MB).`,
+					})
 					return null
 				}
 			} catch (error) {
 				console.error(`Error checking file size for ${filePath}:`, error)
-				getHostBridgeProvider().windowClient.showMessage(
-					ShowMessageRequest.create({
-						type: ShowMessageType.ERROR,
-						message: `Could not check file size for ${path.basename(filePath)}, skipping.`,
-					}),
-				)
+				await getHostBridgeProvider().windowClient.showMessage({
+					type: ShowMessageType.ERROR,
+					message: `Could not check file size for ${path.basename(filePath)}, skipping.`,
+				})
 				return null
 			}
 			return { type: "file", data: filePath }

--- a/src/services/mcp/McpHub.ts
+++ b/src/services/mcp/McpHub.ts
@@ -109,24 +109,20 @@ export class McpHub {
 			try {
 				config = JSON.parse(content)
 			} catch (error) {
-				getHostBridgeProvider().windowClient.showMessage(
-					ShowMessageRequest.create({
-						type: ShowMessageType.ERROR,
-						message: "Invalid MCP settings format. Please ensure your settings follow the correct JSON format.",
-					}),
-				)
+				await getHostBridgeProvider().windowClient.showMessage({
+					type: ShowMessageType.ERROR,
+					message: "Invalid MCP settings format. Please ensure your settings follow the correct JSON format.",
+				})
 				return undefined
 			}
 
 			// Validate against schema
 			const result = McpSettingsSchema.safeParse(config)
 			if (!result.success) {
-				getHostBridgeProvider().windowClient.showMessage(
-					ShowMessageRequest.create({
-						type: ShowMessageType.ERROR,
-						message: "Invalid MCP settings schema.",
-					}),
-				)
+				await getHostBridgeProvider().windowClient.showMessage({
+					type: ShowMessageType.ERROR,
+					message: "Invalid MCP settings schema.",
+				})
 				return undefined
 			}
 
@@ -158,12 +154,10 @@ export class McpHub {
 						if (settings) {
 							try {
 								await this.updateServerConnections(settings.mcpServers)
-								getHostBridgeProvider().windowClient.showMessage(
-									ShowMessageRequest.create({
-										type: ShowMessageType.INFORMATION,
-										message: "MCP servers updated",
-									}),
-								)
+								await getHostBridgeProvider().windowClient.showMessage({
+									type: ShowMessageType.INFORMATION,
+									message: "MCP servers updated",
+								})
 							} catch (error) {
 								console.error("Failed to process MCP settings change:", error)
 							}
@@ -413,12 +407,10 @@ export class McpHub {
 					console.log(`[MCP Fallback Notification] ${name}:`, JSON.stringify(notification, null, 2))
 
 					// Show in VS Code for visibility
-					getHostBridgeProvider().windowClient.showMessage(
-						ShowMessageRequest.create({
-							type: ShowMessageType.INFORMATION,
-							message: `MCP ${name}: ${notification.method || "unknown"} - ${JSON.stringify(notification.params || {})}`,
-						}),
-					)
+					await getHostBridgeProvider().windowClient.showMessage({
+						type: ShowMessageType.INFORMATION,
+						message: `MCP ${name}: ${notification.method || "unknown"} - ${JSON.stringify(notification.params || {})}`,
+					})
 				}
 				console.log(`[MCP Debug] Successfully set fallback notification handler for ${name}`)
 			} catch (error) {
@@ -671,12 +663,10 @@ export class McpHub {
 		const connection = this.connections.find((conn) => conn.server.name === serverName)
 		const config = connection?.server.config
 		if (config) {
-			getHostBridgeProvider().windowClient.showMessage(
-				ShowMessageRequest.create({
-					type: ShowMessageType.INFORMATION,
-					message: `Restarting ${serverName} MCP server...`,
-				}),
-			)
+			await getHostBridgeProvider().windowClient.showMessage({
+				type: ShowMessageType.INFORMATION,
+				message: `Restarting ${serverName} MCP server...`,
+			})
 			connection.server.status = "connecting"
 			connection.server.error = ""
 			await this.notifyWebviewOfServerChanges()
@@ -685,20 +675,16 @@ export class McpHub {
 				await this.deleteConnection(serverName)
 				// Try to connect again using existing config
 				await this.connectToServer(serverName, JSON.parse(config), "internal")
-				getHostBridgeProvider().windowClient.showMessage(
-					ShowMessageRequest.create({
-						type: ShowMessageType.INFORMATION,
-						message: `${serverName} MCP server connected`,
-					}),
-				)
+				await getHostBridgeProvider().windowClient.showMessage({
+					type: ShowMessageType.INFORMATION,
+					message: `${serverName} MCP server connected`,
+				})
 			} catch (error) {
 				console.error(`Failed to restart connection for ${serverName}:`, error)
-				getHostBridgeProvider().windowClient.showMessage(
-					ShowMessageRequest.create({
-						type: ShowMessageType.ERROR,
-						message: `Failed to connect to ${serverName} MCP server`,
-					}),
-				)
+				await getHostBridgeProvider().windowClient.showMessage({
+					type: ShowMessageType.ERROR,
+					message: `Failed to connect to ${serverName} MCP server`,
+				})
 			}
 		}
 
@@ -784,12 +770,10 @@ export class McpHub {
 			if (error instanceof Error) {
 				console.error("Error details:", error.message, error.stack)
 			}
-			getHostBridgeProvider().windowClient.showMessage(
-				ShowMessageRequest.create({
-					type: ShowMessageType.ERROR,
-					message: `Failed to update server state: ${error instanceof Error ? error.message : String(error)}`,
-				}),
-			)
+			await getHostBridgeProvider().windowClient.showMessage({
+				type: ShowMessageType.ERROR,
+				message: `Failed to update server state: ${error instanceof Error ? error.message : String(error)}`,
+			})
 			throw error
 		}
 	}
@@ -946,12 +930,10 @@ export class McpHub {
 			}
 		} catch (error) {
 			console.error("Failed to update autoApprove settings:", error)
-			getHostBridgeProvider().windowClient.showMessage(
-				ShowMessageRequest.create({
-					type: ShowMessageType.ERROR,
-					message: "Failed to update autoApprove settings",
-				}),
-			)
+			await getHostBridgeProvider().windowClient.showMessage({
+				type: ShowMessageType.ERROR,
+				message: "Failed to update autoApprove settings",
+			})
 			throw error // Re-throw to ensure the error is properly handled
 		}
 	}
@@ -1069,12 +1051,10 @@ export class McpHub {
 			if (error instanceof Error) {
 				console.error("Error details:", error.message, error.stack)
 			}
-			getHostBridgeProvider().windowClient.showMessage(
-				ShowMessageRequest.create({
-					type: ShowMessageType.ERROR,
-					message: `Failed to update server timeout: ${error instanceof Error ? error.message : String(error)}`,
-				}),
-			)
+			await getHostBridgeProvider().windowClient.showMessage({
+				type: ShowMessageType.ERROR,
+				message: `Failed to update server timeout: ${error instanceof Error ? error.message : String(error)}`,
+			})
 			throw error
 		}
 	}

--- a/src/services/mcp/McpHub.ts
+++ b/src/services/mcp/McpHub.ts
@@ -109,7 +109,7 @@ export class McpHub {
 			try {
 				config = JSON.parse(content)
 			} catch (error) {
-				await getHostBridgeProvider().windowClient.showMessage({
+				getHostBridgeProvider().windowClient.showMessage({
 					type: ShowMessageType.ERROR,
 					message: "Invalid MCP settings format. Please ensure your settings follow the correct JSON format.",
 				})
@@ -119,7 +119,7 @@ export class McpHub {
 			// Validate against schema
 			const result = McpSettingsSchema.safeParse(config)
 			if (!result.success) {
-				await getHostBridgeProvider().windowClient.showMessage({
+				getHostBridgeProvider().windowClient.showMessage({
 					type: ShowMessageType.ERROR,
 					message: "Invalid MCP settings schema.",
 				})
@@ -154,7 +154,7 @@ export class McpHub {
 						if (settings) {
 							try {
 								await this.updateServerConnections(settings.mcpServers)
-								await getHostBridgeProvider().windowClient.showMessage({
+								getHostBridgeProvider().windowClient.showMessage({
 									type: ShowMessageType.INFORMATION,
 									message: "MCP servers updated",
 								})
@@ -407,7 +407,7 @@ export class McpHub {
 					console.log(`[MCP Fallback Notification] ${name}:`, JSON.stringify(notification, null, 2))
 
 					// Show in VS Code for visibility
-					await getHostBridgeProvider().windowClient.showMessage({
+					getHostBridgeProvider().windowClient.showMessage({
 						type: ShowMessageType.INFORMATION,
 						message: `MCP ${name}: ${notification.method || "unknown"} - ${JSON.stringify(notification.params || {})}`,
 					})
@@ -663,7 +663,7 @@ export class McpHub {
 		const connection = this.connections.find((conn) => conn.server.name === serverName)
 		const config = connection?.server.config
 		if (config) {
-			await getHostBridgeProvider().windowClient.showMessage({
+			getHostBridgeProvider().windowClient.showMessage({
 				type: ShowMessageType.INFORMATION,
 				message: `Restarting ${serverName} MCP server...`,
 			})
@@ -675,13 +675,13 @@ export class McpHub {
 				await this.deleteConnection(serverName)
 				// Try to connect again using existing config
 				await this.connectToServer(serverName, JSON.parse(config), "internal")
-				await getHostBridgeProvider().windowClient.showMessage({
+				getHostBridgeProvider().windowClient.showMessage({
 					type: ShowMessageType.INFORMATION,
 					message: `${serverName} MCP server connected`,
 				})
 			} catch (error) {
 				console.error(`Failed to restart connection for ${serverName}:`, error)
-				await getHostBridgeProvider().windowClient.showMessage({
+				getHostBridgeProvider().windowClient.showMessage({
 					type: ShowMessageType.ERROR,
 					message: `Failed to connect to ${serverName} MCP server`,
 				})
@@ -770,7 +770,7 @@ export class McpHub {
 			if (error instanceof Error) {
 				console.error("Error details:", error.message, error.stack)
 			}
-			await getHostBridgeProvider().windowClient.showMessage({
+			getHostBridgeProvider().windowClient.showMessage({
 				type: ShowMessageType.ERROR,
 				message: `Failed to update server state: ${error instanceof Error ? error.message : String(error)}`,
 			})
@@ -930,7 +930,7 @@ export class McpHub {
 			}
 		} catch (error) {
 			console.error("Failed to update autoApprove settings:", error)
-			await getHostBridgeProvider().windowClient.showMessage({
+			getHostBridgeProvider().windowClient.showMessage({
 				type: ShowMessageType.ERROR,
 				message: "Failed to update autoApprove settings",
 			})
@@ -1051,7 +1051,7 @@ export class McpHub {
 			if (error instanceof Error) {
 				console.error("Error details:", error.message, error.stack)
 			}
-			await getHostBridgeProvider().windowClient.showMessage({
+			getHostBridgeProvider().windowClient.showMessage({
 				type: ShowMessageType.ERROR,
 				message: `Failed to update server timeout: ${error instanceof Error ? error.message : String(error)}`,
 			})


### PR DESCRIPTION
For the host bridge RPCs, you don't need to do `ShowMessageRequest.create({...})`, you can just pass the request directly like: `{...}`. The Message.create() was needed for the ProtoBus because of the way it was implemented, it couldn't be type-checked by the compiled. It's not needed elsewhere.

<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- Opened an issue and discussed your proposed changes with the community / contributors
- Received approval from a core Cline contributor prior to proceeding with the implementation
- Link the associated issue in the "Related Issue" section

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly.

Why this requirement?
We deeply appreciate all community contributions - they are the core reason we're able to operate successfully and keep innovating! We welcome community input and want to make it as easy as possible for people to submit quality work. This process helps our core maintainers review new ideas faster and saves contributor time by ensuring you have the go-ahead before spending time on implementation.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** #XXXX

### Description

<!-- 
Help reviewers understand your changes by making this PR readable and well-organized:

- What problem does this PR solve?
- Why were these changes introduced and what purpose do they serve?
- For larger changes, provide context about your approach and reasoning

Small PRs may need minimal description, but larger changes benefit from explaining where you're coming from. Much of this context can be in the linked issue above, so feel free to reference it rather than repeating everything here.
-->

### Test Procedure

<!-- 
Please walk us through your testing approach and thought process. This helps reviewers understand that you've thoroughly considered the impact of your changes:

- How did you test this change?
- What could potentially break and how did you verify it doesn't?
- What existing functionality might be affected and how did you check it still works?
- Why are you confident this is ready for merge?

We're not looking for exhaustive documentation - just evidence that you've thought through the implications of your changes and tested accordingly.
-->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [ ] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Ensure `showMessage` is awaited and simplify its usage across multiple files by removing unnecessary request creation.
> 
>   - **Behavior**:
>     - Use `await` with `getHostBridgeProvider().windowClient.showMessage` to ensure exceptions are caught and handled.
>     - Simplify `showMessage` calls by passing requests directly without `ShowMessageRequest.create({...})`.
>   - **Files Affected**:
>     - `createRuleFile.ts`, `deleteRuleFile.ts`, `index.ts` in `src/core/controller/file/`.
>     - `resetState.ts`, `updateDefaultTerminalProfile.ts` in `src/core/controller/state/`.
>     - `deleteAllTaskHistory.ts`, `deleteTasksWithIds.ts` in `src/core/controller/task/`.
>     - `index.ts` in `src/core/mentions/` and `src/core/webview/`.
>     - `tasks.ts` in `src/dev/commands/` and `extension.ts`.
>     - `showMessage.ts` in `src/hosts/vscode/hostbridge/window/`.
>     - `commit-message-generator.ts` in `src/integrations/git/`.
>     - `export-markdown.ts`, `open-file.ts`, `process-files.ts` in `src/integrations/misc/`.
>     - `McpHub.ts` in `src/services/mcp/`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 284d208770c1f6e3dc77146d6734612b0b345772. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->