### PR TITLE
Replace VSCode API with Host Provider

### DIFF
--- a/src/core/controller/dictation/startRecording.ts
+++ b/src/core/controller/dictation/startRecording.ts
@@ -31,9 +31,7 @@ async function handleInstallWithCline(
  * Handles copying the installation command to clipboard
  */
 async function handleCopyCommand(installCommand: string): Promise<void> {
-	const vscode = await import("vscode")
-	await vscode.env.clipboard.writeText(installCommand)
-
+	await HostProvider.env.clipboardWriteText({ value: installCommand })
 	await HostProvider.window.showMessage({
 		type: ShowMessageType.INFORMATION,
 		message: `Installation command copied to clipboard: ${installCommand}`,


### PR DESCRIPTION
VSCode API doesn't work cross-platform, this should use the host provider instead.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Replaces VSCode API with Host Provider for clipboard operations in `startRecording.ts`.
> 
>   - **Behavior**:
>     - Replaces VSCode API with `HostProvider` for clipboard operations in `handleCopyCommand()` in `startRecording.ts`.
>     - Uses `HostProvider.env.clipboardWriteText()` instead of `vscode.env.clipboard.writeText()`.
>   - **Misc**:
>     - Updates message display to use `HostProvider.window.showMessage()` in `handleCopyCommand()`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 8005394331e71453821b8db96ef11c8e0f7924c7. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->