### PR TITLE
Don't log otel events to the console because they are really spammy

### DIFF
--- a/.github/workflows/publish-nightly.yml
+++ b/.github/workflows/publish-nightly.yml
@@ -74,8 +74,8 @@ jobs:
                   CLINE_ENVIRONMENT: production
                   # OpenTelemetry production defaults (can be overridden at runtime)
                   OTEL_TELEMETRY_ENABLED: ${{ secrets.OTEL_TELEMETRY_ENABLED }}
-                  OTEL_LOGS_EXPORTER: console,otlp
-                  OTEL_METRICS_EXPORTER: console,otlp
+                  OTEL_LOGS_EXPORTER: otlp
+                  OTEL_METRICS_EXPORTER: otlp
                   OTEL_EXPORTER_OTLP_PROTOCOL: ${{ secrets.OTEL_EXPORTER_OTLP_PROTOCOL }}
                   OTEL_EXPORTER_OTLP_ENDPOINT: ${{ secrets.OTEL_EXPORTER_OTLP_ENDPOINT }}
                   OTEL_EXPORTER_OTLP_HEADERS: ${{ secrets.OTEL_EXPORTER_OTLP_HEADERS }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -99,8 +99,8 @@ jobs:
                   ERROR_SERVICE_API_KEY: ${{ secrets.ERROR_SERVICE_API_KEY }}
                   # OpenTelemetry production defaults (can be overridden at runtime)
                   OTEL_TELEMETRY_ENABLED: ${{ secrets.OTEL_TELEMETRY_ENABLED }}
-                  OTEL_LOGS_EXPORTER: console,otlp
-                  OTEL_METRICS_EXPORTER: console,otlp
+                  OTEL_LOGS_EXPORTER: otlp
+                  OTEL_METRICS_EXPORTER: otlp
                   OTEL_EXPORTER_OTLP_PROTOCOL: ${{ secrets.OTEL_EXPORTER_OTLP_PROTOCOL }}
                   OTEL_EXPORTER_OTLP_ENDPOINT: ${{ secrets.OTEL_EXPORTER_OTLP_ENDPOINT }}
                   OTEL_EXPORTER_OTLP_HEADERS: ${{ secrets.OTEL_EXPORTER_OTLP_HEADERS }}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove console logging from OpenTelemetry configuration in GitHub workflows to reduce log spam.
> 
>   - **Behavior**:
>     - Remove `console` from `OTEL_LOGS_EXPORTER` and `OTEL_METRICS_EXPORTER` in `publish-nightly.yml` and `publish.yml` to prevent logging to the console.
>     - Now only `otlp` is used for both logs and metrics exporters.
>   - **Files Affected**:
>     - `.github/workflows/publish-nightly.yml`
>     - `.github/workflows/publish.yml`
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 139cab232d160ca43e7745f6353d490f58bed392. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->