### PR TITLE
fix(mcp): show Authenticate button when OAuth refresh token expires

### DIFF
--- a/apps/vscode/src/services/mcp/McpHub.ts
+++ b/apps/vscode/src/services/mcp/McpHub.ts
@@ -7,6 +7,7 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js"
 import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js"
 import { getDefaultEnvironment, StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js"
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js"
+import { InvalidGrantError, InvalidTokenError, OAuthError, ServerError } from "@modelcontextprotocol/sdk/server/auth/errors.js"
 import {
 	CallToolResultSchema,
 	ErrorCode,
@@ -676,9 +677,25 @@ export class McpHub {
 				const timeout = resolveMcpServerTimeoutMs(connection.server.config)
 				await client.connect(transport, { timeout })
 			} catch (error) {
-				if (error instanceof UnauthorizedError) {
-					// Server requires OAuth authentication
-					Logger.log(`Server "${name}" requires OAuth authentication`)
+				// Expired refresh tokens surface as InvalidGrantError or InvalidTokenError;
+				// treat them like UnauthorizedError but clear the stale tokens first so
+				// the next auth attempt starts fresh rather than looping on the bad token.
+				const isExpiredTokenError =
+					(error instanceof OAuthError && !(error instanceof ServerError) && !(error instanceof UnauthorizedError)) ||
+					error instanceof InvalidGrantError ||
+					error instanceof InvalidTokenError
+
+				if (error instanceof UnauthorizedError || isExpiredTokenError) {
+					const isInitialAuth = error instanceof UnauthorizedError
+					Logger.log(
+						`Server "${name}" requires OAuth ${isInitialAuth ? "authentication" : "re-authentication (token expired)"}`,
+					)
+
+					// For expired tokens: clear stale token state so the auth flow restarts cleanly
+					if (!isInitialAuth && authProvider) {
+						await (authProvider as any).invalidateCredentials("tokens")
+					}
+
 					const unauthConnection: McpConnection = {
 						server: {
 							name,
@@ -687,7 +704,9 @@ export class McpHub {
 							disabled: false,
 							oauthRequired: true,
 							oauthAuthStatus: "unauthenticated",
-							error: "This MCP server requires authentication to get started.",
+							error: isInitialAuth
+								? "This MCP server requires authentication to get started."
+								: "Authentication expired. Please re-authenticate.",
 						},
 						client,
 						transport,
@@ -1739,6 +1758,28 @@ export class McpHub {
 				content: result.content ?? [],
 			}
 		} catch (error) {
+			// If the tool call fails with an auth error (e.g. expired token that the SDK
+			// couldn't auto-refresh), clear the stale tokens and mark the server as
+			// needing re-authentication. Look up the connection fresh to avoid acting on
+			// a stale reference if a reconnect already replaced it.
+			const isExpiredTokenError =
+				(error instanceof OAuthError && !(error instanceof ServerError) && !(error instanceof UnauthorizedError)) ||
+				error instanceof InvalidGrantError ||
+				error instanceof InvalidTokenError
+
+			if (isExpiredTokenError || error instanceof UnauthorizedError) {
+				const liveConnection = this.connections.find((conn) => conn.server.name === serverName)
+				if (liveConnection?.authProvider) {
+					await (liveConnection.authProvider as any).invalidateCredentials("tokens")
+					liveConnection.server.oauthRequired = true
+					liveConnection.server.oauthAuthStatus = "unauthenticated"
+					liveConnection.server.status = "disconnected"
+					liveConnection.server.error = "Authentication expired. Please re-authenticate."
+					await this.notifyWebviewOfServerChanges()
+				}
+				throw new Error(`Authentication failed for "${serverName}". Please click "Authenticate" to re-authenticate.`)
+			}
+
 			this.telemetryService.captureMcpToolCall(
 				ulid,
 				serverName,


### PR DESCRIPTION
<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- For feature requests: Created a discussion in our Feature Requests discussions board https://github.com/cline/cline/discussions/categories/feature-requests and received approval from core maintainers before implementation
- For all changes: Link the associated issue/discussion in the "Related Issue" section below

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly without prior discussion.

Why this requirement?
We deeply appreciate all community contributions - they are essential to Cline's success! To ensure the best use of everyone's time and maintain project direction, we use our Feature Requests discussions board to gauge community interest and validate feature ideas before implementation begins. This helps us focus development efforts on features that will benefit the most users.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** #XXXX

### Description

**Problem:**
When OAuth refresh tokens expired for MCP servers, users were stuck in a "Retry Connection" loop with no way to re-authenticate. This occurred in two scenarios:
  1. Restarting the MCP server
  2. Calling a tool on the MCP server

**Workaround:** 
Deleting the MCP server from cline_mcp_settings.json and re-adding it - not ideal.

**Root Cause:**
  When the refresh token expired:
  1. The server caught the authentication error
  2. But the server state was never updated to `oauthRequired: true` and `oauthAuthStatus: "unauthenticated"`
  3. The UI checks these properties to decide whether to show "Authenticate" or "Retry Connection"
  4. Without proper state, the UI showed "Retry Connection" which just retried the same failed auth

#### Additional Fix

This PR also fixes a bug in the test infrastructure introduced by #9173:
- `src/test/host-provider-test-utils.ts` still used `getCallbackUri` instead of `getCallbackUrl`
- This caused callback URL mocks to be undefined in tests

<!-- 
Help reviewers understand your changes by making this PR readable and well-organized:

- What problem does this PR solve?
- Why were these changes introduced and what purpose do they serve?
- For larger changes, provide context about your approach and reasoning

Small PRs may need minimal description, but larger changes benefit from explaining where you're coming from. Much of this context can be in the linked issue above, so feel free to reference it rather than repeating everything here.
-->

### Test Procedure

- Manual Testing:
  - Server restart + valid refresh token → Seamless refresh by SDK
  - Server restart + expired refresh token → Shows "Authenticate" button
  - Tool call + valid refresh token → Seamless refresh by SDK
  - Tool call + expired refresh token → Shows "Authenticate" button
- Added missing unitests



<!-- 
Please walk us through your testing approach and thought process. This helps reviewers understand that you've thoroughly considered the impact of your changes:

- How did you test this change?
- What could potentially break and how did you verify it doesn't?
- What existing functionality might be affected and how did you check it still works?
- Why are you confident this is ready for merge?

We're not looking for exhaustive documentation - just evidence that you've thought through the implications of your changes and tested accordingly.
-->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Before:
<img width="480" height="345" alt="image" src="https://github.com/user-attachments/assets/faf5a0de-0dcc-418a-8bd3-d88439963e85" />

After:
Server restart scenario when refresh token expired - Shows "Authenticate" button with error:
  Authentication expired. Please re-authenticate.

<img width="478" height="94" alt="image" src="https://github.com/user-attachments/assets/a6b63a22-562f-42d7-9753-2d29bf78f88b" />


  Tool call scenario when refresh token expired - Shows "Authenticate" button with error:
  Authentication failed. Please re-authenticate.

<img width="544" height="107" alt="image" src="https://github.com/user-attachments/assets/a044d9aa-d30d-4860-a6b1-89b9a30d8318" />


<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes UI to show "Authenticate" button when OAuth refresh token expires, with improved error handling and unit tests.
> 
>   - **Behavior**:
>     - Fixes UI to show "Authenticate" button when OAuth refresh token expires in `McpHub.ts`.
>     - Handles `UnauthorizedError`, `InvalidGrantError`, `InvalidTokenError`, and `OAuthError` to update server state to require re-authentication.
>     - Clears expired tokens using `clearServerTokens()` in `McpOAuthManager.ts`.
>   - **Functions**:
>     - Adds `markServerAsNeedingAuth()` in `McpHub.ts` to update server state and clear tokens.
>     - Modifies `initiateOAuth()` and `completeOAuth()` in `McpHub.ts` for better error handling.
>   - **Tests**:
>     - Adds unit tests in `McpHub.test.ts` and `McpOAuthManager.test.ts` to cover new OAuth error handling scenarios.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 066859d5722117b29569dfe90374ef86722fcfb7. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->