### PR TITLE
fix: close context menu when pressing Escape key (issue #5532)

### DIFF
--- a/.changeset/context-menu-escape-fix.md
+++ b/.changeset/context-menu-escape-fix.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Fix context menu not closing when pressing Escape key by calling setShowContextMenu(false).

--- a/webview-ui/src/components/chat/ChatTextArea.tsx
+++ b/webview-ui/src/components/chat/ChatTextArea.tsx
@@ -560,7 +560,7 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 				}
 				if (showContextMenu) {
 					if (event.key === "Escape") {
-						// event.preventDefault()
+						setShowContextMenu(false)
 						setSelectedType(null)
 						setSelectedMenuIndex(DEFAULT_CONTEXT_MENU_OPTION)
 						setSearchQuery("")


### PR DESCRIPTION
## Summary
- Fixes issue #5532 where the @ mention context menu doesn't close when pressing Escape
- Adds missing \`setShowContextMenu(false)\` call to the Escape key handler
- Matches the behavior of the slash commands menu which already handles Escape correctly

## Root Cause
In the context menu's Escape handler, the code was resetting internal state
(\`setSelectedType(null)\`, \`setSelectedMenuIndex\`, \`setSearchQuery\`) but
never called \`setShowContextMenu(false)\` to actually close the menu.

## Changes
- Added \`setShowContextMenu(false)\` to the Escape handler in \`ChatTextArea.tsx\`
- This matches the pattern used by the slash commands menu

## Test plan
- [x] Linting passes

## Related Issue
Fixes #5532

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes issue #5532 by adding `setShowContextMenu(false)` to the Escape key handler in `ChatTextArea.tsx`, closing the context menu on Escape.
> 
>   - **Behavior**:
>     - Fixes issue #5532 by adding `setShowContextMenu(false)` to the Escape key handler in `ChatTextArea.tsx`.
>     - Matches behavior of slash commands menu, which closes on Escape.
>   - **Root Cause**:
>     - Escape handler was resetting state but not closing the menu.
>   - **Misc**:
>     - Adds changeset file `context-menu-escape-fix.md` for patch release.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for ad27fd677a2e6a667504fa803e36ac5aa491017b. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->