### PR TITLE
fix ctrl-c in task view. should just disconnect the view

### DIFF
--- a/cli/pkg/cli/task/manager.go
+++ b/cli/pkg/cli/task/manager.go
@@ -693,17 +693,24 @@ func (m *Manager) FollowConversation(ctx context.Context, instanceAddress string
 		case <-ctx.Done():
 			return
 		case <-sigChan:
-			// Check if input is currently being shown
-			if coordinator.IsInputAllowed() {
-				// Input form is showing - huh will handle the signal via ErrUserAborted
-				// Do nothing here, let the input handler deal with it
-			} else {
-				// Streaming mode - cancel the task and stay in follow mode
-				m.renderer.RenderTaskCancelled()
-				if err := m.CancelTask(context.Background()); err != nil {
-					fmt.Printf("Error cancelling task: %v\n", err)
+			if interactive {
+				// Interactive mode (task chat)
+				// Check if input is currently being shown
+				if coordinator.IsInputAllowed() {
+					// Input form is showing - huh will handle the signal via ErrUserAborted
+					// Do nothing here, let the input handler deal with it
+				} else {
+					// Streaming mode - cancel the task and stay in follow mode
+					m.renderer.RenderTaskCancelled()
+					if err := m.CancelTask(context.Background()); err != nil {
+						fmt.Printf("Error cancelling task: %v\n", err)
+					}
+					// Don't cancel main context - stay in follow mode
 				}
-				// Don't cancel main context - stay in follow mode
+			} else {
+				// Non-interactive mode (task view --follow)
+				// Just exit without canceling the task
+				cancel()
 			}
 		}
 	}()


### PR DESCRIPTION
### Description

fixes ctrl-c in task view canceling the task and then getting stuck forever

<img width="1740" height="1090" alt="image" src="https://github.com/user-attachments/assets/263f07af-8e02-4bd3-9dc8-bcf7624d785f" />

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes Ctrl+C handling in `FollowConversation()` in `manager.go` to prevent task cancellation in non-interactive mode.
> 
>   - **Behavior**:
>     - Fixes Ctrl+C handling in `FollowConversation()` in `manager.go`.
>     - In non-interactive mode, pressing Ctrl+C exits the view without canceling the task.
>     - In interactive mode, if input is not shown, cancels the task but stays in follow mode.
>   - **Misc**:
>     - Adds newline at end of `manager.go`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 733be3b2a2488e7ef66b31e1ef7266e9007c26b9. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->