### PR TITLE
fix: exclude generate_explanation tool from system prompt for non-VS Code platforms

### DIFF
--- a/.changeset/exclude-generate-explanation-non-vscode.md
+++ b/.changeset/exclude-generate-explanation-non-vscode.md
@@ -1,0 +1,7 @@
+---
+"cline/cline": patch
+---
+
+Exclude generate_explanation tool from system prompt for non-VS Code platforms. The tool uses VS Code's Comments API which doesn't work on JetBrains or CLI.
+
+Fixes #7807

--- a/src/core/prompts/system-prompt/__tests__/__snapshots__/anthropic_claude_sonnet_4-basic.snap
+++ b/src/core/prompts/system-prompt/__tests__/__snapshots__/anthropic_claude_sonnet_4-basic.snap
@@ -253,19 +253,6 @@ Usage:
 <load_mcp_documentation>
 </load_mcp_documentation>
 
-## generate_explanation
-Description: Opens a multi-file diff view and generates AI-powered inline comments explaining the changes between two git references. Use this tool to help users understand code changes from git commits, pull requests, branches, or any git refs. The tool uses git to retrieve file contents and displays a side-by-side diff view with explanatory comments.
-Parameters:
-- title: (required) A descriptive title for the diff view (e.g., 'Changes in commit abc123', 'PR #42: Add authentication', 'Changes between main and feature-branch')
-- from_ref: (required) The git reference for the 'before' state. Can be a commit hash, branch name, tag, or relative reference like HEAD~1, HEAD^, origin/main, etc.
-- to_ref: (optional) The git reference for the 'after' state. Can be a commit hash, branch name, tag, or relative reference. If not provided, compares to the current working directory (including uncommitted changes).
-Usage:
-<generate_explanation>
-<title>Changes in last commit</title>
-<from_ref>HEAD~1</from_ref>
-<to_ref>HEAD</to_ref>
-</generate_explanation>
-
 # Tool Use Examples
 
 ## Example 1: Requesting to execute a command

--- a/src/core/prompts/system-prompt/__tests__/__snapshots__/anthropic_claude_sonnet_4-no-browser.snap
+++ b/src/core/prompts/system-prompt/__tests__/__snapshots__/anthropic_claude_sonnet_4-no-browser.snap
@@ -219,19 +219,6 @@ Usage:
 <load_mcp_documentation>
 </load_mcp_documentation>
 
-## generate_explanation
-Description: Opens a multi-file diff view and generates AI-powered inline comments explaining the changes between two git references. Use this tool to help users understand code changes from git commits, pull requests, branches, or any git refs. The tool uses git to retrieve file contents and displays a side-by-side diff view with explanatory comments.
-Parameters:
-- title: (required) A descriptive title for the diff view (e.g., 'Changes in commit abc123', 'PR #42: Add authentication', 'Changes between main and feature-branch')
-- from_ref: (required) The git reference for the 'before' state. Can be a commit hash, branch name, tag, or relative reference like HEAD~1, HEAD^, origin/main, etc.
-- to_ref: (optional) The git reference for the 'after' state. Can be a commit hash, branch name, tag, or relative reference. If not provided, compares to the current working directory (including uncommitted changes).
-Usage:
-<generate_explanation>
-<title>Changes in last commit</title>
-<from_ref>HEAD~1</from_ref>
-<to_ref>HEAD</to_ref>
-</generate_explanation>
-
 # Tool Use Examples
 
 ## Example 1: Requesting to execute a command

--- a/src/core/prompts/system-prompt/__tests__/__snapshots__/anthropic_claude_sonnet_4-no-focus-chain.snap
+++ b/src/core/prompts/system-prompt/__tests__/__snapshots__/anthropic_claude_sonnet_4-no-focus-chain.snap
@@ -227,19 +227,6 @@ Usage:
 <load_mcp_documentation>
 </load_mcp_documentation>
 
