### PR TITLE
fix: use retry functionality for failed API requests and disable send

### DIFF
--- a/webview-ui/src/components/chat/chat-view/hooks/useMessageHandlers.ts
+++ b/webview-ui/src/components/chat/chat-view/hooks/useMessageHandlers.ts
@@ -118,6 +118,15 @@ export function useMessageHandlers(messages: ClineMessage[], chatState: ChatStat
 			const hasContent = trimmedInput || (images && images.length > 0) || (files && files.length > 0)
 
 			switch (actionType) {
+				case "retry":
+					// For API retry (api_req_failed), always send simple approval without content
+					await TaskServiceClient.askResponse(
+						AskResponseRequest.create({
+							responseType: "yesButtonClicked",
+						}),
+					)
+					clearInputState()
+					break
 				case "approve":
 					if (hasContent) {
 						await TaskServiceClient.askResponse(

--- a/webview-ui/src/components/chat/chat-view/shared/buttonConfig.ts
+++ b/webview-ui/src/components/chat/chat-view/shared/buttonConfig.ts
@@ -11,6 +11,7 @@ export type ButtonActionType =
 	| "new_task" // Start a new task
 	| "cancel" // Cancel streaming
 	| "utility" // Execute utility function (condense, report_bug)
+	| "retry" // Retry the last action
 
 /**
  * Button configuration for different message states
@@ -31,11 +32,11 @@ export interface ButtonConfig {
 export const BUTTON_CONFIGS: Record<string, ButtonConfig> = {
 	// Error recovery states - user must take action
 	api_req_failed: {
-		sendingDisabled: false,
+		sendingDisabled: true,
 		enableButtons: true,
 		primaryText: "Retry",
 		secondaryText: "Start New Task",
-		primaryAction: "approve",
+		primaryAction: "retry",
 		secondaryAction: "new_task",
 	},
 	mistake_limit_reached: {


### PR DESCRIPTION
<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- For feature requests: Created a discussion in our Feature Requests discussions board https://github.com/cline/cline/discussions/categories/feature-requests and received approval from core maintainers before implementation
- For all changes: Link the associated issue/discussion in the "Related Issue" section below

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly without prior discussion.

Why this requirement?
We deeply appreciate all community contributions - they are essential to Cline's success! To ensure the best use of everyone's time and maintain project direction, we use our Feature Requests discussions board to gauge community interest and validate feature ideas before implementation begins. This helps us focus development efforts on features that will benefit the most users.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:**  https://github.com/cline/cline/issues/5733

### Description

<!-- 
Help reviewers understand your changes by making this PR readable and well-organized:

- What problem does this PR solve?
- Why were these changes introduced and what purpose do they serve?
- For larger changes, provide context about your approach and reasoning

Small PRs may need minimal description, but larger changes benefit from explaining where you're coming from. Much of this context can be in the linked issue above, so feel free to reference it rather than repeating everything here.
-->

- Add "retry" action type to ButtonActionType
- Update api_req_failed button config to use retry action with disabled sending
- Implement retry handler in useMessageHandlers to send simple approval and clear input state

### Test Procedure

<!-- 
Please walk us through your testing approach and thought process. This helps reviewers understand that you've thoroughly considered the impact of your changes:

- How did you test this change?
- What could potentially break and how did you verify it doesn't?
- What existing functionality might be affected and how did you check it still works?
- Why are you confident this is ready for merge?

We're not looking for exhaustive documentation - just evidence that you've thought through the implications of your changes and tested accordingly.
-->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

https://github.com/user-attachments/assets/f4647ed1-1ce2-4b57-947f-3e4eb55cd89e




### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add retry functionality for failed API requests with updated button configurations and handlers.
> 
>   - **Behavior**:
>     - Add `retry` action type to `ButtonActionType` in `buttonConfig.ts`.
>     - Update `api_req_failed` button config to use `retry` action with disabled sending in `buttonConfig.ts`.
>     - Implement `retry` handler in `useMessageHandlers.ts` to send simple approval and clear input state.
>   - **Misc**:
>     - Disable sending for `api_req_failed` state in `buttonConfig.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for f76140462dd9fb5e2eea36c8e223aad655748f77. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->