### PR TITLE
fix: add word wrapping for MCP tool call arguments (issue #5886)

### DIFF
--- a/.changeset/mcp-tool-arguments-word-wrap.md
+++ b/.changeset/mcp-tool-arguments-word-wrap.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Add forceWrap support to CodeAccordian and enable it for MCP tool arguments to prevent excessive horizontal scrolling.

--- a/webview-ui/src/components/chat/ChatRow.tsx
+++ b/webview-ui/src/components/chat/ChatRow.tsx
@@ -1331,6 +1331,7 @@ export const ChatRowContent = memo(
 										</div>
 										<CodeAccordian
 											code={useMcpServer.arguments}
+											forceWrap={true}
 											isExpanded={true}
 											language="json"
 											onToggleExpand={handleToggle}

--- a/webview-ui/src/components/common/CodeAccordian.tsx
+++ b/webview-ui/src/components/common/CodeAccordian.tsx
@@ -12,6 +12,7 @@ interface CodeAccordianProps {
 	isExpanded: boolean
 	onToggleExpand: () => void
 	isLoading?: boolean
+	forceWrap?: boolean
 }
 
 /*
@@ -32,6 +33,7 @@ const CodeAccordian = ({
 	isExpanded,
 	onToggleExpand,
 	isLoading,
+	forceWrap,
 }: CodeAccordianProps) => {
 	const inferredLanguage = useMemo(
 		() => code && (language ?? (path ? getLanguageFromPath(path) : undefined)),
@@ -132,11 +134,12 @@ const CodeAccordian = ({
 				<div
 					//className="code-block-scrollable" this doesn't seem to be necessary anymore, on silicon macs it shows the native mac scrollbar instead of the vscode styled one
 					style={{
-						overflowX: "auto",
+						overflowX: forceWrap ? "visible" : "auto",
 						overflowY: "hidden",
 						maxWidth: "100%",
 					}}>
 					<CodeBlock
+						forceWrap={forceWrap}
 						source={`${"```"}${diff !== undefined ? "diff" : inferredLanguage}\n${(
 							code ?? diff ?? ""
 						).trim()}\n${"```"}`}


### PR DESCRIPTION
## Summary
- Fixes issue #5886 where MCP tool call arguments displayed with excessive horizontal scrolling
- Adds `forceWrap` prop to `CodeAccordian` component
- Enables word wrapping for MCP tool arguments in ChatRow

## Changes
1. Added optional `forceWrap` prop to `CodeAccordian` component
2. Pass `forceWrap` through to `CodeBlock` component
3. Adjust `overflowX` style based on `forceWrap` state
4. Enable `forceWrap={true}` for MCP tool arguments display in `ChatRow`

## Test plan
- [x] Linting passes

## Related Issue
Fixes #5886

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes issue #5886 by adding `forceWrap` prop to `CodeAccordian` and enabling it in `ChatRow` to wrap MCP tool arguments and prevent horizontal scrolling.
> 
>   - **Behavior**:
>     - Fixes issue #5886 by adding `forceWrap` prop to `CodeAccordian` to enable word wrapping.
>     - Enables `forceWrap={true}` for MCP tool arguments in `ChatRow` to prevent horizontal scrolling.
>   - **Components**:
>     - Adds `forceWrap` prop to `CodeAccordian` and passes it to `CodeBlock`.
>     - Adjusts `overflowX` style in `CodeAccordian` based on `forceWrap` state.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 32352688f1910bde9f44103040321a58d867cc45. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->