### PR TITLE
Refactoring: Move the FileDiagnostics from the `host` package into common.

### DIFF
--- a/proto/cline/common.proto
+++ b/proto/cline/common.proto
@@ -73,3 +73,32 @@ message KeyValuePair {
   string key = 1;
   string value = 2;
 }
+
+message FileDiagnostics {
+  string file_path = 1;
+  repeated Diagnostic diagnostics = 2;
+}
+
+message Diagnostic {
+  string message = 1;
+  DiagnosticRange range = 2;
+  DiagnosticSeverity severity = 3;
+  optional string source = 4;
+}
+
+message DiagnosticRange {
+  DiagnosticPosition start = 1;
+  DiagnosticPosition end = 2;
+}
+
+message DiagnosticPosition {
+  int32 line = 1;
+  int32 character = 2;
+}
+
+enum DiagnosticSeverity {
+  DIAGNOSTIC_ERROR = 0;
+  DIAGNOSTIC_WARNING = 1;
+  DIAGNOSTIC_INFORMATION = 2;
+  DIAGNOSTIC_HINT = 3;
+}

--- a/proto/host/workspace.proto
+++ b/proto/host/workspace.proto
@@ -44,34 +44,5 @@ message GetDiagnosticsRequest {
 }
 
 message GetDiagnosticsResponse {
-  repeated FileDiagnostics file_diagnostics = 1;
-}
-
-message FileDiagnostics {
-  string file_path = 1;
-  repeated Diagnostic diagnostics = 2;
-}
-
-message Diagnostic {
-  string message = 1;
-  DiagnosticRange range = 2;
-  DiagnosticSeverity severity = 3;
-  optional string source = 4;
-}
-
-message DiagnosticRange {
-  DiagnosticPosition start = 1;
-  DiagnosticPosition end = 2;
-}
-
-message DiagnosticPosition {
-  int32 line = 1;
-  int32 character = 2;
-}
-
-enum DiagnosticSeverity {
-  DIAGNOSTIC_ERROR = 0;
-  DIAGNOSTIC_WARNING = 1;
-  DIAGNOSTIC_INFORMATION = 2;
-  DIAGNOSTIC_HINT = 3;
+  repeated cline.FileDiagnostics file_diagnostics = 1;
 }

--- a/src/core/mentions/index.ts
+++ b/src/core/mentions/index.ts
@@ -15,7 +15,7 @@ import { openExternal } from "@utils/env"
 import { HostProvider } from "@/hosts/host-provider"
 import { ShowMessageType } from "@/shared/proto/host/window"
 import { diagnosticsToProblemsString } from "@integrations/diagnostics"
-import { DiagnosticSeverity } from "@/shared/proto/index.host"
+import { DiagnosticSeverity } from "@/shared/proto/index.cline"
 
 export async function openMention(mention?: string): Promise<void> {
 	if (!mention) {

--- a/src/hosts/vscode/hostbridge/workspace/getDiagnostics.ts
+++ b/src/hosts/vscode/hostbridge/workspace/getDiagnostics.ts
@@ -1,13 +1,6 @@
+import { GetDiagnosticsRequest, GetDiagnosticsResponse } from "@/shared/proto/host/workspace"
+import { Diagnostic, DiagnosticPosition, DiagnosticRange, DiagnosticSeverity, FileDiagnostics } from "@/shared/proto/index.cline"
 import * as vscode from "vscode"
-import {
-	GetDiagnosticsRequest,
-	GetDiagnosticsResponse,
-	FileDiagnostics,
-	Diagnostic,
-	DiagnosticRange,
-	DiagnosticPosition,
-	DiagnosticSeverity,
-} from "@/shared/proto/host/workspace"
 
 export async function getDiagnostics(request: GetDiagnosticsRequest): Promise<GetDiagnosticsResponse> {
 	// Get all diagnostics from VS Code

--- a/src/integrations/diagnostics/__tests__/index.test.ts
+++ b/src/integrations/diagnostics/__tests__/index.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, beforeEach } from "mocha"
 import { expect } from "chai"
 import { getNewDiagnostics, diagnosticsToProblemsString } from "../"
-import { DiagnosticSeverity, FileDiagnostics } from "@shared/proto/index.host"
+import { DiagnosticSeverity, FileDiagnostics } from "@shared/proto/index.cline"
 import * as sinon from "sinon"
 import * as pathUtils from "@/utils/path"
 

--- a/src/integrations/diagnostics/index.ts
+++ b/src/integrations/diagnostics/index.ts
@@ -1,7 +1,7 @@
 import * as path from "path"
 import deepEqual from "fast-deep-equal"
 import { getCwd } from "@/utils/path"
-import { Diagnostic, DiagnosticSeverity, FileDiagnostics } from "@/shared/proto/index.host"
+import { Diagnostic, DiagnosticSeverity, FileDiagnostics } from "@/shared/proto/index.cline"
 
 export function getNewDiagnostics(oldDiagnostics: FileDiagnostics[], newDiagnostics: FileDiagnostics[]): FileDiagnostics[] {
 	const oldMap = new Map<string, Diagnostic[]>()

--- a/src/integrations/editor/DiffViewProvider.ts
+++ b/src/integrations/editor/DiffViewProvider.ts
@@ -7,7 +7,7 @@ import * as diff from "diff"
 import { detectEncoding } from "../misc/extract-text"
 import * as iconv from "iconv-lite"
 import { HostProvider } from "@/hosts/host-provider"
-import { DiagnosticSeverity, FileDiagnostics } from "@/shared/proto/index.host"
+import { DiagnosticSeverity, FileDiagnostics } from "@/shared/proto/index.cline"
 import { diagnosticsToProblemsString, getNewDiagnostics } from "@/integrations/diagnostics"
 
 export abstract class DiffViewProvider {


### PR DESCRIPTION
I am going to reuse the FileDiagnostics in the ProtoBus, so move them into a common location.

Update the imports.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Move `FileDiagnostics` and related messages to `common.proto` for reuse, updating imports and references.
> 
>   - **Refactoring**:
>     - Move `FileDiagnostics`, `Diagnostic`, `DiagnosticRange`, `DiagnosticPosition`, and `DiagnosticSeverity` from `proto/host/workspace.proto` to `proto/cline/common.proto`.
>   - **Imports**:
>     - Update imports in `getDiagnostics.ts`, `index.ts`, `DiffViewProvider.ts`, and `index.test.ts` to use `proto/index.cline` instead of `proto/index.host`.
>   - **Misc**:
>     - Update `GetDiagnosticsResponse` in `workspace.proto` to use `cline.FileDiagnostics`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for eac4729d2f4209706f2068c9f92d50d0a78d0847. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->