### PR TITLE
Make changes to the remote config schema

### DIFF
--- a/src/shared/remote-config/__tests__/schema.test.ts
+++ b/src/shared/remote-config/__tests__/schema.test.ts
@@ -1,27 +1,8 @@
 import { expect } from "chai"
 import { describe, it } from "mocha"
-import {
-	AwsBedrockSettingsSchema,
-	OpenAiCompatibleSchema,
-	ProviderSchema,
-	type RemoteConfig,
-	RemoteConfigSchema,
-} from "../schema"
+import { AwsBedrockSettingsSchema, OpenAiCompatibleSchema, type RemoteConfig, RemoteConfigSchema } from "../schema"
 
 describe("Remote Config Schema", () => {
-	describe("ProviderSchema", () => {
-		it("should accept valid provider names", () => {
-			expect(() => ProviderSchema.parse("OpenAiCompatible")).to.not.throw()
-			expect(() => ProviderSchema.parse("AwsBedrock")).to.not.throw()
-		})
-
-		it("should reject invalid provider names", () => {
-			expect(() => ProviderSchema.parse("InvalidProvider")).to.throw()
-			expect(() => ProviderSchema.parse("")).to.throw()
-			expect(() => ProviderSchema.parse(123)).to.throw()
-		})
-	})
-
 	describe("OpenAiCompatibleSchema", () => {
 		it("should accept valid OpenAI compatible settings", () => {
 			const validSettings = {

--- a/src/shared/remote-config/schema.ts
+++ b/src/shared/remote-config/schema.ts
@@ -68,9 +68,6 @@ const ProviderSettingsSchema = z.object({
 	AwsBedrock: AwsBedrockSettingsSchema.optional(),
 })
 
-// The supported providers
-export const ProviderSchema = z.enum(["OpenAiCompatible", "AwsBedrock"])
-
 export const RemoteConfigSchema = z.object({
 	// The version of the remote config settings, e.g. v1
 	// This field is for internal use only, and won't be visible to the administrator in the UI.
@@ -90,7 +87,6 @@ export const RemoteConfigSchema = z.object({
 })
 
 // Type inference from schemas
-export type Provider = z.infer<typeof ProviderSchema>
 export type OpenAiCompatibleModel = z.infer<typeof OpenAiCompatibleModelSchema>
 export type OpenAiCompatible = z.infer<typeof OpenAiCompatibleSchema>
 export type AwsBedrockModel = z.infer<typeof AwsBedrockModelSchema>


### PR DESCRIPTION
* Make the provider settings explictly typed instead of using Object.keys()  and Object.entries().
* Add model specific settings for OpenAI compatible
* Replace 'customModelEnabled' in AWS Bedrock, with a list of custom models instead.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Update remote config schema to use detailed model settings and support custom models for AWS Bedrock.
> 
>   - **Schema Changes**:
>     - Replace `modelIds` with `models` array in `OpenAiCompatibleSchema` and `AwsBedrockSettingsSchema` for detailed model settings.
>     - Add `customModels` array to `AwsBedrockSettingsSchema` for custom model configurations.
>     - Remove `awsBedrockCustomSelected` and `awsBedrockCustomModelBaseId` from `AwsBedrockSettingsSchema`.
>   - **Tests**:
>     - Update tests in `schema.test.ts` to validate new `models` and `customModels` structures.
>     - Add tests for missing fields and invalid types in `OpenAiCompatibleSchema` and `AwsBedrockSettingsSchema`.
>   - **Type Definitions**:
>     - Add `OpenAiCompatibleModel`, `AwsBedrockModel`, and `AwsBedrockCustomModel` types in `schema.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 84b33b389bdd55afb744d447bf389e352dcb0196. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->