### PR TITLE
fix: prevent tooltip hovering by using inline pointer-events none

### DIFF
--- a/webview-ui/src/components/common/HeroTooltip.tsx
+++ b/webview-ui/src/components/common/HeroTooltip.tsx
@@ -22,7 +22,7 @@ const HeroTooltip: React.FC<HeroTooltipProps> = ({
 	className,
 	showArrow = false,
 	delay = 0,
-	closeDelay = 500,
+	closeDelay = 100,
 	placement = "top",
 	disabled = false,
 }) => {
@@ -46,15 +46,20 @@ const HeroTooltip: React.FC<HeroTooltipProps> = ({
 	return (
 		<Tooltip
 			classNames={{
-				content: "hero-tooltip-content pointer-events-none", // Prevent hovering over tooltip
+				base: "pointer-events-none", // Prevent hovering over tooltip container
+				content: "hero-tooltip-content pointer-events-none", // Prevent hovering over tooltip content
 			}}
 			closeDelay={closeDelay}
-			content={formattedContent} // Immediate close when cursor moves away
+			content={formattedContent}
 			delay={delay}
 			disableAnimation={true}
 			isDisabled={disabled}
-			placement={placement} // Disable animation for immediate appearance/disappearance
-			showArrow={showArrow}>
+			placement={placement}
+			showArrow={showArrow}
+			// Inline style to override any library styles - above classNames aren't applying correctly
+			style={{
+				pointerEvents: "none",
+			}}>
 			{children}
 		</Tooltip>
 	)


### PR DESCRIPTION
### Description

Reduce disappearing delay for tooltips and prevent display persistence when hovering over the tooltip in the TaskHeader UI.

### Test Procedure

render the UI and test interacting with the elements.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [x] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

https://github.com/user-attachments/assets/37edf1cd-57a6-4f19-be75-915885e3e434


<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->
