### PR TITLE
root folder path comparison on windows

### DIFF
--- a/src/core/task/tools/autoApprove.ts
+++ b/src/core/task/tools/autoApprove.ts
@@ -53,7 +53,7 @@ export class AutoApprove {
 	async shouldAutoApproveToolWithPath(blockname: ToolUseName, autoApproveActionpath: string | undefined): Promise<boolean> {
 		let isLocalRead: boolean = false
 		if (autoApproveActionpath) {
-			const cwd = await getCwd(getDesktopDir())
+			const cwd = path.normalize(await getCwd(getDesktopDir()))
 			const absolutePath = path.resolve(cwd, autoApproveActionpath)
 			isLocalRead = absolutePath.startsWith(cwd)
 		} else {


### PR DESCRIPTION
There are different approaches to record a path on Windows ("/" vs "\"). For comparison as trings they have to be converted to the same standard. 

## How to change

On Un*x should be no behavior changes. 
On Windows it should correctly detect if file inside or outside of the root folder, and apply permission auto approval accordingly (without the fix it treats all files as outside of the project)

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Normalize `cwd` in `shouldAutoApproveToolWithPath()` to fix path comparison on Windows, ensuring correct permission auto-approval.
> 
>   - **Behavior**:
>     - Normalizes `cwd` using `path.normalize()` in `shouldAutoApproveToolWithPath()` in `autoApprove.ts` to ensure consistent path comparison on Windows.
>     - Fixes issue where all files were treated as outside the project on Windows, affecting permission auto-approval.
>   - **Platform Specific**:
>     - No behavior changes on Un*x systems.
>     - Correctly detects file location relative to root folder on Windows.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 23aeb98191a6d5160c3238a02b5f942e88e0535e. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->