### PR TITLE
Fix: TaskCancel hook executing twice when canceling a task (#8190)

### DIFF
--- a/.changeset/taskcancel-hook-fix.md
+++ b/.changeset/taskcancel-hook-fix.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Fix TaskCancel hook executing twice when canceling a task (#8190)

--- a/src/core/task/index.ts
+++ b/src/core/task/index.ts
@@ -1414,6 +1414,11 @@ export class Task {
 	}
 
 	async abortTask() {
+		// Guard against double execution - if already aborted, return immediately
+		if (this.taskState.abort) {
+			return
+		}
+
 		try {
 			// PHASE 1: Check if TaskCancel should run BEFORE any cleanup
 			// We must capture this state now because subsequent cleanup will


### PR DESCRIPTION
This is a focused fix for issue #8190. The previous PR (#8512) included many unrelated changes that were causing JetBrains plugin test failures.

**Problem:** TaskCancel hook was executing twice when canceling a task, causing issues with plugins and extensions that listen to this event.

**Solution:** 
- Added guard at the start of abortTask() to prevent double execution
- If task is already aborted, returns immediately without running cleanup again

This PR only touches `src/core/task/index.ts` and doesn't modify any cline-core or JetBrains integration code.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes double execution of TaskCancel hook in `abortTask()` by adding a guard clause in `index.ts`.
> 
>   - **Behavior**:
>     - Fixes double execution of TaskCancel hook in `abortTask()` in `index.ts` by adding a guard clause.
>     - If `taskState.abort` is true, `abortTask()` returns immediately, preventing further execution.
>   - **Files**:
>     - Modifies `index.ts` to implement the fix.
>   - **Misc**:
>     - Adds a changeset file `taskcancel-hook-fix.md` to document the patch.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 397ee39bb676a7e5e3a0822d0601b2c37563e511. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->