### PR TITLE
Fixes broken documentation link in AboutSection

### DIFF
--- a/webview-ui/src/components/settings/sections/AboutSection.tsx
+++ b/webview-ui/src/components/settings/sections/AboutSection.tsx
@@ -41,7 +41,7 @@ const AboutSection = ({ version, renderSectionHeader }: AboutSectionProps) => {
 
 					<h3 className="text-md font-semibold">Resources</h3>
 					<p>
-						<VSCodeLink href="https://docs.cline.bot/getting-started/for-new-coders">Documentation</VSCodeLink>
+						<VSCodeLink href="https://docs.cline.bot/">Documentation</VSCodeLink>
 						{" • "}
 						<VSCodeLink href="https://cline.bot/">https://cline.bot</VSCodeLink>
 					</p>


### PR DESCRIPTION
This pull request makes a small update to the documentation link in the `AboutSection` of the settings UI, ensuring users are directed to the main documentation page.

- Updated the "Documentation" link in the `AboutSection` component to point to the main docs homepage instead of a subpage.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes broken documentation link in `AboutSection` to point to main docs homepage.
> 
>   - **Behavior**:
>     - Updated "Documentation" link in `AboutSection` component to point to `https://docs.cline.bot/` instead of a subpage.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for ac3cc98bd8f94a05ba6d80d0c23cd576a4df6813. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->