### PR TITLE
fix: restore per-request cost display in chat stream

### DIFF
--- a/.changeset/fix-favorite-delete-button.md
+++ b/.changeset/fix-favorite-delete-button.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Fix delete button remaining visible for favorited history items

--- a/.changeset/fix-history-star-alignment.md
+++ b/.changeset/fix-history-star-alignment.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Fix Star button alignment in History for long prompts

--- a/.changeset/fix-path-containment-check.md
+++ b/.changeset/fix-path-containment-check.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Fix path containment check using string.includes() causing false positives

--- a/.changeset/fix-plan-act-accessibility.md
+++ b/.changeset/fix-plan-act-accessibility.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Fix accessibility for Plan/Act mode toggle by using correct ARIA roles

--- a/.changeset/restore-per-request-cost.md
+++ b/.changeset/restore-per-request-cost.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Restore per-request cost display in chat stream

--- a/src/test/e2e/chat.test.ts
+++ b/src/test/e2e/chat.test.ts
@@ -18,10 +18,10 @@ e2e("Chat - can send messages and switch between modes", async ({ helper, sideba
 	await expect(sidebar.getByText("Recent")).toBeVisible()
 	await expect(sidebar.getByText("Hello, Cline!")).toBeVisible()
 
-	// Makes sure the act and plan switches are working correctly
+	// Makes sure the act and plan radio buttons are working correctly
 	// Aria-checked state should be true for Act and false for Plan
-	const actButton = sidebar.getByRole("switch", { name: "Act" })
-	const planButton = sidebar.getByRole("switch", { name: "Plan" })
+	const actButton = sidebar.getByRole("radio", { name: "Act" })
+	const planButton = sidebar.getByRole("radio", { name: "Plan" })
 
 	// Act button should be active. It doesn't have c
 	await expect(actButton).toHaveAttribute("aria-checked", "true")

--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -95,7 +95,7 @@ export function getReadablePath(cwd: string, relPath?: string): string {
 	} else {
 		// show the relative path to the cwd
 		const normalizedRelPath = path.relative(cwd, absolutePath)
-		if (absolutePath.includes(cwd)) {
+		if (isLocatedInPath(cwd, absolutePath)) {
 			return normalizedRelPath.toPosix()
 		} else {
 			// we are outside the cwd, so show the absolute path (useful for when cline passes in '../../' for example)

--- a/webview-ui/src/components/chat/ChatTextArea.tsx
+++ b/webview-ui/src/components/chat/ChatTextArea.tsx
@@ -1793,7 +1793,7 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 							</p>
 						</TooltipContent>
 						<TooltipTrigger>
-							<SwitchContainer data-testid="mode-switch" disabled={false} onClick={onModeToggle}>
+							<SwitchContainer data-testid="mode-switch" disabled={false} onClick={onModeToggle} role="radiogroup">
 								<Slider isAct={mode === "act"} isPlan={mode === "plan"} />
 								{["Plan", "Act"].map((m) => (
 									<div
@@ -1802,9 +1802,10 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 											"pt-0.5 pb-px px-2 z-10 text-xs w-1/2 text-center bg-transparent",
 											mode === m.toLowerCase() ? "text-white" : "text-input-foreground",
 										)}
+										key={m}
 										onMouseLeave={() => setShownTooltipMode(null)}
 										onMouseOver={() => setShownTooltipMode(m.toLowerCase() === "plan" ? "plan" : "act")}
-										role="switch">
+										role="radio">
 										{m}
 									</div>
 								))}

--- a/webview-ui/src/components/chat/RequestStartRow.tsx
+++ b/webview-ui/src/components/chat/RequestStartRow.tsx
@@ -244,6 +244,12 @@ export const RequestStartRow: React.FC<RequestStartRowProps> = ({
 					/>
 				))}
 
+			{apiReqState === "final" && hasCost && !hasCompletionResult && (
+				<div className="flex items-center text-description text-xs ml-1 mt-1">
+					<span className="opacity-70">${Number(cost || 0).toFixed(4)}</span>
+				</div>
+			)}
+
 			{apiReqState === "error" && (
 				<ErrorRow
 					apiReqStreamingFailedMessage={apiReqStreamingFailedMessage}

--- a/webview-ui/src/components/history/HistoryViewItem.tsx
+++ b/webview-ui/src/components/history/HistoryViewItem.tsx
@@ -94,7 +94,7 @@ const HistoryViewItem = ({
 					e.stopPropagation()
 					handleShowTaskWithId(item.id)
 				}}>
-				<div className="flex items-center gap-2">
+				<div className="flex items-center gap-2 min-w-0">
 					<div className="line-clamp-1 overflow-hidden break-words whitespace-pre-wrap flex-1 min-w-0">
 						<span className="ph-no-capture">{item.task}</span>
 					</div>

--- a/webview-ui/src/components/history/HistoryViewItem.tsx
+++ b/webview-ui/src/components/history/HistoryViewItem.tsx
@@ -101,7 +101,10 @@ const HistoryViewItem = ({
 					<div className="flex gap-2 flex-shrink-0">
 						<Button
 							aria-label="Delete"
-							className="p-0 opacity-0 group-hover:opacity-100 transition-opacity"
+							className={cn("p-0 transition-opacity", {
+								"opacity-0 group-hover:opacity-100": !isFavoritedItem,
+								"opacity-0 pointer-events-none": isFavoritedItem,
+							})}
 							disabled={isFavoritedItem}
 							onClick={(e) => {
 								e.stopPropagation()


### PR DESCRIPTION
## Summary
- Fixes #8771
- Restores the per-request cost display that was inadvertently removed in PR #8264 ("refactor: Chat Streaming UI")
- The `cost` prop was being passed to `RequestStartRow` but was never rendered in the UI

## Root cause
During the Chat Streaming UI refactor, the old `VSCodeBadge` component that displayed the cost was removed and not replaced with an equivalent display element. The data was still being passed correctly - only the UI rendering was missing.

## Changes
Added cost display in `RequestStartRow.tsx` when:
- `apiReqState === "final"` (request completed)
- `hasCost` is true (cost data is available)
- `hasCompletionResult` is false (not showing in completion result view)

## Test plan
- [x] Verified compilation passes (`npm run compile`)
- [ ] Manual test: use any model via OpenRouter, verify per-request cost is displayed in chat stream after each API request completes

🤖 Generated with [Claude Code](https://claude.ai/code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Restores per-request cost display in chat stream and fixes UI and accessibility issues.
> 
>   - **Behavior**:
>     - Restores per-request cost display in `RequestStartRow.tsx` when `apiReqState === "final"`, `hasCost` is true, and `hasCompletionResult` is false.
>   - **UI Fixes**:
>     - Fix delete button visibility for favorited items in `HistoryViewItem.tsx`.
>     - Fix star button alignment for long prompts in `HistoryViewItem.tsx`.
>   - **Accessibility**:
>     - Add correct ARIA roles to Plan/Act mode toggle in `ChatTextArea.tsx`.
>   - **Path Handling**:
>     - Fix path containment check in `path.ts` by replacing `string.includes()` with `isLocatedInPath()`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 23d51d2343478eb632f4f391e965e44c34a87677. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->