### PR TITLE
Fixing Content Truncation issues with Large files

### DIFF
--- a/src/core/task/tools/handlers/AccessMcpResourceHandler.ts
+++ b/src/core/task/tools/handlers/AccessMcpResourceHandler.ts
@@ -2,6 +2,7 @@ import type { ToolUse } from "@core/assistant-message"
 import { formatResponse } from "@core/prompts/responses"
 import { ClineAsk, ClineAskUseMcpServer } from "@shared/ExtensionMessage"
 import { telemetryService } from "@/services/telemetry"
+import { truncateContent } from "@/shared/content-limits"
 import { ClineDefaultTool } from "@/shared/tools"
 import type { ToolResponse } from "../../index"
 import { showNotificationForApproval } from "../../utils"
@@ -158,7 +159,10 @@ export class AccessMcpResourceHandler implements IFullyManagedTool {
 		// Display result to user
 		await config.callbacks.say("mcp_server_response", resourceResultPretty)
 
+		// Truncate response if it exceeds 400KB to prevent context overflow
+		const truncatedResult = truncateContent(resourceResultPretty)
+
 		// Return formatted result
-		return formatResponse.toolResult(resourceResultPretty)
+		return formatResponse.toolResult(truncatedResult)
 	}
 }

--- a/src/core/task/tools/handlers/UseMcpToolHandler.ts
+++ b/src/core/task/tools/handlers/UseMcpToolHandler.ts
@@ -2,6 +2,7 @@ import type { ToolUse } from "@core/assistant-message"
 import { formatResponse } from "@core/prompts/responses"
 import { ClineAsk, ClineAskUseMcpServer } from "@shared/ExtensionMessage"
 import { telemetryService } from "@/services/telemetry"
+import { truncateContent } from "@/shared/content-limits"
 import { ClineDefaultTool } from "@/shared/tools"
 import type { ToolResponse } from "../../index"
 import { showNotificationForApproval } from "../../utils"
