### PR TITLE
fix: exclude generate_explanation tool from system prompt for non-VS Code platforms

### DIFF
--- a/.changeset/true-lemons-shop.md
+++ b/.changeset/true-lemons-shop.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Exclude generate_explanation tool from system prompt for non-VS Code platforms

--- a/src/core/prompts/system-prompt/__tests__/__snapshots__/anthropic_claude_sonnet_4-basic.snap
+++ b/src/core/prompts/system-prompt/__tests__/__snapshots__/anthropic_claude_sonnet_4-basic.snap
@@ -253,19 +253,6 @@ Usage:
 <load_mcp_documentation>
 </load_mcp_documentation>
 
-## generate_explanation
-Description: Opens a multi-file diff view and generates AI-powered inline comments explaining the changes between two git references. Use this tool to help users understand code changes from git commits, pull requests, branches, or any git refs. The tool uses git to retrieve file contents and displays a side-by-side diff view with explanatory comments.
-Parameters:
-- title: (required) A descriptive title for the diff view (e.g., 'Changes in commit abc123', 'PR #42: Add authentication', 'Changes between main and feature-branch')
-- from_ref: (required) The git reference for the 'before' state. Can be a commit hash, branch name, tag, or relative reference like HEAD~1, HEAD^, origin/main, etc.
-- to_ref: (optional) The git reference for the 'after' state. Can be a commit hash, branch name, tag, or relative reference. If not provided, compares to the current working directory (including uncommitted changes).
-Usage:
-<generate_explanation>
-<title>Changes in last commit</title>
-<from_ref>HEAD~1</from_ref>
-<to_ref>HEAD</to_ref>
-</generate_explanation>
-
 # Tool Use Examples
 
 ## Example 1: Requesting to execute a command

--- a/src/core/prompts/system-prompt/__tests__/__snapshots__/anthropic_claude_sonnet_4-no-browser.snap
+++ b/src/core/prompts/system-prompt/__tests__/__snapshots__/anthropic_claude_sonnet_4-no-browser.snap
@@ -219,19 +219,6 @@ Usage:
 <load_mcp_documentation>
 </load_mcp_documentation>
 
-## generate_explanation
-Description: Opens a multi-file diff view and generates AI-powered inline comments explaining the changes between two git references. Use this tool to help users understand code changes from git commits, pull requests, branches, or any git refs. The tool uses git to retrieve file contents and displays a side-by-side diff view with explanatory comments.
-Parameters:
-- title: (required) A descriptive title for the diff view (e.g., 'Changes in commit abc123', 'PR #42: Add authentication', 'Changes between main and feature-branch')
-- from_ref: (required) The git reference for the 'before' state. Can be a commit hash, branch name, tag, or relative reference like HEAD~1, HEAD^, origin/main, etc.
-- to_ref: (optional) The git reference for the 'after' state. Can be a commit hash, branch name, tag, or relative reference. If not provided, compares to the current working directory (including uncommitted changes).
-Usage:
-<generate_explanation>
-<title>Changes in last commit</title>
-<from_ref>HEAD~1</from_ref>
-<to_ref>HEAD</to_ref>
-</generate_explanation>
-
 # Tool Use Examples
 
 ## Example 1: Requesting to execute a command

--- a/src/core/prompts/system-prompt/__tests__/__snapshots__/anthropic_claude_sonnet_4-no-focus-chain.snap
+++ b/src/core/prompts/system-prompt/__tests__/__snapshots__/anthropic_claude_sonnet_4-no-focus-chain.snap
@@ -227,19 +227,6 @@ Usage:
 <load_mcp_documentation>
 </load_mcp_documentation>
 
-## generate_explanation
-Description: Opens a multi-file diff view and generates AI-powered inline comments explaining the changes between two git references. Use this tool to help users understand code changes from git commits, pull requests, branches, or any git refs. The tool uses git to retrieve file contents and displays a side-by-side diff view with explanatory comments.
-Parameters:
-- title: (required) A descriptive title for the diff view (e.g., 'Changes in commit abc123', 'PR #42: Add authentication', 'Changes between main and feature-branch')
-- from_ref: (required) The git reference for the 'before' state. Can be a commit hash, branch name, tag, or relative reference like HEAD~1, HEAD^, origin/main, etc.
-- to_ref: (optional) The git reference for the 'after' state. Can be a commit hash, branch name, tag, or relative reference. If not provided, compares to the current working directory (including uncommitted changes).
-Usage:
-<generate_explanation>
-<title>Changes in last commit</title>
-<from_ref>HEAD~1</from_ref>
-<to_ref>HEAD</to_ref>
-</generate_explanation>
-
 # Tool Use Examples
 
 ## Example 1: Requesting to execute a command

