### PR TITLE
feat: add "Add Last Command to Cline" terminal menu

### DIFF
--- a/.changeset/six-singers-rush.md
+++ b/.changeset/six-singers-rush.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": minor
+---
+
+Add "Add Last Command to Cline" terminal menu

--- a/package.json
+++ b/package.json
@@ -175,6 +175,11 @@
 				"category": "Cline"
 			},
 			{
+				"command": "cline.addTerminalCommandToChat",
+				"title": "Add Last Command to Cline",
+				"category": "Cline"
+			},
+			{
 				"command": "cline.focusChatInput",
 				"title": "Jump to Chat Input",
 				"category": "Cline"
@@ -272,7 +277,12 @@
 			"terminal/context": [
 				{
 					"command": "cline.addTerminalOutputToChat",
-					"group": "navigation"
+					"group": "navigation@1"
+				},
+				{
+					"command": "cline.addTerminalCommandToChat",
+					"group": "navigation@2",
+					"when": "cline.terminalHasCommandHistory"
 				}
 			],
 			"scm/title": [

--- a/src/integrations/terminal/CommandHistoryTracker.ts
+++ b/src/integrations/terminal/CommandHistoryTracker.ts
@@ -1,0 +1,177 @@
+import * as vscode from "vscode"
+import { stripAnsi } from "./ansiUtils"
+
+interface CommandHistoryItem {
+	commandLine: string
+	cwd?: string
+	exitCode?: number
+	output: string
+	startTime: number
+	endTime?: number
+}
+
+interface CommandInfo {
+	commandLine: string
+	cwd?: string
+	exitCode?: number
+	cleanOutput: string
+	duration: number
+	timestamp: Date
+}
+
+/**
+ * Tracks terminal command execution history using VSCode's shell integration API.
+ * Listens for command start/end events and maintains a history of recent commands per terminal.
+ */
+export class CommandHistoryTracker {
+	private commandHistory = new Map<vscode.Terminal, CommandHistoryItem[]>()
+	private readonly maxHistoryPerTerminal = 20
+	private disposables: vscode.Disposable[] = []
+	private onHistoryChangedCallback?: () => void
+
+	constructor(onHistoryChanged?: () => void) {
+		this.onHistoryChangedCallback = onHistoryChanged
+		this.setupEventListeners()
+	}
+
+	private setupEventListeners(): void {
+		// Track command start
+		try {
+			const onStartExecution = (vscode.window as any).onDidStartTerminalShellExecution
+			if (onStartExecution) {
+				this.disposables.push(
+					onStartExecution((event: any) => {
+						this.handleCommandStart(event)
+					}),
+				)
+			}
+		} catch (error) {
+			console.log("Shell execution tracking not available:", error)
+		}
+
+		// Track command end
+		try {
+			const onEndExecution = (vscode.window as any).onDidEndTerminalShellExecution
+			if (onEndExecution) {
+				this.disposables.push(
+					onEndExecution((event: any) => {
+						this.handleCommandEnd(event)
+					}),
+				)
+			}
+		} catch (error) {
+			console.log("Shell execution end tracking not available:", error)
+		}
+
+		// Clean up when terminal closes
+		this.disposables.push(
+			vscode.window.onDidCloseTerminal((terminal) => {
+				this.commandHistory.delete(terminal)
+			}),
+		)
+	}
+
+	private handleCommandStart(event: any): void {
+		if (!this.commandHistory.has(event.terminal)) {
+			this.commandHistory.set(event.terminal, [])
+		}
+
+		const history = this.commandHistory.get(event.terminal)!
+		const item: CommandHistoryItem = {
+			commandLine: event.execution.commandLine.value,
+			cwd: event.execution.cwd?.fsPath,
+			exitCode: undefined,
+			output: "",
+			startTime: Date.now(),
+			endTime: undefined,
+		}
+
+		history.push(item)
+
+		// Keep only last N commands per terminal
+		if (history.length > this.maxHistoryPerTerminal) {
+			history.shift()
+		}
+
+		// Notify that history changed
+		this.onHistoryChangedCallback?.()
+		// Collect output asynchronously
+		;(async () => {
+			try {
+				for await (const data of event.execution.read()) {
+					item.output += data
+				}
+			} catch (e) {
+				console.error("Error reading command output:", e)
+			}
+		})()
+	}
+
+	private handleCommandEnd(event: any): void {
+		const history = this.commandHistory.get(event.terminal)
+		if (history && history.length > 0) {
+			const lastItem = history[history.length - 1]
+			if (lastItem.commandLine === event.execution.commandLine.value) {
+				lastItem.exitCode = event.exitCode
+				lastItem.endTime = Date.now()
+			}
+		}
+	}
+
+	/**
+	 * Get the most recent command from a terminal's history
+	 */
+	public getLatestCommand(terminal: vscode.Terminal): CommandInfo | undefined {
+		const history = this.commandHistory.get(terminal)
+		if (!history || history.length === 0) {
+			return undefined
+		}
+
+		const lastCommand = history[history.length - 1]
+
+		return {
+			commandLine: lastCommand.commandLine,
+			cwd: lastCommand.cwd,
+			exitCode: lastCommand.exitCode,
+			cleanOutput: stripAnsi(lastCommand.output),
+			duration: lastCommand.endTime ? lastCommand.endTime - lastCommand.startTime : Date.now() - lastCommand.startTime,
+			timestamp: new Date(lastCommand.startTime),
+		}
+	}
+
+	/**
+	 * Check if a terminal has any command history
+	 */
+	public hasHistory(terminal: vscode.Terminal): boolean {
+		const history = this.commandHistory.get(terminal)
+		return history !== undefined && history.length > 0
+	}
+
+	/**
+	 * Get all commands for a terminal
+	 */
+	public getHistory(terminal: vscode.Terminal): CommandInfo[] {
+		const history = this.commandHistory.get(terminal)
+		if (!history) {
+			return []
+		}
+
+		return history.map((item) => ({
+			commandLine: item.commandLine,
+			cwd: item.cwd,
+			exitCode: item.exitCode,
+			cleanOutput: stripAnsi(item.output),
+			duration: item.endTime ? item.endTime - item.startTime : Date.now() - item.startTime,
+			timestamp: new Date(item.startTime),
+		}))
+	}
+
+	/**
+	 * Clean up resources
+	 */
+	public dispose(): void {
+		this.disposables.forEach((d) => d.dispose())
+		this.disposables = []
+		this.commandHistory.clear()
+	}
+}

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -15,6 +15,7 @@ const ClineCommands = {
 	HistoryButton: prefix + ".historyButtonClicked",
 	AccountButton: prefix + ".accountButtonClicked",
 	TerminalOutput: prefix + ".addTerminalOutputToChat",
+	AddTerminalCommandToChat: prefix + ".addTerminalCommandToChat",
 	AddToChat: prefix + ".addToChat",
 	FixWithCline: prefix + ".fixWithCline",
 	ExplainCode: prefix + ".explainCode",


### PR DESCRIPTION
# Terminal Command Tracking

## Overview

The "Add Last Command to Cline" feature allows you to capture terminal command execution details directly from the terminal context menu and send them to the Cline chat interface.

### Why This Feature Exists

As someone working in Infrastructure rather than development, the command line is my primary tool. During critical moments, I find myself staring at the terminal for half the day, and the output from commands like `kubectl` and `terragrunt` can span pages and pages. I'm honestly tired of carefully selecting the right pieces of output to share with Cline. I just want to feed Cline the entire last command at once—complete with all its context and output—without the tedious manual selection process.

This feature was born from that frustration. One click, and everything about your last command goes straight to Cline.

## Features

### Automatic Command Tracking

Cline automatically tracks terminal commands in the background using VSCode's Shell Integration API. For each command executed, it captures:

- **Command Line**: The exact command that was executed
- **Working Directory**: The directory from which the command ran
- **Execution Time**: When the command started
- **Duration**: How long the command took to complete (in milliseconds)
- **Exit Code**: Command success (0) or failure (non-zero) status
- **Output**: The complete output of the command, cleaned of ANSI escape codes

### Smart Menu Visibility

The menu item "Add Last Command to Cline" appears in the terminal context menu only when:
- Shell integration is enabled (default in VSCode)
- At least one command has been executed in the current terminal
- The terminal is the active terminal

This ensures the menu is only shown when there's actually command data to share.

## Usage

### Basic Usage

1. **Open a terminal** in VSCode
2. **Run any command** (e.g., `ls`, `pwd`, `npm test`, etc.)
3. **Right-click anywhere in the terminal**
4. **Select "Add Last Command to Cline"** from the context menu
5. The command details will be added to the Cline chat

### What Gets Added to Chat

When you use "Add Last Command to Cline", a formatted message is sent to Cline containing:

````
Terminal Command Execution:
Command: `pwd`
Directory: `/Users/username/project`
Time: 11/25/2025, 3:45:00 PM
Duration: 15ms
Exit Code: 0 (Success)

Output:
```
/Users/username/project
```
````

## How it looks like

### Before

https://github.com/user-attachments/assets/de8c0ea1-47da-44d7-9826-510538ec5aae

### After


https://github.com/user-attachments/assets/f31c73d6-4dae-4776-b05c-c5be00c9ed6e


## Technical Details

### Architecture

The feature uses a modular architecture:

**CommandHistoryTracker Module**
- Location: `src/integrations/terminal/CommandHistoryTracker.ts`
- Listens to VSCode shell execution events
- Maintains history of up to 20 recent commands per terminal
- Provides clean API for accessing command data

**Event-Based Tracking**
- `onDidStartTerminalShellExecution`: Captures command start and begins collecting output
- `onDidEndTerminalShellExecution`: Records exit code and end time
- `onDidCloseTerminal`: Cleans up history when terminals close

**Menu Integration**
- Command registered in `package.json` under `contributes.menus.terminal/context`
- Uses context key `cline.terminalHasCommandHistory` for visibility
- Positioned after the standard "Add to Cline" menu item

### Output Processing

**ANSI Code Stripping**
- Uses the existing `stripAnsi()` utility from `src/integrations/terminal/ansiUtils.ts`
- Removes color codes, cursor movements, and OSC sequences
- Ensures clean, readable output in chat

**No Arbitrary Limits**
- Unlike automated terminal output capture, this is a user-initiated action
- No artificial output length limits
- Users get the complete command output

## Limitations

### Shell Integration Required

- Won't work if shell integration is disabled
- May not work with unsupported shells
- Requires VSCode 1.85.0+ for the shell integration API

### Most Recent Command Only

- The menu item adds the **most recent** command from the active terminal
- Future enhancement: Could add a quick pick to select from recent commands

### API Availability

- Uses VSCode's shell integration API which may not be available in all environments
- Gracefully handles when the API is unavailable


<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds "Add Last Command to Cline" feature to track and send the last terminal command to Cline chat in VSCode.
> 
>   - **Feature**:
>     - Adds "Add Last Command to Cline" to terminal context menu in `package.json`.
>     - Registers `cline.addTerminalCommandToChat` command in `extension.ts`.
>     - Uses `CommandHistoryTracker` in `CommandHistoryTracker.ts` to track terminal commands.
>   - **Behavior**:
>     - Tracks command line, working directory, execution time, duration, exit code, and output.
>     - Menu item visible only when shell integration is enabled and a command has been executed.
>   - **Implementation**:
>     - `CommandHistoryTracker` listens to shell execution events, maintains command history.
>     - Strips ANSI codes from command output using `stripAnsi()`.
>     - Updates context key `cline.terminalHasCommandHistory` for menu visibility.
>   - **Misc**:
>     - Adds `AddTerminalCommandToChat` to `ClineCommands` in `registry.ts`.
>     - Handles telemetry for command usage in `extension.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 154aab81e9e93ba1ad5d28ec2a02d29d89b29aa2. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->