### PR TITLE
ref: Move getGlobalStorageDir out of the HostProvider into disk.ts

### DIFF
--- a/src/core/storage/disk.ts
+++ b/src/core/storage/disk.ts
@@ -64,9 +64,7 @@ export async function getDocumentsPath(): Promise<string> {
 }
 
 export async function ensureTaskDirectoryExists(taskId: string): Promise<string> {
-	const taskDir = path.join(HostProvider.get().globalStorageFsPath, "tasks", taskId)
-	await fs.mkdir(taskDir, { recursive: true })
-	return taskDir
+	return getGlobalStorageDir("tasks", taskId)
 }
 
 export async function ensureRulesDirectoryExists(): Promise<string> {
@@ -103,9 +101,7 @@ export async function ensureMcpServersDirectoryExists(): Promise<string> {
 }
 
 export async function ensureSettingsDirectoryExists(): Promise<string> {
-	const settingsDir = path.join(HostProvider.get().globalStorageFsPath, "settings")
-	await fs.mkdir(settingsDir, { recursive: true })
-	return settingsDir
+	return getGlobalStorageDir("settings")
 }
 
 export async function getSavedApiConversationHistory(taskId: string): Promise<Anthropic.MessageParam[]> {
@@ -176,13 +172,17 @@ export async function saveTaskMetadata(taskId: string, metadata: TaskMetadata) {
 }
 
 export async function ensureStateDirectoryExists(): Promise<string> {
-	const stateDir = path.join(HostProvider.get().globalStorageFsPath, "state")
-	await fs.mkdir(stateDir, { recursive: true })
-	return stateDir
+	return getGlobalStorageDir("state")
 }
 
 export async function ensureCacheDirectoryExists(): Promise<string> {
-	return HostProvider.getGlobalStorageDir("cache")
+	return getGlobalStorageDir("cache")
+}
+
+async function getGlobalStorageDir(...subdirs: string[]) {
+	const fullPath = path.resolve(HostProvider.get().globalStorageFsPath, ...subdirs)
+	await fs.mkdir(fullPath, { recursive: true })
+	return fullPath
 }
 
 export async function getTaskHistoryStateFilePath(): Promise<string> {

--- a/src/hosts/host-provider.ts
+++ b/src/hosts/host-provider.ts
@@ -1,5 +1,3 @@
-import fs from "fs/promises"
-import path from "path"
 import { WebviewProvider } from "@/core/webview"
 import { DiffViewProvider } from "@/integrations/editor/DiffViewProvider"
 import { WebviewProviderType } from "@/shared/webview/types"
@@ -126,21 +124,6 @@ export class HostProvider {
 
 	public static get diff() {
 		return HostProvider.get().hostBridge.diffClient
-	}
-
-	/**
-	 * Returns the global storage directory for the extension, or a sub-directory of the global storage dir.
-	 * If the directory does not exist, it is created.
-	 * @param subdirs
-	 * @returns
-	 */
-	public static async getGlobalStorageDir(subdirs?: string) {
-		if (!subdirs) {
-			return HostProvider.get().globalStorageFsPath
-		}
-		const fullPath = path.resolve(HostProvider.get().globalStorageFsPath, subdirs)
-		await fs.mkdir(fullPath, { recursive: true })
-		return fullPath
 	}
 }
 


### PR DESCRIPTION
Move `getGlobalStorageDir` into disk.ts because this is the only place that needs to do this.

Replace duplicated code in disk.ts with the function `getGlobalStorageDir`.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Move `getGlobalStorageDir` from `HostProvider` to `disk.ts` and replace its usage in `disk.ts` for code deduplication.
> 
>   - **Function Relocation**:
>     - Move `getGlobalStorageDir` from `HostProvider` in `host-provider.ts` to `disk.ts`.
>     - Replace direct calls to `HostProvider.getGlobalStorageDir` in `disk.ts` with the new `getGlobalStorageDir` function.
>   - **Code Deduplication**:
>     - Use `getGlobalStorageDir` in `ensureTaskDirectoryExists`, `ensureSettingsDirectoryExists`, `ensureStateDirectoryExists`, and `ensureCacheDirectoryExists` in `disk.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 994ca5db1cf765dd11c8ba65785c2761feb13a37. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->