### PR TITLE
Update scripts/runclinecore.sh to include platform specific node module path

### DIFF
--- a/scripts/runclinecore.sh
+++ b/scripts/runclinecore.sh
@@ -25,6 +25,26 @@ unp $ZIP_FILE > /dev/null
 
 pkill -f cline-core.js || true
 
+# Detect platform name using the same logic as ClineDirs.kt in the plugin.
+OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+ARCH=$(uname -m)
+
+if [[ "$OS" == "darwin" && "$ARCH" == "x86_64" ]]; then
+    PLATFORM_NAME="darwin-x64"
+elif [[ "$OS" == "darwin" && "$ARCH" == "arm64" ]]; then
+    PLATFORM_NAME="darwin-arm64"
+elif [[ "$OS" == *"mingw"* || "$OS" == *"cygwin"* || "$OS" == *"msys"* ]] && [[ "$ARCH" == "x86_64" || "$ARCH" == "amd64" ]]; then
+    # Note: This script requires a bash-compatible environment on Windows (Git Bash, MSYS2, Cygwin)
+    PLATFORM_NAME="win-x64"
+elif [[ "$OS" == "linux" && ("$ARCH" == "x86_64" || "$ARCH" == "amd64") ]]; then
+    PLATFORM_NAME="linux-x64"
+else
+    echo "Unsupported platform: $OS $ARCH"
+    exit 1
+fi
+
+BINARY_MODULES_DIR="./binaries/$PLATFORM_NAME/node_modules"
+
 echo pwd: $(pwd)
 set -x
-NODE_PATH=./node_modules DEV_WORKSPACE_FOLDER=/tmp/ node cline-core.js 2>&1 | tee $LOG_FILE
+NODE_PATH=$BINARY_MODULES_DIR:./node_modules DEV_WORKSPACE_FOLDER=/tmp/ node cline-core.js 2>&1 | tee $LOG_FILE


### PR DESCRIPTION
With the introduction of better sqlite, this script needs to set the correct path for platform specific node modules. The logic is copied from the JB plugin (the vscode extension does not set the node modules path).
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `scripts/runclinecore.sh` to set platform-specific node module paths for compatibility across different OS and architectures.
> 
>   - **Platform Detection**:
>     - Adds platform detection logic in `scripts/runclinecore.sh` using `uname` to determine `OS` and `ARCH`.
>     - Supports `darwin-x64`, `darwin-arm64`, `win-x64`, and `linux-x64` platforms.
>     - Exits with error for unsupported platforms.
>   - **Node Modules Path**:
>     - Sets `NODE_PATH` to include platform-specific node modules directory in `scripts/runclinecore.sh`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 2a4c09b82a3bb801111816d7fc899fbef635ab5a. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->