### PR TITLE
Docs/zai coding plans

### DIFF
--- a/docs/provider-config/zai.mdx
+++ b/docs/provider-config/zai.mdx
@@ -65,7 +65,7 @@ Z AI offers subscription plans specifically designed for coding applications. Th
 - Access to GLM-4.5 model
 - Works exclusively through coding tools like Cline
 
-Both plans offer promotional pricing for the first month: Lite drops from $6 to $3, Pro drops from $30 to $15.
+Both plans offer promotional pricing for the first month: Lite drops from \$6 to \$3, Pro drops from \$30 to \$15.
 
 <Frame>
   <img src="https://storage.googleapis.com/cline_public_images/docs/assets/zAI-coding-plan.png" alt="zAI subscription page showing GLM Coding Lite and Pro plans with pricing" />

--- a/docs/provider-config/zai.mdx
+++ b/docs/provider-config/zai.mdx
@@ -49,6 +49,44 @@ All models feature:
 4.  **Enter API Key:** Paste your Z AI API key into the "Z AI API Key" field.
 5.  **Select Model:** Choose your desired model from the "Model" dropdown.
 
+### GLM Coding Plans
+
+Z AI offers subscription plans specifically designed for coding applications. These plans provide cost-effective access to GLM-4.5 models through a prompt-based structure rather than traditional API usage billing.
+
+#### Plan Options
+
+**GLM Coding Lite** - $3/month
+- 120 prompts per 5-hour cycle
+- Access to GLM-4.5 model
+- Works exclusively through coding tools like Cline
+
+**GLM Coding Pro** - $15/month  
+- 600 prompts per 5-hour cycle
+- Access to GLM-4.5 model
+- Works exclusively through coding tools like Cline
+
+Both plans offer promotional pricing for the first month: Lite drops from $6 to $3, Pro drops from $30 to $15.
+
+<Frame>
+  <img src="https://storage.googleapis.com/cline_public_images/docs/assets/zAI-coding-plan.png" alt="zAI subscription page showing GLM Coding Lite and Pro plans with pricing" />
+</Frame>
+
+#### Setting up GLM Coding Plans
+
+To use the GLM Coding Plans with Cline:
+
+1. **Subscribe:** Go to [https://z.ai/subscribe](https://z.ai/subscribe) and choose your plan.
+
+2. **Create API Key:** After subscribing, log into your zAI dashboard and create an API key for your coding plan.
+
+3. **Configure in Cline:** Open Cline settings, select "Z AI" as your provider, and paste your API key into the "Z AI API Key" field.
+
+<Frame>
+  <img src="https://storage.googleapis.com/cline_public_images/docs/assets/zAI-provider.png" alt="Cline settings with zAI provider selected and API key field highlighted" />
+</Frame>
+
+The setup connects your subscription directly to Cline, giving you access to GLM-4.5's tool-calling capabilities optimized for coding workflows.
+
 ### Z AI's Hybrid Intelligence
 
 Z AI's GLM-4.5 series introduces revolutionary capabilities that set it apart from conventional language models:


### PR DESCRIPTION
### Related Issue

This PR adds documentation for zAI's new GLM Coding Plans integration with Cline.

### Description

Added a new "GLM Coding Plans" section to the existing zAI provider documentation that explains:

- Two subscription tiers: GLM Coding Lite ($3/month, 120 prompts per 5-hour cycle) and GLM Coding Pro ($15/month, 600 prompts per 5-hour cycle)
- Setup instructions for subscribing at z.ai/subscribe and configuring the API key in Cline
- Visual documentation showing the subscription page and Cline configuration

This partnership provides developers with cost-effective access to GLM-4.5 models specifically for coding applications.

### Test Procedure

- Verified the documentation renders correctly in MDX format
- Confirmed all links work properly (z.ai/subscribe)
- Tested that the Frame components display images correctly
- Ensured the new section integrates seamlessly with existing zAI documentation

### Type of Change

- [x] 📚 Documentation update

### Pre-flight Checklist

- [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
- [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
- [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
- [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

The documentation includes visual elements showing the zAI subscription page and Cline configuration interface.

### Additional Notes

This documentation update supports the new zAI partnership and helps users understand how to access GLM-4.5 models through the new subscription plans.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds documentation for zAI's GLM Coding Plans, detailing subscription options, setup instructions, and integration with Cline.
> 
>   - **Documentation**:
>     - Adds "GLM Coding Plans" section to `zai.mdx`.
>     - Describes two subscription tiers: GLM Coding Lite ($3/month, 120 prompts/5-hour) and GLM Coding Pro ($15/month, 600 prompts/5-hour).
>     - Includes setup instructions for subscribing at `z.ai/subscribe` and configuring the API key in Cline.
>     - Provides visual documentation with images of the subscription page and Cline configuration.
>   - **Testing**:
>     - Verified MDX rendering and link functionality.
>     - Tested Frame components for correct image display.
>     - Ensured seamless integration with existing zAI documentation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 51a0be4f9686745f3a2b4534d1888580157235bf. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->