### PR TITLE
fix: move OptionsButtons outside WithCopyButton component

### DIFF
--- a/webview-ui/src/components/chat/ChatRow.tsx
+++ b/webview-ui/src/components/chat/ChatRow.tsx
@@ -1844,15 +1844,6 @@ export const ChatRowContent = memo(
 									ref={contentRef}
 									textToCopy={question}>
 									<Markdown markdown={question} />
-									<OptionsButtons
-										inputValue={inputValue}
-										isActive={
-											(isLast && lastModifiedMessage?.ask === "followup") ||
-											(!selected && options && options.length > 0)
-										}
-										options={options}
-										selected={selected}
-									/>
 									{quoteButtonState.visible && (
 										<QuoteButton
 											left={quoteButtonState.left}
@@ -1863,6 +1854,15 @@ export const ChatRowContent = memo(
 										/>
 									)}
 								</WithCopyButton>
+								<OptionsButtons
+									inputValue={inputValue}
+									isActive={
+										(isLast && lastModifiedMessage?.ask === "followup") ||
+										(!selected && options && options.length > 0)
+									}
+									options={options}
+									selected={selected}
+								/>
 							</div>
 						)
 					case "new_task":
@@ -1930,12 +1930,23 @@ export const ChatRowContent = memo(
 							response = message.text
 						}
 						return (
-							<WithCopyButton
-								onMouseUp={handleMouseUp}
-								position="bottom-right"
-								ref={contentRef}
-								textToCopy={response}>
-								<Markdown markdown={response} />
+							<>
+								<WithCopyButton
+									onMouseUp={handleMouseUp}
+									position="bottom-right"
+									ref={contentRef}
+									textToCopy={response}>
+									<Markdown markdown={response} />
+									{quoteButtonState.visible && (
+										<QuoteButton
+											left={quoteButtonState.left}
+											onClick={() => {
+												handleQuoteClick()
+											}}
+											top={quoteButtonState.top}
+										/>
+									)}
+								</WithCopyButton>
 								<OptionsButtons
 									inputValue={inputValue}
 									isActive={
@@ -1945,16 +1956,7 @@ export const ChatRowContent = memo(
 									options={options}
 									selected={selected}
 								/>
-								{quoteButtonState.visible && (
-									<QuoteButton
-										left={quoteButtonState.left}
-										onClick={() => {
-											handleQuoteClick()
-										}}
-										top={quoteButtonState.top}
-									/>
-								)}
-							</WithCopyButton>
+							</>
 						)
 					}
 					default:


### PR DESCRIPTION
[Linear Issue
](https://linear.app/cline-bot/issue/CLINE-35/copy-button-appears-only-on-last-plan-option-and-copies-incorrect-text)

### Description

Relocate OptionsButtons component to be a sibling of WithCopyButton rather than a child. This fixes the component hierarchy for followup and completion_result message types, ensuring proper rendering and interaction behavior. Also adds QuoteButton support to completion_result.




### Test Procedure

#### Before
<img width="2852" height="1778" alt="image" src="https://github.com/user-attachments/assets/92adc34c-3c9d-4cf5-bbff-502aee631bea" />

The copy button was right at the options and would not copy them. 

#### After
The copy button is right above the options now
<img width="459" height="457" alt="image" src="https://github.com/user-attachments/assets/5b0011e3-fd7c-4aff-afaf-0b88cf94a18a" />


I think its pointless to copy the options or even to keep the copy button there so I just moved this above the whole thing. Theres also UX weirdness where you might click the copy button instead of clicking the options so best just leave copying to the normal text boxes and the options are just for selection and clicking.

I am also open to other philosophies

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [X] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [ ] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Move `OptionsButtons` outside `WithCopyButton` in `ChatRow.tsx` to fix rendering and interaction issues, and add `QuoteButton` support to `completion_result`.
> 
>   - **Behavior**:
>     - Move `OptionsButtons` outside `WithCopyButton` in `ChatRow.tsx` to fix hierarchy for `followup` and `completion_result` message types.
>     - Adds `QuoteButton` support to `completion_result` message type.
>   - **UI Changes**:
>     - `OptionsButtons` now renders as a sibling to `WithCopyButton`, improving interaction and text copying behavior.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 1e024c49e5db6a59edf09e13b992beb03d21c984. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->