### PR TITLE
feat: Adding oracle code assist to the cli

### DIFF
--- a/.changeset/smooth-items-hammer.md
+++ b/.changeset/smooth-items-hammer.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": minor
+---
+
+Adding oca as a provider to cline cli

--- a/cli/pkg/cli/auth/models_list_fetch.go
+++ b/cli/pkg/cli/auth/models_list_fetch.go
@@ -21,6 +21,26 @@ func FetchOpenRouterModels(ctx context.Context, manager *task.Manager) (map[stri
 	return resp.Models, nil
 }
 
+// FetchOcaModels fetches available Oca models from Cline Core
+func FetchOcaModels(ctx context.Context, manager *task.Manager) (map[string]*cline.OcaModelInfo, error) {
+	resp, err := manager.GetClient().Models.RefreshOcaModels(ctx, &cline.StringRequest{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch Oca models: %w", err)
+	}
+	return resp.Models, nil
+}
+
+// ConvertOpenRouterModelsToInterface converts OpenRouter model map to generic interface map.
+// This allows OpenRouter and Cline models to be used with the generic fetching utilities.
+func ConvertOpenRouterModelsToInterface(models map[string]*cline.OpenRouterModelInfo) map[string]interface{} {
+	result := make(map[string]interface{}, len(models))
+	for k, v := range models {
+		result[k] = v
+	}
+	return result
+}
+
+
 // FetchOpenAiModels fetches available OpenAI models from Cline Core
 // Takes the API key and returns a list of model IDs
 func FetchOpenAiModels(ctx context.Context, manager *task.Manager, baseURL, apiKey string) ([]string, error) {
@@ -100,9 +120,9 @@ func ConvertModelsMapToSlice(models map[string]interface{}) []string {
 	return result
 }
 
-// ConvertOpenRouterModelsToInterface converts OpenRouter model map to generic interface map.
-// This allows OpenRouter and Cline models to be used with the generic fetching utilities.
-func ConvertOpenRouterModelsToInterface(models map[string]*cline.OpenRouterModelInfo) map[string]interface{} {
+// ConvertOcaModelsToInterface converts Oca model map to generic interface map.
+// This allows Oca and Cline models to be used with the generic fetching utilities.
+func ConvertOcaModelsToInterface(models map[string]*cline.OcaModelInfo) map[string]interface{} {
 	result := make(map[string]interface{}, len(models))
 	for k, v := range models {
 		result[k] = v

--- a/cli/pkg/cli/auth/providers_byo.go
+++ b/cli/pkg/cli/auth/providers_byo.go
@@ -26,6 +26,7 @@ func GetBYOProviderList() []BYOProviderOption {
 		{Name: "Google Gemini", Provider: cline.ApiProvider_GEMINI},
 		{Name: "Ollama", Provider: cline.ApiProvider_OLLAMA},
 		{Name: "Cerebras", Provider: cline.ApiProvider_CEREBRAS},
+		{Name: "Oracle Code Assist", Provider: cline.ApiProvider_OCA},
 	}
 }
 
@@ -71,6 +72,8 @@ func SupportsBYOModelFetching(provider cline.ApiProvider) bool {
 		return true
 	case cline.ApiProvider_OLLAMA:
 		return true
+	case cline.ApiProvider_OCA:
+		return true
 	}
 
 	return SupportsStaticModelList(provider)
@@ -97,6 +100,8 @@ func GetBYOProviderPlaceholder(provider cline.ApiProvider) string {
 		return "e.g., qwen3-coder:30b"
 	case cline.ApiProvider_CEREBRAS:
 		return "e.g., gpt-oss-120b"
+	case cline.ApiProvider_OCA:
+		return "e.g., oca/llama4"
 	default:
 		return "Enter model ID"
 	}

--- a/cli/pkg/cli/auth/update_api_configurations.go
+++ b/cli/pkg/cli/auth/update_api_configurations.go
@@ -12,7 +12,7 @@ import (
 )
 
 // updateApiConfigurationPartial is a helper that calls the gRPC method with optional verbose logging.
-// This replaces the Manager.UpdateApiConfigurationPartial method to keep auth-specific code in the auth package.
+// This replaces the Manager.updateApiConfigurationPartial method to keep auth-specific code in the auth package.
 func updateApiConfigurationPartial(ctx context.Context, manager *task.Manager, request *cline.UpdateApiConfigurationPartialRequest) error {
 	if global.Config.Verbose {
 		fmt.Println("[DEBUG] Updating API configuration (partial)")
@@ -144,6 +144,17 @@ func GetProviderFields(provider cline.ApiProvider) (ProviderFields, error) {
 			ActModeProviderSpecificModelIDField:  "actModeOpenRouterModelId",
 		}, nil
 
+	case cline.ApiProvider_OCA:
+		return ProviderFields{
+			APIKeyField:                          "ocaApiKey",
+			PlanModeModelIDField:                 "planModeApiModelId",
+			ActModeModelIDField:                  "actModeApiModelId",
+			PlanModeModelInfoField:               "planModeOcaModelInfo",
+			ActModeModelInfoField:                "actModeOcaModelInfo",
+			PlanModeProviderSpecificModelIDField: "planModeOcaModelId",
+			ActModeProviderSpecificModelIDField:  "actModeOcaModelId",
+		}, nil
+
 	default:
 		return ProviderFields{}, fmt.Errorf("unsupported provider: %v", provider)
 	}
@@ -152,9 +163,12 @@ func GetProviderFields(provider cline.ApiProvider) (ProviderFields, error) {
 // ProviderUpdatesPartial defines optional fields for partial provider updates
 // Uses pointers to distinguish between "not provided" and "set to empty"
 type ProviderUpdatesPartial struct {
-	ModelID   *string     // New model ID (optional)
-	APIKey    *string     // New API key (optional)
-	ModelInfo interface{} // New model info (optional, provider-specific)
+	ModelID      *string     // New model ID (optional)
+	APIKey       *string     // New API key (optional)
+	ModelInfo    interface{} // New model info (optional, provider-specific)
+	BaseURL      *string     // New base URL (optional, e.g., for OCA, Ollama)
+	RefreshToken *string     // New refresh token (optional, e.g., for OCA)
+	Mode         *string     // New mode (optional, e.g., "internal" or "external" for OCA)
 }
 
 // GetModelIDFieldName returns the appropriate model ID field name for a provider and mode.
@@ -252,6 +266,8 @@ func setAPIKeyField(apiConfig *cline.ModelsApiConfiguration, fieldName string, v
 		apiConfig.CerebrasApiKey = value
 	case "clineApiKey":
 		apiConfig.ClineApiKey = value
+	case "ocaApiKey":
+		apiConfig.OcaApiKey = value
 	}
 }
 
@@ -270,14 +286,9 @@ func setProviderSpecificModelID(apiConfig *cline.ModelsApiConfiguration, fieldNa
 	case "planModeAwsBedrockCustomModelBaseId":
 		apiConfig.PlanModeAwsBedrockCustomModelBaseId = value
 		apiConfig.ActModeAwsBedrockCustomModelBaseId = value
-	}
-}
-
-// setBaseURLField sets the appropriate base URL field in the config based on the field name
-func setBaseURLField(apiConfig *cline.ModelsApiConfiguration, fieldName string, value *string) {
-	switch fieldName {
-	case "openAiBaseUrl":
-		apiConfig.OpenAiBaseUrl = value
+	case "planModeOcaModelId":
+		apiConfig.PlanModeOcaModelId = value
+		apiConfig.ActModeOcaModelId = value
 	}
 }
 
@@ -443,6 +454,46 @@ func RemoveProviderPartial(ctx context.Context, manager *task.Manager, provider 
 	return nil
 }
 
+// setBaseURLField sets the appropriate base URL field in the config based on the field name
+func setBaseURLField(apiConfig *cline.ModelsApiConfiguration, fieldName string, value *string) {
+	switch fieldName {
+	case "ocaBaseUrl":
+		apiConfig.OcaBaseUrl = value
+	case "ollamaBaseUrl":
+		apiConfig.OllamaBaseUrl = value
+	case "openAiBaseUrl":
+		apiConfig.OpenAiBaseUrl = value
+	case "geminiBaseUrl":
+		apiConfig.GeminiBaseUrl = value
+	case "liteLlmBaseUrl":
+		apiConfig.LiteLlmBaseUrl = value
+	case "anthropicBaseUrl":
+		apiConfig.AnthropicBaseUrl = value
+	case "requestyBaseUrl":
+		apiConfig.RequestyBaseUrl = value
+	case "lmStudioBaseUrl":
+		apiConfig.LmStudioBaseUrl = value
+	case "oca":
+		apiConfig.OcaBaseUrl = value
+	}
+}
+
+// setRefreshTokenField sets the appropriate refresh token field in the config
+func setRefreshTokenField(apiConfig *cline.ModelsApiConfiguration, fieldName string, value *string) {
+	switch fieldName {
+	case "ocaRefreshToken":
+		apiConfig.OcaRefreshToken = value
+	}
+}
+
+// setModeField sets the appropriate mode field in the config
+func setModeField(apiConfig *cline.ModelsApiConfiguration, fieldName string, value *string) {
+	switch fieldName {
+	case "ocaMode":
+		apiConfig.OcaMode = value
+	}
+}
+
 // BedrockOptionalFields holds optional configuration fields for AWS Bedrock
 type BedrockOptionalFields struct {
 	SessionToken            *string // Optional: AWS session token for temporary credentials
@@ -454,6 +505,12 @@ type BedrockOptionalFields struct {
 	UseProfile              *bool   // Optional: Use AWS profile
 	Profile                 *string // Optional: AWS profile name
 	Endpoint                *string // Optional: Custom endpoint URL
+}
+
+// OcaOptionalFields holds optional configuration fields for Oracle Code Assist
+type OcaOptionalFields struct {
+	BaseURL *string // Optional: Base URL
+	Mode    *string // Optional: Mode ("internal" or "external")
 }
 
 // setBedrockOptionalFields sets optional Bedrock-specific fields in the API configuration
@@ -491,6 +548,20 @@ func setBedrockOptionalFields(apiConfig *cline.ModelsApiConfiguration, fields *B
 	}
 }
 
+// setOcaOptionalFields sets optional Oca-specific fields in the API configuration
+func setOcaOptionalFields(apiConfig *cline.ModelsApiConfiguration, fields *OcaOptionalFields) {
+	if fields == nil {
+		return
+	}
+
+	if fields.Mode != nil {
+		apiConfig.OcaMode = fields.Mode
+	}
+	if fields.BaseURL != nil {
+		apiConfig.OcaBaseUrl = fields.BaseURL
+	}
+}
+
 // buildBedrockOptionalFieldMask builds field mask paths for Bedrock optional fields that have values
 func buildBedrockOptionalFieldMask(fields *BedrockOptionalFields) []string {
 	if fields == nil {
@@ -525,6 +596,24 @@ func buildBedrockOptionalFieldMask(fields *BedrockOptionalFields) []string {
 	}
 	if fields.Endpoint != nil {
 		fieldPaths = append(fieldPaths, "awsBedrockEndpoint")
+	}
+
+	return fieldPaths
+}
+
+// buildOcaOptionalFieldMask builds field mask paths for Bedrock optional fields that have values
+func buildOcaOptionalFieldMask(fields *OcaOptionalFields) []string {
+	if fields == nil {
+		return nil
+	}
+
+	var fieldPaths []string
+
+	if fields.Mode != nil {
+		fieldPaths = append(fieldPaths, "ocaMode")
+	}
+	if fields.BaseURL != nil {
+		fieldPaths = append(fieldPaths, "ocaBaseUrl")
 	}
 
 	return fieldPaths

--- a/cli/pkg/cli/auth/wizard_byo.go
+++ b/cli/pkg/cli/auth/wizard_byo.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/charmbracelet/huh"
 	"github.com/cline/cli/pkg/cli/global"
@@ -107,7 +108,12 @@ func (pw *ProviderWizard) handleAddProvider() error {
 		return pw.handleAddBedrockProvider()
 	}
 
-	// Step 3: Get API key and optional baseURL (for non-Bedrock providers)
+	// Step 2b: Special handling for OCA provider
+	if provider == cline.ApiProvider_OCA {
+		return pw.handleAddOcaProvider()
+	}
+
+	// Step 3: Get API key first (for non-Bedrock providers)
 	apiKey, baseURL, err := PromptForAPIKey(provider)
 	if err != nil {
 		return fmt.Errorf("failed to get API key: %w", err)
@@ -159,6 +165,51 @@ func (pw *ProviderWizard) handleAddBedrockProvider() error {
 	}
 
 	fmt.Println("✓ Bedrock provider configured successfully!")
+	return nil
+}
+
+// handleAddOcaProvider handles adding Oracle Code Assist provider with optional settings and auth
+func (pw *ProviderWizard) handleAddOcaProvider() error {
+	// Step 1: Get OCA configuration (base URL and mode)
+	config, err := PromptForOcaConfig(pw.ctx, pw.manager)
+	if err != nil {
+		if strings.Contains(err.Error(), "user aborted") || strings.Contains(err.Error(), "cancelled") {
+			return nil
+		}
+		return fmt.Errorf("failed to get OCA configuration: %w", err)
+	}
+
+	// Apply OCA configuration (base URL and mode)
+	if err := ApplyOcaConfig(pw.ctx, pw.manager, config); err != nil {
+		return fmt.Errorf("failed to save OCA configuration: %w", err)
+	}
+
+	// Step 2: Ensure OCA authentication
+	if err := ensureOcaAuthenticated(pw.ctx); err != nil {
+		return fmt.Errorf("failed to authenticate with OCA: %w", err)
+	}
+
+	// Step 3: Select model
+	modelID, _, err := pw.selectModel(cline.ApiProvider_OCA, "")
+	if err != nil {
+		return fmt.Errorf("model selection failed: %w", err)
+	}
+
+	// Step 4: Apply the OCA model configuration and set as active
+	updates := ProviderUpdatesPartial{
+		ModelID:   &modelID,
+		ModelInfo: nil,
+	}
+
+	if err := UpdateProviderPartial(pw.ctx, pw.manager, cline.ApiProvider_OCA, updates, true); err != nil {
+		return fmt.Errorf("failed to save OCA configuration: %w", err)
+	}
+
+	if err := setWelcomeViewCompleted(pw.ctx, pw.manager); err != nil {
+		verboseLog("Warning: Failed to mark welcome view as completed: %v", err)
+	}
+
+	fmt.Println("✓ OCA provider configured successfully!")
 	return nil
 }
 
@@ -259,6 +310,15 @@ func (pw *ProviderWizard) fetchModelsForProvider(provider cline.ApiProvider, api
 		}
 		// Ollama returns just model IDs without additional info, so modelInfo map is nil
 		return modelIDs, nil, nil
+
+	case cline.ApiProvider_OCA:
+		// OCA supports dynamic model fetching
+		models, err := FetchOcaModels(pw.ctx, pw.manager)
+		if err != nil {
+			return nil, nil, err
+		}
+		interfaceMap := ConvertOcaModelsToInterface(models)
+		return ConvertModelsMapToSlice(interfaceMap), interfaceMap, nil
 	}
 
 	// Fall back to static models for providers that don't support dynamic fetching
@@ -525,8 +585,17 @@ func getProviderModelIDFromState(stateData map[string]interface{}, provider clin
 	return ""
 }
 
-// getProviderAPIKeyFromState retrieves the API key for a specific provider from state
+ // getProviderAPIKeyFromState retrieves the API key for a specific provider from state
 func getProviderAPIKeyFromState(stateData map[string]interface{}, provider cline.ApiProvider) string {
+	// OCA uses account authentication, not API keys. Consider it "present" if authenticated.
+	if provider == cline.ApiProvider_OCA {
+		if state, _ := GetLatestOCAState(context.TODO(), 2 * time.Second); state != nil && state.User != nil {
+			// Return a sentinel non-empty string so upstream checks pass.
+			return "OCA_AUTH_VERIFIED"
+		}
+		return ""
+	}
+
 	fields, err := GetProviderFields(provider)
 	if err != nil {
 		return ""
@@ -656,7 +725,16 @@ func (pw *ProviderWizard) handleRemoveProvider() error {
 		return nil
 	}
 
-	// Step 7: Clear the API key for the selected provider
+	// Step 7: If removing OCA, sign out first
+	if selectedProvider.Provider == cline.ApiProvider_OCA {
+		if err := signOutOca(pw.ctx); err != nil {
+			fmt.Printf("Warning: Failed to sign out of OCA: %v\n", err)
+		} else {
+			fmt.Println("Signed out of OCA.")
+		}
+	}
+
+	// Step 8: Clear the API key for the selected provider
 	if err := pw.clearProviderAPIKey(selectedProvider.Provider); err != nil {
 		return fmt.Errorf("failed to remove provider: %w", err)
 	}
@@ -668,6 +746,16 @@ func (pw *ProviderWizard) handleRemoveProvider() error {
 // clearProviderAPIKey clears the API key field for a specific provider using RemoveProviderPartial
 func (pw *ProviderWizard) clearProviderAPIKey(provider cline.ApiProvider) error {
 	return RemoveProviderPartial(pw.ctx, pw.manager, provider)
+}
+
+
+func signOutOca(ctx context.Context) error {
+	client, err := global.GetDefaultClient(ctx)
+	if err != nil {
+		return err
+	}
+	_, err = client.Ocaaccount.OcaAccountLogoutClicked(ctx, &cline.EmptyRequest{})
+	return err
 }
 
 func setWelcomeViewCompleted(ctx context.Context, manager *task.Manager) error {

--- a/cli/pkg/cli/auth/wizard_byo_oca.go
+++ b/cli/pkg/cli/auth/wizard_byo_oca.go
@@ -1,0 +1,366 @@
+package auth
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/charmbracelet/huh"
+	"github.com/cline/cli/pkg/cli/global"
+	"github.com/cline/cli/pkg/cli/task"
+	"github.com/cline/grpc-go/cline"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/fieldmaskpb"
+)
+
+// OcaConfig holds Oracle Code Assist (OCA) configuration fields
+type OcaConfig struct {
+	BaseURL string
+	Mode    string
+}
+
+// PromptForOcaConfig displays a form for OCA configuration (base URL and mode)
+func PromptForOcaConfig(ctx context.Context, manager *task.Manager) (*OcaConfig, error) {
+	config := &OcaConfig{}
+	var mode string
+
+	// Collect optional settings
+	configForm := huh.NewForm(
+		huh.NewGroup(
+			huh.NewInput().
+				Title("Base URL").
+				Value(&config.BaseURL).
+				Description("Leave empty to use default Base URL"),
+
+			huh.NewSelect[string]().
+				Title("Choose OCA mode (used for authentication)").
+				Description("Select 'Internal' to use Cline's internal OCA, or 'External' for your own OCA instance").
+				Options(
+					huh.NewOption("Internal", "internal"),
+					huh.NewOption("External", "external"),
+				).
+				Value(&mode),
+		),
+	)
+
+	if err := configForm.Run(); err != nil {
+		return nil, fmt.Errorf("failed to get OCA configuration: %w", err)
+	}
+
+	// Trim whitespace from string fields
+	config.BaseURL = strings.TrimSpace(config.BaseURL)
+	config.Mode = strings.TrimSpace(mode)
+
+	return config, nil
+}
+
+// ApplyOcaConfig applies OCA configuration using partial updates
+func ApplyOcaConfig(ctx context.Context, manager *task.Manager, config *OcaConfig) error {
+	// Build the API configuration with all OCA fields
+	apiConfig := &cline.ModelsApiConfiguration{}
+
+	// Set profile authentication fields (always required)
+	optionalFields := &OcaOptionalFields{}
+
+	// Set profile name (can be empty for default profile)
+	if config.BaseURL != "" {
+		optionalFields.BaseURL = proto.String(config.BaseURL)
+	}
+
+	// Set optional fields if provided
+	if config.Mode != "" {
+		optionalFields.Mode = proto.String(config.Mode)
+	}
+
+	// Apply all fields to the config
+	setOcaOptionalFields(apiConfig, optionalFields)
+
+	// Add profile authentication field paths
+	optionalPaths := buildOcaOptionalFieldMask(optionalFields)
+
+	// Create field mask
+	fieldMask := &fieldmaskpb.FieldMask{Paths: optionalPaths}
+
+	// Apply the partial update
+	request := &cline.UpdateApiConfigurationPartialRequest{
+		ApiConfiguration: apiConfig,
+		UpdateMask:       fieldMask,
+	}
+
+	if err := updateApiConfigurationPartial(ctx, manager, request); err != nil {
+		return fmt.Errorf("failed to apply OCA configuration: %w", err)
+	}
+
+	return nil
+}
+
+// ===========================
+// OCA Auth Listener Singleton
+// ===========================
+
+type ocaAuthStream interface {
+	Recv() (*cline.OcaAuthState, error)
+}
+
+// OcaAuthStatusListener manages subscription to OCA auth status updates
+type OcaAuthStatusListener struct {
+	stream        ocaAuthStream
+	updatesCh     chan *cline.OcaAuthState
+	errCh         chan error
+	ctx           context.Context
+	cancel        context.CancelFunc
+	mu            sync.RWMutex
+	lastState     *cline.OcaAuthState
+	firstEventCh  chan struct{}
+	firstEventOnce sync.Once
+}
+
+// NewOcaAuthStatusListener creates a new OCA auth status listener
+func NewOcaAuthStatusListener(parentCtx context.Context) (*OcaAuthStatusListener, error) {
+	client, err := global.GetDefaultClient(parentCtx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get client: %w", err)
+	}
+
+	// Keep the listener alive independently of short-lived caller contexts
+	ctx, cancel := context.WithCancel(context.Background())
+
+	// Subscribe to OCA auth status updates
+	stream, err := client.Ocaaccount.OcaSubscribeToAuthStatusUpdate(ctx, &cline.EmptyRequest{})
+	if err != nil {
+		cancel()
+		return nil, fmt.Errorf("failed to subscribe to OCA auth updates: %w", err)
+	}
+
+	return &OcaAuthStatusListener{
+		stream:       stream,
+		updatesCh:    make(chan *cline.OcaAuthState, 10),
+		errCh:        make(chan error, 1),
+		ctx:          ctx,
+		cancel:       cancel,
+		firstEventCh: make(chan struct{}),
+	}, nil
+}
+
+// Start begins listening to the auth status update stream
+func (l *OcaAuthStatusListener) Start() error {
+	go l.readStream()
+	return nil
+}
+
+func (l *OcaAuthStatusListener) readStream() {
+	defer close(l.updatesCh)
+	defer close(l.errCh)
+
+	for {
+		select {
+		case <-l.ctx.Done():
+			return
+		default:
+			state, err := l.stream.Recv()
+			if err != nil {
+				// Propagate error and exit
+				if err == io.EOF {
+					// Treat as error to notify waiters
+					err = fmt.Errorf("OCA auth status stream closed")
+				}
+				select {
+				case l.errCh <- err:
+				case <-l.ctx.Done():
+				}
+				return
+			}
+
+			l.mu.Lock()
+			l.lastState = state
+			l.mu.Unlock()
+
+			// Notify first event waiters
+			l.firstEventOnce.Do(func() { close(l.firstEventCh) })
+
+			select {
+			case l.updatesCh <- state:
+			case <-l.ctx.Done():
+				return
+			}
+		}
+	}
+}
+
+// WaitForFirstEvent blocks until the first event is received or timeout occurs
+func (l *OcaAuthStatusListener) WaitForFirstEvent(timeout time.Duration) error {
+	// Fast-path if already have a state
+	l.mu.RLock()
+	ready := l.lastState != nil
+	l.mu.RUnlock()
+	if ready {
+		return nil
+	}
+
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+
+	select {
+	case <-l.firstEventCh:
+		return nil
+	case <-timer.C:
+		return fmt.Errorf("timeout waiting for initial OCA auth event")
+	case <-l.ctx.Done():
+		return fmt.Errorf("OCA auth listener cancelled")
+	}
+}
+
+// IsAuthenticated returns true if the last known OCA auth state is authenticated
+func (l *OcaAuthStatusListener) IsAuthenticated() bool {
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+	return isOCAStateAuthenticated(l.lastState)
+}
+
+// WaitForAuthentication waits until OCA authentication succeeds or timeout occurs
+func (l *OcaAuthStatusListener) WaitForAuthentication(timeout time.Duration) error {
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+
+	// If already authenticated, return immediately
+	if l.IsAuthenticated() {
+		return nil
+	}
+
+	for {
+		select {
+		case <-timer.C:
+			return fmt.Errorf("OCA authentication timeout after %v - please try again", timeout)
+		case <-l.ctx.Done():
+			return fmt.Errorf("OCA authentication cancelled")
+		case err := <-l.errCh:
+			return fmt.Errorf("OCA authentication stream error: %w", err)
+		case state := <-l.updatesCh:
+			if isOCAStateAuthenticated(state) {
+				return nil
+			}
+		}
+	}
+}
+
+// Stop closes the stream and cleans up resources
+func (l *OcaAuthStatusListener) Stop() {
+	l.cancel()
+}
+
+func isOCAStateAuthenticated(state *cline.OcaAuthState) bool {
+	return state != nil && state.User != nil
+}
+
+// Singleton holder
+var (
+	ocaListener     *OcaAuthStatusListener
+	ocaListenerOnce sync.Once
+	ocaListenerErr  error
+)
+
+// GetOcaAuthListener returns the OCA auth listener singleton
+func GetOcaAuthListener(ctx context.Context) (*OcaAuthStatusListener, error) {
+	// Allow optional ctx: if nil, use context.TODO(). If already initialized, return singleton.
+	if ctx == nil {
+		ctx = context.TODO()
+	}
+
+	ocaListenerOnce.Do(func() {
+		l, err := NewOcaAuthStatusListener(ctx)
+		if err != nil {
+			ocaListenerErr = err
+			return
+		}
+		if err := l.Start(); err != nil {
+			ocaListenerErr = err
+			return
+		}
+		ocaListener = l
+	})
+	return ocaListener, ocaListenerErr
+}
+
+// IsOCAAuthenticated returns true if the global OCA auth status is authenticated.
+// It attempts a brief wait for the first event to avoid stale reads.
+func IsOCAAuthenticated(ctx context.Context) bool {
+	l, err := GetOcaAuthListener(ctx)
+	if err != nil {
+		return false
+	}
+	_ = l.WaitForFirstEvent(1 * time.Second) // best-effort
+	return l.IsAuthenticated()
+}
+
+ // LatestState returns the last received OCA auth state (may be nil)
+func (l *OcaAuthStatusListener) LatestState() *cline.OcaAuthState {
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+	return l.lastState
+}
+
+// GetLatestOCAState returns the latest known OCA auth state, optionally waiting for the first event
+func GetLatestOCAState(ctx context.Context, timeout time.Duration) (*cline.OcaAuthState, error) {
+	l, err := GetOcaAuthListener(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if timeout > 0 {
+		if err := l.WaitForFirstEvent(timeout); err != nil {
+			return nil, err
+		}
+	}
+	return l.LatestState(), nil
+}
+
+// ensureOcaAuthenticated initiates OCA login (if needed) and waits for success using the singleton listener
+func ensureOcaAuthenticated(ctx context.Context) error {
+	// Ensure listener exists
+	listener, err := GetOcaAuthListener(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to initialize OCA auth listener: %w", err)
+	}
+
+	// Briefly wait for first event to know current state
+	_ = listener.WaitForFirstEvent(1 * time.Second)
+
+	// If already authenticated, nothing to do
+	if listener.IsAuthenticated() {
+		fmt.Println("✓ OCA authentication already active.")
+		return nil
+	}
+
+	// Create gRPC client for initiating login
+	client, err := global.GetDefaultClient(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to obtain client: %w", err)
+	}
+
+	// Start login and wait for authentication
+	waitCtx, cancel := context.WithTimeout(ctx, 5*time.Minute)
+	defer cancel()
+
+	// Initiate login (opens the browser with a callback URL from Cline Core)
+	response, err := client.Ocaaccount.OcaAccountLoginClicked(waitCtx, &cline.EmptyRequest{})
+	if err != nil {
+		return fmt.Errorf("failed to initiate OCA login: %w", err)
+	}
+
+	fmt.Println("\nOpening browser for OCA authentication...")
+	if response != nil && response.Value != "" {
+		fmt.Printf("If the browser doesn't open automatically, visit this URL:\n%s\n\n", response.Value)
+	}
+	fmt.Println("Waiting for you to complete OCA authentication in your browser...")
+	fmt.Println("(This may take a few moments. Timeout: 5 minutes)")
+
+	// Block until authenticated or timeout
+	if err := listener.WaitForAuthentication(5 * time.Minute); err != nil {
+		return err
+	}
+
+	fmt.Println("✓ OCA authentication successful!")
+	return nil
+}

--- a/cli/pkg/generated/providers.go
+++ b/cli/pkg/generated/providers.go
@@ -144,6 +144,7 @@ const (
 	OPENAI_NATIVE = "openai-native"
 	XAI = "xai"
 	CEREBRAS = "cerebras"
+	OCA = "oca"
 )
 
 // AllProviders returns a slice of enabled provider IDs for the CLI build.
@@ -159,6 +160,7 @@ var AllProviders = []string{
 	"openai-native",
 	"xai",
 	"cerebras",
+	"oca",
 }
 
 // ConfigField represents a configuration field requirement
@@ -467,6 +469,16 @@ var rawModelDefinitions = `	{
 	      "supportsImages": true,
 	      "supportsPromptCache": true
 	    },
+	    "claude-haiku-4-5-20251001": {
+	      "maxTokens": 8192,
+	      "contextWindow": 200000,
+	      "inputPrice": 1,
+	      "outputPrice": 5,
+	      "cacheWritesPrice": 1,
+	      "cacheReadsPrice": 0,
+	      "supportsImages": true,
+	      "supportsPromptCache": true
+	    },
 	    "claude-sonnet-4-20250514": {
 	      "maxTokens": 8192,
 	      "contextWindow": 200000,
@@ -575,6 +587,16 @@ var rawModelDefinitions = `	{
 	      "inputPrice": 3,
 	      "outputPrice": 15,
 	      "cacheWritesPrice": 3,
+	      "cacheReadsPrice": 0,
+	      "supportsImages": true,
+	      "supportsPromptCache": true
+	    },
+	    "anthropic.claude-haiku-4-5-20251001-v1:0": {
+	      "maxTokens": 8192,
+	      "contextWindow": 200000,
+	      "inputPrice": 1,
+	      "outputPrice": 5,
+	      "cacheWritesPrice": 1,
 	      "cacheReadsPrice": 0,
 	      "supportsImages": true,
 	      "supportsPromptCache": true
@@ -1389,6 +1411,18 @@ func GetProviderDefinitions() (map[string]ProviderDefinition, error) {
 		HasDynamicModels: false,
 		SetupInstructions: `Get your API key from https://cloud.cerebras.ai/`,
 	}
+
+	// Oca
+	definitions["oca"] = ProviderDefinition{
+		ID:              "oca",
+		Name:            "Oca",
+		RequiredFields:  getFieldsByProvider("oca", configFields, true),
+		OptionalFields:  getFieldsByProvider("oca", configFields, false),
+		Models:          modelDefinitions["oca"],
+		DefaultModelID:  "",
+		HasDynamicModels: false,
+		SetupInstructions: `Configure Oca API credentials`,
+	}
 	
 	return definitions, nil
 }
@@ -1415,6 +1449,7 @@ func GetProviderDisplayName(providerID string) string {
 		"openai-native": "OpenAI",
 		"xai": "X AI (Grok)",
 		"cerebras": "Cerebras",
+		"oca": "Oca",
 	}
 	
 	if name, exists := displayNames[providerID]; exists {

--- a/scripts/cli-providers.mjs
+++ b/scripts/cli-providers.mjs
@@ -94,6 +94,7 @@ const ENABLED_PROVIDERS = [
 	"gemini", // Google Gemini
 	"ollama", // Ollama local models
 	"cerebras", // Cerebras models
+	"oca", // Oracle Code Assist
 ]
 
 /**


### PR DESCRIPTION
** This is a follow up PR for https://github.com/cline/cline/pull/7003 **
### Description

* We are adding oracle code assist as a provider to the cline cli tool.
* We updated the cli-providers.mjs
* We have intorduced an *oca_byo* file in the auth pkg.
* We have added a new provider handler for oca.
* We have also added a new select model and fetch model for oca


<!-- 
Help reviewers understand your changes by making this PR readable and well-organized:

- What problem does this PR solve?
This adds oracle code assist as a provider in cli
-->

### Test Procedure

<!-- 
Please walk us through your testing approach and thought process. This helps reviewers understand that you've thoroughly considered the impact of your changes:

- How did you test this change?
I was able to add oca as a provider, select model and call a task

We're not looking for exhaustive documentation - just evidence that you've thought through the implications of your changes and tested accordingly.
-->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<img width="1410" height="846" alt="image" src="https://github.com/user-attachments/assets/9c347721-0fc2-40b3-b313-fa24af55f1b5" />

<img width="1198" height="385" alt="image" src="https://github.com/user-attachments/assets/5923b812-632b-441f-bf67-3e8ac8567a68" />

<img width="1020" height="396" alt="image" src="https://github.com/user-attachments/assets/807d7f75-356a-4ab2-9870-8c6770dfe17f" />

<img width="1190" height="315" alt="image" src="https://github.com/user-attachments/assets/f0bae8d4-f752-4e30-8193-bc58fd71e87c" />


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds Oracle Code Assist (OCA) as a provider to the Cline CLI, including configuration, authentication, and model handling support.
> 
>   - **Behavior**:
>     - Adds Oracle Code Assist (OCA) as a provider in the Cline CLI.
>     - Supports OCA model fetching and authentication.
>     - Updates `cli-providers.mjs` to include OCA in `ENABLED_PROVIDERS`.
>   - **Configuration**:
>     - Adds OCA configuration handling in `auth/wizard_byo_oca.go` and `auth/update_api_configurations.go`.
>     - Introduces `OcaConfig` and `OcaOptionalFields` for OCA-specific settings.
>   - **Authentication**:
>     - Implements OCA authentication flow in `auth/wizard_byo_oca.go`.
>     - Adds `OcaAuthStatusListener` for managing OCA auth status updates.
>   - **Models**:
>     - Adds `FetchOcaModels()` in `auth/models_list_fetch.go` for OCA model retrieval.
>     - Updates `providers.go` to include OCA model definitions.
>   - **Misc**:
>     - Updates `global.go` and `cline-clients.go` to support OCA paths and configurations.
>     - Adds OCA to `GetProviderDisplayName()` and `GetProviderDefinitions()` in `providers.go`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 2bdad0beea870c9aa9db624b9f7adde40e0e4514. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->