### PR TITLE
Refactoring: Add util functions for working with Diagnostics for a single file.

### DIFF
--- a/src/hosts/vscode/hostbridge/workspace/getDiagnostics.test.ts
+++ b/src/hosts/vscode/hostbridge/workspace/getDiagnostics.test.ts
@@ -1,0 +1,197 @@
+import { describe, it } from "mocha"
+import { expect } from "chai"
+import * as vscode from "vscode"
+import { convertToFileDiagnostics, convertVscodeDiagnostics } from "./getDiagnostics"
+import { DiagnosticSeverity } from "@/shared/proto/index.cline"
+
+describe("getDiagnostics conversion functions", () => {
+	describe("convertToFileDiagnostics", () => {
+		it("should return empty array when no diagnostics are provided", () => {
+			const vscodeDiagnostics: [vscode.Uri, vscode.Diagnostic[]][] = []
+
+			const result = convertToFileDiagnostics(vscodeDiagnostics)
+
+			expect(result).to.deep.equal([])
+		})
+
+		it("should skip files with empty diagnostics arrays", () => {
+			const vscodeDiagnostics: [vscode.Uri, vscode.Diagnostic[]][] = [
+				[vscode.Uri.file("/path/to/file1.ts"), []],
+				[
+					vscode.Uri.file("/path/to/file2.ts"),
+					[new vscode.Diagnostic(new vscode.Range(0, 0, 0, 10), "Error message", vscode.DiagnosticSeverity.Error)],
+				],
+			]
+
+			const result = convertToFileDiagnostics(vscodeDiagnostics)
+
+			expect(result).to.deep.equal([
+				{
+					filePath: "/path/to/file2.ts",
+					diagnostics: [
+						{
+							message: "Error message",
+							range: {
+								start: { line: 0, character: 0 },
+								end: { line: 0, character: 10 },
+							},
+							severity: DiagnosticSeverity.DIAGNOSTIC_ERROR,
+							source: undefined,
+						},
+					],
+				},
+			])
+		})
+
+		it("should convert multiple files with diagnostics", () => {
+			const vscodeDiagnostics: [vscode.Uri, vscode.Diagnostic[]][] = [
+				[
+					vscode.Uri.file("/path/to/file1.ts"),
+					[new vscode.Diagnostic(new vscode.Range(0, 0, 0, 10), "Error in file1", vscode.DiagnosticSeverity.Error)],
+				],
+				[
+					vscode.Uri.file("/path/to/file2.ts"),
+					[new vscode.Diagnostic(new vscode.Range(5, 5, 5, 15), "Warning in file2", vscode.DiagnosticSeverity.Warning)],
+				],
+			]
+
+			const result = convertToFileDiagnostics(vscodeDiagnostics)
+
+			expect(result).to.deep.equal([
+				{
+					filePath: "/path/to/file1.ts",
+					diagnostics: [
+						{
+							message: "Error in file1",
+							range: {
+								start: { line: 0, character: 0 },
+								end: { line: 0, character: 10 },
+							},
+							severity: DiagnosticSeverity.DIAGNOSTIC_ERROR,
+							source: undefined,
+						},
+					],
+				},
+				{
+					filePath: "/path/to/file2.ts",
+					diagnostics: [
+						{
+							message: "Warning in file2",
+							range: {
+								start: { line: 5, character: 5 },
+								end: { line: 5, character: 15 },
+							},
+							severity: DiagnosticSeverity.DIAGNOSTIC_WARNING,
+							source: undefined,
+						},
+					],
+				},
+			])
+		})
+	})
+
+	describe("convertVscodeDiagnostics", () => {
+		it("should convert empty array", () => {
+			const vscodeDiagnostics: vscode.Diagnostic[] = []
+
+			const result = convertVscodeDiagnostics(vscodeDiagnostics)
+
+			expect(result).to.deep.equal([])
+		})
+
+		it("should convert error diagnostic with source", () => {
+			const vscodeDiagnostic = new vscode.Diagnostic(
+				new vscode.Range(10, 5, 10, 20),
+				"Type error",
+				vscode.DiagnosticSeverity.Error,
+			)
+			vscodeDiagnostic.source = "typescript"
+
+			const result = convertVscodeDiagnostics([vscodeDiagnostic])
+
+			expect(result).to.deep.equal([
+				{
+					message: "Type error",
+					range: {
+						start: { line: 10, character: 5 },
+						end: { line: 10, character: 20 },
+					},
+					severity: DiagnosticSeverity.DIAGNOSTIC_ERROR,
+					source: "typescript",
+				},
+			])
+		})
+
+		it("should convert all severity types correctly", () => {
+			const diagnostics = [
+				new vscode.Diagnostic(new vscode.Range(0, 0, 0, 10), "Error", vscode.DiagnosticSeverity.Error),
+				new vscode.Diagnostic(new vscode.Range(1, 0, 1, 10), "Warning", vscode.DiagnosticSeverity.Warning),
+				new vscode.Diagnostic(new vscode.Range(2, 0, 2, 10), "Information", vscode.DiagnosticSeverity.Information),
+				new vscode.Diagnostic(new vscode.Range(3, 0, 3, 10), "Hint", vscode.DiagnosticSeverity.Hint),
+			]
+
+			const result = convertVscodeDiagnostics(diagnostics)
+
+			expect(result).to.deep.equal([
+				{
+					message: "Error",
+					range: {
+						start: { line: 0, character: 0 },
+						end: { line: 0, character: 10 },
+					},
+					severity: DiagnosticSeverity.DIAGNOSTIC_ERROR,
+					source: undefined,
+				},
+				{
+					message: "Warning",
+					range: {
+						start: { line: 1, character: 0 },
+						end: { line: 1, character: 10 },
+					},
+					severity: DiagnosticSeverity.DIAGNOSTIC_WARNING,
+					source: undefined,
+				},
+				{
+					message: "Information",
+					range: {
+						start: { line: 2, character: 0 },
+						end: { line: 2, character: 10 },
+					},
+					severity: DiagnosticSeverity.DIAGNOSTIC_INFORMATION,
+					source: undefined,
+				},
+				{
+					message: "Hint",
+					range: {
+						start: { line: 3, character: 0 },
+						end: { line: 3, character: 10 },
+					},
+					severity: DiagnosticSeverity.DIAGNOSTIC_HINT,
+					source: undefined,
+				},
+			])
+		})
+
+		it("should handle diagnostic without source", () => {
+			const vscodeDiagnostic = new vscode.Diagnostic(
+				new vscode.Range(0, 0, 0, 10),
+				"Simple error",
+				vscode.DiagnosticSeverity.Error,
+			)
+
+			const result = convertVscodeDiagnostics([vscodeDiagnostic])
+
+			expect(result).to.deep.equal([
+				{
+					message: "Simple error",
+					range: {
+						start: { line: 0, character: 0 },
+						end: { line: 0, character: 10 },
+					},
+					severity: DiagnosticSeverity.DIAGNOSTIC_ERROR,
+					source: undefined,
+				},
+			])
+		})
+	})
+})

