### PR TITLE
DEVREL-65 docs(mcp): document env var references for secrets

### DIFF
--- a/docs/mcp/configuring-mcp-servers.mdx
+++ b/docs/mcp/configuring-mcp-servers.mdx
@@ -63,13 +63,9 @@ The file uses a JSON format with a `mcpServers` object containing named server c
 
 ### Referencing environment variables
 
-If you need to add secrets (API keys, tokens, credentials), do not hardcode them in `cline_mcp_settings.json`.
+You can reference environment variables in your MCP server configuration using `${env:VAR_NAME}` syntax. Cline expands these values at runtime while keeping the `${env:...}` placeholder in the settings file, so your secrets never get written to disk.
 
-Instead, reference an environment variable with `${env:VAR_NAME}`.
-
-Cline expands these values at runtime, but keeps the `${env:...}` string in the settings file so your secrets do not get written to disk.
-
-#### Why we recommend this
+#### Why use environment variables
 
 Most MCP servers need credentials somewhere.
 

--- a/docs/mcp/configuring-mcp-servers.mdx
+++ b/docs/mcp/configuring-mcp-servers.mdx
@@ -59,7 +59,32 @@ Settings for all installed MCP servers are located in the `cline_mcp_settings.js
 2. Select the "Configure" tab.
 3. Click the "Configure MCP Servers" button at the bottom of the pane.
 
-The file uses a JSON format with a `mcpServers` object containing named server configurations:
+The file uses a JSON format with a `mcpServers` object containing named server configurations.
+
+### Referencing environment variables
+
+If you need to add secrets (API keys, tokens, credentials), do not hardcode them in `cline_mcp_settings.json`.
+
+Instead, reference an environment variable with `${env:VAR_NAME}`.
+
+Cline expands these values at runtime, but keeps the `${env:...}` string in the settings file so your secrets do not get written to disk.
+
+#### Why we recommend this
+
+Most MCP servers need credentials somewhere.
+
+- Local STDIO servers often read secrets from their process environment (for example `API_KEY` in an `env` block).
+- Remote servers often expect secrets in request headers (for example `Authorization: Bearer ...`).
+
+Hardcoding these values in a JSON settings file makes them easy to leak through normal workflows like commits, diffs, screenshots, and copy-pasted snippets.
+
+Environment variables keep the secret out of the file, make rotation easier, and make the config safe to share.
+
+<Note>
+If the environment variable is not set, Cline leaves the `${env:VAR_NAME}` value unchanged and the server will likely fail to connect.
+</Note>
+
+#### Example: STDIO server env vars
 
 ```json
 {
@@ -68,7 +93,7 @@ The file uses a JSON format with a `mcpServers` object containing named server c
 			"command": "python",
 			"args": ["/path/to/server.py"],
 			"env": {
-				"API_KEY": "your_api_key"
+				"API_KEY": "${env:MY_SERVER_API_KEY}"
 			},
 			"alwaysAllow": ["tool1", "tool2"],
 			"disabled": false
@@ -77,7 +102,24 @@ The file uses a JSON format with a `mcpServers` object containing named server c
 }
 ```
 
-_Example of MCP Server config in Cline (STDIO Transport)_
+#### Example: Remote server auth headers
+
+```json
+{
+	"mcpServers": {
+		"remote-server": {
+			"type": "streamableHttp",
+			"url": "https://your-server-url.com/mcp",
+			"headers": {
+				"Authorization": "Bearer ${env:MY_MCP_TOKEN}"
+			},
+			"disabled": false
+		}
+	}
+}
+```
+
+_Examples of MCP server config using environment variable references_
 
 ---
 

--- a/docs/mcp/configuring-mcp-servers.mdx
+++ b/docs/mcp/configuring-mcp-servers.mdx
@@ -133,25 +133,9 @@ Used for local servers running on your machine:
 -   Simpler setup (no HTTP server needed)
 -   Runs as a child process on your machine
 
+STDIO servers use `command` and `args` fields to launch the server process. See the [STDIO example above](#example-stdio-server-env-vars) for a complete configuration.
+
 For more in-depth information about how STDIO transport works, see [MCP Transport Mechanisms](/mcp/mcp-transport-mechanisms).
-
-STDIO configuration example:
-
-```json
-{
-	"mcpServers": {
-		"local-server": {
-			"command": "node",
-			"args": ["/path/to/server.js"],
-			"env": {
-				"API_KEY": "your_api_key"
-			},
-			"alwaysAllow": ["tool1", "tool2"],
-			"disabled": false
-		}
-	}
-}
-```
 
 ### SSE Transport
 
@@ -163,24 +147,9 @@ Used for remote servers accessed over HTTP/HTTPS:
 -   Requires network access
 -   Allows centralized deployment and management
 
+SSE servers use `url` and optional `headers` fields for authentication. See the [remote server example above](#example-remote-server-auth-headers) for a complete configuration.
+
 For more in-depth information about how SSE transport works, see [MCP Transport Mechanisms](/mcp/mcp-transport-mechanisms).
-
-SSE configuration example:
-
-```json
-{
-	"mcpServers": {
-		"remote-server": {
-			"url": "https://your-server-url.com/mcp",
-			"headers": {
-				"Authorization": "Bearer your-token"
-			},
-			"alwaysAllow": ["tool3"],
-			"disabled": false
-		}
-	}
-}
-```
 
 ---
 

--- a/docs/mcp/configuring-mcp-servers.mdx
+++ b/docs/mcp/configuring-mcp-servers.mdx
@@ -61,11 +61,11 @@ Settings for all installed MCP servers are located in the `cline_mcp_settings.js
 
 The file uses a JSON format with a `mcpServers` object containing named server configurations.
 
