### PR TITLE
Fix: Respect user-configured timeout for MCP tools/resources requests (#7635)

### DIFF
--- a/.changeset/mcp-timeout-fix.md
+++ b/.changeset/mcp-timeout-fix.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Respect user-configured timeout for MCP tools/resources requests (#7635)

--- a/src/services/mcp/McpHub.ts
+++ b/src/services/mcp/McpHub.ts
@@ -649,8 +649,10 @@ export class McpHub {
 				return []
 			}
 
+			// Use server's configured timeout (in seconds) or default, convert to ms
+			const timeoutMs = (connection.server.timeout || DEFAULT_MCP_TIMEOUT_SECONDS) * 1000
 			const response = await connection.client.request({ method: "tools/list" }, ListToolsResultSchema, {
-				timeout: DEFAULT_REQUEST_TIMEOUT_MS,
+				timeout: timeoutMs,
 			})
 
 			// Get autoApprove settings
@@ -681,8 +683,10 @@ export class McpHub {
 				return []
 			}
 
+			// Use server's configured timeout (in seconds) or default, convert to ms
+			const timeoutMs = (connection.server.timeout || DEFAULT_MCP_TIMEOUT_SECONDS) * 1000
 			const response = await connection.client.request({ method: "resources/list" }, ListResourcesResultSchema, {
-				timeout: DEFAULT_REQUEST_TIMEOUT_MS,
+				timeout: timeoutMs,
 			})
 			return response?.resources || []
 		} catch (_error) {
@@ -700,11 +704,13 @@ export class McpHub {
 				return []
 			}
 
+			// Use server's configured timeout (in seconds) or default, convert to ms
+			const timeoutMs = (connection.server.timeout || DEFAULT_MCP_TIMEOUT_SECONDS) * 1000
 			const response = await connection.client.request(
 				{ method: "resources/templates/list" },
 				ListResourceTemplatesResultSchema,
 				{
-					timeout: DEFAULT_REQUEST_TIMEOUT_MS,
+					timeout: timeoutMs,
 				},
 			)
 


### PR DESCRIPTION
This is a focused fix for issue #7635. The previous PR (#8509) included many unrelated changes that were causing JetBrains plugin test failures.

**Problem:** MCP servers that take longer than 5 seconds to respond to tools/list, resources/list, or resources/templates/list were failing even when a higher timeout was explicitly configured in MCP server settings.

**Solution:** 
- Modified fetchToolsList(), fetchResourcesList(), and fetchResourceTemplatesList() methods in McpHub.ts
- Now uses server's configured timeout (in seconds) instead of hardcoded DEFAULT_REQUEST_TIMEOUT_MS (5000ms)
- Falls back to DEFAULT_MCP_TIMEOUT_SECONDS (60s) if no timeout is configured

This PR only touches `src/services/mcp/McpHub.ts` and doesn't modify any cline-core or JetBrains integration code.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes timeout handling in `McpHub.ts` to respect user-configured settings for MCP server requests.
> 
>   - **Behavior**:
>     - `fetchToolsList()`, `fetchResourcesList()`, and `fetchResourceTemplatesList()` in `McpHub.ts` now use server-configured timeout instead of `DEFAULT_REQUEST_TIMEOUT_MS`.
>     - Falls back to `DEFAULT_MCP_TIMEOUT_SECONDS` if no timeout is configured.
>   - **Misc**:
>     - Adds a changeset file `mcp-timeout-fix.md` to document the patch.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 1d0853a4585a8cea234963db0e9be96366a5330f. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->