### PR TITLE
Set telemetry env vars for JetBrains builds [esbuild]

### DIFF
--- a/esbuild.mjs
+++ b/esbuild.mjs
@@ -124,9 +124,12 @@ const copyWasmFiles = {
 }
 
 const buildEnvVars = { "import.meta.url": "_importMetaUrl" }
-if (!production) {
-	buildEnvVars["process.env.IS_DEV"] = "true"
+if (production) {
+	// IS_DEV is always disable in production builds.
+	buildEnvVars["process.env.IS_DEV"] = "false"
 }
+// Set the environment and telemetry env vars. The API key env vars need to be populated in the GitHub
+// workflows from the secrets.
 if (process.env.CLINE_ENVIRONMENT) {
 	buildEnvVars["process.env.CLINE_ENVIRONMENT"] = JSON.stringify(process.env.CLINE_ENVIRONMENT)
 }

--- a/src/standalone/cline-core.ts
+++ b/src/standalone/cline-core.ts
@@ -14,7 +14,6 @@ import { log } from "./utils"
 import { DATA_DIR, EXTENSION_DIR, extensionContext } from "./vscode-context"
 
 async function main() {
-	log(`CLINE_ENVIRONMENT: ${process.env.CLINE_ENVIRONMENT}`)
 	log("\n\n\nStarting cline-core service...\n\n\n")
 
 	await waitForHostBridgeReady()

--- a/src/standalone/vscode-context.ts
+++ b/src/standalone/vscode-context.ts
@@ -9,6 +9,7 @@ import { log } from "./utils"
 import { EnvironmentVariableCollection, MementoStore, readJson, SecretStore } from "./vscode-context-utils"
 
 log("Running standalone cline", ExtensionRegistryInfo.version)
+log(`CLINE_ENVIRONMENT: ${process.env.CLINE_ENVIRONMENT}`)
 
 export const CLINE_DIR = process.env.CLINE_DIR || `${os.homedir()}/.cline`
 export const DATA_DIR = path.join(CLINE_DIR, "data")


### PR DESCRIPTION
In esbuild.js, always set the build env vars, instead of only setting them for production builds.

All the JetBrains builds were being built as !production because it does not have a way to pass the --production flag, allow setting the production value using an env var.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Set telemetry environment variables for all builds and allow JetBrains builds to be treated as production using an environment variable.
> 
>   - **Behavior**:
>     - In `esbuild.mjs`, set telemetry environment variables for all builds, not just production.
>     - Allow JetBrains builds to be treated as production by checking `process.env["IS_DEBUG_BUILD"] === "false"`.
>   - **Logging**:
>     - Add log statement in `vscode-context.ts` to log `CLINE_ENVIRONMENT`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 3d484a02778793762b6ff5036721577c781a21e9. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->