### PR TITLE
fix(ui): add loading indicator and fix api_req_started rendering

### DIFF
--- a/webview-ui/src/components/chat/RequestStartRow.tsx
+++ b/webview-ui/src/components/chat/RequestStartRow.tsx
@@ -1,6 +1,6 @@
-import { ClineMessage, ClineSayTool } from "@shared/ExtensionMessage"
-import { Mode } from "@shared/storage/types"
-import { LucideIcon } from "lucide-react"
+import type { ClineMessage, ClineSayTool } from "@shared/ExtensionMessage"
+import type { Mode } from "@shared/storage/types"
+import type { LucideIcon } from "lucide-react"
 import type React from "react"
 import { useMemo } from "react"
 import { cleanPathPrefix } from "../common/CodeAccordian"
@@ -206,6 +206,9 @@ export const RequestStartRow: React.FC<RequestStartRowProps> = ({
 	// Only show currentActivities if there are NO completed tools
 	// (otherwise they'll be shown in the unified ToolGroupRenderer list)
 	const shouldShowActivities = currentActivities.length > 0 && !hasCompletedTools
+
+	// Initial loading ("Thinking..." before any content) is handled by the MessagesArea Footer
+	// to avoid flicker during the handoff between Footer and this component.
 
 	return (
 		<div>

--- a/webview-ui/src/components/chat/chat-view/components/messages/MessageRenderer.tsx
+++ b/webview-ui/src/components/chat/chat-view/components/messages/MessageRenderer.tsx
@@ -1,10 +1,11 @@
-import { ClineMessage } from "@shared/ExtensionMessage"
-import React, { useMemo } from "react"
+import type { ClineMessage } from "@shared/ExtensionMessage"
+import type React from "react"
+import { useMemo } from "react"
 import BrowserSessionRow from "@/components/chat/BrowserSessionRow"
 import ChatRow from "@/components/chat/ChatRow"
 import { useExtensionState } from "@/context/ExtensionStateContext"
 import { cn } from "@/lib/utils"
-import { MessageHandlers } from "../../types/chatTypes"
+import type { MessageHandlers } from "../../types/chatTypes"
 import { findReasoningForApiReq, isTextMessagePendingToolCall, isToolGroup } from "../../utils/messageUtils"
 import { ToolGroupRenderer } from "./ToolGroupRenderer"
 
@@ -19,6 +20,7 @@ interface MessageRendererProps {
 	onSetQuote: (quote: string | null) => void
 	inputValue: string
 	messageHandlers: MessageHandlers
+	footerActive: boolean
 }
 
 /**
@@ -36,6 +38,7 @@ export const MessageRenderer: React.FC<MessageRendererProps> = ({
 	onSetQuote,
 	inputValue,
 	messageHandlers,
+	footerActive,
 }) => {
 	const { mode } = useExtensionState()
 
@@ -98,7 +101,7 @@ export const MessageRenderer: React.FC<MessageRendererProps> = ({
 	return (
 		<div
 			className={cn({
-				"pb-2.5": isLastMessage,
+				"pb-2.5": isLastMessage && !footerActive,
 			})}
 			data-message-ts={messageOrGroup.ts}>
 			<ChatRow
@@ -135,10 +138,12 @@ export const createMessageRenderer = (
 	onSetQuote: (quote: string | null) => void,
 	inputValue: string,
 	messageHandlers: MessageHandlers,
+	footerActive: boolean,
 ) => {
 	return (index: number, messageOrGroup: ClineMessage | ClineMessage[]) => (
 		<MessageRenderer
 			expandedRows={expandedRows}
+			footerActive={footerActive}
 			groupedMessages={groupedMessages}
 			index={index}
 			inputValue={inputValue}


### PR DESCRIPTION
### Related Issue

Regression from #8264

### Description

The chat streaming UI refactor (#8264) removed the loading indicator that previously showed when an API request was in progress. This left users staring at a frozen UI during the ~500ms-1s latency between sending a message and receiving the first streamed content. The old `ErrorBlockTitle` component showed a spinning `ProgressIndicator` with "API Request..." text during this state, but the new `RequestStartRow` only renders content when tool activities, reasoning, or errors are present.

Additionally, `api_req_started` ChatRows now render as invisible padding since the refactor removed the old accordion UI (cost badge, expandable request payload). Reasoning messages already have their own standalone ChatRows, so these empty rows just waste vertical space throughout the conversation.

Changes:

1. "Thinking..." shimmer in Virtuoso Footer (`MessagesArea.tsx`) - Detects "waiting for response" state by checking if the last message in `modifiedMessages` is: empty (new task), `user_feedback` (follow-up sent), or `api_req_started` with no cost (request in progress, nothing streamed yet). Uses `modifiedMessages` (same source as `groupedMessages`) rather than `clineMessages` from context so both the Footer and the item list update in the same React render cycle, preventing flicker. The Footer is the sole loading indicator - RequestStartRow does not duplicate it.

2. Filter out empty `api_req_started` rows (`messageUtils.ts`) - `api_req_started` messages are now filtered from the visible message list unless they contain error/cancel content. This removes invisible padding that accumulated throughout conversations. Reasoning content is unaffected since `say: "reasoning"` messages render as their own standalone ChatRows.

3. Consistent spacing via `footerActive` flag (`MessageRenderer.tsx`) - Threads `isWaitingForResponse` from `MessagesArea` through the renderer so the last message skips `pb-2.5` bottom padding when the Footer is active, since the Footer provides its own `pt-2` top padding. Without this, there was double spacing between the last message and the indicator.

### Test Procedure

- Start a new task and verify "Thinking..." shimmer appears immediately (no frozen UI during backend processing)
- Verify "Thinking..." transitions smoothly to streamed content (reasoning, tools, text) with no flicker
- Send a follow-up message mid-conversation and verify "Thinking..." appears during the wait
- Verify spacing between "Thinking..." and adjacent messages matches normal ChatRow spacing
- Verify error states still render (cancel a request, trigger an API error)
- Verify conversations don't have invisible padding gaps from empty `api_req_started` rows
- Verify reasoning "Thoughts" sections still appear as standalone collapsible rows

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A - UI change best verified interactively

### Additional Notes

The `api_req_started` filtering is more aggressive than strictly needed for the loading indicator fix, but it cleans up dead weight from the refactor. Every completed `api_req_started` was rendering an empty `<div>` wrapped in a ChatRow with `pt-2.5 px-4` padding, adding invisible spacing throughout conversations.