### PR TITLE
Add comments for HostBridge RPC showSaveDialog

### DIFF
--- a/proto/host/window.proto
+++ b/proto/host/window.proto
@@ -84,6 +84,8 @@ message ShowSaveDialogRequest {
 
 message ShowSaveDialogOptions {
   optional string default_path = 1;
+  // A map of file types to extensions, e.g
+  // "Text Files": { "extensions": ["txt", "md"] }
   map<string, FileExtensionList> filters = 2;
 }
 
@@ -92,6 +94,7 @@ message FileExtensionList {
 }
 
 message ShowSaveDialogResponse {
+  // If the user cancelled the dialog, this will be empty.
   optional string selected_path = 1;
 }
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add comments to `proto/host/window.proto` for `ShowSaveDialogOptions` and `ShowSaveDialogResponse`.
> 
>   - **Comments**:
>     - Add comment to `filters` in `ShowSaveDialogOptions` explaining the map of file types to extensions.
>     - Add comment to `selected_path` in `ShowSaveDialogResponse` indicating it will be empty if the dialog is cancelled.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 3da6e7b5ae4a84944e38370ee670440702b70c03. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->