### PR TITLE
feat(subagents): tune research prompt output and command guidance

### DIFF
--- a/docs/features/subagents.mdx
+++ b/docs/features/subagents.mdx
@@ -18,7 +18,7 @@ When Cline uses the `use_subagents` tool, it launches independent agents simulta
 - Runs with a separate context window and token budget
 - Can read files, search code, list directories, run read-only commands, and use skills
 - Cannot edit files, use the browser, access MCP servers, or spawn nested subagents
-- Returns a result that includes file paths, line numbers, and recommended files for the main agent to read next
+- Returns a result focused on the most relevant file paths for the main agent to read next
 
 Subagent costs (tokens and API spend) are tracked separately per subagent and rolled into the task's total cost. You can see per-subagent stats (tool calls, tokens, cost) in the chat UI as they run.
 
@@ -43,6 +43,7 @@ Example prompts:
 - "I'm new to this codebase. Use subagents to map out the main entry points, the routing layer, and the data access patterns"
 
 Each subagent prompt should describe a focused research question. Cline will run them in parallel and synthesize the results.
+You can also run only one subagent when the task is small enough that parallel discovery would be unnecessary overhead.
 
 ## Auto-Approve Behavior
 
@@ -69,6 +70,7 @@ Subagents cannot write files, apply patches, use the browser, access MCP servers
 
 <Note>
   Commands run by subagents execute in the background and are restricted to read-only operations. Subagents will not run commands that modify files or system state.
+  Subagents also benefit from command pipelines and filters to narrow output quickly before reading files, for example `rg ... | sort | uniq`.
 </Note>
 
 ## When to Use Subagents

--- a/src/core/prompts/system-prompt/__tests__/__snapshots__/anthropic_claude_sonnet_4-basic.snap
+++ b/src/core/prompts/system-prompt/__tests__/__snapshots__/anthropic_claude_sonnet_4-basic.snap
@@ -267,7 +267,7 @@ Usage:
 </generate_explanation>
 
 ## use_subagents
-Description: Run up to five focused in-process subagents in parallel. Each subagent gets its own prompt and returns a comprehensive research result with tool and token stats. Use this for broad exploration when reading many files would consume the main agent's context window.
+Description: Run up to five focused in-process subagents in parallel. Each subagent gets its own prompt and returns a comprehensive research result with tool and token stats. Use this for broad exploration when reading many files would consume the main agent's context window. You do not need to launch multiple subagents every time; using one subagent is valid when it avoids unnecessary context usage for light discovery work.
 Parameters:
 - prompt_1: (required) First subagent prompt.
 - prompt_2: (optional) Optional second subagent prompt.

--- a/src/core/prompts/system-prompt/__tests__/__snapshots__/anthropic_claude_sonnet_4-no-browser.snap
+++ b/src/core/prompts/system-prompt/__tests__/__snapshots__/anthropic_claude_sonnet_4-no-browser.snap
@@ -233,7 +233,7 @@ Usage:
 </generate_explanation>
 
 ## use_subagents
-Description: Run up to five focused in-process subagents in parallel. Each subagent gets its own prompt and returns a comprehensive research result with tool and token stats. Use this for broad exploration when reading many files would consume the main agent's context window.
+Description: Run up to five focused in-process subagents in parallel. Each subagent gets its own prompt and returns a comprehensive research result with tool and token stats. Use this for broad exploration when reading many files would consume the main agent's context window. You do not need to launch multiple subagents every time; using one subagent is valid when it avoids unnecessary context usage for light discovery work.
 Parameters:
 - prompt_1: (required) First subagent prompt.
 - prompt_2: (optional) Optional second subagent prompt.

--- a/src/core/prompts/system-prompt/__tests__/__snapshots__/anthropic_claude_sonnet_4-no-focus-chain.snap
+++ b/src/core/prompts/system-prompt/__tests__/__snapshots__/anthropic_claude_sonnet_4-no-focus-chain.snap
@@ -241,7 +241,7 @@ Usage:
 </generate_explanation>
 
 ## use_subagents
