### PR TITLE
refresh models without full api configuration

### DIFF
--- a/src/core/controller/models/refreshOcaModels.ts
+++ b/src/core/controller/models/refreshOcaModels.ts
@@ -7,6 +7,7 @@ import { DEFAULT_EXTERNAL_OCA_BASE_URL, DEFAULT_INTERNAL_OCA_BASE_URL } from "@/
 import { createOcaHeaders, getAxiosSettings } from "@/services/auth/oca/utils/utils"
 import { Logger } from "@/services/logging/Logger"
 import { ShowMessageType } from "@/shared/proto/index.host"
+import { GlobalStateAndSettings } from "@/shared/storage/state-keys"
 import { Controller } from ".."
 
 /**
@@ -75,13 +76,11 @@ export async function refreshOcaModels(controller: Controller, request: StringRe
 			}
 			console.log("OCA models fetched", models)
 
-			// Fetch current config
+			// Fetch current config to determine existing model selections
 			const apiConfiguration = controller.stateManager.getApiConfiguration()
-			const updatedConfig = { ...apiConfiguration }
-
-			// Which mode(s) to update?
 			const planActSeparateModelsSetting = controller.stateManager.getGlobalSettingsKey("planActSeparateModelsSetting")
 			const currentMode = controller.stateManager.getGlobalSettingsKey("mode")
+
 			const planModeSelectedModelId =
 				apiConfiguration?.planModeOcaModelId && models[apiConfiguration.planModeOcaModelId]
 					? apiConfiguration.planModeOcaModelId
@@ -91,23 +90,26 @@ export async function refreshOcaModels(controller: Controller, request: StringRe
 					? apiConfiguration.actModeOcaModelId
 					: defaultModelId!
 
-			// Save new model selection(s) to configuration object, per plan/act mode setting
+			// Build updates object based on plan/act mode setting
+			const updates: Partial<GlobalStateAndSettings> = {}
+
 			if (planActSeparateModelsSetting) {
 				if (currentMode === "plan") {
-					updatedConfig.planModeOcaModelId = planModeSelectedModelId
-					updatedConfig.planModeOcaModelInfo = models[planModeSelectedModelId]
+					updates.planModeOcaModelId = planModeSelectedModelId
+					updates.planModeOcaModelInfo = models[planModeSelectedModelId]
 				} else {
-					updatedConfig.actModeOcaModelId = actModeSelectedModelId
-					updatedConfig.actModeOcaModelInfo = models[actModeSelectedModelId]
+					updates.actModeOcaModelId = actModeSelectedModelId
+					updates.actModeOcaModelInfo = models[actModeSelectedModelId]
 				}
 			} else {
-				updatedConfig.planModeOcaModelId = planModeSelectedModelId
-				updatedConfig.planModeOcaModelInfo = models[planModeSelectedModelId]
-				updatedConfig.actModeOcaModelId = actModeSelectedModelId
-				updatedConfig.actModeOcaModelInfo = models[actModeSelectedModelId]
+				updates.planModeOcaModelId = planModeSelectedModelId
+				updates.planModeOcaModelInfo = models[planModeSelectedModelId]
+				updates.actModeOcaModelId = actModeSelectedModelId
+				updates.actModeOcaModelInfo = models[actModeSelectedModelId]
 			}
 
-			controller.stateManager.setApiConfiguration(updatedConfig)
+			// Update state directly using batch method
+			controller.stateManager.setGlobalStateBatch(updates)
 
 			HostProvider.window.showMessage({
 				type: ShowMessageType.INFORMATION,

--- a/src/core/controller/ui/initializeWebview.ts
+++ b/src/core/controller/ui/initializeWebview.ts
@@ -2,6 +2,7 @@ import { Empty, EmptyRequest } from "@shared/proto/cline/common"
 import { OpenRouterCompatibleModelInfo } from "@shared/proto/cline/models"
 import { readMcpMarketplaceCatalogFromCache } from "@/core/storage/disk"
 import { telemetryService } from "@/services/telemetry"
+import { GlobalStateAndSettings } from "@/shared/storage/state-keys"
 import type { Controller } from "../index"
 import { sendMcpMarketplaceCatalogEvent } from "../mcp/subscribeToMcpMarketplaceCatalog"
 import { refreshBasetenModels } from "../models/refreshBasetenModels"
@@ -39,32 +40,28 @@ export async function initializeWebview(controller: Controller, _request: EmptyR
 					const modelId = apiConfiguration[modelIdField]
 
 					if (modelId && response.models[modelId]) {
-						const updatedConfig = {
-							...apiConfiguration,
-							[modelInfoField]: response.models[modelId],
-						}
-						controller.stateManager.setApiConfiguration(updatedConfig)
+						controller.stateManager.setGlobalState(modelInfoField, response.models[modelId])
 						await controller.postStateToWebview()
 					}
 				} else {
 					// Shared models: update both plan and act modes
 					const planModelId = apiConfiguration.planModeOpenRouterModelId
 					const actModelId = apiConfiguration.actModeOpenRouterModelId
-					const updatedConfig = { ...apiConfiguration }
+					const updates: Partial<GlobalStateAndSettings> = {}
 
 					// Update plan mode model info if we have a model ID
 					if (planModelId && response.models[planModelId]) {
-						updatedConfig.planModeOpenRouterModelInfo = response.models[planModelId]
+						updates.planModeOpenRouterModelInfo = response.models[planModelId]
 					}
 
 					// Update act mode model info if we have a model ID
 					if (actModelId && response.models[actModelId]) {
-						updatedConfig.actModeOpenRouterModelInfo = response.models[actModelId]
+						updates.actModeOpenRouterModelInfo = response.models[actModelId]
 					}
 
 					// Post state update if we updated any model info
-					if ((planModelId && response.models[planModelId]) || (actModelId && response.models[actModelId])) {
-						controller.stateManager.setApiConfiguration(updatedConfig)
+					if (Object.keys(updates).length > 0) {
+						controller.stateManager.setGlobalStateBatch(updates)
 						await controller.postStateToWebview()
 					}
 				}
@@ -85,32 +82,28 @@ export async function initializeWebview(controller: Controller, _request: EmptyR
 					const modelId = apiConfiguration[modelIdField]
 
 					if (modelId && response.models[modelId]) {
-						const updatedConfig = {
-							...apiConfiguration,
-							[modelInfoField]: response.models[modelId],
-						}
-						controller.stateManager.setApiConfiguration(updatedConfig)
+						controller.stateManager.setGlobalState(modelInfoField, response.models[modelId])
 						await controller.postStateToWebview()
 					}
 				} else {
 					// Shared models: update both plan and act modes
 					const planModelId = apiConfiguration.planModeGroqModelId
 					const actModelId = apiConfiguration.actModeGroqModelId
-					const updatedConfig = { ...apiConfiguration }
+					const updates: Partial<GlobalStateAndSettings> = {}
 
 					// Update plan mode model info if we have a model ID
 					if (planModelId && response.models[planModelId]) {
-						updatedConfig.planModeGroqModelInfo = response.models[planModelId]
+						updates.planModeGroqModelInfo = response.models[planModelId]
 					}
 
 					// Update act mode model info if we have a model ID
 					if (actModelId && response.models[actModelId]) {
-						updatedConfig.actModeGroqModelInfo = response.models[actModelId]
+						updates.actModeGroqModelInfo = response.models[actModelId]
 					}
 
 					// Post state update if we updated any model info
-					if ((planModelId && response.models[planModelId]) || (actModelId && response.models[actModelId])) {
-						controller.stateManager.setApiConfiguration(updatedConfig)
+					if (Object.keys(updates).length > 0) {
+						controller.stateManager.setGlobalStateBatch(updates)
 						await controller.postStateToWebview()
 					}
 				}
@@ -175,32 +168,28 @@ export async function initializeWebview(controller: Controller, _request: EmptyR
 					const modelId = apiConfiguration[modelIdField]
 
 					if (modelId && response.models[modelId]) {
-						const updatedConfig = {
-							...apiConfiguration,
-							[modelInfoField]: response.models[modelId],
-						}
-						controller.stateManager.setApiConfiguration(updatedConfig)
+						controller.stateManager.setGlobalState(modelInfoField, response.models[modelId])
 						await controller.postStateToWebview()
 					}
 				} else {
 					// Shared models: update both plan and act modes
 					const planModelId = apiConfiguration.planModeVercelAiGatewayModelId
 					const actModelId = apiConfiguration.actModeVercelAiGatewayModelId
-					const updatedConfig = { ...apiConfiguration }
+					const updates: Partial<GlobalStateAndSettings> = {}
 
 					// Update plan mode model info if we have a model ID
 					if (planModelId && response.models[planModelId]) {
-						updatedConfig.planModeVercelAiGatewayModelInfo = response.models[planModelId]
+						updates.planModeVercelAiGatewayModelInfo = response.models[planModelId]
 					}
 
 					// Update act mode model info if we have a model ID
 					if (actModelId && response.models[actModelId]) {
-						updatedConfig.actModeVercelAiGatewayModelInfo = response.models[actModelId]
+						updates.actModeVercelAiGatewayModelInfo = response.models[actModelId]
 					}
 
 					// Post state update if we updated any model info
-					if ((planModelId && response.models[planModelId]) || (actModelId && response.models[actModelId])) {
-						controller.stateManager.setApiConfiguration(updatedConfig)
+					if (Object.keys(updates).length > 0) {
+						controller.stateManager.setGlobalStateBatch(updates)
 						await controller.postStateToWebview()
 					}
 				}


### PR DESCRIPTION


### Description

Don't use the full api configuration when refreshing models. Using setGlobalStateBatch is better, and we're working to get rid of the apiConfiguration object.

### Test Procedure

Build and check types

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [x] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Replace `apiConfiguration` with `setGlobalStateBatch` for model state updates in `refreshOcaModels.ts` and `initializeWebview.ts`.
> 
>   - **Behavior**:
>     - Replace `setApiConfiguration` with `setGlobalStateBatch` in `refreshOcaModels.ts` and `initializeWebview.ts` for updating model states.
>     - Directly update state using `setGlobalState` for individual model info updates in `initializeWebview.ts`.
>   - **State Management**:
>     - Remove `apiConfiguration` usage in favor of `setGlobalStateBatch` for batch updates.
>     - Use `setGlobalState` for single state updates when refreshing models.
>   - **Misc**:
>     - Add import for `GlobalStateAndSettings` in both `refreshOcaModels.ts` and `initializeWebview.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for c2eabee9de6f532e081bcb170f7b76c98d352c82. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->