### PR TITLE
Fix Qwen API options inconsistency

### DIFF
--- a/.changeset/ninety-beers-unite.md
+++ b/.changeset/ninety-beers-unite.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Fix Qwwn Api option inconsistency between UI and API layer

--- a/src/api/providers/qwen.ts
+++ b/src/api/providers/qwen.ts
@@ -9,6 +9,7 @@ import {
 	internationalQwenDefaultModelId,
 	MainlandQwenModelId,
 	InternationalQwenModelId,
+	QwenApiRegions,
 } from "@shared/api"
 import { convertToOpenAiMessages } from "../transform/openai-format"
 import { ApiStream } from "../transform/stream"
@@ -17,7 +18,7 @@ import { withRetry } from "../retry"
 
 interface QwenHandlerOptions {
 	qwenApiKey?: string
-	qwenApiLine?: string
+	qwenApiLine?: QwenApiRegions
 	apiModelId?: string
 	thinkingBudgetTokens?: number
 }
@@ -27,7 +28,15 @@ export class QwenHandler implements ApiHandler {
 	private client: OpenAI | undefined
 
 	constructor(options: QwenHandlerOptions) {
-		this.options = options
+		// Ensure options start with defaults but allow overrides
+		this.options = {
+			qwenApiLine: QwenApiRegions.CHINA,
+			...options,
+		}
+	}
+
+	private useChinaApi(): boolean {
+		return this.options.qwenApiLine === QwenApiRegions.CHINA
 	}
 
 	private ensureClient(): OpenAI {
@@ -37,10 +46,9 @@ export class QwenHandler implements ApiHandler {
 			}
 			try {
 				this.client = new OpenAI({
-					baseURL:
-						this.options.qwenApiLine === "china"
-							? "https://dashscope.aliyuncs.com/compatible-mode/v1"
-							: "https://dashscope-intl.aliyuncs.com/compatible-mode/v1",
+					baseURL: this.useChinaApi()
+						? "https://dashscope.aliyuncs.com/compatible-mode/v1"
+						: "https://dashscope-intl.aliyuncs.com/compatible-mode/v1",
 					apiKey: this.options.qwenApiKey,
 				})
 			} catch (error: any) {
@@ -53,7 +61,7 @@ export class QwenHandler implements ApiHandler {
 	getModel(): { id: MainlandQwenModelId | InternationalQwenModelId; info: ModelInfo } {
 		const modelId = this.options.apiModelId
 		// Branch based on API line to let poor typescript know what to do
-		if (this.options.qwenApiLine === "china") {
+		if (this.useChinaApi()) {
 			return {
 				id: (modelId as MainlandQwenModelId) ?? mainlandQwenDefaultModelId,
 				info: mainlandQwenModels[modelId as MainlandQwenModelId] ?? mainlandQwenModels[mainlandQwenDefaultModelId],

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -1151,6 +1151,10 @@ export const huggingFaceModels = {
 
 // Qwen
 // https://bailian.console.aliyun.com/
+export enum QwenApiRegions {
+	CHINA = "china",
+	INTERNATIONAL = "international",
+}
 export type MainlandQwenModelId = keyof typeof mainlandQwenModels
 export type InternationalQwenModelId = keyof typeof internationalQwenModels
 export const internationalQwenDefaultModelId: InternationalQwenModelId = "qwen-coder-plus-latest"

--- a/webview-ui/src/components/settings/providers/QwenProvider.tsx
+++ b/webview-ui/src/components/settings/providers/QwenProvider.tsx
@@ -1,4 +1,4 @@
-import { ApiConfiguration, internationalQwenModels, mainlandQwenModels } from "@shared/api"
+import { internationalQwenModels, mainlandQwenModels, QwenApiRegions } from "@shared/api"
 import { VSCodeDropdown, VSCodeOption } from "@vscode/webview-ui-toolkit/react"
 import { ApiKeyField } from "../common/ApiKeyField"
 import { ModelSelector, DropdownContainer } from "../common/ModelSelector"
@@ -9,6 +9,7 @@ import { DROPDOWN_Z_INDEX } from "../ApiOptions"
 import { useExtensionState } from "@/context/ExtensionStateContext"
 import { useApiConfigurationHandlers } from "../utils/useApiConfigurationHandlers"
 import { Mode } from "@shared/ChatSettings"
+import { useMemo } from "react"
 
 const SUPPORTED_THINKING_MODELS = [
 	"qwen3-235b-a22b",
@@ -32,6 +33,9 @@ interface QwenProviderProps {
 	currentMode: Mode
 }
 
+// Turns enum into an array of values for dropdown options
+export const qwenApiOptions: QwenApiRegions[] = Object.values(QwenApiRegions)
+
 /**
  * The Alibaba Qwen provider configuration component
  */
@@ -43,7 +47,10 @@ export const QwenProvider = ({ showModelOptions, isPopup, currentMode }: QwenPro
 	const { selectedModelId, selectedModelInfo } = normalizeApiConfiguration(apiConfiguration, currentMode)
 
 	// Determine which models to use based on API line selection
-	const qwenModels = apiConfiguration?.qwenApiLine === "china" ? mainlandQwenModels : internationalQwenModels
+	const qwenModels = useMemo(
+		() => (apiConfiguration?.qwenApiLine === QwenApiRegions.CHINA ? mainlandQwenModels : internationalQwenModels),
+		[apiConfiguration?.qwenApiLine],
+	)
 
 	return (
 		<div>
@@ -53,14 +60,17 @@ export const QwenProvider = ({ showModelOptions, isPopup, currentMode }: QwenPro
 				</label>
 				<VSCodeDropdown
 					id="qwen-line-provider"
-					value={apiConfiguration?.qwenApiLine || "china"}
-					onChange={(e: any) => handleFieldChange("qwenApiLine", e.target.value)}
+					value={apiConfiguration?.qwenApiLine || qwenApiOptions[0]}
+					onChange={(e: any) => handleFieldChange("qwenApiLine", e.target.value as QwenApiRegions)}
 					style={{
 						minWidth: 130,
 						position: "relative",
 					}}>
-					<VSCodeOption value="china">China API</VSCodeOption>
-					<VSCodeOption value="international">International API</VSCodeOption>
+					{qwenApiOptions.map((line) => (
+						<VSCodeOption key={line} value={line}>
+							{line.charAt(0).toUpperCase() + line.slice(1)} API
+						</VSCodeOption>
+					))}
 				</VSCodeDropdown>
 			</DropdownContainer>
 			<p
@@ -74,6 +84,7 @@ export const QwenProvider = ({ showModelOptions, isPopup, currentMode }: QwenPro
 			</p>
 
 			<ApiKeyField
+				key="qwenApiKey"
 				initialValue={apiConfiguration?.qwenApiKey || ""}
 				onChange={(value) => handleFieldChange("qwenApiKey", value)}
 				providerName="Qwen"
@@ -83,6 +94,7 @@ export const QwenProvider = ({ showModelOptions, isPopup, currentMode }: QwenPro
 			{showModelOptions && (
 				<>
 					<ModelSelector
+						key="qwenModelSelector"
 						models={qwenModels}
 						selectedModelId={selectedModelId}
 						onChange={(e: any) =>


### PR DESCRIPTION
<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- Opened an issue and discussed your proposed changes with the community / contributors
- Received approval from a core Cline contributor prior to proceeding with the implementation
- Link the associated issue in the "Related Issue" section

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly.

Why this requirement?
We deeply appreciate all community contributions - they are the core reason we're able to operate successfully and keep innovating! We welcome community input and want to make it as easy as possible for people to submit quality work. This process helps our core maintainers review new ideas faster and saves contributor time by ensuring you have the go-ahead before spending time on implementation.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** #XXXX

### Description

<!-- 
Help reviewers understand your changes by making this PR readable and well-organized:

- What problem does this PR solve?
- Why were these changes introduced and what purpose do they serve?
- For larger changes, provide context about your approach and reasoning

Small PRs may need minimal description, but larger changes benefit from explaining where you're coming from. Much of this context can be in the linked issue above, so feel free to reference it rather than repeating everything here.
-->


Refactor Qwen API region handling with enum and improved type safety

#### Issue

1. Webview Layer:  shows "China API" as the default & first option, leading users to believe they're using China API
2. API Handler Layer: Receives undefined for this.options.qwenApiLine when no explicit selection is made


#### Fixes

- Modified the API handler factory to explicitly pass the default China region when qwenApiLine is undefined
- Updated all type annotations to use the new enum instead of loose strings
- Updated the provider component to use the enum values consistently

#### Changess

- Replace string literals with QwenApiRegions enum for better type safety
- Add default region initialization in QwenHandler constructor
- Extract useChinaApi() method for cleaner conditional logic
- Update UI dropdown to use enum values with proper memoization
- Improve code maintainability and reduce magic strings

> TODO: This is a bandaid fix -a more systemic approach is needed to solve the underlying issue

### Test Procedure

<!-- 
Please walk us through your testing approach and thought process. This helps reviewers understand that you've thoroughly considered the impact of your changes:

- How did you test this change?
- What could potentially break and how did you verify it doesn't?
- What existing functionality might be affected and how did you check it still works?
- Why are you confident this is ready for merge?

We're not looking for exhaustive documentation - just evidence that you've thought through the implications of your changes and tested accordingly.
-->

1. Verified that new users see China API selected by default and actually use China endpoints
2. Confirmed that existing configurations with explicit API line selections continue to work
3. Tested switching between China and International APIs works correctly


### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

value is now set to china by default when no explicit changes were made in the UI

<img width="2052" height="1174" alt="Screenshot 2025-07-24 at 11 30 54 PM" src="https://github.com/user-attachments/assets/4082c977-9943-470b-b6a6-5d3d6ec05118" />

### Additional Notes

<!-- Add any additional notes for reviewers -->
