### PR TITLE
Use `--system-prompt-file` to pass the system prompt to Claude Code

### DIFF
--- a/.changeset/popular-flies-explode.md
+++ b/.changeset/popular-flies-explode.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Introduce Claude Code support on Windows and fix E2BIG issues

--- a/docs/provider-config/claude-code.mdx
+++ b/docs/provider-config/claude-code.mdx
@@ -35,26 +35,8 @@ First, you'll need to install and authenticate Claude Code on your system:
 <br />
 
 <Accordion title="Windows Setup">
-On Windows, Cline supports integrating with Claude Code through WSL.
-Windows doesn't support long commands, and Claude Code only accepts the system prompt through a flag, which means we can't properly prompt Claude through Claude Code. Anthropic is [working on a workaround to streamline this](https://github.com/anthropics/claude-code/issues/3411).
-
-1. **Make sure you have WSL set-up**. You can follow [this](https://code.visualstudio.com/docs/remote/wsl#_installation) guide to do it.
-
-2. **Open VSCode from WSL** and verify it's properly set-up. You should see an indicator in the bottom left that says "WSL". You can find an image of the indicator [here](https://code.visualstudio.com/docs/remote/wsl#_from-the-wsl-terminal).
-
-3. Install Cline within WSL and make sure it shows the following:
-
-<Frame>
-	<img
-		src="https://storage.googleapis.com/cline_public_images/docs/assets/cline_wsl_installed_extension.webp"
-		alt="Indicator that an extension is installed on WSL"
-	/>
-</Frame>
-
-4. Clone or [move](https://stackoverflow.com/a/42586455) your project over to WSL
-
-5. Follow the [instructions on how to set up Claude Code normally](#setup), but from the WSL terminal.
-
+	Anthropic introduced full support for Claude Code on Windows. Follow the [instructions on how to set up Claude
+	Codenormally](#setup) and make sure you have the latest Claude Code and Cline versions.
 </Accordion>
 
 ### Finding your Claude Code path

--- a/docs/provider-config/claude-code.mdx
+++ b/docs/provider-config/claude-code.mdx
@@ -35,8 +35,8 @@ First, you'll need to install and authenticate Claude Code on your system:
 <br />
 
 <Accordion title="Windows Setup">
-	Anthropic introduced full support for Claude Code on Windows. Follow the [instructions on how to set up Claude
-	Codenormally](#setup) and make sure you have the latest Claude Code and Cline versions.
+	Anthropic introduced full support for Claude Code on Windows. Follow the [instructions on how to set up Claude Code
+	normally](#setup) and make sure you have the latest Claude Code and Cline versions.
 </Accordion>
 
 ### Finding your Claude Code path

--- a/src/integrations/claude-code/run.test.ts
+++ b/src/integrations/claude-code/run.test.ts
@@ -1,0 +1,163 @@
+import { expect } from "chai"
+import proxyquire from "proxyquire"
+import path from "path"
+import sinon from "sinon"
+
+const createMockProcess = () => {
+	const mockProcess = {
+		stdin: {
+			write: sinon.fake(),
+			end: sinon.fake(),
+		},
+		stdout: {
+			on: sinon.fake(),
+			resume: sinon.fake(),
+		},
+		stderr: {
+			on: sinon.fake(() => {}),
+		},
+		on: sinon.fake((event, callback) => {
+			if (event === "close") {
+				setImmediate(() => callback(0))
+			}
+			if (event === "error") {
+			}
+		}),
+		killed: false,
+		kill: sinon.fake(),
+		exitCode: 0,
+		then: (onResolve: (value: any) => void) => {
+			setImmediate(() => onResolve({ exitCode: 0 }))
+			return Promise.resolve({ exitCode: 0 })
+		},
+		catch: () => Promise.resolve({ exitCode: 0 }),
+		finally: (callback: () => void) => {
+			setImmediate(callback)
+			return Promise.resolve({ exitCode: 0 })
+		},
+	}
+	return mockProcess
+}
+
+const createMockReadlineInterface = () => {
+	const mockInterface = {
+		async *[Symbol.asyncIterator]() {
+			// Simulate Claude CLI JSON output - yield a few chunks then end
+			yield '{"type":"text","text":"Hello"}'
+			yield '{"type":"text","text":" world"}'
+			// Iterator ends naturally when function returns
+			return
+		},
+		close: sinon.fake(),
+	}
+	return mockInterface
+}
+
+const mockExeca = sinon.fake((...args) => {
+	return createMockProcess()
+})
+
+let os = "darwin"
+
+const { MAX_SYSTEM_PROMPT_LENGTH, runClaudeCode } = proxyquire("./run", {
+	"@/utils/path": {
+		getCwd: () => Promise.resolve(path.resolve("./")),
+	},
+	"node:os": {
+		platform: () => os,
+	},
+	execa: {
+		execa: mockExeca,
+	},
+	readline: {
+		createInterface: createMockReadlineInterface,
+	},
+})
+
+describe("Claude Code Integration", () => {
+	const scriptPath = "echo"
+
+	afterEach(() => {
+		sinon.restore()
+	})
+
+	const itCallsTheScriptWithAFile = (systemPrompt: string) => {
+		it("calls the script using with a file", async () => {
+			const cProcess = runClaudeCode({
+				systemPrompt,
+				messages: [],
+				modelId: "test",
+				path: scriptPath,
+			})
+
+			const chunks: string[] = []
+			for await (const chunk of cProcess) {
+				chunks.push(chunk)
+			}
+
+			expect(chunks).to.have.length(2)
+
+			const lastExecaCall = mockExeca.lastCall
+			const params = lastExecaCall.args[1]
+			expect(params).to.not.be.null
+			expect(params.includes("--system-prompt-file")).to.be.true
+			expect(params.includes("--system-prompt")).to.be.false
+		})
+	}
+
+	describe("when it's running on Windows", () => {
+		beforeEach(() => {
+			os = "win32"
+		})
+
+		describe("when the system prompt is longer than the MAX_SYSTEM_PROMPT_LENGTH", () => {
+			const SYSTEM_PROMPT = "a".repeat(MAX_SYSTEM_PROMPT_LENGTH * 1.2)
+
+			itCallsTheScriptWithAFile(SYSTEM_PROMPT)
+		})
+
+		describe("when the system prompt is shorter than the MAX_SYSTEM_PROMPT_LENGTH", () => {
+			const SYSTEM_PROMPT = "a".repeat(MAX_SYSTEM_PROMPT_LENGTH / 2)
+
+			itCallsTheScriptWithAFile(SYSTEM_PROMPT)
+		})
+	})
+
+	describe("when it's not running on Windows", () => {
+		beforeEach(() => {
+			os = "darwin"
+		})
+
+		describe("when the system prompt is longer than the MAX_SYSTEM_PROMPT_LENGTH", () => {
+			const SYSTEM_PROMPT = "a".repeat(MAX_SYSTEM_PROMPT_LENGTH * 1.2)
+
+			itCallsTheScriptWithAFile(SYSTEM_PROMPT)
+		})
+
+		describe("when the system prompt is shorter than the MAX_SYSTEM_PROMPT_LENGTH", () => {
+			const SYSTEM_PROMPT = "a".repeat(MAX_SYSTEM_PROMPT_LENGTH / 2)
+
+			it("calls the script without a file", async () => {
+				const cProcess = runClaudeCode({
+					systemPrompt: SYSTEM_PROMPT,
+					messages: [],
+					modelId: "test",
+					path: scriptPath,
+				})
+
+				const chunks: string[] = []
+				for await (const chunk of cProcess) {
+					chunks.push(chunk)
+				}
+
+				expect(chunks).to.have.length(2)
+
+				const lastExecaCall = mockExeca.lastCall
+				const params = lastExecaCall.args[1]
+				expect(params).to.not.be.null
+				expect(params.includes("--system-prompt-file")).to.be.false
+				expect(params.includes("--system-prompt")).to.be.true
+			})
+		})
+	})
+})

--- a/src/integrations/claude-code/run.ts
+++ b/src/integrations/claude-code/run.ts
@@ -30,8 +30,9 @@ export const MAX_SYSTEM_PROMPT_LENGTH = 65536
 
 export async function* runClaudeCode(options: ClaudeCodeOptions): AsyncGenerator<ClaudeCodeMessage | string> {
 	const isSystemPromptTooLong = options.systemPrompt.length > MAX_SYSTEM_PROMPT_LENGTH
+	const uniqueId = crypto.randomUUID().slice(0, 8)
+	const tempFilePath = path.join(os.tmpdir(), `cline-system-prompt-${uniqueId}.txt`)
 	if (os.platform() === "win32" || isSystemPromptTooLong) {
-		const tempFilePath = path.join(os.tmpdir(), `cline-system-prompt-cc.txt`)
 		// Use a temporary file to prevent ENAMETOOLONG and E2BIG errors
 		// https://github.com/anthropics/claude-code/issues/3411#issuecomment-3082068547
 		await fs.writeFile(tempFilePath, options.systemPrompt, "utf8")
@@ -148,6 +149,8 @@ Anthropic is aware of this issue and is considering a fix: https://github.com/an
 		if (!cProcess.killed) {
 			cProcess.kill()
 		}
+
+		fs.unlink(tempFilePath).catch(console.error)
 	}
 }
 


### PR DESCRIPTION
### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** #4480

### Description

Anthropic recently released a new Claude Code version that supports [using a file to pass the system prompt](https://github.com/anthropics/claude-code/issues/3411#issuecomment-3082068547). 
This PR replaces the current implementation to write a file and use the new flag if the system prompt is too long or it's being executed on Windows.

### Test Procedure

Tested on Windows and MacOS.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [ ] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Use `--system-prompt-file` for long prompts or on Windows in Claude Code to avoid errors, with updated tests and documentation.
> 
>   - **Behavior**:
>     - Use `--system-prompt-file` in `run.ts` for long system prompts or on Windows to avoid `ENAMETOOLONG` and `E2BIG` errors.
>     - If `--system-prompt-file` is unsupported, an error is thrown.
>   - **Testing**:
>     - Added tests in `run.test.ts` to verify behavior on Windows and non-Windows systems with varying prompt lengths.
>   - **Documentation**:
>     - Updated `claude-code.mdx` to reflect new Windows support and setup instructions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 4e98abd4eb4d35d22563394c26663c84f776b83c. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->