### PR TITLE
chore: refactor currentToolUse configuration

### DIFF
--- a/.changeset/mighty-squids-rule.md
+++ b/.changeset/mighty-squids-rule.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+refactor currentToolUse configuration

--- a/test/core/assistant-message/parse-assistant-message.test.ts
+++ b/test/core/assistant-message/parse-assistant-message.test.ts
@@ -1,0 +1,80 @@
+import { describe, it } from "mocha"
+import "should"
+import { parseAssistantMessageV3 } from "../../../src/core/assistant-message"
+
+describe("parseAssistantMessageV3", () => {
+	it("parses LS invoke with path and default recursive", () => {
+		const msg = '<function_calls><invoke name="LS"><parameter name="path">/tmp</parameter></invoke></function_calls>'
+		const result = parseAssistantMessageV3(msg)
+		result.length.should.equal(1)
+		const tool = result[0] as any
+		tool.type.should.equal("tool_use")
+		tool.name.should.equal("list_files")
+		tool.params.should.have.property("path", "/tmp")
+		tool.params.should.have.property("recursive", "false")
+		tool.partial.should.equal(false)
+	})
+
+	it("parses Grep invoke and maps params", () => {
+		const msg =
+			'<function_calls><invoke name="Grep"><parameter name="pattern">TODO</parameter><parameter name="path">./src</parameter><parameter name="include">*.ts</parameter></invoke></function_calls>'
+		const result = parseAssistantMessageV3(msg)
+		result.length.should.equal(1)
+		const tool = result[0] as any
+		tool.type.should.equal("tool_use")
+		tool.name.should.equal("search_files")
+		tool.params.should.have.property("regex", "TODO")
+		tool.params.should.have.property("path", "./src")
+		tool.params.should.have.property("file_pattern", "*.ts")
+		tool.partial.should.equal(false)
+	})
+
+	it("parses Bash invoke and transforms requires_approval", () => {
+		const msg =
+			'<function_calls><invoke name="Bash"><parameter name="command">echo hi</parameter><parameter name="requires_approval">true</parameter></invoke></function_calls>'
+		const result = parseAssistantMessageV3(msg)
+		result.length.should.equal(1)
+		const tool = result[0] as any
+		tool.type.should.equal("tool_use")
+		tool.name.should.equal("execute_command")
+		tool.params.should.have.property("command", "echo hi")
+		tool.params.should.have.property("requires_approval", "true")
+		tool.partial.should.equal(false)
+	})
+
+	it("parses Write invoke and maps file_path and content", () => {
+		const msg =
+			'<function_calls><invoke name="Write"><parameter name="file_path">/a/b.txt</parameter><parameter name="content">hello</parameter></invoke></function_calls>'
+		const result = parseAssistantMessageV3(msg)
+		result.length.should.equal(1)
+		const tool = result[0] as any
+		tool.type.should.equal("tool_use")
+		tool.name.should.equal("write_to_file")
+		tool.params.should.have.property("path", "/a/b.txt")
+		tool.params.should.have.property("content", "hello")
+		tool.partial.should.equal(false)
+	})
+
+	it("parses multiple invokes in order", () => {
+		const msg =
+			"<function_calls>" +
+			'<invoke name="LS"><parameter name="path">/x</parameter></invoke>' +
+			'<invoke name="Grep"><parameter name="pattern">fixme</parameter><parameter name="path">./y</parameter></invoke>' +
+			"</function_calls>"
+		const result = parseAssistantMessageV3(msg)
+		result.length.should.equal(2)
+		const tool1 = result[0] as any
+		const tool2 = result[1] as any
+		tool1.name.should.equal("list_files")
+		tool1.params.should.have.property("path", "/x")
+		tool2.name.should.equal("search_files")
+		tool2.params.should.have.property("regex", "fixme")
+		tool2.params.should.have.property("path", "./y")
+	})
+
+	it("ignores unknown invoke names", () => {
+		const msg = '<function_calls><invoke name="Unknown"><parameter name="x">y</parameter></invoke></function_calls>'
+		const result = parseAssistantMessageV3(msg)
+		result.length.should.equal(0)
+	})
+})


### PR DESCRIPTION
### Description

Refactored function-call parsing to a data-oriented approach and added a safety check.

