### PR TITLE
Add zod schema for the remote config settings

### DIFF
--- a/src/shared/remote-config/__tests__/schema.test.ts
+++ b/src/shared/remote-config/__tests__/schema.test.ts
@@ -1,0 +1,325 @@
+import { expect } from "chai"
+import { describe, it } from "mocha"
+import {
+	AwsBedrockSettingsSchema,
+	ModelInfoSchema,
+	OpenAiCompatibleSchema,
+	OpenAiModelInfoSchema,
+	ProviderSchema,
+	type RemoteConfig,
+	RemoteConfigSchema,
+} from "../schema"
+
+describe("Remote Config Schema", () => {
+	describe("ProviderSchema", () => {
+		it("should accept valid provider names", () => {
+			expect(() => ProviderSchema.parse("OpenAiCompatible")).to.not.throw()
+			expect(() => ProviderSchema.parse("AwsBedrock")).to.not.throw()
+		})
+
+		it("should reject invalid provider names", () => {
+			expect(() => ProviderSchema.parse("InvalidProvider")).to.throw()
+			expect(() => ProviderSchema.parse("")).to.throw()
+			expect(() => ProviderSchema.parse(123)).to.throw()
+		})
+	})
+
+	describe("ModelInfoSchema", () => {
+		it("should accept valid model info with all fields", () => {
+			const validModelInfo = {
+				maxTokens: 4096,
+				contextWindow: 128000,
+				inputPrice: 0.01,
+				outputPrice: 0.02,
+				supportsImages: true,
+			}
+			const result = ModelInfoSchema.parse(validModelInfo)
+			expect(result).to.deep.equal(validModelInfo)
+		})
+
+		it("should accept valid model info with optional fields missing", () => {
+			const minimalModelInfo = {}
+			expect(() => ModelInfoSchema.parse(minimalModelInfo)).to.not.throw()
+		})
+
+		it("should accept valid model info with partial fields", () => {
+			const partialModelInfo = {
+				maxTokens: 2048,
+				supportsImages: false,
+			}
+			expect(() => ModelInfoSchema.parse(partialModelInfo)).to.not.throw()
+		})
+
+		it("should reject invalid field types", () => {
+			expect(() => ModelInfoSchema.parse({ maxTokens: "4096" })).to.throw()
+			expect(() => ModelInfoSchema.parse({ supportsImages: "true" })).to.throw()
+		})
+	})
+
+	describe("OpenAiModelInfoSchema", () => {
+		it("should accept valid OpenAI model info", () => {
+			const validInfo = {
+				temperature: 0.7,
+				isR1FormatRequired: true,
+			}
+			const result = OpenAiModelInfoSchema.parse(validInfo)
+			expect(result).to.deep.equal(validInfo)
+		})
+
+		it("should accept empty object", () => {
+			expect(() => OpenAiModelInfoSchema.parse({})).to.not.throw()
+		})
+
+		it("should reject invalid types", () => {
+			expect(() => OpenAiModelInfoSchema.parse({ temperature: "hot" })).to.throw()
+			expect(() => OpenAiModelInfoSchema.parse({ isR1FormatRequired: 1 })).to.throw()
+		})
+	})
+
+	describe("OpenAiCompatibleSchema", () => {
+		it("should accept valid OpenAI compatible settings", () => {
+			const validSettings = {
+				modelIds: ["gpt-4", "gpt-3.5-turbo"],
+				openAiBaseUrl: "https://api.openai.com/v1",
+				openAiHeaders: { "X-Custom-Header": "value" },
+				azureApiVersion: "2024-02-15-preview",
+			}
+			const result = OpenAiCompatibleSchema.parse(validSettings)
+			expect(result).to.deep.equal(validSettings)
+		})
+
+		it("should apply default empty array for modelIds", () => {
+			const result = OpenAiCompatibleSchema.parse({})
+			expect(result.modelIds).to.deep.equal([])
+			expect(result.openAiHeaders).to.deep.equal({})
+		})
+
+		it("should reject invalid field types", () => {
+			expect(() => OpenAiCompatibleSchema.parse({ modelIds: "not-an-array" })).to.throw()
+			expect(() => OpenAiCompatibleSchema.parse({ openAiHeaders: "not-an-object" })).to.throw()
+		})
+
+		it("should accept headers as record of strings", () => {
+			const settings = {
+				openAiHeaders: {
+					Authorization: "Bearer token",
+					"Content-Type": "application/json",
+				},
+			}
+			const result = OpenAiCompatibleSchema.parse(settings)
+			expect(result.openAiHeaders).to.deep.equal(settings.openAiHeaders)
+		})
+	})
+
+	describe("AwsBedrockSettingsSchema", () => {
+		it("should accept valid AWS Bedrock settings", () => {
+			const validSettings = {
+				modelIds: ["anthropic.claude-v2", "anthropic.claude-instant-v1"],
+				awsBedrockCustomSelected: true,
+				awsBedrockCustomModelBaseId: "custom-model",
+				awsRegion: "us-east-1",
+				awsUseCrossRegionInference: true,
+				awsBedrockUsePromptCache: true,
+				awsBedrockEndpoint: "https://bedrock.us-east-1.amazonaws.com",
+			}
+			const result = AwsBedrockSettingsSchema.parse(validSettings)
+			expect(result).to.deep.equal(validSettings)
+		})
+
+		it("should apply default empty array for modelIds", () => {
+			const result = AwsBedrockSettingsSchema.parse({})
+			expect(result.modelIds).to.deep.equal([])
+		})
+
+		it("should reject invalid field types", () => {
+			expect(() => AwsBedrockSettingsSchema.parse({ modelIds: "not-an-array" })).to.throw()
+			expect(() => AwsBedrockSettingsSchema.parse({ awsBedrockCustomSelected: "true" })).to.throw()
+		})
+	})
+
+	describe("RemoteConfigSchema", () => {
+		it("should accept valid complete remote config", () => {
+			const validConfig: RemoteConfig = {
+				version: "v1",
+				providers: ["OpenAiCompatible", "AwsBedrock"],
+				telemetryEnabled: true,
+				mcpMarketplaceEnabled: true,
+				yoloModeAllowed: false,
+				openAiCompatible: {
+					modelIds: ["gpt-4"],
+					openAiBaseUrl: "https://api.openai.com/v1",
+					openAiHeaders: {},
+				},
+				awsBedrockSettings: {
+					modelIds: ["anthropic.claude-v2"],
+					awsRegion: "us-west-2",
+				},
+			}
+			const result = RemoteConfigSchema.parse(validConfig)
+			expect(result).to.deep.equal(validConfig)
+		})
+
+		it("should require version field", () => {
+			const configWithoutVersion = {
+				providers: [],
+			}
+			expect(() => RemoteConfigSchema.parse(configWithoutVersion)).to.throw()
+		})
+
+		it("should apply default empty array for providers", () => {
+			const result = RemoteConfigSchema.parse({ version: "v1" })
+			expect(result.providers).to.deep.equal([])
+		})
+
+		it("should accept minimal valid config", () => {
+			const minimalConfig = {
+				version: "v1",
+			}
+			expect(() => RemoteConfigSchema.parse(minimalConfig)).to.not.throw()
+		})
+
+		it("should accept config with general settings only", () => {
+			const configWithGeneralSettings = {
+				version: "v1",
+				providers: [],
+				telemetryEnabled: false,
+				mcpMarketplaceEnabled: false,
+				yoloModeAllowed: true,
+			}
+			const result = RemoteConfigSchema.parse(configWithGeneralSettings)
+			expect(result.telemetryEnabled).to.equal(false)
+			expect(result.mcpMarketplaceEnabled).to.equal(false)
+			expect(result.yoloModeAllowed).to.equal(true)
+		})
+
+		it("should accept config with OpenAI compatible provider only", () => {
+			const config = {
+				version: "v1",
+				providers: ["OpenAiCompatible"],
+				openAiCompatible: {
+					modelIds: ["gpt-4", "gpt-3.5-turbo"],
+					openAiBaseUrl: "https://api.openai.com/v1",
+				},
+			}
+			expect(() => RemoteConfigSchema.parse(config)).to.not.throw()
+		})
+
+		it("should accept config with AWS Bedrock provider only", () => {
+			const config = {
+				version: "v1",
+				providers: ["AwsBedrock"],
+				awsBedrockSettings: {
+					modelIds: ["anthropic.claude-v2"],
+					awsRegion: "us-east-1",
+				},
+			}
+			expect(() => RemoteConfigSchema.parse(config)).to.not.throw()
+		})
+
+		it("should accept config with multiple providers", () => {
+			const config = {
+				version: "v1",
+				providers: ["OpenAiCompatible", "AwsBedrock"],
+				openAiCompatible: {
+					modelIds: ["gpt-4"],
+				},
+				awsBedrockSettings: {
+					modelIds: ["anthropic.claude-v2"],
+				},
+			}
+			const result = RemoteConfigSchema.parse(config)
+			expect(result.providers).to.have.lengthOf(2)
+		})
+
+		it("should reject invalid version type", () => {
+			expect(() => RemoteConfigSchema.parse({ version: 123 })).to.throw()
+		})
+
+		it("should reject invalid providers array", () => {
+			expect(() => RemoteConfigSchema.parse({ version: "v1", providers: "OpenAiCompatible" })).to.throw()
+		})
+
+		it("should reject invalid provider in array", () => {
+			expect(() =>
+				RemoteConfigSchema.parse({
+					version: "v1",
+					providers: ["InvalidProvider"],
+				}),
+			).to.throw()
+		})
+
+		it("should reject invalid telemetry setting type", () => {
+			expect(() =>
+				RemoteConfigSchema.parse({
+					version: "v1",
+					telemetryEnabled: "yes",
+				}),
+			).to.throw()
+		})
+
+		it("should allow undefined optional provider settings", () => {
+			const config = {
+				version: "v1",
+				providers: ["OpenAiCompatible"],
+				// openAiCompatible is undefined
+			}
+			expect(() => RemoteConfigSchema.parse(config)).to.not.throw()
+		})
+
+		it("should handle complex nested validation", () => {
+			const config = {
+				version: "v1",
+				providers: ["OpenAiCompatible", "AwsBedrock"],
+				telemetryEnabled: true,
+				mcpMarketplaceEnabled: false,
+				yoloModeAllowed: true,
+				openAiCompatible: {
+					modelIds: ["model1", "model2", "model3"],
+					openAiBaseUrl: "https://custom.openai.api/v1",
+					openAiHeaders: {
+						"X-API-Key": "secret",
+						"X-Custom": "value",
+					},
+					azureApiVersion: "2024-02-15-preview",
+				},
+				awsBedrockSettings: {
+					modelIds: ["bedrock1", "bedrock2"],
+					awsBedrockCustomSelected: true,
+					awsBedrockCustomModelBaseId: "my-custom-model",
+					awsRegion: "eu-west-1",
+					awsUseCrossRegionInference: false,
+					awsBedrockUsePromptCache: true,
+					awsBedrockEndpoint: "https://custom-bedrock.endpoint",
+				},
+			}
+			const result = RemoteConfigSchema.parse(config)
+			expect(result.version).to.equal("v1")
+			expect(result.providers).to.have.lengthOf(2)
+			expect(result.openAiCompatible?.modelIds).to.have.lengthOf(3)
+			expect(result.awsBedrockSettings?.modelIds).to.have.lengthOf(2)
+		})
+	})
+
+	describe("Type Inference", () => {
+		it("should properly infer RemoteConfig type", () => {
+			const config: RemoteConfig = {
+				version: "v1",
+				providers: ["OpenAiCompatible"],
+				telemetryEnabled: true,
+			}
+			// TypeScript compilation will fail if type inference is wrong
+			expect(config.version).to.be.a("string")
+			expect(config.providers).to.be.an("array")
+		})
+
+		it("should allow optional fields to be undefined", () => {
+			const config: RemoteConfig = {
+				version: "v1",
+				providers: [],
+				// All other fields are optional and can be undefined
+			}
+			expect(config.telemetryEnabled).to.be.undefined
+			expect(config.openAiCompatible).to.be.undefined
+		})
+	})
+})

