### PR TITLE
fix(hooks): Prevent `PreToolUse` hook from running before `attempt_completion` tool

### DIFF
--- a/src/core/task/tools/handlers/AttemptCompletionHandler.ts
+++ b/src/core/task/tools/handlers/AttemptCompletionHandler.ts
@@ -93,7 +93,7 @@ export class AttemptCompletionHandler implements IToolHandler, IPartialBlockHand
 		}
 
 		// Remove any partial completion_result message that may exist
-		// PreToolUse hook inserts messages after the partial, so we need to search backwards to find it
+		// Search backwards since other messages may have been inserted after the partial
 		const clineMessages = config.messageState.getClineMessages()
 		const partialCompletionIndex = findLastIndex(
 			clineMessages,

--- a/src/core/task/tools/utils/ToolHookUtils.ts
+++ b/src/core/task/tools/utils/ToolHookUtils.ts
@@ -25,6 +25,10 @@ export class ToolHookUtils {
 			return true // Hooks disabled, continue execution
 		}
 
+		if (block.name == "attempt_completion") {
+			return true // Skip this hook
+		}
+
 		// Import the hook executor dynamically
 		const { executeHook } = await import("@core/hooks/hook-executor")
 


### PR DESCRIPTION

### Related Issue

**Issue:** n/a

### Description

It seems unnecessary to run the `PreToolUse` hook before the `attempt_completion` tool.  This is an internal tool, not something that end-users should need to hook into.  Preventing the `PreToolUse` hook from running in this scenario simplifies some quirky behavior and improves the user experience of the hooks functionality.

This is a simple one.


### Test Procedure

I simply ran through a task with hooks enabled in Feature Settings and a `PreToolUse` hook configured.  I observed that prior to this change the `PreToolUse` hook runs for `attempt_completion` as a task is completing; after this change the hook doesn't run for `attempt_completion`.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

#### Before
<img width="613" height="665" alt="Screenshot 2025-11-13 at 3 38 49 PM" src="https://github.com/user-attachments/assets/29b99471-c47a-4f8d-b118-a97bb95e06ed" />


#### After
<img width="615" height="558" alt="Screenshot 2025-11-13 at 3 37 07 PM" src="https://github.com/user-attachments/assets/9deb700e-f044-417f-a223-250b42db466b" />



### Additional Notes

n/a
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Prevents `PreToolUse` hook from executing for `attempt_completion` tool to simplify behavior.
> 
>   - **Behavior**:
>     - Prevents `PreToolUse` hook from running for `attempt_completion` tool in `ToolHookUtils.ts`.
>     - Simplifies behavior by skipping hook execution for internal tool.
>   - **Code Changes**:
>     - Adds condition in `runPreToolUseIfEnabled()` to return early if `block.name` is `attempt_completion`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for fd578cbe04c9b3eace70d16616ffe871a3558c23. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->