### PR TITLE
feat: Add opus-4-1 to claude-code

### DIFF
--- a/.changeset/new-mails-battle.md
+++ b/.changeset/new-mails-battle.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+feat: Add Opus 4.1 through Claude Code

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -298,6 +298,11 @@ export const claudeCodeModels = {
 		supportsImages: false,
 		supportsPromptCache: false,
 	},
+	"claude-opus-4-1-20250805": {
+		...anthropicModels["claude-opus-4-1-20250805"],
+		supportsImages: false,
+		supportsPromptCache: false,
+	},
 	"claude-opus-4-20250514": {
 		...anthropicModels["claude-opus-4-20250514"],
 		supportsImages: false,


### PR DESCRIPTION
### Description

This PR adds Opus 4.1 to the Claude Code provider.

### Test Procedure

I don't have a Max subscription, so I can't test it.

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)