### PR TITLE
Remove `isExperimental` flag from Parallel Tool Calls feature setting

### DIFF
--- a/webview-ui/src/components/settings/sections/FeatureSettingsSection.tsx
+++ b/webview-ui/src/components/settings/sections/FeatureSettingsSection.tsx
@@ -55,7 +55,6 @@ const agentFeatures: FeatureToggle[] = [
 		description: "Execute multiple tool calls simultaneously",
 		stateKey: "enableParallelToolCalling",
 		settingKey: "enableParallelToolCalling",
-		isExperimental: true,
 	},
 	{
 		id: "strict-plan-mode",


### PR DESCRIPTION
### Related Issue

**Issue:** n/a

### Description

Simple fix to remove thew `isExperimental` flag for this feature setting.


### Test Procedure

Look at the Feature Settings view in the VSCode extension to verify that the prefix `Experimental: ` does not appear at the beginning of the description of the Parallel Tool Calls setting.


### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

**Before:**
<img width="495" height="248" alt="Screenshot 2026-02-04 at 9 38 44 AM" src="https://github.com/user-attachments/assets/b5b301ae-4a34-4d25-953f-34891ba15c6c" />


**After:**
<img width="503" height="254" alt="Screenshot 2026-02-04 at 9 38 33 AM" src="https://github.com/user-attachments/assets/9893af1b-ea6d-4b34-84f0-62a475b9696e" />


### Additional Notes

n/a

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove `isExperimental` flag from `Parallel Tool Calling` feature in `FeatureSettingsSection.tsx`, updating its UI description.
> 
>   - **Behavior**:
>     - Removes `isExperimental` flag from `Parallel Tool Calling` feature in `FeatureSettingsSection.tsx`, removing 'Experimental' label from its description.
>   - **UI**:
>     - Updates `FeatureRow` component to no longer prepend 'Experimental: ' to `Parallel Tool Calling` description.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 4c85c94224658debfda166ebfac16be88f9b3fb5. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->