### PR TITLE
fix: remove hardcoded Ollama host from options

### DIFF
--- a/.changeset/fluffy-toys-beam.md
+++ b/.changeset/fluffy-toys-beam.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Fix Ollama connection issue to default endpoint at port 11434

--- a/src/core/api/providers/ollama.ts
+++ b/src/core/api/providers/ollama.ts
@@ -29,7 +29,7 @@ export class OllamaHandler implements ApiHandler {
 		if (!this.client) {
 			try {
 				const clientOptions: Partial<Config> = {
-					host: this.options.ollamaBaseUrl || "http://localhost:11434",
+					host: this.options.ollamaBaseUrl,
 				}
 
 				// Add API key if provided (for Ollama cloud or authenticated instances)


### PR DESCRIPTION
<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- For feature requests: Created a discussion in our Feature Requests discussions board https://github.com/cline/cline/discussions/categories/feature-requests and received approval from core maintainers before implementation
- For all changes: Link the associated issue/discussion in the "Related Issue" section below

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly without prior discussion.

Why this requirement?
We deeply appreciate all community contributions - they are essential to Cline's success! To ensure the best use of everyone's time and maintain project direction, we use our Feature Requests discussions board to gauge community interest and validate feature ideas before implementation begins. This helps us focus development efforts on features that will benefit the most users.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** #XXXX

### Description

<!-- 
Help reviewers understand your changes by making this PR readable and well-organized:

- What problem does this PR solve?
- Why were these changes introduced and what purpose do they serve?
- For larger changes, provide context about your approach and reasoning

Small PRs may need minimal description, but larger changes benefit from explaining where you're coming from. Much of this context can be in the linked issue above, so feel free to reference it rather than repeating everything here.
-->

Updates the Ollama handler to remove the hardcoded "http://localhost:11434" as the `ollamaBaseUrl` fallback option for the host to allow the Ollama SDK to handle the default endpoint configured on users' machine.

Reason: Ollama allows cross-origin requests from 127.0.0.1 and 0.0.0.0 by default. However, when we use localhost, the browser would resolve it through DNS, which can result in different IP addresses.

Docs: https://github.com/ollama/ollama/blob/main/docs/faq.md#how-can-i-expose-ollama-on-my-network

### Test Procedure

<!-- 
Please walk us through your testing approach and thought process. This helps reviewers understand that you've thoroughly considered the impact of your changes:

- How did you test this change?
- What could potentially break and how did you verify it doesn't?
- What existing functionality might be affected and how did you check it still works?
- Why are you confident this is ready for merge?

We're not looking for exhaustive documentation - just evidence that you've thought through the implications of your changes and tested accordingly.
-->

<img width="1653" height="997" alt="image" src="https://github.com/user-attachments/assets/941ecc1f-b634-47c0-86f3-8ad2ad0c732d" />

1. Makes sure you are signed into ollama and have `Expose Ollama to the network` enabled
2. Verify you are receiving response from Ollama when starting from this branch

<img width="719" height="929" alt="image" src="https://github.com/user-attachments/assets/c1b7c31b-77a9-4934-a730-0e78919af819" />


### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove hardcoded fallback URL in `OllamaHandler` to rely on `ollamaBaseUrl` or SDK default.
> 
>   - **Behavior**:
>     - Removed hardcoded fallback URL `"http://localhost:11434"` from `OllamaHandler` in `ollama.ts`.
>     - `OllamaHandler` now relies on `ollamaBaseUrl` option or SDK default for host configuration.
>   - **Misc**:
>     - Updated changeset to reflect the fix for Ollama connection issue.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 41eec1fa352869436c30f7ac6c12291d24e72ee1. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->