### PR TITLE
fix: use 'cline task --yolo' instead of 'cline --yolo' in PR review workflow

### DIFF
--- a/.github/workflows/cline-pr-review.yml
+++ b/.github/workflows/cline-pr-review.yml
@@ -103,7 +103,7 @@ jobs:
               ]
             }
         run: |
-          npx cline --yolo 'You'\''re a GitHub PR reviewer for the open source Cline repository. Your goal is to give the PR author helpful feedback and give maintainers the context they need to review efficiently.
+          npx cline task --yolo 'You'\''re a GitHub PR reviewer for the open source Cline repository. Your goal is to give the PR author helpful feedback and give maintainers the context they need to review efficiently.
 
           PR: #'"${PR_NUMBER}"'
 


### PR DESCRIPTION
## Summary

Fixes the broken `cline-pr-review.yml` workflow by changing the CLI invocation from `cline --yolo` to `cline task --yolo`.

## Problem

The workflow was failing with:
```
Empty input received from stdin. Please provide content to process.
```

This error occurs because the CLI's default command checks `process.stdin.isTTY` to determine if stdin is piped. In CI environments (GitHub Actions), `process.stdin.isTTY` is `false` even when nothing is actually piped, causing the CLI to wait for stdin input that never arrives.

## Solution

Use the `task` subcommand which passes the prompt directly to `runTask()` without the stdin detection logic:
```bash
# Before (broken in CI)
npx cline --yolo 'prompt...'

# After (works in CI)
npx cline task --yolo 'prompt...'
```

Also updated the model ID from `claude-opus-4-5-20251101` to `claude-opus-4-20250514`.

## Testing

This can be verified by manually triggering the workflow on any PR:
```bash
gh workflow run cline-pr-review.yml -f pr_number=<any-pr-number>
```
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes `cline-pr-review.yml` workflow by changing CLI command to `cline task --yolo` and updates model ID.
> 
>   - **Behavior**:
>     - Fixes `cline-pr-review.yml` workflow by changing CLI command from `cline --yolo` to `cline task --yolo` to avoid stdin issue in CI.
>     - Updates model ID from `claude-opus-4-5-20251101` to `claude-opus-4-20250514` in `cline-pr-review.yml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 2a5a8441600aaea85bff2f10346a79fe4b3e0f3d. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->