### PR TITLE
fix: Esc restores original chat contents in past chats

### DIFF
--- a/.changeset/dark-candies-check.md
+++ b/.changeset/dark-candies-check.md
@@ -1,0 +1,6 @@
+---
+"claude-dev": patch
+---
+
+Fix: Pressing Esc while editing a past chat restores the original contents
+Fix: Pressing enter while editing past chat doesn't allow empty strings

--- a/webview-ui/src/components/chat/UserMessage.tsx
+++ b/webview-ui/src/components/chat/UserMessage.tsx
@@ -78,6 +78,7 @@ const UserMessage: React.FC<UserMessageProps> = ({ text, images, files, messageT
 
 	const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
 		if (e.key === "Escape") {
+			setEditedText(text || "")
 			setIsEditing(false)
 		} else if (e.key === "Enter" && e.metaKey && !checkpointManagerErrorMessage) {
 			handleRestoreWorkspace("taskAndWorkspace")

--- a/webview-ui/src/components/chat/UserMessage.tsx
+++ b/webview-ui/src/components/chat/UserMessage.tsx
@@ -81,10 +81,16 @@ const UserMessage: React.FC<UserMessageProps> = ({ text, images, files, messageT
 			setEditedText(text || "")
 			setIsEditing(false)
 		} else if (e.key === "Enter" && e.metaKey && !checkpointManagerErrorMessage) {
-			handleRestoreWorkspace("taskAndWorkspace")
+			// Check if text is not empty before allowing restore
+			if (editedText.trim() !== "") {
+				handleRestoreWorkspace("taskAndWorkspace")
+			}
 		} else if (e.key === "Enter" && !e.shiftKey && !e.nativeEvent.isComposing && e.keyCode !== 229) {
 			e.preventDefault()
-			handleRestoreWorkspace("task")
+			// Check if text is not empty before allowing restore
+			if (editedText.trim() !== "") {
+				handleRestoreWorkspace("task")
+			}
 		}
 	}
 


### PR DESCRIPTION
<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- For feature requests: Created a discussion in our Feature Requests discussions board https://github.com/cline/cline/discussions/categories/feature-requests and received approval from core maintainers before implementation
- For all changes: Link the associated issue/discussion in the "Related Issue" section below

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly without prior discussion.

Why this requirement?
We deeply appreciate all community contributions - they are essential to Cline's success! To ensure the best use of everyone's time and maintain project direction, we use our Feature Requests discussions board to gauge community interest and validate feature ideas before implementation begins. This helps us focus development efforts on features that will benefit the most users.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** #4431

### Description

This change fixes the behavior of ESC key to cancel the edit, which was not working as expected in the text box of chat history. Instead of restoring the original contents of the text field when ESC was pressed, it was retaining any of the changes that were made during edit. 

<!-- 
Help reviewers understand your changes by making this PR readable and well-organized:

- What problem does this PR solve?
- Why were these changes introduced and what purpose do they serve?
- For larger changes, provide context about your approach and reasoning

Small PRs may need minimal description, but larger changes benefit from explaining where you're coming from. Much of this context can be in the linked issue above, so feel free to reference it rather than repeating everything here.
-->

### Test Procedure

- I ran the tests.
- I ran the extension and manually tested the code commands

<!--
Please walk us through your testing approach and thought process. This helps reviewers understand that you've thoroughly considered the impact of your changes:

- How did you test this change?
- What could potentially break and how did you verify it doesn't?
- What existing functionality might be affected and how did you check it still works?
- Why are you confident this is ready for merge?

We're not looking for exhaustive documentation - just evidence that you've thought through the implications of your changes and tested accordingly.
-->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->

- Behavior : 
   - Pressing ESC keep in the text field while editing restores the original contents.
- Misc : 
   - Adds the `tasty-kiwis-train.md` changeset to document the fix
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes ESC key behavior in `UserMessage.tsx` to restore original chat text when editing is canceled.
> 
>   - **Behavior**:
>     - In `UserMessage.tsx`, pressing ESC while editing a chat message now restores the original text by updating `handleKeyDown` to reset `editedText`.
>   - **Misc**:
>     - Adds `tasty-kiwis-train.md` changeset to document the fix.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for f15b55581d7ce2b9fe8edf1fe7bdd5e8443b409d. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->