### PR TITLE
Replace hardcoded extension identifiers with dynamic package.json values

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -13,7 +13,7 @@
 				"--extensionDevelopmentPath=${workspaceFolder}",
 				"--disable-workspace-trust",
 				// Avoid conflicts with the nightly extension
-				"--disable-extension=claude-dev.cline-nightly",
+				"--disable-extension=saoudrizwan.cline-nightly",
 				"${workspaceFolder}"
 			],
 			"outFiles": [

--- a/scripts/publish-nightly.mjs
+++ b/scripts/publish-nightly.mjs
@@ -167,7 +167,11 @@ class NightlyPublisher {
 	 * Update package.json with nightly configuration
 	 */
 	updatePackageJson() {
-		const pkg = JSON.parse(fs.readFileSync(config.packageJsonPath, "utf-8"))
+		// Replace any occurrences cline. or claude-dev with nightly name
+		const rawContent = fs.readFileSync(config.packageJsonPath, "utf-8")
+		const content = rawContent.replaceAll("claude-dev", config.nightlyName)
+
+		const pkg = JSON.parse(content)
 		const currentVersion = pkg.version
 
 		if (!currentVersion) {

--- a/scripts/publish-nightly.mjs
+++ b/scripts/publish-nightly.mjs
@@ -169,7 +169,7 @@ class NightlyPublisher {
 	updatePackageJson() {
 		// Replace any occurrences cline. or claude-dev with nightly name
 		const rawContent = fs.readFileSync(config.packageJsonPath, "utf-8")
-		const content = rawContent.replaceAll("claude-dev", config.nightlyName)
+		const content = rawContent.replaceAll("claude-dev", config.nightlyName).replaceAll('"cline.', `"${config.nightlyName}.`)
 
 		const pkg = JSON.parse(content)
 		const currentVersion = pkg.version

--- a/src/core/controller/index.ts
+++ b/src/core/controller/index.ts
@@ -650,6 +650,10 @@ export class Controller {
 		const distinctId = getDistinctId()
 		const version = this.context.extension?.packageJSON?.version ?? ""
 		const uriScheme = vscode.env.uriScheme
+		const extensionInfo = {
+			name: this.context.extension?.packageJSON?.name,
+			publisher: this.context.extension?.packageJSON?.publisher,
+		}
 
 		return {
 			version,
@@ -692,6 +696,7 @@ export class Controller {
 			taskHistory: processedTaskHistory,
 			platform,
 			shouldShowAnnouncement,
+			extensionInfo,
 		}
 	}
 

--- a/src/core/controller/ui/openWalkthrough.ts
+++ b/src/core/controller/ui/openWalkthrough.ts
@@ -2,6 +2,7 @@ import type { EmptyRequest } from "@shared/proto/cline/common"
 import { Empty } from "@shared/proto/cline/common"
 import * as vscode from "vscode"
 import { telemetryService } from "@/services/telemetry"
+import { name as pkgName } from "../../../../package.json"
 import type { Controller } from "../index"
 
 /**
@@ -12,7 +13,7 @@ import type { Controller } from "../index"
  */
 export async function openWalkthrough(_controller: Controller, _request: EmptyRequest): Promise<Empty> {
 	try {
-		await vscode.commands.executeCommand("workbench.action.openWalkthrough", "saoudrizwan.claude-dev#ClineWalkthrough")
+		await vscode.commands.executeCommand("workbench.action.openWalkthrough", `saoudrizwan.${pkgName}#ClineWalkthrough`)
 		telemetryService.captureButtonClick("webview_openWalkthrough")
 		return Empty.create({})
 	} catch (error) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -35,6 +35,7 @@ import { focusChatInput, getContextForCommand } from "./hosts/vscode/commandUtil
 import { VscodeDiffViewProvider } from "./hosts/vscode/VscodeDiffViewProvider"
 import { VscodeWebviewProvider } from "./hosts/vscode/VscodeWebviewProvider"
 import { GitCommitGenerator } from "./integrations/git/commit-message-generator"
+import { getClineCommands } from "./registry"
 import { AuthService } from "./services/auth/AuthService"
 import { telemetryService } from "./services/telemetry"
 import { SharedUriHandler } from "./services/uri/SharedUriHandler"
@@ -70,8 +71,10 @@ export async function activate(context: vscode.ExtensionContext) {
 		}),
 	)
 
+	const commands = getClineCommands(context.extension.packageJSON.name)
+
 	context.subscriptions.push(
-		vscode.commands.registerCommand("cline.plusButtonClicked", async (webview: any) => {
+		vscode.commands.registerCommand(commands.PlusButton, async (webview: any) => {
 			console.log("[DEBUG] plusButtonClicked", webview)
 			// Pass the webview type to the event sender
 			const isSidebar = !webview
@@ -98,7 +101,7 @@ export async function activate(context: vscode.ExtensionContext) {
 	)
 
 	context.subscriptions.push(
-		vscode.commands.registerCommand("cline.mcpButtonClicked", (webview: any) => {
+		vscode.commands.registerCommand(commands.McpButton, (webview: any) => {
 			console.log("[DEBUG] mcpButtonClicked", webview)
 
 			const activeInstance = WebviewProvider.getActiveInstance()
@@ -156,11 +159,11 @@ export async function activate(context: vscode.ExtensionContext) {
 		return tabWebview
 	}
 
-	context.subscriptions.push(vscode.commands.registerCommand("cline.popoutButtonClicked", openClineInNewTab))
-	context.subscriptions.push(vscode.commands.registerCommand("cline.openInNewTab", openClineInNewTab))
+	context.subscriptions.push(vscode.commands.registerCommand(commands.PopoutButton, openClineInNewTab))
+	context.subscriptions.push(vscode.commands.registerCommand(commands.OpenInNewTab, openClineInNewTab))
 
 	context.subscriptions.push(
-		vscode.commands.registerCommand("cline.settingsButtonClicked", (webview: any) => {
+		vscode.commands.registerCommand(commands.SettingsButton, (webview: any) => {
 			const isSidebar = !webview
 			const webviewType = isSidebar ? WebviewProviderTypeEnum.SIDEBAR : WebviewProviderTypeEnum.TAB
 
@@ -169,7 +172,7 @@ export async function activate(context: vscode.ExtensionContext) {
 	)
 
 	context.subscriptions.push(
-		vscode.commands.registerCommand("cline.historyButtonClicked", async (webview: any) => {
+		vscode.commands.registerCommand(commands.HistoryButton, async (webview: any) => {
 			console.log("[DEBUG] historyButtonClicked", webview)
 			// Pass the webview type to the event sender
 			const isSidebar = !webview
@@ -181,7 +184,7 @@ export async function activate(context: vscode.ExtensionContext) {
 	)
 
 	context.subscriptions.push(
-		vscode.commands.registerCommand("cline.accountButtonClicked", (webview: any) => {
+		vscode.commands.registerCommand(commands.AccountButton, (webview: any) => {
 			console.log("[DEBUG] accountButtonClicked", webview)
 
 			const isSidebar = !webview
@@ -244,7 +247,7 @@ export async function activate(context: vscode.ExtensionContext) {
 	}
 
 	context.subscriptions.push(
-		vscode.commands.registerCommand("cline.addTerminalOutputToChat", async () => {
+		vscode.commands.registerCommand(commands.TerminalOutput, async () => {
 			const terminal = vscode.window.activeTerminal
 			if (!terminal) {
 				return
@@ -385,7 +388,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
 	// Register the command handlers
 	context.subscriptions.push(
-		vscode.commands.registerCommand("cline.addToChat", async (range?: vscode.Range, diagnostics?: vscode.Diagnostic[]) => {
+		vscode.commands.registerCommand(commands.AddToChat, async (range?: vscode.Range, diagnostics?: vscode.Diagnostic[]) => {
 			const context = await getContextForCommand(range, diagnostics)
 			if (!context) {
 				return
@@ -394,7 +397,7 @@ export async function activate(context: vscode.ExtensionContext) {
 		}),
 	)
 	context.subscriptions.push(
-		vscode.commands.registerCommand("cline.fixWithCline", async (range: vscode.Range, diagnostics: vscode.Diagnostic[]) => {
+		vscode.commands.registerCommand(commands.FixWithCline, async (range: vscode.Range, diagnostics: vscode.Diagnostic[]) => {
 			const context = await getContextForCommand(range, diagnostics)
 			if (!context) {
 				return
@@ -403,7 +406,7 @@ export async function activate(context: vscode.ExtensionContext) {
 		}),
 	)
 	context.subscriptions.push(
-		vscode.commands.registerCommand("cline.explainCode", async (range: vscode.Range) => {
+		vscode.commands.registerCommand(commands.ExplainCode, async (range: vscode.Range) => {
 			const context = await getContextForCommand(range)
 			if (!context) {
 				return
@@ -412,7 +415,7 @@ export async function activate(context: vscode.ExtensionContext) {
 		}),
 	)
 	context.subscriptions.push(
-		vscode.commands.registerCommand("cline.improveCode", async (range: vscode.Range) => {
+		vscode.commands.registerCommand(commands.ImproveCode, async (range: vscode.Range) => {
 			const context = await getContextForCommand(range)
 			if (!context) {
 				return
@@ -423,7 +426,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
 	// Register the focusChatInput command handler
 	context.subscriptions.push(
-		vscode.commands.registerCommand("cline.focusChatInput", async () => {
+		vscode.commands.registerCommand(commands.FocusChatInput, async () => {
 			// Fast path: check for existing active instance
 			let activeWebview = WebviewProvider.getLastActiveInstance() as VscodeWebviewProvider
 
@@ -477,7 +480,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
 	// Register the openWalkthrough command handler
 	context.subscriptions.push(
-		vscode.commands.registerCommand("cline.openWalkthrough", async () => {
+		vscode.commands.registerCommand(commands.Walkthrough, async () => {
 			await vscode.commands.executeCommand("workbench.action.openWalkthrough", `${context.extension.id}#ClineWalkthrough`)
 			telemetryService.captureButtonClick("command_openWalkthrough")
 		}),
@@ -485,10 +488,10 @@ export async function activate(context: vscode.ExtensionContext) {
 
 	// Register the generateGitCommitMessage command handler
 	context.subscriptions.push(
-		vscode.commands.registerCommand("cline.generateGitCommitMessage", async (scm) => {
+		vscode.commands.registerCommand(commands.GenerateCommit, async (scm) => {
 			await GitCommitGenerator?.generate?.(context, scm)
 		}),
-		vscode.commands.registerCommand("cline.abortGitCommitMessage", () => {
+		vscode.commands.registerCommand(commands.AbortCommit, () => {
 			GitCommitGenerator?.abort?.()
 		}),
 	)

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -478,7 +478,7 @@ export async function activate(context: vscode.ExtensionContext) {
 	// Register the openWalkthrough command handler
 	context.subscriptions.push(
 		vscode.commands.registerCommand("cline.openWalkthrough", async () => {
-			await vscode.commands.executeCommand("workbench.action.openWalkthrough", "saoudrizwan.claude-dev#ClineWalkthrough")
+			await vscode.commands.executeCommand("workbench.action.openWalkthrough", `${context.extension.id}#ClineWalkthrough`)
 			telemetryService.captureButtonClick("command_openWalkthrough")
 		}),
 	)
@@ -524,7 +524,7 @@ function setupHostProvider(context: ExtensionContext) {
 	const outputChannel = vscode.window.createOutputChannel("Cline")
 	context.subscriptions.push(outputChannel)
 
-	const getCallbackUri = async () => `${vscode.env.uriScheme || "vscode"}://saoudrizwan.claude-dev`
+	const getCallbackUri = async () => `${vscode.env.uriScheme || "vscode"}://${context.extension.id}`
 	HostProvider.initialize(
 		createWebview,
 		createDiffView,

--- a/src/hosts/vscode/VscodeWebviewProvider.ts
+++ b/src/hosts/vscode/VscodeWebviewProvider.ts
@@ -7,6 +7,7 @@ import { HostProvider } from "@/hosts/host-provider"
 import type { ExtensionMessage } from "@/shared/ExtensionMessage"
 import { WebviewMessage } from "@/shared/WebviewMessage"
 import type { WebviewProviderType } from "@/shared/webview/types"
+import { name as pkgName } from "../../../package.json"
 
 /*
 https://github.com/microsoft/vscode-webview-ui-toolkit-samples/blob/main/default/weather-webview/src/providers/WeatherViewProvider.ts
@@ -16,8 +17,8 @@ https://github.com/KumarVariable/vscode-extension-sidebar-html/blob/master/src/c
 export class VscodeWebviewProvider extends WebviewProvider implements vscode.WebviewViewProvider {
 	// Used in package.json as the view's id. This value cannot be changed due to how vscode caches
 	// views based on their id, and updating the id would break existing instances of the extension.
-	public static readonly SIDEBAR_ID = "claude-dev.SidebarProvider"
-	public static readonly TAB_PANEL_ID = "claude-dev.TabPanelProvider"
+	public static readonly SIDEBAR_ID = `${pkgName}.SidebarProvider`
+	public static readonly TAB_PANEL_ID = `${pkgName}.TabPanelProvider`
 
 	private webview?: vscode.WebviewView | vscode.WebviewPanel
 	private disposables: vscode.Disposable[] = []

--- a/src/hosts/vscode/hostbridge/workspace/openClineSidebarPanel.ts
+++ b/src/hosts/vscode/hostbridge/workspace/openClineSidebarPanel.ts
@@ -1,7 +1,8 @@
 import * as vscode from "vscode"
 import { OpenClineSidebarPanelRequest, OpenClineSidebarPanelResponse } from "@/shared/proto/index.host"
+import { name as pkgName } from "../../../../../package.json"
 
 export async function openClineSidebarPanel(_: OpenClineSidebarPanelRequest): Promise<OpenClineSidebarPanelResponse> {
-	await vscode.commands.executeCommand("claude-dev.SidebarProvider.focus")
+	await vscode.commands.executeCommand(`${pkgName}.SidebarProvider.focus`)
 	return {}
 }

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -1,0 +1,25 @@
+/**
+ * Generate and export command identifiers based on the extension name.
+ * This allows for flexibility if the extension is published with a different name.
+ */
+export function getClineCommands(extensionName: string) {
+	const prefix = extensionName === "claude-dev" ? "cline" : extensionName
+	return {
+		PlusButton: prefix + ".plusButtonClicked",
+		McpButton: prefix + ".mcpButtonClicked",
+		PopoutButton: prefix + ".popoutButtonClicked",
+		OpenInNewTab: prefix + ".openInNewTab",
+		SettingsButton: prefix + ".settingsButtonClicked",
+		HistoryButton: prefix + ".historyButtonClicked",
+		AccountButton: prefix + ".accountButtonClicked",
+		TerminalOutput: prefix + ".addTerminalOutputToChat",
+		AddToChat: prefix + ".addToChat",
+		FixWithCline: prefix + ".fixWithCline",
+		ExplainCode: prefix + ".explainCode",
+		ImproveCode: prefix + ".improveCode",
+		FocusChatInput: prefix + ".focusChatInput",
+		Walkthrough: prefix + ".openWalkthrough",
+		GenerateCommit: prefix + ".generateGitCommitMessage",
+		AbortCommit: prefix + ".abortGitCommitMessage",
+	}
+}

--- a/src/services/test/TestServer.ts
+++ b/src/services/test/TestServer.ts
@@ -10,6 +10,7 @@ import * as path from "path"
 import * as vscode from "vscode"
 import { Controller } from "@/core/controller"
 import { getCwd } from "@/utils/path"
+import { name as pkgName } from "../../../package.json"
 import { calculateToolSuccessRate, getFileChanges, initializeGitRepository, validateWorkspacePath } from "./GitHelper"
 
 /**
@@ -87,10 +88,10 @@ async function updateAutoApprovalSettings(_context: vscode.ExtensionContext, con
 export function createTestServer(controller: Controller): http.Server {
 	// Try to show the Cline sidebar
 	Logger.log("[createTestServer] Opening Cline in sidebar...")
-	vscode.commands.executeCommand("workbench.view.claude-dev-ActivityBar")
+	vscode.commands.executeCommand(`workbench.view.${pkgName}-ActivityBar`)
 
 	// Then ensure the webview is focused/loaded
-	vscode.commands.executeCommand("claude-dev.SidebarProvider.focus")
+	vscode.commands.executeCommand(`${pkgName}.SidebarProvider.focus`)
 
 	// Update auto approval settings is available
 	updateAutoApprovalSettings(controller.context, controller)

--- a/src/shared/ExtensionMessage.ts
+++ b/src/shared/ExtensionMessage.ts
@@ -71,6 +71,7 @@ export interface ExtensionState {
 	focusChainSettings: FocusChainSettings
 	focusChainFeatureFlagEnabled?: boolean
 	customPrompt?: string
+	extensionInfo: { name: string; publisher: string }
 }
 
 export interface ClineMessage {

--- a/src/standalone/vscode-context.ts
+++ b/src/standalone/vscode-context.ts
@@ -7,8 +7,8 @@ import { URI } from "vscode-uri"
 import { log } from "./utils"
 import { EnvironmentVariableCollection, MementoStore, readJson, SecretStore } from "./vscode-context-utils"
 
-export const VERSION = getPackageVersion()
-log("Running standalone cline", VERSION)
+export const { version, name, publisher } = getPackageInfo()
+log("Running standalone cline", version)
 
 export const CLINE_DIR = process.env.CLINE_DIR || `${os.homedir()}/.cline`
 const DATA_DIR = path.join(CLINE_DIR, "data")
@@ -21,7 +21,7 @@ const EXTENSION_DIR = path.join(INSTALL_DIR, "extension")
 const EXTENSION_MODE = process.env.IS_DEV === "true" ? ExtensionMode.Development : ExtensionMode.Production
 
 const extension: Extension<void> = {
-	id: "saoudrizwan.claude-dev",
+	id: `${publisher}.${name}`,
 	isActive: true,
 	extensionPath: EXTENSION_DIR,
 	extensionUri: URI.file(EXTENSION_DIR),
@@ -60,9 +60,9 @@ const extensionContext: ExtensionContext = {
 	workspaceState: new MementoStore(path.join(DATA_DIR, "workspaceState.json")),
 }
 
-function getPackageVersion(): string {
+function getPackageInfo() {
 	const packageJson = JSON.parse(readFileSync(join(__dirname, "package.json"), "utf8"))
-	return packageJson.version
+	return { version: packageJson.version, name: packageJson.name, publisher: packageJson.publisher }
 }
 
 console.log("Finished loading vscode context...")

--- a/webview-ui/src/components/chat/CreditLimitError.tsx
+++ b/webview-ui/src/components/chat/CreditLimitError.tsx
@@ -21,7 +21,7 @@ const CreditLimitError: React.FC<CreditLimitErrorProps> = ({
 	message = "You have run out of credits.",
 	// buyCreditsUrl = "https://app.cline.bot/dashboard/account?tab=credits&redirect=true",
 }) => {
-	const { uriScheme } = useExtensionState()
+	const { uriScheme, extensionInfo } = useExtensionState()
 	const { activeOrganization } = useClineAuth()
 
 	const isPersonal = !activeOrganization?.organizationId
@@ -29,7 +29,7 @@ const CreditLimitError: React.FC<CreditLimitErrorProps> = ({
 		? "https://app.cline.bot/dashboard/account?tab=credits&redirect=true"
 		: "https://app.cline.bot/dashboard/organization?tab=credits&redirect=true"
 
-	const callbackUrl = `${uriScheme || "vscode"}://saoudrizwan.claude-dev`
+	const callbackUrl = `${uriScheme || "vscode"}://${extensionInfo.publisher}.${extensionInfo.name}`
 	const fullPurchaseUrl = new URL(buyCreditsUrl)
 	fullPurchaseUrl.searchParams.set("callback_url", callbackUrl)
 

--- a/webview-ui/src/context/ExtensionStateContext.tsx
+++ b/webview-ui/src/context/ExtensionStateContext.tsx
@@ -206,6 +206,7 @@ export const ExtensionStateContextProvider: React.FC<{
 		strictPlanModeEnabled: false,
 		customPrompt: undefined,
 		useAutoCondense: false,
+		extensionInfo: { name: "claude-dev", publisher: "saoudrizwan" },
 	})
 	const [didHydrateState, setDidHydrateState] = useState(false)
 	const [showWelcome, setShowWelcome] = useState(false)


### PR DESCRIPTION
<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- For feature requests: Created a discussion in our Feature Requests discussions board https://github.com/cline/cline/discussions/categories/feature-requests and received approval from core maintainers before implementation
- For all changes: Link the associated issue/discussion in the "Related Issue" section below

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly without prior discussion.

Why this requirement?
We deeply appreciate all community contributions - they are essential to Cline's success! To ensure the best use of everyone's time and maintain project direction, we use our Feature Requests discussions board to gauge community interest and validate feature ideas before implementation begins. This helps us focus development efforts on features that will benefit the most users.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** #XXXX

### Description

<!-- 
Help reviewers understand your changes by making this PR readable and well-organized:

- What problem does this PR solve?
- Why were these changes introduced and what purpose do they serve?
- For larger changes, provide context about your approach and reasoning

Small PRs may need minimal description, but larger changes benefit from explaining where you're coming from. Much of this context can be in the linked issue above, so feel free to reference it rather than repeating everything here.
-->

Fix issue with nightly build using the extension name registered for stable:

Replace hardcoded "saoudrizwan.claude-dev" and "claude-dev" strings with dynamically imported package name and publisher from package.json across extension activation, webview providers, commands, and test services.

### Test Procedure

<!-- 
Please walk us through your testing approach and thought process. This helps reviewers understand that you've thoroughly considered the impact of your changes:

- How did you test this change?
- What could potentially break and how did you verify it doesn't?
- What existing functionality might be affected and how did you check it still works?
- Why are you confident this is ready for merge?

We're not looking for exhaustive documentation - just evidence that you've thought through the implications of your changes and tested accordingly.
-->


1. Remove the Cline (Nightly) build if you have it installed
2. Restart IDE
4. Run `npm run publish:marketplace:nightly -- --dry-run`
5. Install `dist/cline-nightly.vsix` that should open the right auth link when signing into Cline provider

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [x] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Replace hardcoded extension identifiers with dynamic values from `package.json` across the codebase for flexibility in publishing.
> 
>   - **Behavior**:
>     - Replace hardcoded identifiers "saoudrizwan.claude-dev" and "claude-dev" with dynamic values from `package.json` in `scripts/publish-nightly.mjs` and `src/core/controller/index.ts`.
>     - Update command registration in `src/extension.ts` to use dynamic command identifiers from `getClineCommands()`.
>     - Modify `openWalkthrough()` in `src/core/controller/ui/openWalkthrough.ts` to use dynamic walkthrough identifiers.
>   - **Webview Providers**:
>     - Update `VscodeWebviewProvider` in `src/hosts/vscode/VscodeWebviewProvider.ts` to use dynamic sidebar and tab panel IDs.
>     - Change `openClineSidebarPanel()` in `src/hosts/vscode/hostbridge/workspace/openClineSidebarPanel.ts` to use dynamic focus command.
>   - **Test Services**:
>     - Modify `createTestServer()` in `src/services/test/TestServer.ts` to use dynamic sidebar focus command.
>   - **State Management**:
>     - Add `extensionInfo` to `ExtensionState` in `src/shared/ExtensionMessage.ts` to store dynamic name and publisher.
>     - Update `ExtensionStateContextProvider` in `webview-ui/src/context/ExtensionStateContext.tsx` to initialize `extensionInfo` with dynamic values.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for a55b09211c160fcb891770b575d24edd7d436e0d. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->