### PR TITLE
fix: add visible focus indicator for buttons

### DIFF
--- a/.changeset/fix-button-focus-indicator.md
+++ b/.changeset/fix-button-focus-indicator.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Add visible focus indicator for buttons when navigating with keyboard

--- a/webview-ui/src/main.css
+++ b/webview-ui/src/main.css
@@ -2,8 +2,9 @@ textarea:focus {
 	outline: 1.5px solid var(--vscode-focusBorder, #007fd4);
 }
 
-vscode-button::part(control):focus {
-	outline: none;
+vscode-button::part(control):focus-visible {
+	outline: 1.5px solid var(--vscode-focusBorder, #007fd4);
+	outline-offset: 1px;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Fixes #8675
- The CSS rule was explicitly removing the focus outline from `vscode-button` elements with `outline: none`
- This made keyboard navigation inaccessible as users couldn't see which button was focused
- Changed to show a visible focus ring using `:focus-visible` selector so it only appears when navigating with keyboard (not on mouse click)

## Test plan
- [x] Code compiles successfully
- [ ] Navigate to approval buttons using Tab key
- [ ] Verify visible focus indicator appears on buttons

Generated with [Claude Code](https://claude.ai/code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes focus visibility for `vscode-button` elements to improve keyboard navigation accessibility by using `:focus-visible` in `main.css`.
> 
>   - **Behavior**:
>     - Fixes focus visibility for `vscode-button` elements in `main.css` by replacing `:focus` with `:focus-visible`.
>     - Ensures focus outline appears only during keyboard navigation, not on mouse click.
>   - **Misc**:
>     - Adds `.changeset/fix-button-focus-indicator.md` to document the change.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 479903086ceb18d5cb365d4cc296c000cb1f32c5. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->