-## generate_explanation
-Description: Opens a multi-file diff view and generates AI-powered inline comments explaining the changes between two git references. Use this tool to help users understand code changes from git commits, pull requests, branches, or any git refs. The tool uses git to retrieve file contents and displays a side-by-side diff view with explanatory comments.
-Parameters:
-- title: (required) A descriptive title for the diff view (e.g., 'Changes in commit abc123', 'PR #42: Add authentication', 'Changes between main and feature-branch')
-- from_ref: (required) The git reference for the 'before' state. Can be a commit hash, branch name, tag, or relative reference like HEAD~1, HEAD^, origin/main, etc.
-- to_ref: (optional) The git reference for the 'after' state. Can be a commit hash, branch name, tag, or relative reference. If not provided, compares to the current working directory (including uncommitted changes).
-Usage:
-<generate_explanation>
-<title>Changes in last commit</title>
-<from_ref>HEAD~1</from_ref>
-<to_ref>HEAD</to_ref>
-</generate_explanation>
-
 # Tool Use Examples
 
 ## Example 1: Requesting to execute a command

--- a/src/core/prompts/system-prompt/__tests__/__snapshots__/anthropic_claude_sonnet_4-no-mcp.snap
+++ b/src/core/prompts/system-prompt/__tests__/__snapshots__/anthropic_claude_sonnet_4-no-mcp.snap
@@ -253,19 +253,6 @@ Usage:
 <load_mcp_documentation>
 </load_mcp_documentation>
 
-## generate_explanation
-Description: Opens a multi-file diff view and generates AI-powered inline comments explaining the changes between two git references. Use this tool to help users understand code changes from git commits, pull requests, branches, or any git refs. The tool uses git to retrieve file contents and displays a side-by-side diff view with explanatory comments.
-Parameters:
-- title: (required) A descriptive title for the diff view (e.g., 'Changes in commit abc123', 'PR #42: Add authentication', 'Changes between main and feature-branch')
-- from_ref: (required) The git reference for the 'before' state. Can be a commit hash, branch name, tag, or relative reference like HEAD~1, HEAD^, origin/main, etc.
-- to_ref: (optional) The git reference for the 'after' state. Can be a commit hash, branch name, tag, or relative reference. If not provided, compares to the current working directory (including uncommitted changes).
-Usage:
-<generate_explanation>
-<title>Changes in last commit</title>
-<from_ref>HEAD~1</from_ref>
-<to_ref>HEAD</to_ref>
-</generate_explanation>
-
 # Tool Use Examples
 
 ## Example 1: Requesting to execute a command

