### PR TITLE
refactor: migrate MCP settings watcher to chokidar

### DIFF
--- a/src/services/mcp/McpHub.ts
+++ b/src/services/mcp/McpHub.ts
@@ -34,7 +34,6 @@ import * as path from "path"
 import ReconnectingEventSource from "reconnecting-eventsource"
 import * as vscode from "vscode"
 import { z } from "zod"
-import { FileChangeEvent_ChangeType, SubscribeToFileRequest } from "../../shared/proto/host/watch"
 import { DEFAULT_REQUEST_TIMEOUT_MS } from "./constants"
 import { BaseConfigSchema, McpSettingsSchema, ServerConfigSchema } from "./schemas"
 import { McpConnection, McpServerConfig, Transport } from "./types"
@@ -44,7 +43,7 @@ export class McpHub {
 	private clientVersion: string
 
 	private disposables: vscode.Disposable[] = []
-	private settingsWatcher?: vscode.FileSystemWatcher
+	private settingsWatcher?: FSWatcher
 	private fileWatchers: Map<string, FSWatcher> = new Map()
 	connections: McpConnection[] = []
 	isConnecting: boolean = false
@@ -132,41 +131,32 @@ export class McpHub {
 	private async watchMcpSettingsFile(): Promise<void> {
 		const settingsPath = await this.getMcpSettingsFilePath()
 
-		// Subscribe to file changes using the gRPC WatchService
-		//console.log("[DEBUG] subscribing to mcp file changes")
-		const cancelSubscription = HostProvider.watch.subscribeToFile(
-			SubscribeToFileRequest.create({
-				path: settingsPath,
-			}),
-			{
-				onResponse: async (response) => {
-					// console.log(
-					// 	`[DEBUG] MCP settings ${response.type === FileChangeEvent_ChangeType.CHANGED ? "changed" : "event"}`,
-					// )
-
-					// Only process the file if it was changed (not created or deleted)
-					if (response.type === FileChangeEvent_ChangeType.CHANGED) {
-						const settings = await this.readAndValidateMcpSettingsFile()
-						if (settings) {
-							try {
-								await this.updateServerConnections(settings.mcpServers)
-							} catch (error) {
-								console.error("Failed to process MCP settings change:", error)
-							}
-						}
-					}
-				},
-				onError: (error) => {
-					console.error("Error watching MCP settings file:", error)
-				},
-				onComplete: () => {
-					//console.log("[DEBUG] MCP settings file watch completed")
-				},
+		this.settingsWatcher = chokidar.watch(settingsPath, {
+			persistent: true, // Keep the process running as long as files are being watched
+			ignoreInitial: true, // Don't fire 'add' events when discovering the file initially
+			awaitWriteFinish: {
+				// Wait for writes to finish before emitting events (handles chunked writes)
+				stabilityThreshold: 100, // Wait 100ms for file size to remain constant (matches the debounce from subscribeToFile.ts)
+				pollInterval: 100, // Check file size every 100ms while waiting for stability
 			},
-		)
+			atomic: true, // Handle atomic writes where editors write to a temp file then rename (prevents duplicate events)
+		})
 
-		// Add the cancellation function to disposables
-		this.disposables.push({ dispose: cancelSubscription })
+		this.settingsWatcher.on("change", async () => {
+			console.log(`[DEBUG] MCP settings changed`)
+			const settings = await this.readAndValidateMcpSettingsFile()
+			if (settings) {
+				try {
+					await this.updateServerConnections(settings.mcpServers)
+				} catch (error) {
+					console.error("Failed to process MCP settings change:", error)
+				}
+			}
+		})
+
+		this.settingsWatcher.on("error", (error) => {
+			console.error("Error watching MCP settings file:", error)
+		})
 	}
 
 	private async initializeMcpServers(): Promise<void> {
@@ -1123,7 +1113,7 @@ export class McpHub {
 		}
 		this.connections = []
 		if (this.settingsWatcher) {
-			this.settingsWatcher.dispose()
+			await this.settingsWatcher.close()
 		}
 		this.disposables.forEach((d) => d.dispose())
 	}

--- a/src/services/mcp/McpHub.ts
+++ b/src/services/mcp/McpHub.ts
@@ -143,7 +143,6 @@ export class McpHub {
 		})
 
 		this.settingsWatcher.on("change", async () => {
-			console.log(`[DEBUG] MCP settings changed`)
 			const settings = await this.readAndValidateMcpSettingsFile()
 			if (settings) {
 				try {


### PR DESCRIPTION
### Description

This PR migrates the MCP settings file watching functionality from the host provider's file watcher to chokidar. This change consolidates our file watching approach since we're already using chokidar for watching MCP server build files.

The migration maintains all original functionality while leveraging chokidar's built-in features for more robust file watching.

### Test Procedure

- Tested that MCP settings file changes are still detected and processed correctly
- Tested the dispose method to ensure the watcher is properly cleaned up

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [x] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A - This is a backend refactoring change with no visible UI impact.

### Additional Notes

Changes made:
- Removed unused imports for `FileChangeEvent_ChangeType` and `SubscribeToFileRequest`
- Changed `settingsWatcher` type from `vscode.FileSystemWatcher` to chokidar's `FSWatcher`
- Replaced `watchMcpSettingsFile()` implementation to use chokidar with built-in debouncing and atomic write handling
- Added detailed comments explaining each chokidar configuration option
- Fixed `dispose()` method to use `close()` instead of `dispose()` for the chokidar watcher
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Refactored MCP settings file watcher in `McpHub.ts` to use chokidar, enhancing file watching with debouncing and atomic write handling.
> 
>   - **File Watching**:
>     - Migrated MCP settings file watching from host provider's file watcher to chokidar in `McpHub.ts`.
>     - Updated `watchMcpSettingsFile()` to use chokidar with debouncing and atomic write handling.
>     - Changed `settingsWatcher` type from `vscode.FileSystemWatcher` to chokidar's `FSWatcher`.
>   - **Imports**:
>     - Removed unused imports for `FileChangeEvent_ChangeType` and `SubscribeToFileRequest`.
>   - **Dispose Method**:
>     - Updated `dispose()` method to use `close()` instead of `dispose()` for chokidar watcher.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for e0b0dd151beda8c15007498130356591be5347a0. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->