### PR TITLE
Compile the CLI in the ci workflow (except for windows)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -106,17 +106,19 @@ jobs:
               id: build_step
               run: npm run ci:build
 
+            - name: Build CLI
+              if: runner.os != 'Windows'
+              run: npm run compile-cli-all-platforms
+
             - name: Unit Tests with coverage - Linux
               id: unit_tests_linux
               if: ${{ !cancelled() && steps.build_step.outcome == 'success' && runner.os == 'Linux' }}
-              run: |
-                  npx nyc --nycrc-path .nycrc.unit.json --reporter=lcov npm run test:unit
+              run: npx nyc --nycrc-path .nycrc.unit.json --reporter=lcov npm run test:unit
 
             - name: Unit Tests - Non-Linux
               id: unit_tests_non_linux
               if: ${{ !cancelled() && steps.build_step.outcome == 'success' && runner.os != 'Linux' }}
-              run: |
-                  npm run test:unit
+              run: npm run test:unit
 
             - name: Extension Integration Tests - Linux
               id: integration_tests_linux


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add CLI compilation step for non-Windows platforms in CI workflow.
> 
>   - **CI Workflow**:
>     - Adds `Build CLI` step in `.github/workflows/test.yml` to compile CLI for all platforms except Windows using `npm run compile-cli-all-platforms`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 6e828d742623997dfd074de71dd477cc9b3e5aaf. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->