### PR TITLE
fix: preserve environment variables when toggling server disabled state

### DIFF
--- a/.changeset/fix-mcp-env-vars.md
+++ b/.changeset/fix-mcp-env-vars.md
@@ -1,0 +1,7 @@
+---
+"claude-dev": patch
+---
+
+fix: preserve environment variables when toggling server disabled state
+
+Previously, toggling an MCP server's disabled state via the UI would expand `${env:VAR_NAME}` variables in the config file, replacing the variable references with their actual values. This fix preserves the original variable syntax by reading the raw config file instead of the validated/expanded version.

--- a/package-lock.json
+++ b/package-lock.json
@@ -3128,7 +3128,6 @@
 			"resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.3.tgz",
 			"integrity": "sha512-Iq8QQQ/7X3Sac15oB6p0FmUg/klxQvXLeileoqrTRGJYLV+/9tubbr9ipz0GKHjmXVsgFPo/+W+2cA8eNcR+XA==",
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
 				"@grpc/proto-loader": "^0.8.0",
 				"@js-sdsl/ordered-map": "^4.4.2"
@@ -4031,7 +4030,6 @@
 			"resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.26.0.tgz",
 			"integrity": "sha512-Y5RmPncpiDtTXDbLKswIJzTqu2hyBKxTNsgKqKclDbhIgg1wgtf1fRuvxgTnRfcnxtvvgbIEcqUOzZrJ6iSReg==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@hono/node-server": "^1.19.9",
 				"ajv": "^8.17.1",
@@ -4107,7 +4105,6 @@
 			"resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
 			"integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
 			"license": "Apache-2.0",
-			"peer": true,
 			"engines": {
 				"node": ">=8.0.0"
 			}
