### PR TITLE
make trusted npm publish workflow

### DIFF
--- a/.github/workflows/npm-main.yaml
+++ b/.github/workflows/npm-main.yaml
@@ -1,7 +1,7 @@
 name: Publish NPM Release
 
 on:
-  workflow_dispatch:
+  workflow_call:
     inputs:
       confirm_publish:
         description: 'Type "publish" to confirm you want to publish to NPM'
@@ -10,6 +10,7 @@ on:
 
 permissions:
   contents: write # Required for pushing tags
+  id-token: write # Required for npm trusted publishing (OIDC)
   checks: write # Required by test workflow
   pull-requests: write # Required by test workflow
 
@@ -20,7 +21,7 @@ jobs:
   publish-npm-release:
     needs: test
     name: Publish Cline CLI to NPM
-    if: github.repository == 'cline/cline' && github.ref == 'refs/heads/main' && github.event.inputs.confirm_publish == 'publish'
+    if: github.repository == 'cline/cline' && github.ref == 'refs/heads/main' && inputs.confirm_publish == 'publish'
     runs-on: ubuntu-latest
 
     steps:
@@ -30,11 +31,10 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20.x"
+          node-version: "24.x"
           registry-url: "https://registry.npmjs.org"
 
       - name: Install root dependencies and CLI dependencies
-        if: steps.check_commits.outputs.skip != 'true'
         run: npm ci --include=optional # this will also install cli deps because "cli" in included in root package.json workspaces field
 
       - name: Generate Protos
@@ -73,8 +73,6 @@ jobs:
           cat dist-standalone/package.json | grep version
 
       - name: Publish to NPM with latest tag
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_RELEASE_TOKEN }}
         run: |
           echo "Publishing version ${{ steps.version.outputs.version }} to NPM with tag 'latest'..."
           cd dist-standalone

--- a/.github/workflows/npm-nightly.yaml
+++ b/.github/workflows/npm-nightly.yaml
@@ -1,12 +1,17 @@
 name: Publish NPM Nightly
 
 on:
-  schedule:
-    - cron: "0 12 * * *" # 4 AM PST (UTC-8) = 12 UTC
-  workflow_dispatch:
+  workflow_call:
+    inputs:
+      force_publish:
+        description: "Force publish even if there are no commits in the last 24 hours"
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: read
+  id-token: write # Required for npm trusted publishing (OIDC)
   checks: write # Required by test workflow
   pull-requests: write # Required by test workflow
 
@@ -27,6 +32,12 @@ jobs:
       - name: Check for recent commits
         id: check_commits
         run: |
+          if [ "${{ inputs.force_publish }}" = "true" ]; then
+            echo "force_publish enabled, proceeding with publish"
+            echo "skip=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
           if [ $(git rev-list --count HEAD --since="24 hours ago") -eq 0 ]; then
             echo "No commits in last 24 hours, skipping publish"
             echo "skip=true" >> $GITHUB_OUTPUT
@@ -39,7 +50,7 @@ jobs:
         if: steps.check_commits.outputs.skip != 'true'
         uses: actions/setup-node@v4
         with:
-          node-version: "20.x"
+          node-version: "24.x"
           registry-url: "https://registry.npmjs.org"
 
       - name: Install root dependencies and CLI dependencies
@@ -109,8 +120,6 @@ jobs:
 
       - name: Publish to NPM with nightly tag
         if: steps.check_commits.outputs.skip != 'true'
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_RELEASE_TOKEN }}
         run: |
           echo "Publishing version ${{ steps.version.outputs.version }} to NPM with tag 'nightly'..."
           cd dist-standalone

