### PR TITLE
fix: preserve full model name for VSCode LM BYOK providers

### DIFF
--- a/.changeset/proud-pandas-float.md
+++ b/.changeset/proud-pandas-float.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Fix model name trimming in VSCode LM provider when model identifiers contain multiple slashes (e.g., OpenRouter BYOK models like `github/anthropic/claude-3.5-sonnet`).

--- a/webview-ui/src/components/settings/providers/VSCodeLmProvider.tsx
+++ b/webview-ui/src/components/settings/providers/VSCodeLmProvider.tsx
@@ -54,7 +54,9 @@ export const VSCodeLmProvider = ({ currentMode }: VSCodeLmProviderProps) => {
 							if (!value) {
 								return
 							}
-							const [vendor, family] = value.split("/")
+							const parts = value.split("/")
+							const vendor = parts[0]
+							const family = parts.slice(1).join("/")
 
 							handleModeFieldChange(
 								{ plan: "planModeVsCodeLmModelSelector", act: "actModeVsCodeLmModelSelector" },


### PR DESCRIPTION
## Summary
- Fixed VSCode LM API BYOK provider model name trimming issue
- Model names with slashes (e.g., "anthropic/claude-3.5-sonnet") are now fully preserved
- Previously, only the vendor part was captured, truncating models like "anthropic/claude-3.5-sonnet" to just "anthropic"

## Related Issue
Fixes #6293

## What Changed
Modified `VSCodeLmProvider.tsx` to properly parse model names that contain slashes.

**Before:**
```tsx
const [vendor, family] = value.split("/")
```

This only captured the first two parts of the identifier, so "anthropic/claude-3.5-sonnet" became vendor="anthropic", family="claude-3.5-sonnet" → but the split only took first two parts, so family would be "claude-3.5-sonnet" with further splits being lost.

**After:**
```tsx
const parts = value.split("/")
const vendor = parts[0]
const family = parts.slice(1).join("/")
```

This preserves everything after the first slash as the family name.

## Test Plan
1. Add GitHub Copilot BYOK provider
2. Use VSCode LM API mode to select BYOK provider model
3. Select a model with slashes in the name (e.g., from OpenRouter)
4. Verify the full model name is preserved and displayed correctly
5. Verify the model works correctly when selected

## Checklist
- [x] Code follows project style guidelines (ran linting/formatting)
- [x] Changeset added for this patch change
- [x] Tested locally
- [ ] Tests added/updated (N/A for UI parsing fix)
- [ ] Documentation updated (N/A)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes model name parsing in `VSCodeLmProvider.tsx` to preserve full names with slashes, ensuring correct model selection.
> 
>   - **Behavior**:
>     - Fixes model name parsing in `VSCodeLmProvider.tsx` to preserve full names with slashes (e.g., "anthropic/claude-3.5-sonnet").
>     - Previously, only the vendor part was captured, truncating the model name.
>   - **Code Changes**:
>     - Replaces `const [vendor, family] = value.split("/")` with `const parts = value.split("/"); const vendor = parts[0]; const family = parts.slice(1).join("/")` in `VSCodeLmProvider.tsx`.
>   - **Testing**:
>     - Verified full model name preservation and correct functionality when selecting models with slashes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for ae76e81d0ba423336a420a894ba2e80f0712558e. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->