### PR TITLE
Move ApiHandler Secrets to Own Type

### DIFF
--- a/src/api/providers/dify.ts
+++ b/src/api/providers/dify.ts
@@ -1,15 +1,20 @@
 import { Anthropic } from "@anthropic-ai/sdk"
-import { ApiHandlerOptions, ModelInfo } from "@shared/api"
+import { ModelInfo } from "@shared/api"
 import { ApiHandler } from "../../core/api/index"
 import { ApiStream } from "../../core/api/transform/stream"
 
+interface DifyHandlerOptions {
+	difyApiKey?: string
+	difyBaseUrl?: string
+}
+
 export class DifyHandler implements ApiHandler {
-	private options: ApiHandlerOptions
+	private options: DifyHandlerOptions
 	private baseUrl: string
 	private apiKey: string
 	private conversationId: string | null = null
 
-	constructor(options: ApiHandlerOptions) {
+	constructor(options: DifyHandlerOptions) {
 		this.options = options
 		this.apiKey = options.difyApiKey || ""
 		this.baseUrl = options.difyBaseUrl || ""

--- a/src/core/api/index.ts
+++ b/src/core/api/index.ts
@@ -352,10 +352,6 @@ function createHandlerForProvider(
 					mode === "plan" ? options.planModeHuaweiCloudMaasModelInfo : options.actModeHuaweiCloudMaasModelInfo,
 			})
 		case "dify": // Add Dify.ai handler
-			console.log("[DIFY DEBUG] Instantiating DifyHandler with options:", {
-				difyApiKeyPresent: !!options.difyApiKey,
-				difyBaseUrl: options.difyBaseUrl,
-			})
 			return new DifyHandler({
 				difyApiKey: options.difyApiKey,
 				difyBaseUrl: options.difyBaseUrl,

--- a/src/core/api/providers/__tests__/bedrock.test.ts
+++ b/src/core/api/providers/__tests__/bedrock.test.ts
@@ -1,7 +1,7 @@
 import "should"
 import { ConverseStreamCommand } from "@aws-sdk/client-bedrock-runtime"
-import { ApiHandlerOptions } from "@shared/api"
 import { Readable } from "stream"
+import type { AwsBedrockHandlerOptions } from "../bedrock"
 import { AwsBedrockHandler } from "../bedrock"
 
 describe("AwsBedrockHandler", () => {
@@ -202,8 +202,8 @@ describe("AwsBedrockHandler", () => {
 		})
 	})
 
-	const mockOptions: ApiHandlerOptions = {
-		actModeApiModelId: "anthropic.claude-3-7-sonnet-20250219-v1:0",
+	const mockOptions: AwsBedrockHandlerOptions = {
+		apiModelId: "anthropic.claude-3-7-sonnet-20250219-v1:0",
 		awsRegion: "us-east-1",
 		awsAccessKey: "test-key",
 		awsSecretKey: "test-secret",
@@ -214,9 +214,9 @@ describe("AwsBedrockHandler", () => {
 		awsBedrockUsePromptCache: false,
 		awsUseCrossRegionInference: false,
 		awsBedrockEndpoint: "",
-		actModeAwsBedrockCustomSelected: false,
-		actModeAwsBedrockCustomModelBaseId: undefined,
-		actModeThinkingBudgetTokens: 1600,
+		awsBedrockCustomSelected: false,
+		awsBedrockCustomModelBaseId: undefined,
+		thinkingBudgetTokens: 1600,
 	}
 
 	const mockModelInfo = {

--- a/src/core/api/providers/bedrock.ts
+++ b/src/core/api/providers/bedrock.ts
@@ -16,7 +16,7 @@ import { withRetry } from "../retry"
 import { convertToR1Format } from "../transform/r1-format"
 import { ApiStream } from "../transform/stream"
 
-interface AwsBedrockHandlerOptions extends CommonApiHandlerOptions {
+export interface AwsBedrockHandlerOptions extends CommonApiHandlerOptions {
 	apiModelId?: string
 	awsAccessKey?: string
 	awsSecretKey?: string

--- a/src/core/api/providers/dify.ts
+++ b/src/core/api/providers/dify.ts
@@ -1,7 +1,12 @@
 import { Anthropic } from "@anthropic-ai/sdk"
-import { ApiHandlerOptions, ModelInfo } from "../../../shared/api"
+import { ModelInfo } from "../../../shared/api"
 import { ApiHandler } from "../index"
 import { ApiStream } from "../transform/stream"
+
+interface DifyHandlerOptions {
+	difyApiKey?: string
+	difyBaseUrl?: string
+}
 
 // Dify API Response Types
 export interface DifyFileResponse {
@@ -66,14 +71,14 @@ interface DifyConversationResponse {
 }
 
 export class DifyHandler implements ApiHandler {
-	private options: ApiHandlerOptions
+	private options: DifyHandlerOptions
 	private baseUrl: string
 	private apiKey: string
 	private conversationId: string | null = null
 	private currentTaskId: string | null = null
 	private abortController: AbortController | null = null
 
-	constructor(options: ApiHandlerOptions) {
+	constructor(options: DifyHandlerOptions) {
 		this.options = options
 		this.apiKey = options.difyApiKey || ""
 		this.baseUrl = options.difyBaseUrl || ""

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -37,81 +37,87 @@ export type ApiProvider =
 	| "vercel-ai-gateway"
 	| "zai"
 
+export interface ApiHandlerSecrets {
+	apiKey?: string // anthropic
+	liteLlmApiKey?: string
+	awsAccessKey?: string
+	awsSecretKey?: string
+	openRouterApiKey?: string
+
+	clineAccountId?: string
+	awsSessionToken?: string
+	awsBedrockApiKey?: string
+	openAiApiKey?: string
+	geminiApiKey?: string
+	openAiNativeApiKey?: string
+	ollamaApiKey?: string
+	deepSeekApiKey?: string
+	requestyApiKey?: string
+	togetherApiKey?: string
+	fireworksApiKey?: string
+	qwenApiKey?: string
+	doubaoApiKey?: string
+	mistralApiKey?: string
+	authNonce?: string
+	asksageApiKey?: string
+	xaiApiKey?: string
+	moonshotApiKey?: string
+	zaiApiKey?: string
+	huggingFaceApiKey?: string
+	nebiusApiKey?: string
+	sambanovaApiKey?: string
+	cerebrasApiKey?: string
+	sapAiCoreClientId?: string
+	sapAiCoreClientSecret?: string
+	groqApiKey?: string
+	huaweiCloudMaasApiKey?: string
+	basetenApiKey?: string
+	vercelAiGatewayApiKey?: string
+	difyApiKey?: string
+}
+
 export interface ApiHandlerOptions {
 	// Global configuration (not mode-specific)
-	apiKey?: string // anthropic
-	clineAccountId?: string
 	ulid?: string // Used to identify the task in API requests
 	liteLlmBaseUrl?: string
-	liteLlmApiKey?: string
 	liteLlmUsePromptCache?: boolean
 	openAiHeaders?: Record<string, string> // Custom headers for OpenAI requests
 	anthropicBaseUrl?: string
-	openRouterApiKey?: string
 	openRouterProviderSorting?: string
-	awsAccessKey?: string
-	awsSecretKey?: string
-	awsSessionToken?: string
 	awsRegion?: string
 	awsUseCrossRegionInference?: boolean
 	awsBedrockUsePromptCache?: boolean
 	awsAuthentication?: string
 	awsUseProfile?: boolean
 	awsProfile?: string
-	awsBedrockApiKey?: string
 	awsBedrockEndpoint?: string
 	claudeCodePath?: string
 	vertexProjectId?: string
 	vertexRegion?: string
 	openAiBaseUrl?: string
-	openAiApiKey?: string
 	ollamaBaseUrl?: string
-	ollamaApiKey?: string
 	ollamaApiOptionsCtxNum?: string
 	lmStudioBaseUrl?: string
 	lmStudioModelId?: string
 	lmStudioMaxTokens?: string
-	geminiApiKey?: string
 	geminiBaseUrl?: string
-	openAiNativeApiKey?: string
-	deepSeekApiKey?: string
-	requestyApiKey?: string
 	requestyBaseUrl?: string
-	togetherApiKey?: string
-	fireworksApiKey?: string
 	fireworksModelMaxCompletionTokens?: number
 	fireworksModelMaxTokens?: number
-	qwenApiKey?: string
 	qwenCodeOauthPath?: string
-	doubaoApiKey?: string
-	mistralApiKey?: string
 	azureApiVersion?: string
 	qwenApiLine?: string
 	moonshotApiLine?: string
-	moonshotApiKey?: string
-	huggingFaceApiKey?: string
-	nebiusApiKey?: string
 	asksageApiUrl?: string
-	asksageApiKey?: string
-	xaiApiKey?: string
-	sambanovaApiKey?: string
-	cerebrasApiKey?: string
-	groqApiKey?: string
-	basetenApiKey?: string
-	vercelAiGatewayApiKey?: string
 	requestTimeoutMs?: number
-	sapAiCoreClientId?: string
-	sapAiCoreClientSecret?: string
 	sapAiResourceGroup?: string
 	sapAiCoreTokenUrl?: string
 	sapAiCoreBaseUrl?: string
 	sapAiCoreUseOrchestrationMode?: boolean
-	huaweiCloudMaasApiKey?: string
-	difyApiKey?: string
 	difyBaseUrl?: string
-	zaiApiKey?: string
 	zaiApiLine?: string
 	onRetryAttempt?: (attempt: number, maxRetries: number, delay: number, error: any) => void
+
 	// Plan mode configurations
 	planModeApiModelId?: string
 	planModeThinkingBudgetTokens?: number
@@ -143,8 +149,8 @@ export interface ApiHandlerOptions {
 	planModeHuaweiCloudMaasModelInfo?: ModelInfo
 	planModeVercelAiGatewayModelId?: string
 	planModeVercelAiGatewayModelInfo?: ModelInfo
-	// Act mode configurations
 
+	// Act mode configurations
 	actModeApiModelId?: string
 	actModeThinkingBudgetTokens?: number
 	actModeReasoningEffort?: string
@@ -177,11 +183,12 @@ export interface ApiHandlerOptions {
 	actModeVercelAiGatewayModelInfo?: ModelInfo
 }
 
-export type ApiConfiguration = ApiHandlerOptions & {
-	planModeApiProvider?: ApiProvider
-	actModeApiProvider?: ApiProvider
-	favoritedModelIds?: string[]
-}
+export type ApiConfiguration = ApiHandlerOptions &
+	ApiHandlerSecrets & {
+		planModeApiProvider?: ApiProvider
+		actModeApiProvider?: ApiProvider
+		favoritedModelIds?: string[]
+	}
 
 // Models
 


### PR DESCRIPTION


### Description

Move ApiHandler secrets to own type to separate ApiHandler options and secrets.

This give us more flexibility when passing settings that will route to different storage locations.

### Test Procedure

Type check
Run the extension

Type-only change will not break runtime code.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [ ] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->
