### PR TITLE
Fix API request badge causing text to wrap when hidden

### DIFF
--- a/webview-ui/src/components/chat/ChatRow.tsx
+++ b/webview-ui/src/components/chat/ChatRow.tsx
@@ -1275,7 +1275,7 @@ export const ChatRowContent = memo(
 											style={{
 												opacity: cost != null && cost > 0 ? 1 : 0,
 											}}>
-											${Number(cost || 0)?.toFixed(4)}
+											{cost != null && Number(cost || 0) > 0 ? `$${Number(cost || 0).toFixed(4)}` : ""}
 										</VSCodeBadge>
 									</div>
 									<span className={`codicon codicon-chevron-${isExpanded ? "up" : "down"}`}></span>


### PR DESCRIPTION
### Related Issue

**Issue:** N/A (minor UI bug fix)

### Description

The cost badge in the chat row was using `opacity: 0` to hide itself when there's no cost, but still rendered "$0.0000" which took up horizontal space. This caused the "API Request..." label to wrap to a second line unnecessarily.

Now the badge renders empty content when hidden, taking up no width while still maintaining its height contribution to the row layout (which is needed for consistent row heights when the cost appears).

### Test Procedure

1. Start a new task that triggers an API request
2. Observe that "API Request..." label no longer wraps to a second line
3. Wait for the request to complete and verify the cost badge appears correctly

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes text wrapping issue in `ChatRow.tsx` by rendering empty content for hidden cost badge, maintaining layout consistency.
> 
>   - **Behavior**:
>     - In `ChatRow.tsx`, the cost badge now renders empty content when hidden, preventing unnecessary text wrapping.
>     - Maintains height contribution to row layout for consistent row heights.
>   - **UI**:
>     - Fixes issue where "API Request..." label wrapped to a second line when cost badge was hidden.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for b665090b75b23cbefb2fcf6cd7bb1012cdb36a0a. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->