### PR TITLE
Get the extension version from `ExtensionContext`

### DIFF
--- a/src/core/task/ToolExecutor.ts
+++ b/src/core/task/ToolExecutor.ts
@@ -1898,8 +1898,7 @@ export class ToolExecutor {
 
 						// Derive system information values algorithmically
 						const operatingSystem = os.platform() + " " + os.release()
-						const clineVersion =
-							vscode.extensions.getExtension("saoudrizwan.claude-dev")?.packageJSON.version || "Unknown"
+						const clineVersion = this.context.extension.packageJSON.version || "Unknown"
 						const host = await HostProvider.env.getHostVersion({})
 						const systemInfo = `${host.platform}: ${host.version}, Node.js: ${process.version}, Architecture: ${os.arch()}`
 						const currentMode = this.mode


### PR DESCRIPTION
The extension packageJSON etc is already available in the ExtensionContext, don't need to do `vscode.extensions.getExtension`
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Replace `vscode.extensions.getExtension` with `this.context.extension` in `ToolExecutor.ts` to access extension version directly.
> 
>   - **Behavior**:
>     - In `ToolExecutor` class, replace `vscode.extensions.getExtension` with `this.context.extension` to get `clineVersion` in `ToolExecutor.ts`.
>     - This change uses the `ExtensionContext` to access the extension version directly, avoiding unnecessary calls to `vscode.extensions.getExtension`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 56bca70bd4f3b03187c8e07f02656f618f10b5a1. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->