### PR TITLE
feat(cli): add max-consecutive-mistakes flag for yolo runs

### DIFF
--- a/cli/src/index.test.ts
+++ b/cli/src/index.test.ts
@@ -32,6 +32,7 @@ describe("CLI Commands", () => {
 			.option("--config <path>", "Configuration directory")
 			.option("--thinking [tokens]", "Enable extended thinking")
 			.option("--reasoning-effort <effort>", "Reasoning effort")
+			.option("--max-consecutive-mistakes <count>", "Maximum consecutive mistakes")
 			.action(() => {})
 
 		program
@@ -70,6 +71,7 @@ describe("CLI Commands", () => {
 			.option("--config <path>", "Configuration directory")
 			.option("--thinking [tokens]", "Enable extended thinking")
 			.option("--reasoning-effort <effort>", "Reasoning effort")
+			.option("--max-consecutive-mistakes <count>", "Maximum consecutive mistakes")
 			.action(() => {})
 	})
 
@@ -160,6 +162,13 @@ describe("CLI Commands", () => {
 			const args = ["test prompt", "--reasoning-effort", "high"]
 			taskCmd.parse(args, { from: "user" })
 			expect(taskCmd.opts().reasoningEffort).toBe("high")
+		})
+
+		it("should parse --max-consecutive-mistakes option", () => {
+			const taskCmd = program.commands.find((c) => c.name() === "task")!
+			const args = ["test prompt", "--max-consecutive-mistakes", "999"]
+			taskCmd.parse(args, { from: "user" })
+			expect(taskCmd.opts().maxConsecutiveMistakes).toBe("999")
 		})
 
 		it("should parse short flags", () => {
@@ -306,6 +315,11 @@ describe("CLI Commands", () => {
 		it("should parse --reasoning-effort option", () => {
 			program.parse(["node", "cli", "--reasoning-effort", "medium"])
 			expect(program.opts().reasoningEffort).toBe("medium")
+		})
+
+		it("should parse --max-consecutive-mistakes option", () => {
+			program.parse(["node", "cli", "--max-consecutive-mistakes", "7"])
+			expect(program.opts().maxConsecutiveMistakes).toBe("7")
 		})
 	})
 

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -56,6 +56,7 @@ interface TaskOptions {
 	config?: string
 	thinking?: boolean | string
 	reasoningEffort?: string
+	maxConsecutiveMistakes?: string
 	yolo?: boolean
 	doubleCheckCompletion?: boolean
 	timeout?: string
@@ -88,6 +89,20 @@ function normalizeReasoningEffort(value?: string): OpenaiReasoningEffort | undef
 		`Invalid --reasoning-effort '${value}'. Using 'low'. Valid values: ${OPENAI_REASONING_EFFORT_OPTIONS.join(", ")}.`,
 	)
 	return "low"
+}
+
+function normalizeMaxConsecutiveMistakes(value?: string): number | undefined {
+	if (value === undefined) {
+		return undefined
+	}
+
+	const parsed = Number.parseInt(value, 10)
+	if (Number.isNaN(parsed) || parsed < 1) {
+		printWarning(`Invalid --max-consecutive-mistakes value '${value}'. Expected integer >= 1.`)
+		return undefined
+	}
+
+	return parsed
 }
 
 /**
@@ -147,6 +162,12 @@ function applyTaskOptions(options: TaskOptions): void {
 			StateManager.get().setGlobalState(reasoningKey, reasoningEffort)
 		})
 		telemetryService.captureHostEvent("reasoning_effort_flag", reasoningEffort)
+	}
+
+	const maxConsecutiveMistakes = normalizeMaxConsecutiveMistakes(options.maxConsecutiveMistakes)
+	if (maxConsecutiveMistakes !== undefined) {
+		StateManager.get().setGlobalState("maxConsecutiveMistakes", maxConsecutiveMistakes)
+		telemetryService.captureHostEvent("max_consecutive_mistakes_flag", String(maxConsecutiveMistakes))
 	}
 
 	// Set yolo mode based on --yolo flag
@@ -713,6 +734,7 @@ program
 	.option("--config <path>", "Path to Cline configuration directory")
 	.option("--thinking [tokens]", "Enable extended thinking (default: 1024 tokens)")
 	.option("--reasoning-effort <effort>", "Reasoning effort: none|low|medium|high|xhigh")
+	.option("--max-consecutive-mistakes <count>", "Maximum consecutive mistakes before halting in yolo mode")
 	.option("--json", "Output messages as JSON instead of styled text")
 	.option("--double-check-completion", "Reject first completion attempt to force re-verification")
 	.option("-T, --taskId <id>", "Resume an existing task by ID")
@@ -945,6 +967,7 @@ program
 	.option("--config <path>", "Configuration directory")
 	.option("--thinking [tokens]", "Enable extended thinking (default: 1024 tokens)")
 	.option("--reasoning-effort <effort>", "Reasoning effort: none|low|medium|high|xhigh")
+	.option("--max-consecutive-mistakes <count>", "Maximum consecutive mistakes before halting in yolo mode")
 	.option("--json", "Output messages as JSON instead of styled text")
 	.option("--double-check-completion", "Reject first completion attempt to force re-verification")
 	.option("--acp", "Run in ACP (Agent Client Protocol) mode for editor integration")


### PR DESCRIPTION
### Related Issue

Issue: N/A

### Description

This PR adds a CLI task flag, `--max-consecutive-mistakes <count>`, so automated runs can control when YOLO mode stops after repeated tool/flow errors.

Problem this addresses:
Recent Harbor Terminal Bench runs using Gemini via Vercel were repeatedly ending with `Too many consecutive mistakes (3)`. In these runs, the default threshold of 3 was terminating many trials before the model could recover. We already fixed other major run configuration problems (model routing, prompt delimiter handling, timeout), but this specific threshold remained hardcoded from a CLI operator perspective. That meant we could not isolate model quality from safety-stop sensitivity without code changes.

Why this change is needed:
The core task engine already supports configurable `maxConsecutiveMistakes` in global state, but current CLI options do not expose that setting for task execution. As a result, benchmark runners and CI wrappers cannot tune this value at invocation time. This PR closes that gap by exposing a first-class flag and applying it during task option setup.

Technical approach:
- Added a new CLI option on both task entry surfaces:
  - `cline task ... --max-consecutive-mistakes <count>`
  - `cline ... --max-consecutive-mistakes <count>`
- Extended task option parsing to include `maxConsecutiveMistakes`.
- Added normalization and validation logic:
  - accepts integer values >= 1
  - invalid values produce a warning and are ignored
- When valid, writes `maxConsecutiveMistakes` into state before task execution and emits a telemetry host event.

Debugging journey and non-obvious gotchas:
During investigation, there was an assumption that this might already be externally configurable through historical syntax (`-s max_consecutive_mistakes=...`). That path appears in older/deprecated CLI docs and comments, but does not exist in the current `commander`-based CLI command parser. The key gotcha is that configurability existed in core state and internal flows, yet was not surfaced by current public CLI flags. This made run-time tuning look available in theory while still unavailable in practice.

Decisions and alternatives considered:
I considered bypassing the mistake limit entirely in YOLO mode for benchmark runs, but rejected that because it weakens protection globally and risks runaway loops in normal automation usage. Exposing a threshold knob is safer and more flexible:
- default behavior remains unchanged at 3
- benchmark operators can explicitly raise the limit
- regular users keep existing safeguards unless they opt in

How to test:
1. Parser-level tests (already added) verify the new option is accepted in both command forms.
2. Run `cline task "echo test" --max-consecutive-mistakes 10` and confirm no parse errors.
3. Run with an invalid value (for example `0` or `abc`) and confirm warning is emitted and execution continues with existing configured/default limit.
4. In benchmark wrappers, append `--max-consecutive-mistakes 999` to confirm YOLO stops are no longer dominated by the threshold in early recovery scenarios.

### Test Procedure

I validated this change with focused CLI tests and static checks:

- `npm -C cli run test:run -- src/index.test.ts`
- `npm -C cli run typecheck`

I also added explicit parser tests for:
- task command form parsing (`--max-consecutive-mistakes 999`)
- default command form parsing (`--max-consecutive-mistakes 7`)

Potential break surface considered:
- Existing invocations are unaffected because the new flag is optional.
- Invalid values are handled defensively with warning + no state write.
- Default threshold behavior remains unchanged when the flag is omitted.

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A (CLI flag only)

### Additional Notes

Primary intended usage for benchmark runs:
`cline -y --thinking 6000 --double-check-completion -t 4800 --max-consecutive-mistakes 999 -- '<task prompt>'`

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `--max-consecutive-mistakes` flag to CLI for controlling mistake threshold in YOLO mode, with input validation and telemetry support.
> 
>   - **Behavior**:
>     - Adds `--max-consecutive-mistakes <count>` flag to CLI in `index.ts` for controlling mistake threshold in YOLO mode.
>     - Validates input as integer >= 1; invalid inputs trigger a warning and are ignored.
>     - Updates `applyTaskOptions()` to set `maxConsecutiveMistakes` in global state and emit telemetry event.
>   - **Tests**:
>     - Adds tests in `index.test.ts` to verify parsing of `--max-consecutive-mistakes` in both task and default command forms.
>     - Confirms valid input is parsed correctly and invalid input triggers warnings.
>   - **Misc**:
>     - Updates `normalizeMaxConsecutiveMistakes()` in `index.ts` for input validation and normalization.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 3b3d4383c92ffba953e684da90e92a44eb7ad336. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->