### PR TITLE
Get the extension URI from the ExtensionContext instead of `vscode.extensions.getExtension("saoudrizwan.claude-dev")`

### DIFF
--- a/src/core/controller/ui/subscribeToTheme.ts
+++ b/src/core/controller/ui/subscribeToTheme.ts
@@ -14,7 +14,7 @@ const activeThemeSubscriptions = new Set<StreamingResponseHandler<String>>()
  * @param requestId The ID of the request (passed by the gRPC handler)
  */
 export async function subscribeToTheme(
-	_controller: Controller,
+	controller: Controller,
 	_request: EmptyRequest,
 	responseStream: StreamingResponseHandler<String>,
 	requestId?: string,
@@ -33,7 +33,7 @@ export async function subscribeToTheme(
 	}
 
 	// Send the current theme immediately upon subscription
-	const theme = await getTheme()
+	const theme = await getTheme(controller.context)
 	if (theme) {
 		try {
 			const themeEvent = String.create({

--- a/src/hosts/vscode/VscodeWebviewProvider.ts
+++ b/src/hosts/vscode/VscodeWebviewProvider.ts
@@ -132,7 +132,7 @@ export class VscodeWebviewProvider extends WebviewProvider implements vscode.Web
 			async (e) => {
 				if (e && e.affectsConfiguration("workbench.colorTheme")) {
 					// Send theme update via gRPC subscription
-					const theme = await getTheme()
+					const theme = await getTheme(this.context)
 					if (theme) {
 						await sendThemeEvent(JSON.stringify(theme))
 					}

--- a/src/integrations/theme/getTheme.ts
+++ b/src/integrations/theme/getTheme.ts
@@ -30,8 +30,8 @@ function parseThemeString(themeString: string | undefined): any {
 	return JSON.parse(themeString ?? "{}")
 }
 
-export async function getTheme() {
-	let currentTheme
+export async function getTheme(context: vscode.ExtensionContext) {
+	let currentTheme: string | undefined
 	const colorTheme = vscode.workspace.getConfiguration("workbench").get<string>("colorTheme") || "Default Dark Modern"
 
 	try {
@@ -54,7 +54,7 @@ export async function getTheme() {
 		if (currentTheme === undefined && defaultThemes[colorTheme]) {
 			const filename = `${defaultThemes[colorTheme]}.json`
 			currentTheme = await fs.readFile(
-				path.join(getExtensionUri().fsPath, "src", "integrations", "theme", "default-themes", filename),
+				path.join(context.extensionUri.fsPath, "src", "integrations", "theme", "default-themes", filename),
 				"utf-8",
 			)
 		}
@@ -64,7 +64,7 @@ export async function getTheme() {
 
 		if (parsed.include) {
 			const includeThemeString = await fs.readFile(
-				path.join(getExtensionUri().fsPath, "src", "integrations", "theme", "default-themes", parsed.include),
+				path.join(context.extensionUri.fsPath, "src", "integrations", "theme", "default-themes", parsed.include),
 				"utf-8",
 			)
 			const includeTheme = parseThemeString(includeThemeString)
@@ -134,8 +134,4 @@ export function mergeJson(
 			...second,
 		}
 	}
-}
-
-function getExtensionUri(): vscode.Uri {
-	return vscode.extensions.getExtension("saoudrizwan.claude-dev")!.extensionUri
 }


### PR DESCRIPTION
Removes the use of the vscode API `vscode.extensions.getExtension()` from the codebase.

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Refactor `getTheme` to use `ExtensionContext` for URI, removing hardcoded extension access.
> 
>   - **Refactoring**:
>     - `getTheme` function in `getTheme.ts` now takes `context: vscode.ExtensionContext` as a parameter to access `extensionUri`.
>     - Removed `getExtensionUri()` function from `getTheme.ts`.
>   - **Function Calls**:
>     - Updated `subscribeToTheme` in `subscribeToTheme.ts` to pass `controller.context` to `getTheme`.
>     - Updated `VscodeWebviewProvider` in `VscodeWebviewProvider.ts` to pass `this.context` to `getTheme`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for fc2d6be7c0dbb350380c0c52f876b08458338226. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->