### PR TITLE
fix: apply_patch tool now works with OCA provider's gpt5 model ID

### DIFF
--- a/.changeset/fix-apply-patch-oca-model-id.md
+++ b/.changeset/fix-apply-patch-oca-model-id.md
@@ -1,0 +1,7 @@
+---
+"claude-dev": patch
+---
+
+fix: apply_patch tool now works with OCA provider's gpt5 model ID format
+
+The apply_patch tool's contextRequirements was filtering out models that didn't include "gpt-5" (with hyphen) in their model ID. OCA uses "oca/gpt5" (no hyphen), causing apply_patch to be unavailable and forcing the model to fall back to bash for file edits. Now uses isGPT5ModelFamily() for consistent model detection.

--- a/src/core/prompts/system-prompt/tools/apply_patch.ts
+++ b/src/core/prompts/system-prompt/tools/apply_patch.ts
@@ -1,5 +1,6 @@
 import { ModelFamily } from "@/shared/prompts"
 import { ClineDefaultTool } from "@/shared/tools"
+import { isGPT5ModelFamily } from "@/utils/model-utils"
 import type { ClineToolSpec } from "../spec"
 import { TASK_PROGRESS_PARAMETER } from "../types"
 
@@ -80,7 +81,7 @@ const NATIVE_GPT_5: ClineToolSpec = {
 	id: ClineDefaultTool.APPLY_PATCH,
 	name: "apply_patch",
 	description: APPLY_PATCH_TOOL_DESC,
-	contextRequirements: (context) => context.providerInfo.model.id.includes("gpt-5"),
+	contextRequirements: (context) => isGPT5ModelFamily(context.providerInfo.model.id),
 	parameters: [
 		{
 			name: "input",

--- a/src/utils/__tests__/model-utils.test.ts
+++ b/src/utils/__tests__/model-utils.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from "mocha"
 import "should"
-import { isClaude4PlusModelFamily, shouldSkipReasoningForModel } from "../model-utils"
+import { isClaude4PlusModelFamily, isGPT5ModelFamily, shouldSkipReasoningForModel } from "../model-utils"
 
 describe("shouldSkipReasoningForModel", () => {
 	it("should return true for grok-4 models", () => {
@@ -53,5 +53,32 @@ describe("isClaude4PlusModelFamily", () => {
 		isClaude4PlusModelFamily("gpt-4").should.equal(false)
 		isClaude4PlusModelFamily("gemini-pro").should.equal(false)
 		isClaude4PlusModelFamily("llama-3").should.equal(false)
+	})
+})
+
+describe("isGPT5ModelFamily", () => {
+	it("should return true for GPT-5 model IDs with hyphen", () => {
+		isGPT5ModelFamily("gpt-5").should.equal(true)
+		isGPT5ModelFamily("gpt-5.1").should.equal(true)
+		isGPT5ModelFamily("gpt-5.2-codex").should.equal(true)
+		isGPT5ModelFamily("openai/gpt-5").should.equal(true)
+	})
+
+	it("should return true for GPT-5 model IDs without hyphen (OCA format)", () => {
+		isGPT5ModelFamily("gpt5").should.equal(true)
+		isGPT5ModelFamily("oca/gpt5").should.equal(true)
+	})
+
+	it("should be case insensitive", () => {
+		isGPT5ModelFamily("GPT-5").should.equal(true)
+		isGPT5ModelFamily("GPT5").should.equal(true)
+		isGPT5ModelFamily("OCA/GPT5").should.equal(true)
+	})
+
+	it("should return false for non-GPT-5 models", () => {
+		isGPT5ModelFamily("gpt-4").should.equal(false)
+		isGPT5ModelFamily("gpt-4o").should.equal(false)
+		isGPT5ModelFamily("claude-3-sonnet").should.equal(false)
+		isGPT5ModelFamily("gemini-pro").should.equal(false)
 	})
 })


### PR DESCRIPTION
### Related Issue

**Issue:** #8819

### Description

The `apply_patch` tool's `contextRequirements` was filtering out models that didn't include `"gpt-5"` (with hyphen) in their model ID. OCA (Oracle Code Assistant) uses `"oca/gpt5"` (no hyphen), causing `apply_patch` to be unavailable. This forced the model to fall back to using `bash` for file edits instead.

**Root cause:** The `contextRequirements` check used `model.id.includes("gpt-5")` directly, while other parts of the codebase (like `isGPT5ModelFamily()`) properly handle both hyphenated (`gpt-5`) and non-hyphenated (`gpt5`) formats.

**Fix:** Updated `contextRequirements` to use `isGPT5ModelFamily()` for consistent model detection across the codebase.

### Test Procedure

- Added unit tests for `isGPT5ModelFamily` covering:
  - Hyphenated model IDs: `gpt-5`, `gpt-5.1`, `gpt-5.2-codex`
  - Non-hyphenated model IDs: `gpt5`, `oca/gpt5`
  - Case insensitivity: `GPT-5`, `GPT5`, `OCA/GPT5`
  - Non-matching IDs: `gpt-4`, `gpt-4o`, `claude-3-sonnet`
- All tests pass: `npm run test:unit -- --grep "isGPT5ModelFamily"`

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Additional Notes

This fix ensures OCA users can use the `apply_patch` tool instead of being forced to fall back to `bash` for file modifications.