### PR TITLE
Add an endpoint to the HostBridge for integration testing

### DIFF
--- a/proto/host/testing.proto
+++ b/proto/host/testing.proto
@@ -1,0 +1,17 @@
+syntax = "proto3";
+
+package host;
+option java_package = "bot.cline.host.proto";
+option java_multiple_files = true;
+
+// This is for use in integration tests to get the contents of the webview.
+service TestingService {
+  rpc getWebviewHtml(GetWebviewHtmlRequest) returns (GetWebviewHtmlResponse);
+}
+
+message GetWebviewHtmlRequest {
+}
+
+message GetWebviewHtmlResponse {
+  optional string html = 1;
+}

--- a/src/hosts/vscode/hostbridge/testing/getWebviewHtml.ts
+++ b/src/hosts/vscode/hostbridge/testing/getWebviewHtml.ts
@@ -1,0 +1,5 @@
+import { GetWebviewHtmlRequest, GetWebviewHtmlResponse } from "@/shared/proto/index.host"
+
+export async function getWebviewHtml(_: GetWebviewHtmlRequest): Promise<GetWebviewHtmlResponse> {
+	throw new Error("Unimplemented")
+}


### PR DESCRIPTION
Add an RPC to the HostBridge that returns the contents of the
webview, for use in integration tests.