### PR TITLE
expose a getAvailableSlashCommands rpc endpoint in cline core

### DIFF
--- a/.changeset/major-states-feel.md
+++ b/.changeset/major-states-feel.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": minor
+---
+
+expose `getAvailableSlashCommands` rpc endpoint to UI clients

--- a/proto/cline/slash.proto
+++ b/proto/cline/slash.proto
@@ -8,9 +8,25 @@ option go_package = "github.com/cline/grpc-go/cline";
 option java_multiple_files = true;
 option java_package = "bot.cline.proto";
 
-// SlashService provides methods for managing slash
+// SlashService provides methods for managing slash commands
 service SlashService {
   // Sends button click message
   rpc reportBug(StringRequest) returns (Empty);
   rpc condense(StringRequest) returns (Empty);
+
+  // Get available slash commands for autocomplete (used by CLI)
+  rpc getAvailableSlashCommands(EmptyRequest) returns (SlashCommandsResponse);
+}
+
+// Slash command definition for autocomplete
+message SlashCommandInfo {
+  string name = 1; // Command name without slash, e.g., "newtask", "smol"
+  string description = 2; // Human-readable description
+  string section = 3; // "default", "custom", or "cli"
+  bool cli_compatible = 4; // false for VS Code-only commands like explain-changes
+}
+
+// Response containing all available slash commands
+message SlashCommandsResponse {
+  repeated SlashCommandInfo commands = 1;
 }

--- a/src/core/controller/slash/getAvailableSlashCommands.ts
+++ b/src/core/controller/slash/getAvailableSlashCommands.ts
@@ -1,0 +1,88 @@
+import { EmptyRequest } from "@shared/proto/cline/common"
+import { SlashCommandInfo, SlashCommandsResponse } from "@shared/proto/cline/slash"
+import { BASE_SLASH_COMMANDS } from "@/shared/slashCommands"
+import { Controller } from ".."
+
+/**
+ * Returns all available slash commands for autocomplete.
+ */
+export async function getAvailableSlashCommands(controller: Controller, _request: EmptyRequest): Promise<SlashCommandsResponse> {
+	const commands: SlashCommandInfo[] = []
+
+	// Add built-in commands
+	for (const cmd of [...BASE_SLASH_COMMANDS]) {
+		commands.push(
+			SlashCommandInfo.create({
+				name: cmd.name,
+				description: cmd.description,
+				section: "default",
+				cliCompatible: cmd.cliCompatible,
+			}),
+		)
+	}
+
+	// Get workflow toggles from state
+	const localWorkflowToggles = controller.stateManager.getWorkspaceStateKey("workflowToggles") ?? {}
+	const globalWorkflowToggles = controller.stateManager.getGlobalSettingsKey("globalWorkflowToggles") ?? {}
+	const remoteWorkflowToggles = controller.stateManager.getGlobalStateKey("remoteWorkflowToggles") ?? {}
+	const remoteConfigSettings = controller.stateManager.getRemoteConfigSettings()
+	const remoteWorkflows = remoteConfigSettings?.remoteGlobalWorkflows ?? []
+
+	// Track local workflow names to avoid duplicates from global
+	const localNames = new Set<string>()
+
+	// Add local workflows (enabled only)
+	for (const [path, enabled] of Object.entries(localWorkflowToggles)) {
+		if (enabled) {
+			const fileName = fullPathToFileName(path)
+			localNames.add(fileName)
+			commands.push(
+				SlashCommandInfo.create({
+					name: fileName,
+					description: `Custom workflow: ${fileName}`,
+					section: "custom",
+					cliCompatible: true,
+				}),
+			)
+		}
+	}
+
+	// Add global workflows (enabled only, skip if local exists with same name)
+	for (const [path, enabled] of Object.entries(globalWorkflowToggles)) {
+		if (enabled) {
+			const fileName = fullPathToFileName(path)
+			if (!localNames.has(fileName)) {
+				commands.push(
+					SlashCommandInfo.create({
+						name: fileName,
+						description: `Custom workflow: ${fileName}`,
+						section: "custom",
+						cliCompatible: true,
+					}),
+				)
+			}
+		}
+	}
+
+	// Add remote workflows that are enabled
+	for (const workflow of remoteWorkflows) {
+		const enabled = workflow.alwaysEnabled || remoteWorkflowToggles[workflow.name] !== false
+		if (enabled) {
+			commands.push(
+				SlashCommandInfo.create({
+					name: workflow.name,
+					description: `Remote workflow: ${workflow.name}`,
+					section: "custom",
+					cliCompatible: true,
+				}),
+			)
+		}
+	}
+
+	return SlashCommandsResponse.create({ commands })
+}
+
+function fullPathToFileName(path: string): string {
+	// e.g. replace /path/to/workflow.md with workflow.md
+	return path.replace(/^.*[/\\]/, "")
+}

