### PR TITLE
fix(test): wait for tabs to actually close in getOpenTabs test

### DIFF
--- a/src/hosts/vscode/hostbridge/window/getOpenTabs.test.ts
+++ b/src/hosts/vscode/hostbridge/window/getOpenTabs.test.ts
@@ -28,20 +28,34 @@ describe("Hostbridge - Window - getOpenTabs", () => {
 		})
 	}
 
-	beforeEach(async () => {
-		// Clean up any existing editors
+	async function waitForAllTabsClosed(): Promise<void> {
 		await vscode.commands.executeCommand("workbench.action.closeAllEditors")
+		// Wait for tabs to actually close (Windows can be slow to process this)
+		await pWaitFor(
+			async () => {
+				const request = GetOpenTabsRequest.create({})
+				const response = await getOpenTabs(request)
+				return response.paths.length === 0
+			},
+			{
+				timeout: 5000,
+				interval: 50,
+			},
+		)
+	}
+
+	beforeEach(async () => {
+		// Clean up any existing editors and wait for cleanup to complete
+		await waitForAllTabsClosed()
 	})
 
 	afterEach(async () => {
 		// Clean up test documents and editors
-		await vscode.commands.executeCommand("workbench.action.closeAllEditors")
+		await waitForAllTabsClosed()
 	})
 
 	it("should return empty array when no tabs are open", async () => {
-		// Ensure no tabs are open
-		await vscode.commands.executeCommand("workbench.action.closeAllEditors")
-
+		// beforeEach already ensures no tabs are open
 		const request = GetOpenTabsRequest.create({})
 		const response = await getOpenTabs(request)
 


### PR DESCRIPTION
## Summary

Fixes flaky `getOpenTabs` integration test on Windows.

The test was intermittently failing because `closeAllEditors` command returns before tabs are fully closed. This caused leftover tabs from previous tests to appear, resulting in duplicate tab entries like:
```
["test-file-open-tabs-1.js","test-file-open-tabs-2.js","test-file-open-tabs-2.js"]
```

## Root Cause

The `workbench.action.closeAllEditors` VS Code command is async but doesn't guarantee tabs are closed when the promise resolves. On Windows especially, there can be a delay between the command completing and VS Code actually closing the tabs.

## Fix

Added a `waitForAllTabsClosed` helper that:
1. Executes the `closeAllEditors` command
2. Polls `getOpenTabs` until it returns 0 tabs (with 5s timeout)
3. Used in both `beforeEach` and `afterEach`

This ensures each test starts with a truly clean slate.

## Test Plan

- CI should pass on Windows where this was failing
- The fix adds ~50ms overhead per test in the happy path (just the polling interval)

## History

This test has been flaky before:
- fc8517b52 - Made file names unique per test
- 3847a2545 - Increased timeout
- 0178c3fa9 - Previous flaky fix attempt
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes flaky `getOpenTabs` test on Windows by ensuring tabs are fully closed before tests using a new helper function.
> 
>   - **Behavior**:
>     - Fixes flaky `getOpenTabs` test on Windows by ensuring tabs are fully closed before tests.
>     - Introduces `waitForAllTabsClosed()` to wait for `getOpenTabs` to return 0 tabs.
>     - Used in `beforeEach` and `afterEach` to ensure a clean slate.
>   - **Functions**:
>     - Adds `waitForAllTabsClosed()` in `getOpenTabs.test.ts` to execute `closeAllEditors` and poll `getOpenTabs`.
>   - **Misc**:
>     - Removes redundant `closeAllEditors` calls in individual tests.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for ada0936932f44351aadaa41cb0792cd21c3519f9. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->