### PR TITLE
fix grok browser_user issue due to not being able to process webp images

### DIFF
--- a/src/core/task/ToolExecutor.ts
+++ b/src/core/task/ToolExecutor.ts
@@ -35,7 +35,7 @@ import { ClineAskResponse } from "@shared/WebviewMessage"
 import { extractFileContent, FileContentResult } from "@integrations/misc/extract-file-content"
 import { COMMAND_REQ_APP_STRING } from "@shared/combineCommandSequences"
 import { fileExistsAtPath } from "@utils/fs"
-import { isClaude4ModelFamily, isGemini2dot5ModelFamily } from "@utils/model-utils"
+import { isClaude4ModelFamily, isGemini2dot5ModelFamily, isGrok4ModelFamily, modelDoesntSupportWebp } from "@utils/model-utils"
 import { fixModelHtmlEscaping, removeInvalidChars } from "@utils/string"
 import { setTimeout as setTimeoutPromise } from "node:timers/promises"
 import os from "os"
@@ -124,7 +124,8 @@ export class ToolExecutor {
 	}
 
 	private pushToolResult = (content: ToolResponse, block: ToolUse) => {
-		const isNextGenModel = isClaude4ModelFamily(this.api) || isGemini2dot5ModelFamily(this.api)
+		const isNextGenModel =
+			isClaude4ModelFamily(this.api) || isGemini2dot5ModelFamily(this.api) || isGrok4ModelFamily(this.api)
 
 		if (typeof content === "string") {
 			const resultText = content || "(tool did not return anything)"
@@ -489,7 +490,8 @@ export class ToolExecutor {
 
 						const currentFullJson = block.params.diff
 						// Check if we should use streaming (e.g., for specific models)
-						const isNextGenModel = isClaude4ModelFamily(this.api) || isGemini2dot5ModelFamily(this.api)
+						const isNextGenModel =
+							isClaude4ModelFamily(this.api) || isGemini2dot5ModelFamily(this.api) || isGrok4ModelFamily(this.api)
 						// Going through claude family of models
 						if (isNextGenModel && USE_EXPERIMENTAL_CLAUDE4_FEATURES && currentFullJson) {
 							const streamingResult = await this.handleStreamingJsonReplacement(block, relPath, currentFullJson)
@@ -1182,7 +1184,9 @@ export class ToolExecutor {
 							// Re-make browserSession to make sure latest settings apply
 							if (this.context) {
 								await this.browserSession.dispose()
-								this.browserSession = new BrowserSession(this.context, this.browserSettings)
+
+								let useWebp = this.api ? !modelDoesntSupportWebp(this.api) : true
+								this.browserSession = new BrowserSession(this.context, this.browserSettings, useWebp)
 							} else {
 								console.warn("no controller context available for browserSession")
 							}

--- a/src/services/browser/BrowserSession.ts
+++ b/src/services/browser/BrowserSession.ts
@@ -41,15 +41,17 @@ export class BrowserSession {
 	private lastConnectionAttempt: number = 0
 	browserSettings: BrowserSettings
 	private isConnectedToRemote: boolean = false
+	private useWebp: boolean
 
 	// Telemetry tracking properties
 	private sessionStartTime: number = 0
 	private browserActions: string[] = []
 	private taskId?: string
 
-	constructor(context: vscode.ExtensionContext, browserSettings: BrowserSettings) {
+	constructor(context: vscode.ExtensionContext, browserSettings: BrowserSettings, useWebp: boolean = true) {
 		this.context = context
 		this.browserSettings = browserSettings
+		this.useWebp = useWebp
 	}
 
 	// Tests remote browser connection
@@ -487,14 +489,16 @@ export class BrowserSession {
 			// },
 		}
 
+		const screenshotType = this.useWebp ? "webp" : "png"
 		let screenshotBase64 = await this.page.screenshot({
 			...options,
-			type: "webp",
+			type: screenshotType,
 		})
-		let screenshot = `data:image/webp;base64,${screenshotBase64}`
+		let screenshot = `data:image/${screenshotType};base64,${screenshotBase64}`
 
 		if (!screenshotBase64) {
-			console.info("webp screenshot failed, trying png")
+			// choosing to try screenshot again, regardless of the initial type
+			console.info(`${screenshotType} screenshot failed, trying png`)
 			screenshotBase64 = await this.page.screenshot({
 				...options,
 				type: "png",

--- a/src/utils/model-utils.ts
+++ b/src/utils/model-utils.ts
@@ -20,6 +20,12 @@ export function isGrok4ModelFamily(api: ApiHandler): boolean {
 	return modelId.includes("grok-4")
 }
 
+export function modelDoesntSupportWebp(api: ApiHandler): boolean {
+	const model = api.getModel()
+	const modelId = model.id.toLowerCase()
+	return modelId.includes("grok")
+}
+
 /**
  * Determines if reasoning content should be skipped for a given model
  * Currently skips reasoning for Grok-4 models since they only display "thinking" without useful information


### PR DESCRIPTION
<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- For feature requests: Created a discussion in our Feature Requests discussions board https://github.com/cline/cline/discussions/categories/feature-requests and received approval from core maintainers before implementation
- For all changes: Link the associated issue/discussion in the "Related Issue" section below

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly without prior discussion.

Why this requirement?
We deeply appreciate all community contributions - they are essential to Cline's success! To ensure the best use of everyone's time and maintain project direction, we use our Feature Requests discussions board to gauge community interest and validate feature ideas before implementation begins. This helps us focus development efforts on features that will benefit the most users.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** #XXXX

### Description

The browser use tool does not work for Grok models due to our default for using webp formatted images, and Grok not supporting these. Originally we would get this error when sending the browser screen shots to Grok when using their provider: `400 "Invalid request content: Downloaded response does not contain a valid JPG or PNG image."`. Fixed this by using png format for Grok models

<!-- 
Help reviewers understand your changes by making this PR readable and well-organized:

- What problem does this PR solve?
- Why were these changes introduced and what purpose do they serve?
- For larger changes, provide context about your approach and reasoning

Small PRs may need minimal description, but larger changes benefit from explaining where you're coming from. Much of this context can be in the linked issue above, so feel free to reference it rather than repeating everything here.
-->

### Test Procedure

Tested browser use tool for grok-4, sonnet-4, and gemini-2.5-pro to check that browser use still works for all. Also tested with and without using the remote browser connection.

<!-- 
Please walk us through your testing approach and thought process. This helps reviewers understand that you've thoroughly considered the impact of your changes:

- How did you test this change?
- What could potentially break and how did you verify it doesn't?
- What existing functionality might be affected and how did you check it still works?
- Why are you confident this is ready for merge?

We're not looking for exhaustive documentation - just evidence that you've thought through the implications of your changes and tested accordingly.
-->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Using grok-4 in browser use:

https://github.com/user-attachments/assets/ceb290a3-2b0c-4490-8be8-c8339e8ee2be



<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Enhance `ToolExecutor` and `BrowserSession` to handle webp image support based on model capabilities, adding `modelDoesntSupportWebp()` function.
> 
>   - **Behavior**:
>     - `ToolExecutor` now includes `Grok4` model family in `isNextGenModel` checks in `pushToolResult()` and `handleStreamingJsonReplacement()`.
>     - `BrowserSession` constructor now accepts `useWebp` parameter to determine screenshot format.
>     - `BrowserSession` uses `modelDoesntSupportWebp()` to decide between `webp` and `png` for screenshots.
>   - **Functions**:
>     - Adds `modelDoesntSupportWebp()` in `model-utils.ts` to check if a model supports webp images.
>   - **Misc**:
>     - Adjusts screenshot logic in `doAction()` and `navigateToUrl()` in `BrowserSession` to retry with `png` if `webp` fails.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for be364d96baa3c8aa1f64c465e7fe91669d8625b0. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->