### PR TITLE
Refactoring: Move handlers out of the Controller

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1182,7 +1182,6 @@
 			"integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@babel/code-frame": "^7.27.1",
 				"@babel/generator": "^7.28.3",
@@ -2645,7 +2644,6 @@
 		"node_modules/@grpc/grpc-js": {
 			"version": "1.9.15",
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
 				"@grpc/proto-loader": "^0.7.8",
 				"@types/node": ">=12.12.47"
@@ -3229,7 +3227,6 @@
 			"resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.25.1.tgz",
 			"integrity": "sha512-yO28oVFFC7EBoiKdAn+VqRm+plcfv4v0xp6osG/VsCB0NlPZWi87ajbCZZ8f/RvOFLEu7//rSRmuZZ7lMoe3gQ==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@hono/node-server": "^1.19.7",
 				"ajv": "^8.17.1",
@@ -3298,7 +3295,6 @@
 			"resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
 			"integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
 			"license": "Apache-2.0",
-			"peer": true,
 			"engines": {
 				"node": ">=8.0.0"
 			}
@@ -4914,7 +4910,8 @@
 			"optional": true,
 			"os": [
 				"android"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-android-arm64": {
 			"version": "4.52.4",
@@ -4927,7 +4924,8 @@
 			"optional": true,
 			"os": [
 				"android"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-darwin-arm64": {
 			"version": "4.52.4",
@@ -4940,7 +4938,8 @@
 			"optional": true,
 			"os": [
 				"darwin"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-darwin-x64": {
 			"version": "4.52.4",
@@ -4953,7 +4952,8 @@
 			"optional": true,
 			"os": [
 				"darwin"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-freebsd-arm64": {
 			"version": "4.52.4",
@@ -4966,7 +4966,8 @@
 			"optional": true,
 			"os": [
 				"freebsd"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-freebsd-x64": {
 			"version": "4.52.4",
@@ -4979,7 +4980,8 @@
 			"optional": true,
 			"os": [
 				"freebsd"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-linux-arm-gnueabihf": {
 			"version": "4.52.4",
@@ -4992,7 +4994,8 @@
 			"optional": true,
 			"os": [
 				"linux"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-linux-arm-musleabihf": {
 			"version": "4.52.4",
@@ -5005,7 +5008,8 @@
 			"optional": true,
 			"os": [
 				"linux"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-linux-arm64-gnu": {
 			"version": "4.52.4",
@@ -5018,7 +5022,8 @@
 			"optional": true,
 			"os": [
 				"linux"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-linux-arm64-musl": {
 			"version": "4.52.4",
@@ -5031,7 +5036,8 @@
 			"optional": true,
 			"os": [
 				"linux"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-linux-loong64-gnu": {
 			"version": "4.52.4",
@@ -5044,7 +5050,8 @@
 			"optional": true,
 			"os": [
 				"linux"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-linux-ppc64-gnu": {
 			"version": "4.52.4",
@@ -5057,7 +5064,8 @@
 			"optional": true,
 			"os": [
 				"linux"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-linux-riscv64-gnu": {
 			"version": "4.52.4",
@@ -5070,7 +5078,8 @@
 			"optional": true,
 			"os": [
 				"linux"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-linux-riscv64-musl": {
 			"version": "4.52.4",
@@ -5083,7 +5092,8 @@
 			"optional": true,
 			"os": [
 				"linux"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-linux-s390x-gnu": {
 			"version": "4.52.4",
@@ -5096,7 +5106,8 @@
 			"optional": true,
 			"os": [
 				"linux"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-linux-x64-gnu": {
 			"version": "4.52.4",
@@ -5109,7 +5120,8 @@
 			"optional": true,
 			"os": [
 				"linux"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-linux-x64-musl": {
 			"version": "4.52.4",
@@ -5122,7 +5134,8 @@
 			"optional": true,
 			"os": [
 				"linux"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-openharmony-arm64": {
 			"version": "4.52.4",
@@ -5135,7 +5148,8 @@
 			"optional": true,
 			"os": [
 				"openharmony"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-win32-arm64-msvc": {
 			"version": "4.52.4",
@@ -5148,7 +5162,8 @@
 			"optional": true,
 			"os": [
 				"win32"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-win32-ia32-msvc": {
 			"version": "4.52.4",
@@ -5161,7 +5176,8 @@
 			"optional": true,
 			"os": [
 				"win32"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-win32-x64-gnu": {
 			"version": "4.52.4",
@@ -5174,7 +5190,8 @@
 			"optional": true,
 			"os": [
 				"win32"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-win32-x64-msvc": {
 			"version": "4.52.4",
@@ -5187,7 +5204,8 @@
 			"optional": true,
 			"os": [
 				"win32"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@sap-ai-sdk/ai-api": {
 			"version": "2.1.0",
@@ -6750,7 +6768,8 @@
 			"version": "1.0.8",
 			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
 			"integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/@types/get-folder-size": {
 			"version": "3.0.4",
@@ -6782,7 +6801,6 @@
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.21.tgz",
 			"integrity": "sha512-CsGG2P3I5y48RPMfprQGfy4JPRZ6csfC3ltBZSRItG3ngggmNY/qs2uZKp4p9VbrpqNNSMzUZNFZKzgOGnd/VA==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"undici-types": "~6.21.0"
 			}
@@ -7486,7 +7504,6 @@
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
 			"integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
 			"license": "MIT",
-			"peer": true,
 			"bin": {
 				"acorn": "bin/acorn"
 			},
@@ -8253,7 +8270,6 @@
 				}
 			],
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"baseline-browser-mapping": "^2.8.3",
 				"caniuse-lite": "^1.0.30001741",
@@ -9467,8 +9483,7 @@
 		},
 		"node_modules/devtools-protocol": {
 			"version": "0.0.1342118",
-			"license": "BSD-3-Clause",
-			"peer": true
+			"license": "BSD-3-Clause"
 		},
 		"node_modules/diff": {
 			"version": "5.2.0",
@@ -12444,7 +12459,6 @@
 			"resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
 			"integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
 			"license": "MIT",
-			"peer": true,
 			"bin": {
 				"jiti": "lib/jiti-cli.mjs"
 			}
@@ -12678,7 +12692,6 @@
 			"resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.30.1.tgz",
 			"integrity": "sha512-xi6IyHML+c9+Q3W0S4fCQJOym42pyurFiJUHEcEyHS0CeKzia4yZDEsLlqOFykxOdHpNy0NmvVO31vcSqAxJCg==",
 			"license": "MPL-2.0",
-			"peer": true,
 			"dependencies": {
 				"detect-libc": "^2.0.3"
 			},
@@ -15559,6 +15572,7 @@
 				}
 			],
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"nanoid": "^3.3.11",
 				"picocolors": "^1.1.1",
@@ -15579,6 +15593,7 @@
 				}
 			],
 			"license": "MIT",
+			"peer": true,
 			"bin": {
 				"nanoid": "bin/nanoid.cjs"
 			},
@@ -16246,6 +16261,7 @@
 			"resolved": "https://registry.npmjs.org/rollup/-/rollup-4.52.4.tgz",
 			"integrity": "sha512-CLEVl+MnPAiKh5pl4dEWSyMTpuflgNQiLGhMv8ezD5W/qP8AKvmYpCOKRRNOh7oRKnauBZ4SyeYkMS+1VSyKwQ==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@types/estree": "1.0.8"
 			},
@@ -17671,6 +17687,7 @@
 			"resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
 			"integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"fdir": "^6.5.0",
 				"picomatch": "^4.0.3"
@@ -17687,6 +17704,7 @@
 			"resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
 			"integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=12.0.0"
 			},
@@ -18050,7 +18068,6 @@
 			"version": "5.5.3",
 			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
@@ -18310,6 +18327,7 @@
 			"resolved": "https://registry.npmjs.org/vite/-/vite-7.2.2.tgz",
 			"integrity": "sha512-BxAKBWmIbrDgrokdGZH1IgkIk/5mMHDreLDmCJ0qpyJaAteP8NvMhkwr/ZCQNqNH97bw/dANTE9PDzqwJghfMQ==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"esbuild": "^0.25.0",
 				"fdir": "^6.5.0",
@@ -18384,6 +18402,7 @@
 			"resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
 			"integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=12.0.0"
 			},
@@ -19079,7 +19098,6 @@
 		"node_modules/zod": {
 			"version": "3.25.76",
 			"license": "MIT",
-			"peer": true,
 			"funding": {
 				"url": "https://github.com/sponsors/colinhacks"
 			}

--- a/src/core/controller/index.ts
+++ b/src/core/controller/index.ts
@@ -30,6 +30,7 @@ import { ExtensionRegistryInfo } from "@/registry"
 import { AuthService } from "@/services/auth/AuthService"
 import { OcaAuthService } from "@/services/auth/oca/OcaAuthService"
 import { LogoutReason } from "@/services/auth/types"
+import { BannerService } from "@/services/banner/BannerService"
 import { featureFlagsService } from "@/services/feature-flags"
 import { getDistinctId } from "@/services/logging/distinctId"
 import { telemetryService } from "@/services/telemetry"
@@ -37,7 +38,6 @@ import { getAxiosSettings } from "@/shared/net"
 import { ShowMessageType } from "@/shared/proto/host/window"
 import { getLatestAnnouncementId } from "@/utils/announcements"
 import { getCwd, getDesktopDir } from "@/utils/path"
-import { BannerService } from "../../services/banner/BannerService"
 import { PromptRegistry } from "../prompts/system-prompt"
 import {
 	ensureCacheDirectoryExists,
@@ -1030,37 +1030,5 @@ export class Controller {
 			console.error("Failed to fetch banners:", error)
 		}
 		return []
-	}
-
-	/**
-	 * Dismisses a banner and sends telemetry
-	 * @param bannerId The ID of the banner to dismiss
-	 */
-	async dismissBanner(bannerId: string): Promise<void> {
-		try {
-			await this.ensureBannerService()
-			if (BannerService.isInitialized()) {
-				await BannerService.get().dismissBanner(bannerId)
-				await this.postStateToWebview()
-			}
-		} catch (error) {
-			console.error("Failed to dismiss banner:", error)
-		}
-	}
-
-	/**
-	 * Sends a banner event for telemetry tracking
-	 * @param bannerId The ID of the banner
-	 * @param eventType The type of event (seen, dismiss, click)
-	 */
-	async trackBannerEvent(bannerId: string, eventType: "dismiss"): Promise<void> {
-		try {
-			await this.ensureBannerService()
-			if (BannerService.isInitialized()) {
-				await BannerService.get().sendBannerEvent(bannerId, eventType)
-			}
-		} catch (error) {
-			console.error("Failed to track banner event:", error)
-		}
 	}
 }

--- a/src/core/controller/state/dismissBanner.ts
+++ b/src/core/controller/state/dismissBanner.ts
@@ -1,9 +1,10 @@
+import { BannerService } from "@/services/banner/BannerService"
 import type { StringRequest } from "@/shared/proto/cline/common"
 import { Empty } from "@/shared/proto/cline/common"
 import type { Controller } from ".."
 
 /**
- * Dismisses a banner by ID
+ * Dismisses a banner and sends telemetry
  * @param controller The controller instance
  * @param request The request containing the banner ID to dismiss
  * @returns Empty response
@@ -11,9 +12,14 @@ import type { Controller } from ".."
 export async function dismissBanner(controller: Controller, request: StringRequest): Promise<Empty> {
 	const bannerId = request.value
 
-	if (bannerId) {
-		await controller.dismissBanner(bannerId)
+	if (!bannerId) {
+		return {}
 	}
-
-	return Empty.create()
+	try {
+		await BannerService.get().dismissBanner(bannerId)
+		await controller.postStateToWebview()
+	} catch (error) {
+		console.error("Failed to dismiss banner:", error)
+	}
+	return {}
 }

--- a/src/core/controller/state/trackBannerEvent.ts
+++ b/src/core/controller/state/trackBannerEvent.ts
@@ -1,3 +1,4 @@
+import { BannerService } from "@/services/banner/BannerService"
 import { Empty } from "@/shared/proto/cline/common"
 import type { TrackBannerEventRequest } from "@/shared/proto/cline/state"
 import type { Controller } from ".."
@@ -8,12 +9,19 @@ import type { Controller } from ".."
  * @param request The request containing banner ID and event type
  * @returns Empty response
  */
-export async function trackBannerEvent(controller: Controller, request: TrackBannerEventRequest): Promise<Empty> {
+export async function trackBannerEvent(_controller: Controller, request: TrackBannerEventRequest): Promise<Empty> {
 	const { bannerId, eventType } = request
-
-	if (bannerId && eventType) {
-		await controller.trackBannerEvent(bannerId, eventType as "dismiss")
+	if (!bannerId) {
+		return {}
 	}
-
-	return Empty.create()
+	if (eventType !== "dismiss") {
+		console.error("Unsupported event type ", eventType)
+		return {}
+	}
+	try {
+		await BannerService.get().sendBannerEvent(bannerId, eventType)
+	} catch (error) {
+		console.error("Failed to track banner event:", error)
+	}
+	return {}
 }


### PR DESCRIPTION
Move the handlers for ProtoBus banner RPCs out of the controller. 

We are trying to reduce the size and complexity of the controller class. The handlers for the banner RPCs don't need to be inside of the controller, all the logic is inside the BannerService.

ref PF-367

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Refactor to move banner handling methods from `Controller` to separate files for better code organization.
> 
>   - **Refactoring**:
>     - Move `dismissBanner` method from `Controller` in `index.ts` to `dismissBanner.ts`.
>     - Move `trackBannerEvent` method from `Controller` in `index.ts` to `trackBannerEvent.ts`.
>   - **Behavior**:
>     - `dismissBanner.ts`: Handles banner dismissal and updates the webview state.
>     - `trackBannerEvent.ts`: Handles tracking of banner events, currently only supports "dismiss" event type.
>   - **Imports**:
>     - Add `BannerService` import to `dismissBanner.ts` and `trackBannerEvent.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 5b450bdd95727d4ca4d1473adf42ec2ae9cb0e56. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->