### PR TITLE
feat: make response ID chaining configurable

### DIFF
--- a/src/core/api/transform/openai-response-format.ts
+++ b/src/core/api/transform/openai-response-format.ts
@@ -71,7 +71,10 @@ import { ClineStorageMessage } from "@/shared/messages/content"
  * @param messages - Array of ClineStorageMessage objects to be converted
  * @returns ResponseInput array containing the transformed messages with proper reasoning pairing
  */
-export function convertToOpenAIResponsesInput(_messages: ClineStorageMessage[]): {
+export function convertToOpenAIResponsesInput(
+	_messages: ClineStorageMessage[],
+	options?: { usePreviousResponseId?: boolean },
+): {
 	input: ResponseInput
 	previousResponseId?: string
 } {
@@ -79,12 +82,14 @@ export function convertToOpenAIResponsesInput(_messages: ClineStorageMessage[]):
 	// When chaining, only send new items after that assistant turn.
 	let previousResponseId: string | undefined
 	let messages = _messages
-	for (let i = _messages.length - 1; i >= 0; i--) {
-		const msg = _messages[i]
-		if (msg.role === "assistant" && msg.id) {
-			previousResponseId = msg.id
-			messages = _messages.slice(i + 1)
-			break
+	if (options?.usePreviousResponseId) {
+		for (let i = _messages.length - 1; i >= 0; i--) {
+			const msg = _messages[i]
+			if (msg.role === "assistant" && msg.id) {
+				previousResponseId = msg.id
+				messages = _messages.slice(i + 1)
+				break
+			}
 		}
 	}
 


### PR DESCRIPTION
<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- For feature requests: Created a discussion in our Feature Requests discussions board https://github.com/cline/cline/discussions/categories/feature-requests and received approval from core maintainers before implementation
- For all changes: Link the associated issue/discussion in the "Related Issue" section below

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly without prior discussion.

Why this requirement?
We deeply appreciate all community contributions - they are essential to Cline's success! To ensure the best use of everyone's time and maintain project direction, we use our Feature Requests discussions board to gauge community interest and validate feature ideas before implementation begins. This helps us focus development efforts on features that will benefit the most users.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** #XXXX

### Description

<!-- 
Help reviewers understand your changes by making this PR readable and well-organized:

- What problem does this PR solve?
- Why were these changes introduced and what purpose do they serve?
- For larger changes, provide context about your approach and reasoning

Small PRs may need minimal description, but larger changes benefit from explaining where you're coming from. Much of this context can be in the linked issue above, so feel free to reference it rather than repeating everything here.
-->

Add an optional `usePreviousResponseId` flag to
`convertToOpenAIResponsesInput` and gate previous assistant-response lookup behind it.

This makes response chaining opt-in instead of always-on, so providers can control whether to continue from the latest stored OpenAI response ID.feat(openai): make response ID chaining configurable

Add an optional `usePreviousResponseId` flag to
`convertToOpenAIResponsesInput` and gate previous assistant-response lookup behind it.

This makes response chaining opt-in instead of always-on, so providers can control whether to continue from the latest stored OpenAI response ID.


### Test Procedure

<!-- 
Please walk us through your testing approach and thought process. This helps reviewers understand that you've thoroughly considered the impact of your changes:

- How did you test this change?
- What could potentially break and how did you verify it doesn't?
- What existing functionality might be affected and how did you check it still works?
- Why are you confident this is ready for merge?

We're not looking for exhaustive documentation - just evidence that you've thought through the implications of your changes and tested accordingly.
-->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `usePreviousResponseId` option to `convertToOpenAIResponsesInput` for configurable response ID chaining.
> 
>   - **Behavior**:
>     - Adds `usePreviousResponseId` option to `convertToOpenAIResponsesInput` in `openai-response-format.ts`.
>     - When `usePreviousResponseId` is true, chains from the latest assistant message ID.
>     - Defaults to not chaining if the option is not provided.
>   - **Functionality**:
>     - Modifies logic to slice messages based on the last assistant message ID when chaining is enabled.
>     - Ensures backward compatibility by maintaining existing behavior when the option is not used.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 75632f5182c11ef0fb6e39ea9bdce6668a6b7e5b. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->