### PR TITLE
Enable thinking by default for models that support it to reduce text verbosity in chat

### DIFF
--- a/src/core/storage/utils/state-helpers.ts
+++ b/src/core/storage/utils/state-helpers.ts
@@ -1,4 +1,4 @@
-import { ApiProvider, fireworksDefaultModelId, type OcaModelInfo } from "@shared/api"
+import { ANTHROPIC_MIN_THINKING_BUDGET, ApiProvider, fireworksDefaultModelId, type OcaModelInfo } from "@shared/api"
 import { ExtensionContext } from "vscode"
 import { Controller } from "@/core/controller"
 import { DEFAULT_AUTO_APPROVAL_SETTINGS } from "@/shared/AutoApprovalSettings"
@@ -419,11 +419,6 @@ export async function readGlobalStateFromDisk(context: ExtensionContext): Promis
 		const primaryRootIndex = context.globalState.get<GlobalStateAndSettings["primaryRootIndex"]>("primaryRootIndex")
 		const multiRootEnabled = context.globalState.get<GlobalStateAndSettings["multiRootEnabled"]>("multiRootEnabled")
 
-		// thinking/reasoning default value
-		// undefined means it was never modified, 0 means it was turned off
-		// (having this on by default ensures that <thinking> text does not pollute the user's chat and is instead rendered as reasoning)
-		const defaultThinkingBudgetTokens = 1024 // minimum for claude sonnet
-
 		return {
 			// api configuration fields
 			claudeCodePath,
@@ -466,7 +461,9 @@ export async function readGlobalStateFromDisk(context: ExtensionContext): Promis
 			// Plan mode configurations
 			planModeApiProvider: planModeApiProvider || apiProvider,
 			planModeApiModelId,
-			planModeThinkingBudgetTokens: planModeThinkingBudgetTokens ?? defaultThinkingBudgetTokens,
+			// undefined means it was never modified, 0 means it was turned off
+			// (having this on by default ensures that <thinking> text does not pollute the user's chat and is instead rendered as reasoning)
+			planModeThinkingBudgetTokens: planModeThinkingBudgetTokens ?? ANTHROPIC_MIN_THINKING_BUDGET,
 			planModeReasoningEffort,
 			planModeVsCodeLmModelSelector,
 			planModeAwsBedrockCustomSelected,
@@ -500,7 +497,7 @@ export async function readGlobalStateFromDisk(context: ExtensionContext): Promis
 			// Act mode configurations
 			actModeApiProvider: actModeApiProvider || apiProvider,
 			actModeApiModelId,
-			actModeThinkingBudgetTokens: actModeThinkingBudgetTokens ?? defaultThinkingBudgetTokens,
+			actModeThinkingBudgetTokens: actModeThinkingBudgetTokens ?? ANTHROPIC_MIN_THINKING_BUDGET,
 			actModeReasoningEffort,
 			actModeVsCodeLmModelSelector,
 			actModeAwsBedrockCustomSelected,

--- a/src/core/storage/utils/state-helpers.ts
+++ b/src/core/storage/utils/state-helpers.ts
@@ -419,6 +419,11 @@ export async function readGlobalStateFromDisk(context: ExtensionContext): Promis
 		const primaryRootIndex = context.globalState.get<GlobalStateAndSettings["primaryRootIndex"]>("primaryRootIndex")
 		const multiRootEnabled = context.globalState.get<GlobalStateAndSettings["multiRootEnabled"]>("multiRootEnabled")
 
+		// thinking/reasoning default value
+		// undefined means it was never modified, 0 means it was turned off
+		// (having this on by default ensures that <thinking> text does not pollute the user's chat and is instead rendered as reasoning)
+		const defaultThinkingBudgetTokens = 1024 // minimum for claude sonnet
+
 		return {
 			// api configuration fields
 			claudeCodePath,
@@ -461,7 +466,7 @@ export async function readGlobalStateFromDisk(context: ExtensionContext): Promis
 			// Plan mode configurations
 			planModeApiProvider: planModeApiProvider || apiProvider,
 			planModeApiModelId,
-			planModeThinkingBudgetTokens,
+			planModeThinkingBudgetTokens: planModeThinkingBudgetTokens ?? defaultThinkingBudgetTokens,
 			planModeReasoningEffort,
 			planModeVsCodeLmModelSelector,
 			planModeAwsBedrockCustomSelected,
@@ -495,7 +500,7 @@ export async function readGlobalStateFromDisk(context: ExtensionContext): Promis
 			// Act mode configurations
 			actModeApiProvider: actModeApiProvider || apiProvider,
 			actModeApiModelId,
-			actModeThinkingBudgetTokens,
+			actModeThinkingBudgetTokens: actModeThinkingBudgetTokens ?? defaultThinkingBudgetTokens,
 			actModeReasoningEffort,
 			actModeVsCodeLmModelSelector,
 			actModeAwsBedrockCustomSelected,

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -262,6 +262,7 @@ export const CLAUDE_SONNET_4_1M_TIERS = [
 // https://docs.anthropic.com/en/docs/about-claude/models // prices updated 2025-01-02
 export type AnthropicModelId = keyof typeof anthropicModels
 export const anthropicDefaultModelId: AnthropicModelId = "claude-sonnet-4-20250514"
+export const ANTHROPIC_MIN_THINKING_BUDGET = 1_024
 export const anthropicModels = {
 	"claude-sonnet-4-20250514:1m": {
 		maxTokens: 8192,

--- a/webview-ui/src/components/settings/ThinkingBudgetSlider.tsx
+++ b/webview-ui/src/components/settings/ThinkingBudgetSlider.tsx
@@ -1,4 +1,4 @@
-import { anthropicModels, geminiDefaultModelId, geminiModels } from "@shared/api"
+import { ANTHROPIC_MIN_THINKING_BUDGET, anthropicModels, geminiDefaultModelId, geminiModels } from "@shared/api"
 import { Mode } from "@shared/storage/types"
 import { VSCodeCheckbox } from "@vscode/webview-ui-toolkit/react"
 import { memo, useCallback, useEffect, useMemo, useState } from "react"
@@ -8,7 +8,6 @@ import { getModeSpecificFields } from "./utils/providerUtils"
 import { useApiConfigurationHandlers } from "./utils/useApiConfigurationHandlers"
 
 // Constants
-const DEFAULT_MIN_VALID_TOKENS = 1024
 const MAX_PERCENTAGE = 0.8
 const THUMB_SIZE = 16
 
@@ -143,7 +142,7 @@ const ThinkingBudgetSlider = ({ maxBudget, currentMode }: ThinkingBudgetSliderPr
 
 	const handleToggleChange = (event: any) => {
 		const isChecked = (event.target as HTMLInputElement).checked
-		const newThinkingBudgetValue = isChecked ? DEFAULT_MIN_VALID_TOKENS : 0
+		const newThinkingBudgetValue = isChecked ? ANTHROPIC_MIN_THINKING_BUDGET : 0
 		setIsEnabled(isChecked)
 		setLocalValue(newThinkingBudgetValue)
 
@@ -169,16 +168,16 @@ const ThinkingBudgetSlider = ({ maxBudget, currentMode }: ThinkingBudgetSliderPr
 					</LabelContainer>
 					<RangeInput
 						$max={maxSliderValue}
-						$min={DEFAULT_MIN_VALID_TOKENS}
+						$min={ANTHROPIC_MIN_THINKING_BUDGET}
 						$value={localValue}
 						aria-describedby="thinking-budget-description"
 						aria-label={`Thinking budget: ${localValue.toLocaleString()} tokens`}
 						aria-valuemax={maxSliderValue}
-						aria-valuemin={DEFAULT_MIN_VALID_TOKENS}
+						aria-valuemin={ANTHROPIC_MIN_THINKING_BUDGET}
 						aria-valuenow={localValue}
 						id="thinking-budget-slider"
 						max={maxSliderValue}
-						min={DEFAULT_MIN_VALID_TOKENS}
+						min={ANTHROPIC_MIN_THINKING_BUDGET}
 						onChange={handleSliderChange}
 						onMouseUp={handleSliderComplete}
 						onTouchEnd={handleSliderComplete}


### PR DESCRIPTION
**User feedback has highlighted a key UX issue when comparing Cline to Claude Code:**
> Cline feels verbose while Claude Code is more concise and black-boxed, avoiding cognitive overload. Claude Code does better at showing what needs your attention - Cline shows too much output so you don't know what to read. Claude Code is better at keeping you in the loop without being verbose.

**Problem:**
Previously, Cline's system prompt instructed the model to use <thinking> tags for internal reasoning about task planning and tool selection. This thinking content was displayed directly in the chat view, overwhelming users with information that wasn't actionable for providing feedback or course correction.

**Solution:**
With Anthropic's introduction of the thinking budget parameter, we can now separate this reasoning content into a dedicated UI component. This PR implements this separation as the default behavior, ensuring users are presented only with information that requires their attention while maintaining transparency for those who want to dive deeper into the model's reasoning process.

**Before:**
<img width="294" height="862" alt="Cursor 2025-09-27 01 24 22" src="https://github.com/user-attachments/assets/600122bb-d7b5-4c97-a43e-cbdae0ab9379" />

**After:**
<img width="293" height="534" alt="Cursor 2025-09-27 01 24 36" src="https://github.com/user-attachments/assets/24c6ee88-1035-409b-a3d0-d5030c1fc0e2" />
