### PR TITLE
Use anthropic 1M models only when necessary on bedrock

### DIFF
--- a/.changeset/spotty-guests-fail.md
+++ b/.changeset/spotty-guests-fail.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Use anthropic 1M models only when necessary on bedrock

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,8 +11,8 @@
 			"dependencies": {
 				"@anthropic-ai/sdk": "^0.37.0",
 				"@anthropic-ai/vertex-sdk": "^0.6.4",
-				"@aws-sdk/client-bedrock-runtime": "^3.840.0",
-				"@aws-sdk/credential-providers": "^3.840.0",
+				"@aws-sdk/client-bedrock-runtime": "^3.919.0",
+				"@aws-sdk/credential-providers": "^3.919.0",
 				"@bufbuild/protobuf": "^2.2.5",
 				"@cerebras/cerebras_cloud_sdk": "^1.35.0",
 				"@google-cloud/vertexai": "^1.9.3",
@@ -197,6 +197,8 @@
 		},
 		"node_modules/@aws-crypto/crc32": {
 			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
+			"integrity": "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-crypto/util": "^5.2.0",
@@ -206,10 +208,6 @@
 			"engines": {
 				"node": ">=16.0.0"
 			}
-		},
-		"node_modules/@aws-crypto/crc32/node_modules/tslib": {
-			"version": "2.8.1",
-			"license": "0BSD"
 		},
 		"node_modules/@aws-crypto/sha256-browser": {
 			"version": "5.2.0",
@@ -256,10 +254,6 @@
 				"node": ">=14.0.0"
 			}
 		},
-		"node_modules/@aws-crypto/sha256-browser/node_modules/tslib": {
-			"version": "2.6.3",
-			"license": "0BSD"
-		},
 		"node_modules/@aws-crypto/sha256-js": {
 			"version": "5.2.0",
 			"license": "Apache-2.0",
@@ -272,20 +266,12 @@
 				"node": ">=16.0.0"
 			}
 		},
-		"node_modules/@aws-crypto/sha256-js/node_modules/tslib": {
-			"version": "2.8.1",
-			"license": "0BSD"
-		},
 		"node_modules/@aws-crypto/supports-web-crypto": {
 			"version": "5.2.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^2.6.2"
 			}
-		},
-		"node_modules/@aws-crypto/supports-web-crypto/node_modules/tslib": {
-			"version": "2.6.3",
-			"license": "0BSD"
 		},
 		"node_modules/@aws-crypto/util": {
 			"version": "5.2.0",
@@ -328,655 +314,611 @@
 				"node": ">=14.0.0"
 			}
 		},
-		"node_modules/@aws-crypto/util/node_modules/tslib": {
-			"version": "2.8.1",
-			"license": "0BSD"
-		},
 		"node_modules/@aws-sdk/client-bedrock-runtime": {
-			"version": "3.840.0",
+			"version": "3.919.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.919.0.tgz",
+			"integrity": "sha512-l1jcUNAhoBDaV+2mte1hRr1qjF9D6uRXXPfqp8pKToXcoGTQUo/piEBFYpmgZ5wmBZGnU4zk5WQ6u4mlK8gJdg==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-crypto/sha256-browser": "5.2.0",
 				"@aws-crypto/sha256-js": "5.2.0",
-				"@aws-sdk/core": "3.840.0",
-				"@aws-sdk/credential-provider-node": "3.840.0",
-				"@aws-sdk/eventstream-handler-node": "3.840.0",
-				"@aws-sdk/middleware-eventstream": "3.840.0",
-				"@aws-sdk/middleware-host-header": "3.840.0",
-				"@aws-sdk/middleware-logger": "3.840.0",
-				"@aws-sdk/middleware-recursion-detection": "3.840.0",
-				"@aws-sdk/middleware-user-agent": "3.840.0",
-				"@aws-sdk/region-config-resolver": "3.840.0",
-				"@aws-sdk/token-providers": "3.840.0",
-				"@aws-sdk/types": "3.840.0",
-				"@aws-sdk/util-endpoints": "3.840.0",
-				"@aws-sdk/util-user-agent-browser": "3.840.0",
-				"@aws-sdk/util-user-agent-node": "3.840.0",
-				"@smithy/config-resolver": "^4.1.4",
-				"@smithy/core": "^3.6.0",
-				"@smithy/eventstream-serde-browser": "^4.0.4",
-				"@smithy/eventstream-serde-config-resolver": "^4.1.2",
-				"@smithy/eventstream-serde-node": "^4.0.4",
-				"@smithy/fetch-http-handler": "^5.0.4",
-				"@smithy/hash-node": "^4.0.4",
-				"@smithy/invalid-dependency": "^4.0.4",
-				"@smithy/middleware-content-length": "^4.0.4",
-				"@smithy/middleware-endpoint": "^4.1.13",
-				"@smithy/middleware-retry": "^4.1.14",
-				"@smithy/middleware-serde": "^4.0.8",
-				"@smithy/middleware-stack": "^4.0.4",
-				"@smithy/node-config-provider": "^4.1.3",
-				"@smithy/node-http-handler": "^4.0.6",
-				"@smithy/protocol-http": "^5.1.2",
-				"@smithy/smithy-client": "^4.4.5",
-				"@smithy/types": "^4.3.1",
-				"@smithy/url-parser": "^4.0.4",
-				"@smithy/util-base64": "^4.0.0",
-				"@smithy/util-body-length-browser": "^4.0.0",
-				"@smithy/util-body-length-node": "^4.0.0",
-				"@smithy/util-defaults-mode-browser": "^4.0.21",
-				"@smithy/util-defaults-mode-node": "^4.0.21",
-				"@smithy/util-endpoints": "^3.0.6",
-				"@smithy/util-middleware": "^4.0.4",
-				"@smithy/util-retry": "^4.0.6",
-				"@smithy/util-stream": "^4.2.2",
-				"@smithy/util-utf8": "^4.0.0",
-				"@types/uuid": "^9.0.1",
-				"tslib": "^2.6.2",
-				"uuid": "^9.0.1"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/eventstream-serde-node": {
-			"version": "4.0.4",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/eventstream-serde-universal": "^4.0.4",
-				"@smithy/types": "^4.3.1",
+				"@aws-sdk/core": "3.916.0",
+				"@aws-sdk/credential-provider-node": "3.919.0",
+				"@aws-sdk/eventstream-handler-node": "3.914.0",
+				"@aws-sdk/middleware-eventstream": "3.914.0",
+				"@aws-sdk/middleware-host-header": "3.914.0",
+				"@aws-sdk/middleware-logger": "3.914.0",
+				"@aws-sdk/middleware-recursion-detection": "3.919.0",
+				"@aws-sdk/middleware-user-agent": "3.916.0",
+				"@aws-sdk/middleware-websocket": "3.914.0",
+				"@aws-sdk/region-config-resolver": "3.914.0",
+				"@aws-sdk/token-providers": "3.919.0",
+				"@aws-sdk/types": "3.914.0",
+				"@aws-sdk/util-endpoints": "3.916.0",
+				"@aws-sdk/util-user-agent-browser": "3.914.0",
+				"@aws-sdk/util-user-agent-node": "3.916.0",
+				"@smithy/config-resolver": "^4.4.0",
+				"@smithy/core": "^3.17.1",
+				"@smithy/eventstream-serde-browser": "^4.2.3",
+				"@smithy/eventstream-serde-config-resolver": "^4.3.3",
+				"@smithy/eventstream-serde-node": "^4.2.3",
+				"@smithy/fetch-http-handler": "^5.3.4",
+				"@smithy/hash-node": "^4.2.3",
+				"@smithy/invalid-dependency": "^4.2.3",
+				"@smithy/middleware-content-length": "^4.2.3",
+				"@smithy/middleware-endpoint": "^4.3.5",
+				"@smithy/middleware-retry": "^4.4.5",
+				"@smithy/middleware-serde": "^4.2.3",
+				"@smithy/middleware-stack": "^4.2.3",
+				"@smithy/node-config-provider": "^4.3.3",
+				"@smithy/node-http-handler": "^4.4.3",
+				"@smithy/protocol-http": "^5.3.3",
+				"@smithy/smithy-client": "^4.9.1",
+				"@smithy/types": "^4.8.0",
+				"@smithy/url-parser": "^4.2.3",
+				"@smithy/util-base64": "^4.3.0",
+				"@smithy/util-body-length-browser": "^4.2.0",
+				"@smithy/util-body-length-node": "^4.2.1",
+				"@smithy/util-defaults-mode-browser": "^4.3.4",
+				"@smithy/util-defaults-mode-node": "^4.2.6",
+				"@smithy/util-endpoints": "^3.2.3",
+				"@smithy/util-middleware": "^4.2.3",
+				"@smithy/util-retry": "^4.2.3",
+				"@smithy/util-stream": "^4.5.4",
+				"@smithy/util-utf8": "^4.2.0",
+				"@smithy/uuid": "^1.1.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
 				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@types/uuid": {
-			"version": "9.0.8",
-			"license": "MIT"
-		},
-		"node_modules/@aws-sdk/client-bedrock-runtime/node_modules/tslib": {
-			"version": "2.8.1",
-			"license": "0BSD"
-		},
-		"node_modules/@aws-sdk/client-bedrock-runtime/node_modules/uuid": {
-			"version": "9.0.1",
-			"funding": [
-				"https://github.com/sponsors/broofa",
-				"https://github.com/sponsors/ctavan"
-			],
-			"license": "MIT",
-			"bin": {
-				"uuid": "dist/bin/uuid"
 			}
 		},
 		"node_modules/@aws-sdk/client-cognito-identity": {
-			"version": "3.840.0",
+			"version": "3.919.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.919.0.tgz",
+			"integrity": "sha512-lUmPZZ0orVbIDjSKEPkNdip9qxRAoqVAmWu+DD+3BuGpkI1pmFXL0JEcf95C51b1YfZeIY97t5g+KgZeDg65hg==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-crypto/sha256-browser": "5.2.0",
 				"@aws-crypto/sha256-js": "5.2.0",
-				"@aws-sdk/core": "3.840.0",
-				"@aws-sdk/credential-provider-node": "3.840.0",
-				"@aws-sdk/middleware-host-header": "3.840.0",
-				"@aws-sdk/middleware-logger": "3.840.0",
-				"@aws-sdk/middleware-recursion-detection": "3.840.0",
-				"@aws-sdk/middleware-user-agent": "3.840.0",
-				"@aws-sdk/region-config-resolver": "3.840.0",
-				"@aws-sdk/types": "3.840.0",
-				"@aws-sdk/util-endpoints": "3.840.0",
-				"@aws-sdk/util-user-agent-browser": "3.840.0",
-				"@aws-sdk/util-user-agent-node": "3.840.0",
-				"@smithy/config-resolver": "^4.1.4",
-				"@smithy/core": "^3.6.0",
-				"@smithy/fetch-http-handler": "^5.0.4",
-				"@smithy/hash-node": "^4.0.4",
-				"@smithy/invalid-dependency": "^4.0.4",
-				"@smithy/middleware-content-length": "^4.0.4",
-				"@smithy/middleware-endpoint": "^4.1.13",
-				"@smithy/middleware-retry": "^4.1.14",
-				"@smithy/middleware-serde": "^4.0.8",
-				"@smithy/middleware-stack": "^4.0.4",
-				"@smithy/node-config-provider": "^4.1.3",
-				"@smithy/node-http-handler": "^4.0.6",
-				"@smithy/protocol-http": "^5.1.2",
-				"@smithy/smithy-client": "^4.4.5",
-				"@smithy/types": "^4.3.1",
-				"@smithy/url-parser": "^4.0.4",
-				"@smithy/util-base64": "^4.0.0",
-				"@smithy/util-body-length-browser": "^4.0.0",
-				"@smithy/util-body-length-node": "^4.0.0",
-				"@smithy/util-defaults-mode-browser": "^4.0.21",
-				"@smithy/util-defaults-mode-node": "^4.0.21",
-				"@smithy/util-endpoints": "^3.0.6",
-				"@smithy/util-middleware": "^4.0.4",
-				"@smithy/util-retry": "^4.0.6",
-				"@smithy/util-utf8": "^4.0.0",
+				"@aws-sdk/core": "3.916.0",
+				"@aws-sdk/credential-provider-node": "3.919.0",
+				"@aws-sdk/middleware-host-header": "3.914.0",
+				"@aws-sdk/middleware-logger": "3.914.0",
+				"@aws-sdk/middleware-recursion-detection": "3.919.0",
+				"@aws-sdk/middleware-user-agent": "3.916.0",
+				"@aws-sdk/region-config-resolver": "3.914.0",
+				"@aws-sdk/types": "3.914.0",
+				"@aws-sdk/util-endpoints": "3.916.0",
+				"@aws-sdk/util-user-agent-browser": "3.914.0",
+				"@aws-sdk/util-user-agent-node": "3.916.0",
+				"@smithy/config-resolver": "^4.4.0",
+				"@smithy/core": "^3.17.1",
+				"@smithy/fetch-http-handler": "^5.3.4",
+				"@smithy/hash-node": "^4.2.3",
+				"@smithy/invalid-dependency": "^4.2.3",
+				"@smithy/middleware-content-length": "^4.2.3",
+				"@smithy/middleware-endpoint": "^4.3.5",
+				"@smithy/middleware-retry": "^4.4.5",
+				"@smithy/middleware-serde": "^4.2.3",
+				"@smithy/middleware-stack": "^4.2.3",
+				"@smithy/node-config-provider": "^4.3.3",
+				"@smithy/node-http-handler": "^4.4.3",
+				"@smithy/protocol-http": "^5.3.3",
+				"@smithy/smithy-client": "^4.9.1",
+				"@smithy/types": "^4.8.0",
+				"@smithy/url-parser": "^4.2.3",
+				"@smithy/util-base64": "^4.3.0",
+				"@smithy/util-body-length-browser": "^4.2.0",
+				"@smithy/util-body-length-node": "^4.2.1",
+				"@smithy/util-defaults-mode-browser": "^4.3.4",
+				"@smithy/util-defaults-mode-node": "^4.2.6",
+				"@smithy/util-endpoints": "^3.2.3",
+				"@smithy/util-middleware": "^4.2.3",
+				"@smithy/util-retry": "^4.2.3",
+				"@smithy/util-utf8": "^4.2.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
 				"node": ">=18.0.0"
 			}
