### PR TITLE
fix: update selected items state when deleting history via side icon

### DIFF
--- a/.changeset/history-button-text-fix.md
+++ b/.changeset/history-button-text-fix.md
@@ -1,0 +1,7 @@
+---
+"claude-dev": patch
+---
+
+Fix button text not updating after deleting history item using side delete icon. When deleting a selected history item via the side icon, the selected items state is now properly cleared, causing the button text to correctly revert to "Delete all history" instead of remaining "Delete selected history."
+
+Fixes #6033

--- a/webview-ui/src/components/history/HistoryView.tsx
+++ b/webview-ui/src/components/history/HistoryView.tsx
@@ -168,6 +168,8 @@ const HistoryView = ({ onDone }: HistoryViewProps) => {
 			TaskServiceClient.deleteTasksWithIds(StringArrayRequest.create({ value: [id] }))
 				.then(() => fetchTotalTasksSize())
 				.catch((error) => console.error("Error deleting task:", error))
+			// Remove from selected items to update button text
+			setSelectedItems((prev) => prev.filter((itemId) => itemId !== id))
 		},
 		[fetchTotalTasksSize],
 	)


### PR DESCRIPTION
## Summary
- Fixed button text not updating after deleting history item using side delete icon
- When deleting a selected history item via the side icon, the selected items state now properly removes the deleted item
- Button text correctly reverts to "Delete all history" instead of remaining "Delete selected history"

## Related Issue
Fixes #6033

## What Changed
Modified `handleDeleteHistoryItem` in `HistoryView.tsx` to also remove the deleted item from the `selectedItems` state.

Previously, when you deleted an item using the side trash icon, the function deleted the task but didn't update the `selectedItems` state. The deleted item's ID remained in the `selectedItems` array, so the button continued showing "Delete selected history" even though the selected item no longer existed.

Now, `handleDeleteHistoryItem` calls:
```tsx
setSelectedItems((prev) => prev.filter((itemId) => itemId !== id))
```

This is consistent with how `handleDeleteSelectedHistoryItems` already clears `selectedItems` after deletion.

## Test Plan
1. Navigate to History section
2. Select one or more history items (verify button text changes to "Delete selected history")
3. Delete one of the selected history items using the delete icon beside the entry
4. Verify button text updates back to "Delete all history" when no items are selected
5. Verify button shows correct count when some items remain selected

## Checklist
- [x] Code follows project style guidelines (ran linting/formatting)
- [x] Changeset added for this patch change
- [x] Tested locally
- [ ] Tests added/updated (N/A for simple state fix)
- [ ] Documentation updated (N/A)

🤖 Generated with [Claude Code](https://claude.com/claude-code)