### PR TITLE
fix: preserve file endings and trailing newlines across all edit tools

### DIFF
--- a/.changeset/dull-ravens-yawn.md
+++ b/.changeset/dull-ravens-yawn.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+fix: preserve file endings and trailing newlines across all edit tools

--- a/src/core/task/tools/handlers/ApplyPatchHandler.ts
+++ b/src/core/task/tools/handlers/ApplyPatchHandler.ts
@@ -468,7 +468,7 @@ export class ApplyPatchHandler implements IFullyManagedTool {
 					changes[path] = {
 						type: PatchActionType.UPDATE,
 						oldContent: originalFiles[path],
-						newContent: this.applyChunks(originalFiles[path]!, action.chunks, path).trimEnd(),
+						newContent: this.applyChunks(originalFiles[path]!, action.chunks, path),
 						movePath: action.movePath,
 					}
 					break

--- a/src/core/task/tools/handlers/WriteToFileToolHandler.ts
+++ b/src/core/task/tools/handlers/WriteToFileToolHandler.ts
@@ -480,8 +480,6 @@ export class WriteToFileToolHandler implements IFullyManagedTool {
 			return
 		}
 
-		newContent = newContent.trimEnd() // remove any trailing newlines, since it's automatically inserted by the editor
-
 		return { relPath, absolutePath, fileExists, diff, content, newContent, workspaceContext }
 	}
 

