### PR TITLE
feat: remove mcp enable setting for individual users

### DIFF
--- a/src/core/controller/state/updateSettings.ts
+++ b/src/core/controller/state/updateSettings.ts
@@ -74,11 +74,6 @@ export async function updateSettings(controller: Controller, request: UpdateSett
 			controller.stateManager.setGlobalState("enableCheckpointsSetting", request.enableCheckpointsSetting)
 		}
 
-		// Update MCP marketplace setting
-		if (request.mcpMarketplaceEnabled !== undefined) {
-			controller.stateManager.setGlobalState("mcpMarketplaceEnabled", request.mcpMarketplaceEnabled)
-		}
-
 		// Update MCP responses collapsed setting
 		if (request.mcpResponsesCollapsed !== undefined) {
 			controller.stateManager.setGlobalState("mcpResponsesCollapsed", request.mcpResponsesCollapsed)

--- a/webview-ui/src/components/mcp/configuration/tabs/marketplace/McpMarketplaceView.tsx
+++ b/webview-ui/src/components/mcp/configuration/tabs/marketplace/McpMarketplaceView.tsx
@@ -15,8 +15,9 @@ import McpMarketplaceCard from "./McpMarketplaceCard"
 import McpSubmitCard from "./McpSubmitCard"
 
 const McpMarketplaceView = () => {
-	const { mcpServers, mcpMarketplaceCatalog, setMcpMarketplaceCatalog, mcpMarketplaceEnabled, remoteConfigSettings } =
-		useExtensionState()
+	const { mcpServers, mcpMarketplaceCatalog, setMcpMarketplaceCatalog, remoteConfigSettings } = useExtensionState()
+
+	const showMarketplace = remoteConfigSettings?.mcpMarketplaceEnabled !== false
 	const [isLoading, setIsLoading] = useState(true)
 	const [error, setError] = useState<string | null>(null)
 	const [isRefreshing, setIsRefreshing] = useState(false)
@@ -80,7 +81,7 @@ const McpMarketplaceView = () => {
 		}
 		setError(null)
 
-		if (mcpMarketplaceEnabled) {
+		if (showMarketplace) {
 			McpServiceClient.refreshMcpMarketplace(EmptyRequest.create({}))
 				.then((response) => {
 					setMcpMarketplaceCatalog(response)

--- a/webview-ui/src/components/settings/sections/FeatureSettingsSection.tsx
+++ b/webview-ui/src/components/settings/sections/FeatureSettingsSection.tsx
@@ -181,33 +181,6 @@ const FeatureSettingsSection = ({ renderSectionHeader }: FeatureSettingsSectionP
 						</p>
 					</div>
 					<div style={{ marginTop: 10 }}>
-						<Tooltip>
-							<TooltipTrigger>
-								<div className="flex items-center gap-2">
-									<VSCodeCheckbox
-										checked={mcpMarketplaceEnabled}
-										disabled={remoteConfigSettings?.mcpMarketplaceEnabled !== undefined}
-										onChange={(e: any) => {
-											const checked = e.target.checked === true
-											updateSetting("mcpMarketplaceEnabled", checked)
-										}}>
-										Enable MCP Marketplace
-									</VSCodeCheckbox>
-									{remoteConfigSettings?.mcpMarketplaceEnabled !== undefined && (
-										<i className="codicon codicon-lock text-description text-sm" />
-									)}
-								</div>
-							</TooltipTrigger>
-							<TooltipContent hidden={remoteConfigSettings?.mcpMarketplaceEnabled === undefined}>
-								This setting is managed by your organization's remote configuration
-							</TooltipContent>
-						</Tooltip>
-
-						<p className="text-xs text-description">
-							Enables the MCP Marketplace tab for discovering and installing MCP servers.
-						</p>
-					</div>
-					<div style={{ marginTop: 10 }}>
 						<label
 							className="block text-sm font-medium text-(--vscode-foreground) mb-1"
 							htmlFor="mcp-display-mode-dropdown">


### PR DESCRIPTION
### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** #XXXX
closes https://linear.app/cline-bot/issue/PF-303/remove-mcp-marketplace-enabled-setting-from-the-extension

### Description

This PR removes MCP marketplace Enable option from settings. It will be by default enabled unless organization turn it off via remote config.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

| Before     | After |
| ----------- | ----------- |
| <img width="300" height="300" alt="Screenshot 2025-12-03 at 5 49 55 PM" src="https://github.com/user-attachments/assets/8061201a-624e-44fb-af89-4735b6dd28c2" />     | <img width="300" height="300" alt="Screenshot 2025-12-03 at 5 50 16 PM" src="https://github.com/user-attachments/assets/2ccf4fd4-19b7-49d6-ba4d-7b9d2d145a11" />|



### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove MCP marketplace enable setting for individual users, defaulting to enabled unless disabled by organization via remote config.
> 
>   - **Behavior**:
>     - Removes `mcpMarketplaceEnabled` setting from `updateSettings()` in `updateSettings.ts`.
>     - `McpConfigurationView.tsx` and `McpMarketplaceView.tsx` now default to showing the marketplace unless disabled by remote config.
>   - **UI Changes**:
>     - Removes MCP marketplace enable checkbox from `FeatureSettingsSection.tsx`.
>     - Updates logic in `McpConfigurationView.tsx` and `McpMarketplaceView.tsx` to use `remoteConfigSettings` for marketplace visibility.
>   - **Misc**:
>     - Removes all references to `mcpMarketplaceEnabled` in `McpConfigurationView.tsx`, `McpMarketplaceView.tsx`, and `FeatureSettingsSection.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 9b57c11a53301965e2edd68932f7c5125c9db780. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->