### PR TITLE
add yolo flag

### DIFF
--- a/cli/pkg/cli/task.go
+++ b/cli/pkg/cli/task.go
@@ -90,6 +90,7 @@ func newTaskNewCommand() *cobra.Command {
 		address    string
 		mode       string
 		settings   []string
+		yolo       bool
 	)
 
 	cmd := &cobra.Command{
@@ -125,6 +126,14 @@ func newTaskNewCommand() *cobra.Command {
 				fmt.Printf("Mode set to: %s\n", mode)
 			}
 
+			// Inject yolo_mode_toggled setting if --yolo flag is set
+
+			// Will append to the -s settings to be parsed by the settings parser logic.
+			// If the yoloMode is also set in the settings, this will override that, since it will be set last.
+			if yolo {
+				settings = append(settings, "yolo_mode_toggled=true")
+			}
+
 			// Create the task
 			taskID, err := taskManager.CreateTask(ctx, prompt, images, files, workspaces, settings)
 			if err != nil {
@@ -151,6 +160,7 @@ func newTaskNewCommand() *cobra.Command {
 	cmd.Flags().StringVar(&address, "address", "", "specific Cline instance address to use")
 	cmd.Flags().StringVarP(&mode, "mode", "m", "", "mode (act|plan)")
 	cmd.Flags().StringSliceVarP(&settings, "setting", "s", nil, "task settings (key=value format, e.g., -s aws-region=us-west-2 -s mode=act)")
+	cmd.Flags().BoolVarP(&yolo, "yolo", "y", false, "enable yolo mode (non-interactive)")
 
 	return cmd
 }


### PR DESCRIPTION


### Description

Add a separate flag for yolo mode

### Test Procedure

Tested that the setting is correctly passed to newTask and that it does things yolo-style

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `--yolo` flag to `newTaskNewCommand` in `task.go` for non-interactive mode.
> 
>   - **Behavior**:
>     - Adds `--yolo` flag to `newTaskNewCommand` in `task.go` to enable yolo mode (non-interactive).
>     - Appends `yolo_mode_toggled=true` to settings if `--yolo` is set, overriding existing yolo settings.
>   - **Flags**:
>     - Adds `BoolVarP` for `yolo` flag with short option `-y` in `newTaskNewCommand`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 7725b4ba8636709283cee0e8ead2399c7893889b. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->