### PR TITLE
Remove action buttons from showing for followup and plan_mode_respond

### DIFF
--- a/.changeset/hot-turtles-flash.md
+++ b/.changeset/hot-turtles-flash.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Remove disabled approve / reject buttons from UI.

--- a/webview-ui/src/components/chat/chat-view/shared/buttonConfig.ts
+++ b/webview-ui/src/components/chat/chat-view/shared/buttonConfig.ts
@@ -111,18 +111,18 @@ export const BUTTON_CONFIGS: Record<string, ButtonConfig> = {
 	followup: {
 		sendingDisabled: false,
 		enableButtons: false,
-		primaryText: "Approve",
-		secondaryText: "Reject",
-		primaryAction: "new_task",
+		primaryText: undefined,
+		secondaryText: undefined,
+		primaryAction: undefined,
 		secondaryAction: undefined,
 	},
 	plan_mode_respond: {
 		sendingDisabled: false,
 		enableButtons: false,
-		primaryText: "Approve",
-		secondaryText: "Reject",
-		primaryAction: "approve",
-		secondaryAction: "reject",
+		primaryText: undefined,
+		secondaryText: undefined,
+		primaryAction: undefined,
+		secondaryAction: undefined,
 	},
 
 	// Task lifecycle states


### PR DESCRIPTION
<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- For feature requests: Created a discussion in our Feature Requests discussions board https://github.com/cline/cline/discussions/categories/feature-requests and received approval from core maintainers before implementation
- For all changes: Link the associated issue/discussion in the "Related Issue" section below

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly without prior discussion.

Why this requirement?
We deeply appreciate all community contributions - they are essential to Cline's success! To ensure the best use of everyone's time and maintain project direction, we use our Feature Requests discussions board to gauge community interest and validate feature ideas before implementation begins. This helps us focus development efforts on features that will benefit the most users.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** #XXXX

### Description

<!-- 
Help reviewers understand your changes by making this PR readable and well-organized:

- What problem does this PR solve?
- Why were these changes introduced and what purpose do they serve?
- For larger changes, provide context about your approach and reasoning

Small PRs may need minimal description, but larger changes benefit from explaining where you're coming from. Much of this context can be in the linked issue above, so feel free to reference it rather than repeating everything here.
-->

Set primaryText, secondaryText, and primaryAction to undefined for followup and plan_mode_respond button configurations to disable default approve/reject behavior.

This is addressing the confusions caused by showing disabled action buttons on completed responses for plan mode or follow ups.

### Test Procedure

<!-- 
Please walk us through your testing approach and thought process. This helps reviewers understand that you've thoroughly considered the impact of your changes:

- How did you test this change?
- What could potentially break and how did you verify it doesn't?
- What existing functionality might be affected and how did you check it still works?
- Why are you confident this is ready for merge?

We're not looking for exhaustive documentation - just evidence that you've thought through the implications of your changes and tested accordingly.
-->

Confirm the Disabled Approve and Reject buttons do not show up on completed tasks / plan mode responses.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [x] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Remove disabled approve/reject buttons for `followup` and `plan_mode_respond` states in `buttonConfig.ts`.
> 
>   - **Behavior**:
>     - Set `primaryText`, `secondaryText`, `primaryAction`, and `secondaryAction` to `undefined` for `followup` and `plan_mode_respond` in `BUTTON_CONFIGS` in `buttonConfig.ts`.
>     - Removes disabled approve/reject buttons for these states, preventing confusion on completed responses.
>   - **Misc**:
>     - Adds a changeset file `hot-turtles-flash.md` to document the UI change.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for bca6a4ef8acfe4d6ee1857d9102b451725b026ad. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->