### PR TITLE
Replace vscode show message API calls with the host bridge

### DIFF
--- a/eslint-rules/no-direct-vscode-api.js
+++ b/eslint-rules/no-direct-vscode-api.js
@@ -29,20 +29,21 @@ const disallowedApis = {
 	"vscode.workspace.applyEdit": {
 		messageId: "useHostBridge",
 	},
-	// "vscode.env.openExternal": {
-	// 	messageId: "useUtils",
-	// },
+	"vscode.window.onDidChangeActiveTextEditor": {
+		messageId: "useHostBridge",
+	},
+	"vscode.env.openExternal": {
+		messageId: "useUtils",
+	},
 	// "vscode.window.showWarningMessage": {
 	// 	messageId: "useHostBridgeShowMessage",
 	// },
 	"vscode.window.showOpenDialog": {
 		messageId: "useHostBridgeShowMessage",
 	},
-	// There are too many warnings for these calls, uncomment the following
-	// when the migration is finished.
-	// "vscode.window.showErrorMessage": {
-	// 	messageId: "useHostBridgeShowMessage",
-	// },
+	"vscode.window.showErrorMessage": {
+		messageId: "useHostBridgeShowMessage",
+	},
 	// "vscode.window.showInformationMessage": {
 	// 	messageId: "useHostBridgeShowMessage",
 	// },
@@ -184,6 +185,10 @@ module.exports = createRule({
 				return true
 			}
 			if (filename.includes("/standalone/runtime-files/")) {
+				return true
+			}
+			// Skip unit tests
+			if (filename.endsWith(".test.ts")) {
 				return true
 			}
 		}

--- a/src/integrations/git/commit-message-generator.ts
+++ b/src/integrations/git/commit-message-generator.ts
@@ -38,7 +38,10 @@ async function generate(context: vscode.ExtensionContext, scm?: vscode.SourceCon
 
 	const inputBox = scm?.inputBox
 	if (!inputBox) {
-		vscode.window.showErrorMessage("Git extension not found or no repositories available")
+		HostProvider.window.showMessage({
+			type: ShowMessageType.ERROR,
+			message: "Git extension not found or no repositories available",
+		})
 		return
 	}
 
@@ -100,7 +103,10 @@ Commit message:`
 		}
 	} catch (error) {
 		const errorMessage = error instanceof Error ? error.message : String(error)
-		vscode.window.showErrorMessage(`Failed to generate commit message: ${errorMessage}`)
+		HostProvider.window.showMessage({
+			type: ShowMessageType.ERROR,
+			message: `Failed to generate commit message: ${errorMessage}`,
+		})
 	} finally {
 		vscode.commands.executeCommand("setContext", "cline.isGeneratingCommit", false)
 	}


### PR DESCRIPTION
Replace calls to vscode.window.show*Message with the Host Bridge.

Add APIs that have been fully switched to the Host Bridge to the eslint rule so they cannot be reintroduced later.

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Replaces direct `vscode` message API calls with `HostProvider` methods and updates ESLint rules to enforce this change.
> 
>   - **Behavior**:
>     - Replaces `vscode.window.showErrorMessage` and `vscode.window.showInformationMessage` with `HostProvider.window.showMessage` in `index.ts` and `commit-message-generator.ts`.
>     - Updates ESLint rule in `no-direct-vscode-api.js` to enforce using `HostProvider` for `vscode.window.showErrorMessage` and `vscode.window.showInformationMessage`.
>   - **Files**:
>     - `index.ts`: Replaces all instances of `vscode.window.showErrorMessage` and `vscode.window.showInformationMessage` with `HostProvider.window.showMessage`.
>     - `commit-message-generator.ts`: Similar replacements for error and information messages.
>     - `no-direct-vscode-api.js`: Updates disallowed APIs to include `vscode.window.showErrorMessage` and `vscode.window.showInformationMessage`.
>   - **Misc**:
>     - Skips ESLint checks for `.test.ts` files in `no-direct-vscode-api.js`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for c1d095979d9557dcb8dbb573323da033b08982a1. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->