### PR TITLE
Fixing failing webview test

### DIFF
--- a/webview-ui/src/components/chat/__tests__/Announcement.spec.tsx
+++ b/webview-ui/src/components/chat/__tests__/Announcement.spec.tsx
@@ -1,25 +1,90 @@
 import { fireEvent, render, screen } from "@testing-library/react"
 import type { ComponentProps } from "react"
 import React from "react"
-import { describe, expect, it, vi } from "vitest"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { ClineAuthProvider } from "@/context/ClineAuthContext"
+import { ExtensionStateContextProvider } from "@/context/ExtensionStateContext"
 import Announcement from "../Announcement"
 
+// Mock the VSCode webview toolkit
 vi.mock("@vscode/webview-ui-toolkit/react", () => ({
 	useTheme: () => ({ themeType: "light" }),
 	VSCodeButton: (props: ComponentProps<"button">) => <button {...props}>{props.children}</button>,
 	VSCodeLink: ({ children }: { children: React.ReactNode }) => <a>{children}</a>,
 }))
 
+// Mock the gRPC service client
+vi.mock("@/services/grpc-client", () => ({
+	AccountServiceClient: {
+		accountLoginClicked: vi.fn().mockResolvedValue({}),
+		subscribeToAuthStatusUpdate: vi.fn().mockReturnValue(() => {}),
+		getUserOrganizations: vi.fn().mockResolvedValue({ organizations: [] }),
+	},
+}))
+
+// Mock HeroUI components
+vi.mock("@heroui/react", () => ({
+	Accordion: ({ children }: { children: React.ReactNode }) => <div data-testid="accordion">{children}</div>,
+	AccordionItem: ({ children, title }: { children: React.ReactNode; title: string }) => (
+		<div data-testid="accordion-item">
+			<div>{title}</div>
+			<div>{children}</div>
+		</div>
+	),
+}))
+
+// Mock the settings utils
+vi.mock("../settings/utils/useApiConfigurationHandlers", () => ({
+	useApiConfigurationHandlers: () => ({
+		handleFieldsChange: vi.fn(),
+	}),
+}))
+
+// Mock the entire ExtensionStateContext since it has complex internal logic
+vi.mock("@/context/ExtensionStateContext", () => ({
+	useExtensionState: () => ({
+		apiConfiguration: null,
+		openRouterModels: {},
+		setShowChatModelSelector: vi.fn(),
+		version: "2.0.0",
+		clineMessages: [],
+		taskHistory: [],
+		shouldShowAnnouncement: false,
+		theme: "dark",
+		mcpServers: [],
+		mcpMarketplaceCatalog: { items: [] },
+		workspaceFilePaths: [],
+	}),
+	ExtensionStateContextProvider: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}))
+
+// Test wrapper component that provides all necessary contexts
+const TestWrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+	return <ClineAuthProvider>{children}</ClineAuthProvider>
+}
+
 describe("Announcement", () => {
 	const hideAnnouncement = vi.fn()
 
+	beforeEach(() => {
+		vi.clearAllMocks()
+	})
+
 	it("renders the announcement with the correct version", () => {
-		render(<Announcement hideAnnouncement={hideAnnouncement} version="2.0.0" />)
+		render(
+			<TestWrapper>
+				<Announcement hideAnnouncement={hideAnnouncement} version="2.0.0" />
+			</TestWrapper>,
+		)
 		expect(screen.getByText(/New in v2.0/)).toBeInTheDocument()
 	})
 
 	it("calls hideAnnouncement when close button is clicked", () => {
-		render(<Announcement hideAnnouncement={hideAnnouncement} version="2.0.0" />)
+		render(
+			<TestWrapper>
+				<Announcement hideAnnouncement={hideAnnouncement} version="2.0.0" />
+			</TestWrapper>,
+		)
 		fireEvent.click(screen.getByTestId("close-button"))
 		expect(hideAnnouncement).toHaveBeenCalled()
 	})

--- a/webview-ui/src/components/chat/__tests__/Announcement.spec.tsx
+++ b/webview-ui/src/components/chat/__tests__/Announcement.spec.tsx
@@ -3,7 +3,6 @@ import type { ComponentProps } from "react"
 import React from "react"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 import { ClineAuthProvider } from "@/context/ClineAuthContext"
-import { ExtensionStateContextProvider } from "@/context/ExtensionStateContext"
 import Announcement from "../Announcement"
 
 // Mock the VSCode webview toolkit


### PR DESCRIPTION
### Description
Fixes some tests currently failing in main.

The root cause of failure was that the `ExtensionStateContextProvider` was trying to initialize with real implementations that depend on the VSCode extension host environment. By mocking it entirely and only using the real `ClineAuthProvider` (with mocked dependencies), we created a test environment where:

1. The component gets the state it needs from the mocked `useExtensionState` hook
2. The authentication context is properly provided by `ClineAuthProvider`
3. All external dependencies (VSCode APIs, gRPC services) are mocked
4. The test can focus on the component's behavior rather than wrestling with environment setup

This approach is cleaner and more maintainable because it clearly separates what's being tested (the Announcement component) from the complex infrastructure it normally runs within.


### Test Procedure


### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [X] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [X] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [X] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [X] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [X] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->
