### PR TITLE
feat(hooks): Implement `TaskComplete` hook

### DIFF
--- a/src/core/hooks/__tests__/fixtures/hooks/taskcomplete/context-injection/TaskComplete
+++ b/src/core/hooks/__tests__/fixtures/hooks/taskcomplete/context-injection/TaskComplete
@@ -1,0 +1,7 @@
+#!/usr/bin/env node
+const input = JSON.parse(require('fs').readFileSync(0, 'utf-8'));
+console.log(JSON.stringify({
+  cancel: false,
+  contextModification: "COMPLETED: " + input.taskComplete.taskMetadata.result,
+  errorMessage: ""
+}));

--- a/src/core/hooks/__tests__/fixtures/hooks/taskcomplete/error/TaskComplete
+++ b/src/core/hooks/__tests__/fixtures/hooks/taskcomplete/error/TaskComplete
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+console.error("Hook execution error");
+process.exit(1);

--- a/src/core/hooks/__tests__/fixtures/hooks/taskcomplete/success/TaskComplete
+++ b/src/core/hooks/__tests__/fixtures/hooks/taskcomplete/success/TaskComplete
@@ -1,0 +1,6 @@
+#!/usr/bin/env node
+console.log(JSON.stringify({
+  cancel: false,
+  contextModification: "TaskComplete hook executed successfully",
+  errorMessage: ""
+}));

