### PR TITLE
Oops.  Putting back a small detail that I accidentally removed.

### DIFF
--- a/src/core/task/index.ts
+++ b/src/core/task/index.ts
@@ -882,10 +882,17 @@ export class Task {
 	}
 
 	private async resumeTaskFromHistory() {
-		// code previously here deleted to make room for task resumption logic
+		try {
+			await this.clineIgnoreController.initialize()
+		} catch (error) {
+			console.error("Failed to initialize ClineIgnoreController:", error)
+			// Optionally, inform the user or handle the error appropriately
+		}
+
 		const savedClineMessages = await getSavedClineMessages(this.taskId)
 
-		// remove any resume_task or resume_completed_task messages from the start of the file as they are only used for the UI, and have no effect on the conversation history
+		// Remove any resume messages that may have been added before
+
 		const lastRelevantMessageIndex = findLastIndex(
 			savedClineMessages,
 			(m) => !(m.ask === "resume_task" || m.ask === "resume_completed_task"),


### PR DESCRIPTION
### Related Issue

**Issue:** n/a

### Description

This is me quickly putting back a try-catch that I accidentally removed in a [PR](https://github.com/cline/cline/pull/6895/) just a moment ago.


### Test Procedure

Did not try to trigger the behavior, as it just needs to go back to the way it was.


### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

This change to the logic of `resumeTaskFromHistory()` was not intended to be merged.
<img width="1678" height="843" alt="Screenshot 2025-10-16 at 10 54 11 AM" src="https://github.com/user-attachments/assets/9f316aae-9ccd-4a6a-8a08-17306c7580e2" />




### Additional Notes

(Oops.  My apologies.  Owning my mistake.)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Re-adds a try-catch block in `resumeTaskFromHistory()` in `index.ts` to handle `ClineIgnoreController` initialization errors.
> 
>   - **Behavior**:
>     - Re-adds `try-catch` block in `resumeTaskFromHistory()` in `index.ts` to handle errors during `ClineIgnoreController` initialization.
>   - **Error Handling**:
>     - Logs error to console if `ClineIgnoreController` fails to initialize.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 882568c8419cb8da3d8e72f8e6a85150147e80a8. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->