### PR TITLE
Fix: MCP server toggle disable race condition causing error flash (#7564)

### DIFF
--- a/.changeset/mcp-toggle-race-fix.md
+++ b/.changeset/mcp-toggle-race-fix.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Fix MCP server toggle disable race condition causing error flash (#7564)

--- a/src/services/mcp/McpHub.ts
+++ b/src/services/mcp/McpHub.ts
@@ -1055,6 +1055,8 @@ export class McpHub {
 	// Public methods for server management
 
 	public async toggleServerDisabledRPC(serverName: string, disabled: boolean): Promise<McpServer[]> {
+		// Set flag to prevent file watcher from triggering during our update
+		this.isUpdatingClineSettings = true
 		try {
 			const config = await this.readAndValidateMcpSettingsFile()
 			if (!config) {
@@ -1092,6 +1094,12 @@ export class McpHub {
 				message: `Failed to update server state: ${error instanceof Error ? error.message : String(error)}`,
 			})
 			throw error
+		} finally {
+			// Clear flag after a delay to ensure file watcher event has been processed
+			// The file watcher has a 100ms stabilityThreshold, so we wait a bit longer
+			setTimeout(() => {
+				this.isUpdatingClineSettings = false
+			}, 300)
 		}
 	}
 


### PR DESCRIPTION
This is a focused fix for issue #7564. The previous PR (#8510) included many unrelated changes that were causing JetBrains plugin test failures.

**Problem:** When toggling an MCP server's enabled/disabled state, an error message would briefly flash and other servers would show incorrect status for a moment. This was caused by a race condition between the RPC response updating the config file and the file watcher triggering a second update.

**Solution:** 
- Applied isUpdatingClineSettings flag protection to toggleServerDisabledRPC (similar to PR #8222 for toggleToolAutoApproveRPC)
- The flag prevents file watcher from triggering during UI-initiated updates
- After a 300ms delay (longer than file watcher's 100ms stabilityThreshold), flag is cleared

This PR only touches `src/services/mcp/McpHub.ts` and doesn't modify any cline-core or JetBrains integration code.