--- a/.github/workflows/publish-cli-trusted.yaml
+++ b/.github/workflows/publish-cli-trusted.yaml
@@ -1,0 +1,51 @@
+name: Publish CLI (Trusted)
+
+on:
+  schedule:
+    - cron: "0 12 * * *" # 4 AM PST (UTC-8) = 12 UTC
+  workflow_dispatch:
+    inputs:
+      publish_target:
+        description: "Which publish flow to run"
+        required: true
+        default: "main"
+        type: choice
+        options:
+          - main
+          - nightly
+      confirm_publish:
+        description: 'Required when publish_target=main. Type "publish" to confirm release publish.'
+        required: false
+        type: string
+      force_nightly_publish:
+        description: "Force nightly publish even with no commits in last 24h"
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  id-token: write # Required for npm trusted publishing (OIDC)
+  contents: read
+
+jobs:
+  publish-main:
+    if: |
+      github.repository == 'cline/cline' && (
+        github.event_name == 'workflow_dispatch' &&
+        github.event.inputs.publish_target == 'main' &&
+        github.event.inputs.confirm_publish == 'publish' &&
+        !endsWith(github.actor, '[bot]')
+      )
+    uses: ./.github/workflows/npm-main.yaml
+    with:
+      confirm_publish: ${{ github.event.inputs.confirm_publish }}
+
+  publish-nightly:
+    if: |
+      github.repository == 'cline/cline' && (
+        github.event_name == 'schedule' ||
+        (github.event_name == 'workflow_dispatch' && github.event.inputs.publish_target == 'nightly')
+      )
+    uses: ./.github/workflows/npm-nightly.yaml
+    with:
+      force_publish: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.force_nightly_publish == 'true' }}


### PR DESCRIPTION
<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- For feature requests: Created a discussion in our Feature Requests discussions board https://github.com/cline/cline/discussions/categories/feature-requests and received approval from core maintainers before implementation
- For all changes: Link the associated issue/discussion in the "Related Issue" section below

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly without prior discussion.

Why this requirement?
We deeply appreciate all community contributions - they are essential to Cline's success! To ensure the best use of everyone's time and maintain project direction, we use our Feature Requests discussions board to gauge community interest and validate feature ideas before implementation begins. This helps us focus development efforts on features that will benefit the most users.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** N/A

### Description

This PR introduce a new gh actions workflow for publishing the CLI to npm registry. It uses trusted publishing (https://docs.npmjs.com/trusted-publishers) via OIDC instead of granular tokens. This means that we don't have to worry about token rotation and security issues related to storing tokens in GitHub secrets. The workflow is triggered nightly for nightly releases and manually for main releases. NPM only allows us to trust a single github workflow hence we have to use the same workflow for both nightly and main releases. The workflow checks the trigger event data to determine whether it's a nightly or main release and publishes accordingly.

<!-- 
Help reviewers understand your changes by making this PR readable and well-organized:

- What problem does this PR solve?
- Why were these changes introduced and what purpose do they serve?
- For larger changes, provide context about your approach and reasoning

Small PRs may need minimal description, but larger changes benefit from explaining where you're coming from. Much of this context can be in the linked issue above, so feel free to reference it rather than repeating everything here.
-->

### Test Procedure

I created a test npm project (https://www.npmjs.com/package/trusted-publishing-0209) and set up a new repo with these workflows enabled. I tested publishing both main and nightly builds to the npm registry. I also verified that the workflow fails if the OIDC token is not properly configured or if the npm registry is not set up correctly. I checked that the published packages are available on npm and that they have the correct version numbers. I also tested that the workflow can be triggered manually from the GitHub Actions tab and that it runs successfully.

<!-- 
Please walk us through your testing approach and thought process. This helps reviewers understand that you've thoroughly considered the impact of your changes:

- How did you test this change?
- What could potentially break and how did you verify it doesn't?
- What existing functionality might be affected and how did you check it still works?
- Why are you confident this is ready for merge?

We're not looking for exhaustive documentation - just evidence that you've thought through the implications of your changes and tested accordingly.
-->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [x] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Introduces a trusted npm publish workflow using OIDC, consolidating nightly and main releases into a single workflow with enhanced security.
> 
>   - **Workflows**:
>     - Adds `publish-cli-trusted.yaml` to handle both nightly and main npm releases using OIDC for trusted publishing.
>     - Replaces `workflow_dispatch` with `workflow_call` in `npm-main.yaml` and `npm-nightly.yaml`.
>     - Updates Node.js version to `24.x` in `npm-main.yaml` and `npm-nightly.yaml`.
>   - **Permissions**:
>     - Adds `id-token: write` permission in `npm-main.yaml` and `npm-nightly.yaml` for OIDC.
>   - **Behavior**:
>     - Nightly releases are scheduled and can be forced with `force_nightly_publish` input.
>     - Main releases require manual confirmation with `confirm_publish` input.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 5dd78a1bea1a34c0e022540b6a72c02b65e7a3c6. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->