### PR TITLE
fix: use isLocatedInPath() instead of string.includes() for path containment check

### DIFF
--- a/.changeset/fix-path-containment-check.md
+++ b/.changeset/fix-path-containment-check.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Fix path containment check using string.includes() causing false positives

--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -95,7 +95,7 @@ export function getReadablePath(cwd: string, relPath?: string): string {
 	} else {
 		// show the relative path to the cwd
 		const normalizedRelPath = path.relative(cwd, absolutePath)
-		if (absolutePath.includes(cwd)) {
+		if (isLocatedInPath(cwd, absolutePath)) {
 			return normalizedRelPath.toPosix()
 		} else {
 			// we are outside the cwd, so show the absolute path (useful for when cline passes in '../../' for example)


### PR DESCRIPTION
## Summary
- Fixes #8761
- Replaced `absolutePath.includes(cwd)` with `isLocatedInPath(cwd, absolutePath)` in `getReadablePath()` function
- The existing `isLocatedInPath()` function properly handles path boundaries using `path.relative()`, avoiding false positives when paths share a prefix (e.g., `/home/user/project` incorrectly matching `/home/user/project-backup`)

## Test plan
- [x] Verified compilation passes (`npm run compile`)
- [x] Verified unit tests pass (`npm run test:unit`)
- [ ] Manual test: open workspace `/home/user/project-backup`, reference files should correctly show relative paths

🤖 Generated with [Claude Code](https://claude.ai/code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Replaces string-based path containment check with `isLocatedInPath()` in `getReadablePath()` to prevent false positives from shared path prefixes.
> 
>   - **Behavior**:
>     - Replaces `absolutePath.includes(cwd)` with `isLocatedInPath(cwd, absolutePath)` in `getReadablePath()` in `path.ts`.
>     - `isLocatedInPath()` uses `path.relative()` to handle path boundaries, preventing false positives with shared prefixes (e.g., `/home/user/project` vs `/home/user/project-backup`).
>   - **Misc**:
>     - Adds changeset file `fix-path-containment-check.md` to document the fix.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 6c34006d45dea11297582ebbbc0be34b23fa46e0. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->