### PR TITLE
fix(models): ensure thinking config has default maxBudget value

### DIFF
--- a/src/core/controller/models/refreshOpenRouterModels.ts
+++ b/src/core/controller/models/refreshOpenRouterModels.ts
@@ -64,7 +64,6 @@ interface OpenRouterRawModelInfo {
 		input_cache_read: string
 		input_cache_write: string
 	} | null
-	thinking_config: Record<string, unknown> | null
 	supports_global_endpoint: boolean | null
 	tiers: any[] | null
 	supported_parameters?: OpenRouterSupportedParams[] | null
@@ -92,11 +91,6 @@ export async function refreshOpenRouterModels(controller: Controller): Promise<R
 			}
 			for (const rawModel of rawModels as OpenRouterRawModelInfo[]) {
 				const supportThinking = rawModel.supported_parameters?.some((p) => p === "include_reasoning" || p === "reasoning")
-				// If thinking is supported, ensure maxBudget is set. If not provided, set to default max for Anthropic model.
-				const thinkingBudget =
-					typeof rawModel.thinking_config?.maxBudget === "number"
-						? rawModel.thinking_config?.maxBudget
-						: ANTHROPIC_MAX_THINKING_BUDGET
 
 				const modelInfo: ModelInfo = {
 					maxTokens: rawModel.top_provider?.max_completion_tokens ?? 0,
@@ -108,7 +102,9 @@ export async function refreshOpenRouterModels(controller: Controller): Promise<R
 					cacheWritesPrice: parsePrice(rawModel.pricing?.input_cache_write),
 					cacheReadsPrice: parsePrice(rawModel.pricing?.input_cache_read),
 					description: rawModel.description ?? "",
-					thinkingConfig: supportThinking ? { ...rawModel.thinking_config, maxBudget: thinkingBudget } : undefined,
+					// If thinking is supported, set maxBudget with a default value as a placeholder
+					// to ensure it has a valid thinkingConfig that lets the application know thinking is supported.
+					thinkingConfig: supportThinking ? { maxBudget: ANTHROPIC_MAX_THINKING_BUDGET } : undefined,
 					supportsGlobalEndpoint: rawModel.supports_global_endpoint ?? undefined,
 					tiers: rawModel.tiers ?? undefined,
 				}


### PR DESCRIPTION
<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- For feature requests: Created a discussion in our Feature Requests discussions board https://github.com/cline/cline/discussions/categories/feature-requests and received approval from core maintainers before implementation
- For all changes: Link the associated issue/discussion in the "Related Issue" section below

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly without prior discussion.

Why this requirement?
We deeply appreciate all community contributions - they are essential to Cline's success! To ensure the best use of everyone's time and maintain project direction, we use our Feature Requests discussions board to gauge community interest and validate feature ideas before implementation begins. This helps us focus development efforts on features that will benefit the most users.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** #XXXX

### Description

<!-- 
Help reviewers understand your changes by making this PR readable and well-organized:

- What problem does this PR solve?
- Why were these changes introduced and what purpose do they serve?
- For larger changes, provide context about your approach and reasoning

Small PRs may need minimal description, but larger changes benefit from explaining where you're coming from. Much of this context can be in the linked issue above, so feel free to reference it rather than repeating everything here.
-->

- Add ANTHROPIC_MAX_THINKING_BUDGET import and use as fallback
- Check for both "include_reasoning" and "reasoning" parameters
- Set default maxBudget when thinking is supported but value not provided
- Ensures thinking models always have valid budget configuration

This prevents issues when OpenRouter API doesn't return thinking_config.maxBudget, ensuring all thinking-enabled models have a proper budget value set as it's used to determine if a model support thinking in some part of our code.

### Test Procedure

<!-- 
Please walk us through your testing approach and thought process. This helps reviewers understand that you've thoroughly considered the impact of your changes:

- How did you test this change?
- What could potentially break and how did you verify it doesn't?
- What existing functionality might be affected and how did you check it still works?
- Why are you confident this is ready for merge?

We're not looking for exhaustive documentation - just evidence that you've thought through the implications of your changes and tested accordingly.
-->

Verify you can see thinking budget slider for Claude 4.5 models and GPT-5 models or any models that support reasoning as listed on openrouter:

<img width="582" height="462" alt="image" src="https://github.com/user-attachments/assets/4b49167a-ddd6-4204-aaec-d72e460bb4bf" />

Verify you don't see the thinking budget slider for models that dont support thinking  (e.g. GPT-5 Chat)

<img width="577" height="519" alt="image" src="https://github.com/user-attachments/assets/da97cf3d-555f-4097-9ec0-06d8d7f35eba" />

#### Before

<img width="588" height="544" alt="image" src="https://github.com/user-attachments/assets/35ecfac1-cc04-4206-948e-461c3422512d" />

<img width="585" height="548" alt="image" src="https://github.com/user-attachments/assets/81e5f023-b8dd-414c-b451-f6b9ae7778ba" />

<img width="590" height="502" alt="image" src="https://github.com/user-attachments/assets/3dc3569d-7851-49f2-b87d-d494d646ab23" />



### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Set default `maxBudget` for thinking models in `refreshOpenRouterModels.ts` using `ANTHROPIC_MAX_THINKING_BUDGET` and check for `include_reasoning` and `reasoning` parameters.
> 
>   - **Behavior**:
>     - In `refreshOpenRouterModels.ts`, set default `maxBudget` using `ANTHROPIC_MAX_THINKING_BUDGET` for models supporting thinking but lacking `maxBudget`.
>     - Check for both `include_reasoning` and `reasoning` parameters to determine thinking support.
>   - **Imports**:
>     - Add `ANTHROPIC_MAX_THINKING_BUDGET` import from `@/shared/api`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for a766df2d805e3484601c80124837b5d0f6745e74. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->