### PR TITLE
Fix OpenAI Native provider base URL configuration

### DIFF
--- a/cli/pkg/cli/auth/providers_byo.go
+++ b/cli/pkg/cli/auth/providers_byo.go
@@ -126,9 +126,15 @@ func GetBYOAPIKeyFieldConfig(provider cline.ApiProvider) APIKeyFieldConfig {
 	}
 }
 
+// APIKeyAndBaseURL holds both API key and optional base URL for providers that support it
+type APIKeyAndBaseURL struct {
+	APIKey  string
+	BaseURL string // Empty string if not provided or not applicable
+}
+
 // PromptForAPIKey prompts the user to enter an API key (or base URL for Ollama).
 // For OpenAI Native provider, also prompts for an optional base URL.
-func PromptForAPIKey(provider cline.ApiProvider) (string, error) {
+func PromptForAPIKey(provider cline.ApiProvider) (APIKeyAndBaseURL, error) {
 	var apiKey string
 	config := GetBYOAPIKeyFieldConfig(provider)
 
@@ -149,12 +155,12 @@ func PromptForAPIKey(provider cline.ApiProvider) (string, error) {
 	form := huh.NewForm(huh.NewGroup(apiKeyField))
 
 	if err := form.Run(); err != nil {
-		return "", fmt.Errorf("failed to get API key: %w", err)
+		return APIKeyAndBaseURL{}, fmt.Errorf("failed to get API key: %w", err)
 	}
 
+	var baseURL string
 	// For OpenAI Native provider, also prompt for base URL
 	if provider == cline.ApiProvider_OPENAI_NATIVE {
-		var baseURL string
 		baseURLForm := huh.NewForm(
 			huh.NewGroup(
 				huh.NewInput().
@@ -166,12 +172,12 @@ func PromptForAPIKey(provider cline.ApiProvider) (string, error) {
 		)
 
 		if err := baseURLForm.Run(); err != nil {
-			return "", fmt.Errorf("failed to get base URL: %w", err)
+			return APIKeyAndBaseURL{}, fmt.Errorf("failed to get base URL: %w", err)
 		}
-
-		// TODO - connect baseURL
-		_ = baseURL
 	}
 
-	return apiKey, nil
+	return APIKeyAndBaseURL{
+		APIKey:  apiKey,
+		BaseURL: baseURL,
+	}, nil
 }

--- a/cli/pkg/cli/auth/wizard_byo.go
+++ b/cli/pkg/cli/auth/wizard_byo.go
@@ -108,19 +108,19 @@ func (pw *ProviderWizard) handleAddProvider() error {
 	}
 
 	// Step 3: Get API key first (for non-Bedrock providers)
-	apiKey, err := PromptForAPIKey(provider)
+	apiKeyAndBaseURL, err := PromptForAPIKey(provider)
 	if err != nil {
 		return fmt.Errorf("failed to get API key: %w", err)
 	}
 
 	// Step 4: Try to fetch models and let user select (with fallback to manual entry for providers that don't support fetch)
-	modelID, modelInfo, err := pw.selectModel(provider, apiKey)
+	modelID, modelInfo, err := pw.selectModel(provider, apiKeyAndBaseURL.APIKey)
 	if err != nil {
 		return fmt.Errorf("model selection failed: %w", err)
 	}
 
 	// Step 5: Apply configuration using AddProviderPartial
-	if err := AddProviderPartial(pw.ctx, pw.manager, provider, modelID, apiKey, modelInfo); err != nil {
+	if err := AddProviderPartial(pw.ctx, pw.manager, provider, modelID, apiKeyAndBaseURL.APIKey, modelInfo, apiKeyAndBaseURL.BaseURL); err != nil {
 		return fmt.Errorf("failed to save configuration: %w", err)
 	}
 


### PR DESCRIPTION
- Add APIKeyAndBaseURL struct to handle both API key and base URL
- Update PromptForAPIKey to collect and return base URL for OpenAI Native
- Modify AddProviderPartial to accept and store base URL in openAiBaseUrl field
- Connect base URL input to configuration storage (fixes TODO comment)
- Enable OpenAI Native provider to work with custom endpoints like LM Studio, LocalAI, etc.

Resolves issue where OpenAI Native provider was collecting base URL input but not using it.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes OpenAI Native provider base URL configuration by collecting, storing, and using the base URL in provider setup.
> 
>   - **Behavior**:
>     - `PromptForAPIKey` in `providers_byo.go` now returns `APIKeyAndBaseURL`, collecting both API key and base URL for OpenAI Native.
>     - `AddProviderPartial` in `update_api_configurations.go` updated to accept and store base URL for OpenAI Native.
>     - Base URL input is now connected to configuration storage, resolving a previous TODO.
>   - **Structures**:
>     - Added `APIKeyAndBaseURL` struct in `providers_byo.go` to encapsulate API key and base URL.
>   - **Functions**:
>     - Modified `handleAddProvider` in `wizard_byo.go` to use `APIKeyAndBaseURL` for OpenAI Native.
>     - Updated `AddProviderPartial` to include base URL in field mask if set for OpenAI Native.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 3a37a56878915b36406a24188b58e9adba6cb54b. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->