### PR TITLE
fix: Harden PromptRegistry with health checks and generic fallback

### DIFF
--- a/src/core/prompts/system-prompt/__tests__/integration.test.ts
+++ b/src/core/prompts/system-prompt/__tests__/integration.test.ts
@@ -63,7 +63,9 @@ ${differences}
 
 // Helper to compare two strings and return differences
 const compareStrings = (expected: string, actual: string): string | null => {
-	if (expected === actual) return null
+	if (expected === actual) {
+		return null
+	}
 
 	const expectedLines = expected.split("\n")
 	const actualLines = actual.split("\n")

--- a/src/core/prompts/system-prompt/registry/PromptRegistry.ts
+++ b/src/core/prompts/system-prompt/registry/PromptRegistry.ts
@@ -236,7 +236,11 @@ export class PromptRegistry {
 	 */
 	private loadVariants(): void {
 		try {
-			loadAllVariantConfigs()
+			this.variants = new Map<string, PromptVariant>()
+
+			for (const [id, config] of Object.entries(loadAllVariantConfigs())) {
+				this.variants.set(id, { ...config, id })
+			}
 
 			// Ensure generic variant is always available as a safety fallback
 			this.ensureGenericFallback()

--- a/src/core/prompts/system-prompt/variants/generic/template.ts
+++ b/src/core/prompts/system-prompt/variants/generic/template.ts
@@ -1,4 +1,4 @@
-import { SystemPromptSection } from "../.."
+import { SystemPromptSection } from "../../templates/placeholders"
 
 export const baseTemplate = `{{${SystemPromptSection.AGENT_ROLE}}}
 

--- a/src/core/prompts/system-prompt/variants/gpt-5/template.ts
+++ b/src/core/prompts/system-prompt/variants/gpt-5/template.ts
@@ -1,4 +1,4 @@
-import { SystemPromptSection } from "../.."
+import { SystemPromptSection } from "../../templates/placeholders"
 
 export const baseTemplate = `{{${SystemPromptSection.AGENT_ROLE}}}
 

--- a/src/core/prompts/system-prompt/variants/index.ts
+++ b/src/core/prompts/system-prompt/variants/index.ts
@@ -67,7 +67,7 @@ export function isValidVariantId(id: string): id is VariantId {
  * @param variantId - The ID of the variant to load
  * @returns Promise that resolves to the variant configuration
  */
-export async function loadVariantConfig(variantId: VariantId) {
+export function loadVariantConfig(variantId: VariantId) {
 	return VARIANT_CONFIGS[variantId]
 }
 
@@ -76,6 +76,5 @@ export async function loadVariantConfig(variantId: VariantId) {
  * @returns Promise that resolves to a map of all variant configurations
  */
 export async function loadAllVariantConfigs() {
-	const entries = await Promise.all(Object.entries(VARIANT_CONFIGS).map(async ([id, config]) => [id, config] as const))
-	return Object.fromEntries(entries) as Record<VariantId, any>
+	return Object.fromEntries(Object.entries(VARIANT_CONFIGS).map(([id, config]) => [id, config()]))
 }

--- a/src/core/prompts/system-prompt/variants/index.ts
+++ b/src/core/prompts/system-prompt/variants/index.ts
@@ -29,6 +29,7 @@ export const VARIANT_CONFIGS = {
 	 * Includes additional features like feedback loops and web fetching
 	 */
 	"next-gen": () => import("./next-gen/config").then((m) => m.config),
+	gpt5: () => import("./gpt-5/config").then((m) => m.config),
 
 	/**
 	 * XS variant - Compact models with limited context windows

--- a/src/core/prompts/system-prompt/variants/index.ts
+++ b/src/core/prompts/system-prompt/variants/index.ts
@@ -7,8 +7,14 @@
  */
 
 export { config as genericConfig, type GenericVariantConfig } from "./generic/config"
+export { config as gpt5Config, type GPT5VariantConfig } from "./gpt-5/config"
 export { config as nextGenConfig, type NextGenVariantConfig } from "./next-gen/config"
 export { config as xsConfig, type XsVariantConfig } from "./xs/config"
+
+import { config as genericConfig } from "./generic/config"
+import { config as gpt5Config } from "./gpt-5/config"
+import { config as nextGenConfig } from "./next-gen/config"
+import { config as xsConfig } from "./xs/config"
 
 /**
  * Variant Registry for dynamic loading
@@ -22,20 +28,20 @@ export const VARIANT_CONFIGS = {
 	 * Generic variant - Fallback for all model types
 	 * Optimized for broad compatibility and stable performance
 	 */
-	generic: () => import("./generic/config").then((m) => m.config),
+	generic: () => genericConfig,
 
 	/**
 	 * Next-gen variant - Advanced models with enhanced capabilities
 	 * Includes additional features like feedback loops and web fetching
 	 */
-	"next-gen": () => import("./next-gen/config").then((m) => m.config),
-	gpt5: () => import("./gpt-5/config").then((m) => m.config),
+	"next-gen": nextGenConfig,
+	gpt5: () => gpt5Config,
 
 	/**
 	 * XS variant - Compact models with limited context windows
 	 * Streamlined for efficiency with essential tools only
 	 */
-	xs: () => import("./xs/config").then((m) => m.config),
+	xs: () => xsConfig,
 } as const
 
 /**
@@ -64,8 +70,7 @@ export function isValidVariantId(id: string): id is VariantId {
  * @returns Promise that resolves to the variant configuration
  */
 export async function loadVariantConfig(variantId: VariantId) {
-	const loader = VARIANT_CONFIGS[variantId]
-	return await loader()
+	return VARIANT_CONFIGS[variantId]
 }
 
 /**
@@ -73,6 +78,6 @@ export async function loadVariantConfig(variantId: VariantId) {
  * @returns Promise that resolves to a map of all variant configurations
  */
 export async function loadAllVariantConfigs() {
-	const entries = await Promise.all(Object.entries(VARIANT_CONFIGS).map(async ([id, loader]) => [id, await loader()] as const))
-	return Object.fromEntries(entries) as Record<VariantId, Awaited<ReturnType<(typeof VARIANT_CONFIGS)[VariantId]>>>
+	const entries = await Promise.all(Object.entries(VARIANT_CONFIGS).map(async ([id, config]) => [id, config] as const))
+	return Object.fromEntries(entries) as Record<VariantId, any>
 }

--- a/src/core/prompts/system-prompt/variants/index.ts
+++ b/src/core/prompts/system-prompt/variants/index.ts
@@ -26,20 +26,20 @@ export const VARIANT_CONFIGS = {
 	 * Generic variant - Fallback for all model types
 	 * Optimized for broad compatibility and stable performance
 	 */
-	generic: () => genericConfig,
+	generic: genericConfig,
 
 	/**
 	 * Next-gen variant - Advanced models with enhanced capabilities
 	 * Includes additional features like feedback loops and web fetching
 	 */
-	"next-gen": () => nextGenConfig,
-	gpt5: () => gpt5Config,
+	"next-gen": nextGenConfig,
+	gpt5: gpt5Config,
 
 	/**
 	 * XS variant - Compact models with limited context windows
 	 * Streamlined for efficiency with essential tools only
 	 */
-	xs: () => xsConfig,
+	xs: xsConfig,
 } as const
 
 /**
@@ -76,5 +76,5 @@ export function loadVariantConfig(variantId: VariantId) {
  * @returns A map of all variant configurations
  */
 export function loadAllVariantConfigs() {
-	return Object.fromEntries(Object.entries(VARIANT_CONFIGS).map(([id, config]) => [id, config()]))
+	return VARIANT_CONFIGS
 }

--- a/src/core/prompts/system-prompt/variants/index.ts
+++ b/src/core/prompts/system-prompt/variants/index.ts
@@ -65,7 +65,7 @@ export function isValidVariantId(id: string): id is VariantId {
 /**
  * Load a variant configuration dynamically
  * @param variantId - The ID of the variant to load
- * @returns Promise that resolves to the variant configuration
+ * @returns Variant configuration
  */
 export function loadVariantConfig(variantId: VariantId) {
 	return VARIANT_CONFIGS[variantId]
@@ -73,8 +73,8 @@ export function loadVariantConfig(variantId: VariantId) {
 
 /**
  * Load all variant configurations
- * @returns Promise that resolves to a map of all variant configurations
+ * @returns A map of all variant configurations
  */
-export async function loadAllVariantConfigs() {
+export function loadAllVariantConfigs() {
 	return Object.fromEntries(Object.entries(VARIANT_CONFIGS).map(([id, config]) => [id, config()]))
 }

--- a/src/core/prompts/system-prompt/variants/index.ts
+++ b/src/core/prompts/system-prompt/variants/index.ts
@@ -19,9 +19,7 @@ import { config as xsConfig } from "./xs/config"
 /**
  * Variant Registry for dynamic loading
  *
- * This registry allows for lazy loading of variant configurations,
- * which is useful for reducing initial bundle size and enabling
- * runtime variant selection.
+ * This registry allows for loading variant configurations.
  */
 export const VARIANT_CONFIGS = {
 	/**
@@ -34,7 +32,7 @@ export const VARIANT_CONFIGS = {
 	 * Next-gen variant - Advanced models with enhanced capabilities
 	 * Includes additional features like feedback loops and web fetching
 	 */
-	"next-gen": nextGenConfig,
+	"next-gen": () => nextGenConfig,
 	gpt5: () => gpt5Config,
 
 	/**

--- a/src/core/prompts/system-prompt/variants/next-gen/template.ts
+++ b/src/core/prompts/system-prompt/variants/next-gen/template.ts
@@ -1,4 +1,4 @@
-import { SystemPromptSection } from "../.."
+import { SystemPromptSection } from "../../templates/placeholders"
 
 export const baseTemplate = `{{${SystemPromptSection.AGENT_ROLE}}}
 

--- a/src/core/prompts/system-prompt/variants/xs/overrides.ts
+++ b/src/core/prompts/system-prompt/variants/xs/overrides.ts
@@ -1,4 +1,5 @@
-import { PromptVariant, SystemPromptSection } from "../.."
+import { SystemPromptSection } from "../../templates/placeholders"
+import { PromptVariant } from "../../types"
 
 const XS_EDITING_FILES = `FILE EDITING RULES
 - Default: replace_in_file; write_to_file for new files or full rewrites.


### PR DESCRIPTION
<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- For feature requests: Created a discussion in our Feature Requests discussions board https://github.com/cline/cline/discussions/categories/feature-requests and received approval from core maintainers before implementation
- For all changes: Link the associated issue/discussion in the "Related Issue" section below

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly without prior discussion.

Why this requirement?
We deeply appreciate all community contributions - they are essential to Cline's success! To ensure the best use of everyone's time and maintain project direction, we use our Feature Requests discussions board to gauge community interest and validate feature ideas before implementation begins. This helps us focus development efforts on features that will benefit the most users.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** #XXXX

### Description

<!-- 
Help reviewers understand your changes by making this PR readable and well-organized:

- What problem does this PR solve?
- Why were these changes introduced and what purpose do they serve?
- For larger changes, provide context about your approach and reasoning

Small PRs may need minimal description, but larger changes benefit from explaining where you're coming from. Much of this context can be in the linked issue above, so feel free to reference it rather than repeating everything here.
-->

<img width="1728" height="986" alt="image" src="https://github.com/user-attachments/assets/88f21bbe-f61c-47c5-b947-f68b087569c1" />

- Register and import gpt-5 variant
- Perform registry health check after loading (validate GENERIC, log counts/warnings)
- Always try GENERIC when family-specific variant is missing
- Enhance error diagnostics with available variants and registry state
- Ensure GENERIC variant exists; create minimal fallback if loading fails
- Minor test style cleanup and variants index update to support reliability

### Test Procedure

<!-- 
Please walk us through your testing approach and thought process. This helps reviewers understand that you've thoroughly considered the impact of your changes:

- How did you test this change?
- What could potentially break and how did you verify it doesn't?
- What existing functionality might be affected and how did you check it still works?
- Why are you confident this is ready for merge?

We're not looking for exhaustive documentation - just evidence that you've thought through the implications of your changes and tested accordingly.
-->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

#### Before

<img width="489" height="285" alt="image" src="https://github.com/user-attachments/assets/07b3ff48-a69b-4c5b-b148-be42093857ef" />

#### After

Cline GPT 5

<img width="523" height="1025" alt="Screenshot 2025-08-28 at 3 23 11 PM" src="https://github.com/user-attachments/assets/2b6c2b67-7f9e-4135-9e21-5d19a951d981" />

OPEN AI GPT 5 

<img width="1724" height="998" alt="Screenshot 2025-08-28 at 3 24 49 PM" src="https://github.com/user-attachments/assets/c6f6835c-c23d-4d31-8fd9-bd7fb548d76f" />


### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Enhances `PromptRegistry` with health checks, ensures a generic fallback, and adds GPT-5 variant support.
> 
>   - **Behavior**:
>     - Adds health check in `PromptRegistry` to ensure critical variants like GENERIC are available.
>     - Ensures a minimal GENERIC variant is created if loading fails in `PromptRegistry.ts`.
>     - Always attempts to use GENERIC variant if family-specific variant is missing in `PromptRegistry.ts`.
>   - **Variants**:
>     - Registers and imports new GPT-5 variant in `variants/index.ts`.
>     - Updates `loadAllVariantConfigs()` to return a map of all variant configurations in `variants/index.ts`.
>   - **Error Handling**:
>     - Enhances error diagnostics in `PromptRegistry.ts` with available variants and registry state.
>   - **Misc**:
>     - Minor test style cleanup in `integration.test.ts`.
>     - Updates templates for `generic`, `gpt-5`, and `next-gen` variants to use `SystemPromptSection` placeholders.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 00b78ceaf8b65944ceb45b3cc5fc9502259d5ee6. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->