### PR TITLE
Don't show ESC on the Cancel button on JetBrains

### DIFF
--- a/webview-ui/src/components/chat/chat-view/shared/buttonConfig.ts
+++ b/webview-ui/src/components/chat/chat-view/shared/buttonConfig.ts
@@ -1,5 +1,6 @@
 import type { ClineMessage, ClineSayTool } from "@shared/ExtensionMessage"
 import type { Mode } from "@shared/storage/types"
+import { PLATFORM_CONFIG } from "@/config/platform.config"
 
 /**
  * Button action types that determine the behavior
@@ -183,7 +184,7 @@ export const BUTTON_CONFIGS: Record<string, ButtonConfig> = {
 		sendingDisabled: true,
 		enableButtons: true,
 		primaryText: undefined,
-		secondaryText: "Cancel (ESC)",
+		secondaryText: getCancelButtonText(),
 		primaryAction: undefined,
 		secondaryAction: "cancel",
 	},
@@ -201,10 +202,18 @@ export const BUTTON_CONFIGS: Record<string, ButtonConfig> = {
 		sendingDisabled: true,
 		enableButtons: true,
 		primaryText: undefined,
-		secondaryText: "Cancel (ESC)",
+		secondaryText: getCancelButtonText(),
 		primaryAction: undefined,
 		secondaryAction: "cancel",
 	},
+}
+
+function getCancelButtonText(): string {
+	var text = "Cancel"
+	if (PLATFORM_CONFIG.supportsEscShortcut) {
+		text += " (ESC)"
+	}
+	return text
 }
 
 const errorTypes = ["api_req_failed", "mistake_limit_reached", "auto_approval_max_req_reached"]

--- a/webview-ui/src/config/platform-configs.json
+++ b/webview-ui/src/config/platform-configs.json
@@ -4,13 +4,15 @@
 		"showNavbar": false,
 		"postMessageHandler": "vscode",
 		"togglePlanActKeys": "Meta+Shift+a",
-		"supportsTerminalMentions": true
+		"supportsTerminalMentions": true,
+		"supportsEscShortcut": true
 	},
 	"standalone": {
 		"messageEncoding": "json",
 		"showNavbar": true,
 		"postMessageHandler": "standalone",
 		"togglePlanActKeys": "Meta+Shift+p",
-		"supportsTerminalMentions": false
+		"supportsTerminalMentions": false,
+		"supportsEscShortcut": false
 	}
 }

--- a/webview-ui/src/config/platform.config.ts
+++ b/webview-ui/src/config/platform.config.ts
@@ -8,6 +8,7 @@ export interface PlatformConfig {
 	decodeMessage: MessageDecoder
 	togglePlanActKeys: string
 	supportsTerminalMentions: boolean
+	supportsEscShortcut: boolean
 }
 
 // Internal type for JSON structure (not exported)
@@ -17,6 +18,7 @@ type PlatformConfigJson = {
 	postMessageHandler: "vscode" | "standalone"
 	togglePlanActKeys: string
 	supportsTerminalMentions: boolean
+	supportsEscShortcut: boolean
 }
 
 type PlatformConfigs = Record<string, PlatformConfigJson>
@@ -84,6 +86,7 @@ export const PLATFORM_CONFIG: PlatformConfig = {
 	decodeMessage: messageDecoders[selectedConfig.messageEncoding],
 	togglePlanActKeys: selectedConfig.togglePlanActKeys,
 	supportsTerminalMentions: selectedConfig.supportsTerminalMentions,
+	supportsEscShortcut: selectedConfig.supportsEscShortcut,
 }
 
 type MessageEncoding = "none" | "json"


### PR DESCRIPTION
The ESC keyboard shortcut doesn't work on JetBrains because it is already being used by the IDE.

Fixes FDN-40
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Conditional ESC shortcut display on Cancel button based on platform support in `buttonConfig.ts` and platform configuration updates.
> 
>   - **Behavior**:
>     - `getCancelButtonText()` in `buttonConfig.ts` now checks `PLATFORM_CONFIG.supportsEscShortcut` to conditionally append "(ESC)" to the Cancel button text.
>     - Updates `BUTTON_CONFIGS` in `buttonConfig.ts` to use `getCancelButtonText()` for `secondaryText` in relevant button configurations.
>   - **Platform Configuration**:
>     - Adds `supportsEscShortcut` boolean to `platform-configs.json` for `vscode` and `standalone` platforms.
>     - Updates `PlatformConfig` and `PlatformConfigJson` interfaces in `platform.config.ts` to include `supportsEscShortcut`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 1d0e5f7505c11c803e710677a0e1b6658140993a. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->