### PR TITLE
Add dynamic MCP registration

### DIFF
--- a/.changeset/thick-carrots-marry.md
+++ b/.changeset/thick-carrots-marry.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": minor
+---
+
+Add dynamic MCP registration

--- a/package.json
+++ b/package.json
@@ -233,6 +233,18 @@
 				"category": "Cline"
 			},
 			{
+				"command": "cline.registerMcpServer",
+				"title": "Register MCP Server",
+				"enablement": "false",
+				"category": "Cline"
+			},
+			{
+				"command": "cline.unregisterMcpServer",
+				"title": "Unregister MCP Server",
+				"enablement": "false",
+				"category": "Cline"
+			},
+			{
 				"command": "cline.reviewComment.reply",
 				"title": "Reply",
 				"category": "Cline",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -517,11 +517,6 @@ ${ctx.cellJson || "{}"}
 
 					const servers = await mcpHub.registerMcpServerDynamically(config)
 
-					HostProvider.window.showMessage({
-						type: ShowMessageType.INFORMATION,
-						message: `MCP server "${config.serverName}" registered successfully`,
-					})
-
 					telemetryService.captureButtonClick("command_registerMcpServer", webview.controller?.task?.ulid)
 
 					return { success: true, servers }
@@ -549,11 +544,6 @@ ${ctx.cellJson || "{}"}
 				}
 
 				const servers = await mcpHub.unregisterMcpServerDynamically(serverName)
-
-				HostProvider.window.showMessage({
-					type: ShowMessageType.INFORMATION,
-					message: `MCP server "${serverName}" unregistered successfully`,
-				})
 
 				telemetryService.captureButtonClick("command_unregisterMcpServer", webview.controller?.task?.ulid)
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -491,6 +491,85 @@ ${ctx.cellJson || "{}"}
 		}),
 	)
 
