### PR TITLE
fix: attempt_completion showing twice in chat due to partial logic not being handled correctly

### DIFF
--- a/.changeset/orange-beds-itch.md
+++ b/.changeset/orange-beds-itch.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Fix attempt_completion showing twice in chat due to partial logic not being handled correctly

--- a/src/core/task/ToolExecutor.ts
+++ b/src/core/task/ToolExecutor.ts
@@ -2235,17 +2235,18 @@ export class ToolExecutor {
 								// 	() => {},
 								// )
 							} else {
-								// last message is completion_result
-								// we have command string, which means we have the result as well, so finish it (doesn't have to exist yet)
-								await this.say(
-									"completion_result",
-									this.removeClosingTag(block, "result", result),
-									undefined,
-									undefined,
-									false,
-								)
-								await this.saveCheckpoint(true)
-								await addNewChangesFlagToLastCompletionResultMessage()
+								// Now that we don't stream a command, we shouldn't be completing the attempt_completion tool in the block.partial conditional, and instead do it when partial is false below
+								//
+								// last message is completion_result, we have command string, which means we have the result as well, so finish it (doesn't have to exist yet)
+								// await this.say(
+								// 	"completion_result",
+								// 	this.removeClosingTag(block, "result", result),
+								// 	undefined,
+								// 	undefined,
+								// 	false,
+								// )
+								// await this.saveCheckpoint(true)
+								// await addNewChangesFlagToLastCompletionResultMessage()
 								// await this.ask("command", this.removeClosingTag(block, "command", command), block.partial).catch(
 								// 	() => {},
 								// )


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes duplicate `attempt_completion` messages in chat by adjusting partial logic handling in `ToolExecutor.ts`.
> 
>   - **Behavior**:
>     - Fixes duplicate `attempt_completion` messages in chat by adjusting logic in `ToolExecutor.ts`.
>     - Ensures `attempt_completion` tool completes only when `block.partial` is false.
>   - **Code Changes**:
>     - Comments out premature completion logic for `attempt_completion` in `ToolExecutor.ts`.
>     - Adjusts handling of `command` within `attempt_completion` to prevent early completion.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for bff99f059c36630304a66c7234bf100bc30d3811. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->