### PR TITLE
fix(ui): improve model picker and popup modal styling

### DIFF
--- a/webview-ui/src/components/chat/ModelPickerModal.tsx
+++ b/webview-ui/src/components/chat/ModelPickerModal.tsx
@@ -9,6 +9,7 @@ import { createPortal } from "react-dom"
 import { useWindowSize } from "react-use"
 import styled from "styled-components"
 import { CODE_BLOCK_BG_COLOR } from "@/components/common/CodeBlock"
+import PopupModalContainer from "@/components/common/PopupModalContainer"
 
 const PLAN_MODE_COLOR = "var(--vscode-activityWarningBadge-background)"
 const ACT_MODE_COLOR = "var(--vscode-focusBorder)"
@@ -385,7 +386,12 @@ const ModelPickerModal: React.FC<ModelPickerModalProps> = ({ isOpen, onOpenChang
 			{/* Modal - rendered via portal with fixed positioning */}
 			{isOpen &&
 				createPortal(
-					<FixedModalContainer $arrowPosition={arrowPosition} $menuPosition={menuPosition} ref={modalRef}>
+					<PopupModalContainer
+						$arrowPosition={arrowPosition}
+						$bottomOffset={5}
+						$maxHeight="18em"
+						$menuPosition={menuPosition}
+						ref={modalRef}>
 						{/* Search */}
 						<SearchContainer>
 							<Search size={14} style={{ color: "var(--vscode-descriptionForeground)", flexShrink: 0 }} />
@@ -602,53 +608,12 @@ const ModelPickerModal: React.FC<ModelPickerModalProps> = ({ isOpen, onOpenChang
 								</>
 							)}
 						</ModelListContainer>
-					</FixedModalContainer>,
+					</PopupModalContainer>,
 					document.body,
 				)}
 		</>
 	)
 }
