### PR TITLE
In the log timestamp use current timezone instead of UTC

### DIFF
--- a/src/standalone/utils.ts
+++ b/src/standalone/utils.ts
@@ -4,7 +4,17 @@ import * as health from "grpc-health-check"
 import { StreamingCallbacks } from "@/hosts/host-provider-types"
 
 const log = (...args: unknown[]) => {
-	const timestamp = new Date().toISOString()
+	const now = new Date()
+	const year = now.getFullYear()
+	const month = String(now.getMonth() + 1).padStart(2, "0")
+	const day = String(now.getDate()).padStart(2, "0")
+	const hours = String(now.getHours()).padStart(2, "0")
+	const minutes = String(now.getMinutes()).padStart(2, "0")
+	const seconds = String(now.getSeconds()).padStart(2, "0")
+	const milliseconds = String(now.getMilliseconds()).padStart(3, "0")
+
+	const timestamp = `${year}-${month}-${day}T${hours}:${minutes}:${seconds}.${milliseconds}`
+
 	console.log(`[${timestamp}]`, "#bot.cline.server.ts", ...args)
 }
 


### PR DESCRIPTION
The ISO date format logs in UTC with the timezone information, this is unneccessary,
just log the time in the current timezone- this is what the other external platform logs are doing.