### PR TITLE
feat: refactor UseCustomPrompt into reusable component, add to Ollama

### DIFF
--- a/.changeset/rare-oranges-flash.md
+++ b/.changeset/rare-oranges-flash.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Add "Use custom prompt" option to Ollama provider

--- a/webview-ui/src/components/settings/UseCustomPrompt.tsx
+++ b/webview-ui/src/components/settings/UseCustomPrompt.tsx
@@ -1,0 +1,35 @@
+import { VSCodeCheckbox } from "@vscode/webview-ui-toolkit/react"
+import React, { useCallback, useState } from "react"
+import { useExtensionState } from "@/context/ExtensionStateContext"
+import { updateSetting } from "./utils/settingsHandlers"
+
+interface CustomPromptCheckboxProps {
+	key: string
+}
+
+const UseCustomPromptCheckbox: React.FC<CustomPromptCheckboxProps> = ({ key }) => {
+	const { customPrompt } = useExtensionState()
+	const [isCompactPromptEnabled, setIsCompactPromptEnabled] = useState<boolean>(customPrompt === "compact")
+
+	const toggleCompactPrompt = useCallback((isChecked: boolean) => {
+		setIsCompactPromptEnabled(isChecked)
+		updateSetting("customPrompt", isChecked ? "compact" : "")
+	}, [])
+
+	return (
+		<div key={key}>
+			<VSCodeCheckbox checked={isCompactPromptEnabled} onChange={() => toggleCompactPrompt(!isCompactPromptEnabled)}>
+				Use compact prompt
+			</VSCodeCheckbox>
+			<div className="text-xs text-description">
+				A system prompt optimized for smaller context window (e.g. 8k or less).
+				<div className="text-error flex align-middle">
+					<i className="codicon codicon-x" />
+					Does not support Mcp and Focus Chain
+				</div>
+			</div>
+		</div>
+	)
+}
+
+export default UseCustomPromptCheckbox

--- a/webview-ui/src/components/settings/providers/LMStudioProvider.tsx
+++ b/webview-ui/src/components/settings/providers/LMStudioProvider.tsx
@@ -7,6 +7,7 @@ import { ModelsServiceClient } from "@/services/grpc-client"
 import { BaseUrlField } from "../common/BaseUrlField"
 import { DebouncedTextField } from "../common/DebouncedTextField"
 import { DropdownContainer } from "../common/ModelSelector"
+import UseCustomPromptCheckbox from "../UseCustomPrompt"
 import { getModeSpecificFields } from "../utils/providerUtils"
 import { updateSetting } from "../utils/settingsHandlers"
 import { useApiConfigurationHandlers } from "../utils/useApiConfigurationHandlers"
