### PR TITLE
Remove other references to OTEL_TELEMETRY_ENABLED=1

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -72,12 +72,12 @@ POSTHOG_TELEMETRY_ENABLED=true          # Enable PostHog telemetry (default: tru
 # Example configurations:
 #
 # Console debugging (logs only):
-#   OTEL_TELEMETRY_ENABLED=1
+#   OTEL_TELEMETRY_ENABLED=true
 #   OTEL_LOGS_EXPORTER=console
 #   TEL_DEBUG_DIAGNOSTICS=true
 #
 # OTLP with gRPC (insecure, for local testing):
-#   OTEL_TELEMETRY_ENABLED=1
+#   OTEL_TELEMETRY_ENABLED=true
 #   OTEL_LOGS_EXPORTER=otlp
 #   OTEL_EXPORTER_OTLP_PROTOCOL=grpc
 #   OTEL_EXPORTER_OTLP_ENDPOINT=localhost:4317
@@ -85,7 +85,7 @@ POSTHOG_TELEMETRY_ENABLED=true          # Enable PostHog telemetry (default: tru
 #   OTEL_EXPORTER_OTLP_HEADERS=authorization=Bearer your-token
 #
 # OTLP with HTTP/JSON (production):
-#   OTEL_TELEMETRY_ENABLED=1
+#   OTEL_TELEMETRY_ENABLED=true
 #   OTEL_LOGS_EXPORTER=otlp
 #   OTEL_EXPORTER_OTLP_PROTOCOL=http/json
 #   OTEL_EXPORTER_OTLP_ENDPOINT=https://otel.example.com


### PR DESCRIPTION
We removed all other references to `OTEL_TELEMETRY_ENABLED=1`, but I forgot about some in the `.env.example`. This PR clears them all.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Change `OTEL_TELEMETRY_ENABLED=1` to `OTEL_TELEMETRY_ENABLED=true` in `.env.example` for example configurations.
> 
>   - **Configuration**:
>     - Change `OTEL_TELEMETRY_ENABLED=1` to `OTEL_TELEMETRY_ENABLED=true` in `.env.example` for example configurations.
>     - Affects example configurations for console debugging, OTLP with gRPC, and OTLP with HTTP/JSON.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 6d11bc32e07186e4d6a66e0d533b1fdaaf8c93f6. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->