### PR TITLE
Speed up E2E tests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -61,7 +61,7 @@ jobs:
               uses: actions/cache@v4
               id: vscode-cache
               with:
-                  path: ~/.vscode-test
+                  path: .vscode-test
                   key: vscode-${{ runner.os }}-stable-${{ hashFiles('.vscode-test.mjs', 'package.json') }}
                   restore-keys: |
                       vscode-${{ runner.os }}-stable-

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -91,17 +91,14 @@ jobs:
               if: matrix.runner == 'ubuntu'
               run: sudo apt-get update && sudo apt-get install -y xvfb
 
-            # Build the extension before running tests
-            - name: Build Tests and Extension
-              run: npm run pretest
-
+            # Run optimized E2E tests (eliminates redundant builds)
             - name: Run E2E tests - Linux
               if: matrix.runner == 'ubuntu'
-              run: xvfb-run -a npm run test:e2e
+              run: xvfb-run -a npm run test:e2e:optimal
 
             - name: Run E2E tests - Non-Linux
               if: matrix.runner != 'ubuntu'
-              run: npm run test:e2e
+              run: npm run test:e2e:optimal
 
             - uses: actions/upload-artifact@v4
               if: ${{ failure() }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -91,14 +91,6 @@ jobs:
               if: matrix.runner == 'ubuntu'
               run: sudo apt-get update && sudo apt-get install -y xvfb
 
-            # Log cache status for debugging
-            - name: Log cache status
-              run: |
-                  echo "Root dependencies cache hit: ${{ steps.root-cache.outputs.cache-hit }}"
-                  echo "Webview dependencies cache hit: ${{ steps.webview-cache.outputs.cache-hit }}"
-                  echo "VS Code cache hit: ${{ steps.vscode-cache.outputs.cache-hit }}"
-                  echo "Playwright cache hit: ${{ steps.playwright-cache.outputs.cache-hit }}"
-
             # Build the extension before running tests
             - name: Build Tests and Extension
               run: npm run pretest

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -56,6 +56,29 @@ jobs:
                   path: webview-ui/node_modules
                   key: ${{ runner.os }}-npm-webview-${{ hashFiles('webview-ui/package-lock.json') }}
 
+            # Cache VS Code installation
+            - name: Cache VS Code
+              uses: actions/cache@v4
+              id: vscode-cache
+              with:
+                  path: ~/.vscode-test
+                  key: vscode-${{ runner.os }}-stable-${{ hashFiles('.vscode-test.mjs', 'package.json') }}
+                  restore-keys: |
+                      vscode-${{ runner.os }}-stable-
+
+            # Cache Playwright browsers
+            - name: Cache Playwright browsers
+              uses: actions/cache@v4
+              id: playwright-cache
+              with:
+                  path: |
+                      ~/.cache/ms-playwright
+                      ~/Library/Caches/ms-playwright
+                      ~/AppData/Local/ms-playwright
+                  key: playwright-browsers-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+                  restore-keys: |
+                      playwright-browsers-${{ runner.os }}-
+
             - name: Install root dependencies
               if: steps.root-cache.outputs.cache-hit != 'true'
               run: npm ci
@@ -67,6 +90,14 @@ jobs:
             - name: Install xvfb on Linux
               if: matrix.runner == 'ubuntu'
               run: sudo apt-get update && sudo apt-get install -y xvfb
+
+            # Log cache status for debugging
+            - name: Log cache status
+              run: |
+                  echo "Root dependencies cache hit: ${{ steps.root-cache.outputs.cache-hit }}"
+                  echo "Webview dependencies cache hit: ${{ steps.webview-cache.outputs.cache-hit }}"
+                  echo "VS Code cache hit: ${{ steps.vscode-cache.outputs.cache-hit }}"
+                  echo "Playwright cache hit: ${{ steps.playwright-cache.outputs.cache-hit }}"
 
             # Build the extension before running tests
             - name: Build Tests and Extension

--- a/package.json
+++ b/package.json
@@ -347,6 +347,7 @@
 		"test:coverage": "vscode-test --coverage",
 		"e2e": "playwright test -c playwright.config.ts",
 		"test:e2e": "playwright install && vsce package --no-dependencies --out dist/e2e.vsix && node src/test/e2e/utils/build.js && playwright test",
+		"test:e2e:optimal": "vsce package --no-dependencies --out dist/e2e.vsix && node src/test/e2e/utils/build.js && playwright test",
 		"install:all": "npm install && cd webview-ui && npm install",
 		"dev:webview": "cd webview-ui && npm run dev",
 		"build:webview": "cd webview-ui && npm run build",


### PR DESCRIPTION
### Description

Cut the E2E test run times in half.

The longest test (Windows) was taking OVER 7 minutes. The time for each has been cut in half, with the shortest (MacOS tests) now completing in 2 minutes.

The insight was twofold:

#### Cache large dependencies
We cache the VS Code and Playwright downloads so that they don't reinstall on every run

#### Incredibly inefficient build script
The E2E build process was running the same build steps multiple times. TypeScript checking ran 3 times, linting ran 4 times, and bundling ran 3 times. The workflow built dev, standalone, and test artifacts that E2E tests don't use. E2E tests only need the VSIX file. The redundant builds added the vast majority of the time that was reduced.

### Test Procedure

#### Confirm that caches hit
<img width="1166" height="484" alt="Screenshot 2025-07-19 at 11 33 31 AM" src="https://github.com/user-attachments/assets/67a2fb23-c0dd-4860-b52b-e1c27f089bba" />

#### Confirm that tests still run correclty and pass
<img width="852" height="159" alt="Screenshot 2025-07-19 at 1 02 35 PM" src="https://github.com/user-attachments/assets/14eabc91-fab6-48b5-ac32-ebbf55011cf1" />



### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [x] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Optimize E2E tests by caching VS Code and Playwright downloads and using a new `test:e2e:optimal` script.
> 
>   - **Workflow Changes**:
>     - Add caching for VS Code installation and Playwright browsers in `.github/workflows/e2e.yml` to speed up E2E tests by ~10%.
>     - Modify E2E test steps to use `test:e2e:optimal` script, eliminating redundant builds.
>   - **Scripts**:
>     - Add `test:e2e:optimal` script in `package.json` to run E2E tests without redundant builds.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 7c91440b15cce091981680e61bdab5fca15014fe. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->