### PR TITLE
Adding a retry button for cases when the streaming response breaks wi…

### DIFF
--- a/src/core/task/index.ts
+++ b/src/core/task/index.ts
@@ -2531,7 +2531,19 @@ export class Task {
 						},
 					],
 				})
-				// Returns early to avoid retry since no assistant message was received
+
+				// Offer the user a chance to retry this API request
+				const { response } = await this.ask(
+					"api_req_failed",
+					"No assistant message was received. Would you like to retry the request?",
+				)
+
+				if (response === "yesButtonClicked") {
+					// Signal the loop to continue (i.e., do not end), so it will attempt again
+					return false
+				}
+
+				// Returns early to avoid retry since user dismissed
 				return true
 			}
 


### PR DESCRIPTION
Follow up PR for https://github.com/cline/cline/pull/5432 

### Description
Adds a retry button for the cases when the streaming response breaks with no output. 


### Test Procedure
Tested locally by making openrouter give no output.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [X] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes


### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [X] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [X] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [X] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [X] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots
 
<img width="411" height="331" alt="image" src="https://github.com/user-attachments/assets/c7a9a1d3-863e-419b-a644-7254a37e9502" />

The retry button looks like this 
<img width="484" height="873" alt="image" src="https://github.com/user-attachments/assets/9dac8681-9663-4b66-8cf0-cb9a4c7413d1" />


### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds a retry button in `Task` class for cases when streaming response fails with no output, allowing user to retry the request.
> 
>   - **Behavior**:
>     - Adds a retry button in `Task` class in `index.ts` for cases when streaming response fails with no output.
>     - In `recursivelyMakeClineRequests`, prompts user to retry if no assistant message is received.
>   - **Misc**:
>     - Tested locally with OpenRouter to simulate no output scenario.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 6a96c42052f18c8e53e4ca8232cd04dd7f50e482. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->