### PR TITLE
feat: add lint rule to enforce webview import boundaries

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -133,6 +133,14 @@
 	"overrides": [
 		{
 			"includes": [
+				"webview-ui/**"
+			],
+			"plugins": [
+				"src/dev/grit/webview-import-boundary.grit"
+			]
+		},
+		{
+			"includes": [
 				"**",
 				"!**/hosts/vscode/**",
 				"!**/test/**",

--- a/src/dev/grit/webview-import-boundary.grit
+++ b/src/dev/grit/webview-import-boundary.grit
@@ -1,0 +1,33 @@
+// Enforce import boundaries for webview code.
+// The webview should only import from @shared/* and its own modules,
+// never from extension-only paths like @core/*, @hosts/*, @api/*, etc.
+// This maintains the architectural separation between webview and extension.
+
+or {
+	// Regular imports
+	`import $x from $source` where {
+		or {
+			$source <: includes "@core/",
+			$source <: includes "@hosts/",
+			$source <: includes "@api/",
+			$source <: includes "@services/",
+			$source <: includes "@integrations/",
+			$source <: includes "@packages/",
+			$source <: includes "@generated/"
+		},
+		register_diagnostic(span=$source, message="Webview cannot import from extension modules. Use @shared/* for shared types or communicate via gRPC bridge.")
+	},
+	// Type imports
+	`import type $x from $source` where {
+		or {
+			$source <: includes "@core/",
+			$source <: includes "@hosts/",
+			$source <: includes "@api/",
+			$source <: includes "@services/",
+			$source <: includes "@integrations/",
+			$source <: includes "@packages/",
+			$source <: includes "@generated/"
+		},
+		register_diagnostic(span=$source, message="Webview cannot import types from extension modules. Use @shared/* for shared types.")
+	}
+}


### PR DESCRIPTION
## Summary

Adds a GritQL-based Biome plugin that enforces architectural separation between the webview and extension code at lint time.

The Cline codebase has a host bridge architecture where the webview communicates with the extension via gRPC, not direct imports. This rule catches violations automatically:

**Blocked imports in webview-ui/**:
- `@core/*` - Extension core logic
- `@hosts/*` - Host-specific implementations  
- `@api/*` - API implementations
- `@services/*` - Extension services
- `@integrations/*` - Extension integrations
- `@packages/*` - Extension packages
- `@generated/*` - Generated code (except shared protos)

**Allowed**:
- `@shared/*` - Shared types and proto definitions
- `@/*` (webview's own src)
- `@components/*`, `@context/*`, `@utils/*` (webview internals)

Example lint error:
```
webview-ui/src/foo.ts:4:27 plugin
  × Webview cannot import from extension modules. Use @shared/* for shared types or communicate via gRPC bridge.

  > 4 │ import { something } from "@core/task/Task"
      │                           ^^^^^^^^^^^^^^^^^
```

## Why

This is a guardrail for AI-assisted coding. When Claude or other AI tools generate code, they don't inherently know about architectural boundaries. This lint rule catches violations before they reach code review.

## Test plan

- [x] Created test file with forbidden and allowed imports
- [x] Verified forbidden imports are caught (`@core/`, `@hosts/`, `@api/`)
- [x] Verified allowed imports pass (`@shared/`)
- [x] Verified `import type` syntax is also caught
- [x] Full lint suite passes: `npm run lint`
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds a Biome plugin to enforce import boundaries in `webview-ui`, blocking imports from extension paths and allowing shared imports.
> 
>   - **Behavior**:
>     - Adds a GritQL-based Biome plugin in `webview-import-boundary.grit` to enforce import boundaries for `webview-ui`.
>     - Blocks imports from `@core/*`, `@hosts/*`, `@api/*`, `@services/*`, `@integrations/*`, `@packages/*`, `@generated/*`.
>     - Allows imports from `@shared/*`, `@/*`, `@components/*`, `@context/*`, `@utils/*`.
>     - Provides diagnostic messages for blocked imports.
>   - **Configuration**:
>     - Updates `biome.jsonc` to include the new plugin for `webview-ui/**`.
>   - **Testing**:
>     - Tests verify blocked imports (`@core/`, `@hosts/`, `@api/`) and allowed imports (`@shared/`).
>     - Confirms `import type` syntax is also caught.
>     - Full lint suite passes with `npm run lint`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 6aa1ce9bab6407a136cb6696ff980922f442aae9. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->