### PR TITLE
Fix local CLI install to rebuild cleanly

### DIFF
--- a/scripts/install-local.sh
+++ b/scripts/install-local.sh
@@ -45,6 +45,11 @@ else
     echo -e "${YELLOW}⚠${NC}  Standalone build failed - aborting install"
     exit 1
 fi
+
+# Ensure extension package.json is present for cline-core startup
+mkdir -p "$PROJECT_ROOT/dist-standalone/extension"
+cp "$PROJECT_ROOT/package.json" "$PROJECT_ROOT/dist-standalone/extension/package.json"
+
 echo ""
 
 echo -e "${CYAN}→${NC} ${DIM}Installing to $INSTALL_DIR${NC}"

--- a/standalone/runtime-files/package-lock.json
+++ b/standalone/runtime-files/package-lock.json
@@ -21,6 +21,7 @@
 			"resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.13.3.tgz",
 			"integrity": "sha512-FTXHdOoPbZrBjlVLHuKbDZnsTxXv2BlHF57xw6LuThXacXvtkahEPED0CKMk6obZDf65Hv4k3z62eyPNpvinIg==",
 			"license": "Apache-2.0",
+			"peer": true,
 			"dependencies": {
 				"@grpc/proto-loader": "^0.7.13",
 				"@js-sdsl/ordered-map": "^4.4.2"


### PR DESCRIPTION
<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- For feature requests: Created a discussion in our Feature Requests discussions board https://github.com/cline/cline/discussions/categories/feature-requests and received approval from core maintainers before implementation
- For all changes: Link the associated issue/discussion in the "Related Issue" section below

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly without prior discussion.

Why this requirement?
We deeply appreciate all community contributions - they are essential to Cline's success! To ensure the best use of everyone's time and maintain project direction, we use our Feature Requests discussions board to gauge community interest and validate feature ideas before implementation begins. This helps us focus development efforts on features that will benefit the most users.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** #XXXX

### Description

<!-- 
Help reviewers understand your changes by making this PR readable and well-organized:

- What problem does this PR solve?
- Why were these changes introduced and what purpose do they serve?
- For larger changes, provide context about your approach and reasoning

Small PRs may need minimal description, but larger changes benefit from explaining where you're coming from. Much of this context can be in the linked issue above, so feel free to reference it rather than repeating everything here.
-->

**Summary of the issue**

The local install script could silently reuse stale build artifacts or continue after a failed build. When `compile-cli`/`compile-standalone` failed (often because Go protobuf tools weren’t on PATH), it would still copy an old `dist-standalone/cline-core.js`, leaving the CLI reporting an outdated core version (3.39.x). It also sometimes hit permission errors when copying `node_modules/.bin` over an existing install, leaving runtime deps partially updated.

**What changed**

- Clean rebuilds: remove `cli/bin` and `dist-standalone` before building.
- Fail fast: abort the install if `compile-cli` or `compile-standalone` fails.
- Ensure Go tools are discoverable by adding `$(go env GOPATH)/bin` to PATH during the build.
- Avoid runtime dependency copy conflicts by clearing the install `node_modules` before copying.

**Result**

A fresh local install now rebuilds from scratch and reliably installs the current core version (3.51.0+).


### Test Procedure

<!-- 
Please walk us through your testing approach and thought process. This helps reviewers understand that you've thoroughly considered the impact of your changes:

- How did you test this change?
- What could potentially break and how did you verify it doesn't?
- What existing functionality might be affected and how did you check it still works?
- Why are you confident this is ready for merge?

We're not looking for exhaustive documentation - just evidence that you've thought through the implications of your changes and tested accordingly.
-->

- Ran `bash scripts/install-local.sh`
- Verified `cline version` reports the expected core version

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [x] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

N/A

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes local CLI install script to ensure clean rebuilds and handle build failures by removing old artifacts and ensuring Go tools are available.
> 
>   - **Behavior**:
>     - Removes `cli/bin` and `dist-standalone` before building to ensure clean rebuilds.
>     - Aborts installation if `compile-cli` or `compile-standalone` fails.
>     - Adds `$(go env GOPATH)/bin` to PATH to ensure Go tools are discoverable.
>     - Clears `node_modules` in install directory before copying to avoid conflicts.
>   - **Misc**:
>     - Copies `package.json` to `dist-standalone/extension` to ensure presence for startup.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for c1c4297013f22c70d052094fb0d565abf7b6dc90. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->