### PR TITLE
fix: use max_completion_tokens for GPT-5 models in OpenAI compatible provider

### DIFF
--- a/.changeset/fix-gpt5-max-completion-tokens.md
+++ b/.changeset/fix-gpt5-max-completion-tokens.md
@@ -1,0 +1,9 @@
+---
+"claude-dev": patch
+---
+
+fix: use max_completion_tokens for GPT-5 models in OpenAI compatible provider
+
+GPT-5 and other reasoning models (o1, o3, o4) require the `max_completion_tokens` parameter instead of `max_tokens`. This fix conditionally uses the correct parameter based on whether the model is in the reasoning model family.
+
+Fixes #8912

--- a/src/core/api/providers/openai.ts
+++ b/src/core/api/providers/openai.ts
@@ -135,7 +135,8 @@ export class OpenAiHandler implements ApiHandler {
 			model: modelId,
 			messages: openAiMessages,
 			temperature,
-			max_tokens: maxTokens,
+			// GPT-5 and other reasoning models require max_completion_tokens instead of max_tokens
+			...(isReasoningModelFamily ? { max_completion_tokens: maxTokens } : { max_tokens: maxTokens }),
 			reasoning_effort: reasoningEffort,
 			stream: true,
 			stream_options: { include_usage: true },


### PR DESCRIPTION
## Summary
- GPT-5 and other reasoning models (o1, o3, o4) require the `max_completion_tokens` parameter instead of `max_tokens`
- This fix conditionally uses the correct parameter based on whether the model is in the reasoning model family (`isReasoningModelFamily`)
- The fix is minimal and targeted, only changing the parameter name for reasoning models

## Test plan
- [x] Run `npm run lint` - passes
- [x] Run `npm run test:unit` - all 853 tests pass
- [ ] Manual test with GPT-5 model on OpenAI compatible provider with max tokens set

Fixes #8912

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix parameter naming for reasoning models in `openai.ts` to use `max_completion_tokens` instead of `max_tokens`.
> 
>   - **Behavior**:
>     - In `openai.ts`, change parameter to `max_completion_tokens` for reasoning models (GPT-5, o1, o3, o4) instead of `max_tokens`.
>     - Conditional logic added to determine parameter based on `isReasoningModelFamily`.
>   - **Misc**:
>     - Add changeset file `fix-gpt5-max-completion-tokens.md` documenting the fix and linking to issue #8912.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 6817e9499fa3b893931b0b8c4d5a72d911e3c33f. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->