--- a/src/shared/remote-config/schema.ts
+++ b/src/shared/remote-config/schema.ts
@@ -1,0 +1,72 @@
+import { z } from "zod"
+
+// The supported providers:
+// More providers will be added later
+export const ProviderSchema = z.enum(["OpenAiCompatible", "AwsBedrock"])
+
+export const ModelInfoSchema = z.object({
+	maxTokens: z.number().optional(),
+	contextWindow: z.number().optional(),
+	inputPrice: z.number().optional(),
+	outputPrice: z.number().optional(),
+	supportsImages: z.boolean().optional(),
+	// supportsBrowser: TBD
+})
+
+export const OpenAiModelInfoSchema = z.object({
+	temperature: z.number().optional(),
+	isR1FormatRequired: z.boolean().optional(),
+})
+
+// OpenAiCompatible specific settings
+export const OpenAiCompatibleSchema = z.object({
+	// A list of the allowed models.
+	modelIds: z.array(z.string()).default([]),
+	// OpenAiCompatible specific settings:
+	openAiBaseUrl: z.string().optional(),
+	openAiHeaders: z.record(z.string(), z.string()).default({}),
+	azureApiVersion: z.string().optional(),
+})
+
+// AWS Bedrock specific settings
+export const AwsBedrockSettingsSchema = z.object({
+	// A list of the allowed models.
+	modelIds: z.array(z.string()).default([]),
+	// AWS Bedrock specific settings:
+	awsBedrockCustomSelected: z.boolean().optional(),
+	awsBedrockCustomModelBaseId: z.string().optional(),
+	awsRegion: z.string().optional(),
+	awsUseCrossRegionInference: z.boolean().optional(),
+	awsBedrockUsePromptCache: z.boolean().optional(),
+	awsBedrockEndpoint: z.string().optional(),
+})
+
+export const RemoteConfigSchema = z.object({
+	// The version of the remote config settings, e.g. v1
+	// This field is for internal use only, and won't be visible to the administrator in the UI.
+	version: z.string(),
+
+	// The providers available to the users.
+	providers: z.array(ProviderSchema).default([]),
+
+	// General settings not specific to any provider
+	telemetryEnabled: z.boolean().optional(),
+	mcpMarketplaceEnabled: z.boolean().optional(),
+	// If the user is allowed to enable YOLO mode. Note this is different from the extension setting
+	// yoloModeEnabled, because we do not want to force YOLO enabled for the user.
+	yoloModeAllowed: z.boolean().optional(),
+	// Other top-level settings can be added here later.
+
+	// Provider specific settings. Settings must be included for each of the providers configured above.
+	openAiCompatible: OpenAiCompatibleSchema.optional(),
+	awsBedrockSettings: AwsBedrockSettingsSchema.optional(),
+	// More providers can be added later
+})
+
+// Type inference from schemas
+export type Provider = z.infer<typeof ProviderSchema>
+export type ModelInfo = z.infer<typeof ModelInfoSchema>
+export type OpenAiModelInfo = z.infer<typeof OpenAiModelInfoSchema>
+export type OpenAiCompatible = z.infer<typeof OpenAiCompatibleSchema>
+export type AwsBedrockSettings = z.infer<typeof AwsBedrockSettingsSchema>
+export type RemoteConfig = z.infer<typeof RemoteConfigSchema>