--- a/src/hosts/vscode/hostbridge/workspace/getDiagnostics.ts
+++ b/src/hosts/vscode/hostbridge/workspace/getDiagnostics.ts
@@ -2,61 +2,65 @@ import { GetDiagnosticsRequest, GetDiagnosticsResponse } from "@/shared/proto/ho
 import { Diagnostic, DiagnosticPosition, DiagnosticRange, DiagnosticSeverity, FileDiagnostics } from "@/shared/proto/index.cline"
 import * as vscode from "vscode"
 
-export async function getDiagnostics(request: GetDiagnosticsRequest): Promise<GetDiagnosticsResponse> {
+export async function getDiagnostics(_request: GetDiagnosticsRequest): Promise<GetDiagnosticsResponse> {
 	// Get all diagnostics from VS Code
 	const vscodeAllDiagnostics = vscode.languages.getDiagnostics()
 
-	const fileDiagnostics: FileDiagnostics[] = []
+	const fileDiagnostics = convertToFileDiagnostics(vscodeAllDiagnostics)
 
+	return { fileDiagnostics }
+}
+
+export function convertToFileDiagnostics(vscodeAllDiagnostics: [vscode.Uri, vscode.Diagnostic[]][]): FileDiagnostics[] {
+	const result = []
 	for (const [uri, diagnostics] of vscodeAllDiagnostics) {
 		if (diagnostics.length > 0) {
-			const convertedDiagnostics: Diagnostic[] = diagnostics.map((vsDiagnostic) => {
-				// Convert VS Code severity to proto severity
-				let severity: DiagnosticSeverity
-				switch (vsDiagnostic.severity) {
-					case vscode.DiagnosticSeverity.Error:
-						severity = DiagnosticSeverity.DIAGNOSTIC_ERROR
-						break
-					case vscode.DiagnosticSeverity.Warning:
-						severity = DiagnosticSeverity.DIAGNOSTIC_WARNING
-						break
-					case vscode.DiagnosticSeverity.Information:
-						severity = DiagnosticSeverity.DIAGNOSTIC_INFORMATION
-						break
-					case vscode.DiagnosticSeverity.Hint:
-						severity = DiagnosticSeverity.DIAGNOSTIC_HINT
-						break
-					default:
-						severity = DiagnosticSeverity.DIAGNOSTIC_ERROR
-				}
-
-				return Diagnostic.create({
-					message: vsDiagnostic.message,
-					range: DiagnosticRange.create({
-						start: DiagnosticPosition.create({
-							line: vsDiagnostic.range.start.line,
-							character: vsDiagnostic.range.start.character,
-						}),
-						end: DiagnosticPosition.create({
-							line: vsDiagnostic.range.end.line,
-							character: vsDiagnostic.range.end.character,
-						}),
-					}),
-					severity: severity,
-					source: vsDiagnostic.source || undefined,
-				})
-			})
-
-			fileDiagnostics.push(
+			result.push(
 				FileDiagnostics.create({
 					filePath: uri.fsPath,
-					diagnostics: convertedDiagnostics,
+					diagnostics: convertVscodeDiagnostics(diagnostics),
 				}),
 			)
 		}
 	}
+	return result
+}
 
-	return GetDiagnosticsResponse.create({
-		fileDiagnostics: fileDiagnostics,
-	})
+export function convertVscodeDiagnostics(vscodeDiagnostics: vscode.Diagnostic[]): Diagnostic[] {
+	return vscodeDiagnostics.map(convertVscodeDiagnostic)
+}
+
+function convertVscodeDiagnostic(vscodeDiagnostic: vscode.Diagnostic): Diagnostic {
+	return {
+		message: vscodeDiagnostic.message,
+		range: {
+			start: {
+				line: vscodeDiagnostic.range.start.line,
+				character: vscodeDiagnostic.range.start.character,
+			},
+			end: {
+				line: vscodeDiagnostic.range.end.line,
+				character: vscodeDiagnostic.range.end.character,
+			},
+		},
+		severity: convertSeverity(vscodeDiagnostic.severity),
+		source: vscodeDiagnostic.source,
+	}
+}
+
+// Convert VS Code severity to proto severity
+function convertSeverity(vscodeSeverity: vscode.DiagnosticSeverity): DiagnosticSeverity {
+	switch (vscodeSeverity) {
+		case vscode.DiagnosticSeverity.Error:
+			return DiagnosticSeverity.DIAGNOSTIC_ERROR
+		case vscode.DiagnosticSeverity.Warning:
+			return DiagnosticSeverity.DIAGNOSTIC_WARNING
+		case vscode.DiagnosticSeverity.Information:
+			return DiagnosticSeverity.DIAGNOSTIC_INFORMATION
+		case vscode.DiagnosticSeverity.Hint:
+			return DiagnosticSeverity.DIAGNOSTIC_HINT
+		default:
+			console.warn("Unhandled vscode severity", vscodeSeverity)
+			return DiagnosticSeverity.DIAGNOSTIC_ERROR
+	}
 }

--- a/src/integrations/diagnostics/__tests__/index.test.ts
+++ b/src/integrations/diagnostics/__tests__/index.test.ts
@@ -460,5 +460,55 @@ describe("Diagnostics Tests", () => {
 			// Line 0 should be displayed as Line 1 (1-indexed)
 			expect(result).to.equal("src/file1.ts\n- [Error] Line 1: Error on first line")
 		})
+
+		it("should include all diagnostics when severities is undefined", async () => {
+			const diagnostics: FileDiagnostics[] = [
+				{
+					filePath: "/workspace/src/file1.ts",
+					diagnostics: [
+						{
+							severity: DiagnosticSeverity.DIAGNOSTIC_ERROR,
+							message: "Error message",
+							range: {
+								start: { line: 0, character: 0 },
+								end: { line: 0, character: 10 },
+							},
+						},
+						{
+							severity: DiagnosticSeverity.DIAGNOSTIC_WARNING,
+							message: "Warning message",
+							range: {
+								start: { line: 1, character: 0 },
+								end: { line: 1, character: 10 },
+							},
+						},
+						{
+							severity: DiagnosticSeverity.DIAGNOSTIC_INFORMATION,
+							message: "Info message",
+							range: {
+								start: { line: 2, character: 0 },
+								end: { line: 2, character: 10 },
+							},
+						},
+						{
+							severity: DiagnosticSeverity.DIAGNOSTIC_HINT,
+							message: "Hint message",
+							range: {
+								start: { line: 3, character: 0 },
+								end: { line: 3, character: 10 },
+							},
+						},
+					],
+				},
+			]
+
+			// Call without severities parameter (undefined)
+			const result = await diagnosticsToProblemsString(diagnostics)
+
+			// Should include all diagnostics regardless of severity
+			expect(result).to.equal(
+				"src/file1.ts\n- [Error] Line 1: Error message\n- [Warning] Line 2: Warning message\n- [Information] Line 3: Info message\n- [Hint] Line 4: Hint message",
+			)
+		})
 	})
 })

