### PR TITLE
Add nightly release automation with GitHub Actions

### DIFF
--- a/.github/workflows/publish-nightly.yml
+++ b/.github/workflows/publish-nightly.yml
@@ -1,0 +1,66 @@
+name: "Publish Nightly Release"
+
+on:
+  schedule:
+    - cron: "0 0 * * *" # Daily at 00:00 UTC
+  workflow_dispatch:
+
+permissions:
+    contents: write
+    packages: write
+    checks: write
+    pull-requests: write
+
+jobs:
+    test:
+        uses: ./.github/workflows/test.yml
+
+    publish:
+        needs: test
+        name: Publish Cline (Nightly) Extension
+        runs-on: ubuntu-latest
+        environment: publish
+
+        steps:
+            - uses: actions/checkout@v4
+              with:
+                  ref: ${{ github.event.inputs.tag }}
+
+            - name: Setup Node.js
+              uses: actions/setup-node@v4
+              with:
+                  node-version: "lts/*"
+
+            # Cache root dependencies - only reuse if package-lock.json exactly matches
+            - name: Cache root dependencies
+              uses: actions/cache@v4
+              id: root-cache
+              with:
+                  path: node_modules
+                  key: ${{ runner.os }}-npm-${{ hashFiles('package-lock.json') }}
+
+            # Cache webview-ui dependencies - only reuse if package-lock.json exactly matches
+            - name: Cache webview-ui dependencies
+              uses: actions/cache@v4
+              id: webview-cache
+              with:
+                  path: webview-ui/node_modules
+                  key: ${{ runner.os }}-npm-webview-${{ hashFiles('webview-ui/package-lock.json') }}
+
+            - name: Install root dependencies
+              if: steps.root-cache.outputs.cache-hit != 'true'
+              run: npm ci --include=optional
+
+            - name: Install webview-ui dependencies
+              if: steps.webview-cache.outputs.cache-hit != 'true'
+              run: cd webview-ui && npm ci --include=optional
+
+            - name: Install Publishing Tools
+              run: npm install -g @vscode/vsce ovsx
+
+            - name: Publish Extension as Pre-release
+              env:
+                  VSCE_PAT: ${{ secrets.VSCE_PAT }}
+                  OVSX_PAT: ${{ secrets.OVSX_PAT }}
+                  CLINE_ENVIRONMENT: production
+              run: npm run publish:marketplace:nightly

--- a/.github/workflows/publish-nightly.yml
+++ b/.github/workflows/publish-nightly.yml
@@ -2,7 +2,7 @@ name: "Publish Nightly Release"
 
 on:
   schedule:
-    - cron: "0 0 * * *" # Daily at 00:00 UTC
+    - cron: '0 12 * * *'  # 4 AM PST (UTC-8) = 12 UTC
   workflow_dispatch:
 
 permissions:
@@ -24,6 +24,14 @@ jobs:
         steps:
             - uses: actions/checkout@v4
 
+            - name: Check for recent commits
+              run: |
+                if [ $(git rev-list --count HEAD --since="24 hours ago") -eq 0 ]; then
+                  echo "No commits in last 24 hours, exiting"
+                  exit 0
+                fi
+                echo "Found recent commits, proceeding with build"
+                
             - name: Setup Node.js
               uses: actions/setup-node@v4
               with:

--- a/.github/workflows/publish-nightly.yml
+++ b/.github/workflows/publish-nightly.yml
@@ -23,8 +23,6 @@ jobs:
 
         steps:
             - uses: actions/checkout@v4
-              with:
-                  ref: ${{ github.event.inputs.tag }}
 
             - name: Setup Node.js
               uses: actions/setup-node@v4

--- a/.github/workflows/publish-nightly.yml
+++ b/.github/workflows/publish-nightly.yml
@@ -18,6 +18,7 @@ jobs:
     publish:
         needs: test
         name: Publish Cline (Nightly) Extension
