### PR TITLE
Igor/name to editor link

### DIFF
--- a/.clinerules/workflows/pr-review.md
+++ b/.clinerules/workflows/pr-review.md
@@ -219,6 +219,9 @@ EOF
 
 ## Basic PR Commands
 ```bash
+# Get current PR number
+gh pr view --json number -q .number
+
 # List open PRs
 gh pr list
 

--- a/proto/cline/common.proto
+++ b/proto/cline/common.proto
@@ -55,6 +55,11 @@ message Boolean {
   bool value = 1;
 }
 
+// the same as Boolean, but avoiding name conflicts
+message BooleanResponse {
+  bool value = 1;
+}
+
 message StringArray {
   repeated string values = 1;
 }

--- a/proto/cline/file.proto
+++ b/proto/cline/file.proto
@@ -57,6 +57,12 @@ service FileService {
 
   // Subscribe to workspace file updates
   rpc subscribeToWorkspaceUpdates(EmptyRequest) returns (stream StringArray);
+
+  // Check if file exists in the project
+  rpc ifFileExistsRelativePath(StringRequest) returns (BooleanResponse);
+
+  // Open a file in editor by a relative path
+  rpc openFileRelativePath(StringRequest) returns (Empty);
 }
 
 // Response for refreshRules operation

--- a/src/core/controller/file/__tests__/ifFileExistsRelativePath.test.ts
+++ b/src/core/controller/file/__tests__/ifFileExistsRelativePath.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, beforeEach, afterEach } from "mocha"
+import { expect } from "chai"
+import * as sinon from "sinon"
+import { ifFileExistsRelativePath } from "../ifFileExistsRelativePath"
+import { Controller } from "@core/controller"
+import { StringRequest, BooleanResponse } from "@shared/proto/cline/common"
+import * as pathUtils from "@utils/path"
+
+describe("ifFileExistsRelativePath", () => {
+	let sandbox: sinon.SinonSandbox
+	let mockController: Controller
+	let getWorkspacePathStub: sinon.SinonStub
+	let consoleErrorStub: sinon.SinonStub
+
+	beforeEach(() => {
+		sandbox = sinon.createSandbox()
+
+		// Create a mock controller
+		mockController = {} as any
+
+		// Stub getWorkspacePath utility
+		getWorkspacePathStub = sandbox.stub(pathUtils, "getWorkspacePath")
+
+		// Stub console.error to prevent test output pollution
+		consoleErrorStub = sandbox.stub(console, "error")
+	})
+
+	afterEach(() => {
+		sandbox.restore()
+	})
+
+	it("should return BooleanResponse with boolean value", async () => {
+		getWorkspacePathStub.resolves("/workspace")
+
+		const request = StringRequest.create({
+			value: "src/test.ts",
+		})
+
+		const result = await ifFileExistsRelativePath(mockController, request)
+
+		// The result should be a BooleanResponse object
+		expect(result).to.have.property("value")
+		expect(typeof result.value).to.equal("boolean")
+	})
+
+	it("should return false and log error when no workspace path is available", async () => {
+		const noWorkspaceScenarios = [null, undefined]
+
+		for (const workspaceValue of noWorkspaceScenarios) {
+			getWorkspacePathStub.resolves(workspaceValue)
+			consoleErrorStub.resetHistory()
+
+			const request = StringRequest.create({
+				value: "src/test.ts",
+			})
+
+			const result = await ifFileExistsRelativePath(mockController, request)
+
+			expect(result).to.deep.equal(BooleanResponse.create({ value: false }))
+			expect(consoleErrorStub.called).to.be.true
+		}
+	})
+
+	it("should return false when path is invalid", async () => {
+		getWorkspacePathStub.resolves("/workspace")
+
+		const invalidPaths = ["", undefined]
+
+		for (const invalidPath of invalidPaths) {
+			const request = StringRequest.create({
+				value: invalidPath,
+			})
+
+			const result = await ifFileExistsRelativePath(mockController, request)
+
+			expect(result).to.deep.equal(BooleanResponse.create({ value: false }))
+		}
+	})
+
+	it("should handle valid relative paths correctly", async () => {
+		getWorkspacePathStub.resolves("/workspace")
+
+		// Test with valid workspace-relative paths only
+		const validPaths = ["src/file.ts", "./src/file.ts", "package.json", ".gitignore", "src/components/ui/Button/Button.tsx"]
+
+		for (const testPath of validPaths) {
+			const request = StringRequest.create({
+				value: testPath,
+			})
+
+			const result = await ifFileExistsRelativePath(mockController, request)
+
+			// Each should return a BooleanResponse
+			expect(result).to.have.property("value")
+			expect(typeof result.value).to.equal("boolean")
+		}
+
+		// Verify that getWorkspacePath was called for each path
+		expect(getWorkspacePathStub.callCount).to.equal(validPaths.length)
+	})
+})

--- a/src/core/controller/file/__tests__/openFileRelativePath.test.ts
+++ b/src/core/controller/file/__tests__/openFileRelativePath.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, beforeEach, afterEach } from "mocha"
+import { expect } from "chai"
+import * as sinon from "sinon"
+import { openFileRelativePath } from "../openFileRelativePath"
+import { Controller } from "@core/controller"
+import { StringRequest, Empty } from "@shared/proto/cline/common"
+import * as openFileIntegration from "@integrations/misc/open-file"
+import * as pathUtils from "@utils/path"
+import * as path from "path"
+
+describe("openFileRelativePath", () => {
+	let sandbox: sinon.SinonSandbox
+	let mockController: Controller
+	let openFileIntegrationStub: sinon.SinonStub
+	let getWorkspacePathStub: sinon.SinonStub
+	let consoleErrorStub: sinon.SinonStub
+
+	beforeEach(() => {
+		sandbox = sinon.createSandbox()
+
+		// Create a mock controller
+		mockController = {} as any
+
+		// Stub the openFileIntegration function
+		openFileIntegrationStub = sandbox.stub(openFileIntegration, "openFile")
+
+		// Stub getWorkspacePath utility
+		getWorkspacePathStub = sandbox.stub(pathUtils, "getWorkspacePath")
+
+		// Stub console.error to prevent test output pollution
+		consoleErrorStub = sandbox.stub(console, "error")
+	})
+
+	afterEach(() => {
+		sandbox.restore()
+	})
+
+	it("should return Empty response on successful execution", async () => {
+		getWorkspacePathStub.resolves("/workspace")
+
+		const request = StringRequest.create({
+			value: "src/test.ts",
+		})
+
+		const result = await openFileRelativePath(mockController, request)
+
+		expect(result).to.deep.equal(Empty.create())
+	})
+
+	it("should call openFileIntegration with absolute path when relative path is provided", async () => {
+		const workspacePath = "/workspace"
+		const relativePath = "src/components/Test.tsx"
+		const expectedAbsolutePath = path.resolve(workspacePath, relativePath)
+
+		getWorkspacePathStub.resolves(workspacePath)
+
+		const request = StringRequest.create({
+			value: relativePath,
+		})
+
+		await openFileRelativePath(mockController, request)
+
+		expect(openFileIntegrationStub.calledOnceWith(expectedAbsolutePath)).to.be.true
+	})
+
+	it("should not call openFileIntegration when path is invalid", async () => {
+		getWorkspacePathStub.resolves("/workspace")
+
+		const invalidPaths = ["", undefined]
+
+		for (const invalidPath of invalidPaths) {
+			const request = StringRequest.create({
+				value: invalidPath,
+			})
+
+			await openFileRelativePath(mockController, request)
+
+			expect(openFileIntegrationStub.called).to.be.false
+			openFileIntegrationStub.resetHistory()
+		}
+	})
+
+	it("should return Empty and log error when no workspace path is available", async () => {
+		const noWorkspaceScenarios = [null, undefined]
+
+		for (const workspaceValue of noWorkspaceScenarios) {
+			getWorkspacePathStub.resolves(workspaceValue)
+			consoleErrorStub.resetHistory()
+
+			const request = StringRequest.create({
+				value: "src/test.ts",
+			})
+
+			const result = await openFileRelativePath(mockController, request)
+
+			expect(result).to.deep.equal(Empty.create())
+			expect(consoleErrorStub.called).to.be.true
+			expect(openFileIntegrationStub.called).to.be.false
+		}
+	})
+
+	it("should handle nested directory paths", async () => {
+		const workspacePath = "/workspace"
+		const relativePath = "src/components/ui/Button/Button.tsx"
+		const expectedAbsolutePath = path.resolve(workspacePath, relativePath)
+
+		getWorkspacePathStub.resolves(workspacePath)
+
+		const request = StringRequest.create({
+			value: relativePath,
+		})
+
+		await openFileRelativePath(mockController, request)
+
+		expect(openFileIntegrationStub.calledOnceWith(expectedAbsolutePath)).to.be.true
+	})
+})

--- a/src/core/controller/file/ifFileExistsRelativePath.ts
+++ b/src/core/controller/file/ifFileExistsRelativePath.ts
@@ -1,0 +1,39 @@
+import * as path from "path"
+import * as fs from "fs/promises"
+import { Controller } from ".."
+import { StringRequest, BooleanResponse } from "@shared/proto/cline/common"
+import { getWorkspacePath } from "@utils/path"
+
+/**
+ * Check if a file exists in the project using a relative path
+ * @param controller The controller instance
+ * @param request The request containing the relative file path to check
+ * @returns BooleanResponse indicating whether the file exists
+ */
+export async function ifFileExistsRelativePath(_controller: Controller, request: StringRequest): Promise<BooleanResponse> {
+	const workspacePath = await getWorkspacePath()
+
+	if (!workspacePath) {
+		// If no workspace is open, return false
+		console.error("Error in ifFileExistsRelativePath: No workspace path available") // TODO
+		return BooleanResponse.create({ value: false })
+	}
+
+	if (!request.value) {
+		// If no path provided, return false
+		return BooleanResponse.create({ value: false })
+	}
+
+	try {
+		// Resolve the relative path to absolute path
+		const absolutePath = path.resolve(workspacePath, request.value)
+
+		// Check if the file exists
+		await fs.access(absolutePath)
+
+		return BooleanResponse.create({ value: true })
+	} catch (error) {
+		// File doesn't exist or access is denied
+		return BooleanResponse.create({ value: false })
+	}
+}

--- a/src/core/controller/file/openFileRelativePath.ts
+++ b/src/core/controller/file/openFileRelativePath.ts
@@ -1,0 +1,30 @@
+import * as path from "path"
+import { Controller } from ".."
+import { Empty, StringRequest } from "@shared/proto/cline/common"
+import { openFile as openFileIntegration } from "@integrations/misc/open-file"
+import { getWorkspacePath } from "@utils/path"
+
+/**
+ * Opens a file in the editor by a relative path
+ * @param controller The controller instance
+ * @param request The request message containing the relative file path in the 'value' field
+ * @returns Empty response
+ */
+export async function openFileRelativePath(_controller: Controller, request: StringRequest): Promise<Empty> {
+	const workspacePath = await getWorkspacePath()
+
+	if (!workspacePath) {
+		console.error("Error in openFileRelativePath: No workspace path available")
+		return Empty.create()
+	}
+
+	if (request.value) {
+		// Resolve the relative path to absolute path
+		const absolutePath = path.resolve(workspacePath, request.value)
+
+		// Open the file using the existing integration
+		openFileIntegration(absolutePath)
+	}
+
+	return Empty.create()
+}


### PR DESCRIPTION
### Description

Cline sometimes points to files of the project in its answers, and that' a bit annoying to copypaste or type file paths instead of clicking. 

That feature detects if data marked as a code is a real file in the project, and if so draws an icon for opening that file in editor. A project should be opened, and the file path should be inside that project. 

### Test Procedure

Open a project and then ask a question, which points to files in the answer, something like "find me a class..." or "show how api calls are passed to...". Click icons, if they appear. 

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] ✨ New feature (non-breaking change which adds functionality)

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

https://github.com/user-attachments/assets/9a5fb6b7-5d60-4a42-a0a4-1c6a6790cadb

