### PR TITLE
feat(telemetry): unify instruction-source activation tracking

### DIFF
--- a/src/core/slash-commands/index.ts
+++ b/src/core/slash-commands/index.ts
@@ -27,6 +27,7 @@ type FileBasedWorkflow = {
 	fullPath: string
 	fileName: string
 	isRemote: false
+	scope: "project" | "global"
 }
 
 type RemoteWorkflow = {
@@ -34,6 +35,7 @@ type RemoteWorkflow = {
 	fileName: string
 	isRemote: true
 	contents: string
+	scope: "remote"
 }
 
 type Workflow = FileBasedWorkflow | RemoteWorkflow
@@ -141,6 +143,13 @@ export async function parseSlashCommands(
 
 				// Track telemetry for builtin slash command usage
 				telemetryService.captureSlashCommandUsed(ulid, commandName, "builtin")
+				telemetryService.captureInstructionSourceActivated({
+					ulid,
+					sourceType: "builtin",
+					sourceName: commandName,
+					activationPath: "slash",
+					sourceScope: "first_party",
+				})
 
 				return { processedText: processedText, needsClinerulesFileCheck: commandName === "newrule" }
 			}
@@ -166,6 +175,13 @@ export async function parseSlashCommands(
 
 							// Track telemetry for MCP prompt usage
 							telemetryService.captureSlashCommandUsed(ulid, commandName, "mcp_prompt")
+							telemetryService.captureInstructionSourceActivated({
+								ulid,
+								sourceType: "mcp_prompt",
+								sourceName: commandName,
+								activationPath: "slash",
+								sourceScope: "remote",
+							})
 
 							return { processedText, needsClinerulesFileCheck: false }
 						}
@@ -189,6 +205,13 @@ export async function parseSlashCommands(
 							textWithoutSlashCommand
 
 						telemetryService.captureSlashCommandUsed(ulid, commandName, "skill")
+						telemetryService.captureInstructionSourceActivated({
+							ulid,
+							sourceType: "skill",
+							sourceName: matchingSkill.name,
+							activationPath: "slash",
+							sourceScope: matchingSkill.source === "global" ? "global" : "project",
+						})
 
 						return { processedText, needsClinerulesFileCheck: false }
 					}
@@ -203,6 +226,7 @@ export async function parseSlashCommands(
 					fullPath: filePath,
 					fileName: filePath.replace(/^.*[/\\]/, ""),
 					isRemote: false,
+					scope: "global",
 				}))
 
 			const localWorkflows: Workflow[] = Object.entries(localWorkflowToggles)
@@ -211,6 +235,7 @@ export async function parseSlashCommands(
 					fullPath: filePath,
 					fileName: filePath.replace(/^.*[/\\]/, ""),
 					isRemote: false,
+					scope: "project",
 				}))
 
 			// Get remote workflows from remote config (if state manager is initialized)
@@ -235,6 +260,7 @@ export async function parseSlashCommands(
 					fileName: workflow.name,
 					isRemote: true,
 					contents: workflow.contents,
+					scope: "remote",
 				}))
 
 			// local workflows have precedence over global workflows, which have precedence over remote workflows
