### PR TITLE
Add global endpoint support for Claude Opus 4.5 on Bedrock

### DIFF
--- a/.changeset/good-needles-brake.md
+++ b/.changeset/good-needles-brake.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Add supportsGlobalEndpoint to opus 4.5 bedrock model

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -568,6 +568,7 @@ export const bedrockModels = {
 		contextWindow: 200_000,
 		supportsImages: true,
 		supportsPromptCache: true,
+		supportsGlobalEndpoint: true,
 		inputPrice: 5.0,
 		outputPrice: 25.0,
 		cacheWritesPrice: 6.25,


### PR DESCRIPTION
## Summary
- Enables global endpoint support for Claude Opus 4.5 model on AWS Bedrock by adding the `supportsGlobalEndpoint` flag

## Context
Claude Opus 4.5 on Bedrock supports the global endpoint feature, which allows for cross-region inference routing. This change adds the flag to the model configuration to enable this functionality.

## Changes
- Added `supportsGlobalEndpoint: true` to the `anthropic.claude-opus-4-5-20250514-v1:0` model configuration in `src/shared/api.ts`
- Included changeset documenting this patch change

## Test plan
- [x] Verify that Opus 4.5 model can be selected with global endpoint enabled
- [x] Test inference using global endpoint with Opus 4.5
- [x] Confirm backward compatibility with regional endpoints
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds global endpoint support to Claude Opus 4.5 model in `api.ts` by setting `supportsGlobalEndpoint: true`.
> 
>   - **Behavior**:
>     - Adds `supportsGlobalEndpoint: true` to `anthropic.claude-opus-4-5-20250514-v1:0` in `api.ts` to enable global endpoint support.
>   - **Documentation**:
>     - Adds a changeset file `good-needles-brake.md` documenting the patch change.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 293d7657a3fedbbfc8d67ca681156c78c7d9e1da. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->