@@ -5798,7 +5795,8 @@
 			"optional": true,
 			"os": [
 				"android"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-android-arm64": {
 			"version": "4.57.1",
@@ -5811,7 +5809,8 @@
 			"optional": true,
 			"os": [
 				"android"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-darwin-arm64": {
 			"version": "4.57.1",
@@ -5824,7 +5823,8 @@
 			"optional": true,
 			"os": [
 				"darwin"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-darwin-x64": {
 			"version": "4.57.1",
@@ -5837,7 +5837,8 @@
 			"optional": true,
 			"os": [
 				"darwin"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-freebsd-arm64": {
 			"version": "4.57.1",
@@ -5850,7 +5851,8 @@
 			"optional": true,
 			"os": [
 				"freebsd"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-freebsd-x64": {
 			"version": "4.57.1",
@@ -5863,7 +5865,8 @@
 			"optional": true,
 			"os": [
 				"freebsd"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-linux-arm-gnueabihf": {
 			"version": "4.57.1",
@@ -5876,7 +5879,8 @@
 			"optional": true,
 			"os": [
 				"linux"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-linux-arm-musleabihf": {
 			"version": "4.57.1",
@@ -5889,7 +5893,8 @@
 			"optional": true,
 			"os": [
 				"linux"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-linux-arm64-gnu": {
 			"version": "4.57.1",
@@ -5902,7 +5907,8 @@
 			"optional": true,
 			"os": [
 				"linux"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-linux-arm64-musl": {
 			"version": "4.57.1",
@@ -5915,7 +5921,8 @@
 			"optional": true,
 			"os": [
 				"linux"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-linux-loong64-gnu": {
 			"version": "4.57.1",
@@ -5928,7 +5935,8 @@
 			"optional": true,
 			"os": [
 				"linux"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-linux-loong64-musl": {
 			"version": "4.57.1",
@@ -5941,7 +5949,8 @@
 			"optional": true,
 			"os": [
 				"linux"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-linux-ppc64-gnu": {
 			"version": "4.57.1",
@@ -5954,7 +5963,8 @@
 			"optional": true,
 			"os": [
 				"linux"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-linux-ppc64-musl": {
 			"version": "4.57.1",
@@ -5967,7 +5977,8 @@
 			"optional": true,
 			"os": [
 				"linux"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-linux-riscv64-gnu": {
 			"version": "4.57.1",
@@ -5980,7 +5991,8 @@
 			"optional": true,
 			"os": [
 				"linux"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-linux-riscv64-musl": {
 			"version": "4.57.1",
@@ -5993,7 +6005,8 @@
 			"optional": true,
 			"os": [
 				"linux"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-linux-s390x-gnu": {
 			"version": "4.57.1",
@@ -6006,7 +6019,8 @@
 			"optional": true,
 			"os": [
 				"linux"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-linux-x64-gnu": {
 			"version": "4.57.1",
@@ -6019,7 +6033,8 @@
 			"optional": true,
 			"os": [
 				"linux"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-linux-x64-musl": {
 			"version": "4.57.1",
@@ -6032,7 +6047,8 @@
 			"optional": true,
 			"os": [
 				"linux"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-openbsd-x64": {
 			"version": "4.57.1",
@@ -6045,7 +6061,8 @@
 			"optional": true,
 			"os": [
 				"openbsd"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-openharmony-arm64": {
 			"version": "4.57.1",
@@ -6058,7 +6075,8 @@
 			"optional": true,
 			"os": [
 				"openharmony"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-win32-arm64-msvc": {
 			"version": "4.57.1",
@@ -6071,7 +6089,8 @@
 			"optional": true,
 			"os": [
 				"win32"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-win32-ia32-msvc": {
 			"version": "4.57.1",
@@ -6084,7 +6103,8 @@
 			"optional": true,
 			"os": [
 				"win32"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-win32-x64-gnu": {
 			"version": "4.57.1",
@@ -6097,7 +6117,8 @@
 			"optional": true,
 			"os": [
 				"win32"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-win32-x64-msvc": {
 			"version": "4.57.1",
@@ -6110,7 +6131,8 @@
 			"optional": true,
 			"os": [
 				"win32"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@sap-ai-sdk/ai-api": {
 			"version": "2.6.0",
@@ -7782,7 +7804,6 @@
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.32.tgz",
 			"integrity": "sha512-Ez8QE4DMfhjjTsES9K2dwfV258qBui7qxUsoaixZDiTzbde4U12e1pXGNu/ECsUIOi5/zoCxAQxIhQnaUQ2VvA==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"undici-types": "~6.21.0"
 			}
@@ -7845,7 +7866,6 @@
 			"integrity": "sha512-KkiJeU6VbYbUOp5ITMIc7kBfqlYkKA5KhEHVrGMmUUMt7NeaZg65ojdPk+FtNrBAOXNVM5QM72jnADjM+XVRAQ==",
 			"devOptional": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"csstype": "^3.2.2"
 			}
@@ -8780,7 +8800,6 @@
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
 			"integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
 			"license": "MIT",
-			"peer": true,
 			"bin": {
 				"acorn": "bin/acorn"
 			},
@@ -9745,7 +9764,6 @@
 				}
 			],
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"baseline-browser-mapping": "^2.9.0",
 				"caniuse-lite": "^1.0.30001759",
@@ -11144,8 +11162,7 @@
 			"version": "0.0.1367902",
 			"resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1367902.tgz",
 			"integrity": "sha512-XxtPuC3PGakY6PD7dG66/o8KwJ/LkH2/EKe19Dcw58w53dv4/vSQEkn/SzuyhHE2q4zPgCkxQBxus3VV4ql+Pg==",
-			"license": "BSD-3-Clause",
-			"peer": true
+			"license": "BSD-3-Clause"
 		},
 		"node_modules/diff": {
 			"version": "5.2.2",
@@ -12162,7 +12179,6 @@
 			"resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
 			"integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"accepts": "^2.0.0",
 				"body-parser": "^2.2.1",
@@ -13470,7 +13486,6 @@
 			"resolved": "https://registry.npmjs.org/hono/-/hono-4.11.7.tgz",
 			"integrity": "sha512-l7qMiNee7t82bH3SeyUCt9UF15EVmaBvsppY2zQtrbIhl/yzBTny+YUxsVjSjQ6gaqaeVtZmGocom8TzBlA4Yw==",
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=16.9.0"
 			}
@@ -13749,7 +13764,6 @@
 			"resolved": "https://registry.npmjs.org/@jrichman/ink/-/ink-6.4.7.tgz",
 			"integrity": "sha512-QHyxhNF5VonF5cRmdAJD/UPucB9nRx3FozWMjQrDGfBxfAL9lpyu72/MlFPgloS1TMTGsOt7YN6dTPPA6mh0Aw==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@alcalzone/ansi-tokenize": "^0.2.1",
 				"ansi-escapes": "^7.0.0",
@@ -15003,7 +15017,6 @@
 			"resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
 			"integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
 			"license": "MIT",
-			"peer": true,
 			"bin": {
 				"jiti": "lib/jiti-cli.mjs"
 			}
@@ -15353,7 +15366,6 @@
 			"resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.30.2.tgz",
 			"integrity": "sha512-utfs7Pr5uJyyvDETitgsaqSyjCb2qNRAtuqUeWIAKztsOYdcACf2KtARYXg2pSvhkt+9NfoaNY7fxjl6nuMjIQ==",
 			"license": "MPL-2.0",
-			"peer": true,
 			"dependencies": {
 				"detect-libc": "^2.0.3"
 			},
@@ -19090,7 +19102,6 @@
 			"resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
 			"integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -21798,7 +21809,6 @@
 			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
 			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
@@ -22120,7 +22130,6 @@
 			"resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
 			"integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"esbuild": "^0.27.0",
 				"fdir": "^6.5.0",
@@ -22202,6 +22211,7 @@
 			"os": [
 				"aix"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -22218,6 +22228,7 @@
 			"os": [
 				"android"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -22234,6 +22245,7 @@
 			"os": [
 				"android"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -22250,6 +22262,7 @@
 			"os": [
 				"android"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -22266,6 +22279,7 @@
 			"os": [
 				"darwin"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -22282,6 +22296,7 @@
 			"os": [
 				"darwin"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -22298,6 +22313,7 @@
 			"os": [
 				"freebsd"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -22314,6 +22330,7 @@
 			"os": [
 				"freebsd"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -22330,6 +22347,7 @@
 			"os": [
 				"linux"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -22346,6 +22364,7 @@
 			"os": [
 				"linux"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -22362,6 +22381,7 @@
 			"os": [
 				"linux"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -22378,6 +22398,7 @@
 			"os": [
 				"linux"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -22394,6 +22415,7 @@
 			"os": [
 				"linux"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -22410,6 +22432,7 @@
 			"os": [
 				"linux"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -22426,6 +22449,7 @@
 			"os": [
 				"linux"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -22442,6 +22466,7 @@
 			"os": [
 				"linux"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -22458,6 +22483,7 @@
 			"os": [
 				"linux"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -22474,6 +22500,7 @@
 			"os": [
 				"netbsd"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -22490,6 +22517,7 @@
 			"os": [
 				"netbsd"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -22506,6 +22534,7 @@
 			"os": [
 				"openbsd"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -22522,6 +22551,7 @@
 			"os": [
 				"openbsd"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -22538,6 +22568,7 @@
 			"os": [
 				"openharmony"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -22554,6 +22585,7 @@
 			"os": [
 				"sunos"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -22570,6 +22602,7 @@
 			"os": [
 				"win32"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -22586,6 +22619,7 @@
 			"os": [
 				"win32"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -22602,6 +22636,7 @@
 			"os": [
 				"win32"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -22657,6 +22692,7 @@
 			"os": [
 				"darwin"
 			],
+			"peer": true,
 			"engines": {
 				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
 			}
@@ -23591,7 +23627,6 @@
 			"resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
 			"integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
 			"license": "MIT",
-			"peer": true,
 			"funding": {
 				"url": "https://github.com/sponsors/colinhacks"
 			}


### PR DESCRIPTION
## Summary

Fixes #9065

When using environment variables in the MCP server configuration (e.g., `${env:VAR_NAME}`), toggling a server's disabled state via the UI would overwrite the environment variable references with their resolved values.

## Root Cause

The `toggleServerDisabledRPC` function was using `readAndValidateMcpSettingsFile()` which calls `expandEnvironmentVariables(config)` before returning. When the config was written back to disk, the expanded values replaced the original `${env:...}` syntax.

## Solution

Changed `toggleServerDisabledRPC` to read the raw JSON file directly using `fs.readFile`/`JSON.parse`, matching the pattern already used in:
- `toggleToolAutoApproveRPC` (line 1314)
- `updateServerTimeoutRPC` (line 1507)

This preserves the original environment variable references when writing the config back.

Also added the `isUpdatingClineSettings` flag and `finally` block to prevent the file watcher from triggering unnecessarily during the update (consistent with similar functions).

## Testing

Before this fix:
```json
{
  "testMcpServer": {
    "disabled": false,
    "url": "${env.MCP_URL}",
    "headers": { "Authorization": "Bearer ${env.TOKEN}" }
  }
}
```

After toggling disabled via UI:
```json
{
  "testMcpServer": {
    "disabled": true,
    "url": "http://resolved-value.com",  // ❌ env var lost!
    "headers": { "Authorization": "Bearer actual-token-value" }
  }
}
```

With this fix, the environment variables are preserved:
```json
{
  "testMcpServer": {
    "disabled": true,
    "url": "${env.MCP_URL}",  // ✅ preserved
    "headers": { "Authorization": "Bearer ${env.TOKEN}" }
  }
}
```
----
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fixes environment variable preservation in `toggleServerDisabledRPC` by reading raw JSON and introduces a flag to prevent unnecessary file watcher triggers.
> 
>   - **Behavior**:
>     - `toggleServerDisabledRPC` in `McpHub.ts` now reads raw JSON to preserve environment variables when toggling server disabled state.
>     - Introduces `isUpdatingClineSettings` flag to prevent file watcher triggers during updates.
>   - **Solution**:
>     - Replaces `readAndValidateMcpSettingsFile()` with `fs.readFile`/`JSON.parse` in `toggleServerDisabledRPC` to avoid expanding environment variables.
>     - Adds `finally` block to clear `isUpdatingClineSettings` flag after a delay.
>   - **Consistency**:
>     - Aligns `toggleServerDisabledRPC` with `toggleToolAutoApproveRPC` and `updateServerTimeoutRPC` in terms of reading raw JSON and flag usage.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 09458cfe84d43bbd1d6ad9ad73ceaea54328d13b. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->