### PR TITLE
chore: clean up prompts and fix model family identifier

### DIFF
--- a/src/core/prompts/system-prompt/tools/plan_mode_respond.ts
+++ b/src/core/prompts/system-prompt/tools/plan_mode_respond.ts
@@ -65,8 +65,7 @@ However, if while writing your response you realize you actually need to do more
 		{
 			name: "response",
 			required: true,
-			instruction: `The response to provide to the user. Do not try to use tools in this parameter, this is simply a chat response. (You MUST use the response parameter, do not simply place the response text directly within <plan_mode_respond> tags.)`,
-			usage: "Your response here",
+			instruction: `The response to provide to the user.`,
 		},
 		{
 			name: "task_progress",

--- a/src/core/prompts/system-prompt/variants/native-gpt-5-1/config.ts
+++ b/src/core/prompts/system-prompt/variants/native-gpt-5-1/config.ts
@@ -65,7 +65,7 @@ export const config = createVariant(ModelFamily.NATIVE_GPT_5_1)
 		ClineDefaultTool.TODO,
 	)
 	.placeholders({
-		MODEL_FAMILY: ModelFamily.NATIVE_GPT_5,
+		MODEL_FAMILY: ModelFamily.NATIVE_GPT_5_1,
 	})
 	.config({})
 	// Override components with custom templates from overrides.ts
@@ -78,7 +78,7 @@ export const config = createVariant(ModelFamily.NATIVE_GPT_5_1)
 	.build()
 
 // Compile-time validation
-const validationResult = validateVariant({ ...config, id: ModelFamily.NATIVE_GPT_5 }, { strict: true })
+const validationResult = validateVariant({ ...config, id: ModelFamily.NATIVE_GPT_5_1 }, { strict: true })
 if (!validationResult.isValid) {
 	console.error("GPT-5-1 variant configuration validation failed:", validationResult.errors)
 	throw new Error(`Invalid GPT-5-1 variant configuration: ${validationResult.errors.join(", ")}`)

--- a/src/core/task/StreamResponseHandler.ts
+++ b/src/core/task/StreamResponseHandler.ts
@@ -316,6 +316,7 @@ class ReasoningHandler {
 			thinking: this.pendingReasoning.content,
 			signature: this.pendingReasoning.signature,
 			summary: this.pendingReasoning.summary,
+			call_id: this.pendingReasoning.id,
 		}
 	}
 


### PR DESCRIPTION
<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- For feature requests: Created a discussion in our Feature Requests discussions board https://github.com/cline/cline/discussions/categories/feature-requests and received approval from core maintainers before implementation
- For all changes: Link the associated issue/discussion in the "Related Issue" section below

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly without prior discussion.

Why this requirement?
We deeply appreciate all community contributions - they are essential to Cline's success! To ensure the best use of everyone's time and maintain project direction, we use our Feature Requests discussions board to gauge community interest and validate feature ideas before implementation begins. This helps us focus development efforts on features that will benefit the most users.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** #XXXX

### Description

<!-- 
Help reviewers understand your changes by making this PR readable and well-organized:

- What problem does this PR solve?
- Why were these changes introduced and what purpose do they serve?
- For larger changes, provide context about your approach and reasoning

Small PRs may need minimal description, but larger changes benefit from explaining where you're coming from. Much of this context can be in the linked issue above, so feel free to reference it rather than repeating everything here.
-->

- Simplified plan_mode_respond instruction text by removing redundant explanations and usage field
- Fixed incorrect MODEL_FAMILY references in native-gpt-5-1 config (was using NATIVE_GPT_5 instead of NATIVE_GPT_5_1)
- Added call_id to reasoning handler output for tracking and OpenAI Response API (unreleased)

The prompt simplification makes the response parameter instruction more concise while maintaining clarity. The model family correction ensures the GPT-5-1 variant uses the correct identifier throughout.

### Test Procedure

<!-- 
Please walk us through your testing approach and thought process. This helps reviewers understand that you've thoroughly considered the impact of your changes:

- How did you test this change?
- What could potentially break and how did you verify it doesn't?
- What existing functionality might be affected and how did you check it still works?
- Why are you confident this is ready for merge?

We're not looking for exhaustive documentation - just evidence that you've thought through the implications of your changes and tested accordingly.
-->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Simplified prompt instructions, fixed model family identifier, and added `call_id` tracking in `StreamResponseHandler.ts`.
> 
>   - **Prompts**:
>     - Simplified `plan_mode_respond` instruction text in `plan_mode_respond.ts` by removing redundant explanations and usage field.
>   - **Model Family Identifier**:
>     - Corrected `MODEL_FAMILY` references in `config.ts` for `native-gpt-5-1` to use `NATIVE_GPT_5_1` instead of `NATIVE_GPT_5`.
>   - **Tracking**:
>     - Added `call_id` to `ReasoningHandler` output in `StreamResponseHandler.ts` for tracking and OpenAI Response API.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 0172613d07e937bd50c35257d1d9d98a5ba5174c. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->