### PR TITLE
reference man page in cline --help

### DIFF
--- a/cli/cmd/cline/main.go
+++ b/cli/cmd/cline/main.go
@@ -50,7 +50,10 @@ Or pipe a prompt via stdin:
 Or run with no arguments to enter interactive mode:
   cline
 
-This CLI also provides task management, configuration, and monitoring capabilities.`,
+This CLI also provides task management, configuration, and monitoring capabilities.
+
+For detailed documentation including all commands, options, and examples,
+see the manual page: man cline`,
 		Args: cobra.ArbitraryArgs,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			if outputFormat != "rich" && outputFormat != "json" && outputFormat != "plain" {


### PR DESCRIPTION
### Description

Just adds a documentation hint so people look at `man cline`

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds a reference to `man cline` in the `cline` CLI help text for detailed documentation.
> 
>   - **Documentation**:
>     - Adds a reference to `man cline` in the help text of the `cline` CLI tool in `main.go` for detailed documentation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 9844c8f8fec2936116c72cf2ab2d8b5a99e3a5ad. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->