### PR TITLE
ocd fetch config

### DIFF
--- a/src/core/controller/account/setUserOrganization.ts
+++ b/src/core/controller/account/setUserOrganization.ts
@@ -1,5 +1,6 @@
 import { UserOrganizationUpdateRequest } from "@shared/proto/cline/account"
 import { Empty } from "@shared/proto/cline/common"
+import { fetchRemoteConfig } from "@/core/storage/remote-config/fetch"
 import type { Controller } from "../index"
 
 /**
@@ -16,6 +17,12 @@ export async function setUserOrganization(controller: Controller, request: UserO
 
 		// Switch to the specified organization using the account service
 		await controller.accountService.switchAccount(request.organizationId)
+
+		try {
+			await fetchRemoteConfig(controller)
+		} catch (error) {
+			console.error("Failed to fetch remote config after org switch:", error)
+		}
 
 		return Empty.create({})
 	} catch (error) {

--- a/src/core/controller/index.ts
+++ b/src/core/controller/index.ts
@@ -230,6 +230,12 @@ export class Controller {
 		historyItem?: HistoryItem,
 		taskSettings?: Partial<Settings>,
 	) {
+		try {
+			await fetchRemoteConfig(this)
+		} catch (error) {
+			console.error("Failed to fetch remote config on task init:", error)
+		}
+
 		await this.clearTask() // ensures that an existing task doesn't exist before starting a new one, although this shouldn't be possible since user must clear task before starting a new one
 
 		const autoApprovalSettings = this.stateManager.getGlobalSettingsKey("autoApprovalSettings")


### PR DESCRIPTION

### Description

Fetch on key events like org switch and task start/resume

### Test Procedure

Check that it fetches at those times.

e.g. switch from personal to org and back

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fetch remote configuration on organization switch and task initialization, with error logging on failure.
> 
>   - **Behavior**:
>     - Fetch remote config on organization switch in `setUserOrganization`.
>     - Fetch remote config on task initialization in `initTask`.
>   - **Error Handling**:
>     - Logs error to console if fetching remote config fails in both `setUserOrganization` and `initTask`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 3214649ea2465f32e3094165789242c7d96a6950. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->