### PR TITLE
Fix Bedrock Opus 4.6 model id

### DIFF
--- a/.changeset/plain-lies-repair.md
+++ b/.changeset/plain-lies-repair.md
@@ -1,0 +1,5 @@
+---
+"cline": patch
+---
+
+Fix Bedrock model id

--- a/src/core/api/providers/bedrock.ts
+++ b/src/core/api/providers/bedrock.ts
@@ -113,8 +113,8 @@ interface ProviderChainOptions {
 // a special jp inference profile was created for opus 4.6, sonnet 4.5 & haiku 4.5
 // https://docs.aws.amazon.com/bedrock/latest/userguide/inference-profiles-support.html
 const JP_SUPPORTED_CRIS_MODELS = [
-	"anthropic.claude-opus-4-6-v1:0",
-	"anthropic.claude-opus-4-6-v1:0:1m",
+	"anthropic.claude-opus-4-6-v1",
+	"anthropic.claude-opus-4-6-v1:1m",
 	"anthropic.claude-sonnet-4-5-20250929-v1:0",
 	"anthropic.claude-sonnet-4-5-20250929-v1:0:1m",
 	"anthropic.claude-haiku-4-5-20251001-v1:0",

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -460,7 +460,7 @@ export const bedrockModels = {
 		cacheReadsPrice: 0.3,
 		tiers: CLAUDE_SONNET_1M_TIERS,
 	},
-	"anthropic.claude-opus-4-6-v1:0": {
+	"anthropic.claude-opus-4-6-v1": {
 		maxTokens: 8192,
 		contextWindow: 200_000,
 		supportsImages: true,
@@ -472,7 +472,7 @@ export const bedrockModels = {
 		cacheWritesPrice: 6.25,
 		cacheReadsPrice: 0.5,
 	},
-	"anthropic.claude-opus-4-6-v1:0:1m": {
+	"anthropic.claude-opus-4-6-v1:1m": {
 		maxTokens: 8192,
 		contextWindow: 1_000_000,
 		supportsImages: true,

--- a/webview-ui/src/components/settings/providers/BedrockProvider.tsx
+++ b/webview-ui/src/components/settings/providers/BedrockProvider.tsx
@@ -13,8 +13,8 @@ import { getModeSpecificFields, normalizeApiConfiguration } from "../utils/provi
 import { useApiConfigurationHandlers } from "../utils/useApiConfigurationHandlers"
 
 export const SUPPORTED_BEDROCK_THINKING_MODELS = [
-	"anthropic.claude-opus-4-6-v1:0",
-	`anthropic.claude-opus-4-6-v1:0${CLAUDE_SONNET_1M_SUFFIX}`,
+	"anthropic.claude-opus-4-6-v1",
+	`anthropic.claude-opus-4-6-v1${CLAUDE_SONNET_1M_SUFFIX}`,
 	"anthropic.claude-3-7-sonnet-20250219-v1:0",
 	"anthropic.claude-sonnet-4-20250514-v1:0",
 	"anthropic.claude-sonnet-4-5-20250929-v1:0",


### PR DESCRIPTION
## Summary
- Correct the Bedrock Opus 4.6 model ID from `anthropic.claude-opus-4-6-v1:0` to `anthropic.claude-opus-4-6-v1`
- Correct the 1m variant from `anthropic.claude-opus-4-6-v1:0:1m` to `anthropic.claude-opus-4-6-v1:1m`

## Test plan
- [x] Verify Bedrock Opus 4.6 model works correctly after the fix
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes Bedrock Opus 4.6 model ID and its 1m variant in `bedrock.ts`, `api.ts`, and `BedrockProvider.tsx`.
> 
>   - **Model ID Corrections**:
>     - Corrects Bedrock Opus 4.6 model ID from `anthropic.claude-opus-4-6-v1:0` to `anthropic.claude-opus-4-6-v1` in `bedrock.ts`, `api.ts`, and `BedrockProvider.tsx`.
>     - Corrects 1m variant from `anthropic.claude-opus-4-6-v1:0:1m` to `anthropic.claude-opus-4-6-v1:1m` in `bedrock.ts`, `api.ts`, and `BedrockProvider.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for e596538f18fcc41bcb76e97ed35f36b333ba52c0. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->