### PR TITLE
Log the name of the telemetry provider(s) enabled in the extension

### DIFF
--- a/src/services/telemetry/TelemetryProviderFactory.ts
+++ b/src/services/telemetry/TelemetryProviderFactory.ts
@@ -47,7 +47,7 @@ export class TelemetryProviderFactory {
 			providers.push(new NoOpTelemetryProvider())
 		}
 
-		Logger.info("TelemetryProviderFactory: Created providers - " + providers.map((p) => p.constructor.name).join(", "))
+		Logger.info("TelemetryProviderFactory: Created providers - " + providers.map((p) => p.name()).join(", "))
 		return providers
 	}
 
@@ -107,6 +107,9 @@ export class TelemetryProviderFactory {
  * or for testing purposes
  */
 export class NoOpTelemetryProvider implements ITelemetryProvider {
+	name(): string {
+		return "NoOpTelemetryProvider"
+	}
 	private isOptIn = true
 
 	log(_event: string, _properties?: TelemetryProperties): void {

--- a/src/services/telemetry/__tests__/TelemetryService.metrics.test.ts
+++ b/src/services/telemetry/__tests__/TelemetryService.metrics.test.ts
@@ -3,6 +3,9 @@ import type { ITelemetryProvider, TelemetryProperties, TelemetrySettings } from 
 import { TelemetryService } from "../TelemetryService"
 
 class FakeProvider implements ITelemetryProvider {
+	name(): string {
+		return "FakeProvider"
+	}
 	public counters: Array<{ name: string; value: number; attributes: TelemetryProperties; description?: string }> = []
 	public histograms: Array<{ name: string; value: number; attributes: TelemetryProperties; description?: string }> = []
 	public gauges = new Map<string, Map<string, { value: number; attributes: TelemetryProperties; description?: string }>>()

--- a/src/services/telemetry/providers/ITelemetryProvider.ts
+++ b/src/services/telemetry/providers/ITelemetryProvider.ts
@@ -87,6 +87,11 @@ export interface ITelemetryProvider {
 	getSettings(): TelemetrySettings
 
 	/**
+	 * Returns the name of the telemetry provider.
+	 */
+	name(): string
+
+	/**
 	 * Record a counter metric (cumulative value that only increases)
 	 * Providers that don't support metrics may implement this as a no-op.
 	 * @param name Metric name (e.g., "cline.tokens.input")

--- a/src/services/telemetry/providers/opentelemetry/OpenTelemetryTelemetryProvider.ts
+++ b/src/services/telemetry/providers/opentelemetry/OpenTelemetryTelemetryProvider.ts
@@ -50,6 +50,9 @@ export class OpenTelemetryTelemetryProvider implements ITelemetryProvider {
 			console.log(`[OTEL] Provider initialized - Logger: ${loggerReady}, Meter: ${meterReady}`)
 		}
 	}
+	name(): string {
+		return "OpenTelemetryProvider"
+	}
 
 	public async initialize(): Promise<OpenTelemetryTelemetryProvider> {
 		// Listen for host telemetry changes

--- a/src/services/telemetry/providers/posthog/PostHogTelemetryProvider.ts
+++ b/src/services/telemetry/providers/posthog/PostHogTelemetryProvider.ts
@@ -59,7 +59,9 @@ export class PostHogTelemetryProvider implements ITelemetryProvider {
 		this.telemetrySettings.level = await this.getTelemetryLevel()
 		return this
 	}
-
+	name(): string {
+		return "PostHogTelemetryProvider"
+	}
 	public log(event: string, properties?: TelemetryProperties): void {
 		if (!this.isEnabled() || this.telemetrySettings.level === "off") {
 			return


### PR DESCRIPTION
Right now we are logging the provider type by logging the name of the constructor, but in the compiled code this is obfuscated so it is just some random characters.

Add a name property to the telemetry provider interface.

Before:
`cline-core-service.log:[2025-12-01T19:09:09.142] #bot.cline.server.ts INFO TelemetryProviderFactory: Created providers - yTe`
After:
`cline-core-service.log:[2025-12-01T19:06:39.583] #bot.cline.server.ts INFO TelemetryProviderFactory: Created providers - OpenTelemetryProvider`
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `name()` method to `ITelemetryProvider` interface and implement in providers for clearer logging.
> 
>   - **Behavior**:
>     - Add `name()` method to `ITelemetryProvider` interface in `ITelemetryProvider.ts`.
>     - Update `TelemetryProviderFactory` in `TelemetryProviderFactory.ts` to log provider names using `name()` method.
>   - **Providers**:
>     - Implement `name()` method in `NoOpTelemetryProvider`, `OpenTelemetryTelemetryProvider`, and `PostHogTelemetryProvider`.
>     - Implement `name()` method in `FakeProvider` in `TelemetryService.metrics.test.ts` for testing purposes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 59e87f22904776072104e0128a2f9600fda885a6. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->