### PR TITLE
Adding Grok 4.1 and Grok Code to Cline

### DIFF
--- a/.changeset/loud-numbers-add.md
+++ b/.changeset/loud-numbers-add.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Adding Grok 4.1 and Grok code in Cline.

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -2822,6 +2822,33 @@ export const nebiusDefaultModelId = "Qwen/Qwen2.5-32B-Instruct-fast" satisfies N
 export type XAIModelId = keyof typeof xaiModels
 export const xaiDefaultModelId: XAIModelId = "grok-4"
 export const xaiModels = {
+	"grok-4-1-fast-reasoning": {
+		contextWindow: 2_000_000,
+		supportsImages: false,
+		supportsPromptCache: true,
+		inputPrice: 0.2,
+		cacheReadsPrice: 0.05,
+		outputPrice: 0.5,
+		description: "xAI's Grok 4.1 Reasoning Fast - multimodal model with 2M context.",
+	},
+	"grok-4-1-fast-non-reasoning": {
+		contextWindow: 2_000_000,
+		supportsImages: true,
+		supportsPromptCache: true,
+		inputPrice: 0.2,
+		cacheReadsPrice: 0.05,
+		outputPrice: 0.5,
+		description: "xAI's Grok 4.1 Non-Reasoning Fast - multimodal model with 2M context.",
+	},
+	"grok-code-fast-1": {
+		contextWindow: 256_000,
+		supportsImages: false,
+		supportsPromptCache: true,
+		inputPrice: 0.2,
+		cacheReadsPrice: 0.02,
+		outputPrice: 1.5,
+		description: "xAI's Grok Coding model.",
+	},
 	"grok-4-fast-reasoning": {
 		maxTokens: 30000,
 		contextWindow: 2000000,


### PR DESCRIPTION
### Related Issue


**Issue:** N/A

### Description

Adds Grok 4.1 and Grok Code models: https://docs.x.ai/docs/models

### Test Procedure
I Tested locally all three models, as well ass image support for the non-reasoning model.

### Type of Change


-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A

### Additional Notes

N/A
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add Grok 4.1 and Grok Code models to `xaiModels` in `api.ts` with specific configurations and document the change in a changeset.
> 
>   - **Models**:
>     - Add `grok-4-1-fast-reasoning`, `grok-4-1-fast-non-reasoning`, and `grok-code-fast-1` to `xaiModels` in `api.ts`.
>     - `grok-4-1-fast-reasoning` and `grok-4-1-fast-non-reasoning` have a 2M context window, with the latter supporting images.
>     - `grok-code-fast-1` has a 256K context window, does not support images, and has different pricing.
>   - **Misc**:
>     - Add changeset `loud-numbers-add.md` documenting the addition of Grok 4.1 and Grok Code models.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 96f2ef5ee0f67747a138d4f1310f84ab17c0dcf4. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->