### PR TITLE
Fix: Slash command / mention features remove following word

### DIFF
--- a/.changeset/late-wasps-agree.md
+++ b/.changeset/late-wasps-agree.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Fixed minor bug where entering slash commands would result in the following word being removed from the chat text area

--- a/webview-ui/src/components/chat/ChatTextArea.tsx
+++ b/webview-ui/src/components/chat/ChatTextArea.tsx
@@ -450,6 +450,9 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 
 				setShowContextMenu(false)
 				setSelectedType(null)
+				const queryLength = searchQuery.length
+				setSearchQuery("")
+
 				if (textAreaRef.current) {
 					let insertValue = value || ""
 					if (type === ContextMenuOptionType.URL) {
@@ -464,7 +467,12 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 						insertValue = value || ""
 					}
 
-					const { newValue, mentionIndex } = insertMention(textAreaRef.current.value, cursorPosition, insertValue)
+					const { newValue, mentionIndex } = insertMention(
+						textAreaRef.current.value,
+						cursorPosition,
+						insertValue,
+						queryLength,
+					)
 
 					setInputValue(newValue)
 					const newCursorPosition = newValue.indexOf(" ", mentionIndex + insertValue.length) + 1
@@ -481,7 +489,7 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 					}, 0)
 				}
 			},
-			[setInputValue, cursorPosition],
+			[setInputValue, cursorPosition, searchQuery],
 		)
 
 		const handleSlashCommandsSelect = useCallback(
@@ -557,6 +565,7 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 						// event.preventDefault()
 						setSelectedType(null)
 						setSelectedMenuIndex(DEFAULT_CONTEXT_MENU_OPTION)
+						setSearchQuery("")
 						return
 					}
 

--- a/webview-ui/src/components/chat/ChatTextArea.tsx
+++ b/webview-ui/src/components/chat/ChatTextArea.tsx
@@ -296,7 +296,6 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 		const [showSlashCommandsMenu, setShowSlashCommandsMenu] = useState(false)
 		const [selectedSlashCommandsIndex, setSelectedSlashCommandsIndex] = useState(0)
 		const [slashCommandsQuery, setSlashCommandsQuery] = useState("")
-		const slashCommandsQueryRef = useRef(slashCommandsQuery)
 		const slashCommandsMenuContainerRef = useRef<HTMLDivElement>(null)
 
 		const [thumbnailsHeight, setThumbnailsHeight] = useState(0)
