### PR TITLE
Fix empty content field issue

### DIFF
--- a/.changeset/fine-baboons-sleep.md
+++ b/.changeset/fine-baboons-sleep.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Fix empty content field issue

--- a/src/core/api/transform/openai-format.ts
+++ b/src/core/api/transform/openai-format.ts
@@ -156,9 +156,14 @@ export function convertToOpenAiMessages(
 					},
 				}))
 
+				// Set content to blank when tool_calls are present but content has no text, per OpenAI API spec
+				const hasToolCalls = tool_calls.length > 0
+				const hasMeaningfulContent = content !== undefined && content.trim() !== ""
+				const finalContent = hasMeaningfulContent ? content : hasToolCalls ? null : undefined
+
 				openAiMessages.push({
 					role: "assistant",
-					content,
+					content: finalContent,
 					// Cannot be an empty array. API expects an array with minimum length 1, and will respond with an error if it's empty
 					tool_calls: tool_calls?.length > 0 ? tool_calls : undefined,
 					// @ts-ignore-next-line


### PR DESCRIPTION
<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- For feature requests: Created a discussion in our Feature Requests discussions board https://github.com/cline/cline/discussions/categories/feature-requests and received approval from core maintainers before implementation
- For all changes: Link the associated issue/discussion in the "Related Issue" section below

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly without prior discussion.

Why this requirement?
We deeply appreciate all community contributions - they are essential to Cline's success! To ensure the best use of everyone's time and maintain project direction, we use our Feature Requests discussions board to gauge community interest and validate feature ideas before implementation begins. This helps us focus development efforts on features that will benefit the most users.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** #XXXX

### Description

Prevents empty content blocks in tool calls, which violates the API specification and can cause task-breaking errors.

### Test Procedure

Create a task that uses a model that supports native tool calling, and run the task for an extended period of time.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [X] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [ ] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes empty content field issue in `convertToOpenAiMessages()` by setting `content` to `null` when `tool_calls` are present but `content` is empty.
> 
>   - **Behavior**:
>     - Fixes empty content field issue in `convertToOpenAiMessages()` in `openai-format.ts`.
>     - Sets `content` to `null` when `tool_calls` are present but `content` is empty, per OpenAI API spec.
>   - **Misc**:
>     - Adds changeset `fine-baboons-sleep.md` for patch update.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for c3c8346392b55ceda581dd3137b8ed221b10bbcb. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->