### PR TITLE
hostbridge migrate save textDocument

### DIFF
--- a/proto/host/workspace.proto
+++ b/proto/host/workspace.proto
@@ -4,10 +4,14 @@ package host;
 option java_package = "bot.cline.host.proto";
 option java_multiple_files = true;
 
+import "common.proto";
+
 // Provides methods for working with workspaces/projects.
 service WorkspaceService {
   // Returns a list of the top level directories of the workspace.
   rpc getWorkspacePaths(GetWorkspacePathsRequest) returns (GetWorkspacePathsResponse);
+  // Saves an open document if it's dirty
+  rpc saveOpenDocumentIfDirty(SaveOpenDocumentIfDirtyRequest) returns (cline.Empty);
 }
 
 message GetWorkspacePathsRequest {
@@ -21,4 +25,9 @@ message GetWorkspacePathsResponse {
   // The unique ID for the workspace/project.
   optional string id = 1;
   repeated string paths = 2;
+}
+
+message SaveOpenDocumentIfDirtyRequest {
+  cline.Metadata metadata = 1;
+  string file_path = 2;
 }

--- a/src/hosts/vscode/hostbridge/workspace/saveOpenDocumentIfDirty.ts
+++ b/src/hosts/vscode/hostbridge/workspace/saveOpenDocumentIfDirty.ts
@@ -1,0 +1,14 @@
+import { SaveOpenDocumentIfDirtyRequest } from "@/shared/proto/index.host"
+import { Empty } from "@/shared/proto/common"
+import * as vscode from "vscode"
+import { arePathsEqual } from "@utils/path"
+
+export async function saveOpenDocumentIfDirty(request: SaveOpenDocumentIfDirtyRequest): Promise<Empty> {
+	const existingDocument = vscode.workspace.textDocuments.find((doc) => arePathsEqual(doc.uri.fsPath, request.filePath))
+
+	if (existingDocument && existingDocument.isDirty) {
+		await existingDocument.save()
+	}
+
+	return Empty.create({})
+}

--- a/src/integrations/editor/DiffViewProvider.ts
+++ b/src/integrations/editor/DiffViewProvider.ts
@@ -1,4 +1,3 @@
-import * as vscode from "vscode"
 import * as path from "path"
 import * as fs from "fs/promises"
 import { createDirectoriesForFile } from "@utils/fs"
@@ -31,12 +30,9 @@ export abstract class DiffViewProvider {
 
 		// if the file is already open, ensure it's not dirty before getting its contents
 		if (fileExists) {
-			const existingDocument = vscode.workspace.textDocuments.find((doc) =>
-				arePathsEqual(doc.uri.fsPath, this.absolutePath),
-			)
-			if (existingDocument && existingDocument.isDirty) {
-				await existingDocument.save()
-			}
+			await HostProvider.workspace.saveOpenDocumentIfDirty({
+				filePath: this.absolutePath!,
+			})
 
 			const fileBuffer = await fs.readFile(this.absolutePath)
 			this.fileEncoding = await detectEncoding(fileBuffer)


### PR DESCRIPTION


### Description

Migrate save textdocument on DiffViewProvider

### Test Procedure

## How to Test This

To test the specific functionality you migrated:

1. __Manual Test Scenario:__

   - Open a file in VS Code
   - Make some changes but __don't save__ (the file should show as dirty with a dot in the tab)
   - Ask Cline to edit that same file
   - The code should automatically save your unsaved changes before Cline starts editing
   - You should see the dot disappear from the tab before the diff view opens

2. __What to Watch For:__

   - The file's dirty indicator (dot) should disappear
   - Your unsaved changes should be preserved
   - Cline should then show the diff view with your saved changes as the baseline

3. __Edge Cases to Test:__

   - File is open but already saved (no changes) - should proceed normally
   - File is not open at all - should proceed normally
   - Multiple files with same name in different directories - should only save the exact matching file


### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [x] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `saveOpenDocumentIfDirty` RPC method to save unsaved changes in VS Code before Cline edits.
> 
>   - **Behavior**:
>     - Adds `saveOpenDocumentIfDirty` RPC method in `workspace.proto` to save dirty documents.
>     - Implements `saveOpenDocumentIfDirty` in `saveOpenDocumentIfDirty.ts` to find and save dirty documents in VS Code.
>     - Updates `DiffViewProvider.ts` to use `saveOpenDocumentIfDirty` before reading file contents.
>   - **Edge Cases**:
>     - Handles cases where the file is not open or already saved.
>     - Ensures only the exact matching file is saved when multiple files with the same name exist.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 085a7efd341a17b8672129b423e9478997a46c3e. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->