### PR TITLE
Remove uses of the VSCode API

### DIFF
--- a/src/core/controller/index.ts
+++ b/src/core/controller/index.ts
@@ -41,7 +41,6 @@ https://github.com/KumarVariable/vscode-extension-sidebar-html/blob/master/src/c
 
 export class Controller {
 	readonly id: string
-	private disposables: vscode.Disposable[] = []
 	task?: Task
 
 	mcpHub: McpHub
@@ -120,12 +119,6 @@ export class Controller {
 	*/
 	async dispose() {
 		await this.clearTask()
-		while (this.disposables.length) {
-			const x = this.disposables.pop()
-			if (x) {
-				x.dispose()
-			}
-		}
 		this.mcpHub.dispose()
 
 		console.error("Controller disposed")

--- a/src/services/mcp/McpHub.ts
+++ b/src/services/mcp/McpHub.ts
@@ -30,7 +30,6 @@ import deepEqual from "fast-deep-equal"
 import * as fs from "fs/promises"
 import * as path from "path"
 import ReconnectingEventSource from "reconnecting-eventsource"
-import * as vscode from "vscode"
 import { z } from "zod"
 import { HostProvider } from "@/hosts/host-provider"
 import { ShowMessageType } from "@/shared/proto/host/window"
@@ -44,7 +43,6 @@ export class McpHub {
 	private clientVersion: string
 	private telemetryService: TelemetryService
 
-	private disposables: vscode.Disposable[] = []
 	private settingsWatcher?: FSWatcher
 	private fileWatchers: Map<string, FSWatcher> = new Map()
 	connections: McpConnection[] = []
@@ -1153,6 +1151,5 @@ export class McpHub {
 		if (this.settingsWatcher) {
 			await this.settingsWatcher.close()
 		}
-		this.disposables.forEach((d) => d.dispose())
 	}
 }


### PR DESCRIPTION
Remove unused fields `disposables`, nothing was being added to the disposables list.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove unused `disposables` field and `vscode` import from `McpHub.ts`.
> 
>   - **Code Removal**:
>     - Remove unused `disposables` field from `McpHub` class in `McpHub.ts`.
>     - Delete `this.disposables.forEach((d) => d.dispose())` in `dispose()` method of `McpHub` class.
>   - **Imports**:
>     - Remove import of `vscode` in `McpHub.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for cfcac1aa9e17ae37c6e6381a7e7d890cfa763e9b. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->