### PR TITLE
Revert "readTaskHistory - don't return empty array on parse failure"

### DIFF
--- a/src/core/storage/disk.ts
+++ b/src/core/storage/disk.ts
@@ -200,7 +200,7 @@ export async function saveClineMessages(taskId: string, uiMessages: ClineMessage
 export async function collectEnvironmentMetadata(): Promise<Omit<EnvironmentMetadataEntry, "ts">> {
 	try {
 		const hostVersion = await HostProvider.env.getHostVersion({})
-
+		
 		return {
 			os_name: os.platform(),
 			os_version: os.release(),
@@ -297,8 +297,12 @@ export async function readTaskHistoryFromState(): Promise<HistoryItem[]> {
 		const filePath = await getTaskHistoryStateFilePath()
 		if (await fileExistsAtPath(filePath)) {
 			const contents = await fs.readFile(filePath, "utf8")
-
-			return JSON.parse(contents)
+			try {
+				return JSON.parse(contents)
+			} catch (error) {
+				console.error("[Disk] Failed to parse task history:", error)
+				return []
+			}
 		}
 		return []
 	} catch (error) {


### PR DESCRIPTION
Reverts cline/cline#7773

This causes the extension to crash 
<img width="525" height="1117" alt="Cursor 2025-12-03 14 19 59" src="https://github.com/user-attachments/assets/a456f135-0a3b-494f-8323-ecce447859e1" />

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Reverts `readTaskHistoryFromState()` in `disk.ts` to return an empty array on JSON parse failure, fixing a crash.
> 
>   - **Revert Change**:
>     - Reverts behavior in `readTaskHistoryFromState()` in `disk.ts` to return an empty array on JSON parse failure.
>     - Adds error logging for JSON parse failures in `readTaskHistoryFromState()`.
>   - **Misc**:
>     - Minor whitespace change in `collectEnvironmentMetadata()` in `disk.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 9090cd5becdf16d2ac50c66d9498b23396ba2a29. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->