### PR TITLE
test(oca): add coverage for messages api routing and stream helpers

### DIFF
--- a/src/core/api/providers/__tests__/oca.test.ts
+++ b/src/core/api/providers/__tests__/oca.test.ts
@@ -1,0 +1,93 @@
+import { expect } from "chai"
+import { afterEach, describe, it } from "mocha"
+import sinon from "sinon"
+import { ClineStorageMessage } from "@/shared/messages/content"
+import { ApiFormat } from "@/shared/proto/index.cline"
+import { OcaHandler } from "../oca"
+
+const messages: ClineStorageMessage[] = [{ role: "user", content: "Hello" }]
+
+async function collectChunks(stream: AsyncGenerator<any>) {
+	const chunks: any[] = []
+	for await (const chunk of stream) {
+		chunks.push(chunk)
+	}
+	return chunks
+}
+
+describe("OcaHandler.createMessage", () => {
+	afterEach(() => {
+		sinon.restore()
+	})
+
+	it("routes OPENAI_RESPONSES models to createMessageResponsesApi", async () => {
+		const handler = new OcaHandler({
+			ocaModelInfo: { apiFormat: ApiFormat.OPENAI_RESPONSES } as any,
+		})
+
+		const chatStub = sinon.stub(handler as any, "createMessageChatApi").callsFake(async function* () {
+			yield { type: "text", text: "chat" }
+		})
+		const responsesStub = sinon.stub(handler as any, "createMessageResponsesApi").callsFake(async function* () {
+			yield { type: "text", text: "responses" }
+		})
+		const messagesStub = sinon.stub(handler as any, "createMessageMessagesApi").callsFake(async function* () {
+			yield { type: "text", text: "messages" }
+		})
+
+		const chunks = await collectChunks(handler.createMessage("system", messages))
+
+		expect(chunks).to.deep.equal([{ type: "text", text: "responses" }])
+		sinon.assert.notCalled(chatStub)
+		sinon.assert.calledOnce(responsesStub)
+		sinon.assert.notCalled(messagesStub)
+	})
+
+	it("routes ANTHROPIC_CHAT models to createMessageMessagesApi", async () => {
+		const handler = new OcaHandler({
+			ocaModelInfo: { apiFormat: ApiFormat.ANTHROPIC_CHAT } as any,
+		})
+
+		const chatStub = sinon.stub(handler as any, "createMessageChatApi").callsFake(async function* () {
+			yield { type: "text", text: "chat" }
+		})
+		const responsesStub = sinon.stub(handler as any, "createMessageResponsesApi").callsFake(async function* () {
+			yield { type: "text", text: "responses" }
+		})
+		const messagesStub = sinon.stub(handler as any, "createMessageMessagesApi").callsFake(async function* () {
+			yield { type: "text", text: "messages" }
+		})
+
+		const chunks = await collectChunks(handler.createMessage("system", messages))
+
+		expect(chunks).to.deep.equal([{ type: "text", text: "messages" }])
+		sinon.assert.notCalled(chatStub)
+		sinon.assert.notCalled(responsesStub)
+		sinon.assert.calledOnce(messagesStub)
+	})
+
+	it("defaults to createMessageChatApi for OPENAI_CHAT and undefined apiFormat", async () => {
+		for (const apiFormat of [ApiFormat.OPENAI_CHAT, undefined]) {
+			const handler = new OcaHandler({
+				ocaModelInfo: { apiFormat } as any,
+			})
+
+			const chatStub = sinon.stub(handler as any, "createMessageChatApi").callsFake(async function* () {
+				yield { type: "text", text: "chat" }
+			})
+			const responsesStub = sinon.stub(handler as any, "createMessageResponsesApi").callsFake(async function* () {
+				yield { type: "text", text: "responses" }
+			})
+			const messagesStub = sinon.stub(handler as any, "createMessageMessagesApi").callsFake(async function* () {
+				yield { type: "text", text: "messages" }
+			})
+
+			const chunks = await collectChunks(handler.createMessage("system", messages))
+
+			expect(chunks).to.deep.equal([{ type: "text", text: "chat" }])
+			sinon.assert.calledOnce(chatStub)
+			sinon.assert.notCalled(responsesStub)
+			sinon.assert.notCalled(messagesStub)
+		}
+	})
+})

