### PR TITLE
Checkpoints & Task Locking in cline-core

### DIFF
--- a/.changeset/floppy-worms-repair.md
+++ b/.changeset/floppy-worms-repair.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Added folder locking, task locking, and checkpoints locking to cline-core

--- a/src/core/locks/FolderLockUtils.ts
+++ b/src/core/locks/FolderLockUtils.ts
@@ -1,0 +1,179 @@
+import type { SqliteLockManager } from "./SqliteLockManager"
+import type { FolderLockOptions, FolderLockResult, FolderLockWithRetryResult } from "./types"
+
+/**
+ * Retry configuration for folder lock acquisition
+ */
+export interface FolderLockRetryConfig {
+	initialDelayMs: number
+	incrementPerAttemptMs: number
+	maxTotalTimeoutMs: number
+}
+
+/**
+ * Default retry configuration for folder locks:
+ * - 500ms initial wait - this is typically enough for most cases
+ * - +1s backoff per attempt
+ * - 30s max total timeout
+ */
+export const DEFAULT_RETRY_CONFIG: FolderLockRetryConfig = {
+	initialDelayMs: 500,
+	incrementPerAttemptMs: 1000,
+	maxTotalTimeoutMs: 30000,
+}
+
+/**
+ * Get the lock manager instance for standalone mode.
+ */
+export async function getStandaloneLockManager(): Promise<SqliteLockManager | undefined> {
+	try {
+		const { getLockManager } = await import("../../standalone/lock-manager")
+		return getLockManager()
+	} catch (_importError) {
+		console.debug("Lock manager not available")
+		return undefined
+	}
+}
+
+/**
+ * Attempt to acquire a folder lock with retry logic.
+ * This is a generic utility that works with any folder path.
+ *
+ * @param lockTarget - The folder path to lock
+ * @param config - Optional retry configuration if defaults are not suitable
+ * @returns Promise<boolean> true if lock acquired, false if timeout
+ */
+export async function tryAcquireFolderLockWithRetry(
+	options: FolderLockOptions,
+	config?: FolderLockRetryConfig,
+): Promise<FolderLockWithRetryResult> {
+	return await retryFolderLockAcquisition(async () => {
+		try {
+			const lockManager = await getStandaloneLockManager()
+
+			if (!lockManager) {
+				console.debug("Lock manager not available - skipping lock acquisition")
+				return { acquired: false, skipped: true }
+			}
+
+			console.log(`Attempting to acquire folder lock for: ${options.lockTarget}`)
+
+			const result = await acquireFolderLock(options)
+
+
+			return { acquired: result.acquired, conflictingLock: result.conflictingLock, skipped: false }
+		} catch (error) {
+			console.error("Error in folder lock acquisition attempt:", error)
+			return { acquired: false }
+		}
+	}, config)
+}
+
+/**
+ * Release a folder lock safely with error handling.
+ * This is a generic utility that works with any folder path.
+ *
+ * @param lockTarget - The folder path to release
+ */
+export async function releaseFolderLock(taskId: string, lockTarget: string): Promise<void> {
+	try {
+		const lockManager = await getStandaloneLockManager()
+
+		if (!lockManager) {
+			console.debug("Lock manager not available - skipping lock release")
+			return
+		}
+
+		await lockManager.releaseFolderLockByTarget(taskId, lockTarget)
+		console.log(`Released folder lock for: ${lockTarget}`)
+	} catch (error) {
+		console.error("Error releasing folder lock:", error)
+	}
+}
+
+/**
+ * Acquire a folder lock with no retry
+ * @param options - Folder lock options including heldBy
+ * @returns Result indicating if lock was acquired and any conflicting lock
+ */
+export async function acquireFolderLock(options: FolderLockOptions): Promise<FolderLockResult> {
+	const lockManager = await getStandaloneLockManager()
+
+	if (!lockManager) {
+		console.debug("Lock manager not available - cannot acquire folder lock")
+		return { acquired: false }
+	}
+
+	try {
+		const conflictingLock = await lockManager.registerFolderLock(options.heldBy, options.lockTarget)
+
+		if (conflictingLock === null) {
+			// Lock was successfully acquired
+			return { acquired: true }
+		} else {
+			// Lock already exists, return the conflicting lock
+			return {
+				acquired: false,
+				conflictingLock,
+			}
+		}
+	} catch (error) {
+		console.error("Failed to acquire folder lock:", error)
+		return { acquired: false }
+	}
+}
+
+/**
+ * Retry a folder lock acquisition with exponential backoff.
+ * @param operation - Function that attempts to acquire the lock
+ * @param config - Optional retry configuration, uses defaults if not provided
+ * @returns Promise that resolves with acquisition status and details
+ */
+export async function retryFolderLockAcquisition(
+	operation: () => Promise<FolderLockWithRetryResult>,
+	config: FolderLockRetryConfig = DEFAULT_RETRY_CONFIG,
+): Promise<FolderLockWithRetryResult> {
+	const startTime = Date.now()
+	let attemptCount = 0
+	let lastResult: FolderLockWithRetryResult | undefined
+
+	while (true) {
+		const elapsedTime = Date.now() - startTime
+
+		// Retries = check timeout before starting next attempt
+		if (elapsedTime >= config.maxTotalTimeoutMs) {
+			console.warn(`Folder lock acquisition timed out after ${config.maxTotalTimeoutMs}ms`)
+			return lastResult || { acquired: false }
+		}
+
+		// Attempt lock acquisition
+		try {
+			const result = await operation()
+			lastResult = result
+
+			// Return immediately if skipped or acquired
+			if (result.skipped || result.acquired) {
+				if (result.acquired && attemptCount > 0) {
+					console.debug(`Folder lock acquired after ${attemptCount + 1} attempts (${elapsedTime}ms)`)
+				}
+				return result
+			}
+		} catch (error) {
+			console.error(`Error during folder lock acquisition attempt ${attemptCount + 1}:`, error)
+		}
+
+		// Prep for next attempt
+		attemptCount++
+		const baseDelay = config.initialDelayMs + attemptCount * config.incrementPerAttemptMs
+		const remainingTime = config.maxTotalTimeoutMs - (Date.now() - startTime)
+		const delay = Math.min(baseDelay, Math.max(0, remainingTime))
+
+		if (delay <= 0) {
+			console.warn(`Folder lock acquisition timed out after ${config.maxTotalTimeoutMs}ms`)
+			return lastResult || { acquired: false }
+		}
+
+		console.log(`Folder lock held by another instance, retrying in ${delay}ms (attempt ${attemptCount})`)
+		await new Promise((resolve) => setTimeout(resolve, delay))
+	}
+}

