### PR TITLE
Fix hugging face model description

### DIFF
--- a/src/core/controller/models/refreshHuggingFaceModels.ts
+++ b/src/core/controller/models/refreshHuggingFaceModels.ts
@@ -46,6 +46,7 @@ export async function refreshHuggingFaceModels(
 
 			// Transform HF models to OpenRouter-compatible format
 			for (const rawModel of rawModels) {
+				const providersList = rawModel.providers?.map((provider: { provider: string }) => provider.provider)?.join(", ")
 				const modelInfo = OpenRouterModelInfo.create({
 					maxTokens: 8192, // HF doesn't provide max_tokens, use default
 					contextWindow: 128_000, // FIXME: HF doesn't provide context window, use default
@@ -55,7 +56,7 @@ export async function refreshHuggingFaceModels(
 					outputPrice: 0, // Will be set based on providers
 					cacheWritesPrice: 0,
 					cacheReadsPrice: 0,
-					description: `Available on providers: ${rawModel.providers?.join(", ") || "unknown"}`,
+					description: `Available on providers: ${providersList || "unknown"}`,
 				})
 
 				// Add model-specific configurations if we have them in our static models


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes provider list formatting in `refreshHuggingFaceModels` to correctly display provider names in model descriptions.
> 
>   - **Behavior**:
>     - Fixes provider list formatting in `description` field of `OpenRouterModelInfo` in `refreshHuggingFaceModels`.
>     - Uses `providersList` to join provider names with ", " instead of using `rawModel.providers?.join(", ")`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for f11303e1bcce3a73b8592d30783fdc275042c06f. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->