### PR TITLE
fix(cli): ensure telemetry delivery on shutdown

### DIFF
--- a/src/services/telemetry/TelemetryService.ts
+++ b/src/services/telemetry/TelemetryService.ts
@@ -535,7 +535,9 @@ export class TelemetryService {
 	}
 
 	public captureExtensionActivated() {
-		this.captureToProviders(TelemetryService.EVENTS.USER.EXTENSION_ACTIVATED, {}, false)
+		this.capture({
+			event: TelemetryService.EVENTS.USER.EXTENSION_ACTIVATED,
+		})
 	}
 
 	public captureExtensionStorageError(errorMessage: string, eventName: string) {


### PR DESCRIPTION
### Related Issue

Issue: #XXXX

### Description

This PR fixes CLI telemetry undercounting by addressing delivery reliability and event shape consistency.

Problem observed:
- We launched CLI 2.0 and expected a DAU increase in PostHog, but active user counts remained unexpectedly low compared to install and usage signals.

What was happening:
- The CLI process had no deterministic telemetry flush path before process exit.
- The CLI is often short-lived (especially in non-interactive/piped/command-style usage), which increases the chance that batched PostHog events never get shipped before process termination.
- Some interactive callbacks were also exiting directly, which could bypass cleanup in certain flows.
- `user.extension_activated` was emitted via a low-level path that skipped the standard metadata enrichment pipeline, making platform-segmented analytics less reliable.

Technical approach:
- Introduce centralized CLI teardown helpers in `cli/src/index.ts`:
  - `disposeTelemetryServices()` to flush/close both telemetry and PostHog client resources.
  - `disposeCliContext()` to run state/controller/error cleanup and telemetry disposal in one place.
- Route all CLI shutdown paths through this centralized teardown (plain text mode, interactive cleanup, and signal handling), so telemetry has a chance to flush before process exit.
- Keep process exit behavior intact while ensuring cleanup runs first.
- Update `TelemetryService.captureExtensionActivated()` to go through `capture(...)` instead of direct provider dispatch so normal metadata is included.

Why these choices:
- The root issue was not event call sites alone; events were frequently emitted but not reliably delivered.
- The safest fix is to guarantee teardown consistency rather than patch individual command paths ad hoc.
- Using `capture(...)` for activation aligns this event with every other metadata-enriched event, reducing dashboard/filter mismatch.

Alternatives considered:
- Emitting more required events (`captureRequired`) to bypass opt-out: rejected, because this would violate expected telemetry controls.
- Adding per-command ad hoc delays before exit: rejected, brittle and does not guarantee provider shutdown semantics.
- Keeping activation event as-is and only fixing shutdown: rejected, because missing metadata can still undercount platform-segmented dashboards.

### Test Procedure

What I validated during implementation:
- Confirmed CLI command/event paths in `cli/src/index.ts` and telemetry provider lifecycle in `src/services/telemetry/*`.
- Verified published npm artifacts (`cline@2.0.0` and `cline@2.0.5`) include telemetry event capture paths but no explicit CLI telemetry disposal/shutdown path.
- Ensured all primary exit paths in CLI now route through centralized cleanup.
- Confirmed `captureExtensionActivated` now passes through the metadata-enriched telemetry path.

Manual verification recommended after deploy:
1. Run short-lived CLI commands (`cline task "..." --json`, piped stdin flows, quick auth flow).
2. In PostHog, verify increased counts for:
   - `host.detected` with `name=cline_cli` and `content=initialized`
   - `user.extension_activated`
3. Validate those events include expected metadata fields (`platform`, `cline_type`, `extension_version`, etc.) for dashboard segmentation.

Notes:
- I could not run local TypeScript/lint test suites in this worktree because dependencies were not installed (`node_modules` absent in this environment). Validation here was code-path and artifact inspection focused.

### Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ♻️ Refactor Changes
- [ ] 💅 Cosmetic Changes
- [ ] 📚 Documentation update
- [ ] 🏃 Workflow Changes

### Pre-flight Checklist

- [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
- [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
- [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
- [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A (non-UI telemetry delivery fix)

### Additional Notes

The `Related Issue` is currently left as `#XXXX` because I was not given a specific issue number in this thread. I can update it immediately if you share the correct issue.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Ensure CLI telemetry delivery by centralizing cleanup and enriching event metadata in `cli/src/index.ts` and `TelemetryService.ts`.
> 
>   - **Behavior**:
>     - Introduce `disposeTelemetryServices()` and `disposeCliContext()` in `cli/src/index.ts` for centralized cleanup of telemetry and CLI context.
>     - Route all CLI shutdown paths through these functions to ensure telemetry flush before exit.
>     - Update `captureExtensionActivated()` in `TelemetryService.ts` to use `capture(...)` for metadata enrichment.
>   - **Functions**:
>     - Replace direct cleanup calls with `disposeCliContext()` in `runTaskInPlainTextMode()`, `createInkCleanup()`, and other functions in `cli/src/index.ts`.
>     - Ensure `captureExtensionActivated()` in `initializeCli()` and `runAuth()` uses enriched telemetry path.
>   - **Misc**:
>     - Add `telemetryDisposed` flag in `cli/src/index.ts` to prevent redundant disposal calls.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 9dd324f004b7919879af390c394c506b96226a34. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->