### PR TITLE
add config set command

### DIFF
--- a/cli/cmd/cline/main.go
+++ b/cli/cmd/cline/main.go
@@ -44,6 +44,7 @@ monitoring capabilities from the terminal.`,
 
 	rootCmd.AddCommand(cli.NewTaskCommand())
 	rootCmd.AddCommand(cli.NewInstanceCommand())
+	rootCmd.AddCommand(cli.NewConfigCommand())
 	rootCmd.AddCommand(cli.NewVersionCommand())
 	rootCmd.AddCommand(cli.NewAuthCommand())
 	rootCmd.AddCommand(cli.NewTaskSendCommand())

--- a/cli/pkg/cli/config.go
+++ b/cli/pkg/cli/config.go
@@ -3,6 +3,9 @@ package cli
 import (
 	"fmt"
 
+	"github.com/cline/cli/pkg/cli/config"
+	"github.com/cline/cli/pkg/cli/global"
+	"github.com/cline/cli/pkg/cli/task"
 	"github.com/spf13/cobra"
 )
 
@@ -10,12 +13,13 @@ func NewConfigCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "config",
 		Aliases: []string{"c"},
-		Short:   "View and manage Cline configurations",
-		Long:    `View and manage Cline configurations`,
+		Short:   "Manage Cline configuration",
+		Long:    `Set and manage global Cline configuration variables.`,
 	}
 
 	cmd.AddCommand(newConfigListCommand())
 	cmd.AddCommand(newConfigGetCommand())
+	cmd.AddCommand(setCommand())
 
 	return cmd
 }
@@ -48,5 +52,49 @@ func newConfigListCommand() *cobra.Command {
 		},
 	}
 
+	return cmd
+}
+
+func setCommand() *cobra.Command {
+	var address string
+
+	cmd := &cobra.Command{
+		Use:     "set <key=value> [key=value...]",
+		Aliases: []string{"s"},
+		Short:   "Set configuration variables",
+		Long:    `Set one or more global configuration variables using key=value format.`,
+		Args:    cobra.MinimumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+
+			// Parse using existing task parser
+			settings, err := task.ParseTaskSettings(args)
+			if err != nil {
+				return fmt.Errorf("failed to parse settings: %w", err)
+			}
+
+			// Ensure default instance if no address specified
+			if address == "" {
+				if err := global.EnsureDefaultInstance(ctx); err != nil {
+					return fmt.Errorf("failed to ensure default instance: %w", err)
+				}
+			} else {
+				if err := ensureInstanceAtAddress(ctx, address); err != nil {
+					return fmt.Errorf("failed to ensure instance at address %s: %w", address, err)
+				}
+			}
+
+			// Create manager
+			manager, err := config.NewManager(ctx, address)
+			if err != nil {
+				return err
+			}
+
+			// Update settings
+			return manager.UpdateSettings(ctx, settings)
+		},
+	}
+
+	cmd.Flags().StringVar(&address, "address", "", "specific Cline instance address to use")
 	return cmd
 }

--- a/cli/pkg/cli/config/manager.go
+++ b/cli/pkg/cli/config/manager.go
@@ -1,0 +1,58 @@
+package config
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/cline/cli/pkg/cli/global"
+	"github.com/cline/grpc-go/client"
+	"github.com/cline/grpc-go/cline"
+)
+
+type Manager struct {
+	client        *client.ClineClient
+	clientAddress string
+}
+
+func NewManager(ctx context.Context, address string) (*Manager, error) {
+	var c *client.ClineClient
+	var err error
+
+	if address != "" {
+		c, err = global.GetClientForAddress(ctx, address)
+	} else {
+		c, err = global.GetDefaultClient(ctx)
+	}
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to get client: %w", err)
+	}
+
+	// Get the actual address being used
+	clientAddress := address
+	if address == "" && global.Clients != nil {
+		clientAddress = global.Clients.GetRegistry().GetDefaultInstance()
+	}
+
+	return &Manager{
+		client:        c,
+		clientAddress: clientAddress,
+	}, nil
+}
+
+func (m *Manager) UpdateSettings(ctx context.Context, settings *cline.Settings) error {
+	request := &cline.UpdateSettingsRequestCli{
+		Metadata: &cline.Metadata{},
+		Settings: settings,
+	}
+
+	// Call the updateSettingsCli RPC
+	_, err := m.client.State.UpdateSettingsCli(ctx, request)
+	if err != nil {
+		return fmt.Errorf("failed to update settings: %w", err)
+	}
+
+	fmt.Println("Settings updated successfully")
+	fmt.Printf("Instance: %s\n", m.clientAddress)
+	return nil
+}


### PR DESCRIPTION


### Description

Adds a config set command for setting global settings. Uses the same settings as the task settings flag. 

Does not support secrets yet

### Test Procedure

Tested by adding logging in the updateSettingsCli RPC and confirming that settings were being passed as expected. 

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds a `set` subcommand to the Cline CLI for setting global configuration variables using key-value pairs, with gRPC handling via a new `Manager` class.
> 
>   - **New Feature**:
>     - Adds `set` subcommand to `config` command in `config.go` for setting global configuration variables using key-value pairs.
>     - Introduces `Manager` class in `manager.go` to handle settings update via gRPC.
>   - **Command Registration**:
>     - Registers `NewConfigCommand` in `main.go` to include the new `set` command.
>   - **Limitations**:
>     - Does not support setting secrets yet.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 558b7202aeff04dc8a544203edafaaac2aba76fa. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->