### PR TITLE
Don't show VS Code LM provider on non-VSCode platforms

### DIFF
--- a/webview-ui/src/components/settings/ApiOptions.tsx
+++ b/webview-ui/src/components/settings/ApiOptions.tsx
@@ -6,6 +6,7 @@ import { KeyboardEvent, useCallback, useEffect, useMemo, useRef, useState } from
 import { useInterval } from "react-use"
 import styled from "styled-components"
 import { normalizeApiConfiguration } from "@/components/settings/utils/providerUtils"
+import { PLATFORM_CONFIG, PlatformType } from "@/config/platform.config"
 import { useExtensionState } from "@/context/ExtensionStateContext"
 import { ModelsServiceClient } from "@/services/grpc-client"
 import { highlight } from "../history/HistoryView"
@@ -123,8 +124,8 @@ const ApiOptions = ({ showModelOptions, apiErrorMessage, modelIdErrorMessage, is
 	const itemRefs = useRef<(HTMLDivElement | null)[]>([])
 	const dropdownListRef = useRef<HTMLDivElement>(null)
 
-	const providerOptions = useMemo(
-		() => [
+	const providerOptions = useMemo(() => {
+		const providers = [
 			{ value: "cline", label: "Cline" },
 			{ value: "openrouter", label: "OpenRouter" },
 			{ value: "gemini", label: "Google Gemini" },
@@ -161,9 +162,15 @@ const ApiOptions = ({ showModelOptions, apiErrorMessage, modelIdErrorMessage, is
 			{ value: "huawei-cloud-maas", label: "Huawei Cloud MaaS" },
 			{ value: "dify", label: "Dify.ai" },
 			{ value: "oca", label: "Oracle Code Assist" },
-		],
-		[],
-	)
+		]
+
+		if (PLATFORM_CONFIG.type !== PlatformType.VSCODE) {
+			// Don't include VS Code LM API for non-VSCode platforms
+			return providers.filter((option) => option.value !== "vscode-lm")
+		}
+
+		return providers
+	}, [])
 
 	const currentProviderLabel = useMemo(() => {
 		return providerOptions.find((option) => option.value === selectedProvider)?.label || selectedProvider


### PR DESCRIPTION
<img width="597" height="560" alt="Screenshot 2025-09-28 at 15 41 09" src="https://github.com/user-attachments/assets/187b8383-0c8a-4e48-ac1d-56e7dae7e047" />

<img width="552" height="346" alt="Screenshot 2025-09-28 at 15 49 27" src="https://github.com/user-attachments/assets/39e1a48b-1cdf-48e3-9f44-fbdf7c3dcffa" />

fixes EXT-55
<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Filter out VS Code LM API from provider options in `ApiOptions` for non-VSCode platforms.
> 
>   - **Behavior**:
>     - In `ApiOptions` component, filter out `vscode-lm` from `providerOptions` if `PLATFORM_CONFIG.type` is not `PlatformType.VSCODE`.
>   - **Imports**:
>     - Add `PLATFORM_CONFIG` and `PlatformType` imports in `ApiOptions.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 0004f181fe8e9b052373426bc5d7ae9669e69bbd. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->