### PR TITLE
Remove uses of the VSCode API

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -225,7 +225,8 @@ export async function activate(context: vscode.ExtensionContext) {
 	context.subscriptions.push(vscode.workspace.registerTextDocumentContentProvider(DIFF_VIEW_URI_SCHEME, diffContentProvider))
 
 	const handleUri = async (uri: vscode.Uri) => {
-		const success = await SharedUriHandler.handleUri(uri)
+		const url = decodeURIComponent(uri.toString())
+		const success = await SharedUriHandler.handleUri(url)
 		if (!success) {
 			console.warn("Extension URI handler: Failed to process URI:", uri.toString())
 		}

--- a/src/hosts/external/AuthHandler.ts
+++ b/src/hosts/external/AuthHandler.ts
@@ -159,10 +159,9 @@ export class AuthHandler {
 		try {
 			// Convert HTTP URL to vscode.Uri and use shared handler directly
 			const fullUrl = `http://127.0.0.1:${this.port}${req.url}`
-			const uri = SharedUriHandler.convertHttpUrlToUri(fullUrl)
 
 			// Use SharedUriHandler directly - it handles all validation and processing
-			const success = await SharedUriHandler.handleUri(uri)
+			const success = await SharedUriHandler.handleUri(fullUrl)
 
 			if (success) {
 				this.sendResponse(res, 200, "text/html", TOKEN_REQUEST_VIEW)

--- a/src/services/uri/SharedUriHandler.test.ts
+++ b/src/services/uri/SharedUriHandler.test.ts
@@ -1,0 +1,151 @@
+import { expect } from "chai"
+import { afterEach, beforeEach, describe, it } from "mocha"
+import * as sinon from "sinon"
+import { WebviewProvider } from "@/core/webview"
+import { SharedUriHandler } from "./SharedUriHandler"
+
+describe("SharedUriHandler", () => {
+	let sandbox: sinon.SinonSandbox
+	let handleOpenRouterCallbackStub: sinon.SinonStub
+	let handleAuthCallbackStub: sinon.SinonStub
+
+	beforeEach(() => {
+		sandbox = sinon.createSandbox()
+
+		handleOpenRouterCallbackStub = sandbox.stub().resolves()
+		handleAuthCallbackStub = sandbox.stub().resolves()
+		const mockWebviewProvider = {
+			controller: {
+				handleOpenRouterCallback: handleOpenRouterCallbackStub,
+				handleAuthCallback: handleAuthCallbackStub,
+			},
+		} as any
+		sandbox.stub(WebviewProvider, "getVisibleInstance").returns(mockWebviewProvider)
+	})
+
+	afterEach(() => {
+		sandbox.restore()
+	})
+
+	describe("handleUri", () => {
+		describe("OpenRouter callback handling", () => {
+			it("should successfully handle OpenRouter callback with code", async () => {
+				const result = await SharedUriHandler.handleUri("vscode://cline.cline/openrouter?code=test123")
+
+				expect(result).to.be.true
+				sinon.assert.calledOnceWithExactly(handleOpenRouterCallbackStub, "test123")
+			})
+
+			it("should return false when OpenRouter code is missing", async () => {
+				const result = await SharedUriHandler.handleUri("vscode://cline.cline/openrouter")
+
+				expect(result).to.be.false
+				expect(handleOpenRouterCallbackStub.called).to.be.false
+			})
+
+			it("should handle URL with plus signs in code parameter", async () => {
+				const result = await SharedUriHandler.handleUri("vscode://cline.cline/openrouter?code=test+123+abc")
+
+				expect(result).to.be.true
+				// Plus signs in query params are preserved
+				sinon.assert.calledOnceWithExactly(handleOpenRouterCallbackStub, "test+123+abc")
+			})
+		})
+
+		describe("Auth callback handling", () => {
+			it("should successfully handle auth callback with idToken", async () => {
+				const result = await SharedUriHandler.handleUri("vscode://cline.cline/auth?idToken=jwt123&provider=google")
+
+				expect(result).to.be.true
+				sinon.assert.calledOnceWithExactly(handleAuthCallbackStub, "jwt123", "google")
+			})
+
+			it("should successfully handle auth callback without provider", async () => {
+				const result = await SharedUriHandler.handleUri("vscode://cline.cline/auth?idToken=jwt123")
+
+				expect(result).to.be.true
+				sinon.assert.calledOnceWithExactly(handleAuthCallbackStub, "jwt123", null)
+			})
+
+			it("should return false when idToken is missing", async () => {
+				const result = await SharedUriHandler.handleUri("vscode://cline.cline/auth?provider=google")
+
+				expect(result).to.be.false
+				expect(handleAuthCallbackStub.called).to.be.false
+			})
+		})
+
+		describe("Unknown path handling", () => {
+			it("should return false for unknown paths", async () => {
+				const result = await SharedUriHandler.handleUri("vscode://cline.cline/unknown?param=value")
+
+				expect(result).to.be.false
+				expect(handleAuthCallbackStub.called).to.be.false
+				expect(handleOpenRouterCallbackStub.called).to.be.false
+			})
+		})
+
+		describe("Error handling", () => {
+			it("should catch and log errors from controller methods", async () => {
+				handleOpenRouterCallbackStub.rejects(new Error("Controller error"))
+
+				const result = await SharedUriHandler.handleUri("vscode://cline.cline/openrouter?code=test123")
+
+				expect(result).to.be.false
+			})
+
+			it("should handle malformed URIs gracefully", async () => {
+				const result = await SharedUriHandler.handleUri("invalid://uri")
+
+				expect(result).to.be.false
+				expect(handleAuthCallbackStub.called).to.be.false
+				expect(handleOpenRouterCallbackStub.called).to.be.false
+			})
+		})
+
+		describe("Query parameter parsing", () => {
+			it("should correctly parse multiple query parameters", async () => {
+				const result = await SharedUriHandler.handleUri(
+					"vscode://cline.cline/auth?idToken=jwt123&provider=github&extra=param",
+				)
+
+				expect(result).to.be.true
+				sinon.assert.calledOnceWithExactly(handleAuthCallbackStub, "jwt123", "github")
+			})
+
+			it("should handle URL-encoded parameters", async () => {
+				const result = await SharedUriHandler.handleUri(
+					"vscode://cline.cline/auth?idToken=jwt%20with%20spaces&provider=google",
+				)
+
+				expect(result).to.be.true
+				// URLSearchParams should decode %20 to spaces
+				sinon.assert.calledOnceWithExactly(handleAuthCallbackStub, "jwt with spaces", "google")
+			})
+
+			it("should handle empty query string", async () => {
+				const result = await SharedUriHandler.handleUri("vscode://cline.cline/openrouter")
+
+				expect(result).to.be.false
+				expect(handleAuthCallbackStub.called).to.be.false
+				expect(handleOpenRouterCallbackStub.called).to.be.false
+			})
+		})
+
+		describe("Different URI schemes", () => {
+			it("should handle HTTP scheme URIs", async () => {
+				const result = await SharedUriHandler.handleUri("http://localhost:3000/openrouter?code=test123")
+
+				expect(result).to.be.true
+				sinon.assert.calledOnceWithExactly(handleOpenRouterCallbackStub, "test123")
+			})
+
+			it("should handle HTTPS scheme URIs", async () => {
+				const result = await SharedUriHandler.handleUri("https://example.com/auth?idToken=jwt123&provider=github")
+
+				expect(result).to.be.true
+				sinon.assert.calledOnceWithExactly(handleAuthCallbackStub, "jwt123", "github")
+			})
+		})
+	})
+})


### PR DESCRIPTION
Replace vscode.Uri with a string URL param. Use standard JS functions `URL` and `URLSearchParams` instead of vscode.Uri.parse

Add tests for the SharedUriHandler.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Remove `vscode.Uri` usage by switching to standard JavaScript URL handling and add tests for `SharedUriHandler`.
> 
>   - **Behavior**:
>     - Replace `vscode.Uri` with string URL parameter in `handleUri` in `SharedUriHandler.ts`.
>     - Use `URL` and `URLSearchParams` for URI parsing instead of `vscode.Uri.parse`.
>     - Update `handleUri` function in `extension.ts` and `AuthHandler.ts` to use string URLs.
>   - **Tests**:
>     - Add `SharedUriHandler.test.ts` to test `handleUri` with various URI schemes and parameters.
>     - Test cases include handling of `OpenRouter` and `Auth` callbacks, unknown paths, and error scenarios.
>   - **Misc**:
>     - Remove `convertHttpUrlToUri` function from `SharedUriHandler.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 31c00722f71f1da4614fbd69bc73f3ad43ad5755. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->