### PR DESCRIPTION
Add a zod schema for the remote config settings JSON.

This is based on the doc here: https://docs.google.com/document/d/1DizuUtV_8nUKlDbkhj6psxgD0Vmn2DV-hUb92Gv369M/edit?usp=sharing

Initial providers for the first version are AWS Bedrock and OpenAI compatible.

Add unit tests to check that the validation works correctly.

ref PF-109
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add Zod schema for remote config settings with AWS Bedrock and OpenAI support, including unit tests for validation.
> 
>   - **Schema Addition**:
>     - Add `RemoteConfigSchema` in `schema.ts` for remote config settings, supporting AWS Bedrock and OpenAI compatible providers.
>     - Define `ProviderSchema`, `ModelInfoSchema`, `OpenAiModelInfoSchema`, `OpenAiCompatibleSchema`, and `AwsBedrockSettingsSchema`.
>     - Use `providerSchemasMap` to manage provider-specific schemas.
>   - **Unit Tests**:
>     - Add `schema.test.ts` to test `RemoteConfigSchema` and related schemas.
>     - Validate acceptance of valid configurations and rejection of invalid types.
>     - Ensure default values are applied where specified.
>   - **Type Inference**:
>     - Infer types for `RemoteConfig`, `Provider`, `ModelInfo`, `OpenAiModelInfo`, `OpenAiCompatible`, `AwsBedrockSettings`, and `ProviderSettings`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 96723437e83562bff5f5373b8da94f1bffb49a6c. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->