### PR TITLE
Remove the `do_nothing` feature flag

### DIFF
--- a/src/services/feature-flags/FeatureFlagsService.ts
+++ b/src/services/feature-flags/FeatureFlagsService.ts
@@ -87,10 +87,6 @@ export class FeatureFlagsService {
 		return this.cache.get(flagName) === true
 	}
 
-	public getDoNothingFlag(): boolean {
-		return this.getBooleanFlagEnabled(FeatureFlag.DO_NOTHING)
-	}
-
 	public getHooksEnabled(): boolean {
 		return this.getBooleanFlagEnabled(FeatureFlag.HOOKS)
 	}

--- a/src/shared/services/feature-flags/feature-flags.ts
+++ b/src/shared/services/feature-flags/feature-flags.ts
@@ -4,7 +4,6 @@ export enum FeatureFlag {
 	CUSTOM_INSTRUCTIONS = "custom-instructions",
 	DICTATION = "dictation",
 	FOCUS_CHAIN_CHECKLIST = "focus_chain_checklist",
-	DO_NOTHING = "do_nothing",
 	HOOKS = "hooks",
 	WEBTOOLS = "webtools",
 	// Feature flag for showing the new onboarding flow or old welcome view.
@@ -12,7 +11,6 @@ export enum FeatureFlag {
 }
 
 export const FeatureFlagDefaultValue: Partial<Record<FeatureFlag, FeatureFlagPayload>> = {
-	[FeatureFlag.DO_NOTHING]: false,
 	[FeatureFlag.HOOKS]: false,
 	[FeatureFlag.WEBTOOLS]: false,
 	[FeatureFlag.ONBOARDING_MODELS]: process.env.E2E_TEST === "true" ? { models: {} } : undefined,


### PR DESCRIPTION
### Description

The `do_nothing` feature flag is not used, but we're still charged for the calls to it. This PR removes it.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [x] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove the `do_nothing` feature flag from the codebase, including its method and enum entry.
> 
>   - **Feature Flag Removal**:
>     - Remove `do_nothing` feature flag from `FeatureFlag` enum and `FeatureFlagDefaultValue` in `feature-flags.ts`.
>     - Remove `getDoNothingFlag()` method from `FeatureFlagsService` in `FeatureFlagsService.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 68548e4b7ca41f100092ce96e3b23eb0ba3b4ee9. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->