-		},
-		"node_modules/@aws-sdk/client-cognito-identity/node_modules/tslib": {
-			"version": "2.8.1",
-			"license": "0BSD"
 		},
 		"node_modules/@aws-sdk/client-sso": {
-			"version": "3.840.0",
+			"version": "3.919.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.919.0.tgz",
+			"integrity": "sha512-9DVw/1DCzZ9G7Jofnhpg/XDC3wdJ3NAJdNWY1TrgE5ZcpTM+UTIQMGyaljCv9rgxggutHBgmBI5lP3YMcPk9ZQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-crypto/sha256-browser": "5.2.0",
 				"@aws-crypto/sha256-js": "5.2.0",
-				"@aws-sdk/core": "3.840.0",
-				"@aws-sdk/middleware-host-header": "3.840.0",
-				"@aws-sdk/middleware-logger": "3.840.0",
-				"@aws-sdk/middleware-recursion-detection": "3.840.0",
-				"@aws-sdk/middleware-user-agent": "3.840.0",
-				"@aws-sdk/region-config-resolver": "3.840.0",
-				"@aws-sdk/types": "3.840.0",
-				"@aws-sdk/util-endpoints": "3.840.0",
-				"@aws-sdk/util-user-agent-browser": "3.840.0",
-				"@aws-sdk/util-user-agent-node": "3.840.0",
-				"@smithy/config-resolver": "^4.1.4",
-				"@smithy/core": "^3.6.0",
-				"@smithy/fetch-http-handler": "^5.0.4",
-				"@smithy/hash-node": "^4.0.4",
-				"@smithy/invalid-dependency": "^4.0.4",
-				"@smithy/middleware-content-length": "^4.0.4",
-				"@smithy/middleware-endpoint": "^4.1.13",
-				"@smithy/middleware-retry": "^4.1.14",
-				"@smithy/middleware-serde": "^4.0.8",
-				"@smithy/middleware-stack": "^4.0.4",
-				"@smithy/node-config-provider": "^4.1.3",
-				"@smithy/node-http-handler": "^4.0.6",
-				"@smithy/protocol-http": "^5.1.2",
-				"@smithy/smithy-client": "^4.4.5",
-				"@smithy/types": "^4.3.1",
-				"@smithy/url-parser": "^4.0.4",
-				"@smithy/util-base64": "^4.0.0",
-				"@smithy/util-body-length-browser": "^4.0.0",
-				"@smithy/util-body-length-node": "^4.0.0",
-				"@smithy/util-defaults-mode-browser": "^4.0.21",
-				"@smithy/util-defaults-mode-node": "^4.0.21",
-				"@smithy/util-endpoints": "^3.0.6",
-				"@smithy/util-middleware": "^4.0.4",
-				"@smithy/util-retry": "^4.0.6",
-				"@smithy/util-utf8": "^4.0.0",
+				"@aws-sdk/core": "3.916.0",
+				"@aws-sdk/middleware-host-header": "3.914.0",
+				"@aws-sdk/middleware-logger": "3.914.0",
+				"@aws-sdk/middleware-recursion-detection": "3.919.0",
+				"@aws-sdk/middleware-user-agent": "3.916.0",
+				"@aws-sdk/region-config-resolver": "3.914.0",
+				"@aws-sdk/types": "3.914.0",
+				"@aws-sdk/util-endpoints": "3.916.0",
+				"@aws-sdk/util-user-agent-browser": "3.914.0",
+				"@aws-sdk/util-user-agent-node": "3.916.0",
+				"@smithy/config-resolver": "^4.4.0",
+				"@smithy/core": "^3.17.1",
+				"@smithy/fetch-http-handler": "^5.3.4",
+				"@smithy/hash-node": "^4.2.3",
+				"@smithy/invalid-dependency": "^4.2.3",
+				"@smithy/middleware-content-length": "^4.2.3",
+				"@smithy/middleware-endpoint": "^4.3.5",
+				"@smithy/middleware-retry": "^4.4.5",
+				"@smithy/middleware-serde": "^4.2.3",
+				"@smithy/middleware-stack": "^4.2.3",
+				"@smithy/node-config-provider": "^4.3.3",
+				"@smithy/node-http-handler": "^4.4.3",
+				"@smithy/protocol-http": "^5.3.3",
+				"@smithy/smithy-client": "^4.9.1",
+				"@smithy/types": "^4.8.0",
+				"@smithy/url-parser": "^4.2.3",
+				"@smithy/util-base64": "^4.3.0",
+				"@smithy/util-body-length-browser": "^4.2.0",
+				"@smithy/util-body-length-node": "^4.2.1",
+				"@smithy/util-defaults-mode-browser": "^4.3.4",
+				"@smithy/util-defaults-mode-node": "^4.2.6",
+				"@smithy/util-endpoints": "^3.2.3",
+				"@smithy/util-middleware": "^4.2.3",
+				"@smithy/util-retry": "^4.2.3",
+				"@smithy/util-utf8": "^4.2.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
 				"node": ">=18.0.0"
 			}
-		},
-		"node_modules/@aws-sdk/client-sso/node_modules/tslib": {
-			"version": "2.8.1",
-			"license": "0BSD"
 		},
 		"node_modules/@aws-sdk/core": {
-			"version": "3.840.0",
+			"version": "3.916.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.916.0.tgz",
+			"integrity": "sha512-1JHE5s6MD5PKGovmx/F1e01hUbds/1y3X8rD+Gvi/gWVfdg5noO7ZCerpRsWgfzgvCMZC9VicopBqNHCKLykZA==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/types": "3.840.0",
-				"@aws-sdk/xml-builder": "3.821.0",
-				"@smithy/core": "^3.6.0",
-				"@smithy/node-config-provider": "^4.1.3",
-				"@smithy/property-provider": "^4.0.4",
-				"@smithy/protocol-http": "^5.1.2",
-				"@smithy/signature-v4": "^5.1.2",
-				"@smithy/smithy-client": "^4.4.5",
-				"@smithy/types": "^4.3.1",
-				"@smithy/util-base64": "^4.0.0",
-				"@smithy/util-body-length-browser": "^4.0.0",
-				"@smithy/util-middleware": "^4.0.4",
-				"@smithy/util-utf8": "^4.0.0",
-				"fast-xml-parser": "4.4.1",
+				"@aws-sdk/types": "3.914.0",
+				"@aws-sdk/xml-builder": "3.914.0",
+				"@smithy/core": "^3.17.1",
+				"@smithy/node-config-provider": "^4.3.3",
+				"@smithy/property-provider": "^4.2.3",
+				"@smithy/protocol-http": "^5.3.3",
+				"@smithy/signature-v4": "^5.3.3",
+				"@smithy/smithy-client": "^4.9.1",
+				"@smithy/types": "^4.8.0",
+				"@smithy/util-base64": "^4.3.0",
+				"@smithy/util-middleware": "^4.2.3",
+				"@smithy/util-utf8": "^4.2.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
 				"node": ">=18.0.0"
 			}
-		},
-		"node_modules/@aws-sdk/core/node_modules/tslib": {
-			"version": "2.8.1",
-			"license": "0BSD"
 		},
 		"node_modules/@aws-sdk/credential-provider-cognito-identity": {
-			"version": "3.840.0",
+			"version": "3.919.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.919.0.tgz",
+			"integrity": "sha512-ite9bRCBPsD1vJPUvOU7LaWbq1Y8aL5RrHoxY9T3SMHSVnPX2/uZvF/Tzi/P0gkQYzjDGpvtrJRHONROgcWwpw==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/client-cognito-identity": "3.840.0",
-				"@aws-sdk/types": "3.840.0",
-				"@smithy/property-provider": "^4.0.4",
-				"@smithy/types": "^4.3.1",
+				"@aws-sdk/client-cognito-identity": "3.919.0",
+				"@aws-sdk/types": "3.914.0",
+				"@smithy/property-provider": "^4.2.3",
+				"@smithy/types": "^4.8.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
 				"node": ">=18.0.0"
 			}
-		},
-		"node_modules/@aws-sdk/credential-provider-cognito-identity/node_modules/tslib": {
-			"version": "2.8.1",
-			"license": "0BSD"
 		},
 		"node_modules/@aws-sdk/credential-provider-env": {
-			"version": "3.840.0",
+			"version": "3.916.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.916.0.tgz",
+			"integrity": "sha512-3gDeqOXcBRXGHScc6xb7358Lyf64NRG2P08g6Bu5mv1Vbg9PKDyCAZvhKLkG7hkdfAM8Yc6UJNhbFxr1ud/tCQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "3.840.0",
-				"@aws-sdk/types": "3.840.0",
-				"@smithy/property-provider": "^4.0.4",
-				"@smithy/types": "^4.3.1",
+				"@aws-sdk/core": "3.916.0",
+				"@aws-sdk/types": "3.914.0",
+				"@smithy/property-provider": "^4.2.3",
+				"@smithy/types": "^4.8.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
 				"node": ">=18.0.0"
 			}
-		},
-		"node_modules/@aws-sdk/credential-provider-env/node_modules/tslib": {
-			"version": "2.8.1",
-			"license": "0BSD"
 		},
 		"node_modules/@aws-sdk/credential-provider-http": {
-			"version": "3.840.0",
+			"version": "3.916.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.916.0.tgz",
+			"integrity": "sha512-NmooA5Z4/kPFJdsyoJgDxuqXC1C6oPMmreJjbOPqcwo6E/h2jxaG8utlQFgXe5F9FeJsMx668dtxVxSYnAAqHQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "3.840.0",
-				"@aws-sdk/types": "3.840.0",
-				"@smithy/fetch-http-handler": "^5.0.4",
-				"@smithy/node-http-handler": "^4.0.6",
-				"@smithy/property-provider": "^4.0.4",
-				"@smithy/protocol-http": "^5.1.2",
-				"@smithy/smithy-client": "^4.4.5",
-				"@smithy/types": "^4.3.1",
-				"@smithy/util-stream": "^4.2.2",
+				"@aws-sdk/core": "3.916.0",
+				"@aws-sdk/types": "3.914.0",
+				"@smithy/fetch-http-handler": "^5.3.4",
+				"@smithy/node-http-handler": "^4.4.3",
+				"@smithy/property-provider": "^4.2.3",
+				"@smithy/protocol-http": "^5.3.3",
+				"@smithy/smithy-client": "^4.9.1",
+				"@smithy/types": "^4.8.0",
+				"@smithy/util-stream": "^4.5.4",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
 				"node": ">=18.0.0"
 			}
-		},
-		"node_modules/@aws-sdk/credential-provider-http/node_modules/tslib": {
-			"version": "2.8.1",
-			"license": "0BSD"
 		},
 		"node_modules/@aws-sdk/credential-provider-ini": {
-			"version": "3.840.0",
+			"version": "3.919.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.919.0.tgz",
+			"integrity": "sha512-fAWVfh0P54UFbyAK4tmIPh/X3COFAyXYSp8b2Pc1R6GRwDDMvrAigwGJuyZS4BmpPlXij1gB0nXbhM5Yo4MMMA==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "3.840.0",
-				"@aws-sdk/credential-provider-env": "3.840.0",
-				"@aws-sdk/credential-provider-http": "3.840.0",
-				"@aws-sdk/credential-provider-process": "3.840.0",
-				"@aws-sdk/credential-provider-sso": "3.840.0",
-				"@aws-sdk/credential-provider-web-identity": "3.840.0",
-				"@aws-sdk/nested-clients": "3.840.0",
-				"@aws-sdk/types": "3.840.0",
-				"@smithy/credential-provider-imds": "^4.0.6",
-				"@smithy/property-provider": "^4.0.4",
-				"@smithy/shared-ini-file-loader": "^4.0.4",
-				"@smithy/types": "^4.3.1",
+				"@aws-sdk/core": "3.916.0",
+				"@aws-sdk/credential-provider-env": "3.916.0",
+				"@aws-sdk/credential-provider-http": "3.916.0",
+				"@aws-sdk/credential-provider-process": "3.916.0",
+				"@aws-sdk/credential-provider-sso": "3.919.0",
+				"@aws-sdk/credential-provider-web-identity": "3.919.0",
+				"@aws-sdk/nested-clients": "3.919.0",
+				"@aws-sdk/types": "3.914.0",
+				"@smithy/credential-provider-imds": "^4.2.3",
+				"@smithy/property-provider": "^4.2.3",
+				"@smithy/shared-ini-file-loader": "^4.3.3",
+				"@smithy/types": "^4.8.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
 				"node": ">=18.0.0"
 			}
