### PR TITLE
Fix: Add quotes to file paths containing spaces in mentions (#7789)

### DIFF
--- a/.changeset/quotes-paths-spaces-fix.md
+++ b/.changeset/quotes-paths-spaces-fix.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Add quotes to file paths containing spaces in mentions (#7789)

--- a/src/core/mentions/index.ts
+++ b/src/core/mentions/index.ts
@@ -48,11 +48,12 @@ export async function openMention(mention?: string): Promise<void> {
 
 export async function getFileMentionFromPath(filePath: string) {
 	const cwd = await getCwd()
-	if (!cwd) {
-		return "@/" + filePath
+	const basePath = cwd ? path.relative(cwd, filePath) : filePath
+	// For file paths that contain spaces, wrap them in quotes
+	if (basePath.includes(" ")) {
+		return '@"/' + basePath + '"'
 	}
-	const relativePath = path.relative(cwd, filePath)
-	return "@/" + relativePath
+	return "@/" + basePath
 }
 
 export async function parseMentions(


### PR DESCRIPTION
This is a focused fix for issue #7789. The previous PR (#8505) included many unrelated changes that were causing JetBrains plugin test failures.

**Problem:** File paths containing spaces were not being properly quoted when using "Add to Cline" functionality, causing issues with the mentions system.

**Solution:** 
- Modified getFileMentionFromPath() in src/core/mentions/index.ts
- Wraps paths containing spaces in quotes: @"/path with spaces/file.ts"
- Paths without spaces continue to work as before: @/path/file.ts

This PR only touches `src/core/mentions/index.ts` and doesn't modify any cline-core or JetBrains integration code.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes issue #7789 by quoting file paths with spaces in `getFileMentionFromPath()` in `index.ts`.
> 
>   - **Behavior**:
>     - Fixes issue #7789 by modifying `getFileMentionFromPath()` in `index.ts` to wrap file paths containing spaces in quotes.
>     - Paths without spaces remain unchanged.
>   - **Misc**:
>     - Adds a changeset file `quotes-paths-spaces-fix.md` to document the patch.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 743a5f23ec12aa4cf71c4005d139ca093c220796. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->