### PR TITLE
Fix: add 'http' as alias for 'streamableHttp' in MCP config (#7091)

### DIFF
--- a/.changeset/http-alias-mcp-fix.md
+++ b/.changeset/http-alias-mcp-fix.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Add 'http' as alias for 'streamableHttp' in MCP config (#7091)

--- a/src/services/mcp/schemas.ts
+++ b/src/services/mcp/schemas.ts
@@ -61,7 +61,7 @@ const createServerTypeSchema = () => {
 			.refine((data) => data.type === "sse", { message: TYPE_ERROR_MESSAGE }),
 		// Streamable HTTP config (has url field)
 		BaseConfigSchema.extend({
-			type: z.literal("streamableHttp").optional(),
+			type: z.union([z.literal("streamableHttp"), z.literal("http")]).optional(),
 			transportType: z.string().optional(), // Support legacy field
 			url: z.string().url("URL must be a valid URL format"),
 			headers: z.record(z.string()).optional(),
@@ -73,7 +73,11 @@ const createServerTypeSchema = () => {
 			.transform((data) => {
 				// Support both type and transportType fields
 				// Note: legacy transportType was "http" not "streamableHttp"
-				const finalType = data.type || (data.transportType === "http" ? "streamableHttp" : undefined) || "streamableHttp"
+				// Also accept "http" as type for VS Code compatibility
+				const finalType =
+					(data.type === "http" ? "streamableHttp" : data.type) ||
+					(data.transportType === "http" ? "streamableHttp" : undefined) ||
+					"streamableHttp"
 				return {
 					...data,
 					type: finalType as "streamableHttp",


### PR DESCRIPTION
This is a focused fix for issue #7091. The previous PR (#8484) included many unrelated changes that were causing JetBrains plugin test failures.

**Problem:** MCP config did not accept 'http' as a transport type, only 'streamableHttp', which was inconsistent with other tools and VS Code.

**Solution:** 
- Added 'http' as an alias for 'streamableHttp' in MCP server type schema
- Accepts both 'http' and 'streamableHttp' as transport types
- Maintains backward compatibility

This PR only touches `src/services/mcp/schemas.ts` and doesn't modify any cline-core or JetBrains integration code.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds 'http' as an alias for 'streamableHttp' in MCP config to ensure compatibility and maintain backward compatibility.
> 
>   - **Behavior**:
>     - Adds 'http' as an alias for 'streamableHttp' in `createServerTypeSchema()` in `schemas.ts`.
>     - Accepts both 'http' and 'streamableHttp' as transport types for MCP config.
>     - Ensures backward compatibility by transforming 'http' to 'streamableHttp'.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 5cfbda5740332647ce3e95bf290f4c3daa77e5ea. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->