### PR TITLE
filter out empty string values from remote config

### DIFF
--- a/src/core/storage/remote-config/utils.ts
+++ b/src/core/storage/remote-config/utils.ts
@@ -30,13 +30,20 @@ export function transformRemoteConfigToStateShape(remoteConfig: RemoteConfig): P
 		transformed.planModeApiProvider = "openai"
 		transformed.actModeApiProvider = "openai"
 
-		if (openAiSettings.openAiBaseUrl !== undefined) {
+		if (openAiSettings.openAiBaseUrl !== undefined && openAiSettings.openAiBaseUrl !== "") {
 			transformed.openAiBaseUrl = openAiSettings.openAiBaseUrl
 		}
 		if (openAiSettings.openAiHeaders !== undefined) {
-			transformed.openAiHeaders = openAiSettings.openAiHeaders
+			// Filter out empty string values from headers
+			const filteredHeaders = Object.fromEntries(
+				Object.entries(openAiSettings.openAiHeaders).filter(([_, value]) => value !== ""),
+			)
+			// Only set if there are any non-empty headers
+			if (Object.keys(filteredHeaders).length > 0) {
+				transformed.openAiHeaders = filteredHeaders
+			}
 		}
-		if (openAiSettings.azureApiVersion !== undefined) {
+		if (openAiSettings.azureApiVersion !== undefined && openAiSettings.azureApiVersion !== "") {
 			transformed.azureApiVersion = openAiSettings.azureApiVersion
 		}
 	}
@@ -47,7 +54,7 @@ export function transformRemoteConfigToStateShape(remoteConfig: RemoteConfig): P
 		transformed.planModeApiProvider = "bedrock"
 		transformed.actModeApiProvider = "bedrock"
 
-		if (awsBedrockSettings.awsRegion !== undefined) {
+		if (awsBedrockSettings.awsRegion !== undefined && awsBedrockSettings.awsRegion !== "") {
 			transformed.awsRegion = awsBedrockSettings.awsRegion
 		}
 		if (awsBedrockSettings.awsUseCrossRegionInference !== undefined) {
@@ -59,7 +66,7 @@ export function transformRemoteConfigToStateShape(remoteConfig: RemoteConfig): P
 		if (awsBedrockSettings.awsBedrockUsePromptCache !== undefined) {
 			transformed.awsBedrockUsePromptCache = awsBedrockSettings.awsBedrockUsePromptCache
 		}
-		if (awsBedrockSettings.awsBedrockEndpoint !== undefined) {
+		if (awsBedrockSettings.awsBedrockEndpoint !== undefined && awsBedrockSettings.awsBedrockEndpoint !== "") {
 			transformed.awsBedrockEndpoint = awsBedrockSettings.awsBedrockEndpoint
 		}
 	}


### PR DESCRIPTION


### Description

Do not set remote config settings in the extension for string values that are empty strings. 

### Test Procedure

Test setting a string field to empty in the remote config. 

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Filter out empty string values from remote config settings in `transformRemoteConfigToStateShape` in `utils.ts`.
> 
>   - **Behavior**:
>     - In `transformRemoteConfigToStateShape` in `utils.ts`, filter out empty string values from `openAiBaseUrl`, `openAiHeaders`, `azureApiVersion`, `awsRegion`, and `awsBedrockEndpoint`.
>     - Only set `openAiHeaders` if non-empty after filtering.
>   - **Misc**:
>     - Update logic to ensure only non-empty string values are set in the transformed state.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 4ef3f7552c925b9cef2cecf456ac8df5ec343b54. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->