### PR TITLE
Add multi-file diff to the host bridge.

### DIFF
--- a/proto/host/diff.proto
+++ b/proto/host/diff.proto
@@ -10,17 +10,27 @@ import "cline/common.proto";
 service DiffService {
   // Open the diff view/editor.
   rpc openDiff(OpenDiffRequest) returns (OpenDiffResponse);
+
   // Get the contents of the diff view.
   rpc getDocumentText(GetDocumentTextRequest) returns (GetDocumentTextResponse);
+
   // Replace a text selection in the diff.
   rpc replaceText(ReplaceTextRequest) returns (ReplaceTextResponse);
+
   rpc scrollDiff(ScrollDiffRequest) returns (ScrollDiffResponse);
+
   // Truncate the diff document.
   rpc truncateDocument(TruncateDocumentRequest) returns (TruncateDocumentResponse);
+
   // Save the diff document.
   rpc saveDocument(SaveDocumentRequest) returns (SaveDocumentResponse);
+
   // Close the diff editor UI.
   rpc closeDiff(CloseDiffRequest) returns (CloseDiffResponse);
+
+  // Display a diff view comparing before/after states for multiple files.
+  // Content is passed as in-memory data, not read from the file system.
+  rpc openMultiFileDiff(OpenMultiFileDiffRequest) returns (OpenMultiFileDiffResponse);
 }
 
 message OpenDiffRequest {
@@ -83,3 +93,19 @@ message SaveDocumentRequest {
 }
 
 message SaveDocumentResponse {}
+
+message OpenMultiFileDiffRequest {
+  optional string title = 1;
+  repeated ContentDiff diffs = 2;
+}
+
+message ContentDiff {
+  // The absolute file path.
+  optional string file_path = 1;
+  optional string left_content = 2;
+  optional string right_content = 3;
+}
+
+message OpenMultiFileDiffResponse {
+  
+}

--- a/src/core/mentions/index.test.ts
+++ b/src/core/mentions/index.test.ts
@@ -10,7 +10,7 @@ import * as fs from "fs"
 import * as isBinaryFileModule from "isbinaryfile"
 import * as path from "path"
 import * as sinon from "sinon"
-import { parseMentions } from "../index"
+import { parseMentions } from "."
 
 describe("parseMentions", () => {
 	let sandbox: sinon.SinonSandbox

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -195,10 +195,16 @@ export async function activate(context: vscode.ExtensionContext) {
 	)
 
 	/*
-	We use the text document content provider API to show the left side for diff view by creating a virtual document for the original content. This makes it readonly so users know to edit the right side if they want to keep their changes.
+	We use the text document content provider API to show the left side for diff view by creating a 
+	virtual document for the original content. This makes it readonly so users know to edit the right 
+	side if they want to keep their changes.
 
-	- This API allows you to create readonly documents in VSCode from arbitrary sources, and works by claiming an uri-scheme for which your provider then returns text contents. The scheme must be provided when registering a provider and cannot change afterwards.
-	- Note how the provider doesn't create uris for virtual documents - its role is to provide contents given such an uri. In return, content providers are wired into the open document logic so that providers are always considered.
+	- This API allows you to create readonly documents in VSCode from arbitrary sources, and works by 
+	claiming an uri-scheme for which your provider then returns text contents. The scheme must be 
+	provided when registering a provider and cannot change afterwards.
+	- Note how the provider doesn't create uris for virtual documents - its role is to provide contents
+	 given such an uri. In return, content providers are wired into the open document logic so that 
+	 providers are always considered.
 	https://code.visualstudio.com/api/extension-guides/virtual-documents
 	*/
 	const diffContentProvider = new (class implements vscode.TextDocumentContentProvider {

--- a/src/hosts/vscode/hostbridge/diff/openMultiFileDiff.ts
+++ b/src/hosts/vscode/hostbridge/diff/openMultiFileDiff.ts
@@ -1,0 +1,30 @@
+import { OpenMultiFileDiffRequest, OpenMultiFileDiffResponse } from "@/shared/proto/index.host"
+import * as vscode from "vscode"
+import { DIFF_VIEW_URI_SCHEME } from "../../VscodeDiffViewProvider"
+import { getCwd } from "@/utils/path"
+import path from "path"
+
+export async function openMultiFileDiff(request: OpenMultiFileDiffRequest): Promise<OpenMultiFileDiffResponse> {
+	const cwd = await getCwd()
+	await vscode.commands.executeCommand(
+		"vscode.changes",
+		request.title,
+		request.diffs.map((diff) => {
+			const file = vscode.Uri.file(diff.filePath || "")
+			const relativePath = path.relative(cwd, diff.filePath || "")
+			const left = diff.leftContent ?? ""
+			const right = diff.rightContent ?? ""
+			return [
+				file,
+				vscode.Uri.parse(`${DIFF_VIEW_URI_SCHEME}:${relativePath}`).with({
+					query: Buffer.from(left).toString("base64"),
+				}),
+				vscode.Uri.parse(`${DIFF_VIEW_URI_SCHEME}:${relativePath}`).with({
+					query: Buffer.from(right).toString("base64"),
+				}),
+			]
+		}),
+	)
+
+	return {}
+}

--- a/src/integrations/editor/DiffViewProvider.ts
+++ b/src/integrations/editor/DiffViewProvider.ts
@@ -177,7 +177,8 @@ export abstract class DiffViewProvider {
 			// Only proceed if we have new lines
 
 			// Replace all content up to the current line with accumulated lines
-			// This is necessary (as compared to inserting one line at a time) to handle cases where html tags on previous lines are auto closed for example
+			// This is necessary (as compared to inserting one line at a time) to handle cases where html tags
+			// on previous lines are auto closed for example
 			const contentToReplace = accumulatedLines.slice(0, currentLine + 1).join("\n") + "\n"
 			const rangeToReplace = { startLine: 0, endLine: currentLine + 1 }
 			await this.replaceText(contentToReplace, rangeToReplace, currentLine)


### PR DESCRIPTION
Add an RPC to the Host Bridge to open a diff for multiple files, this is
used when comparing check points or to display the changes cline has made
when it is finished editing.

Switch the file mentions unit test to an integration test because
now it is pulling in vscode dependencies and they cannot be mocked
in the unit tests.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds `openMultiFileDiff` RPC to handle multi-file diffs in VSCode, updating `proto`, `task`, and `extension` files for integration.
> 
>   - **Behavior**:
>     - Adds `openMultiFileDiff` RPC to `DiffService` in `proto/host/diff.proto` for displaying diffs of multiple files.
>     - Implements `openMultiFileDiff` in `openMultiFileDiff.ts` to execute VSCode command for multi-file diff view.
>     - Updates `Task` class in `index.ts` to use `openMultiFileDiff` for presenting diffs when checkpoints are enabled.
>   - **Misc**:
>     - Updates `extension.ts` to register the new diff content provider for handling multi-file diffs.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 6464bac4e13cb83688e08d92494ba00a0da8acfe. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->