### PR TITLE
Configure endpoint instance for dev launch task

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,6 +2,7 @@
 	// See http://go.microsoft.com/fwlink/?LinkId=827846
 	// for the documentation about the extensions.json format
 	"recommendations": [
+		"saoudrizwan.claude-dev",
 		"dbaeumer.vscode-eslint",
 		"connor4312.esbuild-problem-matchers",
 		"ms-vscode.extension-test-runner",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -14,10 +14,9 @@
 			"preLaunchTask": "${defaultBuildTask}",
 			"env": {
 				"IS_DEV": "true",
-				"DEV_WORKSPACE_FOLDER": "${workspaceFolder}"
 				// Cline API instance to connect to: "local", "staging", or "production"
-				// Default to "production"
-				// "CLINE_INSTANCE": "staging"
+				// "CLINE_INSTANCE": "staging", // default to "production" when not set
+				"DEV_WORKSPACE_FOLDER": "${workspaceFolder}"
 			}
 		},
 		{

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -15,6 +15,9 @@
 			"env": {
 				"IS_DEV": "true",
 				"DEV_WORKSPACE_FOLDER": "${workspaceFolder}"
+				// Cline API instance to connect to: "local", "staging", or "production"
+				// Default to "production"
+				// "CLINE_INSTANCE": "staging"
 			}
 		},
 		{

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,8 +51,35 @@ We also welcome contributions to our [documentation](https://github.com/cline/cl
     ```
 4. Launch by pressing `F5` (or `Run`->`Start Debugging`) to open a new VSCode window with the extension loaded. (You may need to install the [esbuild problem matchers extension](https://marketplace.visualstudio.com/items?itemName=connor4312.esbuild-problem-matchers) if you run into issues building the project.)
 
+#### Configuring API Instance for Internal Development
 
+By default, Cline connects to the production API instance. For internal development purposes, you may want to point to a different Cline API instance (staging or local).
 
+To configure the API instance:
+
+1. **Using launch configuration** (recommended): 
+   - Open `.vscode/launch.json`
+   - Uncomment and modify the `CLINE_INSTANCE` environment variable in the "Run Extension" configuration:
+     ```json
+     "env": {
+         "IS_DEV": "true",
+         "DEV_WORKSPACE_FOLDER": "${workspaceFolder}",
+         "CLINE_INSTANCE": "staging"  // or "local" or "production"
+     }
+     ```
+
+2. **Using build-time environment variable**:
+   - Set the `CLINE_INSTANCE` environment variable when building:
+     ```bash
+     CLINE_INSTANCE=staging npm run build
+     ```
+
+Available instances:
+- `"production"` (default) - Production API at `https://api.cline.bot`
+- `"staging"` - Staging API at `https://core-api.staging.int.cline.bot`
+- `"local"` - Local development API at `http://localhost:7777`
+
+You can search for `CLINE_INSTANCE` in the codebase to see how this configuration is used in `src/config.ts` and `webview-ui/src/config.ts`.
 
 ### Creating a Pull Request
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,6 @@
 export type Environment = "production" | "staging" | "local"
 
-const CURRENT_ENVIRONMENT: Environment = "production"
+const CURRENT_ENVIRONMENT: Environment = (process?.env?.CLINE_INSTANCE as Environment) || "production"
 
 interface EnvironmentConfig {
 	appBaseUrl: string

--- a/webview-ui/src/config.ts
+++ b/webview-ui/src/config.ts
@@ -1,6 +1,6 @@
 export type Environment = "production" | "staging" | "local"
 
-const CURRENT_ENVIRONMENT: Environment = "production"
+const CURRENT_ENVIRONMENT: Environment = (process?.env?.CLINE_INSTANCE as Environment) || "production"
 
 interface EnvironmentConfig {
 	appBaseUrl: string


### PR DESCRIPTION
<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- Opened an issue and discussed your proposed changes with the community / contributors
- Received approval from a core Cline contributor prior to proceeding with the implementation
- Link the associated issue in the "Related Issue" section

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly.

Why this requirement?
We deeply appreciate all community contributions - they are the core reason we're able to operate successfully and keep innovating! We welcome community input and want to make it as easy as possible for people to submit quality work. This process helps our core maintainers review new ideas faster and saves contributor time by ensuring you have the go-ahead before spending time on implementation.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** #XXXX

### Description

<!-- 
Help reviewers understand your changes by making this PR readable and well-organized:

- What problem does this PR solve?
- Why were these changes introduced and what purpose do they serve?
- For larger changes, provide context about your approach and reasoning

Small PRs may need minimal description, but larger changes benefit from explaining where you're coming from. Much of this context can be in the linked issue above, so feel free to reference it rather than repeating everything here.
-->

Adding the ability to configure the application environment (production, staging, or local) using the `CLINE_INSTANCE` environment variable:
    
    - Modified `src/config.ts` and `webview-ui/src/config.ts` to read the `CLINE_INSTANCE` environment variable and set the `CURRENT_ENVIRONMENT` accordingly. If the variable is not set, it defaults to "production".
    - Updated `.vscode/launch.json` to include `CLINE_INSTANCE` with a default value of "staging" for development purposes. This allows developers to easily switch between environments during development.
    - Adding usage example to launch.json

### Test Procedure

<!-- 
Please walk us through your testing approach and thought process. This helps reviewers understand that you've thoroughly considered the impact of your changes:

- How did you test this change?
- What could potentially break and how did you verify it doesn't?
- What existing functionality might be affected and how did you check it still works?
- Why are you confident this is ready for merge?

We're not looking for exhaustive documentation - just evidence that you've thought through the implications of your changes and tested accordingly.
-->

1. Uncomment line 18 in .vscode/launch.json that would point to staging
2. Start Debugger or use F5 to start
3. You should see the welcome page where sign in click takes you to the staging instance 
4. rest of the implementation unchanged


<img width="403" height="374" alt="image" src="https://github.com/user-attachments/assets/292c2821-d44c-42c8-82b6-28a65151c145" />


### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [x] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Configure environment using `CLINE_INSTANCE` in `src/config.ts` and `webview-ui/src/config.ts`, with `.vscode/launch.json` updates for development.
> 
>   - **Environment Configuration**:
>     - `src/config.ts` and `webview-ui/src/config.ts` now use `CLINE_INSTANCE` to set `CURRENT_ENVIRONMENT`.
>     - Defaults to "production" if `CLINE_INSTANCE` is not set.
>   - **Development Setup**:
>     - `.vscode/launch.json` updated to include `CLINE_INSTANCE` with default "staging" for development.
>     - Added instructions in `CONTRIBUTING.md` for configuring API instance using `CLINE_INSTANCE`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 31575a1b313b4a684594c71cd1b294f074966114. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->