- Introduced a centralized INVOKE_SPECS hashmap in src/core/assistant-message/parse-assistant-message.ts that defines, per invoke:

  - tool: ToolUseName for the invoke
  - params: per-parameter mapping to ToolParamName (with optional transform)
  - defaults: default ToolParamName values (e.g., LS sets recursive: "false")

- Replaced ad-hoc if/switch logic with:

  - createToolUseFromInvoke(invokeName): constructs a ToolUse from INVOKE_SPECS
  - applyParamFromInvokeSpec(currentToolUse, invokeName, parameterName, value): applies param mappings via INVOKE_SPECS

- Simplified parseAssistantMessageV3 invoke finalization by finalizing on invoke end when a tool exists.

- Added guard at invoke end to ensure tools are finalized only when the current invoke name exists in INVOKE_SPECS:
  - if (currentToolUse && currentInvokeName in INVOKE_SPECS) { ... }

- Tightened typing to avoid implicit any:

  - ParamSpec uses ToolParamName or { to: ToolParamName; transform?: (v: string) => string }
  - defaults uses Partial<Record<ToolParamName, string>>

This improves readability, extensibility, and performance (O(1) hashmap lookups), while preventing unknown invokes from producing tool_use blocks.

### Test Procedure

- Added targeted unit tests at test/core/assistant-message/parse-assistant-message.test.ts covering:

  - LS: maps path and applies default recursive = "false"
  - Grep: maps pattern/path/include to regex/path/file_pattern
  - Bash: maps command and transforms requires_approval to "true"/"false"
  - Write: maps file_path->path and content
  - Multiple invokes in order
  - Unknown invoke is ignored

- Executed targeted test file to avoid unrelated ESLint rule tester failures:

  - Command: TS_NODE_PROJECT='./tsconfig.unit-test.json' npx mocha --no-config --extension ts -r ts-node/register -r source-map-support/register -r ./src/test/requires.ts test/core/assistant-message/parse-assistant-message.test.ts
  - Result: 6 passing

- Verified types via npm run check-types (completed successfully earlier; truncated terminal output noted).

- The changes are limited to the parsing logic and do not affect other systems. Existing functionality using parseAssistantMessageV2 remains unchanged. V3 behavior is validated by tests.

### Type of Change

- [x] ♻️ Refactor Changes
- [x] 🐛 Bug fix (prevent finalizing tool_use for unknown invokes)
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 💅 Cosmetic Changes
- [ ] 📚 Documentation update
- [ ] 🏃 Workflow Changes

### Pre-flight Checklist

- [x] Changes are limited to a single feature/refactor
- [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
- [ ] I have created a changeset using `npm run changeset` (not user-facing; refactor only)
- [x] I have reviewed contributor guidelines

Notes on tests: Targeted tests pass. Full test suite includes unrelated ESLint rule tester cases that fail in this environment; they are unaffected by this refactor.

### Screenshots

N/A (backend parsing change). Test output indicates all targeted tests passed.

### Additional Notes

- Data-oriented map enables fast incremental additions of new tools and parameters by updating INVOKE_SPECS only.
- The guard at invoke end ensures robustness by ignoring unknown invokes during function_call parsing.
- The typing constraints align runtime behavior with the declared ToolParamName set, avoiding accidental parameter name drift.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Refactor `parseAssistantMessageV3` to use a data-driven approach for function-call parsing with `INVOKE_SPECS`, adding safety checks and unit tests.
> 
>   - **Behavior**:
>     - Refactor `parseAssistantMessageV3` in `parse-assistant-message.ts` to use `INVOKE_SPECS` for function-call parsing.
>     - Add guard to finalize tools only if `currentInvokeName` exists in `INVOKE_SPECS`.
>   - **Functions**:
>     - Add `createToolUseFromInvoke()` and `applyParamFromInvokeSpec()` to handle tool creation and parameter application.
>   - **Testing**:
>     - Add unit tests in `parse-assistant-message.test.ts` for various invoke scenarios, including unknown invokes.
>   - **Misc**:
>     - Tighten typing for `ParamSpec` and `defaults` in `parse-assistant-message.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 436f69bdbdbda1b3f17094c0cce07673bca6499b. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->