### PR TITLE
Revert "fix MCP OAuth: add missing scope parameter"

### DIFF
--- a/src/services/mcp/McpOAuthManager.ts
+++ b/src/services/mcp/McpOAuthManager.ts
@@ -85,7 +85,6 @@ class ClineOAuthClientProvider implements OAuthClientProvider {
 			client_name: "Cline",
 			client_uri: "https://cline.bot",
 			software_id: "cline",
-			scope: "openid",
 		}
 	}
 


### PR DESCRIPTION
Reverts cline/cline#9117
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Reverts addition of 'openid' scope in `clientMetadata` of `ClineOAuthClientProvider` in `McpOAuthManager.ts`.
> 
>   - **Behavior**:
>     - Reverts addition of `scope: "openid"` in `clientMetadata` of `ClineOAuthClientProvider` in `McpOAuthManager.ts`.
>     - OAuth client will no longer request 'openid' scope.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 375e40c0fbbc7377d83b5418621422cfbd8f9094. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->