### PR TITLE
update changelog for 3.57.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [3.57.1]
+
+### Fixed
+
+- Fixed Opus 4.6 for bedrock provider
+
 ## [3.57.0]
 
 ### Added


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update `CHANGELOG.md` to document fix for Opus 4.6 in bedrock provider for version 3.57.1.
> 
>   - **Changelog**:
>     - Update `CHANGELOG.md` to include fix for Opus 4.6 for bedrock provider in version 3.57.1.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for a8b3e13bb500c666c1dca737f3b666f4e8b91cb9. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->