### PR TITLE
feat: disable extended thinking by default

### DIFF
--- a/src/shared/storage/state-keys.ts
+++ b/src/shared/storage/state-keys.ts
@@ -1,6 +1,5 @@
 import { AutoApprovalSettings, DEFAULT_AUTO_APPROVAL_SETTINGS } from "@shared/AutoApprovalSettings"
 import {
-	ANTHROPIC_MIN_THINKING_BUDGET,
 	ApiProvider,
 	DEFAULT_API_PROVIDER,
 	LiteLLMModelInfo,
@@ -138,7 +137,7 @@ const API_HANDLER_SETTINGS_FIELDS = {
 
 	// Plan mode configurations
 	planModeApiModelId: { default: undefined as string | undefined },
-	planModeThinkingBudgetTokens: { default: ANTHROPIC_MIN_THINKING_BUDGET as number | undefined },
+	planModeThinkingBudgetTokens: { default: undefined as number | undefined },
 	geminiPlanModeThinkingLevel: { default: undefined as string | undefined },
 	planModeReasoningEffort: { default: undefined as string | undefined },
 	planModeVerbosity: { default: undefined as string | undefined },
@@ -180,7 +179,7 @@ const API_HANDLER_SETTINGS_FIELDS = {
 
 	// Act mode configurations
 	actModeApiModelId: { default: undefined as string | undefined },
-	actModeThinkingBudgetTokens: { default: ANTHROPIC_MIN_THINKING_BUDGET as number | undefined },
+	actModeThinkingBudgetTokens: { default: undefined as number | undefined },
 	geminiActModeThinkingLevel: { default: undefined as string | undefined },
 	actModeReasoningEffort: { default: undefined as string | undefined },
 	actModeVerbosity: { default: undefined as string | undefined },


### PR DESCRIPTION
### Related Issue

N/A - This is a minor configuration change that doesn't require prior discussion.

### Description

Disables extended thinking by default for new users by setting `planModeThinkingBudgetTokens` and `actModeThinkingBudgetTokens` defaults to `undefined` instead of `1024`.

With native tool calling enabled, reasoning is now handled server-side by the model. Extended thinking provides diminishing returns for most use cases since the model is already "thinking" through tool calls natively.

Users who want enhanced reasoning capabilities can still enable extended thinking in settings. This may improve performance for complex tasks, but comes at the cost of increased latency and higher token usage/cost.

### Test Procedure

- Verified that new users (without existing settings) will have thinking disabled by default
- Existing users with thinking enabled will retain their settings (this only affects defaults)
- Users can still enable thinking via the settings UI

### Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)

### Pre-flight Checklist

- [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
- [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
- [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
- [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A - No UI changes, only default configuration change.

### Additional Notes

This change only affects the default value for new users. Existing users who have thinking enabled will not be affected since their settings are persisted.