### PR TITLE
Move save() and getDocument() to the platform specific diff classes

### DIFF
--- a/haiku.txt
+++ b/haiku.txt
@@ -1,7 +1,0 @@
-Summer leaves dancing
-Gentle breeze carries whispers
-Time stands still, peaceful
-
-Fireflies glowing
-Tiny lanterns in twilight
-Magic fills the air

--- a/haiku.txt
+++ b/haiku.txt
@@ -1,0 +1,7 @@
+Summer leaves dancing
+Gentle breeze carries whispers
+Time stands still, peaceful
+
+Fireflies glowing
+Tiny lanterns in twilight
+Magic fills the air

--- a/proto/host/diff.proto
+++ b/proto/host/diff.proto
@@ -10,6 +10,8 @@ import "common.proto";
 service DiffService {
   // Open the diff view/editor.
   rpc openDiff(OpenDiffRequest) returns (OpenDiffResponse);
+  // Get the contents of the diff view.
+  rpc getDocumentText(GetDocumentTextRequest) returns (GetDocumentTextResponse);
   // Replace a text selection in the diff.
   rpc replaceText(ReplaceTextRequest) returns (ReplaceTextResponse);
   // Truncate the diff document.
@@ -31,6 +33,15 @@ message OpenDiffRequest {
 message OpenDiffResponse {
   // A unique identifier for the diff view that was opened.
   optional string diff_id = 1;
+}
+
+message GetDocumentTextRequest {
+  optional cline.Metadata metadata = 1;
+  optional string diff_id = 2;
+}
+
+message GetDocumentTextResponse {
+    optional string content = 1;
 }
 
 message ReplaceTextRequest {

--- a/src/core/task/ToolExecutor.ts
+++ b/src/core/task/ToolExecutor.ts
@@ -634,7 +634,7 @@ export class ToolExecutor {
 						}
 						await this.diffViewProvider.update(newContent, true)
 						await setTimeoutPromise(300) // wait for diff view to update
-						this.diffViewProvider.scrollToFirstDiff()
+						await this.diffViewProvider.scrollToFirstDiff()
 						// showOmissionWarning(this.diffViewProvider.originalContent || "", newContent)
 
 						const completeMessage = JSON.stringify({

--- a/src/hosts/vscode/hostbridge/diff/getDocumentText.ts
+++ b/src/hosts/vscode/hostbridge/diff/getDocumentText.ts
@@ -1,0 +1,5 @@
+import { GetDocumentTextRequest, GetDocumentTextResponse } from "@/shared/proto/index.host"
+
+export async function getDocumentText(_request: GetDocumentTextRequest): Promise<GetDocumentTextResponse> {
+	throw new Error("diffService is not supported. Use the VscodeDiffViewProvider.")
+}

--- a/src/hosts/vscode/hostbridge/diff/saveDocument.ts
+++ b/src/hosts/vscode/hostbridge/diff/saveDocument.ts
@@ -1,4 +1,4 @@
-import { ReplaceTextRequest, ReplaceTextResponse, SaveDocumentRequest, SaveDocumentResponse } from "@/shared/proto/index.host"
+import { SaveDocumentRequest, SaveDocumentResponse } from "@/shared/proto/index.host"
 
 export async function saveDocument(_request: SaveDocumentRequest): Promise<SaveDocumentResponse> {
 	throw new Error("diffService is not supported. Use the VscodeDiffViewProvider.")

--- a/src/integrations/editor/DiffViewProvider.ts
+++ b/src/integrations/editor/DiffViewProvider.ts
@@ -308,7 +308,7 @@ export abstract class DiffViewProvider {
 		const fileExists = this.editType === "modify"
 
 		if (!fileExists) {
-			this.saveDocument()
+			await this.saveDocument()
 			await this.closeDiffView()
 			await fs.unlink(this.absolutePath)
 			// Remove only the directories we created, in reverse order

--- a/src/integrations/editor/DiffViewProvider.ts
+++ b/src/integrations/editor/DiffViewProvider.ts
@@ -229,7 +229,7 @@ export abstract class DiffViewProvider {
 			}
 		}
 
-		this.saveDocument()
+		await this.saveDocument()
 		// get text after save in case there is any auto-formatting done by the editor
 		const postSaveContent = (await this.getDocumentText()) || ""
 

--- a/src/integrations/misc/open-file.ts
+++ b/src/integrations/misc/open-file.ts
@@ -3,7 +3,7 @@ import * as os from "os"
 import * as vscode from "vscode"
 import { arePathsEqual } from "@utils/path"
 import { getHostBridgeProvider } from "@/hosts/host-providers"
-import { ShowTextDocumentRequest, ShowTextDocumentOptions, ShowMessageRequest, ShowMessageType } from "@/shared/proto/host/window"
+import { ShowMessageRequest, ShowMessageType } from "@/shared/proto/host/window"
 import { writeFile } from "@utils/fs"
 
 export async function openImage(dataUri: string) {

--- a/src/standalone/ExternalDiffviewProvider.ts
+++ b/src/standalone/ExternalDiffviewProvider.ts
@@ -54,6 +54,9 @@ export class ExternalDiffViewProvider extends DiffViewProvider {
 	}
 
 	protected override async getDocumentText(): Promise<string | undefined> {
+		if (!this.activeDiffEditorId) {
+			return undefined
+		}
 		return (await getHostBridgeProvider().diffClient.getDocumentText({ diffId: this.activeDiffEditorId })).content
 	}
 

--- a/src/standalone/ExternalDiffviewProvider.ts
+++ b/src/standalone/ExternalDiffviewProvider.ts
@@ -18,11 +18,8 @@ export class ExternalDiffViewProvider extends DiffViewProvider {
 	override async replaceText(
 		content: string,
 		rangeToReplace: { startLine: number; endLine: number },
-		_currentLine: number,
+		_currentLine: number | undefined,
 	): Promise<void> {
-		if (!this.activeDiffEditor) {
-			return
-		}
 		await getHostBridgeProvider().diffClient.replaceText({
 			diffId: this.activeDiffEditorId,
 			content: content,
@@ -32,7 +29,7 @@ export class ExternalDiffViewProvider extends DiffViewProvider {
 	}
 
 	protected override async truncateDocument(lineNumber: number): Promise<void> {
-		if (!this.activeDiffEditor) {
+		if (!this.activeDiffEditorId) {
 			return
 		}
 		await getHostBridgeProvider().diffClient.truncateDocument({
@@ -42,7 +39,7 @@ export class ExternalDiffViewProvider extends DiffViewProvider {
 	}
 
 	protected async saveDocument(): Promise<void> {
-		if (!this.activeDiffEditor) {
+		if (!this.activeDiffEditorId) {
 			return
 		}
 		await getHostBridgeProvider().diffClient.saveDocument({ diffId: this.activeDiffEditorId })
@@ -55,8 +52,13 @@ export class ExternalDiffViewProvider extends DiffViewProvider {
 	override async scrollAnimation(startLine: number, endLine: number): Promise<void> {
 		console.log(`Called ExternalDiffViewProvider.scrollAnimation(${startLine}, ${endLine}) stub`)
 	}
+
+	protected override async getDocumentText(): Promise<string | undefined> {
+		return (await getHostBridgeProvider().diffClient.getDocumentText({ diffId: this.activeDiffEditorId })).content
+	}
+
 	protected override async closeDiffView(): Promise<void> {
-		if (!this.activeDiffEditor) {
+		if (!this.activeDiffEditorId) {
 			return
 		}
 		await getHostBridgeProvider().diffClient.closeDiff({ diffId: this.activeDiffEditorId })


### PR DESCRIPTION
Move logic to save the diff document and get the diff content to the platform specific diff view providers.

Add getDocumentText to the HostBridge diff service.

The ExternalDiffViewProvider should be using its activeDiffEditorId (not the activeDiffEditor, which is the vscode Editor object)

<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- Opened an issue and discussed your proposed changes with the community / contributors
- Received approval from a core Cline contributor prior to proceeding with the implementation
- Link the associated issue in the "Related Issue" section

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly.

Why this requirement?
We deeply appreciate all community contributions - they are the core reason we're able to operate successfully and keep innovating! We welcome community input and want to make it as easy as possible for people to submit quality work. This process helps our core maintainers review new ideas faster and saves contributor time by ensuring you have the go-ahead before spending time on implementation.
-->

 

<!-- 
Help reviewers understand your changes by making this PR readable and well-organized:

- What problem does this PR solve?
- Why were these changes introduced and what purpose do they serve?
- For larger changes, provide context about your approach and reasoning

Small PRs may need minimal description, but larger changes benefit from explaining where you're coming from. Much of this context can be in the linked issue above, so feel free to reference it rather than repeating everything here.
-->

### Test Procedure

Tested manually in the vscode extension host.

<!-- 
Please walk us through your testing approach and thought process. This helps reviewers understand that you've thoroughly considered the impact of your changes:

- How did you test this change?
- What could potentially break and how did you verify it doesn't?
- What existing functionality might be affected and how did you check it still works?
- Why are you confident this is ready for merge?

We're not looking for exhaustive documentation - just evidence that you've thought through the implications of your changes and tested accordingly.
-->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [ ] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Move `save()` and `getDocument()` to platform-specific diff classes and add `getDocumentText` to `DiffService`.
> 
>   - **Behavior**:
>     - Move `save()` and `getDocument()` logic to platform-specific diff view providers in `VscodeDiffViewProvider.ts` and `ExternalDiffViewProvider.ts`.
>     - `ExternalDiffViewProvider` now uses `activeDiffEditorId` instead of `activeDiffEditor`.
>   - **DiffService**:
>     - Add `getDocumentText` method to `DiffService` in `proto/host/diff.proto`.
>   - **Functions**:
>     - Implement `getDocumentText()` and `saveDocument()` in `VscodeDiffViewProvider.ts` and `ExternalDiffViewProvider.ts`.
>     - Update `replaceText()` in `VscodeDiffViewProvider.ts` to handle `currentLine` as optional.
>   - **Misc**:
>     - Minor update in `ToolExecutor.ts` to await `scrollToFirstDiff()`.
>     - Remove unused imports in `open-file.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 9d884a704b5f02b1ae34959bf6c9452d9d8da614. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->