### PR TITLE
markdown styling fix

### DIFF
--- a/webview-ui/src/components/common/MarkdownBlock.tsx
+++ b/webview-ui/src/components/common/MarkdownBlock.tsx
@@ -296,9 +296,14 @@ const StyledMarkdown = styled.div<{ compact?: boolean }>`
 		}
 	}
 
-	hr {
+	hr, ul {
 		margin: 13px 0;
 	}
+
+	li > ul {
+		margin: 4px 0; /* or 0 if you want them very tight */
+	}
+
 `
 
 const PreWithCopyButton = ({ children, ...preProps }: React.HTMLAttributes<HTMLPreElement>) => {


### PR DESCRIPTION
Before:

<img width="638" height="183" alt="Screenshot 2025-12-02 at 3 39 00 PM" src="https://github.com/user-attachments/assets/91fd98ef-1068-4b41-bcdb-36275940b216" />


After:

<img width="533" height="126" alt="Screenshot 2025-12-02 at 3 40 26 PM" src="https://github.com/user-attachments/assets/5c451bf4-584f-4bc8-a125-4deffe4f3388" />


ul fix too:

BEfore:
<img width="543" height="106" alt="Screenshot 2025-12-02 at 3 45 27 PM" src="https://github.com/user-attachments/assets/9d23e7c5-bddb-4fed-a973-4c57b6687eb3" />


After:

<img width="536" height="103" alt="Screenshot 2025-12-02 at 3 45 57 PM" src="https://github.com/user-attachments/assets/85f3b793-3995-4865-a3f1-8f883baf6981" />
