### PR TITLE
🪝Hooks: Trim characters around JSON in hook output

### DIFF
--- a/src/core/hooks/hook-factory.ts
+++ b/src/core/hooks/hook-factory.ts
@@ -318,7 +318,7 @@ class StdioHookRunner<Name extends HookName> extends HookRunner<Name> {
 
 					// Scan from the end to find the last complete JSON object
 					for (let i = lines.length - 1; i >= 0; i--) {
-						const line = lines[i]
+						const line = lines[i].trimEnd()
 
 						// Count braces to track JSON object boundaries
 						for (let j = line.length - 1; j >= 0; j--) {
@@ -344,7 +344,13 @@ class StdioHookRunner<Name extends HookName> extends HookRunner<Name> {
 
 					if (jsonCandidate.trim()) {
 						try {
-							const outputData = JSON.parse(jsonCandidate.trim())
+							// Trim everything before the first opening bracket
+							const trimmedCandidate = jsonCandidate.trim()
+							const firstBraceIndex = trimmedCandidate.indexOf("{")
+							const cleanedJson =
+								firstBraceIndex !== -1 ? trimmedCandidate.slice(firstBraceIndex) : trimmedCandidate
+
+							const outputData = JSON.parse(cleanedJson)
 
 							// Validate structure
 							const validation = validateHookOutput(outputData)


### PR DESCRIPTION
### Related Issue

**Issue:** n/a

### Description

Improve JSON parsing by removing characters around the JSON in the hook stdout output.

* Trim any character (whitespace or not) leading up to the opening bracket.
* Trim any whitespace character following the closing bracket.



### Test Procedure

See screenshot for example of this working.


### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Note the `TaskStart` JSON output at the top is preceded by non-whitespace text characters.  Also note (which you can't actually discern from the screenshot but I know because I manually added the whitespace characters) there are spaces after the closing bracket of that same JSON object.
<img width="613" height="701" alt="Screenshot 2025-11-05 at 3 48 23 PM" src="https://github.com/user-attachments/assets/937e65e9-aa70-4c70-9f12-fb02d39e5b05" />


### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Enhances JSON parsing in `StdioHookRunner` by trimming characters around JSON in hook output.
> 
>   - **Behavior**:
>     - In `StdioHookRunner`, `parseJsonOutput` now trims characters before the first opening bracket and whitespace after the closing bracket in JSON output.
>     - Handles cases where JSON is mixed with debug output by cleaning the JSON string before parsing.
>   - **Functions**:
>     - Modifies `parseJsonOutput` in `StdioHookRunner` to improve JSON extraction and parsing.
>   - **Misc**:
>     - No changes to existing tests or documentation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for af21a3bf8450d56eb1a4cce04c54e0d3f2320e40. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->