-		},
-		"node_modules/@aws-sdk/credential-provider-ini/node_modules/tslib": {
-			"version": "2.8.1",
-			"license": "0BSD"
 		},
 		"node_modules/@aws-sdk/credential-provider-node": {
-			"version": "3.840.0",
+			"version": "3.919.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.919.0.tgz",
+			"integrity": "sha512-GL5filyxYS+eZq8ZMQnY5hh79Wxor7Rljo0SUJxZVwEj8cf3zY0MMuwoXU1HQrVabvYtkPDOWSreX8GkIBtBCw==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/credential-provider-env": "3.840.0",
-				"@aws-sdk/credential-provider-http": "3.840.0",
-				"@aws-sdk/credential-provider-ini": "3.840.0",
-				"@aws-sdk/credential-provider-process": "3.840.0",
-				"@aws-sdk/credential-provider-sso": "3.840.0",
-				"@aws-sdk/credential-provider-web-identity": "3.840.0",
-				"@aws-sdk/types": "3.840.0",
-				"@smithy/credential-provider-imds": "^4.0.6",
-				"@smithy/property-provider": "^4.0.4",
-				"@smithy/shared-ini-file-loader": "^4.0.4",
-				"@smithy/types": "^4.3.1",
+				"@aws-sdk/credential-provider-env": "3.916.0",
+				"@aws-sdk/credential-provider-http": "3.916.0",
+				"@aws-sdk/credential-provider-ini": "3.919.0",
+				"@aws-sdk/credential-provider-process": "3.916.0",
+				"@aws-sdk/credential-provider-sso": "3.919.0",
+				"@aws-sdk/credential-provider-web-identity": "3.919.0",
+				"@aws-sdk/types": "3.914.0",
+				"@smithy/credential-provider-imds": "^4.2.3",
+				"@smithy/property-provider": "^4.2.3",
+				"@smithy/shared-ini-file-loader": "^4.3.3",
+				"@smithy/types": "^4.8.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
 				"node": ">=18.0.0"
 			}
-		},
-		"node_modules/@aws-sdk/credential-provider-node/node_modules/tslib": {
-			"version": "2.8.1",
-			"license": "0BSD"
 		},
 		"node_modules/@aws-sdk/credential-provider-process": {
-			"version": "3.840.0",
+			"version": "3.916.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.916.0.tgz",
+			"integrity": "sha512-SXDyDvpJ1+WbotZDLJW1lqP6gYGaXfZJrgFSXIuZjHb75fKeNRgPkQX/wZDdUvCwdrscvxmtyJorp2sVYkMcvA==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "3.840.0",
-				"@aws-sdk/types": "3.840.0",
-				"@smithy/property-provider": "^4.0.4",
-				"@smithy/shared-ini-file-loader": "^4.0.4",
-				"@smithy/types": "^4.3.1",
+				"@aws-sdk/core": "3.916.0",
+				"@aws-sdk/types": "3.914.0",
+				"@smithy/property-provider": "^4.2.3",
+				"@smithy/shared-ini-file-loader": "^4.3.3",
+				"@smithy/types": "^4.8.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
 				"node": ">=18.0.0"
 			}
-		},
-		"node_modules/@aws-sdk/credential-provider-process/node_modules/tslib": {
-			"version": "2.8.1",
-			"license": "0BSD"
 		},
 		"node_modules/@aws-sdk/credential-provider-sso": {
-			"version": "3.840.0",
+			"version": "3.919.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.919.0.tgz",
+			"integrity": "sha512-oN1XG/frOc2K2KdVwRQjLTBLM1oSFJLtOhuV/6g9N0ASD+44uVJai1CF9JJv5GjHGV+wsqAt+/Dzde0tZEXirA==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/client-sso": "3.840.0",
-				"@aws-sdk/core": "3.840.0",
-				"@aws-sdk/token-providers": "3.840.0",
-				"@aws-sdk/types": "3.840.0",
-				"@smithy/property-provider": "^4.0.4",
-				"@smithy/shared-ini-file-loader": "^4.0.4",
-				"@smithy/types": "^4.3.1",
+				"@aws-sdk/client-sso": "3.919.0",
+				"@aws-sdk/core": "3.916.0",
+				"@aws-sdk/token-providers": "3.919.0",
+				"@aws-sdk/types": "3.914.0",
+				"@smithy/property-provider": "^4.2.3",
+				"@smithy/shared-ini-file-loader": "^4.3.3",
+				"@smithy/types": "^4.8.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
 				"node": ">=18.0.0"
 			}
-		},
-		"node_modules/@aws-sdk/credential-provider-sso/node_modules/tslib": {
-			"version": "2.8.1",
-			"license": "0BSD"
 		},
 		"node_modules/@aws-sdk/credential-provider-web-identity": {
-			"version": "3.840.0",
+			"version": "3.919.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.919.0.tgz",
+			"integrity": "sha512-Wi7RmyWA8kUJ++/8YceC7U5r4LyvOHGCnJLDHliP8rOC8HLdSgxw/Upeq3WmC+RPw1zyGOtEDRS/caop2xLXEA==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "3.840.0",
-				"@aws-sdk/nested-clients": "3.840.0",
-				"@aws-sdk/types": "3.840.0",
-				"@smithy/property-provider": "^4.0.4",
-				"@smithy/types": "^4.3.1",
+				"@aws-sdk/core": "3.916.0",
+				"@aws-sdk/nested-clients": "3.919.0",
+				"@aws-sdk/types": "3.914.0",
+				"@smithy/property-provider": "^4.2.3",
+				"@smithy/shared-ini-file-loader": "^4.3.3",
+				"@smithy/types": "^4.8.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
 				"node": ">=18.0.0"
 			}
-		},
-		"node_modules/@aws-sdk/credential-provider-web-identity/node_modules/tslib": {
-			"version": "2.8.1",
-			"license": "0BSD"
 		},
 		"node_modules/@aws-sdk/credential-providers": {
-			"version": "3.840.0",
+			"version": "3.919.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.919.0.tgz",
+			"integrity": "sha512-YA7PUZpY2H22UdpSuC+hySUwBDqjVEVvg7uCZ6Wt9ChoDcsiVu7esTK60FETDbHk0yHF5WO1IQyHM8kuSz2DxA==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/client-cognito-identity": "3.840.0",
-				"@aws-sdk/core": "3.840.0",
-				"@aws-sdk/credential-provider-cognito-identity": "3.840.0",
-				"@aws-sdk/credential-provider-env": "3.840.0",
-				"@aws-sdk/credential-provider-http": "3.840.0",
-				"@aws-sdk/credential-provider-ini": "3.840.0",
-				"@aws-sdk/credential-provider-node": "3.840.0",
-				"@aws-sdk/credential-provider-process": "3.840.0",
-				"@aws-sdk/credential-provider-sso": "3.840.0",
-				"@aws-sdk/credential-provider-web-identity": "3.840.0",
-				"@aws-sdk/nested-clients": "3.840.0",
-				"@aws-sdk/types": "3.840.0",
-				"@smithy/config-resolver": "^4.1.4",
-				"@smithy/core": "^3.6.0",
-				"@smithy/credential-provider-imds": "^4.0.6",
-				"@smithy/node-config-provider": "^4.1.3",
-				"@smithy/property-provider": "^4.0.4",
-				"@smithy/types": "^4.3.1",
+				"@aws-sdk/client-cognito-identity": "3.919.0",
+				"@aws-sdk/core": "3.916.0",
+				"@aws-sdk/credential-provider-cognito-identity": "3.919.0",
+				"@aws-sdk/credential-provider-env": "3.916.0",
+				"@aws-sdk/credential-provider-http": "3.916.0",
+				"@aws-sdk/credential-provider-ini": "3.919.0",
+				"@aws-sdk/credential-provider-node": "3.919.0",
+				"@aws-sdk/credential-provider-process": "3.916.0",
+				"@aws-sdk/credential-provider-sso": "3.919.0",
+				"@aws-sdk/credential-provider-web-identity": "3.919.0",
+				"@aws-sdk/nested-clients": "3.919.0",
+				"@aws-sdk/types": "3.914.0",
+				"@smithy/config-resolver": "^4.4.0",
+				"@smithy/core": "^3.17.1",
+				"@smithy/credential-provider-imds": "^4.2.3",
+				"@smithy/node-config-provider": "^4.3.3",
+				"@smithy/property-provider": "^4.2.3",
+				"@smithy/types": "^4.8.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
 				"node": ">=18.0.0"
 			}
-		},
-		"node_modules/@aws-sdk/credential-providers/node_modules/tslib": {
-			"version": "2.8.1",
-			"license": "0BSD"
 		},
 		"node_modules/@aws-sdk/eventstream-handler-node": {
-			"version": "3.840.0",
+			"version": "3.914.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.914.0.tgz",
+			"integrity": "sha512-S4Zf+N6xrfQk0Fox+eWftbSqlXh9DUPjuXSbFXwneP7yEJ0+KbbRFsci84MQapNKa5IPb+Kt/li5i7Zp9B4qIw==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/types": "3.840.0",
-				"@smithy/eventstream-codec": "^4.0.4",
-				"@smithy/types": "^4.3.1",
+				"@aws-sdk/types": "3.914.0",
+				"@smithy/eventstream-codec": "^4.2.3",
+				"@smithy/types": "^4.8.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
 				"node": ">=18.0.0"
 			}
-		},
-		"node_modules/@aws-sdk/eventstream-handler-node/node_modules/tslib": {
-			"version": "2.8.1",
-			"license": "0BSD"
 		},
 		"node_modules/@aws-sdk/middleware-eventstream": {
-			"version": "3.840.0",
+			"version": "3.914.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.914.0.tgz",
+			"integrity": "sha512-KsMYBpzCAs2QBjjaZXVj5mM9/QXoC0qBnxjeOZIkZGU68ZIq0ZOsEkCB5tCPfQkghIwd30HMRktPSGOvevl34g==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/types": "3.840.0",
-				"@smithy/protocol-http": "^5.1.2",
-				"@smithy/types": "^4.3.1",
+				"@aws-sdk/types": "3.914.0",
+				"@smithy/protocol-http": "^5.3.3",
+				"@smithy/types": "^4.8.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
 				"node": ">=18.0.0"
 			}
-		},
-		"node_modules/@aws-sdk/middleware-eventstream/node_modules/tslib": {
-			"version": "2.8.1",
-			"license": "0BSD"
 		},
 		"node_modules/@aws-sdk/middleware-host-header": {
-			"version": "3.840.0",
+			"version": "3.914.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.914.0.tgz",
+			"integrity": "sha512-7r9ToySQ15+iIgXMF/h616PcQStByylVkCshmQqcdeynD/lCn2l667ynckxW4+ql0Q+Bo/URljuhJRxVJzydNA==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/types": "3.840.0",
-				"@smithy/protocol-http": "^5.1.2",
-				"@smithy/types": "^4.3.1",
+				"@aws-sdk/types": "3.914.0",
+				"@smithy/protocol-http": "^5.3.3",
+				"@smithy/types": "^4.8.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
 				"node": ">=18.0.0"
 			}
-		},
-		"node_modules/@aws-sdk/middleware-host-header/node_modules/tslib": {
-			"version": "2.8.1",
-			"license": "0BSD"
 		},
 		"node_modules/@aws-sdk/middleware-logger": {
-			"version": "3.840.0",
+			"version": "3.914.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.914.0.tgz",
+			"integrity": "sha512-/gaW2VENS5vKvJbcE1umV4Ag3NuiVzpsANxtrqISxT3ovyro29o1RezW/Avz/6oJqjnmgz8soe9J1t65jJdiNg==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/types": "3.840.0",
-				"@smithy/types": "^4.3.1",
+				"@aws-sdk/types": "3.914.0",
+				"@smithy/types": "^4.8.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
 				"node": ">=18.0.0"
 			}
-		},
-		"node_modules/@aws-sdk/middleware-logger/node_modules/tslib": {
-			"version": "2.8.1",
-			"license": "0BSD"
 		},
 		"node_modules/@aws-sdk/middleware-recursion-detection": {
-			"version": "3.840.0",
+			"version": "3.919.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.919.0.tgz",
+			"integrity": "sha512-q3MAUxLQve4rTfAannUCx2q1kAHkBBsxt6hVUpzi63KC4lBLScc1ltr7TI+hDxlfGRWGo54jRegb2SsY9Jm+Mw==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/types": "3.840.0",
-				"@smithy/protocol-http": "^5.1.2",
-				"@smithy/types": "^4.3.1",
+				"@aws-sdk/types": "3.914.0",
+				"@aws/lambda-invoke-store": "^0.1.1",
+				"@smithy/protocol-http": "^5.3.3",
+				"@smithy/types": "^4.8.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
 				"node": ">=18.0.0"
 			}
-		},
-		"node_modules/@aws-sdk/middleware-recursion-detection/node_modules/tslib": {
-			"version": "2.8.1",
-			"license": "0BSD"
 		},
 		"node_modules/@aws-sdk/middleware-user-agent": {
-			"version": "3.840.0",
+			"version": "3.916.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.916.0.tgz",
+			"integrity": "sha512-mzF5AdrpQXc2SOmAoaQeHpDFsK2GE6EGcEACeNuoESluPI2uYMpuuNMYrUufdnIAIyqgKlis0NVxiahA5jG42w==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "3.840.0",
-				"@aws-sdk/types": "3.840.0",
-				"@aws-sdk/util-endpoints": "3.840.0",
-				"@smithy/core": "^3.6.0",
-				"@smithy/protocol-http": "^5.1.2",
-				"@smithy/types": "^4.3.1",
+				"@aws-sdk/core": "3.916.0",
+				"@aws-sdk/types": "3.914.0",
+				"@aws-sdk/util-endpoints": "3.916.0",
+				"@smithy/core": "^3.17.1",
+				"@smithy/protocol-http": "^5.3.3",
+				"@smithy/types": "^4.8.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
 				"node": ">=18.0.0"
 			}
 		},
