### PR TITLE
feat: remote config - add vertex provider

### DIFF
--- a/src/core/storage/remote-config/utils.ts
+++ b/src/core/storage/remote-config/utils.ts
@@ -137,6 +137,21 @@ export function transformRemoteConfigToStateShape(remoteConfig: RemoteConfig): P
 		}
 	}
 
+	// Map Vertex provider settings
+	const vertexSettings = remoteConfig.providerSettings?.Vertex
+	if (vertexSettings) {
+		transformed.planModeApiProvider = "vertex"
+		transformed.actModeApiProvider = "vertex"
+		providers.push("vertex")
+
+		if (vertexSettings.vertexProjectId !== undefined) {
+			transformed.vertexProjectId = vertexSettings.vertexProjectId
+		}
+		if (vertexSettings.vertexRegion !== undefined) {
+			transformed.vertexRegion = vertexSettings.vertexRegion
+		}
+	}
+
 	// This line needs to stay here, it is order dependent on the above code checking the configured providers
 	if (providers.length > 0) {
 		transformed.remoteConfiguredProviders = providers


### PR DESCRIPTION
### Related Issue

closes https://linear.app/cline-bot/issue/PF-211/extension-add-vertex-provider

### Description

The PR adds vertex provider to remote config

### Test Procedure

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds Vertex provider support to `transformRemoteConfigToStateShape()` in `utils.ts`, mapping specific settings and updating provider list.
> 
>   - **Behavior**:
>     - Adds Vertex provider support in `transformRemoteConfigToStateShape()` in `utils.ts`.
>     - Maps `vertexProjectId` and `vertexRegion` if defined in `remoteConfig`.
>     - Updates `planModeApiProvider` and `actModeApiProvider` to "vertex" when Vertex settings are present.
>     - Appends "vertex" to `providers` list if Vertex settings exist.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 09eb559872211fcec3e7296d9c09004b0946e314. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->