### PR TITLE
wire open command with -s flag to use tasksettings

### DIFF
--- a/proto/cline/state.proto
+++ b/proto/cline/state.proto
@@ -319,6 +319,7 @@ message UpdateSettingsRequestCli {
 message UpdateTaskSettingsRequest {
   Metadata metadata = 1;
   optional Settings settings = 2;
+  optional string task_id = 3;
 }
 
 // Message for updating settings

--- a/src/core/controller/state/updateTaskSettings.ts
+++ b/src/core/controller/state/updateTaskSettings.ts
@@ -35,12 +35,17 @@ export async function updateTaskSettings(controller: Controller, request: Update
 	}
 
 	try {
-		// Ensure we have an active task
-		if (!controller.task) {
-			throw new Error("No active task to update settings for")
+		// Get taskId from request first, otherwise fall back to current task
+		let taskId: string
+		if (request.taskId) {
+			taskId = request.taskId
+		} else {
+			// Use current task if no taskId is provided
+			if (!controller.task) {
+				throw new Error("No active task to update settings for")
+			}
+			taskId = controller.task.taskId
 		}
-
-		const taskId = controller.task.ulid
 
 		if (request.settings) {
 			// Extract all special case fields that need dedicated handlers


### PR DESCRIPTION

### Description

The `cline task open` command in the CLI with the `-s` flag was updating the global settings.

This PR adjusts it to use the task settings, keeping with what's expected as written in the --help menu for this command.

### Test Procedure

Look at the state and confirm the task has the proper settings.json.

Run `cline config list` and see that the setting is appearing properly.

Start a different task and confirm that `cline config list` shows the global setting instead.

Try setting a global secret  with `cline task open` and confirm that it goes to the global settings.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> `cline task open` command now applies task-specific settings with `-s` flag using `UpdateTaskSettings` RPC, separating global secrets handling.
> 
>   - **Behavior**:
>     - `cline task open` with `-s` flag now applies task-specific settings using `UpdateTaskSettings` RPC in `task.go`.
>     - Global secrets are handled separately and applied to global settings.
>   - **Protobuf**:
>     - Add `task_id` to `UpdateTaskSettingsRequest` in `state.proto`.
>   - **Controller Logic**:
>     - `updateTaskSettings()` in `updateTaskSettings.ts` now supports task-specific settings updates, including handling of `taskId`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for b41d2ee6ee469128d754997e1347f9230b1a5368. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->