### PR TITLE
remove dynamic state key cline:clineAccountId

### DIFF
--- a/src/core/storage/state-keys.ts
+++ b/src/core/storage/state-keys.ts
@@ -176,7 +176,7 @@ export interface Settings {
 export interface Secrets {
 	apiKey: string | undefined
 	clineAccountId: string | undefined
-	["cline:clineAccountId"]: string | undefined // Auth_Provider:AccountId
+	"cline:clineAccountId": string | undefined // Auth_Provider:AccountId
 	openRouterApiKey: string | undefined
 	awsAccessKey: string | undefined
 	awsSecretKey: string | undefined

--- a/src/core/storage/utils/state-helpers.ts
+++ b/src/core/storage/utils/state-helpers.ts
@@ -1,7 +1,6 @@
 import { ANTHROPIC_MIN_THINKING_BUDGET, ApiProvider, fireworksDefaultModelId, type OcaModelInfo } from "@shared/api"
 import { ExtensionContext } from "vscode"
 import { Controller } from "@/core/controller"
-import { ClineAuthProvider } from "@/services/auth/providers/ClineAuthProvider"
 import { DEFAULT_AUTO_APPROVAL_SETTINGS } from "@/shared/AutoApprovalSettings"
 import { DEFAULT_BROWSER_SETTINGS } from "@/shared/BrowserSettings"
 import { ClineRulesToggles } from "@/shared/cline-rules"
@@ -55,7 +54,7 @@ export async function readSecretsFromDisk(context: ExtensionContext): Promise<Se
 		context.secrets.get("apiKey") as Promise<Secrets["apiKey"]>,
 		context.secrets.get("openRouterApiKey") as Promise<Secrets["openRouterApiKey"]>,
 		context.secrets.get("clineAccountId") as Promise<Secrets["clineAccountId"]>,
-		context.secrets.get(ClineAuthProvider.secretKeyId) as Promise<Secrets["cline:clineAccountId"]>,
+		context.secrets.get("cline:clineAccountId") as Promise<Secrets["cline:clineAccountId"]>,
 		context.secrets.get("awsAccessKey") as Promise<Secrets["awsAccessKey"]>,
 		context.secrets.get("awsSecretKey") as Promise<Secrets["awsSecretKey"]>,
 		context.secrets.get("awsSessionToken") as Promise<Secrets["awsSessionToken"]>,
@@ -97,7 +96,7 @@ export async function readSecretsFromDisk(context: ExtensionContext): Promise<Se
 		apiKey,
 		openRouterApiKey,
 		clineAccountId: firebaseClineAccountId,
-		[ClineAuthProvider.secretKeyId]: clineAccountId,
+		"cline:clineAccountId": clineAccountId,
 		huggingFaceApiKey,
 		huaweiCloudMaasApiKey,
 		basetenApiKey,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -34,7 +34,6 @@ import { VscodeDiffViewProvider } from "./hosts/vscode/VscodeDiffViewProvider"
 import { VscodeWebviewProvider } from "./hosts/vscode/VscodeWebviewProvider"
 import { ExtensionRegistryInfo } from "./registry"
 import { AuthService } from "./services/auth/AuthService"
-import { ClineAuthProvider } from "./services/auth/providers/ClineAuthProvider"
 import { LogoutReason } from "./services/auth/types"
 import { telemetryService } from "./services/telemetry"
 import { SharedUriHandler } from "./services/uri/SharedUriHandler"
@@ -376,7 +375,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
 	context.subscriptions.push(
 		context.secrets.onDidChange(async (event) => {
-			if (event.key === "clineAccountId" || event.key === ClineAuthProvider.secretKeyId) {
+			if (event.key === "clineAccountId" || event.key === "cline:clineAccountId") {
 				// Check if the secret was removed (logout) or added/updated (login)
 				const secretValue = await context.secrets.get(event.key)
 				const activeWebview = WebviewProvider.getVisibleInstance()

--- a/src/services/auth/AuthService.ts
+++ b/src/services/auth/AuthService.ts
@@ -267,7 +267,7 @@ export class AuthService {
 	 */
 	async clearAuthToken(): Promise<void> {
 		this._controller.stateManager.setSecret("clineAccountId", undefined)
-		this._controller.stateManager.setSecret(ClineAuthProvider.secretKeyId, undefined)
+		this._controller.stateManager.setSecret("cline:clineAccountId", undefined)
 	}
 
 	/**

--- a/src/services/auth/providers/ClineAuthProvider.ts
+++ b/src/services/auth/providers/ClineAuthProvider.ts
@@ -95,7 +95,7 @@ export class ClineAuthProvider implements IAuthProvider {
 	async retrieveClineAuthInfo(controller: Controller): Promise<ClineAuthInfo | null> {
 		try {
 			// Get the stored auth data from secure storage
-			const storedAuthDataString = controller.stateManager.getSecretKey(ClineAuthProvider.secretKeyId)
+			const storedAuthDataString = controller.stateManager.getSecretKey("cline:clineAccountId")
 
 			if (!storedAuthDataString) {
 				Logger.debug("No stored authentication data found")
@@ -108,13 +108,13 @@ export class ClineAuthProvider implements IAuthProvider {
 				storedAuthData = JSON.parse(storedAuthDataString)
 			} catch (e) {
 				console.error("Failed to parse stored auth data:", e)
-				controller.stateManager.setSecret(ClineAuthProvider.secretKeyId, undefined)
+				controller.stateManager.setSecret("cline:clineAccountId", undefined)
 				return null
 			}
 
 			if (!storedAuthData.refreshToken || !storedAuthData?.idToken) {
 				console.error("No valid token found in stored authentication data")
-				controller.stateManager.setSecret(ClineAuthProvider.secretKeyId, undefined)
+				controller.stateManager.setSecret("cline:clineAccountId", undefined)
 				return null
 			}
 
@@ -304,7 +304,7 @@ export class ClineAuthProvider implements IAuthProvider {
 				provider: this.name,
 			}
 
-			controller.stateManager.setSecret(ClineAuthProvider.secretKeyId, JSON.stringify(clineAuthInfo))
+			controller.stateManager.setSecret("cline:clineAccountId", JSON.stringify(clineAuthInfo))
 
 			return clineAuthInfo
 		} catch (error) {
@@ -312,6 +312,4 @@ export class ClineAuthProvider implements IAuthProvider {
 			throw error
 		}
 	}
-
-	static secretKeyId = "cline:clineAccountId" as const // authProvider:clineAccountId
 }


### PR DESCRIPTION

### Description

Remove the dynamic state key in favor of explicitly and statically declaring the key. This makes the code easier to read and less prone to side-effects.

### Test Procedure

Run build and check-types.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [x] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Replace dynamic state key with static `cline:clineAccountId` for improved code clarity.
> 
>   - **Behavior**:
>     - Replace dynamic state key `ClineAuthProvider.secretKeyId` with static string `cline:clineAccountId` in `state-keys.ts`, `state-helpers.ts`, `extension.ts`, `AuthService.ts`, and `ClineAuthProvider.ts`.
>   - **AuthService**:
>     - Update `clearAuthToken()` and `retrieveClineAuthInfo()` to use static key `cline:clineAccountId`.
>   - **ClineAuthProvider**:
>     - Use static key `cline:clineAccountId` for storing and retrieving auth data.
>   - **Misc**:
>     - Remove `ClineAuthProvider.secretKeyId` definition.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 317e38f97aadbe1dbbb7ad86f906defdb6499853. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->