### PR TITLE
test: refactor chat e2e tests to support multi-roots workspace types

### DIFF
--- a/src/test/e2e/chat.test.ts
+++ b/src/test/e2e/chat.test.ts
@@ -52,24 +52,24 @@ e2e.describe("Chat - can send messages and switch between modes", () => {
 			await expect(sidebar.getByText("API Request Failed")).toBeVisible()
 
 			// === slash commands preserve following text ===
+			await inputbox.fill("")
+			await expect(inputbox).toHaveValue("")
 			await inputbox.focus()
 
 			// Type partial slash command to trigger menu
-			await inputbox.type("/new")
+			await inputbox.pressSequentially("/new")
 
 			// Wait for menu to be visible and select first option with Tab
 			await inputbox.press("Tab")
 			await expect(inputbox).toHaveValue("/newtask ")
 
 			// Add following text to verify it works correctly
-			await inputbox.fill("following text should be preserved")
+			await inputbox.pressSequentially("following text should be preserved")
 			await expect(inputbox).toHaveValue("/newtask following text should be preserved")
 
-			await inputbox.press("Control+A")
-			await inputbox.press("Backspace")
-			await expect(inputbox).toHaveValue("")
-
 			// === @ mentions preserve following text ===
+			await inputbox.fill("")
+			await expect(inputbox).toHaveValue("")
 			await inputbox.focus()
 
 			// Type partial @ mention to trigger menu
@@ -80,7 +80,7 @@ e2e.describe("Chat - can send messages and switch between modes", () => {
 			await expect(inputbox).toHaveValue("@problems ")
 
 			// Add following text to verify it works correctly
-			await inputbox.type("following text should be preserved")
+			await inputbox.pressSequentially("following text should be preserved")
 			await expect(inputbox).toHaveValue("@problems following text should be preserved")
 
 			await page.close()

--- a/src/test/e2e/chat.test.ts
+++ b/src/test/e2e/chat.test.ts
@@ -1,129 +1,89 @@
 import { expect } from "@playwright/test"
-import { e2e, e2eMultiRoot } from "./utils/helpers"
+import { E2E_WORKSPACE_TYPES, e2e } from "./utils/helpers"
 
-e2e("Chat - can send messages and switch between modes", async ({ helper, sidebar }) => {
-	// Sign in
-	await helper.signin(sidebar)
+e2e.describe("Chat - can send messages and switch between modes", () => {
+	E2E_WORKSPACE_TYPES.forEach(({ title, workspaceType }) => {
+		e2e.extend({
+			workspaceType,
+		})(title, async ({ helper, sidebar, page }) => {
+			// Sign in
+			await helper.signin(sidebar)
 
-	// Submit a message
-	const inputbox = sidebar.getByTestId("chat-input")
-	await expect(inputbox).toBeVisible()
-	await inputbox.fill("Hello, Cline!")
-	await expect(inputbox).toHaveValue("Hello, Cline!")
-	await sidebar.getByTestId("send-button").click({ delay: 100 })
-	await expect(inputbox).toHaveValue("")
+			// Submit a message
+			const inputbox = sidebar.getByTestId("chat-input")
+			await expect(inputbox).toBeVisible()
+			await inputbox.fill("Hello, Cline!")
+			await expect(inputbox).toHaveValue("Hello, Cline!")
+			await sidebar.getByTestId("send-button").click({ delay: 100 })
+			await expect(inputbox).toHaveValue("")
 
-	// Loading State initially
-	await expect(sidebar.getByText("API Request...")).toBeVisible()
+			// Loading State initially
+			await expect(sidebar.getByText("API Request...")).toBeVisible()
 
-	// The request should eventually fail
-	await expect(sidebar.getByText("API Request Failed")).toBeVisible()
+			// The request should eventually fail
+			await expect(sidebar.getByText("API Request Failed")).toBeVisible()
 
-	await expect(inputbox).toBeVisible()
+			await expect(inputbox).toBeVisible()
 
-	await expect(sidebar.getByRole("button", { name: "Retry" })).toBeVisible()
-	await expect(sidebar.getByRole("button", { name: "Start New Task" })).toBeVisible()
+			await expect(sidebar.getByRole("button", { name: "Retry" })).toBeVisible()
+			await expect(sidebar.getByRole("button", { name: "Start New Task" })).toBeVisible()
 
-	// Starting a new task should clear the current chat view and show the recent tasks
-	await sidebar.getByRole("button", { name: "Start New Task" }).click()
-	await expect(sidebar.getByText("API Request Failed")).not.toBeVisible()
-	await expect(sidebar.getByText("Recent Tasks")).toBeVisible()
-	await expect(sidebar.getByText("Hello, Cline!")).toBeVisible()
+			// Starting a new task should clear the current chat view and show the recent tasks
+			await sidebar.getByRole("button", { name: "Start New Task" }).click()
+			await expect(sidebar.getByText("API Request Failed")).not.toBeVisible()
+			await expect(sidebar.getByText("Recent Tasks")).toBeVisible()
+			await expect(sidebar.getByText("Hello, Cline!")).toBeVisible()
 
-	// Makes sure the act and plan switches are working correctly
-	// Aria-checked state should be true for Act and false for Plan
-	const actButton = sidebar.getByRole("switch", { name: "Act" })
-	const planButton = sidebar.getByRole("switch", { name: "Plan" })
+			// Makes sure the act and plan switches are working correctly
+			// Aria-checked state should be true for Act and false for Plan
+			const actButton = sidebar.getByRole("switch", { name: "Act" })
+			const planButton = sidebar.getByRole("switch", { name: "Plan" })
 
-	await expect(actButton).toBeChecked()
-	await expect(planButton).not.toBeChecked()
+			await expect(actButton).toBeChecked()
+			await expect(planButton).not.toBeChecked()
 
-	await actButton.click()
-	await expect(actButton).not.toBeChecked()
-	await expect(planButton).toBeChecked()
+			await actButton.click()
+			await expect(actButton).not.toBeChecked()
+			await expect(planButton).toBeChecked()
 
-	await sidebar.getByTestId("chat-input").fill("Plan mode submission")
-	await sidebar.getByTestId("send-button").click()
+			await inputbox.fill("Plan mode submission")
+			await sidebar.getByTestId("send-button").click()
 
-	await expect(sidebar.getByText("API Request Failed")).toBeVisible()
-})
+			await expect(sidebar.getByText("API Request Failed")).toBeVisible()
 
-e2e("Chat - slash commands preserve following text", async ({ helper, sidebar }) => {
-	// Sign in
-	await helper.signin(sidebar)
+			// === slash commands preserve following text ===
+			await inputbox.focus()
 
-	const inputbox = sidebar.getByTestId("chat-input")
-	await expect(inputbox).toBeVisible()
+			// Type partial slash command to trigger menu
+			await inputbox.type("/new")
 
-	// Type partial slash command to trigger menu
-	await inputbox.focus()
-	await inputbox.type("/new")
+			// Wait for menu to be visible and select first option with Tab
+			await inputbox.press("Tab")
+			await expect(inputbox).toHaveValue("/newtask ")
 
-	// Wait for menu to be visible and select first option with Tab
-	await inputbox.press("Tab")
-	await expect(inputbox).toHaveValue("/newtask ")
+			// Add following text to verify it works correctly
+			await inputbox.fill("following text should be preserved")
+			await expect(inputbox).toHaveValue("/newtask following text should be preserved")
 
-	// Add following text to verify it works correctly
-	await inputbox.type("following text should be preserved")
-	await expect(inputbox).toHaveValue("/newtask following text should be preserved")
-})
+			await inputbox.press("Control+A")
+			await inputbox.press("Backspace")
+			await expect(inputbox).toHaveValue("")
 
-e2e("Chat - @ mentions preserve following text", async ({ helper, sidebar }) => {
-	// Sign in
-	await helper.signin(sidebar)
+			// === @ mentions preserve following text ===
+			await inputbox.focus()
 
-	const inputbox = sidebar.getByTestId("chat-input")
-	await expect(inputbox).toBeVisible()
+			// Type partial @ mention to trigger menu
+			await inputbox.pressSequentially("@prob")
 
-	// Type partial @ mention to trigger menu
-	await inputbox.focus()
-	await inputbox.type("@prob")
+			// Wait for menu to be visible and select first option with Tab
+			await inputbox.press("Tab")
+			await expect(inputbox).toHaveValue("@problems ")
 
-	// Wait for menu to be visible and select first option with Tab
-	await inputbox.press("Tab")
-	await expect(inputbox).toHaveValue("@problems ")
+			// Add following text to verify it works correctly
+			await inputbox.type("following text should be preserved")
+			await expect(inputbox).toHaveValue("@problems following text should be preserved")
 
-	// Add following text to verify it works correctly
-	await inputbox.type("following text should be preserved")
-	await expect(inputbox).toHaveValue("@problems following text should be preserved")
-})
-
-e2e("Chat - partial slash command completion preserves text", async ({ helper, sidebar }) => {
-	// Sign in
-	await helper.signin(sidebar)
-
-	const inputbox = sidebar.getByTestId("chat-input")
-	await expect(inputbox).toBeVisible()
-
-	// Type partial slash command and complete it
-	await inputbox.focus()
-	await inputbox.type("/new")
-
-	// Complete the command with Tab
-	await inputbox.press("Tab")
-	await expect(inputbox).toHaveValue("/newtask ")
-
-	// Add following text after completion
-	await inputbox.type("some important text after")
-	await expect(inputbox).toHaveValue("/newtask some important text after")
-})
-
-e2eMultiRoot("[Multi-roots] Chat - partial @ mention completion preserves text", async ({ helper, sidebar }) => {
-	// Sign in
-	await helper.signin(sidebar)
-
-	const inputbox = sidebar.getByTestId("chat-input")
-	await expect(inputbox).toBeVisible()
-
-	// Type partial @ mention and complete it
-	await inputbox.focus()
-	await inputbox.type("@prob")
-
-	// Complete the mention with Tab
-	await inputbox.press("Tab")
-	await expect(inputbox).toHaveValue("@problems ")
-
-	// Add following text after completion
-	await inputbox.type("important content follows")
-	await expect(inputbox).toHaveValue("@problems important content follows")
+			await page.close()
+		})
+	})
 })

--- a/src/test/e2e/diff.test.ts
+++ b/src/test/e2e/diff.test.ts
@@ -1,59 +1,52 @@
-import { expect, Frame, Page } from "@playwright/test"
+import { expect } from "@playwright/test"
 import { cleanChatView } from "./utils/common"
-import { e2e, e2eMultiRoot } from "./utils/helpers"
+import { E2E_WORKSPACE_TYPES, e2e } from "./utils/helpers"
 
-/**
- * Shared test logic for diff editor tests
- * @param page - Playwright page object
- * @param sidebar - Sidebar frame for the Cline extension
- */
-async function testDiffEditor(page: Page, sidebar: Frame) {
-	await sidebar.getByRole("button", { name: "Get Started for Free" }).click({ delay: 100 })
-	// Submit a message
-	await cleanChatView(page)
+e2e.describe("Diff Editor", () => {
+	E2E_WORKSPACE_TYPES.forEach(({ title, workspaceType }) => {
+		e2e.extend({
+			workspaceType,
+		})(title, async ({ page, sidebar }) => {
+			await sidebar.getByRole("button", { name: "Get Started for Free" }).click({ delay: 100 })
+			// Submit a message
+			await cleanChatView(page)
 
-	const inputbox = sidebar.getByTestId("chat-input")
-	await expect(inputbox).toBeVisible()
+			const inputbox = sidebar.getByTestId("chat-input")
+			await expect(inputbox).toBeVisible()
 
-	await inputbox.fill("Hello, Cline!")
-	await expect(inputbox).toHaveValue("Hello, Cline!")
-	await sidebar.getByTestId("send-button").click({ delay: 100 })
-	await expect(inputbox).toHaveValue("")
+			await inputbox.fill("Hello, Cline!")
+			await expect(inputbox).toHaveValue("Hello, Cline!")
+			await sidebar.getByTestId("send-button").click({ delay: 100 })
+			await expect(inputbox).toHaveValue("")
 
-	// Loading State initially
-	await expect(sidebar.getByText("API Request...")).toBeVisible()
+			// Loading State initially
+			await expect(sidebar.getByText("API Request...")).toBeVisible()
 
-	// Back to home page with history
-	await sidebar.getByRole("button", { name: "Start New Task" }).click()
-	await expect(sidebar.getByText("Recent Tasks")).toBeVisible()
-	await expect(sidebar.getByText("Hello, Cline!")).toBeVisible() // History with the previous sent message
-	await expect(sidebar.getByText("Tokens:")).toBeVisible() // History with token usage
+			// Back to home page with history
+			await sidebar.getByRole("button", { name: "Start New Task" }).click()
+			await expect(sidebar.getByText("Recent Tasks")).toBeVisible()
+			await expect(sidebar.getByText("Hello, Cline!")).toBeVisible() // History with the previous sent message
+			await expect(sidebar.getByText("Tokens:")).toBeVisible() // History with token usage
 
-	// Submit a file edit request
-	await sidebar.getByTestId("chat-input").click()
-	await sidebar.getByTestId("chat-input").fill("edit_request")
-	await sidebar.getByTestId("send-button").click({ delay: 50 })
+			// Submit a file edit request
+			await sidebar.getByTestId("chat-input").click()
+			await sidebar.getByTestId("chat-input").fill("edit_request")
+			await sidebar.getByTestId("send-button").click({ delay: 50 })
 
-	// Wait for the sidebar to load the file edit request
-	await sidebar.waitForSelector('span:has-text("Cline wants to edit this file:")')
+			// Wait for the sidebar to load the file edit request
+			await sidebar.waitForSelector('span:has-text("Cline wants to edit this file:")')
 
-	// Cline Diff Editor should open with the file name and diff
-	await expect(page.getByText("test.ts: Original ↔ Cline's")).toBeVisible()
+			// Cline Diff Editor should open with the file name and diff
+			await expect(page.getByText("test.ts: Original ↔ Cline's")).toBeVisible()
 
-	// Diff editor should show the original and modified content
-	const diffEditor = page.locator(
-		".monaco-editor.modified-in-monaco-diff-editor > .overflow-guard > .monaco-scrollable-element.editor-scrollable > .lines-content > div:nth-child(4)",
-	)
-	await diffEditor.click()
-	await expect(diffEditor).toBeVisible()
+			// Diff editor should show the original and modified content
+			const diffEditor = page.locator(
+				".monaco-editor.modified-in-monaco-diff-editor > .overflow-guard > .monaco-scrollable-element.editor-scrollable > .lines-content > div:nth-child(4)",
+			)
+			await diffEditor.click()
+			await expect(diffEditor).toBeVisible()
 
-	await page.close()
-}
-
-e2e("Diff editor", async ({ page, sidebar }) => {
-	await testDiffEditor(page, sidebar)
-})
-
-e2eMultiRoot("[Multi-roots] Diff editor", async ({ page, sidebar }) => {
-	await testDiffEditor(page, sidebar)
+			await page.close()
+		})
+	})
 })

--- a/src/test/e2e/editor.test.ts
+++ b/src/test/e2e/editor.test.ts
@@ -1,43 +1,42 @@
-import { expect, Frame, Page } from "@playwright/test"
+import { expect } from "@playwright/test"
 import { addSelectedCodeToClineWebview, getClineEditorWebviewFrame, openTab, toggleNotifications } from "./utils/common"
-import { e2e, e2eMultiRoot } from "./utils/helpers"
+import { E2E_WORKSPACE_TYPES, e2e } from "./utils/helpers"
 
-async function editorTest(page: Page, sidebar: Frame) {
-	await sidebar.getByRole("button", { name: "Get Started for Free" }).click({ delay: 100 })
-	// Sidebar - input should start empty
-	const sidebarInput = sidebar.getByTestId("chat-input")
-	await sidebarInput.click()
-	await toggleNotifications(page)
-	await expect(sidebarInput).toBeEmpty()
+e2e.describe("Code Actions and Editor Panel", () => {
+	E2E_WORKSPACE_TYPES.forEach(({ title, workspaceType }) => {
+		e2e.extend({
+			workspaceType,
+		})(title, async ({ page, sidebar }) => {
+			await sidebar.getByRole("button", { name: "Get Started for Free" }).click({ delay: 100 })
+			// Sidebar - input should start empty
+			const sidebarInput = sidebar.getByTestId("chat-input")
+			await sidebarInput.click()
+			await toggleNotifications(page)
+			await expect(sidebarInput).toBeEmpty()
 
-	// Open file tree and select code from file
-	await openTab(page, "Explorer ")
-	await page.getByRole("treeitem", { name: "index.html" }).locator("a").click()
-	await expect(sidebarInput).not.toBeFocused()
+			// Open file tree and select code from file
+			await openTab(page, "Explorer ")
+			await page.getByRole("treeitem", { name: "index.html" }).locator("a").click()
+			await expect(sidebarInput).not.toBeFocused()
 
-	// Sidebar should be opened and visible after adding code to Cline
-	await addSelectedCodeToClineWebview(page)
-	await expect(sidebarInput).not.toBeEmpty()
-	await expect(sidebarInput).toBeFocused()
+			// Sidebar should be opened and visible after adding code to Cline
+			await addSelectedCodeToClineWebview(page)
+			await expect(sidebarInput).not.toBeEmpty()
+			await expect(sidebarInput).toBeFocused()
 
-	await page.getByRole("button", { name: "Open in Editor" }).click()
-	await page.waitForLoadState("load")
-	const clineEditorTab = page.getByRole("tab", { name: "Cline, Editor Group" })
-	await expect(clineEditorTab).toBeVisible()
+			await page.getByRole("button", { name: "Open in Editor" }).click()
+			await page.waitForLoadState("load")
+			const clineEditorTab = page.getByRole("tab", { name: "Cline, Editor Group" })
+			await expect(clineEditorTab).toBeVisible()
 
-	// Editor Panel
-	const clineEditorWebview = await getClineEditorWebviewFrame(page)
+			// Editor Panel
+			const clineEditorWebview = await getClineEditorWebviewFrame(page)
 
-	await clineEditorWebview.getByTestId("chat-input").click()
-	await expect(clineEditorWebview.getByTestId("chat-input")).toBeEmpty()
-	await addSelectedCodeToClineWebview(page)
-	await expect(clineEditorWebview.getByTestId("chat-input")).not.toBeEmpty()
-}
-
-e2e("Code actions and editor panel", async ({ page, sidebar }) => {
-	await editorTest(page, sidebar)
-})
-
-e2eMultiRoot("[Multi-roots] Code actions and editor panel", async ({ page, sidebar }) => {
-	await editorTest(page, sidebar)
+			await clineEditorWebview.getByTestId("chat-input").click()
+			await expect(clineEditorWebview.getByTestId("chat-input")).toBeEmpty()
+			await addSelectedCodeToClineWebview(page)
+			await expect(clineEditorWebview.getByTestId("chat-input")).not.toBeEmpty()
+			await page.close()
+		})
+	})
 })

--- a/src/test/e2e/utils/helpers.ts
+++ b/src/test/e2e/utils/helpers.ts
@@ -319,9 +319,7 @@ export const e2e = test
 		},
 	})
 
-/**
- * Multi-root workspace variant of the e2e test fixture
- */
-export const e2eMultiRoot = e2e.extend<E2ETestConfigs>({
-	workspaceType: "multi",
-})
+export const E2E_WORKSPACE_TYPES = [
+	{ title: "Single Root", workspaceType: "single" },
+	{ title: "Multi-Roots", workspaceType: "multi" },
+] as const


### PR DESCRIPTION
<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- For feature requests: Created a discussion in our Feature Requests discussions board https://github.com/cline/cline/discussions/categories/feature-requests and received approval from core maintainers before implementation
- For all changes: Link the associated issue/discussion in the "Related Issue" section below

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly without prior discussion.

Why this requirement?
We deeply appreciate all community contributions - they are essential to Cline's success! To ensure the best use of everyone's time and maintain project direction, we use our Feature Requests discussions board to gauge community interest and validate feature ideas before implementation begins. This helps us focus development efforts on features that will benefit the most users.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** #XXXX

### Description

<!-- 
Help reviewers understand your changes by making this PR readable and well-organized:

- What problem does this PR solve?
- Why were these changes introduced and what purpose do they serve?
- For larger changes, provide context about your approach and reasoning

Small PRs may need minimal description, but larger changes benefit from explaining where you're coming from. Much of this context can be in the linked issue above, so feel free to reference it rather than repeating everything here.
-->


- Convert single test functions to parameterized test suite using describe blocks
- Add workspace type iteration for both chat messaging and slash command tests
- Consolidate test structure to run against different workspace configurations
- Maintain existing test logic while improving test coverage and organization
- consolidate chat input tests into single comprehensive test

Merged three separate chat input tests (slash commands, @ mentions, and partial completion) into one comprehensive test to reduce test setup time and improve test efficiency. Simplified test structure while maintaining all original functionality checks.

### Test Procedure

<!-- 
Please walk us through your testing approach and thought process. This helps reviewers understand that you've thoroughly considered the impact of your changes:

- How did you test this change?
- What could potentially break and how did you verify it doesn't?
- What existing functionality might be affected and how did you check it still works?
- Why are you confident this is ready for merge?

We're not looking for exhaustive documentation - just evidence that you've thought through the implications of your changes and tested accordingly.
-->

`npm run test:e2e` should be green

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [x] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Refactor e2e tests to support multiple workspace types using parameterized test suites.
> 
>   - **Test Refactoring**:
>     - Refactor `chat.test.ts`, `diff.test.ts`, and `editor.test.ts` to support multiple workspace types using `E2E_WORKSPACE_TYPES`.
>     - Convert single test functions to parameterized test suites with `describe` blocks.
>     - Consolidate chat input tests into a single comprehensive test.
>   - **Helpers Update**:
>     - Remove `e2eMultiRoot` and replace with `E2E_WORKSPACE_TYPES` in `helpers.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 8a65d1c5640e1b43ecf9e17bbcefc93fa92cc97a. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->