### PR TITLE
Support mentions for filenames with spaces

### DIFF
--- a/src/core/mentions/__tests__/index.test.ts
+++ b/src/core/mentions/__tests__/index.test.ts
@@ -1,0 +1,421 @@
+import { expect } from "chai"
+import * as sinon from "sinon"
+import * as path from "path"
+import { parseMentions } from "../index"
+import { UrlContentFetcher } from "@services/browser/UrlContentFetcher"
+import { FileContextTracker } from "@core/context/context-tracking/FileContextTracker"
+import * as extractTextModule from "@integrations/misc/extract-text"
+import * as isBinaryFileModule from "isbinaryfile"
+import * as terminalModule from "@integrations/terminal/get-latest-output"
+import * as gitModule from "@utils/git"
+import { DiffViewProviderCreator, HostProvider, WebviewProviderCreator } from "@/hosts/host-provider"
+import * as fs from "fs"
+import { vscodeHostBridgeClient } from "@/hosts/vscode/hostbridge/client/host-grpc-client"
+
+describe("parseMentions", () => {
+	let sandbox: sinon.SinonSandbox
+	let urlContentFetcherStub: sinon.SinonStubbedInstance<UrlContentFetcher>
+	let fileContextTrackerStub: sinon.SinonStubbedInstance<FileContextTracker>
+	let fsStatStub: sinon.SinonStub
+	let fsReaddirStub: sinon.SinonStub
+	let extractTextStub: sinon.SinonStub
+	let isBinaryFileStub: sinon.SinonStub
+	let getLatestTerminalOutputStub: sinon.SinonStub
+	let getWorkingStateStub: sinon.SinonStub
+	let getCommitInfoStub: sinon.SinonStub
+	let showMessageStub: sinon.SinonStub
+
+	const cwd = "/test/project"
+
+	beforeEach(() => {
+		sandbox = sinon.createSandbox()
+		HostProvider.reset()
+		HostProvider.initialize(
+			((_) => {}) as WebviewProviderCreator,
+			(() => {}) as DiffViewProviderCreator,
+			vscodeHostBridgeClient,
+			(_) => {},
+		)
+		// Create stubs for dependencies
+		urlContentFetcherStub = {
+			launchBrowser: sandbox.stub().resolves(),
+			closeBrowser: sandbox.stub().resolves(),
+			urlToMarkdown: sandbox.stub().resolves("# Example Website\n\nContent here"),
+		} as any
+
+		fileContextTrackerStub = {
+			trackFileContext: sandbox.stub().resolves(),
+		} as any
+
+		// Stub file system operations using fs.promises
+		fsStatStub = sandbox.stub(fs.promises, "stat")
+		fsReaddirStub = sandbox.stub(fs.promises, "readdir")
+
+		// Stub other modules
+		extractTextStub = sandbox.stub(extractTextModule, "extractTextFromFile")
+		isBinaryFileStub = sandbox.stub(isBinaryFileModule, "isBinaryFile")
+		getLatestTerminalOutputStub = sandbox.stub(terminalModule, "getLatestTerminalOutput")
+		getWorkingStateStub = sandbox.stub(gitModule, "getWorkingState")
+		getCommitInfoStub = sandbox.stub(gitModule, "getCommitInfo")
+		showMessageStub = sandbox.stub(HostProvider.window, "showMessage")
+	})
+
+	afterEach(() => {
+		sandbox.restore()
+	})
+
+	describe("File mentions", () => {
+		it("should handle simple file mention", async () => {
+			const text = "Check @/src/index.ts for details"
+
+			fsStatStub.resolves({ isFile: () => true, isDirectory: () => false })
+			isBinaryFileStub.resolves(false)
+			extractTextStub.resolves("console.log('Hello World');")
+
+			const result = await parseMentions(text, cwd, urlContentFetcherStub, fileContextTrackerStub)
+
+			const expectedOutput = `Check 'src/index.ts' (see below for file content) for details
+
+<file_content path="src/index.ts">
+console.log('Hello World');
+</file_content>`
+
+			expect(result).to.equal(expectedOutput)
+			expect(fileContextTrackerStub.trackFileContext.calledWith("src/index.ts", "file_mentioned")).to.be.true
+		})
+
+		it("should handle quoted file paths with spaces", async () => {
+			const text = 'Open @"/path with spaces/file.txt"'
+
+			fsStatStub.resolves({ isFile: () => true, isDirectory: () => false })
+			isBinaryFileStub.resolves(false)
+			extractTextStub.resolves("console.log('Hello World');")
+
+			const result = await parseMentions(text, cwd, urlContentFetcherStub)
+
+			const expectedOutput = `Open 'path with spaces/file.txt' (see below for file content)
+
+<file_content path="path with spaces/file.txt">
+console.log('Hello World');
+</file_content>`
+
+			expect(result).to.equal(expectedOutput)
+		})
+
+		it("should handle binary files", async () => {
+			const text = "Check @/image.png"
+
+			fsStatStub.resolves({ isFile: () => true, isDirectory: () => false })
+			isBinaryFileStub.resolves(true)
+
+			const result = await parseMentions(text, cwd, urlContentFetcherStub)
+
+			const expectedOutput = `Check 'image.png' (see below for file content)
+
+<file_content path="image.png">
+(Binary file, unable to display content)
+</file_content>`
+
+			expect(result).to.equal(expectedOutput)
+		})
+
+		it("should handle file read errors", async () => {
+			const text = "Check @/missing.txt"
+
+			fsStatStub.rejects(new Error("ENOENT: no such file or directory"))
+
+			const result = await parseMentions(text, cwd, urlContentFetcherStub)
+
+			const expectedOutput = `Check 'missing.txt' (see below for file content)
+
+<file_content path="missing.txt">
+Error fetching content: Failed to access path "missing.txt": ENOENT: no such file or directory
+</file_content>`
+
+			expect(result).to.equal(expectedOutput)
+		})
+	})
+
+	describe("Folder mentions", () => {
+		it("should handle folder mention", async () => {
+			const text = "Look in @/src/ folder"
+
+			fsStatStub.resolves({ isFile: () => false, isDirectory: () => true })
+			fsReaddirStub.resolves([
+				{ name: "index.ts", isFile: () => true, isDirectory: () => false },
+				{ name: "utils", isFile: () => false, isDirectory: () => true },
+				{ name: "README.md", isFile: () => true, isDirectory: () => false },
+			])
+
+			// Set up file content stubs
+			isBinaryFileStub.resolves(false)
+			extractTextStub.withArgs(path.resolve(cwd, "src/index.ts")).resolves("export const main = () => {};")
+			extractTextStub.withArgs(path.resolve(cwd, "src/README.md")).resolves("# Source Code")
+
+			const result = await parseMentions(text, cwd, urlContentFetcherStub)
+
+			const expectedOutput = `Look in 'src/' (see below for folder content) folder
+
+<folder_content path="src/">
+├── index.ts
+├── utils/
+└── README.md
+
+<file_content path="src/index.ts">
+export const main = () => {};
+</file_content>
+
+<file_content path="src/README.md">
+# Source Code
+</file_content>
+</folder_content>`
+
+			expect(result).to.equal(expectedOutput)
+		})
+	})
+
+	describe("URL mentions", () => {
+		it("should handle URL mention", async () => {
+			const text = "Visit @https://example.com for info"
+
+			const result = await parseMentions(text, cwd, urlContentFetcherStub)
+
+			const expectedOutput = `Visit 'https://example.com' (see below for site content) for info
+
+<url_content url="https://example.com">
+# Example Website
+
+Content here
+</url_content>`
+
+			expect(result).to.equal(expectedOutput)
+			expect(urlContentFetcherStub.launchBrowser.called).to.be.true
+			expect(urlContentFetcherStub.urlToMarkdown.calledWith("https://example.com")).to.be.true
+			expect(urlContentFetcherStub.closeBrowser.called).to.be.true
+		})
+
+		it("should handle browser launch errors", async () => {
+			const text = "Visit @https://example.com"
+
+			urlContentFetcherStub.launchBrowser.rejects(new Error("Browser launch failed"))
+
+			const result = await parseMentions(text, cwd, urlContentFetcherStub)
+
+			const expectedOutput = `Visit 'https://example.com' (see below for site content)
+
+<url_content url="https://example.com">
+Error fetching content: Browser launch failed
+</url_content>`
+
+			expect(result).to.equal(expectedOutput)
+			expect(showMessageStub.called).to.be.true
+		})
+
+		it("should handle URL fetch errors", async () => {
+			const text = "Visit @https://example.com"
+
+			urlContentFetcherStub.urlToMarkdown.rejects(new Error("Network error"))
+
+			const result = await parseMentions(text, cwd, urlContentFetcherStub)
+
+			const expectedOutput = `Visit 'https://example.com' (see below for site content)
+
+<url_content url="https://example.com">
+Error fetching content: Network error
+</url_content>`
+
+			expect(result).to.equal(expectedOutput)
+			expect(showMessageStub.called).to.be.true
+		})
+	})
+
+	describe("Special mentions", () => {
+		it("should handle @terminal mention", async () => {
+			const text = "See @terminal output"
+
+			getLatestTerminalOutputStub.resolves("$ npm test\nAll tests passed!")
+
+			const result = await parseMentions(text, cwd, urlContentFetcherStub)
+
+			const expectedOutput = `See Terminal Output (see below for output) output
+
+<terminal_output>
+$ npm test
+All tests passed!
+</terminal_output>`
+
+			expect(result).to.equal(expectedOutput)
+		})
+
+		it("should handle @git-changes mention", async () => {
+			const text = "Review @git-changes"
+
+			getWorkingStateStub.resolves("M  src/index.ts\nA  src/new-file.ts")
+
+			const result = await parseMentions(text, cwd, urlContentFetcherStub)
+
+			const expectedOutput = `Review Working directory changes (see below for details)
+
+<git_working_state>
+M  src/index.ts
+A  src/new-file.ts
+</git_working_state>`
+
+			expect(result).to.equal(expectedOutput)
+		})
+
+		it("should handle git commit hash mention", async () => {
+			const text = "See commit @abcdef1234567890"
+
+			getCommitInfoStub.resolves("commit abcdef1234567890\nAuthor: Test\nDate: 2024-01-01\n\nInitial commit")
+
+			const result = await parseMentions(text, cwd, urlContentFetcherStub)
+
+			const expectedOutput = `See commit Git commit 'abcdef1234567890' (see below for commit info)
+
+<git_commit hash="abcdef1234567890">
+commit abcdef1234567890
+Author: Test
+Date: 2024-01-01
+
+Initial commit
+</git_commit>`
+
+			expect(result).to.equal(expectedOutput)
+		})
+	})
+
+	describe("Multiple mentions", () => {
+		it("should handle multiple mentions in order", async () => {
+			const text = "Check @/file1.txt and @/file2.txt"
+
+			fsStatStub.resolves({ isFile: () => true, isDirectory: () => false })
+			isBinaryFileStub.resolves(false)
+			extractTextStub.withArgs(path.resolve(cwd, "file1.txt")).resolves("Content 1")
+			extractTextStub.withArgs(path.resolve(cwd, "file2.txt")).resolves("Content 2")
+
+			const result = await parseMentions(text, cwd, urlContentFetcherStub)
+
+			const expectedOutput = `Check 'file1.txt' (see below for file content) and 'file2.txt' (see below for file content)
+
+<file_content path="file1.txt">
+Content 1
+</file_content>
+
+<file_content path="file2.txt">
+Content 2
+</file_content>`
+
+			expect(result).to.equal(expectedOutput)
+		})
+
+		it("should handle duplicate mentions only once", async () => {
+			const text = "Check @/file.txt and again @/file.txt"
+
+			fsStatStub.resolves({ isFile: () => true, isDirectory: () => false })
+			isBinaryFileStub.resolves(false)
+			extractTextStub.resolves("Content")
+
+			const result = await parseMentions(text, cwd, urlContentFetcherStub)
+
+			const expectedOutput = `Check 'file.txt' (see below for file content) and again 'file.txt' (see below for file content)
+
+<file_content path="file.txt">
+Content
+</file_content>`
+
+			expect(result).to.equal(expectedOutput)
+		})
+
+		it("should handle mixed mention types", async () => {
+			const text = "Check @/file.txt, and @https://example.com"
+
+			fsStatStub.resolves({ isFile: () => true, isDirectory: () => false })
+			isBinaryFileStub.resolves(false)
+			extractTextStub.resolves("File content")
+
+			const result = await parseMentions(text, cwd, urlContentFetcherStub)
+
+			const expectedOutput = `Check 'file.txt' (see below for file content), and 'https://example.com' (see below for site content)
+
+<file_content path="file.txt">
+File content
+</file_content>
+
+<url_content url="https://example.com">
+# Example Website
+
+Content here
+</url_content>`
+
+			expect(result).to.equal(expectedOutput)
+		})
+	})
+
+	describe("Error handling", () => {
+		it("should handle errors for each mention type gracefully", async () => {
+			const text = "@/error.txt @terminal @git-changes @abc1234567"
+
+			fsStatStub.rejects(new Error("File error"))
+			getLatestTerminalOutputStub.rejects(new Error("Terminal error"))
+			getWorkingStateStub.rejects(new Error("Git state error"))
+			getCommitInfoStub.rejects(new Error("Commit error"))
+
+			const result = await parseMentions(text, cwd, urlContentFetcherStub)
+
+			const expectedOutput = `'error.txt' (see below for file content) Terminal Output (see below for output) Working directory changes (see below for details) Git commit 'abc1234567' (see below for commit info)
+
+<file_content path="error.txt">
+Error fetching content: Failed to access path "error.txt": File error
+</file_content>
+
+<terminal_output>
+Error fetching terminal output: Terminal error
+</terminal_output>
+
+<git_working_state>
+Error fetching working state: Git state error
+</git_working_state>
+
+<git_commit hash="abc1234567">
+Error fetching commit info: Commit error
+</git_commit>`
+
+			expect(result).to.equal(expectedOutput)
+		})
+	})
+
+	describe("Edge cases", () => {
+		it("should handle text with no mentions", async () => {
+			const text = "This is plain text without any mentions"
+
+			const result = await parseMentions(text, cwd, urlContentFetcherStub)
+
+			expect(result).to.equal(text)
+		})
+
+		it("should handle empty text", async () => {
+			const result = await parseMentions("", cwd, urlContentFetcherStub)
+
+			expect(result).to.equal("")
+		})
+
+		it("should handle mentions with trailing punctuation", async () => {
+			const text = "Check @/file.txt!"
+
+			fsStatStub.resolves({ isFile: () => true, isDirectory: () => false })
+			isBinaryFileStub.resolves(false)
+			extractTextStub.resolves("Content")
+
+			const result = await parseMentions(text, cwd, urlContentFetcherStub)
+
+			const expectedOutput = `Check 'file.txt' (see below for file content)!
+
+<file_content path="file.txt">
+Content
+</file_content>`
+
+			expect(result).to.equal(expectedOutput)
+		})
+	})
+})

