### PR TITLE
fix: telemetry banner settings button opens correct tab (issue #4705)

### DIFF
--- a/.changeset/telemetry-settings-tab.md
+++ b/.changeset/telemetry-settings-tab.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Fix telemetry banner settings button to open the General tab where the telemetry setting is located.

--- a/webview-ui/src/components/common/TelemetryBanner.tsx
+++ b/webview-ui/src/components/common/TelemetryBanner.tsx
@@ -16,7 +16,7 @@ export const TelemetryBanner: React.FC = () => {
 
 	const handleOpenSettings = useCallback(() => {
 		handleClose()
-		navigateToSettings()
+		navigateToSettings("general")
 	}, [handleClose, navigateToSettings])
 
 	return (


### PR DESCRIPTION
## Summary
- Fixes issue #4705 where the telemetry banner settings button opened the wrong tab
- Changed `navigateToSettings()` to `navigateToSettings("general")` to open the General tab
- The General tab is where the telemetry setting checkbox is located

## Root Cause
The `TelemetryBanner.tsx` component called `navigateToSettings()` without specifying a target section, so it defaulted to opening the first tab (API Configuration) instead of the General tab where the telemetry setting lives.

## Changes
- Modified `webview-ui/src/components/common/TelemetryBanner.tsx` line 19
- Changed `navigateToSettings()` to `navigateToSettings("general")`

## Test plan
- [x] Linting passes

## Related Issue
Fixes #4705

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes issue #4705 by updating `navigateToSettings()` in `TelemetryBanner.tsx` to open the General tab for telemetry settings.
> 
>   - **Behavior**:
>     - Fixes issue #4705 by changing `navigateToSettings()` to `navigateToSettings("general")` in `TelemetryBanner.tsx` to open the General tab.
>     - Ensures telemetry settings button directs users to the correct tab.
>   - **Root Cause**:
>     - `TelemetryBanner.tsx` called `navigateToSettings()` without specifying a section, defaulting to the first tab.
>   - **Changes**:
>     - Modified line 19 in `TelemetryBanner.tsx` to specify "general" as the target tab.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 8c69bc417b6286300bd16092bf80d972fc15e568. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->