### PR TITLE
fix: Handle errors when LiteLLM API key not configured

### DIFF
--- a/src/core/controller/models/refreshLiteLlmModels.ts
+++ b/src/core/controller/models/refreshLiteLlmModels.ts
@@ -22,7 +22,9 @@ export async function refreshLiteLlmModels(): Promise<Record<string, ModelInfo>>
 		const apiKey = apiConfiguration.liteLlmApiKey
 
 		if (!apiKey) {
-			throw new Error("LiteLLM API key is not configured or is invalid")
+			// LiteLLM not configured - this is expected for most users
+			// Return empty models and skip the event notification below
+			return models
 		}
 
 		// Use the shared utility function to fetch model info
@@ -56,8 +58,10 @@ export async function refreshLiteLlmModels(): Promise<Record<string, ModelInfo>>
 			}
 		}
 	} catch (error) {
+		// Only log unexpected errors (network issues, parsing errors, etc.)
 		console.error("Error fetching LiteLLM models:", error)
-		throw error
+		// Return empty models instead of rethrowing
+		return models
 	}
 
 	// Store in StateManager's in-memory cache

--- a/src/core/controller/models/refreshLiteLlmModelsRpc.ts
+++ b/src/core/controller/models/refreshLiteLlmModelsRpc.ts
@@ -14,8 +14,16 @@ export async function refreshLiteLlmModelsRpc(
 	_controller: Controller,
 	_request: EmptyRequest,
 ): Promise<OpenRouterCompatibleModelInfo> {
-	const models = await refreshLiteLlmModels()
-	return OpenRouterCompatibleModelInfo.create({
-		models: toProtobufModels(models),
-	})
+	try {
+		const models = await refreshLiteLlmModels()
+		return OpenRouterCompatibleModelInfo.create({
+			models: toProtobufModels(models),
+		})
+	} catch (error) {
+		// LiteLLM not configured, this is expected for most users
+		// Return empty models list instead of throwing
+		return OpenRouterCompatibleModelInfo.create({
+			models: {},
+		})
+	}
 }

--- a/src/core/controller/ui/initializeWebview.ts
+++ b/src/core/controller/ui/initializeWebview.ts
@@ -196,7 +196,10 @@ export async function initializeWebview(controller: Controller, _request: EmptyR
 		})
 
 		// State update event sent within the refreshLiteLlmModels function
-		refreshLiteLlmModels()
+		refreshLiteLlmModels().catch((error) => {
+			// LiteLLM not configured, this is expected for most users
+			console.log("LiteLLM not configured, skipping model refresh")
+		})
 
 		// GUI relies on model info to be up-to-date to provide the most accurate pricing, so we need to fetch the latest details on launch.
 		// We do this for all users since many users switch between api providers and if they were to switch back to openrouter it would be showing outdated model info if we hadn't retrieved the latest at this point


### PR DESCRIPTION
### Related Issue

**Issue:** n/a

### Description

This is a simple fix in the extension to handle the scenario where the LiteLLM API key is not configured.  Most users will not have LiteLLM configured, and the resulting user experience is that a handful of uncaught errors appear in the VSCode developer tools console.  This is noisy but it doesn't affect the behavior of the extension.

<img width="546" height="561" alt="Screenshot 2025-11-26 at 2 37 38 PM" src="https://github.com/user-attachments/assets/7a237359-69a1-45c2-a56c-9abc8df2b79f" />

This PR adds error handling to prevent it from making noise in the console output.


### Test Procedure

* Before the fix: search for "LiteLLM" in the console output to observe the noise/red.
* After the fix: search for "LiteLLM" in the console output and find 0 results.


### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

n/a (see above)

### Additional Notes

n/a
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Improves error handling for missing LiteLLM API key by returning empty models and logging messages instead of errors.
> 
>   - **Error Handling**:
>     - In `refreshLiteLlmModels()`, return empty models if LiteLLM API key is not configured, instead of throwing an error.
>     - In `refreshLiteLlmModelsRpc()`, catch errors and return empty models list if LiteLLM is not configured.
>     - In `initializeWebview()`, log a message instead of an error if LiteLLM is not configured during model refresh.
>   - **Logging**:
>     - Log only unexpected errors (e.g., network issues) in `refreshLiteLlmModels()` and `refreshLiteLlmModelsRpc()`.
>     - Log a message in `initializeWebview()` when skipping model refresh due to missing LiteLLM configuration.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 40234079303e620802555af2c05e2520f618bb8f. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->