### PR TITLE
remote config - fix telemetry toggle not displaying properly

### DIFF
--- a/webview-ui/src/components/settings/sections/GeneralSettingsSection.tsx
+++ b/webview-ui/src/components/settings/sections/GeneralSettingsSection.tsx
@@ -11,7 +11,7 @@ interface GeneralSettingsSectionProps {
 
 const GeneralSettingsSection = ({ renderSectionHeader }: GeneralSettingsSectionProps) => {
 	const { telemetrySetting, remoteConfigSettings } = useExtensionState()
-	const isDisabledByRemoteConfig = remoteConfigSettings?.telemetrySetting === "disabled"
+	const isDisabledByRemoteConfig = remoteConfigSettings?.telemetrySetting !== undefined
 
 	return (
 		<div>
@@ -24,7 +24,7 @@ const GeneralSettingsSection = ({ renderSectionHeader }: GeneralSettingsSectionP
 						<HeroTooltip content="This setting is managed by your organization's remote configuration">
 							<div className="flex items-center gap-2 mb-[5px]">
 								<VSCodeCheckbox
-									checked={telemetrySetting !== "disabled"}
+									checked={remoteConfigSettings?.telemetrySetting === "enabled"}
 									disabled={true}
 									onChange={(e: any) => {
 										const checked = e.target.checked === true
@@ -37,7 +37,7 @@ const GeneralSettingsSection = ({ renderSectionHeader }: GeneralSettingsSectionP
 						</HeroTooltip>
 					) : (
 						<VSCodeCheckbox
-							checked={telemetrySetting !== "disabled"}
+							checked={telemetrySetting === "enabled"}
 							className="mb-[5px]"
 							disabled={false}
 							onChange={(e: any) => {


### PR DESCRIPTION

### Description

Fix toggle not corresponding to value

### Test Procedure

Test all three states of the toggle.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes telemetry toggle display in `GeneralSettingsSection` to correctly reflect remote configuration settings.
> 
>   - **Bug Fix**:
>     - Fixes telemetry toggle display in `GeneralSettingsSection` by checking `remoteConfigSettings?.telemetrySetting` for `enabled` state.
>     - Updates `isDisabledByRemoteConfig` to check if `telemetrySetting` is defined instead of checking for "disabled".
>   - **UI**:
>     - Ensures `VSCodeCheckbox` reflects correct telemetry state based on remote config.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 13359c0775812bf0eed8142ee8d254acf3719015. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

fixes PF-146

<!-- ELLIPSIS_HIDDEN -->