### PR TITLE
Fix: preserve model names with slashes in VS Code LM provider (#6293)

### DIFF
--- a/.changeset/vscode-lm-model-name-fix.md
+++ b/.changeset/vscode-lm-model-name-fix.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Preserve model names with slashes in VS Code LM provider (#6293)

--- a/webview-ui/src/components/settings/providers/VSCodeLmProvider.tsx
+++ b/webview-ui/src/components/settings/providers/VSCodeLmProvider.tsx
@@ -54,7 +54,10 @@ export const VSCodeLmProvider = ({ currentMode }: VSCodeLmProviderProps) => {
 							if (!value) {
 								return
 							}
-							const [vendor, family] = value.split("/")
+							// Split the value and preserve all slashes in the family name by joining parts after the vendor
+							const parts = value.split("/")
+							const vendor = parts[0]
+							const family = parts.slice(1).join("/")
 
 							handleModeFieldChange(
 								{ plan: "planModeVsCodeLmModelSelector", act: "actModeVsCodeLmModelSelector" },


### PR DESCRIPTION
This is a focused fix for issue #6293. The previous PR (#8487) included many unrelated changes that were causing JetBrains plugin test failures.

**Problem:** Model names containing slashes (e.g., 'meta-llama/Llama-3.1-8B-Instruct') were being truncated after the first slash in VS Code LM provider.

**Solution:** 
- Modified VSCodeLmProvider to preserve all slashes in model family names
- Splits vendor name from first slash, then joins the rest with slashes
- Example: 'meta-llama/Llama-3.1' → vendor='meta-llama', family='Llama-3.1'

This PR only touches `webview-ui/src/components/settings/providers/VSCodeLmProvider.tsx` and doesn't modify any cline-core or JetBrains integration code.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes issue #6293 by preserving slashes in model names in `VSCodeLmProvider.tsx`, ensuring correct vendor and family separation.
> 
>   - **Behavior**:
>     - Fixes issue #6293 by preserving slashes in model names in `VSCodeLmProvider.tsx`.
>     - Splits model name at the first slash for vendor, joins remaining parts for family.
>     - Example: 'meta-llama/Llama-3.1' → vendor='meta-llama', family='Llama-3.1'.
>   - **Files**:
>     - Modifies `webview-ui/src/components/settings/providers/VSCodeLmProvider.tsx` to implement the fix.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for c9abcffe9f64407dfe5e195606dd7b901ff17fd1. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->