### PR TITLE
fix: enable auto-formatting in postprotos script to prevent build failures

### DIFF
--- a/package.json
+++ b/package.json
@@ -347,7 +347,7 @@
 		"watch:tsc": "tsc --noEmit --watch --project tsconfig.json",
 		"package": "npm run check-types && npm run build:webview && npm run lint && node esbuild.mjs --production",
 		"protos": "node scripts/build-proto.mjs",
-		"postprotos": "biome format src/shared/proto src/core/controller src/hosts/ webview-ui/src/services src/generated --no-errors-on-unmatched",
+		"postprotos": "biome format src/shared/proto src/core/controller src/hosts/ webview-ui/src/services src/generated --write --no-errors-on-unmatched",
 		"clean": "rimraf dist dist-standalone webview-ui/build src/generated out/",
 		"compile-tests": "node ./scripts/build-tests.js",
 		"watch-tests": "tsc -p . -w --outDir out",


### PR DESCRIPTION


### Description

This PR fixes a build-blocking issue where Biome formatter would fail the build process when it encounters formatting inconsistencies (like single quotes vs double quotes) in the generated proto files.

The problem occurred when running the `postprotos` script - Biome would detect formatting issues but only report them without fixing them, causing the build to fail. This was particularly problematic for automated builds and CI/CD pipelines.

### Test Procedure

1. Introduced a formatting issue (single quotes instead of double quotes) in a file
2. Ran `npm run protos` to trigger the postprotos script
3. Verified that with the `--write` flag, Biome now automatically fixes the formatting issues instead of failing
4. Confirmed that the build process completes successfully
5. Tested that existing functionality remains unaffected

### Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

### Pre-flight Checklist

- [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
- [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
- [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
- [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A - This is a build script configuration change

### Additional Notes

This is a small bug fix that adds the `--write` flag to the Biome format command in the postprotos script. This change ensures that formatting issues are automatically fixed rather than causing build failures.