### PR TITLE
chore: switch background element now has a 3:1 contrast ration with thumb an…

### DIFF
--- a/.changeset/tricky-brooms-jump.md
+++ b/.changeset/tricky-brooms-jump.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Updated switch component to adhere to 3:1 contrast accessibility standard for both light and dark vscode themes

--- a/webview-ui/src/components/ui/switch.tsx
+++ b/webview-ui/src/components/ui/switch.tsx
@@ -9,7 +9,7 @@ const Switch = React.forwardRef<
 >(({ className, ...props }, ref) => (
 	<SwitchPrimitives.Root
 		className={cn(
-			"peer inline-flex h-3 w-6 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-background focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-button-background/60 data-[state=unchecked]:bg-input-foreground/50",
+			"peer inline-flex h-3 w-6 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-background focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-button-background/60 data-[state=unchecked]:bg-[#8B8B8B]",
 			className,
 		)}
 		{...props}


### PR DESCRIPTION
### Related Issue

**Issue:**N/A

### Description

- What problem does this PR solve?

Toggled off switch component was not meeting 3:1 contrast standards for accessibility

- Why were these changes introduced and what purpose do they serve?

These changes minimally adjust the component colors to meet contrast standards for both the default light and dark mode of vscode

### Test Procedure
In both the default light and dark modes of vscode:

-  Opened the rules modal to access switch elements of cline.
- For a toggled off rule, checked the color of the rule component background, switch background, and switch thumb
- Verified that the contrast ratio (through this [site](https://webaim.org/resources/contrastchecker/)) was at least 3:1 between the rule component background and switch background, as well as switch background and switch thumb.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [x] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Before:

<img width="256" height="22" alt="image" src="https://github.com/user-attachments/assets/c7fc4fdf-d98c-4ff2-bf8b-a43afbef1d9f" />

<img width="255" height="18" alt="image" src="https://github.com/user-attachments/assets/3dbfe85a-8b72-462d-8f80-90d677972982" />


After:

<img width="256" height="19" alt="image" src="https://github.com/user-attachments/assets/a0dd64cd-5446-4a62-b5fc-1f490a79f2ce" />


<img width="261" height="20" alt="image" src="https://github.com/user-attachments/assets/137f2b4a-7c98-480b-877c-798cb19004ff" />





### Additional Notes
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `switch.tsx` to ensure 3:1 contrast ratio for accessibility in VSCode light and dark modes.
> 
>   - **Accessibility**:
>     - Updated `switch.tsx` to meet 3:1 contrast ratio for accessibility.
>     - Changed `data-[state=unchecked]:bg-input-foreground/50` to `data-[state=unchecked]:bg-[#8B8B8B]` for better contrast.
>   - **Misc**:
>     - Added changeset `tricky-brooms-jump.md` to document the update.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for e65fe845ee0adee618ac3ec9e3ccc4608dfaac24. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->