### PR TITLE
Remove uses of VSCode API

### DIFF
--- a/src/core/task/tools/handlers/ReportBugHandler.ts
+++ b/src/core/task/tools/handlers/ReportBugHandler.ts
@@ -4,7 +4,7 @@ import { processFilesIntoText } from "@integrations/misc/extract-text"
 import { showSystemNotification } from "@integrations/notifications"
 import { createAndOpenGitHubIssue } from "@utils/github-url-utils"
 import * as os from "os"
-import * as vscode from "vscode"
+import { HostProvider } from "@/hosts/host-provider"
 import { ClineDefaultTool } from "@/shared/tools"
 import type { ToolResponse } from "../../index"
 import type { IPartialBlockHandler, IToolHandler } from "../ToolExecutorCoordinator"
@@ -73,9 +73,10 @@ export class ReportBugHandler implements IToolHandler, IPartialBlockHandler {
 
 		// Derive system information values algorithmically
 		const operatingSystem = os.platform() + " " + os.release()
-		const clineVersion = vscode.extensions.getExtension("saoudrizwan.claude-dev")?.packageJSON.version || "Unknown"
-		const systemInfo = `VSCode: ${vscode.version}, Node.js: ${process.version}, Architecture: ${os.arch()}`
 		const currentMode = config.mode
+		const clineVersion = config.context.extension.packageJSON.version
+		const host = await HostProvider.env.getHostVersion({})
+		const systemInfo = `${host.platform}: ${host.version}, Node.js: ${process.version}, Architecture: ${os.arch()}`
 		const apiConfig = config.services.stateManager.getApiConfiguration()
 		const apiProvider = currentMode === "plan" ? apiConfig.planModeApiProvider : apiConfig.actModeApiProvider
 		const providerAndModel = `${apiProvider} / ${config.api.getModel().id}`


### PR DESCRIPTION
Remove uses of the VSCode API that was reintroduced in #5667.

The VSCode API is not portable, code using it will not work on JetBrains.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove VSCode API usage in `ReportBugHandler.ts` to improve portability by using `HostProvider` for system information.
> 
>   - **Behavior**:
>     - Remove VSCode API usage in `ReportBugHandler.ts`.
>     - Replace `vscode.extensions.getExtension` with `config.context.extension.packageJSON.version` for `clineVersion`.
>     - Replace `vscode.version` with `HostProvider.env.getHostVersion` for `systemInfo`.
>   - **Misc**:
>     - Update `systemInfo` format to use `host.platform` and `host.version` instead of `VSCode` specific details.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for bdd134e7399fc21e276dbb49637c9c125dc308ab. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->