### PR TITLE
fix(task): accept response alias for attempt_completion result

### DIFF
--- a/.changeset/blue-points-sit.md
+++ b/.changeset/blue-points-sit.md
@@ -1,0 +1,5 @@
+---
+"cline": patch
+---
+
+Accept `response` as an alias for `attempt_completion`'s `result` parameter to handle provider output variance and prevent false missing-parameter errors.

--- a/src/core/task/tools/handlers/AttemptCompletionHandler.ts
+++ b/src/core/task/tools/handlers/AttemptCompletionHandler.ts
@@ -19,6 +19,10 @@ import { ToolResultUtils } from "../utils/ToolResultUtils"
 
 const TASK_PREVIEW_MAX_CHARS = 8000
 
+function getCompletionResult(params: ToolUse["params"]): string | undefined {
+	return params.result || params.response
+}
+
 function getInitialTaskPreview(config: TaskConfig): string | undefined {
 	const firstTaskMessage = config.messageState
 		.getClineMessages()
@@ -44,7 +48,8 @@ export class AttemptCompletionHandler implements IToolHandler, IPartialBlockHand
 	 * Handle partial block streaming for attempt_completion
 	 */
 	async handlePartialBlock(block: ToolUse, uiHelpers: StronglyTypedUIHelpers): Promise<void> {
-		const result = uiHelpers.removeClosingTag(block, "result", block.params.result)
+		const rawResult = getCompletionResult(block.params)
+		const result = uiHelpers.removeClosingTag(block, "result", rawResult)
 		if (result) {
 			await uiHelpers.say("completion_result", result, undefined, undefined, block.partial)
 		}
@@ -52,7 +57,7 @@ export class AttemptCompletionHandler implements IToolHandler, IPartialBlockHand
 	}
 
 	async execute(config: TaskConfig, block: ToolUse): Promise<ToolResponse> {
-		const result: string | undefined = block.params.result
+		const result: string | undefined = getCompletionResult(block.params)
 		const command: string | undefined = block.params.command
 
 		// Validate required parameters
@@ -315,7 +320,7 @@ export class AttemptCompletionHandler implements IToolHandler, IPartialBlockHand
 						taskMetadata: {
 							taskId: config.taskId,
 							ulid: config.ulid,
-							result: block.params.result || "",
+							result: getCompletionResult(block.params) || "",
 							command: block.params.command || "",
 						},
 					},

--- a/src/core/task/tools/handlers/__tests__/AttemptCompletionHandler.resultAlias.test.ts
+++ b/src/core/task/tools/handlers/__tests__/AttemptCompletionHandler.resultAlias.test.ts
@@ -1,0 +1,69 @@
+import { strict as assert } from "node:assert"
+import { ClineDefaultTool } from "@shared/tools"
+import { describe, it } from "mocha"
+import sinon from "sinon"
+import { TaskState } from "../../../TaskState"
+import type { TaskConfig } from "../../types/TaskConfig"
+import { AttemptCompletionHandler } from "../AttemptCompletionHandler"
+
+function createConfig(options?: { doubleCheckEnabled?: boolean; pending?: boolean }) {
+	const taskState = new TaskState()
+	taskState.doubleCheckCompletionPending = options?.pending ?? false
+	taskState.consecutiveMistakeCount = 2
+
+	const callbacks = {
+		sayAndCreateMissingParamError: sinon.stub().resolves("missing-param"),
+		removeLastPartialMessageIfExistsWithType: sinon.stub().resolves(),
+	} as unknown as TaskConfig["callbacks"]
+
+	const config = {
+		taskId: "task-1",
+		ulid: "ulid-1",
+		taskState,
+		doubleCheckCompletionEnabled: options?.doubleCheckEnabled ?? false,
+		messageState: {
+			getClineMessages: () => [],
+		},
+		callbacks,
+	} as unknown as TaskConfig
+
+	return { config, callbacks, taskState }
+}
+
+describe("AttemptCompletionHandler result alias", () => {
+	it("accepts response as result for validation", async () => {
+		const { config, callbacks, taskState } = createConfig({ doubleCheckEnabled: true, pending: false })
+		const handler = new AttemptCompletionHandler()
+
+		const result = await handler.execute(config, {
+			type: "tool_use",
+			name: ClineDefaultTool.ATTEMPT,
+			params: {
+				response: "done via response alias",
+			},
+			partial: false,
+		})
+
+		assert.equal(taskState.consecutiveMistakeCount, 0)
+		assert.equal(taskState.doubleCheckCompletionPending, true)
+		sinon.assert.notCalled(callbacks.sayAndCreateMissingParamError as sinon.SinonStub)
+		assert.equal(typeof result, "string")
+		assert.ok((result as string).includes("Before completing"))
+	})
+
+	it("still errors when both result and response are missing", async () => {
+		const { config, callbacks, taskState } = createConfig()
+		const handler = new AttemptCompletionHandler()
+
+		const result = await handler.execute(config, {
+			type: "tool_use",
+			name: ClineDefaultTool.ATTEMPT,
+			params: {},
+			partial: false,
+		})
+
+		assert.equal(result, "missing-param")
+		assert.equal(taskState.consecutiveMistakeCount, 3)
+		sinon.assert.calledOnce(callbacks.sayAndCreateMissingParamError as sinon.SinonStub)
+	})
+})


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

### Description

This fixes an intermittent `attempt_completion` failure where Gemini sometimes sends the completion payload under `response` instead of `result`.

Runtime logs from reproduction runs showed mixed payload shapes for the same tool call:
- Some runs emitted `paramKeys: ["result", "task_progress"]`
- Other runs emitted `paramKeys: ["response", "task_progress"]`

When only `result` was accepted, `response` runs incorrectly triggered a missing-parameter error.

What changed:
- Added a single normalization helper in `AttemptCompletionHandler` that resolves completion text as `result || response`
- Applied that normalization in three places:
  - partial streaming display (`handlePartialBlock`)
  - required-parameter validation + execution (`execute`)
  - TaskComplete hook metadata payload

This keeps behavior unchanged for existing `result` payloads while making the handler resilient to provider/model output variance.

### Test Procedure

1. Unit regression test added in `AttemptCompletionHandler.resultAlias.test.ts`:
   - verifies `response` is accepted as completion content and does not trigger missing param errors
   - verifies missing-param behavior still occurs when both `result` and `response` are absent
2. Ran unit tests:
   - `npm run test:unit -- src/core/task/tools/handlers/__tests__/AttemptCompletionHandler.resultAlias.test.ts`
   - result: passing
3. Runtime verification (instrumented reproduction during debugging):
   - confirmed mixed `result`/`response` payloads in live runs
   - confirmed handler succeeds on `response` payloads when alias is enabled

Risk assessment:
- Low risk; scope is limited to `attempt_completion` parameter normalization
- Existing providers sending `result` are unaffected
- Error path for truly missing completion text is preserved

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A (non-UI change)

### Additional Notes

This PR is intentionally narrow and based directly on latest `main` to avoid coupling with prior debugging/instrumentation work.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes `attempt_completion` handler to accept `response` as an alias for `result`, ensuring payload variance is handled.
> 
>   - **Behavior**:
>     - `getCompletionResult()` function added to `AttemptCompletionHandler.ts` to normalize `result` and `response` parameters.
>     - Applied normalization in `handlePartialBlock()`, `execute()`, and `runTaskCompleteHook()` in `AttemptCompletionHandler`.
>   - **Tests**:
>     - New test file `AttemptCompletionHandler.resultAlias.test.ts` added.
>     - Tests ensure `response` is accepted as a valid alias for `result` and verify error handling when both are missing.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for d9ab1c34adfd8719f6fd7093963de6d1e9c1de74. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->