### PR TITLE
fix: use isLocatedInPath() for path containment check

### DIFF
--- a/.changeset/shaggy-wombats-rule.md
+++ b/.changeset/shaggy-wombats-rule.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+fix: use isLocatedInPath() instead of string.includes() for path containment check to prevent false positives

--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -95,7 +95,7 @@ export function getReadablePath(cwd: string, relPath?: string): string {
 	} else {
 		// show the relative path to the cwd
 		const normalizedRelPath = path.relative(cwd, absolutePath)
-		if (absolutePath.includes(cwd)) {
+		if (isLocatedInPath(cwd, absolutePath)) {
 			return normalizedRelPath.toPosix()
 		} else {
 			// we are outside the cwd, so show the absolute path (useful for when cline passes in '../../' for example)


### PR DESCRIPTION
## Summary

Fixes #8761 - Path containment check uses string.includes() causing false positives.

## The Problem

When working in a project directory that shares a prefix with another directory (e.g., \/home/user/project\ and \/home/user/project-backup\), Cline incorrectly identifies file locations because the code uses \string.includes()\ for path containment checks.

**Root cause** in \src/utils/path.ts:98\:
\\\	ypescript
if (absolutePath.includes(cwd)) {  // BUG: /home/user/project matches /home/user/project-backup
\\\

## The Fix

Replaced \string.includes()\ with the existing \isLocatedInPath()\ function which properly handles path boundaries using \path.relative()\:

\\\	ypescript
if (isLocatedInPath(cwd, absolutePath)) {
\\\

The \isLocatedInPath()\ function:
1. Resolves both paths to absolute paths
2. Uses \path.relative()\ to compute the relationship
3. Checks if the relative path starts with \'..'\ (meaning it's outside)
4. Handles cross-drive scenarios on Windows

## Testing

- \/home/user/project\ no longer incorrectly matches \/home/user/project-backup\
- Normal path containment checks continue to work correctly
- Cross-platform compatible (Windows, macOS, Linux)

## Changeset

Added patch changeset for version bump.