### PR TITLE
fix: resolve double quote escaping in Windows cmd.exe for Background Exec mode

### DIFF
--- a/standalone/runtime-files/vscode/enhanced-terminal.js
+++ b/standalone/runtime-files/vscode/enhanced-terminal.js
@@ -200,7 +200,8 @@ class StandaloneTerminalProcess extends EventEmitter {
 			if (shell.toLowerCase().includes("powershell") || shell.toLowerCase().includes("pwsh")) {
 				return ["-Command", command]
 			} else {
-				return ["/c", command]
+				// Use /s /c with quoted command for proper quote handling in cmd.exe
+				return ["/s", "/c", `"${command}"`]
 			}
 		} else {
 			// Use -l for login shell, -c for command


### PR DESCRIPTION

## Description 

Fixes #7470

When Terminal Execution Mode is set to "Background Exec", commands with double quotes were being incorrectly escaped on Windows cmd.exe, causing commands like `echo "\""` or `type "test.txt"` to fail.

The issue was that cmd.exe requires the /s flag and outer quotes when passing commands with special characters via spawn(). Changed from `["/c", command]` to `["/s", "/c", `"${command}"`]` for cmd.exe only.

This is a minimal Windows-specific fix that:
- Only affects Windows cmd.exe (PowerShell and Unix shells unchanged)
- Uses standard Windows cmd.exe syntax for proper quote handling
- No changes to process execution flow or behavior


### Test Procedure

<!-- 
Please walk us through your testing approach and thought process. This helps reviewers understand that you've thoroughly considered the impact of your changes:

- How did you test this change?
- What could potentially break and how did you verify it doesn't?
- What existing functionality might be affected and how did you check it still works?
- Why are you confident this is ready for merge?

We're not looking for exhaustive documentation - just evidence that you've thought through the implications of your changes and tested accordingly.
-->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [X] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [ ] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes double quote escaping in Windows cmd.exe for Background Exec mode by changing command execution arguments in `enhanced-terminal.js`.
> 
>   - **Behavior**:
>     - Fixes double quote escaping issue in Windows `cmd.exe` when using "Background Exec" mode.
>     - Changes command execution from `[/c, command]` to `[/s, /c, "${command}"]` in `enhanced-terminal.js`.
>     - Only affects Windows `cmd.exe`; PowerShell and Unix shells remain unchanged.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for b6965bca33ec1f50122edce618ba1794dfcdb5f1. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->