### PR TITLE
fix(bedrock): handle thinking and redacted_thinking blocks in message conversion and streaming

### DIFF
--- a/src/core/api/providers/__tests__/bedrock.test.ts
+++ b/src/core/api/providers/__tests__/bedrock.test.ts
@@ -1163,5 +1163,63 @@ describe("AwsBedrockHandler", () => {
 			// Turn 4: toolResult
 			formatted[3].content?.[0]?.toolResult?.toolUseId?.should.equal("call-2")
 		})
+
+		it("should silently skip thinking blocks without warnings", () => {
+			const h = new AwsBedrockHandler(mockOptions)
+			const conversation: any[] = [
+				{
+					role: "assistant",
+					content: [
+						{ type: "thinking", thinking: "Let me reason about this...", signature: "sig123" },
+						{ type: "text", text: "Here is my response." },
+					],
+				},
+				{
+					role: "user",
+					content: [{ type: "text", text: "Thanks!" }],
+				},
+			]
+
+			const formatted = h["formatMessagesForConverseAPI"](conversation)
+
+			// Thinking block should be filtered out, only text remains
+			formatted[0].content?.should.have.length(1)
+			formatted[0].content?.[0]?.text?.should.equal("Here is my response.")
+			formatted[1].content?.[0]?.text?.should.equal("Thanks!")
+		})
+
+		it("should silently skip redacted_thinking blocks without warnings", () => {
+			const h = new AwsBedrockHandler(mockOptions)
+			const conversation: any[] = [
+				{
+					role: "assistant",
+					content: [
+						{ type: "redacted_thinking", data: "encrypted_data_here" },
+						{ type: "text", text: "Response after redacted thinking." },
+					],
+				},
+			]
+
+			const formatted = h["formatMessagesForConverseAPI"](conversation)
+
+			// Redacted thinking block should be filtered out
+			formatted[0].content?.should.have.length(1)
+			formatted[0].content?.[0]?.text?.should.equal("Response after redacted thinking.")
+		})
+
+		it("should handle messages with only thinking blocks by producing empty content", () => {
+			const h = new AwsBedrockHandler(mockOptions)
+			const conversation: any[] = [
+				{
+					role: "assistant",
+					content: [{ type: "thinking", thinking: "Internal reasoning only", signature: "sig456" }],
+				},
+			]
+
+			const formatted = h["formatMessagesForConverseAPI"](conversation)
+
+			// All content filtered out
+			formatted[0].content?.should.have.length(0)
+		})
 	})
 })

--- a/src/core/api/providers/bedrock.ts
+++ b/src/core/api/providers/bedrock.ts
@@ -65,14 +65,18 @@ interface ContentBlockStart {
 	start?: {
 		type?: string
 		thinking?: string
+		signature?: string
 		toolUse?: ToolUseStart
 	}
 	contentBlock?: {
 		type?: string
 		thinking?: string
+		signature?: string
 	}
 	type?: string
 	thinking?: string
+	// Redacted thinking block data
+	data?: string
 }
 
 // Define types for stream response deltas
