### PR TITLE
Remove unused functions from vscode wrapper

### DIFF
--- a/webview-ui/src/utils/vscode.ts
+++ b/webview-ui/src/utils/vscode.ts
@@ -51,43 +51,6 @@ class VSCodeAPIWrapper {
 			console.log("postMessage fallback: ", message)
 		}
 	}
-
-	/**
-	 * Get the persistent state stored for this webview.
-	 *
-	 * @remarks When running webview source code inside a web browser, getState will retrieve state
-	 * from local storage (https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage).
-	 *
-	 * @return The current state or `undefined` if no state has been set.
-	 */
-	public getState(): unknown | undefined {
-		if (this.vsCodeApi) {
-			return this.vsCodeApi.getState()
-		} else {
-			const state = localStorage.getItem("vscodeState")
-			return state ? JSON.parse(state) : undefined
-		}
-	}
-
-	/**
-	 * Set the persistent state stored for this webview.
-	 *
-	 * @remarks When running webview source code inside a web browser, setState will set the given
-	 * state using local storage (https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage).
-	 *
-	 * @param newState New persisted state. This must be a JSON serializable object. Can be retrieved
-	 * using {@link getState}.
-	 *
-	 * @return The new state.
-	 */
-	public setState<T extends unknown | undefined>(newState: T): T {
-		if (this.vsCodeApi) {
-			return this.vsCodeApi.setState(newState)
-		} else {
-			localStorage.setItem("vscodeState", JSON.stringify(newState))
-			return newState
-		}
-	}
 }
 
 // Exports class singleton to prevent multiple invocations of acquireVsCodeApi.


### PR DESCRIPTION
Remove unused functions get/setState()

I am refactoring the platform specific code, and part of it is moving the postMessage function, so this whole class is going to end up getting removed in a later PR.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove unused `getState()` and `setState()` functions from `VSCodeAPIWrapper` in `vscode.ts`.
> 
>   - **Code Removal**:
>     - Remove unused `getState()` and `setState()` functions from `VSCodeAPIWrapper` in `vscode.ts`.
>     - These functions managed persistent state using VS Code API or local storage, but were not utilized.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for ee61bfdc6a5b475d2816cc0d8b75949fd8e52e51. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->