--- a/src/core/api/utils/__tests__/messages_api_support.test.ts
+++ b/src/core/api/utils/__tests__/messages_api_support.test.ts
@@ -1,0 +1,243 @@
+import { expect } from "chai"
+import { describe, it } from "mocha"
+import type { ChatCompletionTool as OpenAITool } from "openai/resources/chat/completions"
+import { convertOpenAIToolsToAnthropicTools, handleAnthropicMessagesApiStreamResponse } from "../messages_api_support"
+
+const createAsyncIterable = (events: any[]) =>
+	({
+		async *[Symbol.asyncIterator]() {
+			for (const event of events) {
+				yield event
+			}
+		},
+	}) as any
+
+async function collectChunks(events: any[]) {
+	const chunks: any[] = []
+	for await (const chunk of handleAnthropicMessagesApiStreamResponse(createAsyncIterable(events))) {
+		chunks.push(chunk)
+	}
+	return chunks
+}
+
+describe("messages_api_support", () => {
+	describe("convertOpenAIToolsToAnthropicTools", () => {
+		it("returns undefined when tools are missing", () => {
+			expect(convertOpenAIToolsToAnthropicTools(undefined)).to.equal(undefined)
+			expect(convertOpenAIToolsToAnthropicTools([])).to.equal(undefined)
+		})
+
+		it("converts function tools and defaults schema type to object", () => {
+			const tools: OpenAITool[] = [
+				{
+					type: "function",
+					function: {
+						name: "read_file",
+						description: "Read a file from disk",
+						parameters: {
+							properties: {
+								path: { type: "string" },
+							},
+							required: ["path"],
+						},
+					},
+				},
+			]
+
+			const converted = convertOpenAIToolsToAnthropicTools(tools)
+
+			expect(converted).to.deep.equal([
+				{
+					name: "read_file",
+					description: "Read a file from disk",
+					input_schema: {
+						type: "object",
+						properties: {
+							path: { type: "string" },
+						},
+						required: ["path"],
+					},
+				},
+			])
+		})
+
+		it("filters out invalid tools", () => {
+			const tools = [
+				{
+					type: "other",
+					function: {
+						name: "ignored",
+					},
+				},
+				{
+					type: "function",
+					function: {
+						name: "",
+					},
+				},
+				{
+					type: "function",
+					function: {
+						name: "valid_tool",
+						parameters: { type: "object", properties: {} },
+					},
+				},
+			] as any as OpenAITool[]
+
+			const converted = convertOpenAIToolsToAnthropicTools(tools)
+
+			expect(converted).to.have.length(1)
+			expect(converted?.[0]?.name).to.equal("valid_tool")
+		})
+	})
+
+	describe("handleAnthropicMessagesApiStreamResponse", () => {
+		it("maps usage, reasoning, and text events into ApiStream chunks", async () => {
+			const chunks = await collectChunks([
+				{
+					type: "message_start",
+					message: {
+						usage: {
+							input_tokens: 10,
+							output_tokens: 2,
+							cache_creation_input_tokens: 4,
+							cache_read_input_tokens: 3,
+						},
+					},
+				},
+				{
+					type: "content_block_start",
+					content_block: {
+						type: "thinking",
+						thinking: "first thought",
+						signature: "sig-start",
+					},
+					index: 0,
+				},
+				{
+					type: "content_block_delta",
+					delta: {
+						type: "thinking_delta",
+						thinking: " then more",
+					},
+				},
+				{
+					type: "content_block_delta",
+					delta: {
+						type: "signature_delta",
+						signature: "sig-final",
+					},
+				},
+				{
+					type: "content_block_start",
+					content_block: {
+						type: "text",
+						text: "Hello",
+					},
+					index: 0,
+				},
+				{
+					type: "content_block_start",
+					content_block: {
+						type: "text",
+						text: "World",
+					},
+					index: 1,
+				},
+				{
+					type: "message_delta",
+					usage: {
+						output_tokens: 9,
+					},
+				},
+			])
+
+			expect(chunks).to.deep.equal([
+				{
+					type: "usage",
+					inputTokens: 10,
+					outputTokens: 2,
+					cacheWriteTokens: 4,
+					cacheReadTokens: 3,
+				},
+				{
+					type: "reasoning",
+					reasoning: "first thought",
+					signature: "sig-start",
+				},
+				{
+					type: "reasoning",
+					reasoning: " then more",
+				},
+				{
+					type: "reasoning",
+					reasoning: "",
+					signature: "sig-final",
+				},
+				{
+					type: "text",
+					text: "Hello",
+				},
+				{
+					type: "text",
+					text: "\n",
+				},
+				{
+					type: "text",
+					text: "World",
+				},
+				{
+					type: "usage",
+					inputTokens: 0,
+					outputTokens: 9,
+				},
+			])
+		})
+
+		it("emits tool call chunks and resets tool state on block stop", async () => {
+			const chunks = await collectChunks([
+				{
+					type: "content_block_start",
+					content_block: {
+						type: "tool_use",
+						id: "tool_1",
+						name: "read_file",
+					},
+					index: 0,
+				},
+				{
+					type: "content_block_delta",
+					delta: {
+						type: "input_json_delta",
+						partial_json: '{"path":',
+					},
+				},
+				{
+					type: "content_block_stop",
+				},
+				{
+					type: "content_block_delta",
+					delta: {
+						type: "input_json_delta",
+						partial_json: '"ignored-after-stop"}',
+					},
+				},
+			])
+
+			expect(chunks).to.have.length(1)
+			expect(chunks[0]).to.deep.equal({
+				type: "tool_calls",
+				tool_call: {
+					id: "tool_1",
+					name: "read_file",
+					arguments: "",
+					function: {
+						id: "tool_1",
+						name: "read_file",
+						arguments: '{"path":',
+					},
+				},
+			})
+		})
+	})
+})


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

