### PR TITLE
Fix: Gemini thinkingBudget default to use dynamic thinking for 2.5 Pro/Flash (#7735)

### DIFF
--- a/.changeset/gemini-thinking-budget-default.md
+++ b/.changeset/gemini-thinking-budget-default.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Fix Gemini thinkingBudget default to use dynamic thinking for 2.5 Pro/Flash (#7735)

--- a/src/core/api/providers/gemini.ts
+++ b/src/core/api/providers/gemini.ts
@@ -114,7 +114,18 @@ export class GeminiHandler implements ApiHandler {
 		const contents = messages.map(convertAnthropicMessageToGemini)
 
 		// Configure thinking budget if supported
-		const _thinkingBudget = this.options.thinkingBudgetTokens ?? 0
+		// Default behavior based on model: https://ai.google.dev/gemini-api/docs/thinking#supported-models
+		let _thinkingBudget: number
+		if (this.options.thinkingBudgetTokens !== undefined) {
+			_thinkingBudget = this.options.thinkingBudgetTokens
+		} else {
+			// Gemini 2.5 Pro and Flash require dynamic thinking by default (thinkingBudget of 0 is invalid)
+			if (modelId === "gemini-2.5-pro" || modelId === "gemini-2.5-flash") {
+				_thinkingBudget = -1 // Default to dynamic thinking
+			} else {
+				_thinkingBudget = 0 // Default to off for other models like Flash Lite
+			}
+		}
 		const maxBudget = info.thinkingConfig?.maxBudget ?? 24576
 		const thinkingBudget = Math.min(_thinkingBudget, maxBudget)
 		// When ThinkingLevel is defined, thinking budget cannot be zero


### PR DESCRIPTION
This is a focused fix for issue #7735. The previous PR (#8506) included many unrelated changes that were causing JetBrains plugin test failures.

**Problem:** Gemini 2.5 Pro and Flash models require a non-zero thinkingBudget value, but the default was set to 0, causing API failures.

**Solution:** 
- Sets dynamic thinking (-1) as the default for Gemini 2.5 Pro and Flash models
- Maintains backward compatibility by keeping 0 as the default for other Gemini models
- Allows users to override the default via thinkingBudgetTokens configuration

This PR only touches `src/core/api/providers/gemini.ts` and doesn't modify any cline-core or JetBrains integration code.