### PR TITLE
feat: add tabbed model picker with Recommended and Free tabs

### DIFF
--- a/webview-ui/src/components/settings/OpenRouterModelPicker.tsx
+++ b/webview-ui/src/components/settings/OpenRouterModelPicker.tsx
@@ -44,31 +44,44 @@ export interface OpenRouterModelPickerProps {
 	currentMode: Mode
 }
 
-// Featured models for Cline provider
-const featuredModels = [
+// Featured models for Cline provider organized by tabs
+const recommendedModels = [
 	{
 		id: "anthropic/claude-sonnet-4.5",
-		description: "Recommended for agentic coding in Cline",
-		label: "Best",
+		description: "Best balance of speed, cost, and quality",
+		label: "BEST",
 	},
 	{
 		id: "anthropic/claude-opus-4.5",
-		description: "SOTA performance on coding at 3x lower cost than Opus 4.1",
-		label: "New",
+		description: "State-of-the-art for complex coding",
+		label: "NEW",
+	},
+	{
+		id: "openai/gpt-5.1",
+		description: "OpenAI's latest with strong coding abilities",
+		label: "HOT",
 	},
 	{
 		id: "google/gemini-3-pro-preview",
-		description: "Google's latest reasoning model with 1M context window",
-		label: "Trending",
-	},
-	{
-		id: "x-ai/grok-code-fast-1",
-		description: "Advanced model with 262K context for complex coding",
-		label: "Free",
-		isFree: true,
+		description: "1M context window for large codebases",
+		label: "1M CTX",
 	},
 ]
-const FREE_CLINE_MODELS = featuredModels.filter((m) => m.isFree)
+
+const freeModels = [
+	{
+		id: "x-ai/grok-code-fast-1",
+		description: "Fast inference with strong coding performance",
+		label: "FAST",
+	},
+	{
+		id: "minimax/minimax-m2",
+		description: "Open source model with solid performance",
+		label: "OSS",
+	},
+]
+
+const FREE_CLINE_MODELS = freeModels.map((m) => m.id)
 
 const OpenRouterModelPicker: React.FC<OpenRouterModelPickerProps> = ({ isPopup, currentMode }) => {
 	const { handleModeFieldChange, handleModeFieldsChange } = useApiConfigurationHandlers()
@@ -77,6 +90,7 @@ const OpenRouterModelPicker: React.FC<OpenRouterModelPickerProps> = ({ isPopup, 
 	const [searchTerm, setSearchTerm] = useState(modeFields.openRouterModelId || openRouterDefaultModelId)
 	const [isDropdownVisible, setIsDropdownVisible] = useState(false)
 	const [selectedIndex, setSelectedIndex] = useState(-1)
+	const [activeTab, setActiveTab] = useState<"recommended" | "free">("recommended")
 	const dropdownRef = useRef<HTMLDivElement>(null)
 	const itemRefs = useRef<(HTMLDivElement | null)[]>([])
 	const dropdownListRef = useRef<HTMLDivElement>(null)
@@ -103,7 +117,7 @@ const OpenRouterModelPicker: React.FC<OpenRouterModelPickerProps> = ({ isPopup, 
 		const selected = normalizeApiConfiguration(apiConfiguration, currentMode)
 		const isCline = selected.selectedProvider === "cline"
 		// Makes sure "Free" featured models have $0 pricing for Cline provider
-		if (isCline && FREE_CLINE_MODELS.some((fm) => fm.id === selected.selectedModelId)) {
+		if (isCline && FREE_CLINE_MODELS.includes(selected.selectedModelId)) {
 			return {
 				...selected,
 				selectedModelInfo: {
@@ -293,21 +307,49 @@ const OpenRouterModelPicker: React.FC<OpenRouterModelPickerProps> = ({ isPopup, 
 				</label>
 
 				{modeFields.apiProvider === "cline" && (
-					<div style={{ marginBottom: "6px", marginTop: 4 }}>
-						{featuredModels.map((model) => (
-							<FeaturedModelCard
-								description={model.description}
-								isSelected={selectedModelId === model.id}
-								key={model.id}
-								label={model.label}
-								modelId={model.id}
-								onClick={() => {
-									handleModelChange(model.id)
-									setIsDropdownVisible(false)
-								}}
-							/>
-						))}
-					</div>
+					<>
+						{/* Tabs */}
+						<TabsContainer style={{ marginTop: 4 }}>
+							<Tab active={activeTab === "recommended"} onClick={() => setActiveTab("recommended")}>
+								Recommended
+							</Tab>
+							<Tab active={activeTab === "free"} onClick={() => setActiveTab("free")}>
+								Free
+							</Tab>
+						</TabsContainer>
+
+						{/* Model Cards */}
+						<div style={{ marginBottom: "6px" }}>
+							{activeTab === "recommended" &&
+								recommendedModels.map((model) => (
+									<FeaturedModelCard
+										description={model.description}
+										isSelected={selectedModelId === model.id}
+										key={model.id}
+										label={model.label}
+										modelId={model.id}
+										onClick={() => {
+											handleModelChange(model.id)
+											setIsDropdownVisible(false)
+										}}
+									/>
+								))}
+							{activeTab === "free" &&
+								freeModels.map((model) => (
+									<FeaturedModelCard
+										description={model.description}
+										isSelected={selectedModelId === model.id}
+										key={model.id}
+										label={model.label}
+										modelId={model.id}
+										onClick={() => {
+											handleModelChange(model.id)
+											setIsDropdownVisible(false)
+										}}
+									/>
+								))}
+						</div>
+					</>
 				)}
 
 				<DropdownWrapper ref={dropdownRef}>
@@ -501,5 +543,28 @@ const DropdownItem = styled.div<{ isSelected: boolean }>`
 
 	&:hover {
 		background-color: var(--vscode-list-activeSelectionBackground);
+	}
+`
+
+// Tabs
+
+const TabsContainer = styled.div`
+	display: flex;
+	gap: 0;
+	margin-bottom: 12px;
+	border-bottom: 1px solid #333;
+`
+
+const Tab = styled.div<{ active: boolean }>`
+	padding: 8px 16px;
+	cursor: pointer;
+	font-size: 12px;
+	font-weight: 500;
+	color: ${({ active }) => (active ? "var(--vscode-foreground)" : "var(--vscode-descriptionForeground)")};
+	border-bottom: 2px solid ${({ active }) => (active ? "var(--vscode-textLink-foreground)" : "transparent")};
+	transition: all 0.15s ease;
+
+	&:hover {
+		color: var(--vscode-foreground);
 	}
 `


### PR DESCRIPTION
### Related Issue

<img width="357" height="506" alt="View Billing   Usage" src="https://github.com/user-attachments/assets/721afe01-0860-4802-be2d-aa17588fc3ef" />

<img width="359" height="472" alt="API Provider" src="https://github.com/user-attachments/assets/d7bc3a86-afc6-44f8-a783-61f4decca546" />

(**note:** the `stealth:spectre` model in the image is not included in this PR)

N/A - This is an internal UX improvement for the Cline provider model picker.

### Description

Adds a tabbed interface to the Cline provider model picker, organizing featured models into **Recommended** and **Free** tabs.

**What changed:**
- Replaced the single list of featured models with two tabs
- **Recommended tab**: Sonnet 4.5 (BEST), Opus 4.5 (NEW), GPT-5.1 (HOT), Gemini 3 Pro (1M CTX)
- **Free tab**: Grok Code Fast (FAST), Minimax M2 (OSS)

**Why:**
- Allows Cline to recommend deserving models without increasing visual clutter
- Makes it easier to discover free models
- Badges now communicate differentiated value (STEALTH, FAST, OSS) rather than redundantly stating "FREE" in the Free tab
- Future-proofs the UI for adding more models without overwhelming users

### Test Procedure

- Ran `npm test` - all 430 tests pass
- Ran `npm run format:fix` and `npm run lint`
- Manually verified tab switching works in the extension
- Verified model selection updates correctly from both tabs
- Verified free models show $0 pricing when selected

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [x] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- Add before/after screenshots of the model picker here -->

### Additional Notes

This change only affects the Cline provider model picker. The OpenRouter and other provider pickers remain unchanged.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds tabbed interface to Cline provider model picker in `OpenRouterModelPicker.tsx`, organizing models into "Recommended" and "Free" tabs with updated UI components.
> 
>   - **Behavior**:
>     - Adds tabbed interface in `OpenRouterModelPicker.tsx` for Cline provider model picker with "Recommended" and "Free" tabs.
>     - "Recommended" tab includes models: Sonnet 4.5, Opus 4.5, GPT-5.1, Gemini 3 Pro.
>     - "Free" tab includes models: Grok Code Fast, Minimax M2.
>     - Free models show $0 pricing when selected.
>   - **UI Components**:
>     - Introduces `TabsContainer` and `Tab` styled components for tabbed navigation.
>     - Updates `FeaturedModelCard` usage to handle tab-specific model lists.
>   - **Misc**:
>     - Updates logic to filter and display models based on active tab.
>     - Ensures dropdown visibility and model selection updates correctly.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 1dda3f6ad3da48a8996d8858df02d62a72fcb63e. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->