### PR TITLE
Adding MultiRoot support scaffolding to tasks and adding support for multi root checkpoint manager 

### DIFF
--- a/.changeset/witty-rivers-knock.md
+++ b/.changeset/witty-rivers-knock.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Adding basic multi root algorithm

--- a/src/core/controller/checkpoints/checkpointDiff.ts
+++ b/src/core/controller/checkpoints/checkpointDiff.ts
@@ -3,7 +3,7 @@ import { Controller } from ".."
 
 export async function checkpointDiff(controller: Controller, request: Int64Request): Promise<Empty> {
 	if (request.value) {
-		await controller.task?.checkpointManager?.presentMultifileDiff(request.value, false)
+		await controller.task?.checkpointManager?.presentMultifileDiff?.(request.value, false)
 	}
 	return Empty.create()
 }

--- a/src/core/controller/task/taskCompletionViewChanges.ts
+++ b/src/core/controller/task/taskCompletionViewChanges.ts
@@ -10,7 +10,8 @@ import { Controller } from ".."
 export async function taskCompletionViewChanges(controller: Controller, request: Int64Request): Promise<Empty> {
 	try {
 		if (request.value && controller.task) {
-			await controller.task.checkpointManager?.presentMultifileDiff(request.value, true)
+			// presentMultifileDiff is optional on ICheckpointManager, so capture then optionally invoke
+			await controller.task.checkpointManager?.presentMultifileDiff?.(request.value, true)
 		}
 		return Empty.create()
 	} catch (error) {

--- a/src/core/storage/StateManager.ts
+++ b/src/core/storage/StateManager.ts
@@ -1,3 +1,4 @@
+import { WorkspaceRoot } from "@core/workspace"
 import { ApiConfiguration, fireworksDefaultModelId } from "@shared/api"
 import chokidar, { FSWatcher } from "chokidar"
 import type { ExtensionContext } from "vscode"
@@ -6,9 +7,6 @@ import { STATE_MANAGER_NOT_INITIALIZED } from "./error-messages"
 import { GlobalState, GlobalStateKey, LocalState, LocalStateKey, SecretKey, Secrets } from "./state-keys"
 import { readGlobalStateFromDisk, readSecretsFromDisk, readWorkspaceStateFromDisk } from "./utils/state-helpers"
 
-/**
- * Interface for persistence error event data
- */
 export interface PersistenceErrorEvent {
 	error: Error
 }
@@ -555,6 +553,54 @@ export class StateManager {
 			throw new Error(STATE_MANAGER_NOT_INITIALIZED)
 		}
 		return this.workspaceStateCache[key]
+	}
+
+	/**
+	 * Get workspace roots from global state
+	 */
+	getWorkspaceRoots(): WorkspaceRoot[] | undefined {
+		return this.getGlobalStateKey("workspaceRoots")
+	}
+
+	/**
+	 * Set workspace roots in global state
+	 */
+	setWorkspaceRoots(roots: WorkspaceRoot[]): void {
+		this.setGlobalState("workspaceRoots", roots)
+	}
+
+	/**
+	 * Get primary root index from global state.
+	 * The primary root is the main workspace folder that Cline focuses on when dealing with
+	 * multi-root workspaces. In VS Code, you can have multiple folders open in one workspace,
+	 * and the primary root index indicates which folder (by its position in the array, 0-based)
+	 * should be treated as the main/default working directory for operations.
+	 */
+	getPrimaryRootIndex(): number {
+		return this.getGlobalStateKey("primaryRootIndex") ?? 0
+	}
+
+	/**
+	 * Set primary root index in global state
+	 */
+	setPrimaryRootIndex(index: number): void {
+		this.setGlobalState("primaryRootIndex", index)
+	}
+
+	/**
+	 * Check if multi-root workspace feature is enabled
+	 */
+	isMultiRootEnabled(): boolean {
+		// Feature flag - defaults to false
+		// For now, always return false to disable multi-root support by default
+		return this.getGlobalStateKey("multiRootEnabled") ?? false
+	}
+
+	/**
+	 * Enable or disable multi-root workspace feature
+	 */
+	setMultiRootEnabled(enabled: boolean): void {
+		this.setGlobalState("multiRootEnabled", enabled)
 	}
 
 	/**

--- a/src/core/storage/state-keys.ts
+++ b/src/core/storage/state-keys.ts
@@ -1,6 +1,7 @@
 import { ApiProvider, BedrockModelId, ModelInfo } from "@shared/api"
 import { FocusChainSettings } from "@shared/FocusChainSettings"
 import { LanguageModelChatSelector } from "vscode"
+import { WorkspaceRoot } from "@/core/workspace/WorkspaceRoot"
 import { AutoApprovalSettings } from "@/shared/AutoApprovalSettings"
 import { BrowserSettings } from "@/shared/BrowserSettings"
 import { ClineRulesToggles } from "@/shared/cline-rules"
@@ -83,6 +84,11 @@ export interface GlobalState {
 	focusChainFeatureFlagEnabled: boolean
 	customPrompt: "compact" | undefined
 	difyBaseUrl: string | undefined
+
+	// Multi-root workspace support
+	workspaceRoots: WorkspaceRoot[] | undefined
+	primaryRootIndex: number | undefined
+	multiRootEnabled: boolean | undefined
 
 	// Plan mode configurations
 	planModeApiProvider: ApiProvider

--- a/src/core/storage/utils/state-helpers.ts
+++ b/src/core/storage/utils/state-helpers.ts
@@ -323,6 +323,11 @@ export async function readGlobalStateFromDisk(context: ExtensionContext): Promis
 
 		const taskHistory = await readTaskHistoryFromState(context)
 
+		// Multi-root workspace support
+		const workspaceRoots = context.globalState.get("workspaceRoots") as GlobalState["workspaceRoots"]
+		const primaryRootIndex = context.globalState.get("primaryRootIndex") as number | undefined
+		const multiRootEnabled = context.globalState.get("multiRootEnabled") as boolean | undefined
+
 		return {
 			// api configuration fields
 			claudeCodePath,
@@ -456,6 +461,10 @@ export async function readGlobalStateFromDisk(context: ExtensionContext): Promis
 			mcpMarketplaceCatalog,
 			qwenCodeOauthPath,
 			customPrompt,
+			// Multi-root workspace support
+			workspaceRoots,
+			primaryRootIndex,
+			multiRootEnabled,
 		}
 	} catch (error) {
 		console.error("[StateHelpers] Failed to read global state:", error)

--- a/src/core/workspace/WorkspaceResolver.ts
+++ b/src/core/workspace/WorkspaceResolver.ts
@@ -5,7 +5,6 @@
  * Phase 1+: Will handle multi-root path resolution
  */
 
-import { Logger } from "@services/logging/Logger"
 import * as path from "path"
 import { MigrationReporter, type UsageStats } from "./MigrationReporter"
 import { WorkspaceRoot } from "./WorkspaceRoot"
@@ -81,7 +80,7 @@ export class WorkspaceResolver {
 			this.trackUsage(context, relativePath)
 
 			if (this.traceEnabled) {
-				Logger.debug(`[MULTI-ROOT-TRACE] ${context}: resolving "${relativePath}" against "${cwd}"`)
+				console.debug(`[MULTI-ROOT-TRACE] ${context}: resolving "${relativePath}" against "${cwd}"`)
 			}
 		}
 
@@ -241,7 +240,7 @@ export class WorkspaceResolver {
 		const result = path.basename(filePath)
 
 		if (this.traceEnabled) {
-			Logger.debug(`[MULTI-ROOT-TRACE] ${context}: getting basename for "${filePath}"`)
+			console.debug(`[MULTI-ROOT-TRACE] ${context}: getting basename for "${filePath}"`)
 		}
 
 		return result

--- a/src/core/workspace/WorkspaceRootManager.ts
+++ b/src/core/workspace/WorkspaceRootManager.ts
@@ -65,43 +65,6 @@ export class WorkspaceRootManager {
 	}
 
 	/**
-	 * Add a new workspace root
-	 */
-	async addRoot(rootPath: string, name?: string): Promise<void> {
-		const vcs = await WorkspaceRootManager.detectVcs(rootPath)
-		const gitHash = vcs === VcsType.Git ? await getLatestGitCommitHash(rootPath) : null
-		const commitHash = gitHash === null ? undefined : gitHash
-
-		const root: WorkspaceRoot = {
-			path: rootPath,
-			name: name || path.basename(rootPath),
-			vcs,
-			commitHash,
-		}
-
-		this.roots.push(root)
-	}
-
-	/**
-	 * Remove a workspace root by path
-	 */
-	removeRoot(path: string): boolean {
-		const index = this.roots.findIndex((r) => r.path === path)
-		if (index === -1) {
-			return false
-		}
-
-		this.roots.splice(index, 1)
-
-		// Adjust primary index if needed
-		if (this.primaryIndex >= this.roots.length) {
-			this.primaryIndex = Math.max(0, this.roots.length - 1)
-		}
-
-		return true
-	}
-
-	/**
 	 * Get all workspace roots
 	 */
 	getRoots(): WorkspaceRoot[] {
@@ -113,6 +76,13 @@ export class WorkspaceRootManager {
 	 */
 	getPrimaryRoot(): WorkspaceRoot | undefined {
 		return this.roots[this.primaryIndex]
+	}
+
+	/**
+	 * Get the primary workspace root index
+	 */
+	getPrimaryIndex(): number {
+		return this.primaryIndex
 	}
 
 	/**

--- a/src/core/workspace/__tests__/setup.test.ts
+++ b/src/core/workspace/__tests__/setup.test.ts
@@ -1,0 +1,173 @@
+import { VcsType } from "@core/workspace"
+import { expect } from "chai"
+import * as path from "path"
+import sinon from "sinon"
+import { HostProvider } from "@/hosts/host-provider"
+import * as telemetry from "@/services/telemetry"
+import * as pathUtils from "@/utils/path"
+import { setupWorkspaceManager } from "../setup"
+import type { WorkspaceRoot } from "../WorkspaceRoot"
+import { WorkspaceRootManager } from "../WorkspaceRootManager"
+
+describe("setupWorkspaceManager", () => {
+	const sandbox = sinon.createSandbox()
+	let fakeTelemetry: any
+
+	const cwd = "/Users/test/project"
+	const defaultRoots: WorkspaceRoot[] = [
+		{ path: "/ws/root1", name: "root1", vcs: VcsType.Git, commitHash: "abc" },
+		{ path: "/ws/root2", name: "root2", vcs: VcsType.None },
+	]
+
+	// Minimal stateManager stub with behavior we assert
+	const makeStateManager = ({
+		multiRootEnabled = true,
+		savedRoots,
+		savedPrimaryIndex = 0,
+	}: {
+		multiRootEnabled?: boolean
+		savedRoots?: WorkspaceRoot[]
+		savedPrimaryIndex?: number
+	}) => {
+		const state: { roots?: WorkspaceRoot[]; primaryIndex?: number } = {}
+		return {
+			isMultiRootEnabled: () => multiRootEnabled,
+			getWorkspaceRoots: () => savedRoots,
+			getPrimaryRootIndex: () => savedPrimaryIndex,
+			setWorkspaceRoots: (roots: WorkspaceRoot[]) => {
+				state.roots = roots
+			},
+			setPrimaryRootIndex: (idx: number) => {
+				state.primaryIndex = idx
+			},
+			// for assertions
+			_state: state,
+		}
+	}
+
+	beforeEach(() => {
+		// Stub out path utils for stable behavior
+		sandbox.stub(pathUtils, "getDesktopDir").returns("/Users/test/Desktop" as any)
+		sandbox.stub(pathUtils, "getCwd").resolves(cwd as any)
+
+		// Stub HostProvider window + workspace methods used by setup() error path
+		sandbox.stub(HostProvider, "window").value({
+			showMessage: sandbox.stub().resolves({ selectedOption: undefined }),
+			openSettings: sandbox.stub().resolves(),
+			getVisibleTabs: sandbox.stub().resolves({ paths: [] }),
+			getOpenTabs: sandbox.stub().resolves({ paths: [] }),
+		} as any)
+
+		sandbox.stub(HostProvider, "workspace").value({
+			getWorkspacePaths: sandbox.stub().resolves({ paths: ["/ws/root1", "/ws/root2"] }),
+		} as any)
+
+		// Telemetry stubs via getTelemetryService proxy
+		fakeTelemetry = {
+			captureWorkspaceInitialized: sandbox.stub(),
+			captureWorkspaceInitError: sandbox.stub(),
+		}
+		sandbox.stub(telemetry, "getTelemetryService").resolves(fakeTelemetry)
+
+		// Stub WorkspaceRootManager.fromLegacyCwd to be deterministic
+		sandbox.stub(WorkspaceRootManager, "fromLegacyCwd").callsFake(async (legacyCwd: string) => {
+			// emulate single-root manager with cwd as only root
+			return new WorkspaceRootManager([{ path: legacyCwd, name: path.basename(legacyCwd), vcs: VcsType.None }], 0)
+		})
+	})
+
+	afterEach(() => {
+		sandbox.restore()
+	})
+
+	it("initializes multi-root manager when multi-root is enabled and persists roots + primary index", async () => {
+		const stateManager = makeStateManager({ multiRootEnabled: true })
+		const detectRoots = sandbox.stub().resolves(defaultRoots)
+
+		const manager = await setupWorkspaceManager({
+			stateManager: stateManager as any,
+			historyItem: undefined,
+			detectRoots,
+		})
+
+		// detectRoots used
+		expect(detectRoots.calledOnce).to.equal(true)
+		// manager configured with multi roots
+		expect(manager.getRoots()).to.have.length(2)
+		expect(manager.getPrimaryIndex()).to.equal(0)
+
+		// persisted to state
+		expect(stateManager._state.roots).to.have.length(2)
+		expect(stateManager._state.primaryIndex).to.equal(0)
+
+		// telemetry captured (skipped assertion in unit tests)
+	})
+
+	it("uses single-root cwd when history restore is disabled (historyItem present)", async () => {
+		const savedRoots: WorkspaceRoot[] = [{ path: "/saved/root", name: "saved", vcs: VcsType.None }]
+		const stateManager = makeStateManager({ multiRootEnabled: false, savedRoots, savedPrimaryIndex: 0 })
+		const detectRoots = sandbox.stub().resolves(defaultRoots) // not used
+
+		const manager = await setupWorkspaceManager({
+			stateManager: stateManager as any,
+			historyItem: { id: "h1", ulid: "u1" } as any,
+			detectRoots,
+		})
+
+		// detectRoots not used
+		expect(detectRoots.called).to.equal(false)
+		// current design: single-root path uses cwd (stubbed earlier to "/Users/test/project")
+		expect(manager.getRoots()).to.have.length(1)
+		expect(manager.getRoots()[0].path).to.equal(cwd)
+		// state persisted
+		expect(stateManager._state.roots?.[0].path).to.equal(cwd)
+	})
+
+	it("falls back to fromLegacyCwd in single-root mode when no saved state", async () => {
+		const stateManager = makeStateManager({
+			multiRootEnabled: false,
+			savedRoots: undefined,
+		})
+		const detectRoots = sandbox.stub().resolves(defaultRoots) // not used
+
+		const manager = await setupWorkspaceManager({
+			stateManager: stateManager as any,
+			historyItem: { id: "h2", ulid: "u2" } as any,
+			detectRoots,
+		})
+
+		expect(detectRoots.called).to.equal(false)
+		expect(manager.getRoots()).to.have.length(1)
+		expect(manager.getRoots()[0].path).to.equal(cwd)
+		// persisted
+		expect(stateManager._state.roots?.[0].path).to.equal(cwd)
+		// telemetry called (skipped assertion in unit tests)
+	})
+
+	it("gracefully handles errors and falls back to fromLegacyCwd while warning user", async () => {
+		// Multi-root enabled but detectRoots throws
+		const stateManager = makeStateManager({ multiRootEnabled: true })
+		const detectRoots = sandbox.stub().rejects(new Error("boom"))
+
+		const manager = await setupWorkspaceManager({
+			stateManager: stateManager as any,
+			historyItem: undefined,
+			detectRoots,
+		})
+
+		// fell back to single-root manager from legacy cwd
+		expect(manager.getRoots()).to.have.length(1)
+		expect(manager.getRoots()[0].path).to.equal(cwd)
+
+		// telemetry error captured (skipped assertion in unit tests)
+
+		// persisted fallback state
+		expect(stateManager._state.roots?.[0].path).to.equal(cwd)
+
+		// message shown to user
+		const showMessageSpy = HostProvider.window.showMessage as sinon.SinonStub
+		expect(showMessageSpy.calledOnce).to.equal(true)
+		const msg = showMessageSpy.getCall(0).args[0]
+		expect(msg?.message || "").to.match(/Failed to initialize workspace/i)
+	})
+})

--- a/src/core/workspace/detection.ts
+++ b/src/core/workspace/detection.ts
@@ -1,0 +1,52 @@
+import { VcsType, WorkspaceRoot } from "@core/workspace"
+import * as path from "path"
+import { HostProvider } from "@/hosts/host-provider"
+import { getLatestGitCommitHash, isGitRepository } from "@/utils/git"
+import { getCwd, getDesktopDir } from "@/utils/path"
+
+/**
+ * Detect the VCS type for a given directory path.
+ * Currently supports Git; returns None otherwise.
+ */
+export async function detectVcs(dirPath: string): Promise<VcsType> {
+	try {
+		const isGit = await isGitRepository(dirPath)
+		return isGit ? VcsType.Git : VcsType.None
+	} catch {
+		return VcsType.None
+	}
+}
+
+/**
+ * Detect workspace roots from the host editor (VS Code, etc.).
+ * Falls back to current working directory when no workspace folders are present.
+ */
+export async function detectWorkspaceRoots(): Promise<WorkspaceRoot[]> {
+	const workspacePaths = await HostProvider.workspace.getWorkspacePaths({})
+
+	if (!workspacePaths.paths || workspacePaths.paths.length === 0) {
+		// No workspace folders, use cwd
+		const cwd = await getCwd(getDesktopDir())
+		return [
+			{
+				path: cwd,
+				name: path.basename(cwd),
+				vcs: VcsType.None, // Will be detected later if needed
+			},
+		]
+	}
+
+	// Convert workspace paths to WorkspaceRoots
+	const roots: WorkspaceRoot[] = []
+	for (const workspacePath of workspacePaths.paths) {
+		const vcs = await detectVcs(workspacePath)
+		roots.push({
+			path: workspacePath,
+			name: path.basename(workspacePath),
+			vcs,
+			commitHash: vcs === VcsType.Git ? (await getLatestGitCommitHash(workspacePath)) || undefined : undefined,
+		})
+	}
+
+	return roots
+}

--- a/src/core/workspace/index.ts
+++ b/src/core/workspace/index.ts
@@ -8,11 +8,11 @@ export {
 	resolveWorkspacePath,
 	WorkspaceResolver,
 	workspaceResolver,
-} from "@core/workspace/WorkspaceResolver"
-export type { WorkspaceRoot } from "@core/workspace/WorkspaceRoot"
-export { VcsType } from "@core/workspace/WorkspaceRoot"
-export type { WorkspaceContext } from "@core/workspace/WorkspaceRootManager"
-export { createLegacyWorkspaceRoot, WorkspaceRootManager } from "@core/workspace/WorkspaceRootManager"
+} from "./WorkspaceResolver"
+export type { WorkspaceRoot } from "./WorkspaceRoot"
+export { VcsType } from "./WorkspaceRoot"
+export type { WorkspaceContext } from "./WorkspaceRootManager"
+export { createLegacyWorkspaceRoot, WorkspaceRootManager } from "./WorkspaceRootManager"
 
 // Re-export convenience function at module level for easier imports
 // Usage: import { resolveWorkspacePath } from "@core/workspace"

--- a/src/core/workspace/setup.ts
+++ b/src/core/workspace/setup.ts
@@ -1,0 +1,110 @@
+import { HostProvider } from "@/hosts/host-provider"
+import { telemetryService } from "@/services/telemetry"
+import type { HistoryItem } from "@/shared/HistoryItem"
+import { ShowMessageType } from "@/shared/proto/host/window"
+import { getCwd, getDesktopDir } from "@/utils/path"
+import type { WorkspaceRoot } from "./WorkspaceRoot"
+import { WorkspaceRootManager } from "./WorkspaceRootManager"
+
+type DetectRoots = () => Promise<WorkspaceRoot[]>
+
+/**
+ * Initializes and persists the WorkspaceRootManager (multi-root or single-root),
+ * emits telemetry, and handles fallback on error.
+ *
+ * The caller injects detectRoots to avoid tight coupling to Controller.
+ */
+export async function setupWorkspaceManager({
+	stateManager,
+	detectRoots,
+}: {
+	stateManager: {
+		isMultiRootEnabled(): boolean
+		getWorkspaceRoots(): WorkspaceRoot[] | undefined
+		getPrimaryRootIndex(): number
+		setWorkspaceRoots(roots: WorkspaceRoot[]): void
+		setPrimaryRootIndex(idx: number): void
+	}
+	historyItem?: HistoryItem
+	detectRoots: DetectRoots
+}): Promise<WorkspaceRootManager> {
+	const cwd = await getCwd(getDesktopDir())
+	const multiRootEnabled = stateManager.isMultiRootEnabled()
+	const startTime = performance.now()
+
+	try {
+		let manager: WorkspaceRootManager
+		// Multi-root mode condition which is always false for now as isMultiRootEnabled is hardcoded to false
+		if (multiRootEnabled) {
+			// Multi-root: detect workspace folders
+			const roots = await detectRoots()
+			manager = new WorkspaceRootManager(roots, 0)
+			console.log(`[WorkspaceManager] Multi-root mode: ${roots.length} roots detected`)
+
+			// Telemetry
+			telemetryService.captureWorkspaceInitialized(
+				roots.length,
+				roots.map((r) => r.vcs.toString()),
+				performance.now() - startTime,
+				true,
+			)
+
+			// Persist
+			stateManager.setWorkspaceRoots(manager.getRoots())
+			stateManager.setPrimaryRootIndex(manager.getPrimaryIndex())
+			return manager
+		}
+
+		// Single-root mode code for when we actually start using workspacerootmanager
+		// if (historyItem) {
+		// 	const savedRoots = stateManager.getWorkspaceRoots()
+		// 	if (savedRoots && savedRoots.length > 0) {
+		// 		const primaryIndex = stateManager.getPrimaryRootIndex()
+		// 		manager = new WorkspaceRootManager(savedRoots, primaryIndex)
+		// 		console.log(`[WorkspaceManager] Restored ${savedRoots.length} roots from state`)
+		// 		telemetryService.captureWorkspaceInitialized(
+		// 			savedRoots.length,
+		// 			savedRoots.map((r) => r.vcs.toString()),
+		// 			performance.now() - startTime,
+		// 			false,
+		// 		)
+		// 	} else {
+		// 		manager = await WorkspaceRootManager.fromLegacyCwd(cwd)
+		// 		telemetryService.captureWorkspaceInitialized(
+		// 			1,
+		// 			[manager.getRoots()[0].vcs.toString()],
+		// 			performance.now() - startTime,
+		// 			false,
+		// 		)
+		// 	}
+		// }
+
+		manager = await WorkspaceRootManager.fromLegacyCwd(cwd)
+		telemetryService.captureWorkspaceInitialized(
+			1,
+			[manager.getRoots()[0].vcs.toString()],
+			performance.now() - startTime,
+			false,
+		)
+
+		console.log(`[WorkspaceManager] Single-root mode: ${cwd}`)
+		stateManager.setWorkspaceRoots(manager.getRoots())
+		stateManager.setPrimaryRootIndex(manager.getPrimaryIndex())
+		return manager
+	} catch (error) {
+		// Telemetry + graceful fallback to single-root from cwd
+		const workspaceCount = (await HostProvider.workspace.getWorkspacePaths({})).paths?.length
+		telemetryService.captureWorkspaceInitError(error as Error, true, workspaceCount)
+
+		console.error("[WorkspaceManager] Initialization failed:", error)
+		const manager = await WorkspaceRootManager.fromLegacyCwd(cwd)
+		stateManager.setWorkspaceRoots(manager.getRoots())
+		stateManager.setPrimaryRootIndex(manager.getPrimaryIndex())
+
+		HostProvider.window.showMessage({
+			type: ShowMessageType.WARNING,
+			message: "Failed to initialize workspace. Using single folder mode.",
+		})
+		return manager
+	}
+}

--- a/src/integrations/checkpoints/MultiRootCheckpointManager.ts
+++ b/src/integrations/checkpoints/MultiRootCheckpointManager.ts
@@ -1,0 +1,312 @@
+/**
+ * TODO: MULTI-ROOT CHECKPOINT MANAGER - NOT YET IN USE
+ *
+ * This MultiRootCheckpointManager class has been implemented as part of Phase 1
+ * of the multi-workspace support initiative, but it is NOT currently being used
+ * anywhere in the codebase.
+ *
+ * Current Status:
+ * - The infrastructure is complete and ready
+ * - The feature flag for multi-root is disabled by default
+ * - The checkpoint factory (src/integrations/checkpoints/factory.ts) will
+ *   instantiate this manager when multi-root is enabled
+ *
+ * Follow-up Implementation Required:
+ * 1. Enable the multi-root feature flag in StateManager
+ * 2. Update the checkpoint factory to use this manager when appropriate
+ * 3. Test thoroughly with multiple workspace roots
+ * 4. Add proper restoration logic for all workspace roots (not just primary)
+ * 5. Implement full diff checking across all workspace roots
+ *
+ * See PRD: Multi-Workspace Folder Support for complete requirements
+ */
+
+import { MessageStateHandler } from "@core/task/message-state"
+import { showChangedFilesDiff } from "@core/task/multifile-diff"
+import { VcsType, WorkspaceRootManager } from "@core/workspace"
+import { telemetryService } from "@services/telemetry"
+import { HostProvider } from "@/hosts/host-provider"
+import { ShowMessageType } from "@/shared/proto/host/window"
+import CheckpointTracker from "./CheckpointTracker"
+import { ICheckpointManager } from "./types"
+
+/**
+ * Manages checkpoints across multiple workspace roots.
+ * Only created when multiple roots are detected and feature flag is enabled.
+ *
+ * This implementation follows Option B: Simple All-Workspace Approach
+ * - Checkpoints all Git-enabled workspaces every time
+ * - Commits run in parallel in the background (non-blocking)
+ * - Maintains backward compatibility with single-root expectations
+ */
+export class MultiRootCheckpointManager implements ICheckpointManager {
+	private trackers: Map<string, CheckpointTracker> = new Map()
+	private initialized = false
+	private initPromise?: Promise<void>
+
+	constructor(
+		private workspaceManager: WorkspaceRootManager,
+		private taskId: string,
+		private globalStoragePath: string,
+		private enableCheckpoints: boolean,
+		private messageStateHandler: MessageStateHandler,
+	) {}
+
+	/**
+	 * Initialize checkpoint trackers for all Git-enabled roots
+	 * This is called separately to avoid blocking the Task constructor
+	 */
+	async initialize(): Promise<void> {
+		// Prevent multiple initialization attempts
+		if (this.initialized) {
+			return
+		}
+
+		if (this.initPromise) {
+			return this.initPromise
+		}
+
+		this.initPromise = this.doInitialize()
+		await this.initPromise
+		this.initPromise = undefined
+	}
+
+	private async doInitialize(): Promise<void> {
+		if (!this.enableCheckpoints) {
+			console.log("[MultiRootCheckpointManager] Checkpoints disabled, skipping initialization")
+			return
+		}
+
+		const startTime = performance.now()
+		const roots = this.workspaceManager.getRoots()
+		const gitRoots = roots.filter((root) => root.vcs === VcsType.Git)
+		console.log(
+			`[MultiRootCheckpointManager] Initializing for ${roots.length} workspace roots (${gitRoots.length} Git-enabled)`,
+		)
+
+		// Initialize all Git-enabled roots in parallel
+		const initPromises = gitRoots.map(async (root) => {
+			try {
+				console.log(`[MultiRootCheckpointManager] Creating tracker for ${root.name} at ${root.path}`)
+				const tracker = await CheckpointTracker.create(this.taskId, this.globalStoragePath, this.enableCheckpoints)
+				if (tracker) {
+					this.trackers.set(root.path, tracker)
+					console.log(`[MultiRootCheckpointManager] Successfully initialized tracker for ${root.name}`)
+					return true
+				}
+				return false
+			} catch (error) {
+				console.error(`[MultiRootCheckpointManager] Failed to initialize checkpoint for ${root.name}:`, error)
+				// Continue with other roots even if one fails
+				return false
+			}
+		})
+
+		const results = await Promise.all(initPromises)
+		const successCount = results.filter((r) => r).length
+		const failureCount = results.length - successCount
+
+		this.initialized = true
+		console.log(`[MultiRootCheckpointManager] Initialization complete. Active trackers: ${this.trackers.size}`)
+
+		// TELEMETRY: Track multi-root checkpoint initialization
+		telemetryService.captureMultiRootCheckpoint(
+			this.taskId,
+			"initialized",
+			gitRoots.length,
+			successCount,
+			failureCount,
+			performance.now() - startTime,
+		)
+	}
+
+	/**
+	 * Save checkpoint across all workspace roots
+	 * Commits happen in parallel in the background (non-blocking)
+	 */
+	async saveCheckpoint(): Promise<void> {
+		if (!this.enableCheckpoints || !this.initialized) {
+			return
+		}
+
+		if (this.trackers.size === 0) {
+			console.log("[MultiRootCheckpointManager] No trackers available for checkpoint")
+			return
+		}
+
+		console.log(`[MultiRootCheckpointManager] Creating checkpoint across ${this.trackers.size} workspace(s)`)
+
+		// Commit all roots in parallel (fire and forget for performance)
+		const commitPromises = Array.from(this.trackers.entries()).map(async ([path, tracker]) => {
+			try {
+				const hash = await tracker.commit()
+				if (hash) {
+					const rootName = this.workspaceManager.getRoots().find((r) => r.path === path)?.name || path
+					console.log(`[MultiRootCheckpointManager] Checkpoint created for ${rootName}: ${hash}`)
+				}
+				return { path, hash, success: true }
+			} catch (error) {
+				const rootName = this.workspaceManager.getRoots().find((r) => r.path === path)?.name || path
+				console.error(`[MultiRootCheckpointManager] Failed to checkpoint ${rootName}:`, error)
+				return { path, hash: undefined, success: false }
+			}
+		})
+
+		// Don't await - let commits happen in background for better performance
+		// But do catch any errors to prevent unhandled promise rejections
+		const startTime = performance.now()
+		Promise.all(commitPromises)
+			.then((results) => {
+				const successful = results.filter((r) => r.success).length
+				const failed = results.length - successful
+				console.log(`[MultiRootCheckpointManager] Checkpoint complete: ${successful}/${results.length} successful`)
+
+				// TELEMETRY: Track checkpoint commits
+				telemetryService.captureMultiRootCheckpoint(
+					this.taskId,
+					"committed",
+					results.length,
+					successful,
+					failed,
+					performance.now() - startTime,
+				)
+			})
+			.catch((error) => {
+				console.error("[MultiRootCheckpointManager] Unexpected error during checkpoint:", error)
+			})
+	}
+
+	/**
+	 * Restore checkpoint for workspace roots
+	 * For now, this restores the primary root only for simplicity
+	 * Future enhancement: restore all roots to their respective checkpoints
+	 */
+	async restoreCheckpoint(): Promise<any> {
+		const primaryRoot = this.workspaceManager.getPrimaryRoot()
+		if (!primaryRoot) {
+			console.error("[MultiRootCheckpointManager] No primary root found")
+			return { error: "No primary workspace found" }
+		}
+
+		const tracker = this.trackers.get(primaryRoot.path)
+
+		if (!tracker) {
+			console.error(`[MultiRootCheckpointManager] No tracker found for primary root: ${primaryRoot.path}`)
+			return { error: "No checkpoint tracker for primary workspace" }
+		}
+
+		console.log(`[MultiRootCheckpointManager] Restoring checkpoint for primary root: ${primaryRoot.name}`)
+
+		// TODO: Implement full restore logic similar to TaskCheckpointManager
+		// For now, this is a placeholder that would delegate to the existing restore logic
+		// In a full implementation, we'd restore all roots or provide options to the user
+
+		return {}
+	}
+
+	/**
+	 * Check if the latest task completion has new changes
+	 * Returns true if ANY workspace has changes
+	 */
+	async doesLatestTaskCompletionHaveNewChanges(): Promise<boolean> {
+		if (!this.initialized || this.trackers.size === 0) {
+			return false
+		}
+
+		// Check if any root has changes
+		for (const [path] of this.trackers.entries()) {
+			try {
+				// TODO: Implement proper diff checking logic
+				// This would need to track checkpoint hashes per root
+				// For now, return false as a safe default
+				const rootName = this.workspaceManager.getRoots().find((r) => r.path === path)?.name || path
+				console.log(`[MultiRootCheckpointManager] Checking for changes in ${rootName}`)
+			} catch (error) {
+				console.error(`[MultiRootCheckpointManager] Error checking changes for ${path}:`, error)
+			}
+		}
+
+		return false
+	}
+
+	/**
+	 * Commit changes across all workspaces
+	 * Returns the primary root's commit hash for backward compatibility
+	 */
+	async commit(): Promise<string | undefined> {
+		if (!this.initialized || this.trackers.size === 0) {
+			return undefined
+		}
+
+		const primaryRoot = this.workspaceManager.getPrimaryRoot()
+		if (!primaryRoot) {
+			console.warn("[MultiRootCheckpointManager] No primary root found, committing all roots")
+			// Just commit all roots and return undefined
+			const commitPromises = Array.from(this.trackers.values()).map((tracker) =>
+				tracker.commit().catch((error) => {
+					console.error("[MultiRootCheckpointManager] Commit error:", error)
+					return undefined
+				}),
+			)
+			await Promise.all(commitPromises)
+			return undefined
+		}
+
+		// Commit all roots in parallel
+		const commitPromises = Array.from(this.trackers.values()).map((tracker) =>
+			tracker.commit().catch((error) => {
+				console.error("[MultiRootCheckpointManager] Commit error:", error)
+				return undefined
+			}),
+		)
+
+		const results = await Promise.all(commitPromises)
+
+		// Return primary root's hash for compatibility with existing code
+		const primaryIndex = Array.from(this.trackers.keys()).indexOf(primaryRoot.path)
+		return results[primaryIndex]
+	}
+
+	/**
+	 * Presents a multi-file diff view for the primary workspace root.
+	 * For multi-root v1, this shows diffs for the primary root only.
+	 */
+	async presentMultifileDiff(messageTs: number, seeNewChangesSinceLastTaskCompletion: boolean): Promise<void> {
+		try {
+			if (!this.enableCheckpoints || !this.initialized) {
+				HostProvider.window.showMessage({
+					type: ShowMessageType.ERROR,
+					message: "Checkpoint manager is not initialized.",
+				})
+				return
+			}
+
+			const primaryRoot = this.workspaceManager.getPrimaryRoot()
+			if (!primaryRoot) {
+				HostProvider.window.showMessage({
+					type: ShowMessageType.ERROR,
+					message: "No primary workspace root configured.",
+				})
+				return
+			}
+
+			const tracker = this.trackers.get(primaryRoot.path)
+			if (!tracker) {
+				HostProvider.window.showMessage({
+					type: ShowMessageType.ERROR,
+					message: "No checkpoint tracker available for the primary workspace.",
+				})
+				return
+			}
+
+			await showChangedFilesDiff(this.messageStateHandler, tracker, messageTs, seeNewChangesSinceLastTaskCompletion)
+		} catch (error) {
+			const errorMessage = error instanceof Error ? error.message : "Unknown error"
+			console.error("[MultiRootCheckpointManager] Failed to present multifile diff:", errorMessage)
+			HostProvider.window.showMessage({
+				type: ShowMessageType.ERROR,
+				message: "Failed to present diff: " + errorMessage,
+			})
+		}
+	}
+}

--- a/src/integrations/checkpoints/__tests__/factory.test.ts
+++ b/src/integrations/checkpoints/__tests__/factory.test.ts
@@ -1,0 +1,72 @@
+import type { WorkspaceRootManager } from "@core/workspace/WorkspaceRootManager"
+import { expect } from "chai"
+import { shouldUseMultiRoot } from "../factory"
+
+describe("shouldUseMultiRoot", () => {
+	const makeWr = (roots: { path: string }[]): WorkspaceRootManager => {
+		// minimal mock: only getRoots is used
+		return {
+			getRoots: () => roots as any,
+		} as unknown as WorkspaceRootManager
+	}
+
+	it("returns true when feature flag is on, checkpoints enabled, and more than one root exists", () => {
+		const wr = makeWr([{ path: "/r1" }, { path: "/r2" }])
+		const result = shouldUseMultiRoot({
+			isMultiRootEnabled: true,
+			workspaceManager: wr,
+			enableCheckpoints: true,
+		})
+		expect(result).to.equal(true)
+	})
+
+	it("returns false when feature flag is off", () => {
+		const wr = makeWr([{ path: "/r1" }, { path: "/r2" }])
+		const result = shouldUseMultiRoot({
+			isMultiRootEnabled: false,
+			workspaceManager: wr,
+			enableCheckpoints: true,
+		})
+
+		expect(result).to.equal(false)
+	})
+
+	it("returns false when checkpoints are disabled", () => {
+		const wr = makeWr([{ path: "/r1" }, { path: "/r2" }])
+		const result = shouldUseMultiRoot({
+			isMultiRootEnabled: true,
+			workspaceManager: wr,
+			enableCheckpoints: false,
+		})
+		expect(result).to.equal(false)
+	})
+
+	it("returns false when workspaceManager is undefined", () => {
+		const result = shouldUseMultiRoot({
+			isMultiRootEnabled: true,
+			workspaceManager: undefined,
+			enableCheckpoints: true,
+		})
+		expect(result).to.equal(false)
+	})
+
+	it("returns false when only a single root exists", () => {
+		const wr = makeWr([{ path: "/r1" }])
+		const result = shouldUseMultiRoot({
+			isMultiRootEnabled: true,
+			workspaceManager: wr,
+			enableCheckpoints: true,
+		})
+		expect(result).to.equal(false)
+	})
+
+	it("returns false when there are no roots", () => {
+		const wr = makeWr([])
+		const result = shouldUseMultiRoot({
+			isMultiRootEnabled: true,
+			workspaceManager: wr,
+			enableCheckpoints: true,
+		})
+		expect(result).to.equal(false)
+	})
+})

--- a/src/integrations/checkpoints/factory.ts
+++ b/src/integrations/checkpoints/factory.ts
@@ -1,0 +1,110 @@
+import type { FileContextTracker } from "@core/context/context-tracking/FileContextTracker"
+import type { MessageStateHandler } from "@core/task/message-state"
+import type { TaskState } from "@core/task/TaskState"
+import { WorkspaceRootManager } from "@core/workspace/WorkspaceRootManager"
+import { createTaskCheckpointManager } from "@integrations/checkpoints"
+import { MultiRootCheckpointManager } from "@integrations/checkpoints/MultiRootCheckpointManager"
+import type { ICheckpointManager } from "@integrations/checkpoints/types"
+import type { DiffViewProvider } from "@integrations/editor/DiffViewProvider"
+import type * as vscode from "vscode"
+
+/**
+ * Simple predicate abstracting our multi-root decision.
+ */
+export function shouldUseMultiRoot({
+	isMultiRootEnabled,
+	workspaceManager,
+	enableCheckpoints,
+}: {
+	isMultiRootEnabled: boolean
+	workspaceManager?: WorkspaceRootManager
+	enableCheckpoints: boolean
+}): boolean {
+	return Boolean(isMultiRootEnabled && enableCheckpoints && workspaceManager && workspaceManager.getRoots().length > 1)
+}
+
+type BuildArgs = {
+	// common
+	taskId: string
+	enableCheckpoints: boolean
+	messageStateHandler: MessageStateHandler
+	// single-root deps
+	fileContextTracker: FileContextTracker
+	diffViewProvider: DiffViewProvider
+	taskState: TaskState
+	context: vscode.ExtensionContext
+	// multi-root deps
+	workspaceManager?: WorkspaceRootManager
+	globalStoragePath: string
+	isMultiRootEnabled: boolean
+
+	// callbacks for single-root TaskCheckpointManager
+	updateTaskHistory: (historyItem: any) => Promise<any[]>
+	say: (...args: any[]) => Promise<number | undefined>
+	cancelTask: () => Promise<void>
+	postStateToWebview: () => Promise<void>
+
+	// initial state for single-root
+	initialConversationHistoryDeletedRange?: [number, number]
+	initialCheckpointManagerErrorMessage?: string
+}
+
+/**
+ * Central factory for creating the appropriate checkpoint manager.
+ * - MultiRootCheckpointManager for multi-root tasks
+ * - TaskCheckpointManager for single-root tasks
+ */
+export function buildCheckpointManager(args: BuildArgs): ICheckpointManager {
+	const {
+		taskId,
+		enableCheckpoints,
+		messageStateHandler,
+		fileContextTracker,
+		diffViewProvider,
+		taskState,
+		context,
+		workspaceManager,
+		globalStoragePath,
+		isMultiRootEnabled,
+		updateTaskHistory,
+		say,
+		cancelTask,
+		postStateToWebview,
+		initialConversationHistoryDeletedRange,
+		initialCheckpointManagerErrorMessage,
+	} = args
+
+	if (shouldUseMultiRoot({ isMultiRootEnabled, workspaceManager, enableCheckpoints })) {
+		// Multi-root manager (init should be kicked off externally, non-blocking)
+		return new MultiRootCheckpointManager(
+			workspaceManager!,
+			taskId,
+			globalStoragePath,
+			enableCheckpoints,
+			messageStateHandler,
+		)
+	}
+
+	// Single-root manager
+	return createTaskCheckpointManager(
+		{ taskId },
+		{ enableCheckpoints },
+		{
+			context,
+			diffViewProvider,
+			messageStateHandler,
+			fileContextTracker,
+			taskState,
+		},
+		{
+			updateTaskHistory,
+			say,
+			cancelTask,
+			postStateToWebview,
+		},
+		{
+			conversationHistoryDeletedRange: initialConversationHistoryDeletedRange,
+			checkpointManagerErrorMessage: initialCheckpointManagerErrorMessage,
+		},
+	)
+}

--- a/src/integrations/checkpoints/index.ts
+++ b/src/integrations/checkpoints/index.ts
@@ -17,6 +17,7 @@ import { HostProvider } from "@/hosts/host-provider"
 import { ShowMessageType } from "@/shared/proto/host/window"
 import { MessageStateHandler } from "../../core/task/message-state"
 import { TaskState } from "../../core/task/TaskState"
+import { ICheckpointManager } from "./types"
 
 // Type definitions for better code organization
 type SayFunction = (
@@ -80,7 +81,7 @@ interface CheckpointRestoreStateUpdate {
  *
  * For checkpoint operations, the CheckpointTracker class is used to interact with the underlying git logic.
  */
-export class TaskCheckpointManager {
+export class TaskCheckpointManager implements ICheckpointManager {
 	private readonly task: CheckpointManagerTask
 	private readonly config: CheckpointManagerConfig
 	private readonly services: CheckpointManagerServices

--- a/src/integrations/checkpoints/initializer.ts
+++ b/src/integrations/checkpoints/initializer.ts
@@ -1,0 +1,39 @@
+import type { ICheckpointManager } from "@integrations/checkpoints/types"
+import pTimeout from "p-timeout"
+
+/**
+ * Ensures a checkpoint manager is initialized, handling both single-root and multi-root implementations.
+ * - TaskCheckpointManager exposes `checkpointTrackerCheckAndInit()`
+ * - MultiRootCheckpointManager exposes `initialize()`
+ */
+export async function ensureCheckpointInitialized({
+	checkpointManager,
+	timeoutMs = 15_000,
+	timeoutMessage = "Checkpoints taking too long to initialize. Consider re-opening Cline in a project that uses git, or disabling checkpoints.",
+}: {
+	checkpointManager: ICheckpointManager | undefined
+	timeoutMs?: number
+	timeoutMessage?: string
+}): Promise<void> {
+	if (!checkpointManager) {
+		return
+	}
+	// TaskCheckpointManager path
+	const maybeInit = checkpointManager.checkpointTrackerCheckAndInit
+	if (typeof maybeInit === "function") {
+		await pTimeout(maybeInit.call(checkpointManager), {
+			milliseconds: timeoutMs,
+			message: timeoutMessage,
+		})
+		return
+	}
+
+	// MultiRootCheckpointManager path
+	const maybeInitialize = checkpointManager.initialize
+	if (typeof maybeInitialize === "function") {
+		await pTimeout(maybeInitialize.call(checkpointManager), {
+			milliseconds: timeoutMs,
+			message: timeoutMessage,
+		})
+	}
+}

--- a/src/integrations/checkpoints/types.ts
+++ b/src/integrations/checkpoints/types.ts
@@ -1,0 +1,21 @@
+/**
+ * Common interface for checkpoint managers
+ * Allows single-root and multi-root managers to be used interchangeably
+ */
+export interface ICheckpointManager {
+	saveCheckpoint(isAttemptCompletionMessage?: boolean, completionMessageTs?: number): Promise<void>
+
+	restoreCheckpoint(messageTs: number, restoreType: any, offset?: number): Promise<any>
+
+	doesLatestTaskCompletionHaveNewChanges(): Promise<boolean>
+
+	commit(): Promise<string | undefined>
+
+	presentMultifileDiff?(messageTs: number, seeNewChangesSinceLastTaskCompletion: boolean): Promise<void>
+
+	// Optional method for multi-root specific initialization
+	initialize?(): Promise<void>
+
+	// Optional method for checking and initializing checkpoint tracker
+	checkpointTrackerCheckAndInit?(): Promise<any>
+}

--- a/src/services/telemetry/TelemetryService.ts
+++ b/src/services/telemetry/TelemetryService.ts
@@ -88,6 +88,19 @@ export class TelemetryService {
 			TELEMETRY_ENABLED: "user.telemetry_enabled",
 			EXTENSION_ACTIVATED: "user.extension_activated",
 		},
+		// Workspace-related events for multi-root support
+		WORKSPACE: {
+			// Track workspace initialization
+			INITIALIZED: "workspace.initialized",
+			// Track initialization errors
+			INIT_ERROR: "workspace.init_error",
+			// Track VCS detection
+			VCS_DETECTED: "workspace.vcs_detected",
+			// Track multi-root checkpoint operations
+			MULTI_ROOT_CHECKPOINT: "workspace.multi_root_checkpoint",
+			// Track workspace resolution
+			PATH_RESOLVED: "workspace.path_resolved",
+		},
 		TASK: {
 			// Tracks when a new task/conversation is started
 			CREATED: "task.created",
@@ -994,6 +1007,84 @@ export class TelemetryService {
 			event: TelemetryService.EVENTS.TASK.TERMINAL_HANG,
 			properties: {
 				stage,
+			},
+		})
+	}
+
+	// Workspace telemetry methods
+
+	/**
+	 * Records when workspace is initialized
+	 * @param rootCount Number of workspace roots
+	 * @param vcsTypes Array of VCS types detected
+	 * @param initDurationMs Time taken to initialize in milliseconds
+	 * @param featureFlagEnabled Whether multi-root feature flag is enabled
+	 */
+	public captureWorkspaceInitialized(
+		rootCount: number,
+		vcsTypes: string[],
+		initDurationMs?: number,
+		featureFlagEnabled?: boolean,
+	) {
+		this.capture({
+			event: TelemetryService.EVENTS.WORKSPACE.INITIALIZED,
+			properties: {
+				root_count: rootCount,
+				vcs_types: vcsTypes,
+				is_multi_root: rootCount > 1,
+				has_git: vcsTypes.includes("Git"),
+				has_mercurial: vcsTypes.includes("Mercurial"),
+				init_duration_ms: initDurationMs,
+				feature_flag_enabled: featureFlagEnabled,
+			},
+		})
+	}
+
+	/**
+	 * Records workspace initialization errors
+	 * @param error The error that occurred
+	 * @param fallbackMode Whether system fell back to single-root mode
+	 * @param workspaceCount Number of workspace folders detected
+	 */
+	public captureWorkspaceInitError(error: Error, fallbackMode: boolean, workspaceCount?: number) {
+		this.capture({
+			event: TelemetryService.EVENTS.WORKSPACE.INIT_ERROR,
+			properties: {
+				error_type: error.constructor.name,
+				error_message: error.message.substring(0, MAX_ERROR_MESSAGE_LENGTH),
+				fallback_to_single_root: fallbackMode,
+				workspace_count: workspaceCount ?? 0,
+			},
+		})
+	}
+
+	/**
+	 * Records multi-root checkpoint operations
+	 * @param ulid Task identifier
+	 * @param action Type of checkpoint action
+	 * @param rootCount Number of roots being checkpointed
+	 * @param successCount Number of successful checkpoints
+	 * @param failureCount Number of failed checkpoints
+	 * @param durationMs Total operation duration in milliseconds
+	 */
+	public captureMultiRootCheckpoint(
+		ulid: string,
+		action: "initialized" | "committed" | "restored",
+		rootCount: number,
+		successCount: number,
+		failureCount: number,
+		durationMs?: number,
+	) {
+		this.capture({
+			event: TelemetryService.EVENTS.WORKSPACE.MULTI_ROOT_CHECKPOINT,
+			properties: {
+				ulid,
+				action,
+				root_count: rootCount,
+				success_count: successCount,
+				failure_count: failureCount,
+				success_rate: rootCount > 0 ? successCount / rootCount : 0,
+				duration_ms: durationMs,
 			},
 		})
 	}

--- a/src/shared/ExtensionMessage.ts
+++ b/src/shared/ExtensionMessage.ts
@@ -1,5 +1,6 @@
 // type that represents json data that is sent from extension to webview, called ExtensionMessage and has 'type' enum which can be 'plusButtonClicked' or 'settingsButtonClicked' or 'hello'
 
+import { WorkspaceRoot } from "../core/workspace"
 import { AutoApprovalSettings } from "./AutoApprovalSettings"
 import { ApiConfiguration } from "./api"
 import { BrowserSettings } from "./BrowserSettings"
@@ -72,6 +73,10 @@ export interface ExtensionState {
 	focusChainFeatureFlagEnabled?: boolean
 	customPrompt?: string
 	extensionInfo: { name: string; publisher: string }
+	// NEW: Add workspace information
+	workspaceRoots: WorkspaceRoot[]
+	primaryRootIndex: number
+	isMultiRootWorkspace: boolean
 }
 
 export interface ClineMessage {

--- a/src/test/requires.ts
+++ b/src/test/requires.ts
@@ -9,6 +9,13 @@ Module.prototype.require = function (path: string) {
 	if (path === "vscode") {
 		return require("./vscode-mock")
 	}
+	// Avoid pulling in VSCode-integrated checkpoint/editor code during unit tests
+	if (path === "@integrations/checkpoints") {
+		return {}
+	}
+	if (path === "@integrations/checkpoints/MultiRootCheckpointManager") {
+		return { MultiRootCheckpointManager: class {} }
+	}
 
 	return originalRequire.call(this, path)
 }

--- a/src/utils/git.ts
+++ b/src/utils/git.ts
@@ -259,3 +259,15 @@ function truncateOutput(content: string): string {
 		...lines.slice(-afterLimit),
 	].join("\n")
 }
+
+// NEW: Additional functions for Stage 3 multi-workspace support
+// These are the ONLY new additions needed for workspace detection
+
+/**
+ * Check if a directory is a Git repository (Stage 3 requirement)
+ * @param dirPath - The directory path to check
+ * @returns True if it's a Git repository
+ */
+export async function isGitRepository(dirPath: string): Promise<boolean> {
+	return await checkGitRepo(dirPath)
+}

--- a/webview-ui/src/context/ExtensionStateContext.tsx
+++ b/webview-ui/src/context/ExtensionStateContext.tsx
@@ -207,6 +207,11 @@ export const ExtensionStateContextProvider: React.FC<{
 		customPrompt: undefined,
 		useAutoCondense: false,
 		extensionInfo: { name: "claude-dev", publisher: "saoudrizwan" },
+
+		// NEW: Add workspace information with defaults
+		workspaceRoots: [],
+		primaryRootIndex: 0,
+		isMultiRootWorkspace: false,
 	})
 	const [didHydrateState, setDidHydrateState] = useState(false)
 	const [showWelcome, setShowWelcome] = useState(false)


### PR DESCRIPTION
### Description

This PR introduces initial multi-root workspace support (v1) and wires it into the core task lifecycle. The implementation is designed to be safe, observable, and backward-compatible with single-root workflows.

Key highlights:
- Workspace Manager
  - Adds `setupWorkspaceManager()` to initialize and persist a `WorkspaceRootManager` using dependency-injected root detection and robust fallback behavior.
  - Detects workspace roots via `detectWorkspaceRoots()` using the host provider (VS Code) and per-root VCS detection (Git/None) with latest commit hash where available.
  - Persists `workspaceRoots` and `primaryRootIndex` in global state (via `StateManager`).
  - Emits telemetry for initialization and fallback scenarios.

- Checkpoints (v1 multi-root)
  - Introduces `MultiRootCheckpointManager` that:
    - Initializes CheckpointTrackers for all Git-enabled roots in parallel (non-blocking).
    - Commits checkpoints across roots in parallel; returns the primary root’s hash to maintain backward compatibility.
    - Presents diffs for the primary root (for v1), with error handling and user-facing messages via `HostProvider`.
  - Updates the controller/task wiring to select multi-root vs single-root checkpoint manager via `buildCheckpointManager()` and `shouldUseMultiRoot()` (feature-flag + roots > 1 + checkpoints enabled).
  - Adds `ensureCheckpointInitialized()` to unify initialization paths across single-root/multi-root with a timeout and consistent errors.

- Controller Integration
  - `Controller` initializes the `WorkspaceRootManager` on task init and attaches it to the `Task`.
  - Passes the resolved workspace CWD to the `Task` (primary root path when available) for consistent relative-path behavior.
  - Exposes workspace metadata to the webview state (`workspaceRoots`, `primaryRootIndex`, `isMultiRootWorkspace`).

- State & Telemetry
  - `StateManager` now persists `workspaceRoots` and `primaryRootIndex`.
  - `TelemetryService` includes workspace-centric events (`workspace.initialized`, `workspace.init_error`, `workspace.multi_root_checkpoint`).

- API & UI Safety
  - `presentMultifileDiff` is optional on `ICheckpointManager`; call sites updated to guard with optional chaining and temporary local var.
  - v1 shows diffs for the primary root only (explicitly documented in code comments).

Known v1 limitations and follow-ups:
- Restore is scoped to the primary root (placeholder in multi-root manager).
- `doesLatestTaskCompletionHaveNewChanges()` currently returns a safe default (false) until per-root tracking is added.
- Multi-root features are gated by a feature flag and a multi-root workspace with at least two roots.

Files of interest:
- Workspace
  - `src/core/workspace/setup.ts`, `detection.ts`, `WorkspaceRootManager.ts`, `index.ts`
- Checkpoints
  - `src/integrations/checkpoints/MultiRootCheckpointManager.ts`
  - `src/integrations/checkpoints/factory.ts`, `initializer.ts`, `types.ts`
- Controller/Task wiring
  - `src/core/controller/index.ts`
  - `src/core/controller/checkpoints/checkpointDiff.ts`
  - `src/core/controller/task/taskCompletionViewChanges.ts`
  - `src/core/task/index.ts`
- State/Telemetry
  - `src/core/storage/StateManager.ts`
  - `src/services/telemetry/TelemetryService.ts` (+ `src/services/telemetry/index.ts`)
- Webview state
  - `src/shared/ExtensionMessage.ts`


### Test Procedure
#### Manual
- Run this in the debugger and make sure the task creation etc works same as before
- Make sure checkpoints etc work same as before
- Hit the breakpoints to make sure that the codepaths and the code hit is also same as before as no real multi root code is actually being hit and run


#### Automated:
1. Unit tests (added Priority 1 coverage)
   - shouldUseMultiRoot decision logic
     - `src/integrations/checkpoints/__tests__/factory.test.ts`
   - setupWorkspaceManager scenarios
     - `src/core/workspace/__tests__/setup.test.ts`
2. Run:
   - `npm run test:unit`
   - Expected: unit tests pass (we observed 186 passing, 4 pending locally)
3. Optional:
   - `npm run test` to include integration tests (`vscode-test`)



### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [x] ♻️ Refactor Changes
-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes


### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

Notes:
- Unit tests are passing (`npm run test:unit`); if you prefer full suite (`npm test`) please run locally.
- Please run `npm run format && npm run lint` in CI or locally to ensure formatting/linters are green.
- Add a changeset if this is considered user-facing (recommended).


### Screenshots

N/A (no UI changes). Diff presentations are existing flows; v1 limits diffs to primary root for multi-root workspaces.


### Additional Notes

- Safety & Compatibility
  - Multi-root support is gated by a feature flag and defaults to single-root pathways; single-root behavior is unaffected.
  - Checkpoint commits return primary root hash for backward compatibility in UI/flows expecting a single hash.
  - `presentMultifileDiff` is optional in `ICheckpointManager` to allow gradual adoption without breaking existing implementations.

- Observability
  - Telemetry covers workspace initialization/errors and multi-root checkpoint operations to monitor stability and adoption.

- v1 Scope Decisions
  - Restore functionality and per-root “new changes” detection are explicitly left for v2 to keep v1 safe and minimal.
  - Diff is scoped to primary root for v1 to reduce complexity and avoid UI overload.

- Risks / Mitigations
  - Parallel commits: fire-and-forget design is guarded with try/catch and error logging; telemetry captures success/failure counts.
  - Fallbacks ensure a working single-root mode if anything fails during multi-root detection/initialization.

- Follow-ups (suggested)
  - Expand diff/restore across all roots (with UI affordances).
  - Persist and compare per-root checkpoint hashes to surface “new changes” more precisely.
  - Add documentation for enabling multi-root feature and its current v1 limitations.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> This PR adds initial support for multi-root workspaces, integrating it into task lifecycle, checkpoint management, and telemetry, while ensuring backward compatibility with single-root setups.
> 
>   - **Workspace Management**:
>     - Adds `setupWorkspaceManager()` in `setup.ts` to initialize `WorkspaceRootManager` with multi-root support.
>     - Implements `detectWorkspaceRoots()` in `detection.ts` for root detection using VCS.
>     - Updates `WorkspaceRootManager` to handle multiple roots and primary root selection.
>   - **Checkpoints**:
>     - Introduces `MultiRootCheckpointManager` in `MultiRootCheckpointManager.ts` for managing checkpoints across multiple roots.
>     - Updates `buildCheckpointManager()` in `factory.ts` to choose between single and multi-root managers.
>     - Adds `ensureCheckpointInitialized()` in `initializer.ts` for consistent initialization.
>   - **Controller Integration**:
>     - Modifies `Controller` in `index.ts` to integrate `WorkspaceRootManager` and pass workspace metadata to tasks.
>   - **State & Telemetry**:
>     - Updates `StateManager` in `StateManager.ts` to persist multi-root state.
>     - Enhances `TelemetryService` in `TelemetryService.ts` to track multi-root events.
>   - **Testing**:
>     - Adds unit tests in `setup.test.ts` and `factory.test.ts` to verify multi-root logic.
>   - **Misc**:
>     - Updates `ExtensionState` in `ExtensionMessage.ts` to include workspace metadata.
>     - Adjusts `test/requires.ts` to mock multi-root components during tests.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 64e69e5c5c38e0e45f81ae65cd7b9f45e829874a. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->