### PR TITLE
fix(hooks): Honor `"cancel": true` in hook JSON output

### DIFF
--- a/src/core/task/ToolExecutor.ts
+++ b/src/core/task/ToolExecutor.ts
@@ -113,6 +113,7 @@ export class ToolExecutor {
 		private doesLatestTaskCompletionHaveNewChanges: () => Promise<boolean>,
 		private updateFCListFromToolResponse: (taskProgress: string | undefined) => Promise<void>,
 		private switchToActMode: () => Promise<boolean>,
+		private cancelTask: () => Promise<void>,
 
 		// Atomic hook state helpers from Task
 		private setActiveHookExecution: (hookExecution: NonNullable<typeof taskState.activeHookExecution>) => Promise<void>,
@@ -163,7 +164,7 @@ export class ToolExecutor {
 				saveCheckpoint: this.saveCheckpoint,
 				postStateToWebview: async () => {},
 				reinitExistingTaskFromId: async () => {},
-				cancelTask: async () => {},
+				cancelTask: this.cancelTask,
 				updateTaskHistory: async (_: any) => [],
 				executeCommandTool: this.executeCommandTool,
 				doesLatestTaskCompletionHaveNewChanges: this.doesLatestTaskCompletionHaveNewChanges,

--- a/src/core/task/tools/utils/ToolHookUtils.ts
+++ b/src/core/task/tools/utils/ToolHookUtils.ts
@@ -89,6 +89,12 @@ export class ToolHookUtils {
 
 		// Handle cancellation from hook
 		if (preToolResult.cancel === true) {
+			// Clear the active hook execution state BEFORE calling cancelTask
+			// This prevents abortTask from trying to "cancel" an already-completed hook
+			await config.callbacks.clearActiveHookExecution()
+
+			// Abort the entire task (consistent with PostToolUse and other hook cancellations)
+			await config.callbacks.cancelTask()
 			throw new PreToolUseHookCancellationError(preToolResult.errorMessage || "PreToolUse hook requested cancellation")
 		}
 


### PR DESCRIPTION
### Related Issue

**Issue:** n/a

### Description

This is a quick win fix focused on one small subset of the cancellation behavior.  This came up in a demo yesterday, so it's important to fix this as quickly as possible and worry about other cancel behavior nuances in future PRs.

This PR focuses on honoring the `"cancel": true` returned by hooks in their JSON output in order to abort/cancel the task, ready to be resumed by the user.  Prior to this fix, returning `"cancel": true` would not prevent the task from continuing.  After this fix the cancel works successfully to halt the task.


### Test Procedure

I enabled hooks in the Feature Settings and configured various hooks to return `"cancel": true` and then triggered the different hooks to run by running a task.  I observed that the task successfully picks up the cancellation and halts progress.

_**Note:** I've created the [hooks-demo](https://github.com/cline/hooks-demo) repo to help with manually testing hooks functionality.  Feel free to use it._


### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

#### Before
The task keeps executing despite `"cancel": true` returned by the hook.
<img width="606" height="800" alt="Screenshot 2025-11-14 at 3 59 10 PM" src="https://github.com/user-attachments/assets/c7ee3497-60e1-46c1-8708-80fbefd022e8" />


#### After
Hook returning `"cancel": true` successfully halts the task.
<img width="608" height="803" alt="Screenshot 2025-11-14 at 3 55 29 PM" src="https://github.com/user-attachments/assets/bce90f65-faca-4920-92a6-9ce8ed575d58" />


### Additional Notes

n/a

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes bug to honor `"cancel": true` in hook JSON output, ensuring tasks are aborted in `ToolExecutor` and `Task` classes.
> 
>   - **Behavior**:
>     - Honor `"cancel": true` in hook JSON output to abort tasks in `ToolExecutor` and `Task` classes.
>     - Unified cancellation handling in `handleHookCancellation()` in `index.ts`.
>   - **Functions**:
>     - `handleHookCancellation()` in `index.ts` ensures state is saved before aborting.
>     - `runUserPromptSubmitHook()` and `runPostToolUseHook()` updated to handle cancellation.
>   - **Utils**:
>     - `ToolHookUtils.runPreToolUseIfEnabled()` updated to handle pre-tool use hook cancellations.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for f5ff5524d89179ecabd5cb275368577a5902392d. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->