### PR TITLE
fix(e2e): increase getSidebar timeout for slower macOS CI runners

### DIFF
--- a/src/test/e2e/utils/helpers.ts
+++ b/src/test/e2e/utils/helpers.ts
@@ -97,7 +97,8 @@ export class E2ETestHelper {
 			return null
 		}
 
-		await E2ETestHelper.waitUntil(async () => (await findSidebarFrame()) !== null)
+		// Use longer timeout (30s) for sidebar - macOS CI runners can be slow
+		await E2ETestHelper.waitUntil(async () => (await findSidebarFrame()) !== null, 30000)
 		return (await findSidebarFrame()) || page.mainFrame()
 	}
 


### PR DESCRIPTION
### Related Issue

N/A - This is a small fix for CI test flakiness.

### Description

Increases the `getSidebar` timeout from 10s to 30s to reduce flakiness on macOS CI runners.

The E2E tests were intermittently failing on macOS with `waitUntil timeout after 10000ms` in `getSidebar`. This happens because macOS CI runners can be slower to initialize the VS Code extension and load the Cline sidebar.

### Test Procedure

- Verified the change is isolated to the timeout value
- CI should pass more reliably on macOS after this change

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A - No UI changes.

### Additional Notes

This is a minor infrastructure fix to reduce CI flakiness. No changeset needed as it doesn't affect users.