### PR TITLE
Fix the PATH not being set in the standalone terminal

### DIFF
--- a/standalone/runtime-files/vscode/enhanced-terminal.js
+++ b/standalone/runtime-files/vscode/enhanced-terminal.js
@@ -195,7 +195,8 @@ class StandaloneTerminalProcess extends EventEmitter {
 				return ["/c", command]
 			}
 		} else {
-			return ["-c", command]
+			// Use -l for login shell, -c for command
+			return ["-l", "-c", command]
 		}
 	}
 


### PR DESCRIPTION
`cline-core` cannot depend on its environment being set up properly
by the parent process. Run the terminal commands in a login shell so
that the PATH etc. will be setup correctly.

`-l` is the command flag for bash, zsh, dash and ksh.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `-l` option to `getShellArgs()` in `enhanced-terminal.js` to run commands in a login shell, ensuring environment variables are set correctly.
> 
>   - **Behavior**:
>     - Modify `getShellArgs()` in `enhanced-terminal.js` to include `-l` for login shell, ensuring environment variables like PATH are set correctly.
>   - **Misc**:
>     - Add comment in `getShellArgs()` explaining the use of `-l` and `-c` options.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 40aa05f49e001bfd8bab5d60fa2a96d3965ab804. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->