### PR TITLE
connecting baseURL

### DIFF
--- a/cli/pkg/cli/auth/wizard_byo.go
+++ b/cli/pkg/cli/auth/wizard_byo.go
@@ -108,19 +108,19 @@ func (pw *ProviderWizard) handleAddProvider() error {
 	}
 
 	// Step 3: Get API key first (for non-Bedrock providers)
-	apiKey, err := PromptForAPIKey(provider)
+	credentials, err := PromptForAPIKey(provider)
 	if err != nil {
 		return fmt.Errorf("failed to get API key: %w", err)
 	}
 
 	// Step 4: Try to fetch models and let user select (with fallback to manual entry for providers that don't support fetch)
-	modelID, modelInfo, err := pw.selectModel(provider, apiKey)
+	modelID, modelInfo, err := pw.selectModel(provider, credentials.APIKey)
 	if err != nil {
 		return fmt.Errorf("model selection failed: %w", err)
 	}
 
 	// Step 5: Apply configuration using AddProviderPartial
-	if err := AddProviderPartial(pw.ctx, pw.manager, provider, modelID, apiKey, modelInfo); err != nil {
+	if err := AddProviderPartial(pw.ctx, pw.manager, provider, modelID, credentials, modelInfo); err != nil {
 		return fmt.Errorf("failed to save configuration: %w", err)
 	}
 


### PR DESCRIPTION
### Related Issue

https://github.com/cline/cline/issues/6936

### Description

The solution connects the base URL for OpenAI Native provider configuration.

providers_byo.go:
- Created `ProviderCredentials` struct to hold both API key and optional base URL
- Modified `PromptForAPIKey()` to return `*ProviderCredentials` instead of just a string
- When provider is `OPENAI_NATIVE`, the function now prompts for an optional base URL and stores it in the credentials `struct`


 wizard_byo.go:
- Updated the caller to use the new `ProviderCredentials` `struct`
- Passed `credentials.APIKey` to `selectModel()`
- Passed the entire credentials struct to `AddProviderPartial()`

 update_api_configurations.go:
- Modified `AddProviderPartial()` signature to accept `*ProviderCredentials` instead of just `apiKey` `string`
- Added logic to set `OpenAiBaseUrl` field when provider is `OPENAI_NATIVE` and base URL is provided
- Added `openAiBaseUrl` to the field mask when base URL is present

### Test Procedure

<!-- 
Please walk us through your testing approach and thought process. This helps reviewers understand that you've thoroughly considered the impact of your changes:

- How did you test this change?
- What could potentially break and how did you verify it doesn't?
- What existing functionality might be affected and how did you check it still works?
- Why are you confident this is ready for merge?

We're not looking for exhaustive documentation - just evidence that you've thought through the implications of your changes and tested accordingly.
-->

### Type of Change

-   [X] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [X] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [X] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Introduces `ProviderCredentials` struct to handle API key and optional base URL for OpenAI Native provider, updating related functions to accommodate this change.
> 
>   - **Behavior**:
>     - `PromptForAPIKey()` in `providers_byo.go` now returns `*ProviderCredentials` instead of `string`, prompting for optional base URL for `OPENAI_NATIVE`.
>     - `AddProviderPartial()` in `update_api_configurations.go` updated to accept `*ProviderCredentials`, sets `OpenAiBaseUrl` if provided.
>   - **Structs**:
>     - New `ProviderCredentials` struct in `providers_byo.go` to hold `APIKey` and `BaseURL`.
>   - **Function Updates**:
>     - `handleAddProvider()` in `wizard_byo.go` updated to use `ProviderCredentials`.
>     - `selectModel()` in `wizard_byo.go` now uses `credentials.APIKey`.
>     - `AddProviderPartial()` signature changed to accept `*ProviderCredentials`.
>   - **Misc**:
>     - Added logic to include `openAiBaseUrl` in field mask if base URL is provided in `update_api_configurations.go`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 8c5b7294c63ecfe5120e464b15ee43d8729ccb22. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->