### PR TITLE
Adding Symbol replacement in workflow files via vscode commands

### DIFF
--- a/.changeset/four-parents-fail.md
+++ b/.changeset/four-parents-fail.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": minor
+---
+
+Introducing vscode command mentions in workflow files to query data from other extension as replacement values

--- a/src/core/task/index.ts
+++ b/src/core/task/index.ts
@@ -75,6 +75,7 @@ import { ErrorService } from "@/services/error"
 import { featureFlagsService } from "@/services/feature-flags"
 import { TerminalHangStage, TerminalUserInterventionAction, telemetryService } from "@/services/telemetry"
 import { ShowMessageType } from "@/shared/proto/index.host"
+import { resolveExtensionQueries } from "@/utils/mentions"
 import { isInTestMode } from "../../services/test/TestMode"
 import { ensureLocalClineDirExists } from "../context/instructions/user-instructions/rule-helpers"
 import { refreshWorkflowToggles } from "../context/instructions/user-instructions/workflows"
@@ -2336,6 +2337,19 @@ export class Task {
 
 							if (needsCheck) {
 								needsClinerulesFileCheck = true
+							}
+
+							try {
+								const resolvedText = await resolveExtensionQueries(processedText, vscode.commands.executeCommand)
+								return {
+									...block,
+									text: resolvedText,
+								}
+							} catch (error) {
+								HostProvider.window.showMessage({
+									type: ShowMessageType.ERROR,
+									message: `Failed to resolve query: ${error}`,
+								})
 							}
 
 							return {

--- a/src/test/mention-utils.test.ts
+++ b/src/test/mention-utils.test.ts
@@ -1,0 +1,93 @@
+import { expect } from "chai"
+import { describe, it } from "mocha"
+import { EXT_PREFIX, resolveExtensionQueries } from "@/utils/mentions"
+
+describe("utils/mentions", () => {
+	describe("resolveExtensionQueries", () => {
+		const VALID_EXTENSION_NAME = "VALID_EXTENSION_NAME"
+		const VALID_COMMAND_NAME = "VALID_COMMAND_NAME"
+		const VALID_QUERY_RESULT = "VALID_QUERY_RESULT"
+
+		const qryCmd = (extname: string, cmdName: string): string => `${extname}.${cmdName}`
+		const qryCmdWthPrefix = (extname: string, cmdName: string): string => `${EXT_PREFIX}${qryCmd(extname, cmdName)}`
+
+		const VALID_QUERY = qryCmd(VALID_EXTENSION_NAME, VALID_COMMAND_NAME)
+
+		const INVALID_EXTENSION_NAME = "INVALID_EXTENSION"
+		const INVALID_COMMAND_NAME = "INVALID_COMMAND_NAME"
+
+		const INVALID_EXT_NAME_ERROR = new Error("Invalid extension name")
+		const INVALID_CMD_NAME_ERROR = new Error("Invalid command name")
+
+		const resolve = (txtToResolve: string): Promise<string> => {
+			if (txtToResolve === VALID_QUERY) {
+				return Promise.resolve(VALID_QUERY_RESULT)
+			}
+			if (txtToResolve.includes(INVALID_EXTENSION_NAME)) {
+				throw INVALID_EXT_NAME_ERROR
+			}
+			if (txtToResolve.includes(INVALID_COMMAND_NAME)) {
+				throw INVALID_CMD_NAME_ERROR
+			}
+			// The mock resolver should not be called with unexpected queries.
+			// Using expect.fail() ensures that any unhandled case loudly fails the test.
+			expect.fail(`Mock resolver was called with an unexpected query: ${txtToResolve}`)
+		}
+
+		it("should return the original text if no placeholders are present", async () => {
+			const input = "Some text without any placeholders."
+			const result = await resolveExtensionQueries(input, resolve)
+			expect(result).to.equal(input)
+		})
+
+		it("should resolve a single query placeholder", async () => {
+			const input = `${EXT_PREFIX}${VALID_QUERY}`
+			const result = await resolveExtensionQueries(input, resolve)
+			expect(result).to.equal(VALID_QUERY_RESULT)
+		})
+
+		it("should resolve a single query placeholder within a larger text", async () => {
+			const input = `Some text ${qryCmdWthPrefix(VALID_EXTENSION_NAME, VALID_COMMAND_NAME)} around it.`
+			const result = await resolveExtensionQueries(input, resolve)
+			expect(result).to.equal(`Some text ${VALID_QUERY_RESULT} around it.`)
+		})
+
+		it("should resolve multiple query placeholders within a larger text", async () => {
+			const input = `Some text ${qryCmdWthPrefix(VALID_EXTENSION_NAME, VALID_COMMAND_NAME)} around it.
+Another sentence ${qryCmdWthPrefix(VALID_EXTENSION_NAME, VALID_COMMAND_NAME)} with smth to resolve.
+One last sentence with ${qryCmdWthPrefix(VALID_EXTENSION_NAME, VALID_COMMAND_NAME)} to resolve.`
+			const result = await resolveExtensionQueries(input, resolve)
+
+			const expectedResult = `Some text ${VALID_QUERY_RESULT} around it.
+Another sentence ${VALID_QUERY_RESULT} with smth to resolve.
+One last sentence with ${VALID_QUERY_RESULT} to resolve.`
+			expect(result).to.equal(expectedResult)
+		})
+
+		describe("Error Handling", () => {
+			const testCases = [
+				{
+					description: "should throw an error for an invalid extension name",
+					input: `Some text with ${qryCmdWthPrefix(INVALID_EXTENSION_NAME, VALID_COMMAND_NAME)}`,
+					expectedError: INVALID_EXT_NAME_ERROR,
+				},
+				{
+					description: "should throw an error for an invalid command name",
+					input: `Some text with ${qryCmdWthPrefix(VALID_EXTENSION_NAME, INVALID_COMMAND_NAME)}`,
+					expectedError: INVALID_CMD_NAME_ERROR,
+				},
+			]
+
+			for (const { description, input, expectedError } of testCases) {
+				it(description, async () => {
+					try {
+						await resolveExtensionQueries(input, resolve)
+						expect.fail("Expected resolveExtensionQueries to throw an error.")
+					} catch (error) {
+						expect(error).to.equal(expectedError)
+					}
+				})
+			}
+		})
+	})
+})

--- a/src/utils/mentions.ts
+++ b/src/utils/mentions.ts
@@ -1,0 +1,20 @@
+export const EXT_PREFIX = "@extension:"
+
+export async function resolveExtensionQueries(
+	textToBeResolved: string,
+	resolve: (toBeResolved: string) => Thenable<string>,
+): Promise<string> {
+	const regex = /@extension:[\w.-]+/g
+	const placeholders = [...new Set(textToBeResolved.match(regex) || [])] // Get unique placeholders
+
+	if (placeholders.length === 0) return textToBeResolved
+
+	const entries = await Promise.all(
+		placeholders.map(
+			async (placeholder): Promise<[string, string]> => [placeholder, await resolve(placeholder.slice(EXT_PREFIX.length))],
+		),
+	)
+
+	const replacements = new Map(entries)
+	return textToBeResolved.replace(regex, (match) => replacements.get(match) ?? match)
+}


### PR DESCRIPTION
Introducing syntax to workflow files, where '@extension:<command_name>' will result in a vscode command call for 'command_name' which will yield a replacement value. This allows workflow files to be shared by different users while using individual values without the need to change the workflow file itself.

### Related Issue
**Issue:** #5996

### Description

**Current Issue**
Workflow files cannot reference external data.

**Proposed Solution**
Introduce placeholder values that are dynamically replaced by extension commands.

**Gained Value**
Workflow files become reusable and shareable across different users, while respecting individual configurations provided by other VS Code extensions.

### Test Procedure

The change is defensive, as it only affects inputs that include mentions requiring parsing. If a command fails, the file content remains unchanged. The parser looks for VS Code commands via @extension:<extension_name>.<command_name> and replaces them with the command’s return value. Should any command fail, an error message is shown to the user, which should be enough to identify the root cause (usually spelling errors). Although small, this change has significant impact, as workflow files become more easily shareable.

The replacement function is fully tested line by line. To integrate this change, one additional transformation step was added to the userContent, which is already processed twice in this context via `parseMentions` and `parseSlashCommands`. The integration consists of a single additional return branch wrapped in a try-catch. Given this, it seemed reasonable not to add additional end-to-end tests, as the string replacement logic is already covered. Any error that occurs is caught and displayed via a window message, while control flow continues as before.

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

### Additional Notes
