### PR TITLE
feat(zai): 🚀 Add GLM-4.6 Model Support for Z.AI Provider

### DIFF
--- a/docs/provider-config/zai.mdx
+++ b/docs/provider-config/zai.mdx
@@ -1,9 +1,9 @@
 ---
 title: "Z AI (Zhipu AI)"
-description: "Learn how to configure and use Z AI's GLM-4.5 models with Cline. Experience advanced hybrid reasoning, agentic capabilities, and open-source excellence with regional optimization."
+description: "Learn how to configure and use Z AI's GLM-4.6 and GLM-4.5 models with Cline. Experience advanced hybrid reasoning, agentic capabilities, and open-source excellence with regional optimization."
 ---
 
-Z AI (formerly Zhipu AI) offers the groundbreaking GLM-4.5 series, featuring hybrid reasoning capabilities and agentic AI design. Released in July 2025, these models excel in unified reasoning, coding, and intelligent agent applications while maintaining open-source accessibility under MIT license.
+Z AI (formerly Zhipu AI) offers the groundbreaking GLM-4.6 and GLM-4.5 series, featuring hybrid reasoning capabilities and agentic AI design. These models excel in unified reasoning, coding, and intelligent agent applications while maintaining open-source accessibility under MIT license.
 
 **Website:** [https://z.ai/model-api](https://z.ai/model-api) (International) | [https://open.bigmodel.cn/](https://open.bigmodel.cn/) (China)
 
@@ -25,16 +25,20 @@ Z AI (formerly Zhipu AI) offers the groundbreaking GLM-4.5 series, featuring hyb
 
 Z AI provides different model catalogs based on your selected region:
 
+#### GLM-4.6 Series (Latest)
+-   **GLM-4.6** - Latest flagship model with 355B total parameters, 32B active parameters, and 200K context window. Upgraded across 8 authoritative benchmarks with enhanced performance in coding, reasoning, search, writing, and agent applications.
+
 #### GLM-4.5 Series
--   **GLM-4.5** - Flagship model with 355B total parameters, 32B active parameters
+-   **GLM-4.5** - Previous flagship model with 355B total parameters, 32B active parameters
 -   **GLM-4.5-Air** - Compact model with 106B total parameters, 12B active parameters
 
-#### GLM-4.5 Hybrid Reasoning Models
+#### GLM Hybrid Reasoning Models
+-   **GLM-4.6 (Thinking Mode)** - Advanced reasoning with step-by-step analysis (200K context)
 -   **GLM-4.5 (Thinking Mode)** - Advanced reasoning with step-by-step analysis
 -   **GLM-4.5-Air (Thinking Mode)** - Efficient reasoning for mainstream hardware
 
 All models feature:
--   **128,000 token context window** for extensive document processing
+-   **Up to 200,000 token context window** (GLM-4.6) or 128,000 tokens (GLM-4.5 series) for extensive document processing
 -   **Mixture of Experts (MoE) architecture** for optimal performance
 -   **Agent-native design** integrating reasoning, coding, and tool usage
 -   **Open-source availability** under MIT license
@@ -57,12 +61,12 @@ Z AI offers subscription plans specifically designed for coding applications. Th
 
 **GLM Coding Lite** - $3/month
 - 120 prompts per 5-hour cycle
-- Access to GLM-4.5 model
+- Access to GLM-4.6 and GLM-4.5 models
 - Works exclusively through coding tools like Cline
 
 **GLM Coding Pro** - $15/month  
 - 600 prompts per 5-hour cycle
-- Access to GLM-4.5 model
+- Access to GLM-4.6 and GLM-4.5 models
 - Works exclusively through coding tools like Cline
 
 Both plans offer promotional pricing for the first month: Lite drops from \$6 to \$3, Pro drops from \$30 to \$15.
@@ -85,32 +89,33 @@ To use the GLM Coding Plans with Cline:
   <img src="https://storage.googleapis.com/cline_public_images/docs/assets/zAI-provider.png" alt="Cline settings with zAI provider selected and API key field highlighted" />
 </Frame>
 
-The setup connects your subscription directly to Cline, giving you access to GLM-4.5's tool-calling capabilities optimized for coding workflows.
+The setup connects your subscription directly to Cline, giving you access to GLM-4.6 and GLM-4.5's tool-calling capabilities optimized for coding workflows.
 
 ### Z AI's Hybrid Intelligence
 
-Z AI's GLM-4.5 series introduces revolutionary capabilities that set it apart from conventional language models:
+Z AI's GLM-4.6 and GLM-4.5 series introduce revolutionary capabilities that set them apart from conventional language models:
 
 #### Hybrid Reasoning Architecture
-GLM-4.5 operates in two distinct modes:
+GLM-4.6 and GLM-4.5 operate in two distinct modes:
 - **Thinking Mode:** Designed for complex reasoning tasks and tool usage, engaging in deeper analytical processes
 - **Non-Thinking Mode:** Provides immediate responses for straightforward queries, optimizing efficiency
 
 This dual-mode architecture represents an "agent-native" design philosophy that adapts processing intensity based on query complexity.
 
 #### Exceptional Performance
-GLM-4.5 achieves a comprehensive score of **63.2** across 12 benchmarks spanning agentic tasks, reasoning, and coding challenges, securing **3rd place** among all proprietary and open-source models. GLM-4.5-Air maintains competitive performance with a score of **59.8** while delivering superior efficiency.
+GLM-4.6 represents the latest evolution with upgraded performance across 8 authoritative benchmarks, surpassing GLM-4.5 in coding, reasoning, search, writing, and agent applications. GLM-4.5 achieves a comprehensive score of **63.2** across 12 benchmarks spanning agentic tasks, reasoning, and coding challenges, securing **3rd place** among all proprietary and open-source models. GLM-4.5-Air maintains competitive performance with a score of **59.8** while delivering superior efficiency.
 
 #### Mixture of Experts Excellence
 The sophisticated MoE architecture optimizes performance while maintaining computational efficiency:
-- **GLM-4.5:** 355B total parameters with 32B active parameters
+- **GLM-4.6:** 355B total parameters with 32B active parameters and 200K context window
+- **GLM-4.5:** 355B total parameters with 32B active parameters and 128K context window
 - **GLM-4.5-Air:** 106B total parameters with 12B active parameters
 
 #### Extended Context Capabilities
-The 128,000-token context window enables comprehensive understanding of lengthy documents and codebases, with real-world testing confirming effective processing of nearly 2,000-line codebases while maintaining remarkable performance.
+The extended context window (200K for GLM-4.6, 128K for GLM-4.5 series) enables comprehensive understanding of lengthy documents and codebases, with real-world testing confirming effective processing of nearly 2,000-line codebases while maintaining remarkable performance.
 
 #### Open-Source Leadership
-Released under MIT license, GLM-4.5 provides researchers and developers with access to state-of-the-art capabilities without proprietary restrictions, including base models, hybrid reasoning versions, and optimized FP8 variants.
+Released under MIT license, the GLM series (including GLM-4.6 and GLM-4.5) provides researchers and developers with access to state-of-the-art capabilities without proprietary restrictions, including base models, hybrid reasoning versions, and optimized FP8 variants.
 
 ### Regional Optimization
 
@@ -124,7 +129,7 @@ The region setting determines both API endpoint and available models, with autom
 ### Special Features
 
 #### Agentic Capabilities
-GLM-4.5's unified architecture makes it particularly suitable for complex intelligent agent applications requiring integrated reasoning, coding, and tool utilization capabilities.
+The GLM series' unified architecture makes it particularly suitable for complex intelligent agent applications requiring integrated reasoning, coding, and tool utilization capabilities, with GLM-4.6 offering enhanced performance across all domains.
 
 #### Comprehensive Benchmarking
 Performance evaluation encompasses:
@@ -145,16 +150,16 @@ Complete with dedicated model code, tool parser, and reasoning parser implementa
 ### Performance Comparisons
 
 #### vs Claude 4 Sonnet
-GLM-4.5 shows competitive performance in agentic coding and reasoning tasks, though Claude Sonnet 4 maintains advantages in coding success rates and autonomous multi-feature application development.
+The GLM series shows competitive performance in agentic coding and reasoning tasks, with GLM-4.6 offering enhanced capabilities. Claude Sonnet 4 maintains advantages in coding success rates and autonomous multi-feature application development.
 
 #### vs GPT-4.5
-GLM-4.5 ranks competitively in reasoning and agent benchmarks, with GPT-4.5 generally leading in raw task accuracy on professional benchmarks like MMLU and AIME.
+The GLM series ranks competitively in reasoning and agent benchmarks, with GPT-4.5 generally leading in raw task accuracy on professional benchmarks like MMLU and AIME.
 
 ### Tips and Notes
 
 -   **Region Selection:** Choose the appropriate region for optimal performance and compliance with local regulations.
--   **Model Selection:** GLM-4.5 for maximum performance, GLM-4.5-Air for efficiency and mainstream hardware compatibility.
--   **Context Advantage:** Large 128K context window enables processing of substantial codebases and documents.
+-   **Model Selection:** GLM-4.6 for latest performance improvements, GLM-4.5 for proven capabilities, or GLM-4.5-Air for efficiency and mainstream hardware compatibility.
+-   **Context Advantage:** Large context windows (200K for GLM-4.6, 128K for GLM-4.5) enable processing of substantial codebases and documents.
 -   **Open Source Benefits:** MIT license enables both commercial use and secondary development.
 -   **Agentic Applications:** Particularly strong for applications requiring reasoning, coding, and tool usage integration.
 -   **Hybrid Reasoning:** Use Thinking Mode for complex problems, Non-Thinking Mode for simple queries.

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -3480,11 +3480,23 @@ export type BasetenModelId = keyof typeof basetenModels
 export const basetenDefaultModelId = "moonshotai/Kimi-K2-Instruct" satisfies BasetenModelId
 
 // Z AI
-// https://docs.z.ai/guides/llm/glm-4.5
+// https://docs.z.ai/guides/llm/glm-4.6
 // https://docs.z.ai/guides/overview/pricing
 export type internationalZAiModelId = keyof typeof internationalZAiModels
-export const internationalZAiDefaultModelId: internationalZAiModelId = "glm-4.5"
+export const internationalZAiDefaultModelId: internationalZAiModelId = "glm-4.6"
 export const internationalZAiModels = {
+	"glm-4.6": {
+		maxTokens: 98_304,
+		contextWindow: 200_000,
+		supportsImages: false,
+		supportsPromptCache: true,
+		inputPrice: 0.6,
+		outputPrice: 2.2,
+		cacheWritesPrice: 0,
+		cacheReadsPrice: 0.11,
+		description:
+			"GLM-4.6 is Zhipu's latest SOTA models for reasoning, code, and agentsUpgraded across 8 authoritative benchmarks. With a 355B-parameter MoE architecture and 200K context, it surpasses GLM-4.5 in coding, reasoning, search, writing, and agent applications.",
+	},
 	"glm-4.5": {
 		maxTokens: 98_304,
 		contextWindow: 131_072,
@@ -3495,7 +3507,7 @@ export const internationalZAiModels = {
 		cacheWritesPrice: 0,
 		cacheReadsPrice: 0.11,
 		description:
-			"GLM-4.5 is Zhipu's latest featured model. Its comprehensive capabilities in reasoning, coding, and agent reach the state-of-the-art (SOTA) level among open-source models, with a context length of up to 128k.",
+			"GLM-4.5 is Zhipu's previous flagship model. Its comprehensive capabilities in reasoning, coding, and agent are excellent among open-source models, with a context length of up to 128k.",
 	},
 	"glm-4.5-air": {
 		maxTokens: 98304, // Quantization: fp8
@@ -3512,8 +3524,40 @@ export const internationalZAiModels = {
 } as const satisfies Record<string, ModelInfo>
 
 export type mainlandZAiModelId = keyof typeof mainlandZAiModels
-export const mainlandZAiDefaultModelId: mainlandZAiModelId = "glm-4.5"
+export const mainlandZAiDefaultModelId: mainlandZAiModelId = "glm-4.6"
 export const mainlandZAiModels = {
+	"glm-4.6": {
+		maxTokens: 98_304,
+		contextWindow: 200_000,
+		supportsImages: false,
+		supportsPromptCache: true,
+		inputPrice: 0.29,
+		outputPrice: 1.14,
+		cacheWritesPrice: 0,
+		cacheReadsPrice: 0.057,
+		description:
+			"GLM-4.6 is Zhipu's latest SOTA models for reasoning, code, and agentsUpgraded across 8 authoritative benchmarks. With a 355B-parameter MoE architecture and 200K context, it surpasses GLM-4.5 in coding, reasoning, search, writing, and agent applications.",
+		tiers: [
+			{
+				contextWindow: 32_000,
+				inputPrice: 0.21,
+				outputPrice: 1.0,
+				cacheReadsPrice: 0.043,
+			},
+			{
+				contextWindow: 128_000,
+				inputPrice: 0.29,
+				outputPrice: 1.14,
+				cacheReadsPrice: 0.057,
+			},
+			{
+				contextWindow: Infinity,
+				inputPrice: 0.29,
+				outputPrice: 1.14,
+				cacheReadsPrice: 0.057,
+			},
+		],
+	},
 	"glm-4.5": {
 		maxTokens: 98_304,
 		contextWindow: 131_072,
@@ -3524,7 +3568,7 @@ export const mainlandZAiModels = {
 		cacheWritesPrice: 0,
 		cacheReadsPrice: 0.057,
 		description:
-			"GLM-4.5 is Zhipu's latest featured model. Its comprehensive capabilities in reasoning, coding, and agent reach the state-of-the-art (SOTA) level among open-source models, with a context length of up to 128k.",
+			"GLM-4.5 is Zhipu's previous flagship model. Its comprehensive capabilities in reasoning, coding, and agent are excellent among open-source models, with a context length of up to 128k.",
 		tiers: [
 			{
 				contextWindow: 32_000,


### PR DESCRIPTION
### Description

This PR adds support for GLM-4.6, Zhipu AI's latest flagship model, to the Z.AI provider. GLM-4.6 features an upgraded 200K context window and enhanced performance across coding, reasoning, search, writing, and agent applications.

### Test Procedure

✅ Extension builds successfully
✅ Model appears correctly in dropdown for both international and China regions
✅ Pricing calculations work correctly for both regions
✅ Default model selection works as expected
✅ User testing passed

### Type of Change

### Model Configuration (src/shared/api.ts)

✅ Added GLM-4.6 to internationalZAiModels with international pricing ($0.6 input, $2.2 output per million tokens)
✅ Added GLM-4.6 to mainlandZAiModels with China pricing (¥0.29 input, ¥1.14 output) and tiered pricing structure
✅ Updated default model IDs from glm-4.5 to glm-4.6 for both regions
✅ Updated GLM-4.5 descriptions to reflect it as the "previous flagship model" with "excellent" capabilities (no longer claiming SOTA status)

### Documentation (docs/provider-config/zai.mdx)

✅ Added GLM-4.6 as the featured latest model in the Supported Models section
✅ Updated all references throughout the documentation to mention GLM-4.6
✅ Clarified context window differences: 200K for GLM-4.6, 128K for GLM-4.5 series
✅ Updated subscription plan descriptions to include GLM-4.6
✅ Enhanced "Mixture of Experts Excellence" section with context window specs for each model

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)


### Additional Notes

