### PR TITLE
Add Anthropic to the remote config provider settings

### DIFF
--- a/src/core/storage/remote-config/utils.ts
+++ b/src/core/storage/remote-config/utils.ts
@@ -182,6 +182,17 @@ export function transformRemoteConfigToStateShape(remoteConfig: RemoteConfig): P
 		}
 	}
 
+	const anthropicSettings = remoteConfig.providerSettings?.Anthropic
+	if (anthropicSettings) {
+		transformed.planModeApiProvider = "anthropic"
+		transformed.actModeApiProvider = "anthropic"
+		providers.push("anthropic")
+
+		if (anthropicSettings.baseUrl) {
+			transformed.anthropicBaseUrl = anthropicSettings.baseUrl
+		}
+	}
+
 	// This line needs to stay here, it is order dependent on the above code checking the configured providers
 	if (providers.length > 0) {
 		transformed.remoteConfiguredProviders = providers

--- a/src/shared/remote-config/__tests__/schema.test.ts
+++ b/src/shared/remote-config/__tests__/schema.test.ts
@@ -731,6 +731,13 @@ describe("Remote Config Schema", () => {
 						vertexProjectId: "my-gcp-project",
 						vertexRegion: "us-central1",
 					},
+					Anthropic: {
+						models: [
+							{ id: "claude-3-5-sonnet-20241022" },
+							{ id: "claude-3-5-sonnet-20241024", thinkingBudgetTokens: 1600 },
+						],
+						baseUrl: "https://example.cline.bot",
+					},
 				},
 				enterpriseTelemetry: {
 					promptUploading: {
@@ -782,6 +789,13 @@ describe("Remote Config Schema", () => {
 			expect(result.providerSettings?.Vertex?.models?.[1].thinkingBudgetTokens).to.be.undefined
 			expect(result.providerSettings?.Vertex?.vertexProjectId).to.equal("my-gcp-project")
 			expect(result.providerSettings?.Vertex?.vertexRegion).to.equal("us-central1")
+
+			expect(result.providerSettings?.Anthropic?.models).to.have.lengthOf(2)
+			expect(result.providerSettings?.Anthropic?.models?.[0].id).to.equal("claude-3-5-sonnet-20241022")
+			expect(result.providerSettings?.Anthropic?.models?.[0].thinkingBudgetTokens).to.be.undefined
+			expect(result.providerSettings?.Anthropic?.models?.[1].id).to.equal("claude-3-5-sonnet-20241024")
+			expect(result.providerSettings?.Anthropic?.models?.[1].thinkingBudgetTokens).to.equal(1600)
+			expect(result.providerSettings?.Anthropic?.baseUrl).to.equal("https://example.cline.bot")
 
 			// Verify OpenTelemetry settings
 			expect(result.openTelemetryEnabled).to.equal(true)

--- a/src/shared/remote-config/schema.ts
+++ b/src/shared/remote-config/schema.ts
@@ -99,6 +99,16 @@ export const LiteLLMSchema = z.object({
 	baseUrl: z.string().optional(),
 })
 
+export const AnthropicModelSchema = z.object({
+	id: z.string(),
+	thinkingBudgetTokens: z.number().optional(),
+})
+
+export const AnthropicSchema = z.object({
+	models: z.array(AnthropicModelSchema).optional(),
+	baseUrl: z.string().optional(),
+})
+
 // Provider settings schema
 // Each provider becomes an optional field
 const ProviderSettingsSchema = z.object({
@@ -107,6 +117,7 @@ const ProviderSettingsSchema = z.object({
 	Cline: ClineSettingsSchema.optional(),
 	Vertex: VertexSettingsSchema.optional(),
 	LiteLLM: LiteLLMSchema.optional(),
+	Anthropic: AnthropicSchema.optional(),
 })
 
 export const AllowedMCPServerSchema = z.object({
@@ -234,6 +245,9 @@ export type VertexModel = z.infer<typeof VertexModelSchema>
 
 export type LiteLLMSettings = z.infer<typeof LiteLLMSchema>
 export type LiteLLMModel = z.infer<typeof LiteLLMModelSchema>
+
+export type AnthropicSettings = z.infer<typeof AnthropicSchema>
+export type AnthropicModel = z.infer<typeof AnthropicModelSchema>
 
 export type APIKeySettings = z.infer<typeof APIKeySchema>
 


### PR DESCRIPTION
### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** PF-442

### Description

This PR adds Anthropic to the remotely configured providers.

### Test Procedure

It will be thoroughly tested once we have the platform ready.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add Anthropic as a new provider in remote configuration settings, updating schema, transformation logic, and tests.
> 
>   - **Behavior**:
>     - Adds Anthropic to `transformRemoteConfigToStateShape()` in `utils.ts`, setting `planModeApiProvider` and `actModeApiProvider` to "anthropic" and adding `anthropicBaseUrl` if present.
>     - Updates `RemoteConfigSchema` in `schema.ts` to include `AnthropicSchema` in `ProviderSettingsSchema`.
>   - **Schema**:
>     - Adds `AnthropicModelSchema` and `AnthropicSchema` to `schema.ts`.
>     - Updates type definitions for `AnthropicSettings` and `AnthropicModel` in `schema.ts`.
>   - **Tests**:
>     - Adds test cases for Anthropic settings in `schema.test.ts`, verifying model IDs and `baseUrl`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 9fd40259694b99fb162a4be95a60ee6b6e585c04. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->