### PR TITLE
fix: always write files as UTF-8 to prevent emoji corruption

### DIFF
--- a/src/integrations/editor/FileEditProvider.ts
+++ b/src/integrations/editor/FileEditProvider.ts
@@ -110,8 +110,10 @@ export class FileEditProvider extends DiffViewProvider {
 		}
 
 		try {
-			// Write the content to the file using fs
-			await fs.writeFile(this.absolutePath, this.documentContent, { encoding: this.fileEncoding as BufferEncoding })
+			// Always use UTF-8 for writing - it's the modern standard and handles all characters
+			// including emojis. The detected fileEncoding was used for reading to preserve
+			// compatibility, but writing as UTF-8 ensures no character corruption.
+			await fs.writeFile(this.absolutePath, this.documentContent, { encoding: "utf8" })
 			return true
 		} catch (error) {
 			Logger.error(`Failed to save document to ${this.absolutePath}:`, error)


### PR DESCRIPTION
## Summary

When Cline edits a file and adds emojis (or other non-ASCII characters), they can get corrupted and appear as garbled text like `=Ý` instead of the intended emoji.

## Problem

`FileEditProvider` (used by CLI and non-VS Code contexts) was using `chardet` to detect the original file's encoding, then writing back with that same encoding. For simple files without special characters, `chardet` often detects `ascii`. When Cline then adds emojis to the file, writing with `encoding: 'ascii'` corrupts the multi-byte UTF-8 emoji characters.

Example of the corruption:
```
-                <div className="empty-icon">=Ý</div>
+                <div className="empty-icon">📝</div>
```

## Investigation

Traced the issue through:
1. `DiffViewProvider.open()` - reads file and detects encoding via `chardet`
2. `FileEditProvider.saveDocument()` - writes file using detected encoding
3. When detected encoding is `ascii` and content contains emojis, corruption occurs

The VS Code provider (`VscodeDiffViewProvider`) doesn't have this issue because it uses `document.save()` which handles encoding automatically.

## Fix

Always write files as UTF-8. This is the modern standard, backwards compatible with ASCII, and handles all characters including emojis. The detected encoding is still used for reading to ensure we can read legacy files correctly, but writing as UTF-8 ensures no character corruption.

## Test plan

- [ ] Edit a file that contains only ASCII characters, add an emoji, verify it saves correctly
- [ ] Edit a file that already has emojis, verify they're preserved
- [ ] Create a new file with emojis, verify they save correctly
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> `FileEditProvider.saveDocument()` now writes files as UTF-8 to prevent emoji corruption, while maintaining legacy file compatibility for reading.
> 
>   - **Behavior**:
>     - `FileEditProvider.saveDocument()` now always writes files using UTF-8 encoding to prevent emoji corruption.
>     - Detected encoding is still used for reading files to ensure compatibility with legacy files.
>   - **Problem**:
>     - Previously, files were written using detected encoding, which could be `ascii`, leading to corruption when emojis were added.
>   - **Misc**:
>     - Comments updated in `FileEditProvider.ts` to reflect the change in encoding strategy.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 07193166defeb3f96d6ec136ccf89486c711a06b. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->