### PR TITLE
add taskId flag to CLI

### DIFF
--- a/cli/man/cline.1
+++ b/cli/man/cline.1
@@ -88,6 +88,10 @@ directory
 \f[B]\-\-thinking\f[R] : Enable extended thinking (1024 token budget)
 .PP
 \f[B]\-\-json\f[R] : Output messages as JSON instead of styled text
+.PP
+\f[B]\-T\f[R], \f[B]\-\-taskId\f[R] \f[I]id\f[R] : Resume an existing
+task by ID.
+The prompt argument becomes an optional follow\-up message.
 .SS history (alias: h)
 List task history with pagination.
 .PP
@@ -179,6 +183,10 @@ the task
 .PP
 \f[B]\-\-json\f[R] : Output messages as JSON instead of styled text.
 Forces plain text mode.
+.PP
+\f[B]\-T\f[R], \f[B]\-\-taskId\f[R] \f[I]id\f[R] : Resume an existing
+task by ID instead of starting a new one.
+The prompt becomes an optional follow\-up message.
 .SH JSON OUTPUT FORMAT
 When using \f[B]\-\-json\f[R], each message is output as a JSON object
 with these fields:
@@ -274,6 +282,21 @@ cline history
 \f[I]# Show more tasks with pagination\f[R]
 cline history \-n 20 \-p 2
 .EE
