### PR TITLE
feat(zai): add GLM-5 pricing and set it as default

### DIFF
--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -4119,11 +4119,20 @@ export type BasetenModelId = keyof typeof basetenModels
 export const basetenDefaultModelId = "zai-org/GLM-4.6" satisfies BasetenModelId
 
 // Z AI
-// https://docs.z.ai/guides/llm/glm-4.5
+// https://docs.z.ai/guides/llm/glm-5
 // https://docs.z.ai/guides/overview/pricing
 export type internationalZAiModelId = keyof typeof internationalZAiModels
-export const internationalZAiDefaultModelId: internationalZAiModelId = "glm-4.7"
+export const internationalZAiDefaultModelId: internationalZAiModelId = "glm-5"
 export const internationalZAiModels = {
+	"glm-5": {
+		maxTokens: 128_000,
+		contextWindow: 200_000,
+		supportsImages: false,
+		supportsPromptCache: true,
+		cacheReadsPrice: 0.2,
+		inputPrice: 1.0,
+		outputPrice: 3.2,
+	},
 	"glm-4.7": {
 		maxTokens: 131_000,
 		contextWindow: 200_000,
@@ -4169,8 +4178,17 @@ export const internationalZAiModels = {
 } as const satisfies Record<string, ModelInfo>
 
 export type mainlandZAiModelId = keyof typeof mainlandZAiModels
-export const mainlandZAiDefaultModelId: mainlandZAiModelId = "glm-4.7"
+export const mainlandZAiDefaultModelId: mainlandZAiModelId = "glm-5"
 export const mainlandZAiModels = {
+	"glm-5": {
+		maxTokens: 128_000,
+		contextWindow: 200_000,
+		supportsImages: false,
+		supportsPromptCache: true,
+		cacheReadsPrice: 0.2,
+		inputPrice: 1.0,
+		outputPrice: 3.2,
+	},
 	"glm-4.7": {
 		maxTokens: 131_000,
 		contextWindow: 200_000,

--- a/src/utils/model-utils.ts
+++ b/src/utils/model-utils.ts
@@ -98,6 +98,8 @@ export function isGPT52Model(id: string): boolean {
 export function isGLMModelFamily(id: string): boolean {
 	const modelId = normalize(id)
 	return (
+		modelId.includes("glm-5") ||
+		modelId.includes("glm-4.7") ||
 		modelId.includes("glm-4.6") ||
 		modelId.includes("glm-4.5") ||
 		modelId.includes("z-ai/glm") ||


### PR DESCRIPTION
## Summary
- add `glm-5` to Z AI model catalogs for both international and mainland endpoints
- set `glm-5` as the default model for Z AI
- update GLM family detection to include `glm-5` (and `glm-4.7`) so GLM-specific prompt variant routing still applies

## Model metadata sourced from docs
- Context Length: `200K`
- Maximum Output Tokens: `128K`
- Pricing (per MTok): Input `$1`, Cached Input `$0.2`, Output `$3.2`

## Source references
- https://docs.z.ai/guides/llm/glm-5
- https://docs.z.ai/guides/overview/pricing

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `glm-5` to Z AI model catalogs, set it as default, and update GLM family detection to include `glm-5` and `glm-4.7`.
> 
>   - **Behavior**:
>     - Add `glm-5` to Z AI model catalogs for both international and mainland endpoints in `api.ts`.
>     - Set `glm-5` as the default model for Z AI in `api.ts`.
>     - Update GLM family detection in `isGLMModelFamily()` in `model-utils.ts` to include `glm-5` and `glm-4.7`.
>   - **Model Metadata**:
>     - Context Length: `200K`
>     - Maximum Output Tokens: `128K`
>     - Pricing (per MTok): Input `$1`, Cached Input `$0.2`, Output `$3.2`
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 66a226dfe27e0238006b61be8f9ecaab7758f575. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->