### PR TITLE
Change the script scripts/runclinecore.sh to only install and run cline-core

### DIFF
--- a/scripts/runclinecore.sh
+++ b/scripts/runclinecore.sh
@@ -1,21 +1,21 @@
 #!/usr/bin/env bash
 set -eu #x
-# This compiles the cline-core app, installs it to the user's home directory,
-# and runs the service.
+# This installs the cline-core app to the user's home directory,
+# and starts the service.
 
 CORE_DIR=~/.cline/core
 INSTALL_DIR=$CORE_DIR/0.0.1
 
-# Build cline core
-npm run compile-standalone
+ZIP_FILE=standalone.zip
+ZIP=dist-standalone/${ZIP_FILE}
 
 # Remove old unpacked versions to force reinstall
 rm -rf $CORE_DIR/* || true
 
 mkdir -p $INSTALL_DIR
-cp dist-standalone/standalone.zip $INSTALL_DIR
+cp $ZIP $INSTALL_DIR
 cd $INSTALL_DIR
-unp standalone.zip > /dev/null
+unp $ZIP_FILE > /dev/null
 
 pkill -f cline-core.js || true
-NODE_PATH=./node_modules node cline-core.js
+NODE_PATH=./node_modules DEV_WORKSPACE_FOLDER=/tmp/ node cline-core.js


### PR DESCRIPTION
-and not to build the zip file.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> `scripts/runclinecore.sh` now only installs and runs `cline-core`, removing the build step.
> 
>   - **Behavior**:
>     - `scripts/runclinecore.sh` modified to only install and run `cline-core`, no longer builds the zip file.
>     - Removes `npm run compile-standalone` command.
>     - Sets `DEV_WORKSPACE_FOLDER=/tmp/` when starting `cline-core.js`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 5a539fd75678dcd5169f78292eccaa7f26825aa6. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->