### PR TITLE
fix: wrap file mentions with spaces in quotes

### DIFF
--- a/.changeset/small-lights-doubt.md
+++ b/.changeset/small-lights-doubt.md
@@ -1,0 +1,9 @@
+---
+"claude-dev": patch
+---
+
+fix: wrap file mentions with spaces in quotes
+
+Fixes #7789 - When using "Add to Cline" on files with spaces in their paths,
+the generated mention text is now properly wrapped in quotes so it can be
+parsed correctly.

--- a/src/core/mentions/index.ts
+++ b/src/core/mentions/index.ts
@@ -49,11 +49,17 @@ export async function openMention(mention?: string): Promise<void> {
 
 export async function getFileMentionFromPath(filePath: string) {
 	const cwd = await getCwd()
+	let basePath: string
 	if (!cwd) {
-		return "@/" + filePath
+		basePath = filePath
+	} else {
+		basePath = path.relative(cwd, filePath)
 	}
-	const relativePath = path.relative(cwd, filePath)
-	return "@/" + relativePath
+	// Wrap in quotes if path contains spaces (for proper parsing)
+	if (basePath.includes(" ")) {
+		return `@"/${basePath}"`
+	}
+	return "@/" + basePath
 }
 
 export async function parseMentions(


### PR DESCRIPTION
## Summary
Fixes the "Add to Cline" feature to properly handle files with spaces in their paths.

## Problem
When using "Add to Cline" on files with spaces in their paths (e.g. `My Documents/file.txt`), the generated mention `@/My Documents/file.txt` cannot be parsed correctly because the parser stops at the space.

## Solution
Modified `getFileMentionFromPath()` to wrap paths containing spaces in quotes:
- Paths without spaces: `@/path/to/file.txt` (unchanged)
- Paths with spaces: `@"/path with spaces/file.txt"`

This matches the existing quote syntax for file mentions.

Fixes #7789
