### PR TITLE
fix: add exit code validation for terminal commands

### DIFF
--- a/.changeset/common-seals-wave.md
+++ b/.changeset/common-seals-wave.md
@@ -1,0 +1,16 @@
+---
+"claude-dev": patch
+---
+
+Added exit code validation for terminal commands.
+
+**What's new:**
+- Extract exit code from VSCode shell integration OSC 633;D sequence
+- Add `exitCode` field to `ITerminalProcess` interface
+- Add `exitCode` to `OrchestrationResult`
+- Update result messages to include exit code status (e.g., "Command executed successfully (exit code 0)" or "Command failed with exit code 1")
+
+**Why:**
+Commands now report their exit code in the result message, helping to identify failed commands even when they produce no error output. This is particularly useful for build scripts and other commands where a non-zero exit code indicates failure.
+
+Fixes #7590

--- a/src/hosts/vscode/terminal/VscodeTerminalProcess.test.ts
+++ b/src/hosts/vscode/terminal/VscodeTerminalProcess.test.ts
@@ -443,4 +443,126 @@ describe("TerminalProcess (Integration Tests)", () => {
 		;(emitSpy as sinon.SinonSpy).calledWith("line", "line 3 continued").should.be.true()
 		processAny.buffer.should.equal("")
 	})
+
+	describe("Exit code validation", () => {
+		it("should return undefined exit code initially", () => {
+			const exitCode = process.getExitCode()
+			;(exitCode === undefined).should.be.true()
+		})
+
+		it("should parse exit code 0 from OSC 633;D sequence", async () => {
+			const terminal = TerminalRegistry.createTerminal().terminal
+			createdTerminals.push(terminal)
+
+			// Mock shell integration with output containing exit code 0
+			const mockExecuteCommand = sandbox.stub().returns({
+				read: () => ({
+					async *[Symbol.asyncIterator]() {
+						yield "some-uuid]633;Ctest output]633;D;0]633;P;Cwd=/test\n"
+					},
+				}),
+			})
+
+			sandbox.stub(terminal, "shellIntegration").get(() => ({
+				executeCommand: mockExecuteCommand,
+			}))
+
+			await process.run(terminal, "echo test")
+
+			const exitCode = process.getExitCode()
+			exitCode!.should.equal(0)
+		})
+
+		it("should parse non-zero exit code from OSC 633;D sequence", async () => {
+			const terminal = TerminalRegistry.createTerminal().terminal
+			createdTerminals.push(terminal)
+
+			// Mock shell integration with output containing exit code 1
+			const mockExecuteCommand = sandbox.stub().returns({
+				read: () => ({
+					async *[Symbol.asyncIterator]() {
+						yield "some-uuid]633;Cerror: command not found]633;D;1]633;P;Cwd=/test\n"
+					},
+				}),
+			})
+
+			sandbox.stub(terminal, "shellIntegration").get(() => ({
+				executeCommand: mockExecuteCommand,
+			}))
+
+			await process.run(terminal, "invalid-command")
+
+			const exitCode = process.getExitCode()
+			exitCode!.should.equal(1)
+		})
+
+		it("should parse exit code 127 for command not found", async () => {
+			const terminal = TerminalRegistry.createTerminal().terminal
+			createdTerminals.push(terminal)
+
+			// Mock shell integration with output containing exit code 127
+			const mockExecuteCommand = sandbox.stub().returns({
+				read: () => ({
+					async *[Symbol.asyncIterator]() {
+						yield "uuid]633;Cbash: nonexistent: command not found]633;D;127\n"
+					},
+				}),
+			})
+
+			sandbox.stub(terminal, "shellIntegration").get(() => ({
+				executeCommand: mockExecuteCommand,
+			}))
+
+			await process.run(terminal, "nonexistent")
+
+			const exitCode = process.getExitCode()
+			exitCode!.should.equal(127)
+		})
+
+		it("should return undefined if no exit code sequence is present", async () => {
+			const terminal = TerminalRegistry.createTerminal().terminal
+			createdTerminals.push(terminal)
+
+			// Mock shell integration without exit code in output
+			const mockExecuteCommand = sandbox.stub().returns({
+				read: () => ({
+					async *[Symbol.asyncIterator]() {
+						yield "test output without exit code\n"
+					},
+				}),
+			})
+
+			sandbox.stub(terminal, "shellIntegration").get(() => ({
+				executeCommand: mockExecuteCommand,
+			}))
+
+			await process.run(terminal, "echo test")
+
+			const exitCode = process.getExitCode()
+			;(exitCode === undefined).should.be.true()
+		})
+
+		it("should handle multi-digit exit codes", async () => {
+			const terminal = TerminalRegistry.createTerminal().terminal
+			createdTerminals.push(terminal)
+
+			// Mock shell integration with exit code 255
+			const mockExecuteCommand = sandbox.stub().returns({
+				read: () => ({
+					async *[Symbol.asyncIterator]() {
+						yield "uuid]633;Cfatal error]633;D;255\n"
+					},
+				}),
+			})
+
+			sandbox.stub(terminal, "shellIntegration").get(() => ({
+				executeCommand: mockExecuteCommand,
+			}))
+
+			await process.run(terminal, "exit 255")
+
+			const exitCode = process.getExitCode()
+			exitCode!.should.equal(255)
+		})
+	})
 })

--- a/src/integrations/terminal/types.ts
+++ b/src/integrations/terminal/types.ts
@@ -66,6 +66,12 @@ export interface ITerminalProcess extends EventEmitter<TerminalProcessEvents> {
 	 * May be async to allow for graceful shutdown with SIGKILL fallback.
 	 */
 	terminate?(): void | Promise<void>
+
+	/**
+	 * Get the exit code of the command if available.
+	 * Returns undefined if the command hasn't completed or exit code wasn't captured.
+	 */
+	getExitCode?(): number | undefined
 }
 
 // =============================================================================
@@ -399,4 +405,6 @@ export interface OrchestrationResult {
 	outputLines: string[]
 	/** Path to log file if output was too large and written to file */
 	logFilePath?: string
+	/** Exit code of the command if available (0 = success, non-zero = failure) */
+	exitCode?: number
 }


### PR DESCRIPTION
## Summary
Adds exit code validation for terminal commands to help identify failed commands even when they don't produce error output on stderr.

## Changes
- **VscodeTerminalProcess**: Extract exit code from VSCode shell integration OSC 633;D sequence (e.g., ]633;D;0 for success)
- **ITerminalProcess interface**: Add optional getExitCode() method
- **OrchestrationResult**: Add xitCode field
- **CommandOrchestrator**: Capture exit code and include it in result messages

## Result Messages
- Success: `Command executed successfully (exit code 0).`
- Failure: `Command failed with exit code N.`
- Unknown: `Command executed.` (when exit code not available)

## Testing
The fix captures exit codes via VSCode's shell integration API, which reports the exit code in the terminal escape sequence.

Fixes #7590
