### PR TITLE
feat: add migrate-to-cli URI handler for CLI settings import

### DIFF
--- a/src/services/uri/SharedUriHandler.ts
+++ b/src/services/uri/SharedUriHandler.ts
@@ -1,5 +1,6 @@
 import { WebviewProvider } from "@/core/webview"
 import { Logger } from "@/shared/services/Logger"
+import { migrateToCli } from "./migrateToCli"
 
 /**
  * Shared URI handler that processes both VSCode URI events and HTTP server callbacks
@@ -27,6 +28,11 @@ export class SharedUriHandler {
 					scheme: parsedUrl.protocol,
 				}),
 		)
+
+		// Routes that don't require a visible webview
+		if (path === "/migrate-to-cli") {
+			return migrateToCli()
+		}
 
 		const visibleWebview = WebviewProvider.getVisibleInstance()
 

--- a/src/services/uri/migrateToCli.ts
+++ b/src/services/uri/migrateToCli.ts
@@ -1,0 +1,68 @@
+/**
+ * Exports VS Code extension secrets and settings to the CLI's storage directory (~/.cline/data/)
+ * so the CLI can import them during onboarding without the user re-authenticating.
+ */
+
+import * as fs from "fs"
+import * as os from "os"
+import * as path from "path"
+import { StateManager } from "@/core/storage/StateManager"
+import { HostProvider } from "@/hosts/host-provider"
+import { ShowMessageType } from "@/shared/proto/index.host"
+import { Logger } from "@/shared/services/Logger"
+import { GlobalStateAndSettingKeys, SecretKeys } from "@/shared/storage/state-keys"
+
+const CLI_DATA_DIR = path.join(os.homedir(), ".cline", "data")
+
+export async function migrateToCli(): Promise<boolean> {
+	try {
+		const stateManager = StateManager.get()
+
+		// Read all secrets from StateManager cache
+		const secrets: Record<string, string> = {}
+		for (const key of SecretKeys) {
+			const value = stateManager.getSecretKey(key)
+			if (value) {
+				secrets[key] = value
+			}
+		}
+
+		// Read all globalState settings from StateManager cache
+		const globalState: Record<string, any> = {}
+		for (const key of GlobalStateAndSettingKeys) {
+			const value = stateManager.getGlobalStateKey(key as any)
+			if (value !== undefined) {
+				globalState[key] = value
+			}
+		}
+
+		// Ensure directory exists
+		fs.mkdirSync(CLI_DATA_DIR, { recursive: true })
+
+		// Write secrets with restricted permissions (owner read/write only)
+		const secretsPath = path.join(CLI_DATA_DIR, "secrets.json")
+		fs.writeFileSync(secretsPath, JSON.stringify(secrets, null, 2), { mode: 0o600 })
+
+		// Write globalState with restricted permissions
+		const globalStatePath = path.join(CLI_DATA_DIR, "globalState.json")
+		fs.writeFileSync(globalStatePath, JSON.stringify(globalState, null, 2), { mode: 0o600 })
+
+		Logger.info(
+			`[migrateToCli] Exported ${Object.keys(secrets).length} secrets and ${Object.keys(globalState).length} settings to ${CLI_DATA_DIR}`,
+		)
+
+		HostProvider.window.showMessage({
+			type: ShowMessageType.INFORMATION,
+			message: "Cline CLI setup complete. You can return to your terminal.",
+		})
+
+		return true
+	} catch (error) {
+		Logger.error("[migrateToCli] Failed to export state for CLI:", error)
+		HostProvider.window.showMessage({
+			type: ShowMessageType.ERROR,
+			message: "Failed to export settings to Cline CLI. Check the output log for details.",
+		})
+		return false
+	}
+}


### PR DESCRIPTION
### Related Issue

This is groundwork for the CLI onboarding migration feature. No existing issue -- this is part of the CLI initiative on the `saoudrizwan/cli` branch.

### Description

Adds a `/migrate-to-cli` URI handler to the VS Code extension that exports all user secrets and settings to `~/.cline/data/` so the Cline CLI can import them during first-run onboarding.

The vision: when a user installs the Cline CLI and already has the VS Code extension configured with API keys and settings, the CLI detects this (by checking `~/.vscode/extensions/saoudrizwan.claude-dev-*/` on disk -- no macOS TCC permission prompts since it's a dotfile directory), and offers an "Import from VS Code" option in the onboarding menu. Selecting it opens `vscode://saoudrizwan.claude-dev/migrate-to-cli` which triggers this handler. The extension reads everything from its StateManager caches and writes it to the CLI's storage directory. The CLI polls for the file to appear, picks it up, and the user is fully authenticated without re-entering any API keys. Same flow works for Cursor (`cursor://saoudrizwan.claude-dev/migrate-to-cli`) and VS Code Insiders (`vscode-insiders://`).

This PR ships the extension-side piece first so it's in production by the time the CLI-side changes land in a follow-up PR on `saoudrizwan/cli`.

What the handler does:
- Reads all secret keys (API keys, tokens, account IDs) from `StateManager.getSecretKey()`
- Reads all globalState settings (provider config, model IDs, user preferences) from `StateManager.getGlobalStateKey()`
- Writes `~/.cline/data/secrets.json` and `~/.cline/data/globalState.json` with `0o600` permissions (owner read/write only, matching the CLI's existing security model in `vscode-context-utils.ts`)
- Shows a VS Code notification telling the user to return to their terminal

The route is handled before the webview existence check in `SharedUriHandler` since it doesn't need a visible Cline panel -- it only needs StateManager (singleton, initialized at extension activation) and HostProvider (for the notification). This means it works even if the user hasn't opened the Cline sidebar.

### Test Procedure

- Build extension, configure an API key
- Run `code --open-url "vscode://saoudrizwan.claude-dev/migrate-to-cli"` from terminal
- Verify `~/.cline/data/secrets.json` is created with the configured API keys
- Verify `~/.cline/data/globalState.json` is created with settings
- Verify VS Code shows "Cline CLI setup complete" notification
- Verify file permissions are 0o600 (`stat -f '%Lp' ~/.cline/data/secrets.json` should show `600`)
- Verify existing URI routes (openrouter, auth, task, etc.) still work as before
- Type checks pass (`npx tsc --noEmit`)
- Biome checks pass on changed files

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Additional Notes

The CLI-side follow-up will add:
- Detection of VS Code/Cursor/Insiders extensions via `~/.vscode/extensions/` directory checks
- "Import from VS Code" / "Import from Cursor" menu items in `AuthView.tsx`
- A polling flow in `ImportView.tsx` that opens the URI, waits for the migration files, and confirms success
- Timeout handling (30s) with graceful fallback to manual auth