### PR TITLE
fix: remove hardcoded openid scope to support OAuth 2.1 servers

### DIFF
--- a/.changeset/perky-squids-wink.md
+++ b/.changeset/perky-squids-wink.md
@@ -1,0 +1,4 @@
+---
+"cline": patch
+---
+Fix issue where task_progress updates would interrupt cline asks like plan_mode_respond

--- a/.changeset/salty-geckos-live.md
+++ b/.changeset/salty-geckos-live.md
@@ -1,0 +1,5 @@
+---
+"cline": minor
+---
+
+fix openId scope

--- a/src/services/mcp/McpOAuthManager.ts
+++ b/src/services/mcp/McpOAuthManager.ts
@@ -85,7 +85,6 @@ class ClineOAuthClientProvider implements OAuthClientProvider {
 			client_name: "Cline",
 			client_uri: "https://cline.bot",
 			software_id: "cline",
-			scope: "openid",
 		}
 	}
 


### PR DESCRIPTION


<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- For feature requests: Created a discussion in our Feature Requests discussions board https://github.com/cline/cline/discussions/categories/feature-requests and received approval from core maintainers before implementation
- For all changes: Link the associated issue/discussion in the "Related Issue" section below

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly without prior discussion.

Why this requirement?
We deeply appreciate all community contributions - they are essential to Cline's success! To ensure the best use of everyone's time and maintain project direction, we use our Feature Requests discussions board to gauge community interest and validate feature ideas before implementation begins. This helps us focus development efforts on features that will benefit the most users.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** #9218

### Description
 - Remove hardcoded 'scope: openid' from OAuth client metadata
- Allows MCP SDK to negotiate scopes dynamically with OAuth 2.1 servers
- Fixes issue where OAuth 2.1 servers fail with 'Requested scopes are not valid: openid'
<!-- 
Help reviewers understand your changes by making this PR readable and well-organized:

- What problem does this PR solve?
- Why were these changes introduced and what purpose do they serve?
- For larger changes, provide context about your approach and reasoning

Small PRs may need minimal description, but larger changes benefit from explaining where you're coming from. Much of this context can be in the linked issue above, so feel free to reference it rather than repeating everything here.
-->

### Test Procedure

To verify this fix, test with an OAuth 2.1 enabled MCP server. The server should now connect successfully without the error "Requested scopes are not valid: openid". This change is backward compatible - existing OAuth 2.0 and OpenID Connect servers will continue to work as the MCP SDK now negotiates scopes dynamically based on server requirements.

__Verification:__

```bash
# Check the fix
git diff v3.57.1 HEAD -- src/services/mcp/McpOAuthManager.ts

# Run MCP OAuth tests
npm run test:unit -- --grep "oauth"
```

__Expected Behavior:__

- OAuth 2.1 servers: ✅ Now work (previously failed)
- OAuth 2.0 servers: ✅ Continue to work
- OpenID Connect servers: ✅ Continue to work
- Non-OAuth servers: ✅ No change in behavior



<!-- 
Please walk us through your testing approach and thought process. This helps reviewers understand that you've thoroughly considered the impact of your changes:

- How did you test this change?
- What could potentially break and how did you verify it doesn't?
- What existing functionality might be affected and how did you check it still works?
- Why are you confident this is ready for merge?

We're not looking for exhaustive documentation - just evidence that you've thought through the implications of your changes and tested accordingly.
-->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [ ] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)


<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->


<!-- Add any additional notes for reviewers -->