-		"node_modules/@aws-sdk/middleware-user-agent/node_modules/tslib": {
-			"version": "2.8.1",
-			"license": "0BSD"
+		"node_modules/@aws-sdk/middleware-websocket": {
+			"version": "3.914.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.914.0.tgz",
+			"integrity": "sha512-l7ZA5pbEqR5ro1u6eRhUYfqfYTIFuQfhvaKGDvSetqjVacjK+kpbt1/BOy6eyRfkXTIHgQRfCPMQHmhCIUAjNA==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "3.914.0",
+				"@aws-sdk/util-format-url": "3.914.0",
+				"@smithy/eventstream-codec": "^4.2.3",
+				"@smithy/eventstream-serde-browser": "^4.2.3",
+				"@smithy/fetch-http-handler": "^5.3.4",
+				"@smithy/protocol-http": "^5.3.3",
+				"@smithy/signature-v4": "^5.3.3",
+				"@smithy/types": "^4.8.0",
+				"@smithy/util-hex-encoding": "^4.2.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">= 14.0.0"
+			}
 		},
 		"node_modules/@aws-sdk/nested-clients": {
-			"version": "3.840.0",
+			"version": "3.919.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.919.0.tgz",
+			"integrity": "sha512-5D9OQsMPkbkp4KHM7JZv/RcGCpr3E1L7XX7U9sCxY+sFGeysltoviTmaIBXsJ2IjAJbBULtf0G/J+2cfH5OP+w==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-crypto/sha256-browser": "5.2.0",
 				"@aws-crypto/sha256-js": "5.2.0",
-				"@aws-sdk/core": "3.840.0",
-				"@aws-sdk/middleware-host-header": "3.840.0",
-				"@aws-sdk/middleware-logger": "3.840.0",
-				"@aws-sdk/middleware-recursion-detection": "3.840.0",
-				"@aws-sdk/middleware-user-agent": "3.840.0",
-				"@aws-sdk/region-config-resolver": "3.840.0",
-				"@aws-sdk/types": "3.840.0",
-				"@aws-sdk/util-endpoints": "3.840.0",
-				"@aws-sdk/util-user-agent-browser": "3.840.0",
-				"@aws-sdk/util-user-agent-node": "3.840.0",
-				"@smithy/config-resolver": "^4.1.4",
-				"@smithy/core": "^3.6.0",
-				"@smithy/fetch-http-handler": "^5.0.4",
-				"@smithy/hash-node": "^4.0.4",
-				"@smithy/invalid-dependency": "^4.0.4",
-				"@smithy/middleware-content-length": "^4.0.4",
-				"@smithy/middleware-endpoint": "^4.1.13",
-				"@smithy/middleware-retry": "^4.1.14",
-				"@smithy/middleware-serde": "^4.0.8",
-				"@smithy/middleware-stack": "^4.0.4",
-				"@smithy/node-config-provider": "^4.1.3",
-				"@smithy/node-http-handler": "^4.0.6",
-				"@smithy/protocol-http": "^5.1.2",
-				"@smithy/smithy-client": "^4.4.5",
-				"@smithy/types": "^4.3.1",
-				"@smithy/url-parser": "^4.0.4",
-				"@smithy/util-base64": "^4.0.0",
-				"@smithy/util-body-length-browser": "^4.0.0",
-				"@smithy/util-body-length-node": "^4.0.0",
-				"@smithy/util-defaults-mode-browser": "^4.0.21",
-				"@smithy/util-defaults-mode-node": "^4.0.21",
-				"@smithy/util-endpoints": "^3.0.6",
-				"@smithy/util-middleware": "^4.0.4",
-				"@smithy/util-retry": "^4.0.6",
-				"@smithy/util-utf8": "^4.0.0",
+				"@aws-sdk/core": "3.916.0",
+				"@aws-sdk/middleware-host-header": "3.914.0",
+				"@aws-sdk/middleware-logger": "3.914.0",
+				"@aws-sdk/middleware-recursion-detection": "3.919.0",
+				"@aws-sdk/middleware-user-agent": "3.916.0",
+				"@aws-sdk/region-config-resolver": "3.914.0",
+				"@aws-sdk/types": "3.914.0",
+				"@aws-sdk/util-endpoints": "3.916.0",
+				"@aws-sdk/util-user-agent-browser": "3.914.0",
+				"@aws-sdk/util-user-agent-node": "3.916.0",
+				"@smithy/config-resolver": "^4.4.0",
+				"@smithy/core": "^3.17.1",
+				"@smithy/fetch-http-handler": "^5.3.4",
+				"@smithy/hash-node": "^4.2.3",
+				"@smithy/invalid-dependency": "^4.2.3",
+				"@smithy/middleware-content-length": "^4.2.3",
+				"@smithy/middleware-endpoint": "^4.3.5",
+				"@smithy/middleware-retry": "^4.4.5",
+				"@smithy/middleware-serde": "^4.2.3",
+				"@smithy/middleware-stack": "^4.2.3",
+				"@smithy/node-config-provider": "^4.3.3",
+				"@smithy/node-http-handler": "^4.4.3",
+				"@smithy/protocol-http": "^5.3.3",
+				"@smithy/smithy-client": "^4.9.1",
+				"@smithy/types": "^4.8.0",
+				"@smithy/url-parser": "^4.2.3",
+				"@smithy/util-base64": "^4.3.0",
+				"@smithy/util-body-length-browser": "^4.2.0",
+				"@smithy/util-body-length-node": "^4.2.1",
+				"@smithy/util-defaults-mode-browser": "^4.3.4",
+				"@smithy/util-defaults-mode-node": "^4.2.6",
+				"@smithy/util-endpoints": "^3.2.3",
+				"@smithy/util-middleware": "^4.2.3",
+				"@smithy/util-retry": "^4.2.3",
+				"@smithy/util-utf8": "^4.2.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
 				"node": ">=18.0.0"
 			}
-		},
-		"node_modules/@aws-sdk/nested-clients/node_modules/tslib": {
-			"version": "2.8.1",
-			"license": "0BSD"
 		},
 		"node_modules/@aws-sdk/region-config-resolver": {
-			"version": "3.840.0",
+			"version": "3.914.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.914.0.tgz",
+			"integrity": "sha512-KlmHhRbn1qdwXUdsdrJ7S/MAkkC1jLpQ11n+XvxUUUCGAJd1gjC7AjxPZUM7ieQ2zcb8bfEzIU7al+Q3ZT0u7Q==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/types": "3.840.0",
-				"@smithy/node-config-provider": "^4.1.3",
-				"@smithy/types": "^4.3.1",
-				"@smithy/util-config-provider": "^4.0.0",
-				"@smithy/util-middleware": "^4.0.4",
+				"@aws-sdk/types": "3.914.0",
+				"@smithy/config-resolver": "^4.4.0",
+				"@smithy/types": "^4.8.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
 				"node": ">=18.0.0"
 			}
-		},
-		"node_modules/@aws-sdk/region-config-resolver/node_modules/tslib": {
-			"version": "2.8.1",
-			"license": "0BSD"
 		},
 		"node_modules/@aws-sdk/token-providers": {
-			"version": "3.840.0",
+			"version": "3.919.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.919.0.tgz",
+			"integrity": "sha512-6aFv4lzXbfbkl0Pv37Us8S/ZkqplOQZIEgQg7bfMru7P96Wv2jVnDGsEc5YyxMnnRyIB90naQ5JgslZ4rkpknw==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "3.840.0",
-				"@aws-sdk/nested-clients": "3.840.0",
-				"@aws-sdk/types": "3.840.0",
-				"@smithy/property-provider": "^4.0.4",
-				"@smithy/shared-ini-file-loader": "^4.0.4",
-				"@smithy/types": "^4.3.1",
+				"@aws-sdk/core": "3.916.0",
+				"@aws-sdk/nested-clients": "3.919.0",
+				"@aws-sdk/types": "3.914.0",
+				"@smithy/property-provider": "^4.2.3",
+				"@smithy/shared-ini-file-loader": "^4.3.3",
+				"@smithy/types": "^4.8.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
 				"node": ">=18.0.0"
 			}
-		},
-		"node_modules/@aws-sdk/token-providers/node_modules/tslib": {
-			"version": "2.8.1",
-			"license": "0BSD"
 		},
 		"node_modules/@aws-sdk/types": {
-			"version": "3.840.0",
+			"version": "3.914.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.914.0.tgz",
+			"integrity": "sha512-kQWPsRDmom4yvAfyG6L1lMmlwnTzm1XwMHOU+G5IFlsP4YEaMtXidDzW/wiivY0QFrhfCz/4TVmu0a2aPU57ug==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/types": "^4.3.1",
+				"@smithy/types": "^4.8.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
 				"node": ">=18.0.0"
 			}
-		},
-		"node_modules/@aws-sdk/types/node_modules/tslib": {
-			"version": "2.8.1",
-			"license": "0BSD"
 		},
 		"node_modules/@aws-sdk/util-endpoints": {
-			"version": "3.840.0",
+			"version": "3.916.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.916.0.tgz",
+			"integrity": "sha512-bAgUQwvixdsiGNcuZSDAOWbyHlnPtg8G8TyHD6DTfTmKTHUW6tAn+af/ZYJPXEzXhhpwgJqi58vWnsiDhmr7NQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/types": "3.840.0",
-				"@smithy/types": "^4.3.1",
-				"@smithy/util-endpoints": "^3.0.6",
+				"@aws-sdk/types": "3.914.0",
+				"@smithy/types": "^4.8.0",
+				"@smithy/url-parser": "^4.2.3",
+				"@smithy/util-endpoints": "^3.2.3",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
 				"node": ">=18.0.0"
 			}
 		},
-		"node_modules/@aws-sdk/util-endpoints/node_modules/tslib": {
-			"version": "2.8.1",
-			"license": "0BSD"
+		"node_modules/@aws-sdk/util-format-url": {
+			"version": "3.914.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-3.914.0.tgz",
+			"integrity": "sha512-QpdkoQjvPaYyzZwgk41vFyHQM5s0DsrsbQ8IoPUggQt4HaJUvmL1ShwMcSldbgdzwiRMqXUK8q7jrqUvkYkY6w==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "3.914.0",
+				"@smithy/querystring-builder": "^4.2.3",
+				"@smithy/types": "^4.8.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
 		},
 		"node_modules/@aws-sdk/util-locate-window": {
 			"version": "3.568.0",
@@ -988,32 +930,28 @@
 				"node": ">=16.0.0"
 			}
 		},
-		"node_modules/@aws-sdk/util-locate-window/node_modules/tslib": {
-			"version": "2.6.3",
-			"license": "0BSD"
-		},
 		"node_modules/@aws-sdk/util-user-agent-browser": {
-			"version": "3.840.0",
+			"version": "3.914.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.914.0.tgz",
+			"integrity": "sha512-rMQUrM1ECH4kmIwlGl9UB0BtbHy6ZuKdWFrIknu8yGTRI/saAucqNTh5EI1vWBxZ0ElhK5+g7zOnUuhSmVQYUA==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/types": "3.840.0",
-				"@smithy/types": "^4.3.1",
+				"@aws-sdk/types": "3.914.0",
+				"@smithy/types": "^4.8.0",
 				"bowser": "^2.11.0",
 				"tslib": "^2.6.2"
 			}
 		},
-		"node_modules/@aws-sdk/util-user-agent-browser/node_modules/tslib": {
-			"version": "2.8.1",
-			"license": "0BSD"
-		},
 		"node_modules/@aws-sdk/util-user-agent-node": {
-			"version": "3.840.0",
+			"version": "3.916.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.916.0.tgz",
+			"integrity": "sha512-CwfWV2ch6UdjuSV75ZU99N03seEUb31FIUrXBnwa6oONqj/xqXwrxtlUMLx6WH3OJEE4zI3zt5PjlTdGcVwf4g==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/middleware-user-agent": "3.840.0",
-				"@aws-sdk/types": "3.840.0",
-				"@smithy/node-config-provider": "^4.1.3",
-				"@smithy/types": "^4.3.1",
+				"@aws-sdk/middleware-user-agent": "3.916.0",
+				"@aws-sdk/types": "3.914.0",
+				"@smithy/node-config-provider": "^4.3.3",
+				"@smithy/types": "^4.8.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -1028,24 +966,28 @@
 				}
 			}
 		},
-		"node_modules/@aws-sdk/util-user-agent-node/node_modules/tslib": {
-			"version": "2.8.1",
-			"license": "0BSD"
-		},
 		"node_modules/@aws-sdk/xml-builder": {
-			"version": "3.821.0",
+			"version": "3.914.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.914.0.tgz",
+			"integrity": "sha512-k75evsBD5TcIjedycYS7QXQ98AmOtbnxRJOPtCo0IwYRmy7UvqgS/gBL5SmrIqeV6FDSYRQMgdBxSMp6MLmdew==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/types": "^4.3.1",
+				"@smithy/types": "^4.8.0",
+				"fast-xml-parser": "5.2.5",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
 				"node": ">=18.0.0"
 			}
 		},
-		"node_modules/@aws-sdk/xml-builder/node_modules/tslib": {
-			"version": "2.8.1",
-			"license": "0BSD"
+		"node_modules/@aws/lambda-invoke-store": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.1.1.tgz",
+			"integrity": "sha512-RcLam17LdlbSOSp9VxmUu1eI6Mwxp+OwhD2QhiSNmNCzoDb0EeUXTD2n/WbcnrAYMGlmf05th6QYq23VqvJqpA==",
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=18.0.0"
+			}
 		},
 		"node_modules/@azu/format-text": {
 			"version": "1.0.2",
@@ -1071,11 +1013,6 @@
 				"node": ">=18.0.0"
 			}
 		},
-		"node_modules/@azure/abort-controller/node_modules/tslib": {
-			"version": "2.8.1",
-			"dev": true,
-			"license": "0BSD"
-		},
 		"node_modules/@azure/core-auth": {
 			"version": "1.9.0",
 			"dev": true,
@@ -1088,11 +1025,6 @@
 			"engines": {
 				"node": ">=18.0.0"
 			}
-		},
-		"node_modules/@azure/core-auth/node_modules/tslib": {
-			"version": "2.8.1",
-			"dev": true,
-			"license": "0BSD"
 		},
 		"node_modules/@azure/core-client": {
 			"version": "1.9.4",
@@ -1111,11 +1043,6 @@
 				"node": ">=18.0.0"
 			}
 		},
