### PR TITLE
fix: consolidate successive error retry messages in chat UI

### DIFF
--- a/src/shared/combineErrorRetryMessages.ts
+++ b/src/shared/combineErrorRetryMessages.ts
@@ -1,0 +1,46 @@
+import { ClineMessage } from "./ExtensionMessage"
+
+/**
+ * Consolidates error_retry messages in a retry sequence, keeping only the latest one.
+ *
+ * When an API request fails and auto-retry is enabled, multiple error_retry messages are created
+ * (e.g., "Attempt 1 of 3", "Attempt 2 of 3", "Attempt 3 of 3"), interleaved with api_req_retried
+ * messages. This function filters out earlier retry messages, showing only the most recent one.
+ *
+ * @param messages - An array of ClineMessage objects to process.
+ * @returns A new array of ClineMessage objects with error_retry sequences consolidated.
+ *
+ * @example
+ * const messages: ClineMessage[] = [
+ *   { type: 'say', say: 'error_retry', text: '{"attempt":1,"maxAttempts":3}', ts: 1000 },
+ *   { type: 'say', say: 'api_req_retried', ts: 1001 },
+ *   { type: 'say', say: 'error_retry', text: '{"attempt":2,"maxAttempts":3}', ts: 1002 },
+ *   { type: 'say', say: 'api_req_retried', ts: 1003 },
+ *   { type: 'say', say: 'error_retry', text: '{"attempt":3,"maxAttempts":3}', ts: 1004 },
+ * ];
+ * const result = combineErrorRetryMessages(messages);
+ * // Result: [{ type: 'say', say: 'error_retry', text: '{"attempt":3,"maxAttempts":3}', ts: 1004 }]
+ */
+export function combineErrorRetryMessages(messages: ClineMessage[]): ClineMessage[] {
+	const result: ClineMessage[] = []
+
+	for (let i = 0; i < messages.length; i++) {
+		const message = messages[i]
+
+		if (message.say === "error_retry") {
+			// Look ahead to see if the next non-api_req_retried message is also an error_retry
+			let nextMessage = messages[i + 1]
+			if (nextMessage?.say === "api_req_retried") {
+				nextMessage = messages[i + 2]
+			}
+			if (nextMessage?.say === "error_retry") {
+				// Skip this message, we'll show the next one (or a later one in the sequence)
+				continue
+			}
+		}
+
+		result.push(message)
+	}
+
+	return result
+}

--- a/webview-ui/src/components/chat/ChatView.tsx
+++ b/webview-ui/src/components/chat/ChatView.tsx
@@ -1,6 +1,7 @@
 import { findLast } from "@shared/array"
 import { combineApiRequests } from "@shared/combineApiRequests"
 import { combineCommandSequences } from "@shared/combineCommandSequences"
+import { combineErrorRetryMessages } from "@shared/combineErrorRetryMessages"
 import { combineHookSequences } from "@shared/combineHookSequences"
 import type { ClineApiReqInfo, ClineMessage } from "@shared/ExtensionMessage"
 import { getApiMetrics } from "@shared/getApiMetrics"
@@ -64,7 +65,7 @@ const ChatView = ({ isHidden, showAnnouncement, hideAnnouncement, showHistoryVie
 		// Only combine hook sequences if hooks are enabled (both user setting and feature flag)
 		const areHooksEnabled = hooksEnabled?.user
 		const withHooks = areHooksEnabled ? combineHookSequences(slicedMessages) : slicedMessages
-		return combineApiRequests(combineCommandSequences(withHooks))
+		return combineErrorRetryMessages(combineApiRequests(combineCommandSequences(withHooks)))
 	}, [messages, hooksEnabled])
 	// has to be after api_req_finished are all reduced into api_req_started messages
 	const apiMetrics = useMemo(() => getApiMetrics(modifiedMessages), [modifiedMessages])


### PR DESCRIPTION
### Related Issue

Small bug fix - no prior issue required.

### Description

When API requests fail and auto-retry is enabled, multiple `error_retry` messages were displayed in the chat (e.g., "Attempt 1 of 3", "Attempt 2 of 3", "Attempt 3 of 3"). This created visual clutter during retry sequences.

<img width="304" height="701" alt="Cursor 2025-12-03 19 02 08" src="https://github.com/user-attachments/assets/d295eeeb-64ca-4e5a-8b04-3a60b1203a86" />

This PR adds a new `combineErrorRetryMessages` utility that consolidates successive error retry messages, showing only the latest one in each retry sequence. This follows the same pattern as existing combiners like `combineApiRequests` and `combineCommandSequences`.

<img width="300" height="356" alt="Cursor 2025-12-03 19 01 39" src="https://github.com/user-attachments/assets/1dfbfd53-73c8-4a6a-a846-78a72c2b1dc3" />


### Test Procedure

- Tested by injecting a simulated API failure that triggers the auto-retry flow
- Verified that only the latest retry message is shown instead of all three
- Confirmed normal message flow is unaffected when no retries occur

### Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

### Pre-flight Checklist

- [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
- [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
- [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
- [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A - Minor UI cleanup that reduces message clutter during API retry sequences.

### Additional Notes

No changeset created as this is a minor UI tweak that most users wouldn't notice.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `combineErrorRetryMessages` utility to consolidate error retry messages in chat UI, reducing clutter by showing only the latest message.
> 
>   - **Behavior**:
>     - Adds `combineErrorRetryMessages` utility in `combineErrorRetryMessages.ts` to consolidate successive `error_retry` messages, showing only the latest.
>     - Integrates `combineErrorRetryMessages` in `ChatView.tsx` to reduce message clutter during API retries.
>   - **Misc**:
>     - No changeset created as this is a minor UI tweak.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 6f8acb9b6a31f807a7896f7e8724f33c971a2278. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->