### PR TITLE
do_nothing feature flag

### DIFF
--- a/src/services/feature-flags/FeatureFlagsService.ts
+++ b/src/services/feature-flags/FeatureFlagsService.ts
@@ -1,3 +1,4 @@
+import { Logger } from "@/services/logging/Logger"
 import { FEATURE_FLAGS, FeatureFlag } from "@/shared/services/feature-flags/feature-flags"
 import type { IFeatureFlagsProvider } from "./providers/IFeatureFlagsProvider"
 
@@ -34,6 +35,9 @@ export class FeatureFlagsService {
 			const flagEnabled = await this.getFeatureFlag(flag).catch(() => false)
 			this.cache.set(flag, flagEnabled === true)
 		}
+
+		// Print DO_NOTHING flag status after polling
+		Logger.log(`do_nothing flag: ${this.getDoNothingFlag()}`)
 	}
 
 	private async getFeatureFlag(flagName: FeatureFlag): Promise<boolean> {
@@ -84,6 +88,10 @@ export class FeatureFlagsService {
 
 	public getWorkOsAuthEnabled(): boolean {
 		return this.getBooleanFlagEnabled(FeatureFlag.WORKOS_AUTH, false)
+	}
+
+	public getDoNothingFlag(): boolean {
+		return this.getBooleanFlagEnabled(FeatureFlag.DO_NOTHING, false)
 	}
 
 	/**

--- a/src/shared/services/feature-flags/feature-flags.ts
+++ b/src/shared/services/feature-flags/feature-flags.ts
@@ -5,6 +5,7 @@ export enum FeatureFlag {
 	FOCUS_CHAIN_CHECKLIST = "focus_chain_checklist",
 	MULTI_ROOT_WORKSPACE = "multi_root_workspace",
 	WORKOS_AUTH = "workos_auth",
+	DO_NOTHING = "do_nothing",
 }
 
 export const FEATURE_FLAGS = Object.values(FeatureFlag)


### PR DESCRIPTION
That's a sandbox for feature flags. It retrieves a value for 'do_nothing' feature flag and prints to the log. 

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `DO_NOTHING` feature flag and log its status in `FeatureFlagsService`.
> 
>   - **Feature Flags**:
>     - Adds `DO_NOTHING` to `FeatureFlag` enum in `feature-flags.ts`.
>     - Implements `getDoNothingFlag()` in `FeatureFlagsService.ts` to retrieve `DO_NOTHING` flag status.
>   - **Logging**:
>     - Logs `DO_NOTHING` flag status in `poll()` method of `FeatureFlagsService.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 011fd575f7e607fd2832c253dbf357f678d09ca8. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->