### PR TITLE
fix: add word wrapping for MCP tool arguments

### DIFF
--- a/.changeset/mcp-word-wrap-fix.md
+++ b/.changeset/mcp-word-wrap-fix.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Add forceWrap support to CodeAccordian for MCP tool arguments to enable word wrapping. Resolves #5886

--- a/webview-ui/src/components/chat/ChatRow.tsx
+++ b/webview-ui/src/components/chat/ChatRow.tsx
@@ -812,6 +812,7 @@ export const ChatRowContent = memo(
 										<div className="mb-1 opacity-80 uppercase">Arguments</div>
 										<CodeAccordian
 											code={useMcpServer.arguments}
+											forceWrap={true}
 											isExpanded={true}
 											language="json"
 											onToggleExpand={handleToggle}

--- a/webview-ui/src/components/common/CodeAccordian.tsx
+++ b/webview-ui/src/components/common/CodeAccordian.tsx
@@ -15,6 +15,7 @@ interface CodeAccordianProps {
 	isExpanded: boolean
 	onToggleExpand: () => void
 	isLoading?: boolean
+	forceWrap?: boolean
 }
 
 /*
@@ -35,6 +36,7 @@ const CodeAccordian = ({
 	isExpanded,
 	onToggleExpand,
 	isLoading,
+	forceWrap = false,
 }: CodeAccordianProps) => {
 	const inferredLanguage = useMemo(
 		() => code && (language ?? (path ? getLanguageFromPath(path) : undefined)),
@@ -95,6 +97,7 @@ const CodeAccordian = ({
 			{(!(path || isFeedback || isConsoleLogs) || isExpanded) && (
 				<div className="overflow-x-auto overflow-y-hidden max-w-full">
 					<CodeBlock
+						forceWrap={forceWrap}
 						source={`${"```"}${diff !== undefined ? "diff" : inferredLanguage}\n${(
 							code ?? diff ?? ""
 						).trim()}\n${"```"}`}


### PR DESCRIPTION
## Summary
- Added `forceWrap` prop to `CodeAccordian` component
- Enabled word wrapping for MCP tool call arguments
- Prevents extremely long horizontal scrollbars for JSON arguments

## Changes
- Added `forceWrap?: boolean` prop to `CodeAccordianProps` interface
- Passed `forceWrap` prop through to `CodeBlock` component
- Set `forceWrap={true}` for MCP arguments in `ChatRow.tsx`

## Test plan
- [x] Use MCP server with long JSON arguments
- [x] Verify arguments are word-wrapped instead of horizontally scrolling
- [x] Code blocks still work as before

Resolves #5886

🤖 Generated with [Claude Code](https://claude.com/claude-code)