### PR TITLE
Revert LiteLLM model name change and use the rawModel name

### DIFF
--- a/src/core/controller/models/refreshLiteLlmModels.ts
+++ b/src/core/controller/models/refreshLiteLlmModels.ts
@@ -53,6 +53,11 @@ export async function refreshLiteLlmModels(): Promise<Record<string, ModelInfo>>
 					description: undefined,
 				}
 
+				// Use litellm_params.model as the key since that's the actual model ID users select
+				// model_name may not include the region prefix (e.g., "us." for Bedrock models)
+				if (rawModel.litellm_params?.model) {
+					models[rawModel.litellm_params?.model] = modelInfo
+				}
 				models[rawModel.model_name] = modelInfo
 			}
 		}


### PR DESCRIPTION
### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** #9024 #9115

### Description

This PR reverts the change that uses the specific `litellm_params?.model`, since the model name allows LiteLLM to route models.
The new selector allows inputting whatever model id, which should allow users to still enter very specific model ids.
An option is to keep both in the model list.
List post changes:
<img width="267" height="253" alt="image" src="https://github.com/user-attachments/assets/2912270c-cb18-4d96-a6e2-0c6b985a4d44" />


### Test Procedure

Tested locally.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Reverts model ID handling in `refreshLiteLlmModels.ts` to use both `litellm_params.model` and `model_name` for flexible input and routing.
> 
>   - **Behavior**:
>     - Reverts to using both `litellm_params.model` and `model_name` as keys in `refreshLiteLlmModels()`.
>     - Allows users to input specific model IDs while maintaining routing capabilities.
>   - **Files**:
>     - Modifies `refreshLiteLlmModels.ts` to handle model IDs using both `litellm_params.model` and `model_name`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 8b49418632690df41e8b6beacbbc1ff9d0135014. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->