### PR TITLE
Add better error handling the `DiffViewProvider.saveDocument()`

### DIFF
--- a/src/core/context/instructions/user-instructions/rule-helpers.ts
+++ b/src/core/context/instructions/user-instructions/rule-helpers.ts
@@ -240,7 +240,7 @@ export async function deleteRuleFile(
 		}
 
 		// Delete the file from disk
-		await fs.unlink(rulePath)
+		await fs.unlink(rulePath).catch(() => {})
 
 		// Get the filename for messages
 		const fileName = path.basename(rulePath)

--- a/src/core/context/instructions/user-instructions/rule-helpers.ts
+++ b/src/core/context/instructions/user-instructions/rule-helpers.ts
@@ -240,7 +240,7 @@ export async function deleteRuleFile(
 		}
 
 		// Delete the file from disk
-		await fs.unlink(rulePath).catch(() => {})
+		await fs.rm(rulePath, { force: true })
 
 		// Get the filename for messages
 		const fileName = path.basename(rulePath)

--- a/src/core/controller/task/deleteTasksWithIds.ts
+++ b/src/core/controller/task/deleteTasksWithIds.ts
@@ -74,10 +74,7 @@ async function deleteTaskWithId(controller: Controller, id: string): Promise<voi
 			contextHistoryFilePath,
 			taskMetadataFilePath,
 		]) {
-			const fileExists = await fileExistsAtPath(filePath)
-			if (fileExists) {
-				await fs.unlink(filePath)
-			}
+			await fs.rm(filePath, { force: true })
 		}
 
 		// Remove empty task directory

