### PR TITLE
fix: constrain checkbox click area in settings (issue #6083)

### DIFF
--- a/.changeset/checkbox-click-area-fix.md
+++ b/.changeset/checkbox-click-area-fix.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Fix checkbox toggling when clicking adjacent whitespace by using onChange instead of onClick.

--- a/webview-ui/src/components/settings/ThinkingBudgetSlider.tsx
+++ b/webview-ui/src/components/settings/ThinkingBudgetSlider.tsx
@@ -121,7 +121,7 @@ const ThinkingBudgetSlider = ({ currentMode, maxBudget, showEnableToggle = true 
 	return (
 		<div className="w-full">
 			{showEnableToggle ? (
-				<VSCodeCheckbox checked={isEnabled} onClick={handleToggleChange}>
+				<VSCodeCheckbox checked={isEnabled} onChange={handleToggleChange}>
 					Enable thinking{localValue && localValue > 0 ? ` (${localValue.toLocaleString()} tokens)` : ""}
 				</VSCodeCheckbox>
 			) : null}


### PR DESCRIPTION
## Summary
- Fixes issue #6083 where checkbox toggled when clicking adjacent whitespace
- Changed `onClick` to `onChange` to match standard pattern used by other checkboxes
- This constrains the clickable area to just the checkbox and label elements

## Root Cause
The "Enable thinking" checkbox in `ThinkingBudgetSlider.tsx` used `onClick` instead of `onChange`. This caused the entire row to be clickable rather than just the checkbox control.

## Changes
- Changed `onClick={handleToggleChange}` to `onChange={handleToggleChange}` in VSCodeCheckbox
- The handler function was already compatible with onChange (reads event.target.checked)

## Test plan
- [x] Linting passes

## Related Issue
Fixes #6083

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes issue #6083 by changing `onClick` to `onChange` for the checkbox in `ThinkingBudgetSlider.tsx`, constraining the clickable area.
> 
>   - **Behavior**:
>     - Fixes issue #6083 by changing `onClick` to `onChange` for the "Enable thinking" checkbox in `ThinkingBudgetSlider.tsx`.
>     - Constrains clickable area to checkbox and label, preventing toggling from adjacent whitespace.
>   - **Code Changes**:
>     - Updates `VSCodeCheckbox` component to use `onChange={handleToggleChange}` instead of `onClick`.
>     - `handleToggleChange` function already compatible with `onChange` event.
>   - **Misc**:
>     - Adds changeset file `checkbox-click-area-fix.md` to document the fix.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for ec40d6b0151a277a403d83532eede1640720f86b. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->