### PR TITLE
fix issue where cline is occasionally bricked by the diffViewProvider attempting to close tabs

### DIFF
--- a/src/hosts/vscode/VscodeDiffViewProvider.ts
+++ b/src/hosts/vscode/VscodeDiffViewProvider.ts
@@ -30,7 +30,11 @@ export class VscodeDiffViewProvider extends DiffViewProvider {
 			.filter((tab) => tab.input instanceof vscode.TabInputText && arePathsEqual(tab.input.uri.fsPath, this.absolutePath))
 		for (const tab of tabs) {
 			if (!tab.isDirty) {
-				await vscode.window.tabGroups.close(tab)
+				try {
+					await vscode.window.tabGroups.close(tab)
+				} catch (error) {
+					console.warn("Tab close retry failed:", error.message)
+				}
 			}
 			this.documentWasOpen = true
 		}
@@ -187,7 +191,11 @@ export class VscodeDiffViewProvider extends DiffViewProvider {
 		for (const tab of tabs) {
 			// trying to close dirty views results in save popup
 			if (!tab.isDirty) {
-				await vscode.window.tabGroups.close(tab)
+				try {
+					await vscode.window.tabGroups.close(tab)
+				} catch (error) {
+					console.warn("Tab close retry failed:", error.message)
+				}
 			}
 		}
 	}


### PR DESCRIPTION
<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- For feature requests: Created a discussion in our Feature Requests discussions board https://github.com/cline/cline/discussions/categories/feature-requests and received approval from core maintainers before implementation
- For all changes: Link the associated issue/discussion in the "Related Issue" section below

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly without prior discussion.

Why this requirement?
We deeply appreciate all community contributions - they are essential to Cline's success! To ensure the best use of everyone's time and maintain project direction, we use our Feature Requests discussions board to gauge community interest and validate feature ideas before implementation begins. This helps us focus development efforts on features that will benefit the most users.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** #XXXX

### Description

There is no try-catch on the diffViewEditor logic for closing dirty tabs which occasionally throws an error and bricks cline entirely. The underlying issue is that there's no error handling on the attempt to close the tabs. It may be worth in the future adding logic to re-try on initial failure

<!-- 
Help reviewers understand your changes by making this PR readable and well-organized:

- What problem does this PR solve?
- Why were these changes introduced and what purpose do they serve?
- For larger changes, provide context about your approach and reasoning

Small PRs may need minimal description, but larger changes benefit from explaining where you're coming from. Much of this context can be in the linked issue above, so feel free to reference it rather than repeating everything here.
-->

### Test Procedure

To reproduce this have the same file opened on lhs and rhs and have cline try to edit the file. This will (often) throw an error which results in bricking cline.

<!-- 
Please walk us through your testing approach and thought process. This helps reviewers understand that you've thoroughly considered the impact of your changes:

- How did you test this change?
- What could potentially break and how did you verify it doesn't?
- What existing functionality might be affected and how did you check it still works?
- Why are you confident this is ready for merge?

We're not looking for exhaustive documentation - just evidence that you've thought through the implications of your changes and tested accordingly.
-->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

recording:

https://github.com/user-attachments/assets/ad0a81ae-f347-4ec6-af96-4f277ab8c248



screenshot:
<img width="561" height="158" alt="screenshot bricking" src="https://github.com/user-attachments/assets/d60c6ffe-9cd9-454c-ace4-eaa51794f7dd" />

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add error handling for tab closing in `VscodeDiffViewProvider` to prevent application crashes.
> 
>   - **Error Handling**:
>     - Add try-catch block around `vscode.window.tabGroups.close(tab)` in `VscodeDiffViewProvider` to handle errors when closing tabs.
>     - Logs warning message "Tab close retry failed:" with error message if tab close fails.
>   - **Affected Methods**:
>     - `openDiffEditor()` and `closeDiffView()` methods in `VscodeDiffViewProvider` are updated with error handling for tab closing.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for b0522adf36c90a1048ce03562beec6f3ee8cbe0b. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->