+.SS Resuming Tasks
+.IP
+.EX
+\f[I]# Resume a task by ID (get IDs from cline history)\f[R]
+cline \-T abc123def
+
+\f[I]# Resume a task with a follow\-up message\f[R]
+cline \-T abc123def \(dqNow add unit tests for the changes\(dq
+
+\f[I]# Resume in plan mode to review before continuing\f[R]
+cline \-T abc123def \-p \(dqWhat\(aqs left to do?\(dq
+
+\f[I]# Resume with yolo mode for automated continuation\f[R]
+cline \-T abc123def \-y \(dqContinue with the implementation\(dq
+.EE
 .SS Authentication
 .IP
 .EX
@@ -348,20 +371,19 @@ export CLINE_COMMAND_PERMISSIONS=\(aq{\(dqallow\(dq: [\(dqnpm *\(dq, \(dqgit *\(
 \f[I]# Allow file operations with redirects\f[R]
 export CLINE_COMMAND_PERMISSIONS=\(aq{\(dqallow\(dq: [\(dqcat *\(dq, \(dqecho *\(dq], \(dqallowRedirects\(dq: true}\(aq
 .EE
-.SH FILES
-\f[B]\(ti/.cline/data/\f[R] : Default configuration directory
-containing:
+.SH CONFIGURATION FILES
+.IP
+.EX
+\(ti/.cline/
+├── data/                    # Default configuration directory
+│   ├── globalState.json     # Global settings and state
+│   ├── secrets.json         # API keys and secrets (stored securely)
+│   ├── workspace/           # Workspace\-specific state
+│   └── tasks/               # Task history and conversation data
+└── log/                     # Log files for debugging
+.EE
 .PP
-\f[B]globalState.json\f[R] : Global settings and state
-.PP
-\f[B]secrets.json\f[R] : API keys and secrets (stored securely)
-.PP
-\f[B]workspace/\f[R] : Workspace\-specific state
-.PP
-\f[B]tasks/\f[R] : Task history and conversation data
-.PP
-\f[B]\(ti/.cline/log/\f[R] : Log files for debugging.
-View with \f[CR]cline dev log\f[R].
+View logs with \f[CR]cline dev log\f[R].
 .SH BUGS
 Report bugs at: \c
 .UR https://github.com/cline/cline/issues

--- a/cli/man/cline.1.md
+++ b/cli/man/cline.1.md
@@ -70,6 +70,8 @@ Run a new task with a prompt.
 
 **\--json** :   Output messages as JSON instead of styled text
 
+**-T**, **\--taskId** *id* :   Resume an existing task by ID. The prompt argument becomes an optional follow-up message.
+
 ## history (alias: h)
 
 List task history with pagination.
@@ -153,6 +155,8 @@ When running **cline** with just a prompt (no subcommand), these options are ava
 **\--thinking** :   Enable extended thinking (1024 token budget)
 
 **\--json** :   Output messages as JSON instead of styled text. Forces plain text mode.
+
+**-T**, **\--taskId** *id* :   Resume an existing task by ID instead of starting a new one. The prompt becomes an optional follow-up message.
 
 # JSON OUTPUT FORMAT
 
@@ -249,6 +253,22 @@ cline history
 
 # Show more tasks with pagination
 cline history -n 20 -p 2
+```
+
+## Resuming Tasks
+
+```bash
+# Resume a task by ID (get IDs from cline history)
+cline -T abc123def
+
+# Resume a task with a follow-up message
+cline -T abc123def "Now add unit tests for the changes"
+
+# Resume in plan mode to review before continuing
+cline -T abc123def -p "What's left to do?"
+
+# Resume with yolo mode for automated continuation
+cline -T abc123def -y "Continue with the implementation"
 ```
 
 ## Authentication

--- a/cli/src/components/ChatView.tsx
+++ b/cli/src/components/ChatView.tsx
@@ -137,6 +137,7 @@ import {
 import { isMouseEscapeSequence } from "../utils/input"
 import { jsonParseSafe, parseImagesFromInput } from "../utils/parser"
 import { extractSlashQuery, filterCommands, insertSlashCommand, sortCommandsWorkflowsFirst } from "../utils/slash-commands"
+import { waitFor } from "../utils/timeout"
 import { isFileEditTool, parseToolFromMessage } from "../utils/tools"
 import { shutdownEvent } from "../vscode-shim"
 import { ActionButtons, type ButtonActionType, getButtonConfig, getVisibleButtons } from "./ActionButtons"
@@ -884,6 +885,8 @@ export const ChatView: React.FC<ChatViewProps> = ({
 	)
 
 	// Auto-submit initial prompt if provided
+	// When taskId is also provided, this sends the prompt to resume the existing task
+	// When no taskId, this creates a new task with the prompt
 	useEffect(() => {
 		const autoSubmit = async () => {
 			if (!initialPrompt && (!initialImages || initialImages.length === 0)) {
@@ -904,8 +907,32 @@ export const ChatView: React.FC<ChatViewProps> = ({
 				if (initialPrompt) {
 					setTerminalTitle(initialPrompt)
 				}
-				// initialImages are already data URLs from index.ts processing
-				await ctrl.initTask(initialPrompt || "", initialImages && initialImages.length > 0 ? initialImages : undefined)
+
+				if (taskId) {
+					// Resuming an existing task with a prompt - wait for task to load first
+					// The task loading happens in the other useEffect via showTaskWithId
+					// We need to wait for it to complete before sending the resume message
+					const task = await waitFor(() => ctrl.task, 5000)
+
+					if (task) {
+						// Send the prompt as a message to resume the task
+						await task.handleWebviewAskResponse("messageResponse", initialPrompt || "")
+					} else {
+						// Task failed to load, fall back to creating new task
+						Logger.error(`Failed to load task ${taskId} for resume, creating new task instead`)
+						await ctrl.initTask(
+							initialPrompt || "",
+							initialImages && initialImages.length > 0 ? initialImages : undefined,
+						)
+					}
+				} else {
+					// New task - use initTask
+					// initialImages are already data URLs from index.ts processing
+					await ctrl.initTask(
+						initialPrompt || "",
+						initialImages && initialImages.length > 0 ? initialImages : undefined,
+					)
+				}
 			} catch (_error) {
 				onError?.()
 			}

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -19,6 +19,7 @@ import { BannerService } from "@/services/banner/BannerService"
 import { ErrorService } from "@/services/error/ErrorService"
 import { initializeDistinctId } from "@/services/logging/distinctId"
 import { telemetryService } from "@/services/telemetry"
+import { HistoryItem } from "@/shared/HistoryItem"
 import { Logger } from "@/shared/services/Logger"
 import { Session } from "@/shared/services/Session"
 import { getProviderModelIdKey, ProviderToApiKeyMap } from "@/shared/storage"
@@ -40,6 +41,150 @@ import { getValidCliProviders, isValidCliProvider } from "./utils/providers"
 import { autoUpdateOnStartup, checkForUpdates } from "./utils/update"
 import { initializeCliContext } from "./vscode-context"
 import { CLI_LOG_FILE, shutdownEvent, window } from "./vscode-shim"
+
+/**
+ * Common options shared between runTask and resumeTask
+ */
+interface TaskOptions {
+	act?: boolean
+	plan?: boolean
+	model?: string
+	verbose?: boolean
+	cwd?: string
+	config?: string
+	thinking?: boolean
+	yolo?: boolean
+	timeout?: string
+	json?: boolean
+	stdinWasPiped?: boolean
+}
+
+/**
+ * Apply task-related options (mode, model, thinking, yolo) to StateManager.
+ * Shared between runTask and resumeTask to avoid duplication.
+ */
+function applyTaskOptions(options: TaskOptions): void {
+	// Apply mode flag
+	if (options.plan) {
+		StateManager.get().setGlobalState("mode", "plan")
+		telemetryService.captureHostEvent("mode_flag", "plan")
+	} else if (options.act) {
+		StateManager.get().setGlobalState("mode", "act")
+		telemetryService.captureHostEvent("mode_flag", "act")
+	}
+
+	// Apply model override if specified
+	if (options.model) {
+		const selectedMode = (StateManager.get().getGlobalSettingsKey("mode") || "act") as "act" | "plan"
+		const providerKey = selectedMode === "act" ? "actModeApiProvider" : "planModeApiProvider"
+		const currentProvider = StateManager.get().getGlobalSettingsKey(providerKey) as ApiProvider
+		const modelKey = getProviderModelIdKey(currentProvider, selectedMode)
+		if (modelKey) {
+			StateManager.get().setGlobalState(modelKey, options.model)
+		}
+		telemetryService.captureHostEvent("model_flag", options.model)
+	}
+
+	// Set thinking budget based on --thinking flag
+	const thinkingBudget = options.thinking ? 1024 : 0
+	const currentMode = StateManager.get().getGlobalSettingsKey("mode") || "act"
+	const thinkingKey = currentMode === "act" ? "actModeThinkingBudgetTokens" : "planModeThinkingBudgetTokens"
+	StateManager.get().setGlobalState(thinkingKey, thinkingBudget)
+	if (options.thinking) {
+		telemetryService.captureHostEvent("thinking_flag", "true")
+	}
+
+	// Set yolo mode based on --yolo flag
+	if (options.yolo) {
+		StateManager.get().setGlobalState("yoloModeToggled", true)
+		telemetryService.captureHostEvent("yolo_flag", "true")
+	}
+}
+
+/**
+ * Determine if plain text mode should be used based on options and environment.
+ */
+function shouldUsePlainTextMode(options: TaskOptions): boolean {
+	const isTTY = process.stdout.isTTY === true
+	return !isTTY || !!options.stdinWasPiped || !!options.json || !!options.yolo
+}
+
+/**
+ * Get the reason for using plain text mode (for telemetry).
+ */
+function getPlainTextModeReason(options: TaskOptions): string {
+	if (options.yolo) return "yolo_flag"
+	if (options.json) return "json"
+	if (options.stdinWasPiped) return "piped_stdin"
+	return "redirected_output"
+}
+
+/**
+ * Run a task in plain text mode (no Ink UI).
+ * Handles auth check, task execution, cleanup, and exit.
+ */
+async function runTaskInPlainTextMode(
+	ctx: CliContext,
+	options: TaskOptions,
+	taskConfig: {
+		prompt?: string
+		taskId?: string
+		imageDataUrls?: string[]
+	},
+): Promise<never> {
+	// Set flag so shutdown handler knows not to clear Ink UI lines
+	isPlainTextMode = true
+
+	// Check if auth is configured before attempting to run the task
+	// In plain text mode we can't show the interactive auth flow
+	const hasAuth = await isAuthConfigured()
+	if (!hasAuth) {
+		printWarning("Not authenticated. Please run 'cline auth' first to configure your API credentials.")
+		await ctx.controller.stateManager.flushPendingState()
+		await ctx.controller.dispose()
+		await ErrorService.get().dispose()
+		exit(1)
+	}
+
+	const reason = getPlainTextModeReason(options)
+	telemetryService.captureHostEvent("plain_text_mode", reason)
+
+	// Plain text mode: no Ink rendering, just clean text output
+	const success = await runPlainTextTask({
+		controller: ctx.controller,
+		prompt: taskConfig.prompt,
+		taskId: taskConfig.taskId,
+		imageDataUrls: taskConfig.imageDataUrls,
+		verbose: options.verbose,
+		jsonOutput: options.json,
+		timeoutSeconds: options.timeout ? parseInt(options.timeout, 10) : undefined,
+	})
+
+	// Cleanup
+	await ctx.controller.stateManager.flushPendingState()
+	await ctx.controller.dispose()
+	await ErrorService.get().dispose()
+
+	// Ensure stdout is fully drained before exiting - critical for piping
+	await drainStdout()
+	exit(success ? 0 : 1)
+}
+
+/**
+ * Create the standard cleanup function for Ink apps.
+ */
+function createInkCleanup(ctx: CliContext, onTaskError?: () => boolean): () => Promise<void> {
+	return async () => {
+		await ctx.controller.stateManager.flushPendingState()
+		await ctx.controller.dispose()
+		await ErrorService.get().dispose()
+		if (onTaskError?.()) {
+			printWarning("Task ended with errors.")
+			exit(1)
+		}
+		exit(0)
+	}
+}
 
 // Track active context for graceful shutdown
 let activeContext: CliContext | null = null
@@ -228,24 +373,7 @@ async function runInkApp(element: React.ReactElement, cleanup: () => Promise<voi
 /**
  * Run a task with the given prompt - uses welcome view for consistent behavior
  */
-async function runTask(
-	prompt: string,
-	options: {
-		act?: boolean
-		plan?: boolean
-		model?: string
-		verbose?: boolean
-		cwd?: string
-		config?: string
-		thinking?: boolean
-		yolo?: boolean
-		timeout?: string
-		images?: string[]
-		json?: boolean
-		stdinWasPiped?: boolean
-	},
-	existingContext?: CliContext,
-) {
+async function runTask(prompt: string, options: TaskOptions & { images?: string[] }, existingContext?: CliContext) {
 	const ctx = existingContext || (await initializeCli({ ...options, enableAuth: true }))
 
 	// Parse images from the prompt text (e.g., @/path/to/image.png)
@@ -262,101 +390,23 @@ async function runTask(
 	// Task without prompt starts in interactive mode
 	telemetryService.captureHostEvent("task_command", prompt ? "task" : "interactive")
 
-	if (options.plan) {
-		StateManager.get().setGlobalState("mode", "plan")
-		telemetryService.captureHostEvent("mode_flag", "plan")
-	} else if (options.act) {
-		StateManager.get().setGlobalState("mode", "act")
-		telemetryService.captureHostEvent("mode_flag", "act")
-	}
-
-	if (options.model) {
-		const selectedMode = (StateManager.get().getGlobalSettingsKey("mode") || "act") as "act" | "plan"
-
-		// Get the current provider for the selected mode
-		const providerKey = selectedMode === "act" ? "actModeApiProvider" : "planModeApiProvider"
-		const currentProvider = StateManager.get().getGlobalSettingsKey(providerKey) as ApiProvider
-
-		// Update model ID using provider-specific key (e.g., cline uses actModeOpenRouterModelId)
-		const modelKey = getProviderModelIdKey(currentProvider, selectedMode)
-		if (modelKey) {
-			StateManager.get().setGlobalState(modelKey, options.model)
-		}
-		telemetryService.captureHostEvent("model_flag", options.model)
-	}
-
-	// Set thinking budget based on --thinking flag
-	const thinkingBudget = options.thinking ? 1024 : 0
-	const currentMode = StateManager.get().getGlobalSettingsKey("mode") || "act"
-	const thinkingKey = currentMode === "act" ? "actModeThinkingBudgetTokens" : "planModeThinkingBudgetTokens"
-	StateManager.get().setGlobalState(thinkingKey, thinkingBudget)
-	if (options.thinking) {
-		telemetryService.captureHostEvent("thinking_flag", "true")
-	}
-
-	// Set yolo mode based on --yolo flag
-	if (options.yolo) {
-		StateManager.get().setGlobalState("yoloModeToggled", true)
-		telemetryService.captureHostEvent("yolo_flag", "true")
-	}
-
+	// Apply shared task options (mode, model, thinking, yolo)
+	applyTaskOptions(options)
 	await StateManager.get().flushPendingState()
 
-	// Detect if output is a TTY (interactive terminal) or redirected to a file/pipe
-	const isTTY = process.stdout.isTTY === true
-
 	// Use plain text mode when output is redirected, stdin was piped, JSON mode is enabled, or --yolo flag is used
-	// Ink requires raw mode on stdin which isn't available when stdin is piped
-	// Note: we use the stdinWasPiped flag passed from the caller because process.stdin.isTTY
-	// may not be reliable after stdin has been consumed by readStdinIfPiped()
-	if (!isTTY || options.stdinWasPiped || options.json || options.yolo) {
-		// Set flag so shutdown handler knows not to clear Ink UI lines
-		isPlainTextMode = true
-
-		// Check if auth is configured before attempting to run the task
-		// In plain text mode we can't show the interactive auth flow
-		const hasAuth = await isAuthConfigured()
-		if (!hasAuth) {
-			printWarning("Not authenticated. Please run 'cline auth' first to configure your API credentials.")
-			await ctx.controller.stateManager.flushPendingState()
-			await ctx.controller.dispose()
-			await ErrorService.get().dispose()
-			exit(1)
-		}
-
-		const reason = options.yolo
-			? "yolo_flag"
-			: options.json
-				? "json"
-				: options.stdinWasPiped
-					? "piped_stdin"
-					: "redirected_output"
-		telemetryService.captureHostEvent("plain_text_mode", reason)
-		// Plain text mode: no Ink rendering, just clean text output
-		const success = await runPlainTextTask({
-			controller: ctx.controller,
+	if (shouldUsePlainTextMode(options)) {
+		return runTaskInPlainTextMode(ctx, options, {
 			prompt: taskPrompt,
 			imageDataUrls: imageDataUrls.length > 0 ? imageDataUrls : undefined,
-			verbose: options.verbose,
-			jsonOutput: options.json,
-			timeoutSeconds: options.timeout ? parseInt(options.timeout, 10) : undefined,
 		})
-
-		// Cleanup
-		await ctx.controller.stateManager.flushPendingState()
-		await ctx.controller.dispose()
-		await ErrorService.get().dispose()
-
-		// Ensure stdout is fully drained before exiting - critical for piping
-		await drainStdout()
-		exit(success ? 0 : 1)
 	}
 
-	let taskError = false
-
-	// Render the welcome view with optional initial prompt/images
+	// Interactive mode: Render the welcome view with optional initial prompt/images
 	// If prompt provided (cline task "prompt"), ChatView will auto-submit
 	// If no prompt (cline interactive), user will type it in
+	let taskError = false
+
 	await runInkApp(
 		React.createElement(App, {
 			view: "welcome",
@@ -373,16 +423,7 @@ async function runTask(
 				exit(0)
 			},
 		}),
-		async () => {
-			await ctx.controller.stateManager.flushPendingState()
-			await ctx.controller.dispose()
-			await ErrorService.get().dispose()
-			if (taskError) {
-				printWarning("Task ended with errors.")
-				exit(1)
-			}
-			exit(0)
-		},
+		createInkCleanup(ctx, () => taskError),
 	)
 }
 
@@ -596,7 +637,13 @@ program
 	.option("--config <path>", "Path to Cline configuration directory")
 	.option("--thinking", "Enable extended thinking (1024 token budget)")
 	.option("--json", "Output messages as JSON instead of styled text")
-	.action((prompt, options) => runTask(prompt, options))
+	.option("-T, --taskId <id>", "Resume an existing task by ID")
+	.action((prompt, options) => {
+		if (options.taskId) {
+			return resumeTask(options.taskId, { ...options, initialPrompt: prompt })
+		}
+		return runTask(prompt, options)
+	})
 
 program
 	.command("history")
@@ -710,6 +757,69 @@ async function checkAnyProviderConfigured(): Promise<boolean> {
 }
 
 /**
+ * Validate that a task exists in history
+ * @returns The task history item if found, null otherwise
+ */
+function findTaskInHistory(taskId: string): HistoryItem | null {
+	const taskHistory = StateManager.get().getGlobalStateKey("taskHistory") || []
+	return taskHistory.find((item) => item.id === taskId) || null
+}
+
+/**
+ * Resume an existing task by ID
+ * Loads the task and optionally prefills the input with a prompt
+ */
+async function resumeTask(taskId: string, options: TaskOptions & { initialPrompt?: string }) {
+	const ctx = await initializeCli({ ...options, enableAuth: true })
+
+	// Validate task exists
+	const historyItem = findTaskInHistory(taskId)
+	if (!historyItem) {
+		printWarning(`Task not found: ${taskId}`)
+		printInfo("Use 'cline history' to see available tasks.")
+		await ctx.controller.stateManager.flushPendingState()
+		await ctx.controller.dispose()
+		await ErrorService.get().dispose()
+		exit(1)
+	}
+
+	telemetryService.captureHostEvent("resume_task_command", options.initialPrompt ? "with_prompt" : "interactive")
+
+	// Apply shared task options (mode, model, thinking, yolo)
+	applyTaskOptions(options)
+	await StateManager.get().flushPendingState()
+
+	// Use plain text mode for non-interactive scenarios
+	if (shouldUsePlainTextMode(options)) {
+		return runTaskInPlainTextMode(ctx, options, {
+			prompt: options.initialPrompt,
+			taskId: taskId,
+		})
+	}
+
+	// Interactive mode: render the task view with the existing task
+	let taskError = false
+
+	await runInkApp(
+		React.createElement(App, {
+			view: "task",
+			taskId: taskId,
+			verbose: options.verbose,
+			controller: ctx.controller,
+			isRawModeSupported: checkRawModeSupport(),
+			initialPrompt: options.initialPrompt || undefined,
+			onError: () => {
+				taskError = true
+			},
+			onWelcomeExit: () => {
+				exit(0)
+			},
+		}),
+		createInkCleanup(ctx, () => taskError),
+	)
+}
+
+/**
  * Show welcome prompt and wait for user input
  * If auth is not configured, show auth flow first
  */
@@ -758,6 +868,7 @@ program
 	.option("--thinking", "Enable extended thinking (1024 token budget)")
 	.option("--json", "Output messages as JSON instead of styled text")
 	.option("--acp", "Run in ACP (Agent Client Protocol) mode for editor integration")
+	.option("-T, --taskId <id>", "Resume an existing task by ID")
 	.action(async (prompt, options) => {
 		// Check for ACP mode first - this takes precedence over everything else
 		if (options.acp) {
@@ -794,6 +905,16 @@ program
 			if (options.verbose) {
 				process.stderr.write(`[debug] Received ${stdinInput.length} bytes from stdin\n`)
 			}
+		}
+
+		// Handle --taskId flag to resume an existing task
+		if (options.taskId) {
+			await resumeTask(options.taskId, {
+				...options,
+				initialPrompt: effectivePrompt,
+				stdinWasPiped: !!stdinInput,
+			})
+			return
 		}
 
 		if (effectivePrompt) {

--- a/cli/src/utils/timeout.ts
+++ b/cli/src/utils/timeout.ts
@@ -1,0 +1,36 @@
+/**
+ * Wait for a condition to become truthy, with a timeout.
+ * Uses Promise.race for clean timeout handling instead of polling.
+ *
+ * @param condition - Function that returns the value to check (truthy = done)
+ * @param timeoutMs - Maximum time to wait in milliseconds
+ * @param pollIntervalMs - How often to check the condition (default: 100ms)
+ * @returns The truthy value if condition is met, or undefined if timeout
+ */
+export async function waitFor<T>(
+	condition: () => T | undefined | null,
+	timeoutMs: number,
+	pollIntervalMs: number = 100,
+): Promise<T | undefined> {
+	// Check immediately first
+	const immediate = condition()
+	if (immediate) {
+		return immediate
+	}
+
+	return new Promise((resolve) => {
+		const intervalId = setInterval(() => {
+			const result = condition()
+			if (result) {
+				clearInterval(intervalId)
+				clearTimeout(timeoutId)
+				resolve(result)
+			}
+		}, pollIntervalMs)
+
+		const timeoutId = setTimeout(() => {
+			clearInterval(intervalId)
+			resolve(undefined)
+		}, timeoutMs)
+	})
+}


### PR DESCRIPTION
- allows you to resume a session headlessly or interactively with a taskId

<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- For feature requests: Created a discussion in our Feature Requests discussions board https://github.com/cline/cline/discussions/categories/feature-requests and received approval from core maintainers before implementation
- For all changes: Link the associated issue/discussion in the "Related Issue" section below

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly without prior discussion.

Why this requirement?
We deeply appreciate all community contributions - they are essential to Cline's success! To ensure the best use of everyone's time and maintain project direction, we use our Feature Requests discussions board to gauge community interest and validate feature ideas before implementation begins. This helps us focus development efforts on features that will benefit the most users.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** n/a

### Description

There's no way to quickly resume a task with an id. This flag adds that. This will also be the first step toward a "resume last convo" command that can be used in the CLI. 

<!-- 
Help reviewers understand your changes by making this PR readable and well-organized:

- What problem does this PR solve?
- Why were these changes introduced and what purpose do they serve?
- For larger changes, provide context about your approach and reasoning

Small PRs may need minimal description, but larger changes benefit from explaining where you're coming from. Much of this context can be in the linked issue above, so feel free to reference it rather than repeating everything here.
-->

### Test Procedure

tested these things

```bash
# Resume a task by ID (get IDs from cline history)
cline -T abc123def

# Resume a task with a follow-up message
cline -T abc123def "Now add unit tests for the changes"

# Resume in plan mode to review before continuing
cline -T abc123def -p "What's left to do?"

# Resume with yolo mode for automated continuation
cline -T abc123def -y "Continue with the implementation"
```


<!-- 
Please walk us through your testing approach and thought process. This helps reviewers understand that you've thoroughly considered the impact of your changes:

- How did you test this change?
- What could potentially break and how did you verify it doesn't?
- What existing functionality might be affected and how did you check it still works?
- Why are you confident this is ready for merge?

We're not looking for exhaustive documentation - just evidence that you've thought through the implications of your changes and tested accordingly.
-->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [n/a] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `--taskId` option to Cline CLI for resuming tasks by ID, with updates to task handling and documentation.
> 
>   - **CLI Feature**:
>     - Add `-T, --taskId <id>` option to resume tasks by ID in `index.ts`.
>     - Update `runTask` and `resumeTask` functions to handle task resumption.
>   - **Task Handling**:
>     - Modify `ChatView.tsx` to auto-submit prompts when resuming tasks.
>     - Update `plain-text-task.ts` to handle task resumption in plain text mode.
>   - **Documentation**:
>     - Update `cline.1` and `cline.1.md` to document the `--taskId` option.
>   - **Utilities**:
>     - Add `waitFor` function in `timeout.ts` for condition polling with timeout.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for b3445c6839ba7a649cb6a80c859bad4b66226843. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->