### PR TITLE
fix(prompt): add proactive skeleton guidance to write_to_file tool description

### DIFF
--- a/.changeset/write-to-file-skeleton-guidance.md
+++ b/.changeset/write-to-file-skeleton-guidance.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Add proactive guidance to write_to_file tool description advising models to write a skeleton first and use replace_in_file incrementally when file content is too large for a single response

--- a/src/core/prompts/system-prompt/__tests__/__snapshots__/anthropic_claude_sonnet_4-basic.snap
+++ b/src/core/prompts/system-prompt/__tests__/__snapshots__/anthropic_claude_sonnet_4-basic.snap
@@ -50,7 +50,7 @@ Usage:
 </read_file>
 
 ## write_to_file
-Description: Request to write content to a file at the specified path. If the file exists, it will be overwritten with the provided content. If the file doesn't exist, it will be created. This tool will automatically create any directories needed to write the file.
+Description: Request to write content to a file at the specified path. If the file exists, it will be overwritten with the provided content. If the file doesn't exist, it will be created. This tool will automatically create any directories needed to write the file. If the file content is too large to generate in a single response, write a skeleton first (just imports, class/function signatures, no implementations), then use replace_in_file to fill in each section incrementally.
 Parameters:
 - path: (required) The path of the file to write to (relative to the current working directory /test/project)
 - content: (required) The content to write to the file. ALWAYS provide the COMPLETE intended content of the file, without any truncation or omissions. You MUST include ALL parts of the file, even if they haven't been modified.

--- a/src/core/prompts/system-prompt/__tests__/__snapshots__/anthropic_claude_sonnet_4-no-browser.snap
+++ b/src/core/prompts/system-prompt/__tests__/__snapshots__/anthropic_claude_sonnet_4-no-browser.snap
@@ -50,7 +50,7 @@ Usage:
 </read_file>
 
 ## write_to_file
-Description: Request to write content to a file at the specified path. If the file exists, it will be overwritten with the provided content. If the file doesn't exist, it will be created. This tool will automatically create any directories needed to write the file.
+Description: Request to write content to a file at the specified path. If the file exists, it will be overwritten with the provided content. If the file doesn't exist, it will be created. This tool will automatically create any directories needed to write the file. If the file content is too large to generate in a single response, write a skeleton first (just imports, class/function signatures, no implementations), then use replace_in_file to fill in each section incrementally.
 Parameters:
 - path: (required) The path of the file to write to (relative to the current working directory /test/project)
 - content: (required) The content to write to the file. ALWAYS provide the COMPLETE intended content of the file, without any truncation or omissions. You MUST include ALL parts of the file, even if they haven't been modified.

--- a/src/core/prompts/system-prompt/__tests__/__snapshots__/anthropic_claude_sonnet_4-no-focus-chain.snap
+++ b/src/core/prompts/system-prompt/__tests__/__snapshots__/anthropic_claude_sonnet_4-no-focus-chain.snap
@@ -45,7 +45,7 @@ Usage:
 </read_file>
 
 ## write_to_file
-Description: Request to write content to a file at the specified path. If the file exists, it will be overwritten with the provided content. If the file doesn't exist, it will be created. This tool will automatically create any directories needed to write the file.
+Description: Request to write content to a file at the specified path. If the file exists, it will be overwritten with the provided content. If the file doesn't exist, it will be created. This tool will automatically create any directories needed to write the file. If the file content is too large to generate in a single response, write a skeleton first (just imports, class/function signatures, no implementations), then use replace_in_file to fill in each section incrementally.
 Parameters:
 - path: (required) The path of the file to write to (relative to the current working directory /test/project)
 - content: (required) The content to write to the file. ALWAYS provide the COMPLETE intended content of the file, without any truncation or omissions. You MUST include ALL parts of the file, even if they haven't been modified.

--- a/src/core/prompts/system-prompt/__tests__/__snapshots__/anthropic_claude_sonnet_4-no-mcp.snap
+++ b/src/core/prompts/system-prompt/__tests__/__snapshots__/anthropic_claude_sonnet_4-no-mcp.snap
@@ -50,7 +50,7 @@ Usage:
 </read_file>
 
 ## write_to_file
