### PR TITLE
feat: add dynamic flag to adjust banner cache duration

### DIFF
--- a/src/services/banner/__tests__/BannerService.test.ts
+++ b/src/services/banner/__tests__/BannerService.test.ts
@@ -14,6 +14,7 @@ import { HostRegistryInfo } from "@/registry"
 import { AuthService } from "@/services/auth/AuthService"
 import { getFeatureFlagsService } from "@/services/feature-flags"
 import { mockFetchForTesting } from "@/shared/net"
+import { FeatureFlag } from "@/shared/services/feature-flags/feature-flags"
 import { Logger } from "@/shared/services/Logger"
 import { BannerService } from "../BannerService"
 
@@ -31,6 +32,7 @@ describe("BannerService", () => {
 
 	let mockedPostStateToWebview: sinon.SinonStub
 	let mockController: Controller
+	let flagPayloadStub: sinon.SinonStub
 
 	beforeEach(() => {
 		sandbox = sinon.createSandbox()
@@ -45,6 +47,11 @@ describe("BannerService", () => {
 
 		// Mock feature flag service to enable remote banners
 		sandbox.stub(getFeatureFlagsService(), "getBooleanFlagEnabled").returns(true)
+		flagPayloadStub = sandbox
+			.stub(getFeatureFlagsService(), "getFlagPayload")
+			.callsFake((flag: FeatureFlag) =>
+				flag === FeatureFlag.EXTENSION_REMOTE_BANNERS_TTL ? 24 * 60 * 60 * 1000 : undefined,
+			)
 
 		// Default state manager configuration
 		mockStateManagerConfig = {
@@ -165,8 +172,11 @@ describe("BannerService", () => {
 			})
 		})
 
-		it("should cache banners for 24 hours", async () => {
+		it("should cache banners for the configured hours from PostHog", async () => {
 			const clock = sandbox.useFakeTimers(Date.now())
+			flagPayloadStub.callsFake((flag: FeatureFlag) =>
+				flag === FeatureFlag.EXTENSION_REMOTE_BANNERS_TTL ? 4 * 60 * 60 * 1000 : undefined,
+			)
 
 			const mockResponse = {
 				data: {
@@ -205,13 +215,57 @@ describe("BannerService", () => {
 				await clock.tickAsync(0)
 				expect(mockFetch.callCount).to.equal(1)
 
-				// After 23 hours total, still uses cache
-				await clock.tickAsync(22 * 60 * 60 * 1000)
+				// After 3 hours total, still uses cache
+				await clock.tickAsync(2 * 60 * 60 * 1000)
 				bannerService.getActiveBanners()
 				await clock.tickAsync(0)
 				expect(mockFetch.callCount).to.equal(1)
 
-				// After 25 hours total, cache expired, triggers new background fetch
+				// After 5 hours total, cache expired, triggers new background fetch
+				await clock.tickAsync(2 * 60 * 60 * 1000)
+				bannerService.getActiveBanners()
+				await clock.tickAsync(0)
+				expect(mockFetch.callCount).to.equal(2)
+			})
+
+			clock.restore()
+		})
+
+		it("should fall back to 24 hours when payload is invalid", async () => {
+			const clock = sandbox.useFakeTimers(Date.now())
+			flagPayloadStub.callsFake((flag: FeatureFlag) =>
+				flag === FeatureFlag.EXTENSION_REMOTE_BANNERS_TTL ? "invalid" : undefined,
+			)
+
+			const mockResponse = {
+				data: {
+					items: [
+						{
+							id: "bnr_cached",
+							titleMd: "Cached Banner",
+							bodyMd: "Test",
+							severity: "info" as const,
+							placement: "top" as const,
+							rulesJson: "{}",
+						},
+					],
+				},
+			}
+
+			mockFetch.resolves(createSuccessResponse(mockResponse))
+
+			await mockFetchForTesting(mockFetch, async () => {
+				const bannerService = BannerService.initialize(mockController)
+
+				bannerService.getActiveBanners()
+				await clock.tickAsync(0)
+				expect(mockFetch.callCount).to.equal(1)
+
+				await clock.tickAsync(23 * 60 * 60 * 1000)
+				bannerService.getActiveBanners()
+				await clock.tickAsync(0)
+				expect(mockFetch.callCount).to.equal(1)
+
 				await clock.tickAsync(2 * 60 * 60 * 1000)
 				bannerService.getActiveBanners()
 				await clock.tickAsync(0)

--- a/src/services/feature-flags/FeatureFlagsService.ts
+++ b/src/services/feature-flags/FeatureFlagsService.ts
@@ -102,6 +102,13 @@ export class FeatureFlagsService {
 		return this.cache.get(flagName) === true
 	}
 
+	/**
+	 * Get a cached flag payload (or default) without triggering a network call.
+	 */
+	public getFlagPayload(flagName: FeatureFlag): FeatureFlagPayload | undefined {
+		return this.cache.get(flagName) ?? FeatureFlagDefaultValue[flagName]
+	}
+
 	public getWebtoolsEnabled(): boolean {
 		return this.getBooleanFlagEnabled(FeatureFlag.WEBTOOLS)
 	}

--- a/src/shared/services/feature-flags/feature-flags.ts
+++ b/src/shared/services/feature-flags/feature-flags.ts
@@ -7,6 +7,8 @@ export enum FeatureFlag {
 	ONBOARDING_MODELS = "onboarding_models",
 	// Feature flag for remote banner service
 	REMOTE_BANNERS = "remote-banners",
+	// Feature flag payload (milliseconds) controlling remote banner cache TTL
+	EXTENSION_REMOTE_BANNERS_TTL = "extension_remote_banners_ttl",
 	// Feature flag for DB-backed welcome banners (What's New modal)
 	// When off, hardcoded welcome items are shown instead
 	REMOTE_WELCOME_BANNERS = "remote-welcome-banners",
@@ -17,6 +19,7 @@ export const FeatureFlagDefaultValue: Partial<Record<FeatureFlag, FeatureFlagPay
 	[FeatureFlag.WORKTREES]: false,
 	[FeatureFlag.ONBOARDING_MODELS]: process.env.E2E_TEST === "true" ? { models: {} } : undefined,
 	[FeatureFlag.REMOTE_BANNERS]: process.env.E2E_TEST === "true" || process.env.IS_DEV === "true",
+	[FeatureFlag.EXTENSION_REMOTE_BANNERS_TTL]: 24 * 60 * 60 * 1000,
 	[FeatureFlag.REMOTE_WELCOME_BANNERS]: process.env.E2E_TEST === "true" || process.env.IS_DEV === "true",
 }
 


### PR DESCRIPTION

### Related Issue

closes https://linear.app/cline-bot/issue/PF-503/decrease-banner-cache-duration-to-n-hours-from-24-hours-ensure-backend

flag here: https://us.posthog.com/project/132120/feature_flags/589940

### Description

This PR introduces a feature flag so we can lower the banner cache dynamically via posthog

### Test Procedure

<!-- 
Please walk us through your testing approach and thought process. This helps reviewers understand that you've thoroughly considered the impact of your changes:

- How did you test this change?
- What could potentially break and how did you verify it doesn't?
- What existing functionality might be affected and how did you check it still works?
- Why are you confident this is ready for merge?

We're not looking for exhaustive documentation - just evidence that you've thought through the implications of your changes and tested accordingly.
-->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add feature flag to dynamically adjust banner cache duration in `BannerService` using PostHog.
> 
>   - **Behavior**:
>     - Introduces `EXTENSION_REMOTE_BANNERS_TTL` feature flag in `feature-flags.ts` to dynamically adjust banner cache duration.
>     - Updates `BannerService.ts` to use `getCacheDurationMs()` for cache duration, defaulting to 24 hours if flag payload is invalid.
>   - **Tests**:
>     - Adds tests in `BannerService.test.ts` to verify cache duration adjustment based on feature flag payload and fallback behavior.
>   - **Feature Flags**:
>     - Adds `EXTENSION_REMOTE_BANNERS_TTL` to `FeatureFlag` enum and `FeatureFlagDefaultValue` in `feature-flags.ts`.
>     - Implements `getFlagPayload()` in `FeatureFlagsService.ts` to retrieve flag payloads.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 5c5e2ef88d0dd9a5ca194aea9159a994a19351fc. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->