### PR TITLE
[Tasks directory] Replace uses of context.globalStorageUri with HostProvider.get().globalStorageFsPath

### DIFF
--- a/src/core/context/context-tracking/FileContextTracker.test.ts
+++ b/src/core/context/context-tracking/FileContextTracker.test.ts
@@ -6,19 +6,19 @@ import * as path from "path"
 import * as sinon from "sinon"
 import * as vscode from "vscode"
 import { Controller } from "@/core/controller"
-import { HostProvider } from "@/hosts/host-provider"
 import { setVscodeHostProviderMock } from "@/test/host-provider-test-utils"
 import type { FileMetadataEntry, TaskMetadata } from "./ContextTrackerTypes"
 import { FileContextTracker } from "./FileContextTracker"
 
 describe("FileContextTracker", () => {
+	const filePath = "src/test-file.ts"
+	const taskId = "test-task-id"
+
 	let sandbox: sinon.SinonSandbox
-	let mockController: Controller
 	let _mockWorkspace: sinon.SinonStub
 	let mockFileSystemWatcher: any
 	let chokidarWatchStub: sinon.SinonStub
 	let tracker: FileContextTracker
-	let taskId: string
 	let mockTaskMetadata: TaskMetadata
 	let getTaskMetadataStub: sinon.SinonStub
 	let saveTaskMetadataStub: sinon.SinonStub
@@ -46,11 +46,6 @@ describe("FileContextTracker", () => {
 		// Stub chokidar.watch to return our mock watcher
 		chokidarWatchStub = sandbox.stub(chokidar, "watch").returns(mockFileSystemWatcher as any)
 
-		// Mock controller and context
-		mockController = {
-			context: {} as vscode.ExtensionContext,
-		} as unknown as Controller
-
 		// Mock disk module functions
 		mockTaskMetadata = { files_in_context: [], model_usage: [] }
 		getTaskMetadataStub = sandbox.stub(diskModule, "getTaskMetadata").resolves(mockTaskMetadata)
@@ -59,29 +54,24 @@ describe("FileContextTracker", () => {
 		setVscodeHostProviderMock()
 
 		// Create tracker instance
-		taskId = "test-task-id"
-		tracker = new FileContextTracker(mockController, taskId)
+		tracker = new FileContextTracker({} as Controller, taskId)
 	})
 
 	afterEach(() => {
 		sandbox.restore()
-		// Reset HostProvider after each test to ensure clean state
-		HostProvider.reset()
 	})
 
 	it("should add a record when a file is read by a tool", async () => {
-		const filePath = "src/test-file.ts"
-
 		await tracker.trackFileContext(filePath, "read_tool")
 
 		// Verify getTaskMetadata was called
 		expect(getTaskMetadataStub.calledOnce).to.be.true
-		expect(getTaskMetadataStub.firstCall.args[1]).to.equal(taskId)
+		expect(getTaskMetadataStub.firstCall.args[0]).to.equal(taskId)
 
 		// Verify saveTaskMetadata was called with the correct data
 		expect(saveTaskMetadataStub.calledOnce).to.be.true
 
-		const savedMetadata = saveTaskMetadataStub.firstCall.args[2]
+		const savedMetadata = saveTaskMetadataStub.firstCall.args[1]
 		expect(savedMetadata.files_in_context.length).to.equal(1)
 
 		const fileEntry = savedMetadata.files_in_context[0]
@@ -93,13 +83,11 @@ describe("FileContextTracker", () => {
 	})
 
 	it("should add a record when a file is edited by Cline", async () => {
-		const filePath = "src/test-file.ts"
-
 		await tracker.trackFileContext(filePath, "cline_edited")
 
 		// Verify saveTaskMetadata was called with the correct data
 		expect(saveTaskMetadataStub.calledOnce).to.be.true
-		const savedMetadata = saveTaskMetadataStub.firstCall.args[2]
+		const savedMetadata = saveTaskMetadataStub.firstCall.args[1]
 
 		// Check that we have at least one entry in files_in_context
 		expect(savedMetadata.files_in_context).to.be.an("array").that.is.not.empty
@@ -121,12 +109,10 @@ describe("FileContextTracker", () => {
 	})
 
 	it("should add a record when a file is mentioned", async () => {
-		const filePath = "src/test-file.ts"
-
 		await tracker.trackFileContext(filePath, "file_mentioned")
 
 		// Verify saveTaskMetadata was called with the correct data
-		const savedMetadata = saveTaskMetadataStub.firstCall.args[2]
+		const savedMetadata = saveTaskMetadataStub.firstCall.args[1]
 		const fileEntry = savedMetadata.files_in_context[0]
 
 		expect(fileEntry.path).to.equal(filePath)
@@ -137,12 +123,10 @@ describe("FileContextTracker", () => {
 	})
 
 	it("should add a record when a file is edited by the user", async () => {
-		const filePath = "src/test-file.ts"
-
 		await tracker.trackFileContext(filePath, "user_edited")
 
 		// Verify saveTaskMetadata was called with the correct data
-		const savedMetadata = saveTaskMetadataStub.firstCall.args[2]
+		const savedMetadata = saveTaskMetadataStub.firstCall.args[1]
 		const fileEntry = savedMetadata.files_in_context[0]
 
 		expect(fileEntry.path).to.equal(filePath)
@@ -156,8 +140,6 @@ describe("FileContextTracker", () => {
 	})
 
 	it("should mark existing entries as stale when adding a new entry for the same file", async () => {
-		const filePath = "src/test-file.ts"
-
 		// Add an initial entry
 		mockTaskMetadata.files_in_context = [
 			{
@@ -174,7 +156,7 @@ describe("FileContextTracker", () => {
 		await tracker.trackFileContext(filePath, "cline_edited")
 
 		// Verify the metadata now has two entries - one stale and one active
-		const savedMetadata = saveTaskMetadataStub.firstCall.args[2]
+		const savedMetadata = saveTaskMetadataStub.firstCall.args[1]
 		expect(savedMetadata.files_in_context.length).to.equal(2)
 
 		// First entry should be marked as stale
@@ -187,8 +169,6 @@ describe("FileContextTracker", () => {
 	})
 
 	it("should setup a file watcher for tracked files", async () => {
-		const filePath = "src/test-file.ts"
-
 		await tracker.trackFileContext(filePath, "read_tool")
 
 		// Verify chokidar.watch was called
@@ -199,8 +179,6 @@ describe("FileContextTracker", () => {
 	})
 
 	it("should track user edits when file watcher detects changes", async () => {
-		const filePath = "src/test-file.ts"
-
 		// First track the file to set up the watcher
 		await tracker.trackFileContext(filePath, "read_tool")
 
@@ -226,8 +204,6 @@ describe("FileContextTracker", () => {
 	})
 
 	it("should not track Cline edits as user edits", async () => {
-		const filePath = "src/test-file.ts"
-
 		// First track the file to set up the watcher
 		await tracker.trackFileContext(filePath, "read_tool")
 
@@ -256,8 +232,6 @@ describe("FileContextTracker", () => {
 	})
 
 	it("should dispose file watchers when dispose is called", async () => {
-		const filePath = "src/test-file.ts"
-
 		// Track a file to set up the watcher
 		await tracker.trackFileContext(filePath, "read_tool")
 

--- a/src/core/context/context-tracking/FileContextTracker.ts
+++ b/src/core/context/context-tracking/FileContextTracker.ts
@@ -90,7 +90,7 @@ export class FileContextTracker {
 			}
 
 			// Add file to metadata
-			await this.addFileToFileContextTracker(this.controller.context, this.taskId, filePath, operation)
+			await this.addFileToFileContextTracker(this.taskId, filePath, operation)
 
 			// Set up file watcher for this file
 			await this.setupFileWatcher(filePath)
@@ -104,14 +104,9 @@ export class FileContextTracker {
 	 * This handles the business logic of determining if the file is new, stale, or active.
 	 * It also updates the metadata with the latest read/edit dates.
 	 */
-	async addFileToFileContextTracker(
-		context: vscode.ExtensionContext,
-		taskId: string,
-		filePath: string,
-		source: FileMetadataEntry["record_source"],
-	) {
+	async addFileToFileContextTracker(taskId: string, filePath: string, source: FileMetadataEntry["record_source"]) {
 		try {
-			const metadata = await getTaskMetadata(context, taskId)
+			const metadata = await getTaskMetadata(taskId)
 			const now = Date.now()
 
 			// Mark existing entries for this file as stale
@@ -160,7 +155,7 @@ export class FileContextTracker {
 			}
 
 			metadata.files_in_context.push(newEntry)
-			await saveTaskMetadata(context, taskId, metadata)
+			await saveTaskMetadata(taskId, metadata)
 		} catch (error) {
 			console.error("Failed to add file to metadata:", error)
 		}
@@ -200,7 +195,7 @@ export class FileContextTracker {
 
 		try {
 			// Check task metadata for files that were edited by Cline or users after the message timestamp
-			const taskMetadata = await getTaskMetadata(this.controller.context, this.taskId)
+			const taskMetadata = await getTaskMetadata(this.taskId)
 
 			if (taskMetadata?.files_in_context) {
 				for (const fileEntry of taskMetadata.files_in_context) {

--- a/src/core/context/context-tracking/ModelContextTracker.test.ts
+++ b/src/core/context/context-tracking/ModelContextTracker.test.ts
@@ -2,13 +2,11 @@ import * as diskModule from "@core/storage/disk"
 import { expect } from "chai"
 import { afterEach, beforeEach, describe, it } from "mocha"
 import * as sinon from "sinon"
-import * as vscode from "vscode"
 import type { TaskMetadata } from "./ContextTrackerTypes"
 import { ModelContextTracker } from "./ModelContextTracker"
 
 describe("ModelContextTracker", () => {
 	let sandbox: sinon.SinonSandbox
-	let mockContext: vscode.ExtensionContext
 	let tracker: ModelContextTracker
 	let taskId: string
 	let mockTaskMetadata: TaskMetadata
@@ -18,11 +16,6 @@ describe("ModelContextTracker", () => {
 	beforeEach(() => {
 		sandbox = sinon.createSandbox()
 
-		// Mock controller and context
-		mockContext = {
-			globalStorageUri: { fsPath: "/mock/storage" },
-		} as unknown as vscode.ExtensionContext
-
 		// Mock disk module functions
 		mockTaskMetadata = { files_in_context: [], model_usage: [] }
 		getTaskMetadataStub = sandbox.stub(diskModule, "getTaskMetadata").resolves(mockTaskMetadata)
@@ -30,7 +23,7 @@ describe("ModelContextTracker", () => {
 
 		// Create tracker instance
 		taskId = "test-task-id"
-		tracker = new ModelContextTracker(mockContext, taskId)
+		tracker = new ModelContextTracker(taskId)
 	})
 
 	afterEach(() => {

--- a/src/core/context/context-tracking/ModelContextTracker.test.ts
+++ b/src/core/context/context-tracking/ModelContextTracker.test.ts
@@ -6,9 +6,9 @@ import type { TaskMetadata } from "./ContextTrackerTypes"
 import { ModelContextTracker } from "./ModelContextTracker"
 
 describe("ModelContextTracker", () => {
+	const taskId = "test-task-id"
 	let sandbox: sinon.SinonSandbox
 	let tracker: ModelContextTracker
-	let taskId: string
 	let mockTaskMetadata: TaskMetadata
 	let getTaskMetadataStub: sinon.SinonStub
 	let saveTaskMetadataStub: sinon.SinonStub
@@ -22,7 +22,6 @@ describe("ModelContextTracker", () => {
 		saveTaskMetadataStub = sandbox.stub(diskModule, "saveTaskMetadata").resolves()
 
 		// Create tracker instance
-		taskId = "test-task-id"
 		tracker = new ModelContextTracker(taskId)
 	})
 
@@ -46,13 +45,13 @@ describe("ModelContextTracker", () => {
 
 			// Verify getTaskMetadata was called with correct parameters
 			expect(getTaskMetadataStub.calledOnce).to.be.true
-			expect(getTaskMetadataStub.firstCall.args[1]).to.equal(taskId)
+			expect(getTaskMetadataStub.firstCall.args[0]).to.equal(taskId)
 
 			// Verify saveTaskMetadata was called with the correct data
 			expect(saveTaskMetadataStub.calledOnce).to.be.true
 
 			// Extract the saved metadata from the call arguments
-			const savedMetadata = saveTaskMetadataStub.firstCall.args[2]
+			const savedMetadata = saveTaskMetadataStub.firstCall.args[1]
 
 			// Verify model_usage array has one entry
 			expect(savedMetadata.model_usage.length).to.equal(1)
@@ -98,7 +97,7 @@ describe("ModelContextTracker", () => {
 			expect(saveTaskMetadataStub.calledOnce).to.be.true
 
 			// Extract the saved metadata
-			const savedMetadata = saveTaskMetadataStub.firstCall.args[2]
+			const savedMetadata = saveTaskMetadataStub.firstCall.args[1]
 
 			// Verify model_usage array now has two entries
 			expect(savedMetadata.model_usage.length).to.equal(2)
@@ -159,7 +158,7 @@ describe("ModelContextTracker", () => {
 				expect(saveTaskMetadataStub.calledOnce).to.be.true
 
 				// Get the saved metadata
-				const savedMetadata = saveTaskMetadataStub.firstCall.args[2]
+				const savedMetadata = saveTaskMetadataStub.firstCall.args[1]
 
 				// Since we reset the array for each call, we should always have 1 entry
 				expect(savedMetadata.model_usage.length).to.equal(1)

--- a/src/core/context/context-tracking/ModelContextTracker.ts
+++ b/src/core/context/context-tracking/ModelContextTracker.ts
@@ -1,17 +1,14 @@
 import { getTaskMetadata, saveTaskMetadata } from "@core/storage/disk"
-import * as vscode from "vscode"
 
 export class ModelContextTracker {
 	readonly taskId: string
-	private context: vscode.ExtensionContext
 
-	constructor(context: vscode.ExtensionContext, taskId: string) {
-		this.context = context
+	constructor(taskId: string) {
 		this.taskId = taskId
 	}
 
 	async recordModelUsage(apiProviderId: string, modelId: string, mode: string) {
-		const metadata = await getTaskMetadata(this.context, this.taskId)
+		const metadata = await getTaskMetadata(this.taskId)
 
 		if (!metadata.model_usage) {
 			metadata.model_usage = []
@@ -35,6 +32,6 @@ export class ModelContextTracker {
 			mode: mode,
 		})
 
-		await saveTaskMetadata(this.context, this.taskId, metadata)
+		await saveTaskMetadata(this.taskId, metadata)
 	}
 }

--- a/src/core/controller/file/openFocusChainFile.ts
+++ b/src/core/controller/file/openFocusChainFile.ts
@@ -32,7 +32,7 @@ export async function openFocusChainFile(controller: Controller, request: String
 		}
 	}
 
-	const focusChainFilePath = await ensureFocusChainFile(controller.context, taskId, initialFocusChainContent)
+	const focusChainFilePath = await ensureFocusChainFile(taskId, initialFocusChainContent)
 	telemetryService.captureFocusChainListOpened(taskId)
 	await openFileIntegration(focusChainFilePath)
 

--- a/src/core/storage/StateManager.ts
+++ b/src/core/storage/StateManager.ts
@@ -165,7 +165,7 @@ export class StateManager {
 		}
 
 		try {
-			const taskSettings = await readTaskSettingsFromStorage(this.context, taskId)
+			const taskSettings = await readTaskSettingsFromStorage(taskId)
 			// Populate task cache with loaded settings
 			Object.assign(this.taskStateCache, taskSettings)
 		} catch (error) {
@@ -785,7 +785,7 @@ export class StateManager {
 		try {
 			await Promise.all(
 				Array.from(keys).map((key) => {
-					return writeTaskSettingsToStorage(this.context, taskId, { [key]: this.taskStateCache[key] })
+					return writeTaskSettingsToStorage(taskId, { [key]: this.taskStateCache[key] })
 				}),
 			)
 		} catch (error) {

--- a/src/core/task/focus-chain/file-utils.ts
+++ b/src/core/task/focus-chain/file-utils.ts
@@ -1,7 +1,6 @@
 import { isFocusChainItem } from "@shared/focus-chain-utils"
 import * as fs from "fs/promises"
 import * as path from "path"
-import * as vscode from "vscode"
 import { ensureTaskDirectoryExists } from "../../storage/disk"
 
 /**
@@ -49,12 +48,8 @@ export function extractFocusChainListFromText(text: string): string | null {
  * Ensure a focusChain file exists, creating it with provided content if it doesn't exist
  * Returns the file path
  */
-export async function ensureFocusChainFile(
-	context: vscode.ExtensionContext,
-	taskId: string,
-	initialFocusChainContent?: string,
-): Promise<string> {
-	const taskDir = await ensureTaskDirectoryExists(context, taskId)
+export async function ensureFocusChainFile(taskId: string, initialFocusChainContent?: string): Promise<string> {
+	const taskDir = await ensureTaskDirectoryExists(taskId)
 	const focusChainFilePath = getFocusChainFilePath(taskDir, taskId)
 
 	// Check if file exists

--- a/src/core/task/focus-chain/index.ts
+++ b/src/core/task/focus-chain/index.ts
@@ -1,7 +1,6 @@
 import { FocusChainSettings } from "@shared/FocusChainSettings"
 import * as chokidar from "chokidar"
 import * as fs from "fs/promises"
-import * as vscode from "vscode"
 import { telemetryService } from "@/services/telemetry"
 import { ClineSay } from "../../../shared/ExtensionMessage"
 import { Mode } from "../../../shared/storage/types"
@@ -21,7 +20,6 @@ export interface FocusChainDependencies {
 	taskId: string
 	taskState: TaskState
 	mode: Mode
-	context: vscode.ExtensionContext
 	stateManager: StateManager
 	postStateToWebview: () => Promise<void>
 	say: (type: ClineSay, text?: string, images?: string[], files?: string[], partial?: boolean) => Promise<number | undefined>
@@ -31,7 +29,6 @@ export interface FocusChainDependencies {
 export class FocusChainManager {
 	private taskId: string
 	private taskState: TaskState
-	private context: vscode.ExtensionContext
 	private stateManager: StateManager
 	private postStateToWebview: () => Promise<void>
 	private say: (
@@ -49,7 +46,6 @@ export class FocusChainManager {
 	constructor(dependencies: FocusChainDependencies) {
 		this.taskId = dependencies.taskId
 		this.taskState = dependencies.taskState
-		this.context = dependencies.context
 		this.stateManager = dependencies.stateManager
 		this.postStateToWebview = dependencies.postStateToWebview
 		this.say = dependencies.say
@@ -64,7 +60,7 @@ export class FocusChainManager {
 	 */
 	public async setupFocusChainFileWatcher() {
 		try {
-			const taskDir = await ensureTaskDirectoryExists(this.context, this.taskId)
+			const taskDir = await ensureTaskDirectoryExists(this.taskId)
 			const focusChainFilePath = getFocusChainFilePath(taskDir, this.taskId)
 
 			// Initialize chokidar watcher
@@ -312,7 +308,7 @@ ${listInstrunctionsReminder}\n`
 	 */
 	private async readFocusChainFromDisk(): Promise<string | null> {
 		try {
-			const taskDir = await ensureTaskDirectoryExists(this.context, this.taskId)
+			const taskDir = await ensureTaskDirectoryExists(this.taskId)
 			const todoFilePath = getFocusChainFilePath(taskDir, this.taskId)
 			const markdownContent = await fs.readFile(todoFilePath, "utf8")
 			const todoList = extractFocusChainListFromText(markdownContent)
@@ -340,7 +336,7 @@ ${listInstrunctionsReminder}\n`
 	 */
 	private async writeFocusChainToDisk(todoList: string): Promise<void> {
 		try {
-			const taskDir = await ensureTaskDirectoryExists(this.context, this.taskId)
+			const taskDir = await ensureTaskDirectoryExists(this.taskId)
 			const todoFilePath = getFocusChainFilePath(taskDir, this.taskId)
 			const fileContent = createFocusChainMarkdownContent(this.taskId, todoList)
 			await writeFile(todoFilePath, fileContent, "utf8")

--- a/src/core/task/index.ts
+++ b/src/core/task/index.ts
@@ -225,7 +225,7 @@ export class Task {
 
 		// Initialize file context tracker
 		this.fileContextTracker = new FileContextTracker(controller, this.taskId)
-		this.modelContextTracker = new ModelContextTracker(controller.context, this.taskId)
+		this.modelContextTracker = new ModelContextTracker(this.taskId)
 
 		// Initialize focus chain manager only if enabled
 		const focusChainSettings = this.stateManager.getGlobalSettingsKey("focusChainSettings")
@@ -234,7 +234,6 @@ export class Task {
 				taskId: this.taskId,
 				taskState: this.taskState,
 				mode: this.stateManager.getGlobalSettingsKey("mode"),
-				context: this.getContext(),
 				stateManager: this.stateManager,
 				postStateToWebview: this.postStateToWebview,
 				say: this.say.bind(this),
@@ -719,7 +718,7 @@ export class Task {
 			// Optionally, inform the user or handle the error appropriately
 		}
 
-		const savedClineMessages = await getSavedClineMessages(this.getContext(), this.taskId)
+		const savedClineMessages = await getSavedClineMessages(this.taskId)
 
 		// Remove any resume messages that may have been added before
 		const lastRelevantMessageIndex = findLastIndex(
@@ -741,7 +740,7 @@ export class Task {
 		}
 
 		await this.messageStateHandler.overwriteClineMessages(savedClineMessages)
-		this.messageStateHandler.setClineMessages(await getSavedClineMessages(this.getContext(), this.taskId))
+		this.messageStateHandler.setClineMessages(await getSavedClineMessages(this.taskId))
 
 		// Now present the cline messages to the user and ask if they want to resume (NOTE: we ran into a bug before where the apiconversationhistory wouldn't be initialized when opening a old task, and it was because we were waiting for resume)
 		// This is important in case the user deletes messages without resuming the task first
@@ -751,8 +750,8 @@ export class Task {
 
 		// load the context history state
 
-		const _taskDir = await ensureTaskDirectoryExists(context, this.taskId)
-		await this.contextManager.initializeContextHistory(await ensureTaskDirectoryExists(this.getContext(), this.taskId))
+		const _taskDir = await ensureTaskDirectoryExists(this.taskId)
+		await this.contextManager.initializeContextHistory(await ensureTaskDirectoryExists(this.taskId))
 
 		const lastClineMessage = this.messageStateHandler
 			.getClineMessages()
@@ -1292,7 +1291,7 @@ export class Task {
 		await this.messageStateHandler.saveClineMessagesAndUpdateHistory()
 		await this.contextManager.triggerApplyStandardContextTruncationNoticeChange(
 			Date.now(),
-			await ensureTaskDirectoryExists(this.getContext(), this.taskId),
+			await ensureTaskDirectoryExists(this.taskId),
 			apiConversationHistory,
 		)
 
@@ -1381,7 +1380,7 @@ export class Task {
 			this.api,
 			this.taskState.conversationHistoryDeletedRange,
 			previousApiReqIndex,
-			await ensureTaskDirectoryExists(this.getContext(), this.taskId),
+			await ensureTaskDirectoryExists(this.taskId),
 			this.stateManager.getGlobalSettingsKey("useAutoCondense"),
 		)
 

--- a/src/core/task/message-state.ts
+++ b/src/core/task/message-state.ts
@@ -66,7 +66,7 @@ export class MessageStateHandler {
 
 	async saveClineMessagesAndUpdateHistory(): Promise<void> {
 		try {
-			await saveClineMessages(this.context, this.taskId, this.clineMessages)
+			await saveClineMessages(this.taskId, this.clineMessages)
 
 			// combined as they are in ChatView
 			const apiMetrics = getApiMetrics(combineApiRequests(combineCommandSequences(this.clineMessages.slice(1))))
@@ -78,7 +78,7 @@ export class MessageStateHandler {
 						(message) => !(message.ask === "resume_task" || message.ask === "resume_completed_task"),
 					)
 				]
-			const taskDir = await ensureTaskDirectoryExists(this.context, this.taskId)
+			const taskDir = await ensureTaskDirectoryExists(this.taskId)
 			let taskDirSize = 0
 			try {
 				// getFolderSize.loose silently ignores errors
@@ -112,12 +112,12 @@ export class MessageStateHandler {
 
 	async addToApiConversationHistory(message: Anthropic.MessageParam) {
 		this.apiConversationHistory.push(message)
-		await saveApiConversationHistory(this.context, this.taskId, this.apiConversationHistory)
+		await saveApiConversationHistory(this.taskId, this.apiConversationHistory)
 	}
 
 	async overwriteApiConversationHistory(newHistory: Anthropic.MessageParam[]): Promise<void> {
 		this.apiConversationHistory = newHistory
-		await saveApiConversationHistory(this.context, this.taskId, this.apiConversationHistory)
+		await saveApiConversationHistory(this.taskId, this.apiConversationHistory)
 	}
 
 	async addToClineMessages(message: ClineMessage) {

--- a/src/core/task/tools/handlers/CondenseHandler.ts
+++ b/src/core/task/tools/handlers/CondenseHandler.ts
@@ -70,7 +70,7 @@ export class CondenseHandler implements IToolHandler, IPartialBlockHandler {
 			await config.messageState.saveClineMessagesAndUpdateHistory()
 			await config.services.contextManager.triggerApplyStandardContextTruncationNoticeChange(
 				Date.now(),
-				await ensureTaskDirectoryExists(config.context, config.taskId),
+				await ensureTaskDirectoryExists(config.taskId),
 				apiConversationHistory,
 			)
 

--- a/src/core/task/tools/handlers/SummarizeTaskHandler.ts
+++ b/src/core/task/tools/handlers/SummarizeTaskHandler.ts
@@ -56,7 +56,7 @@ export class SummarizeTaskHandler implements IToolHandler, IPartialBlockHandler 
 			await config.messageState.saveClineMessagesAndUpdateHistory()
 			await config.services.contextManager.triggerApplyStandardContextTruncationNoticeChange(
 				Date.now(),
-				await ensureTaskDirectoryExists(config.context, config.taskId),
+				await ensureTaskDirectoryExists(config.taskId),
 				apiConversationHistory,
 			)
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -491,7 +491,7 @@ export async function activate(context: vscode.ExtensionContext) {
 	context.subscriptions.push(
 		vscode.commands.registerCommand(commands.ReconstructTaskHistory, async () => {
 			const { reconstructTaskHistory } = await import("./core/commands/reconstructTaskHistory")
-			await reconstructTaskHistory(context)
+			await reconstructTaskHistory()
 			telemetryService.captureButtonClick("command_reconstructTaskHistory")
 		}),
 	)

--- a/src/integrations/checkpoints/index.ts
+++ b/src/integrations/checkpoints/index.ts
@@ -671,10 +671,7 @@ export class TaskCheckpointManager implements ICheckpointManager {
 
 				// update the context history state
 				const contextManager = new ContextManager()
-				await contextManager.truncateContextHistory(
-					message.ts,
-					await ensureTaskDirectoryExists(this.getContext(), this.task.taskId),
-				)
+				await contextManager.truncateContextHistory(message.ts, await ensureTaskDirectoryExists(this.task.taskId))
 
 				// aggregate deleted api reqs info so we don't lose costs/tokens
 				const clineMessages = this.services.messageStateHandler.getClineMessages()

--- a/src/services/test/TestServer.ts
+++ b/src/services/test/TestServer.ts
@@ -305,7 +305,7 @@ export function createTestServer(controller: Controller): http.Server {
 						let apiConversationHistory: any[] = []
 						try {
 							if (typeof taskId === "string") {
-								messages = await getSavedClineMessages(visibleWebview.controller.context, taskId)
+								messages = await getSavedClineMessages(taskId)
 							}
 						} catch (error) {
 							Logger.log(`Error getting saved Cline messages: ${error}`)


### PR DESCRIPTION
Replace uses of context.globalStorageUri with HostProvider.get().globalStorageFsPath

This is part of removing dependencies on the VSCode API fom the codebase except for in platform specific code in src/hosts/vscode and src/extension.ts.

Remove unused vscode context param.

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Replaces `context.globalStorageUri` with `HostProvider.get().globalStorageFsPath` and removes unused `vscode.ExtensionContext` parameters to reduce VSCode API dependency.
> 
>   - **Behavior**:
>     - Replaces `context.globalStorageUri` with `HostProvider.get().globalStorageFsPath` in `reconstructTaskHistory.ts`, `StateManager.ts`, and `disk.ts`.
>     - Removes unused `vscode.ExtensionContext` parameter from functions like `reconstructTaskHistory()` and `performTaskHistoryReconstruction()` in `reconstructTaskHistory.ts`.
>   - **Functions**:
>     - Updates `ensureTaskDirectoryExists()` and other functions in `disk.ts` to use `HostProvider.get().globalStorageFsPath`.
>     - Modifies `openFocusChainFile()` in `openFocusChainFile.ts` to remove `context` parameter.
>   - **Misc**:
>     - Adjusts test files like `FileContextTracker.test.ts` and `ModelContextTracker.test.ts` to align with the new function signatures.
>     - Updates command registration in `extension.ts` to reflect changes in `reconstructTaskHistory` function signature.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 376db669f87a0acab786b25552acb49584e97c30. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->