### PR TITLE
feat: set default thinking level for Gemini 3 Pro models

### DIFF
--- a/.changeset/young-melons-change.md
+++ b/.changeset/young-melons-change.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Adds default thinking level for Gemini 3 Pro models in Gemini provider

--- a/src/core/api/providers/gemini.ts
+++ b/src/core/api/providers/gemini.ts
@@ -123,10 +123,12 @@ export class GeminiHandler implements ApiHandler {
 		// When ThinkingLevel is defineded, thinking budget cannot be zero
 		// and only level is used to control thinking behavior.
 		let thinkingLevel: ThinkingLevel | undefined
-		if (this.options.thinkingLevel === "low") {
-			thinkingLevel = ThinkingLevel.LOW
-		} else if (this.options.thinkingLevel === "high") {
+		if (this.options.thinkingLevel === "high") {
 			thinkingLevel = ThinkingLevel.HIGH
+		} else if (this.options.thinkingLevel === "low" || modelId.includes("gemini-3-pro")) {
+			// Thinking level is required for Gemini 3 Pro models.
+			// Set it to LOW by default if not specified but is required.
+			thinkingLevel = ThinkingLevel.LOW
 		}
 
 		// Set up base generation config
@@ -146,7 +148,7 @@ export class GeminiHandler implements ApiHandler {
 			// Turn on dynamic thinking:
 			// thinkingBudget: -1
 			// Turn on fixed thinking budget:
-			thinkingBudget: thinkingLevel ? undefined : thinkingBudget,
+			thinkingBudget: thinkingLevel ? undefined : thinkingBudget, // Use budget only if thinkingLevel is not set
 			thinkingLevel,
 			includeThoughts: thinkingBudget > 0 || !!thinkingLevel,
 		}


### PR DESCRIPTION

<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- For feature requests: Created a discussion in our Feature Requests discussions board https://github.com/cline/cline/discussions/categories/feature-requests and received approval from core maintainers before implementation
- For all changes: Link the associated issue/discussion in the "Related Issue" section below

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly without prior discussion.

Why this requirement?
We deeply appreciate all community contributions - they are essential to Cline's success! To ensure the best use of everyone's time and maintain project direction, we use our Feature Requests discussions board to gauge community interest and validate feature ideas before implementation begins. This helps us focus development efforts on features that will benefit the most users.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** https://github.com/cline/cline/issues/7755

### Description

<!-- 
Help reviewers understand your changes by making this PR readable and well-organized:

- What problem does this PR solve?
- Why were these changes introduced and what purpose do they serve?
- For larger changes, provide context about your approach and reasoning

Small PRs may need minimal description, but larger changes benefit from explaining where you're coming from. Much of this context can be in the linked issue above, so feel free to reference it rather than repeating everything here.
-->

- Reorder thinking level checks to prioritize high over low
- Auto-set thinking level to LOW for Gemini 3 Pro models when not specified
- Add clarifying comment for thinking budget usage
- Ensure thinking level is always defined for Gemini 3 models to prevent errors

This change ensures Gemini 3 Pro models always have a thinking level set (required by the API) and removes the thinking budget when a level is specified, as they are mutually exclusive parameters.


### Test Procedure

<!-- 
Please walk us through your testing approach and thought process. This helps reviewers understand that you've thoroughly considered the impact of your changes:

- How did you test this change?
- What could potentially break and how did you verify it doesn't?
- What existing functionality might be affected and how did you check it still works?
- Why are you confident this is ready for merge?

We're not looking for exhaustive documentation - just evidence that you've thought through the implications of your changes and tested accordingly.
-->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Set default thinking level to `LOW` for Gemini 3 Pro models in `GeminiHandler` and reorder thinking level checks.
> 
>   - **Behavior**:
>     - Auto-set thinking level to `LOW` for Gemini 3 Pro models in `GeminiHandler` if not specified.
>     - Reorder thinking level checks to prioritize `HIGH` over `LOW` in `GeminiHandler`.
>     - Ensure thinking level is always defined for Gemini 3 models to prevent errors.
>   - **Comments**:
>     - Add comment clarifying thinking budget usage in `GeminiHandler`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 4b319ee98b572db7cd1be693ec1fbd69ce414bfd. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->