### PR TITLE
Fix native GPT-5.x prompt routing for GPT-5.1/5.2 Codex models

### DIFF
--- a/src/core/prompts/system-prompt/variants/native-gpt-5-1/config.ts
+++ b/src/core/prompts/system-prompt/variants/native-gpt-5-1/config.ts
@@ -26,13 +26,13 @@ export const config = createVariant(ModelFamily.NATIVE_GPT_5_1)
 		const providerInfo = context.providerInfo
 		const modelId = providerInfo.model.id
 
-		// Codex variants will use GPT-5 variant instead for less strict rules.
-		// Chat variants do not support native tool use.
-		if (modelId.includes("codex") && !modelId.includes("chat")) {
+		// Chat variants do not support native tool use
+		if (modelId.includes("chat")) {
 			return false
 		}
 
-		// gpt-5.1 and gpt-5.2 chat models do not support native tool use
+		// GPT-5.1 and GPT-5.2 models (including codex variants) use extended reasoning
+		// and require reasoning blocks before function calls
 		return (isGPT51Model(modelId) || isGPT52Model(modelId)) && isNextGenModelProvider(providerInfo)
 	})
 	.template(GPT_5_1_TEMPLATE_OVERRIDES.BASE)

--- a/src/core/prompts/system-prompt/variants/native-gpt-5/config.ts
+++ b/src/core/prompts/system-prompt/variants/native-gpt-5/config.ts
@@ -26,8 +26,10 @@ export const config = createVariant(ModelFamily.NATIVE_GPT_5)
 		const modelId = providerInfo.model.id
 		return (
 			isGPT5ModelFamily(modelId) &&
-			// Exclude gpt-5.1 and gpt-5.2 models except for codex variants
-			(modelId.includes("codex") || (!isGPT51Model(modelId) && !isGPT52Model(modelId))) &&
+			// Exclude gpt-5.1 and gpt-5.2 models (including codex variants)
+			// GPT-5.1 and GPT-5.2 use extended reasoning and need the native-gpt-5-1 variant
+			!isGPT51Model(modelId) &&
+			!isGPT52Model(modelId) &&
 			// gpt-5-chat models do not support native tool use
 			!modelId.includes("chat") &&
 			isNextGenModelProvider(providerInfo)


### PR DESCRIPTION
### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** 
- #8649
- #8619
- #8665

### Description

This is a defensive routing fix prompted by sporadic OpenAI native tool-calling failures observed with GPT-5.1/5.2 (Codex) models.

In practice, we were seeing intermittent Responses API errors along the lines of:

- "'function_call' was provided without its required 'reasoning' item".

These are hard to reproduce on demand, but when they happen they break the tool loop. OpenAI documentation for reasoning models (e.g. GPT-5 family) emphasizes that reasoning items associated with tool calls must be preserved/passed back alongside tool outputs, and community reports show the same error when reasoning/tool-call sequencing gets out of sync.

#### Why this change

Cline's `PromptRegistry.getModelFamily()` picks the **first** matching prompt variant, in insertion order. Previously, `native-gpt-5` included an exception that allowed any model ID containing "codex" to match `NATIVE_GPT_5`, even if it was actually GPT-5.1 or GPT-5.2.

That meant models like `gpt-5.2-codex` could incorrectly receive the `NATIVE_GPT_5` prompt ("less strict rules") instead of the stricter `NATIVE_GPT_5_1` prompt intended for GPT-5.1/5.2.

#### What this change does

- Ensures **all GPT-5.1 and GPT-5.2 models (including codex variants)** route to `NATIVE_GPT_5_1`.
- Keeps GPT-5 (and `gpt-5-codex`) on `NATIVE_GPT_5` (the less strict prompt).

This aligns routing with the intent expressed in the variant descriptions and avoids precedence issues where `NATIVE_GPT_5` would capture GPT-5.1/5.2 Codex models first.

This PR is intentionally small and can be kept as a ready-to-merge fix if others report similar GPT-5.1/5.2 Codex tool-calling failures.

### Test Procedure

- Verified the matcher logic by inspection against `PromptRegistry.getModelFamily()` precedence rules.
- Ensured there is no overlap: `NATIVE_GPT_5` now excludes GPT-5.1/5.2 entirely, so those models reliably fall through to `NATIVE_GPT_5_1`.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A (no UI changes)

### Additional Notes

If we decide this routing is too broad, an alternative is to special-case only `gpt-5.2-codex` (and possibly `gpt-5.1-codex`). However, given the registry's first-match behavior, routing *by version* (5 vs 5.1/5.2) is the most robust and easiest-to-reason-about approach.
