### PR TITLE
fix cline auth with acp flag

### DIFF
--- a/cli/src/agent/ClineAgent.ts
+++ b/cli/src/agent/ClineAgent.ts
@@ -1161,7 +1161,11 @@ export class ClineAgent implements acp.Agent {
 
 		if (currentProvider === "cline") {
 			// For Cline provider, check if we have stored auth data
-			return Boolean(stateManager.getSecretKey("clineApiKey") || stateManager.getSecretKey("clineAccountId"))
+			return Boolean(
+				stateManager.getSecretKey("clineApiKey") ||
+					stateManager.getSecretKey("clineAccountId") ||
+					stateManager.getSecretKey("cline:clineAccountId"),
+			)
 		}
 
 		// For OpenAI Codex provider, check OAuth credentials


### PR DESCRIPTION
- was missing a check for "cline:clineAccountId" in the isAuthed method of acp agent


Testing steps:
1. add this to your ~/.config/zed/settings.json:
    ```
      "agent_servers": {
        "cline": {
          "type": "custom",
          "command": "cline",
          "args": ["--acp"],
        },
     },

2. open an acp session with cline (see video)


https://github.com/user-attachments/assets/7804640d-edaa-4144-94c6-358b4669a4a1


https://github.com/user-attachments/assets/54b88732-4e58-4c5a-b285-fcc3b4fde6f4



<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes authentication check in `ClineAgent.ts` by adding support for `cline:clineAccountId` in `isAuthConfigured()` method.
> 
>   - **Behavior**:
>     - Fixes authentication check in `isAuthConfigured()` in `ClineAgent.ts` by adding a check for `cline:clineAccountId`.
>     - Ensures compatibility with environments using either `cline:clineAccountId` or legacy `clineAccountId` keys.
>   - **Misc**:
>     - Updates comment in `isAuthConfigured()` to reflect the new key check.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for e63e1a44627e3bca8c58c80ec6c92708da060a0d. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->