### PR TITLE
Add support for opus 4.5 global endpoint in bedrock

### DIFF
--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -568,6 +568,7 @@ export const bedrockModels = {
 		contextWindow: 200_000,
 		supportsImages: true,
 		supportsPromptCache: true,
+		supportsGlobalEndpoint: true,
 		inputPrice: 5.0,
 		outputPrice: 25.0,
 		cacheWritesPrice: 6.25,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds support for a global endpoint to the `claude-opus-4-5-20251101` model in `bedrockModels` in `api.ts`.
> 
>   - **Behavior**:
>     - Adds `supportsGlobalEndpoint: true` to `claude-opus-4-5-20251101` in `bedrockModels` in `api.ts`.
>   - **Misc**:
>     - No other changes or additions in the codebase.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for d4d579110df52e1508c5f84a54dfd83d7941a537. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->