### PR TITLE
migrate showSaveDialog hostBridge

### DIFF
--- a/proto/host/window.proto
+++ b/proto/host/window.proto
@@ -79,7 +79,7 @@ message ShowSaveDialogRequest {
 }
 
 message ShowSaveDialogOptions {
-  optional string default_uri = 1;
+  optional string default_path = 1;
   map<string, FileExtensionList> filters = 2;
 }
 
@@ -88,5 +88,5 @@ message FileExtensionList {
 }
 
 message ShowSaveDialogResponse {
-  optional string selected_uri = 1;
+  optional string selected_path = 1;
 }

--- a/src/hosts/vscode/hostbridge/window/showSaveDialog.ts
+++ b/src/hosts/vscode/hostbridge/window/showSaveDialog.ts
@@ -6,8 +6,8 @@ export async function showSaveDialog(request: ShowSaveDialogRequest): Promise<Sh
 
 	const vscodeOptions: SaveDialogOptions = {}
 
-	if (options?.defaultUri) {
-		vscodeOptions.defaultUri = Uri.file(options.defaultUri)
+	if (options?.defaultPath) {
+		vscodeOptions.defaultUri = Uri.file(options.defaultPath)
 	}
 
 	if (options?.filters && Object.keys(options.filters).length > 0) {
@@ -20,6 +20,6 @@ export async function showSaveDialog(request: ShowSaveDialogRequest): Promise<Sh
 	const selectedUri = await window.showSaveDialog(vscodeOptions)
 
 	return ShowSaveDialogResponse.create({
-		selectedUri: selectedUri?.fsPath,
+		selectedPath: selectedUri?.fsPath,
 	})
 }

--- a/src/integrations/misc/export-markdown.ts
+++ b/src/integrations/misc/export-markdown.ts
@@ -34,16 +34,16 @@ export async function downloadTask(dateTs: number, conversationHistory: Anthropi
 	const saveResponse = await HostProvider.window.showSaveDialog({
 		options: {
 			filters: { Markdown: { extensions: ["md"] } },
-			defaultUri: path.join(os.homedir(), "Downloads", fileName),
+			defaultPath: path.join(os.homedir(), "Downloads", fileName),
 		},
 	})
 
-	if (saveResponse.selectedUri) {
+	if (saveResponse.selectedPath) {
 		try {
 			// Write content to the selected location
-			await writeFile(saveResponse.selectedUri, markdownContent)
+			await writeFile(saveResponse.selectedPath, markdownContent)
 			await HostProvider.window.showTextDocument({
-				path: saveResponse.selectedUri,
+				path: saveResponse.selectedPath,
 				options: { preview: true },
 			})
 		} catch (error) {


### PR DESCRIPTION


### Description

Migrate the showSaveDialog to hostBridge

### Test Procedure

Test exporting a task, the only place where this function is called.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [x] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Migrates `showSaveDialog` to `hostBridge`, updating proto definitions and refactoring `export-markdown.ts` to use the new implementation.
> 
>   - **Behavior**:
>     - Migrates `showSaveDialog` to `hostBridge` in `WindowService`.
>     - Updates `downloadTask()` in `export-markdown.ts` to use `HostProvider.window.showSaveDialog()`.
>   - **Proto Definitions**:
>     - Adds `showSaveDialog` RPC to `WindowService` in `window.proto`.
>     - Defines `ShowSaveDialogRequest`, `ShowSaveDialogOptions`, and `ShowSaveDialogResponse` messages.
>   - **Implementation**:
>     - Implements `showSaveDialog()` in `showSaveDialog.ts` to handle dialog options and return selected path.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for eff328d20ff58dce294619df4a6422b6d7342d28. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->