### PR TITLE
rpc for updateSettings CLI

### DIFF
--- a/cli/pkg/cli/task/manager.go
+++ b/cli/pkg/cli/task/manager.go
@@ -132,7 +132,7 @@ func (m *Manager) CreateTask(ctx context.Context, prompt string, images, files [
 	}
 
 	// Parse task settings if provided
-	var taskSettings *cline.TaskSettings
+	var taskSettings *cline.Settings
 	if len(settingsFlags) > 0 {
 		var err error
 		taskSettings, err = ParseTaskSettings(settingsFlags)

--- a/cli/pkg/cli/task/settings_parser.go
+++ b/cli/pkg/cli/task/settings_parser.go
@@ -9,12 +9,12 @@ import (
 )
 
 
-func ParseTaskSettings(settingsFlags []string) (*cline.TaskSettings, error) {
+func ParseTaskSettings(settingsFlags []string) (*cline.Settings, error) {
 	if len(settingsFlags) == 0 {
 		return nil, nil
 	}
 
-	settings := &cline.TaskSettings{}
+	settings := &cline.Settings{}
 	nestedSettings := make(map[string]map[string]string)
 
 	for _, flag := range settingsFlags {
@@ -70,8 +70,8 @@ func int32Ptr(i int32) *int32       { return &i }
 func int64Ptr(i int64) *int64       { return &i }
 func float64Ptr(f float64) *float64 { return &f }
 
-// setSimpleField sets a simple (non-nested) field on TaskSettings
-func setSimpleField(settings *cline.TaskSettings, key, value string) error {
+// setSimpleField sets a simple (non-nested) field on Settings
+func setSimpleField(settings *cline.Settings, key, value string) error {
 	switch key {
 	// String fields
 	case "aws_region":
@@ -379,9 +379,9 @@ func setSimpleField(settings *cline.TaskSettings, key, value string) error {
 	return nil
 }
 
-// setNestedField sets a nested field on TaskSettings
+// setNestedField sets a nested field on Settings
 // Currently supports: auto_approval_settings, browser_settings
-func setNestedField(settings *cline.TaskSettings, parentField string, childFields map[string]string) error {
+func setNestedField(settings *cline.Settings, parentField string, childFields map[string]string) error {
 	switch parentField {
 	case "auto_approval_settings":
 		if settings.AutoApprovalSettings == nil {
@@ -496,6 +496,24 @@ func setBrowserSettings(settings *cline.BrowserSettings, fields map[string]strin
 				settings.Viewport = &cline.Viewport{}
 			}
 			settings.Viewport.Height = val
+		case "remote_browser_host":
+			settings.RemoteBrowserHost = strPtr(value)
+		case "remote_browser_enabled":
+			val, err := parseBool(value)
+			if err != nil {
+				return err
+			}
+			settings.RemoteBrowserEnabled = boolPtr(val)
+		case "chrome_executable_path":
+			settings.ChromeExecutablePath = strPtr(value)
+		case "disable_tool_use":
+			val, err := parseBool(value)
+			if err != nil {
+				return err
+			}
+			settings.DisableToolUse = boolPtr(val)
+		case "custom_args":
+			settings.CustomArgs = strPtr(value)
 		default:
 			return fmt.Errorf("unsupported browser_settings field '%s'", key)
 		}

--- a/proto/cline/state.proto
+++ b/proto/cline/state.proto
@@ -18,6 +18,7 @@ service StateService {
   rpc togglePlanActModeProto(TogglePlanActModeRequest) returns (Boolean);
   rpc updateAutoApprovalSettings(AutoApprovalSettingsRequest) returns (Empty);
   rpc updateSettings(UpdateSettingsRequest) returns (Empty);
+  rpc updateSettingsCli(UpdateSettingsRequestCli) returns (Empty);
   rpc updateTelemetrySetting(TelemetrySettingRequest) returns (Empty);
   rpc setWelcomeViewCompleted(BooleanRequest) returns (Empty);
   rpc updateInfoBannerVersion(Int64Request) returns (Empty);
@@ -311,6 +312,12 @@ message BrowserSettingsUpdate {
   optional string custom_args = 6;
 }
 
+message UpdateSettingsRequestCli {
+  Metadata metadata = 1;
+  optional Settings settings = 2;
+  optional Secrets secrets = 3;
+}
+
 // Message for updating settings
 message UpdateSettingsRequest {
   Metadata metadata = 1;
@@ -335,7 +342,7 @@ message UpdateSettingsRequest {
   optional string default_terminal_profile = 21;
   optional bool yolo_mode_toggled = 22;
   optional DictationSettings dictation_settings = 23;
-  optional int32 auto_condense_threshold = 24;
+  optional double auto_condense_threshold = 24;
   optional bool multi_root_enabled = 25;
 }
 

--- a/src/core/controller/state/updateSettingsCli.ts
+++ b/src/core/controller/state/updateSettingsCli.ts
@@ -1,0 +1,247 @@
+import { buildApiHandler } from "@core/api"
+
+import { Empty } from "@shared/proto/cline/common"
+import {
+	PlanActMode,
+	OpenaiReasoningEffort as ProtoOpenaiReasoningEffort,
+	UpdateSettingsRequestCli,
+} from "@shared/proto/cline/state"
+import { convertProtoToApiProvider } from "@shared/proto-conversions/models/api-configuration-conversion"
+import { TelemetrySetting } from "@shared/TelemetrySetting"
+import { Settings } from "@/core/storage/state-keys"
+import { HostProvider } from "@/hosts/host-provider"
+import { TerminalInfo } from "@/integrations/terminal/TerminalRegistry"
+import { ShowMessageType } from "@/shared/proto/host/window"
+import { convertProtoToAutoApprovalSettings } from "@/shared/proto-conversions/models/auto-approval-settings-conversion"
+import { Mode, OpenaiReasoningEffort } from "@/shared/storage/types"
+import { telemetryService } from "../../../services/telemetry"
+import { Controller } from ".."
+
+/**
+ * Updates multiple extension settings in a single request
+ * @param controller The controller instance
+ * @param request The request containing the settings to update
+ * @returns An empty response
+ */
+export async function updateSettingsCli(controller: Controller, request: UpdateSettingsRequestCli): Promise<Empty> {
+	const convertOpenaiReasoningEffort = (effort: ProtoOpenaiReasoningEffort): OpenaiReasoningEffort => {
+		switch (effort) {
+			case ProtoOpenaiReasoningEffort.LOW:
+				return "low"
+			case ProtoOpenaiReasoningEffort.MEDIUM:
+				return "medium"
+			case ProtoOpenaiReasoningEffort.HIGH:
+				return "high"
+			case ProtoOpenaiReasoningEffort.MINIMAL:
+				return "minimal"
+			default:
+				return "medium"
+		}
+	}
+
+	const convertPlanActMode = (mode: PlanActMode): Mode => {
+		return mode === PlanActMode.PLAN ? "plan" : "act"
+	}
+
+	try {
+		if (request.settings) {
+			// Extract all special case fields that need dedicated handlers
+			// These should NOT be included in the batch update
+			const {
+				// Fields requiring conversion
+				autoApprovalSettings,
+				openaiReasoningEffort,
+				mode,
+				customPrompt,
+				planModeApiProvider,
+				actModeApiProvider,
+				// Fields requiring special logic (telemetry, merging, etc.)
+				telemetrySetting,
+				yoloModeToggled,
+				useAutoCondense,
+				focusChainSettings,
+				browserSettings,
+				defaultTerminalProfile,
+				...simpleSettings
+			} = request.settings
+
+			// Batch update for simple pass-through fields
+			const filteredSettings: Partial<Settings> = Object.fromEntries(
+				Object.entries(simpleSettings).filter(([_, value]) => value !== undefined),
+			)
+
+			controller.stateManager.setGlobalStateBatch(filteredSettings)
+
+			// Handle fields requiring type conversion from generated protobuf types to application types
+			if (autoApprovalSettings) {
+				const converted = convertProtoToAutoApprovalSettings({
+					...autoApprovalSettings,
+					metadata: {},
+				})
+				controller.stateManager.setGlobalState("autoApprovalSettings", converted)
+			}
+
+			if (openaiReasoningEffort !== undefined) {
+				const converted = convertOpenaiReasoningEffort(openaiReasoningEffort)
+				controller.stateManager.setGlobalState("openaiReasoningEffort", converted)
+			}
+
+			if (mode !== undefined) {
+				const converted = convertPlanActMode(mode)
+				controller.stateManager.setGlobalState("mode", converted)
+			}
+
+			if (customPrompt === "compact") {
+				controller.stateManager.setGlobalState("customPrompt", "compact")
+			}
+
+			if (planModeApiProvider !== undefined) {
+				const converted = convertProtoToApiProvider(planModeApiProvider)
+				controller.stateManager.setGlobalState("planModeApiProvider", converted)
+			}
+
+			if (actModeApiProvider !== undefined) {
+				const converted = convertProtoToApiProvider(actModeApiProvider)
+				controller.stateManager.setGlobalState("actModeApiProvider", converted)
+			}
+
+			if (controller.task) {
+				const currentMode = controller.stateManager.getGlobalSettingsKey("mode")
+				const apiConfigForHandler = {
+					...controller.stateManager.getApiConfiguration(),
+					ulid: controller.task.ulid,
+				}
+				controller.task.api = buildApiHandler(apiConfigForHandler, currentMode)
+			}
+
+			// Update telemetry setting
+			if (telemetrySetting) {
+				await controller.updateTelemetrySetting(telemetrySetting as TelemetrySetting)
+			}
+
+			// Update yolo mode setting (requires telemetry)
+			if (yoloModeToggled !== undefined) {
+				if (controller.task) {
+					telemetryService.captureYoloModeToggle(controller.task.ulid, yoloModeToggled)
+				}
+				controller.stateManager.setGlobalState("yoloModeToggled", yoloModeToggled)
+			}
+
+			// Update auto-condense setting (requires telemetry)
+			if (useAutoCondense !== undefined) {
+				if (controller.task) {
+					telemetryService.captureAutoCondenseToggle(
+						controller.task.ulid,
+						useAutoCondense,
+						controller.task.api.getModel().id,
+					)
+				}
+				controller.stateManager.setGlobalState("useAutoCondense", useAutoCondense)
+			}
+
+			// Update focus chain settings (requires telemetry on state change)
+			if (focusChainSettings !== undefined) {
+				const currentSettings = controller.stateManager.getGlobalSettingsKey("focusChainSettings")
+				const wasEnabled = currentSettings?.enabled ?? false
+				const isEnabled = focusChainSettings.enabled
+
+				const newFocusChainSettings = {
+					enabled: isEnabled,
+					remindClineInterval: focusChainSettings.remindClineInterval,
+				}
+				controller.stateManager.setGlobalState("focusChainSettings", newFocusChainSettings)
+
+				// Capture telemetry when setting changes
+				if (wasEnabled !== isEnabled) {
+					telemetryService.captureFocusChainToggle(isEnabled)
+				}
+			}
+
+			// Update browser settings (requires careful merging to avoid protobuf defaults)
+			if (browserSettings !== undefined) {
+				const currentSettings = controller.stateManager.getGlobalSettingsKey("browserSettings")
+
+				const newBrowserSettings = {
+					...currentSettings,
+					viewport: {
+						width: browserSettings.viewport?.width || currentSettings.viewport.width,
+						height: browserSettings.viewport?.height || currentSettings.viewport.height,
+					},
+					...(browserSettings.remoteBrowserEnabled !== undefined && {
+						remoteBrowserEnabled: browserSettings.remoteBrowserEnabled,
+					}),
+					...(browserSettings.remoteBrowserHost !== undefined && {
+						remoteBrowserHost: browserSettings.remoteBrowserHost,
+					}),
+					...(browserSettings.chromeExecutablePath !== undefined && {
+						chromeExecutablePath: browserSettings.chromeExecutablePath,
+					}),
+					...(browserSettings.disableToolUse !== undefined && {
+						disableToolUse: browserSettings.disableToolUse,
+					}),
+					...(browserSettings.customArgs !== undefined && {
+						customArgs: browserSettings.customArgs,
+					}),
+				}
+
+				controller.stateManager.setGlobalState("browserSettings", newBrowserSettings)
+			}
+
+			// Update default terminal profile (requires terminal manager updates and notifications)
+			if (defaultTerminalProfile !== undefined) {
+				const profileId = defaultTerminalProfile
+
+				// Update the terminal profile in the state
+				controller.stateManager.setGlobalState("defaultTerminalProfile", profileId)
+
+				let closedCount = 0
+				let busyTerminals: TerminalInfo[] = []
+
+				// Update the terminal manager of the current task if it exists
+				if (controller.task) {
+					// Call the updated setDefaultTerminalProfile method that returns closed terminal info
+					const result = controller.task.terminalManager.setDefaultTerminalProfile(profileId)
+					closedCount = result.closedCount
+					busyTerminals = result.busyTerminals
+
+					// Show information message if terminals were closed
+					if (closedCount > 0) {
+						const message = `Closed ${closedCount} ${closedCount === 1 ? "terminal" : "terminals"} with different profile.`
+						HostProvider.window.showMessage({
+							type: ShowMessageType.INFORMATION,
+							message,
+						})
+					}
+
+					// Show warning if there are busy terminals that couldn't be closed
+					if (busyTerminals.length > 0) {
+						const message =
+							`${busyTerminals.length} busy ${busyTerminals.length === 1 ? "terminal has" : "terminals have"} a different profile. ` +
+							`Close ${busyTerminals.length === 1 ? "it" : "them"} to use the new profile for all commands.`
+						HostProvider.window.showMessage({
+							type: ShowMessageType.WARNING,
+							message,
+						})
+					}
+				}
+			}
+		}
+
+		// Handle secrets update
+		if (request.secrets) {
+			const filteredSecrets = Object.fromEntries(
+				Object.entries(request.secrets).filter(([_, value]) => value !== undefined),
+			)
+
+			controller.stateManager.setSecretsBatch(filteredSecrets)
+		}
+
+		// Post updated state to webview
+		await controller.postStateToWebview()
+
+		return Empty.create()
+	} catch (error) {
+		console.error("Failed to update settings:", error)
+		throw error
+	}
+}


### PR DESCRIPTION


### Description

Adding a new RPC just for updating the settings in the CLI. This is because we are separating the settings and the secrets into different fields, and because the API configuration object is now spread flat at the root level. 

This is intended to be a temporary RPC, and so we can completely remove the API configuration object everywhere in the code, including the webview. We want to get rid of it because it is an artificially constructed field that is not actually saved as such in the storage, and because it mixes together the settings of all the providers and secrets. 

### Test Procedure

Since this is just adding an RPC and changing the protos, we type check and we build protos and confirm that everything builds correctly. 

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->
