### PR TITLE
docs(hooks): Correct the directory mentioned for global hooks dir

### DIFF
--- a/docs/features/hooks/hook-reference.mdx
+++ b/docs/features/hooks/hook-reference.mdx
@@ -432,6 +432,6 @@ Hooks have a 30 second timeout. As long as your hook completes within this time,
 
 Cline searches for hooks in this order:
 1. Project-specific: `.clinerules/hooks/` in workspace root
-2. User-global: `~/Documents/Cline/Rules/Hooks/`
+2. User-global: `~/Documents/Cline/Hooks/`
 
 Project-specific hooks override global hooks with the same name.

--- a/docs/features/hooks/index.mdx
+++ b/docs/features/hooks/index.mdx
@@ -47,7 +47,7 @@ The interface shows you all available hook types and existing hooks organized by
 Hooks are automatically organized by location in the interface:
 
 **Global Hooks** - Apply to all workspaces:
-- Stored in `~/Documents/Cline/Rules/Hooks/`
+- Stored in `~/Documents/Cline/Hooks/`
 - Perfect for personal coding standards and universal rules
 
 **Project-Specific Hooks** - Apply only to current project:


### PR DESCRIPTION
### Related Issue

**Issue:** n/a

### Description

Fix doc to use the correct path for global hooks dir.  Simple, quick fix.


### Test Procedure

n/a

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [x] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

n/a

### Additional Notes

n/a
