### PR TITLE
move clineignore filewatcher to chokidar

### DIFF
--- a/src/core/ignore/ClineIgnoreController.ts
+++ b/src/core/ignore/ClineIgnoreController.ts
@@ -21,15 +21,15 @@ export class ClineIgnoreController {
 		this.cwd = cwd
 		this.ignoreInstance = ignore()
 		this.clineIgnoreContent = undefined
-		// Set up file watcher for .clineignore
-		this.setupFileWatcher()
 	}
 
 	/**
-	 * Initialize the controller by loading custom patterns
+	 * Initialize the controller by loading custom patterns and setting up file watcher
 	 * Must be called after construction and before using the controller
 	 */
 	async initialize(): Promise<void> {
+		// Set up file watcher for .clineignore
+		this.setupFileWatcher()
 		await this.loadClineIgnore()
 	}
 


### PR DESCRIPTION

### Description

Move to filewatcher over to chokidar to remove vscode dependency

### Test Procedure

Add a filepattern to the .clineignore file with a task open and check that the blocking functionality is updated.

Delete the file and confirm that the blocking is updated.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [x] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Refactor `ClineIgnoreController` to use `chokidar` for `.clineignore` file watching, removing VSCode dependency.
> 
>   - **Refactor**:
>     - Replace VSCode file watcher with `chokidar` in `ClineIgnoreController`.
>     - `setupFileWatcher()` now uses `chokidar.watch()` to monitor `.clineignore` file changes, additions, and deletions.
>     - Handles file watcher errors by logging them to the console.
>   - **Behavior**:
>     - `.clineignore` file changes are now detected using `chokidar`, removing VSCode dependency.
>     - `dispose()` method updated to close `chokidar` watcher instead of VSCode disposables.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 125a208ccd92d0f8cfb637bfcb38d14ab9f0e351. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->