### PR TITLE
feat(ui): Improve UX for in-chat CLI Command and MCP tool components 

### DIFF
--- a/.changeset/inline-tool-buttons.md
+++ b/.changeset/inline-tool-buttons.md
@@ -1,0 +1,5 @@
+---
+"cline": patch
+---
+
+Redesign CLI command and MCP tool cards with inline action buttons and auto-approve dropdown

--- a/webview-ui/src/App.stories.tsx
+++ b/webview-ui/src/App.stories.tsx
@@ -685,26 +685,57 @@ const quickStory = (
 	parameters: { docs: { description: { story: description } } },
 })
 
-export const CommandExecution: Story = quickStory(
-	"Command Execution",
+export const CommandPending: Story = quickStory(
+	"Command Pending",
 	"command",
 	"npm install",
-	"Shows command execution request with Run Command/Reject buttons.",
+	"Shows a command waiting for user approval with Run Command/Reject buttons.",
 )
 
-export const CommandOutput: Story = {
+export const CommandRunning: Story = {
 	decorators: [
 		createStoryDecorator({
 			clineMessages: [
-				createAskMessage("command", "npm install"),
-				createAskMessage("command_output", "Installing packages... This may take a few minutes."),
+				createMessage(5, "say", "task", "Install dependencies"),
+				createMessage(4.7, "say", "text", "I'll install the packages for you."),
+				createMessage(
+					4.5,
+					"say",
+					"command",
+					`npm install\nOutput:\nResolving dependencies...\nInstalling packages...`,
+				),
 			],
 		}),
 	],
 	parameters: {
 		docs: {
 			description: {
-				story: "Shows command output with Proceed While Running button during command execution.",
+				story: "Shows a command currently running with output streaming. Status shows 'Running'.",
+			},
+		},
+	},
+}
+
+export const CommandSuccess: Story = {
+	decorators: [
+		createStoryDecorator({
+			clineMessages: [
+				createMessage(5, "say", "task", "Install dependencies"),
+				createMessage(4.7, "say", "text", "I'll install the packages for you."),
+				createMessage(
+					4.5,
+					"say",
+					"command",
+					`npm install\nOutput:\nadded 245 packages in 3.2s\n\n142 packages are looking for funding\n  run \`npm fund\` for details`,
+					{ commandCompleted: true },
+				),
+			],
+		}),
+	],
+	parameters: {
+		docs: {
+			description: {
+				story: "Shows a completed command with Success status and checkmark.",
 			},
 		},
 	},

--- a/webview-ui/src/App.stories.tsx
+++ b/webview-ui/src/App.stories.tsx
@@ -766,12 +766,80 @@ export const BrowserActionLaunch = quickStory(
 	"Launch browser to test the website at http://localhost:3000",
 	"Shows browser action approval with Approve/Reject buttons for browser launch.",
 )
-export const McpServerUsage = quickStory(
-	"MCP Server",
-	"use_mcp_server",
-	JSON.stringify({ tool: "get_weather", location: "New York" }),
-	"Shows MCP server usage approval with Approve/Reject buttons for external tool usage.",
-)
+export const McpToolPending: Story = {
+	decorators: [
+		createStoryDecorator({
+			clineMessages: [
+				createMessage(5, "say", "task", "Get weather information"),
+				createMessage(4.7, "say", "text", "I'll check the weather for you."),
+				createAskMessage(
+					"use_mcp_server",
+					JSON.stringify({
+						type: "use_mcp_tool",
+						serverName: "weather-api",
+						toolName: "get_weather",
+						arguments: JSON.stringify({ location: "New York", units: "celsius" }, null, 2),
+					}),
+				),
+			],
+		}),
+	],
+	parameters: { docs: { description: { story: "Shows MCP tool waiting for user approval." } } },
+}
+
+export const McpToolRunning: Story = {
+	decorators: [
+		createStoryDecorator({
+			clineMessages: [
+				createMessage(5, "say", "task", "Get weather information"),
+				createMessage(4.7, "say", "text", "I'll check the weather for you."),
+				createMessage(
+					4.5,
+					"say",
+					"use_mcp_server",
+					JSON.stringify({
+						type: "use_mcp_tool",
+						serverName: "weather-api",
+						toolName: "get_weather",
+						arguments: JSON.stringify({ location: "New York", units: "celsius" }, null, 2),
+					}),
+				),
+				createMessage(4.4, "say", "mcp_server_request_started", "Calling weather API..."),
+			],
+		}),
+	],
+	parameters: { docs: { description: { story: "Shows MCP tool in running state." } } },
+}
+
+export const McpToolSuccess: Story = {
+	decorators: [
+		createStoryDecorator({
+			clineMessages: [
+				createMessage(5, "say", "task", "Get weather information"),
+				createMessage(4.7, "say", "text", "I'll check the weather for you."),
+				createMessage(
+					4.5,
+					"say",
+					"use_mcp_server",
+					JSON.stringify({
+						type: "use_mcp_tool",
+						serverName: "weather-api",
+						toolName: "get_weather",
+						arguments: JSON.stringify({ location: "New York", units: "celsius" }, null, 2),
+					}),
+				),
+				createMessage(
+					4.4,
+					"say",
+					"mcp_server_response",
+					"Current weather in New York: 72°F (22°C), Partly Cloudy\nHumidity: 45%\nWind: 8 mph NW",
+				),
+				createMessage(4.3, "say", "text", "The weather in New York is currently 72°F with partly cloudy skies."),
+			],
+		}),
+	],
+	parameters: { docs: { description: { story: "Shows MCP tool completed successfully." } } },
+}
 export const Followup = quickStory(
 	"Follow-up",
 	"followup",

--- a/webview-ui/src/components/chat/ChatRow.tsx
+++ b/webview-ui/src/components/chat/ChatRow.tsx
@@ -10,6 +10,9 @@ import {
 	COMPLETION_RESULT_CHANGES_FLAG,
 } from "@shared/ExtensionMessage"
 import { BooleanRequest, StringRequest } from "@shared/proto/cline/common"
+import { AskResponseRequest } from "@shared/proto/cline/task"
+import { ToggleToolAutoApproveRequest } from "@shared/proto/cline/mcp"
+import { convertProtoMcpServersToMcpServers } from "@shared/proto-conversions/mcp/mcp-server-conversion"
 import { Mode } from "@shared/storage/types"
 import deepEqual from "fast-deep-equal"
 import {
@@ -39,6 +42,7 @@ import {
 import { MouseEvent, memo, useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { useSize } from "react-use"
 import { OptionsButtons } from "@/components/chat/OptionsButtons"
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { CheckmarkControl } from "@/components/common/CheckmarkControl"
 import { WithCopyButton } from "@/components/common/CopyButton"
 import McpResponseDisplay from "@/components/mcp/chat-display/McpResponseDisplay"
@@ -46,7 +50,7 @@ import McpResourceRow from "@/components/mcp/configuration/tabs/installed/server
 import McpToolRow from "@/components/mcp/configuration/tabs/installed/server-row/McpToolRow"
 import { useExtensionState } from "@/context/ExtensionStateContext"
 import { cn } from "@/lib/utils"
-import { FileServiceClient, UiServiceClient } from "@/services/grpc-client"
+import { FileServiceClient, McpServiceClient, TaskServiceClient, UiServiceClient } from "@/services/grpc-client"
 import { findMatchingResourceOrTemplate, getMcpServerDisplayName } from "@/utils/mcp"
 import CodeAccordian, { cleanPathPrefix } from "../common/CodeAccordian"
 import { CommandOutputContent, CommandOutputRow } from "./CommandOutputRow"
@@ -148,10 +152,12 @@ export const ChatRowContent = memo(
 		responseStarted,
 	}: ChatRowContentProps) => {
 		const {
+			autoApprovalSettings,
 			backgroundEditEnabled,
 			mcpServers,
 			mcpMarketplaceCatalog,
 			onRelinquishControl,
+			setMcpServers,
 			vscodeTerminalExecutionMode,
 			clineMessages,
 		} = useExtensionState()
@@ -168,6 +174,9 @@ export const ChatRowContent = memo(
 		// Command output expansion state (for all messages, but only used by command messages)
 		const [isOutputFullyExpanded, setIsOutputFullyExpanded] = useState(false)
 		const prevCommandExecutingRef = useRef<boolean>(false)
+
+		// MCP tool card expanded state (default collapsed)
+		const [isMcpArgsExpanded, setIsMcpArgsExpanded] = useState(false)
 
 		const hasAutoExpandedRef = useRef(false)
 		const hasAutoCollapsedRef = useRef(false)
@@ -769,15 +778,16 @@ export const ChatRowContent = memo(
 		if (message.ask === "use_mcp_server" || message.say === "use_mcp_server") {
 			const useMcpServer = JSON.parse(message.text || "{}") as ClineAskUseMcpServer
 			const server = mcpServers.find((server) => server.name === useMcpServer.serverName)
-			return (
-				<div>
-					<div className={HEADER_CLASSNAMES}>
-						{icon}
-						{title}
-					</div>
 
-					<div className="bg-code rounded-xs py-2 px-2.5 mt-2">
-						{useMcpServer.type === "access_mcp_resource" && (
+			// For access_mcp_resource, keep the old styling for now
+			if (useMcpServer.type === "access_mcp_resource") {
+				return (
+					<div>
+						<div className={HEADER_CLASSNAMES}>
+							{icon}
+							{title}
+						</div>
+						<div className="bg-code rounded-xs py-2 px-2.5 mt-2">
 							<McpResourceRow
 								item={{
 									...(findMatchingResourceOrTemplate(
@@ -792,37 +802,182 @@ export const ChatRowContent = memo(
 									uri: useMcpServer.uri || "",
 								}}
 							/>
-						)}
+						</div>
+					</div>
+				)
+			}
 
-						{useMcpServer.type === "use_mcp_tool" && (
-							<div>
-								<div onClick={(e) => e.stopPropagation()}>
-									<McpToolRow
-										serverName={useMcpServer.serverName}
-										tool={{
-											name: useMcpServer.toolName || "",
-											description:
-												server?.tools?.find((tool) => tool.name === useMcpServer.toolName)?.description ||
-												"",
-											autoApprove:
-												server?.tools?.find((tool) => tool.name === useMcpServer.toolName)?.autoApprove ||
-												false,
-										}}
-									/>
-								</div>
-								{useMcpServer.arguments && useMcpServer.arguments !== "{}" && (
-									<div className="mt-2">
-										<div className="mb-1 opacity-80 uppercase">Arguments</div>
-										<CodeAccordian
-											code={useMcpServer.arguments}
-											isExpanded={true}
-											language="json"
-											onToggleExpand={handleToggle}
-										/>
-									</div>
-								)}
+			// For use_mcp_tool, use the new card design
+			const toolName = useMcpServer.toolName || ""
+			const toolInfo = server?.tools?.find((tool) => tool.name === toolName)
+			const autoApprove = toolInfo?.autoApprove ?? false
+			const hasArguments = useMcpServer.arguments && useMcpServer.arguments !== "{}"
+
+			const handleAutoApproveChange = (newValue: boolean) => {
+				if (!useMcpServer.serverName) return
+				McpServiceClient.toggleToolAutoApprove(
+					ToggleToolAutoApproveRequest.create({
+						serverName: useMcpServer.serverName,
+						toolNames: [toolName],
+						autoApprove: newValue,
+					}),
+				)
+					.then((response) => {
+						const mcpServersUpdated = convertProtoMcpServersToMcpServers(response.mcpServers)
+						setMcpServers(mcpServersUpdated)
+					})
+					.catch((error) => {
+						console.error("Error toggling tool auto-approve", error)
+					})
+			}
+
+			const getMcpState = () => {
+				// If it's an ask message, it's pending approval
+				if (message.ask === "use_mcp_server") {
+					return "pending"
+				}
+				if (isMcpServerResponding) {
+					return "running"
+				}
+				return "success"
+			}
+
+			const mcpState = getMcpState()
+
+			return (
+				<div className="rounded-sm border border-editor-group-border overflow-hidden">
+					{/* Header - clickable to collapse/expand */}
+					<button
+						className={cn(
+							"flex items-center gap-2 w-full px-3 py-3 text-left",
+							isMcpArgsExpanded && "border-b border-editor-group-border",
+						)}
+						onClick={() => setIsMcpArgsExpanded(!isMcpArgsExpanded)}
+						type="button">
+						<ChevronDownIcon
+							className={cn("text-description transition-transform", {
+								"rotate-0": isMcpArgsExpanded,
+								"-rotate-90": !isMcpArgsExpanded,
+							})}
+							size={14}
+						/>
+						<i className="codicon codicon-tools text-description" />
+						<span className="text-sm text-foreground font-azeret-mono">{toolName}</span>
+					</button>
+
+					{/* Content area - only visible when expanded */}
+					<div className={cn({ hidden: !isMcpArgsExpanded })}>
+						{/* Arguments section */}
+						{hasArguments && (
+							<div className="px-3 pt-2.5 pb-2">
+								<div className="text-sm text-description mb-1.5">Arguments</div>
+								<CodeAccordian
+									code={useMcpServer.arguments}
+									isExpanded={true}
+									language="json"
+									onToggleExpand={() => {}}
+									variant="subtle"
+									noBorder
+								/>
 							</div>
 						)}
+
+						{/* Response section - find matching response from clineMessages */}
+						{(() => {
+							// Find the mcp_server_response that comes after this message
+							const messageIndex = clineMessages.findIndex((m) => m.ts === message.ts)
+							if (messageIndex >= 0) {
+								// Look for the next mcp_server_response message
+								for (let i = messageIndex + 1; i < clineMessages.length; i++) {
+									const nextMsg = clineMessages[i]
+									if (nextMsg.say === "mcp_server_response" && nextMsg.text) {
+										return (
+											<div className="px-3 pb-2">
+												<div className="text-sm text-description mb-1.5">Response</div>
+												<CodeAccordian
+													code={nextMsg.text}
+													isExpanded={true}
+													language="json"
+													onToggleExpand={() => {}}
+													variant="subtle"
+													noBorder
+												/>
+											</div>
+										)
+									}
+									// Stop if we hit another use_mcp_server (different tool call)
+									if (nextMsg.ask === "use_mcp_server" || nextMsg.say === "use_mcp_server") {
+										break
+									}
+								}
+							}
+							return null
+						})()}
+					</div>
+
+					{/* Footer - always visible */}
+					<div className={cn("flex items-center justify-between px-3 h-10 bg-toolbar-hover/65", {
+						"mt-2": isMcpArgsExpanded,
+					})}>
+						<div className="flex items-center gap-2">
+							{autoApprovalSettings.actions.useMcp && (
+								<Select
+									value={(mcpState === "pending" ? false : autoApprove) ? "auto" : "ask"}
+									onValueChange={(value) => {
+										handleAutoApproveChange(value === "auto")
+									}}>
+									<SelectTrigger
+										className="h-7 border-0 bg-transparent px-0 shadow-none text-sm text-foreground hover:text-description [&_svg]:opacity-100 [&_svg]:text-description"
+										showIcon={true}>
+										<SelectValue />
+									</SelectTrigger>
+									<SelectContent>
+										<SelectItem className="text-sm" value="ask">Ask Everytime</SelectItem>
+										<SelectItem className="text-sm" value="auto">Auto-approve</SelectItem>
+									</SelectContent>
+								</Select>
+							)}
+						</div>
+						<div className="flex items-center gap-2">
+							{mcpState === "pending" && (
+								<>
+									<button
+										className="text-sm text-foreground hover:text-description transition-colors"
+										onClick={(e) => {
+											e.stopPropagation()
+											TaskServiceClient.askResponse(
+												AskResponseRequest.create({ responseType: "noButtonClicked" }),
+											)
+										}}
+										type="button">
+										Cancel
+									</button>
+									<button
+										className="px-2.5 py-1 text-sm bg-button-background text-button-foreground rounded-sm hover:bg-button-hover-background transition-colors"
+										onClick={(e) => {
+											e.stopPropagation()
+											TaskServiceClient.askResponse(
+												AskResponseRequest.create({ responseType: "yesButtonClicked" }),
+											)
+										}}
+										type="button">
+										Run
+									</button>
+								</>
+							)}
+							{mcpState === "running" && (
+								<>
+									<i className="codicon codicon-loading codicon-modifier-spin text-sm text-description" />
+									<span className="text-sm text-description">Cancel</span>
+								</>
+							)}
+							{mcpState === "success" && (
+								<>
+									<i className="codicon codicon-check text-sm text-success" />
+									<span className="text-sm text-success">Success</span>
+								</>
+							)}
+						</div>
 					</div>
 				</div>
 			)
@@ -849,7 +1004,8 @@ export const ChatRowContent = memo(
 					case "api_req_finished":
 						return <InvisibleSpacer /> // we should never see this message type
 					case "mcp_server_response":
-						return <McpResponseDisplay responseText={message.text || ""} />
+						// Response is now rendered inside the MCP tool card
+						return <InvisibleSpacer />
 					case "mcp_notification":
 						return (
 							<div className="flex items-start gap-2 py-2.5 px-3 bg-quote rounded-sm text-base text-foreground opacity-90 mb-2">

--- a/webview-ui/src/components/chat/ChatRow.tsx
+++ b/webview-ui/src/components/chat/ChatRow.tsx
@@ -215,11 +215,10 @@ export const ChatRowContent = memo(
 		const type = message.type === "ask" ? message.ask : message.say
 
 		const isCommandMessage = type === "command"
-		// Check if command has output to determine if it's actually executing
 		const commandHasOutput = message.text?.includes(COMMAND_OUTPUT_STRING) ?? false
-		// A command is executing if it has output but hasn't completed yet
-		const isCommandExecuting = isCommandMessage && !message.commandCompleted && commandHasOutput
-		// A command is pending if it hasn't started (no output) and hasn't completed
+		// A command is executing only if it's the last message, has output, and hasn't completed
+		const isCommandExecuting = isCommandMessage && isLast && !message.commandCompleted && commandHasOutput
+		// A command is pending if it's the last message, hasn't started (no output), and hasn't completed
 		const isCommandPending = isCommandMessage && isLast && !message.commandCompleted && !commandHasOutput
 		const isCommandCompleted = isCommandMessage && message.commandCompleted === true
 
@@ -751,7 +750,6 @@ export const ChatRowContent = memo(
 		if (message.ask === "command" || message.say === "command") {
 			return (
 				<CommandOutputRow
-					icon={icon}
 					isBackgroundExec={vscodeTerminalExecutionMode === "backgroundExec"}
 					isCommandCompleted={isCommandCompleted}
 					isCommandExecuting={isCommandExecuting}
@@ -760,7 +758,6 @@ export const ChatRowContent = memo(
 					message={message}
 					onCancelCommand={onCancelCommand}
 					setIsOutputFullyExpanded={setIsOutputFullyExpanded}
-					title={title}
 				/>
 			)
 		}

--- a/webview-ui/src/components/chat/ChatRow.tsx
+++ b/webview-ui/src/components/chat/ChatRow.tsx
@@ -45,9 +45,7 @@ import { OptionsButtons } from "@/components/chat/OptionsButtons"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { CheckmarkControl } from "@/components/common/CheckmarkControl"
 import { WithCopyButton } from "@/components/common/CopyButton"
-import McpResponseDisplay from "@/components/mcp/chat-display/McpResponseDisplay"
 import McpResourceRow from "@/components/mcp/configuration/tabs/installed/server-row/McpResourceRow"
-import McpToolRow from "@/components/mcp/configuration/tabs/installed/server-row/McpToolRow"
 import { useExtensionState } from "@/context/ExtensionStateContext"
 import { cn } from "@/lib/utils"
 import { FileServiceClient, McpServiceClient, TaskServiceClient, UiServiceClient } from "@/services/grpc-client"
@@ -932,7 +930,7 @@ export const ChatRowContent = memo(
 										<SelectValue />
 									</SelectTrigger>
 									<SelectContent>
-										<SelectItem className="text-sm" value="ask">Ask Everytime</SelectItem>
+										<SelectItem className="text-sm" value="ask">Ask Every Time</SelectItem>
 										<SelectItem className="text-sm" value="auto">Auto-approve</SelectItem>
 									</SelectContent>
 								</Select>

--- a/webview-ui/src/components/chat/ChatRow.tsx
+++ b/webview-ui/src/components/chat/ChatRow.tsx
@@ -842,6 +842,23 @@ export const ChatRowContent = memo(
 
 			const mcpState = getMcpState()
 
+			// Memoize the MCP response lookup to avoid searching clineMessages on every render
+			const mcpResponseText = useMemo(() => {
+				const messageIndex = clineMessages.findIndex((m) => m.ts === message.ts)
+				if (messageIndex >= 0) {
+					for (let i = messageIndex + 1; i < clineMessages.length; i++) {
+						const nextMsg = clineMessages[i]
+						if (nextMsg.say === "mcp_server_response" && nextMsg.text) {
+							return nextMsg.text
+						}
+						if (nextMsg.ask === "use_mcp_server" || nextMsg.say === "use_mcp_server") {
+							break
+						}
+					}
+				}
+				return null
+			}, [clineMessages, message.ts])
+
 			return (
 				<div className="rounded-sm border border-editor-group-border overflow-hidden">
 					{/* Header - clickable to collapse/expand */}
@@ -880,37 +897,20 @@ export const ChatRowContent = memo(
 							</div>
 						)}
 
-						{/* Response section - find matching response from clineMessages */}
-						{(() => {
-							// Find the mcp_server_response that comes after this message
-							const messageIndex = clineMessages.findIndex((m) => m.ts === message.ts)
-							if (messageIndex >= 0) {
-								// Look for the next mcp_server_response message
-								for (let i = messageIndex + 1; i < clineMessages.length; i++) {
-									const nextMsg = clineMessages[i]
-									if (nextMsg.say === "mcp_server_response" && nextMsg.text) {
-										return (
-											<div className="px-3 pb-2">
-												<div className="text-sm text-description mb-1.5">Response</div>
-												<CodeAccordian
-													code={nextMsg.text}
-													isExpanded={true}
-													language="json"
-													onToggleExpand={() => {}}
-													variant="subtle"
-													noBorder
-												/>
-											</div>
-										)
-									}
-									// Stop if we hit another use_mcp_server (different tool call)
-									if (nextMsg.ask === "use_mcp_server" || nextMsg.say === "use_mcp_server") {
-										break
-									}
-								}
-							}
-							return null
-						})()}
+						{/* Response section */}
+						{mcpResponseText && (
+							<div className="px-3 pb-2">
+								<div className="text-sm text-description mb-1.5">Response</div>
+								<CodeAccordian
+									code={mcpResponseText}
+									isExpanded={true}
+									language="json"
+									onToggleExpand={() => {}}
+									variant="subtle"
+									noBorder
+								/>
+							</div>
+						)}
 					</div>
 
 					{/* Footer - always visible */}

--- a/webview-ui/src/components/chat/CommandOutputRow.tsx
+++ b/webview-ui/src/components/chat/CommandOutputRow.tsx
@@ -128,7 +128,7 @@ export const CommandOutputRow = ({
 	// Find the executeSafeCommands action from metadata for the auto-approve dropdown
 	const safeCommandsAction = ACTION_METADATA.find((a) => a.id === "executeSafeCommands")
 
-	// If command is pending, it wasn't auto-approved, so show "Ask Everytime"
+	// If command is pending, it wasn't auto-approved, so show "Ask Every Time"
 	// Otherwise show the current global setting
 	const autoApprove = isCommandPending
 		? false
@@ -249,7 +249,7 @@ export const CommandOutputRow = ({
 						</SelectTrigger>
 						<SelectContent>
 							<SelectItem className="text-sm" value="ask">
-								Ask Everytime
+								Ask Every Time
 							</SelectItem>
 							<SelectItem className="text-sm" value="auto">
 								Auto-approve

--- a/webview-ui/src/components/chat/CommandOutputRow.tsx
+++ b/webview-ui/src/components/chat/CommandOutputRow.tsx
@@ -1,13 +1,19 @@
 import { COMMAND_OUTPUT_STRING, COMMAND_REQ_APP_STRING } from "@shared/combineCommandSequences"
 import { ClineMessage } from "@shared/ExtensionMessage"
+import { AskResponseRequest } from "@shared/proto/cline/task"
 import { StringRequest } from "@shared/proto/cline/common"
-import { ChevronDown, ChevronRight } from "lucide-react"
+import { ChevronRight } from "lucide-react"
 import { memo, useEffect, useRef, useState } from "react"
-import { Button } from "@/components/ui/button"
+import { ACTION_METADATA } from "@/components/chat/auto-approve-menu/constants"
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+import { useAutoApproveActions } from "@/hooks/useAutoApproveActions"
 import { cn } from "@/lib/utils"
-import { FileServiceClient } from "@/services/grpc-client"
+import { FileServiceClient, TaskServiceClient } from "@/services/grpc-client"
 import CodeBlock from "../common/CodeBlock"
 
+/**
+ * Displays the command output content with optional log file link
+ */
 export const CommandOutputContent = memo(
 	({
 		output,
@@ -88,163 +94,235 @@ export const CommandOutputContent = memo(
 
 CommandOutputContent.displayName = "CommandOutputContent"
 
-export const CommandOutputRow = memo(
-	({
-		message,
-		isCommandExecuting = false,
-		isCommandPending = false,
-		isCommandCompleted = false,
-		isBackgroundExec = false,
-		onCancelCommand,
-		isOutputFullyExpanded,
-		setIsOutputFullyExpanded,
-	}: {
-		message: ClineMessage
-		isCommandExecuting?: boolean
-		isCommandPending?: boolean
-		isCommandCompleted?: boolean
-		isBackgroundExec?: boolean
-		onCancelCommand?: () => void
-		isOutputFullyExpanded: boolean
-		setIsOutputFullyExpanded: (expanded: boolean) => void
-	}) => {
-		const [isOutputExpanded, setIsOutputExpanded] = useState(false)
+interface CommandOutputRowProps {
+	message: ClineMessage
+	isCommandExecuting?: boolean
+	isCommandPending?: boolean
+	isCommandCompleted?: boolean
+	isBackgroundExec?: boolean
+	onCancelCommand?: () => void
+	isOutputFullyExpanded: boolean
+	setIsOutputFullyExpanded: (expanded: boolean) => void
+}
 
-		const splitMessage = (text: string) => {
-			const outputIndex = text.indexOf(COMMAND_OUTPUT_STRING)
-			if (outputIndex === -1) {
-				return { command: text, output: "" }
-			}
-			return {
-				command: text.slice(0, outputIndex).trim(),
-				output: text
-					.slice(outputIndex + COMMAND_OUTPUT_STRING.length)
-					.trim()
-					.split("")
-					.map((char) => {
-						switch (char) {
-							case "\t":
-								return "→   "
-							case "\b":
-								return "⌫"
-							case "\f":
-								return "⏏"
-							case "\v":
-								return "⇳"
-							default:
-								return char
-						}
-					})
-					.join(""),
-			}
+/**
+ * Displays a CLI command card with:
+ * - Header with terminal icon
+ * - Command text
+ * - Collapsible output section
+ * - Footer with auto-approve dropdown and action buttons
+ */
+export const CommandOutputRow = ({
+	message,
+	isCommandExecuting = false,
+	isCommandPending = false,
+	isCommandCompleted = false,
+	isBackgroundExec = false,
+	onCancelCommand,
+	isOutputFullyExpanded,
+	setIsOutputFullyExpanded,
+}: CommandOutputRowProps) => {
+	const { isChecked, updateAction } = useAutoApproveActions()
+	const [isOutputExpanded, setIsOutputExpanded] = useState(false)
+
+	// Find the executeSafeCommands action from metadata for the auto-approve dropdown
+	const safeCommandsAction = ACTION_METADATA.find((a) => a.id === "executeSafeCommands")
+
+	// If command is pending, it wasn't auto-approved, so show "Ask Everytime"
+	// Otherwise show the current global setting
+	const autoApprove = isCommandPending
+		? false
+		: safeCommandsAction
+			? isChecked(safeCommandsAction)
+			: false
+
+	// Parse the message text to extract command and output
+	const splitMessage = (text: string) => {
+		const outputIndex = text.indexOf(COMMAND_OUTPUT_STRING)
+		if (outputIndex === -1) {
+			return { command: text, output: "" }
 		}
-
-		const { command: rawCommand, output } = splitMessage(message.text || "")
-		const requestsApproval = rawCommand.endsWith(COMMAND_REQ_APP_STRING)
-		const command = requestsApproval ? rawCommand.slice(0, -COMMAND_REQ_APP_STRING.length) : rawCommand
-		const showCancelButton =
-			(isCommandExecuting || isCommandPending) && typeof onCancelCommand === "function" && isBackgroundExec
-
-		const getStatusDisplay = () => {
-			if (isCommandExecuting) {
-				return { text: "Running", color: "text-description", showCheck: false }
-			}
-			if (isCommandPending) {
-				return { text: "Pending", color: "text-editor-warning-foreground", showCheck: false }
-			}
-			if (isCommandCompleted || (output.length > 0 && !isCommandExecuting && !isCommandPending)) {
-				return { text: "Success", color: "text-success", showCheck: true }
-			}
-			return { text: "Skipped", color: "text-description", showCheck: false }
+		return {
+			command: text.slice(0, outputIndex).trim(),
+			output: text
+				.slice(outputIndex + COMMAND_OUTPUT_STRING.length)
+				.trim()
+				.split("")
+				.map((char) => {
+					switch (char) {
+						case "\t":
+							return "→   "
+						case "\b":
+							return "⌫"
+						case "\f":
+							return "⏏"
+						case "\v":
+							return "⇳"
+						default:
+							return char
+					}
+				})
+				.join(""),
 		}
+	}
 
-		const status = getStatusDisplay()
+	const { command: rawCommand, output } = splitMessage(message.text || "")
+	const requestsApproval = rawCommand.endsWith(COMMAND_REQ_APP_STRING)
+	const command = requestsApproval ? rawCommand.slice(0, -COMMAND_REQ_APP_STRING.length) : rawCommand
+	const showCancelButton =
+		(isCommandExecuting || isCommandPending) && typeof onCancelCommand === "function" && isBackgroundExec
 
-		return (
-			<div className="rounded-sm border border-editor-group-border overflow-hidden">
-				{/* Header */}
-				<div className="flex items-center gap-2 px-3 py-2 border-b border-editor-group-border/50">
-					<i className="codicon codicon-terminal text-description" />
-					<span className="text-sm text-foreground">Run CLI Command</span>
-				</div>
+	// Determine status display based on command state
+	const getStatusDisplay = () => {
+		if (isCommandExecuting) {
+			return { text: "Running", color: "text-description", showCheck: false }
+		}
+		if (isCommandPending) {
+			return { text: "Pending", color: "text-editor-warning-foreground", showCheck: false }
+		}
+		if (isCommandCompleted || (output.length > 0 && !isCommandExecuting && !isCommandPending)) {
+			return { text: "Success", color: "text-success", showCheck: true }
+		}
+		return { text: "Skipped", color: "text-description", showCheck: false }
+	}
 
-				{/* Command text */}
-				<div className="px-3 pt-3 pb-1.5 bg-code">
-					<pre className="font-mono text-sm whitespace-pre-wrap break-words m-0 text-link">{command}</pre>
-				</div>
+	const status = getStatusDisplay()
 
-				{/* Command Output accordion */}
-				{output.length > 0 && (
-					<div>
-						<button
-							className={cn("flex items-center gap-1.5 w-full px-3 text-left", {
-								"py-2": !isOutputExpanded,
-								"pt-2 pb-1": isOutputExpanded,
+	return (
+		<div className="rounded-sm border border-editor-group-border overflow-hidden">
+			{/* Header */}
+			<div className="flex items-center gap-2 px-3 py-2 border-b border-editor-group-border/50">
+				<i className="codicon codicon-terminal text-description" />
+				<span className="text-sm text-foreground">Run CLI Command</span>
+			</div>
+
+			{/* Command text */}
+			<div className="px-3 pt-3 pb-1.5 bg-code">
+				<pre className="font-mono text-sm whitespace-pre-wrap break-words m-0 text-link">{command}</pre>
+			</div>
+
+			{/* Command Output accordion */}
+			{output.length > 0 && (
+				<div>
+					<button
+						className={cn("flex items-center gap-1.5 w-full px-3 text-left", {
+							"py-2": !isOutputExpanded,
+							"pt-2 pb-1": isOutputExpanded,
+						})}
+						onClick={() => setIsOutputExpanded(!isOutputExpanded)}
+						type="button">
+						<ChevronRight
+							className={cn("text-description transition-transform", {
+								"rotate-90": isOutputExpanded,
 							})}
-							onClick={() => setIsOutputExpanded(!isOutputExpanded)}
-							type="button">
-							<ChevronRight
-								className={cn("text-description transition-transform", {
-									"rotate-90": isOutputExpanded,
-								})}
-								size={14}
+							size={14}
+						/>
+						<span className="text-description text-sm">Command Output</span>
+					</button>
+					{isOutputExpanded && (
+						<div>
+							<CommandOutputContent
+								isContainerExpanded={true}
+								isOutputFullyExpanded={isOutputFullyExpanded}
+								onToggle={() => setIsOutputFullyExpanded(!isOutputFullyExpanded)}
+								output={output}
 							/>
-							<span className="text-description text-sm">Command Output</span>
-						</button>
-						{isOutputExpanded && (
-							<div>
-								<CommandOutputContent
-									isContainerExpanded={true}
-									isOutputFullyExpanded={isOutputFullyExpanded}
-									onToggle={() => setIsOutputFullyExpanded(!isOutputFullyExpanded)}
-									output={output}
-								/>
-							</div>
-						)}
-					</div>
-				)}
+						</div>
+					)}
+				</div>
+			)}
 
-				{/* Footer bar */}
-				<div className="flex items-center justify-between px-3 py-2 border-t border-editor-group-border/50">
-					<div className="flex items-center gap-2">
-						<button
-							className="flex items-center gap-1 text-sm text-foreground hover:text-description transition-colors"
-							type="button">
-							<span>Ask Everytime</span>
-							<ChevronDown className="text-description" size={14} />
-						</button>
-						{showCancelButton && (
-							<Button
+			{/* Footer bar with auto-approve dropdown and action buttons */}
+			<div className="flex items-center justify-between px-3 h-10 mt-2 bg-toolbar-hover/65">
+				{/* Left side: Auto-approve dropdown */}
+				<div className="flex items-center gap-2">
+					<Select
+						value={autoApprove ? "auto" : "ask"}
+						onValueChange={(value) => {
+							if (!safeCommandsAction) return
+							updateAction(safeCommandsAction, value === "auto")
+						}}>
+						<SelectTrigger
+							className="h-7 border-0 bg-transparent px-0 shadow-none text-sm text-foreground hover:text-description [&_svg]:opacity-100 [&_svg]:text-description"
+							showIcon={true}>
+							<SelectValue />
+						</SelectTrigger>
+						<SelectContent>
+							<SelectItem className="text-sm" value="ask">
+								Ask Everytime
+							</SelectItem>
+							<SelectItem className="text-sm" value="auto">
+								Auto-approve
+							</SelectItem>
+						</SelectContent>
+					</Select>
+					{requestsApproval && !isCommandPending && (
+						<span className="text-xs text-editor-warning-foreground flex items-center gap-1.5">
+							<i className="codicon codicon-warning text-[11px]" />
+							Requires approval
+						</span>
+					)}
+				</div>
+
+				{/* Right side: Action buttons or status */}
+				<div className="flex items-center gap-2">
+					{/* Pending state: Cancel/Run buttons */}
+					{isCommandPending && (
+						<>
+							<button
+								className="text-sm text-foreground hover:text-description transition-colors"
 								onClick={(e) => {
 									e.stopPropagation()
-									if (isBackgroundExec) {
-										onCancelCommand?.()
-									} else {
-										alert(
-											"This command is running in the VSCode terminal. You can manually stop it using Ctrl+C in the terminal, or switch to Background Execution mode in settings for cancellable commands.",
-										)
-									}
+									TaskServiceClient.askResponse(
+										AskResponseRequest.create({ responseType: "noButtonClicked" }),
+									)
 								}}
-								size="sm"
-								variant="secondary">
-								{isBackgroundExec ? "cancel" : "stop"}
-							</Button>
-						)}
-						{requestsApproval && (
-							<span className="text-xs text-editor-warning-foreground flex items-center gap-1.5">
-								<i className="codicon codicon-warning text-[11px]" />
-								Requires approval
-							</span>
-						)}
-					</div>
-					<div className="flex items-center gap-1.5">
-						{status.showCheck && <i className="codicon codicon-check text-sm text-success" />}
-						<span className={cn("text-sm", status.color)}>{status.text}</span>
-					</div>
+								type="button">
+								Cancel
+							</button>
+							<button
+								className="px-2.5 py-1 text-sm bg-button-background text-button-foreground rounded-sm hover:bg-button-hover-background transition-colors"
+								onClick={(e) => {
+									e.stopPropagation()
+									TaskServiceClient.askResponse(
+										AskResponseRequest.create({ responseType: "yesButtonClicked" }),
+									)
+								}}
+								type="button">
+								Run
+							</button>
+						</>
+					)}
+
+					{/* Executing state: Spinner + optional Cancel */}
+					{isCommandExecuting && (
+						<>
+							<i className="codicon codicon-loading codicon-modifier-spin text-sm text-description" />
+							{showCancelButton ? (
+								<button
+									className="text-sm text-foreground hover:text-description transition-colors"
+									onClick={(e) => {
+										e.stopPropagation()
+										onCancelCommand?.()
+									}}
+									type="button">
+									Cancel
+								</button>
+							) : (
+								<span className="text-sm text-description">Cancel</span>
+							)}
+						</>
+					)}
+
+					{/* Completed state: Status indicator */}
+					{!isCommandPending && !isCommandExecuting && (
+						<div className="flex items-center gap-1.5">
+							{status.showCheck && <i className="codicon codicon-check text-sm text-success" />}
+							<span className={cn("text-sm", status.color)}>{status.text}</span>
+						</div>
+					)}
 				</div>
 			</div>
-		)
-	},
-)
-
-CommandOutputRow.displayName = "CommandOutputRow"
+		</div>
+	)
+}

--- a/webview-ui/src/components/chat/CommandOutputRow.tsx
+++ b/webview-ui/src/components/chat/CommandOutputRow.tsx
@@ -1,12 +1,12 @@
 import { COMMAND_OUTPUT_STRING, COMMAND_REQ_APP_STRING } from "@shared/combineCommandSequences"
 import { ClineMessage } from "@shared/ExtensionMessage"
 import { StringRequest } from "@shared/proto/cline/common"
-import { memo, useEffect, useRef } from "react"
+import { ChevronDown, ChevronRight } from "lucide-react"
+import { memo, useEffect, useRef, useState } from "react"
 import { Button } from "@/components/ui/button"
 import { cn } from "@/lib/utils"
 import { FileServiceClient } from "@/services/grpc-client"
 import CodeBlock from "../common/CodeBlock"
-import ExpandHandle from "./ExpandHandle"
 
 export const CommandOutputContent = memo(
 	({
@@ -20,18 +20,13 @@ export const CommandOutputContent = memo(
 		onToggle: () => void
 		isContainerExpanded: boolean
 	}) => {
-		const outputLines = output.split("\n")
-		const lineCount = outputLines.length
+		const lineCount = output.split("\n").length
 		const shouldAutoShow = lineCount <= 5
 		const outputRef = useRef<HTMLDivElement>(null)
 
-		// Auto-scroll to bottom when output changes (only when showing limited output)
 		useEffect(() => {
 			if (!isOutputFullyExpanded && outputRef.current) {
-				// Direct scrollTop manipulation
 				outputRef.current.scrollTop = outputRef.current.scrollHeight
-
-				// Another attempt with more delay (for slower renders) to ensure scrolling works
 				setTimeout(() => {
 					if (outputRef.current) {
 						outputRef.current.scrollTop = outputRef.current.scrollHeight
@@ -40,28 +35,22 @@ export const CommandOutputContent = memo(
 			}
 		}, [output, isOutputFullyExpanded])
 
-		// Don't render anything if container is collapsed
 		if (!isContainerExpanded) {
 			return null
 		}
 
-		// Check if output contains a log file path indicator
 		const logFilePathMatch = output.match(/📋 Output is being logged to: ([^\n]+)/)
 		const logFilePath = logFilePathMatch ? logFilePathMatch[1].trim() : null
 
-		// Render output with clickable log file path
 		const renderOutput = () => {
 			if (!logFilePath) {
 				return <CodeBlock forceWrap={true} source={`${"```"}shell\n${output}\n${"```"}`} />
 			}
 
-			// Split output into parts: before log path, log path line, after log path
 			const logPathLineStart = output.indexOf("📋 Output is being logged to:")
 			const logPathLineEnd = output.indexOf("\n", logPathLineStart)
 			const beforeLogPath = output.substring(0, logPathLineStart)
 			const afterLogPath = logPathLineEnd !== -1 ? output.substring(logPathLineEnd) : ""
-
-			// Extract just the filename from the full path for display
 			const fileName = logFilePath.split("/").pop() || logFilePath
 
 			return (
@@ -85,20 +74,13 @@ export const CommandOutputContent = memo(
 
 		return (
 			<div
-				className={cn("w-full relative pb-0 overflow-visible border-t border-editor-group-border bg-code rounded-sm", {
-					"rounded-b-none": lineCount > 5,
-				})}>
-				<div
-					className={cn("text-white scroll-smooth bg-code overflow-y-auto", {
-						"max-h-[75px]": !shouldAutoShow && !isOutputFullyExpanded,
-						"max-h-[200px]": !shouldAutoShow && isOutputFullyExpanded,
-						"overflow-y-visible": shouldAutoShow,
-					})}
-					ref={outputRef}>
-					<div className="bg-code">{renderOutput()}</div>
-				</div>
-				{/* Show notch only if there's more than 5 lines */}
-				{lineCount > 5 && <ExpandHandle isExpanded={isOutputFullyExpanded} onToggle={onToggle} />}
+				className={cn("text-white scroll-smooth bg-code overflow-y-auto", {
+					"max-h-[75px]": !shouldAutoShow && !isOutputFullyExpanded,
+					"max-h-[200px]": !shouldAutoShow && isOutputFullyExpanded,
+					"overflow-y-visible": shouldAutoShow,
+				})}
+				ref={outputRef}>
+				<div className="bg-code">{renderOutput()}</div>
 			</div>
 		)
 	},
@@ -112,10 +94,8 @@ export const CommandOutputRow = memo(
 		isCommandExecuting = false,
 		isCommandPending = false,
 		isCommandCompleted = false,
-		isBackgroundExec = false, // vscodeTerminalExecutionMode === "backgroundExec"
+		isBackgroundExec = false,
 		onCancelCommand,
-		icon,
-		title,
 		isOutputFullyExpanded,
 		setIsOutputFullyExpanded,
 	}: {
@@ -125,11 +105,11 @@ export const CommandOutputRow = memo(
 		isCommandCompleted?: boolean
 		isBackgroundExec?: boolean
 		onCancelCommand?: () => void
-		icon?: JSX.Element | null
-		title?: JSX.Element | null
 		isOutputFullyExpanded: boolean
 		setIsOutputFullyExpanded: (expanded: boolean) => void
 	}) => {
+		const [isOutputExpanded, setIsOutputExpanded] = useState(false)
+
 		const splitMessage = (text: string) => {
 			const outputIndex = text.indexOf(COMMAND_OUTPUT_STRING)
 			if (outputIndex === -1) {
@@ -160,109 +140,111 @@ export const CommandOutputRow = memo(
 		}
 
 		const { command: rawCommand, output } = splitMessage(message.text || "")
-
 		const requestsApproval = rawCommand.endsWith(COMMAND_REQ_APP_STRING)
 		const command = requestsApproval ? rawCommand.slice(0, -COMMAND_REQ_APP_STRING.length) : rawCommand
 		const showCancelButton =
 			(isCommandExecuting || isCommandPending) && typeof onCancelCommand === "function" && isBackgroundExec
 
-		const commandHeader = (
-			<div className="flex items-center gap-2.5 mb-3">
-				{icon}
-				{title}
-			</div>
-		)
+		const getStatusDisplay = () => {
+			if (isCommandExecuting) {
+				return { text: "Running", color: "text-description", showCheck: false }
+			}
+			if (isCommandPending) {
+				return { text: "Pending", color: "text-editor-warning-foreground", showCheck: false }
+			}
+			if (isCommandCompleted || (output.length > 0 && !isCommandExecuting && !isCommandPending)) {
+				return { text: "Success", color: "text-success", showCheck: true }
+			}
+			return { text: "Skipped", color: "text-description", showCheck: false }
+		}
+
+		const status = getStatusDisplay()
 
 		return (
-			<>
-				{commandHeader}
-				<div
-					className="bg-code rounded-sm border border-editor-group-border"
-					style={{
-						transition: "all 0.3s ease-in-out",
-					}}>
-					{command && (
-						<div className="bg-code flex items-center justify-between px-2 py-2.5 border-b border-editor-group-border rounded-sm rounded-b-none overflow-hidden">
-							<div className="flex items-center gap-2 flex-1 m-w-0">
-								<div
-									className={cn("bg-description rounded-full w-2 h-2 shrink-0", {
-										"bg-success animate-pulse": isCommandExecuting,
-										"bg-editor-warning-foreground": isCommandPending,
-									})}
-								/>
-								<span
-									className={cn("text-description font-medium text-base shrink-0", {
-										"text-success": isCommandExecuting,
-										"text-editor-warning-foreground": isCommandPending,
-									})}>
-									{getCommandStatusText(isCommandExecuting, isCommandPending, isCommandCompleted)}
-								</span>
-							</div>
-							<div className="flex items-center gap-2 shrink-0">
-								{showCancelButton && (
-									<Button
-										onClick={(e) => {
-											e.stopPropagation()
-											if (isBackgroundExec) {
-												onCancelCommand?.()
-											} else {
-												// For regular terminal mode, show a message
-												alert(
-													"This command is running in the VSCode terminal. You can manually stop it using Ctrl+C in the terminal, or switch to Background Execution mode in settings for cancellable commands.",
-												)
-											}
-										}}
-										size="sm"
-										variant="secondary">
-										{isBackgroundExec ? "cancel" : "stop"}
-									</Button>
-								)}
-							</div>
-						</div>
-					)}
-
-					<div className="bg-code opacity-60 text-sm">
-						<CodeBlock forceWrap={true} source={`${"```"}shell\n${command}\n${"```"}`} />
-					</div>
-
-					{output.length > 0 && (
-						<CommandOutputContent
-							isContainerExpanded={true}
-							isOutputFullyExpanded={isOutputFullyExpanded}
-							onToggle={() => setIsOutputFullyExpanded(!isOutputFullyExpanded)}
-							output={output}
-						/>
-					)}
+			<div className="rounded-sm border border-editor-group-border overflow-hidden">
+				{/* Header */}
+				<div className="flex items-center gap-2 px-3 py-2 border-b border-editor-group-border/50">
+					<i className="codicon codicon-terminal text-description" />
+					<span className="text-sm text-foreground">Run CLI Command</span>
 				</div>
-				{requestsApproval && (
-					<div className="flex items-center gap-2.5 p-2 text-[12px] text-editor-warning-foreground">
-						<i className="codicon codicon-warning" />
-						<span>The model has determined this command requires explicit approval.</span>
+
+				{/* Command text */}
+				<div className="px-3 pt-3 pb-1.5 bg-code">
+					<pre className="font-mono text-sm whitespace-pre-wrap break-words m-0 text-link">{command}</pre>
+				</div>
+
+				{/* Command Output accordion */}
+				{output.length > 0 && (
+					<div>
+						<button
+							className={cn("flex items-center gap-1.5 w-full px-3 text-left", {
+								"py-2": !isOutputExpanded,
+								"pt-2 pb-1": isOutputExpanded,
+							})}
+							onClick={() => setIsOutputExpanded(!isOutputExpanded)}
+							type="button">
+							<ChevronRight
+								className={cn("text-description transition-transform", {
+									"rotate-90": isOutputExpanded,
+								})}
+								size={14}
+							/>
+							<span className="text-description text-sm">Command Output</span>
+						</button>
+						{isOutputExpanded && (
+							<div>
+								<CommandOutputContent
+									isContainerExpanded={true}
+									isOutputFullyExpanded={isOutputFullyExpanded}
+									onToggle={() => setIsOutputFullyExpanded(!isOutputFullyExpanded)}
+									output={output}
+								/>
+							</div>
+						)}
 					</div>
 				)}
-			</>
+
+				{/* Footer bar */}
+				<div className="flex items-center justify-between px-3 py-2 border-t border-editor-group-border/50">
+					<div className="flex items-center gap-2">
+						<button
+							className="flex items-center gap-1 text-sm text-foreground hover:text-description transition-colors"
+							type="button">
+							<span>Ask Everytime</span>
+							<ChevronDown className="text-description" size={14} />
+						</button>
+						{showCancelButton && (
+							<Button
+								onClick={(e) => {
+									e.stopPropagation()
+									if (isBackgroundExec) {
+										onCancelCommand?.()
+									} else {
+										alert(
+											"This command is running in the VSCode terminal. You can manually stop it using Ctrl+C in the terminal, or switch to Background Execution mode in settings for cancellable commands.",
+										)
+									}
+								}}
+								size="sm"
+								variant="secondary">
+								{isBackgroundExec ? "cancel" : "stop"}
+							</Button>
+						)}
+						{requestsApproval && (
+							<span className="text-xs text-editor-warning-foreground flex items-center gap-1.5">
+								<i className="codicon codicon-warning text-[11px]" />
+								Requires approval
+							</span>
+						)}
+					</div>
+					<div className="flex items-center gap-1.5">
+						{status.showCheck && <i className="codicon codicon-check text-sm text-success" />}
+						<span className={cn("text-sm", status.color)}>{status.text}</span>
+					</div>
+				</div>
+			</div>
 		)
 	},
 )
 
 CommandOutputRow.displayName = "CommandOutputRow"
-
-const CommandStatusMap = {
-	executing: "Running",
-	pending: "Pending",
-	completed: "Completed",
-	skipped: "Skipped",
-}
-
-function getCommandStatusText(isExecuting: boolean, isPending: boolean, isCompleted: boolean): string {
-	if (isExecuting) {
-		return CommandStatusMap.executing
-	}
-	if (isPending) {
-		return CommandStatusMap.pending
-	}
-	if (isCompleted) {
-		return CommandStatusMap.completed
-	}
-	return CommandStatusMap.skipped
-}

--- a/webview-ui/src/components/chat/CommandOutputRow.tsx
+++ b/webview-ui/src/components/chat/CommandOutputRow.tsx
@@ -112,7 +112,7 @@ interface CommandOutputRowProps {
  * - Collapsible output section
  * - Footer with auto-approve dropdown and action buttons
  */
-export const CommandOutputRow = ({
+export const CommandOutputRow = memo(({
 	message,
 	isCommandExecuting = false,
 	isCommandPending = false,
@@ -325,4 +325,6 @@ export const CommandOutputRow = ({
 			</div>
 		</div>
 	)
-}
+})
+
+CommandOutputRow.displayName = "CommandOutputRow"

--- a/webview-ui/src/components/chat/CommandOutputRow.tsx
+++ b/webview-ui/src/components/chat/CommandOutputRow.tsx
@@ -256,7 +256,7 @@ export const CommandOutputRow = memo(({
 							</SelectItem>
 						</SelectContent>
 					</Select>
-					{requestsApproval && !isCommandPending && (
+					{requestsApproval && isCommandPending && (
 						<span className="text-xs text-editor-warning-foreground flex items-center gap-1.5">
 							<i className="codicon codicon-warning text-[11px]" />
 							Requires approval

--- a/webview-ui/src/components/chat/chat-view/shared/buttonConfig.ts
+++ b/webview-ui/src/components/chat/chat-view/shared/buttonConfig.ts
@@ -69,11 +69,11 @@ export const BUTTON_CONFIGS: Record<string, ButtonConfig> = {
 	// Command execution states
 	command: {
 		sendingDisabled: false,
-		enableButtons: true,
-		primaryText: "Run Command",
-		secondaryText: "Reject",
-		primaryAction: "approve",
-		secondaryAction: "reject",
+		enableButtons: false, // Buttons are inline in the CommandOutputRow
+		primaryText: undefined,
+		secondaryText: undefined,
+		primaryAction: undefined,
+		secondaryAction: undefined,
 	},
 	command_output: {
 		sendingDisabled: false,
@@ -95,11 +95,11 @@ export const BUTTON_CONFIGS: Record<string, ButtonConfig> = {
 	},
 	use_mcp_server: {
 		sendingDisabled: false,
-		enableButtons: true,
-		primaryText: "Approve",
-		secondaryText: "Reject",
-		primaryAction: "approve",
-		secondaryAction: "reject",
+		enableButtons: false, // Buttons are inline in the MCP tool card
+		primaryText: undefined,
+		secondaryText: undefined,
+		primaryAction: undefined,
+		secondaryAction: undefined,
 	},
 	use_subagents: {
 		sendingDisabled: false,

--- a/webview-ui/src/components/common/CodeAccordian.tsx
+++ b/webview-ui/src/components/common/CodeAccordian.tsx
@@ -15,6 +15,8 @@ interface CodeAccordianProps {
 	isExpanded: boolean
 	onToggleExpand: () => void
 	isLoading?: boolean
+	variant?: "default" | "light" | "subtle"
+	noBorder?: boolean
 }
 
 /*
@@ -35,6 +37,8 @@ const CodeAccordian = ({
 	isExpanded,
 	onToggleExpand,
 	isLoading,
+	variant = "default",
+	noBorder = false,
 }: CodeAccordianProps) => {
 	const inferredLanguage = useMemo(
 		() => code && (language ?? (path ? getLanguageFromPath(path) : undefined)),
@@ -49,7 +53,13 @@ const CodeAccordian = ({
 	}, [code])
 
 	return (
-		<div className="bg-code overflow-hidden rounded-xs border border-editor-group-border">
+		<div
+			className={cn("overflow-hidden rounded-sm", {
+				"border border-editor-group-border": !noBorder,
+				"bg-code": variant === "default",
+				"bg-sidebar": variant === "light",
+				"bg-toolbar-hover/65": variant === "subtle",
+			})}>
 			{(path || isFeedback || isConsoleLogs) && (
 				<Button
 					aria-label={isExpanded ? "Collapse code block" : "Expand code block"}
@@ -93,7 +103,10 @@ const CodeAccordian = ({
 				</Button>
 			)}
 			{(!(path || isFeedback || isConsoleLogs) || isExpanded) && (
-				<div className="overflow-x-auto overflow-y-hidden max-w-full">
+				<div
+					className={cn("overflow-x-auto overflow-y-hidden max-w-full", {
+						"[&_*]:!bg-transparent": variant === "subtle",
+					})}>
 					<CodeBlock
 						source={`${"```"}${diff !== undefined ? "diff" : inferredLanguage}\n${(
 							code ?? diff ?? ""


### PR DESCRIPTION
## Summary

- Redesigns CLI command cards (`CommandOutputRow`) with new card-based layout matching Figma specs
- Redesigns MCP tool cards (`use_mcp_server`) with collapsible arguments and inline response display
- Adds inline action buttons (Run/Cancel) directly in tool cards instead of global action bar
- Adds auto-approve dropdown to both CLI command and MCP tool cards for quick setting changes

## Screenshots

### CLI Command - Pending
<img width="504" alt="CLI Command Pending" src="https://github.com/user-attachments/assets/323ef48e-1d00-46df-8940-5bcf67627ac9" />

### CLI Command - Success
<img width="497" alt="CLI Command Success" src="https://github.com/user-attachments/assets/823d60b2-f90f-402e-9f79-a38b54c6fabe" />

### MCP Tool - Pending
<img width="496" alt="MCP Tool Pending" src="https://github.com/user-attachments/assets/d5bb211d-8f35-48f8-9bd7-9c55b672bff0" />

### MCP Tool - Success
<img width="495" alt="MCP Tool Success" src="https://github.com/user-attachments/assets/ede01036-160a-4018-af0b-5ceb7aa95c33" />

## Changes

### CommandOutputRow.tsx
- Complete redesign with header, command display, collapsible output accordion
- Footer with auto-approve dropdown and inline Cancel/Run buttons
- Status indicators: Pending (warning), Running (spinner), Success (checkmark)

### ChatRow.tsx (MCP Tool Card)
- New card design for `use_mcp_tool` type with collapsible arguments section
- MCP response now displayed inline in the card (replaces separate `McpResponseDisplay`)
- Same inline button pattern and auto-approve dropdown as CLI commands

### buttonConfig.ts
- Disabled global bottom buttons for `command` and `use_mcp_server` types since buttons are now inline

### CodeAccordian.tsx
- Added `variant` prop ("default" | "light" | "subtle") for different backgrounds
- Added `noBorder` prop for borderless rendering

## Test plan

- [ ] CLI Command Card:
  - [ ] Pending state shows Cancel/Run buttons, dropdown shows "Ask Every Time"
  - [ ] Running state shows spinner and Cancel text
  - [ ] Success state shows checkmark and "Success" text
  - [ ] "Requires approval" warning only shows when pending
  - [ ] Dropdown toggles persist the setting

- [ ] MCP Tool Card:
  - [ ] Same button/dropdown behavior as CLI command
  - [ ] Arguments accordion expands/collapses correctly
  - [ ] Tool response displays inline after success
  - [ ] Auto-approve dropdown only visible when global MCP auto-approval is enabled

- [ ] Auto-approve setting actually works (toggle to auto, new commands run automatically)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Redesigns CLI command and MCP tool cards with inline action buttons and auto-approve dropdown, enhancing user interaction and aligning with Figma specs.
> 
>   - **UI Redesign**:
>     - `CommandOutputRow.tsx`: Redesigned CLI command cards with inline Run/Cancel buttons and auto-approve dropdown.
>     - `ChatRow.tsx`: Redesigned MCP tool cards with collapsible arguments and inline response display.
>   - **Functionality**:
>     - Inline action buttons replace global action bar for `command` and `use_mcp_server` types.
>     - Auto-approve dropdown added for quick setting changes.
>   - **Supporting Changes**:
>     - `buttonConfig.ts`: Disabled global buttons for `command` and `use_mcp_server` types.
>     - `CodeAccordian.tsx`: Added `variant` and `noBorder` props for styling.
>   - **Testing**:
>     - Updated stories in `App.stories.tsx` to reflect new UI and functionality.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 366ff07e16d4ca44a9e49b98e9c704742242ea44. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->