### PR TITLE
docs: add missing proto generation step in CONTRIBUTING.md

### DIFF
--- a/.changeset/fix-contributing-proto-step.md
+++ b/.changeset/fix-contributing-proto-step.md
@@ -1,0 +1,6 @@
+---
+"claude-dev": patch
+---
+
+Docs: Add missing proto generation step in CONTRIBUTING.md and new `npm run dev` script for easier terminal workflow (fixes #7335)
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,7 +46,11 @@ We also welcome contributions to our [documentation](https://github.com/cline/cl
     ```bash
     npm run install:all
     ```
-4. Launch by pressing `F5` (or `Run`->`Start Debugging`) to open a new VSCode window with the extension loaded. (You may need to install the [esbuild problem matchers extension](https://marketplace.visualstudio.com/items?itemName=connor4312.esbuild-problem-matchers) if you run into issues building the project.)
+4. Generate Protocol Buffer files (required before first build):
+    ```bash
+    npm run protos
+    ```
+5. Launch by pressing `F5` (or `Run`->`Start Debugging`) to open a new VSCode window with the extension loaded. (You may need to install the [esbuild problem matchers extension](https://marketplace.visualstudio.com/items?itemName=connor4312.esbuild-problem-matchers) if you run into issues building the project.)
 
 
 
@@ -85,8 +89,10 @@ We also welcome contributions to our [documentation](https://github.com/cline/cl
 
 2. **Local Development**
     - Run `npm run install:all` to install dependencies
+    - Run `npm run protos` to generate Protocol Buffer files (required before first build)
     - Run `npm run test` to run tests locally
     - Run → Start Debugging or `>Debug: Select and Start Debugging` and wait for a new VS Code instance to open
+    - **Terminal Workflow**: Use `npm run dev` (generates protos + runs watch mode) or `npm run watch` (if protos already generated)
     - Before submitting PR, run `npm run format:fix` to format your code
 
 3. **Linux-specific Setup**

--- a/package.json
+++ b/package.json
@@ -304,6 +304,7 @@
 		"dev:cli:watch": "node scripts/dev-cli-watch.mjs",
 		"postcompile-standalone": "node scripts/package-standalone.mjs",
 		"postcompile-standalone-npm": "node scripts/package-standalone.mjs --target=npm",
+		"dev": "npm run protos && npm run watch",
 		"watch": "npm-run-all -p watch:*",
 		"watch:esbuild": "node esbuild.mjs --watch",
 		"watch:tsc": "tsc --noEmit --watch --project tsconfig.json",


### PR DESCRIPTION
Fixes #7335

## Changes
- Added step 4 in Local Development Instructions to run `npm run protos`
- Added proto generation step in Extension section  
- Created new `npm run dev` script that runs protos + watch for easier terminal workflow
- Updated Terminal Workflow documentation to mention the new dev script

## Problem
New contributors following the setup docs encountered errors when running `npm run watch` because Protocol Buffer files weren't generated first.

## Solution
- Explicitly document the `npm run protos` step
- Add convenience script `npm run dev` that handles proto generation + watch mode automatically
- Makes setup clearer for contributors using terminal workflow vs F5 in VS Code

## Testing
- Verified `npm run dev` works on fresh clone
- Verified docs are clear and complete
- All linting checks pass
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add missing proto generation step in `CONTRIBUTING.md` and new `npm run dev` script for easier setup.
> 
>   - **Documentation**:
>     - Add step to run `npm run protos` in `CONTRIBUTING.md` under Local Development Instructions and Extension sections.
>     - Update Terminal Workflow documentation to include `npm run dev` script.
>   - **Scripts**:
>     - Add `npm run dev` script in `package.json` to run `protos` and `watch` for easier terminal workflow.
>   - **Problem**:
>     - New contributors faced errors with `npm run watch` due to missing Protocol Buffer files.
>   - **Solution**:
>     - Document `npm run protos` step and add `npm run dev` script for automatic proto generation and watch mode.
>   - **Testing**:
>     - Verified `npm run dev` works on fresh clone and documentation clarity.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for cc388d8a49f8e6dd6b34463789a51f2b5f504f5b. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->