### PR TITLE
Fix io.grpc.StatusException: INTERNAL: invalid int32

### DIFF
--- a/proto/cline/models.proto
+++ b/proto/cline/models.proto
@@ -68,8 +68,8 @@ message ModelTier {
 
 // For OpenRouterCompatibleModelInfo structure in OpenRouterModels
 message OpenRouterModelInfo {
-  optional int32 max_tokens = 1;
-  optional int32 context_window = 2;
+  optional int64 max_tokens = 1;
+  optional int64 context_window = 2;
   optional bool supports_images = 3;
   bool supports_prompt_cache = 4;
   optional double input_price = 5;


### PR DESCRIPTION
Fixes this ProtoBus gRPC error:
```2025-08-14 18:28:36,492 [   4334]   WARN - bot.cline.services.ProtoBusProxyService - Stream cline.ModelsService.subscribeToOpenRouterModels encountered error
io.grpc.StatusException: INTERNAL: invalid int32: 9007199254740991
        at io.grpc.Status.asException(Status.java:548)
        at io.grpc.kotlin.ClientCalls$rpcImpl$1$1$1.onClose(ClientCalls.kt:300)
        at io.grpc.internal.ClientCallImpl.closeObserver(ClientCallImpl.java:564)
        at io.grpc.internal.ClientCallImpl.access$100(ClientCallImpl.java:72)
        at io.grpc.internal.ClientCallImpl$ClientStreamListenerImpl$1StreamClosed.runInternal(ClientCallImpl.java:729)
        at io.grpc.internal.ClientCallImpl$ClientStreamListenerImpl$1StreamClosed.runInContext(ClientCallImpl.java:710)
        at io.grpc.internal.ContextRunnable.run(ContextRunnable.java:37)
        at io.grpc.internal.SerializingExecutor.run(SerializingExecutor.java:133)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
        at java.base/java.lang.Thread.run(Thread.java:1583)
```

The context window is now being set to `Number.MAX_SAFE_INTEGER` to represent infinity. https://github.com/cline/cline/blob/01c4ead15548c906cc690ef030ee447720ccb5b0/src/shared/api.ts#L219-L220
However, this is larger than the max value of int32 and cannot be serialized over the ProtoBus. 

Update the max token and context window sizes to be int64.

