### PR TITLE
Don't use workspace resolver for tasks directory.

### DIFF
--- a/src/core/controller/task/getTotalTasksSize.ts
+++ b/src/core/controller/task/getTotalTasksSize.ts
@@ -8,7 +8,7 @@ import { Controller } from ".."
  * @param _request The empty request
  * @returns The total size as an Int64 value
  */
-export async function getTotalTasksSize(controller: Controller, _request: EmptyRequest): Promise<Int64> {
-	const totalSize = await calculateTotalTasksSize(controller.context.globalStorageUri.fsPath)
-	return Int64.create({ value: totalSize || 0 })
+export async function getTotalTasksSize(_controller: Controller, _request: EmptyRequest): Promise<Int64> {
+	const totalSize = await calculateTotalTasksSize()
+	return { value: totalSize || 0 }
 }

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -1,21 +1,14 @@
-import { workspaceResolver } from "@core/workspace"
 import getFolderSize from "get-folder-size"
+import path from "path"
+import { HostProvider } from "@/hosts/host-provider"
 
 /**
  * Gets the total size of tasks and checkpoints directories
- * @param storagePath The base storage path (typically globalStorageUri.fsPath)
  * @returns The total size in bytes, or null if calculation fails
  */
-export async function getTotalTasksSize(storagePath: string): Promise<number | null> {
-	const tasksDirResult = workspaceResolver.resolveWorkspacePath(storagePath, "tasks", "Utils.storage.getTotalTasksSize")
-	const checkpointsDirResult = workspaceResolver.resolveWorkspacePath(
-		storagePath,
-		"checkpoints",
-		"Utils.storage.getTotalTasksSize",
-	)
-
-	const tasksDir = typeof tasksDirResult === "string" ? tasksDirResult : tasksDirResult.absolutePath
-	const checkpointsDir = typeof checkpointsDirResult === "string" ? checkpointsDirResult : checkpointsDirResult.absolutePath
+export async function getTotalTasksSize(): Promise<number | null> {
+	const tasksDir = path.resolve(HostProvider.get().globalStorageFsPath, "tasks")
+	const checkpointsDir = path.resolve(HostProvider.get().globalStorageFsPath, "checkpoints")
 
 	try {
 		const tasksSize = await getFolderSize.loose(tasksDir)


### PR DESCRIPTION
The tasks and checkpoint directories are not part of the workspace, they are cline internal data directories.

Replace context.globalStorageUri wih HostProvider.globalStorageFsPath

<img width="514" height="844" alt="Screenshot 2025-09-17 at 09 29 57" src="https://github.com/user-attachments/assets/491f09f4-2a8a-4d9a-91c0-b9bae4104cd2" />
