### PR TITLE
Improve the git commit message generator

### DIFF
--- a/package.json
+++ b/package.json
@@ -168,7 +168,10 @@
 				"command": "cline.generateGitCommitMessage",
 				"title": "Generate Commit Message with Cline",
 				"category": "Cline",
-				"icon": "$(robot)"
+				"icon": {
+					"light": "assets/icons/robot_panel_light.png",
+					"dark": "assets/icons/robot_panel_dark.png"
+				}
 			},
 			{
 				"command": "cline.abortGitCommitMessage",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -29,9 +29,9 @@ import { sendAddToInputEvent } from "./core/controller/ui/subscribeToAddToInput"
 import { sendFocusChatInputEvent } from "./core/controller/ui/subscribeToFocusChatInput"
 import { workspaceResolver } from "./core/workspace"
 import { focusChatInput, getContextForCommand } from "./hosts/vscode/commandUtils"
+import { abortCommitGeneration, generateCommitMessage } from "./hosts/vscode/commit-message-generator"
 import { VscodeDiffViewProvider } from "./hosts/vscode/VscodeDiffViewProvider"
 import { VscodeWebviewProvider } from "./hosts/vscode/VscodeWebviewProvider"
-import { GitCommitGenerator } from "./integrations/git/commit-message-generator"
 import { ExtensionRegistryInfo } from "./registry"
 import { AuthService } from "./services/auth/AuthService"
 import { telemetryService } from "./services/telemetry"
@@ -365,10 +365,10 @@ export async function activate(context: vscode.ExtensionContext) {
 	// Register the generateGitCommitMessage command handler
 	context.subscriptions.push(
 		vscode.commands.registerCommand(commands.GenerateCommit, async (scm) => {
-			await GitCommitGenerator?.generate?.(context, scm)
+			generateCommitMessage(webview.controller.stateManager, scm)
 		}),
 		vscode.commands.registerCommand(commands.AbortCommit, () => {
-			GitCommitGenerator?.abort?.()
+			abortCommitGeneration()
 		}),
 	)
 


### PR DESCRIPTION
* Commit message generator shouldn't create it's own StateManager, just use the one from the webview.
* Use the correct Cline logo
* Move it into the vscode specific directory, it uses too many VSCode APIs to work cross-platform.


https://github.com/user-attachments/assets/b5e8b7e7-01aa-44fb-9337-15314dfbac7b

