### PR TITLE
javascript fix(cli): handle stdin redirection in CI environments

### DIFF
--- a/.changeset/fix-cli-stdin-ci.md
+++ b/.changeset/fix-cli-stdin-ci.md
@@ -1,0 +1,5 @@
+---
+"cline": patch
+---
+
+Fix CLI crashing in CI environments and with stdin redirection (e.g., `cline "prompt" < /dev/null`). Now checks both stdin and stdout TTY status before using Ink, and only errors on empty stdin when no prompt is provided.

--- a/cli/src/utils/mode-selection.test.ts
+++ b/cli/src/utils/mode-selection.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, it } from "vitest"
+import { selectOutputMode } from "./mode-selection"
+
+describe("selectOutputMode", () => {
+	describe("interactive mode (Ink)", () => {
+		it("should use interactive mode when both stdin and stdout are TTY", () => {
+			const result = selectOutputMode({
+				stdoutIsTTY: true,
+				stdinIsTTY: true,
+				stdinWasPiped: false,
+			})
+			expect(result.usePlainTextMode).toBe(false)
+			expect(result.reason).toBe("interactive")
+		})
+	})
+
+	describe("yolo flag", () => {
+		it("should use plain text mode when --yolo flag is set", () => {
+			const result = selectOutputMode({
+				stdoutIsTTY: true,
+				stdinIsTTY: true,
+				stdinWasPiped: false,
+				yolo: true,
+			})
+			expect(result.usePlainTextMode).toBe(true)
+			expect(result.reason).toBe("yolo_flag")
+		})
+
+		it("should prioritize yolo over other flags", () => {
+			const result = selectOutputMode({
+				stdoutIsTTY: false,
+				stdinIsTTY: false,
+				stdinWasPiped: true,
+				json: true,
+				yolo: true,
+			})
+			expect(result.reason).toBe("yolo_flag")
+		})
+	})
+
+	describe("json flag", () => {
+		it("should use plain text mode when --json flag is set", () => {
+			const result = selectOutputMode({
+				stdoutIsTTY: true,
+				stdinIsTTY: true,
+				stdinWasPiped: false,
+				json: true,
+			})
+			expect(result.usePlainTextMode).toBe(true)
+			expect(result.reason).toBe("json")
+		})
+	})
+
+	describe("piped stdin", () => {
+		it("should use plain text mode when stdin was piped (echo x | cline)", () => {
+			const result = selectOutputMode({
+				stdoutIsTTY: true,
+				stdinIsTTY: false, // piped stdin is not a TTY
+				stdinWasPiped: true,
+			})
+			expect(result.usePlainTextMode).toBe(true)
+			expect(result.reason).toBe("piped_stdin")
+		})
+
+		it("should use plain text mode when stdin was piped but empty (echo '' | cline 'prompt')", () => {
+			const result = selectOutputMode({
+				stdoutIsTTY: true,
+				stdinIsTTY: false,
+				stdinWasPiped: true, // empty pipe still counts as piped
+			})
+			expect(result.usePlainTextMode).toBe(true)
+			expect(result.reason).toBe("piped_stdin")
+		})
+	})
+
+	describe("stdin redirected (< /dev/null)", () => {
+		it("should use plain text mode when stdin is redirected from /dev/null", () => {
+			// cline "prompt" < /dev/null
+			// stdin is not a TTY, but also not a FIFO/file, so stdinWasPiped=false
+			const result = selectOutputMode({
+				stdoutIsTTY: true,
+				stdinIsTTY: false, // redirected, not a TTY
+				stdinWasPiped: false, // /dev/null is a character device, not FIFO
+			})
+			expect(result.usePlainTextMode).toBe(true)
+			expect(result.reason).toBe("stdin_redirected")
+		})
+	})
+
+	describe("stdout redirected", () => {
+		it("should use plain text mode when stdout is redirected to file", () => {
+			// cline "prompt" > output.txt
+			const result = selectOutputMode({
+				stdoutIsTTY: false,
+				stdinIsTTY: true,
+				stdinWasPiped: false,
+			})
+			expect(result.usePlainTextMode).toBe(true)
+			expect(result.reason).toBe("stdout_redirected")
+		})
+
+		it("should use plain text mode when stdout is piped", () => {
+			// cline "prompt" | grep something
+			const result = selectOutputMode({
+				stdoutIsTTY: false,
+				stdinIsTTY: true,
+				stdinWasPiped: false,
+			})
+			expect(result.usePlainTextMode).toBe(true)
+			expect(result.reason).toBe("stdout_redirected")
+		})
+	})
+
+	describe("GitHub Actions scenarios", () => {
+		it("should use plain text mode in GitHub Actions (stdin is empty FIFO)", () => {
+			// In GitHub Actions: stdin is an empty FIFO pipe
+			// stdinIsTTY=false, stdinWasPiped=true (FIFO detected)
+			const result = selectOutputMode({
+				stdoutIsTTY: true, // GitHub Actions stdout is TTY-like
+				stdinIsTTY: false,
+				stdinWasPiped: true, // empty FIFO still counts as piped
+			})
+			expect(result.usePlainTextMode).toBe(true)
+		})
+
+		it("should use plain text mode with --yolo in CI", () => {
+			const result = selectOutputMode({
+				stdoutIsTTY: false,
+				stdinIsTTY: false,
+				stdinWasPiped: false,
+				yolo: true,
+			})
+			expect(result.usePlainTextMode).toBe(true)
+			expect(result.reason).toBe("yolo_flag")
+		})
+	})
+
+	describe("real-world scenarios", () => {
+		it("cline (no args, interactive terminal)", () => {
+			const result = selectOutputMode({
+				stdoutIsTTY: true,
+				stdinIsTTY: true,
+				stdinWasPiped: false,
+			})
+			expect(result.usePlainTextMode).toBe(false)
+		})
+
+		it('cline "prompt" (prompt arg, interactive terminal)', () => {
+			const result = selectOutputMode({
+				stdoutIsTTY: true,
+				stdinIsTTY: true,
+				stdinWasPiped: false,
+			})
+			expect(result.usePlainTextMode).toBe(false)
+		})
+
+		it('cat file | cline "explain"', () => {
+			const result = selectOutputMode({
+				stdoutIsTTY: true,
+				stdinIsTTY: false,
+				stdinWasPiped: true,
+			})
+			expect(result.usePlainTextMode).toBe(true)
+		})
+
+		it('cline --yolo "prompt"', () => {
+			const result = selectOutputMode({
+				stdoutIsTTY: true,
+				stdinIsTTY: true,
+				stdinWasPiped: false,
+				yolo: true,
+			})
+			expect(result.usePlainTextMode).toBe(true)
+		})
+
+		it('cline "prompt" < /dev/null', () => {
+			const result = selectOutputMode({
+				stdoutIsTTY: true,
+				stdinIsTTY: false,
+				stdinWasPiped: false,
+			})
+			expect(result.usePlainTextMode).toBe(true)
+		})
+
+		it('cline "prompt" > output.log', () => {
+			const result = selectOutputMode({
+				stdoutIsTTY: false,
+				stdinIsTTY: true,
+				stdinWasPiped: false,
+			})
+			expect(result.usePlainTextMode).toBe(true)
+		})
+	})
+})