--- a/src/core/prompts/system-prompt/__tests__/__snapshots__/anthropic_claude_sonnet_4-no-mcp.snap
+++ b/src/core/prompts/system-prompt/__tests__/__snapshots__/anthropic_claude_sonnet_4-no-mcp.snap
@@ -253,19 +253,6 @@ Usage:
 <load_mcp_documentation>
 </load_mcp_documentation>
 
-## generate_explanation
-Description: Opens a multi-file diff view and generates AI-powered inline comments explaining the changes between two git references. Use this tool to help users understand code changes from git commits, pull requests, branches, or any git refs. The tool uses git to retrieve file contents and displays a side-by-side diff view with explanatory comments.
-Parameters:
-- title: (required) A descriptive title for the diff view (e.g., 'Changes in commit abc123', 'PR #42: Add authentication', 'Changes between main and feature-branch')
-- from_ref: (required) The git reference for the 'before' state. Can be a commit hash, branch name, tag, or relative reference like HEAD~1, HEAD^, origin/main, etc.
-- to_ref: (optional) The git reference for the 'after' state. Can be a commit hash, branch name, tag, or relative reference. If not provided, compares to the current working directory (including uncommitted changes).
-Usage:
-<generate_explanation>
-<title>Changes in last commit</title>
-<from_ref>HEAD~1</from_ref>
-<to_ref>HEAD</to_ref>
-</generate_explanation>
-
 # Tool Use Examples
 
 ## Example 1: Requesting to execute a command

