### PR TITLE
Fix deprecation warning

### DIFF
--- a/src/hosts/vscode/hostbridge/window/getVisibleTabs.test.ts
+++ b/src/hosts/vscode/hostbridge/window/getVisibleTabs.test.ts
@@ -186,6 +186,6 @@ describe("Hostbridge - Window - getVisibleTabs", () => {
 		)
 
 		// Clean up temp directory
-		await fs.rmdir(tempDir, { recursive: true }).catch(() => {})
+		await fs.rm(tempDir, { recursive: true }).catch(() => {})
 	})
 })


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Replace `fs.rmdir` with `fs.rm` in `getVisibleTabs.test.ts` to fix deprecation warning.
> 
>   - **Deprecation Fix**:
>     - Replace `fs.rmdir` with `fs.rm` in `getVisibleTabs.test.ts` to address deprecation warning for recursive directory removal.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 2e401ddb77bf6ad5d63f29a1f789612478f123d4. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->