### PR TITLE
docs: add MCP server support documentation for Cline CLI

### DIFF
--- a/docs/cline-cli/configuration.mdx
+++ b/docs/cline-cli/configuration.mdx
@@ -73,6 +73,8 @@ Cline stores configuration in `~/.cline/data/`:
 ├── data/                    # Configuration directory
 │   ├── globalState.json     # Global settings
 │   ├── secrets.json         # API keys (encrypted)
+│   ├── settings/            # Settings files
+│   │   └── cline_mcp_settings.json  # MCP server configuration
 │   ├── workspace/           # Workspace-specific state
 │   └── tasks/               # Task history and data
 └── log/                     # Log files
@@ -171,6 +173,46 @@ cline --config ~/.cline-work "review this PR"
 # Personal projects
 cline --config ~/.cline-personal "help me with this side project"
 ```
+
+## MCP Server Configuration
+
+Cline CLI supports [MCP (Model Context Protocol)](/mcp/mcp-overview) servers, giving you access to external tools and data sources directly from the terminal. The CLI uses the same MCP configuration format as the VS Code extension.
+
+### Setting Up MCP Servers
+
+To configure MCP servers for the CLI, create or edit the settings file at:
+
+```
+~/.cline/data/settings/cline_mcp_settings.json
+```
+
+The file uses the same JSON format as the VS Code extension:
+
+```json
+{
+  "mcpServers": {
+    "my-server": {
+      "command": "node",
+      "args": ["/path/to/server.js"],
+      "env": {
+        "API_KEY": "your_api_key"
+      },
+      "alwaysAllow": ["tool1", "tool2"],
+      "disabled": false
+    }
+  }
+}
+```
+
+For the full configuration reference including STDIO and SSE transport types, see [Configuring MCP Servers](/mcp/configuring-mcp-servers).
+
+<Note>
+The CLI does not yet have a `/mcp` slash command for managing MCP servers interactively. For now, you'll need to edit the `cline_mcp_settings.json` file directly.
+</Note>
+
+### Custom Config Directory
+
+If you use the `CLINE_DIR` environment variable or `--config` flag, the MCP settings file will be located at `<your-config-dir>/settings/cline_mcp_settings.json` instead.
 
 ## Configuration for Local Providers
 

--- a/docs/cline-cli/overview.mdx
+++ b/docs/cline-cli/overview.mdx
@@ -198,6 +198,15 @@ Chains multiple Cline invocations together for creative multi-step workflows.
 | Session summary | ✓ | - |
 | JSON output | - | `--json` |
 | Piped input | - | ✓ |
+| [MCP servers](/cline-cli/configuration#mcp-server-configuration) | ✓ | ✓ |
+
+## MCP Server Support
+
+Cline CLI supports [MCP (Model Context Protocol)](/mcp/mcp-overview) servers, the same extensibility system available in the VS Code extension. MCP servers give Cline access to external tools and data sources — from databases and APIs to browser automation and project management.
+
+To use MCP servers with the CLI, add your server configuration to `~/.cline/data/settings/cline_mcp_settings.json`. The format is identical to the VS Code extension.
+
+[Configure MCP servers for the CLI →](/cline-cli/configuration#mcp-server-configuration)
 
 ## Learn More
 

--- a/docs/mcp/configuring-mcp-servers.mdx
+++ b/docs/mcp/configuring-mcp-servers.mdx
@@ -55,9 +55,21 @@ To set the maximum time to wait for a response after a tool call to the MCP serv
 
 Settings for all installed MCP servers are located in the `cline_mcp_settings.json` file:
 
+**In VS Code:**
+
 1. Click the MCP Servers icon at the top navigation bar of the Cline pane.
 2. Select the "Configure" tab.
 3. Click the "Configure MCP Servers" button at the bottom of the pane.
+
+**In Cline CLI:**
+
+The CLI uses the same configuration format. Edit the file directly at:
+
+```
+~/.cline/data/settings/cline_mcp_settings.json
+```
+
+For more details on CLI-specific setup, see [CLI MCP Configuration](/cline-cli/configuration#mcp-server-configuration).
 
 The file uses a JSON format with a `mcpServers` object containing named server configurations:
 


### PR DESCRIPTION
## Summary

Adds documentation for MCP server support in Cline CLI, which is currently undocumented. Users can use MCPs from the CLI by configuring `~/.cline/data/settings/cline_mcp_settings.json`, but there was no way to discover this.

## Changes

### `docs/cline-cli/configuration.mdx`
- Added `settings/cline_mcp_settings.json` to the configuration directory tree
- Added new **MCP Server Configuration** section with setup instructions, JSON format example, and note about the missing `/mcp` slash command

### `docs/cline-cli/overview.mdx`
- Added **MCP Server Support** section explaining MCP availability in the CLI
- Added MCP servers row to the **Features at a Glance** table

### `docs/mcp/configuring-mcp-servers.mdx`
- Added **Cline CLI** instructions under the "Editing MCP Settings Files" section with the CLI file path

### Cross-linking
All three pages link to each other so users can navigate between CLI overview → CLI config → MCP docs in any direction.

Closes #9385
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds documentation for MCP server support in Cline CLI, including setup instructions and cross-links between relevant documentation pages.
> 
>   - **Documentation**:
>     - Adds `MCP Server Configuration` section in `configuration.mdx` with setup instructions and JSON format example for `cline_mcp_settings.json`.
>     - Adds `MCP Server Support` section in `overview.mdx` explaining MCP availability and configuration in the CLI.
>     - Updates `configuring-mcp-servers.mdx` with CLI-specific instructions for editing `cline_mcp_settings.json`.
>   - **Cross-linking**:
>     - Links between `configuration.mdx`, `overview.mdx`, and `configuring-mcp-servers.mdx` for easy navigation between CLI overview, configuration, and MCP documentation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for a910487be70fa46d741b960d5eb67b5c419f847d. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->