### PR TITLE
feat: add User-Agent header with extension version to Auth requests

### DIFF
--- a/src/services/auth/providers/ClineAuthProvider.ts
+++ b/src/services/auth/providers/ClineAuthProvider.ts
@@ -6,6 +6,7 @@ import { AuthInvalidTokenError, AuthNetworkError } from "@/services/error/ClineE
 import { Logger } from "@/services/logging/Logger"
 import { CLINE_API_ENDPOINT } from "@/shared/cline/api"
 import { fetch, getAxiosSettings } from "@/shared/net"
+import { version as extensionVersion } from "../../../../package.json"
 import { type ClineAccountUserInfo, type ClineAuthInfo } from "../AuthService"
 import { IAuthProvider } from "./IAuthProvider"
 
@@ -224,7 +225,7 @@ export class ClineAuthProvider implements IAuthProvider {
 			const endpoint = new URL(CLINE_API_ENDPOINT.REFRESH_TOKEN, this.config.apiBaseUrl)
 			const response = await fetch(endpoint.toString(), {
 				method: "POST",
-				headers: { "Content-Type": "application/json" },
+				headers: { "Content-Type": "application/json", "User-Agent": extensionVersion },
 				body: JSON.stringify({
 					refreshToken,
 					grantType: "refresh_token",
@@ -287,6 +288,7 @@ export class ClineAuthProvider implements IAuthProvider {
 				headers: {
 					Accept: "application/json",
 					"Content-Type": "application/json",
+					"User-Agent": extensionVersion,
 				},
 			})
 
@@ -327,6 +329,7 @@ export class ClineAuthProvider implements IAuthProvider {
 				headers: {
 					"Content-Type": "application/json",
 					Accept: "application/json",
+					"User-Agent": extensionVersion,
 				},
 				body: JSON.stringify({
 					grant_type: "authorization_code",


### PR DESCRIPTION
<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- For feature requests: Created a discussion in our Feature Requests discussions board https://github.com/cline/cline/discussions/categories/feature-requests and received approval from core maintainers before implementation
- For all changes: Link the associated issue/discussion in the "Related Issue" section below

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly without prior discussion.

Why this requirement?
We deeply appreciate all community contributions - they are essential to Cline's success! To ensure the best use of everyone's time and maintain project direction, we use our Feature Requests discussions board to gauge community interest and validate feature ideas before implementation begins. This helps us focus development efforts on features that will benefit the most users.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** #XXXX

### Description

<!-- 
Help reviewers understand your changes by making this PR readable and well-organized:

- What problem does this PR solve?
- Why were these changes introduced and what purpose do they serve?
- For larger changes, provide context about your approach and reasoning

Small PRs may need minimal description, but larger changes benefit from explaining where you're coming from. Much of this context can be in the linked issue above, so feel free to reference it rather than repeating everything here.
-->

Add User-Agent header containing the extension version to all HTTP requests made by ClineAuthProvider, including token refresh, and authorization calls. This enables better client identification and version tracking on the API side for debugging and analytics purposes.

Changes:
- Import extension version from package.json
- Include User-Agent header in refresh token endpoint request
- Include User-Agent header in user info endpoint request
- Include User-Agent header in authorization code exchange request

### Test Procedure

<!-- 
Please walk us through your testing approach and thought process. This helps reviewers understand that you've thoroughly considered the impact of your changes:

- How did you test this change?
- What could potentially break and how did you verify it doesn't?
- What existing functionality might be affected and how did you check it still works?
- Why are you confident this is ready for merge?

We're not looking for exhaustive documentation - just evidence that you've thought through the implications of your changes and tested accordingly.
-->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [ ] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add User-Agent header with extension version to HTTP requests in ClineAuthProvider for better client identification.
> 
>   - **Behavior**:
>     - Add `User-Agent` header with extension version to HTTP requests in `ClineAuthProvider`.
>     - Affects `refreshToken`, `getAuthRequest`, and `signIn` functions.
>   - **Imports**:
>     - Import `version` as `extensionVersion` from `package.json`.
>   - **Headers**:
>     - Include `User-Agent` in `refreshToken` POST request.
>     - Include `User-Agent` in `getAuthRequest` GET request.
>     - Include `User-Agent` in `signIn` POST request.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 1d504df0f2b8d7496b137be12a0732a944c84fd9. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->