### PR TITLE
feat(api): add gpt-5-codex model with pricing and capabilities

### DIFF
--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -1152,6 +1152,15 @@ export const openAiNativeModels = {
 		outputPrice: 10,
 		cacheReadsPrice: 0.125,
 	},
+	"gpt-5-codex": {
+		maxTokens: 8_192,
+		contextWindow: 400000,
+		supportsImages: true,
+		supportsPromptCache: true,
+		inputPrice: 1.25,
+		outputPrice: 10.0,
+		cacheReadsPrice: 0.125,
+	},
 	o3: {
 		maxTokens: 100_000,
 		contextWindow: 200_000,

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -1154,7 +1154,7 @@ export const openAiNativeModels = {
 	},
 	"gpt-5-codex": {
 		maxTokens: 8_192,
-		contextWindow: 400000,
+		contextWindow: 400_000,
 		supportsImages: true,
 		supportsPromptCache: true,
 		inputPrice: 1.25,


### PR DESCRIPTION
Register gpt-5-codex in openAiNativeModels to expose the new model. Sets maxTokens (8,192), context window (400k), image support, prompt cache, and pricing (input: 1.25, output: 10.0, cache reads: 0.125) to ensure correct capability checks, limits, and billing calculations.
<img width="944" height="387" alt="image" src="https://github.com/user-attachments/assets/54532039-6295-4c37-b4af-4cc325e1a060" />

### Related Issue

Discussion: https://github.com/cline/cline/discussions/6481  
Please upvote the discussion to signal support and help prioritize this change.

### Description

Add OpenAI Native model “gpt-5-codex” to the OpenAI Native provider registry.

Code changes
- File: src/shared/api.ts
- Registry: openAiNativeModels
- Added:
  - "gpt-5-codex": { maxTokens: 8192, contextWindow: 400000, supportsImages: true, supportsPromptCache: true, inputPrice: 1.25, outputPrice: 10.0, cacheReadsPrice: 0.125 }

Rationale
- This enables selecting “gpt-5-codex” under the OpenAI Native provider. The codebase dynamically wires model IDs:
  - Types: OpenAiNativeModelId = keyof typeof openAiNativeModels
  - Backend: OpenAiNativeHandler validates modelId against registry
  - UI: Settings model list reads from openAiNativeModels
- No default model change. Existing behavior is preserved.

Notes
- If cache writes are billed for this model, add cacheWritesPrice similarly to other entries.
- Optional docs update: docs/provider-config/openai.mdx or openai-compatible.mdx to list the new model.

### Test Procedure

Local test run on Windows (PowerShell):

1) Install dependencies
- npm run install:all

2) Build/Typecheck/Lint
- npm run compile
  - Protos generated successfully
  - TypeScript checks passed
  - Lint passed (biome + buf)

3) Unit tests (PowerShell-friendly env setting)
- $env:TS_NODE_PROJECT = 'tsconfig.unit-test.json'; npx mocha
- Result: 227 passing, 4 pending

4) Integration tests (optional)
- npm run test:integration
- Runs VSCode harness; not executed in this session

5) E2E tests (optional)
- npm run test:e2e:optimal (or npm run test:e2e)

Windows script note
- package.json "test:unit" uses Unix-style env var. On Windows, run Mocha via:
  - $env:TS_NODE_PROJECT = 'tsconfig.unit-test.json'; npx mocha
- Optional improvement: add cross-env to make scripts cross-platform.

Condensed logs
- Protos: generated and formatted
- Typecheck: OK
- Lint: OK
- Unit tests: 227 passing, 4 pending

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (unit tests) and code is formatted and linted (npm run format && npm run lint)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Backend change — terminal summary:
```
Protos: OK
Typecheck: OK
Lint: OK
Unit tests: 227 passing, 4 pending
```

### Additional Notes

- Default OpenAI Native model remains unchanged.
- If desired, default can be set via openAiNativeDefaultModelId = "gpt-5-codex".
- Cost calculator uses inputPrice, outputPrice, cacheReadsPrice; values provided match existing OpenAI Native entries.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `gpt-5-codex` model to `openAiNativeModels` in `src/shared/api.ts` with specific capabilities and pricing.
> 
>   - **Behavior**:
>     - Add `gpt-5-codex` to `openAiNativeModels` in `src/shared/api.ts` with maxTokens 8,192, contextWindow 400,000, image support, prompt cache, and pricing (input: 1.25, output: 10.0, cache reads: 0.125).
>     - Enables selection of `gpt-5-codex` in OpenAI Native provider without changing the default model.
>   - **Pricing and Capabilities**:
>     - Sets input price to 1.25, output price to 10.0, and cache reads price to 0.125 for `gpt-5-codex`.
>     - Supports images and prompt cache with a context window of 400,000.
>   - **Misc**:
>     - Notes on potential future addition of cacheWritesPrice if needed.
>     - Suggests optional documentation update to list the new model.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 755990181c02b4f1543fe57baf5033adb819eeef. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->