### PR TITLE
Remove use of VSCode API

### DIFF
--- a/src/core/task/tools/handlers/ReportBugHandler.ts
+++ b/src/core/task/tools/handlers/ReportBugHandler.ts
@@ -73,7 +73,7 @@ export class ReportBugHandler implements IToolHandler, IPartialBlockHandler {
 
 		// Derive system information values algorithmically
 		const operatingSystem = os.platform() + " " + os.release()
-		const clineVersion = vscode.extensions.getExtension("saoudrizwan.claude-dev")?.packageJSON.version || "Unknown"
+		const clineVersion = config.context.extension.packageJSON.version || "Unknown"
 		const systemInfo = `VSCode: ${vscode.version}, Node.js: ${process.version}, Architecture: ${os.arch()}`
 		const currentMode = config.mode
 		const apiConfig = config.services.stateManager.getApiConfiguration()


### PR DESCRIPTION
`vscode.extensions.getExtension("saoudrizwan.claude-dev")` doesn't work cross-platform.

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Replace VSCode API usage with direct config access for `clineVersion` in `ReportBugHandler`.
> 
>   - **Behavior**:
>     - Replace `vscode.extensions.getExtension` with `config.context.extension` to get `clineVersion` in `ReportBugHandler`.
>   - **Misc**:
>     - Remove dependency on VSCode API for extension version retrieval.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for fb2ef1c77c37a5238e0c12f3ebd54626065af145. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->