### PR TITLE
fix: unblock opening a task when using cline account

### DIFF
--- a/src/core/controller/index.ts
+++ b/src/core/controller/index.ts
@@ -251,7 +251,14 @@ export class Controller {
 		historyItem?: HistoryItem,
 		taskSettings?: Partial<Settings>,
 	) {
-		await fetchRemoteConfig(this)
+		// Fire-and-forget: We intentionally don't await fetchRemoteConfig here.
+		// Remote config is already fetched in startRemoteConfigTimer() which runs in the constructor,
+		// so enterprise policies (yoloModeAllowed, allowedMCPServers, etc.) are already applied.
+		// This call just ensures we have the latest state, but we shouldn't block the UI for it.
+		// getGlobalSettingsKey() reads from remoteConfigCache on each call, so any updates
+		// will apply as soon as this fetch completes. The function also calls postStateToWebview()
+		// when done and catches all errors internally.
+		fetchRemoteConfig(this)
 
 		await this.clearTask() // ensures that an existing task doesn't exist before starting a new one, although this shouldn't be possible since user must clear task before starting a new one
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> In `Controller`, `initTask()` no longer awaits `fetchRemoteConfig`, keeping the UI responsive while fetching remote configurations.
> 
>   - **Behavior**:
>     - In `Controller` class, `initTask()` no longer awaits `fetchRemoteConfig`, allowing UI to remain responsive while fetching remote configurations.
>     - `fetchRemoteConfig` is still called in `startRemoteConfigTimer()` during construction, ensuring enterprise policies are applied.
>   - **Comments**:
>     - Added comments in `initTask()` explaining the rationale for not awaiting `fetchRemoteConfig` and how updates are applied post-fetch.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 565c4f1c7a26f756b2d135bb778143c3c8de4ee3. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->