### PR TITLE
Make proto Message types not optional by default

### DIFF
--- a/proto/cline/common.proto
+++ b/proto/cline/common.proto
@@ -8,19 +8,16 @@ message Metadata {
 }
 
 message EmptyRequest {
-  Metadata metadata = 1;
 }
 
 message Empty {
 }
 
 message StringRequest {
-  Metadata metadata = 1;
   string value = 2;
 }
 
 message StringArrayRequest {
-  Metadata metadata = 1;
   repeated string value = 2;
 }
 
@@ -29,7 +26,6 @@ message String {
 }
 
 message Int64Request {
-  Metadata metadata = 1;
   int64 value = 2;
 }
 
@@ -38,7 +34,6 @@ message Int64 {
 }
 
 message BytesRequest {
-  Metadata metadata = 1;
   bytes value = 2;
 }
 
@@ -47,7 +42,6 @@ message Bytes {
 }
 
 message BooleanRequest {
-  Metadata metadata = 1;
   bool value = 2;
 }
 

--- a/proto/host/window.proto
+++ b/proto/host/window.proto
@@ -4,8 +4,6 @@ package host;
 option java_package = "bot.cline.host.proto";
 option java_multiple_files = true;
 
-import "cline/common.proto";
-
 // Provides methods for working with IDE windows and editors.
 service WindowService {
   // Opens a text document in the IDE editor and returns editor information.
@@ -40,7 +38,6 @@ service WindowService {
 }
 
 message ShowTextDocumentRequest {
-  cline.Metadata metadata = 1;
   string path = 2;
   optional ShowTextDocumentOptions options = 3;
 }
@@ -59,7 +56,6 @@ message TextEditorInfo {
 }
 
 message ShowOpenDialogueRequest {
-  cline.Metadata metadata = 1;
   optional bool can_select_many = 2;
   optional string open_label = 3;
   optional ShowOpenDialogueFilterOption filters = 4;

--- a/scripts/build-proto.mjs
+++ b/scripts/build-proto.mjs
@@ -31,7 +31,7 @@ const TS_PROTO_OPTIONS = [
 	"esModuleInterop=true",
 	"outputServices=generic-definitions", // output generic ServiceDefinitions
 	"outputIndex=true", // output an index file for each package which exports all protos in the package.
-	"useOptionals=messages", // Message fields are optional, scalars are not.
+	"useOptionals=none", // scalar and message fields are required unless they are marked as optional.
 	"useDate=false", // Timestamp fields will not be automatically converted to Date.
 ]
 

--- a/src/integrations/diagnostics/__tests__/index.test.ts
+++ b/src/integrations/diagnostics/__tests__/index.test.ts
@@ -47,6 +47,10 @@ describe("Diagnostics Tests", () => {
 						{
 							severity: DiagnosticSeverity.DIAGNOSTIC_ERROR,
 							message: "Error in file1",
+							range: {
+								start: { line: 0, character: 0 },
+								end: { line: 0, character: 10 },
+							},
 						},
 					],
 				},
@@ -114,6 +118,10 @@ describe("Diagnostics Tests", () => {
 						{
 							severity: DiagnosticSeverity.DIAGNOSTIC_ERROR,
 							message: "Error in file1",
+							range: {
+								start: { line: 0, character: 0 },
+								end: { line: 0, character: 10 },
+							},
 						},
 					],
 				},
@@ -125,6 +133,10 @@ describe("Diagnostics Tests", () => {
 						{
 							severity: DiagnosticSeverity.DIAGNOSTIC_ERROR,
 							message: "Error in file1",
+							range: {
+								start: { line: 0, character: 0 },
+								end: { line: 0, character: 10 },
+							},
 						},
 					],
 				},
@@ -134,6 +146,10 @@ describe("Diagnostics Tests", () => {
 						{
 							severity: DiagnosticSeverity.DIAGNOSTIC_ERROR,
 							message: "Error in file2",
+							range: {
+								start: { line: 0, character: 0 },
+								end: { line: 0, character: 10 },
+							},
 						},
 					],
 				},
@@ -198,6 +214,10 @@ describe("Diagnostics Tests", () => {
 						{
 							severity: DiagnosticSeverity.DIAGNOSTIC_WARNING,
 							message: "Warning message",
+							range: {
+								start: { line: 0, character: 0 },
+								end: { line: 0, character: 10 },
+							},
 						},
 					],
 				},
@@ -240,6 +260,10 @@ describe("Diagnostics Tests", () => {
 						{
 							severity: DiagnosticSeverity.DIAGNOSTIC_ERROR,
 							message: "File-level error",
+							range: {
+								start: { line: 0, character: 0 },
+								end: { line: 0, character: 10 },
+							},
 						},
 					],
 				},
@@ -248,7 +272,7 @@ describe("Diagnostics Tests", () => {
 
 			const result = await diagnosticsToProblemsString(diagnostics, severities)
 
-			expect(result).to.equal("src/file1.ts\n- [Error] Line : File-level error")
+			expect(result).to.equal("src/file1.ts\n- [Error] Line 1: File-level error")
 		})
 
 		it("should handle diagnostics with missing start property in range", async () => {

--- a/src/shared/proto-conversions/cline-message.ts
+++ b/src/shared/proto-conversions/cline-message.ts
@@ -188,6 +188,15 @@ export function convertClineMessageToProto(message: AppClineMessage): ProtoCline
 					endIndex: message.conversationHistoryDeletedRange[1],
 				}
 			: undefined,
+		// Additional optional fields for specific ask/say types
+		sayTool: undefined,
+		sayBrowserAction: undefined,
+		browserActionResult: undefined,
+		askUseMcpServer: undefined,
+		planModeResponse: undefined,
+		askQuestion: undefined,
+		askNewTask: undefined,
+		apiReqInfo: undefined,
 	}
 
 	return protoMessage


### PR DESCRIPTION


### Description

In the ts-proto library, we have the option to make Message types not optional by default. This is the recommended option.

With --ts_proto_opt=useOptionals=messages (for message fields) or --ts_proto_opt=useOptionals=all (for message and scalar fields), fields are declared as optional keys, e.g. field?: Message instead of the default field: Message | undefined.

>ts-proto defaults to useOptionals=none because it:

>Prevents typos when initializing messages, and
Provides the most consistent API to readers
Ensures production messages are properly initialized with all fields.
For typo prevention, optional fields make it easy for extra fields to slip into a message (until we get https://github.com/microsoft/TypeScript/issues/12936), i.e.:

```
interface SomeMessage {
  firstName: string;
  lastName: string;
}
// Declared with a typo
const data = { firstName: "a", lastTypo: "b" };
// With useOptionals=none, this correctly fails to compile; if `lastName` was optional, it would not
const message: SomeMessage = { ...data };
```

See [here](https://github.com/stephenh/ts-proto/blob/main/README.markdown) for more info

What this means is that when we declare a Message in our proto files, it's generated TS type will not have the '?' optional operator unless it is marked with 'optional'. This helps with the accuracy of our type checking.

### Test Procedure

Run lint
Run type checks
Make sure tests pass

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [x] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Proto message fields are now required by default, with updates to TypeScript generation and test cases to reflect this change.
> 
>   - **Behavior**:
>     - Proto message fields are now required by default, unless marked optional, in `common.proto` and `window.proto`.
>     - Updated `build-proto.mjs` to set `useOptionals=none` for TypeScript generation.
>   - **Tests**:
>     - Added `range` property to diagnostics in `index.test.ts` to ensure completeness.
>     - Updated test expectations in `index.test.ts` to reflect new proto field requirements.
>   - **Misc**:
>     - Added undefined default values for optional fields in `convertClineMessageToProto()` in `cline-message.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 480b359fe42cce9beada63c55145818897ed147b. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->