### PR TITLE
Fix path containment check bug (#8761)

### DIFF
--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -95,7 +95,7 @@ export function getReadablePath(cwd: string, relPath?: string): string {
 	} else {
 		// show the relative path to the cwd
 		const normalizedRelPath = path.relative(cwd, absolutePath)
-		if (absolutePath.includes(cwd)) {
+		if (isLocatedInPath(cwd, absolutePath)) {
 			return normalizedRelPath.toPosix()
 		} else {
 			// we are outside the cwd, so show the absolute path (useful for when cline passes in '../../' for example)


### PR DESCRIPTION
## Summary

Fixes #8761 - Path containment check uses string.includes() causing false positives

## Bug Description

When working in a project directory that shares a prefix with another directory, Cline incorrectly identifies file locations.

Example:
- Workspace: /home/user/project
- File: /home/user/project-backup/src/file.txt

**Before:** The file was incorrectly identified as inside the workspace because  matched the prefix.

**After:** Properly identifies the file as outside the workspace using  which checks actual path boundaries.

## Changes

- **src/utils/path.ts:** Replace  with 
- **src/utils/path.test.ts:** Add regression tests for bug #8761

## Testing

Added new test cases:
- Verify similar path prefixes don't match (project vs project-backup)
- Verify isLocatedInPath handles empty paths
- Verify proper containment detection

Fixes #8761
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes path containment bug by replacing `includes()` with `isLocatedInPath()` in `path.ts`, ensuring accurate path boundary checks.
> 
>   - **Behavior**:
>     - Fixes path containment check bug by replacing `includes()` with `isLocatedInPath()` in `getReadablePath()` in `path.ts`.
>     - Properly identifies files outside the workspace even with similar path prefixes.
>   - **Testing**:
>     - Adds regression tests in `path.test.ts` for similar path prefixes and empty paths.
>     - Verifies `isLocatedInPath()` handles paths inside, outside, and with similar prefixes correctly.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 8177547280474bacee1ee1dd4415e52d5482722c. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->