### PR TITLE
make cli version built in rather than reading the package.json at runtime

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
     "name": "cline",
-    "version": "1.0.0-nightly.14",
+    "version": "1.0.0-nightly.18",
     "description": "Autonomous coding agent CLI - capable of creating/editing files, running commands, using the browser, and more",
     "main": "cline-core.js",
     "bin": {

--- a/cli/pkg/cli/global/global.go
+++ b/cli/pkg/cli/global/global.go
@@ -23,11 +23,14 @@ var (
 	Config  *GlobalConfig
 	Clients *ClineClients
 
-	// Version info - set at build time via ldflags in cli/version.go
+	// Version info - set at build time via ldflags
+	// Version is the Cline Core version (from root package.json)
 	Version = "dev"
-	Commit  = "unknown"
-	Date    = "unknown"
-	BuiltBy = "unknown"
+	// CliVersion is the CLI package version (from cli/package.json)
+	CliVersion = "dev"
+	Commit     = "unknown"
+	Date       = "unknown"
+	BuiltBy    = "unknown"
 )
 
 func InitializeGlobalConfig(cfg *GlobalConfig) error {

--- a/cli/pkg/cli/version.go
+++ b/cli/pkg/cli/version.go
@@ -1,53 +1,12 @@
 package cli
 
 import (
-	"encoding/json"
 	"fmt"
-	"os"
-	"path/filepath"
 	"runtime"
 
 	"github.com/cline/cli/pkg/cli/global"
 	"github.com/spf13/cobra"
 )
-
-type PackageInfo struct {
-	Version string `json:"version"`
-}
-
-// getCliVersion reads the CLI version from package.json
-func getCliVersion() string {
-	// Try to find package.json relative to the executable
-	execPath, err := os.Executable()
-	if err != nil {
-		return "unknown"
-	}
-	
-	// Look for package.json in the same directory as the executable
-	packagePath := filepath.Join(filepath.Dir(execPath), "package.json")
-	
-	// If not found, try parent directory (for development builds)
-	if _, err := os.Stat(packagePath); os.IsNotExist(err) {
-		packagePath = filepath.Join(filepath.Dir(execPath), "..", "package.json")
-	}
-	
-	// If still not found, try cli directory from project root
-	if _, err := os.Stat(packagePath); os.IsNotExist(err) {
-		packagePath = filepath.Join(filepath.Dir(execPath), "..", "..", "cli", "package.json")
-	}
-	
-	data, err := os.ReadFile(packagePath)
-	if err != nil {
-		return "unknown"
-	}
-	
-	var pkgInfo PackageInfo
-	if err := json.Unmarshal(data, &pkgInfo); err != nil {
-		return "unknown"
-	}
-	
-	return pkgInfo.Version
-}
 
 // NewVersionCommand creates the version command
 func NewVersionCommand() *cobra.Command {
@@ -59,16 +18,14 @@ func NewVersionCommand() *cobra.Command {
 		Short:   "Show version information",
 		Long:    `Display version information for the Cline CLI.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			// Get CLI version from package.json
-			cliVersion := getCliVersion()
-
+			// Versions are injected at build time via ldflags
 			if short {
-				fmt.Println(cliVersion)
+				fmt.Println(global.CliVersion)
 				return nil
 			}
 
 			fmt.Printf("Cline CLI\n")
-			fmt.Printf("Cline CLI Version:  %s\n", cliVersion)
+			fmt.Printf("Cline CLI Version:  %s\n", global.CliVersion)
 			fmt.Printf("Cline Core Version: %s\n", global.Version)
 			fmt.Printf("Commit:             %s\n", global.Commit)
 			fmt.Printf("Built:              %s\n", global.Date)

--- a/package.json
+++ b/package.json
@@ -295,7 +295,7 @@
 		"vscode:prepublish": "npm run package",
 		"compile": "npm run check-types && npm run lint && node esbuild.mjs",
 		"compile-standalone": "npm run check-types && npm run lint && node esbuild.mjs --standalone",
-		"compile-standalone-npm": "npm run check-types && npm run lint && node esbuild.mjs --standalone",
+		"compile-standalone-npm": "npm run protos && npm run protos-go && npm run check-types && npm run lint && node esbuild.mjs --standalone",
 		"compile-cli": "scripts/build-cli.sh",
 		"compile-cli-all-platforms": "scripts/build-cli-all-platforms.sh",
 		"compile-cli-man-page": "pandoc cli/man/cline.1.md -s -t man -o cli/man/cline.1",

--- a/scripts/build-cli-all-platforms.sh
+++ b/scripts/build-cli-all-platforms.sh
@@ -8,13 +8,15 @@ mkdir -p dist-standalone/extension
 cp package.json dist-standalone/extension
 
 # Extract version information for ldflags
-VERSION=$(node -p "require('./package.json').version")
+CORE_VERSION=$(node -p "require('./package.json').version")
+CLI_VERSION=$(node -p "require('./cli/package.json').version")
 COMMIT=$(git rev-parse --short HEAD 2>/dev/null || echo "unknown")
 DATE=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
 BUILT_BY="${USER:-unknown}"
 
 # Build ldflags to inject version info
-LDFLAGS="-X 'github.com/cline/cli/pkg/cli/global.Version=${VERSION}' \
+LDFLAGS="-X 'github.com/cline/cli/pkg/cli/global.Version=${CORE_VERSION}' \
+         -X 'github.com/cline/cli/pkg/cli/global.CliVersion=${CLI_VERSION}' \
          -X 'github.com/cline/cli/pkg/cli/global.Commit=${COMMIT}' \
          -X 'github.com/cline/cli/pkg/cli/global.Date=${DATE}' \
          -X 'github.com/cline/cli/pkg/cli/global.BuiltBy=${BUILT_BY}'"

--- a/scripts/build-cli.sh
+++ b/scripts/build-cli.sh
@@ -8,13 +8,15 @@ mkdir -p dist-standalone/extension
 cp package.json dist-standalone/extension
 
 # Extract version information for ldflags
-VERSION=$(node -p "require('./package.json').version")
+CORE_VERSION=$(node -p "require('./package.json').version")
+CLI_VERSION=$(node -p "require('./cli/package.json').version")
 COMMIT=$(git rev-parse --short HEAD 2>/dev/null || echo "unknown")
 DATE=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
 BUILT_BY="${USER:-unknown}"
 
 # Build ldflags to inject version info
-LDFLAGS="-X 'github.com/cline/cli/pkg/cli/global.Version=${VERSION}' \
+LDFLAGS="-X 'github.com/cline/cli/pkg/cli/global.Version=${CORE_VERSION}' \
+         -X 'github.com/cline/cli/pkg/cli/global.CliVersion=${CLI_VERSION}' \
          -X 'github.com/cline/cli/pkg/cli/global.Commit=${COMMIT}' \
          -X 'github.com/cline/cli/pkg/cli/global.Date=${DATE}' \
          -X 'github.com/cline/cli/pkg/cli/global.BuiltBy=${BUILT_BY}'"


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Embed CLI version at build time using `ldflags` and update related scripts and code.
> 
>   - **Behavior**:
>     - CLI version is now embedded at build time using `ldflags` instead of being read from `package.json` at runtime.
>     - Removes `getCliVersion()` from `version.go`.
>   - **Build Scripts**:
>     - Updates `build-cli.sh` and `build-cli-all-platforms.sh` to extract `CORE_VERSION` and `CLI_VERSION` from `package.json` and `cli/package.json` respectively.
>     - Injects version information into binaries using `ldflags`.
>   - **Code Changes**:
>     - Adds `CliVersion` variable in `global.go` to store CLI version.
>     - Updates `NewVersionCommand()` in `version.go` to use `global.CliVersion` for displaying version.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 4fa045560d0b67995c8a92404c90bdef43580324. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->