### PR TITLE
fix standalone: isolate workspaceState per project via WORKSPACE_STORAGE_DIR

### DIFF
--- a/src/standalone/vscode-context.ts
+++ b/src/standalone/vscode-context.ts
@@ -13,13 +13,10 @@ log("Running standalone cline", version)
 export const CLINE_DIR = process.env.CLINE_DIR || `${os.homedir()}/.cline`
 const DATA_DIR = path.join(CLINE_DIR, "data")
 const INSTALL_DIR = process.env.INSTALL_DIR || __dirname
-const WORKSPACE_STORAGE_DIR = process.env.WORKSPACE_STORAGE_DIR || DATA_DIR
-
-try {
-	mkdirSync(WORKSPACE_STORAGE_DIR, { recursive: true })
-} catch {}
+const WORKSPACE_STORAGE_DIR = process.env.WORKSPACE_STORAGE_DIR || path.join(DATA_DIR, "workspace")
 
 mkdirSync(DATA_DIR, { recursive: true })
+mkdirSync(WORKSPACE_STORAGE_DIR, { recursive: true })
 log("Using settings dir:", DATA_DIR)
 
 const EXTENSION_DIR = path.join(INSTALL_DIR, "extension")
@@ -50,8 +47,9 @@ const extensionContext: ExtensionContext = {
 	globalStorageUri: URI.file(DATA_DIR),
 	globalStoragePath: DATA_DIR, // Deprecated, not used in cline.
 
-	logUri: URI.file(WORKSPACE_STORAGE_DIR),
-	logPath: WORKSPACE_STORAGE_DIR, // Deprecated, not used in cline.
+	// Logs are global per extension, not per workspace.
+	logUri: URI.file(DATA_DIR),
+	logPath: DATA_DIR, // Deprecated, not used in cline.
 
 	extensionUri: URI.file(EXTENSION_DIR),
 	extensionPath: EXTENSION_DIR, // Deprecated, not used in cline.


### PR DESCRIPTION
<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- For feature requests: Created a discussion in our Feature Requests discussions board https://github.com/cline/cline/discussions/categories/feature-requests and received approval from core maintainers before implementation
- For all changes: Link the associated issue/discussion in the "Related Issue" section below

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly without prior discussion.

Why this requirement?
We deeply appreciate all community contributions - they are essential to Cline's success! To ensure the best use of everyone's time and maintain project direction, we use our Feature Requests discussions board to gauge community interest and validate feature ideas before implementation begins. This helps us focus development efforts on features that will benefit the most users.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** [FDN-41](https://linear.app/cline-bot/issue/FDN-41/the-stub-contextworkspacestate-shares-the-same-state-between-all)
The stub context.workspaceState shares the same state between all workspaces

### Description
Problem: Standalone stub used a single ~/.cline/data/workspaceState.json, causing cross-project leakage in IntelliJ.
Change: set up WORKSPACE_STORAGE_DIR and route storageUri, logUri, and workspaceState to it. Keep globalState and secrets under DATA_DIR. 

Each for e.g. IntelliJ project launches cline-core with its own WORKSPACE_STORAGE_DIR, so the stub writes workspaceState to a project-specific workspaceState.json. Global state remains unchanged.

See: 
<!-- 
Help reviewers understand your changes by making this PR readable and well-organized:

- What problem does this PR solve?
- Why were these changes introduced and what purpose do they serve?
- For larger changes, provide context about your approach and reasoning

Small PRs may need minimal description, but larger changes benefit from explaining where you're coming from. Much of this context can be in the linked issue above, so feel free to reference it rather than repeating everything here.
-->

### Test Procedure
Test in intellij, see - https://github.com/cline/intellij-plugin/pull/269
<!-- 
Please walk us through your testing approach and thought process. This helps reviewers understand that you've thoroughly considered the impact of your changes:

- How did you test this change?
- What could potentially break and how did you verify it doesn't?
- What existing functionality might be affected and how did you check it still works?
- Why are you confident this is ready for merge?

We're not looking for exhaustive documentation - just evidence that you've thought through the implications of your changes and tested accordingly.
-->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Isolates workspace state per project in `vscode-context.ts` using `WORKSPACE_STORAGE_DIR`, preventing cross-project data leakage.
> 
>   - **Behavior**:
>     - Introduces `WORKSPACE_STORAGE_DIR` in `vscode-context.ts` to isolate workspace state per project.
>     - Updates `storageUri` and `workspaceState` to use `WORKSPACE_STORAGE_DIR`.
>     - Keeps `globalState` and `secrets` under `DATA_DIR`.
>   - **Files**:
>     - Modifies `vscode-context.ts` to create and use `WORKSPACE_STORAGE_DIR` for project-specific data.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 3a52ce486437b687f602a27434695b6f8fae3ee9. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->