### PR TITLE
fix: Add Nova 2 Lite to JP_SUPPORTED_CRIS_MODELS

### DIFF
--- a/.changeset/big-years-kneel.md
+++ b/.changeset/big-years-kneel.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Add Nova 2 Lite to JP_SUPPORTED_CRIS_MODELS

--- a/src/core/api/providers/bedrock.ts
+++ b/src/core/api/providers/bedrock.ts
@@ -116,6 +116,7 @@ const JP_SUPPORTED_CRIS_MODELS = [
 	"anthropic.claude-sonnet-4-5-20250929-v1:0",
 	"anthropic.claude-sonnet-4-5-20250929-v1:0:1m",
 	"anthropic.claude-haiku-4-5-20251001-v1:0",
+	"amazon.nova-2-lite-v1:0",
 ]
 
 // https://docs.anthropic.com/en/api/claude-on-amazon-bedrock


### PR DESCRIPTION
### Related Issue

**Issue:** N/A (small bug fix)

### Description

Nova 2 Lite model was missing from the JP_SUPPORTED_CRIS_MODELS array in the Bedrock provider. This prevented users in the Japan region from using the Nova 2 Lite model with Cross-Region Inference. This PR adds the model to the supported list.

### Test Procedure

- Tested the change in debug mode
- Confirmed Nova 2 Lite model now works correctly in Bedrock Japan region with Cross-Region Inference enabled

### Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ♻️ Refactor Changes
- [ ] 💅 Cosmetic Changes
- [ ] 📚 Documentation update
- [ ] 🏃 Workflow Changes

### Pre-flight Checklist

- [x] Changes are limited to a single feature, bugfix or chore
**Issue:** N/A (small bug fix)

### Description

Nova 2 Lite model was missing from the JP_SUPPmat
### Description

Nova 2 Litemat
Nova 2 Lite mnt### Test Procedure

- Tested the change in debug mode
- Confirmed Nova 2 Lite model now works correctly in Bedrock Japan region with Cross-Region Inference enabled

### Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an i on
- Tested the chal N- Confirmed Nova 2 Lite model noad
### Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixe

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add Nova 2 Lite to `JP_SUPPORTED_CRIS_MODELS` in `bedrock.ts` to enable support in Japan region.
> 
>   - **Behavior**:
>     - Adds `"amazon.nova-2-lite-v1:0"` to `JP_SUPPORTED_CRIS_MODELS` in `bedrock.ts`, enabling Nova 2 Lite model support in Japan region for Cross-Region Inference.
>   - **Misc**:
>     - Adds a changeset file `big-years-kneel.md` for version tracking.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for b5e419d686bdb6ca5ba9dafc3ad4a958a98260c2. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->