### PR TITLE
add logout reason tracking and improve cleanup handling

### DIFF
--- a/src/core/controller/account/accountLogoutClicked.ts
+++ b/src/core/controller/account/accountLogoutClicked.ts
@@ -1,6 +1,7 @@
 import type { EmptyRequest } from "@shared/proto/cline/common"
 import { Empty } from "@shared/proto/cline/common"
 import { AuthService } from "@/services/auth/AuthService"
+import { LogoutReason } from "@/services/auth/types"
 import type { Controller } from "../index"
 
 /**
@@ -11,6 +12,6 @@ import type { Controller } from "../index"
  */
 export async function accountLogoutClicked(controller: Controller, _request: EmptyRequest): Promise<Empty> {
 	await controller.handleSignOut()
-	await AuthService.getInstance().handleDeauth()
+	await AuthService.getInstance().handleDeauth(LogoutReason.USER_INITIATED)
 	return Empty.create({})
 }

--- a/src/core/controller/index.ts
+++ b/src/core/controller/index.ts
@@ -26,6 +26,7 @@ import { HostProvider } from "@/hosts/host-provider"
 import { ExtensionRegistryInfo } from "@/registry"
 import { AuthService } from "@/services/auth/AuthService"
 import { OcaAuthService } from "@/services/auth/oca/OcaAuthService"
+import { LogoutReason } from "@/services/auth/types"
 import { featureFlagsService } from "@/services/feature-flags"
 import { getDistinctId } from "@/services/logging/distinctId"
 import { telemetryService } from "@/services/telemetry"
