### PR TITLE
Handle quotes and other special chars in the curl request

### DIFF
--- a/.github/workflows/trigger-jetbrains-tests.yml
+++ b/.github/workflows/trigger-jetbrains-tests.yml
@@ -30,17 +30,19 @@ jobs:
             -H "User-Agent: cline-pr-trigger" \
             -H "Content-Type: application/json" \
             https://api.github.com/repos/cline/intellij-plugin/dispatches \
-            -d '{
-              "event_type": "cline-pr-check",
-              "client_payload": {
-                "pr_number": "${{ github.event.number }}",
-                "branch_name": "${{ github.head_ref }}",
-                "action": "${{ github.event.action }}",
-                "sha": "${{ github.event.pull_request.head.sha }}",
-                "pr_title": "${{ github.event.pull_request.title }}",
-                "pr_url": "${{ github.event.pull_request.html_url }}"
-              }
-            }'
+            -d @- <<EOF
+          {
+            "event_type": "cline-pr-check",
+            "client_payload": {
+              "pr_number": "${{ github.event.number }}",
+              "branch_name": "${{ github.head_ref }}",
+              "action": "${{ github.event.action }}",
+              "sha": "${{ github.event.pull_request.head.sha }}",
+              "pr_title": ${{ toJSON(github.event.pull_request.title) }},
+              "pr_url": "${{ github.event.pull_request.html_url }}"
+            }
+          }
+          EOF
 
       - name: Log trigger details
         run: |


### PR DESCRIPTION
This workflow didn't work if the PR title contained quotes, e.g.
https://github.com/cline/cline/pull/6523 - Don't show VS Code LM provider on non-VSCode platforms