-Description: Run up to five focused in-process subagents in parallel. Each subagent gets its own prompt and returns a comprehensive research result with tool and token stats. Use this for broad exploration when reading many files would consume the main agent's context window.
+Description: Run up to five focused in-process subagents in parallel. Each subagent gets its own prompt and returns a comprehensive research result with tool and token stats. Use this for broad exploration when reading many files would consume the main agent's context window. You do not need to launch multiple subagents every time; using one subagent is valid when it avoids unnecessary context usage for light discovery work.
 Parameters:
 - prompt_1: (required) First subagent prompt.
 - prompt_2: (optional) Optional second subagent prompt.

--- a/src/core/prompts/system-prompt/__tests__/__snapshots__/anthropic_claude_sonnet_4-no-mcp.snap
+++ b/src/core/prompts/system-prompt/__tests__/__snapshots__/anthropic_claude_sonnet_4-no-mcp.snap
@@ -267,7 +267,7 @@ Usage:
 </generate_explanation>
 
 ## use_subagents
-Description: Run up to five focused in-process subagents in parallel. Each subagent gets its own prompt and returns a comprehensive research result with tool and token stats. Use this for broad exploration when reading many files would consume the main agent's context window.
+Description: Run up to five focused in-process subagents in parallel. Each subagent gets its own prompt and returns a comprehensive research result with tool and token stats. Use this for broad exploration when reading many files would consume the main agent's context window. You do not need to launch multiple subagents every time; using one subagent is valid when it avoids unnecessary context usage for light discovery work.
 Parameters:
 - prompt_1: (required) First subagent prompt.
 - prompt_2: (optional) Optional second subagent prompt.

--- a/src/core/prompts/system-prompt/__tests__/__snapshots__/cline_devstral-basic.snap
+++ b/src/core/prompts/system-prompt/__tests__/__snapshots__/cline_devstral-basic.snap
@@ -298,7 +298,7 @@ Usage:
 </load_mcp_documentation>
 
 ## use_subagents
-Description: Run up to five focused in-process subagents in parallel. Each subagent gets its own prompt and returns a comprehensive research result with tool and token stats. Use this for broad exploration when reading many files would consume the main agent's context window.
+Description: Run up to five focused in-process subagents in parallel. Each subagent gets its own prompt and returns a comprehensive research result with tool and token stats. Use this for broad exploration when reading many files would consume the main agent's context window. You do not need to launch multiple subagents every time; using one subagent is valid when it avoids unnecessary context usage for light discovery work.
 Parameters:
 - prompt_1: (required) First subagent prompt.
 - prompt_2: (optional) Optional second subagent prompt.

--- a/src/core/prompts/system-prompt/__tests__/__snapshots__/cline_devstral-no-browser.snap
+++ b/src/core/prompts/system-prompt/__tests__/__snapshots__/cline_devstral-no-browser.snap
@@ -264,7 +264,7 @@ Usage:
 </load_mcp_documentation>
 
 ## use_subagents
-Description: Run up to five focused in-process subagents in parallel. Each subagent gets its own prompt and returns a comprehensive research result with tool and token stats. Use this for broad exploration when reading many files would consume the main agent's context window.
+Description: Run up to five focused in-process subagents in parallel. Each subagent gets its own prompt and returns a comprehensive research result with tool and token stats. Use this for broad exploration when reading many files would consume the main agent's context window. You do not need to launch multiple subagents every time; using one subagent is valid when it avoids unnecessary context usage for light discovery work.
 Parameters:
 - prompt_1: (required) First subagent prompt.
 - prompt_2: (optional) Optional second subagent prompt.

--- a/src/core/prompts/system-prompt/__tests__/__snapshots__/cline_devstral-no-focus-chain.snap
+++ b/src/core/prompts/system-prompt/__tests__/__snapshots__/cline_devstral-no-focus-chain.snap
@@ -268,7 +268,7 @@ Usage:
 </load_mcp_documentation>
 
 ## use_subagents
