### PR TITLE
Add Workspace Configuration to commit generation

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -494,7 +494,7 @@ ${ctx.cellJson || "{}"}
 	// Register the generateGitCommitMessage command handler
 	context.subscriptions.push(
 		vscode.commands.registerCommand(commands.GenerateCommit, async (scm) => {
-			generateCommitMsg(webview.controller.stateManager, scm)
+			generateCommitMsg(webview.controller, scm)
 		}),
 		vscode.commands.registerCommand(commands.AbortCommit, () => {
 			abortCommitGeneration()


### PR DESCRIPTION
### Description

We want to send the workspace configuration when we're generating a commit message. This PR adds it.

### Test Procedure

Tested locally that it's included in the prompt, and the generation succeeds and remains relevant to the changes.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Enhance commit message generation by including workspace configuration using `Controller` in `commit-message-generator.ts`.
> 
>   - **Behavior**:
>     - `generateCommitMsg` in `commit-message-generator.ts` now uses `Controller` instead of `StateManager` to access workspace configurations.
>     - `performCommitMsgGeneration` includes workspace configuration in the commit message prompt if available.
>   - **Functions**:
>     - `generateCommitMsgForRepository` and `orchestrateWorkspaceCommitMsgGeneration` updated to use `Controller`.
>     - `generateCommitMsg` command in `extension.ts` updated to pass `Controller`.
>   - **Misc**:
>     - Minor refactoring to replace `StateManager` with `Controller` in `commit-message-generator.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 0ab350583c40d9d5db11feeb1b3f12d2435a8779. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->