-
-// Fixed position modal container - matches original ModelSelectorTooltip positioning
-const FixedModalContainer = styled.div<{ $menuPosition: number; $arrowPosition: number }>`
-	position: fixed;
-	bottom: ${(props) => `calc(100vh - ${props.$menuPosition}px + 5px)`};
-	left: 10px;
-	right: 10px;
-	display: flex;
-	flex-direction: column;
-	max-height: 18em;
-	background: ${CODE_BLOCK_BG_COLOR};
-	border: 1px solid var(--vscode-editorGroup-border);
-	border-bottom: none;
-	border-radius: 6px 6px 0 0;
-	z-index: 49;
-
-	&::before {
-		content: "";
-		position: absolute;
-		bottom: 0;
-		left: 0;
-		right: 0;
-		height: 1px;
-		background: var(--vscode-editorGroup-border);
-		z-index: -1;
-	}
-
-	&::after {
-		content: "";
-		position: absolute;
-		bottom: -5px;
-		right: ${(props) => props.$arrowPosition - 10}px;
-		height: 10px;
-		width: 10px;
-		transform: rotate(45deg);
-		border-right: 1px solid var(--vscode-editorGroup-border);
-		border-bottom: 1px solid var(--vscode-editorGroup-border);
-		background: ${CODE_BLOCK_BG_COLOR};
-		z-index: -1;
-	}
-`
 
 const SearchContainer = styled.div`
 	padding: 4px 10px;

--- a/webview-ui/src/components/chat/ServersToggleModal.tsx
+++ b/webview-ui/src/components/chat/ServersToggleModal.tsx
@@ -4,8 +4,7 @@ import { convertProtoMcpServersToMcpServers } from "@shared/proto-conversions/mc
 import { VSCodeButton } from "@vscode/webview-ui-toolkit/react"
 import React, { useEffect, useRef, useState } from "react"
 import { useClickAway, useWindowSize } from "react-use"
-import styled from "styled-components"
-import { CODE_BLOCK_BG_COLOR } from "@/components/common/CodeBlock"
+import PopupModalContainer from "@/components/common/PopupModalContainer"
 import ServersToggleList from "@/components/mcp/configuration/tabs/installed/ServersToggleList"
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
 import { useExtensionState } from "@/context/ExtensionStateContext"
@@ -70,7 +69,7 @@ const ServersToggleModal: React.FC = () => {
 			</div>
 
 			{isVisible && (
-				<ModalContainer $arrowPosition={arrowPosition} $menuPosition={menuPosition}>
+				<PopupModalContainer $arrowPosition={arrowPosition} $menuPosition={menuPosition}>
 					<div className="flex-shrink-0 px-3 pt-2">
 						<div className="flex justify-between items-center mb-2.5">
 							<div className="m-0 text-sm font-medium">MCP Servers</div>
@@ -89,51 +88,10 @@ const ServersToggleModal: React.FC = () => {
 					<div className="flex-1 overflow-y-auto px-3 pb-3" style={{ minHeight: 0 }}>
 						<ServersToggleList hasTrashIcon={false} isExpandable={false} listGap="small" servers={mcpServers} />
 					</div>
-				</ModalContainer>
+				</PopupModalContainer>
 			)}
 		</div>
 	)
 }
-
-const ModalContainer = styled.div<{ $menuPosition: number; $arrowPosition: number }>`
-	position: fixed;
-	left: 10px;
-	right: 10px;
-	bottom: ${(props) => `calc(100vh - ${props.$menuPosition}px + 6px)`};
-	background: ${CODE_BLOCK_BG_COLOR};
-	border: 1px solid var(--vscode-editorGroup-border);
-	border-bottom: none;
-	border-radius: 6px 6px 0 0;
-	z-index: 49;
-	display: flex;
-	flex-direction: column;
-	max-height: calc(100vh - 100px);
-	overscroll-behavior: contain;
-
-	&::before {
-		content: "";
-		position: absolute;
-		bottom: 0;
-		left: 0;
-		right: 0;
-		height: 1px;
-		background: var(--vscode-editorGroup-border);
-		z-index: -1;
-	}
-
-	&::after {
-		content: "";
-		position: absolute;
-		bottom: -5px;
-		right: ${(props) => props.$arrowPosition - 10}px;
-		height: 10px;
-		width: 10px;
-		transform: rotate(45deg);
-		border-right: 1px solid var(--vscode-editorGroup-border);
-		border-bottom: 1px solid var(--vscode-editorGroup-border);
-		background: ${CODE_BLOCK_BG_COLOR};
-		z-index: -1;
-	}
-`
 
 export default ServersToggleModal

--- a/webview-ui/src/components/cline-rules/ClineRulesToggleModal.tsx
+++ b/webview-ui/src/components/cline-rules/ClineRulesToggleModal.tsx
@@ -13,7 +13,7 @@ import { VSCodeButton, VSCodeLink } from "@vscode/webview-ui-toolkit/react"
 import React, { useEffect, useRef, useState } from "react"
 import { useClickAway, useWindowSize } from "react-use"
 import styled from "styled-components"
-import { CODE_BLOCK_BG_COLOR } from "@/components/common/CodeBlock"
+import PopupModalContainer from "@/components/common/PopupModalContainer"
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
 import { useExtensionState } from "@/context/ExtensionStateContext"
 import { FileServiceClient } from "@/services/grpc-client"
@@ -376,7 +376,7 @@ const ClineRulesToggleModal: React.FC = () => {
 			</div>
 
 			{isVisible && (
-				<ModalContainer $arrowPosition={arrowPosition} $menuPosition={menuPosition}>
+				<PopupModalContainer $arrowPosition={arrowPosition} $menuPosition={menuPosition}>
 					{/* Fixed header section - tabs and description */}
 					<div className="flex-shrink-0 px-2 pt-0">
 						{/* Tabs container */}
@@ -693,52 +693,11 @@ const ClineRulesToggleModal: React.FC = () => {
 							</>
 						)}
 					</div>
-				</ModalContainer>
+				</PopupModalContainer>
 			)}
 		</div>
 	)
 }
-
-const ModalContainer = styled.div<{ $menuPosition: number; $arrowPosition: number }>`
-	position: fixed;
-	left: 10px;
-	right: 10px;
-	bottom: ${(props) => `calc(100vh - ${props.$menuPosition}px + 6px)`};
-	background: ${CODE_BLOCK_BG_COLOR};
-	border: 1px solid var(--vscode-editorGroup-border);
-	border-bottom: none;
-	border-radius: 6px 6px 0 0;
-	z-index: 49;
-	display: flex;
-	flex-direction: column;
-	max-height: calc(100vh - 100px);
-	overscroll-behavior: contain;
-
-	&::before {
-		content: "";
-		position: absolute;
-		bottom: 0;
-		left: 0;
-		right: 0;
-		height: 1px;
-		background: var(--vscode-editorGroup-border);
-		z-index: -1;
-	}
-
-	&::after {
-		content: "";
-		position: absolute;
-		bottom: -5px;
-		right: ${(props) => props.$arrowPosition - 10}px;
-		height: 10px;
-		width: 10px;
-		transform: rotate(45deg);
-		border-right: 1px solid var(--vscode-editorGroup-border);
-		border-bottom: 1px solid var(--vscode-editorGroup-border);
-		background: ${CODE_BLOCK_BG_COLOR};
-		z-index: -1;
-	}
-`
 
 const StyledTabButton = styled.button<{ isActive: boolean }>`
 	background: none;

