### PR TITLE
feat: Add Amazon Bedrock us-west-1 support

### DIFF
--- a/.changeset/yummy-dots-count.md
+++ b/.changeset/yummy-dots-count.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Add us-west-1 to Amazon Bedrock regions

--- a/webview-ui/src/components/settings/providers/BedrockProvider.tsx
+++ b/webview-ui/src/components/settings/providers/BedrockProvider.tsx
@@ -21,7 +21,7 @@ interface BedrockProviderProps {
 
 export const BedrockProvider = ({ showModelOptions, isPopup, currentMode }: BedrockProviderProps) => {
 	const { apiConfiguration } = useExtensionState()
-	const { handleFieldChange, handleFieldsChange, handleModeFieldChange, handleModeFieldsChange } = useApiConfigurationHandlers()
+	const { handleFieldChange, handleModeFieldChange, handleModeFieldsChange } = useApiConfigurationHandlers()
 
 	const { selectedModelId, selectedModelInfo } = normalizeApiConfiguration(apiConfiguration, currentMode)
 	const modeFields = getModeSpecificFields(apiConfiguration, currentMode)
@@ -108,7 +108,7 @@ export const BedrockProvider = ({ showModelOptions, isPopup, currentMode }: Bedr
 					{/* The user will have to choose a region that supports the model they use, but this shouldn't be a problem since they'd have to request access for it in that region in the first place. */}
 					<VSCodeOption value="us-east-1">us-east-1</VSCodeOption>
 					<VSCodeOption value="us-east-2">us-east-2</VSCodeOption>
-					{/* <VSCodeOption value="us-west-1">us-west-1</VSCodeOption> */}
+					<VSCodeOption value="us-west-1">us-west-1</VSCodeOption>
 					<VSCodeOption value="us-west-2">us-west-2</VSCodeOption>
 					{/* <VSCodeOption value="af-south-1">af-south-1</VSCodeOption> */}
 					{/* <VSCodeOption value="ap-east-1">ap-east-1</VSCodeOption> */}


### PR DESCRIPTION
## Summary
- Add Amazon Bedrock us-west-1 region support to the provider configuration ([see docs](https://docs.aws.amazon.com/bedrock/latest/userguide/models-regions.html)).
- Currently only a few models are supported in us-west-1 eg. Sonnet 4, Sonnet 4.5, Nova Pro/Premier

## Test Plan
- [x] Verified us-west-1 region appears in Bedrock provider dropdown
- [x] Confirmed existing regions continue to work correctly
- [x] Code formatting and linting checks pass
- [x] Test suite passes

Ran extension host locally and confirmed calls to bedrock us-west-1 were working correctly. 

## Changes
Adds us-west-1 as an available region option in the Bedrock provider, enabling users to access Amazon Bedrock services in the California region.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `us-west-1` region to Amazon Bedrock provider dropdown in `BedrockProvider.tsx`, enabling California region access.
> 
>   - **Behavior**:
>     - Adds `us-west-1` region to the Amazon Bedrock provider dropdown in `BedrockProvider.tsx`, enabling access to services in the California region.
>   - **Misc**:
>     - Removes unused `handleFieldsChange` from `useApiConfigurationHandlers()` in `BedrockProvider.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 57a9f46e6389059079e8ab0a7b72ed44e8073345. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<img width="1033" height="1365" alt="SCR-20250929-lvcv" src="https://github.com/user-attachments/assets/6a00fa16-96e0-4a29-9079-037244af3648" />
