### PR TITLE
feat(hooks): add Windows hook execution via PowerShell

### DIFF
--- a/.changeset/windows-hooks-powershell.md
+++ b/.changeset/windows-hooks-powershell.md
@@ -1,0 +1,4 @@
+"claude-dev": patch
+---
+
+Add Windows hooks support by running hook files with PowerShell, while keeping extensionless hook naming and file-presence semantics on Windows.

--- a/docs/customization/hooks.mdx
+++ b/docs/customization/hooks.mdx
@@ -143,15 +143,19 @@ echo '{"cancel":false}'
 
 <Steps>
   <Step title="Create the hook file">
-    Save the script above as `~/Documents/Cline/Hooks/file-logger` (macOS/Linux) or create it through the Hooks UI.
+    Save the script above as `~/Documents/Cline/Hooks/file-logger` or create it through the Hooks UI.
   </Step>
   <Step title="Make it executable">
-    Run `chmod +x ~/Documents/Cline/Hooks/file-logger` in your terminal.
+    On macOS/Linux, run `chmod +x ~/Documents/Cline/Hooks/file-logger`.
   </Step>
-  <Step title="Enable it">
+  <Step title="Enable it (macOS/Linux only)">
     In Cline's Hooks tab, find "file-logger" under PreToolUse hooks and toggle it on.
   </Step>
 </Steps>
+
+<Note>
+On Windows, hooks are executed with PowerShell and run whenever the hook file exists.
+</Note>
 
 ### Test It
 
