### PR TITLE
refactor: bedrock proxy

### DIFF
--- a/src/core/api/providers/bedrock.ts
+++ b/src/core/api/providers/bedrock.ts
@@ -9,6 +9,7 @@ import {
 } from "@aws-sdk/client-bedrock-runtime"
 import { fromNodeProviderChain } from "@aws-sdk/credential-providers"
 import { BedrockModelId, bedrockDefaultModelId, bedrockModels, CLAUDE_SONNET_1M_SUFFIX, ModelInfo } from "@shared/api"
+import { NodeHttp2Handler } from "@smithy/node-http-handler"
 import { calculateApiCostOpenAI, calculateApiCostQwen } from "@utils/cost"
 import { ExtensionRegistryInfo } from "@/registry"
 import { ClineStorageMessage } from "@/shared/messages/content"
@@ -285,6 +286,9 @@ export class AwsBedrockHandler implements ApiHandler {
 			region: this.getRegion(),
 			...auth,
 			...(this.options.awsBedrockEndpoint && { endpoint: this.options.awsBedrockEndpoint }),
+			requestHandler: NodeHttp2Handler.create({
+				disableConcurrentStreams: false,
+			}),
 		})
 	}
 


### PR DESCRIPTION
This PR addresses a compatibility issue with Caddy reverse proxy when using Bedrock API with custom VPC endpoints.

### Description

This PR changes the Bedrock Runtime Client configuration to use `disableConcurrentStreams: false` instead of the Bedrock-specific default value of `true`.

**Problem:**

The AWS Bedrock Runtime Client has a unique configuration where it explicitly sets `disableConcurrentStreams: true` as the default value in its runtime configuration. This is different from the underlying `@smithy/node-http-handler` package, which uses `false` as the default to enable HTTP/2 multiplexing.

When `disableConcurrentStreams: true`, the HTTP/2 handler calls `session.close()` after each request, sending an HTTP/2 GOAWAY frame. While nginx handles GOAWAY gracefully by continuing to process active streams, Caddy's HTTP/2 implementation aggressively closes connections when it receives a GOAWAY frame, terminating active streams prematurely.

This results in:
- Streaming responses being truncated after only a few chunks
- "Invalid API Response: The provider returned an empty or unparsable response" errors in Cline
- Connection failures when using Bedrock through Caddy reverse proxy
- `ERR_HTTP2_STREAM_CANCEL` errors

**Why Bedrock differs from other AWS services:**

The Bedrock Runtime Client is the only AWS SDK client that explicitly overrides the default `@smithy/node-http-handler` behavior. Most AWS SDK clients like S3, DynamoDB, and Lambda rely on the default connection reuse behavior. This appears to be a conservative choice for handling long-running streaming responses, but it creates compatibility issues with certain reverse proxy implementations.

**Why this change is correct:**

1. ~~**AWS Official Recommendation**: AWS's own documentation for Amazon Nova bidirectional streaming explicitly shows `disableConcurrentStreams: false` as the recommended configuration~~
2. **Aligns with `@smithy/node-http-handler` defaults**: This change restores the standard behavior expected from the underlying HTTP handler
3. **Better Performance**: Connection reuse reduces latency and overhead from establishing new HTTP/2 sessions
4. **Proxy Compatibility**: Eliminates compatibility issues with Caddy and other reverse proxies that may not handle `session.close()` gracefully

**Use Case:**

Users who configure Bedrock custom VPC endpoints to point to their own proxy servers (for logging, caching, or routing purposes) will benefit from this change, particularly when using Caddy as the reverse proxy.

### Test Procedure

**Testing Environment:**
- Cline VSCode extension connected to Bedrock API
- Caddy reverse proxy configuration:
```caddy
:8080 {
    tls /path/to/cert.pem /path/to/key.pem
    reverse_proxy http://backend:2020 {
        flush_interval -1
        transport http {
            versions 1.1
        }
    }
}
```
- Bedrock custom VPC endpoint configured to point to the Caddy proxy
- NestJS + Fastify backend proxying to actual Bedrock endpoint

