### PR TITLE
fix: only send thinking params to Gemini models that support them

### DIFF
--- a/.changeset/gentle-rocks-wave.md
+++ b/.changeset/gentle-rocks-wave.md
@@ -1,0 +1,6 @@
+---
+"claude-dev": patch
+---
+
+Fix Gemini Vertex models erroring when thinking parameters are not supported. Only send thinkingConfig for models that have it defined, and only send thinkingLevel for models with supportsThinkingLevel enabled.
+

--- a/src/core/api/providers/gemini.ts
+++ b/src/core/api/providers/gemini.ts
@@ -120,15 +120,17 @@ export class GeminiHandler implements ApiHandler {
 		const _thinkingBudget = this.options.thinkingBudgetTokens ?? 0
 		const maxBudget = info.thinkingConfig?.maxBudget ?? 24576
 		const thinkingBudget = Math.min(_thinkingBudget, maxBudget)
-		// When ThinkingLevel is defineded, thinking budget cannot be zero
+		// When ThinkingLevel is defined, thinking budget cannot be zero
 		// and only level is used to control thinking behavior.
+		// Only set thinkingLevel for models that support it
 		let thinkingLevel: ThinkingLevel | undefined
-		if (this.options.thinkingLevel === "high") {
-			thinkingLevel = ThinkingLevel.HIGH
-		} else if (this.options.thinkingLevel === "low" || modelId.includes("gemini-3-pro")) {
-			// Thinking level is required for Gemini 3 Pro models.
-			// Set it to LOW by default if not specified but is required.
-			thinkingLevel = ThinkingLevel.LOW
+		if (info.thinkingConfig?.supportsThinkingLevel) {
+			const level = this.options.thinkingLevel || info.thinkingConfig.geminiThinkingLevel
+			if (level === "high") {
+				thinkingLevel = ThinkingLevel.HIGH
+			} else if (level === "low") {
+				thinkingLevel = ThinkingLevel.LOW
+			}
 		}
 
 		// Set up base generation config
@@ -141,16 +143,18 @@ export class GeminiHandler implements ApiHandler {
 			temperature: info.temperature ?? 1,
 		}
 
-		// Add thinking config if the model supports it
-		requestConfig.thinkingConfig = {
-			// Turn off thinking:
-			// thinkingBudget: 0
-			// Turn on dynamic thinking:
-			// thinkingBudget: -1
-			// Turn on fixed thinking budget:
-			thinkingBudget: thinkingLevel ? undefined : thinkingBudget, // Use budget only if thinkingLevel is not set
-			thinkingLevel,
-			includeThoughts: thinkingBudget > 0 || !!thinkingLevel,
+		// Add thinking config only if the model supports it
+		if (info.thinkingConfig) {
+			requestConfig.thinkingConfig = {
+				// Turn off thinking:
+				// thinkingBudget: 0
+				// Turn on dynamic thinking:
+				// thinkingBudget: -1
+				// Turn on fixed thinking budget:
+				thinkingBudget: thinkingLevel ? undefined : thinkingBudget, // Use budget only if thinkingLevel is not set
+				thinkingLevel,
+				includeThoughts: thinkingBudget > 0 || !!thinkingLevel,
+			}
 		}
 
 		// Generate content using the configured parameters


### PR DESCRIPTION
### Related Issue

**Issue:** #CLINE-418

### Description

Gemini models on Vertex AI and Gemini API were returning 400 INVALID_ARGUMENT errors when `thinkingConfig` parameters were sent to models that don't support them:

- `gemini-2.0-flash-001`: "thinking is not supported by this model"
- `gemini-2.0-flash-exp`: "Request contains an invalid argument"

**Root cause:** The handler was unconditionally sending `thinkingConfig` to all Gemini models, even those without thinking support.

**Fix:** Now the handler respects model metadata from `api.ts`:
- Models without `thinkingConfig` → No thinking parameters sent
- Models with `thinkingConfig.maxBudget` only → Uses `thinkingBudget`  
- Models with `supportsThinkingLevel: true` → Uses `thinkingLevel` (user setting → config's `geminiThinkingLevel` fallback)

### Test Procedure

Tested the following models that were previously failing:

| Provider | Model | Before | After |
|----------|-------|--------|-------|
| Vertex | gemini-2.0-flash-001 | ❌ 400 error | ✅ Works |
| Vertex | gemini-2.0-flash-exp | ❌ 400 error | ✅ Works |


Also verified thinking-capable models still work:
- `gemini-3-pro-preview` with thinking level → ✅ Works
- `gemini-2.5-flash` with thinking budget → ✅ Works

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A - Backend fix, no UI changes.

### Additional Notes

This fix aligns with the ongoing effort to move model-specific logic into centralized metadata in `api.ts`, reducing hardcoded model name checks in handlers.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes error by sending `thinkingConfig` only to Gemini models that support it, based on model metadata in `gemini.ts`.
> 
>   - **Behavior**:
>     - Fixes 400 INVALID_ARGUMENT errors by only sending `thinkingConfig` to models that support it in `gemini.ts`.
>     - Uses `thinkingLevel` only for models with `supportsThinkingLevel` enabled.
>   - **Logic**:
>     - Updates `createMessage()` in `GeminiHandler` to check `thinkingConfig` and `supportsThinkingLevel` before setting parameters.
>     - Adjusts `requestConfig` to conditionally include `thinkingConfig` based on model metadata.
>   - **Misc**:
>     - Corrects comment typo in `gemini.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 69cb6e067a12f57a57ad93ac94f485843545f4b0. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->