### PR TITLE
Fix: normalize path separators in file search to prevent duplicates on Windows (#5747)

### DIFF
--- a/.changeset/normalize-path-separators-fix.md
+++ b/.changeset/normalize-path-separators-fix.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Normalize path separators in file search to prevent duplicates on Windows (#5747)

--- a/src/services/search/file-search.ts
+++ b/src/services/search/file-search.ts
@@ -49,16 +49,18 @@ export async function executeRipgrepForFiles(
 
 			// Convert absolute path to a relative path from workspace root
 			const relativePath = path.relative(workspacePath, line)
+			// Normalize path separators to forward slashes for consistency across platforms
+			const normalizedPath = relativePath.replace(/\\/g, "/")
 
 			// Add file result to array
 			fileResults.push({
-				path: relativePath,
+				path: normalizedPath,
 				type: "file",
-				label: path.basename(relativePath),
+				label: path.basename(normalizedPath),
 			})
 
 			// Extract and add parent directories to the set
-			let dirPath = path.dirname(relativePath)
+			let dirPath = path.dirname(normalizedPath)
 			while (dirPath && dirPath !== "." && dirPath !== "/") {
 				dirSet.add(dirPath)
 				dirPath = path.dirname(dirPath)


### PR DESCRIPTION
This is a focused fix for issue #5747. The previous PR (#8480) included many unrelated changes that were causing JetBrains plugin test failures.

**Problem:** On Windows, file search was returning duplicate entries because path separators were not normalized (mixed backslashes and forward slashes).

**Solution:** 
- Normalized all path separators to forward slashes for consistency across platforms
- Applied to both file results and directory path processing
- Ensures Windows paths match Unix paths for deduplication

This PR only touches `src/services/search/file-search.ts` and doesn't modify any cline-core or JetBrains integration code.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Normalize path separators in `file-search.ts` to prevent duplicate file entries on Windows by converting to forward slashes.
> 
>   - **Behavior**:
>     - Normalizes path separators to forward slashes in `executeRipgrepForFiles()` and `searchWorkspaceFiles()` in `file-search.ts` to prevent duplicate file entries on Windows.
>     - Ensures directory paths are processed consistently across platforms.
>   - **Misc**:
>     - Adds changeset file `normalize-path-separators-fix.md` to document the patch.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for f53f888c82cfb463cc5fb798c1bf6c9fb2e3a7ca. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->