@@ -37,13 +38,12 @@ interface LMStudioApiModel {
  * The LM Studio provider configuration component
  */
 export const LMStudioProvider = ({ currentMode }: LMStudioProviderProps) => {
-	const { apiConfiguration, customPrompt } = useExtensionState()
+	const { apiConfiguration } = useExtensionState()
 	const { handleFieldChange, handleModeFieldChange } = useApiConfigurationHandlers()
 
 	const { lmStudioModelId } = getModeSpecificFields(apiConfiguration, currentMode)
 
 	const [lmStudioModels, setLmStudioModels] = useState<LMStudioApiModel[]>([])
-	const [isCompactPromptEnabled, setIsCompactPromptEnabled] = useState<boolean>(customPrompt === "compact")
 
 	const currentLMStudioModel = useMemo(
 		() => lmStudioModels.find((model) => model.id === lmStudioModelId),
@@ -53,11 +53,6 @@ export const LMStudioProvider = ({ currentMode }: LMStudioProviderProps) => {
 		() => apiConfiguration?.lmStudioBaseUrl || "http://localhost:1234",
 		[apiConfiguration?.lmStudioBaseUrl],
 	)
-
-	const toggleCompactPrompt = useCallback((isChecked: boolean) => {
-		setIsCompactPromptEnabled(isChecked)
-		updateSetting("customPrompt", isChecked ? "compact" : "")
-	}, [])
 
 	// Poll LM Studio models
 	const requestLmStudioModels = useCallback(async () => {
@@ -157,16 +152,7 @@ export const LMStudioProvider = ({ currentMode }: LMStudioProviderProps) => {
 				value={String(currentLoadedContext ?? lmStudioMaxTokens ?? "0")}
 			/>
 
-			<VSCodeCheckbox checked={isCompactPromptEnabled} onChange={() => toggleCompactPrompt(!isCompactPromptEnabled)}>
-				Use compact prompt
-			</VSCodeCheckbox>
-			<div className="text-xs text-description">
-				A system prompt optimized for smaller context window (e.g. 8k or less).
-				<div className="text-error flex align-middle">
-					<i className="codicon codicon-x" />
-					Does not support Mcp and Focus Chain
-				</div>
-			</div>
+			<UseCustomPromptCheckbox key="lmstudio" />
 
 			<div className="text-xs text-description">
 				LM Studio allows you to run models locally on your computer. For instructions on how to get started, see their

--- a/webview-ui/src/components/settings/providers/OllamaProvider.tsx
+++ b/webview-ui/src/components/settings/providers/OllamaProvider.tsx
@@ -9,7 +9,9 @@ import { ApiKeyField } from "../common/ApiKeyField"
 import { BaseUrlField } from "../common/BaseUrlField"
 import { DebouncedTextField } from "../common/DebouncedTextField"
 import OllamaModelPicker from "../OllamaModelPicker"
+import UseCustomPromptCheckbox from "../UseCustomPrompt"
 import { getModeSpecificFields } from "../utils/providerUtils"
+import { updateSetting } from "../utils/settingsHandlers"
 import { useApiConfigurationHandlers } from "../utils/useApiConfigurationHandlers"
 
 /**
@@ -56,7 +58,7 @@ export const OllamaProvider = ({ showModelOptions, isPopup, currentMode }: Ollam
 	useInterval(requestOllamaModels, 2000)
 
 	return (
-		<div>
+		<div className="flex flex-col gap-2">
 			<BaseUrlField
 				initialValue={apiConfiguration?.ollamaBaseUrl}
 				label="Use custom base URL"
@@ -76,7 +78,7 @@ export const OllamaProvider = ({ showModelOptions, isPopup, currentMode }: Ollam
 
 			{/* Model selection - use filterable picker */}
 			<label htmlFor="ollama-model-selection">
-				<span style={{ fontWeight: 500 }}>Model</span>
+				<span className="font-semibold">Model</span>
 			</label>
 			<OllamaModelPicker
 				ollamaModels={ollamaModels}
@@ -89,13 +91,7 @@ export const OllamaProvider = ({ showModelOptions, isPopup, currentMode }: Ollam
 
 			{/* Show status message based on model availability */}
 			{ollamaModels.length === 0 && (
-				<p
-					style={{
-						fontSize: "12px",
-						marginTop: "3px",
-						color: "var(--vscode-descriptionForeground)",
-						fontStyle: "italic",
-					}}>
+				<p className="text-sm mt-1 text-description italic">
 					Unable to fetch models from Ollama server. Please ensure Ollama is running and accessible, or enter the model
 					ID manually above.
 				</p>
@@ -106,7 +102,7 @@ export const OllamaProvider = ({ showModelOptions, isPopup, currentMode }: Ollam
 				onChange={(v) => handleFieldChange("ollamaApiOptionsCtxNum", v || undefined)}
 				placeholder={"e.g. 32768"}
 				style={{ width: "100%" }}>
-				<span style={{ fontWeight: 500 }}>Model Context Window</span>
+				<span className="font-semibold">Model Context Window</span>
 			</DebouncedTextField>
 
 			{showModelOptions && (
@@ -122,13 +118,15 @@ export const OllamaProvider = ({ showModelOptions, isPopup, currentMode }: Ollam
 						}}
 						placeholder="Default: 30000 (30 seconds)"
 						style={{ width: "100%" }}>
-						<span style={{ fontWeight: 500 }}>Request Timeout (ms)</span>
+						<span className="font-semibold">Request Timeout (ms)</span>
 					</DebouncedTextField>
-					<p style={{ fontSize: "12px", marginTop: 3, color: "var(--vscode-descriptionForeground)" }}>
+					<p className="text-xs mt-0 text-description">
 						Maximum time in milliseconds to wait for API responses before timing out.
 					</p>
 				</>
 			)}
+
+			<UseCustomPromptCheckbox key="ollama" />
 
 			<p
 				style={{


### PR DESCRIPTION
<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- For feature requests: Created a discussion in our Feature Requests discussions board https://github.com/cline/cline/discussions/categories/feature-requests and received approval from core maintainers before implementation
- For all changes: Link the associated issue/discussion in the "Related Issue" section below

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly without prior discussion.

Why this requirement?
We deeply appreciate all community contributions - they are essential to Cline's success! To ensure the best use of everyone's time and maintain project direction, we use our Feature Requests discussions board to gauge community interest and validate feature ideas before implementation begins. This helps us focus development efforts on features that will benefit the most users.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** #XXXX

### Description

<!-- 
Help reviewers understand your changes by making this PR readable and well-organized:

- What problem does this PR solve?
- Why were these changes introduced and what purpose do they serve?
- For larger changes, provide context about your approach and reasoning

Small PRs may need minimal description, but larger changes benefit from explaining where you're coming from. Much of this context can be in the linked issue above, so feel free to reference it rather than repeating everything here.
-->

Refactor custom prompt checkbox functionality from LMStudioProvider into a shared UseCustomPrompt component to reduce code duplication and improve maintainability. Add it to the OllamaProvider.

### Test Procedure

<!-- 
Please walk us through your testing approach and thought process. This helps reviewers understand that you've thoroughly considered the impact of your changes:

- How did you test this change?
- What could potentially break and how did you verify it doesn't?
- What existing functionality might be affected and how did you check it still works?
- Why are you confident this is ready for merge?

We're not looking for exhaustive documentation - just evidence that you've thought through the implications of your changes and tested accordingly.
-->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [x] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

<img width="633" height="472" alt="Screenshot 2025-08-25 at 3 16 49 PM" src="https://github.com/user-attachments/assets/e2aaf506-4c8a-4122-97de-7adb90cbe627" />


### Additional Notes

<!-- Add any additional notes for reviewers -->
