### PR TITLE
Add walkthrough button and enable quick wins for new users

### DIFF
--- a/.changeset/stupid-jars-explain.md
+++ b/.changeset/stupid-jars-explain.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Enabling quickwins and adding a button to show that you can do a walkthrough

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -33,6 +33,8 @@ jobs:
         permissions:
             id-token: write
             contents: read
+        env:
+            VITE_CI: true
         steps:
             - uses: actions/checkout@v4
             - name: Setup Node.js environment

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -33,8 +33,6 @@ jobs:
         permissions:
             id-token: write
             contents: read
-        env:
-            VITE_CI: true
         steps:
             - uses: actions/checkout@v4
             - name: Setup Node.js environment

--- a/proto/cline/ui.proto
+++ b/proto/cline/ui.proto
@@ -267,4 +267,7 @@ service UiService {
   
   // Opens a URL in the default browser
   rpc openUrl(StringRequest) returns (Empty);
+  
+  // Opens the Cline walkthrough
+  rpc openWalkthrough(EmptyRequest) returns (Empty);
 }

--- a/webview-ui/src/components/chat/ChatView.tsx
+++ b/webview-ui/src/components/chat/ChatView.tsx
@@ -39,6 +39,7 @@ interface ChatViewProps {
 
 // Use constants from the imported module
 const MAX_IMAGES_AND_FILES_PER_MESSAGE = CHAT_CONSTANTS.MAX_IMAGES_AND_FILES_PER_MESSAGE
+const QUICK_WINS_HISTORY_THRESHOLD = 3
 
 const IS_STANDALONE = window?.__is_standalone__ ?? false
 
@@ -52,7 +53,7 @@ const ChatView = ({ isHidden, showAnnouncement, hideAnnouncement, showHistoryVie
 		navigateToChat,
 		mode,
 	} = useExtensionState()
-	const shouldShowQuickWins = false // !taskHistory || taskHistory.length < QUICK_WINS_HISTORY_THRESHOLD
+	const shouldShowQuickWins = !taskHistory || taskHistory.length < QUICK_WINS_HISTORY_THRESHOLD
 	//const task = messages.length > 0 ? (messages[0].say === "task" ? messages[0] : undefined) : undefined) : undefined
 	const task = useMemo(() => messages.at(0), [messages]) // leaving this less safe version here since if the first message is not a task, then the extension is in a bad state and needs to be debugged (see Cline.abort)
 	const modifiedMessages = useMemo(() => combineApiRequests(combineCommandSequences(messages.slice(1))), [messages])

--- a/webview-ui/src/components/chat/ChatView.tsx
+++ b/webview-ui/src/components/chat/ChatView.tsx
@@ -52,9 +52,12 @@ const ChatView = ({ isHidden, showAnnouncement, hideAnnouncement, showHistoryVie
 		telemetrySetting,
 		navigateToChat,
 		mode,
+		userInfo,
 	} = useExtensionState()
-	const isCI = import.meta.env.CI === "true"
-	const shouldShowQuickWins = !taskHistory || (taskHistory.length < QUICK_WINS_HISTORY_THRESHOLD && !isCI)
+	const shouldShowQuickWins = useMemo(() => {
+		const isProdHostedApp = userInfo?.apiBaseUrl === "https://app.cline.bot"
+		return isProdHostedApp && (!taskHistory || taskHistory.length < QUICK_WINS_HISTORY_THRESHOLD)
+	}, [userInfo?.apiBaseUrl, taskHistory])
 
 	//const task = messages.length > 0 ? (messages[0].say === "task" ? messages[0] : undefined) : undefined) : undefined
 	const task = useMemo(() => messages.at(0), [messages]) // leaving this less safe version here since if the first message is not a task, then the extension is in a bad state and needs to be debugged (see Cline.abort)

--- a/webview-ui/src/components/chat/ChatView.tsx
+++ b/webview-ui/src/components/chat/ChatView.tsx
@@ -53,7 +53,7 @@ const ChatView = ({ isHidden, showAnnouncement, hideAnnouncement, showHistoryVie
 		navigateToChat,
 		mode,
 	} = useExtensionState()
-	const isCI = process.env.CI === "true" || process.env.GITHUB_ACTIONS === "true"
+	const isCI = import.meta.env.VITE_CI === "true"
 	const shouldShowQuickWins = !taskHistory || (taskHistory.length < QUICK_WINS_HISTORY_THRESHOLD && !isCI)
 
 	//const task = messages.length > 0 ? (messages[0].say === "task" ? messages[0] : undefined) : undefined) : undefined

--- a/webview-ui/src/components/chat/ChatView.tsx
+++ b/webview-ui/src/components/chat/ChatView.tsx
@@ -54,10 +54,8 @@ const ChatView = ({ isHidden, showAnnouncement, hideAnnouncement, showHistoryVie
 		mode,
 		userInfo,
 	} = useExtensionState()
-	const shouldShowQuickWins = useMemo(() => {
-		const isProdHostedApp = userInfo?.apiBaseUrl === "https://app.cline.bot"
-		return isProdHostedApp && (!taskHistory || taskHistory.length < QUICK_WINS_HISTORY_THRESHOLD)
-	}, [userInfo?.apiBaseUrl, taskHistory])
+	const isProdHostedApp = userInfo?.apiBaseUrl === "https://app.cline.bot"
+	const shouldShowQuickWins = isProdHostedApp && (!taskHistory || taskHistory.length < QUICK_WINS_HISTORY_THRESHOLD)
 
 	//const task = messages.length > 0 ? (messages[0].say === "task" ? messages[0] : undefined) : undefined) : undefined
 	const task = useMemo(() => messages.at(0), [messages]) // leaving this less safe version here since if the first message is not a task, then the extension is in a bad state and needs to be debugged (see Cline.abort)

--- a/webview-ui/src/components/chat/ChatView.tsx
+++ b/webview-ui/src/components/chat/ChatView.tsx
@@ -53,7 +53,9 @@ const ChatView = ({ isHidden, showAnnouncement, hideAnnouncement, showHistoryVie
 		navigateToChat,
 		mode,
 	} = useExtensionState()
-	const shouldShowQuickWins = !taskHistory || taskHistory.length < QUICK_WINS_HISTORY_THRESHOLD
+	const isCI = process.env.CI === "true" || process.env.GITHUB_ACTIONS === "true"
+	const shouldShowQuickWins = !taskHistory || (taskHistory.length < QUICK_WINS_HISTORY_THRESHOLD && !isCI)
+
 	//const task = messages.length > 0 ? (messages[0].say === "task" ? messages[0] : undefined) : undefined) : undefined
 	const task = useMemo(() => messages.at(0), [messages]) // leaving this less safe version here since if the first message is not a task, then the extension is in a bad state and needs to be debugged (see Cline.abort)
 	const modifiedMessages = useMemo(() => combineApiRequests(combineCommandSequences(messages.slice(1))), [messages])

--- a/webview-ui/src/components/chat/ChatView.tsx
+++ b/webview-ui/src/components/chat/ChatView.tsx
@@ -53,7 +53,7 @@ const ChatView = ({ isHidden, showAnnouncement, hideAnnouncement, showHistoryVie
 		navigateToChat,
 		mode,
 	} = useExtensionState()
-	const isCI = import.meta.env.VITE_CI === "true"
+	const isCI = import.meta.env.CI === "true"
 	const shouldShowQuickWins = !taskHistory || (taskHistory.length < QUICK_WINS_HISTORY_THRESHOLD && !isCI)
 
 	//const task = messages.length > 0 ? (messages[0].say === "task" ? messages[0] : undefined) : undefined) : undefined

--- a/webview-ui/src/components/chat/chat-view/components/layout/WelcomeSection.tsx
+++ b/webview-ui/src/components/chat/chat-view/components/layout/WelcomeSection.tsx
@@ -25,7 +25,7 @@ export const WelcomeSection: React.FC<WelcomeSectionProps> = ({
 			<div className="overflow-y-auto flex flex-col pb-2.5">
 				{telemetrySetting === "unset" && <TelemetryBanner />}
 				{showAnnouncement && <Announcement version={version} hideAnnouncement={hideAnnouncement} />}
-				<HomeHeader />
+				<HomeHeader shouldShowQuickWins={shouldShowQuickWins} />
 				{!shouldShowQuickWins && taskHistory.length > 0 && <HistoryPreview showHistoryView={showHistoryView} />}
 			</div>
 			<SuggestedTasks shouldShowQuickWins={shouldShowQuickWins} />

--- a/webview-ui/src/components/welcome/HomeHeader.tsx
+++ b/webview-ui/src/components/welcome/HomeHeader.tsx
@@ -1,7 +1,21 @@
 import ClineLogoVariable from "@/assets/ClineLogoVariable"
 import HeroTooltip from "@/components/common/HeroTooltip"
+import { UiServiceClient } from "@/services/grpc-client"
+import { EmptyRequest } from "@shared/proto/cline/common"
 
-const HomeHeader = () => {
+interface HomeHeaderProps {
+	shouldShowQuickWins?: boolean
+}
+
+const HomeHeader = ({ shouldShowQuickWins = false }: HomeHeaderProps) => {
+	const handleTakeATour = async () => {
+		try {
+			await UiServiceClient.openWalkthrough(EmptyRequest.create())
+		} catch (error) {
+			console.error("Error opening walkthrough:", error)
+		}
+	}
+
 	return (
 		<div className="flex flex-col items-center mb-5">
 			<div className="my-5">
@@ -21,6 +35,16 @@ const HomeHeader = () => {
 					/>
 				</HeroTooltip>
 			</div>
+			{shouldShowQuickWins && (
+				<div className="mt-4">
+					<button
+						onClick={handleTakeATour}
+						className="flex items-center gap-2 px-4 py-2 rounded-full border border-[var(--vscode-panel-border)] bg-white/[0.02] hover:bg-[var(--vscode-list-hoverBackground)] transition-colors duration-150 ease-in-out text-[var(--vscode-editor-foreground)] text-sm font-medium cursor-pointer">
+						Take a Tour
+						<span className="codicon codicon-play scale-90"></span>
+					</button>
+				</div>
+			)}
 		</div>
 	)
 }

--- a/webview-ui/src/components/welcome/QuickWinCard.tsx
+++ b/webview-ui/src/components/welcome/QuickWinCard.tsx
@@ -7,7 +7,7 @@ interface QuickWinCardProps {
 }
 
 const renderIcon = (iconName?: string) => {
-	if (!iconName) return <span className="codicon codicon-rocket text-lg"></span>
+	if (!iconName) return <span className="codicon codicon-rocket !text-[28px] !leading-[1]"></span>
 
 	let iconClass = "codicon-rocket"
 	switch (iconName) {
@@ -23,21 +23,25 @@ const renderIcon = (iconName?: string) => {
 		default:
 			break
 	}
-	return <span className={`codicon ${iconClass} text-lg`}></span>
+	return <span className={`codicon ${iconClass} !text-[28px] !leading-[1]`}></span>
 }
 
 const QuickWinCard: React.FC<QuickWinCardProps> = ({ task, onExecute }) => {
 	return (
 		<div
-			className="flex items-center p-1 space-x-1.5 rounded-full cursor-pointer group transition-colors duration-150 ease-in-out bg-[var(--vscode-sideBar-background)] border border-[var(--vscode-panel-border)] hover:bg-[var(--vscode-list-hoverBackground)]"
+			className="flex items-center mb-2 py-0 px-5 space-x-3 rounded-full cursor-pointer group transition-colors duration-150 ease-in-out bg-white/[0.02] border border-[var(--vscode-panel-border)] hover:bg-[var(--vscode-list-hoverBackground)]"
 			onClick={() => onExecute()}>
-			<div className="flex-shrink-0 flex items-center justify-center w-5 h-5 text-[var(--vscode-icon-foreground)]">
+			<div className="flex-shrink-0 flex items-center justify-center w-6 h-6 text-[var(--vscode-icon-foreground)]">
 				{renderIcon(task.icon)}
 			</div>
 
 			<div className="flex-grow min-w-0">
-				<h3 className="text-xs font-medium truncate text-[var(--vscode-editor-foreground)]">{task.title}</h3>
-				<p className="text-xs truncate text-[var(--vscode-descriptionForeground)]">{task.description}</p>
+				<h3 className="text-sm font-medium truncate text-[var(--vscode-editor-foreground)] leading-tight mb-0 mt-0 pt-3">
+					{task.title}
+				</h3>
+				<p className="text-xs truncate text-[var(--vscode-descriptionForeground)] leading-tight mt-[1px]">
+					{task.description}
+				</p>
 			</div>
 		</div>
 	)

--- a/webview-ui/src/components/welcome/SuggestedTasks.tsx
+++ b/webview-ui/src/components/welcome/SuggestedTasks.tsx
@@ -13,8 +13,8 @@ export const SuggestedTasks: React.FC<{ shouldShowQuickWins: boolean }> = ({ sho
 		return (
 			<div className="px-4 pt-1 pb-3 select-none">
 				{" "}
-				<h2 className="text-sm font-medium mb-2.5 text-center text-[var(--vscode-editor-foreground)]">
-					Quick <span className="text-[var(--vscode-terminal-ansiBrightCyan)]">[Wins]</span> with Cline
+				<h2 className="text-sm font-medium mb-2.5 text-center text-gray">
+					Quick <span className="text-white">[Wins]</span> with Cline
 				</h2>
 				<div className="flex flex-col space-y-1">
 					{" "}

--- a/webview-ui/src/components/welcome/quickWinTasks.ts
+++ b/webview-ui/src/components/welcome/quickWinTasks.ts
@@ -12,7 +12,7 @@ export const quickWinTasks: QuickWinTask[] = [
 	{
 		id: "nextjs_notetaking_app",
 		title: "Build a Next.js App",
-		description: "Create a beautiful notetaking application with Next.js and Tailwind CSS.",
+		description: "Create a beautiful notetaking app with Next.js and Tailwind",
 		icon: "WebAppIcon",
 		actionCommand: "cline/createNextJsApp",
 		prompt: "Make a beautiful Next.js notetaking app, using Tailwind CSS for styling. Set up the basic structure and a simple UI for adding and viewing notes.",
@@ -21,10 +21,10 @@ export const quickWinTasks: QuickWinTask[] = [
 	{
 		id: "terminal_cli_tool",
 		title: "Craft a CLI Tool",
-		description: "Develop a powerful terminal CLI to automate a cool task.",
+		description: "Develop a powerful terminal CLI to automate a cool task",
 		icon: "TerminalIcon",
 		actionCommand: "cline/createCliTool",
-		prompt: "Make a terminal CLI tool using Node.js that fetches the current weather for a given city using a free weather API and displays it in a user-friendly format.",
+		prompt: "Make a terminal CLI tool using Node.js that organizes files in a directory by type, size, or date. It should have options to sort files into folders, show file statistics, find duplicates, and clean up empty directories. Include colorful output and progress indicators.",
 		buttonText: ">",
 	},
 	{


### PR DESCRIPTION
- Add openWalkthrough RPC method to ui.proto
- Enable quick wins display for users with <3 tasks in history
- Add "Take a Tour" button in HomeHeader when quick wins are shown
- Update WelcomeSection to pass shouldShowQuickWins prop to HomeHeader


### Description

<!-- 
Help reviewers understand your changes by making this PR readable and well-organized:

- What problem does this PR solve?
- Why were these changes introduced and what purpose do they serve?
- For larger changes, provide context about your approach and reasoning

Small PRs may need minimal description, but larger changes benefit from explaining where you're coming from. Much of this context can be in the linked issue above, so feel free to reference it rather than repeating everything here.
-->

### Test Procedure

Find the code for 

`	const shouldShowQuickWins = !taskHistory || taskHistory.length < QUICK_WINS_HISTORY_THRESHOLD`
change it to 


`const shouldShowQuickWins = true`

And you will see 
<img width="429" height="926" alt="image" src="https://github.com/user-attachments/assets/d096c1ee-dfbd-41ab-9b96-9c88e842126d" />

And clicking on take a tour will open a walkthrough

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [X] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [X] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [X] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [X] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [X] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [X] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds walkthrough button and quick wins for new users, enhancing onboarding experience.
> 
>   - **Behavior**:
>     - Adds `openWalkthrough` RPC method to `ui.proto` to open a walkthrough.
>     - Displays quick wins for users with less than 3 tasks in `ChatView.tsx`.
>     - Adds "Take a Tour" button in `HomeHeader` when quick wins are shown.
>   - **Components**:
>     - Updates `WelcomeSection` to pass `shouldShowQuickWins` prop to `HomeHeader`.
>     - Modifies `QuickWinCard` and `SuggestedTasks` to display quick win tasks.
>   - **Misc**:
>     - Updates task descriptions in `quickWinTasks.ts` for clarity.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 5594ad499d5c92f4cf538f92a0c0e6c20f48dc57. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->