--- a/src/core/prompts/system-prompt/__tests__/__snapshots__/cline_native_next_gen.tools.snap
+++ b/src/core/prompts/system-prompt/__tests__/__snapshots__/cline_native_next_gen.tools.snap
@@ -439,36 +439,6 @@
   {
     "type": "function",
     "function": {
-      "name": "generate_explanation",
-      "description": "Opens a multi-file diff view and generates AI-powered inline comments explaining the changes between two git references. Use this tool to help users understand code changes from git commits, pull requests, branches, or any git refs. The tool uses git to retrieve file contents and displays a side-by-side diff view with explanatory comments.",
-      "strict": false,
-      "parameters": {
-        "type": "object",
-        "properties": {
-          "title": {
-            "type": "string",
-            "description": "A descriptive title for the diff view (e.g., 'Changes in commit abc123', 'PR #42: Add authentication', 'Changes between main and feature-branch')"
-          },
-          "from_ref": {
-            "type": "string",
-            "description": "The git reference for the 'before' state. Can be a commit hash, branch name, tag, or relative reference like HEAD~1, HEAD^, origin/main, etc."
-          },
-          "to_ref": {
-            "type": "string",
-            "description": "The git reference for the 'after' state. Can be a commit hash, branch name, tag, or relative reference. If not provided, compares to the current working directory (including uncommitted changes)."
-          }
-        },
-        "required": [
-          "title",
-          "from_ref"
-        ],
-        "additionalProperties": false
-      }
-    }
-  },
-  {
-    "type": "function",
-    "function": {
       "name": "12345670mcp0test_tool",
       "description": "test-server: A test tool",
       "strict": false,

--- a/src/core/prompts/system-prompt/__tests__/__snapshots__/openai_gpt_3-basic.snap
+++ b/src/core/prompts/system-prompt/__tests__/__snapshots__/openai_gpt_3-basic.snap
@@ -253,19 +253,6 @@ Usage:
 <load_mcp_documentation>
 </load_mcp_documentation>
 
-## generate_explanation
-Description: Opens a multi-file diff view and generates AI-powered inline comments explaining the changes between two git references. Use this tool to help users understand code changes from git commits, pull requests, branches, or any git refs. The tool uses git to retrieve file contents and displays a side-by-side diff view with explanatory comments.
-Parameters:
-- title: (required) A descriptive title for the diff view (e.g., 'Changes in commit abc123', 'PR #42: Add authentication', 'Changes between main and feature-branch')
-- from_ref: (required) The git reference for the 'before' state. Can be a commit hash, branch name, tag, or relative reference like HEAD~1, HEAD^, origin/main, etc.
-- to_ref: (optional) The git reference for the 'after' state. Can be a commit hash, branch name, tag, or relative reference. If not provided, compares to the current working directory (including uncommitted changes).
-Usage:
-<generate_explanation>
-<title>Changes in last commit</title>
-<from_ref>HEAD~1</from_ref>
-<to_ref>HEAD</to_ref>
-</generate_explanation>
-
 # Tool Use Examples
 
 ## Example 1: Requesting to execute a command

--- a/src/core/prompts/system-prompt/__tests__/__snapshots__/openai_gpt_3-no-browser.snap
+++ b/src/core/prompts/system-prompt/__tests__/__snapshots__/openai_gpt_3-no-browser.snap
@@ -219,19 +219,6 @@ Usage:
 <load_mcp_documentation>
 </load_mcp_documentation>
 
-## generate_explanation
-Description: Opens a multi-file diff view and generates AI-powered inline comments explaining the changes between two git references. Use this tool to help users understand code changes from git commits, pull requests, branches, or any git refs. The tool uses git to retrieve file contents and displays a side-by-side diff view with explanatory comments.
-Parameters:
-- title: (required) A descriptive title for the diff view (e.g., 'Changes in commit abc123', 'PR #42: Add authentication', 'Changes between main and feature-branch')
-- from_ref: (required) The git reference for the 'before' state. Can be a commit hash, branch name, tag, or relative reference like HEAD~1, HEAD^, origin/main, etc.
-- to_ref: (optional) The git reference for the 'after' state. Can be a commit hash, branch name, tag, or relative reference. If not provided, compares to the current working directory (including uncommitted changes).
-Usage:
-<generate_explanation>
-<title>Changes in last commit</title>
-<from_ref>HEAD~1</from_ref>
-<to_ref>HEAD</to_ref>
-</generate_explanation>
-
 # Tool Use Examples
 
 ## Example 1: Requesting to execute a command

--- a/src/core/prompts/system-prompt/__tests__/__snapshots__/openai_gpt_3-no-focus-chain.snap
+++ b/src/core/prompts/system-prompt/__tests__/__snapshots__/openai_gpt_3-no-focus-chain.snap
@@ -227,19 +227,6 @@ Usage:
 <load_mcp_documentation>
 </load_mcp_documentation>
 
-## generate_explanation
-Description: Opens a multi-file diff view and generates AI-powered inline comments explaining the changes between two git references. Use this tool to help users understand code changes from git commits, pull requests, branches, or any git refs. The tool uses git to retrieve file contents and displays a side-by-side diff view with explanatory comments.
-Parameters:
-- title: (required) A descriptive title for the diff view (e.g., 'Changes in commit abc123', 'PR #42: Add authentication', 'Changes between main and feature-branch')
-- from_ref: (required) The git reference for the 'before' state. Can be a commit hash, branch name, tag, or relative reference like HEAD~1, HEAD^, origin/main, etc.
-- to_ref: (optional) The git reference for the 'after' state. Can be a commit hash, branch name, tag, or relative reference. If not provided, compares to the current working directory (including uncommitted changes).
-Usage:
-<generate_explanation>
-<title>Changes in last commit</title>
-<from_ref>HEAD~1</from_ref>
-<to_ref>HEAD</to_ref>
-</generate_explanation>
-
 # Tool Use Examples
 
 ## Example 1: Requesting to execute a command

--- a/src/core/prompts/system-prompt/__tests__/__snapshots__/openai_gpt_3-no-mcp.snap
+++ b/src/core/prompts/system-prompt/__tests__/__snapshots__/openai_gpt_3-no-mcp.snap
@@ -253,19 +253,6 @@ Usage:
 <load_mcp_documentation>
 </load_mcp_documentation>
 
-## generate_explanation
-Description: Opens a multi-file diff view and generates AI-powered inline comments explaining the changes between two git references. Use this tool to help users understand code changes from git commits, pull requests, branches, or any git refs. The tool uses git to retrieve file contents and displays a side-by-side diff view with explanatory comments.
-Parameters:
-- title: (required) A descriptive title for the diff view (e.g., 'Changes in commit abc123', 'PR #42: Add authentication', 'Changes between main and feature-branch')
-- from_ref: (required) The git reference for the 'before' state. Can be a commit hash, branch name, tag, or relative reference like HEAD~1, HEAD^, origin/main, etc.
-- to_ref: (optional) The git reference for the 'after' state. Can be a commit hash, branch name, tag, or relative reference. If not provided, compares to the current working directory (including uncommitted changes).
-Usage:
-<generate_explanation>
-<title>Changes in last commit</title>
-<from_ref>HEAD~1</from_ref>
-<to_ref>HEAD</to_ref>
-</generate_explanation>
-
 # Tool Use Examples
 
 ## Example 1: Requesting to execute a command

--- a/src/core/prompts/system-prompt/__tests__/__snapshots__/openai_gpt_5-basic.snap
+++ b/src/core/prompts/system-prompt/__tests__/__snapshots__/openai_gpt_5-basic.snap
@@ -253,19 +253,6 @@ Usage:
 <load_mcp_documentation>
 </load_mcp_documentation>
 
-## generate_explanation
-Description: Opens a multi-file diff view and generates AI-powered inline comments explaining the changes between two git references. Use this tool to help users understand code changes from git commits, pull requests, branches, or any git refs. The tool uses git to retrieve file contents and displays a side-by-side diff view with explanatory comments.
-Parameters:
-- title: (required) A descriptive title for the diff view (e.g., 'Changes in commit abc123', 'PR #42: Add authentication', 'Changes between main and feature-branch')
-- from_ref: (required) The git reference for the 'before' state. Can be a commit hash, branch name, tag, or relative reference like HEAD~1, HEAD^, origin/main, etc.
-- to_ref: (optional) The git reference for the 'after' state. Can be a commit hash, branch name, tag, or relative reference. If not provided, compares to the current working directory (including uncommitted changes).
-Usage:
-<generate_explanation>
-<title>Changes in last commit</title>
-<from_ref>HEAD~1</from_ref>
-<to_ref>HEAD</to_ref>
-</generate_explanation>
-
 # Tool Use Examples
 
 ## Example 1: Requesting to execute a command

--- a/src/core/prompts/system-prompt/__tests__/__snapshots__/openai_gpt_5-no-browser.snap
+++ b/src/core/prompts/system-prompt/__tests__/__snapshots__/openai_gpt_5-no-browser.snap
@@ -219,19 +219,6 @@ Usage:
 <load_mcp_documentation>
 </load_mcp_documentation>
 
-## generate_explanation
-Description: Opens a multi-file diff view and generates AI-powered inline comments explaining the changes between two git references. Use this tool to help users understand code changes from git commits, pull requests, branches, or any git refs. The tool uses git to retrieve file contents and displays a side-by-side diff view with explanatory comments.
-Parameters:
-- title: (required) A descriptive title for the diff view (e.g., 'Changes in commit abc123', 'PR #42: Add authentication', 'Changes between main and feature-branch')
-- from_ref: (required) The git reference for the 'before' state. Can be a commit hash, branch name, tag, or relative reference like HEAD~1, HEAD^, origin/main, etc.
-- to_ref: (optional) The git reference for the 'after' state. Can be a commit hash, branch name, tag, or relative reference. If not provided, compares to the current working directory (including uncommitted changes).
-Usage:
-<generate_explanation>
-<title>Changes in last commit</title>
-<from_ref>HEAD~1</from_ref>
-<to_ref>HEAD</to_ref>
-</generate_explanation>
-
 # Tool Use Examples
 
 ## Example 1: Requesting to execute a command

--- a/src/core/prompts/system-prompt/__tests__/__snapshots__/openai_gpt_5-no-focus-chain.snap
+++ b/src/core/prompts/system-prompt/__tests__/__snapshots__/openai_gpt_5-no-focus-chain.snap
@@ -227,19 +227,6 @@ Usage:
 <load_mcp_documentation>
 </load_mcp_documentation>
 
-## generate_explanation
-Description: Opens a multi-file diff view and generates AI-powered inline comments explaining the changes between two git references. Use this tool to help users understand code changes from git commits, pull requests, branches, or any git refs. The tool uses git to retrieve file contents and displays a side-by-side diff view with explanatory comments.
-Parameters:
-- title: (required) A descriptive title for the diff view (e.g., 'Changes in commit abc123', 'PR #42: Add authentication', 'Changes between main and feature-branch')
-- from_ref: (required) The git reference for the 'before' state. Can be a commit hash, branch name, tag, or relative reference like HEAD~1, HEAD^, origin/main, etc.
-- to_ref: (optional) The git reference for the 'after' state. Can be a commit hash, branch name, tag, or relative reference. If not provided, compares to the current working directory (including uncommitted changes).
-Usage:
-<generate_explanation>
-<title>Changes in last commit</title>
-<from_ref>HEAD~1</from_ref>
-<to_ref>HEAD</to_ref>
-</generate_explanation>
-
 # Tool Use Examples
 
 ## Example 1: Requesting to execute a command

--- a/src/core/prompts/system-prompt/__tests__/__snapshots__/openai_gpt_5-no-mcp.snap
+++ b/src/core/prompts/system-prompt/__tests__/__snapshots__/openai_gpt_5-no-mcp.snap
@@ -253,19 +253,6 @@ Usage:
 <load_mcp_documentation>
 </load_mcp_documentation>
 
-## generate_explanation
-Description: Opens a multi-file diff view and generates AI-powered inline comments explaining the changes between two git references. Use this tool to help users understand code changes from git commits, pull requests, branches, or any git refs. The tool uses git to retrieve file contents and displays a side-by-side diff view with explanatory comments.
-Parameters:
-- title: (required) A descriptive title for the diff view (e.g., 'Changes in commit abc123', 'PR #42: Add authentication', 'Changes between main and feature-branch')
-- from_ref: (required) The git reference for the 'before' state. Can be a commit hash, branch name, tag, or relative reference like HEAD~1, HEAD^, origin/main, etc.
-- to_ref: (optional) The git reference for the 'after' state. Can be a commit hash, branch name, tag, or relative reference. If not provided, compares to the current working directory (including uncommitted changes).
-Usage:
-<generate_explanation>
-<title>Changes in last commit</title>
-<from_ref>HEAD~1</from_ref>
-<to_ref>HEAD</to_ref>
-</generate_explanation>
-
 # Tool Use Examples
 
 ## Example 1: Requesting to execute a command

--- a/src/core/prompts/system-prompt/__tests__/__snapshots__/openai_gpt_5_1_native.tools.snap
+++ b/src/core/prompts/system-prompt/__tests__/__snapshots__/openai_gpt_5_1_native.tools.snap
@@ -390,36 +390,6 @@
   {
     "type": "function",
     "function": {
-      "name": "generate_explanation",
-      "description": "Opens a multi-file diff view and generates AI-powered inline comments explaining the changes between two git references. Use this tool to help users understand code changes from git commits, pull requests, branches, or any git refs. The tool uses git to retrieve file contents and displays a side-by-side diff view with explanatory comments.",
-      "strict": false,
-      "parameters": {
-        "type": "object",
-        "properties": {
-          "title": {
-            "type": "string",
-            "description": "A descriptive title for the diff view (e.g., 'Changes in commit abc123', 'PR #42: Add authentication', 'Changes between main and feature-branch')"
-          },
-          "from_ref": {
-            "type": "string",
-            "description": "The git reference for the 'before' state. Can be a commit hash, branch name, tag, or relative reference like HEAD~1, HEAD^, origin/main, etc."
-          },
-          "to_ref": {
-            "type": "string",
-            "description": "The git reference for the 'after' state. Can be a commit hash, branch name, tag, or relative reference. If not provided, compares to the current working directory (including uncommitted changes)."
-          }
-        },
-        "required": [
-          "title",
-          "from_ref"
-        ],
-        "additionalProperties": false
-      }
-    }
-  },
-  {
-    "type": "function",
-    "function": {
       "name": "12345670mcp0test_tool",
       "description": "test-server: A test tool",
       "strict": false,

--- a/src/core/prompts/system-prompt/__tests__/__snapshots__/openai_gpt_5_native.tools.snap
+++ b/src/core/prompts/system-prompt/__tests__/__snapshots__/openai_gpt_5_native.tools.snap
@@ -341,36 +341,6 @@
   {
     "type": "function",
     "function": {
-      "name": "generate_explanation",
-      "description": "Opens a multi-file diff view and generates AI-powered inline comments explaining the changes between two git references. Use this tool to help users understand code changes from git commits, pull requests, branches, or any git refs. The tool uses git to retrieve file contents and displays a side-by-side diff view with explanatory comments.",
-      "strict": false,
-      "parameters": {
-        "type": "object",
-        "properties": {
-          "title": {
-            "type": "string",
-            "description": "A descriptive title for the diff view (e.g., 'Changes in commit abc123', 'PR #42: Add authentication', 'Changes between main and feature-branch')"
-          },
-          "from_ref": {
-            "type": "string",
-            "description": "The git reference for the 'before' state. Can be a commit hash, branch name, tag, or relative reference like HEAD~1, HEAD^, origin/main, etc."
-          },
-          "to_ref": {
-            "type": "string",
-            "description": "The git reference for the 'after' state. Can be a commit hash, branch name, tag, or relative reference. If not provided, compares to the current working directory (including uncommitted changes)."
-          }
-        },
-        "required": [
-          "title",
-          "from_ref"
-        ],
-        "additionalProperties": false
-      }
-    }
-  },
-  {
-    "type": "function",
-    "function": {
       "name": "12345670mcp0test_tool",
       "description": "test-server: A test tool",
       "strict": false,

--- a/src/core/prompts/system-prompt/__tests__/__snapshots__/vertex_gemini3.tools.snap
+++ b/src/core/prompts/system-prompt/__tests__/__snapshots__/vertex_gemini3.tools.snap
@@ -331,28 +331,6 @@
     }
   },
   {
-    "name": "generate_explanation",
-    "description": "Opens a multi-file diff view and generates AI-powered inline comments explaining the changes between two git references. Use this tool to help users understand code changes from git commits, pull requests, branches, or any git refs. The tool uses git to retrieve file contents and displays a side-by-side diff view with explanatory comments.",
-    "parameters": {
-      "type": "OBJECT",
-      "properties": {
-        "title": {
-          "type": "STRING"
-        },
-        "from_ref": {
-          "type": "STRING"
-        },
-        "to_ref": {
-          "type": "STRING"
-        }
-      },
-      "required": [
-        "title",
-        "from_ref"
-      ]
-    }
-  },
-  {
     "name": "12345670mcp0test_tool",
     "description": "test-server: A test tool",
     "parameters": {

--- a/src/core/prompts/system-prompt/tools/generate_explanation.ts
+++ b/src/core/prompts/system-prompt/tools/generate_explanation.ts
@@ -10,6 +10,7 @@ const GENERIC: ClineToolSpec = {
 	name: "generate_explanation",
 	description:
 		"Opens a multi-file diff view and generates AI-powered inline comments explaining the changes between two git references. Use this tool to help users understand code changes from git commits, pull requests, branches, or any git refs. The tool uses git to retrieve file contents and displays a side-by-side diff view with explanatory comments.",
+	contextRequirements: (context) => context.ide === "Visual Studio Code",
 	parameters: [
 		{
 			name: "title",


### PR DESCRIPTION
## Summary

The `generate_explanation` tool (used for the "Explain Changes" feature) relies on VS Code's Comments API to display inline code review comments. This feature doesn't work on JetBrains or CLI platforms.

## Changes

- Added `contextRequirements` function to the `generate_explanation` tool spec that checks if the IDE is VS Code
- The tool will now only be included in the system prompt when running on VS Code
- Updated test snapshots to reflect the conditional inclusion

## Testing

- All existing tests pass with updated snapshots
- The tool is excluded from system prompts when IDE != "Visual Studio Code"
- The tool is included when IDE == "Visual Studio Code"

Fixes #7807

Co-Authored-By: Claude <noreply@anthropic.com>