@@ -263,6 +289,13 @@ export async function parseSlashCommands(
 
 					// Track telemetry for workflow command usage
 					telemetryService.captureSlashCommandUsed(ulid, commandName, "workflow")
+					telemetryService.captureInstructionSourceActivated({
+						ulid,
+						sourceType: "workflow",
+						sourceName: matchingWorkflow.fileName,
+						activationPath: "slash",
+						sourceScope: matchingWorkflow.scope,
+					})
 
 					return { processedText, needsClinerulesFileCheck: false }
 				} catch (error) {

--- a/src/core/task/tools/handlers/UseSkillToolHandler.ts
+++ b/src/core/task/tools/handlers/UseSkillToolHandler.ts
@@ -89,6 +89,18 @@ export class UseSkillToolHandler implements IToolHandler, IPartialBlockHandler {
 				"UseSkillToolHandler.execute",
 			)
 
+			telemetryService.safeCapture(
+				() =>
+					telemetryService.captureInstructionSourceActivated({
+						ulid: config.ulid,
+						sourceType: "skill",
+						sourceName: skillContent.name,
+						activationPath: "use_skill",
+						sourceScope: skillContent.source === "global" ? "global" : "project",
+					}),
+				"UseSkillToolHandler.execute",
+			)
+
 			return `# Skill "${skillContent.name}" is now active
 
 ${skillContent.instructions}

--- a/src/services/telemetry/TelemetryService.test.ts
+++ b/src/services/telemetry/TelemetryService.test.ts
@@ -581,5 +581,38 @@ describe("Telemetry system is abstracted and can easily switch between providers
 			logSpy.restore()
 			await noOpProvider.dispose()
 		})
+
+		it("should capture instruction source activation events correctly", async () => {
+			const noOpProvider = new NoOpTelemetryProvider()
+			const logSpy = sinon.spy(noOpProvider, "log")
+			const telemetryService = new TelemetryService([noOpProvider], MOCK_METADATA)
+
+			logSpy.resetHistory()
+
+			telemetryService.captureInstructionSourceActivated({
+				ulid: "task-999",
+				sourceType: "skill",
+				sourceName: "release-checklist",
+				activationPath: "slash",
+				sourceScope: "global",
+			})
+
+			assert.ok(logSpy.calledOnce, "Log should be called once")
+			const [eventName, properties] = logSpy.firstCall.args
+			assert.strictEqual(
+				eventName,
+				"task.instruction_source_activated",
+				"Event name should be task.instruction_source_activated",
+			)
+			assert.ok(properties, "Properties should be defined")
+			assert.strictEqual(properties.ulid, "task-999", "Properties should include task ULID")
+			assert.strictEqual(properties.sourceType, "skill", "Properties should include sourceType")
+			assert.strictEqual(properties.sourceName, "release-checklist", "Properties should include sourceName")
+			assert.strictEqual(properties.activationPath, "slash", "Properties should include activationPath")
+			assert.strictEqual(properties.sourceScope, "global", "Properties should include sourceScope")
+
+			logSpy.restore()
+			await noOpProvider.dispose()
+		})
 	})
 })

--- a/src/services/telemetry/TelemetryService.ts
+++ b/src/services/telemetry/TelemetryService.ts
@@ -264,6 +264,8 @@ export class TelemetryService {
 			AUTO_COMPACT: "task.summarize_task",
 			// Tracks when slash commands or workflows are activated
 			SLASH_COMMAND_USED: "task.slash_command_used",
+			// Tracks when an instruction source is resolved and activated (slash or tool path)
+			INSTRUCTION_SOURCE_ACTIVATED: "task.instruction_source_activated",
 			// Tracks when a feature is toggled on/off
 			FEATURE_TOGGLED: "task.feature_toggled",
 			// Tracks when individual Cline rules are toggled on/off
@@ -1578,6 +1580,39 @@ export class TelemetryService {
 				ulid,
 				commandName,
 				commandType,
+			},
+		})
+	}
+
+	/**
+	 * Records the resolved instruction source that was activated.
+	 * This normalizes telemetry across slash-command activation and tool-based activation paths.
+	 *
+	 * @param ulid Unique identifier for the task
+	 * @param sourceType The resolved instruction source type
+	 * @param sourceName The resolved source name
+	 * @param activationPath How the source was activated
+	 * @param sourceScope Optional scope/origin of the source
+	 */
+	public captureInstructionSourceActivated(args: {
+		ulid: string
+		sourceType: "builtin" | "workflow" | "mcp_prompt" | "skill"
+		sourceName: string
+		activationPath: "slash" | "use_skill"
+		sourceScope?: "first_party" | "project" | "global" | "remote"
+	}) {
+		if (!args.ulid || !args.sourceName) {
+			return
+		}
+
+		this.capture({
+			event: TelemetryService.EVENTS.TASK.INSTRUCTION_SOURCE_ACTIVATED,
+			properties: {
+				ulid: args.ulid,
+				sourceType: args.sourceType,
+				sourceName: args.sourceName,
+				activationPath: args.activationPath,
+				sourceScope: args.sourceScope,
 			},
 		})
 	}


### PR DESCRIPTION
### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** #XXXX

### Description

This is a follow-up PR to `feat: enable direct skill slash commands with skill-first precedence` (`#9281`) and targets `codex/skill-slash-commands`.

Problem:
- Skill activation telemetry is currently split by invocation path:
  - Slash path emits `task.slash_command_used`.
  - `use_skill` tool path emits `task.skill_used`.
- This makes migration analytics harder when measuring movement from workflows to skills because there is no single normalized activation signal.

What this PR adds:
- New canonical activation event: `task.instruction_source_activated`.
- New telemetry helper: `captureInstructionSourceActivated(...)` in `TelemetryService`.
- Emission from slash resolution in `parseSlashCommands` for:
  - `builtin`
  - `mcp_prompt`
  - `skill`
  - `workflow`
- Emission from `UseSkillToolHandler` for `use_skill` activation path.

Why this approach is preferable:
- Preserves existing telemetry and dashboards (`task.slash_command_used`, `task.skill_used`) with no breaking changes.
- Adds a single normalized event for “what instruction source actually activated,” independent of trigger path.
- Improves migration tracking for workflow deprecation by allowing one queryable stream across slash + tool flows.

### Test Procedure

I used a local targeted feedback loop with grep-based tests:

1. Slash command parsing coverage (existing behavior still intact):
   - `TS_NODE_PROJECT=./tsconfig.unit-test.json npx mocha src/core/slash-commands/__tests__/index.test.ts --grep "parseSlashCommands skill handling"`
   - Result: `3 passing`

2. New telemetry event coverage:
   - `TS_NODE_PROJECT=./tsconfig.unit-test.json npx mocha src/services/telemetry/TelemetryService.test.ts --grep "instruction source activation events correctly"`
   - Result: `1 passing`

What could break and checks performed:
- Existing slash telemetry compatibility: unchanged existing event emission paths remain in place.
- Skill tool flow compatibility: existing `captureSkillUsed` remains and now additionally emits normalized activation event.
- Workflow/skill behavior: unchanged execution behavior; this PR only adds telemetry emission and metadata plumbing.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A (no UI changes).

### Additional Notes

- Base branch: `codex/skill-slash-commands`
- This PR intentionally keeps existing events and adds a normalized event in parallel to avoid telemetry regressions.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `task.instruction_source_activated` event to unify skill activation telemetry across different invocation paths.
> 
>   - **Behavior**:
>     - Adds `task.instruction_source_activated` event to unify skill activation telemetry.
>     - Updates `parseSlashCommands` to emit `task.instruction_source_activated` for `builtin`, `mcp_prompt`, `skill`, and `workflow`.
>     - Updates `UseSkillToolHandler` to emit `task.instruction_source_activated` for `use_skill` path.
>   - **Functions**:
>     - Adds `captureInstructionSourceActivated(...)` to `TelemetryService`.
>   - **Tests**:
>     - Adds test for `captureInstructionSourceActivated` in `TelemetryService.test.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for f69c58c5d34340e5527dae843bcd62a70f57dad6. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->