### PR TITLE
fix: restore dummy thought signature for cross-model transfers (Gemini)

### DIFF
--- a/src/core/api/transform/gemini-format.ts
+++ b/src/core/api/transform/gemini-format.ts
@@ -30,17 +30,13 @@ export function convertAnthropicContentToGemini(content: string | ClineStorageMe
 						},
 					}
 				case "tool_use":
-					// For Gemini: tool calls require thought signatures. If missing, drop the block.
-					// See: https://github.com/cline/cline/issues/8214
-					if (!block.signature) {
-						return undefined
-					}
 					return {
 						functionCall: {
 							name: block.name,
 							args: block.input as Record<string, unknown>,
 						},
-						thoughtSignature: block.signature,
+						// Thought signature is required, so provide a dummy one if not present
+						thoughtSignature: block.signature || GEMINI_DUMMY_THOUGHT_SIGNATURE,
 					}
 				case "tool_result":
 					return {
@@ -52,12 +48,11 @@ export function convertAnthropicContentToGemini(content: string | ClineStorageMe
 						},
 					}
 				case "thinking":
-					// For Gemini: thought signatures are required. If missing, drop the block.
-					// See: https://github.com/cline/cline/issues/8214
-					if (!block.signature) {
-						return undefined
+					return {
+						text: block.thinking,
+						thought: true,
+						thoughtSignature: block.signature || GEMINI_DUMMY_THOUGHT_SIGNATURE,
 					}
-					return { text: block.thinking, thought: true, thoughtSignature: block.signature }
 				default:
 					return undefined
 			}


### PR DESCRIPTION
### Related Issue

**Issue:** #8214
**PRs:** #8291 #8122

### Description

Reverts the signature check from #8291 that dropped blocks without signatures, restoring the fallback to `GEMINI_DUMMY_THOUGHT_SIGNATURE` from #8122 to support transferring history from other models to Gemini.

Per [Google's thought signatures FAQ](https://ai.google.dev/gemini-api/docs/thought-signatures#faqs), the dummy signature `"skip_thought_signature_validator"` should be used when transferring traces from models that don't include thought signatures.

### Test Procedure

- Verified the change restores the `|| GEMINI_DUMMY_THOUGHT_SIGNATURE` fallback for both `tool_use` and `thinking` blocks
- This allows conversations started with Claude/Anthropic to continue with Gemini without 400 errors

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A - backend change

### Additional Notes

This is a minimal fix that restores the original behavior from #8122 while keeping the other protections from #8291 (reasoning_details filtering, etc.) intact.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Restores dummy thought signature fallback in `convertAnthropicContentToGemini` to support cross-model history transfers without errors.
> 
>   - **Behavior**:
>     - Restores fallback to `GEMINI_DUMMY_THOUGHT_SIGNATURE` in `convertAnthropicContentToGemini` for `tool_use` and `thinking` blocks.
>     - Prevents 400 errors when transferring conversations from Claude/Anthropic to Gemini.
>   - **Misc**:
>     - Reverts signature check from #8291 that dropped blocks without signatures.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 904cf6b028ec7bcda51cff7ddfaa184690d4324a. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->