### PR TITLE
Use standard context truncation change

### DIFF
--- a/src/core/context/context-management/ContextManager.ts
+++ b/src/core/context/context-management/ContextManager.ts
@@ -400,9 +400,13 @@ export class ContextManager {
 	 * If the truncation message already exists, does nothing, otherwise adds the message
 	 */
 	async triggerApplyStandardContextTruncationNoticeChange(timestamp: number, taskDirectory: string) {
-		const assistantUpdated = this.applyStandardContextTruncationNoticeChange(timestamp)
+		/*
+        const assistantUpdated = this.applyStandardContextTruncationNoticeChange(timestamp)
 		const userUpdated = this.applyFirstUserMessageReplacement(timestamp)
-		if (assistantUpdated || userUpdated) {
+		if (assistantUpdated || userUpdated)
+		*/
+		const updated = this.applyStandardContextTruncationNoticeChange(timestamp)
+		if (updated) {
 			await this.saveContextHistory(taskDirectory)
 		}
 	}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Simplifies `triggerApplyStandardContextTruncationNoticeChange()` in `ContextManager.ts` to only consider assistant updates for context truncation.
> 
>   - **Behavior**:
>     - In `ContextManager.ts`, `triggerApplyStandardContextTruncationNoticeChange()` now only checks `applyStandardContextTruncationNoticeChange()` for updates, removing the check for `applyFirstUserMessageReplacement()`.
>     - If `applyStandardContextTruncationNoticeChange()` returns true, context history is saved.
>   - **Misc**:
>     - Commented out code related to user message replacement in `triggerApplyStandardContextTruncationNoticeChange()`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for f1d52c19bf560cbc93e09646d7e7ab026ca16e59. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->