### PR TITLE
feat(cli): add Vercel AI Gateway and Cline API key provider support

### DIFF
--- a/.changeset/wise-mirrors-wave.md
+++ b/.changeset/wise-mirrors-wave.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Add Vercel AI Gateway and Cline API key support to CLI authentication

--- a/cli/pkg/cli/auth/auth_menu.go
+++ b/cli/pkg/cli/auth/auth_menu.go
@@ -3,6 +3,7 @@ package auth
 import (
 	"context"
 	"fmt"
+	"os"
 
 	"github.com/charmbracelet/huh"
 	"github.com/cline/cli/pkg/cli/display"
@@ -45,8 +46,15 @@ const (
 // RunAuthFlow is the entry point for the entire auth flow with instance management
 // It spawns a fresh instance for auth operations and cleans it up when done
 func RunAuthFlow(ctx context.Context, args []string) error {
-	// Spawn a fresh instance for auth operations
-	instanceInfo, err := global.Instances.StartNewInstance(ctx)
+	// Get current working directory to use as workspace
+	// This ensures auth operations use the same state database as the main cline command
+	cwd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("failed to get current directory: %w", err)
+	}
+
+	// Spawn a fresh instance for auth operations with the current workspace
+	instanceInfo, err := global.Instances.StartNewInstance(ctx, cwd)
 	if err != nil {
 		return fmt.Errorf("failed to start auth instance: %w", err)
 	}
@@ -187,9 +195,12 @@ func ShowAuthMenuWithStatus(isClineAuthenticated bool, hasOrganizations bool, cu
 	var title string
 	renderer := display.NewRenderer(global.Config.OutputFormat)
 
-	// Always show Cline authentication status
+	// Show authentication status - distinguish between OAuth and API key auth
 	if isClineAuthenticated {
 		title = fmt.Sprintf("Cline Account: %s Authenticated\n", renderer.Green("✓"))
+	} else if currentProvider == "Cline (Official)" {
+		// Using Cline provider with API key (not OAuth)
+		title = fmt.Sprintf("Cline API Key: %s Configured\n", renderer.Green("✓"))
 	} else {
 		title = fmt.Sprintf("Cline Account: %s Not authenticated\n", renderer.Red("✗"))
 	}

--- a/cli/pkg/cli/auth/byo_quick_setup.go
+++ b/cli/pkg/cli/auth/byo_quick_setup.go
@@ -157,7 +157,7 @@ func validateQuickSetupProvider(providerID string) (cline.ApiProvider, error) {
 		// Provider not found - provide helpful error message
 		supportedProviders := []string{
 			"openai-native", "openai", "anthropic", "gemini",
-			"openrouter", "xai", "cerebras", "ollama",
+			"openrouter", "xai", "cerebras", "ollama", "vercel-ai-gateway", "cline",
 		}
 		return cline.ApiProvider_ANTHROPIC, fmt.Errorf(
 			"invalid provider '%s'. Supported providers: %s",
@@ -168,15 +168,17 @@ func validateQuickSetupProvider(providerID string) (cline.ApiProvider, error) {
 
 	// Validate against supported quick setup providers
 	supportedProviders := map[cline.ApiProvider]bool{
-		cline.ApiProvider_OPENAI_NATIVE: true,
-		cline.ApiProvider_OPENAI:        true,
-		cline.ApiProvider_ANTHROPIC:     true,
-		cline.ApiProvider_GEMINI:        true,
-		cline.ApiProvider_OPENROUTER:    true,
-		cline.ApiProvider_XAI:           true,
-		cline.ApiProvider_CEREBRAS:      true,
-		cline.ApiProvider_OLLAMA:        true,
-		cline.ApiProvider_NOUSRESEARCH:  true,
+		cline.ApiProvider_OPENAI_NATIVE:     true,
+		cline.ApiProvider_OPENAI:            true,
+		cline.ApiProvider_ANTHROPIC:         true,
+		cline.ApiProvider_GEMINI:            true,
+		cline.ApiProvider_OPENROUTER:        true,
+		cline.ApiProvider_XAI:               true,
+		cline.ApiProvider_CEREBRAS:          true,
+		cline.ApiProvider_OLLAMA:            true,
+		cline.ApiProvider_NOUSRESEARCH:      true,
+		cline.ApiProvider_VERCEL_AI_GATEWAY: true,
+		cline.ApiProvider_CLINE:             true,
 	}
 
 	if !supportedProviders[provider] {

--- a/cli/pkg/cli/auth/providers_byo.go
+++ b/cli/pkg/cli/auth/providers_byo.go
@@ -14,9 +14,9 @@ type BYOProviderOption struct {
 }
 
 // GetBYOProviderList returns the list of supported BYO providers for CLI configuration.
-// This list excludes Cline provider which is handled separately.
 func GetBYOProviderList() []BYOProviderOption {
 	return []BYOProviderOption{
+		{Name: "Cline (API Key)", Provider: cline.ApiProvider_CLINE},
 		{Name: "Anthropic", Provider: cline.ApiProvider_ANTHROPIC},
 		{Name: "OpenAI Compatible", Provider: cline.ApiProvider_OPENAI},
 		{Name: "OpenAI (Official)", Provider: cline.ApiProvider_OPENAI_NATIVE},
@@ -28,6 +28,7 @@ func GetBYOProviderList() []BYOProviderOption {
 		{Name: "Cerebras", Provider: cline.ApiProvider_CEREBRAS},
 		{Name: "NousResearch", Provider: cline.ApiProvider_NOUSRESEARCH},
 		{Name: "Oracle Code Assist", Provider: cline.ApiProvider_OCA},
+		{Name: "Vercel AI Gateway", Provider: cline.ApiProvider_VERCEL_AI_GATEWAY},
 	}
 }
 
@@ -105,6 +106,10 @@ func GetBYOProviderPlaceholder(provider cline.ApiProvider) string {
 		return "e.g., Hermes-4-405B"
 	case cline.ApiProvider_OCA:
 		return "e.g., oca/llama4"
+	case cline.ApiProvider_VERCEL_AI_GATEWAY:
+		return "e.g., anthropic/claude-sonnet-4.5"
+	case cline.ApiProvider_CLINE:
+		return "e.g., anthropic/claude-sonnet-4.5"
 	default:
 		return "Enter model ID"
 	}

--- a/cli/pkg/cli/auth/update_api_configurations.go
+++ b/cli/pkg/cli/auth/update_api_configurations.go
@@ -174,6 +174,17 @@ func GetProviderFields(provider cline.ApiProvider) (ProviderFields, error) {
 			ActModeProviderSpecificModelIDField:  "actModeNousResearchModelId",
 		}, nil
 
+	case cline.ApiProvider_VERCEL_AI_GATEWAY:
+		return ProviderFields{
+			APIKeyField:                          "vercelAiGatewayApiKey",
+			PlanModeModelIDField:                 "planModeApiModelId",
+			ActModeModelIDField:                  "actModeApiModelId",
+			PlanModeModelInfoField:               "planModeVercelAiGatewayModelInfo",
+			ActModeModelInfoField:                "actModeVercelAiGatewayModelInfo",
+			PlanModeProviderSpecificModelIDField: "planModeVercelAiGatewayModelId",
+			ActModeProviderSpecificModelIDField:  "actModeVercelAiGatewayModelId",
+		}, nil
+
 	default:
 		return ProviderFields{}, fmt.Errorf("unsupported provider: %v", provider)
 	}
@@ -291,6 +302,8 @@ func setAPIKeyField(apiConfig *cline.ModelsApiConfiguration, fieldName string, v
 		apiConfig.HicapApiKey = value
 	case "nousResearchApiKey":
 		apiConfig.NousResearchApiKey = value
+	case "vercelAiGatewayApiKey":
+		apiConfig.VercelAiGatewayApiKey = value
 	}
 }
 
@@ -318,6 +331,9 @@ func setProviderSpecificModelID(apiConfig *cline.ModelsApiConfiguration, fieldNa
 	case "planModeNousResearchModelId":
 		apiConfig.PlanModeNousResearchModelId = value
 		apiConfig.ActModeNousResearchModelId = value
+	case "planModeVercelAiGatewayModelId":
+		apiConfig.PlanModeVercelAiGatewayModelId = value
+		apiConfig.ActModeVercelAiGatewayModelId = value
 	}
 }
 

--- a/proto/cline/state.proto
+++ b/proto/cline/state.proto
@@ -100,6 +100,7 @@ message Secrets {
   optional string oca_api_key = 41;
   optional string oca_refresh_token = 42;
   optional string mcp_o_auth_secrets = 43;
+  optional string cline_api_key = 44;
 }
 
 // NOTE: Add new fields under API_HANDLER_SETTINGS_FIELDS or USER_SETTINGS_FIELDS

--- a/src/shared/proto-conversions/models/api-configuration-conversion.ts
+++ b/src/shared/proto-conversions/models/api-configuration-conversion.ts
@@ -499,6 +499,7 @@ export function convertApiConfigurationToProto(config: ApiConfiguration): ProtoA
 		minimaxApiKey: config.minimaxApiKey,
 		minimaxApiLine: config.minimaxApiLine,
 		nousResearchApiKey: config.nousResearchApiKey,
+		clineApiKey: config.clineApiKey,
 		ocaMode: config.ocaMode,
 		aihubmixApiKey: config.aihubmixApiKey,
 		aihubmixBaseUrl: config.aihubmixBaseUrl,
@@ -679,6 +680,7 @@ export function convertProtoToApiConfiguration(protoConfig: ProtoApiConfiguratio
 		hicapApiKey: protoConfig.hicapApiKey,
 		hicapModelId: protoConfig.hicapModelId,
 		nousResearchApiKey: protoConfig.nousResearchApiKey,
+		clineApiKey: protoConfig.clineApiKey,
 
 		// Plan mode configurations
 		planModeApiProvider:

--- a/src/shared/storage/state-keys.ts
+++ b/src/shared/storage/state-keys.ts
@@ -298,6 +298,7 @@ const GLOBAL_STATE_AND_SETTINGS_FIELDS = { ...GLOBAL_STATE_FIELDS, ...SETTINGS_F
 // Secret keys used in Api Configuration
 const SECRETS_KEYS = [
 	"apiKey",
+	"clineApiKey",
 	"clineAccountId", // Cline Account ID for Firebase
 	"cline:clineAccountId",
 	"openRouterApiKey",


### PR DESCRIPTION
### Related Issue

**Issue:** #8909

### Description

This PR adds two new providers to CLI quick setup authentication, enabling headless authentication for CI/automation workflows where browser-based OAuth isn't possible:

#### New Providers

1. **Vercel AI Gateway** - A meta-provider that routes requests through Vercel's AI Gateway to multiple model providers (Claude, GPT, Gemini) using a single API key

2. **Cline API Key** - Direct API key authentication for Cline's official API, bypassing the OAuth browser flow

#### Usage

```bash
# Vercel AI Gateway
cline auth -p vercel-ai-gateway -k <key> -m anthropic/claude-sonnet-4.5

# Cline API key  
cline auth -p cline -k <key> -m anthropic/claude-sonnet-4.5
```

#### Bug Fix

This PR also fixes a bug where `cline auth` displayed incorrect provider information after configuration. The issue was that:
- The ephemeral auth instance was spawned without workspace context, causing it to use a different state database than the main `cline` command
- `GetProviderConfigurations()` was using `GetDefaultClient` instead of the auth instance from context

**Before:** After configuring Vercel AI Gateway, `cline auth` would show "Active Provider: OpenRouter" (stale data)
**After:** `cline auth` correctly shows the newly configured provider

### Test Procedure

**New Provider Testing:**
- Tested `cline auth -p vercel-ai-gateway` with real API key - configured successfully
- Tested `cline auth -p cline` with real API key - configured successfully
- Ran smoke tests (`01-create-file`, `02-edit-file`) with both providers - all passed
- Verified existing providers still work (pattern additions only)

**Bug Fix Verification:**
```bash
# Configure provider
$ cline auth -p vercel-ai-gateway -k $VERCEL_API_KEY -m google/gemini-2.5-pro
✓ Successfully configured Vercel AI Gateway provider

# Verify main command shows correct provider
$ cline
vercel-ai-gateway/google/gemini-2.5-pro  ✓

# Verify auth menu shows correct provider (this was broken before)
$ cline auth
Active Provider: Vercel AI Gateway  ✓
Active Model: google/gemini-2.5-pro  ✓
```

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A - CLI-only changes, no UI modifications

### Additional Notes

**Implementation approach:**
- New providers follow the exact same pattern as existing BYO providers (Anthropic, OpenRouter, etc.) - just adding entries to switch statements and maps
- The bug fix ensures the ephemeral auth instance uses the current working directory as workspace context, matching the main `cline` command behavior

**Files changed:**
- `auth_menu.go` - Pass workspace to ephemeral instance, improve status display
- `providers_list.go` - Use auth instance from context, add Cline API key detection
- `providers_byo.go` - Add Cline (API Key) to BYO provider list
- `byo_quick_setup.go` - Add new providers to quick setup validation
- `update_api_configurations.go` - Add field mappings for new providers