### PR TITLE
JB Integration Workflow: use pull_request_target to support remote remote PRs

### DIFF
--- a/.github/workflows/trigger-jetbrains-tests.yml
+++ b/.github/workflows/trigger-jetbrains-tests.yml
@@ -65,6 +65,5 @@ jobs:
         run: |
           echo "Triggered IntelliJ Plugin integration test for:"
           echo "  PR #${{ github.event.number }}"
-          echo "  Branch: ${{ github.head_ref }}"
           echo "  Action: ${{ github.event.action }}"
           echo "  SHA: ${{ github.event.pull_request.head.sha }}"


### PR DESCRIPTION
For example in https://github.com/cline/cline/pull/7208 this PR's JB integration test always fails with no private key, this is because GitHub has a security feature that prevents secrets from being shared. So I'm attempting to reconfigure the JB integration workflow so that it can handle it. There are some security concerns, but I think it's safe in this case
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Change GitHub Actions workflow to use `pull_request_target` and sanitize inputs for secure remote PR handling.
> 
>   - **Workflow Change**:
>     - Change event trigger from `pull_request` to `pull_request_target` in `trigger-jetbrains-tests.yml` to access secrets for remote PRs.
>   - **Security**:
>     - Add step to sanitize `RAW_BRANCH_NAME` and `RAW_PR_TITLE` using `jq` to prevent injection attacks.
>   - **Environment Variables**:
>     - Use sanitized `BRANCH_NAME` and `PR_TITLE` in the integration test trigger step.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 076cc55c497df8269066e301216fc489bec4390a. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->