### PR TITLE
Fix: add word wrapping for MCP tool call arguments (#5886)

### DIFF
--- a/.changeset/mcp-tool-arguments-word-wrap-fix.md
+++ b/.changeset/mcp-tool-arguments-word-wrap-fix.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Add word wrapping for MCP tool call arguments (#5886)

--- a/webview-ui/src/components/chat/ChatRow.tsx
+++ b/webview-ui/src/components/chat/ChatRow.tsx
@@ -63,7 +63,6 @@ import { ThinkingRow } from "./ThinkingRow"
 import UserMessage from "./UserMessage"
 
 // State type for api_req_started rendering
-type ApiReqState = "pre" | "thinking" | "error" | "final"
 
 const HEADER_CLASSNAMES = "flex items-center gap-2.5 mb-3"
 
@@ -783,6 +782,7 @@ export const ChatRowContent = memo(
 										<div className="mb-1 opacity-80 uppercase">Arguments</div>
 										<CodeAccordian
 											code={useMcpServer.arguments}
+											forceWrap={true}
 											isExpanded={true}
 											language="json"
 											onToggleExpand={handleToggle}

--- a/webview-ui/src/components/common/CodeAccordian.tsx
+++ b/webview-ui/src/components/common/CodeAccordian.tsx
@@ -14,6 +14,7 @@ interface CodeAccordianProps {
 	isExpanded: boolean
 	onToggleExpand: () => void
 	isLoading?: boolean
+	forceWrap?: boolean
 }
 
 /*
@@ -34,6 +35,7 @@ const CodeAccordian = ({
 	isExpanded,
 	onToggleExpand,
 	isLoading,
+	forceWrap,
 }: CodeAccordianProps) => {
 	const inferredLanguage = useMemo(
 		() => code && (language ?? (path ? getLanguageFromPath(path) : undefined)),
@@ -92,8 +94,11 @@ const CodeAccordian = ({
 				</Button>
 			)}
 			{(!(path || isFeedback || isConsoleLogs) || isExpanded) && (
-				<div className="overflow-x-auto overflow-y-hidden max-w-full">
+				<div className={cn("overflow-x-auto overflow-y-hidden max-w-full", {
+					"overflow-x-visible": forceWrap,
+				})}>
 					<CodeBlock
+						forceWrap={forceWrap}
 						source={`${"```"}${diff !== undefined ? "diff" : inferredLanguage}\n${(
 							code ?? diff ?? ""
 						).trim()}\n${"```"}`}


### PR DESCRIPTION
This is a focused fix for issue #5886. The previous PR (#8479) included many unrelated changes that were causing JetBrains plugin test failures.

**Problem:** MCP tool call arguments with long JSON were not word-wrapped in the chat UI, making them difficult to read on narrow screens.

**Solution:** 
- Added forceWrap prop to CodeAccordian component
- Force-wraps MCP tool arguments (JSON) to prevent horizontal scrolling
- Applied only to MCP tool calls, not code blocks

This PR only touches `webview-ui/src/components/common/CodeAccordian.tsx` and `webview-ui/src/components/chat/ChatRow.tsx` and doesn't modify any cline-core or JetBrains integration code.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds word wrapping for MCP tool call arguments in `ChatRow.tsx` using a new `forceWrap` prop in `CodeAccordian.tsx`.
> 
>   - **Behavior**:
>     - Adds `forceWrap` prop to `CodeAccordian` component in `CodeAccordian.tsx` to enable word wrapping.
>     - Applies `forceWrap` to MCP tool call arguments in `ChatRow.tsx` to prevent horizontal scrolling.
>   - **Files**:
>     - Modifies `CodeAccordian.tsx` to include `forceWrap` logic.
>     - Updates `ChatRow.tsx` to use `forceWrap` for MCP tool arguments.
>   - **Misc**:
>     - Does not affect code blocks or other components.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 5d5caabf975740dee92fe045c3c999cc9d699a06. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->