### PR TITLE
fix: send repo_url to JetBrains tests for fork PR support

### DIFF
--- a/.github/workflows/trigger-jetbrains-tests.yml
+++ b/.github/workflows/trigger-jetbrains-tests.yml
@@ -56,7 +56,8 @@ jobs:
               "action": "${{ github.event.action }}",
               "sha": "${{ github.event.pull_request.head.sha }}",
               "pr_title": $PR_TITLE,
-              "pr_url": "${{ github.event.pull_request.html_url }}"
+              "pr_url": "${{ github.event.pull_request.html_url }}",
+              "repo_url": "${{ github.event.pull_request.head.repo.clone_url }}"
             }
           }
           EOF


### PR DESCRIPTION
### Related Issue

**Issue:** Fixes fork PR test failures reported in cline/intellij-plugin#642

### Description

This PR fixes an issue where JetBrains integration tests were failing for all fork PRs. 

**Problem:** The `trigger-jetbrains-tests.yml` workflow was only sending `branch_name` in the client payload. For fork PRs, that branch exists only in the contributor's fork repository, not in `cline/cline`. When the JetBrains plugin workflow tried to clone the branch, it failed with:
```
fatal: Remote branch fix/sap-replace-creds-in-orchestration-mode not found in upstream origin
```

**Solution:** Added `repo_url` (using `github.event.pull_request.head.repo.clone_url`) to the client payload. This allows the receiving workflow to clone from the correct repository - either `cline/cline` for regular PRs or the contributor's fork for fork PRs.

This change works in tandem with cline/intellij-plugin#642 which updates the receiving workflow to use the `repo_url` field.

### Test Procedure

**Testing approach:**
1. The change is minimal and safe - it only adds an additional field to the JSON payload
2. The field uses GitHub's standard context variables that are always available for PRs
3. For regular PRs from `cline/cline` branches: `repo_url` will point to `cline/cline`
4. For fork PRs: `repo_url` will point to the contributor's fork

**Verification:**
- The companion PR (cline/intellij-plugin#642) has been tested and validates that the receiving end correctly uses this field
- This is a backwards-compatible addition - existing workflows will continue to work

**Risk assessment:**
- Very low risk: Adding a new field to the payload doesn't break existing functionality
- The receiving workflow (intellij-plugin) has already been updated to handle this field

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A - This is a GitHub Actions workflow change with no UI impact.

### Additional Notes

This PR is part of a two-repository fix:
1. **This PR (cline/cline)**: Adds `repo_url` to the outgoing payload
2. **cline/intellij-plugin#642**: Updates the receiving workflow to use `repo_url`

Both changes are required for fork PRs to work correctly with JetBrains integration tests.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `repo_url` to `trigger-jetbrains-tests.yml` payload to support fork PRs in JetBrains tests.
> 
>   - **Behavior**:
>     - Adds `repo_url` to `client_payload` in `trigger-jetbrains-tests.yml` to support fork PRs.
>     - Uses `github.event.pull_request.head.repo.clone_url` to set `repo_url`.
>   - **Testing**:
>     - Verified with companion PR `cline/intellij-plugin#642`.
>     - Backwards-compatible; existing workflows unaffected.
>   - **Risk**:
>     - Low risk; only adds a field to payload, no breaking changes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 08f0495c812f8f3a70f148f14170c6a55e33721c. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->