### PR TITLE
fix: Community bug fixes - DeepSeek XML, decimal input parsing, and path containment

### DIFF
--- a/.changeset/community-bug-fixes-v2.md
+++ b/.changeset/community-bug-fixes-v2.md
@@ -1,0 +1,14 @@
+---
+"claude-dev": patch
+---
+
+fix: community-reported bug fixes
+
+Bug Fixes:
+- DeepSeek V3.2: Handle XML tool patterns in reasoning_content (fixes #8365)
+  - DeepSeek V3.2 sometimes emits tool calls in reasoning content using XML format
+  - Added containsXmlToolPattern() helper to detect these patterns
+  - Yield as text instead of reasoning when patterns detected to allow proper processing
+- Input Parsing: Add safeParseFloat/safeParseInt for decimal inputs (fixes #8129)
+  - Handle edge cases like ".25" or "0." that would previously crash with NaN
+  - Applied to Input Price, Output Price, and Temperature fields in OpenAI Compatible settings

--- a/.changeset/fix-path-containment.md
+++ b/.changeset/fix-path-containment.md
@@ -1,0 +1,13 @@
+---
+"claude-dev": patch
+---
+
+fix: use isLocatedInPath for proper path containment check
+
+Fixes #8761 - Path containment check uses string.includes() causing false positives
+
+The previous implementation used `absolutePath.includes(cwd)` which could incorrectly match
+paths like `/home/user/project-backup` when working in `/home/user/project`.
+
+Changed to use the existing `isLocatedInPath()` function which properly handles path boundaries
+using `path.relative()` to determine if a path is actually contained within another.

--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -95,7 +95,10 @@ export function getReadablePath(cwd: string, relPath?: string): string {
 	} else {
 		// show the relative path to the cwd
 		const normalizedRelPath = path.relative(cwd, absolutePath)
-		if (absolutePath.includes(cwd)) {
+		// Use isLocatedInPath for proper path containment check instead of string.includes()
+		// which can cause false positives (e.g., /project matching /project-backup)
+		// See: https://github.com/cline/cline/issues/8761
+		if (isLocatedInPath(cwd, absolutePath)) {
 			return normalizedRelPath.toPosix()
 		} else {
 			// we are outside the cwd, so show the absolute path (useful for when cline passes in '../../' for example)

--- a/webview-ui/src/components/settings/providers/OpenAICompatible.tsx
+++ b/webview-ui/src/components/settings/providers/OpenAICompatible.tsx
@@ -7,6 +7,7 @@ import { useCallback, useEffect, useRef, useState } from "react"
 import { Tooltip } from "@/components/ui/tooltip"
 import { useExtensionState } from "@/context/ExtensionStateContext"
 import { ModelsServiceClient } from "@/services/grpc-client"
+import { safeParseFloat } from "@/utils/validate"
 import { getAsVar, VSC_DESCRIPTION_FOREGROUND } from "@/utils/vscStyles"
 import { ApiKeyField } from "../common/ApiKeyField"
 import { BaseUrlField } from "../common/BaseUrlField"
@@ -334,7 +335,7 @@ export const OpenAICompatibleProvider = ({ showModelOptions, isPopup, currentMod
 							}
 							onChange={(value) => {
 								const modelInfo = openAiModelInfo ? openAiModelInfo : { ...openAiModelInfoSaneDefaults }
-								modelInfo.inputPrice = Number(value)
+								modelInfo.inputPrice = safeParseFloat(value, openAiModelInfoSaneDefaults.inputPrice ?? 0)
 								handleModeFieldChange(
 									{ plan: "planModeOpenAiModelInfo", act: "actModeOpenAiModelInfo" },
 									modelInfo,
@@ -353,7 +354,7 @@ export const OpenAICompatibleProvider = ({ showModelOptions, isPopup, currentMod
 							}
 							onChange={(value) => {
 								const modelInfo = openAiModelInfo ? openAiModelInfo : { ...openAiModelInfoSaneDefaults }
-								modelInfo.outputPrice = Number(value)
+								modelInfo.outputPrice = safeParseFloat(value, openAiModelInfoSaneDefaults.outputPrice ?? 0)
 								handleModeFieldChange(
 									{ plan: "planModeOpenAiModelInfo", act: "actModeOpenAiModelInfo" },
 									modelInfo,
@@ -382,7 +383,7 @@ export const OpenAICompatibleProvider = ({ showModelOptions, isPopup, currentMod
 										? openAiModelInfoSaneDefaults.temperature
 										: shouldPreserveFormat
 											? (value as any)
-											: parseFloat(value)
+											: safeParseFloat(value, openAiModelInfoSaneDefaults.temperature ?? 0)
 
 								handleModeFieldChange(
 									{ plan: "planModeOpenAiModelInfo", act: "actModeOpenAiModelInfo" },

--- a/webview-ui/src/utils/validate.ts
+++ b/webview-ui/src/utils/validate.ts
@@ -177,6 +177,43 @@ export function validateApiConfiguration(currentMode: Mode, apiConfiguration?: A
 	return undefined
 }
 
+/**
+ * Safely parse a float value, handling edge cases like ".25" or "0."
+ * @param value - The string value to parse
+ * @param defaultValue - Default value to return if parsing fails
+ * @returns The parsed number or the default value
+ */
+export function safeParseFloat(value: string | undefined | null, defaultValue = 0): number {
+	if (value === undefined || value === null || value === "") {
+		return defaultValue
+	}
+	// Handle cases like ".25" by prepending "0"
+	let normalizedValue = value.trim()
+	if (normalizedValue.startsWith(".")) {
+		normalizedValue = "0" + normalizedValue
+	}
+	// Handle cases like "25." by appending "0"
+	if (normalizedValue.endsWith(".")) {
+		normalizedValue = normalizedValue + "0"
+	}
+	const parsed = parseFloat(normalizedValue)
+	return isNaN(parsed) ? defaultValue : parsed
+}
+
+/**
+ * Safely parse an integer value
+ * @param value - The string value to parse
+ * @param defaultValue - Default value to return if parsing fails
+ * @returns The parsed integer or the default value
+ */
+export function safeParseInt(value: string | undefined | null, defaultValue = 0): number {
+	if (value === undefined || value === null || value === "") {
+		return defaultValue
+	}
+	const parsed = parseInt(value.trim(), 10)
+	return isNaN(parsed) ? defaultValue : parsed
+}
+
 export function validateModelId(
 	currentMode: Mode,
 	apiConfiguration?: ApiConfiguration,


### PR DESCRIPTION
## Summary
This PR fixes three community-reported bugs.

## Bug Fixes

### 1. DeepSeek V3.2 XML Tool Pattern Handling (#8365)
- **Problem**: DeepSeek V3.2 sometimes emits tool calls in \easoning_content\ using XML format, which can cause infinite loops
- **Solution**: Added \containsXmlToolPattern()\ helper to detect XML tool patterns and yield as text instead of reasoning when detected
- **Note**: This is complementary to #8390 which handles the 'speciale' variant - my fix handles XML patterns in reasoning_content

### 2. Input Parsing for Decimal Values (#8129)
- **Problem**: Entering decimal values like \.25\ in Input Price, Output Price, or Temperature fields crashes Cline with NaN
- **Solution**: Added \safeParseFloat()\ and \safeParseInt()\ utility functions that handle edge cases like \.25\ or \