### PR TITLE
remove cache hit check for npm publish workflows

### DIFF
--- a/.github/workflows/npm-main.yaml
+++ b/.github/workflows/npm-main.yaml
@@ -42,7 +42,7 @@ jobs:
           key: ${{ runner.os }}-npm-${{ hashFiles('package-lock.json') }}
 
       - name: Install root dependencies and CLI dependencies
-        if: steps.check_commits.outputs.skip != 'true' && steps.root-cache.outputs.cache-hit != 'true'
+        if: steps.check_commits.outputs.skip != 'true'
         run: npm ci --include=optional # this will also install cli deps because "cli" in included in root package.json workspaces field
 
       - name: Generate Protos

--- a/.github/workflows/npm-nightly.yaml
+++ b/.github/workflows/npm-nightly.yaml
@@ -52,7 +52,7 @@ jobs:
           key: ${{ runner.os }}-npm-${{ hashFiles('package-lock.json') }}
 
       - name: Install root dependencies and CLI dependencies
-        if: steps.check_commits.outputs.skip != 'true' && steps.root-cache.outputs.cache-hit != 'true'
+        if: steps.check_commits.outputs.skip != 'true'
         run: npm ci --include=optional # this will also install cli deps because "cli" in included in root package.json workspaces field
 
       - name: Generate Protos


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove cache hit check for dependency installation in npm publish workflows.
> 
>   - **Workflows**:
>     - Remove cache hit check condition from `Install root dependencies and CLI dependencies` step in `npm-main.yaml` and `npm-nightly.yaml`.
>     - Ensures dependencies are installed if `check_commits` step does not skip, regardless of cache status.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for c87586cadc9a1beaf0cae6ddf2d82c666a45b998. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->