### PR TITLE
add man page to cli/package.json

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -6,6 +6,7 @@
 	"bin": {
 		"cline": "./dist/cli.mjs"
 	},
+	"man": "./man/cline.1",
 	"type": "module",
 	"engines": {
 		"node": ">=20.0.0"


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `man` entry to `cli/package.json` for CLI tool documentation.
> 
>   - **Documentation**:
>     - Add `man` entry to `cli/package.json` pointing to `./man/cline.1` for CLI tool documentation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 87e4f1bd1641c1da054d74b389b72bd789651874. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->