### PR TITLE
fix version output with cli ver + core ver

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,68 +1,62 @@
 {
-  "name": "cline",
-  "version": "1.0.0-nightly.6",
-  "description": "Autonomous coding agent CLI - capable of creating/editing files, running commands, using the browser, and more",
-  "main": "cline-core.js",
-  "bin": {
-    "cline": "./bin/cline",
-    "cline-host": "./bin/cline-host"
-  },
-  "man": "./man/cline.1",
-  "scripts": {
-    "postinstall": "node postinstall.js"
-  },
-  "bundleDependencies": [
-    "@grpc/grpc-js",
-    "@grpc/reflection",
-    "better-sqlite3",
-    "grpc-health-check",
-    "open",
-    "vscode-uri"
-  ],
-  "engines": {
-    "node": ">=18.0.0"
-  },
-  "keywords": [
-    "cline",
-    "claude",
-    "dev",
-    "mcp",
-    "openrouter",
-    "coding",
-    "agent",
-    "autonomous",
-    "chatgpt",
-    "sonnet",
-    "ai",
-    "llama",
-    "cli"
-  ],
-  "author": {
-    "name": "Cline Bot Inc."
-  },
-  "license": "Apache-2.0",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/cline/cline"
-  },
-  "homepage": "https://cline.bot",
-  "bugs": {
-    "url": "https://github.com/cline/cline/issues"
-  },
-  "dependencies": {
-    "@grpc/grpc-js": "^1.13.3",
-    "@grpc/reflection": "^1.0.4",
-    "better-sqlite3": "^12.2.0",
-    "grpc-health-check": "^2.0.2",
-    "open": "^10.1.2",
-    "vscode-uri": "^3.1.0"
-  },
-  "os": [
-    "darwin",
-    "linux"
-  ],
-  "cpu": [
-    "x64",
-    "arm64"
-  ]
+    "name": "cline",
+    "version": "1.0.0-nightly.14",
+    "description": "Autonomous coding agent CLI - capable of creating/editing files, running commands, using the browser, and more",
+    "main": "cline-core.js",
+    "bin": {
+        "cline": "./bin/cline",
+        "cline-host": "./bin/cline-host"
+    },
+    "man": "./man/cline.1",
+    "scripts": {
+        "postinstall": "node postinstall.js"
+    },
+    "bundleDependencies": [
+        "@grpc/grpc-js",
+        "@grpc/reflection",
+        "better-sqlite3",
+        "grpc-health-check",
+        "open",
+        "vscode-uri"
+    ],
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "keywords": [
+        "cline",
+        "claude",
+        "dev",
+        "mcp",
+        "openrouter",
+        "coding",
+        "agent",
+        "autonomous",
+        "chatgpt",
+        "sonnet",
+        "ai",
+        "llama",
+        "cli"
+    ],
+    "author": {
+        "name": "Cline Bot Inc."
+    },
+    "license": "Apache-2.0",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/cline/cline"
+    },
+    "homepage": "https://cline.bot",
+    "bugs": {
+        "url": "https://github.com/cline/cline/issues"
+    },
+    "dependencies": {
+        "@grpc/grpc-js": "^1.13.3",
+        "@grpc/reflection": "^1.0.4",
+        "better-sqlite3": "^12.2.0",
+        "grpc-health-check": "^2.0.2",
+        "open": "^10.1.2",
+        "vscode-uri": "^3.1.0"
+    },
+    "os": ["darwin", "linux"],
+    "cpu": ["x64", "arm64"]
 }

--- a/cli/pkg/cli/version.go
+++ b/cli/pkg/cli/version.go
@@ -1,12 +1,53 @@
 package cli
 
 import (
+	"encoding/json"
 	"fmt"
+	"os"
+	"path/filepath"
 	"runtime"
 
 	"github.com/cline/cli/pkg/cli/global"
 	"github.com/spf13/cobra"
 )
