### PR TITLE
Fix: empty tool description causing AWS Bedrock API validation failure (#7696)

### DIFF
--- a/.changeset/bedrock-empty-description-fix.md
+++ b/.changeset/bedrock-empty-description-fix.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Fix empty tool description causing AWS Bedrock API validation failure (#7696)

--- a/src/core/prompts/system-prompt/tools/focus_chain.ts
+++ b/src/core/prompts/system-prompt/tools/focus_chain.ts
@@ -7,7 +7,7 @@ const generic: ClineToolSpec = {
 	variant: ModelFamily.GENERIC,
 	id: ClineDefaultTool.TODO,
 	name: "focus_chain",
-	description: "",
+	description: "Tool for maintaining conversation context across multiple interactions",
 	contextRequirements: (context) => context.focusChainSettings?.enabled === true,
 }
 


### PR DESCRIPTION
This is a focused fix for issue #7696. The previous PR (#8514) included many unrelated changes that were causing JetBrains plugin test failures.

**Problem:** AWS Bedrock API was rejecting requests because the focus_chain tool had an empty description, which fails API validation.

**Solution:** Added a meaningful description to the focus_chain tool: "Tool for maintaining conversation context across multiple interactions".

This PR only touches `src/core/prompts/system-prompt/tools/focus_chain.ts` and doesn't modify any cline-core or JetBrains integration code.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds a description to `focus_chain` tool in `focus_chain.ts` to fix AWS Bedrock API validation failure.
> 
>   - **Behavior**:
>     - Adds description to `focus_chain` tool in `focus_chain.ts` to fix AWS Bedrock API validation failure.
>     - Description added: "Tool for maintaining conversation context across multiple interactions".
>   - **Misc**:
>     - Creates `.changeset/bedrock-empty-description-fix.md` to document the patch.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 4f9dd13c04380d1a78049a32bcd92f11869b6043. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->