### PR TITLE
Clean up API request/thinkingUI implementation

### DIFF
--- a/webview-ui/src/components/chat/ChatView.tsx
+++ b/webview-ui/src/components/chat/ChatView.tsx
@@ -21,6 +21,7 @@ import {
 	ChatLayout,
 	convertHtmlToMarkdown,
 	filterVisibleMessages,
+	groupLowStakesTools,
 	groupMessages,
 	InputSection,
 	MessagesArea,
@@ -324,7 +325,7 @@ const ChatView = ({ isHidden, showAnnouncement, hideAnnouncement, showHistoryVie
 	}, [modifiedMessages, currentFocusChainChecklist])
 
 	const groupedMessages = useMemo(() => {
-		return groupMessages(visibleMessages)
+		return groupLowStakesTools(groupMessages(visibleMessages))
 	}, [visibleMessages])
 
 	// Use scroll behavior hook

--- a/webview-ui/src/components/chat/chat-view/components/layout/MessagesArea.tsx
+++ b/webview-ui/src/components/chat/chat-view/components/layout/MessagesArea.tsx
@@ -124,6 +124,7 @@ export const MessagesArea: React.FC<MessagesAreaProps> = ({
 					style={{
 						flexGrow: 1,
 						overflowY: "scroll", // always show scrollbar
+						overflowAnchor: "none", // prevent scroll jump when content expands
 					}}
 				/>
 			</div>

--- a/webview-ui/src/components/chat/chat-view/components/messages/MessageRenderer.tsx
+++ b/webview-ui/src/components/chat/chat-view/components/messages/MessageRenderer.tsx
@@ -1,9 +1,244 @@
-import { ClineMessage } from "@shared/ExtensionMessage"
-import React from "react"
+import { ClineMessage, ClineSayTool } from "@shared/ExtensionMessage"
+import { StringRequest } from "@shared/proto/cline/common"
+import React, { memo, useCallback, useMemo, useState } from "react"
 import BrowserSessionRow from "@/components/chat/BrowserSessionRow"
 import ChatRow from "@/components/chat/ChatRow"
+import { cleanPathPrefix } from "@/components/common/CodeAccordian"
+import { useExtensionState } from "@/context/ExtensionStateContext"
 import { cn } from "@/lib/utils"
+import { FileServiceClient } from "@/services/grpc-client"
 import { MessageHandlers } from "../../types/chatTypes"
+import {
+	findReasoningForApiReq,
+	isApiReqAbsorbable,
+	isLowStakesTool,
+	isTextMessagePendingToolCall,
+	isToolGroup,
+} from "../../utils/messageUtils"
+
+/**
+ * Get display info for a tool message
+ */
+function getToolDisplayInfo(message: ClineMessage): { icon: string; path: string; label: string } | null {
+	if (message.say !== "tool" && message.ask !== "tool") return null
+	try {
+		const tool = JSON.parse(message.text || "{}") as ClineSayTool
+		switch (tool.tool) {
+			case "readFile":
+				return { icon: "file-code", path: tool.path || "", label: "read" }
+			case "listFilesTopLevel":
+				return { icon: "folder-opened", path: tool.path || "", label: "listed" }
+			case "listFilesRecursive":
+				return { icon: "folder-opened", path: tool.path || "", label: "listed recursively" }
+			case "listCodeDefinitionNames":
+				return { icon: "symbol-class", path: tool.path || "", label: "definitions" }
+			case "searchFiles":
+				return { icon: "search", path: tool.path || "", label: `search: ${tool.regex}` }
+			default:
+				return null
+		}
+	} catch {
+		return null
+	}
+}
+
+/**
+ * Get summary label for a tool group
+ */
+function getToolGroupSummary(messages: ClineMessage[]): string {
+	const toolTypes: string[] = []
+	for (const m of messages) {
+		if (!isLowStakesTool(m)) continue
+		try {
+			const tool = JSON.parse(m.text || "{}") as ClineSayTool
+			if (tool?.tool) toolTypes.push(tool.tool)
+		} catch {
+			// ignore parse errors
+		}
+	}
+
+	const readCount = toolTypes.filter((t) => t === "readFile").length
+	const listCount = toolTypes.filter((t) => t === "listFilesTopLevel" || t === "listFilesRecursive").length
+	const searchCount = toolTypes.filter((t) => t === "searchFiles").length
+	const defCount = toolTypes.filter((t) => t === "listCodeDefinitionNames").length
+
+	const parts: string[] = []
+	if (readCount > 0) parts.push(`${readCount} file${readCount > 1 ? "s" : ""}`)
+	if (listCount > 0) parts.push(`${listCount} folder${listCount > 1 ? "s" : ""}`)
+	if (searchCount > 0) parts.push(`${searchCount} search${searchCount > 1 ? "es" : ""}`)
+	if (defCount > 0) parts.push(`${defCount} definition${defCount > 1 ? "s" : ""}`)
+
+	if (parts.length === 0) return "Files"
+	return parts.join(", ")
+}
+
+interface ToolGroupRendererProps {
+	messages: ClineMessage[]
+	expandedRows: Record<number, boolean>
+	onToggleExpand: (ts: number) => void
+	index: number
+	groupedMessages: (ClineMessage | ClineMessage[])[]
+	allMessages: ClineMessage[]
+}
+
+/**
+ * Check if a tool has expandable content (folders, search results, definitions)
+ */
+function hasExpandableContent(tool: ClineSayTool): boolean {
+	return ["listFilesTopLevel", "listFilesRecursive", "listCodeDefinitionNames", "searchFiles"].includes(tool.tool)
+}
+
+/**
+ * Renders a collapsible group of low-stakes tool calls
+ */
+const ToolGroupRenderer = memo(
+	({ messages, expandedRows, onToggleExpand, index, groupedMessages, allMessages }: ToolGroupRendererProps) => {
+		const groupTs = messages[0]?.ts || 0
+		const isExpanded = expandedRows[groupTs] ?? true // Default expanded
+		const isLast = index === groupedMessages.length - 1
+
+		// Track which individual tool items are expanded (for folders, search, etc.)
+		const [expandedItems, setExpandedItems] = useState<Record<number, boolean>>({})
+
+		const handleToggle = useCallback(() => {
+			onToggleExpand(groupTs)
+		}, [onToggleExpand, groupTs])
+
+		const handleOpenFile = useCallback((filePath: string) => {
+			FileServiceClient.openFileRelativePath(StringRequest.create({ value: filePath })).catch((err) =>
+				console.error("Failed to open file:", err),
+			)
+		}, [])
+
+		const handleItemToggle = useCallback((ts: number) => {
+			setExpandedItems((prev) => ({ ...prev, [ts]: !prev[ts] }))
+		}, [])
+
+		const summary = useMemo(() => getToolGroupSummary(messages), [messages])
+
+		// Build tool items with associated reasoning (reasoning that comes BEFORE a tool)
+		const toolsWithReasoning = useMemo(() => {
+			const result: { tool: ClineMessage; parsedTool: ClineSayTool; reasoning?: string }[] = []
+			let pendingReasoning: string[] = []
+
+			for (const msg of messages) {
+				if (msg.say === "reasoning" && msg.text) {
+					pendingReasoning.push(msg.text)
+				} else if (isLowStakesTool(msg)) {
+					let parsedTool: ClineSayTool
+					try {
+						parsedTool = JSON.parse(msg.text || "{}") as ClineSayTool
+					} catch {
+						parsedTool = { tool: "" } as unknown as ClineSayTool
+					}
+
+					result.push({
+						tool: msg,
+						parsedTool,
+						reasoning: pendingReasoning.length > 0 ? pendingReasoning.join("\n\n") : undefined,
+					})
+					pendingReasoning = []
+				}
+			}
+			return result
+		}, [messages])
+
+		return (
+			<div className={cn("px-4 py-2", { "pb-4": isLast })} style={{ color: "var(--vscode-descriptionForeground)" }}>
+				{/* Collapsible header */}
+				<div
+					onClick={handleToggle}
+					style={{
+						display: "flex",
+						alignItems: "center",
+						gap: "6px",
+						cursor: "pointer",
+						userSelect: "none",
+						fontSize: "13px",
+					}}>
+					<span
+						className={`codicon codicon-chevron-${isExpanded ? "down" : "right"}`}
+						style={{ fontSize: "12px", opacity: 0.7 }}
+					/>
+					<span style={{ opacity: 0.9, flex: 1 }}>{summary}</span>
+				</div>
+
+				{/* Expanded content - files/folders with reasoning in tooltip */}
+				{isExpanded && (
+					<div style={{ marginLeft: "18px", marginTop: "2px" }}>
+						{toolsWithReasoning.map(({ tool, parsedTool, reasoning }) => {
+							const info = getToolDisplayInfo(tool)
+							if (!info) return null
+							const isExpandable = hasExpandableContent(parsedTool)
+							const isItemExpanded = expandedItems[tool.ts] ?? false
+							const content = parsedTool.content || null
+
+							return (
+								<div key={tool.ts}>
+									<div
+										onClick={() => {
+											if (isExpandable) {
+												handleItemToggle(tool.ts)
+											} else {
+												handleOpenFile(info.path)
+											}
+										}}
+										{...(reasoning ? { title: reasoning } : {})}
+										onMouseEnter={(e) => {
+											e.currentTarget.style.color = "var(--vscode-textLink-foreground)"
+										}}
+										onMouseLeave={(e) => {
+											e.currentTarget.style.color = "var(--vscode-descriptionForeground)"
+										}}
+										style={{
+											display: "flex",
+											alignItems: "center",
+											gap: "6px",
+											padding: "2px 0",
+											fontSize: "12px",
+											cursor: "pointer",
+											fontFamily: "var(--vscode-editor-font-family)",
+										}}>
+										<span
+											className={`codicon codicon-${info.icon}`}
+											style={{ fontSize: "12px", opacity: 0.7 }}
+										/>
+										<span
+											style={{
+												flex: 1,
+												whiteSpace: "nowrap",
+												overflow: "hidden",
+												textOverflow: "ellipsis",
+												direction: "rtl",
+												textAlign: "left",
+											}}>
+											{cleanPathPrefix(info.path) + "\u200E"}
+										</span>
+									</div>
+									{/* Expanded content for folders/search/definitions - raw text */}
+									{isExpandable && isItemExpanded && content && (
+										<pre
+											style={{
+												marginLeft: "24px",
+												marginTop: "4px",
+												marginBottom: "4px",
+												fontSize: "11px",
+												opacity: 0.8,
+												whiteSpace: "pre-wrap",
+												wordBreak: "break-word",
+											}}>
+											{content}
+										</pre>
+									)}
+								</div>
+							)
+						})}
+					</div>
+				)}
+			</div>
+		)
+	},
+)
 
 interface MessageRendererProps {
 	index: number
@@ -34,6 +269,40 @@ export const MessageRenderer: React.FC<MessageRendererProps> = ({
 	inputValue,
 	messageHandlers,
 }) => {
+	const { mode } = useExtensionState()
+
+	// Get reasoning content and response status for api_req_started messages
+	const reasoningData = useMemo(() => {
+		if (!Array.isArray(messageOrGroup) && messageOrGroup.say === "api_req_started") {
+			// Use the same message source-of-truth that `groupedMessages` is derived from.
+			return findReasoningForApiReq(messageOrGroup.ts, modifiedMessages)
+		}
+		return { reasoning: undefined, responseStarted: false }
+	}, [messageOrGroup, modifiedMessages])
+
+	// Check if a text message is waiting for tool call completion
+	const isRequestInProgress = useMemo(() => {
+		if (!Array.isArray(messageOrGroup) && messageOrGroup.say === "text") {
+			// Use modifiedMessages so this stays consistent with the rendered list.
+			return isTextMessagePendingToolCall(messageOrGroup.ts, modifiedMessages)
+		}
+		return false
+	}, [messageOrGroup, modifiedMessages])
+
+	// Tool group (low-stakes tools grouped together)
+	if (isToolGroup(messageOrGroup)) {
+		return (
+			<ToolGroupRenderer
+				allMessages={modifiedMessages}
+				expandedRows={expandedRows}
+				groupedMessages={groupedMessages}
+				index={index}
+				messages={messageOrGroup}
+				onToggleExpand={onToggleExpand}
+			/>
+		)
+	}
+
 	// Browser session group
 	if (Array.isArray(messageOrGroup)) {
 		return (
@@ -48,6 +317,13 @@ export const MessageRenderer: React.FC<MessageRendererProps> = ({
 				onToggleExpand={onToggleExpand}
 			/>
 		)
+	}
+
+	// Deterministic flash fix:
+	// If this api_req_started is meant to be absorbed into a low-stakes tool group,
+	// never render it as a standalone row.
+	if (messageOrGroup.say === "api_req_started" && isApiReqAbsorbable(messageOrGroup.ts, modifiedMessages)) {
+		return null
 	}
 
 	// Determine if this is the last message for status display purposes
@@ -67,13 +343,17 @@ export const MessageRenderer: React.FC<MessageRendererProps> = ({
 				inputValue={inputValue}
 				isExpanded={expandedRows[messageOrGroup.ts] || false}
 				isLast={isLast}
+				isRequestInProgress={isRequestInProgress}
 				key={messageOrGroup.ts}
 				lastModifiedMessage={modifiedMessages.at(-1)}
 				message={messageOrGroup}
+				mode={mode}
 				onCancelCommand={() => messageHandlers.executeButtonAction("cancel")}
 				onHeightChange={onHeightChange}
 				onSetQuote={onSetQuote}
 				onToggleExpand={onToggleExpand}
+				reasoningContent={reasoningData.reasoning}
+				responseStarted={reasoningData.responseStarted}
 				sendMessageFromChatRow={messageHandlers.handleSendMessage}
 			/>
 		</div>

--- a/webview-ui/src/components/chat/chat-view/hooks/useScrollBehavior.ts
+++ b/webview-ui/src/components/chat/chat-view/hooks/useScrollBehavior.ts
@@ -241,30 +241,22 @@ export function useScrollBehavior(
 				disableAutoScrollRef.current = true
 			}
 
+			// Only scroll on collapse, never on expand - expanding should stay in place
 			if (isCollapsing && isAtBottom) {
 				const timer = setTimeout(() => {
 					scrollToBottomAuto()
 				}, 0)
 				return () => clearTimeout(timer)
-			} else if (isLast || isSecondToLast) {
-				if (isCollapsing) {
-					if (isSecondToLast && !isLastCollapsedApiReq) {
-						return
-					}
-					const timer = setTimeout(() => {
-						scrollToBottomAuto()
-					}, 0)
-					return () => clearTimeout(timer)
-				} else {
-					const timer = setTimeout(() => {
-						virtuosoRef.current?.scrollToIndex({
-							index: groupedMessages.length - (isLast ? 1 : 2),
-							align: "start",
-						})
-					}, 0)
-					return () => clearTimeout(timer)
+			} else if (isCollapsing && (isLast || isSecondToLast)) {
+				if (isSecondToLast && !isLastCollapsedApiReq) {
+					return
 				}
+				const timer = setTimeout(() => {
+					scrollToBottomAuto()
+				}, 0)
+				return () => clearTimeout(timer)
 			}
+			// When expanding, don't scroll - let the element expand in place
 		},
 		[groupedMessages, expandedRows, scrollToBottomAuto, isAtBottom],
 	)

--- a/webview-ui/src/components/common/MarkdownBlock.tsx
+++ b/webview-ui/src/components/common/MarkdownBlock.tsx
@@ -44,6 +44,7 @@ const ActModeHighlight: React.FC = () => {
 interface MarkdownBlockProps {
 	markdown?: string
 	compact?: boolean
+	showCursor?: boolean
 }
 
 /**
@@ -206,7 +207,7 @@ const remarkPreventBoldFilenames = () => {
 	}
 }
 
-const StyledMarkdown = styled.div<{ compact?: boolean }>`
+const StyledMarkdown = styled.div<{ compact?: boolean; $showCursor?: boolean }>`
 	pre {
 		background-color: ${CODE_BLOCK_BG_COLOR};
 		border-radius: 3px;
@@ -304,6 +305,26 @@ const StyledMarkdown = styled.div<{ compact?: boolean }>`
 		margin: 4px 0; /* or 0 if you want them very tight */
 	}
 
+	/* Blinking cursor at end of content */
+	${(props) =>
+		props.$showCursor &&
+		`
+		& > :last-child::after {
+			content: '';
+			display: inline-block;
+			width: 2px;
+			height: 1em;
+			background-color: currentColor;
+			margin-left: 2px;
+			vertical-align: text-bottom;
+			animation: cursorBlink 1s ease-in-out infinite;
+		}
+
+		@keyframes cursorBlink {
+			0%, 100% { opacity: 1; }
+			50% { opacity: 0; }
+		}
+	`}
 `
 
 const PreWithCopyButton = ({ children, ...preProps }: React.HTMLAttributes<HTMLPreElement>) => {
@@ -364,7 +385,7 @@ const remarkFilePathDetection = () => {
 	}
 }
 
-const MarkdownBlock = memo(({ markdown, compact }: MarkdownBlockProps) => {
+const MarkdownBlock = memo(({ markdown, compact, showCursor }: MarkdownBlockProps) => {
 	const [reactContent, setMarkdown] = useRemark({
 		remarkPlugins: [
 			remarkPreventBoldFilenames,
@@ -461,7 +482,7 @@ const MarkdownBlock = memo(({ markdown, compact }: MarkdownBlockProps) => {
 
 	return (
 		<div>
-			<StyledMarkdown className="ph-no-capture" compact={compact}>
+			<StyledMarkdown $showCursor={showCursor} className="ph-no-capture" compact={compact}>
 				{reactContent}
 			</StyledMarkdown>
 		</div>


### PR DESCRIPTION
### Related Issue

N/A

### Description


https://github.com/user-attachments/assets/5e1532d9-5089-42dc-b5bf-ce5d7d8d0f25


Improves thinking/reasoning UI by displaying extended thinking content inline during API requests with animated state transitions. Moves API cost display from request rows to checkpoint lines to reduce clutter.

**Key changes:**
- New `LoadingStatusLine` component with pulse/shimmer animations for request states
- Inline reasoning text with blinking cursor during thinking state
- Hide completed API requests (cost moves to checkpoint line)
- New utility functions: `findReasoningForApiReq()`, `findApiReqInfoForCheckpoint()`, `hasResponseStarted()`
- `ApiReqState` union type for explicit request lifecycle state
- Styled-components for animations and modal

### Test Procedure

- Ran full test suite: 430/430 passing
- Manual testing of API request flow: pre-thinking → thinking stream → final
- Verified cost badge appears on checkpoint line after request completes
- Verified reasoning text streams with blinking cursor
- Tested error state display

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [x] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- Add before/after screenshots of thinking UI -->

### Additional Notes

Files changed:
- `ChatRow.tsx` - Inline thinking display with styled-components
- `LoadingStatusLine.tsx` - New state-based loading indicator
- `CheckmarkControl.tsx` - Added cost badge prop
- `messageUtils.ts` - New reasoning/API info utilities
- `MessageRenderer.tsx` - Props for reasoning state
- `MarkdownBlock.tsx` - Cursor support

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Enhances API request UI with animations, inline reasoning display, and moves cost display to checkpoints.
> 
>   - **Behavior**:
>     - Adds `LoadingStatusLine` component with animations for API request states in `LoadingStatusLine.tsx`.
>     - Displays reasoning text inline with a blinking cursor during the thinking state in `ChatRow.tsx`.
>     - Moves API cost display from request rows to checkpoint lines in `CheckmarkControl.tsx`.
>   - **Utilities**:
>     - Adds `findReasoningForApiReq()`, `findApiReqInfoForCheckpoint()`, `hasResponseStarted()` in `messageUtils.ts`.
>     - Introduces `ApiReqState` type for request lifecycle states in `ChatRow.tsx`.
>   - **UI Components**:
>     - Updates `ChatRow.tsx` to handle new thinking and reasoning display logic.
>     - Modifies `MarkdownBlock.tsx` to support cursor display.
>     - Enhances `CheckmarkControl.tsx` to show cost and request details inline.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for aed8106dbf2366a8a3c1a98b6582dac5a8f94d55. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->