### PR TITLE
Update the GitHub test action to produce more readable output

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -102,7 +102,7 @@ jobs:
             #   run: npm run test:unit
 
             # Run extension tests with coverage
-            - name: Extension Tests with Coverage
+            - name: Extension Integration Tests with Coverage
               id: extension_coverage
               continue-on-error: true
               run: |
@@ -133,7 +133,6 @@ jobs:
                   path: |
                       extension_coverage.txt
                       webview-ui/webview_coverage.txt
-                  retention-period: workflow # Artifacts are automatically deleted when the workflow completes
 
             # Set the check as failed if any of the tests failed
             - name: Check for test failures

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -106,7 +106,7 @@ jobs:
               id: extension_coverage
               continue-on-error: true
               run: |
-                  node ./scripts/test-ci.js > extension_coverage.txt 2>&1
+                  node ./scripts/test-ci.js 2>&1 | tee extension_coverage.txt
                   # Default the encoding to UTF-8 - It's not the default on Windows
                   PYTHONUTF8=1 PYTHONPATH=.github/scripts python -m coverage_check extract-coverage extension_coverage.txt --type=extension --github-output --verbose
 
@@ -118,7 +118,7 @@ jobs:
                   cd webview-ui
                   # Ensure coverage dependency is installed
                   npm install --no-save @vitest/coverage-v8
-                  npm run test:coverage > webview_coverage.txt 2>&1
+                  npm run test:coverage 2>&1 | tee webview_coverage.txt
                   cd ..
                   # Default the encoding to UTF-8 - It's not the default on Windows
                   PYTHONUTF8=1 PYTHONPATH=.github/scripts python -m coverage_check extract-coverage webview-ui/webview_coverage.txt --type=webview --github-output --verbose
@@ -136,18 +136,17 @@ jobs:
                   retention-period: workflow # Artifacts are automatically deleted when the workflow completes
 
             # Set the check as failed if any of the tests failed
-            - name: Print test results and check for failures
+            - name: Check for test failures
               run: |
-                  echo "Extension Tests Result: ${{ steps.extension_coverage.outcome }}"
-                  cat extension_coverage.txt
-
-                  echo "Webview Tests Result: ${{ steps.webview_coverage.outcome }}"
-                  cat webview-ui/webview_coverage.txt
-
                   # Check if any of the test steps failed
                   # https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/accessing-contextual-information-about-workflow-runs#steps-context
+                  if [ "${{ steps.extension_coverage.outcome }}" != "success" ]; then
+                      echo "Extension integration tests failed."
+                  fi
+                  if [ "${{ steps.webview_coverage.outcome }}" != "success" ]; then
+                      echo "Webview tests failed."
+                  fi
                   if [ "${{ steps.extension_coverage.outcome }}" != "success" ] || [ "${{ steps.webview_coverage.outcome }}" != "success" ]; then
-                      echo "Tests failed."
                       exit 1
                   fi
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -140,10 +140,10 @@ jobs:
                   # Check if any of the test steps failed
                   # https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/accessing-contextual-information-about-workflow-runs#steps-context
                   if [ "${{ steps.extension_coverage.outcome }}" != "success" ]; then
-                      echo "Extension integration tests failed."
+                      echo "Extension Integration Tests failed, see previous step for test output."
                   fi
                   if [ "${{ steps.webview_coverage.outcome }}" != "success" ]; then
-                      echo "Webview tests failed."
+                      echo "Webview Tests failed, see previous step for test output."
                   fi
                   if [ "${{ steps.extension_coverage.outcome }}" != "success" ] || [ "${{ steps.webview_coverage.outcome }}" != "success" ]; then
                       exit 1


### PR DESCRIPTION
Change the test.yml to show the output of the tests while they are being run, instead of waiting for both the integration and webview tests to finish.

With this change, you don't have to scroll back thousands of lines to see the failed integration tests.

When checking if the tests have failed, say which set of tests has failed instead of just 'tests failed'.

See https://github.com/cline/cline/actions/runs/16711660733/job/47297620551 for example of what it looks like when the tests fail.

Use tee to still save the output to the coverage file.

Remove unsupported tag `retention-period: workflow`
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Improve GitHub Actions test workflow for real-time output and specify failed tests, with added CI failure handling tests.
> 
>   - **GitHub Actions Workflow**:
>     - Update `.github/workflows/test.yml` to use `tee` for real-time test output while saving to coverage files.
>     - Remove unsupported `retention-period: workflow` tag.
>     - Modify failure check step to specify which tests failed.
>   - **Test Files**:
>     - Add failing assertions in `getOpenTabs.test.ts` and `ErrorRow.test.tsx` to test CI failure handling.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 861909aed6f300cf59d4455f01643788dc2a190c. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->