### PR TITLE
fix: disable auto port forwarding in workspace settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -27,5 +27,7 @@
 		"source.removeUnused.biome": "always",
 		"source.removeUnusedImports": "always",
 		"source.organizeImports.biome": "always"
-	}
+	},
+	// Disable auto-forwarding ports to prevent Simple Browser from opening the Vite dev server
+	"remote.autoForwardPorts": false
 }


### PR DESCRIPTION
### Related Issue

N/A - Minor developer experience fix

### Description

Prevents VS Code from auto-opening Simple Browser when the Vite dev server starts on port 25463 during extension development. 

When pressing F5 to debug the extension, VS Code's port forwarding feature detects the Vite dev server and auto-opens it in Simple Browser. This is confusing because the webview shows a blank page (it needs the VS Code extension context to function). The Cline webview should only render in the VS Code sidebar, not in a browser tab.

### Test Procedure

1. Open the cline workspace in VS Code
2. Press F5 to launch the Extension Development Host
3. Verify that Simple Browser no longer auto-opens with localhost:25463
4. Verify the Cline sidebar still works correctly in the Extension Development Host

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A - Internal workspace settings change

### Additional Notes

No changeset needed - this is an internal developer workflow fix, not a user-facing change.