### PR TITLE
fix: support non-ASCII characters in workflow filenames

### DIFF
--- a/.changeset/fix-favorite-delete-button.md
+++ b/.changeset/fix-favorite-delete-button.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Fix delete button remaining visible for favorited history items

--- a/.changeset/fix-history-star-alignment.md
+++ b/.changeset/fix-history-star-alignment.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Fix Star button alignment in History for long prompts

--- a/.changeset/fix-path-containment-check.md
+++ b/.changeset/fix-path-containment-check.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Fix path containment check using string.includes() causing false positives

--- a/.changeset/fix-plan-act-accessibility.md
+++ b/.changeset/fix-plan-act-accessibility.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Fix accessibility for Plan/Act mode toggle by using correct ARIA roles

--- a/.changeset/fix-workflow-non-ascii.md
+++ b/.changeset/fix-workflow-non-ascii.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Fix workflow files with non-ASCII characters in filenames not being read

--- a/.changeset/restore-per-request-cost.md
+++ b/.changeset/restore-per-request-cost.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Restore per-request cost display in chat stream

--- a/src/core/slash-commands/index.ts
+++ b/src/core/slash-commands/index.ts
@@ -99,7 +99,8 @@ export async function parseSlashCommands(
 	//
 	// Only ONE slash command per message is processed (first match found).
 	// Note: Colons are allowed to support MCP prompt commands like /mcp:server:prompt
-	const slashCommandInTextRegex = /(^|\s)\/([a-zA-Z0-9_.:@-]+)(?=\s|$)/
+	// Note: Non-ASCII characters are allowed to support workflow files with unicode names
+	const slashCommandInTextRegex = /(^|\s)\/([^\s]+)(?=\s|$)/
 
 	// Helper function to calculate positions and remove slash command from text
 	const removeSlashCommand = (

--- a/src/test/e2e/chat.test.ts
+++ b/src/test/e2e/chat.test.ts
@@ -18,10 +18,10 @@ e2e("Chat - can send messages and switch between modes", async ({ helper, sideba
 	await expect(sidebar.getByText("Recent")).toBeVisible()
 	await expect(sidebar.getByText("Hello, Cline!")).toBeVisible()
 
-	// Makes sure the act and plan switches are working correctly
+	// Makes sure the act and plan radio buttons are working correctly
 	// Aria-checked state should be true for Act and false for Plan
-	const actButton = sidebar.getByRole("switch", { name: "Act" })
-	const planButton = sidebar.getByRole("switch", { name: "Plan" })
+	const actButton = sidebar.getByRole("radio", { name: "Act" })
+	const planButton = sidebar.getByRole("radio", { name: "Plan" })
 
 	// Act button should be active. It doesn't have c
 	await expect(actButton).toHaveAttribute("aria-checked", "true")

--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -95,7 +95,7 @@ export function getReadablePath(cwd: string, relPath?: string): string {
 	} else {
 		// show the relative path to the cwd
 		const normalizedRelPath = path.relative(cwd, absolutePath)
-		if (absolutePath.includes(cwd)) {
+		if (isLocatedInPath(cwd, absolutePath)) {
 			return normalizedRelPath.toPosix()
 		} else {
 			// we are outside the cwd, so show the absolute path (useful for when cline passes in '../../' for example)

--- a/webview-ui/src/components/chat/ChatTextArea.tsx
+++ b/webview-ui/src/components/chat/ChatTextArea.tsx
@@ -1793,7 +1793,7 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 							</p>
 						</TooltipContent>
 						<TooltipTrigger>
-							<SwitchContainer data-testid="mode-switch" disabled={false} onClick={onModeToggle}>
+							<SwitchContainer data-testid="mode-switch" disabled={false} onClick={onModeToggle} role="radiogroup">
 								<Slider isAct={mode === "act"} isPlan={mode === "plan"} />
 								{["Plan", "Act"].map((m) => (
 									<div
@@ -1802,9 +1802,10 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 											"pt-0.5 pb-px px-2 z-10 text-xs w-1/2 text-center bg-transparent",
 											mode === m.toLowerCase() ? "text-white" : "text-input-foreground",
 										)}
+										key={m}
 										onMouseLeave={() => setShownTooltipMode(null)}
 										onMouseOver={() => setShownTooltipMode(m.toLowerCase() === "plan" ? "plan" : "act")}
-										role="switch">
+										role="radio">
 										{m}
 									</div>
 								))}

--- a/webview-ui/src/components/chat/RequestStartRow.tsx
+++ b/webview-ui/src/components/chat/RequestStartRow.tsx
@@ -244,6 +244,12 @@ export const RequestStartRow: React.FC<RequestStartRowProps> = ({
 					/>
 				))}
 
+			{apiReqState === "final" && hasCost && !hasCompletionResult && (
+				<div className="flex items-center text-description text-xs ml-1 mt-1">
+					<span className="opacity-70">${Number(cost || 0).toFixed(4)}</span>
+				</div>
+			)}
+
 			{apiReqState === "error" && (
 				<ErrorRow
 					apiReqStreamingFailedMessage={apiReqStreamingFailedMessage}

--- a/webview-ui/src/components/history/HistoryViewItem.tsx
+++ b/webview-ui/src/components/history/HistoryViewItem.tsx
@@ -94,7 +94,7 @@ const HistoryViewItem = ({
 					e.stopPropagation()
 					handleShowTaskWithId(item.id)
 				}}>
-				<div className="flex items-center gap-2">
+				<div className="flex items-center gap-2 min-w-0">
 					<div className="line-clamp-1 overflow-hidden break-words whitespace-pre-wrap flex-1 min-w-0">
 						<span className="ph-no-capture">{item.task}</span>
 					</div>

--- a/webview-ui/src/components/history/HistoryViewItem.tsx
+++ b/webview-ui/src/components/history/HistoryViewItem.tsx
@@ -101,7 +101,10 @@ const HistoryViewItem = ({
 					<div className="flex gap-2 flex-shrink-0">
 						<Button
 							aria-label="Delete"
-							className="p-0 opacity-0 group-hover:opacity-100 transition-opacity"
+							className={cn("p-0 transition-opacity", {
+								"opacity-0 group-hover:opacity-100": !isFavoritedItem,
+								"opacity-0 pointer-events-none": isFavoritedItem,
+							})}
 							disabled={isFavoritedItem}
 							onClick={(e) => {
 								e.stopPropagation()


### PR DESCRIPTION
## Summary
- Fixes workflow files with non-ASCII filenames (e.g., Chinese, Japanese characters) not being read properly
- The slash command regex was limited to ASCII characters only

## Root Cause
The `slashCommandInTextRegex` pattern at `src/core/slash-commands/index.ts:102` used `[a-zA-Z0-9_.:@-]+` which only matches ASCII alphanumeric characters, dots, underscores, colons, at-signs, and hyphens.

When a user types `/Changelog收集器.md`, the regex fails to capture the full command name because it stops at the first non-ASCII character.

## Changes
Changed the regex pattern from:
```regex
/(^|\s)\/([a-zA-Z0-9_.:@-]+)(?=\s|$)/
```
to:
```regex
/(^|\s)\/([^\s]+)(?=\s|$)/
```

The new pattern `[^\s]+` matches any non-whitespace characters, which:
- Supports all Unicode characters (Chinese, Japanese, etc.)
- Still properly terminates at whitespace (due to `(?=\s|$)` lookahead)
- Maintains the same behavior for ASCII-only filenames

## Test plan
- [x] Build compiles successfully
- [ ] Create workflow file with ASCII name (e.g., `changelog.md`) - verify it works
- [ ] Create workflow file with non-ASCII name (e.g., `Changelog收集器.md`) - verify it now works
- [ ] Verify the content appears in `<explicit_instructions>` tag instead of raw filename in `<task>`

Fixes #5648

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update regex to support non-ASCII workflow filenames and fix various UI and functionality issues.
> 
>   - **Behavior**:
>     - Update `slashCommandInTextRegex` in `index.ts` to `/([^\s]+)(?=\s|$)/` to support non-ASCII characters in workflow filenames.
>     - Fix delete button visibility for favorited history items in `HistoryViewItem.tsx`.
>     - Restore per-request cost display in `RequestStartRow.tsx`.
>   - **UI/UX**:
>     - Fix Star button alignment in `HistoryViewItem.tsx` for long prompts.
>     - Improve accessibility for Plan/Act mode toggle in `ChatTextArea.tsx` by using correct ARIA roles.
>   - **Misc**:
>     - Fix path containment check in `path.ts` by replacing `string.includes()` with `isLocatedInPath()`.
>     - Add changeset files for documentation of fixes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 7e9ca508b46285ef6548c574ef8e58e92eff004c. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->