### PR TITLE
Remove fake setting Supports Browser Use

### DIFF
--- a/webview-ui/src/components/settings/providers/OpenAICompatible.tsx
+++ b/webview-ui/src/components/settings/providers/OpenAICompatible.tsx
@@ -210,21 +210,6 @@ export const OpenAICompatibleProvider = ({ showModelOptions, isPopup, currentMod
 					</VSCodeCheckbox>
 
 					<VSCodeCheckbox
-						checked={!!openAiModelInfo?.supportsImages}
-						onChange={(e: any) => {
-							const isChecked = e.target.checked === true
-							const modelInfo = openAiModelInfo ? openAiModelInfo : { ...openAiModelInfoSaneDefaults }
-							modelInfo.supportsImages = isChecked
-							handleModeFieldChange(
-								{ plan: "planModeOpenAiModelInfo", act: "actModeOpenAiModelInfo" },
-								modelInfo,
-								currentMode,
-							)
-						}}>
-						Supports browser use
-					</VSCodeCheckbox>
-
-					<VSCodeCheckbox
 						checked={!!openAiModelInfo?.isR1FormatRequired}
 						onChange={(e: any) => {
 							const isChecked = e.target.checked === true


### PR DESCRIPTION
There is a setting under OpenAI compatible for "Supports browser use", but this setting is exactly the same as "Supports images".

There is no actual setting in the extension for "Supports browser use" so just remove it from the UI.

I have left the label 'Supports browser use' because is still useful for the user.

<img width="1278" height="2058" alt="Screenshot 2025-10-07 at 22 59 34" src="https://github.com/user-attachments/assets/50638d4e-4de9-46bf-a109-48dd93c17a76" />

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove redundant "Supports browser use" setting from `OpenAICompatible.tsx` UI component.
> 
>   - **UI Changes**:
>     - Remove `VSCodeCheckbox` for "Supports browser use" in `OpenAICompatible.tsx` as it duplicates "Supports images" functionality.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 09ce3db1b593c98b655be9a7ae93d381913c3a89. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->