### PR TITLE
refactor: unify import paths to use @shared alias

### DIFF
--- a/webview-ui/src/context/ExtensionStateContext.tsx
+++ b/webview-ui/src/context/ExtensionStateContext.tsx
@@ -1,19 +1,7 @@
 import type React from "react"
 import { createContext, useCallback, useContext, useEffect, useRef, useState } from "react"
-import "../../../src/shared/webview/types"
+import "@shared/webview/types"
 import { DEFAULT_AUTO_APPROVAL_SETTINGS } from "@shared/AutoApprovalSettings"
-import { findLastIndex } from "@shared/array"
-import { DEFAULT_BROWSER_SETTINGS } from "@shared/BrowserSettings"
-import { DEFAULT_PLATFORM, type ExtensionState } from "@shared/ExtensionMessage"
-import { DEFAULT_FOCUS_CHAIN_SETTINGS } from "@shared/FocusChainSettings"
-import { DEFAULT_MCP_DISPLAY_MODE } from "@shared/McpDisplayMode"
-import type { UserInfo } from "@shared/proto/cline/account"
-import { EmptyRequest, StringRequest } from "@shared/proto/cline/common"
-import type { OpenRouterCompatibleModelInfo } from "@shared/proto/cline/models"
-import { type TerminalProfile } from "@shared/proto/cline/state"
-import { WebviewProviderType as WebviewProviderTypeEnum, WebviewProviderTypeRequest } from "@shared/proto/cline/ui"
-import { convertProtoToClineMessage } from "@shared/proto-conversions/cline-message"
-import { convertProtoMcpServersToMcpServers } from "@shared/proto-conversions/mcp/mcp-server-conversion"
 import {
 	basetenDefaultModelId,
 	basetenModels,
@@ -26,8 +14,20 @@ import {
 	requestyDefaultModelInfo,
 	vercelAiGatewayDefaultModelId,
 	vercelAiGatewayDefaultModelInfo,
-} from "../../../src/shared/api"
-import type { McpMarketplaceCatalog, McpServer, McpViewTab } from "../../../src/shared/mcp"
+} from "@shared/api"
+import { findLastIndex } from "@shared/array"
+import { DEFAULT_BROWSER_SETTINGS } from "@shared/BrowserSettings"
+import { DEFAULT_PLATFORM, type ExtensionState } from "@shared/ExtensionMessage"
+import { DEFAULT_FOCUS_CHAIN_SETTINGS } from "@shared/FocusChainSettings"
+import { DEFAULT_MCP_DISPLAY_MODE } from "@shared/McpDisplayMode"
+import type { McpMarketplaceCatalog, McpServer, McpViewTab } from "@shared/mcp"
+import type { UserInfo } from "@shared/proto/cline/account"
+import { EmptyRequest, StringRequest } from "@shared/proto/cline/common"
+import type { OpenRouterCompatibleModelInfo } from "@shared/proto/cline/models"
+import { type TerminalProfile } from "@shared/proto/cline/state"
+import { WebviewProviderType as WebviewProviderTypeEnum, WebviewProviderTypeRequest } from "@shared/proto/cline/ui"
+import { convertProtoToClineMessage } from "@shared/proto-conversions/cline-message"
+import { convertProtoMcpServersToMcpServers } from "@shared/proto-conversions/mcp/mcp-server-conversion"
 import { McpServiceClient, ModelsServiceClient, StateServiceClient, UiServiceClient } from "../services/grpc-client"
 
 export interface ExtensionStateContextType extends ExtensionState {


### PR DESCRIPTION
### Related Issue

**Issue:** N/A (Small refactor, no functional changes)

---

### Description

This PR refactors a single file by replacing deep relative imports such as  
`../../../src/shared/...` with the path alias `@shared/...`.

Benefits:
- Improves readability by removing long relative paths
- Unifies import style across the project
- Provides better IDE support for autocomplete and navigation

Scope is limited to one file only. No functional changes.

---

### Test Procedure

- Ran `npm run lint` and `npm run format:fix` → no formatting or linting errors  
- Ran `npm run test` → all unit tests passed  
- Launched the VSCode extension in debug mode (`F5`) → webview loaded successfully with no runtime errors  

Since this is a path refactor only, no logic or features are affected.

---

### Type of Change

-   [ ] 🐛 Bug fix  
-   [ ] ✨ New feature  
-   [ ] 💥 Breaking change  
-   [x] ♻️ Refactor Changes  
-   [ ] 💅 Cosmetic Changes  
-   [ ] 📚 Documentation update  
-   [ ] 🏃 Workflow Changes  

---

### Pre-flight Checklist

-   [x] Changes are limited to a single refactor (import path replacement)  
-   [x] Tests are passing (`npm test`) and code is formatted/linted (`npm run format && npm run lint`)  
-   [ ] I have created a changeset using `npm run changeset` (not required since this is not user-facing)  
-   [x] I have reviewed the [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)  

---

### Screenshots

N/A (no UI changes)

---

### Additional Notes

- Small change, one file only  
- Pure refactor, no logic modifications  
- Safe to merge without functional impact  
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Refactor import paths in `ExtensionStateContext.tsx` to use `@shared` alias for improved readability and consistency.
> 
>   - **Refactor**:
>     - Replaces deep relative imports with `@shared` alias in `ExtensionStateContext.tsx`.
>     - Improves readability and unifies import style across the project.
>   - **Testing**:
>     - No functional changes; all tests pass, and no linting or formatting errors detected.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 815f60a69fc4ec87a1c60c33f57d1c6666c14aa0. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->