### PR TITLE
fix(deps): upgrade openai sdk to 6.21.0 for xhigh reasoning

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -82,7 +82,7 @@
 				"ollama": "^0.5.13",
 				"open": "^10.1.2",
 				"open-graph-scraper": "^6.9.0",
-				"openai": "^6.9.0",
+				"openai": "^6.21.0",
 				"os-name": "^6.0.0",
 				"p-mutex": "^1.0.0",
 				"p-timeout": "^6.1.4",
@@ -161,7 +161,7 @@
 		},
 		"cli": {
 			"name": "cline",
-			"version": "2.0.5",
+			"version": "2.2.0",
 			"cpu": [
 				"x64",
 				"arm64"
@@ -3128,7 +3128,6 @@
 			"resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.3.tgz",
 			"integrity": "sha512-Iq8QQQ/7X3Sac15oB6p0FmUg/klxQvXLeileoqrTRGJYLV+/9tubbr9ipz0GKHjmXVsgFPo/+W+2cA8eNcR+XA==",
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
 				"@grpc/proto-loader": "^0.8.0",
 				"@js-sdsl/ordered-map": "^4.4.2"
@@ -4031,7 +4030,6 @@
 			"resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.26.0.tgz",
 			"integrity": "sha512-Y5RmPncpiDtTXDbLKswIJzTqu2hyBKxTNsgKqKclDbhIgg1wgtf1fRuvxgTnRfcnxtvvgbIEcqUOzZrJ6iSReg==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@hono/node-server": "^1.19.9",
 				"ajv": "^8.17.1",
@@ -4107,7 +4105,6 @@
 			"resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
 			"integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
 			"license": "Apache-2.0",
-			"peer": true,
 			"engines": {
 				"node": ">=8.0.0"
 			}
@@ -5798,7 +5795,8 @@
 			"optional": true,
 			"os": [
 				"android"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-android-arm64": {
 			"version": "4.57.1",
@@ -5811,7 +5809,8 @@
 			"optional": true,
 			"os": [
 				"android"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-darwin-arm64": {
 			"version": "4.57.1",
@@ -5824,7 +5823,8 @@
 			"optional": true,
 			"os": [
 				"darwin"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-darwin-x64": {
 			"version": "4.57.1",
@@ -5837,7 +5837,8 @@
 			"optional": true,
 			"os": [
 				"darwin"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-freebsd-arm64": {
 			"version": "4.57.1",
@@ -5850,7 +5851,8 @@
 			"optional": true,
 			"os": [
 				"freebsd"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-freebsd-x64": {
 			"version": "4.57.1",
@@ -5863,7 +5865,8 @@
 			"optional": true,
 			"os": [
 				"freebsd"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-linux-arm-gnueabihf": {
 			"version": "4.57.1",
@@ -5876,7 +5879,8 @@
 			"optional": true,
 			"os": [
 				"linux"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-linux-arm-musleabihf": {
 			"version": "4.57.1",
@@ -5889,7 +5893,8 @@
 			"optional": true,
 			"os": [
 				"linux"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-linux-arm64-gnu": {
 			"version": "4.57.1",
@@ -5902,7 +5907,8 @@
 			"optional": true,
 			"os": [
 				"linux"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-linux-arm64-musl": {
 			"version": "4.57.1",
@@ -5915,7 +5921,8 @@
 			"optional": true,
 			"os": [
 				"linux"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-linux-loong64-gnu": {
 			"version": "4.57.1",
@@ -5928,7 +5935,8 @@
 			"optional": true,
 			"os": [
 				"linux"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-linux-loong64-musl": {
 			"version": "4.57.1",
@@ -5941,7 +5949,8 @@
 			"optional": true,
 			"os": [
 				"linux"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-linux-ppc64-gnu": {
 			"version": "4.57.1",
@@ -5954,7 +5963,8 @@
 			"optional": true,
 			"os": [
 				"linux"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-linux-ppc64-musl": {
 			"version": "4.57.1",
@@ -5967,7 +5977,8 @@
 			"optional": true,
 			"os": [
 				"linux"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-linux-riscv64-gnu": {
 			"version": "4.57.1",
@@ -5980,7 +5991,8 @@
 			"optional": true,
 			"os": [
 				"linux"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-linux-riscv64-musl": {
 			"version": "4.57.1",
@@ -5993,7 +6005,8 @@
 			"optional": true,
 			"os": [
 				"linux"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-linux-s390x-gnu": {
 			"version": "4.57.1",
@@ -6006,7 +6019,8 @@
 			"optional": true,
 			"os": [
 				"linux"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-linux-x64-gnu": {
 			"version": "4.57.1",
@@ -6019,7 +6033,8 @@
 			"optional": true,
 			"os": [
 				"linux"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-linux-x64-musl": {
 			"version": "4.57.1",
@@ -6032,7 +6047,8 @@
 			"optional": true,
 			"os": [
 				"linux"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-openbsd-x64": {
 			"version": "4.57.1",
@@ -6045,7 +6061,8 @@
 			"optional": true,
 			"os": [
 				"openbsd"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-openharmony-arm64": {
 			"version": "4.57.1",
@@ -6058,7 +6075,8 @@
 			"optional": true,
 			"os": [
 				"openharmony"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-win32-arm64-msvc": {
 			"version": "4.57.1",
@@ -6071,7 +6089,8 @@
 			"optional": true,
 			"os": [
 				"win32"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-win32-ia32-msvc": {
 			"version": "4.57.1",
@@ -6084,7 +6103,8 @@
 			"optional": true,
 			"os": [
 				"win32"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-win32-x64-gnu": {
 			"version": "4.57.1",
@@ -6097,7 +6117,8 @@
 			"optional": true,
 			"os": [
 				"win32"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-win32-x64-msvc": {
 			"version": "4.57.1",
@@ -6110,7 +6131,8 @@
 			"optional": true,
 			"os": [
 				"win32"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@sap-ai-sdk/ai-api": {
 			"version": "2.6.0",
@@ -7782,7 +7804,6 @@
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.32.tgz",
 			"integrity": "sha512-Ez8QE4DMfhjjTsES9K2dwfV258qBui7qxUsoaixZDiTzbde4U12e1pXGNu/ECsUIOi5/zoCxAQxIhQnaUQ2VvA==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"undici-types": "~6.21.0"
 			}
@@ -7845,7 +7866,6 @@
 			"integrity": "sha512-KkiJeU6VbYbUOp5ITMIc7kBfqlYkKA5KhEHVrGMmUUMt7NeaZg65ojdPk+FtNrBAOXNVM5QM72jnADjM+XVRAQ==",
 			"devOptional": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"csstype": "^3.2.2"
 			}
@@ -8780,7 +8800,6 @@
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
 			"integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
 			"license": "MIT",
-			"peer": true,
 			"bin": {
 				"acorn": "bin/acorn"
 			},
@@ -9745,7 +9764,6 @@
 				}
 			],
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"baseline-browser-mapping": "^2.9.0",
 				"caniuse-lite": "^1.0.30001759",
@@ -11144,8 +11162,7 @@
 			"version": "0.0.1367902",
 			"resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1367902.tgz",
 			"integrity": "sha512-XxtPuC3PGakY6PD7dG66/o8KwJ/LkH2/EKe19Dcw58w53dv4/vSQEkn/SzuyhHE2q4zPgCkxQBxus3VV4ql+Pg==",
-			"license": "BSD-3-Clause",
-			"peer": true
+			"license": "BSD-3-Clause"
 		},
 		"node_modules/diff": {
 			"version": "5.2.2",
@@ -12162,7 +12179,6 @@
 			"resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
 			"integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"accepts": "^2.0.0",
 				"body-parser": "^2.2.1",
@@ -13470,7 +13486,6 @@
 			"resolved": "https://registry.npmjs.org/hono/-/hono-4.11.7.tgz",
 			"integrity": "sha512-l7qMiNee7t82bH3SeyUCt9UF15EVmaBvsppY2zQtrbIhl/yzBTny+YUxsVjSjQ6gaqaeVtZmGocom8TzBlA4Yw==",
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=16.9.0"
 			}
@@ -13749,7 +13764,6 @@
 			"resolved": "https://registry.npmjs.org/@jrichman/ink/-/ink-6.4.7.tgz",
 			"integrity": "sha512-QHyxhNF5VonF5cRmdAJD/UPucB9nRx3FozWMjQrDGfBxfAL9lpyu72/MlFPgloS1TMTGsOt7YN6dTPPA6mh0Aw==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@alcalzone/ansi-tokenize": "^0.2.1",
 				"ansi-escapes": "^7.0.0",
@@ -15003,7 +15017,6 @@
 			"resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
 			"integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
 			"license": "MIT",
-			"peer": true,
 			"bin": {
 				"jiti": "lib/jiti-cli.mjs"
 			}
@@ -15353,7 +15366,6 @@
 			"resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.30.2.tgz",
 			"integrity": "sha512-utfs7Pr5uJyyvDETitgsaqSyjCb2qNRAtuqUeWIAKztsOYdcACf2KtARYXg2pSvhkt+9NfoaNY7fxjl6nuMjIQ==",
 			"license": "MPL-2.0",
-			"peer": true,
 			"dependencies": {
 				"detect-libc": "^2.0.3"
 			},
@@ -17834,9 +17846,9 @@
 			}
 		},
 		"node_modules/openai": {
-			"version": "6.18.0",
-			"resolved": "https://registry.npmjs.org/openai/-/openai-6.18.0.tgz",
-			"integrity": "sha512-odLRYyz9rlzz6g8gKn61RM2oP5UUm428sE2zOxZqS9MzVfD5/XW8UoEjpnRkzTuScXP7ZbP/m7fC+bl8jCOZZw==",
+			"version": "6.21.0",
+			"resolved": "https://registry.npmjs.org/openai/-/openai-6.21.0.tgz",
+			"integrity": "sha512-26dQFi76dB8IiN/WKGQOV+yKKTTlRCxQjoi2WLt0kMcH8pvxVyvfdBDkld5GTl7W1qvBpwVOtFcsqktj3fBRpA==",
 			"license": "Apache-2.0",
 			"bin": {
 				"openai": "bin/cli"
@@ -19090,7 +19102,6 @@
 			"resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
 			"integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -21798,7 +21809,6 @@
 			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
 			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
@@ -22120,7 +22130,6 @@
 			"resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
 			"integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"esbuild": "^0.27.0",
 				"fdir": "^6.5.0",
@@ -22202,6 +22211,7 @@
 			"os": [
 				"aix"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -22218,6 +22228,7 @@
 			"os": [
 				"android"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -22234,6 +22245,7 @@
 			"os": [
 				"android"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -22250,6 +22262,7 @@
 			"os": [
 				"android"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -22266,6 +22279,7 @@
 			"os": [
 				"darwin"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -22282,6 +22296,7 @@
 			"os": [
 				"darwin"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -22298,6 +22313,7 @@
 			"os": [
 				"freebsd"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -22314,6 +22330,7 @@
 			"os": [
 				"freebsd"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -22330,6 +22347,7 @@
 			"os": [
 				"linux"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -22346,6 +22364,7 @@
 			"os": [
 				"linux"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -22362,6 +22381,7 @@
 			"os": [
 				"linux"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -22378,6 +22398,7 @@
 			"os": [
 				"linux"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -22394,6 +22415,7 @@
 			"os": [
 				"linux"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -22410,6 +22432,7 @@
 			"os": [
 				"linux"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -22426,6 +22449,7 @@
 			"os": [
 				"linux"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -22442,6 +22466,7 @@
 			"os": [
 				"linux"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -22458,6 +22483,7 @@
 			"os": [
 				"linux"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -22474,6 +22500,7 @@
 			"os": [
 				"netbsd"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -22490,6 +22517,7 @@
 			"os": [
 				"netbsd"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -22506,6 +22534,7 @@
 			"os": [
 				"openbsd"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -22522,6 +22551,7 @@
 			"os": [
 				"openbsd"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -22538,6 +22568,7 @@
 			"os": [
 				"openharmony"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -22554,6 +22585,7 @@
 			"os": [
 				"sunos"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -22570,6 +22602,7 @@
 			"os": [
 				"win32"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -22586,6 +22619,7 @@
 			"os": [
 				"win32"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -22602,6 +22636,7 @@
 			"os": [
 				"win32"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -22657,6 +22692,7 @@
 			"os": [
 				"darwin"
 			],
+			"peer": true,
 			"engines": {
 				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
 			}
@@ -23591,7 +23627,6 @@
 			"resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
 			"integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
 			"license": "MIT",
-			"peer": true,
 			"funding": {
 				"url": "https://github.com/sponsors/colinhacks"
 			}

--- a/package.json
+++ b/package.json
@@ -571,7 +571,7 @@
 		"ollama": "^0.5.13",
 		"open": "^10.1.2",
 		"open-graph-scraper": "^6.9.0",
-		"openai": "^6.9.0",
+		"openai": "^6.21.0",
 		"os-name": "^6.0.0",
 		"p-mutex": "^1.0.0",
 		"p-timeout": "^6.1.4",


### PR DESCRIPTION
### Related Issue

Issue: N/A (reported build failure in this thread)

### Description

This change fixes a TypeScript build failure in the CLI caused by an SDK type mismatch around OpenAI reasoning effort values.

Problem
- The CLI build failed with `TS2322` in `openai-native.ts` because our internal normalized reasoning options include `xhigh`, while the currently installed `openai` SDK version in this branch exposed `ChatCompletionReasoningEffort` without `xhigh`.
- The compile error occurred when assigning `requestedEffort` into a typed `reasoning` object for the Responses API path.

Technical approach
- Upgraded `openai` from `^6.9.0` to `^6.21.0`.
- Updated lockfile entries accordingly.
- Kept `openai-native.ts` behavior unchanged after dependency upgrade.

Debugging journey
- First, I reproduced and confirmed the failing type path in `openai-native.ts`.
- I temporarily added a local fallback mapping for `xhigh` to `high` to unblock compilation, then validated builds.
- After that, I verified the latest published `openai` package and checked type declarations directly in the packed artifact.
- Confirmed `openai@6.21.0` includes `xhigh` in `ReasoningEffort` types.
- Reverted local fallback code so we do not carry behavior changes that are no longer necessary.
- Final state is dependency-only, with source logic unchanged from prior behavior.

Gotchas discovered
- A standalone `cd cli && npx tsc --noEmit` can fail in this repo when proto generated files are not present yet. Running `npm run cli:build` first (which runs protos) resolves that environment issue.
- The lockfile delta is larger than a one-line version bump because npm rewrites the relevant dependency graph entries.

Decisions and alternatives considered
- Alternative considered: keep old SDK and patch code with custom narrowing or `xhigh -> high` mapping.
- Decision: upgrade SDK instead. This keeps us aligned with current OpenAI type definitions and avoids unnecessary provider-specific behavior changes.

### Test Procedure

1. Ran `npm run cli:build` and confirmed success.
2. Ran `cd cli && npx tsc --noEmit` after proto generation and confirmed success.
3. Verified updated SDK type declarations include `xhigh` for reasoning effort.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Not applicable. No UI changes.

### Additional Notes

No user-facing behavior change was intended beyond resolving the build-blocking type mismatch by aligning SDK types with currently supported reasoning effort values.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Upgrade `openai` SDK to `6.21.0` to fix TypeScript build error due to `xhigh` reasoning effort type mismatch.
> 
>   - **Behavior**:
>     - Upgrades `openai` SDK from `^6.9.0` to `^6.21.0` in `package.json` to fix TypeScript build error `TS2322` in `openai-native.ts`.
>     - Resolves type mismatch for `xhigh` reasoning effort values in `ChatCompletionReasoningEffort`.
>   - **Technical Details**:
>     - Lockfile updated to reflect new `openai` version.
>     - No changes to `openai-native.ts` logic post-upgrade.
>   - **Debugging**:
>     - Verified `openai@6.21.0` includes `xhigh` in `ReasoningEffort` types.
>     - Removed temporary local fallback mapping for `xhigh` to `high`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 7abe59bebf70483043701f772080cce3c5dbd562. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->