### PR TITLE
feat: Show early feedback when editing files

### DIFF
--- a/.changeset/feat-early-feedback-editing.md
+++ b/.changeset/feat-early-feedback-editing.md
@@ -1,0 +1,7 @@
+---
+"claude-dev": patch
+---
+
+feat: Show early feedback when editing files
+
+Display immediate visual feedback in the diff view when file edits begin, improving user experience by showing progress earlier instead of waiting for the first content chunk to arrive.


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

### Description

When the model generates large diffs (especially for notebooks), there was a long perceived delay between the model's thinking and the edit dialog appearing. The file path is available within milliseconds, but the UI waited for diff content to start streaming.

Now shows "Preparing to edit {filename}..." immediately when a complete file path is detected, giving users instant feedback that an edit is in progress.

### Test Procedure

- Ask Cline to edit a large file (especially a notebook)
- Verify that feedback appears immediately when the file path is detected
- Verify the normal edit flow continues to work correctly after

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A - UX improvement for perceived latency

### Additional Notes

This is a draft PR for early feedback on the approach.
