### PR TITLE
Add comments for HostBridge RPC showSaveDialog

### DIFF
--- a/proto/host/window.proto
+++ b/proto/host/window.proto
@@ -84,6 +84,8 @@ message ShowSaveDialogRequest {
 
 message ShowSaveDialogOptions {
   optional string default_path = 1;
+  // A map of file types to extensions, e.g
+  // "Text Files": { "extensions": ["txt", "md"] }
   map<string, FileExtensionList> filters = 2;
 }
 
@@ -92,6 +94,7 @@ message FileExtensionList {
 }
 
 message ShowSaveDialogResponse {
+  // If the user cancelled the dialog, this will be empty.
   optional string selected_path = 1;
 }
 


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add comments to `proto/host/window.proto` and update gRPC handling to include JSON encoding/decoding.
> 
>   - **Comments**:
>     - Add comments to `ShowSaveDialogOptions` and `ShowSaveDialogResponse` in `proto/host/window.proto` for better understanding of fields.


<!-- ELLIPSIS_HIDDEN -->