--- a/src/core/locks/types.ts
+++ b/src/core/locks/types.ts
@@ -12,3 +12,19 @@ export interface SqliteLockManagerOptions {
 	dbPath: string
 	instanceAddress: string // cline core address
 }
+
+export interface FolderLockOptions {
+	lockTarget: string // The cwdHash of the folder to lock
+	heldBy: string // taskId of the locking task
+}
+
+export interface FolderLockResult {
+	acquired: boolean // success or failure
+	conflictingLock?: LockRow // conflicting lock if available
+}
+
+export interface FolderLockWithRetryResult {
+	acquired: boolean // success or failure
+	skipped?: boolean // lock attempt was skipped (VS Code expected behavior)
+	conflictingLock?: LockRow // conflicting lock if available
+}

--- a/src/core/task/TaskLockUtils.ts
+++ b/src/core/task/TaskLockUtils.ts
@@ -1,0 +1,36 @@
+import { releaseFolderLock, tryAcquireFolderLockWithRetry } from "@/core/locks/FolderLockUtils"
+import type { FolderLockOptions, FolderLockWithRetryResult } from "@/core/locks/types"
+
+/**
+ * Base path for task folders
+ */
+const TASKS_BASE_PATH = "~/.cline/data/tasks"
+
+/**
+ * Attempt to acquire task folder lock with retry logic.
+ * This is a convenience wrapper around the generic folder lock utility
+ * that uses the taskId as the lock target.
+ *
+ * @param taskId - The unique identifier for the task
+ * @returns Promise<FolderLockWithRetryResult> with acquisition status and any conflicting lock info
+ */
+export async function tryAcquireTaskLockWithRetry(taskId: string): Promise<FolderLockWithRetryResult> {
+	const options: FolderLockOptions = {
+		lockTarget: `${TASKS_BASE_PATH}/${taskId}`,
+		heldBy: taskId, // will be automatically swapped for instance address in SqliteLockManager
+	}
+
+	const result = await tryAcquireFolderLockWithRetry(options)
+	return { acquired: result.acquired, skipped: result.skipped, conflictingLock: result.conflictingLock }
+}
+
+/**
+ * Release task folder lock safely.
+ * This is a convenience wrapper around the generic folder lock utility
+ * that uses the taskId as the lock target.
+ *
+ * @param taskId - The unique identifier for the task
+ */
+export async function releaseTaskLock(taskId: string): Promise<void> {
+	await releaseFolderLock(taskId, `${TASKS_BASE_PATH}/${taskId}`)
+}

