### PR TITLE
fix(hooks): Reorder the UI elements so that `PreToolUse` appears above tool

### DIFF
--- a/src/core/hooks/hook-executor.ts
+++ b/src/core/hooks/hook-executor.ts
@@ -236,7 +236,7 @@ async function updateHookMessage(
  * This is called immediately after a hook message is created.
  *
  * The algorithm:
- * 1. Find the most recent tool message (ask or say with type "tool")
+ * 1. Find the most recent tool message (ask or say with type "tool", "command", "use_mcp_server", or "browser_action_launch")
  * 2. Find any hook messages that came after it
  * 3. Delete the tool message
  * 4. Re-add the tool message at the end (after hook messages)
@@ -244,8 +244,18 @@ async function updateHookMessage(
 async function reorderHookAndToolMessages(messageStateHandler: MessageStateHandler): Promise<void> {
 	const clineMessages = messageStateHandler.getClineMessages()
 
+	// Define all message types that represent tool executions with PreToolUse hooks
+	const toolMessageTypes = ["tool", "command", "use_mcp_server", "browser_action_launch"]
+
 	// Find the most recent tool message
-	const lastToolMessageIndex = clineMessages.map((m) => m.ask || m.say).lastIndexOf("tool")
+	let lastToolMessageIndex = -1
+	for (let i = clineMessages.length - 1; i >= 0; i--) {
+		const msgType = clineMessages[i].ask || clineMessages[i].say
+		if (msgType && toolMessageTypes.includes(msgType)) {
+			lastToolMessageIndex = i
+			break
+		}
+	}
 
 	if (lastToolMessageIndex === -1) {
 		return // No tool message found, nothing to reorder

--- a/src/shared/combineHookSequences.ts
+++ b/src/shared/combineHookSequences.ts
@@ -185,10 +185,10 @@ function findImmediateNextToolTimestamp(hookIndex: number, messages: ClineMessag
  * This map indicates which hooks should be moved to appear before which tools.
  * Only PreToolUse hooks are included; PostToolUse hooks stay in their original position.
  *
- * Key insight: A PreToolUse hook should only be mapped to a tool if the hook was
- * created AFTER the tool already exists in the message stream. This can happen when
- * hooks arrive late or out of order. If the hook timestamp < tool timestamp, it means
- * the hook naturally appears before the tool chronologically and should NOT be moved.
+ * A PreToolUse hook should only be mapped to a tool if the hook was created AFTER the
+ * tool already exists in the message stream. This can happen when hooks arrive late
+ * or out of order. If the hook timestamp < tool timestamp, it means the hook
+ * naturally appears before the tool chronologically and should NOT be moved.
  *
  * @param processedMessages Messages after filtering and combining
  * @param originalMessages Original messages array (used to find tools)


### PR DESCRIPTION
### Related Issue

**Issue:** n/a

### Description

This PR reorders the `PreToolUse` hook UI block to appear above the "Cline wants to" tool use message in the webview.  See screenshots for a visual explanation of how this improves the user experience in the extension.


### Test Procedure

I tested this manually by enabling hooks and configuring a `PreToolUse` hook and then I ran a simple task to verify that the ordering changes to what we want it to be.  Ran this against `main` branch for the "before" and then ran this against this PR branch for the "after".

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

#### Before
<img width="699" height="372" alt="Screenshot 2025-11-13 at 3 50 49 PM" src="https://github.com/user-attachments/assets/0bb0d247-f239-4edf-a9ea-4a7e84e0db6d" />


#### After
<img width="517" height="381" alt="Screenshot 2025-11-13 at 3 47 29 PM" src="https://github.com/user-attachments/assets/26cbc5c6-b373-4752-a46e-ec2c9c1051e2" />


### Additional Notes

Thank you for talking about this yesterday and coming up with a simpler solution than the direction I'd gone down, @abeatrix!  That was very helpful.