-		"node_modules/@azure/core-client/node_modules/tslib": {
-			"version": "2.8.1",
-			"dev": true,
-			"license": "0BSD"
-		},
 		"node_modules/@azure/core-rest-pipeline": {
 			"version": "1.21.0",
 			"dev": true,
@@ -1133,11 +1060,6 @@
 				"node": ">=18.0.0"
 			}
 		},
-		"node_modules/@azure/core-rest-pipeline/node_modules/tslib": {
-			"version": "2.8.1",
-			"dev": true,
-			"license": "0BSD"
-		},
 		"node_modules/@azure/core-tracing": {
 			"version": "1.2.0",
 			"dev": true,
@@ -1148,11 +1070,6 @@
 			"engines": {
 				"node": ">=18.0.0"
 			}
-		},
-		"node_modules/@azure/core-tracing/node_modules/tslib": {
-			"version": "2.8.1",
-			"dev": true,
-			"license": "0BSD"
 		},
 		"node_modules/@azure/core-util": {
 			"version": "1.12.0",
@@ -1166,11 +1083,6 @@
 			"engines": {
 				"node": ">=18.0.0"
 			}
-		},
-		"node_modules/@azure/core-util/node_modules/tslib": {
-			"version": "2.8.1",
-			"dev": true,
-			"license": "0BSD"
 		},
 		"node_modules/@azure/identity": {
 			"version": "4.10.2",
@@ -1193,11 +1105,6 @@
 				"node": ">=20.0.0"
 			}
 		},
-		"node_modules/@azure/identity/node_modules/tslib": {
-			"version": "2.8.1",
-			"dev": true,
-			"license": "0BSD"
-		},
 		"node_modules/@azure/logger": {
 			"version": "1.2.0",
 			"dev": true,
@@ -1209,11 +1116,6 @@
 			"engines": {
 				"node": ">=18.0.0"
 			}
-		},
-		"node_modules/@azure/logger/node_modules/tslib": {
-			"version": "2.8.1",
-			"dev": true,
-			"license": "0BSD"
 		},
 		"node_modules/@azure/msal-browser": {
 			"version": "4.14.0",
@@ -2172,17 +2074,9 @@
 				"@firebase/app-compat": "0.x"
 			}
 		},
-		"node_modules/@firebase/analytics-compat/node_modules/tslib": {
-			"version": "2.8.1",
-			"license": "0BSD"
-		},
 		"node_modules/@firebase/analytics-types": {
 			"version": "0.8.3",
 			"license": "Apache-2.0"
-		},
-		"node_modules/@firebase/analytics/node_modules/tslib": {
-			"version": "2.8.1",
-			"license": "0BSD"
 		},
 		"node_modules/@firebase/app": {
 			"version": "0.10.18",
@@ -2232,10 +2126,6 @@
 				"@firebase/app-compat": "0.x"
 			}
 		},
-		"node_modules/@firebase/app-check-compat/node_modules/tslib": {
-			"version": "2.8.1",
-			"license": "0BSD"
-		},
 		"node_modules/@firebase/app-check-interop-types": {
 			"version": "0.3.3",
 			"license": "Apache-2.0"
@@ -2243,10 +2133,6 @@
 		"node_modules/@firebase/app-check-types": {
 			"version": "0.5.3",
 			"license": "Apache-2.0"
-		},
-		"node_modules/@firebase/app-check/node_modules/tslib": {
-			"version": "2.8.1",
-			"license": "0BSD"
 		},
 		"node_modules/@firebase/app-compat": {
 			"version": "0.2.48",
@@ -2262,17 +2148,9 @@
 				"node": ">=18.0.0"
 			}
 		},
-		"node_modules/@firebase/app-compat/node_modules/tslib": {
-			"version": "2.8.1",
-			"license": "0BSD"
-		},
 		"node_modules/@firebase/app-types": {
 			"version": "0.9.3",
 			"license": "Apache-2.0"
-		},
-		"node_modules/@firebase/app/node_modules/tslib": {
-			"version": "2.8.1",
-			"license": "0BSD"
 		},
 		"node_modules/@firebase/auth": {
 			"version": "1.8.2",
@@ -2313,10 +2191,6 @@
 				"@firebase/app-compat": "0.x"
 			}
 		},
-		"node_modules/@firebase/auth-compat/node_modules/tslib": {
-			"version": "2.8.1",
-			"license": "0BSD"
-		},
 		"node_modules/@firebase/auth-interop-types": {
 			"version": "0.2.4",
 			"license": "Apache-2.0"
@@ -2329,10 +2203,6 @@
 				"@firebase/util": "1.x"
 			}
 		},
-		"node_modules/@firebase/auth/node_modules/tslib": {
-			"version": "2.8.1",
-			"license": "0BSD"
-		},
 		"node_modules/@firebase/component": {
 			"version": "0.6.12",
 			"license": "Apache-2.0",
@@ -2343,10 +2213,6 @@
 			"engines": {
 				"node": ">=18.0.0"
 			}
-		},
-		"node_modules/@firebase/component/node_modules/tslib": {
-			"version": "2.8.1",
-			"license": "0BSD"
 		},
 		"node_modules/@firebase/data-connect": {
 			"version": "0.2.0",
@@ -2361,10 +2227,6 @@
 			"peerDependencies": {
 				"@firebase/app": "0.x"
 			}
-		},
-		"node_modules/@firebase/data-connect/node_modules/tslib": {
-			"version": "2.8.1",
-			"license": "0BSD"
 		},
 		"node_modules/@firebase/database": {
 			"version": "1.0.11",
@@ -2397,10 +2259,6 @@
 				"node": ">=18.0.0"
 			}
 		},
-		"node_modules/@firebase/database-compat/node_modules/tslib": {
-			"version": "2.8.1",
-			"license": "0BSD"
-		},
 		"node_modules/@firebase/database-types": {
 			"version": "1.0.8",
 			"license": "Apache-2.0",
@@ -2408,10 +2266,6 @@
 				"@firebase/app-types": "0.9.3",
 				"@firebase/util": "1.10.3"
 			}
-		},
-		"node_modules/@firebase/database/node_modules/tslib": {
-			"version": "2.8.1",
-			"license": "0BSD"
 		},
 		"node_modules/@firebase/firestore": {
 			"version": "4.7.6",
@@ -2449,10 +2303,6 @@
 				"@firebase/app-compat": "0.x"
 			}
 		},
-		"node_modules/@firebase/firestore-compat/node_modules/tslib": {
-			"version": "2.8.1",
-			"license": "0BSD"
-		},
 		"node_modules/@firebase/firestore-types": {
 			"version": "3.0.3",
 			"license": "Apache-2.0",
@@ -2460,10 +2310,6 @@
 				"@firebase/app-types": "0.x",
 				"@firebase/util": "1.x"
 			}
-		},
-		"node_modules/@firebase/firestore/node_modules/tslib": {
-			"version": "2.8.1",
-			"license": "0BSD"
 		},
 		"node_modules/@firebase/functions": {
 			"version": "0.12.1",
@@ -2500,17 +2346,9 @@
 				"@firebase/app-compat": "0.x"
 			}
 		},
-		"node_modules/@firebase/functions-compat/node_modules/tslib": {
-			"version": "2.8.1",
-			"license": "0BSD"
-		},
 		"node_modules/@firebase/functions-types": {
 			"version": "0.6.3",
 			"license": "Apache-2.0"
-		},
-		"node_modules/@firebase/functions/node_modules/tslib": {
-			"version": "2.8.1",
-			"license": "0BSD"
 		},
 		"node_modules/@firebase/installations": {
 			"version": "0.6.12",
@@ -2539,20 +2377,12 @@
 				"@firebase/app-compat": "0.x"
 			}
 		},
-		"node_modules/@firebase/installations-compat/node_modules/tslib": {
-			"version": "2.8.1",
-			"license": "0BSD"
-		},
 		"node_modules/@firebase/installations-types": {
 			"version": "0.5.3",
 			"license": "Apache-2.0",
 			"peerDependencies": {
 				"@firebase/app-types": "0.x"
 			}
-		},
-		"node_modules/@firebase/installations/node_modules/tslib": {
-			"version": "2.8.1",
-			"license": "0BSD"
 		},
 		"node_modules/@firebase/logger": {
 			"version": "0.4.4",
@@ -2563,10 +2393,6 @@
 			"engines": {
 				"node": ">=18.0.0"
 			}
-		},
-		"node_modules/@firebase/logger/node_modules/tslib": {
-			"version": "2.8.1",
-			"license": "0BSD"
 		},
 		"node_modules/@firebase/messaging": {
 			"version": "0.12.16",
@@ -2596,17 +2422,9 @@
 				"@firebase/app-compat": "0.x"
 			}
 		},
-		"node_modules/@firebase/messaging-compat/node_modules/tslib": {
-			"version": "2.8.1",
-			"license": "0BSD"
-		},
 		"node_modules/@firebase/messaging-interop-types": {
 			"version": "0.2.3",
 			"license": "Apache-2.0"
-		},
-		"node_modules/@firebase/messaging/node_modules/tslib": {
-			"version": "2.8.1",
-			"license": "0BSD"
 		},
 		"node_modules/@firebase/performance": {
 			"version": "0.6.12",
@@ -2637,17 +2455,9 @@
 				"@firebase/app-compat": "0.x"
 			}
 		},
-		"node_modules/@firebase/performance-compat/node_modules/tslib": {
-			"version": "2.8.1",
-			"license": "0BSD"
-		},
 		"node_modules/@firebase/performance-types": {
 			"version": "0.2.3",
 			"license": "Apache-2.0"
-		},
-		"node_modules/@firebase/performance/node_modules/tslib": {
-			"version": "2.8.1",
-			"license": "0BSD"
 		},
 		"node_modules/@firebase/remote-config": {
 			"version": "0.5.0",
@@ -2678,17 +2488,9 @@
 				"@firebase/app-compat": "0.x"
 			}
 		},
-		"node_modules/@firebase/remote-config-compat/node_modules/tslib": {
-			"version": "2.8.1",
-			"license": "0BSD"
-		},
 		"node_modules/@firebase/remote-config-types": {
 			"version": "0.4.0",
 			"license": "Apache-2.0"
-		},
-		"node_modules/@firebase/remote-config/node_modules/tslib": {
-			"version": "2.8.1",
-			"license": "0BSD"
 		},
 		"node_modules/@firebase/storage": {
 			"version": "0.13.5",
@@ -2722,10 +2524,6 @@
 				"@firebase/app-compat": "0.x"
 			}
 		},
-		"node_modules/@firebase/storage-compat/node_modules/tslib": {
-			"version": "2.8.1",
-			"license": "0BSD"
-		},
 		"node_modules/@firebase/storage-types": {
 			"version": "0.8.3",
 			"license": "Apache-2.0",
@@ -2733,10 +2531,6 @@
 				"@firebase/app-types": "0.x",
 				"@firebase/util": "1.x"
 			}
-		},
-		"node_modules/@firebase/storage/node_modules/tslib": {
-			"version": "2.8.1",
-			"license": "0BSD"
 		},
 		"node_modules/@firebase/util": {
 			"version": "1.10.3",
@@ -2747,10 +2541,6 @@
 			"engines": {
 				"node": ">=18.0.0"
 			}
-		},
-		"node_modules/@firebase/util/node_modules/tslib": {
-			"version": "2.8.1",
-			"license": "0BSD"
 		},
 		"node_modules/@firebase/vertexai": {
 			"version": "1.0.3",
@@ -2769,10 +2559,6 @@
 				"@firebase/app": "0.x",
 				"@firebase/app-types": "0.x"
 			}
-		},
-		"node_modules/@firebase/vertexai/node_modules/tslib": {
-			"version": "2.8.1",
-			"license": "0BSD"
 		},
 		"node_modules/@firebase/webchannel-wrapper": {
 			"version": "1.0.3",
@@ -5787,194 +5573,190 @@
 			"license": "(Unlicense OR Apache-2.0)"
 		},
 		"node_modules/@smithy/abort-controller": {
-			"version": "4.0.4",
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.2.3.tgz",
+			"integrity": "sha512-xWL9Mf8b7tIFuAlpjKtRPnHrR8XVrwTj5NPYO/QwZPtc0SDLsPxb56V5tzi5yspSMytISHybifez+4jlrx0vkQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/types": "^4.3.1",
+				"@smithy/types": "^4.8.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
 				"node": ">=18.0.0"
 			}
-		},
-		"node_modules/@smithy/abort-controller/node_modules/tslib": {
-			"version": "2.8.1",
-			"license": "0BSD"
 		},
 		"node_modules/@smithy/config-resolver": {
-			"version": "4.1.4",
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.0.tgz",
+			"integrity": "sha512-Kkmz3Mup2PGp/HNJxhCWkLNdlajJORLSjwkcfrj0E7nu6STAEdcMR1ir5P9/xOmncx8xXfru0fbUYLlZog/cFg==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/node-config-provider": "^4.1.3",
-				"@smithy/types": "^4.3.1",
-				"@smithy/util-config-provider": "^4.0.0",
-				"@smithy/util-middleware": "^4.0.4",
+				"@smithy/node-config-provider": "^4.3.3",
+				"@smithy/types": "^4.8.0",
+				"@smithy/util-config-provider": "^4.2.0",
+				"@smithy/util-endpoints": "^3.2.3",
+				"@smithy/util-middleware": "^4.2.3",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
 				"node": ">=18.0.0"
 			}
