### PR TITLE
Add encodeRequest helper to grpc-client-base

### DIFF
--- a/webview-ui/src/services/grpc-client-base.ts
+++ b/webview-ui/src/services/grpc-client-base.ts
@@ -1,6 +1,21 @@
 import { vscode } from "../utils/vscode"
 import { v4 as uuidv4 } from "uuid"
 
+/**
+ * Helper function to encode request objects
+ */
+function encodeRequest(request: any): unknown {
+	if (request === null || request === undefined) {
+		return {}
+	} else if (typeof request.toJSON === "function") {
+		return request.toJSON()
+	} else if (typeof request === "object") {
+		return { ...request }
+	} else {
+		return { value: request }
+	}
+}
+
 export interface Callbacks<TResponse> {
 	onResponse: (response: TResponse) => void
 	onError: (error: Error) => void
@@ -12,7 +27,7 @@ export abstract class ProtoBusClient {
 	static async makeRequest<TRequest, TResponse>(
 		methodName: string,
 		request: TRequest,
-		encodeRequest: (_: TRequest) => unknown,
+		_encodeRequest: (_: TRequest) => unknown,
 		decodeResponse: (_: unknown) => TResponse,
 	): Promise<TResponse> {
 		return new Promise((resolve, reject) => {
@@ -55,7 +70,7 @@ export abstract class ProtoBusClient {
 		methodName: string,
 		request: TRequest,
 		callbacks: Callbacks<TResponse>,
-		encodeRequest: (_: TRequest) => unknown,
+		_encodeRequest: (_: TRequest) => unknown,
 		decodeResponse: (_: unknown) => TResponse,
 	): () => void {
 		const requestId = uuidv4()


### PR DESCRIPTION
Add encodeRequest helper to grpc-client-base

Root cause:

In the TypeScript implementation, the generated client code is passing proto.cline.EmptyRequest.toJSON as the encodeRequest function, which might not handle all the edge cases that the original encodeRequest helper function handled in the Javascript file.

Fix:

This commit adds the missing `encodeRequest` helper function to `grpc-client-base.ts`. This function handles the encoding of request objects before they are sent via gRPC. It checks for null/undefined requests, `toJSON` methods, and object types, providing appropriate encoding for each case. This ensures that requests are properly formatted for the gRPC service. The `encodeRequest` function is used in `makeRequest` and other methods.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `encodeRequest` helper to `grpc-client-base.ts` for handling request encoding in gRPC client.
> 
>   - **Functionality**:
>     - Adds `encodeRequest` function to `grpc-client-base.ts` to handle request encoding for gRPC.
>     - Handles null/undefined requests, `toJSON` methods, and object types.
>   - **Integration**:
>     - Replaces `encodeRequest` parameter with `_encodeRequest` in `makeRequest` and `makeStreamingRequest` methods to indicate internal use.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 4e7fb67e984be9eb50e972a7906831f511f46f84. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->