### PR TITLE
clean exits 

### DIFF
--- a/cli/cmd/cline/main.go
+++ b/cli/cmd/cline/main.go
@@ -105,6 +105,10 @@ This CLI also provides task management, configuration, and monitoring capabiliti
 					fmt.Printf("\n%s\n\n", rendered)
 
 					if err := auth.HandleAuthMenuNoArgs(ctx); err != nil {
+						// Check if user cancelled - exit cleanly
+						if err == huh.ErrUserAborted {
+							return nil
+						}
 						return fmt.Errorf("auth setup failed: %w", err)
 					}
 
@@ -133,6 +137,10 @@ This CLI also provides task management, configuration, and monitoring capabiliti
 				// Pass the mode flag to banner so it shows correct mode
 				prompt, err = promptForInitialTask(ctx, instanceAddress, mode)
 				if err != nil {
+					// Check if user cancelled - exit cleanly without error
+					if err == huh.ErrUserAborted {
+						return nil
+					}
 					return err
 				}
 				if prompt == "" {
@@ -217,7 +225,9 @@ func promptForInitialTask(ctx context.Context, instanceAddress, modeFlag string)
 	if err != nil {
 		// Check if user cancelled with Control-C
 		if err == huh.ErrUserAborted {
-			os.Exit(0)
+			// Return a special error that indicates clean cancellation
+			// This allows deferred cleanup to run
+			return "", huh.ErrUserAborted
 		}
 		return "", err
 	}

--- a/cli/pkg/cli/auth/auth_menu.go
+++ b/cli/pkg/cli/auth/auth_menu.go
@@ -3,7 +3,6 @@ package auth
 import (
 	"context"
 	"fmt"
-	"os"
 
 	"github.com/charmbracelet/huh"
 	"github.com/cline/cli/pkg/cli/global"
@@ -122,6 +121,10 @@ func HandleAuthMenuNoArgs(ctx context.Context) error {
 
 	action, err := ShowAuthMenuWithStatus(isClineAuth, hasOrganizations, currentProvider, currentModel)
 	if err != nil {
+		// Check if user cancelled - propagate for clean exit
+		if err == huh.ErrUserAborted {
+			return huh.ErrUserAborted
+		}
 		return err
 	}
 
@@ -205,7 +208,8 @@ func ShowAuthMenuWithStatus(isClineAuthenticated bool, hasOrganizations bool, cu
 	if err := form.Run(); err != nil {
 		// Check if user cancelled with Control-C
 		if err == huh.ErrUserAborted {
-			os.Exit(0)
+			// Return the error to allow deferred cleanup to run
+			return "", huh.ErrUserAborted
 		}
 		return "", fmt.Errorf("failed to get menu choice: %w", err)
 	}
@@ -275,7 +279,7 @@ func HandleSelectProvider(ctx context.Context) error {
 	if err := form.Run(); err != nil {
 		// Check if user cancelled with Control-C
 		if err == huh.ErrUserAborted {
-			os.Exit(0)
+			return huh.ErrUserAborted
 		}
 		return fmt.Errorf("failed to select provider: %w", err)
 	}

--- a/go.work.sum
+++ b/go.work.sum
@@ -1,6 +1,7 @@
 cel.dev/expr v0.24.0/go.mod h1:hLPLo1W4QUmuYdA72RBX06QTs6MXw941piREPl3Yfiw=
 cloud.google.com/go/compute/metadata v0.7.0/go.mod h1:j5MvL9PprKL39t166CoB1uVHfQMs4tFQZZcKwksXUjo=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.29.0/go.mod h1:Cz6ft6Dkn3Et6l2v2a9/RpN7epQ1GtDlO6lj8bEcOvw=
+github.com/bits-and-blooms/bitset v1.22.0/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6a/7QIWpPxHddWR8=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/charmbracelet/harmonica v0.2.0/go.mod h1:KSri/1RMQOZLbw7AHqgcBycp8pgJnQMYYT8QZRqZ1Ao=
 github.com/cncf/xds/go v0.0.0-20250501225837-2ac532fd4443/go.mod h1:W+zGtBO5Y1IgJhy4+A9GOqVhqLpfZi+vwmdNXUehLA8=
@@ -11,7 +12,9 @@ github.com/envoyproxy/protoc-gen-validate v1.2.1/go.mod h1:d/C80l/jxXLdfEIhX1W2T
 github.com/go-jose/go-jose/v4 v4.1.1/go.mod h1:BdsZGqgdO3b6tTc6LSE56wcDbMMLuPsw5d4ZD5f94kA=
 github.com/golang/glog v1.2.5/go.mod h1:6AhwSGph0fcJtXVM/PEHPqZlFeoLxhs7/t5UDAwmO+w=
 github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51/go.mod h1:CzGEWj7cYgsdH8dAjBGEr58BoE7ScuLd+fwFZ44+/x8=
+github.com/klauspost/cpuid/v2 v2.2.3/go.mod h1:RVVoqg1df56z8g3pUjL/3lE5UfnlrJX8tyFgg4nqhuY=
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
+github.com/mattn/go-sqlite3 v1.14.16/go.mod h1:2eHXhiwb8IkHr+BDWZGa96P6+rkvnG63S2DGjv9HUNg=
 github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10/go.mod h1:t/avpk3KcrXxUnYOhZhMXJlSEyie6gQbtLq5NM3loB8=
 github.com/sahilm/fuzzy v0.1.1 h1:ceu5RHF8DGgoi+/dR5PsECjCDH1BE3Fnmpo7aVXOdRA=
 github.com/sahilm/fuzzy v0.1.1/go.mod h1:VFvziUEIMCrT6A6tw2RFIXPXXmzXbOsSHF0DOI8ZK9Y=
@@ -25,7 +28,12 @@ golang.org/x/tools v0.33.0/go.mod h1:CIJMaWEY88juyUfo7UbgPqbC8rU2OqfAV1h2Qp0oMYI
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20231012003039-104605ab7028/go.mod h1:NDW/Ps6MPRej6fsCIbMTohpP40sJ/P/vI1MoTEGwX90=
 google.golang.org/genproto/googleapis/api v0.0.0-20250707201910-8d1bb00bc6a7/go.mod h1:kXqgZtrWaf6qS3jZOCnCH7WYfrvFjkC51bM8fz3RsCA=
+lukechampine.com/uint128 v1.3.0/go.mod h1:c4eWIwlEGaxC/+H1VguhU4PHXNWDCDMUlWdIWl2j1gk=
+modernc.org/cc/v3 v3.41.0/go.mod h1:Ni4zjJYJ04CDOhG7dn640WGfwBzfE0ecX8TyMB0Fv0Y=
+modernc.org/ccgo/v3 v3.16.15/go.mod h1:yT7B+/E2m43tmMOT51GMoM98/MtHIcQQSleGnddkUNI=
 modernc.org/httpfs v1.0.6/go.mod h1:7dosgurJGp0sPaRanU53W4xZYKh14wfzX420oZADeHM=
 modernc.org/opt v0.1.3/go.mod h1:WdSiB5evDcignE70guQKxYUl14mgWtbClRi5wmkkTX0=
 modernc.org/strutil v1.2.0/go.mod h1:/mdcBmfOibveCTBxUl5B5l6W+TTH1FXPLHZE6bTosX0=
+modernc.org/tcl v1.15.2/go.mod h1:3+k/ZaEbKrC8ePv8zJWPtBSW0V7Gg9g8rkmhI1Kfs3c=
 modernc.org/token v1.1.0/go.mod h1:UGzOrNV1mAFSEB63lOFHIpNRUVMvYTc6yu1SMY/XTDM=
+modernc.org/z v1.7.3/go.mod h1:Ipv4tsdxZRbQyLq9Q1M6gdbkxYzdlrciF2Hi/lS7nWE=


### PR DESCRIPTION
making sure user control-c's they don't see a bunch of garbage - and instances are cleaned up quietly. 
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Handle user cancellations gracefully in CLI operations by checking for `huh.ErrUserAborted` and updating dependencies in `go.work.sum`.
> 
>   - **Behavior**:
>     - Handle user-initiated cancellations (e.g., Control-C) gracefully in `main.go` and `auth_menu.go` by checking for `huh.ErrUserAborted` and returning it to allow deferred cleanup.
>     - Specific functions updated include `HandleAuthMenuNoArgs`, `ShowAuthMenuWithStatus`, `promptForInitialTask`, and `HandleSelectProvider`.
>   - **Dependencies**:
>     - Updated `go.work.sum` to include new dependencies: `github.com/bits-and-blooms/bitset`, `github.com/klauspost/cpuid/v2`, and `github.com/mattn/go-sqlite3`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for e76b65a5788066ae203228130da3e2e406f62544. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->