### PR TITLE
feat: Enforce remote config's local MCP market place settings and filter by allowlist and source

### DIFF
--- a/src/services/mcp/McpHub.ts
+++ b/src/services/mcp/McpHub.ts
@@ -226,7 +226,7 @@ export class McpHub {
 
 			if (remoteConfig.blockPersonalRemoteMCPServers === true) {
 				const remoteMCPServers = remoteConfig.remoteMCPServers || []
-				const allowedUrls = remoteMCPServers.map((server: { name: string; url: string }) => server.url)
+				const allowedUrls = remoteMCPServers.map((server) => server.url)
 
 				if (!allowedUrls.includes(config.url)) {
 					return
@@ -236,7 +236,6 @@ export class McpHub {
 
 		// Validate local MCP servers based on remote config
 		if (config.type === "stdio") {
-			const { StateManager } = await import("@core/storage/StateManager")
 			const stateManager = StateManager.get()
 			const remoteConfig = stateManager.getRemoteConfigSettings()
 


### PR DESCRIPTION
### Related Issue

closes https://linear.app/cline-bot/issue/PF-372/add-conditional-logic-to-load-local-mcp-servers-without-url
part of https://linear.app/cline-bot/issue/PF-286/extension-mcp-remote-server-configuration

### Description

This PR add enforcement from remote config's local MCP market place settings and filter by allowlist and source (GitHub only). See this comment for the rules: https://linear.app/cline-bot/issue/PF-286/extension-mcp-remote-server-configuration#comment-8d4db004

### Test Procedure

*Semgrep not in the allowlist and therefore not loaded*

<img width="700" height="500" alt="Screenshot 2025-12-12 at 1 39 20 PM" src="https://github.com/user-attachments/assets/8ef7299f-2c46-4119-bb50-79c5436cca08" />

<img width="700" height="300" alt="Screenshot 2025-12-12 at 1 39 29 PM" src="https://github.com/user-attachments/assets/59e36191-e1b0-41dc-ac82-d0a2b0dc1d06" />

*MCP market place is turned off via remote config: 

<img width="700" height="500" alt="Screenshot 2025-12-12 at 2 45 48 PM" src="https://github.com/user-attachments/assets/081b28df-93eb-4971-bbb6-d06be645bad0" />

*Jetbrain mcp isn't allowed because its url is not from GitHub

<img width="700" height="500" alt="Screenshot 2025-12-12 at 2 51 03 PM" src="https://github.com/user-attachments/assets/91b6d51f-ae83-4665-98e5-1ba3d74c6b3e" />



### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Enforces remote config settings for local MCP marketplace servers in `McpHub.ts`, filtering by allowlist and GitHub source.
> 
>   - **Behavior**:
>     - Enforces remote config settings for local MCP marketplace servers in `McpHub.ts`.
>     - Filters servers by allowlist and source (GitHub only) in `connectToServer()`.
>     - Blocks all local servers if marketplace is disabled.
>   - **Validation**:
>     - Validates GitHub marketplace servers against allowlist.
>     - Blocks non-GitHub local servers if no allowlist is configured.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for c3b389c3dc2042b9adabffaf129bdcb943208898. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->