--- a/src/hosts/vscode/VscodeDiffViewProvider.ts
+++ b/src/hosts/vscode/VscodeDiffViewProvider.ts
@@ -96,16 +96,33 @@ export class VscodeDiffViewProvider extends DiffViewProvider {
 		if (!this.activeDiffEditor || !this.activeDiffEditor.document) {
 			throw new Error("User closed text editor, unable to edit file...")
 		}
+
 		// Place cursor at the beginning of the diff editor to keep it out of the way of the stream animation
 		const beginningOfDocument = new vscode.Position(0, 0)
 		this.activeDiffEditor.selection = new vscode.Selection(beginningOfDocument, beginningOfDocument)
 
 		// Replace the text in the diff editor document.
-		const document = this.activeDiffEditor?.document
+		const document = this.activeDiffEditor.document
 		const edit = new vscode.WorkspaceEdit()
-		const range = new vscode.Range(rangeToReplace.startLine, 0, rangeToReplace.endLine, 0)
-		edit.replace(document.uri, range, content)
+
+		// IMPORTANT: VS Code may treat an out-of-bounds end position as an insertion instead of a
+		// replacement. Always validate the range against the current document to keep edits
+		// strictly within the real end-of-file.
+		const startLine = Math.max(0, Math.min(rangeToReplace.startLine, document.lineCount - 1))
+		const desiredEndLine = Math.max(rangeToReplace.startLine, rangeToReplace.endLine)
+		const validatedRange = document.validateRange(
+			new vscode.Range(new vscode.Position(startLine, 0), new vscode.Position(desiredEndLine, 0)),
+		)
+
+		edit.replace(document.uri, validatedRange, content)
 		await vscode.workspace.applyEdit(edit)
+
+		// Preserve trailing newline: if content ends with newline, ensure document does too
+		if (content.endsWith("\n") && !document.getText().endsWith("\n")) {
+			const fixEdit = new vscode.WorkspaceEdit()
+			fixEdit.insert(document.uri, document.lineAt(Math.max(0, document.lineCount - 1)).range.end, "\n")
+			await vscode.workspace.applyEdit(fixEdit)
+		}
 
 		if (currentLine !== undefined) {
 			// Update decorations for the entire changed section

--- a/src/integrations/editor/FileEditProvider.ts
+++ b/src/integrations/editor/FileEditProvider.ts
@@ -43,19 +43,48 @@ export class FileEditProvider extends DiffViewProvider {
 
 		// Split the document into lines
 		const lines = this.documentContent.split("\n")
+		const originalEndsWithNewline = this.documentContent.endsWith("\n")
+
+		// If original ends with newline, split creates a trailing empty string that isn't a real line.
+		// Remove it for line-based operations, we'll add it back at the end if needed.
+		const realLines = originalEndsWithNewline && lines[lines.length - 1] === "" ? lines.slice(0, -1) : lines
 
 		// Replace the specified range with the new content
 		const newContentLines = content.split("\n")
-		// Remove trailing empty line if present in newContentLines for proper splicing
-		if (newContentLines[newContentLines.length - 1] === "") {
+		const contentEndsWithNewline = content.endsWith("\n")
+
+		// Determine if we're replacing to the end of the document
+		const replacingToEnd = rangeToReplace.endLine >= realLines.length
+
+		// Handle trailing empty string from split:
+		// - If content ends with \n, split creates an empty string at the end
+		// - When replacing to end: this empty string becomes the document's trailing newline - keep it
+		// - When replacing middle: this empty string would create an extra newline - remove it
+		//   (the join operation will naturally add newlines between lines)
+		// - If content doesn't end with \n but split created empty string, remove it
+		if (!contentEndsWithNewline && newContentLines[newContentLines.length - 1] === "") {
+			newContentLines.pop()
+		} else if (contentEndsWithNewline && !replacingToEnd && newContentLines[newContentLines.length - 1] === "") {
+			// Content ends with newline but we're replacing middle section - remove trailing empty string
 			newContentLines.pop()
 		}
 
-		// Splice the lines array to replace the range
-		lines.splice(rangeToReplace.startLine, rangeToReplace.endLine - rangeToReplace.startLine, ...newContentLines)
+		// Splice the real lines array to replace the range
+		realLines.splice(rangeToReplace.startLine, rangeToReplace.endLine - rangeToReplace.startLine, ...newContentLines)
 
 		// Join the lines back together
-		this.documentContent = lines.join("\n")
+		let result = realLines.join("\n")
+
+		// Preserve trailing newline: add it back if original had one OR if we replaced to end with content that ends with newline
+		const shouldHaveTrailingNewline = originalEndsWithNewline || (replacingToEnd && contentEndsWithNewline)
+		if (shouldHaveTrailingNewline && !result.endsWith("\n")) {
+			result += "\n"
+		} else if (!shouldHaveTrailingNewline && result.endsWith("\n")) {
+			// Shouldn't have trailing newline but result has one - remove it
+			result = result.slice(0, -1)
+		}
+
+		this.documentContent = result
 	}
 
 	protected async scrollEditorToLine(_line: number): Promise<void> {

--- a/src/test/diff-logic.test.ts
+++ b/src/test/diff-logic.test.ts
@@ -1,0 +1,54 @@
+import * as assert from "assert"
+import { describe, it } from "mocha"
+import { FileEditProvider } from "../integrations/editor/FileEditProvider"
+
+describe("FileEditProvider Trailing Newline", () => {
+	// Helper to set up provider without calling open()
+	function setupProvider(initialContent: string): FileEditProvider {
+		const provider = new FileEditProvider()
+		provider["isEditing"] = true
+		provider["documentContent"] = initialContent
+		provider["originalContent"] = initialContent
+		return provider
+	}
+
+	it("preserves trailing newline when content ends with newline", async () => {
+		const provider = setupProvider("line1\nline2\n")
+
+		await provider.replaceText("new1\nnew2\n", { startLine: 0, endLine: 2 }, undefined)
+		const result = await provider.getContent()
+
+		assert.strictEqual(result, "new1\nnew2\n")
+		assert.strictEqual(result?.endsWith("\n"), true)
+	})
+
+	it("does not add trailing newline when content does not end with newline", async () => {
+		const provider = setupProvider("line1\nline2")
+
+		await provider.replaceText("new1\nnew2", { startLine: 0, endLine: 2 }, undefined)
+		const result = await provider.getContent()
+
+		assert.strictEqual(result, "new1\nnew2")
+		assert.strictEqual(result?.endsWith("\n"), false)
+	})
+
+	it("preserves trailing newline when replacing middle section", async () => {
+		const provider = setupProvider("line1\nline2\nline3\n")
+
+		await provider.replaceText("new2\n", { startLine: 1, endLine: 2 }, undefined)
+		const result = await provider.getContent()
+
+		assert.strictEqual(result, "line1\nnew2\nline3\n")
+		assert.strictEqual(result?.endsWith("\n"), true)
+	})
+
+	it("handles file without trailing newline correctly", async () => {
+		const provider = setupProvider("line1\nline2")
+
+		await provider.replaceText("new1\nnew2\n", { startLine: 0, endLine: 2 }, undefined)
+		const result = await provider.getContent()
+
+		assert.strictEqual(result, "new1\nnew2\n")
+		assert.strictEqual(result?.endsWith("\n"), true)
+	})
+})

--- a/src/test/diff-newline-repro.test.ts
+++ b/src/test/diff-newline-repro.test.ts
@@ -1,0 +1,82 @@
+import * as assert from "assert"
+import { describe, it } from "mocha"
+import { DiffViewProvider } from "../integrations/editor/DiffViewProvider"
+
+class TestDiffViewProvider extends DiffViewProvider {
+	public documentText: string = ""
+	public replacements: { content: string; range: { startLine: number; endLine: number } }[] = []
+
+	async openDiffEditor(): Promise<void> {}
+	async scrollEditorToLine(line: number): Promise<void> {}
+	async scrollAnimation(startLine: number, endLine: number): Promise<void> {}
+	async truncateDocument(lineNumber: number): Promise<void> {
+		const lines = this.documentText.split("\n")
+		this.documentText = lines.slice(0, lineNumber).join("\n")
+	}
+	async getDocumentText(): Promise<string | undefined> {
+		return this.documentText
+	}
+	async saveDocument(): Promise<Boolean> {
+		return true
+	}
+	async closeAllDiffViews(): Promise<void> {}
+	async resetDiffView(): Promise<void> {}
+
+	async replaceText(
+		content: string,
+		rangeToReplace: { startLine: number; endLine: number },
+		currentLine: number | undefined,
+	): Promise<void> {
+		this.replacements.push({ content, range: rangeToReplace })
+		// Simulate the replacement
+		const lines = this.documentText.split("\n")
+		const newLines = content.split("\n")
+		// Preserve trailing newline logic (simplified)
+		if (!content.endsWith("\n") && newLines[newLines.length - 1] === "") {
+			newLines.pop()
+		}
+		lines.splice(rangeToReplace.startLine, rangeToReplace.endLine - rangeToReplace.startLine, ...newLines)
+		this.documentText = lines.join("\n")
+	}
+
+	public setup(initialContent: string) {
+		this.isEditing = true
+		this.documentText = initialContent
+		this.originalContent = initialContent
+	}
+}
+
+describe("DiffViewProvider Newline handling", () => {
+	it("preserves trailing newline through update() when content ends with newline", async () => {
+		const provider = new TestDiffViewProvider()
+		provider.setup("line1\nline2\n")
+
+		await provider.update("new1\nnew2\n", true)
+		const result = await provider.getDocumentText()
+
+		assert.strictEqual(result, "new1\nnew2\n")
+		assert.strictEqual(result?.endsWith("\n"), true)
+	})
+
+	it("does not add trailing newline when content does not end with newline", async () => {
+		const provider = new TestDiffViewProvider()
+		provider.setup("line1\nline2")
+
+		await provider.update("new1\nnew2", true)
+		const result = await provider.getDocumentText()
+
+		assert.strictEqual(result, "new1\nnew2")
+		assert.strictEqual(result?.endsWith("\n"), false)
+	})
+
+	it("handles file without trailing newline correctly", async () => {
+		const provider = new TestDiffViewProvider()
+		provider.setup("[6]: http://chris.beams.io/posts/git-commit/#seven-rules")
+
+		await provider.update("new content\n", true)
+		const result = await provider.getDocumentText()
+
+		assert.strictEqual(result, "new content\n")
+		assert.strictEqual(result?.endsWith("\n"), true)
+	})
+})


### PR DESCRIPTION
### Related Issue

**PR:** #8167

### Description

Removed manual newline manipulation logic in `ApplyPatchHandler`, `WriteToFileToolHandler`, and `DiffViewProvider` to adopt a "pass-through" philosophy.

Previously, tool handlers were aggressively trimming trailing newlines while the `DiffViewProvider` attempted to manually add them back. This conflict triggered a truncation bug in the diff editor where line counts were calculated from the trimmed content, causing the editor to immediately delete any newlines it just wrote.

Key changes:
- Removed `.trimEnd()` from `ApplyPatchHandler` and `WriteToFileToolHandler` to preserve calculated content exactly.
- Removed manual "add-back" and "strip-back" newline logic from `DiffViewProvider.update()` and `saveChanges()`.
- `DiffViewProvider` now trusts handler output exactly as-is, ensuring zero, one, or multiple trailing newlines are preserved correctly.
- Fixed range validation in `VscodeDiffViewProvider.replaceText()` to prevent VS Code from treating out-of-bounds positions as insertions rather than replacements.
- Added trailing newline fix-up in `VscodeDiffViewProvider` to re-add newlines that VS Code's `applyEdit` may strip.
- Rewrote `FileEditProvider.replaceText()` to properly handle `split("\n")` semantics and preserve trailing newlines in background edit mode.
- Fixed "ghost diffs" and incorrect line removals at the end of files.

### Test Procedure

- Verify that `ApplyPatchHandler` and `WriteToFileToolHandler` preserve trailing newlines in the output without trimming.
- Verify that `DiffViewProvider` correctly displays diffs for files with zero, one, or multiple trailing newlines.
- Confirm that "ghost diffs" (incorrect line removals at the end of files) are no longer present when applying changes.
- Ensure that the editor does not immediately delete newlines after writing them.
- Run unit tests: `npm run test:unit -- src/test/diff-logic.test.ts src/test/diff-newline-repro.test.ts`

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [x] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- ... (standard template text) ... -->

### Additional Notes

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Preserve file endings and trailing newlines across edit tools by removing manual newline manipulations and adding tests.
> 
>   - **Behavior**:
>     - Removed `.trimEnd()` from `ApplyPatchHandler` and `WriteToFileToolHandler` to preserve content exactly.
>     - Removed manual newline logic from `DiffViewProvider.update()` and `saveChanges()`.
>     - `DiffViewProvider` now preserves trailing newlines as-is.
>     - Fixed range validation in `VscodeDiffViewProvider.replaceText()` to prevent out-of-bounds insertions.
>     - Added trailing newline fix-up in `VscodeDiffViewProvider` for VS Code edge cases.
>     - Rewrote `FileEditProvider.replaceText()` to handle `split("\n")` semantics correctly.
>     - Fixed "ghost diffs" and incorrect line removals at file ends.
>   - **Tests**:
>     - Added `diff-logic.test.ts` to test `FileEditProvider` newline handling.
>     - Added `diff-newline-repro.test.ts` to test `DiffViewProvider` newline handling.
>   - **Misc**:
>     - Adjusted `replaceText()` in `VscodeDiffViewProvider` and `FileEditProvider` to handle trailing newlines correctly.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 60478201e312a1ce807505884d05350fc7d6d7be. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->