### PR TITLE
fix: disable browser tool by default

### DIFF
--- a/src/shared/BrowserSettings.ts
+++ b/src/shared/BrowserSettings.ts
@@ -22,7 +22,7 @@ export const DEFAULT_BROWSER_SETTINGS: BrowserSettings = {
 	remoteBrowserHost: "http://localhost:9222",
 	chromeExecutablePath: "", // Changed from undefined to empty string
 	// chromeType: "chromium",
-	disableToolUse: false,
+	disableToolUse: true,
 	customArgs: "",
 }
 


### PR DESCRIPTION
### Related Issue

N/A - Small config change that doesn't require prior discussion.

### Description

Disables the browser tool by default. The browser tool can conflict with the new websearch tool, so having it off by default provides a better out-of-box experience. Users who want browser automation can still enable it in settings.

### Test Procedure

- Verified the default value change in `src/shared/BrowserSettings.ts`
- This only affects the default setting for new users/fresh installs
- Existing users who have explicitly set this setting will not be affected

### Type of Change

-   [x] Bug fix (non-breaking change which fixes an issue)

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A - No UI changes, just a default value change.

### Additional Notes

Single line change from `disableToolUse: false` to `disableToolUse: true`.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Change default `disableToolUse` to `true` in `src/shared/BrowserSettings.ts` to prevent conflicts with new websearch tool.
> 
>   - **Behavior**:
>     - Change default `disableToolUse` to `true` in `DEFAULT_BROWSER_SETTINGS` in `src/shared/BrowserSettings.ts`.
>     - Affects only new users or fresh installs; existing users' settings remain unchanged.
>   - **Rationale**:
>     - Prevents conflict with new websearch tool, improving out-of-box experience.
>   - **Misc**:
>     - Single line change from `disableToolUse: false` to `disableToolUse: true`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 817c2aefdabd025edf244999e80541bbf3243757. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->