### PR TITLE
Fixes Cannot restore checkpoint more than once

### DIFF
--- a/webview-ui/src/components/common/CheckmarkControl.tsx
+++ b/webview-ui/src/components/common/CheckmarkControl.tsx
@@ -111,6 +111,7 @@ export const CheckmarkControl = ({ messageTs, isCheckpointCheckedOut }: Checkmar
 			)
 		} catch (err) {
 			console.error("Checkpoint restore task error:", err)
+		} finally {
 			setRestoreTaskDisabled(false)
 		}
 	}
@@ -127,6 +128,7 @@ export const CheckmarkControl = ({ messageTs, isCheckpointCheckedOut }: Checkmar
 			)
 		} catch (err) {
 			console.error("Checkpoint restore workspace error:", err)
+		} finally {
 			setRestoreWorkspaceDisabled(false)
 		}
 	}
@@ -143,6 +145,7 @@ export const CheckmarkControl = ({ messageTs, isCheckpointCheckedOut }: Checkmar
 			)
 		} catch (err) {
 			console.error("Checkpoint restore both error:", err)
+		} finally {
 			setRestoreBothDisabled(false)
 		}
 	}


### PR DESCRIPTION
### Related Issue

__Issue:__ #8866

### Description

This PR fixes a bug where checkpoint restore buttons would become permanently disabled after being clicked once, preventing users from restoring to the same checkpoint multiple times.

__Problem:__ When users clicked any of the three restore options ("Restore Files & Task", "Restore Files Only", or "Restore Task Only"), the corresponding button would be disabled and remain disabled for the duration of the task, even after the restore operation completed successfully.

__Solution:__ Added `finally` blocks to the three restore handler functions in `CheckmarkControl.tsx`:

- `handleRestoreTask()`
- `handleRestoreWorkspace()`
- `handleRestoreBoth()`

Previously, these functions only reset the disabled state in the `catch` block on error. Now, the `finally` block ensures the disabled state is always reset after the operation completes, whether successful or not.

### Test Procedure

__Testing approach:__

1. Created a task with multiple checkpoints
2. Clicked "Restore Files & Task" on a checkpoint → Verified button re-enabled after completion
3. Clicked the same button again on the same checkpoint → Verified it worked a second time
4. Tested "Restore Files Only" button → Verified it re-enabled after completion
5. Tested "Restore Task Only" button → Verified it re-enabled after completion
6. Tested switching between different restore types on the same checkpoint → All worked correctly

__What could break:__

- The disabled state could interfere with concurrent operations, but the existing debounce logic prevents this
- The `onRelinquishControl` cleanup could conflict, but it operates independently and provides redundant safety

__Confidence:__ The fix follows React async error handling best practices using `try-catch-finally` pattern. The change is minimal (3 lines added), focused, and maintains all existing functionality including error handling and loading states.

### Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ♻️ Refactor Changes
- [ ] 💅 Cosmetic Changes
- [ ] 📚 Documentation update
- [ ] 🏃 Workflow Changes

### Pre-flight Checklist

- [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
- [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
- [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
- [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots


https://github.com/user-attachments/assets/6810e765-c30c-42bd-989b-fecc187fb96f



### Additional Notes

The fix is minimal and surgical - only 3 lines of code changed (added `finally` blocks). All existing error handling, loading states, and user feedback mechanisms remain intact. The change makes the restore functionality work as users would naturally expect.
