### PR TITLE
enabling multiple deletedRanges

### DIFF
--- a/proto/cline/hooks.proto
+++ b/proto/cline/hooks.proto
@@ -75,6 +75,12 @@ message TaskCompleteData {
   map<string, string> task_metadata = 1;
 }
 
+// Message for deleted range tuple (start, end indices)
+message DeletedRange {
+  int32 start_index = 1;
+  int32 end_index = 2;
+}
+
 // Data for PreCompact hook
 message PreCompactData {
   // Task identification
@@ -118,4 +124,7 @@ message PreCompactData {
   // Use this to analyze total context size, overhead, and exactly what the model sees
   // This file will be automatically cleaned up after the hook completes
   string context_raw_path = 13;
+
+  // Multiple non-contiguous deleted ranges (for advanced context compaction)
+  repeated DeletedRange deleted_ranges = 14;
 }

--- a/proto/cline/ui.proto
+++ b/proto/cline/ui.proto
@@ -218,6 +218,8 @@ message ClineMessage {
   ClineAskNewTask ask_new_task = 21;
   ClineApiReqInfo api_req_info = 22;
   ClineModelInfo model_info = 23;
+
+  repeated ConversationHistoryDeletedRange conversation_history_deleted_ranges = 24;
 }
 
 // UiService provides methods for managing UI interactions

--- a/src/core/commands/reconstructTaskHistory.ts
+++ b/src/core/commands/reconstructTaskHistory.ts
@@ -189,6 +189,7 @@ async function reconstructTaskHistoryItem(taskId: string): Promise<HistoryItem |
 			size: taskInfo.size,
 			isFavorited: taskInfo.isFavorited,
 			conversationHistoryDeletedRange: taskInfo.conversationHistoryDeletedRange,
+			conversationHistoryDeletedRanges: taskInfo.conversationHistoryDeletedRanges,
 		}
 
 		return historyItem
