### PR TITLE
fix: provider options

### DIFF
--- a/.changeset/early-actors-marry.md
+++ b/.changeset/early-actors-marry.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Fix Provider Options to properly handle retry attempts

--- a/src/core/api/index.ts
+++ b/src/core/api/index.ts
@@ -37,6 +37,10 @@ import { XAIHandler } from "./providers/xai"
 import { ZAiHandler } from "./providers/zai"
 import { ApiStream, ApiStreamUsageChunk } from "./transform/stream"
 
+export type CommonApiHandlerOptions = {
+	onRetryAttempt?: (attempt: number, maxRetries: number, delay: number, error: any) => void
+}
+
 export interface ApiHandler {
 	createMessage(systemPrompt: string, messages: Anthropic.Messages.MessageParam[]): ApiStream
 	getModel(): ApiHandlerModel
@@ -63,14 +67,10 @@ function createHandlerForProvider(
 	options: Omit<ApiConfiguration, "apiProvider">,
 	mode: Mode,
 ): ApiHandler {
-	const commonOptions: Partial<typeof options> = {
-		onRetryAttempt: options.onRetryAttempt,
-	}
-
 	switch (apiProvider) {
 		case "anthropic":
 			return new AnthropicHandler({
-				...commonOptions,
+				onRetryAttempt: options.onRetryAttempt,
 				apiKey: options.apiKey,
 				anthropicBaseUrl: options.anthropicBaseUrl,
 				apiModelId: mode === "plan" ? options.planModeApiModelId : options.actModeApiModelId,
@@ -79,7 +79,7 @@ function createHandlerForProvider(
 			})
 		case "openrouter":
 			return new OpenRouterHandler({
-				...commonOptions,
+				onRetryAttempt: options.onRetryAttempt,
 				openRouterApiKey: options.openRouterApiKey,
 				openRouterModelId: mode === "plan" ? options.planModeOpenRouterModelId : options.actModeOpenRouterModelId,
 				openRouterModelInfo: mode === "plan" ? options.planModeOpenRouterModelInfo : options.actModeOpenRouterModelInfo,
@@ -90,7 +90,7 @@ function createHandlerForProvider(
 			})
 		case "bedrock":
 			return new AwsBedrockHandler({
-				...commonOptions,
+				onRetryAttempt: options.onRetryAttempt,
 				apiModelId: mode === "plan" ? options.planModeApiModelId : options.actModeApiModelId,
 				awsAccessKey: options.awsAccessKey,
 				awsSecretKey: options.awsSecretKey,
@@ -112,7 +112,7 @@ function createHandlerForProvider(
 			})
 		case "vertex":
 			return new VertexHandler({
-				...commonOptions,
+				onRetryAttempt: options.onRetryAttempt,
 				vertexProjectId: options.vertexProjectId,
 				vertexRegion: options.vertexRegion,
 				apiModelId: mode === "plan" ? options.planModeApiModelId : options.actModeApiModelId,
@@ -124,7 +124,7 @@ function createHandlerForProvider(
 			})
 		case "openai":
 			return new OpenAiHandler({
-				...commonOptions,
+				onRetryAttempt: options.onRetryAttempt,
 				openAiApiKey: options.openAiApiKey,
 				openAiBaseUrl: options.openAiBaseUrl,
 				azureApiVersion: options.azureApiVersion,
@@ -135,7 +135,7 @@ function createHandlerForProvider(
 			})
 		case "ollama":
 			return new OllamaHandler({
-				...commonOptions,
+				onRetryAttempt: options.onRetryAttempt,
 				ollamaBaseUrl: options.ollamaBaseUrl,
 				ollamaApiKey: options.ollamaApiKey,
 				ollamaModelId: mode === "plan" ? options.planModeOllamaModelId : options.actModeOllamaModelId,
@@ -144,14 +144,14 @@ function createHandlerForProvider(
 			})
 		case "lmstudio":
 			return new LmStudioHandler({
-				...commonOptions,
+				onRetryAttempt: options.onRetryAttempt,
 				lmStudioBaseUrl: options.lmStudioBaseUrl,
 				lmStudioModelId: mode === "plan" ? options.planModeLmStudioModelId : options.actModeLmStudioModelId,
 				lmStudioMaxTokens: options.lmStudioMaxTokens,
 			})
 		case "gemini":
 			return new GeminiHandler({
-				...commonOptions,
+				onRetryAttempt: options.onRetryAttempt,
 				vertexProjectId: options.vertexProjectId,
 				vertexRegion: options.vertexRegion,
 				geminiApiKey: options.geminiApiKey,
@@ -163,20 +163,20 @@ function createHandlerForProvider(
 			})
 		case "openai-native":
 			return new OpenAiNativeHandler({
-				...commonOptions,
+				onRetryAttempt: options.onRetryAttempt,
 				openAiNativeApiKey: options.openAiNativeApiKey,
 				reasoningEffort: mode === "plan" ? options.planModeReasoningEffort : options.actModeReasoningEffort,
 				apiModelId: mode === "plan" ? options.planModeApiModelId : options.actModeApiModelId,
 			})
 		case "deepseek":
 			return new DeepSeekHandler({
-				...commonOptions,
+				onRetryAttempt: options.onRetryAttempt,
 				deepSeekApiKey: options.deepSeekApiKey,
 				apiModelId: mode === "plan" ? options.planModeApiModelId : options.actModeApiModelId,
 			})
 		case "requesty":
 			return new RequestyHandler({
-				...commonOptions,
+				onRetryAttempt: options.onRetryAttempt,
 				requestyBaseUrl: options.requestyBaseUrl,
 				requestyApiKey: options.requestyApiKey,
 				reasoningEffort: mode === "plan" ? options.planModeReasoningEffort : options.actModeReasoningEffort,
@@ -187,19 +187,19 @@ function createHandlerForProvider(
 			})
 		case "fireworks":
 			return new FireworksHandler({
-				...commonOptions,
+				onRetryAttempt: options.onRetryAttempt,
 				fireworksApiKey: options.fireworksApiKey,
 				fireworksModelId: mode === "plan" ? options.planModeFireworksModelId : options.actModeFireworksModelId,
 			})
 		case "together":
 			return new TogetherHandler({
-				...commonOptions,
+				onRetryAttempt: options.onRetryAttempt,
 				togetherApiKey: options.togetherApiKey,
 				togetherModelId: mode === "plan" ? options.planModeTogetherModelId : options.actModeTogetherModelId,
 			})
 		case "qwen":
 			return new QwenHandler({
-				...commonOptions,
+				onRetryAttempt: options.onRetryAttempt,
 				qwenApiKey: options.qwenApiKey,
 				qwenApiLine:
 					options.qwenApiLine === QwenApiRegions.INTERNATIONAL ? QwenApiRegions.INTERNATIONAL : QwenApiRegions.CHINA,
@@ -214,25 +214,25 @@ function createHandlerForProvider(
 			})
 		case "doubao":
 			return new DoubaoHandler({
-				...commonOptions,
+				onRetryAttempt: options.onRetryAttempt,
 				doubaoApiKey: options.doubaoApiKey,
 				apiModelId: mode === "plan" ? options.planModeApiModelId : options.actModeApiModelId,
 			})
 		case "mistral":
 			return new MistralHandler({
-				...commonOptions,
+				onRetryAttempt: options.onRetryAttempt,
 				mistralApiKey: options.mistralApiKey,
 				apiModelId: mode === "plan" ? options.planModeApiModelId : options.actModeApiModelId,
 			})
 		case "vscode-lm":
 			return new VsCodeLmHandler({
-				...commonOptions,
+				onRetryAttempt: options.onRetryAttempt,
 				vsCodeLmModelSelector:
 					mode === "plan" ? options.planModeVsCodeLmModelSelector : options.actModeVsCodeLmModelSelector,
 			})
 		case "cline":
 			return new ClineHandler({
-				...commonOptions,
+				onRetryAttempt: options.onRetryAttempt,
 				clineAccountId: options.clineAccountId,
 				ulid: options.ulid,
 				reasoningEffort: mode === "plan" ? options.planModeReasoningEffort : options.actModeReasoningEffort,
@@ -244,7 +244,7 @@ function createHandlerForProvider(
 			})
 		case "litellm":
 			return new LiteLlmHandler({
-				...commonOptions,
+				onRetryAttempt: options.onRetryAttempt,
 				liteLlmApiKey: options.liteLlmApiKey,
 				liteLlmBaseUrl: options.liteLlmBaseUrl,
 				liteLlmModelId: mode === "plan" ? options.planModeLiteLlmModelId : options.actModeLiteLlmModelId,
@@ -256,14 +256,14 @@ function createHandlerForProvider(
 			})
 		case "moonshot":
 			return new MoonshotHandler({
-				...commonOptions,
+				onRetryAttempt: options.onRetryAttempt,
 				moonshotApiKey: options.moonshotApiKey,
 				moonshotApiLine: options.moonshotApiLine,
 				apiModelId: mode === "plan" ? options.planModeApiModelId : options.actModeApiModelId,
 			})
 		case "huggingface":
 			return new HuggingFaceHandler({
-				...commonOptions,
+				onRetryAttempt: options.onRetryAttempt,
 				huggingFaceApiKey: options.huggingFaceApiKey,
 				huggingFaceModelId: mode === "plan" ? options.planModeHuggingFaceModelId : options.actModeHuggingFaceModelId,
 				huggingFaceModelInfo:
@@ -271,39 +271,39 @@ function createHandlerForProvider(
 			})
 		case "nebius":
 			return new NebiusHandler({
-				...commonOptions,
+				onRetryAttempt: options.onRetryAttempt,
 				nebiusApiKey: options.nebiusApiKey,
 				apiModelId: mode === "plan" ? options.planModeApiModelId : options.actModeApiModelId,
 			})
 		case "asksage":
 			return new AskSageHandler({
-				...commonOptions,
+				onRetryAttempt: options.onRetryAttempt,
 				asksageApiKey: options.asksageApiKey,
 				asksageApiUrl: options.asksageApiUrl,
 				apiModelId: mode === "plan" ? options.planModeApiModelId : options.actModeApiModelId,
 			})
 		case "xai":
 			return new XAIHandler({
-				...commonOptions,
+				onRetryAttempt: options.onRetryAttempt,
 				xaiApiKey: options.xaiApiKey,
 				reasoningEffort: mode === "plan" ? options.planModeReasoningEffort : options.actModeReasoningEffort,
 				apiModelId: mode === "plan" ? options.planModeApiModelId : options.actModeApiModelId,
 			})
 		case "sambanova":
 			return new SambanovaHandler({
-				...commonOptions,
+				onRetryAttempt: options.onRetryAttempt,
 				sambanovaApiKey: options.sambanovaApiKey,
 				apiModelId: mode === "plan" ? options.planModeApiModelId : options.actModeApiModelId,
 			})
 		case "cerebras":
 			return new CerebrasHandler({
-				...commonOptions,
+				onRetryAttempt: options.onRetryAttempt,
 				cerebrasApiKey: options.cerebrasApiKey,
 				apiModelId: mode === "plan" ? options.planModeApiModelId : options.actModeApiModelId,
 			})
 		case "groq":
 			return new GroqHandler({
-				...commonOptions,
+				onRetryAttempt: options.onRetryAttempt,
 				groqApiKey: options.groqApiKey,
 				groqModelId: mode === "plan" ? options.planModeGroqModelId : options.actModeGroqModelId,
 				groqModelInfo: mode === "plan" ? options.planModeGroqModelInfo : options.actModeGroqModelInfo,
@@ -318,7 +318,7 @@ function createHandlerForProvider(
 			})
 		case "sapaicore":
 			return new SapAiCoreHandler({
-				...commonOptions,
+				onRetryAttempt: options.onRetryAttempt,
 				sapAiCoreClientId: options.sapAiCoreClientId,
 				sapAiCoreClientSecret: options.sapAiCoreClientSecret,
 				sapAiCoreTokenUrl: options.sapAiCoreTokenUrl,
@@ -331,7 +331,7 @@ function createHandlerForProvider(
 			})
 		case "claude-code":
 			return new ClaudeCodeHandler({
-				...commonOptions,
+				onRetryAttempt: options.onRetryAttempt,
 				claudeCodePath: options.claudeCodePath,
 				apiModelId: mode === "plan" ? options.planModeApiModelId : options.actModeApiModelId,
 				thinkingBudgetTokens:
@@ -361,7 +361,7 @@ function createHandlerForProvider(
 			})
 		default:
 			return new AnthropicHandler({
-				...commonOptions,
+				onRetryAttempt: options.onRetryAttempt,
 				apiKey: options.apiKey,
 				anthropicBaseUrl: options.anthropicBaseUrl,
 				apiModelId: mode === "plan" ? options.planModeApiModelId : options.actModeApiModelId,

--- a/src/core/api/index.ts
+++ b/src/core/api/index.ts
@@ -66,6 +66,7 @@ function createHandlerForProvider(
 	switch (apiProvider) {
 		case "anthropic":
 			return new AnthropicHandler({
+				...options,
 				apiKey: options.apiKey,
 				anthropicBaseUrl: options.anthropicBaseUrl,
 				apiModelId: mode === "plan" ? options.planModeApiModelId : options.actModeApiModelId,
@@ -74,6 +75,7 @@ function createHandlerForProvider(
 			})
 		case "openrouter":
 			return new OpenRouterHandler({
+				...options,
 				openRouterApiKey: options.openRouterApiKey,
 				openRouterModelId: mode === "plan" ? options.planModeOpenRouterModelId : options.actModeOpenRouterModelId,
 				openRouterModelInfo: mode === "plan" ? options.planModeOpenRouterModelInfo : options.actModeOpenRouterModelInfo,
@@ -84,6 +86,7 @@ function createHandlerForProvider(
 			})
 		case "bedrock":
 			return new AwsBedrockHandler({
+				...options,
 				apiModelId: mode === "plan" ? options.planModeApiModelId : options.actModeApiModelId,
 				awsAccessKey: options.awsAccessKey,
 				awsSecretKey: options.awsSecretKey,
@@ -105,6 +108,7 @@ function createHandlerForProvider(
 			})
 		case "vertex":
 			return new VertexHandler({
+				...options,
 				vertexProjectId: options.vertexProjectId,
 				vertexRegion: options.vertexRegion,
 				apiModelId: mode === "plan" ? options.planModeApiModelId : options.actModeApiModelId,
@@ -116,6 +120,7 @@ function createHandlerForProvider(
 			})
 		case "openai":
 			return new OpenAiHandler({
+				...options,
 				openAiApiKey: options.openAiApiKey,
 				openAiBaseUrl: options.openAiBaseUrl,
 				azureApiVersion: options.azureApiVersion,
@@ -126,6 +131,7 @@ function createHandlerForProvider(
 			})
 		case "ollama":
 			return new OllamaHandler({
+				...options,
 				ollamaBaseUrl: options.ollamaBaseUrl,
 				ollamaApiKey: options.ollamaApiKey,
 				ollamaModelId: mode === "plan" ? options.planModeOllamaModelId : options.actModeOllamaModelId,
@@ -134,12 +140,14 @@ function createHandlerForProvider(
 			})
 		case "lmstudio":
 			return new LmStudioHandler({
+				...options,
 				lmStudioBaseUrl: options.lmStudioBaseUrl,
 				lmStudioModelId: mode === "plan" ? options.planModeLmStudioModelId : options.actModeLmStudioModelId,
 				lmStudioMaxTokens: options.lmStudioMaxTokens,
 			})
 		case "gemini":
 			return new GeminiHandler({
+				...options,
 				vertexProjectId: options.vertexProjectId,
 				vertexRegion: options.vertexRegion,
 				geminiApiKey: options.geminiApiKey,
@@ -151,17 +159,20 @@ function createHandlerForProvider(
 			})
 		case "openai-native":
 			return new OpenAiNativeHandler({
+				...options,
 				openAiNativeApiKey: options.openAiNativeApiKey,
 				reasoningEffort: mode === "plan" ? options.planModeReasoningEffort : options.actModeReasoningEffort,
 				apiModelId: mode === "plan" ? options.planModeApiModelId : options.actModeApiModelId,
 			})
 		case "deepseek":
 			return new DeepSeekHandler({
+				...options,
 				deepSeekApiKey: options.deepSeekApiKey,
 				apiModelId: mode === "plan" ? options.planModeApiModelId : options.actModeApiModelId,
 			})
 		case "requesty":
 			return new RequestyHandler({
+				...options,
 				requestyBaseUrl: options.requestyBaseUrl,
 				requestyApiKey: options.requestyApiKey,
 				reasoningEffort: mode === "plan" ? options.planModeReasoningEffort : options.actModeReasoningEffort,
@@ -172,16 +183,19 @@ function createHandlerForProvider(
 			})
 		case "fireworks":
 			return new FireworksHandler({
+				...options,
 				fireworksApiKey: options.fireworksApiKey,
 				fireworksModelId: mode === "plan" ? options.planModeFireworksModelId : options.actModeFireworksModelId,
 			})
 		case "together":
 			return new TogetherHandler({
+				...options,
 				togetherApiKey: options.togetherApiKey,
 				togetherModelId: mode === "plan" ? options.planModeTogetherModelId : options.actModeTogetherModelId,
 			})
 		case "qwen":
 			return new QwenHandler({
+				...options,
 				qwenApiKey: options.qwenApiKey,
 				qwenApiLine:
 					options.qwenApiLine === QwenApiRegions.INTERNATIONAL ? QwenApiRegions.INTERNATIONAL : QwenApiRegions.CHINA,
@@ -196,21 +210,25 @@ function createHandlerForProvider(
 			})
 		case "doubao":
 			return new DoubaoHandler({
+				...options,
 				doubaoApiKey: options.doubaoApiKey,
 				apiModelId: mode === "plan" ? options.planModeApiModelId : options.actModeApiModelId,
 			})
 		case "mistral":
 			return new MistralHandler({
+				...options,
 				mistralApiKey: options.mistralApiKey,
 				apiModelId: mode === "plan" ? options.planModeApiModelId : options.actModeApiModelId,
 			})
 		case "vscode-lm":
 			return new VsCodeLmHandler({
+				...options,
 				vsCodeLmModelSelector:
 					mode === "plan" ? options.planModeVsCodeLmModelSelector : options.actModeVsCodeLmModelSelector,
 			})
 		case "cline":
 			return new ClineHandler({
+				...options,
 				clineAccountId: options.clineAccountId,
 				ulid: options.ulid,
 				reasoningEffort: mode === "plan" ? options.planModeReasoningEffort : options.actModeReasoningEffort,
@@ -222,6 +240,7 @@ function createHandlerForProvider(
 			})
 		case "litellm":
 			return new LiteLlmHandler({
+				...options,
 				liteLlmApiKey: options.liteLlmApiKey,
 				liteLlmBaseUrl: options.liteLlmBaseUrl,
 				liteLlmModelId: mode === "plan" ? options.planModeLiteLlmModelId : options.actModeLiteLlmModelId,
@@ -233,12 +252,14 @@ function createHandlerForProvider(
 			})
 		case "moonshot":
 			return new MoonshotHandler({
+				...options,
 				moonshotApiKey: options.moonshotApiKey,
 				moonshotApiLine: options.moonshotApiLine,
 				apiModelId: mode === "plan" ? options.planModeApiModelId : options.actModeApiModelId,
 			})
 		case "huggingface":
 			return new HuggingFaceHandler({
+				...options,
 				huggingFaceApiKey: options.huggingFaceApiKey,
 				huggingFaceModelId: mode === "plan" ? options.planModeHuggingFaceModelId : options.actModeHuggingFaceModelId,
 				huggingFaceModelInfo:
@@ -246,33 +267,39 @@ function createHandlerForProvider(
 			})
 		case "nebius":
 			return new NebiusHandler({
+				...options,
 				nebiusApiKey: options.nebiusApiKey,
 				apiModelId: mode === "plan" ? options.planModeApiModelId : options.actModeApiModelId,
 			})
 		case "asksage":
 			return new AskSageHandler({
+				...options,
 				asksageApiKey: options.asksageApiKey,
 				asksageApiUrl: options.asksageApiUrl,
 				apiModelId: mode === "plan" ? options.planModeApiModelId : options.actModeApiModelId,
 			})
 		case "xai":
 			return new XAIHandler({
+				...options,
 				xaiApiKey: options.xaiApiKey,
 				reasoningEffort: mode === "plan" ? options.planModeReasoningEffort : options.actModeReasoningEffort,
 				apiModelId: mode === "plan" ? options.planModeApiModelId : options.actModeApiModelId,
 			})
 		case "sambanova":
 			return new SambanovaHandler({
+				...options,
 				sambanovaApiKey: options.sambanovaApiKey,
 				apiModelId: mode === "plan" ? options.planModeApiModelId : options.actModeApiModelId,
 			})
 		case "cerebras":
 			return new CerebrasHandler({
+				...options,
 				cerebrasApiKey: options.cerebrasApiKey,
 				apiModelId: mode === "plan" ? options.planModeApiModelId : options.actModeApiModelId,
 			})
 		case "groq":
 			return new GroqHandler({
+				...options,
 				groqApiKey: options.groqApiKey,
 				groqModelId: mode === "plan" ? options.planModeGroqModelId : options.actModeGroqModelId,
 				groqModelInfo: mode === "plan" ? options.planModeGroqModelInfo : options.actModeGroqModelInfo,
@@ -287,6 +314,7 @@ function createHandlerForProvider(
 			})
 		case "sapaicore":
 			return new SapAiCoreHandler({
+				...options,
 				sapAiCoreClientId: options.sapAiCoreClientId,
 				sapAiCoreClientSecret: options.sapAiCoreClientSecret,
 				sapAiCoreTokenUrl: options.sapAiCoreTokenUrl,
@@ -299,6 +327,7 @@ function createHandlerForProvider(
 			})
 		case "claude-code":
 			return new ClaudeCodeHandler({
+				...options,
 				claudeCodePath: options.claudeCodePath,
 				apiModelId: mode === "plan" ? options.planModeApiModelId : options.actModeApiModelId,
 				thinkingBudgetTokens:
@@ -328,6 +357,7 @@ function createHandlerForProvider(
 			})
 		default:
 			return new AnthropicHandler({
+				...options,
 				apiKey: options.apiKey,
 				anthropicBaseUrl: options.anthropicBaseUrl,
 				apiModelId: mode === "plan" ? options.planModeApiModelId : options.actModeApiModelId,

--- a/src/core/api/index.ts
+++ b/src/core/api/index.ts
@@ -38,7 +38,7 @@ import { ZAiHandler } from "./providers/zai"
 import { ApiStream, ApiStreamUsageChunk } from "./transform/stream"
 
 export type CommonApiHandlerOptions = {
-	onRetryAttempt?: (attempt: number, maxRetries: number, delay: number, error: any) => void
+	onRetryAttempt?: ApiConfiguration["onRetryAttempt"]
 }
 
 export interface ApiHandler {

--- a/src/core/api/index.ts
+++ b/src/core/api/index.ts
@@ -63,10 +63,14 @@ function createHandlerForProvider(
 	options: Omit<ApiConfiguration, "apiProvider">,
 	mode: Mode,
 ): ApiHandler {
+	const commonOptions: Partial<typeof options> = {
+		onRetryAttempt: options.onRetryAttempt,
+	}
+
 	switch (apiProvider) {
 		case "anthropic":
 			return new AnthropicHandler({
-				...options,
+				...commonOptions,
 				apiKey: options.apiKey,
 				anthropicBaseUrl: options.anthropicBaseUrl,
 				apiModelId: mode === "plan" ? options.planModeApiModelId : options.actModeApiModelId,
@@ -75,7 +79,7 @@ function createHandlerForProvider(
 			})
 		case "openrouter":
 			return new OpenRouterHandler({
-				...options,
+				...commonOptions,
 				openRouterApiKey: options.openRouterApiKey,
 				openRouterModelId: mode === "plan" ? options.planModeOpenRouterModelId : options.actModeOpenRouterModelId,
 				openRouterModelInfo: mode === "plan" ? options.planModeOpenRouterModelInfo : options.actModeOpenRouterModelInfo,
@@ -86,7 +90,7 @@ function createHandlerForProvider(
 			})
 		case "bedrock":
 			return new AwsBedrockHandler({
-				...options,
+				...commonOptions,
 				apiModelId: mode === "plan" ? options.planModeApiModelId : options.actModeApiModelId,
 				awsAccessKey: options.awsAccessKey,
 				awsSecretKey: options.awsSecretKey,
@@ -108,7 +112,7 @@ function createHandlerForProvider(
 			})
 		case "vertex":
 			return new VertexHandler({
-				...options,
+				...commonOptions,
 				vertexProjectId: options.vertexProjectId,
 				vertexRegion: options.vertexRegion,
 				apiModelId: mode === "plan" ? options.planModeApiModelId : options.actModeApiModelId,
@@ -120,7 +124,7 @@ function createHandlerForProvider(
 			})
 		case "openai":
 			return new OpenAiHandler({
-				...options,
+				...commonOptions,
 				openAiApiKey: options.openAiApiKey,
 				openAiBaseUrl: options.openAiBaseUrl,
 				azureApiVersion: options.azureApiVersion,
@@ -131,7 +135,7 @@ function createHandlerForProvider(
 			})
 		case "ollama":
 			return new OllamaHandler({
-				...options,
+				...commonOptions,
 				ollamaBaseUrl: options.ollamaBaseUrl,
 				ollamaApiKey: options.ollamaApiKey,
 				ollamaModelId: mode === "plan" ? options.planModeOllamaModelId : options.actModeOllamaModelId,
@@ -140,14 +144,14 @@ function createHandlerForProvider(
 			})
 		case "lmstudio":
 			return new LmStudioHandler({
-				...options,
+				...commonOptions,
 				lmStudioBaseUrl: options.lmStudioBaseUrl,
 				lmStudioModelId: mode === "plan" ? options.planModeLmStudioModelId : options.actModeLmStudioModelId,
 				lmStudioMaxTokens: options.lmStudioMaxTokens,
 			})
 		case "gemini":
 			return new GeminiHandler({
-				...options,
+				...commonOptions,
 				vertexProjectId: options.vertexProjectId,
 				vertexRegion: options.vertexRegion,
 				geminiApiKey: options.geminiApiKey,
@@ -159,20 +163,20 @@ function createHandlerForProvider(
 			})
 		case "openai-native":
 			return new OpenAiNativeHandler({
-				...options,
+				...commonOptions,
 				openAiNativeApiKey: options.openAiNativeApiKey,
 				reasoningEffort: mode === "plan" ? options.planModeReasoningEffort : options.actModeReasoningEffort,
 				apiModelId: mode === "plan" ? options.planModeApiModelId : options.actModeApiModelId,
 			})
 		case "deepseek":
 			return new DeepSeekHandler({
-				...options,
+				...commonOptions,
 				deepSeekApiKey: options.deepSeekApiKey,
 				apiModelId: mode === "plan" ? options.planModeApiModelId : options.actModeApiModelId,
 			})
 		case "requesty":
 			return new RequestyHandler({
-				...options,
+				...commonOptions,
 				requestyBaseUrl: options.requestyBaseUrl,
 				requestyApiKey: options.requestyApiKey,
 				reasoningEffort: mode === "plan" ? options.planModeReasoningEffort : options.actModeReasoningEffort,
@@ -183,19 +187,19 @@ function createHandlerForProvider(
 			})
 		case "fireworks":
 			return new FireworksHandler({
-				...options,
+				...commonOptions,
 				fireworksApiKey: options.fireworksApiKey,
 				fireworksModelId: mode === "plan" ? options.planModeFireworksModelId : options.actModeFireworksModelId,
 			})
 		case "together":
 			return new TogetherHandler({
-				...options,
+				...commonOptions,
 				togetherApiKey: options.togetherApiKey,
 				togetherModelId: mode === "plan" ? options.planModeTogetherModelId : options.actModeTogetherModelId,
 			})
 		case "qwen":
 			return new QwenHandler({
-				...options,
+				...commonOptions,
 				qwenApiKey: options.qwenApiKey,
 				qwenApiLine:
 					options.qwenApiLine === QwenApiRegions.INTERNATIONAL ? QwenApiRegions.INTERNATIONAL : QwenApiRegions.CHINA,
@@ -210,25 +214,25 @@ function createHandlerForProvider(
 			})
 		case "doubao":
 			return new DoubaoHandler({
-				...options,
+				...commonOptions,
 				doubaoApiKey: options.doubaoApiKey,
 				apiModelId: mode === "plan" ? options.planModeApiModelId : options.actModeApiModelId,
 			})
 		case "mistral":
 			return new MistralHandler({
-				...options,
+				...commonOptions,
 				mistralApiKey: options.mistralApiKey,
 				apiModelId: mode === "plan" ? options.planModeApiModelId : options.actModeApiModelId,
 			})
 		case "vscode-lm":
 			return new VsCodeLmHandler({
-				...options,
+				...commonOptions,
 				vsCodeLmModelSelector:
 					mode === "plan" ? options.planModeVsCodeLmModelSelector : options.actModeVsCodeLmModelSelector,
 			})
 		case "cline":
 			return new ClineHandler({
-				...options,
+				...commonOptions,
 				clineAccountId: options.clineAccountId,
 				ulid: options.ulid,
 				reasoningEffort: mode === "plan" ? options.planModeReasoningEffort : options.actModeReasoningEffort,
@@ -240,7 +244,7 @@ function createHandlerForProvider(
 			})
 		case "litellm":
 			return new LiteLlmHandler({
-				...options,
+				...commonOptions,
 				liteLlmApiKey: options.liteLlmApiKey,
 				liteLlmBaseUrl: options.liteLlmBaseUrl,
 				liteLlmModelId: mode === "plan" ? options.planModeLiteLlmModelId : options.actModeLiteLlmModelId,
@@ -252,14 +256,14 @@ function createHandlerForProvider(
 			})
 		case "moonshot":
 			return new MoonshotHandler({
-				...options,
+				...commonOptions,
 				moonshotApiKey: options.moonshotApiKey,
 				moonshotApiLine: options.moonshotApiLine,
 				apiModelId: mode === "plan" ? options.planModeApiModelId : options.actModeApiModelId,
 			})
 		case "huggingface":
 			return new HuggingFaceHandler({
-				...options,
+				...commonOptions,
 				huggingFaceApiKey: options.huggingFaceApiKey,
 				huggingFaceModelId: mode === "plan" ? options.planModeHuggingFaceModelId : options.actModeHuggingFaceModelId,
 				huggingFaceModelInfo:
@@ -267,39 +271,39 @@ function createHandlerForProvider(
 			})
 		case "nebius":
 			return new NebiusHandler({
-				...options,
+				...commonOptions,
 				nebiusApiKey: options.nebiusApiKey,
 				apiModelId: mode === "plan" ? options.planModeApiModelId : options.actModeApiModelId,
 			})
 		case "asksage":
 			return new AskSageHandler({
-				...options,
+				...commonOptions,
 				asksageApiKey: options.asksageApiKey,
 				asksageApiUrl: options.asksageApiUrl,
 				apiModelId: mode === "plan" ? options.planModeApiModelId : options.actModeApiModelId,
 			})
 		case "xai":
 			return new XAIHandler({
-				...options,
+				...commonOptions,
 				xaiApiKey: options.xaiApiKey,
 				reasoningEffort: mode === "plan" ? options.planModeReasoningEffort : options.actModeReasoningEffort,
 				apiModelId: mode === "plan" ? options.planModeApiModelId : options.actModeApiModelId,
 			})
 		case "sambanova":
 			return new SambanovaHandler({
-				...options,
+				...commonOptions,
 				sambanovaApiKey: options.sambanovaApiKey,
 				apiModelId: mode === "plan" ? options.planModeApiModelId : options.actModeApiModelId,
 			})
 		case "cerebras":
 			return new CerebrasHandler({
-				...options,
+				...commonOptions,
 				cerebrasApiKey: options.cerebrasApiKey,
 				apiModelId: mode === "plan" ? options.planModeApiModelId : options.actModeApiModelId,
 			})
 		case "groq":
 			return new GroqHandler({
-				...options,
+				...commonOptions,
 				groqApiKey: options.groqApiKey,
 				groqModelId: mode === "plan" ? options.planModeGroqModelId : options.actModeGroqModelId,
 				groqModelInfo: mode === "plan" ? options.planModeGroqModelInfo : options.actModeGroqModelInfo,
@@ -314,7 +318,7 @@ function createHandlerForProvider(
 			})
 		case "sapaicore":
 			return new SapAiCoreHandler({
-				...options,
+				...commonOptions,
 				sapAiCoreClientId: options.sapAiCoreClientId,
 				sapAiCoreClientSecret: options.sapAiCoreClientSecret,
 				sapAiCoreTokenUrl: options.sapAiCoreTokenUrl,
@@ -327,7 +331,7 @@ function createHandlerForProvider(
 			})
 		case "claude-code":
 			return new ClaudeCodeHandler({
-				...options,
+				...commonOptions,
 				claudeCodePath: options.claudeCodePath,
 				apiModelId: mode === "plan" ? options.planModeApiModelId : options.actModeApiModelId,
 				thinkingBudgetTokens:
@@ -357,7 +361,7 @@ function createHandlerForProvider(
 			})
 		default:
 			return new AnthropicHandler({
-				...options,
+				...commonOptions,
 				apiKey: options.apiKey,
 				anthropicBaseUrl: options.anthropicBaseUrl,
 				apiModelId: mode === "plan" ? options.planModeApiModelId : options.actModeApiModelId,

--- a/src/core/api/providers/anthropic.ts
+++ b/src/core/api/providers/anthropic.ts
@@ -1,11 +1,11 @@
 import { Anthropic } from "@anthropic-ai/sdk"
 import { Stream as AnthropicStream } from "@anthropic-ai/sdk/streaming"
 import { AnthropicModelId, anthropicDefaultModelId, anthropicModels, CLAUDE_SONNET_4_1M_SUFFIX, ModelInfo } from "@shared/api"
-import { ApiHandler } from "../index"
+import { ApiHandler, CommonApiHandlerOptions } from "../index"
 import { withRetry } from "../retry"
 import { ApiStream } from "../transform/stream"
 
-interface AnthropicHandlerOptions {
+interface AnthropicHandlerOptions extends CommonApiHandlerOptions {
 	apiKey?: string
 	anthropicBaseUrl?: string
 	apiModelId?: string

--- a/src/core/api/providers/asksage.ts
+++ b/src/core/api/providers/asksage.ts
@@ -1,10 +1,10 @@
 import { Anthropic } from "@anthropic-ai/sdk"
 import { AskSageModelId, askSageDefaultModelId, askSageDefaultURL, askSageModels, ModelInfo } from "@shared/api"
-import { ApiHandler } from ".."
+import { ApiHandler, CommonApiHandlerOptions } from ".."
 import { withRetry } from "../retry"
 import { ApiStream } from "../transform/stream"
 
-interface AskSageHandlerOptions {
+interface AskSageHandlerOptions extends CommonApiHandlerOptions {
 	asksageApiKey?: string
 	asksageApiUrl?: string
 	apiModelId?: string

--- a/src/core/api/providers/bedrock.ts
+++ b/src/core/api/providers/bedrock.ts
@@ -11,12 +11,12 @@ import {
 import { fromNodeProviderChain } from "@aws-sdk/credential-providers"
 import { BedrockModelId, bedrockDefaultModelId, bedrockModels, CLAUDE_SONNET_4_1M_SUFFIX, ModelInfo } from "@shared/api"
 import { calculateApiCostOpenAI } from "@utils/cost"
-import { ApiHandler } from "../"
+import { ApiHandler, CommonApiHandlerOptions } from "../"
 import { withRetry } from "../retry"
 import { convertToR1Format } from "../transform/r1-format"
 import { ApiStream } from "../transform/stream"
 
-interface AwsBedrockHandlerOptions {
+interface AwsBedrockHandlerOptions extends CommonApiHandlerOptions {
 	apiModelId?: string
 	awsAccessKey?: string
 	awsSecretKey?: string

--- a/src/core/api/providers/cerebras.ts
+++ b/src/core/api/providers/cerebras.ts
@@ -1,11 +1,11 @@
 import { Anthropic } from "@anthropic-ai/sdk"
 import Cerebras from "@cerebras/cerebras_cloud_sdk"
 import { CerebrasModelId, cerebrasDefaultModelId, cerebrasModels, ModelInfo } from "@shared/api"
-import { ApiHandler } from "../index"
+import { ApiHandler, CommonApiHandlerOptions } from "../index"
 import { withRetry } from "../retry"
 import { ApiStream } from "../transform/stream"
 
-interface CerebrasHandlerOptions {
+interface CerebrasHandlerOptions extends CommonApiHandlerOptions {
 	cerebrasApiKey?: string
 	apiModelId?: string
 }

--- a/src/core/api/providers/claude-code.ts
+++ b/src/core/api/providers/claude-code.ts
@@ -2,11 +2,11 @@ import type { Anthropic } from "@anthropic-ai/sdk"
 import { filterMessagesForClaudeCode } from "@/integrations/claude-code/message-filter"
 import { runClaudeCode } from "@/integrations/claude-code/run"
 import { ClaudeCodeModelId, claudeCodeDefaultModelId, claudeCodeModels } from "@/shared/api"
-import { type ApiHandler } from ".."
+import { CommonApiHandlerOptions, type ApiHandler } from ".."
 import { withRetry } from "../retry"
 import { type ApiStream, ApiStreamUsageChunk } from "../transform/stream"
 
-interface ClaudeCodeHandlerOptions {
+interface ClaudeCodeHandlerOptions extends CommonApiHandlerOptions {
 	claudeCodePath?: string
 	apiModelId?: string
 	thinkingBudgetTokens?: number

--- a/src/core/api/providers/cline.ts
+++ b/src/core/api/providers/cline.ts
@@ -8,14 +8,15 @@ import { ClineAccountService } from "@/services/account/ClineAccountService"
 import { AuthService } from "@/services/auth/AuthService"
 import { CLINE_ACCOUNT_AUTH_ERROR_MESSAGE } from "@/shared/ClineAccount"
 import { version as extensionVersion } from "../../../../package.json"
-import { ApiHandler } from "../"
+import { ApiHandler, CommonApiHandlerOptions } from "../"
 import { withRetry } from "../retry"
 import { createOpenRouterStream } from "../transform/openrouter-stream"
 import { ApiStream, ApiStreamUsageChunk } from "../transform/stream"
 import { OpenRouterErrorResponse } from "./types"
 
-interface ClineHandlerOptions {
+interface ClineHandlerOptions extends CommonApiHandlerOptions {
 	ulid?: string
+	taskId?: string
 	reasoningEffort?: string
 	thinkingBudgetTokens?: number
 	openRouterProviderSorting?: string

--- a/src/core/api/providers/deepseek.ts
+++ b/src/core/api/providers/deepseek.ts
@@ -2,13 +2,13 @@ import { Anthropic } from "@anthropic-ai/sdk"
 import { DeepSeekModelId, deepSeekDefaultModelId, deepSeekModels, ModelInfo } from "@shared/api"
 import { calculateApiCostOpenAI } from "@utils/cost"
 import OpenAI from "openai"
-import { ApiHandler } from "../"
+import { ApiHandler, CommonApiHandlerOptions } from "../"
 import { withRetry } from "../retry"
 import { convertToOpenAiMessages } from "../transform/openai-format"
 import { convertToR1Format } from "../transform/r1-format"
 import { ApiStream } from "../transform/stream"
 
-interface DeepSeekHandlerOptions {
+interface DeepSeekHandlerOptions extends CommonApiHandlerOptions {
 	deepSeekApiKey?: string
 	apiModelId?: string
 }

--- a/src/core/api/providers/doubao.ts
+++ b/src/core/api/providers/doubao.ts
@@ -1,12 +1,12 @@
 import { Anthropic } from "@anthropic-ai/sdk"
 import { DoubaoModelId, doubaoDefaultModelId, doubaoModels, ModelInfo } from "@shared/api"
 import OpenAI from "openai"
-import { ApiHandler } from ".."
+import { ApiHandler, CommonApiHandlerOptions } from ".."
 import { withRetry } from "../retry"
 import { convertToOpenAiMessages } from "../transform/openai-format"
 import { ApiStream } from "../transform/stream"
 
-interface DoubaoHandlerOptions {
+interface DoubaoHandlerOptions extends CommonApiHandlerOptions {
 	doubaoApiKey?: string
 	apiModelId?: string
 }

--- a/src/core/api/providers/fireworks.ts
+++ b/src/core/api/providers/fireworks.ts
@@ -1,12 +1,12 @@
 import { Anthropic } from "@anthropic-ai/sdk"
 import { FireworksModelId, fireworksDefaultModelId, fireworksModels, ModelInfo } from "@shared/api"
 import OpenAI from "openai"
-import { ApiHandler } from ".."
+import { ApiHandler, CommonApiHandlerOptions } from ".."
 import { withRetry } from "../retry"
 import { convertToOpenAiMessages } from "../transform/openai-format"
 import { ApiStream } from "../transform/stream"
 
-interface FireworksHandlerOptions {
+interface FireworksHandlerOptions extends CommonApiHandlerOptions {
 	fireworksApiKey?: string
 	fireworksModelId?: string
 	fireworksModelMaxCompletionTokens?: number

--- a/src/core/api/providers/gemini.ts
+++ b/src/core/api/providers/gemini.ts
@@ -3,7 +3,7 @@ import type { Anthropic } from "@anthropic-ai/sdk"
 import { type GenerateContentConfig, type GenerateContentResponseUsageMetadata, GoogleGenAI, Part } from "@google/genai"
 import { telemetryService } from "@services/posthog/PostHogClientProvider"
 import { GeminiModelId, geminiDefaultModelId, geminiModels, ModelInfo } from "@shared/api"
-import { ApiHandler } from "../"
+import { ApiHandler, CommonApiHandlerOptions } from "../"
 import { withRetry } from "../retry"
 import { convertAnthropicMessageToGemini } from "../transform/gemini-format"
 import { ApiStream } from "../transform/stream"
@@ -11,7 +11,7 @@ import { ApiStream } from "../transform/stream"
 // Define a default TTL for the cache (e.g., 15 minutes in seconds)
 const _DEFAULT_CACHE_TTL_SECONDS = 900
 
-interface GeminiHandlerOptions {
+interface GeminiHandlerOptions extends CommonApiHandlerOptions {
 	isVertex?: boolean
 	vertexProjectId?: string
 	vertexRegion?: string

--- a/src/core/api/providers/groq.ts
+++ b/src/core/api/providers/groq.ts
@@ -2,12 +2,12 @@ import { Anthropic } from "@anthropic-ai/sdk"
 import { GroqModelId, groqDefaultModelId, groqModels, ModelInfo } from "@shared/api"
 import { calculateApiCostOpenAI } from "@utils/cost"
 import OpenAI from "openai"
-import { ApiHandler } from "../"
+import { ApiHandler, CommonApiHandlerOptions } from "../"
 import { withRetry } from "../retry"
 import { convertToOpenAiMessages } from "../transform/openai-format"
 import { ApiStream } from "../transform/stream"
 
-interface GroqHandlerOptions {
+interface GroqHandlerOptions extends CommonApiHandlerOptions {
 	groqApiKey?: string
 	groqModelId?: string
 	groqModelInfo?: ModelInfo

--- a/src/core/api/providers/huggingface.ts
+++ b/src/core/api/providers/huggingface.ts
@@ -2,12 +2,12 @@ import { Anthropic } from "@anthropic-ai/sdk"
 import { HuggingFaceModelId, huggingFaceDefaultModelId, huggingFaceModels, ModelInfo } from "@shared/api"
 import { calculateApiCostOpenAI } from "@utils/cost"
 import OpenAI from "openai"
-import { ApiHandler } from "../"
+import { ApiHandler, CommonApiHandlerOptions } from "../"
 import { withRetry } from "../retry"
 import { convertToOpenAiMessages } from "../transform/openai-format"
 import { ApiStream } from "../transform/stream"
 
-interface HuggingFaceHandlerOptions {
+interface HuggingFaceHandlerOptions extends CommonApiHandlerOptions {
 	huggingFaceApiKey?: string
 	huggingFaceModelId?: string
 	huggingFaceModelInfo?: ModelInfo

--- a/src/core/api/providers/litellm.ts
+++ b/src/core/api/providers/litellm.ts
@@ -1,12 +1,12 @@
 import { Anthropic } from "@anthropic-ai/sdk"
 import { LiteLLMModelInfo, liteLlmDefaultModelId, liteLlmModelInfoSaneDefaults } from "@shared/api"
 import OpenAI from "openai"
-import { ApiHandler } from ".."
+import { ApiHandler, CommonApiHandlerOptions } from ".."
 import { withRetry } from "../retry"
 import { convertToOpenAiMessages } from "../transform/openai-format"
 import { ApiStream } from "../transform/stream"
 
-interface LiteLlmHandlerOptions {
+interface LiteLlmHandlerOptions extends CommonApiHandlerOptions {
 	liteLlmApiKey?: string
 	liteLlmBaseUrl?: string
 	liteLlmModelId?: string

--- a/src/core/api/providers/lmstudio.ts
+++ b/src/core/api/providers/lmstudio.ts
@@ -1,12 +1,12 @@
 import type { Anthropic } from "@anthropic-ai/sdk"
 import { type ModelInfo, openAiModelInfoSaneDefaults } from "@shared/api"
 import OpenAI from "openai"
-import type { ApiHandler } from "../"
+import type { ApiHandler, CommonApiHandlerOptions } from "../"
 import { withRetry } from "../retry"
 import { convertToOpenAiMessages } from "../transform/openai-format"
 import type { ApiStream } from "../transform/stream"
 
-interface LmStudioHandlerOptions {
+interface LmStudioHandlerOptions extends CommonApiHandlerOptions {
 	lmStudioBaseUrl?: string
 	lmStudioModelId?: string
 	lmStudioMaxTokens?: string

--- a/src/core/api/providers/mistral.ts
+++ b/src/core/api/providers/mistral.ts
@@ -1,12 +1,12 @@
 import { Anthropic } from "@anthropic-ai/sdk"
 import { Mistral } from "@mistralai/mistralai"
 import { MistralModelId, ModelInfo, mistralDefaultModelId, mistralModels } from "@shared/api"
-import { ApiHandler } from "../"
+import { ApiHandler, CommonApiHandlerOptions } from "../"
 import { withRetry } from "../retry"
 import { convertToMistralMessages } from "../transform/mistral-format"
 import { ApiStream } from "../transform/stream"
 
-interface MistralHandlerOptions {
+interface MistralHandlerOptions extends CommonApiHandlerOptions {
 	mistralApiKey?: string
 	apiModelId?: string
 }

--- a/src/core/api/providers/moonshot.ts
+++ b/src/core/api/providers/moonshot.ts
@@ -1,12 +1,12 @@
 import { Anthropic } from "@anthropic-ai/sdk"
 import OpenAI from "openai"
 import { ModelInfo, MoonshotModelId, moonshotDefaultModelId, moonshotModels } from "@/shared/api"
-import { ApiHandler } from "../index"
+import { ApiHandler, CommonApiHandlerOptions } from "../index"
 import { withRetry } from "../retry"
 import { convertToOpenAiMessages } from "../transform/openai-format"
 import { ApiStream } from "../transform/stream"
 
-interface MoonshotHandlerOptions {
+interface MoonshotHandlerOptions extends CommonApiHandlerOptions {
 	moonshotApiKey?: string
 	moonshotApiLine?: string
 	apiModelId?: string

--- a/src/core/api/providers/nebius.ts
+++ b/src/core/api/providers/nebius.ts
@@ -1,13 +1,13 @@
 import { Anthropic } from "@anthropic-ai/sdk"
 import { type ModelInfo, type NebiusModelId, nebiusDefaultModelId, nebiusModels } from "@shared/api"
 import OpenAI from "openai"
-import { ApiHandler } from "../index"
+import { ApiHandler, CommonApiHandlerOptions } from "../index"
 import { withRetry } from "../retry"
 import { convertToOpenAiMessages } from "../transform/openai-format"
 import { convertToR1Format } from "../transform/r1-format"
 import { ApiStream } from "../transform/stream"
 
-interface NebiusHandlerOptions {
+interface NebiusHandlerOptions extends CommonApiHandlerOptions {
 	nebiusApiKey?: string
 	apiModelId?: string
 }

--- a/src/core/api/providers/ollama.ts
+++ b/src/core/api/providers/ollama.ts
@@ -1,12 +1,12 @@
 import type { Anthropic } from "@anthropic-ai/sdk"
 import { type ModelInfo, openAiModelInfoSaneDefaults } from "@shared/api"
 import { type Config, type Message, Ollama } from "ollama"
-import type { ApiHandler } from "../"
+import type { ApiHandler, CommonApiHandlerOptions } from "../"
 import { withRetry } from "../retry"
 import { convertToOllamaMessages } from "../transform/ollama-format"
 import type { ApiStream } from "../transform/stream"
 
-interface OllamaHandlerOptions {
+interface OllamaHandlerOptions extends CommonApiHandlerOptions {
 	ollamaBaseUrl?: string
 	ollamaApiKey?: string
 	ollamaModelId?: string

--- a/src/core/api/providers/openai-native.ts
+++ b/src/core/api/providers/openai-native.ts
@@ -3,12 +3,12 @@ import { ModelInfo, OpenAiNativeModelId, openAiNativeDefaultModelId, openAiNativ
 import { calculateApiCostOpenAI } from "@utils/cost"
 import OpenAI from "openai"
 import type { ChatCompletionReasoningEffort } from "openai/resources/chat/completions"
-import { ApiHandler } from "../"
+import { ApiHandler, CommonApiHandlerOptions } from "../"
 import { withRetry } from "../retry"
 import { convertToOpenAiMessages } from "../transform/openai-format"
 import { ApiStream } from "../transform/stream"
 
-interface OpenAiNativeHandlerOptions {
+interface OpenAiNativeHandlerOptions extends CommonApiHandlerOptions {
 	openAiNativeApiKey?: string
 	reasoningEffort?: string
 	apiModelId?: string

--- a/src/core/api/providers/openai.ts
+++ b/src/core/api/providers/openai.ts
@@ -2,13 +2,13 @@ import { Anthropic } from "@anthropic-ai/sdk"
 import { azureOpenAiDefaultApiVersion, ModelInfo, OpenAiCompatibleModelInfo, openAiModelInfoSaneDefaults } from "@shared/api"
 import OpenAI, { AzureOpenAI } from "openai"
 import type { ChatCompletionReasoningEffort } from "openai/resources/chat/completions"
-import { ApiHandler } from "../index"
+import { ApiHandler, CommonApiHandlerOptions } from "../index"
 import { withRetry } from "../retry"
 import { convertToOpenAiMessages } from "../transform/openai-format"
 import { convertToR1Format } from "../transform/r1-format"
 import { ApiStream } from "../transform/stream"
 
-interface OpenAiHandlerOptions {
+interface OpenAiHandlerOptions extends CommonApiHandlerOptions {
 	openAiApiKey?: string
 	openAiBaseUrl?: string
 	azureApiVersion?: string

--- a/src/core/api/providers/openrouter.ts
+++ b/src/core/api/providers/openrouter.ts
@@ -4,22 +4,13 @@ import { ModelInfo, openRouterDefaultModelId, openRouterDefaultModelInfo } from 
 import { shouldSkipReasoningForModel } from "@utils/model-utils"
 import axios from "axios"
 import OpenAI from "openai"
-import { ApiHandler } from "../"
+import { ApiHandler, CommonApiHandlerOptions } from "../"
 import { withRetry } from "../retry"
 import { createOpenRouterStream } from "../transform/openrouter-stream"
 import { ApiStream, ApiStreamUsageChunk } from "../transform/stream"
 import { OpenRouterErrorResponse } from "./types"
 
-interface OpenRouterHandlerOptions {
-	openRouterApiKey?: string
-	openRouterModelId?: string
-	openRouterModelInfo?: ModelInfo
-	openRouterProviderSorting?: string
-	reasoningEffort?: string
-	thinkingBudgetTokens?: number
-}
-
-interface OpenRouterHandlerOptions {
+interface OpenRouterHandlerOptions extends CommonApiHandlerOptions {
 	openRouterApiKey?: string
 	openRouterModelId?: string
 	openRouterModelInfo?: ModelInfo

--- a/src/core/api/providers/qwen.ts
+++ b/src/core/api/providers/qwen.ts
@@ -10,13 +10,13 @@ import {
 	QwenApiRegions,
 } from "@shared/api"
 import OpenAI from "openai"
-import { ApiHandler } from "../"
+import { ApiHandler, CommonApiHandlerOptions } from "../"
 import { withRetry } from "../retry"
 import { convertToOpenAiMessages } from "../transform/openai-format"
 import { convertToR1Format } from "../transform/r1-format"
 import { ApiStream } from "../transform/stream"
 
-interface QwenHandlerOptions {
+interface QwenHandlerOptions extends CommonApiHandlerOptions {
 	qwenApiKey?: string
 	qwenApiLine?: QwenApiRegions
 	apiModelId?: string

--- a/src/core/api/providers/requesty.ts
+++ b/src/core/api/providers/requesty.ts
@@ -2,12 +2,12 @@ import { Anthropic } from "@anthropic-ai/sdk"
 import { ModelInfo, requestyDefaultModelId, requestyDefaultModelInfo } from "@shared/api"
 import { calculateApiCostOpenAI } from "@utils/cost"
 import OpenAI from "openai"
-import { ApiHandler } from "../index"
+import { ApiHandler, CommonApiHandlerOptions } from "../index"
 import { withRetry } from "../retry"
 import { convertToOpenAiMessages } from "../transform/openai-format"
 import { ApiStream } from "../transform/stream"
 
-interface RequestyHandlerOptions {
+interface RequestyHandlerOptions extends CommonApiHandlerOptions {
 	requestyBaseUrl?: string
 	requestyApiKey?: string
 	reasoningEffort?: string

--- a/src/core/api/providers/sambanova.ts
+++ b/src/core/api/providers/sambanova.ts
@@ -1,13 +1,13 @@
 import { Anthropic } from "@anthropic-ai/sdk"
 import { ModelInfo, SambanovaModelId, sambanovaDefaultModelId, sambanovaModels } from "@shared/api"
 import OpenAI from "openai"
-import { ApiHandler } from "../index"
+import { ApiHandler, CommonApiHandlerOptions } from "../index"
 import { withRetry } from "../retry"
 import { convertToOpenAiMessages } from "../transform/openai-format"
 import { convertToR1Format } from "../transform/r1-format"
 import { ApiStream } from "../transform/stream"
 
-interface SambanovaHandlerOptions {
+interface SambanovaHandlerOptions extends CommonApiHandlerOptions {
 	sambanovaApiKey?: string
 	apiModelId?: string
 }

--- a/src/core/api/providers/sapaicore.ts
+++ b/src/core/api/providers/sapaicore.ts
@@ -7,11 +7,11 @@ import {
 import { ModelInfo, SapAiCoreModelId, sapAiCoreDefaultModelId, sapAiCoreModels } from "@shared/api"
 import axios from "axios"
 import OpenAI from "openai"
-import { ApiHandler } from "../"
+import { ApiHandler, CommonApiHandlerOptions } from "../"
 import { convertToOpenAiMessages } from "../transform/openai-format"
 import { ApiStream } from "../transform/stream"
 
-interface SapAiCoreHandlerOptions {
+interface SapAiCoreHandlerOptions extends CommonApiHandlerOptions {
 	sapAiCoreClientId?: string
 	sapAiCoreClientSecret?: string
 	sapAiCoreTokenUrl?: string

--- a/src/core/api/providers/together.ts
+++ b/src/core/api/providers/together.ts
@@ -1,13 +1,13 @@
 import { Anthropic } from "@anthropic-ai/sdk"
 import { ModelInfo, openAiModelInfoSaneDefaults } from "@shared/api"
 import OpenAI from "openai"
-import { ApiHandler } from "../index"
+import { ApiHandler, CommonApiHandlerOptions } from "../index"
 import { withRetry } from "../retry"
 import { convertToOpenAiMessages } from "../transform/openai-format"
 import { convertToR1Format } from "../transform/r1-format"
 import { ApiStream } from "../transform/stream"
 
-interface TogetherHandlerOptions {
+interface TogetherHandlerOptions extends CommonApiHandlerOptions {
 	togetherApiKey?: string
 	togetherModelId?: string
 }

--- a/src/core/api/providers/vertex.ts
+++ b/src/core/api/providers/vertex.ts
@@ -1,12 +1,12 @@
 import { Anthropic } from "@anthropic-ai/sdk"
 import { AnthropicVertex } from "@anthropic-ai/vertex-sdk"
 import { ModelInfo, VertexModelId, vertexDefaultModelId, vertexModels } from "@shared/api"
-import { ApiHandler } from "../"
+import { ApiHandler, CommonApiHandlerOptions } from "../"
 import { withRetry } from "../retry"
 import { ApiStream } from "../transform/stream"
 import { GeminiHandler } from "./gemini"
 
-interface VertexHandlerOptions {
+interface VertexHandlerOptions extends CommonApiHandlerOptions {
 	vertexProjectId?: string
 	vertexRegion?: string
 	apiModelId?: string

--- a/src/core/api/providers/vscode-lm.ts
+++ b/src/core/api/providers/vscode-lm.ts
@@ -3,13 +3,13 @@ import { ModelInfo, openAiModelInfoSaneDefaults } from "@shared/api"
 import { SELECTOR_SEPARATOR, stringifyVsCodeLmModelSelector } from "@shared/vsCodeSelectorUtils"
 import { calculateApiCostAnthropic } from "@utils/cost"
 import * as vscode from "vscode"
-import { ApiHandler, SingleCompletionHandler } from "../"
+import { ApiHandler, SingleCompletionHandler, CommonApiHandlerOptions } from "../"
 import { withRetry } from "../retry"
 import { ApiStream } from "../transform/stream"
 import { convertToVsCodeLmMessages } from "../transform/vscode-lm-format"
 import type { LanguageModelChatSelector as LanguageModelChatSelectorFromTypes } from "./types"
 
-interface VsCodeLmHandlerOptions {
+interface VsCodeLmHandlerOptions extends CommonApiHandlerOptions {
 	vsCodeLmModelSelector?: any
 }
 

--- a/src/core/api/providers/xai.ts
+++ b/src/core/api/providers/xai.ts
@@ -3,18 +3,12 @@ import { ModelInfo, XAIModelId, xaiDefaultModelId, xaiModels } from "@shared/api
 import { shouldSkipReasoningForModel } from "@utils/model-utils"
 import OpenAI from "openai"
 import { ChatCompletionReasoningEffort } from "openai/resources/chat/completions"
-import { ApiHandler } from "../"
+import { ApiHandler, CommonApiHandlerOptions } from "../"
 import { withRetry } from "../retry"
 import { convertToOpenAiMessages } from "../transform/openai-format"
 import { ApiStream } from "../transform/stream"
 
-interface XAIHandlerOptions {
-	xaiApiKey?: string
-	reasoningEffort?: string
-	apiModelId?: string
-}
-
-interface XAIHandlerOptions {
+interface XAIHandlerOptions extends CommonApiHandlerOptions {
 	xaiApiKey?: string
 	reasoningEffort?: string
 	apiModelId?: string


### PR DESCRIPTION
### Related Issue

**Issue:** #5202 

### Description

When introducing the changes to the [provider options](https://github.com/cline/cline/pull/4729), we started passing a limited amount of options. However, we need `onRetryAttempt` to [properly handle retries](https://github.com/cline/cline/blob/main/src/api/retry.ts#L58).

We could also have a smaller base options object, instead of passing all options, but this seemed simpler.

cc @celestial-vault 

### Test Procedure

To verify the issue, you can go to the newest version of Cline and make enough requests to get rate-limited.
Once you do, you will see that the API request loads for a while because we don't update it to inform the user that we are waiting to retry.
I tested this on my machine and included a screenshot at the bottom showing the fixed behavior.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

After my changes:
<img width="449" height="60" alt="image" src="https://github.com/user-attachments/assets/4e9ab2c7-4967-410e-8487-b8919a4ef675" />

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes provider options in `index.ts` to include `onRetryAttempt` for proper retry handling across multiple handlers.
> 
>   - **Behavior**:
>     - Passes all options, including `onRetryAttempt`, to handlers in `createHandlerForProvider()` in `index.ts`.
>     - Ensures proper handling of retries by including `onRetryAttempt` in options.
>   - **Handlers**:
>     - Affects `AnthropicHandler`, `OpenRouterHandler`, `AwsBedrockHandler`, and 25 other handlers in `index.ts`.
>   - **Misc**:
>     - Adds changeset `early-actors-marry.md` to document the fix.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 3c0baa8776a47929bd5888612b85a4e9d0bead44. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->