### PR TITLE
fix: update button text when deleting history item via side icon (issue #6033)

### DIFF
--- a/.changeset/button-text-update-after-delete.md
+++ b/.changeset/button-text-update-after-delete.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Fix button text not updating when deleting selected history items using the side delete icon.

--- a/webview-ui/src/components/history/HistoryView.tsx
+++ b/webview-ui/src/components/history/HistoryView.tsx
@@ -154,10 +154,12 @@ const HistoryView = ({ onDone }: HistoryViewProps) => {
 	const handleDeleteHistoryItem = useCallback(
 		(id: string) => {
 			TaskServiceClient.deleteTasksWithIds(StringArrayRequest.create({ value: [id] }))
-				.then(() => fetchTotalTasksSize())
+				.then(() => {
+					fetchTotalTasksSize()
+					// Clear from selected items to update button text state after successful deletion
+					setSelectedItems((prev) => prev.filter((itemId) => itemId !== id))
+				})
 				.catch((error) => console.error("Error deleting task:", error))
-			// Clear from selected items to update button text state
-			setSelectedItems((prev) => prev.filter((itemId) => itemId !== id))
 		},
 		[fetchTotalTasksSize],
 	)

--- a/webview-ui/src/components/history/HistoryView.tsx
+++ b/webview-ui/src/components/history/HistoryView.tsx
@@ -156,6 +156,8 @@ const HistoryView = ({ onDone }: HistoryViewProps) => {
 			TaskServiceClient.deleteTasksWithIds(StringArrayRequest.create({ value: [id] }))
 				.then(() => fetchTotalTasksSize())
 				.catch((error) => console.error("Error deleting task:", error))
+			// Clear from selected items to update button text state
+			setSelectedItems((prev) => prev.filter((itemId) => itemId !== id))
 		},
 		[fetchTotalTasksSize],
 	)


### PR DESCRIPTION
## Summary
- Fixes issue #6033 where button text doesn't update after deleting selected history item via side icon
- Button remained "Delete selected history" instead of reverting to "Delete all history"
- Root cause: deleted item's ID remained in selectedItems state

## Changes
- Added `setSelectedItems((prev) => prev.filter((itemId) => itemId !== id))` to `handleDeleteHistoryItem`
- This clears the deleted item from selectedItems, triggering button text update

## Test plan
- [x] Linting passes

## Related Issue
Fixes #6033

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes button text update issue when deleting a history item via side icon in `HistoryView.tsx`.
> 
>   - **Behavior**:
>     - Fixes issue #6033 where button text did not update after deleting a selected history item via the side icon in `HistoryView.tsx`.
>     - Updates `selectedItems` state in `handleDeleteHistoryItem` to remove the deleted item's ID, triggering the button text update.
>   - **Misc**:
>     - Adds changeset file `button-text-update-after-delete.md` to document the fix.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 890810cfc604a97b859fefbd385a040578a38b7b. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->