### PR TITLE
Add an RPC to the host bridge to scroll the diff viewer.

### DIFF
--- a/proto/host/diff.proto
+++ b/proto/host/diff.proto
@@ -14,6 +14,7 @@ service DiffService {
   rpc getDocumentText(GetDocumentTextRequest) returns (GetDocumentTextResponse);
   // Replace a text selection in the diff.
   rpc replaceText(ReplaceTextRequest) returns (ReplaceTextResponse);
+  rpc scrollDiff(ScrollDiffRequest) returns (ScrollDiffResponse);
   // Truncate the diff document.
   rpc truncateDocument(TruncateDocumentRequest) returns (TruncateDocumentResponse);
   // Save the diff document.
@@ -54,10 +55,17 @@ message ReplaceTextRequest {
 
 message ReplaceTextResponse {}
 
+message ScrollDiffRequest {
+  optional string diff_id = 1;
+  optional int32 line = 2;
+}
+
+message ScrollDiffResponse {}
+
 message TruncateDocumentRequest {
   optional cline.Metadata metadata = 1;
   optional string diff_id = 2;
-  optional int32 end_line = 5;
+  optional int32 end_line = 3;
 }
 
 message TruncateDocumentResponse {}

--- a/src/hosts/external/ExternalDiffviewProvider.ts
+++ b/src/hosts/external/ExternalDiffviewProvider.ts
@@ -61,7 +61,12 @@ export class ExternalDiffViewProvider extends DiffViewProvider {
 		}
 	}
 
-	protected override async scrollEditorToLine(_line: number): Promise<void> {}
+	protected override async scrollEditorToLine(line: number): Promise<void> {
+		if (!this.activeDiffEditorId) {
+			return
+		}
+		await HostProvider.diff.scrollDiff({ diffId: this.activeDiffEditorId, line: line })
+	}
 
 	override async scrollAnimation(_startLine: number, _endLine: number): Promise<void> {}
 

--- a/src/hosts/vscode/hostbridge/diff/scrollDiff.ts
+++ b/src/hosts/vscode/hostbridge/diff/scrollDiff.ts
@@ -1,0 +1,5 @@
+import { ScrollDiffRequest, ScrollDiffResponse } from "@/shared/proto/index.host"
+
+export async function scrollDiff(_request: ScrollDiffRequest): Promise<ScrollDiffResponse> {
+	throw new Error("diffService is not supported. Use the VscodeDiffViewProvider.")
+}


### PR DESCRIPTION
Add the implememntation of scrollToLine to the ExternalDiffViewProvider
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `scrollDiff` RPC to `DiffService` and implements it in `ExternalDiffViewProvider.ts`, with a placeholder in `scrollDiff.ts`.
> 
>   - **RPC Addition**:
>     - Adds `scrollDiff` RPC to `DiffService` in `proto/host/diff.proto`.
>     - Defines `ScrollDiffRequest` with `diff_id` and `line` fields.
>     - Defines `ScrollDiffResponse`.
>   - **Implementation**:
>     - Implements `scrollEditorToLine()` in `ExternalDiffViewProvider.ts` to call `scrollDiff` with `diffId` and `line`.
>   - **Misc**:
>     - Adds `scrollDiff.ts` with a function that throws an error indicating unsupported service.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for b343f9fee5a01cc0d394edce856ee8ca9c102622. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->