### PR TITLE
fix(terminal): surface command exit codes in results

### DIFF
--- a/src/integrations/terminal/CommandOrchestrator.test.ts
+++ b/src/integrations/terminal/CommandOrchestrator.test.ts
@@ -1,0 +1,114 @@
+import assert from "node:assert/strict"
+import { EventEmitter } from "events"
+import { describe, it } from "mocha"
+import { orchestrateCommandExecution } from "./CommandOrchestrator"
+import type {
+	CommandExecutorCallbacks,
+	ITerminalManager,
+	ITerminalProcess,
+	OrchestrationResult,
+	TerminalCompletionDetails,
+	TerminalProcessEvents,
+	TerminalProcessResultPromise,
+} from "./types"
+
+class FakeTerminalProcess extends EventEmitter<TerminalProcessEvents> implements ITerminalProcess {
+	isHot = false
+	waitForShellIntegration = false
+	private readonly promise: Promise<void>
+	private resolvePromise!: () => void
+	private rejectPromise!: (error: Error) => void
+
+	constructor() {
+		super()
+		this.promise = new Promise<void>((resolve, reject) => {
+			this.resolvePromise = resolve
+			this.rejectPromise = reject
+		})
+	}
+
+	continue(): void {
+		this.emit("continue")
+		this.resolvePromise()
+	}
+
+	getUnretrievedOutput(): string {
+		return ""
+	}
+
+	getCompletionDetails(): TerminalCompletionDetails {
+		return {}
+	}
+
+	complete(details?: TerminalCompletionDetails): void {
+		this.emit("completed", details)
+		this.emit("continue")
+		this.resolvePromise()
+	}
+
+	fail(error: Error): void {
+		this.emit("error", error)
+		this.rejectPromise(error)
+	}
+
+	asResultPromise(): TerminalProcessResultPromise {
+		const processWithPromise = this as unknown as FakeTerminalProcess & Partial<TerminalProcessResultPromise>
+		processWithPromise.then = this.promise.then.bind(this.promise)
+		processWithPromise.catch = this.promise.catch.bind(this.promise)
+		processWithPromise.finally = this.promise.finally.bind(this.promise)
+		return processWithPromise as TerminalProcessResultPromise
+	}
+}
+
+function createCallbacks(): CommandExecutorCallbacks {
+	return {
+		say: async () => undefined,
+		ask: async () => ({ response: "messageResponse" }),
+		updateBackgroundCommandState: () => {},
+		updateClineMessage: async () => {},
+		getClineMessages: () => [],
+		addToUserMessageContent: () => {},
+	}
+}
+
+function createTerminalManager(): ITerminalManager {
+	return {
+		processOutput: (outputLines: string[]) => outputLines.join("\n"),
+	} as ITerminalManager
+}
+
+describe("CommandOrchestrator exit status messaging", () => {
+	it("reports non-zero exit codes as command failures", async () => {
+		const process = new FakeTerminalProcess()
+		const orchestrationPromise = orchestrateCommandExecution(
+			process.asResultPromise(),
+			createTerminalManager(),
+			createCallbacks(),
+			{ command: "false" },
+		)
+
+		process.complete({ exitCode: 2, signal: null })
+		const result: OrchestrationResult = await orchestrationPromise
+
+		assert.equal(result.completed, true)
+		assert.equal(result.exitCode, 2)
+		assert.match(result.result as string, /^Command failed with exit code 2\./)
+	})
+
+	it("reports successful command completion with explicit exit code", async () => {
+		const process = new FakeTerminalProcess()
+		const orchestrationPromise = orchestrateCommandExecution(
+			process.asResultPromise(),
+			createTerminalManager(),
+			createCallbacks(),
+			{ command: "echo ok" },
+		)
+
+		process.complete({ exitCode: 0, signal: null })
+		const result: OrchestrationResult = await orchestrationPromise
+
+		assert.equal(result.completed, true)
+		assert.equal(result.exitCode, 0)
+		assert.match(result.result as string, /^Command executed successfully \(exit code 0\)\./)
+	})
+})