--- a/src/core/task/index.ts
+++ b/src/core/task/index.ts
@@ -729,7 +729,7 @@ export class Task {
 	}> {
 		// If this Cline instance was aborted by the provider, then the only thing keeping us alive is a promise still running in the background, in which case we don't want to send its result to the webview as it is attached to a new instance of Cline now. So we can safely ignore the result of any active promises, and this class will be deallocated. (Although we set Cline = undefined in provider, that simply removes the reference to this instance, but the instance is still alive until this promise resolves or rejects.)
 		if (this.taskState.abort) {
-			throw new Error("Cline instance aborted ASKASKASK")
+			throw new Error("Cline instance aborted")
 		}
 		let askTs: number
 		if (partial !== undefined) {
@@ -831,11 +831,6 @@ export class Task {
 		await pWaitFor(() => this.taskState.askResponse !== undefined || this.taskState.lastMessageTs !== askTs, {
 			interval: 100,
 		})
-
-		// Check if task was aborted during the wait
-		if (this.taskState.abort) {
-			throw new Error("Cline instance aborted AAAA")
-		}
 
 		if (this.taskState.lastMessageTs !== askTs) {
 			throw new Error("Current ask promise was ignored") // could happen if we send multiple asks in a row i.e. with command_output. It's important that when we know an ask could fail, it is handled gracefully

--- a/src/core/task/index.ts
+++ b/src/core/task/index.ts
@@ -831,7 +831,6 @@ export class Task {
 		await pWaitFor(() => this.taskState.askResponse !== undefined || this.taskState.lastMessageTs !== askTs, {
 			interval: 100,
 		})
-
 		if (this.taskState.lastMessageTs !== askTs) {
 			throw new Error("Current ask promise was ignored") // could happen if we send multiple asks in a row i.e. with command_output. It's important that when we know an ask could fail, it is handled gracefully
 		}

--- a/src/core/task/index.ts
+++ b/src/core/task/index.ts
@@ -729,7 +729,7 @@ export class Task {
 	}> {
 		// If this Cline instance was aborted by the provider, then the only thing keeping us alive is a promise still running in the background, in which case we don't want to send its result to the webview as it is attached to a new instance of Cline now. So we can safely ignore the result of any active promises, and this class will be deallocated. (Although we set Cline = undefined in provider, that simply removes the reference to this instance, but the instance is still alive until this promise resolves or rejects.)
 		if (this.taskState.abort) {
-			throw new Error("Cline instance aborted")
+			throw new Error("Cline instance aborted ASKASKASK")
 		}
 		let askTs: number
 		if (partial !== undefined) {
@@ -831,6 +831,12 @@ export class Task {
 		await pWaitFor(() => this.taskState.askResponse !== undefined || this.taskState.lastMessageTs !== askTs, {
 			interval: 100,
 		})
+
+		// Check if task was aborted during the wait
+		if (this.taskState.abort) {
+			throw new Error("Cline instance aborted AAAA")
+		}
+
 		if (this.taskState.lastMessageTs !== askTs) {
 			throw new Error("Current ask promise was ignored") // could happen if we send multiple asks in a row i.e. with command_output. It's important that when we know an ask could fail, it is handled gracefully
 		}

--- a/src/core/task/index.ts
+++ b/src/core/task/index.ts
@@ -1218,8 +1218,9 @@ export class Task {
 		await this.browserSession.dispose()
 		this.clineIgnoreController.dispose()
 		this.fileContextTracker.dispose()
-		await this.diffViewProvider.revertChanges() // need to await for when we want to make sure directories/files are reverted before re-starting the task from a checkpoint
-
+		// need to await for when we want to make sure directories/files are reverted before
+		// re-starting the task from a checkpoint
+		await this.diffViewProvider.revertChanges()
 		// Clear the notification callback when task is aborted
 		this.mcpHub.clearNotificationCallback()
 	}

--- a/src/hosts/external/ExternalDiffviewProvider.ts
+++ b/src/hosts/external/ExternalDiffviewProvider.ts
@@ -42,16 +42,19 @@ export class ExternalDiffViewProvider extends DiffViewProvider {
 		})
 	}
 
-	protected async saveDocument(): Promise<void> {
+	protected async saveDocument(): Promise<Boolean> {
 		if (!this.activeDiffEditorId) {
-			return
+			return false
 		}
 		try {
 			await getHostBridgeProvider().diffClient.saveDocument({ diffId: this.activeDiffEditorId })
+			return true
 		} catch (err: any) {
 			if (err.code === status.NOT_FOUND) {
-				// This can happen when the task is reloaded.
+				// This can happen when the task is reloaded or the diff editor is closed. So, don't
+				// consider it a real error.
 				console.log("Diff not found:", this.activeDiffEditorId)
+				return false
 			} else {
 				throw err
 			}

--- a/src/hosts/external/ExternalDiffviewProvider.ts
+++ b/src/hosts/external/ExternalDiffviewProvider.ts
@@ -48,13 +48,9 @@ export class ExternalDiffViewProvider extends DiffViewProvider {
 		await getHostBridgeProvider().diffClient.saveDocument({ diffId: this.activeDiffEditorId })
 	}
 
-	protected override async scrollEditorToLine(line: number): Promise<void> {
-		console.log(`Called ExternalDiffViewProvider.scrollEditorToLine(${line}) stub`)
-	}
+	protected override async scrollEditorToLine(_line: number): Promise<void> {}
 
-	override async scrollAnimation(startLine: number, endLine: number): Promise<void> {
-		console.log(`Called ExternalDiffViewProvider.scrollAnimation(${startLine}, ${endLine}) stub`)
-	}
+	override async scrollAnimation(_startLine: number, _endLine: number): Promise<void> {}
 
 	protected override async getDocumentText(): Promise<string | undefined> {
 		if (!this.activeDiffEditorId) {

--- a/src/hosts/vscode/VscodeDiffViewProvider.ts
+++ b/src/hosts/vscode/VscodeDiffViewProvider.ts
@@ -168,13 +168,15 @@ export class VscodeDiffViewProvider extends DiffViewProvider {
 		return problems
 	}
 
-	protected override async saveDocument(): Promise<void> {
+	protected override async saveDocument(): Promise<Boolean> {
 		if (!this.activeDiffEditor) {
-			return
+			return false
 		}
-		if (this.activeDiffEditor.document.isDirty) {
-			await this.activeDiffEditor.document.save()
+		if (!this.activeDiffEditor.document.isDirty) {
+			return false
 		}
+		await this.activeDiffEditor.document.save()
+		return true
 	}
 
 	protected async closeDiffView(): Promise<void> {

--- a/src/integrations/editor/DiffViewProvider.ts
+++ b/src/integrations/editor/DiffViewProvider.ts
@@ -303,7 +303,6 @@ export abstract class DiffViewProvider {
 		const fileExists = this.editType === "modify"
 
 		if (!fileExists) {
-			await this.saveDocument()
 			await this.closeDiffView()
 			await fs.rm(this.absolutePath, { force: true })
 			// Remove only the directories we created, in reverse order

--- a/src/integrations/editor/DiffViewProvider.ts
+++ b/src/integrations/editor/DiffViewProvider.ts
@@ -122,8 +122,10 @@ export abstract class DiffViewProvider {
 
 	/**
 	 * Save the contents of the diff editor UI to the file.
+	 *
+	 * @returns true if the file was saved.
 	 */
-	protected abstract saveDocument(): Promise<void>
+	protected abstract saveDocument(): Promise<Boolean>
 
 	/**
 	 * Closes the diff editor tab or window.
@@ -303,6 +305,9 @@ export abstract class DiffViewProvider {
 		const fileExists = this.editType === "modify"
 
 		if (!fileExists) {
+			// This is a load-bearing save statement- even though the file is saved and then immediately deleted.
+			// In vscode, it will not close the diff editor correctly if the file is not saved.
+			await this.saveDocument()
 			await this.closeDiffView()
 			await fs.rm(this.absolutePath, { force: true })
 			// Remove only the directories we created, in reverse order

--- a/src/integrations/editor/DiffViewProvider.ts
+++ b/src/integrations/editor/DiffViewProvider.ts
@@ -305,7 +305,7 @@ export abstract class DiffViewProvider {
 		if (!fileExists) {
 			await this.saveDocument()
 			await this.closeDiffView()
-			await fs.unlink(this.absolutePath)
+			await fs.rm(this.absolutePath, { force: true })
 			// Remove only the directories we created, in reverse order
 			for (let i = this.createdDirs.length - 1; i >= 0; i--) {
 				await fs.rmdir(this.createdDirs[i])

--- a/standalone/runtime-files/vscode/vscode-stubs.js
+++ b/standalone/runtime-files/vscode/vscode-stubs.js
@@ -834,7 +834,7 @@ vscode.workspace.applyEdit = function (edit, metadata) {
 	console.log("Called stubbed function: vscode.workspace.applyEdit")
 	return false
 }
-vscode.workspace.textDocuments = createStub("vscode.workspace.textDocuments")
+vscode.workspace.textDocuments = []
 vscode.workspace.openTextDocument = function (uri) {
 	console.log("Called stubbed function: vscode.workspace.openTextDocument")
 	return Promise.resolve(null)


### PR DESCRIPTION
Closing the diff tab fails if it can't delete the file, but the operation should continue even if the delete failed. Otherwise, the diff editor tab is stuck open.

Use rm with force:true to delete the file without causing an error if it is already deleted.

Update two more locations in the extension where it deletes a files, without checking for `ENOENT`.

Change the ExternalDiffViewProvider to not throw an error if it couldn't save the diff because the diff editor was closed.

<!-- ELLIPSIS_HIDDEN -->

Tested manually in the vscode extension host.
----

> [!IMPORTANT]
> Fixes issue where diff editor couldn't be closed if file was deleted by using `fs.rm` with `force: true` and handling closed diff editor cases.
> 
>   - **Behavior**:
>     - Use `fs.rm` with `force: true` in `deleteRuleFile()` in `rule-helpers.ts` and `deleteTaskWithId()` in `deleteTasksWithIds.ts` to handle file deletion without error if file is already deleted.
>     - `ExternalDiffViewProvider` in `ExternalDiffviewProvider.ts` updated to not throw error if diff editor is closed before saving.
>   - **Functions**:
>     - Modify `saveDocument()` in `ExternalDiffViewProvider.ts` and `VscodeDiffViewProvider.ts` to return `Boolean` indicating success.
>     - Update `revertChanges()` in `DiffViewProvider.ts` to use `fs.rm` with `force: true` for file deletion.
>   - **Misc**:
>     - Fix typo in `vscode-stubs.js` by setting `vscode.workspace.textDocuments` to an empty array.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for b2605be1a6670b23fd897f2a74fcabdbe2b2008e. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->