### PR TITLE
Fix problem compiling integration tests

### DIFF
--- a/src/core/task/index.ts
+++ b/src/core/task/index.ts
@@ -1,6 +1,5 @@
 import { setTimeout as setTimeoutPromise } from "node:timers/promises"
 import { Anthropic } from "@anthropic-ai/sdk"
-import { RedactedThinkingBlock, TextBlock, ThinkingBlock } from "@anthropic-ai/sdk/resources/index.mjs"
 import { ApiHandler, ApiProviderInfo, buildApiHandler } from "@core/api"
 import { ApiStream } from "@core/api/transform/stream"
 import { parseAssistantMessageV2 } from "@core/assistant-message"
@@ -2184,7 +2183,9 @@ export class Task {
 							// @ts-ignore-next-line
 							reasoning_details: reasoningDetails.length > 0 ? reasoningDetails : undefined,
 						},
-					] as Array<RedactedThinkingBlock | ThinkingBlock | TextBlock>,
+					] as Array<
+						Anthropic.Messages.RedactedThinkingBlock | Anthropic.Messages.ThinkingBlock | Anthropic.Messages.TextBlock
+					>,
 				})
 
 				// NOTE: this comment is here for future reference - this was a workaround for userMessageContent not getting set to true. It was due to it not recursively calling for partial blocks when didRejectTool, so it would get stuck waiting for a partial block to complete before it could continue.


### PR DESCRIPTION
Fixes the error below. The integraion tests are compiled to CommonJS and cannot import an .mjs file directly.

```
> claude-dev@3.32.0 compile-tests
> node ./scripts/build-tests.js

node:child_process:957
    throw err;
    ^

Error: Command failed: tsc -p ./tsconfig.test.json --outDir out
    at genericNodeError (node:internal/errors:983:15)
    at wrappedFn (node:internal/errors:537:14)
    at checkExecSyncError (node:child_process:882:11)
    at execSync (node:child_process:954:15)
    at Object.<anonymous> (/Users/sjf/cline/scripts/build-tests.js:56:1)
    at Module._compile (node:internal/modules/cjs/loader:1734:14)
    at Object..js (node:internal/modules/cjs/loader:1899:10)
    at Module.load (node:internal/modules/cjs/loader:1469:32)
    at Function._load (node:internal/modules/cjs/loader:1286:12)
    at TracingChannel.traceSync (node:diagnostics_channel:322:14) {
  status: 2,
  signal: null,
  output: [
    null,
    "src/core/task/index.ts(3,65): error TS7016: Could not find a declaration file for module '@anthropic-ai/sdk/resources/index.mjs'. '/Users/sjf/cline/node_modules/@anthropic-ai/sdk/resources/index.mjs' implicitly has an 'any' type.\n" +
      "  There are types at '/Users/sjf/cline/node_modules/@anthropic-ai/sdk/resources/index.d.ts', but this result could not be resolved under your current 'moduleResolution' setting. Consider updating to 'node16', 'nodenext', or 'bundler'.\n",
    ''
  ],
  pid: 22680,
  stdout: "src/core/task/index.ts(3,65): error TS7016: Could not find a declaration file for module '@anthropic-ai/sdk/resources/index.mjs'. '/Users/sjf/cline/node_modules/@anthropic-ai/sdk/resources/index.mjs' implicitly has an 'any' type.\n" +
    "  There are types at '/Users/sjf/cline/node_modules/@anthropic-ai/sdk/resources/index.d.ts', but this result could not be resolved under your current 'moduleResolution' setting. Consider updating to 'node16', 'nodenext', or 'bundler'.\n",
  stderr: ''
}

Node.js v23.11.0
```
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes integration test compilation error by changing import method for certain types in `index.ts`.
> 
>   - **Behavior**:
>     - Fixes compilation error in integration tests by changing import of `RedactedThinkingBlock`, `TextBlock`, and `ThinkingBlock` from `@anthropic-ai/sdk/resources/index.mjs` to `Anthropic.Messages` in `index.ts`.
>   - **Misc**:
>     - Removes unused import of `RedactedThinkingBlock`, `TextBlock`, and `ThinkingBlock` from `@anthropic-ai/sdk/resources/index.mjs` in `index.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for bb090bac5896994c9a8e9b52545d2d6f7987eeb6. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->