### PR TITLE
Remove Shortcut of Cline from its title as it does not work for multiple OS 

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,15 +102,8 @@
 			"activitybar": [
 				{
 					"id": "claude-dev-ActivityBar",
-					"title": "Cline (⌘+')",
-					"icon": "assets/icons/icon.svg",
-					"when": "isMac"
-				},
-				{
-					"id": "claude-dev-ActivityBar",
-					"title": "Cline (Ctrl+')",
-					"icon": "assets/icons/icon.svg",
-					"when": "!isMac"
+					"title": "Cline",
+					"icon": "assets/icons/icon.svg"
 				}
 			]
 		},


### PR DESCRIPTION


### Description
<img width="1194" height="456" alt="image" src="https://github.com/user-attachments/assets/43270006-a0a4-4df0-94a0-22fca05e84ac" />


### Test Procedure

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [X] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [X] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [X] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [X] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [X] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove OS-specific shortcut keys from `activitybar` title in `package.json` for consistent display across all operating systems.
> 
>   - **Behavior**:
>     - Removed OS-specific shortcut keys from `activitybar` title in `package.json`, simplifying it to "Cline".
>     - Ensures consistent display across all operating systems.
>   - **Misc**:
>     - Removed conditional `when` clauses for `isMac` and `!isMac` in `package.json`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 80d6f17f72d25bb94dbcf59ae3b7f5939948d1f3. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->