### PR TITLE
fix(anthropic): sanitize messages to SDK MessageParam shape

### DIFF
--- a/src/core/api/transform/anthropic-format.ts
+++ b/src/core/api/transform/anthropic-format.ts
@@ -1,3 +1,4 @@
+import Anthropic from "@anthropic-ai/sdk"
 import { ClineStorageMessage } from "@/shared/messages/content"
 
 /**
@@ -8,11 +9,11 @@ export function sanitizeAnthropicMessages(
 	messages: Array<ClineStorageMessage>,
 	lastUserMsgIndex?: number,
 	secondLastMsgUserIndex?: number,
-): Array<ClineStorageMessage> {
+): Array<Anthropic.Messages.MessageParam> {
 	return messages.map((_message, index) => {
-		const message = removeReasoningDetails(_message)
+		const message = removeUnknownParams(_message)
 		const addCacheControl = lastUserMsgIndex !== undefined && secondLastMsgUserIndex !== undefined
-
+		// Construct message
 		if (addCacheControl && (index === lastUserMsgIndex || index === secondLastMsgUserIndex)) {
 			return {
 				...message,
@@ -56,22 +57,20 @@ export function sanitizeAnthropicMessages(
 }
 
 /**
- * Remove reasoning details from a single Anthropic message parameter
+ * Remove reasoning details and other known params that are not Anthropic specific.
  */
-function removeReasoningDetails(param: ClineStorageMessage): ClineStorageMessage {
-	if (Array.isArray(param.content)) {
-		return {
-			...param,
-			content: param.content.map((item) => {
-				if (item.type === "text") {
+function removeUnknownParams(param: ClineStorageMessage): Anthropic.Messages.MessageParam {
+	// Construct new content array with known Anthropic content blocks only.
+	return {
+		role: param.role === "user" ? "user" : "assistant",
+		content: Array.isArray(param.content)
+			? param.content.map((item) => {
 					return {
 						...item,
+						// Ensure reasoning_details is removed
 						reasoning_details: undefined,
 					}
-				}
-				return item
-			}),
-		}
+				})
+			: param.content, // String content remains unchanged
 	}
-	return param
 }


### PR DESCRIPTION
<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- For feature requests: Created a discussion in our Feature Requests discussions board https://github.com/cline/cline/discussions/categories/feature-requests and received approval from core maintainers before implementation
- For all changes: Link the associated issue/discussion in the "Related Issue" section below

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly without prior discussion.

Why this requirement?
We deeply appreciate all community contributions - they are essential to Cline's success! To ensure the best use of everyone's time and maintain project direction, we use our Feature Requests discussions board to gauge community interest and validate feature ideas before implementation begins. This helps us focus development efforts on features that will benefit the most users.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** #XXXX

### Description

<!-- 
Help reviewers understand your changes by making this PR readable and well-organized:

- What problem does this PR solve?
- Why were these changes introduced and what purpose do they serve?
- For larger changes, provide context about your approach and reasoning

Small PRs may need minimal description, but larger changes benefit from explaining where you're coming from. Much of this context can be in the linked issue above, so feel free to reference it rather than repeating everything here.
-->

- Use Anthropic SDK types and return Array<Messages.MessageParam>
- Replace removeReasoningDetails with removeUnknownParams
- Strip unsupported fields (e.g., reasoning_details) and normalize role
- Keep string content unchanged; map array content to known blocks
- Continue adding ephemeral cache_control to targeted user messages

This ensures only Anthropic-supported fields are sent, improving type safety and preventing API errors.

### Test Procedure

<!-- 
Please walk us through your testing approach and thought process. This helps reviewers understand that you've thoroughly considered the impact of your changes:

- How did you test this change?
- What could potentially break and how did you verify it doesn't?
- What existing functionality might be affected and how did you check it still works?
- Why are you confident this is ready for merge?

We're not looking for exhaustive documentation - just evidence that you've thought through the implications of your changes and tested accordingly.
-->

No error when using Cline, Anthropic, OpenAi provider etc

<img width="655" height="1086" alt="image" src="https://github.com/user-attachments/assets/2e4b7476-bb3c-4707-b481-ae571c74c327" />

Switched to OpenRouter for follow-up and confirmed the message sharp works across providers:

<img width="643" height="1077" alt="image" src="https://github.com/user-attachments/assets/bd10f2da-5ae4-41a8-924b-29850c95b583" />

<img width="649" height="1090" alt="image" src="https://github.com/user-attachments/assets/d731a0dd-ffd8-4064-bfa0-61b3c18378f1" />


### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Sanitizes messages to conform to Anthropic SDK `MessageParam` type by removing unsupported fields and normalizing roles in `anthropic-format.ts`.
> 
>   - **Behavior**:
>     - `sanitizeAnthropicMessages()` in `anthropic-format.ts` now returns `Array<Anthropic.Messages.MessageParam>`.
>     - Replaces `removeReasoningDetails` with `removeUnknownParams` to strip unsupported fields and normalize roles.
>     - Adds ephemeral `cache_control` to last two user messages if indices are provided.
>   - **Functions**:
>     - `removeUnknownParams()` removes `reasoning_details` and normalizes content to known Anthropic blocks.
>   - **Misc**:
>     - Imports `Anthropic` from `@anthropic-ai/sdk` in `anthropic-format.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 8ac4092707ecf6434abc2c3985e03a2cb3a070b8. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->