### PR TITLE
Add vscode.workspace.findFiles to `no-direct-vscode-api` eslint rule.

### DIFF
--- a/eslint-rules/no-direct-vscode-api.js
+++ b/eslint-rules/no-direct-vscode-api.js
@@ -47,6 +47,9 @@ const disallowedApis = {
 	// "vscode.window.showInformationMessage": {
 	// 	messageId: "useHostBridgeShowMessage",
 	// },
+	"vscode.workspace.findFiles": {
+		messageId: "useNative",
+	},
 }
 
 module.exports = createRule({
@@ -85,6 +88,10 @@ module.exports = createRule({
 				"Found: {{code}}",
 			useUtils:
 				"Use utilities in @/utils instead of calling vscode APIs directly.\n" +
+				"This provides a consistent abstraction across VSCode and standalone environments.\n" +
+				"Found: {{code}}",
+			useNative:
+				"Use a native Javascript API instead of calling the vscode API.\n" +
 				"This provides a consistent abstraction across VSCode and standalone environments.\n" +
 				"Found: {{code}}",
 		},


### PR DESCRIPTION
Add `vscode.workspace.findFiles` to the list of the Vscode API calls that should not be re-introduced to the extension unintentionally.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `vscode.workspace.findFiles` to disallowed APIs in `no-direct-vscode-api.js` ESLint rule, promoting native JavaScript alternatives.
> 
>   - **ESLint Rule Update**:
>     - Add `vscode.workspace.findFiles` to `disallowedApis` in `no-direct-vscode-api.js`.
>     - Add `useNative` message for `vscode.workspace.findFiles` to encourage using native JavaScript APIs.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 00d02ee2586023eb21c5e5f91f97071af18b701e. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->