### PR TITLE
fix: enable image support for GLM multimodal models

### DIFF
--- a/.changeset/slow-pillows-tell.md
+++ b/.changeset/slow-pillows-tell.md
@@ -1,0 +1,4 @@
+"claude-dev": patch
+---
+
+fix: enable image support for GLM multimodal models

--- a/package-lock.json
+++ b/package-lock.json
@@ -162,7 +162,7 @@
 		},
 		"cli": {
 			"name": "cline",
-			"version": "2.4.1",
+			"version": "2.4.2",
 			"cpu": [
 				"x64",
 				"arm64"

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -4248,7 +4248,7 @@ export const internationalZAiModels = {
 	"glm-5": {
 		maxTokens: 128_000,
 		contextWindow: 200_000,
-		supportsImages: false,
+		supportsImages: true,
 		supportsPromptCache: true,
 		cacheReadsPrice: 0.2,
 		inputPrice: 1.0,
@@ -4257,7 +4257,7 @@ export const internationalZAiModels = {
 	"glm-4.7": {
 		maxTokens: 131_000,
 		contextWindow: 200_000,
-		supportsImages: false,
+		supportsImages: true,
 		supportsPromptCache: true,
 		cacheReadsPrice: 0.11,
 		inputPrice: 0.6,
@@ -4296,6 +4296,18 @@ export const internationalZAiModels = {
 		description:
 			"GLM-4.5-Air is the lightweight version of GLM-4.5. It balances performance and cost-effectiveness, and can flexibly switch to hybrid thinking models.",
 	},
+	"glm-4.5v": {
+		maxTokens: 98_304,
+		contextWindow: 131_072,
+		supportsImages: true,
+		supportsPromptCache: true,
+		inputPrice: 0.6,
+		outputPrice: 2.2,
+		cacheWritesPrice: 0,
+		cacheReadsPrice: 0.11,
+		description:
+			"GLM-4.5V is Zhipu's multimodal vision-language model with 108B parameters, excelling in image analysis, OCR, and vision-language tasks.",
+	},
 } as const satisfies Record<string, ModelInfo>
 
 export type mainlandZAiModelId = keyof typeof mainlandZAiModels
@@ -4304,7 +4316,7 @@ export const mainlandZAiModels = {
 	"glm-5": {
 		maxTokens: 128_000,
 		contextWindow: 200_000,
-		supportsImages: false,
+		supportsImages: true,
 		supportsPromptCache: true,
 		cacheReadsPrice: 0.2,
 		inputPrice: 1.0,
@@ -4313,7 +4325,7 @@ export const mainlandZAiModels = {
 	"glm-4.7": {
 		maxTokens: 131_000,
 		contextWindow: 200_000,
-		supportsImages: false,
+		supportsImages: true,
 		supportsPromptCache: true,
 		cacheReadsPrice: 0.11,
 		inputPrice: 0.6,
@@ -4391,6 +4403,18 @@ export const mainlandZAiModels = {
 				cacheReadsPrice: 0.017,
 			},
 		],
+	},
+	"glm-4.5v": {
+		maxTokens: 98_304,
+		contextWindow: 131_072,
+		supportsImages: true,
+		supportsPromptCache: true,
+		inputPrice: 0.6,
+		outputPrice: 2.2,
+		cacheWritesPrice: 0,
+		cacheReadsPrice: 0.11,
+		description:
+			"GLM-4.5V is Zhipu's multimodal vision-language model with 108B parameters, excelling in image analysis, OCR, and vision-language tasks.",
 	},
 } as const satisfies Record<string, ModelInfo>
 


### PR DESCRIPTION
## Summary

- Set `supportsImages: true` for `glm-5` and `glm-4.7` (both models support vision/multimodal capabilities)
- Add `glm-4.5v` model definition with `supportsImages: true` 
- GLM-4.5V is Zhipu's 108B parameter multimodal vision-language model excelling in image analysis, OCR, and vision-language tasks

## Problem

When using GLM models (like glm-4.7) through the CLI or extension, the `read_file` tool was unable to read image files because the model definitions had `supportsImages: false`. This caused the tool to throw an error: `"Current model does not support image input"`.

According to [Zhipu AI documentation](https://docs.z.ai/guides/llm/glm-5) and recent model announcements, GLM-4.7 and GLM-5 both support vision/multimodal capabilities with their Modality including Image support.

## Solution

Updated the model definitions in `src/shared/api.ts` for both `internationalZAiModels` and `mainlandZAiModels`:

1. Changed `supportsImages: false` → `supportsImages: true` for:
   - `glm-5` (supports vision per documentation)
   - `glm-4.7` (supports vision per documentation)

2. Added new `glm-4.5v` model definition:
   - A dedicated vision-language model with 108B parameters
   - `supportsImages: true`
   - Excels in image analysis, OCR, and vision-language tasks

## Testing

- TypeScript syntax check passes
- The changes follow existing model definition patterns
- Pricing and context window values match the text-only variants

Fixes #9340
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Enable image support for `glm-5`, `glm-4.7`, and add `glm-4.5v` model with image capabilities in `src/shared/api.ts`.
> 
>   - **Behavior**:
>     - Set `supportsImages: true` for `glm-5` and `glm-4.7` in `src/shared/api.ts` to enable image support.
>     - Add `glm-4.5v` model definition with `supportsImages: true` in `src/shared/api.ts`.
>   - **Models**:
>     - `glm-4.5v` is a new model with 108B parameters, excelling in image analysis, OCR, and vision-language tasks.
>   - **Problem**:
>     - Previously, `read_file` tool could not read image files for GLM models due to `supportsImages: false`.
>   - **Solution**:
>     - Updated model definitions to reflect image support capabilities as per Zhipu AI documentation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 2bb449bf1711e3a869661fe69ea32eacec72c956. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->