### PR TITLE
fix: ensure document finalization in approval flow

### DIFF
--- a/.changeset/clean-shrimps-repeat.md
+++ b/.changeset/clean-shrimps-repeat.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+fix: finalize document content during approval flow

--- a/src/core/task/tools/utils/FileProviderOperations.ts
+++ b/src/core/task/tools/utils/FileProviderOperations.ts
@@ -33,7 +33,10 @@ export class FileProviderOperations {
 	async createFile(path: string, content: string, isFinal: boolean = true): Promise<FileOpsResult | undefined> {
 		this.provider.editType = "create"
 		await this.openFile(path)
-		await this.provider.update(content, isFinal)
+		// Always pass isFinal=true to update() to ensure proper document finalization
+		// (extends replacement range to full document, truncates trailing content).
+		// The isFinal parameter here only controls whether to save after the update.
+		await this.provider.update(content, true)
 
 		if (isFinal) {
 			return await this.saveChanges()
@@ -48,7 +51,10 @@ export class FileProviderOperations {
 	async modifyFile(path: string, content: string, isFinal: boolean = true): Promise<FileOpsResult | undefined> {
 		this.provider.editType = "modify"
 		await this.openFile(path)
-		await this.provider.update(content, isFinal)
+		// Always pass isFinal=true to update() to ensure proper document finalization
+		// (extends replacement range to full document, truncates trailing content).
+		// The isFinal parameter here only controls whether to save after the update.
+		await this.provider.update(content, true)
 
 		if (isFinal) {
 			return await this.saveChanges()
@@ -70,7 +76,8 @@ export class FileProviderOperations {
 			return undefined
 		} else {
 			// Update with empty content to show the file will be deleted
-			await this.provider.update("", isFinal)
+			// Always pass isFinal=true to update() to ensure proper document finalization
+			await this.provider.update("", true)
 			return undefined
 		}
 	}


### PR DESCRIPTION
### Related Issue

**Issue:** #8651

### Description

fix: ensure document finalization in approval flow

When file operations use the approval flow (isFinal=false), document content wasn't finalized before approval, causing duplication when shortening files. Always pass isFinal=true to update() so truncation happens correctly while keeping isFinal to control saving behavior only. Adds coverage for truncation behavior.

### Test Procedure

Use model model/gpt-5.2-codex 

- Disable auto-approve edits. Ask model to remove specific lines from a file. 
- Enable auto-approve edits. Ask model to remove specific lines from a file. 
- Again, for both, but add lines to a file.

- Repeat for cline/claude-sonnet-4.5 (uses replace_in_file instead of apply_patch)

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A (no UI changes).

### Additional Notes

None.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Ensure document finalization in approval flow by always passing `isFinal=true` to `update()` in `FileProviderOperations.ts`, with tests added for verification.
> 
>   - **Behavior**:
>     - Always pass `isFinal=true` to `update()` in `createFile()`, `modifyFile()`, and `deleteFile()` in `FileProviderOperations.ts` to ensure document finalization.
>     - `isFinal` now only controls whether to save after the update.
>   - **Tests**:
>     - Add tests in `DiffViewProvider.test.ts` to verify document finalization with `isFinal=true`.
>     - Tests cover large file handling, content reduction, and newline preservation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for b2f96078017fba2475984055074e0331bd585b47. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->