### PR TITLE
fix: ensure exactly one newline at end of files in FileEditProvider

### DIFF
--- a/.changeset/fix-file-ending-newlines-7cdb0d17.md
+++ b/.changeset/fix-file-ending-newlines-7cdb0d17.md
@@ -1,0 +1,13 @@
+---"claude-dev": patch---
+fix: ensure exactly one newline at end of files in FileEditProvider
+
+Fixes inconsistent file formatting by normalizing trailing newlines to exactly one per file during save operations. This addresses issue #8610 where Cline was removing or not adding blank lines at the end of files.
+
+Behavior:
+- Ensures exactly one newline at end of all files after code changes
+- Handles empty files, single/multi-line content, and existing newlines
+- Normalizes multiple trailing newlines to exactly one
+
+Misc:
+- Modified FileEditProvider.saveDocument() to enforce consistent newline behavior
+- Maintains JetBrains plugin compatibility and existing functionality

--- a/src/integrations/editor/FileEditProvider.ts
+++ b/src/integrations/editor/FileEditProvider.ts
@@ -110,6 +110,10 @@ export class FileEditProvider extends DiffViewProvider {
 		}
 
 		try {
+			// Ensure there is exactly one newline at the end of the file
+			// This ensures consistent file formatting and prevents issues with some tools
+			this.documentContent = this.processContentForSaving(this.documentContent)
+
 			// Write the content to the file using fs
 			await fs.writeFile(this.absolutePath, this.documentContent, { encoding: this.fileEncoding as BufferEncoding })
 			return true
@@ -117,6 +121,17 @@ export class FileEditProvider extends DiffViewProvider {
 			Logger.error(`Failed to save document to ${this.absolutePath}:`, error)
 			return false
 		}
+	}
+
+	private processContentForSaving(content: string): string {
+		// Remove any trailing newlines and add exactly one
+		// This handles cases where there might be 0, 1, or multiple trailing newlines
+		let processedContent = content.trimEnd()
+		if (processedContent.length > 0) {
+			// Only add newline if the content is not empty
+			processedContent += "\n"
+		}
+		return processedContent
 	}
 
 	protected async closeAllDiffViews(): Promise<void> {


### PR DESCRIPTION
<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- For feature requests: Created a discussion in our Feature Requests discussions board https://github.com/cline/cline/discussions/categories/feature-requests and received approval from core maintainers before implementation
- For all changes: Link the associated issue/discussion in the "Related Issue" section below

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly without prior discussion.

Why this requirement?
We deeply appreciate all community contributions - they are essential to Cline's success! To ensure the best use of everyone's time and maintain project direction, we use our Feature Requests discussions board to gauge community interest and validate feature ideas before implementation begins. This helps us focus development efforts on features that will benefit the most users.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** #8610 

### Description

Adds consistent newline handling to FileEditProvider.saveDocument() to ensure every file has exactly one trailing newline after code modifications. This addresses inconsistent file formatting while maintaining compatibility with JetBrains plugin line number validation.

Fixes file formatting consistency by normalizing trailing newlines to exactly one per file during save operations. Handles edge cases including empty files, single/multi-line content, and files with existing newlines.

<!-- 
Help reviewers understand your changes by making this PR readable and well-organized:

- What problem does this PR solve?
- Why were these changes introduced and what purpose do they serve?
- For larger changes, provide context about your approach and reasoning

Small PRs may need minimal description, but larger changes benefit from explaining where you're coming from. Much of this context can be in the linked issue above, so feel free to reference it rather than repeating everything here.
-->

### Test Procedure

- I ran the tests.
- I ran the extension and manually tested the code commands

<!--
Please walk us through your testing approach and thought process. This helps reviewers understand that you've thoroughly considered the impact of your changes:

- How did you test this change?
- What could potentially break and how did you verify it doesn't?
- What existing functionality might be affected and how did you check it still works?
- Why are you confident this is ready for merge?

We're not looking for exhaustive documentation - just evidence that you've thought through the implications of your changes and tested accordingly.
-->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->

- Behavior :

  - Ensures exactly one newline at end of all files after code changes
  - Handles empty files, single/multi-line content, and existing newlines
  - Normalizes multiple trailing newlines to exactly one

- Misc :

  - Modified FileEditProvider.saveDocument() to enforce consistent newline behavior
  - Maintains JetBrains plugin compatibility and existing functionality

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Ensures exactly one newline at end of files in `saveDocument()` in `FileEditProvider.ts`, handling various edge cases for consistent file formatting.
> 
>   - **Behavior**:
>     - Ensures exactly one newline at end of files in `saveDocument()` in `FileEditProvider.ts`.
>     - Handles empty files, single/multi-line content, and existing newlines.
>     - Normalizes multiple trailing newlines to exactly one.
>   - **Misc**:
>     - Modifies `saveDocument()` to enforce consistent newline behavior.
>     - Maintains JetBrains plugin compatibility and existing functionality.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 79d43ba8d98d76241caa0add0b3d2c82924d456b. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->