### PR TITLE
Add a check to the proto scripts to warn about using int64 types.

### DIFF
--- a/package.json
+++ b/package.json
@@ -345,7 +345,7 @@
 		"watch:esbuild": "node esbuild.js --watch",
 		"watch:tsc": "tsc --noEmit --watch --project tsconfig.json",
 		"package": "npm run check-types && npm run build:webview && npm run lint && node esbuild.js --production",
-		"protos": "node scripts/build-proto.mjs && node scripts/generate-protobus-setup.mjs && node scripts/generate-host-bridge-client.mjs",
+		"protos": "node scripts/build-proto.mjs",
 		"postprotos": "prettier src/shared/proto src/core/controller src/hosts/ webview-ui/src/services src/generated --write --log-level warn",
 		"clean": "rimraf dist dist-standalone webview-ui/build src/generated out/",
 		"compile-tests": "node ./scripts/build-tests.js",

--- a/scripts/generate-host-bridge-client.mjs
+++ b/scripts/generate-host-bridge-client.mjs
@@ -15,7 +15,7 @@ const VSCODE_CLIENT_FILE = path.resolve("src/generated/hosts/vscode/hostbridge-g
 /**
  * Main function to generate the host bridge client
  */
-async function main() {
+export async function main() {
 	const { hostServices } = await loadServicesFromProtoDescriptor()
 
 	await generateTypesFile(hostServices)
@@ -234,8 +234,10 @@ const ${name}ServiceRegistry = createServiceRegistry("${name}")
 ${methods}`
 }
 
-// Run the main function
-main().catch((error) => {
-	console.error(chalk.red("Error:"), error)
-	process.exit(1)
-})
+// Only run main if this script is executed directly
+if (import.meta.url === `file://${process.argv[1]}`) {
+	main().catch((error) => {
+		console.error(chalk.red("Error:"), error)
+		process.exit(1)
+	})
+}

--- a/scripts/generate-protobus-setup.mjs
+++ b/scripts/generate-protobus-setup.mjs
@@ -12,7 +12,7 @@ const STANDALONE_SERVER_SETUP_FILE = path.resolve("src/generated/hosts/standalon
 
 const SCRIPT_NAME = path.relative(process.cwd(), fileURLToPath(import.meta.url))
 
-async function main() {
+export async function main() {
 	const { protobusServices } = await loadServicesFromProtoDescriptor()
 	await generateWebviewProtobusClients(protobusServices)
 	await generateVscodeServiceTypes(protobusServices)
@@ -205,4 +205,10 @@ function getDirName(serviceName) {
 	return domain.charAt(0).toLowerCase() + domain.slice(1)
 }
 
-main()
+// Only run main if this script is executed directly
+if (import.meta.url === `file://${process.argv[1]}`) {
+	main().catch((error) => {
+		console.error(chalk.red("Error:"), error)
+		process.exit(1)
+	})
+}

--- a/scripts/proto-utils.mjs
+++ b/scripts/proto-utils.mjs
@@ -10,7 +10,7 @@ const DESCRIPTOR_SET = path.resolve("dist-standalone/proto/descriptor_set.pb")
 const typeNameToFQN = new Map()
 
 function addTypeNameToFqn(name, fqn) {
-	if (typeNameToFQN.has(name)) {
+	if (typeNameToFQN.has(name) && typeNameToFQN.get(name) !== fqn) {
 		throw new Error(`Proto type ${name} redefined (${fqn}).`)
 	}
 	typeNameToFQN.set(name, fqn)
@@ -23,11 +23,15 @@ export function getFqn(name) {
 	return typeNameToFQN.get(name)
 }
 
-export async function loadServicesFromProtoDescriptor() {
-	// Load service definitions from descriptor set
+export async function loadProtoDescriptorSet() {
 	const descriptorBuffer = await fs.readFile(DESCRIPTOR_SET)
 	const packageDefinition = protoLoader.loadFileDescriptorSetFromBuffer(descriptorBuffer)
-	const proto = grpc.loadPackageDefinition(packageDefinition)
+	return grpc.loadPackageDefinition(packageDefinition)
+}
+
+export async function loadServicesFromProtoDescriptor() {
+	// Load service definitions from descriptor set
+	const proto = await loadProtoDescriptorSet()
 
 	// Extract host services and proto messages from the proto definition
 	const hostServices = {}


### PR DESCRIPTION
Javascript cannot represent the full range of int64. So, when the protos are deserialized from JSON int64's are converted to strings. The typescript code is expecting a number and not a string, and this causes errors.

This was not noticed before now because in the vscode ProtoBus and HostBridge, the proto messages are not serialized and deserialized, they are just passed around as JS objects.

However, in IntelliJ the protos are serialized when they are sent through the ProtoBus. When the response messages contains an int64, it is deserialized to a string instead of a number for safety. This is causes parts of Cline to fail in IntelliJ, e.g. the task history view won't load because `Task.getTotalTasksSize()` returns a string when it is expecting a number.

<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- Opened an issue and discussed your proposed changes with the community / contributors
- Received approval from a core Cline contributor prior to proceeding with the implementation
- Link the associated issue in the "Related Issue" section

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly.

Why this requirement?
We deeply appreciate all community contributions - they are the core reason we're able to operate successfully and keep innovating! We welcome community input and want to make it as easy as possible for people to submit quality work. This process helps our core maintainers review new ideas faster and saves contributor time by ensuring you have the go-ahead before spending time on implementation.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** #XXXX

### Description

<!-- 
Help reviewers understand your changes by making this PR readable and well-organized:

- What problem does this PR solve?
- Why were these changes introduced and what purpose do they serve?
- For larger changes, provide context about your approach and reasoning

Small PRs may need minimal description, but larger changes benefit from explaining where you're coming from. Much of this context can be in the linked issue above, so feel free to reference it rather than repeating everything here.
-->

### Test Procedure

<!-- 
Please walk us through your testing approach and thought process. This helps reviewers understand that you've thoroughly considered the impact of your changes:

- How did you test this change?
- What could potentially break and how did you verify it doesn't?
- What existing functionality might be affected and how did you check it still works?
- Why are you confident this is ready for merge?

We're not looking for exhaustive documentation - just evidence that you've thought through the implications of your changes and tested accordingly.
-->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [ ] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->
