### PR TITLE
fix(terminal): simplify cmd.exe command arguments

### DIFF
--- a/standalone/runtime-files/vscode/enhanced-terminal.js
+++ b/standalone/runtime-files/vscode/enhanced-terminal.js
@@ -200,8 +200,7 @@ class StandaloneTerminalProcess extends EventEmitter {
 			if (shell.toLowerCase().includes("powershell") || shell.toLowerCase().includes("pwsh")) {
 				return ["-Command", command]
 			} else {
-				// Use /s /c with quoted command for proper quote handling in cmd.exe
-				return ["/s", "/c", `"${command}"`]
+				return ["/c", command]
 			}
 		} else {
 			// Use -l for login shell, -c for command


### PR DESCRIPTION
Remove /s flag and extra quoting from cmd.exe shell arguments. The previous approach with /s /c and quoted command was causing issues with proper command execution in Windows cmd.exe.



### Description

Solves this 
<img width="347" height="398" alt="image" src="https://github.com/user-attachments/assets/936ee20e-94ba-4e17-bc04-259231589f74" />

Reason 

`The `/s /c "command"` pattern was causing Windows cmd.exe to misinterpret commands, especially those containing quotes or paths with backslashes. The error you saw (`'\"echo Current directory: c:\Mac\Home\Documents\"' is not recognized...`) was because the entire quoted string was being treated as an executable name rather than a command to run.
`


### Test Procedure

<!-- 
Please walk us through your testing approach and thought process. This helps reviewers understand that you've thoroughly considered the impact of your changes:

- How did you test this change?
- What could potentially break and how did you verify it doesn't?
- What existing functionality might be affected and how did you check it still works?
- Why are you confident this is ready for merge?

We're not looking for exhaustive documentation - just evidence that you've thought through the implications of your changes and tested accordingly.
-->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [ ] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Simplifies `cmd.exe` command arguments in `enhanced-terminal.js` to fix misinterpretation issues in Windows.
> 
>   - **Behavior**:
>     - Simplifies `cmd.exe` command arguments in `getShellArgs()` by removing `/s` flag and extra quoting.
>     - Fixes command misinterpretation issue in Windows `cmd.exe`.
>   - **Files**:
>     - Updates `enhanced-terminal.js` to adjust command execution logic for Windows.
>   - **Misc**:
>     - Resolves error where quoted command was treated as executable name.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 3b102cdec41003546f0507f7854dcbc7eefb3d1a. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->