### PR TITLE
feat: make Read File UI/UX consistent across approval states

### DIFF
--- a/.changeset/accumulative-read-approval-list.md
+++ b/.changeset/accumulative-read-approval-list.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Improve read tool approval UX with accumulative file list. When manual approval is required, files now appear in a growing list with a dynamic header ("Cline read N files and wants to read:") instead of showing each file as a separate isolated block. The currently pending file is highlighted in blue and turns gray after approval.

--- a/webview-ui/src/components/chat/FileToolRow.tsx
+++ b/webview-ui/src/components/chat/FileToolRow.tsx
@@ -1,0 +1,225 @@
+import type { ClineSayTool } from "@shared/ExtensionMessage"
+import { StringRequest } from "@shared/proto/cline/common"
+import type { LucideIcon } from "lucide-react"
+import { memo, useCallback } from "react"
+import { TypewriterText } from "@/components/chat/TypewriterText"
+import { cleanPathPrefix } from "@/components/common/CodeAccordian"
+import { Button } from "@/components/ui/button"
+import { cn } from "@/lib/utils"
+import { FileServiceClient } from "@/services/grpc-client"
+
+export interface FileToolRowProps {
+	/** The lucide icon component to display */
+	icon: LucideIcon
+	/** The file/folder path to display (relative/display path) */
+	filePath: string
+	/** Optional custom display text (overrides filePath display, e.g. for search results) */
+	displayText?: string
+	/** If true, renders a disabled row with typewriter activity text instead of clickable path */
+	isActive?: boolean
+	/** Activity text shown during active state (e.g. "Reading src/App.tsx...") */
+	activityText?: string
+	/** If true, the item is expandable (folders, search, definitions) rather than opening file */
+	isExpandable?: boolean
+	/** Whether the expandable item is currently expanded */
+	isExpanded?: boolean
+	/** Callback for expand/collapse toggle */
+	onToggle?: () => void
+	/** Expandable content (e.g., file list for folders) */
+	expandedContent?: string | null
+	/** Absolute path to use for opening file (if different from filePath) */
+	absolutePath?: string
+	/** Warning icon for outside-workspace files */
+	outsideWorkspace?: boolean
+	/** Highlight the file path in blue (e.g., for pending approval) */
+	isHighlighted?: boolean
+}
+
+/**
+ * A shared compact file/folder row used in both ToolGroupRenderer (grouped tools)
+ * and individual ChatRow tool cases (e.g., readFile with approval).
+ *
+ * Renders a single-line entry: [icon] [path/activity text]
+ * Clicking opens the file in the editor or toggles expansion for folders.
+ */
+export const FileToolRow = memo<FileToolRowProps>(
+	({
+		icon: Icon,
+		filePath,
+		displayText,
+		isActive,
+		activityText,
+		isExpandable,
+		isExpanded,
+		onToggle,
+		expandedContent,
+		absolutePath,
+		outsideWorkspace,
+		isHighlighted,
+	}) => {
+		const handleOpenFile = useCallback(() => {
+			if (absolutePath) {
+				FileServiceClient.openFile(StringRequest.create({ value: absolutePath })).catch((err) =>
+					console.error("Failed to open file:", err),
+				)
+			} else if (filePath) {
+				FileServiceClient.openFileRelativePath(StringRequest.create({ value: filePath })).catch((err) =>
+					console.error("Failed to open file:", err),
+				)
+			}
+		}, [filePath, absolutePath])
+
+		const handleClick = useCallback(() => {
+			if (isExpandable && onToggle) {
+				onToggle()
+			} else {
+				handleOpenFile()
+			}
+		}, [isExpandable, onToggle, handleOpenFile])
+
+		// Active items render with "Reading..." TypewriterText (disabled, not clickable)
+		if (isActive && activityText) {
+			return (
+				<div className="min-w-0">
+					<Button
+						className="flex items-center gap-[3px] text-[13px] text-description py-[1px] min-w-0 max-w-full px-0 leading-tight -my-0.5"
+						disabled
+						size="icon"
+						variant="text">
+						<Icon className="opacity-70 shrink-0 size-[12px]" />
+						<span className="flex-1 min-w-0 whitespace-nowrap overflow-hidden text-ellipsis text-left text-[13px]">
+							<TypewriterText speed={15} text={activityText} />
+						</span>
+					</Button>
+				</div>
+			)
+		}
+
+		// Completed/static items render as clickable
+		return (
+			<div className="min-w-0">
+				<Button
+					className={cn(
+						"flex items-center gap-[3px] cursor-pointer text-[13px] py-[1px] hover:text-link min-w-0 max-w-full px-0 leading-tight -my-0.5",
+						isHighlighted ? "text-link" : "text-description",
+					)}
+					onClick={handleClick}
+					size="icon"
+					variant="text">
+					<Icon className={cn("shrink-0 size-[12px]", isHighlighted ? "opacity-90" : "opacity-70")} />
+					{outsideWorkspace && (
+						<span
+							className="codicon codicon-sign-out ph-no-capture"
+							style={{
+								color: "var(--vscode-editorWarning-foreground)",
+								marginBottom: "-1.5px",
+								transform: "rotate(-90deg)",
+							}}
+							title="This file is outside of your workspace"
+						/>
+					)}
+					<span
+						className={cn(
+							"flex-1 min-w-0 whitespace-nowrap overflow-hidden text-ellipsis text-left [direction:rtl] text-[13px]",
+							{
+								"[direction:ltr]": !!displayText,
+							},
+						)}>
+						{(displayText || cleanPathPrefix(filePath)) + "\u200E"}
+					</span>
+				</Button>
+				{/* Expanded content for folders/search/definitions - file lists only */}
+				{isExpandable && isExpanded && expandedContent && (
+					<pre className="m-1 ml-4 text-xs opacity-80 whitespace-pre-wrap break-words p-2 max-h-40 overflow-auto rounded-xs">
+						{expandedContent}
+					</pre>
+				)}
+			</div>
+		)
+	},
+)
+
+// ============================================================================
+// Helper functions shared between ToolGroupRenderer and ChatRow
+// ============================================================================
+
+/**
+ * Get display info for a tool type (icon, path, label, displayText).
+ */
+export function getToolDisplayInfo(tool: ClineSayTool, getIcon: (toolName: string) => LucideIcon) {
+	const icon = getIcon(tool.tool)
+	const filePath = tool.path || ""
+	const folderPath = filePath + "/"
+
+	switch (tool.tool) {
+		case "readFile":
+			return { icon, path: filePath, label: "read" }
+		case "listFilesTopLevel":
+			return { icon, path: folderPath, label: "listed" }
+		case "listFilesRecursive":
+			return { icon, path: folderPath, label: "listed recursively" }
+		case "listCodeDefinitionNames":
+			return { icon, path: folderPath, label: "definitions" }
+		case "searchFiles":
+			return {
+				icon,
+				path: folderPath,
+				label: `search: ${tool.regex}`,
+				displayText: formatSearchDisplay(tool.regex || "", filePath, tool.filePattern),
+			}
+		default:
+			return null
+	}
+}
+
+/**
+ * Format activity text for active tool items (e.g., "Reading src/App.tsx...").
+ */
+export function getActivityText(tool: ClineSayTool): string | null {
+	const cleanedPath = cleanPathPrefix(tool.path || "")
+	switch (tool.tool) {
+		case "readFile":
+			return tool.path ? `Reading ${cleanedPath}...` : null
+		case "listFilesTopLevel":
+		case "listFilesRecursive":
+			return tool.path ? `Exploring ${cleanedPath}/...` : null
+		case "searchFiles":
+			return tool.regex && tool.path ? `Searching ${formatSearchRegex(tool.regex, tool.path, tool.filePattern)}...` : null
+		case "listCodeDefinitionNames":
+			return tool.path ? `Analyzing ${cleanedPath}/...` : null
+		default:
+			return null
+	}
+}
+
+/**
+ * Format search regex for compact display.
+ */
+function formatSearchDisplay(regex: string, path: string, filePattern?: string): string {
+	const terms = regex
+		.split("|")
+		.map((t) => t.trim().replace(/\\b/g, "").replace(/\\s\?/g, " "))
+		.filter(Boolean)
+
+	const termDisplay = terms.length > 3 ? `${terms.length} patterns` : `"${terms.join(" | ")}"`
+	let result = `${termDisplay} in ${cleanPathPrefix(path)}/`
+
+	if (filePattern && filePattern !== "*") {
+		result += ` (${filePattern})`
+	}
+
+	return result
+}
+
+/**
+ * Format search regex for activity text.
+ */
+function formatSearchRegex(regex: string, path: string, filePattern?: string): string {
+	const cleanedPath = cleanPathPrefix(path)
+	const terms = regex
+		.split("|")
+		.map((t) => t.trim().replace(/\\b/g, "").replace(/\\s\?/g, " "))
+		.filter(Boolean)
+		.join(" | ")
+	return filePattern && filePattern !== "*" ? `"${terms}" in ${cleanedPath}/ (${filePattern})` : `"${terms}" in ${cleanedPath}/`
+}

