### PR TITLE
Make the default bedrock model Sonnet 4.5

### DIFF
--- a/.changeset/silent-hounds-read.md
+++ b/.changeset/silent-hounds-read.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Make Sonnet 4.5 the default Amazon Bedrock model id

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -352,7 +352,7 @@ export const claudeCodeModels = {
 // AWS Bedrock
 // https://docs.aws.amazon.com/bedrock/latest/userguide/conversation-inference.html
 export type BedrockModelId = keyof typeof bedrockModels
-export const bedrockDefaultModelId: BedrockModelId = "anthropic.claude-sonnet-4-20250514-v1:0" // TODO: update to 4-5
+export const bedrockDefaultModelId: BedrockModelId = "anthropic.claude-sonnet-4-5-20250929-v1:0"
 export const bedrockModels = {
 	"anthropic.claude-sonnet-4-5-20250929-v1:0": {
 		maxTokens: 8192,


### PR DESCRIPTION
### Related Issue

**Issue:** NA, just an open TODO

### Description

Cleaning up this todo and Updating the default Bedrock model to Sonnet 4.5

### Test Procedure
- Confirmed Sonnet 4.5 is working

### Type of Change


-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ x I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots
- NA, just model change

### Additional Notes

Nope

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Updates the default Bedrock model to Sonnet 4.5 in `api.ts`.
> 
>   - **Behavior**:
>     - Updates `bedrockDefaultModelId` in `api.ts` to `anthropic.claude-sonnet-4-5-20250929-v1:0`.
>   - **Documentation**:
>     - Adds `.changeset/silent-hounds-read.md` to document the change as a patch for `claude-dev`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 91c7377c03fa8d9c223f8a3937f02bb8d0e2c50b. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->