### PR TITLE
Break up state and settings types

### DIFF
--- a/src/core/context/instructions/user-instructions/cline-rules.ts
+++ b/src/core/context/instructions/user-instructions/cline-rules.ts
@@ -74,7 +74,7 @@ export async function refreshClineRulesToggles(
 	localToggles: ClineRulesToggles
 }> {
 	// Global toggles
-	const globalClineRulesToggles = controller.stateManager.getGlobalStateKey("globalClineRulesToggles")
+	const globalClineRulesToggles = controller.stateManager.getGlobalSettingsKey("globalClineRulesToggles")
 	const globalClineRulesFilePath = await ensureRulesDirectoryExists()
 	const updatedGlobalToggles = await synchronizeRuleToggles(globalClineRulesFilePath, globalClineRulesToggles)
 	controller.stateManager.setGlobalState("globalClineRulesToggles", updatedGlobalToggles)

--- a/src/core/context/instructions/user-instructions/rule-helpers.ts
+++ b/src/core/context/instructions/user-instructions/rule-helpers.ts
@@ -247,11 +247,11 @@ export async function deleteRuleFile(
 		// Update the appropriate toggles
 		if (isGlobal) {
 			if (type === "workflow") {
-				const toggles = controller.stateManager.getGlobalStateKey("globalWorkflowToggles")
+				const toggles = controller.stateManager.getGlobalSettingsKey("globalWorkflowToggles")
 				delete toggles[rulePath]
 				controller.stateManager.setGlobalState("globalWorkflowToggles", toggles)
 			} else {
-				const toggles = controller.stateManager.getGlobalStateKey("globalClineRulesToggles")
+				const toggles = controller.stateManager.getGlobalSettingsKey("globalClineRulesToggles")
 				delete toggles[rulePath]
 				controller.stateManager.setGlobalState("globalClineRulesToggles", toggles)
 			}

--- a/src/core/context/instructions/user-instructions/workflows.ts
+++ b/src/core/context/instructions/user-instructions/workflows.ts
@@ -15,7 +15,7 @@ export async function refreshWorkflowToggles(
 	localWorkflowToggles: ClineRulesToggles
 }> {
 	// Global workflows
-	const globalWorkflowToggles = controller.stateManager.getGlobalStateKey("globalWorkflowToggles")
+	const globalWorkflowToggles = controller.stateManager.getGlobalSettingsKey("globalWorkflowToggles")
 	const globalClineWorkflowsFilePath = await ensureWorkflowsDirectoryExists()
 	const updatedGlobalWorkflowToggles = await synchronizeRuleToggles(globalClineWorkflowsFilePath, globalWorkflowToggles)
 	controller.stateManager.setGlobalState("globalWorkflowToggles", updatedGlobalWorkflowToggles)

--- a/src/core/controller/browser/discoverBrowser.ts
+++ b/src/core/controller/browser/discoverBrowser.ts
@@ -19,7 +19,7 @@ export async function discoverBrowser(controller: Controller, _request: EmptyReq
 			// This way we don't override the user's preference
 
 			// Test the connection to get the endpoint
-			const browserSettings = controller.stateManager.getGlobalStateKey("browserSettings")
+			const browserSettings = controller.stateManager.getGlobalSettingsKey("browserSettings")
 			const browserSession = new BrowserSession(controller.context, browserSettings)
 			const result = await browserSession.testConnection(discoveredHost)
 

--- a/src/core/controller/browser/getBrowserConnectionInfo.ts
+++ b/src/core/controller/browser/getBrowserConnectionInfo.ts
@@ -11,7 +11,7 @@ import { Controller } from "../index"
 export async function getBrowserConnectionInfo(controller: Controller, _: EmptyRequest): Promise<BrowserConnectionInfo> {
 	try {
 		// Get browser settings from extension state
-		const browserSettings = controller.stateManager.getGlobalStateKey("browserSettings")
+		const browserSettings = controller.stateManager.getGlobalSettingsKey("browserSettings")
 
 		// Check if there's an active browser session by using the controller's handleWebviewMessage approach
 		// This is similar to what's done in controller/index.ts for the "getBrowserConnectionInfo" message

--- a/src/core/controller/browser/getDetectedChromePath.ts
+++ b/src/core/controller/browser/getDetectedChromePath.ts
@@ -11,7 +11,7 @@ import { Controller } from "../index"
  */
 export async function getDetectedChromePath(controller: Controller, _: EmptyRequest): Promise<ChromePath> {
 	try {
-		const browserSettings = controller.stateManager.getGlobalStateKey("browserSettings")
+		const browserSettings = controller.stateManager.getGlobalSettingsKey("browserSettings")
 		const browserSession = new BrowserSession(controller.context, browserSettings)
 		const result = await browserSession.getDetectedChromePath()
 

--- a/src/core/controller/browser/testBrowserConnection.ts
+++ b/src/core/controller/browser/testBrowserConnection.ts
@@ -12,7 +12,7 @@ import { Controller } from "../index"
  */
 export async function testBrowserConnection(controller: Controller, request: StringRequest): Promise<BrowserConnection> {
 	try {
-		const browserSettings = controller.stateManager.getGlobalStateKey("browserSettings")
+		const browserSettings = controller.stateManager.getGlobalSettingsKey("browserSettings")
 		const browserSession = new BrowserSession(controller.context, browserSettings)
 		const text = request.value || ""
 

--- a/src/core/controller/file/toggleClineRule.ts
+++ b/src/core/controller/file/toggleClineRule.ts
@@ -24,7 +24,7 @@ export async function toggleClineRule(controller: Controller, request: ToggleCli
 
 	// This is the same core logic as in the original handler
 	if (isGlobal) {
-		const toggles = controller.stateManager.getGlobalStateKey("globalClineRulesToggles")
+		const toggles = controller.stateManager.getGlobalSettingsKey("globalClineRulesToggles")
 		toggles[rulePath] = enabled
 		controller.stateManager.setGlobalState("globalClineRulesToggles", toggles)
 	} else {
@@ -41,7 +41,7 @@ export async function toggleClineRule(controller: Controller, request: ToggleCli
 	}
 
 	// Get the current state to return in the response
-	const globalToggles = controller.stateManager.getGlobalStateKey("globalClineRulesToggles")
+	const globalToggles = controller.stateManager.getGlobalSettingsKey("globalClineRulesToggles")
 	const localToggles = controller.stateManager.getWorkspaceStateKey("localClineRulesToggles")
 
 	return ToggleClineRules.create({

--- a/src/core/controller/file/toggleWorkflow.ts
+++ b/src/core/controller/file/toggleWorkflow.ts
@@ -21,7 +21,7 @@ export async function toggleWorkflow(controller: Controller, request: ToggleWork
 	// Update the toggles based on isGlobal flag
 	if (isGlobal) {
 		// Global workflows
-		const toggles = controller.stateManager.getGlobalStateKey("globalWorkflowToggles")
+		const toggles = controller.stateManager.getGlobalSettingsKey("globalWorkflowToggles")
 		toggles[workflowPath] = enabled
 		controller.stateManager.setGlobalState("globalWorkflowToggles", toggles)
 		await controller.postStateToWebview()

--- a/src/core/controller/index.ts
+++ b/src/core/controller/index.ts
@@ -120,7 +120,7 @@ export class Controller {
 	}
 
 	async getCurrentMode(): Promise<Mode> {
-		return this.stateManager.getGlobalStateKey("mode")
+		return this.stateManager.getGlobalSettingsKey("mode")
 	}
 
 	/*
@@ -172,22 +172,22 @@ export class Controller {
 		await this.clearTask() // ensures that an existing task doesn't exist before starting a new one, although this shouldn't be possible since user must clear task before starting a new one
 
 		const apiConfiguration = this.stateManager.getApiConfiguration()
-		const autoApprovalSettings = this.stateManager.getGlobalStateKey("autoApprovalSettings")
-		const browserSettings = this.stateManager.getGlobalStateKey("browserSettings")
-		const focusChainSettings = this.stateManager.getGlobalStateKey("focusChainSettings")
-		const preferredLanguage = this.stateManager.getGlobalStateKey("preferredLanguage")
-		const openaiReasoningEffort = this.stateManager.getGlobalStateKey("openaiReasoningEffort")
-		const mode = this.stateManager.getGlobalStateKey("mode")
-		const shellIntegrationTimeout = this.stateManager.getGlobalStateKey("shellIntegrationTimeout")
+		const autoApprovalSettings = this.stateManager.getGlobalSettingsKey("autoApprovalSettings")
+		const browserSettings = this.stateManager.getGlobalSettingsKey("browserSettings")
+		const focusChainSettings = this.stateManager.getGlobalSettingsKey("focusChainSettings")
+		const preferredLanguage = this.stateManager.getGlobalSettingsKey("preferredLanguage")
+		const openaiReasoningEffort = this.stateManager.getGlobalSettingsKey("openaiReasoningEffort")
+		const mode = this.stateManager.getGlobalSettingsKey("mode")
+		const shellIntegrationTimeout = this.stateManager.getGlobalSettingsKey("shellIntegrationTimeout")
 		const terminalReuseEnabled = this.stateManager.getGlobalStateKey("terminalReuseEnabled")
-		const terminalOutputLineLimit = this.stateManager.getGlobalStateKey("terminalOutputLineLimit")
-		const defaultTerminalProfile = this.stateManager.getGlobalStateKey("defaultTerminalProfile")
-		const enableCheckpointsSetting = this.stateManager.getGlobalStateKey("enableCheckpointsSetting")
+		const terminalOutputLineLimit = this.stateManager.getGlobalSettingsKey("terminalOutputLineLimit")
+		const defaultTerminalProfile = this.stateManager.getGlobalSettingsKey("defaultTerminalProfile")
+		const enableCheckpointsSetting = this.stateManager.getGlobalSettingsKey("enableCheckpointsSetting")
 		const isNewUser = this.stateManager.getGlobalStateKey("isNewUser")
 		const taskHistory = this.stateManager.getGlobalStateKey("taskHistory")
-		const strictPlanModeEnabled = this.stateManager.getGlobalStateKey("strictPlanModeEnabled")
-		const yoloModeToggled = this.stateManager.getGlobalStateKey("yoloModeToggled")
-		const useAutoCondense = this.stateManager.getGlobalStateKey("useAutoCondense")
+		const strictPlanModeEnabled = this.stateManager.getGlobalSettingsKey("strictPlanModeEnabled")
+		const yoloModeToggled = this.stateManager.getGlobalSettingsKey("yoloModeToggled")
+		const useAutoCondense = this.stateManager.getGlobalSettingsKey("useAutoCondense")
 
 		const NEW_USER_TASK_COUNT_THRESHOLD = 10
 
@@ -374,7 +374,7 @@ export class Controller {
 			const clineProvider: ApiProvider = "cline"
 
 			// Get current settings to determine how to update providers
-			const planActSeparateModelsSetting = this.stateManager.getGlobalStateKey("planActSeparateModelsSetting")
+			const planActSeparateModelsSetting = this.stateManager.getGlobalSettingsKey("planActSeparateModelsSetting")
 
 			const currentMode = await this.getCurrentMode()
 
@@ -649,32 +649,32 @@ export class Controller {
 		const apiConfiguration = this.stateManager.getApiConfiguration()
 		const lastShownAnnouncementId = this.stateManager.getGlobalStateKey("lastShownAnnouncementId")
 		const taskHistory = this.stateManager.getGlobalStateKey("taskHistory")
-		const autoApprovalSettings = this.stateManager.getGlobalStateKey("autoApprovalSettings")
-		const browserSettings = this.stateManager.getGlobalStateKey("browserSettings")
-		const focusChainSettings = this.stateManager.getGlobalStateKey("focusChainSettings")
-		const preferredLanguage = this.stateManager.getGlobalStateKey("preferredLanguage")
-		const openaiReasoningEffort = this.stateManager.getGlobalStateKey("openaiReasoningEffort")
-		const mode = this.stateManager.getGlobalStateKey("mode")
-		const strictPlanModeEnabled = this.stateManager.getGlobalStateKey("strictPlanModeEnabled")
-		const useAutoCondense = this.stateManager.getGlobalStateKey("useAutoCondense")
+		const autoApprovalSettings = this.stateManager.getGlobalSettingsKey("autoApprovalSettings")
+		const browserSettings = this.stateManager.getGlobalSettingsKey("browserSettings")
+		const focusChainSettings = this.stateManager.getGlobalSettingsKey("focusChainSettings")
+		const preferredLanguage = this.stateManager.getGlobalSettingsKey("preferredLanguage")
+		const openaiReasoningEffort = this.stateManager.getGlobalSettingsKey("openaiReasoningEffort")
+		const mode = this.stateManager.getGlobalSettingsKey("mode")
+		const strictPlanModeEnabled = this.stateManager.getGlobalSettingsKey("strictPlanModeEnabled")
+		const useAutoCondense = this.stateManager.getGlobalSettingsKey("useAutoCondense")
 		const userInfo = this.stateManager.getGlobalStateKey("userInfo")
 		const mcpMarketplaceEnabled = this.stateManager.getGlobalStateKey("mcpMarketplaceEnabled")
 		const mcpDisplayMode = this.stateManager.getGlobalStateKey("mcpDisplayMode")
-		const telemetrySetting = this.stateManager.getGlobalStateKey("telemetrySetting")
-		const planActSeparateModelsSetting = this.stateManager.getGlobalStateKey("planActSeparateModelsSetting")
-		const enableCheckpointsSetting = this.stateManager.getGlobalStateKey("enableCheckpointsSetting")
-		const globalClineRulesToggles = this.stateManager.getGlobalStateKey("globalClineRulesToggles")
-		const globalWorkflowToggles = this.stateManager.getGlobalStateKey("globalWorkflowToggles")
-		const shellIntegrationTimeout = this.stateManager.getGlobalStateKey("shellIntegrationTimeout")
+		const telemetrySetting = this.stateManager.getGlobalSettingsKey("telemetrySetting")
+		const planActSeparateModelsSetting = this.stateManager.getGlobalSettingsKey("planActSeparateModelsSetting")
+		const enableCheckpointsSetting = this.stateManager.getGlobalSettingsKey("enableCheckpointsSetting")
+		const globalClineRulesToggles = this.stateManager.getGlobalSettingsKey("globalClineRulesToggles")
+		const globalWorkflowToggles = this.stateManager.getGlobalSettingsKey("globalWorkflowToggles")
+		const shellIntegrationTimeout = this.stateManager.getGlobalSettingsKey("shellIntegrationTimeout")
 		const terminalReuseEnabled = this.stateManager.getGlobalStateKey("terminalReuseEnabled")
-		const defaultTerminalProfile = this.stateManager.getGlobalStateKey("defaultTerminalProfile")
+		const defaultTerminalProfile = this.stateManager.getGlobalSettingsKey("defaultTerminalProfile")
 		const isNewUser = this.stateManager.getGlobalStateKey("isNewUser")
 		const welcomeViewCompleted = Boolean(
 			this.stateManager.getGlobalStateKey("welcomeViewCompleted") || this.authService.getInfo()?.user?.uid,
 		)
-		const customPrompt = this.stateManager.getGlobalStateKey("customPrompt")
+		const customPrompt = this.stateManager.getGlobalSettingsKey("customPrompt")
 		const mcpResponsesCollapsed = this.stateManager.getGlobalStateKey("mcpResponsesCollapsed")
-		const terminalOutputLineLimit = this.stateManager.getGlobalStateKey("terminalOutputLineLimit")
+		const terminalOutputLineLimit = this.stateManager.getGlobalSettingsKey("terminalOutputLineLimit")
 		const favoritedModelIds = this.stateManager.getGlobalStateKey("favoritedModelIds")
 
 		const localClineRulesToggles = this.stateManager.getWorkspaceStateKey("localClineRulesToggles")

--- a/src/core/controller/models/refreshRequestyModels.ts
+++ b/src/core/controller/models/refreshRequestyModels.ts
@@ -21,7 +21,7 @@ export async function refreshRequestyModels(controller: Controller, _: EmptyRequ
 	const models: Record<string, OpenRouterModelInfo> = {}
 	try {
 		const apiKey = controller.stateManager.getSecretKey("requestyApiKey")
-		const baseUrl = controller.stateManager.getGlobalStateKey("requestyBaseUrl")
+		const baseUrl = controller.stateManager.getGlobalSettingsKey("requestyBaseUrl")
 
 		const resolvedUrl = toRequestyServiceUrl(baseUrl)
 		const url = new URL(`${resolvedUrl.pathname}/models`, resolvedUrl).toString()

--- a/src/core/controller/state/updateSettings.ts
+++ b/src/core/controller/state/updateSettings.ts
@@ -180,7 +180,7 @@ export async function updateSettings(controller: Controller, request: UpdateSett
 		// Update focus chain settings
 		if (request.focusChainSettings !== undefined) {
 			{
-				const currentSettings = controller.stateManager.getGlobalStateKey("focusChainSettings")
+				const currentSettings = controller.stateManager.getGlobalSettingsKey("focusChainSettings")
 				const wasEnabled = currentSettings?.enabled ?? false
 				const isEnabled = request.focusChainSettings.enabled
 
@@ -206,7 +206,7 @@ export async function updateSettings(controller: Controller, request: UpdateSett
 		// Update browser settings
 		if (request.browserSettings !== undefined) {
 			// Get current browser settings to preserve fields not in the request
-			const currentSettings = controller.stateManager.getGlobalStateKey("browserSettings")
+			const currentSettings = controller.stateManager.getGlobalSettingsKey("browserSettings")
 
 			// Convert from protobuf format to shared format, merging with existing settings
 			const newBrowserSettings: SharedBrowserSettings = {

--- a/src/core/controller/ui/initializeWebview.ts
+++ b/src/core/controller/ui/initializeWebview.ts
@@ -30,7 +30,7 @@ export async function initializeWebview(controller: Controller, _request: EmptyR
 			if (response && response.models) {
 				// Update model info in state (this needs to be done here since we don't want to update state while settings is open, and we may refresh models there)
 				const apiConfiguration = controller.stateManager.getApiConfiguration()
-				const planActSeparateModelsSetting = controller.stateManager.getGlobalStateKey("planActSeparateModelsSetting")
+				const planActSeparateModelsSetting = controller.stateManager.getGlobalSettingsKey("planActSeparateModelsSetting")
 				const currentMode = await controller.getCurrentMode()
 
 				if (planActSeparateModelsSetting) {
@@ -76,7 +76,7 @@ export async function initializeWebview(controller: Controller, _request: EmptyR
 			if (response && response.models) {
 				// Update model info in state for Groq (this needs to be done here since we don't want to update state while settings is open, and we may refresh models there)
 				const apiConfiguration = controller.stateManager.getApiConfiguration()
-				const planActSeparateModelsSetting = controller.stateManager.getGlobalStateKey("planActSeparateModelsSetting")
+				const planActSeparateModelsSetting = controller.stateManager.getGlobalSettingsKey("planActSeparateModelsSetting")
 				const currentMode = await controller.getCurrentMode()
 
 				if (planActSeparateModelsSetting) {
@@ -122,7 +122,7 @@ export async function initializeWebview(controller: Controller, _request: EmptyR
 			if (response && response.models) {
 				// Update model info in state for Baseten (this needs to be done here since we don't want to update state while settings is open, and we may refresh models there)
 				const apiConfiguration = controller.stateManager.getApiConfiguration()
-				const planActSeparateModelsSetting = controller.stateManager.getGlobalStateKey("planActSeparateModelsSetting")
+				const planActSeparateModelsSetting = controller.stateManager.getGlobalSettingsKey("planActSeparateModelsSetting")
 
 				const currentMode = await controller.getCurrentMode()
 
@@ -164,7 +164,7 @@ export async function initializeWebview(controller: Controller, _request: EmptyR
 			if (response && response.models) {
 				// Update model info in state for Vercel AI Gateway (this needs to be done here since we don't want to update state while settings is open, and we may refresh models there)
 				const apiConfiguration = controller.stateManager.getApiConfiguration()
-				const planActSeparateModelsSetting = controller.stateManager.getGlobalStateKey("planActSeparateModelsSetting")
+				const planActSeparateModelsSetting = controller.stateManager.getGlobalSettingsKey("planActSeparateModelsSetting")
 				const currentMode = await controller.getCurrentMode()
 
 				if (planActSeparateModelsSetting) {

--- a/src/core/storage/StateManager.ts
+++ b/src/core/storage/StateManager.ts
@@ -11,7 +11,18 @@ import {
 	writeTaskSettingsToStorage,
 } from "./disk"
 import { STATE_MANAGER_NOT_INITIALIZED } from "./error-messages"
-import { GlobalState, GlobalStateKey, LocalState, LocalStateKey, SecretKey, Secrets } from "./state-keys"
+import {
+	GlobalState,
+	GlobalStateAndSettings,
+	GlobalStateAndSettingsKey,
+	GlobalStateKey,
+	LocalState,
+	LocalStateKey,
+	SecretKey,
+	Secrets,
+	Settings,
+	SettingsKey,
+} from "./state-keys"
 import { readGlobalStateFromDisk, readSecretsFromDisk, readWorkspaceStateFromDisk } from "./utils/state-helpers"
 
 export interface PersistenceErrorEvent {
@@ -23,16 +34,16 @@ export interface PersistenceErrorEvent {
  * Provides immediate reads/writes with async disk persistence
  */
 export class StateManager {
-	private globalStateCache: GlobalState = {} as GlobalState
-	private taskStateCache: Partial<GlobalState> = {}
+	private globalStateCache: GlobalStateAndSettings = {} as GlobalStateAndSettings
+	private taskStateCache: Partial<Settings> = {}
 	private secretsCache: Secrets = {} as Secrets
 	private workspaceStateCache: LocalState = {} as LocalState
 	private context: ExtensionContext
 	private isInitialized = false
 
 	// Debounced persistence state
-	private pendingGlobalState = new Set<GlobalStateKey>()
-	private pendingTaskState = new Set<GlobalStateKey>()
+	private pendingGlobalState = new Set<GlobalStateAndSettingsKey>()
+	private pendingTaskState = new Set<SettingsKey>()
 	private pendingSecrets = new Set<SecretKey>()
 	private pendingWorkspaceState = new Set<LocalStateKey>()
 	private persistenceTimeout: NodeJS.Timeout | null = null
@@ -76,7 +87,7 @@ export class StateManager {
 	/**
 	 * Set method for global state keys - updates cache immediately and schedules debounced persistence
 	 */
-	setGlobalState<K extends keyof GlobalState>(key: K, value: GlobalState[K]): void {
+	setGlobalState<K extends keyof GlobalStateAndSettings>(key: K, value: GlobalStateAndSettings[K]): void {
 		if (!this.isInitialized) {
 			throw new Error(STATE_MANAGER_NOT_INITIALIZED)
 		}
@@ -92,7 +103,7 @@ export class StateManager {
 	/**
 	 * Batch set method for global state keys - updates cache immediately and schedules debounced persistence
 	 */
-	setGlobalStateBatch(updates: Partial<GlobalState>): void {
+	setGlobalStateBatch(updates: Partial<GlobalStateAndSettings>): void {
 		if (!this.isInitialized) {
 			throw new Error(STATE_MANAGER_NOT_INITIALIZED)
 		}
@@ -113,7 +124,7 @@ export class StateManager {
 	/**
 	 * Set method for task settings keys - updates cache immediately and schedules debounced persistence
 	 */
-	setTaskSettings<K extends keyof GlobalState>(taskId: string, key: K, value: GlobalState[K]): void {
+	setTaskSettings<K extends keyof Settings>(taskId: string, key: K, value: Settings[K]): void {
 		if (!this.isInitialized) {
 			throw new Error(STATE_MANAGER_NOT_INITIALIZED)
 		}
@@ -129,7 +140,7 @@ export class StateManager {
 	/**
 	 * Batch set method for task settings keys - updates cache immediately and schedules debounced persistence
 	 */
-	setTaskSettingsBatch(taskId: string, updates: Partial<GlobalState>): void {
+	setTaskSettingsBatch(taskId: string, updates: Partial<Settings>): void {
 		if (!this.isInitialized) {
 			throw new Error(STATE_MANAGER_NOT_INITIALIZED)
 		}
@@ -139,7 +150,7 @@ export class StateManager {
 
 		// Then track the keys for persistence
 		Object.keys(updates).forEach((key) => {
-			this.pendingTaskState.add(key as GlobalStateKey)
+			this.pendingTaskState.add(key as SettingsKey)
 		})
 
 		// Schedule debounced persistence
@@ -614,14 +625,24 @@ export class StateManager {
 	}
 
 	/**
-	 * Get method for global state keys - reads from in-memory cache
+	 * Get method for global settings keys - reads from in-memory cache
 	 */
-	getGlobalStateKey<K extends keyof GlobalState>(key: K): GlobalState[K] {
+	getGlobalSettingsKey<K extends keyof Settings>(key: K): Settings[K] {
 		if (!this.isInitialized) {
 			throw new Error(STATE_MANAGER_NOT_INITIALIZED)
 		}
 		if (this.taskStateCache[key] !== undefined) {
 			return this.taskStateCache[key]
+		}
+		return this.globalStateCache[key]
+	}
+
+	/**
+	 * Get method for global state keys - reads from in-memory cache
+	 */
+	getGlobalStateKey<K extends keyof GlobalState>(key: K): GlobalState[K] {
+		if (!this.isInitialized) {
+			throw new Error(STATE_MANAGER_NOT_INITIALIZED)
 		}
 		return this.globalStateCache[key]
 	}
@@ -682,7 +703,7 @@ export class StateManager {
 		this.pendingWorkspaceState.clear()
 		this.pendingTaskState.clear()
 
-		this.globalStateCache = {} as GlobalState
+		this.globalStateCache = {} as GlobalStateAndSettings
 		this.secretsCache = {} as Secrets
 		this.workspaceStateCache = {} as LocalState
 		this.taskStateCache = {}
@@ -728,7 +749,7 @@ export class StateManager {
 	/**
 	 * Private method to batch persist global state keys with Promise.all
 	 */
-	private async persistGlobalStateBatch(keys: Set<GlobalStateKey>): Promise<void> {
+	private async persistGlobalStateBatch(keys: Set<GlobalStateAndSettingsKey>): Promise<void> {
 		try {
 			await Promise.all(
 				Array.from(keys).map((key) => {
@@ -748,7 +769,7 @@ export class StateManager {
 	/**
 	 * Private method to batch persist task state keys with Promise.all
 	 */
-	private async persistTaskStateBatch(keys: Set<GlobalStateKey>, taskId: string | undefined): Promise<void> {
+	private async persistTaskStateBatch(keys: Set<SettingsKey>, taskId: string | undefined): Promise<void> {
 		if (!taskId) {
 			return
 		}

--- a/src/core/storage/state-keys.ts
+++ b/src/core/storage/state-keys.ts
@@ -18,7 +18,31 @@ export type GlobalStateKey = keyof GlobalState
 
 export type LocalStateKey = keyof LocalState
 
+export type SettingsKey = keyof Settings
+
+export type GlobalStateAndSettingsKey = keyof (GlobalState & Settings)
+
+export type GlobalStateAndSettings = GlobalState & Settings
+
 export interface GlobalState {
+	lastShownAnnouncementId: string | undefined
+	taskHistory: HistoryItem[]
+	userInfo: UserInfo | undefined
+	mcpMarketplaceCatalog: McpMarketplaceCatalog | undefined
+	favoritedModelIds: string[]
+	mcpMarketplaceEnabled: boolean
+	mcpResponsesCollapsed: boolean
+	terminalReuseEnabled: boolean
+	isNewUser: boolean
+	welcomeViewCompleted: boolean | undefined
+	mcpDisplayMode: McpDisplayMode
+	// Multi-root workspace support
+	workspaceRoots: WorkspaceRoot[] | undefined
+	primaryRootIndex: number
+	multiRootEnabled: boolean
+}
+
+export interface Settings {
 	awsRegion: string | undefined
 	awsUseCrossRegionInference: boolean | undefined
 	awsBedrockUsePromptCache: boolean | undefined
@@ -28,8 +52,6 @@ export interface GlobalState {
 	awsUseProfile: boolean | undefined
 	vertexProjectId: string | undefined
 	vertexRegion: string | undefined
-	lastShownAnnouncementId: string | undefined
-	taskHistory: HistoryItem[]
 	requestyBaseUrl: string | undefined
 	openAiBaseUrl: string | undefined
 	openAiHeaders: Record<string, string>
@@ -45,7 +67,6 @@ export interface GlobalState {
 	globalClineRulesToggles: ClineRulesToggles
 	globalWorkflowToggles: ClineRulesToggles
 	browserSettings: BrowserSettings
-	userInfo: UserInfo | undefined
 	liteLlmBaseUrl: string | undefined
 	liteLlmUsePromptCache: boolean | undefined
 	fireworksModelMaxCompletionTokens: number | undefined
@@ -53,22 +74,14 @@ export interface GlobalState {
 	qwenApiLine: string | undefined
 	moonshotApiLine: string | undefined
 	zaiApiLine: string | undefined
-	mcpMarketplaceCatalog: McpMarketplaceCatalog | undefined
 	telemetrySetting: TelemetrySetting
 	asksageApiUrl: string | undefined
 	planActSeparateModelsSetting: boolean
 	enableCheckpointsSetting: boolean
-	mcpMarketplaceEnabled: boolean
-	favoritedModelIds: string[]
 	requestTimeoutMs: number | undefined
 	shellIntegrationTimeout: number
-	mcpResponsesCollapsed: boolean
-	terminalReuseEnabled: boolean
 	defaultTerminalProfile: string
-	isNewUser: boolean
-	welcomeViewCompleted: boolean | undefined
 	terminalOutputLineLimit: number
-	mcpDisplayMode: McpDisplayMode
 	sapAiCoreTokenUrl: string | undefined
 	sapAiCoreBaseUrl: string | undefined
 	sapAiResourceGroup: string | undefined
@@ -84,11 +97,6 @@ export interface GlobalState {
 	focusChainSettings: FocusChainSettings
 	customPrompt: "compact" | undefined
 	difyBaseUrl: string | undefined
-
-	// Multi-root workspace support
-	workspaceRoots: WorkspaceRoot[] | undefined
-	primaryRootIndex: number
-	multiRootEnabled: boolean
 
 	// Plan mode configurations
 	planModeApiProvider: ApiProvider

--- a/src/core/storage/utils/state-helpers.ts
+++ b/src/core/storage/utils/state-helpers.ts
@@ -10,7 +10,7 @@ import { Mode, OpenaiReasoningEffort } from "@/shared/storage/types"
 import { TelemetrySetting } from "@/shared/TelemetrySetting"
 import { UserInfo } from "@/shared/UserInfo"
 import { readTaskHistoryFromState } from "../disk"
-import { GlobalState, LocalState, SecretKey, Secrets } from "../state-keys"
+import { GlobalState, GlobalStateAndSettings, LocalState, SecretKey, Secrets } from "../state-keys"
 
 export async function readSecretsFromDisk(context: ExtensionContext): Promise<Secrets> {
 	const [
@@ -140,7 +140,7 @@ export async function readWorkspaceStateFromDisk(context: ExtensionContext): Pro
 	}
 }
 
-export async function readGlobalStateFromDisk(context: ExtensionContext): Promise<GlobalState> {
+export async function readGlobalStateFromDisk(context: ExtensionContext): Promise<GlobalStateAndSettings> {
 	try {
 		// Get all global state values
 		const strictPlanModeEnabled = context.globalState.get("strictPlanModeEnabled") as boolean | undefined
@@ -206,8 +206,8 @@ export async function readGlobalStateFromDisk(context: ExtensionContext): Promis
 		const focusChainSettings = context.globalState.get("focusChainSettings") as FocusChainSettings | undefined
 
 		const mcpMarketplaceCatalog = context.globalState.get("mcpMarketplaceCatalog") as GlobalState["mcpMarketplaceCatalog"]
-		const qwenCodeOauthPath = context.globalState.get("qwenCodeOauthPath") as GlobalState["qwenCodeOauthPath"]
-		const customPrompt = context.globalState.get("customPrompt") as GlobalState["customPrompt"]
+		const qwenCodeOauthPath = context.globalState.get<GlobalStateAndSettings["qwenCodeOauthPath"]>("qwenCodeOauthPath")
+		const customPrompt = context.globalState.get<GlobalStateAndSettings["customPrompt"]>("customPrompt")
 
 		// Get mode-related configurations
 		const mode = context.globalState.get("mode") as Mode | undefined

--- a/src/core/task/index.ts
+++ b/src/core/task/index.ts
@@ -1341,7 +1341,7 @@ export class Task {
 		const model = this.api.getModel()
 		const apiConfig = this.stateManager.getApiConfiguration()
 		const providerId = (this.mode === "plan" ? apiConfig.planModeApiProvider : apiConfig.actModeApiProvider) as string
-		const customPrompt = this.stateManager.getGlobalStateKey("customPrompt")
+		const customPrompt = this.stateManager.getGlobalSettingsKey("customPrompt")
 		return { model, providerId, customPrompt }
 	}
 

--- a/src/services/test/TestServer.ts
+++ b/src/services/test/TestServer.ts
@@ -49,7 +49,7 @@ let messageCatcherDisposable: vscode.Disposable | undefined
  */
 async function updateAutoApprovalSettings(_context: vscode.ExtensionContext, controller?: Controller) {
 	try {
-		const autoApprovalSettings = controller?.stateManager.getGlobalStateKey("autoApprovalSettings")
+		const autoApprovalSettings = controller?.stateManager.getGlobalSettingsKey("autoApprovalSettings")
 
 		// Enable all actions
 		const updatedSettings: AutoApprovalSettings = {


### PR DESCRIPTION


### Description

Break up state and settings types for better granularity, especially when making gRPC calls.

Split up state and settings getter functions.

### Test Procedure

Run type check

Build the extension and confirm the settings are properly fetched.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [x] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Refactor state management to separate settings from state using new methods in `StateManager`, affecting multiple files for improved code clarity.
> 
>   - **State Management**:
>     - Introduced `getGlobalSettingsKey()` in `StateManager` to access settings separately from state.
>     - Updated `setGlobalState()` to handle both state and settings in `StateManager`.
>     - Modified `state-keys.ts` to define `Settings` and `GlobalState` separately.
>   - **Code Refactor**:
>     - Replaced `getGlobalStateKey()` with `getGlobalSettingsKey()` for settings access in `discoverBrowser.ts`, `getBrowserConnectionInfo.ts`, `getDetectedChromePath.ts`, `testBrowserConnection.ts`, `toggleClineRule.ts`, `toggleWorkflow.ts`, `index.ts`, `refreshRequestyModels.ts`, `updateSettings.ts`, `initializeWebview.ts`, and `TestServer.ts`.
>     - Updated `setGlobalState()` calls to handle settings in `updateSettings.ts` and `initializeWebview.ts`.
>   - **Miscellaneous**:
>     - Adjusted `state-helpers.ts` to read settings and state separately from disk.
>     - Updated `Task` class in `task/index.ts` to use new settings access methods.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 0d0e26d985707d068ca5b4af2b97173b2b458d83. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->