### PR TITLE
fix: add retry logic to SAP AI Core provider

### DIFF
--- a/.changeset/five-numbers-stare.md
+++ b/.changeset/five-numbers-stare.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+fix: automatically retry on rate limit errors with SAP AI Core provider

--- a/src/core/api/providers/sapaicore.ts
+++ b/src/core/api/providers/sapaicore.ts
@@ -9,6 +9,7 @@ import { ModelInfo, SapAiCoreModelId, sapAiCoreDefaultModelId, sapAiCoreModels }
 import axios from "axios"
 import OpenAI from "openai"
 import { ApiHandler, CommonApiHandlerOptions } from "../"
+import { withRetry } from "../retry"
 import { convertToOpenAiMessages } from "../transform/openai-format"
 import { ApiStream } from "../transform/stream"
 
@@ -454,6 +455,7 @@ export class SapAiCoreHandler implements ApiHandler {
 		return this.deployments?.some((d) => d.name.split(":")[0].toLowerCase() === modelId.split(":")[0].toLowerCase()) ?? false
 	}
 
+	@withRetry()
 	async *createMessage(systemPrompt: string, messages: Anthropic.Messages.MessageParam[]): ApiStream {
 		if (this.options.sapAiCoreUseOrchestrationMode) {
 			yield* this.createMessageWithOrchestration(systemPrompt, messages)


### PR DESCRIPTION
### Description

This PR adds missing retry decorator to the SAP AI Core provider.

### Test Procedure

- Tested provider usage for regressions

### Type of Change

-   [X] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [X] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [X] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [X] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [X] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)


### Additional Notes

Previously missing providers were added via https://github.com/cline/cline/pull/3596

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds retry logic to `createMessage()` in `sapaicore.ts` to handle rate limit errors in SAP AI Core provider.
> 
>   - **Behavior**:
>     - Adds `@withRetry()` decorator to `createMessage()` in `sapaicore.ts` to handle rate limit errors automatically.
>   - **Misc**:
>     - Adds import for `withRetry` in `sapaicore.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 911b3f9287eb1f8dc7bd1288f1a1c6a540e13daf. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->