### PR TITLE
fix: telemetry banner settings button should open General tab

### DIFF
--- a/.changeset/telemetry-banner-settings-tab.md
+++ b/.changeset/telemetry-banner-settings-tab.md
@@ -1,0 +1,7 @@
+---
+"cline/cline": patch
+---
+
+Fix telemetry banner settings button to open the General tab where the telemetry setting is located.
+
+Fixes #4705

--- a/webview-ui/src/components/common/TelemetryBanner.tsx
+++ b/webview-ui/src/components/common/TelemetryBanner.tsx
@@ -16,7 +16,7 @@ export const TelemetryBanner: React.FC = () => {
 
 	const handleOpenSettings = useCallback(() => {
 		handleClose()
-		navigateToSettings()
+		navigateToSettings("general")
 	}, [handleClose, navigateToSettings])
 
 	return (


### PR DESCRIPTION
## Summary

When clicking the settings link in the anonymous telemetry banner, it was opening the first tab (API Configuration) by default instead of the General tab where the telemetry setting is actually located.

## Changes

- Modified `TelemetryBanner.tsx` to pass `"general"` as the target section when calling `navigateToSettings()`
- This ensures the settings view opens directly to the General tab which contains the telemetry toggle

## Testing

- Clicking the settings link in the telemetry banner now opens the General tab
- The General tab contains the telemetry setting toggle

Fixes #4705

Co-Authored-By: Claude <noreply@anthropic.com>