### PR TITLE
Add a setting to disable the `Add Remote Servers` feature in the extension.

### DIFF
--- a/src/shared/remote-config/__tests__/schema.test.ts
+++ b/src/shared/remote-config/__tests__/schema.test.ts
@@ -314,7 +314,7 @@ describe("Remote Config Schema", () => {
 				version: "v1",
 				telemetryEnabled: true,
 				mcpMarketplaceEnabled: false,
-				usersCannotAddRemoteServers: true,
+				blockPersonalRemoteMCPServers: true,
 				allowedMCPServers: [{ id: "https://github.com/mcp/filesystem" }, { id: "https://github.com/mcp/github" }],
 				yoloModeAllowed: true,
 				openTelemetryEnabled: true,

--- a/src/shared/remote-config/schema.ts
+++ b/src/shared/remote-config/schema.ts
@@ -150,8 +150,8 @@ export const RemoteConfigSchema = z.object({
 
 	// A list of pre-configured remote MCP servers.
 	remoteMCPServers: z.array(RemoteMCPServerSchema).optional(),
-	// If this is true, users cannot add more remote MCP servers in the extension.
-	usersCannotAddRemoteServers: z.boolean().optional(),
+	// If this is true, users cannot use or configure MCP servers that are not remotely configured.
+	blockPersonalRemoteMCPServers: z.boolean().optional(),
 
 	// If the user is allowed to enable YOLO mode. Note this is different from the extension setting
 	// yoloModeEnabled, because we do not want to force YOLO enabled for the user.


### PR DESCRIPTION
We need to be able to optionally prevent the users from adding more Remote MCP servers in the extension.

<img width="1768" height="1114" alt="Screenshot 2025-11-21 at 12 14 33" src="https://github.com/user-attachments/assets/4fcc467e-1b41-4d2c-bbee-711f91998be0" />


ref PF-285