### PR TITLE
restore yolo mode to what it was before cline cli started

### DIFF
--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -76,7 +76,24 @@ async function disposeTelemetryServices(): Promise<void> {
 	await Promise.allSettled([telemetryService.dispose(), PostHogClientProvider.getInstance().dispose()])
 }
 
+/**
+ * Restore yoloModeToggled to its original value from before this CLI session.
+ * This ensures the --yolo flag is session-only and doesn't leak into future runs.
+ * Must be called before flushPendingState so the restored value gets persisted.
+ */
+function restoreYoloState(): void {
+	if (savedYoloModeToggled !== null) {
+		try {
+			StateManager.get().setGlobalState("yoloModeToggled", savedYoloModeToggled)
+			savedYoloModeToggled = null
+		} catch {
+			// StateManager may not be initialized (e.g., early exit before init)
+		}
+	}
+}
+
 async function disposeCliContext(ctx: CliContext): Promise<void> {
+	restoreYoloState()
 	await ctx.controller.stateManager.flushPendingState()
 	await ctx.controller.dispose()
 	await ErrorService.get().dispose()
@@ -189,9 +206,12 @@ function applyTaskOptions(options: TaskOptions): void {
 		telemetryService.captureHostEvent("max_consecutive_mistakes_flag", String(maxConsecutiveMistakes))
 	}
 
-	// Set yolo mode based on --yolo flag
+	// Override yolo mode only if --yolo flag is explicitly passed.
+	// The original value is saved in initializeCli and restored on exit.
 	if (options.yolo) {
-		StateManager.get().setGlobalState("yoloModeToggled", true)
+		const state = StateManager.get()
+		savedYoloModeToggled = state.getGlobalSettingsKey("yoloModeToggled") ?? false
+		state.setGlobalState("yoloModeToggled", true)
 		telemetryService.captureHostEvent("yolo_flag", "true")
 	}
 
@@ -296,6 +316,9 @@ let activeContext: CliContext | null = null
 let isShuttingDown = false
 // Track if we're in plain text mode (no Ink UI) - set by runTask when piped stdin detected
 let isPlainTextMode = false
+// Track the original yoloModeToggled value from before this CLI session so we can restore it on exit.
+// The --yolo flag should only affect the current invocation, not persist across runs.
+let savedYoloModeToggled: boolean | null = null
 
 /**
  * Wait for stdout to fully drain before exiting.
@@ -337,6 +360,10 @@ function setupSignalHandlers() {
 		printWarning(`${signal} received, shutting down...`)
 
 		try {
+			// Restore yolo state before any cleanup - this is idempotent and safe
+			// even if disposeCliContext also calls it (restoreYoloState checks savedYoloModeToggled !== null)
+			restoreYoloState()
+
 			if (activeContext) {
 				const task = activeContext.controller.task
 				if (task) {
@@ -344,6 +371,12 @@ function setupSignalHandlers() {
 				}
 				await disposeCliContext(activeContext)
 			} else {
+				// Best-effort flush of restored yolo state when no active context
+				try {
+					await StateManager.get().flushPendingState()
+				} catch {
+					// StateManager may not be initialized yet
+				}
 				await ErrorService.get().dispose()
 				await disposeTelemetryServices()
 			}
@@ -437,6 +470,7 @@ async function initializeCli(options: InitOptions): Promise<CliContext> {
 	)
 
 	await StateManager.initialize(extensionContext as any)
+
 	await ErrorService.initialize()
 
 	// Initialize OpenAI Codex OAuth manager with extension context for secrets storage


### PR DESCRIPTION
<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- For feature requests: Created a discussion in our Feature Requests discussions board https://github.com/cline/cline/discussions/categories/feature-requests and received approval from core maintainers before implementation
- For all changes: Link the associated issue/discussion in the "Related Issue" section below

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly without prior discussion.

Why this requirement?
We deeply appreciate all community contributions - they are essential to Cline's success! To ensure the best use of everyone's time and maintain project direction, we use our Feature Requests discussions board to gauge community interest and validate feature ideas before implementation begins. This helps us focus development efforts on features that will benefit the most users.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** N/A

### Description

Cline CLI was persisting yolo mode state when users add the -y flag to a cli invocation. This PR makes it so that cline -y will first read yolo mode state from settings upon initialization, temporarily set yolo to true, run the task, and restore yolo state

<!-- 
Help reviewers understand your changes by making this PR readable and well-organized:

- What problem does this PR solve?
- Why were these changes introduced and what purpose do they serve?
- For larger changes, provide context about your approach and reasoning

Small PRs may need minimal description, but larger changes benefit from explaining where you're coming from. Much of this context can be in the linked issue above, so feel free to reference it rather than repeating everything here.
-->

### Test Procedure

Ran `cline -y` while globalSettings.json yolo mode was set to false. observed in real time that yolo was changed to true, and when the task was complete, observed in real time the yolo state was set back to false.

<!-- 
Please walk us through your testing approach and thought process. This helps reviewers understand that you've thoroughly considered the impact of your changes:

- How did you test this change?
- What could potentially break and how did you verify it doesn't?
- What existing functionality might be affected and how did you check it still works?
- Why are you confident this is ready for merge?

We're not looking for exhaustive documentation - just evidence that you've thought through the implications of your changes and tested accordingly.
-->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [X] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [X] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [X] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [X] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Ensure `--yolo` flag in Cline CLI is session-specific by saving and restoring the original `yoloModeToggled` state.
> 
>   - **Behavior**:
>     - `--yolo` flag now only affects the current session and does not persist across runs.
>     - Original `yoloModeToggled` state is saved in `initializeCli()` and restored in `restoreYoloState()`.
>   - **Functions**:
>     - `restoreYoloState()` added to reset `yoloModeToggled` to its original value.
>     - `applyTaskOptions()` modified to set `didTemporarilyOverrideYolo` when `--yolo` is used.
>     - `disposeCliContext()` and `setupSignalHandlers()` updated to call `restoreYoloState()`.
>   - **Variables**:
>     - Added `savedYoloModeToggled` and `didTemporarilyOverrideYolo` to track and manage yolo state.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 7b76a7c105ccf1afebbd651b1ea68cbbe8d53b53. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->