--- a/src/core/hooks/__tests__/taskcomplete.test.ts
+++ b/src/core/hooks/__tests__/taskcomplete.test.ts
@@ -1,0 +1,540 @@
+import { afterEach, beforeEach, describe, it } from "mocha"
+import "should"
+import fs from "fs/promises"
+import os from "os"
+import path from "path"
+import sinon from "sinon"
+import { StateManager } from "../../storage/StateManager"
+import { HookFactory } from "../hook-factory"
+import { loadFixture } from "./test-utils"
+
+describe("TaskComplete Hook", () => {
+	// These tests assume uniform executable script execution via embedded shell
+	// Windows support pending embedded shell implementation
+	before(function () {
+		if (process.platform === "win32") {
+			this.skip()
+		}
+	})
+
+	let tempDir: string
+	let sandbox: sinon.SinonSandbox
+	let getEnv: () => { tempDir: string }
+
+	// Helper to write executable hook script
+	const writeHookScript = async (hookPath: string, nodeScript: string): Promise<void> => {
+		await fs.writeFile(hookPath, nodeScript)
+		await fs.chmod(hookPath, 0o755)
+	}
+
+	beforeEach(async () => {
+		sandbox = sinon.createSandbox()
+		tempDir = path.join(os.tmpdir(), `hook-test-${Date.now()}-${Math.random().toString(36).slice(2)}`)
+		await fs.mkdir(tempDir, { recursive: true })
+
+		// Create .clinerules/hooks directory
+		const hooksDir = path.join(tempDir, ".clinerules", "hooks")
+		await fs.mkdir(hooksDir, { recursive: true })
+
+		// Mock StateManager to return our temp directory
+		sandbox.stub(StateManager, "get").returns({
+			getGlobalStateKey: () => [{ path: tempDir }],
+		} as any)
+
+		getEnv = () => ({ tempDir })
+
+		// Reset hook discovery cache for clean test state
+		const { HookDiscoveryCache } = await import("../HookDiscoveryCache")
+		HookDiscoveryCache.resetForTesting()
+	})
+
+	afterEach(async () => {
+		sandbox.restore()
+
+		// Clean up hook discovery cache
+		const { HookDiscoveryCache } = await import("../HookDiscoveryCache")
+		HookDiscoveryCache.resetForTesting()
+
+		try {
+			await fs.rm(tempDir, { recursive: true, force: true })
+		} catch (error) {
+			// Ignore cleanup errors
+		}
+	})
+
+	describe("Hook Input Format", () => {
+		it("should receive task metadata with result and command", async () => {
+			const hookPath = path.join(tempDir, ".clinerules", "hooks", "TaskComplete")
+			const hookScript = `#!/usr/bin/env node
+const input = JSON.parse(require('fs').readFileSync(0, 'utf-8'));
+const metadata = input.taskComplete.taskMetadata;
+const hasAllFields = metadata.taskId && metadata.ulid && metadata.result;
+console.log(JSON.stringify({
+  cancel: false,
+  contextModification: hasAllFields ? "All metadata present" : "Missing metadata",
+  errorMessage: ""
+}))`
+
+			await writeHookScript(hookPath, hookScript)
+
+			const factory = new HookFactory()
+			const runner = await factory.create("TaskComplete")
+
+			const result = await runner.run({
+				taskId: "test-task-id",
+				taskComplete: {
+					taskMetadata: {
+						taskId: "test-task-id",
+						ulid: "test-ulid",
+						result: "Task completed successfully",
+						command: "npm start",
+					},
+				},
+			})
+
+			result.cancel.should.be.false()
+			result.contextModification!.should.equal("All metadata present")
+		})
+
+		it("should handle completion without command", async () => {
+			const hookPath = path.join(tempDir, ".clinerules", "hooks", "TaskComplete")
+			const hookScript = `#!/usr/bin/env node
+const input = JSON.parse(require('fs').readFileSync(0, 'utf-8'));
+const metadata = input.taskComplete.taskMetadata;
+const command = metadata.command || "";
+console.log(JSON.stringify({
+  cancel: false,
+  contextModification: "Command: '" + command + "'",
+  errorMessage: ""
+}))`
+
+			await writeHookScript(hookPath, hookScript)
+
+			const factory = new HookFactory()
+			const runner = await factory.create("TaskComplete")
+
+			const result = await runner.run({
+				taskId: "test-task-id",
+				taskComplete: {
+					taskMetadata: {
+						taskId: "test-task-id",
+						ulid: "test-ulid",
+						result: "Task completed",
+						command: "",
+					},
+				},
+			})
+
+			result.cancel.should.be.false()
+			result.contextModification!.should.equal("Command: ''")
+		})
+
+		it("should receive all common hook input fields", async () => {
+			const hookPath = path.join(tempDir, ".clinerules", "hooks", "TaskComplete")
+			const hookScript = `#!/usr/bin/env node
+const input = JSON.parse(require('fs').readFileSync(0, 'utf-8'));
+const hasAllFields = input.clineVersion && input.hookName === 'TaskComplete' && 
+                     input.timestamp && input.taskId && 
+                     input.workspaceRoots !== undefined;
+console.log(JSON.stringify({
+  cancel: false,
+  contextModification: hasAllFields ? "All fields present" : "Missing fields",
+  errorMessage: ""
+}))`
+
+			await writeHookScript(hookPath, hookScript)
+
+			const factory = new HookFactory()
+			const runner = await factory.create("TaskComplete")
+
+			const result = await runner.run({
+				taskId: "test-task-id",
+				taskComplete: {
+					taskMetadata: {
+						taskId: "test-task-id",
+						ulid: "test-ulid",
+						result: "Test task",
+						command: "",
+					},
+				},
+			})
+
+			result.cancel.should.be.false()
+			result.contextModification!.should.equal("All fields present")
+		})
+
+		it("should receive result text for logging", async () => {
+			const hookPath = path.join(tempDir, ".clinerules", "hooks", "TaskComplete")
+			const hookScript = `#!/usr/bin/env node
+const input = JSON.parse(require('fs').readFileSync(0, 'utf-8'));
+const result = input.taskComplete.taskMetadata.result;
+console.log(JSON.stringify({
+  cancel: false,
+  contextModification: "Result length: " + result.length,
+  errorMessage: ""
+}))`
+
+			await writeHookScript(hookPath, hookScript)
+
+			const factory = new HookFactory()
+			const runner = await factory.create("TaskComplete")
+
+			const result = await runner.run({
+				taskId: "test-task-id",
+				taskComplete: {
+					taskMetadata: {
+						taskId: "test-task-id",
+						ulid: "test-ulid",
+						result: "I've successfully completed the task by implementing all required features.",
+						command: "",
+					},
+				},
+			})
+
+			result.cancel.should.be.false()
+			result.contextModification!.should.equal("Result length: 75")
+		})
+	})
+
+	describe("Hook Behavior", () => {
+		it("should execute successfully and capture context modification", async () => {
+			const hookPath = path.join(tempDir, ".clinerules", "hooks", "TaskComplete")
+			const hookScript = `#!/usr/bin/env node
+console.log(JSON.stringify({
+  cancel: false,
+  contextModification: "TaskComplete hook executed successfully",
+  errorMessage: ""
+}))`
+
+			await writeHookScript(hookPath, hookScript)
+
+			const factory = new HookFactory()
+			const runner = await factory.create("TaskComplete")
+
+			const result = await runner.run({
+				taskId: "test-task-id",
+				taskComplete: {
+					taskMetadata: {
+						taskId: "test-task-id",
+						ulid: "test-ulid",
+						result: "Test task",
+						command: "",
+					},
+				},
+			})
+
+			result.cancel.should.be.false()
+			result.contextModification!.should.equal("TaskComplete hook executed successfully")
+		})
+
+		it("should capture contextModification for logging even though task is complete", async () => {
+			const hookPath = path.join(tempDir, ".clinerules", "hooks", "TaskComplete")
+			const hookScript = `#!/usr/bin/env node
+const input = JSON.parse(require('fs').readFileSync(0, 'utf-8'));
+console.log(JSON.stringify({
+  cancel: false,
+  contextModification: "TASK_COMPLETE: Task '" + input.taskComplete.taskMetadata.taskId + "' finished",
+  errorMessage: ""
+}))`
+
+			await writeHookScript(hookPath, hookScript)
+
+			const factory = new HookFactory()
+			const runner = await factory.create("TaskComplete")
+
+			const result = await runner.run({
+				taskId: "test-task-id",
+				taskComplete: {
+					taskMetadata: {
+						taskId: "test-task-id",
+						ulid: "test-ulid",
+						result: "Build a todo app",
+						command: "",
+					},
+				},
+			})
+
+			result.cancel.should.be.false()
+			result.contextModification!.should.equal("TASK_COMPLETE: Task 'test-task-id' finished")
+		})
+
+		it("should not block task completion when hook returns cancel: true", async () => {
+			const hookPath = path.join(tempDir, ".clinerules", "hooks", "TaskComplete")
+			const hookScript = `#!/usr/bin/env node
+console.log(JSON.stringify({
+  cancel: true,
+  contextModification: "",
+  errorMessage: "Hook tried to block completion"
+}))`
+
+			await writeHookScript(hookPath, hookScript)
+
+			const factory = new HookFactory()
+			const runner = await factory.create("TaskComplete")
+
+			const result = await runner.run({
+				taskId: "test-task-id",
+				taskComplete: {
+					taskMetadata: {
+						taskId: "test-task-id",
+						ulid: "test-ulid",
+						result: "Test task",
+						command: "",
+					},
+				},
+			})
+
+			// Hook can return cancel: true, but it's ignored (task is already complete)
+			// This is similar to TaskCancel behavior
+			result.cancel.should.be.true()
+			result.errorMessage!.should.equal("Hook tried to block completion")
+		})
+	})
+
+	describe("Error Handling", () => {
+		it("should handle hook script errors", async () => {
+			const hookPath = path.join(tempDir, ".clinerules", "hooks", "TaskComplete")
+			const hookScript = `#!/usr/bin/env node
+console.error("Hook execution error");
+process.exit(1);`
+
+			await writeHookScript(hookPath, hookScript)
+
+			const factory = new HookFactory()
+			const runner = await factory.create("TaskComplete")
+
+			try {
+				await runner.run({
+					taskId: "test-task-id",
+					taskComplete: {
+						taskMetadata: {
+							taskId: "test-task-id",
+							ulid: "test-ulid",
+							result: "Test task",
+							command: "",
+						},
+					},
+				})
+				throw new Error("Should have thrown")
+			} catch (error: any) {
+				error.message.should.match(/TaskComplete.*exited with code 1/)
+			}
+		})
+
+		it("should handle malformed JSON output from hook", async () => {
+			const hookPath = path.join(tempDir, ".clinerules", "hooks", "TaskComplete")
+			const hookScript = `#!/usr/bin/env node
+console.log("not valid json")`
+
+			await writeHookScript(hookPath, hookScript)
+
+			const factory = new HookFactory()
+			const runner = await factory.create("TaskComplete")
+
+			// When hook exits 0 but has malformed JSON, it returns success without context
+			const result = await runner.run({
+				taskId: "test-task-id",
+				taskComplete: {
+					taskMetadata: {
+						taskId: "test-task-id",
+						ulid: "test-ulid",
+						result: "Test task",
+						command: "",
+					},
+				},
+			})
+
+			// Hook succeeded (exit 0) but couldn't parse JSON, so returns success without context
+			result.cancel.should.be.false()
+			;(result.contextModification === undefined || result.contextModification === "").should.be.true()
+		})
+	})
+
+	describe("Global and Workspace Hooks", () => {
+		let globalHooksDir: string
+		let originalGetAllHooksDirs: any
+
+		beforeEach(async () => {
+			// Create global hooks directory
+			globalHooksDir = path.join(tempDir, "global-hooks")
+			await fs.mkdir(globalHooksDir, { recursive: true })
+
+			// Mock getAllHooksDirs to include our test global directory
+			const diskModule = require("../../storage/disk")
+			originalGetAllHooksDirs = diskModule.getAllHooksDirs
+			sandbox.stub(diskModule, "getAllHooksDirs").callsFake(async () => {
+				const workspaceDirs = await originalGetAllHooksDirs()
+				return [globalHooksDir, ...workspaceDirs]
+			})
+		})
+
+		it("should execute both global and workspace TaskComplete hooks", async () => {
+			// Create global hook
+			const globalHookPath = path.join(globalHooksDir, "TaskComplete")
+			const globalHookScript = `#!/usr/bin/env node
+console.log(JSON.stringify({
+  cancel: false,
+  contextModification: "GLOBAL: Task complete",
+  errorMessage: ""
+}))`
+			await writeHookScript(globalHookPath, globalHookScript)
+
+			// Create workspace hook
+			const workspaceHookPath = path.join(tempDir, ".clinerules", "hooks", "TaskComplete")
+			const workspaceHookScript = `#!/usr/bin/env node
+console.log(JSON.stringify({
+  cancel: false,
+  contextModification: "WORKSPACE: Task complete",
+  errorMessage: ""
+}))`
+			await writeHookScript(workspaceHookPath, workspaceHookScript)
+
+			const factory = new HookFactory()
+			const runner = await factory.create("TaskComplete")
+			const result = await runner.run({
+				taskId: "test-task-id",
+				taskComplete: {
+					taskMetadata: {
+						taskId: "test-task-id",
+						ulid: "test-ulid",
+						result: "Test task",
+						command: "",
+					},
+				},
+			})
+
+			result.cancel.should.be.false()
+			result.contextModification!.should.match(/GLOBAL: Task complete/)
+			result.contextModification!.should.match(/WORKSPACE: Task complete/)
+		})
+
+		it("should handle when global hook has error but workspace succeeds", async () => {
+			const globalHookPath = path.join(globalHooksDir, "TaskComplete")
+			const globalHookScript = `#!/usr/bin/env node
+console.error("Global hook error");
+process.exit(1);`
+			await writeHookScript(globalHookPath, globalHookScript)
+
+			const workspaceHookPath = path.join(tempDir, ".clinerules", "hooks", "TaskComplete")
+			const workspaceHookScript = `#!/usr/bin/env node
+console.log(JSON.stringify({
+  cancel: false,
+  contextModification: "Workspace succeeded",
+  errorMessage: ""
+}))`
+			await writeHookScript(workspaceHookPath, workspaceHookScript)
+
+			const factory = new HookFactory()
+			const runner = await factory.create("TaskComplete")
+
+			// Both hooks run in parallel, if one fails the whole thing fails
+			try {
+				await runner.run({
+					taskId: "test-task-id",
+					taskComplete: {
+						taskMetadata: {
+							taskId: "test-task-id",
+							ulid: "test-ulid",
+							result: "Test task",
+							command: "",
+						},
+					},
+				})
+				throw new Error("Should have thrown")
+			} catch (error: any) {
+				error.message.should.match(/TaskComplete.*exited with code 1/)
+			}
+		})
+	})
+
+	describe("No Hook Behavior", () => {
+		it("should succeed when no hook exists", async () => {
+			const factory = new HookFactory()
+			const runner = await factory.create("TaskComplete")
+
+			const result = await runner.run({
+				taskId: "test-task-id",
+				taskComplete: {
+					taskMetadata: {
+						taskId: "test-task-id",
+						ulid: "test-ulid",
+						result: "Test task",
+						command: "",
+					},
+				},
+			})
+
+			result.cancel.should.be.false()
+		})
+	})
+
+	describe("Fixture-Based Tests", () => {
+		it("should work with success fixture", async () => {
+			await loadFixture("hooks/taskcomplete/success", getEnv().tempDir)
+
+			const factory = new HookFactory()
+			const runner = await factory.create("TaskComplete")
+
+			const result = await runner.run({
+				taskId: "test-task-id",
+				taskComplete: {
+					taskMetadata: {
+						taskId: "test-task-id",
+						ulid: "test-ulid",
+						result: "Test task",
+						command: "",
+					},
+				},
+			})
+
+			result.cancel.should.be.false()
+			result.contextModification!.should.equal("TaskComplete hook executed successfully")
+		})
+
+		it("should work with error fixture", async () => {
+			await loadFixture("hooks/taskcomplete/error", getEnv().tempDir)
+
+			const factory = new HookFactory()
+			const runner = await factory.create("TaskComplete")
+
+			try {
+				await runner.run({
+					taskId: "test-task-id",
+					taskComplete: {
+						taskMetadata: {
+							taskId: "test-task-id",
+							ulid: "test-ulid",
+							result: "Test task",
+							command: "",
+						},
+					},
+				})
+				throw new Error("Should have thrown")
+			} catch (error: any) {
+				error.message.should.match(/TaskComplete.*exited with code 1/)
+			}
+		})
+
+		it("should work with context-injection fixture", async () => {
+			await loadFixture("hooks/taskcomplete/context-injection", getEnv().tempDir)
+
+			const factory = new HookFactory()
+			const runner = await factory.create("TaskComplete")
+
+			const result = await runner.run({
+				taskId: "test-task-id",
+				taskComplete: {
+					taskMetadata: {
+						taskId: "test-task-id",
+						ulid: "test-ulid",
+						result: "Build a todo app",
+						command: "",
+					},
+				},
+			})
+
+			result.cancel.should.be.false()
+			result.contextModification!.should.equal("COMPLETED: Build a todo app")
+		})
+	})
+})

