### PR TITLE
fix: checkbox toggles when clicking adjacent whitespace in settings

### DIFF
--- a/.changeset/checkbox-change-handler.md
+++ b/.changeset/checkbox-change-handler.md
@@ -1,0 +1,7 @@
+---
+"cline/cline": patch
+---
+
+Fix "Enable extended thinking" checkbox toggling when clicking adjacent whitespace. Changed from onClick to onChange handler for proper checkbox behavior.
+
+Fixes #6083

--- a/webview-ui/src/components/settings/ThinkingBudgetSlider.tsx
+++ b/webview-ui/src/components/settings/ThinkingBudgetSlider.tsx
@@ -105,8 +105,8 @@ const ThinkingBudgetSlider = ({ currentMode, maxBudget, showEnableToggle = true 
 		)
 	}
 
-	const handleToggleChange = (event: React.FormEvent<HTMLInputElement>) => {
-		const isChecked = event.currentTarget.checked
+	const handleToggleChange = (event: any) => {
+		const isChecked = event.target.checked === true
 		const newThinkingBudgetValue = isChecked ? ANTHROPIC_MIN_THINKING_BUDGET : 0
 		setIsEnabled(isChecked)
 		setLocalValue(newThinkingBudgetValue)

--- a/webview-ui/src/components/settings/ThinkingBudgetSlider.tsx
+++ b/webview-ui/src/components/settings/ThinkingBudgetSlider.tsx
@@ -105,8 +105,8 @@ const ThinkingBudgetSlider = ({ currentMode, maxBudget, showEnableToggle = true 
 		)
 	}
 
-	const handleToggleChange = (event: any) => {
-		const isChecked = (event.target as HTMLInputElement).checked
+	const handleToggleChange = (event: React.FormEvent<HTMLInputElement>) => {
+		const isChecked = event.currentTarget.checked
 		const newThinkingBudgetValue = isChecked ? ANTHROPIC_MIN_THINKING_BUDGET : 0
 		setIsEnabled(isChecked)
 		setLocalValue(newThinkingBudgetValue)
@@ -121,7 +121,7 @@ const ThinkingBudgetSlider = ({ currentMode, maxBudget, showEnableToggle = true 
 	return (
 		<div className="w-full">
 			{showEnableToggle ? (
-				<VSCodeCheckbox checked={isEnabled} onClick={handleToggleChange}>
+				<VSCodeCheckbox checked={isEnabled} onChange={handleToggleChange}>
 					Enable thinking{localValue && localValue > 0 ? ` (${localValue.toLocaleString()} tokens)` : ""}
 				</VSCodeCheckbox>
 			) : null}


### PR DESCRIPTION
## Summary

The "Enable extended thinking" checkbox in the settings panel was toggling when clicking on the blank space beside it, not just the checkbox control itself.

## Changes

- Changed from `onClick` to `onChange` handler for the VSCodeCheckbox component
- The `onChange` event only fires when the checkbox value actually changes, providing more precise control
- Updated event type from `any` to `React.FormEvent<HTMLInputElement>` for better type safety

## Testing

- The checkbox now only toggles when directly interacting with the checkbox control
- Clicking adjacent whitespace no longer triggers the toggle

Fixes #6083

Co-Authored-By: Claude <noreply@anthropic.com>