### PR TITLE
thinking budget update

### DIFF
--- a/.changeset/mighty-needles-play.md
+++ b/.changeset/mighty-needles-play.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Added automatic thinking budget validation that clamps values to model limits when switching models.

--- a/src/core/api/utils/__tests__/thinkingBudgetValidation.test.ts
+++ b/src/core/api/utils/__tests__/thinkingBudgetValidation.test.ts
@@ -1,0 +1,222 @@
+import { ModelInfo } from "@shared/api"
+import { expect } from "chai"
+import { describe, it } from "mocha"
+import { clampThinkingBudget, getMaxThinkingBudgetForModel } from "../thinkingBudgetValidation"
+
+describe("thinkingBudgetValidation", () => {
+	describe("getMaxThinkingBudgetForModel", () => {
+		it("should return thinkingConfig.maxBudget when available", () => {
+			const modelInfo: ModelInfo = {
+				maxTokens: 8192,
+				contextWindow: 200000,
+				supportsImages: true,
+				supportsPromptCache: true,
+				thinkingConfig: {
+					maxBudget: 32767,
+				},
+			}
+
+			expect(getMaxThinkingBudgetForModel(modelInfo)).to.equal(32767)
+		})
+
+		it("should return maxTokens - 1 when thinkingConfig.maxBudget is not available", () => {
+			const modelInfo: ModelInfo = {
+				maxTokens: 8192,
+				contextWindow: 200000,
+				supportsImages: true,
+				supportsPromptCache: true,
+			}
+
+			expect(getMaxThinkingBudgetForModel(modelInfo)).to.equal(8191)
+		})
+
+		it("should prefer thinkingConfig.maxBudget over maxTokens when both are available", () => {
+			const modelInfo: ModelInfo = {
+				maxTokens: 8192,
+				contextWindow: 200000,
+				supportsImages: true,
+				supportsPromptCache: true,
+				thinkingConfig: {
+					maxBudget: 5000,
+				},
+			}
+
+			expect(getMaxThinkingBudgetForModel(modelInfo)).to.equal(5000)
+		})
+
+		it("should return undefined when neither thinkingConfig.maxBudget nor maxTokens are available", () => {
+			const modelInfo: ModelInfo = {
+				contextWindow: 200000,
+				supportsImages: true,
+				supportsPromptCache: true,
+			}
+
+			expect(getMaxThinkingBudgetForModel(modelInfo)).to.be.undefined
+		})
+
+		it("should return undefined when maxTokens is 0", () => {
+			const modelInfo: ModelInfo = {
+				maxTokens: 0,
+				contextWindow: 200000,
+				supportsImages: true,
+				supportsPromptCache: true,
+			}
+
+			expect(getMaxThinkingBudgetForModel(modelInfo)).to.be.undefined
+		})
+	})
+
+	describe("clampThinkingBudget", () => {
+		it("should return original value when it is below the limit", () => {
+			const modelInfo: ModelInfo = {
+				maxTokens: 8192,
+				contextWindow: 200000,
+				supportsImages: true,
+				supportsPromptCache: true,
+			}
+
+			expect(clampThinkingBudget(5000, modelInfo)).to.equal(5000)
+		})
+
+		it("should return original value when it equals the limit", () => {
+			const modelInfo: ModelInfo = {
+				maxTokens: 8192,
+				contextWindow: 200000,
+				supportsImages: true,
+				supportsPromptCache: true,
+			}
+
+			expect(clampThinkingBudget(8191, modelInfo)).to.equal(8191)
+		})
+
+		it("should return clamped value when it exceeds the limit", () => {
+			const modelInfo: ModelInfo = {
+				maxTokens: 4096,
+				contextWindow: 200000,
+				supportsImages: true,
+				supportsPromptCache: true,
+			}
+
+			expect(clampThinkingBudget(10000, modelInfo)).to.equal(4095)
+		})
+
+		it("should use thinkingConfig.maxBudget for clamping when available", () => {
+			const modelInfo: ModelInfo = {
+				maxTokens: 8192,
+				contextWindow: 200000,
+				supportsImages: true,
+				supportsPromptCache: true,
+				thinkingConfig: {
+					maxBudget: 5000,
+				},
+			}
+
+			expect(clampThinkingBudget(7000, modelInfo)).to.equal(5000)
+		})
+
+		it("should return original value when model has no limits", () => {
+			const modelInfo: ModelInfo = {
+				contextWindow: 200000,
+				supportsImages: true,
+				supportsPromptCache: true,
+			}
+
+			expect(clampThinkingBudget(10000, modelInfo)).to.equal(10000)
+		})
+
+		it("should handle edge case with very small maxTokens", () => {
+			const modelInfo: ModelInfo = {
+				maxTokens: 1,
+				contextWindow: 200000,
+				supportsImages: true,
+				supportsPromptCache: true,
+			}
+
+			expect(clampThinkingBudget(1000, modelInfo)).to.equal(0)
+		})
+
+		it("should handle zero thinking budget value", () => {
+			const modelInfo: ModelInfo = {
+				maxTokens: 8192,
+				contextWindow: 200000,
+				supportsImages: true,
+				supportsPromptCache: true,
+			}
+
+			expect(clampThinkingBudget(0, modelInfo)).to.equal(0)
+		})
+
+		it("should handle negative thinking budget value", () => {
+			const modelInfo: ModelInfo = {
+				maxTokens: 8192,
+				contextWindow: 200000,
+				supportsImages: true,
+				supportsPromptCache: true,
+			}
+
+			expect(clampThinkingBudget(-100, modelInfo)).to.equal(-100)
+		})
+	})
+
+	describe("real-world model scenarios", () => {
+		it("should handle Anthropic Claude model (uses maxTokens)", () => {
+			const claudeModel: ModelInfo = {
+				maxTokens: 8192,
+				contextWindow: 200000,
+				supportsImages: true,
+				supportsPromptCache: true,
+				inputPrice: 3.0,
+				outputPrice: 15.0,
+			}
+
+			expect(getMaxThinkingBudgetForModel(claudeModel)).to.equal(8191)
+			expect(clampThinkingBudget(10000, claudeModel)).to.equal(8191)
+			expect(clampThinkingBudget(5000, claudeModel)).to.equal(5000)
+		})
+
+		it("should handle Gemini model (uses thinkingConfig.maxBudget)", () => {
+			const geminiModel: ModelInfo = {
+				maxTokens: 65536,
+				contextWindow: 1048576,
+				supportsImages: true,
+				supportsPromptCache: true,
+				thinkingConfig: {
+					maxBudget: 32767,
+				},
+				inputPrice: 2.5,
+				outputPrice: 15,
+			}
+
+			expect(getMaxThinkingBudgetForModel(geminiModel)).to.equal(32767)
+			expect(clampThinkingBudget(50000, geminiModel)).to.equal(32767)
+			expect(clampThinkingBudget(20000, geminiModel)).to.equal(20000)
+		})
+
+		it("should handle model switching scenario (high to low limit)", () => {
+			const highLimitModel: ModelInfo = {
+				maxTokens: 65536,
+				contextWindow: 1048576,
+				supportsImages: true,
+				supportsPromptCache: true,
+				thinkingConfig: {
+					maxBudget: 32767,
+				},
+			}
+
+			const lowLimitModel: ModelInfo = {
+				maxTokens: 4096,
+				contextWindow: 200000,
+				supportsImages: true,
+				supportsPromptCache: true,
+			}
+
+			const originalBudget = 25000
+
+			// Original budget is valid for high limit model
+			expect(clampThinkingBudget(originalBudget, highLimitModel)).to.equal(25000)
+
+			// Same budget gets clamped for low limit model
+			expect(clampThinkingBudget(originalBudget, lowLimitModel)).to.equal(4095)
+		})
+	})
+})

