### PR TITLE
Fix: CLI not recognizing Ollama provider with default base URL (#7581)

### DIFF
--- a/.changeset/ollama-default-url-fix.md
+++ b/.changeset/ollama-default-url-fix.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Fix CLI not recognizing Ollama provider with default base URL (#7581)

--- a/cli/pkg/cli/auth/update_api_configurations.go
+++ b/cli/pkg/cli/auth/update_api_configurations.go
@@ -333,6 +333,10 @@ func AddProviderPartial(ctx context.Context, manager *task.Manager, provider cli
 	apiConfig := &cline.ModelsApiConfiguration{}
 
 	// Set API key field
+	// For Ollama, if the base URL is empty, use the default value
+	if fields.APIKeyField == "ollamaBaseUrl" && apiKey == "" {
+		apiKey = "http://localhost:11434"
+	}
 	if apiKey != "" || fields.APIKeyField != "ollamaBaseUrl" {
 		setAPIKeyField(apiConfig, fields.APIKeyField, proto.String(apiKey))
 	}


### PR DESCRIPTION
This is a focused fix for issue #7581. The previous PR (#8517) included many unrelated changes that were causing JetBrains plugin test failures.

**Problem:** When configuring Ollama provider in CLI, pressing Enter without entering a custom base URL left the field empty, causing the provider detection logic to fail.

**Solution:** Sets the default base URL "http://localhost:11434" when the user accepts the default by pressing Enter, ensuring the provider is properly recognized.

This PR only touches `cli/pkg/cli/auth/update_api_configurations.go` and doesn't modify any cline-core or JetBrains integration code.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes CLI issue by setting default base URL for Ollama provider in `update_api_configurations.go`.
> 
>   - **Behavior**:
>     - Sets default base URL `http://localhost:11434` for Ollama provider in `AddProviderPartial()` in `update_api_configurations.go` when user presses Enter without input.
>   - **Files**:
>     - Modifies `update_api_configurations.go` to handle default base URL for Ollama provider.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 647002ed8b141e7792f2209098fdd632195c4a9a. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->