-### Referencing environment variables
+## Referencing environment variables
 
 You can reference environment variables in your MCP server configuration using `${env:VAR_NAME}` syntax. Cline expands these values at runtime while keeping the `${env:...}` placeholder in the settings file, so your secrets never get written to disk.
 
-#### Why use environment variables
+### Why use environment variables
 
 Most MCP servers need credentials somewhere.
 

--- a/docs/mcp/connecting-to-a-remote-server.mdx
+++ b/docs/mcp/connecting-to-a-remote-server.mdx
@@ -156,6 +156,10 @@ Key configuration options:
 -   **autoApprove**: List of tool names that don't require confirmation
 -   **timeout**: Maximum time in seconds to wait for server responses (default: 60)
 
+<Tip>
+For auth tokens, use `${env:VAR_NAME}` inside `headers` instead of hardcoding secrets in `cline_mcp_settings.json`. See <a href="/mcp/configuring-mcp-servers#referencing-environment-variables">Referencing environment variables</a>.
+</Tip>
+
 For additional MCP settings, click the "Advanced MCP Settings" link to access VSCode settings.
 
 ### Using MCP Server Tools


### PR DESCRIPTION
This pull request updates the MCP server configuration documentation to strongly recommend referencing environment variables for secrets (like API keys and tokens) instead of hardcoding them in `cline_mcp_settings.json`. It provides clear guidance and examples for both local and remote MCP server setups, and adds a tip to related documentation to reinforce this best practice.

**Improvements to security and documentation:**

* Added a new section explaining how to reference environment variables in MCP server settings files, including why this approach is recommended and a note about failure modes if the variable is not set.
* Updated the STDIO server example to show using an environment variable reference (`"${env:MY_SERVER_API_KEY}"`) instead of a hardcoded API key.
* Added a new example for remote servers, demonstrating how to use environment variable references in HTTP authorization headers.
* Added a tip to the remote server connection documentation, advising users to use environment variable references for auth tokens and linking to the new documentation section.
<!-- ELLIPSIS_HIDDEN -->

DEVREL-65
----

> [!IMPORTANT]
> Update MCP server configuration docs to recommend using environment variables for secrets, enhancing security.
> 
>   - **Security and Documentation**:
>     - Strongly recommend using environment variables for secrets in `cline_mcp_settings.json`.
>     - Add section on referencing environment variables in `configuring-mcp-servers.mdx`, explaining benefits and failure modes.
>     - Update STDIO server example to use `${env:MY_SERVER_API_KEY}`.
>     - Add remote server example using `${env:MY_MCP_TOKEN}` in HTTP headers.
>     - Add tip in `connecting-to-a-remote-server.mdx` to use environment variables for auth tokens.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 2370d9d88f6e17bea73824dfd8815ec6307fb258. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->