### PR TITLE
fix publish-cli-trusted workflow

### DIFF
--- a/.github/workflows/publish-cli-trusted.yaml
+++ b/.github/workflows/publish-cli-trusted.yaml
@@ -25,7 +25,9 @@ on:
 
 permissions:
   id-token: write # Required for npm trusted publishing (OIDC)
-  contents: read
+  contents: write # Required because npm-main creates/pushes git tags
+  checks: write # Required by nested reusable test workflow
+  pull-requests: write # Required by nested reusable test workflow
 
 jobs:
   publish-main:


### PR DESCRIPTION
- parent workflow needs to request permissions for children workflows

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update permissions in `publish-cli-trusted.yaml` to ensure child workflows have necessary access for operations.
> 
>   - **Permissions**:
>     - Update `contents` permission to `write` in `publish-cli-trusted.yaml` for git tag creation and pushing.
>     - Add `checks: write` and `pull-requests: write` permissions for nested reusable test workflows.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 2b62ccfb9361465aea6996b308e23400b5809da1. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->