--- a/src/core/api/utils/thinkingBudgetValidation.ts
+++ b/src/core/api/utils/thinkingBudgetValidation.ts
@@ -1,0 +1,23 @@
+import { ModelInfo } from "@shared/api"
+
+export function getMaxThinkingBudgetForModel(modelInfo: ModelInfo): number | undefined {
+	// Prefer explicit thinkingConfig.maxBudget if available
+	if (modelInfo.thinkingConfig?.maxBudget) {
+		return modelInfo.thinkingConfig.maxBudget
+	}
+
+	// Fallback to maxTokens - 1 (as current buildApiHandler does)
+	if (modelInfo.maxTokens) {
+		return modelInfo.maxTokens - 1
+	}
+
+	return undefined
+}
+
+export function clampThinkingBudget(value: number, modelInfo: ModelInfo): number {
+	const maxBudget = getMaxThinkingBudgetForModel(modelInfo)
+	if (maxBudget !== undefined && value > maxBudget) {
+		return maxBudget
+	}
+	return value
+}

--- a/src/core/controller/models/updateApiConfigurationProto.ts
+++ b/src/core/controller/models/updateApiConfigurationProto.ts
@@ -1,8 +1,51 @@
-import { buildApiHandler } from "@core/api"
+import { buildApiHandler, createHandlerForProvider } from "@core/api"
+import { clampThinkingBudget } from "@core/api/utils/thinkingBudgetValidation"
+import { ApiConfiguration } from "@shared/api"
 import { Empty } from "@shared/proto/cline/common"
 import { UpdateApiConfigurationRequest } from "@shared/proto/cline/models"
 import { convertProtoToApiConfiguration } from "@shared/proto-conversions/models/api-configuration-conversion"
 import type { Controller } from "../index"
