### PR TITLE
Support prompt caching and thinking for Opus 4.1

### DIFF
--- a/src/api/providers/anthropic.ts
+++ b/src/api/providers/anthropic.ts
@@ -55,6 +55,7 @@ export class AnthropicHandler implements ApiHandler {
 			case "claude-3-5-sonnet-20241022":
 			case "claude-3-5-haiku-20241022":
 			case "claude-opus-4-20250514":
+			case "claude-opus-4-1-20250805":
 			case "claude-3-opus-20240229":
 			case "claude-3-haiku-20240307": {
 				/*
@@ -122,6 +123,7 @@ export class AnthropicHandler implements ApiHandler {
 						switch (modelId) {
 							case "claude-sonnet-4-20250514":
 							case "claude-opus-4-20250514":
+							case "claude-opus-4-1-20250805":
 							case "claude-3-7-sonnet-20250219":
 							case "claude-3-5-sonnet-20241022":
 							case "claude-3-5-haiku-20241022":

--- a/webview-ui/src/components/settings/providers/AnthropicProvider.tsx
+++ b/webview-ui/src/components/settings/providers/AnthropicProvider.tsx
@@ -14,6 +14,7 @@ export const SUPPORTED_ANTHROPIC_THINKING_MODELS = [
 	"claude-3-7-sonnet-20250219",
 	"claude-sonnet-4-20250514",
 	"claude-opus-4-20250514",
+	"claude-opus-4-1-20250805",
 ]
 
 /**


### PR DESCRIPTION

### Description
https://github.com/cline/cline/pull/5369

In this PR I missed thinking UX and prompt caching so this PR fixes that

### Test Procedure
Tested locally with the debugger
<img width="366" height="342" alt="image" src="https://github.com/user-attachments/assets/9227a77e-a43f-4541-a4ef-c019a56c5513" />
<img width="368" height="148" alt="image" src="https://github.com/user-attachments/assets/a9091020-a534-43db-b607-f893758c14e0" />



### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [X] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [X] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [X] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [X] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [X] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->
