### PR TITLE
remove global --config flag for cli

### DIFF
--- a/cli/cmd/cline/main.go
+++ b/cli/cmd/cline/main.go
@@ -13,7 +13,6 @@ import (
 
 var (
 	coreAddress  string
-	cfgFile      string
 	verbose      bool
 	outputFormat string
 )
@@ -32,7 +31,6 @@ monitoring capabilities from the terminal.`,
 			}
 
 			return global.InitializeGlobalConfig(&global.GlobalConfig{
-				ConfigPath:   cfgFile,
 				Verbose:      verbose,
 				OutputFormat: outputFormat,
 				CoreAddress:  coreAddress,
@@ -41,7 +39,6 @@ monitoring capabilities from the terminal.`,
 	}
 
 	rootCmd.PersistentFlags().StringVar(&coreAddress, "address", fmt.Sprintf("localhost:%d", common.DEFAULT_CLINE_CORE_PORT), "Cline Core gRPC address")
-	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.cline/config.yaml)")
 	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "verbose output")
 	rootCmd.PersistentFlags().StringVarP(&outputFormat, "output-format", "o", "rich", "output format (rich|json|plain)")
 


### PR DESCRIPTION
For now, we won't allow the user to configure their config directory, it's always just ~/.cline

## Testing Procedure

Build and run the cline command, the flag is no longer available in help

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Removes global `--config` flag from CLI, defaulting config directory to `~/.cline`.
> 
>   - **Behavior**:
>     - Removes global `--config` flag from CLI in `main.go`, defaulting config directory to `~/.cline`.
>   - **Code Changes**:
>     - Deletes `cfgFile` variable and its usage in `main.go`.
>     - Removes `StringVar` call for `--config` flag in `main.go`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for ab9065b9f90a7e7e992fba797c23bd8b8776ea97. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->