### PR TITLE
Improve MCP Streamable HTTP error handling and session cleanup

### DIFF
--- a/src/services/mcp/McpHub.ts
+++ b/src/services/mcp/McpHub.ts
@@ -350,7 +350,6 @@ export class McpHub {
 								errorMessage.toLowerCase().includes("not found")
 
 							if (isSessionExpired) {
-								console.log(`Session expired for "${name}", reinitializing connection...`)
 								connection.server.status = "connecting"
 								await this.notifyWebviewOfServerChanges()
 
@@ -358,7 +357,6 @@ export class McpHub {
 								await this.deleteConnection(name)
 								try {
 									await this.connectToServer(name, config, source)
-									console.log(`Successfully reinitialized "${name}" after session expiry`)
 								} catch (reconnectError) {
 									console.error(`Failed to reinitialize "${name}":`, reconnectError)
 								}
@@ -573,7 +571,6 @@ export class McpHub {
 				if (connection.transport && "terminateSession" in connection.transport) {
 					try {
 						await (connection.transport as StreamableHTTPClientTransport).terminateSession()
-						console.log(`Session terminated for "${name}"`)
 					} catch (terminateError) {
 						// 405 Method Not Allowed is expected if server doesn't support session termination
 						// Other errors are logged but don't prevent cleanup

--- a/src/services/mcp/McpHub.ts
+++ b/src/services/mcp/McpHub.ts
@@ -342,9 +342,33 @@ export class McpHub {
 						console.error(`Transport error for "${name}":`, error)
 						const connection = this.findConnection(name, source)
 						if (connection) {
+							// Check if it's a StreamableHTTPError with status code 404 (session expired)
+							const errorMessage = error instanceof Error ? error.message : String(error)
+							const isSessionExpired =
+								(error.constructor.name === "StreamableHTTPError" && (error as any).code === 404) ||
+								errorMessage.includes("404") ||
+								errorMessage.toLowerCase().includes("not found")
+
+							if (isSessionExpired) {
+								console.log(`Session expired for "${name}", reinitializing connection...`)
+								connection.server.status = "connecting"
+								await this.notifyWebviewOfServerChanges()
+
+								// Reinitialize by closing and reconnecting
+								await this.deleteConnection(name)
+								try {
+									await this.connectToServer(name, config, source)
+									console.log(`Successfully reinitialized "${name}" after session expiry`)
+								} catch (reconnectError) {
+									console.error(`Failed to reinitialize "${name}":`, reconnectError)
+								}
+								return
+							}
+
+							// For all other errors, mark as disconnected
 							connection.server.status = "disconnected"
 							McpHub.mcpServerKeys.delete(connection.server.uid || name)
-							this.appendErrorMessage(connection, error instanceof Error ? error.message : `${error}`)
+							this.appendErrorMessage(connection, errorMessage)
 						}
 						await this.notifyWebviewOfServerChanges()
 					}
@@ -545,6 +569,21 @@ export class McpHub {
 		const connection = this.connections.find((conn) => conn.server.name === name)
 		if (connection) {
 			try {
+				// For StreamableHTTP transport, terminate the session gracefully
+				if (connection.transport && "terminateSession" in connection.transport) {
+					try {
+						await (connection.transport as StreamableHTTPClientTransport).terminateSession()
+						console.log(`Session terminated for "${name}"`)
+					} catch (terminateError) {
+						// 405 Method Not Allowed is expected if server doesn't support session termination
+						// Other errors are logged but don't prevent cleanup
+						const errorMsg = terminateError instanceof Error ? terminateError.message : String(terminateError)
+						if (!errorMsg.includes("405")) {
+							console.error(`Error terminating session for "${name}":`, terminateError)
+						}
+					}
+				}
+
 				// Only close transport and client if they exist (disabled servers don't have them)
 				if (connection.transport) {
 					await connection.transport.close()


### PR DESCRIPTION
### Description

This PR improves error handling and session management for MCP Streamable HTTP transport connections. While the basic Streamable HTTP functionality already works correctly (as validated by testing), these changes add defensive robustness for edge cases:

**Changes:**
1. **Automatic reconnection on session expiry**: Detects 404 errors (indicating expired sessions) and automatically reinitializes the connection without user intervention
2. **Graceful session termination**: Properly calls `terminateSession()` when disconnecting StreamableHTTP transports, allowing servers to clean up resources immediately
3. **Improved error detection**: Better handling of StreamableHTTPError types with specific status code checking

**What the SDK already handles:**
- Session ID capture and storage (automatic)
- Including session IDs in requests (automatic)
- Basic HTTP communication

**What these changes add:**
- Recovery from session expiry (404 errors)
- Clean shutdown with proper session termination
- Better error categorization for StreamableHTTP-specific errors

```"When a client receives HTTP 404 in response to a request containing an Mcp-Session-Id, it MUST start a new session by sending a new InitializeRequest without a session ID attached."```


```"Clients that no longer need a particular session (e.g., because the user is leaving the client application) SHOULD send an HTTP DELETE to the MCP endpoint with the Mcp-Session-Id header, to explicitly terminate the session."```

### Test Procedure

**Testing approach:**
1. Created a test MCP server using the SDK's example (Streamable HTTP transport)
2. Connected Cline to the test server
3. Verified tool execution works correctly (tested `add` tool with multiple calculations)
4. Verified resource access works correctly (tested `greeting` resource template)
5. Confirmed multiple requests maintain stable connection
6. Validated that basic functionality works without these changes (tested on production Cline)

**What could break:**
- Session expiry handling could interfere with legitimate 404 responses
  - Mitigation: Only triggers on specific error patterns (StreamableHTTPError with 404 code OR error message containing '404'/'not found')
- Session termination could cause issues with servers that don't support it
  - Mitigation: Wrapped in try-catch, handles 405 (Method Not Allowed) gracefully

### Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] ♻️ Refactor Changes
- [ ] 💅 Cosmetic Changes
- [ ] 📚 Documentation update
- [ ] 🏃 Workflow Changes

### Pre-flight Checklist

- [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
- [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
- [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
- [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

### Additional Notes

----

> [!IMPORTANT]
> Improves error handling and session management for MCP Streamable HTTP connections in `McpHub.ts` by adding automatic reconnection on session expiry and graceful session termination.
> 
>   - **Behavior**:
>     - Detects 404 errors in `StreamableHTTPClientTransport` and reinitializes connections in `McpHub.ts`.
>     - Calls `terminateSession()` for `StreamableHTTPClientTransport` in `deleteConnection()` in `McpHub.ts`.
>   - **Error Handling**:
>     - Checks for `StreamableHTTPError` with 404 status or error message containing '404'/'not found' in `connectToServer()` in `McpHub.ts`.
>     - Handles 405 errors gracefully during session termination in `deleteConnection()` in `McpHub.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for e71d2df5477408e17185858c10cc0f290d80eef1. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Enhances MCP Streamable HTTP error handling and session cleanup in `McpHub.ts` by adding automatic reconnection on session expiry and graceful session termination.
> 
>   - **Behavior**:
>     - Detects 404 errors in `StreamableHTTPClientTransport` and reinitializes connections in `McpHub.ts`.
>     - Calls `terminateSession()` for `StreamableHTTPClientTransport` in `deleteConnection()` in `McpHub.ts`.
>   - **Error Handling**:
>     - Checks for `StreamableHTTPError` with 404 status or error message containing '404'/'not found' in `connectToServer()` in `McpHub.ts`.
>     - Handles 405 errors gracefully during session termination in `deleteConnection()` in `McpHub.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for d420875f86b11691b8a0894307b8c2d6103ba1d2. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->