### PR TITLE
fix piping stdin into cline

### DIFF
--- a/cli/man/cline.1
+++ b/cli/man/cline.1
@@ -9,6 +9,8 @@ cline \- orchestrate and interact with Cline AI coding agents
 \f[B]cline\f[R] \f[I]command\f[R] [\f[I]subcommand\f[R]]
 [\f[I]options\f[R]] [\f[I]arguments\f[R]]
 .SH DESCRIPTION
+Try: cat README.md | cline \(lqSummarize this for me:\(rq
+.PP
 \f[B]cline\f[R] is a command\-line interface for orchestrating multiple
 Cline AI coding agents.
 Cline is an autonomous AI agent who can read, write, and execute code

--- a/cli/man/cline.1.md
+++ b/cli/man/cline.1.md
@@ -18,6 +18,8 @@ cline - orchestrate and interact with Cline AI coding agents
 
 # DESCRIPTION
 
+Try: cat README.md | cline "Summarize this for me:"
+
 **cline** is a command-line interface for orchestrating multiple Cline AI coding agents. Cline is an autonomous AI agent who can read, write, and execute code across your projects. He operates through a client-server architecture where **Cline Core** runs as a standalone service, and the CLI acts as a scriptable interface for managing tasks, instances, and agent interactions.
 
 The CLI is designed for both interactive use and automation, making it ideal for CI/CD pipelines, parallel task execution, and terminal-based workflows. Multiple frontends (CLI, VSCode, JetBrains) can attach to the same Cline Core instance, enabling seamless task handoff between environments.


### PR DESCRIPTION
### Description

Now you can do this:

cat LICENSE | cline "Tell me about this project's license: "

And it concatenates whatever is piped to the starting prompt

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> The PR adds support for piping stdin into the `cline` command, allowing input from both stdin and command line arguments, with updates to `main.go`, `cline.1`, and `cline.1.md`.
> 
>   - **Behavior**:
>     - `cline` command now supports piping input from stdin, allowing usage like `cat LICENSE | cline "Tell me about this project's license: "`.
>     - Introduces `getContentFromStdinAndArgs()` in `main.go` to read and combine input from stdin and command line arguments.
>   - **Documentation**:
>     - Updates `cline.1` and `cline.1.md` to include examples of using stdin with `cline` command.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 5c53b86d9dc0ba8da588347142d8667d3c3bc642. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->