### PR TITLE
fix: correct overflow and alignment in completion outputs

### DIFF
--- a/webview-ui/src/components/chat/CompletionOutputRow.tsx
+++ b/webview-ui/src/components/chat/CompletionOutputRow.tsx
@@ -52,7 +52,7 @@ export const CompletionOutputRow = memo(
 						<CopyButton className="text-success" textToCopy={text} />
 					</div>
 					{/* Content */}
-					<div className="w-full relative overflow-visible border-t-1 border-description/20 rounded-b-sm">
+					<div className="w-full relative overflow-hidden border-t-1 border-description/20 rounded-b-sm">
 						<div
 							className={cn(
 								"completion-output-content",

--- a/webview-ui/src/components/chat/PlanCompletionOutputRow.tsx
+++ b/webview-ui/src/components/chat/PlanCompletionOutputRow.tsx
@@ -33,7 +33,7 @@ const PlanCompletionOutputRow = memo(({ text, headClassNames }: PlanCompletionOu
 			</div>
 
 			{/* Content */}
-			<div className="w-full relative overflow-visible border-t-1 border-description/20 rounded-b-sm">
+			<div className="w-full relative overflow-hidden border-t-1 border-description/20 rounded-b-sm">
 				<div
 					className={cn(
 						"plan-completion-content",

--- a/webview-ui/src/components/common/MarkdownBlock.tsx
+++ b/webview-ui/src/components/common/MarkdownBlock.tsx
@@ -295,14 +295,14 @@ const InlineCodeWithFileCheck: React.FC<ComponentProps<"code"> & { [key: string]
 	if (isFilePath) {
 		return (
 			<Button
-				className="p-0 ml-0.5 mt-0.5 leading-none align-middle transition-opacity relative top-px text-preformat translate-y-[-2px] gap-0.5"
+				className="p-0 ml-0.5 leading-none align-middle transition-opacity text-preformat gap-0.5 inline text-left"
 				onClick={() => FileServiceClient.openFileRelativePath({ value: filePath })}
 				size="icon"
 				title={`Open ${filePath} in editor`}
 				type="button"
 				variant="icon">
 				<code {...props} />
-				<SquareArrowOutUpRightIcon />
+				<SquareArrowOutUpRightIcon className="inline align-middle ml-0.5" />
 			</Button>
 		)
 	}


### PR DESCRIPTION

<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- For feature requests: Created a discussion in our Feature Requests discussions board https://github.com/cline/cline/discussions/categories/feature-requests and received approval from core maintainers before implementation
- For all changes: Link the associated issue/discussion in the "Related Issue" section below

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly without prior discussion.

Why this requirement?
We deeply appreciate all community contributions - they are essential to Cline's success! To ensure the best use of everyone's time and maintain project direction, we use our Feature Requests discussions board to gauge community interest and validate feature ideas before implementation begins. This helps us focus development efforts on features that will benefit the most users.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** #XXXX

### Description

<!-- 
Help reviewers understand your changes by making this PR readable and well-organized:

- What problem does this PR solve?
- Why were these changes introduced and what purpose do they serve?
- For larger changes, provide context about your approach and reasoning

Small PRs may need minimal description, but larger changes benefit from explaining where you're coming from. Much of this context can be in the linked issue above, so feel free to reference it rather than repeating everything here.
-->

- Change overflow-visible to overflow-hidden in CompletionOutputRow and PlanCompletionOutputRow to prevent content overflow issues
- Adjust inline code file path button alignment by removing vertical translation classes and adding inline display
- Improve icon positioning in MarkdownBlock by using inline and align-middle classes

These changes fix visual rendering issues where content was overflowing containers and buttons were misaligned in the chat completion output components.


### Test Procedure

<!-- 
Please walk us through your testing approach and thought process. This helps reviewers understand that you've thoroughly considered the impact of your changes:

- How did you test this change?
- What could potentially break and how did you verify it doesn't?
- What existing functionality might be affected and how did you check it still works?
- Why are you confident this is ready for merge?

We're not looking for exhaustive documentation - just evidence that you've thought through the implications of your changes and tested accordingly.
-->

Before

<img width="418" height="498" alt="image" src="https://github.com/user-attachments/assets/6ed1b47d-b5f9-4110-a277-23d8da95454e" />


After

<img width="406" height="527" alt="image" src="https://github.com/user-attachments/assets/d9812aca-a999-4972-80e1-dccb1606ca41" />


### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->
