### PR TITLE
fix(hooks): Fix edge case for hooks-enabled schema in the CLI

### DIFF
--- a/src/core/hooks/hooks-utils.ts
+++ b/src/core/hooks/hooks-utils.ts
@@ -8,16 +8,9 @@
  * @returns true if hooks are enabled and supported on this platform, false otherwise
  */
 export function getHooksEnabledSafe(userSetting: boolean | undefined): boolean {
-	// Handle legacy ClineFeatureSetting object format {user: boolean, featureFlag: boolean}
-	// This can occur if the migration hasn't run yet or if reading from an old state
-	let booleanValue: boolean
-	if (typeof userSetting === "object" && userSetting !== null) {
-		// Legacy format - extract the user preference
-		booleanValue = (userSetting as any).user === true
-	} else {
-		// Modern boolean format or undefined
-		booleanValue = userSetting ?? false
-	}
+	// Handle legacy object format: {user: boolean, featureFlag: boolean}, which
+	// can occur if the migration hasn't run yet or if reading from an old state.
+	const booleanValue = Boolean((userSetting as any)?.user ?? userSetting)
 
 	// Force hooks to false on Windows (not yet supported)
 	return process.platform === "win32" ? false : booleanValue


### PR DESCRIPTION
### Related Issue

**Issue:** n/a

### Description

__Before change:__
```
./cli/bin/cline config get hooks-enabled
hooks-enabled: map[featureFlag:false user:false]
```

__After change:__
```
./cli/bin/cline config get hooks-enabled
hooks-enabled: false
```

I noticed that the `./cli/bin/cline config get hooks-enabled` command isn't working properly for me in local development.  In [this PR](https://github.com/cline/cline/pull/7948) I introduced the `hooks-enabled` config setting for the CLI as part of wiring up hooks to work in the CLI.  In that PR I changed the schema of the corresponding feature setting from `{user: bool, featureFlag: bool}` to simply `bool`, and I included a migration to address this change.  I believe that due to my development workflow of switching back and forth among various states/commits of the code base (plus the version of the published extension, etc.) my environment reintroduced the old schema at some point.

This PR adds defensive logic inside the `getHooksEnabledSafe()` function to account for this possibility, converting to the correct expected boolean value for all of the following scenarios:

__Legacy object formats (we only care about the value of `user`):__
- `{user: true, featureFlag: false}` → `true`
- `{user: true, featureFlag: true}` → `true`
- `{user: false, featureFlag: false}` → `false`
- `{user: false, featureFlag: true}` → `false`

__Modern boolean formats:__
- `true` → `true`
- `false` → `false`
- `undefined` → `false`


### Test Procedure

To test I compiled the standalone and the CLI:
```
npm run compile-standalone-npm
npm run compile-cli
```

And then ran the locally compiled CLI:
```
./cli/bin/cline config get hooks-enabled
hooks-enabled: false

./cli/bin/cline config set hooks-enabled=true
hooks-enabled: true
```


### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

n/a

### Additional Notes

n/a
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes `hooks-enabled` schema handling in CLI by updating `getHooksEnabledSafe()` to support legacy and modern formats.
> 
>   - **Behavior**:
>     - Fixes `hooks-enabled` schema handling in CLI by updating `getHooksEnabledSafe()` in `hooks-utils.ts`.
>     - Converts legacy object format `{user: bool, featureFlag: bool}` to boolean, prioritizing `user` value.
>     - Ensures `hooks-enabled` returns `false` on Windows.
>   - **Testing**:
>     - Compiled standalone and CLI to verify changes.
>     - Tested `config get` and `config set` commands for `hooks-enabled`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 1b9beb40fdefa04d4bec7c0d8ebc22f5e2cafe14. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->