### PR TITLE
Use ExtensionRegistryInfo to get the extension version

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -12,6 +12,7 @@ import "./utils/path" // necessary to have access to String.prototype.toPosix
 
 import { HostProvider } from "@/hosts/host-provider"
 import { FileContextTracker } from "./core/context/context-tracking/FileContextTracker"
+import { ExtensionRegistryInfo } from "./registry"
 import { ErrorService } from "./services/error"
 import { featureFlagsService } from "./services/feature-flags"
 import { initializeDistinctId } from "./services/logging/distinctId"
@@ -62,7 +63,7 @@ export async function initialize(context: vscode.ExtensionContext): Promise<Webv
 
 async function showVersionUpdateAnnouncement(context: vscode.ExtensionContext) {
 	// Version checking for autoupdate notification
-	const currentVersion = context.extension.packageJSON.version
+	const currentVersion = ExtensionRegistryInfo.version
 	const previousVersion = context.globalState.get<string>("clineVersion")
 	// Perform post-update actions if necessary
 	try {
@@ -71,7 +72,7 @@ async function showVersionUpdateAnnouncement(context: vscode.ExtensionContext) {
 
 			// Use the same condition as announcements: focus when there's a new announcement to show
 			const lastShownAnnouncementId = context.globalState.get<string>("lastShownAnnouncementId")
-			const latestAnnouncementId = getLatestAnnouncementId(context)
+			const latestAnnouncementId = getLatestAnnouncementId()
 
 			if (lastShownAnnouncementId !== latestAnnouncementId) {
 				// Focus Cline when there's a new announcement to show (major/minor updates or fresh installs)

--- a/src/core/controller/index.ts
+++ b/src/core/controller/index.ts
@@ -23,6 +23,7 @@ import * as path from "path"
 import * as vscode from "vscode"
 import { clineEnvConfig } from "@/config"
 import { HostProvider } from "@/hosts/host-provider"
+import { ExtensionRegistryInfo } from "@/registry"
 import { AuthService } from "@/services/auth/AuthService"
 import { getDistinctId } from "@/services/logging/distinctId"
 import { telemetryService } from "@/services/telemetry"
@@ -108,7 +109,7 @@ export class Controller {
 		this.mcpHub = new McpHub(
 			() => ensureMcpServersDirectoryExists(),
 			() => ensureSettingsDirectoryExists(this.context),
-			this.context.extension?.packageJSON?.version ?? "1.0.0",
+			ExtensionRegistryInfo.version,
 			telemetryService,
 		)
 
@@ -688,11 +689,11 @@ export class Controller {
 			.sort((a, b) => b.ts - a.ts)
 			.slice(0, 100) // for now we're only getting the latest 100 tasks, but a better solution here is to only pass in 3 for recent task history, and then get the full task history on demand when going to the task history view (maybe with pagination?)
 
-		const latestAnnouncementId = getLatestAnnouncementId(this.context)
+		const latestAnnouncementId = getLatestAnnouncementId()
 		const shouldShowAnnouncement = lastShownAnnouncementId !== latestAnnouncementId
 		const platform = process.platform as Platform
 		const distinctId = getDistinctId()
-		const version = this.context.extension?.packageJSON?.version ?? ""
+		const version = ExtensionRegistryInfo.version
 
 		return {
 			version,

--- a/src/core/controller/ui/onDidShowAnnouncement.ts
+++ b/src/core/controller/ui/onDidShowAnnouncement.ts
@@ -12,7 +12,7 @@ import type { Controller } from "../index"
  */
 export async function onDidShowAnnouncement(controller: Controller, _request: EmptyRequest): Promise<Boolean> {
 	try {
-		const latestAnnouncementId = getLatestAnnouncementId(controller.context)
+		const latestAnnouncementId = getLatestAnnouncementId()
 		// Update the lastShownAnnouncementId to the current latestAnnouncementId
 		controller.stateManager.setGlobalState("lastShownAnnouncementId", latestAnnouncementId)
 		return Boolean.create({ value: false })

--- a/src/core/task/tools/handlers/ReportBugHandler.ts
+++ b/src/core/task/tools/handlers/ReportBugHandler.ts
@@ -5,6 +5,7 @@ import { showSystemNotification } from "@integrations/notifications"
 import { createAndOpenGitHubIssue } from "@utils/github-url-utils"
 import * as os from "os"
 import { HostProvider } from "@/hosts/host-provider"
+import { ExtensionRegistryInfo } from "@/registry"
 import { ClineDefaultTool } from "@/shared/tools"
 import type { ToolResponse } from "../../index"
 import type { IPartialBlockHandler, IToolHandler } from "../ToolExecutorCoordinator"
@@ -74,7 +75,7 @@ export class ReportBugHandler implements IToolHandler, IPartialBlockHandler {
 		// Derive system information values algorithmically
 		const operatingSystem = os.platform() + " " + os.release()
 		const currentMode = config.mode
-		const clineVersion = config.context.extension.packageJSON.version
+		const clineVersion = ExtensionRegistryInfo.version
 		const host = await HostProvider.env.getHostVersion({})
 		const systemInfo = `${host.platform}: ${host.version}, Node.js: ${process.version}, Architecture: ${os.arch()}`
 		const apiConfig = config.services.stateManager.getApiConfiguration()

--- a/src/utils/announcements.ts
+++ b/src/utils/announcements.ts
@@ -1,4 +1,4 @@
-import * as vscode from "vscode"
+import { ExtensionRegistryInfo } from "@/registry"
 
 /**
  * Gets the latest announcement ID based on the extension version
@@ -7,6 +7,7 @@ import * as vscode from "vscode"
  * @param context The VSCode extension context
  * @returns The announcement ID string (major.minor version) or empty string if unavailable
  */
-export function getLatestAnnouncementId(context: vscode.ExtensionContext): string {
-	return context.extension?.packageJSON?.version?.split(".").slice(0, 2).join(".") ?? ""
+export function getLatestAnnouncementId(): string {
+	const version = ExtensionRegistryInfo.version
+	return version.split(".").slice(0, 2).join(".")
 }


### PR DESCRIPTION
Replace uses of the `vscode.ExtensionContext.extension.packageJSON` with `ExtensionRegistryInfo.version`