### PR TITLE
Abstracted getting of open and visible tabls by Hostbridge

### DIFF
--- a/proto/host/window.proto
+++ b/proto/host/window.proto
@@ -14,6 +14,8 @@ service WindowService {
   rpc showMessage(ShowMessageRequest) returns (SelectedResponse);
   rpc showInputBox(ShowInputBoxRequest) returns (ShowInputBoxResponse);
   rpc showSaveDialog(ShowSaveDialogRequest) returns (ShowSaveDialogResponse);
+  rpc getOpenTabs(GetOpenTabsRequest) returns (GetOpenTabsResponse);
+  rpc getVisibleTabs(GetVisibleTabsRequest) returns (GetVisibleTabsResponse);
 }
 
 message ShowTextDocumentRequest {
@@ -101,4 +103,20 @@ message ShowInputBoxRequest {
 
 message ShowInputBoxResponse {
   optional string response = 1;
+}
+
+message GetOpenTabsRequest {
+  // empty
+}
+
+message GetOpenTabsResponse {
+  repeated string paths = 1;
+}
+
+message GetVisibleTabsRequest {
+  // empty
+}
+
+message GetVisibleTabsResponse {
+  repeated string paths = 1;
 }

--- a/src/hosts/vscode/hostbridge/window/getOpenTabs.test.ts
+++ b/src/hosts/vscode/hostbridge/window/getOpenTabs.test.ts
@@ -1,0 +1,71 @@
+/* eslint-disable eslint-rules/no-direct-vscode-api */
+import { describe, it, beforeEach, afterEach } from "mocha"
+import { strict as assert } from "assert"
+import * as vscode from "vscode"
+import { getOpenTabs } from "@/hosts/vscode/hostbridge/window/getOpenTabs"
+import { GetOpenTabsRequest } from "@/shared/proto/host/window"
+
+describe("Hostbridge - Window - getOpenTabs", () => {
+	async function createAndOpenTestDocument(fileNumber: number, column: vscode.ViewColumn): Promise<void> {
+		const content = `// Test file ${fileNumber}\nconsole.log('Hello from file ${fileNumber}');`
+		const doc = await vscode.workspace.openTextDocument({
+			content,
+			language: "javascript",
+		})
+		await vscode.window.showTextDocument(doc, column)
+	}
+
+	beforeEach(async () => {
+		// Clean up any existing editors
+		await vscode.commands.executeCommand("workbench.action.closeAllEditors")
+	})
+
+	afterEach(async () => {
+		// Clean up test documents and editors
+		await vscode.commands.executeCommand("workbench.action.closeAllEditors")
+	})
+
+	it("should return empty array when no tabs are open", async () => {
+		// Ensure no tabs are open
+		await vscode.commands.executeCommand("workbench.action.closeAllEditors")
+
+		const request = GetOpenTabsRequest.create({})
+		const response = await getOpenTabs(request)
+
+		assert.strictEqual(response.paths.length, 0, "Should return empty array when no tabs are open")
+	})
+
+	it("should return paths of open text document tabs", async () => {
+		// Open the documents in editors (this creates the tabs)
+		await createAndOpenTestDocument(1, vscode.ViewColumn.One)
+		await createAndOpenTestDocument(2, vscode.ViewColumn.Two)
+
+		// Wait a bit for tabs to be fully created
+		await new Promise((resolve) => setTimeout(resolve, 100))
+
+		const request = GetOpenTabsRequest.create({})
+		const response = await getOpenTabs(request)
+
+		// Should have 2 tabs open
+		assert.strictEqual(response.paths.length, 2, `Expected 2 tabs, got ${response.paths.length}`)
+	})
+
+	it("should return all open tabs even when multiple files are opened in the same ViewColumn", async () => {
+		// Open all documents in the same column (only the last one will be visible, but all are open as tabs)
+		await createAndOpenTestDocument(1, vscode.ViewColumn.One)
+		await createAndOpenTestDocument(2, vscode.ViewColumn.One)
+		await createAndOpenTestDocument(3, vscode.ViewColumn.One)
+
+		// Wait a bit for tabs to be fully created
+		await new Promise((resolve) => setTimeout(resolve, 100))
+
+		const request = GetOpenTabsRequest.create({})
+		const response = await getOpenTabs(request)
+		// Sanity check
+		const visibleEditors = vscode.window.visibleTextEditors.length
+		assert.strictEqual(visibleEditors, 1, `Expected 1 visible editor, got ${visibleEditors}`)
+
+		// Should have all 3 tabs open, even though only 1 is visible
+		assert.strictEqual(response.paths.length, 3, `Expected 3 open tabs, got ${response.paths.length}`)
+	})
+})

--- a/src/hosts/vscode/hostbridge/window/getOpenTabs.ts
+++ b/src/hosts/vscode/hostbridge/window/getOpenTabs.ts
@@ -1,0 +1,11 @@
+import { window, TabInputText } from "vscode"
+import { GetOpenTabsRequest, GetOpenTabsResponse } from "@/shared/proto/host/window"
+
+export async function getOpenTabs(_: GetOpenTabsRequest): Promise<GetOpenTabsResponse> {
+	const openTabPaths = window.tabGroups.all
+		.flatMap((group) => group.tabs)
+		.map((tab) => (tab.input as TabInputText)?.uri?.fsPath)
+		.filter(Boolean)
+
+	return GetOpenTabsResponse.create({ paths: openTabPaths })
+}

--- a/src/hosts/vscode/hostbridge/window/getVisibleTabs.test.ts
+++ b/src/hosts/vscode/hostbridge/window/getVisibleTabs.test.ts
@@ -1,0 +1,117 @@
+/* eslint-disable eslint-rules/no-direct-vscode-api */
+import { describe, it, beforeEach, afterEach } from "mocha"
+import { strict as assert } from "assert"
+import * as vscode from "vscode"
+import { getVisibleTabs } from "@/hosts/vscode/hostbridge/window/getVisibleTabs"
+import { GetVisibleTabsRequest } from "@/shared/proto/host/window"
+
+describe("Hostbridge - Window - getVisibleTabs", () => {
+	/**
+	 * Helper function to create and open a test document in a specific column
+	 */
+	async function createAndOpenTestDocument(fileNumber: number, column: vscode.ViewColumn): Promise<void> {
+		const content = `// Test file ${fileNumber}\nconsole.log('Hello from file ${fileNumber}');`
+		const doc = await vscode.workspace.openTextDocument({
+			content,
+			language: "javascript",
+		})
+		await vscode.window.showTextDocument(doc, column)
+	}
+
+	beforeEach(async () => {
+		// Clean up any existing editors
+		await vscode.commands.executeCommand("workbench.action.closeAllEditors")
+	})
+
+	afterEach(async () => {
+		// Clean up test documents and editors
+		await vscode.commands.executeCommand("workbench.action.closeAllEditors")
+	})
+
+	it("should return empty array when no visible editors are open", async () => {
+		// Ensure no editors are open
+		await vscode.commands.executeCommand("workbench.action.closeAllEditors")
+
+		const request = GetVisibleTabsRequest.create({})
+		const response = await getVisibleTabs(request)
+
+		assert.strictEqual(response.paths.length, 0, "Should return empty array when no visible editors are open")
+	})
+
+	it("should return paths of visible text editors", async () => {
+		// Open the first document in an editor (this makes it visible)
+		await createAndOpenTestDocument(1, vscode.ViewColumn.One)
+
+		// Wait a bit for editor to be fully created
+		await new Promise((resolve) => setTimeout(resolve, 100))
+
+		const request = GetVisibleTabsRequest.create({})
+		const response = await getVisibleTabs(request)
+
+		// Should have 1 visible editor
+		assert.strictEqual(response.paths.length, 1, `Expected 1 visible editor, got ${response.paths.length}`)
+
+		// Open the second document in a different column (both should now be visible)
+		await createAndOpenTestDocument(2, vscode.ViewColumn.Two)
+
+		// Wait a bit for editor to be fully created
+		await new Promise((resolve) => setTimeout(resolve, 100))
+
+		const response2 = await getVisibleTabs(request)
+
+		// Should have 2 visible editors
+		assert.strictEqual(response2.paths.length, 2, `Expected 2 visible editors, got ${response2.paths.length}`)
+	})
+
+	it("should only return visible editors, not all open tabs", async () => {
+		// Open all documents in the same column (only the last one will be visible)
+		await createAndOpenTestDocument(1, vscode.ViewColumn.One)
+		await createAndOpenTestDocument(2, vscode.ViewColumn.One)
+		await createAndOpenTestDocument(3, vscode.ViewColumn.One)
+
+		// Wait a bit for editors to be fully created
+		await new Promise((resolve) => setTimeout(resolve, 100))
+
+		const request = GetVisibleTabsRequest.create({})
+		const response = await getVisibleTabs(request)
+
+		// Should have only 1 visible editor (the last one opened in the same column)
+		assert.strictEqual(response.paths.length, 1, `Expected 1 visible editor, got ${response.paths.length}`)
+
+		// Verify that we have the correct number of visible text editors
+		const actualVisibleEditors = vscode.window.visibleTextEditors.length
+		assert.strictEqual(
+			response.paths.length,
+			actualVisibleEditors,
+			`Response should match actual visible editors count: ${actualVisibleEditors}`,
+		)
+	})
+
+	it("should return only visible editors from multiple columns with multiple files", async () => {
+		// Open multiple documents in column one (only the last one will be visible in that column)
+		await createAndOpenTestDocument(1, vscode.ViewColumn.One)
+		await createAndOpenTestDocument(2, vscode.ViewColumn.One)
+		await createAndOpenTestDocument(3, vscode.ViewColumn.One)
+
+		// Open multiple documents in column two (only the last one will be visible in that column)
+		await createAndOpenTestDocument(4, vscode.ViewColumn.Two)
+		await createAndOpenTestDocument(5, vscode.ViewColumn.Two)
+
+		// Wait a bit for editors to be fully created
+		await new Promise((resolve) => setTimeout(resolve, 100))
+
+		const request = GetVisibleTabsRequest.create({})
+		const response = await getVisibleTabs(request)
+
+		// Should have only 2 visible editors (one from each column, despite having 5 total open tabs)
+		assert.strictEqual(response.paths.length, 2, `Expected 2 visible editors, got ${response.paths.length}`)
+
+		// Verify that we have the correct number of visible text editors
+		const actualVisibleEditors = vscode.window.visibleTextEditors.length
+		assert.strictEqual(
+			response.paths.length,
+			actualVisibleEditors,
+			`Response should match actual visible editors count: ${actualVisibleEditors}`,
+		)
+	})
+})

--- a/src/hosts/vscode/hostbridge/window/getVisibleTabs.ts
+++ b/src/hosts/vscode/hostbridge/window/getVisibleTabs.ts
@@ -1,0 +1,8 @@
+import { window, TabInputText } from "vscode"
+import { GetVisibleTabsRequest, GetVisibleTabsResponse } from "@/shared/proto/host/window"
+
+export async function getVisibleTabs(_: GetVisibleTabsRequest): Promise<GetVisibleTabsResponse> {
+	const visibleTabPaths = window.visibleTextEditors?.map((editor) => editor.document?.uri?.fsPath).filter(Boolean)
+
+	return GetVisibleTabsResponse.create({ paths: visibleTabPaths })
+}


### PR DESCRIPTION
This commit introduces a new abstraction layer for managing editor tabs through the Hostbridge. It adds `getOpenTabs` and `getVisibleTabs` RPCs to the `window.proto` definition.

Key changes:

- Implemented `getOpenTabs` and `getVisibleTabs` handlers for the VS Code host.
- Updated core task logic to use the new Hostbridge methods instead of direct API calls.
- Added comprehensive unit tests for the new tab management functions.

No behavior change is expected. Requests like "Explain me that class" should work. 