### PR TITLE
Multiroot mentions support

### DIFF
--- a/.changeset/short-bobcats-deny.md
+++ b/.changeset/short-bobcats-deny.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Added multiroot support for file mentions

--- a/proto/cline/file.proto
+++ b/proto/cline/file.proto
@@ -107,6 +107,7 @@ message FileSearchRequest {
   optional string mentions_request_id = 3;  // Optional request ID for tracking requests
   optional int32 limit = 4;          // Optional limit for results (default: 20)
   optional FileSearchType selected_type = 5;  // Optional selected type filter
+  optional string workspace_hint = 6;  // Optional workspace name to search in
 }
 
 // Result for file search operations
@@ -120,6 +121,7 @@ message FileInfo {
   string path = 1;                   // Relative path from workspace root
   string type = 2;                   // "file" or "folder"
   optional string label = 3;         // Display name (usually basename)
+  optional string workspace_name = 4;  // Workspace this result came from
 }
 
 // Response for searchCommits

--- a/src/core/controller/index.ts
+++ b/src/core/controller/index.ts
@@ -65,6 +65,26 @@ export class Controller {
 	// NEW: Add workspace manager (optional initially)
 	private workspaceManager?: WorkspaceRootManager
 
+	// Public getter for workspace manager with lazy initialization - To get workspaces when task isn't initialized (Used by file mentions)
+	async ensureWorkspaceManager(): Promise<WorkspaceRootManager | undefined> {
+		if (!this.workspaceManager) {
+			try {
+				this.workspaceManager = await setupWorkspaceManager({
+					stateManager: this.stateManager,
+					detectRoots: detectWorkspaceRoots,
+				})
+			} catch (error) {
+				console.error("[Controller] Failed to initialize workspace manager:", error)
+			}
+		}
+		return this.workspaceManager
+	}
+
+	// Synchronous getter for workspace manager
+	getWorkspaceManager(): WorkspaceRootManager | undefined {
+		return this.workspaceManager
+	}
+
 	constructor(readonly context: vscode.ExtensionContext) {
 		PromptRegistry.getInstance() // Ensure prompts and tools are registered
 		HostProvider.get().logToChannel("ClineProvider instantiated")

--- a/src/core/task/index.ts
+++ b/src/core/task/index.ts
@@ -2329,6 +2329,7 @@ export class Task {
 								this.cwd,
 								this.urlContentFetcher,
 								this.fileContextTracker,
+								this.workspaceManager,
 							)
 
 							// when parsing slash commands, we still want to allow the user to provide their desired context

--- a/src/services/search/file-search.ts
+++ b/src/services/search/file-search.ts
@@ -3,10 +3,10 @@ import * as fs from "fs"
 import type { FzfResultItem } from "fzf"
 import * as path from "path"
 import * as readline from "readline"
+import type { WorkspaceRoot, WorkspaceRootManager } from "@/core/workspace"
 import { HostProvider } from "@/hosts/host-provider"
 import { GetOpenTabsRequest } from "@/shared/proto/host/window"
 import { getBinaryLocation } from "@/utils/fs"
-import { asRelativePath, isLocatedInWorkspace } from "@/utils/path"
 
 // Wrapper function for childProcess.spawn
 export type SpawnFunction = typeof childProcess.spawn
@@ -107,16 +107,17 @@ export async function searchWorkspaceFiles(
 	workspacePath: string,
 	limit: number = 20,
 	selectedType?: "file" | "folder",
-): Promise<{ path: string; type: "file" | "folder"; label?: string }[]> {
+	workspaceName?: string,
+): Promise<{ path: string; type: "file" | "folder"; label?: string; workspaceName?: string }[]> {
 	try {
 		// Get currently active files and convert to search format
 		const activeFilePaths = await getActiveFiles()
 		const activeFiles: { path: string; type: "file" | "folder"; label?: string }[] = []
 
 		for (const filePath of activeFilePaths) {
-			if (await isLocatedInWorkspace(filePath)) {
-				const relativePath = await asRelativePath(filePath)
-				const normalizedPath = relativePath.toPosix()
+			if (filePath.startsWith(workspacePath + path.sep) || filePath.startsWith(workspacePath + "/")) {
+				const relativePath = path.relative(workspacePath, filePath)
+				const normalizedPath = relativePath.replace(/\\/g, "/")
 				activeFiles.push({
 					path: normalizedPath,
 					type: "file",
@@ -138,12 +139,15 @@ export async function searchWorkspaceFiles(
 
 		// If no query, return the combined items
 		if (!query.trim()) {
+			const addWorkspaceName = (items: typeof combinedItems) =>
+				workspaceName ? items.map((item) => ({ ...item, workspaceName })) : items
+
 			if (selectedType === "file") {
-				return combinedItems.filter((item) => item.type === "file").slice(0, limit)
+				return addWorkspaceName(combinedItems.filter((item) => item.type === "file").slice(0, limit))
 			} else if (selectedType === "folder") {
-				return combinedItems.filter((item) => item.type === "folder").slice(0, limit)
+				return addWorkspaceName(combinedItems.filter((item) => item.type === "folder").slice(0, limit))
 			}
-			return combinedItems.slice(0, limit)
+			return addWorkspaceName(combinedItems.slice(0, limit))
 		}
 
 		// Match Scoring - Prioritize the label (filename) by including it twice in the search string
@@ -171,7 +175,7 @@ export async function searchWorkspaceFiles(
 					// Keep original type if path doesn't exist
 				}
 
-				return { ...item, type }
+				return workspaceName ? { ...item, type, workspaceName } : { ...item, type }
 			},
 		)
 
@@ -198,4 +202,90 @@ export const OrderbyMatchScore = (a: FzfResultItem<any>, b: FzfResultItem<any>) 
 	}
 
 	return countGaps(a.positions) - countGaps(b.positions)
+}
+
+/**
+ * Search for files across multiple workspace roots or a specific workspace
+ * Similar to searchWorkspaceFiles but supports multiroot workspaces
+ */
+export async function searchWorkspaceFilesMultiroot(
+	query: string,
+	workspaceManager: WorkspaceRootManager,
+	limit: number = 20,
+	selectedType?: "file" | "folder",
+	workspaceHint?: string,
+): Promise<{ path: string; type: "file" | "folder"; label?: string; workspaceName?: string }[]> {
+	try {
+		const workspaceRoots = workspaceManager?.getRoots?.() || []
+
+		if (workspaceRoots.length === 0) {
+			return []
+		}
+
+		let workspacesToSearch: WorkspaceRoot[] = []
+
+		// Search only the user-specified workspace (Ex input: @frontend:/query)
+		if (workspaceHint) {
+			const targetWorkspace = workspaceRoots.find((root: WorkspaceRoot) => root.name === workspaceHint)
+			if (targetWorkspace) {
+				workspacesToSearch = [targetWorkspace]
+			} else {
+				return []
+			}
+		} else {
+			// Search all workspaces if no hint provided
+			workspacesToSearch = workspaceRoots
+		}
+
+		// Execute parallel searches across workspaces
+		const searchPromises = workspacesToSearch.map(async (workspace) => {
+			try {
+				const results = await searchWorkspaceFiles(query, workspace.path, limit, selectedType, workspace.name)
+				return results
+			} catch (error) {
+				console.error(`[searchWorkspaceFilesMultiroot] Error searching workspace ${workspace.name}:`, error)
+				return []
+			}
+		})
+
+		// Wait for all searches to finish, fatten, add workspace prefixes if needed
+		const allResults = await Promise.all(searchPromises)
+		let flatResults = allResults.flat()
+		if (workspacesToSearch.length > 1) {
+			const pathCounts = new Map<string, number>()
+			for (const result of flatResults) {
+				pathCounts.set(result.path, (pathCounts.get(result.path) || 0) + 1)
+			}
+
+			flatResults = flatResults.map((result) => {
+				if (pathCounts.get(result.path)! > 1 && result.workspaceName) {
+					return {
+						...result,
+						label: `${result.workspaceName}:/${result.path}`,
+					}
+				}
+				return result
+			})
+		}
+
+		// Apply fuzzy matching across all results if needed
+		if (query.trim() && flatResults.length > limit) {
+			const fzfModule = await import("fzf")
+			const fzf = new fzfModule.Fzf(flatResults, {
+				selector: (item: { label?: string; path: string }) => `${item.label || ""} ${item.label || ""} ${item.path}`,
+				tiebreakers: [OrderbyMatchScore, fzfModule.byLengthAsc],
+			})
+			flatResults = fzf
+				.find(query)
+				.slice(0, limit)
+				.map((result) => result.item)
+		} else {
+			flatResults = flatResults.slice(0, limit)
+		}
+
+		return flatResults
+	} catch (error) {
+		console.error("[searchWorkspaceFilesMultiroot] Error in multiroot search:", error)
+		return []
+	}
 }

--- a/src/shared/context-mentions.ts
+++ b/src/shared/context-mentions.ts
@@ -51,7 +51,9 @@ Mention regex:
 */
 export const mentionRegex = new RegExp(
 	`@(` +
-		`/[^\\s]*?` + // Simple file paths (can't contain)
+		`[\\w-]+:/[^\\s]*?` + // Workspace-prefixed file paths: @workspace:name/path
+		`|[\\w-]+:"\\/[^"]*?"` + // Workspace-prefixed quoted file paths
+		`|/[^\\s]*?` + // Simple file paths (can't contain)
 		`|"\\/[^"]*?"` + // Quoted file paths which can contain spaces
 		`|(?:\\w+:\\/\\/)[^\\s]+?` + // URLs
 		`|[a-f0-9]{7,40}\\b` + // Git commit hashes

--- a/src/shared/proto-conversions/file/search-result-conversion.ts
+++ b/src/shared/proto-conversions/file/search-result-conversion.ts
@@ -4,12 +4,13 @@ import { FileInfo } from "@shared/proto/cline/file"
  * Converts domain search result objects to proto FileInfo objects
  */
 export function convertSearchResultsToProtoFileInfos(
-	results: { path: string; type: "file" | "folder"; label?: string }[],
+	results: { path: string; type: "file" | "folder"; label?: string; workspaceName?: string }[],
 ): FileInfo[] {
 	return results.map((result) => ({
 		path: result.path,
 		type: result.type,
 		label: result.label,
+		workspaceName: result.workspaceName,
 	}))
 }
 
@@ -18,10 +19,11 @@ export function convertSearchResultsToProtoFileInfos(
  */
 export function convertProtoFileInfosToSearchResults(
 	protoResults: FileInfo[],
-): { path: string; type: "file" | "folder"; label?: string }[] {
+): { path: string; type: "file" | "folder"; label?: string; workspaceName?: string }[] {
 	return protoResults.map((protoResult) => ({
 		path: protoResult.path,
 		type: protoResult.type as "file" | "folder",
 		label: protoResult.label,
+		workspaceName: protoResult.workspaceName,
 	}))
 }

--- a/webview-ui/src/components/chat/ContextMenu.tsx
+++ b/webview-ui/src/components/chat/ContextMenu.tsx
@@ -116,20 +116,24 @@ const ContextMenu: React.FC<ContextMenuProps> = ({
 			case ContextMenuOptionType.File:
 			case ContextMenuOptionType.Folder:
 				if (option.value) {
+					// Use label if it differs from just the basename (indicates workspace prefix or custom label)
+					const displayText =
+						option.label && option.label !== option.value.split("/").pop() ? option.label : option.value
+
 					return (
 						<>
-							<span>/</span>
-							{option.value?.startsWith("/.") && <span>.</span>}
+							{!displayText.includes(":") && <span>/</span>}
+							{displayText.startsWith("/.") && <span>.</span>}
 							<span
 								className="ph-no-capture"
 								style={{
 									whiteSpace: "nowrap",
 									overflow: "hidden",
 									textOverflow: "ellipsis",
-									direction: "rtl",
+									direction: displayText.includes(":") ? "ltr" : "rtl",
 									textAlign: "left",
 								}}>
-								{cleanPathPrefix(option.value || "") + "\u200E"}
+								{displayText.includes(":") ? displayText : cleanPathPrefix(displayText) + "\u200E"}
 							</span>
 						</>
 					)
@@ -201,51 +205,77 @@ const ContextMenu: React.FC<ContextMenuProps> = ({
 						<span>Searching...</span>
 					</div>
 				)}
-				{filteredOptions.map((option, index) => (
-					<div
-						key={`${option.type}-${option.value || index}`}
-						onClick={() => isOptionSelectable(option) && onSelect(option.type, option.value)}
-						onMouseEnter={() => isOptionSelectable(option) && setSelectedIndex(index)}
-						style={{
-							padding: "8px 12px",
-							cursor: isOptionSelectable(option) ? "pointer" : "default",
-							color:
-								index === selectedIndex && isOptionSelectable(option)
-									? "var(--vscode-quickInputList-focusForeground)"
-									: "",
-							borderBottom: "1px solid var(--vscode-editorGroup-border)",
-							display: "flex",
-							alignItems: "center",
-							justifyContent: "space-between",
-							backgroundColor:
-								index === selectedIndex && isOptionSelectable(option)
-									? "var(--vscode-quickInputList-focusBackground)"
-									: "",
-						}}>
+				{filteredOptions.map((option, index) => {
+					// Include workspace name in key for files/folders to handle duplicates across workspaces
+					const workspacePrefix = option.workspaceName ? `${option.workspaceName}:` : ""
+					const generatedKey = `${option.type}-${workspacePrefix}${option.value || index}`
+
+					return (
 						<div
+							key={generatedKey}
+							onClick={() => {
+								if (isOptionSelectable(option)) {
+									// Use label if it contains workspace prefix, otherwise use value
+									const mentionValue = option.label?.includes(":") ? option.label : option.value
+									onSelect(option.type, mentionValue)
+								}
+							}}
+							onMouseEnter={() => isOptionSelectable(option) && setSelectedIndex(index)}
 							style={{
+								padding: "8px 12px",
+								cursor: isOptionSelectable(option) ? "pointer" : "default",
+								color:
+									index === selectedIndex && isOptionSelectable(option)
+										? "var(--vscode-quickInputList-focusForeground)"
+										: "",
+								borderBottom: "1px solid var(--vscode-editorGroup-border)",
 								display: "flex",
 								alignItems: "center",
-								flex: 1,
-								minWidth: 0,
-								overflow: "hidden",
+								justifyContent: "space-between",
+								backgroundColor:
+									index === selectedIndex && isOptionSelectable(option)
+										? "var(--vscode-quickInputList-focusBackground)"
+										: "",
 							}}>
-							<i
-								className={`codicon codicon-${getIconForOption(option)}`}
+							<div
 								style={{
-									marginRight: "8px",
-									flexShrink: 0,
-									fontSize: "14px",
-								}}
-							/>
-							{renderOptionContent(option)}
-						</div>
-						{(option.type === ContextMenuOptionType.File ||
-							option.type === ContextMenuOptionType.Folder ||
-							option.type === ContextMenuOptionType.Git) &&
-							!option.value && (
+									display: "flex",
+									alignItems: "center",
+									flex: 1,
+									minWidth: 0,
+									overflow: "hidden",
+								}}>
 								<i
-									className="codicon codicon-chevron-right"
+									className={`codicon codicon-${getIconForOption(option)}`}
+									style={{
+										marginRight: "8px",
+										flexShrink: 0,
+										fontSize: "14px",
+									}}
+								/>
+								{renderOptionContent(option)}
+							</div>
+							{(option.type === ContextMenuOptionType.File ||
+								option.type === ContextMenuOptionType.Folder ||
+								option.type === ContextMenuOptionType.Git) &&
+								!option.value && (
+									<i
+										className="codicon codicon-chevron-right"
+										style={{
+											fontSize: "14px",
+											flexShrink: 0,
+											marginLeft: 8,
+										}}
+									/>
+								)}
+							{(option.type === ContextMenuOptionType.Problems ||
+								option.type === ContextMenuOptionType.Terminal ||
+								((option.type === ContextMenuOptionType.File ||
+									option.type === ContextMenuOptionType.Folder ||
+									option.type === ContextMenuOptionType.Git) &&
+									option.value)) && (
+								<i
+									className="codicon codicon-add"
 									style={{
 										fontSize: "14px",
 										flexShrink: 0,
@@ -253,23 +283,9 @@ const ContextMenu: React.FC<ContextMenuProps> = ({
 									}}
 								/>
 							)}
-						{(option.type === ContextMenuOptionType.Problems ||
-							option.type === ContextMenuOptionType.Terminal ||
-							((option.type === ContextMenuOptionType.File ||
-								option.type === ContextMenuOptionType.Folder ||
-								option.type === ContextMenuOptionType.Git) &&
-								option.value)) && (
-							<i
-								className="codicon codicon-add"
-								style={{
-									fontSize: "14px",
-									flexShrink: 0,
-									marginLeft: 8,
-								}}
-							/>
-						)}
-					</div>
-				))}
+						</div>
+					)
+				})}
 			</div>
 		</div>
 	)

--- a/webview-ui/src/utils/context-mentions.ts
+++ b/webview-ui/src/utils/context-mentions.ts
@@ -1,12 +1,12 @@
 import { mentionRegex } from "@shared/context-mentions"
 import { Fzf } from "fzf"
-import * as path from "path"
 import { PLATFORM_CONFIG } from "@/config/platform.config"
 
 export interface SearchResult {
 	path: string
 	type: "file" | "folder"
 	label?: string
+	workspaceName?: string
 }
 
 export function insertMention(
@@ -26,7 +26,6 @@ export function insertMention(
 	if (value.startsWith("/") && value.includes(" ")) {
 		formattedValue = `"${value}"`
 	}
-
 	let newValue: string
 	let mentionIndex: number
 
@@ -95,6 +94,7 @@ export interface ContextMenuQueryItem {
 	value?: string
 	label?: string
 	description?: string
+	workspaceName?: string
 }
 
 function getContextMenuEntries(): ContextMenuOptionType[] {
@@ -133,8 +133,9 @@ export function getContextMenuOptions(
 		const item = {
 			type: result.type === "folder" ? ContextMenuOptionType.Folder : ContextMenuOptionType.File,
 			value: formattedPath,
-			label: result.label || path.basename(result.path),
+			label: result.label,
 			description: formattedPath,
+			workspaceName: result.workspaceName,
 		}
 		return item
 	})
@@ -148,6 +149,7 @@ export function getContextMenuOptions(
 					value: item.value,
 					label: item.label,
 					description: item.description,
+					workspaceName: item.workspaceName,
 				}))
 			return files.length > 0 ? files : [{ type: ContextMenuOptionType.NoResults }]
 		}
@@ -160,6 +162,7 @@ export function getContextMenuOptions(
 					value: item.value,
 					label: item.label,
 					description: item.description,
+					workspaceName: item.workspaceName,
 				}))
 			return folders.length > 0 ? folders : [{ type: ContextMenuOptionType.NoResults }]
 		}


### PR DESCRIPTION
<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- For feature requests: Created a discussion in our Feature Requests discussions board https://github.com/cline/cline/discussions/categories/feature-requests and received approval from core maintainers before implementation
- For all changes: Link the associated issue/discussion in the "Related Issue" section below

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly without prior discussion.

Why this requirement?
We deeply appreciate all community contributions - they are essential to Cline's success! To ensure the best use of everyone's time and maintain project direction, we use our Feature Requests discussions board to gauge community interest and validate feature ideas before implementation begins. This helps us focus development efforts on features that will benefit the most users.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** #XXXX

### Description

This PR adds multiroot workspace support for file mentions, allowing users to reference files from specific workspaces in multiroot projects using the syntax `@workspace:/path/to/file`.

__Core Changes:__

- Extended `FileSearchRequest` protobuf with optional `workspace_hint` parameter to filter searches to specific workspaces
- Added `workspace_name` field to `FileInfo` to annotate search results with their originating workspace
- Implemented `searchWorkspaceFilesMultiroot()` in `file-search.ts` that performs parallel searches across all workspace roots or targets a specific workspace when a hint is provided
- Modified `searchFiles()` RPC handler to detect multiroot environments and delegate to the appropriate search implementation
- Updated `parseMentions()` to handle workspace-prefixed mentions and search across multiple workspaces when files exist in multiple locations
- Added `ensureWorkspaceManager()` to `Controller` for lazy initialization of workspace manager when needed by file mentions

__Behavior:__

When a user types `@frontend:/src/config.json` in a multiroot workspace, the system searches only the "frontend" workspace. Without a workspace hint (e.g., `@/config.json`), the system searches all workspaces and returns results annotated with workspace names. If a file exists in multiple workspaces, all instances are included in the context with workspace annotations.


### Test Procedure

__Single Root Workspace Test:__

1. Open a single-root workspace
2. Create a file at `src/config.json`
3. Type `@/src/config.json` in chat
4. Type `@config.json` in chat
5. Confirm the file content is returned without workspace annotations

__Multiroot with Workspace Hint:__

1. Open a multiroot workspace with folders named "frontend" and "backend"
2. Create `src/config.json` in both folders with different content
3. Type `@frontend:/src/config.json` in chat
4. Confirm only the frontend workspace's file content is returned with `workspace="frontend"` annotation

__Multiroot without Workspace Hint:__

1. Using the same multiroot workspace from above
2. Type `@/src/config.json` in chat (no workspace prefix)
3. Type `@config.json` in chat (no workspace prefix)
4. Confirm both files are returned, each with their respective workspace annotations (`workspace="frontend"` and `workspace="backend"`)


### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [X] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [X] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [X] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [X] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [X] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

This implementation maintains backward compatibility with single-workspace projects by detecting multiroot environments and falling back to legacy behavior when the workspace manager is unavailable or only one root exists.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds multiroot workspace support for file mentions, enabling workspace-specific file referencing and updating search and UI components accordingly.
> 
>   - **Behavior**:
>     - Adds multiroot workspace support for file mentions using `@workspace:/path/to/file` syntax.
>     - Updates `parseMentions()` in `index.ts` to handle workspace-prefixed mentions.
>     - Modifies `searchFiles()` in `searchFiles.ts` to support multiroot environments.
>   - **Search**:
>     - Adds `searchWorkspaceFilesMultiroot()` in `file-search.ts` for parallel searches across workspaces.
>     - Extends `FileSearchRequest` protobuf with `workspace_hint`.
>   - **UI**:
>     - Updates `ChatTextArea.tsx` to parse workspace hints from queries.
>     - Modifies `ContextMenu.tsx` to display workspace-prefixed paths.
>   - **Testing**:
>     - Adds tests for multiroot workspace mentions in `index.test.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 67c4d74997121a747f5a4716d7acf425b1fae83f. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->