### PR TITLE
Add cerebras rate limit handling

### DIFF
--- a/.changeset/friendly-geckos-accept.md
+++ b/.changeset/friendly-geckos-accept.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": minor
+---
+
+implemented a retry strategy for Cerebras to handle rate limit issues due to its generation speed


### PR DESCRIPTION
### Description

Cerebras models are so fast that users hit rate limits very quickly. This is a small rate limit handling system that will automatically retry silently so the user doesn't have to wait 60 seconds and start again manually.

### Test Procedure

I played around with qwen-3-coder-480b-free + paid, llama-4-scout, and qwen-3-235b-a22b-instruct-2507 and really tried to max out the rate limits. The only time I got an error was when I had fully run out of tokens for the whole day.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)