### PR TITLE
fix(cli): support auto-updates for nightly versions

### DIFF
--- a/cli/src/utils/update.ts
+++ b/cli/src/utils/update.ts
@@ -248,7 +248,7 @@ interface ParsedVersion {
  * Handles both stable versions (2.0.0) and nightly versions (2.0.0-nightly.1736365200).
  */
 function parseVersion(version: string): ParsedVersion {
-	const nightlyMatch = version.match(/^(.+)-nightly\.(\d+)$/)
+	const nightlyMatch = version.match(/^(\d+\.\d+\.\d+)-nightly\.(\d+)$/)
 	if (nightlyMatch) {
 		return {
 			base: nightlyMatch[1].split(".").map(Number),


### PR DESCRIPTION
### Related Issue

This came up during discussion with Max about the nightly CLI builds. No existing issue.

### Description

The CLI auto-update logic was broken for nightly builds. Users who installed `cline@nightly` would never receive automatic updates because:

1. `getLatestVersion()` hardcoded the npm registry URL to `cline/latest`, so it always checked the stable version instead of the nightly tag
2. Update commands hardcoded `@latest` (e.g., `npm install -g cline@latest`), so even if an update was triggered, it would install stable instead of nightly
3. `compareVersions()` couldn't parse nightly version strings like `2.0.0-nightly.1736365200` - the `-nightly.1736365200` part would become `NaN` when split on `.` and converted to numbers

Changes:
- Added `isNightlyVersion()` to detect nightly builds by checking for `-nightly.` in the version string
- Added `getNpmTag()` to return "nightly" or "latest" based on current version
- Updated `getLatestVersion()` and `getInstallationInfo()` to use the correct npm tag
- Rewrote `compareVersions()` with proper parsing for nightly versions (extracts base version + timestamp, compares timestamps for nightly-to-nightly)

### Test Procedure

- Code compiles cleanly (`npm run compile`)
- Verified the logic manually:
  - `isNightlyVersion("2.0.0")` returns false
  - `isNightlyVersion("2.0.0-nightly.1736365200")` returns true
  - `getNpmTag("2.0.0")` returns "latest"
  - `getNpmTag("2.0.0-nightly.1736365200")` returns "nightly"
  - `compareVersions("2.0.0-nightly.1736365200", "2.0.0-nightly.1736451600")` returns -1 (older)
  - `compareVersions("2.0.0-nightly.1736451600", "2.0.0-nightly.1736365200")` returns 1 (newer)
  - `compareVersions("2.0.0-nightly.1736365200", "2.0.0")` returns -1 (nightly is pre-release, less than stable)

### Type of Change

-   [x] Bug fix (non-breaking change which fixes an issue)

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

No changeset needed - this is an internal CLI fix, not a user-facing extension change.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes CLI auto-update logic for nightly builds by handling nightly version strings and using correct npm tags.
> 
>   - **Behavior**:
>     - Fixes auto-update logic for nightly builds in `update.ts` by using correct npm tags and handling nightly version strings.
>     - `getLatestVersion()` now fetches the correct version based on the current version's tag.
>     - `getInstallationInfo()` generates update commands using the appropriate tag.
>   - **Functions**:
>     - Adds `isNightlyVersion()` to detect nightly builds.
>     - Adds `getNpmTag()` to determine the npm tag based on the current version.
>     - Rewrites `compareVersions()` to handle nightly version strings by parsing base version and timestamp.
>   - **Misc**:
>     - Updates `autoUpdateOnStartup()` and `checkForUpdates()` to use new logic for version comparison and update command generation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for c40ff2282309a6a32a4d13c919df62d9ffa125bf. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->