### PR TITLE
flaky test - api request display race condition

### DIFF
--- a/webview-ui/src/components/chat/ErrorBlockTitle.tsx
+++ b/webview-ui/src/components/chat/ErrorBlockTitle.tsx
@@ -62,8 +62,7 @@ export const ErrorBlockTitle = ({
 			details.title = titleText
 			details.classNames.push("font-bold text-(--vscode-errorForeground)")
 		} else if (retryStatus) {
-			// Handle retry state
-			details.title = "API Request"
+			// Handle retry state - keep default "API Request..." title but add styling
 			details.classNames.push("text-(--vscode-foreground)")
 		}
 


### PR DESCRIPTION


### Description

Fixed failing E2E tests that were looking for "API Request..." text during API request loading state. The `ErrorBlockTitle` component was incorrectly removing the ellipsis when `retryStatus` was present, changing the title to "API Request" instead of keeping "API Request...".

The fix ensures the default loading state title "API Request..." is preserved when retry status is present, only adding the styling class without modifying the title text.

### Test Procedure

- Ran full E2E test suite: `npm run test:e2e`
- All 7 tests now pass, including the previously failing diff.test.ts tests
- Verified the "API Request..." text is visible during loading/retry states
- Confirmed existing functionality remains intact (completed requests still show "API Request" without ellipsis)

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes `ErrorBlockTitle` to preserve 'API Request...' during retry states by adding styling without altering text.
> 
>   - **Behavior**:
>     - Fixes `ErrorBlockTitle` component to preserve 'API Request...' during retry states by only adding styling class.
>   - **Tests**:
>     - All 7 E2E tests pass, including previously failing `diff.test.ts` tests.
>     - Verified 'API Request...' text visibility during loading/retry states.
>     - Confirmed no regression in completed request titles.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for edf762c54e941e4bf4392b521e7332f028faa39e. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->