### PR TITLE
fix(api): preserve selected Vercel model when model metadata is missing

### DIFF
--- a/src/core/api/providers/__tests__/vercel-ai-gateway.test.ts
+++ b/src/core/api/providers/__tests__/vercel-ai-gateway.test.ts
@@ -1,0 +1,41 @@
+import "should"
+import { openRouterDefaultModelId, openRouterDefaultModelInfo } from "@shared/api"
+import { VercelAIGatewayHandler } from "../vercel-ai-gateway"
+
+describe("VercelAIGatewayHandler", () => {
+	describe("getModel", () => {
+		it("should return configured model and info when both are provided", () => {
+			const customModelInfo = {
+				...openRouterDefaultModelInfo,
+				maxTokens: 123456,
+			}
+
+			const handler = new VercelAIGatewayHandler({
+				openRouterModelId: "google/gemini-3-pro-preview",
+				openRouterModelInfo: customModelInfo,
+			})
+
+			const result = handler.getModel()
+			result.id.should.equal("google/gemini-3-pro-preview")
+			result.info.should.deepEqual(customModelInfo)
+		})
+
+		it("should preserve configured model ID when model info is missing", () => {
+			const handler = new VercelAIGatewayHandler({
+				openRouterModelId: "google/gemini-3-pro-preview",
+			})
+
+			const result = handler.getModel()
+			result.id.should.equal("google/gemini-3-pro-preview")
+			result.info.should.deepEqual(openRouterDefaultModelInfo)
+		})
+
+		it("should fall back to default model when model ID is missing", () => {
+			const handler = new VercelAIGatewayHandler({})
+			const result = handler.getModel()
+
+			result.id.should.equal(openRouterDefaultModelId)
+			result.info.should.deepEqual(openRouterDefaultModelInfo)
+		})
+	})
+})

--- a/src/core/api/providers/vercel-ai-gateway.ts
+++ b/src/core/api/providers/vercel-ai-gateway.ts
@@ -138,6 +138,11 @@ export class VercelAIGatewayHandler implements ApiHandler {
 		if (modelId && modelInfo) {
 			return { id: modelId, info: modelInfo }
 		}
+		// If we have a model ID but no model info, preserve the selected model ID
+		// and fall back only the metadata to defaults.
+		if (modelId) {
+			return { id: modelId, info: openRouterDefaultModelInfo }
+		}
 		return { id: openRouterDefaultModelId, info: openRouterDefaultModelInfo }
 	}
 }


### PR DESCRIPTION
### Related Issue

Issue: N/A

### Description

This PR fixes a model selection bug in the Vercel AI Gateway provider that can silently route requests to the wrong model.

Problem statement:
- In Harbor benchmark runs, we configured trials with `vercel:google/gemini-3-pro-preview`.
- At runtime, many trial artifacts (`prompt_manifest.latest.json`) reported `anthropic/claude-sonnet-4.5`.
- This produced misleading benchmark conclusions because the configured model and the effective model diverged.

Root cause:
- `VercelAIGatewayHandler.getModel()` only returned the configured model when both `openRouterModelId` and `openRouterModelInfo` were present.
- If model info was missing, the method fell back to `openRouterDefaultModelId`, which is currently `anthropic/claude-sonnet-4.5`.
- That fallback changed the actual model identity, not only metadata.

Why this happened in practice:
- The configuration path can set a provider model ID even when per-model metadata is unavailable or not hydrated.
- In that state, using a default model ID is dangerous because it changes model behavior rather than preserving intent.

Technical approach in this PR:
- Updated `VercelAIGatewayHandler.getModel()` to match the already-correct behavior in `ClineHandler.getModel()`.
- New behavior:
  1. If `modelId` and `modelInfo` exist, return both.
  2. If only `modelId` exists, preserve that ID and use `openRouterDefaultModelInfo` as metadata.
  3. If no `modelId` exists, use default ID and default info.

Why this is the right tradeoff:
- Preserving the configured model ID prevents silent model swaps.
- Falling back only metadata is safer than falling back model identity.
- This keeps runtime behavior aligned with user or evaluator intent even when metadata is incomplete.

Debugging journey and validation context:
- We started from benchmark anomalies where Gemini-labeled runs showed unexpectedly Claude-like outcomes.
- We compared `config.json` model settings with runtime prompt manifests in trial artifacts.
- We consistently observed configured Gemini plus runtime Sonnet in affected Vercel runs.
- We then traced model resolution from provider config to `buildApiHandler()` to `VercelAIGatewayHandler.getModel()`.
- We found the strict `modelId && modelInfo` guard causing default-model fallback.
- We verified that `ClineHandler` already contained the safer fallback and mirrored that pattern here.

Alternatives considered:
- Fail hard when `modelInfo` is missing.
  - Rejected because this would turn recoverable config states into hard execution failures.
- Hydrate model metadata eagerly in every auth or config path before task start.
  - Useful follow-up, but larger surface area and not required to fix incorrect model routing.
- Keep existing fallback to default model.
  - Rejected because it silently violates configured model selection.

Non-obvious gotcha discovered:
- A fallback that seems like a metadata default can become a model routing default if `id` and `info` are coupled in one condition.
- This is especially risky in benchmark pipelines where model identity is the primary controlled variable.

### Test Procedure

What I ran locally:
1. `npm ci`
2. `npm run protos`
3. `npm run test:unit -- src/core/api/providers/__tests__/vercel-ai-gateway.test.ts`

What was verified:
- New unit tests validate all three getModel branches:
  - configured id and info
  - configured id without info
  - missing id
- Existing unit suite invoked in this run stayed green in this environment.
- Mocha summary from the run: `865 passing`, `4 pending`.

Risk assessment:
- Low risk, narrow scope.
- Behavior only changes when `modelInfo` is missing.
- Normal path with both id and info remains unchanged.

### Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ♻️ Refactor Changes
- [ ] 💅 Cosmetic Changes
- [ ] 📚 Documentation update
- [ ] 🏃 Workflow Changes

### Pre-flight Checklist

- [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
- [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
- [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
- [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A. This is a backend provider selection fix.

### Additional Notes

This fix intentionally aligns Vercel AI Gateway model fallback behavior with the existing Cline provider behavior to keep model identity stable under partial metadata conditions.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes model selection in `VercelAIGatewayHandler` to preserve configured model ID when metadata is missing, preventing silent model swaps.
> 
>   - **Behavior**:
>     - Fixes model selection in `VercelAIGatewayHandler.getModel()` to preserve configured model ID when metadata is missing.
>     - Aligns behavior with `ClineHandler.getModel()` to prevent silent model swaps.
>   - **Tests**:
>     - Adds `vercel-ai-gateway.test.ts` to test `getModel()` for cases with both model ID and info, only model ID, and missing model ID.
>   - **Misc**:
>     - Updates `getModel()` in `vercel-ai-gateway.ts` to use default metadata when only model ID is present.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for e7fc7a788870dc9032c2158161cafa0bafc20d60. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->