### PR TITLE
fix(oca): Paper Cut Fixes

### DIFF
--- a/src/core/controller/models/refreshOcaModels.ts
+++ b/src/core/controller/models/refreshOcaModels.ts
@@ -4,7 +4,7 @@ import axios from "axios"
 import { HostProvider } from "@/hosts/host-provider"
 import { OcaAuthService } from "@/services/auth/oca/OcaAuthService"
 import { DEFAULT_OCA_BASE_URL } from "@/services/auth/oca/utils/constants"
-import { createOcaHeaders, getProxyAgents } from "@/services/auth/oca/utils/utils"
+import { createOcaHeaders, getAxiosSettings } from "@/services/auth/oca/utils/utils"
 import { Logger } from "@/services/logging/Logger"
 import { ShowMessageType } from "@/shared/proto/index.host"
 import { Controller } from ".."
@@ -25,12 +25,19 @@ export async function refreshOcaModels(controller: Controller, request: StringRe
 	const models: Record<string, OcaModelInfo> = {}
 	let defaultModelId: string | undefined
 	const ocaAccessToken = await OcaAuthService.getInstance().getAuthToken()
+	if (!ocaAccessToken) {
+		HostProvider.window.showMessage({
+			type: ShowMessageType.ERROR,
+			message: "Not authenticated with OCA. Please sign in first.",
+		})
+		return OcaCompatibleModelInfo.create({ error: "Not authenticated with OCA" })
+	}
 	const baseUrl = request.value || DEFAULT_OCA_BASE_URL
 	const modelsUrl = `${baseUrl}/v1/model/info`
 	const headers = await createOcaHeaders(ocaAccessToken!, "models-refresh")
 	try {
 		Logger.log(`Making refresh oca model request with customer opc-request-id: ${headers["opc-request-id"]}`)
-		const response = await axios.get(modelsUrl, { headers, ...getProxyAgents() })
+		const response = await axios.get(modelsUrl, { headers, ...getAxiosSettings() })
 		if (response.data?.data) {
 			if (response.data.data.length === 0) {
 				HostProvider.window.showMessage({


### PR DESCRIPTION
## refreshOcaModels, OcaAuthProvider, and utils consolidation for fetch adapter and clearer auth errors

### Summary

This PR implements a small set of reliability and portability fixes centered on auth clarity and a single axios configuration path.

**Changes**

* **refreshOcaModels**

  * Add an explicit auth guard. If no OCA access token is available, return a typed error through `OcaCompatibleModelInfo` and show a user-facing error.
  * Replace proxy-agent usage with `getAxiosSettings()` (uses axios fetch adapter).
  * Remove `getProxyAgents` import. Import and use `getAxiosSettings` instead.

* **OcaAuthProvider**

  * Migrate discovery and token POST requests to `getAxiosSettings()`.
  * Add a clear error when the auth code exchange completes without an `id_token` to speed up OIDC troubleshooting.

* **utils/constants**

  * Rotate `DEFAULT_IDCS_CLIENT_ID` to a new value.

* **utils/utils**

  * Add `getAxiosSettings()` helper (axios fetch adapter) and remove proxy agent specific helpers.
  * Revise `createOcaHeaders` to avoid direct coupling to `vscode` and `package.json`.

    * Use `HostProvider.env.getHostVersion()` for host and IDE details.
    * Use `ExtensionRegistryInfo.version` for the extension version.
    * Set headers:
      `client: Cline`
      `client-version: <ExtensionRegistryInfo.version>`
      `client-ide: <host id or name>`
      `client-ide-version: <HostProvider.env.getHostVersion()>`
      `opc-request-id: <uuid>`
  * Note: `HttpsProxyAgent` is still imported somewhere but now unused. Consider removing it to avoid lint and TS warnings.

**Rationale**

* **Reliability and UX**: Users now see a clear error if they try to refresh OCA models without being authenticated.
* **Portability**: Header construction no longer depends on `vscode` and `package.json`. Using `HostProvider` and `ExtensionRegistryInfo` reduces host coupling.
* **Simplicity**: Standardize axios configuration through `getAxiosSettings()` that uses the fetch adapter.
* **Auth robustness**: An explicit error is raised when `id_token` is missing during the auth code exchange.

**Potential behavior changes**

* **Proxy handling**: `getProxyAgents()` was replaced by the axios fetch adapter in `getAxiosSettings()`. If a deployment requires explicit agent-based proxying or environment-driven proxy support beyond what fetch provides, a follow-up may be needed to add fetch-compatible proxy config or reintroduce agent support behind the same helper.

**Files touched**

* `src/core/controller/models/refreshOcaModels.ts`
* `src/services/auth/oca/providers/OcaAuthProvider.ts`
* `src/services/auth/oca/utils/constants.ts`
* `src/services/auth/oca/utils/utils.ts`

---

### Description

This PR focuses on three goals.

1. Provide a clear user-facing error and typed return path when a user attempts to refresh OCA models without an access token. This prevents silent failures and gives actionable feedback.

2. Consolidate all axios configuration into a single helper, `getAxiosSettings()`, that uses the axios fetch adapter. This removes local proxy agent code and reduces configuration drift between auth and model flows.

3. Decouple header construction from direct `vscode` and `package.json` imports. `createOcaHeaders` now sources host and extension metadata from `HostProvider` and `ExtensionRegistryInfo`, which allows these headers to be constructed in non-VS Code hosts and improves testability.

For auth, we now surface a dedicated error when the OIDC code exchange completes without an `id_token`. This is a common failure pattern in misconfigured OIDC flows and the clearer signal improves diagnosis.

---

### Test Procedure

Use the steps below to validate the change set.

1. **Auth guard for model refresh**

   * Sign out or clear OCA auth so no access token is present.
   * Trigger model refresh.
   * Expect a user-visible error that explains authentication is required.
   * Confirm that `refreshOcaModels` returns an `OcaCompatibleModelInfo` with a typed error rather than a silent or generic failure.

2. **Successful model refresh after auth**

   * Complete OCA sign-in to obtain a valid access token.
   * Trigger model refresh again.
   * Expect a successful fetch of models, no proxy-agent code paths used, and network requests created via `getAxiosSettings()`.

3. **Auth code exchange without id\_token**

   * Simulate an auth response that omits `id_token` (for example via a mocked token endpoint or a controlled test double).
   * Expect an explicit error that calls out the missing `id_token`.
   * Confirm this error is logged and surfaced in a way that helps diagnose OIDC misconfiguration.

4. **Header construction without vscode or package.json**

   * Run in the host environment where `HostProvider.env.getHostVersion()` and `ExtensionRegistryInfo.version` are available.
   * Inspect outbound requests and confirm headers are present:

     * `client: Cline`
     * `client-version: <extension version>`
     * `client-ide: <host id or name>`
     * `client-ide-version: <host version>`
     * `opc-request-id: <uuid>`
   * Verify no direct import of `vscode` or `package.json` exists in `createOcaHeaders`.

5. **Proxy pathways**

   * If you depend on environment variables like `HTTP_PROXY` or `HTTPS_PROXY`, verify whether the axios fetch adapter honors your environment in your deployment setup.
   * If it does not meet your needs, document required follow-ups to add fetch-compatible proxy configuration to `getAxiosSettings()`.

6. **Regression checks**

   * Sign-in flow works end to end (discovery, auth, token exchange).
   * Model listing and refresh commands function as before.
   * No TypeScript lint errors from unused imports. If `HttpsProxyAgent` is still imported, remove it and re-run lint.

---

### Type of Change

* [x] 🐛 Bug fix (non-breaking change which fixes an issue)
* [ ] ✨ New feature (non-breaking change which adds functionality)
* [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] ♻️ Refactor Changes
* [ ] 💅 Cosmetic Changes
* [ ] 📚 Documentation update
* [ ] 🏃 Workflow Changes

---

### Pre-flight Checklist

* [ ] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
* [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
* [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
* [ ] I have reviewed [[contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

---

### Screenshots

N/A. No UI changes.

---

### Additional Notes

* `DEFAULT_IDCS_CLIENT_ID` has been rotated. Review environment and deployment notes if you override this value.
* If your environment requires strict proxy agent configuration, please open a follow-up issue so we can extend `getAxiosSettings()` with fetch-compatible proxy support or optional agent injection through a single code path.
* Consider removing any leftover `HttpsProxyAgent` imports to avoid lint warnings.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add auth guard, unify axios config with fetch adapter, and improve error handling in OCA auth flows.
> 
>   - **Behavior**:
>     - Add auth guard in `refreshOcaModels` to return error if no OCA access token.
>     - Replace `getProxyAgents()` with `getAxiosSettings()` using fetch adapter in `refreshOcaModels` and `OcaAuthProvider`.
>     - Raise error in `OcaAuthProvider` if `id_token` is missing during auth code exchange.
>   - **Utils**:
>     - Add `getAxiosSettings()` in `utils.ts` for axios fetch adapter.
>     - Revise `createOcaHeaders()` to use `HostProvider.env.getHostVersion()` and `ExtensionRegistryInfo.version`.
>   - **Constants**:
>     - Rotate `DEFAULT_IDCS_CLIENT_ID` in `constants.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 53e3d826cf623ef3b1fe3574afd75e6187cb39c4. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->