### PR TITLE
Use HostBridge to open diff

### DIFF
--- a/src/integrations/checkpoints/index.ts
+++ b/src/integrations/checkpoints/index.ts
@@ -519,7 +519,7 @@ export class TaskCheckpointManager {
 				leftContent: file.before,
 				rightContent: file.after,
 			}))
-			HostProvider.diff.openMultiFileDiff({ title, diffs })
+			await HostProvider.diff.openMultiFileDiff({ title, diffs })
 
 			relinquishButton()
 		} catch (error) {


### PR DESCRIPTION
Use the host bridge to multi file diff. Using the VSCode API directly will not work on JetBrains.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Switches `presentMultifileDiff` in `TaskCheckpointManager` to use `HostProvider.diff.openMultiFileDiff` for compatibility with JetBrains IDEs.
> 
>   - **Behavior**:
>     - `presentMultifileDiff` in `TaskCheckpointManager` now uses `HostProvider.diff.openMultiFileDiff` to open multi-file diffs.
>     - Removes dependency on VSCode API for opening diffs, enabling compatibility with JetBrains IDEs.
>   - **Imports**:
>     - Removes unused import `DIFF_VIEW_URI_SCHEME` from `index.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for a4af5eccfab65928ddd4c753f15d8e8c1018126d. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->