### PR TITLE
broken link fixed

### DIFF
--- a/docs/getting-started/installing-cline.mdx
+++ b/docs/getting-started/installing-cline.mdx
@@ -10,7 +10,7 @@ description: "Get Cline up and running in your favorite IDE with these simple in
 ## Before You Begin
 
 <CardGroup cols={1}>
-  <Card title="Create Your Account" icon="user-plus" href="https://authkit.cline.bot/">
+  <Card title="Create Your Account" icon="user-plus" href="https://app.cline.bot/login">
     Sign up for a **free Cline account** to get:
     - Access to multiple AI models including stealth models
     - Seamless setup without managing API keys


### PR DESCRIPTION
just a broken link in the very beginning of the docs 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix broken link in `installing-cline.mdx` documentation for account creation.
> 
>   - **Docs**:
>     - Fix broken link in `installing-cline.mdx` from `https://app.cline.bot/signup` to `https://authkit.cline.bot/` for account creation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for f32fcb59dbd13bce2c4313b8009009ddf09574f2. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->