+
+/**
+ * Validates and clamps thinking budget tokens to ensure they don't exceed model limits
+ * @param config The API configuration to validate
+ * @returns The validated configuration with clamped thinking budget values
+ */
+function validateAndClampThinkingBudgets(config: ApiConfiguration): ApiConfiguration {
+	try {
+		let configChanged = false
+		const validatedConfig = { ...config }
+
+		// Validate plan mode thinking budget
+		if (validatedConfig.planModeThinkingBudgetTokens && validatedConfig.planModeThinkingBudgetTokens > 0) {
+			const planHandler = createHandlerForProvider(validatedConfig.planModeApiProvider, validatedConfig, "plan")
+			const planModelInfo = planHandler.getModel().info
+			const clampedPlanValue = clampThinkingBudget(validatedConfig.planModeThinkingBudgetTokens, planModelInfo)
+
+			if (clampedPlanValue !== validatedConfig.planModeThinkingBudgetTokens) {
+				validatedConfig.planModeThinkingBudgetTokens = clampedPlanValue
+				configChanged = true
+			}
+		}
+
+		// Validate act mode thinking budget
+		if (validatedConfig.actModeThinkingBudgetTokens && validatedConfig.actModeThinkingBudgetTokens > 0) {
+			const actHandler = createHandlerForProvider(validatedConfig.actModeApiProvider, validatedConfig, "act")
+			const actModelInfo = actHandler.getModel().info
+			const clampedActValue = clampThinkingBudget(validatedConfig.actModeThinkingBudgetTokens, actModelInfo)
+
+			if (clampedActValue !== validatedConfig.actModeThinkingBudgetTokens) {
+				validatedConfig.actModeThinkingBudgetTokens = clampedActValue
+				configChanged = true
+			}
+		}
+
+		return validatedConfig
+	} catch (error) {
+		console.error("[APICONFIG: validateAndClampThinkingBudgets] Error validating thinking budgets:", error)
+		return config // Return original config if validation fails
+	}
+}
 
 /**
  * Updates API configuration
@@ -23,13 +66,16 @@ export async function updateApiConfigurationProto(
 		// Convert proto ApiConfiguration to application ApiConfiguration
 		const appApiConfiguration = convertProtoToApiConfiguration(request.apiConfiguration)
 
+		// Validate and clamp thinking budget tokens before persisting
+		const validatedConfig = validateAndClampThinkingBudgets(appApiConfiguration)
+
 		// Update the API configuration in storage
-		controller.stateManager.setApiConfiguration(appApiConfiguration)
+		controller.stateManager.setApiConfiguration(validatedConfig)
 
 		// Update the task's API handler if there's an active task
 		if (controller.task) {
 			const currentMode = await controller.getCurrentMode()
-			controller.task.api = buildApiHandler({ ...appApiConfiguration, ulid: controller.task.ulid }, currentMode)
+			controller.task.api = buildApiHandler({ ...validatedConfig, ulid: controller.task.ulid }, currentMode)
 		}
 
 		// Post updated state to webview

--- a/webview-ui/src/components/settings/ThinkingBudgetSlider.tsx
+++ b/webview-ui/src/components/settings/ThinkingBudgetSlider.tsx
@@ -1,7 +1,7 @@
 import { anthropicModels, geminiDefaultModelId, geminiModels } from "@shared/api"
 import { Mode } from "@shared/storage/types"
 import { VSCodeCheckbox } from "@vscode/webview-ui-toolkit/react"
-import { memo, useCallback, useMemo, useState } from "react"
+import { memo, useCallback, useEffect, useMemo, useState } from "react"
 import styled from "styled-components"
 import { useExtensionState } from "@/context/ExtensionStateContext"
 import { getModeSpecificFields } from "./utils/providerUtils"
@@ -114,6 +114,16 @@ const ThinkingBudgetSlider = ({ maxBudget, currentMode }: ThinkingBudgetSliderPr
 
 	// Add local state for the slider value
 	const [localValue, setLocalValue] = useState(modeFields.thinkingBudgetTokens || 0)
+
+	// Sync local state with backend values when they change
+	useEffect(() => {
+		const backendValue = modeFields.thinkingBudgetTokens || 0
+
+		if (backendValue !== localValue) {
+			setLocalValue(backendValue)
+			setIsEnabled(backendValue > 0)
+		}
+	}, [modeFields.thinkingBudgetTokens, currentMode])
 
 	const handleSliderChange = useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
 		const value = parseInt(event.target.value, 10)


### PR DESCRIPTION
# Fix: Auto-clamp thinking budget when switching to models with lower limits

## Problem
When users switched from a model with high thinking token limits to a model with lower limits, the thinking budget value wasn't automatically clamped to the new model's maximum. This caused API errors because the system would attempt to use the old (invalid) high value with the new model that couldn't support it.

**Example scenario:**
1. User sets thinking budget to 32,767 tokens on Gemini 2.5 Pro (max: 32,767)
2. User switches to Gemini 2.5 Flash (max: 24,576) 
3. UI still shows 32,767 tokens
4. API requests fail with "thinking budget exceeds model limit" errors

## Solution
Added automatic validation and clamping of thinking budget values when model configurations change:

- **Backend validation**: Added `validateAndClampThinkingBudgets()` in `updateApiConfigurationProto.ts` that automatically clamps values before persisting configuration
- **Shared utilities**: Created reusable validation functions in `src/core/api/utils/thinkingBudgetValidation.ts`
- **UI synchronization**: Added `useEffect` in `ThinkingBudgetSlider.tsx` to sync local state with backend-corrected values
- **Consistent logic**: Refactored existing validation in `buildApiHandler()` to use shared utilities

## How to Test
1. Set thinking budget to maximum value on a high-limit model (e.g., Gemini 2.5 Pro: 32,767 tokens)
2. Switch to a lower-limit model (e.g., Gemini 2.5 Flash: 24,576 tokens)
3. **Expected result**: Thinking budget automatically clamps to 24,576 and UI updates immediately
4. **Previous behavior**: Value stayed at 32,767, causing API errors

The fix ensures thinking budget values are always valid for the selected model, preventing API errors and providing a smooth user experience.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [X] 🐛 Bug fix (non-breaking change which fixes an issue)

### Screenshots

https://github.com/user-attachments/assets/6bc8c498-9280-47a5-981f-2e14393555a1




<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes thinking budget clamping issue by adding validation logic in backend and UI, ensuring values adhere to model limits.
> 
>   - **Behavior**:
>     - Added `validateAndClampThinkingBudgets()` in `updateApiConfigurationProto.ts` to clamp thinking budget values to model limits.
>     - Refactored `buildApiHandler()` in `index.ts` to use `clampThinkingBudget()` for consistent logic.
>     - UI in `ThinkingBudgetSlider.tsx` now syncs local state with backend-corrected values using `useEffect`.
>   - **Utilities**:
>     - Created `clampThinkingBudget()` and `getMaxThinkingBudgetForModel()` in `thinkingBudgetValidation.ts` for reusable validation logic.
>   - **Tests**:
>     - Added tests in `thinkingBudgetValidation.test.ts` to cover various scenarios for budget clamping and model switching.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for dce27bb10da1af5e33919fff18ead1acc4318f38. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->