### PR TITLE
fix: reduce JetBrains workflow comment spam on PRs

### DIFF
--- a/.github/workflows/trigger-jetbrains-tests.yml
+++ b/.github/workflows/trigger-jetbrains-tests.yml
@@ -1,17 +1,26 @@
 name: Trigger Jetbrains Plugin <-> Cline Tests
 on:
   pull_request_target:
-    types: [opened, synchronize, reopened]
+    types: [opened, reopened]
+  issue_comment:
+    types: [created]
 permissions:
   contents: read
+  pull-requests: read
 concurrency:
-  group: jetbrains-trigger-${{ github.event.number }}
+  group: jetbrains-trigger-${{ github.event.pull_request.number || github.event.issue.number }}
   cancel-in-progress: true
 
 jobs:
   trigger-integration-test:
     name: Run Tests
     runs-on: ubuntu-latest
+    # Run on PR open/reopen, or when someone comments /test-jetbrains on a PR
+    if: |
+      github.event_name == 'pull_request_target' ||
+      (github.event_name == 'issue_comment' &&
+       github.event.issue.pull_request &&
+       contains(github.event.comment.body, '/test-jetbrains'))
     steps:
       - name: Generate GitHub App Token
         id: app-token
@@ -22,16 +31,28 @@ jobs:
           owner: cline
           repositories: intellij-plugin
 
+      - name: Get PR details (for issue_comment trigger)
+        id: pr-details
+        if: github.event_name == 'issue_comment'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PR_DATA=$(gh api repos/${{ github.repository }}/pulls/${{ github.event.issue.number }})
+          echo "head_ref=$(echo "$PR_DATA" | jq -r '.head.ref')" >> $GITHUB_OUTPUT
+          echo "head_sha=$(echo "$PR_DATA" | jq -r '.head.sha')" >> $GITHUB_OUTPUT
+          echo "title=$(echo "$PR_DATA" | jq -r '.title')" >> $GITHUB_OUTPUT
+          echo "html_url=$(echo "$PR_DATA" | jq -r '.html_url')" >> $GITHUB_OUTPUT
+
       - name: Sanitize untrusted inputs
         id: sanitize
         env:
-          RAW_BRANCH_NAME: ${{ github.head_ref }}
-          RAW_PR_TITLE: ${{ github.event.pull_request.title }}
+          RAW_BRANCH_NAME: ${{ github.event_name == 'pull_request_target' && github.head_ref || steps.pr-details.outputs.head_ref }}
+          RAW_PR_TITLE: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.title || steps.pr-details.outputs.title }}
         run: |
           # Sanitize branch name for JSON
           BRANCH_NAME_JSON=$(jq -n --arg b "$RAW_BRANCH_NAME" '$b')
           echo "branch_name=$BRANCH_NAME_JSON" >> $GITHUB_OUTPUT
-          
+
           # Sanitize PR title for JSON
           PR_TITLE_JSON=$(jq -n --arg t "$RAW_PR_TITLE" '$t')
           echo "pr_title=$PR_TITLE_JSON" >> $GITHUB_OUTPUT
@@ -40,6 +61,9 @@ jobs:
         env:
           BRANCH_NAME: ${{ steps.sanitize.outputs.branch_name }}
           PR_TITLE: ${{ steps.sanitize.outputs.pr_title }}
+          PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
+          PR_SHA: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || steps.pr-details.outputs.head_sha }}
+          PR_URL: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.html_url || steps.pr-details.outputs.html_url }}
         run: |
           curl -X POST \
             -H "Authorization: Bearer ${{ steps.app-token.outputs.token }}" \
@@ -51,19 +75,23 @@ jobs:
           {
             "event_type": "cline-pr-check",
             "client_payload": {
-              "pr_number": "${{ github.event.number }}",
+              "pr_number": "$PR_NUMBER",
               "branch_name": $BRANCH_NAME,
               "action": "${{ github.event.action }}",
-              "sha": "${{ github.event.pull_request.head.sha }}",
+              "sha": "$PR_SHA",
               "pr_title": $PR_TITLE,
-              "pr_url": "${{ github.event.pull_request.html_url }}"
+              "pr_url": "$PR_URL"
             }
           }
           EOF
 
       - name: Log trigger details
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
+          PR_SHA: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || steps.pr-details.outputs.head_sha }}
         run: |
           echo "Triggered IntelliJ Plugin integration test for:"
-          echo "  PR #${{ github.event.number }}"
+          echo "  PR #$PR_NUMBER"
+          echo "  Trigger: ${{ github.event_name }}"
           echo "  Action: ${{ github.event.action }}"
-          echo "  SHA: ${{ github.event.pull_request.head.sha }}"
+          echo "  SHA: $PR_SHA"


### PR DESCRIPTION
## Problem

The JetBrains integration test workflow triggers on every push to a PR (`synchronize` event), and the JetBrains side posts a comment with the test results. This means every PR gets littered with bot comments - one for each commit pushed.

## Solution

Change the trigger conditions so the workflow only runs:
1. When a PR is opened or reopened (not on every subsequent push)
2. When someone manually requests it by commenting `/test-jetbrains`

This gives us the best of both worlds: automatic testing on new PRs, plus the ability to re-run tests on demand after making changes.

## Why the extra complexity

The simple part is changing the trigger and adding an `if` condition. The complex part is that `issue_comment` events don't have the same context as `pull_request_target` events.

When triggered by `pull_request_target`, we have access to:
- `github.head_ref` (branch name)
- `github.event.pull_request.head.sha`
- `github.event.pull_request.title`
- `github.event.pull_request.html_url`

When triggered by `issue_comment`, we only get:
- `github.event.issue.number`
- `github.event.comment.body`

The payload we send to the JetBrains repo needs all those PR details (branch name, SHA, title, URL). So I added a step that fetches the missing PR details via the GitHub API when the workflow is triggered by a comment.

## Changes

1. Removed `synchronize` from `pull_request_target` types
2. Added `issue_comment` trigger
3. Added `pull-requests: read` permission (needed for gh api call)
4. Added conditional step to fetch PR details when triggered via comment
5. Updated all the env vars to use the right source depending on trigger type

## Testing

To test the `/test-jetbrains` command:
1. Open a PR
2. Comment `/test-jetbrains` on the PR
3. Verify the workflow triggers and sends the correct payload to JetBrains
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> The PR modifies the JetBrains workflow to reduce comment spam by changing triggers and adding a manual comment-based trigger.
> 
>   - **Behavior**:
>     - Workflow now triggers on `pull_request_target` for `opened` and `reopened` events, and on `issue_comment` for `/test-jetbrains` command.
>     - Removed `synchronize` event from triggers to reduce comment spam.
>   - **Permissions**:
>     - Added `pull-requests: read` permission for GitHub API calls.
>   - **Workflow Steps**:
>     - Added step to fetch PR details via GitHub API when triggered by `issue_comment`.
>     - Updated environment variables to use correct sources based on trigger type.
>   - **Misc**:
>     - Updated concurrency group to handle both PR and issue numbers.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 0a85bcb5e0a3764a34d6ac0c0eb8041cdec23998. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->