### PR TITLE
print task id in headless modes

### DIFF
--- a/cli/src/utils/plain-text-task.test.ts
+++ b/cli/src/utils/plain-text-task.test.ts
@@ -1,0 +1,28 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { emitTaskStartedMessage } from "./task-start-output"
+
+describe("emitTaskStartedMessage", () => {
+	afterEach(() => {
+		vi.restoreAllMocks()
+	})
+
+	it("writes structured task_started JSON to stdout in json mode", () => {
+		const stdoutWriteSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true)
+		const stderrWriteSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true)
+
+		emitTaskStartedMessage("task-123", true)
+
+		expect(stdoutWriteSpy).toHaveBeenCalledWith('{"type":"task_started","taskId":"task-123"}\n')
+		expect(stderrWriteSpy).not.toHaveBeenCalled()
+	})
+
+	it("writes human-readable task started line to stderr in non-json mode", () => {
+		const stdoutWriteSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true)
+		const stderrWriteSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true)
+
+		emitTaskStartedMessage("task-456", false)
+
+		expect(stderrWriteSpy).toHaveBeenCalledWith("Task started: task-456\n")
+		expect(stdoutWriteSpy).not.toHaveBeenCalled()
+	})
+})

--- a/cli/src/utils/task-start-output.ts
+++ b/cli/src/utils/task-start-output.ts
@@ -1,0 +1,8 @@
+export function emitTaskStartedMessage(taskId: string, jsonOutput: boolean): void {
+	if (jsonOutput) {
+		process.stdout.write(JSON.stringify({ type: "task_started", taskId }) + "\n")
+		return
+	}
+
+	process.stderr.write(`Task started: ${taskId}\n`)
+}


### PR DESCRIPTION
<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- For feature requests: Created a discussion in our Feature Requests discussions board https://github.com/cline/cline/discussions/categories/feature-requests and received approval from core maintainers before implementation
- For all changes: Link the associated issue/discussion in the "Related Issue" section below

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly without prior discussion.

Why this requirement?
We deeply appreciate all community contributions - they are essential to Cline's success! To ensure the best use of everyone's time and maintain project direction, we use our Feature Requests discussions board to gauge community interest and validate feature ideas before implementation begins. This helps us focus development efforts on features that will benefit the most users.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** N/A

### Description

In json mode, print taskId to stdout as first message. In other headless modes (plain, yolo), print task id to stderr. Helps in CI/CD use cases when you need to know the task id for a task in order to continue that task at a later time.

<!-- 
Help reviewers understand your changes by making this PR readable and well-organized:

- What problem does this PR solve?
- Why were these changes introduced and what purpose do they serve?
- For larger changes, provide context about your approach and reasoning

Small PRs may need minimal description, but larger changes benefit from explaining where you're coming from. Much of this context can be in the linked issue above, so feel free to reference it rather than repeating everything here.
-->

### Test Procedure

`cline -y "say hello"`: expect to see "task started: 12345\nHello!"
`cline -y "say hello" 2>/dev/null`: expect to see "Hello!"
`cline --json "say hello"` expect to see `{"type":"task_started","taskId":"12345"}\n...`

<!-- 
Please walk us through your testing approach and thought process. This helps reviewers understand that you've thoroughly considered the impact of your changes:

- How did you test this change?
- What could potentially break and how did you verify it doesn't?
- What existing functionality might be affected and how did you check it still works?
- Why are you confident this is ready for merge?

We're not looking for exhaustive documentation - just evidence that you've thought through the implications of your changes and tested accordingly.
-->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [X] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [X] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [X] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [X] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Prints task ID to stdout in JSON mode and stderr in non-JSON modes for CI/CD workflows.
> 
>   - **Behavior**:
>     - In `plain-text-task.ts`, `emitTaskStartedMessage()` is called to print task ID to stdout in JSON mode and stderr in non-JSON modes.
>     - Supports CI/CD workflows by providing task ID for task continuation.
>   - **Functions**:
>     - Adds `emitTaskStartedMessage()` in `task-start-output.ts` to handle task ID output.
>   - **Tests**:
>     - Adds tests in `plain-text-task.test.ts` to verify task ID output to stdout in JSON mode and stderr in non-JSON modes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 72dcf349b915f864d3b7e310cdc5dd571a7ce9ef. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->