### PR TITLE
feat(api): add GLM-5 model and update ZAi defaults

### DIFF
--- a/.changeset/add-glm-5-model.md
+++ b/.changeset/add-glm-5-model.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Add GLM-5 model support for ZAi (international and mainland) and Cerebras providers, and update defaults from GLM-4.7 to GLM-5.

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -807,6 +807,10 @@ export const OPENROUTER_PROVIDER_PREFERENCES: Record<string, { order: string[]; 
 		order: ["deepseek", "novita", "fireworks", "nebius"],
 		allow_fallbacks: false,
 	},
+	"z-ai/glm-5": {
+		order: ["z-ai", "novita", "baseten", "fireworks", "chutes"],
+		allow_fallbacks: false,
+	},
 	"z-ai/glm-4.6": {
 		order: ["z-ai", "novita", "baseten", "fireworks", "chutes"],
 		allow_fallbacks: false,
@@ -3454,8 +3458,19 @@ export const sambanovaModels = {
 // Cerebras
 // https://inference-docs.cerebras.ai/api-reference/models
 export type CerebrasModelId = keyof typeof cerebrasModels
-export const cerebrasDefaultModelId: CerebrasModelId = "zai-glm-4.7"
+export const cerebrasDefaultModelId: CerebrasModelId = "zai-glm-5"
 export const cerebrasModels = {
+	"zai-glm-5": {
+		maxTokens: 40000,
+		contextWindow: 131072,
+		supportsImages: false,
+		supportsPromptCache: false,
+		temperature: 0.9,
+		inputPrice: 0,
+		outputPrice: 0,
+		description:
+			"Highly capable general-purpose model on Cerebras (up to 1,000 tokens/s), competitive with leading proprietary models on coding tasks.",
+	},
 	"zai-glm-4.7": {
 		maxTokens: 40000,
 		contextWindow: 131072,
@@ -4122,8 +4137,17 @@ export const basetenDefaultModelId = "zai-org/GLM-4.6" satisfies BasetenModelId
 // https://docs.z.ai/guides/llm/glm-4.5
 // https://docs.z.ai/guides/overview/pricing
 export type internationalZAiModelId = keyof typeof internationalZAiModels
-export const internationalZAiDefaultModelId: internationalZAiModelId = "glm-4.7"
+export const internationalZAiDefaultModelId: internationalZAiModelId = "glm-5"
 export const internationalZAiModels = {
+	"glm-5": {
+		maxTokens: 131_000,
+		contextWindow: 200_000,
+		supportsImages: false,
+		supportsPromptCache: true,
+		cacheReadsPrice: 0.11,
+		inputPrice: 0.6,
+		outputPrice: 2.2,
+	},
 	"glm-4.7": {
 		maxTokens: 131_000,
 		contextWindow: 200_000,
@@ -4169,8 +4193,17 @@ export const internationalZAiModels = {
 } as const satisfies Record<string, ModelInfo>
 
 export type mainlandZAiModelId = keyof typeof mainlandZAiModels
-export const mainlandZAiDefaultModelId: mainlandZAiModelId = "glm-4.7"
+export const mainlandZAiDefaultModelId: mainlandZAiModelId = "glm-5"
 export const mainlandZAiModels = {
+	"glm-5": {
+		maxTokens: 131_000,
+		contextWindow: 200_000,
+		supportsImages: false,
+		supportsPromptCache: true,
+		cacheReadsPrice: 0.11,
+		inputPrice: 0.6,
+		outputPrice: 2.2,
+	},
 	"glm-4.7": {
 		maxTokens: 131_000,
 		contextWindow: 200_000,

--- a/src/utils/model-utils.ts
+++ b/src/utils/model-utils.ts
@@ -98,6 +98,8 @@ export function isGPT52Model(id: string): boolean {
 export function isGLMModelFamily(id: string): boolean {
 	const modelId = normalize(id)
 	return (
+		modelId.includes("glm-5") ||
+		modelId.includes("glm-4.7") ||
 		modelId.includes("glm-4.6") ||
 		modelId.includes("glm-4.5") ||
 		modelId.includes("z-ai/glm") ||


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

### Description

Add GLM-5 model support for ZAi (both international and mainland China) and Cerebras providers, following the same pattern as the GLM-4.7 addition (#8258).

- Add `glm-5` model configuration for both international and mainland ZAi
- Add `zai-glm-5` model configuration for Cerebras
- Update default model from `glm-4.7` to `glm-5` across all three providers
- Add `z-ai/glm-5` to OpenRouter provider preferences
- Update `isGLMModelFamily()` in model-utils to recognize `glm-5` (and `glm-4.7` which was previously missing)

Note: Pricing is placeholder (same as glm-4.7) and should be updated once official GLM-5 pricing is published.

### Test Procedure

- Verified the changes follow the exact same pattern as the GLM-4.7 addition (commit `0b308d61`)
- `isGLMModelFamily()` now correctly matches `glm-5` model IDs, ensuring the GLM system prompt variant is applied
- `shouldSkipReasoningForModel()` already uses `modelId.includes("glm")` which covers `glm-5` without changes
- CLI ModelPicker imports `internationalZAiDefaultModelId` and `internationalZAiModels` from shared, so it picks up the new default automatically

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A - Backend model configuration changes only.

### Additional Notes

Modeled after #8258 (GLM-4.7 addition). Snapshot tests will need regeneration with `UPDATE_SNAPSHOTS=true npm run test:unit`.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add GLM-5 model support and update defaults for ZAi and Cerebras providers, with utility updates for model recognition.
> 
>   - **Behavior**:
>     - Add `glm-5` model configuration for international and mainland ZAi, and Cerebras in `api.ts`.
>     - Update default model to `glm-5` for ZAi and Cerebras providers in `api.ts`.
>     - Add `z-ai/glm-5` to OpenRouter provider preferences in `api.ts`.
>     - Update `isGLMModelFamily()` in `model-utils.ts` to include `glm-5`.
>   - **Misc**:
>     - Placeholder pricing for `glm-5` same as `glm-4.7` in `api.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 5e6116c8c0e5cbb161fb64e64b7f56c200762db0. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->