@@ -82,6 +86,7 @@ interface ContentBlockDelta {
 		type?: string
 		thinking?: string
 		text?: string
+		signature?: string
 		reasoningContent?: {
 			text?: string
 		}
@@ -102,7 +107,7 @@ interface ToolUseDelta {
 }
 
 // Define types for supported content types
-type SupportedContentType = "text" | "image" | "thinking"
+type SupportedContentType = "text" | "image" | "thinking" | "redacted_thinking" | "document"
 
 interface ContentItem {
 	type: SupportedContentType
@@ -628,6 +633,7 @@ export class AwsBedrockHandler implements ApiHandler {
 									yield {
 										type: "reasoning",
 										reasoning: reasoningBlock.text,
+										...(reasoningBlock.signature ? { signature: reasoningBlock.signature } : {}),
 									}
 								}
 							}
@@ -680,15 +686,31 @@ export class AwsBedrockHandler implements ApiHandler {
 						) {
 							if (blockIndex !== undefined) {
 								blockTypes.set(blockIndex, "reasoning")
+								// Capture signature if provided at block start
+								const signature = blockStart.start?.signature || blockStart.contentBlock?.signature || undefined
 								// Initialize content if provided
 								const initialContent =
 									blockStart.start?.thinking || blockStart.contentBlock?.thinking || blockStart.thinking || ""
-								if (initialContent) {
+								if (initialContent || signature) {
 									yield {
 										type: "reasoning",
-										reasoning: initialContent,
+										reasoning: initialContent || "",
+										...(signature ? { signature } : {}),
 									}
 								}
+							}
+						}
+
+						// Handle redacted thinking blocks
+						if (
+							blockStart.start?.type === "redacted_thinking" ||
+							blockStart.contentBlock?.type === "redacted_thinking" ||
+							blockStart.type === "redacted_thinking"
+						) {
+							yield {
+								type: "reasoning",
+								reasoning: "[Redacted thinking block]",
+								...(blockStart.data ? { redacted_data: blockStart.data } : {}),
 							}
 						}
 					}
@@ -707,8 +729,16 @@ export class AwsBedrockHandler implements ApiHandler {
 							const blockType = blockTypes.get(blockIndex)
 							const delta = chunk.contentBlockDelta.delta as ContentBlockDelta["delta"]
 
+							// Handle signature delta - used to send thinking block signatures
+							if (delta?.type === "signature_delta" && delta?.signature) {
+								yield {
+									type: "reasoning",
+									reasoning: "", // reasoning text already sent via thinking_delta
+									signature: delta.signature,
+								}
+							}
 							// Handle thinking delta (Anthropic SDK format)
-							if (delta?.type === "thinking_delta" || delta?.thinking) {
+							else if (delta?.type === "thinking_delta" || delta?.thinking) {
 								const thinkingContent = delta.thinking || delta.text || ""
 								if (thinkingContent) {
 									yield {
@@ -957,6 +987,12 @@ export class AwsBedrockHandler implements ApiHandler {
 									input: item.input,
 								},
 							}
+						}
+
+						// Skip thinking blocks - Bedrock Converse API handles thinking via
+						// the thinking config parameter, not by replaying blocks in history
+						if (item.type === "thinking" || item.type === "redacted_thinking") {
+							return null
 						}
 
 						if (item.type === "tool_result") {


### PR DESCRIPTION
## Summary

Fixes #9269 — Thinking blocks missing in Bedrock Opus 4.6 with `WARN Unsupported content type: thinking`

## Problem

When using Bedrock with Opus 4.6 (and other thinking-enabled models), the `formatMessagesForConverseAPI()` function in `bedrock.ts` had no handler for `thinking` or `redacted_thinking` content blocks. These blocks from previous conversation turns fell through to the fallback case, triggering `Logger.warn("Unsupported content type: thinking")` and being silently dropped.

Additionally, the streaming handler was missing:
- Signature capture from thinking responses (needed for valid thinking block round-trips)
- `signature_delta` handling in `contentBlockDelta`
- `redacted_thinking` block handling in `contentBlockStart`

## Changes

### `src/core/api/providers/bedrock.ts`
- **Message conversion**: Added explicit `thinking` and `redacted_thinking` handlers in `formatMessagesForConverseAPI()` that silently skip these blocks (Bedrock Converse API handles thinking via the `thinking` config parameter, not by replaying blocks in history)
- **Streaming — signature capture**: Added `signature` field to reasoning chunks from `additionalModelResponseFields.thinkingResponse.reasoning[]`
- **Streaming — signature_delta**: Added `signature_delta` case in `contentBlockDelta` processing (matching the Anthropic provider pattern)
- **Streaming — redacted_thinking**: Added `redacted_thinking` detection in `contentBlockStart`
- **Interface updates**: Extended `ContentBlockStart`/`ContentBlockDelta` with `signature` and `data` fields
- **Type fix**: Added `redacted_thinking` and `document` to `SupportedContentType` union (fixes pre-existing type error)

### `src/core/api/providers/__tests__/bedrock.test.ts`
- 3 new tests for `formatMessagesForConverseAPI`:
  - Silently skips `thinking` blocks without warnings
  - Silently skips `redacted_thinking` blocks without warnings
  - Handles messages containing only thinking blocks (produces empty content)

## Testing

All **44 Bedrock tests pass** (41 existing + 3 new), biome lint passes, build compiles cleanly.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add handling for `thinking` and `redacted_thinking` blocks in Bedrock message conversion and streaming, with tests to ensure correct behavior.
> 
>   - **Message Conversion**:
>     - Add handlers for `thinking` and `redacted_thinking` in `formatMessagesForConverseAPI()` in `bedrock.ts` to skip these blocks.
>     - Extend `ContentBlockStart` and `ContentBlockDelta` with `signature` and `data` fields.
>     - Add `redacted_thinking` and `document` to `SupportedContentType`.
>   - **Streaming**:
>     - Capture `signature` from `thinking` responses in `executeConverseStream()` in `bedrock.ts`.
>     - Handle `signature_delta` in `contentBlockDelta`.
>     - Detect `redacted_thinking` in `contentBlockStart`.
>   - **Testing**:
>     - Add tests in `bedrock.test.ts` to ensure `thinking` and `redacted_thinking` blocks are skipped without warnings and handle messages with only thinking blocks.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 1f8ec2579ec6d1b9bbb6693893fda82bd9d35884. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->