### PR TITLE
Remove references to vscode.env.uriScheme

### DIFF
--- a/src/services/telemetry/TelemetryService.ts
+++ b/src/services/telemetry/TelemetryService.ts
@@ -3,7 +3,6 @@ import type { BrowserSettings } from "@shared/BrowserSettings"
 import { ShowMessageType } from "@shared/proto/host/window"
 import type { TaskFeedbackType } from "@shared/WebviewMessage"
 import * as os from "os"
-import * as vscode from "vscode"
 import { ClineAccountUserInfo } from "@/services/auth/AuthService"
 import { Setting } from "@/shared/proto/index.host"
 import { Mode } from "@/shared/storage/types"
@@ -209,35 +208,27 @@ export class TelemetryService {
 	public async updateTelemetryState(didUserOptIn: boolean): Promise<void> {
 		// First check global telemetry level - telemetry should only be enabled when level is "all"
 
-		// We only enable telemetry if global vscode telemetry is enabled
-		const telemetrySettings = await HostProvider.env.getTelemetrySettings({})
-		if (telemetrySettings.isEnabled === Setting.DISABLED) {
-			// Only show warning if user has opted in to Cline telemetry but VS Code telemetry is disabled
+		// We only enable telemetry if global host telemetry is enabled
+		const hostSetting = await HostProvider.env.getTelemetrySettings({})
+		if (hostSetting.isEnabled === Setting.DISABLED) {
+			// Only show warning if user has opted in to Cline telemetry but host telemetry is disabled
 			if (didUserOptIn) {
-				const isVsCodeHost = vscode?.env?.uriScheme === "vscode"
-				if (isVsCodeHost) {
-					void HostProvider.window
-						.showMessage({
-							type: ShowMessageType.WARNING,
-							message:
-								"Anonymous Cline error and usage reporting is enabled, but VSCode telemetry is disabled. To enable error and usage reporting for this extension, enable VSCode telemetry in settings.",
-							options: {
-								items: ["Open Settings"],
-							},
-						})
-						.then((response) => {
-							if (response.selectedOption === "Open Settings") {
-								void HostProvider.window.openSettings({
-									query: "telemetry.telemetryLevel",
-								})
-							}
-						})
-				} else {
-					void HostProvider.window.showMessage({
+				void HostProvider.window
+					.showMessage({
 						type: ShowMessageType.WARNING,
-						message: "Anonymous Cline error and usage reporting is enabled, but host telemetry is disabled.",
+						message:
+							"Anonymous Cline error and usage reporting is enabled, but IDE telemetry is disabled. To enable error and usage reporting for this extension, enable telemetry in IDE settings.",
+						options: {
+							items: ["Open Settings"],
+						},
 					})
-				}
+					.then((response) => {
+						if (response.selectedOption === "Open Settings") {
+							void HostProvider.window.openSettings({
+								query: "telemetry.telemetryLevel",
+							})
+						}
+					})
 			}
 		}
 


### PR DESCRIPTION
`vscode.env.uriScheme` was being used to check for VSCode. Now JetBrains returns UNSUPPORTED for getTelemetrySetting. So, we do not need to check specifically for VSCode.