### PR TITLE
docs: add JSON output section and ClineMessage schema to CLI reference

### DIFF
--- a/cli/man/cline.1.md
+++ b/cli/man/cline.1.md
@@ -78,6 +78,28 @@ These options apply to all subcommands:
 
 :   Output format. Options: **rich** (default), **json**, **plain**
 
+    When you use **-F json**, the CLI prints each client message as JSON.
+
+    Each message is a **ClineMessage** object.
+
+    Required fields:
+
+    - **type**: "ask" or "say"
+    - **text**: message text
+    - **ts**: Unix epoch timestamp in milliseconds
+
+    Optional fields (omitted when empty):
+
+    - **reasoning**: reasoning text
+    - **say**: say subtype (present when type is "say")
+    - **ask**: ask subtype (present when type is "ask")
+    - **partial**: streaming flag
+    - **images**: list of image URIs
+    - **files**: list of file paths
+    - **lastCheckpointHash**: git checkpoint hash
+    - **isCheckpointCheckedOut**: checkpoint checkout flag
+    - **isOperationOutsideWorkspace**: workspace safety flag
+
 **-h**, **\--help**
 
 :   Display help information for the command.

--- a/docs/cline-cli/cli-reference.mdx
+++ b/docs/cline-cli/cli-reference.mdx
@@ -377,20 +377,20 @@ When you run a command with `-F json` (or `--output-format json`), Cline prints 
 
 ### ClineMessage schema
 
-| Field | Type | Notes |
-|-------|------|-------|
-| `type` | `"ask" or "say"` | Top-level message category. |
-| `text` | `string` | Human-readable message content. |
-| `ts` | `number` | Unix epoch timestamp in milliseconds. |
-| `reasoning` | `string` | Optional. Model reasoning text when present. |
-| `say` | `string` | Optional. Present when `type` is `"say"`. |
-| `ask` | `string` | Optional. Present when `type` is `"ask"`. |
-| `partial` | `boolean` | Optional. `true` for streaming updates. |
-| `images` | `string[]` | Optional. Image URIs when included with a message. |
-| `files` | `string[]` | Optional. File paths when attached to a message. |
-| `lastCheckpointHash` | `string` | Optional. Git checkpoint hash when available. |
-| `isCheckpointCheckedOut` | `boolean` | Optional. `true` if Cline checked out a checkpoint. |
-| `isOperationOutsideWorkspace` | `boolean` | Optional. `true` if an operation happened outside the workspace. |
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `type` | `"ask" or "say"` | Yes | Top-level message category. |
+| `text` | `string` | Yes | Human-readable message content. |
+| `ts` | `number` | Yes | Unix epoch timestamp in milliseconds. |
+| `reasoning` | `string` | No | Omitted when empty. |
+| `say` | `string` | No | Omitted when empty. Present when `type` is `"say"`. |
+| `ask` | `string` | No | Omitted when empty. Present when `type` is `"ask"`. |
+| `partial` | `boolean` | No | Omitted when false. `true` for streaming updates. |
+| `images` | `string[]` | No | Omitted when empty. Image URIs when included with a message. |
+| `files` | `string[]` | No | Omitted when empty. File paths when attached to a message. |
+| `lastCheckpointHash` | `string` | No | Omitted when empty. Git checkpoint hash when available. |
+| `isCheckpointCheckedOut` | `boolean` | No | Omitted when false. `true` if Cline checked out a checkpoint. |
+| `isOperationOutsideWorkspace` | `boolean` | No | Omitted when false. `true` if an operation happened outside the workspace. |
 
 <Note>
 Most fields are optional and omitted when empty. If you parse this output, treat missing fields as “not present”, not as empty strings.


### PR DESCRIPTION
This pull request adds documentation for the JSON output format available in the Cline CLI when using the `-F json` flag. The new section describes the structure of the JSON messages, provides a schema table for the `ClineMessage` object, and includes a sample output for reference.

Documentation updates:

* Added a new section to `cli-reference.mdx` explaining the `-F json` (or `--output-format json`) flag, detailing the `ClineMessage` JSON schema, field descriptions, and an example output.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds documentation for JSON output in Cline CLI, detailing `ClineMessage` schema and example output in `cli-reference.mdx` and `cline.1.md`.
> 
>   - **Documentation**:
>     - Adds JSON output section to `cli-reference.mdx`, explaining `-F json` flag, `ClineMessage` schema, and example output.
>     - Updates `cline.1.md` to include JSON output format details under global options.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 41753c404fc94755cd8b126c463b91e728f56757. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->