### PR TITLE
Add 1m context window model variant for claude sonnet 4

### DIFF
--- a/.changeset/beige-bobcats-watch.md
+++ b/.changeset/beige-bobcats-watch.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Add 1m context window model support for claude sonnet 4

--- a/src/api/providers/bedrock.ts
+++ b/src/api/providers/bedrock.ts
@@ -2,7 +2,7 @@ import { Anthropic } from "@anthropic-ai/sdk"
 import { withRetry } from "../retry"
 import { ApiHandler } from "../"
 import { convertToR1Format } from "../transform/r1-format"
-import { bedrockDefaultModelId, BedrockModelId, bedrockModels, ModelInfo } from "@shared/api"
+import { bedrockDefaultModelId, BedrockModelId, bedrockModels, CLAUDE_SONNET_4_1M_SUFFIX, ModelInfo } from "@shared/api"
 import { calculateApiCostOpenAI } from "../../utils/cost"
 import { ApiStream } from "../transform/stream"
 import { fromNodeProviderChain } from "@aws-sdk/credential-providers"
@@ -117,7 +117,15 @@ export class AwsBedrockHandler implements ApiHandler {
 	@withRetry({ maxRetries: 4 })
 	async *createMessage(systemPrompt: string, messages: Anthropic.Messages.MessageParam[]): ApiStream {
 		// cross region inference requires prefixing the model id with the region
-		const modelId = await this.getModelId()
+		const rawModelId = await this.getModelId()
+
+		const modelId = rawModelId.endsWith(CLAUDE_SONNET_4_1M_SUFFIX)
+			? rawModelId.slice(0, -CLAUDE_SONNET_4_1M_SUFFIX.length)
+			: rawModelId
+
+		// Doesn't require any special handling, we can just use the claude model and send 1m context
+		// const enable1mContextWindow = rawModelId.endsWith(CLAUDE_SONNET_4_1M_SUFFIX)
+
 		const model = this.getModel()
 
 		// This baseModelId is used to indicate the capabilities of the model.

--- a/src/api/transform/openrouter-stream.ts
+++ b/src/api/transform/openrouter-stream.ts
@@ -146,6 +146,9 @@ export async function createOpenRouterStream(
 	const isKimiK2 = model.id === "moonshotai/kimi-k2"
 	openRouterProviderSorting = isKimiK2 ? undefined : openRouterProviderSorting
 
+	// Force 1m context window for Claude Sonnet 4
+	const isClaudeSonnet4 = model.id === "anthropic/claude-sonnet-4"
+
 	// @ts-ignore-next-line
 	const stream = await client.chat.completions.create({
 		model: model.id,
@@ -164,6 +167,8 @@ export async function createOpenRouterStream(
 		...(isKimiK2
 			? { provider: { order: ["groq", "together", "baseten", "parasail", "novita", "deepinfra"], allow_fallbacks: false } }
 			: {}),
+		// limit providers to only those that support the 1m context window
+		...(isClaudeSonnet4 ? { provider: { order: ["anthropic", "amazon-bedrock"], allow_fallbacks: false } } : {}),
 	})
 
 	return stream

--- a/src/core/controller/models/refreshOpenRouterModels.ts
+++ b/src/core/controller/models/refreshOpenRouterModels.ts
@@ -6,6 +6,7 @@ import path from "path"
 import fs from "fs/promises"
 import { fileExistsAtPath } from "@utils/fs"
 import { GlobalFileNames } from "@core/storage/disk"
+import { CLAUDE_SONNET_4_1M_TIERS } from "@/shared/api"
 
 /**
  * Refreshes the OpenRouter models and returns the updated model list
@@ -49,6 +50,12 @@ export async function refreshOpenRouterModels(
 
 				switch (rawModel.id) {
 					case "anthropic/claude-sonnet-4":
+						modelInfo.supportsPromptCache = true
+						modelInfo.cacheWritesPrice = 3.75
+						modelInfo.cacheReadsPrice = 0.3
+						modelInfo.contextWindow = 1_000_000 // limiting providers to those that support 1m context window
+						modelInfo.tiers = CLAUDE_SONNET_4_1M_TIERS
+						break
 					case "anthropic/claude-3-7-sonnet":
 					case "anthropic/claude-3-7-sonnet:beta":
 					case "anthropic/claude-3.7-sonnet":

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -200,11 +200,40 @@ export interface OpenAiCompatibleModelInfo extends ModelInfo {
 	isR1FormatRequired?: boolean
 }
 
+export const CLAUDE_SONNET_4_1M_SUFFIX = ":1m"
+export const CLAUDE_SONNET_4_1M_TIERS = [
+	{
+		contextWindow: 200000,
+		inputPrice: 3.0,
+		outputPrice: 15,
+		cacheWritesPrice: 3.75,
+		cacheReadsPrice: 0.3,
+	},
+	{
+		contextWindow: Number.MAX_SAFE_INTEGER, // storing infinity in vs storage is not possible, it converts to 'null', which causes crash in webview ModelInfoView
+		inputPrice: 6,
+		outputPrice: 22.5,
+		cacheWritesPrice: 7.5,
+		cacheReadsPrice: 0.6,
+	},
+]
+
 // Anthropic
 // https://docs.anthropic.com/en/docs/about-claude/models // prices updated 2025-01-02
 export type AnthropicModelId = keyof typeof anthropicModels
 export const anthropicDefaultModelId: AnthropicModelId = "claude-sonnet-4-20250514"
 export const anthropicModels = {
+	"claude-sonnet-4-20250514:1m": {
+		maxTokens: 8192,
+		contextWindow: 1_000_000,
+		supportsImages: true,
+		supportsPromptCache: true,
+		inputPrice: 3.0,
+		outputPrice: 15.0,
+		cacheWritesPrice: 3.75,
+		cacheReadsPrice: 0.3,
+		tiers: CLAUDE_SONNET_4_1M_TIERS,
+	},
 	"claude-sonnet-4-20250514": {
 		maxTokens: 8192,
 		contextWindow: 200_000,
@@ -331,6 +360,17 @@ export const claudeCodeModels = {
 export type BedrockModelId = keyof typeof bedrockModels
 export const bedrockDefaultModelId: BedrockModelId = "anthropic.claude-sonnet-4-20250514-v1:0"
 export const bedrockModels = {
+	"anthropic.claude-sonnet-4-20250514-v1:0:1m": {
+		maxTokens: 8192,
+		contextWindow: 1_000_000,
+		supportsImages: true,
+		supportsPromptCache: true,
+		inputPrice: 3.0,
+		outputPrice: 15.0,
+		cacheWritesPrice: 3.75,
+		cacheReadsPrice: 0.3,
+		tiers: CLAUDE_SONNET_4_1M_TIERS,
+	},
 	"anthropic.claude-sonnet-4-20250514-v1:0": {
 		maxTokens: 8192,
 		contextWindow: 200_000,
@@ -482,7 +522,7 @@ export const bedrockModels = {
 export const openRouterDefaultModelId = "anthropic/claude-sonnet-4" // will always exist in openRouterModels
 export const openRouterDefaultModelInfo: ModelInfo = {
 	maxTokens: 8192,
-	contextWindow: 200_000,
+	contextWindow: 1_000_000,
 	supportsImages: true,
 
 	supportsPromptCache: true,
@@ -490,6 +530,7 @@ export const openRouterDefaultModelInfo: ModelInfo = {
 	outputPrice: 15.0,
 	cacheWritesPrice: 3.75,
 	cacheReadsPrice: 0.3,
+	tiers: CLAUDE_SONNET_4_1M_TIERS,
 	description:
 		"Claude Sonnet 4 delivers superior intelligence across coding, agentic search, and AI agent capabilities. It's a powerful choice for agentic coding, and can complete tasks across the entire software development lifecycle—from initial planning to bug fixes, maintenance to large refactors. It offers strong performance in both planning and solving for complex coding tasks, making it an ideal choice to power end-to-end software development processes.\n\nRead more in the [blog post here](https://www.anthropic.com/claude/sonnet)",
 }

--- a/src/utils/cost.ts
+++ b/src/utils/cost.ts
@@ -81,7 +81,7 @@ export function calculateApiCostAnthropic(
 		outputTokens,
 		cacheCreationInputTokensNum,
 		cacheReadInputTokensNum,
-		inputTokens,
+		inputTokens + cacheCreationInputTokensNum + cacheReadInputTokensNum, // used for tiered price lookup
 		thinkingBudgetTokens,
 	)
 }

--- a/webview-ui/src/components/chat/Announcement.tsx
+++ b/webview-ui/src/components/chat/Announcement.tsx
@@ -44,20 +44,12 @@ const Announcement = ({ version, hideAnnouncement }: AnnouncementProps) => {
 			<h3 style={h3TitleStyle}>
 				🎉{"  "}New in v{minorVersion}
 			</h3>
-			<ul style={ulStyle}>
-				<li>
-					<b>GPT-5 Model Support:</b> Added support for the new GPT-5 model family including GPT-5, GPT-5 Mini, and
-					GPT-5 Nano with prompt caching support. GPT-5 is now the default model for new users.
-				</li>
-				<li>
-					<b>Improved Onboarding:</b> New users now see a "Take a Tour" button that opens the VSCode walkthrough to help
-					them get started with Cline more easily.
-				</li>
-				<li>
-					<b>Enhanced Plan Mode:</b> Better exploration parameter support in plan mode for more thorough planning before
-					execution.
-				</li>
-			</ul>
+			<b>1M Context Window:</b> Claude Sonnet 4 now supports a 1 million token context window to handle larger codebases and
+			more complex tasks. Cline/OpenRouter users get instant access, Anthropic users with Tier 4 access can select the{" "}
+			<code>
+				claude-sonnet-4-20250514<b>:1m</b>
+			</code>{" "}
+			model.
 			<Accordion isCompact className="pl-0">
 				<AccordionItem
 					key="1"

--- a/webview-ui/src/components/settings/common/ModelInfoView.tsx
+++ b/webview-ui/src/components/settings/common/ModelInfoView.tsx
@@ -33,13 +33,13 @@ const formatTiers = (
 			return (
 				<span style={{ paddingLeft: "15px" }} key={index}>
 					{formatPrice(price)}/million tokens (
-					{tier.contextWindow === Number.POSITIVE_INFINITY ? (
+					{tier.contextWindow === Number.POSITIVE_INFINITY || tier.contextWindow >= Number.MAX_SAFE_INTEGER ? (
 						<span>
 							{">"} {prevLimit.toLocaleString()}
 						</span>
 					) : (
 						<span>
-							{"<="} {tier.contextWindow.toLocaleString()}
+							{"<="} {tier.contextWindow?.toLocaleString()}
 						</span>
 					)}
 					{" tokens)"}

--- a/webview-ui/src/components/settings/providers/AnthropicProvider.tsx
+++ b/webview-ui/src/components/settings/providers/AnthropicProvider.tsx
@@ -1,4 +1,4 @@
-import { anthropicModels } from "@shared/api"
+import { anthropicModels, CLAUDE_SONNET_4_1M_SUFFIX } from "@shared/api"
 import { ApiKeyField } from "../common/ApiKeyField"
 import { BaseUrlField } from "../common/BaseUrlField"
 import { ModelSelector } from "../common/ModelSelector"
@@ -13,6 +13,7 @@ import { Mode } from "@shared/storage/types"
 export const SUPPORTED_ANTHROPIC_THINKING_MODELS = [
 	"claude-3-7-sonnet-20250219",
 	"claude-sonnet-4-20250514",
+	`claude-sonnet-4-20250514${CLAUDE_SONNET_4_1M_SUFFIX}`,
 	"claude-opus-4-20250514",
 	"claude-opus-4-1-20250805",
 ]

--- a/webview-ui/src/components/settings/providers/BedrockProvider.tsx
+++ b/webview-ui/src/components/settings/providers/BedrockProvider.tsx
@@ -1,4 +1,4 @@
-import { bedrockDefaultModelId, bedrockModels } from "@shared/api"
+import { bedrockDefaultModelId, bedrockModels, CLAUDE_SONNET_4_1M_SUFFIX } from "@shared/api"
 import { VSCodeCheckbox, VSCodeDropdown, VSCodeOption, VSCodeRadio, VSCodeRadioGroup } from "@vscode/webview-ui-toolkit/react"
 import { useState } from "react"
 import { DebouncedTextField } from "../common/DebouncedTextField"
@@ -314,12 +314,16 @@ export const BedrockProvider = ({ showModelOptions, isPopup, currentMode }: Bedr
 
 					{(selectedModelId === "anthropic.claude-3-7-sonnet-20250219-v1:0" ||
 						selectedModelId === "anthropic.claude-sonnet-4-20250514-v1:0" ||
+						selectedModelId === `anthropic.claude-sonnet-4-20250514-v1:0${CLAUDE_SONNET_4_1M_SUFFIX}` ||
 						selectedModelId === "anthropic.claude-opus-4-1-20250805-v1:0" ||
 						selectedModelId === "anthropic.claude-opus-4-20250514-v1:0" ||
 						(modeFields.awsBedrockCustomSelected &&
 							modeFields.awsBedrockCustomModelBaseId === "anthropic.claude-3-7-sonnet-20250219-v1:0") ||
 						(modeFields.awsBedrockCustomSelected &&
 							modeFields.awsBedrockCustomModelBaseId === "anthropic.claude-sonnet-4-20250514-v1:0") ||
+						(modeFields.awsBedrockCustomSelected &&
+							modeFields.awsBedrockCustomModelBaseId ===
+								`anthropic.claude-sonnet-4-20250514-v1:0${CLAUDE_SONNET_4_1M_SUFFIX}`) ||
 						(modeFields.awsBedrockCustomSelected &&
 							modeFields.awsBedrockCustomModelBaseId === "anthropic.claude-opus-4-1-20250805-v1:0") ||
 						(modeFields.awsBedrockCustomSelected &&


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add support for a 1 million token context window variant of Claude Sonnet 4, including model handling, pricing, and UI updates.
> 
>   - **Model Support**:
>     - Add `claude-sonnet-4-20250514:1m` to `anthropicModels` and `bedrockModels` in `api.ts` with a 1 million token context window.
>     - Update `refreshOpenRouterModels.ts` to include 1m context window support for `claude-sonnet-4`.
>   - **API Handling**:
>     - Modify `AnthropicHandler` in `anthropic.ts` and `AwsBedrockHandler` in `bedrock.ts` to handle `CLAUDE_SONNET_4_1M_SUFFIX` for model ID and enable 1m context window.
>     - Add 1m context window beta header in `anthropic.ts` and `bedrock.ts`.
>   - **UI Components**:
>     - Update `Announcement.tsx` to announce 1m context window support.
>     - Modify `ModelInfoView.tsx` to display tiered pricing for 1m context window.
>     - Update `AnthropicProvider.tsx` and `BedrockProvider.tsx` to include the new model variant in model selection.
>   - **Pricing and Cost Calculation**:
>     - Add `CLAUDE_SONNET_4_1M_TIERS` in `api.ts` for tiered pricing.
>     - Update `calculateApiCostAnthropic()` in `cost.ts` to use total input tokens for tiered pricing lookup.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 0d18cf5d4b551d4560ad16b3a6064e8ebce15d0b. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->