### PR TITLE
fix: add line breaks between segments in CLI plain mode (issue #7534)

### DIFF
--- a/.changeset/cli-plain-mode-line-breaks.md
+++ b/.changeset/cli-plain-mode-line-breaks.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Add blank line separator between segments in CLI plain mode to prevent text from running together.

--- a/cli/pkg/cli/display/segment_streamer.go
+++ b/cli/pkg/cli/display/segment_streamer.go
@@ -82,6 +82,12 @@ func (ss *StreamingSegment) Freeze() {
 }
 
 func (ss *StreamingSegment) renderFinal(currentBuffer string) {
+	// Add blank line separator between segments in plain mode
+	// to prevent consecutive segments from running together
+	if ss.outputFormat == "plain" {
+		output.Println("")
+	}
+
 	var bodyContent string
 
 	// Use ToolRenderer for all body rendering to centralize logic


### PR DESCRIPTION
## Summary
- Fixes issue #7534 where consecutive text segments run together in CLI plain mode
- Adds blank line separator before each segment in plain mode
- Matches the separation behavior of rich mode

## Root Cause
In plain mode (\`-F plain\`), the rich headers (which include a blank line separator) are skipped. This caused consecutive text segments to run together without any separation.

## Changes
- Added \`output.Println("")\` at the beginning of \`renderFinal()\` in \`cli/pkg/cli/display/segment_streamer.go\`
- Only applies to plain mode output format
- Creates separation between segments (thinking, response, tool results, etc.)

## Test plan
- Code change follows existing patterns in the file
- Go code is syntactically correct

## Related Issue
Fixes #7534

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes issue #7534 by adding line breaks between segments in CLI plain mode to prevent text from running together.
> 
>   - **Behavior**:
>     - Fixes issue #7534 by adding a blank line separator between segments in CLI plain mode.
>     - Ensures plain mode matches rich mode separation behavior.
>   - **Code Changes**:
>     - Adds `output.Println("")` in `renderFinal()` in `segment_streamer.go` for plain mode.
>   - **Misc**:
>     - Adds a changeset file `cli-plain-mode-line-breaks.md` to document the change.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for d2be3fa4c6af3f0841f81ccc8e11f494b6373fa8. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->