### PR TITLE
fix: Update the Sonnet 4.5 Model ID for OpenRouter

### DIFF
--- a/.changeset/violet-readers-report.md
+++ b/.changeset/violet-readers-report.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Update the Sonnet 4.5 Model ID on OpenRouter

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -49,7 +49,7 @@ body:
     attributes:
       label: Provider/Model
       description: What provider and model were you using when the issue occurred?
-      placeholder: 'e.g., cline:anthropic/claude-sonnet-4.5, gemini:gemini-2.5-pro-exp-03-25'
+      placeholder: 'e.g., cline:anthropic/claude-4.5-sonnet, gemini:gemini-2.5-pro-exp-03-25'
     validations:
       required: false
   - type: textarea

--- a/src/core/api/transform/openrouter-stream.ts
+++ b/src/core/api/transform/openrouter-stream.ts
@@ -29,7 +29,7 @@ export async function createOpenRouterStream(
 	// this was initially specifically for claude models (some models may 'support prompt caching' automatically without this)
 	// handles direct model.id match logic
 	switch (model.id) {
-		case "anthropic/claude-sonnet-4.5":
+		case "anthropic/claude-4.5-sonnet":
 		case "anthropic/claude-sonnet-4":
 		case "anthropic/claude-opus-4.1":
 		case "anthropic/claude-opus-4":
@@ -89,7 +89,7 @@ export async function createOpenRouterStream(
 	// (models usually default to max tokens allowed)
 	let maxTokens: number | undefined
 	switch (model.id) {
-		case "anthropic/claude-sonnet-4.5":
+		case "anthropic/claude-4.5-sonnet":
 		case "anthropic/claude-sonnet-4":
 		case "anthropic/claude-opus-4.1":
 		case "anthropic/claude-opus-4":
@@ -126,7 +126,7 @@ export async function createOpenRouterStream(
 
 	let reasoning: { max_tokens: number } | undefined
 	switch (model.id) {
-		case "anthropic/claude-sonnet-4.5":
+		case "anthropic/claude-4.5-sonnet":
 		case "anthropic/claude-sonnet-4":
 		case "anthropic/claude-opus-4.1":
 		case "anthropic/claude-opus-4":

--- a/src/core/controller/models/refreshOpenRouterModels.ts
+++ b/src/core/controller/models/refreshOpenRouterModels.ts
@@ -108,7 +108,7 @@ export async function refreshOpenRouterModels(
 				})
 
 				switch (rawModel.id) {
-					case "anthropic/claude-sonnet-4.5":
+					case "anthropic/claude-4.5-sonnet":
 					case "anthropic/claude-sonnet-4":
 						// NOTE: we artificially restrict the context window to 200k to keep costs low for users, and have a :1m model variant created below for users that want to use the full 1m.
 						modelInfo.contextWindow = 200_000
@@ -214,7 +214,7 @@ export async function refreshOpenRouterModels(
 				models[rawModel.id] = modelInfo
 
 				// add custom :1m model variant
-				if (rawModel.id === "anthropic/claude-sonnet-4.5") {
+				if (rawModel.id === "anthropic/claude-4.5-sonnet") {
 					const claudeSonnet451mModelInfo = cloneDeep(modelInfo)
 					claudeSonnet451mModelInfo.contextWindow = 1_000_000 // limiting providers to those that support 1m context window
 					claudeSonnet451mModelInfo.tiers = CLAUDE_SONNET_4_5_1M_TIERS

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -599,8 +599,8 @@ export const bedrockModels = {
 
 // OpenRouter
 // https://openrouter.ai/models?order=newest&supported_parameters=tools
-export const openRouterDefaultModelId = "anthropic/claude-sonnet-4.5" // will always exist in openRouterModels
-export const openRouterClaudeSonnet451mModelId = `anthropic/claude-sonnet-4.5${CLAUDE_SONNET_4_5_1M_SUFFIX}`
+export const openRouterDefaultModelId = "anthropic/claude-4.5-sonnet" // will always exist in openRouterModels
+export const openRouterClaudeSonnet451mModelId = `anthropic/claude-4.5-sonnet${CLAUDE_SONNET_4_5_1M_SUFFIX}`
 export const openRouterDefaultModelInfo: ModelInfo = {
 	maxTokens: 8192,
 	contextWindow: 200_000,

--- a/webview-ui/src/components/common/NewModelBanner.tsx
+++ b/webview-ui/src/components/common/NewModelBanner.tsx
@@ -54,7 +54,7 @@ export const NewModelBanner: React.FC = () => {
 	}
 
 	const setNewModel = () => {
-		const modelId = "anthropic/claude-sonnet-4.5"
+		const modelId = "anthropic/claude-4.5-sonnet"
 		// set both plan and act modes to use new model
 		handleFieldsChange({
 			planModeOpenRouterModelId: modelId,

--- a/webview-ui/src/components/settings/OpenRouterModelPicker.tsx
+++ b/webview-ui/src/components/settings/OpenRouterModelPicker.tsx
@@ -46,7 +46,7 @@ export interface OpenRouterModelPickerProps {
 // Featured models for Cline provider
 const featuredModels = [
 	{
-		id: "anthropic/claude-sonnet-4.5",
+		id: "anthropic/claude-4.5-sonnet",
 		description: "Recommended for agentic coding in Cline",
 		label: "New",
 	},
@@ -217,7 +217,7 @@ const OpenRouterModelPicker: React.FC<OpenRouterModelPickerProps> = ({ isPopup, 
 	const showBudgetSlider = useMemo(() => {
 		return (
 			Object.entries(openRouterModels)?.some(([id, m]) => id === selectedModelId && m.thinkingConfig) ||
-			selectedModelId?.toLowerCase().includes("claude-sonnet-4.5") ||
+			selectedModelId?.toLowerCase().includes("claude-4.5-sonnet") ||
 			selectedModelId?.toLowerCase().includes("claude-sonnet-4") ||
 			selectedModelId?.toLowerCase().includes("claude-opus-4.1") ||
 			selectedModelId?.toLowerCase().includes("claude-opus-4") ||
@@ -229,16 +229,16 @@ const OpenRouterModelPicker: React.FC<OpenRouterModelPickerProps> = ({ isPopup, 
 
 	// Check if the current model is Claude Sonnet 4.5 and determine the alternate variant
 	const claudeSonnet45Variant = useMemo(() => {
-		if (selectedModelId === "anthropic/claude-sonnet-4.5") {
+		if (selectedModelId === "anthropic/claude-4.5-sonnet") {
 			return {
-				current: "anthropic/claude-sonnet-4.5",
-				alternate: "anthropic/claude-sonnet-4.5:1m",
+				current: "anthropic/claude-4.5-sonnet",
+				alternate: "anthropic/claude-4.5-sonnet:1m",
 				linkText: "Switch to 1M context window model",
 			}
-		} else if (selectedModelId === "anthropic/claude-sonnet-4.5:1m") {
+		} else if (selectedModelId === "anthropic/claude-4.5-sonnet:1m") {
 			return {
-				current: "anthropic/claude-sonnet-4.5:1m",
-				alternate: "anthropic/claude-sonnet-4.5",
+				current: "anthropic/claude-4.5-sonnet:1m",
+				alternate: "anthropic/claude-4.5-sonnet",
 				linkText: "Switch to 200K context window model",
 			}
 		}
@@ -379,9 +379,9 @@ const OpenRouterModelPicker: React.FC<OpenRouterModelPickerProps> = ({ isPopup, 
 					</VSCodeLink>
 					If you're unsure which model to choose, Cline works best with{" "}
 					<VSCodeLink
-						onClick={() => handleModelChange("anthropic/claude-sonnet-4.5")}
+						onClick={() => handleModelChange("anthropic/claude-4.5-sonnet")}
 						style={{ display: "inline", fontSize: "inherit" }}>
-						anthropic/claude-sonnet-4.5.
+						anthropic/claude-4.5-sonnet.
 					</VSCodeLink>
 					You can also try searching "free" for no-cost options currently available.
 				</p>


### PR DESCRIPTION
### Description

The new Model ID is anthropic/claude-4.5-sonnet and not claude-sonnet-4.5

### Test Procedure

Tested locally

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update Sonnet 4.5 model ID to `anthropic/claude-4.5-sonnet` across multiple files for consistency.
> 
>   - **Model ID Update**:
>     - Change model ID from `anthropic/claude-sonnet-4.5` to `anthropic/claude-4.5-sonnet` in `openrouter-stream.ts`, `refreshOpenRouterModels.ts`, and `api.ts`.
>     - Update model ID in `NewModelBanner.tsx` and `OpenRouterModelPicker.tsx` to reflect the new ID.
>   - **Misc**:
>     - Update placeholder in `bug_report.yml` to use the new model ID.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for e4f3abe52a9765fa90a8945c3277afc32845581e. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->