### PR TITLE
Disable specifically the Cline extensions in launch.json

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -12,7 +12,10 @@
 			"args": [
 				"--extensionDevelopmentPath=${workspaceFolder}",
 				"--disable-workspace-trust",
-				"--disable-extensions", // Avoid conflicts with installed extensions
+				"--disable-extension",
+				"saoudrizwan.claude-dev", // Avoid conflicts with installed Cline
+				"--disable-extension",
+				"saoudrizwan.cline-nightly", // Avoid conflicts with installed Cline Nightly
 				"${workspaceFolder}"
 			],
 			"outFiles": [
@@ -33,7 +36,10 @@
 			"args": [
 				"--extensionDevelopmentPath=${workspaceFolder}",
 				"--disable-workspace-trust",
-				"--disable-extensions", // Avoid conflicts with installed extensions
+				"--disable-extension",
+				"saoudrizwan.claude-dev", // Avoid conflicts with installed Cline
+				"--disable-extension",
+				"saoudrizwan.cline-nightly", // Avoid conflicts with installed Cline Nightly
 				"${workspaceFolder}"
 			],
 			"outFiles": [
@@ -54,7 +60,10 @@
 			"args": [
 				"--extensionDevelopmentPath=${workspaceFolder}",
 				"--disable-workspace-trust",
-				"--disable-extensions", // Avoid conflicts with installed extensions
+				"--disable-extension",
+				"saoudrizwan.claude-dev", // Avoid conflicts with installed Cline
+				"--disable-extension",
+				"saoudrizwan.cline-nightly", // Avoid conflicts with installed Cline Nightly
 				"${workspaceFolder}"
 			],
 			"outFiles": [
@@ -77,7 +86,10 @@
 				"--user-data-dir=${workspaceFolder}/dist/tmp/user",
 				"--profile-temp",
 				"--sync=off",
-				"--disable-extensions", // Avoid conflicts with installed extensions
+				"--disable-extension",
+				"saoudrizwan.claude-dev", // Avoid conflicts with installed Cline
+				"--disable-extension",
+				"saoudrizwan.cline-nightly", // Avoid conflicts with installed Cline Nightly
 				"--extensionDevelopmentPath=${workspaceFolder}",
 				"${workspaceFolder}"
 			],


### PR DESCRIPTION
### Related Issue

__Issue:__ #XXXX

### Description

This PR replaces the global `--disable-extensions` flag in `.vscode/launch.json` with specific `--disable-extension` flags for the production and nightly versions of Cline (`saoudrizwan.claude-dev` and `saoudrizwan.claude-dev-nightly`).

__Why?__ Previously, running the extension in development mode would disable all other installed extensions. This change allows developers to test Cline alongside other extensions (like theme extensions, language support, git tools, jupyter notebooks, etc.) while still preventing conflicts with already installed versions of Cline.

### Test Procedure

- __How did you test this change?__

  - Launched a development version of cline. Verified other extensions work, but other cline installations are not installed alongside.

- __What could potentially break?__
  - If the extension IDs change in the future, they would need to be updated here. However, these are the stable IDs for the marketplace versions.

- __Existing functionality affected?__
  - Only the development launch configuration is affected. It now provides a more realistic testing environment by keeping other extensions enabled.

### Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ♻️ Refactor Changes
- [ ] 💅 Cosmetic Changes
- [ ] 📚 Documentation update
- [x] 🏃 Workflow Changes

### Pre-flight Checklist

- [x] Changes are limited to a single feature, bugfix or chore
- [x] Tests are passing (`npm test`) and code is formatted and linted (N/A for launch.json changes)
- [ ] I have created a changeset using `npm run changeset` (Not required for internal workflow changes)
- [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A (Internal configuration change)

### Additional Notes