-Description: Run up to five focused in-process subagents in parallel. Each subagent gets its own prompt and returns a comprehensive research result with tool and token stats. Use this for broad exploration when reading many files would consume the main agent's context window.
+Description: Run up to five focused in-process subagents in parallel. Each subagent gets its own prompt and returns a comprehensive research result with tool and token stats. Use this for broad exploration when reading many files would consume the main agent's context window. You do not need to launch multiple subagents every time; using one subagent is valid when it avoids unnecessary context usage for light discovery work.
 Parameters:
 - prompt_1: (required) First subagent prompt.
 - prompt_2: (optional) Optional second subagent prompt.

--- a/src/core/prompts/system-prompt/__tests__/__snapshots__/cline_devstral-no-mcp.snap
+++ b/src/core/prompts/system-prompt/__tests__/__snapshots__/cline_devstral-no-mcp.snap
@@ -298,7 +298,7 @@ Usage:
 </load_mcp_documentation>
 
 ## use_subagents
-Description: Run up to five focused in-process subagents in parallel. Each subagent gets its own prompt and returns a comprehensive research result with tool and token stats. Use this for broad exploration when reading many files would consume the main agent's context window.
+Description: Run up to five focused in-process subagents in parallel. Each subagent gets its own prompt and returns a comprehensive research result with tool and token stats. Use this for broad exploration when reading many files would consume the main agent's context window. You do not need to launch multiple subagents every time; using one subagent is valid when it avoids unnecessary context usage for light discovery work.
 Parameters:
 - prompt_1: (required) First subagent prompt.
 - prompt_2: (optional) Optional second subagent prompt.

