### PR TITLE
feat(openai): add xhigh reasoning effort for Responses API

### DIFF
--- a/cli/pkg/cli/task/settings_parser.go
+++ b/cli/pkg/cli/task/settings_parser.go
@@ -570,8 +570,10 @@ func parseOpenaiReasoningEffort(value string) (cline.OpenaiReasoningEffort, erro
 		return cline.OpenaiReasoningEffort_MEDIUM, nil
 	case "high":
 		return cline.OpenaiReasoningEffort_HIGH, nil
+	case "xhigh":
+		return cline.OpenaiReasoningEffort_XHIGH, nil
 	default:
-		return cline.OpenaiReasoningEffort_LOW, fmt.Errorf("invalid openai_reasoning_effort '%s': expected low/medium/high", value)
+		return cline.OpenaiReasoningEffort_LOW, fmt.Errorf("invalid openai_reasoning_effort '%s': expected low/medium/high/xhigh", value)
 	}
 }
 

--- a/proto/cline/state.proto
+++ b/proto/cline/state.proto
@@ -273,6 +273,7 @@ enum OpenaiReasoningEffort {
   MEDIUM = 1;
   HIGH = 2;
   MINIMAL = 3;
+  XHIGH = 4;
 }
 
 enum McpDisplayMode {

--- a/src/core/api/providers/__tests__/openai-native.test.ts
+++ b/src/core/api/providers/__tests__/openai-native.test.ts
@@ -1,0 +1,49 @@
+import { expect } from "chai"
+import sinon from "sinon"
+import { OpenAiNativeHandler } from "../openai-native"
+
+const createAsyncIterable = (data: any[] = []) => {
+	return {
+		[Symbol.asyncIterator]: async function* () {
+			yield* data
+		},
+	}
+}
+
+describe("OpenAiNativeHandler (Responses API)", () => {
+	it("sends reasoning.effort=xhigh when configured", async () => {
+		const fakeClient = {
+			responses: {
+				create: sinon.stub().resolves(createAsyncIterable([])),
+			},
+		}
+
+		const handler = new OpenAiNativeHandler({
+			openAiNativeApiKey: "test-api-key",
+			apiModelId: "gpt-5.1-codex",
+			reasoningEffort: "xhigh",
+		})
+
+		sinon.stub(handler, "ensureClient" as any).returns(fakeClient)
+
+		const tools = [
+			{
+				type: "function",
+				function: {
+					name: "noop",
+					description: "noop",
+					parameters: { type: "object", properties: {} },
+					strict: true,
+				},
+			},
+		] as any
+
+		for await (const _ of handler.createMessage("system", [], tools)) {
+		}
+
+		sinon.assert.calledOnce(fakeClient.responses.create)
+		const callArgs = fakeClient.responses.create.getCall(0).args[0]
+		expect(callArgs.reasoning?.effort).to.equal("xhigh")
+	})
+})
+

--- a/src/core/api/providers/openai-native.ts
+++ b/src/core/api/providers/openai-native.ts
@@ -182,7 +182,10 @@ export class OpenAiNativeHandler implements ApiHandler {
 			tools: responseTools,
 			// previous_response_id,
 			// store: true,
-			reasoning: { effort: "medium", summary: "auto" },
+			reasoning: {
+				effort: this.options.reasoningEffort || "medium",
+				summary: "auto",
+			} as any,
 			// include: ["reasoning.encrypted_content"],
 		})
 

--- a/src/core/controller/state/updateSettings.ts
+++ b/src/core/controller/state/updateSettings.ts
@@ -119,6 +119,9 @@ export async function updateSettings(controller: Controller, request: UpdateSett
 				case ProtoOpenaiReasoningEffort.MINIMAL:
 					reasoningEffort = "minimal"
 					break
+				case ProtoOpenaiReasoningEffort.XHIGH:
+					reasoningEffort = "xhigh"
+					break
 				default:
 					throw new Error(`Invalid OpenAI reasoning effort value: ${request.openaiReasoningEffort}`)
 			}

--- a/src/core/controller/state/updateSettingsCli.ts
+++ b/src/core/controller/state/updateSettingsCli.ts
@@ -34,6 +34,8 @@ export async function updateSettingsCli(controller: Controller, request: UpdateS
 				return "high"
 			case ProtoOpenaiReasoningEffort.MINIMAL:
 				return "minimal"
+			case ProtoOpenaiReasoningEffort.XHIGH:
+				return "xhigh"
 			default:
 				return "medium"
 		}

