### PR TITLE
fix(hooks): Call `combineHookSequences()` from the CLI. [CLINE-1268]

### DIFF
--- a/cli/src/components/ChatView.tsx
+++ b/cli/src/components/ChatView.tsx
@@ -103,6 +103,7 @@
 
 import type { ApiProvider, ModelInfo } from "@shared/api"
 import { combineCommandSequences } from "@shared/combineCommandSequences"
+import { combineHookSequences } from "@shared/combineHookSequences"
 import type { ClineAsk, ClineMessage } from "@shared/ExtensionMessage"
 import { getApiMetrics, getLastApiReqTotalTokens } from "@shared/getApiMetrics"
 import { EmptyRequest, StringRequest } from "@shared/proto/cline/common"
@@ -604,8 +605,10 @@ export const ChatView: React.FC<ChatViewProps> = ({
 			return true
 		})
 
-		// Combine command messages with their output (like webview does)
-		return combineCommandSequences(filtered)
+		// Combine hook messages with their output, then command messages (like webview does)
+		// CLI always has hooks enabled, so we always apply combineHookSequences
+		const withHooks = combineHookSequences(filtered)
+		return combineCommandSequences(withHooks)
 	}, [messages])
 
 	// Detect task switches by watching first message timestamp change.


### PR DESCRIPTION
### Related Issue

**Issue:** CLINE-1268

### Description

Fix for the following error in the CLI:

```
Encountered two children with the same key, `1770067921439`. Keys should be unique so that components maintain their identity across updates. Non-unique keys may cause children to be duplicated and/or omitted — the behavior is unsupported and could change in a future version.
```

Note that [the Linear task](https://linear.app/cline-bot/issue/CLINE-1268/hooks-bug-duplicate-react-child-key-error-after-provider-switch) has a good visual of what the broken behavior looks like.  The goal of this PR is to ensure that the above error doesn't happen when hooks are configured (which means the CLI should simply work as normal).



### Test Procedure

1) Check out this branch.  Then replace your local `cline` CLI with one built fresh from this branch.

```bash
# Remove the currently installed instance of cline CLI.
rm $(which cline)
```

```bash
# Build and install a fresh cline CLI from branch.
npm run install:all
npm run cli:build
npm run cli:link
```

2) Create a hook that outputs multiple lines and enable the hook.  Simply outputting the contents of the incoming JSON payload that a hook receives from Cline is fine for this.  I recommend creating this as a `PreToolUse` hook.

```bash
#!/usr/bin/env bash

input=$(cat)
echo $input | jq
```

3) Run the freshly built `cline` CLI, triggering the hook.  An example prompt that works with `PreToolUse` is: `What does this repo do?`

4) Observe the smooth run of the CLI (i.e. you shouldn't encounter any `Encountered two children with the same key` errors).  This is the success criteria we're looking for.




### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

n/a

### Additional Notes

n/a

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes non-unique key error in CLI by calling `combineHookSequences()` before `combineCommandSequences()` in `ChatView`.
> 
>   - **Behavior**:
>     - Fixes non-unique key error in CLI by ensuring unique keys in `ChatView`.
>     - Calls `combineHookSequences()` before `combineCommandSequences()` in `ChatView` to handle hook messages properly.
>   - **Imports**:
>     - Adds import for `combineHookSequences` in `ChatView.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for d4c4b9888f74f92f36f6ed1c4af08c173ca3ff5c. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->