### PR TITLE
Shorten task completion message - next gen models

### DIFF
--- a/src/core/prompts/system-prompt/tools/attempt_completion.ts
+++ b/src/core/prompts/system-prompt/tools/attempt_completion.ts
@@ -77,12 +77,12 @@ const NATIVE_NEXT_GEN: ClineToolSpec = {
 	id,
 	name: "attempt_completion",
 	description:
-		"Once you've completed the user's task, use this tool to present the final result to the user, including a brief and very short (1-2 paragraph) summary of the task and what was done to resolve it. Provide the basics, hitting the highlights, but do delve into the specifics. You should only call this tool when you have completed all tasks in the task_progress list, and completed all changes that are necessary to satisfy the user's request. You should not provide the contents of the task_progress list in the result parameter, it must be included in the task_progress parameter.",
+		"Once you've completed the user's task, use this tool to present the final result to the user, if applicable. Otherwise, just a final reply. You should only call this tool when you have completed all tasks in the task_progress list, and completed all changes that are necessary to satisfy the user's request. You should not provide the contents of the task_progress list in the result parameter, it must be included in the task_progress parameter.",
 	parameters: [
 		{
 			name: "result",
 			required: true,
-			instruction: "A clear, brief and very short (1-2 paragraph) summary of the final result of the task.",
+			instruction: "A final message, possibly even just a word or two. Keep it snappy.",
 		},
 		{
 			name: "command",


### PR DESCRIPTION


### Description

Prompt next gen models to only return short task completion messages, not to summarize the whole task.

### Test Procedure

Test with GPT and Sonnet

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [ ] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Shortens task completion messages in `NATIVE_NEXT_GEN` variant of `attempt_completion.ts` for brevity and clarity.
> 
>   - **Behavior**:
>     - Updates `NATIVE_NEXT_GEN` variant in `attempt_completion.ts` to shorten task completion messages.
>     - Changes `result` parameter instruction to "A final message, possibly even just a word or two. Keep it snappy."
>     - Modifies `description` to emphasize presenting a final result or reply without summarizing the task.
>   - **Misc**:
>     - No changes to other variants like `generic` or `GPT_5`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 1595ad81a6e0c4121d00a70b2d95ab2db43a9ffa. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->