### PR TITLE
added baseten link to docs.json

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -183,7 +183,8 @@
 					"provider-config/openrouter",
 					"provider-config/sap-aicore",
 					"provider-config/vercel-ai-gateway",
-					"provider-config/requesty"
+					"provider-config/requesty",
+					"provider-config/baseten"
 				]
 			},
 			{

--- a/docs/provider-config/baseten.mdx
+++ b/docs/provider-config/baseten.mdx
@@ -17,25 +17,26 @@ Baseten provides on-demand frontier model APIs designed for production applicati
 ### Supported Models
 
 Cline supports all current models under Baseten Model APIs, including:
+For the most updated pricing, please visit: https://www.baseten.co/products/model-apis/
 
 **Reasoning Models:**
--   `deepseek-ai/DeepSeek-R1` - DeepSeek's first-generation reasoning model (163K context) - $2.55/$5.95 per 1M tokens
--   `deepseek-ai/DeepSeek-R1-0528` - Latest revision of DeepSeek's reasoning model (163K context) - $2.55/$5.95 per 1M tokens
--   `deepseek-ai/DeepSeek-V3.1` - Hybrid reasoning with advanced tool calling (163K context) - $0.50/$1.50 per 1M tokens
--   `deepseek-ai/DeepSeek-V3-0324` - Fast general-purpose with enhanced reasoning (163K context) - $0.77/$0.77 per 1M tokens
+-   `deepseek-ai/DeepSeek-R1` - DeepSeek's first-generation reasoning model (163K context) - \$2.55/\$5.95 per 1M tokens
+-   `deepseek-ai/DeepSeek-R1-0528` - Latest revision of DeepSeek's reasoning model (163K context) - \$2.55/\$5.95 per 1M tokens
+-   `deepseek-ai/DeepSeek-V3.1` - Hybrid reasoning with advanced tool calling (163K context) - \$0.50/\$1.50 per 1M tokens
+-   `deepseek-ai/DeepSeek-V3-0324` - Fast general-purpose with enhanced reasoning (163K context) - \$0.77/\$0.77 per 1M tokens
 
 **Flagship Models:**
--   `openai/gpt-oss-120b` (OpenAI) - 120B MoE with strong reasoning capabilities (128K context) - $0.10/$0.50 per 1M tokens
--   `moonshotai/Kimi-K2-Instruct` (Moonshot AI) - 1 trillion parameter model for agentic tasks (131K context) - $0.60/$2.50 per 1M tokens
--   `moonshotai/Kimi-K2-Instruct-0905` (Moonshot AI) - September update with enhanced capabilities (262K context) - $0.60/$2.50 per 1M tokens
+-   `openai/gpt-oss-120b` (OpenAI) - 120B MoE with strong reasoning capabilities (128K context) - \$0.10/\$0.50 per 1M tokens
+-   `moonshotai/Kimi-K2-Instruct` (Moonshot AI) - 1 trillion parameter model for agentic tasks (131K context) - \$0.60/\$2.50 per 1M tokens
+-   `moonshotai/Kimi-K2-Instruct-0905` (Moonshot AI) - September update with enhanced capabilities (262K context) - \$0.60/\$2.50 per 1M tokens
 
 **Meta Llama 4 Series:**
--   `meta-llama/Llama-4-Maverick-17B-128E-Instruct` - High-efficiency processing (1M context!) - $0.19/$0.72 per 1M tokens
--   `meta-llama/Llama-4-Scout-17B-16E-Instruct` - Precise context understanding (1M context!) - $0.13/$0.50 per 1M tokens
+-   `meta-llama/Llama-4-Maverick-17B-128E-Instruct` - High-efficiency processing (1M context!) - \$0.19/\$0.72 per 1M tokens
+-   `meta-llama/Llama-4-Scout-17B-16E-Instruct` - Precise context understanding (1M context!) - \$0.13/\$0.50 per 1M tokens
 
 **Coding Specialists:**
--   `Qwen/Qwen3-Coder-480B-A35B-Instruct` (Alibaba Cloud) - Advanced coding and reasoning (262K context) - $0.38/$1.53 per 1M tokens
--   `Qwen/Qwen3-235B-A22B-Instruct-2507` (Alibaba Cloud) - Math and reasoning expert (262K context) - $0.22/$0.80 per 1M tokens
+-   `Qwen/Qwen3-Coder-480B-A35B-Instruct`- Advanced coding and reasoning (262K context) - \$0.38/\$1.53 per 1M tokens
+-   `Qwen/Qwen3-235B-A22B-Instruct-2507` - Math and reasoning expert (262K context) - \$0.22/\$0.80 per 1M tokens
 
 ### Configuration in Cline
 
@@ -111,4 +112,4 @@ Baseten's OpenAI compatibility makes migration straightforward:
 
 ### Pricing Information
 
-Current pricing is highly competitive and transparent. For the most up-to-date pricing, visit the [Baseten Model APIs page](https://www.baseten.co/products/model-apis/). Prices typically range from $0.10-$6.00 per million tokens, making Baseten significantly more cost-effective than many closed-model alternatives while providing access to state-of-the-art open-source models.
+Current pricing is highly competitive and transparent. For the most up-to-date pricing, visit the [Baseten Model APIs page](https://www.baseten.co/products/model-apis/). Prices typically range from \$0.10-\$6.00 per million tokens, making Baseten significantly more cost-effective than many closed-model alternatives while providing access to state-of-the-art open-source models.


### PR DESCRIPTION
### Related Issue

 #6148

### Description

In the previous PR, we added `baseten.mdx` under the provider-config folder, but the link was not included in `docs.json` so not appearing on the sidebar on the site. This change fixes that. The `baseten.mdx` pricing section is also reformatted to show up correctly.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [x] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `baseten` link to `docs.json` and correct pricing format in `baseten.mdx`.
> 
>   - **Documentation**:
>     - Add `provider-config/baseten` link to `docs.json` to ensure it appears in the sidebar.
>     - Correct pricing format in `baseten.mdx` by adding escape characters for dollar signs.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 1f24b43224a253752462a131e210bf7f3bc7cb9e. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->