### PR TITLE
Fix cursor state after restoring files to be disabled after checked out

### DIFF
--- a/.changeset/silver-llamas-pretend.md
+++ b/.changeset/silver-llamas-pretend.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Fix cursor state after restoring files to be disabled after checked out

--- a/webview-ui/src/components/common/CheckmarkControl.tsx
+++ b/webview-ui/src/components/common/CheckmarkControl.tsx
@@ -219,7 +219,11 @@ export const CheckmarkControl = ({ messageTs, isCheckpointCheckedOut }: Checkmar
 										onClick={handleRestoreWorkspace}
 										disabled={restoreWorkspaceDisabled || isCheckpointCheckedOut}
 										style={{
-											cursor: restoreWorkspaceDisabled || isCheckpointCheckedOut ? "wait" : "pointer",
+											cursor: isCheckpointCheckedOut
+												? "not-allowed"
+												: restoreWorkspaceDisabled
+													? "wait"
+													: "pointer",
 											width: "100%",
 											marginBottom: "10px",
 										}}>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update cursor style for `Restore Files` button in `CheckmarkControl.tsx` to `not-allowed` when checkpoint is checked out.
> 
>   - **UI Behavior**:
>     - In `CheckmarkControl.tsx`, updates cursor style for `Restore Files` button to `not-allowed` when `isCheckpointCheckedOut` is true, instead of `wait`.
>     - Retains `wait` cursor when `restoreWorkspaceDisabled` is true and `isCheckpointCheckedOut` is false.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 9b06f4335d98c7bbb4b56e391cc9b22c9a1c9121. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->