### PR TITLE
Fix: Correctly pass headers for MCP SSE transport

### DIFF
--- a/src/services/mcp/McpHub.ts
+++ b/src/services/mcp/McpHub.ts
@@ -278,18 +278,13 @@ export class McpHub {
 					break
 				}
 				case "sse": {
-					const sseOptions = {
-						requestInit: {
-							headers: config.headers,
-						},
-					}
 					const reconnectingEventSourceOptions = {
 						max_retry_time: 5000,
 						withCredentials: config.headers?.["Authorization"] ? true : false,
+						headers: config.headers,
 					}
 					global.EventSource = ReconnectingEventSource
 					transport = new SSEClientTransport(new URL(config.url), {
-						...sseOptions,
 						eventSourceInit: reconnectingEventSourceOptions,
 					})
 


### PR DESCRIPTION
Fix(mcp): Correctly pass headers for SSE transport

Previously, headers for SSE-based MCP servers, including Authorization for Bearer Token authentication, were not being sent. This was due to the `headers` object being placed inside a `requestInit` property within the transport options.

The underlying `reconnecting-eventsource` library, used by `SSEClientTransport`, expects all connection options, including `headers`, to be inside the `eventSourceInit` object. The `requestInit` property was being ignored, causing authentication to fail.

This commit fixes the issue by removing the redundant `sseOptions` and `requestInit` wrapper, and placing the `headers` object directly into the `reconnectingEventSourceOptions` object. This ensures that all necessary options are correctly passed to the underlying transport library.