### PR TITLE
Fix file paths with spaces before extensions from VS Code LM API (#7827)

### DIFF
--- a/src/core/task/tools/handlers/WriteToFileToolHandler.ts
+++ b/src/core/task/tools/handlers/WriteToFileToolHandler.ts
@@ -351,6 +351,14 @@ export class WriteToFileToolHandler implements IFullyManagedTool {
 				? { absolutePath: pathResult, resolvedPath: relPath }
 				: { absolutePath: pathResult.absolutePath, resolvedPath: pathResult.resolvedPath }
 
+		// Normalize paths to fix LLM output issues (e.g., VS Code LM API inserting spaces before extensions)
+		// Removes spaces immediately before file extensions while preserving legitimate spaces in filenames
+		// e.g., "file .ts" becomes "file.ts", but "My File.ts" stays as "My File.ts"
+		const normalizedRelPath = relPath.replace(/ (\.[a-zA-Z0-9]+)$/, ".$1")
+		const normalizedResolvedPath = resolvedPath.replace(/ (\.[a-zA-Z0-9]+)$/, ".$1")
+		// Update absolutePath to use normalized path
+		const normalizedAbsolutePath = absolutePath.replace(/ (\.[a-zA-Z0-9]+)$/, ".$1")
+
 		// Determine workspace context for telemetry
 		const fallbackAbsolutePath = path.resolve(config.cwd, relPath)
 		const workspaceContext = {
@@ -361,13 +369,13 @@ export class WriteToFileToolHandler implements IFullyManagedTool {
 		}
 
 		// Check clineignore access first
-		const accessValidation = this.validator.checkClineIgnorePath(resolvedPath)
+		const accessValidation = this.validator.checkClineIgnorePath(normalizedResolvedPath)
 		if (!accessValidation.ok) {
 			// Show error and return early (full original behavior)
-			await config.callbacks.say("clineignore_error", resolvedPath)
+			await config.callbacks.say("clineignore_error", normalizedResolvedPath)
 
 			// Push tool result and save checkpoint using existing utilities
-			const errorResponse = formatResponse.toolError(formatResponse.clineIgnoreError(resolvedPath))
+			const errorResponse = formatResponse.toolError(formatResponse.clineIgnoreError(normalizedResolvedPath))
 			ToolResultUtils.pushToolResult(
 				errorResponse,
 				block,
@@ -388,7 +396,7 @@ export class WriteToFileToolHandler implements IFullyManagedTool {
 		if (config.services.diffViewProvider.editType !== undefined) {
 			fileExists = config.services.diffViewProvider.editType === "modify"
 		} else {
-			fileExists = await fileExistsAtPath(absolutePath)
+			fileExists = await fileExistsAtPath(normalizedAbsolutePath)
 			config.services.diffViewProvider.editType = fileExists ? "modify" : "create"
 		}
 
@@ -399,12 +407,12 @@ export class WriteToFileToolHandler implements IFullyManagedTool {
 		if (diff) {
 			// Handle replace_in_file with diff construction
 			// Apply model-specific fixes (deepseek models tend to use unescaped html entities in diffs)
-			diff = applyModelContentFixes(diff, config.api.getModel().id, resolvedPath)
+			diff = applyModelContentFixes(diff, config.api.getModel().id, normalizedResolvedPath)
 
 			// open the editor if not done already.  This is to fix diff error when model provides correct search-replace text but Cline throws error
 			// because file is not open.
 			if (!config.services.diffViewProvider.isEditing) {
-				await config.services.diffViewProvider.open(absolutePath, { displayPath: relPath })
+				await config.services.diffViewProvider.open(normalizedAbsolutePath, { displayPath: normalizedRelPath })
 			}
 
 			try {
@@ -475,7 +483,7 @@ export class WriteToFileToolHandler implements IFullyManagedTool {
 			}
 
 			// Apply model-specific fixes (llama, gemini, and other models may add escape characters)
-			newContent = applyModelContentFixes(newContent, config.api.getModel().id, resolvedPath)
+			newContent = applyModelContentFixes(newContent, config.api.getModel().id, normalizedResolvedPath)
 		} else {
 			// can't happen, since we already checked for content/diff above. but need to do this for type error
 			return
@@ -483,7 +491,15 @@ export class WriteToFileToolHandler implements IFullyManagedTool {
 
 		newContent = newContent.trimEnd() // remove any trailing newlines, since it's automatically inserted by the editor
 
-		return { relPath, absolutePath, fileExists, diff, content, newContent, workspaceContext }
+		return {
+			relPath: normalizedRelPath,
+			absolutePath: normalizedAbsolutePath,
+			fileExists,
+			diff,
+			content,
+			newContent,
+			workspaceContext,
+		}
 	}
 
 	private getModelInfo(config: TaskConfig) {


### PR DESCRIPTION
Some LLM providers (notably Claude Sonnet 4.5 via VS Code LM API) insert
spurious spaces before periods in file extensions (e.g., "file .ts" instead
of "file.ts"). This is an upstream issue with how GitHub Copilot's
integration layer processes Claude's output.

This fix adds a heuristic normalization to remove spaces immediately
before file extensions while preserving legitimate spaces in filenames
(e.g., "My File.ts" is preserved, but "file .ts" becomes "file.ts").

Fixes #7827
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes file path normalization by removing spaces before extensions and includes minor updates across several files.
> 
>   - **Behavior**:
>     - Normalize file paths by removing spaces before extensions in `normalizeFilePath()` in `WriteToFileToolHandler.ts`.
>     - Add blank line before segments in plain mode in `NewStreamingSegment()` in `segment_streamer.go`.
>     - Generate descriptive approval prompts in `getApprovalPrompt()` in `input_handler.go`.
>     - Handle empty choices in OpenAI API responses in `createMessage()` in `openai.ts`.
>     - Use `litellm_params.model` as key in `refreshLiteLlmModels()` in `refreshLiteLlmModels.ts`.
>   - **Misc**:
>     - Fix context menu visibility issue in `ChatTextArea.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for b6b1bee12c6b9e2eef95a4befb1c5aa7b8309b9b. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->