### PR TITLE
🪝Hooks: Remove console debug logging

### DIFF
--- a/src/core/task/ToolExecutor.ts
+++ b/src/core/task/ToolExecutor.ts
@@ -459,7 +459,6 @@ export class ToolExecutor {
 
 		const executionTimeMs = Date.now() - executionStartTime
 
-		console.log(`[HOOK-UI] PostToolUse executing for tool: ${block.name}`)
 		const postToolResult = await executeHook({
 			hookName: "PostToolUse",
 			hookInput: {
@@ -595,7 +594,6 @@ export class ToolExecutor {
 				pendingToolInfo.resourceUri = block.params.uri
 			}
 
-			console.log(`[HOOK-UI] PreToolUse executing for tool: ${block.name}`)
 			const preToolResult = await executeHook({
 				hookName: "PreToolUse",
 				hookInput: {

--- a/webview-ui/src/components/chat/HookMessage.tsx
+++ b/webview-ui/src/components/chat/HookMessage.tsx
@@ -81,11 +81,6 @@ interface HookMetadata {
  * - Running hooks: Always shows pending tool info
  */
 const HookMessage = memo(({ message, CommandOutput }: HookMessageProps) => {
-	// Log when component mounts/updates
-	console.log(
-		`[HOOK-UI RENDER] HookMessage rendering: ${JSON.stringify({ hookName: message.text?.substring(0, 100), ts: message.ts })}`,
-	)
-
 	// Parse hook metadata and output
 	const { metadata, output } = useMemo(() => {
 		const splitMessage = (text: string) => {
@@ -228,9 +223,6 @@ const HookMessage = memo(({ message, CommandOutput }: HookMessageProps) => {
 						<button
 							onClick={(e) => {
 								e.stopPropagation()
-								console.log(
-									`[HOOK-UI CANCEL] Hook cancel button clicked for ${metadata.hookName}${metadata.toolName ? ` (${metadata.toolName})` : ""}`,
-								)
 								// Cancel the task - cancelling a hook always cancels the entire task
 								TaskServiceClient.cancelTask(EmptyRequest.create({})).catch((err) =>
 									console.error("Failed to cancel task:", err),


### PR DESCRIPTION

### Related Issue

**Issue:** n/a

### Description

This PR removes unneeded debug logging that (prior to this PR) is being outputted to the developer tool console when hooks are enabled.  This cleans that up to make the console logs less noisy when hooks are enabled.


### Test Procedure

Verified the change by watching the developer tools console output.

Before: Lots of `HOOK-UI`-related entries.
After: Zero `HOOK-UI`-related entries.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

n/a

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Removes unnecessary console debug logging related to hooks in `ToolExecutor.ts` and `HookMessage.tsx` to reduce console noise.
> 
>   - **Behavior**:
>     - Removes console debug logs related to `PreToolUse` and `PostToolUse` hooks in `ToolExecutor.ts`.
>     - Removes console debug logs for rendering and cancel actions in `HookMessage.tsx`.
>   - **Misc**:
>     - Reduces noise in developer console when hooks are enabled.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 04ac953eda3f2ecb5acf4541258131afb3900165. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->