### PR TITLE
Add global rules and workflows to the remote config schema

### DIFF
--- a/src/shared/remote-config/__tests__/schema.test.ts
+++ b/src/shared/remote-config/__tests__/schema.test.ts
@@ -330,6 +330,25 @@ describe("Remote Config Schema", () => {
 				openTelemetryLogBatchSize: 512,
 				openTelemetryLogBatchTimeout: 5000,
 				openTelemetryLogMaxQueueSize: 2048,
+				globalRules: [
+					{
+						alwaysEnabled: true,
+						name: "company-standards.md",
+						contents: "# Company Standards\n\nAll code must follow these standards...",
+					},
+					{
+						alwaysEnabled: false,
+						name: "optional-guidelines.md",
+						contents: "# Optional Guidelines\n\nConsider these best practices...",
+					},
+				],
+				globalWorkflows: [
+					{
+						alwaysEnabled: true,
+						name: "deployment-workflow.md",
+						contents: "# Deployment Workflow\n\n1. Run tests\n2. Build\n3. Deploy",
+					},
+				],
 				providerSettings: {
 					OpenAiCompatible: {
 						models: [
@@ -433,6 +452,19 @@ describe("Remote Config Schema", () => {
 			expect(result.openTelemetryLogBatchSize).to.equal(512)
 			expect(result.openTelemetryLogBatchTimeout).to.equal(5000)
 			expect(result.openTelemetryLogMaxQueueSize).to.equal(2048)
+
+			// Verify Global Instructions settings
+			expect(result.globalRules).to.have.lengthOf(2)
+			expect(result.globalRules?.[0].alwaysEnabled).to.equal(true)
+			expect(result.globalRules?.[0].name).to.equal("company-standards.md")
+			expect(result.globalRules?.[0].contents).to.include("Company Standards")
+			expect(result.globalRules?.[1].alwaysEnabled).to.equal(false)
+			expect(result.globalRules?.[1].name).to.equal("optional-guidelines.md")
+
+			expect(result.globalWorkflows).to.have.lengthOf(1)
+			expect(result.globalWorkflows?.[0].alwaysEnabled).to.equal(true)
+			expect(result.globalWorkflows?.[0].name).to.equal("deployment-workflow.md")
+			expect(result.globalWorkflows?.[0].contents).to.include("Deployment Workflow")
 		})
 	})
 

--- a/src/shared/remote-config/schema.ts
+++ b/src/shared/remote-config/schema.ts
@@ -86,10 +86,23 @@ export const AllowedMCPServerSchema = z.object({
 	id: z.string(),
 })
 
+// Settings for a global cline rules or workflow file.
+export const GlobalInstructionsFileSchema = z.object({
+	// When this is enabled, the user cannot turn off this rule or workflow.
+	alwaysEnabled: z.boolean(),
+	// The name of the rules or workflow file.
+	name: z.string(),
+	// The contents of the rules or workflow file
+	contents: z.string(),
+})
+
 export const RemoteConfigSchema = z.object({
 	// The version of the remote config settings, e.g. v1
 	// This field is for internal use only, and won't be visible to the administrator in the UI.
 	version: z.string(),
+
+	// Provider specific settings
+	providerSettings: ProviderSettingsSchema.optional(),
 
 	// General settings not specific to any provider
 	telemetryEnabled: z.boolean().optional(),
@@ -119,11 +132,9 @@ export const RemoteConfigSchema = z.object({
 	openTelemetryLogBatchTimeout: z.number().optional(),
 	openTelemetryLogMaxQueueSize: z.number().optional(),
 
-	// Other top-level settings can be added here later.
-
-	// Provider specific settings
-	// Each provider in providerSchemasMap is automatically available as an optional field
-	providerSettings: ProviderSettingsSchema.optional(),
+	// Rules & Workflows
+	globalRules: z.array(GlobalInstructionsFileSchema).optional(),
+	globalWorkflows: z.array(GlobalInstructionsFileSchema).optional(),
 })
 
 // Type inference from schemas
@@ -135,3 +146,4 @@ export type AwsBedrockCustomModel = z.infer<typeof AwsBedrockCustomModelSchema>
 export type AwsBedrockSettings = z.infer<typeof AwsBedrockSettingsSchema>
 export type ProviderSettings = z.infer<typeof ProviderSettingsSchema>
 export type RemoteConfig = z.infer<typeof RemoteConfigSchema>
+export type GlobalInstructionsFile = z.infer<typeof GlobalInstructionsFileSchema>


### PR DESCRIPTION
Add a way for the admin to configure global cline rules and workflows for their users.

fixes PF-202
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `globalRules` and `globalWorkflows` to `RemoteConfigSchema` for admin configuration of user rules and workflows.
> 
>   - **Schema Changes**:
>     - Add `globalRules` and `globalWorkflows` to `RemoteConfigSchema` in `schema.ts`.
>     - Define `GlobalInstructionsFileSchema` for rules and workflows.
>   - **Tests**:
>     - Update `schema.test.ts` to test `globalRules` and `globalWorkflows` in `RemoteConfigSchema`.
>     - Ensure tests cover cases with `alwaysEnabled`, `name`, and `contents` fields.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for c5e4b12a656799e8efdf45c5197058dc5b55bcf1. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->