### PR TITLE
Fix: use correct OpenAI-compatible endpoint for LM Studio (#8030)

### DIFF
--- a/.changeset/lm-studio-endpoint-fix.md
+++ b/.changeset/lm-studio-endpoint-fix.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Use correct OpenAI-compatible endpoint for LM Studio (#8030)

--- a/src/core/controller/models/getLmStudioModels.ts
+++ b/src/core/controller/models/getLmStudioModels.ts
@@ -14,11 +14,11 @@ export async function getLmStudioModels(_controller: Controller, request: String
 		if (!URL.canParse(baseUrl)) {
 			return StringArray.create({ values: [] })
 		}
-		const endpoint = new URL("api/v0/models", baseUrl)
+		const endpoint = new URL("v1/models", baseUrl)
 
 		const response = await fetch(endpoint.href)
 		const data = await response.json()
-		const models = data?.data?.map((m: unknown) => JSON.stringify(m)) || []
+		const models = data?.data?.map((model: any) => model.id) || []
 
 		return StringArray.create({ values: models })
 	} catch (error) {


### PR DESCRIPTION
This is a focused fix for issue #8030. The previous PR (#8493) included many unrelated changes that were causing JetBrains plugin test failures.

**Problem:** LM Studio provider was using incorrect API endpoint (api/v0/models) and not properly parsing model IDs, causing model fetching to fail.

**Solution:** 
- Changed endpoint from api/v0/models to v1/models (OpenAI-compatible)
- Fixed model ID parsing from JSON.stringify(model) to model.id

This PR only touches `src/core/controller/models/getLmStudioModels.ts` and doesn't modify any cline-core or JetBrains integration code.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes LM Studio provider by updating API endpoint and correcting model ID parsing in `getLmStudioModels.ts`.
> 
>   - **Behavior**:
>     - Change API endpoint in `getLmStudioModels.ts` from `api/v0/models` to `v1/models` for OpenAI compatibility.
>     - Fix model ID parsing by changing from `JSON.stringify(model)` to `model.id`.
>   - **Misc**:
>     - Add changeset file `lm-studio-endpoint-fix.md` for patch release notes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for e13ad8e56eb6cefc9003e57ec1b213b05a48212e. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->