--- a/src/shared/slashCommands.ts
+++ b/src/shared/slashCommands.ts
@@ -1,0 +1,54 @@
+export interface SlashCommand {
+	name: string
+	description?: string
+	section?: "default" | "custom"
+	cliCompatible?: boolean
+}
+
+export const BASE_SLASH_COMMANDS: SlashCommand[] = [
+	{
+		name: "newtask",
+		description: "Create a new task with context from the current task",
+		section: "default",
+		cliCompatible: true,
+	},
+	{
+		name: "smol",
+		description: "Condenses your current context window",
+		section: "default",
+		cliCompatible: true,
+	},
+	{
+		name: "newrule",
+		description: "Create a new Cline rule based on your conversation",
+		section: "default",
+		cliCompatible: true,
+	},
+	{
+		name: "reportbug",
+		description: "Create a Github issue with Cline",
+		section: "default",
+		cliCompatible: true,
+	},
+	{
+		name: "deep-planning",
+		description: "Create a comprehensive implementation plan before coding",
+		section: "default",
+		cliCompatible: true,
+	},
+	{
+		name: "subagent",
+		description: "Invoke a Cline CLI subagent for focused research tasks",
+		section: "default",
+		cliCompatible: true,
+	},
+]
+
+// VS Code-only slash commands
+export const VSCODE_ONLY_COMMANDS: SlashCommand[] = [
+	{
+		name: "explain-changes",
+		description: "Explain code changes between git refs (PRs, commits, branches, etc.)",
+		section: "default",
+	},
+]

