### PR TITLE
Fix metrics typo

### DIFF
--- a/src/services/telemetry/providers/opentelemetry/OpenTelemetryExporterFactory.ts
+++ b/src/services/telemetry/providers/opentelemetry/OpenTelemetryExporterFactory.ts
@@ -107,7 +107,7 @@ export function createOTLPMetricReader(
 		const metricsUrl = new URL(endpoint)
 		if (!metricsUrl.pathname.endsWith("/v1/metrics")) {
 			const base = endpoint.endsWith("/") ? endpoint.slice(0, -1) : endpoint
-			metricsUrl.pathname = `${base}/v1/mtrics`
+			metricsUrl.pathname = `${base}/v1/metrics`
 		}
 
 		switch (protocol) {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes typo in `createOTLPMetricReader` function, correcting metrics endpoint path in `OpenTelemetryExporterFactory.ts`.
> 
>   - **Fix**:
>     - Corrects typo in `createOTLPMetricReader` function in `OpenTelemetryExporterFactory.ts`, changing `/v1/mtrics` to `/v1/metrics` for the metrics endpoint path.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 10e9cdef332939c77661bfb8fe12aa78328a4e5d. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->