### PR TITLE
Guard ActionButtons when no task

### DIFF
--- a/webview-ui/src/components/chat/chat-view/components/layout/ActionButtons.tsx
+++ b/webview-ui/src/components/chat/chat-view/components/layout/ActionButtons.tsx
@@ -72,6 +72,10 @@ export const ActionButtons: React.FC<ActionButtonsProps> = ({
 		}
 	}, [messages, setSendingDisabled])
 
+	if (!task) {
+		return null
+	}
+
 	const { showScrollToBottom, scrollToBottomSmooth, disableAutoScrollRef } = scrollBehavior
 
 	if (showScrollToBottom) {

--- a/webview-ui/src/components/chat/chat-view/hooks/useScrollBehavior.ts
+++ b/webview-ui/src/components/chat/chat-view/hooks/useScrollBehavior.ts
@@ -72,24 +72,20 @@ export function useScrollBehavior(
 			}
 
 			let groupIndex = -1
-			let currentVisibleIndex = 0
 
 			for (let i = 0; i < groupedMessages.length; i++) {
 				const group = groupedMessages[i]
 				if (Array.isArray(group)) {
-					const groupSize = group.length
 					const messageInGroup = group.some((msg) => msg.ts === targetMessage.ts)
 					if (messageInGroup) {
 						groupIndex = i
 						break
 					}
-					currentVisibleIndex += groupSize
 				} else {
 					if (group.ts === targetMessage.ts) {
 						groupIndex = i
 						break
 					}
-					currentVisibleIndex++
 				}
 			}
 
@@ -194,6 +190,12 @@ export function useScrollBehavior(
 			scrollToMessage(pendingScrollToMessage)
 		}
 	}, [pendingScrollToMessage, groupedMessages, scrollToMessage])
+
+	useEffect(() => {
+		if (!messages?.length) {
+			setShowScrollToBottom(false)
+		}
+	}, [messages.length])
 
 	const handleWheel = useCallback((event: Event) => {
 		const wheelEvent = event as WheelEvent


### PR DESCRIPTION
<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- For feature requests: Created a discussion in our Feature Requests discussions board https://github.com/cline/cline/discussions/categories/feature-requests and received approval from core maintainers before implementation
- For all changes: Link the associated issue/discussion in the "Related Issue" section below

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly without prior discussion.

Why this requirement?
We deeply appreciate all community contributions - they are essential to Cline's success! To ensure the best use of everyone's time and maintain project direction, we use our Feature Requests discussions board to gauge community interest and validate feature ideas before implementation begins. This helps us focus development efforts on features that will benefit the most users.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** #XXXX

### Description

<!-- 
Help reviewers understand your changes by making this PR readable and well-organized:

- What problem does this PR solve?
- Why were these changes introduced and what purpose do they serve?
- For larger changes, provide context about your approach and reasoning

Small PRs may need minimal description, but larger changes benefit from explaining where you're coming from. Much of this context can be in the linked issue above, so feel free to reference it rather than repeating everything here.
-->

Minor follow-up on https://github.com/cline/cline/pull/5462 - Guard ActionButtons when no task; fix scroll deps/empty state

- Return null from ActionButtons if no task to avoid rendering controls without context
- Hide “scroll to bottom” button when there are no messages
- Clean up unused index-tracking logic in scrollToMessage

### Test Procedure

<!-- 
Please walk us through your testing approach and thought process. This helps reviewers understand that you've thoroughly considered the impact of your changes:

- How did you test this change?
- What could potentially break and how did you verify it doesn't?
- What existing functionality might be affected and how did you check it still works?
- Why are you confident this is ready for merge?

We're not looking for exhaustive documentation - just evidence that you've thought through the implications of your changes and tested accordingly.
-->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Guard `ActionButtons` and hide "scroll to bottom" button when no task or messages are present.
> 
>   - **Behavior**:
>     - `ActionButtons` in `ActionButtons.tsx` now returns `null` if `task` is not present, preventing rendering of buttons without context.
>     - In `useScrollBehavior.ts`, hides "scroll to bottom" button when `messages` array is empty.
>   - **Code Cleanup**:
>     - Removed unused index-tracking logic in `useScrollBehavior.ts` related to message grouping.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for c3851b7e8244338e5f1d86b39ff2fd5241e44154. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->