### PR TITLE
fix: update vercel provider cost note and sign-up url

### DIFF
--- a/.changeset/little-files-throw.md
+++ b/.changeset/little-files-throw.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+fix: update vercel provider cost note and sign-up url

--- a/webview-ui/src/components/settings/providers/VercelAIGatewayProvider.tsx
+++ b/webview-ui/src/components/settings/providers/VercelAIGatewayProvider.tsx
@@ -102,7 +102,7 @@ export const VercelAIGatewayProvider = ({ showModelOptions, isPopup, currentMode
 						<span>
 							{" "}
 							<a
-								href="https://vercel.com/"
+								href="https://vercel.com/d?to=%2F%5Bteam%5D%2F%7E%2Fai"
 								style={{
 									color: "var(--vscode-textLink-foreground)",
 									textDecoration: "none",
@@ -171,16 +171,6 @@ export const VercelAIGatewayProvider = ({ showModelOptions, isPopup, currentMode
 					)}
 				</>
 			)}
-
-			<p
-				style={{
-					fontSize: "12px",
-					marginTop: "15px",
-					color: "var(--vscode-descriptionForeground)",
-					fontStyle: "italic",
-				}}>
-				Note: Free tier users will see $0 costs as these requests are provided at no charge by Vercel AI Gateway.
-			</p>
 		</div>
 	)
 }


### PR DESCRIPTION
### Description

Vercel AI Gateway recently updated the service to report cost to free-tier users as well, to avoid user confusion. The actual cost behavior is unchanged -- free-tier users "pay" via the free credits they are granted ($5/30d currently).

This change:
- removes the short note describing the obsolete free-tier behavior from the Vercel AI Gateway provider view
- updates the url to sign up for an API key to deep-link to the main AI Gateway Overview page in the dashboard

### Test Procedure

Manually ran and used updated provider.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [x] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Before (note snippet at bottom describing free tier $0 cost):
<img width="445" height="455" alt="Screenshot 2025-09-29 at 1 23 42 PM" src="https://github.com/user-attachments/assets/52383683-f6dd-43ba-bcb1-43434a2df44c" />

After (note snippet is gone):
<img width="737" height="381" alt="Screenshot 2025-09-29 at 1 23 14 PM" src="https://github.com/user-attachments/assets/64423ac3-c252-47af-8ff7-2489f9f4057a" />


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Updates `VercelAIGatewayProvider` to remove obsolete cost note and update API key sign-up URL.
> 
>   - **Behavior**:
>     - Removes obsolete note about $0 cost for free-tier users in `VercelAIGatewayProvider`.
>     - Updates API key sign-up URL to deep-link to AI Gateway Overview in `VercelAIGatewayProvider`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for bf31d0f36d498898bc37ebeafa7a3c8b40a53251. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->