### PR TITLE
fix: 'disable checkpoints' button font size does not match surrounding text

### DIFF
--- a/webview-ui/src/components/chat/task-header/TaskHeader.tsx
+++ b/webview-ui/src/components/chat/task-header/TaskHeader.tsx
@@ -764,7 +764,7 @@ const TaskHeader: React.FC<TaskHeaderProps> = ({
 										{checkpointTrackerErrorMessage.replace(/disabling checkpoints\.$/, "")}
 										{checkpointTrackerErrorMessage.endsWith("disabling checkpoints.") && (
 											<button
-												className="underline cursor-pointer bg-transparent border-0 p-0 text-inherit font-inherit"
+												className="underline cursor-pointer bg-transparent border-0 p-0 text-inherit"
 												onClick={() => {
 													// First open the settings panel using direct navigation
 													navigateToSettings()

--- a/webview-ui/src/components/chat/task-header/TaskHeader.tsx
+++ b/webview-ui/src/components/chat/task-header/TaskHeader.tsx
@@ -779,7 +779,8 @@ const TaskHeader: React.FC<TaskHeaderProps> = ({
 															console.error("Error scrolling to checkpoint settings:", error)
 														}
 													}, 300)
-												}}>
+												}}
+												style={{ fontSize: "inherit" }}>
 												disabling checkpoints.
 											</button>
 										)}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fix font size of 'disable checkpoints' button in `TaskHeader.tsx` to match surrounding text.
> 
>   - **UI Fix**:
>     - In `TaskHeader.tsx`, adjusted the `disable checkpoints` button by removing `font-inherit` class and adding `style={{ fontSize: "inherit" }}` to match surrounding text size.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 28e58e04ad0b3e299368a208db78925f86705378. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->