### PR TITLE
🪝Hooks: `TaskResume` hook [ENG-1002]

### DIFF
--- a/src/core/hooks/__tests__/fixtures/hooks/taskresume/context-deleted/TaskResume
+++ b/src/core/hooks/__tests__/fixtures/hooks/taskresume/context-deleted/TaskResume
@@ -1,0 +1,11 @@
+#!/usr/bin/env node
+const input = JSON.parse(require('fs').readFileSync(0, 'utf-8'));
+const deleted = input.taskResume?.previousState?.conversationHistoryDeleted === 'true';
+
+console.log(JSON.stringify({
+  shouldContinue: true,
+  contextModification: deleted
+    ? "TASK_CONTEXT: Some conversation history was truncated due to context window limits"
+    : "",
+  errorMessage: ""
+}));

--- a/src/core/hooks/__tests__/fixtures/hooks/taskresume/context-injection/TaskResume
+++ b/src/core/hooks/__tests__/fixtures/hooks/taskresume/context-injection/TaskResume
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+const input = JSON.parse(require('fs').readFileSync(0, 'utf-8'));
+const taskId = input.taskResume?.taskMetadata?.taskId || 'unknown';
+
+console.log(JSON.stringify({
+  shouldContinue: true,
+  contextModification: `WORKSPACE_RULES: Task ${taskId} resumed - review previous context`,
+  errorMessage: ""
+}));

--- a/src/core/hooks/__tests__/fixtures/hooks/taskresume/error/TaskResume
+++ b/src/core/hooks/__tests__/fixtures/hooks/taskresume/error/TaskResume
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+console.error("TaskResume hook encountered an error");
+process.exit(1);

--- a/src/core/hooks/__tests__/fixtures/hooks/taskresume/long-pause/TaskResume
+++ b/src/core/hooks/__tests__/fixtures/hooks/taskresume/long-pause/TaskResume
@@ -1,0 +1,13 @@
+#!/usr/bin/env node
+const input = JSON.parse(require('fs').readFileSync(0, 'utf-8'));
+const lastMessageTs = parseInt(input.taskResume?.previousState?.lastMessageTs || '0');
+const now = Date.now();
+const hoursAgo = Math.floor((now - lastMessageTs) / 3600000);
+
+console.log(JSON.stringify({
+  shouldContinue: true,
+  contextModification: hoursAgo >= 1
+    ? `TASK_CONTEXT: Task was paused ${hoursAgo} hours ago - you may need to re-familiarize yourself with the context`
+    : "",
+  errorMessage: ""
+}));

--- a/src/core/hooks/__tests__/fixtures/hooks/taskresume/message-count/TaskResume
+++ b/src/core/hooks/__tests__/fixtures/hooks/taskresume/message-count/TaskResume
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+const input = JSON.parse(require('fs').readFileSync(0, 'utf-8'));
+const messageCount = parseInt(input.taskResume?.previousState?.messageCount || '0');
+
+console.log(JSON.stringify({
+  shouldContinue: true,
+  contextModification: `TASK_CONTEXT: Resuming task with ${messageCount} previous messages`,
+  errorMessage: ""
+}));

--- a/src/core/hooks/__tests__/fixtures/hooks/taskresume/recent-resume/TaskResume
+++ b/src/core/hooks/__tests__/fixtures/hooks/taskresume/recent-resume/TaskResume
@@ -1,0 +1,13 @@
+#!/usr/bin/env node
+const input = JSON.parse(require('fs').readFileSync(0, 'utf-8'));
+const lastMessageTs = parseInt(input.taskResume?.previousState?.lastMessageTs || '0');
+const now = Date.now();
+const minutesAgo = Math.floor((now - lastMessageTs) / 60000);
+
+console.log(JSON.stringify({
+  shouldContinue: true,
+  contextModification: minutesAgo < 5 
+    ? "TASK_CONTEXT: Recently paused task - context is still fresh"
+    : "",
+  errorMessage: ""
+}));

--- a/src/core/hooks/__tests__/fixtures/hooks/taskresume/success/TaskResume
+++ b/src/core/hooks/__tests__/fixtures/hooks/taskresume/success/TaskResume
@@ -1,0 +1,8 @@
+#!/usr/bin/env node
+const input = JSON.parse(require('fs').readFileSync(0, 'utf-8'));
+
+console.log(JSON.stringify({
+  shouldContinue: true,
+  contextModification: "TaskResume hook executed successfully",
+  errorMessage: ""
+}));

