### PR TITLE
fix: feature-flags cache persistence during auth transitions

### DIFF
--- a/src/services/auth/AuthService.ts
+++ b/src/services/auth/AuthService.ts
@@ -393,8 +393,6 @@ export class AuthService {
 		// Identify the user in telemetry if available
 		if (this._clineAuthInfo?.userInfo?.id) {
 			telemetryService.identifyAccount(this._clineAuthInfo.userInfo)
-			// Reset feature flags to ensure they are fetched for the new/logged in user
-			featureFlagsService.reset(this._clineAuthInfo?.userInfo?.id)
 			// Poll feature flags immediately for authenticated users to ensure cache is populated
 			await featureFlagsService.poll(this._clineAuthInfo?.userInfo?.id)
 		} else {

--- a/src/services/feature-flags/FeatureFlagsService.ts
+++ b/src/services/feature-flags/FeatureFlagsService.ts
@@ -152,20 +152,6 @@ export class FeatureFlagsService {
 	}
 
 	/**
-	 * Reset the feature flags cache
-	 * Should run on user auth state changes to ensure flags are up-to-date
-	 */
-	public reset(userId?: string): void {
-		// Skip known user ID to avoid redundant resets
-		if (userId && this.cacheInfo.userId === userId) {
-			return
-		}
-		// Invalidate cache by resetting timestamp, but keep existing values
-		// until poll() repopulates them. This prevents empty cache during auth transitions.
-		this.cacheInfo = { updateTime: 0, userId: userId || null }
-	}
-
-	/**
 	 * For testing: directly set a feature flag in the cache
 	 */
 	public test(flagName: FeatureFlag, value: boolean) {


### PR DESCRIPTION
 <!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- For feature requests: Created a discussion in our Feature Requests discussions board https://github.com/cline/cline/discussions/categories/feature-requests and received approval from core maintainers before implementation
- For all changes: Link the associated issue/discussion in the "Related Issue" section below

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly without prior discussion.

Why this requirement?
We deeply appreciate all community contributions - they are essential to Cline's success! To ensure the best use of everyone's time and maintain project direction, we use our Feature Requests discussions board to gauge community interest and validate feature ideas before implementation begins. This helps us focus development efforts on features that will benefit the most users.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** #XXXX

### Description

<!-- 
Help reviewers understand your changes by making this PR readable and well-organized:

- What problem does this PR solve?
- Why were these changes introduced and what purpose do they serve?
- For larger changes, provide context about your approach and reasoning

Small PRs may need minimal description, but larger changes benefit from explaining where you're coming from. Much of this context can be in the linked issue above, so feel free to reference it rather than repeating everything here.
-->

Restructured feature flags polling and cache management to prevent empty cache states during authentication transitions:

- Move cache timestamp update to after successful population in poll() method to ensure cache validity reflects actual data availability
- Remove cache.clear() from reset() method to preserve existing flag values until new data is fetched
- Split polling logic in AuthService to explicitly handle authenticated vs unauthenticated states
- Poll feature flags immediately after reset for authenticated users to ensure cache is populated

This prevents temporary cache misses when users log in/out while maintaining cache freshness guarantees.

### Test Procedure

<!-- 
Please walk us through your testing approach and thought process. This helps reviewers understand that you've thoroughly considered the impact of your changes:

- How did you test this change?
- What could potentially break and how did you verify it doesn't?
- What existing functionality might be affected and how did you check it still works?
- Why are you confident this is ready for merge?

We're not looking for exhaustive documentation - just evidence that you've thought through the implications of your changes and tested accordingly.
-->

Confirm the experimental features are showing up in your feature settings before and after auth:

<img width="534" height="352" alt="image" src="https://github.com/user-attachments/assets/9cea0b95-31c2-451c-a82b-7dfa22994082" />


### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fix feature-flags cache management during authentication transitions to prevent premature clearing and ensure proper population.
> 
>   - **Behavior**:
>     - In `AuthService.ts`, poll feature flags immediately after authentication state changes to ensure cache is populated for authenticated users.
>     - In `FeatureFlagsService.ts`, update cache timestamp only after successful data retrieval in `poll()`.
>   - **Methods**:
>     - Remove `reset()` method from `FeatureFlagsService.ts` to prevent clearing cache during auth transitions.
>     - Split polling logic in `AuthService.ts` to handle authenticated vs unauthenticated states.
>   - **Misc**:
>     - Ensure cache is not cleared prematurely during auth transitions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 7ca6b907d4ed885ecc5b035e4cbf91d9a68c5986. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->