### PR TITLE
feat(commit): respect Preferred Language in commit message generation

### DIFF
--- a/.changeset/evil-buttons-walk.md
+++ b/.changeset/evil-buttons-walk.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": minor
+---
+
+Make commit message generator honor Preferred Language setting

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "claude-dev",
-	"version": "3.33.1",
+	"version": "3.34.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "claude-dev",
-			"version": "3.33.1",
+			"version": "3.34.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@anthropic-ai/sdk": "^0.37.0",

--- a/src/hosts/vscode/commit-message-generator.ts
+++ b/src/hosts/vscode/commit-message-generator.ts
@@ -1,4 +1,5 @@
 import { buildApiHandler } from "@core/api"
+import { DEFAULT_LANGUAGE_SETTINGS, getLanguageKey, LanguageDisplay } from "@shared/Languages"
 import * as vscode from "vscode"
 import { StateManager } from "@/core/storage/StateManager"
 import { HostProvider } from "@/hosts/host-provider"
@@ -67,6 +68,15 @@ async function performCommitGeneration(stateManager: StateManager, gitDiff: stri
 		vscode.commands.executeCommand("setContext", "cline.isGeneratingCommit", true)
 
 		const prompts = [PROMPT.instruction]
+
+		// Respect user's preferred language setting for commit messages
+		const preferredLanguageRaw = stateManager.getGlobalSettingsKey("preferredLanguage")
+		const preferredLanguage = getLanguageKey(preferredLanguageRaw as LanguageDisplay)
+		if (preferredLanguage && preferredLanguage !== DEFAULT_LANGUAGE_SETTINGS) {
+			// Follow existing pattern used in task system: "Speak in <langKey>."
+			// This keeps conventional commit type prefixes intact while changing body language.
+			prompts.push(`# Preferred Language\n\nSpeak in ${preferredLanguage}.`)
+		}
 
 		const currentInput = inputBox?.value?.trim() || ""
 		if (currentInput) {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> `performCommitGeneration()` in `commit-message-generator.ts` now respects the user's preferred language setting for commit messages.
> 
>   - **Behavior**:
>     - `performCommitGeneration()` in `commit-message-generator.ts` now respects the user's preferred language setting for commit messages.
>     - Retrieves `preferredLanguage` from `StateManager` and adjusts prompts if it differs from `DEFAULT_LANGUAGE_SETTINGS`.
>     - Adds language-specific prompt: "Speak in <langKey>." to maintain conventional commit type prefixes.
>   - **Misc**:
>     - Adds import for `DEFAULT_LANGUAGE_SETTINGS`, `getLanguageKey`, and `LanguageDisplay` from `@shared/Languages`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 5cc1d6e72457bbd08f7c9c948ccb91b1d4b4980e. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->