### PR TITLE
add oneshot command

### DIFF
--- a/cli/pkg/cli/task.go
+++ b/cli/pkg/cli/task.go
@@ -23,6 +23,7 @@ func NewTaskCommand() *cobra.Command {
 	}
 
 	cmd.AddCommand(newTaskNewCommand())
+	cmd.AddCommand(newTaskOneshotCommand())
 	cmd.AddCommand(newTaskCancelCommand())
 	cmd.AddCommand(newTaskFollowCommand())
 	cmd.AddCommand(NewTaskSendCommand())
@@ -161,6 +162,71 @@ func newTaskNewCommand() *cobra.Command {
 	cmd.Flags().StringVarP(&mode, "mode", "m", "", "mode (act|plan)")
 	cmd.Flags().StringSliceVarP(&settings, "setting", "s", nil, "task settings (key=value format, e.g., -s aws-region=us-west-2 -s mode=act)")
 	cmd.Flags().BoolVarP(&yolo, "yolo", "y", false, "enable yolo mode (non-interactive)")
+
+	return cmd
+}
+
+func newTaskOneshotCommand() *cobra.Command {
+	var (
+		images     []string
+		files      []string
+		workspaces []string
+		address    string
+		settings   []string
+	)
+
+	cmd := &cobra.Command{
+		Use:     "oneshot <prompt>",
+		Aliases: []string{"o"},
+		Short:   "Create a task in yolo+plan mode and view until completion",
+		Long:    `Creates a new task in yolo mode (non-interactive) and plan mode, then streams the conversation until completion.`,
+		Args:    cobra.MinimumNArgs(0),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+
+			// Get prompt from args/stdin
+			prompt, err := getContentFromStdinAndArgs(args)
+			if err != nil {
+				return fmt.Errorf("failed to read prompt: %w", err)
+			}
+
+			if prompt == "" {
+				return fmt.Errorf("prompt required: provide as argument or pipe via stdin")
+			}
+
+			// Ensure task manager
+			if err := ensureTaskManager(ctx, address); err != nil {
+				return err
+			}
+
+			// Set mode to plan
+			if err := taskManager.SetMode(ctx, "plan", nil, nil, nil); err != nil {
+				return fmt.Errorf("failed to set plan mode: %w", err)
+			}
+			fmt.Println("Mode set to: plan")
+
+			// Inject yolo mode into settings
+			settings = append(settings, "yolo_mode_toggled=true")
+
+			// Create task
+			taskID, err := taskManager.CreateTask(ctx, prompt, images, files, workspaces, settings)
+			if err != nil {
+				return fmt.Errorf("failed to create task: %w", err)
+			}
+
+			fmt.Printf("Task created in yolo+plan mode (ID: %s)\n", taskID)
+			fmt.Printf("Using instance: %s\n", taskManager.GetCurrentInstance())
+
+			// Follow until completion
+			return taskManager.FollowConversationUntilCompletion(ctx)
+		},
+	}
+
+	cmd.Flags().StringSliceVarP(&images, "image", "i", nil, "attach image files")
+	cmd.Flags().StringSliceVarP(&files, "file", "f", nil, "attach files")
+	cmd.Flags().StringSliceVarP(&workspaces, "workdir", "w", nil, "workdir directory paths")
+	cmd.Flags().StringVar(&address, "address", "", "specific Cline instance address to use")
+	cmd.Flags().StringSliceVarP(&settings, "setting", "s", nil, "task settings (key=value format, e.g., -s model=claude)")
 
 	return cmd
 }


### PR DESCRIPTION


### Description

Add oneshot command.

Sets yolo mode and follows task.

### Test Procedure

Test that it does what it's told.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `oneshot` command in `task.go` to create and follow tasks in `yolo+plan` mode until completion.
> 
>   - **New Command**:
>     - Adds `oneshot` command in `task.go` using `newTaskOneshotCommand()`.
>     - Command creates a task in `yolo+plan` mode and follows it until completion.
>     - Supports attaching images, files, and specifying workspaces and settings.
>   - **Command Integration**:
>     - Integrates `oneshot` command into `NewTaskCommand()`.
>     - Uses `ensureTaskManager()` to initialize task manager.
>     - Sets task mode to `plan` and toggles `yolo_mode` in settings.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 31162de07175680363e061456d6728bb5bca9308. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->