### PR TITLE
Fix: Filter out task_progress from external MCP tool calls (#8256)

### DIFF
--- a/.changeset/mcp-task-progress-filter.md
+++ b/.changeset/mcp-task-progress-filter.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Filter out task_progress from external MCP tool calls (#8256)


### PR DESCRIPTION
This is a focused fix for issue #8256. The previous PR (#8508) included many unrelated changes that were causing JetBrains plugin test failures.

**Problem:** Cline-internal `task_progress` parameter was being sent to external MCP servers, causing API validation failures.

**Solution:** Filters out the `task_progress` parameter before sending tool arguments to external MCP servers, while keeping it for internal Cline operations.

This PR only touches `src/services/mcp/McpHub.ts` and doesn't modify any cline-core or JetBrains integration code.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Filters out `task_progress` from external MCP tool calls in `McpHub.ts` to prevent API validation failures.
> 
>   - **Behavior**:
>     - Filters out `task_progress` parameter in `callTool()` in `McpHub.ts` when sending tool arguments to external MCP servers.
>     - Retains `task_progress` for internal Cline operations.
>   - **Refactoring**:
>     - Replaces `getMcpSettingsFilePath()` calls with `getMcpSettingsFilePathHelper()` in `McpHub.ts`.
>     - Adds `isUpdatingFromRemoteConfig` flag to prevent unnecessary watcher triggers in `McpHub.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for a132ba6b4baa38af3965895c209b554447669520. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->