### PR TITLE
fix: OpenAI Response API message format

### DIFF
--- a/src/core/task/StreamResponseHandler.ts
+++ b/src/core/task/StreamResponseHandler.ts
@@ -311,6 +311,10 @@ class ReasoningHandler {
 			return null
 		}
 
+		if (!this.pendingReasoning.summary.length && !this.pendingReasoning.content) {
+			return null
+		}
+
 		// Ensure signature is set if it's hidden in the summary / reasoning details
 		// to ensure it's always accessible at the top level by each provider.
 		if (!this.pendingReasoning.signature && this.pendingReasoning.summary.length) {

--- a/src/core/task/index.ts
+++ b/src/core/task/index.ts
@@ -2811,6 +2811,7 @@ export class Task {
 			const { toolUseHandler, reasonsHandler } = this.streamHandler.getHandlers()
 			const stream = this.attemptApiRequest(previousApiReqIndex) // yields only if the first chunk is successful, otherwise will allow the user to retry the request (most likely due to rate limit error, which gets thrown on the first chunk)
 
+			let assistantMessageId = ""
 			let assistantMessage = "" // For UI display (includes XML)
 			let assistantTextOnly = "" // For API history (text only, no tool XML)
 			let assistantTextSignature: string | undefined
@@ -2888,6 +2889,9 @@ export class Task {
 							}
 							if (chunk.signature) {
 								assistantTextSignature = chunk.signature
+							}
+							if (chunk.id) {
+								assistantMessageId = chunk.id
 							}
 							assistantMessage += chunk.text
 							assistantTextOnly += chunk.text // Accumulate text separately
@@ -3068,6 +3072,7 @@ export class Task {
 						// reasoning_details only exists for cline/openrouter providers
 						reasoning_details: thinkingBlock?.summary as any[],
 						signature: assistantTextSignature,
+						call_id: assistantMessageId,
 					})
 				}
 

--- a/src/shared/messages/content.ts
+++ b/src/shared/messages/content.ts
@@ -25,7 +25,7 @@ export const REASONING_DETAILS_PROVIDERS = ["cline", "openrouter"]
  * This ensures backward compatibility where the messages were stored in Anthropic format with additional
  * fields unknown to Anthropic SDK.
  */
-export interface ClineTextContentBlock extends Anthropic.TextBlockParam {
+export interface ClineTextContentBlock extends Anthropic.TextBlockParam, ClineSharedMessageParam {
 	// reasoning_details only exists for providers listed in REASONING_DETAILS_PROVIDERS
 	reasoning_details?: ClineReasoningDetailParam[]
 	// Thought Signature associates with Gemini


### PR DESCRIPTION
Fixed the message structure to match the OpenAI Responses API format.

Updated Message ID placement: The message id is stored and set at the message level, not inside the content array.

This fixes an error occuring in the current code when reasoning item is followed by a message text block: 400 Item 'rs_...' of type 'reasoning' was provided without its required following item."

<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- For feature requests: Created a discussion in our Feature Requests discussions board https://github.com/cline/cline/discussions/categories/feature-requests and received approval from core maintainers before implementation
- For all changes: Link the associated issue/discussion in the "Related Issue" section below

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly without prior discussion.

Why this requirement?
We deeply appreciate all community contributions - they are essential to Cline's success! To ensure the best use of everyone's time and maintain project direction, we use our Feature Requests discussions board to gauge community interest and validate feature ideas before implementation begins. This helps us focus development efforts on features that will benefit the most users.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** #XXXX

### Description

<!-- 
Help reviewers understand your changes by making this PR readable and well-organized:

- What problem does this PR solve?
- Why were these changes introduced and what purpose do they serve?
- For larger changes, provide context about your approach and reasoning

Small PRs may need minimal description, but larger changes benefit from explaining where you're coming from. Much of this context can be in the linked issue above, so feel free to reference it rather than repeating everything here.
-->

### Test Procedure

<!-- 
Please walk us through your testing approach and thought process. This helps reviewers understand that you've thoroughly considered the impact of your changes:

- How did you test this change?
- What could potentially break and how did you verify it doesn't?
- What existing functionality might be affected and how did you check it still works?
- Why are you confident this is ready for merge?

We're not looking for exhaustive documentation - just evidence that you've thought through the implications of your changes and tested accordingly.
-->

1. Start Debugger - enable native tool calling
2. Start a task with gpt-5 using the OpenAI provider - response API is used automatically when in debugger
3. Ask a follow up question "What's your name" to makes sure Cline response with a regular text block and verify you are not running into any error.
4. Verify other providers are not affected (no error)

<img width="585" height="1198" alt="image" src="https://github.com/user-attachments/assets/4d691f35-15ed-4d7d-9235-b2ac028af1bd" />


Before: message block followed by reason block would returns error

<img width="720" height="626" alt="image" src="https://github.com/user-attachments/assets/97f53744-bca9-4619-a079-62b63b71a13c" />


### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

Feature is not available to public yet.

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes message ID placement and reasoning item handling in OpenAI Response API integration to prevent errors.
> 
>   - **Behavior**:
>     - Fixes message ID placement in `convertToOpenAIResponsesInput()` in `openai-response-format.ts` to be at the message level, not inside content.
>     - Ensures reasoning items in `convertToOpenAIResponsesInput()` are only included if they have content, preventing API errors.
>   - **Handlers**:
>     - Adds check in `ReasoningHandler` in `StreamResponseHandler.ts` to skip empty reasoning items.
>     - Updates `Task` in `index.ts` to handle message IDs and reasoning items correctly during task execution.
>   - **Models**:
>     - Extends `ClineTextContentBlock` in `content.ts` to include `ClineSharedMessageParam` for message ID handling.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 2b974a15edb4b6d83f48ce56836046eca91c536a. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->