### PR TITLE
fix: sync favorite state to running task to prevent reset

### DIFF
--- a/.changeset/fix-favorite-state-reset.md
+++ b/.changeset/fix-favorite-state-reset.md
@@ -1,0 +1,4 @@
+---
+---
+
+fix: sync favorite state to running task to prevent reset (#9147)

--- a/src/core/controller/task/toggleTaskFavorite.ts
+++ b/src/core/controller/task/toggleTaskFavorite.ts
@@ -41,7 +41,7 @@ export async function toggleTaskFavorite(controller: Controller, request: TaskFa
 		// Sync the favorite state to the running task so that subsequent
 		// saves don't overwrite the value with the stale cached copy.
 		if (controller.task?.taskId === request.taskId) {
-			controller.task.messageStateHandler.setTaskIsFavorited(request.isFavorited)
+			await controller.task.messageStateHandler.setTaskIsFavorited(request.isFavorited)
 		}
 
 		// Post to webview

--- a/src/core/controller/task/toggleTaskFavorite.ts
+++ b/src/core/controller/task/toggleTaskFavorite.ts
@@ -38,6 +38,12 @@ export async function toggleTaskFavorite(controller: Controller, request: TaskFa
 			Logger.error("Error processing task history:", historyErr)
 		}
 
+		// Sync the favorite state to the running task so that subsequent
+		// saves don't overwrite the value with the stale cached copy.
+		if (controller.task?.taskId === request.taskId) {
+			controller.task.messageStateHandler.setTaskIsFavorited(request.isFavorited)
+		}
+
 		// Post to webview
 		try {
 			await controller.postStateToWebview()

--- a/src/core/task/message-state.ts
+++ b/src/core/task/message-state.ts
@@ -73,9 +73,12 @@ export class MessageStateHandler extends EventEmitter<MessageStateHandlerEvents>
 	/**
 	 * Update the in-memory favorite state so that subsequent saves
 	 * persist the correct value instead of overwriting external changes.
+	 * Protected by stateMutex to avoid racing with an ongoing save.
 	 */
-	setTaskIsFavorited(isFavorited: boolean): void {
-		this.taskIsFavorited = isFavorited
+	async setTaskIsFavorited(isFavorited: boolean): Promise<void> {
+		await this.withStateLock(() => {
+			this.taskIsFavorited = isFavorited
+		})
 	}
 
 	/**

--- a/src/core/task/message-state.ts
+++ b/src/core/task/message-state.ts
@@ -71,6 +71,14 @@ export class MessageStateHandler extends EventEmitter<MessageStateHandlerEvents>
 	}
 
 	/**
+	 * Update the in-memory favorite state so that subsequent saves
+	 * persist the correct value instead of overwriting external changes.
+	 */
+	setTaskIsFavorited(isFavorited: boolean): void {
+		this.taskIsFavorited = isFavorited
+	}
+
+	/**
 	 * Emit a clineMessagesChanged event with the change details
 	 */
 	private emitClineMessagesChanged(change: ClineMessageChange): void {


### PR DESCRIPTION
## Problem

Fixes #9147

When a user toggles the favorite status of a **running** task, `toggleTaskFavorite` updates the global `taskHistory` but the running task's `MessageStateHandler` still holds the stale `taskIsFavorited` value. On the next save (e.g. after an API response), `saveClineMessagesAndUpdateHistoryInternal` overwrites the history entry with the old `isFavorited` value, effectively resetting the favorite.

## Root Cause

`MessageStateHandler.taskIsFavorited` is set once in the constructor and never updated externally. The save path at line 159 always writes this cached value back:

```ts
isFavorited: this.taskIsFavorited,  // stale!
```

## Fix

1. Add `setTaskIsFavorited()` to `MessageStateHandler` so the in-memory state can be updated externally.
2. In `toggleTaskFavorite`, after updating global state, sync the value to the running task's `MessageStateHandler` if the toggled task is currently active.

## Changes

- `src/core/task/message-state.ts` — add `setTaskIsFavorited()` method
- `src/core/controller/task/toggleTaskFavorite.ts` — call `setTaskIsFavorited()` on the running task

2 files changed, 14 insertions.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes favorite state reset issue by syncing in-memory state for running tasks in `toggleTaskFavorite` and `MessageStateHandler`.
> 
>   - **Behavior**:
>     - Fixes issue where toggling favorite status of a running task resets on save.
>     - `toggleTaskFavorite` now updates `MessageStateHandler` for active tasks.
>   - **Methods**:
>     - Adds `setTaskIsFavorited()` to `MessageStateHandler` in `message-state.ts` to update in-memory favorite state.
>     - Calls `setTaskIsFavorited()` in `toggleTaskFavorite.ts` to sync state for active tasks.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for e82077cb471aa68cf1cf62e11aa0a0259a8c9be1. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->