### PR TITLE
feat: add output precision and threshold rules to double-check prompt

### DIFF
--- a/src/core/task/tools/handlers/AttemptCompletionHandler.ts
+++ b/src/core/task/tools/handlers/AttemptCompletionHandler.ts
@@ -76,7 +76,9 @@ export class AttemptCompletionHandler implements IToolHandler, IPartialBlockHand
 					"1. All requested changes have been made\n" +
 					"2. No steps were skipped or partially completed\n" +
 					"3. Edge cases and error handling are addressed\n" +
-					"4. The solution matches what was asked for, not just what was convenient" +
+					"4. The solution matches what was asked for, not just what was convenient\n" +
+					"5. Output files contain exactly what was specified--no extra columns, fields, debug output, or commentary\n" +
+					"6. If the task specifies numerical thresholds or accuracy targets, verify your result meets the criteria. If close but not passing, iterate rather than declaring completion" +
 					taskSection +
 					"\n\nIf everything checks out, call attempt_completion again with your final result.",
 			)


### PR DESCRIPTION
### Related Issue

Builds on #9178 and #9180

### Description

Moves Robin's Terminal-Bench-proven rules (output precision and threshold iteration) from the system prompt into the double-check completion re-verification checklist. These rules were proven effective at fixing specific benchmark failures (log-summary-date-ranges and dna-insert), but they belong in the double-check prompt where they're enforced at completion verification time rather than in every system prompt message.

Adds items 5 and 6 to the checklist:
- 5: Output files contain exactly what was specified -- no extra columns, fields, debug output, or commentary
- 6: If the task specifies numerical thresholds or accuracy targets, verify the result meets the criteria before declaring completion

### Test Procedure

The double-check prompt is a string returned as a tool error. The existing unit tests cover the boolean toggle logic. This change only modifies the text content of the rejection message.

### Type of Change

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Refactor Changes
-   [ ] Cosmetic Changes
-   [ ] Documentation update
-   [ ] Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds output precision and threshold verification rules to the double-check prompt in `AttemptCompletionHandler.ts`.
> 
>   - **Behavior**:
>     - Adds rules 5 and 6 to the double-check prompt in `AttemptCompletionHandler.ts` to ensure output precision and threshold verification.
>     - Rule 5: Output files must match specifications without extra data.
>     - Rule 6: Numerical thresholds or accuracy targets must be met before completion.
>   - **Misc**:
>     - Fixes missing newline in the checklist string in `AttemptCompletionHandler.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 7f7e33d2a1858da67eac76fabd9583eef7762c95. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->