### PR TITLE
fix: set pager environment variables in VSCode terminals to prevent blocking

### DIFF
--- a/.changeset/git-pager-env-fix.md
+++ b/.changeset/git-pager-env-fix.md
@@ -1,0 +1,7 @@
+---
+"claude-dev": patch
+---
+
+Set pager environment variables (PAGER, GIT_PAGER, MANPAGER) to "cat" when creating VSCode terminals to prevent commands like `git diff` and `git log` from hanging in interactive pagers.
+
+Fixes #8582

--- a/src/hosts/vscode/terminal/VscodeTerminalRegistry.ts
+++ b/src/hosts/vscode/terminal/VscodeTerminalRegistry.ts
@@ -27,6 +27,11 @@ export class TerminalRegistry {
 			iconPath: new vscode.ThemeIcon("cline-icon"),
 			env: {
 				CLINE_ACTIVE: "true",
+				// Prevent interactive pagers from blocking terminal commands
+				PAGER: "cat",
+				GIT_PAGER: "cat",
+				SYSTEMD_PAGER: "",
+				MANPAGER: "cat",
 			},
 		}
 


### PR DESCRIPTION
## Summary
- Sets pager environment variables (PAGER, GIT_PAGER, MANPAGER) to "cat" when creating VSCode terminals
- Prevents commands like `git diff`, `git log`, and `git show` from hanging in interactive pagers

## Related Issue
Fixes #8582

## What Changed
Modified `VscodeTerminalRegistry.createTerminal()` to set the same environment variables that are used in Background Exec mode:
- `PAGER: "cat"` - Prevents less from being used
- `GIT_PAGER: "cat"` - Prevents git from using less
- `SYSTEMD_PAGER: ""` - Disables systemd pager
- `MANPAGER: "cat"` - Disables man pager

This brings integrated terminal mode in line with Background Exec mode, which already sets these variables in `StandaloneTerminalProcess`.

## Test Plan
1. Use Cline with integrated terminal mode
2. Run commands that previously would hang: `git diff`, `git log`, `git show`
3. Verify that commands complete without blocking
4. Verify that output is displayed directly in the terminal (no pager interaction)

## Checklist
- [x] Code follows project style guidelines (ran linting/formatting)
- [x] Changeset added for this patch change
- [x] Tested locally
- [ ] Tests added/updated (N/A for env var change)
- [ ] Documentation updated (N/A)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Sets pager environment variables in `VscodeTerminalRegistry.createTerminal()` to prevent VSCode terminal commands from hanging.
> 
>   - **Behavior**:
>     - Sets `PAGER`, `GIT_PAGER`, and `MANPAGER` to `"cat"` in `VscodeTerminalRegistry.createTerminal()` to prevent commands from hanging in interactive pagers.
>     - Sets `SYSTEMD_PAGER` to an empty string to disable systemd pager.
>   - **Files**:
>     - Modifies `VscodeTerminalRegistry.ts` to implement the environment variable changes.
>   - **Misc**:
>     - Adds a changeset file `git-pager-env-fix.md` to document the patch change.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for e81d4f12c0ec33049cdac0b208669597cca62520. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->