### PR TITLE
remove prepublish script

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -21,7 +21,6 @@
 		"node": ">=20.0.0"
 	},
 	"scripts": {
-		"prepublishOnly": "npm run build:production",
 		"package:brew": "npx tsx ./scripts/update-brew-formula.mts",
 		"package": "npm pack --pack-destination ./dist",
 		"build": "npm run typecheck && npx tsx esbuild.mts",


### PR DESCRIPTION
- this was breaking the publish npm workflow when we try to run npm
publish from the dist-standalone folder (dist-standalone doesn't have
the esbuilt.ts file)
- we don't need this script anyway because we use the npm-main.yaml
workflow to publish the cli

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove `prepublishOnly` script from `cli/package.json` to fix npm publish workflow issues.
> 
>   - **Scripts**:
>     - Remove `prepublishOnly` script from `cli/package.json` to prevent breaking npm publish workflow from `dist-standalone` folder.
>     - Publishing is handled by `npm-main.yaml`, making the script redundant.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 00227b0fe6cfe91307da6705159efe834ae88038. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->