### PR TITLE
Add Remote MCP Servers Schema to the remote config

### DIFF
--- a/src/shared/remote-config/schema.ts
+++ b/src/shared/remote-config/schema.ts
@@ -113,6 +113,13 @@ export const AllowedMCPServerSchema = z.object({
 	id: z.string(),
 })
 
+export const RemoteMCPServerSchema = z.object({
+	// The name of the MCP server
+	name: z.string(),
+	// The URL of the MCP server
+	url: z.string(),
+})
+
 // Settings for a global cline rules or workflow file.
 export const GlobalInstructionsFileSchema = z.object({
 	// When this is enabled, the user cannot turn off this rule or workflow.
@@ -137,6 +144,7 @@ export const RemoteConfigSchema = z.object({
 	// MCP settings
 	mcpMarketplaceEnabled: z.boolean().optional(),
 	allowedMCPServers: z.array(AllowedMCPServerSchema).optional(),
+	remoteMCPServers: z.array(RemoteMCPServerSchema).optional(),
 
 	// If the user is allowed to enable YOLO mode. Note this is different from the extension setting
 	// yoloModeEnabled, because we do not want to force YOLO enabled for the user.
@@ -167,6 +175,7 @@ export const RemoteConfigSchema = z.object({
 // Type inference from schemas
 export type RemoteConfig = z.infer<typeof RemoteConfigSchema>
 export type MCPServer = z.infer<typeof AllowedMCPServerSchema>
+export type RemoteMCPServer = z.infer<typeof RemoteMCPServerSchema>
 export type GlobalInstructionsFile = z.infer<typeof GlobalInstructionsFileSchema>
 
 export type ProviderSettings = z.infer<typeof ProviderSettingsSchema>


### PR DESCRIPTION
### Description

This PR adds the remote MCP server schema to the remote config.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `RemoteMCPServerSchema` to `schema.ts` and update `RemoteConfigSchema` to include optional `remoteMCPServers`.
> 
>   - **Schema Changes**:
>     - Add `RemoteMCPServerSchema` to define `name` and `url` for remote MCP servers in `schema.ts`.
>     - Update `RemoteConfigSchema` to include `remoteMCPServers` as an optional array of `RemoteMCPServerSchema`.
>   - **Type Inference**:
>     - Add `RemoteMCPServer` type inferred from `RemoteMCPServerSchema`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 02b1d4eb0fb2391dd6f4bb5171b27918319f4919. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->