### PR TITLE
Hostbridge diff diagnostics

### DIFF
--- a/proto/host/diff.proto
+++ b/proto/host/diff.proto
@@ -21,6 +21,8 @@ service DiffService {
   rpc saveDocument(SaveDocumentRequest) returns (SaveDocumentResponse);
   // Close the diff editor UI.
   rpc closeDiff(CloseDiffRequest) returns (CloseDiffResponse);
+  // Get diagnostics for diff edit analysis.
+  rpc getDiagnostics(GetDiagnosticsRequest) returns (GetDiagnosticsResponse);
 }
 
 message OpenDiffRequest {
@@ -83,3 +85,40 @@ message SaveDocumentRequest {
 }
 
 message SaveDocumentResponse {}
+
+message GetDiagnosticsRequest {
+  optional cline.Metadata metadata = 1;
+}
+
+message GetDiagnosticsResponse {
+  repeated FileDiagnostics file_diagnostics = 1;
+}
+
+message FileDiagnostics {
+  string file_path = 1;
+  repeated Diagnostic diagnostics = 2;
+}
+
+message Diagnostic {
+  string message = 1;
+  DiagnosticRange range = 2;
+  DiagnosticSeverity severity = 3;
+  optional string source = 4;
+}
+
+message DiagnosticRange {
+  DiagnosticPosition start = 1;
+  DiagnosticPosition end = 2;
+}
+
+message DiagnosticPosition {
+  int32 line = 1;
+  int32 character = 2;
+}
+
+enum DiagnosticSeverity {
+  DIAGNOSTIC_ERROR = 0;
+  DIAGNOSTIC_WARNING = 1;
+  DIAGNOSTIC_INFORMATION = 2;
+  DIAGNOSTIC_HINT = 3;
+}

--- a/src/core/mentions/index.ts
+++ b/src/core/mentions/index.ts
@@ -6,7 +6,7 @@ import { mentionRegexGlobal } from "@shared/context-mentions"
 import fs from "fs/promises"
 import { extractTextFromFile } from "@integrations/misc/extract-text"
 import { isBinaryFile } from "isbinaryfile"
-import { diagnosticsToProblemsString } from "@integrations/diagnostics"
+import { diagnosticsToProblemsString, getAllDiagnostics } from "@/integrations/diagnostics"
 import { getLatestTerminalOutput } from "@integrations/terminal/get-latest-output"
 import { getCommitInfo } from "@utils/git"
 import { getWorkingState } from "@utils/git"
@@ -225,8 +225,13 @@ async function getFileOrFolderContent(mentionPath: string, cwd: string): Promise
 }
 
 async function getWorkspaceProblems(): Promise<string> {
-	const diagnostics = vscode.languages.getDiagnostics()
-	const result = diagnosticsToProblemsString(diagnostics, [vscode.DiagnosticSeverity.Error, vscode.DiagnosticSeverity.Warning])
+	console.log("🏷️  @PROBLEMS: Getting workspace problems via hostbridge")
+	const diagnostics = await getAllDiagnostics()
+	const result = await diagnosticsToProblemsString(diagnostics, [
+		vscode.DiagnosticSeverity.Error,
+		vscode.DiagnosticSeverity.Warning,
+	])
+	console.log(`🏷️  @PROBLEMS: Processed ${diagnostics.length} diagnostic entries`)
 	if (!result) {
 		return "No errors or warnings detected."
 	}

--- a/src/core/mentions/index.ts
+++ b/src/core/mentions/index.ts
@@ -225,13 +225,11 @@ async function getFileOrFolderContent(mentionPath: string, cwd: string): Promise
 }
 
 async function getWorkspaceProblems(): Promise<string> {
-	console.log("🏷️  @PROBLEMS: Getting workspace problems via hostbridge")
 	const diagnostics = await getAllDiagnostics()
 	const result = await diagnosticsToProblemsString(diagnostics, [
 		vscode.DiagnosticSeverity.Error,
 		vscode.DiagnosticSeverity.Warning,
 	])
-	console.log(`🏷️  @PROBLEMS: Processed ${diagnostics.length} diagnostic entries`)
 	if (!result) {
 		return "No errors or warnings detected."
 	}

--- a/src/hosts/vscode/VscodeDiffViewProvider.ts
+++ b/src/hosts/vscode/VscodeDiffViewProvider.ts
@@ -3,13 +3,13 @@ import * as path from "path"
 import * as vscode from "vscode"
 import { DecorationController } from "@/hosts/vscode/DecorationController"
 import { DiffViewProvider } from "@integrations/editor/DiffViewProvider"
-import { diagnosticsToProblemsString, getNewDiagnostics } from "@/integrations/diagnostics"
+import { getNewDiagnostics, diagnosticsToProblemsString, getAllDiagnostics, DiagnosticTuple } from "@/integrations/diagnostics"
 
 export const DIFF_VIEW_URI_SCHEME = "cline-diff"
 
 export class VscodeDiffViewProvider extends DiffViewProvider {
 	private activeDiffEditor?: vscode.TextEditor
-	private preDiagnostics: [vscode.Uri, vscode.Diagnostic[]][] = []
+	private preDiagnostics: DiagnosticTuple[] = []
 
 	private fadedOverlayController?: DecorationController
 	private activeLineController?: DecorationController
@@ -19,7 +19,7 @@ export class VscodeDiffViewProvider extends DiffViewProvider {
 			throw new Error("No file path set")
 		}
 		// get diagnostics before editing the file, we'll compare to diagnostics after editing to see if cline needs to fix anything
-		this.preDiagnostics = vscode.languages.getDiagnostics()
+		this.preDiagnostics = await getAllDiagnostics()
 
 		// if the file was already open, close it (must happen after showing the diff view since if it's the only tab the column will close)
 		this.documentWasOpen = false
@@ -166,7 +166,7 @@ export class VscodeDiffViewProvider extends DiffViewProvider {
 
 	protected override async getNewDiagnosticProblems(): Promise<string> {
 		// Get the diagnostics after changing the document.
-		const postDiagnostics = vscode.languages.getDiagnostics()
+		const postDiagnostics = await getAllDiagnostics()
 		const newProblems = getNewDiagnostics(this.preDiagnostics, postDiagnostics)
 		// Only including errors since warnings can be distracting (if user wants to fix warnings they can use the @problems mention)
 		// will be empty string if no errors

--- a/src/hosts/vscode/hostbridge/diff/getDiagnostics.ts
+++ b/src/hosts/vscode/hostbridge/diff/getDiagnostics.ts
@@ -10,11 +10,8 @@ import {
 } from "@/shared/proto/host/diff"
 
 export async function getDiagnostics(request: GetDiagnosticsRequest): Promise<GetDiagnosticsResponse> {
-	console.log("🔧 HOSTBRIDGE: getDiagnostics called via DiffService")
-
 	// Get all diagnostics from VS Code
 	const vscodeAllDiagnostics = vscode.languages.getDiagnostics()
-	console.log(`🔧 HOSTBRIDGE: Found ${vscodeAllDiagnostics.length} files with diagnostics`)
 
 	const fileDiagnostics: FileDiagnostics[] = []
 
@@ -66,10 +63,7 @@ export async function getDiagnostics(request: GetDiagnosticsRequest): Promise<Ge
 		}
 	}
 
-	const response = GetDiagnosticsResponse.create({
+	return GetDiagnosticsResponse.create({
 		fileDiagnostics: fileDiagnostics,
 	})
-
-	console.log(`🔧 HOSTBRIDGE: Returning ${fileDiagnostics.length} files with diagnostics to client`)
-	return response
 }

--- a/src/hosts/vscode/hostbridge/diff/getDiagnostics.ts
+++ b/src/hosts/vscode/hostbridge/diff/getDiagnostics.ts
@@ -1,0 +1,75 @@
+import * as vscode from "vscode"
+import {
+	GetDiagnosticsRequest,
+	GetDiagnosticsResponse,
+	FileDiagnostics,
+	Diagnostic,
+	DiagnosticRange,
+	DiagnosticPosition,
+	DiagnosticSeverity,
+} from "@/shared/proto/host/diff"
+
+export async function getDiagnostics(request: GetDiagnosticsRequest): Promise<GetDiagnosticsResponse> {
+	console.log("🔧 HOSTBRIDGE: getDiagnostics called via DiffService")
+
+	// Get all diagnostics from VS Code
+	const vscodeAllDiagnostics = vscode.languages.getDiagnostics()
+	console.log(`🔧 HOSTBRIDGE: Found ${vscodeAllDiagnostics.length} files with diagnostics`)
+
+	const fileDiagnostics: FileDiagnostics[] = []
+
+	for (const [uri, diagnostics] of vscodeAllDiagnostics) {
+		if (diagnostics.length > 0) {
+			const convertedDiagnostics: Diagnostic[] = diagnostics.map((vsDiagnostic) => {
+				// Convert VS Code severity to proto severity
+				let severity: DiagnosticSeverity
+				switch (vsDiagnostic.severity) {
+					case vscode.DiagnosticSeverity.Error:
+						severity = DiagnosticSeverity.DIAGNOSTIC_ERROR
+						break
+					case vscode.DiagnosticSeverity.Warning:
+						severity = DiagnosticSeverity.DIAGNOSTIC_WARNING
+						break
+					case vscode.DiagnosticSeverity.Information:
+						severity = DiagnosticSeverity.DIAGNOSTIC_INFORMATION
+						break
+					case vscode.DiagnosticSeverity.Hint:
+						severity = DiagnosticSeverity.DIAGNOSTIC_HINT
+						break
+					default:
+						severity = DiagnosticSeverity.DIAGNOSTIC_ERROR
+				}
+
+				return Diagnostic.create({
+					message: vsDiagnostic.message,
+					range: DiagnosticRange.create({
+						start: DiagnosticPosition.create({
+							line: vsDiagnostic.range.start.line,
+							character: vsDiagnostic.range.start.character,
+						}),
+						end: DiagnosticPosition.create({
+							line: vsDiagnostic.range.end.line,
+							character: vsDiagnostic.range.end.character,
+						}),
+					}),
+					severity: severity,
+					source: vsDiagnostic.source || undefined,
+				})
+			})
+
+			fileDiagnostics.push(
+				FileDiagnostics.create({
+					filePath: uri.fsPath,
+					diagnostics: convertedDiagnostics,
+				}),
+			)
+		}
+	}
+
+	const response = GetDiagnosticsResponse.create({
+		fileDiagnostics: fileDiagnostics,
+	})
+
+	console.log(`🔧 HOSTBRIDGE: Returning ${fileDiagnostics.length} files with diagnostics to client`)
+	return response
+}

--- a/src/integrations/diagnostics/index.ts
+++ b/src/integrations/diagnostics/index.ts
@@ -13,15 +13,11 @@ export type DiagnosticTuple = [vscode.Uri, vscode.Diagnostic[]]
  * Get all diagnostics from the host bridge
  */
 export async function getAllDiagnostics(): Promise<DiagnosticTuple[]> {
-	console.log("📞 CLIENT: Calling HostProvider.diff.getDiagnostics() via hostbridge")
-
 	const response = await HostProvider.diff.getDiagnostics(
 		GetDiagnosticsRequest.create({
 			metadata: Metadata.create({}),
 		}),
 	)
-
-	console.log(`📞 CLIENT: Received ${response.fileDiagnostics.length} files with diagnostics from hostbridge`)
 
 	const result: DiagnosticTuple[] = []
 


### PR DESCRIPTION
### Description

Migrate the diff edit diagnostics functionality from direct VS Code API calls to hostbridge. 

**Changes:**
- Add `getDiagnostics` RPC to `DiffService` in `proto/host/diff.proto`
- Implement VS Code diagnostics handler in `src/hosts/vscode/hostbridge/diff/getDiagnostics.ts`
- Update `VscodeDiffViewProvider` to use `getAllDiagnostics()` via hostbridge instead of direct `vscode.languages.getDiagnostics()`
- Update `@problems` mention functionality to use hostbridge abstraction
- Preserve complete before/after diff edit diagnostics comparison workflow

The diagnostics functionality now flows through: `Client → HostProvider.diff.getDiagnostics() → gRPC → VS Code Implementation → Response`, enabling other platforms to implement the same interface.

### Test Procedure
1. **@problems mention testing:** Verified `@problems` in chat triggers hostbridge call and displays workspace diagnostics correctly
2. **Diff edit diagnostics testing:** Asked Cline to fix TypeScript errors in test file, confirmed:
   - Pre-edit diagnostics capture via hostbridge 
   - Post-edit diagnostics capture via hostbridge
   - Before/after comparison logic works correctly
   - Successful execution after fixes applied

**Verified hostbridge flow:** Console logs showed complete gRPC request/response cycle with proper diagnostic data transformation between proto and VS Code formats. Both functionalities work identically to before, but now use hostbridge instead of direct VS Code APIs.

### Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] ♻️ Refactor Changes
- [ ] 💅 Cosmetic Changes
- [ ] 📚 Documentation update
- [ ] 🏃 Workflow Changes

### Pre-flight Checklist

- [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
- [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
- [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
- [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots
<img width="598" height="489" alt="Screenshot 2025-08-05 at 22 27 23" src="https://github.com/user-attachments/assets/fa6764d2-78c6-4cd7-a361-dae87e1a9476" />
