### PR TITLE
fix: model list not being updated in time for user to use shortcut button to update model to stealth model

### DIFF
--- a/.changeset/tame-rabbits-travel.md
+++ b/.changeset/tame-rabbits-travel.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+fix: model list not being updated in time for user to use shortcut button to update model to stealth model

--- a/webview-ui/src/components/chat/Announcement.tsx
+++ b/webview-ui/src/components/chat/Announcement.tsx
@@ -2,6 +2,7 @@ import { Accordion, AccordionItem } from "@heroui/react"
 import { EmptyRequest } from "@shared/proto/cline/common"
 import { VSCodeButton, VSCodeLink } from "@vscode/webview-ui-toolkit/react"
 import { CSSProperties, memo, useState } from "react"
+import { useMount } from "react-use"
 import { useClineAuth } from "@/context/ClineAuthContext"
 import { useExtensionState } from "@/context/ExtensionStateContext"
 import { AccountServiceClient } from "@/services/grpc-client"
@@ -43,12 +44,15 @@ Patch releases (3.19.1 → 3.19.2) will not trigger new announcements.
 const Announcement = ({ version, hideAnnouncement }: AnnouncementProps) => {
 	const minorVersion = version.split(".").slice(0, 2).join(".") // 2.0.0 -> 2.0
 	const { clineUser } = useClineAuth()
-	const { apiConfiguration, openRouterModels, setShowChatModelSelector } = useExtensionState()
+	const { apiConfiguration, openRouterModels, setShowChatModelSelector, refreshOpenRouterModels } = useExtensionState()
 	const user = apiConfiguration?.clineAccountId ? clineUser : undefined
 	const { handleFieldsChange } = useApiConfigurationHandlers()
 
 	const [didClickGrokCodeButton, setDidClickGrokCodeButton] = useState(false)
 	const [didClickCodeSupernovaButton, setDidClickCodeSupernovaButton] = useState(false)
+
+	// Need to get latest model list in case user hits shortcut button to set model
+	useMount(refreshOpenRouterModels)
 
 	const setGrokCodeFast1 = () => {
 		const modelId = "x-ai/grok-code-fast-1"


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Use `useMount` to refresh the model list in `Announcement.tsx` to ensure the latest models are available for shortcut button functionality.
> 
>   - **Behavior**:
>     - Use `useMount` to call `refreshOpenRouterModels` in `Announcement.tsx` to ensure the model list is updated when the component mounts.
>     - This ensures the user can use the shortcut button to update the model to a stealth model with the latest list.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 8c5e9e42e2fdd5e83defc22a57e8a9c3a0961e3e. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->