### PR TITLE
cli polish ahead of release - disable doctor, better node errors, log sorting, change update cache file path

### DIFF
--- a/cli/cmd/cline/main.go
+++ b/cli/cmd/cline/main.go
@@ -182,7 +182,7 @@ see the manual page: man cline`,
 	rootCmd.AddCommand(cli.NewVersionCommand())
 	rootCmd.AddCommand(cli.NewAuthCommand())
 	rootCmd.AddCommand(cli.NewLogsCommand())
-	rootCmd.AddCommand(cli.NewDoctorCommand())
+	// rootCmd.AddCommand(cli.NewDoctorCommand()) // Disabled for now
 
 	if err := rootCmd.ExecuteContext(context.Background()); err != nil {
 		os.Exit(1)

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,68 +1,62 @@
 {
-	"name": "cline",
-	"version": "1.0.0-nightly.18",
-	"description": "Autonomous coding agent CLI - capable of creating/editing files, running commands, using the browser, and more",
-	"main": "cline-core.js",
-	"bin": {
-		"cline": "./bin/cline",
-		"cline-host": "./bin/cline-host"
-	},
-	"man": "./man/cline.1",
-	"scripts": {
-		"postinstall": "node postinstall.js"
-	},
-	"bundleDependencies": [
-		"@grpc/grpc-js",
-		"@grpc/reflection",
-		"better-sqlite3",
-		"grpc-health-check",
-		"open",
-		"vscode-uri"
-	],
-	"engines": {
-		"node": ">=18.0.0"
-	},
-	"keywords": [
-		"cline",
-		"claude",
-		"dev",
-		"mcp",
-		"openrouter",
-		"coding",
-		"agent",
-		"autonomous",
-		"chatgpt",
-		"sonnet",
-		"ai",
-		"llama",
-		"cli"
-	],
-	"author": {
-		"name": "Cline Bot Inc."
-	},
-	"license": "Apache-2.0",
-	"repository": {
-		"type": "git",
-		"url": "https://github.com/cline/cline"
-	},
-	"homepage": "https://cline.bot",
-	"bugs": {
-		"url": "https://github.com/cline/cline/issues"
-	},
-	"dependencies": {
-		"@grpc/grpc-js": "^1.13.3",
-		"@grpc/reflection": "^1.0.4",
-		"better-sqlite3": "^12.2.0",
-		"grpc-health-check": "^2.0.2",
-		"open": "^10.1.2",
-		"vscode-uri": "^3.1.0"
-	},
-	"os": [
-		"darwin",
-		"linux"
-	],
-	"cpu": [
-		"x64",
-		"arm64"
-	]
+    "name": "cline",
+    "version": "1.0.3",
+    "description": "Autonomous coding agent CLI - capable of creating/editing files, running commands, using the browser, and more",
+    "main": "cline-core.js",
+    "bin": {
+        "cline": "./bin/cline",
+        "cline-host": "./bin/cline-host"
+    },
+    "man": "./man/cline.1",
+    "scripts": {
+        "postinstall": "node postinstall.js"
+    },
+    "bundleDependencies": [
+        "@grpc/grpc-js",
+        "@grpc/reflection",
+        "better-sqlite3",
+        "grpc-health-check",
+        "open",
+        "vscode-uri"
+    ],
+    "engines": {
+        "node": ">=20.0.0"
+    },
+    "keywords": [
+        "cline",
+        "claude",
+        "dev",
+        "mcp",
+        "openrouter",
+        "coding",
+        "agent",
+        "autonomous",
+        "chatgpt",
+        "sonnet",
+        "ai",
+        "llama",
+        "cli"
+    ],
+    "author": {
+        "name": "Cline Bot Inc."
+    },
+    "license": "Apache-2.0",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/cline/cline"
+    },
+    "homepage": "https://cline.bot",
+    "bugs": {
+        "url": "https://github.com/cline/cline/issues"
+    },
+    "dependencies": {
+        "@grpc/grpc-js": "^1.13.3",
+        "@grpc/reflection": "^1.0.4",
+        "better-sqlite3": "^12.2.0",
+        "grpc-health-check": "^2.0.2",
+        "open": "^10.1.2",
+        "vscode-uri": "^3.1.0"
+    },
+    "os": ["darwin", "linux"],
+    "cpu": ["x64", "arm64"]
 }

--- a/cli/pkg/cli/logs.go
+++ b/cli/pkg/cli/logs.go
@@ -208,9 +208,9 @@ func listLogFiles(logsDir string) ([]logFileInfo, error) {
 		})
 	}
 
-	// Sort by created time (newest first)
+	// Sort by created time (oldest first)
 	sort.Slice(logs, func(i, j int) bool {
-		return logs[i].created.After(logs[j].created)
+		return logs[i].created.Before(logs[j].created)
 	})
 
 	return logs, nil

--- a/cli/pkg/cli/updater/updater.go
+++ b/cli/pkg/cli/updater/updater.go
@@ -375,7 +375,7 @@ func showFailureMessage(channel string) {
 
 func getCacheFilePath() string {
 	configDir := filepath.Join(os.Getenv("HOME"), ".cline", "data")
-	return filepath.Join(configDir, ".update-cache")
+	return filepath.Join(configDir, "cli-update-cache")
 }
 
 func loadCache() (cacheData, error) {


### PR DESCRIPTION
- Disabled the `doctor` command since it's not as complete and understandable / documented as I would like
- Renamed the auto-update cache file from ~/.cline/data/.update-cache to ~/.cline/data/cli-update-cache
- Changed sorting order of `cline log list` so that most recent logs are at the end of the output rather than the top
- Output more helpful error message for the most common issue failing to launch cline when the node version is incorrect:

<img width="870" height="512" alt="Screenshot 2025-10-31 at 1 55 51 PM" src="https://github.com/user-attachments/assets/876792f5-e28c-4822-aae6-9058cc96d520" />

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Disable `doctor` command, improve error messages, change log sorting, and update file paths in CLI tool.
> 
>   - **Behavior**:
>     - Disable `doctor` command in `main.go` as it is incomplete.
>     - Update error message in `RetryOperation()` in `utils.go` to include Node.js version check and debugging steps.
>   - **File Paths**:
>     - Rename update cache file path from `~/.cline/data/.update-cache` to `~/.cline/data/cli-update-cache` in `updater.go`.
>   - **Sorting**:
>     - Change log sorting in `listLogFiles()` in `logs.go` to display oldest logs first.
>   - **Node Version**:
>     - Update Node.js version requirement to `>=20.0.0` in `package.json`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for c112a237ccf801446a97362b9c6cc81806739e9a. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->