### PR TITLE
Add platform-agnostic support for ripgrep

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -18,6 +18,7 @@ import { cleanupTestMode, initializeTestMode } from "./services/test/TestMode"
 import { WebviewProviderType } from "./shared/webview/types"
 import "./utils/path" // necessary to have access to String.prototype.toPosix
 
+import path from "node:path"
 import type { ExtensionContext } from "vscode"
 import { HostProvider } from "@/hosts/host-provider"
 import { vscodeHostBridgeClient } from "@/hosts/vscode/hostbridge/client/host-grpc-client"
@@ -29,6 +30,7 @@ import { fixWithCline } from "./core/controller/commands/fixWithCline"
 import { improveWithCline } from "./core/controller/commands/improveWithCline"
 import { sendAddToInputEvent } from "./core/controller/ui/subscribeToAddToInput"
 import { sendFocusChatInputEvent } from "./core/controller/ui/subscribeToFocusChatInput"
+import { workspaceResolver } from "./core/workspace"
 import { focusChatInput, getContextForCommand } from "./hosts/vscode/commandUtils"
 import { VscodeDiffViewProvider } from "./hosts/vscode/VscodeDiffViewProvider"
 import { VscodeWebviewProvider } from "./hosts/vscode/VscodeWebviewProvider"
@@ -37,6 +39,7 @@ import { AuthService } from "./services/auth/AuthService"
 import { telemetryService } from "./services/telemetry"
 import { SharedUriHandler } from "./services/uri/SharedUriHandler"
 import { ShowMessageType } from "./shared/proto/host/window"
