### PR TITLE
fix: enhance terminal creation with environment configuration

### DIFF
--- a/.changeset/every-animals-flow.md
+++ b/.changeset/every-animals-flow.md
@@ -1,0 +1,49 @@
+---
+"claude-dev": patch
+---
+
+# Terminal Profile Environment Variables Fix
+
+## Issue
+
+When Cline's "Default Terminal Profile" setting was set to "Default", environment variables defined in VS Code's custom terminal profiles were not being passed to Cline's terminal sessions.
+
+## GitHub Issue: #7793
+
+## Root Cause
+
+Three issues in the codebase:
+shell.ts: Profile interfaces were missing the env property, so environment variables were never read from VS Code's configuration.
+TerminalRegistry.ts: The createTerminal() method only set CLINE_ACTIVE as an environment variable and didn't accept profile env vars.
+TerminalManager.ts: When profile was "default", the code set expectedShellConfig to undefined, skipping the env var extraction entirely.
+
+## Changes Made
+
+1. shell.ts
+   Added env?: Record<string, string> to WindowsTerminalProfile, MacTerminalProfile, and LinuxTerminalProfile interfaces
+   Created TerminalProfileConfig interface with path and env properties
+   Modified getShell() to return TerminalProfileConfig instead of just a string
+   Modified getShellForProfile() to return TerminalProfileConfig
+   Updated getWindowsShellFromVSCode(), getMacShellFromVSCode(), and getLinuxShellFromVSCode() to return TerminalProfileConfig with env vars
+
+2. TerminalRegistry.ts
+   Added profileEnv?: Record<string, string> parameter to createTerminal()
+   Merged profile env vars with CLINE_ACTIVE when creating terminal options
+
+3. TerminalManager.ts
+   Changed expectedShellConfig to always call getShellForProfile() instead of returning undefined when profile is "default"
+   Updated createTerminal() calls to pass expectedShellConfig.env
+
+## Testing
+
+Add a custom terminal profile in VS Code settings with env vars
+Set that profile as default in VS Code
+Set Cline's "Default Terminal Profile" to "Default"
+Ask Cline to run echo $MY_VAR
+Verify the env var is correctly set
+
+## Files Changed
+
+1. shell.ts
+2. TerminalRegistry.ts
+3. TerminalManager.ts

