### PR TITLE
tag released cli versions

### DIFF
--- a/.github/workflows/npm-main.yaml
+++ b/.github/workflows/npm-main.yaml
@@ -9,7 +9,7 @@ on:
         type: string
 
 permissions:
-  contents: read
+  contents: write # Required for pushing tags
   checks: write # Required by test workflow
   pull-requests: write # Required by test workflow
 
@@ -87,6 +87,13 @@ jobs:
           echo "Publishing version ${{ steps.version.outputs.version }} to NPM with tag 'latest'..."
           cd dist-standalone
           npm publish --tag latest --access public
+
+      - name: Tag release
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag "v${{ steps.version.outputs.version }}-cli"
+          git push origin "v${{ steps.version.outputs.version }}-cli"
 
       - name: Summary
         run: |


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add tagging of released CLI versions in `.github/workflows/npm-main.yaml`.
> 
>   - **Workflow Changes**:
>     - Update `.github/workflows/npm-main.yaml` to change `permissions` from `contents: read` to `contents: write` to allow pushing tags.
>     - Add a new step `Tag release` to tag the release version with `v<version>-cli` and push it to the repository.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 775f9f2380659d886341b7824b5a47673d85fc64. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->