### PR TITLE
fix: hide delete button for favorited history items

### DIFF
--- a/.changeset/fix-favorite-delete-button.md
+++ b/.changeset/fix-favorite-delete-button.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Fix delete button remaining visible for favorited history items

--- a/.changeset/fix-history-star-alignment.md
+++ b/.changeset/fix-history-star-alignment.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Fix Star button alignment in History for long prompts

--- a/.changeset/fix-path-containment-check.md
+++ b/.changeset/fix-path-containment-check.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Fix path containment check using string.includes() causing false positives

--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -95,7 +95,7 @@ export function getReadablePath(cwd: string, relPath?: string): string {
 	} else {
 		// show the relative path to the cwd
 		const normalizedRelPath = path.relative(cwd, absolutePath)
-		if (absolutePath.includes(cwd)) {
+		if (isLocatedInPath(cwd, absolutePath)) {
 			return normalizedRelPath.toPosix()
 		} else {
 			// we are outside the cwd, so show the absolute path (useful for when cline passes in '../../' for example)

--- a/webview-ui/src/components/history/HistoryViewItem.tsx
+++ b/webview-ui/src/components/history/HistoryViewItem.tsx
@@ -94,7 +94,7 @@ const HistoryViewItem = ({
 					e.stopPropagation()
 					handleShowTaskWithId(item.id)
 				}}>
-				<div className="flex items-center gap-2">
+				<div className="flex items-center gap-2 min-w-0">
 					<div className="line-clamp-1 overflow-hidden break-words whitespace-pre-wrap flex-1 min-w-0">
 						<span className="ph-no-capture">{item.task}</span>
 					</div>

--- a/webview-ui/src/components/history/HistoryViewItem.tsx
+++ b/webview-ui/src/components/history/HistoryViewItem.tsx
@@ -101,7 +101,10 @@ const HistoryViewItem = ({
 					<div className="flex gap-2 flex-shrink-0">
 						<Button
 							aria-label="Delete"
-							className="p-0 opacity-0 group-hover:opacity-100 transition-opacity"
+							className={cn("p-0 transition-opacity", {
+								"opacity-0 group-hover:opacity-100": !isFavoritedItem,
+								"opacity-0 pointer-events-none": isFavoritedItem,
+							})}
 							disabled={isFavoritedItem}
 							onClick={(e) => {
 								e.stopPropagation()


### PR DESCRIPTION
## Summary
- Fixes #8752
- The delete button was remaining visible and interactive on hover even when a history item was favorited
- Changed the button's className to conditionally apply hover styles only when the item is not favorited
- When an item is favorited, the delete button is now completely hidden with `opacity-0` and `pointer-events-none`

## Root cause
The original CSS `group-hover:opacity-100` was overriding the `disabled` state styles from the Button component. While the button was technically disabled (via `disabled={isFavoritedItem}`), it was still visually appearing on hover due to CSS specificity.

## Test plan
- [x] Verified compilation passes (`npm run compile`)
- [ ] Manual test: mark a history item as favorite, verify the delete button no longer appears on hover

🤖 Generated with [Claude Code](https://claude.ai/code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes delete button visibility for favorited items, star button alignment, and path containment checks.
> 
>   - **Behavior**:
>     - In `HistoryViewItem.tsx`, hide delete button for favorited items using `opacity-0` and `pointer-events-none`.
>     - Fixes star button alignment for long prompts in history items.
>   - **Path Handling**:
>     - In `path.ts`, replace `string.includes()` with `isLocatedInPath()` to fix false positives in path containment checks.
>   - **Misc**:
>     - Add changeset files for each fix.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 51798081661d61d5f3d1f563bc06b8f8158f13ca. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->