### PR TITLE
Remove unused code from the commit-message-generator

### DIFF
--- a/src/integrations/git/commit-message-generator.ts
+++ b/src/integrations/git/commit-message-generator.ts
@@ -1,7 +1,6 @@
 import * as vscode from "vscode"
-import { writeTextToClipboard } from "@utils/env"
 import { HostProvider } from "@/hosts/host-provider"
-import { ShowMessageType, ShowTextDocumentRequest } from "@/shared/proto/host/window"
+import { ShowMessageType } from "@/shared/proto/host/window"
 import { buildApiHandler } from "@/api"
 import { readStateFromDisk } from "@/core/storage/utils/state-helpers"
 import { getWorkingState } from "@/utils/git"
@@ -118,33 +117,6 @@ function abort() {
 }
 
 /**
- * Formats the git diff into a prompt for the AI
- * @param gitDiff The git diff to format
- * @returns A formatted prompt for the AI
- */
-function formatGitDiffPrompt(gitDiff: string): string {
-	// Limit the diff size to avoid token limits
-	const maxDiffLength = 5000
-	let truncatedDiff = gitDiff
-
-	if (gitDiff.length > maxDiffLength) {
-		truncatedDiff = gitDiff.substring(0, maxDiffLength) + "\n\n[Diff truncated due to size]"
-	}
-
-	return `Based on the following git diff, generate a concise and descriptive commit message:
-
-${truncatedDiff}
-
-The commit message should:
-1. Start with a short summary (50-72 characters)
-2. Use the imperative mood (e.g., "Add feature" not "Added feature")
-3. Describe what was changed and why
-4. Be clear and descriptive
-
-Commit message:`
-}
-
-/**
  * Extracts the commit message from the AI response
  * @param str String containing the AI response
  * @returns The extracted commit message
@@ -155,108 +127,4 @@ export function extractCommitMessage(str: string): string {
 		.trim()
 		.replace(/^```[^\n]*\n?|```$/g, "")
 		.trim()
-}
-
-/**
- * Copies the generated commit message to the clipboard
- * @param message The commit message to copy
- */
-export async function copyCommitMessageToClipboard(message: string): Promise<void> {
-	await writeTextToClipboard(message)
-	HostProvider.window.showMessage({
-		type: ShowMessageType.INFORMATION,
-		message: "Commit message copied to clipboard",
-	})
-}
-
-/**
- * Shows a dialog with options to apply the generated commit message
- * @param message The generated commit message
- */
-export async function showCommitMessageOptions(message: string): Promise<void> {
-	const copyAction = "Copy to Clipboard"
-	const applyAction = "Apply to Git Input"
-	const editAction = "Edit Message"
-
-	const selectedAction = (
-		await HostProvider.window.showMessage({
-			type: ShowMessageType.INFORMATION,
-			message: "Commit message generated",
-			options: {
-				modal: false,
-				detail: message,
-				items: [copyAction, applyAction, editAction],
-			},
-		})
-	).selectedOption
-
-	// Handle user dismissing the dialog (selectedAction is undefined)
-	if (!selectedAction) {
-		return
-	}
-
-	switch (selectedAction) {
-		case copyAction:
-			await copyCommitMessageToClipboard(message)
-			break
-		case applyAction:
-			await applyCommitMessageToGitInput(message)
-			break
-		case editAction:
-			await editCommitMessage(message)
-			break
-	}
-}
-
-/**
- * Applies the commit message to the Git input box in the Source Control view
- * @param message The commit message to apply
- */
-async function applyCommitMessageToGitInput(message: string): Promise<void> {
-	// Set the SCM input box value
-	const gitExtension = vscode.extensions.getExtension("vscode.git")?.exports
-	if (gitExtension) {
-		const api = gitExtension.getAPI(1)
-		if (api && api.repositories.length > 0) {
-			const repo = api.repositories[0]
-			repo.inputBox.value = message
-			HostProvider.window.showMessage({
-				type: ShowMessageType.INFORMATION,
-				message: "Commit message applied to Git input",
-			})
-		} else {
-			HostProvider.window.showMessage({
-				type: ShowMessageType.ERROR,
-				message: "No Git repositories found",
-			})
-			await copyCommitMessageToClipboard(message)
-		}
-	} else {
-		HostProvider.window.showMessage({
-			type: ShowMessageType.ERROR,
-			message: "Git extension not found",
-		})
-		await copyCommitMessageToClipboard(message)
-	}
-}
-
-/**
- * Opens the commit message in an editor for further editing
- * @param message The commit message to edit
- */
-async function editCommitMessage(message: string): Promise<void> {
-	const document = await vscode.workspace.openTextDocument({
-		content: message,
-		language: "markdown",
-	})
-
-	await HostProvider.window.showTextDocument(
-		ShowTextDocumentRequest.create({
-			path: document.uri.fsPath,
-		}),
-	)
-	HostProvider.window.showMessage({
-		type: ShowMessageType.INFORMATION,
-		message: "Edit the commit message and copy when ready",
-	})
 }


### PR DESCRIPTION
These functions don't appear anywhere else in the codebase.

The git-commit message generator still works the same.

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove unused functions and imports from `commit-message-generator.ts`.
> 
>   - **Code Removal**:
>     - Remove `formatGitDiffPrompt()`, `copyCommitMessageToClipboard()`, `showCommitMessageOptions()`, `applyCommitMessageToGitInput()`, and `editCommitMessage()` from `commit-message-generator.ts`.
>     - Remove unused import `writeTextToClipboard` from `@utils/env`.
>     - Remove `ShowTextDocumentRequest` import from `@/shared/proto/host/window`.

> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for b5060a12d4e884be13fc4461fa8b5f834d926b72. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->