### PR TITLE
fix(hooks): Want `TaskCancel` to trigger properly

### DIFF
--- a/src/core/task/index.ts
+++ b/src/core/task/index.ts
@@ -99,6 +99,7 @@ import { isInTestMode } from "../../services/test/TestMode"
 import { ensureLocalClineDirExists } from "../context/instructions/user-instructions/rule-helpers"
 import { refreshWorkflowToggles } from "../context/instructions/user-instructions/workflows"
 import { Controller } from "../controller"
+import { executeHook } from "../hooks/hook-executor"
 import { StateManager } from "../storage/StateManager"
 import { FocusChainManager } from "./focus-chain"
 import { MessageStateHandler } from "./message-state"
@@ -859,7 +860,6 @@ export class Task {
 			return {}
 		}
 
-		const { executeHook } = await import("../hooks/hook-executor")
 		const { extractUserPromptFromContent } = await import("./utils/extractUserPromptFromContent")
 
 		// Extract clean user prompt from content, stripping system wrappers and metadata
@@ -942,8 +942,6 @@ export class Task {
 		// Add TaskStart hook context to the conversation if provided
 		const hooksEnabled = this.stateManager.getGlobalSettingsKey("hooksEnabled")
 		if (hooksEnabled) {
-			const { executeHook } = await import("../hooks/hook-executor")
-
 			const taskStartResult = await executeHook({
 				hookName: "TaskStart",
 				hookInput: {
@@ -1092,8 +1090,6 @@ export class Task {
 		// Run TaskResume hook AFTER user clicks resume button
 		const hooksEnabled = this.stateManager.getGlobalSettingsKey("hooksEnabled")
 		if (hooksEnabled) {
-			const { executeHook } = await import("../hooks/hook-executor")
-
 			const clineMessages = this.messageStateHandler.getClineMessages()
 			const taskResumeResult = await executeHook({
 				hookName: "TaskResume",
@@ -1420,6 +1416,25 @@ export class Task {
 			const hooksEnabled = this.stateManager.getGlobalSettingsKey("hooksEnabled")
 			if (hooksEnabled && shouldRunTaskCancelHook) {
 				try {
+					await executeHook({
+						hookName: "TaskCancel",
+						hookInput: {
+							taskCancel: {
+								taskMetadata: {
+									taskId: this.taskId,
+									ulid: this.ulid,
+									completionStatus: this.taskState.abandoned ? "abandoned" : "cancelled",
+								},
+							},
+						},
+						isCancellable: false, // TaskCancel is NOT cancellable
+						say: this.say.bind(this),
+						// No setActiveHookExecution or clearActiveHookExecution for non-cancellable hooks
+						messageStateHandler: this.messageStateHandler,
+						taskId: this.taskId,
+						hooksEnabled,
+					})
+
 					// TaskCancel completed successfully
 					// Present resume button after successful TaskCancel hook
 					const lastClineMessage = this.messageStateHandler


### PR DESCRIPTION
### Related Issue

**Issue:** n/a

### Description

I noticed that the `TaskCancel` hook hasn't been getting triggered recently in the `main` branch and in the published extension (and in development branches stemmed from `main`, etc.).

#### Investigating the Cause
At some point a couple weeks ago there was a merge that clobbered the logic that triggers `TaskCancel` (likely due to two complex branches getting merged into `main` around the same time).

`git bisect` pointed to `abe4721a` as the first commit where the functionality is missing, and that gives me a good understanding of what needs to happen to re-enable `TaskCancel` hooks.  This PR does that.


### Test Procedure

* Prior to this change set, trying to run a `TaskCancel` hooks doesn't work.
* With this change set, running a `TaskCancel` hook does work.  I verified this by running a task with hooks enabled and a `TaskCancel` hook configured in the extension and then observing that `TaskCancel` was triggered successfully.


### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

n/a

### Additional Notes

n/a


<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes `TaskCancel` hook not triggering in `Task` class by ensuring `executeHook` is correctly imported and used in `abortTask()`.
> 
>   - **Behavior**:
>     - Fixes `TaskCancel` hook not triggering in `Task` class in `index.ts`.
>     - Ensures `executeHook` is imported and used correctly in `abortTask()`.
>     - `TaskCancel` hook now executes when a task is aborted, handling task cancellations properly.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for fac2b7bdb800a274413ab564661506103a152389. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->