### PR TITLE
fix taskHistory migration

### DIFF
--- a/src/core/storage/state-migrations.ts
+++ b/src/core/storage/state-migrations.ts
@@ -95,8 +95,9 @@ export async function migrateTaskHistoryToFile(context: vscode.ExtensionContext)
 			migrationAction = "Merged task history from old and new locations"
 		}
 
-		// Perform migration operations concurrently
-		await Promise.all([writeTaskHistoryToState(context, finalData), context.globalState.update("taskHistory", undefined)])
+		// Perform migration operations sequentially - only clear old data if write succeeds
+		await writeTaskHistoryToState(context, finalData)
+		void context.globalState.update("taskHistory", undefined)
 
 		console.log(`[Storage Migration] ${migrationAction}`)
 	} catch (error) {


### PR DESCRIPTION

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** #XXXX

### Description

Add to the new taskHistory location each time the migration is run, instead of overwriting from the old location completely.

This solves an issue where the old location taskHistory was not deleted (to ease developer experience working across main and the old production version) and, since it was not deleted, would override the taskHistory in the new location each time the migration was run. This results in a bug when the user in exclusively in the new version where new tasks are not persisted across Cline restarts.

The solution is to ADD TO the taskHistory in the new location each time taskHistory in the old location is detected. After doing so, we REMOVE the taskHistory in the new location so the migration doesn't keep running and overriding the new location.

### Test Procedure

Run the migration by building dev. Confirm that the same taskHistory appears.

Confirm that the taskHistory now appears as blank in the old prod version. (not deleted, just moved).

Create a new task in the old prod version after closing the extension dev host.

Run the dev host and have the migration run again. confirm that your new task from the old location shows up.

Create a new task in the dev host, in the new location.

Close the dev host again and create a new task in the prod version, in the old location.

Run the dev host yet again and confirm that your newest task stacks up on top of the task you last made in the dev host.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fix task history migration to add data to the new location instead of overwriting it, preventing data loss across versions.
> 
>   - **Behavior**:
>     - In `migrateTaskHistoryToFile()`, task history from the old location is added to the new location instead of overwriting it.
>     - If the new location is empty, old data is moved; otherwise, old and new data are merged.
>     - After successful migration, old task history is cleared from `globalState` to prevent repeated migrations.
>   - **Logging**:
>     - Logs migration actions and errors in `migrateTaskHistoryToFile()` for better traceability.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for e262d4fb57472c94fd751ee5eea2830a0322dcd3. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->