### PR TITLE
environment override

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -19,6 +19,11 @@ export interface EnvironmentConfig {
 }
 
 function getClineEnv(): Environment {
+	const _override = process?.env?.CLINE_ENVIRONMENT_OVERRIDE
+	if (_override && Object.values(Environment).includes(_override as Environment)) {
+		return _override as Environment
+	}
+
 	const _env = process?.env?.CLINE_ENVIRONMENT
 	if (_env && Object.values(Environment).includes(_env as Environment)) {
 		return _env as Environment


### PR DESCRIPTION
We need an easy way to switch VS Code estansion to Staging, even for builds from Marketplace:
- give QA an easy way to test pre-release features on Staging, with no cost ability to switch main<->staging for comparison, detecting regressions and testing backward compatibility
- engage Cline teammates to use Staging, for getting early signals
- free backend developers from requirements to build yet another component for testing everything locally (they have enough to build every iteration).

Right now switching to Staging or Local is possible only by compiling a local version, and there is no way to override it. 

That PR gives a way to run with the specific environment:
```
CLINE_ENVIRONMENT_OVERRIDE=staging code .   
```

## Testing

Completely stop VS Code, run `CLINE_ENVIRONMENT_OVERRIDE=staging code . `, try logout/login and see where you're redirected for authentication.

### Type of Change

-   [X] ✨ New feature (non-breaking change which adds functionality)


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds environment override feature using `CLINE_ENVIRONMENT_OVERRIDE` in `config.ts` to switch environments without recompiling.
> 
>   - **New Feature**:
>     - Adds environment override capability using `CLINE_ENVIRONMENT_OVERRIDE` in `getClineEnv()` in `config.ts`.
>     - Allows switching to `staging` or `local` without recompiling.
>   - **Testing**:
>     - Verified by stopping VS Code, setting `CLINE_ENVIRONMENT_OVERRIDE=staging`, and checking authentication redirection.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for beab61e9e3933e84a093d7590f0b27eaef8401f7. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->