### PR TITLE
disable telemetry for self-hosted environments

### DIFF
--- a/.changeset/violet-parrots-tell.md
+++ b/.changeset/violet-parrots-tell.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Disable PostHog and build-time OpenTelemetry telemetry in self-hosted/on-premise mode. Enterprise customers running self-hosted deployments will no longer send any telemetry to Cline's collectors. Runtime environment OTEL and remote config OTEL remain available for enterprises to configure their own telemetry collection.

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -512,4 +512,31 @@ describe("ClineEndpoint configuration", () => {
 			}
 		})
 	})
+
+	describe("isSelfHosted() method", () => {
+		it("should return true when not initialized (safety fallback)", async () => {
+			// Reset singleton state - already done in beforeEach, not initialized
+			ClineEndpoint.isInitialized().should.be.false()
+			ClineEndpoint.isSelfHosted().should.be.true()
+		})
+
+		it("should return true when in self-hosted mode", async () => {
+			const config = {
+				appBaseUrl: "https://app.enterprise.com",
+				apiBaseUrl: "https://api.enterprise.com",
+				mcpBaseUrl: "https://mcp.enterprise.com",
+			}
+			await fs.writeFile(path.join(tempDir, ".cline", "endpoints.json"), JSON.stringify(config), "utf8")
+			await ClineEndpoint.initialize()
+
+			ClineEndpoint.isSelfHosted().should.be.true()
+		})
+
+		it("should return false when in normal mode (no endpoints.json)", async () => {
+			// No endpoints.json file exists
+			await ClineEndpoint.initialize()
+
+			ClineEndpoint.isSelfHosted().should.be.false()
+		})
+	})
 })

--- a/src/config.ts
+++ b/src/config.ts
@@ -75,6 +75,19 @@ class ClineEndpoint {
 	}
 
 	/**
+	 * Checks if Cline is running in self-hosted/on-premise mode.
+	 * @returns true if in selfHosted mode, or true if not initialized (safety fallback to prevent accidental external calls)
+	 */
+	public static isSelfHosted(): boolean {
+		// Safety fallback: if not initialized, treat as selfHosted
+		// to prevent accidental external service calls before configuration is loaded
+		if (!ClineEndpoint._initialized) {
+			return true
+		}
+		return ClineEndpoint.config.environment === Environment.selfHosted
+	}
+
+	/**
 	 * Returns the singleton instance.
 	 * @throws Error if not initialized
 	 */

