### PR TITLE
Fix: Enable send button after streaming task_progress

### DIFF
--- a/webview-ui/src/components/chat/ChatView.tsx
+++ b/webview-ui/src/components/chat/ChatView.tsx
@@ -89,6 +89,7 @@ const ChatView = ({ isHidden, showAnnouncement, hideAnnouncement, showHistoryVie
 		expandedRows,
 		setExpandedRows,
 		textAreaRef,
+		setSendingDisabled,
 	} = chatState
 
 	useEffect(() => {
@@ -177,7 +178,12 @@ const ChatView = ({ isHidden, showAnnouncement, hideAnnouncement, showHistoryVie
 			document.removeEventListener("copy", handleCopy)
 		}
 	}, [])
-	// Button state is now managed by useButtonState hook
+	// Enable sending button when we stopped streaming
+	useEffect(() => {
+		if (task?.partial !== true) {
+			setSendingDisabled(false)
+		}
+	}, [task?.partial, setSendingDisabled])
 
 	useEffect(() => {
 		setExpandedRows({})
@@ -199,12 +205,7 @@ const ChatView = ({ isHidden, showAnnouncement, hideAnnouncement, showHistoryVie
 					value: selectedModelInfo.supportsImages,
 				}),
 			)
-			if (
-				response &&
-				response.values1 &&
-				response.values2 &&
-				(response.values1.length > 0 || response.values2.length > 0)
-			) {
+			if (response?.values1.length > 0 || response?.values2.length > 0) {
 				const currentTotal = selectedImages.length + selectedFiles.length
 				const availableSlots = MAX_IMAGES_AND_FILES_PER_MESSAGE - currentTotal
 

--- a/webview-ui/src/components/chat/chat-view/components/layout/ActionButtons.tsx
+++ b/webview-ui/src/components/chat/chat-view/components/layout/ActionButtons.tsx
@@ -33,7 +33,7 @@ export const ActionButtons: React.FC<ActionButtonsProps> = ({
 	const { inputValue, selectedImages, selectedFiles, setSendingDisabled } = chatState
 
 	const isStreaming = useMemo(() => task?.partial === true, [task])
-	const [buttonConfig, setButtonConfig] = useState<ButtonConfig | undefined>(undefined)
+	const [buttonConfig, setButtonConfig] = useState<ButtonConfig>(BUTTON_CONFIGS.default)
 
 	const [lastMessage, secondLastMessage] = useMemo(() => {
 		return [messages.at(-1), messages.at(-2)]

--- a/webview-ui/src/components/chat/chat-view/hooks/useChatState.ts
+++ b/webview-ui/src/components/chat/chat-view/hooks/useChatState.ts
@@ -24,13 +24,21 @@ export function useChatState(messages: ClineMessage[]): ChatState {
 	// Refs
 	const textAreaRef = useRef<HTMLTextAreaElement>(null)
 
+	// Filter out task_progress messages for message state handling. This fixes a bug where task_progress updates would interrupt cline asks like plan_mode_respond.
+	/*
+	Whenever we use a cline ask, the extension and webview are put into a state that await user input before proceeding. Before progress list updates, we would never create cline says during or after a cline ask before the user has the chance to give input to the ask. But with progress list updates, which are sent as a cline say during or after a potential cline ask -- we need to make sure the webview is aware we're still waiting for the ask's input.
+	*/
+	const nonTaskProgressMessages = useMemo(() => {
+		return messages.filter((message) => message.say !== "task_progress")
+	}, [messages])
+
 	// Derived state
-	const lastMessage = useMemo(() => messages.at(-1), [messages])
-	const secondLastMessage = useMemo(() => messages.at(-2), [messages])
+	const lastMessage = useMemo(() => nonTaskProgressMessages.at(-1), [nonTaskProgressMessages])
+	const secondLastMessage = useMemo(() => nonTaskProgressMessages.at(-2), [nonTaskProgressMessages])
 	const clineAsk = useMemo(() => (lastMessage?.type === "ask" ? lastMessage.ask : undefined), [lastMessage])
 
 	// Clear expanded rows when task changes
-	const task = useMemo(() => messages.at(0), [messages])
+	const task = useMemo(() => nonTaskProgressMessages.at(0), [nonTaskProgressMessages])
 	const clearExpandedRows = useCallback(() => {
 		setExpandedRows({})
 	}, [])

--- a/webview-ui/src/components/chat/chat-view/shared/buttonConfig.test.ts
+++ b/webview-ui/src/components/chat/chat-view/shared/buttonConfig.test.ts
@@ -1,4 +1,4 @@
-import type { ClineMessage } from "@shared/ExtensionMessage"
+import type { ClineAsk, ClineMessage, ClineSay } from "@shared/ExtensionMessage"
 import { describe, expect, it } from "vitest"
 import { BUTTON_CONFIGS, getButtonConfig } from "./buttonConfig"
 
@@ -30,7 +30,7 @@ describe("getButtonConfig", () => {
 			it(`returns correct config for ${errorState}`, () => {
 				const errorMessage: ClineMessage = {
 					type: "ask",
-					ask: errorState as any,
+					ask: errorState as ClineAsk,
 					partial: true,
 					text: "",
 					ts: Date.now(),
@@ -94,29 +94,52 @@ describe("getButtonConfig", () => {
 	})
 
 	// Test other specific ask states
-	describe("Other Ask States", () => {
+	describe("Other States", () => {
 		const stateConfigs = [
-			{ ask: "followup", expectedConfig: "followup" },
-			{ ask: "browser_action_launch", expectedConfig: "browser_action_launch" },
-			{ ask: "use_mcp_server", expectedConfig: "use_mcp_server" },
-			{ ask: "plan_mode_respond", expectedConfig: "plan_mode_respond" },
-			{ ask: "completion_result", expectedConfig: "completion_result" },
-			{ ask: "resume_task", expectedConfig: "resume_task" },
-			{ ask: "resume_completed_task", expectedConfig: "resume_completed_task" },
-			{ ask: "new_task", expectedConfig: "new_task" },
-			{ ask: "condense", expectedConfig: "condense" },
-			{ ask: "report_bug", expectedConfig: "report_bug" },
+			{ ask: "followup", say: undefined, expectedConfig: "followup" },
+			{
+				ask: "browser_action_launch",
+				say: undefined,
+				expectedConfig: "browser_action_launch",
+			},
+			{
+				ask: "use_mcp_server",
+				say: undefined,
+				expectedConfig: "use_mcp_server",
+			},
+			{
+				ask: "plan_mode_respond",
+				say: undefined,
+				expectedConfig: "plan_mode_respond",
+			},
+			{
+				ask: "completion_result",
+				say: undefined,
+				expectedConfig: "completion_result",
+			},
+			{ ask: "resume_task", say: undefined, expectedConfig: "resume_task" },
+			{
+				ask: "resume_completed_task",
+				say: undefined,
+				expectedConfig: "resume_completed_task",
+			},
+			{ ask: "new_task", say: undefined, expectedConfig: "new_task" },
+			{ ask: "condense", say: undefined, expectedConfig: "condense" },
+			{ ask: "report_bug", say: undefined, expectedConfig: "report_bug" },
+			{ ask: undefined, say: "task_progress", expectedConfig: undefined },
 		]
 
-		stateConfigs.forEach(({ ask, expectedConfig }) => {
-			it(`returns ${expectedConfig} config for ${ask} ask`, () => {
+		stateConfigs.forEach(({ ask, say, expectedConfig }) => {
+			it(`returns ${expectedConfig} config for ${ask ?? say} ${ask ? "ask" : "say"}`, () => {
 				const message: ClineMessage = {
-					type: "ask",
-					ask: ask as any,
+					type: ask ? "ask" : "say",
+					ask: ask as ClineAsk | undefined,
+					say: say as ClineSay | undefined,
 					ts: Date.now(),
+					partial: false,
 				}
 				const config = getButtonConfig(message)
-				expect(config).toEqual(BUTTON_CONFIGS[expectedConfig])
+				expect(config).toEqual(expectedConfig ? BUTTON_CONFIGS[expectedConfig] : undefined)
 			})
 		})
 	})

--- a/webview-ui/src/components/chat/chat-view/shared/buttonConfig.test.ts
+++ b/webview-ui/src/components/chat/chat-view/shared/buttonConfig.test.ts
@@ -126,7 +126,7 @@ describe("getButtonConfig", () => {
 			{ ask: "new_task", say: undefined, expectedConfig: "new_task" },
 			{ ask: "condense", say: undefined, expectedConfig: "condense" },
 			{ ask: "report_bug", say: undefined, expectedConfig: "report_bug" },
-			{ ask: undefined, say: "task_progress", expectedConfig: undefined },
+			{ ask: undefined, say: "task_progress", expectedConfig: "default" },
 		]
 
 		stateConfigs.forEach(({ ask, say, expectedConfig }) => {

--- a/webview-ui/src/components/chat/chat-view/shared/buttonConfig.ts
+++ b/webview-ui/src/components/chat/chat-view/shared/buttonConfig.ts
@@ -212,7 +212,7 @@ const errorTypes = ["api_req_failed", "mistake_limit_reached", "auto_approval_ma
  * Determines button configuration based on message type and state
  * This is the single source of truth used by both ActionButtons and useMessageHandlers
  */
-export function getButtonConfig(message: ClineMessage | undefined, _mode: Mode = "act"): ButtonConfig | undefined {
+export function getButtonConfig(message: ClineMessage | undefined, _mode: Mode = "act"): ButtonConfig {
 	if (!message) {
 		return BUTTON_CONFIGS.default
 	}
@@ -293,5 +293,5 @@ export function getButtonConfig(message: ClineMessage | undefined, _mode: Mode =
 		return BUTTON_CONFIGS.api_req_active
 	}
 
-	return isStreaming ? BUTTON_CONFIGS.partial : undefined
+	return isStreaming ? BUTTON_CONFIGS.partial : BUTTON_CONFIGS.default
 }

--- a/webview-ui/src/components/chat/chat-view/shared/buttonConfig.ts
+++ b/webview-ui/src/components/chat/chat-view/shared/buttonConfig.ts
@@ -212,7 +212,7 @@ const errorTypes = ["api_req_failed", "mistake_limit_reached", "auto_approval_ma
  * Determines button configuration based on message type and state
  * This is the single source of truth used by both ActionButtons and useMessageHandlers
  */
-export function getButtonConfig(message: ClineMessage | undefined, _mode: Mode = "act"): ButtonConfig {
+export function getButtonConfig(message: ClineMessage | undefined, _mode: Mode = "act"): ButtonConfig | undefined {
 	if (!message) {
 		return BUTTON_CONFIGS.default
 	}
@@ -293,5 +293,5 @@ export function getButtonConfig(message: ClineMessage | undefined, _mode: Mode =
 		return BUTTON_CONFIGS.api_req_active
 	}
 
-	return BUTTON_CONFIGS.partial
+	return isStreaming ? BUTTON_CONFIGS.partial : undefined
 }


### PR DESCRIPTION
<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- For feature requests: Created a discussion in our Feature Requests discussions board https://github.com/cline/cline/discussions/categories/feature-requests and received approval from core maintainers before implementation
- For all changes: Link the associated issue/discussion in the "Related Issue" section below

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly without prior discussion.

Why this requirement?
We deeply appreciate all community contributions - they are essential to Cline's success! To ensure the best use of everyone's time and maintain project direction, we use our Feature Requests discussions board to gauge community interest and validate feature ideas before implementation begins. This helps us focus development efforts on features that will benefit the most users.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** #XXXX

### Description

<!-- 
Help reviewers understand your changes by making this PR readable and well-organized:

- What problem does this PR solve?
- Why were these changes introduced and what purpose do they serve?
- For larger changes, provide context about your approach and reasoning

Small PRs may need minimal description, but larger changes benefit from explaining where you're coming from. Much of this context can be in the linked issue above, so feel free to reference it rather than repeating everything here.
-->
    
Addresses an issue where the send button remained disabled after a streaming response for task_progress completed.

We did not update Action Buttons to handle task_progress when we introduced it to Cline Message. To avoid this to happen again, decoupled sending button disable state from the action buttons. Now send button is olnly disabled during stream.
    

- The `setSendingDisabled(false)` call was moved to a `useEffect` hook in `ChatView.tsx` that triggers when `task?.partial` is no longer true, ensuring the button is re-enabled once streaming has finished - this state should not be dependent on action buttons states.
- The button configuration logic in `ActionButtons.tsx` was refactored to use a single `buttonConfig` state and improve clarity.

### Test Procedure

<!-- 
Please walk us through your testing approach and thought process. This helps reviewers understand that you've thoroughly considered the impact of your changes:

- How did you test this change?
- What could potentially break and how did you verify it doesn't?
- What existing functionality might be affected and how did you check it still works?
- Why are you confident this is ready for merge?

We're not looking for exhaustive documentation - just evidence that you've thought through the implications of your changes and tested accordingly.
-->
 
https://github.com/user-attachments/assets/3208c2c3-181b-4c17-b201-de69c771bd70

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->
