### PR TITLE
Upgrade GitHub Actions for Node 24 compatibility

### DIFF
--- a/.github/workflows/changeset-converter.yml
+++ b/.github/workflows/changeset-converter.yml
@@ -46,13 +46,13 @@ jobs:
                   fi
 
             - name: Git Checkout
-              uses: actions/checkout@v4
+              uses: actions/checkout@v6
               with:
                   fetch-depth: 0
                   ref: ${{ env.GIT_REF }}
 
             - name: Setup Node.js
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v6
               with:
                   node-version: ${{ env.NODE_VERSION }}
                   cache: "npm"

--- a/.github/workflows/claude-issue-triage.yml
+++ b/.github/workflows/claude-issue-triage.yml
@@ -35,7 +35,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -40,7 +40,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/cline-pr-review.yml
+++ b/.github/workflows/cline-pr-review.yml
@@ -44,7 +44,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -55,7 +55,7 @@ jobs:
           git log -1 --format="Commit: %H%nAuthor: %an <%ae>%nDate: %ad%nMessage: %s"
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: "npm"

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -34,15 +34,15 @@ jobs:
             id-token: write
             contents: read
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v6
             - name: Setup Node.js environment
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v6
               with:
                   node-version: 22
 
             # Cache root dependencies - only reuse if package-lock.json exactly matches
             - name: Cache root dependencies
-              uses: actions/cache@v4
+              uses: actions/cache@v5
               id: root-cache
               with:
                   path: node_modules
@@ -50,7 +50,7 @@ jobs:
 
             # Cache webview-ui dependencies - only reuse if package-lock.json exactly matches
             - name: Cache webview-ui dependencies
-              uses: actions/cache@v4
+              uses: actions/cache@v5
               id: webview-cache
               with:
                   path: webview-ui/node_modules
@@ -58,7 +58,7 @@ jobs:
 
             # Cache VS Code installation
             - name: Cache VS Code
-              uses: actions/cache@v4
+              uses: actions/cache@v5
               id: vscode-cache
               with:
                   path: .vscode-test
@@ -68,7 +68,7 @@ jobs:
 
             # Cache Playwright browsers
             - name: Cache Playwright browsers
-              uses: actions/cache@v4
+              uses: actions/cache@v5
               id: playwright-cache
               with:
                   path: |
@@ -100,7 +100,7 @@ jobs:
               if: matrix.runner != 'ubuntu'
               run: npm run test:e2e:optimal
 
-            - uses: actions/upload-artifact@v4
+            - uses: actions/upload-artifact@v6
               if: ${{ failure() }}
               with:
                   name: playwright-recordings-${{ matrix.runner }}

--- a/.github/workflows/label-jetbrains-issues.yml
+++ b/.github/workflows/label-jetbrains-issues.yml
@@ -10,7 +10,7 @@ jobs:
     permissions:
       issues: write
     steps:
-      - uses: actions/github-script@v7
+      - uses: actions/github-script@v8
         with:
           script: |
             const body = context.payload.issue.body || '';

--- a/.github/workflows/npm-main.yaml
+++ b/.github/workflows/npm-main.yaml
@@ -25,23 +25,23 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20.x'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: '1.24'
           cache-dependency-path: cli/go.sum
 
       # Cache root dependencies - only reuse if package-lock.json exactly matches
       - name: Cache root dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         id: root-cache
         with:
           path: node_modules
@@ -49,7 +49,7 @@ jobs:
 
       # Cache webview-ui dependencies - only reuse if package-lock.json exactly matches
       - name: Cache webview-ui dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         id: webview-cache
         with:
           path: webview-ui/node_modules

--- a/.github/workflows/npm-nightly.yaml
+++ b/.github/workflows/npm-nightly.yaml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Check for recent commits
         id: check_commits
