### PR TITLE
refactor: migrate FileContextTracker to chokidar

### DIFF
--- a/src/core/context/context-tracking/FileContextTracker.test.ts
+++ b/src/core/context/context-tracking/FileContextTracker.test.ts
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, it } from "mocha"
 import * as path from "path"
 import * as sinon from "sinon"
 import * as vscode from "vscode"
+import chokidar from "chokidar"
 import type { FileMetadataEntry, TaskMetadata } from "./ContextTrackerTypes"
 import { FileContextTracker } from "./FileContextTracker"
 
@@ -14,6 +15,7 @@ describe("FileContextTracker", () => {
 	let mockContext: vscode.ExtensionContext
 	let mockWorkspace: sinon.SinonStub
 	let mockFileSystemWatcher: any
+	let chokidarWatchStub: sinon.SinonStub
 	let tracker: FileContextTracker
 	let taskId: string
 	let mockTaskMetadata: TaskMetadata
@@ -32,16 +34,16 @@ describe("FileContextTracker", () => {
 			} as vscode.WorkspaceFolder,
 		])
 
-		// Mock file system watcher
+		// Mock chokidar file watcher
 		mockFileSystemWatcher = {
-			dispose: sandbox.stub(),
-			onDidChange: sandbox.stub().returns({ dispose: () => {} }),
+			close: sandbox.stub().resolves(),
+			on: sandbox.stub(),
 		}
+		// Return the watcher itself for chaining
+		mockFileSystemWatcher.on.returns(mockFileSystemWatcher)
 
-		// Use a function replacement instead of a direct stub
-		vscode.workspace.createFileSystemWatcher = function () {
-			return mockFileSystemWatcher
-		}
+		// Stub chokidar.watch to return our mock watcher
+		chokidarWatchStub = sandbox.stub(chokidar, "watch").returns(mockFileSystemWatcher as any)
 
 		// Mock controller and context
 		mockContext = {
@@ -186,17 +188,13 @@ describe("FileContextTracker", () => {
 	it("should setup a file watcher for tracked files", async () => {
 		const filePath = "src/test-file.ts"
 
-		// Create a spy to track if createFileSystemWatcher was called
-		const createWatcherSpy = sinon.spy(vscode.workspace, "createFileSystemWatcher")
-
 		await tracker.trackFileContext(filePath, "read_tool")
 
-		// Verify createFileSystemWatcher was called
-		expect(createWatcherSpy.called).to.be.true
-		createWatcherSpy.restore()
+		// Verify chokidar.watch was called
+		expect(chokidarWatchStub.called).to.be.true
 
-		// Verify onDidChange was called to set up the change listener
-		expect(mockFileSystemWatcher.onDidChange.called).to.be.true
+		// Verify change listener was set up
+		expect(mockFileSystemWatcher.on.called).to.be.true
 	})
 
 	it("should track user edits when file watcher detects changes", async () => {
@@ -212,8 +210,8 @@ describe("FileContextTracker", () => {
 		// Create a spy on trackFileContext to verify it's called with the right parameters
 		const trackFileContextSpy = sandbox.spy(tracker, "trackFileContext")
 
-		// Get the callback that was registered with onDidChange
-		const callback = mockFileSystemWatcher.onDidChange.firstCall.args[0]
+		// Get the callback that was registered with chokidar "change" event
+		const callback = mockFileSystemWatcher.on.firstCall.args[1]
 
 		// Directly call the callback to simulate a file change event
 		callback(vscode.Uri.file(path.resolve("/mock/workspace", filePath)))
@@ -242,8 +240,8 @@ describe("FileContextTracker", () => {
 		// Create a spy on trackFileContext to verify it's not called
 		const trackFileContextSpy = sandbox.spy(tracker, "trackFileContext")
 
-		// Get the callback that was registered with onDidChange
-		const callback = mockFileSystemWatcher.onDidChange.firstCall.args[0]
+		// Get the callback that was registered with chokidar "change" event
+		const callback = mockFileSystemWatcher.on.firstCall.args[1]
 
 		// Directly call the callback to simulate a file change event
 		callback(vscode.Uri.file(path.resolve("/mock/workspace", filePath)))
@@ -263,9 +261,9 @@ describe("FileContextTracker", () => {
 		await tracker.trackFileContext(filePath, "read_tool")
 
 		// Call dispose
-		tracker.dispose()
+		await tracker.dispose()
 
-		// Verify the watcher was disposed
-		expect(mockFileSystemWatcher.dispose.called).to.be.true
+		// Verify the watcher was closed
+		expect(mockFileSystemWatcher.close.called).to.be.true
 	})
 })

--- a/src/core/context/context-tracking/FileContextTracker.ts
+++ b/src/core/context/context-tracking/FileContextTracker.ts
@@ -1,11 +1,11 @@
 import * as path from "path"
 import * as vscode from "vscode"
+import chokidar, { FSWatcher } from "chokidar"
 import { getTaskMetadata, saveTaskMetadata } from "@core/storage/disk"
 import { getWorkspaceState, updateWorkspaceState } from "@core/storage/state"
 import { getGlobalState } from "@core/storage/state"
 import type { FileMetadataEntry } from "./ContextTrackerTypes"
 import type { ClineMessage } from "@shared/ExtensionMessage"
-import { HostProvider } from "@/hosts/host-provider"
 import { getCwd } from "@/utils/path"
 
 // This class is responsible for tracking file operations that may result in stale context.
@@ -27,7 +27,7 @@ export class FileContextTracker {
 	readonly taskId: string
 
 	// File tracking and watching
-	private fileWatchers = new Map<string, vscode.FileSystemWatcher>()
+	private fileWatchers = new Map<string, FSWatcher>()
 	private recentlyModifiedFiles = new Set<string>()
 	private recentlyEditedByCline = new Set<string>()
 
@@ -51,14 +51,21 @@ export class FileContextTracker {
 			return
 		}
 
-		// Create a file system watcher for this specific file
-		const fileUri = vscode.Uri.file(path.resolve(cwd, filePath))
-		const watcher = vscode.workspace.createFileSystemWatcher(
-			new vscode.RelativePattern(path.dirname(fileUri.fsPath), path.basename(fileUri.fsPath)),
-		)
+		// Create a chokidar file watcher for this specific file
+		const resolvedFilePath = path.resolve(cwd, filePath)
+		const watcher = chokidar.watch(resolvedFilePath, {
+			persistent: true, // Keep process alive while watching
+			ignoreInitial: true, // Don't emit events for existing files on startup
+			atomic: true, // Handle atomic writes (editors that use temp files)
+			awaitWriteFinish: {
+				// Wait for writes to finish before emitting events
+				stabilityThreshold: 100, // Wait 100ms for file size to stabilize
+				pollInterval: 100, // Check every 100ms while waiting
+			},
+		})
 
 		// Track file changes
-		watcher.onDidChange(() => {
+		watcher.on("change", () => {
 			if (this.recentlyEditedByCline.has(filePath)) {
 				this.recentlyEditedByCline.delete(filePath) // This was an edit by Cline, no need to inform Cline
 			} else {
@@ -179,10 +186,9 @@ export class FileContextTracker {
 	/**
 	 * Disposes all file watchers
 	 */
-	dispose(): void {
-		for (const watcher of this.fileWatchers.values()) {
-			watcher.dispose()
-		}
+	async dispose(): Promise<void> {
+		const closePromises = Array.from(this.fileWatchers.values()).map((watcher) => watcher.close())
+		await Promise.all(closePromises)
 		this.fileWatchers.clear()
 	}
 


### PR DESCRIPTION
### Description

This PR migrates the `FileContextTracker` class from using VSCode's `FileSystemWatcher` to using `chokidar`, which is already being used elsewhere in the codebase (e.g., McpHub).

### Test Procedure

- The existing functionality remains unchanged - only the underlying file watching mechanism has been replaced

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [x] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A - This is a backend refactoring with no UI changes.

### Additional Notes

This change makes the `dispose()` method async, which may require updates to callers. The migration maintains all existing functionality while leveraging chokidar's built-in features for more reliable file watching.
