### PR TITLE
fix: add support for haiku 4.5 in JP_SUPPORTED_CRIS_MODELS and enable global endpoint support

### DIFF
--- a/src/core/api/providers/bedrock.ts
+++ b/src/core/api/providers/bedrock.ts
@@ -109,9 +109,13 @@ interface ProviderChainOptions {
 	profile?: string
 }
 
-// a special jp inference profile was created for sonnet 4.5
+// a special jp inference profile was created for sonnet 4.5 & haiku 4.5
 // https://docs.aws.amazon.com/bedrock/latest/userguide/inference-profiles-support.html
-const JP_SUPPORTED_CRIS_MODELS = ["anthropic.claude-sonnet-4-5-20250929-v1:0", "anthropic.claude-sonnet-4-5-20250929-v1:0:1m"]
+const JP_SUPPORTED_CRIS_MODELS = [
+	"anthropic.claude-sonnet-4-5-20250929-v1:0",
+	"anthropic.claude-sonnet-4-5-20250929-v1:0:1m",
+	"anthropic.claude-haiku-4-5-20251001-v1:0",
+]
 
 // https://docs.anthropic.com/en/api/claude-on-amazon-bedrock
 export class AwsBedrockHandler implements ApiHandler {

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -384,6 +384,7 @@ export const bedrockModels = {
 		supportsImages: true,
 		supportsPromptCache: true,
 		supportsReasoning: true,
+		supportsGlobalEndpoint: true,
 		inputPrice: 1,
 		outputPrice: 5.0,
 		cacheWritesPrice: 1.25,


### PR DESCRIPTION
<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- For feature requests: Created a discussion in our Feature Requests discussions board https://github.com/cline/cline/discussions/categories/feature-requests and received approval from core maintainers before implementation
- For all changes: Link the associated issue/discussion in the "Related Issue" section below

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly without prior discussion.

Why this requirement?
We deeply appreciate all community contributions - they are essential to Cline's success! To ensure the best use of everyone's time and maintain project direction, we use our Feature Requests discussions board to gauge community interest and validate feature ideas before implementation begins. This helps us focus development efforts on features that will benefit the most users.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** #7007

### Description
This PR fixes AWS Bedrock cross-region inference support for Claude Haiku 4.5 in the Japan (ap-northeast-1) region and enables global endpoint support for the model.

**Problem:**
- Claude Haiku 4.5 (`anthropic.claude-haiku-4-5-20251001-v1:0`) was not included in the `JP_SUPPORTED_CRIS_MODELS` array, causing it to fall back to the generic `apac.` prefix instead of the correct `jp.` prefix when using cross-region inference in Japan regions
- The model was missing the `supportsGlobalEndpoint: true` flag, preventing users from utilizing AWS Bedrock's global inference profiles

**Solution:**
1. Added `anthropic.claude-haiku-4-5-20251001-v1:0` to the `JP_SUPPORTED_CRIS_MODELS` array in [`bedrock.ts`](src/core/api/providers/bedrock.ts)
2. Added `supportsGlobalEndpoint: true` to the Haiku 4.5 model definition in [`api.ts`](src/shared/api.ts)

These changes align Haiku 4.5 with the existing Sonnet 4.5 configuration, which already had both JP cross-region and global endpoint support.
<!-- 
Help reviewers understand your changes by making this PR readable and well-organized:

- What problem does this PR solve?
- Why were these changes introduced and what purpose do they serve?
- For larger changes, provide context about your approach and reasoning

Small PRs may need minimal description, but larger changes benefit from explaining where you're coming from. Much of this context can be in the linked issue above, so feel free to reference it rather than repeating everything here.
-->

### Test Procedure

1. Configured AWS Bedrock provider with Claude Haiku 4.5 model
2. Enabled cross-region inference in settings
3. Set region to `ap-northeast-1` (Tokyo)
4. Verified the model ID resolves to `jp.anthropic.claude-haiku-4-5-20251001-v1:0`
5. Enabled global inference option
6. Verified the model ID resolves to `global.anthropic.claude-haiku-4-5-20251001-v1:0`

<!-- 
Please walk us through your testing approach and thought process. This helps reviewers understand that you've thoroughly considered the impact of your changes:

- How did you test this change?
- What could potentially break and how did you verify it doesn't?
- What existing functionality might be affected and how did you check it still works?
- Why are you confident this is ready for merge?

We're not looking for exhaustive documentation - just evidence that you've thought through the implications of your changes and tested accordingly.
-->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots
Not applicable
<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes
This is a straightforward fix that mirrors the existing configuration for Claude Sonnet 4.5. 

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds support for Claude Haiku 4.5 in Japan and enables global endpoint usage in AWS Bedrock.
> 
>   - **Behavior**:
>     - Added `anthropic.claude-haiku-4-5-20251001-v1:0` to `JP_SUPPORTED_CRIS_MODELS` in `bedrock.ts` for correct regional prefixing in Japan.
>     - Set `supportsGlobalEndpoint: true` for `anthropic.claude-haiku-4-5-20251001-v1:0` in `api.ts` to enable global endpoint usage.
>   - **Models**:
>     - Updated `bedrockModels` in `api.ts` to include global endpoint support for Haiku 4.5.
>   - **Misc**:
>     - Aligns Haiku 4.5 configuration with Sonnet 4.5 for consistency.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for f7909dc2ed28973ec865c2357e73c39602c3cc3c. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->