### PR TITLE
Move the OutputChannel to the HostProvider

### DIFF
--- a/.clinerules/cline-overview.md
+++ b/.clinerules/cline-overview.md
@@ -716,7 +716,7 @@ The Controller class manages MCP servers through the McpHub service:
 class Controller {
   mcpHub?: McpHub
 
-  constructor(context: vscode.ExtensionContext, outputChannel: vscode.OutputChannel, webviewProvider: WebviewProvider) {
+  constructor(context: vscode.ExtensionContext, webviewProvider: WebviewProvider) {
     this.mcpHub = new McpHub(this)
   }
 

--- a/src/core/context/context-tracking/FileContextTracker.test.ts
+++ b/src/core/context/context-tracking/FileContextTracker.test.ts
@@ -60,6 +60,7 @@ describe("FileContextTracker", () => {
 			((_) => {}) as WebviewProviderCreator,
 			(() => {}) as DiffViewProviderCreator,
 			vscodeHostBridgeClient,
+			(_) => {},
 		)
 
 		// Create tracker instance

--- a/src/core/controller/index.ts
+++ b/src/core/controller/index.ts
@@ -59,12 +59,12 @@ export class Controller {
 
 	constructor(
 		readonly context: vscode.ExtensionContext,
-		private readonly outputChannel: vscode.OutputChannel,
 		postMessage: (message: ExtensionMessage) => Thenable<boolean> | undefined,
 		id: string,
 	) {
 		this.id = id
-		this.outputChannel.appendLine("ClineProvider instantiated")
+
+		HostProvider.get().logToChannel("ClineProvider instantiated")
 		this.postMessage = postMessage
 
 		this.workspaceTracker = new WorkspaceTracker()
@@ -79,7 +79,7 @@ export class Controller {
 		this.authService.restoreRefreshTokenAndRetrieveAuthInfo()
 
 		// Clean up legacy checkpoints
-		cleanupLegacyCheckpoints(this.context.globalStorageUri.fsPath, this.outputChannel).catch((error) => {
+		cleanupLegacyCheckpoints(this.context.globalStorageUri.fsPath).catch((error) => {
 			console.error("Failed to cleanup legacy checkpoints:", error)
 		})
 	}

--- a/src/core/webview/index.ts
+++ b/src/core/webview/index.ts
@@ -11,7 +11,7 @@ import { v4 as uuidv4 } from "uuid"
 import { Uri } from "vscode"
 import { ExtensionMessage } from "@/shared/ExtensionMessage"
 import { HostProvider } from "@/hosts/host-provider"
-import { ShowMessageRequest, ShowMessageType } from "@/shared/proto/host/window"
+import { ShowMessageType } from "@/shared/proto/host/window"
 
 export abstract class WebviewProvider {
 	public static readonly sideBarId = "claude-dev.SidebarProvider" // used in package.json as the view's id. This value cannot be changed due to how vscode caches views based on their id, and updating the id would break existing instances of the extension.
@@ -24,13 +24,13 @@ export abstract class WebviewProvider {
 
 	constructor(
 		readonly context: vscode.ExtensionContext,
-		protected readonly outputChannel: vscode.OutputChannel,
+
 		private readonly providerType: WebviewProviderType,
 	) {
 		WebviewProvider.activeInstances.add(this)
 		this.clientId = uuidv4()
 		WebviewProvider.clientIdMap.set(this, this.clientId)
-		this.controller = new Controller(context, outputChannel, (message) => this.postMessageToWebview(message), this.clientId)
+		this.controller = new Controller(context, (message) => this.postMessageToWebview(message), this.clientId)
 	}
 
 	// Add a method to get the client ID

--- a/src/exports/index.ts
+++ b/src/exports/index.ts
@@ -1,50 +1,48 @@
-import * as vscode from "vscode"
 import { Controller } from "@core/controller"
 import { ClineAPI } from "./cline"
-import { getGlobalState } from "@core/storage/state"
 import { sendChatButtonClickedEvent } from "@core/controller/ui/subscribeToChatButtonClicked"
-import { WebviewProviderType as WebviewProviderTypeEnum } from "@shared/proto/cline/ui"
+import { HostProvider } from "@/hosts/host-provider"
 
-export function createClineAPI(outputChannel: vscode.OutputChannel, sidebarController: Controller): ClineAPI {
+export function createClineAPI(sidebarController: Controller): ClineAPI {
 	const api: ClineAPI = {
 		startNewTask: async (task?: string, images?: string[]) => {
-			outputChannel.appendLine("Starting new task")
+			HostProvider.get().logToChannel("Starting new task")
 			await sidebarController.clearTask()
 			await sidebarController.postStateToWebview()
 
 			await sendChatButtonClickedEvent(sidebarController.id)
 			await sidebarController.initTask(task, images)
-			outputChannel.appendLine(
+			HostProvider.get().logToChannel(
 				`Task started with message: ${task ? `"${task}"` : "undefined"} and ${images?.length || 0} image(s)`,
 			)
 		},
 
 		sendMessage: async (message?: string, images?: string[]) => {
-			outputChannel.appendLine(
+			HostProvider.get().logToChannel(
 				`Sending message: ${message ? `"${message}"` : "undefined"} with ${images?.length || 0} image(s)`,
 			)
 			if (sidebarController.task) {
 				await sidebarController.task.handleWebviewAskResponse("messageResponse", message || "", images || [])
 			} else {
-				outputChannel.appendLine("No active task to send message to")
+				HostProvider.get().logToChannel("No active task to send message to")
 			}
 		},
 
 		pressPrimaryButton: async () => {
-			outputChannel.appendLine("Pressing primary button")
+			HostProvider.get().logToChannel("Pressing primary button")
 			if (sidebarController.task) {
 				await sidebarController.task.handleWebviewAskResponse("yesButtonClicked", "", [])
 			} else {
-				outputChannel.appendLine("No active task to press button for")
+				HostProvider.get().logToChannel("No active task to press button for")
 			}
 		},
 
 		pressSecondaryButton: async () => {
-			outputChannel.appendLine("Pressing secondary button")
+			HostProvider.get().logToChannel("Pressing secondary button")
 			if (sidebarController.task) {
 				await sidebarController.task.handleWebviewAskResponse("noButtonClicked", "", [])
 			} else {
-				outputChannel.appendLine("No active task to press button for")
+				HostProvider.get().logToChannel("No active task to press button for")
 			}
 		},
 	}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,45 +1,45 @@
 // The module 'vscode' contains the VS Code extensibility API
 // Import the module and reference it with the alias vscode in your code below
-import { setTimeout as setTimeoutPromise } from "node:timers/promises"
-import * as vscode from "vscode"
-import pWaitFor from "p-wait-for"
-import { Logger } from "./services/logging/Logger"
-import { createClineAPI } from "./exports"
-import "./utils/path" // necessary to have access to String.prototype.toPosix
 import { DIFF_VIEW_URI_SCHEME } from "@hosts/vscode/VscodeDiffViewProvider"
-import assert from "node:assert"
-import { posthogClientProvider } from "./services/posthog/PostHogClientProvider"
-import { WebviewProvider } from "./core/webview"
-import { sendMcpButtonClickedEvent } from "./core/controller/ui/subscribeToMcpButtonClicked"
-import { sendChatButtonClickedEvent } from "./core/controller/ui/subscribeToChatButtonClicked"
-import { ErrorService } from "./services/error/ErrorService"
-import { initializeTestMode, cleanupTestMode } from "./services/test/TestMode"
-import { telemetryService } from "./services/posthog/telemetry/TelemetryService"
-import { sendSettingsButtonClickedEvent } from "./core/controller/ui/subscribeToSettingsButtonClicked"
-import { v4 as uuidv4 } from "uuid"
 import { WebviewProviderType as WebviewProviderTypeEnum } from "@shared/proto/cline/ui"
-import { WebviewProviderType } from "./shared/webview/types"
-import { sendHistoryButtonClickedEvent } from "./core/controller/ui/subscribeToHistoryButtonClicked"
+import assert from "node:assert"
+import { setTimeout as setTimeoutPromise } from "node:timers/promises"
+import pWaitFor from "p-wait-for"
+import { v4 as uuidv4 } from "uuid"
+import * as vscode from "vscode"
 import { sendAccountButtonClickedEvent } from "./core/controller/ui/subscribeToAccountButtonClicked"
+import { sendChatButtonClickedEvent } from "./core/controller/ui/subscribeToChatButtonClicked"
+import { sendHistoryButtonClickedEvent } from "./core/controller/ui/subscribeToHistoryButtonClicked"
+import { sendMcpButtonClickedEvent } from "./core/controller/ui/subscribeToMcpButtonClicked"
+import { sendSettingsButtonClickedEvent } from "./core/controller/ui/subscribeToSettingsButtonClicked"
 import {
-	migrateWorkspaceToGlobalStorage,
 	migrateCustomInstructionsToGlobalRules,
+	migrateLegacyApiConfigurationToModeSpecific,
 	migrateModeFromWorkspaceStorageToControllerState,
 	migrateWelcomeViewCompleted,
-	migrateLegacyApiConfigurationToModeSpecific,
+	migrateWorkspaceToGlobalStorage,
 } from "./core/storage/state-migrations"
+import { WebviewProvider } from "./core/webview"
+import { createClineAPI } from "./exports"
+import { ErrorService } from "./services/error/ErrorService"
+import { Logger } from "./services/logging/Logger"
+import { posthogClientProvider } from "./services/posthog/PostHogClientProvider"
+import { telemetryService } from "./services/posthog/telemetry/TelemetryService"
+import { cleanupTestMode, initializeTestMode } from "./services/test/TestMode"
+import { WebviewProviderType } from "./shared/webview/types"
+import "./utils/path" // necessary to have access to String.prototype.toPosix
 
-import { sendFocusChatInputEvent } from "./core/controller/ui/subscribeToFocusChatInput"
-import { FileContextTracker } from "./core/context/context-tracking/FileContextTracker"
-import { vscodeHostBridgeClient } from "@/hosts/vscode/hostbridge/client/host-grpc-client"
-import { VscodeWebviewProvider } from "./hosts/vscode/VscodeWebviewProvider"
-import { ExtensionContext } from "vscode"
-import { AuthService } from "./services/auth/AuthService"
-import { writeTextToClipboard, readTextFromClipboard } from "@/utils/env"
-import { VscodeDiffViewProvider } from "./hosts/vscode/VscodeDiffViewProvider"
 import { HostProvider } from "@/hosts/host-provider"
-import { ShowMessageType } from "./shared/proto/host/window"
+import { vscodeHostBridgeClient } from "@/hosts/vscode/hostbridge/client/host-grpc-client"
+import { readTextFromClipboard, writeTextToClipboard } from "@/utils/env"
+import { ExtensionContext } from "vscode"
+import { FileContextTracker } from "./core/context/context-tracking/FileContextTracker"
+import { sendFocusChatInputEvent } from "./core/controller/ui/subscribeToFocusChatInput"
+import { VscodeDiffViewProvider } from "./hosts/vscode/VscodeDiffViewProvider"
+import { VscodeWebviewProvider } from "./hosts/vscode/VscodeWebviewProvider"
 import { GitCommitGenerator } from "./integrations/git/commit-message-generator"
+import { AuthService } from "./services/auth/AuthService"
+import { ShowMessageType } from "./shared/proto/host/window"
 /*
 Built using https://github.com/microsoft/vscode-webview-ui-toolkit
 

--- a/src/hosts/external/ExternalWebviewProvider.ts
+++ b/src/hosts/external/ExternalWebviewProvider.ts
@@ -8,8 +8,8 @@ export class ExternalWebviewProvider extends WebviewProvider {
 	// This hostname cannot be changed without updating the external webview handler.
 	private RESOURCE_HOSTNAME: string = "internal.resources"
 
-	constructor(context: vscode.ExtensionContext, outputChannel: vscode.OutputChannel, providerType: WebviewProviderType) {
-		super(context, outputChannel, providerType)
+	constructor(context: vscode.ExtensionContext, providerType: WebviewProviderType) {
+		super(context, providerType)
 	}
 
 	override getWebviewUri(uri: URI) {

--- a/src/hosts/host-provider.ts
+++ b/src/hosts/host-provider.ts
@@ -62,7 +62,7 @@ export class HostProvider {
 	 */
 	public static get(): HostProvider {
 		if (!HostProvider.instance) {
-			throw new Error("HostProvider not initialized. Call HostProvider.initialize() first.")
+			throw new Error("HostProvider not setup. Call HostProvider.initialize() first.")
 		}
 		return HostProvider.instance
 	}

--- a/src/hosts/host-provider.ts
+++ b/src/hosts/host-provider.ts
@@ -23,26 +23,37 @@ export class HostProvider {
 	createDiffViewProvider: DiffViewProviderCreator
 	hostBridge: HostBridgeClientProvider
 
+	// Logs to a user-visible output channel.
+	logToChannel: LogToChannel
+
 	// Private constructor to enforce singleton pattern
 	private constructor(
 		createWebviewProvider: WebviewProviderCreator,
 		createDiffViewProvider: DiffViewProviderCreator,
 		hostBridge: HostBridgeClientProvider,
+		logToChannel: LogToChannel,
 	) {
 		this.createWebviewProvider = createWebviewProvider
 		this.createDiffViewProvider = createDiffViewProvider
 		this.hostBridge = hostBridge
+		this.logToChannel = logToChannel
 	}
 
 	public static initialize(
 		webviewProviderCreator: WebviewProviderCreator,
 		diffViewProviderCreator: DiffViewProviderCreator,
 		hostBridgeProvider: HostBridgeClientProvider,
+		logToChannel: LogToChannel,
 	): HostProvider {
 		if (HostProvider.instance) {
 			throw new Error("Host providers have already been initialized.")
 		}
-		HostProvider.instance = new HostProvider(webviewProviderCreator, diffViewProviderCreator, hostBridgeProvider)
+		HostProvider.instance = new HostProvider(
+			webviewProviderCreator,
+			diffViewProviderCreator,
+			hostBridgeProvider,
+			logToChannel,
+		)
 		return HostProvider.instance
 	}
 
@@ -99,3 +110,5 @@ export type WebviewProviderCreator = (providerType: WebviewProviderType) => Webv
  * A function that creates DiffViewProvider instances
  */
 export type DiffViewProviderCreator = () => DiffViewProvider
+
+export type LogToChannel = (message: string) => void

--- a/src/hosts/vscode/VscodeWebviewProvider.ts
+++ b/src/hosts/vscode/VscodeWebviewProvider.ts
@@ -6,8 +6,6 @@ import type { Uri } from "vscode"
 import * as vscode from "vscode"
 import type { ExtensionMessage } from "@/shared/ExtensionMessage"
 import type { WebviewProviderType } from "@/shared/webview/types"
-import { WebviewProvider } from "@core/webview"
-import { sendDidBecomeVisibleEvent } from "@core/controller/ui/subscribeToDidBecomeVisible"
 import { HostProvider } from "@/hosts/host-provider"
 
 /*
@@ -125,7 +123,7 @@ export class VscodeWebviewProvider extends WebviewProvider implements vscode.Web
 		// if the extension is starting a new session, clear previous task state
 		this.controller.clearTask()
 
-			HostProvider.get().logToChannel("Webview view resolved")
+		HostProvider.get().logToChannel("Webview view resolved")
 
 		// Title setting logic removed to allow VSCode to use the container title primarily.
 	}

--- a/src/hosts/vscode/VscodeWebviewProvider.ts
+++ b/src/hosts/vscode/VscodeWebviewProvider.ts
@@ -6,6 +6,9 @@ import type { Uri } from "vscode"
 import * as vscode from "vscode"
 import type { ExtensionMessage } from "@/shared/ExtensionMessage"
 import type { WebviewProviderType } from "@/shared/webview/types"
+import { WebviewProvider } from "@core/webview"
+import { sendDidBecomeVisibleEvent } from "@core/controller/ui/subscribeToDidBecomeVisible"
+import { HostProvider } from "@/hosts/host-provider"
 
 /*
 https://github.com/microsoft/vscode-webview-ui-toolkit-samples/blob/main/default/weather-webview/src/providers/WeatherViewProvider.ts
@@ -15,8 +18,8 @@ https://github.com/KumarVariable/vscode-extension-sidebar-html/blob/master/src/c
 export class VscodeWebviewProvider extends WebviewProvider implements vscode.WebviewViewProvider {
 	public webview?: vscode.WebviewView | vscode.WebviewPanel
 
-	constructor(context: vscode.ExtensionContext, outputChannel: vscode.OutputChannel, providerType: WebviewProviderType) {
-		super(context, outputChannel, providerType)
+	constructor(context: vscode.ExtensionContext, providerType: WebviewProviderType) {
+		super(context, providerType)
 	}
 
 	override getWebviewUri(uri: Uri) {
@@ -122,7 +125,7 @@ export class VscodeWebviewProvider extends WebviewProvider implements vscode.Web
 		// if the extension is starting a new session, clear previous task state
 		this.controller.clearTask()
 
-		this.outputChannel.appendLine("Webview view resolved")
+			HostProvider.get().logToChannel("Webview view resolved")
 
 		// Title setting logic removed to allow VSCode to use the container title primarily.
 	}

--- a/src/integrations/checkpoints/CheckpointMigration.ts
+++ b/src/integrations/checkpoints/CheckpointMigration.ts
@@ -2,17 +2,17 @@ import fs from "fs/promises"
 import * as path from "path"
 import * as vscode from "vscode"
 import { fileExistsAtPath } from "@utils/fs"
+import { HostProvider } from "@/hosts/host-provider"
 
 /**
  * Cleans up legacy checkpoints from task folders.
  * This is a one-time operation that runs when the extension is updated to use the new checkpoint system.
  *
  * @param globalStoragePath - Path to the extension's global storage
- * @param outputChannel - VSCode output channel for logging
  */
-export async function cleanupLegacyCheckpoints(globalStoragePath: string, outputChannel: vscode.OutputChannel): Promise<void> {
+export async function cleanupLegacyCheckpoints(globalStoragePath: string): Promise<void> {
 	try {
-		outputChannel.appendLine("Checking for legacy checkpoints...")
+		HostProvider.get().logToChannel("Checking for legacy checkpoints...")
 
 		const tasksDir = path.join(globalStoragePath, "tasks")
 
@@ -45,27 +45,29 @@ export async function cleanupLegacyCheckpoints(globalStoragePath: string, output
 			const checkpointsDir = path.join(mostRecentFolder.path, "checkpoints")
 
 			if (await fileExistsAtPath(checkpointsDir)) {
-				outputChannel.appendLine("Found legacy checkpoints directory, cleaning up...")
+				HostProvider.get().logToChannel("Found legacy checkpoints directory, cleaning up...")
 
 				// Legacy checkpoints found, delete checkpoints directories in all task folders
 				for (const folder of folderStats) {
 					const folderCheckpointsDir = path.join(folder.path, "checkpoints")
 					if (await fileExistsAtPath(folderCheckpointsDir)) {
-						outputChannel.appendLine(`Deleting legacy checkpoints in ${folder.folder}`)
+						HostProvider.get().logToChannel(`Deleting legacy checkpoints in ${folder.folder}`)
 						try {
 							await fs.rm(folderCheckpointsDir, { recursive: true, force: true })
 						} catch (error) {
 							// Ignore error if directory removal fails
-							outputChannel.appendLine(`Warning: Failed to delete checkpoints in ${folder.folder}, continuing...`)
+							HostProvider.get().logToChannel(
+								`Warning: Failed to delete checkpoints in ${folder.folder}, continuing...`,
+							)
 						}
 					}
 				}
 
-				outputChannel.appendLine("Legacy checkpoints cleanup completed")
+				HostProvider.get().logToChannel("Legacy checkpoints cleanup completed")
 			}
 		}
 	} catch (error) {
-		outputChannel.appendLine(`Error cleaning up legacy checkpoints: ${error}`)
+		HostProvider.get().logToChannel(`Error cleaning up legacy checkpoints: ${error}`)
 		console.error("Error cleaning up legacy checkpoints:", error)
 	}
 }

--- a/src/services/logging/Logger.ts
+++ b/src/services/logging/Logger.ts
@@ -1,18 +1,10 @@
-import type { OutputChannel } from "vscode"
+import { HostProvider } from "@/hosts/host-provider"
 import { ErrorService } from "../error/ErrorService"
 
 /**
  * Simple logging utility for the extension's backend code.
- * Uses VS Code's OutputChannel which must be initialized from extension.ts
- * to ensure proper registration with the extension context.
  */
 export class Logger {
-	private static outputChannel: OutputChannel
-
-	static initialize(outputChannel: OutputChannel) {
-		Logger.outputChannel = outputChannel
-	}
-
 	static error(message: string, error?: Error) {
 		Logger.#output("ERROR", message, error)
 		ErrorService.logMessage(message, "error")
@@ -50,7 +42,7 @@ export class Logger {
 		if (error?.message) {
 			fullMessage += ` ${error.message}`
 		}
-		Logger.outputChannel.appendLine(`${level} ${fullMessage}`)
+		HostProvider.get().logToChannel(`${level} ${fullMessage}`)
 		console.log(`[${Logger.#timestamp()}] ${level} ${fullMessage}`)
 		if (error?.stack) {
 			console.log(`Stack trace:\n${error.stack}`)

--- a/src/services/logging/Logger.ts
+++ b/src/services/logging/Logger.ts
@@ -26,24 +26,12 @@ export class Logger {
 	static trace(message: string) {
 		Logger.#output("TRACE", message)
 	}
-	static #timestamp() {
-		const now = new Date()
-		const year = now.getFullYear()
-		const month = String(now.getMonth() + 1).padStart(2, "0")
-		const day = String(now.getDate()).padStart(2, "0")
-		const hour = String(now.getHours()).padStart(2, "0")
-		const minute = String(now.getMinutes()).padStart(2, "0")
-		const second = String(now.getSeconds()).padStart(2, "0")
-		const timestamp = `${year}-${month}-${day}T${hour}:${minute}:${second}`
-		return timestamp
-	}
 	static #output(level: string, message: string, error?: Error) {
 		let fullMessage = message
 		if (error?.message) {
 			fullMessage += ` ${error.message}`
 		}
 		HostProvider.get().logToChannel(`${level} ${fullMessage}`)
-		console.log(`[${Logger.#timestamp()}] ${level} ${fullMessage}`)
 		if (error?.stack) {
 			console.log(`Stack trace:\n${error.stack}`)
 		}

--- a/src/standalone/cline-core.ts
+++ b/src/standalone/cline-core.ts
@@ -7,26 +7,33 @@ import { HostProvider } from "@/hosts/host-provider"
 import { WebviewProviderType } from "@shared/webview/types"
 import { v4 as uuidv4 } from "uuid"
 import { log } from "./utils"
-import { extensionContext, outputChannel, postMessage } from "./vscode-context"
+import { extensionContext, postMessage } from "./vscode-context"
 import { startProtobusService } from "./protobus-service"
+import { WebviewProvider } from "@/core/webview"
+import { DiffViewProvider } from "@/integrations/editor/DiffViewProvider"
 
 async function main() {
 	log("\n\n\nStarting cline-core service...\n\n\n")
 
+	setupHostProvider()
+
 	// Set up global error handlers to prevent process crashes
 	setupGlobalErrorHandlers()
 
-	HostProvider.initialize(createWebview, createDiffView, new ExternalHostBridgeClientManager())
 	activate(extensionContext)
-	const controller = new Controller(extensionContext, outputChannel, postMessage, uuidv4())
+	const controller = new Controller(extensionContext, postMessage, uuidv4())
 	startProtobusService(controller)
 }
 
-function createWebview() {
-	return new ExternalWebviewProvider(extensionContext, outputChannel, WebviewProviderType.SIDEBAR)
-}
-function createDiffView() {
-	return new ExternalDiffViewProvider()
+function setupHostProvider() {
+	const createWebview = (_: WebviewProviderType): WebviewProvider => {
+		return new ExternalWebviewProvider(extensionContext, WebviewProviderType.SIDEBAR)
+	}
+	const createDiffView = (): DiffViewProvider => {
+		return new ExternalDiffViewProvider()
+	}
+	const logToChannel = console.log
+	HostProvider.initialize(createWebview, createDiffView, new ExternalHostBridgeClientManager(), logToChannel)
 }
 
 /**

--- a/src/standalone/cline-core.ts
+++ b/src/standalone/cline-core.ts
@@ -32,8 +32,8 @@ function setupHostProvider() {
 	const createDiffView = (): DiffViewProvider => {
 		return new ExternalDiffViewProvider()
 	}
-	const logToChannel = console.log
-	HostProvider.initialize(createWebview, createDiffView, new ExternalHostBridgeClientManager(), logToChannel)
+
+	HostProvider.initialize(createWebview, createDiffView, new ExternalHostBridgeClientManager(), log)
 }
 
 /**

--- a/src/standalone/vscode-context-stubs.ts
+++ b/src/standalone/vscode-context-stubs.ts
@@ -3,20 +3,9 @@ import * as vscode from "vscode"
 
 import { log } from "./utils"
 
-const outputChannel: vscode.OutputChannel = {
-	append: (text) => process.stdout.write(text),
-	appendLine: (line) => console.log(`OUTPUT_CHANNEL: ${line}`),
-	clear: () => {},
-	show: () => {},
-	hide: () => {},
-	dispose: () => {},
-	name: "",
-	replace: function (value: string): void {},
-}
-
 function postMessage(message: ExtensionMessage): Promise<boolean> {
 	log("postMessage stub called:", JSON.stringify(message).slice(0, 200))
 	return Promise.resolve(true)
 }
 
-export { outputChannel, postMessage }
+export { postMessage }

--- a/src/standalone/vscode-context.ts
+++ b/src/standalone/vscode-context.ts
@@ -5,7 +5,7 @@ import path, { join } from "path"
 import type { Extension, ExtensionContext } from "vscode"
 import { ExtensionKind, ExtensionMode } from "vscode"
 import { log } from "./utils"
-import { outputChannel, postMessage } from "./vscode-context-stubs"
+import { postMessage } from "./vscode-context-stubs"
 import { EnvironmentVariableCollection, MementoStore, readJson, SecretStore } from "./vscode-context-utils"
 
 const VERSION = getPackageVersion()
@@ -66,4 +66,4 @@ function getPackageVersion(): string {
 
 console.log("Finished loading vscode context...")
 
-export { extensionContext, outputChannel, postMessage }
+export { extensionContext, postMessage }

--- a/standalone/runtime-files/vscode/vscode-impls.js
+++ b/standalone/runtime-files/vscode/vscode-impls.js
@@ -40,14 +40,6 @@ vscode.window = {
 		console.log("Stubbed showTextDocument:", ...args)
 		return {}
 	},
-	createOutputChannel: (name) => {
-		console.log("Stubbed createOutputChannel:", name)
-		return {
-			appendLine: console.log,
-			show: () => {},
-			dispose: () => {},
-		}
-	},
 	createTerminal: (...args) => {
 		console.log("Enhanced createTerminal:", ...args)
 


### PR DESCRIPTION
Replace the vscode `OutputChannel.appendLine` with `HostProvider.logToChannel`.

Remove places where the cline OutputChannel was being passed around. Now it is stored in the HostProvider, so we don't need to do this.  We  don't need to initialize the `Logger` to setup the output channel anymore, the channel is set up when the HostProvider is initialized.

Remove the OutputChannel from the vscode-impls.

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Refactor logging by moving `OutputChannel` management to `HostProvider`, simplifying code and centralizing logging functionality.
> 
>   - **Behavior**:
>     - Replaces `vscode.OutputChannel.appendLine` with `HostProvider.logToChannel` for logging.
>     - Removes `OutputChannel` parameter from `Controller` and `WebviewProvider` constructors.
>     - Initializes `OutputChannel` in `HostProvider` during setup in `extension.ts` and `cline-core.ts`.
>   - **Refactoring**:
>     - Updates `Logger` class to use `HostProvider.logToChannel` for logging.
>     - Modifies `cleanupLegacyCheckpoints()` in `CheckpointMigration.ts` to use `HostProvider.logToChannel`.
>     - Updates tests in `cline-api.test.ts` to mock `logToChannel` instead of `OutputChannel`.
>   - **Misc**:
>     - Removes `OutputChannel` creation from `vscode-impls.js` and `vscode-context-stubs.ts`.
>     - Adjusts `createClineAPI()` in `index.ts` to no longer require `OutputChannel`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 2e6face2ce93e9e4430688d3653e6c1e5bf8ade9. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->