--- a/src/core/prompts/system-prompt/__tests__/__snapshots__/cline_native_next_gen.tools.snap
+++ b/src/core/prompts/system-prompt/__tests__/__snapshots__/cline_native_next_gen.tools.snap
@@ -470,7 +470,7 @@
     "type": "function",
     "function": {
       "name": "use_subagents",
-      "description": "Run up to five focused in-process subagents in parallel. Each subagent gets its own prompt and returns a comprehensive research result with tool and token stats. Use this for broad exploration when reading many files would consume the main agent's context window.",
+      "description": "Run up to five focused in-process subagents in parallel. Each subagent gets its own prompt and returns a comprehensive research result with tool and token stats. Use this for broad exploration when reading many files would consume the main agent's context window. You do not need to launch multiple subagents every time; using one subagent is valid when it avoids unnecessary context usage for light discovery work.",
       "strict": false,
       "parameters": {
         "type": "object",

--- a/src/core/prompts/system-prompt/__tests__/__snapshots__/openai_gpt_3-basic.snap
+++ b/src/core/prompts/system-prompt/__tests__/__snapshots__/openai_gpt_3-basic.snap
@@ -267,7 +267,7 @@ Usage:
 </generate_explanation>
 
 ## use_subagents
-Description: Run up to five focused in-process subagents in parallel. Each subagent gets its own prompt and returns a comprehensive research result with tool and token stats. Use this for broad exploration when reading many files would consume the main agent's context window.
+Description: Run up to five focused in-process subagents in parallel. Each subagent gets its own prompt and returns a comprehensive research result with tool and token stats. Use this for broad exploration when reading many files would consume the main agent's context window. You do not need to launch multiple subagents every time; using one subagent is valid when it avoids unnecessary context usage for light discovery work.
 Parameters:
 - prompt_1: (required) First subagent prompt.
 - prompt_2: (optional) Optional second subagent prompt.

--- a/src/core/prompts/system-prompt/__tests__/__snapshots__/openai_gpt_3-no-browser.snap
+++ b/src/core/prompts/system-prompt/__tests__/__snapshots__/openai_gpt_3-no-browser.snap
@@ -233,7 +233,7 @@ Usage:
 </generate_explanation>
 
 ## use_subagents
-Description: Run up to five focused in-process subagents in parallel. Each subagent gets its own prompt and returns a comprehensive research result with tool and token stats. Use this for broad exploration when reading many files would consume the main agent's context window.
+Description: Run up to five focused in-process subagents in parallel. Each subagent gets its own prompt and returns a comprehensive research result with tool and token stats. Use this for broad exploration when reading many files would consume the main agent's context window. You do not need to launch multiple subagents every time; using one subagent is valid when it avoids unnecessary context usage for light discovery work.
 Parameters:
 - prompt_1: (required) First subagent prompt.
 - prompt_2: (optional) Optional second subagent prompt.

--- a/src/core/prompts/system-prompt/__tests__/__snapshots__/openai_gpt_3-no-focus-chain.snap
+++ b/src/core/prompts/system-prompt/__tests__/__snapshots__/openai_gpt_3-no-focus-chain.snap
@@ -241,7 +241,7 @@ Usage:
 </generate_explanation>
 
 ## use_subagents
-Description: Run up to five focused in-process subagents in parallel. Each subagent gets its own prompt and returns a comprehensive research result with tool and token stats. Use this for broad exploration when reading many files would consume the main agent's context window.
+Description: Run up to five focused in-process subagents in parallel. Each subagent gets its own prompt and returns a comprehensive research result with tool and token stats. Use this for broad exploration when reading many files would consume the main agent's context window. You do not need to launch multiple subagents every time; using one subagent is valid when it avoids unnecessary context usage for light discovery work.
 Parameters:
 - prompt_1: (required) First subagent prompt.
 - prompt_2: (optional) Optional second subagent prompt.

--- a/src/core/prompts/system-prompt/__tests__/__snapshots__/openai_gpt_3-no-mcp.snap
+++ b/src/core/prompts/system-prompt/__tests__/__snapshots__/openai_gpt_3-no-mcp.snap
@@ -267,7 +267,7 @@ Usage:
 </generate_explanation>
 
 ## use_subagents
-Description: Run up to five focused in-process subagents in parallel. Each subagent gets its own prompt and returns a comprehensive research result with tool and token stats. Use this for broad exploration when reading many files would consume the main agent's context window.
+Description: Run up to five focused in-process subagents in parallel. Each subagent gets its own prompt and returns a comprehensive research result with tool and token stats. Use this for broad exploration when reading many files would consume the main agent's context window. You do not need to launch multiple subagents every time; using one subagent is valid when it avoids unnecessary context usage for light discovery work.
 Parameters:
 - prompt_1: (required) First subagent prompt.
 - prompt_2: (optional) Optional second subagent prompt.

--- a/src/core/prompts/system-prompt/__tests__/__snapshots__/openai_gpt_5-basic.snap
+++ b/src/core/prompts/system-prompt/__tests__/__snapshots__/openai_gpt_5-basic.snap
@@ -267,7 +267,7 @@ Usage:
 </generate_explanation>
 
 ## use_subagents
-Description: Run up to five focused in-process subagents in parallel. Each subagent gets its own prompt and returns a comprehensive research result with tool and token stats. Use this for broad exploration when reading many files would consume the main agent's context window.
+Description: Run up to five focused in-process subagents in parallel. Each subagent gets its own prompt and returns a comprehensive research result with tool and token stats. Use this for broad exploration when reading many files would consume the main agent's context window. You do not need to launch multiple subagents every time; using one subagent is valid when it avoids unnecessary context usage for light discovery work.
 Parameters:
 - prompt_1: (required) First subagent prompt.
 - prompt_2: (optional) Optional second subagent prompt.

--- a/src/core/prompts/system-prompt/__tests__/__snapshots__/openai_gpt_5-no-browser.snap
+++ b/src/core/prompts/system-prompt/__tests__/__snapshots__/openai_gpt_5-no-browser.snap
@@ -233,7 +233,7 @@ Usage:
 </generate_explanation>
 
 ## use_subagents
-Description: Run up to five focused in-process subagents in parallel. Each subagent gets its own prompt and returns a comprehensive research result with tool and token stats. Use this for broad exploration when reading many files would consume the main agent's context window.
+Description: Run up to five focused in-process subagents in parallel. Each subagent gets its own prompt and returns a comprehensive research result with tool and token stats. Use this for broad exploration when reading many files would consume the main agent's context window. You do not need to launch multiple subagents every time; using one subagent is valid when it avoids unnecessary context usage for light discovery work.
 Parameters:
 - prompt_1: (required) First subagent prompt.
 - prompt_2: (optional) Optional second subagent prompt.

--- a/src/core/prompts/system-prompt/__tests__/__snapshots__/openai_gpt_5-no-focus-chain.snap
+++ b/src/core/prompts/system-prompt/__tests__/__snapshots__/openai_gpt_5-no-focus-chain.snap
@@ -241,7 +241,7 @@ Usage:
 </generate_explanation>
 
 ## use_subagents
-Description: Run up to five focused in-process subagents in parallel. Each subagent gets its own prompt and returns a comprehensive research result with tool and token stats. Use this for broad exploration when reading many files would consume the main agent's context window.
+Description: Run up to five focused in-process subagents in parallel. Each subagent gets its own prompt and returns a comprehensive research result with tool and token stats. Use this for broad exploration when reading many files would consume the main agent's context window. You do not need to launch multiple subagents every time; using one subagent is valid when it avoids unnecessary context usage for light discovery work.
 Parameters:
 - prompt_1: (required) First subagent prompt.
 - prompt_2: (optional) Optional second subagent prompt.

--- a/src/core/prompts/system-prompt/__tests__/__snapshots__/openai_gpt_5-no-mcp.snap
+++ b/src/core/prompts/system-prompt/__tests__/__snapshots__/openai_gpt_5-no-mcp.snap
@@ -267,7 +267,7 @@ Usage:
 </generate_explanation>
 
 ## use_subagents
-Description: Run up to five focused in-process subagents in parallel. Each subagent gets its own prompt and returns a comprehensive research result with tool and token stats. Use this for broad exploration when reading many files would consume the main agent's context window.
+Description: Run up to five focused in-process subagents in parallel. Each subagent gets its own prompt and returns a comprehensive research result with tool and token stats. Use this for broad exploration when reading many files would consume the main agent's context window. You do not need to launch multiple subagents every time; using one subagent is valid when it avoids unnecessary context usage for light discovery work.
 Parameters:
 - prompt_1: (required) First subagent prompt.
 - prompt_2: (optional) Optional second subagent prompt.

--- a/src/core/prompts/system-prompt/__tests__/__snapshots__/openai_gpt_5_1_native.tools.snap
+++ b/src/core/prompts/system-prompt/__tests__/__snapshots__/openai_gpt_5_1_native.tools.snap
@@ -421,7 +421,7 @@
     "type": "function",
     "function": {
       "name": "use_subagents",
-      "description": "Run up to five focused in-process subagents in parallel. Each subagent gets its own prompt and returns a comprehensive research result with tool and token stats. Use this for broad exploration when reading many files would consume the main agent's context window.",
+      "description": "Run up to five focused in-process subagents in parallel. Each subagent gets its own prompt and returns a comprehensive research result with tool and token stats. Use this for broad exploration when reading many files would consume the main agent's context window. You do not need to launch multiple subagents every time; using one subagent is valid when it avoids unnecessary context usage for light discovery work.",
       "strict": false,
       "parameters": {
         "type": "object",

--- a/src/core/prompts/system-prompt/__tests__/__snapshots__/openai_gpt_5_native.tools.snap
+++ b/src/core/prompts/system-prompt/__tests__/__snapshots__/openai_gpt_5_native.tools.snap
@@ -372,7 +372,7 @@
     "type": "function",
     "function": {
       "name": "use_subagents",
-      "description": "Run up to five focused in-process subagents in parallel. Each subagent gets its own prompt and returns a comprehensive research result with tool and token stats. Use this for broad exploration when reading many files would consume the main agent's context window.",
+      "description": "Run up to five focused in-process subagents in parallel. Each subagent gets its own prompt and returns a comprehensive research result with tool and token stats. Use this for broad exploration when reading many files would consume the main agent's context window. You do not need to launch multiple subagents every time; using one subagent is valid when it avoids unnecessary context usage for light discovery work.",
       "strict": false,
       "parameters": {
         "type": "object",

--- a/src/core/prompts/system-prompt/__tests__/__snapshots__/openrouter_arcee_ai_trinity_large_preview-basic.snap
+++ b/src/core/prompts/system-prompt/__tests__/__snapshots__/openrouter_arcee_ai_trinity_large_preview-basic.snap
@@ -276,7 +276,7 @@ Usage:
 </generate_explanation>
 
 ## use_subagents
-Description: Run up to five focused in-process subagents in parallel. Each subagent gets its own prompt and returns a comprehensive research result with tool and token stats. Use this for broad exploration when reading many files would consume the main agent's context window.
+Description: Run up to five focused in-process subagents in parallel. Each subagent gets its own prompt and returns a comprehensive research result with tool and token stats. Use this for broad exploration when reading many files would consume the main agent's context window. You do not need to launch multiple subagents every time; using one subagent is valid when it avoids unnecessary context usage for light discovery work.
 Parameters:
 - prompt_1: (required) First subagent prompt.
 - prompt_2: (optional) Optional second subagent prompt.

--- a/src/core/prompts/system-prompt/__tests__/__snapshots__/openrouter_arcee_ai_trinity_large_preview-no-browser.snap
+++ b/src/core/prompts/system-prompt/__tests__/__snapshots__/openrouter_arcee_ai_trinity_large_preview-no-browser.snap
@@ -242,7 +242,7 @@ Usage:
 </generate_explanation>
 
 ## use_subagents
-Description: Run up to five focused in-process subagents in parallel. Each subagent gets its own prompt and returns a comprehensive research result with tool and token stats. Use this for broad exploration when reading many files would consume the main agent's context window.
+Description: Run up to five focused in-process subagents in parallel. Each subagent gets its own prompt and returns a comprehensive research result with tool and token stats. Use this for broad exploration when reading many files would consume the main agent's context window. You do not need to launch multiple subagents every time; using one subagent is valid when it avoids unnecessary context usage for light discovery work.
 Parameters:
 - prompt_1: (required) First subagent prompt.
 - prompt_2: (optional) Optional second subagent prompt.

--- a/src/core/prompts/system-prompt/__tests__/__snapshots__/openrouter_arcee_ai_trinity_large_preview-no-focus-chain.snap
+++ b/src/core/prompts/system-prompt/__tests__/__snapshots__/openrouter_arcee_ai_trinity_large_preview-no-focus-chain.snap
@@ -250,7 +250,7 @@ Usage:
 </generate_explanation>
 
 ## use_subagents
-Description: Run up to five focused in-process subagents in parallel. Each subagent gets its own prompt and returns a comprehensive research result with tool and token stats. Use this for broad exploration when reading many files would consume the main agent's context window.
+Description: Run up to five focused in-process subagents in parallel. Each subagent gets its own prompt and returns a comprehensive research result with tool and token stats. Use this for broad exploration when reading many files would consume the main agent's context window. You do not need to launch multiple subagents every time; using one subagent is valid when it avoids unnecessary context usage for light discovery work.
 Parameters:
 - prompt_1: (required) First subagent prompt.
 - prompt_2: (optional) Optional second subagent prompt.

--- a/src/core/prompts/system-prompt/__tests__/__snapshots__/openrouter_arcee_ai_trinity_large_preview-no-mcp.snap
+++ b/src/core/prompts/system-prompt/__tests__/__snapshots__/openrouter_arcee_ai_trinity_large_preview-no-mcp.snap
@@ -276,7 +276,7 @@ Usage:
 </generate_explanation>
 
 ## use_subagents
-Description: Run up to five focused in-process subagents in parallel. Each subagent gets its own prompt and returns a comprehensive research result with tool and token stats. Use this for broad exploration when reading many files would consume the main agent's context window.
+Description: Run up to five focused in-process subagents in parallel. Each subagent gets its own prompt and returns a comprehensive research result with tool and token stats. Use this for broad exploration when reading many files would consume the main agent's context window. You do not need to launch multiple subagents every time; using one subagent is valid when it avoids unnecessary context usage for light discovery work.
 Parameters:
 - prompt_1: (required) First subagent prompt.
 - prompt_2: (optional) Optional second subagent prompt.

--- a/src/core/prompts/system-prompt/__tests__/__snapshots__/vertex_gemini3.tools.snap
+++ b/src/core/prompts/system-prompt/__tests__/__snapshots__/vertex_gemini3.tools.snap
@@ -354,7 +354,7 @@
   },
   {
     "name": "use_subagents",
-    "description": "Run up to five focused in-process subagents in parallel. Each subagent gets its own prompt and returns a comprehensive research result with tool and token stats. Use this for broad exploration when reading many files would consume the main agent's context window.",
+    "description": "Run up to five focused in-process subagents in parallel. Each subagent gets its own prompt and returns a comprehensive research result with tool and token stats. Use this for broad exploration when reading many files would consume the main agent's context window. You do not need to launch multiple subagents every time; using one subagent is valid when it avoids unnecessary context usage for light discovery work.",
     "parameters": {
       "type": "OBJECT",
       "properties": {

--- a/src/core/prompts/system-prompt/tools/subagent.ts
+++ b/src/core/prompts/system-prompt/tools/subagent.ts
@@ -9,7 +9,7 @@ const generic: ClineToolSpec = {
 	id,
 	name: "use_subagents",
 	description:
-		"Run up to five focused in-process subagents in parallel. Each subagent gets its own prompt and returns a comprehensive research result with tool and token stats. Use this for broad exploration when reading many files would consume the main agent's context window.",
+		"Run up to five focused in-process subagents in parallel. Each subagent gets its own prompt and returns a comprehensive research result with tool and token stats. Use this for broad exploration when reading many files would consume the main agent's context window. You do not need to launch multiple subagents every time; using one subagent is valid when it avoids unnecessary context usage for light discovery work.",
 	contextRequirements: (context) => context.subagentsEnabled === true && !context.isSubagentRun,
 	parameters: [
 		{

--- a/src/core/task/tools/subagent/SubagentRunner.ts
+++ b/src/core/task/tools/subagent/SubagentRunner.ts
@@ -76,15 +76,17 @@ interface SubagentToolCall {
 }
 
 const SUBAGENT_SYSTEM_SUFFIX = `\n\n# Subagent Execution Mode
-You are running as a research subagent. Your job is to thoroughly explore the codebase and gather comprehensive information to answer the question.
-Explore broadly, read related files, trace through call chains, and build a complete picture before reporting back.
+You are running as a research subagent. Your job is to explore the codebase and gather information to answer the question.
+Explore, read related files, trace through call chains, and build a complete picture before reporting back.
 You can read files, list directories, search for patterns, list code definitions, and run commands.
 Only use execute_command for readonly operations like ls, grep, git log, git diff, gh, etc.
+When it makes sense, be clever about chaining commands or in-command scripting in execute_command to quickly get relevant context - and using pipes / filters to help narrow results.
 Do not run commands that modify files or system state.
 When you have a comprehensive answer, call the attempt_completion tool.
 The attempt_completion result field is sent directly to the main agent, so put your full final findings there.
-Include file paths and line numbers in that result field.
-Also include a section titled "Recommended files for main agent" with a list of the highest-value files the main agent should read next, and a one-line reason for each file.
+Unless the subagent prompt explicitly asks for detailed analysis, keep the result concise and focus on the files the main agent should read next.
+Include a section titled "Relevant file paths" and list only file paths, one per line.
+Do not include line numbers, summaries, or per-file explanations unless explicitly requested.
 `
 
 function serializeToolResult(result: unknown): string {


### PR DESCRIPTION
### Related Issue

Issue: N/A (prompt and UX tuning requested by maintainer feedback)

### Description

@candieduniverse had some great ideas about our subagent prompts! And this PR incorporates those:

This PR tunes subagent prompting so research runs are more useful and less verbose by default.

Problem being solved:
- Subagent output guidance was pushing heavy analysis format (line numbers plus a recommended-files section with per-file reasoning) even when the main agent only needed a concise handoff.
- The command-use guidance did not clearly encourage in-command scripting patterns that can quickly narrow results during discovery.
- The parent `use_subagents` description implied parallel fanout as the default pattern without clearly stating that one subagent is also a valid context-efficient strategy.

What changed and why:
- Updated the subagent execution suffix to default to concise handoff behavior: a `Relevant file paths` section with file paths only, unless deeper analysis is explicitly requested in the prompt.
- Removed the default requirement for line numbers, summaries, and per-file explanations.
- Reworded the subagent opener language to be less heavy while keeping the same exploration intent.
- Added a single-line instruction that encourages being clever with command chaining or in-command scripting in `execute_command`, with pipes and filters for narrowing noisy output.
- Added guidance in the `use_subagents` tool description that launching only one subagent is valid when multiple would waste context for small discovery tasks.
- Updated docs to match the new behavior and expectations.

Debugging and implementation notes:
- Prompt integration snapshots failed immediately after changing prompt text, which was expected because the shared tool description and prompt suffix are rendered across many model families.
- I regenerated snapshots in update mode so CI has a coherent baseline for the new wording.
- No runtime logic or tool permissions were changed. This is prompt-content behavior plus docs alignment.

Alternatives considered:
- Keeping line numbers as a default and only dropping the recommended-files section. Rejected because the request was explicitly to avoid analysis-style output unless needed.
- Adding more concrete command examples in the core prompt. Rejected in favor of a single non-prescriptive instruction so models keep flexibility.

### Test Procedure

I tested prompt rendering and snapshot consistency directly:

1. `npx cross-env TS_NODE_PROJECT=./tsconfig.unit-test.json mocha src/core/prompts/system-prompt/__tests__/integration.test.ts`
- Result: snapshot mismatches across prompt variants, expected due wording updates.

2. `npx cross-env TS_NODE_PROJECT=./tsconfig.unit-test.json mocha src/core/prompts/system-prompt/__tests__/integration.test.ts -- --update-snapshots`
- Result: pass, snapshots updated.
- Final summary from run: `930 passing`, `4 pending`.

I also validated that changes are scoped to prompt/docs/snapshots and the branch is clean after commit.

### Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ♻️ Refactor Changes
- [x] 💅 Cosmetic Changes
- [x] 📚 Documentation update
- [ ] 🏃 Workflow Changes

### Pre-flight Checklist

- [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
- [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
- [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
- [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A

### Additional Notes

Because this prompt string is shared and snapshot-covered, snapshot updates span multiple model-family snapshot files even though behavior changes were localized to subagent prompt instructions.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Refines subagent prompt behavior and guidance for efficiency, reducing verbosity and clarifying single subagent use in `SubagentRunner.ts` and documentation.
> 
>   - **Behavior**:
>     - Updated subagent execution suffix in `SubagentRunner.ts` to default to concise handoff with a `Relevant file paths` section, excluding line numbers and summaries unless requested.
>     - Removed default requirement for line numbers, summaries, and per-file explanations.
>     - Reworded subagent opener language to be less verbose.
>     - Added instruction for command chaining and in-command scripting in `execute_command`.
>     - Clarified `use_subagents` description to validate single subagent use for small tasks.
>   - **Documentation**:
>     - Updated `subagents.mdx` to reflect new behavior and expectations.
>     - Regenerated snapshots in `__snapshots__` to align with updated prompt text.
>   - **Testing**:
>     - Snapshot tests updated to reflect wording changes, ensuring consistency across prompt variants.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for d8298c0c1cdac62f0a4e72c99a885676117c9fc3. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->