### PR TITLE
Add global storage path to the Host Provider

### DIFF
--- a/src/core/controller/index.ts
+++ b/src/core/controller/index.ts
@@ -31,7 +31,12 @@ import { ShowMessageType } from "@/shared/proto/host/window"
 import { getLatestAnnouncementId } from "@/utils/announcements"
 import { getCwd, getDesktopDir } from "@/utils/path"
 import { PromptRegistry } from "../prompts/system-prompt"
-import { ensureMcpServersDirectoryExists, ensureSettingsDirectoryExists, GlobalFileNames } from "../storage/disk"
+import {
+	ensureCacheDirectoryExists,
+	ensureMcpServersDirectoryExists,
+	ensureSettingsDirectoryExists,
+	GlobalFileNames,
+} from "../storage/disk"
 import { PersistenceErrorEvent, StateManager } from "../storage/StateManager"
 import { Task } from "../task"
 import { sendMcpMarketplaceCatalogEvent } from "./mcp/subscribeToMcpMarketplaceCatalog"
@@ -552,15 +557,9 @@ export class Controller {
 		// Dont send settingsButtonClicked because its bad ux if user is on welcome
 	}
 
-	private async ensureCacheDirectoryExists(): Promise<string> {
-		const cacheDir = path.join(this.context.globalStorageUri.fsPath, "cache")
-		await fs.mkdir(cacheDir, { recursive: true })
-		return cacheDir
-	}
-
 	// Read OpenRouter models from disk cache
 	async readOpenRouterModels(): Promise<Record<string, ModelInfo> | undefined> {
-		const openRouterModelsFilePath = path.join(await this.ensureCacheDirectoryExists(), GlobalFileNames.openRouterModels)
+		const openRouterModelsFilePath = path.join(await ensureCacheDirectoryExists(), GlobalFileNames.openRouterModels)
 		const fileExists = await fileExistsAtPath(openRouterModelsFilePath)
 		if (fileExists) {
 			const fileContents = await fs.readFile(openRouterModelsFilePath, "utf8")
@@ -571,10 +570,7 @@ export class Controller {
 
 	// Read Vercel AI Gateway models from disk cache
 	async readVercelAiGatewayModels(): Promise<Record<string, ModelInfo> | undefined> {
-		const vercelAiGatewayModelsFilePath = path.join(
-			await this.ensureCacheDirectoryExists(),
-			GlobalFileNames.vercelAiGatewayModels,
-		)
+		const vercelAiGatewayModelsFilePath = path.join(await ensureCacheDirectoryExists(), GlobalFileNames.vercelAiGatewayModels)
 		const fileExists = await fileExistsAtPath(vercelAiGatewayModelsFilePath)
 		if (fileExists) {
 			const fileContents = await fs.readFile(vercelAiGatewayModelsFilePath, "utf8")

--- a/src/core/controller/models/refreshBasetenModels.ts
+++ b/src/core/controller/models/refreshBasetenModels.ts
@@ -1,4 +1,4 @@
-import { GlobalFileNames } from "@core/storage/disk"
+import { ensureCacheDirectoryExists, GlobalFileNames } from "@core/storage/disk"
 import { EmptyRequest } from "@shared/proto/cline/common"
 import { OpenRouterCompatibleModelInfo, OpenRouterModelInfo } from "@shared/proto/cline/models"
 import { fileExistsAtPath } from "@utils/fs"
@@ -19,7 +19,7 @@ export async function refreshBasetenModels(
 	_request: EmptyRequest,
 ): Promise<OpenRouterCompatibleModelInfo> {
 	console.log("=== refreshBasetenModels called ===")
-	const basetenModelsFilePath = path.join(await ensureCacheDirectoryExists(controller), GlobalFileNames.basetenModels)
+	const basetenModelsFilePath = path.join(await ensureCacheDirectoryExists(), GlobalFileNames.basetenModels)
 
 	// Get the Baseten API key from the controller's state
 	const basetenApiKey = controller.stateManager.getSecretKey("basetenApiKey")
@@ -122,7 +122,7 @@ export async function refreshBasetenModels(
 		console.error("Baseten API Error:", errorMessage)
 
 		// If we failed to fetch models, try to read cached models first
-		const cachedModels = await readBasetenModels(controller)
+		const cachedModels = await readBasetenModels()
 		if (cachedModels && Object.keys(cachedModels).length > 0) {
 			console.log("Using cached Baseten models")
 			// Filter cached models to only include those in static basetenModels
@@ -172,19 +172,10 @@ export async function refreshBasetenModels(
 }
 
 /**
- * Ensures the cache directory exists and returns its path
- */
-async function ensureCacheDirectoryExists(controller: Controller): Promise<string> {
-	const cacheDir = path.join(controller.context.globalStorageUri.fsPath, "cache")
-	await fs.mkdir(cacheDir, { recursive: true })
-	return cacheDir
-}
-
-/**
  * Reads cached Baseten models from disk
  */
-async function readBasetenModels(controller: Controller): Promise<Record<string, Partial<OpenRouterModelInfo>> | undefined> {
-	const basetenModelsFilePath = path.join(await ensureCacheDirectoryExists(controller), GlobalFileNames.basetenModels)
+async function readBasetenModels(): Promise<Record<string, Partial<OpenRouterModelInfo>> | undefined> {
+	const basetenModelsFilePath = path.join(await ensureCacheDirectoryExists(), GlobalFileNames.basetenModels)
 	const fileExists = await fileExistsAtPath(basetenModelsFilePath)
 	if (fileExists) {
 		try {

--- a/src/core/controller/models/refreshGroqModels.ts
+++ b/src/core/controller/models/refreshGroqModels.ts
@@ -1,4 +1,4 @@
-import { GlobalFileNames } from "@core/storage/disk"
+import { ensureCacheDirectoryExists, GlobalFileNames } from "@core/storage/disk"
 import { EmptyRequest } from "@shared/proto/cline/common"
 import { OpenRouterCompatibleModelInfo, OpenRouterModelInfo } from "@shared/proto/cline/models"
 import { fileExistsAtPath } from "@utils/fs"
@@ -16,7 +16,7 @@ import { Controller } from ".."
  * @returns Response containing the Groq models
  */
 export async function refreshGroqModels(controller: Controller, _request: EmptyRequest): Promise<OpenRouterCompatibleModelInfo> {
-	const groqModelsFilePath = path.join(await ensureCacheDirectoryExists(controller), GlobalFileNames.groqModels)
+	const groqModelsFilePath = path.join(await ensureCacheDirectoryExists(), GlobalFileNames.groqModels)
 
 	const groqApiKey = controller.stateManager.getSecretKey("groqApiKey")
 
@@ -165,7 +165,7 @@ export async function refreshGroqModels(controller: Controller, _request: EmptyR
  * Reads cached Groq models from disk
  */
 async function readGroqModels(controller: Controller): Promise<Record<string, Partial<OpenRouterModelInfo>> | undefined> {
-	const groqModelsFilePath = path.join(await ensureCacheDirectoryExists(controller), GlobalFileNames.groqModels)
+	const groqModelsFilePath = path.join(await ensureCacheDirectoryExists(), GlobalFileNames.groqModels)
 	const fileExists = await fileExistsAtPath(groqModelsFilePath)
 	if (fileExists) {
 		try {
@@ -245,13 +245,4 @@ function generateModelDescription(rawModel: any, staticModelInfo?: any): string 
 	}
 
 	return `${ownedBy} model with ${contextWindow.toLocaleString()} token context window`
-}
-
-/**
- * Ensures the cache directory exists and returns its path
- */
-async function ensureCacheDirectoryExists(controller: Controller): Promise<string> {
-	const cacheDir = path.join(controller.context.globalStorageUri.fsPath, "cache")
-	await fs.mkdir(cacheDir, { recursive: true })
-	return cacheDir
 }

--- a/src/core/controller/models/refreshHuggingFaceModels.ts
+++ b/src/core/controller/models/refreshHuggingFaceModels.ts
@@ -5,20 +5,8 @@ import { fileExistsAtPath } from "@utils/fs"
 import axios from "axios"
 import fs from "fs/promises"
 import path from "path"
+import { ensureCacheDirectoryExists } from "@/core/storage/disk"
 import { Controller } from ".."
-
-/**
- * Ensures the cache directory exists and returns its path
- */
-async function ensureCacheDirectoryExists(controller: Controller): Promise<string> {
-	const cacheDir = path.join(controller.context.globalStorageUri.fsPath, "cache")
-	try {
-		await fs.mkdir(cacheDir, { recursive: true })
-	} catch (_error) {
-		// Directory might already exist
-	}
-	return cacheDir
-}
 
 /**
  * Refreshes the Hugging Face models and returns the updated model list
@@ -27,10 +15,10 @@ async function ensureCacheDirectoryExists(controller: Controller): Promise<strin
  * @returns Response containing the Hugging Face models
  */
 export async function refreshHuggingFaceModels(
-	controller: Controller,
+	_controller: Controller,
 	_request: EmptyRequest,
 ): Promise<OpenRouterCompatibleModelInfo> {
-	const huggingFaceModelsFilePath = path.join(await ensureCacheDirectoryExists(controller), "huggingface_models.json")
+	const huggingFaceModelsFilePath = path.join(await ensureCacheDirectoryExists(), "huggingface_models.json")
 
 	let models: Record<string, OpenRouterModelInfo> = {}
 

--- a/src/core/controller/models/refreshOpenRouterModels.ts
+++ b/src/core/controller/models/refreshOpenRouterModels.ts
@@ -1,4 +1,4 @@
-import { GlobalFileNames } from "@core/storage/disk"
+import { ensureCacheDirectoryExists, GlobalFileNames } from "@core/storage/disk"
 import { EmptyRequest } from "@shared/proto/cline/common"
 import { OpenRouterCompatibleModelInfo, OpenRouterModelInfo } from "@shared/proto/cline/models"
 import { fileExistsAtPath } from "@utils/fs"
@@ -77,7 +77,7 @@ export async function refreshOpenRouterModels(
 	controller: Controller,
 	_request: EmptyRequest,
 ): Promise<OpenRouterCompatibleModelInfo> {
-	const openRouterModelsFilePath = path.join(await ensureCacheDirectoryExists(controller), GlobalFileNames.openRouterModels)
+	const openRouterModelsFilePath = path.join(await ensureCacheDirectoryExists(), GlobalFileNames.openRouterModels)
 
 	let models: Record<string, OpenRouterModelInfo> = {}
 	try {
@@ -259,7 +259,7 @@ export async function refreshOpenRouterModels(
  * Reads cached OpenRouter models from disk
  */
 async function readOpenRouterModels(controller: Controller): Promise<Record<string, OpenRouterModelInfo> | undefined> {
-	const openRouterModelsFilePath = path.join(await ensureCacheDirectoryExists(controller), GlobalFileNames.openRouterModels)
+	const openRouterModelsFilePath = path.join(await ensureCacheDirectoryExists(), GlobalFileNames.openRouterModels)
 	const fileExists = await fileExistsAtPath(openRouterModelsFilePath)
 	if (fileExists) {
 		try {
@@ -271,13 +271,4 @@ async function readOpenRouterModels(controller: Controller): Promise<Record<stri
 		}
 	}
 	return undefined
-}
-
-/**
- * Ensures the cache directory exists and returns its path
- */
-async function ensureCacheDirectoryExists(controller: Controller): Promise<string> {
-	const cacheDir = path.join(controller.context.globalStorageUri.fsPath, "cache")
-	await fs.mkdir(cacheDir, { recursive: true })
-	return cacheDir
 }

--- a/src/core/controller/models/refreshVercelAiGatewayModels.ts
+++ b/src/core/controller/models/refreshVercelAiGatewayModels.ts
@@ -1,4 +1,4 @@
-import { GlobalFileNames } from "@core/storage/disk"
+import { ensureCacheDirectoryExists, GlobalFileNames } from "@core/storage/disk"
 import { EmptyRequest } from "@shared/proto/cline/common"
 import { OpenRouterCompatibleModelInfo, OpenRouterModelInfo } from "@shared/proto/cline/models"
 import { fileExistsAtPath } from "@utils/fs"
@@ -14,13 +14,10 @@ import { Controller } from ".."
  * @returns Response containing Vercel AI Gateway models
  */
 export async function refreshVercelAiGatewayModels(
-	controller: Controller,
+	_controller: Controller,
 	_request: EmptyRequest,
 ): Promise<OpenRouterCompatibleModelInfo> {
-	const vercelAiGatewayModelsFilePath = path.join(
-		await ensureCacheDirectoryExists(controller),
-		GlobalFileNames.vercelAiGatewayModels,
-	)
+	const vercelAiGatewayModelsFilePath = path.join(await ensureCacheDirectoryExists(), GlobalFileNames.vercelAiGatewayModels)
 
 	let models: Record<string, OpenRouterModelInfo> = {}
 
@@ -65,7 +62,7 @@ export async function refreshVercelAiGatewayModels(
 		console.error("Error fetching Vercel AI Gateway models:", error)
 
 		// If we failed to fetch models, try to read cached models
-		const cachedModels = await readVercelAiGatewayModels(controller)
+		const cachedModels = await readVercelAiGatewayModels()
 		if (cachedModels) {
 			models = cachedModels
 		}
@@ -77,11 +74,8 @@ export async function refreshVercelAiGatewayModels(
 /**
  * Reads cached Vercel AI Gateway models from disk
  */
-async function readVercelAiGatewayModels(controller: Controller): Promise<Record<string, OpenRouterModelInfo> | undefined> {
-	const vercelAiGatewayModelsFilePath = path.join(
-		await ensureCacheDirectoryExists(controller),
-		GlobalFileNames.vercelAiGatewayModels,
-	)
+async function readVercelAiGatewayModels(): Promise<Record<string, OpenRouterModelInfo> | undefined> {
+	const vercelAiGatewayModelsFilePath = path.join(await ensureCacheDirectoryExists(), GlobalFileNames.vercelAiGatewayModels)
 	const fileExists = await fileExistsAtPath(vercelAiGatewayModelsFilePath)
 	if (fileExists) {
 		try {
@@ -93,13 +87,4 @@ async function readVercelAiGatewayModels(controller: Controller): Promise<Record
 		}
 	}
 	return undefined
-}
-
-/**
- * Ensures the cache directory exists and returns its path
- */
-async function ensureCacheDirectoryExists(controller: Controller): Promise<string> {
-	const cacheDir = path.join(controller.context.globalStorageUri.fsPath, "cache")
-	await fs.mkdir(cacheDir, { recursive: true })
-	return cacheDir
 }

--- a/src/core/storage/disk.ts
+++ b/src/core/storage/disk.ts
@@ -8,6 +8,7 @@ import fs from "fs/promises"
 import os from "os"
 import * as path from "path"
 import * as vscode from "vscode"
+import { HostProvider } from "@/hosts/host-provider"
 import { GlobalState } from "./state-keys"
 
 export const GlobalFileNames = {
@@ -187,6 +188,10 @@ export async function ensureStateDirectoryExists(context: vscode.ExtensionContex
 	const stateDir = path.join(context.globalStorageUri.fsPath, "state")
 	await fs.mkdir(stateDir, { recursive: true })
 	return stateDir
+}
+
+export async function ensureCacheDirectoryExists(): Promise<string> {
+	return HostProvider.getGlobalStorageDir("cache")
 }
 
 export async function getTaskHistoryStateFilePath(context: vscode.ExtensionContext): Promise<string> {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -537,6 +537,7 @@ function setupHostProvider(context: ExtensionContext) {
 		getCallbackUrl,
 		getBinaryLocation,
 		context.extensionUri.fsPath,
+		context.globalStorageUri.fsPath,
 	)
 }
 

--- a/src/standalone/cline-core.ts
+++ b/src/standalone/cline-core.ts
@@ -11,7 +11,7 @@ import { DiffViewProvider } from "@/integrations/editor/DiffViewProvider"
 import { waitForHostBridgeReady } from "./hostbridge-client"
 import { startProtobusService } from "./protobus-service"
 import { log } from "./utils"
-import { EXTENSION_DIR, extensionContext } from "./vscode-context"
+import { DATA_DIR, EXTENSION_DIR, extensionContext } from "./vscode-context"
 
 async function main() {
 	log("\n\n\nStarting cline-core service...\n\n\n")
@@ -56,6 +56,7 @@ function setupHostProvider() {
 		getCallbackUrl,
 		getBinaryLocation,
 		EXTENSION_DIR,
+		DATA_DIR,
 	)
 }
 

--- a/src/standalone/vscode-context.ts
+++ b/src/standalone/vscode-context.ts
@@ -11,7 +11,7 @@ export const { version, name, publisher } = getPackageInfo()
 log("Running standalone cline", version)
 
 export const CLINE_DIR = process.env.CLINE_DIR || `${os.homedir()}/.cline`
-const DATA_DIR = path.join(CLINE_DIR, "data")
+export const DATA_DIR = path.join(CLINE_DIR, "data")
 const INSTALL_DIR = process.env.INSTALL_DIR || __dirname
 const WORKSPACE_STORAGE_DIR = process.env.WORKSPACE_STORAGE_DIR || path.join(DATA_DIR, "workspace")
 

--- a/src/test/host-provider-test-utils.ts
+++ b/src/test/host-provider-test-utils.ts
@@ -16,6 +16,7 @@ export function setVscodeHostProviderMock(options?: {
 	getCallbackUri?: () => Promise<string>
 	getBinaryLocation?: (name: string) => Promise<string>
 	extensionFsPath?: string
+	globalStorageFsPath?: string
 }) {
 	HostProvider.reset()
 	HostProvider.initialize(
@@ -26,5 +27,6 @@ export function setVscodeHostProviderMock(options?: {
 		options?.getCallbackUri ?? (async () => "http://example.com:1234/"),
 		options?.getBinaryLocation ?? (async (n) => `/mock/path/to/binary/${n}`),
 		options?.extensionFsPath ?? "/mock/path/to/extension",
+		options?.globalStorageFsPath ?? "/mock/path/to/globalstorage",
 	)
 }


### PR DESCRIPTION
Add a the field `globalStorageFsPath` to replace the VSCode `context.globalStorageUri`
Remove duplicated code for getting the cache directory.
Add a util function to the HostProvider to get sub-directories of the global storage dir, and ensure that the sub-directory is created.