+        if: github.repository == 'cline/cline'
         runs-on: ubuntu-latest
         environment: publish
 

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -12,6 +12,8 @@
 			"args": [
 				"--extensionDevelopmentPath=${workspaceFolder}",
 				"--disable-workspace-trust",
+				// Avoid conflicts with the nightly extension
+				"--disable-extension=claude-dev.cline-nightly",
 				"${workspaceFolder}"
 			],
 			"outFiles": [
@@ -31,6 +33,7 @@
 			"args": [
 				"--extensionDevelopmentPath=${workspaceFolder}",
 				"--disable-workspace-trust",
+				"--disable-extension=claude-dev.cline-nightly",
 				"${workspaceFolder}"
 			],
 			"outFiles": [
@@ -50,6 +53,7 @@
 			"args": [
 				"--extensionDevelopmentPath=${workspaceFolder}",
 				"--disable-workspace-trust",
+				"--disable-extension=claude-dev.cline-nightly",
 				"${workspaceFolder}"
 			],
 			"outFiles": [

--- a/package.json
+++ b/package.json
@@ -365,6 +365,7 @@
 		"test:webview": "cd webview-ui && npm run test",
 		"publish:marketplace": "vsce publish --allow-package-secrets sendgrid && ovsx publish",
 		"publish:marketplace:prerelease": "vsce publish --allow-package-secrets sendgrid --pre-release && ovsx publish --pre-release",
+		"publish:marketplace:nightly": "node ./scripts/publish-nightly.mjs",
 		"prepare": "husky",
 		"changeset": "changeset",
 		"version-packages": "changeset version",

--- a/scripts/publish-nightly.mjs
+++ b/scripts/publish-nightly.mjs
@@ -1,0 +1,379 @@
+#!/usr/bin/env node
+
+/**
+ * Nightly publish script for VS Code extension
+ * Converts package.json to testing version, packages, publishes, and restores
+ *
+ * This script:
+ * 1. Backs up the original package.json
+ * 2. Updates package.json with:
+ *    - New version (major.minor.timestamp format)
+ *    - Changes name to "cline-nightly"
+ *    - Changes displayName to "Cline (Nightly)"
+ * 3. Packages the extension as a .vsix file
+ * 4. Publishes to VS Code Marketplace (if VSCE_PAT is set)
+ * 5. Publishes to OpenVSX Registry (if OVSX_PAT is set)
+ * 6. Restores the original package.json
+ *
+ * Usage:
+ *   node scripts/nightly-publish.mjs
+ *
+ * Environment variables:
+ *   VSCE_PAT  - Personal Access Token for VS Code Marketplace
+ *   OVSX_PAT  - Personal Access Token for OpenVSX Registry
+ *
+ * Dependencies:
+ *   - vsce (VS Code Extension Manager)
+ *   - ovsx (OpenVSX CLI)
+ */
+
+import { execFileSync, execSync } from "node:child_process"
+import fs from "node:fs"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+
+// Get __dirname equivalent in ES modules
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+
+// ANSI color codes for console output
+const colors = {
+	reset: "\x1b[0m",
+	red: "\x1b[31m",
+	green: "\x1b[32m",
+	yellow: "\x1b[33m",
+}
+
+// Logging utilities
+const log = {
+	info: (msg) => console.log(`${colors.green}[INFO]${colors.reset} ${msg}`),
+	warn: (msg) => console.log(`${colors.yellow}[WARN]${colors.reset} ${msg}`),
+	error: (msg) => console.error(`${colors.red}[ERROR]${colors.reset} ${msg}`),
+}
+
+// Configuration
+const config = {
+	// The name and display name for the nightly version
+	nightlyName: "cline-nightly",
+	nightlyDisplayName: "Cline (Nightly)",
+	projectRoot: path.join(__dirname, ".."),
+	get packageJsonPath() {
+		return path.join(this.projectRoot, "package.json")
+	},
+	get packageBackupPath() {
+		return path.join(this.projectRoot, "package.json.backup")
+	},
+	get distDir() {
+		return path.join(this.projectRoot, "dist")
+	},
+	get vsixPath() {
+		return path.join(this.distDir, "cline-nightly.vsix")
+	},
+}
+
+// Utility class for managing the publish process
+class NightlyPublisher {
+	constructor() {
+		this.originalPackageJson = null
+		this.hasBackup = false
+	}
+
+	/**
+	 * Check if required dependencies are installed
+	 */
+	checkDependencies() {
+		const dependencies = [
+			{ name: "vsce", check: "vsce --version" },
+			{ name: "npx", check: "npx --version" },
+		]
+
+		const missing = []
+
+		for (const dep of dependencies) {
+			try {
+				execSync(dep.check, { stdio: "ignore" })
+			} catch {
+				missing.push(dep.name)
+			}
+		}
+
+		if (missing.length > 0) {
+			throw new Error(
+				`Missing required dependencies: ${missing.join(", ")}. Please install them before running this script.`,
+			)
+		}
+
+		log.info("All dependencies are installed")
+	}
+
+	/**
+	 * Check if a command exists
+	 */
+	commandExists(command) {
+		try {
+			execSync(`which ${command}`, { stdio: "ignore" })
+			return true
+		} catch {
+			return false
+		}
+	}
+
+	/**
+	 * Create backup of package.json
+	 */
+	backupPackageJson() {
+		if (!fs.existsSync(config.packageJsonPath)) {
+			throw new Error(`package.json not found at ${config.packageJsonPath}`)
+		}
+
+		log.info("Backing up original package.json")
+		this.originalPackageJson = fs.readFileSync(config.packageJsonPath, "utf-8")
+		fs.writeFileSync(config.packageBackupPath, this.originalPackageJson)
+		this.hasBackup = true
+	}
+
+	/**
+	 * Restore original package.json
+	 */
+	restorePackageJson() {
+		if (this.hasBackup && fs.existsSync(config.packageBackupPath)) {
+			log.info("Restoring original package.json")
+			fs.writeFileSync(config.packageJsonPath, this.originalPackageJson)
+			fs.unlinkSync(config.packageBackupPath)
+			this.hasBackup = false
+		}
+	}
+
+	/**
+	 * Generate new version with timestamp
+	 * Format: major.minor.timestamp
+	 */
+	generateVersion(currentVersion) {
+		// Extract major.minor from current version (e.g., "3.27.1" -> "3.27")
+		const versionParts = currentVersion.split(".")
+		if (versionParts.length < 2) {
+			throw new Error(`Invalid version format: ${currentVersion}`)
+		}
+
+		const major = versionParts[0]
+		const minor = versionParts[1]
+		const timestamp = Math.floor(Date.now() / 1000)
+
+		return `${major}.${minor}.${timestamp}`
+	}
+
+	/**
+	 * Update package.json with nightly configuration
+	 */
+	updatePackageJson() {
+		const pkg = JSON.parse(fs.readFileSync(config.packageJsonPath, "utf-8"))
+		const currentVersion = pkg.version
+
+		if (!currentVersion) {
+			throw new Error("Could not read version from package.json")
+		}
+
+		log.info(`Current version: ${currentVersion}`)
+
+		const newVersion = this.generateVersion(currentVersion)
+		log.info(`New version: ${newVersion}`)
+
+		// Update package.json fields
+		pkg.version = newVersion
+		pkg.name = config.nightlyName
+		pkg.displayName = config.nightlyDisplayName
+
+		// Save updated package.json
+		log.info("Updating package.json for nightly build")
+		fs.writeFileSync(config.packageJsonPath, JSON.stringify(pkg, null, "\t"))
+
+		return newVersion
+	}
+
+	/**
+	 * Package the extension
+	 */
+	packageExtension() {
+		// Ensure dist directory exists
+		if (!fs.existsSync(config.distDir)) {
+			fs.mkdirSync(config.distDir, { recursive: true })
+		}
+
+		log.info("Packaging extension")
+
+		const args = [
+			"package",
+			"--pre-release",
+			"--no-update-package-json",
+			"--no-git-tag-version",
+			"--no-dependencies",
+			"--out",
+			config.vsixPath,
+		]
+
+		try {
+			execFileSync("vsce", args, {
+				stdio: "inherit",
+				cwd: config.projectRoot,
+			})
+			log.info(`Package created: ${config.vsixPath}`)
+		} catch (error) {
+			throw new Error(`Failed to package extension: ${error.message}`)
+		}
+	}
+
+	/**
+	 * Publish to VS Code Marketplace
+	 */
+	publishToVSCodeMarketplace() {
+		const token = process.env.VSCE_PAT
+
+		if (!token) {
+			log.warn("VSCE_PAT not set, skipping VS Code Marketplace publish")
+			return false
+		}
+
+		log.info("Publishing to VS Code Marketplace")
+
+		const args = ["publish", "--pre-release", "--no-git-tag-version", "--packagePath", config.vsixPath]
+
+		try {
+			execFileSync("vsce", args, {
+				env: { ...process.env, VSCE_PAT: token },
+				stdio: "inherit",
+				cwd: config.projectRoot,
+			})
+			log.info("Successfully published to VS Code Marketplace")
+			return true
+		} catch (error) {
+			throw new Error(`Failed to publish to VS Code Marketplace: ${error.message}`)
+		}
+	}
+
+	/**
+	 * Publish to OpenVSX Registry
+	 */
+	publishToOpenVSX() {
+		const token = process.env.OVSX_PAT
+
+		if (!token) {
+			log.warn("OVSX_PAT not set, skipping OpenVSX Registry publish")
+			return false
+		}
+
+		log.info("Publishing to OpenVSX Registry")
+
+		const args = ["ovsx", "publish", "--pre-release", "--packagePath", config.vsixPath, "--pat", token]
+
+		try {
+			execFileSync("npx", args, {
+				stdio: "inherit",
+				cwd: config.projectRoot,
+			})
+			log.info("Successfully published to OpenVSX Registry")
+			return true
+		} catch (error) {
+			throw new Error(`Failed to publish to OpenVSX Registry: ${error.message}`)
+		}
+	}
+
+	/**
+	 * Main execution flow
+	 */
+	async run(isDryRun = false) {
+		try {
+			log.info(`Starting nightly publish process${isDryRun ? " (dry run)" : ""}`)
+
+			// Step 1: Check dependencies
+			this.checkDependencies()
+
+			// Step 2: Backup package.json
+			this.backupPackageJson()
+
+			// Step 3: Update package.json
+			const newVersion = this.updatePackageJson()
+
+			// Step 4: Package extension
+			this.packageExtension()
+
+			// Step 5: Publish to marketplaces (skip if dry run)
+			let vsCodePublished = false
+			let openVSXPublished = false
+
+			if (isDryRun) {
+				log.info("Dry run mode: Skipping marketplace publishing")
+			} else {
+				vsCodePublished = this.publishToVSCodeMarketplace()
+				openVSXPublished = this.publishToOpenVSX()
+			}
+
+			// Summary
+			log.info(`Nightly publish process completed successfully${isDryRun ? " (dry run)" : ""}`)
+			log.info(`Package created for v${newVersion}: ${config.vsixPath}`)
+
+			if (!isDryRun && !vsCodePublished && !openVSXPublished) {
+				log.warn("Extension was packaged but not published to any marketplace")
+				log.warn("Set VSCE_PAT and/or OVSX_PAT environment variables to enable publishing")
+			}
+		} catch (error) {
+			log.error(`Publish failed: ${error.message}`)
+			process.exit(1)
+		} finally {
+			// Always restore package.json
+			this.restorePackageJson()
+		}
+	}
+}
+
+// Handle cleanup on process exit
+const publisher = new NightlyPublisher()
+
+process.on("exit", () => {
+	publisher.restorePackageJson()
+})
+
+process.on("SIGINT", () => {
+	log.info("\nInterrupted, cleaning up...")
+	publisher.restorePackageJson()
+	process.exit(130)
+})
+
+process.on("SIGTERM", () => {
+	log.info("\nTerminated, cleaning up...")
+	publisher.restorePackageJson()
+	process.exit(143)
+})
+
+// Parse command line arguments
+const args = process.argv.slice(2)
+const isDryRun = args.includes("--dry-run") || args.includes("-n")
+const showHelp = args.includes("--help") || args.includes("-h")
+
+if (showHelp) {
+	console.log(`
+Nightly publish script for VS Code extension
+
+Usage:
+  node scripts/nightly-publish.mjs [options]
+
+Options:
+  --dry-run, -n    Run without actually publishing (package only)
+  --help, -h       Show this help message
+
+Environment variables:
+  VSCE_PAT         Personal Access Token for VS Code Marketplace
+  OVSX_PAT         Personal Access Token for OpenVSX Registry
+
+Examples:
+  node scripts/nightly-publish.mjs                    # Full publish
+  node scripts/nightly-publish.mjs --dry-run          # Package only
+  VSCE_PAT="token" node scripts/nightly-publish.mjs   # Publish to VS Code only
+`)
+	process.exit(0)
+}
+
+// Run the publisher
+publisher.run(isDryRun).catch((error) => {
+	log.error(error.message)
+	process.exit(1)
+})

--- a/scripts/publish-nightly.mjs
+++ b/scripts/publish-nightly.mjs
@@ -16,7 +16,8 @@
  * 6. Restores the original package.json
  *
  * Usage:
- *   node scripts/nightly-publish.mjs
+ *   npm run publish:marketplace:nightly
+ *   npm run publish:marketplace:nightly -- --dry-run
  *
  * Environment variables:
  *   VSCE_PAT  - Personal Access Token for VS Code Marketplace
@@ -354,7 +355,7 @@ if (showHelp) {
 Nightly publish script for VS Code extension
 
 Usage:
-  node scripts/nightly-publish.mjs [options]
+  npm run publish:marketplace:nightly [options]
 
 Options:
   --dry-run, -n    Run without actually publishing (package only)
@@ -365,9 +366,9 @@ Environment variables:
   OVSX_PAT         Personal Access Token for OpenVSX Registry
 
 Examples:
-  node scripts/nightly-publish.mjs                    # Full publish
-  node scripts/nightly-publish.mjs --dry-run          # Package only
-  VSCE_PAT="token" node scripts/nightly-publish.mjs   # Publish to VS Code only
+  npm run publish:marketplace:nightly                    # Full publish
+  npm run publish:marketplace:nightly  -- --dry-run      # Package only
+  VSCE_PAT="token" npm run publish:marketplace:nightly   # Publish to VS Code only
 `)
 	process.exit(0)
 }


### PR DESCRIPTION
<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- For feature requests: Created a discussion in our Feature Requests discussions board https://github.com/cline/cline/discussions/categories/feature-requests and received approval from core maintainers before implementation
- For all changes: Link the associated issue/discussion in the "Related Issue" section below

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly without prior discussion.

Why this requirement?
We deeply appreciate all community contributions - they are essential to Cline's success! To ensure the best use of everyone's time and maintain project direction, we use our Feature Requests discussions board to gauge community interest and validate feature ideas before implementation begins. This helps us focus development efforts on features that will benefit the most users.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** https://github.com/cline/cline/issues/6011

### Description

<!-- 
Help reviewers understand your changes by making this PR readable and well-organized:

- What problem does this PR solve?
- Why were these changes introduced and what purpose do they serve?
- For larger changes, provide context about your approach and reasoning

Small PRs may need minimal description, but larger changes benefit from explaining where you're coming from. Much of this context can be in the linked issue above, so feel free to reference it rather than repeating everything here.
-->

<img width="530" height="166" alt="image" src="https://github.com/user-attachments/assets/b1165aff-85d5-40b2-996a-c42a474b3b88" />

- Add GitHub workflow to publish nightly releases daily at 00:00 UTC
- Add publish:marketplace:nightly npm script
- Create publish-nightly.mjs script to handle version updates and publishing
- Script converts package to "cline-nightly" with timestamp-based versioning
- Publishes to both VS Code Marketplace and OpenVSX Registry

IMPORTANT: The nightly build is published as a separated extension and is intended for QA and internal testing only. Users MUST DISABLE the main extension for the Nightly extension to work correctly. Else, things could look buggy as things will be getting registered twice, like:

<img width="514" height="202" alt="image" src="https://github.com/user-attachments/assets/587e62c7-3d08-498f-a62a-f179f830afe6" />


### Test Procedure

<!-- 
Please walk us through your testing approach and thought process. This helps reviewers understand that you've thoroughly considered the impact of your changes:

- How did you test this change?
- What could potentially break and how did you verify it doesn't?
- What existing functionality might be affected and how did you check it still works?
- Why are you confident this is ready for merge?

We're not looking for exhaustive documentation - just evidence that you've thought through the implications of your changes and tested accordingly.
-->

Run `npm run publish:marketplace:nightly -- --dry-run` to execute the script that will be used in CI for the publishing purpose. With the `--dry-run` flag, the extension will not be publish, but you should see the cline-nightly.vsix package created in the ./dist directory

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [x] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

<img width="979" height="1389" alt="image" src="https://github.com/user-attachments/assets/fdf965eb-90b5-451b-8e0a-70832ec5dab2" />


### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds GitHub Actions workflow and script for nightly release automation of Cline extension.
> 
>   - **GitHub Actions Workflow**:
>     - Adds `publish-nightly.yml` to automate nightly releases at 00:00 UTC.
>     - Checks for recent commits; exits if none in the last 24 hours.
>     - Runs tests before publishing.
>   - **Scripts**:
>     - Adds `publish:marketplace:nightly` npm script in `package.json`.
>     - Creates `publish-nightly.mjs` to update version, package, and publish.
>     - Converts package to `cline-nightly` with timestamp versioning.
>     - Publishes to VS Code Marketplace and OpenVSX Registry.
>   - **Misc**:
>     - Nightly build is a separate extension for QA/testing; main extension must be disabled for it to work correctly.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for d75af2006ef8b08ebb1dcd1182b56f62f5a529dc. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->