### PR TITLE
fix(ui): close WhatsNewModal when selecting model options

### DIFF
--- a/webview-ui/src/components/common/WhatsNewModal.tsx
+++ b/webview-ui/src/components/common/WhatsNewModal.tsx
@@ -64,6 +64,7 @@ export const WhatsNewModal: React.FC<WhatsNewModalProps> = ({ open, onClose, ver
 		setTimeout(() => {
 			setDidClickDevstralButton(true)
 			setShowChatModelSelector(true)
+			onClose()
 		}, 10)
 	}
 
@@ -81,6 +82,7 @@ export const WhatsNewModal: React.FC<WhatsNewModalProps> = ({ open, onClose, ver
 		setTimeout(() => {
 			setDidClickGPT52Button(true)
 			setShowChatModelSelector(true)
+			onClose()
 		}, 10)
 	}
 
@@ -201,7 +203,7 @@ export const WhatsNewModal: React.FC<WhatsNewModalProps> = ({ open, onClose, ver
 											appearance="primary"
 											onClick={setDevstral}
 											style={{ transform: "scale(0.85)", transformOrigin: "left center" }}>
-											Try Devstral-2512
+											Try for Free Devstral-2512
 										</VSCodeButton>
 									)}
 								</div>


### PR DESCRIPTION
Close the modal automatically when users click "Try Devstral" or "Try GPT-5.2" buttons to improve UX flow. Also update Devstral button text to clarify it's free.



### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** #XXXX

### Description

<!-- 
Help reviewers understand your changes by making this PR readable and well-organized:

- What problem does this PR solve?
- Why were these changes introduced and what purpose do they serve?
- For larger changes, provide context about your approach and reasoning

Small PRs may need minimal description, but larger changes benefit from explaining where you're coming from. Much of this context can be in the linked issue above, so feel free to reference it rather than repeating everything here.
-->

### Test Procedure

<!-- 
Please walk us through your testing approach and thought process. This helps reviewers understand that you've thoroughly considered the impact of your changes:

- How did you test this change?
- What could potentially break and how did you verify it doesn't?
- What existing functionality might be affected and how did you check it still works?
- Why are you confident this is ready for merge?

We're not looking for exhaustive documentation - just evidence that you've thought through the implications of your changes and tested accordingly.
-->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [ ] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Close `WhatsNewModal` when "Try Devstral" or "Try GPT-5.2" buttons are clicked and update button text for clarity.
> 
>   - **Behavior**:
>     - `onClose()` is called in `setDevstral()` and `setGPT52()` in `WhatsNewModal.tsx` to close the modal when "Try Devstral" or "Try GPT-5.2" buttons are clicked.
>     - Updates button text from "Try Devstral-2512" to "Try for Free Devstral-2512" for clarity.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for daa13e12652919bd55e9f3a802d0771b048db9e6. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->