### PR TITLE
Release-Eng: Changelog generator script

### DIFF
--- a/scripts/release/cline-generate-changelog.sh
+++ b/scripts/release/cline-generate-changelog.sh
@@ -106,15 +106,21 @@ fi
 
 echo "Gathering PR list..." >&2
 # shellcheck disable=SC2086
-PR_LIST=$("${SCRIPT_DIR}/gh-list-prs-since-last-release.sh" ${TAG_FLAG} 2>/dev/null)
+if ! PR_LIST=$("${SCRIPT_DIR}/gh-list-prs-since-last-release.sh" ${TAG_FLAG}); then
+  echo "Error: Failed to gather PR list (see above for details)." >&2
+  exit 1
+fi
 
 echo "Gathering first-time contributor PRs..." >&2
 # shellcheck disable=SC2086
-FIRST_TIME_PRS=$("${SCRIPT_DIR}/gh-first-time-contributors.sh" ${TAG_FLAG} ${DEBUG_FLAG} 2>/dev/null)
+if ! FIRST_TIME_PRS=$("${SCRIPT_DIR}/gh-first-time-contributors.sh" ${TAG_FLAG} ${DEBUG_FLAG}); then
+  echo "Warning: Could not gather first-time contributor data; continuing without it." >&2
+  FIRST_TIME_PRS=""
+fi
 
 if [ -z "${PR_LIST}" ]; then
-  echo "Error: No PRs found since last release." >&2
-  exit 1
+  echo "(No PR references found since last release — nothing to generate.)" >&2
+  exit 0
 fi
 
 # ---------------------------------------------------------------------------
@@ -188,8 +194,14 @@ Format requirements:
 echo "Generating ${SCOPE} changelog with cline (model: ${MODEL})..." >&2
 echo "" >&2
 
-RAW_OUTPUT=$(cline -a -y --timeout 120 -m "${MODEL}" "${PROMPT}")
-CHANGELOG=$(echo "${RAW_OUTPUT}" | sed -n '/^## /,$p')
+if ! RAW_OUTPUT=$(cline -a -y --timeout 120 -m "${MODEL}" "${PROMPT}"); then
+  echo "Error: cline task failed or timed out. Verify your auth with 'cline auth' and try again." >&2
+  exit 1
+fi
+
+# Strip any markdown code fences a model may have wrapped the output in,
+# then extract from the first section header to end.
+CHANGELOG=$(echo "${RAW_OUTPUT}" | sed '/^```/d' | sed -n '/^## /,$p')
 
 if [ -z "${CHANGELOG}" ]; then
   if [ -z "${RAW_OUTPUT}" ]; then

--- a/scripts/release/gh-first-time-contributors.sh
+++ b/scripts/release/gh-first-time-contributors.sh
@@ -151,8 +151,9 @@ process_window() {
     echo "[debug] ${newer}: PR objects fetched: $(echo "${pr_list}" | jq 'length')" >&2
   fi
 
+  # Filter out PRs with null authors (deleted GitHub accounts) before extracting logins
   local authors
-  authors=$(echo "${pr_list}" | jq -r '.[].author.login' | sort -u)
+  authors=$(echo "${pr_list}" | jq -r '[.[].author | select(. != null) | .login] | unique | .[]')
 
   if [ -z "${authors}" ]; then
     echo "- (no PR authors found)"

--- a/scripts/release/gh-list-prs-since-last-release.sh
+++ b/scripts/release/gh-list-prs-since-last-release.sh
@@ -57,6 +57,13 @@ if [ -z "${FROM_TAG}" ]; then
   exit 1
 fi
 
+# Validate the tag/ref exists before using it
+if ! git rev-parse --verify --quiet "${FROM_TAG}^{}" >/dev/null 2>&1 && \
+   ! git rev-parse --verify --quiet "${FROM_TAG}" >/dev/null 2>&1; then
+  echo "Error: '${FROM_TAG}' is not a valid tag or revision in this repository." >&2
+  exit 1
+fi
+
 echo "Generating changelog since ${FROM_TAG}..." >&2
 
 # Get repo owner and name from remote
@@ -69,7 +76,12 @@ QUERY_BODY=$(git log --first-parent --pretty=%s "${FROM_TAG}..${BASE_REF}" |
   grep -Eo '#[0-9]+' |
   tr -d '#' |
   sort -un |
-  awk '{printf "pr%s: pullRequest(number: %s) { number title url } ", $1, $1}')
+  awk '{printf "pr%s: pullRequest(number: %s) { number title url } ", $1, $1}' || true)
+
+if [ -z "${QUERY_BODY}" ]; then
+  echo "No PR references found in merge commits since ${FROM_TAG}." >&2
+  exit 0
+fi
 
 # gh exits 1 when GitHub returns partial results alongside an errors array
 # (e.g. a merge commit subject references an issue number, not a PR).