--- a/src/core/hooks/__tests__/taskresume.test.ts
+++ b/src/core/hooks/__tests__/taskresume.test.ts
@@ -1,0 +1,703 @@
+import { afterEach, beforeEach, describe, it } from "mocha"
+import "should"
+import fs from "fs/promises"
+import os from "os"
+import path from "path"
+import sinon from "sinon"
+import { StateManager } from "../../storage/StateManager"
+import { HookFactory } from "../hook-factory"
+
+describe("TaskResume Hook", () => {
+	// These tests assume uniform executable script execution via embedded shell
+	// Windows support pending embedded shell implementation
+	before(function () {
+		if (process.platform === "win32") {
+			this.skip()
+		}
+	})
+
+	let tempDir: string
+	let sandbox: sinon.SinonSandbox
+
+	// Helper to write executable hook script
+	const writeHookScript = async (hookPath: string, nodeScript: string): Promise<void> => {
+		await fs.writeFile(hookPath, nodeScript)
+		await fs.chmod(hookPath, 0o755)
+	}
+
+	beforeEach(async () => {
+		sandbox = sinon.createSandbox()
+		tempDir = path.join(os.tmpdir(), `hook-test-${Date.now()}-${Math.random().toString(36).slice(2)}`)
+		await fs.mkdir(tempDir, { recursive: true })
+
+		// Create .clinerules/hooks directory
+		const hooksDir = path.join(tempDir, ".clinerules", "hooks")
+		await fs.mkdir(hooksDir, { recursive: true })
+
+		// Mock StateManager to return our temp directory
+		sandbox.stub(StateManager, "get").returns({
+			getGlobalStateKey: () => [{ path: tempDir }],
+		} as any)
+	})
+
+	afterEach(async () => {
+		sandbox.restore()
+		try {
+			await fs.rm(tempDir, { recursive: true, force: true })
+		} catch (error) {
+			// Ignore cleanup errors
+		}
+	})
+
+	describe("Hook Input Format", () => {
+		it("should receive all required taskResume fields", async () => {
+			const hookPath = path.join(tempDir, ".clinerules", "hooks", "TaskResume")
+			const hookScript = `#!/usr/bin/env node
+const input = JSON.parse(require('fs').readFileSync(0, 'utf-8'));
+const hasRequiredFields = 
+  input.taskResume && 
+  input.taskResume.taskMetadata &&
+  input.taskResume.previousState &&
+  typeof input.taskResume.taskMetadata.taskId === 'string' &&
+  typeof input.taskResume.previousState.messageCount === 'string';
+console.log(JSON.stringify({
+  shouldContinue: true,
+  contextModification: hasRequiredFields ? "All fields present" : "Missing fields"
+}))`
+
+			await writeHookScript(hookPath, hookScript)
+
+			const factory = new HookFactory()
+			const runner = await factory.create("TaskResume")
+
+			const result = await runner.run({
+				taskId: "test-task",
+				taskResume: {
+					taskMetadata: {
+						taskId: "test-task",
+						ulid: "test-ulid",
+					},
+					previousState: {
+						lastMessageTs: Date.now().toString(),
+						messageCount: "5",
+						conversationHistoryDeleted: "false",
+					},
+				},
+			})
+
+			result.shouldContinue.should.be.true()
+			result.contextModification!.should.equal("All fields present")
+		})
+
+		it("should receive all common hook input fields", async () => {
+			const hookPath = path.join(tempDir, ".clinerules", "hooks", "TaskResume")
+			const hookScript = `#!/usr/bin/env node
+const input = JSON.parse(require('fs').readFileSync(0, 'utf-8'));
+const hasAllFields = input.clineVersion && input.hookName && input.timestamp && 
+                     input.taskId && input.workspaceRoots !== undefined;
+console.log(JSON.stringify({
+  shouldContinue: true,
+  contextModification: hasAllFields ? "All fields present" : "Missing fields"
+}))`
+
+			await writeHookScript(hookPath, hookScript)
+
+			const factory = new HookFactory()
+			const runner = await factory.create("TaskResume")
+
+			const result = await runner.run({
+				taskId: "test-task",
+				taskResume: {
+					taskMetadata: { taskId: "test-task", ulid: "test-ulid" },
+					previousState: {
+						lastMessageTs: Date.now().toString(),
+						messageCount: "5",
+						conversationHistoryDeleted: "false",
+					},
+				},
+			})
+
+			result.contextModification!.should.equal("All fields present")
+		})
+	})
+
+	describe("Time-Based Calculations", () => {
+		it("should correctly calculate minutes ago for recent resumes", async () => {
+			const hookPath = path.join(tempDir, ".clinerules", "hooks", "TaskResume")
+			const hookScript = `#!/usr/bin/env node
+const input = JSON.parse(require('fs').readFileSync(0, 'utf-8'));
+const lastTs = parseInt(input.taskResume.previousState.lastMessageTs);
+const now = Date.now();
+const minutesAgo = Math.floor((now - lastTs) / 60000);
+console.log(JSON.stringify({
+  shouldContinue: true,
+  contextModification: "Minutes ago: " + minutesAgo
+}))`
+
+			await writeHookScript(hookPath, hookScript)
+
+			const factory = new HookFactory()
+			const runner = await factory.create("TaskResume")
+
+			// Test various time intervals
+			const testCases = [
+				{ offset: 2 * 60 * 1000, expected: 2 }, // 2 minutes
+				{ offset: 30 * 60 * 1000, expected: 30 }, // 30 minutes
+				{ offset: 90 * 60 * 1000, expected: 90 }, // 90 minutes
+			]
+
+			for (const { offset, expected } of testCases) {
+				const timestamp = Date.now() - offset
+				const result = await runner.run({
+					taskId: "test-task",
+					taskResume: {
+						taskMetadata: { taskId: "test-task", ulid: "test-ulid" },
+						previousState: {
+							lastMessageTs: timestamp.toString(),
+							messageCount: "5",
+							conversationHistoryDeleted: "false",
+						},
+					},
+				})
+
+				result.contextModification!.should.equal(`Minutes ago: ${expected}`)
+			}
+		})
+
+		it("should handle very old timestamps (days ago)", async () => {
+			const hookPath = path.join(tempDir, ".clinerules", "hooks", "TaskResume")
+			const hookScript = `#!/usr/bin/env node
+const input = JSON.parse(require('fs').readFileSync(0, 'utf-8'));
+const lastTs = parseInt(input.taskResume.previousState.lastMessageTs);
+const now = Date.now();
+const daysAgo = Math.floor((now - lastTs) / (24 * 60 * 60 * 1000));
+console.log(JSON.stringify({
+  shouldContinue: true,
+  contextModification: daysAgo > 0 ? "Days ago: " + daysAgo : "Recent"
+}))`
+
+			await writeHookScript(hookPath, hookScript)
+
+			const factory = new HookFactory()
+			const runner = await factory.create("TaskResume")
+
+			// Test 7 days ago
+			const sevenDaysAgo = Date.now() - 7 * 24 * 60 * 60 * 1000
+			const result = await runner.run({
+				taskId: "test-task",
+				taskResume: {
+					taskMetadata: { taskId: "test-task", ulid: "test-ulid" },
+					previousState: {
+						lastMessageTs: sevenDaysAgo.toString(),
+						messageCount: "5",
+						conversationHistoryDeleted: "false",
+					},
+				},
+			})
+
+			result.contextModification!.should.equal("Days ago: 7")
+		})
+
+		it("should handle edge case: future timestamp", async () => {
+			const hookPath = path.join(tempDir, ".clinerules", "hooks", "TaskResume")
+			const hookScript = `#!/usr/bin/env node
+const input = JSON.parse(require('fs').readFileSync(0, 'utf-8'));
+const lastTs = parseInt(input.taskResume.previousState.lastMessageTs);
+const now = Date.now();
+const isFuture = lastTs > now;
+console.log(JSON.stringify({
+  shouldContinue: true,
+  contextModification: isFuture ? "Future timestamp detected" : "Normal timestamp"
+}))`
+
+			await writeHookScript(hookPath, hookScript)
+
+			const factory = new HookFactory()
+			const runner = await factory.create("TaskResume")
+
+			const futureTimestamp = Date.now() + 60 * 60 * 1000 // 1 hour in future
+			const result = await runner.run({
+				taskId: "test-task",
+				taskResume: {
+					taskMetadata: { taskId: "test-task", ulid: "test-ulid" },
+					previousState: {
+						lastMessageTs: futureTimestamp.toString(),
+						messageCount: "5",
+						conversationHistoryDeleted: "false",
+					},
+				},
+			})
+
+			result.contextModification!.should.equal("Future timestamp detected")
+		})
+	})
+
+	describe("Message Count Analysis", () => {
+		it("should analyze message count thresholds", async () => {
+			const hookPath = path.join(tempDir, ".clinerules", "hooks", "TaskResume")
+			const hookScript = `#!/usr/bin/env node
+const input = JSON.parse(require('fs').readFileSync(0, 'utf-8'));
+const count = parseInt(input.taskResume.previousState.messageCount);
+let category;
+if (count < 5) category = "short";
+else if (count < 20) category = "medium";
+else category = "long";
+console.log(JSON.stringify({
+  shouldContinue: true,
+  contextModification: "Conversation length: " + category + " (" + count + " messages)"
+}))`
+
+			await writeHookScript(hookPath, hookScript)
+
+			const factory = new HookFactory()
+			const runner = await factory.create("TaskResume")
+
+			const testCases = [
+				{ count: "2", expected: "short (2 messages)" },
+				{ count: "10", expected: "medium (10 messages)" },
+				{ count: "50", expected: "long (50 messages)" },
+			]
+
+			for (const { count, expected } of testCases) {
+				const result = await runner.run({
+					taskId: "test-task",
+					taskResume: {
+						taskMetadata: { taskId: "test-task", ulid: "test-ulid" },
+						previousState: {
+							lastMessageTs: Date.now().toString(),
+							messageCount: count,
+							conversationHistoryDeleted: "false",
+						},
+					},
+				})
+
+				result.contextModification!.should.equal(`Conversation length: ${expected}`)
+			}
+		})
+
+		it("should handle zero message count", async () => {
+			const hookPath = path.join(tempDir, ".clinerules", "hooks", "TaskResume")
+			const hookScript = `#!/usr/bin/env node
+const input = JSON.parse(require('fs').readFileSync(0, 'utf-8'));
+const count = parseInt(input.taskResume.previousState.messageCount);
+console.log(JSON.stringify({
+  shouldContinue: true,
+  contextModification: count === 0 ? "Empty conversation" : "Has messages"
+}))`
+
+			await writeHookScript(hookPath, hookScript)
+
+			const factory = new HookFactory()
+			const runner = await factory.create("TaskResume")
+
+			const result = await runner.run({
+				taskId: "test-task",
+				taskResume: {
+					taskMetadata: { taskId: "test-task", ulid: "test-ulid" },
+					previousState: {
+						lastMessageTs: Date.now().toString(),
+						messageCount: "0",
+						conversationHistoryDeleted: "false",
+					},
+				},
+			})
+
+			result.contextModification!.should.equal("Empty conversation")
+		})
+	})
+
+	describe("State Combination Analysis", () => {
+		it("should analyze combination of long pause and many messages", async () => {
+			const hookPath = path.join(tempDir, ".clinerules", "hooks", "TaskResume")
+			const hookScript = `#!/usr/bin/env node
+const input = JSON.parse(require('fs').readFileSync(0, 'utf-8'));
+const lastTs = parseInt(input.taskResume.previousState.lastMessageTs);
+const count = parseInt(input.taskResume.previousState.messageCount);
+const hoursAgo = Math.floor((Date.now() - lastTs) / (60 * 60 * 1000));
+const isStale = hoursAgo > 24 && count > 20;
+console.log(JSON.stringify({
+  shouldContinue: true,
+  contextModification: isStale ? "STALE_TASK: Long conversation paused for extended time" : "Active task"
+}))`
+
+			await writeHookScript(hookPath, hookScript)
+
+			const factory = new HookFactory()
+			const runner = await factory.create("TaskResume")
+
+			const oneDayAgo = Date.now() - 25 * 60 * 60 * 1000
+			const result = await runner.run({
+				taskId: "test-task",
+				taskResume: {
+					taskMetadata: { taskId: "test-task", ulid: "test-ulid" },
+					previousState: {
+						lastMessageTs: oneDayAgo.toString(),
+						messageCount: "30",
+						conversationHistoryDeleted: "false",
+					},
+				},
+			})
+
+			result.contextModification!.should.equal("STALE_TASK: Long conversation paused for extended time")
+		})
+
+		it("should combine context deletion with other state", async () => {
+			const hookPath = path.join(tempDir, ".clinerules", "hooks", "TaskResume")
+			const hookScript = `#!/usr/bin/env node
+const input = JSON.parse(require('fs').readFileSync(0, 'utf-8'));
+const deleted = input.taskResume.previousState.conversationHistoryDeleted === 'true';
+const count = parseInt(input.taskResume.previousState.messageCount);
+console.log(JSON.stringify({
+  shouldContinue: true,
+  contextModification: deleted && count > 10 
+    ? "CONTEXT_WARNING: Large conversation with truncated history" 
+    : "Normal state"
+}))`
+
+			await writeHookScript(hookPath, hookScript)
+
+			const factory = new HookFactory()
+			const runner = await factory.create("TaskResume")
+
+			const result = await runner.run({
+				taskId: "test-task",
+				taskResume: {
+					taskMetadata: { taskId: "test-task", ulid: "test-ulid" },
+					previousState: {
+						lastMessageTs: Date.now().toString(),
+						messageCount: "25",
+						conversationHistoryDeleted: "true",
+					},
+				},
+			})
+
+			result.contextModification!.should.equal("CONTEXT_WARNING: Large conversation with truncated history")
+		})
+	})
+
+	describe("Error Handling", () => {
+		it("should handle malformed JSON output", async () => {
+			const hookPath = path.join(tempDir, ".clinerules", "hooks", "TaskResume")
+			const hookScript = `#!/usr/bin/env node
+console.log("not valid json")`
+
+			await writeHookScript(hookPath, hookScript)
+
+			const factory = new HookFactory()
+			const runner = await factory.create("TaskResume")
+
+			try {
+				await runner.run({
+					taskId: "test-task",
+					taskResume: {
+						taskMetadata: { taskId: "test-task", ulid: "test-ulid" },
+						previousState: {
+							lastMessageTs: Date.now().toString(),
+							messageCount: "5",
+							conversationHistoryDeleted: "false",
+						},
+					},
+				})
+				throw new Error("Should have thrown parse error")
+			} catch (error: any) {
+				error.message.should.match(/Failed to parse hook output/)
+			}
+		})
+
+		it("should handle invalid timestamp gracefully", async () => {
+			const hookPath = path.join(tempDir, ".clinerules", "hooks", "TaskResume")
+			const hookScript = `#!/usr/bin/env node
+const input = JSON.parse(require('fs').readFileSync(0, 'utf-8'));
+const lastTs = parseInt(input.taskResume.previousState.lastMessageTs);
+const isValid = !isNaN(lastTs) && lastTs > 0;
+console.log(JSON.stringify({
+  shouldContinue: true,
+  contextModification: isValid ? "Valid timestamp" : "Invalid timestamp"
+}))`
+
+			await writeHookScript(hookPath, hookScript)
+
+			const factory = new HookFactory()
+			const runner = await factory.create("TaskResume")
+
+			const result = await runner.run({
+				taskId: "test-task",
+				taskResume: {
+					taskMetadata: { taskId: "test-task", ulid: "test-ulid" },
+					previousState: {
+						lastMessageTs: "invalid",
+						messageCount: "5",
+						conversationHistoryDeleted: "false",
+					},
+				},
+			})
+
+			result.contextModification!.should.equal("Invalid timestamp")
+		})
+	})
+
+	describe("Global and Workspace Hooks", () => {
+		let globalHooksDir: string
+		let originalGetAllHooksDirs: any
+
+		beforeEach(async () => {
+			globalHooksDir = path.join(tempDir, "global-hooks")
+			await fs.mkdir(globalHooksDir, { recursive: true })
+
+			const diskModule = require("../../storage/disk")
+			originalGetAllHooksDirs = diskModule.getAllHooksDirs
+			sandbox.stub(diskModule, "getAllHooksDirs").callsFake(async () => {
+				const workspaceDirs = await originalGetAllHooksDirs()
+				return [globalHooksDir, ...workspaceDirs]
+			})
+		})
+
+		it("should execute both global and workspace TaskResume hooks", async () => {
+			const globalHookPath = path.join(globalHooksDir, "TaskResume")
+			const globalHookScript = `#!/usr/bin/env node
+console.log(JSON.stringify({
+  shouldContinue: true,
+  contextModification: "GLOBAL: Task resumed"
+}))`
+			await writeHookScript(globalHookPath, globalHookScript)
+
+			const workspaceHookPath = path.join(tempDir, ".clinerules", "hooks", "TaskResume")
+			const workspaceHookScript = `#!/usr/bin/env node
+console.log(JSON.stringify({
+  shouldContinue: true,
+  contextModification: "WORKSPACE: Task resumed"
+}))`
+			await writeHookScript(workspaceHookPath, workspaceHookScript)
+
+			const factory = new HookFactory()
+			const runner = await factory.create("TaskResume")
+
+			const result = await runner.run({
+				taskId: "test-task",
+				taskResume: {
+					taskMetadata: { taskId: "test-task", ulid: "test-ulid" },
+					previousState: {
+						lastMessageTs: Date.now().toString(),
+						messageCount: "5",
+						conversationHistoryDeleted: "false",
+					},
+				},
+			})
+
+			result.shouldContinue.should.be.true()
+			result.contextModification!.should.match(/GLOBAL: Task resumed/)
+			result.contextModification!.should.match(/WORKSPACE: Task resumed/)
+		})
+
+		it("should combine context modifications from both hooks with time analysis", async () => {
+			const oneDayAgo = Date.now() - 24 * 60 * 60 * 1000
+
+			const globalHookPath = path.join(globalHooksDir, "TaskResume")
+			const globalHookScript = `#!/usr/bin/env node
+const input = JSON.parse(require('fs').readFileSync(0, 'utf-8'));
+const lastTs = parseInt(input.taskResume.previousState.lastMessageTs);
+const daysAgo = Math.floor((Date.now() - lastTs) / (24 * 60 * 60 * 1000));
+console.log(JSON.stringify({
+  shouldContinue: true,
+  contextModification: "GLOBAL_POLICY: " + (daysAgo > 0 ? "Review task context" : "Continue")
+}))`
+			await writeHookScript(globalHookPath, globalHookScript)
+
+			const workspaceHookPath = path.join(tempDir, ".clinerules", "hooks", "TaskResume")
+			const workspaceHookScript = `#!/usr/bin/env node
+const input = JSON.parse(require('fs').readFileSync(0, 'utf-8'));
+const count = parseInt(input.taskResume.previousState.messageCount);
+console.log(JSON.stringify({
+  shouldContinue: true,
+  contextModification: "PROJECT_NOTE: " + count + " messages in history"
+}))`
+			await writeHookScript(workspaceHookPath, workspaceHookScript)
+
+			const factory = new HookFactory()
+			const runner = await factory.create("TaskResume")
+
+			const result = await runner.run({
+				taskId: "test-task",
+				taskResume: {
+					taskMetadata: { taskId: "test-task", ulid: "test-ulid" },
+					previousState: {
+						lastMessageTs: oneDayAgo.toString(),
+						messageCount: "15",
+						conversationHistoryDeleted: "false",
+					},
+				},
+			})
+
+			result.contextModification!.should.match(/GLOBAL_POLICY: Review task context/)
+			result.contextModification!.should.match(/PROJECT_NOTE: 15 messages in history/)
+		})
+	})
+
+	describe("No Hook Behavior", () => {
+		it("should allow resume when no hook exists", async () => {
+			const factory = new HookFactory()
+			const runner = await factory.create("TaskResume")
+
+			const result = await runner.run({
+				taskId: "test-task",
+				taskResume: {
+					taskMetadata: { taskId: "test-task", ulid: "test-ulid" },
+					previousState: {
+						lastMessageTs: Date.now().toString(),
+						messageCount: "5",
+						conversationHistoryDeleted: "false",
+					},
+				},
+			})
+
+			result.shouldContinue.should.be.true()
+		})
+	})
+
+	describe("Fixture-Based Tests", () => {
+		const loadFixtureAndCreateRunner = async (fixtureName: string) => {
+			const { loadFixture } = await import("./test-utils")
+			await loadFixture(`hooks/taskresume/${fixtureName}`, tempDir)
+
+			const factory = new HookFactory()
+			return await factory.create("TaskResume")
+		}
+
+		it("should work with success fixture", async () => {
+			const runner = await loadFixtureAndCreateRunner("success")
+
+			const result = await runner.run({
+				taskId: "test-task",
+				taskResume: {
+					taskMetadata: { taskId: "test-task", ulid: "test-ulid" },
+					previousState: {
+						lastMessageTs: Date.now().toString(),
+						messageCount: "5",
+						conversationHistoryDeleted: "false",
+					},
+				},
+			})
+
+			result.shouldContinue.should.be.true()
+			result.contextModification!.should.equal("TaskResume hook executed successfully")
+		})
+
+		it("should work with recent-resume fixture", async () => {
+			const runner = await loadFixtureAndCreateRunner("recent-resume")
+
+			const twoMinutesAgo = Date.now() - 2 * 60 * 1000
+			const result = await runner.run({
+				taskId: "test-task",
+				taskResume: {
+					taskMetadata: { taskId: "test-task", ulid: "test-ulid" },
+					previousState: {
+						lastMessageTs: twoMinutesAgo.toString(),
+						messageCount: "5",
+						conversationHistoryDeleted: "false",
+					},
+				},
+			})
+
+			result.shouldContinue.should.be.true()
+			result.contextModification!.should.match(/Recently paused task/)
+		})
+
+		it("should work with long-pause fixture", async () => {
+			const runner = await loadFixtureAndCreateRunner("long-pause")
+
+			const twoDaysAgo = Date.now() - 48 * 60 * 60 * 1000
+			const result = await runner.run({
+				taskId: "test-task",
+				taskResume: {
+					taskMetadata: { taskId: "test-task", ulid: "test-ulid" },
+					previousState: {
+						lastMessageTs: twoDaysAgo.toString(),
+						messageCount: "5",
+						conversationHistoryDeleted: "false",
+					},
+				},
+			})
+
+			result.shouldContinue.should.be.true()
+			result.contextModification!.should.match(/paused 48 hours ago/)
+		})
+
+		it("should work with context-deleted fixture", async () => {
+			const runner = await loadFixtureAndCreateRunner("context-deleted")
+
+			const result = await runner.run({
+				taskId: "test-task",
+				taskResume: {
+					taskMetadata: { taskId: "test-task", ulid: "test-ulid" },
+					previousState: {
+						lastMessageTs: Date.now().toString(),
+						messageCount: "50",
+						conversationHistoryDeleted: "true",
+					},
+				},
+			})
+
+			result.shouldContinue.should.be.true()
+			result.contextModification!.should.match(/truncated/)
+		})
+
+		it("should work with message-count fixture", async () => {
+			const runner = await loadFixtureAndCreateRunner("message-count")
+
+			const result = await runner.run({
+				taskId: "test-task",
+				taskResume: {
+					taskMetadata: { taskId: "test-task", ulid: "test-ulid" },
+					previousState: {
+						lastMessageTs: Date.now().toString(),
+						messageCount: "25",
+						conversationHistoryDeleted: "false",
+					},
+				},
+			})
+
+			result.shouldContinue.should.be.true()
+			result.contextModification!.should.equal("TASK_CONTEXT: Resuming task with 25 previous messages")
+		})
+
+		it("should work with context-injection fixture", async () => {
+			const runner = await loadFixtureAndCreateRunner("context-injection")
+
+			const result = await runner.run({
+				taskId: "test-task",
+				taskResume: {
+					taskMetadata: { taskId: "test-task", ulid: "test-ulid" },
+					previousState: {
+						lastMessageTs: Date.now().toString(),
+						messageCount: "5",
+						conversationHistoryDeleted: "false",
+					},
+				},
+			})
+
+			result.shouldContinue.should.be.true()
+			result.contextModification!.should.equal("WORKSPACE_RULES: Task test-task resumed - review previous context")
+		})
+
+		it("should work with error fixture", async () => {
+			const runner = await loadFixtureAndCreateRunner("error")
+
+			try {
+				await runner.run({
+					taskId: "test-task",
+					taskResume: {
+						taskMetadata: { taskId: "test-task", ulid: "test-ulid" },
+						previousState: {
+							lastMessageTs: Date.now().toString(),
+							messageCount: "5",
+							conversationHistoryDeleted: "false",
+						},
+					},
+				})
+				throw new Error("Should have thrown")
+			} catch (error: any) {
+				error.message.should.match(/exited with code 1/)
+			}
+		})
+	})
+})

