### PR TITLE
Fix CLI auth state persistence with explicit flush mechanism

### DIFF
--- a/cli/pkg/cli/auth/byo_quick_setup.go
+++ b/cli/pkg/cli/auth/byo_quick_setup.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"strings"
-	"time"
 
 	"github.com/cline/cli/pkg/cli/global"
 	"github.com/cline/cli/pkg/cli/task"
@@ -76,10 +75,11 @@ func QuickSetupFromFlags(ctx context.Context, provider, apiKey, modelID, baseURL
 		}
 	}
 
-	// WORKAROUND: Wait for debounced state persistence to complete
-	// Fixes `cline auth` issue when ran in docker environments
-	// TODO: implement better solution w/ changes in StateManager
-	time.Sleep(600 * time.Millisecond)
+	// Flush pending state changes to disk immediately
+	// This ensures all configuration changes are persisted before the instance terminates
+	if _, err := manager.GetClient().State.FlushPendingState(ctx, &cline.EmptyRequest{}); err != nil {
+		return fmt.Errorf("failed to flush pending state: %w", err)
+	}
 
 	// Success message
 	fmt.Printf("\n✓ Successfully configured %s provider\n", GetProviderDisplayName(providerEnum))

--- a/proto/cline/state.proto
+++ b/proto/cline/state.proto
@@ -31,6 +31,7 @@ service StateService {
   rpc installClineCli(EmptyRequest) returns (Empty);
   rpc checkCliInstallation(EmptyRequest) returns (Boolean);
   rpc getProcessInfo(EmptyRequest) returns (ProcessInfo);
+  rpc flushPendingState(EmptyRequest) returns (Empty);
 }
 
 message AutoApprovalActions {

--- a/src/core/controller/state/flushPendingState.ts
+++ b/src/core/controller/state/flushPendingState.ts
@@ -1,0 +1,17 @@
+import type { EmptyRequest } from "@shared/proto/cline/common"
+import { Empty } from "@shared/proto/cline/common"
+import type { Controller } from "../index"
+
+/**
+ * Flush all pending state changes immediately to disk
+ * Bypasses the debounced persistence and forces immediate writes
+ */
+export async function flushPendingState(controller: Controller, request: EmptyRequest): Promise<Empty> {
+	try {
+		await controller.stateManager.flushPendingState()
+		return Empty.create({})
+	} catch (error) {
+		console.error("[flushPendingState] Error flushing pending state:", error)
+		throw error
+	}
+}


### PR DESCRIPTION


### Description

Fixes CLI auth bug where `cline auth` configuration was lost due to race condition between StateManager's 500ms debounced persistence and CLI process termination.

Implemented explicit `flushPendingState()` mechanism that forces immediate write before termination. Replaces sleep workaround.

### Test Procedure

1. `rm -rf ~/.cline`
2. `cline auth -v --provider openrouter --apikey <key> --modelid <model>`
3. Verified `globalState.json` and `secrets.json` contain correct values
4. Confirmed `cline start` bypasses wizard

Result: All state persists correctly.

### Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ♻️ Refactor Changes

### Pre-flight Checklist

- [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
- [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
- [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
- [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)
