### PR TITLE
Add missing remote config setting for: AWS use global inference

### DIFF
--- a/src/shared/remote-config/__tests__/schema.test.ts
+++ b/src/shared/remote-config/__tests__/schema.test.ts
@@ -322,6 +322,7 @@ describe("Remote Config Schema", () => {
 						],
 						awsRegion: "eu-west-1",
 						awsUseCrossRegionInference: false,
+						awsUseGlobalInference: true,
 						awsBedrockUsePromptCache: true,
 						awsBedrockEndpoint: "https://custom-bedrock.endpoint",
 					},
@@ -345,6 +346,7 @@ describe("Remote Config Schema", () => {
 			expect(result.providerSettings?.AwsBedrock?.customModels).to.have.lengthOf(2)
 			expect(result.providerSettings?.AwsBedrock?.awsRegion).to.equal("eu-west-1")
 			expect(result.providerSettings?.AwsBedrock?.awsUseCrossRegionInference).to.equal(false)
+			expect(result.providerSettings?.AwsBedrock?.awsUseGlobalInference).to.equal(true)
 			expect(result.providerSettings?.AwsBedrock?.awsBedrockUsePromptCache).to.equal(true)
 			expect(result.providerSettings?.AwsBedrock?.awsBedrockEndpoint).to.equal("https://custom-bedrock.endpoint")
 		})

--- a/src/shared/remote-config/schema.ts
+++ b/src/shared/remote-config/schema.ts
@@ -57,6 +57,7 @@ export const AwsBedrockSettingsSchema = z.object({
 	// AWS Bedrock specific settings:
 	awsRegion: z.string().optional(),
 	awsUseCrossRegionInference: z.boolean().optional(),
+	awsUseGlobalInference: z.boolean().optional(),
 	awsBedrockUsePromptCache: z.boolean().optional(),
 	awsBedrockEndpoint: z.string().optional(),
 })


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `awsUseGlobalInference` to `AwsBedrockSettingsSchema` and update tests in `schema.test.ts`.
> 
>   - **Schema Changes**:
>     - Add `awsUseGlobalInference` as an optional boolean in `AwsBedrockSettingsSchema` in `schema.ts`.
>   - **Test Updates**:
>     - Update `AwsBedrockSettingsSchema` test in `schema.test.ts` to include `awsUseGlobalInference` validation.
>     - Add expectation for `awsUseGlobalInference` to be `true` in `RemoteConfigSchema` test in `schema.test.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 6caec14eb1c42de9ffa4d8cdccf68d13e3094d86. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->