### PR TITLE
Revise contributing guidelines and fix PR template link to feature requests board

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,14 +2,14 @@
 Thank you for contributing to Cline!
 
 ⚠️ Important: Before submitting this PR, please ensure you have:
-- For feature requests: Created a discussion in our [Feature Requests board](https://github.com/cline/cline/discussions/categories/feature-requests) and received approval from core maintainers before implementation
+- For feature requests: Created a discussion in our Feature Requests discussions board https://github.com/cline/cline/discussions/categories/feature-requests and received approval from core maintainers before implementation
 - For all changes: Link the associated issue/discussion in the "Related Issue" section below
 
 Limited exceptions:
 Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly without prior discussion.
 
 Why this requirement?
-We deeply appreciate all community contributions - they are essential to Cline's success! To ensure the best use of everyone's time and maintain project direction, we use GitHub Discussions to gauge community interest and validate feature ideas before implementation begins. This helps us focus development efforts on features that will benefit the most users.
+We deeply appreciate all community contributions - they are essential to Cline's success! To ensure the best use of everyone's time and maintain project direction, we use our Feature Requests discussions board to gauge community interest and validate feature ideas before implementation begins. This helps us focus development efforts on features that will benefit the most users.
 -->
 
 ### Related Issue

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,15 +14,11 @@ Bug reports help make Cline better for everyone! Before creating a new issue, pl
 ## Before Contributing
 
 All contributions must begin with a GitHub Issue, unless the change is for small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality.
-
-- **For bug fixes**: 
-    - Search existing [GitHub Issues](https://github.com/cline/cline/issues) to avoid duplicates
-    - If no existing issue found, create a new one using the "Bug Report" template
-- **For features and contributions**:
-    - First check the [Feature Requests discussions board](https://github.com/cline/cline/discussions/categories/feature-requests) for similar ideas
-    - If your idea is new, create a new feature request
-    - Wait for approval from core maintainers before starting implementation
-    - Once approved, feel free to begin working on a PR with the help of our community!
+**For features and contributions**:
+- First check the [Feature Requests discussions board](https://github.com/cline/cline/discussions/categories/feature-requests) for similar ideas
+- If your idea is new, create a new feature request  
+- Wait for approval from core maintainers before starting implementation
+- Once approved, feel free to begin working on a PR with the help of our community!
 
 **PRs without approved issues may be closed.**
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,13 +15,14 @@ Bug reports help make Cline better for everyone! Before creating a new issue, pl
 
 All contributions must begin with a GitHub Issue, unless the change is for small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality.
 
-- **Check existing issues**: Search [GitHub Issues](https://github.com/cline/cline/issues).
-- **Create an issue**: Use appropriate templates:
-    - **Contributions:** Use the "Contribution Request" template to propose what you'd like to work on.
-    - **Bugs:** "Bug Report" template for reporting issues.
-    - **Features:** "Detailed Feature Proposal" template for suggesting new features.
-- **Wait for approval**: A core Cline contributor must approve your contribution request before you start implementation.
-- **Claim issues**: Once approved, the issue will be assigned to you.
+- **For bug fixes**: 
+    - Search existing [GitHub Issues](https://github.com/cline/cline/issues) to avoid duplicates
+    - If no existing issue found, create a new one using the "Bug Report" template
+- **For features and contributions**:
+    - First check the [Feature Requests discussions board](https://github.com/cline/cline/discussions/categories/feature-requests) for similar ideas
+    - If your idea is new, create a new feature request
+    - Wait for approval from core maintainers before starting implementation
+    - Once approved, feel free to begin working on a PR with the help of our community!
 
 **PRs without approved issues may be closed.**
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Revises contributing guidelines and updates PR template to direct contributors to the Feature Requests board for feature discussions.
> 
>   - **PR Template**:
>     - Updates link to Feature Requests board in `.github/pull_request_template.md`.
>     - Emphasizes using the Feature Requests board for feature discussions.
>   - **Contributing Guidelines**:
>     - Revises `CONTRIBUTING.md` to direct contributors to check the Feature Requests board before proposing new features.
>     - Clarifies the process for feature requests and contributions, requiring approval from core maintainers.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 58ba9a635584418ce9ebae69c3b650eb63b50a55. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->