+import { fileExistsAtPath } from "./utils/fs"
 /*
 Built using https://github.com/microsoft/vscode-webview-ui-toolkit
 
@@ -522,7 +525,41 @@ function setupHostProvider(context: ExtensionContext) {
 	context.subscriptions.push(outputChannel)
 
 	const getCallbackUri = async () => `${vscode.env.uriScheme || "vscode"}://saoudrizwan.claude-dev`
-	HostProvider.initialize(createWebview, createDiffView, vscodeHostBridgeClient, outputChannel.appendLine, getCallbackUri)
+	HostProvider.initialize(
+		createWebview,
+		createDiffView,
+		vscodeHostBridgeClient,
+		outputChannel.appendLine,
+		getCallbackUri,
+		getBinaryLocation,
+	)
+}
+
+async function getBinaryLocation(name: string): Promise<string> {
+	// The only binary currently supported is the rg binary from the VSCode installation.
+	if (!name.startsWith("rg")) {
+		throw new Error(`Binary '${name}' is not supported`)
+	}
+
+	const checkPath = async (pkgFolder: string) => {
+		const fullPathResult = workspaceResolver.resolveWorkspacePath(
+			vscode.env.appRoot,
+			path.join(pkgFolder, name),
+			"Services.ripgrep.getBinPath",
+		)
+		const fullPath = typeof fullPathResult === "string" ? fullPathResult : fullPathResult.absolutePath
+		return (await fileExistsAtPath(fullPath)) ? fullPath : undefined
+	}
+
+	const binPath =
+		(await checkPath("node_modules/@vscode/ripgrep/bin/")) ||
+		(await checkPath("node_modules/vscode-ripgrep/bin")) ||
+		(await checkPath("node_modules.asar.unpacked/vscode-ripgrep/bin/")) ||
+		(await checkPath("node_modules.asar.unpacked/@vscode/ripgrep/bin/"))
+	if (!binPath) {
+		throw new Error("Could not find ripgrep binary")
+	}
+	return binPath
 }
 
 // This method is called when your extension is deactivated

--- a/src/hosts/host-provider.ts
+++ b/src/hosts/host-provider.ts
@@ -29,6 +29,12 @@ export class HostProvider {
 	// Returns a callback URI that will redirect to Cline.
 	getCallbackUri: () => Promise<string>
 
+	// Returns the location of the binary `name`.
+	// Use `getBinaryLocation()` from utils/ts.ts instead of using
+	// this directly. The helper function correctly handles the file
+	// extension on Windows.
+	getBinaryLocation: (name: string) => Promise<string>
+
 	// Private constructor to enforce singleton pattern
 	private constructor(
 		createWebviewProvider: WebviewProviderCreator,
@@ -36,12 +42,14 @@ export class HostProvider {
 		hostBridge: HostBridgeClientProvider,
 		logToChannel: LogToChannel,
 		getCallbackUri: () => Promise<string>,
+		getBinaryLocation: (name: string) => Promise<string>,
 	) {
 		this.createWebviewProvider = createWebviewProvider
 		this.createDiffViewProvider = createDiffViewProvider
 		this.hostBridge = hostBridge
 		this.logToChannel = logToChannel
 		this.getCallbackUri = getCallbackUri
+		this.getBinaryLocation = getBinaryLocation
 	}
 
 	public static initialize(
@@ -50,6 +58,7 @@ export class HostProvider {
 		hostBridgeProvider: HostBridgeClientProvider,
 		logToChannel: LogToChannel,
 		getCallbackUri: () => Promise<string>,
+		getBinaryLocation: (name: string) => Promise<string>,
 	): HostProvider {
 		if (HostProvider.instance) {
 			throw new Error("Host providers have already been initialized.")
@@ -60,6 +69,7 @@ export class HostProvider {
 			hostBridgeProvider,
 			logToChannel,
 			getCallbackUri,
+			getBinaryLocation,
 		)
 		return HostProvider.instance
 	}

--- a/src/services/ripgrep/index.ts
+++ b/src/services/ripgrep/index.ts
@@ -1,19 +1,16 @@
 import { ClineIgnoreController } from "@core/ignore/ClineIgnoreController"
-import { workspaceResolver } from "@core/workspace"
-import { fileExistsAtPath } from "@utils/fs"
 import * as childProcess from "child_process"
 import * as path from "path"
 import * as readline from "readline"
-import * as vscode from "vscode"
+import { getBinaryLocation } from "@/utils/fs"
 
 /*
 This file provides functionality to perform regex searches on files using ripgrep.
 Inspired by: https://github.com/DiscreteTom/vscode-ripgrep-utils
 
 Key components:
-1. getBinPath: Locates the ripgrep binary within the VSCode installation.
-2. execRipgrep: Executes the ripgrep command and returns the output.
-3. regexSearchFiles: The main function that performs regex searches on files.
+* execRipgrep: Executes the ripgrep command and returns the output.
+* regexSearchFiles: The main function that performs regex searches on files.
    - Parameters:
      * cwd: The current working directory (for relative path calculation)
      * directoryPath: The directory to search in
@@ -48,9 +45,6 @@ rel/path/to/helper.ts
 │----
 */
 
