### PR TITLE
fix: Thinking blocks displaying as single line without word wrap

### DIFF
--- a/.changeset/thinking-block-word-wrap.md
+++ b/.changeset/thinking-block-word-wrap.md
@@ -1,0 +1,7 @@
+---
+"cline/cline": patch
+---
+
+Fix Thinking blocks (Claude Sonnet 4.5) displaying as a single long line without proper word wrapping. Removed the `truncated` class that was overriding `whitespace-pre-wrap`.
+
+Fixes #7876

--- a/webview-ui/src/components/chat/ThinkingRow.tsx
+++ b/webview-ui/src/components/chat/ThinkingRow.tsx
@@ -57,7 +57,7 @@ export const ThinkingRow = memo(({ showTitle = false, reasoningContent, isVisibl
 					variant="text">
 					<div
 						className={cn(
-							"flex max-h-[150px] overflow-y-auto text-description leading-normal truncated whitespace-pre-wrap break-words flex-1 [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden [direction:ltr]",
+							"flex max-h-[150px] overflow-y-auto text-description leading-normal whitespace-pre-wrap break-words flex-1 [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden [direction:ltr]",
 							{
 								"pl-2 border-l border-description/50": showTitle,
 							},


### PR DESCRIPTION
## Summary

Thinking blocks from Claude Sonnet 4.5 models were displaying as a single long line without proper word wrapping, making the content completely unreadable.

## Changes

- Removed the `truncated` Tailwind class from the ThinkingRow component
- The `truncated` class (`overflow: hidden; text-overflow: ellipsis; white-space: nowrap`) was overriding `whitespace-pre-wrap`, preventing proper line breaks
- Now Thinking blocks properly wrap text and preserve newlines

## Testing

- Thinking blocks from Claude Sonnet 4.5 now display with proper word wrapping
- Newlines in Thinking content are now rendered correctly
- The content is readable without horizontal scrolling

Fixes #7876

Co-Authored-By: Claude <noreply@anthropic.com>