-		},
-		"node_modules/@smithy/config-resolver/node_modules/tslib": {
-			"version": "2.8.1",
-			"license": "0BSD"
 		},
 		"node_modules/@smithy/core": {
-			"version": "3.6.0",
+			"version": "3.17.1",
+			"resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.17.1.tgz",
+			"integrity": "sha512-V4Qc2CIb5McABYfaGiIYLTmo/vwNIK7WXI5aGveBd9UcdhbOMwcvIMxIw/DJj1S9QgOMa/7FBkarMdIC0EOTEQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/middleware-serde": "^4.0.8",
-				"@smithy/protocol-http": "^5.1.2",
-				"@smithy/types": "^4.3.1",
-				"@smithy/util-base64": "^4.0.0",
-				"@smithy/util-body-length-browser": "^4.0.0",
-				"@smithy/util-middleware": "^4.0.4",
-				"@smithy/util-stream": "^4.2.2",
-				"@smithy/util-utf8": "^4.0.0",
+				"@smithy/middleware-serde": "^4.2.3",
+				"@smithy/protocol-http": "^5.3.3",
+				"@smithy/types": "^4.8.0",
+				"@smithy/util-base64": "^4.3.0",
+				"@smithy/util-body-length-browser": "^4.2.0",
+				"@smithy/util-middleware": "^4.2.3",
+				"@smithy/util-stream": "^4.5.4",
+				"@smithy/util-utf8": "^4.2.0",
+				"@smithy/uuid": "^1.1.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
 				"node": ">=18.0.0"
 			}
-		},
-		"node_modules/@smithy/core/node_modules/tslib": {
-			"version": "2.8.1",
-			"license": "0BSD"
 		},
 		"node_modules/@smithy/credential-provider-imds": {
-			"version": "4.0.6",
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.3.tgz",
+			"integrity": "sha512-hA1MQ/WAHly4SYltJKitEsIDVsNmXcQfYBRv2e+q04fnqtAX5qXaybxy/fhUeAMCnQIdAjaGDb04fMHQefWRhw==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/node-config-provider": "^4.1.3",
-				"@smithy/property-provider": "^4.0.4",
-				"@smithy/types": "^4.3.1",
-				"@smithy/url-parser": "^4.0.4",
+				"@smithy/node-config-provider": "^4.3.3",
+				"@smithy/property-provider": "^4.2.3",
+				"@smithy/types": "^4.8.0",
+				"@smithy/url-parser": "^4.2.3",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
 				"node": ">=18.0.0"
 			}
 		},
-		"node_modules/@smithy/credential-provider-imds/node_modules/tslib": {
-			"version": "2.8.1",
-			"license": "0BSD"
-		},
 		"node_modules/@smithy/eventstream-codec": {
-			"version": "4.0.4",
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-4.2.3.tgz",
+			"integrity": "sha512-rcr0VH0uNoMrtgKuY7sMfyKqbHc4GQaQ6Yp4vwgm+Z6psPuOgL+i/Eo/QWdXRmMinL3EgFM0Z1vkfyPyfzLmjw==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-crypto/crc32": "5.2.0",
-				"@smithy/types": "^4.3.1",
-				"@smithy/util-hex-encoding": "^4.0.0",
+				"@smithy/types": "^4.8.0",
+				"@smithy/util-hex-encoding": "^4.2.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
 				"node": ">=18.0.0"
 			}
-		},
-		"node_modules/@smithy/eventstream-codec/node_modules/tslib": {
-			"version": "2.8.1",
-			"license": "0BSD"
 		},
 		"node_modules/@smithy/eventstream-serde-browser": {
-			"version": "4.0.4",
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-4.2.3.tgz",
+			"integrity": "sha512-EcS0kydOr2qJ3vV45y7nWnTlrPmVIMbUFOZbMG80+e2+xePQISX9DrcbRpVRFTS5Nqz3FiEbDcTCAV0or7bqdw==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/eventstream-serde-universal": "^4.0.4",
-				"@smithy/types": "^4.3.1",
+				"@smithy/eventstream-serde-universal": "^4.2.3",
+				"@smithy/types": "^4.8.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
 				"node": ">=18.0.0"
 			}
-		},
-		"node_modules/@smithy/eventstream-serde-browser/node_modules/tslib": {
-			"version": "2.8.1",
-			"license": "0BSD"
 		},
 		"node_modules/@smithy/eventstream-serde-config-resolver": {
-			"version": "4.1.2",
+			"version": "4.3.3",
+			"resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-4.3.3.tgz",
+			"integrity": "sha512-GewKGZ6lIJ9APjHFqR2cUW+Efp98xLu1KmN0jOWxQ1TN/gx3HTUPVbLciFD8CfScBj2IiKifqh9vYFRRXrYqXA==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/types": "^4.3.1",
+				"@smithy/types": "^4.8.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
 				"node": ">=18.0.0"
 			}
 		},
-		"node_modules/@smithy/eventstream-serde-config-resolver/node_modules/tslib": {
-			"version": "2.8.1",
-			"license": "0BSD"
+		"node_modules/@smithy/eventstream-serde-node": {
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-4.2.3.tgz",
+			"integrity": "sha512-uQobOTQq2FapuSOlmGLUeGTpvcBLE5Fc7XjERUSk4dxEi4AhTwuyHYZNAvL4EMUp7lzxxkKDFaJ1GY0ovrj0Kg==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/eventstream-serde-universal": "^4.2.3",
+				"@smithy/types": "^4.8.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
 		},
 		"node_modules/@smithy/eventstream-serde-universal": {
-			"version": "4.0.4",
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-4.2.3.tgz",
+			"integrity": "sha512-QIvH/CKOk1BZPz/iwfgbh1SQD5Y0lpaw2kLA8zpLRRtYMPXeYUEWh+moTaJyqDaKlbrB174kB7FSRFiZ735tWw==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/eventstream-codec": "^4.0.4",
-				"@smithy/types": "^4.3.1",
+				"@smithy/eventstream-codec": "^4.2.3",
+				"@smithy/types": "^4.8.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
 				"node": ">=18.0.0"
 			}
-		},
-		"node_modules/@smithy/eventstream-serde-universal/node_modules/tslib": {
-			"version": "2.8.1",
-			"license": "0BSD"
 		},
 		"node_modules/@smithy/fetch-http-handler": {
-			"version": "5.0.4",
+			"version": "5.3.4",
+			"resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.4.tgz",
+			"integrity": "sha512-bwigPylvivpRLCm+YK9I5wRIYjFESSVwl8JQ1vVx/XhCw0PtCi558NwTnT2DaVCl5pYlImGuQTSwMsZ+pIavRw==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/protocol-http": "^5.1.2",
-				"@smithy/querystring-builder": "^4.0.4",
-				"@smithy/types": "^4.3.1",
-				"@smithy/util-base64": "^4.0.0",
+				"@smithy/protocol-http": "^5.3.3",
+				"@smithy/querystring-builder": "^4.2.3",
+				"@smithy/types": "^4.8.0",
+				"@smithy/util-base64": "^4.3.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
 				"node": ">=18.0.0"
 			}
-		},
-		"node_modules/@smithy/fetch-http-handler/node_modules/tslib": {
-			"version": "2.8.1",
-			"license": "0BSD"
 		},
 		"node_modules/@smithy/hash-node": {
-			"version": "4.0.4",
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.3.tgz",
+			"integrity": "sha512-6+NOdZDbfuU6s1ISp3UOk5Rg953RJ2aBLNLLBEcamLjHAg1Po9Ha7QIB5ZWhdRUVuOUrT8BVFR+O2KIPmw027g==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/types": "^4.3.1",
-				"@smithy/util-buffer-from": "^4.0.0",
-				"@smithy/util-utf8": "^4.0.0",
+				"@smithy/types": "^4.8.0",
+				"@smithy/util-buffer-from": "^4.2.0",
+				"@smithy/util-utf8": "^4.2.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
 				"node": ">=18.0.0"
 			}
-		},
-		"node_modules/@smithy/hash-node/node_modules/tslib": {
-			"version": "2.8.1",
-			"license": "0BSD"
 		},
 		"node_modules/@smithy/invalid-dependency": {
-			"version": "4.0.4",
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.2.3.tgz",
+			"integrity": "sha512-Cc9W5DwDuebXEDMpOpl4iERo8I0KFjTnomK2RMdhhR87GwrSmUmwMxS4P5JdRf+LsjOdIqumcerwRgYMr/tZ9Q==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/types": "^4.3.1",
+				"@smithy/types": "^4.8.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
 				"node": ">=18.0.0"
 			}
-		},
-		"node_modules/@smithy/invalid-dependency/node_modules/tslib": {
-			"version": "2.8.1",
-			"license": "0BSD"
 		},
 		"node_modules/@smithy/is-array-buffer": {
-			"version": "4.0.0",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.0.tgz",
+			"integrity": "sha512-DZZZBvC7sjcYh4MazJSGiWMI2L7E0oCiRHREDzIxi/M2LY79/21iXt6aPLHge82wi5LsuRF5A06Ds3+0mlh6CQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^2.6.2"
@@ -5982,276 +5764,237 @@
 			"engines": {
 				"node": ">=18.0.0"
 			}
-		},
-		"node_modules/@smithy/is-array-buffer/node_modules/tslib": {
-			"version": "2.8.1",
-			"license": "0BSD"
 		},
 		"node_modules/@smithy/middleware-content-length": {
-			"version": "4.0.4",
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.3.tgz",
+			"integrity": "sha512-/atXLsT88GwKtfp5Jr0Ks1CSa4+lB+IgRnkNrrYP0h1wL4swHNb0YONEvTceNKNdZGJsye+W2HH8W7olbcPUeA==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/protocol-http": "^5.1.2",
-				"@smithy/types": "^4.3.1",
+				"@smithy/protocol-http": "^5.3.3",
+				"@smithy/types": "^4.8.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
 				"node": ">=18.0.0"
 			}
-		},
-		"node_modules/@smithy/middleware-content-length/node_modules/tslib": {
-			"version": "2.8.1",
-			"license": "0BSD"
 		},
 		"node_modules/@smithy/middleware-endpoint": {
-			"version": "4.1.13",
+			"version": "4.3.5",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.3.5.tgz",
+			"integrity": "sha512-SIzKVTvEudFWJbxAaq7f2GvP3jh2FHDpIFI6/VAf4FOWGFZy0vnYMPSRj8PGYI8Hjt29mvmwSRgKuO3bK4ixDw==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/core": "^3.6.0",
-				"@smithy/middleware-serde": "^4.0.8",
-				"@smithy/node-config-provider": "^4.1.3",
-				"@smithy/shared-ini-file-loader": "^4.0.4",
-				"@smithy/types": "^4.3.1",
-				"@smithy/url-parser": "^4.0.4",
-				"@smithy/util-middleware": "^4.0.4",
+				"@smithy/core": "^3.17.1",
+				"@smithy/middleware-serde": "^4.2.3",
+				"@smithy/node-config-provider": "^4.3.3",
+				"@smithy/shared-ini-file-loader": "^4.3.3",
+				"@smithy/types": "^4.8.0",
+				"@smithy/url-parser": "^4.2.3",
+				"@smithy/util-middleware": "^4.2.3",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
 				"node": ">=18.0.0"
 			}
 		},
-		"node_modules/@smithy/middleware-endpoint/node_modules/tslib": {
-			"version": "2.8.1",
-			"license": "0BSD"
-		},
 		"node_modules/@smithy/middleware-retry": {
-			"version": "4.1.14",
+			"version": "4.4.5",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.4.5.tgz",
+			"integrity": "sha512-DCaXbQqcZ4tONMvvdz+zccDE21sLcbwWoNqzPLFlZaxt1lDtOE2tlVpRSwcTOJrjJSUThdgEYn7HrX5oLGlK9A==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/node-config-provider": "^4.1.3",
-				"@smithy/protocol-http": "^5.1.2",
-				"@smithy/service-error-classification": "^4.0.6",
-				"@smithy/smithy-client": "^4.4.5",
-				"@smithy/types": "^4.3.1",
-				"@smithy/util-middleware": "^4.0.4",
-				"@smithy/util-retry": "^4.0.6",
-				"tslib": "^2.6.2",
-				"uuid": "^9.0.1"
+				"@smithy/node-config-provider": "^4.3.3",
+				"@smithy/protocol-http": "^5.3.3",
+				"@smithy/service-error-classification": "^4.2.3",
+				"@smithy/smithy-client": "^4.9.1",
+				"@smithy/types": "^4.8.0",
+				"@smithy/util-middleware": "^4.2.3",
+				"@smithy/util-retry": "^4.2.3",
+				"@smithy/uuid": "^1.1.0",
+				"tslib": "^2.6.2"
 			},
 			"engines": {
 				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/middleware-retry/node_modules/tslib": {
-			"version": "2.8.1",
-			"license": "0BSD"
-		},
-		"node_modules/@smithy/middleware-retry/node_modules/uuid": {
-			"version": "9.0.1",
-			"funding": [
-				"https://github.com/sponsors/broofa",
-				"https://github.com/sponsors/ctavan"
-			],
-			"license": "MIT",
-			"bin": {
-				"uuid": "dist/bin/uuid"
 			}
 		},
 		"node_modules/@smithy/middleware-serde": {
-			"version": "4.0.8",
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.3.tgz",
+			"integrity": "sha512-8g4NuUINpYccxiCXM5s1/V+uLtts8NcX4+sPEbvYQDZk4XoJfDpq5y2FQxfmUL89syoldpzNzA0R9nhzdtdKnQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/protocol-http": "^5.1.2",
-				"@smithy/types": "^4.3.1",
+				"@smithy/protocol-http": "^5.3.3",
+				"@smithy/types": "^4.8.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
 				"node": ">=18.0.0"
 			}
-		},
-		"node_modules/@smithy/middleware-serde/node_modules/tslib": {
-			"version": "2.8.1",
-			"license": "0BSD"
 		},
 		"node_modules/@smithy/middleware-stack": {
-			"version": "4.0.4",
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.3.tgz",
+			"integrity": "sha512-iGuOJkH71faPNgOj/gWuEGS6xvQashpLwWB1HjHq1lNNiVfbiJLpZVbhddPuDbx9l4Cgl0vPLq5ltRfSaHfspA==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/types": "^4.3.1",
+				"@smithy/types": "^4.8.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
 				"node": ">=18.0.0"
 			}
