### PR TITLE
Fix: cline provider auth should print url in case it doesn't auto-open

### DIFF
--- a/cli/pkg/cli/auth/auth_cline_provider.go
+++ b/cli/pkg/cli/auth/auth_cline_provider.go
@@ -109,13 +109,16 @@ func signIn(ctx context.Context) error {
 		return fmt.Errorf("failed to obtain client: %w", err)
 	}
 
-	_, err = client.Account.AccountLoginClicked(ctx, &cline.EmptyRequest{})
+	response, err := client.Account.AccountLoginClicked(ctx, &cline.EmptyRequest{})
 	if err != nil {
 		verboseLog("Failed to initiate login: %v", err)
 		return fmt.Errorf("failed to initiate login: %w", err)
 	}
 
 	fmt.Println("\n  Opening browser for authentication...")
+	if response != nil && response.Value != "" {
+		fmt.Printf("  If the browser doesn't open automatically, visit this URL:\n  %s\n\n", response.Value)
+	}
 	fmt.Println("  Waiting for you to complete authentication in your browser...")
 	fmt.Println("   (This may take a few moments. Timeout: 5 minutes)")
 

--- a/scripts/build-cli-all-platforms.sh
+++ b/scripts/build-cli-all-platforms.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -eux
+set -eu
 
 npm run protos
 npm run protos-go

--- a/scripts/build-cli.sh
+++ b/scripts/build-cli.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -eux
+set -eu
 
 npm run protos
 npm run protos-go


### PR DESCRIPTION
### Description

When doing `cline auth` with the cline provider, print the URL on stdout so that in case cline fails to open the browser automatically, the user still can:

  Opening browser for authentication...
  If the browser doesn't open automatically, visit this URL:
  https://app.cline.bot/auth?callback_url=http%3A%2F%2F127.0.0.1%3A48801%2Fauth

  Waiting for you to complete authentication in your browser...
   (This may take a few moments. Timeout: 5 minutes)


### Test Procedure

use `cline auth` with cline provider & instead of using the automatically opened page, copy-paste the URL

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes `cline auth` to print URL if browser fails to open automatically and reduces verbosity in build scripts.
> 
>   - **Behavior**:
>     - In `auth_cline_provider.go`, `signIn()` now prints the authentication URL if the browser fails to open automatically.
>   - **Scripts**:
>     - Remove `-x` flag from `set -eux` to `set -eu` in `build-cli-all-platforms.sh` and `build-cli.sh` to reduce verbosity.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for ce962be707ffa9d3e47c5e4234325ef798347330. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->