### PR TITLE
readTaskHistory - don't return empty array on parse failure

### DIFF
--- a/src/core/storage/disk.ts
+++ b/src/core/storage/disk.ts
@@ -177,7 +177,7 @@ export async function saveClineMessages(taskId: string, uiMessages: ClineMessage
 export async function collectEnvironmentMetadata(): Promise<Omit<EnvironmentMetadataEntry, "ts">> {
 	try {
 		const hostVersion = await HostProvider.env.getHostVersion({})
-		
+
 		return {
 			os_name: os.platform(),
 			os_version: os.release(),
@@ -274,12 +274,8 @@ export async function readTaskHistoryFromState(): Promise<HistoryItem[]> {
 		const filePath = await getTaskHistoryStateFilePath()
 		if (await fileExistsAtPath(filePath)) {
 			const contents = await fs.readFile(filePath, "utf8")
-			try {
-				return JSON.parse(contents)
-			} catch (error) {
-				console.error("[Disk] Failed to parse task history:", error)
-				return []
-			}
+
+			return JSON.parse(contents)
 		}
 		return []
 	} catch (error) {


### PR DESCRIPTION


### Description

If the JSON parse fails, we should throw an error instead of returning an empty array. This can lead to corrupted data. 

### Test Procedure



### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->
