### PR TITLE
fix: restore keyboard focus indicators on buttons

### DIFF
--- a/.changeset/cruel-teams-cover.md
+++ b/.changeset/cruel-teams-cover.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+fix: restore keyboard focus indicators on VSCode buttons for accessibility

--- a/webview-ui/src/main.css
+++ b/webview-ui/src/main.css
@@ -2,8 +2,8 @@ textarea:focus {
 	outline: 1.5px solid var(--vscode-focusBorder, #007fd4);
 }
 
-vscode-button::part(control):focus {
-	outline: none;
+vscode-button::part(control):focus-visible {
+	outline: 1.5px solid var(--vscode-focusBorder, #007fd4);
 }
 
 /*


### PR DESCRIPTION
## Summary
Restores keyboard focus indicators on buttons that were accidentally removed during the Tailwind v4 upgrade.

## Problem
The CSS rule \scode-button::part(control):focus { outline: none; }\ was removing focus outlines from all buttons, making it impossible for keyboard users to see which button is focused. This is a WCAG 2.4.7 violation.

## Solution
Changed the selector from \:focus\ to \:focus-visible\ and added a proper outline:
- Uses VS Code's \--vscode-focusBorder\ color variable for consistency
- Only shows focus ring for keyboard navigation, not mouse clicks
- Maintains clean appearance while restoring accessibility

## Testing
- Verified focus indicators appear when tabbing through buttons
- Confirmed mouse clicks don't show unnecessary focus rings

Fixes #8675