### PR TITLE
docs: Add note about Claude Sonnet 3.5v2 Prompt Caching on Bedrock

### DIFF
--- a/.changeset/quick-clocks-jog.md
+++ b/.changeset/quick-clocks-jog.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Add Sonnet 3.5v2 Prompt Caching docs

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -471,6 +471,10 @@ export const bedrockModels = {
 		contextWindow: 200_000,
 		supportsImages: true,
 
+		// Note: Bedrock no longer supports PromptCache on new AWS accounts for Sonnet 3.5v2
+		// AWS accounts that were previously given access will retain access. New accounts
+		// will not be given access and our encouraged to use PromptCache with newer models.
+		// See the announcement at https://aws.amazon.com/about-aws/whats-new/2025/04/amazon-bedrock-general-availability-prompt-caching/
 		supportsPromptCache: true,
 		inputPrice: 3.0,
 		outputPrice: 15.0,


### PR DESCRIPTION
### Related Issue

**Issue:** NA, I believe this falls under the limited exception of a simple fixes that don't change functionality.


### Description
Making it clear to the developers why we still enable prompt caching on Sonnet 3.5v2 even though the default AWS account configuration for new accounts will be that Sonnet 3.5v2 does not support prompt caching.

### Test Procedure
All comments so functionality should not be impacted at all. 

- Ran `npm run test` 

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [x] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots
No UI changes, just a note to future devs.

### Additional Notes

More of a practice PR that anything for my first contribution :) 
