### PR TITLE
Add a flag to build the webview without minification, compact, etc.

### DIFF
--- a/webview-ui/package.json
+++ b/webview-ui/package.json
@@ -6,7 +6,7 @@
 	"scripts": {
 		"dev": "vite",
 		"build": "tsc -b && vite build",
-		"build:test": "tsc -b && vite build",
+		"build:test": "tsc -b && vite build -- --dev-build",
 		"preview": "vite preview",
 		"lint": "eslint . --ext .ts,.tsx",
 		"test": "vitest run",

--- a/webview-ui/vite.config.ts
+++ b/webview-ui/vite.config.ts
@@ -26,6 +26,8 @@ const writePortToFile = (): Plugin => {
 	}
 }
 
+const isDevBuild = process.argv.includes("--dev-build")
+
 export default defineConfig({
 	plugins: [react(), tailwindcss(), writePortToFile()],
 	test: {
@@ -40,12 +42,26 @@ export default defineConfig({
 	build: {
 		outDir: "build",
 		reportCompressedSize: false,
+		// Only minify in production build
+		minify: !isDevBuild,
+		// Enable inline source maps for dev build
+		sourcemap: isDevBuild ? "inline" : false,
 		rollupOptions: {
 			output: {
 				inlineDynamicImports: true,
 				entryFileNames: `assets/[name].js`,
 				chunkFileNames: `assets/[name].js`,
 				assetFileNames: `assets/[name].[ext]`,
+				// Disable compact output for dev build
+				compact: !isDevBuild,
+				// Add generous formatting for dev build
+				...(isDevBuild && {
+					generatedCode: {
+						constBindings: false,
+						objectShorthand: false,
+						arrowFunctions: false,
+					},
+				}),
 			},
 		},
 		chunkSizeWarningLimit: 100000,


### PR DESCRIPTION
When the webview is built wuth build:test:
* don't compact the compiled code
* don't minify
* use inline source maps (the embedded JCEF browser can't load source maps from .map files).