### PR TITLE
fix: support CLINE_DIR environment variable in CLI (fixes #8379)

### DIFF
--- a/cli/pkg/cli/global/global.go
+++ b/cli/pkg/cli/global/global.go
@@ -37,11 +37,16 @@ var (
 
 func InitializeGlobalConfig(cfg *GlobalConfig) error {
 	if cfg.ConfigPath == "" {
-		homeDir, err := os.UserHomeDir()
-		if err != nil {
-			return fmt.Errorf("failed to get home directory: %w", err)
+		// Check CLINE_DIR environment variable first
+		if clineDir := os.Getenv("CLINE_DIR"); clineDir != "" {
+			cfg.ConfigPath = clineDir
+		} else {
+			homeDir, err := os.UserHomeDir()
+			if err != nil {
+				return fmt.Errorf("failed to get home directory: %w", err)
+			}
+			cfg.ConfigPath = filepath.Join(homeDir, ".cline")
 		}
-		cfg.ConfigPath = filepath.Join(homeDir, ".cline")
 	}
 
 	// Ensure .cline directory exists


### PR DESCRIPTION
## Summary
- The CLINE_DIR environment variable is now properly respected by the CLI
- Users can now override the default ~/.cline directory via environment variable

## Root Cause
`InitializeGlobalConfig()` in `global.go` only checked if `cfg.ConfigPath` was empty, then defaulted to `~/.cline` without checking the `CLINE_DIR` environment variable.

## Changes
- Added check for `CLINE_DIR` environment variable before defaulting to home directory
- Priority: `--config` flag > `CLINE_DIR` env var > default `~/.cline`

## Test Plan
1. `export CLINE_DIR=/custom/path/cline`
2. `cline version`
3. Verify `/custom/path/cline` is used instead of `~/.cline`
4. Verify directory is created and used for DB/config/runtime data

## Files Changed
- `cli/pkg/cli/global/global.go`

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> The PR ensures the `CLINE_DIR` environment variable is respected in the CLI for configuration paths, with additional minor updates across various components.
> 
>   - **Behavior**:
>     - `InitializeGlobalConfig()` in `global.go` now checks `CLINE_DIR` environment variable before defaulting to `~/.cline`.
>     - Priority order for config path: `--config` flag > `CLINE_DIR` env var > default `~/.cline`.
>   - **Functions**:
>     - `isUserReadyToUse()` in `main.go` now checks if a BYO provider is configured.
>     - `getLmStudioModels()` in `getLmStudioModels.ts` now fetches model IDs instead of JSON strings.
>     - `refreshLiteLlmModels()` in `refreshLiteLlmModels.ts` uses `isKnownReasoningModel()` to determine reasoning capability.
>   - **Misc**:
>     - Added server capability checks in `fetchResourcesList()` and `fetchResourceTemplatesList()` in `McpHub.ts`.
>     - `UserMessage.tsx` now restores original text on blur and escape key press.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for c313c70e5c80f91a67e607077667d7e95f4dc61e. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->