@@ -37,14 +37,14 @@ jobs:
 
       - name: Setup Node.js
         if: steps.check_commits.outputs.skip != 'true'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20.x'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Setup Go
         if: steps.check_commits.outputs.skip != 'true'
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: '1.24'
           cache-dependency-path: cli/go.sum
@@ -52,7 +52,7 @@ jobs:
       # Cache root dependencies - only reuse if package-lock.json exactly matches
       - name: Cache root dependencies
         if: steps.check_commits.outputs.skip != 'true'
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         id: root-cache
         with:
           path: node_modules
@@ -61,7 +61,7 @@ jobs:
       # Cache webview-ui dependencies - only reuse if package-lock.json exactly matches
       - name: Cache webview-ui dependencies
         if: steps.check_commits.outputs.skip != 'true'
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         id: webview-cache
         with:
           path: webview-ui/node_modules

--- a/.github/workflows/publish-nightly.yml
+++ b/.github/workflows/publish-nightly.yml
@@ -23,7 +23,7 @@ jobs:
         environment: PublishNightly
 
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v6
 
             - name: Check for recent commits
               run: |
@@ -34,13 +34,13 @@ jobs:
                 echo "Found recent commits, proceeding with build"
                 
             - name: Setup Node.js
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v6
               with:
                   node-version: "lts/*"
 
             # Cache root dependencies - only reuse if package-lock.json exactly matches
             - name: Cache root dependencies
-              uses: actions/cache@v4
+              uses: actions/cache@v5
               id: root-cache
               with:
                   path: node_modules
@@ -48,7 +48,7 @@ jobs:
 
             # Cache webview-ui dependencies - only reuse if package-lock.json exactly matches
             - name: Cache webview-ui dependencies
-              uses: actions/cache@v4
+              uses: actions/cache@v5
               id: webview-cache
               with:
                   path: webview-ui/node_modules

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,20 +33,20 @@ jobs:
         environment: publish
 
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v6
               with:
                   ref: ${{ github.event.inputs.tag }}
                   fetch-depth: 0
                   fetch-tags: true
 
             - name: Setup Node.js
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v6
               with:
                   node-version: "lts/*"
 
             # Cache root dependencies - only reuse if package-lock.json exactly matches
             - name: Cache root dependencies
-              uses: actions/cache@v4
+              uses: actions/cache@v5
               id: root-cache
               with:
                   path: node_modules
@@ -54,7 +54,7 @@ jobs:
 
             # Cache webview-ui dependencies - only reuse if package-lock.json exactly matches
             - name: Cache webview-ui dependencies
-              uses: actions/cache@v4
+              uses: actions/cache@v5
               id: webview-cache
               with:
                   path: webview-ui/node_modules

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -12,7 +12,7 @@ jobs:
             issues: write
             pull-requests: write
         steps:
-            - uses: actions/stale@v9
+            - uses: actions/stale@v10
               with:
                   days-before-issue-stale: 60
                   days-before-issue-close: 14

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,22 +22,22 @@ jobs:
         name: Quality Checks
         steps:
             - name: Checkout code
-              uses: actions/checkout@v4
+              uses: actions/checkout@v6
 
             - name: Setup Node.js environment
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v6
               with:
                   node-version: 22
 
             - name: Cache root dependencies
-              uses: actions/cache@v4
+              uses: actions/cache@v5
               id: root-cache
               with:
                   path: node_modules
                   key: ${{ runner.os }}-npm-${{ hashFiles('package-lock.json') }}
 
             - name: Cache webview-ui dependencies
-              uses: actions/cache@v4
+              uses: actions/cache@v5
               id: webview-cache
               with:
                   path: webview-ui/node_modules
@@ -67,22 +67,22 @@ jobs:
                 shell: bash
         steps:
             - name: Checkout code
-              uses: actions/checkout@v4
+              uses: actions/checkout@v6
 
             - name: Setup Node.js environment
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v6
               with:
                   node-version: 22
 
             - name: Cache root dependencies
