### PR TITLE
fix(bedrock): add sts client userAgentAppId

### DIFF
--- a/.changeset/flat-swans-notice.md
+++ b/.changeset/flat-swans-notice.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Add sts client userAgentAppId

--- a/src/core/api/providers/bedrock.ts
+++ b/src/core/api/providers/bedrock.ts
@@ -104,6 +104,7 @@ interface CachePointContentBlock {
 
 // Define provider options type based on AWS SDK patterns
 interface ProviderChainOptions {
+	clientConfig?: { userAgentAppId?: string }
 	ignoreCache?: boolean
 	profile?: string
 }
@@ -211,7 +212,12 @@ export class AwsBedrockHandler implements ApiHandler {
 		sessionToken?: string
 	}> {
 		// Configure provider options
-		const providerOptions: ProviderChainOptions = {}
+		const providerOptions: ProviderChainOptions = {
+			clientConfig: {
+				// set the inner sts client userAgentAppId
+				userAgentAppId: `cline#${ExtensionRegistryInfo.version}`,
+			},
+		}
 		const useProfile =
 			(this.options.awsAuthentication === undefined && this.options.awsUseProfile) ||
 			this.options.awsAuthentication === "profile"


### PR DESCRIPTION
<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- For feature requests: Created a discussion in our Feature Requests discussions board https://github.com/cline/cline/discussions/categories/feature-requests and received approval from core maintainers before implementation
- For all changes: Link the associated issue/discussion in the "Related Issue" section below

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly without prior discussion.

Why this requirement?
We deeply appreciate all community contributions - they are essential to Cline's success! To ensure the best use of everyone's time and maintain project direction, we use our Feature Requests discussions board to gauge community interest and validate feature ideas before implementation begins. This helps us focus development efforts on features that will benefit the most users.
-->

### Related Issue

Cannot identify the version of Cline calling [STS](https://docs.aws.amazon.com/STS/latest/APIReference/welcome.html) client when using role chaining. Related to #7273.

### Description

<!-- 
Help reviewers understand your changes by making this PR readable and well-organized:

- What problem does this PR solve?
- Why were these changes introduced and what purpose do they serve?
- For larger changes, provide context about your approach and reasoning

Small PRs may need minimal description, but larger changes benefit from explaining where you're coming from. Much of this context can be in the linked issue above, so feel free to reference it rather than repeating everything here.
-->

Role chaining is when you use a role to assume a second role ([docs](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles.html)). STS calls from Cline when an AWS profile uses role chaining did not report the cline version:

```
aws-sdk-js/3.922.0 ua/2.1 os/darwin#24.6.0 lang/js md/nodejs#22.19.0 api/sts#3.922.0 m/E,w,v
```

**Root Cause**: Since auth is handled separately from Bedrock Runtime Client initialization, the `userAgentAppId` set there is not automatically propagated to the STS calls as expected from https://github.com/aws/aws-sdk-js-v3/pull/7469.

### Test Procedure

<!-- 
Please walk us through your testing approach and thought process. This helps reviewers understand that you've thoroughly considered the impact of your changes:

- How did you test this change?
- What could potentially break and how did you verify it doesn't?
- What existing functionality might be affected and how did you check it still works?
- Why are you confident this is ready for merge?

We're not looking for exhaustive documentation - just evidence that you've thought through the implications of your changes and tested accordingly.
-->

I created a role-chaining profile to use with Cline – configured Cline to use `role-b`.
```
[profile role-a]
...
region=us-west-2

[profile role-b]
source_profile=role-a
role_arn=arn:aws:iam::123456789123:role/role-name
region=us-west-2
```

I sent a few requests with the bedrock provider, and I saw the correct userAgent value for the STS AssumeRole requests in CloudTrail:
```
aws-sdk-js/3.922.0 ua/2.1 os/darwin#24.6.0 lang/js md/nodejs#22.19.0 api/sts#3.922.0 m/E,w,v app/cline#3.38.3
```

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

```sh
// before
2025-11-27T01:09:10Z	AssumeRole	sts.amazonaws.com	aws-sdk-js/3.922.0 ua/2.1 os/darwin#24.6.0 lang/js md/nodejs#22.19.0 api/sts#3.922.0 m/E,w,v
// after
2025-11-27T01:12:23Z	AssumeRole	sts.amazonaws.com	aws-sdk-js/3.922.0 ua/2.1 os/darwin#24.6.0 lang/js md/nodejs#22.19.0 api/sts#3.922.0 m/E,w,v app/cline#3.38.3
```

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `userAgentAppId` to STS client configuration in `bedrock.ts` to report Cline version in role chaining scenarios.
> 
>   - **Behavior**:
>     - Adds `userAgentAppId` to STS client configuration in `bedrock.ts` to report Cline version in STS calls.
>     - Affects role chaining scenarios where Cline version was not previously reported.
>   - **Code Changes**:
>     - Updates `ProviderChainOptions` interface to include `clientConfig` with `userAgentAppId`.
>     - Modifies `getAwsCredentials()` in `AwsBedrockHandler` to set `userAgentAppId` using `ExtensionRegistryInfo.version`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 676343b604ed8d709347ceca84f56b2d83c02f07. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->