### PR TITLE
Replace vscode context.globalStoragePath with HostProvider.globalStorageFsPath

### DIFF
--- a/src/core/commands/reconstructTaskHistory.ts
+++ b/src/core/commands/reconstructTaskHistory.ts
@@ -122,14 +122,14 @@ async function performTaskHistoryReconstruction(context: vscode.ExtensionContext
 	reconstructedItems.sort((a, b) => b.ts - a.ts)
 
 	// Write reconstructed history
-	await writeTaskHistoryToState(context, reconstructedItems)
+	await writeTaskHistoryToState(reconstructedItems)
 
 	return result
 }
 
 async function backupExistingTaskHistory(context: vscode.ExtensionContext): Promise<void> {
 	try {
-		const existingHistory = await readTaskHistoryFromState(context)
+		const existingHistory = await readTaskHistoryFromState()
 		if (existingHistory.length > 0) {
 			const backupPath = path.join(context.globalStorageUri.fsPath, "state", `taskHistory.backup.${Date.now()}.json`)
 

--- a/src/core/context/context-tracking/FileContextTracker.ts
+++ b/src/core/context/context-tracking/FileContextTracker.ts
@@ -285,7 +285,7 @@ export class FileContextTracker {
 	static async cleanupOrphanedWarnings(context: vscode.ExtensionContext): Promise<void> {
 		const startTime = Date.now()
 		try {
-			const taskHistory = await readTaskHistoryFromState(context)
+			const taskHistory = await readTaskHistoryFromState()
 			const existingTaskIds = new Set(taskHistory.map((task) => task.id))
 			const allStateKeys = context.workspaceState.keys()
 			const pendingWarningKeys = allStateKeys.filter((key) => key.startsWith("pendingFileContextWarning_"))

--- a/src/core/storage/StateManager.ts
+++ b/src/core/storage/StateManager.ts
@@ -275,7 +275,7 @@ export class StateManager {
 	 */
 	private async setupTaskHistoryWatcher(): Promise<void> {
 		try {
-			const historyFile = await getTaskHistoryStateFilePath(this.context)
+			const historyFile = await getTaskHistoryStateFilePath()
 
 			// Close any existing watcher before creating a new one
 			if (this.taskHistoryWatcher) {
@@ -295,7 +295,7 @@ export class StateManager {
 					if (!this.isInitialized) {
 						return
 					}
-					const onDisk = await readTaskHistoryFromState(this.context)
+					const onDisk = await readTaskHistoryFromState()
 					const cached = this.globalStateCache["taskHistory"]
 					if (JSON.stringify(onDisk) !== JSON.stringify(cached)) {
 						this.globalStateCache["taskHistory"] = onDisk
@@ -764,7 +764,7 @@ export class StateManager {
 				Array.from(keys).map((key) => {
 					if (key === "taskHistory") {
 						// Route task history persistence to file, not VS Code globalState
-						return writeTaskHistoryToState(this.context, this.globalStateCache[key])
+						return writeTaskHistoryToState(this.globalStateCache[key])
 					}
 					return this.context.globalState.update(key, this.globalStateCache[key])
 				}),

--- a/src/core/storage/disk.ts
+++ b/src/core/storage/disk.ts
@@ -184,8 +184,8 @@ export async function saveTaskMetadata(context: vscode.ExtensionContext, taskId:
 	}
 }
 
-export async function ensureStateDirectoryExists(context: vscode.ExtensionContext): Promise<string> {
-	const stateDir = path.join(context.globalStorageUri.fsPath, "state")
+export async function ensureStateDirectoryExists(): Promise<string> {
+	const stateDir = path.join(HostProvider.get().globalStorageFsPath, "state")
 	await fs.mkdir(stateDir, { recursive: true })
 	return stateDir
 }
@@ -194,18 +194,18 @@ export async function ensureCacheDirectoryExists(): Promise<string> {
 	return HostProvider.getGlobalStorageDir("cache")
 }
 
-export async function getTaskHistoryStateFilePath(context: vscode.ExtensionContext): Promise<string> {
-	return path.join(await ensureStateDirectoryExists(context), "taskHistory.json")
+export async function getTaskHistoryStateFilePath(): Promise<string> {
+	return path.join(await ensureStateDirectoryExists(), "taskHistory.json")
 }
 
-export async function taskHistoryStateFileExists(context: vscode.ExtensionContext): Promise<boolean> {
-	const filePath = await getTaskHistoryStateFilePath(context)
+export async function taskHistoryStateFileExists(): Promise<boolean> {
+	const filePath = await getTaskHistoryStateFilePath()
 	return fileExistsAtPath(filePath)
 }
 
-export async function readTaskHistoryFromState(context: vscode.ExtensionContext): Promise<HistoryItem[]> {
+export async function readTaskHistoryFromState(): Promise<HistoryItem[]> {
 	try {
-		const filePath = await getTaskHistoryStateFilePath(context)
+		const filePath = await getTaskHistoryStateFilePath()
 		if (await fileExistsAtPath(filePath)) {
 			const contents = await fs.readFile(filePath, "utf8")
 			try {
@@ -222,9 +222,9 @@ export async function readTaskHistoryFromState(context: vscode.ExtensionContext)
 	}
 }
 
-export async function writeTaskHistoryToState(context: vscode.ExtensionContext, items: HistoryItem[]): Promise<void> {
+export async function writeTaskHistoryToState(items: HistoryItem[]): Promise<void> {
 	try {
-		const filePath = await getTaskHistoryStateFilePath(context)
+		const filePath = await getTaskHistoryStateFilePath()
 		// Always create the file; if items is empty, write [] to ensure presence on first startup
 		await fs.writeFile(filePath, JSON.stringify(items))
 	} catch (error) {

--- a/src/core/storage/state-migrations.ts
+++ b/src/core/storage/state-migrations.ts
@@ -84,7 +84,7 @@ export async function migrateTaskHistoryToFile(context: vscode.ExtensionContext)
 		let finalData: HistoryItem[]
 		let migrationAction: string
 
-		const newLocationData = await readTaskHistoryFromState(context)
+		const newLocationData = await readTaskHistoryFromState()
 
 		if (newLocationData.length === 0) {
 			// Move old data to new location
@@ -97,9 +97,9 @@ export async function migrateTaskHistoryToFile(context: vscode.ExtensionContext)
 		}
 
 		// Perform migration operations sequentially - only clear old data if write succeeds
-		await writeTaskHistoryToState(context, finalData)
+		await writeTaskHistoryToState(finalData)
 
-		const successfullyWrittenData = await readTaskHistoryFromState(context)
+		const successfullyWrittenData = await readTaskHistoryFromState()
 
 		if (!Array.isArray(successfullyWrittenData)) {
 			console.error("[Storage Migration] Failed to write taskHistory to file: Written data is not an array")

--- a/src/core/storage/utils/state-helpers.ts
+++ b/src/core/storage/utils/state-helpers.ts
@@ -403,7 +403,7 @@ export async function readGlobalStateFromDisk(context: ExtensionContext): Promis
 			}
 		}
 
-		const taskHistory = await readTaskHistoryFromState(context)
+		const taskHistory = await readTaskHistoryFromState()
 
 		// Multi-root workspace support
 		const workspaceRoots = context.globalState.get<GlobalStateAndSettings["workspaceRoots"]>("workspaceRoots")


### PR DESCRIPTION
Replace uses of context.globalStorageUri with HostProvider.get().globalStorageFsPath

This is part of removing dependencies on the VSCode API fom the codebase except for in platform specific code in src/hosts/vscode and src/extension.ts.

Remove unused vscode context param.

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Replaces `vscode.ExtensionContext` with `HostProvider.globalStorageFsPath` for accessing global storage paths, simplifying function parameters and ensuring consistent usage across the codebase.
> 
>   - **Behavior**:
>     - Replaces `vscode.ExtensionContext` with `HostProvider.globalStorageFsPath` for accessing global storage paths.
>     - Updates functions like `ensureStateDirectoryExists()`, `getTaskHistoryStateFilePath()`, and `taskHistoryStateFileExists()` in `disk.ts` to use `HostProvider`.
>     - Removes `context` parameter from functions like `readTaskHistoryFromState()` and `writeTaskHistoryToState()` in `disk.ts`.
>   - **Functions**:
>     - Updates `performTaskHistoryReconstruction()` and `backupExistingTaskHistory()` in `reconstructTaskHistory.ts` to remove `context` parameter.
>     - Modifies `cleanupOrphanedWarnings()` in `FileContextTracker.ts` to remove `context` parameter.
>     - Adjusts `setupTaskHistoryWatcher()` in `StateManager.ts` to remove `context` parameter.
>   - **Misc**:
>     - Ensures consistent usage of `HostProvider` for global storage path access across the codebase.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for d140699a1a4659d91091cc7884a7651949e9ed97. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->