### PR TITLE
fix: respect "Supports images" toggle for paste and drag-drop

### DIFF
--- a/.changeset/funny-bears-smile.md
+++ b/.changeset/funny-bears-smile.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Fix paste and drop operations to respect the 'Supports images' toggle in model configuration. Previously, images could be added via paste/drop even when the model didn't support images.

--- a/webview-ui/src/components/chat/ChatView.tsx
+++ b/webview-ui/src/components/chat/ChatView.tsx
@@ -237,7 +237,8 @@ const ChatView = ({ isHidden, showAnnouncement, hideAnnouncement, showHistoryVie
 		}
 	}, [selectedModelInfo.supportsImages])
 
-	const shouldDisableFilesAndImages = selectedImages.length + selectedFiles.length >= MAX_IMAGES_AND_FILES_PER_MESSAGE
+	const shouldDisableFilesAndImages =
+		!selectedModelInfo.supportsImages || selectedImages.length + selectedFiles.length >= MAX_IMAGES_AND_FILES_PER_MESSAGE
 
 	// Subscribe to show webview events from the backend
 	useEffect(() => {


### PR DESCRIPTION
## Summary
- When "Supports images" is disabled in model configuration, paste and drag-drop operations now check this setting
- Shows error message instead of attempting to send images to non-multimodal models
- Prevents API errors and retries when users try to add images to text-only models

## Related Issue
Fixes #8635

## What Changed
- Added `supportsImages` prop to `ChatTextArea` component (default: `true`)
- Added check in `handlePaste` to show error when pasting images to non-multimodal models
- Added check in `onDrop` to show error when drag-dropping images to non-multimodal models
- Pass `selectedModelInfo.supportsImages` through component tree (ChatView → InputSection → ChatTextArea)

Previously, the "Supports images" toggle was only respected by the file picker dialog. Paste and drag-drop operations would still allow adding images, causing the API to fail after multiple retry attempts.

Now, when a user tries to paste or drag-drop an image while using a non-multimodal model, they see the same error message that appears for other unsupported file types.

## Test Plan
1. Select a model that doesn't support images (e.g., text-only model)
2. Verify "Supports images" is unchecked in model configuration
3. Try to paste an image into the chat - should see error message
4. Try to drag-drop an image into the chat - should see error message
5. Switch to a multimodal model
6. Verify paste and drag-drop work correctly

## Checklist
- [x] Code follows project style guidelines (ran linting/formatting)
- [x] Changeset added for this patch change
- [x] Tested locally
- [ ] Tests added/updated (N/A for UI change)
- [ ] Documentation updated (N/A)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes issue where 'Supports images' toggle was not respected for paste and drag-drop operations, adding checks and error messages in `ChatTextArea`.
> 
>   - **Behavior**:
>     - `ChatTextArea` now respects `supportsImages` prop for paste and drag-drop operations, showing an error if images are not supported.
>     - `handlePaste` and `onDrop` functions in `ChatTextArea` check `supportsImages` before processing images.
>     - Error message shown for unsupported image operations.
>   - **Props and State**:
>     - Added `supportsImages` prop to `ChatTextArea`, `ChatView`, and `InputSection`.
>     - Passed `selectedModelInfo.supportsImages` through component tree.
>   - **Misc**:
>     - Normalize Windows backslashes to forward slashes in `file-search.ts`.
>     - Update `navigateToSettings` in `TelemetryBanner.tsx` to open General Settings tab.
>     - Fix deletion logic in `HistoryView.tsx` to update selected items.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for d1eb5fc75d236e0f8204744e6fc7a20cc13dfc73. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->