@@ -125,8 +126,7 @@ export class Controller {
 	// Auth methods
 	async handleSignOut() {
 		try {
-			// TODO: update to clineAccountId and then move clineApiKey to a clear function.
-			this.stateManager.setSecret("clineAccountId", undefined)
+			// AuthService now handles its own storage cleanup in handleDeauth()
 			this.stateManager.setGlobalState("userInfo", undefined)
 
 			// Update API providers through cache service
@@ -154,7 +154,7 @@ export class Controller {
 	// Oca Auth methods
 	async handleOcaSignOut() {
 		try {
-			await this.ocaAuthService.handleDeauth()
+			await this.ocaAuthService.handleDeauth(LogoutReason.USER_INITIATED)
 			await this.postStateToWebview()
 			HostProvider.window.showMessage({
 				type: ShowMessageType.INFORMATION,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -34,6 +34,7 @@ import { VscodeDiffViewProvider } from "./hosts/vscode/VscodeDiffViewProvider"
 import { VscodeWebviewProvider } from "./hosts/vscode/VscodeWebviewProvider"
 import { ExtensionRegistryInfo } from "./registry"
 import { AuthService } from "./services/auth/AuthService"
+import { LogoutReason } from "./services/auth/types"
 import { telemetryService } from "./services/telemetry"
 import { SharedUriHandler } from "./services/uri/SharedUriHandler"
 import { ShowMessageType } from "./shared/proto/host/window"
@@ -386,7 +387,7 @@ export async function activate(context: vscode.ExtensionContext) {
 					authService?.restoreRefreshTokenAndRetrieveAuthInfo()
 				} else {
 					// Secret was removed - handle logout for all windows
-					authService?.handleDeauth()
+					authService?.handleDeauth(LogoutReason.CROSS_WINDOW_SYNC)
 				}
 			}
 		}),

--- a/src/services/auth/AuthService.ts
+++ b/src/services/auth/AuthService.ts
@@ -10,6 +10,7 @@ import { featureFlagsService } from "../feature-flags"
 import { ClineAuthProvider } from "./providers/ClineAuthProvider"
 import { FirebaseAuthProvider } from "./providers/FirebaseAuthProvider"
 import { IAuthProvider } from "./providers/IAuthProvider"
+import { LogoutReason } from "./types"
 
 export type ServiceConfig = {
 	URI?: string
@@ -138,6 +139,7 @@ export class AuthService {
 				} else {
 					this._clineAuthInfo = null
 					this._authenticated = false
+					telemetryService.captureAuthLoggedOut(this._provider?.name, LogoutReason.ERROR_RECOVERY)
 				}
 				await this.sendAuthStatusUpdate()
 			}
@@ -206,17 +208,20 @@ export class AuthService {
 		const authUrlString = authUrl.toString()
 
 		await openExternal(authUrlString)
+		telemetryService.captureAuthStarted(this._provider.name)
 		return String.create({ value: authUrlString })
 	}
 
-	async handleDeauth(): Promise<void> {
+	async handleDeauth(reason: LogoutReason = LogoutReason.UNKNOWN): Promise<void> {
 		if (!this._provider) {
 			throw new Error("Auth provider is not set")
 		}
 
 		try {
+			telemetryService.captureAuthLoggedOut(this._provider.name, reason)
 			this._clineAuthInfo = null
 			this._authenticated = false
+			this._controller.stateManager.setSecret("clineAccountId", undefined)
 			this.sendAuthStatusUpdate()
 		} catch (error) {
 			console.error("Error signing out:", error)
@@ -233,14 +238,17 @@ export class AuthService {
 			this._clineAuthInfo = await this._provider.signIn(this._controller, authorizationCode, provider)
 			this._authenticated = this._clineAuthInfo?.idToken !== undefined
 
+			telemetryService.captureAuthSucceeded(this._provider.name)
 			await this.sendAuthStatusUpdate()
 		} catch (error) {
 			console.error("Error signing in with custom token:", error)
+			telemetryService.captureAuthFailed(this._provider.name)
 			throw error
 		}
 	}
 
 	/**
+	 * @deprecated Use handleDeauth() instead. Storage clearing is now handled consistently within the auth domain.
 	 * Clear the authentication token from the extension's storage.
 	 * This is typically called when the user logs out.
 	 */
@@ -266,11 +274,13 @@ export class AuthService {
 				console.warn("No user found after restoring auth token")
 				this._authenticated = false
 				this._clineAuthInfo = null
+				telemetryService.captureAuthLoggedOut(this._provider?.name, LogoutReason.ERROR_RECOVERY)
 			}
 		} catch (error) {
 			console.error("Error restoring auth token:", error)
 			this._authenticated = false
 			this._clineAuthInfo = null
+			telemetryService.captureAuthLoggedOut(this._provider?.name, LogoutReason.ERROR_RECOVERY)
 			return
 		}
 	}

--- a/src/services/auth/oca/OcaAuthService.ts
+++ b/src/services/auth/oca/OcaAuthService.ts
@@ -4,6 +4,7 @@ import type { Controller } from "@/core/controller"
 import { getRequestRegistry, type StreamingResponseHandler } from "@/core/controller/grpc-handler"
 import { AuthHandler } from "@/hosts/external/AuthHandler"
 import { openExternal } from "@/utils/env"
+import { LogoutReason } from "../types"
 import { OcaAuthProvider } from "./providers/OcaAuthProvider"
 import type { OcaConfig } from "./utils/types"
 import { getOcaConfig } from "./utils/utils"
@@ -149,7 +150,7 @@ export class OcaAuthService {
 		return ProtoString.create({ value: authUrlString })
 	}
 
-	async handleDeauth(): Promise<void> {
+	async handleDeauth(_: LogoutReason = LogoutReason.UNKNOWN): Promise<void> {
 		try {
 			this.clearAuth()
 			this._ocaAuthState = null

--- a/src/services/auth/types.ts
+++ b/src/services/auth/types.ts
@@ -1,0 +1,14 @@
+/**
+ * Enum defining different reasons why a user might be logged out
+ * Used for telemetry tracking to understand logout patterns
+ */
+export enum LogoutReason {
+	/** User explicitly clicked logout button in UI */
+	USER_INITIATED = "user_initiated",
+	/** Auth tokens were cleared in another VSCode window (cross-window sync) */
+	CROSS_WINDOW_SYNC = "cross_window_sync",
+	/** Auth provider encountered an error and cleared tokens */
+	ERROR_RECOVERY = "error_recovery",
+	/** Unknown or unspecified reason */
+	UNKNOWN = "unknown",
+}

--- a/src/services/telemetry/TelemetryService.ts
+++ b/src/services/telemetry/TelemetryService.ts
@@ -88,6 +88,10 @@ export class TelemetryService {
 			OPT_OUT: "user.opt_out",
 			TELEMETRY_ENABLED: "user.telemetry_enabled",
 			EXTENSION_ACTIVATED: "user.extension_activated",
+			AUTH_STARTED: "user.auth_started",
+			AUTH_SUCCEEDED: "user.auth_succeeded",
+			AUTH_FAILED: "user.auth_failed",
+			AUTH_LOGGED_OUT: "user.auth_logged_out",
 		},
 		DICTATION: {
 			// Tracks when voice recording is started
@@ -291,6 +295,60 @@ export class TelemetryService {
 	public captureExtensionActivated() {
 		// Use provider's log method for the activation event
 		this.provider.log(TelemetryService.EVENTS.USER.EXTENSION_ACTIVATED)
+	}
+
+	/**
+	 * Records when authentication flow is started
+	 * @param provider The authentication provider being used
+	 */
+	public captureAuthStarted(provider?: string) {
+		this.capture({
+			event: TelemetryService.EVENTS.USER.AUTH_STARTED,
+			properties: {
+				provider,
+			},
+		})
+	}
+
+	/**
+	 * Records when authentication flow succeeds
+	 * @param provider The authentication provider that was used
+	 */
+	public captureAuthSucceeded(provider?: string) {
+		this.capture({
+			event: TelemetryService.EVENTS.USER.AUTH_SUCCEEDED,
+			properties: {
+				provider,
+			},
+		})
+	}
+
+	/**
+	 * Records when authentication flow fails
+	 * @param provider The authentication provider that was used
+	 */
+	public captureAuthFailed(provider?: string) {
+		this.capture({
+			event: TelemetryService.EVENTS.USER.AUTH_FAILED,
+			properties: {
+				provider,
+			},
+		})
+	}
+
+	/**
+	 * Records when user logs out of their account
+	 * @param provider The authentication provider that was used
+	 * @param reason The reason for logout (user action, cross-window sync, error, etc.)
+	 */
+	public captureAuthLoggedOut(provider?: string, reason?: string) {
+		this.capture({
+			event: TelemetryService.EVENTS.USER.AUTH_LOGGED_OUT,
+			properties: {
+				provider,
+				reason,
+			},
+		})
 	}
 
 	/**


### PR DESCRIPTION
- Add LogoutReason enum to track different logout scenarios
- Update handleDeauth() calls to include logout reasons
- Move auth storage cleanup from Controller to AuthService for better encapsulation
- Add telemetry events to capture logout reasons for analytics

No expected behavior is expected. 
Telemetry should have auth-related events. 

### Type of Change

-   [X] ♻️ Refactor Changes

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `LogoutReason` enum for tracking logout scenarios, refactors auth storage cleanup, and enhances telemetry with logout reason events.
> 
>   - **Behavior**:
>     - Introduces `LogoutReason` enum in `types.ts` to track logout scenarios.
>     - Updates `handleDeauth()` in `AuthService.ts` and `OcaAuthService.ts` to accept `LogoutReason`.
>     - Adds telemetry events in `TelemetryService.ts` for logout reasons.
>   - **Refactoring**:
>     - Moves auth storage cleanup from `Controller` to `AuthService` for better encapsulation.
>     - Updates `accountLogoutClicked.ts` and `index.ts` to use `LogoutReason` in `handleDeauth()` calls.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 7354cb2d8e58cb3b52ea83a47b3d1a486b524b68. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->