### PR TITLE
set the cli's 'ide version' to just the cli version rather than being blank, to make environment_history work for CLI

### DIFF
--- a/cli/pkg/hostbridge/env.go
+++ b/cli/pkg/hostbridge/env.go
@@ -77,7 +77,7 @@ func (s *EnvService) GetHostVersion(ctx context.Context, req *cline.EmptyRequest
 
 	return &host.GetHostVersionResponse{
 		Platform:     proto.String("Cline CLI"),
-		Version:      proto.String(""),
+		Version:      proto.String(global.CliVersion),
 		ClineType:    proto.String("CLI"),
 		ClineVersion: proto.String(global.CliVersion),
 	}, nil


### PR DESCRIPTION
### Description

Previously, our generic Go host implementation of the host bridge wouldn't return any version number as the "ide version", since the CLI would just display it from the UI anyway. But now with the environment_history in metadata yaml, we need this function to operate correctly, or else it'll say "undefined" in the metadata

### Test Procedure

Make a CLI task, and check that the ~/.cline/data/task/<x>/task_metadata.json is correct. You can use `cline t l` to list the tasks, the one at the end is the most recent

```
Andreis-MacBook-Pro.lung 1764200559075: cat task_metadata.json 
{
  "files_in_context": [],
  "model_usage": [
    {
      "ts": 1764200559085,
      "model_id": "anthropic/claude-sonnet-4.5",
      "model_provider_id": "cline",
      "mode": "plan"
    }
  ],
  "environment_history": [
    {
      "ts": 1764200559084,
      "os_name": "darwin",
      "os_version": "24.6.0",
      "os_arch": "arm64",
      "host_name": "Cline CLI",
      "host_version": "1.0.3",
      "cline_version": "3.38.2"
    }
  ]
}%                                                                              
```

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Set `Version` to `global.CliVersion` in `GetHostVersion()` in `env.go` to fix blank "ide version" in metadata.
> 
>   - **Behavior**:
>     - Sets `Version` to `global.CliVersion` in `GetHostVersion()` in `env.go` to populate CLI version in environment history.
>   - **Misc**:
>     - Fixes issue where "ide version" was blank in metadata, causing it to display "undefined".
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for a292720bbbcb334126f2a1e97888c2ddc64afc98. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->