### PR TITLE
fix z index mcp response dropdown

### DIFF
--- a/webview-ui/src/components/mcp/chat-display/McpResponseDisplay.tsx
+++ b/webview-ui/src/components/mcp/chat-display/McpResponseDisplay.tsx
@@ -50,6 +50,7 @@ const ResponseContainer = styled.div`
 	border-radius: 3px;
 	border: 1px solid var(--vscode-editorGroup-border);
 	overflow: hidden;
+	z-index: 0;
 
 	.response-content {
 		overflow-x: auto;


### PR DESCRIPTION

### Description

Mcp response dropdown was showing up above mcp and cline rules modals

### Test Procedure

Test that this no longer happens.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

https://github.com/user-attachments/assets/75684b22-88ce-4b44-8b4e-977c934ee88c


<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Set `z-index: 0` for `ResponseContainer` in `McpResponseDisplay.tsx` to fix dropdown layering issue with modals.
> 
>   - **Behavior**:
>     - Set `z-index: 0` for `ResponseContainer` in `McpResponseDisplay.tsx` to ensure dropdown appears below modals.
>   - **Test**:
>     - Verify dropdown no longer appears above MCP and Cline rules modals.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 013b78c0907b11b3943d75c6857cd22aaec43a1d. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->