### PR TITLE
Fix issue where checkpointing blocked UI

### DIFF
--- a/.changeset/wet-fishes-study.md
+++ b/.changeset/wet-fishes-study.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Fix issue where checkpointing blocked UI


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Modify `Task` class to perform non-blocking checkpoint creation, preventing UI freeze during operations.
> 
>   - **Behavior**:
>     - Modify checkpoint creation in `Task` class to be non-blocking, preventing UI freeze during checkpoint operations.
>     - Use asynchronous promise in `checkpointTracker.commit()` to handle git operations in the background.
>     - Update checkpoint message with commit hash after completion.
>   - **Functions**:
>     - Changes in `Task` class, specifically in `saveCheckpoint()` method.
>     - Uses `this.checkpointTracker.commit().then()` for non-blocking execution.
>   - **Misc**:
>     - Add comments explaining the non-blocking behavior and its necessity for UI responsiveness.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 419534ccd4241fc11827741eb0d76ba0c9d21277. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->