### PR TITLE
Remove --no-stash flag from lint-staged in pre-commit hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,1 @@
-lint-staged --no-stash
+lint-staged


### PR DESCRIPTION


### Context

It's been sufficient time since the Prettier → Biome migration that all team members should have the proper tooling installed. The original workaround is no longer needed and is now causing more problems than it solves.

<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- For feature requests: Created a discussion in our Feature Requests discussions board https://github.com/cline/cline/discussions/categories/feature-requests and received approval from core maintainers before implementation
- For all changes: Link the associated issue/discussion in the "Related Issue" section below

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly without prior discussion.

Why this requirement?
We deeply appreciate all community contributions - they are essential to Cline's success! To ensure the best use of everyone's time and maintain project direction, we use our Feature Requests discussions board to gauge community interest and validate feature ideas before implementation begins. This helps us focus development efforts on features that will benefit the most users.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** #XXXX

### Description

<!-- 
Help reviewers understand your changes by making this PR readable and well-organized:

- What problem does this PR solve?
- Why were these changes introduced and what purpose do they serve?
- For larger changes, provide context about your approach and reasoning

Small PRs may need minimal description, but larger changes benefit from explaining where you're coming from. Much of this context can be in the linked issue above, so feel free to reference it rather than repeating everything here.
-->

#### Problem

The `--no-stash` flag was originally added to work around issues where teammates hadn't installed Biome after our migration from Prettier. When the formatter failed, lint-staged's default stashing behavior would remove staged changes, causing frustration.

However, this workaround now causes a different problem: lint-staged runs formatters on files containing both staged AND unstaged changes. When Biome formats these files, it inadvertently stages unstaged modifications, effectively merging work-in-progress changes into commits.

#### Solution

Remove the `--no-stash` flag to restore lint-staged's default behavior:

- Stash unstaged changes before running formatters
- Run formatters only on staged content
- Restore the stash after formatting

This ensures that only intentionally staged changes are included in commits, preventing accidental inclusion of work-in-progress modifications.

It also aligns with the pre-commit hook documented in https://biomejs.dev/recipes/git-hooks/#lint-staged

### Test Procedure

<!-- 
Please walk us through your testing approach and thought process. This helps reviewers understand that you've thoroughly considered the impact of your changes:

- How did you test this change?
- What could potentially break and how did you verify it doesn't?
- What existing functionality might be affected and how did you check it still works?
- Why are you confident this is ready for merge?

We're not looking for exhaustive documentation - just evidence that you've thought through the implications of your changes and tested accordingly.
-->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [x] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove `--no-stash` flag from `lint-staged` in `.husky/pre-commit` to prevent accidental inclusion of unstaged changes in commits.
> 
>   - **Behavior**:
>     - Remove `--no-stash` flag from `lint-staged` in `.husky/pre-commit` to restore default stashing behavior.
>     - Ensures only staged changes are formatted and committed, preventing accidental inclusion of unstaged changes.
>   - **Context**:
>     - Original workaround for Prettier to Biome migration is no longer needed and causes issues.
>     - Aligns with Biome's recommended pre-commit hook setup.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 8d162367ce3daf3c0defeb107ebc585af55c2565. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->