### PR TITLE
fix: test e2e click “Show Code Actions” button then wait for listbox on macOS

### DIFF
--- a/src/test/e2e/utils/common.ts
+++ b/src/test/e2e/utils/common.ts
@@ -11,7 +11,8 @@ export const addSelectedCodeToClineWebview = async (_page: Page) => {
 	await _page.locator("div:nth-child(4) > span > span").first().click()
 	await _page.getByRole("textbox", { name: "The editor is not accessible" }).press("ControlOrMeta+a")
 
-	await _page.getByRole("listbox", { name: /Show Code Actions / }).click()
+	await _page.getByRole("button", { name: /Show Code Actions/ }).click()
+	await _page.getByRole("listbox").first().waitFor({ state: "visible" })
 	await _page.keyboard.press("Enter", { delay: 100 }) // First action - "Add to Cline"
 }
 

--- a/src/test/e2e/utils/common.ts
+++ b/src/test/e2e/utils/common.ts
@@ -11,8 +11,14 @@ export const addSelectedCodeToClineWebview = async (_page: Page) => {
 	await _page.locator("div:nth-child(4) > span > span").first().click()
 	await _page.getByRole("textbox", { name: "The editor is not accessible" }).press("ControlOrMeta+a")
 
-	await _page.getByRole("button", { name: /Show Code Actions/ }).click()
-	await _page.getByRole("listbox").first().waitFor({ state: "visible" })
+	// Open Code Actions via keyboard for cross-platform reliability
+	await _page.keyboard.press("ControlOrMeta+.")
+	// Wait for the Code Actions UI to appear (listbox or menu depending on platform/version)
+	try {
+		await _page.getByRole("listbox").first().waitFor({ state: "visible", timeout: 3000 })
+	} catch {
+		await _page.getByRole("menu").first().waitFor({ state: "visible" })
+	}
 	await _page.keyboard.press("Enter", { delay: 100 }) // First action - "Add to Cline"
 }
 

--- a/src/test/e2e/utils/common.ts
+++ b/src/test/e2e/utils/common.ts
@@ -15,9 +15,9 @@ export const addSelectedCodeToClineWebview = async (_page: Page) => {
 	await _page.keyboard.press("ControlOrMeta+.")
 	// Wait for the Code Actions UI to appear (listbox or menu depending on platform/version)
 	try {
-		await _page.getByRole("listbox").first().waitFor({ state: "visible", timeout: 3000 })
+		await _page.getByRole("listbox").first().waitFor({ state: "visible", timeout: 5000 })
 	} catch {
-		await _page.getByRole("menu").first().waitFor({ state: "visible" })
+		await _page.getByRole("menu").first().waitFor({ state: "visible", timeout: 5000 })
 	}
 	await _page.keyboard.press("Enter", { delay: 100 }) // First action - "Add to Cline"
 }


### PR DESCRIPTION


<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- For feature requests: Created a discussion in our Feature Requests discussions board https://github.com/cline/cline/discussions/categories/feature-requests and received approval from core maintainers before implementation
- For all changes: Link the associated issue/discussion in the "Related Issue" section below

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly without prior discussion.

Why this requirement?
We deeply appreciate all community contributions - they are essential to Cline's success! To ensure the best use of everyone's time and maintain project direction, we use our Feature Requests discussions board to gauge community interest and validate feature ideas before implementation begins. This helps us focus development efforts on features that will benefit the most users.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** #XXXX

### Description
Fixes a flaky Playwright step in addSelectedCodeToClineWebview where the test attempted to click a non-existent listbox. The accessible name belongs to a button; the listbox appears after the click.

<!-- 
Help reviewers understand your changes by making this PR readable and well-organized:

- What problem does this PR solve?
- Why were these changes introduced and what purpose do they serve?
- For larger changes, provide context about your approach and reasoning

Small PRs may need minimal description, but larger changes benefit from explaining where you're coming from. Much of this context can be in the linked issue above, so feel free to reference it rather than repeating everything here.
-->

### Test Procedure

<!-- 
Please walk us through your testing approach and thought process. This helps reviewers understand that you've thoroughly considered the impact of your changes:

- How did you test this change?
- What could potentially break and how did you verify it doesn't?
- What existing functionality might be affected and how did you check it still works?
- Why are you confident this is ready for merge?

We're not looking for exhaustive documentation - just evidence that you've thought through the implications of your changes and tested accordingly.
-->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes flaky test in `addSelectedCodeToClineWebview` by using keyboard shortcuts and waiting for UI elements for cross-platform reliability.
> 
>   - **Behavior**:
>     - Fixes flaky test in `addSelectedCodeToClineWebview` in `common.ts` by using keyboard shortcut `ControlOrMeta+.` to open Code Actions.
>     - Waits for either `listbox` or `menu` to appear, ensuring cross-platform compatibility.
>   - **Misc**:
>     - Adds error handling for waiting on UI elements in `addSelectedCodeToClineWebview`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for d8b63a2ce5fda0f8050bb3d9f12bc5b69ab044ba. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->