### PR TITLE
🪝Hooks: `PreToolUse` should run only after approval logic

### DIFF
--- a/src/core/hooks/PreToolUseHookCancellationError.ts
+++ b/src/core/hooks/PreToolUseHookCancellationError.ts
@@ -1,0 +1,10 @@
+/**
+ * Error thrown when a PreToolUse hook requests cancellation.
+ * This signals to the tool handler that execution should be aborted.
+ */
+export class PreToolUseHookCancellationError extends Error {
+	constructor(message: string = "PreToolUse hook requested cancellation") {
+		super(message)
+		this.name = "PreToolUseHookCancellationError"
+	}
+}

--- a/src/core/prompts/responses.ts
+++ b/src/core/prompts/responses.ts
@@ -20,6 +20,8 @@ export const formatResponse = {
 
 	toolDenied: () => `The user denied this operation.`,
 
+	toolCancelled: () => `Tool execution was cancelled by a PreToolUse hook.`,
+
 	toolError: (error?: string) => `The tool execution failed with the following error:\n<error>\n${error}\n</error>`,
 
 	clineIgnoreError: (path: string) =>

--- a/src/core/task/TaskState.ts
+++ b/src/core/task/TaskState.ts
@@ -39,6 +39,12 @@ export class TaskState {
 	didAlreadyUseTool = false
 	didEditFile: boolean = false
 
+	/**
+	 * Timestamp of the current tool ask message being processed
+	 * Used to insert PreToolUse hook messages at the correct position
+	 */
+	currentToolAskMessageTs?: number
+
 	// Error tracking
 	consecutiveMistakeCount: number = 0
 	didAutomaticallyRetryFailedApiRequest = false

--- a/src/core/task/ToolExecutor.ts
+++ b/src/core/task/ToolExecutor.ts
@@ -683,6 +683,16 @@ export class ToolExecutor {
 
 			// Re-throw the error after PostToolUse completes
 			throw error
+		} finally {
+			// Clean up the hook runner after tool execution completes (success or error)
+			if (config.preToolUseRunner) {
+				delete config.preToolUseRunner
+			}
+
+			// Clear any pending tool message state if it exists
+			if (this.taskState.currentToolAskMessageTs !== undefined) {
+				this.taskState.currentToolAskMessageTs = undefined
+			}
 		}
 
 		// Early return if hook requested cancellation

--- a/src/core/task/ToolExecutor.ts
+++ b/src/core/task/ToolExecutor.ts
@@ -620,6 +620,7 @@ export class ToolExecutor {
 							hooksEnabled,
 							toolName: block.name,
 							pendingToolInfo,
+							taskState: this.taskState, // Pass taskState for hook message ordering
 						})
 
 						// Handle cancellation from hook

--- a/src/core/task/__tests__/ToolExecutor-cleanup.test.ts
+++ b/src/core/task/__tests__/ToolExecutor-cleanup.test.ts
@@ -1,0 +1,126 @@
+import { expect } from "chai"
+import { afterEach, beforeEach, describe, it } from "mocha"
+import sinon from "sinon"
+import { createMockToolExecutor, createMockToolUse } from "./test-utils"
+
+describe("ToolExecutor state cleanup", () => {
+	let sandbox: sinon.SinonSandbox
+
+	beforeEach(() => {
+		sandbox = sinon.createSandbox()
+	})
+
+	afterEach(() => {
+		sandbox.restore()
+	})
+
+	it("should clean up preToolUseRunner in finally block on success", async () => {
+		const executor = createMockToolExecutor()
+		const config = executor.asToolConfig()
+		const block = createMockToolUse("read_file", { path: "test.txt" })
+
+		// Add a preToolUseRunner to the config
+		config.preToolUseRunner = {
+			run: sandbox.stub().resolves(),
+		}
+
+		// Mock coordinator to succeed
+		config.coordinator.execute = sandbox.stub().resolves("Success")
+
+		await executor.handleCompleteBlock(block, config)
+
+		// Verify cleanup happened
+		expect(config.preToolUseRunner).to.be.undefined
+	})
+
+	it("should clean up state even when tool execution fails", async () => {
+		const executor = createMockToolExecutor()
+		const config = executor.asToolConfig()
+		const block = createMockToolUse("read_file", { path: "nonexistent.txt" })
+
+		// Add a preToolUseRunner to the config
+		config.preToolUseRunner = {
+			run: sandbox.stub().resolves(),
+		}
+
+		// Mock tool to throw error
+		config.coordinator.execute = sandbox.stub().rejects(new Error("File not found"))
+
+		// Set current tool ask message ts
+		executor.taskState.currentToolAskMessageTs = 12345
+
+		try {
+			await executor.handleCompleteBlock(block, config)
+		} catch (e) {
+			// Expected error
+		}
+
+		// Verify cleanup happened despite error
+		expect(config.preToolUseRunner).to.be.undefined
+		expect(executor.taskState.currentToolAskMessageTs).to.be.undefined
+	})
+
+	it("should clean up state when task is aborted during execution", async () => {
+		const executor = createMockToolExecutor()
+		const config = executor.asToolConfig()
+		const block = createMockToolUse("execute_command", { command: "long_running_cmd" })
+
+		// Add a preToolUseRunner to the config
+		config.preToolUseRunner = {
+			run: sandbox.stub().resolves(),
+		}
+
+		// Set current tool ask message ts
+		executor.taskState.currentToolAskMessageTs = 12345
+
+		// Mock coordinator to simulate abort
+		config.coordinator.execute = sandbox.stub().callsFake(async () => {
+			executor.taskState.abort = true
+			return "Aborted"
+		})
+
+		await executor.handleCompleteBlock(block, config)
+
+		// Verify cleanup happened
+		expect(config.preToolUseRunner).to.be.undefined
+		expect(executor.taskState.currentToolAskMessageTs).to.be.undefined
+	})
+
+	it("should clean up even if preToolUseRunner throws", async () => {
+		const executor = createMockToolExecutor()
+		const config = executor.asToolConfig()
+		const block = createMockToolUse("read_file", { path: "test.txt" })
+
+		// Add a preToolUseRunner that throws
+		config.preToolUseRunner = {
+			run: sandbox.stub().rejects(new Error("Hook failed")),
+		}
+
+		try {
+			await executor.handleCompleteBlock(block, config)
+		} catch (e) {
+			// Expected error from hook
+		}
+
+		// Verify cleanup happened despite hook failure
+		expect(config.preToolUseRunner).to.be.undefined
+	})
+
+	it("should handle case where preToolUseRunner is not set", async () => {
+		const executor = createMockToolExecutor()
+		const config = executor.asToolConfig()
+		const block = createMockToolUse("read_file", { path: "test.txt" })
+
+		// Don't set preToolUseRunner
+		expect(config.preToolUseRunner).to.be.undefined
+
+		// Mock coordinator to succeed
+		config.coordinator.execute = sandbox.stub().resolves("Success")
+
+		// Should not throw
+		await executor.handleCompleteBlock(block, config)
+
+		// Should still be undefined (no error)
+		expect(config.preToolUseRunner).to.be.undefined
+	})
+})

--- a/src/core/task/__tests__/hooks-integration.test.ts
+++ b/src/core/task/__tests__/hooks-integration.test.ts
@@ -1,7 +1,7 @@
 import { expect } from "chai"
 import { afterEach, beforeEach, describe, it } from "mocha"
 import sinon from "sinon"
-import { createMockTask, createMockToolUse } from "./test-utils"
+import { createMockTask } from "./test-utils"
 
 describe("Hooks integration", () => {
 	let sandbox: sinon.SinonSandbox
@@ -39,11 +39,6 @@ describe("Hooks integration", () => {
 		// 2. PreToolUse hook runs
 		// 3. Tool executes
 		// 4. PostToolUse hook would run (not in scope for this PR)
-
-		const block = createMockToolUse("write_to_file", {
-			path: "test.txt",
-			content: "Hello World",
-		})
 
 		// Step 1: User approves (simulated)
 		executionLog.push("Approval")

--- a/src/core/task/__tests__/hooks-integration.test.ts
+++ b/src/core/task/__tests__/hooks-integration.test.ts
@@ -1,0 +1,182 @@
+import { expect } from "chai"
+import { afterEach, beforeEach, describe, it } from "mocha"
+import sinon from "sinon"
+import { createMockTask, createMockToolUse } from "./test-utils"
+
+describe("Hooks integration", () => {
+	let sandbox: sinon.SinonSandbox
+
+	beforeEach(() => {
+		sandbox = sinon.createSandbox()
+	})
+
+	afterEach(() => {
+		sandbox.restore()
+	})
+
+	it("should track hook execution order when hooks are enabled", async () => {
+		const task = createMockTask({ hooksEnabled: true })
+		const executionLog: string[] = []
+
+		// Mock the stateManager to report hooks enabled
+		task.getStateManager().getGlobalSettingsKey = sandbox.stub().callsFake((key: string) => {
+			if (key === "hooksEnabled") {
+				return true
+			}
+			return false
+		})
+
+		// Track execution order - this simulates what would happen in real execution
+		const mockPreToolUseRunner = {
+			run: sandbox.stub().callsFake(async () => {
+				executionLog.push("PreToolUse")
+				return { cancel: false }
+			}),
+		}
+
+		// Simulate the tool execution flow where:
+		// 1. Approval happens
+		// 2. PreToolUse hook runs
+		// 3. Tool executes
+		// 4. PostToolUse hook would run (not in scope for this PR)
+
+		const block = createMockToolUse("write_to_file", {
+			path: "test.txt",
+			content: "Hello World",
+		})
+
+		// Step 1: User approves (simulated)
+		executionLog.push("Approval")
+
+		// Step 2: PreToolUse hook runs (from ToolExecutor)
+		if (mockPreToolUseRunner) {
+			await mockPreToolUseRunner.run()
+		}
+
+		// Step 3: Tool executes (simulated)
+		executionLog.push("ToolExecution")
+
+		// Verify execution order
+		expect(executionLog).to.deep.equal(["Approval", "PreToolUse", "ToolExecution"])
+	})
+
+	it("should not execute PreToolUse hook when hooks are disabled", async () => {
+		const task = createMockTask({ hooksEnabled: false })
+		const executionLog: string[] = []
+
+		// Mock the stateManager to report hooks disabled
+		task.getStateManager().getGlobalSettingsKey = sandbox.stub().callsFake((key: string) => {
+			if (key === "hooksEnabled") {
+				return false
+			}
+			return undefined
+		})
+
+		const mockPreToolUseRunner = {
+			run: sandbox.stub().callsFake(async () => {
+				executionLog.push("PreToolUse")
+			}),
+		}
+
+		// Simulate flow with hooks disabled
+		executionLog.push("Approval")
+
+		// PreToolUse should NOT run when hooks disabled
+		const hooksEnabled = task.getStateManager().getGlobalSettingsKey("hooksEnabled")
+		if (hooksEnabled && mockPreToolUseRunner) {
+			await mockPreToolUseRunner.run()
+		}
+
+		executionLog.push("ToolExecution")
+
+		// Verify PreToolUse was NOT called
+		expect(executionLog).to.deep.equal(["Approval", "ToolExecution"])
+		expect(executionLog).to.not.include("PreToolUse")
+	})
+
+	it("should allow hook cancellation to stop tool execution", async () => {
+		const task = createMockTask({ hooksEnabled: true })
+		const executionLog: string[] = []
+
+		// Mock the stateManager to report hooks enabled
+		task.getStateManager().getGlobalSettingsKey = sandbox.stub().callsFake((key: string) => {
+			if (key === "hooksEnabled") {
+				return true
+			}
+			return false
+		})
+
+		const mockPreToolUseRunner = {
+			run: sandbox.stub().callsFake(async () => {
+				executionLog.push("PreToolUse-Cancelled")
+				return { cancel: true, errorMessage: "User cancelled via hook" }
+			}),
+		}
+
+		// Simulate flow where hook cancels
+		executionLog.push("Approval")
+
+		const hookResult = await mockPreToolUseRunner.run()
+
+		// Tool should NOT execute if hook cancelled
+		if (!hookResult.cancel) {
+			executionLog.push("ToolExecution")
+		} else {
+			executionLog.push("CancellationHandled")
+		}
+
+		// Verify execution stopped after hook cancellation
+		expect(executionLog).to.deep.equal(["Approval", "PreToolUse-Cancelled", "CancellationHandled"])
+		expect(executionLog).to.not.include("ToolExecution")
+	})
+
+	it("should handle hook errors gracefully", async () => {
+		const task = createMockTask({ hooksEnabled: true })
+		const executionLog: string[] = []
+
+		// Mock the stateManager to report hooks enabled
+		task.getStateManager().getGlobalSettingsKey = sandbox.stub().callsFake((key: string) => {
+			if (key === "hooksEnabled") {
+				return true
+			}
+			return false
+		})
+
+		const mockPreToolUseRunner = {
+			run: sandbox.stub().rejects(new Error("Hook execution failed")),
+		}
+
+		// Simulate flow where hook throws error
+		executionLog.push("Approval")
+
+		try {
+			await mockPreToolUseRunner.run()
+			executionLog.push("ToolExecution")
+		} catch (error: any) {
+			executionLog.push("HookError")
+			// In real implementation, tool execution should not proceed
+		}
+
+		// Verify error was caught and tool did not execute
+		expect(executionLog).to.deep.equal(["Approval", "HookError"])
+		expect(executionLog).to.not.include("ToolExecution")
+	})
+
+	it("should preserve task state after hook execution", async () => {
+		const task = createMockTask({ hooksEnabled: true })
+
+		// Set initial state
+		task.taskState.currentToolAskMessageTs = 12345
+		const initialTs = task.taskState.currentToolAskMessageTs
+
+		// Mock hook that doesn't modify state
+		const mockPreToolUseRunner = {
+			run: sandbox.stub().resolves({ cancel: false }),
+		}
+
+		await mockPreToolUseRunner.run()
+
+		// Verify state preserved
+		expect(task.taskState.currentToolAskMessageTs).to.equal(initialTs)
+	})
+})

--- a/src/core/task/__tests__/message-timestamp.test.ts
+++ b/src/core/task/__tests__/message-timestamp.test.ts
@@ -1,0 +1,74 @@
+import { expect } from "chai"
+import { describe, it } from "mocha"
+import { createMockTask } from "./test-utils"
+
+describe("Task.say() message timestamp", () => {
+	it("should return timestamp when completing a partial message", async () => {
+		// Setup task with minimal config
+		const task = createMockTask()
+
+		// Mock the message state to track partial messages
+		const messages: any[] = []
+		task.messageStateHandler.getClineMessages = () => messages
+		task.messageStateHandler.addToClineMessages = async (msg: any) => {
+			messages.push(msg)
+		}
+
+		// Send partial message
+		const partialTs = await task.say("text", "Hello", undefined, undefined, true)
+		expect(partialTs).to.be.greaterThan(0)
+
+		// Complete the partial message - CRITICAL: should return timestamp
+		const completeTs = await task.say("text", "Hello World", undefined, undefined, false)
+		expect(completeTs).to.not.be.undefined
+		expect(completeTs).to.equal(partialTs) // Should be same timestamp
+	})
+
+	it("should return timestamp for new non-partial messages", async () => {
+		const task = createMockTask()
+
+		// Mock the message state
+		const messages: any[] = []
+		task.messageStateHandler.getClineMessages = () => messages
+		task.messageStateHandler.addToClineMessages = async (msg: any) => {
+			messages.push(msg)
+		}
+
+		const ts = await task.say("text", "Hello")
+		expect(ts).to.be.greaterThan(0)
+	})
+
+	it("should return undefined when updating existing partial message", async () => {
+		const task = createMockTask()
+
+		// Setup message state with an existing partial message
+		const existingMessage = {
+			ts: Date.now(),
+			type: "say",
+			say: "text",
+			text: "Hello",
+			partial: true,
+		}
+		const messages: any[] = [existingMessage]
+		task.messageStateHandler.getClineMessages = () => messages
+
+		// Update the partial message - should return undefined
+		const ts = await task.say("text", "Hello World", undefined, undefined, true)
+		expect(ts).to.be.undefined
+	})
+
+	it("should return new timestamp for new partial message", async () => {
+		const task = createMockTask()
+
+		// Setup empty message state
+		const messages: any[] = []
+		task.messageStateHandler.getClineMessages = () => messages
+		task.messageStateHandler.addToClineMessages = async (msg: any) => {
+			messages.push(msg)
+		}
+
+		// Create new partial message - should return timestamp
+		const ts = await task.say("text", "Hello", undefined, undefined, true)
+		expect(ts).to.be.greaterThan(0)
+	})
+})

--- a/src/core/task/__tests__/test-utils.ts
+++ b/src/core/task/__tests__/test-utils.ts
@@ -1,0 +1,301 @@
+import { ClineDefaultTool } from "@shared/tools"
+import sinon from "sinon"
+import * as vscode from "vscode"
+import { ToolUse } from "../../assistant-message"
+import { Task } from "../index"
+import { TaskState } from "../TaskState"
+import { ToolExecutor } from "../ToolExecutor"
+
+/**
+ * Creates a minimal mock Task instance for testing
+ */
+export function createMockTask(options: any = {}): Task {
+	const taskState = new TaskState()
+	const messageStateHandler = {
+		getClineMessages: sinon.stub().returns([]),
+		setClineMessages: sinon.stub(),
+		addToClineMessages: sinon.stub().resolves(),
+		updateClineMessage: sinon.stub().resolves(),
+		saveClineMessagesAndUpdateHistory: sinon.stub().resolves(),
+		getApiConversationHistory: sinon.stub().returns([]),
+		setApiConversationHistory: sinon.stub(),
+		addToApiConversationHistory: sinon.stub().resolves(),
+		overwriteApiConversationHistory: sinon.stub().resolves(),
+		overwriteClineMessages: sinon.stub().resolves(),
+	} as any
+
+	const mockController = {
+		context: { globalState: { get: sinon.stub(), update: sinon.stub() } } as any,
+		mcpHub: {
+			isConnecting: false,
+			setNotificationCallback: sinon.stub(),
+			clearNotificationCallback: sinon.stub(),
+		} as any,
+		updateTaskHistory: sinon.stub().resolves([]),
+		postStateToWebview: sinon.stub().resolves(),
+		reinitExistingTaskFromId: sinon.stub().resolves(),
+		cancelTask: sinon.stub().resolves(),
+		shouldShowBackgroundTerminalSuggestion: sinon.stub().returns(false),
+		updateBackgroundCommandState: sinon.stub(),
+		toggleActModeForYoloMode: sinon.stub().resolves(false),
+	}
+
+	const mockStateManager = {
+		getGlobalSettingsKey: sinon.stub().callsFake((key: string) => {
+			const defaults: any = {
+				mode: "act",
+				hooksEnabled: options.hooksEnabled || false,
+				enableCheckpointsSetting: false,
+				strictPlanModeEnabled: false,
+				yoloModeToggled: false,
+				maxConsecutiveMistakes: 3,
+				autoApprovalSettings: {},
+				browserSettings: {},
+				focusChainSettings: { enabled: false },
+			}
+			return defaults[key]
+		}),
+		getApiConfiguration: sinon.stub().returns({
+			apiProvider: "anthropic",
+			apiModelId: "claude-4-sonnet-20250514",
+		}),
+		getGlobalStateKey: sinon.stub().returns(true),
+	} as any
+
+	const params: any = {
+		controller: mockController,
+		mcpHub: mockController.mcpHub,
+		updateTaskHistory: mockController.updateTaskHistory,
+		postStateToWebview: mockController.postStateToWebview,
+		reinitExistingTaskFromId: mockController.reinitExistingTaskFromId,
+		cancelTask: mockController.cancelTask,
+		shellIntegrationTimeout: 5000,
+		terminalReuseEnabled: true,
+		terminalOutputLineLimit: 500,
+		subagentTerminalOutputLineLimit: 2000,
+		defaultTerminalProfile: "bash",
+		vscodeTerminalExecutionMode: "vscodeTerminal",
+		cwd: "/test/workspace",
+		stateManager: mockStateManager,
+		workspaceManager: undefined,
+		task: "Test task",
+		images: [],
+		files: [],
+		historyItem: undefined,
+		taskId: "test-task-id",
+		taskLockAcquired: false,
+	}
+
+	// Create a partial Task instance for testing
+	const task = Object.create(Task.prototype)
+	task.taskId = params.taskId
+	task.ulid = "test-ulid"
+	task.taskState = taskState
+	task.messageStateHandler = messageStateHandler
+	// Make stateManager accessible for testing
+	Object.defineProperty(task, "stateManager", {
+		get: () => mockStateManager,
+		configurable: true,
+	})
+	task.controller = mockController
+
+	// Add the say method that we're testing
+	task.say = async function (
+		type: any,
+		text?: string,
+		images?: string[],
+		files?: string[],
+		partial?: boolean,
+	): Promise<number | undefined> {
+		if (partial !== undefined) {
+			const lastMessage = messageStateHandler.getClineMessages().at(-1)
+			const isUpdatingPreviousPartial =
+				lastMessage && lastMessage.partial && lastMessage.type === "say" && lastMessage.say === type
+
+			if (partial) {
+				if (isUpdatingPreviousPartial) {
+					lastMessage.text = text
+					lastMessage.images = images
+					lastMessage.files = files
+					lastMessage.partial = partial
+					return undefined
+				} else {
+					const sayTs = Date.now()
+					this.taskState.lastMessageTs = sayTs
+					await messageStateHandler.addToClineMessages({
+						ts: sayTs,
+						type: "say",
+						say: type,
+						text,
+						images,
+						files,
+						partial,
+					})
+					return sayTs
+				}
+			} else {
+				if (isUpdatingPreviousPartial) {
+					this.taskState.lastMessageTs = lastMessage.ts
+					lastMessage.text = text
+					lastMessage.images = images
+					lastMessage.files = files
+					lastMessage.partial = false
+					await messageStateHandler.saveClineMessagesAndUpdateHistory()
+					return lastMessage.ts // Return the timestamp
+				} else {
+					const sayTs = Date.now()
+					this.taskState.lastMessageTs = sayTs
+					await messageStateHandler.addToClineMessages({
+						ts: sayTs,
+						type: "say",
+						say: type,
+						text,
+						images,
+						files,
+					})
+					return sayTs
+				}
+			}
+		} else {
+			const sayTs = Date.now()
+			this.taskState.lastMessageTs = sayTs
+			await messageStateHandler.addToClineMessages({
+				ts: sayTs,
+				type: "say",
+				say: type,
+				text,
+				images,
+				files,
+			})
+			return sayTs
+		}
+	}
+
+	return task
+}
+
+/**
+ * Creates a minimal mock TaskConfig for handler testing
+ */
+export function createMockTaskConfig(options: any = {}): any {
+	const taskState = new TaskState()
+
+	return {
+		taskId: "test-task-id",
+		ulid: "test-ulid",
+		context: {} as vscode.ExtensionContext,
+		mode: options.mode || "act",
+		strictPlanModeEnabled: false,
+		yoloModeToggled: false,
+		vscodeTerminalExecutionMode: "vscodeTerminal",
+		cwd: "/test/workspace",
+		workspaceManager: undefined,
+		isMultiRootEnabled: false,
+		taskState,
+		messageState: {
+			getClineMessages: sinon.stub().returns([]),
+			addToClineMessages: sinon.stub().resolves(),
+		} as any,
+		api: {
+			getModel: sinon.stub().returns({ id: "claude-4-sonnet-20250514", info: {} }),
+		} as any,
+		autoApprovalSettings: {},
+		autoApprover: {
+			shouldAutoApproveTool: sinon.stub().returns(false),
+			shouldAutoApproveToolWithPath: sinon.stub().resolves(false),
+		} as any,
+		browserSettings: {},
+		focusChainSettings: { enabled: false },
+		services: {
+			mcpHub: {} as any,
+			browserSession: {} as any,
+			urlContentFetcher: {} as any,
+			diffViewProvider: {
+				isEditing: false,
+				reset: sinon.stub().resolves(),
+				revertChanges: sinon.stub().resolves(),
+			} as any,
+			fileContextTracker: {} as any,
+			clineIgnoreController: {} as any,
+			contextManager: {} as any,
+			stateManager: {} as any,
+		},
+		callbacks: {
+			say: sinon.stub().resolves(Date.now()),
+			ask: sinon.stub().resolves({ response: "yesButtonClicked" }),
+			saveCheckpoint: sinon.stub().resolves(),
+			postStateToWebview: sinon.stub().resolves(),
+			reinitExistingTaskFromId: sinon.stub().resolves(),
+			cancelTask: sinon.stub().resolves(),
+			updateTaskHistory: sinon.stub().resolves([]),
+			executeCommandTool: sinon.stub().resolves([false, ""]),
+			doesLatestTaskCompletionHaveNewChanges: sinon.stub().resolves(false),
+			updateFCListFromToolResponse: sinon.stub().resolves(),
+			sayAndCreateMissingParamError: sinon.stub().resolves(""),
+			removeLastPartialMessageIfExistsWithType: sinon.stub().resolves(),
+			shouldAutoApproveTool: sinon.stub().returns(false),
+			shouldAutoApproveToolWithPath: sinon.stub().resolves(false),
+			applyLatestBrowserSettings: sinon.stub().resolves(),
+			switchToActMode: sinon.stub().resolves(false),
+		},
+		coordinator: {
+			execute: sinon.stub().resolves("Success"),
+			has: sinon.stub().returns(true),
+			getHandler: sinon.stub().returns(null),
+		} as any,
+		preToolUseRunner: options.preToolUseRunner,
+	}
+}
+
+/**
+ * Creates a mock ToolUse block for testing
+ */
+export function createMockToolUse(name: ClineDefaultTool | string, params: any): ToolUse {
+	return {
+		type: "tool_use",
+		name: name as ClineDefaultTool,
+		params,
+		partial: false,
+	}
+}
+
+/**
+ * Creates a minimal mock ToolExecutor for testing
+ */
+export function createMockToolExecutor(): any {
+	const taskState = new TaskState()
+	const messageStateHandler = {
+		getClineMessages: sinon.stub().returns([]),
+		addToClineMessages: sinon.stub().resolves(),
+	} as any
+
+	const mockStateManager = {
+		getGlobalSettingsKey: sinon.stub().returns(false),
+	} as any
+
+	const executor = Object.create(ToolExecutor.prototype)
+	executor.taskState = taskState
+	executor.messageStateHandler = messageStateHandler
+	executor.stateManager = mockStateManager
+
+	// Add methods needed for testing
+	executor.asToolConfig = () => createMockTaskConfig()
+
+	executor.handleCompleteBlock = async function (block: ToolUse, config: any) {
+		try {
+			if (config.preToolUseRunner) {
+				await config.preToolUseRunner.run()
+			}
+			await config.coordinator.execute(config, block)
+		} finally {
+			if (config.preToolUseRunner) {
+				delete config.preToolUseRunner
+			}
+			if (this.taskState.currentToolAskMessageTs !== undefined) {
+				this.taskState.currentToolAskMessageTs = undefined
+			}
+		}
+	}
+
+	return executor
+}

--- a/src/core/task/index.ts
+++ b/src/core/task/index.ts
@@ -754,7 +754,7 @@ export class Task {
 					// await this.postStateToWebview()
 					const protoMessage = convertClineMessageToProto(lastMessage)
 					await sendPartialMessageEvent(protoMessage) // more performant than an entire postStateToWebview
-					return undefined
+					return lastMessage.ts // Return the timestamp of the completed message
 				} else {
 					// this is a new partial=false message, so add it like normal
 					const sayTs = Date.now()

--- a/src/core/task/index.ts
+++ b/src/core/task/index.ts
@@ -237,6 +237,14 @@ export class Task {
 	// Cache service
 	private stateManager: StateManager
 
+	/**
+	 * Get the state manager instance
+	 * PUBLIC: Exposed for testing purposes
+	 */
+	public getStateManager(): StateManager {
+		return this.stateManager
+	}
+
 	// Message and conversation state
 	messageStateHandler: MessageStateHandler
 

--- a/src/core/task/index.ts
+++ b/src/core/task/index.ts
@@ -673,6 +673,7 @@ export class Task {
 			text: this.taskState.askResponseText,
 			images: this.taskState.askResponseImages,
 			files: this.taskState.askResponseFiles,
+			askTs,
 		}
 		this.taskState.askResponse = undefined
 		this.taskState.askResponseText = undefined

--- a/src/core/task/tools/handlers/AccessMcpResourceHandler.ts
+++ b/src/core/task/tools/handlers/AccessMcpResourceHandler.ts
@@ -100,7 +100,12 @@ export class AccessMcpResourceHandler implements IFullyManagedTool {
 
 			await config.callbacks.removeLastPartialMessageIfExistsWithType("say", "use_mcp_server")
 
-			const didApprove = await ToolResultUtils.askApprovalAndPushFeedback("use_mcp_server", completeMessage, config)
+			const { didApprove, askTs } = await ToolResultUtils.askApprovalAndPushFeedback(
+				"use_mcp_server",
+				completeMessage,
+				config,
+			)
+			config.taskState.currentToolAskMessageTs = askTs
 			if (!didApprove) {
 				telemetryService.captureToolUsage(
 					config.ulid,

--- a/src/core/task/tools/handlers/AccessMcpResourceHandler.ts
+++ b/src/core/task/tools/handlers/AccessMcpResourceHandler.ts
@@ -1,10 +1,8 @@
 import type { ToolUse } from "@core/assistant-message"
 import { formatResponse } from "@core/prompts/responses"
 import { ClineAsk, ClineAskUseMcpServer } from "@shared/ExtensionMessage"
-import { telemetryService } from "@/services/telemetry"
 import { ClineDefaultTool } from "@/shared/tools"
 import type { ToolResponse } from "../../index"
-import { showNotificationForApproval } from "../../utils"
 import type { IFullyManagedTool } from "../ToolExecutorCoordinator"
 import type { TaskConfig } from "../types/TaskConfig"
 import type { StronglyTypedUIHelpers } from "../types/UIHelpers"
@@ -76,60 +74,20 @@ export class AccessMcpResourceHandler implements IFullyManagedTool {
 		const shouldAutoApprove = config.callbacks.shouldAutoApproveTool(block.name)
 
 		if (shouldAutoApprove) {
-			// Auto-approval flow
-			await config.callbacks.removeLastPartialMessageIfExistsWithType("ask", "use_mcp_server")
-			await config.callbacks.say("use_mcp_server", completeMessage, undefined, undefined, false)
-
-			// Capture telemetry
-			telemetryService.captureToolUsage(
-				config.ulid,
-				block.name,
-				config.api.getModel().id,
-				provider,
-				true,
-				true,
-				undefined,
-				block.isNativeToolCall,
-			)
+			// Auto-approval flow - Standard pattern for approved tools:
+			// 1. Clean up partial messages and send the complete tool message
+			// 2. Record telemetry for the auto-approved tool execution
+			await ToolResultUtils.cleanupAndSendToolMessage(config, "use_mcp_server", completeMessage)
+			ToolResultUtils.captureAutoApprovedTool(config, block)
 		} else {
 			// Manual approval flow
-			const notificationMessage = `Cline wants to access ${uri || "unknown resource"} on ${server_name || "unknown server"}`
-
-			// Show notification
-			showNotificationForApproval(notificationMessage, config.autoApprovalSettings.enableNotifications)
-
-			await config.callbacks.removeLastPartialMessageIfExistsWithType("say", "use_mcp_server")
-
-			const { didApprove, askTs } = await ToolResultUtils.askApprovalAndPushFeedback(
-				"use_mcp_server",
-				completeMessage,
+			const result = await ToolResultUtils.executeManualApprovalForMcpOperation(
 				config,
+				block,
+				`Cline wants to access ${uri || "unknown resource"} on ${server_name || "unknown server"}`,
+				completeMessage,
 			)
-			config.taskState.currentToolAskMessageTs = askTs
-			if (!didApprove) {
-				telemetryService.captureToolUsage(
-					config.ulid,
-					block.name,
-					config.api.getModel().id,
-					provider,
-					false,
-					false,
-					undefined,
-					block.isNativeToolCall,
-				)
-				return formatResponse.toolDenied()
-			} else {
-				telemetryService.captureToolUsage(
-					config.ulid,
-					block.name,
-					config.api.getModel().id,
-					provider,
-					false,
-					true,
-					undefined,
-					block.isNativeToolCall,
-				)
-			}
+			if (result) return result
 		}
 
 		// Run PreToolUse hook after approval

--- a/src/core/task/tools/handlers/AccessMcpResourceHandler.ts
+++ b/src/core/task/tools/handlers/AccessMcpResourceHandler.ts
@@ -8,6 +8,7 @@ import { showNotificationForApproval } from "../../utils"
 import type { IFullyManagedTool } from "../ToolExecutorCoordinator"
 import type { TaskConfig } from "../types/TaskConfig"
 import type { StronglyTypedUIHelpers } from "../types/UIHelpers"
+import { ToolHookUtils } from "../utils/ToolHookUtils"
 import { ToolResultUtils } from "../utils/ToolResultUtils"
 
 export class AccessMcpResourceHandler implements IFullyManagedTool {
@@ -126,6 +127,13 @@ export class AccessMcpResourceHandler implements IFullyManagedTool {
 			}
 		}
 
+		// Run PreToolUse hook after approval
+		const shouldContinue = await ToolHookUtils.runPreToolUseIfEnabled(config, block)
+		if (!shouldContinue) {
+			return formatResponse.toolCancelled()
+		}
+
+		// Show MCP request started message
 		await config.callbacks.say("mcp_server_request_started")
 
 		// Execute the MCP resource access

--- a/src/core/task/tools/handlers/ApplyPatchHandler.ts
+++ b/src/core/task/tools/handlers/ApplyPatchHandler.ts
@@ -685,7 +685,10 @@ export class ApplyPatchHandler implements IFullyManagedTool {
 
 		if (shouldAutoApprove) {
 			await config.callbacks.removeLastPartialMessageIfExistsWithType("ask", "tool")
-			await config.callbacks.say("tool", completeMessage, undefined, undefined, false)
+			const sayTs = await config.callbacks.say("tool", completeMessage, undefined, undefined, false)
+			// When completing a partial message, say() returns undefined but updates the existing message
+			// In that case, get the timestamp from the last message
+			config.taskState.currentToolAskMessageTs = sayTs ?? config.messageState.getClineMessages().at(-1)?.ts
 			telemetryService.captureToolUsage(
 				config.ulid,
 				this.name,

--- a/src/core/task/tools/handlers/ApplyPatchHandler.ts
+++ b/src/core/task/tools/handlers/ApplyPatchHandler.ts
@@ -1,7 +1,6 @@
 import { readFile } from "node:fs/promises"
 import type { ToolUse } from "@core/assistant-message"
 import { resolveWorkspacePath } from "@core/workspace"
-import { processFilesIntoText } from "@integrations/misc/extract-text"
 import type { ClineSayTool } from "@shared/ExtensionMessage"
 import { fileExistsAtPath } from "@utils/fs"
 import { getReadablePath, isLocatedInWorkspace } from "@utils/path"
@@ -18,6 +17,7 @@ import type { StronglyTypedUIHelpers } from "../types/UIHelpers"
 import { type FileOpsResult, FileProviderOperations } from "../utils/FileProviderOperations"
 import { PatchParser } from "../utils/PatchParser"
 import { PathResolver } from "../utils/PathResolver"
+import { ToolHookUtils } from "../utils/ToolHookUtils"
 import { ToolResultUtils } from "../utils/ToolResultUtils"
 
 interface FileChange {
@@ -699,32 +699,48 @@ export class ApplyPatchHandler implements IFullyManagedTool {
 				undefined,
 				block.isNativeToolCall,
 			)
-			return true
+		} else {
+			showNotificationForApproval(`Cline wants to edit '${message.path}'`, config.autoApprovalSettings.enableNotifications)
+
+			await config.callbacks.removeLastPartialMessageIfExistsWithType("say", "tool")
+
+			const { didApprove, askTs } = await ToolResultUtils.askApprovalAndPushFeedback("tool", completeMessage, config)
+			config.taskState.currentToolAskMessageTs = askTs
+
+			if (!didApprove) {
+				telemetryService.captureToolUsage(
+					config.ulid,
+					this.name,
+					modelId,
+					providerId,
+					false,
+					false,
+					undefined,
+					block.isNativeToolCall,
+				)
+				return false
+			}
+
+			telemetryService.captureToolUsage(
+				config.ulid,
+				this.name,
+				modelId,
+				providerId,
+				false,
+				true,
+				undefined,
+				block.isNativeToolCall,
+			)
 		}
 
-		showNotificationForApproval(`Cline wants to edit '${message.path}'`, config.autoApprovalSettings.enableNotifications)
-
-		await config.callbacks.removeLastPartialMessageIfExistsWithType("say", "tool")
-		const { response, text, images, files } = await config.callbacks.ask("tool", completeMessage, false)
-
-		if (text || images?.length || files?.length) {
-			const fileContent = files?.length ? await processFilesIntoText(files) : ""
-			ToolResultUtils.pushAdditionalToolFeedback(config.taskState.userMessageContent, text, images, fileContent)
-			await config.callbacks.say("user_feedback", text, images, files)
+		// Run PreToolUse hook after approval
+		const shouldContinue = await ToolHookUtils.runPreToolUseIfEnabled(config, block)
+		if (!shouldContinue) {
+			await this.revertChanges()
+			config.taskState.didRejectTool = true
+			return false
 		}
 
-		const approved = response === "yesButtonClicked"
-		config.taskState.didRejectTool = !approved
-		telemetryService.captureToolUsage(
-			config.ulid,
-			this.name,
-			modelId,
-			providerId,
-			false,
-			approved,
-			undefined,
-			block.isNativeToolCall,
-		)
-		return approved
+		return true
 	}
 }

--- a/src/core/task/tools/handlers/AttemptCompletionHandler.ts
+++ b/src/core/task/tools/handlers/AttemptCompletionHandler.ts
@@ -124,7 +124,8 @@ export class AttemptCompletionHandler implements IToolHandler, IPartialBlockHand
 			}
 
 			// complete command message - need to ask for approval
-			const didApprove = await ToolResultUtils.askApprovalAndPushFeedback("command", command, config)
+			const { didApprove, askTs } = await ToolResultUtils.askApprovalAndPushFeedback("command", command, config)
+			config.taskState.currentToolAskMessageTs = askTs
 			if (!didApprove) {
 				return formatResponse.toolDenied()
 			}

--- a/src/core/task/tools/handlers/AttemptCompletionHandler.ts
+++ b/src/core/task/tools/handlers/AttemptCompletionHandler.ts
@@ -11,6 +11,7 @@ import type { ToolResponse } from "../../index"
 import type { IPartialBlockHandler, IToolHandler } from "../ToolExecutorCoordinator"
 import type { TaskConfig } from "../types/TaskConfig"
 import type { StronglyTypedUIHelpers } from "../types/UIHelpers"
+import { ToolHookUtils } from "../utils/ToolHookUtils"
 import { ToolResultUtils } from "../utils/ToolResultUtils"
 
 export class AttemptCompletionHandler implements IToolHandler, IPartialBlockHandler {
@@ -51,6 +52,12 @@ export class AttemptCompletionHandler implements IToolHandler, IPartialBlockHand
 		}
 
 		config.taskState.consecutiveMistakeCount = 0
+
+		// Run PreToolUse hook (no approval needed for attempt_completion, so run it early)
+		const shouldContinue = await ToolHookUtils.runPreToolUseIfEnabled(config, block)
+		if (!shouldContinue) {
+			return formatResponse.toolCancelled()
+		}
 
 		// Show notification if enabled
 		if (config.autoApprovalSettings.enableNotifications) {

--- a/src/core/task/tools/handlers/BrowserToolHandler.ts
+++ b/src/core/task/tools/handlers/BrowserToolHandler.ts
@@ -100,7 +100,12 @@ export class BrowserToolHandler implements IFullyManagedTool {
 						config.autoApprovalSettings.enableNotifications,
 					)
 					await config.callbacks.removeLastPartialMessageIfExistsWithType("say", "browser_action_launch")
-					const didApprove = await ToolResultUtils.askApprovalAndPushFeedback("browser_action_launch", url, config)
+					const { didApprove, askTs } = await ToolResultUtils.askApprovalAndPushFeedback(
+						"browser_action_launch",
+						url,
+						config,
+					)
+					config.taskState.currentToolAskMessageTs = askTs
 					if (!didApprove) {
 						return formatResponse.toolDenied()
 					}

--- a/src/core/task/tools/handlers/BrowserToolHandler.ts
+++ b/src/core/task/tools/handlers/BrowserToolHandler.ts
@@ -7,6 +7,7 @@ import { showNotificationForApproval } from "../../utils"
 import type { IFullyManagedTool } from "../ToolExecutorCoordinator"
 import type { TaskConfig } from "../types/TaskConfig"
 import type { StronglyTypedUIHelpers } from "../types/UIHelpers"
+import { ToolHookUtils } from "../utils/ToolHookUtils"
 import { ToolResultUtils } from "../utils/ToolResultUtils"
 
 export class BrowserToolHandler implements IFullyManagedTool {
@@ -165,6 +166,13 @@ export class BrowserToolHandler implements IFullyManagedTool {
 						browserActionResult = await browserSession.closeBrowser()
 						break
 				}
+			}
+
+			// Run PreToolUse hook after approval but before execution
+			const shouldContinue = await ToolHookUtils.runPreToolUseIfEnabled(config, block)
+			if (!shouldContinue) {
+				await config.services.browserSession.closeBrowser()
+				return formatResponse.toolCancelled()
 			}
 
 			// Handle results based on action type

--- a/src/core/task/tools/handlers/ExecuteCommandToolHandler.ts
+++ b/src/core/task/tools/handlers/ExecuteCommandToolHandler.ts
@@ -157,7 +157,10 @@ export class ExecuteCommandToolHandler implements IFullyManagedTool {
 		if ((!requiresApprovalPerLLM && autoApproveSafe) || (requiresApprovalPerLLM && autoApproveSafe && autoApproveAll)) {
 			// Auto-approve flow
 			await config.callbacks.removeLastPartialMessageIfExistsWithType("ask", "command")
-			await config.callbacks.say("command", actualCommand, undefined, undefined, false)
+			const sayTs = await config.callbacks.say("command", actualCommand, undefined, undefined, false)
+			// When completing a partial message, say() returns undefined but updates the existing message
+			// In that case, get the timestamp from the last message
+			config.taskState.currentToolAskMessageTs = sayTs ?? config.messageState.getClineMessages().at(-1)?.ts
 			didAutoApprove = true
 			telemetryService.captureToolUsage(
 				config.ulid,

--- a/src/core/task/tools/handlers/ExecuteCommandToolHandler.ts
+++ b/src/core/task/tools/handlers/ExecuteCommandToolHandler.ts
@@ -176,11 +176,12 @@ export class ExecuteCommandToolHandler implements IFullyManagedTool {
 				config.autoApprovalSettings.enableNotifications,
 			)
 
-			const didApprove = await ToolResultUtils.askApprovalAndPushFeedback(
+			const { didApprove, askTs } = await ToolResultUtils.askApprovalAndPushFeedback(
 				"command",
 				actualCommand + `${autoApproveSafe && requiresApprovalPerLLM ? COMMAND_REQ_APP_STRING : ""}`,
 				config,
 			)
+			config.taskState.currentToolAskMessageTs = askTs
 			if (!didApprove) {
 				telemetryService.captureToolUsage(
 					config.ulid,

--- a/src/core/task/tools/handlers/ExecuteCommandToolHandler.ts
+++ b/src/core/task/tools/handlers/ExecuteCommandToolHandler.ts
@@ -14,6 +14,7 @@ import type { ToolValidator } from "../ToolValidator"
 import type { TaskConfig } from "../types/TaskConfig"
 import type { StronglyTypedUIHelpers } from "../types/UIHelpers"
 import { applyModelContentFixes } from "../utils/ModelContentProcessor"
+import { ToolHookUtils } from "../utils/ToolHookUtils"
 import { ToolResultUtils } from "../utils/ToolResultUtils"
 
 // Default timeout for commands in yolo mode and background exec mode
@@ -203,6 +204,12 @@ export class ExecuteCommandToolHandler implements IFullyManagedTool {
 				workspaceContext,
 				block.isNativeToolCall,
 			)
+		}
+
+		// Run PreToolUse hook after approval
+		const shouldContinue = await ToolHookUtils.runPreToolUseIfEnabled(config, block)
+		if (!shouldContinue) {
+			return formatResponse.toolCancelled()
 		}
 
 		// Setup timeout notification for long-running auto-approved commands

--- a/src/core/task/tools/handlers/ListCodeDefinitionNamesToolHandler.ts
+++ b/src/core/task/tools/handlers/ListCodeDefinitionNamesToolHandler.ts
@@ -86,7 +86,10 @@ export class ListCodeDefinitionNamesToolHandler implements IFullyManagedTool {
 		if (await config.callbacks.shouldAutoApproveToolWithPath(block.name, relDirPath)) {
 			// Auto-approval flow
 			await config.callbacks.removeLastPartialMessageIfExistsWithType("ask", "tool")
-			await config.callbacks.say("tool", completeMessage, undefined, undefined, false)
+			const sayTs = await config.callbacks.say("tool", completeMessage, undefined, undefined, false)
+			// When completing a partial message, say() returns undefined but updates the existing message
+			// In that case, get the timestamp from the last message
+			config.taskState.currentToolAskMessageTs = sayTs ?? config.messageState.getClineMessages().at(-1)?.ts
 
 			// Capture telemetry
 			telemetryService.captureToolUsage(

--- a/src/core/task/tools/handlers/ListCodeDefinitionNamesToolHandler.ts
+++ b/src/core/task/tools/handlers/ListCodeDefinitionNamesToolHandler.ts
@@ -11,6 +11,7 @@ import type { IFullyManagedTool } from "../ToolExecutorCoordinator"
 import type { ToolValidator } from "../ToolValidator"
 import type { TaskConfig } from "../types/TaskConfig"
 import type { StronglyTypedUIHelpers } from "../types/UIHelpers"
+import { ToolHookUtils } from "../utils/ToolHookUtils"
 import { ToolResultUtils } from "../utils/ToolResultUtils"
 
 export class ListCodeDefinitionNamesToolHandler implements IFullyManagedTool {
@@ -132,6 +133,12 @@ export class ListCodeDefinitionNamesToolHandler implements IFullyManagedTool {
 					block.isNativeToolCall,
 				)
 			}
+		}
+
+		// Run PreToolUse hook after approval
+		const shouldContinue = await ToolHookUtils.runPreToolUseIfEnabled(config, block)
+		if (!shouldContinue) {
+			return formatResponse.toolCancelled()
 		}
 
 		return result

--- a/src/core/task/tools/handlers/ListCodeDefinitionNamesToolHandler.ts
+++ b/src/core/task/tools/handlers/ListCodeDefinitionNamesToolHandler.ts
@@ -3,10 +3,8 @@ import { getWorkspaceBasename, resolveWorkspacePath } from "@core/workspace"
 import { parseSourceCodeForDefinitionsTopLevel } from "@services/tree-sitter"
 import { getReadablePath, isLocatedInWorkspace } from "@utils/path"
 import { formatResponse } from "@/core/prompts/responses"
-import { telemetryService } from "@/services/telemetry"
 import { ClineDefaultTool } from "@/shared/tools"
 import type { ToolResponse } from "../../index"
-import { showNotificationForApproval } from "../../utils"
 import type { IFullyManagedTool } from "../ToolExecutorCoordinator"
 import type { ToolValidator } from "../ToolValidator"
 import type { TaskConfig } from "../types/TaskConfig"
@@ -84,59 +82,26 @@ export class ListCodeDefinitionNamesToolHandler implements IFullyManagedTool {
 		const completeMessage = JSON.stringify(sharedMessageProps)
 
 		if (await config.callbacks.shouldAutoApproveToolWithPath(block.name, relDirPath)) {
-			// Auto-approval flow
-			await config.callbacks.removeLastPartialMessageIfExistsWithType("ask", "tool")
-			const sayTs = await config.callbacks.say("tool", completeMessage, undefined, undefined, false)
-			// When completing a partial message, say() returns undefined but updates the existing message
-			// In that case, get the timestamp from the last message
-			config.taskState.currentToolAskMessageTs = sayTs ?? config.messageState.getClineMessages().at(-1)?.ts
-
-			// Capture telemetry
-			telemetryService.captureToolUsage(
-				config.ulid,
-				block.name,
-				config.api.getModel().id,
-				provider,
-				true,
-				true,
-				undefined,
-				block.isNativeToolCall,
-			)
+			// Auto-approval flow - Standard pattern for approved tools:
+			// 1. Clean up partial messages and send the complete tool message
+			// 2. Record telemetry for the auto-approved tool execution
+			await ToolResultUtils.cleanupAndSendToolMessage(config, "tool", completeMessage)
+			ToolResultUtils.captureAutoApprovedTool(config, block)
 		} else {
-			// Manual approval flow
-			const notificationMessage = `Cline wants to analyze code definitions in ${getWorkspaceBasename(absolutePath, "ListCodeDefinitionNamesToolHandler.notification")}`
-
-			// Show notification
-			showNotificationForApproval(notificationMessage, config.autoApprovalSettings.enableNotifications)
-
+			// Manual approval flow - Standard pattern for tools requiring approval:
+			// 1. Show notification to user
+			// 2. Clean up any partial messages from the UI
+			// 3. Ask for approval and handle any user feedback
+			// 4. Handle approval result with telemetry and return early if denied
+			ToolResultUtils.showToolNotification(
+				`Cline wants to analyze code definitions in ${getWorkspaceBasename(absolutePath, "ListCodeDefinitionNamesToolHandler.notification")}`,
+				config.autoApprovalSettings.enableNotifications,
+			)
 			await config.callbacks.removeLastPartialMessageIfExistsWithType("say", "tool")
+			const { didApprove } = await ToolResultUtils.askToolApproval(config, "tool", completeMessage)
 
-			const { didApprove, askTs } = await ToolResultUtils.askApprovalAndPushFeedback("tool", completeMessage, config)
-			config.taskState.currentToolAskMessageTs = askTs
-			if (!didApprove) {
-				telemetryService.captureToolUsage(
-					config.ulid,
-					block.name,
-					config.api.getModel().id,
-					provider,
-					false,
-					false,
-					undefined,
-					block.isNativeToolCall,
-				)
-				return formatResponse.toolDenied()
-			} else {
-				telemetryService.captureToolUsage(
-					config.ulid,
-					block.name,
-					config.api.getModel().id,
-					provider,
-					false,
-					true,
-					undefined,
-					block.isNativeToolCall,
-				)
-			}
+			const result = ToolResultUtils.handleApprovalResult(didApprove, config, block)
+			if (result) return result
 		}
 
 		// Run PreToolUse hook after approval

--- a/src/core/task/tools/handlers/ListCodeDefinitionNamesToolHandler.ts
+++ b/src/core/task/tools/handlers/ListCodeDefinitionNamesToolHandler.ts
@@ -108,7 +108,8 @@ export class ListCodeDefinitionNamesToolHandler implements IFullyManagedTool {
 
 			await config.callbacks.removeLastPartialMessageIfExistsWithType("say", "tool")
 
-			const didApprove = await ToolResultUtils.askApprovalAndPushFeedback("tool", completeMessage, config)
+			const { didApprove, askTs } = await ToolResultUtils.askApprovalAndPushFeedback("tool", completeMessage, config)
+			config.taskState.currentToolAskMessageTs = askTs
 			if (!didApprove) {
 				telemetryService.captureToolUsage(
 					config.ulid,

--- a/src/core/task/tools/handlers/ListFilesToolHandler.ts
+++ b/src/core/task/tools/handlers/ListFilesToolHandler.ts
@@ -125,7 +125,8 @@ export class ListFilesToolHandler implements IFullyManagedTool {
 
 			await config.callbacks.removeLastPartialMessageIfExistsWithType("say", "tool")
 
-			const didApprove = await ToolResultUtils.askApprovalAndPushFeedback("tool", completeMessage, config)
+			const { didApprove, askTs } = await ToolResultUtils.askApprovalAndPushFeedback("tool", completeMessage, config)
+			config.taskState.currentToolAskMessageTs = askTs
 			if (!didApprove) {
 				telemetryService.captureToolUsage(
 					config.ulid,

--- a/src/core/task/tools/handlers/ListFilesToolHandler.ts
+++ b/src/core/task/tools/handlers/ListFilesToolHandler.ts
@@ -12,6 +12,7 @@ import type { IFullyManagedTool } from "../ToolExecutorCoordinator"
 import type { ToolValidator } from "../ToolValidator"
 import type { TaskConfig } from "../types/TaskConfig"
 import type { StronglyTypedUIHelpers } from "../types/UIHelpers"
+import { ToolHookUtils } from "../utils/ToolHookUtils"
 import { ToolResultUtils } from "../utils/ToolResultUtils"
 
 export class ListFilesToolHandler implements IFullyManagedTool {
@@ -149,6 +150,12 @@ export class ListFilesToolHandler implements IFullyManagedTool {
 					block.isNativeToolCall,
 				)
 			}
+		}
+
+		// Run PreToolUse hook after approval
+		const shouldContinue = await ToolHookUtils.runPreToolUseIfEnabled(config, block)
+		if (!shouldContinue) {
+			return formatResponse.toolCancelled()
 		}
 
 		return result

--- a/src/core/task/tools/handlers/ListFilesToolHandler.ts
+++ b/src/core/task/tools/handlers/ListFilesToolHandler.ts
@@ -103,7 +103,10 @@ export class ListFilesToolHandler implements IFullyManagedTool {
 		if (await config.callbacks.shouldAutoApproveToolWithPath(block.name, relDirPath)) {
 			// Auto-approval flow
 			await config.callbacks.removeLastPartialMessageIfExistsWithType("ask", "tool")
-			await config.callbacks.say("tool", completeMessage, undefined, undefined, false)
+			const sayTs = await config.callbacks.say("tool", completeMessage, undefined, undefined, false)
+			// When completing a partial message, say() returns undefined but updates the existing message
+			// In that case, get the timestamp from the last message
+			config.taskState.currentToolAskMessageTs = sayTs ?? config.messageState.getClineMessages().at(-1)?.ts
 
 			// Capture telemetry
 			telemetryService.captureToolUsage(

--- a/src/core/task/tools/handlers/ReadFileToolHandler.ts
+++ b/src/core/task/tools/handlers/ReadFileToolHandler.ts
@@ -13,6 +13,7 @@ import type { IFullyManagedTool } from "../ToolExecutorCoordinator"
 import type { ToolValidator } from "../ToolValidator"
 import type { TaskConfig } from "../types/TaskConfig"
 import type { StronglyTypedUIHelpers } from "../types/UIHelpers"
+import { ToolHookUtils } from "../utils/ToolHookUtils"
 import { ToolResultUtils } from "../utils/ToolResultUtils"
 
 export class ReadFileToolHandler implements IFullyManagedTool {
@@ -147,6 +148,12 @@ export class ReadFileToolHandler implements IFullyManagedTool {
 					block.isNativeToolCall,
 				)
 			}
+		}
+
+		// Run PreToolUse hook after approval
+		const shouldContinue = await ToolHookUtils.runPreToolUseIfEnabled(config, block)
+		if (!shouldContinue) {
+			return formatResponse.toolCancelled()
 		}
 
 		// Execute the actual file read operation

--- a/src/core/task/tools/handlers/ReadFileToolHandler.ts
+++ b/src/core/task/tools/handlers/ReadFileToolHandler.ts
@@ -101,7 +101,10 @@ export class ReadFileToolHandler implements IFullyManagedTool {
 		if (await config.callbacks.shouldAutoApproveToolWithPath(block.name, relPath)) {
 			// Auto-approval flow
 			await config.callbacks.removeLastPartialMessageIfExistsWithType("ask", "tool")
-			await config.callbacks.say("tool", completeMessage, undefined, undefined, false)
+			const sayTs = await config.callbacks.say("tool", completeMessage, undefined, undefined, false)
+			// When completing a partial message, say() returns undefined but updates the existing message
+			// In that case, get the timestamp from the last message
+			config.taskState.currentToolAskMessageTs = sayTs ?? config.messageState.getClineMessages().at(-1)?.ts
 
 			// Capture telemetry
 			telemetryService.captureToolUsage(

--- a/src/core/task/tools/handlers/ReadFileToolHandler.ts
+++ b/src/core/task/tools/handlers/ReadFileToolHandler.ts
@@ -123,7 +123,13 @@ export class ReadFileToolHandler implements IFullyManagedTool {
 
 			await config.callbacks.removeLastPartialMessageIfExistsWithType("say", "tool")
 
-			const didApprove = await ToolResultUtils.askApprovalAndPushFeedback("tool", completeMessage, config)
+			const { didApprove, askTs } = await ToolResultUtils.askApprovalAndPushFeedback("tool", completeMessage, config)
+
+			// Store the tool ask message timestamp for PreToolUse hook ordering
+			if (askTs) {
+				config.taskState.currentToolAskMessageTs = askTs
+			}
+
 			if (!didApprove) {
 				telemetryService.captureToolUsage(
 					config.ulid,

--- a/src/core/task/tools/handlers/ReadFileToolHandler.ts
+++ b/src/core/task/tools/handlers/ReadFileToolHandler.ts
@@ -4,11 +4,9 @@ import { formatResponse } from "@core/prompts/responses"
 import { getWorkspaceBasename, resolveWorkspacePath } from "@core/workspace"
 import { extractFileContent } from "@integrations/misc/extract-file-content"
 import { arePathsEqual, getReadablePath, isLocatedInWorkspace } from "@utils/path"
-import { telemetryService } from "@/services/telemetry"
 import { ClineSayTool } from "@/shared/ExtensionMessage"
 import { ClineDefaultTool } from "@/shared/tools"
 import type { ToolResponse } from "../../index"
-import { showNotificationForApproval } from "../../utils"
 import type { IFullyManagedTool } from "../ToolExecutorCoordinator"
 import type { ToolValidator } from "../ToolValidator"
 import type { TaskConfig } from "../types/TaskConfig"
@@ -99,64 +97,26 @@ export class ReadFileToolHandler implements IFullyManagedTool {
 		const completeMessage = JSON.stringify(sharedMessageProps)
 
 		if (await config.callbacks.shouldAutoApproveToolWithPath(block.name, relPath)) {
-			// Auto-approval flow
-			await config.callbacks.removeLastPartialMessageIfExistsWithType("ask", "tool")
-			const sayTs = await config.callbacks.say("tool", completeMessage, undefined, undefined, false)
-			// When completing a partial message, say() returns undefined but updates the existing message
-			// In that case, get the timestamp from the last message
-			config.taskState.currentToolAskMessageTs = sayTs ?? config.messageState.getClineMessages().at(-1)?.ts
-
-			// Capture telemetry
-			telemetryService.captureToolUsage(
-				config.ulid,
-				block.name,
-				config.api.getModel().id,
-				provider,
-				true,
-				true,
-				workspaceContext,
-				block.isNativeToolCall,
-			)
+			// Auto-approval flow - Standard pattern for approved tools:
+			// 1. Clean up partial messages and send the complete tool message
+			// 2. Record telemetry for the auto-approved tool execution
+			await ToolResultUtils.cleanupAndSendToolMessage(config, "tool", completeMessage)
+			ToolResultUtils.captureAutoApprovedTool(config, block, workspaceContext)
 		} else {
-			// Manual approval flow
-			const notificationMessage = `Cline wants to read ${getWorkspaceBasename(absolutePath, "ReadFileToolHandler.notification")}`
-
-			// Show notification
-			showNotificationForApproval(notificationMessage, config.autoApprovalSettings.enableNotifications)
-
+			// Manual approval flow - Standard pattern for tools requiring approval:
+			// 1. Show notification to user
+			// 2. Clean up any partial messages from the UI
+			// 3. Ask for approval and handle any user feedback
+			// 4. Handle approval result with telemetry and return early if denied
+			ToolResultUtils.showToolNotification(
+				`Cline wants to read ${getWorkspaceBasename(absolutePath, "ReadFileToolHandler.notification")}`,
+				config.autoApprovalSettings.enableNotifications,
+			)
 			await config.callbacks.removeLastPartialMessageIfExistsWithType("say", "tool")
+			const { didApprove } = await ToolResultUtils.askToolApproval(config, "tool", completeMessage)
 
-			const { didApprove, askTs } = await ToolResultUtils.askApprovalAndPushFeedback("tool", completeMessage, config)
-
-			// Store the tool ask message timestamp for PreToolUse hook ordering
-			if (askTs) {
-				config.taskState.currentToolAskMessageTs = askTs
-			}
-
-			if (!didApprove) {
-				telemetryService.captureToolUsage(
-					config.ulid,
-					block.name,
-					config.api.getModel().id,
-					provider,
-					false,
-					false,
-					workspaceContext,
-					block.isNativeToolCall,
-				)
-				return formatResponse.toolDenied()
-			} else {
-				telemetryService.captureToolUsage(
-					config.ulid,
-					block.name,
-					config.api.getModel().id,
-					provider,
-					false,
-					true,
-					workspaceContext,
-					block.isNativeToolCall,
-				)
-			}
+			const result = ToolResultUtils.handleApprovalResult(didApprove, config, block, workspaceContext)
+			if (result) return result
 		}
 
 		// Run PreToolUse hook after approval

--- a/src/core/task/tools/handlers/SearchFilesToolHandler.ts
+++ b/src/core/task/tools/handlers/SearchFilesToolHandler.ts
@@ -331,7 +331,8 @@ export class SearchFilesToolHandler implements IFullyManagedTool {
 
 			await config.callbacks.removeLastPartialMessageIfExistsWithType("say", "tool")
 
-			const didApprove = await ToolResultUtils.askApprovalAndPushFeedback("tool", completeMessage, config)
+			const { didApprove, askTs } = await ToolResultUtils.askApprovalAndPushFeedback("tool", completeMessage, config)
+			config.taskState.currentToolAskMessageTs = askTs
 			if (!didApprove) {
 				telemetryService.captureToolUsage(
 					config.ulid,

--- a/src/core/task/tools/handlers/SearchFilesToolHandler.ts
+++ b/src/core/task/tools/handlers/SearchFilesToolHandler.ts
@@ -309,7 +309,10 @@ export class SearchFilesToolHandler implements IFullyManagedTool {
 		if (await config.callbacks.shouldAutoApproveToolWithPath(block.name, relDirPath)) {
 			// Auto-approval flow
 			await config.callbacks.removeLastPartialMessageIfExistsWithType("ask", "tool")
-			await config.callbacks.say("tool", completeMessage, undefined, undefined, false)
+			const sayTs = await config.callbacks.say("tool", completeMessage, undefined, undefined, false)
+			// When completing a partial message, say() returns undefined but updates the existing message
+			// In that case, get the timestamp from the last message
+			config.taskState.currentToolAskMessageTs = sayTs ?? config.messageState.getClineMessages().at(-1)?.ts
 
 			// Capture telemetry
 			telemetryService.captureToolUsage(

--- a/src/core/task/tools/handlers/SearchFilesToolHandler.ts
+++ b/src/core/task/tools/handlers/SearchFilesToolHandler.ts
@@ -10,7 +10,6 @@ import { telemetryService } from "@/services/telemetry"
 import { ClineSayTool } from "@/shared/ExtensionMessage"
 import { ClineDefaultTool } from "@/shared/tools"
 import type { ToolResponse } from "../../index"
-import { showNotificationForApproval } from "../../utils"
 import type { IFullyManagedTool } from "../ToolExecutorCoordinator"
 import type { ToolValidator } from "../ToolValidator"
 import type { TaskConfig } from "../types/TaskConfig"
@@ -307,59 +306,26 @@ export class SearchFilesToolHandler implements IFullyManagedTool {
 		const completeMessage = JSON.stringify(sharedMessageProps)
 
 		if (await config.callbacks.shouldAutoApproveToolWithPath(block.name, relDirPath)) {
-			// Auto-approval flow
-			await config.callbacks.removeLastPartialMessageIfExistsWithType("ask", "tool")
-			const sayTs = await config.callbacks.say("tool", completeMessage, undefined, undefined, false)
-			// When completing a partial message, say() returns undefined but updates the existing message
-			// In that case, get the timestamp from the last message
-			config.taskState.currentToolAskMessageTs = sayTs ?? config.messageState.getClineMessages().at(-1)?.ts
-
-			// Capture telemetry
-			telemetryService.captureToolUsage(
-				config.ulid,
-				block.name,
-				config.api.getModel().id,
-				provider,
-				true,
-				true,
-				workspaceContext,
-				block.isNativeToolCall,
-			)
+			// Auto-approval flow - Standard pattern for approved tools:
+			// 1. Clean up partial messages and send the complete tool message
+			// 2. Record telemetry for the auto-approved tool execution
+			await ToolResultUtils.cleanupAndSendToolMessage(config, "tool", completeMessage)
+			ToolResultUtils.captureAutoApprovedTool(config, block, workspaceContext)
 		} else {
-			// Manual approval flow
-			const notificationMessage = `Cline wants to search files for ${regex}`
-
-			// Show notification
-			showNotificationForApproval(notificationMessage, config.autoApprovalSettings.enableNotifications)
-
+			// Manual approval flow - Standard pattern for tools requiring approval:
+			// 1. Show notification to user
+			// 2. Clean up any partial messages from the UI
+			// 3. Ask for approval and handle any user feedback
+			// 4. Handle approval result with telemetry and return early if denied
+			ToolResultUtils.showToolNotification(
+				`Cline wants to search files for ${regex}`,
+				config.autoApprovalSettings.enableNotifications,
+			)
 			await config.callbacks.removeLastPartialMessageIfExistsWithType("say", "tool")
+			const { didApprove } = await ToolResultUtils.askToolApproval(config, "tool", completeMessage)
 
-			const { didApprove, askTs } = await ToolResultUtils.askApprovalAndPushFeedback("tool", completeMessage, config)
-			config.taskState.currentToolAskMessageTs = askTs
-			if (!didApprove) {
-				telemetryService.captureToolUsage(
-					config.ulid,
-					block.name,
-					config.api.getModel().id,
-					provider,
-					false,
-					false,
-					workspaceContext,
-					block.isNativeToolCall,
-				)
-				return formatResponse.toolDenied()
-			} else {
-				telemetryService.captureToolUsage(
-					config.ulid,
-					block.name,
-					config.api.getModel().id,
-					provider,
-					false,
-					true,
-					workspaceContext,
-					block.isNativeToolCall,
-				)
-			}
+			const result = ToolResultUtils.handleApprovalResult(didApprove, config, block, workspaceContext)
+			if (result) return result
 		}
 
 		// Run PreToolUse hook after approval

--- a/src/core/task/tools/handlers/SearchFilesToolHandler.ts
+++ b/src/core/task/tools/handlers/SearchFilesToolHandler.ts
@@ -15,6 +15,7 @@ import type { IFullyManagedTool } from "../ToolExecutorCoordinator"
 import type { ToolValidator } from "../ToolValidator"
 import type { TaskConfig } from "../types/TaskConfig"
 import type { StronglyTypedUIHelpers } from "../types/UIHelpers"
+import { ToolHookUtils } from "../utils/ToolHookUtils"
 import { ToolResultUtils } from "../utils/ToolResultUtils"
 
 export class SearchFilesToolHandler implements IFullyManagedTool {
@@ -355,6 +356,12 @@ export class SearchFilesToolHandler implements IFullyManagedTool {
 					block.isNativeToolCall,
 				)
 			}
+		}
+
+		// Run PreToolUse hook after approval
+		const shouldContinue = await ToolHookUtils.runPreToolUseIfEnabled(config, block)
+		if (!shouldContinue) {
+			return formatResponse.toolCancelled()
 		}
 
 		return results

--- a/src/core/task/tools/handlers/UseMcpToolHandler.ts
+++ b/src/core/task/tools/handlers/UseMcpToolHandler.ts
@@ -115,7 +115,12 @@ export class UseMcpToolHandler implements IFullyManagedTool {
 
 			await config.callbacks.removeLastPartialMessageIfExistsWithType("say", "use_mcp_server")
 
-			const didApprove = await ToolResultUtils.askApprovalAndPushFeedback("use_mcp_server", completeMessage, config)
+			const { didApprove, askTs } = await ToolResultUtils.askApprovalAndPushFeedback(
+				"use_mcp_server",
+				completeMessage,
+				config,
+			)
+			config.taskState.currentToolAskMessageTs = askTs
 			if (!didApprove) {
 				telemetryService.captureToolUsage(
 					config.ulid,

--- a/src/core/task/tools/handlers/UseMcpToolHandler.ts
+++ b/src/core/task/tools/handlers/UseMcpToolHandler.ts
@@ -8,6 +8,7 @@ import { showNotificationForApproval } from "../../utils"
 import type { IFullyManagedTool } from "../ToolExecutorCoordinator"
 import type { TaskConfig } from "../types/TaskConfig"
 import type { StronglyTypedUIHelpers } from "../types/UIHelpers"
+import { ToolHookUtils } from "../utils/ToolHookUtils"
 import { ToolResultUtils } from "../utils/ToolResultUtils"
 
 export class UseMcpToolHandler implements IFullyManagedTool {
@@ -139,6 +140,12 @@ export class UseMcpToolHandler implements IFullyManagedTool {
 					block.isNativeToolCall,
 				)
 			}
+		}
+
+		// Run PreToolUse hook after approval
+		const shouldContinue = await ToolHookUtils.runPreToolUseIfEnabled(config, block)
+		if (!shouldContinue) {
+			return formatResponse.toolCancelled()
 		}
 
 		// Show MCP request started message

--- a/src/core/task/tools/handlers/WebFetchToolHandler.ts
+++ b/src/core/task/tools/handlers/WebFetchToolHandler.ts
@@ -83,7 +83,8 @@ export class WebFetchToolHandler implements IFullyManagedTool {
 				)
 				await config.callbacks.removeLastPartialMessageIfExistsWithType("say", "tool")
 
-				const didApprove = await ToolResultUtils.askApprovalAndPushFeedback("tool", completeMessage, config)
+				const { didApprove, askTs } = await ToolResultUtils.askApprovalAndPushFeedback("tool", completeMessage, config)
+				config.taskState.currentToolAskMessageTs = askTs
 				if (!didApprove) {
 					telemetryService.captureToolUsage(
 						config.ulid,

--- a/src/core/task/tools/handlers/WebFetchToolHandler.ts
+++ b/src/core/task/tools/handlers/WebFetchToolHandler.ts
@@ -64,7 +64,10 @@ export class WebFetchToolHandler implements IFullyManagedTool {
 			if (config.callbacks.shouldAutoApproveTool(this.name)) {
 				// Auto-approve flow
 				await config.callbacks.removeLastPartialMessageIfExistsWithType("ask", "tool")
-				await config.callbacks.say("tool", completeMessage, undefined, undefined, false)
+				const sayTs = await config.callbacks.say("tool", completeMessage, undefined, undefined, false)
+				// When completing a partial message, say() returns undefined but updates the existing message
+				// In that case, get the timestamp from the last message
+				config.taskState.currentToolAskMessageTs = sayTs ?? config.messageState.getClineMessages().at(-1)?.ts
 				telemetryService.captureToolUsage(
 					config.ulid,
 					"web_fetch",

--- a/src/core/task/tools/handlers/WebFetchToolHandler.ts
+++ b/src/core/task/tools/handlers/WebFetchToolHandler.ts
@@ -9,6 +9,7 @@ import { showNotificationForApproval } from "../../utils"
 import type { IFullyManagedTool } from "../ToolExecutorCoordinator"
 import type { TaskConfig } from "../types/TaskConfig"
 import type { StronglyTypedUIHelpers } from "../types/UIHelpers"
+import { ToolHookUtils } from "../utils/ToolHookUtils"
 import { ToolResultUtils } from "../utils/ToolResultUtils"
 
 export class WebFetchToolHandler implements IFullyManagedTool {
@@ -107,6 +108,12 @@ export class WebFetchToolHandler implements IFullyManagedTool {
 						block.isNativeToolCall,
 					)
 				}
+			}
+
+			// Run PreToolUse hook after approval
+			const shouldContinue = await ToolHookUtils.runPreToolUseIfEnabled(config, block)
+			if (!shouldContinue) {
+				return formatResponse.toolCancelled()
 			}
 
 			// Execute the actual fetch

--- a/src/core/task/tools/handlers/WriteToFileToolHandler.ts
+++ b/src/core/task/tools/handlers/WriteToFileToolHandler.ts
@@ -18,6 +18,7 @@ import type { TaskConfig } from "../types/TaskConfig"
 import type { StronglyTypedUIHelpers } from "../types/UIHelpers"
 import { applyModelContentFixes } from "../utils/ModelContentProcessor"
 import { ToolDisplayUtils } from "../utils/ToolDisplayUtils"
+import { ToolHookUtils } from "../utils/ToolHookUtils"
 import { ToolResultUtils } from "../utils/ToolResultUtils"
 
 export class WriteToFileToolHandler implements IFullyManagedTool {
@@ -268,6 +269,13 @@ export class WriteToFileToolHandler implements IFullyManagedTool {
 						block.isNativeToolCall,
 					)
 				}
+			}
+
+			// Run PreToolUse hook after approval
+			const shouldContinue = await ToolHookUtils.runPreToolUseIfEnabled(config, block)
+			if (!shouldContinue) {
+				await config.services.diffViewProvider.revertChanges()
+				return formatResponse.toolCancelled()
 			}
 
 			// Mark the file as edited by Cline

--- a/src/core/task/tools/handlers/WriteToFileToolHandler.ts
+++ b/src/core/task/tools/handlers/WriteToFileToolHandler.ts
@@ -170,7 +170,10 @@ export class WriteToFileToolHandler implements IFullyManagedTool {
 			if (await config.callbacks.shouldAutoApproveToolWithPath(block.name, relPath)) {
 				// Auto-approval flow
 				await config.callbacks.removeLastPartialMessageIfExistsWithType("ask", "tool")
-				await config.callbacks.say("tool", completeMessage, undefined, undefined, false)
+				const sayTs = await config.callbacks.say("tool", completeMessage, undefined, undefined, false)
+				// When completing a partial message, say() returns undefined but updates the existing message
+				// In that case, get the timestamp from the last message
+				config.taskState.currentToolAskMessageTs = sayTs ?? config.messageState.getClineMessages().at(-1)?.ts
 
 				// Capture telemetry
 				telemetryService.captureToolUsage(

--- a/src/core/task/tools/types/TaskConfig.ts
+++ b/src/core/task/tools/types/TaskConfig.ts
@@ -23,6 +23,14 @@ import type { ToolExecutorCoordinator } from "../ToolExecutorCoordinator"
 import { TASK_CALLBACKS_KEYS, TASK_CONFIG_KEYS, TASK_SERVICES_KEYS } from "../utils/ToolConstants"
 
 /**
+ * Runner for PreToolUse hook execution.
+ * Handlers should call run() after approval succeeds but before execution.
+ */
+export interface PreToolUseRunner {
+	run(): Promise<void>
+}
+
+/**
  * Strongly-typed configuration object passed to tool handlers
  */
 export interface TaskConfig {
@@ -59,6 +67,13 @@ export interface TaskConfig {
 
 	// Tool coordination
 	coordinator: ToolExecutorCoordinator
+
+	/**
+	 * Optional PreToolUse hook runner.
+	 * When present, handlers must call this after approval but before execution.
+	 * Will throw PreToolUseHookCancellationError if hook requests cancellation.
+	 */
+	preToolUseRunner?: PreToolUseRunner
 }
 
 /**

--- a/src/core/task/tools/utils/ToolHookUtils.ts
+++ b/src/core/task/tools/utils/ToolHookUtils.ts
@@ -1,0 +1,43 @@
+import type { ToolUse } from "@core/assistant-message"
+import { PreToolUseHookCancellationError } from "@core/hooks/PreToolUseHookCancellationError"
+import type { TaskConfig } from "../types/TaskConfig"
+
+/**
+ * Utility functions for tool hook execution.
+ */
+export class ToolHookUtils {
+	/**
+	 * Runs the PreToolUse hook if enabled.
+	 *
+	 * This should be called by tool handlers after approval succeeds
+	 * but before the actual tool execution begins.
+	 *
+	 * @param config Task configuration containing optional preToolUseRunner
+	 * @param block The tool use block being executed
+	 * @returns true to continue execution, false if hook cancelled
+	 *
+	 * @example
+	 * // After approval logic
+	 * const shouldContinue = await ToolHookUtils.runPreToolUseIfEnabled(config, block)
+	 * if (!shouldContinue) {
+	 *     return formatResponse.toolCancelled()
+	 * }
+	 * // Continue with execution...
+	 */
+	static async runPreToolUseIfEnabled(config: TaskConfig, block: ToolUse): Promise<boolean> {
+		if (!config.preToolUseRunner) {
+			return true // Hooks disabled, continue
+		}
+
+		try {
+			await config.preToolUseRunner.run()
+			return true // Hook succeeded, continue
+		} catch (error) {
+			if (error instanceof PreToolUseHookCancellationError) {
+				return false // Hook cancelled, stop
+			}
+			// Other errors should propagate
+			throw error
+		}
+	}
+}

--- a/src/core/task/tools/utils/ToolResultUtils.ts
+++ b/src/core/task/tools/utils/ToolResultUtils.ts
@@ -123,7 +123,9 @@ export class ToolResultUtils {
 		completeMessage: string,
 		config: TaskConfig,
 	): Promise<{ didApprove: boolean; askTs?: number }> {
-		const { response, text, images, files, askTs } = await config.callbacks.ask(type, completeMessage, false)
+		const { response, text, images, files } = await config.callbacks.ask(type, completeMessage, false)
+		// Get the timestamp from the ask message that was just created
+		const askTs = config.messageState.getClineMessages().at(-1)?.ts
 
 		if (text || (images && images.length > 0) || (files && files.length > 0)) {
 			let fileContentString = ""

--- a/src/core/task/tools/utils/ToolResultUtils.ts
+++ b/src/core/task/tools/utils/ToolResultUtils.ts
@@ -116,9 +116,14 @@ export class ToolResultUtils {
 
 	/**
 	 * Handles tool approval flow and processes any user feedback
+	 * Returns approval status and the timestamp of the tool ask message (for hook ordering)
 	 */
-	static async askApprovalAndPushFeedback(type: ClineAsk, completeMessage: string, config: TaskConfig) {
-		const { response, text, images, files } = await config.callbacks.ask(type, completeMessage, false)
+	static async askApprovalAndPushFeedback(
+		type: ClineAsk,
+		completeMessage: string,
+		config: TaskConfig,
+	): Promise<{ didApprove: boolean; askTs?: number }> {
+		const { response, text, images, files, askTs } = await config.callbacks.ask(type, completeMessage, false)
 
 		if (text || (images && images.length > 0) || (files && files.length > 0)) {
 			let fileContentString = ""
@@ -133,10 +138,10 @@ export class ToolResultUtils {
 		if (response !== "yesButtonClicked") {
 			// User pressed reject button or responded with a message, which we treat as a rejection
 			config.taskState.didRejectTool = true // Prevent further tool uses in this message
-			return false
+			return { didApprove: false, askTs }
 		} else {
 			// User hit the approve button, and may have provided feedback
-			return true
+			return { didApprove: true, askTs }
 		}
 	}
 }


### PR DESCRIPTION
### Related Issue

**Issue:** #7334

### Description

Prior to this fix, when hooks are enabled the `PreToolUse` hook is automatically running before every tool even though auto-approval of a given tool was toggled off.  This is problematic because users are expecting their tools to require approval, yet the hooks UI starts processing as though it's just about to execute things anyway.

After this fix the `PreToolUse` hook only runs after the user clicks the approve button (or as it did before if the tool's auto-approve toggle is on).

_**Note:** I also noticed that the `PreToolUse` hook UI block was rendering after the tool block, so I changed it so that the `PreToolUse` hook UI block gets inserted above the tool use in the UI._


### Test Procedure

I tested this manually by enabling hooks in Feature Settings, made sure I have a `PreToolUse` hook configured to run, and then ran the two scenarios:
* Scenario A: Auto-approve all (does not present the "Approve" button)
* Scenario B: Auto-approve none (requires user to click "Approve" in order for a tool to run)

And I observed that the UI behavior is now working as intended for both scenarios.


### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

#### Before Approval Sequence Change (hook runs before approval)
<img width="612" height="404" alt="Screenshot 2025-11-10 at 3 44 41 PM" src="https://github.com/user-attachments/assets/1db3a199-f284-43ca-afb5-265e2a642665" />
...
<img width="608" height="570" alt="Screenshot 2025-11-10 at 3 45 12 PM" src="https://github.com/user-attachments/assets/cdd0f5d7-ac86-4a73-a4e4-130ed9bfade0" />


#### After Approval Sequence Change (hook runs after approval)
<img width="618" height="331" alt="Screenshot 2025-11-10 at 3 42 14 PM" src="https://github.com/user-attachments/assets/610754ed-a9fb-44eb-a4c1-5aa521b25b06" />
...
<img width="609" height="507" alt="Screenshot 2025-11-10 at 3 42 44 PM" src="https://github.com/user-attachments/assets/d466be88-602a-4a86-a2e9-9de48509965d" />


----
#### Before UI Ordering Change
<img width="612" height="512" alt="Screenshot 2025-11-10 at 3 05 09 PM" src="https://github.com/user-attachments/assets/aa1e2b9f-90f4-463b-81ba-2d64d12ddd3e" />

#### After UI Ordering Change
<img width="614" height="543" alt="Screenshot 2025-11-10 at 2 25 59 PM" src="https://github.com/user-attachments/assets/517a251a-1cfb-4f4d-aecd-76ddc4cd589d" />



### Additional Notes

Note that this change was ~500 lines before I added tests and refactored things for qlty.  Also note that the remaining qlty failure is due to code coverage.  I will not be making this PR longer than it is now (~1,500 lines) unless a human asks me to.


<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> The PR ensures `PreToolUse` hooks execute only after tool approval, reorders UI elements, and adds utilities and tests for hook management.
> 
>   - **Behavior**:
>     - `PreToolUse` hook now runs only after tool approval in `ToolExecutor.ts` and other handlers.
>     - UI block for `PreToolUse` hook is reordered to appear before tool execution in `hook-executor.ts`.
>   - **Utilities**:
>     - Adds `ToolHookUtils` for managing hook execution in `ToolHookUtils.ts`.
>     - Adds `ToolResultUtils` for handling tool result and approval logic in `ToolResultUtils.ts`.
>   - **Testing**:
>     - Adds tests for hook execution order and state cleanup in `hooks-integration.test.ts` and `ToolExecutor-cleanup.test.ts`.
>   - **Misc**:
>     - Introduces `PreToolUseHookCancellationError` for handling hook cancellation in `PreToolUseHookCancellationError.ts`.
>     - Updates `TaskConfig` to include `preToolUseRunner` for hook management.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 40df78aa975211bc024b23718c4dd87fb23f5e31. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->