### PR TITLE
feat: add direct navigation to settings sections

### DIFF
--- a/webview-ui/src/App.tsx
+++ b/webview-ui/src/App.tsx
@@ -20,6 +20,7 @@ const AppContent = () => {
 		showMcp,
 		mcpTab,
 		showSettings,
+		settingsTargetSection,
 		showHistory,
 		showAccount,
 		showAnnouncement,
@@ -61,7 +62,7 @@ const AppContent = () => {
 
 	return (
 		<div className="flex h-screen w-full flex-col">
-			{showSettings && <SettingsView onDone={hideSettings} />}
+			{showSettings && <SettingsView onDone={hideSettings} targetSection={settingsTargetSection} />}
 			{showHistory && <HistoryView onDone={hideHistory} />}
 			{showMcp && <McpView initialTab={mcpTab} onDone={closeMcpView} />}
 			{showAccount && (

--- a/webview-ui/src/components/browser/BrowserSettingsMenu.tsx
+++ b/webview-ui/src/components/browser/BrowserSettingsMenu.tsx
@@ -1,8 +1,8 @@
-import { EmptyRequest, StringRequest } from "@shared/proto/cline/common"
+import { EmptyRequest } from "@shared/proto/cline/common"
 import { VSCodeButton } from "@vscode/webview-ui-toolkit/react"
 import { useEffect, useRef, useState } from "react"
 import { useExtensionState } from "@/context/ExtensionStateContext"
-import { BrowserServiceClient, UiServiceClient } from "../../services/grpc-client"
+import { BrowserServiceClient } from "../../services/grpc-client"
 
 interface ConnectionInfo {
 	isConnected: boolean
@@ -63,17 +63,7 @@ export const BrowserSettingsMenu = () => {
 	}, [showInfoPopover])
 
 	const openBrowserSettings = () => {
-		// First open the settings panel using direct navigation
-		navigateToSettings()
-
-		// After a short delay, send a message to scroll to browser settings
-		setTimeout(async () => {
-			try {
-				await UiServiceClient.scrollToSettings(StringRequest.create({ value: "browser" }))
-			} catch (error) {
-				console.error("Error scrolling to browser settings:", error)
-			}
-		}, 300) // Give the settings panel time to open
+		navigateToSettings("browser")
 	}
 
 	const toggleInfoPopover = () => {

--- a/webview-ui/src/components/chat/auto-approve-menu/AutoApproveBar.tsx
+++ b/webview-ui/src/components/chat/auto-approve-menu/AutoApproveBar.tsx
@@ -1,7 +1,5 @@
-import { StringRequest } from "@shared/proto/cline/common"
 import { useRef, useState } from "react"
 import { useExtensionState } from "@/context/ExtensionStateContext"
-import { UiServiceClient } from "@/services/grpc-client"
 import { getAsVar, VSC_TITLEBAR_INACTIVE_FOREGROUND } from "@/utils/vscStyles"
 import AutoApproveModal from "./AutoApproveModal"
 import { ACTION_METADATA } from "./constants"
@@ -16,19 +14,10 @@ const AutoApproveBar = ({ style }: AutoApproveBarProps) => {
 	const [isModalVisible, setIsModalVisible] = useState(false)
 	const buttonRef = useRef<HTMLDivElement>(null)
 
-	const handleNavigateToFeatures = async (e: React.MouseEvent) => {
+	const handleNavigateToFeatures = (e: React.MouseEvent) => {
 		e.preventDefault()
 		e.stopPropagation()
-
-		navigateToSettings()
-
-		setTimeout(async () => {
-			try {
-				await UiServiceClient.scrollToSettings(StringRequest.create({ value: "features" }))
-			} catch (error) {
-				console.error("Error scrolling to features settings:", error)
-			}
-		}, 300)
+		navigateToSettings("features")
 	}
 
 	const getEnabledActionsText = () => {

--- a/webview-ui/src/components/chat/auto-approve-menu/AutoApproveModal.tsx
+++ b/webview-ui/src/components/chat/auto-approve-menu/AutoApproveModal.tsx
@@ -1,9 +1,7 @@
-import { StringRequest } from "@shared/proto/cline/common"
 import React, { useEffect, useRef, useState } from "react"
 import { useClickAway } from "react-use"
 import { useExtensionState } from "@/context/ExtensionStateContext"
 import { useAutoApproveActions } from "@/hooks/useAutoApproveActions"
-import { UiServiceClient } from "@/services/grpc-client"
 import { getAsVar, VSC_TITLEBAR_INACTIVE_FOREGROUND } from "@/utils/vscStyles"
 import AutoApproveMenuItem from "./AutoApproveMenuItem"
 import { ActionMetadata } from "./types"
@@ -21,21 +19,10 @@ const AutoApproveModal: React.FC<AutoApproveModalProps> = ({ isVisible, setIsVis
 	const { navigateToSettings } = useExtensionState()
 	const { isChecked, updateAction } = useAutoApproveActions()
 
-	const handleNotificationsLinkClick = async (e: React.MouseEvent) => {
+	const handleNotificationsLinkClick = (e: React.MouseEvent) => {
 		e.preventDefault()
 		e.stopPropagation()
-
-		// Navigate to settings
-		navigateToSettings()
-
-		// Scroll to general section
-		setTimeout(async () => {
-			try {
-				await UiServiceClient.scrollToSettings(StringRequest.create({ value: "general" }))
-			} catch (error) {
-				console.error("Error scrolling to general settings:", error)
-			}
-		}, 300)
+		navigateToSettings("general")
 	}
 
 	const modalRef = useRef<HTMLDivElement>(null)

--- a/webview-ui/src/components/chat/task-header/TaskHeader.tsx
+++ b/webview-ui/src/components/chat/task-header/TaskHeader.tsx
@@ -1,12 +1,10 @@
 import { ClineMessage } from "@shared/ExtensionMessage"
-import { StringRequest } from "@shared/proto/cline/common"
 import { ChevronDownIcon, ChevronRightIcon } from "lucide-react"
 import React, { useCallback, useLayoutEffect, useMemo, useState } from "react"
 import Thumbnails from "@/components/common/Thumbnails"
 import { getModeSpecificFields, normalizeApiConfiguration } from "@/components/settings/utils/providerUtils"
 import { useExtensionState } from "@/context/ExtensionStateContext"
 import { cn } from "@/lib/utils"
-import { UiServiceClient } from "@/services/grpc-client"
 import { getEnvironmentColor } from "@/utils/environmentColors"
 import CopyTaskButton from "./buttons/CopyTaskButton"
 import DeleteTaskButton from "./buttons/DeleteTaskButton"
@@ -103,14 +101,7 @@ const TaskHeader: React.FC<TaskHeaderProps> = ({
 	const toggleTaskExpanded = useCallback(() => setIsTaskExpanded(!isTaskExpanded), [setIsTaskExpanded, isTaskExpanded])
 
 	const handleCheckpointSettingsClick = useCallback(() => {
-		navigateToSettings()
-		setTimeout(async () => {
-			try {
-				await UiServiceClient.scrollToSettings(StringRequest.create({ value: "features" }))
-			} catch (error) {
-				console.error("Error scrolling to checkpoint settings:", error)
-			}
-		}, 300)
+		navigateToSettings("features")
 	}, [navigateToSettings])
 
 	const environmentBorderColor = getEnvironmentColor(environment, "border")

--- a/webview-ui/src/components/common/CliInstallBanner.tsx
+++ b/webview-ui/src/components/common/CliInstallBanner.tsx
@@ -1,11 +1,10 @@
-import { StringRequest } from "@shared/proto/cline/common"
 import { EmptyRequest, Int64Request } from "@shared/proto/index.cline"
 import { VSCodeButton } from "@vscode/webview-ui-toolkit/react"
 import { Terminal, XIcon } from "lucide-react"
 import { useCallback, useEffect, useState } from "react"
 import { Button } from "@/components/ui/button"
 import { useExtensionState } from "@/context/ExtensionStateContext"
-import { StateServiceClient, UiServiceClient } from "@/services/grpc-client"
+import { StateServiceClient } from "@/services/grpc-client"
 import { isMacOSOrLinux } from "@/utils/platformUtils"
 import { getAsVar, VSC_INACTIVE_SELECTION_BACKGROUND } from "@/utils/vscStyles"
 
@@ -62,18 +61,9 @@ export const CliInstallBanner: React.FC = () => {
 		}
 	}
 
-	const handleEnableSubagents = async () => {
+	const handleEnableSubagents = () => {
 		if (!subagentsEnabled) {
-			// Navigate to settings and enable subagents
-			navigateToSettings()
-			// Scroll to features section after a brief delay to ensure settings is rendered
-			setTimeout(async () => {
-				try {
-					await UiServiceClient.scrollToSettings(StringRequest.create({ value: "features" }))
-				} catch (error) {
-					console.error("Error scrolling to features settings:", error)
-				}
-			}, 300)
+			navigateToSettings("features")
 		}
 	}
 

--- a/webview-ui/src/components/mcp/configuration/tabs/installed/ConfigureServersView.tsx
+++ b/webview-ui/src/components/mcp/configuration/tabs/installed/ConfigureServersView.tsx
@@ -1,7 +1,7 @@
-import { EmptyRequest, StringRequest } from "@shared/proto/cline/common"
+import { EmptyRequest } from "@shared/proto/cline/common"
 import { VSCodeButton, VSCodeLink } from "@vscode/webview-ui-toolkit/react"
 import { useExtensionState } from "@/context/ExtensionStateContext"
-import { McpServiceClient, UiServiceClient } from "@/services/grpc-client"
+import { McpServiceClient } from "@/services/grpc-client"
 import ServersToggleList from "./ServersToggleList"
 
 const ConfigureServersView = () => {
@@ -48,21 +48,7 @@ const ConfigureServersView = () => {
 				</VSCodeButton>
 
 				<div style={{ textAlign: "center" }}>
-					<VSCodeLink
-						onClick={() => {
-							// First open the settings panel using direct navigation
-							navigateToSettings()
-
-							// After a short delay, send a message to scroll to browser settings
-							setTimeout(async () => {
-								try {
-									await UiServiceClient.scrollToSettings(StringRequest.create({ value: "features" }))
-								} catch (error) {
-									console.error("Error scrolling to mcp settings:", error)
-								}
-							}, 300)
-						}}
-						style={{ fontSize: "12px" }}>
+					<VSCodeLink onClick={() => navigateToSettings("features")} style={{ fontSize: "12px" }}>
 						Advanced MCP Settings
 					</VSCodeLink>
 				</div>

--- a/webview-ui/src/context/ExtensionStateContext.tsx
+++ b/webview-ui/src/context/ExtensionStateContext.tsx
@@ -54,6 +54,7 @@ export interface ExtensionStateContextType extends ExtensionState {
 	hooksEnabled?: ClineFeatureSetting
 	mcpTab?: McpViewTab
 	showSettings: boolean
+	settingsTargetSection?: string
 	showHistory: boolean
 	showAccount: boolean
 	showAnnouncement: boolean
@@ -97,7 +98,7 @@ export interface ExtensionStateContextType extends ExtensionState {
 
 	// Navigation functions
 	navigateToMcp: (tab?: McpViewTab) => void
-	navigateToSettings: () => void
+	navigateToSettings: (targetSection?: string) => void
 	navigateToHistory: () => void
 	navigateToAccount: () => void
 	navigateToChat: () => void
@@ -123,6 +124,7 @@ export const ExtensionStateContextProvider: React.FC<{
 	const [showMcp, setShowMcp] = useState(false)
 	const [mcpTab, setMcpTab] = useState<McpViewTab | undefined>(undefined)
 	const [showSettings, setShowSettings] = useState(false)
+	const [settingsTargetSection, setSettingsTargetSection] = useState<string | undefined>(undefined)
 	const [showHistory, setShowHistory] = useState(false)
 	const [showAccount, setShowAccount] = useState(false)
 	const [showAnnouncement, setShowAnnouncement] = useState(false)
@@ -135,7 +137,10 @@ export const ExtensionStateContextProvider: React.FC<{
 	}, [setShowMcp, setMcpTab])
 
 	// Hide functions
-	const hideSettings = useCallback(() => setShowSettings(false), [setShowSettings])
+	const hideSettings = useCallback(() => {
+		setShowSettings(false)
+		setSettingsTargetSection(undefined)
+	}, [])
 	const hideHistory = useCallback(() => setShowHistory(false), [setShowHistory])
 	const hideAccount = useCallback(() => setShowAccount(false), [setShowAccount])
 	const hideAnnouncement = useCallback(() => setShowAnnouncement(false), [setShowAnnouncement])
@@ -155,12 +160,16 @@ export const ExtensionStateContextProvider: React.FC<{
 		[setShowMcp, setMcpTab, setShowSettings, setShowHistory, setShowAccount],
 	)
 
-	const navigateToSettings = useCallback(() => {
-		setShowHistory(false)
-		closeMcpView()
-		setShowAccount(false)
-		setShowSettings(true)
-	}, [setShowSettings, setShowHistory, closeMcpView, setShowAccount])
+	const navigateToSettings = useCallback(
+		(targetSection?: string) => {
+			setShowHistory(false)
+			closeMcpView()
+			setShowAccount(false)
+			setSettingsTargetSection(targetSection)
+			setShowSettings(true)
+		},
+		[closeMcpView],
+	)
 
 	const navigateToHistory = useCallback(() => {
 		setShowSettings(false)
@@ -705,6 +714,7 @@ export const ExtensionStateContextProvider: React.FC<{
 		showMcp,
 		mcpTab,
 		showSettings,
+		settingsTargetSection,
 		showHistory,
 		showAccount,
 		showAnnouncement,


### PR DESCRIPTION
### Description
Replace delayed scroll-to-settings approach with direct section targeting. Settings sections can now be opened directly via navigateToSettings(section) parameter, eliminating the need for setTimeout-based scrolling workarounds. This way the settings navigation feels much snappier than before

[See Linear Issue](https://linear.app/cline-bot/issue/CLINE-34/cline-api-configuration-screen-flashes-briefly-when-navigating-to)



### Test Procedure

1. Auto approve settings 
<img width="470" height="365" alt="image" src="https://github.com/user-attachments/assets/c8467f49-ad9e-4c91-9e11-1359aa7541bb" />


Click on Configure notification settings here. 

2. MCP settings 
<img width="458" height="440" alt="image" src="https://github.com/user-attachments/assets/081e25e1-145a-48be-8c68-c0ce679209bb" />
Click on Advanced MCP settings


3. Browser settings
<img width="536" height="244" alt="image" src="https://github.com/user-attachments/assets/0d41d23b-6edd-4df1-beed-d8add15fc51f" />

Click on the settings icon 

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [X] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [ ] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Replaces delayed scroll-to-settings with direct section targeting using `navigateToSettings(section)` across multiple components.
> 
>   - **Behavior**:
>     - Replaces delayed scroll-to-settings with direct section targeting using `navigateToSettings(section)`.
>     - Removes `setTimeout` workaround in `BrowserSettingsMenu.tsx`, `AutoApproveBar.tsx`, `AutoApproveModal.tsx`, `TaskHeader.tsx`, `CliInstallBanner.tsx`, and `ConfigureServersView.tsx`.
>   - **Context**:
>     - Updates `navigateToSettings` in `ExtensionStateContext.tsx` to accept `targetSection` parameter.
>     - Adds `settingsTargetSection` state to manage targeted navigation.
>   - **Components**:
>     - Updates `App.tsx` to pass `targetSection` to `SettingsView`.
>     - Modifies `BrowserSettingsMenu.tsx` to use direct navigation for browser settings.
>     - Adjusts `AutoApproveBar.tsx` and `AutoApproveModal.tsx` for feature and general settings navigation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 99a2a9b4714b29220c9206ca051e1345d0e1b1d0. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->