### PR TITLE
Revert "fix(hooks): Fix the underlying Windows detection logic [#8703]"

### DIFF
--- a/.changeset/shiny-cities-doubt.md
+++ b/.changeset/shiny-cities-doubt.md
@@ -1,5 +1,0 @@
----
-"claude-dev": patch
----
-
-Bug fix for the isMacOSOrLinux() function in the webview-ui/ code for the extension.

--- a/webview-ui/src/components/chat/chat-view/components/layout/WelcomeSection.tsx
+++ b/webview-ui/src/components/chat/chat-view/components/layout/WelcomeSection.tsx
@@ -15,7 +15,7 @@ import { PLATFORM_CONFIG, PlatformType } from "@/config/platform.config"
 import { useClineAuth } from "@/context/ClineAuthContext"
 import { useExtensionState } from "@/context/ExtensionStateContext"
 import { AccountServiceClient, StateServiceClient } from "@/services/grpc-client"
-import { useIsMacOSOrLinux } from "@/utils/platformUtils"
+import { isMacOSOrLinux } from "@/utils/platformUtils"
 import { WelcomeSectionProps } from "../../types/chatTypes"
 
 /**
@@ -39,11 +39,9 @@ export const WelcomeSection: React.FC<WelcomeSectionProps> = ({
 	const shouldShowInfoBanner = lastDismissedInfoBannerVersion < CURRENT_INFO_BANNER_VERSION
 	const shouldShowNewModelBanner = lastDismissedModelBannerVersion < CURRENT_MODEL_BANNER_VERSION
 
-	const isMacOSOrLinux = useIsMacOSOrLinux()
-
 	// Show CLI banner if not dismissed and platform is VSCode (not JetBrains/standalone)
 	const shouldShowCliBanner =
-		isMacOSOrLinux &&
+		isMacOSOrLinux() &&
 		PLATFORM_CONFIG.type === PlatformType.VSCODE &&
 		lastDismissedCliBannerVersion < CURRENT_CLI_BANNER_VERSION
 
@@ -151,8 +149,8 @@ export const WelcomeSection: React.FC<WelcomeSectionProps> = ({
 			banners.push({
 				id: "cli-install",
 				icon: <Terminal className="w-5 h-5" />,
-				title: isMacOSOrLinux ? "CLI & Subagents Available" : "Cline CLI Info",
-				description: isMacOSOrLinux ? (
+				title: isMacOSOrLinux() ? "CLI & Subagents Available" : "Cline CLI Info",
+				description: isMacOSOrLinux() ? (
 					<>
 						Use Cline in your terminal and enable subagent capabilities.{" "}
 						<VSCodeLink href="https://docs.cline.bot/cline-cli/overview" style={{ display: "inline" }}>
@@ -167,7 +165,7 @@ export const WelcomeSection: React.FC<WelcomeSectionProps> = ({
 						</VSCodeLink>
 					</>
 				),
-				actions: isMacOSOrLinux
+				actions: isMacOSOrLinux()
 					? [
 							{ label: "Install", onClick: handleInstallCli, variant: "primary" },
 							{

--- a/webview-ui/src/components/cline-rules/ClineRulesToggleModal.tsx
+++ b/webview-ui/src/components/cline-rules/ClineRulesToggleModal.tsx
@@ -17,7 +17,7 @@ import PopupModalContainer from "@/components/common/PopupModalContainer"
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
 import { useExtensionState } from "@/context/ExtensionStateContext"
 import { FileServiceClient } from "@/services/grpc-client"
-import { useIsMacOSOrLinux } from "@/utils/platformUtils"
+import { isMacOSOrLinux } from "@/utils/platformUtils"
 import HookRow from "./HookRow"
 import NewRuleRow from "./NewRuleRow"
 import RuleRow from "./RuleRow"
@@ -51,8 +51,7 @@ const ClineRulesToggleModal: React.FC = () => {
 		Array<{ workspaceName: string; hooks: Array<{ name: string; enabled: boolean; absolutePath: string }> }>
 	>([])
 
-	const isMacOSOrLinux = useIsMacOSOrLinux()
-	const isWindows = !isMacOSOrLinux
+	const isWindows = !isMacOSOrLinux()
 	const [isVisible, setIsVisible] = useState(false)
 	const buttonRef = useRef<HTMLDivElement>(null)
 	const modalRef = useRef<HTMLDivElement>(null)

--- a/webview-ui/src/components/common/CliInstallBanner.tsx
+++ b/webview-ui/src/components/common/CliInstallBanner.tsx
@@ -5,14 +5,13 @@ import { useCallback, useEffect, useState } from "react"
 import { Button } from "@/components/ui/button"
 import { useExtensionState } from "@/context/ExtensionStateContext"
 import { StateServiceClient } from "@/services/grpc-client"
-import { useIsMacOSOrLinux } from "@/utils/platformUtils"
+import { isMacOSOrLinux } from "@/utils/platformUtils"
 import { getAsVar, VSC_INACTIVE_SELECTION_BACKGROUND } from "@/utils/vscStyles"
 
 export const CURRENT_CLI_BANNER_VERSION = 1
 
 export const CliInstallBanner: React.FC = () => {
 	const { navigateToSettings, subagentsEnabled } = useExtensionState()
-	const isMacOSOrLinux = useIsMacOSOrLinux()
 	const [isCopied, setIsCopied] = useState(false)
 	const [isClineCliInstalled, setIsClineCliInstalled] = useState(false)
 
@@ -93,10 +92,10 @@ export const CliInstallBanner: React.FC = () => {
 			}}>
 			<h4 className="m-0 flex items-center gap-2" style={{ paddingRight: "24px" }}>
 				<Terminal className="w-4 h-4" />
-				{isMacOSOrLinux ? "Cline for CLI is here!" : "Cline CLI Information"}
+				{isMacOSOrLinux() ? "Cline for CLI is here!" : "Cline CLI Information"}
 			</h4>
 			<p className="m-0">
-				{isMacOSOrLinux ? (
+				{isMacOSOrLinux() ? (
 					<>
 						Install to use Cline directly in your terminal and enable subagent capabilities. Cline can spawn{" "}
 						<code>cline</code> commands to handle focused tasks like exploring large codebases for information. This
@@ -139,7 +138,7 @@ export const CliInstallBanner: React.FC = () => {
 						<span className={`codicon ${isCopied ? "codicon-check" : "codicon-copy"}`}></span>
 					</VSCodeButton>
 				</div>
-				{isMacOSOrLinux ? (
+				{isMacOSOrLinux() ? (
 					<div className="flex gap-2">
 						<VSCodeButton
 							appearance="primary"

--- a/webview-ui/src/components/settings/sections/FeatureSettingsSection.tsx
+++ b/webview-ui/src/components/settings/sections/FeatureSettingsSection.tsx
@@ -8,7 +8,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip
 import { PLATFORM_CONFIG, PlatformType } from "@/config/platform.config"
 import { useExtensionState } from "@/context/ExtensionStateContext"
 import { StateServiceClient } from "@/services/grpc-client"
-import { useIsMacOSOrLinux } from "@/utils/platformUtils"
+import { isMacOSOrLinux } from "@/utils/platformUtils"
 import Section from "../Section"
 import SubagentOutputLineLimitSlider from "../SubagentOutputLineLimitSlider"
 import { updateSetting } from "../utils/settingsHandlers"
@@ -37,7 +37,6 @@ const FeatureSettingsSection = ({ renderSectionHeader }: FeatureSettingsSectionP
 		enableParallelToolCalling,
 	} = useExtensionState()
 
-	const isMacOSOrLinux = useIsMacOSOrLinux()
 	const [isClineCliInstalled, setIsClineCliInstalled] = useState(false)
 
 	const handleReasoningEffortChange = (newValue: OpenaiReasoningEffort) => {
@@ -71,7 +70,7 @@ const FeatureSettingsSection = ({ renderSectionHeader }: FeatureSettingsSectionP
 			<Section>
 				<div style={{ marginBottom: 20 }}>
 					{/* Subagents - Only show on macOS and Linux */}
