### PR TITLE
feat: add Arcee AI Trinity Large Preview to free models

### DIFF
--- a/src/shared/cline/onboarding.ts
+++ b/src/shared/cline/onboarding.ts
@@ -22,6 +22,22 @@ export const CLINE_ONBOARDING_MODELS: OnboardingModel[] = [
 		},
 	},
 	{
+		group: "free",
+		id: "arcee-ai/trinity-large-preview:free",
+		name: "Arcee AI: Trinity Large Preview",
+		score: 88,
+		latency: 2,
+		badge: "New",
+		info: {
+			contextWindow: 131_000,
+			supportsImages: false,
+			supportsPromptCache: false,
+			inputPrice: 0,
+			outputPrice: 0,
+			tiers: [],
+		},
+	},
+	{
 		group: "frontier",
 		id: "anthropic/claude-sonnet-4.5",
 		name: "Anthropic: Claude Sonnet 4.5",

--- a/webview-ui/src/components/settings/OpenRouterModelPicker.tsx
+++ b/webview-ui/src/components/settings/OpenRouterModelPicker.tsx
@@ -80,6 +80,11 @@ export const freeModels = [
 		description: "KwaiKAT's most advanced agentic coding model in the KAT-Coder series",
 		label: "FREE",
 	},
+	{
+		id: "arcee-ai/trinity-large-preview:free",
+		description: "Arcee AI's advanced large preview model in the Trinity series",
+		label: "FREE",
+	},
 ]
 
 const FREE_CLINE_MODELS = freeModels.map((m) => m.id)

--- a/webview-ui/src/components/settings/utils/providerUtils.ts
+++ b/webview-ui/src/components/settings/utils/providerUtils.ts
@@ -824,7 +824,7 @@ export function filterOpenRouterModelIds(modelIds: string[], provider: ApiProvid
 		// For Cline provider: exclude :free models, but keep Minimax models
 		return modelIds.filter((id) => {
 			// Keep all Minimax and devstral models regardless of :free suffix
-			if (id.toLowerCase().includes("minimax-m2")) {
+			if (id.toLowerCase().includes("minimax-m2") || id.toLowerCase().includes("arcee-ai/trinity-large")) {
 				return true
 			}
 			// Filter out other :free models


### PR DESCRIPTION

### Description
Add arcee-ai/trinity-large-preview:free as a new free model option:
- Add to onboarding models with 131k context window and score of 88
- Include in OpenRouterModelPicker free models list
- Update filter to preserve Trinity Large models like Minimax models





### Test Procedure

<!-- 
Please walk us through your testing approach and thought process. This helps reviewers understand that you've thoroughly considered the impact of your changes:

- How did you test this change?
- What could potentially break and how did you verify it doesn't?
- What existing functionality might be affected and how did you check it still works?
- Why are you confident this is ready for merge?

We're not looking for exhaustive documentation - just evidence that you've thought through the implications of your changes and tested accordingly.
-->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [X] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [ ] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `arcee-ai/trinity-large-preview:free` to free models and update filtering logic in Cline provider.
> 
>   - **Behavior**:
>     - Add `arcee-ai/trinity-large-preview:free` to `CLINE_ONBOARDING_MODELS` in `onboarding.ts` with a 131k context window and score of 88.
>     - Include `arcee-ai/trinity-large-preview:free` in `freeModels` in `OpenRouterModelPicker.tsx`.
>     - Update `filterOpenRouterModelIds()` in `providerUtils.ts` to preserve `arcee-ai/trinity-large` models for Cline provider.
>   - **Misc**:
>     - Add description and label for `arcee-ai/trinity-large-preview:free` in `OpenRouterModelPicker.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 33ae6bc8f42a2bcdff616684c1ca750392ce1ff1. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->