### PR TITLE
Fix: CLI plain mode missing line breaks between segments (#7534)

### DIFF
--- a/.changeset/plain-mode-line-breaks-7534.md
+++ b/.changeset/plain-mode-line-breaks-7534.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Fix CLI plain mode missing line breaks between segments (#7534)

--- a/cli/pkg/cli/display/segment_streamer.go
+++ b/cli/pkg/cli/display/segment_streamer.go
@@ -45,6 +45,9 @@ func NewStreamingSegment(sayType, prefix string, mdRenderer *MarkdownRenderer, s
 			output.Println("")
 			output.Print(rendered)
 		}
+	} else if outputFormat == "plain" || !isTTY() {
+		// In plain mode, add a blank line before each segment for separation
+		output.Println("")
 	}
 
 	return ss


### PR DESCRIPTION
This is a focused fix for issue #7534 that only addresses the plain mode line break issue without including unrelated changes that were causing JetBrains plugin test failures.

**Problem:** CLI plain mode was concatenating segments (thinking, response, tool results, etc.) without line breaks between them, making output hard to read.

**Solution:** Adds a blank line separator before each segment in plain mode, matching the behavior of rich mode.

This PR only touches `cli/pkg/cli/display/segment_streamer.go` and doesn't modify any cline-core or JetBrains integration code, so it should pass JetBrains plugin tests.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds line breaks between segments in CLI plain mode in `segment_streamer.go` to improve readability.
> 
>   - **Behavior**:
>     - Adds a blank line before each segment in plain mode in `NewStreamingSegment()` in `segment_streamer.go`.
>     - Matches the behavior of rich mode by separating segments with line breaks.
>   - **Misc**:
>     - Creates a changeset file `plain-mode-line-breaks-7534.md` to document the fix.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 00b8e2f86db87546f7d204ad1b9c973b1a534d36. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->