### PR TITLE
api config - make field mask a string array

### DIFF
--- a/proto/cline/models.proto
+++ b/proto/cline/models.proto
@@ -321,7 +321,7 @@ message UpdateApiConfigurationRequestNew {
   // - "options.openAiHeaders" (for options fields)
   // - "secrets.apiKey" (for secrets fields)
   // - "secrets.openRouterApiKey" (for secrets fields)
-  google.protobuf.FieldMask update_mask = 3;
+  repeated string update_mask = 3;
 }
 
 // Request for partially updating API configuration using FieldMask


### PR DESCRIPTION


### Description

### Problem

The `UpdateApiConfigurationRequest` RPC was failing in the IntelliJ plugin due to a field name mismatch. The frontend was sending field masks with camelCase field names (e.g., `["secrets.liteLlmApiKey"]`), but the backend was receiving them in snake_case (e.g., `["secrets.lite_llm_api_key"]`). This caused lookups to fail since the actual TypeScript object keys use camelCase.

### Root Cause

The issue stemmed from how different protobuf libraries handle `google.protobuf.FieldMask` during JSON serialization:

- __ts-proto__ (used in the webview): Treats FieldMask as a plain string array, preserving field names as-is
- __protobuf-java__ (used in IntelliJ plugin): Applies the protobuf JSON spec strictly, which mandates converting field names in FieldMask paths to snake_case to match the proto definition

When requests from the IntelliJ plugin were serialized via `JsonFormat.printer()`, the field mask paths were automatically converted from camelCase to snake_case, breaking compatibility with the backend's camelCase object keys.

### Solution

Changed the `update_mask` field from `google.protobuf.FieldMask` to `repeated string` in the proto definition. This eliminates the special handling and preserves field names exactly as provided by the frontend, ensuring consistency across both VS Code and IntelliJ.

Since ts-proto doesn't provide any FieldMask utilities anyway (no runtime validation or helper methods), using a plain string array is more pragmatic and avoids cross-library serialization inconsistencies.


### Test Procedure

Test that updates in the LiteLlm provider, which is using the new updateApiConfiguration RPC, work correctly in Jetbrains.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Changed `update_mask` in `UpdateApiConfigurationRequestNew` to `repeated string` to fix serialization issues between `ts-proto` and `protobuf-java`.
> 
>   - **Behavior**:
>     - Changed `update_mask` field in `UpdateApiConfigurationRequestNew` from `google.protobuf.FieldMask` to `repeated string` in `models.proto`.
>     - Ensures field names are preserved as camelCase, fixing serialization issues between `ts-proto` and `protobuf-java`.
>   - **Root Cause**:
>     - `ts-proto` treats `FieldMask` as a string array, while `protobuf-java` converts to snake_case, causing mismatches.
>   - **Solution**:
>     - Using `repeated string` avoids cross-library serialization inconsistencies.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for a689698b614d97635c302812701f9d342fdbaa78. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->