### PR TITLE
fix: base64 images in MCP responses no longer render as text

### DIFF
--- a/.changeset/mcp-base64-image-fix.md
+++ b/.changeset/mcp-base64-image-fix.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Fix base64 images in MCP responses rendering as unusable text strings

--- a/webview-ui/src/components/mcp/chat-display/utils/mcpRichUtil.ts
+++ b/webview-ui/src/components/mcp/chat-display/utils/mcpRichUtil.ts
@@ -394,14 +394,17 @@ export const buildDisplaySegments = (responseText: string, urlMatches: UrlMatch[
 			})
 		}
 
-		// Add the URL text itself (truncate data URIs since they're very long)
-		const isDataUri = url.startsWith("data:")
-		const urlContent = isDataUri ? truncateSingleDataUri(fullMatch) : fullMatch
-		segments.push({
-			type: "url",
-			content: urlContent,
-			key: `url-${segmentIndex++}`,
-		})
+		// Add the URL text itself, but skip for data:image URIs since the image will be displayed
+		// and showing the base64 string as text is unusable
+		if (!url.startsWith("data:image/")) {
+			const isDataUri = url.startsWith("data:")
+			const urlContent = isDataUri ? truncateSingleDataUri(fullMatch) : fullMatch
+			segments.push({
+				type: "url",
+				content: urlContent,
+				key: `url-${segmentIndex++}`,
+			})
+		}
 
 		// Add embedded content after the URL
 		if (match.isImage) {


### PR DESCRIPTION
## Summary
- Fixed base64 images in MCP responses rendering as unusable text strings alongside the actual image in rich display mode
- The `buildDisplaySegments` function was adding both a URL text segment and an image segment for all URLs

## Changes
- Modified `buildDisplaySegments()` in `mcpRichUtil.ts` to skip adding URL text segment for `data:image/` URLs
- Images are still rendered correctly, but the base64 string is no longer shown as text

## Test plan
- [x] MCP server responds with base64 image
- [x] Image renders correctly in rich display mode
- [x] Base64 string is NOT shown as text
- [x] Unit tests pass

Resolves #7060

🤖 Generated with [Claude Code](https://claude.com/claude-code)