### PR TITLE
Robust Checkpoints timeout, error handling

### DIFF
--- a/.changeset/many-ligers-beam.md
+++ b/.changeset/many-ligers-beam.md
@@ -1,0 +1,8 @@
+---
+"claude-dev": patch
+---
+
+Added checkpointTrackerErrorMessage to HistoryItem - restored with task, prevents re-initialization if timed out before
+Never re-init checkpoint tracker if it timed out before
+Warning at 7s that it's taking awhile, timeout and give up at 15s
+Fixed click to open settings - now opens to correct tab

--- a/src/core/task/index.ts
+++ b/src/core/task/index.ts
@@ -2064,12 +2064,12 @@ export class Task {
 		) {
 			try {
 				// Warning Timer - If checkpoints take a while to to initialize, show a warning message
-				let warningTimer: NodeJS.Timeout | null = null
-				let warningShown = false
+				let checkpointsWarningTimer: NodeJS.Timeout | null = null
+				let checkpointsWarningShown = false
 
-				warningTimer = setTimeout(async () => {
-					if (!warningShown) {
-						warningShown = true
+				checkpointsWarningTimer = setTimeout(async () => {
+					if (!checkpointsWarningShown) {
+						checkpointsWarningShown = true
 						this.taskState.checkpointTrackerErrorMessage =
 							"Checkpoints are taking longer than expected to initialize. Working in a large repository? Consider re-opening Cline in a project that uses git, or disabling checkpoints."
 						await this.postStateToWebview()

--- a/src/core/task/index.ts
+++ b/src/core/task/index.ts
@@ -2085,6 +2085,10 @@ export class Task {
 							"Checkpoints taking too long to initialize. Consider re-opening Cline in a project that uses git, or disabling checkpoints.",
 					},
 				)
+				if (checkpointsWarningTimer) {
+					clearTimeout(checkpointsWarningTimer)
+					checkpointsWarningTimer = null
+				}
 			} catch (error) {
 				const errorMessage = error instanceof Error ? error.message : "Unknown error"
 				console.error("Failed to initialize checkpoint tracker:", errorMessage)

--- a/src/core/task/index.ts
+++ b/src/core/task/index.ts
@@ -2063,7 +2063,7 @@ export class Task {
 			!this.taskState.checkpointTrackerErrorMessage
 		) {
 			try {
-				// Set up a warning timer for 7 seconds
+				// Warning Timer - If checkpoints take a while to to initialize, show a warning message
 				let warningTimer: NodeJS.Timeout | null = null
 				let warningShown = false
 
@@ -2076,6 +2076,7 @@ export class Task {
 					}
 				}, 7_000)
 
+				// Timeout - If checkpoints take too long to initialize, warn user and disable checkpoints for the task
 				this.checkpointTracker = await pTimeout(
 					CheckpointTracker.create(this.taskId, this.context.globalStorageUri.fsPath, this.enableCheckpoints),
 					{

--- a/src/core/task/message-state.ts
+++ b/src/core/task/message-state.ts
@@ -20,6 +20,7 @@ interface MessageStateHandlerParams {
 	taskIsFavorited?: boolean
 	updateTaskHistory: (historyItem: HistoryItem) => Promise<HistoryItem[]>
 	taskState: TaskState
+	checkpointTrackerErrorMessage?: string
 }
 
 export class MessageStateHandler {
@@ -27,6 +28,7 @@ export class MessageStateHandler {
 	private clineMessages: ClineMessage[] = []
 	private taskIsFavorited: boolean
 	private checkpointTracker: CheckpointTracker | undefined
+	private checkpointTrackerErrorMessage: string | undefined
 	private updateTaskHistory: (historyItem: HistoryItem) => Promise<HistoryItem[]>
 	private context: vscode.ExtensionContext
 	private taskId: string
@@ -38,6 +40,7 @@ export class MessageStateHandler {
 		this.taskState = params.taskState
 		this.taskIsFavorited = params.taskIsFavorited ?? false
 		this.updateTaskHistory = params.updateTaskHistory
+		this.checkpointTrackerErrorMessage = this.taskState.checkpointTrackerErrorMessage
 	}
 
 	setCheckpointTracker(tracker: CheckpointTracker | undefined) {
@@ -98,6 +101,7 @@ export class MessageStateHandler {
 				cwdOnTaskInitialization: cwd,
 				conversationHistoryDeletedRange: this.taskState.conversationHistoryDeletedRange,
 				isFavorited: this.taskIsFavorited,
+				checkpointTrackerErrorMessage: this.taskState.checkpointTrackerErrorMessage,
 			})
 		} catch (error) {
 			console.error("Failed to save cline messages:", error)

--- a/src/integrations/checkpoints/CheckpointTracker.ts
+++ b/src/integrations/checkpoints/CheckpointTracker.ts
@@ -1,7 +1,6 @@
 import fs from "fs/promises"
 import * as path from "path"
 import simpleGit from "simple-git"
-import * as vscode from "vscode"
 import { telemetryService } from "@/services/posthog/telemetry/TelemetryService"
 import { GitOperations } from "./CheckpointGitOperations"
 import { getShadowGitPath, getWorkingDirectory, hashWorkingDir } from "./CheckpointUtils"

--- a/src/shared/HistoryItem.ts
+++ b/src/shared/HistoryItem.ts
@@ -13,4 +13,5 @@ export type HistoryItem = {
 	cwdOnTaskInitialization?: string
 	conversationHistoryDeletedRange?: [number, number]
 	isFavorited?: boolean
+	checkpointTrackerErrorMessage?: string
 }

--- a/webview-ui/src/components/settings/SettingsView.tsx
+++ b/webview-ui/src/components/settings/SettingsView.tsx
@@ -111,7 +111,7 @@ const SettingsView = ({ onDone, targetSection }: SettingsViewProps) => {
 		switch (message.type) {
 			// Handle tab navigation through targetSection prop instead
 			case "grpc_response":
-				if (message.grpc_response?.message?.action === "scrollToSettings") {
+				if (message.grpc_response?.message?.key === "scrollToSettings") {
 					const tabId = message.grpc_response?.message?.value
 					if (tabId) {
 						console.log("Opening settings tab from GRPC response:", tabId)


### PR DESCRIPTION
<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- Opened an issue and discussed your proposed changes with the community / contributors
- Received approval from a core Cline contributor prior to proceeding with the implementation
- Link the associated issue in the "Related Issue" section

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly.

Why this requirement?
We deeply appreciate all community contributions - they are the core reason we're able to operate successfully and keep innovating! We welcome community input and want to make it as easy as possible for people to submit quality work. This process helps our core maintainers review new ideas faster and saves contributor time by ensuring you have the go-ahead before spending time on implementation.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** #XXXX

### Description

This PR improves checkpoint initialization by expanding to a two-stage timeout mechanism and preventing redundant initialization attempts. When checkpoints take longer than expected to initialize, users now receive an early warning at 7 seconds, followed by a hard timeout at 15 seconds that disables checkpoints for the remainder of the task. The timeout state is persisted in both TaskState and HistoryItem, ensuring that checkpoints won't be re-initialized on subsequent operations or task restorations if they previously failed due to timeout. This also corrects the settings navigation link to properly open the features tab when these warnings are displayed.

Future improvements:
- When we abort the checkpoints initialization at 15 seconds, the git command still continues in the background and creates a checkpoints shadow git repository. It would be nice if we could abort/kill this process and cleanup the shadow repo.
- Feature to disable checkpoints for a repository.
- Remember which repositories encounter the 15 second timeout, and perhaps auto-disable checkpoints for these.
- Typed error messages for checkpoints

### Test Procedure

Ensure checkpoints are enabled in settings. Start a new task in a large repository that you have not used Cline in before. [gecko-dev](https://github.com/mozilla/gecko-dev) is a good one to test with. After 7 seconds, a warning should appear. After 15 seconds, the warning will update to inform users that checkpoints have timed out and will not be available.

Resume the task after it has completed and ensure it does not hang. Switch to another task, then back to the first task, then resume the task and ensure it does not hang.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [X] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [X] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [X] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [X] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [X] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots


https://github.com/user-attachments/assets/852f1e7a-c916-49f9-9880-dca80a7d6c83



### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Introduces robust timeout and error handling for checkpoint initialization in tasks, preventing re-initialization on timeout and fixing settings navigation.
> 
>   - **Behavior**:
>     - Implements a two-stage timeout for checkpoint initialization in `Task` class: warning at 7s, timeout at 15s.
>     - Prevents re-initialization of checkpoints if they previously timed out, using `checkpointTrackerErrorMessage` in `TaskState` and `HistoryItem`.
>     - Fixes settings navigation to open the correct tab in `SettingsView.tsx`.
>   - **State Management**:
>     - Adds `checkpointTrackerErrorMessage` to `HistoryItem` and `TaskState` to track timeout errors.
>     - Updates `MessageStateHandler` to handle `checkpointTrackerErrorMessage`.
>   - **Files and Classes**:
>     - Modifies `Task` class in `index.ts` to handle checkpoint timeouts and error messages.
>     - Updates `CheckpointTracker` in `CheckpointTracker.ts` to support new timeout logic.
>     - Adjusts `SettingsView.tsx` to fix tab navigation issue.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 65ef11d6ffe0d5e2254037b49adb810012d70ba8. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->