**Before the change:**
1. Made API requests through Cline
3. Observed truncated responses after first few chunks
4. Got "Invalid API Response: The provider returned an empty or unparsable response" errors
5. Connection was terminated prematurely with `ERR_HTTP2_STREAM_CANCEL` errors

**After the change:**
1. Made multiple API requests through Cline
2. All streaming responses completed successfully
3. No connection errors or truncated responses
4. Verified that HTTP/2 sessions are being reused efficiently

**Additional verification:**
- Tested with direct Bedrock endpoint (no proxy) - works correctly both before and after
- Tested with nginx reverse proxy - works correctly (both before and after)
- Tested with Caddy reverse proxy - now works correctly with this change (was broken before)
- Confirmed no breaking changes for users not using reverse proxies
- Verified behavior matches AWS Nova documentation recommendations

### Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ♻️ Refactor Changes
- [ ] 💅 Cosmetic Changes
- [ ] 📚 Documentation update
- [ ] 🏃 Workflow Changes

### Pre-flight Checklist

- [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
- [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
- [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
- [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshot
Before
<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/d14b5c1a-a70a-4a5a-bffa-5cdb1ffabf07" />

After
<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/03597804-50ec-4d43-a252-a29fe95bb5ca" />



### Additional Notes

**Background on `disableConcurrentStreams`:**

This setting controls whether the HTTP/2 handler creates a new session for each request (`true`) or reuses existing sessions for multiple concurrent requests (`false`).

When `disableConcurrentStreams: true`:
- Each request gets its own HTTP/2 session
- Session is closed immediately after the request via `session.close()`
- This sends an HTTP/2 GOAWAY frame

**Why Bedrock Runtime Client differs from other AWS services:**

The Bedrock Runtime Client is the only AWS SDK client that explicitly overrides the default `@smithy/node-http-handler` behavior by setting `disableConcurrentStreams: true` in its `runtimeConfig.ts`:
```typescript
requestHandler: NodeHttp2Handler.create(
  config?.requestHandler ?? (async () => ({ 
    ...(await defaultConfigProvider()), 
    disableConcurrentStreams: true 
  }))
)
```

In contrast:
- The underlying `@smithy/node-http-handler` package defaults to `disableConcurrentStreams: false`
- DynamoDB, S3, and other AWS service clients use the default connection reuse behavior
- AWS's own Nova documentation recommends `disableConcurrentStreams: false` for bidirectional streaming

**The Caddy issue:**

While nginx handles HTTP/2 GOAWAY frames gracefully by continuing to process active streams, Caddy's implementation can prematurely close connections when receiving GOAWAY. This is a known behavioral difference between reverse proxy implementations.

**Related AWS SDK Issues:**
- aws/aws-sdk-js-v3#4423 discusses race conditions with destroyed sessions when using `disableConcurrentStreams`
- aws/aws-sdk-js-v3#3809 shows consecutive requests failing without session reuse

This change aligns Cline's Bedrock client configuration with AWS best practices, the underlying `@smithy/node-http-handler` defaults, and improves compatibility with modern reverse proxy deployments.

**For reviewers:**

If you'd like to test this with Caddy specifically, I can provide a complete docker-compose setup that reproduces the issue and demonstrates the fix.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Refactor `AwsBedrockHandler` in `bedrock.ts` to set `disableConcurrentStreams` to `false`, improving compatibility with Caddy reverse proxy.
> 
>   - **Behavior**:
>     - Change `disableConcurrentStreams` to `false` in `AwsBedrockHandler` in `bedrock.ts` to fix compatibility with Caddy reverse proxy.
>     - Aligns with AWS Nova documentation and `@smithy/node-http-handler` defaults.
>     - Improves performance by enabling HTTP/2 multiplexing.
>   - **Use Case**:
>     - Benefits users with custom VPC endpoints using Caddy for logging, caching, or routing.
>   - **Testing**:
>     - Verified with Cline VSCode extension, Caddy, and nginx proxies.
>     - Confirmed no breaking changes for non-proxy users.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 964c2253e8b624b4f10b7e9910f3a99e4449847b. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->