### PR TITLE
fix: update SectionHeader to prevent content overlap

### DIFF
--- a/.changeset/hot-coins-pull.md
+++ b/.changeset/hot-coins-pull.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Fix: Sticky header in settings view overlaping with content on scroll

--- a/webview-ui/src/components/settings/SectionHeader.tsx
+++ b/webview-ui/src/components/settings/SectionHeader.tsx
@@ -1,6 +1,5 @@
+import { cn } from "@heroui/theme"
 import { HTMLAttributes } from "react"
-
-import { OPENROUTER_MODEL_PICKER_Z_INDEX } from "./OpenRouterModelPicker"
 
 type SectionHeaderProps = HTMLAttributes<HTMLDivElement> & {
 	children: React.ReactNode
@@ -9,12 +8,9 @@ type SectionHeaderProps = HTMLAttributes<HTMLDivElement> & {
 
 export const SectionHeader = ({ description, children, className, ...props }: SectionHeaderProps) => {
 	return (
-		<div
-			className={`sticky top-0 text-foreground px-5 py-3 ${className || ""}`}
-			{...props}
-			style={{ zIndex: OPENROUTER_MODEL_PICKER_Z_INDEX + 20 }}>
+		<div className={cn("text-foreground px-5 py-3", className)} {...props}>
 			<h4 className="m-0">{children}</h4>
-			{description && <p className="text-[var(--vscode-descriptionForeground)] text-sm mt-2 mb-0">{description}</p>}
+			{description && <p className="text-description text-sm mt-2 mb-0">{description}</p>}
 		</div>
 	)
 }


### PR DESCRIPTION
Remove sticky positioning and z-index styling from SectionHeader component to fix overlapping content issues during scroll. Also clean up unused imports and update description text styling to use semantic class.

<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- For feature requests: Created a discussion in our Feature Requests discussions board https://github.com/cline/cline/discussions/categories/feature-requests and received approval from core maintainers before implementation
- For all changes: Link the associated issue/discussion in the "Related Issue" section below

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly without prior discussion.

Why this requirement?
We deeply appreciate all community contributions - they are essential to Cline's success! To ensure the best use of everyone's time and maintain project direction, we use our Feature Requests discussions board to gauge community interest and validate feature ideas before implementation begins. This helps us focus development efforts on features that will benefit the most users.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** #XXXX
https://github.com/cline/cline/issues/6319
### Description

<!-- 
Help reviewers understand your changes by making this PR readable and well-organized:

- What problem does this PR solve?
- Why were these changes introduced and what purpose do they serve?
- For larger changes, provide context about your approach and reasoning

Small PRs may need minimal description, but larger changes benefit from explaining where you're coming from. Much of this context can be in the linked issue above, so feel free to reference it rather than repeating everything here.
-->

### Test Procedure

<!-- 
Please walk us through your testing approach and thought process. This helps reviewers understand that you've thoroughly considered the impact of your changes:

- How did you test this change?
- What could potentially break and how did you verify it doesn't?
- What existing functionality might be affected and how did you check it still works?
- Why are you confident this is ready for merge?

We're not looking for exhaustive documentation - just evidence that you've thought through the implications of your changes and tested accordingly.
-->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

#### Before

<img width="474" height="534" alt="image" src="https://github.com/user-attachments/assets/36deda4a-02ce-4740-a501-e1b6f50292ca" />

#### After

We won't need to show the section header at all time because:
1. It takes up a lot of space in a small screen
2. The title is already showing up in the side

<img width="526" height="483" alt="image" src="https://github.com/user-attachments/assets/3ea5c434-7869-4323-9034-d46b280a126c" />


<img width="492" height="334" alt="image" src="https://github.com/user-attachments/assets/e7980a72-ee0f-4edf-8072-8ed532673b6c" />


### Additional Notes

<!-- Add any additional notes for reviewers -->
