### PR TITLE
fix(cli): correct provider model ID key generation for anthropic and separate providers

### DIFF
--- a/src/shared/storage/provider-keys.ts
+++ b/src/shared/storage/provider-keys.ts
@@ -24,7 +24,6 @@ import {
 
 // Note: "cline" provider uses the same model ID key as "openrouter"
 const ProviderKeyMap: Partial<Record<ApiProvider, string>> = {
-	anthropic: "apiModelId",
 	openrouter: "OpenRouterModelId",
 	cline: "OpenRouterModelId", // Cline provider uses OpenRouter model IDs
 	openai: "OpenAiModelId",


### PR DESCRIPTION
## Summary

Fixes two bugs in provider model ID key handling that were introduced in commit 6e9a4ff0f:

- Anthropic provider returned invalid settings key (`actModeapiModelId` instead of `actModeApiModelId`) due to lowercase "a" in ProviderKeyMap
- Settings panel used act provider for both act and plan model key lookups, causing incorrect key targeting when providers differ

## Changes

1. Removed `anthropic: "apiModelId"` from ProviderKeyMap so it falls through to the generic `actModeApiModelId`/`planModeApiModelId` keys (as the comment already indicated it should)

2. Updated SettingsPanelContent to derive plan model keys from `planModeApiProvider` instead of `actModeApiProvider`:
   - Model ID reading in useMemo
   - Model syncing when disabling separate models
   - Model selection handler
   - Manual model ID editing (handleSave)

## Test plan

- [ ] Verify Anthropic model selection persists correctly in CLI settings
- [ ] Verify changing models with "separate models" enabled writes to correct keys
- [ ] Verify model IDs display correctly after selection
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes incorrect provider model ID key handling for Anthropic and ensures correct provider usage in settings panel.
> 
>   - **Behavior**:
>     - Fixes Anthropic provider key mapping by removing `anthropic: "apiModelId"` from `ProviderKeyMap` in `provider-keys.ts`.
>     - Updates `SettingsPanelContent` in `SettingsPanelContent.tsx` to use `planModeApiProvider` for plan model keys instead of `actModeApiProvider`.
>   - **Functions**:
>     - Modifies `useMemo` in `SettingsPanelContent.tsx` to derive model keys using both `actProvider` and `planProvider`.
>     - Updates model syncing logic when disabling separate models in `SettingsPanelContent.tsx`.
>     - Adjusts model selection handler and manual model ID editing in `SettingsPanelContent.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for e16ce7c263ebe3843bd2d50cbe9db56e494252d1. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->