### PR TITLE
Move “focus Cline sidebar” to HostBridge.

### DIFF
--- a/proto/host/workspace.proto
+++ b/proto/host/workspace.proto
@@ -26,6 +26,9 @@ service WorkspaceService {
 
   // Opens the IDE file explorer panel and selects a file or directory.
   rpc openInFileExplorerPanel(OpenInFileExplorerPanelRequest) returns (OpenInFileExplorerPanelResponse); 
+
+  // Opens and focuses the Cline sidebar panel in the host IDE.
+  rpc openClineSidebarPanel(OpenClineSidebarPanelRequest) returns (OpenClineSidebarPanelResponse);
 }
 
 message GetWorkspacePathsRequest {
@@ -86,3 +89,7 @@ message OpenInFileExplorerPanelRequest {
   string path = 1;
 }
 message OpenInFileExplorerPanelResponse {}
+
+// Request/response for opening the Cline sidebar
+message OpenClineSidebarPanelRequest {}
+message OpenClineSidebarPanelResponse {}

--- a/src/common.ts
+++ b/src/common.ts
@@ -75,7 +75,7 @@ async function showVersionUpdateAnnouncement(context: vscode.ExtensionContext) {
 				const message = previousVersion
 					? `Cline has been updated to v${currentVersion}`
 					: `Welcome to Cline v${currentVersion}`
-				await vscode.commands.executeCommand("claude-dev.SidebarProvider.focus")
+				await HostProvider.workspace.openClineSidebarPanel({})
 				await new Promise((resolve) => setTimeout(resolve, 200))
 				HostProvider.window.showMessage({
 					type: ShowMessageType.INFORMATION,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -443,8 +443,8 @@ export async function activate(context: vscode.ExtensionContext) {
 				if (tabInstances.length > 0) {
 					activeWebview = tabInstances[tabInstances.length - 1]
 				} else {
-					// Try to focus sidebar
-					await vscode.commands.executeCommand("claude-dev.SidebarProvider.focus")
+					// Try to focus sidebar via hostbridge
+					await HostProvider.workspace.openClineSidebarPanel({})
 
 					// Small delay for focus to complete
 					await new Promise((resolve) => setTimeout(resolve, 200))

--- a/src/hosts/vscode/hostbridge/workspace/openClineSidebarPanel.ts
+++ b/src/hosts/vscode/hostbridge/workspace/openClineSidebarPanel.ts
@@ -1,0 +1,7 @@
+import * as vscode from "vscode"
+import { OpenClineSidebarPanelRequest, OpenClineSidebarPanelResponse } from "@/shared/proto/index.host"
+
+export async function openClineSidebarPanel(_: OpenClineSidebarPanelRequest): Promise<OpenClineSidebarPanelResponse> {
+	await vscode.commands.executeCommand("claude-dev.SidebarProvider.focus")
+	return {}
+}


### PR DESCRIPTION
<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- For feature requests: Created a discussion in our Feature Requests discussions board https://github.com/cline/cline/discussions/categories/feature-requests and received approval from core maintainers before implementation
- For all changes: Link the associated issue/discussion in the "Related Issue" section below

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly without prior discussion.

Why this requirement?
We deeply appreciate all community contributions - they are essential to Cline's success! To ensure the best use of everyone's time and maintain project direction, we use our Feature Requests discussions board to gauge community interest and validate feature ideas before implementation begins. This helps us focus development efforts on features that will benefit the most users.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** #XXXX
vscode.commands.executeCommand("claude-dev.SidebarProvider.focus") to HostBridge. 

### Description
Add openClineSidebarPanel RPC and route VS Code focus via hostbridge
<!-- 
Help reviewers understand your changes by making this PR readable and well-organized:

- What problem does this PR solve?
- Why were these changes introduced and what purpose do they serve?
- For larger changes, provide context about your approach and reasoning

Small PRs may need minimal description, but larger changes benefit from explaining where you're coming from. Much of this context can be in the linked issue above, so feel free to reference it rather than repeating everything here.
-->

### Test Procedure
Command Palette: Cline: Jump to Chat Input
Simulate update: bump minor version in package.json, reload and Cline is focused.
<!-- 
Please walk us through your testing approach and thought process. This helps reviewers understand that you've thoroughly considered the impact of your changes:

- How did you test this change?
- What could potentially break and how did you verify it doesn't?
- What existing functionality might be affected and how did you check it still works?
- Why are you confident this is ready for merge?

We're not looking for exhaustive documentation - just evidence that you've thought through the implications of your changes and tested accordingly.
-->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [x] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Refactor Cline sidebar focus logic to use a new HostBridge RPC method `openClineSidebarPanel`.
> 
>   - **Behavior**:
>     - Adds `openClineSidebarPanel` RPC to `proto/host/workspace.proto` for focusing the Cline sidebar.
>     - Replaces `vscode.commands.executeCommand("claude-dev.SidebarProvider.focus")` with `HostProvider.workspace.openClineSidebarPanel({})` in `src/common.ts` and `src/extension.ts`.
>   - **Implementation**:
>     - Implements `openClineSidebarPanel` in `openClineSidebarPanel.ts` to execute the focus command.
>   - **Misc**:
>     - Minor refactor to centralize sidebar focus logic via HostBridge.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 497838526848f67199202727572d5e688be08bb8. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->