### PR TITLE
Override undici timeout to guarantee that ollama timeout will be honored.

### DIFF
--- a/.changeset/rare-deer-prove.md
+++ b/.changeset/rare-deer-prove.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+fix(ollama): prevent 300s first-byte aborts and honor request timeouts


### PR DESCRIPTION
### Related Issue

**Issue:** #[6549](https://github.com/cline/cline/issues/6549)

### Description

When there's a delay longer than 300 seconds between the initial request and the first token response from Ollama the cline-configured ollama timeout will be ignored (assuming the timeout is > 300s) and the API call will timeout due to the default undici timeout being only 300s / 5 minute.

This PR replaces the original fetch with a custom call directly to undici to override the the timeout. The change applies to only the Ollama provider.

Notes:
 - No API changes.
 - Removed app-level Promise.race timeout and redundant try/catch wrappers (i believe errors should bubble to the @withRetry decorator)
 - Adds undici as a runtime dependency

### Test Procedure

**How did you test this change?**
 1. Set the ollama timeout in cline to >300 seconds.
 2. Make an request to a local ollama server to process a large-ish file, that takes it longer than 5 minutes to respond.
 3. Ensure that the fetch doesn't fail at or near 300 seconds (I was consistently seeing 302 seconds).
 4. For very long requests, ensure that it _does_ fail when we hit the ollama timeout.

**What could potentially break and how did you verify it doesn't?**
 - Other providers unaffected, code is limited to ollama provider.
 - Adding undici as a root dependency should be ok as i believe it's included in Node 18+.

**Why are you confident this is ready for merge?**
 - Change is isolated to Ollama
 - The original stream / output code is untouched.
 - Removes redundant timeout race that previously masked root transport errors.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [x] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A - Backend change only.

### Additional Notes

I left the 30 second default timeout, but should this be increased to a few minutes? 30 seconds might be a bit quick for most people running Ollama models locally.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Overrides undici timeout in Ollama provider to respect cline-configured timeout, adding `undici` as a dependency and removing redundant timeout handling.
> 
>   - **Behavior**:
>     - Overrides undici timeout in `ollama.ts` to respect cline-configured timeout for Ollama requests.
>     - Removes `Promise.race` timeout and redundant try/catch in `createMessage()`.
>   - **Dependencies**:
>     - Adds `undici` as a runtime dependency in `package.json`.
>   - **Functions**:
>     - Modifies `ensureClient()` in `ollama.ts` to use a custom fetch with no headers/body timeout.
>     - Updates `createMessage()` in `ollama.ts` to handle request timeouts using `AbortController`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 8f4a2da7df7794d32206d95925e71d00c21ce253. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->