### PR TITLE
cli/fix - quick auth should exit process

### DIFF
--- a/cli/src/components/App.test.tsx
+++ b/cli/src/components/App.test.tsx
@@ -82,9 +82,8 @@ describe("App", () => {
 		})
 
 		it("should render AuthView when view is auth", () => {
-			const { lastFrame } = render(<App authQuickSetup={{ provider: "openai" }} controller={mockController} view="auth" />)
+			const { lastFrame } = render(<App controller={mockController} view="auth" />)
 			expect(lastFrame()).toContain("AuthView")
-			expect(lastFrame()).toContain("openai")
 		})
 
 		it("should render ChatView when view is welcome", () => {

--- a/cli/src/components/App.tsx
+++ b/cli/src/components/App.tsx
@@ -81,13 +81,6 @@ interface AppProps {
 	globalSkills?: SkillInfo[]
 	localSkills?: SkillInfo[]
 	onToggleSkill?: (isGlobal: boolean, skillPath: string, enabled: boolean) => void
-	// For auth view
-	authQuickSetup?: {
-		provider?: string
-		apikey?: string
-		modelid?: string
-		baseurl?: string
-	}
 	// For welcome view
 	onWelcomeSubmit?: (prompt: string, imagePaths: string[]) => void
 	onWelcomeExit?: () => void
@@ -133,7 +126,6 @@ export const App: React.FC<AppProps> = ({
 	globalSkills,
 	localSkills,
 	onToggleSkill,
-	authQuickSetup,
 	onWelcomeSubmit,
 	onWelcomeExit,
 	initialPrompt,
@@ -237,7 +229,6 @@ export const App: React.FC<AppProps> = ({
 					onComplete={onComplete}
 					onError={onError}
 					onNavigateToWelcome={handleNavigateToWelcome}
-					quickSetup={authQuickSetup}
 				/>
 			)
 			break

--- a/cli/src/components/ProviderPicker.tsx
+++ b/cli/src/components/ProviderPicker.tsx
@@ -5,30 +5,11 @@
 import React, { useMemo } from "react"
 import { StateManager } from "@/core/storage/StateManager"
 import type { ApiConfiguration } from "@/shared/api"
-import providersData from "@/shared/providers/providers.json"
+import { CLI_EXCLUDED_PROVIDERS, getProviderLabel, getProviderOrder } from "../utils/providers"
 import { SearchableList, SearchableListItem } from "./SearchableList"
 
-// Create a lookup map from provider value to display label
-const providerLabels: Record<string, string> = Object.fromEntries(
-	providersData.list.map((p: { value: string; label: string }) => [p.value, p.label]),
-)
-
-// Get provider order from providers.json (same order as webview)
-const providerOrder: string[] = providersData.list.map((p: { value: string }) => p.value)
-
-/**
- * Providers that are not supported in CLI.
- * - vscode-lm: Requires VS Code's Language Model API (see ENG-1490 for OAuth-based support)
- */
-export const CLI_EXCLUDED_PROVIDERS = new Set<string>(["vscode-lm"])
-
-export function getProviderLabel(providerId: string): string {
-	return providerLabels[providerId] || providerId
-}
-
-export function getProviderOrder(): string[] {
-	return providerOrder
-}
+// Re-export for backwards compatibility
+export { CLI_EXCLUDED_PROVIDERS, getProviderLabel, getProviderOrder }
 
 /**
  * Check if a provider is configured (has required credentials/settings)
@@ -147,9 +128,9 @@ export const ProviderPicker: React.FC<ProviderPickerProps> = ({ onSelect, isActi
 
 	// Use providers.json order, filtered to exclude CLI-incompatible providers
 	const items: SearchableListItem[] = useMemo(() => {
-		const sorted = providerOrder.filter((p) => !CLI_EXCLUDED_PROVIDERS.has(p))
+		const sorted = getProviderOrder().filter((p: string) => !CLI_EXCLUDED_PROVIDERS.has(p))
 
-		return sorted.map((providerId) => ({
+		return sorted.map((providerId: string) => ({
 			id: providerId,
 			label: getProviderLabel(providerId),
 			suffix: isProviderConfigured(providerId, apiConfig) ? "(Configured)" : undefined,

--- a/cli/src/utils/providers.ts
+++ b/cli/src/utils/providers.ts
@@ -1,0 +1,48 @@
+/**
+ * Shared provider metadata utilities
+ * Used by both UI components and CLI commands
+ */
+
+import providersData from "@/shared/providers/providers.json"
+
+// Create a lookup map from provider value to display label
+const providerLabels: Record<string, string> = Object.fromEntries(
+	providersData.list.map((p: { value: string; label: string }) => [p.value, p.label]),
+)
+
+// Get provider order from providers.json (same order as webview)
+const providerOrder: string[] = providersData.list.map((p: { value: string }) => p.value)
+
+/**
+ * Providers that are not supported in CLI.
+ * - vscode-lm: Requires VS Code's Language Model API (see ENG-1490 for OAuth-based support)
+ */
+export const CLI_EXCLUDED_PROVIDERS = new Set<string>(["vscode-lm"])
+
+/**
+ * Get the display label for a provider ID
+ */
+export function getProviderLabel(providerId: string): string {
+	return providerLabels[providerId] || providerId
+}
+
+/**
+ * Get the ordered list of all provider IDs (from providers.json)
+ */
+export function getProviderOrder(): string[] {
+	return providerOrder
+}
+
+/**
+ * Get the list of valid CLI provider IDs (excluding unsupported providers)
+ */
+export function getValidCliProviders(): string[] {
+	return providerOrder.filter((p) => !CLI_EXCLUDED_PROVIDERS.has(p))
+}
+
+/**
+ * Check if a provider ID is valid for CLI use
+ */
+export function isValidCliProvider(providerId: string): boolean {
+	return providerOrder.includes(providerId) && !CLI_EXCLUDED_PROVIDERS.has(providerId)
+}


### PR DESCRIPTION
- this will support ci/cd use case

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds quick auth setup mode to CLI, removing `quickSetup` prop and centralizing provider utilities.
> 
>   - **Behavior**:
>     - `performQuickAuthSetup()` added to `index.ts` for quick auth setup without UI, exits process after configuration.
>     - Removes `quickSetup` prop from `App` and `AuthView`.
>     - `AuthView` now exits the Ink app after successful configuration if `onNavigateToWelcome` is not provided.
>   - **Refactoring**:
>     - Centralizes provider utilities in `providers.ts`.
>     - Refactors `ProviderPicker.tsx` to use utilities from `providers.ts`.
>   - **Testing**:
>     - Updates `App.test.tsx` to remove `authQuickSetup` prop usage.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 8742cbf5f5af3a301feb26c3f2e894751a22bc11. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->