### PR TITLE
Replace context.globalStorageUri with the HostProvider

### DIFF
--- a/src/core/controller/file/openTaskHistory.ts
+++ b/src/core/controller/file/openTaskHistory.ts
@@ -1,6 +1,7 @@
 import { openFile as openFileIntegration } from "@integrations/misc/open-file"
 import { Empty, StringRequest } from "@shared/proto/cline/common"
 import path from "path"
+import { HostProvider } from "@/hosts/host-provider"
 import { Controller } from ".."
 /**
  * Opens a file in the editor
@@ -8,8 +9,8 @@ import { Controller } from ".."
  * @param request The request message containing the file path in the 'value' field
  * @returns Empty response
  */
-export async function openTaskHistory(controller: Controller, request: StringRequest): Promise<Empty> {
-	const globalStoragePath = controller.context.globalStorageUri.fsPath
+export async function openTaskHistory(_controller: Controller, request: StringRequest): Promise<Empty> {
+	const globalStoragePath = HostProvider.get().globalStorageFsPath
 	const taskHistoryPath = path.join(globalStoragePath, "tasks", request.value, "api_conversation_history.json")
 	if (request.value) {
 		openFileIntegration(taskHistoryPath)

--- a/src/core/controller/index.ts
+++ b/src/core/controller/index.ts
@@ -593,7 +593,7 @@ export class Controller {
 		const history = this.stateManager.getGlobalStateKey("taskHistory")
 		const historyItem = history.find((item) => item.id === id)
 		if (historyItem) {
-			const taskDirPath = path.join(this.context.globalStorageUri.fsPath, "tasks", id)
+			const taskDirPath = path.join(HostProvider.get().globalStorageFsPath, "tasks", id)
 			const apiConversationHistoryFilePath = path.join(taskDirPath, GlobalFileNames.apiConversationHistory)
 			const uiMessagesFilePath = path.join(taskDirPath, GlobalFileNames.uiMessages)
 			const contextHistoryFilePath = path.join(taskDirPath, GlobalFileNames.contextHistory)

--- a/src/core/controller/task/deleteAllTaskHistory.ts
+++ b/src/core/controller/task/deleteAllTaskHistory.ts
@@ -51,7 +51,7 @@ export async function deleteAllTaskHistory(controller: Controller): Promise<Dele
 
 				// Delete non-favorited task directories
 				const preserveTaskIds = favoritedTasks.map((task) => task.id)
-				await cleanupTaskFiles(controller, preserveTaskIds)
+				await cleanupTaskFiles(preserveTaskIds)
 
 				// Update webview
 				try {
@@ -91,13 +91,13 @@ export async function deleteAllTaskHistory(controller: Controller): Promise<Dele
 
 		try {
 			// Remove all contents of tasks directory
-			const taskDirPath = path.join(controller.context.globalStorageUri.fsPath, "tasks")
+			const taskDirPath = path.join(HostProvider.get().globalStorageFsPath, "tasks")
 			if (await fileExistsAtPath(taskDirPath)) {
 				await fs.rm(taskDirPath, { recursive: true, force: true })
 			}
 
 			// Remove checkpoints directory contents
-			const checkpointsDirPath = path.join(controller.context.globalStorageUri.fsPath, "checkpoints")
+			const checkpointsDirPath = path.join(HostProvider.get().globalStorageFsPath, "checkpoints")
 			if (await fileExistsAtPath(checkpointsDirPath)) {
 				await fs.rm(checkpointsDirPath, { recursive: true, force: true })
 			}
@@ -127,8 +127,8 @@ export async function deleteAllTaskHistory(controller: Controller): Promise<Dele
 /**
  * Helper function to cleanup task files while preserving specified tasks
  */
-async function cleanupTaskFiles(controller: Controller, preserveTaskIds: string[]) {
-	const taskDirPath = path.join(controller.context.globalStorageUri.fsPath, "tasks")
+async function cleanupTaskFiles(preserveTaskIds: string[]) {
+	const taskDirPath = path.join(HostProvider.get().globalStorageFsPath, "tasks")
 
 	try {
 		if (await fileExistsAtPath(taskDirPath)) {

--- a/src/core/controller/task/deleteTasksWithIds.ts
+++ b/src/core/controller/task/deleteTasksWithIds.ts
@@ -80,8 +80,8 @@ async function deleteTaskWithId(controller: Controller, id: string): Promise<voi
 
 		// If no tasks remain, clean up everything
 		if (updatedTaskHistory.length === 0) {
-			const taskDirPath = path.join(controller.context.globalStorageUri.fsPath, "tasks")
-			const checkpointsDirPath = path.join(controller.context.globalStorageUri.fsPath, "checkpoints")
+			const taskDirPath = path.join(HostProvider.get().globalStorageFsPath, "tasks")
+			const checkpointsDirPath = path.join(HostProvider.get().globalStorageFsPath, "checkpoints")
 
 			if (await fileExistsAtPath(taskDirPath)) {
 				await fs.rm(taskDirPath, { recursive: true, force: true })

--- a/src/dev/commands/tasks.ts
+++ b/src/dev/commands/tasks.ts
@@ -27,7 +27,7 @@ export function registerTaskCommands(context: vscode.ExtensionContext, controlle
 			}
 
 			const tasksCount = parseInt(count)
-			const globalStoragePath = context.globalStorageUri.fsPath
+			const globalStoragePath = HostProvider.get().globalStorageFsPath
 			const tasksDir = path.join(globalStoragePath, "tasks")
 
 			vscode.window.withProgress(


### PR DESCRIPTION
Replace uses of `context.globalStorageUri` with `HostProvider.get().globalStorageFsPath`

This is part of removing dependencies on the VSCode API fom the codebase except for in platform specific code in src/hosts/vscode and src/extension.ts.