### PR TITLE
Fix: crash on usage chunks with empty choices in OpenAI-compatible APIs (#8384)

### DIFF
--- a/.changeset/openai-usage-chunk-fix.md
+++ b/.changeset/openai-usage-chunk-fix.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Fix crash on usage chunks with empty choices in OpenAI-compatible APIs (#8384)


### PR DESCRIPTION
This is a focused fix for issue #8384. The previous PR (#8518) included many unrelated changes that were causing JetBrains plugin test failures.

**Problem:** Some OpenAI-compatible APIs send usage chunks with empty choices arrays, causing crashes when trying to access chunk.choices[0].

**Solution:** 
- Check if chunk.choices exists and is not empty before accessing it
- Handle usage-only chunks separately by yielding usage information and continuing
- Extracted usage yielding into a reusable helper function

This PR only touches `src/core/api/providers/openai.ts` and doesn't modify any cline-core or JetBrains integration code.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix crash in `OpenAiHandler` by checking for empty choices in usage chunks and handling them separately in `openai.ts`.
> 
>   - **Behavior**:
>     - Fix crash in `OpenAiHandler` in `openai.ts` by checking if `chunk.choices` exists and is not empty before accessing.
>     - Handle usage-only chunks by yielding usage information and continuing.
>   - **Functions**:
>     - Extracted `yieldUsage()` helper function to yield usage information from a chunk in `openai.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for ba1be2fa45c6b1e0d669410b163df579324212f0. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->