### PR TITLE
fix: add missing await in scrollToFirstDiff()

### DIFF
--- a/.changeset/shy-carpets-rest.md
+++ b/.changeset/shy-carpets-rest.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+fix: add missing await in scrollToFirstDiff() to ensure scroll completes

--- a/src/integrations/editor/DiffViewProvider.ts
+++ b/src/integrations/editor/DiffViewProvider.ts
@@ -456,7 +456,7 @@ export abstract class DiffViewProvider {
 		for (const part of diffs) {
 			if (part.added || part.removed) {
 				// Found the first diff, scroll to it
-				this.scrollEditorToLine(lineCount)
+				await this.scrollEditorToLine(lineCount)
 				return
 			}
 			if (!part.removed) {


### PR DESCRIPTION
## Summary

Adds a missing await keyword in the scrollToFirstDiff() method to ensure the scroll operation completes before the function returns.

## The Problem

The scrollEditorToLine() call was missing await:

this.scrollEditorToLine(lineCount)

This could potentially cause the scroll operation to not complete before the function returned, leading to timing issues.

## The Fix

Added await to ensure proper async behavior:

await this.scrollEditorToLine(lineCount)

## Testing

- Verified scroll behavior works correctly
- No breaking changes

## Changeset

Added patch changeset for version bump.