### PR TITLE
Use the correct binary path for cline-core

### DIFF
--- a/src/core/task/ToolExecutor.ts
+++ b/src/core/task/ToolExecutor.ts
@@ -247,6 +247,7 @@ export class ToolExecutor {
 	 * Handles errors during tool execution
 	 */
 	private async handleError(action: string, error: Error, block: ToolUse): Promise<void> {
+		console.log(error)
 		const errorString = `Error ${action}: ${error.message}`
 		await this.say("error", errorString)
 

--- a/src/services/ripgrep/index.ts
+++ b/src/services/ripgrep/index.ts
@@ -111,7 +111,7 @@ export async function regexSearchFiles(
 	try {
 		output = await execRipgrep(args)
 	} catch (error) {
-		throw Error("Error calling ripgrep", error)
+		throw Error("Error calling ripgrep", { cause: error })
 	}
 	const results: SearchResult[] = []
 	let currentResult: Partial<SearchResult> | null = null

--- a/src/standalone/cline-core.ts
+++ b/src/standalone/cline-core.ts
@@ -45,7 +45,7 @@ function setupHostProvider() {
 	const getCallbackUri = (): Promise<string> => {
 		return AuthHandler.getInstance().getCallbackUri()
 	}
-	const getBinaryLocation = async (name: string): Promise<string> => path.join(".", name)
+	const getBinaryLocation = async (name: string): Promise<string> => path.join(process.cwd(), name)
 
 	HostProvider.initialize(
 		createWebview,


### PR DESCRIPTION
When cline-core is run, binaries are in the cwd.

When tools fail with an error, log the exception to the console. This makes debugging cline-core easier.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Corrects binary path for `cline-core` and enhances error logging for debugging.
> 
>   - **Behavior**:
>     - Update `getBinaryLocation` in `cline-core.ts` to use `process.cwd()` for correct binary path.
>     - Log exceptions in `handleError` in `ToolExecutor.ts` to console for better debugging.
>   - **Error Handling**:
>     - Modify error throwing in `regexSearchFiles` in `index.ts` to include error cause.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 66ee392cd019746b09f0109e1c7a9da847d8f565. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->