-const isWindows = /^win/.test(process.platform)
-const binName = isWindows ? "rg.exe" : "rg"
-
 interface SearchResult {
 	filePath: string
 	line: number
@@ -62,28 +56,11 @@ interface SearchResult {
 
 const MAX_RESULTS = 300
 
-export async function getBinPath(vscodeAppRoot: string): Promise<string | undefined> {
-	const checkPath = async (pkgFolder: string) => {
-		const fullPathResult = workspaceResolver.resolveWorkspacePath(
-			vscodeAppRoot,
-			path.join(pkgFolder, binName),
-			"Services.ripgrep.getBinPath",
-		)
-		const fullPath = typeof fullPathResult === "string" ? fullPathResult : fullPathResult.absolutePath
-		return (await fileExistsAtPath(fullPath)) ? fullPath : undefined
-	}
+async function execRipgrep(args: string[]): Promise<string> {
+	const binPath: string = await getBinaryLocation("rg")
 
-	return (
-		(await checkPath("node_modules/@vscode/ripgrep/bin/")) ||
-		(await checkPath("node_modules/vscode-ripgrep/bin")) ||
-		(await checkPath("node_modules.asar.unpacked/vscode-ripgrep/bin/")) ||
-		(await checkPath("node_modules.asar.unpacked/@vscode/ripgrep/bin/"))
-	)
-}
-
-async function execRipgrep(bin: string, args: string[]): Promise<string> {
 	return new Promise((resolve, reject) => {
-		const rgProcess = childProcess.spawn(bin, args)
+		const rgProcess = childProcess.spawn(binPath, args)
 		// cross-platform alternative to head, which is ripgrep author's recommendation for limiting output.
 		const rl = readline.createInterface({
 			input: rgProcess.stdout,
@@ -128,20 +105,13 @@ export async function regexSearchFiles(
 	filePattern?: string,
 	clineIgnoreController?: ClineIgnoreController,
 ): Promise<string> {
-	const vscodeAppRoot = vscode.env.appRoot
-	const rgPath = await getBinPath(vscodeAppRoot)
-
-	if (!rgPath) {
-		throw new Error("Could not find ripgrep binary")
-	}
-
 	const args = ["--json", "-e", regex, "--glob", filePattern || "*", "--context", "1", directoryPath]
 
 	let output: string
 	try {
-		output = await execRipgrep(rgPath, args)
-	} catch {
-		return "No results found"
+		output = await execRipgrep(args)
+	} catch (error) {
+		throw Error("Error calling ripgrep", error)
 	}
 	const results: SearchResult[] = []
 	let currentResult: Partial<SearchResult> | null = null

--- a/src/standalone/cline-core.ts
+++ b/src/standalone/cline-core.ts
@@ -2,6 +2,7 @@ import { ExternalDiffViewProvider } from "@hosts/external/ExternalDiffviewProvid
 import { ExternalWebviewProvider } from "@hosts/external/ExternalWebviewProvider"
 import { ExternalHostBridgeClientManager } from "@hosts/external/host-bridge-client-manager"
 import { WebviewProviderType } from "@shared/webview/types"
+import * as path from "path"
 import { initialize, tearDown } from "@/common"
 import { WebviewProvider } from "@/core/webview"
 import { AuthHandler } from "@/hosts/external/AuthHandler"
@@ -44,8 +45,16 @@ function setupHostProvider() {
 	const getCallbackUri = (): Promise<string> => {
 		return AuthHandler.getInstance().getCallbackUri()
 	}
+	const getBinaryLocation = async (name: string): Promise<string> => path.join(".", name)
 
-	HostProvider.initialize(createWebview, createDiffView, new ExternalHostBridgeClientManager(), log, getCallbackUri)
+	HostProvider.initialize(
+		createWebview,
+		createDiffView,
+		new ExternalHostBridgeClientManager(),
+		log,
+		getCallbackUri,
+		getBinaryLocation,
+	)
 }
 
 /**

--- a/src/test/host-provider-test-utils.ts
+++ b/src/test/host-provider-test-utils.ts
@@ -14,6 +14,7 @@ export function setVscodeHostProviderMock(options?: {
 	hostBridgeClient?: HostBridgeClientProvider
 	logToChannel?: (message: string) => void
 	getCallbackUri?: () => Promise<string>
+	getBinaryLocation?: (name: string) => Promise<string>
 }) {
 	HostProvider.reset()
 	HostProvider.initialize(
@@ -22,5 +23,6 @@ export function setVscodeHostProviderMock(options?: {
 		options?.hostBridgeClient ?? vscodeHostBridgeClient,
 		options?.logToChannel ?? ((_) => {}),
 		options?.getCallbackUri ?? (async () => "http://example.com:1234/"),
+		options?.getBinaryLocation ?? (async (n) => `/mock/path/${n}`),
 	)
 }

--- a/src/test/services/search/file-search.test.ts
+++ b/src/test/services/search/file-search.test.ts
@@ -1,4 +1,3 @@
-import * as ripgrep from "@services/ripgrep"
 import * as fileSearch from "@services/search/file-search"
 import * as childProcess from "child_process"
 import * as fs from "fs"
@@ -7,7 +6,7 @@ import { describe, it } from "mocha"
 import should from "should"
 import sinon from "sinon"
 import { Readable } from "stream"
-import * as vscode from "vscode"
+import { setVscodeHostProviderMock } from "@/test/host-provider-test-utils"
 
 describe("File Search", () => {
 	let sandbox: sinon.SinonSandbox
@@ -21,10 +20,14 @@ describe("File Search", () => {
 		const spawnWrapper: typeof childProcess.spawn = (command, options) => spawnStub(command, options)
 
 		sandbox.stub(fileSearch, "getSpawnFunction").returns(spawnWrapper)
-		// Use replaceGetter instead of stub().value() for non-configurable properties
-		sandbox.replaceGetter(vscode.env, "appRoot", () => "mock/app/root")
 		sandbox.stub(fs.promises, "lstat").resolves({ isDirectory: () => false } as fs.Stats)
-		sandbox.stub(ripgrep, "getBinPath").resolves("mock/ripgrep/path")
+
+		// Mock fs.access to return true for both Unix and Windows ripgrep binary paths
+		const accessStub = sandbox.stub(fs.promises, "access")
+		accessStub.withArgs("/mock/path/rg").resolves()
+		accessStub.withArgs("/mock/path/rg.exe").resolves()
+
+		setVscodeHostProviderMock()
 	})
 
 	afterEach(() => {
@@ -68,7 +71,7 @@ describe("File Search", () => {
 			// Create a new stub for executeRipgrepForFiles
 			sandbox.stub(fileSearch, "executeRipgrepForFiles").resolves(expectedResult)
 
-			const result = await fileSearch.executeRipgrepForFiles("mock/path", "/workspace", 5000)
+			const result = await fileSearch.executeRipgrepForFiles("/workspace", 5000)
 
 			should(result).be.an.Array()
 			// Don't assert on the exact length as it may vary
@@ -120,7 +123,7 @@ describe("File Search", () => {
 				},
 			} as unknown as childProcess.ChildProcess)
 
-			await should(fileSearch.executeRipgrepForFiles("mock/path", "/workspace", 5000)).be.rejectedWith(
+			await should(fileSearch.executeRipgrepForFiles("/workspace", 5000)).be.rejectedWith(
 				`ripgrep process error: ${mockError}`,
 			)
 		})

--- a/src/utils/fs.ts
+++ b/src/utils/fs.ts
@@ -1,6 +1,9 @@
 import { workspaceResolver } from "@core/workspace"
 import fs from "fs/promises"
 import * as path from "path"
+import { HostProvider } from "@/hosts/host-provider"
+
+const IS_WINDOWS = /^win/.test(process.platform)
 
 /**
  * Asynchronously creates all non-existing subdirectories for a given file path
@@ -148,4 +151,14 @@ export const readDirectory = async (directoryPath: string, excludedPaths: string
 	} catch {
 		throw new Error(`Error reading directory at ${directoryPath}`)
 	}
+}
+
+export async function getBinaryLocation(name: string): Promise<string> {
+	const binName = IS_WINDOWS ? `${name}.exe` : name
+	const location = await HostProvider.get().getBinaryLocation(binName)
+
+	if (!(await fileExistsAtPath(location))) {
+		throw new Error(`Could not find binary ${name} at: ${location}`)
+	}
+	return location
 }


### PR DESCRIPTION
Add a method to the host provider that returns the location of the ripgrep binary.

Add a util in utils/fs.ts to handle adding the .exe file extension on windows, and checking that the binary is present.

Update the places where ripgrep is called.


https://github.com/user-attachments/assets/53b39c29-a1e6-4240-b6d6-295a4157b1b5


<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add platform-agnostic support for ripgrep by implementing a method to determine its binary location and updating relevant code to use this method.
> 
>   - **Behavior**:
>     - Adds `getBinaryLocation()` method in `utils/fs.ts` to determine the location of the ripgrep binary, handling `.exe` extension on Windows.
>     - Updates `HostProvider` in `host-provider.ts` to include `getBinaryLocation` method.
>     - Modifies `getBinaryLocation()` in `extension.ts` and `cline-core.ts` to support ripgrep binary location.
>   - **Functionality**:
>     - Replaces direct ripgrep path usage with `getBinaryLocation()` in `ripgrep/index.ts` and `file-search.ts`.
>     - Removes `getBinPath()` function from `ripgrep/index.ts`.
>   - **Testing**:
>     - Updates `file-search.test.ts` to mock `getBinaryLocation()` and test ripgrep execution.
>     - Adds `getBinaryLocation` mock in `host-provider-test-utils.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for e6eb31f3bb25bcf89c7511a4fc430f1e5825210e. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->