### PR TITLE
Change available Cerebras models + modify context window

### DIFF
--- a/.changeset/chilly-sheep-rhyme.md
+++ b/.changeset/chilly-sheep-rhyme.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Strip thinking tokens from Cerebras reasoning model inputs

--- a/.changeset/chilly-sheep-rhyme.md
+++ b/.changeset/chilly-sheep-rhyme.md
@@ -2,4 +2,4 @@
 "claude-dev": patch
 ---
 
-Strip thinking tokens from Cerebras reasoning model inputs
+Improve cerebras Qwen model performance by removing thinking tokens from the model input

--- a/.changeset/kind-boxes-remember.md
+++ b/.changeset/kind-boxes-remember.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": minor
+---
+
+Change available Cerebras models - limit to Qwen and llama 3.3 70b

--- a/.changeset/wet-spiders-watch.md
+++ b/.changeset/wet-spiders-watch.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": minor
+---
+
+Change Cerebras Qwen 3 32b context window from 16k to 64k

--- a/src/api/providers/cerebras.ts
+++ b/src/api/providers/cerebras.ts
@@ -56,7 +56,7 @@ export class CerebrasHandler implements ApiHandler {
 
 		// Check if this is a reasoning model that uses thinking tags
 		const modelId = this.getModel().id
-		const isReasoningModel = modelId.includes("qwen") || modelId.includes("deepseek-r1-distill")
+		const isReasoningModel = modelId.includes("qwen")
 
 		// Convert Anthropic messages to Cerebras format
 		for (const message of messages) {

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -2463,8 +2463,8 @@ export const cerebrasModels = {
 		description: "Powerful model with ~2600 tokens/s",
 	},
 	"qwen-3-32b": {
-		maxTokens: 16382,
-		contextWindow: 16382,
+		maxTokens: 64000,
+		contextWindow: 64000,
 		supportsImages: false,
 		supportsPromptCache: false,
 		inputPrice: 0,

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -2471,6 +2471,15 @@ export const cerebrasModels = {
 		outputPrice: 0,
 		description: "SOTA coding performance with ~2500 tokens/s",
 	},
+	"qwen-3-235b-a22b": {
+		maxTokens: 40000,
+		contextWindow: 40000,
+		supportsImages: false,
+		supportsPromptCache: false,
+		inputPrice: 0,
+		outputPrice: 0,
+		description: "SOTA performance with ~1500 tokens/s",
+	},
 	"deepseek-r1-distill-llama-70b": {
 		maxTokens: 8192,
 		contextWindow: 8192,

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -2433,29 +2433,11 @@ export const sambanovaModels = {
 // Cerebras
 // https://inference-docs.cerebras.ai/api-reference/models
 export type CerebrasModelId = keyof typeof cerebrasModels
-export const cerebrasDefaultModelId: CerebrasModelId = "llama3.1-8b"
+export const cerebrasDefaultModelId: CerebrasModelId = "qwen-3-32b"
 export const cerebrasModels = {
-	"llama-4-scout-17b-16e-instruct": {
-		maxTokens: 8192,
-		contextWindow: 8192,
-		supportsImages: false,
-		supportsPromptCache: false,
-		inputPrice: 0,
-		outputPrice: 0,
-		description: "Fast inference model with ~2700 tokens/s",
-	},
-	"llama3.1-8b": {
-		maxTokens: 8192,
-		contextWindow: 8192,
-		supportsImages: false,
-		supportsPromptCache: false,
-		inputPrice: 0,
-		outputPrice: 0,
-		description: "Efficient model with ~2100 tokens/s",
-	},
 	"llama-3.3-70b": {
-		maxTokens: 8192,
-		contextWindow: 8192,
+		maxTokens: 64000,
+		contextWindow: 64000,
 		supportsImages: false,
 		supportsPromptCache: false,
 		inputPrice: 0,
@@ -2479,15 +2461,6 @@ export const cerebrasModels = {
 		inputPrice: 0,
 		outputPrice: 0,
 		description: "SOTA performance with ~1500 tokens/s",
-	},
-	"deepseek-r1-distill-llama-70b": {
-		maxTokens: 8192,
-		contextWindow: 8192,
-		supportsImages: false,
-		supportsPromptCache: false,
-		inputPrice: 0,
-		outputPrice: 0,
-		description: "Advanced reasoning model with ~2300 tokens/s (private preview)",
 	},
 } as const satisfies Record<string, ModelInfo>
 


### PR DESCRIPTION
Rebased Replica of the PR https://github.com/cline/cline/pull/5073  to upgrade cerebras provider

This solves the merge conflicts 


### Description

Bump up context from 16k -> 64k so users can have more intelligent/capable Qwen 3 32b models through the Cerebras provider. Also changed available models to:

llama-3.3-70b (64k context)
qwen-3-32b (64k context)
qwen-3-235b-a22b (40k context)

### Test Procedure

Run Cline locally and notice that there are only the 3 models listed above shown as available under the Cerebras provider. Select Cerebras as a provider with Qwen 3 32b as the model. Then, enter a query (such as "make a snake game in python") and notice that the context is shown as 64k and the model is capable of handling more text than it was previously.

Repeat with llama 3.3 70b and Qwen 235b

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots


### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Increase context window for Qwen 3 32b model to 64k and remove thinking tags for reasoning models in Cerebras.
> 
>   - **Behavior**:
>     - Increase context window for `qwen-3-32b` model from 16k to 64k in `api.ts`.
>     - Remove thinking tags from input for reasoning models in `CerebrasHandler` in `cerebras.ts`.
>   - **Misc**:
>     - Add changeset `wet-spiders-watch.md` for context window change.
>     - Add changeset `chilly-sheep-rhyme.md` for performance improvement by removing thinking tokens.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 72af1bc12b98866ae318505df98f311863911bda. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update Cerebras models by removing thinking tokens, changing context window, and limiting available models to Qwen and llama 3.3 70b.
> 
>   - **Behavior**:
>     - Remove thinking tokens from Cerebras Qwen model input in `cerebras.ts`.
>     - Change context window for Cerebras Qwen 3 32b from 16k to 64k in `api.ts`.
>     - Limit available Cerebras models to Qwen and llama 3.3 70b in `api.ts`.
>   - **Defaults**:
>     - Update default Cerebras model to `qwen-3-32b` in `api.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 3df11650cdf134fb913f8474eaaa90d8f8a6e71f. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->