### PR TITLE
fix: Unbreak the Code Actions and Editor Panel test

### DIFF
--- a/src/test/e2e/utils/common.ts
+++ b/src/test/e2e/utils/common.ts
@@ -1,4 +1,4 @@
-import type { Locator, Page } from "@playwright/test"
+import type { Page } from "@playwright/test"
 
 export const openTab = async (_page: Page, tabName: string) => {
 	await _page
@@ -8,36 +8,20 @@ export const openTab = async (_page: Page, tabName: string) => {
 }
 
 export const addSelectedCodeToClineWebview = async (_page: Page) => {
-	const clickActionIfVisible = async (locator: Locator) => {
-		try {
-			await locator.waitFor({ state: "visible", timeout: 5000 })
-			await locator.click({ delay: 100 })
-			return true
-		} catch {
-			return false
-		}
-	}
-
 	await _page.locator("div:nth-child(4) > span > span").first().click()
 	await _page.getByRole("textbox", { name: "The editor is not accessible" }).press("ControlOrMeta+a")
 
 	// Open Code Actions via keyboard for cross-platform reliability
 	await _page.keyboard.press("ControlOrMeta+.")
+
 	// Target the explicit action instead of pressing Enter on the first item.
 	// The first item can vary by platform or diagnostics.
-	const addToClineOption = _page.getByRole("option", { name: /Add to Cline/i }).first()
-	const addToClineMenuItem = _page.getByRole("menuitem", { name: /Add to Cline/i }).first()
-
-	if (await clickActionIfVisible(addToClineOption)) {
-		return
-	}
-
-	if (await clickActionIfVisible(addToClineMenuItem)) {
-		return
-	}
-
-	// Fallback for unexpected code action UIs.
-	await _page.keyboard.press("Enter", { delay: 100 })
+	const addToCline = _page.getByText(/Add to Cline/i)
+	await addToCline.waitFor({ state: "visible" })
+	// For whatever reason, we need to move the mouse to make the context menu item clickable
+	await _page.mouse.move(10, 10)
+	await _page.mouse.move(20, 10)
+	await addToCline.click()
 }
 
 export const toggleNotifications = async (_page: Page) => {


### PR DESCRIPTION
### Description

This test is failing because of some change to the quick actions menu. I believe the existing code was often failing and falling back to hitting enter, but it is prone to timeouts because waiting 5s for the two locators consumes 10s of the available 20s test time.

Moving the mouse makes the item clickable. 🤷 

### Test Procedure

```
npm test
npx playwright test -c playwright.config.ts src/test/e2e/editor.test.ts
```
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes test failure in `addSelectedCodeToClineWebview` by ensuring the context menu item is clickable through mouse movement.
> 
>   - **Behavior**:
>     - Fixes test failure in `addSelectedCodeToClineWebview` by ensuring the context menu item is clickable.
>     - Removes `clickActionIfVisible` function and replaces it with mouse movement to make the item clickable.
>   - **Imports**:
>     - Removes unused `Locator` import from `common.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for c54147a9033ef71c8b37b2caccf6aaee39606fb2. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->