### PR TITLE
ensure t v / t v -f / t c output an error if no task is active

### DIFF
--- a/cli/pkg/cli/task.go
+++ b/cli/pkg/cli/task.go
@@ -346,6 +346,18 @@ func newTaskChatCommand() *cobra.Command {
 				return err
 			}
 
+			// Check if there's an active task before entering follow mode
+			err := taskManager.CheckSendEnabled(ctx)
+			if err != nil {
+				// Handle specific error cases
+				if errors.Is(err, task.ErrNoActiveTask) {
+					fmt.Println("No active task found. Use 'cline task new' to create a task first.")
+					return nil
+				}
+				// For other errors (like task busy), we can still enter follow mode
+				// as the user may want to observe the task
+			}
+
 			return taskManager.FollowConversation(ctx, taskManager.GetCurrentInstance(), true)
 		},
 	}

--- a/cli/pkg/cli/task/manager.go
+++ b/cli/pkg/cli/task/manager.go
@@ -3,6 +3,7 @@ package task
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"os/signal"
@@ -610,6 +611,17 @@ func (m *Manager) CancelTask(ctx context.Context) error {
 
 // ShowConversation displays the current conversation
 func (m *Manager) ShowConversation(ctx context.Context) error {
+	// Check if there's an active task before showing conversation
+	err := m.CheckSendEnabled(ctx)
+	if err != nil {
+		// Handle specific error cases
+		if errors.Is(err, ErrNoActiveTask) {
+			fmt.Println("No active task found. Use 'cline task new' to create a task first.")
+			return nil
+		}
+		// For other errors (like task busy), we can still show the conversation
+	}
+
 	// Disable streaming mode for static view
 	m.mu.Lock()
 	m.isStreamingMode = false
@@ -646,6 +658,18 @@ func (m *Manager) ShowConversation(ctx context.Context) error {
 }
 
 func (m *Manager) FollowConversation(ctx context.Context, instanceAddress string, interactive bool) error {
+	// Check if there's an active task before entering follow mode
+	err := m.CheckSendEnabled(ctx)
+	if err != nil {
+		// Handle specific error cases
+		if errors.Is(err, ErrNoActiveTask) {
+			fmt.Println("No active task found. Use 'cline task new' to create a task first.")
+			return nil
+		}
+		// For other errors (like task busy), we can still enter follow mode
+		// as the user may want to observe the task
+	}
+
 	// Enable streaming mode
 	m.mu.Lock()
 	m.isStreamingMode = true
@@ -746,6 +770,18 @@ func (m *Manager) FollowConversation(ctx context.Context, instanceAddress string
 
 // FollowConversationUntilCompletion streams conversation updates until task completion
 func (m *Manager) FollowConversationUntilCompletion(ctx context.Context) error {
+	// Check if there's an active task before entering follow mode
+	err := m.CheckSendEnabled(ctx)
+	if err != nil {
+		// Handle specific error cases
+		if errors.Is(err, ErrNoActiveTask) {
+			fmt.Println("No active task found. Use 'cline task new' to create a task first.")
+			return nil
+		}
+		// For other errors (like task busy), we can still enter follow mode
+		// as the user may want to observe the task
+	}
+
 	// Enable streaming mode
 	m.mu.Lock()
 	m.isStreamingMode = true


### PR DESCRIPTION
### Description

If there's no task active in an instance, make sure that `task view` `task chat` and `task view --follow` all print a nice error with suggestion for what user should do
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Ensure `task view`, `task chat`, and `task view --follow` print an error if no active task is found, suggesting creating a new task.
> 
>   - **Behavior**:
>     - `task view`, `task chat`, and `task view --follow` now check for active tasks using `CheckSendEnabled()`.
>     - If no active task, print "No active task found. Use 'cline task new' to create a task first."
>   - **Functions**:
>     - `CheckSendEnabled()` in `manager.go` checks for active tasks and returns `ErrNoActiveTask` if none.
>     - Error handling added to `ShowConversation()`, `FollowConversation()`, and `FollowConversationUntilCompletion()` in `manager.go`.
>     - Error handling added to `newTaskChatCommand()` in `task.go`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for ec83819cfd0c543267a355e8538f4c7c4dbfd6d6. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->