### PR TITLE
fix: add word wrapping for MCP tool call arguments

### DIFF
--- a/.changeset/mcp-tool-arguments-word-wrap.md
+++ b/.changeset/mcp-tool-arguments-word-wrap.md
@@ -1,0 +1,7 @@
+---
+"cline/cline": patch
+---
+
+Add word wrapping for MCP tool call arguments in the chat view to prevent horizontal scrolling with long JSON content.
+
+Fixes #5886

--- a/webview-ui/src/components/chat/ChatRow.tsx
+++ b/webview-ui/src/components/chat/ChatRow.tsx
@@ -783,6 +783,7 @@ export const ChatRowContent = memo(
 										<div className="mb-1 opacity-80 uppercase">Arguments</div>
 										<CodeAccordian
 											code={useMcpServer.arguments}
+											forceWrap={true}
 											isExpanded={true}
 											language="json"
 											onToggleExpand={handleToggle}

--- a/webview-ui/src/components/common/CodeAccordian.tsx
+++ b/webview-ui/src/components/common/CodeAccordian.tsx
@@ -14,6 +14,7 @@ interface CodeAccordianProps {
 	isExpanded: boolean
 	onToggleExpand: () => void
 	isLoading?: boolean
+	forceWrap?: boolean
 }
 
 /*
@@ -34,6 +35,7 @@ const CodeAccordian = ({
 	isExpanded,
 	onToggleExpand,
 	isLoading,
+	forceWrap = false,
 }: CodeAccordianProps) => {
 	const inferredLanguage = useMemo(
 		() => code && (language ?? (path ? getLanguageFromPath(path) : undefined)),
@@ -92,8 +94,9 @@ const CodeAccordian = ({
 				</Button>
 			)}
 			{(!(path || isFeedback || isConsoleLogs) || isExpanded) && (
-				<div className="overflow-x-auto overflow-y-hidden max-w-full">
+				<div className={forceWrap ? "" : "overflow-x-auto overflow-y-hidden max-w-full"}>
 					<CodeBlock
+						forceWrap={forceWrap}
 						source={`${"```"}${diff !== undefined ? "diff" : inferredLanguage}\n${(
 							code ?? diff ?? ""
 						).trim()}\n${"```"}`}


### PR DESCRIPTION
## Summary

MCP tool call arguments with long JSON content were displaying without word wrapping, causing excessive horizontal scrolling and making the content difficult to read.

## Changes

- Added `forceWrap` prop to the `CodeAccordian` component
- Modified `ChatRow.tsx` to pass `forceWrap=true` when displaying MCP tool arguments
- This enables word wrapping for long JSON arguments in the chat view

## Testing

- MCP tool arguments now wrap text instead of requiring horizontal scrolling
- JSON content is more readable with wrapped lines

Fixes #5886

Co-Authored-By: Claude <noreply@anthropic.com>