### PR TITLE
feat: prevent user under remote config from removing remote mcp servers configured by the org

### DIFF
--- a/src/services/mcp/McpHub.ts
+++ b/src/services/mcp/McpHub.ts
@@ -1449,7 +1449,11 @@ export class McpHub {
 		}
 	}
 
-	public async addRemoteServer(serverName: string, serverUrl: string, transportType: string = "streamableHttp"): Promise<McpServer[]> {
+	public async addRemoteServer(
+		serverName: string,
+		serverUrl: string,
+		transportType: string = "streamableHttp",
+	): Promise<McpServer[]> {
 		try {
 			const settings = await this.readAndValidateMcpSettingsFile()
 			if (!settings) {


### PR DESCRIPTION
### Related Issue

closes https://linear.app/cline-bot/issue/PF-461/prevent-user-from-circumventing-remotely-configured-servers-cant-be
part of https://linear.app/cline-bot/issue/PF-286/extension-mcp-remote-server-configuration

### Description

previously, users under remote config are **not** allowed to remove remote mcp servers configured by their org (there is no delete button, and each extension refresh will validate any local edits users make against cline_mcp_settings.json file), but the refresh now went from 30 seconds to an hour, and we want a mechanism to restore the removed mcp server sooner, so we add a restore method to guard against this.  

Note that remote config for mcp is currently under a feature flag. 

### Test Procedure


https://github.com/user-attachments/assets/4ad85dc0-f0fc-49a8-bbe6-bfb769335401



### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `restoreRemoteConfiguredServers()` to `McpHub` to restore remotely configured MCP servers if manually deleted, ensuring enterprise-managed servers are not removed by users.
> 
>   - **Behavior**:
>     - Adds `restoreRemoteConfiguredServers()` to `McpHub` to restore remotely configured MCP servers if manually deleted.
>     - Invoked in `watchMcpSettingsFile()` to ensure prompt restoration of deleted servers.
>     - Remote config feature is under a feature flag.
>   - **Error Handling**:
>     - Logs errors to `Logger` if restoration fails.
>   - **Misc**:
>     - Updates `McpHub` to handle restoration logic and ensure enterprise-managed servers are not removed by users.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 77818011c11245d3905afb09a891239095b74ac9. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->