### PR TITLE
fix: add o5 to isReasoningModelFamily

### DIFF
--- a/src/core/api/providers/openai.ts
+++ b/src/core/api/providers/openai.ts
@@ -66,7 +66,8 @@ export class OpenAiHandler implements ApiHandler {
 		const modelId = this.options.openAiModelId ?? ""
 		const isDeepseekReasoner = modelId.includes("deepseek-reasoner")
 		const isR1FormatRequired = this.options.openAiModelInfo?.isR1FormatRequired ?? false
-		const isReasoningModelFamily = modelId.includes("o1") || modelId.includes("o3") || modelId.includes("o4")
+		const isReasoningModelFamily =
+			modelId.includes("o1") || modelId.includes("o3") || modelId.includes("o4") || modelId.includes("o5")
 
 		let openAiMessages: OpenAI.Chat.ChatCompletionMessageParam[] = [
 			{ role: "system", content: systemPrompt },
@@ -122,9 +123,9 @@ export class OpenAiHandler implements ApiHandler {
 					type: "usage",
 					inputTokens: chunk.usage.prompt_tokens || 0,
 					outputTokens: chunk.usage.completion_tokens || 0,
-					// @ts-ignore-next-line
+					// @ts-expect-error-next-line
 					cacheReadTokens: chunk.usage.prompt_tokens_details?.cached_tokens || 0,
-					// @ts-ignore-next-line
+					// @ts-expect-error-next-line
 					cacheWriteTokens: chunk.usage.prompt_cache_miss_tokens || 0,
 				}
 			}


### PR DESCRIPTION
### Related Issue

No existing issue — this is a small bugfix for Azure compatibility.

### Description

Azure reasoning models (`o1`, `o3`, `o4`, `o5`) do not accept custom `temperature` values.  
Sending `temperature: 0` causes a `400 Unsupported value` error.  

This PR adds `o5` to `isReasoningModelFamily` in `OpenAiHandler`, preventing `temperature` from being passed to Azure.  
This mirrors the earlier fix for `o1`, `o3`, and `o4`.

### Test Procedure

- Updated `src/core/api/providers/openai.ts` to include `"o5"` in the `isReasoningModelFamily` check.  
- Ran `npm run test` to confirm no regressions.  
- Verified with Azure OpenAI `o5`:
  - No `temperature` field is sent.  
  - Requests succeed without `400 Unsupported value` error.  

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)

### Pre-flight Checklist

-   [x] Changes are limited to a single bugfix  
-   [x] Tests are passing (`npm test`) and code is formatted/linted (`npm run format && npm run lint`)  
-   [x] I have created a changeset using `npm run changeset`  
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)  

### Screenshots

N/A — backend-only fix.

### Additional Notes

Adds `o5` to `isReasoningModelFamily` in `OpenAiHandler` to prevent temperature errors with Azure OpenAI.  

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `o5` to `isReasoningModelFamily` in `OpenAiHandler` to prevent `temperature` errors with Azure OpenAI.
> 
>   - **Behavior**:
>     - Adds `o5` to `isReasoningModelFamily` in `OpenAiHandler` in `openai.ts` to prevent `temperature` from being sent to Azure, avoiding `400 Unsupported value` errors.
>   - **Misc**:
>     - Changes `@ts-ignore-next-line` to `@ts-expect-error-next-line` in `openai.ts` for better error handling.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 96de7681427067024f83d5f88df46164cf888a9b. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->