### PR TITLE
fix: Handle tool_use blocks in Claude Code backward compatibility path

### DIFF
--- a/src/core/api/providers/claude-code.ts
+++ b/src/core/api/providers/claude-code.ts
@@ -113,7 +113,18 @@ export class ClaudeCodeHandler implements ApiHandler {
 							}
 							break
 						case "tool_use":
-							console.error(`tool_use is not supported yet. Received: ${JSON.stringify(content)}`)
+							// Yield tool_use blocks to the streaming pipeline for proper tool execution
+							yield {
+								type: "tool_calls",
+								tool_call: {
+									call_id: content.id,
+									function: {
+										id: content.id,
+										name: content.name,
+										arguments: content.input,
+									},
+								},
+							}
 							break
 					}
 				}


### PR DESCRIPTION
### Related Issue

**Issue:** #7393
<!-- You'll need to create a bug report issue first or reference an existing one -->

### Description

**Problem:**
The Claude Code API provider's backward compatibility path was not handling `tool_use` content blocks, causing interactive tools to fail completely. When the AI attempted to use tools like `ask_followup_question`, `attempt_completion`, or MCP tools, the provider would log "tool_use is not supported yet" and break without yielding the tool call to the streaming pipeline.

This resulted in:
- Console errors: `tool_use is not supported yet`
- Task execution failures: `Error: Current ask promise was ignored` (Task.ask line 666)
- Complete inability to use interactive features with Claude Code provider

**Root Cause:**
In `src/core/api/providers/claude-code.ts` (lines 115-117), the `tool_use` case handler only logged an error and broke without yielding anything to the streaming pipeline.

**Solution:**
Modified the handler to transform Anthropic's `tool_use` format into the streaming system's expected `ApiStreamToolCallsChunk` format, properly mapping:
- `content.id` → `call_id` and `function.id`
- `content.name` → `function.name`
- `content.input` → `function.arguments`

**Note:** The modern path (with `--include-partial-messages` flag) already handles tool_use correctly. This fix specifically addresses the backward compatibility path.

### Test Procedure

**Testing approach:**
1. Verified TypeScript compilation passes with no type errors related to changes
2. Confirmed the yielded structure conforms to `ApiStreamToolCallsChunk` interface defined in `src/core/api/transform/stream.ts`
3. Tested the change maintains consistency with how other content types (text, reasoning) are handled in the same switch statement

**What could potentially break:**
- Tool execution flow if the streaming pipeline expects a different format
- Checked: The `ApiStreamToolCallsChunk` interface explicitly defines this exact structure, so the format is correct

**Existing functionality affected:**
- All Claude Code tool executions in backward compatibility mode
- Verified: The change only adds missing functionality (was throwing error before), doesn't modify existing working paths
- Modern path (with `--include-partial-messages`) is unaffected and continues to work as before

**Confidence:**
High confidence - this is a straightforward transformation from Anthropic's API format to Cline's internal streaming format. The implementation follows the same pattern as other content type handlers in the file and uses the exact type structure defined in the streaming interface.

**Recommended live testing:**
1. Configure Claude Code as provider
2. Trigger `ask_followup_question` tool (e.g., ask AI to make a choice)
3. Verify no "tool_use is not supported yet" errors
4. Confirm user prompts appear correctly
5. Test other interactive tools (`attempt_completion`, MCP tools)

### Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ♻️ Refactor Changes
- [ ] 💅 Cosmetic Changes
- [ ] 📚 Documentation update
- [ ] 🏃 Workflow Changes

### Pre-flight Checklist

- [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
- [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
  - Note: Basic TypeScript validation passes, full test suite recommended before merge
- [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
  - Note: This needs to be run before merging
- [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Not applicable - this is a backend fix with no UI changes. The fix enables interactive tool functionality that was previously throwing errors in the console.

### Additional Notes

**Files changed:** 1 file, 12 insertions, 1 deletion
- `src/core/api/providers/claude-code.ts`

**Backward compatibility:** This fix only affects the backward compatibility code path and adds missing functionality without changing existing behavior. The modern path continues to work unchanged.

**Testing priority:** High - this affects core tool execution functionality for Claude Code users.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes `tool_use` block handling in `ClaudeCodeHandler` for backward compatibility by transforming to `ApiStreamToolCallsChunk` format.
> 
>   - **Behavior**:
>     - Fixes handling of `tool_use` blocks in `ClaudeCodeHandler` in `claude-code.ts` for backward compatibility.
>     - Transforms `tool_use` content to `ApiStreamToolCallsChunk` format, mapping `content.id` to `call_id` and `function.id`, `content.name` to `function.name`, and `content.input` to `function.arguments`.
>   - **Testing**:
>     - Verified TypeScript compilation and structure conformity to `ApiStreamToolCallsChunk`.
>     - Ensured consistency with other content type handlers in the switch statement.
>   - **Misc**:
>     - Affects backward compatibility path only; modern path remains unchanged.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 366205171c67224b598b0d61e21c855061d4334e. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->