--- a/src/integrations/diagnostics/index.ts
+++ b/src/integrations/diagnostics/index.ts
@@ -27,28 +27,36 @@ export function getNewDiagnostics(oldDiagnostics: FileDiagnostics[], newDiagnost
 // will return empty string if no problems with the given severity are found
 export async function diagnosticsToProblemsString(
 	diagnostics: FileDiagnostics[],
-	severities: DiagnosticSeverity[],
+	severities?: DiagnosticSeverity[],
 ): Promise<string> {
-	const cwd = await getCwd()
-	let result = ""
+	let results = []
 	for (const fileDiagnostics of diagnostics) {
-		const problems = fileDiagnostics.diagnostics.filter((d) => severities.includes(d.severity))
-
-		if (problems.length > 0) {
-			const filePath = path.relative(cwd, fileDiagnostics.filePath).toPosix()
-			result += `\n\n${filePath}`
-
-			for (const diagnostic of problems) {
-				const label = severityToString(diagnostic.severity)
-				// Lines are 0-indexed
-				const line = diagnostic.range?.start ? `${diagnostic.range.start.line + 1}` : ""
-
-				const source = diagnostic.source ? `${diagnostic.source} ` : ""
-				result += `\n- [${source}${label}] Line ${line}: ${diagnostic.message}`
-			}
+		const problems = fileDiagnostics.diagnostics.filter((d) => !severities || severities.includes(d.severity))
+		const problemString = await singleFileDiagnosticsToProblemsString(fileDiagnostics.filePath, problems)
+		if (problemString) {
+			results.push(problemString)
 		}
 	}
-	return result.trim()
+	return results.join("\n\n")
+}
+
+export async function singleFileDiagnosticsToProblemsString(filePath: string, diagnostics: Diagnostic[]): Promise<string> {
+	if (!diagnostics.length) {
+		return ""
+	}
+	const cwd = await getCwd()
+	const relPath = path.relative(cwd, filePath).toPosix()
+	let result = `${relPath}`
+
+	for (const diagnostic of diagnostics) {
+		const label = severityToString(diagnostic.severity)
+		// Lines are 0-indexed
+		const line = diagnostic.range?.start ? `${diagnostic.range.start.line + 1}` : ""
+
+		const source = diagnostic.source ? `${diagnostic.source} ` : ""
+		result += `\n- [${source}${label}] Line ${line}: ${diagnostic.message}`
+	}
+	return result
 }
 
 function severityToString(severity: DiagnosticSeverity): string {


### PR DESCRIPTION
These utils will be used to build the 'Add to Cline' context menu action for external hosts. The context menu action only deals with diagnostics for a single file, so the current functions need to be adapted slightly.

Export util function for converting vscode diagnostics for a single file to Host Bridge diagnostics.

Export a util for converting diagnostics for a single file from `diagnostics/index.ts`.

Make the severity filter optional for `diagnosticsToProblemsString`.

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Refactor to add utility functions for single file diagnostics conversion and make severity filter optional in `diagnosticsToProblemsString`.
> 
>   - **Utilities**:
>     - Add `convertToFileDiagnostics` and `convertVscodeDiagnostics` in `getDiagnostics.ts` for converting VSCode diagnostics to Host Bridge diagnostics for a single file.
>     - Refactor `getDiagnostics` to use `convertToFileDiagnostics`.
>   - **Functionality**:
>     - Make severity filter optional in `diagnosticsToProblemsString` in `index.ts`.
>   - **Tests**:
>     - Add tests for `convertToFileDiagnostics` and `convertVscodeDiagnostics` in `getDiagnostics.test.ts`.
>     - Add test for optional severity filter in `index.test.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 909616a34014d8f5df0eeaf8cb86dbeb591e996d. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->