### PR TITLE
🪝Hooks: `TaskCancel` hook [ENG-1003]

### DIFF
--- a/src/core/hooks/__tests__/fixtures/hooks/taskcancel/error/TaskCancel
+++ b/src/core/hooks/__tests__/fixtures/hooks/taskcancel/error/TaskCancel
@@ -1,0 +1,5 @@
+#!/usr/bin/env node
+// Note: For TaskCancel, contextModification is completely ignored.
+
+console.error("Hook execution error");
+process.exit(1);

--- a/src/core/hooks/__tests__/fixtures/hooks/taskcancel/false-no-error/TaskCancel
+++ b/src/core/hooks/__tests__/fixtures/hooks/taskcancel/false-no-error/TaskCancel
@@ -1,0 +1,7 @@
+#!/usr/bin/env node
+// Note: For TaskCancel, contextModification is completely ignored.
+
+console.log(JSON.stringify({
+  shouldContinue: false,
+  errorMessage: ""
+}));

--- a/src/core/hooks/__tests__/fixtures/hooks/taskcancel/false-with-error/TaskCancel
+++ b/src/core/hooks/__tests__/fixtures/hooks/taskcancel/false-with-error/TaskCancel
@@ -1,0 +1,7 @@
+#!/usr/bin/env node
+// Note: For TaskCancel, contextModification is completely ignored.
+
+console.log(JSON.stringify({
+  shouldContinue: false,
+  errorMessage: "some error happened"
+}));

--- a/src/core/hooks/__tests__/fixtures/hooks/taskcancel/true-no-error/TaskCancel
+++ b/src/core/hooks/__tests__/fixtures/hooks/taskcancel/true-no-error/TaskCancel
@@ -1,0 +1,7 @@
+#!/usr/bin/env node
+// Note: For TaskCancel, contextModification is completely ignored.
+
+console.log(JSON.stringify({
+  shouldContinue: true,
+  errorMessage: ""
+}));

--- a/src/core/hooks/__tests__/fixtures/hooks/taskcancel/true-with-error/TaskCancel
+++ b/src/core/hooks/__tests__/fixtures/hooks/taskcancel/true-with-error/TaskCancel
@@ -1,0 +1,7 @@
+#!/usr/bin/env node
+// Note: For TaskCancel, contextModification is completely ignored.
+
+console.log(JSON.stringify({
+  shouldContinue: true,
+  errorMessage: "some error happened"
+}));

