### PR TITLE
fix: Preserve `taskId`after configuration changes from UI

### DIFF
--- a/.changeset/three-walls-call.md
+++ b/.changeset/three-walls-call.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+preserve taskId after configuration changes

--- a/src/core/controller/index.ts
+++ b/src/core/controller/index.ts
@@ -401,7 +401,12 @@ export class Controller {
 
 				if (this.task) {
 					const { apiConfiguration: updatedApiConfiguration } = await getAllExtensionState(this.context)
-					this.task.api = buildApiHandler(updatedApiConfiguration)
+					// Preserve the current taskId when rebuilding the API handler
+					const effectiveConfig = {
+						...updatedApiConfiguration,
+						taskId: this.task.taskId,
+					}
+					this.task.api = buildApiHandler(effectiveConfig)
 				}
 			}
 		}
@@ -479,7 +484,12 @@ export class Controller {
 			}
 
 			if (this.task) {
-				this.task.api = buildApiHandler(updatedConfig)
+				// Preserve the current taskId when rebuilding the API handler
+				const effectiveConfig = {
+					...updatedConfig,
+					taskId: this.task.taskId,
+				}
+				this.task.api = buildApiHandler(effectiveConfig)
 			}
 
 			await this.postStateToWebview()
@@ -644,9 +654,11 @@ export class Controller {
 		await storeSecret(this.context, "openRouterApiKey", apiKey)
 		await this.postStateToWebview()
 		if (this.task) {
+			// Preserve the current taskId when rebuilding the API handler
 			this.task.api = buildApiHandler({
 				apiProvider: openrouter,
 				openRouterApiKey: apiKey,
+				taskId: this.task.taskId,
 			})
 		}
 		// await this.postMessageToWebview({ type: "action", action: "settingsButtonClicked" }) // bad ux if user is on welcome

--- a/src/core/controller/models/updateApiConfigurationProto.ts
+++ b/src/core/controller/models/updateApiConfigurationProto.ts
@@ -29,7 +29,12 @@ export async function updateApiConfigurationProto(
 
 		// Update the task's API handler if there's an active task
 		if (controller.task) {
-			controller.task.api = buildApiHandler(appApiConfiguration)
+			// Preserve the current taskId when rebuilding the API handler
+			const effectiveConfig = {
+				...appApiConfiguration,
+				taskId: controller.task.taskId,
+			}
+			controller.task.api = buildApiHandler(effectiveConfig)
 		}
 
 		// Post updated state to webview

--- a/src/core/controller/state/updateSettings.ts
+++ b/src/core/controller/state/updateSettings.ts
@@ -21,7 +21,12 @@ export async function updateSettings(controller: Controller, request: UpdateSett
 			await updateApiConfiguration(controller.context, apiConfiguration)
 
 			if (controller.task) {
-				controller.task.api = buildApiHandler(apiConfiguration)
+				// Preserve the current taskId when rebuilding the API handler
+				const effectiveConfig = {
+					...apiConfiguration,
+					taskId: controller.task.taskId,
+				}
+				controller.task.api = buildApiHandler(effectiveConfig)
 			}
 		}
 


### PR DESCRIPTION
<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- Opened an issue and discussed your proposed changes with the community / contributors
- Received approval from a core Cline contributor prior to proceeding with the implementation
- Link the associated issue in the "Related Issue" section

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly.

Why this requirement?
We deeply appreciate all community contributions - they are the core reason we're able to operate successfully and keep innovating! We welcome community input and want to make it as easy as possible for people to submit quality work. This process helps our core maintainers review new ideas faster and saves contributor time by ensuring you have the go-ahead before spending time on implementation.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** https://github.com/cline/cline/issues/4998

### Description

When using Cline with LiteLLM as the provider, the `litellm_session_id` parameter is expected to always start with the prefix `cline-` (e.g., `cline-1752787916188`) to allow proper session grouping in the LiteLLM proxy. However, after changing the model or updating the LiteLLM configuration in Cline, some requests to the `/chat/completions` endpoint are sent with a session ID in UUID format (e.g., `14bcef9a-0199-4a0a-9815-b1eb3152083f`) instead of the expected `cline-...` format. This breaks session grouping and makes it difficult to track requests belonging to the same Cline session.

<!-- 
Help reviewers understand your changes by making this PR readable and well-organized:

- What problem does this PR solve?
- Why were these changes introduced and what purpose do they serve?
- For larger changes, provide context about your approach and reasoning

Small PRs may need minimal description, but larger changes benefit from explaining where you're coming from. Much of this context can be in the linked issue above, so feel free to reference it rather than repeating everything here.
-->

### Test Procedure

<!-- 
Please walk us through your testing approach and thought process. This helps reviewers understand that you've thoroughly considered the impact of your changes:

- How did you test this change?
- What could potentially break and how did you verify it doesn't?
- What existing functionality might be affected and how did you check it still works?
- Why are you confident this is ready for merge?

We're not looking for exhaustive documentation - just evidence that you've thought through the implications of your changes and tested accordingly.
-->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->
