### PR TITLE
fix: prevent empty provider settings from forcing provider change

### DIFF
--- a/src/core/storage/remote-config/utils.ts
+++ b/src/core/storage/remote-config/utils.ts
@@ -107,7 +107,7 @@ export function transformRemoteConfigToStateShape(remoteConfig: RemoteConfig): P
 	// An empty object {} shouldn't force the provider, only allow it as an option.
 	// This prevents users from being forced to a provider when the admin only
 	// intended to enable it, not require it.
-	const hasProviderConfig = (settings: object | undefined): boolean =>
+	const hasProviderConfig = <T extends object>(settings: T | undefined): settings is T =>
 		settings !== undefined && Object.keys(settings).length > 0
 
 	// Map OpenAiCompatible provider settings

--- a/src/core/storage/remote-config/utils.ts
+++ b/src/core/storage/remote-config/utils.ts
@@ -103,9 +103,16 @@ export function transformRemoteConfigToStateShape(remoteConfig: RemoteConfig): P
 	// Map provider settings
 	const providers: ApiProvider[] = []
 
+	// Helper to check if a provider settings object has actual configuration.
+	// An empty object {} shouldn't force the provider, only allow it as an option.
+	// This prevents users from being forced to a provider when the admin only
+	// intended to enable it, not require it.
+	const hasProviderConfig = (settings: object | undefined): boolean =>
+		settings !== undefined && Object.keys(settings).length > 0
+
 	// Map OpenAiCompatible provider settings
 	const openAiSettings = remoteConfig.providerSettings?.OpenAiCompatible
-	if (openAiSettings) {
+	if (hasProviderConfig(openAiSettings)) {
 		transformed.planModeApiProvider = "openai"
 		transformed.actModeApiProvider = "openai"
 		providers.push("openai")
@@ -126,7 +133,7 @@ export function transformRemoteConfigToStateShape(remoteConfig: RemoteConfig): P
 
 	// Map AwsBedrock provider settings
 	const awsBedrockSettings = remoteConfig.providerSettings?.AwsBedrock
-	if (awsBedrockSettings) {
+	if (hasProviderConfig(awsBedrockSettings)) {
 		transformed.planModeApiProvider = "bedrock"
 		transformed.actModeApiProvider = "bedrock"
 		providers.push("bedrock")
@@ -149,7 +156,7 @@ export function transformRemoteConfigToStateShape(remoteConfig: RemoteConfig): P
 	}
 
 	const clineSettings = remoteConfig.providerSettings?.Cline
-	if (clineSettings) {
+	if (hasProviderConfig(clineSettings)) {
 		transformed.planModeApiProvider = "cline"
 		transformed.actModeApiProvider = "cline"
 		providers.push("cline")
@@ -157,7 +164,7 @@ export function transformRemoteConfigToStateShape(remoteConfig: RemoteConfig): P
 
 	// Map LiteLLM provider settings
 	const liteLlmSettings = remoteConfig.providerSettings?.LiteLLM
-	if (liteLlmSettings) {
+	if (hasProviderConfig(liteLlmSettings)) {
 		transformed.planModeApiProvider = "litellm"
 		transformed.actModeApiProvider = "litellm"
 		providers.push("litellm")
@@ -169,7 +176,7 @@ export function transformRemoteConfigToStateShape(remoteConfig: RemoteConfig): P
 
 	// Map Vertex provider settings
 	const vertexSettings = remoteConfig.providerSettings?.Vertex
-	if (vertexSettings) {
+	if (hasProviderConfig(vertexSettings)) {
 		transformed.planModeApiProvider = "vertex"
 		transformed.actModeApiProvider = "vertex"
 		providers.push("vertex")


### PR DESCRIPTION
### Related Issue

N/A - Internal bug discovered during testing

### Description

When a user is signed into Cline account and their organization's remote config has an empty provider settings object (e.g., `"providerSettings": {"AwsBedrock": {}}`), the user's provider is incorrectly forced to that provider (bedrock) even though there's no actual configuration.

#### User Experience

1. User signs into Cline on an org with rules
2. Admin changes rules on dashboard (no provider changes intended)
3. User opens CLI again
4. Provider unexpectedly changes from "cline" to "bedrock"

#### Root Cause Analysis

The bug is in `src/core/storage/remote-config/utils.ts` in the `transformRemoteConfigToStateShape` function.

The code at lines 121-125:

```typescript
const awsBedrockSettings = remoteConfig.providerSettings?.AwsBedrock
if (awsBedrockSettings) {
    transformed.planModeApiProvider = "bedrock"
    transformed.actModeApiProvider = "bedrock"
    providers.push("bedrock")
```

The condition `if (awsBedrockSettings)` is TRUE even when `AwsBedrock: {}` is an empty object because `{}` is truthy in JavaScript.

This causes:
1. `transformed.actModeApiProvider = "bedrock"` is set
2. `"bedrock"` is added to the `providers` array
3. `remoteConfiguredProviders = ["bedrock"]` is set

Then in `applyRemoteConfig` (lines 308-315):

```typescript
const apiConfiguration = stateManager.getApiConfiguration()
if (isProviderValid(apiConfiguration.actModeApiProvider, transformed)) {
    transformed.actModeApiProvider = apiConfiguration.actModeApiProvider
}
```

The `isProviderValid("cline", transformed)` function checks if "cline" is in `remoteConfiguredProviders` (which is `["bedrock"]`). Since it's not, it returns FALSE, and the user's "cline" provider is NOT preserved. Instead, "bedrock" from the transformation overwrites it.

#### Impact

Any organization that has an empty provider settings object will force ALL users in that org to use that provider, even if the admin only intended to "enable" it as an option, not force it.

#### The Fix

Added a helper function `hasProviderConfig` that checks if a provider settings object has actual configuration (non-empty) before treating it as configured. Empty objects are now ignored, allowing users to keep their preferred provider.

### Test Procedure

1. Create a test org with `providerSettings: {"AwsBedrock": {}}`
2. Sign into Cline account
3. Verify provider stays as "cline" when remote config is fetched
4. Verify that if `AwsBedrock` has actual settings (e.g., `{awsRegion: "us-east-1"}`), it properly sets the provider to bedrock

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

### Pre-flight Checklist

- [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
- [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
- [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
- [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Additional Notes

This bug was discovered during internal testing when an org admin accidentally had an empty provider settings object in their remote config. The fix ensures that empty objects don't trigger provider forcing behavior.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes bug in `transformRemoteConfigToStateShape` to prevent empty provider settings from forcing provider change by adding a configuration check.
> 
>   - **Behavior**:
>     - Fixes bug in `transformRemoteConfigToStateShape` in `utils.ts` where empty provider settings forced provider change.
>     - Adds `hasProviderConfig` function to check for non-empty provider settings before applying.
>   - **Functions**:
>     - Updates `transformRemoteConfigToStateShape` to use `hasProviderConfig` for `OpenAiCompatible`, `AwsBedrock`, `Cline`, `LiteLLM`, and `Vertex` settings.
>   - **Impact**:
>     - Prevents users from being forced to a provider when the admin only intended to enable it as an option.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for ffb5c69c954a9f0d6e6b58e5ba7c36f89cffa79a. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->