-              uses: actions/cache@v4
+              uses: actions/cache@v5
               id: root-cache
               with:
                   path: node_modules
                   key: ${{ runner.os }}-npm-${{ hashFiles('package-lock.json') }}
 
             - name: Cache webview-ui dependencies
-              uses: actions/cache@v4
+              uses: actions/cache@v5
               id: webview-cache
               with:
                   path: webview-ui/node_modules
@@ -136,7 +136,7 @@ jobs:
                   npm run test:coverage
 
             - name: Save Coverage Reports
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@v6
               # Only upload artifacts on Linux - We only need coverage from one OS
               if: runner.os == 'Linux'
               with:
@@ -150,22 +150,22 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout code
-              uses: actions/checkout@v4
+              uses: actions/checkout@v6
 
             - name: Setup Node.js environment
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v6
               with:
                   node-version: 22
                   
             - name: Cache root dependencies
-              uses: actions/cache@v4
+              uses: actions/cache@v5
               id: root-cache
               with:
                   path: node_modules
                   key: ${{ runner.os }}-npm-${{ hashFiles('package-lock.json') }}
 
             - name: Cache webview-ui dependencies
-              uses: actions/cache@v4
+              uses: actions/cache@v5
               id: webview-cache
               with:
                   path: webview-ui/node_modules
@@ -173,7 +173,7 @@ jobs:
 
             # Cache testing-platform dependencies
             - name: Cache testing-platform dependencies
-              uses: actions/cache@v4
+              uses: actions/cache@v5
               id: testing-platform-cache
               with:
                 path: testing-platform/node_modules
@@ -207,7 +207,7 @@ jobs:
                 npm run test:tp-orchestrator -- tests/specs/ --count=1 --coverage
 
             - name: Save Coverage Reports
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@v6
               with:
                 name: test-platform-integration-core-coverage
                 path: coverage/**/lcov.info
@@ -218,10 +218,10 @@ jobs:
         # Run on PRs to main, pushes to main, and manual dispatches
         steps:
             - name: Checkout code
-              uses: actions/checkout@v4
+              uses: actions/checkout@v6
 
             - name: Download unit tests coverage reports
-              uses: actions/download-artifact@v4
+              uses: actions/download-artifact@v7
               with:
                   name: pr-coverage-reports
                   path: .
@@ -246,7 +246,7 @@ jobs:
                   add-prefix: webview-ui/
 
             - name: Download test platform integration core coverage artifact
-              uses: actions/download-artifact@v4
+              uses: actions/download-artifact@v7
               continue-on-error: true
               id: download-integration-coverage
               with:


### PR DESCRIPTION
## Summary

Upgrade GitHub Actions to their latest versions to ensure compatibility with Node 24, as Node 20 will reach end-of-life in April 2026.

## Changes

