### PR TITLE
feat: adds navigation bar component and restructure app layout

### DIFF
--- a/webview-ui/src/App.tsx
+++ b/webview-ui/src/App.tsx
@@ -1,14 +1,14 @@
+import type { Boolean, EmptyRequest } from "@shared/proto/cline/common"
 import { useEffect } from "react"
+import AccountView from "./components/account/AccountView"
 import ChatView from "./components/chat/ChatView"
 import HistoryView from "./components/history/HistoryView"
+import McpView from "./components/mcp/configuration/McpConfigurationView"
 import SettingsView from "./components/settings/SettingsView"
 import WelcomeView from "./components/welcome/WelcomeView"
-import AccountView from "./components/account/AccountView"
 import { useExtensionState } from "./context/ExtensionStateContext"
-import { UiServiceClient } from "./services/grpc-client"
-import McpView from "./components/mcp/configuration/McpConfigurationView"
 import { Providers } from "./Providers"
-import { Boolean, EmptyRequest } from "@shared/proto/cline/common"
+import { UiServiceClient } from "./services/grpc-client"
 
 const AppContent = () => {
 	const {
@@ -44,32 +44,30 @@ const AppContent = () => {
 					console.error("Failed to acknowledge announcement:", error)
 				})
 		}
-	}, [shouldShowAnnouncement])
+	}, [shouldShowAnnouncement, setShouldShowAnnouncement, setShowAnnouncement])
 
 	if (!didHydrateState) {
 		return null
 	}
 
+	if (showWelcome) {
+		return <WelcomeView />
+	}
+
 	return (
-		<>
-			{showWelcome ? (
-				<WelcomeView />
-			) : (
-				<>
-					{showSettings && <SettingsView onDone={hideSettings} />}
-					{showHistory && <HistoryView onDone={hideHistory} />}
-					{showMcp && <McpView initialTab={mcpTab} onDone={closeMcpView} />}
-					{showAccount && <AccountView onDone={hideAccount} />}
-					{/* Do not conditionally load ChatView, it's expensive and there's state we don't want to lose (user input, disableInput, askResponse promise, etc.) */}
-					<ChatView
-						showHistoryView={navigateToHistory}
-						isHidden={showSettings || showHistory || showMcp || showAccount}
-						showAnnouncement={showAnnouncement}
-						hideAnnouncement={hideAnnouncement}
-					/>
-				</>
-			)}
-		</>
+		<div className="flex h-full w-full">
+			{showSettings && <SettingsView onDone={hideSettings} />}
+			{showHistory && <HistoryView onDone={hideHistory} />}
+			{showMcp && <McpView initialTab={mcpTab} onDone={closeMcpView} />}
+			{showAccount && <AccountView onDone={hideAccount} />}
+			{/* Do not conditionally load ChatView, it's expensive and there's state we don't want to lose (user input, disableInput, askResponse promise, etc.) */}
+			<ChatView
+				showHistoryView={navigateToHistory}
+				isHidden={showSettings || showHistory || showMcp || showAccount}
+				showAnnouncement={showAnnouncement}
+				hideAnnouncement={hideAnnouncement}
+			/>
+		</div>
 	)
 }
 

--- a/webview-ui/src/components/chat/ChatView.tsx
+++ b/webview-ui/src/components/chat/ChatView.tsx
@@ -1,32 +1,32 @@
-import { useCallback, useEffect, useMemo } from "react"
-import { useMount } from "react-use"
-import { ClineApiReqInfo, ClineMessage } from "@shared/ExtensionMessage"
 import { findLast } from "@shared/array"
 import { combineApiRequests } from "@shared/combineApiRequests"
 import { combineCommandSequences } from "@shared/combineCommandSequences"
+import type { ClineApiReqInfo, ClineMessage } from "@shared/ExtensionMessage"
 import { getApiMetrics } from "@shared/getApiMetrics"
+import { BooleanRequest, EmptyRequest, StringRequest } from "@shared/proto/cline/common"
+import { useCallback, useEffect, useMemo } from "react"
+import { useMount } from "react-use"
+import { normalizeApiConfiguration } from "@/components/settings/utils/providerUtils"
 import { useExtensionState } from "@/context/ExtensionStateContext"
 import { FileServiceClient, UiServiceClient } from "@/services/grpc-client"
