### PR TITLE
Fix: Jumpy input saving

### DIFF
--- a/webview-ui/src/components/settings/utils/useDebouncedInput.ts
+++ b/webview-ui/src/components/settings/utils/useDebouncedInput.ts
@@ -18,11 +18,6 @@ export function useDebouncedInput<T>(
 	// Local state to prevent jumpy input - initialize once
 	const [localValue, setLocalValue] = useState(initialValue)
 
-	// Update local value when initialValue changes (e.g., when component remounts with new data)
-	useEffect(() => {
-		setLocalValue(initialValue)
-	}, [initialValue])
-
 	// Debounced backend save - saves after user stops changing value
 	useDebounceEffect(
 		() => {


### PR DESCRIPTION
\
### Description

UseEffect was overwriting the input whenever the initialValue changed, which happened with every keystroke due to save-on-input.

Now, the user's input is not overwritten by the incoming value - it is treated as ground truth.

### Test Procedure

Test that the input is no longer jumpy on fast keystrokes.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Removes `useEffect` in `useDebouncedInput.ts` to prevent input from being jumpy by preserving user's input as ground truth.
> 
>   - **Behavior**:
>     - Removes `useEffect` in `useDebouncedInput.ts` that reset `localValue` on `initialValue` change, preventing input from being jumpy.
>     - User's input is now preserved as ground truth, not overwritten by incoming values.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for b5c989983731523ccb3a4a93ffa6354cd8f0b154. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->