### PR TITLE
add windows to cli publish package json

### DIFF
--- a/scripts/package-npm.mjs
+++ b/scripts/package-npm.mjs
@@ -121,7 +121,7 @@ async function createNpmPackageJson() {
 		homepage: pkg.homepage,
 		bugs: pkg.bugs,
 		dependencies: pkg.dependencies,
-		os: ["darwin", "linux"],
+		os: ["darwin", "linux", "win32"],
 		cpu: ["x64", "arm64"],
 	}
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add Windows support to the NPM package JSON in `scripts/package-npm.mjs`.
> 
>   - **Behavior**:
>     - Adds `win32` to the `os` field in the `createNpmPackageJson()` function in `scripts/package-npm.mjs`, enabling Windows support for the NPM package.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for cb4c0e3a75f6b9027ca0f35ffad5d20c32ea3203. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->