### PR TITLE
fix 10s wait when using cline instance kill -a

### DIFF
--- a/cli/pkg/cli/task/manager.go
+++ b/cli/pkg/cli/task/manager.go
@@ -658,18 +658,6 @@ func (m *Manager) ShowConversation(ctx context.Context) error {
 }
 
 func (m *Manager) FollowConversation(ctx context.Context, instanceAddress string, interactive bool) error {
-	// Check if there's an active task before entering follow mode
-	err := m.CheckSendEnabled(ctx)
-	if err != nil {
-		// Handle specific error cases
-		if errors.Is(err, ErrNoActiveTask) {
-			fmt.Println("No active task found. Use 'cline task new' to create a task first.")
-			return nil
-		}
-		// For other errors (like task busy), we can still enter follow mode
-		// as the user may want to observe the task
-	}
-
 	// Enable streaming mode
 	m.mu.Lock()
 	m.isStreamingMode = true
@@ -770,18 +758,6 @@ func (m *Manager) FollowConversation(ctx context.Context, instanceAddress string
 
 // FollowConversationUntilCompletion streams conversation updates until task completion
 func (m *Manager) FollowConversationUntilCompletion(ctx context.Context) error {
-	// Check if there's an active task before entering follow mode
-	err := m.CheckSendEnabled(ctx)
-	if err != nil {
-		// Handle specific error cases
-		if errors.Is(err, ErrNoActiveTask) {
-			fmt.Println("No active task found. Use 'cline task new' to create a task first.")
-			return nil
-		}
-		// For other errors (like task busy), we can still enter follow mode
-		// as the user may want to observe the task
-	}
-
 	// Enable streaming mode
 	m.mu.Lock()
 	m.isStreamingMode = true


### PR DESCRIPTION
Now skips killing JetBrains instances & tracks which ones its killing properly so there's no 10s timeout waiting for non-killed instances to shutdown (they aren't supposed to)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes 10s wait in `cline instance kill -a` by tracking killed instances and removes redundant task checks in `manager.go`.
> 
>   - **Behavior**:
>     - `killAllCLIInstances()` in `instances.go` now tracks killed instances using `killedAddresses` map to avoid 10s wait for non-killed instances.
>     - Skips killing JetBrains instances, only targets CLI instances.
>   - **Code Simplification**:
>     - Removes redundant `CheckSendEnabled()` calls in `FollowConversation()` and `FollowConversationUntilCompletion()` in `manager.go`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for acc61e8184c19f8fc0c722b7d1952c791c345d7e. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->