### PR TITLE
Only show the info banner messages about the right sidebar in VSCode

### DIFF
--- a/src/hosts/vscode/hostbridge-grpc-service.ts
+++ b/src/hosts/vscode/hostbridge-grpc-service.ts
@@ -50,7 +50,6 @@ export class ServiceRegistry {
 		}
 
 		this.methodMetadata[methodName] = { isStreaming, ...metadata }
-		console.log(`Registered ${this.serviceName} method: ${methodName}${isStreaming ? " (streaming)" : ""}`)
 	}
 
 	/**

--- a/webview-ui/src/components/common/InfoBanner.tsx
+++ b/webview-ui/src/components/common/InfoBanner.tsx
@@ -1,41 +1,41 @@
-import { Int64Request } from "@shared/proto/cline/common"
 import { VSCodeButton } from "@vscode/webview-ui-toolkit/react"
 import { useCallback } from "react"
+import { PlatformType } from "@/config/platform.config"
+import { usePlatform } from "@/context/PlatformContext"
 import { StateServiceClient } from "@/services/grpc-client"
 export const CURRENT_INFO_BANNER_VERSION = 1
 export const InfoBanner: React.FC = () => {
 	const handleClose = useCallback((e: React.MouseEvent) => {
 		e.preventDefault()
 		e.stopPropagation()
-		const request = Int64Request.create({
-			value: CURRENT_INFO_BANNER_VERSION,
-		})
-		StateServiceClient.updateInfoBannerVersion(request).catch(console.error)
+		StateServiceClient.updateInfoBannerVersion({ value: CURRENT_INFO_BANNER_VERSION }).catch(console.error)
 	}, [])
+	if (usePlatform().type === PlatformType.VSCODE) {
+		return (
+			<a
+				className="bg-banner-background px-3 py-2 flex flex-col gap-1 shrink-0 mb-1 relative text-sm m-4 no-underline transition-colors hover:brightness-120"
+				href="https://docs.cline.bot/features/customization/opening-cline-in-sidebar"
+				rel="noopener noreferrer"
+				style={{ color: "var(--vscode-foreground)" }}
+				target="_blank">
+				<h3 className="m-0">💡 Cline in the Right Sidebar</h3>
+				<p className="m-0">
+					Keep your files visible when chatting with Cline. Drag the Cline icon to the right sidebar panel for a better
+					experience. <span className="text-link cursor-pointer">See how →</span>
+				</p>
 
-	return (
-		<a
-			className="bg-banner-background px-3 py-2 flex flex-col gap-1 shrink-0 mb-1 relative text-sm m-4 no-underline transition-colors hover:brightness-120"
-			href="https://docs.cline.bot/features/customization/opening-cline-in-sidebar"
-			rel="noopener noreferrer"
-			style={{ color: "var(--vscode-foreground)" }}
-			target="_blank">
-			<h3 className="m-0">💡 Cline in the Right Sidebar</h3>
-			<p className="m-0">
-				Keep your files visible when chatting with Cline. Drag the Cline icon to the right sidebar panel for a better
-				experience. <span className="text-link cursor-pointer">See how →</span>
-			</p>
-
-			{/* Close button */}
-			<VSCodeButton
-				appearance="icon"
-				data-testid="info-banner-close-button"
-				onClick={handleClose}
-				style={{ position: "absolute", top: "8px", right: "8px" }}>
-				<span className="codicon codicon-close"></span>
-			</VSCodeButton>
-		</a>
-	)
+				{/* Close button */}
+				<VSCodeButton
+					appearance="icon"
+					data-testid="info-banner-close-button"
+					onClick={handleClose}
+					style={{ position: "absolute", top: "8px", right: "8px" }}>
+					<span className="codicon codicon-close"></span>
+				</VSCodeButton>
+			</a>
+		)
+	}
+	return null
 }
 
 export default InfoBanner

--- a/webview-ui/src/config/platform.config.ts
+++ b/webview-ui/src/config/platform.config.ts
@@ -1,6 +1,7 @@
 import platformConfigs from "./platform-configs.json"
 
 export interface PlatformConfig {
+	type: PlatformType
 	messageEncoding: MessageEncoding
 	showNavbar: boolean
 	postMessage: PostMessageFunction
@@ -8,6 +9,24 @@ export interface PlatformConfig {
 	decodeMessage: MessageDecoder
 	togglePlanActKeys: string
 	supportsTerminalMentions: boolean
+}
+
+export enum PlatformType {
+	VSCODE = 0,
+	STANDALONE = 1,
+}
+
+function stringToPlatformType(name: string): PlatformType {
+	const mapping: Record<string, PlatformType> = {
+		vscode: PlatformType.VSCODE,
+		standalone: PlatformType.STANDALONE,
+	}
+	if (name in mapping) {
+		return mapping[name]
+	}
+	console.error("Unknown platform:", name)
+	// Default to VSCode for unknown types
+	return PlatformType.VSCODE
 }
 
 // Internal type for JSON structure (not exported)
@@ -76,7 +95,9 @@ const selectedConfig = configs[__PLATFORM__]
 console.log("[PLATFORM_CONFIG] Build platform:", __PLATFORM__)
 
 // Build the platform config with injected functions
+// Callers should use this in the situations where the react component is not available.
 export const PLATFORM_CONFIG: PlatformConfig = {
+	type: stringToPlatformType(__PLATFORM__),
 	messageEncoding: selectedConfig.messageEncoding,
 	showNavbar: selectedConfig.showNavbar,
 	postMessage: postMessageStrategies[selectedConfig.postMessageHandler],


### PR DESCRIPTION
Add a `type` field to the PlatConfig with type of the IDE: VSCode, standalone, etc.
Make the info banner conditional on the type.
Quiet the gRPC logs on startup.

<img width="673" height="810" alt="Screenshot 2025-09-26 at 19 08 43" src="https://github.com/user-attachments/assets/b3ce4479-13d6-4500-a2b9-69fccebc8489" />
<img width="628" height="1019" alt="Screenshot 2025-09-26 at 19 17 53" src="https://github.com/user-attachments/assets/38901030-a86b-4d8e-a142-c950fe687d25" />
