### PR TITLE
Remove deprecated GPT-4.5 Preview

### DIFF
--- a/.changeset/sixty-dogs-ring.md
+++ b/.changeset/sixty-dogs-ring.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": minor
+---
+
+Remove deprecated GPT-4.5 Preview

--- a/docs/provider-config/openai-compatible.mdx
+++ b/docs/provider-config/openai-compatible.mdx
@@ -43,7 +43,6 @@ While the "OpenAI Compatible" provider type allows connecting to various endpoin
 -   `o1`
 -   `o1-preview`
 -   `o1-mini`
--   `gpt-4.5-preview`
 -   `gpt-4o`
 -   `gpt-4o-mini`
 

--- a/docs/provider-config/openai.mdx
+++ b/docs/provider-config/openai.mdx
@@ -26,7 +26,6 @@ Cline is compatible with a variety of OpenAI models, including but not limited t
 -   `o1`
 -   `o1-preview`
 -   `o1-mini`
--   `gpt-4.5-preview`
 -   `gpt-4o`
 -   `gpt-4o-mini`
 -   'gpt-4.1'

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -1148,14 +1148,6 @@ export const openAiNativeModels = {
 		inputPrice: 5,
 		outputPrice: 15,
 	},
-	"gpt-4.5-preview": {
-		maxTokens: 16_384,
-		contextWindow: 128_000,
-		supportsImages: true,
-		supportsPromptCache: true,
-		inputPrice: 75,
-		outputPrice: 150,
-	},
 } as const satisfies Record<string, ModelInfo>
 
 // Azure OpenAI


### PR DESCRIPTION
### Description

Remove deprecated GPT-4.5 Preview

### Test Procedure

As it has been deprecated for a few weeks already, there wasn't a good method to test the before/after behavior, just simply remove it.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Additional Notes

Reference:
https://platform.openai.com/docs/models/gpt-4.5-preview
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove deprecated `gpt-4.5-preview` model from codebase and documentation.
> 
>   - **Model Removal**:
>     - Remove `gpt-4.5-preview` from `openAiNativeModels` in `api.ts`.
>   - **Documentation**:
>     - Remove `gpt-4.5-preview` from `openai-compatible.mdx` and `openai.mdx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for e92153f641aec1705b3220d7c61bc1b96560f7a8. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->