### PR TITLE
fix: add missing call_id in anthropic stream handler

### DIFF
--- a/src/core/api/providers/anthropic.ts
+++ b/src/core/api/providers/anthropic.ts
@@ -97,9 +97,8 @@ export class AnthropicHandler implements ApiHandler {
 								"anthropic-beta": "context-1m-2025-08-07",
 							},
 						}
-					} else {
-						return undefined
 					}
+					return undefined
 				})(),
 			)
 		} else {
@@ -217,6 +216,7 @@ export class AnthropicHandler implements ApiHandler {
 									type: "tool_calls",
 									tool_call: {
 										...lastStartedToolCall,
+										call_id: lastStartedToolCall.id,
 										function: {
 											...lastStartedToolCall,
 											id: lastStartedToolCall.id,

--- a/src/core/api/transform/tool-call-processor.ts
+++ b/src/core/api/transform/tool-call-processor.ts
@@ -48,6 +48,7 @@ export class ToolCallProcessor {
 					type: "tool_calls",
 					tool_call: {
 						...toolCallDelta,
+						call_id: this.lastToolCall.id,
 						function: {
 							...toolCallDelta.function,
 							id: this.lastToolCall.id,
@@ -74,7 +75,7 @@ export class ToolCallProcessor {
 	}
 }
 
-export function getOpenAIToolParams(tools?: OpenAITool[], enableParallelToolCalls: boolean = false) {
+export function getOpenAIToolParams(tools?: OpenAITool[], enableParallelToolCalls = false) {
 	return tools?.length
 		? {
 				tools,


### PR DESCRIPTION
## Summary

- The Anthropic stream handler did not set `call_id` when yielding `tool_calls` chunks during streaming, unlike other providers (Bedrock, OpenAI Native, OpenAI Codex) which all set it correctly.
- This caused `toolUseIdMap` in `TaskState` to never be populated for Anthropic API calls, since the condition `chunk.tool_call.function?.id && chunk.tool_call.call_id` always failed.
- As a result, tool results were created as `{type: "text"}` blocks (via the `"cline"` fallback path) instead of proper `{type: "tool_result"}` blocks, and `ContextManager.ensureToolResultsFollowToolUse()` backfilled placeholder `tool_result` blocks with `content: "result missing"`.

The fix adds `call_id: lastStartedToolCall.id` to the yielded `tool_call` object, consistent with how other providers handle it.

## Test plan

- [ ] Verify tool results are properly formatted as `tool_result` blocks (not `text` blocks) when using the Anthropic provider
- [ ] Confirm no `"result missing"` placeholders appear in API request messages
- [ ] Check that multi-tool-use responses correctly map each result to its corresponding tool_use
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes missing `call_id` in `AnthropicHandler` to ensure proper tool result formatting.
> 
>   - **Behavior**:
>     - Adds `call_id: lastStartedToolCall.id` to `tool_call` object in `createMessage()` in `anthropic.ts`.
>     - Fixes issue where `toolUseIdMap` in `TaskState` was not populated for Anthropic API calls.
>     - Ensures tool results are formatted as `{type: "tool_result"}` blocks instead of `{type: "text"}` blocks.
>   - **Testing**:
>     - Verify tool results are `tool_result` blocks with Anthropic provider.
>     - Confirm no `"result missing"` placeholders in API messages.
>     - Check correct mapping of multi-tool-use responses to tool_use.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for ba548a4cb94ae06ab6b0f905f20c8a9bc9ae6404. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->