### PR TITLE
Add the OS name and version to the telemetry metadata

### DIFF
--- a/src/services/telemetry/TelemetryService.ts
+++ b/src/services/telemetry/TelemetryService.ts
@@ -2,6 +2,7 @@ import { HostProvider } from "@hosts/host-provider"
 import type { BrowserSettings } from "@shared/BrowserSettings"
 import { ShowMessageType } from "@shared/proto/host/window"
 import type { TaskFeedbackType } from "@shared/WebviewMessage"
+import * as os from "os"
 import * as vscode from "vscode"
 import { ClineAccountUserInfo } from "@/services/auth/AuthService"
 import { Mode } from "@/shared/storage/types"
@@ -24,6 +25,11 @@ export type TelemetryMetadata = {
 	platform: string
 	/** The version of the host environment */
 	platform_version: string
+	/** The operating system type, e.g. darwin, win32. This is the value returned by os.platform() */
+	os_type: string
+	/** The operating system version e.g. 'Windows 10 Pro', 'Darwin Kernel Version 21.6.0...'
+	 * This is the value returned by os.version() */
+	os_version: string
 	/** Whether the extension is running in development mode */
 	is_dev: string | undefined
 }
@@ -143,6 +149,8 @@ export class TelemetryService {
 			extension_version: extensionVersion,
 			platform: hostVersion.platform || "unknown",
 			platform_version: hostVersion.version || "unknown",
+			os_type: os.platform(),
+			os_version: os.version(),
 			is_dev: process.env.IS_DEV,
 		}
 		return new TelemetryService(provider, metadata)


### PR DESCRIPTION
Add the OS name and version to the telemetry metadata properties.
Update the test.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add OS name and version to telemetry metadata in `TelemetryService` and update tests accordingly.
> 
>   - **Telemetry Metadata**:
>     - Add `os_type` and `os_version` to `TelemetryMetadata` in `TelemetryService.ts`.
>     - Use `os.platform()` and `os.version()` to populate these fields.
>   - **TelemetryService**:
>     - Update `create()` method to include `os_type` and `os_version` in metadata.
>   - **Tests**:
>     - Update `TelemetryService.test.ts` to include `os_type` and `os_version` in `MOCK_METADATA`.
>     - Ensure tests validate the inclusion of OS details in telemetry events.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for bf00beaddf820147208985c47e1b55e5a52f5291. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->