### PR TITLE
feat(gpt) reasoning effort minimal

### DIFF
--- a/.changeset/wise-seas-shave.md
+++ b/.changeset/wise-seas-shave.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Reasoning Effort Minimal on OpenAI

--- a/proto/cline/state.proto
+++ b/proto/cline/state.proto
@@ -56,6 +56,7 @@ enum OpenaiReasoningEffort {
   LOW = 0;
   MEDIUM = 1;
   HIGH = 2;
+  MINIMAL = 3;
 }
 
 enum McpDisplayMode {

--- a/src/core/controller/state/updateSettings.ts
+++ b/src/core/controller/state/updateSettings.ts
@@ -98,6 +98,9 @@ export async function updateSettings(controller: Controller, request: UpdateSett
 				case ProtoOpenaiReasoningEffort.HIGH:
 					reasoningEffort = "high"
 					break
+				case ProtoOpenaiReasoningEffort.MINIMAL:
+					reasoningEffort = "minimal"
+					break
 				default:
 					throw new Error(`Invalid OpenAI reasoning effort value: ${request.openaiReasoningEffort}`)
 			}

--- a/src/shared/storage/types.ts
+++ b/src/shared/storage/types.ts
@@ -1,3 +1,3 @@
-export type OpenaiReasoningEffort = "low" | "medium" | "high"
+export type OpenaiReasoningEffort = "minimal" | "low" | "medium" | "high"
 
 export type Mode = "plan" | "act"

--- a/webview-ui/src/components/settings/sections/FeatureSettingsSection.tsx
+++ b/webview-ui/src/components/settings/sections/FeatureSettingsSection.tsx
@@ -104,6 +104,7 @@ const FeatureSettingsSection = ({ renderSectionHeader }: FeatureSettingsSectionP
 								const newValue = e.target.currentValue as OpenaiReasoningEffort
 								handleReasoningEffortChange(newValue)
 							}}>
+							<VSCodeOption value="minimal">Minimal</VSCodeOption>
 							<VSCodeOption value="low">Low</VSCodeOption>
 							<VSCodeOption value="medium">Medium</VSCodeOption>
 							<VSCodeOption value="high">High</VSCodeOption>

--- a/webview-ui/src/components/settings/utils/settingsHandlers.ts
+++ b/webview-ui/src/components/settings/utils/settingsHandlers.ts
@@ -12,6 +12,8 @@ import { BrowserServiceClient, StateServiceClient } from "@/services/grpc-client
 const convertToProtoValue = (field: keyof UpdateSettingsRequest, value: any): any => {
 	if (field === "openaiReasoningEffort" && typeof value === "string") {
 		switch (value) {
+			case "minimal":
+				return OpenaiReasoningEffort.MINIMAL
 			case "low":
 				return OpenaiReasoningEffort.LOW
 			case "medium":


### PR DESCRIPTION
### Related Issue

None. 

### Description

GPT-5 has added a new Reasoning Effort option: "Minimal." (The default remains "Medium.")  
This is a useful option that prioritizes faster response speed.  
https://openai.com/index/introducing-gpt-5-for-developers/

### Test Procedure

All existing tests are passing.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<img width="305" height="367" alt="screenshot 2025-08-30 153748" src="https://github.com/user-attachments/assets/209fe946-3930-4aa5-bedc-1a3c3c78281f" />

### Additional Notes

None.
