### PR TITLE
Fix: Obey delete task popup cancel

### DIFF
--- a/.changeset/green-falcons-itch.md
+++ b/.changeset/green-falcons-itch.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Fix for delete task dialog

--- a/src/core/controller/task/deleteTasksWithIds.ts
+++ b/src/core/controller/task/deleteTasksWithIds.ts
@@ -30,7 +30,7 @@ export async function deleteTasksWithIds(controller: Controller, request: String
 		options: { modal: true, items: ["Delete"] },
 	})
 
-	if (userChoice === undefined) {
+	if (userChoice.selectedOption !== "Delete") {
 		return Empty.create()
 	}
 


### PR DESCRIPTION
<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- For feature requests: Created a discussion in our Feature Requests discussions board https://github.com/cline/cline/discussions/categories/feature-requests and received approval from core maintainers before implementation
- For all changes: Link the associated issue/discussion in the "Related Issue" section below

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly without prior discussion.

Why this requirement?
We deeply appreciate all community contributions - they are essential to Cline's success! To ensure the best use of everyone's time and maintain project direction, we use our Feature Requests discussions board to gauge community interest and validate feature ideas before implementation begins. This helps us focus development efforts on features that will benefit the most users.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** #5259 

### Description

Fixes an issue where cancelling/closing the delete task popup was still deleting the task. Introduced in #4745.


### Test Procedure

Try to delete a task, hit cancel (or close the popup), and confirm the task is deleted. Test again, but confirm that confirming does delete it.


<!-- 
Please walk us through your testing approach and thought process. This helps reviewers understand that you've thoroughly considered the impact of your changes:

- How did you test this change?
- What could potentially break and how did you verify it doesn't?
- What existing functionality might be affected and how did you check it still works?
- Why are you confident this is ready for merge?

We're not looking for exhaustive documentation - just evidence that you've thought through the implications of your changes and tested accordingly.
-->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [X] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [X] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [X] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [X] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [X] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes issue in `deleteTasksWithIds.ts` where canceling the delete task popup still deleted the task by checking `userChoice.selectedOption`.
> 
>   - **Behavior**:
>     - Fixes issue in `deleteTasksWithIds.ts` where canceling the delete task popup still deleted the task.
>     - Now checks if `userChoice.selectedOption` is not "Delete" before proceeding with deletion.
>   - **Misc**:
>     - Adds a changeset file `green-falcons-itch.md` for the patch update.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 8f5aad65fa07cee6d0a89b6cfd8c2d967c9343cb. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->