### PR TITLE
fix(compaction): Use consistent icon for compaction

### DIFF
--- a/webview-ui/src/components/chat/ChatRow.tsx
+++ b/webview-ui/src/components/chat/ChatRow.tsx
@@ -11,6 +11,7 @@ import {
 import { BooleanRequest, Int64Request, StringRequest } from "@shared/proto/cline/common"
 import { VSCodeBadge, VSCodeProgressRing } from "@vscode/webview-ui-toolkit/react"
 import deepEqual from "fast-deep-equal"
+import { FoldVerticalIcon } from "lucide-react"
 import React, { MouseEvent, memo, useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { useSize } from "react-use"
 import styled from "styled-components"
@@ -750,7 +751,9 @@ export const ChatRowContent = memo(
 					return (
 						<>
 							<div style={headerStyle}>
-								{toolIcon("book")}
+								<span style={{ color: normalColor, marginBottom: "-1.5px" }}>
+									<FoldVerticalIcon size={16} />
+								</span>
 								<span style={{ fontWeight: "bold" }}>Cline is condensing the conversation:</span>
 							</div>
 							<div


### PR DESCRIPTION
### Related Issue

**Issue:** n/a

### Description

I noticed that the compaction message icon is different from the compaction actionable status icon.  Making these two the same.


### Test Procedure

I got compaction to trigger and then observed the icon used.


### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

#### Before
<img width="541" height="234" alt="Screenshot 2025-11-20 at 3 41 22 PM" src="https://github.com/user-attachments/assets/b216b32a-e9de-4b99-804f-c48e3f39595a" />


#### After
<img width="542" height="294" alt="Screenshot 2025-11-20 at 8 49 25 PM" src="https://github.com/user-attachments/assets/b1128e25-7017-41ee-b1b9-84a7598c2181" />


### Additional Notes

n/a