+	// Register the registerMcpServer command handler
+	// This allows other VSCode extensions to dynamically register MCP servers at runtime
+	context.subscriptions.push(
+		vscode.commands.registerCommand(
+			commands.RegisterMcpServer,
+			async (config: {
+				serverName: string
+				command?: string
+				args?: string[]
+				env?: Record<string, string>
+				cwd?: string
+				url?: string
+				headers?: Record<string, string>
+				transportType?: "stdio" | "sse" | "streamableHttp"
+				disabled?: boolean
+				autoApprove?: string[]
+				timeout?: number
+			}) => {
+				try {
+					const mcpHub = webview.controller.mcpHub
+					if (!mcpHub) {
+						throw new Error("MCP Hub is not initialized")
+					}
+
+					const servers = await mcpHub.registerMcpServerDynamically(config)
+
+					HostProvider.window.showMessage({
+						type: ShowMessageType.INFORMATION,
+						message: `MCP server "${config.serverName}" registered successfully`,
+					})
+
+					telemetryService.captureButtonClick("command_registerMcpServer", webview.controller?.task?.ulid)
+
+					return { success: true, servers }
+				} catch (error) {
+					const errorMessage = error instanceof Error ? error.message : String(error)
+					HostProvider.window.showMessage({
+						type: ShowMessageType.ERROR,
+						message: `Failed to register MCP server: ${errorMessage}`,
+					})
+					telemetryService.captureButtonClick("command_registerMcpServer_failed", webview.controller?.task?.ulid)
+					return { success: false, error: errorMessage }
+				}
+			},
+		),
+	)
+
+	// Register the unregisterMcpServer command handler
+	// This allows other VSCode extensions to clean up their dynamically registered MCP servers
+	context.subscriptions.push(
+		vscode.commands.registerCommand(commands.UnregisterMcpServer, async (serverName: string) => {
+			try {
+				const mcpHub = webview.controller.mcpHub
+				if (!mcpHub) {
+					throw new Error("MCP Hub is not initialized")
+				}
+
+				const servers = await mcpHub.unregisterMcpServerDynamically(serverName)
+
+				HostProvider.window.showMessage({
+					type: ShowMessageType.INFORMATION,
+					message: `MCP server "${serverName}" unregistered successfully`,
+				})
+
+				telemetryService.captureButtonClick("command_unregisterMcpServer", webview.controller?.task?.ulid)
+
+				return { success: true, servers }
+			} catch (error) {
+				const errorMessage = error instanceof Error ? error.message : String(error)
+				HostProvider.window.showMessage({
+					type: ShowMessageType.ERROR,
+					message: `Failed to unregister MCP server: ${errorMessage}`,
+				})
+				telemetryService.captureButtonClick("command_unregisterMcpServer_failed", webview.controller?.task?.ulid)
+				return { success: false, error: errorMessage }
+			}
+		}),
+	)
+
 	// Register the generateGitCommitMessage command handler
 	context.subscriptions.push(
 		vscode.commands.registerCommand(commands.GenerateCommit, async (scm) => {

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -29,6 +29,8 @@ const ClineCommands = {
 	JupyterGenerateCell: prefix + ".jupyterGenerateCell",
 	JupyterExplainCell: prefix + ".jupyterExplainCell",
 	JupyterImproveCell: prefix + ".jupyterImproveCell",
+	RegisterMcpServer: prefix + ".registerMcpServer",
+	UnregisterMcpServer: prefix + ".unregisterMcpServer"
 }
 
 /**

--- a/src/services/mcp/McpHub.ts
+++ b/src/services/mcp/McpHub.ts
@@ -1771,7 +1771,7 @@ export class McpHub {
 			}
 
 			// Check if server already exists
-			if (settings.mcpServers[serverName]) {
+			if (settings.mcpServers[serverName] || this.transientServers.has(serverName)) {
 				throw new Error(`An MCP server with the name "${serverName}" already exists`)
 			}
 


### PR DESCRIPTION
This change exposes two APIs via VSCode commands interface, that allow Cline to mimic the behavior the VSCode LM API registerMcpServerDefinitionProvider:

https://code.visualstudio.com/api/references/vscode-api#lm

Copilot already supports this, VSCode extensions that implement MCP servers can register them dynamically, no need to change any JSON file, the MCP servers can be activated and deactivated at runtime according to the extension logic.

The current Cline setup makes the dynamic registration cumbersome, the only possible workaround is that the extension changes the Cline MCP JSON file and forces a VSCode window reload, and morever a STDIO proxy is required to handle the whole communication.

WIth the dynamic registration, the extension simply starts a localhost HTTP server on a random port and passes the HTTP endpoint to Cline, making it active only after the extension has finished its bootstrap. No JSON change, the registration is valid only for that single session, it's not persisted in the Cline JSON file, no need of a STDIO proxy.

The Cline register/unregister commands are not available via UI, they're accessible only via the executeCommand VSCode API.

The MCPHub code has no tests support, so no tests have been added here.

Feature Request: https://github.com/cline/cline/discussions/7935

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add dynamic MCP server registration and unregistration via VSCode commands, enabling runtime management without JSON file changes.
> 
>   - **Behavior**:
>     - Adds `cline.registerMcpServer` and `cline.unregisterMcpServer` commands in `package.json` for dynamic MCP server management.
>     - Implements command handlers in `activate()` in `extension.ts` to register/unregister MCP servers dynamically.
>     - MCP servers can be activated/deactivated at runtime without JSON file changes.
>   - **McpHub**:
>     - Adds `registerMcpServerDynamically()` and `unregisterMcpServerDynamically()` in `McpHub.ts` for transient server management.
>     - Transient servers are not persisted to the settings file and are valid only for the session.
>   - **Misc**:
>     - Updates `ClineCommands` in `registry.ts` to include new MCP server commands.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 7df4f4b095779deae76387a9fd96489d9d84aa33. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->