### PR TITLE
fix(ollama): abort streaming requests when task is cancelled

### DIFF
--- a/.changeset/whole-books-hear.md
+++ b/.changeset/whole-books-hear.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+fix(ollama): abort streaming requests when task is cancelled

--- a/src/core/api/index.ts
+++ b/src/core/api/index.ts
@@ -51,6 +51,7 @@ export interface ApiHandler {
 	createMessage(systemPrompt: string, messages: ClineStorageMessage[], tools?: ClineTool[], useResponseApi?: boolean): ApiStream
 	getModel(): ApiHandlerModel
 	getApiStreamUsage?(): Promise<ApiStreamUsageChunk | undefined>
+	abort?(): void
 }
 
 export interface ApiHandlerModel {

--- a/src/core/api/providers/ollama.ts
+++ b/src/core/api/providers/ollama.ts
@@ -121,4 +121,8 @@ export class OllamaHandler implements ApiHandler {
 			},
 		}
 	}
+
+	abort(): void {
+		this.client?.abort()
+	}
 }

--- a/src/core/task/index.ts
+++ b/src/core/task/index.ts
@@ -2915,6 +2915,7 @@ export class Task {
 					)
 
 					if (this.taskState.abort) {
+						this.api.abort?.()
 						if (!this.taskState.abandoned) {
 							// only need to gracefully abort if this instance isn't abandoned (sometimes openrouter stream hangs, in which case this would affect future instances of cline)
 							await abortStream("user_cancelled")


### PR DESCRIPTION
### Related Issue

**Issue:** #7468

### Description

When a user clicks cancel during an Ollama streaming request, Cline breaks out of the stream loop but never tells the Ollama client to actually abort the HTTP request. The Ollama server continues generating in the background, keeping the GPU busy and blocking subsequent requests until completion.

This PR calls the Ollama SDK's built-in `abort()` method when the user cancels a task, which uses an AbortController internally to close the HTTP connection immediately.

**Changes:**
- Add optional `abort?(): void` method to `ApiHandler` interface
- Implement `abort()` in `OllamaHandler` that calls `this.client?.abort()`
- Call `this.api.abort?.()` in Task when aborting the stream

### Test Procedure

1. Start a chat with Ollama provider
2. Let the model begin generating a response
3. Click the cancel button
4. Observe GPU usage drops immediately (vs continuing to generate in the background)
5. Start a new request - it should proceed immediately without waiting for the previous generation to complete

Verified that non-Ollama providers are unaffected since the `abort()` method is optional.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A - Backend change. The user-visible effect is that GPU usage stops immediately when cancelling an Ollama request.

### Additional Notes

Note: The Ollama server itself has a known limitation where it may continue processing briefly even after the client aborts ([ollama/ollama#2876](https://github.com/ollama/ollama/issues/2876)). However, calling `abort()` immediately closes the HTTP connection, which frees up the client for new requests and reduces wasted GPU cycles.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `abort()` method to `OllamaHandler` and calls it on task cancellation to immediately stop HTTP requests.
> 
>   - **Behavior**:
>     - Calls `abort()` on Ollama client when task is cancelled to stop HTTP request immediately.
>     - Ensures GPU resources are freed up immediately after cancellation.
>   - **Interfaces**:
>     - Adds optional `abort?(): void` method to `ApiHandler` interface.
>   - **Implementations**:
>     - Implements `abort()` in `OllamaHandler` to call `this.client?.abort()`.
>     - Calls `this.api.abort?.()` in `Task` class when aborting the stream.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for aeb0209f2768da5b4c56f10a71a473f4e61b9e37. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->