### PR TITLE
fix(claude-code): add opus 4.6 1m model option

### DIFF
--- a/.changeset/chilly-birds-fly.md
+++ b/.changeset/chilly-birds-fly.md
@@ -2,4 +2,4 @@
 "cline": patch
 ---
 
-Add Claude Code provider support for Claude Opus 4.6 1M via both full model name (`claude-opus-4-6[1m]`) and alias (`opus[1m]`), and align the `opus` alias with Opus 4.6.
+Add Claude Code provider support for Claude Opus 4.6 and Sonnet 4.5 1M variants via both full model names and aliases (`opus[1m]`, `sonnet[1m]`), and align the `opus` alias with Opus 4.6.

--- a/src/core/api/providers/__tests__/claude-code.test.ts
+++ b/src/core/api/providers/__tests__/claude-code.test.ts
@@ -256,6 +256,26 @@ describe("ClaudeCodeHandler", () => {
 			model.info.contextWindow.should.equal(1_000_000)
 		})
 
+		it("should support Sonnet 1m alias model id", () => {
+			const handler = new ClaudeCodeHandler({
+				apiModelId: "sonnet[1m]",
+			})
+
+			const model = handler.getModel()
+			model.id.should.equal("sonnet[1m]")
+			model.info.contextWindow.should.equal(1_000_000)
+		})
+
+		it("should support Sonnet 4.5 1m model id", () => {
+			const handler = new ClaudeCodeHandler({
+				apiModelId: "claude-sonnet-4-5-20250929[1m]",
+			})
+
+			const model = handler.getModel()
+			model.id.should.equal("claude-sonnet-4-5-20250929[1m]")
+			model.info.contextWindow.should.equal(1_000_000)
+		})
+
 		it("should return default model when not specified", () => {
 			const handler = new ClaudeCodeHandler({})
 

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -341,6 +341,11 @@ export const claudeCodeModels = {
 		supportsImages: false,
 		supportsPromptCache: false,
 	},
+	"sonnet[1m]": {
+		...anthropicModels["claude-sonnet-4-5-20250929:1m"],
+		supportsImages: false,
+		supportsPromptCache: false,
+	},
 	opus: {
 		...anthropicModels["claude-opus-4-6"],
 		supportsImages: false,
@@ -358,6 +363,11 @@ export const claudeCodeModels = {
 	},
 	"claude-sonnet-4-5-20250929": {
 		...anthropicModels["claude-sonnet-4-5-20250929"],
+		supportsImages: false,
+		supportsPromptCache: false,
+	},
+	"claude-sonnet-4-5-20250929[1m]": {
+		...anthropicModels["claude-sonnet-4-5-20250929:1m"],
 		supportsImages: false,
 		supportsPromptCache: false,
 	},

--- a/webview-ui/src/components/settings/providers/ClaudeCodeProvider.tsx
+++ b/webview-ui/src/components/settings/providers/ClaudeCodeProvider.tsx
@@ -11,6 +11,9 @@ import { SUPPORTED_ANTHROPIC_THINKING_MODELS } from "./AnthropicProvider"
 
 const SUPPORTED_CLAUDE_CODE_THINKING_MODELS = [
 	...SUPPORTED_ANTHROPIC_THINKING_MODELS,
+	"sonnet",
+	"sonnet[1m]",
+	"claude-sonnet-4-5-20250929[1m]",
 	"claude-opus-4-6[1m]",
 	"opus",
 	"opus[1m]",


### PR DESCRIPTION
### Related Issue

Issue: #9207

### Description

This is a follow-up fix to the Vertex Opus 4.6 1M work, adding the equivalent Opus 4.6 1M option for the Claude Code provider.

Problem
The Claude Code provider model list had `claude-opus-4-6` but no 1M context variant for Opus 4.6, so users could not explicitly select a 1M Opus 4.6 model in Claude Code provider settings.

What changed
- Added `claude-opus-4-6[1m]` to `claudeCodeModels` in `src/shared/api.ts`.
  - It reuses the Opus 4.6 1M metadata from `anthropicModels["claude-opus-4-6:1m"]`.
  - It keeps Claude Code specific overrides (`supportsImages: false`, `supportsPromptCache: false`) consistent with other Claude Code model entries.
- Updated Claude Code settings logic to recognize this model as reasoning-capable by extending the thinking-model list used by `ClaudeCodeProvider`.
- Added a provider unit test in `src/core/api/providers/__tests__/claude-code.test.ts` verifying `ClaudeCodeHandler.getModel()` resolves `claude-opus-4-6[1m]` and returns a 1,000,000 token context window.

Debugging and design notes
- Claude Code model IDs use `[1m]` format, while Anthropic API model metadata in our shared map uses `:1m`. I kept these intentionally different:
  - Claude Code provider key: `claude-opus-4-6[1m]`
  - Source metadata key: `claude-opus-4-6:1m`
- This keeps provider-facing model IDs aligned with Claude Code conventions while still reusing our centralized pricing/context metadata.
- I did not change runtime model ID transformation in `ClaudeCodeHandler` because this provider passes model IDs directly to the Claude CLI, and this patch is scoped to adding the missing option plus UI/test support.

Alternatives considered
- Adding a `:1m` key to Claude Code models for symmetry with Anthropic provider.
  - Rejected because Claude Code conventions and docs use `[1m]` for the 1M variant.
- Duplicating full model metadata values instead of spreading from `anthropicModels`.
  - Rejected to avoid drift and keep pricing/context definitions centralized.

### Test Procedure

Ran:
- `npx biome check src/shared/api.ts webview-ui/src/components/settings/providers/ClaudeCodeProvider.tsx src/core/api/providers/__tests__/claude-code.test.ts .changeset/chilly-birds-fly.md`

Validated:
- Claude Code model registry includes Opus 4.6 1M variant.
- Claude Code provider thinking slider eligibility includes the new 1M model id.
- Unit test coverage includes model selection path for `claude-opus-4-6[1m]`.

Not run in this worktree:
- Full `npm test` / full typecheck, because `node_modules` is not installed here.

### Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ♻️ Refactor Changes
- [ ] 💅 Cosmetic Changes
- [ ] 📚 Documentation update
- [ ] 🏃 Workflow Changes

### Pre-flight Checklist

- [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
- [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
- [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
- [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Not applicable for this provider model list and model-resolution change.

### Additional Notes

This PR intentionally focuses only on Claude Code provider parity for Opus 4.6 1M model selection.
----
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add support for `claude-opus-4-6[1m]` model in Claude Code provider, including tests and UI updates.
> 
>   - **Behavior**:
>     - Added `claude-opus-4-6[1m]` to `claudeCodeModels` in `api.ts`, reusing metadata from `anthropicModels`.
>     - Updated `ClaudeCodeProvider.tsx` to include `claude-opus-4-6[1m]` in `SUPPORTED_CLAUDE_CODE_THINKING_MODELS`.
>   - **Tests**:
>     - Added unit tests in `claude-code.test.ts` to verify `ClaudeCodeHandler.getModel()` resolves `claude-opus-4-6[1m]` and returns a 1,000,000 token context window.
>   - **Misc**:
>     - Ensured model ID conventions are consistent with Claude Code provider standards.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for ee441f9b0a6fa7ce0f8f1a7f469c9b0d25d6e15f. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->