### PR TITLE
fix(changesets): include root package in npm workspaces

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
 			"version": "3.61.0",
 			"license": "Apache-2.0",
 			"workspaces": [
+				".",
 				"cli"
 			],
 			"dependencies": {
@@ -10287,6 +10288,10 @@
 			"resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
 			"integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==",
 			"license": "MIT"
+		},
+		"node_modules/claude-dev": {
+			"resolved": "",
+			"link": true
 		},
 		"node_modules/clean-stack": {
 			"version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
 	"version": "3.61.0",
 	"icon": "assets/icons/icon.png",
 	"workspaces": [
+		".",
 		"cli"
 	],
 	"engines": {


### PR DESCRIPTION
### Related Issue

Issue: N/A

This addresses a regression on `main` where the changeset CI job fails in the release workflow run:
https://github.com/cline/cline/actions/runs/22003228483/job/63580789828

### Description

Problem

The `changeset-pr-version-bump` job runs `npm run version-packages`, which executes `changeset version`. That step failed with:

`Found changeset dark-hotels-care for package claude-dev which is not in the workspace`

The failing changeset targets `claude-dev`, which is the root extension package.

Root cause

The repo was converted into an npm workspace for CLI work, but root `package.json` had:

`"workspaces": ["cli"]`

With that config, Changesets only saw workspace package `cline` and did not treat `claude-dev` as a workspace package. Any new changeset targeting `claude-dev` then hard-failed release versioning.

I verified this by reproducing locally with `npm run version-packages` and by creating a minimal isolated reproduction. In both cases:

- `workspaces: ["cli"]` failed with the exact same error.
- `workspaces: [".", "cli"]` succeeded.

Technical approach

I made the smallest config correction that aligns with how Changesets and npm workspaces expect package discovery:

1. Added `"."` to root `workspaces` so the root package (`claude-dev`) is explicitly part of the workspace graph.
2. Updated `package-lock.json` to keep it in sync with the workspace graph, including the root link entry that npm expects for a root workspace package.

Why this approach

I considered alternatives and rejected them for being less clean:

- Retargeting changesets from `claude-dev` to `cline` is semantically wrong for extension-only changes.
- Adding CI-only hacks around changesets package resolution would hide config drift rather than fixing it.
- Removing workspaces would regress the CLI workspace setup that was intentionally added.

This fix keeps workspace intent intact and restores correct release behavior.

Side effects and implications

- Workspace-aware tooling now sees both workspace packages: `claude-dev` and `cline`.
- Any future broad workspace command (`npm ... -ws`) will include root too.
- Existing CI and scripts in this repo currently do not use broad workspace npm invocations, so there is no immediate behavior regression.
- No circular dependency is introduced by this change alone. There is no `claude-dev <-> cline` dependency loop in package manifests.

Debugging journey

The key path was:

1. Pull and inspect full failing GitHub Actions log.
2. Confirm exact failing command and error site in release workflow.
3. Reproduce locally to rule out runner-only behavior.
4. Validate package discovery behavior under current workspace config.
5. Run controlled minimal repro with two workspace variants to isolate root cause.
6. Apply minimal config fix and verify that `changeset status` now resolves `claude-dev` correctly.

### Test Procedure

I validated with the following checks:

1. Reproduced failure before fix:
   - `npm run version-packages`
   - Error: `Found changeset ... for package claude-dev which is not in the workspace`
2. Verified behavior after fix:
   - `npx changeset status`
   - Result: success, package `claude-dev` listed for patch bump
3. Verified lockfile/workspace install consistency:
   - `npm ci --ignore-scripts --dry-run`
   - Result: success

Potential breakage considered

- Workspace command fanout changes if `-ws` is used in future scripts.
- Lockfile drift risk if workspace list changes again without lockfile update.

Checks against those concerns

- Confirmed current repo scripts/workflows are not using broad workspace npm invocations.
- Kept lockfile aligned with workspace graph in the same patch.

### Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ♻️ Refactor Changes
- [ ] 💅 Cosmetic Changes
- [ ] 📚 Documentation update
- [ ] 🏃 Workflow Changes

### Pre-flight Checklist

- [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
- [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
- [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
- [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Not applicable. This is a release/workspace configuration fix.

### Additional Notes

If maintainers want an extra guardrail, we can add a small CI assertion that `changeset status` runs successfully on `main` and fails fast if workspace configuration ever drifts again.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes changeset CI job failure by including root package `claude-dev` in npm workspaces in `package.json`.
> 
>   - **Behavior**:
>     - Fixes changeset CI job failure by including root package `claude-dev` in npm workspaces in `package.json`.
>     - Ensures `changeset version` can correctly identify `claude-dev` as part of the workspace.
>   - **Technical Approach**:
>     - Adds `"."` to `workspaces` in `package.json` to explicitly include the root package.
>     - Updates `package-lock.json` to align with the new workspace configuration.
>   - **Side Effects**:
>     - Workspace-aware tooling now recognizes both `claude-dev` and `cline` as workspace packages.
>     - No immediate behavior regression in existing CI and scripts as they do not use broad workspace commands.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for d9b97bc512c9cc527020eb5f74687bc501932c82. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->