### PR TITLE
Refactoring: Move vscode specific code out of the WebviewProvider

### DIFF
--- a/src/core/webview/WebviewProvider.ts
+++ b/src/core/webview/WebviewProvider.ts
@@ -58,7 +58,7 @@ export abstract class WebviewProvider {
 		return Array.from(WebviewProvider.activeInstances).find((instance) => instance.isActive())
 	}
 
-	protected abstract isActive(): Boolean
+	protected abstract isActive(): boolean
 
 	public static getAllInstances(): WebviewProvider[] {
 		return Array.from(WebviewProvider.activeInstances)

--- a/src/core/webview/WebviewProvider.ts
+++ b/src/core/webview/WebviewProvider.ts
@@ -13,8 +13,6 @@ import { HostProvider } from "@/hosts/host-provider"
 import { ShowMessageType } from "@/shared/proto/host/window"
 
 export abstract class WebviewProvider {
-	public static readonly sideBarId = "claude-dev.SidebarProvider" // used in package.json as the view's id. This value cannot be changed due to how vscode caches views based on their id, and updating the id would break existing instances of the extension.
-	public static readonly tabPanelId = "claude-dev.TabPanelProvider"
 	private static activeInstances: Set<WebviewProvider> = new Set()
 	private static clientIdMap = new Map<WebviewProvider, string>()
 	controller: Controller
@@ -24,7 +22,6 @@ export abstract class WebviewProvider {
 
 	constructor(
 		readonly context: vscode.ExtensionContext,
-
 		private readonly providerType: WebviewProviderType,
 	) {
 		WebviewProvider.activeInstances.add(this)
@@ -58,14 +55,10 @@ export abstract class WebviewProvider {
 	}
 
 	public static getActiveInstance(): WebviewProvider | undefined {
-		return Array.from(WebviewProvider.activeInstances).find((instance) => {
-			const webview = instance.getWebview()
-			if (webview && webview.viewType === "claude-dev.TabPanelProvider" && "active" in webview) {
-				return webview.active === true
-			}
-			return false
-		})
+		return Array.from(WebviewProvider.activeInstances).find((instance) => instance.isActive())
 	}
+
+	protected abstract isActive(): Boolean
 
 	public static getAllInstances(): WebviewProvider[] {
 		return Array.from(WebviewProvider.activeInstances)
@@ -116,21 +109,6 @@ export abstract class WebviewProvider {
 	}
 
 	/**
-	 * Initializes and sets up the webview when it's first created.
-	 *
-	 * @param webviewView - The webview view or panel instance to be resolved
-	 * @returns A promise that resolves when the webview has been fully initialized
-	 */
-	abstract resolveWebviewView(webviewView: vscode.WebviewView | vscode.WebviewPanel): Promise<void>
-
-	/**
-	 * Gets the current webview instance.
-	 *
-	 * @returns The webview instance (WebviewView, WebviewPanel, or similar)
-	 */
-	abstract getWebview(): any
-
-	/**
 	 * Converts a local URI to a webview URI that can be used within the webview.
 	 *
 	 * @param uri - The local URI to convert
@@ -177,14 +155,6 @@ export abstract class WebviewProvider {
 		// we installed this package in the extension so that we can access it how its intended from the extension (the font file is likely bundled in vscode), and we just import the css fileinto our react app we don't have access to it
 		// don't forget to add font-src ${webview.cspSource};
 		const codiconsUri = this.getExtensionUri("node_modules", "@vscode", "codicons", "dist", "codicon.css")
-
-		// const scriptUri = webview.asWebviewUri(vscode.Uri.joinPath(this._extensionUri, "assets", "main.js"))
-
-		// const styleResetUri = webview.asWebviewUri(vscode.Uri.joinPath(this._extensionUri, "assets", "reset.css"))
-		// const styleVSCodeUri = webview.asWebviewUri(vscode.Uri.joinPath(this._extensionUri, "assets", "vscode.css"))
-
-		// // Same for stylesheet
-		// const stylesheetUri = webview.asWebviewUri(vscode.Uri.joinPath(this._extensionUri, "assets", "main.css"))
 
 		// Use a nonce to only allow a specific script to be run.
 		/*
@@ -349,9 +319,6 @@ export abstract class WebviewProvider {
 	 * @returns A URI pointing to the file/resource
 	 */
 	private getExtensionUri(...pathList: string[]): Uri {
-		if (!this.getWebview()) {
-			throw Error("webview is not initialized.")
-		}
 		return this.getWebviewUri(Uri.joinPath(this.context.extensionUri, ...pathList))
 	}
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -57,7 +57,7 @@ export async function activate(context: vscode.ExtensionContext) {
 	vscode.commands.executeCommand("setContext", "cline.isDevMode", IS_DEV && IS_DEV === "true")
 
 	context.subscriptions.push(
-		vscode.window.registerWebviewViewProvider(WebviewProvider.sideBarId, sidebarWebview, {
+		vscode.window.registerWebviewViewProvider(VscodeWebviewProvider.SIDEBAR_ID, sidebarWebview, {
 			webviewOptions: { retainContextWhenHidden: true },
 		}),
 	)
@@ -119,7 +119,7 @@ export async function activate(context: vscode.ExtensionContext) {
 		Logger.log("Opening Cline in new tab")
 		// (this example uses webviewProvider activation event which is necessary to deserialize cached webview, but since we use retainContextWhenHidden, we don't need to use that event)
 		// https://github.com/microsoft/vscode-extension-samples/blob/main/webview-sample/src/extension.ts
-		const tabWebview = HostProvider.get().createWebviewProvider(WebviewProviderType.TAB)
+		const tabWebview = HostProvider.get().createWebviewProvider(WebviewProviderType.TAB) as VscodeWebviewProvider
 		//const column = vscode.window.activeTextEditor ? vscode.window.activeTextEditor.viewColumn : undefined
 		const lastCol = Math.max(...vscode.window.visibleTextEditors.map((editor) => editor.viewColumn || 0))
 
@@ -130,7 +130,7 @@ export async function activate(context: vscode.ExtensionContext) {
 		}
 		const targetCol = hasVisibleEditors ? Math.max(lastCol + 1, 1) : vscode.ViewColumn.Two
 
-		const panel = vscode.window.createWebviewPanel(WebviewProvider.tabPanelId, "Cline", targetCol, {
+		const panel = vscode.window.createWebviewPanel(VscodeWebviewProvider.TAB_PANEL_ID, "Cline", targetCol, {
 			enableScripts: true,
 			retainContextWhenHidden: true,
 			localResourceRoots: [context.extensionUri],
@@ -501,7 +501,7 @@ export async function activate(context: vscode.ExtensionContext) {
 	context.subscriptions.push(
 		vscode.commands.registerCommand("cline.focusChatInput", async () => {
 			// Fast path: check for existing active instance
-			let activeWebview = WebviewProvider.getLastActiveInstance()
+			let activeWebview = WebviewProvider.getLastActiveInstance() as VscodeWebviewProvider
 
 			if (activeWebview) {
 				// Instance exists - just reveal and focus it
@@ -518,7 +518,7 @@ export async function activate(context: vscode.ExtensionContext) {
 				WebviewProvider.setLastActiveControllerId(null)
 
 				// Check for existing tab instances first (cheaper than focusing sidebar)
-				const tabInstances = WebviewProvider.getTabInstances()
+				const tabInstances = WebviewProvider.getTabInstances() as VscodeWebviewProvider[]
 				if (tabInstances.length > 0) {
 					activeWebview = tabInstances[tabInstances.length - 1]
 				} else {
@@ -527,8 +527,11 @@ export async function activate(context: vscode.ExtensionContext) {
 
 					// Small delay for focus to complete
 					await new Promise((resolve) => setTimeout(resolve, 200))
-					// Last resort: create new tab
-					activeWebview = WebviewProvider.getSidebarInstance() || (await openClineInNewTab())
+					activeWebview = WebviewProvider.getSidebarInstance() as VscodeWebviewProvider
+					if (!activeWebview) {
+						// Last resort: create new tab
+						activeWebview = (await openClineInNewTab()) as VscodeWebviewProvider
+					}
 				}
 			}
 

--- a/src/hosts/external/ExternalWebviewProvider.ts
+++ b/src/hosts/external/ExternalWebviewProvider.ts
@@ -23,7 +23,7 @@ export class ExternalWebviewProvider extends WebviewProvider {
 	override isVisible() {
 		return true
 	}
-	protected override isActive(): Boolean {
+	protected override isActive(): boolean {
 		return true
 	}
 }

--- a/src/hosts/external/ExternalWebviewProvider.ts
+++ b/src/hosts/external/ExternalWebviewProvider.ts
@@ -23,11 +23,7 @@ export class ExternalWebviewProvider extends WebviewProvider {
 	override isVisible() {
 		return true
 	}
-	override getWebview() {
-		return {}
-	}
-
-	override resolveWebviewView(_: any): Promise<void> {
-		return Promise.resolve()
+	protected override isActive(): Boolean {
+		return true
 	}
 }


### PR DESCRIPTION
Now that the extension and cline-core setup code paths has been separated,
the Vscode specific parts of the webview can be moved into the
Vscode webview provider, and removed from the parent class and
the ExternalWebviewProvider.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Refactor to move VSCode-specific logic from `WebviewProvider` to `VscodeWebviewProvider`, updating references and improving modularity.
> 
>   - **Refactoring**:
>     - Move VSCode-specific constants `sideBarId` and `tabPanelId` from `WebviewProvider` to `VscodeWebviewProvider`.
>     - Remove `resolveWebviewView()` and `getWebview()` from `WebviewProvider`.
>     - Implement `isActive()` in `VscodeWebviewProvider` and `ExternalWebviewProvider`.
>   - **Code Updates**:
>     - Update `extension.ts` to use `VscodeWebviewProvider.SIDEBAR_ID` and `VscodeWebviewProvider.TAB_PANEL_ID`.
>     - Cast instances to `VscodeWebviewProvider` in `extension.ts` where necessary.
>   - **Misc**:
>     - Remove unused code and comments from `WebviewProvider`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for a3e1a225e2b99f9a0a33102a7259e5dcc6569e64. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->