### PR TITLE
fix(models): reinstate minimax m2.5 free promo surfaces

### DIFF
--- a/.changeset/minimax-free-return.md
+++ b/.changeset/minimax-free-return.md
@@ -1,0 +1,5 @@
+---
+"cline": patch
+---
+
+Reinstate MiniMax M2.5 free promo surfaces across Cline, including free pricing behavior, featured model lists, banner CTA, What's New promo copy, and onboarding free model selection.

--- a/cli/src/constants/featured-models.ts
+++ b/cli/src/constants/featured-models.ts
@@ -33,6 +33,12 @@ export const FEATURED_MODELS: { recommended: FeaturedModel[]; free: FeaturedMode
 	],
 	free: [
 		{
+			id: "minimax/minimax-m2.5",
+			name: "MiniMax M2.5",
+			description: "MiniMax-M2.5 is a lightweight, state-of-the-art LLM optimized for coding and agentic workflows",
+			labels: ["FREE"],
+		},
+		{
 			id: "z-ai/glm-5",
 			name: "Z-AI GLM5",
 			description: "Z.AI's latest GLM 5 model with strong coding and agent performance",

--- a/src/core/api/providers/cline.ts
+++ b/src/core/api/providers/cline.ts
@@ -30,7 +30,7 @@ interface ClineHandlerOptions extends CommonApiHandlerOptions {
 	clineApiKey?: string
 }
 
-const CLINE_FREE_MODELS = ["kwaipilot/kat-coder-pro", "z-ai/glm-5"]
+const CLINE_FREE_MODELS = ["minimax/minimax-m2.5", "kwaipilot/kat-coder-pro", "z-ai/glm-5"]
 
 export class ClineHandler implements ApiHandler {
 	private options: ClineHandlerOptions

--- a/src/shared/cline/banner.ts
+++ b/src/shared/cline/banner.ts
@@ -104,6 +104,23 @@ export const BANNER_DATA: BannerCardData[] = [
 		],
 	},
 
+	// Minimax free promo banner
+	{
+		// Bump this version string when copy/CTA changes and you want the banner to reappear.
+		id: "minimax-m2.5-free-2026-feb-18",
+		icon: "zap",
+		title: "Try MiniMax M2.5 Free",
+		description: "SOTA coding capability with lightning fast inference, free in Cline.",
+		actions: [
+			{
+				title: "Try now",
+				action: BannerActionType.SetModel,
+				arg: "minimax/minimax-m2.5",
+				tab: "free",
+			},
+		],
+	},
+
 	// ChatGPT integration banner
 	{
 		id: "chatgpt-integration-v1",

--- a/src/shared/cline/onboarding.ts
+++ b/src/shared/cline/onboarding.ts
@@ -23,6 +23,22 @@ export const CLINE_ONBOARDING_MODELS: OnboardingModel[] = [
 	},
 	{
 		group: "free",
+		id: "minimax/minimax-m2.5",
+		name: "MiniMax: MiniMax M2.5",
+		score: 90,
+		latency: 2,
+		badge: "New",
+		info: {
+			contextWindow: 192_000,
+			supportsImages: false,
+			supportsPromptCache: true,
+			inputPrice: 0,
+			outputPrice: 0,
+			tiers: [],
+		},
+	},
+	{
+		group: "free",
 		id: "arcee-ai/trinity-large-preview:free",
 		name: "Arcee AI: Trinity Large Preview",
 		score: 88,

--- a/webview-ui/src/components/common/WhatsNewModal.tsx
+++ b/webview-ui/src/components/common/WhatsNewModal.tsx
@@ -89,6 +89,10 @@ export const WhatsNewModal: React.FC<WhatsNewModalProps> = ({ open, onClose, ver
 							promo! <InlineModelLink label="Try now" modelId="z-ai/glm-5" pickerTab="free" />
 						</li>
 						<li className="mb-2">
+							<strong>MiniMax M2.5:</strong> SOTA coding capability with lightning fast inference, now available
+							with free promo! <InlineModelLink label="Try now" modelId="minimax/minimax-m2.5" pickerTab="free" />
+						</li>
+						<li className="mb-2">
 							<strong>Cline CLI 2.0:</strong> Major upgrade bringing interactive and autonomous agentic coding to
 							your terminal. Install with <code style={inlineCodeStyle}>npm install -g cline</code>
 							<a

--- a/webview-ui/src/components/settings/OpenRouterModelPicker.tsx
+++ b/webview-ui/src/components/settings/OpenRouterModelPicker.tsx
@@ -59,6 +59,11 @@ export const recommendedModels = [
 		label: "BEST",
 	},
 	{
+		id: "minimax/minimax-m2.5",
+		description: "Great coding capability and subagent use",
+		label: "HOT",
+	},
+	{
 		id: "anthropic/claude-opus-4.6",
 		description: "Most intelligent model for agents and coding",
 		label: "NEW",
@@ -76,6 +81,11 @@ export const recommendedModels = [
 ]
 
 export const freeModels = [
+	{
+		id: "minimax/minimax-m2.5",
+		description: "MiniMax-M2.5 is a lightweight, state-of-the-art LLM optimized for coding and agentic workflows",
+		label: "FREE",
+	},
 	{
 		id: "z-ai/glm-5",
 		description: "Z.AI's latest GLM 5 model with strong coding and agent performance",


### PR DESCRIPTION
### Related Issue

Issue: N/A
Follow-up context: #9361 and #9377

### Description

This PR restores MiniMax M2.5 free-promo surfaces after we removed them in #9361.

After that removal, we confirmed MiniMax M2.5 is still intended to be free. This PR brings it back in the same high-visibility places users rely on for discovery and free-model behavior, and also restores it in onboarding free selection.

What was restored

1. Free pricing behavior in Cline provider
- `src/core/api/providers/cline.ts`
- Added `minimax/minimax-m2.5` back to `CLINE_FREE_MODELS` so usage cost is overridden to zero for this model.

2. Featured model surfaces
- `webview-ui/src/components/settings/OpenRouterModelPicker.tsx`
  - Added MiniMax M2.5 back to `recommendedModels`.
  - Added MiniMax M2.5 back to `freeModels`.
- `cli/src/constants/featured-models.ts`
  - Added MiniMax M2.5 back to free featured models.

3. Banner promo surface
- `src/shared/cline/banner.ts`
- Added a MiniMax M2.5 free promo banner with CTA routing to the `free` tab.

4. What’s New modal promo surface
- `webview-ui/src/components/common/WhatsNewModal.tsx`
- Added MiniMax M2.5 free promo line item and link to the free tab.

5. Onboarding free models
- `src/shared/cline/onboarding.ts`
- Added MiniMax M2.5 into the free onboarding group (similar class of surfacing as other free models).

How I identified scope

- Used commit history and blame on the removal commit:
  - `36c68a6ab` removed the original MiniMax promo surfaces.
- Cross-checked earlier commits where MiniMax was introduced/promoted:
  - `7896e6d89`, `955ae2f62`, and `ecde79cf0`.
- Restored only the MiniMax-specific pieces while preserving the current Sonnet 4.6 default/not-free direction from #9377.

Non-obvious decision

- I did not revert Sonnet-related free behavior while restoring MiniMax.
- This keeps current product intent intact: Sonnet 4.6 remains non-free/default as merged in #9377, while MiniMax M2.5 is restored as free.

### Test Procedure

1. Static checks
- `git diff --name-only | rg '\\.(ts|tsx)$' | xargs npx biome check --diagnostic-level=error --no-errors-on-unmatched`
- Result: pass

2. Unit tests
- `npm run -s test:unit -- src/core/api/providers/__tests__/claude-code.test.ts`
- In this repo this command runs the broader suite
- Result: `1014 passing, 4 pending`

3. Manual verification points from diff
- MiniMax M2.5 is present in free-model arrays and promo surfaces.
- Free pricing override path includes MiniMax M2.5 again.
- Onboarding now includes MiniMax M2.5 in free group.

### Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ♻️ Refactor Changes
- [x] 💅 Cosmetic Changes
- [ ] 📚 Documentation update
- [ ] 🏃 Workflow Changes

### Pre-flight Checklist

- [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
- [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
- [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
- [ ] I have reviewed contributor guidelines

### Screenshots

No screenshots included.

### Additional Notes

Changeset added:
- `.changeset/minimax-free-return.md`

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Reinstates MiniMax M2.5 as a free model across pricing, featured lists, banners, and onboarding.
> 
>   - **Behavior**:
>     - Restores MiniMax M2.5 to `CLINE_FREE_MODELS` in `cline.ts` for free pricing.
>     - Adds MiniMax M2.5 to `recommendedModels` and `freeModels` in `OpenRouterModelPicker.tsx`.
>     - Includes MiniMax M2.5 in `FEATURED_MODELS` in `featured-models.ts`.
>   - **UI Components**:
>     - Adds MiniMax M2.5 promo banner in `banner.ts`.
>     - Updates `WhatsNewModal.tsx` to include MiniMax M2.5 promo.
>     - Restores MiniMax M2.5 in onboarding models in `onboarding.ts`.
>   - **Misc**:
>     - Adds changeset file `minimax-free-return.md` for documentation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for fa28807b995d06d988f628a4afbaadf7af4b2c1c. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->