### PR TITLE
feat: add environment-based visual indicators to UI

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -5,6 +5,7 @@ export enum Environment {
 }
 
 export interface EnvironmentConfig {
+	environment: Environment
 	appBaseUrl: string
 	apiBaseUrl: string
 	mcpBaseUrl: string
@@ -32,10 +33,11 @@ function getClineEnv(): Environment {
 }
 
 // Config getter function to avoid storing all configs in memory
-function getEnvironmentConfig(env: Environment): EnvironmentConfig {
-	switch (env) {
+function getEnvironmentConfig(environment: Environment): EnvironmentConfig {
+	switch (environment) {
 		case Environment.staging:
 			return {
+				environment,
 				appBaseUrl: "https://staging-app.cline.bot",
 				apiBaseUrl: "https://core-api.staging.int.cline.bot",
 				mcpBaseUrl: "https://api.cline.bot/v1/mcp",
@@ -50,6 +52,7 @@ function getEnvironmentConfig(env: Environment): EnvironmentConfig {
 			}
 		case Environment.local:
 			return {
+				environment,
 				appBaseUrl: "http://localhost:3000",
 				apiBaseUrl: "http://localhost:7777",
 				mcpBaseUrl: "https://api.cline.bot/v1/mcp",
@@ -61,6 +64,7 @@ function getEnvironmentConfig(env: Environment): EnvironmentConfig {
 			}
 		default:
 			return {
+				environment,
 				appBaseUrl: "https://app.cline.bot",
 				apiBaseUrl: "https://api.cline.bot",
 				mcpBaseUrl: "https://api.cline.bot/v1/mcp",
@@ -77,9 +81,8 @@ function getEnvironmentConfig(env: Environment): EnvironmentConfig {
 }
 
 // Get environment once at module load
-const CLINE_ENVIRONMENT = getClineEnv()
-const _configCache = getEnvironmentConfig(CLINE_ENVIRONMENT)
+const _configCache = getEnvironmentConfig(getClineEnv())
 
-console.info("Cline environment:", CLINE_ENVIRONMENT)
+console.info("Cline environment:", _configCache.environment)
 
 export const clineEnvConfig = _configCache

--- a/src/core/controller/index.ts
+++ b/src/core/controller/index.ts
@@ -754,6 +754,7 @@ export class Controller {
 		const platform = process.platform as Platform
 		const distinctId = getDistinctId()
 		const version = ExtensionRegistryInfo.version
+		const environment = clineEnvConfig.environment
 
 		// Set feature flag in dictation settings based on platform
 		const updatedDictationSettings = {
@@ -784,6 +785,8 @@ export class Controller {
 			telemetrySetting,
 			planActSeparateModelsSetting,
 			enableCheckpointsSetting: enableCheckpointsSetting ?? true,
+			platform,
+			environment,
 			distinctId,
 			globalClineRulesToggles: globalClineRulesToggles || {},
 			localClineRulesToggles: localClineRulesToggles || {},
@@ -800,7 +803,6 @@ export class Controller {
 			terminalOutputLineLimit,
 			customPrompt,
 			taskHistory: processedTaskHistory,
-			platform,
 			shouldShowAnnouncement,
 			favoritedModelIds,
 			autoCondenseThreshold,

--- a/src/shared/ExtensionMessage.ts
+++ b/src/shared/ExtensionMessage.ts
@@ -2,6 +2,7 @@
 
 import { WorkspaceRoot } from "@shared/multi-root/types"
 import { GlobalStateAndSettings } from "@shared/storage/state-keys"
+import type { Environment } from "../config"
 import { AutoApprovalSettings } from "./AutoApprovalSettings"
 import { ApiConfiguration } from "./api"
 import { BrowserSettings } from "./BrowserSettings"
@@ -51,6 +52,7 @@ export interface ExtensionState {
 	planActSeparateModelsSetting: boolean
 	enableCheckpointsSetting?: boolean
 	platform: Platform
+	environment?: Environment
 	shouldShowAnnouncement: boolean
 	taskHistory: HistoryItem[]
 	telemetrySetting: TelemetrySetting

--- a/webview-ui/src/assets/ClineLogoVariable.tsx
+++ b/webview-ui/src/assets/ClineLogoVariable.tsx
@@ -1,21 +1,32 @@
 import { SVGProps } from "react"
+import type { Environment } from "../../../src/config"
+import { getEnvironmentColor } from "../utils/environmentColors"
 
 /**
- * ClineLogoVariable component renders the Cline logo with automatic theme adaptation.
+ * ClineLogoVariable component renders the Cline logo with automatic theme adaptation
+ * and environment-based color indicators.
  *
- * This component uses the VS Code theme variable `--vscode-icon-foreground` for the fill color,
- * which automatically adjusts based on the active VS Code theme (light, dark, high contrast)
- * to ensure optimal contrast with the background.
+ * This component uses VS Code theme variables for the fill color, with environment-specific colors:
+ * - Local: yellow/orange (development/experimental)
+ * - Staging: blue (stable testing)
+ * - Production: gray/white (default icon color)
  *
- * @param {SVGProps<SVGSVGElement>} props - Standard SVG props including className, style, etc.
- * @returns {JSX.Element} SVG Cline logo that adapts to VS Code themes
+ * @param {SVGProps<SVGSVGElement> & { environment?: Environment }} props - Standard SVG props plus optional environment
+ * @returns {JSX.Element} SVG Cline logo that adapts to VS Code themes and environment
  */
-const ClineLogoVariable = (props: SVGProps<SVGSVGElement>) => (
-	<svg fill="none" height="50" viewBox="0 0 47 50" width="47" xmlns="http://www.w3.org/2000/svg" {...props}>
-		<path
-			d="M46.4075 28.1192L43.5011 22.3166V18.9747C43.5011 13.4354 39.0302 8.94931 33.5162 8.94931H28.5491C28.9086 8.21513 29.106 7.3898 29.106 6.5189C29.106 3.44039 26.6149 0.949219 23.5363 0.949219C20.4578 0.949219 17.9667 3.44039 17.9667 6.5189C17.9667 7.3898 18.1641 8.21513 18.5236 8.94931H13.5565C8.04249 8.94931 3.57155 13.4354 3.57155 18.9747V22.3166L0.604424 28.104C0.305687 28.6863 0.305687 29.3799 0.604424 29.9622L3.57155 35.6838V39.0256C3.57155 44.5649 8.04249 49.0511 13.5565 49.0511H33.5162C39.0302 49.0511 43.5011 44.5649 43.5011 39.0256V35.6838L46.4024 29.942C46.691 29.3698 46.691 28.6964 46.4075 28.1192ZM20.4983 32.8483C20.4983 35.3648 18.4578 37.4053 15.9413 37.4053C13.4248 37.4053 11.3843 35.3648 11.3843 32.8483V24.747C11.3843 22.2305 13.4248 20.19 15.9413 20.19C18.4578 20.19 20.4983 22.2305 20.4983 24.747V32.8483ZM35.182 32.8483C35.182 35.3648 33.1415 37.4053 30.625 37.4053C28.1085 37.4053 26.068 35.3648 26.068 32.8483V24.747C26.068 22.2305 28.1085 20.19 30.625 20.19C33.1415 20.19 35.182 22.2305 35.182 24.747V32.8483Z"
-			fill="var(--vscode-icon-foreground)"
-		/>
-	</svg>
-)
+const ClineLogoVariable = (props: SVGProps<SVGSVGElement> & { environment?: Environment }) => {
+	const { environment, ...svgProps } = props
+
+	// Determine fill color based on environment
+	const fillColor = environment ? getEnvironmentColor(environment) : "var(--vscode-icon-foreground)"
+
+	return (
+		<svg fill="none" height="50" viewBox="0 0 47 50" width="47" xmlns="http://www.w3.org/2000/svg" {...svgProps}>
+			<path
+				d="M46.4075 28.1192L43.5011 22.3166V18.9747C43.5011 13.4354 39.0302 8.94931 33.5162 8.94931H28.5491C28.9086 8.21513 29.106 7.3898 29.106 6.5189C29.106 3.44039 26.6149 0.949219 23.5363 0.949219C20.4578 0.949219 17.9667 3.44039 17.9667 6.5189C17.9667 7.3898 18.1641 8.21513 18.5236 8.94931H13.5565C8.04249 8.94931 3.57155 13.4354 3.57155 18.9747V22.3166L0.604424 28.104C0.305687 28.6863 0.305687 29.3799 0.604424 29.9622L3.57155 35.6838V39.0256C3.57155 44.5649 8.04249 49.0511 13.5565 49.0511H33.5162C39.0302 49.0511 43.5011 44.5649 43.5011 39.0256V35.6838L46.4024 29.942C46.691 29.3698 46.691 28.6964 46.4075 28.1192ZM20.4983 32.8483C20.4983 35.3648 18.4578 37.4053 15.9413 37.4053C13.4248 37.4053 11.3843 35.3648 11.3843 32.8483V24.747C11.3843 22.2305 13.4248 20.19 15.9413 20.19C18.4578 20.19 20.4983 22.2305 20.4983 24.747V32.8483ZM35.182 32.8483C35.182 35.3648 33.1415 37.4053 30.625 37.4053C28.1085 37.4053 26.068 35.3648 26.068 32.8483V24.747C26.068 22.2305 28.1085 20.19 30.625 20.19C33.1415 20.19 35.182 22.2305 35.182 24.747V32.8483Z"
+				fill={fillColor}
+			/>
+		</svg>
+	)
+}
 export default ClineLogoVariable

--- a/webview-ui/src/components/account/AccountView.tsx
+++ b/webview-ui/src/components/account/AccountView.tsx
@@ -6,7 +6,9 @@ import deepEqual from "fast-deep-equal"
 import { memo, useCallback, useEffect, useRef, useState } from "react"
 import { useInterval } from "react-use"
 import { type ClineUser, handleSignOut } from "@/context/ClineAuthContext"
+import { useExtensionState } from "@/context/ExtensionStateContext"
 import { AccountServiceClient } from "@/services/grpc-client"
+import { getEnvironmentColor } from "@/utils/environmentColors"
 import VSCodeButtonLink from "../common/VSCodeButtonLink"
 import { AccountWelcomeView } from "./AccountWelcomeView"
 import { CreditBalance } from "./CreditBalance"
@@ -34,10 +36,15 @@ type CachedData = {
 }
 
 const AccountView = ({ onDone, clineUser, organizations, activeOrganization }: AccountViewProps) => {
+	const { environment } = useExtensionState()
+	const titleColor = getEnvironmentColor(environment)
+
 	return (
 		<div className="fixed inset-0 flex flex-col overflow-hidden pt-[10px] pl-[20px]">
 			<div className="flex justify-between items-center mb-[17px] pr-[17px]">
-				<h3 className="text-[var(--vscode-foreground)] m-0">Account</h3>
+				<h3 className="m-0" style={{ color: titleColor }}>
+					Account
+				</h3>
 				<VSCodeButton onClick={onDone}>Done</VSCodeButton>
 			</div>
 			<div className="flex-grow overflow-hidden pr-[8px] flex flex-col">

--- a/webview-ui/src/components/account/AccountWelcomeView.tsx
+++ b/webview-ui/src/components/account/AccountWelcomeView.tsx
@@ -1,23 +1,28 @@
 import { VSCodeButton, VSCodeLink } from "@vscode/webview-ui-toolkit/react"
 import { handleSignIn } from "@/context/ClineAuthContext"
-import ClineLogoWhite from "../../assets/ClineLogoWhite"
+import { useExtensionState } from "@/context/ExtensionStateContext"
+import ClineLogoVariable from "../../assets/ClineLogoVariable"
 
-export const AccountWelcomeView = () => (
-	<div className="flex flex-col items-center pr-3">
-		<ClineLogoWhite className="size-16 mb-4" />
+export const AccountWelcomeView = () => {
+	const { environment } = useExtensionState()
 
-		<p>
-			Sign up for an account to get access to the latest models, billing dashboard to view usage and credits, and more
-			upcoming features.
-		</p>
+	return (
+		<div className="flex flex-col items-center pr-3">
+			<ClineLogoVariable className="size-16 mb-4" environment={environment} />
 
-		<VSCodeButton className="w-full mb-4" onClick={() => handleSignIn()}>
-			Sign up with Cline
-		</VSCodeButton>
+			<p>
+				Sign up for an account to get access to the latest models, billing dashboard to view usage and credits, and more
+				upcoming features.
+			</p>
 
-		<p className="text-[var(--vscode-descriptionForeground)] text-xs text-center m-0">
-			By continuing, you agree to the <VSCodeLink href="https://cline.bot/tos">Terms of Service</VSCodeLink> and{" "}
-			<VSCodeLink href="https://cline.bot/privacy">Privacy Policy.</VSCodeLink>
-		</p>
-	</div>
-)
+			<VSCodeButton className="w-full mb-4" onClick={() => handleSignIn()}>
+				Sign up with Cline
+			</VSCodeButton>
+
+			<p className="text-[var(--vscode-descriptionForeground)] text-xs text-center m-0">
+				By continuing, you agree to the <VSCodeLink href="https://cline.bot/tos">Terms of Service</VSCodeLink> and{" "}
+				<VSCodeLink href="https://cline.bot/privacy">Privacy Policy.</VSCodeLink>
+			</p>
+		</div>
+	)
+}

--- a/webview-ui/src/components/chat/task-header/TaskHeader.tsx
+++ b/webview-ui/src/components/chat/task-header/TaskHeader.tsx
@@ -7,6 +7,7 @@ import Thumbnails from "@/components/common/Thumbnails"
 import { getModeSpecificFields, normalizeApiConfiguration } from "@/components/settings/utils/providerUtils"
 import { useExtensionState } from "@/context/ExtensionStateContext"
 import { UiServiceClient } from "@/services/grpc-client"
+import { getEnvironmentColor } from "@/utils/environmentColors"
 import CopyTaskButton from "./buttons/CopyTaskButton"
 import DeleteTaskButton from "./buttons/DeleteTaskButton"
 import NewTaskButton from "./buttons/NewTaskButton"
@@ -58,6 +59,7 @@ const TaskHeader: React.FC<TaskHeaderProps> = ({
 		mode,
 		expandTaskHeader: isTaskExpanded,
 		setExpandTaskHeader: setIsTaskExpanded,
+		environment,
 	} = useExtensionState()
 
 	// Simplified computed values
@@ -86,6 +88,7 @@ const TaskHeader: React.FC<TaskHeaderProps> = ({
 	}, [navigateToSettings])
 
 	const highlightedText = useMemo(() => highlightText(task.text, false), [task.text])
+	const environmentBorderColor = getEnvironmentColor(environment, "border")
 
 	return (
 		<div className={"p-2 flex flex-col gap-1.5"}>
@@ -99,11 +102,13 @@ const TaskHeader: React.FC<TaskHeaderProps> = ({
 				className={cn(
 					"relative overflow-hidden cursor-pointer rounded-sm flex flex-col gap-1.5 z-10 pt-2 pb-2 px-2 hover:opacity-100 bg-[var(--vscode-toolbar-hoverBackground)]/65",
 					{
-						"opacity-100 border-1 border-[var(--vscode-editorGroup-border)]": isTaskExpanded, // No hover effects when expanded, add border
-						"hover:bg-[var(--vscode-toolbar-hoverBackground)] border-1 border-[var(--vscode-editorGroup-border)]":
-							!isTaskExpanded, // Hover effects only when collapsed
+						"opacity-100 border-1": isTaskExpanded, // No hover effects when expanded, add border
+						"hover:bg-[var(--vscode-toolbar-hoverBackground)] border-1": !isTaskExpanded, // Hover effects only when collapsed
 					},
-				)}>
+				)}
+				style={{
+					borderColor: environmentBorderColor,
+				}}>
 				{/* Task Title */}
 				<div className="flex justify-between items-center cursor-pointer" onClick={toggleTaskExpanded}>
 					<div className="flex justify-between items-center">

--- a/webview-ui/src/components/history/HistoryView.tsx
+++ b/webview-ui/src/components/history/HistoryView.tsx
@@ -7,6 +7,7 @@ import { Virtuoso } from "react-virtuoso"
 import DangerButton from "@/components/common/DangerButton"
 import { useExtensionState } from "@/context/ExtensionStateContext"
 import { TaskServiceClient } from "@/services/grpc-client"
+import { getEnvironmentColor } from "@/utils/environmentColors"
 import { formatLargeNumber, formatSize } from "@/utils/format"
 
 type HistoryViewProps = {
@@ -46,7 +47,7 @@ const CustomFilterRadio = ({ checked, onChange, icon, label }: CustomFilterRadio
 
 const HistoryView = ({ onDone }: HistoryViewProps) => {
 	const extensionStateContext = useExtensionState()
-	const { taskHistory, onRelinquishControl } = extensionStateContext
+	const { taskHistory, onRelinquishControl, environment } = extensionStateContext
 	const [searchQuery, setSearchQuery] = useState("")
 	const [sortOption, setSortOption] = useState<SortOption>("newest")
 	const [lastNonRelevantSort, setLastNonRelevantSort] = useState<SortOption | null>("newest")
@@ -317,7 +318,7 @@ const HistoryView = ({ onDone }: HistoryViewProps) => {
 					}}>
 					<h3
 						style={{
-							color: "var(--vscode-foreground)",
+							color: getEnvironmentColor(environment),
 							margin: 0,
 						}}>
 						History

--- a/webview-ui/src/components/mcp/configuration/McpConfigurationView.tsx
+++ b/webview-ui/src/components/mcp/configuration/McpConfigurationView.tsx
@@ -7,6 +7,7 @@ import { useEffect, useState } from "react"
 import styled from "styled-components"
 import { useExtensionState } from "@/context/ExtensionStateContext"
 import { McpServiceClient } from "@/services/grpc-client"
+import { getEnvironmentColor } from "@/utils/environmentColors"
 import AddRemoteServerForm from "./tabs/add-server/AddRemoteServerForm"
 import ConfigureServersView from "./tabs/installed/ConfigureServersView"
 import McpMarketplaceView from "./tabs/marketplace/McpMarketplaceView"
@@ -17,7 +18,7 @@ type McpViewProps = {
 }
 
 const McpConfigurationView = ({ onDone, initialTab }: McpViewProps) => {
-	const { mcpMarketplaceEnabled, setMcpServers } = useExtensionState()
+	const { mcpMarketplaceEnabled, setMcpServers, environment } = useExtensionState()
 	const [activeTab, setActiveTab] = useState<McpViewTab>(initialTab || (mcpMarketplaceEnabled ? "marketplace" : "configure"))
 
 	const handleTabChange = (tab: McpViewTab) => {
@@ -75,7 +76,13 @@ const McpConfigurationView = ({ onDone, initialTab }: McpViewProps) => {
 					alignItems: "center",
 					padding: "10px 17px 5px 20px",
 				}}>
-				<h3 style={{ color: "var(--vscode-foreground)", margin: 0 }}>MCP Servers</h3>
+				<h3
+					style={{
+						color: getEnvironmentColor(environment),
+						margin: 0,
+					}}>
+					MCP Servers
+				</h3>
 				<VSCodeButton onClick={onDone}>Done</VSCodeButton>
 			</div>
 

--- a/webview-ui/src/components/settings/SettingsView.tsx
+++ b/webview-ui/src/components/settings/SettingsView.tsx
@@ -17,6 +17,7 @@ import { useEvent } from "react-use"
 import HeroTooltip from "@/components/common/HeroTooltip"
 import { useExtensionState } from "@/context/ExtensionStateContext"
 import { StateServiceClient } from "@/services/grpc-client"
+import { getEnvironmentColor } from "@/utils/environmentColors"
 import { Tab, TabContent, TabHeader, TabList, TabTrigger } from "../common/Tab"
 import SectionHeader from "./SectionHeader"
 import AboutSection from "./sections/AboutSection"
@@ -139,7 +140,7 @@ const SettingsView = ({ onDone, targetSection }: SettingsViewProps) => {
 		[],
 	) // Empty deps - these imports never change
 
-	const { version } = useExtensionState()
+	const { version, environment } = useExtensionState()
 
 	// Initialize active tab with memoized calculation
 	const initialTab = useMemo(() => targetSection || SETTINGS_TABS[0].id, [targetSection])
@@ -295,11 +296,15 @@ const SettingsView = ({ onDone, targetSection }: SettingsViewProps) => {
 		return <Component {...props} />
 	}, [activeTab, handleResetState, version])
 
+	const titleColor = getEnvironmentColor(environment)
+
 	return (
 		<Tab>
 			<TabHeader className="flex justify-between items-center gap-2">
 				<div className="flex items-center gap-1">
-					<h3 className="text-foreground m-0">Settings</h3>
+					<h3 className="m-0" style={{ color: titleColor }}>
+						Settings
+					</h3>
 				</div>
 				<div className="flex gap-2">
 					<VSCodeButton onClick={onDone}>Done</VSCodeButton>

--- a/webview-ui/src/components/welcome/HomeHeader.tsx
+++ b/webview-ui/src/components/welcome/HomeHeader.tsx
@@ -1,6 +1,7 @@
 import { EmptyRequest } from "@shared/proto/cline/common"
 import ClineLogoVariable from "@/assets/ClineLogoVariable"
 import HeroTooltip from "@/components/common/HeroTooltip"
+import { useExtensionState } from "@/context/ExtensionStateContext"
 import { UiServiceClient } from "@/services/grpc-client"
 
 interface HomeHeaderProps {
@@ -8,6 +9,8 @@ interface HomeHeaderProps {
 }
 
 const HomeHeader = ({ shouldShowQuickWins = false }: HomeHeaderProps) => {
+	const { environment } = useExtensionState()
+
 	const handleTakeATour = async () => {
 		try {
 			await UiServiceClient.openWalkthrough(EmptyRequest.create())
@@ -19,7 +22,7 @@ const HomeHeader = ({ shouldShowQuickWins = false }: HomeHeaderProps) => {
 	return (
 		<div className="flex flex-col items-center mb-5">
 			<div className="my-5">
-				<ClineLogoVariable className="size-16" />
+				<ClineLogoVariable className="size-16" environment={environment} />
 			</div>
 			<div className="text-center flex items-center justify-center">
 				<h2 className="m-0 text-lg">{"What can I do for you?"}</h2>

--- a/webview-ui/src/context/ExtensionStateContext.tsx
+++ b/webview-ui/src/context/ExtensionStateContext.tsx
@@ -14,6 +14,7 @@ import { convertProtoToClineMessage } from "@shared/proto-conversions/cline-mess
 import { convertProtoMcpServersToMcpServers } from "@shared/proto-conversions/mcp/mcp-server-conversion"
 import type React from "react"
 import { createContext, useCallback, useContext, useEffect, useRef, useState } from "react"
+import { Environment } from "../../../src/config"
 import {
 	basetenDefaultModelId,
 	basetenModels,
@@ -187,6 +188,7 @@ export const ExtensionStateContextProvider: React.FC<{
 		openaiReasoningEffort: "medium",
 		mode: "act",
 		platform: DEFAULT_PLATFORM,
+		environment: Environment.production,
 		telemetrySetting: "unset",
 		distinctId: "",
 		planActSeparateModelsSetting: true,

--- a/webview-ui/src/utils/environmentColors.ts
+++ b/webview-ui/src/utils/environmentColors.ts
@@ -1,0 +1,29 @@
+import type { Environment } from "../../../src/config"
+
+/**
+ * Gets the appropriate color for the current environment.
+ *
+ * Environment color scheme:
+ * - Local: Yellow/orange (warning color) - indicates development/experimental environment
+ * - Staging: Blue (focus border) - indicates stable testing environment
+ * - Production: Default VSCode colors - standard appearance
+ *
+ * @param environment - The current environment (local, staging, or production)
+ * @param type - The type of color needed: "primary" for text/fills, "border" for borders
+ * @returns CSS variable string for the appropriate environment color
+ */
+export const getEnvironmentColor = (environment: Environment | undefined, type: "primary" | "border" = "primary"): string => {
+	if (type === "border") {
+		return environment === "local"
+			? "var(--vscode-activityWarningBadge-background)" // Yellow/orange for local
+			: environment === "staging"
+				? "var(--vscode-focusBorder)" // Blue for staging
+				: "var(--vscode-editorGroup-border)" // Default for production
+	}
+
+	return environment === "local"
+		? "var(--vscode-activityWarningBadge-background)" // Yellow/orange for local
+		: environment === "staging"
+			? "var(--vscode-focusBorder)" // Blue for staging
+			: "var(--vscode-foreground)" // Default for production
+}


### PR DESCRIPTION
# PR Description: Add Visual Environment Indicators with Color Coding

## Motivation

As we encourage teammates to use the Staging environment for development work and QA partners for testing, we need a clear way to distinguish which environment is being used. This is especially important for:

- __Preventing confusion__ during development and testing workflows
- __Making environment always visible__ on screenshots and screen recordings for documentation and bug reports
- __Supporting QA partners__ who need to clearly identify which environment they're testing

## Solution

Implemented subtle color-coded visual indicators throughout the UI that change based on the current environment:

### Color Scheme

- __Local__: Yellow/Orange (warning badge color) - Signals development/experimental environment
- __Staging__: Blue (focus border color) - Signals stable testing environment
- __Production__: Default VSCode colors (gray/white) - Standard appearance (no changes should be visible)

### Visual Indicators Applied To:

1. __Cline Logo__ - On welcome/home screens
2. __Section Titles__ - Account, History, MCP Servers, Settings views
3. __Task Header Border__ - Active task card during conversations

The indicators are:

- ✅ Always visible but non-disruptive
- ✅ Maintain current UI formatting and layout
- ✅ Use existing VSCode theme variables for consistency
- ✅ Appear in screenshots and screen recordings

## Technical Implementation

### Core Changes

- `src/config.ts`: Added `environment` field to `EnvironmentConfig` interface
- `src/core/controller/index.ts`: Pass environment to webview state
- `src/shared/ExtensionMessage.ts`: Added `environment` to `ExtensionState`

### UI Changes

- __New utility__: `webview-ui/src/utils/environmentColors.ts`

  - Centralized color mapping logic
  - Supports "primary" (text/fills) and "border" color types
  - Single source of truth for environment colors

- __Updated components__ (6 files):

  - `ClineLogoVariable.tsx` - Dynamic logo coloring
  - `AccountView.tsx` - Title color indicator
  - `HistoryView.tsx` - Title color indicator
  - `McpConfigurationView.tsx` - Title color indicator
  - `SettingsView.tsx` - Title color indicator
  - `TaskHeader.tsx` - Border color indicator

## Testing

- Verify colors appear correctly in local, staging, and production environments
- Confirm colors work in both light and dark themes

## Benefits

- __Clarity__: Environment is immediately visible in any view
- __Safety__: Reduces risk of accidentally working in wrong environment
- __Documentation__: Screenshots automatically show environment context
- __Team Communication__: Easier to discuss issues when environment is visible
- __Maintainability__: Single utility function for all environment colors

### Type of Change

-   [X] 💅 Cosmetic Changes

### Screenshots (Staging environment indicator is ON)

<img width="626" height="1011" alt="image" src="https://github.com/user-attachments/assets/d7cb24c2-d41d-4cc8-b6fe-182b992c7f22" />
<img width="624" height="1009" alt="image" src="https://github.com/user-attachments/assets/d41d8444-5dab-41d8-84e8-8cdb51c16220" />
<img width="629" height="1014" alt="image" src="https://github.com/user-attachments/assets/6348d587-5a63-40c2-a520-37661a228e0f" />

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds environment-based color indicators to UI components to distinguish between local, staging, and production environments.
> 
>   - **Behavior**:
>     - Adds environment-based color indicators to UI components to distinguish between local, staging, and production environments.
>     - Uses yellow/orange for local, blue for staging, and default colors for production.
>   - **Core Changes**:
>     - `src/config.ts`: Adds `environment` field to `EnvironmentConfig`.
>     - `src/core/controller/index.ts`: Passes environment to webview state.
>     - `src/shared/ExtensionMessage.ts`: Adds `environment` to `ExtensionState`.
>   - **UI Changes**:
>     - `ClineLogoVariable.tsx`: Dynamic logo coloring based on environment.
>     - `AccountView.tsx`, `HistoryView.tsx`, `McpConfigurationView.tsx`, `SettingsView.tsx`, `TaskHeader.tsx`: Apply color indicators to titles and borders.
>     - `environmentColors.ts`: Utility for environment color mapping.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 9e251f6d38c354b4c49f5ea446f57d86e610bad8. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->