### PR TITLE
Fix openrouter/cline gpt-5 contextWindow by setting to 272k since it's inaccurately reported as 400k

### DIFF
--- a/src/core/controller/models/refreshOpenRouterModels.ts
+++ b/src/core/controller/models/refreshOpenRouterModels.ts
@@ -122,6 +122,7 @@ export async function refreshOpenRouterModels(
 					case "openai/gpt-5-mini":
 					case "openai/gpt-5-nano":
 						modelInfo.maxTokens = 8_192 // 128000 breaks context window truncation
+						modelInfo.contextWindow = 272_000 // openrouter reports 400k but the input limit is actually 400k-128k
 						break
 					default:
 						if (rawModel.id.startsWith("openai/")) {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes `contextWindow` for OpenAI GPT-5 models in `refreshOpenRouterModels.ts` to 272,000 due to incorrect OpenRouter reporting.
> 
>   - **Behavior**:
>     - Adjusts `contextWindow` to 272,000 for `openai/gpt-5`, `openai/gpt-5-chat`, `openai/gpt-5-mini`, and `openai/gpt-5-nano` in `refreshOpenRouterModels.ts`.
>     - Corrects the discrepancy where OpenRouter reports 400k but the actual input limit is 400k-128k.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 1635cc4b015d49fea32b9acb6d12b16885a4949d. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->