### PR TITLE
Added checkpoints warning for multiroot scenarios

### DIFF
--- a/.changeset/legal-shirts-drop.md
+++ b/.changeset/legal-shirts-drop.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Added checkpoints warning when users start a multiroot task

--- a/webview-ui/src/components/chat/task-header/CheckpointError.tsx
+++ b/webview-ui/src/components/chat/task-header/CheckpointError.tsx
@@ -15,7 +15,9 @@ export const CheckpointError: React.FC<CheckpointErrorProps> = ({
 
 	const messages = useMemo(() => {
 		const message = checkpointManagerErrorMessage?.replace(/disabling checkpoints\.$/, "")
-		const showDisableButton = checkpointManagerErrorMessage?.endsWith("disabling checkpoints.")
+		const showDisableButton =
+			checkpointManagerErrorMessage?.endsWith("disabling checkpoints.") ||
+			checkpointManagerErrorMessage?.includes("multi-root workspaces")
 		const showGitInstructions = checkpointManagerErrorMessage?.includes("Git must be installed to use checkpoints.")
 		return { message, showDisableButton, showGitInstructions }
 	}, [checkpointManagerErrorMessage])


### PR DESCRIPTION
<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- For feature requests: Created a discussion in our Feature Requests discussions board https://github.com/cline/cline/discussions/categories/feature-requests and received approval from core maintainers before implementation
- For all changes: Link the associated issue/discussion in the "Related Issue" section below

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly without prior discussion.

Why this requirement?
We deeply appreciate all community contributions - they are essential to Cline's success! To ensure the best use of everyone's time and maintain project direction, we use our Feature Requests discussions board to gauge community interest and validate feature ideas before implementation begins. This helps us focus development efforts on features that will benefit the most users.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** #XXXX

### Description

Adds a warning that checkpoints are not currently supported with multiroot workspaces.

### Test Procedure

- Enable the multiroot feature flag in FeatureFlagService.ts
- Launch Cline in debug
- Enable multiroot in Feature Settings
- Ensure Checkpoints are enabled
- Start a new task with multiroot enabled and multiple workspaces added to VS Code.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [X] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [X] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [X] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [X] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [X] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<img width="618" height="267" alt="image" src="https://github.com/user-attachments/assets/43c010c6-3c58-4197-97e5-68856304503c" />

### Additional Notes

<!-- Add any additional notes for reviewers -->
