### PR TITLE
simplify package-npm script

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -6,6 +6,15 @@
 	"bin": {
 		"cline": "./dist/cli.mjs"
 	},
+	"os": [
+		"darwin",
+		"linux",
+		"win32"
+	],
+	"cpu": [
+		"x64",
+		"arm64"
+	],
 	"man": "./man/cline.1",
 	"type": "module",
 	"engines": {

--- a/scripts/package-npm.mjs
+++ b/scripts/package-npm.mjs
@@ -27,7 +27,7 @@ async function main() {
 	await cleanBuildDir()
 	await buildTypeScriptCli()
 	await copyCliDist()
-	await createNpmPackageJson()
+	await copyPackageJson()
 	await copyReadme()
 	await createNpmIgnoreFile()
 
@@ -90,45 +90,14 @@ async function copyCliDist() {
 }
 
 /**
- * Create package.json for NPM publication
- * Reads from cli/package.json and modifies for publication
+ * Copy package.json from cli/ directory
  */
-async function createNpmPackageJson() {
-	console.log("Creating NPM package.json...")
-
-	const sourcePackageJson = path.join(CLI_DIR, "package.json")
-
-	if (!fs.existsSync(sourcePackageJson)) {
-		console.error(`Error: package.json not found at ${sourcePackageJson}`)
-		process.exit(1)
-	}
-
-	const pkg = JSON.parse(fs.readFileSync(sourcePackageJson, "utf8"))
-
-	// Modify for NPM publication
-	const npmPkg = {
-		name: "cline", // Change from @cline/cli to cline for NPM
-		version: pkg.version,
-		description: pkg.description,
-		main: pkg.main,
-		bin: pkg.bin,
-		type: pkg.type,
-		engines: pkg.engines,
-		keywords: pkg.keywords,
-		author: pkg.author,
-		license: pkg.license,
-		repository: pkg.repository,
-		homepage: pkg.homepage,
-		bugs: pkg.bugs,
-		dependencies: pkg.dependencies,
-		os: ["darwin", "linux", "win32"],
-		cpu: ["x64", "arm64"],
-	}
-
-	const destPackageJson = path.join(BUILD_DIR, "package.json")
-	fs.writeFileSync(destPackageJson, JSON.stringify(npmPkg, null, "\t"))
-
-	console.log(`✓ package.json created (name: cline, version: ${pkg.version})`)
+async function copyPackageJson() {
+	console.log("Copying package.json...")
+	const source = path.join(CLI_DIR, "package.json")
+	const dest = path.join(BUILD_DIR, "package.json")
+	await cpr(source, dest)
+	console.log(`✓ package.json copied`)
 }
 
 /**


### PR DESCRIPTION
cli/package.json is already formatted correctly for publishing

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Simplifies NPM packaging by copying `package.json` directly and updating it with `os` and `cpu` fields.
> 
>   - **Scripts**:
>     - Replace `createNpmPackageJson()` with `copyPackageJson()` in `scripts/package-npm.mjs` to directly copy `package.json` from `cli` directory.
>   - **Package Configuration**:
>     - Add `os` and `cpu` fields to `cli/package.json` to specify supported platforms and architectures.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 2f7a8a65255e6f71f5ad756e28758008d5e2e814. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->