### PR TITLE
[Fix] Stale state in new modelpickers search term

### DIFF
--- a/src/core/storage/state.ts
+++ b/src/core/storage/state.ts
@@ -528,6 +528,8 @@ export async function getAllExtensionState(context: vscode.ExtensionContext) {
 			actModeSapAiCoreModelId,
 			actModeGroqModelId,
 			actModeGroqModelInfo,
+			actModeHuggingFaceModelId,
+			actModeHuggingFaceModelInfo,
 		},
 		isNewUser: isNewUser ?? true,
 		welcomeViewCompleted,

--- a/webview-ui/src/components/settings/GroqModelPicker.tsx
+++ b/webview-ui/src/components/settings/GroqModelPicker.tsx
@@ -67,6 +67,12 @@ const GroqModelPicker: React.FC<GroqModelPickerProps> = ({ isPopup, currentMode 
 			})
 	})
 
+	// Sync external changes when the modelId changes
+	useEffect(() => {
+		const currentModelId = modeFields.groqModelId || groqDefaultModelId
+		setSearchTerm(currentModelId)
+	}, [modeFields.groqModelId])
+
 	// Debounce search term to reduce re-renders
 	useEffect(() => {
 		const timer = setTimeout(() => {

--- a/webview-ui/src/components/settings/HuggingFaceModelPicker.tsx
+++ b/webview-ui/src/components/settings/HuggingFaceModelPicker.tsx
@@ -63,6 +63,12 @@ const HuggingFaceModelPicker: React.FC<HuggingFaceModelPickerProps> = ({ isPopup
 			})
 	})
 
+	// Sync external changes when the modelId changes
+	useEffect(() => {
+		const currentModelId = modeFields.huggingFaceModelId || huggingFaceDefaultModelId
+		setSearchTerm(currentModelId)
+	}, [modeFields.huggingFaceModelId])
+
 	useEffect(() => {
 		const handleClickOutside = (event: MouseEvent) => {
 			if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
@@ -173,8 +179,25 @@ const HuggingFaceModelPicker: React.FC<HuggingFaceModelPickerProps> = ({ isPopup
 						}}
 						onFocus={() => setIsDropdownVisible(true)}
 						onKeyDown={handleKeyDown}
-						className="w-full relative z-[1000]"
-					/>
+						className="w-full relative z-[1000]">
+						{searchTerm && (
+							<div
+								className="input-icon-button codicon codicon-close"
+								aria-label="Clear search"
+								onClick={() => {
+									setSearchTerm("")
+									setIsDropdownVisible(true)
+								}}
+								slot="end"
+								style={{
+									display: "flex",
+									justifyContent: "center",
+									alignItems: "center",
+									height: "100%",
+								}}
+							/>
+						)}
+					</VSCodeTextField>
 					{isDropdownVisible && (
 						<div
 							ref={dropdownListRef}

--- a/webview-ui/src/components/settings/OpenRouterModelPicker.tsx
+++ b/webview-ui/src/components/settings/OpenRouterModelPicker.tsx
@@ -67,7 +67,6 @@ const OpenRouterModelPicker: React.FC<OpenRouterModelPickerProps> = ({ isPopup, 
 	const { apiConfiguration, openRouterModels, refreshOpenRouterModels } = useExtensionState()
 	const modeFields = getModeSpecificFields(apiConfiguration, currentMode)
 	const [searchTerm, setSearchTerm] = useState(modeFields.openRouterModelId || openRouterDefaultModelId)
-	const [isSearchInputDirty, setIsSearchInputDirty] = useState(false)
 	const [isDropdownVisible, setIsDropdownVisible] = useState(false)
 	const [selectedIndex, setSelectedIndex] = useState(-1)
 	const dropdownRef = useRef<HTMLDivElement>(null)
@@ -98,22 +97,11 @@ const OpenRouterModelPicker: React.FC<OpenRouterModelPickerProps> = ({ isPopup, 
 
 	useMount(refreshOpenRouterModels)
 
-	// Sync external changes only when user isn't actively typing
+	// Sync external changes when the modelId changes
 	useEffect(() => {
-		if (!isSearchInputDirty) {
-			const currentModelId = modeFields.openRouterModelId || openRouterDefaultModelId
-			setSearchTerm(currentModelId)
-		}
-	}, [modeFields.openRouterModelId, isSearchInputDirty])
-
-	// Reset dirty flag after user stops typing (1 second timeout)
-	useEffect(() => {
-		if (!isSearchInputDirty) return
-		const timeout = setTimeout(() => {
-			setIsSearchInputDirty(false)
-		}, 1000)
-		return () => clearTimeout(timeout)
-	}, [searchTerm, isSearchInputDirty])
+		const currentModelId = modeFields.openRouterModelId || openRouterDefaultModelId
+		setSearchTerm(currentModelId)
+	}, [modeFields.openRouterModelId])
 
 	useEffect(() => {
 		const handleClickOutside = (event: MouseEvent) => {
@@ -269,8 +257,7 @@ const OpenRouterModelPicker: React.FC<OpenRouterModelPickerProps> = ({ isPopup, 
 						placeholder="Search and select a model..."
 						value={searchTerm}
 						onInput={(e) => {
-							setIsSearchInputDirty(true)
-							handleModelChange((e.target as HTMLInputElement)?.value?.toLowerCase())
+							setSearchTerm((e.target as HTMLInputElement)?.value.toLowerCase() || "")
 							setIsDropdownVisible(true)
 						}}
 						onFocus={() => setIsDropdownVisible(true)}
@@ -285,7 +272,7 @@ const OpenRouterModelPicker: React.FC<OpenRouterModelPickerProps> = ({ isPopup, 
 								className="input-icon-button codicon codicon-close"
 								aria-label="Clear search"
 								onClick={() => {
-									handleModelChange("")
+									setSearchTerm("")
 									setIsDropdownVisible(true)
 								}}
 								slot="end"


### PR DESCRIPTION


### Description

Fix stale state in new model pickers `searchTerm`.

We also change the search box to only use local state and not update the actual `modelId` field until an option is clicked. This prevents random typing from getting saved, and simplifies the state syncing when the apiConfiguration changes. It also means that if a search term is cleared, we're not clearing the model ID as well.

### Test Procedure

Set different models for plan/act mode to true.

Using the same provider (Openrouter, Groq, or Huggingface), select different models. Confirm that when switching between plan and act tabs they stay separate. Close settings and confirm that they are indeed saved by switching between plan and act.

Type random input in the search term. Clear the search term. Close and confirm that the model ID is the same as before.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix stale state in model pickers by using local state for `searchTerm` and updating `modelId` only upon selection.
> 
>   - **Behavior**:
>     - Fix stale state in model pickers by using local state for `searchTerm` in `GroqModelPicker.tsx`, `HuggingFaceModelPicker.tsx`, and `OpenRouterModelPicker.tsx`.
>     - `modelId` is only updated when a model is selected, not during typing.
>     - Clearing `searchTerm` does not clear `modelId`.
>   - **Components**:
>     - Add `useEffect` to sync `searchTerm` with `modelId` changes in `GroqModelPicker.tsx`, `HuggingFaceModelPicker.tsx`, and `OpenRouterModelPicker.tsx`.
>     - Remove `isSearchInputDirty` state from `OpenRouterModelPicker.tsx`.
>     - Add clear button to `VSCodeTextField` in all model pickers for clearing `searchTerm`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for b47a8b1ea69c41555222ae585cd63bdd2f68a48c. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->