### PR TITLE
fix: skip OAuth for MCP servers with custom Authorization header

### DIFF
--- a/src/services/mcp/McpHub.ts
+++ b/src/services/mcp/McpHub.ts
@@ -250,8 +250,10 @@ export class McpHub {
 			let transport: StdioClientTransport | SSEClientTransport | StreamableHTTPClientTransport
 
 			// Create OAuth provider for remote transports (SSE and HTTP)
+			// Skip OAuth if user has provided custom Authorization header
+			const hasCustomAuth = config.headers?.["Authorization"] || config.headers?.["authorization"]
 			const authProvider =
-				config.type === "sse" || config.type === "streamableHttp"
+				(config.type === "sse" || config.type === "streamableHttp") && !hasCustomAuth
 					? await this.mcpOAuthManager.getOrCreateProvider(name, config.url)
 					: undefined
 


### PR DESCRIPTION
## Summary
- When a user provides a custom Authorization header in their MCP server config, skip creating the OAuth provider
- This allows users to authenticate with their own tokens/credentials instead of going through the OAuth flow

## Changes
- Check for custom `Authorization` header (case-insensitive) before creating OAuth provider
- Only affects SSE and streamableHttp transport types

## Test plan
- [x] Unit tests pass (592 webview + 430 backend)
- [x] Manual testing confirms custom Authorization headers are now sent correctly to MCP servers

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Skips OAuth provider creation in `McpHub.ts` for `sse` and `streamableHttp` transports if a custom Authorization header is provided.
> 
>   - **Behavior**:
>     - Skips OAuth provider creation in `connectToServer()` in `McpHub.ts` if a custom `Authorization` header is present in MCP server config.
>     - Affects only `sse` and `streamableHttp` transport types.
>   - **Testing**:
>     - Unit tests pass (592 webview + 430 backend).
>     - Manual testing confirms custom Authorization headers are sent correctly.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 566644038562a04e210f6da379b80a967c3884fc. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->