### PR TITLE
fix: move Sign Up with Cline button to new line in WhatsNewModal

### DIFF
--- a/webview-ui/src/components/common/WhatsNewModal.tsx
+++ b/webview-ui/src/components/common/WhatsNewModal.tsx
@@ -88,9 +88,11 @@ export const WhatsNewModal: React.FC<WhatsNewModalProps> = ({ open, onClose, ver
 					<ul className="text-sm pl-3 list-disc" style={{ color: "var(--vscode-descriptionForeground)" }}>
 						<li className="mb-2">
 							<strong>OpenAI:</strong> Added gpt-5.2-codex model support
-							<AuthButton>
-								<ModelButton label="Try now!" modelId="openai/gpt-5.2-codex" />
-							</AuthButton>
+							<div>
+								<AuthButton>
+									<ModelButton label="Try now!" modelId="openai/gpt-5.2-codex" />
+								</AuthButton>
+							</div>
 						</li>
 						<li className="mb-2">
 							<strong>Skills:</strong> Extend Cline with instruction sets for specialized tasks.{" "}


### PR DESCRIPTION
## Summary

- Fix the "Sign Up with Cline" button appearing inline with text in the WhatsNewModal
- Wrap the AuthButton in a div to force it onto its own line

## Test Procedure

Open the WhatsNewModal and verify the button appears on its own line below the text.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Pre-flight Checklist

- [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
- [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
- [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Wrap `AuthButton` in a `div` in `WhatsNewModal` to move "Sign Up with Cline" button to a new line.
> 
>   - **UI Fix**:
>     - In `WhatsNewModal`, wrap `AuthButton` in a `div` to ensure the "Sign Up with Cline" button appears on a new line, separate from the text.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 5879112abebb3bfbe07b9e6ea21028cdfdd206df. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->