### PR TITLE
feat: add timeout for presentAssistantMessage during streaming

### DIFF
--- a/src/core/task/index.ts
+++ b/src/core/task/index.ts
@@ -2618,6 +2618,14 @@ export class Task {
 			this.taskState.isStreaming = true
 			let didReceiveUsageChunk = false
 			let didFinalizeReasoningForUi = false
+			const presentAssistantMessageTimeoutMs = (() => {
+				const raw = process.env.CLINE_PRESENT_ASSISTANT_MESSAGE_TIMEOUT_MS
+				if (raw === undefined) {
+					return 1000
+				}
+				const parsed = Number.parseInt(raw, 10)
+				return Number.isFinite(parsed) && parsed > 0 ? parsed : 1000
+			})()
 
 			const finalizePendingReasoningMessage = async (thinking: string): Promise<boolean> => {
 				const pendingReasoningIndex = findLastIndex(
@@ -2731,9 +2739,35 @@ export class Task {
 
 					// Present content once per chunk. Calling this from multiple case branches can
 					// race partial updates and duplicate text rows in the chat.
-					await this.presentAssistantMessage().catch((error) =>
-						Logger.debug("[Task] Failed to present message: " + error),
+					const presentStartedAt = Date.now()
+					const presentPromise = this.presentAssistantMessage().catch((error) => {
+						Logger.debug(`[Task] Failed to present message: ${error}`)
+					})
+					const pendingBlocks = this.taskState.assistantMessageContent.slice(
+						this.taskState.currentStreamingContentIndex,
 					)
+					const hasPendingToolUseBlock = pendingBlocks.some((block) => block.type === "tool_use")
+					const shouldTimeboxPresent =
+						presentAssistantMessageTimeoutMs > 0 && (!hasPendingToolUseBlock || this.isParallelToolCallingEnabled())
+					if (shouldTimeboxPresent) {
+						const presentResult = await Promise.race([
+							presentPromise.then(() => "done" as const),
+							setTimeoutPromise(presentAssistantMessageTimeoutMs).then(() => "timeout" as const),
+						])
+						if (presentResult === "timeout") {
+							Logger.warn(
+								`[Task ${this.taskId}] presentAssistantMessage timed out after ${presentAssistantMessageTimeoutMs}ms; continuing stream consumption`,
+							)
+							void presentPromise.then(() => {
+								const elapsedMs = Date.now() - presentStartedAt
+								Logger.debug(
+									`[Task ${this.taskId}] presentAssistantMessage settled after timeout elapsedMs=${elapsedMs}`,
+								)
+							})
+						}
+					} else {
+						await presentPromise
+					}
 
 					if (this.taskState.abort) {
 						this.api.abort?.()


### PR DESCRIPTION
Introduce a configurable timeout for `presentAssistantMessage` calls during stream consumption to prevent the stream from being blocked indefinitely if message presentation stalls.

- Add `CLINE_PRESENT_ASSISTANT_MESSAGE_TIMEOUT_MS` env var support (defaults to 1000ms) with safe integer parsing
- Use `Promise.race` to continue stream consumption if presentation exceeds the timeout threshold
- Log a warning when timeout occurs and debug log when the deferred promise eventually settles, including elapsed time


### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** #XXXX

### Description

<!-- 
Help reviewers understand your changes by making this PR readable and well-organized:

- What problem does this PR solve?
- Why were these changes introduced and what purpose do they serve?
- For larger changes, provide context about your approach and reasoning

Small PRs may need minimal description, but larger changes benefit from explaining where you're coming from. Much of this context can be in the linked issue above, so feel free to reference it rather than repeating everything here.
-->

### Test Procedure

<!-- 
Please walk us through your testing approach and thought process. This helps reviewers understand that you've thoroughly considered the impact of your changes:

- How did you test this change?
- What could potentially break and how did you verify it doesn't?
- What existing functionality might be affected and how did you check it still works?
- Why are you confident this is ready for merge?

We're not looking for exhaustive documentation - just evidence that you've thought through the implications of your changes and tested accordingly.
-->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [ ] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add timeout for `presentAssistantMessage` in `index.ts` to prevent indefinite blocking during streaming, configurable via `CLINE_PRESENT_ASSISTANT_MESSAGE_TIMEOUT_MS` env var.
> 
>   - **Behavior**:
>     - Add timeout for `presentAssistantMessage` in `index.ts` using `Promise.race` to prevent indefinite blocking during streaming.
>     - Introduce `CLINE_PRESENT_ASSISTANT_MESSAGE_TIMEOUT_MS` env var (default 1000ms) for timeout configuration.
>     - Log warning on timeout and debug log when deferred promise settles, including elapsed time.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for ad6d989e68d544dece0844bae0ad9cb3522e8421. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->