--- a/src/services/telemetry/TelemetryProviderFactory.ts
+++ b/src/services/telemetry/TelemetryProviderFactory.ts
@@ -1,3 +1,4 @@
+import { ClineEndpoint } from "@/config"
 import {
 	getValidOpenTelemetryConfig,
 	getValidRuntimeOpenTelemetryConfig,
@@ -105,12 +106,15 @@ export class TelemetryProviderFactory {
 	public static getDefaultConfigs(): TelemetryProviderConfig[] {
 		const configs: TelemetryProviderConfig[] = []
 
-		if (isPostHogConfigValid(posthogConfig)) {
+		// Skip PostHog in selfHosted mode - enterprise customers should not send telemetry to PostHog
+		if (!ClineEndpoint.isSelfHosted() && isPostHogConfigValid(posthogConfig)) {
 			configs.push({ type: "posthog", ...posthogConfig })
 		}
 
+		// Skip build-time OTEL in selfHosted mode - enterprise customers should not send telemetry to Cline's collector
+		// Note: Runtime env OTEL and remote config OTEL are still allowed (user/org explicitly configured them)
 		const otelConfig = getValidOpenTelemetryConfig()
-		if (otelConfig) {
+		if (!ClineEndpoint.isSelfHosted() && otelConfig) {
 			configs.push({
 				type: "opentelemetry",
 				config: otelConfig,

--- a/src/services/telemetry/TelemetryService.test.ts
+++ b/src/services/telemetry/TelemetryService.test.ts
@@ -9,7 +9,9 @@
 
 import * as assert from "assert"
 import * as sinon from "sinon"
+import { ClineEndpoint } from "@/config"
 import { HostProvider } from "@/hosts/host-provider"
+import * as otelConfigModule from "@/shared/services/config/otel-config"
 import * as posthogConfigModule from "@/shared/services/config/posthog-config"
 import { setVscodeHostProviderMock } from "@/test/host-provider-test-utils"
 import { NoOpTelemetryProvider, TelemetryProviderFactory } from "./TelemetryProviderFactory"
@@ -260,6 +262,7 @@ describe("Telemetry system is abstracted and can easily switch between providers
 		it("should return default configurations", () => {
 			// Mock PostHog config validation to return true for this test
 			const isPostHogConfigValidStub = sinon.stub(posthogConfigModule, "isPostHogConfigValid").returns(true)
+			const isSelfHostedStub = sinon.stub(ClineEndpoint, "isSelfHosted").returns(false)
 
 			const defaultConfigs = TelemetryProviderFactory.getDefaultConfigs()
 
@@ -270,7 +273,127 @@ describe("Telemetry system is abstracted and can easily switch between providers
 				"Should include PostHog configuration",
 			)
 
-			// Restore the stub
+			// Restore the stubs
+			isPostHogConfigValidStub.restore()
+			isSelfHostedStub.restore()
+		})
+
+		it("should NOT include PostHog config when in selfHosted mode", () => {
+			// Stub ClineEndpoint.isSelfHosted() to return true (selfHosted mode)
+			const isSelfHostedStub = sinon.stub(ClineEndpoint, "isSelfHosted").returns(true)
+			// Even if PostHog config is valid, it should be skipped
+			const isPostHogConfigValidStub = sinon.stub(posthogConfigModule, "isPostHogConfigValid").returns(true)
+
+			const configs = TelemetryProviderFactory.getDefaultConfigs()
+
+			// Should NOT include PostHog when in selfHosted mode
+			const hasPosthog = configs.some((c) => c.type === "posthog")
+			assert.strictEqual(hasPosthog, false, "Should NOT include PostHog configuration in selfHosted mode")
+
+			// Restore the stubs
+			isSelfHostedStub.restore()
+			isPostHogConfigValidStub.restore()
+		})
+
+		it("should include PostHog config when NOT in selfHosted mode and config is valid", () => {
+			// Stub ClineEndpoint.isSelfHosted() to return false (normal mode)
+			const isSelfHostedStub = sinon.stub(ClineEndpoint, "isSelfHosted").returns(false)
+			const isPostHogConfigValidStub = sinon.stub(posthogConfigModule, "isPostHogConfigValid").returns(true)
+
+			const configs = TelemetryProviderFactory.getDefaultConfigs()
+
+			// Should include PostHog when NOT in selfHosted mode and config is valid
+			const hasPosthog = configs.some((c) => c.type === "posthog")
+			assert.strictEqual(hasPosthog, true, "Should include PostHog configuration when not in selfHosted mode")
+
+			// Restore the stubs
+			isSelfHostedStub.restore()
+			isPostHogConfigValidStub.restore()
+		})
+
+		it("should NOT include build-time OTEL config when in selfHosted mode", () => {
+			// Stub ClineEndpoint.isSelfHosted() to return true (selfHosted mode)
+			const isSelfHostedStub = sinon.stub(ClineEndpoint, "isSelfHosted").returns(true)
+			// Even if build-time OTEL config is valid, it should be skipped
+			const getValidOtelConfigStub = sinon.stub(otelConfigModule, "getValidOpenTelemetryConfig").returns({
+				enabled: true,
+				metricsExporter: "otlp",
+			})
+			// Disable runtime OTEL to isolate test
+			const getRuntimeOtelConfigStub = sinon.stub(otelConfigModule, "getValidRuntimeOpenTelemetryConfig").returns(null)
+			// Disable PostHog to isolate test
+			const isPostHogConfigValidStub = sinon.stub(posthogConfigModule, "isPostHogConfigValid").returns(false)
+
+			const configs = TelemetryProviderFactory.getDefaultConfigs()
+
+			// Should NOT include build-time OTEL when in selfHosted mode
+			const hasOtel = configs.some((c) => c.type === "opentelemetry")
+			assert.strictEqual(hasOtel, false, "Should NOT include build-time OTEL configuration in selfHosted mode")
+
+			// Restore the stubs
+			isSelfHostedStub.restore()
+			getValidOtelConfigStub.restore()
+			getRuntimeOtelConfigStub.restore()
+			isPostHogConfigValidStub.restore()
+		})
+
+		it("should include build-time OTEL config when NOT in selfHosted mode", () => {
+			// Stub ClineEndpoint.isSelfHosted() to return false (normal mode)
+			const isSelfHostedStub = sinon.stub(ClineEndpoint, "isSelfHosted").returns(false)
+			const getValidOtelConfigStub = sinon.stub(otelConfigModule, "getValidOpenTelemetryConfig").returns({
+				enabled: true,
+				metricsExporter: "otlp",
+			})
+			// Disable runtime OTEL to isolate test
+			const getRuntimeOtelConfigStub = sinon.stub(otelConfigModule, "getValidRuntimeOpenTelemetryConfig").returns(null)
+			// Disable PostHog to isolate test
+			const isPostHogConfigValidStub = sinon.stub(posthogConfigModule, "isPostHogConfigValid").returns(false)
+
+			const configs = TelemetryProviderFactory.getDefaultConfigs()
+
+			// Should include build-time OTEL when NOT in selfHosted mode
+			const hasOtel = configs.some((c) => c.type === "opentelemetry")
+			assert.strictEqual(hasOtel, true, "Should include build-time OTEL configuration when not in selfHosted mode")
+
+			// Restore the stubs
+			isSelfHostedStub.restore()
+			getValidOtelConfigStub.restore()
+			getRuntimeOtelConfigStub.restore()
+			isPostHogConfigValidStub.restore()
+		})
+
+		it("should STILL include runtime env OTEL config even in selfHosted mode", () => {
+			// Stub ClineEndpoint.isSelfHosted() to return true (selfHosted mode)
+			const isSelfHostedStub = sinon.stub(ClineEndpoint, "isSelfHosted").returns(true)
+			// Disable build-time OTEL
+			const getValidOtelConfigStub = sinon.stub(otelConfigModule, "getValidOpenTelemetryConfig").returns(null)
+			// Enable runtime OTEL (user explicitly configured it)
+			const getRuntimeOtelConfigStub = sinon.stub(otelConfigModule, "getValidRuntimeOpenTelemetryConfig").returns({
+				enabled: true,
+				metricsExporter: "otlp",
+				otlpEndpoint: "http://user-collector:4317",
+			})
+			// Disable PostHog to isolate test
+			const isPostHogConfigValidStub = sinon.stub(posthogConfigModule, "isPostHogConfigValid").returns(false)
+
+			const configs = TelemetryProviderFactory.getDefaultConfigs()
+
+			// Should STILL include runtime env OTEL even in selfHosted mode (user explicitly enabled it)
+			const hasOtel = configs.some((c) => c.type === "opentelemetry")
+			assert.strictEqual(hasOtel, true, "Should include runtime env OTEL configuration even in selfHosted mode")
+
+			// Verify it has bypassUserSettings: true
+			const otelConfig = configs.find((c) => c.type === "opentelemetry")
+			assert.strictEqual(
+				(otelConfig as any).bypassUserSettings,
+				true,
+				"Runtime env OTEL should have bypassUserSettings: true",
+			)
+
+			// Restore the stubs
+			isSelfHostedStub.restore()
+			getValidOtelConfigStub.restore()
+			getRuntimeOtelConfigStub.restore()
 			isPostHogConfigValidStub.restore()
 		})
 


### PR DESCRIPTION
# Disable Telemetry in Self-Hosted Mode

## Summary

This PR disables PostHog and build-time OpenTelemetry telemetry when Cline runs in self-hosted/on-premise mode (`~/.cline/endpoints.json` exists). Enterprise customers should not send any telemetry to Cline's collectors.

## Changes

### Core Implementation

**`src/config.ts`**
- Added `ClineEndpoint.isSelfHosted()` static method with safety fallback
- Returns `true` if not initialized (prevents accidental telemetry before config is loaded)
- Returns `true` if `~/.cline/endpoints.json` exists (selfHosted mode)

**`src/services/telemetry/TelemetryProviderFactory.ts`**
- Skip PostHog provider when `isSelfHosted()` returns `true`
- Skip build-time OTEL provider when `isSelfHosted()` returns `true`
- Runtime env OTEL (`CLINE_OTEL_TELEMETRY_ENABLED`) is still allowed (user explicitly enabled it)
- Remote config OTEL is still allowed (handled separately in `applyRemoteConfig()`)

### Tests

**`src/__tests__/config.test.ts`**
- Added `isSelfHosted()` method test suite:
  - Returns `true` when not initialized (safety fallback)
  - Returns `true` when in self-hosted mode
  - Returns `false` when in normal mode

**`src/services/telemetry/TelemetryService.test.ts`**
- Added PostHog selfHosted tests:
  - Should NOT include PostHog config when in selfHosted mode
  - Should include PostHog config when NOT in selfHosted mode
- Added OTEL selfHosted tests:
  - Should NOT include build-time OTEL config when in selfHosted mode
  - Should include build-time OTEL config when NOT in selfHosted mode
  - Should STILL include runtime env OTEL config even in selfHosted mode

### Changeset

**`.changeset/violet-parrots-tell.md`**
- Added patch changeset for this user-facing change

## Behavior Summary

| Provider | Normal Mode | Self-Hosted Mode |
|----------|-------------|------------------|
| PostHog | ✅ Enabled | ❌ Disabled |
| Build-time OTEL (Cline's collector) | ✅ Enabled | ❌ Disabled |
| Runtime env OTEL (`CLINE_OTEL_*`) | ✅ Enabled | ✅ Enabled |
| Remote config OTEL | ✅ Enabled | ✅ Enabled |
