### PR TITLE
fix(ui): improve WhatsNew modal design and responsiveness

### DIFF
--- a/webview-ui/src/components/common/WhatsNewModal.tsx
+++ b/webview-ui/src/components/common/WhatsNewModal.tsx
@@ -3,7 +3,6 @@ import { EmptyRequest } from "@shared/proto/cline/common"
 import React, { useCallback, useRef } from "react"
 import { useMount } from "react-use"
 import { Dialog, DialogContent } from "@/components/ui/dialog"
-import { PLATFORM_CONFIG, PlatformType } from "@/config/platform.config"
 import { useClineAuth } from "@/context/ClineAuthContext"
 import { useExtensionState } from "@/context/ExtensionStateContext"
 import { AccountServiceClient } from "@/services/grpc-client"
@@ -16,7 +15,6 @@ interface WhatsNewModalProps {
 }
 
 export const WhatsNewModal: React.FC<WhatsNewModalProps> = ({ open, onClose, version }) => {
-	const isVscode = PLATFORM_CONFIG.type === PlatformType.VSCODE
 	const { clineUser } = useClineAuth()
 	const { openRouterModels, setShowChatModelSelector, refreshOpenRouterModels } = useExtensionState()
 	const { handleFieldsChange } = useApiConfigurationHandlers()
@@ -65,7 +63,7 @@ export const WhatsNewModal: React.FC<WhatsNewModalProps> = ({ open, onClose, ver
 
 	const AuthButton: React.FC<{ children: React.ReactNode }> = ({ children }) =>
 		clineUser ? (
-			<div className="flex gap-2 flex-wrap my-1.5">{children}</div>
+			<div className="flex gap-2 flex-wrap">{children}</div>
 		) : (
 			<Button className="my-1" onClick={handleShowAccount} size="sm">
 				Sign Up with Cline
@@ -74,31 +72,20 @@ export const WhatsNewModal: React.FC<WhatsNewModalProps> = ({ open, onClose, ver
 
 	return (
 		<Dialog onOpenChange={(isOpen) => !isOpen && onClose()} open={open}>
-			<DialogContent aria-describedby="whats-new-description" aria-labelledby="whats-new-title" className="p-0 gap-0">
-				{/* Content area */}
-				<div className="p-5 pr-10" id="whats-new-description">
-					{/* Badge */}
-					<div className="mb-3">
-						<span
-							className="px-2 py-1 text-xs font-semibold rounded"
-							style={{
-								backgroundColor: "color-mix(in srgb, var(--vscode-button-background) 30%, transparent)",
-								color: "var(--vscode-button-foreground)",
-							}}>
-							NEW
-						</span>
-					</div>
-
-					{/* Title */}
+			<DialogContent
+				aria-describedby="whats-new-description"
+				aria-labelledby="whats-new-title"
+				className="pt-5 px-5 pb-4 gap-0">
+				<div id="whats-new-description">
 					<h2
-						className="text-lg font-semibold mb-3"
+						className="text-lg font-semibold mb-3 pr-6"
 						id="whats-new-title"
 						style={{ color: "var(--vscode-editor-foreground)" }}>
 						🎉 New in v{version}
 					</h2>
 
 					{/* Description */}
-					<ul className="text-sm mb-3 pl-3 list-disc" style={{ color: "var(--vscode-descriptionForeground)" }}>
+					<ul className="text-sm pl-3 list-disc" style={{ color: "var(--vscode-descriptionForeground)" }}>
 						<li className="mb-2">
 							<strong>Cline provider</strong> now runs on the Vercel AI Gateway for better latency and fewer errors.
 						</li>
@@ -109,7 +96,7 @@ export const WhatsNewModal: React.FC<WhatsNewModalProps> = ({ open, onClose, ver
 								<ModelButton label="Try GLM-4.6" modelId="z-ai/glm-4.6" />
 							</AuthButton>
 						</li>
-						<li className="mb-2">
+						<li>
 							<strong>Kat-Coder Pro</strong>, free for a limited time!
 							<br />
 							<AuthButton>
@@ -117,13 +104,6 @@ export const WhatsNewModal: React.FC<WhatsNewModalProps> = ({ open, onClose, ver
 							</AuthButton>
 						</li>
 					</ul>
-
-					{/* Action button */}
-					<div className="flex gap-3 pt-4 border-t-1 border-description/20">
-						<Button data-testid="close-whats-new-modal" onClick={onClose} size="sm" variant="secondary">
-							Dismiss
-						</Button>
-					</div>
 				</div>
 			</DialogContent>
 		</Dialog>

--- a/webview-ui/src/components/ui/dialog.tsx
+++ b/webview-ui/src/components/ui/dialog.tsx
@@ -37,14 +37,14 @@ const DialogContent = React.forwardRef<React.ElementRef<typeof DialogPrimitive.C
 			<DialogOverlay />
 			<DialogPrimitive.Content
 				className={cn(
-					"fixed left-[50%] top-[35%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-35%] gap-4 border border-input-placeholder/10 bg-background p-3 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 sm:rounded-lg focus:outline-none",
+					"fixed left-[50%] top-[35%] z-50 grid w-[calc(100%-2rem)] max-w-lg translate-x-[-50%] translate-y-[-35%] gap-4 border border-input-placeholder/10 bg-background p-3 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 rounded-lg focus:outline-none",
 					className,
 				)}
 				ref={ref}
 				{...props}>
 				{children}
 				{!hideClose && (
-					<DialogPrimitive.Close className="absolute right-4 top-4 rounded-xs opacity-70 ring-offset-background transition-opacity hover:opacity-100 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
+					<DialogPrimitive.Close className="absolute right-4 top-4 rounded-xs opacity-70 ring-offset-background transition-opacity hover:opacity-100 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground cursor-pointer">
 						<XIcon className="size-2" />
 						<span className="sr-only">Close</span>
 					</DialogPrimitive.Close>


### PR DESCRIPTION
### Related Issue

N/A - Minor UI polish for WhatsNew modal

Before:
<img width="443" height="753" alt="Cursor 2025-12-17 05 15 38" src="https://github.com/user-attachments/assets/3c997ed2-9516-4b93-8d15-d2db7fb18075" />

After:
<img width="403" height="664" alt="Cursor 2025-12-17 05 06 44" src="https://github.com/user-attachments/assets/c5bd3ae5-f90e-4cd9-b162-d64ef5189b95" />


### Description

Improves the WhatsNew modal design with several polish fixes:

- **Small viewport spacing**: Modal now has consistent 1rem margin from edges on small screens (was touching edges)
- **Consistent rounded corners**: Applied `rounded-lg` at all viewport sizes (was only `sm:rounded-lg`)
- **Removed redundant UI elements**:
  - Removed "NEW" badge (title already says "🎉 New in v...")
  - Removed "Dismiss" button (X close button is sufficient, and clicking outside also closes)
- **Tighter layout**: Reduced excess bottom padding and removed unnecessary margins
- **Better UX**: Added `cursor-pointer` to dialog close button
- **Code cleanup**: Removed unused imports (`PLATFORM_CONFIG`, `PlatformType`, `isVscode`)

### Test Procedure

- Tested modal at various viewport widths to verify spacing
- Verified X button and click-outside-to-close both work
- Confirmed modal displays correctly with all content visible

### Type of Change

-   [x] 💅 Cosmetic Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A - Minor spacing/padding adjustments

### Additional Notes

Changeset skipped as this is a minor UI polish that doesn't warrant a changelog entry.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Improves `WhatsNewModal` design and responsiveness by adjusting spacing, removing redundant elements, and cleaning up code.
> 
>   - **UI Improvements**:
>     - `WhatsNewModal.tsx`: Consistent 1rem margin on small screens, applied `rounded-lg` at all sizes, removed "NEW" badge and "Dismiss" button, reduced bottom padding, and added `cursor-pointer` to close button.
>   - **Code Cleanup**:
>     - Removed unused imports: `PLATFORM_CONFIG`, `PlatformType`, `isVscode` in `WhatsNewModal.tsx`.
>   - **Dialog Adjustments**:
>     - `dialog.tsx`: Adjusted `DialogContent` to have consistent rounded corners and added `cursor-pointer` to close button.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for b1ceeae726253b966a9700665a753342aeb5c320. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->