### PR TITLE
Fix flakey test getOpenTabs and re-enable unit tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -96,10 +96,8 @@ jobs:
             - name: Build Tests and Extension
               run: npm run pretest
 
-            # Unit Tests disabled due to module system conflicts between backend and webview-ui
-            # FIX: Right now the tests are run when the PR is being reviewed, but if main is updated after that, the PR can merge without the tests being run on the latest version of main.
-            # - name: Unit Tests
-            #   run: npm run test:unit
+            - name: Unit Tests
+              run: npm run test:unit
 
             # Run extension tests with coverage
             - name: Extension Tests with Coverage

--- a/src/hosts/vscode/hostbridge/window/getOpenTabs.test.ts
+++ b/src/hosts/vscode/hostbridge/window/getOpenTabs.test.ts
@@ -2,6 +2,7 @@
 import { describe, it, beforeEach, afterEach } from "mocha"
 import { strict as assert } from "assert"
 import * as vscode from "vscode"
+import pWaitFor from "p-wait-for"
 import { getOpenTabs } from "@/hosts/vscode/hostbridge/window/getOpenTabs"
 import { GetOpenTabsRequest } from "@/shared/proto/host/window"
 
@@ -54,8 +55,18 @@ describe("Hostbridge - Window - getOpenTabs", () => {
 		await createAndOpenTestDocument(1, vscode.ViewColumn.One)
 		await createAndOpenTestDocument(2, vscode.ViewColumn.Two)
 
-		// Wait a bit for tabs to be fully created
-		await new Promise((resolve) => setTimeout(resolve, 100))
+		// Wait for tabs to be fully created
+		await pWaitFor(
+			async () => {
+				const request = GetOpenTabsRequest.create({})
+				const response = await getOpenTabs(request)
+				return response.paths.length === 2
+			},
+			{
+				timeout: 2000,
+				interval: 50,
+			},
+		)
 
 		const request = GetOpenTabsRequest.create({})
 		const response = await getOpenTabs(request)
@@ -74,8 +85,18 @@ describe("Hostbridge - Window - getOpenTabs", () => {
 		await createAndOpenTestDocument(2, vscode.ViewColumn.One)
 		await createAndOpenTestDocument(3, vscode.ViewColumn.One)
 
-		// Wait a bit for tabs to be fully created
-		await new Promise((resolve) => setTimeout(resolve, 100))
+		// Wait for tabs to be fully created
+		await pWaitFor(
+			async () => {
+				const request = GetOpenTabsRequest.create({})
+				const response = await getOpenTabs(request)
+				return response.paths.length === 3
+			},
+			{
+				timeout: 2000,
+				interval: 50,
+			},
+		)
 
 		const request = GetOpenTabsRequest.create({})
 		const response = await getOpenTabs(request)


### PR DESCRIPTION
Update the integration test `getOpenTabs.test.ts` to wait until the tabs are opened, instead of using a fixed 100ms wait.

- Replace fixed 100ms timeout with pWaitFor polling mechanism
- Set 2-second timeout with 50ms polling interval
- Test now waits exactly as long as needed for tabs to be created