### PR TITLE
feat: Rework OpenAI reasoning effort handling

### DIFF
--- a/.changeset/pink-squids-wash.md
+++ b/.changeset/pink-squids-wash.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": minor
+---
+
+OpenAI Reasoning Effort: Rework from global setting to individual model-level effort picker

--- a/cli/pkg/cli/config/manager.go
+++ b/cli/pkg/cli/config/manager.go
@@ -100,7 +100,6 @@ func (m *Manager) ListSettings(ctx context.Context) error {
 		"terminalOutputLineLimit",
 		"mode",
 		"preferredLanguage",
-		"openaiReasoningEffort",
 		"strictPlanModeEnabled",
 		"focusChainSettings",
 		"useAutoCondense",

--- a/cli/pkg/cli/config/settings_renderer.go
+++ b/cli/pkg/cli/config/settings_renderer.go
@@ -30,14 +30,14 @@ func isSensitiveField(fieldName string) bool {
 	if fieldName == "" {
 		return false
 	}
-	
+
 	lowerName := strings.ToLower(fieldName)
 	for _, keyword := range sensitiveKeywords {
 		if strings.Contains(lowerName, keyword) {
 			return true
 		}
 	}
-	
+
 	return false
 }
 
@@ -47,14 +47,14 @@ func formatValue(val interface{}, fieldName string, censor bool) string {
 	if str, ok := val.(string); ok && str == "" {
 		return "''"
 	}
-	
+
 	if censor && isSensitiveField(fieldName) {
 		valStr := fmt.Sprintf("%v", val)
 		if valStr != "" && valStr != "''" {
 			return "********"
 		}
 	}
-	
+
 	return fmt.Sprintf("%v", val)
 }
 
@@ -75,7 +75,7 @@ func RenderField(key string, value interface{}, censor bool) error {
 
 	// Simple values - just print key: value
 	case "mode", "telemetrySetting", "preferredLanguage", "customPrompt",
-		"defaultTerminalProfile", "mcpDisplayMode", "openaiReasoningEffort",
+		"defaultTerminalProfile", "mcpDisplayMode",
 		"planActSeparateModelsSetting", "enableCheckpointsSetting",
 		"mcpMarketplaceEnabled", "terminalReuseEnabled",
 		"mcpResponsesCollapsed", "strictPlanModeEnabled",

--- a/cli/pkg/cli/task/settings_parser.go
+++ b/cli/pkg/cli/task/settings_parser.go
@@ -8,7 +8,6 @@ import (
 	"github.com/cline/grpc-go/cline"
 )
 
-
 func ParseTaskSettings(settingsFlags []string) (*cline.Settings, *cline.Secrets, error) {
 	if len(settingsFlags) == 0 {
 		return nil, nil, nil
@@ -359,12 +358,6 @@ func setSimpleField(settings *cline.Settings, key, value string) error {
 	// Note: We can use &val directly for enums because the parser functions return a new local variable.
 	// This is different from using &value (the loop variable), which would cause all fields to share
 	// the same memory address.
-	case "openai_reasoning_effort":
-		val, err := parseOpenaiReasoningEffort(value)
-		if err != nil {
-			return err
-		}
-		settings.OpenaiReasoningEffort = &val
 	case "mode":
 		val, err := parsePlanActMode(value)
 		if err != nil {
@@ -571,20 +564,6 @@ func parseFloat64(value string) (float64, error) {
 }
 
 // Enum parsing helpers
-func parseOpenaiReasoningEffort(value string) (cline.OpenaiReasoningEffort, error) {
-	lower := strings.ToLower(value)
-	switch lower {
-	case "low":
-		return cline.OpenaiReasoningEffort_LOW, nil
-	case "medium":
-		return cline.OpenaiReasoningEffort_MEDIUM, nil
-	case "high":
-		return cline.OpenaiReasoningEffort_HIGH, nil
-	default:
-		return cline.OpenaiReasoningEffort_LOW, fmt.Errorf("invalid openai_reasoning_effort '%s': expected low/medium/high", value)
-	}
-}
-
 func parsePlanActMode(value string) (cline.PlanActMode, error) {
 	lower := strings.ToLower(value)
 	switch lower {

--- a/proto/cline/models.proto
+++ b/proto/cline/models.proto
@@ -246,6 +246,9 @@ message OpenAiCompatibleModelInfo {
   repeated ModelTier tiers = 12;
   optional double temperature = 13;
   optional bool is_r1_format_required = 14;
+  optional bool is_reasoning_model_family = 15;
+  optional string reasoning_effort = 16;
+  optional bool set_reasoning_effort = 17;
 }
 
 // Model info for LiteLLM models

--- a/proto/cline/state.proto
+++ b/proto/cline/state.proto
@@ -138,7 +138,6 @@ message Settings {
    optional bool yolo_mode_toggled = 47;
    optional bool use_auto_condense = 48;
    optional string preferred_language = 49;
-   optional OpenaiReasoningEffort openai_reasoning_effort = 50;
    optional PlanActMode mode = 51;
    optional DictationSettings dictation_settings = 52;
    optional FocusChainSettings focus_chain_settings = 53;
@@ -254,13 +253,6 @@ enum PlanActMode {
   ACT = 1;
 }
 
-enum OpenaiReasoningEffort {
-  LOW = 0;
-  MEDIUM = 1;
-  HIGH = 2;
-  MINIMAL = 3;
-}
-
 enum McpDisplayMode {
   RICH = 0;
   PLAIN = 1;
@@ -336,7 +328,6 @@ message UpdateSettingsRequest {
   optional int32 terminal_output_line_limit = 12;
   optional PlanActMode mode = 13;
   optional string preferred_language = 14;
-  optional OpenaiReasoningEffort openai_reasoning_effort = 15;
   optional bool strict_plan_mode_enabled = 16;
   optional FocusChainSettings focus_chain_settings = 17;
   optional bool use_auto_condense = 18;

--- a/src/core/controller/index.ts
+++ b/src/core/controller/index.ts
@@ -830,7 +830,6 @@ export class Controller {
 		const focusChainSettings = this.stateManager.getGlobalSettingsKey("focusChainSettings")
 		const dictationSettings = this.stateManager.getGlobalSettingsKey("dictationSettings")
 		const preferredLanguage = this.stateManager.getGlobalSettingsKey("preferredLanguage")
-		const openaiReasoningEffort = this.stateManager.getGlobalSettingsKey("openaiReasoningEffort")
 		const mode = this.stateManager.getGlobalSettingsKey("mode")
 		const strictPlanModeEnabled = this.stateManager.getGlobalSettingsKey("strictPlanModeEnabled")
 		const yoloModeToggled = this.stateManager.getGlobalSettingsKey("yoloModeToggled")
@@ -902,7 +901,6 @@ export class Controller {
 			focusChainSettings,
 			dictationSettings: updatedDictationSettings,
 			preferredLanguage,
-			openaiReasoningEffort,
 			mode,
 			strictPlanModeEnabled,
 			yoloModeToggled,

--- a/src/core/controller/state/updateSettings.ts
+++ b/src/core/controller/state/updateSettings.ts
@@ -1,14 +1,8 @@
 import { buildApiHandler } from "@core/api"
 
 import { Empty } from "@shared/proto/cline/common"
-import {
-	PlanActMode,
-	McpDisplayMode as ProtoMcpDisplayMode,
-	OpenaiReasoningEffort as ProtoOpenaiReasoningEffort,
-	UpdateSettingsRequest,
-} from "@shared/proto/cline/state"
-import { convertProtoToApiProvider } from "@shared/proto-conversions/models/api-configuration-conversion"
-import { OpenaiReasoningEffort } from "@shared/storage/types"
+import { PlanActMode, McpDisplayMode as ProtoMcpDisplayMode, UpdateSettingsRequest } from "@shared/proto/cline/state"
+import { convertProtoToApiConfiguration } from "@shared/proto-conversions/models/api-configuration-conversion"
 import { TelemetrySetting } from "@shared/TelemetrySetting"
 import { ClineEnv } from "@/config"
 import { HostProvider } from "@/hosts/host-provider"
@@ -33,18 +27,7 @@ export async function updateSettings(controller: Controller, request: UpdateSett
 		}
 
 		if (request.apiConfiguration) {
-			const protoApiConfiguration = request.apiConfiguration
-
-			const convertedApiConfigurationFromProto = {
-				...protoApiConfiguration,
-				// Convert proto ApiProvider enums to native string types
-				planModeApiProvider: protoApiConfiguration.planModeApiProvider
-					? convertProtoToApiProvider(protoApiConfiguration.planModeApiProvider)
-					: undefined,
-				actModeApiProvider: protoApiConfiguration.actModeApiProvider
-					? convertProtoToApiProvider(protoApiConfiguration.actModeApiProvider)
-					: undefined,
-			}
+			const convertedApiConfigurationFromProto = convertProtoToApiConfiguration(request.apiConfiguration)
 
 			controller.stateManager.setApiConfiguration(convertedApiConfigurationFromProto)
 
@@ -106,29 +89,6 @@ export async function updateSettings(controller: Controller, request: UpdateSett
 		if (request.mode !== undefined) {
 			const mode = request.mode === PlanActMode.PLAN ? "plan" : "act"
 			controller.stateManager.setGlobalState("mode", mode)
-		}
-
-		if (request.openaiReasoningEffort !== undefined) {
-			// Convert proto enum to string type
-			let reasoningEffort: OpenaiReasoningEffort
-			switch (request.openaiReasoningEffort) {
-				case ProtoOpenaiReasoningEffort.LOW:
-					reasoningEffort = "low"
-					break
-				case ProtoOpenaiReasoningEffort.MEDIUM:
-					reasoningEffort = "medium"
-					break
-				case ProtoOpenaiReasoningEffort.HIGH:
-					reasoningEffort = "high"
-					break
-				case ProtoOpenaiReasoningEffort.MINIMAL:
-					reasoningEffort = "minimal"
-					break
-				default:
-					throw new Error(`Invalid OpenAI reasoning effort value: ${request.openaiReasoningEffort}`)
-			}
-
-			controller.stateManager.setGlobalState("openaiReasoningEffort", reasoningEffort)
 		}
 
 		if (request.preferredLanguage !== undefined) {

--- a/src/core/controller/state/updateSettingsCli.ts
+++ b/src/core/controller/state/updateSettingsCli.ts
@@ -1,11 +1,7 @@
 import { buildApiHandler } from "@core/api"
 
 import { Empty } from "@shared/proto/cline/common"
-import {
-	PlanActMode,
-	OpenaiReasoningEffort as ProtoOpenaiReasoningEffort,
-	UpdateSettingsRequestCli,
-} from "@shared/proto/cline/state"
+import { PlanActMode, UpdateSettingsRequestCli } from "@shared/proto/cline/state"
 import { convertProtoToApiProvider } from "@shared/proto-conversions/models/api-configuration-conversion"
 import { Settings } from "@shared/storage/state-keys"
 import { TelemetrySetting } from "@shared/TelemetrySetting"
@@ -13,7 +9,7 @@ import { ClineEnv } from "@/config"
 import { HostProvider } from "@/hosts/host-provider"
 import { TerminalInfo } from "@/integrations/terminal/TerminalRegistry"
 import { ShowMessageType } from "@/shared/proto/host/window"
-import { Mode, OpenaiReasoningEffort } from "@/shared/storage/types"
+import { Mode } from "@/shared/storage/types"
 import { telemetryService } from "../../../services/telemetry"
 import { Controller } from ".."
 
@@ -24,21 +20,6 @@ import { Controller } from ".."
  * @returns An empty response
  */
 export async function updateSettingsCli(controller: Controller, request: UpdateSettingsRequestCli): Promise<Empty> {
-	const convertOpenaiReasoningEffort = (effort: ProtoOpenaiReasoningEffort): OpenaiReasoningEffort => {
-		switch (effort) {
-			case ProtoOpenaiReasoningEffort.LOW:
-				return "low"
-			case ProtoOpenaiReasoningEffort.MEDIUM:
-				return "medium"
-			case ProtoOpenaiReasoningEffort.HIGH:
-				return "high"
-			case ProtoOpenaiReasoningEffort.MINIMAL:
-				return "minimal"
-			default:
-				return "medium"
-		}
-	}
-
 	const convertPlanActMode = (mode: PlanActMode): Mode => {
 		return mode === PlanActMode.PLAN ? "plan" : "act"
 	}
@@ -55,7 +36,6 @@ export async function updateSettingsCli(controller: Controller, request: UpdateS
 			const {
 				// Fields requiring conversion
 				autoApprovalSettings,
-				openaiReasoningEffort,
 				mode,
 				customPrompt,
 				planModeApiProvider,
@@ -102,11 +82,6 @@ export async function updateSettingsCli(controller: Controller, request: UpdateS
 				}
 
 				controller.stateManager.setGlobalState("autoApprovalSettings", mergedSettings)
-			}
-
-			if (openaiReasoningEffort !== undefined) {
-				const converted = convertOpenaiReasoningEffort(openaiReasoningEffort)
-				controller.stateManager.setGlobalState("openaiReasoningEffort", converted)
 			}
 
 			if (mode !== undefined) {

--- a/src/core/controller/state/updateTaskSettings.ts
+++ b/src/core/controller/state/updateTaskSettings.ts
@@ -1,11 +1,7 @@
 import { Empty } from "@shared/proto/cline/common"
-import {
-	PlanActMode,
-	OpenaiReasoningEffort as ProtoOpenaiReasoningEffort,
-	UpdateTaskSettingsRequest,
-} from "@shared/proto/cline/state"
+import { PlanActMode, UpdateTaskSettingsRequest } from "@shared/proto/cline/state"
 import { convertProtoToApiProvider } from "@shared/proto-conversions/models/api-configuration-conversion"
-import { Mode, OpenaiReasoningEffort } from "@/shared/storage/types"
+import { Mode } from "@/shared/storage/types"
 import { Controller } from ".."
 
 /**
@@ -15,21 +11,6 @@ import { Controller } from ".."
  * @returns An empty response
  */
 export async function updateTaskSettings(controller: Controller, request: UpdateTaskSettingsRequest): Promise<Empty> {
-	const convertOpenaiReasoningEffort = (effort: ProtoOpenaiReasoningEffort): OpenaiReasoningEffort => {
-		switch (effort) {
-			case ProtoOpenaiReasoningEffort.LOW:
-				return "low"
-			case ProtoOpenaiReasoningEffort.MEDIUM:
-				return "medium"
-			case ProtoOpenaiReasoningEffort.HIGH:
-				return "high"
-			case ProtoOpenaiReasoningEffort.MINIMAL:
-				return "minimal"
-			default:
-				return "medium"
-		}
-	}
-
 	const convertPlanActMode = (mode: PlanActMode): Mode => {
 		return mode === PlanActMode.PLAN ? "plan" : "act"
 	}
@@ -47,7 +28,6 @@ export async function updateTaskSettings(controller: Controller, request: Update
 			const {
 				// Fields requiring conversion
 				autoApprovalSettings,
-				openaiReasoningEffort,
 				mode,
 				customPrompt,
 				planModeApiProvider,
@@ -86,11 +66,6 @@ export async function updateTaskSettings(controller: Controller, request: Update
 					},
 				}
 				controller.stateManager.setTaskSettings(taskId, "autoApprovalSettings", mergedSettings)
-			}
-
-			if (openaiReasoningEffort !== undefined) {
-				const converted = convertOpenaiReasoningEffort(openaiReasoningEffort)
-				controller.stateManager.setTaskSettings(taskId, "openaiReasoningEffort", converted)
 			}
 
 			if (mode !== undefined) {

--- a/src/core/controller/task/newTask.ts
+++ b/src/core/controller/task/newTask.ts
@@ -1,5 +1,5 @@
 import { String } from "@shared/proto/cline/common"
-import { PlanActMode, OpenaiReasoningEffort as ProtoOpenaiReasoningEffort } from "@shared/proto/cline/state"
+import { PlanActMode } from "@shared/proto/cline/state"
 import { NewTaskRequest } from "@shared/proto/cline/task"
 import { Settings } from "@shared/storage/state-keys"
 import { convertProtoToApiProvider } from "@/shared/proto-conversions/models/api-configuration-conversion"
@@ -13,21 +13,6 @@ import { Controller } from ".."
  * @returns Empty response
  */
 export async function newTask(controller: Controller, request: NewTaskRequest): Promise<String> {
-	const convertOpenaiReasoningEffort = (effort: ProtoOpenaiReasoningEffort): string => {
-		switch (effort) {
-			case ProtoOpenaiReasoningEffort.LOW:
-				return "low"
-			case ProtoOpenaiReasoningEffort.MEDIUM:
-				return "medium"
-			case ProtoOpenaiReasoningEffort.HIGH:
-				return "high"
-			case ProtoOpenaiReasoningEffort.MINIMAL:
-				return "minimal"
-			default:
-				return "medium"
-		}
-	}
-
 	const convertPlanActMode = (mode: PlanActMode): string => {
 		return mode === PlanActMode.PLAN ? "plan" : "act"
 	}
@@ -68,9 +53,6 @@ export async function newTask(controller: Controller, request: NewTaskRequest): 
 					disableToolUse: request.taskSettings.browserSettings.disableToolUse,
 					customArgs: request.taskSettings.browserSettings.customArgs,
 				},
-			}),
-			...(request.taskSettings?.openaiReasoningEffort !== undefined && {
-				openaiReasoningEffort: convertOpenaiReasoningEffort(request.taskSettings.openaiReasoningEffort),
 			}),
 			...(request.taskSettings?.mode !== undefined && {
 				mode: convertPlanActMode(request.taskSettings.mode),

--- a/src/core/storage/utils/state-helpers.ts
+++ b/src/core/storage/utils/state-helpers.ts
@@ -8,7 +8,6 @@ import { ClineRulesToggles } from "@/shared/cline-rules"
 import { DEFAULT_DICTATION_SETTINGS, DictationSettings } from "@/shared/DictationSettings"
 import { DEFAULT_FOCUS_CHAIN_SETTINGS } from "@/shared/FocusChainSettings"
 import { DEFAULT_MCP_DISPLAY_MODE } from "@/shared/McpDisplayMode"
-import { OpenaiReasoningEffort } from "@/shared/storage/types"
 import { readTaskHistoryFromState } from "../disk"
 export async function readSecretsFromDisk(context: ExtensionContext): Promise<Secrets> {
 	const [
@@ -239,8 +238,6 @@ export async function readGlobalStateFromDisk(context: ExtensionContext): Promis
 		const difyBaseUrl = context.globalState.get<GlobalStateAndSettings["difyBaseUrl"]>("difyBaseUrl")
 		const ocaBaseUrl = context.globalState.get("ocaBaseUrl") as string | undefined
 		const ocaMode = context.globalState.get("ocaMode") as string | undefined
-		const openaiReasoningEffort =
-			context.globalState.get<GlobalStateAndSettings["openaiReasoningEffort"]>("openaiReasoningEffort")
 		const preferredLanguage = context.globalState.get<GlobalStateAndSettings["preferredLanguage"]>("preferredLanguage")
 		const focusChainSettings = context.globalState.get<GlobalStateAndSettings["focusChainSettings"]>("focusChainSettings")
 		const dictationSettings = context.globalState.get<GlobalStateAndSettings["dictationSettings"]>("dictationSettings") as
@@ -591,7 +588,6 @@ export async function readGlobalStateFromDisk(context: ExtensionContext): Promis
 			globalClineRulesToggles: globalClineRulesToggles || {},
 			browserSettings: { ...DEFAULT_BROWSER_SETTINGS, ...browserSettings }, // this will ensure that older versions of browserSettings (e.g. before remoteBrowserEnabled was added) are merged with the default values (false for remoteBrowserEnabled)
 			preferredLanguage: preferredLanguage || "English",
-			openaiReasoningEffort: (openaiReasoningEffort as OpenaiReasoningEffort) || "medium",
 			mode: mode || "act",
 			userInfo,
 			mcpMarketplaceEnabled: mcpMarketplaceEnabledRaw ?? true,

--- a/src/core/task/index.ts
+++ b/src/core/task/index.ts
@@ -411,15 +411,6 @@ export class Task {
 		const mode = this.stateManager.getGlobalSettingsKey("mode")
 		const currentProvider = mode === "plan" ? apiConfiguration.planModeApiProvider : apiConfiguration.actModeApiProvider
 
-		const openaiReasoningEffort = this.stateManager.getGlobalSettingsKey("openaiReasoningEffort")
-		if (currentProvider === "openai" || currentProvider === "openai-native" || currentProvider === "sapaicore") {
-			if (mode === "plan") {
-				effectiveApiConfiguration.planModeReasoningEffort = openaiReasoningEffort
-			} else {
-				effectiveApiConfiguration.actModeReasoningEffort = openaiReasoningEffort
-			}
-		}
-
 		// Now that ulid is initialized, we can build the API handler
 		this.api = buildApiHandler(effectiveApiConfiguration, mode)
 

--- a/src/shared/ExtensionMessage.ts
+++ b/src/shared/ExtensionMessage.ts
@@ -12,7 +12,7 @@ import { DictationSettings } from "./DictationSettings"
 import { FocusChainSettings } from "./FocusChainSettings"
 import { HistoryItem } from "./HistoryItem"
 import { McpDisplayMode } from "./McpDisplayMode"
-import { Mode, OpenaiReasoningEffort } from "./storage/types"
+import { Mode } from "./storage/types"
 import { TelemetrySetting } from "./TelemetrySetting"
 import { UserInfo } from "./UserInfo"
 // webview will hold state
@@ -43,7 +43,6 @@ export interface ExtensionState {
 	browserSettings: BrowserSettings
 	remoteBrowserHost?: string
 	preferredLanguage?: string
-	openaiReasoningEffort?: OpenaiReasoningEffort
 	mode: Mode
 	checkpointManagerErrorMessage?: string
 	clineMessages: ClineMessage[]

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -233,6 +233,9 @@ export interface ModelInfo {
 export interface OpenAiCompatibleModelInfo extends ModelInfo {
 	temperature?: number
 	isR1FormatRequired?: boolean
+	isReasoningModelFamily?: boolean
+	reasoningEffort?: "minimal" | "low" | "medium" | "high"
+	setReasoningEffort?: boolean
 }
 
 export interface OcaModelInfo extends OpenAiCompatibleModelInfo {
@@ -1037,9 +1040,12 @@ export const openAiModelInfoSaneDefaults: OpenAiCompatibleModelInfo = {
 	supportsImages: true,
 	supportsPromptCache: false,
 	isR1FormatRequired: false,
+	isReasoningModelFamily: false,
 	inputPrice: 0,
 	outputPrice: 0,
 	temperature: 0,
+	reasoningEffort: undefined,
+	setReasoningEffort: false,
 }
 
 // Gemini
@@ -1229,6 +1235,7 @@ export const openAiNativeModels = {
 		inputPrice: 1.25,
 		outputPrice: 10.0,
 		cacheReadsPrice: 0.125,
+		isReasoningModelFamily: true,
 	},
 	"gpt-5-mini-2025-08-07": {
 		maxTokens: 8_192,
@@ -1238,6 +1245,7 @@ export const openAiNativeModels = {
 		inputPrice: 0.25,
 		outputPrice: 2.0,
 		cacheReadsPrice: 0.025,
+		isReasoningModelFamily: true,
 	},
 	"gpt-5-nano-2025-08-07": {
 		maxTokens: 8_192,
@@ -1247,6 +1255,7 @@ export const openAiNativeModels = {
 		inputPrice: 0.05,
 		outputPrice: 0.4,
 		cacheReadsPrice: 0.005,
+		isReasoningModelFamily: true,
 	},
 	"gpt-5-chat-latest": {
 		maxTokens: 8_192,
@@ -1265,6 +1274,7 @@ export const openAiNativeModels = {
 		inputPrice: 2.0,
 		outputPrice: 8.0,
 		cacheReadsPrice: 0.5,
+		isReasoningModelFamily: true,
 	},
 	"o4-mini": {
 		maxTokens: 100_000,
@@ -1274,6 +1284,7 @@ export const openAiNativeModels = {
 		inputPrice: 1.1,
 		outputPrice: 4.4,
 		cacheReadsPrice: 0.275,
+		isReasoningModelFamily: true,
 	},
 	"gpt-4.1": {
 		maxTokens: 32_768,
@@ -1310,6 +1321,7 @@ export const openAiNativeModels = {
 		inputPrice: 1.1,
 		outputPrice: 4.4,
 		cacheReadsPrice: 0.55,
+		isReasoningModelFamily: true,
 	},
 	// don't support tool use yet
 	o1: {
@@ -1365,7 +1377,7 @@ export const openAiNativeModels = {
 		inputPrice: 5,
 		outputPrice: 15,
 	},
-} as const satisfies Record<string, ModelInfo>
+} as const satisfies Record<string, OpenAiCompatibleModelInfo>
 
 // Azure OpenAI
 // https://learn.microsoft.com/en-us/azure/ai-services/openai/api-version-deprecation

--- a/src/shared/proto-conversions/models/api-configuration-conversion.ts
+++ b/src/shared/proto-conversions/models/api-configuration-conversion.ts
@@ -7,6 +7,7 @@ import {
 	OcaModelInfo as ProtoOcaModelInfo,
 	ThinkingConfig,
 } from "@shared/proto/cline/models"
+import { normalizeReasoningEffort } from "@shared/reasoning"
 import {
 	ApiConfiguration,
 	ApiProvider,
@@ -203,6 +204,9 @@ function convertOpenAiCompatibleModelInfoToProto(
 		tiers: info.tiers || [],
 		temperature: info.temperature,
 		isR1FormatRequired: info.isR1FormatRequired,
+		isReasoningModelFamily: info.isReasoningModelFamily,
+		reasoningEffort: info.reasoningEffort,
+		setReasoningEffort: info.setReasoningEffort,
 	}
 }
 
@@ -229,6 +233,9 @@ function convertProtoToOpenAiCompatibleModelInfo(
 		tiers: info.tiers.length > 0 ? info.tiers : undefined,
 		temperature: info.temperature,
 		isR1FormatRequired: info.isR1FormatRequired,
+		isReasoningModelFamily: info.isReasoningModelFamily,
+		reasoningEffort: normalizeReasoningEffort(info.reasoningEffort),
+		setReasoningEffort: info.setReasoningEffort,
 	}
 }
 

--- a/src/shared/reasoning.ts
+++ b/src/shared/reasoning.ts
@@ -1,0 +1,63 @@
+import { OpenaiReasoningEffort } from "./storage/types"
+
+export const OPENAI_REASONING_EFFORTS: readonly OpenaiReasoningEffort[] = ["minimal", "low", "medium", "high"] as const
+
+export type OpenaiReasoningEffortOption = (typeof OPENAI_REASONING_EFFORTS)[number]
+
+export function normalizeReasoningEffort(value?: string | null): OpenaiReasoningEffortOption | undefined {
+	if (!value) {
+		return undefined
+	}
+	const normalized = value.trim().toLowerCase() as OpenaiReasoningEffortOption
+	return OPENAI_REASONING_EFFORTS.includes(normalized) ? normalized : undefined
+}
+
+export function supportsReasoningEffortForModel(modelId?: string | null): boolean {
+	if (!modelId) {
+		return false
+	}
+
+	const normalized = modelId.trim().toLowerCase()
+	if (!normalized) {
+		return false
+	}
+
+	const withoutPrefix = normalized.startsWith("openai/") ? normalized.slice("openai/".length) : normalized
+	const [baseId] = withoutPrefix.split(":")
+
+	if (baseId.includes("gpt-5") && !baseId.includes("chat")) {
+		return true
+	}
+
+	const reasoningPatterns = ["o1", "o3", "o4"]
+	return reasoningPatterns.some((pattern) => {
+		const boundaryPattern = new RegExp(`(^|[\\/\-])${pattern}(?:-|$)`)
+		return boundaryPattern.test(baseId)
+	})
+}
+
+/**
+ * Resolve reasoning effort with clear fallback precedence:
+ * 1. Mode-specific effort (highest priority) - from plan/act mode settings
+ * 2. Model-specific default effort - from the model's configuration
+ * 3. undefined (let API decide)
+ */
+export function resolveReasoningEffort(
+	modeSpecificEffort?: string | null,
+	modelSpecificDefaultEffort?: string | null,
+): OpenaiReasoningEffortOption | undefined {
+	// Try mode-specific first (plan/act mode setting)
+	const modeResolved = normalizeReasoningEffort(modeSpecificEffort)
+	if (modeResolved) {
+		return modeResolved
+	}
+
+	// Try model-specific default (from model configuration)
+	const modelResolved = normalizeReasoningEffort(modelSpecificDefaultEffort)
+	if (modelResolved) {
+		return modelResolved
+	}
+
+	// Let API decide
+	return undefined
+}

--- a/src/shared/storage/state-keys.ts
+++ b/src/shared/storage/state-keys.ts
@@ -7,7 +7,7 @@ import { FocusChainSettings } from "@shared/FocusChainSettings"
 import { HistoryItem } from "@shared/HistoryItem"
 import { McpDisplayMode } from "@shared/McpDisplayMode"
 import { WorkspaceRoot } from "@shared/multi-root/types"
-import { Mode, OpenaiReasoningEffort } from "@shared/storage/types"
+import { Mode } from "@shared/storage/types"
 import { TelemetrySetting } from "@shared/TelemetrySetting"
 import { UserInfo } from "@shared/UserInfo"
 import { LanguageModelChatSelector } from "vscode"
@@ -98,7 +98,6 @@ export interface Settings {
 	yoloModeToggled: boolean
 	useAutoCondense: boolean
 	preferredLanguage: string
-	openaiReasoningEffort: OpenaiReasoningEffort
 	mode: Mode
 	dictationSettings: DictationSettings
 	focusChainSettings: FocusChainSettings

--- a/webview-ui/src/components/settings/common/ReasoningEffortDropdown.tsx
+++ b/webview-ui/src/components/settings/common/ReasoningEffortDropdown.tsx
@@ -1,0 +1,47 @@
+import { OPENAI_REASONING_EFFORTS, type OpenaiReasoningEffortOption } from "@shared/reasoning"
+import { VSCodeDropdown, VSCodeOption } from "@vscode/webview-ui-toolkit/react"
+import { DROPDOWN_Z_INDEX, DropdownContainer } from "../ApiOptions"
+
+interface ReasoningEffortDropdownProps {
+	value: OpenaiReasoningEffortOption
+	onChange: (value: OpenaiReasoningEffortOption) => void
+	zIndex?: number
+}
+
+export const ReasoningEffortDropdown = ({ value, onChange, zIndex = DROPDOWN_Z_INDEX - 100 }: ReasoningEffortDropdownProps) => {
+	return (
+		<div style={{ marginTop: "10px" }}>
+			<label htmlFor="reasoning-effort-dropdown">
+				<span style={{ fontWeight: 500 }}>Reasoning Effort</span>
+			</label>
+			<DropdownContainer className="dropdown-container" zIndex={zIndex}>
+				<VSCodeDropdown
+					id="reasoning-effort-dropdown"
+					onChange={(e: any) => {
+						const selectedValue = e.target.value as OpenaiReasoningEffortOption
+						if (OPENAI_REASONING_EFFORTS.includes(selectedValue)) {
+							onChange(selectedValue)
+						}
+					}}
+					style={{ minWidth: 130, marginTop: 3 }}
+					value={value}>
+					{OPENAI_REASONING_EFFORTS.map((effort) => (
+						<VSCodeOption key={effort} value={effort}>
+							{effort.charAt(0).toUpperCase() + effort.slice(1)}
+						</VSCodeOption>
+					))}
+				</VSCodeDropdown>
+			</DropdownContainer>
+			<p
+				style={{
+					fontSize: "12px",
+					marginTop: 3,
+					marginBottom: "10px",
+					color: "var(--vscode-descriptionForeground)",
+				}}>
+				Controls the amount of structured reasoning requested for this model. Higher effort may increase quality and
+				latency.
+			</p>
+		</div>
+	)
+}

--- a/webview-ui/src/components/settings/sections/FeatureSettingsSection.tsx
+++ b/webview-ui/src/components/settings/sections/FeatureSettingsSection.tsx
@@ -1,7 +1,6 @@
 import { SUPPORTED_DICTATION_LANGUAGES } from "@shared/DictationSettings"
 import { McpDisplayMode } from "@shared/McpDisplayMode"
 import { EmptyRequest } from "@shared/proto/index.cline"
-import { OpenaiReasoningEffort } from "@shared/storage/types"
 import { VSCodeButton, VSCodeCheckbox, VSCodeDropdown, VSCodeOption, VSCodeTextField } from "@vscode/webview-ui-toolkit/react"
 import { memo, useEffect, useState } from "react"
 import HeroTooltip from "@/components/common/HeroTooltip"
@@ -24,7 +23,6 @@ const FeatureSettingsSection = ({ renderSectionHeader }: FeatureSettingsSectionP
 		mcpMarketplaceEnabled,
 		mcpDisplayMode,
 		mcpResponsesCollapsed,
-		openaiReasoningEffort,
 		strictPlanModeEnabled,
 		yoloModeToggled,
 		dictationSettings,
@@ -37,10 +35,6 @@ const FeatureSettingsSection = ({ renderSectionHeader }: FeatureSettingsSectionP
 	} = useExtensionState()
 
 	const [isClineCliInstalled, setIsClineCliInstalled] = useState(false)
-
-	const handleReasoningEffortChange = (newValue: OpenaiReasoningEffort) => {
-		updateSetting("openaiReasoningEffort", newValue)
-	}
 
 	// Poll for CLI installation status while the component is mounted
 	useEffect(() => {
@@ -239,29 +233,6 @@ const FeatureSettingsSection = ({ renderSectionHeader }: FeatureSettingsSectionP
 						</VSCodeCheckbox>
 						<p className="text-xs text-[var(--vscode-descriptionForeground)]">
 							Sets the default display mode for MCP response panels
-						</p>
-					</div>
-					<div style={{ marginTop: 10 }}>
-						<label
-							className="block text-sm font-medium text-[var(--vscode-foreground)] mb-1"
-							htmlFor="openai-reasoning-effort-dropdown">
-							OpenAI Reasoning Effort
-						</label>
-						<VSCodeDropdown
-							className="w-full"
-							currentValue={openaiReasoningEffort || "medium"}
-							id="openai-reasoning-effort-dropdown"
-							onChange={(e: any) => {
-								const newValue = e.target.currentValue as OpenaiReasoningEffort
-								handleReasoningEffortChange(newValue)
-							}}>
-							<VSCodeOption value="minimal">Minimal</VSCodeOption>
-							<VSCodeOption value="low">Low</VSCodeOption>
-							<VSCodeOption value="medium">Medium</VSCodeOption>
-							<VSCodeOption value="high">High</VSCodeOption>
-						</VSCodeDropdown>
-						<p className="text-xs mt-[5px] text-[var(--vscode-descriptionForeground)]">
-							Reasoning effort for the OpenAI family of models(applies to all OpenAI model providers)
 						</p>
 					</div>
 					<div style={{ marginTop: 10 }}>

--- a/webview-ui/src/components/settings/utils/settingsHandlers.ts
+++ b/webview-ui/src/components/settings/utils/settingsHandlers.ts
@@ -1,4 +1,4 @@
-import { McpDisplayMode, OpenaiReasoningEffort, UpdateSettingsRequest } from "@shared/proto/cline/state"
+import { McpDisplayMode, UpdateSettingsRequest } from "@shared/proto/cline/state"
 import { StateServiceClient } from "@/services/grpc-client"
 
 /**
@@ -9,20 +9,7 @@ import { StateServiceClient } from "@/services/grpc-client"
  * @throws Error if the value is invalid for the field
  */
 const convertToProtoValue = (field: keyof UpdateSettingsRequest, value: any): any => {
-	if (field === "openaiReasoningEffort" && typeof value === "string") {
-		switch (value) {
-			case "minimal":
-				return OpenaiReasoningEffort.MINIMAL
-			case "low":
-				return OpenaiReasoningEffort.LOW
-			case "medium":
-				return OpenaiReasoningEffort.MEDIUM
-			case "high":
-				return OpenaiReasoningEffort.HIGH
-			default:
-				throw new Error(`Invalid OpenAI reasoning effort value: ${value}`)
-		}
-	} else if (field === "mcpDisplayMode" && typeof value === "string") {
+	if (field === "mcpDisplayMode" && typeof value === "string") {
 		switch (value) {
 			case "rich":
 				return McpDisplayMode.RICH

--- a/webview-ui/src/context/ExtensionStateContext.tsx
+++ b/webview-ui/src/context/ExtensionStateContext.tsx
@@ -186,7 +186,6 @@ export const ExtensionStateContextProvider: React.FC<{
 		dictationSettings: DEFAULT_DICTATION_SETTINGS,
 		focusChainSettings: DEFAULT_FOCUS_CHAIN_SETTINGS,
 		preferredLanguage: "English",
-		openaiReasoningEffort: "medium",
 		mode: "act",
 		platform: DEFAULT_PLATFORM,
 		environment: Environment.production,


### PR DESCRIPTION
### Description
- Remove global setting for OAI reasoning effort
- Replace it with individual effort picker per model
- This allows for different reasoning efforts in Plan vs Act
- For native OpenAI: Always show effort picker if model supports it
- -> We set this per OAI model now with isReasoningModelFamily
- For OpenAI Compatible provider: Show checkbox which can enable picker
- -> Allows setting reasoning effort for non-OAI models as well

### Test Procedure

- Tested that in OpenAI provider reasoning effort picker gets shown for supported models + reasoning_effort is actually sent
→ Also verified that reasoning effort is not sent for models that do not support it
- In OpenAI Compatible provider: Verified that reasoning effort only gets sent if the checkbox is enabled
- Verified that the correct reasoning effort is transmitted when enabled
- Verified that different reasoning effort enabled/disabled values work for Plan vs Act modes

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [x] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [ ] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots
For OpenAI native provider:
<img width="434" height="281" alt="image" src="https://github.com/user-attachments/assets/1713f7cf-12d9-4d26-b21f-55eeb01360fc" />

For OpenAI Compatible Provider:
<img width="432" height="540" alt="image" src="https://github.com/user-attachments/assets/580d1584-f20b-48f9-b4a0-3f4ccdd4e3b9" />

### Additional Notes

Related to pull request #3484 but takes more comprehensive approach
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Rework OpenAI reasoning effort handling by removing global settings and introducing model-specific configurations, enhancing control in Plan and Act modes.
> 
>   - **Behavior**:
>     - Remove global `openaiReasoningEffort` setting from `state.proto` and `updateSettings.ts`.
>     - Introduce model-specific reasoning effort in `OpenAiCompatibleModelInfo` and `OpenAiNativeModelId`.
>     - Add `ReasoningEffortDropdown` component for UI in `ReasoningEffortDropdown.tsx`.
>     - Update `OpenAINativeProvider` and `OpenAICompatibleProvider` to handle reasoning effort per model.
>   - **Models**:
>     - Add `isReasoningModelFamily`, `reasoningEffort`, and `setReasoningEffort` to `OpenAiCompatibleModelInfo` in `models.proto`.
>     - Update `convertProtoToOpenAiCompatibleModelInfo` and `convertOpenAiCompatibleModelInfoToProto` in `api-configuration-conversion.ts`.
>   - **UI**:
>     - Add reasoning effort dropdown in `OpenAICompatible.tsx` and `OpenAINative.tsx`.
>     - Remove reasoning effort setting from `FeatureSettingsSection.tsx`.
>   - **Misc**:
>     - Add `resolveReasoningEffort` and `supportsReasoningEffortForModel` functions in `reasoning.ts`.
>     - Update `ExtensionStateContext.tsx` to reflect new state structure.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 7c71e0c190f0140f70580cf678275a61cd3337e4. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->