### PR TITLE
Update zAI endpoint, subscription plans, and usage details

### DIFF
--- a/.changeset/great-jars-flow.md
+++ b/.changeset/great-jars-flow.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Update zAI endpoint, subscription plans, and usage details

--- a/docs/provider-config/zai.mdx
+++ b/docs/provider-config/zai.mdx
@@ -56,16 +56,23 @@ Z AI offers subscription plans specifically designed for coding applications. Th
 #### Plan Options
 
 **GLM Coding Lite** - $3/month
-- 120 prompts per 5-hour cycle
-- Access to GLM-4.5 model
+- Powered by GLM-4.5
+- Up to ~120 prompts every 5 hours (about 3× the usage quota of the Claude Pro plan)
 - Works exclusively through coding tools like Cline
 
-**GLM Coding Pro** - $15/month  
-- 600 prompts per 5-hour cycle
-- Access to GLM-4.5 model
-- Works exclusively through coding tools like Cline
+**GLM Coding Pro** - $15/month
+- All Lite plan benefits
+- 5× Lite plan usage (~600 prompts every 5 hours, about 3× the usage quota of the Claude Max (5x) plan)
+- 40%–60% faster compared to Lite
+- Built-in image & video understanding and web search MCP
 
-Both plans offer promotional pricing for the first month: Lite drops from \$6 to \$3, Pro drops from \$30 to \$15.
+**GLM Coding Max** - $30/month
+- All Pro plan benefits
+- 4× Pro plan usage (~2400 prompts every 5 hours)
+- Guaranteed peak-hour performance
+- Early access to new features
+
+All plans offer promotional pricing for the first month: Lite drops from $6 to $3, Pro drops from $30 to $15, and Max drops from $60 to $30.
 
 <Frame>
   <img src="https://storage.googleapis.com/cline_public_images/docs/assets/zAI-coding-plan.png" alt="zAI subscription page showing GLM Coding Lite and Pro plans with pricing" />
@@ -84,6 +91,14 @@ To use the GLM Coding Plans with Cline:
 <Frame>
   <img src="https://storage.googleapis.com/cline_public_images/docs/assets/zAI-provider.png" alt="Cline settings with zAI provider selected and API key field highlighted" />
 </Frame>
+
+#### Usage Details
+
+In terms of token consumption, each prompt typically allows 15–20 model calls, giving a total monthly allowance of tens of billions of tokens — all at only ~1% of standard API pricing, making it extremely cost-effective.
+
+Once subscribed, GLM-4.5 is automatically available in the supported tools using your plan's quota—no additional configuration required. If the quota is exhausted, it will automatically reset at the start of the next 5-hour cycle. The system will not consume other resource packs or account balance. Users with a Coding Plan can only use the plan's quota in supported tools and cannot call the model separately via API.
+
+**Note:** API calls are billed separately and do not use the Coding Plan quota. Please refer to the API pricing for details.
 
 The setup connects your subscription directly to Cline, giving you access to GLM-4.5's tool-calling capabilities optimized for coding workflows.
 

--- a/src/core/api/providers/zai.ts
+++ b/src/core/api/providers/zai.ts
@@ -39,7 +39,9 @@ export class ZAiHandler implements ApiHandler {
 			}
 			try {
 				this.client = new OpenAI({
-					baseURL: this.useChinaApi() ? "https://open.bigmodel.cn/api/paas/v4" : "https://api.z.ai/api/paas/v4",
+					baseURL: this.useChinaApi()
+						? "https://open.bigmodel.cn/api/coding/paas/v4"
+						: "https://api.z.ai/api/coding/paas/v4",
 					apiKey: this.options.zaiApiKey,
 					defaultHeaders: {
 						"HTTP-Referer": "https://cline.bot",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Updates zAI endpoint URLs in `zai.ts` and enhances subscription plans and usage details in `zai.mdx`.
> 
>   - **API Endpoint Update**:
>     - Changes `baseURL` in `ZAiHandler` in `zai.ts` to use `/coding/paas/v4` for both international and China endpoints.
>   - **Subscription Plans**:
>     - Adds `GLM Coding Max` plan in `zai.mdx` with 4× Pro plan usage and early access to features.
>     - Updates `GLM Coding Lite` and `Pro` plans with new prompt limits and benefits.
>     - All plans offer promotional pricing for the first month.
>   - **Usage Details**:
>     - Describes token consumption and quota reset behavior in `zai.mdx`.
>     - Clarifies that API calls are billed separately from Coding Plan quota.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for c9b04e9532e1d2cbf776cb703ea5d82f08329b1a. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->