### PR TITLE
Add an RPC to the host bridge to show the problems in the IDE

### DIFF
--- a/proto/host/workspace.proto
+++ b/proto/host/workspace.proto
@@ -10,12 +10,17 @@ import "cline/common.proto";
 service WorkspaceService {
   // Returns a list of the top level directories of the workspace.
   rpc getWorkspacePaths(GetWorkspacePathsRequest) returns (GetWorkspacePathsResponse);
+
   // Saves an open document if it's open in the editor and has unsaved changes. 
   // Returns true if the document was saved, returns false if the document was not found, or did not
   // need to be saved.
   rpc saveOpenDocumentIfDirty(SaveOpenDocumentIfDirtyRequest) returns (SaveOpenDocumentIfDirtyResponse);
+
   // Get diagnostics from the workspace.
   rpc getDiagnostics(GetDiagnosticsRequest) returns (GetDiagnosticsResponse);
+
+  // Makes the problems panel/pane visible in the IDE and focuses it.
+  rpc openProblemsPanel(OpenProblemsPanelRequest) returns (OpenProblemsPanelResponse);
 }
 
 message GetWorkspacePathsRequest {
@@ -46,3 +51,6 @@ message GetDiagnosticsRequest {
 message GetDiagnosticsResponse {
   repeated cline.FileDiagnostics file_diagnostics = 1;
 }
+
+message OpenProblemsPanelRequest {}
+message OpenProblemsPanelResponse {}

--- a/src/core/mentions/index.ts
+++ b/src/core/mentions/index.ts
@@ -35,7 +35,7 @@ export async function openMention(mention?: string): Promise<void> {
 			openFile(absPath)
 		}
 	} else if (mention === "problems") {
-		vscode.commands.executeCommand("workbench.actions.view.problems")
+		await HostProvider.workspace.openProblemsPanel({})
 	} else if (mention === "terminal") {
 		vscode.commands.executeCommand("workbench.action.terminal.focus")
 	} else if (mention.startsWith("http")) {

--- a/src/hosts/vscode/hostbridge/workspace/openProblemsPanel.ts
+++ b/src/hosts/vscode/hostbridge/workspace/openProblemsPanel.ts
@@ -1,0 +1,7 @@
+import * as vscode from "vscode"
+import { OpenProblemsPanelRequest, OpenProblemsPanelResponse } from "@/shared/proto/index.host"
+
+export async function openProblemsPanel(_: OpenProblemsPanelRequest): Promise<OpenProblemsPanelResponse> {
+	vscode.commands.executeCommand("workbench.actions.view.problems")
+	return {}
+}


### PR DESCRIPTION
Add an RPC that makes the problems panel visible and focuses it.

Update the place where this is used.