### PR TITLE
Add Dockerfile and GitHub Actions workflow for Docker builds

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,33 @@
+name: Docker Build
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  docker-build:
+    runs-on: ubuntu-latest
+    name: Build Docker Image
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile
+          push: false
+          tags: cline:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM ubuntu:24.04
+
+RUN apt-get update && apt-get install -y \
+    nodejs \
+    npm \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN npm install -g cline
+


### PR DESCRIPTION
So users know how to build Dockerfile

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add Dockerfile and GitHub Actions workflow for building Docker images on main branch events.
> 
>   - **Dockerfile**:
>     - New `Dockerfile` added based on `ubuntu:24.04`.
>     - Installs `nodejs` and `npm`.
>     - Installs `cline` globally with SSL configuration adjustments.
>   - **GitHub Actions Workflow**:
>     - New workflow `docker-build.yml` triggers on `push` and `pull_request` to `main`.
>     - Sets up Docker Buildx and builds Docker image using `docker/build-push-action@v5`.
>     - Uses caching with `cache-from` and `cache-to` options.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for d8497ca5050b6a11a53eba2d1e50b3c1e1028170. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->