### PR TITLE
Add a workflow that will trigger the Jetbrains tests for PRs in the cline repo.

### DIFF
--- a/.github/workflows/trigger-jetbrains-tests.yml
+++ b/.github/workflows/trigger-jetbrains-tests.yml
@@ -1,0 +1,51 @@
+name: Trigger Jetbrains Plugin <-> Cline Tests
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+permissions:
+  contents: read
+concurrency:
+  group: jetbrains-trigger-${{ github.event.number }}
+  cancel-in-progress: true
+
+jobs:
+  trigger-integration-test:
+    name: Run Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: 1998650
+          private-key: ${{ secrets.CLINE_JETBRAINS_WORKFLOW_KEY }}
+          owner: cline
+          repositories: intellij-plugin
+
+      - name: Trigger IntelliJ Plugin Integration Test
+        run: |
+          curl -X POST \
+            -H "Authorization: Bearer ${{ steps.app-token.outputs.token }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            -H "User-Agent: cline-pr-trigger" \
+            -H "Content-Type: application/json" \
+            https://api.github.com/repos/cline/intellij-plugin/dispatches \
+            -d '{
+              "event_type": "cline-pr-check",
+              "client_payload": {
+                "pr_number": "${{ github.event.number }}",
+                "branch_name": "${{ github.head_ref }}",
+                "action": "${{ github.event.action }}",
+                "sha": "${{ github.event.pull_request.head.sha }}",
+                "pr_title": "${{ github.event.pull_request.title }}",
+                "pr_url": "${{ github.event.pull_request.html_url }}"
+              }
+            }'
+
+      - name: Log trigger details
+        run: |
+          echo "Triggered IntelliJ Plugin integration test for:"
+          echo "  PR #${{ github.event.number }}: ${{ github.event.pull_request.title }}"
+          echo "  Branch: ${{ github.head_ref }}"
+          echo "  Action: ${{ github.event.action }}"
+          echo "  SHA: ${{ github.event.pull_request.head.sha }}"


### PR DESCRIPTION
Changes in the cline repo have the potential to cause breakages in the JetBrains repo. The creator of the PR might not found out until some time later that they have made a change that causes problems for JetBrains.

This workflow will trigger the workflow `.github/workflows/test-changes-from-cline-repo.yml` in the JetBrains repo, that runs the JetBrains integration tests. When the tests complete, the workflow will leave a comment on the PR with the results of the tests.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds a GitHub Actions workflow to trigger JetBrains tests for PRs in the cline repo, ensuring integration stability.
> 
>   - **Workflow**:
>     - Adds `.github/workflows/trigger-jetbrains-tests.yml` to trigger JetBrains tests on PR events (opened, synchronized, reopened) in the cline repo.
>     - Uses `actions/create-github-app-token@v1` to generate a GitHub App token for authentication.
>     - Sends a POST request to `https://api.github.com/repos/cline/intellij-plugin/dispatches` to trigger the JetBrains integration tests.
>   - **Logging**:
>     - Logs PR number, title, branch, action, and SHA after triggering the tests.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 241ac953d0524efea083755ff673cce0b847b9a4. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->