-Description: Request to write content to a file at the specified path. If the file exists, it will be overwritten with the provided content. If the file doesn't exist, it will be created. This tool will automatically create any directories needed to write the file.
+Description: Request to write content to a file at the specified path. If the file exists, it will be overwritten with the provided content. If the file doesn't exist, it will be created. This tool will automatically create any directories needed to write the file. If the file content is too large to generate in a single response, write a skeleton first (just imports, class/function signatures, no implementations), then use replace_in_file to fill in each section incrementally.
 Parameters:
 - path: (required) The path of the file to write to (relative to the current working directory /test/project)
 - content: (required) The content to write to the file. ALWAYS provide the COMPLETE intended content of the file, without any truncation or omissions. You MUST include ALL parts of the file, even if they haven't been modified.

--- a/src/core/prompts/system-prompt/__tests__/__snapshots__/cline_devstral-basic.snap
+++ b/src/core/prompts/system-prompt/__tests__/__snapshots__/cline_devstral-basic.snap
@@ -50,7 +50,7 @@ Usage:
 </read_file>
 
 ## write_to_file
-Description: Request to write content to a file at the specified path. If the file exists, it will be overwritten with the provided content. If the file doesn't exist, it will be created. This tool will automatically create any directories needed to write the file.
+Description: Request to write content to a file at the specified path. If the file exists, it will be overwritten with the provided content. If the file doesn't exist, it will be created. This tool will automatically create any directories needed to write the file. If the file content is too large to generate in a single response, write a skeleton first (just imports, class/function signatures, no implementations), then use replace_in_file to fill in each section incrementally.
 Parameters:
 - path: (required) The path of the file to write to (relative to the current working directory /test/project)
 - content: (required) The content to write to the file. ALWAYS provide the COMPLETE intended content of the file, without any truncation or omissions. You MUST include ALL parts of the file, even if they haven't been modified.

--- a/src/core/prompts/system-prompt/__tests__/__snapshots__/cline_devstral-no-browser.snap
+++ b/src/core/prompts/system-prompt/__tests__/__snapshots__/cline_devstral-no-browser.snap
@@ -50,7 +50,7 @@ Usage:
 </read_file>
 
 ## write_to_file
-Description: Request to write content to a file at the specified path. If the file exists, it will be overwritten with the provided content. If the file doesn't exist, it will be created. This tool will automatically create any directories needed to write the file.
+Description: Request to write content to a file at the specified path. If the file exists, it will be overwritten with the provided content. If the file doesn't exist, it will be created. This tool will automatically create any directories needed to write the file. If the file content is too large to generate in a single response, write a skeleton first (just imports, class/function signatures, no implementations), then use replace_in_file to fill in each section incrementally.
 Parameters:
 - path: (required) The path of the file to write to (relative to the current working directory /test/project)
 - content: (required) The content to write to the file. ALWAYS provide the COMPLETE intended content of the file, without any truncation or omissions. You MUST include ALL parts of the file, even if they haven't been modified.

--- a/src/core/prompts/system-prompt/__tests__/__snapshots__/cline_devstral-no-focus-chain.snap
+++ b/src/core/prompts/system-prompt/__tests__/__snapshots__/cline_devstral-no-focus-chain.snap
@@ -45,7 +45,7 @@ Usage:
 </read_file>
 
 ## write_to_file
-Description: Request to write content to a file at the specified path. If the file exists, it will be overwritten with the provided content. If the file doesn't exist, it will be created. This tool will automatically create any directories needed to write the file.
+Description: Request to write content to a file at the specified path. If the file exists, it will be overwritten with the provided content. If the file doesn't exist, it will be created. This tool will automatically create any directories needed to write the file. If the file content is too large to generate in a single response, write a skeleton first (just imports, class/function signatures, no implementations), then use replace_in_file to fill in each section incrementally.
 Parameters:
 - path: (required) The path of the file to write to (relative to the current working directory /test/project)
 - content: (required) The content to write to the file. ALWAYS provide the COMPLETE intended content of the file, without any truncation or omissions. You MUST include ALL parts of the file, even if they haven't been modified.

