### PR TITLE
fix: make initial checkpoint commit non-blocking but block unsafe tools [#AI-26]

### DIFF
--- a/.changeset/fix-checkpoint-blocking.md
+++ b/.changeset/fix-checkpoint-blocking.md
@@ -1,0 +1,6 @@
+---
+"claude-dev": patch
+---
+
+Make initial checkpoint commit non-blocking while ensuring safe execution of tools. This improves responsiveness when starting tasks in large repositories by allowing read-only tools to run in parallel with the initial git commit.
+

--- a/src/shared/tools.ts
+++ b/src/shared/tools.ts
@@ -36,3 +36,17 @@ export enum ClineDefaultTool {
 // Array of all tool names for compatibility
 // Automatically generated from the enum values
 export const toolUseNames = Object.values(ClineDefaultTool) as ClineDefaultTool[]
+
+// Tools that are safe to run in parallel with the initial checkpoint commit
+// These are tools that do not modify the workspace state
+export const READ_ONLY_TOOLS = [
+	ClineDefaultTool.LIST_FILES,
+	ClineDefaultTool.FILE_READ,
+	ClineDefaultTool.SEARCH,
+	ClineDefaultTool.LIST_CODE_DEF,
+	ClineDefaultTool.BROWSER,
+	ClineDefaultTool.ASK,
+	ClineDefaultTool.ATTEMPT,
+	ClineDefaultTool.WEB_SEARCH,
+	ClineDefaultTool.WEB_FETCH,
+] as const


### PR DESCRIPTION
### Related Issue

Closes [AI-26] Make first checkpoint commits non-blocking

### Description

This PR addresses a responsiveness issue where the initial checkpoint `git commit` would block the extension when starting a new task in large repositories (10GB+).

**The Solution:**
The initial checkpoint commit is now triggered asynchronously, allowing the first API request to proceed immediately. To ensure data integrity while maintaining responsiveness, a "safe tool gating" mechanism was implemented:

1.  **Non-Blocking Start**: The `git commit` promise is captured but not awaited immediately in the task initialization flow.
2.  **Unsafe Tool Blocking**: If the model attempts to use a state-modifying tool (e.g., `write_to_file`, `execute_command`) while the initial commit is still pending, execution pauses until the commit completes. This prevents race conditions where files could be modified before the initial state is fully captured.
3.  **Safe Tool Whitelist**: Read-only tools (e.g., `list_files`, `read_file`, `browser_action`) are whitelisted in `src/shared/tools.ts` (`READ_ONLY_TOOLS`). These tools are allowed to execute in parallel with the ongoing commit, allowing the model to explore the codebase while the checkpoint finishes in the background.

**Changes:**
- `src/core/task/index.ts`: Added logic to capture the commit promise and check tool safety in `presentAssistantMessage` / `executeTool`.
- `src/shared/tools.ts`: Defined `READ_ONLY_TOOLS` constant for centralized management of safe tools.

### Test Procedure

1.  **Simulated Latency**: Added a 15-second artificial delay to `CheckpointGitOperations.ts` to reliably reproduce the race condition window.
2.  **Race Condition Verification**: Verified that without the fix, tools would execute before the commit finished.
3.  **Blocking Verification**: Confirmed that `write_to_file` correctly pauses and waits for the 15s delay to finish before executing.
4.  **Non-Blocking Verification**: Confirmed that `list_files` bypasses the wait and executes immediately, demonstrating the performance improvement.
5.  **Lint & Format**: Ran `npm run lint` and `npm run format:fix` successfully.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`) *(Note: Unit tests skipped due to local env issues, manual tests passed)*
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Additional Notes

The safe tool list (`READ_ONLY_TOOLS`) includes:
- `list_files`
- `read_file`
- `search_files`
- `list_code_definition_names`
- `browser_action`, `web_search`, `web_fetch`
- `ask_followup_question`, `attempt_completion`
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Make initial checkpoint commit non-blocking, allowing read-only tools to execute concurrently while blocking state-modifying tools until commit completion.
> 
>   - **Behavior**:
>     - Initial checkpoint `git commit` in `Task` class is now non-blocking, allowing immediate API request processing.
>     - State-modifying tools (e.g., `write_to_file`, `execute_command`) are blocked until the initial commit completes.
>     - Read-only tools (e.g., `list_files`, `read_file`) execute concurrently with the commit.
>   - **Code Changes**:
>     - `index.ts`: Added logic to handle non-blocking commits and tool execution gating in `presentAssistantMessage` and `executeTool`.
>     - `tools.ts`: Introduced `READ_ONLY_TOOLS` constant to manage safe tools.
>   - **Testing**:
>     - Simulated 15s delay in `CheckpointGitOperations.ts` to test race conditions.
>     - Verified blocking and non-blocking behavior for different tools.
>     - Linting and formatting checks performed, with a note on a failing format fix.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 97b6bf3f69750f8e14605f6dbc89caacded31fb1. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->