### PR TITLE
fix:  improve caching and prevent duplicate fetches in AccountView

### DIFF
--- a/.changeset/cuddly-dingos-tap.md
+++ b/.changeset/cuddly-dingos-tap.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Fix issue on Account view where balance is fetched twice that cause janky UI

--- a/webview-ui/src/components/account/AccountView.tsx
+++ b/webview-ui/src/components/account/AccountView.tsx
@@ -41,7 +41,7 @@ const AccountView = ({ onDone, clineUser, organizations, activeOrganization }: A
 				<VSCodeButton onClick={onDone}>Done</VSCodeButton>
 			</div>
 			<div className="flex-grow overflow-hidden pr-[8px] flex flex-col">
-				<div className="h-full mb-[5px]">
+				<div className="h-full mb-1.5">
 					{clineUser?.uid ? (
 						<ClineAccountView
 							activeOrganization={activeOrganization}
@@ -89,20 +89,25 @@ export const ClineAccountView = ({ clineUser, userOrganizations, activeOrganizat
 	}, [])
 
 	// Simple cache function without dependencies
-	const cacheCurrentData = (id: string) => {
-		dataCache.current.set(id, {
-			balance,
-			usageData,
-			paymentsData,
-			lastFetchTime,
-		})
-	}
+	const cacheCurrentData = useCallback(
+		(id: string) => {
+			dataCache.current.set(id, {
+				balance,
+				usageData,
+				paymentsData,
+				lastFetchTime,
+			})
+		},
+		[balance, usageData, paymentsData, lastFetchTime],
+	)
 	// Track the active organization ID to detect changes
 	const [lastActiveOrgId, setLastActiveOrgId] = useState<string | undefined>(activeOrganization?.organizationId)
 	// Use ref for debounce timeout to avoid re-renders
 	const debounceTimeoutRef = useRef<NodeJS.Timeout | null>(null)
 	// Track if manual fetch is in progress to avoid duplicate fetches
 	const manualFetchInProgressRef = useRef<boolean>(false)
+	// Track if initial mount fetch has completed to avoid duplicate fetches
+	const initialFetchCompleteRef = useRef<boolean>(false)
 
 	const fetchUserCredit = useCallback(async () => {
 		try {
@@ -119,7 +124,6 @@ export const ClineAccountView = ({ clineUser, userOrganizations, activeOrganizat
 		}
 	}, [])
 
-	// biome-ignore lint/correctness/useExhaustiveDependencies: <cacheCurrentData changes on every re-render>
 	const fetchCreditBalance = useCallback(
 		async (id: string, skipCache = false) => {
 			try {
@@ -159,7 +163,6 @@ export const ClineAccountView = ({ clineUser, userOrganizations, activeOrganizat
 		[isLoading, uid, fetchUserCredit, loadCachedData],
 	)
 
-	// biome-ignore lint/correctness/useExhaustiveDependencies: <cacheCurrentData changes on every re-render>
 	const handleOrganizationChange = useCallback(
 		async (event: any) => {
 			const target = event.target as HTMLSelectElement
@@ -169,26 +172,43 @@ export const ClineAccountView = ({ clineUser, userOrganizations, activeOrganizat
 
 			const newValue = target.value
 			if (newValue !== dropdownValue) {
+				// Clear any pending debounced fetch since we're doing a manual one
+				if (debounceTimeoutRef.current) {
+					clearTimeout(debounceTimeoutRef.current)
+					debounceTimeoutRef.current = null
+				}
+
 				// Cache current data before switching
 				cacheCurrentData(dropdownValue)
 				setDropdownValue(newValue)
+
 				// Load cached data for new selection immediately, or clear if no cache
+				// Only clear if we don't have cached data to avoid unnecessary flashing
 				if (!loadCachedData(newValue)) {
 					// No cached data - clear current state to avoid showing wrong data
 					setBalance(null)
 					setUsageData([])
 					setPaymentsData([])
 				}
+
+				// Set flag to indicate manual fetch in progress
+				manualFetchInProgressRef.current = true
+
+				// Fetch the new data
+				await fetchCreditBalance(newValue)
+
+				// Update the last active org ID to prevent the effect from triggering
+				setLastActiveOrgId(newValue === uid ? undefined : newValue)
+
+				// Send the change to the server
+				const organizationId = newValue === uid ? undefined : newValue
+				await AccountServiceClient.setUserOrganization({ organizationId })
+
+				// Clear the manual fetch flag after everything is done
+				manualFetchInProgressRef.current = false
 			}
-			// Set flag to indicate manual fetch in progress
-			manualFetchInProgressRef.current = true
-			await fetchCreditBalance(newValue)
-			manualFetchInProgressRef.current = false
-			// Send the change to the server
-			const organizationId = newValue === uid ? undefined : newValue
-			AccountServiceClient.setUserOrganization({ organizationId })
 		},
-		[uid, dropdownValue, loadCachedData],
+		[uid, dropdownValue, loadCachedData, fetchCreditBalance, cacheCurrentData],
 	)
 
 	// Fetch balance every 60 seconds
@@ -199,33 +219,39 @@ export const ClineAccountView = ({ clineUser, userOrganizations, activeOrganizat
 	const clineUrl = appBaseUrl || "https://app.cline.bot"
 
 	// Fetch balance on mount
-	// biome-ignore lint/correctness/useExhaustiveDependencies: <Only run once on mount>
 	useEffect(() => {
 		async function initialFetch() {
 			await fetchCreditBalance(dropdownValue)
+			initialFetchCompleteRef.current = true
 		}
 		initialFetch()
 	}, [])
 
-	// biome-ignore lint/correctness/useExhaustiveDependencies: <cacheCurrentData changes on every re-render>
 	useEffect(() => {
 		// Handle organization changes with 500ms debounce
 		const currentActiveOrgId = activeOrganization?.organizationId
-		const hasDropdownChanged = dropdownValue !== (currentActiveOrgId || uid)
 		const hasActiveOrgChanged = currentActiveOrgId !== lastActiveOrgId
 
-		if (hasDropdownChanged || hasActiveOrgChanged) {
+		// Only handle external organization changes (not dropdown changes)
+		// Dropdown changes are handled by handleOrganizationChange
+		const isExternalOrgChange = hasActiveOrgChanged && !manualFetchInProgressRef.current
+
+		if (isExternalOrgChange) {
 			// Clear any existing timeout
 			if (debounceTimeoutRef.current) {
 				clearTimeout(debounceTimeoutRef.current)
 			}
 
-			// If dropdown changed, load cached data for the current dropdown value
-			if (hasDropdownChanged) {
-				// Cache the previous data first
-				cacheCurrentData(lastActiveOrgId || uid)
-				// Load cached data for current dropdown value, or clear if no cache
-				if (!loadCachedData(dropdownValue)) {
+			// Update dropdown to match the new active organization
+			const newDropdownValue = currentActiveOrgId || uid
+			if (newDropdownValue !== dropdownValue) {
+				// Cache current data before switching
+				cacheCurrentData(dropdownValue)
+				setDropdownValue(newDropdownValue)
+
+				// Load cached data for new selection immediately, or clear if no cache
+				// Only clear data if initial fetch has completed to avoid clearing on mount
+				if (!loadCachedData(newDropdownValue) && initialFetchCompleteRef.current) {
 					// No cached data - clear to avoid showing wrong data
 					setBalance(null)
 					setUsageData([])
@@ -233,15 +259,15 @@ export const ClineAccountView = ({ clineUser, userOrganizations, activeOrganizat
 				}
 			}
 
-			// Only set timeout if manual fetch is not in progress
-			if (!manualFetchInProgressRef.current) {
+			// Only set timeout if initial fetch is complete
+			if (initialFetchCompleteRef.current) {
 				// Set new timeout to fetch after 500ms
 				debounceTimeoutRef.current = setTimeout(() => {
-					fetchCreditBalance(dropdownValue)
+					fetchCreditBalance(newDropdownValue)
 					setLastActiveOrgId(currentActiveOrgId)
 				}, 500)
 			} else {
-				// Manual fetch is handling this, just update the active org ID
+				// Just update the active org ID
 				setLastActiveOrgId(currentActiveOrgId)
 			}
 		}
@@ -252,7 +278,15 @@ export const ClineAccountView = ({ clineUser, userOrganizations, activeOrganizat
 				clearTimeout(debounceTimeoutRef.current)
 			}
 		}
-	}, [dropdownValue, activeOrganization?.organizationId, lastActiveOrgId, uid])
+	}, [
+		activeOrganization?.organizationId,
+		lastActiveOrgId,
+		uid,
+		dropdownValue,
+		loadCachedData,
+		fetchCreditBalance,
+		cacheCurrentData,
+	])
 
 	return (
 		<div className="h-full flex flex-col">


### PR DESCRIPTION
<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- For feature requests: Created a discussion in our Feature Requests discussions board https://github.com/cline/cline/discussions/categories/feature-requests and received approval from core maintainers before implementation
- For all changes: Link the associated issue/discussion in the "Related Issue" section below

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly without prior discussion.

Why this requirement?
We deeply appreciate all community contributions - they are essential to Cline's success! To ensure the best use of everyone's time and maintain project direction, we use our Feature Requests discussions board to gauge community interest and validate feature ideas before implementation begins. This helps us focus development efforts on features that will benefit the most users.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** #XXXX

### Description

<!-- 
Help reviewers understand your changes by making this PR readable and well-organized:

- What problem does this PR solve?
- Why were these changes introduced and what purpose do they serve?
- For larger changes, provide context about your approach and reasoning

Small PRs may need minimal description, but larger changes benefit from explaining where you're coming from. Much of this context can be in the linked issue above, so feel free to reference it rather than repeating everything here.
-->

- Wrap cacheCurrentData in useCallback with proper dependencies
- Add initialFetchCompleteRef to track mount fetch completion
- Improve organization change handling to prevent race conditions
- Remove biome-ignore comments for exhaustive dependencies
- Replace mb-[5px] with mb-1.5 for consistent Tailwind spacing


Manual Organization Switch (via dropdown):

1. Clear any pending debounced fetches
2. Cache current data and switch dropdown value
3. Load cached data if available
4. Fetch new data once
5. Update server with new organization
6. Update tracking state to prevent effect from triggering


External Organization Changes (from server/other sources):

1. Effect detects the change
2. Only triggers if it's not a manual change in progress
3. Updates dropdown to match
4. Debounced fetch after 500ms

Result:

- Before: Organization switch → 2 API calls (immediate + debounced)
- After: Organization switch → 1 API call (immediate only)

The fix ensures that:

- Manual dropdown changes only trigger one fetch
- External organization changes are handled separately with debouncing
- No race conditions between manual and automatic fetches
- Proper state synchronization between dropdown and active organization
- Cached data is preserved and used appropriately


### Test Procedure

<!-- 
Please walk us through your testing approach and thought process. This helps reviewers understand that you've thoroughly considered the impact of your changes:

- How did you test this change?
- What could potentially break and how did you verify it doesn't?
- What existing functionality might be affected and how did you check it still works?
- Why are you confident this is ready for merge?

We're not looking for exhaustive documentation - just evidence that you've thought through the implications of your changes and tested accordingly.
-->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->


BEFORE


https://github.com/user-attachments/assets/0e8d4187-7973-4a57-acb6-bd7a544c1078



AFTER


https://github.com/user-attachments/assets/07667913-5b3e-4edf-864f-733dbe2607a4



### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Improve caching and prevent duplicate fetches in `AccountView` by enhancing caching logic and handling race conditions.
> 
>   - **Caching and Fetching**:
>     - Wrap `cacheCurrentData` in `useCallback` with dependencies in `AccountView.tsx`.
>     - Add `initialFetchCompleteRef` to track initial fetch completion in `ClineAccountView`.
>     - Improve organization change handling to prevent race conditions in `handleOrganizationChange()`.
>   - **Code Cleanup**:
>     - Remove biome-ignore comments for exhaustive dependencies in `AccountView.tsx`.
>     - Replace `mb-[5px]` with `mb-1.5` for consistent Tailwind spacing in `AccountView.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 1791c32389bfbb43b3c886166bb7be980ec66638. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->