### PR TITLE
fix(cerebras): trigger auto-compaction when context window exceeded

### DIFF
--- a/src/core/context/context-management/context-error-handling.ts
+++ b/src/core/context/context-management/context-error-handling.ts
@@ -67,7 +67,21 @@ function checkIsCerebrasContextWindowError(response: any): boolean {
 		const status = response?.status ?? response?.code ?? response?.error?.status ?? response?.response?.status
 		const message: string = String(response?.message || response?.error?.message || "")
 
-		return String(status) === "400" && message.includes("Please reduce the length of the messages or completion")
+		if (String(status) !== "400") {
+			return false
+		}
+
+		// Known Cerebras context window error patterns
+		const CEREBRAS_CONTEXT_PATTERNS = [
+			/reduce.*length.*messages.*completion/i,
+			/\bcontext\s*(?:length|window)\b/i,
+			/\bmaximum\s*context\b/i,
+			/\b(?:input\s*)?tokens?\s*exceed/i,
+			/\btoo\s*many\s*tokens?\b/i,
+			/input is too long/i,
+		] as const
+
+		return CEREBRAS_CONTEXT_PATTERNS.some((pattern) => pattern.test(message))
 	} catch {
 		return false
 	}

--- a/src/utils/model-utils.ts
+++ b/src/utils/model-utils.ts
@@ -97,6 +97,8 @@ export function isGLMModelFamily(id: string): boolean {
 	return (
 		modelId.includes("glm-4.6") ||
 		modelId.includes("glm-4.5") ||
+		modelId.includes("glm-4.7") ||
+		modelId.includes("zai-glm") || // Cerebras pattern (e.g., zai-glm-4.7)
 		modelId.includes("z-ai/glm") ||
 		modelId.includes("zai-org/glm")
 	)
@@ -163,7 +165,8 @@ export function isNextGenModelFamily(id: string): boolean {
 		isGemini3ModelFamily(modelId) ||
 		isNextGenOpenSourceModelFamily(modelId) ||
 		isDeepSeek32ModelFamily(modelId) ||
-		isDeepSeekNativeModelFamily(modelId)
+		isDeepSeekNativeModelFamily(modelId) ||
+		isGLMModelFamily(modelId)
 	)
 }
 


### PR DESCRIPTION
## Summary

Fixes Cerebras/GLM models failing with repeated "rate limit exceeded" errors instead of auto-compacting when the context window is exceeded.

## The Problem

When using Cerebras provider (e.g., GLM 4.7 with 128K context), users would see:
- "Context window exceeded" shown in the task header (pre-computed from token count)
- But instead of auto-compacting, the system would retry 3 times with "Cerebras API rate limit exceeded" errors and then give up

```
⏺ Retrying... (attempt 1/3)
   Cerebras API rate limit exceeded.

⏺ Retrying... (attempt 2/3)
   Cerebras API rate limit exceeded.

⏺ Retrying... (attempt 3/3)
   Cerebras API rate limit exceeded.

⏺ Failed after 3 retries
   Cerebras API rate limit exceeded.
```

## Root Cause Analysis

Four issues were preventing auto-compaction:

### 1. Pre-flight compaction check skipped for GLM models

The pre-flight context window check in `task/index.ts` only runs for "next-gen" models:

```typescript
if (useAutoCondense && isNextGenModelFamily(this.api.getModel().id)) {
  shouldCompact = this.contextManager.shouldCompactContextWindow(...)
}
```

GLM models weren't in `isNextGenModelFamily`, so this check was skipped entirely.

### 2. isGLMModelFamily didn't match Cerebras model IDs

The existing `isGLMModelFamily` function checked for patterns like `glm-4.6`, `z-ai/glm`, but Cerebras uses `zai-glm-4.7` which didn't match.

### 3. HTTP 400 errors lost their status code

When Cerebras returned HTTP 400 (bad request) for context window errors, the handler wrapped it in a new Error:

```typescript
} else if (error?.status === 400) {
  throw new Error(`Cerebras API bad request: ${error.message}`)
}
```

This stripped the `status` property, so `checkIsCerebrasContextWindowError()` couldn't detect it (it checks `response?.status === "400"`).

### 4. Cerebras returns 429 for oversized context

Cerebras's rate limiter counts input tokens toward the rate limit quota. When context is too large, they return HTTP 429 (rate limit) instead of HTTP 400 (bad request). The retry decorator sees 429 and keeps retrying, thinking it's a temporary rate limit.

### 5. Context error detection was fragile

The Cerebras context error detection used exact string matching:

```typescript
return String(status) === "400" && message.includes("Please reduce the length of the messages or completion")
```

Other providers use robust regex patterns to catch variations in error messages.

## The Fix

### 1. Add GLM to next-gen model family

GLM models now get pre-flight compaction checks when `useAutoCondense` is enabled.

### 2. Update isGLMModelFamily for Cerebras patterns

Added `zai-glm` and `glm-4.7` patterns to match Cerebras model IDs.

### 3. Preserve original HTTP 400 errors

Instead of wrapping 400 errors, we now rethrow them to preserve the status code.

### 4. Detect context-related 429 errors

Before treating 429 as retryable, check if the error message contains context-related patterns. If so, reclassify as 400 to trigger compaction instead of retrying:

```typescript
if (error?.status === 429 || error?.code === "rate_limit_exceeded") {
  const errorMessage = String(error?.message || "")
  const isContextRelated =
    /reduce.*length|context.*length|too.*many.*tokens|tokens.*exceed|input.*too.*long/i.test(errorMessage)
  if (isContextRelated) {
    error.status = 400 // Treat as bad request for context window detection
    throw error
  }
  // Regular rate limit - retry
  throw new Error(`Cerebras API rate limit exceeded.`)
}
```

### 5. Use robust regex patterns for error detection

Cerebras context error detection now uses regex patterns like other providers (OpenRouter, Vercel, Bedrock).

## Multi-layered Protection

After this fix, context window issues are handled at multiple levels:

1. **Pre-flight check** (if autoCondense enabled): Detects oversized context before API call, triggers compaction
2. **429 with context message**: Detected as context error, triggers compaction (doesn't retry)
3. **400 error**: Detected as context error, triggers compaction

## Files Changed

- `src/core/api/providers/cerebras.ts` - Error handling improvements
- `src/core/context/context-management/context-error-handling.ts` - Robust regex patterns
- `src/utils/model-utils.ts` - GLM model family detection + next-gen inclusion

## Test Plan

- [ ] Test with Cerebras GLM 4.7 model
- [ ] Fill context window to ~100% capacity
- [ ] Verify auto-compaction triggers instead of repeated "rate limit exceeded" errors
- [ ] Verify regular rate limits still retry properly (not context-related)