### PR TITLE
Use HostProvider for creating and using the OpenRouter auth URL

### DIFF
--- a/proto/cline/account.proto
+++ b/proto/cline/account.proto
@@ -36,6 +36,8 @@ service AccountService {
   rpc getUserOrganizations(EmptyRequest) returns (UserOrganizationsResponse);
 
   rpc setUserOrganization(UserOrganizationUpdateRequest) returns (Empty);
+
+  rpc openrouterAuthClicked(EmptyRequest) returns (Empty);
 }
 
 message AuthStateChangedRequest {

--- a/proto/cline/models.proto
+++ b/proto/cline/models.proto
@@ -25,7 +25,7 @@ service ModelsService {
   rpc subscribeToOpenRouterModels(EmptyRequest) returns (stream OpenRouterCompatibleModelInfo);
   // Updates API configuration
   rpc updateApiConfigurationProto(UpdateApiConfigurationRequest) returns (Empty);
-   // Refreshes and returns Groq models
+  // Refreshes and returns Groq models
   rpc refreshGroqModels(EmptyRequest) returns (OpenRouterCompatibleModelInfo);
   // Refreshes and returns Baseten models
   rpc refreshBasetenModels(EmptyRequest) returns (OpenRouterCompatibleModelInfo);

--- a/src/core/controller/account/openrouterAuthClicked.ts
+++ b/src/core/controller/account/openrouterAuthClicked.ts
@@ -1,0 +1,17 @@
+import { HostProvider } from "@/hosts/host-provider"
+import { openExternal } from "@/utils/env"
+
+import { Controller } from ".."
+import { EmptyRequest, Empty } from "@shared/proto/cline/common"
+
+/**
+ * Initiates OpenRouter auth
+ */
+export async function openrouterAuthClicked(_: Controller, __: EmptyRequest): Promise<Empty> {
+	const callbackUri = await HostProvider.get().getCallbackUri()
+	const authUri = `https://openrouter.ai/auth?callback_url=${callbackUri}/openrouter`
+
+	await openExternal(authUri)
+
+	return {}
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -32,6 +32,7 @@ import { AuthService } from "./services/auth/AuthService"
 import { telemetryService } from "./services/posthog/PostHogClientProvider"
 import { SharedUriHandler } from "./services/uri/SharedUriHandler"
 import { ShowMessageType } from "./shared/proto/host/window"
+import { AuthHandler } from "./hosts/external/AuthHandler"
 /*
 Built using https://github.com/microsoft/vscode-webview-ui-toolkit
 

--- a/src/hosts/external/AuthHandler.ts
+++ b/src/hosts/external/AuthHandler.ts
@@ -6,6 +6,10 @@ import { SharedUriHandler } from "@/services/uri/SharedUriHandler"
 
 const SERVER_TIMEOUT = 10 * 60 * 1000 // 10 minutes
 
+const PORT_RANGE_START = 48801
+const PORT_RANGE_END = 48811
+const PORTS: number[] = Array.from({ length: PORT_RANGE_END - PORT_RANGE_START + 1 }, (_, i) => PORT_RANGE_START + i)
+
 /**
  * Handles OAuth authentication flow by creating a local server to receive tokens.
  */
@@ -57,38 +61,62 @@ export class AuthHandler {
 	}
 
 	private async createServer(): Promise<void> {
-		return new Promise((resolve, reject) => {
+		return new Promise(async (resolve, reject) => {
 			try {
 				const server = http.createServer(this.handleRequest.bind(this))
 
-				// Use callback to ensure server is ready before getting address
-				server.listen(0, "127.0.0.1", () => {
-					const address = server.address()
-					if (!address) {
-						console.error("AuthHandler: Failed to get server address")
+				// Try to bind on a port from the allowed range
+				for (const port of PORTS) {
+					try {
+						await this.tryListenOnPort(server, port)
+
+						const address = server.address()
+						if (!address) {
+							console.error("AuthHandler: Failed to get server address")
+							this.server = null
+							this.port = 0
+							this.serverCreationPromise = null
+							reject(new Error("Failed to get server address"))
+							return
+						}
+
+						// Get the assigned port and set up the server
+						this.port = (address as AddressInfo).port
+						this.server = server
+						console.log("AuthHandler: Server started on port", this.port)
+						this.updateTimeout()
+						this.serverCreationPromise = null
+
+						// Attach a general error logger for visibility after successful bind
+						server.on("error", (error) => {
+							console.error("AuthHandler: Server error", error)
+						})
+
+						resolve()
+						return
+					} catch (error) {
+						const err = error as NodeJS.ErrnoException
+						if (err?.code === "EADDRINUSE") {
+							console.warn(`AuthHandler: Port ${port} in use, trying next...`)
+							continue
+						}
+						console.error("AuthHandler: Server error", error)
 						this.server = null
 						this.port = 0
 						this.serverCreationPromise = null
-						reject(new Error("Failed to get server address"))
+						reject(error)
 						return
 					}
+				}
 
-					// Get the assigned port and set up the server
-					this.port = (address as AddressInfo).port
-					this.server = server
-					console.log("AuthHandler: Server started on port", this.port)
-					this.updateTimeout()
-					this.serverCreationPromise = null
-					resolve()
-				})
-
-				server.on("error", (error) => {
-					console.error("AuthHandler: Server error", error)
-					this.server = null
-					this.port = 0
-					this.serverCreationPromise = null
-					reject(error)
-				})
+				// If we reach here, all ports in the range are occupied
+				console.error(`AuthHandler: No available port in range ${PORT_RANGE_START}-${PORT_RANGE_END}`)
+				this.server = null
+				this.port = 0
+				this.serverCreationPromise = null
+				reject(
+					new Error(`No available port found for local auth callback (tried ${PORT_RANGE_START}-${PORT_RANGE_END}).`),
+				)
 			} catch (error) {
 				console.error("AuthHandler: Failed to create server", error)
 				this.server = null
@@ -96,6 +124,20 @@ export class AuthHandler {
 				this.serverCreationPromise = null
 				reject(error)
 			}
+		})
+	}
+
+	private tryListenOnPort(server: Server, port: number): Promise<void> {
+		return new Promise((resolve, reject) => {
+			const onError = (error: NodeJS.ErrnoException) => {
+				server.off("error", onError)
+				reject(error)
+			}
+			server.once("error", onError)
+			server.listen(port, "127.0.0.1", () => {
+				server.off("error", onError)
+				resolve()
+			})
 		})
 	}
 

--- a/webview-ui/src/components/settings/providers/OpenRouterProvider.tsx
+++ b/webview-ui/src/components/settings/providers/OpenRouterProvider.tsx
@@ -1,10 +1,10 @@
-import { VSCodeCheckbox, VSCodeDropdown, VSCodeOption, VSCodeLink } from "@vscode/webview-ui-toolkit/react"
+import { VSCodeCheckbox, VSCodeDropdown, VSCodeOption, VSCodeLink, VSCodeButton } from "@vscode/webview-ui-toolkit/react"
 import { DebouncedTextField } from "../common/DebouncedTextField"
 import { DropdownContainer } from "../common/ModelSelector"
 import { useState } from "react"
-import { getOpenRouterAuthUrl } from "../utils/providerUtils"
+import { AccountServiceClient } from "@/services/grpc-client"
+import { EmptyRequest } from "@shared/proto/cline/common"
 import { useOpenRouterKeyInfo } from "../../ui/hooks/useOpenRouterKeyInfo"
-import VSCodeButtonLink from "../../common/VSCodeButtonLink"
 import OpenRouterModelPicker, { OPENROUTER_MODEL_PICKER_Z_INDEX } from "../OpenRouterModelPicker"
 import { formatPrice } from "../utils/pricingUtils"
 import { useExtensionState } from "@/context/ExtensionStateContext"
@@ -59,7 +59,7 @@ interface OpenRouterProviderProps {
  * The OpenRouter provider configuration component
  */
 export const OpenRouterProvider = ({ showModelOptions, isPopup, currentMode }: OpenRouterProviderProps) => {
-	const { apiConfiguration, uriScheme } = useExtensionState()
+	const { apiConfiguration } = useExtensionState()
 	const { handleFieldChange } = useApiConfigurationHandlers()
 
 	const [providerSortingSelected, setProviderSortingSelected] = useState(!!apiConfiguration?.openRouterProviderSorting)
@@ -81,12 +81,18 @@ export const OpenRouterProvider = ({ showModelOptions, isPopup, currentMode }: O
 					</div>
 				</DebouncedTextField>
 				{!apiConfiguration?.openRouterApiKey && (
-					<VSCodeButtonLink
-						href={getOpenRouterAuthUrl(uriScheme)}
+					<VSCodeButton
+						onClick={async () => {
+							try {
+								await AccountServiceClient.openrouterAuthClicked(EmptyRequest.create())
+							} catch (error) {
+								console.error("Failed to open OpenRouter auth:", error)
+							}
+						}}
 						style={{ margin: "5px 0 0 0" }}
 						appearance="secondary">
 						Get OpenRouter API Key
-					</VSCodeButtonLink>
+					</VSCodeButton>
 				)}
 				<p
 					style={{

--- a/webview-ui/src/components/settings/utils/providerUtils.ts
+++ b/webview-ui/src/components/settings/utils/providerUtils.ts
@@ -539,10 +539,3 @@ export async function syncModeConfigurations(
 	// Make the atomic update
 	await handleFieldsChange(updates)
 }
-
-/**
- * Gets the OpenRouter authentication URL
- */
-export function getOpenRouterAuthUrl(uriScheme?: string) {
-	return `https://openrouter.ai/auth?callback_url=${uriScheme || "vscode"}://saoudrizwan.claude-dev/openrouter`
-}


### PR DESCRIPTION

### Description

Authentication to OpenRouter should use the standard way of getting a callback URI, not hardcoding it. 

### Test Procedure

No behavior changes for VS Code is expected

### Type of Change

-   [x] ♻️ Refactor Changes

