### PR TITLE
fix: Return the updated token

### DIFF
--- a/.changeset/slimy-eels-yell.md
+++ b/.changeset/slimy-eels-yell.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+fix: Return the updated token

--- a/src/services/auth/AuthService.ts
+++ b/src/services/auth/AuthService.ts
@@ -120,7 +120,7 @@ export class AuthService {
 	 */
 	async getAuthToken(): Promise<string | null> {
 		try {
-			const clineAccountAuthToken = this._clineAuthInfo?.idToken
+			let clineAccountAuthToken = this._clineAuthInfo?.idToken
 			if (!this._clineAuthInfo || !clineAccountAuthToken) {
 				// Not authenticated
 				return null
@@ -133,12 +133,14 @@ export class AuthService {
 				if (updatedAuthInfo) {
 					this._clineAuthInfo = updatedAuthInfo
 					this._authenticated = true
+					clineAccountAuthToken = updatedAuthInfo.idToken
 				} else {
 					this._clineAuthInfo = null
 					this._authenticated = false
 				}
 				await this.sendAuthStatusUpdate()
 			}
+
 			// IMPORTANT: Prefix with 'workos:' so backend can route verification to WorkOS provider
 			const prefix = this._provider?.name === "cline" ? "workos:" : ""
 			return clineAccountAuthToken ? `${prefix}${clineAccountAuthToken}` : null


### PR DESCRIPTION
### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** #6489

### Description

When refreshing the auth token, we're still returning the old one. This PR updates it to make sure we return the refreshed one.

### Test Procedure

Tested locally, the auth still works. We should test the refresh logic once the token is about to expire/expired (in 30 mins)

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)
