### PR TITLE
Add os/cline-ver/host-info to task metadata & change "Task History -> EXPORT" to just open the task directory

### DIFF
--- a/src/core/context/context-tracking/ContextTrackerTypes.ts
+++ b/src/core/context/context-tracking/ContextTrackerTypes.ts
@@ -15,7 +15,18 @@ export interface ModelMetadataEntry {
 	mode: string
 }
 
+export interface EnvironmentMetadataEntry {
+	ts: number
+	os_name: string
+	os_version: string
+	os_arch: string
+	host_name: string
+	host_version: string
+	cline_version: string
+}
+
 export interface TaskMetadata {
 	files_in_context: FileMetadataEntry[]
 	model_usage: ModelMetadataEntry[]
+	environment_history: EnvironmentMetadataEntry[]
 }

--- a/src/core/context/context-tracking/EnvironmentContextTracker.ts
+++ b/src/core/context/context-tracking/EnvironmentContextTracker.ts
@@ -1,0 +1,43 @@
+import { collectEnvironmentMetadata, getTaskMetadata, saveTaskMetadata } from "@core/storage/disk"
+import type { EnvironmentMetadataEntry } from "./ContextTrackerTypes"
+
+export class EnvironmentContextTracker {
+	readonly taskId: string
+
+	constructor(taskId: string) {
+		this.taskId = taskId
+	}
+
+	async recordEnvironment() {
+		const metadata = await getTaskMetadata(this.taskId)
+
+		if (!metadata.environment_history) {
+			metadata.environment_history = []
+		}
+
+		const currentEnv = await collectEnvironmentMetadata()
+		const currentEnvWithTs: EnvironmentMetadataEntry = {
+			ts: Date.now(),
+			...currentEnv,
+		}
+
+		const lastEntry = metadata.environment_history[metadata.environment_history.length - 1]
+		if (lastEntry && this.isSameEnvironment(lastEntry, currentEnvWithTs)) {
+			return // No change, don't add duplicate
+		}
+
+		metadata.environment_history.push(currentEnvWithTs)
+		await saveTaskMetadata(this.taskId, metadata)
+	}
+
+	private isSameEnvironment(a: EnvironmentMetadataEntry, b: EnvironmentMetadataEntry): boolean {
+		return (
+			a.os_name === b.os_name &&
+			a.os_version === b.os_version &&
+			a.os_arch === b.os_arch &&
+			a.host_name === b.host_name &&
+			a.host_version === b.host_version &&
+			a.cline_version === b.cline_version
+		)
+	}
+}

