### PR TITLE
Add commit hash to PR review comments

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -44,6 +44,12 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Print HEAD commit
+        run: |
+          echo "HEAD is at: $(git rev-parse HEAD)"
+          echo "Short: $(git rev-parse --short HEAD)"
+          git log -1 --format="Commit: %H%nAuthor: %an <%ae>%nDate: %ad%nMessage: %s"
+
       - name: Get PR number
         id: pr
         run: |
@@ -229,7 +235,13 @@ jobs:
 
             After your investigation, post a single helpful comment that helps the author and gives maintainers context.
 
-            Start with a warm thank you for their contribution. Be conversational, not robotic.
+            Start by noting the commit hash you reviewed:
+            ```bash
+            git rev-parse --short HEAD
+            ```
+            Include this at the top of your comment: "Reviewed at commit: <short hash>"
+
+            Then thank them for their contribution. Be conversational, not robotic.
 
             Include what's relevant:
             - In-depth explanation of what the PR does - Be comprehensive. A maintainer should be able to read this section and fully understand the author's intent, why they made the changes, how they implemented it, and what files/systems are affected. Don't just summarize - explain.

--- a/.github/workflows/cline-pr-review.yml
+++ b/.github/workflows/cline-pr-review.yml
@@ -48,6 +48,12 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Print HEAD commit
+        run: |
+          echo "HEAD is at: $(git rev-parse HEAD)"
+          echo "Short: $(git rev-parse --short HEAD)"
+          git log -1 --format="Commit: %H%nAuthor: %an <%ae>%nDate: %ad%nMessage: %s"
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
@@ -269,7 +275,13 @@ jobs:
 
           After your investigation, post a single helpful comment that helps the author and gives maintainers context.
 
-          Start with a warm thank you for their contribution. Be conversational, not robotic.
+          Start by noting the commit hash you reviewed:
+          ```bash
+          git rev-parse --short HEAD
+          ```
+          Include this at the top of your comment: "Reviewed at commit: <short hash>"
+
+          Then thank them for their contribution. Be conversational, not robotic.
 
           Include what'\''s relevant:
           - In-depth explanation of what the PR does - Be comprehensive. A maintainer should be able to read this section and fully understand the author'\''s intent, why they made the changes, how they implemented it, and what files/systems are affected. Don'\''t just summarize - explain.


### PR DESCRIPTION
### Related Issue

**Issue:** N/A (small workflow improvement)

### Description

When the automated PR review runs, it's helpful to know which commit was reviewed. This change:
- Instructs the reviewer to include "Reviewed at commit: <hash>" at the top of its PR comment
- Also logs the HEAD commit info in the GitHub Actions output for debugging
thanks @candieduniverse for the suggestion!

### Test Procedure

- Verified the YAML syntax is valid
- The change is additive and won't affect existing review functionality

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [x] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A - workflow change only

### Additional Notes

No changeset needed as this is an internal workflow improvement, not a user-facing change.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds commit hash logging to PR review workflows for better traceability and debugging.
> 
>   - **Behavior**:
>     - Adds logging of HEAD commit details in `claude-pr-review.yml` and `cline-pr-review.yml` for debugging purposes.
>     - Instructs reviewers to include "Reviewed at commit: <short hash>" in PR comments.
>   - **Workflow**:
>     - Updates `claude-pr-review.yml` and `cline-pr-review.yml` to print commit hash using `git rev-parse` and `git log`.
>     - Modifies reviewer instructions to include commit hash in comments.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 72fc4ebbd28d3a52a603f0c7fd30a8d7f2e19ebf. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->