### PR TITLE
if yolo mode is on, don't ask permission to use mcp tools

### DIFF
--- a/src/core/task/tools/handlers/UseMcpToolHandler.ts
+++ b/src/core/task/tools/handlers/UseMcpToolHandler.ts
@@ -89,7 +89,7 @@ export class UseMcpToolHandler implements IFullyManagedTool {
 			?.find((conn: any) => conn.server.name === server_name)
 			?.server.tools?.find((tool: any) => tool.name === tool_name)?.autoApprove
 
-		if (config.callbacks.shouldAutoApproveTool(block.name) && isToolAutoApproved) {
+		if (config.callbacks.shouldAutoApproveTool(block.name) || isToolAutoApproved) {
 			// Auto-approval flow
 			await config.callbacks.removeLastPartialMessageIfExistsWithType("ask", "use_mcp_server")
 			await config.callbacks.say("use_mcp_server", completeMessage, undefined, undefined, false)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Modify `UseMcpToolHandler.ts` to auto-approve MCP tool usage if either `shouldAutoApproveTool()` or `isToolAutoApproved` is true.
> 
>   - **Behavior**:
>     - In `UseMcpToolHandler.ts`, change condition in `execute()` to auto-approve tool usage if `shouldAutoApproveTool()` returns true or `isToolAutoApproved` is true.
>     - Affects the auto-approval flow by allowing tools to be used without manual approval if either condition is met.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 91b07df3f975b5b31f6329b1ddc62bffd92543cd. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->