### PR TITLE
feat(logging): replace HostProvider with node-machine-id for machine identification

### DIFF
--- a/cli/pkg/hostbridge/env.go
+++ b/cli/pkg/hostbridge/env.go
@@ -68,19 +68,6 @@ func (s *EnvService) ClipboardReadText(ctx context.Context, req *cline.EmptyRequ
 	}, nil
 }
 
-// GetMachineId returns a stable machine identifier for telemetry distinctId purposes
-func (s *EnvService) GetMachineId(ctx context.Context, req *cline.EmptyRequest) (*cline.String, error) {
-	if s.verbose {
-		log.Printf("GetMachineId called")
-	}
-
-	// TODO: Implement actual machine ID functionality
-	// For now, return empty string
-	return &cline.String{
-		Value: "",
-	}, nil
-}
-
 // GetHostVersion returns the host platform name and version
 func (s *EnvService) GetHostVersion(ctx context.Context, req *cline.EmptyRequest) (*host.GetHostVersionResponse, error) {
 	if s.verbose {

--- a/package-lock.json
+++ b/package-lock.json
@@ -60,6 +60,7 @@
 				"jwt-decode": "^4.0.0",
 				"mammoth": "^1.8.0",
 				"nice-grpc": "^2.1.12",
+				"node-machine-id": "^1.1.12",
 				"ollama": "^0.5.13",
 				"open": "^10.1.2",
 				"open-graph-scraper": "^6.9.0",
@@ -8172,19 +8173,6 @@
 				"url": "https://github.com/fb55/domutils?sponsor=1"
 			}
 		},
-		"node_modules/dotenv": {
-			"version": "17.2.2",
-			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.2.tgz",
-			"integrity": "sha512-Sf2LSQP+bOlhKWWyhFsn0UsfdK/kCWRv1iuA2gXAwt3dyNabr6QSj00I2V10pidqz69soatm9ZwZvpQMTIOd5Q==",
-			"dev": true,
-			"license": "BSD-2-Clause",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://dotenvx.com"
-			}
-		},
 		"node_modules/dprint-node": {
 			"version": "1.0.8",
 			"dev": true,
@@ -12418,6 +12406,12 @@
 		},
 		"node_modules/node-int64": {
 			"version": "0.4.0",
+			"license": "MIT"
+		},
+		"node_modules/node-machine-id": {
+			"version": "1.1.12",
+			"resolved": "https://registry.npmjs.org/node-machine-id/-/node-machine-id-1.1.12.tgz",
+			"integrity": "sha512-QNABxbrPa3qEIfrE6GOJ7BYIuignnJw7iQ2YPbc3Nla1HzRJjXzZOiikfF8m7eAMfichLt3M4VgLOetqgDmgGQ==",
 			"license": "MIT"
 		},
 		"node_modules/node-preload": {

--- a/package.json
+++ b/package.json
@@ -445,6 +445,7 @@
 		"jwt-decode": "^4.0.0",
 		"mammoth": "^1.8.0",
 		"nice-grpc": "^2.1.12",
+		"node-machine-id": "^1.1.12",
 		"ollama": "^0.5.13",
 		"open": "^10.1.2",
 		"open-graph-scraper": "^6.9.0",

--- a/proto/host/env.proto
+++ b/proto/host/env.proto
@@ -15,9 +15,6 @@ service EnvService {
   // Reads text from the system clipboard.
   rpc clipboardReadText(cline.EmptyRequest) returns (cline.String);
 
-  // Returns a stable machine identifier for telemetry distinctId purposes.
-  rpc getMachineId(cline.EmptyRequest) returns (cline.String);
-
   // Returns the name and version of the host IDE or environment.
   rpc getHostVersion(cline.EmptyRequest) returns (GetHostVersionResponse);
 

--- a/src/hosts/vscode/hostbridge/env/getMachineId.ts
+++ b/src/hosts/vscode/hostbridge/env/getMachineId.ts
@@ -1,7 +1,0 @@
-import { EmptyRequest, String } from "@shared/proto/cline/common"
-import * as vscode from "vscode"
-
-export async function getMachineId(_: EmptyRequest): Promise<String> {
-	const id = vscode.env.machineId || ""
-	return String.create({ value: id })
-}

--- a/src/services/logging/distinctId.ts
+++ b/src/services/logging/distinctId.ts
@@ -1,7 +1,6 @@
+import { machineId } from "node-machine-id"
 import { v4 as uuidv4 } from "uuid"
 import { ExtensionContext } from "vscode"
-import { HostProvider } from "@/hosts/host-provider"
-import { EmptyRequest } from "@/shared/proto/cline/common"
 
 /*
  * Unique identifier for the current installation.
@@ -36,14 +35,17 @@ export async function initializeDistinctId(context: ExtensionContext, uuid: () =
 }
 
 /*
- * Host-provided UUID when running via HostBridge; fall back to VS Code's machineId
+ * Get machine ID using node-machine-id package
+ * This works across all platforms (VS Code, JetBrains, CLI)
  */
 async function getMachineId(): Promise<string | undefined> {
 	try {
-		const response = await HostProvider.env.getMachineId(EmptyRequest.create({}))
-		return response.value
+		// Get the machine ID using node-machine-id package
+		// This provides a deterministic ID across different operating systems
+		const id = await machineId()
+		return id
 	} catch (error) {
-		console.log("Failed to get machine ID", error)
+		console.log("Failed to get machine ID from node-machine-id", error)
 		return undefined
 	}
 }


### PR DESCRIPTION
Replace custom HostProvider.env.getMachineId() implementation with the node-machine-id npm package for retrieving machine identifiers. This simplifies the codebase by using a well-maintained library instead of custom host provider logic.

Changes:
- Add node-machine-id dependency (^1.1.12)
- Remove dotenv dev dependency (no longer needed)
- Update distinctId service to use node-machine-id directly
- Refactor tests to stub node-machine-id instead of HostProvider
- Remove HostProvider mock utilities from tests

This change improves maintainability and reduces custom code while maintaining the same functionality for generating stable machine IDs.



### Test Procedure
- Run the debugger repeatedly and stop at get machine id to make sure its always the same.


### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [X] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [X] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [X] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [X] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [X] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Replace custom machine ID logic with `node-machine-id` package for improved maintainability and test refactoring.
> 
>   - **Behavior**:
>     - Replace `HostProvider.env.getMachineId()` with `node-machine-id` package for machine ID retrieval in `distinctId.ts`.
>     - Remove `getMachineId` RPC from `env.proto` and `env.go`.
>     - Update `distinctId` service to use `node-machine-id` directly.
>   - **Dependencies**:
>     - Add `node-machine-id` dependency in `package.json`.
>     - Remove `dotenv` dev dependency from `package.json`.
>   - **Tests**:
>     - Refactor `distinctId.test.ts` to stub `node-machine-id` instead of `HostProvider`.
>     - Remove `HostProvider` mock utilities from tests.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for c03d5573fbca599d20a4859bc0b3b5d95a89ba87. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->