### PR TITLE
fix auth check for acp mode

### DIFF
--- a/.changeset/tender-berries-search.md
+++ b/.changeset/tender-berries-search.md
@@ -1,0 +1,5 @@
+---
+"cline": patch
+---
+
+fix acp auth check so acp mode can be used with more providers

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -797,7 +797,7 @@ devCommand
  * If `welcomeViewCompleted` is undefined (first run), checks if ANY provider has credentials
  * and sets the flag accordingly.
  */
-async function isAuthConfigured(): Promise<boolean> {
+export async function isAuthConfigured(): Promise<boolean> {
 	const stateManager = StateManager.get()
 
 	// Check welcomeViewCompleted first - this is the single source of truth


### PR DESCRIPTION
- acp code wasn't using the proper 'isAuthConfigured' method for checking auth status

<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- For feature requests: Created a discussion in our Feature Requests discussions board https://github.com/cline/cline/discussions/categories/feature-requests and received approval from core maintainers before implementation
- For all changes: Link the associated issue/discussion in the "Related Issue" section below

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly without prior discussion.

Why this requirement?
We deeply appreciate all community contributions - they are essential to Cline's success! To ensure the best use of everyone's time and maintain project direction, we use our Feature Requests discussions board to gauge community interest and validate feature ideas before implementation begins. This helps us focus development efforts on features that will benefit the most users.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** N/A

### Description

Cline ACP mode was using a different auth check method. This PR updates it to use the same 'isAuthConfigured' method as the rest of the cli, ensuring consistent auth status checks
<!-- 
Help reviewers understand your changes by making this PR readable and well-organized:

- What problem does this PR solve?
- Why were these changes introduced and what purpose do they serve?
- For larger changes, provide context about your approach and reasoning

Small PRs may need minimal description, but larger changes benefit from explaining where you're coming from. Much of this context can be in the linked issue above, so feel free to reference it rather than repeating everything here.
-->

### Test Procedure
Ran Cline ACP mode with bedrock provider and verified am able to run cline in Zed.

1. run `npm run cli:link`
2. `cline auth` with bedrock provider (i used aws profile method)
3. open zed and create new cline acp session
4. expectation: cline should work in zed at this point; it should NOT ask you to sign with cline or chatgpt (because you are authed with bedrock)

<!-- 
Please walk us through your testing approach and thought process. This helps reviewers understand that you've thoroughly considered the impact of your changes:

- How did you test this change?
- What could potentially break and how did you verify it doesn't?
- What existing functionality might be affected and how did you check it still works?
- Why are you confident this is ready for merge?

We're not looking for exhaustive documentation - just evidence that you've thought through the implications of your changes and tested accordingly.
-->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes authentication check in ACP mode by using shared `isAuthConfigured()` method for consistent auth checks.
> 
>   - **Behavior**:
>     - Replaces custom `isAuthConfigured()` in `ClineAgent` with shared `isAuthConfigured()` from `index.ts` for consistent auth checks.
>   - **Functions**:
>     - Removes `isAuthConfigured()` from `ClineAgent` class.
>     - Exports `isAuthConfigured()` in `index.ts` for broader use.
>   - **Misc**:
>     - Updates `newSession()` in `ClineAgent` to use the shared `isAuthConfigured()` method.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 7b5c1d2776b06d7611c64a29956116bf1bbbca05. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->