### PR TITLE
When packaging cline-core for debug builds include map files

### DIFF
--- a/scripts/package-standalone.mjs
+++ b/scripts/package-standalone.mjs
@@ -142,7 +142,13 @@ function createIsIgnored(standaloneIgnores) {
 
 	// Combine with default ignore list
 	// Also ignore the dist directory- the build directory for the extension.
-	const allIgnore = [...defaultIgnore, ...expandedIgnore, ...standaloneIgnores]
+	let allIgnore = [...defaultIgnore, ...expandedIgnore, ...standaloneIgnores]
+
+	// Map files need to be included in the debug build. Remove .map ignores when IS_DEBUG_BUILD is set
+	if (process.env.IS_DEBUG_BUILD) {
+		allIgnore = allIgnore.filter((pattern) => !pattern.endsWith(".map"))
+		console.log("Debug build: Including .map files in package")
+	}
 
 	// Split into ignore and negate list
 	const [ignore, negate] = allIgnore.reduce(


### PR DESCRIPTION
When the env var IS_DEBUG_BUILD is set, include .map files in the package.

This allows debugging of the compiled cline-core.js file. 

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Include `.map` files in the package when `IS_DEBUG_BUILD` is set in `package-standalone.mjs`.
> 
>   - **Behavior**:
>     - When `IS_DEBUG_BUILD` is set, `.map` files are included in the package by modifying the ignore list in `createIsIgnored()` in `package-standalone.mjs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 52c71b8ddd7570645942947dc7a597ad87a63fce. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->