### PR TITLE
fix: prevent race condition in telemetry service initialization

### DIFF
--- a/src/services/telemetry/index.ts
+++ b/src/services/telemetry/index.ts
@@ -43,12 +43,20 @@ export async function getTelemetryService(): Promise<TelemetryService> {
 		return _initializationPromise
 	}
 
-	// Start initialization and store the promise to prevent concurrent initialization
+	// Start initialization and store the promise to prevent concurrent initialization.
+	// Ensure that on failure we reset the initialization promise so future calls can retry.
 	_initializationPromise = TelemetryService.create()
-	_telemetryServiceInstance = await _initializationPromise
-	_initializationPromise = null
+		.then((service) => {
+			_telemetryServiceInstance = service
+			_initializationPromise = null
+			return service
+		})
+		.catch((error) => {
+			_initializationPromise = null
+			throw error
+		})
 
-	return _telemetryServiceInstance
+	return _initializationPromise
 }
 
 /**


### PR DESCRIPTION
<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- For feature requests: Created a discussion in our Feature Requests discussions board https://github.com/cline/cline/discussions/categories/feature-requests and received approval from core maintainers before implementation
- For all changes: Link the associated issue/discussion in the "Related Issue" section below

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly without prior discussion.

Why this requirement?
We deeply appreciate all community contributions - they are essential to Cline's success! To ensure the best use of everyone's time and maintain project direction, we use our Feature Requests discussions board to gauge community interest and validate feature ideas before implementation begins. This helps us focus development efforts on features that will benefit the most users.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** #XXXX

### Description

<!-- 
Help reviewers understand your changes by making this PR readable and well-organized:

- What problem does this PR solve?
- Why were these changes introduced and what purpose do they serve?
- For larger changes, provide context about your approach and reasoning

Small PRs may need minimal description, but larger changes benefit from explaining where you're coming from. Much of this context can be in the linked issue above, so feel free to reference it rather than repeating everything here.
-->

Add promise tracking to prevent concurrent initialization of the telemetry service singleton. When multiple callers invoke getTelemetryService() simultaneously, they now share the same initialization promise instead of creating duplicate instances.

Changes:
- Add _initializationPromise to track ongoing initialization
- Refactor getTelemetryService() to check for and reuse in-flight initialization
- Update resetTelemetryService() to clear both instance and promise
- Ensure single initialization even with concurrent access

This resolves race conditions where parallel calls during startup could bypass the singleton pattern and create multiple TelemetryService instances.


### Test Procedure

<!-- 
Please walk us through your testing approach and thought process. This helps reviewers understand that you've thoroughly considered the impact of your changes:

- How did you test this change?
- What could potentially break and how did you verify it doesn't?
- What existing functionality might be affected and how did you check it still works?
- Why are you confident this is ready for merge?

We're not looking for exhaustive documentation - just evidence that you've thought through the implications of your changes and tested accordingly.
-->

Before: Check the output log and confirm the Telemetry was initialized twice

<img width="1583" height="147" alt="image" src="https://github.com/user-attachments/assets/0f43ae27-87dc-4eb9-9577-30dfecf3649f" />

After: Verify it only print once to confirm it wasn't initialized twice

<img width="1280" height="210" alt="image" src="https://github.com/user-attachments/assets/9a6f027c-7600-4062-8e35-ae57db1fdea2" />


### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Prevent race condition in telemetry service initialization by tracking initialization promise in `index.ts`.
> 
>   - **Behavior**:
>     - Add `_initializationPromise` to track ongoing initialization in `index.ts`.
>     - Refactor `getTelemetryService()` to check and reuse in-flight initialization promise.
>     - Update `resetTelemetryService()` to clear both instance and promise.
>   - **Concurrency**:
>     - Ensure single initialization of `TelemetryService` even with concurrent access.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 8fa8ee7b87d68600b556bc90e32221aae60b7048. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->