@@ -488,7 +487,7 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 		const handleSlashCommandsSelect = useCallback(
 			(command: SlashCommand) => {
 				setShowSlashCommandsMenu(false)
-				const queryLength = slashCommandsQueryRef.current.length
+				const queryLength = slashCommandsQuery.length
 				setSlashCommandsQuery("")
 
 				if (textAreaRef.current) {
@@ -761,11 +760,9 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 					const slashIndex = newValue.indexOf("/")
 					const query = newValue.slice(slashIndex + 1, newCursorPosition)
 					setSlashCommandsQuery(query)
-					slashCommandsQueryRef.current = query
 					setSelectedSlashCommandsIndex(0)
 				} else {
 					setSlashCommandsQuery("")
-					slashCommandsQueryRef.current = ""
 					setSelectedSlashCommandsIndex(0)
 				}
 

--- a/webview-ui/src/utils/__tests__/context-mentions.test.ts
+++ b/webview-ui/src/utils/__tests__/context-mentions.test.ts
@@ -41,9 +41,9 @@ describe("context-mentions", () => {
 			const position = 10
 			const value = "/path with spaces/file.txt"
 
-			const result = insertMention(text, position, value)
+			const result = insertMention(text, position, value, 3)
 
-			expect(result.newValue).toBe('Check @"/path with spaces/file.txt"  and more')
+			expect(result.newValue).toBe('Check @"/path with spaces/file.txt" and more')
 			expect(result.mentionIndex).toBe(6)
 		})
 

--- a/webview-ui/src/utils/context-mentions.ts
+++ b/webview-ui/src/utils/context-mentions.ts
@@ -8,7 +8,12 @@ export interface SearchResult {
 	label?: string
 }
 
-export function insertMention(text: string, position: number, value: string): { newValue: string; mentionIndex: number } {
+export function insertMention(
+	text: string,
+	position: number,
+	value: string,
+	partialQueryLength: number = 0,
+): { newValue: string; mentionIndex: number } {
 	const beforeCursor = text.slice(0, position)
 	const afterCursor = text.slice(position)
 
@@ -26,8 +31,11 @@ export function insertMention(text: string, position: number, value: string): { 
 
 	if (lastAtIndex !== -1) {
 		// If there's an '@' symbol, replace everything after it with the new mention
-		const beforeMention = text.slice(0, lastAtIndex)
-		newValue = beforeMention + "@" + formattedValue + " " + afterCursor.replace(/^[^\s]*/, "")
+		const beforeAt = text.substring(0, lastAtIndex + 1)
+		const afterPartialQuery = text.substring(lastAtIndex + 1 + partialQueryLength)
+
+		// replace the partial query with the full mention
+		newValue = beforeAt + formattedValue + (afterPartialQuery.startsWith(" ") ? afterPartialQuery : " " + afterPartialQuery)
 		mentionIndex = lastAtIndex
 	} else {
 		// If there's no '@' symbol, insert the mention at the cursor position

--- a/webview-ui/src/utils/slash-commands.ts
+++ b/webview-ui/src/utils/slash-commands.ts
@@ -157,15 +157,19 @@ export function getMatchingSlashCommands(
 /**
  * Insert a slash command at position or replace partial command
  */
-export function insertSlashCommand(text: string, commandName: string): { newValue: string; commandIndex: number } {
+export function insertSlashCommand(
+	text: string,
+	commandName: string,
+	partialCommandLength: number,
+): { newValue: string; commandIndex: number } {
 	const slashIndex = text.indexOf("/")
 
-	// where the command ends, at the end of entire text or first space
-	const commandEndIndex = text.indexOf(" ", slashIndex)
+	const beforeSlash = text.substring(0, slashIndex + 1)
+	const afterPartialCommand = text.substring(slashIndex + 1 + partialCommandLength)
 
 	// replace the partial command with the full command
 	const newValue =
-		text.substring(0, slashIndex + 1) + commandName + (commandEndIndex > -1 ? text.substring(commandEndIndex) : " ") // add extra space at the end if only slash command
+		beforeSlash + commandName + (afterPartialCommand.startsWith(" ") ? afterPartialCommand : " " + afterPartialCommand)
 
 	return { newValue, commandIndex: slashIndex }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- For feature requests: Created a discussion in our Feature Requests discussions board https://github.com/cline/cline/discussions/categories/feature-requests and received approval from core maintainers before implementation
- For all changes: Link the associated issue/discussion in the "Related Issue" section below

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly without prior discussion.

Why this requirement?
We deeply appreciate all community contributions - they are essential to Cline's success! To ensure the best use of everyone's time and maintain project direction, we use our Feature Requests discussions board to gauge community interest and validate feature ideas before implementation begins. This helps us focus development efforts on features that will benefit the most users.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** #XXXX

### Description

Fixes a bug where calling a slash command removes the first word after the slash command/mention. If users type a prompt before jumping back to the beginning, then enter a slash command/mention, it would remove the first word of their prompt.

### Test Procedure

<!-- 
Please walk us through your testing approach and thought process. This helps reviewers understand that you've thoroughly considered the impact of your changes:

- How did you test this change?
- What could potentially break and how did you verify it doesn't?
- What existing functionality might be affected and how did you check it still works?
- Why are you confident this is ready for merge?

We're not looking for exhaustive documentation - just evidence that you've thought through the implications of your changes and tested accordingly.
-->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [X] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [X] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [X] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [X] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [X] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Bug:

https://github.com/user-attachments/assets/cb6eac09-83ee-4c5f-9af9-19f71ac12b02



Fixed:

https://github.com/user-attachments/assets/09f76cf5-2b64-4294-9ac9-3dd6773b8d1a





### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes bug in `ChatTextArea.tsx` where slash commands or mentions removed the following word by updating `insertMention` and `insertSlashCommand` to handle partial queries correctly.
> 
>   - **Behavior**:
>     - Fixes bug in `ChatTextArea.tsx` where slash commands or mentions removed the following word.
>     - Updates `insertMention` and `insertSlashCommand` to handle partial queries correctly.
>   - **Functions**:
>     - `insertMention` in `context-mentions.ts` now accepts `partialQueryLength` to replace partial mentions.
>     - `insertSlashCommand` in `slash-commands.ts` now accepts `partialCommandLength` to replace partial commands.
>   - **Tests**:
>     - Updates `context-mentions.test.ts` to test new behavior of `insertMention` with partial queries.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for a86029ba15318638ca2b665cac419bc5bbd126d2. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->