### PR TITLE
Normalize paths to fix windows test for workspace paths

### DIFF
--- a/src/core/workspace/__tests__/WorkspacePathAdapter.test.ts
+++ b/src/core/workspace/__tests__/WorkspacePathAdapter.test.ts
@@ -10,15 +10,7 @@ import * as sinon from "sinon"
 import { createWorkspacePathAdapter, WorkspacePathAdapter } from "../WorkspacePathAdapter"
 import { VcsType, WorkspaceRoot } from "../WorkspaceRoot"
 import { WorkspaceRootManager } from "../WorkspaceRootManager"
-
-/**
- * Helper function to normalize paths for cross-platform testing
- * Converts all backslashes to forward slashes for consistent comparison
- * This ensures tests work on Windows, macOS, and Linux
- */
-function normalizePath(p: string): string {
-	return p.replace(/\\/g, "/")
-}
+import "@utils/path"
 
 describe("WorkspacePathAdapter", () => {
 	let consoleWarnStub: sinon.SinonStub
@@ -68,7 +60,7 @@ describe("WorkspacePathAdapter", () => {
 
 		it("should get relative path from cwd", () => {
 			const result = adapter.getRelativePath("/test/workspace/src/file.ts")
-			expect(normalizePath(result)).to.equal("src/file.ts")
+			expect(result.toPosix()).to.equal("src/file.ts")
 		})
 
 		it("should return single workspace root", () => {
@@ -105,17 +97,17 @@ describe("WorkspacePathAdapter", () => {
 
 		it("should resolve path with workspace hint by name", () => {
 			const result = adapter.resolvePath("src/index.ts", "backend")
-			expect(normalizePath(result)).to.equal("/workspace/backend/src/index.ts")
+			expect(result.toPosix()).to.equal("/workspace/backend/src/index.ts")
 		})
 
 		it("should resolve path with workspace hint by path", () => {
 			const result = adapter.resolvePath("src/index.ts", "/workspace/shared")
-			expect(normalizePath(result)).to.equal("/workspace/shared/src/index.ts")
+			expect(result.toPosix()).to.equal("/workspace/shared/src/index.ts")
 		})
 
 		it("should default to primary workspace without hint", () => {
 			const result = adapter.resolvePath("src/index.ts")
-			expect(normalizePath(result)).to.equal("/workspace/frontend/src/index.ts")
+			expect(result.toPosix()).to.equal("/workspace/frontend/src/index.ts")
 		})
 
 		it("should handle absolute paths belonging to a workspace", () => {
@@ -137,7 +129,7 @@ describe("WorkspacePathAdapter", () => {
 			const paths = adapter.getAllPossiblePaths("src/config.ts")
 			expect(paths).to.have.length(3)
 			// Normalize each path for cross-platform comparison
-			const normalizedPaths = paths.map((p) => normalizePath(p))
+			const normalizedPaths = paths.map((p) => p.toPosix())
 			expect(normalizedPaths).to.deep.equal([
 				"/workspace/frontend/src/config.ts",
 				"/workspace/backend/src/config.ts",
@@ -155,7 +147,7 @@ describe("WorkspacePathAdapter", () => {
 
 		it("should get relative path from appropriate workspace", () => {
 			const result = adapter.getRelativePath("/workspace/backend/src/api.ts")
-			expect(normalizePath(result)).to.equal("src/api.ts")
+			expect(result.toPosix()).to.equal("src/api.ts")
 		})
 
 		it("should return all workspace roots", () => {
@@ -177,7 +169,7 @@ describe("WorkspacePathAdapter", () => {
 		it("should warn for invalid workspace hint", () => {
 			const result = adapter.resolvePath("src/file.ts", "nonexistent")
 
-			expect(normalizePath(result)).to.equal("/workspace/frontend/src/file.ts") // Falls back to primary
+			expect(result.toPosix()).to.equal("/workspace/frontend/src/file.ts") // Falls back to primary
 			expect(consoleWarnStub.calledOnce).to.be.true
 			expect(consoleWarnStub.firstCall.args[0]).to.include("not found")
 		})
@@ -193,7 +185,7 @@ describe("WorkspacePathAdapter", () => {
 			})
 
 			const result = adapter.resolvePath("src/file.ts")
-			expect(normalizePath(result)).to.include("/fallback/src/file.ts")
+			expect(result.toPosix()).to.include("/fallback/src/file.ts")
 			expect(consoleWarnStub.called).to.be.true
 		})
 


### PR DESCRIPTION


### Description
Solves the failing tests for windows for workspace path as the paths were hard coded
```


  209 passing (249ms)
  4 pending
  8 failing

  1) WorkspacePathAdapter
       Single-Root Mode
         should get relative path from cwd:

      AssertionError: expected 'src\file.ts' to equal 'src/file.ts'
      + expected - actual

      -src\file.ts
      +src/file.ts
      
      at Context.<anonymous> (src\core\workspace\__tests__\WorkspacePathAdapter.test.ts:62:22)
      at processImmediate (node:internal/timers:485:21)

  2) WorkspacePathAdapter
       Multi-Root Mode
         should resolve path with workspace hint by name:

      AssertionError: expected '\workspace\backend\src\index.ts' to equal '/workspace/backend/src/index.ts'
      + expected - actual

      -\workspace\backend\src\index.ts
      +/workspace/backend/src/index.ts
      
      at Context.<anonymous> (src\core\workspace\__tests__\WorkspacePathAdapter.test.ts:99:22)
      at processImmediate (node:internal/timers:485:21)

  3) WorkspacePathAdapter
       Multi-Root Mode
         should resolve path with workspace hint by path:

      AssertionError: expected '\workspace\shared\src\index.ts' to equal '/workspace/shared/src/index.ts'
      + expected - actual

      -\workspace\shared\src\index.ts
      +/workspace/shared/src/index.ts
      
      at Context.<anonymous> (src\core\workspace\__tests__\WorkspacePathAdapter.test.ts:104:22)
      at processImmediate (node:internal/timers:485:21)

```

### Test Procedure

<!-- 
Please walk us through your testing approach and thought process. This helps reviewers understand that you've thoroughly considered the impact of your changes:

- How did you test this change?
- What could potentially break and how did you verify it doesn't?
- What existing functionality might be affected and how did you check it still works?
- Why are you confident this is ready for merge?

We're not looking for exhaustive documentation - just evidence that you've thought through the implications of your changes and tested accordingly.
-->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [ ] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes path normalization in `WorkspacePathAdapter.test.ts` for Windows compatibility by using `toPosix()` for path comparisons.
> 
>   - **Behavior**:
>     - Fixes path normalization in `WorkspacePathAdapter.test.ts` by using `toPosix()` for consistent path formatting.
>     - Ensures tests pass on Windows by comparing paths in POSIX format.
>   - **Tests**:
>     - Updates assertions in `WorkspacePathAdapter.test.ts` to use `toPosix()` for path comparisons.
>     - Handles path normalization in `getRelativePath`, `resolvePath`, and `getAllPossiblePaths` functions.
>   - **Misc**:
>     - Imports `@utils/path` in `WorkspacePathAdapter.test.ts` for path utilities.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for aa162da330b58c58e096a698251c802ce3ac34f2. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->