### PR TITLE
Update logging

### DIFF
--- a/scripts/runclinecore.sh
+++ b/scripts/runclinecore.sh
@@ -1,10 +1,12 @@
 #!/usr/bin/env bash
 set -eu #x
+
 # This installs the cline-core app to the user's home directory,
 # and starts the service.
 
 CORE_DIR=~/.cline/core
 INSTALL_DIR=$CORE_DIR/0.0.1
+LOG_FILE=~/.cline/cline-core-service.log
 
 ZIP_FILE=standalone.zip
 ZIP=dist-standalone/${ZIP_FILE}
@@ -18,4 +20,5 @@ cd $INSTALL_DIR
 unp $ZIP_FILE > /dev/null
 
 pkill -f cline-core.js || true
-NODE_PATH=./node_modules DEV_WORKSPACE_FOLDER=/tmp/ node cline-core.js
+
+NODE_PATH=./node_modules DEV_WORKSPACE_FOLDER=/tmp/ node cline-core.js 2>&1 | tee $LOG_FILE

--- a/src/standalone/protobus-service.ts
+++ b/src/standalone/protobus-service.ts
@@ -31,11 +31,11 @@ export function startProtobusService(controller: Controller) {
 	const host = process.env.PROTOBUS_ADDRESS || `127.0.0.1:${PROTOBUS_PORT}`
 	server.bindAsync(host, grpc.ServerCredentials.createInsecure(), (err) => {
 		if (err) {
-			log(`Error: Failed to bind to ${host}, port may be unavailable. ${err.message}`)
+			log(`Could not start ProtoBus service: Failed to bind to ${host}, port may be unavailable. ${err.message}`)
 			process.exit(1)
 		}
 		server.start()
-		log(`gRPC server listening on ${host}`)
+		log(`ProtoBus gRPC server listening on ${host}`)
 	})
 }
 
@@ -64,11 +64,11 @@ function wrapHandler<TRequest, TResponse>(
 ): grpc.handleUnaryCall<TRequest, TResponse> {
 	return async (call: grpc.ServerUnaryCall<TRequest, TResponse>, callback: grpc.sendUnaryData<TResponse>) => {
 		try {
-			log(`gRPC request: ${call.getPath()}`)
+			log(`ProtoBus request: ${call.getPath()}`)
 			const result = await handler(controller, call.request)
 			callback(null, result)
 		} catch (err: any) {
-			log(`gRPC handler error: ${call.getPath()}\n${err.stack}`)
+			log(`ProtoBus handler error: ${call.getPath()}\n${err.stack}`)
 			callback({
 				code: grpc.status.INTERNAL,
 				message: err.message || "Internal error",
@@ -84,14 +84,14 @@ function wrapStreamingResponseHandler<TRequest, TResponse>(
 	return async (call: grpc.ServerWritableStream<TRequest, TResponse>) => {
 		try {
 			const requestId = call.metadata.get("request-id").pop()?.toString()
-			log(`gRPC streaming request: ${call.getPath()}`)
+			log(`ProtoBus gRPC streaming request: ${call.getPath()}`)
 
 			const responseHandler: StreamingResponseHandler<TResponse> = (response, isLast, sequenceNumber) => {
 				try {
 					call.write(response) // Use a bound version of call.write to maintain proper 'this' context
 
 					if (isLast === true) {
-						log(`Closing stream for ${requestId}`)
+						log(`Closing ProtoBus stream for ${requestId}`)
 						call.end()
 					}
 					return Promise.resolve()
@@ -101,7 +101,7 @@ function wrapStreamingResponseHandler<TRequest, TResponse>(
 			}
 			await handler(controller, call.request, responseHandler, requestId)
 		} catch (err: any) {
-			log(`gRPC handler error: ${call.getPath()}\n${err.stack}`)
+			log(`ProtoBus handler error: ${call.getPath()}\n${err.stack}`)
 			call.destroy({
 				code: grpc.status.INTERNAL,
 				message: err.message || "Internal error",


### PR DESCRIPTION
Update logs for the protobus service in cline-core.
Save the logs from the script `runclinecore.sh` to the ~/.cline directory
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Update ProtoBus service logging and redirect script output to a log file.
> 
>   - **Logging Updates**:
>     - In `protobus-service.ts`, update log messages to include "ProtoBus" for clarity in `startProtobusService()`, `wrapHandler()`, and `wrapStreamingResponseHandler()`.
>   - **Script Changes**:
>     - In `runclinecore.sh`, redirect output of `cline-core.js` to `~/.cline/cline-core-service.log` using `tee` for logging.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 846b1671c17c9a5ad874adfc23dada75116864a4. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->