### PR TITLE
fix: post state to stream after setting plan mode in yolo mode

### DIFF
--- a/src/core/task/tools/handlers/PlanModeRespondHandler.ts
+++ b/src/core/task/tools/handlers/PlanModeRespondHandler.ts
@@ -73,6 +73,8 @@ export class PlanModeRespondHandler implements IToolHandler, IPartialBlockHandle
 
 			if (switchSuccessful) {
 				// Complete the plan mode response tool call (this is a unique case where we auto-respond to the user with an ask response)
+				// Create the ask in case it wasn't streamed
+				await config.callbacks.ask(this.name, JSON.stringify(sharedMessage), true).catch(() => {})
 				const lastPlanMessage = findLast(config.messageState.getClineMessages(), (m: any) => m.ask === this.name)
 				if (lastPlanMessage) {
 					lastPlanMessage.text = JSON.stringify({


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Post state to webview after setting plan mode in yolo mode in `PlanModeRespondHandler`.
> 
>   - **Behavior**:
>     - In `PlanModeRespondHandler`, after setting plan mode in yolo mode, post state to webview using `postStateToWebview()`.
>     - Ensures the state is updated in the UI after switching to ACT mode.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for fe3e596d83ad391d945f6536b99e27049df44a8e. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->