### PR TITLE
Remove getConfiguration from PostHogClientProvider

### DIFF
--- a/package.json
+++ b/package.json
@@ -331,10 +331,6 @@
 					"when": "config.git.enabled && scmProvider == git && cline.isGeneratingCommit"
 				}
 			]
-		},
-		"configuration": {
-			"title": "Cline",
-			"properties": {}
 		}
 	},
 	"scripts": {

--- a/src/services/posthog/telemetry/TelemetryService.ts
+++ b/src/services/posthog/telemetry/TelemetryService.ts
@@ -173,7 +173,7 @@ export class TelemetryService {
 			}
 		}
 
-		this.provider.toggleOptIn(didUserOptIn)
+		this.provider.toggleClineTelemetry(didUserOptIn)
 	}
 
 	private addProperties(properties: any): any {


### PR DESCRIPTION

### Description

Remove the getConfiguration from PostHogClientProvider. The call was checking the cline-level telemetry setting, however this is now in the globalState. This variable is being checked and set on webview initialization and whenever the setting is changed via the TelemetryService.updateTelemetryState().

Also added in some comments about how the IDE-level telemetry settings differs between VS Code and Cursor.

Also, defaulting the TelemetrySettings object that we create to false and "off", so that each is turned on only after checking the corresponding setting. This helps prevent bugs where we fail to turn it off when we should.

### Test Procedure

Log the settings stored in the PostHogClientProvider class level when the log() function is called and ensure that they're set correctly based on the IDE-level telemetry setting and the Cline-level telemetry setting.

This can be done by adding the following two logs in the PostHogClientProvider:

```
vscode.env.onDidChangeTelemetryEnabled((isTelemetryEnabled) => {
    this.telemetrySettings.host = isTelemetryEnabled
	console.log("[PostHogClientProvider] telemetry settings", this.telemetrySettings)})
```

```
public toggleClineTelemetry(optIn: boolean): void {
		if (optIn && !this.telemetrySettings.cline) {
			this.client.optIn()
		}
		if (!optIn && this.telemetrySettings.cline) {
			this.client.optOut()
		}
		this.telemetrySettings.cline = optIn

		console.log("[PostHogClientProvider] telemetry settings", this.telemetrySettings)
}
```

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [x] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->
