### PR TITLE
fix: leading slash missing in webview from files shown in chat window

### DIFF
--- a/webview-ui/src/components/chat/ChatRow.tsx
+++ b/webview-ui/src/components/chat/ChatRow.tsx
@@ -486,6 +486,7 @@ export const ChatRowContent = memo(
 										msUserSelect: isImage ? "text" : "none",
 									}}>
 									{tool.path?.startsWith(".") && <span>.</span>}
+									{tool.path && !tool.path.startsWith(".") && <span>/</span>}
 									<span
 										className="ph-no-capture"
 										style={{

--- a/webview-ui/src/components/common/CodeAccordian.tsx
+++ b/webview-ui/src/components/common/CodeAccordian.tsx
@@ -87,6 +87,7 @@ const CodeAccordian = ({
 					) : (
 						<>
 							{path?.startsWith(".") && <span>.</span>}
+							{path && !path.startsWith(".") && <span>/</span>}
 							<span
 								style={{
 									whiteSpace: "nowrap",


### PR DESCRIPTION
<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- For feature requests: Created a discussion in our Feature Requests discussions board https://github.com/cline/cline/discussions/categories/feature-requests and received approval from core maintainers before implementation
- For all changes: Link the associated issue/discussion in the "Related Issue" section below

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly without prior discussion.

Why this requirement?
We deeply appreciate all community contributions - they are essential to Cline's success! To ensure the best use of everyone's time and maintain project direction, we use our Feature Requests discussions board to gauge community interest and validate feature ideas before implementation begins. This helps us focus development efforts on features that will benefit the most users.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** #XXXX
In the webview the leading / is missing from file links

### Description
File paths in the webview were missing the leading '/' character
While ContextMenu.tsx correctly displayed leading slashes, ChatRow.tsx and CodeAccordian.tsx were missing this logic.

<!-- 
Help reviewers understand your changes by making this PR readable and well-organized:

- What problem does this PR solve?
- Why were these changes introduced and what purpose do they serve?
- For larger changes, provide context about your approach and reasoning

Small PRs may need minimal description, but larger changes benefit from explaining where you're coming from. Much of this context can be in the linked issue above, so feel free to reference it rather than repeating everything here.
-->

### Test Procedure

- creation: Ask Cline to "Create a new file at /src/test.js"
- reading: Ask Cline to "Read the file /package.json"
- Test relative paths: Ask Cline to "Read ./src/extension.ts"
Expected: All file paths should display with appropriate leading / or . prefixes

<!-- 
Please walk us through your testing approach and thought process. This helps reviewers understand that you've thoroughly considered the impact of your changes:

- How did you test this change?
- What could potentially break and how did you verify it doesn't?
- What existing functionality might be affected and how did you check it still works?
- Why are you confident this is ready for merge?

We're not looking for exhaustive documentation - just evidence that you've thought through the implications of your changes and tested accordingly.
-->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [x] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots
<img width="224" height="63" alt="Screenshot 2025-09-11 at 01 53 38" src="https://github.com/user-attachments/assets/101ad859-95a4-4a2f-8568-48c52957bb1c" />
<img width="234" height="69" alt="Screenshot 2025-09-11 at 01 53 53" src="https://github.com/user-attachments/assets/55bead03-fd19-400b-b55a-8c803106441d" />

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes missing leading slash in file paths in `ChatRow.tsx` and `CodeAccordian.tsx` for webview display.
> 
>   - **Behavior**:
>     - Fixes missing leading slash in file paths in `ChatRow.tsx` and `CodeAccordian.tsx`.
>     - Ensures paths not starting with '.' are prefixed with '/'.
>   - **Test Procedure**:
>     - Create a file at `/src/test.js` and read `/package.json`.
>     - Test relative paths like `./src/extension.ts`.
>     - Verify paths display with correct leading '/' or '.' prefixes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 629c3771fae68262df8e12342df404deed2194af. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->