@@ -203,6 +204,9 @@ export class UseMcpToolHandler implements IFullyManagedTool {
 			if (toolResultImages.length > 0 && !supportsImages) {
 				toolResultText += `\n\n[${toolResultImages.length} images were provided in the response, and while they are displayed to the user, you do not have the ability to view them.]`
 			}
+
+			// Truncate response if it exceeds 400KB to prevent context overflow
+			toolResultText = truncateContent(toolResultText)
 
 			// Return formatted result (only pass images if model supports them)
 			return formatResponse.toolResult(toolResultText, supportsImages ? toolResultImages : undefined)

--- a/src/integrations/misc/extract-text.ts
+++ b/src/integrations/misc/extract-text.ts
@@ -5,8 +5,9 @@ import { isBinaryFile } from "isbinaryfile"
 import * as chardet from "jschardet"
 import mammoth from "mammoth"
 import * as path from "path"
-// @ts-ignore-next-line
+// @ts-expect-error-next-line
 import pdf from "pdf-parse/lib/pdf-parse"
+import { truncateContent } from "@/shared/content-limits"
 import { Logger } from "@/shared/services/Logger"
 import { sanitizeNotebookForLLM } from "./notebook-utils"
 
@@ -38,29 +39,41 @@ export async function extractTextFromFile(filePath: string): Promise<string> {
 }
 
 /**
- * Expects the fs.access call to have already been performed prior to calling
+ * Expects the fs.access call to have already been performed prior to calling.
+ * Content is automatically truncated if it exceeds 400KB to prevent context overflow.
  */
 export async function callTextExtractionFunctions(filePath: string): Promise<string> {
 	const fileExtension = path.extname(filePath).toLowerCase()
 
+	let content: string
+
 	switch (fileExtension) {
 		case ".pdf":
-			return extractTextFromPDF(filePath)
+			content = await extractTextFromPDF(filePath)
+			break
 		case ".docx":
-			return extractTextFromDOCX(filePath)
+			content = await extractTextFromDOCX(filePath)
+			break
 		case ".ipynb":
-			return extractTextFromIPYNB(filePath)
+			content = await extractTextFromIPYNB(filePath)
+			break
 		case ".xlsx":
-			return extractTextFromExcel(filePath)
+			content = await extractTextFromExcel(filePath)
+			break
 		default:
-			const fileBuffer = await fs.readFile(filePath)
-			if (fileBuffer.byteLength > 20 * 1000 * 1024) {
+			// Check file size with stat() first - faster than reading entire file for size check
+			const fileStat = await fs.stat(filePath)
+			if (fileStat.size > 20 * 1000 * 1024) {
 				// 20MB limit (20 * 1000 * 1024 bytes, decimal MB)
 				throw new Error(`File is too large to read into context.`)
 			}
+			const fileBuffer = await fs.readFile(filePath)
 			const encoding = await detectEncoding(fileBuffer, fileExtension)
-			return iconv.decode(fileBuffer, encoding)
+			content = iconv.decode(fileBuffer, encoding)
 	}
+
+	// Truncate content if it exceeds 400KB to prevent context overflow
+	return truncateContent(content)
 }
 
 async function extractTextFromPDF(filePath: string): Promise<string> {

--- a/src/shared/content-limits.ts
+++ b/src/shared/content-limits.ts
@@ -1,0 +1,39 @@
+/**
+ * Content size limits to prevent massive files/responses from bricking conversations.
+ * 400KB ≈ ~100,000 tokens, which is a reasonable limit for context.
+ */
+
+/** Maximum content size in bytes (400KB) */
+export const MAX_CONTENT_SIZE_BYTES = 400 * 1024
+
+/**
+ * Format bytes into a human-readable string (e.g., "1.5 MB", "400 KB").
+ */
+export function formatBytes(bytes: number): string {
+	if (bytes < 1024) {
+		return `${bytes} B`
+	}
+	if (bytes < 1024 * 1024) {
+		return `${(bytes / 1024).toFixed(1)} KB`
+	}
+	return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
+}
+
+/**
+ * Truncate content if it exceeds the maximum size limit.
+ * Shows the beginning of the content with a clear truncation notice at the very end.
+ *
+ * @param content The content to potentially truncate
+ * @param maxSize Maximum size in bytes (defaults to MAX_CONTENT_SIZE_BYTES)
+ * @returns The original content if under limit, or truncated content with message at end
+ */
+export function truncateContent(content: string, maxSize: number = MAX_CONTENT_SIZE_BYTES): string {
+	if (content.length <= maxSize) {
+		return content
+	}
+
+	const truncatedContent = content.slice(0, maxSize)
+	const truncatedAmount = content.length - maxSize
+
+	return `${truncatedContent}\n\n---\n\n[FILE TRUNCATED: This content is ${formatBytes(content.length)} but only the first ${formatBytes(maxSize)} is shown (${formatBytes(truncatedAmount)} truncated). Use search_files to find specific patterns, or execute_command with grep/head/tail for targeted reading.]`
+}


### PR DESCRIPTION

### Description

This PR adds content truncation (100KB limit) to prevent large files and MCP responses from overwhelming the conversation context. Without this limit, reading very large files or receiving huge MCP tool responses could "brick" conversations by consuming too much context.

**Changes:**
- Add `truncateContent()` utility in `src/shared/content-limits.ts` with a 100KB limit (~25,000 tokens)
- Apply truncation to file reading in `extract-text.ts` (PDF, DOCX, IPYNB, XLSX, and plain text)
- Apply truncation to MCP tool responses (`UseMcpToolHandler.ts`) and MCP resource access (`AccessMcpResourceHandler.ts`)
- Update tool descriptions for `read_file`, `access_mcp_resource`, and `use_mcp_tool` to inform the model about truncation behavior
- Truncation message guides users to use `search_files` or `grep/head/tail` for targeted reading of large files

### Test Procedure

1. Read a file larger than 100KB - verify it's truncated with a clear message
2. Call an MCP tool that returns a very large response - verify truncation applies
3. Normal files under 100KB should not be affected

### Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

### Pre-flight Checklist

- [x] Changes are limited to a single feature, bugfix or chore
- [ ] Tests are passing (`npm test`)
- [ ] I have created a changeset using `npm run changeset`
- [x] I have reviewed contributor guidelines


### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [ ] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds content truncation utility to limit large file and MCP response sizes to 400KB, applied in file reading and MCP handlers.
> 
>   - **Behavior**:
>     - Introduces `truncateContent()` in `content-limits.ts` to limit content to 400KB (~100,000 tokens).
>     - Applies truncation to file reading in `extract-text.ts` for PDF, DOCX, IPYNB, XLSX, and plain text files.
>     - Applies truncation to MCP tool responses in `AccessMcpResourceHandler.ts` and `UseMcpToolHandler.ts`.
>   - **Documentation**:
>     - Updates tool descriptions to inform about truncation behavior.
>     - Guides users to use `search_files` or `grep/head/tail` for targeted reading of large files.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for a6061dc19a389a67afc6c2041e941ead0fa8a84a. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->