### PR TITLE
Fix broken link in docs to Cline tools implementation

### DIFF
--- a/docs/exploring-clines-tools/cline-tools-guide.mdx
+++ b/docs/exploring-clines-tools/cline-tools-guide.mdx
@@ -56,7 +56,7 @@ Cline is your AI assistant that can:
 
 ## Available Tools
 
-For the most up-to-date implementation details, you can view the full source code in the [Cline repository](https://github.com/cline/cline/blob/main/src/core/Cline.ts).
+For the most up-to-date implementation details, you can view the full source code in the [Cline repository](https://github.com/cline/cline/blob/main/src/core/prompts/system-prompt/tools).
 
 Cline has access to the following tools for various tasks:
 


### PR DESCRIPTION
### Related Issue

**Issue:** Fixing broken link to the tools implementation in the [Cline Tools Reference Guide](https://docs.cline.bot/exploring-clines-tools/cline-tools-guide).

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [x] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots
Doesn't seem necessary, there won't be any visual change.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix broken link in `cline-tools-guide.mdx` to point to the correct tools directory.
> 
>   - **Documentation**:
>     - Fix broken link in `cline-tools-guide.mdx` to point to `src/core/prompts/system-prompt/tools` instead of `src/core/Cline.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for aa11d4a1446d0d106fa6edb82933d20959c2430a. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->