### PR TITLE
fix(telemetry): prevent property shifting in workspace context tracking

### DIFF
--- a/src/services/telemetry/TelemetryService.ts
+++ b/src/services/telemetry/TelemetryService.ts
@@ -885,12 +885,14 @@ export class TelemetryService {
 		provider: string,
 		autoApproved: boolean,
 		success: boolean,
-		workspaceContext?: {
-			isMultiRootEnabled: boolean
-			usedWorkspaceHint: boolean
-			resolvedToNonPrimary: boolean
-			resolutionMethod: "hint" | "primary_fallback" | "path_detection"
-		},
+		workspaceContext:
+			| {
+					isMultiRootEnabled: boolean
+					usedWorkspaceHint: boolean
+					resolvedToNonPrimary: boolean
+					resolutionMethod: "hint" | "primary_fallback" | "path_detection"
+			  }
+			| undefined = undefined,
 		isNativeToolCall = false,
 	) {
 		this.capture({
@@ -902,13 +904,18 @@ export class TelemetryService {
 				success,
 				modelId,
 				provider,
-				// Workspace context (optional)
-				...(workspaceContext && {
-					workspace_multi_root_enabled: workspaceContext.isMultiRootEnabled,
-					workspace_hint_used: workspaceContext.usedWorkspaceHint,
-					workspace_resolved_non_primary: workspaceContext.resolvedToNonPrimary,
-					workspace_resolution_method: workspaceContext.resolutionMethod,
-				}),
+				// Workspace context (optional) - set to undefined if not provided
+				// else the properties will not be included, and the value for isNativeToolCall will be shifted.
+				workspaceContext: {
+					...(workspaceContext
+						? {
+								workspace_multi_root_enabled: workspaceContext.isMultiRootEnabled,
+								workspace_hint_used: workspaceContext.usedWorkspaceHint,
+								workspace_resolved_non_primary: workspaceContext.resolvedToNonPrimary,
+								workspace_resolution_method: workspaceContext.resolutionMethod,
+							}
+						: undefined),
+				},
 				isNativeToolCall,
 			},
 		})


### PR DESCRIPTION
<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- For feature requests: Created a discussion in our Feature Requests discussions board https://github.com/cline/cline/discussions/categories/feature-requests and received approval from core maintainers before implementation
- For all changes: Link the associated issue/discussion in the "Related Issue" section below

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly without prior discussion.

Why this requirement?
We deeply appreciate all community contributions - they are essential to Cline's success! To ensure the best use of everyone's time and maintain project direction, we use our Feature Requests discussions board to gauge community interest and validate feature ideas before implementation begins. This helps us focus development efforts on features that will benefit the most users.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** #XXXX

### Description

<!-- 
Help reviewers understand your changes by making this PR readable and well-organized:

- What problem does this PR solve?
- Why were these changes introduced and what purpose do they serve?
- For larger changes, provide context about your approach and reasoning

Small PRs may need minimal description, but larger changes benefit from explaining where you're coming from. Much of this context can be in the linked issue above, so feel free to reference it rather than repeating everything here.
-->

Wrap workspace context properties in a dedicated object instead of conditionally spreading them. This ensures that when workspaceContext is not provided, the structure remains consistent and subsequent properties like isNativeToolCall maintain their correct positions in the telemetry payload.

Previously, the conditional spread operator could cause property misalignment when workspaceContext was undefined, leading to isNativeToolCall value being assigned to the wrong property.

### Test Procedure

<!-- 
Please walk us through your testing approach and thought process. This helps reviewers understand that you've thoroughly considered the impact of your changes:

- How did you test this change?
- What could potentially break and how did you verify it doesn't?
- What existing functionality might be affected and how did you check it still works?
- Why are you confident this is ready for merge?

We're not looking for exhaustive documentation - just evidence that you've thought through the implications of your changes and tested accordingly.
-->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes telemetry property misalignment in `captureToolUsage()` by wrapping `workspaceContext` in a dedicated object in `TelemetryService.ts`.
> 
>   - **Behavior**:
>     - Fixes property misalignment in telemetry payloads in `captureToolUsage()` in `TelemetryService.ts` by wrapping `workspaceContext` properties in a dedicated object.
>     - Ensures `isNativeToolCall` maintains correct position when `workspaceContext` is undefined.
>   - **Misc**:
>     - Updates default value of `workspaceContext` to `undefined` in `captureToolUsage()` in `TelemetryService.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 9be0365399d78763b64ba65bd3abe80026e0299e. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->