### PR TITLE
Fix remote config check

### DIFF
--- a/src/core/storage/remote-config/fetch.ts
+++ b/src/core/storage/remote-config/fetch.ts
@@ -235,7 +235,7 @@ async function ensureUserInOrgWithRemoteConfig(controller: Controller): Promise<
 
 		// Cache and apply the remote config
 		await writeRemoteConfigToCache(organizationId, config)
-		if (!isRemoteConfigEnabled(organizationId)) {
+		if (isRemoteConfigEnabled(organizationId)) {
 			await applyRemoteConfig(config, undefined, controller.mcpHub)
 		} else {
 			clearRemoteConfig()


### PR DESCRIPTION
### Description

The check is wrong. Thankfully it hasn't been released yet.

### Test Procedure

Tested locally remote config is applied.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix incorrect logic in `ensureUserInOrgWithRemoteConfig` to apply remote config only when enabled.
> 
>   - **Bug Fix**:
>     - Corrected logic in `ensureUserInOrgWithRemoteConfig` in `fetch.ts` to apply remote config only if `isRemoteConfigEnabled(organizationId)` returns true.
>   - **Behavior**:
>     - Previously, remote config was applied when it was not enabled due to incorrect condition check.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for b51861532a5b0cf7c8f8303e14e824e7b0628c0c. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->