--- a/webview-ui/src/components/chat/chat-view/components/messages/ToolGroupRenderer.tsx
+++ b/webview-ui/src/components/chat/chat-view/components/messages/ToolGroupRenderer.tsx
@@ -1,11 +1,7 @@
 import { ClineMessage, ClineSayTool } from "@shared/ExtensionMessage"
-import { StringRequest } from "@shared/proto/cline/common"
 import { memo, useCallback, useMemo, useState } from "react"
-import { TypewriterText } from "@/components/chat/TypewriterText"
-import { cleanPathPrefix } from "@/components/common/CodeAccordian"
-import { Button } from "@/components/ui/button"
+import { FileToolRow, getActivityText, getToolDisplayInfo } from "@/components/chat/FileToolRow"
 import { cn } from "@/lib/utils"
-import { FileServiceClient } from "@/services/grpc-client"
 import { getIconByToolName, getToolsNotInCurrentActivities, isLowStakesTool } from "../../utils/messageUtils"
 
 interface ToolGroupRendererProps {
@@ -20,39 +16,10 @@ interface ToolWithReasoning {
 	reasoning?: string
 	isActive?: boolean
 	activityText?: string
+	isPendingApproval?: boolean
 }
 
 const EXPANDABLE_TOOLS = new Set(["listFilesTopLevel", "listFilesRecursive", "listCodeDefinitionNames", "searchFiles"])
-
-// Helper to format activity text for active items (from RequestStartRow logic)
-const getActivityText = (tool: ClineSayTool): string | null => {
-	const cleanedPath = cleanPathPrefix(tool.path || "")
-	const formatSearchRegex = (regex: string, path: string, filePattern?: string): string => {
-		const cleanedPath = cleanPathPrefix(path)
-		const terms = regex
-			.split("|")
-			.map((t) => t.trim().replace(/\\b/g, "").replace(/\\s\?/g, " "))
-			.filter(Boolean)
-			.join(" | ")
-		return filePattern && filePattern !== "*"
-			? `"${terms}" in ${cleanedPath}/ (${filePattern})`
-			: `"${terms}" in ${cleanedPath}/`
-	}
-
-	switch (tool.tool) {
-		case "readFile":
-			return tool.path ? `Reading ${cleanedPath}...` : null
-		case "listFilesTopLevel":
-		case "listFilesRecursive":
-			return tool.path ? `Exploring ${cleanedPath}/...` : null
-		case "searchFiles":
-			return tool.regex && tool.path ? `Searching ${formatSearchRegex(tool.regex, tool.path, tool.filePattern)}...` : null
-		case "listCodeDefinitionNames":
-			return tool.path ? `Analyzing ${cleanedPath}/...` : null
-		default:
-			return null
-	}
-}
 
 // Calculate current activities (from RequestStartRow logic)
 const getCurrentActivities = (allMessages: ClineMessage[]): ClineMessage[] => {
@@ -84,10 +51,12 @@ const getCurrentActivities = (allMessages: ClineMessage[]): ClineMessage[] => {
 		const msg = allMessages[i]
 		// Only collect tools that are currently executing (ask === "tool")
 		// Skip completed tools (say === "tool") - they should be in the completed list
+		// Also skip pending approval tools that are not partial (they show in pending section)
 		if (msg.say === "tool" || msg.ask !== "tool") {
 			continue
 		}
-		if (isLowStakesTool(msg)) {
+		// Only show as "active" activity if still streaming (partial)
+		if (isLowStakesTool(msg) && msg.partial) {
 			activities.push(msg)
 		}
 	}
@@ -97,12 +66,13 @@ const getCurrentActivities = (allMessages: ClineMessage[]): ClineMessage[] => {
 
 /**
  * Renders a collapsible group of low-stakes tool calls.
- * Shows both completed tools AND currently active tools in a unified list (only for last group).
+ * Shows completed tools, active tools, AND pending approval tools in a unified accumulative list.
  */
 export const ToolGroupRenderer = memo(({ messages, allMessages, isLastGroup }: ToolGroupRendererProps) => {
 	const [expandedItems, setExpandedItems] = useState<Record<number, boolean>>({})
 
 	// Filter out tools in the "current activities" range (being shown in loading state)
+	// This only filters ask tools that are still streaming - pending approval tools are kept
 	const filteredMessages = useMemo(() => getToolsNotInCurrentActivities(messages, allMessages), [messages, allMessages])
 
 	// Get current activities (active reading/exploring) - only for last group
@@ -113,10 +83,41 @@ export const ToolGroupRenderer = memo(({ messages, allMessages, isLastGroup }: T
 		return getCurrentActivities(allMessages)
 	}, [allMessages, isLastGroup])
 
-	// Build completed tool items
-	const completedTools = useMemo(() => buildToolsWithReasoning(filteredMessages), [filteredMessages])
+	// Split messages into completed tools and pending approval tools
+	// Use raw `messages` (not filtered) to find pending approval tools,
+	// since getToolsNotInCurrentActivities filters out ask tools
+	const { completedTools, pendingApprovalTools } = useMemo(() => {
+		const completed: ToolWithReasoning[] = []
+		const pending: ToolWithReasoning[] = []
 
-	// Build active tool items
+		// Find pending approval tools from raw messages (not filtered)
+		// These are ask tools that have finished streaming (not partial)
+		for (const msg of messages) {
+			if (msg.say === "reasoning") continue
+			if (isLowStakesTool(msg) && msg.type === "ask" && !msg.partial) {
+				pending.push({
+					tool: msg,
+					parsedTool: parseToolSafe(msg.text),
+					isPendingApproval: true,
+				})
+			}
+		}
+
+		// Find completed tools from filtered messages
+		for (const msg of filteredMessages) {
+			if (msg.say === "reasoning") continue
+			if (isLowStakesTool(msg) && msg.type === "say") {
+				completed.push({
+					tool: msg,
+					parsedTool: parseToolSafe(msg.text),
+				})
+			}
+		}
+
+		return { completedTools: completed, pendingApprovalTools: pending }
+	}, [messages, filteredMessages])
+
+	// Build active tool items (still streaming)
 	const activeTools = useMemo(() => {
 		return currentActivities
 			.map((msg) => {
@@ -132,129 +133,108 @@ export const ToolGroupRenderer = memo(({ messages, allMessages, isLastGroup }: T
 			.filter((item) => item.activityText)
 	}, [currentActivities])
 
-	// Merge: completed items first, then active items (active only added to last group)
 	// Deduplicate - exclude completed items that match active items by path
-	const allTools = useMemo(() => {
-		// Get paths of active items
+	const dedupedCompleted = useMemo(() => {
 		const activePaths = new Set(activeTools.map((item) => item.parsedTool.path).filter(Boolean))
+		const pendingPaths = new Set(pendingApprovalTools.map((item) => item.parsedTool.path).filter(Boolean))
+		return completedTools.filter((item) => !activePaths.has(item.parsedTool.path) && !pendingPaths.has(item.parsedTool.path))
+	}, [completedTools, activeTools, pendingApprovalTools])
 
-		// Filter out completed items that are also being actively read
-		const dedupedCompleted = completedTools.filter((item) => !activePaths.has(item.parsedTool.path))
+	const completedCount = dedupedCompleted.length
+	const hasPendingApproval = pendingApprovalTools.length > 0
+	const hasCompleted = completedCount > 0
+	const hasActive = activeTools.length > 0
 
-		return [...dedupedCompleted, ...activeTools]
-	}, [completedTools, activeTools])
-
-	const summary = getToolGroupSummary(filteredMessages)
-
-	const handleOpenFile = useCallback((filePath: string) => {
-		FileServiceClient.openFileRelativePath(StringRequest.create({ value: filePath })).catch((err) =>
-			console.error("Failed to open file:", err),
-		)
-	}, [])
+	const summary = getToolGroupSummary(dedupedCompleted)
 
 	const handleItemToggle = useCallback((ts: number) => {
 		setExpandedItems((prev) => ({ ...prev, [ts]: !prev[ts] }))
 	}, [])
 
-	// Don't render if no tools to show
-	if (allTools.length === 0) {
+	// Don't render if no tools to show at all
+	if (!hasCompleted && !hasPendingApproval && !hasActive) {
 		return null
 	}
 
 	return (
 		<div className={cn("px-4 py-2 ml-1 text-description")}>
-			{/* Header */}
-			<div className="text-[13px] text-foreground mb-1">{summary}:</div>
+			{/* Completed tools section */}
+			{hasCompleted && (
+				<>
+					<div className="text-[13px] text-foreground mb-1">{summary}:</div>
+					<div className="min-w-0">
+						{dedupedCompleted.map(({ tool, parsedTool }) => {
+							const info = getToolDisplayInfo(parsedTool, getIconByToolName)
+							if (!info) return null
+							const isExpandable = EXPANDABLE_TOOLS.has(parsedTool.tool)
+							const isItemExpanded = expandedItems[tool.ts] ?? false
+							return (
+								<FileToolRow
+									displayText={info.displayText}
+									expandedContent={parsedTool.content || null}
+									filePath={info.path}
+									icon={info.icon}
+									isExpandable={isExpandable}
+									isExpanded={isItemExpanded}
+									key={tool.ts}
+									onToggle={() => handleItemToggle(tool.ts)}
+								/>
+							)
+						})}
+					</div>
+				</>
+			)}
 
-			{/* Content - unified list of completed + active tools */}
-			<div className="min-w-0">
-				{allTools.map(({ tool, parsedTool, isActive, activityText }) => {
-					const info = getToolDisplayInfo(parsedTool)
-					if (!info) {
-						return null
-					}
-
-					const isExpandable = EXPANDABLE_TOOLS.has(parsedTool.tool)
-					const isItemExpanded = expandedItems[tool.ts] ?? false
-					const content = parsedTool.content || null
-
-					// Active items render with "Reading..." TypewriterText (match completed item structure exactly)
-					if (isActive && activityText) {
+			{/* Active tools (still streaming - typewriter animation) */}
+			{hasActive && (
+				<div className="min-w-0">
+					{activeTools.map(({ tool, parsedTool, activityText }) => {
+						const info = getToolDisplayInfo(parsedTool, getIconByToolName)
+						if (!info) return null
 						return (
-							<div className="min-w-0" key={tool.ts}>
-								{/* ACTIVE "READING..." ITEM STYLING - Modify vertical spacing here via py-0 and -my-0.5 */}
-								<Button
-									className="flex items-center gap-[3px] text-[13px] text-description py-[1px] min-w-0 max-w-full px-0 leading-tight -my-0.5"
-									disabled
-									size="icon"
-									variant="text">
-									<info.icon className="opacity-70 shrink-0 size-[12px]" />
-									<span className="flex-1 min-w-0 whitespace-nowrap overflow-hidden text-ellipsis text-left text-[13px]">
-										<TypewriterText speed={15} text={activityText} />
-									</span>{" "}
-								</Button>
-							</div>
+							<FileToolRow
+								activityText={activityText ?? undefined}
+								filePath={info.path}
+								icon={info.icon}
+								isActive={true}
+								key={tool.ts}
+							/>
 						)
-					}
+					})}
+				</div>
+			)}
 
-					// Completed items render normally (clickable)
-					return (
-						<div className="min-w-0" key={tool.ts}>
-							<Button
-								className="flex items-center gap-[3px] cursor-pointer text-[13px] text-description py-[1px] hover:text-link min-w-0 max-w-full px-0 leading-tight -my-0.5"
-								onClick={() => (isExpandable ? handleItemToggle(tool.ts) : handleOpenFile(info.path))}
-								size="icon"
-								variant="text">
-								<info.icon className="opacity-70 shrink-0 size-[12px]" />
-								<span
-									className={cn(
-										"flex-1 min-w-0 whitespace-nowrap overflow-hidden text-ellipsis text-left [direction:rtl] text-[13px]",
-										{
-											"[direction:ltr]": !!info.displayText,
-										},
-									)}>
-									{(info.displayText || cleanPathPrefix(info.path)) + "\u200E"}
-								</span>
-							</Button>
-							{/* Expanded content for folders/search/definitions - file lists only */}
-							{isExpandable && isItemExpanded && content && (
-								<pre className="m-1 ml-4 text-xs opacity-80 whitespace-pre-wrap break-words p-2 max-h-40 overflow-auto rounded-xs">
-									{content}
-								</pre>
-							)}
-						</div>
-					)
-				})}
-			</div>
+			{/* Pending approval section */}
+			{hasPendingApproval && (
+				<>
+					<div className="text-[13px] text-foreground mb-1 mt-2">Cline wants to read:</div>
+					<div className="min-w-0">
+						{pendingApprovalTools.map(({ tool, parsedTool }) => {
+							const info = getToolDisplayInfo(parsedTool, getIconByToolName)
+							if (!info) return null
+							const isExpandable = EXPANDABLE_TOOLS.has(parsedTool.tool)
+							const isItemExpanded = expandedItems[tool.ts] ?? false
+							return (
+								<FileToolRow
+									displayText={info.displayText}
+									expandedContent={parsedTool.content || null}
+									filePath={info.path}
+									icon={info.icon}
+									isExpandable={isExpandable}
+									isExpanded={isItemExpanded}
+									isHighlighted={true}
+									key={tool.ts}
+									onToggle={() => handleItemToggle(tool.ts)}
+									outsideWorkspace={parsedTool.operationIsLocatedInWorkspace === false}
+								/>
+							)
+						})}
+					</div>
+				</>
+			)}
 		</div>
 	)
 })
-
-/**
- * Build tool items WITHOUT reasoning.
- * Reasoning should not be displayed in file lists - only file/folder content.
- */
-function buildToolsWithReasoning(messages: ClineMessage[]): ToolWithReasoning[] {
-	const result: ToolWithReasoning[] = []
-
-	for (const msg of messages) {
-		// Skip reasoning messages - they should not be in file lists
-		if (msg.say === "reasoning") {
-			continue
-		}
-
-		if (isLowStakesTool(msg)) {
-			const parsedTool = parseToolSafe(msg.text)
-			result.push({
-				tool: msg,
-				parsedTool,
-				reasoning: undefined, // Never show reasoning in file lists
-			})
-		}
-	}
-
-	return result
-}
 
 /**
  * Safely parse tool JSON, returning empty tool on failure.
@@ -268,66 +248,12 @@ function parseToolSafe(text: string | undefined): ClineSayTool {
 }
 
 /**
- * Get display info for a tool.
+ * Get summary label for completed tools - shows what's been added to context.
  */
-function getToolDisplayInfo(tool: ClineSayTool) {
-	const icon = getIconByToolName(tool.tool)
-	const filePath = tool.path || ""
-	const folderPath = filePath + "/"
-
-	switch (tool.tool) {
-		case "readFile":
-			return { icon, path: filePath, label: "read" }
-		case "listFilesTopLevel":
-			return { icon, path: folderPath, label: "listed" }
-		case "listFilesRecursive":
-			return { icon, path: folderPath, label: "listed recursively" }
-		case "listCodeDefinitionNames":
-			return { icon, path: folderPath, label: "definitions" }
-		case "searchFiles":
-			return {
-				icon,
-				path: folderPath,
-				label: `search: ${tool.regex}`,
-				displayText: formatSearchDisplay(tool.regex || "", filePath, tool.filePattern),
-			}
-		default:
-			return null
-	}
-}
-
-/**
- * Format search regex for display - simplify complex patterns
- */
-function formatSearchDisplay(regex: string, path: string, filePattern?: string): string {
-	// Split by | and clean up regex syntax
-	const terms = regex
-		.split("|")
-		.map((t) => t.trim().replace(/\\b/g, "").replace(/\\s\?/g, " "))
-		.filter(Boolean)
-
-	const termDisplay = terms.length > 3 ? `${terms.length} patterns` : `"${terms.join(" | ")}"`
-	let result = `${termDisplay} in ${cleanPathPrefix(path)}/`
-
-	if (filePattern && filePattern !== "*") {
-		result += ` (${filePattern})`
-	}
-
-	return result
-}
-
-/**
- * Get summary label for a tool group - shows what's been added to context.
- */
-function getToolGroupSummary(messages: ClineMessage[]): string {
+function getToolGroupSummary(completedTools: ToolWithReasoning[]): string {
 	const counts = { read: 0, list: 0, search: 0, def: 0 }
 
-	for (const msg of messages) {
-		if (!isLowStakesTool(msg)) {
-			continue
-		}
-
-		const tool = parseToolSafe(msg.text)
+	for (const { parsedTool: tool } of completedTools) {
 		switch (tool.tool) {
 			case "readFile":
 				counts.read++

--- a/webview-ui/src/components/chat/chat-view/utils/messageUtils.ts
+++ b/webview-ui/src/components/chat/chat-view/utils/messageUtils.ts
@@ -721,7 +721,6 @@ export function groupLowStakesTools(groupedMessages: (ClineMessage | ClineMessag
 	let pendingReasoning: ClineMessage[] = []
 	let pendingApiReq: ClineMessage[] = []
 	let hasTools = false
-	const pendingTools: ClineMessage[] = []
 
 	const flushPending = () => {
 		pendingApiReq.forEach((m) => result.push(m))
@@ -768,15 +767,12 @@ export function groupLowStakesTools(groupedMessages: (ClineMessage | ClineMessag
 		const isLast = i === groupedMessages.length - 1
 
 		// Low-stakes tool - absorb pending and add to group
+		// Pending approval tools (ask type) stay in the group so ToolGroupRenderer
+		// can show them in an accumulative list with a "wants to read" section.
 		if (isLowStakesTool(message)) {
 			absorbPending()
 			hasTools = true
 			toolGroup.push(message)
-			// If the streaming has stopped and the last message is still an ask,
-			// this means the tool requires user approval - show the old tool block UI.
-			if (message.type === "ask" && !message.partial && isLast) {
-				pendingTools.push(message)
-			}
 			continue
 		}
 
@@ -824,10 +820,6 @@ export function groupLowStakesTools(groupedMessages: (ClineMessage | ClineMessag
 	// Finalize any remaining work
 	commitToolGroup()
 	flushPending()
-
-	if (pendingTools.length > 0) {
-		result.push(...pendingTools)
-	}
 
 	return result
 }


### PR DESCRIPTION

Changeset created. Here's the PR description:

---

### Related Issue

**Issue:** N/A — UX improvement for read tool approval flow

### Description

When auto-approve is off, each `read_file` tool approval previously appeared as a separate, isolated block in the chat stream. Users had no visibility into which files had already been read vs which file was currently awaiting approval.

This PR enhances the `ToolGroupRenderer` to show an **accumulative file list** during the manual approval flow — the same compact list style users already see with auto-approved reads:

- All files appear in a single growing list rather than individual blocks
- The currently pending file is highlighted in blue; previously approved files appear in gray
- Header updates dynamically: "Cline wants to read:" → "Cline read 3 files and wants to read:" → "Cline read 6 files:"
- After approving a file, the blue highlight clears immediately as the conversation advances

### Test Procedure

- Disable auto-approve for read tools
- Start a task that requires reading multiple files
- Verify files accumulate in a list as each is approved
- Verify only the current pending file is highlighted blue
- Verify the header count updates after each approval
- Verify all files turn gray and header shows "Cline read N files:" when complete
- Verify auto-approved reads still work identically (grouped list, no regressions)

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [x] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Before:
<img width="864" height="1604" alt="image" src="https://github.com/user-attachments/assets/e4499c48-ee83-47d3-b6cd-c6a16a3bf5c2" />

After:
<img width="523" height="385" alt="image" src="https://github.com/user-attachments/assets/9d18a3c2-507a-46d1-8f6d-ced10dc4d680" />
<img width="520" height="1023" alt="Screenshot 2026-02-11 at 12 00 53 PM" src="https://github.com/user-attachments/assets/f0b428f0-7e5c-43dd-8629-1a714ea5a68e" />


### Additional Notes

Files changed:
- `ToolGroupRenderer.tsx` — Split rendering into completed, active, and pending approval sections with optimistic read counting and contextual blue highlight
- `messageUtils.ts` — Pending approval tools stay in the tool group instead of being extracted as separate ChatRow items

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Enhance file read approval UI/UX by consolidating requests into a single list with dynamic headers and highlights in `ToolGroupRenderer.tsx`.
> 
>   - **Behavior**:
>     - `ToolGroupRenderer` now shows an accumulative file list for manual approval in `ToolGroupRenderer.tsx`.
>     - Pending files are highlighted in blue; approved files are gray.
>     - Header updates dynamically to reflect the number of files read and pending.
>   - **Components**:
>     - New `FileToolRow` component in `FileToolRow.tsx` for rendering file rows with icons and activity text.
>     - `ChatRow.tsx` updated to use `FileToolRow` for `readFile` tool rendering.
>   - **Utils**:
>     - `getToolsNotInCurrentActivities` in `messageUtils.ts` updated to handle pending approval tools.
>     - `getToolDisplayInfo` and `getActivityText` added to `FileToolRow.tsx` for tool display logic.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for b9ac3fab3bec83b59cc653efdacf80835e5f1343. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->