### PR TITLE
fix: correct IS_STANDALONE env check to use string comparison

### DIFF
--- a/.changeset/fix-proxy-standalone-check.md
+++ b/.changeset/fix-proxy-standalone-check.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Fixed TLS/proxy issues for users behind corporate MITM inspection proxies by correcting the IS_STANDALONE environment variable check. The check now uses explicit string comparison (`=== "true"`) instead of truthy evaluation, which was incorrectly triggering standalone mode in VSCode builds because the string `"false"` is truthy in JavaScript.

--- a/src/shared/net.ts
+++ b/src/shared/net.ts
@@ -112,8 +112,9 @@ export const fetch: typeof globalThis.fetch = (() => {
 
 	let baseFetch: typeof globalThis.fetch = globalThis.fetch
 	// Note: See esbuild.mjs, process.env.IS_STANDALONE is statically rewritten
-	// 'true' in the JetBrains/CLI build.
-	if (process.env.IS_STANDALONE) {
+	// to "true" or "false" (as strings) in the JetBrains/CLI build.
+	// We must use explicit string comparison because "false" is truthy in JS.
+	if (process.env.IS_STANDALONE === "true") {
 		// Configure undici with ProxyAgent
 		const agent = new EnvHttpProxyAgent({})
 		setGlobalDispatcher(agent)


### PR DESCRIPTION
### Problem

Users behind corporate MITM (Man-in-the-Middle) inspection proxies were experiencing TLS verification failures and high CPU load in VSCode (issues #8080 and #8090).

### Root Cause

The `IS_STANDALONE` environment variable is statically rewritten by esbuild to `"true"` or `"false"` **as strings**. The original code used a truthy check(Before PR https://github.com/cline/cline/pull/7927):

```javascript
if (process.env.IS_STANDALONE) {  // BUG: "false" is truthy!
```

In JavaScript, the string `"false"` is truthy (non-empty string), so VSCode builds were incorrectly entering standalone mode. This caused:
- `setGlobalDispatcher()` to configure undici's proxy agent
- VSCode's built-in fetch (which handles proxy/TLS correctly) to be bypassed
- TLS failures for users behind corporate MITM proxies that require OS certificate trust

### Fix

Changed to explicit string comparison:

```javascript
if (process.env.IS_STANDALONE === "true") {  // Correct!
```

### Impact

| Platform | Before Fix | After Fix |
|----------|-----------|-----------|
| **VSCode** | ❌ Incorrectly used undici (broke MITM proxies) | ✅ Uses VSCode's native fetch |
| **JetBrains** | ✅ Correctly used undici | ✅ No change (still uses undici) |
| **CLI** | ✅ Correctly used undici | ✅ No change (still uses undici) |

### Test Procedure

1. Build a local VSIX package with this fix
2. Install in VSCode configured with a MITM proxy
3. Send a test message in chat - should work without TLS errors
4. Also verified in JetBrains that proxy routing still works correctly

**Note:** JetBrains works with or without this fix since it always runs in standalone mode (`IS_STANDALONE = "true"`).

### Related Issues

- Fixes #8080 (TLS verification failures)
- Fixes #8090 (High CPU load)


### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [X] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [ ] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes `IS_STANDALONE` check in `net.ts` to use string comparison, preventing incorrect standalone mode activation in VSCode builds.
> 
>   - **Behavior**:
>     - Fixes `IS_STANDALONE` environment variable check in `net.ts` to use `=== "true"` for string comparison, preventing incorrect standalone mode activation.
>   - **Misc**:
>     - Adds changeset `fix-proxy-standalone-check.md` documenting the fix for TLS/proxy issues in MITM proxy environments.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 18f58d6791099738d9b41d034e8efd703a348ed4. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->