### PR TITLE
Fix check for debug build in package-standalone script

### DIFF
--- a/scripts/package-standalone.mjs
+++ b/scripts/package-standalone.mjs
@@ -145,7 +145,7 @@ function createIsIgnored(standaloneIgnores) {
 	let allIgnore = [...defaultIgnore, ...expandedIgnore, ...standaloneIgnores]
 
 	// Map files need to be included in the debug build. Remove .map ignores when IS_DEBUG_BUILD is set
-	if (process.env.IS_DEBUG_BUILD) {
+	if (process.env.IS_DEBUG_BUILD == "true") {
 		allIgnore = allIgnore.filter((pattern) => !pattern.endsWith(".map"))
 		console.log("Debug build: Including .map files in package")
 	}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes `IS_DEBUG_BUILD` check in `package-standalone.mjs` to correctly include `.map` files in debug builds.
> 
>   - **Behavior**:
>     - Fixes the check for `IS_DEBUG_BUILD` in `package-standalone.mjs` to compare against the string "true".
>     - Ensures `.map` files are included in the debug build when `IS_DEBUG_BUILD` is set to "true".
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 2bb0a50dfbe5c77c26d0da4bd2c6944f45d637db. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->