@@ -444,14 +448,15 @@ cline config set hooks-enabled=true
 ```
 
 <Note>
-CLI hooks are only supported on macOS and Linux.
+Windows hooks require PowerShell (`powershell.exe`) available on your PATH.
 </Note>
 
 ## Troubleshooting
 
 **Hook not running?**
-- Check that the file is executable (`chmod +x hookname`)
-- Verify the hook is enabled (toggle is on in the Hooks tab)
+- On macOS/Linux, check that the file is executable (`chmod +x hookname`)
+- On Windows, ensure PowerShell is available (`powershell -NoProfile -Command "$PSVersionTable.PSVersion"`)
+- On macOS/Linux, verify the hook is enabled (toggle is on in the Hooks tab)
 - Check that Hooks are enabled globally in Settings
 
 **Hook output not parsed?**

--- a/src/core/hooks/HookProcess.ts
+++ b/src/core/hooks/HookProcess.ts
@@ -7,6 +7,32 @@ import { escapeShellPath } from "./shell-escape"
 // Maximum total output size (stdout + stderr combined)
 const MAX_HOOK_OUTPUT_SIZE = 1024 * 1024 // 1MB
 
+interface HookLaunchConfig {
+	command: string
+	args: string[]
+	shell: boolean
+	detached: boolean
+}
+
+function getHookLaunchConfig(scriptPath: string): HookLaunchConfig {
+	if (process.platform === "win32") {
+		return {
+			command: "powershell.exe",
+			args: ["-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass", "-File", scriptPath],
+			shell: false,
+			detached: false,
+		}
+	}
+
+	const escapedScriptPath = escapeShellPath(scriptPath)
+	return {
+		command: escapedScriptPath,
+		args: [],
+		shell: true,
+		detached: true,
+	}
+}
+
 /**
  * HookProcess manages the execution of a hook script with streaming output capabilities.
  * Similar to StandaloneTerminalProcess but specialized for hook execution.
@@ -100,16 +126,15 @@ export class HookProcess extends EventEmitter {
 					this.abortSignal.addEventListener("abort", abortHandler, { once: true })
 				}
 
-				// Spawn the hook process through shell on all platforms
-				// This is the git-style approach: the shell interprets the shebang line
-				// and executes the appropriate interpreter (bash, node, python, etc.)
-				// On Unix: detached=true creates a process group, allowing us to kill all children
-				const escapedScriptPath = escapeShellPath(this.scriptPath)
-				this.childProcess = spawn(escapedScriptPath, [], {
+				// Windows executes hooks with PowerShell directly.
+				// Unix executes hook files through the shell for shebang support.
+				const launchConfig = getHookLaunchConfig(this.scriptPath)
+				this.childProcess = spawn(launchConfig.command, launchConfig.args, {
 					stdio: ["pipe", "pipe", "pipe"],
-					shell: true, // Use shell on all platforms for shebang interpretation
-					detached: process.platform !== "win32", // Create process group on Unix
+					shell: launchConfig.shell,
+					detached: launchConfig.detached,
 					cwd: this.cwd, // Execute from the determined workspace root
+					windowsHide: true,
 				})
 
 				let didEmitEmptyLine = false

--- a/src/core/hooks/__tests__/hooks-utils.test.ts
+++ b/src/core/hooks/__tests__/hooks-utils.test.ts
@@ -33,9 +33,9 @@ describe("hooks-utils", () => {
 				})
 			})
 
-			it("should return false", () => {
+			it("should return true", () => {
 				const result = getHooksEnabledSafe()
-				result.should.be.false()
+				result.should.be.true()
 			})
 		})
 

--- a/src/core/hooks/hook-factory.ts
+++ b/src/core/hooks/hook-factory.ts
@@ -916,9 +916,8 @@ export class HookFactory {
 	}
 
 	/**
-	 * Finds a hook on Windows using git-style hook discovery.
-	 * Like git, we look for a file with the hook name (no extension) and execute it
-	 * through the shell, which handles shebangs and script interpretation.
+	 * Finds a hook on Windows by checking for a hook file with the canonical hook name.
+	 * Hooks are extensionless by design (`HookName`) for parity with existing Unix naming.
 	 *
 	 * @param hookName the name of the hook to search for
 	 * @param hooksDir the hooks directory path to search
@@ -933,7 +932,7 @@ export class HookFactory {
 			return stat.isFile() ? candidate : undefined
 		} catch (error) {
 			HookFactory.handleHookDiscoveryError(error, hookName, candidate)
-			// Expected error (file doesn't exist), return undefined
+			// Expected errors (missing/non-readable hook) return no match.
 			return undefined
 		}
 	}
@@ -954,7 +953,7 @@ export class HookFactory {
 			return stat.isFile() ? candidate : undefined
 		} catch (error) {
 			HookFactory.handleHookDiscoveryError(error, hookName, candidate)
-			// Expected error (file doesn't exist or not executable), return undefined
+			// Expected errors (missing/non-executable hook) return no match.
 			return undefined
 		}
 	}

--- a/src/core/hooks/hooks-utils.ts
+++ b/src/core/hooks/hooks-utils.ts
@@ -1,24 +1,14 @@
 /**
  * Determines if hooks are safely enabled based on platform support.
  *
- * Hooks are not yet supported on Windows, so this function ensures they
- * remain disabled on that platform regardless of user settings.
+ * NOTE: This function is the single choke point used by the task runtime and
+ * webview state to determine the effective hooks setting.
+ *
+ * Hooks are now supported on Windows. Individual hook execution still depends
+ * on hook discovery and platform-specific execution details.
  *
  * @returns true if hooks are enabled and supported on this platform, false otherwise
  */
 export function getHooksEnabledSafe(): boolean {
-	// Hooks are not yet supported on Windows.
-	//
-	// NOTE: This function is the single choke point used by the task runtime and
-	// webview state to determine the *effective* hooks setting. Hard-coding here
-	// ensures hooks are always enabled everywhere (TaskStart/Resume/Cancel,
-	// PreToolUse/PostToolUse, UI grouping) without having to override multiple
-	// call sites.
-	if (process.platform === "win32") {
-		return false
-	}
-
-	// Hard-coded: always enable hooks on supported platforms (macOS/Linux),
-	// regardless of persisted user setting.
 	return true
 }

--- a/webview-ui/src/components/cline-rules/ClineRulesToggleModal.tsx
+++ b/webview-ui/src/components/cline-rules/ClineRulesToggleModal.tsx
@@ -680,7 +680,9 @@ const ClineRulesToggleModal: React.FC = () => {
 							<>
 								<div className="text-xs text-description mb-4">
 									<p>
-										Toggle to enable/disable (chmod +x/-x).{" "}
+										{isWindows
+											? "On Windows, hooks execute whenever the hook file exists."
+											: "Toggle to enable/disable (chmod +x/-x)."}{" "}
 										<VSCodeLink
 											className="text-xs"
 											href="https://docs.cline.bot/features/hooks"
@@ -695,8 +697,8 @@ const ClineRulesToggleModal: React.FC = () => {
 									<div className="flex items-center gap-2 px-5 py-3 mb-4 bg-vscode-inputValidation-warningBackground border-l-[3px] border-vscode-inputValidation-warningBorder">
 										<i className="codicon codicon-warning text-sm" />
 										<span className="text-base">
-											Hook toggling is not supported on Windows. Hooks can be created, edited, and deleted,
-											but cannot be enabled/disabled and will not execute.
+											Hook toggling is not supported on Windows. Hooks can be created, edited, and deleted, and
+											execute whenever the hook file exists.
 										</span>
 									</div>
 								)}

--- a/webview-ui/src/components/cline-rules/HookRow.tsx
+++ b/webview-ui/src/components/cline-rules/HookRow.tsx
@@ -60,7 +60,7 @@ const HookRow: React.FC<HookRowProps> = ({
 					<div
 						title={
 							isWindows
-								? "Hook toggling not supported on Windows. Hooks can be edited and deleted, but won't execute."
+								? "Hook toggling is not supported on Windows. Hooks execute when the hook file exists."
 								: undefined
 						}>
 						<Switch


### PR DESCRIPTION
### Related Issue

Issue: none

### Description

This PR adds hook execution support on Windows.

Before this change, hooks were effectively disabled on Windows at runtime. The hook system relied on Unix style executable-bit behavior and shell shebang execution patterns, and Windows could not participate in the same enable or disable flow because there is no equivalent chmod +x toggle model. As a result, Windows users could create and edit hook files, but hooks did not run.

This change enables Windows hooks by switching Windows execution to PowerShell while preserving existing behavior on macOS and Linux.

Core behavior after this PR:

- Windows hook execution now runs through `powershell.exe` in `HookProcess`, using `-NoProfile`, `-NonInteractive`, `-ExecutionPolicy Bypass`, and `-File <hookPath>`.
- Hook lookup remains intentionally simple and low risk: a hook runs if the canonical hook file exists.
- No extra hook state metadata file was introduced for Windows. There is no separate on or off persistence layer for Windows hooks in this PR.
- On Windows, enabled state is presence based. If the hook file exists, it is considered enabled.
- Toggle UX remains disabled on Windows, and UI copy now reflects actual behavior: hooks execute when the file exists.
- macOS and Linux behavior remains the same: executable bit still controls enabled state.

Template and docs updates:

- Windows hook templates now generate PowerShell content instead of Unix shell content.
- Docs now explain Windows PowerShell requirement and presence based semantics.
- UI messages in the hooks modal and row tooltip were updated to match runtime behavior.

Implementation details and decisions:

- I intentionally kept Windows semantics minimal and predictable for maintainability.
- I did not add extension based discovery complexity. Hook naming stays canonical and extensionless.
- I did not add a Windows specific toggle state file, to avoid introducing a second source of truth.
- I kept Unix logic intact and isolated Windows behavior to the Windows execution path and Windows enabled-state interpretation.

Debugging and iteration notes:

- Initial exploration considered Python execution and extension support.
- During review iteration we simplified to PowerShell only on Windows for better default availability.
- We then removed extension handling to keep the patch focused, less invasive, and easier to reason about for maintainers.
- Along the way we confirmed that trying to mirror chmod style toggle semantics on Windows introduces unnecessary complexity and edge cases, so we retained file presence semantics there.

### Test Procedure

Automated tests run locally:

- `npx cross-env TS_NODE_PROJECT=./tsconfig.unit-test.json mocha --no-config --require ts-node/register --require source-map-support/register --require ./src/test/requires.ts src/test/hook-management.test.ts src/test/hook-executor.test.ts src/core/hooks/__tests__/hooks-utils.test.ts`
  - Result: passing
- `npx cross-env TS_NODE_PROJECT=./tsconfig.unit-test.json mocha --no-config --require ts-node/register --require source-map-support/register --require ./src/test/requires.ts src/test/hook-management-integration.test.ts`
  - Result: passing
- `npm run test:webview`
  - Result: passing

Reviewer validation checklist for Windows:

1. Open Hooks UI on Windows and create a hook such as `TaskStart`.
2. Confirm the hook file is created and toggle is disabled in UI.
3. Add a simple PowerShell body that prints valid hook JSON to stdout.
4. Start a task and verify the hook runs.
5. Delete the hook file and verify it no longer runs.
6. Confirm no manual chmod style step is required on Windows.

Regression checklist for macOS and Linux:

1. Create a hook and verify default non executable state.
2. Toggle on and off and confirm executable-bit behavior remains unchanged.
3. Run a task and confirm enabled hooks still execute through the existing Unix path.

Why this should not break existing behavior:

- Windows specific launch behavior is isolated in `HookProcess` behind platform checks.
- Unix execution path and executable-bit checks are preserved.
- Hook discovery keeps canonical naming and existing path conventions.
- UI only updates explanatory text for Windows and keeps toggle disabling as before.

### Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ♻️ Refactor Changes
- [ ] 💅 Cosmetic Changes
- [x] 📚 Documentation update
- [ ] 🏃 Workflow Changes

### Pre-flight Checklist

- [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
- [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
- [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
- [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

No visual layout changes beyond Windows hooks copy updates.

### Additional Notes

I kept this change intentionally small in surface area for easier review:

- no protocol changes
- no new persistence format
- no Windows only metadata file
- no changes to Unix toggle semantics

If maintainers prefer to expand Windows toggling semantics later, that can be done in a follow-up without reworking this runtime foundation.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add Windows hook execution support using PowerShell, maintaining Unix behavior and updating UI and documentation accordingly.
> 
>   - **Behavior**:
>     - Windows hooks now execute via `powershell.exe` in `HookProcess`, using `-NoProfile`, `-NonInteractive`, `-ExecutionPolicy Bypass`, and `-File <hookPath>`.
>     - On Windows, hooks are enabled if the file exists; no chmod equivalent.
>     - macOS/Linux behavior unchanged; executable bit still controls enabled state.
>   - **UI**:
>     - Updated hooks modal and tooltip in `ClineRulesToggleModal.tsx` and `HookRow.tsx` to reflect Windows behavior.
>     - Toggle switch disabled on Windows; hooks execute if file exists.
>   - **Templates**:
>     - Windows hook templates in `templates.ts` now generate PowerShell scripts.
>   - **Tests**:
>     - Updated `hooks-utils.test.ts` to reflect Windows support for hooks.
>   - **Misc**:
>     - Updated documentation in `hooks.mdx` to include Windows-specific instructions.
>     - `getHooksEnabledSafe()` in `hooks-utils.ts` now returns true for all platforms.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 626362a1f039e290c644a1f618afdc6237817d4a. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->