--- a/webview-ui/src/components/common/PopupModalContainer.tsx
+++ b/webview-ui/src/components/common/PopupModalContainer.tsx
@@ -1,0 +1,56 @@
+import styled from "styled-components"
+import { CODE_BLOCK_BG_COLOR } from "./CodeBlock"
+
+interface PopupModalContainerProps {
+	$menuPosition: number
+	$arrowPosition: number
+	$bottomOffset?: number
+	$maxHeight?: string
+}
+
+/**
+ * Shared styled container for popup modals (ModelPicker, ServersToggle, ClineRulesToggle).
+ * Provides consistent positioning, styling, and arrow pointer.
+ */
+const PopupModalContainer = styled.div<PopupModalContainerProps>`
+	position: fixed;
+	left: 10px;
+	right: 10px;
+	bottom: ${(props) => `calc(100vh - ${props.$menuPosition}px + ${props.$bottomOffset ?? 6}px)`};
+	display: flex;
+	flex-direction: column;
+	max-height: ${(props) => props.$maxHeight ?? "calc(100vh - 100px)"};
+	background: ${CODE_BLOCK_BG_COLOR};
+	border: 1px solid var(--vscode-editorGroup-border);
+	border-bottom: none;
+	border-radius: 6px 6px 0 0;
+	z-index: 49;
+	overscroll-behavior: contain;
+
+	&::before {
+		content: "";
+		position: absolute;
+		bottom: 0;
+		left: 0;
+		right: 0;
+		height: 1px;
+		background: var(--vscode-editorGroup-border);
+		z-index: -1;
+	}
+
+	&::after {
+		content: "";
+		position: absolute;
+		bottom: -5px;
+		right: ${(props) => props.$arrowPosition - 10}px;
+		height: 10px;
+		width: 10px;
+		transform: rotate(45deg);
+		border-right: 1px solid var(--vscode-editorGroup-border);
+		border-bottom: 1px solid var(--vscode-editorGroup-border);
+		background: ${CODE_BLOCK_BG_COLOR};
+		z-index: -1;
+	}
+`
+
+export default PopupModalContainer


### PR DESCRIPTION
### Related Issue

**Issue:** N/A - Minor UI polish improvements

### Description

This PR improves the styling and UX of the model picker modal and other popup modals (MCP servers, Cline rules/workflows):

- Add tooltips to Plan/Act mode tabs showing their purpose
- Add checkmark to selected model and provider rows
- Hide model provider name on very small viewports (<280px)
- Fix double hover dim effect on provider row
- Improve provider list styling consistency with model list
- Add consistent arrow pointers to all popup modals
- Unify modal widths to align with chat content (10px inset)
- Fix z-index so tooltips appear above modals
- Fix transparent selection background on some themes using linear-gradient
- Swap icon positions and use ArrowLeftRight for plan/act split toggle (more intuitive)
- Close provider list when user starts typing in search
- Improve row heights for consistency (search bar min-height)

### Test Procedure

- Opened model picker modal and verified tooltips on Plan/Act tabs
- Verified checkmark appears on selected model and provider
- Resized viewport to verify provider name hides at small widths
- Tested hover effects on provider rows (no double dim)
- Verified arrow pointers on all three modals (model picker, MCP servers, rules/workflows)
- Tested with different VS Code themes to verify selection backgrounds are always visible
- Verified typing in search closes the provider list

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [x] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A - Minor UI polish, best verified by testing locally

### Additional Notes

These are cosmetic improvements to make the model picker and popup modals more polished and consistent.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Enhance styling and UX of model picker and popup modals with consistent design and improved interaction.
> 
>   - **Styling and UX Improvements**:
>     - Add tooltips to Plan/Act mode tabs in `ModelPickerModal.tsx`.
>     - Add checkmark to selected model and provider rows in `ModelPickerModal.tsx`.
>     - Hide model provider name on viewports <280px in `ModelPickerModal.tsx`.
>     - Fix double hover dim effect on provider row in `ModelPickerModal.tsx`.
>     - Improve provider list styling consistency with model list in `ModelPickerModal.tsx`.
>     - Add consistent arrow pointers to all popup modals using `PopupModalContainer.tsx`.
>     - Unify modal widths to align with chat content in `ModelPickerModal.tsx`, `ServersToggleModal.tsx`, and `ClineRulesToggleModal.tsx`.
>     - Fix z-index so tooltips appear above modals in `ModelPickerModal.tsx`.
>     - Fix transparent selection background on some themes using linear-gradient in `ModelPickerModal.tsx`.
>     - Swap icon positions and use `ArrowLeftRight` for plan/act split toggle in `ModelPickerModal.tsx`.
>     - Close provider list when user starts typing in search in `ModelPickerModal.tsx`.
>     - Improve row heights for consistency in `ModelPickerModal.tsx`.
>   - **Functional Adjustments**:
>     - Calculate positions for modal and arrow on viewport resize in `ModelPickerModal.tsx`, `ServersToggleModal.tsx`, and `ClineRulesToggleModal.tsx`.
>     - Close modals when clicking outside in `ServersToggleModal.tsx` and `ClineRulesToggleModal.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 690b3cc7663ebae85f23a78eb0bbfc77b4eb66d0. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->