-import { normalizeApiConfiguration } from "@/components/settings/utils/providerUtils"
-import { BooleanRequest, EmptyRequest, StringRequest } from "@shared/proto/cline/common"
-
+import { Navbar } from "../menu/Navbar"
 // Import utilities and hooks from the new structure
 import {
+	ActionButtons,
+	CHAT_CONSTANTS,
+	ChatLayout,
 	convertHtmlToMarkdown,
 	filterVisibleMessages,
 	groupMessages,
-	CHAT_CONSTANTS,
-	useChatState,
-	useButtonState,
-	useScrollBehavior,
-	useMessageHandlers,
-	useIsStreaming,
-	ChatLayout,
-	WelcomeSection,
-	TaskSection,
-	MessagesArea,
-	ActionButtons,
 	InputSection,
+	MessagesArea,
+	TaskSection,
+	useButtonState,
+	useChatState,
+	useIsStreaming,
+	useMessageHandlers,
+	useScrollBehavior,
+	WelcomeSection,
 } from "./chat-view"
 
 interface ChatViewProps {
@@ -48,6 +48,7 @@ const ChatView = ({ isHidden, showAnnouncement, hideAnnouncement, showHistoryVie
 		telemetrySetting,
 		navigateToChat,
 		chatSettings,
+		showNavbar,
 	} = useExtensionState()
 	const shouldShowQuickWins = false // !taskHistory || taskHistory.length < QUICK_WINS_HISTORY_THRESHOLD
 	//const task = messages.length > 0 ? (messages[0].say === "task" ? messages[0] : undefined) : undefined) : undefined
@@ -321,6 +322,7 @@ const ChatView = ({ isHidden, showAnnouncement, hideAnnouncement, showHistoryVie
 
 	return (
 		<ChatLayout isHidden={isHidden}>
+			{showNavbar && <Navbar />}
 			{task ? (
 				<TaskSection
 					task={task}

--- a/webview-ui/src/components/menu/Navbar.tsx
+++ b/webview-ui/src/components/menu/Navbar.tsx
@@ -1,0 +1,65 @@
+import { DatabaseIcon, HistoryIcon, PlusIcon, SettingsIcon, UserCircleIcon } from "lucide-react"
+import { useMemo } from "react"
+import { useExtensionState } from "../../context/ExtensionStateContext"
+import { TabTrigger } from "../common/Tab"
+
+export const Navbar = () => {
+	const { showNavbar, navigateToHistory, navigateToSettings, navigateToAccount, navigateToMcp, navigateToChat } =
+		useExtensionState()
+
+	const SETTINGS_TABS = useMemo(
+		() => [
+			{
+				id: "chat",
+				name: "Chat",
+				icon: PlusIcon,
+				navigate: navigateToChat,
+			},
+			{
+				id: "mcp",
+				name: "MCP",
+				icon: DatabaseIcon,
+				navigate: navigateToMcp,
+			},
+			{
+				id: "history",
+				name: "History",
+				icon: HistoryIcon,
+				navigate: navigateToHistory,
+			},
+			{
+				id: "account",
+				name: "Account",
+				icon: UserCircleIcon,
+				navigate: navigateToAccount,
+			},
+			{
+				id: "settings",
+				name: "Settings",
+				icon: SettingsIcon,
+				navigate: navigateToSettings,
+			},
+		],
+		[navigateToAccount, navigateToChat, navigateToHistory, navigateToMcp, navigateToSettings],
+	)
+	if (!showNavbar) {
+		return null
+	}
+
+	return (
+		<div
+			id="navbar-header"
+			className="fixed top-0 right-2 inline-flex justify-end bg-transparent shadow-sm max-h-[20px] w-full gap-2 mb-1 z-10 border-none items-center">
+			{SETTINGS_TABS.map((tab) => (
+				<TabTrigger
+					key={`navbar-trigger-${tab.id}`}
+					value={tab.id}
+					className="bg-transparent border-none text-white m-0 p-0"
+					data-testid={`tab-${tab.id}`}
+					onSelect={() => tab.navigate()}>
+					<tab.icon className="text-white" strokeWidth={1} size={18} />
+				</TabTrigger>
+			))}
+		</div>
+	)
+}


### PR DESCRIPTION
<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- For feature requests: Created a discussion in our Feature Requests discussions board https://github.com/cline/cline/discussions/categories/feature-requests and received approval from core maintainers before implementation
- For all changes: Link the associated issue/discussion in the "Related Issue" section below

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly without prior discussion.

Why this requirement?
We deeply appreciate all community contributions - they are essential to Cline's success! To ensure the best use of everyone's time and maintain project direction, we use our Feature Requests discussions board to gauge community interest and validate feature ideas before implementation begins. This helps us focus development efforts on features that will benefit the most users.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** #XXXX

### Description

<!-- 
Help reviewers understand your changes by making this PR readable and well-organized:

- What problem does this PR solve?
- Why were these changes introduced and what purpose do they serve?
- For larger changes, provide context about your approach and reasoning

Small PRs may need minimal description, but larger changes benefit from explaining where you're coming from. Much of this context can be in the linked issue above, so feel free to reference it rather than repeating everything here.
-->

- Add new Navbar component for consistent navigation
- Restructure App.tsx to use flex layout with proper container
- Update ChatView to include navbar and reorganize imports
- Enhance ExtensionStateContext with navbar-related state management

### Test Procedure

<!-- 
Please walk us through your testing approach and thought process. This helps reviewers understand that you've thoroughly considered the impact of your changes:

- How did you test this change?
- What could potentially break and how did you verify it doesn't?
- What existing functionality might be affected and how did you check it still works?
- Why are you confident this is ready for merge?

We're not looking for exhaustive documentation - just evidence that you've thought through the implications of your changes and tested accordingly.
-->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [ ] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->
