### PR TITLE
ApiHandler - Openrouter - Automatically derive modelInfo

### DIFF
--- a/src/core/api/providers/openrouter.ts
+++ b/src/core/api/providers/openrouter.ts
@@ -1,4 +1,5 @@
 import { setTimeout as setTimeoutPromise } from "node:timers/promises"
+import { StateManager } from "@core/storage/StateManager"
 import { ModelInfo, openRouterDefaultModelId, openRouterDefaultModelInfo } from "@shared/api"
 import { shouldSkipReasoningForModel } from "@utils/model-utils"
 import axios from "axios"
@@ -214,9 +215,11 @@ export class OpenRouterHandler implements ApiHandler {
 	}
 
 	getModel(): { id: string; info: ModelInfo } {
+		const modelId = this.options.openRouterModelId || openRouterDefaultModelId
+		const cachedModelInfo = StateManager.get().getModelInfo("openRouter", modelId)
 		return {
-			id: this.options.openRouterModelId || openRouterDefaultModelId,
-			info: this.options.openRouterModelInfo || openRouterDefaultModelInfo,
+			id: modelId,
+			info: cachedModelInfo || openRouterDefaultModelInfo,
 		}
 	}
 }

--- a/src/core/controller/models/refreshOpenRouterModels.ts
+++ b/src/core/controller/models/refreshOpenRouterModels.ts
@@ -4,6 +4,7 @@ import axios from "axios"
 import cloneDeep from "clone-deep"
 import fs from "fs/promises"
 import path from "path"
+import { StateManager } from "@/core/storage/StateManager"
 import {
 	ANTHROPIC_MAX_THINKING_BUDGET,
 	CLAUDE_SONNET_1M_TIERS,
@@ -78,7 +79,7 @@ interface OpenRouterRawModelInfo {
 export async function refreshOpenRouterModels(controller: Controller): Promise<Record<string, ModelInfo>> {
 	const openRouterModelsFilePath = path.join(await ensureCacheDirectoryExists(), GlobalFileNames.openRouterModels)
 
-	const models: Record<string, ModelInfo> = {}
+	let models: Record<string, ModelInfo> = {}
 	try {
 		const response = await axios.get("https://openrouter.ai/api/v1/models", getAxiosSettings())
 
@@ -242,12 +243,17 @@ export async function refreshOpenRouterModels(controller: Controller): Promise<R
 		// If we failed to fetch models, try to read cached models
 		const cachedModels = await controller.readOpenRouterModels()
 		if (cachedModels) {
-			// Cached models are already in application format (ModelInfo)
-			return appendClineStealthModels(cachedModels as Record<string, ModelInfo>)
+			models = cachedModels
 		}
 	}
+
 	// Append stealth models if any
-	return appendClineStealthModels(models)
+	const finalModels = appendClineStealthModels(models)
+
+	// Store in StateManager's in-memory cache
+	StateManager.get().setModelsCache("openRouter", finalModels)
+
+	return finalModels
 }
 
 /**

--- a/src/core/storage/StateManager.ts
+++ b/src/core/storage/StateManager.ts
@@ -1,4 +1,4 @@
-import { ApiConfiguration } from "@shared/api"
+import { ApiConfiguration, ModelInfo } from "@shared/api"
 import {
 	GlobalState,
 	GlobalStateAndSettings,
@@ -43,6 +43,28 @@ export class StateManager {
 	private workspaceStateCache: LocalState = {} as LocalState
 	private context: ExtensionContext
 	private isInitialized = false
+
+	// In-memory model info cache (not persisted to disk)
+	// These are for dynamic providers that fetch models from APIs
+	private modelInfoCache: {
+		openRouterModels: Record<string, ModelInfo> | null
+		groqModels: Record<string, ModelInfo> | null
+		basetenModels: Record<string, ModelInfo> | null
+		huggingFaceModels: Record<string, ModelInfo> | null
+		requestyModels: Record<string, ModelInfo> | null
+		huaweiCloudMaasModels: Record<string, ModelInfo> | null
+		hicapModels: Record<string, ModelInfo> | null
+		aihubmixModels: Record<string, ModelInfo> | null
+	} = {
+		openRouterModels: null,
+		groqModels: null,
+		basetenModels: null,
+		huggingFaceModels: null,
+		requestyModels: null,
+		huaweiCloudMaasModels: null,
+		hicapModels: null,
+		aihubmixModels: null,
+	}
 
 	// Debounced persistence state
 	private pendingGlobalState = new Set<GlobalStateAndSettingsKey>()
@@ -346,6 +368,29 @@ export class StateManager {
 		}
 
 		this.remoteConfigCache = {} as GlobalStateAndSettings
+	}
+
+	/**
+	 * Set models cache for a specific provider (in-memory only, not persisted)
+	 */
+	setModelsCache(
+		provider: "openRouter" | "groq" | "baseten" | "huggingFace" | "requesty" | "huaweiCloudMaas" | "hicap" | "aihubmix",
+		models: Record<string, ModelInfo>,
+	): void {
+		const cacheKey = `${provider}Models` as keyof typeof this.modelInfoCache
+		this.modelInfoCache[cacheKey] = models
+	}
+
+	/**
+	 * Get model info by provider and model ID (from in-memory cache)
+	 */
+	getModelInfo(
+		provider: "openRouter" | "groq" | "baseten" | "huggingFace" | "requesty" | "huaweiCloudMaas" | "hicap" | "aihubmix",
+		modelId: string,
+	): ModelInfo | undefined {
+		const cacheKey = `${provider}Models` as keyof typeof this.modelInfoCache
+		console.log("[OpenRouter] modelInfoCache:", this.modelInfoCache)
+		return this.modelInfoCache[cacheKey]?.[modelId]
 	}
 
 	/**


### PR DESCRIPTION


### Description

Automatically derive the modelInfo from the modelId in the openrouter api handler.

In refreshOpenrouterModels we cache the available models and modelInfos in memory in the statemanager. We then check against this with the modelId in the openrouter handler.

In this way, we avoid having to pass in the modelInfo from the frontend, which ultimately gets it from the backend anyways.

This solves a bug in the CLI where, with the cline auth command, the modelInfo is actually not being set and so it's always defaulting to the default modelInfo.

### Test Procedure

Log that the correct modelInfo is being used in openrouter based on the modelId

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [x] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Automatically derive `modelInfo` from `modelId` in OpenRouter API handler using in-memory caching in `StateManager`.
> 
>   - **Behavior**:
>     - Automatically derive `modelInfo` from `modelId` in `OpenRouterHandler`.
>     - Cache available models and their information in memory using `StateManager`.
>     - Fixes a bug in CLI where `modelInfo` was not being set correctly.
>   - **Caching**:
>     - `refreshOpenRouterModels` caches models in `StateManager`.
>     - `StateManager` provides methods `setModelsCache` and `getModelInfo` for managing in-memory cache.
>   - **Code Changes**:
>     - Updated `getModel` method in `OpenRouterHandler` to use cached `modelInfo`.
>     - Modified `refreshOpenRouterModels` to store models in `StateManager` cache.
>     - Added in-memory model info cache to `StateManager`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for fcfd285964d9d2bd944f5d52a7ed5e1eefbe193d. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->