### PR TITLE
Support prompt caching and thinking for Opus 4.1 through openrouter

### DIFF
--- a/.changeset/quiet-flies-suffer.md
+++ b/.changeset/quiet-flies-suffer.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Support prompt caching and thinking for Opus 4.1 through openrouter

--- a/src/api/transform/openrouter-stream.ts
+++ b/src/api/transform/openrouter-stream.ts
@@ -25,6 +25,7 @@ export async function createOpenRouterStream(
 	switch (model.id) {
 		case "anthropic/claude-sonnet-4":
 		case "anthropic/claude-opus-4":
+		case "anthropic/claude-opus-4.1":
 		case "anthropic/claude-3.7-sonnet":
 		case "anthropic/claude-3.7-sonnet:beta":
 		case "anthropic/claude-3.7-sonnet:thinking":
@@ -83,6 +84,7 @@ export async function createOpenRouterStream(
 	switch (model.id) {
 		case "anthropic/claude-sonnet-4":
 		case "anthropic/claude-opus-4":
+		case "anthropic/claude-opus-4.1":
 		case "anthropic/claude-3.7-sonnet":
 		case "anthropic/claude-3.7-sonnet:beta":
 		case "anthropic/claude-3.7-sonnet:thinking":
@@ -118,6 +120,7 @@ export async function createOpenRouterStream(
 	switch (model.id) {
 		case "anthropic/claude-sonnet-4":
 		case "anthropic/claude-opus-4":
+		case "anthropic/claude-opus-4.1":
 		case "anthropic/claude-3.7-sonnet":
 		case "anthropic/claude-3.7-sonnet:beta":
 		case "anthropic/claude-3.7-sonnet:thinking":

--- a/src/core/controller/models/refreshOpenRouterModels.ts
+++ b/src/core/controller/models/refreshOpenRouterModels.ts
@@ -50,6 +50,7 @@ export async function refreshOpenRouterModels(
 				switch (rawModel.id) {
 					case "anthropic/claude-sonnet-4":
 					case "anthropic/claude-opus-4":
+					case "anthropic/claude-opus-4.1":
 					case "anthropic/claude-3-7-sonnet":
 					case "anthropic/claude-3-7-sonnet:beta":
 					case "anthropic/claude-3.7-sonnet":

--- a/webview-ui/src/components/settings/OpenRouterModelPicker.tsx
+++ b/webview-ui/src/components/settings/OpenRouterModelPicker.tsx
@@ -211,7 +211,7 @@ const OpenRouterModelPicker: React.FC<OpenRouterModelPickerProps> = ({ isPopup, 
 	const showBudgetSlider = useMemo(() => {
 		return (
 			selectedModelId?.toLowerCase().includes("claude-sonnet-4") ||
-			selectedModelId?.toLowerCase().includes("claude-opus-4") ||
+			selectedModelId?.toLowerCase().includes("claude-opus-4") || // Also includes "claude-opus-4.1"
 			selectedModelId?.toLowerCase().includes("claude-3-7-sonnet") ||
 			selectedModelId?.toLowerCase().includes("claude-3.7-sonnet") ||
 			selectedModelId?.toLowerCase().includes("claude-3.7-sonnet:thinking")


### PR DESCRIPTION

### Related Issue

Follow up to https://github.com/cline/cline/pull/5386

### Description
Supports prompt caching and thinking for Opus 4.1 through OpenRouter


### Test Procedure
Tested locally with a debugger


### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [X] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [X] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [X] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [X] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [X] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add support for `anthropic/claude-opus-4.1` model in prompt caching, thinking budget, and UI components.
> 
>   - **Behavior**:
>     - Adds support for `anthropic/claude-opus-4.1` in `createOpenRouterStream()` in `openrouter-stream.ts` for prompt caching and thinking budget.
>     - Updates `refreshOpenRouterModels()` in `refreshOpenRouterModels.ts` to include `anthropic/claude-opus-4.1` for model info refresh.
>     - Modifies `OpenRouterModelPicker.tsx` to handle `claude-opus-4.1` in the budget slider logic.
>   - **Misc**:
>     - Adds changeset `quiet-flies-suffer.md` to document the update.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 4cf4441decc161369d47fdd2a455f99fd95905c0. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->