### PR TITLE
Use the active webview in  ProtoBus `getWebviewHtml`.

### DIFF
--- a/src/core/controller/ui/getWebviewHtml.ts
+++ b/src/core/controller/ui/getWebviewHtml.ts
@@ -11,7 +11,7 @@ import type { Controller } from "../index"
 export async function getWebviewHtml(_controller: Controller, _: EmptyRequest): Promise<String> {
 	const webviewProvider = WebviewProvider.getLastActiveInstance()
 	if (!webviewProvider) {
-		throw Error("No active webview")
+		throw new Error("No active webview")
 	}
 	return Promise.resolve(String.create({ value: webviewProvider.getHtmlContent() }))
 }

--- a/src/core/controller/ui/getWebviewHtml.ts
+++ b/src/core/controller/ui/getWebviewHtml.ts
@@ -1,16 +1,17 @@
-import type { Controller } from "../index"
+import { WebviewProvider } from "@/core/webview"
 import { EmptyRequest, String } from "@shared/proto/cline/common"
-import { HostProvider } from "@/hosts/host-provider"
-import { WebviewProviderType } from "@/shared/webview/types"
+import type { Controller } from "../index"
 
 /**
- * Initialize webview when it launches
- * @param controller The controller instance
- * @param request The empty request
- * @returns Empty response
+ * Returns the HTML content of the webview.
+ *
+ * This is only used by the standalone service. The Vscode extension gets the HTML directly from the webview when it
+ * resolved through `resolveWebviewView()`.
  */
 export async function getWebviewHtml(_controller: Controller, _: EmptyRequest): Promise<String> {
-	const webviewProvider = HostProvider.get().createWebviewProvider(WebviewProviderType.SIDEBAR)
-
+	const webviewProvider = WebviewProvider.getLastActiveInstance()
+	if (!webviewProvider) {
+		throw Error("No active webview")
+	}
 	return Promise.resolve(String.create({ value: webviewProvider.getHtmlContent() }))
 }


### PR DESCRIPTION
Don't create a new webview just to get the HTML contents of the webview because this creates another Controller, and all its associated dependencies.

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> `getWebviewHtml` now uses the last active webview instance, improving resource management and adding error handling for no active webview.
> 
>   - **Behavior**:
>     - `getWebviewHtml` now uses `WebviewProvider.getLastActiveInstance()` instead of creating a new webview.
>     - Throws an error if no active webview is found.
>   - **Imports**:
>     - Reorders imports in `getWebviewHtml.ts` for clarity.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for b3909150105d6c9c98b3ebbfb753cf90d74455c6. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->