--- a/src/core/task/index.ts
+++ b/src/core/task/index.ts
@@ -31,6 +31,7 @@ import {
 	getSavedApiConversationHistory,
 	getSavedClineMessages,
 } from "@core/storage/disk"
+import { releaseTaskLock } from "@core/task/TaskLockUtils"
 import { isMultiRootEnabled } from "@core/workspace/multi-root-utils"
 import { WorkspaceRootManager } from "@core/workspace/WorkspaceRootManager"
 import { buildCheckpointManager, shouldUseMultiRoot } from "@integrations/checkpoints/factory"
@@ -104,6 +105,7 @@ type TaskParams = {
 	files?: string[]
 	historyItem?: HistoryItem
 	taskId: string
+	taskLockAcquired: boolean
 }
 
 export class Task {
@@ -153,6 +155,9 @@ export class Task {
 	// Workspace manager
 	workspaceManager?: WorkspaceRootManager
 
+	// Task Locking (Sqlite)
+	private taskLockAcquired: boolean
+
 	constructor(params: TaskParams) {
 		const {
 			controller,
@@ -173,6 +178,7 @@ export class Task {
 			files,
 			historyItem,
 			taskId,
+			taskLockAcquired,
 		} = params
 
 		this.taskInitializationStartTime = performance.now()
@@ -184,6 +190,7 @@ export class Task {
 		this.reinitExistingTaskFromId = reinitExistingTaskFromId
 		this.cancelTask = cancelTask
 		this.clineIgnoreController = new ClineIgnoreController(cwd)
+		this.taskLockAcquired = taskLockAcquired
 
 		// TODO(ae) this is a hack to replace the terminal manager for standalone,
 		// until we have proper host bridge support for terminal execution. The
@@ -934,24 +941,37 @@ export class Task {
 	}
 
 	async abortTask() {
-		// Check for incomplete progress before aborting
-		if (this.FocusChainManager) {
-			this.FocusChainManager.checkIncompleteProgressOnCompletion()
-		}
+		try {
+			// Check for incomplete progress before aborting
+			if (this.FocusChainManager) {
+				this.FocusChainManager.checkIncompleteProgressOnCompletion()
+			}
 
-		this.taskState.abort = true // will stop any autonomously running promises
-		this.terminalManager.disposeAll()
-		this.urlContentFetcher.closeBrowser()
-		await this.browserSession.dispose()
-		this.clineIgnoreController.dispose()
-		this.fileContextTracker.dispose()
-		// need to await for when we want to make sure directories/files are reverted before
-		// re-starting the task from a checkpoint
-		await this.diffViewProvider.revertChanges()
-		// Clear the notification callback when task is aborted
-		this.mcpHub.clearNotificationCallback()
-		if (this.FocusChainManager) {
-			this.FocusChainManager.dispose()
+			this.taskState.abort = true // will stop any autonomously running promises
+			this.terminalManager.disposeAll()
+			this.urlContentFetcher.closeBrowser()
+			await this.browserSession.dispose()
+			this.clineIgnoreController.dispose()
+			this.fileContextTracker.dispose()
+			// need to await for when we want to make sure directories/files are reverted before
+			// re-starting the task from a checkpoint
+			await this.diffViewProvider.revertChanges()
+			// Clear the notification callback when task is aborted
+			this.mcpHub.clearNotificationCallback()
+			if (this.FocusChainManager) {
+				this.FocusChainManager.dispose()
+			}
+		} finally {
+			// Release task folder lock
+			if (this.taskLockAcquired) {
+				try {
+					await releaseTaskLock(this.taskId)
+					this.taskLockAcquired = false
+					console.info(`[Task ${this.taskId}] Task lock released`)
+				} catch (error) {
+					console.error(`[Task ${this.taskId}] Failed to release task lock:`, error)
+				}
+			}
 		}
 	}
 

--- a/src/integrations/checkpoints/CheckpointLockUtils.ts
+++ b/src/integrations/checkpoints/CheckpointLockUtils.ts
@@ -1,0 +1,37 @@
+import { releaseFolderLock, tryAcquireFolderLockWithRetry } from "@/core/locks/FolderLockUtils"
+import type { FolderLockOptions, FolderLockWithRetryResult } from "@/core/locks/types"
+
+/**
+ * Base path for checkpoint folders
+ */
+const CHECKPOINTS_BASE_PATH = "~/.cline/data/checkpoints"
+
+/**
+ * Attempt to acquire checkpoint folder lock with retry logic.
+ * This is a convenience wrapper around the generic folder lock utility
+ * that automatically derives the correct folder path from the cwdHash.
+ *
+ * @param cwdHash - The hash of the working directory
+ * @param taskId - The task ID (swapped to instance address in SqliteLockManager)
+ * @returns Promise<FolderLockWithRetryResult> with acquisition status and any conflicting lock info
+ */
+export async function tryAcquireCheckpointLockWithRetry(cwdHash: string, taskId: string): Promise<FolderLockWithRetryResult> {
+	const options: FolderLockOptions = {
+		lockTarget: `${CHECKPOINTS_BASE_PATH}/${cwdHash}`,
+		heldBy: taskId,
+	}
+
+	const result = await tryAcquireFolderLockWithRetry(options)
+	return { acquired: result.acquired, skipped: result.skipped, conflictingLock: result.conflictingLock }
+}
+
+/**
+ * Release checkpoint folder lock safely.
+ * This is a convenience wrapper around the generic folder lock utility
+ * that automatically derives the correct folder path from the cwdHash.
+ *
+ * @param cwdHash - The hash of the working directory
+ */
+export async function releaseCheckpointLock(cwdHash: string, taskId: string): Promise<void> {
+	await releaseFolderLock(taskId, `${CHECKPOINTS_BASE_PATH}/${cwdHash}`)
+}

--- a/src/standalone/cline-core.ts
+++ b/src/standalone/cline-core.ts
@@ -10,6 +10,7 @@ import { AuthHandler } from "@/hosts/external/AuthHandler"
 import { HostProvider } from "@/hosts/host-provider"
 import { DiffViewProvider } from "@/integrations/editor/DiffViewProvider"
 import { HOSTBRIDGE_PORT, waitForHostBridgeReady } from "./hostbridge-client"
+import { setLockManager } from "./lock-manager"
 import { PROTOBUS_PORT, startProtobusService } from "./protobus-service"
 import { log } from "./utils"
 import { initializeContext } from "./vscode-context"
@@ -70,10 +71,16 @@ async function main() {
 			instanceAddress: protobusAddress,
 		})
 
+		// Make lock manager available to other modules
+		setLockManager(globalLockManager)
+
 		await globalLockManager.registerInstance({
 			hostAddress,
 		})
 		log(`Registered instance in SQLite locks: ${protobusAddress}`)
+
+		// Clean up any orphaned folder locks from dead instances
+		globalLockManager.cleanupOrphanedFolderLocks()
 
 		// Mark instance healthy after services are up
 		globalLockManager.touchInstance()
@@ -192,7 +199,10 @@ async function shutdownGracefully(lockManager?: SqliteLockManager) {
 		// Step 2: Clean up lock manager entry
 		log("Cleaning up lock manager entry...")
 		try {
+			// First unregister the instance
 			lockManager?.unregisterInstance()
+			// Then clean up any folder locks held by this instance
+			lockManager?.cleanupOrphanedFolderLocks()
 			lockManager?.close()
 			log("Lock manager entry cleaned up successfully")
 		} catch (error) {

--- a/src/standalone/lock-manager.ts
+++ b/src/standalone/lock-manager.ts
@@ -1,0 +1,24 @@
+import type { SqliteLockManager } from "@/core/locks/SqliteLockManager"
+
+/**
+ * Module-level reference to the SqliteLockManager instance.
+ * This is set by cline-core and accessed by folder lock utilities.
+ */
+let lockManagerInstance: SqliteLockManager | undefined
+
+/**
+ * Get the SqliteLockManager instance for use in standalone mode.
+ * @returns The SqliteLockManager instance, or undefined if not initialized
+ */
+export function getLockManager(): SqliteLockManager | undefined {
+	return lockManagerInstance
+}
+
+/**
+ * Set the SqliteLockManager instance after it has been created.
+ * This is called by cline-core when the lock manager is initialized.
+ * @param lockManager - The SqliteLockManager instance to set
+ */
+export function setLockManager(lockManager: SqliteLockManager): void {
+	lockManagerInstance = lockManager
+}


### PR DESCRIPTION
### Description

This PR implements folder locking for both the Checkpoint system and Task management in cline-core to prevent race conditions when multiple cline-core instances operate on shared resources. The implementation adds folder lock support to the existing SQLite lock registry, which uses a unified schema tracking instance, folder, and file locks with UNIQUE constraints on (`lock_type`, `lock_target`).

__Checkpoint Locking__: `CheckpointTracker` operations (commit and resetHead) acquire a folder lock using the workspace's cline-core checkpoints path as the lock target before performing git operations on the shadow repository.

__Task Locking__: Tasks acquire a folder lock using the cline-core task path as the lock target during initialization in `Controller.initTask()`, preventing multiple instances from running the same task concurrently. The lock is released in `Task.abortTask() `within a finally block to ensure cleanup even under failure conditions.

Both implementations use a retry mechanism with 500ms initial delay, 1s incremental backoff, and 30s total timeout, configurable via const `DEFAULT_RETRY_CONFIG: FolderLockRetryConfig` in `FolderLockUtils`.


The system handles several operational scenarios:
- VS Code mode bypasses locking entirely (lock manager unavailable), tasks and checkpoints can re-acquire their own locks without blocking, and database initialization uses file-based locking with stale detection to prevent concurrent lock creation.
- The lock manager is exposed through a module-level singleton (`lock-manager.ts`) initialized at cline-core startup, and orphaned folder locks are cleaned up at both startup and shutdown by querying for locks whose held_by value doesn't exist in the instance registry.
- Retry logic uses existing `Atomics.wait()` for synchronous sleep during initialization and async `setTimeout()` delays during checkpoint and task operations, with timeout checks before each retry attempt. Lock cleanups on startup and shutdown ensure availability even under partial failures.
- Lock cleanups on startup and shutdown to ensure availability even under partial failures.

### Test Procedure
```
npm run compile-standalone
npm run compile-cli

```
Run this command while starting a cline-cli task, observe the folder locks that appear/disappear when the task is started and checkpoint operations occur:
`while true; do clear; echo "$(date '+%H:%M:%S.%3N')"; sqlite3 ~/.cline/data/locks.db "SELECT * FROM locks" -header -column; sleep 0.1; done`

When closing the task, all locks should be cleared. If you manage to get locks to persist (kill all cline processes etc), then when the next instance starts it should clean up the remaining task/checkpoint/folder locks.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [X] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [X] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [X] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [X] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [X] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

https://github.com/user-attachments/assets/3fce61e0-ecb0-4bce-83a9-d1514e3a1eb4


### Additional Notes


<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Introduces folder locking in cline-core to prevent race conditions, with task and checkpoint locks managed via SQLite and retry logic.
> 
>   - **Folder Locking**:
>     - Implements folder locking in `SqliteLockManager` with methods `registerFolderLock`, `releaseFolderLockByTarget`, and `cleanupOrphanedFolderLocks`.
>     - Adds retry logic for lock acquisition in `FolderLockUtils` with `tryAcquireFolderLockWithRetry()` and `retryFolderLockAcquisition()`.
>   - **Task Locking**:
>     - `Controller.initTask()` acquires a task lock using `tryAcquireTaskLockWithRetry()` from `TaskLockUtils`.
>     - `Task.abortTask()` releases the task lock using `releaseTaskLock()`.
>   - **Checkpoint Locking**:
>     - `CheckpointTracker.commit()` and `resetHead()` acquire and release checkpoint locks using `tryAcquireCheckpointLockWithRetry()` and `releaseCheckpointLock()` from `CheckpointLockUtils`.
>   - **Miscellaneous**:
>     - Adds `FolderLockOptions`, `FolderLockResult`, and `FolderLockWithRetryResult` types in `types.ts`.
>     - Initializes lock manager in `cline-core.ts` and exposes it via `lock-manager.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 7b8c53c257334e49023db747878b407b43bc0d9e. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->