### PR TITLE
feat: implement lazy evaluation for dynamic tool instructions

### DIFF
--- a/.changeset/shaggy-coats-open.md
+++ b/.changeset/shaggy-coats-open.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+feat: implement lazy evaluation for dynamic tool instructions to support context-aware prompts

--- a/src/core/prompts/system-prompt/registry/PromptBuilder.ts
+++ b/src/core/prompts/system-prompt/registry/PromptBuilder.ts
@@ -1,6 +1,6 @@
 import type { ClineDefaultTool } from "@/shared/tools"
 import { ClineToolSet } from "../registry/ClineToolSet"
-import { type ClineToolSpec } from "../spec"
+import { type ClineToolSpec, resolveInstruction } from "../spec"
 import { STANDARD_PLACEHOLDERS } from "../templates/placeholders"
 import { TemplateEngine } from "../templates/TemplateEngine"
 import type { ComponentRegistry, PromptVariant, SystemPromptContext } from "../types"
@@ -207,21 +207,22 @@ export class PromptBuilder {
 		const sections = [
 			title,
 			description.join("\n"),
-			PromptBuilder.buildParametersSection(filteredParams),
+			PromptBuilder.buildParametersSection(filteredParams, context),
 			PromptBuilder.buildUsageSection(config.id, filteredParams),
 		]
 
 		return sections.filter(Boolean).join("\n")
 	}
 
-	private static buildParametersSection(params: any[]): string {
+	private static buildParametersSection(params: any[], context: SystemPromptContext): string {
 		if (!params.length) {
 			return "Parameters: None"
 		}
 
 		const paramList = params.map((p) => {
 			const requiredText = p.required ? "required" : "optional"
-			return `- ${p.name}: (${requiredText}) ${p.instruction}`
+			const instruction = resolveInstruction(p.instruction, context)
+			return `- ${p.name}: (${requiredText}) ${instruction}`
 		})
 
 		return ["Parameters:", ...paramList].join("\n")


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

### Description

This PR introduces a flexible infrastructure for generating dynamic tool instructions in the system prompt.

**Problem:**
Currently, tool instructions in `ClineToolSpec` are defined as static strings. This limits the ability to adapt the prompt based on runtime context—such as user settings, environment details, or specific file types—without creating entirely new tool variants or embedding complex conditional logic directly into the `PromptBuilder`.

**Solution:**
I have implemented a "Value or Provider" pattern (lazy evaluation) for tool parameter instructions. This allows an instruction to be defined either as a static string (preserving backward compatibility) or as a function that accepts the `SystemPromptContext` and returns a string.

**Key Changes:**
1.  **Type Definition Update:** Updated `ClineToolSpecParameter` in `src/core/prompts/system-prompt/spec.ts` to allow `instruction` to be `string | ((context: SystemPromptContext) => string)`.
2.  **Resolution Helper:** Added a `resolveInstruction` helper function that checks the type of the instruction and executes it if it's a function, or returns it directly if it's a string.
3.  **PromptBuilder Refactor:** Updated `PromptBuilder.ts` to pass the `SystemPromptContext` into `buildParametersSection` and use `resolveInstruction` to generate the final prompt text.

This change is purely infrastructural and agnostic to specific features, paving the way for future enhancements like context-aware notebook interactions without cluttering the core logic.

### Test Procedure

-   **Backward Compatibility:** Verified that existing tools, which all use static string instructions, continue to compile and function exactly as before. The `resolveInstruction` helper ensures that string inputs are passed through unchanged.
-   **Type Safety:** The TypeScript compiler confirms that the new union type is handled correctly in all usages within `spec.ts` and `PromptBuilder.ts`.
-   **Runtime Verification:** Ran the extension locally to ensure the system prompt is generated correctly with the existing static instructions.

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [x] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

_No UI changes. This is a backend infrastructure update._

### Additional Notes

This PR serves as the foundation for an upcoming feature that will conditionally inject specialized instructions for Jupyter Notebooks based on user settings. By merging this infrastructure first, we keep the feature implementation clean and isolated.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Implements lazy evaluation for tool instructions in `ClineToolSpecParameter`, allowing dynamic generation based on runtime context.
> 
>   - **Behavior**:
>     - Implements lazy evaluation for tool instructions in `ClineToolSpecParameter` by allowing `instruction` to be `string | ((context: SystemPromptContext) => string)` in `spec.ts`.
>     - Adds `resolveInstruction` function in `spec.ts` to evaluate instructions based on their type.
>     - Updates `PromptBuilder.ts` to use `resolveInstruction` in `buildParametersSection`.
>   - **Backward Compatibility**:
>     - Ensures existing static string instructions continue to function without changes.
>   - **Type Safety**:
>     - TypeScript compiler confirms correct handling of new union type in `spec.ts` and `PromptBuilder.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 80af13614350612352aecd52a1eb1753f2d80092. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->