-					{isMacOSOrLinux && PLATFORM_CONFIG.type === PlatformType.VSCODE && (
+					{isMacOSOrLinux() && PLATFORM_CONFIG.type === PlatformType.VSCODE && (
 						<div
 							className="relative p-3 mb-3 rounded-md"
 							id="subagents-section"
@@ -395,14 +394,14 @@ const FeatureSettingsSection = ({ renderSectionHeader }: FeatureSettingsSectionP
 					<div className="mt-2.5">
 						<VSCodeCheckbox
 							checked={hooksEnabled}
-							disabled={!isMacOSOrLinux}
+							disabled={!isMacOSOrLinux()}
 							onChange={(e: any) => {
 								const checked = e.target.checked === true
 								updateSetting("hooksEnabled", checked)
 							}}>
 							Enable Hooks
 						</VSCodeCheckbox>
-						{!isMacOSOrLinux ? (
+						{!isMacOSOrLinux() ? (
 							<p className="text-xs mt-1" style={{ color: "var(--vscode-inputValidation-warningForeground)" }}>
 								Hooks are not yet supported on Windows. This feature is currently available on macOS and Linux
 								only.

--- a/webview-ui/src/utils/platformUtils.ts
+++ b/webview-ui/src/utils/platformUtils.ts
@@ -1,5 +1,3 @@
-import { useExtensionState } from "@/context/ExtensionStateContext"
-
 export interface NavigatorUAData {
 	platform: string
 	brands: { brand: string; version: string }[]
@@ -44,10 +42,10 @@ export const isChrome = userAgent.indexOf("Chrome") >= 0
 export const isSafari = !isChrome && userAgent.indexOf("Safari") >= 0
 
 /**
- * React hook to check whether the platform is macOS or Linux
- * @returns true if platform is darwin (macOS) or linux, false for Windows or unknown
+ * Checks if the platform is macOS or Linux
+ * @returns true if platform is darwin (macOS) or linux
  */
-export const useIsMacOSOrLinux = (): boolean => {
-	const { platform } = useExtensionState()
-	return platform !== "win32" && platform !== "unknown"
+export const isMacOSOrLinux = (): boolean => {
+	const platform = process?.platform
+	return !platform?.startsWith("win") // Non-Windows
 }


### PR DESCRIPTION
Reverts cline/cline#8168
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Reverts platform detection logic by replacing `useIsMacOSOrLinux` hook with `isMacOSOrLinux` function call across multiple components.
> 
>   - **Behavior**:
>     - Reverts the change in `isMacOSOrLinux` logic by replacing `useIsMacOSOrLinux` hook with `isMacOSOrLinux` function call in `WelcomeSection.tsx`, `ClineRulesToggleModal.tsx`, `CliInstallBanner.tsx`, and `FeatureSettingsSection.tsx`.
>     - Affects platform-specific UI elements and logic, such as CLI installation and subagent enabling.
>   - **Functions**:
>     - `isMacOSOrLinux` in `platformUtils.ts` now directly checks `process.platform` instead of using a hook.
>   - **Misc**:
>     - Removes `.changeset/shiny-cities-doubt.md` file.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 97cc893de10c981f82c44fed9eae6ad9ccf50dc0. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->