### PR TITLE
fix: error_retry message breaking browser session row flow

### DIFF
--- a/webview-ui/src/components/chat/BrowserSessionRow.tsx
+++ b/webview-ui/src/components/chat/BrowserSessionRow.tsx
@@ -198,7 +198,8 @@ const BrowserSessionRow = memo((props: BrowserSessionRowProps) => {
 				message.say === "api_req_started" ||
 				message.say === "text" ||
 				message.say === "reasoning" ||
-				message.say === "browser_action"
+				message.say === "browser_action" ||
+				message.say === "error_retry"
 			) {
 				// These messages lead to the next result, so they should always go in nextActionMessages
 				nextActionMessages.push(message)
@@ -539,6 +540,7 @@ const BrowserSessionRowContent = memo(
 					case "api_req_started":
 					case "text":
 					case "reasoning":
+					case "error_retry":
 						return (
 							<div style={chatRowContentContainerStyle}>
 								<ChatRowContent

--- a/webview-ui/src/components/chat/chat-view/utils/messageUtils.ts
+++ b/webview-ui/src/components/chat/chat-view/utils/messageUtils.ts
@@ -65,6 +65,7 @@ export function isBrowserSessionMessage(message: ClineMessage): boolean {
 			"browser_action_result",
 			"checkpoint_created",
 			"reasoning",
+			"error_retry",
 		].includes(message.say!)
 	}
 	return false


### PR DESCRIPTION
Chat messages are grouped during a browser session and displayed in a BrowserSessionRow, however if the group is broken with an unexpected message it breaks apart the BrowserSessionRow.

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add handling for `error_retry` messages in browser session flow in `BrowserSessionRow.tsx` and `messageUtils.ts`.
> 
>   - **Behavior**:
>     - Add `error_retry` to the list of message types that lead to the next result in `BrowserSessionRow` and `BrowserSessionRowContent` in `BrowserSessionRow.tsx`.
>     - Include `error_retry` in `isBrowserSessionMessage()` in `messageUtils.ts` to ensure it is recognized as part of a browser session.
>   - **Misc**:
>     - No changes to constants or other utility functions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 3487c2200f26403815de069c4ad03026b4f98a44. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->