### PR TITLE
Init Sync Worker when applying remote config

### DIFF
--- a/src/core/storage/remote-config/utils.ts
+++ b/src/core/storage/remote-config/utils.ts
@@ -2,6 +2,7 @@ import { synchronizeRemoteRuleToggles } from "@core/context/instructions/user-in
 import { RemoteConfig } from "@shared/remote-config/schema"
 import { GlobalStateAndSettings, RemoteConfigFields } from "@shared/storage/state-keys"
 import { AuthService } from "@/services/auth/AuthService"
+import { getDistinctId } from "@/services/logging/distinctId"
 import { Logger } from "@/services/logging/Logger"
 import { getTelemetryService, telemetryService } from "@/services/telemetry"
 import { OpenTelemetryClientProvider } from "@/services/telemetry/providers/opentelemetry/OpenTelemetryClientProvider"
@@ -9,6 +10,7 @@ import { OpenTelemetryTelemetryProvider } from "@/services/telemetry/providers/o
 import { type TelemetryService } from "@/services/telemetry/TelemetryService"
 import { ApiProvider } from "@/shared/api"
 import { isOpenTelemetryConfigValid, remoteConfigToOtelConfig } from "@/shared/services/config/otel-config"
+import { syncWorker } from "@/shared/services/worker/sync"
 import { ensureSettingsDirectoryExists } from "../disk"
 import { StateManager } from "../StateManager"
 import { syncRemoteMcpServersToSettings } from "./syncRemoteMcpServers"
@@ -232,6 +234,19 @@ async function applyRemoteOTELConfig(transformed: Partial<RemoteConfigFields>, t
 	}
 }
 
+async function applyRemoteSyncQueueConfig(transformed: Partial<RemoteConfigFields>) {
+	try {
+		const blobStoreConfig = transformed.blobStoreConfig
+		if (!blobStoreConfig) {
+			return
+		}
+
+		syncWorker().init({ ...blobStoreConfig, userDistinctId: getDistinctId() })
+	} catch (err) {
+		console.error("[REMOTE CONFIG DEBUG] Failed to apply remote sync queue config", err)
+	}
+}
+
 export function clearRemoteConfig() {
 	try {
 		const stateManager = StateManager.get()
@@ -300,6 +315,8 @@ export async function applyRemoteConfig(
 	if (previousRemoteMCPServers !== undefined) {
 		stateManager.setRemoteConfigField("previousRemoteMCPServers", previousRemoteMCPServers)
 	}
+
+	applyRemoteSyncQueueConfig(transformed)
 
 	// Sync remote MCP servers to settings file (AFTER cache is populated, so sync can read previous state)
 	if (remoteConfig.remoteMCPServers !== undefined) {


### PR DESCRIPTION
### Description

When remote config changes, we need to initiate the sync worker

### Test Procedure

Tested locally

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `applyRemoteSyncQueueConfig()` to initialize sync worker on remote config change in `utils.ts`.
> 
>   - **Behavior**:
>     - Adds `applyRemoteSyncQueueConfig()` in `utils.ts` to initialize sync worker with new remote config.
>     - Calls `applyRemoteSyncQueueConfig()` in `applyRemoteConfig()` to ensure sync worker is initialized on config change.
>   - **Functions**:
>     - `applyRemoteSyncQueueConfig()` initializes sync worker using `syncWorker().init()` with `blobStoreConfig` and `userDistinctId`.
>   - **Imports**:
>     - Adds `getDistinctId` and `syncWorker` imports in `utils.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 0dcd7d36cbdedba44a1918b0816560ac9067acd2. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->