@@ -209,6 +210,7 @@ interface TaskInfo {
 	size?: number
 	isFavorited?: boolean
 	conversationHistoryDeletedRange?: [number, number]
+	conversationHistoryDeletedRanges?: Array<[number, number]>
 }
 
 function extractTaskInformation(clineMessages: ClineMessage[], metadata: any): TaskInfo {

--- a/src/core/hooks/precompact-executor.ts
+++ b/src/core/hooks/precompact-executor.ts
@@ -124,6 +124,8 @@ export interface PreCompactHookParams {
 	apiConversationHistory: ClineStorageMessage[]
 	/** Current deleted range (if any) */
 	conversationHistoryDeletedRange?: [number, number]
+	/** Multiple non-contiguous deleted ranges (if any) */
+	conversationHistoryDeletedRanges?: Array<[number, number]>
 	/** Cline messages for extracting token usage */
 	clineMessages: ClineMessage[]
 
@@ -231,6 +233,11 @@ export async function executePreCompactHookWithCleanup(params: PreCompactHookPar
 					deletedRangeEnd,
 					contextJsonPath: contextJsonPath,
 					contextRawPath: contextRawPath,
+					deletedRanges:
+						params.conversationHistoryDeletedRanges?.map((range) => ({
+							startIndex: range[0],
+							endIndex: range[1],
+						})) ?? [],
 				},
 			},
 			isCancellable: true,

--- a/src/core/task/TaskState.ts
+++ b/src/core/task/TaskState.ts
@@ -34,6 +34,7 @@ export class TaskState {
 
 	// Context and history
 	conversationHistoryDeletedRange?: [number, number]
+	conversationHistoryDeletedRanges?: Array<[number, number]>
 
 	// Tool execution flags
 	didRejectTool = false

--- a/src/core/task/index.ts
+++ b/src/core/task/index.ts
@@ -322,6 +322,7 @@ export class Task {
 			this.ulid = historyItem.ulid ?? ulid()
 			this.taskIsFavorited = historyItem.isFavorited
 			this.taskState.conversationHistoryDeletedRange = historyItem.conversationHistoryDeletedRange
+			this.taskState.conversationHistoryDeletedRanges = historyItem.conversationHistoryDeletedRanges
 			if (historyItem.checkpointManagerErrorMessage) {
 				this.taskState.checkpointManagerErrorMessage = historyItem.checkpointManagerErrorMessage
 			}
@@ -382,6 +383,7 @@ export class Task {
 					cancelTask: this.cancelTask,
 					postStateToWebview: this.postStateToWebview,
 					initialConversationHistoryDeletedRange: this.taskState.conversationHistoryDeletedRange,
+					initialConversationHistoryDeletedRanges: this.taskState.conversationHistoryDeletedRanges,
 					initialCheckpointManagerErrorMessage: this.taskState.checkpointManagerErrorMessage,
 					stateManager: this.stateManager,
 				})

--- a/src/core/task/message-state.ts
+++ b/src/core/task/message-state.ts
@@ -118,6 +118,7 @@ export class MessageStateHandler {
 				shadowGitConfigWorkTree: await this.checkpointTracker?.getShadowGitConfigWorkTree(),
 				cwdOnTaskInitialization: cwd,
 				conversationHistoryDeletedRange: this.taskState.conversationHistoryDeletedRange,
+				conversationHistoryDeletedRanges: this.taskState.conversationHistoryDeletedRanges,
 				isFavorited: this.taskIsFavorited,
 				checkpointManagerErrorMessage: this.taskState.checkpointManagerErrorMessage,
 				modelId: lastModelInfo?.modelInfo?.modelId,
@@ -165,6 +166,7 @@ export class MessageStateHandler {
 			// it's important that apiConversationHistory is initialized before we add cline messages
 			message.conversationHistoryIndex = this.apiConversationHistory.length - 1 // NOTE: this is the index of the last added message which is the user message, and once the clinemessages have been presented we update the apiconversationhistory with the completed assistant message. This means when resetting to a message, we need to +1 this index to get the correct assistant message that this tool use corresponds to
 			message.conversationHistoryDeletedRange = this.taskState.conversationHistoryDeletedRange
+			message.conversationHistoryDeletedRanges = this.taskState.conversationHistoryDeletedRanges
 			this.clineMessages.push(message)
 			await this.saveClineMessagesAndUpdateHistoryInternal()
 		})

--- a/src/core/task/tools/handlers/SummarizeTaskHandler.ts
+++ b/src/core/task/tools/handlers/SummarizeTaskHandler.ts
@@ -54,6 +54,7 @@ export class SummarizeTaskHandler implements IToolHandler, IPartialBlockHandler 
 						ulid: config.ulid,
 						apiConversationHistory: apiHistory,
 						conversationHistoryDeletedRange: config.taskState.conversationHistoryDeletedRange,
+						conversationHistoryDeletedRanges: config.taskState.conversationHistoryDeletedRanges,
 						contextManager: config.services.contextManager,
 						clineMessages: config.messageState.getClineMessages(),
 						messageStateHandler: config.messageState,

--- a/src/integrations/checkpoints/factory.ts
+++ b/src/integrations/checkpoints/factory.ts
@@ -46,6 +46,7 @@ type BuildArgs = {
 
 	// initial state for single-root
 	initialConversationHistoryDeletedRange?: [number, number]
+	initialConversationHistoryDeletedRanges?: Array<[number, number]>
 	initialCheckpointManagerErrorMessage?: string
 
 	stateManager: StateManager
@@ -69,6 +70,7 @@ export function buildCheckpointManager(args: BuildArgs): ICheckpointManager {
 		cancelTask,
 		postStateToWebview,
 		initialConversationHistoryDeletedRange,
+		initialConversationHistoryDeletedRanges,
 		initialCheckpointManagerErrorMessage,
 		stateManager,
 	} = args
@@ -99,6 +101,7 @@ export function buildCheckpointManager(args: BuildArgs): ICheckpointManager {
 		},
 		{
 			conversationHistoryDeletedRange: initialConversationHistoryDeletedRange,
+			conversationHistoryDeletedRanges: initialConversationHistoryDeletedRanges,
 			checkpointManagerErrorMessage: initialCheckpointManagerErrorMessage,
 		},
 	)

--- a/src/integrations/checkpoints/index.ts
+++ b/src/integrations/checkpoints/index.ts
@@ -50,6 +50,7 @@ interface CheckpointManagerCallbacks {
 }
 interface CheckpointManagerInternalState {
 	conversationHistoryDeletedRange?: [number, number]
+	conversationHistoryDeletedRanges?: Array<[number, number]>
 	checkpointTracker?: CheckpointTracker
 	checkpointManagerErrorMessage?: string
 	checkpointTrackerInitPromise?: Promise<CheckpointTracker | undefined>
@@ -57,6 +58,7 @@ interface CheckpointManagerInternalState {
 
 interface CheckpointRestoreStateUpdate {
 	conversationHistoryDeletedRange?: [number, number]
+	conversationHistoryDeletedRanges?: Array<[number, number]>
 	checkpointManagerErrorMessage?: string
 }
 
@@ -363,6 +365,9 @@ export class TaskCheckpointManager implements ICheckpointManager {
 				if (this.state.conversationHistoryDeletedRange !== undefined) {
 					checkpointManagerStateUpdate.conversationHistoryDeletedRange = this.state.conversationHistoryDeletedRange
 				}
+				if (this.state.conversationHistoryDeletedRanges !== undefined) {
+					checkpointManagerStateUpdate.conversationHistoryDeletedRanges = this.state.conversationHistoryDeletedRanges
+				}
 			} else {
 				sendRelinquishControlEvent()
 
@@ -663,6 +668,8 @@ export class TaskCheckpointManager implements ICheckpointManager {
 				// Update conversation history deleted range in our state
 				this.state.conversationHistoryDeletedRange = message.conversationHistoryDeletedRange
 				this.taskState.conversationHistoryDeletedRange = message.conversationHistoryDeletedRange
+				this.state.conversationHistoryDeletedRanges = message.conversationHistoryDeletedRanges
+				this.taskState.conversationHistoryDeletedRanges = message.conversationHistoryDeletedRanges
 
 				const apiConversationHistory = this.services.messageStateHandler.getApiConversationHistory()
 				const newConversationHistory = apiConversationHistory.slice(0, (message.conversationHistoryIndex || 0) + 2) // +1 since this index corresponds to the last user message, and another +1 since slice end index is exclusive
@@ -852,14 +859,6 @@ export class TaskCheckpointManager implements ICheckpointManager {
 		} catch (error) {
 			console.error("Failed to post state to webview after checkpoint error:", error)
 		}
-		// TODO - Future telemetry event capture here
-	}
-
-	/**
-	 * Updates the conversation history deleted range
-	 */
-	updateConversationHistoryDeletedRange(range: [number, number] | undefined): void {
-		this.state.conversationHistoryDeletedRange = range
 		// TODO - Future telemetry event capture here
 	}
 

--- a/src/shared/ExtensionMessage.ts
+++ b/src/shared/ExtensionMessage.ts
@@ -125,6 +125,7 @@ export interface ClineMessage {
 	isOperationOutsideWorkspace?: boolean
 	conversationHistoryIndex?: number
 	conversationHistoryDeletedRange?: [number, number] // for when conversation history is truncated for API requests
+	conversationHistoryDeletedRanges?: Array<[number, number]> // for multiple non-contiguous deleted ranges
 	modelInfo?: ClineMessageModelInfo
 }
 

--- a/src/shared/HistoryItem.ts
+++ b/src/shared/HistoryItem.ts
@@ -13,6 +13,7 @@ export type HistoryItem = {
 	shadowGitConfigWorkTree?: string
 	cwdOnTaskInitialization?: string
 	conversationHistoryDeletedRange?: [number, number]
+	conversationHistoryDeletedRanges?: Array<[number, number]>
 	isFavorited?: boolean
 	checkpointManagerErrorMessage?: string
 

--- a/src/shared/proto-conversions/cline-message.ts
+++ b/src/shared/proto-conversions/cline-message.ts
@@ -195,6 +195,11 @@ export function convertClineMessageToProto(message: AppClineMessage): ProtoCline
 					endIndex: message.conversationHistoryDeletedRange[1],
 				}
 			: undefined,
+		conversationHistoryDeletedRanges:
+			message.conversationHistoryDeletedRanges?.map((range) => ({
+				startIndex: range[0],
+				endIndex: range[1],
+			})) ?? [],
 		// Additional optional fields for specific ask/say types
 		sayTool: undefined,
 		sayBrowserAction: undefined,
@@ -270,6 +275,14 @@ export function convertProtoToClineMessage(protoMessage: ProtoClineMessage): App
 			protoMessage.conversationHistoryDeletedRange.startIndex,
 			protoMessage.conversationHistoryDeletedRange.endIndex,
 		]
+	}
+
+	// Convert conversationHistoryDeletedRanges from array of objects to array of tuples
+	if (protoMessage.conversationHistoryDeletedRanges.length > 0) {
+		message.conversationHistoryDeletedRanges = protoMessage.conversationHistoryDeletedRanges.map((range) => [
+			range.startIndex,
+			range.endIndex,
+		])
 	}
 
 	return message


### PR DESCRIPTION
<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- For feature requests: Created a discussion in our Feature Requests discussions board https://github.com/cline/cline/discussions/categories/feature-requests and received approval from core maintainers before implementation
- For all changes: Link the associated issue/discussion in the "Related Issue" section below

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly without prior discussion.

Why this requirement?
We deeply appreciate all community contributions - they are essential to Cline's success! To ensure the best use of everyone's time and maintain project direction, we use our Feature Requests discussions board to gauge community interest and validate feature ideas before implementation begins. This helps us focus development efforts on features that will benefit the most users.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** #XXXX

### Description

Addings a 2d array of `deletedRanges` which enables us to extend the functionality of the singular `deletedRange` by allowing multiple ranges of blocks to be removed from the conversation history when making api requests. This pr adds this new field but does not use it or migrate any logic away from using the base `deletedRange`.

<!-- 
Help reviewers understand your changes by making this PR readable and well-organized:

- What problem does this PR solve?
- Why were these changes introduced and what purpose do they serve?
- For larger changes, provide context about your approach and reasoning

Small PRs may need minimal description, but larger changes benefit from explaining where you're coming from. Much of this context can be in the linked issue above, so feel free to reference it rather than repeating everything here.
-->

### Test Procedure

<!-- 
Please walk us through your testing approach and thought process. This helps reviewers understand that you've thoroughly considered the impact of your changes:

- How did you test this change?
- What could potentially break and how did you verify it doesn't?
- What existing functionality might be affected and how did you check it still works?
- Why are you confident this is ready for merge?

We're not looking for exhaustive documentation - just evidence that you've thought through the implications of your changes and tested accordingly.
-->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [ ] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add support for multiple non-contiguous deleted ranges in task history and state management.
> 
>   - **Proto Changes**:
>     - Add `DeletedRange` message to `hooks.proto` and `ui.proto`.
>     - Add `repeated DeletedRange deleted_ranges` to `PreCompactData` in `hooks.proto` and `ClineMessage` in `ui.proto`.
>   - **Task State Management**:
>     - Add `conversationHistoryDeletedRanges` to `TaskState` in `TaskState.ts`.
>     - Update `Task` constructor in `index.ts` to initialize `conversationHistoryDeletedRanges`.
>     - Modify `MessageStateHandler` in `message-state.ts` to handle `conversationHistoryDeletedRanges`.
>   - **Functionality**:
>     - Update `executePreCompactHookWithCleanup` in `precompact-executor.ts` to handle `deletedRanges`.
>     - Modify `reconstructTaskHistoryItem` in `reconstructTaskHistory.ts` to include `conversationHistoryDeletedRanges`.
>     - Update `SummarizeTaskHandler` in `SummarizeTaskHandler.ts` to pass `conversationHistoryDeletedRanges` to hooks.
>   - **Checkpoint Management**:
>     - Add `conversationHistoryDeletedRanges` handling in `TaskCheckpointManager` in `index.ts` and `factory.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 43bb1f2c97e8b7f8d726a637c5616c5d8d025d4a. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->