### PR TITLE
Fix credit error tests

### DIFF
--- a/.changeset/odd-tables-pump.md
+++ b/.changeset/odd-tables-pump.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Fix credit error tests

--- a/webview-ui/src/components/chat/ErrorRow.test.tsx
+++ b/webview-ui/src/components/chat/ErrorRow.test.tsx
@@ -99,7 +99,7 @@ describe("ErrorRow", () => {
 			render(<ErrorRow message={mockMessage} errorType="error" apiRequestFailedMessage="Insufficient credits error" />)
 
 			expect(screen.getByTestId("credit-limit-error")).toBeInTheDocument()
-			expect(screen.getByText("You have run out of credit.")).toBeInTheDocument()
+			expect(screen.getByText("You have run out of credits.")).toBeInTheDocument()
 		})
 
 		it("renders rate limit error with request ID", async () => {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix typo in `ErrorRow.test.tsx` credit limit error message.
> 
>   - **Tests**:
>     - Fix typo in `ErrorRow.test.tsx` by changing "You have run out of credit." to "You have run out of credits." in the credit limit error test case.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 180c97760111251d1f0141122dae9c8cd05d6a85. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->