### PR TITLE
fix: move notification toggle to auto-approve menu

### DIFF
--- a/webview-ui/src/components/chat/auto-approve-menu/AutoApproveModal.tsx
+++ b/webview-ui/src/components/chat/auto-approve-menu/AutoApproveModal.tsx
@@ -1,9 +1,11 @@
+import { VSCodeCheckbox } from "@vscode/webview-ui-toolkit/react"
 import React, { useEffect, useRef, useState } from "react"
 import { useClickAway } from "react-use"
 import { useExtensionState } from "@/context/ExtensionStateContext"
 import { useAutoApproveActions } from "@/hooks/useAutoApproveActions"
-import { getAsVar, VSC_TITLEBAR_INACTIVE_FOREGROUND } from "@/utils/vscStyles"
+import { getAsVar, VSC_DESCRIPTION_FOREGROUND, VSC_TITLEBAR_INACTIVE_FOREGROUND } from "@/utils/vscStyles"
 import AutoApproveMenuItem from "./AutoApproveMenuItem"
+import { updateAutoApproveSettings } from "./AutoApproveSettingsAPI"
 import { ActionMetadata } from "./types"
 
 const breakpoint = 500
@@ -16,14 +18,8 @@ interface AutoApproveModalProps {
 }
 
 const AutoApproveModal: React.FC<AutoApproveModalProps> = ({ isVisible, setIsVisible, buttonRef, ACTION_METADATA }) => {
-	const { navigateToSettings } = useExtensionState()
+	const { autoApprovalSettings } = useExtensionState()
 	const { isChecked, updateAction } = useAutoApproveActions()
-
-	const handleNotificationsLinkClick = (e: React.MouseEvent) => {
-		e.preventDefault()
-		e.stopPropagation()
-		navigateToSettings("general")
-	}
 	const modalRef = useRef<HTMLDivElement>(null)
 	const itemsContainerRef = useRef<HTMLDivElement>(null)
 	const [containerWidth, setContainerWidth] = useState(0)
@@ -77,17 +73,11 @@ const AutoApproveModal: React.FC<AutoApproveModalProps> = ({ isVisible, setIsVis
 				}}>
 				<div className="mb-2.5 text-muted-foreground text-xs cursor-pointer" onClick={() => setIsVisible(false)}>
 					Let Cline take these actions without asking for approval.{" "}
-					<span
-						className="underline cursor-pointer hover:text-foreground"
-						onClick={handleNotificationsLinkClick}
-						style={{ textDecoration: "underline" }}>
-						Configure notification settings
-					</span>
-					{" | "}
 					<a
 						className="text-link hover:text-link-hover"
 						href="https://docs.cline.bot/features/auto-approve#auto-approve"
 						rel="noopener"
+						style={{ fontSize: "inherit" }}
 						target="_blank">
 						Docs
 					</a>
@@ -115,6 +105,32 @@ const AutoApproveModal: React.FC<AutoApproveModalProps> = ({ isVisible, setIsVis
 					{ACTION_METADATA.map((action) => (
 						<AutoApproveMenuItem action={action} isChecked={isChecked} key={action.id} onToggle={updateAction} />
 					))}
+				</div>
+
+				{/* Separator line */}
+				<div
+					style={{
+						height: "0.5px",
+						background: getAsVar(VSC_DESCRIPTION_FOREGROUND),
+						opacity: 0.1,
+						margin: "8px 0",
+					}}
+				/>
+
+				{/* Notifications toggle */}
+				<div className="flex items-center gap-2">
+					<VSCodeCheckbox
+						checked={autoApprovalSettings.enableNotifications}
+						onChange={async (e: any) => {
+							const checked = e.target.checked === true
+							await updateAutoApproveSettings({
+								...autoApprovalSettings,
+								version: (autoApprovalSettings.version ?? 1) + 1,
+								enableNotifications: checked,
+							})
+						}}>
+						<span className="text-sm">Enable notifications</span>
+					</VSCodeCheckbox>
 				</div>
 			</div>
 		</div>

--- a/webview-ui/src/components/settings/sections/GeneralSettingsSection.tsx
+++ b/webview-ui/src/components/settings/sections/GeneralSettingsSection.tsx
@@ -1,5 +1,4 @@
 import { VSCodeCheckbox, VSCodeLink } from "@vscode/webview-ui-toolkit/react"
-import { updateAutoApproveSettings } from "@/components/chat/auto-approve-menu/AutoApproveSettingsAPI"
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
 import { useExtensionState } from "@/context/ExtensionStateContext"
 import PreferredLanguageSetting from "../PreferredLanguageSetting"
@@ -11,32 +10,13 @@ interface GeneralSettingsSectionProps {
 }
 
 const GeneralSettingsSection = ({ renderSectionHeader }: GeneralSettingsSectionProps) => {
-	const { telemetrySetting, remoteConfigSettings, autoApprovalSettings } = useExtensionState()
+	const { telemetrySetting, remoteConfigSettings } = useExtensionState()
 
 	return (
 		<div>
 			{renderSectionHeader("general")}
 			<Section>
 				<PreferredLanguageSetting />
-
-				<div className="mb-[5px]" id="enable-notifications">
-					<VSCodeCheckbox
-						checked={autoApprovalSettings.enableNotifications}
-						onChange={async (e: any) => {
-							const checked = e.target.checked === true
-							await updateAutoApproveSettings({
-								...autoApprovalSettings,
-								version: (autoApprovalSettings.version ?? 1) + 1,
-								enableNotifications: checked,
-							})
-						}}>
-						Enable notifications
-					</VSCodeCheckbox>
-
-					<p className="text-sm mt-[5px] text-description">
-						Receive system notifications when Cline requires approval to proceed or when a task is completed.
-					</p>
-				</div>
 
 				<div className="mb-[5px]">
 					<Tooltip>

--- a/webview-ui/src/components/ui/button.tsx
+++ b/webview-ui/src/components/ui/button.tsx
@@ -17,7 +17,7 @@ const buttonVariants = cva(
 				ghost: "hover:bg-accent/10",
 				link: "text-link underline-offset-4 hover:underline p-0 m-0",
 				text: "text-foreground",
-				icon: "hover:opacity-80 p-0 m-0 border-0 cursor-pointer hover:shadow-none focus:ring-0 focus:ring-offset-0",
+				icon: "p-0 m-0 border-0 cursor-pointer hover:shadow-none focus:ring-0 focus:ring-offset-0",
 			},
 			size: {
 				default: "py-1.5 px-4 [&_svg]:size-3",


### PR DESCRIPTION
## Summary

- Move the "Enable notifications" toggle from General Settings into the auto-approve menu
- Remove the "Configure notification settings" link since the toggle is now inline
- Remove hover dimming effect on auto-approve menu items
- Fix docs link font size to inherit from parent
- Make separator line thinner

## Test plan

- [ ] Open auto-approve menu and verify notification toggle appears at the bottom with a separator
- [ ] Toggle notifications on/off and verify it persists
- [ ] Verify General Settings no longer has the notification toggle
- [ ] Hover over menu items and verify they don't dim
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Move notification toggle to auto-approve menu and adjust related UI elements.
> 
>   - **UI Changes**:
>     - Move "Enable notifications" toggle from `GeneralSettingsSection.tsx` to `AutoApproveModal.tsx`.
>     - Remove "Configure notification settings" link in `AutoApproveModal.tsx`.
>     - Remove hover dimming effect on auto-approve menu items in `button.tsx`.
>     - Adjust font size for docs link in `AutoApproveModal.tsx` to inherit from parent.
>     - Make separator line thinner in `AutoApproveModal.tsx`.
>   - **Behavior**:
>     - Notification toggle now appears at the bottom of the auto-approve menu with a separator.
>     - Notification toggle state persists across sessions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 07200f303df106caff49876cd618d16f0b413d7b. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->