### PR TITLE
Fixed proto name issue

### DIFF
--- a/.changeset/fruity-crabs-mate.md
+++ b/.changeset/fruity-crabs-mate.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Fixed proto naming issue - RPC >>> Rpc

--- a/cli/pkg/cli/auth/models_list_fetch.go
+++ b/cli/pkg/cli/auth/models_list_fetch.go
@@ -14,7 +14,7 @@ import (
 
 // FetchOpenRouterModels fetches available OpenRouter models from Cline Core
 func FetchOpenRouterModels(ctx context.Context, manager *task.Manager) (map[string]*cline.OpenRouterModelInfo, error) {
-	resp, err := manager.GetClient().Models.RefreshOpenRouterModelsRPC(ctx, &cline.EmptyRequest{})
+	resp, err := manager.GetClient().Models.RefreshOpenRouterModelsRpc(ctx, &cline.EmptyRequest{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch OpenRouter models: %w", err)
 	}

--- a/proto/cline/models.proto
+++ b/proto/cline/models.proto
@@ -16,13 +16,13 @@ service ModelsService {
   // Fetches available models from VS Code LM API
   rpc getVsCodeLmModels(EmptyRequest) returns (VsCodeLmModelsArray);
   // Refreshes and returns OpenRouter models
-  rpc refreshOpenRouterModelsRPC(EmptyRequest) returns (OpenRouterCompatibleModelInfo);
+  rpc refreshOpenRouterModelsRpc(EmptyRequest) returns (OpenRouterCompatibleModelInfo);
   // Refreshes and returns Hugging Face models
   rpc refreshHuggingFaceModels(EmptyRequest) returns (OpenRouterCompatibleModelInfo);
   // Refreshes and returns OpenAI models
   rpc refreshOpenAiModels(OpenAiModelsRequest) returns (StringArray);
   // Refreshes and returns Vercel AI Gateway models
-  rpc refreshVercelAiGatewayModelsRPC(EmptyRequest) returns (OpenRouterCompatibleModelInfo);
+  rpc refreshVercelAiGatewayModelsRpc(EmptyRequest) returns (OpenRouterCompatibleModelInfo);
   // Refreshes and returns Requesty models
   rpc refreshRequestyModels(EmptyRequest) returns (OpenRouterCompatibleModelInfo);
   // Subscribe to OpenRouter models updates
@@ -32,9 +32,9 @@ service ModelsService {
   // Updates API configuration with partial values (only updates fields that are explicitly set)
   rpc updateApiConfigurationPartial(UpdateApiConfigurationPartialRequest) returns (Empty);
   // Refreshes and returns Groq models
-  rpc refreshGroqModelsRPC(EmptyRequest) returns (OpenRouterCompatibleModelInfo);
+  rpc refreshGroqModelsRpc(EmptyRequest) returns (OpenRouterCompatibleModelInfo);
   // Refreshes and returns Baseten models
-  rpc refreshBasetenModelsRPC(EmptyRequest) returns (OpenRouterCompatibleModelInfo);
+  rpc refreshBasetenModelsRpc(EmptyRequest) returns (OpenRouterCompatibleModelInfo);
   // Fetches available models from SAP AI Core
   rpc getSapAiCoreModels(SapAiCoreModelsRequest) returns (SapAiCoreModelsResponse);
   // Fetches available models from OCA

--- a/src/core/controller/models/refreshBasetenModelsRpc.ts
+++ b/src/core/controller/models/refreshBasetenModelsRpc.ts
@@ -10,7 +10,7 @@ import { refreshBasetenModels } from "./refreshBasetenModels"
  * @param request Empty request object
  * @returns Response containing Baseten models (protobuf types)
  */
-export async function refreshBasetenModelsRPC(
+export async function refreshBasetenModelsRpc(
 	controller: Controller,
 	_request: EmptyRequest,
 ): Promise<OpenRouterCompatibleModelInfo> {

--- a/src/core/controller/models/refreshGroqModelsRpc.ts
+++ b/src/core/controller/models/refreshGroqModelsRpc.ts
@@ -10,7 +10,7 @@ import { refreshGroqModels } from "./refreshGroqModels"
  * @param request Empty request object
  * @returns Response containing Groq models (protobuf types)
  */
-export async function refreshGroqModelsRPC(
+export async function refreshGroqModelsRpc(
 	controller: Controller,
 	_request: EmptyRequest,
 ): Promise<OpenRouterCompatibleModelInfo> {

--- a/src/core/controller/models/refreshOpenRouterModelsRpc.ts
+++ b/src/core/controller/models/refreshOpenRouterModelsRpc.ts
@@ -10,7 +10,7 @@ import { refreshOpenRouterModels } from "./refreshOpenRouterModels"
  * @param request Empty request (unused but required for gRPC signature)
  * @returns OpenRouterCompatibleModelInfo with protobuf types
  */
-export async function refreshOpenRouterModelsRPC(
+export async function refreshOpenRouterModelsRpc(
 	controller: Controller,
 	_request: EmptyRequest,
 ): Promise<OpenRouterCompatibleModelInfo> {

--- a/src/core/controller/models/refreshVercelAiGatewayModelsRpc.ts
+++ b/src/core/controller/models/refreshVercelAiGatewayModelsRpc.ts
@@ -10,7 +10,7 @@ import { refreshVercelAiGatewayModels } from "./refreshVercelAiGatewayModels"
  * @param request Empty request object
  * @returns Response containing Vercel AI Gateway models (protobuf types)
  */
-export async function refreshVercelAiGatewayModelsRPC(
+export async function refreshVercelAiGatewayModelsRpc(
 	controller: Controller,
 	_request: EmptyRequest,
 ): Promise<OpenRouterCompatibleModelInfo> {

--- a/webview-ui/src/components/settings/BasetenModelPicker.tsx
+++ b/webview-ui/src/components/settings/BasetenModelPicker.tsx
@@ -53,7 +53,7 @@ const BasetenModelPicker: React.FC<BasetenModelPickerProps> = ({ isPopup, curren
 	}, [apiConfiguration, currentMode])
 
 	useMount(() => {
-		ModelsServiceClient.refreshBasetenModelsRPC(EmptyRequest.create({}))
+		ModelsServiceClient.refreshBasetenModelsRpc(EmptyRequest.create({}))
 			.then((response) => {
 				setBasetenModels({
 					[basetenDefaultModelId]: basetenModels[basetenDefaultModelId],

--- a/webview-ui/src/components/settings/GroqModelPicker.tsx
+++ b/webview-ui/src/components/settings/GroqModelPicker.tsx
@@ -53,7 +53,7 @@ const GroqModelPicker: React.FC<GroqModelPickerProps> = ({ isPopup, currentMode 
 	}, [apiConfiguration, currentMode])
 
 	useMount(() => {
-		ModelsServiceClient.refreshGroqModelsRPC(EmptyRequest.create({}))
+		ModelsServiceClient.refreshGroqModelsRpc(EmptyRequest.create({}))
 			.then((response) => {
 				setGroqModels({
 					[groqDefaultModelId]: groqModels[groqDefaultModelId],

--- a/webview-ui/src/components/settings/providers/VercelAIGatewayProvider.tsx
+++ b/webview-ui/src/components/settings/providers/VercelAIGatewayProvider.tsx
@@ -35,7 +35,7 @@ export const VercelAIGatewayProvider = ({ showModelOptions, isPopup, currentMode
 	useMount(() => {
 		if (showModelOptions) {
 			setIsLoadingModels(true)
-			ModelsServiceClient.refreshVercelAiGatewayModelsRPC(EmptyRequest.create({}))
+			ModelsServiceClient.refreshVercelAiGatewayModelsRpc(EmptyRequest.create({}))
 				.then((response) => {
 					if (response && response.models) {
 						setVercelAiGatewayModels(fromProtobufModels(response.models))

--- a/webview-ui/src/context/ExtensionStateContext.tsx
+++ b/webview-ui/src/context/ExtensionStateContext.tsx
@@ -620,7 +620,7 @@ export const ExtensionStateContextProvider: React.FC<{
 	}, [])
 
 	const refreshOpenRouterModels = useCallback(() => {
-		ModelsServiceClient.refreshOpenRouterModelsRPC(EmptyRequest.create({}))
+		ModelsServiceClient.refreshOpenRouterModelsRpc(EmptyRequest.create({}))
 			.then((response: OpenRouterCompatibleModelInfo) => {
 				const models = fromProtobufModels(response.models)
 				setOpenRouterModels({


### PR DESCRIPTION
<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- For feature requests: Created a discussion in our Feature Requests discussions board https://github.com/cline/cline/discussions/categories/feature-requests and received approval from core maintainers before implementation
- For all changes: Link the associated issue/discussion in the "Related Issue" section below

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly without prior discussion.

Why this requirement?
We deeply appreciate all community contributions - they are essential to Cline's success! To ensure the best use of everyone's time and maintain project direction, we use our Feature Requests discussions board to gauge community interest and validate feature ideas before implementation begins. This helps us focus development efforts on features that will benefit the most users.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** #XXXX

### Description

The protobuf convention treats acronyms as single words, so when the proto defined refreshOpenRouterModels**RPC**, protoc created RefreshOpenRouterModels**Rpc** instead, which manifested as an error when trying to switch Cline models in the CLI. Changing it to refreshOpenRouterModelsRpc fixed the issue. Also updated the other affected providers. 

https://protobuf.dev/programming-guides/style/

> In all cases, treat abbreviations as though they are single words: use GetDnsRequest rather than GetDNSRequest, dns_request rather than d_n_s_request

### Test Procedure

<!-- 
Please walk us through your testing approach and thought process. This helps reviewers understand that you've thoroughly considered the impact of your changes:

- How did you test this change?
- What could potentially break and how did you verify it doesn't?
- What existing functionality might be affected and how did you check it still works?
- Why are you confident this is ready for merge?

We're not looking for exhaustive documentation - just evidence that you've thought through the implications of your changes and tested accordingly.
-->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [ ] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->
Related to #6981 

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes protobuf RPC naming convention by changing 'RPC' to 'Rpc' across multiple files and methods.
> 
>   - **Behavior**:
>     - Fixes naming convention for protobuf RPC methods by changing `refreshOpenRouterModelsRPC` to `refreshOpenRouterModelsRpc` in `models.proto` and `models_list_fetch.go`.
>     - Updates similar RPC method names in `models.proto` for `refreshVercelAiGatewayModels`, `refreshGroqModels`, and `refreshBasetenModels`.
>   - **Functions**:
>     - Renames `refreshOpenRouterModelsRPC()` to `refreshOpenRouterModelsRpc()` in `refreshOpenRouterModelsRpc.ts`.
>     - Renames `refreshVercelAiGatewayModelsRPC()` to `refreshVercelAiGatewayModelsRpc()` in `refreshVercelAiGatewayModelsRpc.ts`.
>     - Renames `refreshGroqModelsRPC()` to `refreshGroqModelsRpc()` in `refreshGroqModelsRpc.ts`.
>     - Renames `refreshBasetenModelsRPC()` to `refreshBasetenModelsRpc()` in `refreshBasetenModelsRpc.ts`.
>   - **UI Components**:
>     - Updates `BasetenModelPicker.tsx`, `GroqModelPicker.tsx`, and `VercelAIGatewayProvider.tsx` to use the renamed RPC methods.
>   - **Context**:
>     - Updates `ExtensionStateContext.tsx` to use the renamed `refreshOpenRouterModelsRpc()` method.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for abd395cddfbc9849276e551ae6d3022639bb89bd. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->