### PR TITLE
run ~/.clinerc

### DIFF
--- a/.changeset/perfect-chairs-agree.md
+++ b/.changeset/perfect-chairs-agree.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": minor
+---
+
+Automatically runs your ~/.clinerc in new terminals

--- a/src/integrations/terminal/ClineRcRunner.ts
+++ b/src/integrations/terminal/ClineRcRunner.ts
@@ -1,0 +1,83 @@
+import * as vscode from "vscode"
+import * as fs from "node:fs"
+import * as path from "node:path"
+import * as os from "node:os"
+import { TerminalProcess } from "./TerminalProcess"
+
+/**
+ * Runs the user's ~/.clinerc (if present) in the given terminal and waits for completion,
+ * with a hard 3s cap so we never get stuck.
+ *
+ * Behavior:
+ * - Detects shell type (bash/zsh/sh, fish, PowerShell; skips cmd).
+ * - Sources ~/.clinerc if it exists.
+ * - Uses TerminalProcess to stream output and detect natural completion (via shell integration when available).
+ * - If the rc doesn't finish quickly (e.g., it blocks), resolves after 3s to avoid hanging.
+ */
+export async function runClineRc(terminal: vscode.Terminal, shellPath?: string): Promise<void> {
+	const clinercPath = path.join(os.homedir(), ".clinerc")
+
+	if (!fs.existsSync(clinercPath)) {
+		return
+	}
+
+	// Detect shell type from provided shellPath or environment
+	const shellToCheck = shellPath || process.env.SHELL || process.env.COMSPEC || ""
+	const shellName = path.basename(shellToCheck).toLowerCase()
+
+	// Build shell-specific command to source rc
+	let command: string | undefined
+	if (shellName.includes("fish")) {
+		// fish shell
+		command = `test -f "${clinercPath}" ; and source "${clinercPath}"`
+	} else if (shellName.includes("powershell") || shellName.includes("pwsh")) {
+		// PowerShell
+		const psPath = clinercPath.replace(/\\/g, "/")
+		command = `$p="${psPath}"; if (Test-Path $p) { . $p }`
+	} else if (shellName.includes("cmd")) {
+		// cmd.exe not supported by .clinerc (POSIX/PowerShell), skip
+		return
+	} else {
+		// Works for bash, zsh, sh
+		command = `[ -f "${clinercPath}" ] && source "${clinercPath}"`
+	}
+
+	if (!command) {
+		return
+	}
+
+	const rcProcess = new TerminalProcess()
+
+	await new Promise<void>((resolve) => {
+		let resolved = false
+
+		const finish = () => {
+			if (resolved) {
+				return
+			}
+			resolved = true
+			clearTimeout(timer)
+			resolve()
+		}
+
+		// Prefer natural completion from TerminalProcess
+		rcProcess.once("completed", finish)
+
+		// Safety timeout to avoid hanging if rc blocks
+		const timer = setTimeout(() => {
+			try {
+				// Stop listening and resolve early if the rc appears to block
+				rcProcess.continue()
+			} catch {}
+			finish()
+		}, 3000)
+
+		// Start execution; TerminalProcess handles shell integration or fallback
+		try {
+			rcProcess.run(terminal, command!)
+		} catch {
+			// If starting fails, resolve via timeout
+			finish()
+		}
+	})
+}

--- a/src/integrations/terminal/TerminalManager.ts
+++ b/src/integrations/terminal/TerminalManager.ts
@@ -4,6 +4,7 @@ import { arePathsEqual } from "@utils/path"
 import { getShellForProfile } from "@utils/shell"
 import { mergePromise, TerminalProcess, TerminalProcessResultPromise } from "./TerminalProcess"
 import { TerminalInfo, TerminalRegistry } from "./TerminalRegistry"
+import { runClineRc } from "./ClineRcRunner"
 
 /*
 TerminalManager:
@@ -304,6 +305,8 @@ export class TerminalManager {
 
 		// If all terminals are busy or don't match shell profile, create a new one with the configured shell
 		const newTerminalInfo = TerminalRegistry.createTerminal(cwd, expectedShellPath)
+		// Run user's rc file and wait up to ~3s for a completion marker before allowing commands to proceed
+		await runClineRc(newTerminalInfo.terminal, expectedShellPath)
 		this.terminalIds.add(newTerminalInfo.id)
 		return newTerminalInfo
 	}


### PR DESCRIPTION

### Problem

When Cline executes commands that use internal pagers (e.g., `git show`), the terminal can become stuck waiting for user input. This creates several issues:
* Requires constant monitoring of terminals to detect stalled processes
* Wastes time when discovering stuck terminals instead of completed results
* Can corrupt command output

While most commands can be configured to disable pagers through parameters or environment variables, implementing these fixes currently requires explicit prompt rewriting and custom rules for each case.

### Solution

This PR introduces a .clinerc configuration file that runs automatically when Cline opens a new terminal. This follows the Unix convention of rc files (like `.bashrc`) and provides a flexible way to customize terminal behavior.

### Key Features

* Automatically executes `.clinerc` when opening terminals
* Allows users to set environment variables (e.g., `PAGER=cat`)
* Supports creating command aliases and other shell customizations
* Includes a 3-second execution timeout to prevent delays

### Why This Approach?

Initially, I considered hardcoding environment variables like `PAGER`, but this would be inflexible and wouldn't address all use cases. The `.clinerc` approach provides a more elegant, Unix-style solution that gives users full control over their terminal environment.

### Example configuration

```
cat > ~/.clinerc << 'EOF'
export PAGER=cat
export GIT_PAGER=cat
export SYSTEMD_PAGER=cat
export LESS="-FRX"
EOF
```

### Test Procedure

Checkout to a very large commit and ask "Run 'git show' command"

### Type of Change


-   [x] ✨ New feature (non-breaking change which adds functionality)


### Screenshots

Before:
(the ':' at the last line is a prompt for a pager)
<img width="1557" height="486" alt="Screenshot 2025-08-09 at 3 53 22 PM" src="https://github.com/user-attachments/assets/9ca3889d-57c3-49a9-aa73-629d036827df" />

After:
(long output came without pagination and a command successfully finished)
<img width="1543" height="595" alt="Screenshot 2025-08-09 at 8 29 10 PM" src="https://github.com/user-attachments/assets/7e3ef7f9-05de-4065-b2c2-7249c24eb88a" />
