### PR TITLE
bugfix: fixes issue where thinking output wasn't passed through from

### DIFF
--- a/.changeset/cyan-bottles-battle.md
+++ b/.changeset/cyan-bottles-battle.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Fixes an issue where thinking text from litellm was not being passed through to Cline thinking UI

--- a/src/core/api/providers/litellm.ts
+++ b/src/core/api/providers/litellm.ts
@@ -244,16 +244,16 @@ export class LiteLlmHandler implements ApiHandler {
 				}
 			}
 
-			// Handle reasoning events (thinking)
-			// Thinking is not in the standard types but may be in the response
+			// Handle reasoning events
+			// This is not in the standard types but may be in the response
 			interface ThinkingDelta {
-				thinking?: string
+				reasoning_content?: string
 			}
 
-			if ((delta as ThinkingDelta)?.thinking) {
+			if ((delta as ThinkingDelta)?.reasoning_content) {
 				yield {
 					type: "reasoning",
-					reasoning: (delta as ThinkingDelta).thinking || "",
+					reasoning: (delta as ThinkingDelta).reasoning_content || "",
 				}
 			}
 


### PR DESCRIPTION
<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- For feature requests: Created a discussion in our Feature Requests discussions board https://github.com/cline/cline/discussions/categories/feature-requests and received approval from core maintainers before implementation
- For all changes: Link the associated issue/discussion in the "Related Issue" section below

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly without prior discussion.

Why this requirement?
We deeply appreciate all community contributions - they are essential to Cline's success! To ensure the best use of everyone's time and maintain project direction, we use our Feature Requests discussions board to gauge community interest and validate feature ideas before implementation begins. This helps us focus development efforts on features that will benefit the most users.
-->

### Related Issue

**Issue:** #5506 

### Description

#### What problem does this solve?

Currently when using Cline with LiteLLM, no thinking is shown in the Cline UI.
The reason is because the key used in the LiteLLM output thinking text extraction code is incorrectly set to "thinking" but it should be "reasoning_content".

#### Solution

Replace incorrect key "thinking" -> "reasoning_content" used to reference thinking text in output deltas. This is specified as the standard that LiteLLM uses in [the docs](https://docs.litellm.ai/docs/reasoning_content).

### Test Procedure

<!-- 
Please walk us through your testing approach and thought process. This helps reviewers understand that you've thoroughly considered the impact of your changes:

- How did you test this change?
- What could potentially break and how did you verify it doesn't?
- What existing functionality might be affected and how did you check it still works?
- Why are you confident this is ready for merge?

We're not looking for exhaustive documentation - just evidence that you've thought through the implications of your changes and tested accordingly.
-->

#### How did I test the change:
Ran these steps:
- Run Cline branch in debug mode with Cline pointed to a LiteLLM (v1.73.1) instance (which points to vertex API) with
- send message "think" from Cline
- confirm "Thinking" text is visible in Cline UI

For these configurations (set on LiteLLM):
- [x] models
  - [x] claude sonnet 4
  - [x] gemini 2.5 pro
- [x] streaming configs (set on LiteLLM):
  - [x] streaming
  - [x] non-streaming

Configuration used:
- streaming mode = on / off
- model = claude sonnet 4 / gemini 2.5 pro
- model configuration set:
  - max output tokens = 64k
  - temp = 1
- extended thinking mode on + thinking budget set to 3k tokens.

#### What could potentially break and how did I verify it doesn't?
It's possible that "thinking" output key was used for older versions of LiteLLM however
- there doesn't seem to be any evidence for that: "reasoning_content" was first introduced in [this commit on LiteLLM in February](https://github.com/BerriAI/litellm/commit/ab7c4d1a), no "thinking" properties exist alongside it.
- thinking output text wasn't tested in the [Cline PR that introduced "thinking" output extraction for litellm](https://github.com/cline/cline/pull/2615)

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

<img width="402" height="622" alt="image" src="https://github.com/user-attachments/assets/9d9e38ac-e979-4cf2-854c-f36f6e33c2c2" />


### Additional Notes


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes key mismatch in `LiteLlmHandler` to correctly display thinking text from LiteLLM in Cline UI.
> 
>   - **Bug Fix**:
>     - In `LiteLlmHandler` class in `litellm.ts`, change key from `thinking` to `reasoning_content` for extracting thinking text from LiteLLM output.
>     - Ensures thinking text is displayed in Cline UI when using LiteLLM.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 4e10c0797a6ec5ebe3dc8a2f7e5758ba0bafed42. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->