### PR TITLE
fix: telemetry settings button should open General tab

### DIFF
--- a/.changeset/telemetry-settings-tab-fix.md
+++ b/.changeset/telemetry-settings-tab-fix.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Fix settings button in telemetry popup to open the General tab instead of defaulting to API Configuration tab. Resolves #4705

--- a/webview-ui/src/components/common/TelemetryBanner.tsx
+++ b/webview-ui/src/components/common/TelemetryBanner.tsx
@@ -16,7 +16,7 @@ export const TelemetryBanner: React.FC = () => {
 
 	const handleOpenSettings = useCallback(() => {
 		handleClose()
-		navigateToSettings()
+		navigateToSettings("general")
 	}, [handleClose, navigateToSettings])
 
 	return (


### PR DESCRIPTION
## Summary
- Fixed settings button in telemetry popup to open the General tab instead of defaulting to API Configuration tab
- The `navigateToSettings()` function accepts a `targetSection` parameter, but it was being called without any argument

## Changes
- Updated `TelemetryBanner.tsx` to call `navigateToSettings("general")` instead of `navigateToSettings()`

## Test plan
- [x] Click settings link in telemetry banner
- [x] Verify it opens the General settings tab (where the telemetry toggle is located)
- [x] Unit tests pass

Resolves #4705

🤖 Generated with [Claude Code](https://claude.com/claude-code)