### PR DESCRIPTION
### Related Issue

**Issue:** OPS-265

### Description

Adds three bash scripts to scripts/release/ that automate changelog generation for each Cline release using the Cline CLI itself.

How it works:

* `gh-list-prs-since-last-release.sh` — Determines which PRs are in the git history in `main` since the latest release tag.

* `gh-first-time-contributors.sh` — Determines which PRs represent an author's first-ever contributions in this repo.

* `cline-generate-changelog.sh` — Uses the two `gh-*.sh` scripts, then feeds their output to the cline CLI with a structured prompt to synthesize a consistently formatted changelog.  Expects `--scope vscode` or `--scope cli` to produces entries appropriate for either `cline/CHANGELOG.md` or `cline/cli/CHANGELOG.md`.


### Test Procedure

Run the scripts.  Notably, we want to run the `cline-generate-changelog.sh` script, which drives the other two helper scripts.  The typical usage pattern is to run the script with the defaults in order to generate a changelog that's useful for the regular (weekly) release process.

Basic usage:
```bash
# Current release (from latest tag to now — original behaviour, unchanged)
scripts/release/cline-generate-changelog.sh --scope vscode

# From a specific tag to now
scripts/release/cline-generate-changelog.sh --scope vscode --from-tag v3.62.0

# Bounded past window (both tags specified)
scripts/release/cline-generate-changelog.sh --scope vscode --from-tag v3.63.0 --to-tag v3.64.0
```

To produce a CLI-specific changelog:
```bash
scripts/release/cline-generate-changelog.sh --scope cli
```


You'll see output like the following:
```
scripts/release/cline-generate-changelog.sh --scope vscode
Gathering PR list...
Generating changelog from v3.64.0 to main...
Gathering first-time contributor PRs...
Finding first-time contributor PRs since v3.64.0 (through main)...
Generating vscode changelog with cline (model: claude-sonnet-4-6, timeout: 120s)...

## Added
- MiniMax M2.5 model support
- `/skills` slash command (CLI feature, but included as it may be relevant)

## Fixed
- Smarter retry logic for write_to_file tool
- Error messages when displaying featured models in CLI
- Telemetry reporting for versions > 2.0

## Changed
- Removed deprecated Cerebras models
- Disabled auto-condense threshold setting (now hardcoded)

The changelog excludes purely internal changes like the security policy documentation (#9365) and focuses on user-facing improvements to the extension experience.
```

From there the release commander is responsible for copy-pasting the Added/Fixed/Changed to the appropriate changelog doc.


### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

n/a

### Additional Notes

n/a
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds scripts to automate changelog generation for Cline releases, identifying merged PRs and first-time contributors, and generating formatted changelogs using the Cline CLI.
> 
>   - **Scripts Added**:
>     - `cline-generate-changelog.sh`: Automates changelog generation using Cline CLI, supports `--scope` for VSCode or CLI changelogs.
>     - `gh-list-prs-since-last-release.sh`: Lists PRs merged into `main` since the last release tag.
>     - `gh-first-time-contributors.sh`: Identifies first-time contributor PRs, supports single and multi-window modes.
>   - **Functionality**:
>     - `cline-generate-changelog.sh` uses `gh-list-prs-since-last-release.sh` and `gh-first-time-contributors.sh` to gather data and generate a formatted changelog.
>     - Supports `--from-tag`, `--to-tag`, and `--debug` options for custom ranges and debugging.
>     - Handles missing tags in shallow clones by requiring `git fetch --tags`.
>   - **Error Handling**:
>     - Validates required dependencies (`git`, `gh`, `jq`, `cline`).
>     - Checks for valid tags and handles errors in data fetching gracefully.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for a7476753d6095716e7e44dbabf4a319b0208a86d. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->