### PR TITLE
feat(skills): add skillsEnabled setting to gate Skills feature

### DIFF
--- a/proto/cline/state.proto
+++ b/proto/cline/state.proto
@@ -230,6 +230,7 @@ message Settings {
   optional bool cline_web_tools_enabled = 134;
   optional bool hooks_enabled = 135;
   optional bool azure_identity = 136;
+  optional bool skills_enabled = 137;
 }
 
 message DictationSettings {
@@ -372,6 +373,7 @@ message UpdateSettingsRequest {
   optional bool enable_parallel_tool_calling = 35;
   optional bool background_edit_enabled = 36;
   optional string oca_reasoning_effort = 37;
+  optional bool skills_enabled = 38;
 }
 
 message UpdateTerminalConnectionTimeoutRequest {

--- a/src/core/controller/index.ts
+++ b/src/core/controller/index.ts
@@ -851,6 +851,7 @@ export class Controller {
 		const lastDismissedModelBannerVersion = this.stateManager.getGlobalStateKey("lastDismissedModelBannerVersion") || 0
 		const lastDismissedCliBannerVersion = this.stateManager.getGlobalStateKey("lastDismissedCliBannerVersion") || 0
 		const subagentsEnabled = this.stateManager.getGlobalSettingsKey("subagentsEnabled")
+		const skillsEnabled = this.stateManager.getGlobalSettingsKey("skillsEnabled")
 
 		const localClineRulesToggles = this.stateManager.getWorkspaceStateKey("localClineRulesToggles")
 		const localWindsurfRulesToggles = this.stateManager.getWorkspaceStateKey("localWindsurfRulesToggles")
@@ -955,6 +956,7 @@ export class Controller {
 			nativeToolCallSetting: this.stateManager.getGlobalStateKey("nativeToolCallEnabled"),
 			enableParallelToolCalling: this.stateManager.getGlobalSettingsKey("enableParallelToolCalling"),
 			backgroundEditEnabled: this.stateManager.getGlobalSettingsKey("backgroundEditEnabled"),
+			skillsEnabled,
 		}
 	}
 

--- a/src/core/controller/state/updateSettings.ts
+++ b/src/core/controller/state/updateSettings.ts
@@ -363,6 +363,10 @@ export async function updateSettings(controller: Controller, request: UpdateSett
 			controller.stateManager.setGlobalState("subagentsEnabled", !!request.subagentsEnabled)
 		}
 
+		if (request.skillsEnabled !== undefined) {
+			controller.stateManager.setGlobalState("skillsEnabled", !!request.skillsEnabled)
+		}
+
 		if (request.nativeToolCallEnabled !== undefined) {
 			controller.stateManager.setGlobalState("nativeToolCallEnabled", !!request.nativeToolCallEnabled)
 			if (controller.task) {

--- a/src/core/storage/utils/state-helpers.ts
+++ b/src/core/storage/utils/state-helpers.ts
@@ -323,6 +323,7 @@ export async function readGlobalStateFromDisk(context: ExtensionContext): Promis
 		const openTelemetryLogMaxQueueSize =
 			context.globalState.get<GlobalStateAndSettings["openTelemetryLogMaxQueueSize"]>("openTelemetryLogMaxQueueSize")
 		const subagentsEnabled = context.globalState.get<GlobalStateAndSettings["subagentsEnabled"]>("subagentsEnabled")
+		const skillsEnabled = context.globalState.get<GlobalStateAndSettings["skillsEnabled"]>("skillsEnabled")
 		const backgroundEditEnabled =
 			context.globalState.get<GlobalStateAndSettings["backgroundEditEnabled"]>("backgroundEditEnabled")
 
@@ -708,6 +709,7 @@ export async function readGlobalStateFromDisk(context: ExtensionContext): Promis
 			// Hooks require explicit user opt-in and are only supported on macOS/Linux
 			hooksEnabled: getHooksEnabledSafe(hooksEnabled),
 			subagentsEnabled: subagentsEnabled ?? false,
+			skillsEnabled: skillsEnabled ?? false,
 			enableParallelToolCalling: enableParallelToolCalling ?? false,
 			lastDismissedInfoBannerVersion: lastDismissedInfoBannerVersion ?? 0,
 			lastDismissedModelBannerVersion: lastDismissedModelBannerVersion ?? 0,

--- a/src/core/task/index.ts
+++ b/src/core/task/index.ts
@@ -1764,8 +1764,9 @@ export class Task {
 			maxConsecutiveMistakes: this.stateManager.getGlobalSettingsKey("maxConsecutiveMistakes"),
 		})
 
-		// Discover and filter available skills
-		const allSkills = await discoverSkills(this.cwd)
+		// Discover and filter available skills (gated by skillsEnabled setting)
+		const skillsEnabled = this.stateManager.getGlobalSettingsKey("skillsEnabled") ?? false
+		const allSkills = skillsEnabled ? await discoverSkills(this.cwd) : []
 		const availableSkills = getAvailableSkills(allSkills)
 
 		const promptContext: SystemPromptContext = {

--- a/src/shared/ExtensionMessage.ts
+++ b/src/shared/ExtensionMessage.ts
@@ -104,6 +104,7 @@ export interface ExtensionState {
 	hooksEnabled?: boolean
 	remoteConfigSettings?: Partial<RemoteConfigFields>
 	subagentsEnabled?: boolean
+	skillsEnabled?: boolean
 	nativeToolCallSetting?: boolean
 	enableParallelToolCalling?: boolean
 	backgroundEditEnabled?: boolean

--- a/src/shared/storage/state-keys.ts
+++ b/src/shared/storage/state-keys.ts
@@ -130,6 +130,7 @@ export interface Settings {
 	aihubmixAppCode: string | undefined
 	hooksEnabled: boolean
 	subagentsEnabled: boolean
+	skillsEnabled: boolean
 	enableParallelToolCalling: boolean
 	backgroundEditEnabled: boolean
 

--- a/webview-ui/src/components/settings/sections/FeatureSettingsSection.tsx
+++ b/webview-ui/src/components/settings/sections/FeatureSettingsSection.tsx
@@ -31,6 +31,7 @@ const FeatureSettingsSection = ({ renderSectionHeader }: FeatureSettingsSectionP
 		focusChainSettings,
 		multiRootSetting,
 		hooksEnabled,
+		skillsEnabled,
 		remoteConfigSettings,
 		subagentsEnabled,
 		nativeToolCallSetting,
@@ -431,6 +432,22 @@ const FeatureSettingsSection = ({ renderSectionHeader }: FeatureSettingsSectionP
 								</span>
 							</p>
 						)}
+					</div>
+					<div className="mt-2.5">
+						<VSCodeCheckbox
+							checked={skillsEnabled}
+							onChange={(e: any) => {
+								const checked = e.target.checked === true
+								updateSetting("skillsEnabled", checked)
+							}}>
+							Enable Skills
+						</VSCodeCheckbox>
+						<p className="text-xs">
+							<span className="text-(--vscode-errorForeground)">Experimental: </span>{" "}
+							<span className="text-description">
+								Enables Skills for reusable, on-demand agent instructions from .cline/skills/ directories.
+							</span>
+						</p>
 					</div>
 					<div style={{ marginTop: 10 }}>
 						<Tooltip>

--- a/webview-ui/src/context/ExtensionStateContext.tsx
+++ b/webview-ui/src/context/ExtensionStateContext.tsx
@@ -244,6 +244,7 @@ export const ExtensionStateContextProvider: React.FC<{
 		lastDismissedCliBannerVersion: 0,
 		subagentsEnabled: false,
 		backgroundEditEnabled: false,
+		skillsEnabled: false,
 
 		// NEW: Add workspace information with defaults
 		workspaceRoots: [],


### PR DESCRIPTION
### Related Issue

**Issue:** #8296 #8335 

### Description

This PR adds a feature flag to gate the experimental Skills system. It introduces an "Enable Skills" toggle in **Settings → Features** that controls whether the Skills functionality is active.

**Behavior:**
- When **disabled** (default): No directory scanning occurs and the `use_skill` tool is not available
- When **enabled**: Skills are discovered from project and global directories, and the `use_skill` tool becomes available

This allows for gradual rollout of the Skills feature while it remains experimental.

**Key changes:**
- Add `skillsEnabled` to Settings interface and ExtensionState
- Add `skills_enabled` to proto definitions for state sync
- Gate skill discovery in `Task.attemptApiRequest()`
- Add UI toggle in FeatureSettingsSection

### Test Procedure

- **Manual testing:**
  - Verified toggle appears in Settings → Features
  - Confirmed skills are NOT discovered when toggle is off (default)
  - Confirmed skills ARE discovered when toggle is on
  - Verified `use_skill` tool only appears in available tools when enabled
  - Tested toggle state persists across sessions

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A - Simple toggle UI addition in existing Features settings section.

### Additional Notes

**Files modified:**
- `proto/cline/state.proto` - Added `skills_enabled` field
- `src/core/controller/index.ts` - Added skillsEnabled to state management
- `src/core/controller/state/updateSettings.ts` - Handle settings update
- `src/core/storage/utils/state-helpers.ts` - State helper for skillsEnabled
- `src/core/task/index.ts` - Gate skill discovery with setting check
- `src/shared/ExtensionMessage.ts` - Added skillsEnabled to Settings type
- `src/shared/storage/state-keys.ts` - Added storage key
- `webview-ui/src/components/settings/sections/FeatureSettingsSection.tsx` - UI toggle
- `webview-ui/src/context/ExtensionStateContext.tsx` - State context update

**Note:** This is part of the Skills feature implementation. The base Skills system is in PR #8335.
