### PR TITLE
Refactoring: move vscode specific property out of the WebviewProvider

### DIFF
--- a/src/core/webview/index.ts
+++ b/src/core/webview/index.ts
@@ -4,7 +4,6 @@ import { getNonce } from "./getNonce"
 
 import { WebviewProviderType } from "@/shared/webview/types"
 import { Controller } from "@core/controller/index"
-import { CacheService } from "@core/storage/CacheService"
 import { findLast } from "@shared/array"
 import { readFile } from "fs/promises"
 import path from "node:path"
@@ -19,7 +18,6 @@ export abstract class WebviewProvider {
 	public static readonly tabPanelId = "claude-dev.TabPanelProvider"
 	private static activeInstances: Set<WebviewProvider> = new Set()
 	private static clientIdMap = new Map<WebviewProvider, string>()
-	protected disposables: vscode.Disposable[] = []
 	controller: Controller
 	private clientId: string
 
@@ -47,12 +45,6 @@ export abstract class WebviewProvider {
 	}
 
 	async dispose() {
-		while (this.disposables.length) {
-			const x = this.disposables.pop()
-			if (x) {
-				x.dispose()
-			}
-		}
 		await this.controller.dispose()
 		WebviewProvider.activeInstances.delete(this)
 		// Remove from client ID map

--- a/src/hosts/vscode/VscodeWebviewProvider.ts
+++ b/src/hosts/vscode/VscodeWebviewProvider.ts
@@ -14,7 +14,8 @@ https://github.com/KumarVariable/vscode-extension-sidebar-html/blob/master/src/c
 */
 
 export class VscodeWebviewProvider extends WebviewProvider implements vscode.WebviewViewProvider {
-	public webview?: vscode.WebviewView | vscode.WebviewPanel
+	private webview?: vscode.WebviewView | vscode.WebviewPanel
+	private disposables: vscode.Disposable[] = []
 
 	constructor(context: vscode.ExtensionContext, providerType: WebviewProviderType) {
 		super(context, providerType)
@@ -165,6 +166,12 @@ export class VscodeWebviewProvider extends WebviewProvider implements vscode.Web
 	override async dispose() {
 		if (this.webview && "dispose" in this.webview) {
 			this.webview.dispose()
+		}
+		while (this.disposables.length) {
+			const x = this.disposables.pop()
+			if (x) {
+				x.dispose()
+			}
 		}
 		super.dispose()
 	}


### PR DESCRIPTION
The vscode.disposables array is only used in the VscodeWebviewProvider.

Move it out of the generic WebviewProvider which should not vscode specific code, into the VscodeWebviewProvider.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Refactor `disposables` management from `WebviewProvider` to `VscodeWebviewProvider` and clean up unused code in `McpHub`.
> 
>   - **Refactoring**:
>     - Move `disposables` array from `WebviewProvider` to `VscodeWebviewProvider`.
>     - Update `dispose()` method in `VscodeWebviewProvider` to handle `disposables`.
>   - **Code Cleanup**:
>     - Remove unused `postMessageToWebview` function in `McpHub` class.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 9cceacb61bd1dc338b3a53004a1a2864e23b3077. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->