### PR TITLE
fix(auth): prevent random logouts during token refresh retry delay

### DIFF
--- a/.changeset/fix-random-logout-retry-delay.md
+++ b/.changeset/fix-random-logout-retry-delay.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Fix random logouts during token refresh retry delay

--- a/src/services/auth/providers/ClineAuthProvider.ts
+++ b/src/services/auth/providers/ClineAuthProvider.ts
@@ -204,7 +204,10 @@ export class ClineAuthProvider {
 					Logger.debug(
 						`Waiting ${Math.ceil((this.RETRY_DELAY_MS - timeSinceLastAttempt) / 1000)}s before retry attempt ${this.refreshRetryCount + 1}/${this.MAX_REFRESH_RETRIES}`,
 					)
-					return null
+					// Return stored data instead of null to prevent logout during retry delay.
+					// Returning null here causes restoreRefreshTokenAndRetrieveAuthInfo() to
+					// interpret it as "no auth data" and log the user out.
+					return storedAuthData
 				}
 
 				// Check if we've exceeded max retries


### PR DESCRIPTION
This PR fixes a long-standing bug that causes users to be randomly logged out of their Cline account. The issue has been plaguing users for months and has been the subject of multiple fix attempts (PRs #8021, #8386, #8470, #8032).

After a deep investigation tracing through the entire auth flow, I found the bug:

**Location:** `src/services/auth/providers/ClineAuthProvider.ts` line 207

When a token refresh fails with a network error, the code sets `refreshRetryCount = 1` and waits 30 seconds before retrying (to avoid hammering the server). During this 30-second window, if anything calls `restoreRefreshTokenAndRetrieveAuthInfo()`, the function returns `null` instead of the stored auth data:

```typescript
// Check if we need to wait before retrying
if (timeSinceLastAttempt < this.RETRY_DELAY_MS && this.refreshRetryCount > 0) {
    Logger.debug(\`Waiting...\`)
    return null  // BUG: Should return storedAuthData
}
```

This `null` propagates to `AuthService.restoreRefreshTokenAndRetrieveAuthInfo()` which interprets it as "no auth data exists" and logs the user out:

```typescript
async restoreRefreshTokenAndRetrieveAuthInfo(): Promise<void> {
    this._clineAuthInfo = await this.retrieveAuthInfo()
    if (this._clineAuthInfo) {
        this._authenticated = true
    } else {
        // NULL = USER LOGGED OUT
        this._authenticated = false
        this._clineAuthInfo = null
        telemetryService.captureAuthLoggedOut(...)
    }
}
```

### What Triggers This

The following actions call `restoreRefreshTokenAndRetrieveAuthInfo()`:

1. **User switches organization** (via `ClineAccountService.switchAccount()`)
2. **Cross-window sync** (when another VS Code window updates the auth secret)
3. **Extension startup** (in Controller constructor)

If ANY of these happen within 30 seconds of a failed token refresh, the user gets logged out unexpectedly.

### Why It's Inconsistent

The code already handles similar cases correctly by returning `storedAuthData`:

| Scenario | Current Behavior | Correct? |
|----------|------------------|----------|
| Max retries exceeded (line 214) | \`return storedAuthData\` | Yes |
| Network error during refresh (line 251) | \`return storedAuthData\` | Yes |
| Token still valid after failed attempt (line 197) | \`return storedAuthData\` | Yes |
| **Waiting for retry delay (line 207)** | \`return null\` | **NO - This is the bug** |

### Why Web App Never Has This Issue

The web app (app.cline.bot) doesn't have this aggressive "restore on startup/cross-tab" behavior. It just uses the token from localStorage and only refreshes when making an API request. The extension's more aggressive restore flow creates many more opportunities for this bug to trigger.

## The Fix

Changed line 207 from `return null` to `return storedAuthData`.

This ensures:
- During retry delay, user stays logged in with existing credentials
- The 30-second delay is still respected (no server hammering)
- After 30 seconds, the next call will attempt refresh
- `getAuthToken()` already has expiry checks to prevent using truly expired tokens

## Investigation Details

### Auth Flow Traced

1. **Login Flow**: User clicks login -> OAuth redirect -> callback with auth code -> token exchange -> store in VS Code SecretStorage -> update in-memory state -> broadcast to webview

2. **Token Storage**: Stored in VS Code's SecretStorage (encrypted by OS credential manager) under key `"cline:clineAccountId"` as JSON containing \`{idToken, refreshToken, expiresAt, userInfo, provider, startedAt}\`

3. **Token Refresh**: Triggered when token expires within 5 minutes. Uses retry logic with 30-second delay between attempts (max 3 retries). On 400/401 response, logs out immediately. On network error, returns stale data.

4. **Cross-Window Sync**: `context.secrets.onDidChange` event fires in ALL windows when auth secret changes. Each window then calls `restoreRefreshTokenAndRetrieveAuthInfo()`.

5. **Startup Restore**: Controller constructor calls `restoreRefreshTokenAndRetrieveAuthInfo()` to load auth from storage.

### Key Difference from getAuthToken()

`getAuthToken()` (used for API requests) handles null correctly:
```typescript
const updatedAuthInfo = await provider.retrieveClineAuthInfo(this._controller)
if (updatedAuthInfo) {
    // Update state
} 
// If null, just continues with existing state - NO LOGOUT
```

But `restoreRefreshTokenAndRetrieveAuthInfo()` unconditionally overwrites the in-memory state:
```typescript
this._clineAuthInfo = await this.retrieveAuthInfo()  // Overwrites with null!
if (!this._clineAuthInfo) {
    // LOGOUT
}
```

## Test Plan

- [x] Code compiles
- [x] Unit tests pass
- [ ] Manual testing: Sign in, disconnect network, trigger org switch or cross-window sync within 30s, verify user stays logged in
- [ ] Verify token refresh still works correctly after the 30s delay

## Related PRs

- #8021 - Fixed premature logout on network errors (but introduced 401 surge)
- #8386 - Added post-refresh validation to prevent 401s
- #8470 - Extended expired token checks
- #8032 - Comprehensive auth state refactor (addresses same issue differently)

This PR is the minimal fix for the core bug. PR #8032 is a more comprehensive refactor that could be considered for future improvements.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes random logouts during token refresh retry delay by returning stored auth data instead of null in `ClineAuthProvider.ts`.
> 
>   - **Behavior**:
>     - Fixes bug in `ClineAuthProvider.ts` where `retrieveClineAuthInfo()` returned `null` during token refresh retry delay, causing random logouts.
>     - Changes line 207 to return `storedAuthData` instead of `null` to maintain user session during retry delay.
>   - **Root Cause**:
>     - `restoreRefreshTokenAndRetrieveAuthInfo()` interpreted `null` as no auth data, leading to logout.
>     - Triggered by actions like organization switch, cross-window sync, or extension startup within 30s of a failed refresh.
>   - **Consistency**:
>     - Aligns behavior with other scenarios where `storedAuthData` is returned, ensuring consistent handling of auth data.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 61ecc606853e8a59c105cdb5dea97c849dd46fe7. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->