--- a/src/core/prompts/system-prompt/__tests__/__snapshots__/cline_devstral-no-mcp.snap
+++ b/src/core/prompts/system-prompt/__tests__/__snapshots__/cline_devstral-no-mcp.snap
@@ -50,7 +50,7 @@ Usage:
 </read_file>
 
 ## write_to_file
-Description: Request to write content to a file at the specified path. If the file exists, it will be overwritten with the provided content. If the file doesn't exist, it will be created. This tool will automatically create any directories needed to write the file.
+Description: Request to write content to a file at the specified path. If the file exists, it will be overwritten with the provided content. If the file doesn't exist, it will be created. This tool will automatically create any directories needed to write the file. If the file content is too large to generate in a single response, write a skeleton first (just imports, class/function signatures, no implementations), then use replace_in_file to fill in each section incrementally.
 Parameters:
 - path: (required) The path of the file to write to (relative to the current working directory /test/project)
 - content: (required) The content to write to the file. ALWAYS provide the COMPLETE intended content of the file, without any truncation or omissions. You MUST include ALL parts of the file, even if they haven't been modified.

--- a/src/core/prompts/system-prompt/__tests__/__snapshots__/cline_native_next_gen.tools.snap
+++ b/src/core/prompts/system-prompt/__tests__/__snapshots__/cline_native_next_gen.tools.snap
@@ -84,7 +84,7 @@
     "type": "function",
     "function": {
       "name": "write_to_file",
-      "description": "[IMPORTANT: Always output the absolutePath first] Request to write content to a file at the specified path. If the file exists, it will be overwritten with the provided content. If the file doesn't exist, it will be created. This tool will automatically create any directories needed to write the file.",
+      "description": "[IMPORTANT: Always output the absolutePath first] Request to write content to a file at the specified path. If the file exists, it will be overwritten with the provided content. If the file doesn't exist, it will be created. This tool will automatically create any directories needed to write the file. If the file content is too large to generate in a single response, write a skeleton first (just imports, class/function signatures, no implementations), then use replace_in_file to fill in each section incrementally.",
       "strict": false,
       "parameters": {
         "type": "object",

--- a/src/core/prompts/system-prompt/__tests__/__snapshots__/openai_gpt_3-basic.snap
+++ b/src/core/prompts/system-prompt/__tests__/__snapshots__/openai_gpt_3-basic.snap
@@ -50,7 +50,7 @@ Usage:
 </read_file>
 
 ## write_to_file
-Description: Request to write content to a file at the specified path. If the file exists, it will be overwritten with the provided content. If the file doesn't exist, it will be created. This tool will automatically create any directories needed to write the file.
+Description: Request to write content to a file at the specified path. If the file exists, it will be overwritten with the provided content. If the file doesn't exist, it will be created. This tool will automatically create any directories needed to write the file. If the file content is too large to generate in a single response, write a skeleton first (just imports, class/function signatures, no implementations), then use replace_in_file to fill in each section incrementally.
 Parameters:
 - path: (required) The path of the file to write to (relative to the current working directory /test/project)
 - content: (required) The content to write to the file. ALWAYS provide the COMPLETE intended content of the file, without any truncation or omissions. You MUST include ALL parts of the file, even if they haven't been modified.

--- a/src/core/prompts/system-prompt/__tests__/__snapshots__/openai_gpt_3-no-browser.snap
+++ b/src/core/prompts/system-prompt/__tests__/__snapshots__/openai_gpt_3-no-browser.snap
@@ -50,7 +50,7 @@ Usage:
 </read_file>
 
 ## write_to_file
-Description: Request to write content to a file at the specified path. If the file exists, it will be overwritten with the provided content. If the file doesn't exist, it will be created. This tool will automatically create any directories needed to write the file.
+Description: Request to write content to a file at the specified path. If the file exists, it will be overwritten with the provided content. If the file doesn't exist, it will be created. This tool will automatically create any directories needed to write the file. If the file content is too large to generate in a single response, write a skeleton first (just imports, class/function signatures, no implementations), then use replace_in_file to fill in each section incrementally.
 Parameters:
 - path: (required) The path of the file to write to (relative to the current working directory /test/project)
 - content: (required) The content to write to the file. ALWAYS provide the COMPLETE intended content of the file, without any truncation or omissions. You MUST include ALL parts of the file, even if they haven't been modified.

--- a/src/core/prompts/system-prompt/__tests__/__snapshots__/openai_gpt_3-no-focus-chain.snap
+++ b/src/core/prompts/system-prompt/__tests__/__snapshots__/openai_gpt_3-no-focus-chain.snap
@@ -45,7 +45,7 @@ Usage:
 </read_file>
 
 ## write_to_file
-Description: Request to write content to a file at the specified path. If the file exists, it will be overwritten with the provided content. If the file doesn't exist, it will be created. This tool will automatically create any directories needed to write the file.
+Description: Request to write content to a file at the specified path. If the file exists, it will be overwritten with the provided content. If the file doesn't exist, it will be created. This tool will automatically create any directories needed to write the file. If the file content is too large to generate in a single response, write a skeleton first (just imports, class/function signatures, no implementations), then use replace_in_file to fill in each section incrementally.
 Parameters:
 - path: (required) The path of the file to write to (relative to the current working directory /test/project)
 - content: (required) The content to write to the file. ALWAYS provide the COMPLETE intended content of the file, without any truncation or omissions. You MUST include ALL parts of the file, even if they haven't been modified.

--- a/src/core/prompts/system-prompt/__tests__/__snapshots__/openai_gpt_3-no-mcp.snap
+++ b/src/core/prompts/system-prompt/__tests__/__snapshots__/openai_gpt_3-no-mcp.snap
@@ -50,7 +50,7 @@ Usage:
 </read_file>
 
 ## write_to_file
-Description: Request to write content to a file at the specified path. If the file exists, it will be overwritten with the provided content. If the file doesn't exist, it will be created. This tool will automatically create any directories needed to write the file.
+Description: Request to write content to a file at the specified path. If the file exists, it will be overwritten with the provided content. If the file doesn't exist, it will be created. This tool will automatically create any directories needed to write the file. If the file content is too large to generate in a single response, write a skeleton first (just imports, class/function signatures, no implementations), then use replace_in_file to fill in each section incrementally.
 Parameters:
 - path: (required) The path of the file to write to (relative to the current working directory /test/project)
 - content: (required) The content to write to the file. ALWAYS provide the COMPLETE intended content of the file, without any truncation or omissions. You MUST include ALL parts of the file, even if they haven't been modified.

--- a/src/core/prompts/system-prompt/__tests__/__snapshots__/openai_gpt_5-basic.snap
+++ b/src/core/prompts/system-prompt/__tests__/__snapshots__/openai_gpt_5-basic.snap
@@ -50,7 +50,7 @@ Usage:
 </read_file>
 
 ## write_to_file
-Description: Request to write content to a file at the specified path. If the file exists, it will be overwritten with the provided content. If the file doesn't exist, it will be created. This tool will automatically create any directories needed to write the file.
+Description: Request to write content to a file at the specified path. If the file exists, it will be overwritten with the provided content. If the file doesn't exist, it will be created. This tool will automatically create any directories needed to write the file. If the file content is too large to generate in a single response, write a skeleton first (just imports, class/function signatures, no implementations), then use replace_in_file to fill in each section incrementally.
 Parameters:
 - path: (required) The path of the file to write to (relative to the current working directory /test/project)
 - content: (required) The content to write to the file. ALWAYS provide the COMPLETE intended content of the file, without any truncation or omissions. You MUST include ALL parts of the file, even if they haven't been modified.

--- a/src/core/prompts/system-prompt/__tests__/__snapshots__/openai_gpt_5-no-browser.snap
+++ b/src/core/prompts/system-prompt/__tests__/__snapshots__/openai_gpt_5-no-browser.snap
@@ -50,7 +50,7 @@ Usage:
 </read_file>
 
 ## write_to_file
-Description: Request to write content to a file at the specified path. If the file exists, it will be overwritten with the provided content. If the file doesn't exist, it will be created. This tool will automatically create any directories needed to write the file.
+Description: Request to write content to a file at the specified path. If the file exists, it will be overwritten with the provided content. If the file doesn't exist, it will be created. This tool will automatically create any directories needed to write the file. If the file content is too large to generate in a single response, write a skeleton first (just imports, class/function signatures, no implementations), then use replace_in_file to fill in each section incrementally.
 Parameters:
 - path: (required) The path of the file to write to (relative to the current working directory /test/project)
 - content: (required) The content to write to the file. ALWAYS provide the COMPLETE intended content of the file, without any truncation or omissions. You MUST include ALL parts of the file, even if they haven't been modified.

--- a/src/core/prompts/system-prompt/__tests__/__snapshots__/openai_gpt_5-no-focus-chain.snap
+++ b/src/core/prompts/system-prompt/__tests__/__snapshots__/openai_gpt_5-no-focus-chain.snap
@@ -45,7 +45,7 @@ Usage:
 </read_file>
 
 ## write_to_file
-Description: Request to write content to a file at the specified path. If the file exists, it will be overwritten with the provided content. If the file doesn't exist, it will be created. This tool will automatically create any directories needed to write the file.
+Description: Request to write content to a file at the specified path. If the file exists, it will be overwritten with the provided content. If the file doesn't exist, it will be created. This tool will automatically create any directories needed to write the file. If the file content is too large to generate in a single response, write a skeleton first (just imports, class/function signatures, no implementations), then use replace_in_file to fill in each section incrementally.
 Parameters:
 - path: (required) The path of the file to write to (relative to the current working directory /test/project)
 - content: (required) The content to write to the file. ALWAYS provide the COMPLETE intended content of the file, without any truncation or omissions. You MUST include ALL parts of the file, even if they haven't been modified.

--- a/src/core/prompts/system-prompt/__tests__/__snapshots__/openai_gpt_5-no-mcp.snap
+++ b/src/core/prompts/system-prompt/__tests__/__snapshots__/openai_gpt_5-no-mcp.snap
@@ -50,7 +50,7 @@ Usage:
 </read_file>
 
 ## write_to_file
-Description: Request to write content to a file at the specified path. If the file exists, it will be overwritten with the provided content. If the file doesn't exist, it will be created. This tool will automatically create any directories needed to write the file.
+Description: Request to write content to a file at the specified path. If the file exists, it will be overwritten with the provided content. If the file doesn't exist, it will be created. This tool will automatically create any directories needed to write the file. If the file content is too large to generate in a single response, write a skeleton first (just imports, class/function signatures, no implementations), then use replace_in_file to fill in each section incrementally.
 Parameters:
 - path: (required) The path of the file to write to (relative to the current working directory /test/project)
 - content: (required) The content to write to the file. ALWAYS provide the COMPLETE intended content of the file, without any truncation or omissions. You MUST include ALL parts of the file, even if they haven't been modified.

--- a/src/core/prompts/system-prompt/__tests__/__snapshots__/openrouter_arcee_ai_trinity_large_preview-basic.snap
+++ b/src/core/prompts/system-prompt/__tests__/__snapshots__/openrouter_arcee_ai_trinity_large_preview-basic.snap
@@ -59,7 +59,7 @@ Usage:
 </read_file>
 
 ## write_to_file
-Description: Request to write content to a file at the specified path. If the file exists, it will be overwritten with the provided content. If the file doesn't exist, it will be created. This tool will automatically create any directories needed to write the file.
+Description: Request to write content to a file at the specified path. If the file exists, it will be overwritten with the provided content. If the file doesn't exist, it will be created. This tool will automatically create any directories needed to write the file. If the file content is too large to generate in a single response, write a skeleton first (just imports, class/function signatures, no implementations), then use replace_in_file to fill in each section incrementally.
 Parameters:
 - path: (required) The path of the file to write to (relative to the current working directory /test/project)
 - content: (required) The content to write to the file. ALWAYS provide the COMPLETE intended content of the file, without any truncation or omissions. You MUST include ALL parts of the file, even if they haven't been modified.

--- a/src/core/prompts/system-prompt/__tests__/__snapshots__/openrouter_arcee_ai_trinity_large_preview-no-browser.snap
+++ b/src/core/prompts/system-prompt/__tests__/__snapshots__/openrouter_arcee_ai_trinity_large_preview-no-browser.snap
@@ -59,7 +59,7 @@ Usage:
 </read_file>
 
 ## write_to_file
-Description: Request to write content to a file at the specified path. If the file exists, it will be overwritten with the provided content. If the file doesn't exist, it will be created. This tool will automatically create any directories needed to write the file.
+Description: Request to write content to a file at the specified path. If the file exists, it will be overwritten with the provided content. If the file doesn't exist, it will be created. This tool will automatically create any directories needed to write the file. If the file content is too large to generate in a single response, write a skeleton first (just imports, class/function signatures, no implementations), then use replace_in_file to fill in each section incrementally.
 Parameters:
 - path: (required) The path of the file to write to (relative to the current working directory /test/project)
 - content: (required) The content to write to the file. ALWAYS provide the COMPLETE intended content of the file, without any truncation or omissions. You MUST include ALL parts of the file, even if they haven't been modified.

--- a/src/core/prompts/system-prompt/__tests__/__snapshots__/openrouter_arcee_ai_trinity_large_preview-no-focus-chain.snap
+++ b/src/core/prompts/system-prompt/__tests__/__snapshots__/openrouter_arcee_ai_trinity_large_preview-no-focus-chain.snap
@@ -54,7 +54,7 @@ Usage:
 </read_file>
 
 ## write_to_file
-Description: Request to write content to a file at the specified path. If the file exists, it will be overwritten with the provided content. If the file doesn't exist, it will be created. This tool will automatically create any directories needed to write the file.
+Description: Request to write content to a file at the specified path. If the file exists, it will be overwritten with the provided content. If the file doesn't exist, it will be created. This tool will automatically create any directories needed to write the file. If the file content is too large to generate in a single response, write a skeleton first (just imports, class/function signatures, no implementations), then use replace_in_file to fill in each section incrementally.
 Parameters:
 - path: (required) The path of the file to write to (relative to the current working directory /test/project)
 - content: (required) The content to write to the file. ALWAYS provide the COMPLETE intended content of the file, without any truncation or omissions. You MUST include ALL parts of the file, even if they haven't been modified.

--- a/src/core/prompts/system-prompt/__tests__/__snapshots__/openrouter_arcee_ai_trinity_large_preview-no-mcp.snap
+++ b/src/core/prompts/system-prompt/__tests__/__snapshots__/openrouter_arcee_ai_trinity_large_preview-no-mcp.snap
@@ -59,7 +59,7 @@ Usage:
 </read_file>
 
 ## write_to_file
-Description: Request to write content to a file at the specified path. If the file exists, it will be overwritten with the provided content. If the file doesn't exist, it will be created. This tool will automatically create any directories needed to write the file.
+Description: Request to write content to a file at the specified path. If the file exists, it will be overwritten with the provided content. If the file doesn't exist, it will be created. This tool will automatically create any directories needed to write the file. If the file content is too large to generate in a single response, write a skeleton first (just imports, class/function signatures, no implementations), then use replace_in_file to fill in each section incrementally.
 Parameters:
 - path: (required) The path of the file to write to (relative to the current working directory /test/project)
 - content: (required) The content to write to the file. ALWAYS provide the COMPLETE intended content of the file, without any truncation or omissions. You MUST include ALL parts of the file, even if they haven't been modified.

--- a/src/core/prompts/system-prompt/__tests__/__snapshots__/vertex_gemini3.tools.snap
+++ b/src/core/prompts/system-prompt/__tests__/__snapshots__/vertex_gemini3.tools.snap
@@ -38,7 +38,7 @@
   },
   {
     "name": "write_to_file",
-    "description": "Request to write content to a file at the specified path. If the file exists, it will be overwritten with the provided content. If the file doesn't exist, it will be created. This tool will automatically create any directories needed to write the file.",
+    "description": "Request to write content to a file at the specified path. If the file exists, it will be overwritten with the provided content. If the file doesn't exist, it will be created. This tool will automatically create any directories needed to write the file. If the file content is too large to generate in a single response, write a skeleton first (just imports, class/function signatures, no implementations), then use replace_in_file to fill in each section incrementally.",
     "parameters": {
       "type": "OBJECT",
       "properties": {

--- a/src/core/prompts/system-prompt/tools/write_to_file.ts
+++ b/src/core/prompts/system-prompt/tools/write_to_file.ts
@@ -29,7 +29,7 @@ const GENERIC: ClineToolSpec = {
 	id,
 	name: "write_to_file",
 	description:
-		"Request to write content to a file at the specified path. If the file exists, it will be overwritten with the provided content. If the file doesn't exist, it will be created. This tool will automatically create any directories needed to write the file.",
+		"Request to write content to a file at the specified path. If the file exists, it will be overwritten with the provided content. If the file doesn't exist, it will be created. This tool will automatically create any directories needed to write the file. If the file content is too large to generate in a single response, write a skeleton first (just imports, class/function signatures, no implementations), then use replace_in_file to fill in each section incrementally.",
 	parameters: [
 		{
 			name: "path",
@@ -53,7 +53,7 @@ const NATIVE_NEXT_GEN: ClineToolSpec = {
 	id,
 	name: "write_to_file",
 	description:
-		"[IMPORTANT: Always output the absolutePath first] Request to write content to a file at the specified path. If the file exists, it will be overwritten with the provided content. If the file doesn't exist, it will be created. This tool will automatically create any directories needed to write the file.",
+		"[IMPORTANT: Always output the absolutePath first] Request to write content to a file at the specified path. If the file exists, it will be overwritten with the provided content. If the file doesn't exist, it will be created. This tool will automatically create any directories needed to write the file. If the file content is too large to generate in a single response, write a skeleton first (just imports, class/function signatures, no implementations), then use replace_in_file to fill in each section incrementally.",
 	parameters: [
 		{
 			name: "absolutePath",


### PR DESCRIPTION
## Problem

When `write_to_file` fails due to output token limits (content parameter arrives empty), the model has no upfront guidance about alternative strategies. It only learns about the skeleton + replace_in_file approach *after* failing, via the error response. This means the first failure is essentially wasted — the model has to fail before it gets the advice.

**Related issues:** #7998, #7863, #8051, #8739, #7965

## Solution

Add proactive guidance directly to the `write_to_file` tool description so the model knows *before* attempting a write that large files should use the skeleton + replace_in_file strategy. This is a single sentence appended to the tool description:

> If the file content is too large to generate in a single response, write a skeleton first (just imports, class/function signatures, no implementations), then use replace_in_file to fill in each section incrementally.

Updated for both `GENERIC` and `NATIVE_NEXT_GEN` tool spec variants (which covers all model families via fallback).

## Changes

- **`src/core/prompts/system-prompt/tools/write_to_file.ts`** — Appended skeleton guidance to GENERIC and NATIVE_NEXT_GEN tool descriptions
- **22 snapshot files** — Updated to reflect the new tool description text
- **Changeset** — Patch version bump

## Test Procedure

```bash
npm run test:unit -- --grep "write_to_file"
npm run test:unit -- --grep "PromptRegistry"
```

All tests passing. Snapshots updated via `UPDATE_SNAPSHOTS=true npm run test:unit`.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Pre-flight Checklist

- [x] Changes are limited to a single feature, bugfix or chore
- [x] Tests are passing
- [x] I have created a changeset using `npm run changeset`
- [x] I have reviewed contributor guidelines

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds proactive guidance to `write_to_file` tool description for handling large file content by suggesting a skeleton approach, with updates to tool descriptions and snapshots.
> 
>   - **Behavior**:
>     - Appended guidance to `write_to_file` tool description in `write_to_file.ts` for handling large file content by suggesting a skeleton approach.
>     - Updated descriptions for both `GENERIC` and `NATIVE_NEXT_GEN` variants.
>   - **Snapshots**:
>     - Updated 22 snapshot files to reflect the new tool description text.
>   - **Misc**:
>     - Patch version bump in changeset.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 2ff9e4ded66883db3695d33d3bdfbd38a602c554. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->