### PR TITLE
Fix #5726: editing chat message with 'Restore chat' button sending the old message

### DIFF
--- a/webview-ui/src/components/chat/UserMessage.tsx
+++ b/webview-ui/src/components/chat/UserMessage.tsx
@@ -39,7 +39,6 @@ const UserMessage: React.FC<UserMessageProps> = ({ text, images, files, messageT
 	}, [isEditing])
 
 	const handleRestoreWorkspace = async (type: ClineCheckpointRestore) => {
-		const delay = type === "task" ? 500 : 1000 // Delay for task and workspace restore
 		setIsEditing(false)
 
 		if (text === editedText) {
@@ -57,7 +56,7 @@ const UserMessage: React.FC<UserMessageProps> = ({ text, images, files, messageT
 
 			setTimeout(() => {
 				sendMessageFromChatRow?.(editedText, images || [], files || [])
-			}, delay)
+			}, 1_000) // FIXME: The checkpointRestore function ends by calling the cancelTask function, which restores a new task from history (with the updated task messages after the restore). We need to wait for the task to be initialized before sending this message, and for now are using this hack to wait for 1 second for all the state to propagate. The correct solution here would be to send some signal from the task class to the chat view that the task is initialized and ready to receive a message. However, the message edit ux could be greatly improved by not having to delete/resend the message and instead do an in-place edit.
 		} catch (err) {
 			console.error("Checkpoint restore error:", err)
 		}

--- a/webview-ui/src/components/chat/UserMessage.tsx
+++ b/webview-ui/src/components/chat/UserMessage.tsx
@@ -54,9 +54,11 @@ const UserMessage: React.FC<UserMessageProps> = ({ text, images, files, messageT
 				}),
 			)
 
+			// FIXME: The checkpointRestore function ends by calling the cancelTask function, which restores a new task from history (with the updated task messages after the restore). We need to wait for the task to be initialized before sending this message, and for now are using this hack to wait for 1 second for all the state to propagate. The correct solution here would be to send some signal from the task class to the chat view that the task is initialized and ready to receive a message. However, the message edit ux could be greatly improved by not having to delete/resend the message and instead do an in-place edit.
+			const delay = 1_000
 			setTimeout(() => {
 				sendMessageFromChatRow?.(editedText, images || [], files || [])
-			}, 1_000) // FIXME: The checkpointRestore function ends by calling the cancelTask function, which restores a new task from history (with the updated task messages after the restore). We need to wait for the task to be initialized before sending this message, and for now are using this hack to wait for 1 second for all the state to propagate. The correct solution here would be to send some signal from the task class to the chat view that the task is initialized and ready to receive a message. However, the message edit ux could be greatly improved by not having to delete/resend the message and instead do an in-place edit.
+			}, delay)
 		} catch (err) {
 			console.error("Checkpoint restore error:", err)
 		}


### PR DESCRIPTION
Fixes https://github.com/cline/cline/issues/5726
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes 'Restore chat' button sending old message by adding a fixed delay in `UserMessage.tsx`.
> 
>   - **Behavior**:
>     - Fixes issue where 'Restore chat' button sends old message instead of edited one in `UserMessage.tsx`.
>     - Implements a fixed 1-second delay in `handleRestoreWorkspace()` to ensure task initialization before sending message.
>   - **Misc**:
>     - Removes conditional delay logic in `handleRestoreWorkspace()`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 0c5189cf8f3985bddcd7604d2d9f1fb5cff5fe57. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->