### PR TITLE
fix: add null check when filtering tools by type in Responses API providers

### DIFF
--- a/proto/cline/state.proto
+++ b/proto/cline/state.proto
@@ -383,7 +383,7 @@ message UpdateTaskSettingsRequest {
 
 // Message for updating settings
 message UpdateSettingsRequest {
-  reserved 26;  // was hooks_enabled (removed - now always enabled on macOS/Linux)
+  reserved 26; // was hooks_enabled (removed - now always enabled on macOS/Linux)
 
   Metadata metadata = 1;
   optional ModelsApiConfiguration api_configuration = 2;

--- a/src/core/api/providers/oca.ts
+++ b/src/core/api/providers/oca.ts
@@ -313,7 +313,7 @@ export class OcaHandler implements ApiHandler {
 
 		// Convert ChatCompletion tools to Responses API format if provided
 		const responseTools = tools
-			?.filter((tool) => tool.type === "function")
+			?.filter((tool) => tool?.type === "function")
 			.map((tool: any) => ({
 				type: "function" as const,
 				name: tool.function.name,

--- a/src/core/api/providers/openai-codex.ts
+++ b/src/core/api/providers/openai-codex.ts
@@ -157,7 +157,7 @@ export class OpenAiCodexHandler implements ApiHandler {
 		// Pass through strict value from tool (MCP/custom tools have strict: false, built-in tools default to true)
 		if (tools && tools.length > 0) {
 			body.tools = tools
-				.filter((tool: any) => tool.type === "function")
+				.filter((tool: any) => tool?.type === "function")
 				.map((tool: any) => ({
 					type: "function",
 					name: tool.function.name,

--- a/src/core/api/providers/openai-native.ts
+++ b/src/core/api/providers/openai-native.ts
@@ -159,7 +159,7 @@ export class OpenAiNativeHandler implements ApiHandler {
 
 		// Convert ChatCompletion tools to Responses API format if provided
 		const responseTools = tools
-			?.filter((tool) => tool.type === "function")
+			?.filter((tool) => tool?.type === "function")
 			.map((tool: any) => ({
 				type: "function" as const,
 				name: tool.function.name,


### PR DESCRIPTION
### Related Issue

User reports of runtime errors with the OpenAI Codex provider (no GitHub issue, reported directly).

### Description

Users reported seeing this error when using the OpenAI Codex provider:

```json
{"message":"Cannot read properties of undefined (reading 'type')","modelId":"gpt-5.2-codex"}
```

#### Investigation

Traced through all `.type` accesses in the OpenAI Codex provider code path:

| Location | Code Pattern | Status |
|----------|-------------|--------|
| `openai-codex.ts:169` | `tool.type === "function"` | BUG - no null check |
| `openai-codex.ts:354+` | `event?.type === ...` | Safe (optional chaining) |
| `openai-codex.ts:412+` | `item.type === ...` | Safe (inside `if (item)` block) |
| `openai-codex.ts:427` | `content?.type === ...` | Safe (optional chaining) |

The bug was in the tools filtering code that runs before sending requests to the Responses API:

```ts
// Before (crashes if tools array contains undefined element)
tools.filter((tool: any) => tool.type === "function")

// After (safely handles undefined elements)
tools.filter((tool: any) => tool?.type === "function")
```

#### Root Cause

The `tools` array is built from multiple sources:
1. Built-in Cline tools (converted via `toolSpecFunctionDefinition`)
2. MCP server tools (converted via `mcpToolToClineToolSpec`)

While the conversion functions should always return valid tool objects, defensive coding is warranted here because:
- MCP tools come from external servers with varying implementations
- The tools array passes through several transformation layers
- A single undefined element crashes the entire request

#### Fix

Added optional chaining (`tool?.type`) to safely filter tools in all three providers that use the OpenAI Responses API format:

- `openai-codex.ts` - ChatGPT Plus/Pro subscription provider
- `openai-native.ts` - OpenAI API with Responses format  
- `oca.ts` - OpenAI-compatible API with Responses format

This is a minimal, defensive fix that prevents the crash regardless of how undefined elements might enter the array.

### Test Procedure

1. Verified the build compiles successfully with `npm run compile`
2. The fix is purely defensive - adds null safety without changing behavior for valid inputs
3. Undefined elements are now filtered out instead of crashing
4. All three affected providers have consistent null-safe filtering

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

### Pre-flight Checklist

- [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
- [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
- [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
- [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Additional Notes

This is a small defensive fix. The error was likely triggered by edge cases in MCP tool configurations or race conditions in the tool conversion pipeline. Rather than trying to find and fix every possible source of undefined elements, this fix ensures the filtering code handles them gracefully.

Compared the pattern to other providers - notably, the `openai-codex.ts` response processing code already follows the safer pattern of checking `if (item)` before accessing `item.type`, which is why only the tools filtering was affected.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds null checks in `oca.ts`, `openai-codex.ts`, and `openai-native.ts` to prevent crashes when filtering tools by type.
> 
>   - **Behavior**:
>     - Adds null check (`tool?.type`) in `oca.ts`, `openai-codex.ts`, and `openai-native.ts` to prevent crashes when filtering tools by type.
>     - Handles undefined elements in tools array gracefully, preventing runtime errors.
>   - **Misc**:
>     - Fixes a comment formatting issue in `state.proto`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 47fd1675eae4659e9b8f387f87a7c5be84979c1e. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->