### PR TITLE
fix: telemetry banner settings link opens General Settings tab

### DIFF
--- a/webview-ui/src/components/common/TelemetryBanner.tsx
+++ b/webview-ui/src/components/common/TelemetryBanner.tsx
@@ -16,7 +16,7 @@ export const TelemetryBanner: React.FC = () => {
 
 	const handleOpenSettings = useCallback(() => {
 		handleClose()
-		navigateToSettings()
+		navigateToSettings("general") // Open General Settings tab where telemetry setting is
 	}, [handleClose, navigateToSettings])
 
 	return (


### PR DESCRIPTION
## Summary
- Fixes telemetry banner settings button to open the General Settings tab
- Previously opened the default API Configuration tab instead

## Details
The settings button in the telemetry popup was opening the default API Configuration tab instead of the General Settings tab where the telemetry setting is located.

This fix passes `"general"` as the `targetSection` parameter to `navigateToSettings()` to open the correct tab.

## Testing
Manual verification:
1. Ensure telemetry is disabled (to see the banner)
2. Click the "settings" link in the telemetry banner
3. Verify the Settings view opens with the "General" tab selected
4. Verify the telemetry setting is visible on that tab

Fixes #4705
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes telemetry banner settings link to open the correct tab and normalizes file paths in `file-search.ts`.
> 
>   - **Behavior**:
>     - Fixes telemetry banner settings link to open "General" tab by passing `"general"` to `navigateToSettings()` in `TelemetryBanner.tsx`.
>     - Previously opened "API Configuration" tab.
>   - **File Path Normalization**:
>     - Normalizes Windows backslashes to forward slashes in `executeRipgrepForFiles()` in `file-search.ts`.
>   - **History Item Deletion**:
>     - Updates `handleDeleteHistoryItem()` and `handleDeleteSelectedHistoryItems()` in `HistoryView.tsx` to remove deleted items from `selectedItems`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for e68553031f47286097d541dc2ac7520d3e31d9c0. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->