### PR TITLE
Test is still flaking, increase the timeout

### DIFF
--- a/src/hosts/vscode/hostbridge/window/getOpenTabs.test.ts
+++ b/src/hosts/vscode/hostbridge/window/getOpenTabs.test.ts
@@ -63,7 +63,7 @@ describe("Hostbridge - Window - getOpenTabs", () => {
 				return response.paths.length === 2
 			},
 			{
-				timeout: 2000,
+				timeout: 4000,
 				interval: 50,
 			},
 		)
@@ -93,7 +93,7 @@ describe("Hostbridge - Window - getOpenTabs", () => {
 				return response.paths.length === 3
 			},
 			{
-				timeout: 2000,
+				timeout: 4000,
 				interval: 50,
 			},
 		)


### PR DESCRIPTION
The `getOpenTabs` test is still timing out, try increasing the timeout.
Example run https://github.com/cline/cline/actions/runs/16834478571/job/47690343037?pr=5448

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Increase timeout in `getOpenTabs.test.ts` to address test flakiness.
> 
>   - **Tests**:
>     - Increase timeout from 2000ms to 4000ms in `getOpenTabs.test.ts` for two test cases to address flakiness.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 3bf7456031d4ed5b729cab0f18f4c7c60efb8cc0. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->