### PR TITLE
Fix: support CLINE_DIR environment variable in CLI (#8379)

### DIFF
--- a/.changeset/cline-dir-env-var-fix.md
+++ b/.changeset/cline-dir-env-var-fix.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Support CLINE_DIR environment variable in CLI (#8379)

--- a/cli/pkg/cli/global/global.go
+++ b/cli/pkg/cli/global/global.go
@@ -37,11 +37,16 @@ var (
 
 func InitializeGlobalConfig(cfg *GlobalConfig) error {
 	if cfg.ConfigPath == "" {
-		homeDir, err := os.UserHomeDir()
-		if err != nil {
-			return fmt.Errorf("failed to get home directory: %w", err)
+		// Check CLINE_DIR environment variable first
+		if clineDir := os.Getenv("CLINE_DIR"); clineDir != "" {
+			cfg.ConfigPath = clineDir
+		} else {
+			homeDir, err := os.UserHomeDir()
+			if err != nil {
+				return fmt.Errorf("failed to get home directory: %w", err)
+			}
+			cfg.ConfigPath = filepath.Join(homeDir, ".cline")
 		}
-		cfg.ConfigPath = filepath.Join(homeDir, ".cline")
 	}
 
 	// Ensure .cline directory exists


### PR DESCRIPTION
This is a focused fix for issue #8379. The previous PR (#8503) included many unrelated changes that were causing JetBrains plugin test failures.

**Problem:** CLI was not respecting CLINE_DIR environment variable, making it difficult to use custom configuration paths.

**Solution:** 
- Check CLINE_DIR environment variable before defaulting to home directory
- Allows users to specify custom config location via environment variable

This PR only touches `cli/pkg/cli/global/global.go` and doesn't modify any cline-core or JetBrains integration code.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Support `CLINE_DIR` environment variable in `InitializeGlobalConfig()` to allow custom config paths in CLI.
> 
>   - **Behavior**:
>     - `InitializeGlobalConfig()` in `global.go` now checks `CLINE_DIR` environment variable for custom config path.
>     - Defaults to home directory if `CLINE_DIR` is not set.
>   - **Misc**:
>     - Adds a changeset file `cline-dir-env-var-fix.md` to document the patch.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 18ce5d26c918320914918e5ed261879b10d2a431. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->