### PR TITLE
Use staging endpoint for MCP marketplace (in staging)

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -62,7 +62,7 @@ class ClineEndpoint {
 					environment: Environment.staging,
 					appBaseUrl: "https://staging-app.cline.bot",
 					apiBaseUrl: "https://core-api.staging.int.cline.bot",
-					mcpBaseUrl: "https://api.cline.bot/v1/mcp",
+					mcpBaseUrl: "https://core-api.staging.int.cline.bot/v1/mcp",
 					firebase: {
 						apiKey: "AIzaSyASSwkwX1kSO8vddjZkE5N19QU9cVQ0CIk",
 						authDomain: "cline-staging.firebaseapp.com",


### PR DESCRIPTION
I have imported the MCP marketplace into the staging DB, so we do not need to use the prod endpoint.

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update `mcpBaseUrl` for staging environment in `ClineEndpoint` class in `config.ts`.
> 
>   - **Behavior**:
>     - Update `mcpBaseUrl` in `ClineEndpoint` class in `config.ts` for staging environment to `https://core-api.staging.int.cline.bot/v1/mcp`.
>   - **Misc**:
>     - No changes to production or local environment configurations.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 0bf311f2a29a9309f9ff580b15712e31ac3381c8. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->