### PR TITLE
docs: improve PR creation skill to use --body-file flag

### DIFF
--- a/.cline/skills/create-pull-request/SKILL.md
+++ b/.cline/skills/create-pull-request/SKILL.md
@@ -147,14 +147,29 @@ When filling out the template:
 
 ### Create PR with gh CLI
 
+**Use a temporary file for the PR body** to avoid shell escaping issues, newline problems, and other command-line flakiness:
+
+1. Write the PR body to a temporary file:
+   ```
+   /tmp/pr-body.md
+   ```
+
+2. Create the PR using the file:
+   ```bash
+   gh pr create --title "PR_TITLE" --body-file /tmp/pr-body.md --base main
+   ```
+
+3. Clean up the temporary file:
+   ```bash
+   rm /tmp/pr-body.md
+   ```
+
+For draft PRs:
 ```bash
-gh pr create --title "PR_TITLE" --body "PR_BODY" --base main
+gh pr create --title "PR_TITLE" --body-file /tmp/pr-body.md --base main --draft
 ```
 
-Alternatively, create as draft if the user wants review before marking ready:
-```bash
-gh pr create --title "PR_TITLE" --body "PR_BODY" --base main --draft
-```
+**Why use a file?** Passing complex markdown with newlines, special characters, and checkboxes directly via `--body` is error-prone. The `--body-file` flag handles all content reliably.
 
 ## Post-Creation
 


### PR DESCRIPTION
### Related Issue

**Issue:** #8573

### Description

Improves the PR creation skill documentation to use `--body-file` instead of inline `--body` when creating PRs with `gh` CLI. This approach avoids shell escaping issues, newline problems, and command-line flakiness when dealing with complex markdown content like templates with checkboxes, multiple sections, and special characters.

The change was motivated by the work done in #8785, where creating PRs with complex bodies exposed the brittleness of the inline approach.

### Changes

- Replace inline `--body` examples with `--body-file` approach
- Add step-by-step instructions for writing to temp file, creating PR, and cleaning up
- Document why this approach is more reliable
- Update both regular and draft PR examples

### Test Procedure

- Review the updated skill documentation
- Verify the new approach is clearer and more robust

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [x] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A - documentation only

### Additional Notes

No changeset needed as this is an internal skill documentation update that doesn't affect user-facing features.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update documentation to recommend `--body-file` for `gh pr create` and make minor code improvements for error handling and performance.
> 
>   - **Documentation**:
>     - Update `SKILL.md` to recommend `--body-file` over `--body` for `gh pr create` to avoid shell escaping issues.
>     - Add instructions for using a temporary file for PR body.
>     - Explain benefits of using `--body-file` for complex markdown content.
>   - **Code Changes**:
>     - Fix typo in `index.ts` by changing "his" to "Cline's".
>     - Add throttling to `update()` in `DiffViewProvider.ts` to prevent performance issues during streaming.
>     - Modify `extractTextFromIPYNB()` in `extract-text.ts` to strip outputs for context size reduction.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for a2c09ddbedd60e90e7d8d81824fb020b60a808e0. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->