### PR TITLE
feat: add team setup callout to provider settings and docs

### DIFF
--- a/docs/provider-config/aws-bedrock/api-key.mdx
+++ b/docs/provider-config/aws-bedrock/api-key.mdx
@@ -11,6 +11,10 @@ description: "Set up AWS Bedrock with Cline using Bedrock API Keys. Simplest set
 -   **Cline:** A VS Code extension that acts as a coding assistant by integrating with AI models—empowering developers to generate code, debug, and analyze data.
 -   **Developer Focus:** This guide is tailored for individual developers that want to enable access to frontier models via AWS Bedrock with a simplified setup using API Keys.
 
+<Info>
+**Team setup:** [Centralized configuration →](https://cline.bot/enterprise/provider-setup)
+</Info>
+
 ---
 
 ### Step 1: Prepare Your AWS Environment

--- a/docs/provider-config/aws-bedrock/cli-profile.mdx
+++ b/docs/provider-config/aws-bedrock/cli-profile.mdx
@@ -8,6 +8,10 @@ description: "Configure AWS Bedrock to use AWS CLI profiles for authentication w
 
 Cline offers the option of utilizing AWS credentials or AWS profiles to access AWS Bedrock services. SSO/Federated roles are suggested over Legacy IAM configuration; this guide describes how to configure your environment so that Cline uses SSO roles for authentication.
 
+<Info>
+**Team setup:** [Centralized configuration →](https://cline.bot/enterprise/provider-setup)
+</Info>
+
 ---
 
 ### Configuration Steps

--- a/docs/provider-config/aws-bedrock/iam-credentials.mdx
+++ b/docs/provider-config/aws-bedrock/iam-credentials.mdx
@@ -11,6 +11,10 @@ description: "Set up AWS Bedrock with Cline using IAM Access Key and Secret Key 
 -   **Cline:** A VS Code extension that acts as a coding assistant by integrating with AI models—empowering developers to generate code, debug, and analyze data.
 -   **Enterprise Focus:** This guide is tailored for organizations with established AWS environments (using IAM roles, AWS SSO, AWS Organizations, etc.) to ensure secure and compliant usage.
 
+<Info>
+**Team setup:** [Centralized configuration →](https://cline.bot/enterprise/provider-setup)
+</Info>
+
 ---
 
 ### Step 1: Prepare Your AWS Environment

--- a/docs/provider-config/gcp-vertex-ai.mdx
+++ b/docs/provider-config/gcp-vertex-ai.mdx
@@ -11,6 +11,10 @@ A fully managed service that provides access to leading generative AI models—s
 
 This guide is tailored for organizations with established GCP environments (leveraging IAM roles, service accounts, and best practices in resource management) to ensure secure and compliant usage.
 
+<Info>
+**Team setup:** [Centralized configuration →](https://cline.bot/enterprise/provider-setup)
+</Info>
+
 ---
 
 ### Step 1: Prepare Your GCP Environment

--- a/docs/provider-config/litellm-and-cline-using-codestral.mdx
+++ b/docs/provider-config/litellm-and-cline-using-codestral.mdx
@@ -7,6 +7,10 @@ description: "Learn how to set up and run LiteLLM with Cline using the Codestral
 
 This guide demonstrates how to run a demo for LiteLLM starting with the Codestral model for use with Cline.
 
+<Info>
+**Team setup:** [Centralized configuration →](https://cline.bot/enterprise/provider-setup)
+</Info>
+
 #### Prerequisites
 
 -   [Docker CLI or Docker Desktop](https://www.docker.com/get-started/) installed to run the LiteLLM image locally

--- a/webview-ui/src/components/chat/ModelPickerModal.tsx
+++ b/webview-ui/src/components/chat/ModelPickerModal.tsx
@@ -10,6 +10,7 @@ import { useWindowSize } from "react-use"
 import styled from "styled-components"
 import { CODE_BLOCK_BG_COLOR } from "@/components/common/CodeBlock"
 import PopupModalContainer from "@/components/common/PopupModalContainer"
+import { buildOrgSetupUrl } from "@/components/settings/common/ProviderHelpCallout"
 
 const PLAN_MODE_COLOR = "var(--vscode-activityWarningBadge-background)"
 const ACT_MODE_COLOR = "var(--vscode-focusBorder)"
@@ -28,7 +29,7 @@ import {
 import { useApiConfigurationHandlers } from "@/components/settings/utils/useApiConfigurationHandlers"
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
 import { useExtensionState } from "@/context/ExtensionStateContext"
-import { StateServiceClient } from "@/services/grpc-client"
+import { StateServiceClient, UiServiceClient } from "@/services/grpc-client"
 import { getConfiguredProviders, getProviderLabel } from "@/utils/getConfiguredProviders"
 import ThinkingBudgetSlider from "../settings/ThinkingBudgetSlider"
 
@@ -47,6 +48,7 @@ const SETTINGS_ONLY_PROVIDERS: ApiProvider[] = [
 ]
 
 const OPENROUTER_MODEL_PROVIDERS: ApiProvider[] = ["cline", "openrouter", "vercel-ai-gateway"]
+const TEAM_SETUP_PROVIDERS: ApiProvider[] = ["bedrock", "vertex", "litellm"]
 
 interface ModelPickerModalProps {
 	isOpen: boolean
@@ -639,6 +641,33 @@ const ModelPickerModal: React.FC<ModelPickerModalProps> = ({ isOpen, onOpenChang
 									</Tooltip>
 								</div>
 							</div>
+							{TEAM_SETUP_PROVIDERS.includes(selectedProvider) && (
+								<div className="mt-1 text-[11px] text-description">
+									<span>Team setup:</span>{" "}
+									<button
+										onClick={(e) => {
+											e.preventDefault()
+											e.stopPropagation()
+											UiServiceClient.openUrl(
+												StringRequest.create({ value: buildOrgSetupUrl(selectedProvider) }),
+											).catch(console.error)
+										}}
+										style={{
+											background: "transparent",
+											border: "none",
+											padding: 0,
+											margin: 0,
+											display: "inline",
+											fontSize: "inherit",
+											fontFamily: "inherit",
+											color: "var(--vscode-textLink-foreground)",
+											cursor: "pointer",
+										}}
+										type="button">
+										Centralized configuration →
+									</button>
+								</div>
+							)}
 							{/* Thinking budget slider - shown when model supports thinking, greyed out when disabled */}
 							{supportsThinking && (
 								<div className="flex items-center gap-2 py-1.5 px-0 mt-0.5 w-full">
@@ -729,7 +758,9 @@ const ModelPickerModal: React.FC<ModelPickerModalProps> = ({ isOpen, onOpenChang
 										key={model.id}
 										onClick={() => handleSelectModel(model.id, openRouterModels[model.id])}
 										onMouseEnter={() => setSelectedIndex(index)}
-										ref={(el) => (itemRefs.current[index] = el)}>
+										ref={(el) => {
+											itemRefs.current[index] = el
+										}}>
 										<ModelInfoRow>
 											<ModelName>{model.name}</ModelName>
 											<ModelProvider>{model.provider}</ModelProvider>
@@ -749,7 +780,9 @@ const ModelPickerModal: React.FC<ModelPickerModalProps> = ({ isOpen, onOpenChang
 										key={model.id}
 										onClick={() => handleSelectModel(model.id, model.info)}
 										onMouseEnter={() => setSelectedIndex(globalIndex)}
-										ref={(el) => (itemRefs.current[globalIndex] = el)}>
+										ref={(el) => {
+											itemRefs.current[globalIndex] = el
+										}}>
 										<ModelInfoRow>
 											<ModelName>{model.name}</ModelName>
 											<ModelProvider>{model.provider}</ModelProvider>

--- a/webview-ui/src/components/settings/common/ProviderHelpCallout.tsx
+++ b/webview-ui/src/components/settings/common/ProviderHelpCallout.tsx
@@ -1,0 +1,86 @@
+import { VSCodeLink } from "@vscode/webview-ui-toolkit/react"
+import React from "react"
+
+export type ProviderHelpLink = {
+	label: string
+	href: string
+}
+
+export function buildOrgSetupUrl(provider: string): string {
+	const baseUrl = "https://cline.bot/enterprise/provider-setup"
+	const url = new URL(baseUrl)
+	url.searchParams.set("utm_source", "cline_extension")
+	url.searchParams.set("utm_medium", "product")
+	url.searchParams.set("utm_campaign", "team_setup")
+	url.searchParams.set("utm_content", provider)
+	return url.toString()
+}
+
+type ProviderHelpCalloutProps = {
+	/**
+	 * Individual/self-serve setup docs links (provider-specific).
+	 * Keep this short (1-3) so it stays scannable.
+	 */
+	docsLinks: ProviderHelpLink[]
+	className?: string
+	orgSetupHref?: string
+	orgSetupLabel?: string
+	orgSetupLinkText?: string
+}
+
+export const ProviderHelpCallout: React.FC<ProviderHelpCalloutProps> = ({
+	docsLinks,
+	className,
+	orgSetupHref,
+	orgSetupLabel = "Team setup:",
+	orgSetupLinkText = "Centralized configuration →",
+}) => {
+	if (!docsLinks.length && !orgSetupHref) {
+		return null
+	}
+
+	return (
+		<div className={className}>
+			{docsLinks.length > 0 && (
+				<p
+					style={{
+						fontSize: "12px",
+						marginTop: "5px",
+						color: "var(--vscode-descriptionForeground)",
+					}}>
+					<span style={{ fontWeight: 500 }}>Provider setup (docs):</span>{" "}
+					{docsLinks.map((link, index) => (
+						<React.Fragment key={link.href}>
+							<VSCodeLink
+								href={link.href}
+								rel="noopener noreferrer"
+								style={{ display: "inline", fontSize: "inherit" }}
+								target="_blank">
+								{link.label}
+							</VSCodeLink>
+							{index < docsLinks.length - 1 ? <span style={{ opacity: 0.7 }}> · </span> : null}
+						</React.Fragment>
+					))}
+				</p>
+			)}
+
+			{orgSetupHref && (
+				<p
+					style={{
+						fontSize: "12px",
+						marginTop: "5px",
+						color: "var(--vscode-descriptionForeground)",
+					}}>
+					<span style={{ fontWeight: 500 }}>{orgSetupLabel}</span>{" "}
+					<VSCodeLink
+						href={orgSetupHref}
+						rel="noopener noreferrer"
+						style={{ display: "inline", fontSize: "inherit" }}
+						target="_blank">
+						{orgSetupLinkText}
+					</VSCodeLink>
+				</p>
+			)}
+		</div>
+	)
+}

--- a/webview-ui/src/components/settings/providers/BedrockProvider.tsx
+++ b/webview-ui/src/components/settings/providers/BedrockProvider.tsx
@@ -8,6 +8,7 @@ import { useExtensionState } from "@/context/ExtensionStateContext"
 import { DebouncedTextField } from "../common/DebouncedTextField"
 import { ModelInfoView } from "../common/ModelInfoView"
 import { DropdownContainer } from "../common/ModelSelector"
+import { buildOrgSetupUrl, ProviderHelpCallout, type ProviderHelpLink } from "../common/ProviderHelpCallout"
 import ThinkingBudgetSlider from "../ThinkingBudgetSlider"
 import { getModeSpecificFields, normalizeApiConfiguration } from "../utils/providerUtils"
 import { useApiConfigurationHandlers } from "../utils/useApiConfigurationHandlers"
@@ -42,6 +43,32 @@ export const BedrockProvider = ({ showModelOptions, isPopup, currentMode }: Bedr
 	const { selectedModelId, selectedModelInfo } = normalizeApiConfiguration(apiConfiguration, currentMode)
 	const modeFields = getModeSpecificFields(apiConfiguration, currentMode)
 	const [awsEndpointSelected, setAwsEndpointSelected] = useState(!!apiConfiguration?.awsBedrockEndpoint)
+	const awsAuthentication = apiConfiguration?.awsAuthentication ?? (apiConfiguration?.awsProfile ? "profile" : "credentials")
+
+	const bedrockDocsLinks: ProviderHelpLink[] = (() => {
+		const apiKey: ProviderHelpLink = {
+			label: "API key",
+			href: "https://docs.cline.bot/provider-config/aws-bedrock/api-key",
+		}
+		const iamCredentials: ProviderHelpLink = {
+			label: "IAM credentials",
+			href: "https://docs.cline.bot/provider-config/aws-bedrock/iam-credentials",
+		}
+		const cliProfile: ProviderHelpLink = {
+			label: "CLI profile",
+			href: "https://docs.cline.bot/provider-config/aws-bedrock/cli-profile",
+		}
+
+		switch (awsAuthentication) {
+			case "apikey":
+				return [apiKey]
+			case "profile":
+				return [cliProfile]
+			case "credentials":
+			default:
+				return [iamCredentials]
+		}
+	})()
 
 	return (
 		<div className="flex flex-col gap-1">
@@ -55,6 +82,8 @@ export const BedrockProvider = ({ showModelOptions, isPopup, currentMode }: Bedr
 				<VSCodeRadio value="profile">AWS Profile</VSCodeRadio>
 				<VSCodeRadio value="credentials">AWS Credentials</VSCodeRadio>
 			</VSCodeRadioGroup>
+
+			<ProviderHelpCallout className="mb-2.5" docsLinks={bedrockDocsLinks} orgSetupHref={buildOrgSetupUrl("bedrock")} />
 
 			{(apiConfiguration?.awsAuthentication === undefined && apiConfiguration?.awsUseProfile) ||
 			apiConfiguration?.awsAuthentication === "profile" ? (

--- a/webview-ui/src/components/settings/providers/BedrockProvider.tsx
+++ b/webview-ui/src/components/settings/providers/BedrockProvider.tsx
@@ -43,7 +43,9 @@ export const BedrockProvider = ({ showModelOptions, isPopup, currentMode }: Bedr
 	const { selectedModelId, selectedModelInfo } = normalizeApiConfiguration(apiConfiguration, currentMode)
 	const modeFields = getModeSpecificFields(apiConfiguration, currentMode)
 	const [awsEndpointSelected, setAwsEndpointSelected] = useState(!!apiConfiguration?.awsBedrockEndpoint)
-	const awsAuthentication = apiConfiguration?.awsAuthentication ?? (apiConfiguration?.awsProfile ? "profile" : "credentials")
+	const awsAuthentication =
+		apiConfiguration?.awsAuthentication ??
+		(apiConfiguration?.awsUseProfile || apiConfiguration?.awsProfile ? "profile" : "credentials")
 
 	const bedrockDocsLinks: ProviderHelpLink[] = (() => {
 		const apiKey: ProviderHelpLink = {

--- a/webview-ui/src/components/settings/providers/LiteLlmProvider.tsx
+++ b/webview-ui/src/components/settings/providers/LiteLlmProvider.tsx
@@ -7,6 +7,7 @@ import { ModelsServiceClient } from "@/services/grpc-client"
 import { DebouncedTextField } from "../common/DebouncedTextField"
 import { ModelInfoView } from "../common/ModelInfoView"
 import { ModelSelector } from "../common/ModelSelector"
+import { buildOrgSetupUrl, ProviderHelpCallout } from "../common/ProviderHelpCallout"
 import ThinkingBudgetSlider from "../ThinkingBudgetSlider"
 import { normalizeApiConfiguration } from "../utils/providerUtils"
 import { useApiConfigurationHandlers } from "../utils/useApiConfigurationHandlers"
@@ -54,6 +55,11 @@ export const LiteLlmProvider = ({ showModelOptions, isPopup, currentMode }: Lite
 
 	return (
 		<div>
+			<ProviderHelpCallout
+				className="mb-2.5"
+				docsLinks={[{ label: "LiteLLM", href: "https://docs.cline.bot/provider-config/litellm" }]}
+				orgSetupHref={buildOrgSetupUrl("litellm")}
+			/>
 			<DebouncedTextField
 				initialValue={apiConfiguration?.liteLlmBaseUrl || ""}
 				onChange={async (value) => {

--- a/webview-ui/src/components/settings/providers/OpenAICompatible.tsx
+++ b/webview-ui/src/components/settings/providers/OpenAICompatible.tsx
@@ -12,6 +12,7 @@ import { ApiKeyField } from "../common/ApiKeyField"
 import { BaseUrlField } from "../common/BaseUrlField"
 import { DebouncedTextField } from "../common/DebouncedTextField"
 import { ModelInfoView } from "../common/ModelInfoView"
+import { ProviderHelpCallout } from "../common/ProviderHelpCallout"
 import { getModeSpecificFields, normalizeApiConfiguration } from "../utils/providerUtils"
 import { useApiConfigurationHandlers } from "../utils/useApiConfigurationHandlers"
 
@@ -71,6 +72,10 @@ export const OpenAICompatibleProvider = ({ showModelOptions, isPopup, currentMod
 
 	return (
 		<div>
+			<ProviderHelpCallout
+				className="mb-2.5"
+				docsLinks={[{ label: "OpenAI Compatible", href: "https://docs.cline.bot/provider-config/openai-compatible" }]}
+			/>
 			<Tooltip>
 				<TooltipTrigger>
 					<div className="mb-2.5">
@@ -151,8 +156,8 @@ export const OpenAICompatibleProvider = ({ showModelOptions, isPopup, currentMod
 						</div>
 
 						<div>
-							{headerEntries.map(([key, value], index) => (
-								<div key={index} style={{ display: "flex", gap: 5, marginTop: 5 }}>
+							{headerEntries.map(([key, value]) => (
+								<div key={key} style={{ display: "flex", gap: 5, marginTop: 5 }}>
 									<DebouncedTextField
 										disabled={remoteConfigSettings?.openAiHeaders !== undefined}
 										initialValue={key}

--- a/webview-ui/src/components/settings/providers/OpenAICompatible.tsx
+++ b/webview-ui/src/components/settings/providers/OpenAICompatible.tsx
@@ -156,8 +156,8 @@ export const OpenAICompatibleProvider = ({ showModelOptions, isPopup, currentMod
 						</div>
 
 						<div>
-							{headerEntries.map(([key, value]) => (
-								<div key={key} style={{ display: "flex", gap: 5, marginTop: 5 }}>
+							{headerEntries.map(([key, value], index) => (
+								<div key={`${index}-${key}`} style={{ display: "flex", gap: 5, marginTop: 5 }}>
 									<DebouncedTextField
 										disabled={remoteConfigSettings?.openAiHeaders !== undefined}
 										initialValue={key}

--- a/webview-ui/src/components/settings/providers/RequestyProvider.tsx
+++ b/webview-ui/src/components/settings/providers/RequestyProvider.tsx
@@ -7,6 +7,7 @@ import { useExtensionState } from "@/context/ExtensionStateContext"
 import { AccountServiceClient } from "@/services/grpc-client"
 import { ApiKeyField } from "../common/ApiKeyField"
 import { DebouncedTextField } from "../common/DebouncedTextField"
+import { ProviderHelpCallout } from "../common/ProviderHelpCallout"
 import RequestyModelPicker from "../RequestyModelPicker"
 import { useApiConfigurationHandlers } from "../utils/useApiConfigurationHandlers"
 
@@ -38,6 +39,10 @@ export const RequestyProvider = ({ showModelOptions, isPopup, currentMode }: Req
 				onChange={(value) => handleFieldChange("requestyApiKey", value)}
 				providerName="Requesty"
 				signupUrl={apiKeyUrl}
+			/>
+			<ProviderHelpCallout
+				className="mt-2"
+				docsLinks={[{ label: "Requesty", href: "https://docs.cline.bot/provider-config/requesty" }]}
 			/>
 			{!apiConfiguration?.requestyApiKey && (
 				<VSCodeButton

--- a/webview-ui/src/components/settings/providers/VSCodeLmProvider.tsx
+++ b/webview-ui/src/components/settings/providers/VSCodeLmProvider.tsx
@@ -7,6 +7,7 @@ import * as vscodemodels from "vscode"
 import { useExtensionState } from "@/context/ExtensionStateContext"
 import { ModelsServiceClient } from "@/services/grpc-client"
 import { DROPDOWN_Z_INDEX, DropdownContainer } from "../ApiOptions"
+import { ProviderHelpCallout } from "../common/ProviderHelpCallout"
 import { getModeSpecificFields } from "../utils/providerUtils"
 import { useApiConfigurationHandlers } from "../utils/useApiConfigurationHandlers"
 
@@ -17,7 +18,7 @@ interface VSCodeLmProviderProps {
 export const VSCodeLmProvider = ({ currentMode }: VSCodeLmProviderProps) => {
 	const [vsCodeLmModels, setVsCodeLmModels] = useState<vscodemodels.LanguageModelChatSelector[]>([])
 	const { apiConfiguration } = useExtensionState()
-	const { handleFieldChange, handleModeFieldChange } = useApiConfigurationHandlers()
+	const { handleModeFieldChange } = useApiConfigurationHandlers()
 
 	const { vsCodeLmModelSelector } = getModeSpecificFields(apiConfiguration, currentMode)
 
@@ -46,6 +47,12 @@ export const VSCodeLmProvider = ({ currentMode }: VSCodeLmProviderProps) => {
 				<label htmlFor="vscode-lm-model">
 					<span style={{ fontWeight: 500 }}>Language Model</span>
 				</label>
+				<ProviderHelpCallout
+					className="mt-2"
+					docsLinks={[
+						{ label: "VS Code LM API", href: "https://docs.cline.bot/provider-config/vscode-language-model-api" },
+					]}
+				/>
 				{vsCodeLmModels.length > 0 ? (
 					<VSCodeDropdown
 						id="vscode-lm-model"

--- a/webview-ui/src/components/settings/providers/VercelAIGatewayProvider.tsx
+++ b/webview-ui/src/components/settings/providers/VercelAIGatewayProvider.tsx
@@ -2,6 +2,7 @@ import { Mode } from "@shared/storage/types"
 import { VSCodeLink } from "@vscode/webview-ui-toolkit/react"
 import { useExtensionState } from "@/context/ExtensionStateContext"
 import { DebouncedTextField } from "../common/DebouncedTextField"
+import { ProviderHelpCallout } from "../common/ProviderHelpCallout"
 import { useApiConfigurationHandlers } from "../utils/useApiConfigurationHandlers"
 import VercelModelPicker from "../VercelModelPicker"
 
@@ -52,6 +53,11 @@ export const VercelAIGatewayProvider = ({ showModelOptions, isPopup, currentMode
 					)}
 				</p>
 			</div>
+
+			<ProviderHelpCallout
+				className="mt-2"
+				docsLinks={[{ label: "Vercel AI Gateway", href: "https://docs.cline.bot/provider-config/vercel-ai-gateway" }]}
+			/>
 
 			{showModelOptions && <VercelModelPicker currentMode={currentMode} isPopup={isPopup} />}
 		</div>

--- a/webview-ui/src/components/settings/providers/VertexProvider.tsx
+++ b/webview-ui/src/components/settings/providers/VertexProvider.tsx
@@ -1,12 +1,13 @@
 import { vertexGlobalModels, vertexModels } from "@shared/api"
 import VertexData from "@shared/providers/vertex.json"
 import { Mode } from "@shared/storage/types"
-import { VSCodeDropdown, VSCodeLink, VSCodeOption } from "@vscode/webview-ui-toolkit/react"
+import { VSCodeDropdown, VSCodeOption } from "@vscode/webview-ui-toolkit/react"
 import { useExtensionState } from "@/context/ExtensionStateContext"
 import { DROPDOWN_Z_INDEX, DropdownContainer } from "../ApiOptions"
 import { DebouncedTextField } from "../common/DebouncedTextField"
 import { ModelInfoView } from "../common/ModelInfoView"
 import { ModelSelector } from "../common/ModelSelector"
+import { buildOrgSetupUrl, ProviderHelpCallout } from "../common/ProviderHelpCallout"
 import ThinkingBudgetSlider from "../ThinkingBudgetSlider"
 import { normalizeApiConfiguration } from "../utils/providerUtils"
 import { useApiConfigurationHandlers } from "../utils/useApiConfigurationHandlers"
@@ -85,24 +86,11 @@ export const VertexProvider = ({ showModelOptions, isPopup, currentMode }: Verte
 				</VSCodeDropdown>
 			</DropdownContainer>
 
-			<p
-				style={{
-					fontSize: "12px",
-					marginTop: "5px",
-					color: "var(--vscode-descriptionForeground)",
-				}}>
-				To use Google Cloud Vertex AI, you need to
-				<VSCodeLink
-					href="https://cloud.google.com/vertex-ai/generative-ai/docs/partner-models/use-claude#before_you_begin"
-					style={{ display: "inline", fontSize: "inherit" }}>
-					{"1) create a Google Cloud account › enable the Vertex AI API › enable the desired Claude models,"}
-				</VSCodeLink>{" "}
-				<VSCodeLink
-					href="https://cloud.google.com/docs/authentication/provide-credentials-adc#google-idp"
-					style={{ display: "inline", fontSize: "inherit" }}>
-					{"2) install the Google Cloud CLI › configure Application Default Credentials."}
-				</VSCodeLink>
-			</p>
+			<ProviderHelpCallout
+				className="mt-2"
+				docsLinks={[{ label: "GCP Vertex AI", href: "https://docs.cline.bot/provider-config/gcp-vertex-ai" }]}
+				orgSetupHref={buildOrgSetupUrl("vertex")}
+			/>
 
 			{showModelOptions && (
 				<>


### PR DESCRIPTION
### Related Issue

**Issue:** N/A (Internal feature request for enterprise provider setup UX)

### Description

Adds a "Team setup: Centralized configuration →" link alongside "Provider setup (docs)" in provider settings and the model picker for enterprise-oriented providers (AWS Bedrock, GCP Vertex AI, LiteLLM).

**What this PR does:**
- Adds a reusable `ProviderHelpCallout` component that displays docs links and optional team setup links
- Shows the team setup link only for providers where centralized/remote configuration applies (Bedrock, Vertex, LiteLLM)
- Team setup link opens externally with UTMs (`utm_source=cline_extension`, `utm_medium=product`, `utm_campaign=team_setup`, `utm_content=<provider>`)
- Adds matching callouts in the relevant provider docs pages pointing to `https://cline.bot/enterprise/provider-setup`

### Test Procedure

- Verified the team setup link appears in provider settings for Bedrock, Vertex, and LiteLLM
- Verified the link does NOT appear for other providers (Anthropic, OpenRouter, etc.)
- Confirmed the link opens in external browser with correct UTM parameters
- Confirmed the model picker shows the team setup row when those providers are selected
- Tested docs pages render correctly with the new callout

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [x] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

*Team setup link in provider settings (Bedrock example):*
<img width="372" height="217" alt="image" src="https://github.com/user-attachments/assets/12af37f0-c7ce-4192-a7fa-e21908bddfe7" />


*Team setup link in model picker:*
<img width="429" height="283" alt="image" src="https://github.com/user-attachments/assets/0a71a823-485c-40be-adf9-475b381c4daf" />


### Additional Notes

The corresponding landing page at `cline.bot/enterprise/provider-setup` is being added in a separate PR to cline-web.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds a team setup callout to provider settings and documentation for AWS Bedrock, GCP Vertex AI, and LiteLLM, enhancing enterprise provider setup UX.
> 
>   - **Behavior**:
>     - Adds `ProviderHelpCallout` component for displaying docs and team setup links.
>     - Displays team setup link for AWS Bedrock, GCP Vertex AI, and LiteLLM in `ModelPickerModal.tsx` and provider settings.
>     - Team setup link opens externally with UTMs for tracking.
>   - **Documentation**:
>     - Updates AWS Bedrock, GCP Vertex AI, and LiteLLM docs to include team setup callout.
>     - Adds links to `https://cline.bot/enterprise/provider-setup` in relevant docs.
>   - **Components**:
>     - `ProviderHelpCallout.tsx`: New component for displaying provider help links.
>     - `ModelPickerModal.tsx`: Integrates team setup link for specific providers.
>     - Updates provider components like `BedrockProvider.tsx`, `LiteLlmProvider.tsx`, and `VertexProvider.tsx` to use `ProviderHelpCallout`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 886853d0ba1171c18a214851b84c6caba9041d06. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->