--- a/src/core/hooks/__tests__/taskcancel.test.ts
+++ b/src/core/hooks/__tests__/taskcancel.test.ts
@@ -1,0 +1,609 @@
+import { afterEach, beforeEach, describe, it } from "mocha"
+import "should"
+import fs from "fs/promises"
+import os from "os"
+import path from "path"
+import sinon from "sinon"
+import { StateManager } from "../../storage/StateManager"
+import { HookFactory } from "../hook-factory"
+import { loadFixture } from "./test-utils"
+
+describe("TaskCancel Hook", () => {
+	// These tests assume uniform executable script execution via embedded shell
+	// Windows support pending embedded shell implementation
+	before(function () {
+		if (process.platform === "win32") {
+			this.skip()
+		}
+	})
+
+	let tempDir: string
+	let sandbox: sinon.SinonSandbox
+	let getEnv: () => { tempDir: string }
+
+	// Helper to write executable hook script
+	const writeHookScript = async (hookPath: string, nodeScript: string): Promise<void> => {
+		await fs.writeFile(hookPath, nodeScript)
+		await fs.chmod(hookPath, 0o755)
+	}
+
+	beforeEach(async () => {
+		sandbox = sinon.createSandbox()
+		tempDir = path.join(os.tmpdir(), `hook-test-${Date.now()}-${Math.random().toString(36).slice(2)}`)
+		await fs.mkdir(tempDir, { recursive: true })
+
+		// Create .clinerules/hooks directory
+		const hooksDir = path.join(tempDir, ".clinerules", "hooks")
+		await fs.mkdir(hooksDir, { recursive: true })
+
+		// Mock StateManager to return our temp directory
+		sandbox.stub(StateManager, "get").returns({
+			getGlobalStateKey: () => [{ path: tempDir }],
+		} as any)
+
+		getEnv = () => ({ tempDir })
+	})
+
+	afterEach(async () => {
+		sandbox.restore()
+		try {
+			await fs.rm(tempDir, { recursive: true, force: true })
+		} catch (error) {
+			// Ignore cleanup errors
+		}
+	})
+
+	describe("Hook Input Format", () => {
+		it("should receive task metadata with completionStatus", async () => {
+			const hookPath = path.join(tempDir, ".clinerules", "hooks", "TaskCancel")
+			const hookScript = `#!/usr/bin/env node
+const input = JSON.parse(require('fs').readFileSync(0, 'utf-8'));
+const metadata = input.taskCancel.taskMetadata;
+const hasAllFields = metadata.taskId && metadata.ulid && metadata.completionStatus;
+console.log(JSON.stringify({
+  shouldContinue: true,
+  contextModification: hasAllFields ? "Test passed" : "Missing metadata",
+  errorMessage: ""
+}))`
+
+			await writeHookScript(hookPath, hookScript)
+
+			const factory = new HookFactory()
+			const runner = await factory.create("TaskCancel")
+
+			const result = await runner.run({
+				taskId: "test-task-id",
+				taskCancel: {
+					taskMetadata: {
+						taskId: "test-task-id",
+						ulid: "test-ulid",
+						completionStatus: "cancelled",
+					},
+				},
+			})
+
+			result.shouldContinue.should.be.true()
+			// Note: contextModification is ignored for TaskCancel hooks
+		})
+
+		it("should handle 'abandoned' completion status", async () => {
+			const hookPath = path.join(tempDir, ".clinerules", "hooks", "TaskCancel")
+			const hookScript = `#!/usr/bin/env node
+const input = JSON.parse(require('fs').readFileSync(0, 'utf-8'));
+const status = input.taskCancel.taskMetadata.completionStatus;
+// Verify we can read the status (for logging purposes)
+if (status !== "abandoned") {
+  process.exit(1);
+}
+console.log(JSON.stringify({
+  shouldContinue: true,
+  contextModification: "",
+  errorMessage: ""
+}))`
+
+			await writeHookScript(hookPath, hookScript)
+
+			const factory = new HookFactory()
+			const runner = await factory.create("TaskCancel")
+
+			const result = await runner.run({
+				taskId: "test-task-id",
+				taskCancel: {
+					taskMetadata: {
+						taskId: "test-task-id",
+						ulid: "test-ulid",
+						completionStatus: "abandoned",
+					},
+				},
+			})
+
+			result.shouldContinue.should.be.true()
+			// Note: contextModification is ignored for TaskCancel hooks
+		})
+
+		it("should receive all common hook input fields", async () => {
+			const hookPath = path.join(tempDir, ".clinerules", "hooks", "TaskCancel")
+			const hookScript = `#!/usr/bin/env node
+const input = JSON.parse(require('fs').readFileSync(0, 'utf-8'));
+const hasAllFields = input.clineVersion && input.hookName === 'TaskCancel' && 
+                     input.timestamp && input.taskId && 
+                     input.workspaceRoots !== undefined;
+// Exit with error if fields are missing (for test verification)
+if (!hasAllFields) {
+  process.exit(1);
+}
+console.log(JSON.stringify({
+  shouldContinue: true,
+  contextModification: "",
+  errorMessage: ""
+}))`
+
+			await writeHookScript(hookPath, hookScript)
+
+			const factory = new HookFactory()
+			const runner = await factory.create("TaskCancel")
+
+			const result = await runner.run({
+				taskId: "test-task-id",
+				taskCancel: {
+					taskMetadata: {
+						taskId: "test-task-id",
+						ulid: "test-ulid",
+						completionStatus: "cancelled",
+					},
+				},
+			})
+
+			result.shouldContinue.should.be.true()
+			// Note: contextModification is ignored for TaskCancel hooks
+		})
+	})
+
+	describe("Fire-and-Forget Behavior", () => {
+		it("should ignore contextModification regardless of content", async () => {
+			const hookPath = path.join(tempDir, ".clinerules", "hooks", "TaskCancel")
+			const hookScript = `#!/usr/bin/env node
+console.log(JSON.stringify({
+  shouldContinue: true,
+  contextModification: "This is a context modification that should be ignored",
+  errorMessage: ""
+}))`
+
+			await writeHookScript(hookPath, hookScript)
+
+			const factory = new HookFactory()
+			const runner = await factory.create("TaskCancel")
+
+			const result1 = await runner.run({
+				taskId: "test-task-id",
+				taskCancel: {
+					taskMetadata: {
+						taskId: "test-task-id",
+						ulid: "test-ulid",
+						completionStatus: "cancelled",
+					},
+				},
+			})
+
+			// Hook returns contextModification, but it's completely ignored
+			result1.shouldContinue.should.be.true()
+			result1.contextModification!.should.equal("This is a context modification that should be ignored")
+
+			// Update hook to return different contextModification
+			const hookScript2 = `#!/usr/bin/env node
+console.log(JSON.stringify({
+  shouldContinue: true,
+  contextModification: "Different context that is also ignored",
+  errorMessage: ""
+}))`
+			await writeHookScript(hookPath, hookScript2)
+
+			const result2 = await runner.run({
+				taskId: "test-task-id",
+				taskCancel: {
+					taskMetadata: {
+						taskId: "test-task-id",
+						ulid: "test-ulid",
+						completionStatus: "cancelled",
+					},
+				},
+			})
+
+			// Both results behave identically - contextModification has no effect
+			result2.shouldContinue.should.be.true()
+			result2.contextModification!.should.equal("Different context that is also ignored")
+			// The key point: both executions succeeded with shouldContinue: true
+			// The contextModification value is different but behavior is identical
+		})
+
+		it("should succeed regardless of hook return value", async () => {
+			const hookPath = path.join(tempDir, ".clinerules", "hooks", "TaskCancel")
+			const hookScript = `#!/usr/bin/env node
+// Note: contextModification is ignored for TaskCancel hooks
+console.log(JSON.stringify({
+  shouldContinue: true,
+  contextModification: "",
+  errorMessage: ""
+}))`
+
+			await writeHookScript(hookPath, hookScript)
+
+			const factory = new HookFactory()
+			const runner = await factory.create("TaskCancel")
+
+			const result = await runner.run({
+				taskId: "test-task-id",
+				taskCancel: {
+					taskMetadata: {
+						taskId: "test-task-id",
+						ulid: "test-ulid",
+						completionStatus: "cancelled",
+					},
+				},
+			})
+
+			// TaskCancel is fire-and-forget, so it always reports success
+			result.shouldContinue.should.be.true()
+		})
+
+		it("should return error message when hook returns shouldContinue: false", async () => {
+			const hookPath = path.join(tempDir, ".clinerules", "hooks", "TaskCancel")
+			const hookScript = `#!/usr/bin/env node
+console.log(JSON.stringify({
+  shouldContinue: false,
+  contextModification: "",
+  errorMessage: "Hook tried to block cancellation"
+}))`
+
+			await writeHookScript(hookPath, hookScript)
+
+			const factory = new HookFactory()
+			const runner = await factory.create("TaskCancel")
+
+			const result = await runner.run({
+				taskId: "test-task-id",
+				taskCancel: {
+					taskMetadata: {
+						taskId: "test-task-id",
+						ulid: "test-ulid",
+						completionStatus: "cancelled",
+					},
+				},
+			})
+
+			// Hook result includes shouldContinue: false and errorMessage
+			// In abortTask(), the errorMessage will be surfaced to the user via this.say("error", ...)
+			// but cancellation will still proceed (fire-and-forget behavior)
+			result.shouldContinue.should.be.false()
+			result.errorMessage!.should.equal("Hook tried to block cancellation")
+		})
+
+		it("should execute without errors for cleanup purposes", async () => {
+			const hookPath = path.join(tempDir, ".clinerules", "hooks", "TaskCancel")
+			const hookScript = `#!/usr/bin/env node
+const input = JSON.parse(require('fs').readFileSync(0, 'utf-8'));
+const status = input.taskCancel.taskMetadata.completionStatus;
+// Hook can perform cleanup/logging based on status
+// Note: contextModification is ignored for TaskCancel hooks
+console.log(JSON.stringify({
+  shouldContinue: true,
+  contextModification: "",
+  errorMessage: ""
+}))`
+
+			await writeHookScript(hookPath, hookScript)
+
+			const factory = new HookFactory()
+			const runner = await factory.create("TaskCancel")
+
+			const result = await runner.run({
+				taskId: "test-task-id",
+				taskCancel: {
+					taskMetadata: {
+						taskId: "test-task-id",
+						ulid: "test-ulid",
+						completionStatus: "cancelled",
+					},
+				},
+			})
+
+			result.shouldContinue.should.be.true()
+		})
+	})
+
+	describe("Error Handling", () => {
+		it("should surface hook errors to the user", async () => {
+			const hookPath = path.join(tempDir, ".clinerules", "hooks", "TaskCancel")
+			const hookScript = `#!/usr/bin/env node
+console.error("Hook execution error");
+process.exit(1);`
+
+			await writeHookScript(hookPath, hookScript)
+
+			const factory = new HookFactory()
+			const runner = await factory.create("TaskCancel")
+
+			// TaskCancel hook errors should throw (they will be caught and surfaced in abortTask)
+			try {
+				await runner.run({
+					taskId: "test-task-id",
+					taskCancel: {
+						taskMetadata: {
+							taskId: "test-task-id",
+							ulid: "test-ulid",
+							completionStatus: "cancelled",
+						},
+					},
+				})
+				throw new Error("Should have thrown")
+			} catch (error: any) {
+				error.message.should.match(/TaskCancel.*exited with code 1/)
+			}
+		})
+
+		it("should handle malformed JSON output from hook", async () => {
+			const hookPath = path.join(tempDir, ".clinerules", "hooks", "TaskCancel")
+			const hookScript = `#!/usr/bin/env node
+console.log("not valid json")`
+
+			await writeHookScript(hookPath, hookScript)
+
+			const factory = new HookFactory()
+			const runner = await factory.create("TaskCancel")
+
+			try {
+				await runner.run({
+					taskId: "test-task-id",
+					taskCancel: {
+						taskMetadata: {
+							taskId: "test-task-id",
+							ulid: "test-ulid",
+							completionStatus: "cancelled",
+						},
+					},
+				})
+				throw new Error("Should have thrown")
+			} catch (error: any) {
+				error.message.should.match(/Failed to parse hook output/)
+			}
+		})
+	})
+
+	describe("Global and Workspace Hooks", () => {
+		let globalHooksDir: string
+		let originalGetAllHooksDirs: any
+
+		beforeEach(async () => {
+			// Create global hooks directory
+			globalHooksDir = path.join(tempDir, "global-hooks")
+			await fs.mkdir(globalHooksDir, { recursive: true })
+
+			// Mock getAllHooksDirs to include our test global directory
+			const diskModule = require("../../storage/disk")
+			originalGetAllHooksDirs = diskModule.getAllHooksDirs
+			sandbox.stub(diskModule, "getAllHooksDirs").callsFake(async () => {
+				const workspaceDirs = await originalGetAllHooksDirs()
+				return [globalHooksDir, ...workspaceDirs]
+			})
+		})
+
+		it("should execute both global and workspace TaskCancel hooks", async () => {
+			// Create global hook
+			const globalHookPath = path.join(globalHooksDir, "TaskCancel")
+			const globalHookScript = `#!/usr/bin/env node
+// Note: contextModification is ignored for TaskCancel hooks
+console.log(JSON.stringify({
+  shouldContinue: true,
+  contextModification: "",
+  errorMessage: ""
+}))`
+			await writeHookScript(globalHookPath, globalHookScript)
+
+			// Create workspace hook
+			const workspaceHookPath = path.join(tempDir, ".clinerules", "hooks", "TaskCancel")
+			const workspaceHookScript = `#!/usr/bin/env node
+// Note: contextModification is ignored for TaskCancel hooks
+console.log(JSON.stringify({
+  shouldContinue: true,
+  contextModification: "",
+  errorMessage: ""
+}))`
+			await writeHookScript(workspaceHookPath, workspaceHookScript)
+
+			const factory = new HookFactory()
+			const runner = await factory.create("TaskCancel")
+			const result = await runner.run({
+				taskId: "test-task-id",
+				taskCancel: {
+					taskMetadata: {
+						taskId: "test-task-id",
+						ulid: "test-ulid",
+						completionStatus: "cancelled",
+					},
+				},
+			})
+
+			result.shouldContinue.should.be.true()
+			// Both hooks executed successfully
+		})
+
+		it("should execute both hooks with different completion statuses", async () => {
+			const globalHookPath = path.join(globalHooksDir, "TaskCancel")
+			const globalHookScript = `#!/usr/bin/env node
+const input = JSON.parse(require('fs').readFileSync(0, 'utf-8'));
+// Can perform cleanup based on completion status
+// Note: contextModification is ignored for TaskCancel hooks
+console.log(JSON.stringify({
+  shouldContinue: true,
+  contextModification: "",
+  errorMessage: ""
+}))`
+			await writeHookScript(globalHookPath, globalHookScript)
+
+			const workspaceHookPath = path.join(tempDir, ".clinerules", "hooks", "TaskCancel")
+			const workspaceHookScript = `#!/usr/bin/env node
+// Note: contextModification is ignored for TaskCancel hooks
+console.log(JSON.stringify({
+  shouldContinue: true,
+  contextModification: "",
+  errorMessage: ""
+}))`
+			await writeHookScript(workspaceHookPath, workspaceHookScript)
+
+			const factory = new HookFactory()
+			const runner = await factory.create("TaskCancel")
+			const result = await runner.run({
+				taskId: "test-task-id",
+				taskCancel: {
+					taskMetadata: {
+						taskId: "test-task-id",
+						ulid: "test-ulid",
+						completionStatus: "abandoned",
+					},
+				},
+			})
+
+			result.shouldContinue.should.be.true()
+			// Both hooks executed successfully
+		})
+	})
+
+	describe("No Hook Behavior", () => {
+		it("should succeed when no hook exists", async () => {
+			const factory = new HookFactory()
+			const runner = await factory.create("TaskCancel")
+
+			const result = await runner.run({
+				taskId: "test-task-id",
+				taskCancel: {
+					taskMetadata: {
+						taskId: "test-task-id",
+						ulid: "test-ulid",
+						completionStatus: "cancelled",
+					},
+				},
+			})
+
+			result.shouldContinue.should.be.true()
+		})
+	})
+
+	describe("Fixture-Based Tests", () => {
+		it("should handle shouldContinue: false with no error message", async () => {
+			await loadFixture("hooks/taskcancel/false-no-error", getEnv().tempDir)
+
+			const factory = new HookFactory()
+			const runner = await factory.create("TaskCancel")
+
+			const result = await runner.run({
+				taskId: "test-task-id",
+				taskCancel: {
+					taskMetadata: {
+						taskId: "test-task-id",
+						ulid: "test-ulid",
+						completionStatus: "cancelled",
+					},
+				},
+			})
+
+			result.shouldContinue.should.be.false()
+			result.errorMessage!.should.equal("")
+			// In abortTask(), no error is surfaced since errorMessage is empty
+			// Cancellation still proceeds (fire-and-forget)
+		})
+
+		it("should handle shouldContinue: false with error message", async () => {
+			await loadFixture("hooks/taskcancel/false-with-error", getEnv().tempDir)
+
+			const factory = new HookFactory()
+			const runner = await factory.create("TaskCancel")
+
+			const result = await runner.run({
+				taskId: "test-task-id",
+				taskCancel: {
+					taskMetadata: {
+						taskId: "test-task-id",
+						ulid: "test-ulid",
+						completionStatus: "cancelled",
+					},
+				},
+			})
+
+			result.shouldContinue.should.be.false()
+			result.errorMessage!.should.equal("some error happened")
+			// In abortTask(), the errorMessage WILL be surfaced to user via this.say("error", ...)
+			// Cancellation still proceeds (fire-and-forget)
+		})
+
+		it("should handle shouldContinue: true with no error message", async () => {
+			await loadFixture("hooks/taskcancel/true-no-error", getEnv().tempDir)
+
+			const factory = new HookFactory()
+			const runner = await factory.create("TaskCancel")
+
+			const result = await runner.run({
+				taskId: "test-task-id",
+				taskCancel: {
+					taskMetadata: {
+						taskId: "test-task-id",
+						ulid: "test-ulid",
+						completionStatus: "cancelled",
+					},
+				},
+			})
+
+			result.shouldContinue.should.be.true()
+			result.errorMessage!.should.equal("")
+			// Normal success case - no errors to surface
+		})
+
+		it("should handle shouldContinue: true with error message", async () => {
+			await loadFixture("hooks/taskcancel/true-with-error", getEnv().tempDir)
+
+			const factory = new HookFactory()
+			const runner = await factory.create("TaskCancel")
+
+			const result = await runner.run({
+				taskId: "test-task-id",
+				taskCancel: {
+					taskMetadata: {
+						taskId: "test-task-id",
+						ulid: "test-ulid",
+						completionStatus: "cancelled",
+					},
+				},
+			})
+
+			result.shouldContinue.should.be.true()
+			result.errorMessage!.should.equal("some error happened")
+			// In abortTask(), the errorMessage WILL be surfaced to user via this.say("error", ...)
+			// This is the scenario that was fixed - error messages are now displayed regardless of shouldContinue value
+			// Cancellation still proceeds (fire-and-forget)
+		})
+
+		it("should handle hook that exits with non-zero status code", async () => {
+			await loadFixture("hooks/taskcancel/error", getEnv().tempDir)
+
+			const factory = new HookFactory()
+			const runner = await factory.create("TaskCancel")
+
+			try {
+				await runner.run({
+					taskId: "test-task-id",
+					taskCancel: {
+						taskMetadata: {
+							taskId: "test-task-id",
+							ulid: "test-ulid",
+							completionStatus: "cancelled",
+						},
+					},
+				})
+				throw new Error("Should have thrown")
+			} catch (error: any) {
+				error.message.should.match(/TaskCancel.*exited with code 1/)
+				// In abortTask(), this error WILL be caught and surfaced to user via this.say("error", ...)
+				// Cancellation still proceeds (fire-and-forget)
+			}
+		})
+	})
+})


