### PR TITLE
Consolidate duplicated code in BrowserSession and UrlContextFetcher

### DIFF
--- a/src/services/browser/utils.ts
+++ b/src/services/browser/utils.ts
@@ -1,0 +1,26 @@
+import { fileExistsAtPath } from "@utils/fs"
+import * as fs from "fs/promises"
+import * as path from "path"
+// @ts-ignore
+import PCR from "puppeteer-chromium-resolver"
+import { launch } from "puppeteer-core"
+import { HostProvider } from "@/hosts/host-provider"
+
+interface PCRStats {
+	puppeteer: { launch: typeof launch }
+	executablePath: string
+}
+
+export async function ensureChromiumExists(): Promise<PCRStats> {
+	const puppeteerDir = path.join(HostProvider.get().globalStorageFsPath, "puppeteer")
+	const dirExists = await fileExistsAtPath(puppeteerDir)
+	if (!dirExists) {
+		await fs.mkdir(puppeteerDir, { recursive: true })
+	}
+	// if chromium doesn't exist, this will download it to path.join(puppeteerDir, ".chromium-browser-snapshots")
+	// if it does exist it will return the path to existing chromium
+	const stats: PCRStats = await PCR({
+		downloadPath: puppeteerDir,
+	})
+	return stats
+}


### PR DESCRIPTION
Move duplicated function ensureChromiumExists to utils.ts

Replace context.globalStorageUri with the HostProvider.globalStorageFsPath.
This is part of removing dependencies on the VSCode API fom the codebase except for in platform specific code in src/hosts/vscode and src/extension.ts.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Consolidates duplicated `ensureChromiumExists` function into `utils.ts` and replaces `context.globalStorageUri` with `HostProvider.globalStorageFsPath` to reduce VSCode API dependencies.
> 
>   - **Code Consolidation**:
>     - Moved `ensureChromiumExists` function to `utils.ts`.
>     - Updated `BrowserSession.ts` and `UrlContentFetcher.ts` to use `ensureChromiumExists` from `utils.ts`.
>   - **Dependency Reduction**:
>     - Replaced `context.globalStorageUri` with `HostProvider.globalStorageFsPath` in `utils.ts` to reduce VSCode API dependencies.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 833f28848c7c0e2dd42a73f7e9439e33be288236. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->