### PR TITLE
Add a configuration for the toggle plan/act mode keyboard shortcut.

### DIFF
--- a/webview-ui/src/components/chat/ChatTextArea.tsx
+++ b/webview-ui/src/components/chat/ChatTextArea.tsx
@@ -20,6 +20,7 @@ import Tooltip from "@/components/common/Tooltip"
 import ApiOptions from "@/components/settings/ApiOptions"
 import { getModeSpecificFields, normalizeApiConfiguration } from "@/components/settings/utils/providerUtils"
 import { useExtensionState } from "@/context/ExtensionStateContext"
+import { usePlatform } from "@/context/PlatformContext"
 import { FileServiceClient, ModelsServiceClient, StateServiceClient } from "@/services/grpc-client"
 import {
 	ContextMenuOptionType,
@@ -1072,7 +1073,7 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 			}, changeModeDelay)
 		}, [mode, showModelSelector, submitApiConfig, inputValue, selectedImages, selectedFiles])
 
-		useShortcut("Meta+Shift+a", onModeToggle, { disableTextInputs: false }) // important that we don't disable the text input here
+		useShortcut(usePlatform().togglePlanActKeys, onModeToggle, { disableTextInputs: false }) // important that we don't disable the text input here
 
 		const handleContextButtonClick = useCallback(() => {
 			// Focus the textarea first
@@ -1422,6 +1423,10 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 				),
 			)
 		}
+		// Replace Meta with the platform specific key and uppercase the command letter.
+		const togglePlanActKeys = usePlatform()
+			.togglePlanActKeys.replace("Meta", metaKeyChar)
+			.replace(/.$/, (match) => match.toUpperCase())
 
 		return (
 			<div>
@@ -1784,7 +1789,7 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 					</div>
 					{/* Tooltip for Plan/Act toggle remains outside the conditional rendering */}
 					<Tooltip
-						hintText={`Toggle w/ ${metaKeyChar}+Shift+A`}
+						hintText={`Toggle w/ ${togglePlanActKeys}`}
 						style={{ zIndex: 1000 }}
 						tipText={`In ${shownTooltipMode === "act" ? "Act" : "Plan"}  mode, Cline will ${shownTooltipMode === "act" ? "complete the task immediately" : "gather information to architect a plan"}`}
 						visible={shownTooltipMode !== null}>

--- a/webview-ui/src/config/platform-configs.json
+++ b/webview-ui/src/config/platform-configs.json
@@ -2,11 +2,13 @@
 	"vscode": {
 		"messageEncoding": "none",
 		"showNavbar": false,
-		"postMessageHandler": "vscode"
+		"postMessageHandler": "vscode",
+		"togglePlanActKeys": "Meta+Shift+a"
 	},
 	"standalone": {
 		"messageEncoding": "json",
 		"showNavbar": true,
-		"postMessageHandler": "standalone"
+		"postMessageHandler": "standalone",
+		"togglePlanActKeys": "Meta+Shift+p"
 	}
 }

--- a/webview-ui/src/config/platform.config.ts
+++ b/webview-ui/src/config/platform.config.ts
@@ -6,6 +6,7 @@ export interface PlatformConfig {
 	postMessage: PostMessageFunction
 	encodeMessage: MessageEncoder
 	decodeMessage: MessageDecoder
+	togglePlanActKeys: string
 }
 
 // Internal type for JSON structure (not exported)
@@ -13,6 +14,7 @@ type PlatformConfigJson = {
 	messageEncoding: "none" | "json"
 	showNavbar: boolean
 	postMessageHandler: "vscode" | "standalone"
+	togglePlanActKeys: string
 }
 
 type PlatformConfigs = Record<string, PlatformConfigJson>
@@ -78,6 +80,7 @@ export const PLATFORM_CONFIG: PlatformConfig = {
 	postMessage: postMessageStrategies[selectedConfig.postMessageHandler],
 	encodeMessage: messageEncoders[selectedConfig.messageEncoding],
 	decodeMessage: messageDecoders[selectedConfig.messageEncoding],
+	togglePlanActKeys: selectedConfig.togglePlanActKeys,
 }
 
 type MessageEncoding = "none" | "json"

--- a/webview-ui/src/context/PlatformContext.tsx
+++ b/webview-ui/src/context/PlatformContext.tsx
@@ -13,5 +13,4 @@ export const usePlatform = () => {
 }
 
 // Optional convenience hooks for individual config values
-export const useMessageEncoding = () => usePlatform().messageEncoding
 export const useShowNavbar = () => usePlatform().showNavbar


### PR DESCRIPTION
JetBrains already uses cmd-shift-p, so cmd-shift-a instead. Add a new field to the platform specific config for the keyboard shortcut.

fixes FDN-3

