### PR TITLE
Fix: StreamableHttp MCP reconnection (#8367)

### DIFF
--- a/src/services/mcp/McpHub.ts
+++ b/src/services/mcp/McpHub.ts
@@ -452,6 +452,9 @@ export class McpHub {
 					break
 				}
 				case "streamableHttp": {
+					// Use ReconnectingEventSource for auto-reconnection on connection drops
+					global.EventSource = ReconnectingEventSource
+
 					// Custom fetch wrapper that treats 404 as 405 for GET requests.
 					// The MCP SDK sends a GET request to check for SSE stream support.
 					// Per MCP spec, servers should return 405 if they don't support SSE,


### PR DESCRIPTION
**Issue:** #8367 

### Description

StreamableHttp was missing the ReconnectingEventSource object, already used for auto-reconnection or connection drops in SSE mode.

After adding it to StreamableHttp, the connection was stable, tested for hours, no drops anymore.

### Test Procedure

No tests are present for McpHub.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

### Additional Notes
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `ReconnectingEventSource` to `streamableHttp` transport in `McpHub.ts` for improved connection stability.
> 
>   - **Behavior**:
>     - Adds `ReconnectingEventSource` to `streamableHttp` transport in `McpHub.ts` for auto-reconnection on connection drops.
>   - **Misc**:
>     - No new tests added for `McpHub`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for a7c02498948cadef5db5c495cbca282a4e5262fe. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->