### PR TITLE
fix: address error from system prompt validator

### DIFF
--- a/src/core/prompts/system-prompt/variants/gemini-3/config.ts
+++ b/src/core/prompts/system-prompt/variants/gemini-3/config.ts
@@ -38,7 +38,6 @@ export const config = createVariant(ModelFamily.GEMINI_3)
 		SystemPromptSection.EDITING_FILES,
 		SystemPromptSection.FEEDBACK,
 		SystemPromptSection.TODO,
-		SystemPromptSection.MCP,
 		SystemPromptSection.TASK_PROGRESS,
 		SystemPromptSection.SYSTEM_INFO,
 		SystemPromptSection.OBJECTIVE,

--- a/src/core/prompts/system-prompt/variants/variant-validator.ts
+++ b/src/core/prompts/system-prompt/variants/variant-validator.ts
@@ -125,9 +125,14 @@ export class VariantValidator {
 
 		// Check component overrides reference valid components
 		if (variant.componentOverrides) {
-			const invalidOverrides = Object.keys(variant.componentOverrides).filter(
-				(key) => !variant.componentOrder.includes(key as SystemPromptSection),
-			)
+			const invalidOverrides = Object.keys(variant.componentOverrides).filter((key) => {
+				const override = variant.componentOverrides[key as SystemPromptSection]
+				// Skip overrides that explicitly disable a component - these are valid even without being in componentOrder
+				if (override?.enabled === false) {
+					return false
+				}
+				return !variant.componentOrder.includes(key as SystemPromptSection)
+			})
 			if (invalidOverrides.length > 0) {
 				warnings.push(`Component overrides for unused components: ${invalidOverrides.join(", ")}`)
 			}
@@ -147,7 +152,14 @@ export class VariantValidator {
 
 		// Check tool overrides reference valid tools
 		if (variant.toolOverrides) {
-			const invalidOverrides = Object.keys(variant.toolOverrides).filter((key) => !variant.tools?.includes(key as any))
+			const invalidOverrides = Object.keys(variant.toolOverrides).filter((key) => {
+				const override = variant.toolOverrides![key as keyof typeof variant.toolOverrides]
+				// Skip overrides that explicitly disable a tool - these are valid even without being in tools list
+				if (override?.enabled === false) {
+					return false
+				}
+				return !variant.tools?.includes(key as any)
+			})
 			if (invalidOverrides.length > 0) {
 				warnings.push(`Tool overrides for unused tools: ${invalidOverrides.join(", ")}`)
 			}

--- a/src/core/prompts/system-prompt/variants/xs/overrides.ts
+++ b/src/core/prompts/system-prompt/variants/xs/overrides.ts
@@ -94,6 +94,6 @@ export const xsComponentOverrides: PromptVariant["componentOverrides"] = {
 		enabled: true, // Use default user instructions
 	},
 	[SystemPromptSection.FEEDBACK]: {
-		enabled: true, // Use default feedback section
+		enabled: false,
 	},
 }


### PR DESCRIPTION
The validator now correctly handles overrides with `enabled: false`, treating them as valid configuration even when the component/tool isn't included in the active lists.

<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- For feature requests: Created a discussion in our Feature Requests discussions board https://github.com/cline/cline/discussions/categories/feature-requests and received approval from core maintainers before implementation
- For all changes: Link the associated issue/discussion in the "Related Issue" section below

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly without prior discussion.

Why this requirement?
We deeply appreciate all community contributions - they are essential to Cline's success! To ensure the best use of everyone's time and maintain project direction, we use our Feature Requests discussions board to gauge community interest and validate feature ideas before implementation begins. This helps us focus development efforts on features that will benefit the most users.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** #XXXX

### Description

<!-- 
Help reviewers understand your changes by making this PR readable and well-organized:

- What problem does this PR solve?
- Why were these changes introduced and what purpose do they serve?
- For larger changes, provide context about your approach and reasoning

Small PRs may need minimal description, but larger changes benefit from explaining where you're coming from. Much of this context can be in the linked issue above, so feel free to reference it rather than repeating everything here.
-->

Address error from system prompt validators:


- Gemini 3.0 variant configuration warnings: "Components defined but not used in template: MCP_SECTION"
- GPT-5 variant configuration warnings: "Component overrides for unused components: EDITING_FILES_SECTION"
- XS variant configuration warnings: "Component overrides for unused components: TOOL_USE_SECTION, TOOLS_SECTION, MCP_SECTION, TODO_SECTION, FEEDBACK_SECTION"

Changes included:

- Remove SystemPromptSection.MCP from Gemini-3 component order
- Disable feedback section in XS variant component overrides
- Update variant validator to allow disabled overrides without requiring them in componentOrder/tools list


### Test Procedure

<!-- 
Please walk us through your testing approach and thought process. This helps reviewers understand that you've thoroughly considered the impact of your changes:

- How did you test this change?
- What could potentially break and how did you verify it doesn't?
- What existing functionality might be affected and how did you check it still works?
- Why are you confident this is ready for merge?

We're not looking for exhaustive documentation - just evidence that you've thought through the implications of your changes and tested accordingly.
-->

Open your debugger console and verified the error no longer show up:

<img width="924" height="278" alt="image" src="https://github.com/user-attachments/assets/eb04deac-c915-402d-a1d5-7474611bde6a" />


### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes validation logic to correctly handle disabled component/tool overrides and addresses configuration warnings in Gemini 3.0 and XS variants.
> 
>   - **Behavior**:
>     - `variant-validator.ts`: Updated to allow disabled component/tool overrides without requiring them in `componentOrder` or `tools` list.
>     - `gemini-3/config.ts`: Removed `SystemPromptSection.MCP` from component order.
>     - `xs/overrides.ts`: Disabled `SystemPromptSection.FEEDBACK` in XS variant.
>   - **Validation**:
>     - `validateComponents()` and `validateTools()` in `variant-validator.ts` now skip validation for disabled overrides.
>   - **Warnings**:
>     - Addresses warnings for unused components in Gemini 3.0 and XS variants.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 29f679b909bb92cbd3cba97a9d11805408e9c3ce. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->