--- a/src/test/slash-commands.test.ts
+++ b/src/test/slash-commands.test.ts
@@ -1,0 +1,407 @@
+import { afterEach, beforeEach, describe, it } from "mocha";
+import "should";
+import * as sinon from "sinon";
+import { Controller } from "../core/controller";
+import { getAvailableSlashCommands } from "../core/controller/slash/getAvailableSlashCommands";
+import { EmptyRequest } from "../shared/proto/cline/common";
+import { BASE_SLASH_COMMANDS } from "../shared/slashCommands";
+
+/**
+ * Unit tests for getAvailableSlashCommands RPC endpoint
+ * Tests the slash command discovery and filtering functionality
+ */
+describe("getAvailableSlashCommands", () => {
+  let mockController: Partial<Controller>;
+  let mockStateManager: {
+    getWorkspaceStateKey: sinon.SinonStub;
+    getGlobalSettingsKey: sinon.SinonStub;
+    getGlobalStateKey: sinon.SinonStub;
+    getRemoteConfigSettings: sinon.SinonStub;
+  };
+
+  beforeEach(() => {
+    mockStateManager = {
+      getWorkspaceStateKey: sinon.stub(),
+      getGlobalSettingsKey: sinon.stub(),
+      getGlobalStateKey: sinon.stub(),
+      getRemoteConfigSettings: sinon.stub(),
+    };
+
+    // Default stubs return empty/null values
+    mockStateManager.getWorkspaceStateKey.returns(null);
+    mockStateManager.getGlobalSettingsKey.returns(null);
+    mockStateManager.getGlobalStateKey.returns(null);
+    mockStateManager.getRemoteConfigSettings.returns(null);
+
+    mockController = {
+      stateManager: mockStateManager as any,
+    };
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe("Base Slash Commands", () => {
+    it("should return all base slash commands", async () => {
+      const response = await getAvailableSlashCommands(
+        mockController as Controller,
+        EmptyRequest.create()
+      );
+
+      // Should have at least all base commands
+      response.commands.length.should.be.greaterThanOrEqual(
+        BASE_SLASH_COMMANDS.length
+      );
+
+      // Verify each base command is present
+      for (const baseCmd of BASE_SLASH_COMMANDS) {
+        const found = response.commands.find(
+          (cmd) => cmd.name === baseCmd.name
+        );
+        found!.should.not.be.undefined();
+        found!.description.should.equal(baseCmd.description);
+        found!.section.should.equal("default");
+        found!.cliCompatible.should.equal(baseCmd.cliCompatible ?? false);
+      }
+    });
+
+    it("should mark base commands with section 'default'", async () => {
+      const response = await getAvailableSlashCommands(
+        mockController as Controller,
+        EmptyRequest.create()
+      );
+
+      const baseCommandNames = BASE_SLASH_COMMANDS.map((cmd) => cmd.name);
+      for (const cmd of response.commands) {
+        if (baseCommandNames.includes(cmd.name)) {
+          cmd.section.should.equal("default");
+        }
+      }
+    });
+  });
+
+  describe("Local Workflow Toggles", () => {
+    it("should include enabled local workflows", async () => {
+      mockStateManager.getWorkspaceStateKey
+        .withArgs("workflowToggles")
+        .returns({
+          "/path/to/my-workflow.md": true,
+          "/path/to/another-workflow.md": true,
+        });
+
+      const response = await getAvailableSlashCommands(
+        mockController as Controller,
+        EmptyRequest.create()
+      );
+
+      const myWorkflow = response.commands.find(
+        (cmd) => cmd.name === "my-workflow.md"
+      );
+      myWorkflow!.should.not.be.undefined();
+      myWorkflow!.section.should.equal("custom");
+      myWorkflow!.cliCompatible.should.equal(true);
+
+      const anotherWorkflow = response.commands.find(
+        (cmd) => cmd.name === "another-workflow.md"
+      );
+      anotherWorkflow!.should.not.be.undefined();
+    });
+
+    it("should exclude disabled local workflows", async () => {
+      mockStateManager.getWorkspaceStateKey
+        .withArgs("workflowToggles")
+        .returns({
+          "/path/to/enabled-workflow.md": true,
+          "/path/to/disabled-workflow.md": false,
+        });
+
+      const response = await getAvailableSlashCommands(
+        mockController as Controller,
+        EmptyRequest.create()
+      );
+
+      const enabled = response.commands.find(
+        (cmd) => cmd.name === "enabled-workflow.md"
+      );
+      enabled!.should.not.be.undefined();
+
+      const disabled = response.commands.find(
+        (cmd) => cmd.name === "disabled-workflow.md"
+      );
+      (disabled === undefined).should.be.true();
+    });
+
+    it("should extract filename from full path", async () => {
+      mockStateManager.getWorkspaceStateKey
+        .withArgs("workflowToggles")
+        .returns({
+          "/Users/test/project/.clinerules/workflows/deep-analysis.md": true,
+        });
+
+      const response = await getAvailableSlashCommands(
+        mockController as Controller,
+        EmptyRequest.create()
+      );
+
+      const workflow = response.commands.find(
+        (cmd) => cmd.name === "deep-analysis.md"
+      );
+      workflow!.should.not.be.undefined();
+    });
+
+    it("should handle Windows-style paths", async () => {
+      mockStateManager.getWorkspaceStateKey
+        .withArgs("workflowToggles")
+        .returns({
+          "C:\\Users\\test\\project\\.clinerules\\workflows\\windows-workflow.md":
+            true,
+        });
+
+      const response = await getAvailableSlashCommands(
+        mockController as Controller,
+        EmptyRequest.create()
+      );
+
+      const workflow = response.commands.find(
+        (cmd) => cmd.name === "windows-workflow.md"
+      );
+      workflow!.should.not.be.undefined();
+    });
+  });
+
+  describe("Global Workflow Toggles", () => {
+    it("should include enabled global workflows", async () => {
+      mockStateManager.getGlobalSettingsKey
+        .withArgs("globalWorkflowToggles")
+        .returns({
+          "/global/path/global-workflow.md": true,
+        });
+
+      const response = await getAvailableSlashCommands(
+        mockController as Controller,
+        EmptyRequest.create()
+      );
+
+      const workflow = response.commands.find(
+        (cmd) => cmd.name === "global-workflow.md"
+      );
+      workflow!.should.not.be.undefined();
+      workflow!.section.should.equal("custom");
+    });
+
+    it("should exclude disabled global workflows", async () => {
+      mockStateManager.getGlobalSettingsKey
+        .withArgs("globalWorkflowToggles")
+        .returns({
+          "/global/path/disabled-global.md": false,
+        });
+
+      const response = await getAvailableSlashCommands(
+        mockController as Controller,
+        EmptyRequest.create()
+      );
+
+      const workflow = response.commands.find(
+        (cmd) => cmd.name === "disabled-global.md"
+      );
+      (workflow === undefined).should.be.true();
+    });
+  });
+
+  describe("Workflow Deduplication", () => {
+    it("should prefer local workflows over global workflows with same name", async () => {
+      // Same filename in both local and global
+      mockStateManager.getWorkspaceStateKey
+        .withArgs("workflowToggles")
+        .returns({
+          "/local/path/shared-workflow.md": true,
+        });
+      mockStateManager.getGlobalSettingsKey
+        .withArgs("globalWorkflowToggles")
+        .returns({
+          "/global/path/shared-workflow.md": true,
+        });
+
+      const response = await getAvailableSlashCommands(
+        mockController as Controller,
+        EmptyRequest.create()
+      );
+
+      // Should only appear once
+      const matches = response.commands.filter(
+        (cmd) => cmd.name === "shared-workflow.md"
+      );
+      matches.length.should.equal(1);
+    });
+
+    it("should include global workflow if local with same name is disabled", async () => {
+      mockStateManager.getWorkspaceStateKey
+        .withArgs("workflowToggles")
+        .returns({
+          "/local/path/shared-workflow.md": false, // disabled locally
+        });
+      mockStateManager.getGlobalSettingsKey
+        .withArgs("globalWorkflowToggles")
+        .returns({
+          "/global/path/shared-workflow.md": true, // enabled globally
+        });
+
+      const response = await getAvailableSlashCommands(
+        mockController as Controller,
+        EmptyRequest.create()
+      );
+
+      // Global should appear since local is disabled
+      const workflow = response.commands.find(
+        (cmd) => cmd.name === "shared-workflow.md"
+      );
+      workflow!.should.not.be.undefined();
+    });
+  });
+
+  describe("Remote Workflows", () => {
+    it("should include alwaysEnabled remote workflows", async () => {
+      mockStateManager.getRemoteConfigSettings.returns({
+        remoteGlobalWorkflows: [
+          { name: "always-on-workflow", alwaysEnabled: true },
+        ],
+      });
+
+      const response = await getAvailableSlashCommands(
+        mockController as Controller,
+        EmptyRequest.create()
+      );
+
+      const workflow = response.commands.find(
+        (cmd) => cmd.name === "always-on-workflow"
+      );
+      workflow!.should.not.be.undefined();
+      workflow!.section.should.equal("custom");
+    });
+
+    it("should include remote workflows enabled by toggle", async () => {
+      mockStateManager.getRemoteConfigSettings.returns({
+        remoteGlobalWorkflows: [
+          { name: "toggle-workflow", alwaysEnabled: false },
+        ],
+      });
+      mockStateManager.getGlobalStateKey
+        .withArgs("remoteWorkflowToggles")
+        .returns({
+          "toggle-workflow": true, // not explicitly disabled
+        });
+
+      const response = await getAvailableSlashCommands(
+        mockController as Controller,
+        EmptyRequest.create()
+      );
+
+      const workflow = response.commands.find(
+        (cmd) => cmd.name === "toggle-workflow"
+      );
+      workflow!.should.not.be.undefined();
+    });
+
+    it("should exclude remote workflows explicitly disabled by toggle", async () => {
+      mockStateManager.getRemoteConfigSettings.returns({
+        remoteGlobalWorkflows: [
+          { name: "disabled-remote", alwaysEnabled: false },
+        ],
+      });
+      mockStateManager.getGlobalStateKey
+        .withArgs("remoteWorkflowToggles")
+        .returns({
+          "disabled-remote": false,
+        });
+
+      const response = await getAvailableSlashCommands(
+        mockController as Controller,
+        EmptyRequest.create()
+      );
+
+      const workflow = response.commands.find(
+        (cmd) => cmd.name === "disabled-remote"
+      );
+      (workflow === undefined).should.be.true();
+    });
+
+    it("should include remote workflows by default if not explicitly disabled", async () => {
+      mockStateManager.getRemoteConfigSettings.returns({
+        remoteGlobalWorkflows: [
+          { name: "default-enabled", alwaysEnabled: false },
+        ],
+      });
+      // No toggle entry for this workflow
+      mockStateManager.getGlobalStateKey
+        .withArgs("remoteWorkflowToggles")
+        .returns({});
+
+      const response = await getAvailableSlashCommands(
+        mockController as Controller,
+        EmptyRequest.create()
+      );
+
+      const workflow = response.commands.find(
+        (cmd) => cmd.name === "default-enabled"
+      );
+      workflow!.should.not.be.undefined();
+    });
+  });
+
+  describe("Edge Cases", () => {
+    it("should handle null/undefined state values gracefully", async () => {
+      mockStateManager.getWorkspaceStateKey.returns(null);
+      mockStateManager.getGlobalSettingsKey.returns(undefined);
+      mockStateManager.getGlobalStateKey.returns(null);
+      mockStateManager.getRemoteConfigSettings.returns(null);
+
+      const response = await getAvailableSlashCommands(
+        mockController as Controller,
+        EmptyRequest.create()
+      );
+
+      // Should still return base commands
+      response.commands.length.should.be.greaterThanOrEqual(
+        BASE_SLASH_COMMANDS.length
+      );
+    });
+
+    it("should handle empty workflow toggle objects", async () => {
+      mockStateManager.getWorkspaceStateKey
+        .withArgs("workflowToggles")
+        .returns({});
+      mockStateManager.getGlobalSettingsKey
+        .withArgs("globalWorkflowToggles")
+        .returns({});
+      mockStateManager.getGlobalStateKey
+        .withArgs("remoteWorkflowToggles")
+        .returns({});
+      mockStateManager.getRemoteConfigSettings.returns({
+        remoteGlobalWorkflows: [],
+      });
+
+      const response = await getAvailableSlashCommands(
+        mockController as Controller,
+        EmptyRequest.create()
+      );
+
+      // Should only have base commands
+      response.commands.length.should.equal(BASE_SLASH_COMMANDS.length);
+    });
+
+    it("should handle remote config with no remoteGlobalWorkflows property", async () => {
+      mockStateManager.getRemoteConfigSettings.returns({});
+
+      const response = await getAvailableSlashCommands(
+        mockController as Controller,
+        EmptyRequest.create()
+      );
+
+      // Should not throw, just return base commands
+      response.commands.length.should.be.greaterThanOrEqual(
+        BASE_SLASH_COMMANDS.length
+      );
+    });
+  });
+});

--- a/webview-ui/src/components/chat/ChatTextArea.tsx
+++ b/webview-ui/src/components/chat/ChatTextArea.tsx
@@ -5,6 +5,7 @@ import { FileSearchRequest, FileSearchType, RelativePathsRequest } from "@shared
 import { UpdateApiConfigurationRequest } from "@shared/proto/cline/models"
 import { PlanActMode, TogglePlanActModeRequest } from "@shared/proto/cline/state"
 import { convertApiConfigurationToProto } from "@shared/proto-conversions/models/api-configuration-conversion"
+import { type SlashCommand } from "@shared/slashCommands"
 import { Mode } from "@shared/storage/types"
 import { VSCodeButton } from "@vscode/webview-ui-toolkit/react"
 import { AtSignIcon, PlusIcon } from "lucide-react"
@@ -42,7 +43,6 @@ import {
 	getMatchingSlashCommands,
 	insertSlashCommand,
 	removeSlashCommand,
-	type SlashCommand,
 	shouldShowSlashCommandsMenu,
 	slashCommandDeleteRegex,
 	slashCommandRegexGlobal,

--- a/webview-ui/src/components/chat/SlashCommandMenu.tsx
+++ b/webview-ui/src/components/chat/SlashCommandMenu.tsx
@@ -1,5 +1,6 @@
+import { type SlashCommand } from "@shared/slashCommands"
 import React, { useCallback, useEffect, useRef } from "react"
-import { getMatchingSlashCommands, SlashCommand } from "@/utils/slash-commands"
+import { getMatchingSlashCommands } from "@/utils/slash-commands"
 
 interface SlashCommandMenuProps {
 	onSelect: (command: SlashCommand) => void

--- a/webview-ui/src/utils/slash-commands.ts
+++ b/webview-ui/src/utils/slash-commands.ts
@@ -1,52 +1,5 @@
 import { PLATFORM_CONFIG, PlatformType } from "@/config/platform.config"
-
-export interface SlashCommand {
-	name: string
-	description?: string
-	section?: "default" | "custom"
-}
-
-const BASE_SLASH_COMMANDS: SlashCommand[] = [
-	{
-		name: "newtask",
-		description: "Create a new task with context from the current task",
-		section: "default",
-	},
-	{
-		name: "smol",
-		description: "Condenses your current context window",
-		section: "default",
-	},
-	{
-		name: "newrule",
-		description: "Create a new Cline rule based on your conversation",
-		section: "default",
-	},
-	{
-		name: "reportbug",
-		description: "Create a Github issue with Cline",
-		section: "default",
-	},
-	{
-		name: "deep-planning",
-		description: "Create a comprehensive implementation plan before coding",
-		section: "default",
-	},
-	{
-		name: "subagent",
-		description: "Invoke a Cline CLI subagent for focused research tasks",
-		section: "default",
-	},
-]
-
-// VS Code-only slash commands
-const VSCODE_ONLY_COMMANDS: SlashCommand[] = [
-	{
-		name: "explain-changes",
-		description: "Explain code changes between git refs (PRs, commits, branches, etc.)",
-		section: "default",
-	},
-]
+import { BASE_SLASH_COMMANDS, type SlashCommand, VSCODE_ONLY_COMMANDS } from "../../../src/shared/slashCommands.ts"
 
 export const DEFAULT_SLASH_COMMANDS: SlashCommand[] =
 	PLATFORM_CONFIG.type === PlatformType.VSCODE ? [...BASE_SLASH_COMMANDS, ...VSCODE_ONLY_COMMANDS] : BASE_SLASH_COMMANDS


### PR DESCRIPTION
- **expose a getAvailableSlashCommands rpc endpoint in cline core**
- **add tests for getAvailableSlashCommands rpc endpoint**

<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- For feature requests: Created a discussion in our Feature Requests discussions board https://github.com/cline/cline/discussions/categories/feature-requests and received approval from core maintainers before implementation
- For all changes: Link the associated issue/discussion in the "Related Issue" section below

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly without prior discussion.

Why this requirement?
We deeply appreciate all community contributions - they are essential to Cline's success! To ensure the best use of everyone's time and maintain project direction, we use our Feature Requests discussions board to gauge community interest and validate feature ideas before implementation begins. This helps us focus development efforts on features that will benefit the most users.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** PRD-135

### Description

This will expose an rpc endpoint in cline core that returns the available slash commands for the current project. This will be used initally by the cline cli to provide slash command autocompletion.

<!-- 
Help reviewers understand your changes by making this PR readable and well-organized:

- What problem does this PR solve?
- Why were these changes introduced and what purpose do they serve?
- For larger changes, provide context about your approach and reasoning

Small PRs may need minimal description, but larger changes benefit from explaining where you're coming from. Much of this context can be in the linked issue above, so feel free to reference it rather than repeating everything here.
-->

### Test Procedure

Added unit tests and tested cli autocompletion manually (cli autocompletion pr's will be opened shortly).

<!-- 
Please walk us through your testing approach and thought process. This helps reviewers understand that you've thoroughly considered the impact of your changes:

- How did you test this change?
- What could potentially break and how did you verify it doesn't?
- What existing functionality might be affected and how did you check it still works?
- Why are you confident this is ready for merge?

We're not looking for exhaustive documentation - just evidence that you've thought through the implications of your changes and tested accordingly.
-->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [X] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [X] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [X] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [X] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [X] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

This PR has no UI changes.
<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds `getAvailableSlashCommands` RPC endpoint to expose available slash commands for CLI autocompletion, with comprehensive tests and UI integration.
> 
>   - **RPC Endpoint**:
>     - Adds `getAvailableSlashCommands` RPC endpoint in `proto/cline/slash.proto`.
>     - Implements `getAvailableSlashCommands` function in `getAvailableSlashCommands.ts` to return available slash commands.
>   - **Slash Commands**:
>     - Defines `SlashCommand` interface and `BASE_SLASH_COMMANDS` in `slashCommands.ts`.
>     - Handles local, global, and remote workflows in `getAvailableSlashCommands.ts`.
>   - **Tests**:
>     - Adds comprehensive tests in `slash-commands.test.ts` for `getAvailableSlashCommands`.
>     - Tests cover base commands, local/global/remote workflows, and edge cases.
>   - **UI Integration**:
>     - Updates `ChatTextArea.tsx` and `SlashCommandMenu.tsx` to integrate slash command functionality.
>     - Refactors `slash-commands.ts` to use shared slash command definitions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 34fd7c0103f914557a5c665970cfb58160f9e1b9. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->