### PR TITLE
fix requesty's api key url

### DIFF
--- a/.changeset/eighty-rocks-switch.md
+++ b/.changeset/eighty-rocks-switch.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Fixes the API Keys URL for Requesty

--- a/docs/provider-config/requesty.mdx
+++ b/docs/provider-config/requesty.mdx
@@ -10,7 +10,7 @@ Cline supports accessing models through the [Requesty](https://www.requesty.ai/)
 ### Getting an API Key
 
 1.  **Sign Up/Sign In:** Go to the [Requesty website](https://www.requesty.ai/) and create an account or sign in.
-2.  **Get API Key:** You can get an API key from the [API Management](https://app.requesty.ai/manage-api) section of your Requesty dashboard.
+2.  **Get API Key:** You can get an API key from the [API Management](https://app.requesty.ai/api-keys) section of your Requesty dashboard.
 
 ### Supported Models
 
@@ -26,7 +26,7 @@ Requesty provides access to a wide range of models. Cline will automatically fet
 ### Tips and Notes
 
 -   **Optimizations**: Requesty offers a range of in-flight cost optimizations to lower your costs.
--   **Unified and simplified billing**: Unrestricted access to all providers and models, automatic balance top ups and more via a single [API key](https://app.requesty.ai/manage-api).
+-   **Unified and simplified billing**: Unrestricted access to all providers and models, automatic balance top ups and more via a single [API key](https://app.requesty.ai/api-keys).
 -   **Cost tracking**: Track cost per model, coding language, changed file, and more via the [Cost dashboard](https://app.requesty.ai/cost-management) or the [Requesty VS Code extension](https://marketplace.visualstudio.com/items?itemName=Requesty.requesty).
 -   **Stats and logs**: See your [coding stats dashboard](https://app.requesty.ai/usage-stats) or go through your [LLM interaction logs](https://app.requesty.ai/logs).
 -   **Fallback policies**: Keep your LLM working for you with fallback policies when providers are down.

--- a/webview-ui/src/components/settings/providers/RequestyProvider.tsx
+++ b/webview-ui/src/components/settings/providers/RequestyProvider.tsx
@@ -26,7 +26,7 @@ export const RequestyProvider = ({ showModelOptions, isPopup, currentMode }: Req
 				initialValue={apiConfiguration?.requestyApiKey || ""}
 				onChange={(value) => handleFieldChange("requestyApiKey", value)}
 				providerName="Requesty"
-				signupUrl="https://app.requesty.ai/manage-api"
+				signupUrl="https://app.requesty.ai/api-keys"
 			/>
 
 			{showModelOptions && <RequestyModelPicker isPopup={isPopup} currentMode={currentMode} />}


### PR DESCRIPTION
### Related Issue
**Issue:** #5497

### Description

The base URL to get an API key from Requesty is incorrect, and takes you to a 404. This PR changes the base URL to the correct one.

### Test Procedure
1. Go to Cline in VSCode
2. Select Requesty as the API provider
3. Click the "Get API key" text, and see if it takes you to the correct page, or a 404

### Type of Change
-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)

### Pre-flight 
-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots
<img width="277" height="171" alt="Screenshot 2025-08-11 at 17 28 15" src="https://github.com/user-attachments/assets/68138199-6b15-4988-90d4-5d86d028d615" />
