### PR TITLE
Make the Terminal entry in the @mentions configurable

### DIFF
--- a/webview-ui/src/config/platform-configs.json
+++ b/webview-ui/src/config/platform-configs.json
@@ -3,12 +3,14 @@
 		"messageEncoding": "none",
 		"showNavbar": false,
 		"postMessageHandler": "vscode",
-		"togglePlanActKeys": "Meta+Shift+a"
+		"togglePlanActKeys": "Meta+Shift+a",
+        "supportsTerminalMentions": true
 	},
 	"standalone": {
 		"messageEncoding": "json",
 		"showNavbar": true,
 		"postMessageHandler": "standalone",
-		"togglePlanActKeys": "Meta+Shift+p"
+		"togglePlanActKeys": "Meta+Shift+p",
+        "supportsTerminalMentions": false
 	}
 }

--- a/webview-ui/src/config/platform.config.ts
+++ b/webview-ui/src/config/platform.config.ts
@@ -7,6 +7,7 @@ export interface PlatformConfig {
 	encodeMessage: MessageEncoder
 	decodeMessage: MessageDecoder
 	togglePlanActKeys: string
+	supportsTerminalMentions: boolean
 }
 
 // Internal type for JSON structure (not exported)
@@ -15,6 +16,7 @@ type PlatformConfigJson = {
 	showNavbar: boolean
 	postMessageHandler: "vscode" | "standalone"
 	togglePlanActKeys: string
+	supportsTerminalMentions: boolean
 }
 
 type PlatformConfigs = Record<string, PlatformConfigJson>
@@ -81,6 +83,7 @@ export const PLATFORM_CONFIG: PlatformConfig = {
 	encodeMessage: messageEncoders[selectedConfig.messageEncoding],
 	decodeMessage: messageDecoders[selectedConfig.messageEncoding],
 	togglePlanActKeys: selectedConfig.togglePlanActKeys,
+	supportsTerminalMentions: selectedConfig.supportsTerminalMentions,
 }
 
 type MessageEncoding = "none" | "json"

--- a/webview-ui/src/utils/context-mentions.ts
+++ b/webview-ui/src/utils/context-mentions.ts
@@ -1,6 +1,7 @@
 import { mentionRegex } from "@shared/context-mentions"
 import { Fzf } from "fzf"
 import * as path from "path"
+import { PLATFORM_CONFIG } from "@/config/platform.config"
 
 export interface SearchResult {
 	path: string
@@ -96,17 +97,22 @@ export interface ContextMenuQueryItem {
 	description?: string
 }
 
-const DEFAULT_CONTEXT_MENU_OPTIONS = [
-	ContextMenuOptionType.URL,
-	ContextMenuOptionType.Problems,
-	ContextMenuOptionType.Terminal,
-	ContextMenuOptionType.Git,
-	ContextMenuOptionType.Folder,
-	ContextMenuOptionType.File,
-]
+function getContextMenuEntries(): ContextMenuOptionType[] {
+	const entries = [
+		ContextMenuOptionType.URL,
+		ContextMenuOptionType.Problems,
+		ContextMenuOptionType.Git,
+		ContextMenuOptionType.Folder,
+		ContextMenuOptionType.File,
+	]
+	if (PLATFORM_CONFIG.supportsTerminalMentions) {
+		entries.splice(2, 0, ContextMenuOptionType.Terminal)
+	}
+	return entries
+}
 
 export function getContextMenuOptionIndex(option: ContextMenuOptionType) {
-	return DEFAULT_CONTEXT_MENU_OPTIONS.findIndex((item) => item === option)
+	return getContextMenuEntries().findIndex((item) => item === option)
 }
 
 export function getContextMenuOptions(
@@ -163,7 +169,7 @@ export function getContextMenuOptions(
 			return commits.length > 0 ? [workingChanges, ...commits] : [workingChanges]
 		}
 
-		return DEFAULT_CONTEXT_MENU_OPTIONS.map((type) => ({ type }))
+		return getContextMenuEntries().map((type) => ({ type }))
 	}
 
 	const lowerQuery = query.toLowerCase()


### PR DESCRIPTION
JetBrains doesn't support `@terminal` mentions, so don't show it in the mentions context menu.

fixes FDN-5
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds `supportsTerminalMentions` to platform configs to conditionally show `@terminal` mentions in context menu.
> 
>   - **Behavior**:
>     - Adds `supportsTerminalMentions` boolean to `platform-configs.json` to control `@terminal` mention visibility.
>     - `getContextMenuEntries()` in `context-mentions.ts` now conditionally includes `Terminal` based on `supportsTerminalMentions`.
>   - **Config**:
>     - Updates `PlatformConfig` and `PlatformConfigJson` interfaces in `platform.config.ts` to include `supportsTerminalMentions`.
>     - Modifies `PLATFORM_CONFIG` in `platform.config.ts` to use `supportsTerminalMentions` from selected platform config.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for d93aa8ba353de9af1f5bd9ee3149375aba385b49. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->