### PR TITLE
Clean up cline-core.ts

### DIFF
--- a/src/standalone/cline-core.ts
+++ b/src/standalone/cline-core.ts
@@ -16,14 +16,9 @@ import { EXTENSION_DIR, extensionContext } from "./vscode-context"
 async function main() {
 	log("\n\n\nStarting cline-core service...\n\n\n")
 
-	try {
-		await waitForHostBridgeReady()
-		log("HostBridge is serving; continuing startup")
-	} catch (err) {
-		log(`ERROR: HostBridge error: ${String(err)}`)
-		process.exit(1)
-	}
+	await waitForHostBridgeReady()
 
+	// The host bridge should be available before creating the host provider because it depends on the host bridge.
 	setupHostProvider()
 
 	// Set up global error handlers to prevent process crashes
@@ -31,6 +26,7 @@ async function main() {
 
 	const webviewProvider = await initialize(extensionContext)
 
+	// Enable the localhost HTTP server that handles auth redirects.
 	AuthHandler.getInstance().setEnabled(true)
 
 	startProtobusService(webviewProvider.controller)
@@ -46,6 +42,7 @@ function setupHostProvider() {
 	const getCallbackUrl = (): Promise<string> => {
 		return AuthHandler.getInstance().getCallbackUrl()
 	}
+	// cline-core expects the binaries to be unpacked in the directory where it is running.
 	const getBinaryLocation = async (name: string): Promise<string> => path.join(process.cwd(), name)
 
 	HostProvider.initialize(

--- a/src/standalone/hostbridge-client.ts
+++ b/src/standalone/hostbridge-client.ts
@@ -5,42 +5,41 @@ import { log } from "./utils"
 
 export const HOSTBRIDGE_PORT = 26041
 
-export async function waitForHostBridgeReady(timeoutMs = 60000, intervalMs = 500, address?: string): Promise<void> {
+export async function waitForHostBridgeReady(timeoutMs = 60000, intervalMs = 500): Promise<void> {
+	const address = process.env.HOST_BRIDGE_ADDRESS || `localhost:${HOSTBRIDGE_PORT}`
 	const client = createHealthClient(address)
 	const deadline = Date.now() + timeoutMs
-	while (Date.now() < deadline) {
-		// eslint-disable-next-line no-await-in-loop
-		const ok = await checkHealthOnce(client)
-		if (ok) {
-			try {
-				client.close?.()
-			} catch {}
-			return
-		}
-		log("Waiting for hostbridge to be ready...")
-		// eslint-disable-next-line no-await-in-loop
-		await new Promise((r) => setTimeout(r, intervalMs))
-	}
 	try {
-		client.close?.()
-	} catch {}
-	throw new Error("HostBridge health check timed out")
+		while (Date.now() < deadline) {
+			const ok = await checkHealthOnce(client)
+			if (ok) {
+				log(`HostBridge serving at ${address}; continuing startup`)
+				return
+			}
+			log("Waiting for hostbridge to be ready...")
+			await new Promise((r) => setTimeout(r, intervalMs))
+		}
+	} finally {
+		client.close()
+	}
+	log("HostBridge health check timed out")
+	process.exit(1)
 }
 
 // Client-side health check for the hostbridge service (kept at bottom for clarity)
 const SERVING_STATUS = 1
-function createHealthClient(address?: string) {
+function createHealthClient(address: string) {
 	const healthDef = protoLoader.loadSync(health.protoPath)
 	const grpcObj = grpc.loadPackageDefinition(healthDef) as unknown as any
 	const Health = grpcObj.grpc.health.v1.Health
-	const target = address || process.env.HOST_BRIDGE_ADDRESS || `localhost:${HOSTBRIDGE_PORT}`
-	return new Health(target, grpc.credentials.createInsecure())
+	return new Health(address, grpc.credentials.createInsecure())
 }
 
 async function checkHealthOnce(client: any): Promise<boolean> {
 	return new Promise<boolean>((resolve) => {
 		client.check({ service: "" }, (err: unknown, resp: any) => {
 			if (err) {
+				console.debug(err.toString())
 				return resolve(false)
 			}
 			return resolve(resp?.status === SERVING_STATUS)


### PR DESCRIPTION
Move all the logic for waiting for the host bridge into `hostbridge-client.ts`
Add some comments
Use try/finally, remove unused param, log the error message when the health check fails.

<img width="1176" height="477" alt="Screenshot 2025-09-16 at 14 06 34" src="https://github.com/user-attachments/assets/f82bb42d-13d5-4ff9-b00b-3a61fd157a30" />


<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Refactor host bridge logic into `hostbridge-client.ts`, improve error handling, and add comments in `cline-core.ts`.
> 
>   - **Refactoring**:
>     - Move `waitForHostBridgeReady` logic from `cline-core.ts` to `hostbridge-client.ts`.
>   - **Error Handling**:
>     - Use `try/finally` in `waitForHostBridgeReady` to ensure client closure.
>     - Log error message when health check fails in `hostbridge-client.ts`.
>   - **Code Cleanup**:
>     - Remove unused `address` parameter from `waitForHostBridgeReady`.
>     - Add comments in `cline-core.ts` for better code understanding.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 9ae12bbfaba2c7f7f5e5a863d5f0338676279620. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->