### PR TITLE
fix: Standalone, ensure cwd is the install dir to find resources reliably

### DIFF
--- a/.changeset/kind-paws-win.md
+++ b/.changeset/kind-paws-win.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+fix: Standalone, ensure cwd is the install dir to find resources reliably

--- a/src/standalone/cline-core.ts
+++ b/src/standalone/cline-core.ts
@@ -31,6 +31,9 @@ async function main() {
 		process.exit(0)
 	}
 
+	// Resource loading assumes cwd is the installation directory
+	process.chdir(__dirname)
+
 	// Initialize context with optional custom directory from CLI
 	const { extensionContext, DATA_DIR, EXTENSION_DIR } = initializeContext(args.config)
 


### PR DESCRIPTION
### Related Issue

**Issue:** #7746 

### Description

We look for resources like .pb descriptors and rg relative to the current working directory. When we started launching Cline core under the user's login shell to collect their environment variables properly, we also gave that shell control of the working directory.

### Test Procedure

1. Patch a related change in cline/intellij-plugin, see the related issue
2. `echo 'cd /tmp' >> ~/.bash_profile` or whatever is appropriate for your shell
3. `./gradlew :runIde` and ask Cline to search for something in the codebase; check that it gets results

### Type of Change

-   [X] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [X] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [X] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [X] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [X] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes resource loading issue in `cline-core.ts` by setting the current working directory to the installation directory.
> 
>   - **Behavior**:
>     - In `cline-core.ts`, set the current working directory to the installation directory using `process.chdir(__dirname)` to ensure resources are loaded reliably.
>   - **Misc**:
>     - Add changeset file `kind-paws-win.md` to document the patch fix.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for f2043f9404a0e97024de099fc99bdd8333fbdfd7. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->