### PR TITLE
Remove duplicate statemanager in migration

### DIFF
--- a/src/core/storage/state-migrations.ts
+++ b/src/core/storage/state-migrations.ts
@@ -3,7 +3,6 @@ import path from "path"
 import * as vscode from "vscode"
 import { HistoryItem } from "@/shared/HistoryItem"
 import { ensureRulesDirectoryExists, readTaskHistoryFromState, writeTaskHistoryToState } from "./disk"
-import { StateManager } from "./StateManager"
 
 export async function migrateWorkspaceToGlobalStorage(context: vscode.ExtensionContext) {
 	// Keys to migrate from workspace storage back to global storage
@@ -566,44 +565,68 @@ export async function migrateWelcomeViewCompleted(context: vscode.ExtensionConte
 		if (welcomeViewCompleted === undefined) {
 			console.log("Migrating welcomeViewCompleted setting...")
 
-			// Get all extension state to check for existing API keys
-			const stateManager = new StateManager(context)
-			await stateManager.initialize()
-			const config = stateManager.getApiConfiguration()
+			// Fetch API keys directly from secrets
+			const apiKey = await context.secrets.get("apiKey")
+			const openRouterApiKey = await context.secrets.get("openRouterApiKey")
+			const clineAccountId = await context.secrets.get("clineAccountId")
+			const openAiApiKey = await context.secrets.get("openAiApiKey")
+			const ollamaApiKey = await context.secrets.get("ollamaApiKey")
+			const liteLlmApiKey = await context.secrets.get("liteLlmApiKey")
+			const geminiApiKey = await context.secrets.get("geminiApiKey")
+			const openAiNativeApiKey = await context.secrets.get("openAiNativeApiKey")
+			const deepSeekApiKey = await context.secrets.get("deepSeekApiKey")
+			const requestyApiKey = await context.secrets.get("requestyApiKey")
+			const togetherApiKey = await context.secrets.get("togetherApiKey")
+			const qwenApiKey = await context.secrets.get("qwenApiKey")
+			const doubaoApiKey = await context.secrets.get("doubaoApiKey")
+			const mistralApiKey = await context.secrets.get("mistralApiKey")
+			const asksageApiKey = await context.secrets.get("asksageApiKey")
+			const xaiApiKey = await context.secrets.get("xaiApiKey")
+			const sambanovaApiKey = await context.secrets.get("sambanovaApiKey")
+			const sapAiCoreClientId = await context.secrets.get("sapAiCoreClientId")
+			const difyApiKey = await context.secrets.get("difyApiKey")
 
-			// This is the original logic used for checking is the welcome view should be shown
+			// Fetch configuration values from global state
+			const awsRegion = context.globalState.get("awsRegion")
+			const vertexProjectId = context.globalState.get("vertexProjectId")
+			const planModeOllamaModelId = context.globalState.get("planModeOllamaModelId")
+			const planModeLmStudioModelId = context.globalState.get("planModeLmStudioModelId")
+			const actModeOllamaModelId = context.globalState.get("actModeOllamaModelId")
+			const actModeLmStudioModelId = context.globalState.get("actModeLmStudioModelId")
+			const planModeVsCodeLmModelSelector = context.globalState.get("planModeVsCodeLmModelSelector")
+			const actModeVsCodeLmModelSelector = context.globalState.get("actModeVsCodeLmModelSelector")
+
+			// This is the original logic used for checking if the welcome view should be shown
 			// It was located in the ExtensionStateContextProvider
-			const hasKey = config
-				? [
-						config.apiKey,
-						config.openRouterApiKey,
-						config.awsRegion,
-						config.vertexProjectId,
-						config.openAiApiKey,
-						config.ollamaApiKey,
-						config.planModeOllamaModelId,
-						config.planModeLmStudioModelId,
-						config.actModeOllamaModelId,
-						config.actModeLmStudioModelId,
-						config.liteLlmApiKey,
-						config.geminiApiKey,
-						config.openAiNativeApiKey,
-						config.deepSeekApiKey,
-						config.requestyApiKey,
-						config.togetherApiKey,
-						config.qwenApiKey,
-						config.doubaoApiKey,
-						config.mistralApiKey,
-						config.planModeVsCodeLmModelSelector,
-						config.actModeVsCodeLmModelSelector,
-						config.clineAccountId,
-						config.asksageApiKey,
-						config.xaiApiKey,
-						config.sambanovaApiKey,
-						config.sapAiCoreClientId,
-						config.difyApiKey,
-					].some((key) => key !== undefined)
-				: false
+			const hasKey = [
+				apiKey,
+				openRouterApiKey,
+				awsRegion,
+				vertexProjectId,
+				openAiApiKey,
+				ollamaApiKey,
+				planModeOllamaModelId,
+				planModeLmStudioModelId,
+				actModeOllamaModelId,
+				actModeLmStudioModelId,
+				liteLlmApiKey,
+				geminiApiKey,
+				openAiNativeApiKey,
+				deepSeekApiKey,
+				requestyApiKey,
+				togetherApiKey,
+				qwenApiKey,
+				doubaoApiKey,
+				mistralApiKey,
+				planModeVsCodeLmModelSelector,
+				actModeVsCodeLmModelSelector,
+				clineAccountId,
+				asksageApiKey,
+				xaiApiKey,
+				sambanovaApiKey,
+				sapAiCoreClientId,
+				difyApiKey,
+			].some((key) => key !== undefined)
 
 			// Set welcomeViewCompleted based on whether user has keys
 			await context.globalState.update("welcomeViewCompleted", hasKey)


### PR DESCRIPTION


### Description

Use the VS Code API directly. This will be removed when the state manager moves to a higher level. 

### Test Procedure

Test that the code builds successfully. 

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [x] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Removes `StateManager` from `migrateWelcomeViewCompleted()` in `state-migrations.ts`, using VS Code API directly for fetching secrets and global state.
> 
>   - **Behavior**:
>     - Removes `StateManager` usage in `migrateWelcomeViewCompleted()` in `state-migrations.ts`.
>     - Directly fetches API keys and configuration values using VS Code API.
>   - **Code Simplification**:
>     - Eliminates `StateManager` initialization and configuration fetching.
>     - Directly accesses secrets and global state for migration logic.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 5788acc820abd6d15c39c101955f8d8cf5e30b18. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->