--- a/src/core/prompts/commands/deep-planning/variants/anthropic.ts
+++ b/src/core/prompts/commands/deep-planning/variants/anthropic.ts
@@ -28,7 +28,7 @@ export function createAnthropicVariant(): DeepPlanningVariant {
  * Generates the deep-planning template with shell-specific commands
  */
 function generateTemplate(): string {
-	const detectedShell = getShell()
+	const detectedShell = getShell()?.path
 
 	// FIXME: detectedShell returns a non-string value on some Windows machines
 	let isPowerShell = false

--- a/src/core/prompts/commands/deep-planning/variants/gemini.ts
+++ b/src/core/prompts/commands/deep-planning/variants/gemini.ts
@@ -28,7 +28,7 @@ export function createGeminiVariant(): DeepPlanningVariant {
  * Generates the deep-planning template with shell-specific commands
  */
 function generateTemplate(): string {
-	const detectedShell = getShell()
+	const detectedShell = getShell()?.path
 
 	// FIXME: detectedShell returns a non-string value on some Windows machines
 	let isPowerShell = false

--- a/src/core/prompts/commands/deep-planning/variants/gemini3.ts
+++ b/src/core/prompts/commands/deep-planning/variants/gemini3.ts
@@ -29,7 +29,7 @@ export function createGemini3Variant(): DeepPlanningVariant {
  * @param enableNativeToolCalls Whether native tool calling is enabled
  */
 export function generateGemini3Template(focusChainEnabled: boolean, enableNativeToolCalls: boolean): string {
-	const detectedShell = getShell()
+	const detectedShell = getShell()?.path
 
 	let isPowerShell = false
 	try {

--- a/src/core/prompts/commands/deep-planning/variants/generic.ts
+++ b/src/core/prompts/commands/deep-planning/variants/generic.ts
@@ -20,7 +20,7 @@ export function createGenericVariant(): DeepPlanningVariant {
  * Generates the deep-planning template with shell-specific commands
  */
 function generateTemplate(): string {
-	const detectedShell = getShell()
+	const detectedShell = getShell()?.path
 
 	// FIXME: detectedShell returns a non-string value on some Windows machines
 	let isPowerShell = false

--- a/src/core/prompts/commands/deep-planning/variants/gpt51.ts
+++ b/src/core/prompts/commands/deep-planning/variants/gpt51.ts
@@ -29,7 +29,7 @@ export function createGPT51Variant(): DeepPlanningVariant {
  * @param enableNativeToolCalls Whether native tool calling is enabled
  */
 export function generateGPT51Template(focusChainEnabled: boolean, enableNativeToolCalls: boolean): string {
-	const detectedShell = getShell()
+	const detectedShell = getShell()?.path
 
 	let isPowerShell = false
 	try {

--- a/src/core/prompts/system-prompt-legacy/families/local-models/compact-system-prompt.ts
+++ b/src/core/prompts/system-prompt-legacy/families/local-models/compact-system-prompt.ts
@@ -139,7 +139,7 @@ Include options/trade-offs when helpful, ask if plan matches, then add the exact
 
 ## SYSTEM INFO
 OS: ${osName()}
-Shell: ${getShell()}
+Shell: ${getShell()?.path}
 Home: ${os.homedir().toPosix()}
 CWD: ${cwd.toPosix()}`
 }

--- a/src/core/prompts/system-prompt-legacy/families/next-gen-models/gpt-5.ts
+++ b/src/core/prompts/system-prompt-legacy/families/next-gen-models/gpt-5.ts
@@ -823,7 +823,7 @@ RULES
 SYSTEM INFORMATION
 
 Operating System: ${osName()}
-Default Shell: ${getShell()}
+Default Shell: ${getShell()?.path}
 Home Directory: ${os.homedir().toPosix()}
 Current Working Directory: ${cwd.toPosix()}
 

--- a/src/core/prompts/system-prompt/components/system_info.ts
+++ b/src/core/prompts/system-prompt/components/system_info.ts
@@ -30,7 +30,7 @@ export async function getSystemEnv(context: SystemPromptContext, isTesting = fal
 		: {
 				os: osName(),
 				ide: context.ide,
-				shell: getShell(),
+				shell: getShell()?.path,
 				homeDir: osModule.homedir(),
 				workingDir: currentWorkDir,
 				workspaces: workspaces,

--- a/src/integrations/terminal/TerminalManager.ts
+++ b/src/integrations/terminal/TerminalManager.ts
@@ -380,7 +380,7 @@ export class TerminalManager {
 		this.defaultTerminalProfile = profileId
 
 		// Get the shell path for the new profile
-		const newShellPath = profileId !== "default" ? getShellForProfile(profileId).path : undefined
+		const newShellPath = getShellForProfile(profileId)?.path
 
 		// Handle terminal management for the profile change
 		const result = this.handleTerminalProfileChange(newShellPath)

--- a/src/integrations/terminal/TerminalManager.ts
+++ b/src/integrations/terminal/TerminalManager.ts
@@ -226,8 +226,8 @@ export class TerminalManager {
 
 	async getOrCreateTerminal(cwd: string): Promise<TerminalInfo> {
 		const terminals = TerminalRegistry.getAllTerminals()
-		const expectedShellPath =
-			this.defaultTerminalProfile !== "default" ? getShellForProfile(this.defaultTerminalProfile) : undefined
+		const expectedShellConfig = getShellForProfile(this.defaultTerminalProfile)
+		const expectedShellPath = expectedShellConfig?.path
 
 		// Find available terminal from our pool first (created for this task)
 		console.log(`[TerminalManager] Looking for terminal in cwd: ${cwd}`)
@@ -304,7 +304,7 @@ export class TerminalManager {
 		}
 
 		// If all terminals are busy or don't match shell profile, create a new one with the configured shell
-		const newTerminalInfo = TerminalRegistry.createTerminal(cwd, expectedShellPath)
+		const newTerminalInfo = TerminalRegistry.createTerminal(cwd, expectedShellPath, expectedShellConfig?.env)
 		this.terminalIds.add(newTerminalInfo.id)
 		return newTerminalInfo
 	}
@@ -380,7 +380,7 @@ export class TerminalManager {
 		this.defaultTerminalProfile = profileId
 
 		// Get the shell path for the new profile
-		const newShellPath = profileId !== "default" ? getShellForProfile(profileId) : undefined
+		const newShellPath = profileId !== "default" ? getShellForProfile(profileId).path : undefined
 
 		// Handle terminal management for the profile change
 		const result = this.handleTerminalProfileChange(newShellPath)

--- a/src/integrations/terminal/TerminalRegistry.ts
+++ b/src/integrations/terminal/TerminalRegistry.ts
@@ -20,12 +20,17 @@ export class TerminalRegistry {
 	private static terminals: TerminalInfo[] = []
 	private static nextTerminalId = 1
 
-	static createTerminal(cwd?: string | vscode.Uri | undefined, shellPath?: string): TerminalInfo {
+	static createTerminal(
+		cwd?: string | vscode.Uri | undefined,
+		shellPath?: string,
+		profileEnv?: Record<string, string>,
+	): TerminalInfo {
 		const terminalOptions: vscode.TerminalOptions = {
 			cwd,
 			name: "Cline",
 			iconPath: new vscode.ThemeIcon("cline-icon"),
 			env: {
+				...profileEnv,
 				CLINE_ACTIVE: "true",
 			},
 		}

--- a/src/test/shell.test.ts
+++ b/src/test/shell.test.ts
@@ -61,61 +61,61 @@ describe("Shell Detection Tests", () => {
 			mockVsCodeConfig("windows", "PowerShell", {
 				PowerShell: { path: "C:\\Program Files\\PowerShell\\7\\pwsh.exe" },
 			})
-			expect(getShell()).to.equal("C:\\Program Files\\PowerShell\\7\\pwsh.exe")
+			expect(getShell()?.path).to.equal("C:\\Program Files\\PowerShell\\7\\pwsh.exe")
 		})
 
 		it("uses PowerShell 7 path if source is 'PowerShell' but no explicit path", () => {
 			mockVsCodeConfig("windows", "PowerShell", {
 				PowerShell: { source: "PowerShell" },
 			})
-			expect(getShell()).to.equal("C:\\Program Files\\PowerShell\\7\\pwsh.exe")
+			expect(getShell()?.path).to.equal("C:\\Program Files\\PowerShell\\7\\pwsh.exe")
 		})
 
 		it("falls back to legacy PowerShell if profile includes 'powershell' but no path/source", () => {
 			mockVsCodeConfig("windows", "PowerShell", {
 				PowerShell: {},
 			})
-			expect(getShell()).to.equal("C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe")
+			expect(getShell()?.path).to.equal("C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe")
 		})
 
 		it("handles undefined shell profile gracefully", () => {
 			mockVsCodeConfig("windows", "NonExistentProfile", {})
-			expect(getShell()).to.equal("C:\\Windows\\System32\\cmd.exe")
+			expect(getShell()?.path).to.equal("C:\\Windows\\System32\\cmd.exe")
 		})
 
 		it("uses WSL bash when profile indicates WSL source", () => {
 			mockVsCodeConfig("windows", "WSL", {
 				WSL: { source: "WSL" },
 			})
-			expect(getShell()).to.equal("/bin/bash")
+			expect(getShell()?.path).to.equal("/bin/bash")
 		})
 
 		it("uses WSL bash when profile name includes 'wsl'", () => {
 			mockVsCodeConfig("windows", "Ubuntu WSL", {
 				"Ubuntu WSL": {},
 			})
-			expect(getShell()).to.equal("/bin/bash")
+			expect(getShell()?.path).to.equal("/bin/bash")
 		})
 
 		it("defaults to cmd.exe if no special profile is matched", () => {
 			mockVsCodeConfig("windows", "CommandPrompt", {
 				CommandPrompt: {},
 			})
-			expect(getShell()).to.equal("C:\\Windows\\System32\\cmd.exe")
+			expect(getShell()?.path).to.equal("C:\\Windows\\System32\\cmd.exe")
 		})
 
 		it("respects userInfo() if no VS Code config is available", () => {
 			vscode.workspace.getConfiguration = () => ({ get: () => undefined }) as any
 			;(userInfo as any) = () => ({ shell: "C:\\Custom\\PowerShell.exe" })
 
-			expect(getShell()).to.equal("C:\\Custom\\PowerShell.exe")
+			expect(getShell()?.path).to.equal("C:\\Custom\\PowerShell.exe")
 		})
 
 		it("respects an odd COMSPEC if no userInfo shell is available", () => {
 			vscode.workspace.getConfiguration = () => ({ get: () => undefined }) as any
 			process.env.COMSPEC = "D:\\CustomCmd\\cmd.exe"
 
-			expect(getShell()).to.equal("D:\\CustomCmd\\cmd.exe")
+			expect(getShell()?.path).to.equal("D:\\CustomCmd\\cmd.exe")
 		})
 	})
 
@@ -131,27 +131,27 @@ describe("Shell Detection Tests", () => {
 			mockVsCodeConfig("osx", "MyCustomShell", {
 				MyCustomShell: { path: "/usr/local/bin/fish" },
 			})
-			expect(getShell()).to.equal("/usr/local/bin/fish")
+			expect(getShell()?.path).to.equal("/usr/local/bin/fish")
 		})
 
 		it("falls back to userInfo().shell if no VS Code config is available", () => {
 			vscode.workspace.getConfiguration = () => ({ get: () => undefined }) as any
 			;(userInfo as any) = () => ({ shell: "/opt/homebrew/bin/zsh" })
 
-			expect(getShell()).to.equal("/opt/homebrew/bin/zsh")
+			expect(getShell()?.path).to.equal("/opt/homebrew/bin/zsh")
 		})
 
 		it("falls back to SHELL env var if no userInfo shell is found", () => {
 			vscode.workspace.getConfiguration = () => ({ get: () => undefined }) as any
 			process.env.SHELL = "/usr/local/bin/zsh"
 
-			expect(getShell()).to.equal("/usr/local/bin/zsh")
+			expect(getShell()?.path).to.equal("/usr/local/bin/zsh")
 		})
 
 		it("falls back to /bin/zsh if no config, userInfo, or env variable is set", () => {
 			vscode.workspace.getConfiguration = () => ({ get: () => undefined }) as any
 			// userInfo => null, SHELL => undefined
-			expect(getShell()).to.equal("/bin/zsh")
+			expect(getShell()?.path).to.equal("/bin/zsh")
 		})
 	})
 
@@ -167,27 +167,27 @@ describe("Shell Detection Tests", () => {
 			mockVsCodeConfig("linux", "CustomProfile", {
 				CustomProfile: { path: "/usr/bin/fish" },
 			})
-			expect(getShell()).to.equal("/usr/bin/fish")
+			expect(getShell()?.path).to.equal("/usr/bin/fish")
 		})
 
 		it("falls back to userInfo().shell if no VS Code config is available", () => {
 			vscode.workspace.getConfiguration = () => ({ get: () => undefined }) as any
 			;(userInfo as any) = () => ({ shell: "/usr/bin/zsh" })
 
-			expect(getShell()).to.equal("/usr/bin/zsh")
+			expect(getShell()?.path).to.equal("/usr/bin/zsh")
 		})
 
 		it("falls back to SHELL env var if no userInfo shell is found", () => {
 			vscode.workspace.getConfiguration = () => ({ get: () => undefined }) as any
 			process.env.SHELL = "/usr/bin/fish"
 
-			expect(getShell()).to.equal("/usr/bin/fish")
+			expect(getShell()?.path).to.equal("/usr/bin/fish")
 		})
 
 		it("falls back to /bin/bash if nothing is set", () => {
 			vscode.workspace.getConfiguration = () => ({ get: () => undefined }) as any
 			// userInfo => null, SHELL => undefined
-			expect(getShell()).to.equal("/bin/bash")
+			expect(getShell()?.path).to.equal("/bin/bash")
 		})
 	})
 
@@ -199,7 +199,7 @@ describe("Shell Detection Tests", () => {
 			Object.defineProperty(process, "platform", { value: "sunos" })
 			vscode.workspace.getConfiguration = () => ({ get: () => undefined }) as any
 
-			expect(getShell()).to.equal("/bin/sh")
+			expect(getShell()?.path).to.equal("/bin/sh")
 		})
 
 		it("handles VS Code config errors gracefully, falling back to userInfo shell if present", () => {
@@ -209,7 +209,7 @@ describe("Shell Detection Tests", () => {
 			}
 			;(userInfo as any) = () => ({ shell: "/bin/bash" })
 
-			expect(getShell()).to.equal("/bin/bash")
+			expect(getShell()?.path).to.equal("/bin/bash")
 		})
 
 		it("handles userInfo errors gracefully, falling back to environment variable if present", () => {
@@ -220,7 +220,7 @@ describe("Shell Detection Tests", () => {
 			}
 			process.env.SHELL = "/bin/zsh"
 
-			expect(getShell()).to.equal("/bin/zsh")
+			expect(getShell()?.path).to.equal("/bin/zsh")
 		})
 
 		it("falls back fully to default shell paths if everything fails", () => {
@@ -234,7 +234,7 @@ describe("Shell Detection Tests", () => {
 			// No SHELL in env
 			delete process.env.SHELL
 
-			expect(getShell()).to.equal("/bin/bash")
+			expect(getShell()?.path).to.equal("/bin/bash")
 		})
 	})
 })

--- a/src/utils/shell.ts
+++ b/src/utils/shell.ts
@@ -147,7 +147,12 @@ function getMacShellFromVSCode(): TerminalProfileConfig | null {
 	}
 
 	const profile = profiles[defaultProfileName]
-	return profile || null
+
+	if (!profile?.path) {
+		return null
+	}
+
+	return profile
 }
 
 /** Attempts to retrieve a shell config from VS Code config on Linux. */
@@ -158,7 +163,12 @@ function getLinuxShellFromVSCode(): TerminalProfileConfig | null {
 	}
 
 	const profile = profiles[defaultProfileName]
-	return profile || null
+
+	if (!profile?.path) {
+		return null
+	}
+
+	return profile
 }
 
 // -----------------------------------------------------

--- a/src/utils/shell.ts
+++ b/src/utils/shell.ts
@@ -23,6 +23,7 @@ const SHELL_PATHS = {
 
 interface MacTerminalProfile {
 	path?: string
+	env?: Record<string, string>
 }
 
 type MacTerminalProfiles = Record<string, MacTerminalProfile>
@@ -30,15 +31,22 @@ type MacTerminalProfiles = Record<string, MacTerminalProfile>
 interface WindowsTerminalProfile {
 	path?: string
 	source?: "PowerShell" | "WSL"
+	env?: Record<string, string>
 }
 
 type WindowsTerminalProfiles = Record<string, WindowsTerminalProfile>
 
 interface LinuxTerminalProfile {
 	path?: string
+	env?: Record<string, string>
 }
 
 type LinuxTerminalProfiles = Record<string, LinuxTerminalProfile>
+
+interface TerminalProfileConfig {
+	path?: string
+	env?: Record<string, string>
+}
 
 // -----------------------------------------------------
 // 1) VS Code Terminal Configuration Helpers
@@ -81,8 +89,8 @@ function getLinuxTerminalConfig() {
 // 2) Platform-Specific VS Code Shell Retrieval
 // -----------------------------------------------------
 
-/** Attempts to retrieve a shell path from VS Code config on Windows. */
-function getWindowsShellFromVSCode(): string | null {
+/** Attempts to retrieve a shell config from VS Code config on Windows. */
+function getWindowsShellFromVSCode(): TerminalProfileConfig | null {
 	const { defaultProfileName, profiles } = getWindowsTerminalConfig()
 	if (!defaultProfileName) {
 		return null
@@ -96,49 +104,61 @@ function getWindowsShellFromVSCode(): string | null {
 	if (defaultProfileName.toLowerCase().includes("powershell")) {
 		if (profile?.path) {
 			// If there's an explicit PowerShell path, return that
-			return profile.path
+			return profile
 		} else if (profile?.source === "PowerShell") {
 			// If the profile is sourced from PowerShell, assume the newest
-			return SHELL_PATHS.POWERSHELL_7
+			return {
+				path: SHELL_PATHS.POWERSHELL_7,
+				env: profile?.env,
+			}
 		}
 		// Otherwise, assume legacy Windows PowerShell
-		return SHELL_PATHS.POWERSHELL_LEGACY
+		return {
+			path: SHELL_PATHS.POWERSHELL_LEGACY,
+			env: profile?.env,
+		}
 	}
 
 	// If there's a specific path, return that immediately
 	if (profile?.path) {
-		return profile.path
+		return profile
 	}
 
 	// If the profile indicates WSL
 	if (profile?.source === "WSL" || defaultProfileName.toLowerCase().includes("wsl")) {
-		return SHELL_PATHS.WSL_BASH
+		return {
+			path: SHELL_PATHS.WSL_BASH,
+			env: profile?.env,
+		}
 	}
 
 	// If nothing special detected, we assume cmd
-	return SHELL_PATHS.CMD
+	return {
+		path: SHELL_PATHS.CMD,
+		env: profile?.env,
+	}
 }
 
-/** Attempts to retrieve a shell path from VS Code config on macOS. */
-function getMacShellFromVSCode(): string | null {
+/** Attempts to retrieve a shell config from VS Code config on macOS. */
+function getMacShellFromVSCode(): TerminalProfileConfig | null {
 	const { defaultProfileName, profiles } = getMacTerminalConfig()
 	if (!defaultProfileName) {
 		return null
 	}
 
 	const profile = profiles[defaultProfileName]
-	return profile?.path || null
+	return profile || null
 }
 
-/** Attempts to retrieve a shell path from VS Code config on Linux. */
-function getLinuxShellFromVSCode(): string | null {
+/** Attempts to retrieve a shell config from VS Code config on Linux. */
+function getLinuxShellFromVSCode(): TerminalProfileConfig | null {
 	const { defaultProfileName, profiles } = getLinuxTerminalConfig()
 	if (!defaultProfileName) {
 		return null
 	}
 
 	const profile = profiles[defaultProfileName]
-	return profile?.path || null
+	return profile || null
 }
 
 // -----------------------------------------------------
@@ -272,8 +292,8 @@ export function getAvailableTerminalProfiles(): TerminalProfile[] {
 	return profiles
 }
 
-/** Gets the shell path for a specific terminal profile */
-export function getShellForProfile(profileId: string): string {
+/** Gets the shell config for a specific terminal profile */
+export function getShellForProfile(profileId: string): TerminalProfileConfig {
 	// If it's the default profile, use the existing getShell() logic
 	if (profileId === "default") {
 		return getShell()
@@ -284,7 +304,7 @@ export function getShellForProfile(profileId: string): string {
 	const profile = profiles.find((p) => p.id === profileId)
 
 	if (profile?.path) {
-		return profile.path
+		return profile
 	}
 
 	// Fallback to default shell if profile not found
@@ -295,7 +315,7 @@ export function getShellForProfile(profileId: string): string {
 // 5) Publicly Exposed Shell Getter
 // -----------------------------------------------------
 
-export function getShell(): string {
+export function getShell(): TerminalProfileConfig {
 	// 1. Check VS Code config first.
 	if (process.platform === "win32") {
 		// Special logic for Windows
@@ -320,21 +340,21 @@ export function getShell(): string {
 	// 2. If no shell from VS Code, try userInfo()
 	const userInfoShell = getShellFromUserInfo()
 	if (userInfoShell) {
-		return userInfoShell
+		return { path: userInfoShell }
 	}
 
 	// 3. If still nothing, try environment variable
 	const envShell = getShellFromEnv()
 	if (envShell) {
-		return envShell
+		return { path: envShell }
 	}
 
 	// 4. Finally, fall back to a default
 	if (process.platform === "win32") {
 		// On Windows, if we got here, we have no config, no COMSPEC, and one very messed up operating system.
 		// Use CMD as a last resort
-		return SHELL_PATHS.CMD
+		return { path: SHELL_PATHS.CMD }
 	}
 	// On macOS/Linux, fallback to a POSIX shell - This is the behavior of our old shell detection method.
-	return SHELL_PATHS.FALLBACK
+	return { path: SHELL_PATHS.FALLBACK }
 }


### PR DESCRIPTION
### Related Issue

**Issue:** #7793

### Description

When Cline's "Default Terminal Profile" setting was set to "Default", environment variables defined in VS Code's custom terminal profiles were not being passed to Cline's terminal sessions.

### Root Cause

Three issues in the codebase:
`shell.ts`: Profile interfaces were missing the env property, so environment variables were never read from VS Code's configuration.
`TerminalRegistry.ts`: The `createTerminal()` method only set CLINE_ACTIVE as an environment variable and didn't accept profile env vars.
`TerminalManager.ts`: When profile was "default", the code set `expectedShellConfig` to undefined, skipping the env var extraction entirely.

### Changes Made

1. `shell.ts`
   - Added `env?: Record<string, string>` to `WindowsTerminalProfile`, `MacTerminalProfile`, and `LinuxTerminalProfile` interfaces
   - Created `TerminalProfileConfig` interface with path and env properties
   - Modified `getShell()` to return `TerminalProfileConfig` instead of just a string
   - Modified `getShellForProfile()` to return `TerminalProfileConfig`
   - Updated `getWindowsShellFromVSCode()`, `getMacShellFromVSCode()`, and `getLinuxShellFromVSCode()` to return `TerminalProfileConfig` with env vars

2. `TerminalRegistry.ts`
   - Added `profileEnv?: Record<string, string>` parameter to `createTerminal()`
   Merged profile env vars with CLINE_ACTIVE when creating terminal options

3. `TerminalManager.ts`
   - Changed `expectedShellConfig` to always call `getShellForProfile()` instead of returning undefined when profile is "default"
   Updated `createTerminal()` calls to pass `expectedShellConfig.env`
   
4. `shell.test.ts`
    - Updated all test assertions to use getShell()?.path instead of getShell() to match the new TerminalProfileConfig return type

5. `src/core/prompts`
    - Updated files that call `getShell()` to use the new `TerminalProfileConfig` return type (accessing `.path` property where needed)

### Test Procedure

Add a custom terminal profile in VS Code settings with env vars
Set that profile as default in VS Code
Set Cline's "Default Terminal Profile" to "Default"
Ask Cline to run echo $MY_VAR
Verify the env var is correctly set

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<img width="444" height="665" alt="Screenshot_20251203_185247" src="https://github.com/user-attachments/assets/630205fc-4c28-4121-bc14-6f39439b6765" />

<img width="425" height="436" alt="Screenshot_20251203_192041" src="https://github.com/user-attachments/assets/85019824-918c-4c7e-bfdb-d97b70fa40e7" />


### Additional Notes

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Enhance terminal creation by incorporating environment variables from VS Code's terminal profiles into Cline's terminal sessions.
> 
>   - **Behavior**:
>     - `shell.ts`: Added `env` property to terminal profile interfaces and created `TerminalProfileConfig`.
>     - `TerminalRegistry.ts`: Updated `createTerminal()` to accept `profileEnv` and merge with `CLINE_ACTIVE`.
>     - `TerminalManager.ts`: Modified `getOrCreateTerminal()` to use `getShellForProfile()` for "default" profile and pass `expectedShellConfig.env`.
>   - **Functions**:
>     - `getShell()`, `getShellForProfile()`, `getWindowsShellFromVSCode()`, `getMacShellFromVSCode()`, `getLinuxShellFromVSCode()` updated to handle `TerminalProfileConfig`.
>   - **Tests**:
>     - `shell.test.ts`: Updated tests to check for `env` in shell configurations.
>   - **Misc**:
>     - Updated `getSystemEnv()` in `system_info.ts` to use `getShell()?.path`.
>     - Minor updates in `compact-system-prompt.ts` and `gpt-5.ts` to use `getShell()?.path`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 6de54df79ef39a8eaa765040d8df80ee02ad15d8. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->