+
+type PackageInfo struct {
+	Version string `json:"version"`
+}
+
+// getCliVersion reads the CLI version from package.json
+func getCliVersion() string {
+	// Try to find package.json relative to the executable
+	execPath, err := os.Executable()
+	if err != nil {
+		return "unknown"
+	}
+	
+	// Look for package.json in the same directory as the executable
+	packagePath := filepath.Join(filepath.Dir(execPath), "package.json")
+	
+	// If not found, try parent directory (for development builds)
+	if _, err := os.Stat(packagePath); os.IsNotExist(err) {
+		packagePath = filepath.Join(filepath.Dir(execPath), "..", "package.json")
+	}
+	
+	// If still not found, try cli directory from project root
+	if _, err := os.Stat(packagePath); os.IsNotExist(err) {
+		packagePath = filepath.Join(filepath.Dir(execPath), "..", "..", "cli", "package.json")
+	}
+	
+	data, err := os.ReadFile(packagePath)
+	if err != nil {
+		return "unknown"
+	}
+	
+	var pkgInfo PackageInfo
+	if err := json.Unmarshal(data, &pkgInfo); err != nil {
+		return "unknown"
+	}
+	
+	return pkgInfo.Version
+}
 
 // NewVersionCommand creates the version command
 func NewVersionCommand() *cobra.Command {
@@ -16,20 +57,24 @@ func NewVersionCommand() *cobra.Command {
 		Use:     "version",
 		Aliases: []string{"v"},
 		Short:   "Show version information",
-		Long:    `Display version information for the Cline Go host.`,
+		Long:    `Display version information for the Cline CLI.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			// Get CLI version from package.json
+			cliVersion := getCliVersion()
+
 			if short {
-				fmt.Println(global.Version)
+				fmt.Println(cliVersion)
 				return nil
 			}
 
-			fmt.Printf("Cline Go Host\n")
-			fmt.Printf("Version:    %s\n", global.Version)
-			fmt.Printf("Commit:     %s\n", global.Commit)
-			fmt.Printf("Built:      %s\n", global.Date)
-			fmt.Printf("Built by:   %s\n", global.BuiltBy)
-			fmt.Printf("Go version: %s\n", runtime.Version())
-			fmt.Printf("OS/Arch:    %s/%s\n", runtime.GOOS, runtime.GOARCH)
+			fmt.Printf("Cline CLI\n")
+			fmt.Printf("Cline CLI Version:  %s\n", cliVersion)
+			fmt.Printf("Cline Core Version: %s\n", global.Version)
+			fmt.Printf("Commit:             %s\n", global.Commit)
+			fmt.Printf("Built:              %s\n", global.Date)
+			fmt.Printf("Built by:           %s\n", global.BuiltBy)
+			fmt.Printf("Go version:         %s\n", runtime.Version())
+			fmt.Printf("OS/Arch:            %s/%s\n", runtime.GOOS, runtime.GOARCH)
 
 			return nil
 		},

--- a/scripts/build-cli-all-platforms.sh
+++ b/scripts/build-cli-all-platforms.sh
@@ -14,10 +14,10 @@ DATE=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
 BUILT_BY="${USER:-unknown}"
 
 # Build ldflags to inject version info
-LDFLAGS="-X 'github.com/cline/cli/pkg/cli.Version=${VERSION}' \
-         -X 'github.com/cline/cli/pkg/cli.Commit=${COMMIT}' \
-         -X 'github.com/cline/cli/pkg/cli.Date=${DATE}' \
-         -X 'github.com/cline/cli/pkg/cli.BuiltBy=${BUILT_BY}'"
+LDFLAGS="-X 'github.com/cline/cli/pkg/cli/global.Version=${VERSION}' \
+         -X 'github.com/cline/cli/pkg/cli/global.Commit=${COMMIT}' \
+         -X 'github.com/cline/cli/pkg/cli/global.Date=${DATE}' \
+         -X 'github.com/cline/cli/pkg/cli/global.BuiltBy=${BUILT_BY}'"
 
 cd cli
 

--- a/scripts/build-cli.sh
+++ b/scripts/build-cli.sh
@@ -14,10 +14,10 @@ DATE=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
 BUILT_BY="${USER:-unknown}"
 
 # Build ldflags to inject version info
-LDFLAGS="-X 'github.com/cline/cli/pkg/cli.Version=${VERSION}' \
-         -X 'github.com/cline/cli/pkg/cli.Commit=${COMMIT}' \
-         -X 'github.com/cline/cli/pkg/cli.Date=${DATE}' \
-         -X 'github.com/cline/cli/pkg/cli.BuiltBy=${BUILT_BY}'"
+LDFLAGS="-X 'github.com/cline/cli/pkg/cli/global.Version=${VERSION}' \
+         -X 'github.com/cline/cli/pkg/cli/global.Commit=${COMMIT}' \
+         -X 'github.com/cline/cli/pkg/cli/global.Date=${DATE}' \
+         -X 'github.com/cline/cli/pkg/cli/global.BuiltBy=${BUILT_BY}'"
 
 cd cli
 


### PR DESCRIPTION
### Description

Added separate version for cli & cline core, output works well now in npm build

<img width="577" height="187" alt="Screenshot 2025-10-15 at 5 52 32 PM" src="https://github.com/user-attachments/assets/670c8993-c991-4dca-967b-0cf8dac688bd" />


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix CLI version output by reading from `package.json` and updating version command and build scripts.
> 
>   - **Behavior**:
>     - `getCliVersion()` in `version.go` reads CLI version from `package.json`.
>     - `NewVersionCommand()` in `version.go` now displays both CLI and core versions.
>   - **Build Scripts**:
>     - Update `build-cli-all-platforms.sh` and `build-cli.sh` to use `global.Version`, `global.Commit`, `global.Date`, and `global.BuiltBy` for version info.
>   - **Misc**:
>     - Update `version` in `package.json` to `1.0.0-nightly.14`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 9c28bac1f6ed6574d3901238cb1635af4a43666a. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->