### PR TITLE
fix: cleanup recording state when VoiceRecorder unmounts

### DIFF
--- a/.changeset/fix-dictation-unmount-cleanup.md
+++ b/.changeset/fix-dictation-unmount-cleanup.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Fix buttons disappearing when disabling dictation mode during recording

--- a/.changeset/fix-favorite-delete-button.md
+++ b/.changeset/fix-favorite-delete-button.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Fix delete button remaining visible for favorited history items

--- a/.changeset/fix-history-star-alignment.md
+++ b/.changeset/fix-history-star-alignment.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Fix Star button alignment in History for long prompts

--- a/.changeset/fix-path-containment-check.md
+++ b/.changeset/fix-path-containment-check.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Fix path containment check using string.includes() causing false positives

--- a/.changeset/fix-plan-act-accessibility.md
+++ b/.changeset/fix-plan-act-accessibility.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Fix accessibility for Plan/Act mode toggle by using correct ARIA roles

--- a/.changeset/restore-per-request-cost.md
+++ b/.changeset/restore-per-request-cost.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Restore per-request cost display in chat stream

--- a/src/test/e2e/chat.test.ts
+++ b/src/test/e2e/chat.test.ts
@@ -18,10 +18,10 @@ e2e("Chat - can send messages and switch between modes", async ({ helper, sideba
 	await expect(sidebar.getByText("Recent")).toBeVisible()
 	await expect(sidebar.getByText("Hello, Cline!")).toBeVisible()
 
-	// Makes sure the act and plan switches are working correctly
+	// Makes sure the act and plan radio buttons are working correctly
 	// Aria-checked state should be true for Act and false for Plan
-	const actButton = sidebar.getByRole("switch", { name: "Act" })
-	const planButton = sidebar.getByRole("switch", { name: "Plan" })
+	const actButton = sidebar.getByRole("radio", { name: "Act" })
+	const planButton = sidebar.getByRole("radio", { name: "Plan" })
 
 	// Act button should be active. It doesn't have c
 	await expect(actButton).toHaveAttribute("aria-checked", "true")

--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -95,7 +95,7 @@ export function getReadablePath(cwd: string, relPath?: string): string {
 	} else {
 		// show the relative path to the cwd
 		const normalizedRelPath = path.relative(cwd, absolutePath)
-		if (absolutePath.includes(cwd)) {
+		if (isLocatedInPath(cwd, absolutePath)) {
 			return normalizedRelPath.toPosix()
 		} else {
 			// we are outside the cwd, so show the absolute path (useful for when cline passes in '../../' for example)

--- a/webview-ui/src/components/chat/ChatTextArea.tsx
+++ b/webview-ui/src/components/chat/ChatTextArea.tsx
@@ -1793,7 +1793,7 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 							</p>
 						</TooltipContent>
 						<TooltipTrigger>
-							<SwitchContainer data-testid="mode-switch" disabled={false} onClick={onModeToggle}>
+							<SwitchContainer data-testid="mode-switch" disabled={false} onClick={onModeToggle} role="radiogroup">
 								<Slider isAct={mode === "act"} isPlan={mode === "plan"} />
 								{["Plan", "Act"].map((m) => (
 									<div
@@ -1802,9 +1802,10 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 											"pt-0.5 pb-px px-2 z-10 text-xs w-1/2 text-center bg-transparent",
 											mode === m.toLowerCase() ? "text-white" : "text-input-foreground",
 										)}
+										key={m}
 										onMouseLeave={() => setShownTooltipMode(null)}
 										onMouseOver={() => setShownTooltipMode(m.toLowerCase() === "plan" ? "plan" : "act")}
-										role="switch">
+										role="radio">
 										{m}
 									</div>
 								))}

--- a/webview-ui/src/components/chat/RequestStartRow.tsx
+++ b/webview-ui/src/components/chat/RequestStartRow.tsx
@@ -244,6 +244,12 @@ export const RequestStartRow: React.FC<RequestStartRowProps> = ({
 					/>
 				))}
 
+			{apiReqState === "final" && hasCost && !hasCompletionResult && (
+				<div className="flex items-center text-description text-xs ml-1 mt-1">
+					<span className="opacity-70">${Number(cost || 0).toFixed(4)}</span>
+				</div>
+			)}
+
 			{apiReqState === "error" && (
 				<ErrorRow
 					apiReqStreamingFailedMessage={apiReqStreamingFailedMessage}

--- a/webview-ui/src/components/chat/VoiceRecorder.tsx
+++ b/webview-ui/src/components/chat/VoiceRecorder.tsx
@@ -39,6 +39,18 @@ const VoiceRecorder: React.FC<VoiceRecorderProps> = ({
 		onRecordingStateChange?.(isRecording)
 	}, [isRecording, onRecordingStateChange])
 
+	// Cleanup on unmount - cancel recording and reset state
+	useEffect(() => {
+		return () => {
+			// Cancel any active recording when component unmounts
+			DictationServiceClient.cancelRecording(EmptyRequest.create({})).catch((error) => {
+				console.error("Error canceling recording on unmount:", error)
+			})
+			// Notify parent that recording has stopped
+			onRecordingStateChange?.(false)
+		}
+	}, [onRecordingStateChange])
+
 	// Auto-clear authentication errors when user signs in
 	useEffect(() => {
 		if (isAuthenticated && error) {

--- a/webview-ui/src/components/history/HistoryViewItem.tsx
+++ b/webview-ui/src/components/history/HistoryViewItem.tsx
@@ -94,7 +94,7 @@ const HistoryViewItem = ({
 					e.stopPropagation()
 					handleShowTaskWithId(item.id)
 				}}>
-				<div className="flex items-center gap-2">
+				<div className="flex items-center gap-2 min-w-0">
 					<div className="line-clamp-1 overflow-hidden break-words whitespace-pre-wrap flex-1 min-w-0">
 						<span className="ph-no-capture">{item.task}</span>
 					</div>

--- a/webview-ui/src/components/history/HistoryViewItem.tsx
+++ b/webview-ui/src/components/history/HistoryViewItem.tsx
@@ -101,7 +101,10 @@ const HistoryViewItem = ({
 					<div className="flex gap-2 flex-shrink-0">
 						<Button
 							aria-label="Delete"
-							className="p-0 opacity-0 group-hover:opacity-100 transition-opacity"
+							className={cn("p-0 transition-opacity", {
+								"opacity-0 group-hover:opacity-100": !isFavoritedItem,
+								"opacity-0 pointer-events-none": isFavoritedItem,
+							})}
 							disabled={isFavoritedItem}
 							onClick={(e) => {
 								e.stopPropagation()


### PR DESCRIPTION
## Summary
- Adds cleanup effect to VoiceRecorder that cancels any active recording and notifies parent when component unmounts
- Fixes issue where chat buttons disappear when disabling dictation mode during active recording

## Root Cause
When dictation is disabled while recording is active:
1. VoiceRecorder component unmounts
2. But `isVoiceRecording` state in ChatTextArea remains `true`
3. This causes the Send button to be hidden (`{!isVoiceRecording && ...}`) and PulsingBorder to remain visible

## Changes
Added a cleanup useEffect that:
1. Calls `DictationServiceClient.cancelRecording()` to stop any active backend recording
2. Calls `onRecordingStateChange(false)` to notify parent that recording has stopped

## Test plan
- [x] Build compiles successfully
- [ ] Enable dictation in settings
- [ ] Start voice recording
- [ ] While recording is active, go to Settings > Feature Settings and disable dictation
- [ ] Verify the Send button reappears and the pulsing border animation stops
- [ ] Verify no errors in console

Fixes #6464

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds cleanup effect to `VoiceRecorder` to handle unmounting, fixes chat button visibility during dictation, and includes various minor fixes and improvements.
> 
>   - **VoiceRecorder Cleanup**:
>     - Adds cleanup `useEffect` in `VoiceRecorder` to cancel active recordings and notify parent on unmount.
>     - Calls `DictationServiceClient.cancelRecording()` and `onRecordingStateChange(false)`.
>   - **ChatTextArea**:
>     - Fixes issue where chat buttons disappear when disabling dictation mode during active recording.
>     - Adds ARIA roles to Plan/Act mode toggle for accessibility.
>   - **RequestStartRow**:
>     - Restores per-request cost display when `apiReqState` is "final" and `hasCost` is true.
>   - **HistoryViewItem**:
>     - Fixes delete button visibility for favorited items.
>     - Fixes star button alignment for long prompts.
>   - **Path Utility**:
>     - Replaces `string.includes()` with `isLocatedInPath()` to fix false positives in path containment check.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for ffb2b84345d689f7ab47daa97163cbd52043f8f2. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->