### PR TITLE
Update flakey test for getOpenTabs

### DIFF
--- a/src/hosts/vscode/hostbridge/window/getOpenTabs.test.ts
+++ b/src/hosts/vscode/hostbridge/window/getOpenTabs.test.ts
@@ -9,11 +9,11 @@ import { getOpenTabs } from "@/hosts/vscode/hostbridge/window/getOpenTabs"
 import { GetOpenTabsRequest } from "@/shared/proto/host/window"
 
 describe("Hostbridge - Window - getOpenTabs", () => {
-	async function createAndOpenTestDocument(fileNumber: number, column: vscode.ViewColumn): Promise<void> {
-		const content = `// Test file ${fileNumber}\nconsole.log('Hello from file ${fileNumber}');`
+	async function createAndOpenTestDocument(name: string, column: vscode.ViewColumn): Promise<void> {
+		const content = `// Test file ${name}\nconsole.log('Hello from file ${name}');`
 
 		// Create an untitled document with a custom name
-		const uri = vscode.Uri.parse(`untitled:test-file-${fileNumber}.js`)
+		const uri = vscode.Uri.parse(`untitled:test-file-${name}.js`)
 
 		const doc = await vscode.workspace.openTextDocument(uri)
 
@@ -54,8 +54,8 @@ describe("Hostbridge - Window - getOpenTabs", () => {
 
 	it("should return paths of open text document tabs", async () => {
 		// Open the documents in editors (this creates the tabs)
-		await createAndOpenTestDocument(1, vscode.ViewColumn.One)
-		await createAndOpenTestDocument(2, vscode.ViewColumn.Two)
+		await createAndOpenTestDocument("open-tabs-1", vscode.ViewColumn.One)
+		await createAndOpenTestDocument("open-tabs-2", vscode.ViewColumn.Two)
 
 		// Wait for tabs to be fully created
 		await pWaitFor(
@@ -86,9 +86,9 @@ describe("Hostbridge - Window - getOpenTabs", () => {
 
 	it("should return all open tabs even when multiple files are opened in the same ViewColumn", async () => {
 		// Open all documents in the same column (only the last one will be visible, but all are open as tabs)
-		await createAndOpenTestDocument(1, vscode.ViewColumn.One)
-		await createAndOpenTestDocument(2, vscode.ViewColumn.One)
-		await createAndOpenTestDocument(3, vscode.ViewColumn.One)
+		await createAndOpenTestDocument("same-column-1", vscode.ViewColumn.One)
+		await createAndOpenTestDocument("same-column-2", vscode.ViewColumn.One)
+		await createAndOpenTestDocument("same-column-3", vscode.ViewColumn.One)
 
 		// Wait for tabs to be fully created
 		await pWaitFor(
@@ -128,7 +128,7 @@ describe("Hostbridge - Window - getOpenTabs", () => {
 		await vscode.window.showTextDocument(document, { preview: false })
 
 		// Also open an untitled document
-		await createAndOpenTestDocument(1, vscode.ViewColumn.One)
+		await createAndOpenTestDocument("includes-deleted", vscode.ViewColumn.One)
 
 		// Wait for tabs to be created
 		await pWaitFor(
@@ -161,7 +161,7 @@ describe("Hostbridge - Window - getOpenTabs", () => {
 		)
 		try {
 			// Clean up temp directory
-			await fs.rmdir(tempDir, { recursive: true })
+			await fs.rm(tempDir, { recursive: true })
 		} catch (error) {
 			console.error(error)
 		}


### PR DESCRIPTION
From the output of this run, it looks like that tabs are not resetting properly in between test runs. Make the file names unique per test so this is easier to debug.
https://github.com/cline/cline/actions/runs/18479896861/job/52652420536#step:12:802
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `getOpenTabs.test.ts` to use unique file names for tests and improve directory cleanup.
> 
>   - **Tests**:
>     - Update `createAndOpenTestDocument` in `getOpenTabs.test.ts` to use unique file names per test (e.g., "open-tabs-1", "same-column-1").
>     - Modify test cases to reflect new naming convention for better debugging.
>   - **Misc**:
>     - Replace `fs.rmdir` with `fs.rm` for directory cleanup in `getOpenTabs.test.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 205934a59cda692061443d946388b7ce53606fe1. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->