### PR TITLE
fix: include root workspace so changesets can version claude-dev

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
 			"version": "3.64.0",
 			"license": "Apache-2.0",
 			"workspaces": [
+				".",
 				"cli"
 			],
 			"dependencies": {
@@ -10287,6 +10288,10 @@
 			"resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
 			"integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==",
 			"license": "MIT"
+		},
+		"node_modules/claude-dev": {
+			"resolved": "",
+			"link": true
 		},
 		"node_modules/clean-stack": {
 			"version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
 	"version": "3.64.0",
 	"icon": "assets/icons/icon.png",
 	"workspaces": [
+		".",
 		"cli"
 	],
 	"engines": {


### PR DESCRIPTION
## Summary
- add the repository root (`"."`) to npm workspaces in `package.json`
- align `package-lock.json` workspace metadata and add the root workspace link entry (`node_modules/claude-dev`)
- fix `changesets/action` failure where changesets targeting `claude-dev` errored with "not in the workspace"

## Validation
- `npx changeset status --verbose`
- `npm ci --dry-run`
