### PR TITLE
feat: enable direct skill slash commands with skill-first precedence

### DIFF
--- a/cli/src/components/SlashCommandMenu.tsx
+++ b/cli/src/components/SlashCommandMenu.tsx
@@ -38,13 +38,27 @@ export const SlashCommandMenu: React.FC<SlashCommandMenuProps> = ({ commands, se
 	const { items: visibleCommands, startIndex } = getVisibleWindow(commands, selectedIndex)
 	const hasMoreBelow = startIndex + visibleCommands.length < commands.length
 
+	const getTypeLabel = (section?: string) => {
+		switch (section) {
+			case "custom":
+				return "[Workflow]"
+			case "skill":
+				return "[Skill]"
+			case "mcp":
+				return "[MCP]"
+			default:
+				return ""
+		}
+	}
+
 	return (
 		<Box flexDirection="column" marginBottom={1} paddingLeft={1} paddingRight={1}>
 			{visibleCommands.map((cmd, idx) => {
 				const isSelected = startIndex + idx === selectedIndex
-				// Only show description for default commands (not workflows)
-				const showDescription = cmd.section === "default" || !cmd.section
-				const commandPrefix = `${isSelected ? "❯" : " "} /${cmd.name}`
+				const showDescription =
+					cmd.section === "default" || cmd.section === "mcp" || cmd.section === "skill" || !cmd.section
+				const typeLabel = getTypeLabel(cmd.section)
+				const commandPrefix = `${isSelected ? "❯" : " "} /${cmd.name}${typeLabel ? ` ${typeLabel}` : ""}`
 				const truncatedCommand = truncateText(commandPrefix, contentWidth)
 				const descriptionText = showDescription && cmd.description ? ` - ${cmd.description}` : ""
 				const fullLine = truncateText(truncatedCommand + descriptionText, contentWidth)

--- a/cli/src/utils/slash-commands.test.ts
+++ b/cli/src/utils/slash-commands.test.ts
@@ -1,0 +1,34 @@
+import type { SlashCommandInfo } from "@shared/proto/cline/slash"
+import { describe, expect, it } from "vitest"
+import { extractSlashQuery, sortCommandsWorkflowsFirst } from "./slash-commands"
+
+describe("slash-commands utils", () => {
+	describe("sortCommandsWorkflowsFirst", () => {
+		it("sorts sections by priority: skill, custom, default, mcp", () => {
+			const commands: SlashCommandInfo[] = [
+				{ name: "zz-default", section: "default", description: "", cliCompatible: true },
+				{ name: "aa-mcp", section: "mcp", description: "", cliCompatible: true },
+				{ name: "bb-workflow", section: "custom", description: "", cliCompatible: true },
+				{ name: "cc-skill", section: "skill", description: "", cliCompatible: true },
+			]
+
+			const sorted = sortCommandsWorkflowsFirst(commands)
+			expect(sorted.map((c) => c.name)).toEqual(["cc-skill", "bb-workflow", "zz-default", "aa-mcp"])
+		})
+	})
+
+	describe("extractSlashQuery", () => {
+		it("supports colon-delimited commands while typing", () => {
+			const result = extractSlashQuery("please run /mcp:github:issue_to_fix_workflow")
+			expect(result.inSlashMode).toBe(true)
+			expect(result.query).toBe("mcp:github:issue_to_fix_workflow")
+		})
+
+		it("does not enter slash mode for a second command after a completed colon command", () => {
+			const text = "/mcp:github:prompt /skill-candidate"
+			const result = extractSlashQuery(text, text.length)
+			expect(result.inSlashMode).toBe(false)
+			expect(result.query).toBe("")
+		})
+	})
+})

--- a/docs/cline-cli/interactive-mode.mdx
+++ b/docs/cline-cli/interactive-mode.mdx
@@ -85,7 +85,7 @@ Compare @src/old-api.ts with @src/new-api.ts and list the breaking changes
 
 ## Slash Commands
 
-Type `/` to see available commands. Slash commands provide quick access to settings, history, and workflows.
+Type `/` to see available commands. Slash commands provide quick access to settings, history, skills, and workflows.
 
 ### Built-in Commands
 
@@ -105,6 +105,18 @@ If you have [workflows](/features/slash-commands/workflows/index) configured, th
 ```
 /code-review
 ```
+
+Legacy filename-style workflow commands like `/code-review.md` are also supported for compatibility.
+
+### Skill Commands
+
+If you have [skills](/features/skills) enabled and discovered, they also appear as slash commands.
+
+```
+/my-skill
+```
+
+If a skill and workflow share the same command name, the skill command wins for `/name`.
 
 ## Settings Panel
 

--- a/docs/cline-cli/overview.mdx
+++ b/docs/cline-cli/overview.mdx
@@ -32,7 +32,7 @@ Key features:
 - **Real-time conversation** - Type messages, see Cline's responses, and iterate on tasks
 - **Visual feedback** - Animated welcome screen, syntax-highlighted code, and progress indicators
 - **File mentions** with `@` - Reference workspace files with fuzzy search autocomplete
-- **Slash commands** with `/` - Quick access to `/settings`, `/history`, `/models`, and workflows
+- **Slash commands** with `/` - Quick access to `/settings`, `/history`, `/models`, skills, and workflows
 - **Keyboard shortcuts** - `Tab` to toggle Plan/Act, `Shift+Tab` for auto-approve all
 - **Session summaries** - See tasks completed, files modified, and token usage on exit
 - **Settings panel** - Configure providers, models, and features without leaving the CLI

--- a/docs/features/skills.mdx
+++ b/docs/features/skills.mdx
@@ -98,6 +98,20 @@ description: Deploy applications to AWS using CDK. Use when deploying, updating 
 
 Asking "deploy this to AWS" would trigger Cline to activate the skill, load its detailed instructions, and follow them to complete your request.
 
+## Calling Skills with Slash Commands
+
+Enabled skills are also available as slash commands.
+
+- Type `/` in chat and pick a skill from the **Skill Commands** section
+- Use `/skill-name` directly (for example, `/aws-deploy`)
+- Skill commands use the skill's `name` from `SKILL.md`
+
+When a skill name collides with a workflow name, the skill command wins for `/name`.
+
+<Note>
+  Workflows are still supported, but we recommend creating new automation as skills. Workflow support is planned for future deprecation.
+</Note>
+
 ## Example: Data Analysis Skill
 
 Here's a practical skill for data analysis tasks. Create a directory called `data-analysis/` with this `SKILL.md`:
@@ -208,12 +222,12 @@ The best skills encode institutional knowledge that would otherwise live only in
 | Feature | Purpose | When Active |
 |---------|---------|-------------|
 | **Rules** | Define how Cline should behave | Always (or contextually) |
-| **Workflows** | Step-by-step task automation | Invoked with `/workflow.md` |
+| **Workflows** | Step-by-step task automation | Invoked with `/workflow` (legacy `/workflow.md` also works) |
 | **Skills** | Domain expertise loaded on-demand | Triggered by matching requests |
 
 **Rules** set constraints and preferences (like "always use TypeScript" or "follow this style guide").
 
-**Workflows** are explicit sequences you invoke for specific tasks (like `/release.md` for a release process).
+**Workflows** are explicit sequences you invoke for specific tasks (like `/release` for a release process).
 
 **Skills** are expertise that Cline activates automatically when relevant (like data analysis knowledge when you're working with CSV files).
 
@@ -224,4 +238,3 @@ Use rules for ongoing constraints, workflows for explicit automation, and skills
 - [Cline Rules](/features/cline-rules) for always-active project guidance
 - [Workflows](/features/slash-commands/workflows/index) for explicit task automation
 - [Hooks](/features/hooks/index) for injecting custom logic at key moments
-

--- a/docs/features/slash-commands/workflows/best-practices.mdx
+++ b/docs/features/slash-commands/workflows/best-practices.mdx
@@ -16,7 +16,7 @@ Creating a workflow is simpler than you might think. There's actually a workflow
 
 First, **save the [create-new-workflow.md](https://github.com/cline/prompts/blob/main/workflows/create-new-workflow.md) file to your workspace** (e.g., in `.clinerules/workflows/`).
 
-Then, type `/create-new-workflow.md` and Cline guides you through it:
+Then, type `/create-new-workflow` and Cline guides you through it:
 
 1.  It asks for the purpose and a concise name.
 2.  You describe the objective and expected outputs.

--- a/docs/features/slash-commands/workflows/index.mdx
+++ b/docs/features/slash-commands/workflows/index.mdx
@@ -6,7 +6,15 @@ description: "Learn what Cline workflows are, why they are useful, and how to st
 
 Workflows in Cline are Markdown files that define a series of steps to guide Cline through repetitive or complex tasks. They are a powerful way to automate your development processes directly within your editor.
 
-To invoke a workflow, you simply type `/` followed by the workflow's filename in the chat (e.g., `/deploy.md`).
+To invoke a workflow, type `/` followed by the workflow name in chat (for example, `/deploy`).
+
+<Note>
+  Legacy filename-style commands like `/deploy.md` are still supported for compatibility.
+</Note>
+
+<Warning>
+  Workflows remain supported today, but new automation should prefer [skills](/features/skills). Workflow support is planned for future deprecation.
+</Warning>
 
 ## Why Use Cline Workflows?
 
@@ -51,10 +59,18 @@ This is tedious and easy to mess up. You might forget to run the tests or format
 **With a Cline workflow**, you define these steps once in a `release.md` file. Then, you just type:
 
 ```bash
-/release.md
+/release
 ```
 
 Cline will then meticulously follow your instructions: updating files, running tests, and executing git commands—pausing only if it encounters an error or needs your input.
+
+## Skills and Name Collisions
+
+Skills and workflows both appear as slash commands.
+
+- If a skill and workflow share the same command name, the skill wins for `/name`.
+- For file-backed workflows, `/name.md` remains a compatibility alias you can invoke explicitly.
+- To avoid ambiguity, prefer unique names between skills and workflows.
 
 ## Where are Workflows Stored?
 

--- a/docs/features/slash-commands/workflows/quickstart.mdx
+++ b/docs/features/slash-commands/workflows/quickstart.mdx
@@ -83,7 +83,8 @@ This workflow will automate the process of fetching PR details, analyzing the co
     ````
 
     <Note>
-      When you run this workflow, you will replace `PR_NUMBER` with the actual number of the pull request you want to review (e.g., `/pr-review.md 123`).
+      When you run this workflow, you will replace `PR_NUMBER` with the actual number of the pull request you want to review (e.g., `/pr-review 123`).
+      Legacy `/pr-review.md` still works.
     </Note>
   </Step>
 
@@ -91,7 +92,7 @@ This workflow will automate the process of fetching PR details, analyzing the co
     Now you're ready to run your new workflow.
 
     1.  Open the Cline chat panel.
-    2.  Type `/pr-review.md` followed by the PR number (e.g., `/pr-review.md 42`) and press Enter.
+    2.  Type `/pr-review` followed by the PR number (e.g., `/pr-review 42`) and press Enter.
     3.  Cline will fetch the PR details, analyze the code, and present you with its findings before submitting the review.
 
     <Tip>

--- a/src/core/controller/slash/getAvailableSlashCommands.ts
+++ b/src/core/controller/slash/getAvailableSlashCommands.ts
@@ -1,5 +1,7 @@
+import { discoverSkills, getAvailableSkills } from "@core/context/instructions/user-instructions/skills"
 import { EmptyRequest } from "@shared/proto/cline/common"
 import { SlashCommandInfo, SlashCommandsResponse } from "@shared/proto/cline/slash"
+import { toWorkflowCommandName } from "@shared/slash-command-names"
 import { BASE_SLASH_COMMANDS } from "@/shared/slashCommands"
 import { Controller } from ".."
 
@@ -27,19 +29,52 @@ export async function getAvailableSlashCommands(controller: Controller, _request
 	const remoteWorkflowToggles = controller.stateManager.getGlobalStateKey("remoteWorkflowToggles") ?? {}
 	const remoteConfigSettings = controller.stateManager.getRemoteConfigSettings()
 	const remoteWorkflows = remoteConfigSettings?.remoteGlobalWorkflows ?? []
+	const globalSkillsToggles = controller.stateManager.getGlobalSettingsKey("globalSkillsToggles") ?? {}
+	const localSkillsToggles = controller.stateManager.getWorkspaceStateKey("localSkillsToggles") ?? {}
 
-	// Track local workflow names to avoid duplicates from global
-	const localNames = new Set<string>()
+	// Add enabled skills first so skills can win workflow name collisions.
+	const skillNames = new Set<string>()
+	try {
+		const cwd = controller.getWorkspaceManager?.()?.getPrimaryRoot?.()?.path ?? process.cwd()
+		const resolvedSkills = getAvailableSkills(await discoverSkills(cwd))
+		for (const skill of resolvedSkills) {
+			const toggles = skill.source === "global" ? globalSkillsToggles : localSkillsToggles
+			if (toggles[skill.path] === false) {
+				continue
+			}
+
+			if (!skillNames.has(skill.name)) {
+				skillNames.add(skill.name)
+
+				commands.push(
+					SlashCommandInfo.create({
+						name: skill.name,
+						description: skill.description,
+						section: "skill",
+						cliCompatible: true,
+					}),
+				)
+			}
+		}
+	} catch {
+		// Skills are additive for slash autocomplete. If discovery fails, continue.
+	}
+
+	// Track workflow names to avoid duplicates from global/remote
+	const workflowNames = new Set<string>()
 
 	// Add local workflows (enabled only)
 	for (const [path, enabled] of Object.entries(localWorkflowToggles)) {
 		if (enabled) {
-			const fileName = fullPathToFileName(path)
-			localNames.add(fileName)
+			const fileName = toWorkflowCommandName(path)
+			if (skillNames.has(fileName) || workflowNames.has(fileName)) {
+				continue
+			}
+			workflowNames.add(fileName)
 			commands.push(
 				SlashCommandInfo.create({
 					name: fileName,
-					description: `Custom workflow: ${fileName}`,
+					description: "Workflow command",
 					section: "custom",
 					cliCompatible: true,
 				}),
@@ -50,17 +85,19 @@ export async function getAvailableSlashCommands(controller: Controller, _request
 	// Add global workflows (enabled only, skip if local exists with same name)
 	for (const [path, enabled] of Object.entries(globalWorkflowToggles)) {
 		if (enabled) {
-			const fileName = fullPathToFileName(path)
-			if (!localNames.has(fileName)) {
-				commands.push(
-					SlashCommandInfo.create({
-						name: fileName,
-						description: `Custom workflow: ${fileName}`,
-						section: "custom",
-						cliCompatible: true,
-					}),
-				)
+			const fileName = toWorkflowCommandName(path)
+			if (skillNames.has(fileName) || workflowNames.has(fileName)) {
+				continue
 			}
+			workflowNames.add(fileName)
+			commands.push(
+				SlashCommandInfo.create({
+					name: fileName,
+					description: "Workflow command",
+					section: "custom",
+					cliCompatible: true,
+				}),
+			)
 		}
 	}
 
@@ -68,10 +105,15 @@ export async function getAvailableSlashCommands(controller: Controller, _request
 	for (const workflow of remoteWorkflows) {
 		const enabled = workflow.alwaysEnabled || remoteWorkflowToggles[workflow.name] !== false
 		if (enabled) {
+			const workflowName = toWorkflowCommandName(workflow.name)
+			if (skillNames.has(workflowName) || workflowNames.has(workflowName)) {
+				continue
+			}
+			workflowNames.add(workflowName)
 			commands.push(
 				SlashCommandInfo.create({
-					name: workflow.name,
-					description: `Remote workflow: ${workflow.name}`,
+					name: workflowName,
+					description: "Workflow command",
 					section: "custom",
 					cliCompatible: true,
 				}),
@@ -80,9 +122,4 @@ export async function getAvailableSlashCommands(controller: Controller, _request
 	}
 
 	return SlashCommandsResponse.create({ commands })
-}
-
-function fullPathToFileName(path: string): string {
-	// e.g. replace /path/to/workflow.md with workflow.md
-	return path.replace(/^.*[/\\]/, "")
 }

--- a/src/core/task/index.ts
+++ b/src/core/task/index.ts
@@ -3086,6 +3086,25 @@ export class Task {
 		const providerInfo = this.getCurrentProviderInfo()
 		const cwd = this.cwd
 		const { localWorkflowToggles, globalWorkflowToggles } = await refreshWorkflowToggles(this.controller, cwd)
+		let cachedAvailableSkills: Awaited<ReturnType<typeof discoverSkills>> | undefined
+
+		const getEnabledSkills = async () => {
+			if (cachedAvailableSkills) {
+				return cachedAvailableSkills
+			}
+
+			const discoveredSkills = await discoverSkills(cwd)
+			const resolvedSkills = getAvailableSkills(discoveredSkills)
+			const globalSkillsToggles = this.stateManager.getGlobalSettingsKey("globalSkillsToggles") ?? {}
+			const localSkillsToggles = this.stateManager.getWorkspaceStateKey("localSkillsToggles") ?? {}
+
+			cachedAvailableSkills = resolvedSkills.filter((skill) => {
+				const toggles = skill.source === "global" ? globalSkillsToggles : localSkillsToggles
+				return toggles[skill.path] !== false
+			})
+
+			return cachedAvailableSkills
+		}
 
 		const hasUserContentTag = (text: string): boolean => {
 			return USER_CONTENT_TAGS.some((tag) => text.includes(tag))
@@ -3118,6 +3137,7 @@ export class Task {
 				useNativeToolCalls,
 				providerInfo,
 				mcpPromptFetcher,
+				await getEnabledSkills(),
 			)
 
 			if (needsCheck) {

--- a/src/services/telemetry/TelemetryService.ts
+++ b/src/services/telemetry/TelemetryService.ts
@@ -1565,9 +1565,13 @@ export class TelemetryService {
 	 * Records when slash commands or workflows are activated
 	 * @param ulid Unique identifier for the task
 	 * @param commandName The name of the command (e.g., "newtask", "reportbug", or custom workflow name)
-	 * @param commandType Whether it's a built-in command, custom workflow, or MCP prompt
+	 * @param commandType Whether it's a built-in command, custom workflow, MCP prompt, or skill
 	 */
-	public captureSlashCommandUsed(ulid: string, commandName: string, commandType: "builtin" | "workflow" | "mcp_prompt") {
+	public captureSlashCommandUsed(
+		ulid: string,
+		commandName: string,
+		commandType: "builtin" | "workflow" | "mcp_prompt" | "skill",
+	) {
 		this.capture({
 			event: TelemetryService.EVENTS.TASK.SLASH_COMMAND_USED,
 			properties: {

--- a/src/shared/slash-command-names.ts
+++ b/src/shared/slash-command-names.ts
@@ -1,0 +1,19 @@
+const WORKFLOW_EXTENSION_REGEX = /\.(md|txt)$/i
+
+/**
+ * Converts a workflow filename/path into a clean slash command name.
+ * Example: "pr-review.md" -> "pr-review"
+ */
+export function toWorkflowCommandName(input: string): string {
+	const fileName = input.replace(/^.*[/\\]/, "")
+	return fileName.replace(WORKFLOW_EXTENSION_REGEX, "")
+}
+
+/**
+ * Returns all accepted command aliases for a workflow.
+ * First alias is the normalized display command name.
+ */
+export function getWorkflowCommandAliases(fileName: string): string[] {
+	const normalized = toWorkflowCommandName(fileName)
+	return normalized === fileName ? [fileName] : [normalized, fileName]
+}

--- a/src/shared/slashCommands.ts
+++ b/src/shared/slashCommands.ts
@@ -1,7 +1,7 @@
 export interface SlashCommand {
 	name: string
 	description?: string
-	section?: "default" | "custom" | "mcp"
+	section?: "default" | "custom" | "mcp" | "skill"
 	cliCompatible?: boolean
 }
 

--- a/src/test/slash-command-names.test.ts
+++ b/src/test/slash-command-names.test.ts
@@ -1,0 +1,33 @@
+import { describe, it } from "mocha"
+import "should"
+import { getWorkflowCommandAliases, toWorkflowCommandName } from "../shared/slash-command-names"
+
+describe("slash-command-names", () => {
+	describe("toWorkflowCommandName", () => {
+		it("removes .md extension", () => {
+			toWorkflowCommandName("my-workflow.md").should.equal("my-workflow")
+		})
+
+		it("removes .txt extension", () => {
+			toWorkflowCommandName("my-workflow.txt").should.equal("my-workflow")
+		})
+
+		it("keeps names without extension", () => {
+			toWorkflowCommandName("my-workflow").should.equal("my-workflow")
+		})
+
+		it("extracts file name from full path", () => {
+			toWorkflowCommandName("/tmp/.clinerules/workflows/my-workflow.md").should.equal("my-workflow")
+		})
+	})
+
+	describe("getWorkflowCommandAliases", () => {
+		it("returns normalized name and original file name when extension exists", () => {
+			getWorkflowCommandAliases("my-workflow.md").should.deepEqual(["my-workflow", "my-workflow.md"])
+		})
+
+		it("returns single alias when already normalized", () => {
+			getWorkflowCommandAliases("my-workflow").should.deepEqual(["my-workflow"])
+		})
+	})
+})

--- a/src/test/slash-commands.test.ts
+++ b/src/test/slash-commands.test.ts
@@ -365,7 +365,7 @@ describe("getAvailableSlashCommands", () => {
 			const response = await getAvailableSlashCommands(mockController as Controller, EmptyRequest.create())
 			const skill = response.commands.find((cmd) => cmd.name === "summarize-pr" && cmd.section === "skill")
 
-			skill?.description.should.equal("Summarize pull request")
+			skill?.description.should.equal("Summarize a pull request")
 		})
 
 		it("should keep skill description unchanged when it overrides a remote workflow", async () => {
@@ -379,7 +379,7 @@ describe("getAvailableSlashCommands", () => {
 			const response = await getAvailableSlashCommands(mockController as Controller, EmptyRequest.create())
 			const skill = response.commands.find((cmd) => cmd.name === "summarize-pr" && cmd.section === "skill")
 
-			skill?.description.should.equal("Summarize pull request")
+			skill?.description.should.equal("Summarize a pull request")
 		})
 	})
 })

--- a/src/test/slash-commands.test.ts
+++ b/src/test/slash-commands.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, it } from "mocha"
 import "should"
+import * as skillsUtils from "@core/context/instructions/user-instructions/skills"
 import * as sinon from "sinon"
 import { Controller } from "../core/controller"
 import { getAvailableSlashCommands } from "../core/controller/slash/getAvailableSlashCommands"
@@ -36,6 +37,9 @@ describe("getAvailableSlashCommands", () => {
 		mockController = {
 			stateManager: mockStateManager as any,
 		}
+
+		sinon.stub(skillsUtils, "discoverSkills").resolves([])
+		sinon.stub(skillsUtils, "getAvailableSkills").returns([])
 	})
 
 	afterEach(() => {
@@ -86,12 +90,12 @@ describe("getAvailableSlashCommands", () => {
 
 			const response = await getAvailableSlashCommands(mockController as Controller, EmptyRequest.create())
 
-			const myWorkflow = response.commands.find((cmd) => cmd.name === "my-workflow.md")
+			const myWorkflow = response.commands.find((cmd) => cmd.name === "my-workflow")
 			myWorkflow!.should.not.be.undefined()
 			myWorkflow!.section.should.equal("custom")
 			myWorkflow!.cliCompatible.should.equal(true)
 
-			const anotherWorkflow = response.commands.find((cmd) => cmd.name === "another-workflow.md")
+			const anotherWorkflow = response.commands.find((cmd) => cmd.name === "another-workflow")
 			anotherWorkflow!.should.not.be.undefined()
 		})
 
@@ -103,10 +107,10 @@ describe("getAvailableSlashCommands", () => {
 
 			const response = await getAvailableSlashCommands(mockController as Controller, EmptyRequest.create())
 
-			const enabled = response.commands.find((cmd) => cmd.name === "enabled-workflow.md")
+			const enabled = response.commands.find((cmd) => cmd.name === "enabled-workflow")
 			enabled!.should.not.be.undefined()
 
-			const disabled = response.commands.find((cmd) => cmd.name === "disabled-workflow.md")
+			const disabled = response.commands.find((cmd) => cmd.name === "disabled-workflow")
 			;(disabled === undefined).should.be.true()
 		})
 
@@ -117,7 +121,7 @@ describe("getAvailableSlashCommands", () => {
 
 			const response = await getAvailableSlashCommands(mockController as Controller, EmptyRequest.create())
 
-			const workflow = response.commands.find((cmd) => cmd.name === "deep-analysis.md")
+			const workflow = response.commands.find((cmd) => cmd.name === "deep-analysis")
 			workflow!.should.not.be.undefined()
 		})
 
@@ -128,7 +132,7 @@ describe("getAvailableSlashCommands", () => {
 
 			const response = await getAvailableSlashCommands(mockController as Controller, EmptyRequest.create())
 
-			const workflow = response.commands.find((cmd) => cmd.name === "windows-workflow.md")
+			const workflow = response.commands.find((cmd) => cmd.name === "windows-workflow")
 			workflow!.should.not.be.undefined()
 		})
 	})
@@ -141,7 +145,7 @@ describe("getAvailableSlashCommands", () => {
 
 			const response = await getAvailableSlashCommands(mockController as Controller, EmptyRequest.create())
 
-			const workflow = response.commands.find((cmd) => cmd.name === "global-workflow.md")
+			const workflow = response.commands.find((cmd) => cmd.name === "global-workflow")
 			workflow!.should.not.be.undefined()
 			workflow!.section.should.equal("custom")
 		})
@@ -153,7 +157,7 @@ describe("getAvailableSlashCommands", () => {
 
 			const response = await getAvailableSlashCommands(mockController as Controller, EmptyRequest.create())
 
-			const workflow = response.commands.find((cmd) => cmd.name === "disabled-global.md")
+			const workflow = response.commands.find((cmd) => cmd.name === "disabled-global")
 			;(workflow === undefined).should.be.true()
 		})
 	})
@@ -171,7 +175,7 @@ describe("getAvailableSlashCommands", () => {
 			const response = await getAvailableSlashCommands(mockController as Controller, EmptyRequest.create())
 
 			// Should only appear once
-			const matches = response.commands.filter((cmd) => cmd.name === "shared-workflow.md")
+			const matches = response.commands.filter((cmd) => cmd.name === "shared-workflow")
 			matches.length.should.equal(1)
 		})
 
@@ -186,7 +190,7 @@ describe("getAvailableSlashCommands", () => {
 			const response = await getAvailableSlashCommands(mockController as Controller, EmptyRequest.create())
 
 			// Global should appear since local is disabled
-			const workflow = response.commands.find((cmd) => cmd.name === "shared-workflow.md")
+			const workflow = response.commands.find((cmd) => cmd.name === "shared-workflow")
 			workflow!.should.not.be.undefined()
 		})
 	})
@@ -280,6 +284,102 @@ describe("getAvailableSlashCommands", () => {
 
 			// Should not throw, just return base commands
 			response.commands.length.should.be.greaterThanOrEqual(BASE_SLASH_COMMANDS.length)
+		})
+	})
+
+	describe("Skills", () => {
+		beforeEach(() => {
+			;(skillsUtils.discoverSkills as sinon.SinonStub).resolves([
+				{
+					name: "summarize-pr",
+					description: "Summarize a pull request",
+					path: "/Users/test/.cline/skills/summarize-pr/SKILL.md",
+					source: "global",
+				},
+				{
+					name: "project-planner",
+					description: "Plan a project",
+					path: "/workspace/.clinerules/skills/project-planner/SKILL.md",
+					source: "project",
+				},
+			])
+			;(skillsUtils.getAvailableSkills as sinon.SinonStub).callsFake((skills) => skills)
+		})
+
+		it("should include enabled skills as slash commands", async () => {
+			mockStateManager.getGlobalSettingsKey.withArgs("globalSkillsToggles").returns({
+				"/Users/test/.cline/skills/summarize-pr/SKILL.md": true,
+			})
+			mockStateManager.getWorkspaceStateKey.withArgs("localSkillsToggles").returns({
+				"/workspace/.clinerules/skills/project-planner/SKILL.md": true,
+			})
+
+			const response = await getAvailableSlashCommands(mockController as Controller, EmptyRequest.create())
+
+			const globalSkill = response.commands.find((cmd) => cmd.name === "summarize-pr")
+			globalSkill!.should.not.be.undefined()
+			globalSkill!.section.should.equal("skill")
+
+			const localSkill = response.commands.find((cmd) => cmd.name === "project-planner")
+			localSkill!.should.not.be.undefined()
+			localSkill!.section.should.equal("skill")
+		})
+
+		it("should prefer skill when skill and workflow names collide", async () => {
+			mockStateManager.getWorkspaceStateKey.withArgs("workflowToggles").returns({
+				"/path/to/summarize-pr.md": true,
+			})
+			mockStateManager.getGlobalSettingsKey.withArgs("globalSkillsToggles").returns({
+				"/Users/test/.cline/skills/summarize-pr/SKILL.md": true,
+			})
+
+			const response = await getAvailableSlashCommands(mockController as Controller, EmptyRequest.create())
+			const skillMatches = response.commands.filter((cmd) => cmd.name === "summarize-pr" && cmd.section === "skill")
+			const workflowMatches = response.commands.filter((cmd) => cmd.name === "summarize-pr" && cmd.section === "custom")
+
+			skillMatches.length.should.equal(1)
+			workflowMatches.length.should.equal(0)
+		})
+
+		it("should exclude disabled skills", async () => {
+			mockStateManager.getGlobalSettingsKey.withArgs("globalSkillsToggles").returns({
+				"/Users/test/.cline/skills/summarize-pr/SKILL.md": false,
+			})
+			mockStateManager.getWorkspaceStateKey.withArgs("localSkillsToggles").returns({
+				"/workspace/.clinerules/skills/project-planner/SKILL.md": false,
+			})
+
+			const response = await getAvailableSlashCommands(mockController as Controller, EmptyRequest.create())
+			const skillCommands = response.commands.filter((cmd) => cmd.section === "skill")
+			skillCommands.length.should.equal(0)
+		})
+
+		it("should keep skill description unchanged when it overrides a workflow", async () => {
+			mockStateManager.getWorkspaceStateKey.withArgs("workflowToggles").returns({
+				"/path/to/summarize-pr.md": true,
+			})
+			mockStateManager.getGlobalSettingsKey.withArgs("globalSkillsToggles").returns({
+				"/Users/test/.cline/skills/summarize-pr/SKILL.md": true,
+			})
+
+			const response = await getAvailableSlashCommands(mockController as Controller, EmptyRequest.create())
+			const skill = response.commands.find((cmd) => cmd.name === "summarize-pr" && cmd.section === "skill")
+
+			skill?.description.should.equal("Summarize pull request")
+		})
+
+		it("should keep skill description unchanged when it overrides a remote workflow", async () => {
+			mockStateManager.getRemoteConfigSettings.returns({
+				remoteGlobalWorkflows: [{ name: "summarize-pr", alwaysEnabled: true }],
+			})
+			mockStateManager.getGlobalSettingsKey.withArgs("globalSkillsToggles").returns({
+				"/Users/test/.cline/skills/summarize-pr/SKILL.md": true,
+			})
+
+			const response = await getAvailableSlashCommands(mockController as Controller, EmptyRequest.create())
+			const skill = response.commands.find((cmd) => cmd.name === "summarize-pr" && cmd.section === "skill")
+
+			skill?.description.should.equal("Summarize pull request")
 		})
 	})
 })


### PR DESCRIPTION
### Related Issue


- https://github.com/cline/cline/pull/8335
- https://github.com/cline/cline/pull/8395
- https://github.com/cline/cline/pull/8396
- https://github.com/cline/cline/pull/8397
- https://github.com/cline/cline/pull/8548
- https://github.com/cline/cline/pull/8955

### Description

This PR adds direct skill invocation via slash commands (`/skill-name`) while preserving existing workflow behavior during the transition period.

Primary product/architecture decisions:

- Skills and workflows both remain supported for now.
- Skill commands win on name collisions (`/name` resolves to the skill when both exist).
- Workflow compatibility is preserved (normalized `/workflow` plus legacy `/workflow.md` alias support).
- We intentionally did **not** unify CLI and webview internals in this PR; each surface keeps its current architecture and is updated consistently.
- Workflow deprecation direction is documented explicitly, but not enforced yet.

Implementation details:

- Core slash parsing and execution:
  - Added skill-first resolution in slash parsing so explicit `/skill-name` loads skill instructions before workflow matching.
  - Kept workflow alias matching so extensionless and legacy filename forms continue to work.
- Slash command discovery (core RPC used by CLI):
  - Exposes enabled skills as slash commands.
  - Filters workflows on collisions so skill command is the surfaced `/name`.
- Webview:
  - Added skill commands to slash menu data pipeline.
  - Added section/type labeling and collision-safe filtering behavior.
  - Removed `.md` display suffix for workflows.
- CLI:
  - Updated slash menu sorting/labels for skill/workflow/MCP sections.
  - Added targeted CLI tests around slash menu ordering and parsing behavior.
- Shared naming utility:
  - Introduced shared workflow command-name normalization helpers used by both discovery and parser paths.
- Telemetry:
  - Slash-invoked skills are tracked through existing `task.slash_command_used` with `commandType="skill"` and `commandName=<skill-name>`.

Docs updates included in a separate commit in this branch:

- Skills page now documents direct slash invocation and collision behavior.
- Workflow slash docs now prefer extensionless commands and document legacy `.md` compatibility.
- CLI docs updated to reflect skill slash commands and precedence.
- Workflow docs explicitly call out planned workflow deprecation direction.


### Test Procedure

Targeted verification performed for this PR:

- Type-check:
  - `npm run check-types`
- Skill toggle behavior (skills disabled should not appear):
  - `TS_NODE_PROJECT=./tsconfig.unit-test.json npx mocha -r ts-node/register -r source-map-support/register -r ./src/test/requires.ts src/test/slash-commands.test.ts --grep "should exclude disabled skills"`
- CLI validation:
  - `cd cli && npm run test:run -- src/utils/slash-commands.test.ts`
- Additional targeted core slash precedence checks (skill over workflow):
  - `npm run test:unit -- --grep "parseSlashCommands skill handling|prefer skill over workflow on name collision"`
- In-session extension validation:
  - Verified skill/workflow collision behavior in slash menu with test command names and confirmed skill precedence.

Risk/compatibility checks covered:

- Legacy workflow slash invocations (`/name.md`) remain supported.
- Normalized workflow commands (`/name`) work without `.md` suffix.
- Skills can be toggled off without surfacing as slash commands.
- CLI and webview each render command sections/type labels correctly under current architecture.

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [x] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<img width="682" height="305" alt="Screenshot 2026-02-12 at 4 36 12 PM" src="https://github.com/user-attachments/assets/52344fb7-c959-4875-a899-0b0660d12d10" />
<img width="535" height="324" alt="Screenshot 2026-02-12 at 5 37 57 PM" src="https://github.com/user-attachments/assets/bde79761-fd2a-44e9-be79-909dcac8a52b" />


### Additional Notes

This PR intentionally keeps workflows and skills side-by-side for migration safety.

The implementation and docs are explicit that workflows are expected to be deprecated in a future phase, with this PR establishing the compatibility bridge (`/name` + legacy `/name.md`) and skill-first command routing needed for that transition.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> This PR enables direct skill invocation via slash commands with skill-first precedence, updating parsing, command discovery, UI components, and documentation accordingly.
> 
>   - **Behavior**:
>     - Adds skill-first resolution for slash commands, prioritizing `/skill-name` over workflows in `parseSlashCommands()`.
>     - Maintains workflow alias support for legacy and extensionless forms.
>   - **Command Discovery**:
>     - Exposes enabled skills as slash commands in `getAvailableSlashCommands()`.
>     - Filters workflows on name collisions, prioritizing skills.
>   - **UI Components**:
>     - Updates `SlashCommandMenu` and `ChatTextArea` to include skill commands and handle collisions.
>     - Adds type labeling and collision-safe filtering in `SlashCommandMenu`.
>   - **Utilities**:
>     - Introduces `toWorkflowCommandName()` and `getWorkflowCommandAliases()` for command normalization.
>   - **Telemetry**:
>     - Tracks skill invocation via `captureSlashCommandUsed()` with `commandType="skill"`.
>   - **Tests**:
>     - Adds tests for skill precedence and command parsing in `slash-commands.test.ts` and `slash-command-names.test.ts`.
>   - **Documentation**:
>     - Updates CLI and skills documentation to reflect new slash command behavior and precedence.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 60bb1a439d872505f642da7c42ee6a541be5ec21. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->