### PR TITLE
Don't enable gRPC debug logs in the cli

### DIFF
--- a/cli/pkg/cli/global/cline-clients.go
+++ b/cli/pkg/cli/global/cline-clients.go
@@ -478,8 +478,9 @@ func startClineCore(corePort, hostPort int) (*exec.Cmd, error) {
 	
 	env = append(env,
 		fmt.Sprintf("NODE_PATH=%s", nodePath),
-		"GRPC_TRACE=all",
-		"GRPC_VERBOSITY=DEBUG",
+		// These control gRPC debug logging
+		//"GRPC_TRACE=all",
+		//"GRPC_VERBOSITY=DEBUG",
 		"NODE_ENV=development",
 	)
 	cmd.Env = env


### PR DESCRIPTION
If you need these for development you can enable them locally, they shouldn't be turned on in the released version; they are spammy af.