### PR TITLE
feat(provider): add Gatewayz provider (OpenAI-compatible) + docs + UI + CLI generation

### DIFF
--- a/cli/pkg/generated/providers.go
+++ b/cli/pkg/generated/providers.go
@@ -144,6 +144,7 @@ const (
 	OPENAI_NATIVE = "openai-native"
 	XAI = "xai"
 	CEREBRAS = "cerebras"
+	GATEWAYZ = "gatewayz"
 )
 
 // AllProviders returns a slice of enabled provider IDs for the CLI build.
@@ -159,6 +160,7 @@ var AllProviders = []string{
 	"openai-native",
 	"xai",
 	"cerebras",
+	"gatewayz",
 }
 
 // ConfigField represents a configuration field requirement
@@ -317,6 +319,15 @@ var rawConfigFields = `	[
 	    "placeholder": "Enter your API key"
 	  },
 	  {
+	    "name": "gatewayzApiKey",
+	    "type": "string",
+	    "comment": "",
+	    "category": "gatewayz",
+	    "required": true,
+	    "fieldType": "password",
+	    "placeholder": "Enter your API key"
+	  },
+	  {
 	    "name": "ulid",
 	    "type": "string",
 	    "comment": "Used to identify the task in API requests",
@@ -416,6 +427,15 @@ var rawConfigFields = `	[
 	    "placeholder": ""
 	  },
 	  {
+	    "name": "gatewayzBaseUrl",
+	    "type": "string",
+	    "comment": "",
+	    "category": "general",
+	    "required": false,
+	    "fieldType": "url",
+	    "placeholder": "https://api.example.com"
+	  },
+	  {
 	    "name": "onRetryAttempt",
 	    "type": "(attempt: number, maxRetries: number, delay: number, error: any) => void",
 	    "comment": "",
@@ -463,6 +483,16 @@ var rawModelDefinitions = `	{
 	      "inputPrice": 3,
 	      "outputPrice": 15,
 	      "cacheWritesPrice": 3,
+	      "cacheReadsPrice": 0,
+	      "supportsImages": true,
+	      "supportsPromptCache": true
+	    },
+	    "claude-haiku-4-5-20251001": {
+	      "maxTokens": 8192,
+	      "contextWindow": 200000,
+	      "inputPrice": 1,
+	      "outputPrice": 5,
+	      "cacheWritesPrice": 1,
 	      "cacheReadsPrice": 0,
 	      "supportsImages": true,
 	      "supportsPromptCache": true
@@ -575,6 +605,16 @@ var rawModelDefinitions = `	{
 	      "inputPrice": 3,
 	      "outputPrice": 15,
 	      "cacheWritesPrice": 3,
+	      "cacheReadsPrice": 0,
+	      "supportsImages": true,
+	      "supportsPromptCache": true
+	    },
+	    "anthropic.claude-haiku-4-5-20251001-v1:0": {
+	      "maxTokens": 8192,
+	      "contextWindow": 200000,
+	      "inputPrice": 1,
+	      "outputPrice": 5,
+	      "cacheWritesPrice": 1,
 	      "cacheReadsPrice": 0,
 	      "supportsImages": true,
 	      "supportsPromptCache": true
@@ -744,6 +784,24 @@ var rawModelDefinitions = `	{
 	      "supportsImages": false,
 	      "supportsPromptCache": false,
 	      "description": "A compact 20B open-weight Mixture-of-Experts language model designed for strong reasoning and tool use, ideal for edge devices and local inference."
+	    },
+	    "qwen.qwen3-coder-30b-a3b-v1:0": {
+	      "maxTokens": 8192,
+	      "contextWindow": 262144,
+	      "inputPrice": 0,
+	      "outputPrice": 0,
+	      "supportsImages": false,
+	      "supportsPromptCache": false,
+	      "description": "Qwen3 Coder 30B MoE model with 3.3B activated parameters, optimized for code generation and analysis with 256K context window."
+	    },
+	    "qwen.qwen3-coder-480b-a35b-v1:0": {
+	      "maxTokens": 8192,
+	      "contextWindow": 262144,
+	      "inputPrice": 0,
+	      "outputPrice": 1,
+	      "supportsImages": false,
+	      "supportsPromptCache": false,
+	      "description": "Qwen3 Coder 480B flagship MoE model with 35B activated parameters, designed for complex coding tasks with advanced reasoning capabilities and 256K context window."
 	    }
 	  },
 	  "gemini": {
@@ -1389,6 +1447,18 @@ func GetProviderDefinitions() (map[string]ProviderDefinition, error) {
 		HasDynamicModels: false,
 		SetupInstructions: `Get your API key from https://cloud.cerebras.ai/`,
 	}
+
+	// Gatewayz
+	definitions["gatewayz"] = ProviderDefinition{
+		ID:              "gatewayz",
+		Name:            "Gatewayz",
+		RequiredFields:  getFieldsByProvider("gatewayz", configFields, true),
+		OptionalFields:  getFieldsByProvider("gatewayz", configFields, false),
+		Models:          modelDefinitions["gatewayz"],
+		DefaultModelID:  "gatewayz/default",
+		HasDynamicModels: false,
+		SetupInstructions: `Configure Gatewayz API credentials`,
+	}
 	
 	return definitions, nil
 }
