### PR TITLE
fix: strip thinking content from commit message generation

### DIFF
--- a/.changeset/fix-commit-thinking-output.md
+++ b/.changeset/fix-commit-thinking-output.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Fix commit message generator showing thinking content instead of actual message

--- a/src/hosts/vscode/commit-message-generator.ts
+++ b/src/hosts/vscode/commit-message-generator.ts
@@ -220,8 +220,12 @@ export function abortCommitGeneration() {
  * @returns The extracted commit message
  */
 function extractCommitMessage(str: string): string {
+	// Remove thinking blocks (e.g., <think>...</think>) that some models output
+	let result = str.replace(/<think>[\s\S]*?<\/think>/gi, "")
+	// Also handle unclosed thinking blocks (still being streamed)
+	result = result.replace(/<think>[\s\S]*$/gi, "")
 	// Remove any markdown formatting or extra text
-	return str
+	return result
 		.trim()
 		.replace(/^```[^\n]*\n?|```$/g, "")
 		.trim()


### PR DESCRIPTION
## Summary
- Fixes #8975
- Some AI models (like Gemini) output `<think>...</think>` blocks containing reasoning before the actual response
- The commit message generator now filters out these thinking blocks to show only the clean commit message

## Test plan
- [x] Code compiles successfully
- [ ] Generate commit message with a model that outputs thinking content
- [ ] Verify thinking content is not shown in the commit message input

Generated with [Claude Code](https://claude.ai/code)