### PR TITLE
fix: extract OpenRouter model filtering into reusable utility and use it different model pickers

### DIFF
--- a/webview-ui/src/components/chat/ModelPickerModal.tsx
+++ b/webview-ui/src/components/chat/ModelPickerModal.tsx
@@ -32,6 +32,7 @@ import { freeModels, recommendedModels } from "@/components/settings/OpenRouterM
 import { SUPPORTED_ANTHROPIC_THINKING_MODELS } from "@/components/settings/providers/AnthropicProvider"
 import { SUPPORTED_BEDROCK_THINKING_MODELS } from "@/components/settings/providers/BedrockProvider"
 import {
+	filterOpenRouterModelIds,
 	getModelsForProvider,
 	getModeSpecificFields,
 	normalizeApiConfiguration,
@@ -128,11 +129,14 @@ const ModelPickerModal: React.FC<ModelPickerModalProps> = ({ isOpen, onOpenChang
 	// Get models for current provider
 	const allModels = useMemo((): ModelItem[] => {
 		if (OPENROUTER_MODEL_PROVIDERS.includes(selectedProvider)) {
-			return Object.entries(openRouterModels || {}).map(([id, info]) => ({
+			const modelIds = Object.keys(openRouterModels || {})
+			const filteredIds = filterOpenRouterModelIds(modelIds, selectedProvider)
+
+			return filteredIds.map((id) => ({
 				id,
 				name: id.split("/").pop() || id,
 				provider: id.split("/")[0],
-				info,
+				info: openRouterModels[id],
 			}))
 		}
 

--- a/webview-ui/src/components/settings/OpenRouterModelPicker.tsx
+++ b/webview-ui/src/components/settings/OpenRouterModelPicker.tsx
@@ -15,7 +15,7 @@ import { ModelInfoView } from "./common/ModelInfoView"
 import { DropdownContainer } from "./common/ModelSelector"
 import FeaturedModelCard from "./FeaturedModelCard"
 import ThinkingBudgetSlider from "./ThinkingBudgetSlider"
-import { getModeSpecificFields, normalizeApiConfiguration } from "./utils/providerUtils"
+import { filterOpenRouterModelIds, getModeSpecificFields, normalizeApiConfiguration } from "./utils/providerUtils"
 import { useApiConfigurationHandlers } from "./utils/useApiConfigurationHandlers"
 
 // Star icon for favorites
@@ -164,20 +164,7 @@ const OpenRouterModelPicker: React.FC<OpenRouterModelPickerProps> = ({ isPopup, 
 
 	const modelIds = useMemo(() => {
 		const unfilteredModelIds = Object.keys(openRouterModels).sort((a, b) => a.localeCompare(b))
-
-		if (modeFields.apiProvider === "cline") {
-			// For Cline provider: exclude :free models, but keep Minimax models
-			return unfilteredModelIds.filter((id) => {
-				// Keep all Minimax models regardless of :free suffix
-				if (id.toLowerCase().includes("minimax-m2")) {
-					return true
-				}
-				// Filter out other :free models
-				return !id.includes(":free")
-			})
-		}
-		// For OpenRouter and Vercel AI Gateway providers: exclude Cline-specific models
-		return unfilteredModelIds.filter((id) => !id.startsWith("cline/"))
+		return filterOpenRouterModelIds(unfilteredModelIds, modeFields.apiProvider || "openrouter")
 	}, [openRouterModels, modeFields.apiProvider])
 
 	const searchableItems = useMemo(() => {

--- a/webview-ui/src/components/settings/utils/providerUtils.ts
+++ b/webview-ui/src/components/settings/utils/providerUtils.ts
@@ -791,3 +791,28 @@ export async function syncModeConfigurations(
 	// Make the atomic update
 	await handleFieldsChange(updates)
 }
+
+/**
+ * Filters OpenRouter model IDs based on provider-specific rules.
+ * For Cline provider: excludes :free models (except Minimax models)
+ * For OpenRouter/Vercel: excludes cline/ prefixed models
+ * @param modelIds Array of model IDs to filter
+ * @param provider The current API provider
+ * @returns Filtered array of model IDs
+ */
+export function filterOpenRouterModelIds(modelIds: string[], provider: ApiProvider): string[] {
+	if (provider === "cline") {
+		// For Cline provider: exclude :free models, but keep Minimax models
+		return modelIds.filter((id) => {
+			// Keep all Minimax models regardless of :free suffix
+			if (id.toLowerCase().includes("minimax-m2")) {
+				return true
+			}
+			// Filter out other :free models
+			return !id.includes(":free")
+		})
+	}
+
+	// For OpenRouter and Vercel AI Gateway providers: exclude Cline-specific models
+	return modelIds.filter((id) => !id.startsWith("cline/"))
+}


### PR DESCRIPTION

### Description

- Add filterOpenRouterModelIds function to providerUtils.ts
- Apply consistent filtering logic in ModelPickerModal and OpenRouterModelPicker
- For Cline provider: exclude :free models except Minimax
- For OpenRouter/Vercel: exclude cline/ prefixed models



This solves the issue so users can't see free models in Openrouter as they are not meant to be used through cline as they are severely rate limited.



### Test Procedure

Search for devstral and you should not be able to see the free model

<img width="480" height="232" alt="image" src="https://github.com/user-attachments/assets/9d5479b7-cd2d-492a-ab58-f329e612e693" />


<img width="418" height="721" alt="image" src="https://github.com/user-attachments/assets/2f575c88-a265-4b90-b3c4-b8c08c3f0c83" />


### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [X] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [ ] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Standardizes model filtering logic across components using a new utility function `filterOpenRouterModelIds`.
> 
>   - **Behavior**:
>     - Introduces `filterOpenRouterModelIds` in `providerUtils.ts` to standardize model filtering.
>     - Applies consistent filtering in `ModelPickerModal` and `OpenRouterModelPicker`.
>     - For `cline` provider: excludes `:free` models except `Minimax`.
>     - For `OpenRouter`/`Vercel`: excludes `cline/` prefixed models.
>   - **Components**:
>     - Updates `ModelPickerModal` to use `filterOpenRouterModelIds` for model filtering.
>     - Updates `OpenRouterModelPicker` to use `filterOpenRouterModelIds` for model filtering.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 43fd758e0185c0d779478db76c34320cdde82890. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->