@@ -1415,6 +1485,7 @@ func GetProviderDisplayName(providerID string) string {
 		"openai-native": "OpenAI",
 		"xai": "X AI (Grok)",
 		"cerebras": "Cerebras",
+		"gatewayz": "Gatewayz",
 	}
 	
 	if name, exists := displayNames[providerID]; exists {

--- a/docs/provider-config/gatewayz.mdx
+++ b/docs/provider-config/gatewayz.mdx
@@ -1,0 +1,25 @@
+---
+title: "Gatewayz"
+description: "Configure Gatewayz with Cline (API key, base URL, model selection)."
+---
+
+**Website:** https://gatewayz.io
+
+### Getting an API Key
+
+1. Sign up or sign in at the Gatewayz console.
+2. Find API keys under the account or developer section.
+3. Create a key (name it e.g. "Cline") and copy it.
+
+### Configuration in Cline
+
+1. Open Cline settings.
+2. Choose "Gatewayz" from the API Provider dropdown.
+3. Paste your Gatewayz API key into the "Gatewayz API Key" field.
+4. (Optional) Enable a custom base URL and paste your Gatewayz endpoint.
+5. Select a model from the Model dropdown.
+
+### Notes
+
+- Gatewayz exposes a unified OpenAI-compatible endpoint. Cline uses the OpenAI client to connect. If Gatewayz requires special headers, request parameters, or a model naming pattern, we can adjust the handler to match.
+- Monitor Gatewayz billing. Cline creates usage chunks but prices in docs/provider-config reflect placeholders; update with Gatewayz pricing when available.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "claude-dev",
-	"version": "3.33.1",
+	"version": "3.34.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "claude-dev",
-			"version": "3.33.1",
+			"version": "3.34.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@anthropic-ai/sdk": "^0.37.0",

--- a/scripts/cli-providers.mjs
+++ b/scripts/cli-providers.mjs
@@ -94,6 +94,7 @@ const ENABLED_PROVIDERS = [
 	"gemini", // Google Gemini
 	"ollama", // Ollama local models
 	"cerebras", // Cerebras models
+	"gatewayz", // Gatewayz
 ]
 
 /**
@@ -116,9 +117,9 @@ function extractDefaultModelIds(content) {
 	for (const regex of patterns) {
 		// Reset regex state for each pattern
 		regex.lastIndex = 0
-		let match
+		let match = regex.exec(content)
 
-		while ((match = regex.exec(content)) !== null) {
+		while (match !== null) {
 			const [, providerPrefix, modelId] = match
 			// Map prefix to provider ID (e.g., "anthropic" -> "anthropic", "openAiNative" -> "openai-native")
 			const providerId = providerPrefix
@@ -132,6 +133,7 @@ function extractDefaultModelIds(content) {
 				const cleanModelId = modelId.split(":")[0]
 				defaultIds[providerId] = cleanModelId
 			}
+			match = regex.exec(content)
 		}
 	}
 
@@ -263,7 +265,6 @@ function parseConfigurationFields(optionsContent, providerApiKeyMap, apiSecretsF
 	// These are the actual authentication fields that need to be collected
 	for (const fieldName of apiSecretsFields.fieldNames) {
 		const fieldInfo = apiSecretsFields.fields[fieldName]
-		const lowerName = fieldName.toLowerCase()
 
 		// Determine which provider this field belongs to
 		let category = "general"
@@ -373,7 +374,7 @@ function parseConfigurationFields(optionsContent, providerApiKeyMap, apiSecretsF
 
 		// Check if this field is required for any provider using the auto-discovered API key map
 		// A field is marked as required if it appears in any provider's required fields list
-		for (const [providerId, requiredFields] of Object.entries(providerApiKeyMap)) {
+		for (const [_providerId, requiredFields] of Object.entries(providerApiKeyMap)) {
 			if (requiredFields.includes(name)) {
 				required = true
 				break
@@ -826,7 +827,7 @@ func getFieldsByProvider(providerID string, allFields []ConfigField, required bo
 /**
  * Generate provider metadata for each provider
  */
-function generateProviderMetadata(providers, configFields, modelDefinitions, defaultModelIds) {
+function generateProviderMetadata(providers, _configFields, modelDefinitions, defaultModelIds) {
 	return providers
 		.map((providerId) => {
 			const displayName = getProviderDisplayName(providerId)
@@ -906,14 +907,18 @@ function getDefaultModelId(providerId, models, defaultModelIds) {
 
 	// Fallback to pattern matching if no explicit default was found
 	const modelIds = Object.keys(models)
-	if (modelIds.length === 0) return ""
+	if (modelIds.length === 0) {
+		return ""
+	}
 
 	// Look for common default patterns
 	const defaultPatterns = ["latest", "default", "sonnet", "gpt-4", "claude-3", "gemini-pro"]
 
 	for (const pattern of defaultPatterns) {
 		const match = modelIds.find((id) => id.toLowerCase().includes(pattern))
-		if (match) return match
+		if (match) {
+			return match
+		}
 	}
 
 	// Return first model if no pattern matches
@@ -1002,7 +1007,7 @@ async function main() {
 }
 
 // Add helper function to the generated Go code
-const helperFunction = `
+const _helperFunction = `
 // getFieldsByProvider filters configuration fields by provider and requirement
 func getFieldsByProvider(providerID string, allFields []ConfigField, required bool) []ConfigField {
 	var fields []ConfigField

--- a/src/core/api/index.ts
+++ b/src/core/api/index.ts
@@ -12,6 +12,7 @@ import { DeepSeekHandler } from "./providers/deepseek"
 import { DifyHandler } from "./providers/dify"
 import { DoubaoHandler } from "./providers/doubao"
 import { FireworksHandler } from "./providers/fireworks"
+import { GatewayzHandler } from "./providers/gatewayz"
 import { GeminiHandler } from "./providers/gemini"
 import { GroqHandler } from "./providers/groq"
 import { HuaweiCloudMaaSHandler } from "./providers/huawei-cloud-maas"
@@ -388,6 +389,17 @@ function createHandlerForProvider(
 						? options.planModeOcaModelInfo?.supportsPromptCache
 						: options.actModeOcaModelInfo?.supportsPromptCache,
 				taskId: options.ulid,
+			})
+		case "gatewayz":
+			return new GatewayzHandler({
+				onRetryAttempt: options.onRetryAttempt,
+				gatewayzBaseUrl: options.gatewayzBaseUrl,
+				gatewayzApiKey: options.gatewayzApiKey,
+				gatewayzModelId: mode === "plan" ? options.planModeGatewayzModelId : options.actModeGatewayzModelId,
+				gatewayzModelInfo: mode === "plan" ? options.planModeGatewayzModelInfo : options.actModeGatewayzModelInfo,
+				reasoningEffort: mode === "plan" ? options.planModeReasoningEffort : options.actModeReasoningEffort,
+				thinkingBudgetTokens:
+					mode === "plan" ? options.planModeThinkingBudgetTokens : options.actModeThinkingBudgetTokens,
 			})
 		default:
 			return new AnthropicHandler({

--- a/src/core/api/providers/gatewayz.ts
+++ b/src/core/api/providers/gatewayz.ts
@@ -1,0 +1,109 @@
+import { Anthropic } from "@anthropic-ai/sdk"
+import { gatewayzDefaultModelId, gatewayzDefaultModelInfo, ModelInfo } from "@shared/api"
+import { calculateApiCostOpenAI } from "@utils/cost"
+import OpenAI from "openai"
+import { ApiHandler, CommonApiHandlerOptions } from "../"
+import { withRetry } from "../retry"
+import { convertToOpenAiMessages } from "../transform/openai-format"
+import { ApiStream } from "../transform/stream"
+
+interface GatewayzHandlerOptions extends CommonApiHandlerOptions {
+	gatewayzBaseUrl?: string
+	gatewayzApiKey?: string
+	gatewayzModelId?: string
+	gatewayzModelInfo?: ModelInfo
+	reasoningEffort?: string
+	thinkingBudgetTokens?: number
+}
+
+export class GatewayzHandler implements ApiHandler {
+	private options: GatewayzHandlerOptions
+	private client: OpenAI | undefined
+
+	constructor(options: GatewayzHandlerOptions) {
+		this.options = options
+	}
+
+	private ensureClient(): OpenAI {
+		if (!this.client) {
+			if (!this.options.gatewayzApiKey) {
+				throw new Error("Gatewayz API key is required")
+			}
+			try {
+				const baseURL = this.options.gatewayzBaseUrl || "https://api.gatewayz.io"
+				this.client = new OpenAI({
+					baseURL,
+					apiKey: this.options.gatewayzApiKey,
+					defaultHeaders: {
+						"HTTP-Referer": "https://cline.bot",
+						"X-Title": "Cline",
+					},
+				})
+			} catch (error: any) {
+				throw new Error(`Error creating Gatewayz client: ${error.message}`)
+			}
+		}
+		return this.client
+	}
+
+	@withRetry()
+	async *createMessage(systemPrompt: string, messages: Anthropic.Messages.MessageParam[]): ApiStream {
+		const client = this.ensureClient()
+		const model = this.getModel()
+
+		// Convert messages to OpenAI chat messages
+		const openAiMessages = [{ role: "system", content: systemPrompt }, ...convertToOpenAiMessages(messages)]
+
+		// We'll stream using the OpenAI SDK
+		const stream = await client.chat.completions.create({
+			model: model.id,
+			messages: openAiMessages,
+			max_tokens: model.info.maxTokens || undefined,
+			temperature: 0,
+			stream: true,
+			stream_options: { include_usage: true },
+		})
+
+		let lastUsage: any
+
+		for await (const chunk of stream) {
+			const delta = chunk.choices?.[0]?.delta
+			if (delta?.content) {
+				yield { type: "text", text: delta.content }
+			}
+
+			// Gatewayz (OpenAI-compatible) may include usage in chunks
+			if (chunk.usage) {
+				lastUsage = chunk.usage
+			}
+		}
+
+		// After stream finishes, emit usage summary if we can
+		if (lastUsage) {
+			const inputTokens = lastUsage.prompt_tokens || 0
+			const outputTokens = lastUsage.completion_tokens || 0
+			const cacheWriteTokens = lastUsage.prompt_tokens_details?.caching_tokens
+			const cacheReadTokens = lastUsage.prompt_tokens_details?.cached_tokens
+
+			const totalCost = calculateApiCostOpenAI(model.info, inputTokens, outputTokens, cacheWriteTokens, cacheReadTokens)
+
+			yield {
+				type: "usage",
+				inputTokens,
+				outputTokens,
+				cacheWriteTokens,
+				cacheReadTokens,
+				totalCost,
+			}
+		}
+	}
+
+	getModel(): { id: string; info: ModelInfo } {
+		const modelId = this.options.gatewayzModelId
+		const modelInfo = this.options.gatewayzModelInfo
+		if (modelId && modelInfo) {
+			return { id: modelId, info: modelInfo }
+		}
+		return { id: gatewayzDefaultModelId, info: gatewayzDefaultModelInfo }
+	}
+}

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -37,6 +37,7 @@ export type ApiProvider =
 	| "vercel-ai-gateway"
 	| "zai"
 	| "oca"
+	| "gatewayz"
 
 export interface ApiHandlerSecrets {
 	apiKey?: string // anthropic
@@ -75,6 +76,7 @@ export interface ApiHandlerSecrets {
 	basetenApiKey?: string
 	vercelAiGatewayApiKey?: string
 	difyApiKey?: string
+	gatewayzApiKey?: string
 }
 
 export interface ApiHandlerOptions {
@@ -117,6 +119,7 @@ export interface ApiHandlerOptions {
 	sapAiCoreBaseUrl?: string
 	sapAiCoreUseOrchestrationMode?: boolean
 	difyBaseUrl?: string
+	gatewayzBaseUrl?: string
 	zaiApiLine?: string
 	onRetryAttempt?: (attempt: number, maxRetries: number, delay: number, error: any) => void
 	ocaBaseUrl?: string
@@ -155,6 +158,8 @@ export interface ApiHandlerOptions {
 	planModeVercelAiGatewayModelInfo?: ModelInfo
 	planModeOcaModelId?: string
 	planModeOcaModelInfo?: OcaModelInfo
+	planModeGatewayzModelId?: string
+	planModeGatewayzModelInfo?: ModelInfo
 	// Act mode configurations
 
 	// Act mode configurations
@@ -190,6 +195,8 @@ export interface ApiHandlerOptions {
 	actModeVercelAiGatewayModelInfo?: ModelInfo
 	actModeOcaModelId?: string
 	actModeOcaModelInfo?: OcaModelInfo
+	actModeGatewayzModelId?: string
+	actModeGatewayzModelInfo?: ModelInfo
 }
 
 export type ApiConfiguration = ApiHandlerOptions &
@@ -3826,3 +3833,20 @@ export const qwenCodeModels = {
 } as const satisfies Record<string, ModelInfo>
 export type QwenCodeModelId = keyof typeof qwenCodeModels
 export const qwenCodeDefaultModelId: QwenCodeModelId = "qwen3-coder-plus"
+
+// Gatewayz
+// https://gatewayz.io
+export type GatewayzModelId = keyof typeof gatewayzModels
+export const gatewayzDefaultModelId: GatewayzModelId = "gatewayz/default"
+export const gatewayzDefaultModelInfo: ModelInfo = {
+	maxTokens: 8192,
+	contextWindow: 32768,
+	supportsImages: false,
+	supportsPromptCache: false,
+	inputPrice: 0.0,
+	outputPrice: 0.0,
+	description: "Gatewayz default model",
+}
+export const gatewayzModels = {
+	"gatewayz/default": gatewayzDefaultModelInfo,
+} as const satisfies Record<string, ModelInfo>

--- a/webview-ui/src/components/settings/ApiOptions.tsx
+++ b/webview-ui/src/components/settings/ApiOptions.tsx
@@ -23,6 +23,7 @@ import { DeepSeekProvider } from "./providers/DeepSeekProvider"
 import { DifyProvider } from "./providers/DifyProvider"
 import { DoubaoProvider } from "./providers/DoubaoProvider"
 import { FireworksProvider } from "./providers/FireworksProvider"
+import { GatewayzProvider } from "./providers/GatewayzProvider"
 import { GeminiProvider } from "./providers/GeminiProvider"
 import { GroqProvider } from "./providers/GroqProvider"
 import { HuaweiCloudMaasProvider } from "./providers/HuaweiCloudMaasProvider"
@@ -163,6 +164,7 @@ const ApiOptions = ({ showModelOptions, apiErrorMessage, modelIdErrorMessage, is
 			{ value: "huawei-cloud-maas", label: "Huawei Cloud MaaS" },
 			{ value: "dify", label: "Dify.ai" },
 			{ value: "oca", label: "Oracle Code Assist" },
+			{ value: "gatewayz", label: "Gatewayz" },
 		]
 
 		if (PLATFORM_CONFIG.type !== PlatformType.VSCODE) {
@@ -505,6 +507,10 @@ const ApiOptions = ({ showModelOptions, apiErrorMessage, modelIdErrorMessage, is
 			)}
 
 			{apiConfiguration && selectedProvider === "oca" && <OcaProvider currentMode={currentMode} isPopup={isPopup} />}
+
+			{apiConfiguration && selectedProvider === "gatewayz" && (
+				<GatewayzProvider currentMode={currentMode} isPopup={isPopup} showModelOptions={showModelOptions} />
+			)}
 
 			{apiErrorMessage && (
 				<p

--- a/webview-ui/src/components/settings/providers/GatewayzProvider.tsx
+++ b/webview-ui/src/components/settings/providers/GatewayzProvider.tsx
@@ -1,0 +1,79 @@
+import { gatewayzModels } from "@shared/api"
+import { Mode } from "@shared/storage/types"
+import { VSCodeCheckbox } from "@vscode/webview-ui-toolkit/react"
+import { useState } from "react"
+import { useExtensionState } from "@/context/ExtensionStateContext"
+import { ApiKeyField } from "../common/ApiKeyField"
+import { DebouncedTextField } from "../common/DebouncedTextField"
+import { ModelSelector } from "../common/ModelSelector"
+import { normalizeApiConfiguration } from "../utils/providerUtils"
+import { useApiConfigurationHandlers } from "../utils/useApiConfigurationHandlers"
+
+interface GatewayzProviderProps {
+	showModelOptions: boolean
+	isPopup?: boolean
+	currentMode: Mode
+}
+
+export const GatewayzProvider = ({ showModelOptions, isPopup, currentMode }: GatewayzProviderProps) => {
+	const { apiConfiguration } = useExtensionState()
+	const { handleFieldChange, handleModeFieldChange } = useApiConfigurationHandlers()
+	const [gatewayzEndpointSelected, setGatewayzEndpointSelected] = useState(!!apiConfiguration?.gatewayzBaseUrl)
+
+	const { selectedModelId } = normalizeApiConfiguration(apiConfiguration, currentMode)
+
+	const signupUrl = apiConfiguration?.gatewayzBaseUrl
+		? new URL("api-keys", apiConfiguration.gatewayzBaseUrl).toString()
+		: "https://gatewayz.io"
+
+	return (
+		<div>
+			<ApiKeyField
+				initialValue={apiConfiguration?.gatewayzApiKey || ""}
+				onChange={(value) => handleFieldChange("gatewayzApiKey", value)}
+				providerName="Gatewayz"
+				signupUrl={signupUrl}
+			/>
+			<VSCodeCheckbox
+				checked={gatewayzEndpointSelected}
+				onChange={(e: any) => {
+					const isChecked = e.target.checked === true
+					setGatewayzEndpointSelected(isChecked)
+					if (!isChecked) {
+						handleFieldChange("gatewayzBaseUrl", undefined)
+					}
+				}}>
+				Use custom base URL
+			</VSCodeCheckbox>
+			{gatewayzEndpointSelected && (
+				<DebouncedTextField
+					initialValue={apiConfiguration?.gatewayzBaseUrl ?? ""}
+					onChange={(value) => {
+						if (value.length === 0) {
+							handleFieldChange("gatewayzBaseUrl", undefined)
+						} else {
+							handleFieldChange("gatewayzBaseUrl", value)
+						}
+					}}
+					placeholder="Custom base URL"
+					style={{ width: "100%", marginBottom: 5 }}
+					type="text"
+				/>
+			)}
+			{showModelOptions && (
+				<ModelSelector
+					label="Model"
+					models={gatewayzModels}
+					onChange={(e: any) =>
+						handleModeFieldChange(
+							{ plan: "planModeGatewayzModelId", act: "actModeGatewayzModelId" },
+							e.target.value,
+							currentMode,
+						)
+					}
+					selectedModelId={selectedModelId}
+				/>
+			)}
+		</div>
+	)
+}

--- a/webview-ui/src/components/settings/utils/providerUtils.ts
+++ b/webview-ui/src/components/settings/utils/providerUtils.ts
@@ -19,6 +19,8 @@ import {
 	doubaoModels,
 	fireworksDefaultModelId,
 	fireworksModels,
+	gatewayzDefaultModelId,
+	gatewayzModels,
 	geminiDefaultModelId,
 	geminiModels,
 	groqDefaultModelId,
@@ -357,6 +359,8 @@ export function normalizeApiConfiguration(
 				selectedModelId: ocaModelId || "",
 				selectedModelInfo: ocaModelInfo || liteLlmModelInfoSaneDefaults,
 			}
+		case "gatewayz":
+			return getProviderData(gatewayzModels, gatewayzDefaultModelId)
 		default:
 			return getProviderData(anthropicModels, anthropicDefaultModelId)
 	}
@@ -624,6 +628,7 @@ export async function syncModeConfigurations(
 			break
 
 		// Providers that use apiProvider + apiModelId fields
+		case "gatewayz":
 		case "anthropic":
 		case "claude-code":
 		case "vertex":


### PR DESCRIPTION
This PR adds Gatewayz as an official provider for Cline.

## Included:
- API model and config schema additions in `src/shared/api.ts`
- Gatewayz API handler `src/core/api/providers/gatewayz.ts` (OpenAI-compatible streaming)
- Wiring into provider factory `src/core/api/index.ts`
- Webview settings UI `webview-ui/src/components/settings/providers/GatewayzProvider.tsx` and registration in `ApiOptions.tsx` + providerUtils
- Documentation at `docs/provider-config/gatewayz.mdx`
- Added `gatewayz` to the CLI providers whitelist in `scripts/cli-providers.mjs` and regenerated `cli/pkg/generated/providers.go`

## Notes:
- The implementation assumes Gatewayz supports an OpenAI-compatible streaming chat completions endpoint
- Model entries and pricing in `src/shared/api.ts` are placeholders. Please replace them with Gatewayz's real model IDs and pricing once available

## Checklist for reviewers:
- [ ] Confirm model IDs and pricing are correct in `src/shared/api.ts`
- [ ] Confirm Gatewayz supports the OpenAI-compatible streaming API used in `gatewayz.ts`
- [ ] Confirm UI copy and the signup URL are correct in `docs/provider-config/gatewayz.mdx`
- [ ] Confirm `cli/pkg/generated/providers.go` is committed after running `node scripts/cli-providers.mjs` locally
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds Gatewayz as an OpenAI-compatible provider to Cline, including API, UI, CLI, and documentation updates.
> 
>   - **Behavior**:
>     - Adds Gatewayz as a new provider in `src/shared/api.ts`, supporting OpenAI-compatible streaming.
>     - Implements `GatewayzHandler` in `src/core/api/providers/gatewayz.ts` for API interactions.
>     - Integrates Gatewayz into provider factory in `src/core/api/index.ts`.
>   - **UI**:
>     - Adds `GatewayzProvider` component in `webview-ui/src/components/settings/providers/GatewayzProvider.tsx`.
>     - Updates `ApiOptions.tsx` to include Gatewayz in provider dropdown.
>   - **CLI**:
>     - Adds Gatewayz to CLI providers in `scripts/cli-providers.mjs`.
>     - Regenerates `cli/pkg/generated/providers.go` to include Gatewayz.
>   - **Documentation**:
>     - Adds configuration guide for Gatewayz in `docs/provider-config/gatewayz.mdx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for fb35abbdac8a64e058cec0821ff3672546d5d87c. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->