### PR TITLE
Fix OTEL endpoints

### DIFF
--- a/src/services/telemetry/providers/opentelemetry/OpenTelemetryExporterFactory.ts
+++ b/src/services/telemetry/providers/opentelemetry/OpenTelemetryExporterFactory.ts
@@ -24,6 +24,15 @@ export function createConsoleLogExporter(): ConsoleLogRecordExporter {
 	return new ConsoleLogRecordExporter()
 }
 
+export function ensurePathSuffix(url: URL, suffix: string): void {
+	const pathname = url.pathname
+	const normalizedPathname = pathname.endsWith("/") ? pathname.slice(0, -1) : pathname
+	url.pathname = normalizedPathname
+	if (!normalizedPathname.endsWith(suffix)) {
+		url.pathname = `${normalizedPathname}${suffix}`
+	}
+}
+
 /**
  * Create an OTLP log exporter based on protocol
  */
@@ -36,11 +45,7 @@ export function createOTLPLogExporter(
 	try {
 		let exporter: any = null
 		const logsUrl = new URL(endpoint)
-		if (!logsUrl.pathname.endsWith("/v1/logs")) {
-			const pathname = logsUrl.pathname
-			const base = pathname.endsWith("/") ? logsUrl.pathname.slice(0, -1) : pathname
-			logsUrl.pathname = `${base}/v1/logs`
-		}
+		ensurePathSuffix(logsUrl, "/v1/logs")
 
 		switch (protocol) {
 			case "grpc": {
@@ -106,11 +111,7 @@ export function createOTLPMetricReader(
 		let exporter: any = null
 
 		const metricsUrl = new URL(endpoint)
-		if (!metricsUrl.pathname.endsWith("/v1/metrics")) {
-			const pathname = metricsUrl.pathname
-			const base = pathname.endsWith("/") ? metricsUrl.pathname.slice(0, -1) : pathname
-			metricsUrl.pathname = `${base}/v1/metrics`
-		}
+		ensurePathSuffix(metricsUrl, "/v1/metrics")
 
 		switch (protocol) {
 			case "grpc": {


### PR DESCRIPTION
### Description

Misconfigured paths lead to lost telemetry. This PR fixes a few bugs introduced in a PR that hasn't been released yet.

### Test Procedure

Tested with a local collector and ensured logs are being received.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes OTEL exporter path configuration by introducing `ensurePathSuffix()` to append correct path suffixes in `OpenTelemetryExporterFactory.ts`.
> 
>   - **Behavior**:
>     - Introduces `ensurePathSuffix()` in `OpenTelemetryExporterFactory.ts` to append correct path suffixes to URLs.
>     - Fixes path configuration for log and metric exporters by using `ensurePathSuffix()` in `createOTLPLogExporter()` and `createOTLPMetricReader()`.
>     - Updates diagnostic wrapping in `createOTLPLogExporter()` and `createOTLPMetricReader()` to use corrected URLs.
>   - **Misc**:
>     - Removes redundant path suffix logic in `createOTLPLogExporter()` and `createOTLPMetricReader()`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for e1aeb5d0e52de99e0f0978fd68a82a54f0625736. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->