### PR TITLE
fix: clear streaming decorations after final update

### DIFF
--- a/src/hosts/vscode/VscodeDiffViewProvider.ts
+++ b/src/hosts/vscode/VscodeDiffViewProvider.ts
@@ -167,7 +167,10 @@ export class VscodeDiffViewProvider extends DiffViewProvider {
 			edit.delete(document.uri, new vscode.Range(lineNumber, 0, document.lineCount, 0))
 			await vscode.workspace.applyEdit(edit)
 		}
-		// Clear all decorations at the end (before applying final edit)
+	}
+
+	protected override async onFinalUpdate(): Promise<void> {
+		// Clear all decorations at the end of streaming
 		this.fadedOverlayController?.clear()
 		this.activeLineController?.clear()
 	}

--- a/src/integrations/editor/DiffViewProvider.ts
+++ b/src/integrations/editor/DiffViewProvider.ts
@@ -242,7 +242,16 @@ export abstract class DiffViewProvider {
 		if (isFinal) {
 			// Handle any remaining lines if the new content is shorter than the original
 			await this.safelyTruncateDocument(this.streamedLines.length)
+			// Allow subclasses to perform cleanup (e.g., clearing decorations)
+			await this.onFinalUpdate()
 		}
+	}
+
+	/**
+	 * Called after the final update is complete. Subclasses can override to perform cleanup.
+	 */
+	protected async onFinalUpdate(): Promise<void> {
+		// Default no-op
 	}
 
 	async showFile(absolutePath: string): Promise<void> {


### PR DESCRIPTION
## Summary

Fixes a visual regression introduced in #8651 where the yellow streaming animation decoration doesn't clear at the end of file edits.

<img width="2465" height="1340" alt="Code 2026-01-16 16 12 38" src="https://github.com/user-attachments/assets/503da82f-4c5f-4448-a709-59cda05bdcd6" />


## Problem

#8651 introduced `safelyTruncateDocument()` which skips calling `truncateDocument()` when there's nothing to truncate (i.e., when `lineNumber >= lineCount`). However, `VscodeDiffViewProvider.truncateDocument()` was also responsible for clearing the streaming decorations (`fadedOverlayController` and `activeLineController`). When truncation was skipped, decorations never got cleared, leaving the yellow highlight stuck at the end of the file.

## Solution

Added an `onFinalUpdate()` hook in `DiffViewProvider` that's always called after the final update completes. `VscodeDiffViewProvider` overrides it to clear decorations. This decouples decoration cleanup from truncation logic.

## Test Plan

1. Ask Cline to write a new file with multiple lines
2. Watch the streaming animation
3. Verify the yellow highlight clears when streaming completes
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `onFinalUpdate()` hook to `DiffViewProvider` to ensure streaming decorations are cleared after final update, fixing a visual regression.
> 
>   - **Behavior**:
>     - Adds `onFinalUpdate()` hook in `DiffViewProvider` to ensure cleanup after final update.
>     - `VscodeDiffViewProvider` overrides `onFinalUpdate()` to clear `fadedOverlayController` and `activeLineController`.
>   - **Problem**:
>     - `safelyTruncateDocument()` in `DiffViewProvider` skipped `truncateDocument()` when unnecessary, preventing decoration cleanup.
>   - **Solution**:
>     - Decouples decoration cleanup from truncation logic by using `onFinalUpdate()` hook.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 2e2a9183bff5024fdb05f0b8b27deec34025e1c9. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->