### PR TITLE
fix(task): prevent duplicate partial text from reentrant presentation

### DIFF
--- a/src/core/task/index.ts
+++ b/src/core/task/index.ts
@@ -2681,7 +2681,6 @@ export class Task {
 							}
 
 							await this.processNativeToolCalls(assistantTextOnly, toolUseHandler.getPartialToolUsesAsContent())
-							await this.presentAssistantMessage()
 							break
 						}
 						case "text": {
@@ -2707,13 +2706,12 @@ export class Task {
 							if (this.taskState.assistantMessageContent.length > prevLength) {
 								this.taskState.userMessageContentReady = false // new content we need to present, reset to false in case previous content set this to true
 							}
-							// Process the new text content as it streams in without awaiting for full message
-							this.presentAssistantMessage()
 							break
 						}
 					}
 
-					// present content to user - we don't want the stream to break if present fails, so we catch errors here
+					// Present content once per chunk. Calling this from multiple case branches can
+					// race partial updates and duplicate text rows in the chat.
 					await this.presentAssistantMessage().catch((error) =>
 						Logger.debug("[Task] Failed to present message: " + error),
 					)


### PR DESCRIPTION
### Related Issue

Issue: #XXXX

### Description

This PR fixes a streaming race in task response presentation that could duplicate assistant text in chat.

What was happening

In webview chat, the same partial assistant sentence could render twice, for example:

- "I'll help you test by performing those steps. Let"
- immediately repeated as the same partial text again

This showed up most clearly with newer models that stream extremely fast, often one token or one word per chunk. Older model patterns tended to deliver larger chunks with natural spacing between events, so this race was much harder to trigger.

Root cause

Inside the stream loop in `Task` (`src/core/task/index.ts`), `presentAssistantMessage()` was being triggered from multiple places during the same chunk cycle:

- directly inside `case "text"`
- directly inside `case "tool_calls"`
- again after the `switch` in the common "present content" block

Under very fast chunk cadence, those paths could overlap in practice and process the same partial text state more than once before the next content state was fully advanced, resulting in duplicate partial text emissions.

Why this was so painful to diagnose

The duplicate output looked at first like a provider content problem because the affected providers were also streaming heavy reasoning traces. That created two overlapping symptoms:

1. reasoning text that looked very similar to the final visible answer
2. an actual duplicate partial text emission race in the presentation path

The first symptom made the second one harder to isolate. We initially looked at reasoning interleaving behavior, then moved to instrumentation in the stream loop and presentation path. The key signal was repeated logs for identical "Saying text chunk" payloads for a single incremental text state.

What this PR changes

The fix makes presentation single-path per chunk cycle:

- removes the direct `await this.presentAssistantMessage()` call from `case "tool_calls"`
- removes the direct `this.presentAssistantMessage()` call from `case "text"`
- keeps the single common `presentAssistantMessage()` call after the switch

This preserves existing behavior while eliminating redundant re-entrant presentation calls.

Why this approach

- Minimal surface area
- Keeps existing stream parsing and content accumulation behavior intact
- Addresses the race directly where duplicate rendering was introduced
- Avoids introducing provider-specific heuristics for what is fundamentally a scheduler/presentation sequencing issue

Behavioral result

- partial text updates are emitted once per stream chunk cycle
- duplicate same-content partial rows are prevented
- tool call handling still works through the existing common presentation path

### Test Procedure

Manual and focused validation:

1. Reproduced duplicate partial text behavior with high-frequency streaming models that emit very small deltas.
2. Added temporary instrumentation to confirm repeated `say("text", ..., partial=true)` emissions for identical content states.
3. Applied this fix and repeated the same scenario.
4. Verified that partial text updates are no longer duplicated in chat.
5. Verified that tool call progression still presents correctly after text streaming.

Local checks:

- Ran `pnpm exec biome lint src/core/task/index.ts` from the branch worktree.
- Confirmed no new lint errors were introduced by this change (only existing informational diagnostics in this file).

Potential regression areas considered:

- Missing final partial updates for text when tool calls begin
- Skipped tool execution due to presentation ordering
- Out-of-order content progression when chunks arrive rapidly

These were sanity-checked during manual replay of the previously failing pattern.

### Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ♻️ Refactor Changes
- [ ] 💅 Cosmetic Changes
- [ ] 📚 Documentation update
- [ ] 🏃 Workflow Changes

### Pre-flight Checklist

- [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
- [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
- [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
- [x] I have reviewed contributor guidelines

### Screenshots

N/A

### Additional Notes

No provider-specific behavior was changed in this PR. This is intentionally scoped to presentation call sequencing in the task stream loop.

The temporary debugging instrumentation used during investigation was not included in this PR.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes race condition in `Task` class to prevent duplicate partial text emissions by ensuring `presentAssistantMessage()` is called once per chunk cycle.
> 
>   - **Behavior**:
>     - Fixes race condition in `Task` class in `src/core/task/index.ts` causing duplicate partial text emissions during fast streaming.
>     - Removes redundant `presentAssistantMessage()` calls from `case "tool_calls"` and `case "text"`.
>     - Ensures `presentAssistantMessage()` is called once per chunk cycle after the `switch` statement.
>   - **Misc**:
>     - No changes to provider-specific behavior; focuses on presentation call sequencing.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for da35467d48c21575e097551cfbbf692806f3162f. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->