### PR TITLE
Fix: Cline force-opening sidebar after each update (#8077)

### DIFF
--- a/.changeset/cline-force-open-fix.md
+++ b/.changeset/cline-force-open-fix.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Fix Cline force-opening sidebar after each update (#8077)

--- a/src/common.ts
+++ b/src/common.ts
@@ -107,6 +107,8 @@ async function showVersionUpdateAnnouncement(context: vscode.ExtensionContext) {
 					type: ShowMessageType.INFORMATION,
 					message,
 				})
+				// Update lastShownAnnouncementId immediately to prevent repeated auto-focus on minor updates
+				await context.globalState.update("lastShownAnnouncementId", latestAnnouncementId)
 			}
 			// Always update the main version tracker for the next launch.
 			await context.globalState.update("clineVersion", currentVersion)


### PR DESCRIPTION
This is a focused fix for issue #8077. The previous PR (#8511) included many unrelated changes that were causing JetBrains plugin test failures.

**Problem:** Cline was forcing itself to open on every minor version update, closing other tabs like Explorer, Source Control, and Search. The issue was that lastShownAnnouncementId was only updated when user explicitly dismissed the announcement banner, not when they just closed the sidebar.

**Solution:** Updated showVersionUpdateAnnouncement() in src/common.ts to immediately update lastShownAnnouncementId after showing the version update notification. This prevents repeated auto-focus behavior on subsequent patch updates.

This PR only touches `src/common.ts` and doesn't modify any cline-core or JetBrains integration code.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes Cline sidebar force-opening issue by updating `lastShownAnnouncementId` immediately in `src/common.ts`.
> 
>   - **Behavior**:
>     - Fixes issue #8077 where Cline sidebar was force-opening after each update.
>     - Updates `lastShownAnnouncementId` immediately in `showVersionUpdateAnnouncement()` in `src/common.ts` to prevent repeated auto-focus on minor updates.
>   - **Scope**:
>     - Only modifies `src/common.ts`, no changes to cline-core or JetBrains integration.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for bdd502774c1cad8c77305446c49ada6a9ab4b734. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->