### PR TITLE
refactor hostbridge: add openSettings RPC and vscode hostbridge;

### DIFF
--- a/proto/host/window.proto
+++ b/proto/host/window.proto
@@ -26,6 +26,9 @@ service WindowService {
   // Opens a file in the IDE.
   rpc openFile(OpenFileRequest) returns (OpenFileResponse);
 
+  // Opens the host settings UI, optionally focusing a specific query/section.
+  rpc openSettings(OpenSettingsRequest) returns (OpenSettingsResponse);
+
   // Returns the open tabs.
   rpc getOpenTabs(GetOpenTabsRequest) returns (GetOpenTabsResponse);
 
@@ -126,6 +129,13 @@ message OpenFileRequest {
 }
 
 message OpenFileResponse {}
+
+message OpenSettingsRequest {
+  // Optional query to focus a particular settings section/key.
+  optional string query = 1;
+}
+
+message OpenSettingsResponse {}
 
 message GetOpenTabsRequest {}
 

--- a/proto/host/window.proto
+++ b/proto/host/window.proto
@@ -132,6 +132,14 @@ message OpenFileResponse {}
 
 message OpenSettingsRequest {
   // Optional query to focus a particular settings section/key.
+  // This value is host-specific. In VS Code, it is passed directly as the
+  // Settings search query to the "workbench.action.openSettings" command.
+  // Examples (VS Code, see - https://code.visualstudio.com/docs/getstarted/settings#settings-editor-filters.):
+  // - "telemetry.telemetryLevel" → focuses the Telemetry Level setting
+  // - "@id:telemetry.telemetryLevel" → navigates by exact setting id
+  // - "@modified", "@ext:publisher.extension"
+  // - Plain keywords/categories
+  // If not provided the host opens the settings UI without specific focus.
   optional string query = 1;
 }
 

--- a/src/hosts/vscode/hostbridge/window/openSettings.ts
+++ b/src/hosts/vscode/hostbridge/window/openSettings.ts
@@ -1,0 +1,8 @@
+import * as vscode from "vscode"
+import { OpenSettingsRequest, OpenSettingsResponse } from "@/shared/proto/host/window"
+
+export async function openSettings(request: OpenSettingsRequest): Promise<OpenSettingsResponse> {
+	// VS Code can be queried to focus a specific setting section
+	await vscode.commands.executeCommand("workbench.action.openSettings", request.query ?? undefined)
+	return OpenSettingsResponse.create({})
+}

--- a/src/services/posthog/telemetry/TelemetryService.ts
+++ b/src/services/posthog/telemetry/TelemetryService.ts
@@ -150,7 +150,7 @@ export class TelemetryService {
 						})
 						.then((response) => {
 							if (response.selectedOption === "Open Settings") {
-								void vscode.commands.executeCommand("workbench.action.openSettings", "telemetry.telemetryLevel")
+								void HostProvider.window.openSettings({ query: "telemetry.telemetryLevel" })
 							}
 						})
 				} else {


### PR DESCRIPTION
<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- For feature requests: Created a discussion in our Feature Requests discussions board https://github.com/cline/cline/discussions/categories/feature-requests and received approval from core maintainers before implementation
- For all changes: Link the associated issue/discussion in the "Related Issue" section below

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly without prior discussion.

Why this requirement?
We deeply appreciate all community contributions - they are essential to Cline's success! To ensure the best use of everyone's time and maintain project direction, we use our Feature Requests discussions board to gauge community interest and validate feature ideas before implementation begins. This helps us focus development efforts on features that will benefit the most users.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** #XXXX
vscode.commands.executeCommand("workbench.action.openSettings") -> hostbridge

### Description
Refactor VS Code-specific workbench.action.openSettings into HostBridge. Implement VScode handler with optional query. Updated telemetryService to use the new handler.
<!-- 
Help reviewers understand your changes by making this PR readable and well-organized:

- What problem does this PR solve?
- Why were these changes introduced and what purpose do they serve?
- For larger changes, provide context about your approach and reasoning

Small PRs may need minimal description, but larger changes benefit from explaining where you're coming from. Much of this context can be in the linked issue above, so feel free to reference it rather than repeating everything here.
-->

### Test Procedure
- In VS Code, set “Telemetry: Telemetry Level” to Off.
- In Cline Settings, enable “Allow error and usage reporting”.
- At launch bottom-right warning notification with “Open Settings”.
- On button click VS Code Settings opens focused on telemetry.
<!-- 
Please walk us through your testing approach and thought process. This helps reviewers understand that you've thoroughly considered the impact of your changes:

- How did you test this change?
- What could potentially break and how did you verify it doesn't?
- What existing functionality might be affected and how did you check it still works?
- Why are you confident this is ready for merge?

We're not looking for exhaustive documentation - just evidence that you've thought through the implications of your changes and tested accordingly.
-->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [x] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Refactor to add `openSettings` RPC for opening settings UI with optional focus, updating VS Code host bridge and `TelemetryService`.
> 
>   - **Behavior**:
>     - Introduces `openSettings` RPC in `proto/host/window.proto` to open host settings UI with optional query focus.
>     - Implements `openSettings()` in `openSettings.ts` to execute VS Code command with optional query.
>     - Updates `TelemetryService.ts` to use `HostProvider.window.openSettings()` instead of direct VS Code command.
>   - **Protobuf**:
>     - Adds `OpenSettingsRequest` and `OpenSettingsResponse` messages in `proto/host/window.proto`.
>   - **Misc**:
>     - Refactors telemetry settings opening logic in `TelemetryService.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 4c1357799da32c0ed5935219c9ee39ca92b60a87. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->