--- a/src/core/prompts/system-prompt/__tests__/__snapshots__/cline_native_next_gen.tools.snap
+++ b/src/core/prompts/system-prompt/__tests__/__snapshots__/cline_native_next_gen.tools.snap
@@ -439,36 +439,6 @@
   {
     "type": "function",
     "function": {
-      "name": "generate_explanation",
-      "description": "Opens a multi-file diff view and generates AI-powered inline comments explaining the changes between two git references. Use this tool to help users understand code changes from git commits, pull requests, branches, or any git refs. The tool uses git to retrieve file contents and displays a side-by-side diff view with explanatory comments.",
-      "strict": false,
-      "parameters": {
-        "type": "object",
-        "properties": {
-          "title": {
-            "type": "string",
-            "description": "A descriptive title for the diff view (e.g., 'Changes in commit abc123', 'PR #42: Add authentication', 'Changes between main and feature-branch')"
-          },
-          "from_ref": {
-            "type": "string",
-            "description": "The git reference for the 'before' state. Can be a commit hash, branch name, tag, or relative reference like HEAD~1, HEAD^, origin/main, etc."
-          },
-          "to_ref": {
-            "type": "string",
-            "description": "The git reference for the 'after' state. Can be a commit hash, branch name, tag, or relative reference. If not provided, compares to the current working directory (including uncommitted changes)."
-          }
-        },
-        "required": [
-          "title",
-          "from_ref"
-        ],
-        "additionalProperties": false
-      }
-    }
-  },
-  {
-    "type": "function",
-    "function": {
       "name": "12345670mcp0test_tool",
       "description": "test-server: A test tool",
       "strict": false,

--- a/src/core/prompts/system-prompt/__tests__/__snapshots__/openai_gpt_3-basic.snap
+++ b/src/core/prompts/system-prompt/__tests__/__snapshots__/openai_gpt_3-basic.snap
@@ -253,19 +253,6 @@ Usage:
 <load_mcp_documentation>
 </load_mcp_documentation>
 
-## generate_explanation
-Description: Opens a multi-file diff view and generates AI-powered inline comments explaining the changes between two git references. Use this tool to help users understand code changes from git commits, pull requests, branches, or any git refs. The tool uses git to retrieve file contents and displays a side-by-side diff view with explanatory comments.
-Parameters:
-- title: (required) A descriptive title for the diff view (e.g., 'Changes in commit abc123', 'PR #42: Add authentication', 'Changes between main and feature-branch')
-- from_ref: (required) The git reference for the 'before' state. Can be a commit hash, branch name, tag, or relative reference like HEAD~1, HEAD^, origin/main, etc.
-- to_ref: (optional) The git reference for the 'after' state. Can be a commit hash, branch name, tag, or relative reference. If not provided, compares to the current working directory (including uncommitted changes).
-Usage:
-<generate_explanation>
-<title>Changes in last commit</title>
-<from_ref>HEAD~1</from_ref>
-<to_ref>HEAD</to_ref>
-</generate_explanation>
-
 # Tool Use Examples
 
 ## Example 1: Requesting to execute a command

--- a/src/core/prompts/system-prompt/__tests__/__snapshots__/openai_gpt_3-no-browser.snap
+++ b/src/core/prompts/system-prompt/__tests__/__snapshots__/openai_gpt_3-no-browser.snap
@@ -219,19 +219,6 @@ Usage:
 <load_mcp_documentation>
 </load_mcp_documentation>
 
-## generate_explanation
-Description: Opens a multi-file diff view and generates AI-powered inline comments explaining the changes between two git references. Use this tool to help users understand code changes from git commits, pull requests, branches, or any git refs. The tool uses git to retrieve file contents and displays a side-by-side diff view with explanatory comments.
-Parameters:
-- title: (required) A descriptive title for the diff view (e.g., 'Changes in commit abc123', 'PR #42: Add authentication', 'Changes between main and feature-branch')
-- from_ref: (required) The git reference for the 'before' state. Can be a commit hash, branch name, tag, or relative reference like HEAD~1, HEAD^, origin/main, etc.
-- to_ref: (optional) The git reference for the 'after' state. Can be a commit hash, branch name, tag, or relative reference. If not provided, compares to the current working directory (including uncommitted changes).
-Usage:
-<generate_explanation>
-<title>Changes in last commit</title>
-<from_ref>HEAD~1</from_ref>
-<to_ref>HEAD</to_ref>
-</generate_explanation>
-
 # Tool Use Examples
 
 ## Example 1: Requesting to execute a command

--- a/src/core/prompts/system-prompt/__tests__/__snapshots__/openai_gpt_3-no-focus-chain.snap
+++ b/src/core/prompts/system-prompt/__tests__/__snapshots__/openai_gpt_3-no-focus-chain.snap
@@ -227,19 +227,6 @@ Usage:
 <load_mcp_documentation>
 </load_mcp_documentation>
 
-## generate_explanation
-Description: Opens a multi-file diff view and generates AI-powered inline comments explaining the changes between two git references. Use this tool to help users understand code changes from git commits, pull requests, branches, or any git refs. The tool uses git to retrieve file contents and displays a side-by-side diff view with explanatory comments.
-Parameters:
-- title: (required) A descriptive title for the diff view (e.g., 'Changes in commit abc123', 'PR #42: Add authentication', 'Changes between main and feature-branch')
-- from_ref: (required) The git reference for the 'before' state. Can be a commit hash, branch name, tag, or relative reference like HEAD~1, HEAD^, origin/main, etc.
-- to_ref: (optional) The git reference for the 'after' state. Can be a commit hash, branch name, tag, or relative reference. If not provided, compares to the current working directory (including uncommitted changes).
-Usage:
-<generate_explanation>
-<title>Changes in last commit</title>
-<from_ref>HEAD~1</from_ref>
-<to_ref>HEAD</to_ref>
-</generate_explanation>
-
 # Tool Use Examples
 
 ## Example 1: Requesting to execute a command

--- a/src/core/prompts/system-prompt/__tests__/__snapshots__/openai_gpt_3-no-mcp.snap
+++ b/src/core/prompts/system-prompt/__tests__/__snapshots__/openai_gpt_3-no-mcp.snap
@@ -253,19 +253,6 @@ Usage:
 <load_mcp_documentation>
 </load_mcp_documentation>
 
-## generate_explanation
-Description: Opens a multi-file diff view and generates AI-powered inline comments explaining the changes between two git references. Use this tool to help users understand code changes from git commits, pull requests, branches, or any git refs. The tool uses git to retrieve file contents and displays a side-by-side diff view with explanatory comments.
-Parameters:
-- title: (required) A descriptive title for the diff view (e.g., 'Changes in commit abc123', 'PR #42: Add authentication', 'Changes between main and feature-branch')
-- from_ref: (required) The git reference for the 'before' state. Can be a commit hash, branch name, tag, or relative reference like HEAD~1, HEAD^, origin/main, etc.
-- to_ref: (optional) The git reference for the 'after' state. Can be a commit hash, branch name, tag, or relative reference. If not provided, compares to the current working directory (including uncommitted changes).
-Usage:
-<generate_explanation>
-<title>Changes in last commit</title>
-<from_ref>HEAD~1</from_ref>
-<to_ref>HEAD</to_ref>
-</generate_explanation>
-
 # Tool Use Examples
 
 ## Example 1: Requesting to execute a command

--- a/src/core/prompts/system-prompt/__tests__/__snapshots__/openai_gpt_5-basic.snap
+++ b/src/core/prompts/system-prompt/__tests__/__snapshots__/openai_gpt_5-basic.snap
@@ -253,19 +253,6 @@ Usage:
 <load_mcp_documentation>
 </load_mcp_documentation>
 
-## generate_explanation
-Description: Opens a multi-file diff view and generates AI-powered inline comments explaining the changes between two git references. Use this tool to help users understand code changes from git commits, pull requests, branches, or any git refs. The tool uses git to retrieve file contents and displays a side-by-side diff view with explanatory comments.
-Parameters:
-- title: (required) A descriptive title for the diff view (e.g., 'Changes in commit abc123', 'PR #42: Add authentication', 'Changes between main and feature-branch')
-- from_ref: (required) The git reference for the 'before' state. Can be a commit hash, branch name, tag, or relative reference like HEAD~1, HEAD^, origin/main, etc.
-- to_ref: (optional) The git reference for the 'after' state. Can be a commit hash, branch name, tag, or relative reference. If not provided, compares to the current working directory (including uncommitted changes).
-Usage:
-<generate_explanation>
-<title>Changes in last commit</title>
-<from_ref>HEAD~1</from_ref>
-<to_ref>HEAD</to_ref>
-</generate_explanation>
-
 # Tool Use Examples
 
 ## Example 1: Requesting to execute a command

--- a/src/core/prompts/system-prompt/__tests__/__snapshots__/openai_gpt_5-no-browser.snap
+++ b/src/core/prompts/system-prompt/__tests__/__snapshots__/openai_gpt_5-no-browser.snap
@@ -219,19 +219,6 @@ Usage:
 <load_mcp_documentation>
 </load_mcp_documentation>
 
-## generate_explanation
-Description: Opens a multi-file diff view and generates AI-powered inline comments explaining the changes between two git references. Use this tool to help users understand code changes from git commits, pull requests, branches, or any git refs. The tool uses git to retrieve file contents and displays a side-by-side diff view with explanatory comments.
-Parameters:
-- title: (required) A descriptive title for the diff view (e.g., 'Changes in commit abc123', 'PR #42: Add authentication', 'Changes between main and feature-branch')
-- from_ref: (required) The git reference for the 'before' state. Can be a commit hash, branch name, tag, or relative reference like HEAD~1, HEAD^, origin/main, etc.
-- to_ref: (optional) The git reference for the 'after' state. Can be a commit hash, branch name, tag, or relative reference. If not provided, compares to the current working directory (including uncommitted changes).
-Usage:
-<generate_explanation>
-<title>Changes in last commit</title>
-<from_ref>HEAD~1</from_ref>
-<to_ref>HEAD</to_ref>
-</generate_explanation>
-
 # Tool Use Examples
 
 ## Example 1: Requesting to execute a command

--- a/src/core/prompts/system-prompt/__tests__/__snapshots__/openai_gpt_5-no-focus-chain.snap
+++ b/src/core/prompts/system-prompt/__tests__/__snapshots__/openai_gpt_5-no-focus-chain.snap
@@ -227,19 +227,6 @@ Usage:
 <load_mcp_documentation>
 </load_mcp_documentation>
 
-## generate_explanation
-Description: Opens a multi-file diff view and generates AI-powered inline comments explaining the changes between two git references. Use this tool to help users understand code changes from git commits, pull requests, branches, or any git refs. The tool uses git to retrieve file contents and displays a side-by-side diff view with explanatory comments.
-Parameters:
-- title: (required) A descriptive title for the diff view (e.g., 'Changes in commit abc123', 'PR #42: Add authentication', 'Changes between main and feature-branch')
-- from_ref: (required) The git reference for the 'before' state. Can be a commit hash, branch name, tag, or relative reference like HEAD~1, HEAD^, origin/main, etc.
-- to_ref: (optional) The git reference for the 'after' state. Can be a commit hash, branch name, tag, or relative reference. If not provided, compares to the current working directory (including uncommitted changes).
-Usage:
-<generate_explanation>
-<title>Changes in last commit</title>
-<from_ref>HEAD~1</from_ref>
-<to_ref>HEAD</to_ref>
-</generate_explanation>
-
 # Tool Use Examples
 
 ## Example 1: Requesting to execute a command

--- a/src/core/prompts/system-prompt/__tests__/__snapshots__/openai_gpt_5-no-mcp.snap
+++ b/src/core/prompts/system-prompt/__tests__/__snapshots__/openai_gpt_5-no-mcp.snap
@@ -253,19 +253,6 @@ Usage:
 <load_mcp_documentation>
 </load_mcp_documentation>
 
-## generate_explanation
-Description: Opens a multi-file diff view and generates AI-powered inline comments explaining the changes between two git references. Use this tool to help users understand code changes from git commits, pull requests, branches, or any git refs. The tool uses git to retrieve file contents and displays a side-by-side diff view with explanatory comments.
-Parameters:
-- title: (required) A descriptive title for the diff view (e.g., 'Changes in commit abc123', 'PR #42: Add authentication', 'Changes between main and feature-branch')
-- from_ref: (required) The git reference for the 'before' state. Can be a commit hash, branch name, tag, or relative reference like HEAD~1, HEAD^, origin/main, etc.
-- to_ref: (optional) The git reference for the 'after' state. Can be a commit hash, branch name, tag, or relative reference. If not provided, compares to the current working directory (including uncommitted changes).
-Usage:
-<generate_explanation>
-<title>Changes in last commit</title>
-<from_ref>HEAD~1</from_ref>
-<to_ref>HEAD</to_ref>
-</generate_explanation>
-
 # Tool Use Examples
 
 ## Example 1: Requesting to execute a command

--- a/src/core/prompts/system-prompt/__tests__/__snapshots__/openai_gpt_5_1_native.tools.snap
+++ b/src/core/prompts/system-prompt/__tests__/__snapshots__/openai_gpt_5_1_native.tools.snap
@@ -390,36 +390,6 @@
   {
     "type": "function",
     "function": {
-      "name": "generate_explanation",
-      "description": "Opens a multi-file diff view and generates AI-powered inline comments explaining the changes between two git references. Use this tool to help users understand code changes from git commits, pull requests, branches, or any git refs. The tool uses git to retrieve file contents and displays a side-by-side diff view with explanatory comments.",
-      "strict": false,
-      "parameters": {
-        "type": "object",
-        "properties": {
-          "title": {
-            "type": "string",
-            "description": "A descriptive title for the diff view (e.g., 'Changes in commit abc123', 'PR #42: Add authentication', 'Changes between main and feature-branch')"
-          },
-          "from_ref": {
-            "type": "string",
-            "description": "The git reference for the 'before' state. Can be a commit hash, branch name, tag, or relative reference like HEAD~1, HEAD^, origin/main, etc."
-          },
-          "to_ref": {
-            "type": "string",
-            "description": "The git reference for the 'after' state. Can be a commit hash, branch name, tag, or relative reference. If not provided, compares to the current working directory (including uncommitted changes)."
-          }
-        },
-        "required": [
-          "title",
-          "from_ref"
-        ],
-        "additionalProperties": false
-      }
-    }
-  },
-  {
-    "type": "function",
-    "function": {
       "name": "12345670mcp0test_tool",
       "description": "test-server: A test tool",
       "strict": false,

--- a/src/core/prompts/system-prompt/__tests__/__snapshots__/openai_gpt_5_native.tools.snap
+++ b/src/core/prompts/system-prompt/__tests__/__snapshots__/openai_gpt_5_native.tools.snap
@@ -376,36 +376,6 @@
   {
     "type": "function",
     "function": {
-      "name": "generate_explanation",
-      "description": "Opens a multi-file diff view and generates AI-powered inline comments explaining the changes between two git references. Use this tool to help users understand code changes from git commits, pull requests, branches, or any git refs. The tool uses git to retrieve file contents and displays a side-by-side diff view with explanatory comments.",
-      "strict": false,
-      "parameters": {
-        "type": "object",
-        "properties": {
-          "title": {
-            "type": "string",
-            "description": "A descriptive title for the diff view (e.g., 'Changes in commit abc123', 'PR #42: Add authentication', 'Changes between main and feature-branch')"
-          },
-          "from_ref": {
-            "type": "string",
-            "description": "The git reference for the 'before' state. Can be a commit hash, branch name, tag, or relative reference like HEAD~1, HEAD^, origin/main, etc."
-          },
-          "to_ref": {
-            "type": "string",
-            "description": "The git reference for the 'after' state. Can be a commit hash, branch name, tag, or relative reference. If not provided, compares to the current working directory (including uncommitted changes)."
-          }
-        },
-        "required": [
-          "title",
-          "from_ref"
-        ],
-        "additionalProperties": false
-      }
-    }
-  },
-  {
-    "type": "function",
-    "function": {
       "name": "12345670mcp0test_tool",
       "description": "test-server: A test tool",
       "strict": false,

--- a/src/core/prompts/system-prompt/__tests__/__snapshots__/vertex_gemini3.tools.snap
+++ b/src/core/prompts/system-prompt/__tests__/__snapshots__/vertex_gemini3.tools.snap
@@ -331,28 +331,6 @@
     }
   },
   {
-    "name": "generate_explanation",
-    "description": "Opens a multi-file diff view and generates AI-powered inline comments explaining the changes between two git references. Use this tool to help users understand code changes from git commits, pull requests, branches, or any git refs. The tool uses git to retrieve file contents and displays a side-by-side diff view with explanatory comments.",
-    "parameters": {
-      "type": "OBJECT",
-      "properties": {
-        "title": {
-          "type": "STRING"
-        },
-        "from_ref": {
-          "type": "STRING"
-        },
-        "to_ref": {
-          "type": "STRING"
-        }
-      },
-      "required": [
-        "title",
-        "from_ref"
-      ]
-    }
-  },
-  {
     "name": "12345670mcp0test_tool",
     "description": "test-server: A test tool",
     "parameters": {

--- a/src/core/prompts/system-prompt/tools/generate_explanation.ts
+++ b/src/core/prompts/system-prompt/tools/generate_explanation.ts
@@ -10,6 +10,7 @@ const GENERIC: ClineToolSpec = {
 	name: "generate_explanation",
 	description:
 		"Opens a multi-file diff view and generates AI-powered inline comments explaining the changes between two git references. Use this tool to help users understand code changes from git commits, pull requests, branches, or any git refs. The tool uses git to retrieve file contents and displays a side-by-side diff view with explanatory comments.",
+	contextRequirements: (context) => context.ide === "Visual Studio Code",
 	parameters: [
 		{
 			name: "title",


### PR DESCRIPTION
### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** #7807 

### Description

This PR excludes `generate_explanation` tool from system prompt for non VS Code platforms. Adds a `contextRequirements` check to the `generate_explanation` tool so it is only included when the IDE is Visual Studio Code.

### Test Procedure

1. Verified tool inclusion when `context.ide === "Visual Studio Code"`
2. Verified tool exclusion for non-VS Code contexts
3. Updated unit test snapshots

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots
N/A

### Additional Notes

N/A


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Restricts `generate_explanation` tool to Visual Studio Code by adding `contextRequirements` and updates test snapshots accordingly.
> 
>   - **Behavior**:
>     - Adds `contextRequirements` to `generate_explanation` in `generate_explanation.ts` to restrict tool usage to Visual Studio Code.
>     - Removes `generate_explanation` tool from system prompts for non-VS Code platforms in multiple snapshot files.
>   - **Testing**:
>     - Updates unit test snapshots in `anthropic_claude_sonnet_4-basic.snap`, `openai_gpt_3-basic.snap`, and `vertex_gemini3.tools.snap` to reflect the exclusion of the tool for non-VS Code platforms.
>   - **Misc**:
>     - Adds a changeset `true-lemons-shop.md` to document the patch change.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for e736400b0d3f1d4681fadfdad04bd75ed73f28b1. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->