### PR TITLE
Fix int32 overflow in the models proto

### DIFF
--- a/proto/cline/models.proto
+++ b/proto/cline/models.proto
@@ -50,20 +50,20 @@ message LanguageModelChatSelector {
 
 // Price tier for tiered pricing models
 message PriceTier {
-  int32 token_limit = 1;  // Upper limit (inclusive) of input tokens for this price
+  int64 token_limit = 1;  // Upper limit (inclusive) of input tokens for this price
   double price = 2;       // Price per million tokens for this tier
 }
 
 // Thinking configuration for models that support thinking/reasoning
 message ThinkingConfig {
-  optional int32 max_budget = 1;                    // Max allowed thinking budget tokens
+  optional int64 max_budget = 1;                    // Max allowed thinking budget tokens
   optional double output_price = 2;                 // Output price per million tokens when budget > 0
   repeated PriceTier output_price_tiers = 3;        // Optional: Tiered output price when budget > 0
 }
 
 // Model tier for tiered pricing structures
 message ModelTier {
-  int32 context_window = 1;
+  int64 context_window = 1;
   optional double input_price = 2;
   optional double output_price = 3;
   optional double cache_writes_price = 4;
@@ -161,8 +161,8 @@ enum ApiProvider {
 
 // Model info for OpenAI-compatible models
 message OpenAiCompatibleModelInfo {
-  optional int32 max_tokens = 1;
-  optional int32 context_window = 2;
+  optional int64 max_tokens = 1;
+  optional int64 context_window = 2;
   optional bool supports_images = 3;
   bool supports_prompt_cache = 4;
   optional double input_price = 5;
@@ -179,8 +179,8 @@ message OpenAiCompatibleModelInfo {
 
 // Model info for LiteLLM models
 message LiteLLMModelInfo {
-  optional int32 max_tokens = 1;
-  optional int32 context_window = 2;
+  optional int64 max_tokens = 1;
+  optional int64 context_window = 2;
   optional bool supports_images = 3;
   bool supports_prompt_cache = 4;
   optional double input_price = 5;
@@ -232,8 +232,8 @@ message ModelsApiConfiguration {
   optional string requesty_base_url = 33;
   optional string together_api_key = 34;
   optional string fireworks_api_key = 35;
-  optional int32 fireworks_model_max_completion_tokens = 36;
-  optional int32 fireworks_model_max_tokens = 37;
+  optional int64 fireworks_model_max_completion_tokens = 36;
+  optional int64 fireworks_model_max_tokens = 37;
   optional string qwen_api_key = 38;
   optional string doubao_api_key = 39;
   optional string mistral_api_key = 40;
@@ -245,7 +245,7 @@ message ModelsApiConfiguration {
   optional string xai_api_key = 46;
   optional string sambanova_api_key = 47;
   optional string cerebras_api_key = 48;
-  optional int32 request_timeout_ms = 49;
+  optional int64 request_timeout_ms = 49;
   optional string sap_ai_core_client_id = 50;
   optional string sap_ai_core_client_secret = 51;
   optional string sap_ai_resource_group = 52;
@@ -273,7 +273,7 @@ message ModelsApiConfiguration {
   // Plan mode configurations
   optional ApiProvider plan_mode_api_provider = 100;
   optional string plan_mode_api_model_id = 101;
-  optional int32 plan_mode_thinking_budget_tokens = 102;
+  optional int64 plan_mode_thinking_budget_tokens = 102;
   optional string plan_mode_reasoning_effort = 103;
   optional LanguageModelChatSelector plan_mode_vs_code_lm_model_selector = 104;
   optional bool plan_mode_aws_bedrock_custom_selected = 105;
@@ -305,7 +305,7 @@ message ModelsApiConfiguration {
   // Act mode configurations
   optional ApiProvider act_mode_api_provider = 200;
   optional string act_mode_api_model_id = 201;
-  optional int32 act_mode_thinking_budget_tokens = 202;
+  optional int64 act_mode_thinking_budget_tokens = 202;
   optional string act_mode_reasoning_effort = 203;
   optional LanguageModelChatSelector act_mode_vs_code_lm_model_selector = 204;
   optional bool act_mode_aws_bedrock_custom_selected = 205;


### PR DESCRIPTION
Cline-core is setting some of these values in the models proto to the javascript Number.MAX_SAFE_VALUE, which won't fit in int32, so these protobuf messages fail to serialize to and can't be transported.

Just change all the int32s in this file to int64 beceause this is the second time this same issue has occured.

Fixes:
```
2025-08-28 16:30:03,824 [   3479]   WARN - bot.cline.services.ProtoBusProxyService - Stream cline.ModelsService.subscribeToOpenRouterModels encountered error
io.grpc.StatusException: INTERNAL: invalid int32: 9007199254740991
        at io.grpc.Status.asException(Status.java:548)
        at io.grpc.kotlin.ClientCalls$rpcImpl$1$1$1.onClose(ClientCalls.kt:300)
        at io.grpc.internal.ClientCallImpl.closeObserver(ClientCallImpl.java:564)
        at io.grpc.internal.ClientCallImpl.access$100(ClientCallImpl.java:72)
        at io.grpc.internal.ClientCallImpl$ClientStreamListenerImpl$1StreamClosed.runInternal(ClientCallImpl.java:729)
        at io.grpc.internal.ClientCallImpl$ClientStreamListenerImpl$1StreamClosed.runInContext(ClientCallImpl.java:710)
        at io.grpc.internal.ContextRunnable.run(ContextRunnable.java:37)
        at io.grpc.internal.SerializingExecutor.run(SerializingExecutor.java:133)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Wor
```
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Convert all `int32` fields to `int64` in `proto/cline/models.proto` to fix overflow issues.
> 
>   - **Behavior**:
>     - Change all `int32` fields to `int64` in `proto/cline/models.proto` to prevent overflow issues.
>     - Affects fields like `token_limit`, `max_budget`, `context_window`, `max_tokens`, and `request_timeout_ms`.
>   - **Messages**:
>     - `PriceTier`, `ThinkingConfig`, `ModelTier`, `OpenAiCompatibleModelInfo`, `LiteLLMModelInfo`, and `ModelsApiConfiguration` updated to use `int64`.
>   - **Misc**:
>     - Fixes serialization errors due to `int32` overflow when using large values like `Number.MAX_SAFE_VALUE`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 3667a20d39ac142377b7d76553e655f57396caef. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->