--- a/cli/src/utils/mode-selection.ts
+++ b/cli/src/utils/mode-selection.ts
@@ -1,0 +1,63 @@
+/**
+ * Mode selection logic for CLI - determines whether to use Ink (interactive) or plain text mode
+ *
+ * This is extracted as a pure function for testability. The decision tree:
+ * - Plain text mode when output is redirected (stdout not TTY)
+ * - Plain text mode when input is redirected (stdin not TTY) - Ink requires raw mode
+ * - Plain text mode when stdin was piped (e.g., echo "x" | cline)
+ * - Plain text mode when --json flag is used
+ * - Plain text mode when --yolo flag is used
+ * - Otherwise: Interactive Ink mode
+ */
+
+export interface ModeSelectionInput {
+	/** Is stdout connected to a TTY (interactive terminal)? */
+	stdoutIsTTY: boolean
+	/** Is stdin connected to a TTY (interactive terminal)? */
+	stdinIsTTY: boolean
+	/** Was stdin piped (FIFO or file), even if empty? */
+	stdinWasPiped: boolean
+	/** --json flag for machine-readable output */
+	json?: boolean
+	/** --yolo flag for auto-approve mode */
+	yolo?: boolean
+}
+
+export interface ModeSelectionResult {
+	/** Use plain text mode instead of Ink */
+	usePlainTextMode: boolean
+	/** Reason for the mode selection (for telemetry/debugging) */
+	reason: "interactive" | "yolo_flag" | "json" | "piped_stdin" | "stdin_redirected" | "stdout_redirected"
+}
+
+/**
+ * Determine whether to use plain text mode or interactive Ink mode
+ *
+ * @param input - Environment and option flags
+ * @returns Mode selection result with reason
+ */
+export function selectOutputMode(input: ModeSelectionInput): ModeSelectionResult {
+	// Priority order matters - check most specific flags first
+
+	if (input.yolo) {
+		return { usePlainTextMode: true, reason: "yolo_flag" }
+	}
+
+	if (input.json) {
+		return { usePlainTextMode: true, reason: "json" }
+	}
+
+	if (input.stdinWasPiped) {
+		return { usePlainTextMode: true, reason: "piped_stdin" }
+	}
+
+	if (!input.stdinIsTTY) {
+		return { usePlainTextMode: true, reason: "stdin_redirected" }
+	}
+
+	if (!input.stdoutIsTTY) {
+		return { usePlainTextMode: true, reason: "stdout_redirected" }
+	}
+
+	return { usePlainTextMode: false, reason: "interactive" }
+}