--- a/src/core/task/index.ts
+++ b/src/core/task/index.ts
@@ -938,6 +938,52 @@ export class Task {
 
 		this.taskState.isInitialized = true
 
+		// Initialize newUserContent array for hook context
+		const newUserContent: UserContent = []
+
+		// Run TaskResume hook
+		const hooksEnabled = featureFlagsService.getHooksEnabled() && this.stateManager.getGlobalSettingsKey("hooksEnabled")
+		if (hooksEnabled) {
+			try {
+				const { HookFactory } = await import("../hooks/hook-factory")
+				const hookFactory = new HookFactory()
+				const taskResumeHook = await hookFactory.create("TaskResume")
+
+				const clineMessages = this.messageStateHandler.getClineMessages()
+				const taskResumeResult = await taskResumeHook.run({
+					taskId: this.taskId,
+					taskResume: {
+						taskMetadata: {
+							taskId: this.taskId,
+							ulid: this.ulid,
+						},
+						previousState: {
+							lastMessageTs: lastClineMessage?.ts?.toString() || "",
+							messageCount: clineMessages.length.toString(),
+							conversationHistoryDeleted: (this.taskState.conversationHistoryDeletedRange !== undefined).toString(),
+						},
+					},
+				})
+
+				// Check if hook indicates an error condition (non-blocking)
+				if (!taskResumeResult.shouldContinue && taskResumeResult.errorMessage) {
+					await this.say("error", taskResumeResult.errorMessage)
+				}
+
+				// Add context if provided
+				if (taskResumeResult.contextModification) {
+					newUserContent.push({
+						type: "text",
+						text: `<hook_context source="TaskResume" type="general">\n${taskResumeResult.contextModification}\n</hook_context>`,
+					})
+				}
+			} catch (hookError) {
+				const errorMessage = `TaskResume hook failed: ${hookError instanceof Error ? hookError.message : String(hookError)}`
+				await this.say("error", errorMessage)
+				// Non-fatal: continue with resume
+			}
+		}
+
 		const { response, text, images, files } = await this.ask(askType) // calls poststatetowebview
 		let responseText: string | undefined
 		let responseImages: string[] | undefined
@@ -977,7 +1023,8 @@ export class Task {
 			throw new Error("Unexpected: No existing API conversation history")
 		}
 
-		const newUserContent: UserContent = [...modifiedOldUserContent]
+		// Add previous content to newUserContent array
+		newUserContent.push(...modifiedOldUserContent)
 
 		const agoText = (() => {
 			const timestamp = lastClineMessage?.ts ?? Date.now()


### PR DESCRIPTION
### Related Issue

**Issue:** ENG-1002

### Description

This is a first pass at implementing the details for `TaskResume`.  I'm anticipating revisiting this hook for further polish once we use it a bit internally.  It's a more complicated use case than the other hooks.  The following are my open questions to get more clarity on (I'll bring these questions to @Garoth outside of this PR):

* Resuming a task and then closing it without doing anything resets the recency of the task, and we need to think through how we want that to work instead.
* Requirement to provide context to the hook about what has changed in the repo since the last time the task was closed; I'm not sure what the scope of this requirement is, so let's discuss it.
* There's also currently no implemented way of preventing a task from resuming; if that's something this hook needs to be able to do then let's clarify that as a requirement and figure out how to do it technically (I'm not sure it would be easy to do).

**In the meantime, this PR is a working implementation that does the following:**

* Enables users to create hook scripts that execute whenever a task is re-opened ("resumed").
* Time info of when the task was closed last is successfully available to the hook.
* Context modification works (it's part of the next API Request that's outputted) after resuming.
* Failures within the hook executable don't block the agent.
* Error message gets outputted in red text similar to how the other hooks work.

### Test Procedure

Follows a similar testing procedure to the other hooks PRs.

* Ran `npm test` to confirm that the tests are succeeding.

Manual verification:
* Enabled the hooks feature flag (which requires temporarily hard-coding `FeatureFlags::getHooksEnabled()` to return true) in order to see the toggle in Feature Settings and then toggling it on.
* I then loaded a directory I'm using as a test repo/workspace that contains a `.clinerules/hooks/` directory and an executable script named TaskResume whose contents I copied from one of the fixture files in this PR.
* I then created a new task in the extension and observed the output in the webview to prove the general behavior is working as intended for this initial pass (will discuss further refinement to come in the next few days, after this PR).
* See the screenshots for what the current behavior is (it's intentional, but not yet polished).

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

#### Scenario 1: How long ago?
This hook:
```javascript
#!/usr/bin/env node
const input = JSON.parse(require('fs').readFileSync(0, 'utf-8'));

const lastMessageTs = parseInt(input.taskResume.previousState.lastMessageTs);
const now = Date.now();
const minutesAgo = Math.floor((now - lastMessageTs) / 60000);

let context;
if (minutesAgo < 5) {
  context = "FRESH_TASK: Just paused moments ago - context is current";
} else if (minutesAgo < 60) {
  context = `RECENT_TASK: Paused ${minutesAgo} minutes ago - context may still be relevant`;
} else {
  const hoursAgo = Math.floor(minutesAgo / 60);
  context = `OLD_TASK: Paused ${hoursAgo} hours ago - carefully review previous context`;
}

console.log(JSON.stringify({
  shouldContinue: true,
  contextModification: context,
  errorMessage: ""
}));
```

Results in this behavior:
<img width="598" height="498" alt="Screenshot 2025-10-16 at 1 47 59 PM" src="https://github.com/user-attachments/assets/a8b59431-18bc-4b12-9b7a-25eba96cf8b3" />


----

#### Scenario 2: `"shouldContinue": false` is a no-op
This hook:
```javascript
#!/usr/bin/env node
console.log(JSON.stringify({
  shouldContinue: false,
  contextModification: "Set shouldContinue to false, but this message should still appear",
  errorMessage: "Note: shouldContinue false is informational only for TaskResume"
}));
```

Results in this behavior:
<img width="593" height="260" alt="Screenshot 2025-10-16 at 2 26 10 PM" src="https://github.com/user-attachments/assets/1ef2848c-425d-430b-901f-6bf48fe1f578" />


----

#### Scenario 3: Non-zero exit is a no-op
This hook:
```javascript
#!/usr/bin/env node
console.error("Hook intentionally failed");
process.exit(1);
```

Results in this behavior:
<img width="590" height="297" alt="Screenshot 2025-10-16 at 2 32 58 PM" src="https://github.com/user-attachments/assets/672ea1b1-8385-4fb6-841d-418575ee4bc6" />


----

#### Scenario 4: Additional detail about previous state
This hook:
```javascript
#!/usr/bin/env node
const input = JSON.parse(require('fs').readFileSync(0, 'utf-8'));

const count = parseInt(input.taskResume.previousState.messageCount);
const deleted = input.taskResume.previousState.conversationHistoryDeleted === 'true';

let context;
if (count === 0) {
  context = "EMPTY_TASK: No previous messages";
} else if (count < 10) {
  context = `SHORT_CONVERSATION: ${count} messages - task just started`;
} else if (count < 50) {
  context = `MEDIUM_CONVERSATION: ${count} messages - task in progress`;
} else {
  context = `LONG_CONVERSATION: ${count} messages - complex ongoing task`;
}

if (deleted) {
  context += " (some history was compacted)";
}

console.log(JSON.stringify({
  shouldContinue: true,
  contextModification: context,
  errorMessage: ""
}));
```

Results in this behavior:
<img width="597" height="410" alt="Screenshot 2025-10-16 at 2 46 20 PM" src="https://github.com/user-attachments/assets/1fc28e94-8059-410a-897d-b574ccf02707" />



### Additional Notes

This is another of the hook implementations. Testing it is similar to how we tested `UserPromptSubmit` and `TaskStart`.  In this case the "task resume" behavior is triggered whenever a task is re-opened.


<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Introduces `TaskResume` hook to execute scripts on task resumption, with context modification and error handling, including comprehensive tests and fixtures.
> 
>   - **Behavior**:
>     - Adds `TaskResume` hook in `index.ts` to execute scripts on task resumption, providing previous state context.
>     - Allows context modification and error handling without blocking the agent.
>   - **Tests**:
>     - Adds `taskresume.test.ts` for testing `TaskResume` hook with various scenarios including time-based calculations, message count analysis, and error handling.
>     - Includes fixture-based tests for different hook behaviors.
>   - **Fixtures**:
>     - Adds multiple hook scripts in `__tests__/fixtures/hooks/taskresume/` for scenarios like `context-deleted`, `context-injection`, `error`, `long-pause`, `message-count`, `recent-resume`, and `success`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 4fe65ca1e0b086fd7c44ef8b5b25c617e3a01456. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->