### PR TITLE
feat: add GPT-5.3 Codex model for ChatGPT subscription users

### DIFF
--- a/cli/src/constants/featured-models.ts
+++ b/cli/src/constants/featured-models.ts
@@ -19,8 +19,8 @@ export const FEATURED_MODELS = {
 			labels: ["BEST"],
 		},
 		{
-			id: "openai/gpt-5.3-codex",
-			name: "GPT 5.3 Codex",
+			id: "openai/gpt-5.2-codex",
+			name: "GPT 5.2 Codex",
 			description: "OpenAI's latest with strong coding abilities",
 			labels: ["NEW"],
 		},

--- a/webview-ui/src/components/settings/OpenRouterModelPicker.tsx
+++ b/webview-ui/src/components/settings/OpenRouterModelPicker.tsx
@@ -64,7 +64,7 @@ export const recommendedModels = [
 		label: "NEW",
 	},
 	{
-		id: "openai/gpt-5.3-codex",
+		id: "openai/gpt-5.2-codex",
 		description: "OpenAI's latest with strong coding abilities",
 		label: "NEW",
 	},


### PR DESCRIPTION
## Summary

OpenAI released GPT-5.3 Codex today. This adds it to the OpenAI Codex provider (ChatGPT Plus/Pro subscription) model list.

- Add `gpt-5.3-codex` to `openAiCodexModels` with same specs as 5.2 (128k max tokens, 400k context, reasoning support)
- Update default model from `gpt-5.2-codex` to `gpt-5.3-codex`
- Update featured models in CLI and webview OpenRouter picker

## Test plan

- [x] Tested locally with ChatGPT subscription - model works via the Codex backend API
- [ ] Verify model appears in OpenAI Codex provider dropdown
- [ ] Verify it's selected as default for new users
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add `gpt-5.3-codex` to OpenAI Codex models and set it as the default model, updating CLI and webview pickers.
> 
>   - **Behavior**:
>     - Add `gpt-5.3-codex` to `openAiCodexModels` with 128k max tokens, 400k context, reasoning support.
>     - Update default model from `gpt-5.2-codex` to `gpt-5.3-codex` in `api.ts`.
>     - Update featured models in CLI and webview OpenRouter picker.
>   - **Testing**:
>     - Tested locally with ChatGPT subscription; model works via Codex backend API.
>     - Pending verification for model appearance in OpenAI Codex provider dropdown and default selection for new users.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for c10daaa98d987b53076ee81cca620b2f499544f5. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->