### PR TITLE
Replace context.globalStorageUri with the HostProvider in CheckpointTracker

### DIFF
--- a/src/integrations/checkpoints/CheckpointTracker.ts
+++ b/src/integrations/checkpoints/CheckpointTracker.ts
@@ -38,7 +38,6 @@ import { getShadowGitPath, getWorkingDirectory, hashWorkingDir } from "./Checkpo
  */
 
 class CheckpointTracker {
-	private globalStoragePath: string
 	private taskId: string
 	private cwd: string
 	private cwdHash: string
@@ -61,8 +60,7 @@ class CheckpointTracker {
 	 * @param cwd - The current working directory to track files in
 	 * @param cwdHash - Hash of the working directory path for shadow git organization
 	 */
-	private constructor(globalStoragePath: string, taskId: string, cwd: string, cwdHash: string) {
-		this.globalStoragePath = globalStoragePath
+	private constructor(taskId: string, cwd: string, cwdHash: string) {
 		this.taskId = taskId
 		this.cwd = cwd
 		this.cwdHash = cwdHash
@@ -89,14 +87,7 @@ class CheckpointTracker {
 	 * Configuration:
 	 * - Respects 'cline.enableCheckpoints' VS Code setting
 	 */
-	public static async create(
-		taskId: string,
-		globalStoragePath: string | undefined,
-		enableCheckpointsSetting: boolean,
-	): Promise<CheckpointTracker | undefined> {
-		if (!globalStoragePath) {
-			throw new Error("Global storage path is required to create a checkpoint tracker")
-		}
+	public static async create(taskId: string, enableCheckpointsSetting: boolean): Promise<CheckpointTracker | undefined> {
 		try {
 			console.info(`Creating new CheckpointTracker for task ${taskId}`)
 			const startTime = performance.now()
@@ -118,9 +109,9 @@ class CheckpointTracker {
 			const cwdHash = hashWorkingDir(workingDir)
 			console.debug(`Repository ID (cwdHash): ${cwdHash}`)
 
-			const newTracker = new CheckpointTracker(globalStoragePath, taskId, workingDir, cwdHash)
+			const newTracker = new CheckpointTracker(taskId, workingDir, cwdHash)
 
-			const gitPath = await getShadowGitPath(newTracker.globalStoragePath, newTracker.taskId, newTracker.cwdHash)
+			const gitPath = await getShadowGitPath(newTracker.cwdHash)
 			await newTracker.gitOperations.initShadowGit(gitPath, workingDir, taskId)
 
 			const durationMs = Math.round(performance.now() - startTime)
@@ -163,7 +154,7 @@ class CheckpointTracker {
 			console.info(`Creating new checkpoint commit for task ${this.taskId}`)
 			const startTime = performance.now()
 
-			const gitPath = await getShadowGitPath(this.globalStoragePath, this.taskId, this.cwdHash)
+			const gitPath = await getShadowGitPath(this.cwdHash)
 			const git = simpleGit(path.dirname(gitPath))
 
 			console.info(`Using shadow git at: ${gitPath}`)
@@ -224,7 +215,7 @@ class CheckpointTracker {
 			return this.lastRetrievedShadowGitConfigWorkTree
 		}
 		try {
-			const gitPath = await getShadowGitPath(this.globalStoragePath, this.taskId, this.cwdHash)
+			const gitPath = await getShadowGitPath(this.cwdHash)
 			this.lastRetrievedShadowGitConfigWorkTree = await this.gitOperations.getShadowGitConfigWorkTree(gitPath)
 			return this.lastRetrievedShadowGitConfigWorkTree
 		} catch (error) {
@@ -253,7 +244,7 @@ class CheckpointTracker {
 		console.info(`Resetting to checkpoint: ${commitHash}`)
 		const startTime = performance.now()
 
-		const gitPath = await getShadowGitPath(this.globalStoragePath, this.taskId, this.cwdHash)
+		const gitPath = await getShadowGitPath(this.cwdHash)
 		const git = simpleGit(path.dirname(gitPath))
 		console.debug(`Using shadow git at: ${gitPath}`)
 		await git.reset(["--hard", this.cleanCommitHash(commitHash)]) // Hard reset to target commit
@@ -289,7 +280,7 @@ class CheckpointTracker {
 	> {
 		const startTime = performance.now()
 
-		const gitPath = await getShadowGitPath(this.globalStoragePath, this.taskId, this.cwdHash)
+		const gitPath = await getShadowGitPath(this.cwdHash)
 		const git = simpleGit(path.dirname(gitPath))
 
 		console.info(`Getting diff between commits: ${lhsHash || "initial"} -> ${rhsHash || "working directory"}`)
@@ -354,7 +345,7 @@ class CheckpointTracker {
 	public async getDiffCount(lhsHash: string, rhsHash?: string): Promise<number> {
 		const startTime = performance.now()
 
-		const gitPath = await getShadowGitPath(this.globalStoragePath, this.taskId, this.cwdHash)
+		const gitPath = await getShadowGitPath(this.cwdHash)
 		const git = simpleGit(path.dirname(gitPath))
 
 		console.info(`Getting diff count between commits: ${lhsHash || "initial"} -> ${rhsHash || "working directory"}`)

--- a/src/integrations/checkpoints/CheckpointUtils.ts
+++ b/src/integrations/checkpoints/CheckpointUtils.ts
@@ -1,6 +1,7 @@
 import { access, constants, mkdir } from "fs/promises"
 import os from "os"
 import * as path from "path"
+import { HostProvider } from "@/hosts/host-provider"
 import { getCwd, getDesktopDir } from "@/utils/path"
 
 /**
@@ -12,17 +13,12 @@ import { getCwd, getDesktopDir } from "@/utils/path"
  *     {cwdHash}/
  *       .git/
  *
- * @param globalStoragePath - The VS Code global storage path
- * @param taskId - The ID of the task
  * @param cwdHash - Hash of the working directory path
  * @returns Promise<string> The absolute path to the shadow git directory
  * @throws Error if global storage path is invalid
  */
-export async function getShadowGitPath(globalStoragePath: string, _taskId: string, cwdHash: string): Promise<string> {
-	if (!globalStoragePath) {
-		throw new Error("Global storage uri is invalid")
-	}
-	const checkpointsDir = path.join(globalStoragePath, "checkpoints", cwdHash)
+export async function getShadowGitPath(cwdHash: string): Promise<string> {
+	const checkpointsDir = path.join(HostProvider.get().globalStorageFsPath, "checkpoints", cwdHash)
 	await mkdir(checkpointsDir, { recursive: true })
 	const gitPath = path.join(checkpointsDir, ".git")
 	return gitPath

--- a/src/integrations/checkpoints/MultiRootCheckpointManager.ts
+++ b/src/integrations/checkpoints/MultiRootCheckpointManager.ts
@@ -88,7 +88,7 @@ export class MultiRootCheckpointManager implements ICheckpointManager {
 		const initPromises = gitRoots.map(async (root) => {
 			try {
 				console.log(`[MultiRootCheckpointManager] Creating tracker for ${root.name} at ${root.path}`)
-				const tracker = await CheckpointTracker.create(this.taskId, this.globalStoragePath, this.enableCheckpoints)
+				const tracker = await CheckpointTracker.create(this.taskId, this.enableCheckpoints)
 				if (tracker) {
 					this.trackers.set(root.path, tracker)
 					console.log(`[MultiRootCheckpointManager] Successfully initialized tracker for ${root.name}`)

--- a/src/integrations/checkpoints/index.ts
+++ b/src/integrations/checkpoints/index.ts
@@ -274,7 +274,6 @@ export class TaskCheckpointManager implements ICheckpointManager {
 						try {
 							this.state.checkpointTracker = await CheckpointTracker.create(
 								this.task.taskId,
-								this.services.context.globalStorageUri.fsPath,
 								this.config.enableCheckpoints,
 							)
 							this.services.messageStateHandler.setCheckpointTracker(this.state.checkpointTracker)
@@ -424,11 +423,7 @@ export class TaskCheckpointManager implements ICheckpointManager {
 			// Initialize checkpoint tracker if needed
 			if (!this.state.checkpointTracker && this.config.enableCheckpoints && !this.state.checkpointManagerErrorMessage) {
 				try {
-					this.state.checkpointTracker = await CheckpointTracker.create(
-						this.task.taskId,
-						this.services.context.globalStorageUri.fsPath,
-						this.config.enableCheckpoints,
-					)
+					this.state.checkpointTracker = await CheckpointTracker.create(this.task.taskId, this.config.enableCheckpoints)
 					this.services.messageStateHandler.setCheckpointTracker(this.state.checkpointTracker)
 				} catch (error) {
 					const errorMessage = error instanceof Error ? error.message : "Unknown error"
@@ -591,11 +586,7 @@ export class TaskCheckpointManager implements ICheckpointManager {
 
 			if (this.config.enableCheckpoints && !this.state.checkpointTracker && !this.state.checkpointManagerErrorMessage) {
 				try {
-					this.state.checkpointTracker = await CheckpointTracker.create(
-						this.task.taskId,
-						this.services.context.globalStorageUri.fsPath,
-						this.config.enableCheckpoints,
-					)
+					this.state.checkpointTracker = await CheckpointTracker.create(this.task.taskId, this.config.enableCheckpoints)
 					this.services.messageStateHandler.setCheckpointTracker(this.state.checkpointTracker)
 				} catch (error) {
 					const errorMessage = error instanceof Error ? error.message : "Unknown error"
@@ -797,18 +788,11 @@ export class TaskCheckpointManager implements ICheckpointManager {
 			}, 7_000)
 
 			// Timeout - If checkpoints take too long to initialize, warn user and disable checkpoints for the task
-			const tracker = await pTimeout(
-				CheckpointTracker.create(
-					this.task.taskId,
-					this.services.context.globalStorageUri.fsPath,
-					this.config.enableCheckpoints,
-				),
-				{
-					milliseconds: 15_000,
-					message:
-						"Checkpoints taking too long to initialize. Consider re-opening Cline in a project that uses git, or disabling checkpoints.",
-				},
-			)
+			const tracker = await pTimeout(CheckpointTracker.create(this.task.taskId, this.config.enableCheckpoints), {
+				milliseconds: 15_000,
+				message:
+					"Checkpoints taking too long to initialize. Consider re-opening Cline in a project that uses git, or disabling checkpoints.",
+			})
 
 			// Update the state with the created tracker
 			this.state.checkpointTracker = tracker


### PR DESCRIPTION
Replace context.globalStorageUri with the HostProvider.globalStorageFsPath.

Remove globalStoragePath param, it doesn't need to be passed around anymore.

Remove unused param taskId from shadowGit