### PR TITLE
Fix tool use argument handling in Claude Code provider

### DIFF
--- a/.changeset/polite-mammals-cut.md
+++ b/.changeset/polite-mammals-cut.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Fix tool use argument handling in Claude Code provider to correctly stringify object arguments for the stream handler.

--- a/src/core/api/providers/claude-code.ts
+++ b/src/core/api/providers/claude-code.ts
@@ -121,7 +121,7 @@ export class ClaudeCodeHandler implements ApiHandler {
 									function: {
 										id: content.id,
 										name: content.name,
-										arguments: content.input,
+										arguments: JSON.stringify(content.input),
 									},
 								},
 							}


### PR DESCRIPTION
<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- For feature requests: Created a discussion in our Feature Requests discussions board https://github.com/cline/cline/discussions/categories/feature-requests and received approval from core maintainers before implementation
- For all changes: Link the associated issue/discussion in the "Related Issue" section below

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly without prior discussion.

Why this requirement?
We deeply appreciate all community contributions - they are essential to Cline's success! To ensure the best use of everyone's time and maintain project direction, we use our Feature Requests discussions board to gauge community interest and validate feature ideas before implementation begins. This helps us focus development efforts on features that will benefit the most users.
-->

### Related Issue

**Issue:** #7467

### Description

This PR fixes a bug where tool calls from the Claude Code provider would fail with "missing parameter" errors.

The issue was caused by a type mismatch:

- The Claude Code CLI returns tool arguments as complete objects (e.g., `{ path: "." }`).
- The `StreamResponseHandler` expects tool arguments to be string chunks (e.g., `'{"path": "."'`) because it is designed for streaming.
- When the object was passed to the handler, it was concatenated with a string, resulting in `"[object Object]"`, which failed JSON parsing and validation.

This fix modifies `src/core/api/providers/claude-code.ts` to `JSON.stringify()` the tool arguments before yielding them. This ensures the `StreamResponseHandler` receives a string as expected, resolving the issue without modifying the core handler logic.


### Test Procedure

1. Configured Claude Code as the provider.
2. Triggered a tool use (e.g., "list files in current directory").
3. Verified that the tool call is now correctly parsed and executed, whereas previously it failed with a missing parameter error.
4. Verified that no "missing parameter" errors occur.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots
Before fix, string was trying to concatenate with object:
<img width="404" height="509" alt="Screenshot 2025-12-10 at 10 21 23 AM" src="https://github.com/user-attachments/assets/c095c2ac-c4a3-45b2-9558-157d67135b88" />


### Additional Notes

This is a fix to https://github.com/cline/cline/pull/7394 where it looks like live testing wasn't completed. Close though!

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes tool use argument handling in `ClaudeCodeHandler` by stringifying arguments to prevent JSON parsing errors.
> 
>   - **Behavior**:
>     - Fixes tool use argument handling in `ClaudeCodeHandler` in `claude-code.ts` by using `JSON.stringify()` on `content.input` to ensure arguments are strings.
>     - Resolves "missing parameter" errors caused by type mismatches in tool calls.
>   - **Testing**:
>     - Verified tool calls execute correctly without errors when using Claude Code provider.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for a5a66b518411cbad9b21d78f295054f13dbf505d. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->