### Description

Adds focused unit test coverage for the Oracle Code Assist Messages API path introduced in #9447.

This PR covers:
- `OcaHandler.createMessage` routing for `OPENAI_CHAT`, `OPENAI_RESPONSES`, and `ANTHROPIC_CHAT`
- `convertOpenAIToolsToAnthropicTools` behavior for empty, invalid, and valid inputs
- `handleAnthropicMessagesApiStreamResponse` mapping of usage/reasoning/text/tool-call events

### Test Procedure

- Ran targeted unit tests:
  - `npm run test:unit -- --grep "messages_api_support|OcaHandler.createMessage"`
- Result: `8 passing`
- Ran type checks:
  - `npm run check-types`
- Result: pass

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A

### Additional Notes

This is intentionally tests-only and does not change runtime behavior.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add unit tests for Oracle Code Assist Messages API routing and stream handling.
> 
>   - **Tests**:
>     - Add `oca.test.ts` to test `OcaHandler.createMessage` routing for `OPENAI_CHAT`, `OPENAI_RESPONSES`, and `ANTHROPIC_CHAT`.
>     - Add `messages_api_support.test.ts` to test `convertOpenAIToolsToAnthropicTools` for empty, invalid, and valid inputs.
>     - Test `handleAnthropicMessagesApiStreamResponse` for mapping usage, reasoning, text, and tool-call events.
>   - **Behavior**:
>     - `OcaHandler.createMessage` routes `OPENAI_RESPONSES` to `createMessageResponsesApi`, `ANTHROPIC_CHAT` to `createMessageMessagesApi`, and defaults `OPENAI_CHAT` to `createMessageChatApi`.
>     - `convertOpenAIToolsToAnthropicTools` returns `undefined` for missing tools, converts valid tools, and filters invalid ones.
>     - `handleAnthropicMessagesApiStreamResponse` maps events into `ApiStream` chunks and handles tool call chunks.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for edf8070900d78acd564144836ec55352a0744cbd. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->