### PR TITLE
docs: add security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,27 @@
+# Security Policy
+
+## Supported Versions
+
+We actively patch only the most recent minor release of Cline. Older versions receive fixes at our discretion.
+
+## Reporting a Vulnerability
+
+We appreciate your efforts to responsibly disclose your findings and will make every effort to acknowledge your contributions.
+
+To report a security issue, please use the GitHub Security Advisory ["Report a Vulnerability"](https://github.com/cline/cline/security/advisories/new) tab.
+
+The team will send a response indicating the next steps in handling your report. After the initial reply, the security team will keep you informed of the progress towards a fix and full announcement, and may ask for additional information or guidance.
+
+When reporting, please include:
+
+- A short summary of the issue
+- Steps to reproduce or a proof of concept
+- Any logs, stack traces, or screenshots that might help us understand the problem
+
+We acknowledge reports within 48 hours and aim to release a fix or mitigation within 30 days. While we work on a resolution, please keep the details private.
+
+## Escalation
+
+If you do not receive an acknowledgement of your report within 5 business days, you may send an email to security@cline.bot.
+
+Thank you for helping us keep Cline users safe.


### PR DESCRIPTION
## Summary

Adds a SECURITY.md to the repo root with a standard security policy covering:

- Supported versions (latest minor release only)
- How to report vulnerabilities via GitHub Security Advisories
- What to include in a report
- Response timeline (48h acknowledgement, 30-day fix target)
- Escalation path (security@cline.bot) if no response within 5 business days
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `SECURITY.md` with security policy, including reporting process, response timeline, and escalation path.
> 
>   - **Security Policy**:
>     - Adds `SECURITY.md` to repo root with security policy.
>     - Covers supported versions (latest minor release only).
>     - Details vulnerability reporting via GitHub Security Advisories.
>     - Specifies report contents: summary, reproduction steps, logs.
>     - Response timeline: 48h acknowledgement, 30-day fix target.
>     - Escalation path: email security@cline.bot if no response in 5 business days.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 23622df3f393e235be47f60a035349647ed7d675. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->