### PR TITLE
Don't throw an exception if deleting a directory fails.

### DIFF
--- a/src/integrations/editor/DiffViewProvider.ts
+++ b/src/integrations/editor/DiffViewProvider.ts
@@ -324,7 +324,7 @@ export abstract class DiffViewProvider {
 					await fs.rmdir(this.createdDirs[i])
 					console.log(`Directory ${this.createdDirs[i]} has been deleted.`)
 				} catch (error) {
-					console.log("Could not delete directory", error)
+					console.log(`Could not delete directory ${this.createdDirs[i]}`, error)
 				}
 			}
 		} else {

--- a/src/integrations/editor/DiffViewProvider.ts
+++ b/src/integrations/editor/DiffViewProvider.ts
@@ -316,12 +316,17 @@ export abstract class DiffViewProvider {
 			await this.saveDocument()
 			await this.closeAllDiffViews()
 			await fs.rm(this.absolutePath, { force: true })
+			console.log(`File ${this.absolutePath} has been deleted.`)
+
 			// Remove only the directories we created, in reverse order
 			for (let i = this.createdDirs.length - 1; i >= 0; i--) {
-				await fs.rmdir(this.createdDirs[i])
-				console.log(`Directory ${this.createdDirs[i]} has been deleted.`)
+				try {
+					await fs.rmdir(this.createdDirs[i])
+					console.log(`Directory ${this.createdDirs[i]} has been deleted.`)
+				} catch (error) {
+					console.log("Could not delete directory", error)
+				}
 			}
-			console.log(`File ${this.absolutePath} has been deleted.`)
 		} else {
 			// revert document
 			// Apply the edit and save, since contents shouldn't have changed this won't show in local history unless of


### PR DESCRIPTION
The external diff view provider throws an error while reverting the diff if the directory is missing. This is not a real error though, we should continue the revert even if deleting the directories failed.

Fixes:
```
[2025-08-27T22:52:23.673] #bot.cline.server.ts ProtoBus handler error: /cline.TaskService/clearTask
Error: ENOENT: no such file or directory, rmdir '/Users/sjf/plugin/.github/actions/build-test-upload'
    at async Object.rmdir (node:internal/fs/promises:818:10)
    at async ExternalDiffViewProvider.revertChanges (/path/to/cline/core/0.0.1/cline-core.js:848418:9)
    at async Task.abortTask (/path/to/cline/core/0.0.1/cline-core.js:830605:9)
    at async Controller.clearTask (/path/to/cline/core/0.0.1/cline-core.js:832296:9)
    at async clearTask (/path/to/cline/core/0.0.1/cline-core.js:658823:3)
    at async Object.clearTask (/path/to/cline/core/0.0.1/cline-core.js:872829:23)
```
<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Wrap `fs.rmdir` in a try-catch block in `DiffViewProvider.ts` to prevent exceptions if directory deletion fails.
> 
>   - **Behavior**:
>     - In `DiffViewProvider.ts`, wrap `fs.rmdir` in a try-catch block to prevent exceptions if directory deletion fails.
>     - Log an error message if directory deletion fails, instead of throwing an exception.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for e98cb339e9fa99d5c68b372fcd62b3493dc8d7c5. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->