### PR TITLE
CI: Nightly Publish workflow for Cline Nightly (VS Code Marketplace only)

### DIFF
--- a/.github/workflows/nightly-publish.yml
+++ b/.github/workflows/nightly-publish.yml
@@ -1,0 +1,89 @@
+name: Nightly Publish
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Git ref to build (default: main)"
+        required: false
+        default: "main"
+
+permissions:
+  contents: read
+
+jobs:
+  publish-nightly:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.ref || 'main' }}
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "lts/*"
+
+      # Cache root dependencies - only reuse if package-lock.json exactly matches
+      - name: Cache root dependencies
+        uses: actions/cache@v4
+        id: root-cache
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-npm-${{ hashFiles('package-lock.json') }}
+
+      # Cache webview-ui dependencies - only reuse if package-lock.json exactly matches
+      - name: Cache webview-ui dependencies
+        uses: actions/cache@v4
+        id: webview-cache
+        with:
+          path: webview-ui/node_modules
+          key: ${{ runner.os }}-npm-webview-${{ hashFiles('webview-ui/package-lock.json') }}
+
+      - name: Install root dependencies
+        if: steps.root-cache.outputs.cache-hit != 'true'
+        run: npm ci --include=optional
+
+      - name: Install webview-ui dependencies
+        if: steps.webview-cache.outputs.cache-hit != 'true'
+        run: cd webview-ui && npm ci --include=optional
+
+      - name: Install Publishing Tool
+        run: npm install -g @vscode/vsce
+
+      # Forge a strictly increasing nightly patch version (monotonic)
+      - name: Compute Nightly patch number
+        id: nightly_version
+        env:
+          RUN_NUMBER: ${{ github.run_number }}
+        run: echo "patch=$(( 6000 + ${RUN_NUMBER} ))" >> $GITHUB_OUTPUT
+
+      - name: Patch package.json for Nightly
+        env:
+          NIGHTLY_PATCH: ${{ steps.nightly_version.outputs.patch }}
+        run: |
+          node <<'EOF'
+          const fs = require('fs');
+          const pkgPath = 'package.json';
+          const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
+          const [maj, min] = (pkg.version || '0.0.0').split('.');
+          pkg.name = 'cline-nightly';
+          pkg.displayName = 'Cline Nightly';
+          pkg.preview = true;
+          pkg.version = `${maj}.${min}.${process.env.NIGHTLY_PATCH}`;
+          fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2));
+          console.log(`🔖 Nightly ID: ${pkg.publisher}.${pkg.name}`);
+          console.log(`🔖 Nightly version: ${pkg.version}`);
+          EOF
+
+      - name: Publish to VS Code Marketplace
+        env:
+          VSCE_PAT: ${{ secrets.VSCE_PAT }}
+          CLINE_ENVIRONMENT: nightly
+        # vsce will invoke "vscode:prepublish" which builds the extension (webview + bundle)
+        run: vsce publish --allow-package-secrets sendgrid


### PR DESCRIPTION
### Related Issue

**Issue:** #6011

### Description

Adds a Nightly Publish GitHub Actions workflow to publish a separate “Cline Nightly” extension to the VS Code Marketplace immediately on pushes to main and via manual dispatch. This mirrors RooCode’s nightly strategy while adhering to our requirement to publish only to the Microsoft Marketplace (no Open VSX).

Key details:
- Separate listing: ID `saoudrizwan.cline-nightly`, displayName “Cline Nightly”
- CI-only manifest patch (no commit): `name`, `displayName`, `preview`, and version set to `major.minor.(6000 + run_number)`
- Build uses the existing `vscode:prepublish` hook (`npm run package`) to build the webview and bundle
- Publish uses `VSCE_PAT`; no `ovsx` calls are included

### Test Procedure

1) Prerequisites
   - Ensure repository secret `VSCE_PAT` is configured for publisher “saoudrizwan”.
   - Confirm the workflow file exists at `.github/workflows/nightly-publish.yml`.

2) Manual dispatch test
   - From this branch or `main`, run “Nightly Publish” via “Run workflow” and specify the ref if needed.
   - Observe logs:
     - Dependencies are installed (or restored from cache).
     - `package.json` is patched for Nightly (`name`/`displayName`/`preview`/`version`).
     - `vsce publish` runs and succeeds.
   - Verify outcome:
     - A new or updated listing for “Cline Nightly” (`saoudrizwan.cline-nightly`) exists on the Marketplace.
     - Published version matches `major.minor.(6000 + run_number)`.

3) Push-to-main test (post-merge)
   - Merge this PR.
   - A push to `main` should automatically trigger a Nightly publish.
   - Confirm publish success in workflow logs and Marketplace listing updates.

4) Safety checks
   - Ensure no `ovsx` publish step is present.
   - Confirm stable listing is unaffected.

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [x] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single chore (workflow addition)
-   [ ] Tests are passing (`n/a` – workflow-only; standard CI test suites continue to run unchanged)
-   [ ] I have created a changeset using `npm run changeset` (`n/a` – not required for workflow-only change; no user-facing change)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

n/a (workflow only)

### Additional Notes

- Versioning scheme is inspired by RooCode’s nightly (monotonic, run-number-based), adapted to publish only to the VS Code Marketplace per project requirements.
- First successful publish will create the “Cline Nightly” listing; subsequent publishes will update it.
