### PR TITLE
Fix: Increase gRPC message size limits to prevent crashes on large tasks (#7959)

### DIFF
--- a/.changeset/grpc-message-size-fix.md
+++ b/.changeset/grpc-message-size-fix.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Increase gRPC message size limits to prevent crashes on large tasks (#7959)

--- a/src/standalone/protobus-service.ts
+++ b/src/standalone/protobus-service.ts
@@ -12,7 +12,12 @@ export const PROTOBUS_PORT = 26040
 
 export function startProtobusService(controller: Controller): Promise<string> {
 	return new Promise((resolve, reject) => {
-		const server = new grpc.Server()
+		// Increase gRPC message size limits to handle large task state
+		// Default is 4MiB which can be exceeded by tasks with extensive conversation history
+		const server = new grpc.Server({
+			"grpc.max_receive_message_length": 100 * 1024 * 1024, // 100MB
+			"grpc.max_send_message_length": 100 * 1024 * 1024, // 100MB
+		})
 
 		// Set up health check.
 		const healthImpl = new health.HealthImplementation({ "": "SERVING" })


### PR DESCRIPTION
This is a focused fix for issue #7959. The previous PR (#8513) included many unrelated changes that were causing JetBrains plugin test failures.

**Problem:** CLI was crashing with gRPC assert when message size exceeded default 4MiB limit on tasks with extensive conversation history.

**Solution:** 
- Increased max_receive_message_length to 100MB
- Increased max_send_message_length to 100MB
- Default 4MiB limit was too small for large tasks

This PR only touches `src/standalone/protobus-service.ts` and doesn't modify any cline-core or JetBrains integration code.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Increase gRPC message size limits to 100MB in `protobus-service.ts` to prevent crashes on large tasks.
> 
>   - **Behavior**:
>     - Increase `grpc.max_receive_message_length` and `grpc.max_send_message_length` to 100MB in `startProtobusService()` in `protobus-service.ts` to prevent crashes on large tasks.
>     - Default 4MiB limit was insufficient for tasks with extensive conversation history.
>   - **Misc**:
>     - Adds a changeset file `grpc-message-size-fix.md` to document the patch.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 85a7fbbdc058e3557f66f1328327a89fc41edef6. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->