### PR TITLE
Don't keep regenerating the telemetry UUID

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -148,6 +148,7 @@
 				"!src/core/storage/FileContextTracker.ts",
 				"!src/core/context/context-tracking/FileContextTracker.ts",
 				"!src/common.ts",
+				"!src/services/logging/distinctId.ts",
 				"!src/core/storage/utils/state-helpers.ts",
 				"!src/extension.ts"
 			],

--- a/src/services/logging/distinctId.ts
+++ b/src/services/logging/distinctId.ts
@@ -2,29 +2,37 @@ import { v4 as uuidv4 } from "uuid"
 import { ExtensionContext } from "vscode"
 import { HostProvider } from "@/hosts/host-provider"
 import { EmptyRequest } from "@/shared/proto/cline/common"
-import { Logger } from "./Logger"
 
 /*
  * Unique identifier for the current installation.
  */
 let _distinctId: string = ""
 
+/**
+ * Some environments don't return a value for the machine ID. For these situations we generated
+ * a unique ID and store it locally.
+ */
+export const _GENERATED_MACHINE_ID_KEY = "cline.generatedMachineId"
+
 export async function initializeDistinctId(context: ExtensionContext, uuid: () => string = uuidv4) {
-	// NOTE: Backward compatibility in case where cline.distinctId was set in older versions
-	const existingId = context.globalState.get<string>("cline.distinctId")
-	const machineId = await getMachineId()
-	let distinctId = existingId || machineId
+	// Try to read the ID from storage.
+	let distinctId = context.globalState.get<string>(_GENERATED_MACHINE_ID_KEY)
 
 	if (!distinctId) {
-		console.warn("No machine ID found, generating UUID")
-		distinctId = uuid()
+		// Get the ID from the host environment.
+		distinctId = await getMachineId()
+	}
+	if (!distinctId) {
+		// Fallback to generating a unique ID and keeping in global storage.
+		console.warn("No machine ID found for telemetry, generating UUID")
+		// Add a prefix to the UUID so we can see in the telemetry how many clients are don't have a machine ID.
+		distinctId = "cl-" + uuid()
+		context.globalState.update(_GENERATED_MACHINE_ID_KEY, distinctId)
 	}
 
 	setDistinctId(distinctId)
 
-	if (process.env.IS_DEV) {
-		console.log("Telemetry distinct ID initialized:", distinctId)
-	}
+	console.log("Telemetry distinct ID initialized:", distinctId)
 }
 
 /*
@@ -34,8 +42,8 @@ async function getMachineId(): Promise<string | undefined> {
 	try {
 		const response = await HostProvider.env.getMachineId(EmptyRequest.create({}))
 		return response.value
-	} catch (e) {
-		Logger.warn(`Failed to get machine ID: ${e instanceof Error ? e.message : String(e)}`)
+	} catch (error) {
+		console.log("Failed to get machine ID", error)
 		return undefined
 	}
 }


### PR DESCRIPTION
Some environments do not return a value for the vscode machine ID.
For these cases we are generating a UUID. But the UUID was not being stored, so a new one was being created everytime the extension started.

Start storing the generated ID in the global state.

I am changing the name of the key to be more descriptive, because we only want to store the generated ID. If there is an actual machine ID, we should just use that and not store it. The old key name was only ever been read, it was never written, so this will have no affect on existing users.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Store generated UUID in global state to prevent regeneration on extension start, using a new key for clarity.
> 
>   - **Behavior**:
>     - Store generated UUID in global state using `_GENERATED_MACHINE_ID_KEY` in `distinctId.ts`.
>     - Use host machine ID if available; otherwise, generate and store UUID with prefix `cl-`.
>     - Log initialization of telemetry distinct ID.
>   - **Tests**:
>     - Update `distinctId.test.ts` to test storing and retrieving UUID from global state.
>     - Ensure `initializeDistinctId()` handles missing machine ID and errors gracefully.
>   - **Misc**:
>     - Rename key from `cline.distinctId` to `_GENERATED_MACHINE_ID_KEY` for clarity.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 7304693f924f3f49e65333eb7bc8001bf1196e27. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->