### PR TITLE
Add an RPC to the host bridge to reveal a directory in the IDE file explorer

### DIFF
--- a/proto/host/workspace.proto
+++ b/proto/host/workspace.proto
@@ -21,6 +21,9 @@ service WorkspaceService {
 
   // Makes the problems panel/pane visible in the IDE and focuses it.
   rpc openProblemsPanel(OpenProblemsPanelRequest) returns (OpenProblemsPanelResponse);
+
+  // Opens the IDE file explorer panel and selects a file or directory.
+  rpc openInFileExplorerPanel(OpenInFileExplorerPanelRequest) returns (OpenInFileExplorerPanelResponse); 
 }
 
 message GetWorkspacePathsRequest {
@@ -54,3 +57,8 @@ message GetDiagnosticsResponse {
 
 message OpenProblemsPanelRequest {}
 message OpenProblemsPanelResponse {}
+
+message OpenInFileExplorerPanelRequest {
+  string path = 1;
+}
+message OpenInFileExplorerPanelResponse {}

--- a/src/core/mentions/index.ts
+++ b/src/core/mentions/index.ts
@@ -13,6 +13,7 @@ import * as vscode from "vscode"
 import { HostProvider } from "@/hosts/host-provider"
 import { ShowMessageType } from "@/shared/proto/host/window"
 import { DiagnosticSeverity } from "@/shared/proto/index.cline"
+import { isDirectory } from "@/utils/fs"
 import { getCwd } from "@/utils/path"
 import { FileContextTracker } from "../context/context-tracking/FileContextTracker"
 
@@ -29,8 +30,8 @@ export async function openMention(mention?: string): Promise<void> {
 	if (isFileMention(mention)) {
 		const relPath = getFilePathFromMention(mention)
 		const absPath = path.resolve(cwd, relPath)
-		if (mention.endsWith("/")) {
-			vscode.commands.executeCommand("revealInExplorer", vscode.Uri.file(absPath))
+		if (await isDirectory(absPath)) {
+			await HostProvider.workspace.openInFileExplorerPanel({ path: absPath })
 		} else {
 			openFile(absPath)
 		}

--- a/src/hosts/vscode/hostbridge/workspace/openInFileExplorerPanel.ts
+++ b/src/hosts/vscode/hostbridge/workspace/openInFileExplorerPanel.ts
@@ -1,0 +1,8 @@
+import * as vscode from "vscode"
+
+import { OpenInFileExplorerPanelRequest, OpenInFileExplorerPanelResponse } from "@/shared/proto/index.host"
+
+export async function openInFileExplorerPanel(request: OpenInFileExplorerPanelRequest): Promise<OpenInFileExplorerPanelResponse> {
+	vscode.commands.executeCommand("revealInExplorer", vscode.Uri.file(request.path || ""))
+	return {}
+}


### PR DESCRIPTION
When the user clicks on a directory file mention, it should open that directory in the explorer panel in the IDE. Add an RPC for this to the host bridge.

I had to change the logic to check if the mention is a directory or not because the current check was not working properly anymore. So, now it uses file.stat to check if its a directory instead of checking if the path ends in /.