--- a/src/core/context/context-tracking/FileContextTracker.test.ts
+++ b/src/core/context/context-tracking/FileContextTracker.test.ts
@@ -47,7 +47,7 @@ describe("FileContextTracker", () => {
 		chokidarWatchStub = sandbox.stub(chokidar, "watch").returns(mockFileSystemWatcher as any)
 
 		// Mock disk module functions
-		mockTaskMetadata = { files_in_context: [], model_usage: [] }
+		mockTaskMetadata = { files_in_context: [], model_usage: [], environment_history: [] }
 		getTaskMetadataStub = sandbox.stub(diskModule, "getTaskMetadata").resolves(mockTaskMetadata)
 		saveTaskMetadataStub = sandbox.stub(diskModule, "saveTaskMetadata").resolves()
 

--- a/src/core/context/context-tracking/ModelContextTracker.test.ts
+++ b/src/core/context/context-tracking/ModelContextTracker.test.ts
@@ -17,7 +17,7 @@ describe("ModelContextTracker", () => {
 		sandbox = sinon.createSandbox()
 
 		// Mock disk module functions
-		mockTaskMetadata = { files_in_context: [], model_usage: [] }
+		mockTaskMetadata = { files_in_context: [], model_usage: [], environment_history: [] }
 		getTaskMetadataStub = sandbox.stub(diskModule, "getTaskMetadata").resolves(mockTaskMetadata)
 		saveTaskMetadataStub = sandbox.stub(diskModule, "saveTaskMetadata").resolves()
 

--- a/src/core/controller/index.ts
+++ b/src/core/controller/index.ts
@@ -5,7 +5,6 @@ import { detectWorkspaceRoots } from "@core/workspace/detection"
 import { setupWorkspaceManager } from "@core/workspace/setup"
 import type { WorkspaceRootManager } from "@core/workspace/WorkspaceRootManager"
 import { cleanupLegacyCheckpoints } from "@integrations/checkpoints/CheckpointMigration"
-import { downloadTask } from "@integrations/misc/export-markdown"
 import { ClineAccountService } from "@services/account/ClineAccountService"
 import { McpHub } from "@services/mcp/McpHub"
 import type { ApiProvider, ModelInfo } from "@shared/api"
@@ -20,6 +19,7 @@ import type { UserInfo } from "@shared/UserInfo"
 import { fileExistsAtPath } from "@utils/fs"
 import axios from "axios"
 import fs from "fs/promises"
+import open from "open"
 import pWaitFor from "p-wait-for"
 import * as path from "path"
 import type { FolderLockWithRetryResult } from "src/core/locks/types"
@@ -824,8 +824,9 @@ export class Controller {
 	}
 
 	async exportTaskWithId(id: string) {
-		const { historyItem, apiConversationHistory } = await this.getTaskWithId(id)
-		await downloadTask(historyItem.ts, apiConversationHistory)
+		const { taskDirPath } = await this.getTaskWithId(id)
+		console.log(`[EXPORT] Opening task directory: ${taskDirPath}`)
+		await open(taskDirPath)
 	}
 
 	async deleteTaskFromState(id: string) {

--- a/src/core/task/index.ts
+++ b/src/core/task/index.ts
@@ -5,6 +5,7 @@ import { AssistantMessageContent, parseAssistantMessageV2, ToolUse } from "@core
 import { ContextManager } from "@core/context/context-management/ContextManager"
 import { checkContextWindowExceededError } from "@core/context/context-management/context-error-handling"
 import { getContextWindowInfo } from "@core/context/context-management/context-window-utils"
+import { EnvironmentContextTracker } from "@core/context/context-tracking/EnvironmentContextTracker"
 import { FileContextTracker } from "@core/context/context-tracking/FileContextTracker"
 import { ModelContextTracker } from "@core/context/context-tracking/ModelContextTracker"
 import {
@@ -227,6 +228,7 @@ export class Task {
 	// Metadata tracking
 	private fileContextTracker: FileContextTracker
 	private modelContextTracker: ModelContextTracker
+	private environmentContextTracker: EnvironmentContextTracker
 
 	// Focus Chain
 	private FocusChainManager?: FocusChainManager
@@ -363,9 +365,10 @@ export class Task {
 			updateTaskHistory: this.updateTaskHistory,
 		})
 
-		// Initialize file context tracker
+		// Initialize context trackers
 		this.fileContextTracker = new FileContextTracker(controller, this.taskId)
 		this.modelContextTracker = new ModelContextTracker(this.taskId)
+		this.environmentContextTracker = new EnvironmentContextTracker(this.taskId)
 
 		// Initialize focus chain manager only if enabled
 		const focusChainSettings = this.stateManager.getGlobalSettingsKey("focusChainSettings")
@@ -1017,6 +1020,13 @@ export class Task {
 			})
 		}
 
+		// Record environment metadata for new task
+		try {
+			await this.environmentContextTracker.recordEnvironment()
+		} catch (error) {
+			console.error("Failed to record environment metadata:", error)
+		}
+
 		await this.initiateTaskLoop(userContent)
 	}
 
@@ -1277,6 +1287,13 @@ export class Task {
 				type: "text",
 				text: `<hook_context source="UserPromptSubmit">\n${userPromptHookResult.contextModification}\n</hook_context>`,
 			})
+		}
+
+		// Record environment metadata when resuming task (tracks cross-platform migrations)
+		try {
+			await this.environmentContextTracker.recordEnvironment()
+		} catch (error) {
+			console.error("Failed to record environment metadata on resume:", error)
 		}
 
 		await this.messageStateHandler.overwriteApiConversationHistory(modifiedApiConversationHistory)

--- a/src/integrations/misc/export-markdown.ts
+++ b/src/integrations/misc/export-markdown.ts
@@ -1,58 +1,9 @@
 import { Anthropic } from "@anthropic-ai/sdk"
-import { writeFile } from "@utils/fs"
-import os from "os"
-import * as path from "path"
-import { HostProvider } from "@/hosts/host-provider"
-import { ShowMessageType } from "@/shared/proto/host/window"
-import { openFile } from "./open-file"
 
-export async function downloadTask(dateTs: number, conversationHistory: Anthropic.MessageParam[]) {
-	// File name
-	const date = new Date(dateTs)
-	const month = date.toLocaleString("en-US", { month: "short" }).toLowerCase()
-	const day = date.getDate()
-	const year = date.getFullYear()
-	let hours = date.getHours()
-	const minutes = date.getMinutes().toString().padStart(2, "0")
-	const seconds = date.getSeconds().toString().padStart(2, "0")
-	const ampm = hours >= 12 ? "pm" : "am"
-	hours = hours % 12
-	hours = hours ? hours : 12 // the hour '0' should be '12'
-	const fileName = `cline_task_${month}-${day}-${year}_${hours}-${minutes}-${seconds}-${ampm}.md`
-
-	// Generate markdown
-	const markdownContent = conversationHistory
-		.map((message) => {
-			const role = message.role === "user" ? "**User:**" : "**Assistant:**"
-			const content = Array.isArray(message.content)
-				? message.content.map((block) => formatContentBlockToMarkdown(block)).join("\n")
-				: message.content
-			return `${role}\n\n${content}\n\n`
-		})
-		.join("---\n\n")
-
-	// Prompt user for save location
-	const saveResponse = await HostProvider.window.showSaveDialog({
-		options: {
-			filters: { Markdown: { extensions: ["md"] } },
-			defaultPath: path.join(os.homedir(), "Downloads", fileName),
-		},
-	})
-
-	if (saveResponse.selectedPath) {
-		try {
-			// Write content to the selected location
-			await writeFile(saveResponse.selectedPath, markdownContent)
-			await openFile(saveResponse.selectedPath, false, true)
-		} catch (error) {
-			await HostProvider.window.showMessage({
-				type: ShowMessageType.ERROR,
-				message: `Failed to save markdown file: ${error instanceof Error ? error.message : String(error)}`,
-			})
-		}
-	}
-}
-
+/**
+ * Formats a content block to markdown for display in API request messages.
+ * Used by Task class to format user content for the api_req_started message.
+ */
 export function formatContentBlockToMarkdown(block: Anthropic.ContentBlockParam): string {
 	switch (block.type) {
 		case "text":


### PR DESCRIPTION
### Description

Currently, when you go to Task History and press EXPORT, it was making a markdown version of the conversation. This is not very useful, since the data isn't structured, can't be imported anywhere aside from an LLM, and didn't have a lot of useful information for helping us debug real issues that people were facing. Now, the EXPORT button simply opens the task directory, which contains the api history, the messages displayed to the user, the focus chain checklist, and the task metadata

The task metadata now contains `environment_history`, an array that shows which OS/IDE/cline version was used in that task. Whenever a task is started OR RESUMED we add more elements to this history, if it changed. This means that if a task was started in the CLI, and then you updated the CLI version and resumed it, that would be reflected. If you then resumed the task in JetBrains, that would also be logged. This way, if a user submits this file to us, we will be able to understand what happened with that task with pretty high precision, and avoid needing them to type out / remember all this info about their OS version and whatever

```
{
  "files_in_context": [],
  "model_usage": [
    {
      "ts": 1764190050716,
      "model_id": "anthropic/claude-sonnet-4.5",
      "model_provider_id": "cline",
      "mode": "plan"
    }
  ],
  "environment_history": [
    {
      "ts": 1764190050715,
      "os_name": "darwin",
      "os_version": "24.6.0",
      "os_arch": "arm64",
      "host_name": "Visual Studio Code",
      "host_version": "1.106.0",
      "cline_version": "3.38.2"
    }
  ]
}
```


https://github.com/user-attachments/assets/4fb3b5ab-9c2d-4fcc-abf6-9eb28079d7c5


### Test Procedure

- Make a new task
- Go to Task History
- Press EXPORT
- View the task metadata
- Bonus points: update your IDE during this process, or start in CLI and then resume the task in JetBrains

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [x] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> This PR adds environment metadata tracking to tasks and changes the task export functionality to open the task directory instead of exporting markdown.
> 
>   - **Behavior**:
>     - `exportTaskWithId()` in `index.ts` now opens the task directory instead of exporting markdown.
>     - `TaskMetadata` in `ContextTrackerTypes.ts` now includes `environment_history` to track OS/IDE/CLI version changes.
>     - `EnvironmentContextTracker` class added to track environment metadata on task start and resume.
>   - **Tests**:
>     - Updated `FileContextTracker.test.ts` and `ModelContextTracker.test.ts` to include `environment_history` in `mockTaskMetadata`.
>   - **Misc**:
>     - Removed `downloadTask()` from `export-markdown.ts` and related imports in `index.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 4a51b1476481f1c1e4cc00a9228042cc61fa1744. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->