--- a/webview-ui/src/components/chat/HookMessage.tsx
+++ b/webview-ui/src/components/chat/HookMessage.tsx
@@ -219,7 +219,7 @@ const HookMessage = memo(({ message, CommandOutput }: HookMessageProps) => {
 							</span>
 						)}
 					</div>
-					{isRunning && metadata.hookName !== "TaskCancel" && (
+					{isRunning && metadata.hookName !== "TaskCancel" && metadata.hookName !== "TaskComplete" && (
 						<button
 							onClick={(e) => {
 								e.stopPropagation()


### PR DESCRIPTION
### Related Issue

**Issue:** #ENG-1004

### Description

This is the implementation of `TaskComplete`, one of the original hooks defined in the Hooks MVP requirements doc.  This is a hook just like any other hook, and it gets triggered when the task is completed (right after the final task output message is displayed).

### Test Procedure

I've manually verified this hook by configuring a hook named `TaskComplete` (with `chmod +x`) in the `.clinerules/hooks/` directory of a demo repo and then triggering it by running a task (ex: "What does this repo do?") to successful completion.  The result is a `TaskComplete` hook UI block that appears at the very end of the task, and the "Start a New Task" button appears after the hook runs.

There are also unit tests for this PR, which follow the same pattern of unit tests for other existing hook implementations.


### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

#### The new `TaskComplete` hook, look look!
<img width="605" height="799" alt="Screenshot 2025-11-17 at 1 57 40 PM" src="https://github.com/user-attachments/assets/e52f8710-174b-402a-a793-365b77bc5531" />

### Additional Notes

n/a
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Implement `TaskComplete` hook to trigger on task completion, with tests and UI updates.
> 
>   - **Behavior**:
>     - Implement `TaskComplete` hook in `AttemptCompletionHandler.ts` to trigger after task completion.
>     - Hook is non-cancellable and logs errors without affecting task completion.
>     - UI updates in `HookMessage.tsx` to handle `TaskComplete` hook, preventing abort button display.
>   - **Tests**:
>     - Add `taskcomplete.test.ts` to test `TaskComplete` hook behavior, input format, error handling, and global/workspace hooks.
>     - Include fixture-based tests for success, error, and context-injection scenarios.
>   - **Fixtures**:
>     - Add `TaskComplete` scripts for success, error, and context-injection in `__tests__/fixtures/hooks/taskcomplete/`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 226513512fa4ecc8ef224f921a8e02f783a01f55. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->