### PR TITLE
Fixing banner to not show CLI release for windows users

### DIFF
--- a/webview-ui/src/components/chat/chat-view/components/layout/WelcomeSection.tsx
+++ b/webview-ui/src/components/chat/chat-view/components/layout/WelcomeSection.tsx
@@ -22,14 +22,14 @@ export const WelcomeSection: React.FC<WelcomeSectionProps> = ({
 	taskHistory,
 	shouldShowQuickWins,
 }) => {
-	const { lastDismissedInfoBannerVersion, lastDismissedCliBannerVersion, platform } = useExtensionState()
+	const { lastDismissedInfoBannerVersion, lastDismissedCliBannerVersion } = useExtensionState()
 
 	const shouldShowInfoBanner = lastDismissedInfoBannerVersion < CURRENT_INFO_BANNER_VERSION
 	// const shouldShowNewModelBanner = lastDismissedModelBannerVersion < CURRENT_MODEL_BANNER_VERSION
 
 	// Show CLI banner if not dismissed and platform is VSCode (not JetBrains/standalone)
 	const shouldShowCliBanner =
-		isMacOSOrLinux(platform) &&
+		isMacOSOrLinux() &&
 		PLATFORM_CONFIG.type === PlatformType.VSCODE &&
 		lastDismissedCliBannerVersion < CURRENT_CLI_BANNER_VERSION
 

--- a/webview-ui/src/components/common/CliInstallBanner.tsx
+++ b/webview-ui/src/components/common/CliInstallBanner.tsx
@@ -11,7 +11,7 @@ import { getAsVar, VSC_INACTIVE_SELECTION_BACKGROUND } from "@/utils/vscStyles"
 export const CURRENT_CLI_BANNER_VERSION = 1
 
 export const CliInstallBanner: React.FC = () => {
-	const { navigateToSettings, subagentsEnabled, platform } = useExtensionState()
+	const { navigateToSettings, subagentsEnabled } = useExtensionState()
 	const [isCopied, setIsCopied] = useState(false)
 	const [isClineCliInstalled, setIsClineCliInstalled] = useState(false)
 
@@ -101,10 +101,10 @@ export const CliInstallBanner: React.FC = () => {
 			}}>
 			<h4 className="m-0 flex items-center gap-2" style={{ paddingRight: "24px" }}>
 				<Terminal className="w-4 h-4" />
-				{isMacOSOrLinux(platform) ? "Cline for CLI is here!" : "Cline CLI Information"}
+				{isMacOSOrLinux() ? "Cline for CLI is here!" : "Cline CLI Information"}
 			</h4>
 			<p className="m-0">
-				{isMacOSOrLinux(platform) ? (
+				{isMacOSOrLinux() ? (
 					<>
 						Install to use Cline directly in your terminal and enable subagent capabilities. Cline can spawn{" "}
 						<code>cline</code> commands to handle focused tasks like exploring large codebases for information. This
@@ -147,7 +147,7 @@ export const CliInstallBanner: React.FC = () => {
 						<span className={`codicon ${isCopied ? "codicon-check" : "codicon-copy"}`}></span>
 					</VSCodeButton>
 				</div>
-				{isMacOSOrLinux(platform) ? (
+				{isMacOSOrLinux() ? (
 					<div className="flex gap-2">
 						<VSCodeButton
 							appearance="primary"

--- a/webview-ui/src/components/settings/sections/FeatureSettingsSection.tsx
+++ b/webview-ui/src/components/settings/sections/FeatureSettingsSection.tsx
@@ -34,7 +34,6 @@ const FeatureSettingsSection = ({ renderSectionHeader }: FeatureSettingsSectionP
 		hooksEnabled,
 		remoteConfigSettings,
 		subagentsEnabled,
-		platform,
 	} = useExtensionState()
 
 	const [isClineCliInstalled, setIsClineCliInstalled] = useState(false)
@@ -70,7 +69,7 @@ const FeatureSettingsSection = ({ renderSectionHeader }: FeatureSettingsSectionP
 			<Section>
 				<div style={{ marginBottom: 20 }}>
 					{/* Subagents - Only show on macOS and Linux */}
-					{isMacOSOrLinux(platform) && PLATFORM_CONFIG.type === PlatformType.VSCODE && (
+					{isMacOSOrLinux() && PLATFORM_CONFIG.type === PlatformType.VSCODE && (
 						<div
 							className="relative p-3 mb-3 rounded-md"
 							id="subagents-section"

--- a/webview-ui/src/utils/platformUtils.ts
+++ b/webview-ui/src/utils/platformUtils.ts
@@ -43,9 +43,9 @@ export const isSafari = !isChrome && userAgent.indexOf("Safari") >= 0
 
 /**
  * Checks if the platform is macOS or Linux
- * @param platform - The platform string (typically from extension state)
  * @returns true if platform is darwin (macOS) or linux
  */
-export const isMacOSOrLinux = (platform: string): boolean => {
-	return platform === "darwin" || platform === "linux"
+export const isMacOSOrLinux = (): boolean => {
+	const platform = process?.platform
+	return !platform?.startsWith("win") // Non-Windows
 }


### PR DESCRIPTION

### Description
Title says it all 

### Test Procedure


### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [X] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [X] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [ ] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes CLI banner to only show for macOS and Linux users by updating platform checks in relevant components.
> 
>   - **Behavior**:
>     - Fixes CLI banner display logic to exclude Windows users by checking platform in `WelcomeSection`, `CliInstallBanner`, and `FeatureSettingsSection`.
>     - Uses `isMacOSOrLinux()` function from `platformUtils.ts` to determine platform.
>   - **Functions**:
>     - Adds `isMacOSOrLinux()` function in `platformUtils.ts` to check if platform is macOS or Linux.
>   - **Components**:
>     - Updates `WelcomeSection.tsx` to use `isMacOSOrLinux()` for CLI banner logic.
>     - Updates `CliInstallBanner.tsx` to use `isMacOSOrLinux()` for banner text and button logic.
>     - Updates `FeatureSettingsSection.tsx` to conditionally render subagent settings based on platform.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 4251456646c43cf83c2a5479e455fcc1b6d57e73. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->