### PR TITLE
refactor: Use MCP icon in the navar and update styling 

### DIFF
--- a/webview-ui/src/components/menu/Navbar.tsx
+++ b/webview-ui/src/components/menu/Navbar.tsx
@@ -1,7 +1,16 @@
-import { DatabaseIcon, HistoryIcon, PlusIcon, SettingsIcon, UserCircleIcon } from "lucide-react"
+import { HistoryIcon, PlusIcon, SettingsIcon, UserCircleIcon } from "lucide-react"
 import { useMemo } from "react"
 import { useExtensionState } from "../../context/ExtensionStateContext"
-import { TabTrigger } from "../common/Tab"
+import { VSCodeButton } from "@vscode/webview-ui-toolkit/react"
+import HeroTooltip from "../common/HeroTooltip"
+
+// Custom MCP Server Icon component using VSCode codicon
+const McpServerIcon = ({ className, size }: { className?: string; size?: number }) => (
+	<span
+		className={`codicon codicon-server flex items-center ${className || ""}`}
+		style={{ fontSize: size ? `${size}px` : "12.5px", marginBottom: "1px" }}
+	/>
+)
 
 export const Navbar = () => {
 	const { navigateToHistory, navigateToSettings, navigateToAccount, navigateToMcp, navigateToChat } = useExtensionState()
@@ -11,30 +20,35 @@ export const Navbar = () => {
 			{
 				id: "chat",
 				name: "Chat",
+				tooltip: "New Task",
 				icon: PlusIcon,
 				navigate: navigateToChat,
 			},
 			{
 				id: "mcp",
 				name: "MCP",
-				icon: DatabaseIcon,
+				tooltip: "MCP Servers",
+				icon: McpServerIcon,
 				navigate: navigateToMcp,
 			},
 			{
 				id: "history",
 				name: "History",
+				tooltip: "History",
 				icon: HistoryIcon,
 				navigate: navigateToHistory,
 			},
 			{
 				id: "account",
 				name: "Account",
+				tooltip: "Account",
 				icon: UserCircleIcon,
 				navigate: navigateToAccount,
 			},
 			{
 				id: "settings",
 				name: "Settings",
+				tooltip: "Settings",
 				icon: SettingsIcon,
 				navigate: navigateToSettings,
 			},
@@ -45,16 +59,22 @@ export const Navbar = () => {
 	return (
 		<nav
 			id="cline-navbar-container"
-			className="flex-none inline-flex justify-end bg-transparent shadow-sm gap-2 mb-1 z-10 border-none items-center mr-4!">
+			className="flex-none inline-flex justify-end bg-transparent gap-2 mb-1 z-10 border-none items-center mr-4!"
+			style={{ gap: "4px" }}>
 			{SETTINGS_TABS.map((tab) => (
-				<TabTrigger
-					key={`navbar-trigger-${tab.id}`}
-					value={tab.id}
-					className="bg-transparent border-none text-white m-0 p-0 cursor-pointer"
-					data-testid={`tab-${tab.id}`}
-					onSelect={() => tab.navigate()}>
-					<tab.icon className="text-white" strokeWidth={1} size={18} />
-				</TabTrigger>
+				<HeroTooltip key={`navbar-tooltip-${tab.id}`} content={tab.tooltip} placement="bottom">
+					<VSCodeButton
+						key={`navbar-button-${tab.id}`}
+						appearance="icon"
+						aria-label={tab.tooltip}
+						data-testid={`tab-${tab.id}`}
+						onClick={() => tab.navigate()}
+						style={{ padding: "0px", height: "20px" }}>
+						<div className="flex items-center gap-1 text-xs whitespace-nowrap min-w-0 w-full">
+							<tab.icon className="text-[var(--vscode-foreground)]" strokeWidth={1} size={18} />
+						</div>
+					</VSCodeButton>
+				</HeroTooltip>
 			))}
 		</nav>
 	)


### PR DESCRIPTION
- Replace database icon with MCP server icon (codicon-server)
- Remove shadow-sm class for a flatter appearance
- Maintain consistent button styling with VSCodeButton components
- Use the theme foreground color for the icons
- Add tooltips using HeroTooltip

<img width="505" height="262" alt="Screenshot 2025-08-03 at 22 59 28" src="https://github.com/user-attachments/assets/97e508d0-f6b3-4e9e-afb5-88060139673f" />



<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Refactor `Navbar.tsx` to update icon, remove shadow, use `VSCodeButton`, and add tooltips.
> 
>   - **Icons**:
>     - Replace `DatabaseIcon` with `McpServerIcon` using VSCode codicon in `Navbar.tsx`.
>   - **Styling**:
>     - Remove `shadow-sm` class from `nav` element for a flatter appearance in `Navbar.tsx`.
>     - Use `VSCodeButton` for consistent button styling in `Navbar.tsx`.
>   - **Tooltips**:
>     - Add tooltips to each tab using `HeroTooltip` in `Navbar.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for b4e144ec9fa25d1a109713bd9c9781fa85ab4c3f. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->