### PR TITLE
feat(cli): allow --thinking flag to accept custom token budget

### DIFF
--- a/cli/src/index.test.ts
+++ b/cli/src/index.test.ts
@@ -30,7 +30,7 @@ describe("CLI Commands", () => {
 			.option("-v, --verbose", "Show verbose output")
 			.option("-c, --cwd <path>", "Working directory")
 			.option("--config <path>", "Configuration directory")
-			.option("--thinking", "Enable extended thinking")
+			.option("--thinking [tokens]", "Enable extended thinking")
 			.option("--reasoning-effort <effort>", "Reasoning effort")
 			.action(() => {})
 
@@ -68,7 +68,7 @@ describe("CLI Commands", () => {
 			.option("-v, --verbose", "Verbose output")
 			.option("-c, --cwd <path>", "Working directory")
 			.option("--config <path>", "Configuration directory")
-			.option("--thinking", "Enable extended thinking")
+			.option("--thinking [tokens]", "Enable extended thinking")
 			.option("--reasoning-effort <effort>", "Reasoning effort")
 			.action(() => {})
 	})
@@ -146,6 +146,13 @@ describe("CLI Commands", () => {
 			const args = ["test prompt", "--thinking"]
 			taskCmd.parse(args, { from: "user" })
 			expect(taskCmd.opts().thinking).toBe(true)
+		})
+
+		it("should parse --thinking with token budget", () => {
+			const taskCmd = program.commands.find((c) => c.name() === "task")!
+			const args = ["test prompt", "--thinking", "8000"]
+			taskCmd.parse(args, { from: "user" })
+			expect(taskCmd.opts().thinking).toBe("8000")
 		})
 
 		it("should parse --reasoning-effort option", () => {
@@ -289,6 +296,11 @@ describe("CLI Commands", () => {
 		it("should parse --thinking flag", () => {
 			program.parse(["node", "cli", "--thinking"])
 			expect(program.opts().thinking).toBe(true)
+		})
+
+		it("should parse --thinking with token budget", () => {
+			program.parse(["node", "cli", "--thinking", "4096"])
+			expect(program.opts().thinking).toBe("4096")
 		})
 
 		it("should parse --reasoning-effort option", () => {


### PR DESCRIPTION
### Related Issue

Extends #9168 (reasoning effort model config)

### Description

The `--thinking` CLI flag previously only toggled extended thinking on/off with a hardcoded 1024 token budget. This change makes it accept an optional number so users can set whatever budget they want.

#### New commands this unlocks

```bash
# Before: only boolean toggle (always 1024 tokens)
cline "prompt" --thinking

# After: optional custom budget
cline "prompt" --thinking           # 1024 tokens (default, same as before)
cline "prompt" --thinking 4096      # 4096 tokens
cline "prompt" --thinking 8000      # 8000 tokens
```

Invalid values (negative numbers, non-numeric strings) get a warning and fall back to 1024.

#### Context on budget sizing

The webview settings UI caps the thinking budget slider at 6000 tokens. You're unlikely to see meaningful benefit going much higher than that for most tasks, but the CLI doesn't enforce a cap -- if you want to experiment with larger budgets, you can.

The budget is applied to both plan and act modes (synced when separate models is disabled, which is the default).

#### Changes

- `cli/src/index.ts`: Changed `--thinking` option from boolean to `[tokens]` (optional argument). Updated `applyTaskOptions` to parse the number with validation and fallback.
- `cli/src/index.test.ts`: Added tests for `--thinking` with a numeric argument alongside existing boolean tests.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> The `--thinking` CLI flag now accepts an optional token budget, defaulting to 1024, with validation for invalid inputs.
> 
>   - **Behavior**:
>     - `--thinking` flag in `cli/src/index.ts` now accepts an optional token budget, defaulting to 1024 if not specified.
>     - Invalid values (negative, non-numeric) fall back to 1024 with a warning.
>   - **Functions**:
>     - `applyTaskOptions` in `cli/src/index.ts` updated to parse and validate `--thinking` token budget.
>   - **Tests**:
>     - Added tests in `cli/src/index.test.ts` for `--thinking` with numeric argument and validation of invalid inputs.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for b714ff9e0ce6162ecb62b4fa51843a5dc1565dd7. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->