### PR TITLE
Revert "chore: extract storage migrations to extension layer"

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -1,4 +1,11 @@
 import * as vscode from "vscode"
+import {
+	cleanupMcpMarketplaceCatalogFromGlobalState,
+	migrateCustomInstructionsToGlobalRules,
+	migrateTaskHistoryToFile,
+	migrateWelcomeViewCompleted,
+	migrateWorkspaceToGlobalStorage,
+} from "./core/storage/state-migrations"
 import { WebviewProvider } from "./core/webview"
 import "./utils/path" // necessary to have access to String.prototype.toPosix
 
@@ -63,6 +70,21 @@ export async function initialize(context: vscode.ExtensionContext): Promise<Webv
 	// Setup the external services
 	await ErrorService.initialize()
 	await featureFlagsService.poll(null)
+
+	// Migrate custom instructions to global Cline rules (one-time cleanup)
+	await migrateCustomInstructionsToGlobalRules(context)
+
+	// Migrate welcomeViewCompleted setting based on existing API keys (one-time cleanup)
+	await migrateWelcomeViewCompleted(context)
+
+	// Migrate workspace storage values back to global storage (reverting previous migration)
+	await migrateWorkspaceToGlobalStorage(context)
+
+	// Ensure taskHistory.json exists and migrate legacy state (runs once)
+	await migrateTaskHistoryToFile(context)
+
+	// Clean up MCP marketplace catalog from global state (moved to disk cache)
+	await cleanupMcpMarketplaceCatalogFromGlobalState(context)
 
 	// Clean up orphaned file context warnings (startup cleanup)
 	await FileContextTracker.cleanupOrphanedWarnings(context)


### PR DESCRIPTION
Reverts cline/cline#8843

As it forces onboarding flow every time

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Revert storage migrations to be handled directly in `initialize()` in `common.ts` instead of an extension layer.
> 
>   - **Revert Storage Migrations**:
>     - Move migration functions (`migrateCustomInstructionsToGlobalRules`, `migrateWelcomeViewCompleted`, `migrateWorkspaceToGlobalStorage`, `migrateTaskHistoryToFile`, `cleanupMcpMarketplaceCatalogFromGlobalState`) back to `initialize()` in `common.ts`.
>     - Remove `performStorageMigrations()` from `extension.ts`.
>   - **Misc**:
>     - Remove import of migration functions from `extension.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 2a9be4972f4c942eda5b668b81629e03f9f08b45. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->