### PR TITLE
feat(settings): allow Minimax models with :free suffix for Cline provider

### DIFF
--- a/webview-ui/src/components/settings/OpenRouterModelPicker.tsx
+++ b/webview-ui/src/components/settings/OpenRouterModelPicker.tsx
@@ -126,8 +126,15 @@ const OpenRouterModelPicker: React.FC<OpenRouterModelPickerProps> = ({ isPopup, 
 		const unfilteredModelIds = Object.keys(openRouterModels).sort((a, b) => a.localeCompare(b))
 
 		if (modeFields.apiProvider === "cline") {
-			// For Cline provider: exclude :free models
-			return unfilteredModelIds.filter((id) => !id.includes(":free"))
+			// For Cline provider: exclude :free models, but keep Minimax models
+			return unfilteredModelIds.filter((id) => {
+				// Keep all Minimax models regardless of :free suffix
+				if (id.toLowerCase().includes("minimax-m2")) {
+					return true
+				}
+				// Filter out other :free models
+				return !id.includes(":free")
+			})
 		} else {
 			// For OpenRouter provider: exclude Cline-specific models
 			return unfilteredModelIds.filter((id) => !id.startsWith("cline/"))


### PR DESCRIPTION
Update OpenRouterModelPicker to include Minimax M2 models even when they have the :free suffix. Previously, all :free models were filtered out for the Cline provider, but Minimax models should be available regardless of their pricing tier to ensure users have access to these specific models.
<img width="463" height="921" alt="image" src="https://github.com/user-attachments/assets/d009fca0-e857-4b20-b0b7-6e3ab6b9b892" />



### Description


### Test Procedure



### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [ ] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `OpenRouterModelPicker` to include Minimax M2 models with `:free` suffix for Cline provider.
> 
>   - **Behavior**:
>     - Update `OpenRouterModelPicker` in `OpenRouterModelPicker.tsx` to include Minimax M2 models with `:free` suffix for Cline provider.
>     - Previously, all `:free` models were excluded for Cline; now Minimax models are included regardless of suffix.
>   - **Filtering Logic**:
>     - Modify filtering logic in `OpenRouterModelPicker` to check for `minimax-m2` in model IDs and include them even if they have `:free` suffix.
>     - Other `:free` models remain excluded for Cline provider.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for dc425719b53a76f386bcdf0fce9c65fe6b2997b3. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->