### PR TITLE
display completion messages in processStateUpdate

### DIFF
--- a/cli/pkg/cli/task/manager.go
+++ b/cli/pkg/cli/task/manager.go
@@ -1007,6 +1007,14 @@ func (m *Manager) processStateUpdate(stateUpdate *cline.State, coordinator *Stre
 				}
 			}
 
+		case msg.Say == string(types.SayTypeCompletionResult):
+			msgKey := fmt.Sprintf("%d", msg.Timestamp)
+			if !msg.Partial && !coordinator.IsProcessedInCurrentTurn(msgKey) {
+				fmt.Println()
+				m.displayMessage(msg, false, false, i)
+				coordinator.MarkProcessedInCurrentTurn(msgKey)
+			}
+
 		case msg.Ask == string(types.AskTypeCommandOutput):
 			msgKey := fmt.Sprintf("%d", msg.Timestamp)
 			if !coordinator.IsProcessedInCurrentTurn(msgKey) {


### PR DESCRIPTION
- **display completion messages in processStateUpdate**

### Related Issue

**Issue:** CLINE-84, ENG-1392

### Description

In oneshot mode, the task completion message was not being displayed because we weren't handling that case in the processStateUpdateFunction. This PR adds that functionality so that user can now see the task completion message in cline oneshot mode.
<!-- 
Help reviewers understand your changes by making this PR readable and well-organized:

- What problem does this PR solve?
- Why were these changes introduced and what purpose do they serve?
- For larger changes, provide context about your approach and reasoning

Small PRs may need minimal description, but larger changes benefit from explaining where you're coming from. Much of this context can be in the linked issue above, so feel free to reference it rather than repeating everything here.
-->

### Test Procedure

1. `cli/bin/cline -o "how is your cat"` (verified that the completion message is displayed after task completion)
2. `cli/bin/cline t o <previous_task_id>`
3. `cli/bin/cline t v` (verified that the task has the same content as the content I saw from step 1)
<!-- 
Please walk us through your testing approach and thought process. This helps reviewers understand that you've thoroughly considered the impact of your changes:

- How did you test this change?
- What could potentially break and how did you verify it doesn't?
- What existing functionality might be affected and how did you check it still works?
- Why are you confident this is ready for merge?

We're not looking for exhaustive documentation - just evidence that you've thought through the implications of your changes and tested accordingly.
-->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [X] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [X] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [X] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [X] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [X] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots
left pane is what i see with oneshot mode, right pane is what i see with `cline t v`
<img width="1916" height="732" alt="image" src="https://github.com/user-attachments/assets/d7839a94-e221-4472-9d13-fbf557da6be1" />

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds handling for task completion messages in oneshot mode in `processStateUpdate` in `manager.go`.
> 
>   - **Behavior**:
>     - Adds handling for `SayTypeCompletionResult` in `processStateUpdate` in `manager.go` to display task completion messages in oneshot mode.
>   - **Testing**:
>     - Verified completion message display with `cli/bin/cline -o "how is your cat"`.
>     - Verified task content consistency with `cli/bin/cline t v`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 0f8e5a2bdd20b4675fde32c0d50a913a0768ef4b. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->