### PR TITLE
fix: remove attempt_completion tool from READ_ONLY_TOOLS

### DIFF
--- a/src/shared/tools.ts
+++ b/src/shared/tools.ts
@@ -46,7 +46,6 @@ export const READ_ONLY_TOOLS = [
 	ClineDefaultTool.LIST_CODE_DEF,
 	ClineDefaultTool.BROWSER,
 	ClineDefaultTool.ASK,
-	ClineDefaultTool.ATTEMPT,
 	ClineDefaultTool.WEB_SEARCH,
 	ClineDefaultTool.WEB_FETCH,
 ] as const


### PR DESCRIPTION


<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- For feature requests: Created a discussion in our Feature Requests discussions board https://github.com/cline/cline/discussions/categories/feature-requests and received approval from core maintainers before implementation
- For all changes: Link the associated issue/discussion in the "Related Issue" section below

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly without prior discussion.

Why this requirement?
We deeply appreciate all community contributions - they are essential to Cline's success! To ensure the best use of everyone's time and maintain project direction, we use our Feature Requests discussions board to gauge community interest and validate feature ideas before implementation begins. This helps us focus development efforts on features that will benefit the most users.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** #8008

### Description

Adding ClineDefaultTool.ATTEMPT (attempt_completion tool) to READ_ONLY_TOOLS was causing tools to be called after task completion. Removing this terminates the task properly only after other tool calls are complete.

### Test Procedure

**Before fix:**
Asked cline `list files here with ls`
Response
```
Task Completed

Here are the files in the current working directory (as listed by `ls`):

...

Cline wants to execute this command:

Pending

ls

```

**After fix**

Asked cline `list files here with ls`
Response
```
Task Completed

Here are the files in the current working directory (as listed by `ls`):

...
```

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A

### Additional Notes

N/A

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Removes `ClineDefaultTool.ATTEMPT` from `READ_ONLY_TOOLS` in `tools.ts` to fix task completion behavior.
> 
>   - **Behavior**:
>     - Removes `ClineDefaultTool.ATTEMPT` from `READ_ONLY_TOOLS` in `tools.ts` to prevent tool calls after task completion.
>     - Fixes issue where tasks were not terminating properly after tool execution.
>   - **Test Procedure**:
>     - Before: Task completion message followed by pending tool execution.
>     - After: Task completion message without pending tool execution.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for fa04299820cd8f0b7b573c484228bd3bdd1e9686. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->