### PR TITLE
docs: fix Global Rules directory location for Linux/WSL systems

### DIFF
--- a/.changeset/nasty-plums-run.md
+++ b/.changeset/nasty-plums-run.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Fix Global Rules directory documentation for Linux/WSL systems

--- a/docs/features/cline-rules.mdx
+++ b/docs/features/cline-rules.mdx
@@ -11,7 +11,19 @@ You can create a rule by clicking the `+` button in the Rules tab. This will ope
 Once you save the file:
 
 -   Your rule will be stored in the `.clinerules/` directory in your project (if it's a Workspace Rule)
--   Or in the `Documents/Cline/Rules` directory (if it's a Global Rule).
+-   Or in the Global Rules directory (if it's a Global Rule):
+
+### Global Rules Directory Location
+
+The location of your Global Rules directory depends on your operating system:
+
+| Operating System | Default Location | Notes |
+|------------------|------------------|-------|
+| **Windows** | `Documents\Cline\Rules` | Uses system Documents folder |
+| **macOS** | `~/Documents/Cline/Rules` | Uses user Documents folder |
+| **Linux/WSL** | `~/Documents/Cline/Rules` | May fall back to `~/Cline/Rules` on some systems |
+
+> **Note for Linux/WSL users**: If you don't find your global rules in `~/Documents/Cline/Rules`, check `~/Cline/Rules` as the location may vary depending on your system configuration and whether the Documents directory exists.
 
 You can also have Cline create a rule for you by using the [`/newrule` slash command](/features/slash-commands/new-rule) in the chat.
 


### PR DESCRIPTION
### Related Issue

__Issue:__ #5153

### Description

This PR fixes incorrect documentation for the Global Rules directory location on Linux/WSL systems. The previous documentation stated that Global Rules are universally stored in `Documents/Cline/Rules`, but on Linux/WSL systems, the actual location can vary and may fall back to `~/Cline/Rules/` depending on system configuration.

__Changes made:__

- Added a platform-specific table showing correct paths for Windows, macOS, and Linux/WSL
- Added a specific note for Linux/WSL users explaining the potential fallback location
- Clarified that the location may vary depending on system configuration and whether the Documents directory exists

This addresses the confusion reported by users who couldn't find their Global Rules in the documented location on Linux systems.

### Test Procedure

__Testing approach:__

- Verified the documentation changes render correctly in the MDX format
- Cross-referenced the code in `src/core/storage/disk.ts` to confirm the actual behavior matches the updated documentation
- Confirmed that the `getDocumentsPath()` function does indeed have platform-specific logic that can result in different paths on Linux systems
- Reviewed the `ensureRulesDirectoryExists()` function to understand the fallback behavior

__What could potentially break:__

- This is a documentation-only change, so no functional code is affected
- The change only clarifies existing behavior rather than changing it

__Confidence level:__ High - this is a straightforward documentation correction that accurately reflects the existing codebase behavior.

### Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ♻️ Refactor Changes
- [ ] 💅 Cosmetic Changes
- [x] 📚 Documentation update
- [ ] 🏃 Workflow Changes

### Pre-flight Checklist

- [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
- [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
- [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
- [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Not applicable - this is a documentation text change only.

### Additional Notes

This change helps Linux/WSL users who were confused by the previous documentation and couldn't locate their Global Rules files. The updated documentation provides clear guidance for all platforms and explains the potential variation on Linux systems.


<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes documentation for Global Rules directory on Linux/WSL, adding platform-specific paths and notes.
> 
>   - **Documentation Update**:
>     - Corrects Global Rules directory location for Linux/WSL in `cline-rules.mdx`.
>     - Adds platform-specific table for Windows, macOS, and Linux/WSL paths.
>     - Includes note for Linux/WSL users about potential fallback to `~/Cline/Rules`.
>   - **Verification**:
>     - Confirmed documentation matches behavior in `src/core/storage/disk.ts`.
>     - Reviewed `getDocumentsPath()` and `ensureRulesDirectoryExists()` for path logic.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 026723b238210e0d6afd34f9ee94e871d6af3033. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->