### PR TITLE
fix: update history delete button text when deleting via side icon

### DIFF
--- a/.changeset/history-button-text-fix.md
+++ b/.changeset/history-button-text-fix.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Fix history delete button text not updating when deleting selected items via side icon. Resolves #6033

--- a/webview-ui/src/components/history/HistoryView.tsx
+++ b/webview-ui/src/components/history/HistoryView.tsx
@@ -168,6 +168,8 @@ const HistoryView = ({ onDone }: HistoryViewProps) => {
 			TaskServiceClient.deleteTasksWithIds(StringArrayRequest.create({ value: [id] }))
 				.then(() => fetchTotalTasksSize())
 				.catch((error) => console.error("Error deleting task:", error))
+			// Remove from selected items to update button text
+			setSelectedItems((prev) => prev.filter((itemId) => itemId !== id))
 		},
 		[fetchTotalTasksSize],
 	)


### PR DESCRIPTION
## Summary
- Fixed button text not updating after deleting selected history item via side icon
- When deleting a selected item using the trash icon, the button still showed "Delete selected history"

## Changes
- Added `setSelectedItems((prev) => prev.filter((itemId) => itemId !== id))` to `handleDeleteHistoryItem`
- This clears the deleted item from the selectedItems state, updating the button text

## Test plan
- [x] Select one or more history items
- [x] Delete a selected item using the side trash icon
- [x] Verify button text updates to "Delete all history" if no items selected
- [x] Verify button text updates correctly if other items remain selected

Resolves #6033

🤖 Generated with [Claude Code](https://claude.com/claude-code)