### PR TITLE
fix: stop auto-opening sidebar on extension update

### DIFF
--- a/.changeset/remove-auto-open.md
+++ b/.changeset/remove-auto-open.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Stop automatically opening Cline sidebar on extension update - only show a notification

--- a/src/common.ts
+++ b/src/common.ts
@@ -104,17 +104,15 @@ async function showVersionUpdateAnnouncement(context: vscode.ExtensionContext) {
 		if (!previousVersion || currentVersion !== previousVersion) {
 			Logger.log(`Cline version changed: ${previousVersion} -> ${currentVersion}. First run or update detected.`)
 
-			// Use the same condition as announcements: focus when there's a new announcement to show
+			// Check if there's a new announcement to show
 			const lastShownAnnouncementId = context.globalState.get<string>("lastShownAnnouncementId")
 			const latestAnnouncementId = getLatestAnnouncementId()
 
 			if (lastShownAnnouncementId !== latestAnnouncementId) {
-				// Focus Cline when there's a new announcement to show (major/minor updates or fresh installs)
+				// Show notification when there's a new announcement (major/minor updates or fresh installs)
 				const message = previousVersion
 					? `Cline has been updated to v${currentVersion}`
 					: `Welcome to Cline v${currentVersion}`
-				await HostProvider.workspace.openClineSidebarPanel({})
-				await new Promise((resolve) => setTimeout(resolve, 200))
 				HostProvider.window.showMessage({
 					type: ShowMessageType.INFORMATION,
 					message,


### PR DESCRIPTION
### Related Issue

This is a minor UX fix - no prior issue/discussion required per template guidelines.

### Description

When Cline updates, it currently forces the sidebar to open on VS Code launch. This is disruptive - extensions shouldn't steal focus during startup.

This change removes that behavior while keeping everything else:
- Notification still appears ("Cline has been updated to vX.X.X")
- Announcement UI still shows when user manually opens Cline
- Version tracking continues to work as expected

### Test Procedure

- Simulated an update by modifying the stored `clineVersion` in globalState
- Restarted VS Code and verified:
  - Notification appears as expected
  - Sidebar does NOT auto-open/steal focus
  - Manually opening Cline shows the announcement component correctly

### Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

### Pre-flight Checklist

- [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
- [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
- [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
- [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A - removes behavior rather than adding UI

### Additional Notes

Removed from `src/common.ts`:
- `openClineSidebarPanel()` call that auto-focuses the sidebar
- 200ms delay that was only needed for the above