### PR TITLE
wip: focus diff preview for write-to-file changes

### DIFF
--- a/src/core/task/tools/handlers/WriteToFileToolHandler.ts
+++ b/src/core/task/tools/handlers/WriteToFileToolHandler.ts
@@ -16,6 +16,7 @@ import type { IFullyManagedTool } from "../ToolExecutorCoordinator"
 import type { ToolValidator } from "../ToolValidator"
 import type { TaskConfig } from "../types/TaskConfig"
 import type { StronglyTypedUIHelpers } from "../types/UIHelpers"
+import { DiffUtils } from "../utils/DiffUtils"
 import { applyModelContentFixes } from "../utils/ModelContentProcessor"
 import { ToolDisplayUtils } from "../utils/ToolDisplayUtils"
 import { ToolResultUtils } from "../utils/ToolResultUtils"
@@ -52,13 +53,20 @@ export class WriteToFileToolHandler implements IFullyManagedTool {
 			const { relPath, absolutePath, fileExists, diff, content, newContent } = result
 
 			// Create and show partial UI message
+			// Create focused diff for the preview
+			const focusedDiff = DiffUtils.createFocusedDiff(
+				relPath,
+				config.services.diffViewProvider.originalContent || "",
+				newContent,
+			)
+
 			const sharedMessageProps: ClineSayTool = {
 				tool: fileExists ? "editedExistingFile" : "newFileCreated",
 				path: getReadablePath(
 					config.cwd,
 					uiHelpers.removeClosingTag(block, block.params.path ? "path" : "absolutePath", relPath),
 				),
-				content: diff || content,
+				content: focusedDiff || diff || content,
 				operationIsLocatedInWorkspace: await isLocatedInWorkspace(relPath),
 			}
 			const partialMessage = JSON.stringify(sharedMessageProps)
@@ -133,11 +141,18 @@ export class WriteToFileToolHandler implements IFullyManagedTool {
 
 			const { relPath, absolutePath, fileExists, diff, content, newContent, workspaceContext } = result
 
+			// Create focused diff for the preview
+			const focusedDiff = DiffUtils.createFocusedDiff(
+				relPath,
+				config.services.diffViewProvider.originalContent || "",
+				newContent,
+			)
+
 			// Handle approval flow
 			const sharedMessageProps: ClineSayTool = {
 				tool: fileExists ? "editedExistingFile" : "newFileCreated",
 				path: getReadablePath(config.cwd, relPath),
-				content: diff || content,
+				content: focusedDiff || diff || content,
 				operationIsLocatedInWorkspace: await isLocatedInWorkspace(relPath),
 			}
 			// if isEditingFile false, that means we have the full contents of the file already.

--- a/src/core/task/tools/utils/DiffUtils.ts
+++ b/src/core/task/tools/utils/DiffUtils.ts
@@ -1,0 +1,100 @@
+import * as diff from "diff"
+
+export class DiffUtils {
+	/**
+	 * Creates a focused diff showing the changes with context
+	 * @param filename Name of the file being modified
+	 * @param oldContent Original content of the file
+	 * @param newContent New content after changes
+	 * @param contextLines Number of lines of context to show before and after changes (default: 5)
+	 * @returns Formatted diff string with context
+	 */
+	static createFocusedDiff(
+		filename: string,
+		oldContent: string = "",
+		newContent: string = "",
+		contextLines: number = 5,
+	): string {
+		const changes = diff.diffLines(oldContent, newContent, { newlineIsToken: true })
+
+		let result = `--- ${filename}\n+++ ${filename}\n`
+		let currentLine = 1
+		let inChangeBlock = false
+		let contextBuffer: string[] = []
+		let changeLines: string[] = []
+
+		const flushContextBuffer = () => {
+			if (contextBuffer.length > 0) {
+				result += contextBuffer.join("\n") + "\n"
+				contextBuffer = []
+			}
+		}
+
+		const addContextSeparator = () => {
+			if (result && !result.endsWith("...\n")) {
+				result += "...\n"
+			}
+		}
+
+		for (const part of changes) {
+			const lines = part.value.split("\n")
+			// Remove empty string that split adds when there's a trailing newline
+			if (lines[lines.length - 1] === "") {
+				lines.pop()
+			}
+
+			if (part.added || part.removed) {
+				if (!inChangeBlock) {
+					inChangeBlock = true
+					// Add context before the change
+					flushContextBuffer()
+					addContextSeparator()
+				}
+
+				const prefix = part.added ? "+" : "-"
+				changeLines.push(...lines.map((line) => (line ? `${prefix} ${line}` : prefix)))
+			} else {
+				if (inChangeBlock) {
+					// We're transitioning from changed lines to unchanged lines
+					inChangeBlock = false
+
+					// Add the changed lines
+					result += changeLines.join("\n") + "\n"
+					changeLines = []
+
+					// Add context after the change
+					const contextAfter = lines.slice(0, contextLines)
+					if (contextAfter.length > 0) {
+						result += contextAfter.map((line) => `  ${line}`).join("\n") + "\n"
+					}
+					if (lines.length > contextLines) {
+						result += "...\n"
+					}
+				} else {
+					// We're in an unchanged section, buffer the context
+					if (contextBuffer.length < contextLines) {
+						// Add to buffer if we're still collecting context
+						contextBuffer.push(...lines.map((line) => `  ${line}`))
+						// Keep only the last contextLines
+						if (contextBuffer.length > contextLines) {
+							contextBuffer = contextBuffer.slice(-contextLines)
+							if (contextBuffer[0] !== "...\n") {
+								contextBuffer.unshift("...\n")
+							}
+						}
+					}
+				}
+				currentLine += lines.length
+			}
+		}
+
+		// Handle any remaining changed lines at the end
+		if (changeLines.length > 0) {
+			flushContextBuffer()
+			addContextSeparator()
+			result += changeLines.join("\n") + "\n"
+		}
+
+		return result
+	}
+}


### PR DESCRIPTION
- Add DiffUtils.createFocusedDiff to generate context-aware diffs (default 5 lines)
- Use focused diff in WriteToFileToolHandler partial and approval messages using diffViewProvider.originalContent + newContent
- Fall back to existing diff/content when focused diff is unavailable

This improves readability of change previews, reduces noise on large files, and provides clearer context around edits without overwhelming the UI.

<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- For feature requests: Created a discussion in our Feature Requests discussions board https://github.com/cline/cline/discussions/categories/feature-requests and received approval from core maintainers before implementation
- For all changes: Link the associated issue/discussion in the "Related Issue" section below

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly without prior discussion.

Why this requirement?
We deeply appreciate all community contributions - they are essential to Cline's success! To ensure the best use of everyone's time and maintain project direction, we use our Feature Requests discussions board to gauge community interest and validate feature ideas before implementation begins. This helps us focus development efforts on features that will benefit the most users.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** #XXXX

### Description

<!-- 
Help reviewers understand your changes by making this PR readable and well-organized:

- What problem does this PR solve?
- Why were these changes introduced and what purpose do they serve?
- For larger changes, provide context about your approach and reasoning

Small PRs may need minimal description, but larger changes benefit from explaining where you're coming from. Much of this context can be in the linked issue above, so feel free to reference it rather than repeating everything here.
-->

### Test Procedure

<!-- 
Please walk us through your testing approach and thought process. This helps reviewers understand that you've thoroughly considered the impact of your changes:

- How did you test this change?
- What could potentially break and how did you verify it doesn't?
- What existing functionality might be affected and how did you check it still works?
- Why are you confident this is ready for merge?

We're not looking for exhaustive documentation - just evidence that you've thought through the implications of your changes and tested accordingly.
-->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [ ] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->