### PR DESCRIPTION
### Related Issue

**Issue:** ENG-1003


### Description

Implements a hook for when the user hits the cancel button on a running task.  Because it represents the ending of a code path this hook doesn't support context modification.


### Test Procedure

Follows a similar testing procedure to the other hooks PRs.

* Ran npm test to confirm that the tests are succeeding.

Manual verification:

* Enabled the hooks feature flag (which requires temporarily hard-coding `FeatureFlags::getHooksEnabled()` to return `true`) in order to see the toggle in Feature Settings and then toggling it on.
* I then loaded a directory I'm using as a test repo/workspace that contains a `.clinerules/hooks/` directory and an executable script named `TaskCancel` that appends a log entry to a log file I created for this purpose.
* I tailed the log file to show when the hook gets executed.
* I then started a new task in the extension and then hit the cancel button while the extension was working through the task.  I started and then canceled a number of times to observe that the log gets appended to with each cancel.

Here's the code for the `.clinerules/hooks/TaskCancel` executable script that I tested with to show a realistic use case:
```javascript
#!/usr/bin/env node

const fs = require('fs');
const path = require('path');

// Read hook input from stdin
const input = JSON.parse(fs.readFileSync(0, 'utf-8'));

// Create a log file to verify the hook was called
const logDir = path.join(process.env.HOME || process.env.USERPROFILE, '.cline-hook-logs');
if (!fs.existsSync(logDir)) {
  fs.mkdirSync(logDir, { recursive: true });
}

const logFile = path.join(logDir, 'taskcancel.log');
const timestamp = new Date().toISOString();
const logEntry = `
=== TaskCancel Hook Executed ===
Timestamp: ${timestamp}
Task ID: ${input.taskId}
ULID: ${input.taskCancel.taskMetadata.ulid}
Completion Status: ${input.taskCancel.taskMetadata.completionStatus}
Hook Name: ${input.hookName}
Cline Version: ${input.clineVersion}
================================

