### PR TITLE
fix: handle invalid signature fields for Anthropic and Gemini providers [ENG-1349]

### DIFF
--- a/.changeset/rich-baboons-serve.md
+++ b/.changeset/rich-baboons-serve.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Fix invalid signature field issues when switching between Gemini and Anthropic providers.

--- a/src/core/api/providers/gemini.ts
+++ b/src/core/api/providers/gemini.ts
@@ -16,9 +16,6 @@ import { RetriableError, withRetry } from "../retry"
 import { convertAnthropicMessageToGemini } from "../transform/gemini-format"
 import { ApiStream } from "../transform/stream"
 
-// Define a default TTL for the cache (e.g., 15 minutes in seconds)
-const _DEFAULT_CACHE_TTL_SECONDS = 900
-
 const rateLimitPatterns = [/got status: 429/i, /429 Too Many Requests/i, /rate limit exceeded/i, /too many requests/i]
 
 interface GeminiHandlerOptions extends CommonApiHandlerOptions {

--- a/src/core/api/transform/gemini-format.ts
+++ b/src/core/api/transform/gemini-format.ts
@@ -2,6 +2,14 @@ import { Anthropic } from "@anthropic-ai/sdk"
 import { Content, GenerateContentResponse, Part } from "@google/genai"
 import { ClineStorageMessage } from "@/shared/messages/content"
 
+// Source: https://ai.google.dev/gemini-api/docs/thought-signatures#faqs
+// While injecting custom function call blocks into the request is strongly discouraged,
+// in cases where it can't be avoided, e.g. providing information to the model on function
+// calls and responses that were executed deterministically by the client, or transferring a
+// trace from a different model that does not include thought signatures, you can set the following dummy signatures of either
+// "context_engineering_is_the_way_to_go" or "skip_thought_signature_validator" in the thought signature field to skip validation.
+const GEMINI_DUMMY_THOUGHT_SIGNATURE = "skip_thought_signature_validator"
+
 export function convertAnthropicContentToGemini(content: string | ClineStorageMessage["content"]): Part[] {
 	if (typeof content === "string") {
 		return [{ text: content }]
@@ -27,7 +35,8 @@ export function convertAnthropicContentToGemini(content: string | ClineStorageMe
 							name: block.name,
 							args: block.input as Record<string, unknown>,
 						},
-						thoughtSignature: block.signature,
+						// Thought signature is required, so provide a dummy one if not present
+						thoughtSignature: block.signature || GEMINI_DUMMY_THOUGHT_SIGNATURE,
 					}
 				case "tool_result":
 					return {


### PR DESCRIPTION
<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- For feature requests: Created a discussion in our Feature Requests discussions board https://github.com/cline/cline/discussions/categories/feature-requests and received approval from core maintainers before implementation
- For all changes: Link the associated issue/discussion in the "Related Issue" section below

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly without prior discussion.

Why this requirement?
We deeply appreciate all community contributions - they are essential to Cline's success! To ensure the best use of everyone's time and maintain project direction, we use our Feature Requests discussions board to gauge community interest and validate feature ideas before implementation begins. This helps us focus development efforts on features that will benefit the most users.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** https://github.com/cline/cline/issues/7620

### Description

<!-- 
Help reviewers understand your changes by making this PR readable and well-organized:

- What problem does this PR solve?
- Why were these changes introduced and what purpose do they serve?
- For larger changes, provide context about your approach and reasoning

Small PRs may need minimal description, but larger changes benefit from explaining where you're coming from. Much of this context can be in the linked issue above, so feel free to reference it rather than repeating everything here.
-->

- Add dummy thought signature fallback for Gemini API when signature is missing
- Filter out thinking blocks without signatures before sending to Anthropic API
- Update signature field cleaning to apply to non-thinking blocks only
- Remove unused DEFAULT_CACHE_TTL_SECONDS constant

This ensures proper message conversion between providers by using Gemini's documented dummy signature "skip_thought_signature_validator" when original signature is unavailable, and prevents invalid thinking blocks from being sent to Anthropic's API which requires valid signatures.

### Test Procedure

<!-- 
Please walk us through your testing approach and thought process. This helps reviewers understand that you've thoroughly considered the impact of your changes:

- How did you test this change?
- What could potentially break and how did you verify it doesn't?
- What existing functionality might be affected and how did you check it still works?
- Why are you confident this is ready for merge?

We're not looking for exhaustive documentation - just evidence that you've thought through the implications of your changes and tested accordingly.
-->

1. Enable Native Tool Call and Extended Thinking
2. Make a plan with gemini-3-pro-preview (provider Google Gemini) in Plan mode
3. Switch to Act with Claude-sonnet-4-5-20250929 (provider: Anthropic)
4. Verify there is no error when switching between these providers

#### After: switching between gemini's gemini 3 pro and anthropic sonnet

<img width="1546" height="1196" alt="image" src="https://github.com/user-attachments/assets/ec5c3c3a-74ba-4b3e-a065-2669d8965e66" />

#### Before: 

switching from anthropic to gemini

<img width="922" height="971" alt="image" src="https://github.com/user-attachments/assets/47aeb10a-b025-4758-991b-3ad5d2fe454f" />


switching from gemini to anthropic

<img width="1538" height="543" alt="image" src="https://github.com/user-attachments/assets/f34f0a89-adbb-488e-bb5c-19051dbf5b81" />


### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes handling of invalid signature fields for Gemini and Anthropic providers by adding a dummy signature for Gemini and filtering invalid thinking blocks for Anthropic.
> 
>   - **Behavior**:
>     - Adds dummy thought signature `skip_thought_signature_validator` for Gemini API in `gemini-format.ts` when signature is missing.
>     - Filters out thinking blocks without signatures in `convertClineStorageToAnthropicMessage()` in `content.ts` before sending to Anthropic API.
>     - Updates signature field cleaning in `cleanContentBlock()` in `content.ts` to apply to non-thinking blocks only.
>   - **Misc**:
>     - Removes unused `DEFAULT_CACHE_TTL_SECONDS` constant in `gemini.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 721e9603b8ca130c72e0d96f3a3f771d426f78e0. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->