### PR TITLE
Improve the error messaging when Cline receives empty or unparsable responses from API providers 

### DIFF
--- a/src/core/task/index.ts
+++ b/src/core/task/index.ts
@@ -2198,8 +2198,8 @@ export class Task {
 				})
 
 				const baseErrorMessage =
-					"Unexpected API Response: The language model did not provide any assistant messages. This may indicate an issue with the API or the model's output."
-				const errorText = reqId ? `${baseErrorMessage} (reqId: ${reqId})` : baseErrorMessage
+					"Invalid API Response: The provider returned an empty or unparsable response. This is a provider-side issue where the model failed to generate valid output or returned tool calls that Cline cannot process. Retrying the request may help resolve this issue."
+				const errorText = reqId ? `${baseErrorMessage} (Request ID: ${reqId})` : baseErrorMessage
 
 				await this.say("error", errorText)
 				await this.messageStateHandler.addToApiConversationHistory({


### PR DESCRIPTION

### Description

This PR improves the error messaging when Cline receives empty or unparsable responses from API providers (like OpenRouter). 

**Problem solved:** Users were seeing a generic error message that didn't clearly indicate whether the issue was with Cline or the API provider. This led to confusion and misdirected frustration toward Cline when providers returned invalid responses.

**Purpose:** The updated error message now:
- Explicitly states the issue is "provider-side" 
- Clarifies that the provider returned empty/unparsable content or unsupported tool calls
- Suggests retrying as a potential solution
- Properly attributes responsibility to the API provider, not Cline

### Test Procedure

**Testing approach:**
- Tested the error message display when receiving empty responses from API providers
- Verified the error appears correctly with and without request IDs
- Confirmed the message properly attributes the issue to the provider

**Verification:**
- The error handling flow remains unchanged - only the message text was updated
- Existing error recovery mechanisms (retry prompts) continue to work as before
- No changes to the actual error detection or handling logic

**Confidence:** This is a simple string change with no functional impact. The error message will display when the same conditions are met (empty assistant message), but with clearer attribution and guidance.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [x] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots


### Additional Notes

This change improves user experience by providing clearer error attribution when API providers return invalid responses. It helps users understand that empty responses or unsupported tool calls from providers like OpenRouter are not Cline's fault, reducing confusion and support burden.