`;

// Append to log file
fs.appendFileSync(logFile, logEntry);

// Return success with context modification
console.log(JSON.stringify({
  shouldContinue: true,
  contextModification: `TaskCancel hook executed at ${timestamp}`,
  errorMessage: ""
}));
```

Here's some of the log output:
```
=== TaskCancel Hook Executed ===
Timestamp: 2025-10-17T16:52:20.120Z
Task ID: 1760660194503
ULID: 01K7QRD1682TH8KFC8X8TZCEZD
Completion Status: cancelled
Hook Name: TaskCancel
Cline Version: 3.33.1
================================


=== TaskCancel Hook Executed ===
Timestamp: 2025-10-17T16:52:20.247Z
Task ID: 1760660194503
ULID: 01K7QRD1682TH8KFC8X8TZCEZD
Completion Status: abandoned
Hook Name: TaskCancel
Cline Version: 3.33.1
================================


=== TaskCancel Hook Executed ===
Timestamp: 2025-10-17T16:52:30.138Z
Task ID: 1760660194503
ULID: 01K7QRD1682TH8KFC8X8TZCEZD
Completion Status: cancelled
Hook Name: TaskCancel
Cline Version: 3.33.1
================================


=== TaskCancel Hook Executed ===
Timestamp: 2025-10-17T16:52:30.346Z
Task ID: 1760660194503
ULID: 01K7QRD1682TH8KFC8X8TZCEZD
Completion Status: abandoned
Hook Name: TaskCancel
Cline Version: 3.33.1
================================
```

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes


### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)


### Screenshots

#### Scenario: Non-zero exit code shows an error
This hook:
```javascript
#!/usr/bin/env node

console.error("Hook execution error");
process.exit(1);
```

Results in this behavior:
<img width="594" height="216" alt="Screenshot 2025-10-17 at 12 41 11 PM" src="https://github.com/user-attachments/assets/1f52dd64-8712-42ca-908c-65291405ce70" />

----

#### Scenario: False, no error message shows an error
This hook:
```javascript
#!/usr/bin/env node

console.log(JSON.stringify({
  shouldContinue: false,
  errorMessage: ""
}));
```

Results in this behavior:
<img width="587" height="182" alt="Screenshot 2025-10-17 at 12 44 17 PM" src="https://github.com/user-attachments/assets/4634197c-3830-4144-870c-e5c485429ebc" />

----

#### Scenario: False with error message shows an error
This hook:
```javascript
#!/usr/bin/env node

console.log(JSON.stringify({
  shouldContinue: false,
  errorMessage: "some error happened"
}));
```

Results in this behavior:
<img width="587" height="182" alt="Screenshot 2025-10-17 at 12 45 07 PM" src="https://github.com/user-attachments/assets/249f9798-95e2-4623-8268-d422c732345a" />

----

#### Scenario: True, no error message doesn't display error
This hook:
```javascript
#!/usr/bin/env node

console.log(JSON.stringify({
  shouldContinue: true,
  errorMessage: ""
}));

```

Results in this behavior (as expected for this test case, nothing to see in the output):
<img width="588" height="210" alt="Screenshot 2025-10-17 at 12 47 01 PM" src="https://github.com/user-attachments/assets/ca928e7b-aa02-46fe-a243-ea5eea909897" />

----

#### Scenario: True with error message shows an error
This hook:
```javascript
#!/usr/bin/env node

console.log(JSON.stringify({
  shouldContinue: true,
  errorMessage: "some error happened"
}));
```

Results in this behavior:
<img width="587" height="213" alt="Screenshot 2025-10-17 at 12 48 55 PM" src="https://github.com/user-attachments/assets/db9c86c1-c361-40d3-8b25-107b3293d511" />



### Additional Notes

With each hook implementation I'm getting better at reasoning about the permutations of inputs.