### PR TITLE
Fix OTEL endpoint modification and log level issues

### DIFF
--- a/src/services/telemetry/providers/opentelemetry/OpenTelemetryExporterFactory.ts
+++ b/src/services/telemetry/providers/opentelemetry/OpenTelemetryExporterFactory.ts
@@ -35,6 +35,10 @@ export function createOTLPLogExporter(
 ): LogRecordExporter | null {
 	try {
 		let exporter: any = null
+		const logsUrl = new URL(endpoint)
+		if (logsUrl.pathname === "/" || logsUrl.pathname === "") {
+			logsUrl.pathname = "/v1/logs"
+		}
 
 		switch (protocol) {
 			case "grpc": {
@@ -49,13 +53,11 @@ export function createOTLPLogExporter(
 				break
 			}
 			case "http/json": {
-				const logsUrl = endpoint.endsWith("/v1/logs") ? endpoint : `${endpoint}/v1/logs`
-				exporter = new OTLPLogExporterHTTP({ url: logsUrl, headers })
+				exporter = new OTLPLogExporterHTTP({ url: logsUrl.toString(), headers })
 				break
 			}
 			case "http/protobuf": {
-				const logsUrl = endpoint.endsWith("/v1/logs") ? endpoint : `${endpoint}/v1/logs`
-				exporter = new OTLPLogExporterProto({ url: logsUrl, headers })
+				exporter = new OTLPLogExporterProto({ url: logsUrl.toString(), headers })
 				break
 			}
 			default:
@@ -101,6 +103,11 @@ export function createOTLPMetricReader(
 	try {
 		let exporter: any = null
 
+		const metricsUrl = new URL(endpoint)
+		if (metricsUrl.pathname === "/" || metricsUrl.pathname === "") {
+			metricsUrl.pathname = "/v1/metrics"
+		}
+
 		switch (protocol) {
 			case "grpc": {
 				const grpcEndpoint = endpoint.replace(/^https?:\/\//, "")
@@ -114,13 +121,11 @@ export function createOTLPMetricReader(
 				break
 			}
 			case "http/json": {
-				const metricsUrl = endpoint.endsWith("/v1/metrics") ? endpoint : `${endpoint}/v1/metrics`
-				exporter = new OTLPMetricExporterHTTP({ url: metricsUrl, headers })
+				exporter = new OTLPMetricExporterHTTP({ url: metricsUrl.toString(), headers })
 				break
 			}
 			case "http/protobuf": {
-				const metricsUrl = endpoint.endsWith("/v1/metrics") ? endpoint : `${endpoint}/v1/metrics`
-				exporter = new OTLPMetricExporterProto({ url: metricsUrl, headers })
+				exporter = new OTLPMetricExporterProto({ url: metricsUrl.toString(), headers })
 				break
 			}
 			default:

--- a/src/services/telemetry/providers/opentelemetry/OpenTelemetryTelemetryProvider.ts
+++ b/src/services/telemetry/providers/opentelemetry/OpenTelemetryTelemetryProvider.ts
@@ -301,6 +301,10 @@ export class OpenTelemetryTelemetryProvider implements ITelemetryProvider {
 	 * Get the current telemetry level from VS Code settings
 	 */
 	private async getTelemetryLevel(): Promise<TelemetrySettings["level"]> {
+		if (this.bypassUserSettings) {
+			return "all"
+		}
+
 		const hostSettings = await HostProvider.env.getTelemetrySettings({})
 		if (hostSettings.isEnabled === Setting.DISABLED) {
 			return "off"


### PR DESCRIPTION
### Description

OTEL right now has two problems:
- When our customers configure a custom endpoint, we append `/v1/logs/` or `/v1/metrics` at the end
- When someone has telemetry logs off in their VSCode, we don't send logs to remotely configured OTEL

### Test Procedure


### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes OTEL endpoint appending and ensures logs are sent when telemetry is disabled in VSCode, with updated headers and endpoint handling.
> 
>   - **Behavior**:
>     - Fixes endpoint appending by ensuring `/v1/logs` and `/v1/metrics` are only added if not present in `OpenTelemetryExporterFactory.ts`.
>     - Ensures logs are sent to OTEL even if telemetry logs are disabled in VSCode by bypassing user settings in `OpenTelemetryTelemetryProvider.ts`.
>   - **Configuration**:
>     - Adds `otlpMetricsHeaders` and `otlpLogsHeaders` to `RemoteConfigSchema` in `schema.ts` and `OpenTelemetryClientConfig` in `otel-config.ts`.
>     - Updates `transformRemoteConfigToStateShape()` in `utils.ts` to handle new headers.
>   - **Providers**:
>     - Updates `OpenTelemetryClientProvider.ts` to use specific headers for metrics and logs.
>     - Modifies `createOTLPLogExporter()` and `createOTLPMetricReader()` in `OpenTelemetryExporterFactory.ts` to handle new endpoint logic.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for d465e0059f9a6a60347e2ce6f3e75bf5e3a522b1. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->