### PR TITLE
Change default strict plan mode setting to enabled

### DIFF
--- a/src/core/controller/index.ts
+++ b/src/core/controller/index.ts
@@ -210,7 +210,7 @@ export class Controller {
 			preferredLanguage,
 			openaiReasoningEffort,
 			mode,
-			strictPlanModeEnabled ?? false,
+			strictPlanModeEnabled ?? true,
 			shellIntegrationTimeout,
 			terminalReuseEnabled ?? true,
 			terminalOutputLineLimit ?? 500,

--- a/src/core/storage/utils/state-helpers.ts
+++ b/src/core/storage/utils/state-helpers.ts
@@ -372,7 +372,7 @@ export async function readStateFromDisk(context: ExtensionContext) {
 			actModeBasetenModelId,
 			actModeBasetenModelInfo,
 		},
-		strictPlanModeEnabled: strictPlanModeEnabled ?? false,
+		strictPlanModeEnabled: strictPlanModeEnabled ?? true,
 		isNewUser: isNewUser ?? true,
 		welcomeViewCompleted,
 		lastShownAnnouncementId,

--- a/webview-ui/src/context/ExtensionStateContext.tsx
+++ b/webview-ui/src/context/ExtensionStateContext.tsx
@@ -196,7 +196,7 @@ export const ExtensionStateContextProvider: React.FC<{
 		isNewUser: false,
 		welcomeViewCompleted: false,
 		mcpResponsesCollapsed: false, // Default value (expanded), will be overwritten by extension state
-		strictPlanModeEnabled: false,
+		strictPlanModeEnabled: true,
 	})
 	const [didHydrateState, setDidHydrateState] = useState(false)
 	const [showWelcome, setShowWelcome] = useState(false)
@@ -526,7 +526,9 @@ export const ExtensionStateContextProvider: React.FC<{
 		relinquishControlUnsubscribeRef.current = UiServiceClient.subscribeToRelinquishControl(EmptyRequest.create({}), {
 			onResponse: () => {
 				// Call all registered callbacks
-				relinquishControlCallbacks.current.forEach((callback) => callback())
+				relinquishControlCallbacks.current.forEach((callback) => {
+					callback()
+				})
 			},
 			onError: (error) => {
 				console.error("Error in relinquishControl subscription:", error)


### PR DESCRIPTION
This PR changes the default behavior of strict plan mode from OFF to ON by default.

## Changes Made
- Updated default from false to true in state-helpers.ts (primary backend default)
- Updated fallback default in controller/index.ts (Task initialization)
- Updated frontend default in ExtensionStateContext.tsx for consistency
- Fixed linting issue with forEach callback return value

## Impact
- New users will now have strict plan mode enabled by default
- Existing users who haven't explicitly configured this setting will also get the new default
- Prevents file edits in Plan Mode, enforcing cleaner separation of planning vs execution phases
- Users can still manually disable the setting if they prefer the old behavior

## Files Changed
- src/core/storage/utils/state-helpers.ts
- src/core/controller/index.ts  
- webview-ui/src/context/ExtensionStateContext.tsx