### PR TITLE
Remove --workdir / -w flag (wasnt completed)

### DIFF
--- a/cli/cmd/cline/main.go
+++ b/cli/cmd/cline/main.go
@@ -25,13 +25,12 @@ var (
 	outputFormat string
 
 	// Task creation flags (for root command)
-	images     []string
-	files      []string
-	workspaces []string
-	mode       string
-	settings   []string
-	yolo       bool
-	oneshot    bool
+	images   []string
+	files    []string
+	mode     string
+	settings []string
+	yolo     bool
+	oneshot  bool
 )
 
 func main() {
@@ -158,13 +157,12 @@ see the manual page: man cline`,
 			}
 
 			return cli.CreateAndFollowTask(ctx, prompt, cli.TaskOptions{
-				Images:     images,
-				Files:      files,
-				Workspaces: workspaces,
-				Mode:       mode,
-				Settings:   settings,
-				Yolo:       yolo,
-				Address:    instanceAddress,
+				Images:   images,
+				Files:    files,
+				Mode:     mode,
+				Settings: settings,
+				Yolo:     yolo,
+				Address:  instanceAddress,
 			})
 		},
 	}
@@ -176,7 +174,6 @@ see the manual page: man cline`,
 	// Task creation flags (only apply when using root command with prompt)
 	rootCmd.Flags().StringSliceVarP(&images, "image", "i", nil, "attach image files")
 	rootCmd.Flags().StringSliceVarP(&files, "file", "f", nil, "attach files")
-	rootCmd.Flags().StringSliceVarP(&workspaces, "workdir", "w", nil, "workdir directory paths")
 	rootCmd.Flags().StringVarP(&mode, "mode", "m", "plan", "mode (act|plan) - defaults to plan")
 	rootCmd.Flags().StringSliceVarP(&settings, "setting", "s", nil, "task settings (key=value format)")
 	rootCmd.Flags().BoolVarP(&yolo, "yolo", "y", false, "enable yolo mode (non-interactive)")

--- a/cli/pkg/cli/task.go
+++ b/cli/pkg/cli/task.go
@@ -18,13 +18,12 @@ import (
 
 // TaskOptions contains options for creating a task
 type TaskOptions struct {
-	Images     []string
-	Files      []string
-	Workspaces []string
-	Mode       string
-	Settings   []string
-	Yolo       bool
-	Address    string
+	Images   []string
+	Files    []string
+	Mode     string
+	Settings []string
+	Yolo     bool
+	Address  string
 }
 
 func NewTaskCommand() *cobra.Command {
@@ -96,13 +95,12 @@ func ensureInstanceAtAddress(ctx context.Context, address string) error {
 
 func newTaskNewCommand() *cobra.Command {
 	var (
-		images     []string
-		files      []string
-		workspaces []string
-		address    string
-		mode       string
-		settings   []string
-		yolo       bool
+		images   []string
+		files    []string
+		address  string
+		mode     string
+		settings []string
+		yolo     bool
 	)
 
 	cmd := &cobra.Command{
@@ -155,7 +153,7 @@ func newTaskNewCommand() *cobra.Command {
 			}
 
 			// Create the task
-			taskID, err := taskManager.CreateTask(ctx, prompt, images, files, workspaces, settings)
+			taskID, err := taskManager.CreateTask(ctx, prompt, images, files, settings)
 			if err != nil {
 				return fmt.Errorf("failed to create task: %w", err)
 			}
@@ -170,7 +168,6 @@ func newTaskNewCommand() *cobra.Command {
 
 	cmd.Flags().StringSliceVarP(&images, "image", "i", nil, "attach image files")
 	cmd.Flags().StringSliceVarP(&files, "file", "f", nil, "attach files")
-	cmd.Flags().StringSliceVarP(&workspaces, "workdir", "w", nil, "workdir directory paths")
 	cmd.Flags().StringVar(&address, "address", "", "specific Cline instance address to use")
 	cmd.Flags().StringVarP(&mode, "mode", "m", "", "mode (act|plan)")
 	cmd.Flags().StringSliceVarP(&settings, "setting", "s", nil, "task settings (key=value format, e.g., -s aws-region=us-west-2 -s mode=act)")
@@ -631,7 +628,7 @@ func CreateAndFollowTask(ctx context.Context, prompt string, opts TaskOptions) e
 	}
 
 	// Create the task
-	taskID, err := taskManager.CreateTask(ctx, prompt, opts.Images, opts.Files, opts.Workspaces, opts.Settings)
+	taskID, err := taskManager.CreateTask(ctx, prompt, opts.Images, opts.Files, opts.Settings)
 	if err != nil {
 		return fmt.Errorf("failed to create task: %w", err)
 	}

--- a/cli/pkg/cli/task/manager.go
+++ b/cli/pkg/cli/task/manager.go
@@ -126,7 +126,7 @@ func (m *Manager) GetCurrentInstance() string {
 }
 
 // CreateTask creates a new task
-func (m *Manager) CreateTask(ctx context.Context, prompt string, images, files []string, workspacePaths []string, settingsFlags []string) (string, error) {
+func (m *Manager) CreateTask(ctx context.Context, prompt string, images, files []string, settingsFlags []string) (string, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -137,9 +137,6 @@ func (m *Manager) CreateTask(ctx context.Context, prompt string, images, files [
 		}
 		if len(images) > 0 {
 			m.renderer.RenderDebug("Images: %v", images)
-		}
-		if len(workspacePaths) > 0 {
-			m.renderer.RenderDebug("Workspaces: %v", workspacePaths)
 		}
 		if len(settingsFlags) > 0 {
 			m.renderer.RenderDebug("Settings: %v", settingsFlags)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove incomplete `--workdir` flag and related code from CLI implementation.
> 
>   - **Behavior**:
>     - Remove `--workdir`/`-w` flag from `main.go` and `task.go`, which was not fully implemented.
>     - Remove `workspaces` variable and its usage in `CreateTask()` in `manager.go`.
>   - **Code Cleanup**:
>     - Delete `workspaces` related code in `main.go`, `task.go`, and `manager.go`.
>     - Adjust function calls to exclude `workspaces` parameter in `CreateTask()` in `manager.go` and `CreateAndFollowTask()` in `task.go`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 30be8fd2547650cb17aa42758fdbe98b09d707b9. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->