### PR TITLE
fix: attempt_completion command showing twice in chat view when updating progress checklist

### DIFF
--- a/.changeset/heavy-walls-own.md
+++ b/.changeset/heavy-walls-own.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+fix: attempt_completion command showing twice in chat view when updating progress checklist

--- a/src/core/task/ToolExecutor.ts
+++ b/src/core/task/ToolExecutor.ts
@@ -2229,10 +2229,11 @@ export class ToolExecutor {
 							// const secondLastMessage = this.clineMessages.at(-2)
 							// NOTE: we do not want to auto approve a command run as part of the attempt_completion tool
 							if (lastMessage && lastMessage.ask === "command") {
+								// we are not going to stream the attempt_completion's command anymore since we might also need to send out a task_progress message before waiting for the user to approve the command, so the tool call checks everything on the progress check list.
 								// update command
-								await this.ask("command", this.removeClosingTag(block, "command", command), block.partial).catch(
-									() => {},
-								)
+								// await this.ask("command", this.removeClosingTag(block, "command", command), block.partial).catch(
+								// 	() => {},
+								// )
 							} else {
 								// last message is completion_result
 								// we have command string, which means we have the result as well, so finish it (doesn't have to exist yet)
@@ -2245,9 +2246,9 @@ export class ToolExecutor {
 								)
 								await this.saveCheckpoint(true)
 								await addNewChangesFlagToLastCompletionResultMessage()
-								await this.ask("command", this.removeClosingTag(block, "command", command), block.partial).catch(
-									() => {},
-								)
+								// await this.ask("command", this.removeClosingTag(block, "command", command), block.partial).catch(
+								// 	() => {},
+								// )
 							}
 						} else {
 							// no command, still outputting partial result


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Prevents `attempt_completion` command from showing twice in chat by commenting out `ask` calls in `ToolExecutor.ts`.
> 
>   - **Behavior**:
>     - Prevents `attempt_completion` command from showing twice in chat by commenting out `ask` calls in `ToolExecutor.ts`.
>     - Ensures `attempt_completion` tool does not auto-approve commands, allowing task progress messages before user approval.
>   - **Code**:
>     - Comments out `await this.ask("command", ...)` in `ToolExecutor.ts` at lines 2234-2236 and 2249-2251.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 2bd181c94985c9d56b810632911f1b93636a7734. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->