### PR TITLE
automate announcement display for major.minor releases

### DIFF
--- a/src/core/controller/index.ts
+++ b/src/core/controller/index.ts
@@ -55,7 +55,9 @@ export class Controller {
 	mcpHub: McpHub
 	accountService: ClineAccountService
 	authService: AuthService
-	latestAnnouncementId = "june-25-2025_16:11:00" // update to some unique identifier when we add a new announcement
+	get latestAnnouncementId(): string {
+		return this.context.extension?.packageJSON?.version?.split(".").slice(0, 2).join(".") ?? ""
+	}
 
 	constructor(
 		readonly context: vscode.ExtensionContext,

--- a/webview-ui/src/components/chat/Announcement.tsx
+++ b/webview-ui/src/components/chat/Announcement.tsx
@@ -30,7 +30,9 @@ const linkContainerStyle: CSSProperties = { margin: "0" }
 const linkStyle: CSSProperties = { display: "inline" }
 
 /*
-You must update the latestAnnouncementId in ClineProvider for new announcements to show to users. This new id will be compared with what's in state for the 'last announcement shown', and if it's different then the announcement will render. As soon as an announcement is shown, the id will be updated in state. This ensures that announcements are not shown more than once, even if the user doesn't close it themselves.
+Announcements are automatically shown when the major.minor version changes (for ex 3.19.x → 3.20.x or 4.0.x). 
+The latestAnnouncementId is now automatically generated from the extension's package.json version. 
+Patch releases (3.19.1 → 3.19.2) will not trigger new announcements.
 */
 const Announcement = ({ version, hideAnnouncement }: AnnouncementProps) => {
 	const minorVersion = version.split(".").slice(0, 2).join(".") // 2.0.0 -> 2.0


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

### Description
- Every update triggered announcements (including patches)
- Now only major.minor version bumps trigger announcements

Replace the hardcoded `latestAnnouncementId` with dynamic version-based logic that automatically generates announcement IDs from the extension version.

1. **Zero maintenance**: no more manual date string updates
2. **Automatic**: works for all future releases without intervention
3. **Backward compatible**: uses existing storage and display logic

### Test Procedure

Can be tested by manually changing package.json version to trigger announcement. See that it appears only on first load.

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [x] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots



### Additional Notes