-		},
-		"node_modules/@smithy/middleware-stack/node_modules/tslib": {
-			"version": "2.8.1",
-			"license": "0BSD"
 		},
 		"node_modules/@smithy/node-config-provider": {
-			"version": "4.1.3",
+			"version": "4.3.3",
+			"resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.3.tgz",
+			"integrity": "sha512-NzI1eBpBSViOav8NVy1fqOlSfkLgkUjUTlohUSgAEhHaFWA3XJiLditvavIP7OpvTjDp5u2LhtlBhkBlEisMwA==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/property-provider": "^4.0.4",
-				"@smithy/shared-ini-file-loader": "^4.0.4",
-				"@smithy/types": "^4.3.1",
+				"@smithy/property-provider": "^4.2.3",
+				"@smithy/shared-ini-file-loader": "^4.3.3",
+				"@smithy/types": "^4.8.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
 				"node": ">=18.0.0"
 			}
-		},
-		"node_modules/@smithy/node-config-provider/node_modules/tslib": {
-			"version": "2.8.1",
-			"license": "0BSD"
 		},
 		"node_modules/@smithy/node-http-handler": {
-			"version": "4.0.6",
+			"version": "4.4.3",
+			"resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.4.3.tgz",
+			"integrity": "sha512-MAwltrDB0lZB/H6/2M5PIsISSwdI5yIh6DaBB9r0Flo9nx3y0dzl/qTMJPd7tJvPdsx6Ks/cwVzheGNYzXyNbQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/abort-controller": "^4.0.4",
-				"@smithy/protocol-http": "^5.1.2",
-				"@smithy/querystring-builder": "^4.0.4",
-				"@smithy/types": "^4.3.1",
+				"@smithy/abort-controller": "^4.2.3",
+				"@smithy/protocol-http": "^5.3.3",
+				"@smithy/querystring-builder": "^4.2.3",
+				"@smithy/types": "^4.8.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
 				"node": ">=18.0.0"
 			}
-		},
-		"node_modules/@smithy/node-http-handler/node_modules/tslib": {
-			"version": "2.8.1",
-			"license": "0BSD"
 		},
 		"node_modules/@smithy/property-provider": {
-			"version": "4.0.4",
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.3.tgz",
+			"integrity": "sha512-+1EZ+Y+njiefCohjlhyOcy1UNYjT+1PwGFHCxA/gYctjg3DQWAU19WigOXAco/Ql8hZokNehpzLd0/+3uCreqQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/types": "^4.3.1",
+				"@smithy/types": "^4.8.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
 				"node": ">=18.0.0"
 			}
-		},
-		"node_modules/@smithy/property-provider/node_modules/tslib": {
-			"version": "2.8.1",
-			"license": "0BSD"
 		},
 		"node_modules/@smithy/protocol-http": {
-			"version": "5.1.2",
+			"version": "5.3.3",
+			"resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.3.tgz",
+			"integrity": "sha512-Mn7f/1aN2/jecywDcRDvWWWJF4uwg/A0XjFMJtj72DsgHTByfjRltSqcT9NyE9RTdBSN6X1RSXrhn/YWQl8xlw==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/types": "^4.3.1",
+				"@smithy/types": "^4.8.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
 				"node": ">=18.0.0"
 			}
-		},
-		"node_modules/@smithy/protocol-http/node_modules/tslib": {
-			"version": "2.8.1",
-			"license": "0BSD"
 		},
 		"node_modules/@smithy/querystring-builder": {
-			"version": "4.0.4",
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.3.tgz",
+			"integrity": "sha512-LOVCGCmwMahYUM/P0YnU/AlDQFjcu+gWbFJooC417QRB/lDJlWSn8qmPSDp+s4YVAHOgtgbNG4sR+SxF/VOcJQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/types": "^4.3.1",
-				"@smithy/util-uri-escape": "^4.0.0",
+				"@smithy/types": "^4.8.0",
+				"@smithy/util-uri-escape": "^4.2.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
 				"node": ">=18.0.0"
 			}
-		},
-		"node_modules/@smithy/querystring-builder/node_modules/tslib": {
-			"version": "2.8.1",
-			"license": "0BSD"
 		},
 		"node_modules/@smithy/querystring-parser": {
-			"version": "4.0.4",
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.3.tgz",
+			"integrity": "sha512-cYlSNHcTAX/wc1rpblli3aUlLMGgKZ/Oqn8hhjFASXMCXjIqeuQBei0cnq2JR8t4RtU9FpG6uyl6PxyArTiwKA==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/types": "^4.3.1",
+				"@smithy/types": "^4.8.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
 				"node": ">=18.0.0"
 			}
 		},
-		"node_modules/@smithy/querystring-parser/node_modules/tslib": {
-			"version": "2.8.1",
-			"license": "0BSD"
-		},
 		"node_modules/@smithy/service-error-classification": {
-			"version": "4.0.6",
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.2.3.tgz",
+			"integrity": "sha512-NkxsAxFWwsPsQiwFG2MzJ/T7uIR6AQNh1SzcxSUnmmIqIQMlLRQDKhc17M7IYjiuBXhrQRjQTo3CxX+DobS93g==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/types": "^4.3.1"
+				"@smithy/types": "^4.8.0"
 			},
 			"engines": {
 				"node": ">=18.0.0"
 			}
 		},
 		"node_modules/@smithy/shared-ini-file-loader": {
-			"version": "4.0.4",
+			"version": "4.3.3",
+			"resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.3.3.tgz",
+			"integrity": "sha512-9f9Ixej0hFhroOK2TxZfUUDR13WVa8tQzhSzPDgXe5jGL3KmaM9s8XN7RQwqtEypI82q9KHnKS71CJ+q/1xLtQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/types": "^4.3.1",
+				"@smithy/types": "^4.8.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
 				"node": ">=18.0.0"
 			}
-		},
-		"node_modules/@smithy/shared-ini-file-loader/node_modules/tslib": {
-			"version": "2.8.1",
-			"license": "0BSD"
 		},
 		"node_modules/@smithy/signature-v4": {
-			"version": "5.1.2",
+			"version": "5.3.3",
+			"resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.3.tgz",
+			"integrity": "sha512-CmSlUy+eEYbIEYN5N3vvQTRfqt0lJlQkaQUIf+oizu7BbDut0pozfDjBGecfcfWf7c62Yis4JIEgqQ/TCfodaA==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/is-array-buffer": "^4.0.0",
-				"@smithy/protocol-http": "^5.1.2",
-				"@smithy/types": "^4.3.1",
-				"@smithy/util-hex-encoding": "^4.0.0",
-				"@smithy/util-middleware": "^4.0.4",
-				"@smithy/util-uri-escape": "^4.0.0",
-				"@smithy/util-utf8": "^4.0.0",
+				"@smithy/is-array-buffer": "^4.2.0",
+				"@smithy/protocol-http": "^5.3.3",
+				"@smithy/types": "^4.8.0",
+				"@smithy/util-hex-encoding": "^4.2.0",
+				"@smithy/util-middleware": "^4.2.3",
+				"@smithy/util-uri-escape": "^4.2.0",
+				"@smithy/util-utf8": "^4.2.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
 				"node": ">=18.0.0"
 			}
-		},
-		"node_modules/@smithy/signature-v4/node_modules/tslib": {
-			"version": "2.8.1",
-			"license": "0BSD"
 		},
 		"node_modules/@smithy/smithy-client": {
-			"version": "4.4.5",
+			"version": "4.9.1",
+			"resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.9.1.tgz",
+			"integrity": "sha512-Ngb95ryR5A9xqvQFT5mAmYkCwbXvoLavLFwmi7zVg/IowFPCfiqRfkOKnbc/ZRL8ZKJ4f+Tp6kSu6wjDQb8L/g==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/core": "^3.6.0",
-				"@smithy/middleware-endpoint": "^4.1.13",
-				"@smithy/middleware-stack": "^4.0.4",
-				"@smithy/protocol-http": "^5.1.2",
-				"@smithy/types": "^4.3.1",
-				"@smithy/util-stream": "^4.2.2",
+				"@smithy/core": "^3.17.1",
+				"@smithy/middleware-endpoint": "^4.3.5",
+				"@smithy/middleware-stack": "^4.2.3",
+				"@smithy/protocol-http": "^5.3.3",
+				"@smithy/types": "^4.8.0",
+				"@smithy/util-stream": "^4.5.4",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
 				"node": ">=18.0.0"
 			}
-		},
-		"node_modules/@smithy/smithy-client/node_modules/tslib": {
-			"version": "2.8.1",
-			"license": "0BSD"
 		},
 		"node_modules/@smithy/types": {
-			"version": "4.3.1",
+			"version": "4.8.0",
+			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.8.0.tgz",
+			"integrity": "sha512-QpELEHLO8SsQVtqP+MkEgCYTFW0pleGozfs3cZ183ZBj9z3VC1CX1/wtFMK64p+5bhtZo41SeLK1rBRtd25nHQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^2.6.2"
@@ -6259,45 +6002,39 @@
 			"engines": {
 				"node": ">=18.0.0"
 			}
-		},
-		"node_modules/@smithy/types/node_modules/tslib": {
-			"version": "2.8.1",
-			"license": "0BSD"
 		},
 		"node_modules/@smithy/url-parser": {
-			"version": "4.0.4",
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.3.tgz",
+			"integrity": "sha512-I066AigYvY3d9VlU3zG9XzZg1yT10aNqvCaBTw9EPgu5GrsEl1aUkcMvhkIXascYH1A8W0LQo3B1Kr1cJNcQEw==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/querystring-parser": "^4.0.4",
-				"@smithy/types": "^4.3.1",
+				"@smithy/querystring-parser": "^4.2.3",
+				"@smithy/types": "^4.8.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
 				"node": ">=18.0.0"
 			}
-		},
-		"node_modules/@smithy/url-parser/node_modules/tslib": {
-			"version": "2.8.1",
-			"license": "0BSD"
 		},
 		"node_modules/@smithy/util-base64": {
-			"version": "4.0.0",
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.3.0.tgz",
+			"integrity": "sha512-GkXZ59JfyxsIwNTWFnjmFEI8kZpRNIBfxKjv09+nkAWPt/4aGaEWMM04m4sxgNVWkbt2MdSvE3KF/PfX4nFedQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/util-buffer-from": "^4.0.0",
-				"@smithy/util-utf8": "^4.0.0",
+				"@smithy/util-buffer-from": "^4.2.0",
+				"@smithy/util-utf8": "^4.2.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
 				"node": ">=18.0.0"
 			}
-		},
-		"node_modules/@smithy/util-base64/node_modules/tslib": {
-			"version": "2.8.1",
-			"license": "0BSD"
 		},
 		"node_modules/@smithy/util-body-length-browser": {
-			"version": "4.0.0",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.2.0.tgz",
+			"integrity": "sha512-Fkoh/I76szMKJnBXWPdFkQJl2r9SjPt3cMzLdOB6eJ4Pnpas8hVoWPYemX/peO0yrrvldgCUVJqOAjUrOLjbxg==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^2.6.2"
@@ -6305,13 +6042,11 @@
 			"engines": {
 				"node": ">=18.0.0"
 			}
-		},
-		"node_modules/@smithy/util-body-length-browser/node_modules/tslib": {
-			"version": "2.8.1",
-			"license": "0BSD"
 		},
 		"node_modules/@smithy/util-body-length-node": {
-			"version": "4.0.0",
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.2.1.tgz",
+			"integrity": "sha512-h53dz/pISVrVrfxV1iqXlx5pRg3V2YWFcSQyPyXZRrZoZj4R4DeWRDo1a7dd3CPTcFi3kE+98tuNyD2axyZReA==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^2.6.2"
@@ -6319,28 +6054,24 @@
 			"engines": {
 				"node": ">=18.0.0"
 			}
-		},
-		"node_modules/@smithy/util-body-length-node/node_modules/tslib": {
-			"version": "2.8.1",
-			"license": "0BSD"
 		},
 		"node_modules/@smithy/util-buffer-from": {
-			"version": "4.0.0",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.0.tgz",
+			"integrity": "sha512-kAY9hTKulTNevM2nlRtxAG2FQ3B2OR6QIrPY3zE5LqJy1oxzmgBGsHLWTcNhWXKchgA0WHW+mZkQrng/pgcCew==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/is-array-buffer": "^4.0.0",
+				"@smithy/is-array-buffer": "^4.2.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
 				"node": ">=18.0.0"
 			}
-		},
-		"node_modules/@smithy/util-buffer-from/node_modules/tslib": {
-			"version": "2.8.1",
-			"license": "0BSD"
 		},
 		"node_modules/@smithy/util-config-provider": {
-			"version": "4.0.0",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.2.0.tgz",
+			"integrity": "sha512-YEjpl6XJ36FTKmD+kRJJWYvrHeUvm5ykaUS5xK+6oXffQPHeEM4/nXlZPe+Wu0lsgRUcNZiliYNh/y7q9c2y6Q==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^2.6.2"
@@ -6348,67 +6079,58 @@
 			"engines": {
 				"node": ">=18.0.0"
 			}
-		},
-		"node_modules/@smithy/util-config-provider/node_modules/tslib": {
-			"version": "2.8.1",
-			"license": "0BSD"
 		},
 		"node_modules/@smithy/util-defaults-mode-browser": {
-			"version": "4.0.21",
+			"version": "4.3.4",
+			"resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.4.tgz",
+			"integrity": "sha512-qI5PJSW52rnutos8Bln8nwQZRpyoSRN6k2ajyoUHNMUzmWqHnOJCnDELJuV6m5PML0VkHI+XcXzdB+6awiqYUw==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/property-provider": "^4.0.4",
-				"@smithy/smithy-client": "^4.4.5",
-				"@smithy/types": "^4.3.1",
-				"bowser": "^2.11.0",
+				"@smithy/property-provider": "^4.2.3",
+				"@smithy/smithy-client": "^4.9.1",
+				"@smithy/types": "^4.8.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
 				"node": ">=18.0.0"
 			}
