### PR TITLE
fix: use accurate line count method in revertChanges()

### DIFF
--- a/.changeset/few-plums-drive.md
+++ b/.changeset/few-plums-drive.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+fix: use accurate line count method in revertChanges() instead of regex

--- a/src/integrations/editor/DiffViewProvider.ts
+++ b/src/integrations/editor/DiffViewProvider.ts
@@ -430,8 +430,7 @@ export abstract class DiffViewProvider {
 			// revert document
 			// Apply the edit and save, since contents shouldn't have changed this won't show in local history unless of
 			// course the user made changes and saved during the edit.
-			const contents = (await this.getDocumentText()) || ""
-			const lineCount = (contents.match(/\n/g) || []).length + 1
+			const lineCount = await this.getDocumentLineCount()
 			await this.replaceText(this.originalContent ?? "", { startLine: 0, endLine: lineCount }, undefined)
 
 			await this.saveDocument()


### PR DESCRIPTION
## Summary

Fixes inaccurate line count calculation in the revertChanges() method by using the proper abstract method instead of regex.

## The Problem

The revertChanges() method used regex-based line counting:
- Could be inaccurate with mixed line endings (CRLF vs LF)
- Could fail on empty documents
- Didn't leverage the existing getDocumentLineCount() abstraction

## The Fix

Changed from regex to the abstract getDocumentLineCount() method which provides the actual document line count from the editor implementation.

Before:
const contents = (await this.getDocumentText()) || ''
const lineCount = (contents.match(/\n/g) || []).length + 1

After:
const lineCount = await this.getDocumentLineCount()

## Testing

- Verified revert works correctly with different line ending styles
- Works correctly with empty documents
- No breaking changes

## Changeset

Added patch changeset for version bump.