### PR TITLE
JSON encode/decode ProtoBus messages in the webview when not in Vscode

### DIFF
--- a/scripts/generate-protobus-setup.mjs
+++ b/scripts/generate-protobus-setup.mjs
@@ -40,11 +40,11 @@ async function generateWebviewProtobusClients(protobusServices) {
 			}
 			if (!rpc.responseStream) {
 				rpcs.push(`    static async ${rpcName}(request: ${requestType}): Promise<${responseType}> {
-		return this.makeRequest("${rpcName}", request)
+		return this.makeUnaryRequest("${rpcName}", request, ${requestType}.toJSON, ${responseType}.fromJSON)
 	}`)
 			} else {
 				rpcs.push(`    static ${rpcName}(request: ${requestType}, callbacks: Callbacks<${responseType}>): ()=>void {
-		return this.makeStreamingRequest("${rpcName}", request, callbacks)
+		return this.makeStreamingRequest("${rpcName}", request, ${requestType}.toJSON, ${responseType}.fromJSON, callbacks)
 	}`)
 			}
 		}

--- a/src/standalone/utils.ts
+++ b/src/standalone/utils.ts
@@ -11,7 +11,8 @@ const log = (...args: unknown[]) => {
 function getPackageDefinition() {
 	// Load service definitions.
 	const descriptorSet = fs.readFileSync("proto/descriptor_set.pb")
-	const descriptorDefs = protoLoader.loadFileDescriptorSetFromBuffer(descriptorSet)
+	const options = { longs: Number } // Encode int64 fields as numbers
+	const descriptorDefs = protoLoader.loadFileDescriptorSetFromBuffer(descriptorSet, options)
 	const healthDef = protoLoader.loadSync(health.protoPath)
 	const packageDefinition = { ...descriptorDefs, ...healthDef }
 	return packageDefinition


### PR DESCRIPTION
### 1. __Modified gRPC Client Generation__ (`scripts/generate-protobus-setup.mjs`)

- __In VSCode__: Messages are passed as JS protobuf objects directly. Because the webview and the host are both using Javascript, it can skip the encoding.
- __In Standalone mode__: Messages are JSON encoded/decoded for transport between the webview and the host.

This is part of the effort to make Cline work as a standalone application outside of VSCode, ensuring proper message serialization across different runtime environments.

### 2. __Modified gRPC Client Generation__ (`scripts/generate-protobus-setup.mjs`)

- Updated the generated client methods to pass JSON encoder/decoder functions

### 3. __Updated Standalone Utils__ (`src/standalone/utils.ts`)

- Added options `{ longs: Number }` when loading the protobuf descriptor
- This ensures int64 fields are received as JavaScript numbers instead of Long objects

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add JSON encoding/decoding for gRPC messages in standalone mode, while using protobuf objects in VSCode, with updates to `ProtoBusClient` and `generate-protobus-setup.mjs`.
> 
>   - **Behavior**:
>     - In `ProtoBusClient`, `makeUnaryRequest` and `makeStreamingRequest` now use `encode` and `decode` methods for JSON handling in standalone mode.
>     - `encode` and `decode` methods added to `ProtoBusClient` to conditionally JSON encode/decode messages based on `window.__is_standalone__`.
>   - **Scripts**:
>     - Updated `generate-protobus-setup.mjs` to use `makeUnaryRequest` and `makeStreamingRequest` with JSON encoding/decoding.
>   - **Utils**:
>     - Added `options` to `protoLoader.loadFileDescriptorSetFromBuffer` in `utils.ts` to encode int64 fields as numbers.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 4954f15236a8a522c0b718894db39b31ef5fe750. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->