### PR TITLE
✨ feat(deepseek): Update DeepSeek models context window from 64K to 128K

### DIFF
--- a/src/core/context/context-management/context-window-utils.ts
+++ b/src/core/context/context-management/context-window-utils.ts
@@ -13,7 +13,7 @@ export function getContextWindowInfo(api: ApiHandler) {
 
 	// Handle special cases like DeepSeek
 	if (api instanceof OpenAiHandler && api.getModel().id.toLowerCase().includes("deepseek")) {
-		contextWindow = 64_000
+		contextWindow = 128_000
 	}
 
 	let maxAllowedSize: number

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -1246,7 +1246,7 @@ export const deepSeekDefaultModelId: DeepSeekModelId = "deepseek-chat"
 export const deepSeekModels = {
 	"deepseek-chat": {
 		maxTokens: 8_000,
-		contextWindow: 64_000,
+		contextWindow: 128_000,
 		supportsImages: false,
 		supportsPromptCache: true, // supports context caching, but not in the way anthropic does it (deepseek reports input tokens and reads/writes in the same usage report) FIXME: we need to show users cache stats how deepseek does it
 		inputPrice: 0, // technically there is no input price, it's all either a cache hit or miss (ApiOptions will not show this). Input is the sum of cache reads and writes
@@ -1256,7 +1256,7 @@ export const deepSeekModels = {
 	},
 	"deepseek-reasoner": {
 		maxTokens: 8_000,
-		contextWindow: 64_000,
+		contextWindow: 128_000,
 		supportsImages: false,
 		supportsPromptCache: true, // supports context caching, but not in the way anthropic does it (deepseek reports input tokens and reads/writes in the same usage report) FIXME: we need to show users cache stats how deepseek does it
 		inputPrice: 0, // technically there is no input price, it's all either a cache hit or miss (ApiOptions will not show this)


### PR DESCRIPTION
## Description

This PR updates the context window configuration for DeepSeek models from 64K to 128K to align with DeepSeek's official API documentation and improve model performance.

## Changes

1. **Updated `src/shared/api.ts`**:
   - Changed `contextWindow` for `deepseek-chat` and `deepseek-reasoner` models from `64_000` to `128_000`

2. **Updated `src/core/context/context-management/context-window-utils.ts`**:
   - Modified the special case handling for DeepSeek models to use 128K context window instead of 64K

## Benefits

- **Improved Performance**: DeepSeek models now have access to the full 128K context window as officially supported
- **Better Compatibility**: Aligns with DeepSeek's API specifications
- **Enhanced User Experience**: Users can utilize the full context capacity without artificial limitations

## Testing

The changes have been compiled and linted successfully, maintaining backward compatibility while providing the enhanced context window support.