### PR TITLE
Improve HostBridge error handling and logging robustness

### DIFF
--- a/src/core/controller/account/accountLoginClicked.ts
+++ b/src/core/controller/account/accountLoginClicked.ts
@@ -1,7 +1,6 @@
 import { Controller } from "../index"
 import { AuthService } from "@/services/auth/AuthService"
 import { EmptyRequest, String } from "../../../shared/proto/common"
-import { openExternal } from "@utils/env"
 
 const authService = AuthService.getInstance()
 
@@ -13,6 +12,6 @@ const authService = AuthService.getInstance()
  * @param controller The controller instance.
  * @returns The login URL as a string.
  */
-export async function accountLoginClicked(controller: Controller, _: EmptyRequest): Promise<String> {
+export async function accountLoginClicked(_controller: Controller, _: EmptyRequest): Promise<String> {
 	return await authService.createAuthRequest()
 }

--- a/src/core/controller/checkpoints/checkpointRestore.ts
+++ b/src/core/controller/checkpoints/checkpointRestore.ts
@@ -1,8 +1,10 @@
+import { getHostBridgeProvider } from "@/hosts/host-providers"
 import { Controller } from ".."
 import { ClineCheckpointRestore } from "../../../shared/WebviewMessage"
 import { CheckpointRestoreRequest } from "../../../shared/proto/checkpoints"
 import { Empty } from "../../../shared/proto/common"
 import pWaitFor from "p-wait-for"
+import { ShowMessageType } from "@/shared/proto/index.host"
 
 export async function checkpointRestore(controller: Controller, request: CheckpointRestoreRequest): Promise<Empty> {
 	await controller.cancelTask() // we cannot alter message history say if the task is active, as it could be in the middle of editing a file or running a command, which expect the ask to be responded to rather than being superseded by a new message eg add deleted_api_reqs
@@ -11,8 +13,13 @@ export async function checkpointRestore(controller: Controller, request: Checkpo
 		// wait for messages to be loaded
 		await pWaitFor(() => controller.task?.taskState.isInitialized === true, {
 			timeout: 3_000,
-		}).catch(() => {
-			console.error("Failed to init new cline instance")
+		}).catch((error) => {
+			console.log("Failed to init new Cline instance to restore checkpoint", error)
+			getHostBridgeProvider().windowClient.showMessage({
+				type: ShowMessageType.ERROR,
+				message: "Failed to restore checkpoint",
+			})
+			throw error
 		})
 
 		// NOTE: cancelTask awaits abortTask, which awaits diffViewProvider.revertChanges, which reverts any edited files, allowing us to reset to a checkpoint rather than running into a state where the revertChanges function is called alongside or after the checkpoint reset

--- a/src/core/controller/file/copyToClipboard.ts
+++ b/src/core/controller/file/copyToClipboard.ts
@@ -1,6 +1,5 @@
-import * as vscode from "vscode"
 import { Controller } from ".."
-import { Empty, StringRequest } from "../../../shared/proto/common"
+import { Empty, StringRequest } from "@shared/proto/common"
 import { writeTextToClipboard } from "@/utils/env"
 
 /**
@@ -9,7 +8,7 @@ import { writeTextToClipboard } from "@/utils/env"
  * @param request The request containing the text to copy
  * @returns Empty response
  */
-export async function copyToClipboard(controller: Controller, request: StringRequest): Promise<Empty> {
+export async function copyToClipboard(_controller: Controller, request: StringRequest): Promise<Empty> {
 	try {
 		if (request.value) {
 			await writeTextToClipboard(request.value)

--- a/src/core/task/index.ts
+++ b/src/core/task/index.ts
@@ -4,8 +4,9 @@ import { AnthropicHandler } from "@api/providers/anthropic"
 import { ClineHandler } from "@api/providers/cline"
 import { OpenRouterHandler } from "@api/providers/openrouter"
 import { ApiStream } from "@api/transform/stream"
+import { DIFF_VIEW_URI_SCHEME } from "@hosts/vscode/VscodeDiffViewProvider"
 import CheckpointTracker from "@integrations/checkpoints/CheckpointTracker"
-import { DIFF_VIEW_URI_SCHEME, DiffViewProvider } from "@integrations/editor/DiffViewProvider"
+import { DiffViewProvider } from "@integrations/editor/DiffViewProvider"
 import { formatContentBlockToMarkdown } from "@integrations/misc/export-markdown"
 import { showSystemNotification } from "@integrations/notifications"
 import { TerminalManager } from "@integrations/terminal/TerminalManager"
@@ -36,6 +37,9 @@ import pWaitFor from "p-wait-for"
 import * as path from "path"
 import * as vscode from "vscode"
 
+import { createDiffViewProvider } from "@/hosts/host-providers"
+import { ClineErrorType } from "@/services/error/ClineError"
+import { ErrorService } from "@/services/error/ErrorService"
 import { parseAssistantMessageV2, parseAssistantMessageV3, ToolUseName } from "@core/assistant-message"
 import {
 	checkIsAnthropicContextWindowError,
@@ -82,9 +86,6 @@ import { MessageStateHandler } from "./message-state"
 import { TaskState } from "./TaskState"
 import { ToolExecutor } from "./ToolExecutor"
 import { updateApiReqMsg } from "./utils"
-import { createDiffViewProvider } from "@/hosts/host-providers"
-import { ErrorService } from "@/services/error/ErrorService"
-import { ClineErrorType } from "@/services/error/ClineError"
 export const USE_EXPERIMENTAL_CLAUDE4_FEATURES = false
 
 export type ToolResponse = string | Array<Anthropic.TextBlockParam | Anthropic.ImageBlockParam>
@@ -1433,7 +1434,7 @@ export class Task {
 			Logger.info("Executing command in Node: " + command)
 			return this.executeCommandInNode(command)
 		}
-		Logger.info("Executing command in VS code terminal: " + command)
+		Logger.info("Executing command in terminal: " + command)
 
 		const terminalInfo = await this.terminalManager.getOrCreateTerminal(this.cwd)
 		terminalInfo.terminal.show() // weird visual bug when creating new terminals (even manually) where there's an empty space at the top.

--- a/src/core/task/index.ts
+++ b/src/core/task/index.ts
@@ -828,7 +828,6 @@ export class Task {
 		await pWaitFor(() => this.taskState.askResponse !== undefined || this.taskState.lastMessageTs !== askTs, {
 			interval: 100,
 		})
-
 		if (this.taskState.lastMessageTs !== askTs) {
 			throw new Error("Current ask promise was ignored") // could happen if we send multiple asks in a row i.e. with command_output. It's important that when we know an ask could fail, it is handled gracefully
 		}

--- a/src/core/task/index.ts
+++ b/src/core/task/index.ts
@@ -726,7 +726,7 @@ export class Task {
 	}> {
 		// If this Cline instance was aborted by the provider, then the only thing keeping us alive is a promise still running in the background, in which case we don't want to send its result to the webview as it is attached to a new instance of Cline now. So we can safely ignore the result of any active promises, and this class will be deallocated. (Although we set Cline = undefined in provider, that simply removes the reference to this instance, but the instance is still alive until this promise resolves or rejects.)
 		if (this.taskState.abort) {
-			throw new Error("Cline instance aborted")
+			throw new Error("Cline instance aborted ASKASKASK")
 		}
 		let askTs: number
 		if (partial !== undefined) {
@@ -828,6 +828,12 @@ export class Task {
 		await pWaitFor(() => this.taskState.askResponse !== undefined || this.taskState.lastMessageTs !== askTs, {
 			interval: 100,
 		})
+
+		// Check if task was aborted during the wait
+		if (this.taskState.abort) {
+			throw new Error("Cline instance aborted AAAA")
+		}
+
 		if (this.taskState.lastMessageTs !== askTs) {
 			throw new Error("Current ask promise was ignored") // could happen if we send multiple asks in a row i.e. with command_output. It's important that when we know an ask could fail, it is handled gracefully
 		}

--- a/src/core/task/index.ts
+++ b/src/core/task/index.ts
@@ -726,7 +726,7 @@ export class Task {
 	}> {
 		// If this Cline instance was aborted by the provider, then the only thing keeping us alive is a promise still running in the background, in which case we don't want to send its result to the webview as it is attached to a new instance of Cline now. So we can safely ignore the result of any active promises, and this class will be deallocated. (Although we set Cline = undefined in provider, that simply removes the reference to this instance, but the instance is still alive until this promise resolves or rejects.)
 		if (this.taskState.abort) {
-			throw new Error("Cline instance aborted ASKASKASK")
+			throw new Error("Cline instance aborted")
 		}
 		let askTs: number
 		if (partial !== undefined) {
@@ -828,11 +828,6 @@ export class Task {
 		await pWaitFor(() => this.taskState.askResponse !== undefined || this.taskState.lastMessageTs !== askTs, {
 			interval: 100,
 		})
-
-		// Check if task was aborted during the wait
-		if (this.taskState.abort) {
-			throw new Error("Cline instance aborted AAAA")
-		}
 
 		if (this.taskState.lastMessageTs !== askTs) {
 			throw new Error("Current ask promise was ignored") // could happen if we send multiple asks in a row i.e. with command_output. It's important that when we know an ask could fail, it is handled gracefully

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,7 +6,7 @@ import pWaitFor from "p-wait-for"
 import { Logger } from "./services/logging/Logger"
 import { createClineAPI } from "./exports"
 import "./utils/path" // necessary to have access to String.prototype.toPosix
-import { DIFF_VIEW_URI_SCHEME } from "./integrations/editor/DiffViewProvider"
+import { DIFF_VIEW_URI_SCHEME } from "@hosts/vscode/VscodeDiffViewProvider"
 import assert from "node:assert"
 import { posthogClientProvider } from "./services/posthog/PostHogClientProvider"
 import { WebviewProvider } from "./core/webview"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -717,15 +717,6 @@ function maybeSetupHostProviders(context: ExtensionContext) {
 	}
 }
 
-// TODO: Find a solution for automatically removing DEV related content from production builds.
-//  This type of code is fine in production to keep. We just will want to remove it from production builds
-//  to bring down built asset sizes.
-//
-// This is a workaround to reload the extension when the source code changes
-// since vscode doesn't support hot reload for extensions
-const IS_DEV = process.env.IS_DEV
-const DEV_WORKSPACE_FOLDER = process.env.DEV_WORKSPACE_FOLDER
-
 // This method is called when your extension is deactivated
 export async function deactivate() {
 	// Dispose all webview instances
@@ -737,6 +728,15 @@ export async function deactivate() {
 
 	Logger.log("Cline extension deactivated")
 }
+
+// TODO: Find a solution for automatically removing DEV related content from production builds.
+//  This type of code is fine in production to keep. We just will want to remove it from production builds
+//  to bring down built asset sizes.
+//
+// This is a workaround to reload the extension when the source code changes
+// since vscode doesn't support hot reload for extensions
+const IS_DEV = process.env.IS_DEV
+const DEV_WORKSPACE_FOLDER = process.env.DEV_WORKSPACE_FOLDER
 
 // Set up development mode file watcher
 if (IS_DEV && IS_DEV !== "false") {

--- a/src/hosts/external/grpc-types.ts
+++ b/src/hosts/external/grpc-types.ts
@@ -1,5 +1,6 @@
 import * as grpc from "@grpc/grpc-js"
 import { Controller } from "@core/controller"
+import { Channel, createChannel } from "nice-grpc"
 
 /**
  * Type definition for a gRPC handler function.
@@ -36,3 +37,51 @@ export type GrpcStreamingResponseHandlerWrapper = <TRequest, TResponse>(
 ) => grpc.handleServerStreamingCall<TRequest, TResponse>
 
 export type StreamingResponseWriter<TResponse> = (response: TResponse, isLast?: boolean, sequenceNumber?: number) => Promise<void>
+
+/**
+ * Abstract base class for type-safe gRPC client implementations.
+ *
+ * Provides automatic connection management with lazy initialization and
+ * transparent reconnection on network failures. Ensures type safety through
+ * generic client typing and consistent error handling patterns.
+ *
+ * @template TClient - The specific gRPC client type (e.g., niceGrpc.host.DiffServiceClient)
+ */
+export abstract class BaseGrpcClient<TClient> {
+	private client: TClient | null = null
+	private channel: Channel | null = null
+	protected address: string
+
+	constructor(address: string) {
+		this.address = address
+	}
+
+	protected abstract createClient(channel: Channel): TClient
+
+	protected getClient(): TClient {
+		if (!this.client || !this.channel) {
+			this.channel = createChannel(this.address)
+			this.client = this.createClient(this.channel)
+		}
+		return this.client
+	}
+
+	protected destroyClient(): void {
+		this.channel?.close()
+		this.client = null
+		this.channel = null
+	}
+
+	protected async makeRequest<T>(requestFn: (client: TClient) => Promise<T>): Promise<T> {
+		const client = this.getClient()
+
+		try {
+			return await requestFn(client)
+		} catch (error: any) {
+			if (error?.code === "UNAVAILABLE") {
+				this.destroyClient()
+			}
+			throw error
+		}
+	}
+}

--- a/src/hosts/external/host-bridge-client-manager.ts
+++ b/src/hosts/external/host-bridge-client-manager.ts
@@ -14,7 +14,7 @@ import {
 	DiffServiceClientInterface,
 } from "@generated/hosts/host-bridge-client-types"
 import { HostBridgeClientProvider } from "@/hosts/host-provider-types"
-import { HOSTBRIDGE_PORT } from "../../standalone/cline-core"
+import { HOSTBRIDGE_PORT } from "@/standalone/protobus-service"
 
 /**
  * Manager to hold the gRPC clients for the host bridge. The clients should be re-used to avoid

--- a/src/hosts/external/host-bridge-client-manager.ts
+++ b/src/hosts/external/host-bridge-client-manager.ts
@@ -21,7 +21,6 @@ import { HOSTBRIDGE_PORT } from "@/standalone/protobus-service"
  * creating a new TCP connection every time a rpc is made.
  */
 export class ExternalHostBridgeClientManager implements HostBridgeClientProvider {
-	private channel: Channel
 	watchServiceClient: WatchServiceClientInterface
 	workspaceClient: WorkspaceServiceClientInterface
 	envClient: EnvServiceClientInterface
@@ -30,16 +29,11 @@ export class ExternalHostBridgeClientManager implements HostBridgeClientProvider
 
 	constructor() {
 		const address = process.env.HOST_BRIDGE_ADDRESS || `localhost:${HOSTBRIDGE_PORT}`
-		this.channel = createChannel(address)
 
-		this.watchServiceClient = new WatchServiceClientImpl(this.channel)
-		this.workspaceClient = new WorkspaceServiceClientImpl(this.channel)
-		this.envClient = new EnvServiceClientImpl(this.channel)
-		this.windowClient = new WindowServiceClientImpl(this.channel)
-		this.diffClient = new DiffServiceClientImpl(this.channel)
-	}
-
-	public close(): void {
-		this.channel.close()
+		this.watchServiceClient = new WatchServiceClientImpl(address)
+		this.workspaceClient = new WorkspaceServiceClientImpl(address)
+		this.envClient = new EnvServiceClientImpl(address)
+		this.windowClient = new WindowServiceClientImpl(address)
+		this.diffClient = new DiffServiceClientImpl(address)
 	}
 }

--- a/src/hosts/vscode/VscodeDiffViewProvider.ts
+++ b/src/hosts/vscode/VscodeDiffViewProvider.ts
@@ -2,8 +2,10 @@ import { arePathsEqual } from "@/utils/path"
 import * as path from "path"
 import * as vscode from "vscode"
 import { DecorationController } from "@/hosts/vscode/DecorationController"
-import { DIFF_VIEW_URI_SCHEME, DiffViewProvider } from "@integrations/editor/DiffViewProvider"
+import { DiffViewProvider } from "@integrations/editor/DiffViewProvider"
 import { diagnosticsToProblemsString, getNewDiagnostics } from "@/integrations/diagnostics"
+
+export const DIFF_VIEW_URI_SCHEME = "cline-diff"
 
 export class VscodeDiffViewProvider extends DiffViewProvider {
 	private activeDiffEditor?: vscode.TextEditor

--- a/src/integrations/editor/DiffViewProvider.ts
+++ b/src/integrations/editor/DiffViewProvider.ts
@@ -9,8 +9,6 @@ import { detectEncoding } from "../misc/extract-text"
 import * as iconv from "iconv-lite"
 import { getHostBridgeProvider } from "@/hosts/host-providers"
 
-export const DIFF_VIEW_URI_SCHEME = "cline-diff"
-
 export abstract class DiffViewProvider {
 	editType?: "create" | "modify"
 	isEditing = false

--- a/src/services/auth/AuthService.ts
+++ b/src/services/auth/AuthService.ts
@@ -6,6 +6,7 @@ import { FirebaseAuthProvider } from "./providers/FirebaseAuthProvider"
 import { Controller } from "@/core/controller"
 import { storeSecret } from "@/core/storage/state"
 import { clineEnvConfig } from "@/config"
+import { openExternal } from "@/utils/env"
 
 const DefaultClineAccountURI = `${clineEnvConfig.appBaseUrl}/auth`
 let authProviders: any[] = []
@@ -187,7 +188,7 @@ export class AuthService {
 
 		const authUrlString = authUrl.toString()
 
-		await vscode.env.openExternal(vscode.Uri.parse(authUrlString))
+		await openExternal(authUrlString)
 		return String.create({ value: authUrlString })
 	}
 

--- a/src/services/logging/Logger.ts
+++ b/src/services/logging/Logger.ts
@@ -46,12 +46,12 @@ export class Logger {
 		return timestamp
 	}
 	static #output(level: string, message: string, error?: Error) {
-		var mesg = message
+		var fullMessage = message
 		if (error?.message) {
-			mesg += ` ${error.message}`
+			fullMessage += ` ${error.message}`
 		}
-		Logger.outputChannel.appendLine(`${level} ${message}`)
-		console.log(`[${Logger.#timestamp()}] ${level} ${message}`)
+		Logger.outputChannel.appendLine(`${level} ${fullMessage}`)
+		console.log(`[${Logger.#timestamp()}] ${level} ${fullMessage}`)
 		if (error?.stack) {
 			console.log(`Stack trace:\n${error.stack}`)
 		}

--- a/src/services/logging/Logger.ts
+++ b/src/services/logging/Logger.ts
@@ -13,25 +13,47 @@ export class Logger {
 		Logger.outputChannel = outputChannel
 	}
 
-	static error(message: string, exception?: Error) {
-		Logger.outputChannel.appendLine(`ERROR: ${message}`)
+	static error(message: string, error?: Error) {
+		Logger.#output("ERROR", message, error)
 		ErrorService.logMessage(message, "error")
-		exception && ErrorService.logException(exception)
+		error && ErrorService.logException(error)
 	}
 	static warn(message: string) {
-		Logger.outputChannel.appendLine(`WARN: ${message}`)
+		Logger.#output("WARN", message)
 		ErrorService.logMessage(message, "warning")
 	}
 	static log(message: string) {
-		Logger.outputChannel.appendLine(`LOG: ${message}`)
+		Logger.#output("LOG", message)
 	}
 	static debug(message: string) {
-		Logger.outputChannel.appendLine(`DEBUG: ${message}`)
+		Logger.#output("DEBUG", message)
 	}
 	static info(message: string) {
-		Logger.outputChannel.appendLine(`INFO: ${message}`)
+		Logger.#output("INFO", message)
 	}
 	static trace(message: string) {
-		Logger.outputChannel.appendLine(`TRACE: ${message}`)
+		Logger.#output("TRACE", message)
+	}
+	static #timestamp() {
+		const now = new Date()
+		const year = now.getFullYear()
+		const month = String(now.getMonth() + 1).padStart(2, "0")
+		const day = String(now.getDate()).padStart(2, "0")
+		const hour = String(now.getHours()).padStart(2, "0")
+		const minute = String(now.getMinutes()).padStart(2, "0")
+		const second = String(now.getSeconds()).padStart(2, "0")
+		const timestamp = `${year}-${month}-${day}T${hour}:${minute}:${second}`
+		return timestamp
+	}
+	static #output(level: string, message: string, error?: Error) {
+		var mesg = message
+		if (error?.message) {
+			mesg += ` ${error.message}`
+		}
+		Logger.outputChannel.appendLine(`${level} ${message}`)
+		console.log(`[${Logger.#timestamp()}] ${level} ${message}`)
+		if (error?.stack) {
+			console.log(`Stack trace:\n${error.stack}`)
+		}
 	}
 }

--- a/src/standalone/cline-core.ts
+++ b/src/standalone/cline-core.ts
@@ -36,15 +36,14 @@ function createDiffView() {
 function setupGlobalErrorHandlers() {
 	// Handle unhandled exceptions
 	process.on("uncaughtException", (error: Error) => {
-		log(`Uncaught Exception: ${error.message}`)
+		log(`ERROR: Uncaught exception: ${error.message}`)
 		log(`Stack trace: ${error.stack}`)
 		// Log the error but don't exit the process
 	})
 
 	// Handle unhandled promise rejections
-	process.on("unhandledRejection", (reason: any, promise: Promise<any>) => {
-		log(`Unhandled Promise Rejection at: ${promise}`)
-		log(`Reason: ${reason}`)
+	process.on("unhandledRejection", (reason: any, _promise: Promise<any>) => {
+		log(`ERROR: Unhandled promise rejection: ${reason}`)
 		if (reason instanceof Error) {
 			log(`Stack trace: ${reason.stack}`)
 		}
@@ -69,8 +68,6 @@ function setupGlobalErrorHandlers() {
 		log("Received SIGTERM, shutting down gracefully...")
 		process.exit(0)
 	})
-
-	log("Global error handlers set up successfully")
 }
 
 main()

--- a/src/standalone/cline-core.ts
+++ b/src/standalone/cline-core.ts
@@ -11,7 +11,7 @@ import { extensionContext, outputChannel, postMessage } from "./vscode-context"
 import { startProtobusService } from "./protobus-service"
 
 async function main() {
-	log("Starting cline-core service...")
+	log("\n\n\nStarting cline-core service...\n\n\n")
 
 	// Set up global error handlers to prevent process crashes
 	setupGlobalErrorHandlers()
@@ -53,9 +53,6 @@ function setupGlobalErrorHandlers() {
 	// Handle process warnings (optional, for debugging)
 	process.on("warning", (warning: Error) => {
 		log(`Process Warning: ${warning.name}: ${warning.message}`)
-		if (warning.stack) {
-			log(`Stack trace: ${warning.stack}`)
-		}
 	})
 
 	// Graceful shutdown handlers

--- a/src/standalone/cline-core.ts
+++ b/src/standalone/cline-core.ts
@@ -1,67 +1,27 @@
-import * as grpc from "@grpc/grpc-js"
-import { ReflectionService } from "@grpc/reflection"
-import * as health from "grpc-health-check"
-import * as hostProviders from "@hosts/host-providers"
 import { activate } from "@/extension"
 import { Controller } from "@core/controller"
-import { extensionContext, outputChannel, postMessage } from "./vscode-context"
-import { getPackageDefinition, log } from "./utils"
-import { GrpcHandler, GrpcStreamingResponseHandler } from "@hosts/external/grpc-types"
-import { addProtobusServices } from "@generated/standalone/server-setup"
-import { StreamingResponseHandler } from "@core/controller/grpc-handler"
-import { ExternalHostBridgeClientManager } from "@hosts/external/host-bridge-client-manager"
+import { ExternalDiffViewProvider } from "@hosts/external/ExternalDiffviewProvider"
 import { ExternalWebviewProvider } from "@hosts/external/ExternalWebviewProvider"
+import { ExternalHostBridgeClientManager } from "@hosts/external/host-bridge-client-manager"
+import * as hostProviders from "@hosts/host-providers"
 import { WebviewProviderType } from "@shared/webview/types"
 import { v4 as uuidv4 } from "uuid"
-import { ExternalDiffViewProvider } from "@hosts/external/ExternalDiffviewProvider"
+import { log } from "./utils"
+import { extensionContext, outputChannel, postMessage } from "./vscode-context"
 
 export const PROTOBUS_PORT = 26040
 export const HOSTBRIDGE_PORT = 26041
 
 async function main() {
-	log("Starting standalone service...")
+	log("Starting cline-core service...")
+
+	// Set up global error handlers to prevent process crashes
+	setupGlobalErrorHandlers()
 
 	hostProviders.initializeHostProviders(createWebview, createDiffView, new ExternalHostBridgeClientManager())
 	activate(extensionContext)
 	const controller = new Controller(extensionContext, outputChannel, postMessage, uuidv4())
 	startProtobusService(controller)
-}
-
-function startProtobusService(controller: Controller) {
-	const server = new grpc.Server()
-
-	// Set up health check.
-	const healthImpl = new health.HealthImplementation({ "": "SERVING" })
-	healthImpl.addToServer(server)
-
-	// Add all the handlers for the ProtoBus services to the server.
-	addProtobusServices(server, controller, wrapHandler, wrapStreamingResponseHandler)
-
-	// Create reflection service with protobus service names
-	const packageDefinition = getPackageDefinition()
-	const reflection = new ReflectionService(packageDefinition, {
-		services: getProtobusServiceNames(packageDefinition),
-	})
-	reflection.addToServer(server)
-
-	// Start the server.
-	const host = process.env.PROTOBUS_ADDRESS || `127.0.0.1:${PROTOBUS_PORT}`
-	server.bindAsync(host, grpc.ServerCredentials.createInsecure(), (err) => {
-		if (err) {
-			log(`Error: Failed to bind to ${host}, port may be unavailable. ${err.message}`)
-			process.exit(1)
-		}
-		server.start()
-		log(`gRPC server listening on ${host}`)
-	})
-}
-
-function getProtobusServiceNames(packageDefinition: { [x: string]: any }): string[] {
-	// Filter service names to only include cline services
-	const protobusServiceNames = Object.keys(packageDefinition).filter(
-		(name) => name.startsWith("cline.") || name.startsWith("grpc.health"),
-	)
-	return protobusServiceNames
 }
 
 function createWebview() {
@@ -72,66 +32,47 @@ function createDiffView() {
 }
 
 /**
- * Wraps a Promise-based handler function to make it compatible with gRPC's callback-based API.
- * This function converts an async handler that returns a Promise into a function that uses
- * the gRPC callback pattern.
- *
- * @template TRequest - The type of the request object
- * @template TResponse - The type of the response object
- * @param handler - The Promise-based handler function to wrap
- * @param controllerInstance - The controller instance to pass to the handler
- * @returns A gRPC-compatible callback-style handler function
+ * Sets up global error handlers to prevent the process from crashing
+ * on unhandled exceptions and promise rejections
  */
-function wrapHandler<TRequest, TResponse>(
-	handler: GrpcHandler<TRequest, TResponse>,
-	controller: Controller,
-): grpc.handleUnaryCall<TRequest, TResponse> {
-	return async (call: grpc.ServerUnaryCall<TRequest, TResponse>, callback: grpc.sendUnaryData<TResponse>) => {
-		try {
-			log(`gRPC request: ${call.getPath()}`)
-			const result = await handler(controller, call.request)
-			callback(null, result)
-		} catch (err: any) {
-			log(`gRPC handler error: ${call.getPath()}\n${err.stack}`)
-			callback({
-				code: grpc.status.INTERNAL,
-				message: err.message || "Internal error",
-			} as grpc.ServiceError)
+function setupGlobalErrorHandlers() {
+	// Handle unhandled exceptions
+	process.on("uncaughtException", (error: Error) => {
+		log(`Uncaught Exception: ${error.message}`)
+		log(`Stack trace: ${error.stack}`)
+		// Log the error but don't exit the process
+	})
+
+	// Handle unhandled promise rejections
+	process.on("unhandledRejection", (reason: any, promise: Promise<any>) => {
+		log(`Unhandled Promise Rejection at: ${promise}`)
+		log(`Reason: ${reason}`)
+		if (reason instanceof Error) {
+			log(`Stack trace: ${reason.stack}`)
 		}
-	}
-}
+		// Log the error but don't exit the process
+	})
 
-function wrapStreamingResponseHandler<TRequest, TResponse>(
-	handler: GrpcStreamingResponseHandler<TRequest, TResponse>,
-	controller: Controller,
-): grpc.handleServerStreamingCall<TRequest, TResponse> {
-	return async (call: grpc.ServerWritableStream<TRequest, TResponse>) => {
-		try {
-			const requestId = call.metadata.get("request-id").pop()?.toString()
-			log(`gRPC streaming request: ${call.getPath()}`)
-
-			const responseHandler: StreamingResponseHandler = (response, isLast, sequenceNumber) => {
-				try {
-					call.write(response) // Use a bound version of call.write to maintain proper 'this' context
-
-					if (isLast === true) {
-						log(`Closing stream for ${requestId}`)
-						call.end()
-					}
-					return Promise.resolve()
-				} catch (error) {
-					return Promise.reject(error)
-				}
-			}
-			await handler(controller, call.request, responseHandler, requestId)
-		} catch (err: any) {
-			log(`gRPC handler error: ${call.getPath()}\n${err.stack}`)
-			call.destroy({
-				code: grpc.status.INTERNAL,
-				message: err.message || "Internal error",
-			} as grpc.ServiceError)
+	// Handle process warnings (optional, for debugging)
+	process.on("warning", (warning: Error) => {
+		log(`Process Warning: ${warning.name}: ${warning.message}`)
+		if (warning.stack) {
+			log(`Stack trace: ${warning.stack}`)
 		}
-	}
+	})
+
+	// Graceful shutdown handlers
+	process.on("SIGINT", () => {
+		log("Received SIGINT, shutting down gracefully...")
+		process.exit(0)
+	})
+
+	process.on("SIGTERM", () => {
+		log("Received SIGTERM, shutting down gracefully...")
+		process.exit(0)
+	})
+
+	log("Global error handlers set up successfully")
 }
 
 main()

--- a/src/standalone/cline-core.ts
+++ b/src/standalone/cline-core.ts
@@ -8,9 +8,7 @@ import { WebviewProviderType } from "@shared/webview/types"
 import { v4 as uuidv4 } from "uuid"
 import { log } from "./utils"
 import { extensionContext, outputChannel, postMessage } from "./vscode-context"
-
-export const PROTOBUS_PORT = 26040
-export const HOSTBRIDGE_PORT = 26041
+import { startProtobusService } from "./protobus-service"
 
 async function main() {
 	log("Starting cline-core service...")

--- a/src/standalone/protobus-service.ts
+++ b/src/standalone/protobus-service.ts
@@ -1,0 +1,108 @@
+import { Controller } from "@core/controller"
+import { StreamingResponseHandler } from "@core/controller/grpc-handler"
+import { addProtobusServices } from "@generated/standalone/server-setup"
+import * as grpc from "@grpc/grpc-js"
+import { ReflectionService } from "@grpc/reflection"
+import { GrpcHandler, GrpcStreamingResponseHandler } from "@hosts/external/grpc-types"
+import * as health from "grpc-health-check"
+import { getPackageDefinition, log } from "./utils"
+
+function startProtobusService(controller: Controller) {
+	const server = new grpc.Server()
+
+	// Set up health check.
+	const healthImpl = new health.HealthImplementation({ "": "SERVING" })
+	healthImpl.addToServer(server)
+
+	// Add all the handlers for the ProtoBus services to the server.
+	addProtobusServices(server, controller, wrapHandler, wrapStreamingResponseHandler)
+
+	// Create reflection service with protobus service names
+	const packageDefinition = getPackageDefinition()
+	const reflection = new ReflectionService(packageDefinition, {
+		services: getProtobusServiceNames(packageDefinition),
+	})
+	reflection.addToServer(server)
+
+	// Start the server.
+	const host = process.env.PROTOBUS_ADDRESS || `127.0.0.1:${PROTOBUS_PORT}`
+	server.bindAsync(host, grpc.ServerCredentials.createInsecure(), (err) => {
+		if (err) {
+			log(`Error: Failed to bind to ${host}, port may be unavailable. ${err.message}`)
+			process.exit(1)
+		}
+		server.start()
+		log(`gRPC server listening on ${host}`)
+	})
+}
+
+function getProtobusServiceNames(packageDefinition: { [x: string]: any }): string[] {
+	// Filter service names to only include cline services
+	const protobusServiceNames = Object.keys(packageDefinition).filter(
+		(name) => name.startsWith("cline.") || name.startsWith("grpc.health"),
+	)
+	return protobusServiceNames
+}
+
+/**
+ * Wraps a Promise-based handler function to make it compatible with gRPC's callback-based API.
+ * This function converts an async handler that returns a Promise into a function that uses
+ * the gRPC callback pattern.
+ *
+ * @template TRequest - The type of the request object
+ * @template TResponse - The type of the response object
+ * @param handler - The Promise-based handler function to wrap
+ * @param controllerInstance - The controller instance to pass to the handler
+ * @returns A gRPC-compatible callback-style handler function
+ */
+function wrapHandler<TRequest, TResponse>(
+	handler: GrpcHandler<TRequest, TResponse>,
+	controller: Controller,
+): grpc.handleUnaryCall<TRequest, TResponse> {
+	return async (call: grpc.ServerUnaryCall<TRequest, TResponse>, callback: grpc.sendUnaryData<TResponse>) => {
+		try {
+			log(`gRPC request: ${call.getPath()}`)
+			const result = await handler(controller, call.request)
+			callback(null, result)
+		} catch (err: any) {
+			log(`gRPC handler error: ${call.getPath()}\n${err.stack}`)
+			callback({
+				code: grpc.status.INTERNAL,
+				message: err.message || "Internal error",
+			} as grpc.ServiceError)
+		}
+	}
+}
+
+function wrapStreamingResponseHandler<TRequest, TResponse>(
+	handler: GrpcStreamingResponseHandler<TRequest, TResponse>,
+	controller: Controller,
+): grpc.handleServerStreamingCall<TRequest, TResponse> {
+	return async (call: grpc.ServerWritableStream<TRequest, TResponse>) => {
+		try {
+			const requestId = call.metadata.get("request-id").pop()?.toString()
+			log(`gRPC streaming request: ${call.getPath()}`)
+
+			const responseHandler: StreamingResponseHandler = (response, isLast, sequenceNumber) => {
+				try {
+					call.write(response) // Use a bound version of call.write to maintain proper 'this' context
+
+					if (isLast === true) {
+						log(`Closing stream for ${requestId}`)
+						call.end()
+					}
+					return Promise.resolve()
+				} catch (error) {
+					return Promise.reject(error)
+				}
+			}
+			await handler(controller, call.request, responseHandler, requestId)
+		} catch (err: any) {
+			log(`gRPC handler error: ${call.getPath()}\n${err.stack}`)
+			call.destroy({
+				code: grpc.status.INTERNAL,
+				message: err.message || "Internal error",
+			} as grpc.ServiceError)
+		}
+	}
+}

--- a/src/standalone/protobus-service.ts
+++ b/src/standalone/protobus-service.ts
@@ -7,7 +7,7 @@ import { GrpcHandler, GrpcStreamingResponseHandler } from "@hosts/external/grpc-
 import * as health from "grpc-health-check"
 import { getPackageDefinition, log } from "./utils"
 
-function startProtobusService(controller: Controller) {
+export function startProtobusService(controller: Controller) {
 	const server = new grpc.Server()
 
 	// Set up health check.

--- a/src/standalone/protobus-service.ts
+++ b/src/standalone/protobus-service.ts
@@ -7,6 +7,9 @@ import { GrpcHandler, GrpcStreamingResponseHandler } from "@hosts/external/grpc-
 import * as health from "grpc-health-check"
 import { getPackageDefinition, log } from "./utils"
 
+export const PROTOBUS_PORT = 26040
+export const HOSTBRIDGE_PORT = 26041
+
 export function startProtobusService(controller: Controller) {
 	const server = new grpc.Server()
 


### PR DESCRIPTION
**Update the host bridge client to reconnect if there are network errors**

Before, if the host bridge service was not available when `cline-core` started,
it would fail to setup the clients and even if the host bridge became available later,
it wouldn't try to reconnect.

I have added some logic to reset the channel if the request fails because the service
was unavailable. It will try to reconnect on the next request.

- Enhance Logger class to work without OutputChannel dependency
- Add global error handlers for cline-core process
- Add better error handling to checkpoint restore functionality
- Move DIFF_VIEW_URI_SCHEME constant to VscodeDiffViewProvider
- Update account login to use openExternal util instead of vscode SDK
- Move the ProtoBus service out of cline-core.ts into its own file.
- Include timestamps and stack traces in error logging
- Remove unused imports and refactor for better code clarity

This improves the overall stability and maintainability of the gRPC
client-server communication system, with enhanced error recovery
and more informative logging for debugging purposes.

### Test Procedure


Tested with `./scripts/runclinecore.sh`
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Enhance gRPC error handling and logging with new `BaseGrpcClient`, improved `Logger`, and robust error management across the codebase.
> 
>   - **Behavior**:
>     - `BaseGrpcClient` class in `grpc-types.ts` for automatic connection management and error handling.
>     - `ExternalHostBridgeClientManager` in `host-bridge-client-manager.ts` uses `BaseGrpcClient` for client management.
>     - Global error handlers added in `cline-core.ts` to prevent process crashes.
>   - **Logging**:
>     - `Logger` class updated to include timestamps and stack traces in `Logger.ts`.
>   - **Error Handling**:
>     - Improved error handling in `checkpointRestore()` in `checkpointRestore.ts` with user notifications.
>     - Enhanced error handling in `protobus-service.ts` with `wrapHandler` and `wrapStreamingResponseHandler` functions.
>   - **Misc**:
>     - `DIFF_VIEW_URI_SCHEME` moved to `VscodeDiffViewProvider` in `VscodeDiffViewProvider.ts`.
>     - `openExternal` used in `AuthService.ts` for opening URLs.
>     - Removed unused imports and refactored code for clarity in multiple files.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 0e8713be2fa9221f1b0aa4661c331fde3a95a95f. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->