### PR TITLE
fix: add a refresh guard flag for auth

### DIFF
--- a/src/services/auth/AuthService.ts
+++ b/src/services/auth/AuthService.ts
@@ -69,7 +69,7 @@ export class AuthService {
 	protected _activeAuthStatusUpdateHandlers = new Set<StreamingResponseHandler<AuthState>>()
 	protected _handlerToController = new Map<StreamingResponseHandler<AuthState>, Controller>()
 	protected _controller: Controller
-	protected _isRefreshing: boolean = false
+	protected _refreshPromise: Promise<void> | null = null
 
 	/**
 	 * Creates an instance of AuthService.
@@ -153,49 +153,56 @@ export class AuthService {
 			// Check if token has expired
 
 			if (await provider.shouldRefreshIdToken(clineAccountAuthToken, this._clineAuthInfo.expiresAt)) {
-				// Prevent concurrent refresh attempts
-				if (this._isRefreshing) {
-					Logger.info("Token refresh already in progress, using existing token")
+				// If a refresh is already in progress, wait for it to complete
+				if (this._refreshPromise) {
+					Logger.info("Token refresh already in progress, waiting for completion")
+					await this._refreshPromise
+					// After waiting, return the updated token
+					clineAccountAuthToken = this._clineAuthInfo?.idToken
 					return clineAccountAuthToken ? `workos:${clineAccountAuthToken}` : null
 				}
 
-				this._isRefreshing = true
-				let authStatusChanged = false
+				// Start a new refresh operation
+				this._refreshPromise = (async () => {
+					let authStatusChanged = false
 
-				try {
-					const updatedAuthInfo = await provider.retrieveClineAuthInfo(this._controller)
-					if (updatedAuthInfo) {
-						this._clineAuthInfo = updatedAuthInfo
-						this._authenticated = true
-						clineAccountAuthToken = updatedAuthInfo.idToken
-						authStatusChanged = true
+					try {
+						const updatedAuthInfo = await provider.retrieveClineAuthInfo(this._controller)
+						if (updatedAuthInfo) {
+							this._clineAuthInfo = updatedAuthInfo
+							this._authenticated = true
+							clineAccountAuthToken = updatedAuthInfo.idToken
+							authStatusChanged = true
+						}
+					} catch (error) {
+						// Only log out for permanent auth failures, not network issues
+						if (error instanceof AuthInvalidTokenError) {
+							Logger.error("Token is invalid or expired:", error)
+							this._clineAuthInfo = null
+							this._authenticated = false
+							telemetryService.captureAuthLoggedOut(this._provider?.name, LogoutReason.ERROR_RECOVERY)
+							authStatusChanged = true
+						} else if (error instanceof AuthNetworkError) {
+							Logger.error("Network error refreshing token", error)
+							// Keep existing auth info, will retry on next getAuthToken() call
+						} else {
+							throw error // Re-throw unexpected errors
+						}
+					} finally {
+						this._refreshPromise = null
 					}
-				} catch (error) {
-					// Only log out for permanent auth failures, not network issues
-					if (error instanceof AuthInvalidTokenError) {
-						Logger.error("Token is invalid or expired:", error)
-						this._clineAuthInfo = null
-						this._authenticated = false
-						telemetryService.captureAuthLoggedOut(this._provider?.name, LogoutReason.ERROR_RECOVERY)
-						authStatusChanged = true
-					} else if (error instanceof AuthNetworkError) {
-						Logger.error("Network error refreshing token", error)
-						// Keep existing auth info, will retry on next getAuthToken() call
-					} else {
-						throw error // Re-throw unexpected errors
-					}
-				} finally {
-					this._isRefreshing = false
-				}
 
-				// Defer auth status update to avoid infinite loop
-				if (authStatusChanged) {
-					setImmediate(() => {
-						this.sendAuthStatusUpdate().catch((error) => {
-							Logger.error("Error sending auth status update after token refresh:", error)
+					// Defer auth status update to avoid infinite loop
+					if (authStatusChanged) {
+						setImmediate(() => {
+							this.sendAuthStatusUpdate().catch((error) => {
+								Logger.error("Error sending auth status update after token refresh:", error)
+							})
 						})
-					})
-				}
+					}
+				})()
+
+				await this._refreshPromise
 			}
 
 			return clineAccountAuthToken ? `workos:${clineAccountAuthToken}` : null


### PR DESCRIPTION
<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- For feature requests: Created a discussion in our Feature Requests discussions board https://github.com/cline/cline/discussions/categories/feature-requests and received approval from core maintainers before implementation
- For all changes: Link the associated issue/discussion in the "Related Issue" section below

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly without prior discussion.

Why this requirement?
We deeply appreciate all community contributions - they are essential to Cline's success! To ensure the best use of everyone's time and maintain project direction, we use our Feature Requests discussions board to gauge community interest and validate feature ideas before implementation begins. This helps us focus development efforts on features that will benefit the most users.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** #XXXX

### Description

<!-- 
Help reviewers understand your changes by making this PR readable and well-organized:

- What problem does this PR solve?
- Why were these changes introduced and what purpose do they serve?
- For larger changes, provide context about your approach and reasoning

Small PRs may need minimal description, but larger changes benefit from explaining where you're coming from. Much of this context can be in the linked issue above, so feel free to reference it rather than repeating everything here.
-->

Add a refresh guard flag for auth service

Implemented atomic refresh handling

- When a refresh is needed, the code first checks if _refreshPromise exists
- If it exists, concurrent calls wait for the same Promise to complete and then return the refreshed token
- If it doesn't exist, a new Promise is created and stored in _refreshPromise
- The Promise is cleared in the finally block after completion

### Test Procedure

<!-- 
Please walk us through your testing approach and thought process. This helps reviewers understand that you've thoroughly considered the impact of your changes:

- How did you test this change?
- What could potentially break and how did you verify it doesn't?
- What existing functionality might be affected and how did you check it still works?
- Why are you confident this is ready for merge?

We're not looking for exhaustive documentation - just evidence that you've thought through the implications of your changes and tested accordingly.
-->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds a refresh guard in `AuthService` to prevent simultaneous token refresh operations using `_refreshPromise`.
> 
>   - **Behavior**:
>     - Adds `_refreshPromise` in `AuthService` to track ongoing token refresh operations.
>     - In `internalGetAuthToken()`, checks `_refreshPromise` to prevent simultaneous refreshes.
>     - Logs "Token refresh already in progress" if a refresh is ongoing and waits for completion.
>     - Handles `AuthInvalidTokenError` by logging out and capturing telemetry.
>     - Handles `AuthNetworkError` by logging and retrying on next call.
>   - **Misc**:
>     - Defers auth status update using `setImmediate()` to avoid infinite loops.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for a2a462a3c7673e02f9d90169bb2741a318e142ab. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->