### PR TITLE
Fix partial plan_mode_respond cline ask being interrupted by task_progress say

### DIFF
--- a/src/core/task/ToolExecutor.ts
+++ b/src/core/task/ToolExecutor.ts
@@ -2100,10 +2100,6 @@ export class ToolExecutor {
 						// Store the number of options for telemetry
 						const options = parsePartialArrayString(optionsRaw || "[]")
 
-						if (!block.partial && this.focusChainSettings.enabled) {
-							await this.updateFCListFromToolResponse(block.params.task_progress)
-						}
-
 						this.taskState.isAwaitingPlanResponse = true
 						let {
 							text,
@@ -2167,6 +2163,10 @@ export class ToolExecutor {
 								formatResponse.toolResult(`<user_message>\n${text}\n</user_message>`, images, fileContentString),
 								block,
 							)
+						}
+
+						if (!block.partial && this.focusChainSettings.enabled) {
+							await this.updateFCListFromToolResponse(block.params.task_progress)
 						}
 
 						//

--- a/src/core/task/index.ts
+++ b/src/core/task/index.ts
@@ -729,9 +729,8 @@ export class Task {
 		let askTs: number
 		if (partial !== undefined) {
 			const clineMessages = this.messageStateHandler.getClineMessages()
-			const lastAskMessageIndex = findLastIndex(clineMessages, (m) => m.type === "ask")
-			const lastMessage = lastAskMessageIndex !== -1 ? clineMessages[lastAskMessageIndex] : undefined
-			const lastMessageIndex = lastAskMessageIndex
+			const lastMessage = clineMessages.at(-1)
+			const lastMessageIndex = clineMessages.length - 1
 
 			const isUpdatingPreviousPartial =
 				lastMessage && lastMessage.partial && lastMessage.type === "ask" && lastMessage.ask === type


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes interruption issue in `plan_mode_respond` by adjusting `updateFCListFromToolResponse` call order in `ToolExecutor.ts` and simplifies message handling in `index.ts`.
> 
>   - **Behavior**:
>     - Fixes interruption issue in `plan_mode_respond` by moving `updateFCListFromToolResponse` call after `ask()` in `ToolExecutor.ts`.
>   - **Message Handling**:
>     - Simplifies retrieval of last message in `ask()` in `index.ts` by using `at(-1)` and `length - 1` instead of `findLastIndex`.
>   - **Misc**:
>     - Removes redundant `updateFCListFromToolResponse` call before `ask()` in `ToolExecutor.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for da880e521f92ad00faa5b24302bd0e4b435dd609. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->