### PR TITLE
Baseten provider Kimi K2 0711, Llama 4 Maverick and Llama 4 Scout Model APIs deprecation

### DIFF
--- a/.changeset/dry-scissors-know.md
+++ b/.changeset/dry-scissors-know.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": minor
+---
+
+Baseten Provider Model APIs Deprecation

--- a/docs/provider-config/baseten.mdx
+++ b/docs/provider-config/baseten.mdx
@@ -18,6 +18,8 @@ Baseten provides on-demand frontier model APIs designed for production applicati
 
 Cline supports all current models under Baseten Model APIs, including:
 For the most updated pricing, please visit: https://www.baseten.co/products/model-apis/
+Note: Kimi K2 0711, Llama 4 Maverick, and Llama 4 Scout Model APIs have been deprecated at 5pm PT on October 8th.
+https://www.baseten.co/resources/changelog/model-api-deprecation-notice-kimi-k2-0711-scout-maverick/
 
 **Reasoning Models:**
 -   `deepseek-ai/DeepSeek-R1` - DeepSeek's first-generation reasoning model (163K context) - \$2.55/\$5.95 per 1M tokens
@@ -27,12 +29,7 @@ For the most updated pricing, please visit: https://www.baseten.co/products/mode
 
 **Flagship Models:**
 -   `openai/gpt-oss-120b` (OpenAI) - 120B MoE with strong reasoning capabilities (128K context) - \$0.10/\$0.50 per 1M tokens
--   `moonshotai/Kimi-K2-Instruct` (Moonshot AI) - 1 trillion parameter model for agentic tasks (131K context) - \$0.60/\$2.50 per 1M tokens
 -   `moonshotai/Kimi-K2-Instruct-0905` (Moonshot AI) - September update with enhanced capabilities (262K context) - \$0.60/\$2.50 per 1M tokens
-
-**Meta Llama 4 Series:**
--   `meta-llama/Llama-4-Maverick-17B-128E-Instruct` - High-efficiency processing (1M context!) - \$0.19/\$0.72 per 1M tokens
--   `meta-llama/Llama-4-Scout-17B-16E-Instruct` - Precise context understanding (1M context!) - \$0.13/\$0.50 per 1M tokens
 
 **Coding Specialists:**
 -   `Qwen/Qwen3-Coder-480B-A35B-Instruct`- Advanced coding and reasoning (262K context) - \$0.38/\$1.53 per 1M tokens

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -3382,17 +3382,6 @@ export const basetenModels = {
 		cacheReadsPrice: 0,
 		description: "Mixture-of-experts LLM with math and reasoning capabilities",
 	},
-	"meta-llama/Llama-4-Maverick-17B-128E-Instruct": {
-		maxTokens: 131072,
-		contextWindow: 1000000,
-		supportsImages: false,
-		supportsPromptCache: false,
-		inputPrice: 0.19,
-		outputPrice: 0.72,
-		cacheWritesPrice: 0,
-		cacheReadsPrice: 0,
-		description: "High-efficiency language processing",
-	},
 	"deepseek-ai/DeepSeek-R1": {
 		maxTokens: 131072,
 		contextWindow: 163840,
@@ -3414,17 +3403,6 @@ export const basetenModels = {
 		cacheWritesPrice: 0,
 		cacheReadsPrice: 0,
 		description: "Fast general-purpose LLM with enhanced reasoning capabilities",
-	},
-	"meta-llama/Llama-4-Scout-17B-16E-Instruct": {
-		maxTokens: 131072,
-		contextWindow: 1000000,
-		supportsImages: false,
-		supportsPromptCache: false,
-		inputPrice: 0.13,
-		outputPrice: 0.5,
-		cacheWritesPrice: 0,
-		cacheReadsPrice: 0,
-		description: "Precise context understanding with efficient reasoning capabilities",
 	},
 	"deepseek-ai/DeepSeek-V3.1": {
 		maxTokens: 131072,
@@ -3470,17 +3448,6 @@ export const basetenModels = {
 		cacheReadsPrice: 0,
 		description: "State of the art language model for agentic and coding tasks. Septemeber Update.",
 	},
-	"moonshotai/Kimi-K2-Instruct": {
-		maxTokens: 131000,
-		contextWindow: 131000,
-		supportsImages: false,
-		supportsPromptCache: false,
-		inputPrice: 0.6,
-		outputPrice: 2.5,
-		cacheWritesPrice: 0,
-		cacheReadsPrice: 0,
-		description: "State of the art language model for agentic and coding tasks",
-	},
 	"deepseek-ai/DeepSeek-R1-0528": {
 		maxTokens: 131072,
 		contextWindow: 163840,
@@ -3494,7 +3461,7 @@ export const basetenModels = {
 	},
 } as const satisfies Record<string, ModelInfo>
 export type BasetenModelId = keyof typeof basetenModels
-export const basetenDefaultModelId = "moonshotai/Kimi-K2-Instruct" satisfies BasetenModelId
+export const basetenDefaultModelId = "moonshotai/Kimi-K2-Instruct-0905" satisfies BasetenModelId
 
 // Z AI
 // https://docs.z.ai/guides/llm/glm-4.5


### PR DESCRIPTION

### Related Issues

#6148
#5238

### Description
In light of the newer kimik2 version and the lack of usage from the llama4 series models, Baseten will be deprecating the Kimi K2 0711, Llama 4 Maverick and Llama 4 Scout endpoints: https://www.baseten.co/resources/changelog/model-api-deprecation-notice-kimi-k2-0711-scout-maverick/. The cline integration and docs are modified according to reflect these changes in our API.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [x] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [x] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)
