### PR TITLE
Fix parallel tool calling by tracking tool use via call_id

### DIFF
--- a/src/core/task/index.ts
+++ b/src/core/task/index.ts
@@ -63,7 +63,6 @@ import {
 } from "@shared/ExtensionMessage"
 import { HistoryItem } from "@shared/HistoryItem"
 import { DEFAULT_LANGUAGE_SETTINGS, getLanguageKey, LanguageDisplay } from "@shared/Languages"
-import { CLINE_MCP_TOOL_IDENTIFIER } from "@shared/mcp"
 import { USER_CONTENT_TAGS } from "@shared/messages/constants"
 import { convertClineMessageToProto } from "@shared/proto-conversions/cline-message"
 import { ClineDefaultTool, READ_ONLY_TOOLS } from "@shared/tools"
@@ -2932,14 +2931,9 @@ export class Task {
 								chunk.tool_call.call_id,
 							)
 							// Extract and store tool_use_id for creating proper ToolResultBlockParam
-							if (chunk.tool_call.function?.id && chunk.tool_call.function?.name) {
-								this.taskState.toolUseIdMap.set(chunk.tool_call.function.name, chunk.tool_call.function.id)
-
-								// For MCP tools, also store the mapping with the transformed name
-								// since getPartialToolUsesAsContent() will transform the name to "use_mcp_tool"
-								if (chunk.tool_call.function.name.includes(CLINE_MCP_TOOL_IDENTIFIER)) {
-									this.taskState.toolUseIdMap.set(ClineDefaultTool.MCP_USE, chunk.tool_call.function.id)
-								}
+							// Use call_id as key to support multiple calls to the same tool
+							if (chunk.tool_call.function?.id && chunk.tool_call.call_id) {
+								this.taskState.toolUseIdMap.set(chunk.tool_call.call_id, chunk.tool_call.function.id)
 							}
 
 							this.processNativeToolCalls(assistantTextOnly, toolUseHandler.getPartialToolUsesAsContent())

--- a/src/core/task/tools/utils/ToolResultUtils.ts
+++ b/src/core/task/tools/utils/ToolResultUtils.ts
@@ -35,8 +35,8 @@ export class ToolResultUtils {
 					})()
 				: toolDescription(block)
 
-			// Get tool_use_id from map, or use "cline" as fallback for backward compatibility
-			const toolUseId = toolUseIdMap?.get(block.name) || "cline"
+			// Get tool_use_id from map using call_id, or use "cline" as fallback for backward compatibility
+			const toolUseId = toolUseIdMap?.get(block.call_id || "") || "cline"
 
 			// If we have already added a tool result for this tool use, skip adding another one
 			if (
@@ -53,7 +53,7 @@ export class ToolResultUtils {
 		} else {
 			// For complex content (arrays with text/image blocks), pass it through directly
 			// The content array should already be properly formatted with type, text, source, etc.
-			const toolUseId = toolUseIdMap?.get(block.name) || "cline"
+			const toolUseId = toolUseIdMap?.get(block.call_id || "") || "cline"
 
 			// If using backward-compatible "cline" ID and content is an array, spread it directly
 			// instead of wrapping it (which would cause JSON.stringify in createToolResultBlock)


### PR DESCRIPTION
<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- For feature requests: Created a discussion in our Feature Requests discussions board https://github.com/cline/cline/discussions/categories/feature-requests and received approval from core maintainers before implementation
- For all changes: Link the associated issue/discussion in the "Related Issue" section below

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly without prior discussion.

Why this requirement?
We deeply appreciate all community contributions - they are essential to Cline's success! To ensure the best use of everyone's time and maintain project direction, we use our Feature Requests discussions board to gauge community interest and validate feature ideas before implementation begins. This helps us focus development efforts on features that will benefit the most users.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** #8020

### Description
Previously, tool results were tracked using the tool name as a key. This caused a critical bug during parallel tool execution: if the same tool (e.g., `read_file`) was called multiple times in a single turn, subsequent calls would overwrite the previous ones in the `toolUseIdMap`. This resulted in missing tool results for all but the last call.

This commit changes the tracking mechanism to use the unique `call_id` provided by the LLM as the key. This ensures that every tool call is tracked independently, regardless of the tool name.

Specific changes:
- Updated `toolUseIdMap` in `Task.ts` to store `call_id -> tool_id` instead of `tool_name -> tool_id`.
- Updated `ToolResultUtils.ts` to retrieve tool IDs using `block.call_id`.
- Removed legacy MCP-specific logic that manually mapped the generic `use_mcp_tool` name to an ID. This is no longer necessary (and would be incorrect) as MCP tools now also use the robust `call_id` tracking, enabling parallel execution for them as well.

### Test Procedure

Before change

<img width="734" height="600" alt="Screenshot 2025-12-10 at 7 37 30 PM" src="https://github.com/user-attachments/assets/4296f8be-52fe-49c5-868e-737e1e89ba57" />

After change

<img width="521" height="444" alt="Screenshot 2025-12-10 at 8 57 58 PM" src="https://github.com/user-attachments/assets/848494e4-e481-420c-bf25-b9a344d75e75" />

Parallel tool calls work with other models as well

<img width="382" height="583" alt="Screenshot 2025-12-10 at 9 03 07 PM" src="https://github.com/user-attachments/assets/e9dee35b-083a-40d8-a085-b3615eed9c0a" />

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes parallel tool execution bug by using `call_id` for unique tool call tracking in `Task.ts` and `ToolResultUtils.ts`.
> 
>   - **Behavior**:
>     - Fixes bug in parallel tool execution by using `call_id` instead of `tool_name` for tracking in `toolUseIdMap` in `Task.ts`.
>     - Updates `ToolResultUtils.ts` to retrieve tool IDs using `block.call_id`.
>   - **Misc**:
>     - Removes legacy MCP-specific logic for tool ID mapping in `Task.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 6b40c9857c2936c5b8238065a721aa182de50b33. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->