### PR TITLE
chore:  Reduce frontend Modules

### DIFF
--- a/webview-ui/package-lock.json
+++ b/webview-ui/package-lock.json
@@ -9,6 +9,7 @@
 			"version": "0.3.0",
 			"dependencies": {
 				"@floating-ui/react": "^0.27.4",
+				"@fontsource/azeret-mono": "^5.2.11",
 				"@heroui/react": "^2.8.0-beta.2",
 				"@paper-design/shaders-react": "^0.0.46",
 				"@radix-ui/react-hover-card": "^1.1.15",
@@ -1107,6 +1108,14 @@
 			"resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz",
 			"integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
 			"license": "MIT"
+		},
+		"node_modules/@fontsource/azeret-mono": {
+			"version": "5.2.11",
+			"resolved": "https://registry.npmjs.org/@fontsource/azeret-mono/-/azeret-mono-5.2.11.tgz",
+			"integrity": "sha512-DlufUsIj1AK6Z/26X/1bZj4SFsfuE6Cb1wYToGX3HoxTYrNzN0TUQ3Yv8bJ3kmvO3vOTCgOjFV81OJe2FERrUg==",
+			"funding": {
+				"url": "https://github.com/sponsors/ayuhito"
+			}
 		},
 		"node_modules/@formatjs/ecma402-abstract": {
 			"version": "2.3.4",

--- a/webview-ui/package.json
+++ b/webview-ui/package.json
@@ -17,6 +17,7 @@
 	},
 	"dependencies": {
 		"@floating-ui/react": "^0.27.4",
+		"@fontsource/azeret-mono": "^5.2.11",
 		"@heroui/react": "^2.8.0-beta.2",
 		"@paper-design/shaders-react": "^0.0.46",
 		"@radix-ui/react-hover-card": "^1.1.15",


### PR DESCRIPTION
### Related Issue

None.

### Description

#### npx knip

I will not delete the `uuid` module as it was actually in use.

```bash
Unused dependencies (3)
@fontsource/azeret-mono  package.json:20:4
firebase                 package.json:35:4
uuid                     package.json:57:4
```

##### before

```bash
du -sh node_modules/
734M    node_modules/
```

##### after
```bash
du -sh node_modules/
583M    node_modules/
```

### Test Procedure

None.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots


### Additional Notes



<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove unused dependencies `@fontsource/azeret-mono` and `firebase` from `package.json`, reducing `node_modules` size.
> 
>   - **Dependencies**:
>     - Removed `@fontsource/azeret-mono` and `firebase` from `dependencies` in `package.json`.
>     - Retained `uuid` as it is in use.
>   - **Size Reduction**:
>     - Reduced `node_modules` size from 734M to 583M.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for a297baf306273dccf755711d49d671611a45aea2. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->