### PR TITLE
fix: prevent duplicate lines when replacing longer files with shorter content

### DIFF
--- a/.changeset/social-doodles-mix.md
+++ b/.changeset/social-doodles-mix.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+fix: prevent duplicate lines when replacing longer files with shorter content

--- a/src/integrations/editor/DiffViewProvider.ts
+++ b/src/integrations/editor/DiffViewProvider.ts
@@ -188,7 +188,13 @@ export abstract class DiffViewProvider {
 				contentToReplace += "\n"
 			}
 
-			const rangeToReplace = { startLine: 0, endLine: currentLine + 1 }
+			// On final update, replace the ENTIRE document to avoid leftover content.
+			// When new content is shorter than original, replacing only up to currentLine+1
+			// would leave old content that "shifts up" after replacement.
+			// Use Infinity to trigger end-of-document handling in replaceText.
+			const rangeToReplace = isFinal
+				? { startLine: 0, endLine: Number.MAX_SAFE_INTEGER }
+				: { startLine: 0, endLine: currentLine + 1 }
 			await this.replaceText(contentToReplace, rangeToReplace, currentLine)
 
 			// Scroll to the actual change location if provided.


### PR DESCRIPTION
### Related Issue

**Issue:** #8167, #8341

### Description

This PR fixes a bug where **content from the original file would appear duplicated at the end** when using `write_to_file` or `replace_in_file` to replace a file with fewer lines than the original.

**Example Bug Scenario:**
- Original file: 20 lines
- New content: 5 lines ending with `\n`
- Result: New 5 lines + "original line 7" duplicated at the end

**Root Cause:**

In `DiffViewProvider.ts` `update()` method, on final update (`isFinal=true`), the code only replaced content up to `currentLine + 1`. Due to VS Code's Range semantics, this caused a subtle but critical bug:

1. `Range(startLine, 0, endLine, 0)` replaces up to the **START** of endLine, not through it
2. When new content ends with `\n`, old content "shifts up" one line into the replacement range
3. The subsequent `truncateDocument(currentLine + 1)` call would then miss the shifted content
4. Result: Old content survives and appears duplicated

**The Fix:**

On final update, replace the **ENTIRE document** using `MAX_SAFE_INTEGER` as the end line instead of `currentLine + 1`. This ensures all original content is replaced regardless of line count differences or trailing newlines.

```typescript
// Before (buggy):
const rangeToReplace = { startLine: 0, endLine: currentLine + 1 }

// After (fixed):
const rangeToReplace = isFinal
    ? { startLine: 0, endLine: Number.MAX_SAFE_INTEGER }
    : { startLine: 0, endLine: currentLine + 1 }
```

Supporting changes in `VscodeDiffViewProvider.ts`:
- `replaceText()` converts `MAX_SAFE_INTEGER` to actual document end position
- `truncateDocument()` uses valid `(lastLine, lastLineLength)` instead of out-of-bounds `(lineCount, 0)`

### Test Procedure

1. **Manual Testing:** Verified the exact bug scenario (20-line file → 5-line file) no longer produces duplicate content
2. **Added Unit Tests:** 3 new test cases in `diff-newline-repro.test.ts`:
   - `updates file with fewer lines than original (20 lines → 5 lines)` - exact bug scenario
   - `handles file replacement with trailing newline`
   - `handles complete file replacement with different line counts`
3. **Existing Tests:** Ran `npm test` to ensure no regressions

This was tested with both **Enable Background Edit** enabled and disabled.

- Fix directly addresses the root cause (partial document replacement on final update)
- New content always replaces entire document on `isFinal`, eliminating any possibility of leftover content
- Tests cover the exact reported bug scenario

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

### Additional Notes

This bug was particularly hard to diagnose because:
1. It only occurred when new content was shorter than original
2. It depended on trailing newlines in the new content
3. VS Code's Range semantics are counterintuitive (end position is exclusive)

The fix is minimal - only changing the end line calculation on final update while preserving the streaming behavior during intermediate updates.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes content duplication bug when replacing longer files with shorter content in `DiffViewProvider` by ensuring entire document replacement on final update.
> 
>   - **Behavior**:
>     - Fixes bug in `DiffViewProvider.ts` where replacing a file with fewer lines than the original caused content duplication.
>     - On final update, replaces entire document using `MAX_SAFE_INTEGER` to ensure all original content is replaced.
>   - **Implementation**:
>     - In `VscodeDiffViewProvider.ts`, `replaceText()` now converts `MAX_SAFE_INTEGER` to actual document end position.
>     - `truncateDocument()` uses valid `(lastLine, lastLineLength)` instead of out-of-bounds `(lineCount, 0)`.
>   - **Testing**:
>     - Adds test cases in `diff-newline-repro.test.ts` to cover scenarios of replacing longer files with shorter content and ensure no content duplication.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 08af8e8344285f525ad8ec05cbdb6b53ca3f4a90. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->