### PR DESCRIPTION
### Related Issue

**Issue:** Fixes regression introduced in #9038

### Description

Fix CLI crashing in CI environments (like GitHub Actions) when stdin is redirected (e.g., `< /dev/null`).

**Problem:**
In CI environments, stdin is typically redirected from `/dev/null`, meaning `process.stdin.isTTY` is `false`. The CLI was:
1. Detecting this as "piped input" and trying to read from stdin
2. Erroring with `Empty input received from stdin` even when a prompt argument was provided

This broke the `cline-pr-review.yml` workflow which runs:
```bash
npx cline --yolo 'Your PR review prompt...'
```

**Solution:**
1. **Extract mode selection into testable utility** - Created `cli/src/utils/mode-selection.ts` with `selectOutputMode()` function that determines when to use plain text mode vs interactive Ink mode.

2. **Add comprehensive unit tests** - Added 17 test cases in `cli/src/utils/mode-selection.test.ts` covering all stdin/stdout/TTY scenarios.

3. **Check `stdinIsTTY` for plain text mode** - Now uses plain text mode when stdin is not a TTY, avoiding Ink's raw mode requirement which fails on non-TTY streams.

4. **Only error on empty stdin when no prompt provided** - Changed from `if (stdinInput === "")` to `if (stdinInput === "" && !prompt)`. This allows:
   - `echo "" | cline` → error (no content, no prompt)
   - `cline "prompt" < /dev/null` → OK (has prompt, ignore empty stdin)
   - `cat file | cline "explain"` → OK (has content AND prompt)

### Test Procedure

**Unit tests (17 test cases):**
```bash
cd cli && npm test -- --reporter=verbose src/utils/mode-selection.test.ts
```

Tests cover:
- Yolo flag → plain text mode
- JSON flag → plain text mode
- Piped stdin → plain text mode
- Stdin not TTY → plain text mode
- Stdout not TTY → plain text mode
- Interactive (both TTYs) → Ink mode
- Reason codes for telemetry

**Manual testing:**
```bash
# Redirected stdin (CI scenario) - previously crashed
cline "say hello" < /dev/null       # ✅ Works

# Empty piped stdin with prompt - previously errored
echo "" | cline "say hello"          # ✅ Works

# Empty piped stdin without prompt - should error
echo "" | cline                      # ✅ Errors as expected

# Yolo mode
cline --yolo "say hello"             # ✅ Works

# Redirected stdout
cline "say hello" > output.txt       # ✅ Works

# Piped input with content
echo "explain this" | cline          # ✅ Works
```

Verified the exact error from failed CI runs (`Empty input received from stdin. Please provide content to process.`) matches what this fix addresses.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots
<img width="1112" height="665" alt="Screenshot 2026-02-05 at 11 39 45 AM" src="https://github.com/user-attachments/assets/7e7e828e-4f14-4bf5-82d1-1211a9d4f3ed" />

### Additional Notes

Once this PR is merged and a new CLI version is published to npm, the `cline-pr-review.yml` workflow will work automatically.