### PR TITLE
fix: preserve BOM (Byte Order Mark) for files that originally had it

### DIFF
--- a/.changeset/real-squids-clap.md
+++ b/.changeset/real-squids-clap.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+fix: preserve BOM (Byte Order Mark) for files that originally had it


### PR DESCRIPTION
## Summary

Fixes encoding issues for files that originally had a Byte Order Mark (BOM) by preserving it through the edit cycle.

## The Problem

The BOM was being stripped from files during the update() method but never added back when saving. This caused encoding issues for files that originally had a BOM (like some UTF-8 with BOM files that certain tools require).

## The Fix

1. **In update()**: Only strip BOM if the original file didn't have one
2. **In saveChanges()**: Add BOM back if the original file had it

## Testing

- Verified files with BOM retain their BOM after editing
- Verified files without BOM don't get BOM added
- No impact on normal file editing workflow

## Changeset

Added patch changeset for version bump.