### PR TITLE
Fix plan/act hover color and act mode color

### DIFF
--- a/webview-ui/src/components/chat/ChatTextArea.tsx
+++ b/webview-ui/src/components/chat/ChatTextArea.tsx
@@ -93,7 +93,7 @@ interface GitCommit {
 	description: string
 }
 
-const PLAN_MODE_COLOR = "var(--vscode-inputValidation-warningBorder)"
+const PLAN_MODE_COLOR = "var(--vscode-activityWarningBadge-background)"
 const ACT_MODE_COLOR = "var(--vscode-focusBorder)"
 
 const SwitchOption = styled.div.withConfig({


### PR DESCRIPTION
After changes to the plan/act toggle I saw some themes not use an acceptable color for act mode:
<img width="142" height="110" alt="Cursor 2025-08-09 02 02 12" src="https://github.com/user-attachments/assets/2ccde846-dde3-4051-8a11-8da7cc22ecd2" />

I also found that the hover opacity effect was removed as well, which is important for the user to know that the toggle can be clicked or not (see plan mode bg color change):

<img width="148" height="97" alt="Cursor 2025-08-09 02 01 34" src="https://github.com/user-attachments/assets/53c7b1a8-9d2d-480a-b9c8-0560fab71e26" />

<img width="147" height="88" alt="Cursor 2025-08-09 02 01 40" src="https://github.com/user-attachments/assets/d1fa7987-67b9-41c4-b605-44adb85e66ef" />

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes color issues in plan/act toggle by updating `ACT_MODE_COLOR` and adding hover effects in `ChatTextArea.tsx`.
> 
>   - **Color Adjustments**:
>     - Change `ACT_MODE_COLOR` from `var(--vscode-menu-selectionBackground)` to `var(--vscode-focusBorder)` in `ChatTextArea.tsx`.
>     - Add hover effect to `SwitchOption` to change background color to `var(--vscode-toolbar-hoverBackground)` when not active.
>   - **Code Cleanup**:
>     - Remove `className` for background color in `SwitchOption` for both plan and act modes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 3d8eaa8eee7f2c45b56ec143da6cca99f169e132. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->