### PR TITLE
feat(openrouter): Support Custom Base URL for OpenRouter API

### DIFF
--- a/src/api/providers/openrouter.ts
+++ b/src/api/providers/openrouter.ts
@@ -20,6 +20,7 @@ interface OpenRouterHandlerOptions {
 }
 
 interface OpenRouterHandlerOptions {
+	openRouterBaseUrl?: string
 	openRouterApiKey?: string
 	openRouterModelId?: string
 	openRouterModelInfo?: ModelInfo
@@ -44,7 +45,7 @@ export class OpenRouterHandler implements ApiHandler {
 			}
 			try {
 				this.client = new OpenAI({
-					baseURL: "https://openrouter.ai/api/v1",
+					baseURL: this.options.openRouterBaseUrl || "https://openrouter.ai/api/v1",
 					apiKey: this.options.openRouterApiKey,
 					defaultHeaders: {
 						"HTTP-Referer": "https://cline.bot", // Optional, for including your app on openrouter.ai rankings.
@@ -182,7 +183,8 @@ export class OpenRouterHandler implements ApiHandler {
 	async *fetchGenerationDetails(genId: string) {
 		// console.log("Fetching generation details for:", genId)
 		try {
-			const response = await axios.get(`https://openrouter.ai/api/v1/generation?id=${genId}`, {
+			const baseUrl = this.options.openRouterBaseUrl || "https://openrouter.ai/api/v1"
+			const response = await axios.get(`${baseUrl}/generation?id=${genId}`, {
 				headers: {
 					Authorization: `Bearer ${this.options.openRouterApiKey}`,
 				},

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -43,6 +43,7 @@ export interface ApiHandlerOptions {
 	liteLlmUsePromptCache?: boolean
 	openAiHeaders?: Record<string, string> // Custom headers for OpenAI requests
 	anthropicBaseUrl?: string
+	openRouterBaseUrl?: string
 	openRouterApiKey?: string
 	openRouterProviderSorting?: string
 	awsAccessKey?: string

--- a/webview-ui/src/components/settings/providers/OpenRouterProvider.tsx
+++ b/webview-ui/src/components/settings/providers/OpenRouterProvider.tsx
@@ -10,6 +10,7 @@ import { formatPrice } from "../utils/pricingUtils"
 import { useExtensionState } from "@/context/ExtensionStateContext"
 import { useApiConfigurationHandlers } from "../utils/useApiConfigurationHandlers"
 import { Mode } from "@shared/storage/types"
+import { BaseUrlField } from "../common/BaseUrlField"
 /**
  * Component to display OpenRouter balance information
  */
@@ -80,6 +81,12 @@ export const OpenRouterProvider = ({ showModelOptions, isPopup, currentMode }: O
 						)}
 					</div>
 				</DebouncedTextField>
+				<BaseUrlField
+					initialValue={apiConfiguration?.openRouterBaseUrl}
+					onChange={(value) => handleFieldChange("openRouterBaseUrl", value)}
+					placeholder="Default: https://openrouter.ai/api/v1"
+					label="Use custom base URL"
+				/>
 				{!apiConfiguration?.openRouterApiKey && (
 					<VSCodeButton
 						onClick={async () => {


### PR DESCRIPTION
Hi team,

  This pull request introduces a new configuration option, openRouterBaseUrl, allowing users to specify a custom base URL for the OpenRouter provider.

  Description

  This change provides more flexibility for users who need to route OpenRouter API requests through a proxy or connect to a self-hosted or alternative OpenRouter-compatible endpoint.

  Key Changes:

   1. Frontend (`OpenRouterProvider.tsx`): A new "Use custom base URL" field has been added to the OpenRouter settings panel. If left empty, the default URL (https://openrouter.ai/api/v1) will be used.
   2. API Handler (`openrouter.ts`): The OpenRouterHandler has been updated to use the openRouterBaseUrl from the configuration for all API calls. It gracefully falls back to the default URL if the custom one is not set.

  This enhancement ensures that users with specific network requirements can still leverage the OpenRouter integration seamlessly.

  Thank you for your time and consideration. I look forward to getting this merged