### PR TITLE
Fixed issue affecting first-time credential entry for SAP AI Core

### DIFF
--- a/.changeset/famous-baboons-vanish.md
+++ b/.changeset/famous-baboons-vanish.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Fixed issue with sap ai core client credentials storage

--- a/webview-ui/src/components/settings/providers/SapAiCoreProvider.tsx
+++ b/webview-ui/src/components/settings/providers/SapAiCoreProvider.tsx
@@ -43,7 +43,7 @@ export const SapAiCoreProvider = ({ showModelOptions, isPopup, currentMode }: Sa
 			)}
 
 			<DebouncedTextField
-				initialValue={apiConfiguration?.sapAiCoreClientSecret ? "********" : ""}
+				initialValue={apiConfiguration?.sapAiCoreClientSecret || ""}
 				onChange={(value) => handleFieldChange("sapAiCoreClientSecret", value)}
 				style={{ width: "100%" }}
 				type="password"


### PR DESCRIPTION
### Related Issue

**Issue:** #5097

### Description

Since the last version, the reduced mask (********) has been affecting users who are storing the client secret for the first time. The value gets modified to the mask even before it's saved, simply by pressing the Tab key.

As this reduced mask is not a standard across the product, the simplest and most effective solution is to remove it.

### Test Procedure

1. Open the Cline for the first time, without any SAP AI Core configuration
2. Enter the Client Secret
3. Press TAB
4. Client Secret mask size should remain as is

### Type of Change

-   [X] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [X] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [X] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [X] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [X] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Removed premature mask from `sapAiCoreClientSecret` in `SapAiCoreProvider.tsx` to fix first-time credential entry issue.
> 
>   - **Behavior**:
>     - Removed mask ("********") from `initialValue` of `sapAiCoreClientSecret` in `SapAiCoreProvider.tsx`.
>     - Fixes issue where mask was applied before saving, affecting first-time credential entry.
>   - **Test Procedure**:
>     - Enter client secret for the first time and press TAB; mask size should remain unchanged.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for da204c3c6ea402413c4939453e7ec1ec359de158. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->