### PR TITLE
Cover OpenRouter streaming in case of no text response

### DIFF
--- a/src/api/transform/openrouter-stream.ts
+++ b/src/api/transform/openrouter-stream.ts
@@ -157,6 +157,8 @@ export async function createOpenRouterStream(
 		stream_options: { include_usage: true },
 		transforms: shouldApplyMiddleOutTransform ? ["middle-out"] : undefined,
 		include_reasoning: true,
+		// Force text-formatted output to reduce cases where providers emit no final content
+		response_format: { type: "text" },
 		...(model.id.startsWith("openai/o") ? { reasoning_effort: reasoningEffort || "medium" } : {}),
 		...(reasoning ? { reasoning } : {}),
 		...(openRouterProviderSorting ? { provider: { sort: openRouterProviderSorting } } : {}),


### PR DESCRIPTION
### Description

This PR fixes a rare but disruptive failure mode observed when using OpenRouter (and our Cline provider). In long-running sessions, the stream could occasionally end “cleanly” without emitting any delta.content (assistant text) and without surfacing a conventional error, even though token usage and/or partial chunks (e.g., reasoning or provider metadata) were returned. Our Task loop aggregates assistant text exclusively from text deltas, so this produced an empty assistant message and the UI showed “Unexpected API Response: The language model did not provide any assistant messages,” despite having shown “Thinking” while streaming.

Root cause
- Provider-path specific. Anthropic-direct doesn’t exhibit this; it only appeared when routed through OpenRouter (and therefore also through the Cline API which uses the same stream builder).
- The OpenRouter stream could terminate early or be filtered by upstream safety without finish_reason === "error", returning usage and sometimes other fields but no content deltas.
- Our handlers treated this as a normal end-of-iterator. Task then saw assistantMessage === "" and raised the error.

What this PR does
- Harden OpenRouter-backed handlers against “ended-without-text” streams by synthesizing a minimal assistant text line when any chunks were observed but no text arrived, avoiding empty assistant responses.
- Surface a clearer message when the provider indicates safety filtering.
- Nudge providers to return text output by setting response_format: { type: "text" } on OpenRouter chat.completions requests.

Scope of changes
- src/api/providers/openrouter.ts
  - Track sawText, sawReasoning, sawAnyChunk, lastFinishReason during streaming.
  - If the iterator ends with !sawText and (sawReasoning || didOutputUsage || sawAnyChunk), emit one minimal text chunk:
    - “[Provider ended stream without final assistant text. Proceeding with available information.]”
    - If finish_reason suggests filtering (content_filter/blocked/safety), emit:
      “[Provider redacted final text due to safety filtering. No assistant text was returned.]”
  - Preserve existing mid-stream “finish_reason === error” handling and usage backfill.
- src/api/providers/cline.ts
  - Mirrors the same guard and synthesis logic since the Cline provider proxies OpenRouter.
- src/api/transform/openrouter-stream.ts
  - Adds response_format: { type: "text" } to reduce cases where providers omit output text.

Why this approach
- Minimal behavioral change that preserves all normal flows, while preventing an “empty assistant” end state that confused users.
- Anthropic-direct behavior remains unchanged; these changes only apply to OpenRouter-backed paths.
- If the provider filters output, the user gets an explicit safety note instead of a generic error.

Alternatives considered
- Throwing and auto-retrying on empty-text ends. We opted for a non-invasive synthesis first for UX stability; retry can be layered on later behind a model/provider guard.
- Surfacing structured tool_call chunks for function-call-only completions. Useful long-term; out of scope for this hotfix.

### Test Procedure

Functional tests (manual)
1) OpenRouter + anthropic/claude-sonnet-4:
   - Run several long interactions. Expect normal text streaming most of the time (no change).
   - In rare early-end cases (previously produced the red “Unexpected API Response”), expect a single minimal assistant line instead.
2) Cline provider + anthropic/claude-sonnet-4:
   - Repeat the same verification; behavior should match OpenRouter since it goes through the same stream builder.
3) Anthropic-direct + anthropic/claude-sonnet-4:
   - Verify normal operation remains unchanged (no synthetic lines).
4) Safety redaction simulation (if available from provider):
   - Confirm the synthesized note mentions redaction rather than a generic line.

Regression checks
- Tool use, usage accounting, and checkpoints unaffected.
- Confirm no changes to Anthropic-direct requests.
- Run “npm run check-types”, “npm run lint”, and basic integration tests: all should pass.

Why I’m confident
- Changes only activate on a very specific terminal condition (no text emitted but chunks observed) and only in OpenRouter-backed providers.
- Normal streams (with text) and explicit error finishes are not affected.

### Type of Change

-   [X] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature
-   [ ] 💥 Breaking change
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [X] Changes are limited to a single feature/bugfix
-   [X] Tests/build/lint pass locally
-   [X] Changeset created if required
-   [X] Contributor guidelines reviewed

### Screenshots

- N/A; behavior is visible in-stream only under a rare provider condition.
- If desired, attach logs showing:
  - prior: “Unexpected API Response” despite reasoning/usage
  - now: minimal assistant text line in its place

### Additional Notes

- This is intentionally conservative. A follow-up could:
  - Add a single automatic retry for OpenRouter-only empty-text ends.
  - Emit structured tool_call chunks to support function-call-only responses without relying on text serialization.
  - Add lightweight breadcrumbs (sawText/sawAnyChunk/finishReason) to telemetry to quantify frequency by model/provider.