### PR TITLE
Revert "Adding frequency penalty for gemini models"

### DIFF
--- a/src/core/api/providers/gemini.ts
+++ b/src/core/api/providers/gemini.ts
@@ -22,7 +22,6 @@ interface GeminiHandlerOptions extends CommonApiHandlerOptions {
 	thinkingBudgetTokens?: number
 	apiModelId?: string
 	ulid?: string
-	frequencyPenalty?: number
 }
 
 /**
@@ -119,8 +118,6 @@ export class GeminiHandler implements ApiHandler {
 			...{ systemInstruction: systemPrompt },
 			// Set temperature (default to 0)
 			temperature: 0,
-			// Set frequency penalty if provided
-			frequencyPenalty: 0.5,
 		}
 
 		// Add thinking config if the model supports it

--- a/src/core/api/transform/openrouter-stream.ts
+++ b/src/core/api/transform/openrouter-stream.ts
@@ -111,7 +111,6 @@ export async function createOpenRouterStream(
 
 	let temperature: number | undefined = 0
 	let topP: number | undefined
-	let frequency_penalty: number | undefined = 0
 	if (
 		model.id.startsWith("deepseek/deepseek-r1") ||
 		model.id === "perplexity/sonar-reasoning" ||
@@ -122,9 +121,6 @@ export async function createOpenRouterStream(
 		temperature = 0.7
 		topP = 0.95
 		openAiMessages = convertToR1Format([{ role: "user", content: systemPrompt }, ...messages])
-	}
-	if (model.id.startsWith("google")) {
-		frequency_penalty = 0.5
 	}
 
 	let reasoning: { max_tokens: number } | undefined
@@ -166,7 +162,6 @@ export async function createOpenRouterStream(
 		max_tokens: maxTokens,
 		temperature: temperature,
 		top_p: topP,
-		frequency_penalty: frequency_penalty,
 		messages: openAiMessages,
 		stream: true,
 		stream_options: { include_usage: true },


### PR DESCRIPTION
Reverts cline/cline#5893

While this did not fail in my testing of openrouter as it cleared up the error offically the frequency penalty param is not supported for gemini model family even its shown in the SDK and google docs 

<img width="787" height="489" alt="image" src="https://github.com/user-attachments/assets/c1b50ac7-3915-4172-93a6-10ad87fc3110" />


So I am reverting this 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Reverts frequency penalty parameter for Gemini models in `gemini.ts` and `openrouter-stream.ts` due to lack of official support.
> 
>   - **Revert Changes**:
>     - Remove `frequencyPenalty` from `GeminiHandlerOptions` in `gemini.ts`.
>     - Remove setting of `frequencyPenalty` in `GeminiHandler` class in `gemini.ts`.
>     - Remove `frequency_penalty` variable and its usage in `createOpenRouterStream` function in `openrouter-stream.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 9c466e031054ace1a28831e3bd67f86246e7e171. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->