### PR TITLE
fix: normalize Windows path separators in file search to prevent duplicates

### DIFF
--- a/src/services/search/file-search.ts
+++ b/src/services/search/file-search.ts
@@ -52,7 +52,7 @@ export async function executeRipgrepForFiles(
 
 			// Add file result to array
 			fileResults.push({
-				path: relativePath,
+				path: relativePath.replace(/\\/g, "/"), // Normalize Windows backslashes to forward slashes
 				type: "file",
 				label: path.basename(relativePath),
 			})
@@ -82,7 +82,7 @@ export async function executeRipgrepForFiles(
 
 			// Transform directory paths from Set into structured results
 			const dirResults = Array.from(dirSet, (dirPath): { path: string; type: "folder"; label?: string } => ({
-				path: dirPath,
+				path: dirPath.replace(/\\/g, "/"), // Normalize Windows backslashes to forward slashes
 				type: "folder",
 				label: path.basename(dirPath),
 			}))


### PR DESCRIPTION
## Summary
- Fixes duplicate file paths appearing in @context search on Windows
- Normalizes all paths from ripgrep to use forward slashes for consistent comparison

## Details
On Windows, ripgrep returns file paths with backslashes (e.g., `\routers\searched_sku.py`) while active files use forward slashes (e.g., `/routers/searched_sku.py`). This caused the same file to appear twice in @context search results.

This fix adds `.replace(/\\/g, "/")` to normalize paths from ripgrep output, ensuring consistent path separators for comparison and deduplication.

## Testing
- Manual testing on Windows would verify files appear only once
- Existing E2E tests continue to pass

Fixes #5747
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Normalizes Windows path separators in `executeRipgrepForFiles` in `file-search.ts` to prevent duplicate file paths in search results.
> 
>   - **Behavior**:
>     - Normalizes Windows path separators to forward slashes in `executeRipgrepForFiles` in `file-search.ts` to prevent duplicate file paths in search results.
>     - Applies normalization to both file and directory paths.
>   - **Testing**:
>     - Manual testing on Windows to verify deduplication.
>     - Existing E2E tests continue to pass.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for b135fcb45b9293e6b8d6db38b15faa80bf33d332. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->