--- a/src/core/controller/state/updateTaskSettings.ts
+++ b/src/core/controller/state/updateTaskSettings.ts
@@ -25,6 +25,8 @@ export async function updateTaskSettings(controller: Controller, request: Update
 				return "high"
 			case ProtoOpenaiReasoningEffort.MINIMAL:
 				return "minimal"
+			case ProtoOpenaiReasoningEffort.XHIGH:
+				return "xhigh"
 			default:
 				return "medium"
 		}

--- a/src/core/controller/task/newTask.ts
+++ b/src/core/controller/task/newTask.ts
@@ -23,6 +23,8 @@ export async function newTask(controller: Controller, request: NewTaskRequest): 
 				return "high"
 			case ProtoOpenaiReasoningEffort.MINIMAL:
 				return "minimal"
+			case ProtoOpenaiReasoningEffort.XHIGH:
+				return "xhigh"
 			default:
 				return "medium"
 		}

--- a/src/shared/storage/types.ts
+++ b/src/shared/storage/types.ts
@@ -1,3 +1,3 @@
-export type OpenaiReasoningEffort = "minimal" | "low" | "medium" | "high"
+export type OpenaiReasoningEffort = "minimal" | "low" | "medium" | "high" | "xhigh"
 
 export type Mode = "plan" | "act"

--- a/webview-ui/src/components/settings/sections/FeatureSettingsSection.tsx
+++ b/webview-ui/src/components/settings/sections/FeatureSettingsSection.tsx
@@ -225,11 +225,12 @@ const FeatureSettingsSection = ({ renderSectionHeader }: FeatureSettingsSectionP
 								const newValue = e.target.currentValue as OpenaiReasoningEffort
 								handleReasoningEffortChange(newValue)
 							}}>
-							<VSCodeOption value="minimal">Minimal</VSCodeOption>
-							<VSCodeOption value="low">Low</VSCodeOption>
-							<VSCodeOption value="medium">Medium</VSCodeOption>
-							<VSCodeOption value="high">High</VSCodeOption>
-						</VSCodeDropdown>
+								<VSCodeOption value="minimal">Minimal</VSCodeOption>
+								<VSCodeOption value="low">Low</VSCodeOption>
+								<VSCodeOption value="medium">Medium</VSCodeOption>
+								<VSCodeOption value="high">High</VSCodeOption>
+								<VSCodeOption value="xhigh">X-High</VSCodeOption>
+							</VSCodeDropdown>
 						<p className="text-xs mt-[5px] text-(--vscode-descriptionForeground)">
 							Reasoning effort for the OpenAI family of models(applies to all OpenAI model providers)
 						</p>

--- a/webview-ui/src/components/settings/utils/settingsHandlers.ts
+++ b/webview-ui/src/components/settings/utils/settingsHandlers.ts
@@ -19,6 +19,8 @@ const convertToProtoValue = (field: keyof UpdateSettingsRequest, value: any): an
 				return OpenaiReasoningEffort.MEDIUM
 			case "high":
 				return OpenaiReasoningEffort.HIGH
+			case "xhigh":
+				return OpenaiReasoningEffort.XHIGH
 			default:
 				throw new Error(`Invalid OpenAI reasoning effort value: ${value}`)
 		}


### PR DESCRIPTION
### Summary
Adds `xhigh` as an OpenAI reasoning effort option and forwards it through to the OpenAI **Responses API** request payload for allowlisted OpenAI Native models.

### Changes
- Add `XHIGH` to the proto enum and CLI parsing.
- Add `xhigh` to stored reasoning effort type + settings UI dropdown.
- Map proto enum ↔ string in controller update paths.
- For OpenAI Native Responses API models, send `reasoning.effort` from user configuration (previously hardcoded to `medium`).
- Add a unit test asserting `reasoning.effort=xhigh` is passed to `client.responses.create`.

- ### Notes
- The Responses API path is used only when the selected OpenAI Native model has `apiFormat: OPENAI_RESPONSES` (i.e. allowlisted models).
 
### Testing
- Not run locally.