### PR TITLE
Replace VSCode API with the host bridge.

### DIFF
--- a/proto/host/workspace.proto
+++ b/proto/host/workspace.proto
@@ -27,6 +27,9 @@ service WorkspaceService {
 
   // Opens and focuses the Cline sidebar panel in the host IDE.
   rpc openClineSidebarPanel(OpenClineSidebarPanelRequest) returns (OpenClineSidebarPanelResponse);
+
+  // Opens and focuses the terminal panel.
+  rpc openTerminalPanel(OpenTerminalRequest) returns (OpenTerminalResponse);
 }
 
 message GetWorkspacePathsRequest {
@@ -82,12 +85,11 @@ message SearchWorkspaceItemsResponse {
 
 message OpenProblemsPanelRequest {}
 message OpenProblemsPanelResponse {}
-
 message OpenInFileExplorerPanelRequest {
   string path = 1;
 }
 message OpenInFileExplorerPanelResponse {}
-
-// Request/response for opening the Cline sidebar
 message OpenClineSidebarPanelRequest {}
 message OpenClineSidebarPanelResponse {}
+message OpenTerminalRequest {}
+message OpenTerminalResponse {}

--- a/src/core/mentions/index.ts
+++ b/src/core/mentions/index.ts
@@ -9,7 +9,6 @@ import { getCommitInfo, getWorkingState } from "@utils/git"
 import fs from "fs/promises"
 import { isBinaryFile } from "isbinaryfile"
 import * as path from "path"
-import * as vscode from "vscode"
 import { HostProvider } from "@/hosts/host-provider"
 import { ShowMessageType } from "@/shared/proto/host/window"
 import { DiagnosticSeverity } from "@/shared/proto/index.cline"
@@ -38,7 +37,7 @@ export async function openMention(mention?: string): Promise<void> {
 	} else if (mention === "problems") {
 		await HostProvider.workspace.openProblemsPanel({})
 	} else if (mention === "terminal") {
-		vscode.commands.executeCommand("workbench.action.terminal.focus")
+		await HostProvider.workspace.openTerminalPanel({})
 	} else if (mention.startsWith("http")) {
 		await openExternal(mention)
 	}

--- a/src/hosts/vscode/hostbridge/workspace/openTerminalPanel.ts
+++ b/src/hosts/vscode/hostbridge/workspace/openTerminalPanel.ts
@@ -1,0 +1,7 @@
+import * as vscode from "vscode"
+import { OpenTerminalRequest, OpenTerminalResponse } from "@/shared/proto/index.host"
+
+export async function openTerminalPanel(_: OpenTerminalRequest): Promise<OpenTerminalResponse> {
+	vscode.commands.executeCommand("workbench.action.terminal.focus")
+	return {}
+}


### PR DESCRIPTION
Add a method to the host bridge to open and focus the terminal panel.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Replaces VSCode API with host bridge method to open terminal panel, adding new RPC method and updating `openMention()` function.
> 
>   - **Behavior**:
>     - Adds `openTerminalPanel` RPC method to `WorkspaceService` in `workspace.proto` to open and focus the terminal panel.
>     - Updates `openMention()` in `index.ts` to use `HostProvider.workspace.openTerminalPanel()` instead of `vscode.commands.executeCommand()`.
>   - **Implementation**:
>     - Implements `openTerminalPanel()` in `openTerminalPanel.ts` to execute `vscode.commands.executeCommand("workbench.action.terminal.focus")`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 36c6c3dcbba2f4ce304240339ca8f7059593fd34. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->