### PR TITLE
fix: respect Preferred Language setting in commit message generator

### DIFF
--- a/.changeset/fix-commit-message-language.md
+++ b/.changeset/fix-commit-message-language.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Respect Preferred Language setting when generating commit messages

--- a/src/hosts/vscode/commit-message-generator.ts
+++ b/src/hosts/vscode/commit-message-generator.ts
@@ -160,6 +160,12 @@ async function performCommitMsgGeneration(stateManager: StateManager, gitDiff: s
 
 		const prompts = [PROMPT.instruction]
 
+		// Add preferred language instruction if set and not English
+		const preferredLanguage = stateManager.getGlobalSettingsKey("preferredLanguage")
+		if (preferredLanguage && preferredLanguage !== "English") {
+			prompts.push(`IMPORTANT: Generate the commit message in ${preferredLanguage}.`)
+		}
+
 		const currentInput = inputBox.value?.trim() || ""
 		if (currentInput) {
 			prompts.push(PROMPT.user.replace("{{USER_CURRENT_INPUT}}", currentInput))


### PR DESCRIPTION
## Summary
- Fixes #7055
- The commit message generator now reads the user's Preferred Language setting
- When the language is set to something other than English, an instruction is added to generate the commit message in that language

## Test plan
- [x] Code compiles successfully
- [ ] Set Preferred Language to non-English (e.g., "Simplified Chinese - 简体中文")
- [ ] Generate a commit message
- [ ] Verify the message is generated in the selected language

Generated with [Claude Code](https://claude.ai/code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds support for generating commit messages in user's preferred language in `commit-message-generator.ts`.
> 
>   - **Behavior**:
>     - In `performCommitMsgGeneration()` in `commit-message-generator.ts`, checks user's `preferredLanguage` setting.
>     - If `preferredLanguage` is set and not "English", adds instruction to generate commit message in that language.
>   - **Misc**:
>     - Adds changeset file `fix-commit-message-language.md` to document the change.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 7a5424aa71a4851c4e590c279e3e9932741fb0a5. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->