| Action | Old Version(s) | New Version | Release | Files |
|--------|---------------|-------------|---------|-------|
| `actions/cache` | [`v4`](https://github.com/actions/cache/releases/tag/v4) | [`v5`](https://github.com/actions/cache/releases/tag/v5) | [Release](https://github.com/actions/cache/releases/tag/v5) | e2e.yml, npm-main.yaml, npm-nightly.yaml, publish-nightly.yml, publish.yml, test.yml |
| `actions/checkout` | [`v4`](https://github.com/actions/checkout/releases/tag/v4) | [`v6`](https://github.com/actions/checkout/releases/tag/v6) | [Release](https://github.com/actions/checkout/releases/tag/v6) | changeset-converter.yml, claude-issue-triage.yml, claude-pr-review.yml, cline-pr-review.yml, e2e.yml, npm-main.yaml, npm-nightly.yaml, publish-nightly.yml, publish.yml, test.yml |
| `actions/download-artifact` | [`v4`](https://github.com/actions/download-artifact/releases/tag/v4) | [`v7`](https://github.com/actions/download-artifact/releases/tag/v7) | [Release](https://github.com/actions/download-artifact/releases/tag/v7) | test.yml |
| `actions/github-script` | [`v7`](https://github.com/actions/github-script/releases/tag/v7) | [`v8`](https://github.com/actions/github-script/releases/tag/v8) | [Release](https://github.com/actions/github-script/releases/tag/v8) | label-jetbrains-issues.yml |
| `actions/setup-go` | [`v5`](https://github.com/actions/setup-go/releases/tag/v5) | [`v6`](https://github.com/actions/setup-go/releases/tag/v6) | [Release](https://github.com/actions/setup-go/releases/tag/v6) | npm-main.yaml, npm-nightly.yaml |
| `actions/setup-node` | [`v4`](https://github.com/actions/setup-node/releases/tag/v4) | [`v6`](https://github.com/actions/setup-node/releases/tag/v6) | [Release](https://github.com/actions/setup-node/releases/tag/v6) | changeset-converter.yml, cline-pr-review.yml, e2e.yml, npm-main.yaml, npm-nightly.yaml, publish-nightly.yml, publish.yml, test.yml |
| `actions/stale` | [`v9`](https://github.com/actions/stale/releases/tag/v9) | [`v10`](https://github.com/actions/stale/releases/tag/v10) | [Release](https://github.com/actions/stale/releases/tag/v10) | stale.yml |
| `actions/upload-artifact` | [`v4`](https://github.com/actions/upload-artifact/releases/tag/v4) | [`v6`](https://github.com/actions/upload-artifact/releases/tag/v6) | [Release](https://github.com/actions/upload-artifact/releases/tag/v6) | e2e.yml, test.yml |

## Context

Per [GitHub's announcement](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/), Node 20 is being deprecated and runners will begin using Node 24 by default starting March 4th, 2026.

### Why this matters

- **Node 20 EOL**: April 2026
- **Node 24 default**: March 4th, 2026
- **Action**: Update to latest action versions that support Node 24

### Security Note

Actions that were previously pinned to commit SHAs remain pinned to SHAs (updated to the latest release SHA) to maintain the security benefits of immutable references.

### Testing

These changes only affect CI/CD workflow configurations and should not impact application functionality. The workflows should be tested by running them on a branch before merging.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Upgrade GitHub Actions to latest versions for Node 24 compatibility across multiple workflow files.
> 
>   - **Actions Updated**:
>     - `actions/checkout` from `v4` to `v6` in `changeset-converter.yml`, `claude-issue-triage.yml`, `claude-pr-review.yml`, `cline-pr-review.yml`, `e2e.yml`, `npm-main.yaml`, `npm-nightly.yaml`, `publish-nightly.yml`, `publish.yml`, `test.yml`.
>     - `actions/setup-node` from `v4` to `v6` in `changeset-converter.yml`, `cline-pr-review.yml`, `e2e.yml`, `npm-main.yaml`, `npm-nightly.yaml`, `publish-nightly.yml`, `publish.yml`, `test.yml`.
>     - `actions/cache` from `v4` to `v5` in `e2e.yml`, `npm-main.yaml`, `npm-nightly.yaml`, `publish-nightly.yml`, `publish.yml`, `test.yml`.
>   - **Other Updates**:
>     - `actions/download-artifact` from `v4` to `v7` in `test.yml`.
>     - `actions/github-script` from `v7` to `v8` in `label-jetbrains-issues.yml`.
>     - `actions/stale` from `v9` to `v10` in `stale.yml`.
>     - `actions/upload-artifact` from `v4` to `v6` in `e2e.yml`, `test.yml`.
>   - **Context**:
>     - Node 20 EOL in April 2026; Node 24 becomes default in March 2026.
>     - Actions pinned to commit SHAs updated to latest release SHAs for security.
>   - **Testing**:
>     - Changes affect CI/CD workflows; should be tested on a branch before merging.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for c50eec94c0df2b363436ac02be85b3df005136a4. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->