### PR TITLE
Remove orphaned tool_results after truncation

### DIFF
--- a/.changeset/hot-ants-fry.md
+++ b/.changeset/hot-ants-fry.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Remove orphaned tool_results after truncation


### PR DESCRIPTION
<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- For feature requests: Created a discussion in our Feature Requests discussions board https://github.com/cline/cline/discussions/categories/feature-requests and received approval from core maintainers before implementation
- For all changes: Link the associated issue/discussion in the "Related Issue" section below

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly without prior discussion.

Why this requirement?
We deeply appreciate all community contributions - they are essential to Cline's success! To ensure the best use of everyone's time and maintain project direction, we use our Feature Requests discussions board to gauge community interest and validate feature ideas before implementation begins. This helps us focus development efforts on features that will benefit the most users.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** #XXXX

### Description

This PR fixes an issue where orphaned tool_result blocks could appear in the conversation history after context truncation removes their corresponding tool_use blocks from assistant messages. When context truncation occurs, any tool_result blocks in the first user message after the truncated section are now automatically filtered out, preventing API contract violations. Additionally, the ensureToolResultsFollowToolUse method now skips (rather than preserves) any orphaned tool results that lack corresponding tool_use blocks, which can occur after truncation. These changes maintain conversation integrity while ensuring the first two messages (the original user-assistant pair) remain untouched as per the existing architecture.

Fixes an issue that could occur when using native tool calling:
```
{"message":"400 {\"type\":\"error\",\"error\":{\"type\":\"invalid_request_error\",\"message\":\"messages.2.content.1: unexpected `tool_use_id` found in `tool_result` blocks: toolu_XXXXXXXXXXXXXXX Each `tool_result` block must have a corresponding `tool_use` block in the previous message.\"},\"request_id\":\"req_YYYYYYYYYYYYYYYYY\"}","status":400,"request_id":"req_YYYYYYYYYYYYYYYYYY","modelId":"claude-sonnet-4-5-20250929","providerId":"anthropic","details":{"type":"error","error":{"type":"invalid_request_error","message":"messages.2.content.1: unexpected `tool_use_id` found in `tool_result` blocks: toolu_XXXXXXXXXXXXXXX. Each `tool_result` block must have a corresponding `tool_use` block in the previous message."},"request_id":"req_0YYYYYYYYYYYYYYYYY"}}
Request ID: req_YYYYYYYYYYYYYYYYY
```

> unexpected `tool_use_id` found in `tool_result` blocks: <block>. Each `tool_result` block must have a corresponding `tool_use` block in the previous message


### Test Procedure

Create a long running task using native tool calling until truncations begin. Ensure the error above does nor occur.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [X] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Removes orphaned `tool_result` blocks after context truncation in `ContextManager.ts` and updates tests.
> 
>   - **Behavior**:
>     - Removes orphaned `tool_result` blocks from the first user message after truncation in `ContextManager.ts`.
>     - Updates `ensureToolResultsFollowToolUse` to skip orphaned `tool_result` blocks.
>   - **Tests**:
>     - Adds test case in `ContextManager.test.ts` to verify removal of orphaned `tool_result` blocks after truncation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for b7488a52ba90b9a94b0afad9ce1d1dcd1848a73e. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->