### PR TITLE
fix: skip reasoning for GLM models

### DIFF
--- a/.changeset/major-groups-lie.md
+++ b/.changeset/major-groups-lie.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+fix: skip reasoning for GLM models

--- a/src/utils/model-utils.ts
+++ b/src/utils/model-utils.ts
@@ -34,7 +34,7 @@ export function shouldSkipReasoningForModel(modelId?: string): boolean {
 	if (!modelId) {
 		return false
 	}
-	return modelId.includes("grok-4") || modelId.includes("devstral")
+	return modelId.includes("grok-4") || modelId.includes("devstral") || modelId.includes("glm")
 }
 
 export function isAnthropicModelId(modelId: string): modelId is AnthropicModelId {


### PR DESCRIPTION
### Description

This PR updates `shouldSkipReasoningForModel` in `src/utils/model-utils.ts` to include GLM-4 models.

GLM-4 models output thinking content in text tags when reasoning is enabled, which is not currently supported by the UI. Disabling reasoning for these models ensures cleaner output by preventing the raw thinking tags from appearing in the chat

This would only ever sent `\n` in the reasoning block before. Not very useful.

<img width="1070" height="320" alt="Screenshot 2025-12-16 at 3 47 15 PM" src="https://github.com/user-attachments/assets/1bdab840-6d10-4c7a-ab3f-9671dbfaaf61" />

### Test Procedure

1. Configured Cline to use a GLM-4 model (e.g., `glm-4.6`).
2. Verified that without this change, the model output included empty reasoning blocks.
3. Applied the change to skip reasoning for GLM models.
4. Verified that the output is now clean and free of rendered empty thinking section.
5. Confirmed that other models (e.g., Claude) still handle reasoning correctly.

### Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ♻️ Refactor Changes
- [ ] 💅 Cosmetic Changes
- [ ] 📚 Documentation update
- [ ] 🏃 Workflow Changes

### Pre-flight Checklist

- [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
- [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
- [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
- [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)



<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Updates `shouldSkipReasoningForModel` to skip reasoning for GLM models, ensuring cleaner output by preventing unsupported thinking content.
> 
>   - **Behavior**:
>     - Updates `shouldSkipReasoningForModel` in `model-utils.ts` to skip reasoning for GLM models.
>     - Ensures GLM-4 models do not output unsupported thinking content in text tags.
>   - **Testing**:
>     - Verified GLM-4 models output cleanly without reasoning blocks.
>     - Confirmed other models like Claude still handle reasoning correctly.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 84c4c0d6c247cec946106266858eada1e2e4d2f7. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->