--- a/src/integrations/terminal/standalone/StandaloneTerminalManager.ts
+++ b/src/integrations/terminal/standalone/StandaloneTerminalManager.ts
@@ -73,10 +73,10 @@ export class StandaloneTerminalManager implements ITerminalManager {
 	private terminalIds: Set<number> = new Set()
 
 	/** Timeout for shell integration (not used in standalone, but kept for interface compatibility) */
-	private shellIntegrationTimeout: number = 4000
+	private shellIntegrationTimeout = 4000
 
 	/** Whether terminal reuse is enabled */
-	private terminalReuseEnabled: boolean = true
+	private terminalReuseEnabled = true
 
 	/** Maximum output lines to keep */
 	private terminalOutputLineLimit: number = DEFAULT_TERMINAL_OUTPUT_LINE_LIMIT
@@ -85,7 +85,7 @@ export class StandaloneTerminalManager implements ITerminalManager {
 	private subagentTerminalOutputLineLimit: number = DEFAULT_SUBAGENT_TERMINAL_OUTPUT_LINE_LIMIT
 
 	/** Default terminal profile */
-	private defaultTerminalProfile: string = "default"
+	private defaultTerminalProfile = "default"
 
 	// =========================================================================
 	// Background Command Tracking
@@ -365,7 +365,7 @@ export class StandaloneTerminalManager implements ITerminalManager {
 	 * @param force If true, closes even busy terminals
 	 * @returns Number of terminals closed
 	 */
-	closeTerminals(filterFn: (terminal: TerminalInfo) => boolean, force: boolean = false): number {
+	closeTerminals(filterFn: (terminal: TerminalInfo) => boolean, force = false): number {
 		const terminalsToClose = this.filterTerminals(filterFn)
 		let closedCount = 0
 
@@ -474,7 +474,7 @@ export class StandaloneTerminalManager implements ITerminalManager {
 		this.backgroundTimeouts.set(id, timeoutId)
 
 		// Listen for completion - clear timeout
-		process.on("completed", () => {
+		process.on("completed", (details) => {
 			// Guard: Skip if already handled by timeout
 			if (backgroundCommand.status !== "running") {
 				return
@@ -484,7 +484,23 @@ export class StandaloneTerminalManager implements ITerminalManager {
 				clearTimeout(timeout)
 				this.backgroundTimeouts.delete(id)
 			}
-			backgroundCommand.status = "completed"
+			const exitCode = details?.exitCode
+			const signal = details?.signal
+			if (typeof exitCode === "number") {
+				backgroundCommand.exitCode = exitCode
+			}
+
+			if ((typeof exitCode === "number" && exitCode !== 0) || signal) {
+				backgroundCommand.status = "error"
+				if (typeof exitCode === "number" && exitCode !== 0) {
+					logStream.write(`\n[EXIT_CODE] Process exited with code ${exitCode}\n`)
+				}
+				if (signal) {
+					logStream.write(`\n[SIGNAL] Process terminated by signal ${signal}\n`)
+				}
+			} else {
+				backgroundCommand.status = "completed"
+			}
 			logStream.end()
 		})
 
@@ -503,7 +519,7 @@ export class StandaloneTerminalManager implements ITerminalManager {
 			// Try to extract exit code from error message if available
 			const exitCodeMatch = error.message.match(/exit code (\d+)/)
 			if (exitCodeMatch) {
-				backgroundCommand.exitCode = parseInt(exitCodeMatch[1], 10)
+				backgroundCommand.exitCode = Number.parseInt(exitCodeMatch[1], 10)
 			}
 			logStream.end()
 		})

--- a/src/integrations/terminal/types.ts
+++ b/src/integrations/terminal/types.ts
@@ -14,10 +14,17 @@ import type { EventEmitter } from "events"
 /**
  * Event types for terminal process
  */
+export interface TerminalCompletionDetails {
+	/** Process exit code when available */
+	exitCode?: number | null
+	/** Termination signal when available */
+	signal?: NodeJS.Signals | null
+}
+
 export interface TerminalProcessEvents {
 	line: [line: string]
 	continue: []
-	completed: []
+	completed: [details?: TerminalCompletionDetails]
 	error: [error: Error]
 	no_shell_integration: []
 }
@@ -57,6 +64,11 @@ export interface ITerminalProcess extends EventEmitter<TerminalProcessEvents> {
 	 * @returns The unretrieved output
 	 */
 	getUnretrievedOutput(): string
+
+	/**
+	 * Get completion metadata for the most recent command execution.
+	 */
+	getCompletionDetails?(): TerminalCompletionDetails
 
 	/**
 	 * Terminate the process if it's still running.
@@ -136,7 +148,7 @@ export type TerminalProcessResultPromise = Promise<void> &
 		/** Listen for line output events */
 		on(event: "line", listener: (line: string) => void): TerminalProcessResultPromise
 		/** Listen for completion event */
-		on(event: "completed", listener: () => void): TerminalProcessResultPromise
+		on(event: "completed", listener: (details?: TerminalCompletionDetails) => void): TerminalProcessResultPromise
 		/** Listen for continue event */
 		on(event: "continue", listener: () => void): TerminalProcessResultPromise
 		/** Listen for error events */
@@ -399,4 +411,8 @@ export interface OrchestrationResult {
 	outputLines: string[]
 	/** Path to log file if output was too large and written to file */
 	logFilePath?: string
+	/** Process exit code when available */
+	exitCode?: number | null
+	/** Process termination signal when available */
+	signal?: NodeJS.Signals | null
 }


### PR DESCRIPTION
### Related Issue

Issue: N/A

### Description

This is PR 2 in the TerminalBench score recovery sequence.

In Harbor TerminalBench failures, we saw cases where command execution looked successful in the assistant-facing summary even when the underlying process exited non-zero. That makes the agent overconfident and increases premature completion risk. The main issue was that orchestration returned a generic "Command executed" message on completion without carrying explicit exit status through the terminal process contract.

This PR makes command completion status explicit and consistent end to end.

What changed:
- Added terminal completion metadata (`exitCode`, `signal`) to the shared terminal process event contract.
- Propagated completion metadata from standalone child process close events.
- Propagated completion metadata from VSCode shell integration output by parsing `]633;D;<exitCode>` markers when available.
- Updated command orchestration result text to distinguish:
  - `Command executed successfully (exit code 0).`
  - `Command failed with exit code N.`
  - `Command terminated by signal X.`
- Updated standalone background command tracking to mark non-zero exit/signal as error and persist exit details.

Why this should improve TerminalBench:
- Strict benchmark tasks often depend on correctly handling failed compile/test/script steps.
- The model now gets direct, structured failure signals instead of ambiguous success phrasing.
- This should reduce false-positive progress and improve retry/fix loops.

Files changed:
- `src/integrations/terminal/types.ts`
- `src/integrations/terminal/CommandOrchestrator.ts`
- `src/integrations/terminal/standalone/StandaloneTerminalProcess.ts`
- `src/integrations/terminal/standalone/StandaloneTerminalManager.ts`
- `src/hosts/vscode/terminal/VscodeTerminalProcess.ts`
- `src/integrations/terminal/CommandOrchestrator.test.ts`

Decisions and tradeoffs:
- I kept this PR focused on signaling, not timeout policy changes, to isolate behavior impact.
- For VSCode terminals, exit code is best-effort because shell integration can be unavailable; we still preserve existing fallback behavior in those cases.
- The orchestration API now carries optional exit metadata so callers can consume richer status in follow-up changes.

### Test Procedure

1. Focused unit test for new behavior:
- `npm run test:unit -- src/integrations/terminal/CommandOrchestrator.test.ts`
- Verifies non-zero exit produces explicit failure status text.
- Verifies zero exit produces explicit success status text.

2. Type safety across all packages:
- `npm run check-types`

Manual sanity checks recommended:
- Run a failing command (`false`, `bash -lc 'exit 7'`) and confirm returned command summary says it failed with that exit code.
- Run a successful command (`echo ok`) and confirm explicit exit code 0 success summary.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Not applicable for this terminal/runtime behavior change.

### Additional Notes

Planned follow-up PRs in this TerminalBench series include timeout strategy tuning and CLI prompt parsing fixes.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Enhances terminal command execution feedback by capturing and propagating exit codes and signals across VSCode and standalone processes.
> 
>   - **Behavior**:
>     - Adds `exitCode` and `signal` to terminal completion metadata in `types.ts`.
>     - Updates `VscodeTerminalProcess` and `StandaloneTerminalProcess` to emit `completed` events with exit details.
>     - Modifies `CommandOrchestrator` to handle and report exit codes and signals in result messages.
>   - **Testing**:
>     - Adds tests in `CommandOrchestrator.test.ts` to verify exit code handling for success and failure cases.
>   - **Misc**:
>     - Updates `StandaloneTerminalManager` to track and log exit codes and signals for background commands.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for b338a6afdfd9c9b91a81253292975aa356a7f0c7. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->