### PR TITLE
Replace `process.env` usage with a BUILD_CONSTANTS variable

### DIFF
--- a/scripts/test-standalone-core-api-server.ts
+++ b/scripts/test-standalone-core-api-server.ts
@@ -130,7 +130,7 @@ async function main(): Promise<void> {
 			PROTOBUS_ADDRESS: `127.0.0.1:${PROTOBUS_PORT}`,
 			HOST_BRIDGE_ADDRESS: `localhost:${HOSTBRIDGE_PORT}`,
 			E2E_TEST,
-			CLINE_ENVIRONMENT_OVERRIDE: CLINE_ENVIRONMENT,
+			CLINE_ENVIRONMENT,
 			CLINE_DIR: userDataDir,
 			INSTALL_DIR: extensionsDir,
 		},

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -6,7 +6,6 @@
  * @see {@link https://esbuild.github.io/api/#define|docs}
  */
 export const BUILD_CONSTANTS = {
-	IS_STANDALONE: process.env.IS_STANDALONE,
 	TELEMETRY_SERVICE_API_KEY: process.env.TELEMETRY_SERVICE_API_KEY,
 	ERROR_SERVICE_API_KEY: process.env.ERROR_SERVICE_API_KEY,
 	OTEL_TELEMETRY_ENABLED: process.env.OTEL_TELEMETRY_ENABLED,

--- a/src/shared/net.ts
+++ b/src/shared/net.ts
@@ -94,7 +94,6 @@
  */
 
 import { EnvHttpProxyAgent, setGlobalDispatcher, fetch as undiciFetch } from "undici"
-import { BUILD_CONSTANTS } from "./constants"
 
 let mockFetch: typeof globalThis.fetch | undefined
 
@@ -112,8 +111,10 @@ export const fetch: typeof globalThis.fetch = (() => {
 	// Note: Don't use Logger here; it may not be initialized.
 
 	let baseFetch: typeof globalThis.fetch = globalThis.fetch
+	// Note: See esbuild.mjs, process.env.IS_STANDALONE is statically rewritten
+	// to "true" or "false" (as strings) in the JetBrains/CLI build.
 	// We must use explicit string comparison because "false" is truthy in JS.
-	if (BUILD_CONSTANTS.IS_STANDALONE === "true") {
+	if (process.env.IS_STANDALONE === "true") {
 		// Configure undici with ProxyAgent
 		const agent = new EnvHttpProxyAgent({})
 		setGlobalDispatcher(agent)


### PR DESCRIPTION
### Description

`process.env` usage for variables that are `defined` in the `esbuild` option causes misunderstandings when reading the code.
This PR makes the replacement more explicit. 

### Test Procedure

I built the extension locally and tested that the variables were still being replaced in the webview and extension host.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [x] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Refactor to replace `process.env` with `BUILD_CONSTANTS` for build-time variable management in telemetry and error tracking configurations.
> 
>   - **Refactor**:
>     - Replace `process.env` with `BUILD_CONSTANTS` in `constants.ts` for build-time variable definitions.
>     - Update `getOtelConfig()` in `otel-config.ts` to use `BUILD_CONSTANTS` for telemetry configuration.
>     - Modify `posthogConfig` in `posthog-config.ts` to use `BUILD_CONSTANTS` for API keys.
>   - **Misc**:
>     - Add `constants.ts` to define `BUILD_CONSTANTS` object for build-time variable replacement.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 3e85cb99dd680ada161e2d9a894c34f38b1bb81a. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->