### PR TITLE
fix: ensure hasThinkingBudget validates non-empty thinkingConfig object

### DIFF
--- a/.changeset/ripe-rats-nail.md
+++ b/.changeset/ripe-rats-nail.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Fix: show reasoning budget slider to models with valid thinking config

--- a/src/core/controller/models/refreshOpenRouterModels.ts
+++ b/src/core/controller/models/refreshOpenRouterModels.ts
@@ -1,11 +1,11 @@
 import { ensureCacheDirectoryExists, GlobalFileNames } from "@core/storage/disk"
-import { ModelInfo } from "@shared/api"
+import type { ModelInfo } from "@shared/api"
 import axios from "axios"
 import cloneDeep from "clone-deep"
 import fs from "fs/promises"
 import path from "path"
 import { CLAUDE_SONNET_1M_TIERS, openRouterClaudeSonnet41mModelId, openRouterClaudeSonnet451mModelId } from "@/shared/api"
-import { Controller } from ".."
+import type { Controller } from ".."
 
 type OpenRouterSupportedParams =
 	| "frequency_penalty"
@@ -59,7 +59,7 @@ interface OpenRouterRawModelInfo {
 		input_cache_read: string
 		input_cache_write: string
 	} | null
-	thinking_config: any | null
+	thinking_config: Record<string, unknown> | null
 	supports_global_endpoint: boolean | null
 	tiers: any[] | null
 	supported_parameters?: OpenRouterSupportedParams[] | null
@@ -97,7 +97,7 @@ export async function refreshOpenRouterModels(controller: Controller): Promise<R
 					cacheWritesPrice: parsePrice(rawModel.pricing?.input_cache_write),
 					cacheReadsPrice: parsePrice(rawModel.pricing?.input_cache_read),
 					description: rawModel.description ?? "",
-					thinkingConfig: supportThinking ? (rawModel.thinking_config ?? {}) : undefined,
+					thinkingConfig: (supportThinking && rawModel.thinking_config) || undefined,
 					supportsGlobalEndpoint: rawModel.supports_global_endpoint ?? undefined,
 					tiers: rawModel.tiers ?? undefined,
 				}

--- a/webview-ui/src/components/settings/utils/pricingUtils.ts
+++ b/webview-ui/src/components/settings/utils/pricingUtils.ts
@@ -1,4 +1,4 @@
-import { ModelInfo } from "@shared/api"
+import type { ModelInfo } from "@shared/api"
 
 /**
  * Formats a price as a currency string
@@ -24,7 +24,7 @@ export const formatTokenPrice = (price: number) => {
  * Helper function to determine if a model supports thinking budget
  */
 export const hasThinkingBudget = (modelInfo: ModelInfo): boolean => {
-	return !!modelInfo.thinkingConfig
+	return !!modelInfo.thinkingConfig && Object.keys(modelInfo.thinkingConfig).length > 0
 }
 
 /**


### PR DESCRIPTION
<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- For feature requests: Created a discussion in our Feature Requests discussions board https://github.com/cline/cline/discussions/categories/feature-requests and received approval from core maintainers before implementation
- For all changes: Link the associated issue/discussion in the "Related Issue" section below

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly without prior discussion.

Why this requirement?
We deeply appreciate all community contributions - they are essential to Cline's success! To ensure the best use of everyone's time and maintain project direction, we use our Feature Requests discussions board to gauge community interest and validate feature ideas before implementation begins. This helps us focus development efforts on features that will benefit the most users.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** #XXXX

### Description

<!-- 
Help reviewers understand your changes by making this PR readable and well-organized:

- What problem does this PR solve?
- Why were these changes introduced and what purpose do they serve?
- For larger changes, provide context about your approach and reasoning

Small PRs may need minimal description, but larger changes benefit from explaining where you're coming from. Much of this context can be in the linked issue above, so feel free to reference it rather than repeating everything here.
-->

Previously, hasThinkingBudget would return true for empty objects ({}), causing incorrect behavior. Now checks both for truthiness and that the object contains at least one key.

Also updates thinkingConfig assignment logic to avoid setting empty objects and converts imports to type-only imports for better tree-shaking.

### Test Procedure

<!-- 
Please walk us through your testing approach and thought process. This helps reviewers understand that you've thoroughly considered the impact of your changes:

- How did you test this change?
- What could potentially break and how did you verify it doesn't?
- What existing functionality might be affected and how did you check it still works?
- Why are you confident this is ready for merge?

We're not looking for exhaustive documentation - just evidence that you've thought through the implications of your changes and tested accordingly.
-->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

Before:

<img width="426" height="637" alt="image" src="https://github.com/user-attachments/assets/36d4c75d-4d4f-4347-99a4-12d0688da3b1" />

<img width="426" height="719" alt="image" src="https://github.com/user-attachments/assets/942e9eab-5300-46c4-bf98-3007bf8145eb" />

After

<img width="504" height="598" alt="image" src="https://github.com/user-attachments/assets/5e34ec94-c3b9-4bf3-b080-0c4f36a35899" />

<img width="511" height="642" alt="image" src="https://github.com/user-attachments/assets/cabb4616-1b52-469a-8557-fad0eb654338" />


### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes `hasThinkingBudget` to validate non-empty `thinkingConfig` and optimizes `thinkingConfig` assignment and imports.
> 
>   - **Behavior**:
>     - Fixes `hasThinkingBudget` in `pricingUtils.ts` to validate non-empty `thinkingConfig` objects.
>     - Updates `thinkingConfig` assignment in `refreshOpenRouterModels.ts` to avoid setting empty objects.
>   - **Imports**:
>     - Converts imports to type-only in `refreshOpenRouterModels.ts` and `pricingUtils.ts` for better tree-shaking.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for e7b917bd01d6a772ef5c8c69f29a55acc859f61e. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->