-		},
-		"node_modules/@smithy/util-defaults-mode-browser/node_modules/tslib": {
-			"version": "2.8.1",
-			"license": "0BSD"
 		},
 		"node_modules/@smithy/util-defaults-mode-node": {
-			"version": "4.0.21",
+			"version": "4.2.6",
+			"resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.6.tgz",
+			"integrity": "sha512-c6M/ceBTm31YdcFpgfgQAJaw3KbaLuRKnAz91iMWFLSrgxRpYm03c3bu5cpYojNMfkV9arCUelelKA7XQT36SQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/config-resolver": "^4.1.4",
-				"@smithy/credential-provider-imds": "^4.0.6",
-				"@smithy/node-config-provider": "^4.1.3",
-				"@smithy/property-provider": "^4.0.4",
-				"@smithy/smithy-client": "^4.4.5",
-				"@smithy/types": "^4.3.1",
+				"@smithy/config-resolver": "^4.4.0",
+				"@smithy/credential-provider-imds": "^4.2.3",
+				"@smithy/node-config-provider": "^4.3.3",
+				"@smithy/property-provider": "^4.2.3",
+				"@smithy/smithy-client": "^4.9.1",
+				"@smithy/types": "^4.8.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
 				"node": ">=18.0.0"
 			}
-		},
-		"node_modules/@smithy/util-defaults-mode-node/node_modules/tslib": {
-			"version": "2.8.1",
-			"license": "0BSD"
 		},
 		"node_modules/@smithy/util-endpoints": {
-			"version": "3.0.6",
+			"version": "3.2.3",
+			"resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.2.3.tgz",
+			"integrity": "sha512-aCfxUOVv0CzBIkU10TubdgKSx5uRvzH064kaiPEWfNIvKOtNpu642P4FP1hgOFkjQIkDObrfIDnKMKkeyrejvQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/node-config-provider": "^4.1.3",
-				"@smithy/types": "^4.3.1",
+				"@smithy/node-config-provider": "^4.3.3",
+				"@smithy/types": "^4.8.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
 				"node": ">=18.0.0"
 			}
-		},
-		"node_modules/@smithy/util-endpoints/node_modules/tslib": {
-			"version": "2.8.1",
-			"license": "0BSD"
 		},
 		"node_modules/@smithy/util-hex-encoding": {
-			"version": "4.0.0",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.2.0.tgz",
+			"integrity": "sha512-CCQBwJIvXMLKxVbO88IukazJD9a4kQ9ZN7/UMGBjBcJYvatpWk+9g870El4cB8/EJxfe+k+y0GmR9CAzkF+Nbw==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^2.6.2"
@@ -6416,65 +6138,57 @@
 			"engines": {
 				"node": ">=18.0.0"
 			}
-		},
-		"node_modules/@smithy/util-hex-encoding/node_modules/tslib": {
-			"version": "2.8.1",
-			"license": "0BSD"
 		},
 		"node_modules/@smithy/util-middleware": {
-			"version": "4.0.4",
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.3.tgz",
+			"integrity": "sha512-v5ObKlSe8PWUHCqEiX2fy1gNv6goiw6E5I/PN2aXg3Fb/hse0xeaAnSpXDiWl7x6LamVKq7senB+m5LOYHUAHw==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/types": "^4.3.1",
+				"@smithy/types": "^4.8.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
 				"node": ">=18.0.0"
 			}
-		},
-		"node_modules/@smithy/util-middleware/node_modules/tslib": {
-			"version": "2.8.1",
-			"license": "0BSD"
 		},
 		"node_modules/@smithy/util-retry": {
-			"version": "4.0.6",
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.2.3.tgz",
+			"integrity": "sha512-lLPWnakjC0q9z+OtiXk+9RPQiYPNAovt2IXD3CP4LkOnd9NpUsxOjMx1SnoUVB7Orb7fZp67cQMtTBKMFDvOGg==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/service-error-classification": "^4.0.6",
-				"@smithy/types": "^4.3.1",
+				"@smithy/service-error-classification": "^4.2.3",
+				"@smithy/types": "^4.8.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
 				"node": ">=18.0.0"
 			}
-		},
-		"node_modules/@smithy/util-retry/node_modules/tslib": {
-			"version": "2.8.1",
-			"license": "0BSD"
 		},
 		"node_modules/@smithy/util-stream": {
-			"version": "4.2.2",
+			"version": "4.5.4",
+			"resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.4.tgz",
+			"integrity": "sha512-+qDxSkiErejw1BAIXUFBSfM5xh3arbz1MmxlbMCKanDDZtVEQ7PSKW9FQS0Vud1eI/kYn0oCTVKyNzRlq+9MUw==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/fetch-http-handler": "^5.0.4",
-				"@smithy/node-http-handler": "^4.0.6",
-				"@smithy/types": "^4.3.1",
-				"@smithy/util-base64": "^4.0.0",
-				"@smithy/util-buffer-from": "^4.0.0",
-				"@smithy/util-hex-encoding": "^4.0.0",
-				"@smithy/util-utf8": "^4.0.0",
+				"@smithy/fetch-http-handler": "^5.3.4",
+				"@smithy/node-http-handler": "^4.4.3",
+				"@smithy/types": "^4.8.0",
+				"@smithy/util-base64": "^4.3.0",
+				"@smithy/util-buffer-from": "^4.2.0",
+				"@smithy/util-hex-encoding": "^4.2.0",
+				"@smithy/util-utf8": "^4.2.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
 				"node": ">=18.0.0"
 			}
-		},
-		"node_modules/@smithy/util-stream/node_modules/tslib": {
-			"version": "2.8.1",
-			"license": "0BSD"
 		},
 		"node_modules/@smithy/util-uri-escape": {
-			"version": "4.0.0",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.0.tgz",
+			"integrity": "sha512-igZpCKV9+E/Mzrpq6YacdTQ0qTiLm85gD6N/IrmyDvQFA4UnU3d5g3m8tMT/6zG/vVkWSU+VxeUyGonL62DuxA==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^2.6.2"
@@ -6482,25 +6196,31 @@
 			"engines": {
 				"node": ">=18.0.0"
 			}
-		},
-		"node_modules/@smithy/util-uri-escape/node_modules/tslib": {
-			"version": "2.8.1",
-			"license": "0BSD"
 		},
 		"node_modules/@smithy/util-utf8": {
-			"version": "4.0.0",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.0.tgz",
+			"integrity": "sha512-zBPfuzoI8xyBtR2P6WQj63Rz8i3AmfAaJLuNG8dWsfvPe8lO4aCPYLn879mEgHndZH1zQ2oXmG8O1GGzzaoZiw==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/util-buffer-from": "^4.0.0",
+				"@smithy/util-buffer-from": "^4.2.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
 				"node": ">=18.0.0"
 			}
 		},
-		"node_modules/@smithy/util-utf8/node_modules/tslib": {
-			"version": "2.8.1",
-			"license": "0BSD"
+		"node_modules/@smithy/uuid": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@smithy/uuid/-/uuid-1.1.0.tgz",
+			"integrity": "sha512-4aUIteuyxtBUhVdiQqcDhKFitwfd9hqoSDYY2KRXiWtgoWJ9Bmise+KfEPDiVHWeJepvF8xJO9/9+WDIciMFFw==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
 		},
 		"node_modules/@streamparser/json": {
 			"version": "0.0.22",
@@ -7156,11 +6876,6 @@
 			"engines": {
 				"node": ">=18.0.0"
 			}
-		},
-		"node_modules/@typespec/ts-http-runtime/node_modules/tslib": {
-			"version": "2.8.1",
-			"dev": true,
-			"license": "0BSD"
 		},
 		"node_modules/@vscode/codicons": {
 			"version": "0.0.36",
@@ -8014,10 +7729,6 @@
 				"node": ">=4"
 			}
 		},
-		"node_modules/ast-types/node_modules/tslib": {
-			"version": "2.7.0",
-			"license": "0BSD"
-		},
 		"node_modules/astral-regex": {
 			"version": "2.0.0",
 			"dev": true,
@@ -8326,7 +8037,9 @@
 			"license": "BSD-2-Clause"
 		},
 		"node_modules/bowser": {
-			"version": "2.11.0",
+			"version": "2.12.1",
+			"resolved": "https://registry.npmjs.org/bowser/-/bowser-2.12.1.tgz",
+			"integrity": "sha512-z4rE2Gxh7tvshQ4hluIT7XcFrgLIQaw9X3A+kTTRdovCz5PMukm/0QC/BKSYPj3omF5Qfypn9O/c5kgpmvYUCw==",
 			"license": "MIT"
 		},
 		"node_modules/brace-expansion": {
@@ -10567,20 +10280,18 @@
 			"license": "BSD-3-Clause"
 		},
 		"node_modules/fast-xml-parser": {
-			"version": "4.4.1",
+			"version": "5.2.5",
+			"resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.2.5.tgz",
+			"integrity": "sha512-pfX9uG9Ki0yekDHx2SiuRIyFdyAr1kMIMitPvb0YBo8SUfKvia7w7FIyd/l6av85pFYRhZscS75MwMnbvY+hcQ==",
 			"funding": [
 				{
 					"type": "github",
 					"url": "https://github.com/sponsors/NaturalIntelligence"
-				},
-				{
-					"type": "paypal",
-					"url": "https://paypal.me/naturalintelligence"
 				}
 			],
 			"license": "MIT",
 			"dependencies": {
-				"strnum": "^1.0.5"
+				"strnum": "^2.1.0"
 			},
 			"bin": {
 				"fxparser": "src/cli/cli.js"
@@ -17466,7 +17177,15 @@
 			}
 		},
 		"node_modules/strnum": {
-			"version": "1.0.5",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.1.tgz",
+			"integrity": "sha512-7ZvoFTiCnGxBtDqJ//Cu6fWtZtc7Y3x+QOirG15wztbdngGSkht27o2pyGWrVy0b4WAy3jbKmnoK6g5VlVNUUw==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				}
+			],
 			"license": "MIT"
 		},
 		"node_modules/structured-source": {
@@ -17962,6 +17681,12 @@
 			"engines": {
 				"node": ">=6"
 			}
+		},
+		"node_modules/tslib": {
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+			"license": "0BSD"
 		},
 		"node_modules/tunnel": {
 			"version": "0.0.6",

--- a/package.json
+++ b/package.json
@@ -405,8 +405,8 @@
 	"dependencies": {
 		"@anthropic-ai/sdk": "^0.37.0",
 		"@anthropic-ai/vertex-sdk": "^0.6.4",
-		"@aws-sdk/client-bedrock-runtime": "^3.840.0",
-		"@aws-sdk/credential-providers": "^3.840.0",
+		"@aws-sdk/client-bedrock-runtime": "^3.919.0",
+		"@aws-sdk/credential-providers": "^3.919.0",
 		"@bufbuild/protobuf": "^2.2.5",
 		"@cerebras/cerebras_cloud_sdk": "^1.35.0",
 		"@google-cloud/vertexai": "^1.9.3",


### PR DESCRIPTION
Call the bedrock CountTokens API and invoke the standard anthropic model if 1M tokens of context is unnecessary

### Description

<!-- 
Help reviewers understand your changes by making this PR readable and well-organized:

- What problem does this PR solve?
- Why were these changes introduced and what purpose do they serve?
- For larger changes, provide context about your approach and reasoning

Small PRs may need minimal description, but larger changes benefit from explaining where you're coming from. Much of this context can be in the linked issue above, so feel free to reference it rather than repeating everything here.
-->

When using a Claude Sonnet 1M model on bedrock with less than 200k context, the 1M context window is not necessary. Since Bedrock capacity for the 1M model is separate from the standard one, it takes away capacity from the requests that actually do need the 1M model.

This change calls the [CountTokens Bedrock API](https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_CountTokens.html) before making a request. If the input token count is less than 200k, it will call the model with the standard context window.

The CountTokens API is relatively new, [released in August](https://aws.amazon.com/about-aws/whats-new/2025/08/count-tokens-api-anthropics-claude-models-bedrock/). I needed to bump the AWS SDK version to [at least 3.872.0](https://github.com/aws/aws-sdk-js-v3/releases/tag/v3.872.0) get access to it.

I considered using the existing token estimate, but the CountTokens API seems more bulletproof. In my testing, it didn't add any meaningful latency.

### Test Procedure

Ask Cline to generate a 1mb file, and then read it repeatedly. Observing the debug logs, it disabled the 1M context until crossing the 200k boundary.

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

<img width="1136" height="961" alt="Screenshot 2025-10-29 at 4 12 02 PM" src="https://github.com/user-attachments/assets/e9215ad7-33a0-4234-88f2-8699e529454c" />


### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Optimize Anthropic model usage on AWS Bedrock by checking token count with CountTokens API and selecting appropriate model.
> 
>   - **Behavior**:
>     - Calls `CountTokensCommand` in `bedrock.ts` to determine token count before invoking models.
>     - Uses standard model if token count is below 200k, otherwise uses 1M model.
>   - **Dependencies**:
>     - Updates `@aws-sdk/client-bedrock-runtime` and `@aws-sdk/credential-providers` to `^3.919.0` in `package.json`.
>   - **Functions**:
>     - Adds `getInputTokens()` and `shouldEnable1mContextWindow()` in `bedrock.ts` to manage model selection logic.
>     - Introduces `strip1MSuffix()` in `bedrock.ts` to handle model ID formatting.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 03fe806eb0bb046f2ed569b006fac81e07d3bb5a. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->