--- a/src/core/mentions/index.ts
+++ b/src/core/mentions/index.ts
@@ -240,7 +240,7 @@ function isFileMention(mention: string): boolean {
 function getFilePathFromMention(mention: string): string {
 	// Remove quotes
 	const match = mention.match(/^"(.*)"$/)
-	var filePath = match ? match[1] : mention
+	const filePath = match ? match[1] : mention
 	// Remove leading slash
 	return filePath.slice(1)
 }

--- a/src/core/mentions/index.ts
+++ b/src/core/mentions/index.ts
@@ -14,7 +14,7 @@ import { FileContextTracker } from "../context/context-tracking/FileContextTrack
 import { getCwd } from "@/utils/path"
 import { openExternal } from "@utils/env"
 import { HostProvider } from "@/hosts/host-provider"
-import { ShowMessageRequest, ShowMessageType } from "@/shared/proto/host/window"
+import { ShowMessageType } from "@/shared/proto/host/window"
 
 export async function openMention(mention?: string): Promise<void> {
 	if (!mention) {
@@ -26,8 +26,8 @@ export async function openMention(mention?: string): Promise<void> {
 		return
 	}
 
-	if (mention.startsWith("/")) {
-		const relPath = mention.slice(1)
+	if (isFileMention(mention)) {
+		const relPath = getFilePathFromMention(mention)
 		const absPath = path.resolve(cwd, relPath)
 		if (mention.endsWith("/")) {
 			vscode.commands.executeCommand("revealInExplorer", vscode.Uri.file(absPath))
@@ -54,8 +54,8 @@ export async function parseMentions(
 		mentions.add(mention)
 		if (mention.startsWith("http")) {
 			return `'${mention}' (see below for site content)`
-		} else if (mention.startsWith("/")) {
-			const mentionPath = mention.slice(1) // Remove the leading '/'
+		} else if (isFileMention(mention)) {
+			const mentionPath = getFilePathFromMention(mention)
 			return mentionPath.endsWith("/")
 				? `'${mentionPath}' (see below for folder content)`
 				: `'${mentionPath}' (see below for file content)`
@@ -106,8 +106,8 @@ export async function parseMentions(
 				}
 			}
 			parsedText += `\n\n<url_content url="${mention}">\n${result}\n</url_content>`
-		} else if (mention.startsWith("/")) {
-			const mentionPath = mention.slice(1)
+		} else if (isFileMention(mention)) {
+			const mentionPath = getFilePathFromMention(mention)
 			try {
 				const content = await getFileOrFolderContent(mentionPath, cwd)
 				if (mention.endsWith("/")) {
@@ -231,4 +231,16 @@ async function getWorkspaceProblems(): Promise<string> {
 		return "No errors or warnings detected."
 	}
 	return result
+}
+
+function isFileMention(mention: string): boolean {
+	return mention.startsWith("/") || mention.startsWith('"/')
+}
+
+function getFilePathFromMention(mention: string): string {
+	// Remove quotes
+	const match = mention.match(/^"(.*)"$/)
+	var filePath = match ? match[1] : mention
+	// Remove leading slash
+	return filePath.slice(1)
 }

--- a/src/shared/context-mentions.ts
+++ b/src/shared/context-mentions.ts
@@ -29,10 +29,10 @@ Mention regex:
       - **Exact Word ('terminal')**: Matches the exact word 'terminal'.
       - **Word Boundary (`\b`)**: Ensures that 'terminal' is matched as a whole word and not as part of another word (e.g., 'terminals').
 
-  - `(?=[.,;:!?]?(?=[\s\r\n]|$))`:
+  - `(?=[.,;:!?()]*(?=[\s\r\n]|$))`:
 	- **Positive Lookahead (`(?=...)`)**: Ensures that the match is followed by specific patterns without including them in the match.
-	- `[.,;:!?]?`: 
-	  - **Optional Punctuation (`[.,;:!?]?`)**: Matches zero or one of the specified punctuation marks.
+	- `[.,;:!?()]*`: 
+	  - **Optional Punctuation (`[.,;:!?()]*`)**: Matches zero or more of the specified punctuation marks (including parentheses).
 	- `(?=[\s\r\n]|$)`: 
 	  - **Nested Positive Lookahead (`(?=[\s\r\n]|$)`)**: Ensures that the punctuation (if present) is followed by a whitespace character, a line break, or the end of the string.
   
@@ -49,6 +49,16 @@ Mention regex:
   - `mentionRegexGlobal`: Creates a global version of the `mentionRegex` to find all matches within a given string.
 
 */
-export const mentionRegex =
-	/@((?:\/|\w+:\/\/)[^\s]+?|[a-f0-9]{7,40}\b|problems\b|terminal\b|git-changes\b)(?=[.,;:!?]?(?=[\s\r\n]|$))/
+export const mentionRegex = new RegExp(
+	`@(` +
+		`/[^\\s]*?` + // Simple file paths (can't contain)
+		`|"\\/[^"]*?"` + // Quoted file paths which can contain spaces
+		`|(?:\\w+:\\/\\/)[^\\s]+?` + // URLs
+		`|[a-f0-9]{7,40}\\b` + // Git commit hashes
+		`|problems\\b` + // Exact word 'problems'
+		`|terminal\\b` + // Exact word 'terminal'
+		`|git-changes\\b` + // Exact word 'git-changes'
+		`)` +
+		`(?=[.,;:!?()]*(?=[\\s\\r\\n]|$))`, // Lookahead for trailing punctuation (multiple allowed)
+)
 export const mentionRegexGlobal = new RegExp(mentionRegex.source, "g")

--- a/webview-ui/src/utils/__tests__/context-mentions.test.ts
+++ b/webview-ui/src/utils/__tests__/context-mentions.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from "vitest"
+import { insertMention, insertMentionDirectly } from "../context-mentions"
+
+describe("context-mentions", () => {
+	describe("insertMention", () => {
+		it("should add quotes to file paths with spaces", () => {
+			const text = "Check @"
+			const position = 7
+			const value = "/path with spaces/file.txt"
+
+			const result = insertMention(text, position, value)
+
+			expect(result.newValue).toBe('Check @"/path with spaces/file.txt" ')
+			expect(result.mentionIndex).toBe(6)
+		})
+
+		it("should not add quotes to file paths without spaces", () => {
+			const text = "Check @"
+			const position = 7
+			const value = "/path/without/spaces.txt"
+
+			const result = insertMention(text, position, value)
+
+			expect(result.newValue).toBe("Check @/path/without/spaces.txt ")
+			expect(result.mentionIndex).toBe(6)
+		})
+
+		it("should not add quotes to non-file mentions", () => {
+			const text = "Check @"
+			const position = 7
+			const value = "terminal"
+
+			const result = insertMention(text, position, value)
+
+			expect(result.newValue).toBe("Check @terminal ")
+			expect(result.mentionIndex).toBe(6)
+		})
+
+		it("should replace existing partial mention", () => {
+			const text = "Check @/pa and more"
+			const position = 10
+			const value = "/path with spaces/file.txt"
+
+			const result = insertMention(text, position, value)
+
+			expect(result.newValue).toBe('Check @"/path with spaces/file.txt"  and more')
+			expect(result.mentionIndex).toBe(6)
+		})
+
+		it("should handle folder paths with spaces", () => {
+			const text = "Look in @"
+			const position = 9
+			const value = "/folder with spaces/"
+
+			const result = insertMention(text, position, value)
+
+			expect(result.newValue).toBe('Look in @"/folder with spaces/" ')
+			expect(result.mentionIndex).toBe(8)
+		})
+	})
+
+	describe("insertMentionDirectly", () => {
+		it("should add quotes to file paths with spaces", () => {
+			const text = "Some text "
+			const position = 10
+			const value = "/folder with spaces/"
+
+			const result = insertMentionDirectly(text, position, value)
+
+			expect(result.newValue).toBe('Some text @"/folder with spaces/" ')
+			expect(result.mentionIndex).toBe(10)
+		})
+
+		it("should not add quotes to file paths without spaces", () => {
+			const text = "Some text "
+			const position = 10
+			const value = "/folder/without/spaces/"
+
+			const result = insertMentionDirectly(text, position, value)
+
+			expect(result.newValue).toBe("Some text @/folder/without/spaces/ ")
+			expect(result.mentionIndex).toBe(10)
+		})
+
+		it("should handle URLs without adding quotes", () => {
+			const text = "Visit "
+			const position = 6
+			const value = "https://example.com"
+
+			const result = insertMentionDirectly(text, position, value)
+
+			expect(result.newValue).toBe("Visit @https://example.com ")
+			expect(result.mentionIndex).toBe(6)
+		})
+
+		it("should handle special mentions without adding quotes", () => {
+			const text = "Check "
+			const position = 6
+			const value = "git-changes"
+
+			const result = insertMentionDirectly(text, position, value)
+
+			expect(result.newValue).toBe("Check @git-changes ")
+			expect(result.mentionIndex).toBe(6)
+		})
+	})
+})

--- a/webview-ui/src/utils/context-mentions.ts
+++ b/webview-ui/src/utils/context-mentions.ts
@@ -15,17 +15,23 @@ export function insertMention(text: string, position: number, value: string): { 
 	// Find the position of the last '@' symbol before the cursor
 	const lastAtIndex = beforeCursor.lastIndexOf("@")
 
+	// For file/folder paths that contain spaces, wrap them in quotes
+	let formattedValue = value
+	if (value.startsWith("/") && value.includes(" ")) {
+		formattedValue = `"${value}"`
+	}
+
 	let newValue: string
 	let mentionIndex: number
 
 	if (lastAtIndex !== -1) {
 		// If there's an '@' symbol, replace everything after it with the new mention
 		const beforeMention = text.slice(0, lastAtIndex)
-		newValue = beforeMention + "@" + value + " " + afterCursor.replace(/^[^\s]*/, "")
+		newValue = beforeMention + "@" + formattedValue + " " + afterCursor.replace(/^[^\s]*/, "")
 		mentionIndex = lastAtIndex
 	} else {
 		// If there's no '@' symbol, insert the mention at the cursor position
-		newValue = beforeCursor + "@" + value + " " + afterCursor
+		newValue = beforeCursor + "@" + formattedValue + " " + afterCursor
 		mentionIndex = position
 	}
 
@@ -35,7 +41,14 @@ export function insertMention(text: string, position: number, value: string): { 
 export function insertMentionDirectly(text: string, position: number, value: string): { newValue: string; mentionIndex: number } {
 	const beforeCursor = text.slice(0, position)
 	const afterCursor = text.slice(position)
-	const newValue = beforeCursor + "@" + value + " " + afterCursor
+
+	// For file/folder paths that contain spaces, wrap them in quotes
+	let formattedValue = value
+	if (value.startsWith("/") && value.includes(" ")) {
+		formattedValue = `"${value}"`
+	}
+
+	const newValue = beforeCursor + "@" + formattedValue + " " + afterCursor
 	const mentionIndex = position
 	return { newValue, mentionIndex }
 }


### PR DESCRIPTION
This change allows users to reference files with spaces in their names, which was previously impossible due to the space-delimited mention syntax.
File names with spaces can be @ mentioned by quoting the file name, e.g. @"/path with spaces/file.txt".

Fixes #5304

- Update mention regex in `src/shared/context-mentions.ts` to accept quoted file paths
  - Add support for quoted file paths that can contain spaces.
  - Allow multiple trailing punctuation chars; previously only a single limited punctuation characters were allowed.
  - Maintain support for unquoted paths, URLs, git hashes, and special keywords

- Update `src/core/mentions/index.ts` to handle quoted file names in mention parsing
  - Process quoted file paths by removing quotes when accessing the file system
  - Preserve existing functionality for all other mention types

- Update `webview-ui/src/utils/context-mentions.ts` to auto-quote file names with spaces
  - `insertMention()` and `insertMentionDirectly()` now wrap file paths containing spaces in quotes
  - Non-file mentions (URLs, keywords) remain unquoted

- Add comprehensive unit tests:
  - New test file `src/core/mentions/__tests__/index.test.ts` covering all mention types
  - New test file `webview-ui/src/utils/__tests__/context-mentions.test.ts` for webview mention insertion
  - Expanded `src/shared/__tests__/context-mentions.test.ts` to cover quoted paths and edge cases

https://github.com/user-attachments/assets/944e7794-8f46-4460-a166-a7f53c043dff



<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Support for file mentions with spaces by quoting paths, updating regex, parsing logic, and UI components, with comprehensive tests added.
> 
>   - **Behavior**:
>     - Support for file mentions with spaces by quoting file paths, e.g., `@"/path with spaces/file.txt"`.
>     - Updated mention regex in `context-mentions.ts` to handle quoted file paths and allow multiple trailing punctuation characters.
>     - Updated `parseMentions()` in `index.ts` to process quoted file paths by removing quotes.
>     - Updated `insertMention()` and `insertMentionDirectly()` in `context-mentions.ts` to auto-quote file paths with spaces.
>   - **Tests**:
>     - Added `index.test.ts` for mention parsing covering all mention types.
>     - Added `context-mentions.test.ts` for webview mention insertion.
>     - Expanded `context-mentions.test.ts` to cover quoted paths and edge cases.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 3cbf5ba45ce30d05206dcccd472cb9a7ebe02940. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->