### PR TITLE
feat: Enable extensions to send os types as query param for banners

### DIFF
--- a/src/services/banner/BannerService.test.ts
+++ b/src/services/banner/BannerService.test.ts
@@ -424,9 +424,15 @@ describe("BannerService", () => {
 				}
 
 				axiosGetStub.resolves(mockResponse)
+
+				// Clear cache to ensure fresh API call for each platform test
+				bannerService.clearCache()
+
 				await bannerService.fetchActiveBanners()
 
-				const call = axiosGetStub.getCall(axiosGetStub.callCount - 1)
+				expect(axiosGetStub.called).to.be.true
+				const call = axiosGetStub.lastCall
+				expect(call).to.not.be.null
 				const url = call.args[0]
 				expect(url).to.include(`os=${expected}`)
 
@@ -435,7 +441,7 @@ describe("BannerService", () => {
 					configurable: true,
 				})
 
-				axiosGetStub.reset()
+				axiosGetStub.resetHistory()
 			}
 		})
 	})

--- a/src/services/banner/BannerService.ts
+++ b/src/services/banner/BannerService.ts
@@ -232,15 +232,15 @@ export class BannerService {
 	 */
 	private async getOSType(): Promise<string> {
 		try {
-			const raw_os_type = process.platform
-			if (raw_os_type.includes("win32")) {
-				return "windows"
-			} else if (raw_os_type.includes("linux")) {
-				return "linux"
-			} else if (raw_os_type.includes("macos")) {
-				return "macos"
-			} else {
-				return "unknown"
+			switch (process.platform) {
+				case "win32":
+					return "windows"
+				case "linux":
+					return "linux"
+				case "darwin":
+					return "macos"
+				default:
+					return "unknown"
 			}
 		} catch (error) {
 			Logger.error("BannerService: Error getting OS type", error)


### PR DESCRIPTION
### Related Issue

closes https://linear.app/cline-bot/issue/PF-369/p1-add-operating-system-type-to-core-api-banner-rule-evaluation

### Description

This PR enables extensions to send os types as query param for banners endpoint.

### Test Procedure

<!-- 
Please walk us through your testing approach and thought process. This helps reviewers understand that you've thoroughly considered the impact of your changes:

- How did you test this change?
- What could potentially break and how did you verify it doesn't?
- What existing functionality might be affected and how did you check it still works?
- Why are you confident this is ready for merge?

We're not looking for exhaustive documentation - just evidence that you've thought through the implications of your changes and tested accordingly.
-->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds OS type as a query parameter in `BannerService` API requests and handles detection errors gracefully.
> 
>   - **Behavior**:
>     - `fetchActiveBanners()` in `BannerService.ts` now includes `os` query parameter in API requests.
>     - Handles OS detection errors by defaulting to `os=unknown`.
>   - **Functions**:
>     - Adds `getOSType()` to `BannerService.ts` to determine OS type (`windows`, `linux`, `macos`, `unknown`).
>   - **Tests**:
>     - Adds tests in `BannerService.test.ts` to verify OS parameter inclusion and error handling for OS detection.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 5e90e69a8e9479fc270248f2325caf5845b57b46. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->