### PR TITLE
Move use of `vscode.version` to the host bridge

### DIFF
--- a/proto/host/env.proto
+++ b/proto/host/env.proto
@@ -16,4 +16,13 @@ service EnvService {
 
   // Returns a stable machine identifier for telemetry distinctId purposes.
   rpc getMachineId(cline.EmptyRequest) returns (cline.String);
+
+  rpc getHostVersion(cline.EmptyRequest) returns (GetHostVersionResponse);
+}
+
+message GetHostVersionResponse {
+  // The name of the host platform, e.g VSCode
+  optional string platform = 1; 
+  // The version of the host platform, e.g. 1.103.0
+  optional string version = 2;
 }

--- a/src/core/task/ToolExecutor.ts
+++ b/src/core/task/ToolExecutor.ts
@@ -56,6 +56,7 @@ import { AutoApprove } from "./tools/autoApprove"
 import { showNotificationForApprovalIfAutoApprovalEnabled } from "./utils"
 import { Mode } from "@shared/storage/types"
 import { continuationPrompt } from "../prompts/contextManagement"
+import { HostProvider } from "@/hosts/host-provider"
 
 export class ToolExecutor {
 	private autoApprover: AutoApprove
@@ -1897,7 +1898,8 @@ export class ToolExecutor {
 						const operatingSystem = os.platform() + " " + os.release()
 						const clineVersion =
 							vscode.extensions.getExtension("saoudrizwan.claude-dev")?.packageJSON.version || "Unknown"
-						const systemInfo = `VSCode: ${vscode.version}, Node.js: ${process.version}, Architecture: ${os.arch()}`
+						const host = await HostProvider.env.getHostVersion({})
+						const systemInfo = `${host.platform}: ${host.version}, Node.js: ${process.version}, Architecture: ${os.arch()}`
 						const currentMode = this.mode
 						const apiConfig = this.cacheService.getApiConfiguration()
 						const apiProvider = currentMode === "plan" ? apiConfig.planModeApiProvider : apiConfig.actModeApiProvider

--- a/src/hosts/vscode/hostbridge/env/getHostVersion.ts
+++ b/src/hosts/vscode/hostbridge/env/getHostVersion.ts
@@ -1,0 +1,7 @@
+import { GetHostVersionResponse } from "@/shared/proto/index.host"
+import { EmptyRequest, String } from "@shared/proto/cline/common"
+import * as vscode from "vscode"
+
+export async function getHostVersion(_: EmptyRequest): Promise<GetHostVersionResponse> {
+	return { platform: "VSCode", version: vscode.version }
+}


### PR DESCRIPTION
Add an RPC to the host bridge to get the version of the host IDE.
Implement this for VScode.

This is used when creating a bug report to collect system information. Now the bug report will contain the correct host name and version.

 
<img width="730" height="1025" alt="Screenshot 2025-08-17 at 01 16 42" src="https://github.com/user-attachments/assets/6e27ee7f-02d5-4d37-bbe2-5db08dc63615" />

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Introduces `getHostVersion` RPC in `EnvService` to retrieve host IDE version, implemented for VSCode and integrated into `ToolExecutor`.
> 
>   - **Behavior**:
>     - Adds `getHostVersion` RPC to `EnvService` in `env.proto` to retrieve host IDE version.
>     - Implements `getHostVersion` for VSCode in `getHostVersion.ts`, returning platform as "VSCode" and version using `vscode.version`.
>   - **Integration**:
>     - Updates `ToolExecutor` in `ToolExecutor.ts` to use `HostProvider.env.getHostVersion()` for system information, replacing direct `vscode.version` usage.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 56c90fae7433ef7081b588aa532c0275fbd69bc8. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->