### PR TITLE
fix: restore original text when cancelling edit (fixes #4431)

### DIFF
--- a/webview-ui/src/components/chat/UserMessage.tsx
+++ b/webview-ui/src/components/chat/UserMessage.tsx
@@ -72,12 +72,14 @@ const UserMessage: React.FC<UserMessageProps> = ({ text, images, files, messageT
 			return
 		}
 
-		// Otherwise, close edit mode
+		// Otherwise, close edit mode and restore original text
+		setEditedText(text || "")
 		setIsEditing(false)
 	}
 
 	const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
 		if (e.key === "Escape") {
+			setEditedText(text || "")
 			setIsEditing(false)
 		} else if (e.key === "Enter" && e.metaKey && !checkpointManagerErrorMessage) {
 			handleRestoreWorkspace("taskAndWorkspace")


### PR DESCRIPTION
## Summary
- When pressing Escape or clicking away while editing a chat message, the edited text now properly reverts to the original message content
- Previously, `editedText` state was not reset, causing the edited version to persist visually

## Root Cause
In `UserMessage.tsx`:
- The `handleKeyDown` Escape handler only called `setIsEditing(false)` without resetting `editedText`
- The `handleBlur` click-away handler had the same issue

## Test Plan
1. Edit any past user message in the chat
2. Modify the text
3. Press Escape or click outside the textarea
4. Verify the text reverts to the original message content

## Files Changed
- `webview-ui/src/components/chat/UserMessage.tsx`

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes issue in `UserMessage.tsx` where edited text did not revert to original on cancelling edit by resetting `editedText` in `handleKeyDown` and `handleBlur`.
> 
>   - **Behavior**:
>     - Fixes issue where edited text did not revert to original when cancelling edit in `UserMessage.tsx`.
>     - `handleKeyDown` and `handleBlur` now reset `editedText` to original text on Escape or blur.
>   - **Files Changed**:
>     - `UserMessage.tsx`: Updates `handleKeyDown` and `handleBlur` to restore original text.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 045a75c5caf9660c0365af539314f2bad0947a35. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->