### PR TITLE
Fix browser session not being persisted between browser tool calls

### DIFF
--- a/src/core/task/tools/handlers/BrowserToolHandler.ts
+++ b/src/core/task/tools/handlers/BrowserToolHandler.ts
@@ -112,15 +112,8 @@ export class BrowserToolHandler implements IFullyManagedTool {
 				await config.callbacks.say("browser_action_result", "")
 
 				// Re-make browserSession to make sure latest settings apply
-				const browserSession = config.services.browserSession
-				if (config.context) {
-					await browserSession.dispose()
-					const apiHandlerModel = config.api.getModel()
-					const useWebp = config.api ? !modelDoesntSupportWebp(apiHandlerModel) : true
-					config.services.browserSession = new BrowserSession(config.context, config.browserSettings, useWebp)
-				} else {
-					console.warn("no controller context available for browserSession")
-				}
+				// This updates the ToolExecutor browserSession and returns it, for us to modify the local config object accordingly. (Previously we would set config.services.browserSession = new BrowserSession... but this would not update the ToolExecutor.browserSession which is used in subsequent browser tool calls)
+				config.services.browserSession = await config.callbacks.applyLatestBrowserSettings()
 				await config.services.browserSession.launchBrowser()
 				browserActionResult = await config.services.browserSession.navigateToUrl(url)
 			} else {

--- a/src/core/task/tools/types/TaskConfig.ts
+++ b/src/core/task/tools/types/TaskConfig.ts
@@ -104,6 +104,8 @@ export interface TaskCallbacks {
 	reinitExistingTaskFromId: (taskId: string) => Promise<void>
 	cancelTask: () => Promise<void>
 	updateTaskHistory: (update: any) => Promise<any[]>
+
+	applyLatestBrowserSettings: () => Promise<BrowserSession>
 }
 
 /**


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes browser session persistence by adding `applyLatestBrowserSettings` to update session settings in `ToolExecutor.ts` and `BrowserToolHandler.ts`.
> 
>   - **Behavior**:
>     - Adds `applyLatestBrowserSettings()` to `ToolExecutor.ts` to update browser session settings.
>     - Updates `BrowserToolHandler.ts` to use `applyLatestBrowserSettings()` before launching the browser.
>   - **TaskConfig**:
>     - Adds `applyLatestBrowserSettings` to `TaskCallbacks` in `TaskConfig.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for f40daf9f112e6acff6d88148a8b24c8a04f779e1. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->