### PR TITLE
fix(minimax): revert duplicate stream row regression paths

### DIFF
--- a/src/core/api/providers/minimax.ts
+++ b/src/core/api/providers/minimax.ts
@@ -103,13 +103,7 @@ export class MinimaxHandler implements ApiHandler {
 							yield {
 								type: "reasoning",
 								reasoning: chunk.content_block.thinking || "",
-							}
-							if (chunk.content_block.thinking && chunk.content_block.signature) {
-								yield {
-									type: "reasoning",
-									reasoning: chunk.content_block.thinking,
-									signature: chunk.content_block.signature,
-								}
+								signature: chunk.content_block.signature,
 							}
 							break
 						case "redacted_thinking":


### PR DESCRIPTION
### Related Issue
Issue: #XXXX

### Description
This PR reverts two changes that were part of the duplicate chat row mitigation around MiniMax streaming.

Context from investigation:
- Duplicate chat rows were observed after MiniMax was added to `ClientProvider` flow and traced through task streaming.
- `git blame` and history pointed to two relevant paths:
  - MiniMax reasoning event emission in `src/core/api/providers/minimax.ts`
  - Task-level duplicate text-row guard introduced by `b514f18e4` in `src/core/task/index.ts`

What this PR changes:
1. Revert MiniMax duplicate reasoning emission behavior
- In `src/core/api/providers/minimax.ts`, `content_block_start` for `thinking` now emits a single `reasoning` chunk with optional `signature`.
- Removed the second duplicate `reasoning` yield that repeated the same thinking text.

2. Revert Task-level duplicate completed text guard from `b514f18e4`
- Removed `isDuplicateCompletedTextSay` guard from `src/core/task/index.ts`.
- Removed the matching unit test case in `src/core/task/__tests__/Task.say.test.ts`.

Why do both reverts together:
- The provider-level duplicate reasoning emission is model-specific and is the narrower fix for MiniMax stream behavior.
- The Task-level dedupe guard was a broader behavior change in a shared path. This PR intentionally removes that global guard and returns to prior task behavior while fixing MiniMax at the source.

Debugging notes:
- MiniMax trace blame showed the duplicate reasoning shape came from the standardized reasoning change in `e747d211e6`.
- The Task dedupe guard came from `b514f18e4` and was explicitly linked to MiniMax-style timing.
- Reverting both here restores previous task semantics and keeps the provider output aligned with Anthropic-style single reasoning emission at `content_block_start`.

### Test Procedure
What I ran:
- `npx biome check --write src/core/api/providers/minimax.ts`
- Verified final diff only touches:
  - `src/core/api/providers/minimax.ts`
  - `src/core/task/index.ts`
  - `src/core/task/__tests__/Task.say.test.ts`

What I did not run:
- Full unit/integration suite was not run in this pass.

### Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ♻️ Refactor Changes
- [ ] 💅 Cosmetic Changes
- [ ] 📚 Documentation update
- [ ] 🏃 Workflow Changes

### Pre-flight Checklist
- [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
- [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
- [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
- [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots
N/A

### Additional Notes
- Commit sequence in this branch:
  - `bbf977dea` fix(minimax): emit single reasoning chunk on thinking start
  - `9d0f70cf6` revert(task): remove duplicate completed text dedupe guard

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Reverts duplicate reasoning emission in `minimax.ts` and removes task-level duplicate text-row guard in `task/index.ts`.
> 
>   - **Behavior**:
>     - Reverts duplicate reasoning emission in `minimax.ts` to emit a single `reasoning` chunk with optional `signature`.
>     - Removes task-level duplicate text-row guard from `task/index.ts`.
>   - **Tests**:
>     - Removes related unit test case from `Task.say.test.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 9d0f70cf65f743cc4678d8816e36c4760b1aa096. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->