### PR TITLE
Fix: Improve screen reader accessibility for MCP servers / Cline rules screens

### DIFF
--- a/.changeset/seven-pumas-worry.md
+++ b/.changeset/seven-pumas-worry.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Screen readers properly announce buttons in the MCP servers / Cline rules / workflows screens. Reflects the current selection of Cline rules / workflows tab to screen readers.

--- a/webview-ui/src/components/chat/ServersToggleModal.tsx
+++ b/webview-ui/src/components/chat/ServersToggleModal.tsx
@@ -57,7 +57,7 @@ const ServersToggleModal: React.FC = () => {
 				<Tooltip tipText="Manage MCP Servers" visible={isVisible ? false : undefined}>
 					<VSCodeButton
 						appearance="icon"
-						aria-label="MCP Servers"
+						aria-label={isVisible ? "Hide MCP Servers" : "Show MCP Servers"}
 						onClick={() => setIsVisible(!isVisible)}
 						style={{ padding: "0px 0px", height: "20px" }}>
 						<div className="flex items-center gap-1 text-xs whitespace-nowrap min-w-0 w-full">
@@ -92,6 +92,7 @@ const ServersToggleModal: React.FC = () => {
 						<div className="m-0 text-base font-semibold">MCP Servers</div>
 						<VSCodeButton
 							appearance="icon"
+							aria-label="Go to MCP server settings"
 							onClick={() => {
 								setIsVisible(false)
 								navigateToMcp("installed")

--- a/webview-ui/src/components/cline-rules/ClineRulesToggleModal.tsx
+++ b/webview-ui/src/components/cline-rules/ClineRulesToggleModal.tsx
@@ -199,7 +199,7 @@ const ClineRulesToggleModal: React.FC = () => {
 				<Tooltip tipText="Manage Cline Rules & Workflows" visible={isVisible ? false : undefined}>
 					<VSCodeButton
 						appearance="icon"
-						aria-label="Cline Rules"
+						aria-label={isVisible ? "Hide Cline Rules & Workflows" : "Show Cline Rules & Workflows"}
 						onClick={() => setIsVisible(!isVisible)}
 						style={{ padding: "0px 0px", height: "20px" }}>
 						<div className="flex items-center gap-1 text-xs whitespace-nowrap min-w-0 w-full">
@@ -395,7 +395,7 @@ export const TabButton = ({
 	isActive: boolean
 	onClick: () => void
 }) => (
-	<StyledTabButton isActive={isActive} onClick={onClick}>
+	<StyledTabButton aria-pressed={isActive} isActive={isActive} onClick={onClick}>
 		{children}
 	</StyledTabButton>
 )

--- a/webview-ui/src/components/cline-rules/NewRuleRow.tsx
+++ b/webview-ui/src/components/cline-rules/NewRuleRow.tsx
@@ -133,7 +133,7 @@ const NewRuleRow: React.FC<NewRuleRowProps> = ({ isGlobal, ruleType }) => {
 						<div className="flex items-center ml-2 space-x-2">
 							<VSCodeButton
 								appearance="icon"
-								aria-label="New rule file"
+								aria-label={ruleType === "workflow" ? "New workflow file..." : "New rule file..."}
 								onClick={(e) => {
 									e.stopPropagation()
 									setIsExpanded(true)


### PR DESCRIPTION
<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- For feature requests: Created a discussion in our Feature Requests discussions board https://github.com/cline/cline/discussions/categories/feature-requests and received approval from core maintainers before implementation
- For all changes: Link the associated issue/discussion in the "Related Issue" section below

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly without prior discussion.

Why this requirement?
We deeply appreciate all community contributions - they are essential to Cline's success! To ensure the best use of everyone's time and maintain project direction, we use our Feature Requests discussions board to gauge community interest and validate feature ideas before implementation begins. This helps us focus development efforts on features that will benefit the most users.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** #4245 

### Description
Made it easier for screen reader users to navigate in the screens described in the title. It also tells screen readers which tab is being selected in the Cline rules / workflows screen.

<!-- 
Help reviewers understand your changes by making this PR readable and well-organized:

- What problem does this PR solve?
- Why were these changes introduced and what purpose do they serve?
- For larger changes, provide context about your approach and reasoning

Small PRs may need minimal description, but larger changes benefit from explaining where you're coming from. Much of this context can be in the linked issue above, so feel free to reference it rather than repeating everything here.
-->

### Test Procedure

<!-- 
Please walk us through your testing approach and thought process. This helps reviewers understand that you've thoroughly considered the impact of your changes:

- How did you test this change?
- What could potentially break and how did you verify it doesn't?
- What existing functionality might be affected and how did you check it still works?
- Why are you confident this is ready for merge?

We're not looking for exhaustive documentation - just evidence that you've thought through the implications of your changes and tested accordingly.
-->

1. Go to Cline chat screen.
2. Try to show / hide MCP servers and Cline rules / workflows
3. Screen readers properly announce what would happen by pressing the buttons, E.G. "Show MCP servers" or "Hide MCP servers"
4. In the rules / workflow screen, screen readers announces which tab is being selected.
5. When adding new rule / workflow file, screen readers announce "new rule file" or "new workflow file" respectively (before my fix, they always said new rule file regardless of the actual file type being created)

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Improves screen reader accessibility for MCP servers and Cline rules/workflows screens by updating aria-labels and button states.
> 
>   - **Accessibility Improvements**:
>     - `ServersToggleModal.tsx`: Updates `aria-label` for buttons to announce "Show/Hide MCP Servers" based on visibility.
>     - `ClineRulesToggleModal.tsx`: Updates `aria-label` for buttons to announce "Show/Hide Cline Rules & Workflows" based on visibility. Adds `aria-pressed` to `TabButton` to indicate active tab.
>     - `NewRuleRow.tsx`: Updates `aria-label` to announce "New rule file" or "New workflow file" based on `ruleType`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 544a905ea3238181dac07f51971faa6676cb13a2. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->