### PR TITLE
fix: remove placeholder tools from final native tool list

### DIFF
--- a/src/core/prompts/system-prompt/__tests__/PromptRegistry.test.ts
+++ b/src/core/prompts/system-prompt/__tests__/PromptRegistry.test.ts
@@ -102,6 +102,36 @@ describe("PromptRegistry", () => {
 		})
 	})
 
+	describe("native tools", () => {
+		it("should not include focus_chain in native tools output", async () => {
+			const nativeContext: SystemPromptContext = {
+				...mockContext,
+				enableNativeToolCalls: true,
+				providerInfo: {
+					...mockProviderInfo,
+					providerId: "openai-native",
+					model: { ...mockProviderInfo.model, id: "gpt-5" },
+				},
+			}
+
+			await registry.get(nativeContext)
+			const nativeTools = registry.nativeTools
+
+			expect(nativeTools).to.be.an("array").that.is.not.empty
+
+			// OpenAI-native tools are function tools; keep a fallback for other providers.
+			const toolNames = (nativeTools as any[]).map((tool) => {
+				if (tool?.type === "function") {
+					return tool.function?.name
+				}
+				return tool?.name
+			})
+
+			expect(toolNames).to.not.include("focus_chain")
+			expect(JSON.stringify(nativeTools)).to.not.include('"focus_chain"')
+		})
+	})
+
 	describe("getAvailableModels", () => {
 		it("should return list of available model IDs", () => {
 			const models = registry.getAvailableModels()

--- a/src/core/prompts/system-prompt/__tests__/__snapshots__/cline_native_next_gen.tools.snap
+++ b/src/core/prompts/system-prompt/__tests__/__snapshots__/cline_native_next_gen.tools.snap
@@ -425,20 +425,6 @@
   {
     "type": "function",
     "function": {
-      "name": "focus_chain",
-      "description": "",
-      "strict": false,
-      "parameters": {
-        "type": "object",
-        "properties": {},
-        "required": [],
-        "additionalProperties": false
-      }
-    }
-  },
-  {
-    "type": "function",
-    "function": {
       "name": "generate_explanation",
       "description": "Opens a multi-file diff view and generates AI-powered inline comments explaining the changes between two git references. Use this tool to help users understand code changes from git commits, pull requests, branches, or any git refs. The tool uses git to retrieve file contents and displays a side-by-side diff view with explanatory comments.",
       "strict": false,

--- a/src/core/prompts/system-prompt/__tests__/__snapshots__/openai_gpt_5_1_native.tools.snap
+++ b/src/core/prompts/system-prompt/__tests__/__snapshots__/openai_gpt_5_1_native.tools.snap
@@ -376,20 +376,6 @@
   {
     "type": "function",
     "function": {
-      "name": "focus_chain",
-      "description": "",
-      "strict": false,
-      "parameters": {
-        "type": "object",
-        "properties": {},
-        "required": [],
-        "additionalProperties": false
-      }
-    }
-  },
-  {
-    "type": "function",
-    "function": {
       "name": "generate_explanation",
       "description": "Opens a multi-file diff view and generates AI-powered inline comments explaining the changes between two git references. Use this tool to help users understand code changes from git commits, pull requests, branches, or any git refs. The tool uses git to retrieve file contents and displays a side-by-side diff view with explanatory comments.",
       "strict": false,

--- a/src/core/prompts/system-prompt/__tests__/__snapshots__/openai_gpt_5_native.tools.snap
+++ b/src/core/prompts/system-prompt/__tests__/__snapshots__/openai_gpt_5_native.tools.snap
@@ -327,20 +327,6 @@
   {
     "type": "function",
     "function": {
-      "name": "focus_chain",
-      "description": "",
-      "strict": false,
-      "parameters": {
-        "type": "object",
-        "properties": {},
-        "required": [],
-        "additionalProperties": false
-      }
-    }
-  },
-  {
-    "type": "function",
-    "function": {
       "name": "generate_explanation",
       "description": "Opens a multi-file diff view and generates AI-powered inline comments explaining the changes between two git references. Use this tool to help users understand code changes from git commits, pull requests, branches, or any git refs. The tool uses git to retrieve file contents and displays a side-by-side diff view with explanatory comments.",
       "strict": false,

--- a/src/core/prompts/system-prompt/__tests__/__snapshots__/vertex_gemini3.tools.snap
+++ b/src/core/prompts/system-prompt/__tests__/__snapshots__/vertex_gemini3.tools.snap
@@ -322,15 +322,6 @@
     }
   },
   {
-    "name": "focus_chain",
-    "description": "",
-    "parameters": {
-      "type": "OBJECT",
-      "properties": {},
-      "required": []
-    }
-  },
-  {
     "name": "generate_explanation",
     "description": "Opens a multi-file diff view and generates AI-powered inline comments explaining the changes between two git references. Use this tool to help users understand code changes from git commits, pull requests, branches, or any git refs. The tool uses git to retrieve file contents and displays a side-by-side diff view with explanatory comments.",
     "parameters": {

--- a/src/core/prompts/system-prompt/__tests__/integration.test.ts
+++ b/src/core/prompts/system-prompt/__tests__/integration.test.ts
@@ -233,6 +233,14 @@ describe("Prompt System Integration Tests", () => {
 						}
 
 						expect(tools).to.be.an("array").that.is.not.empty
+						const toolNames = (tools as any[]).map((tool) => {
+							if (tool?.type === "function") {
+								return tool.function?.name
+							}
+							return tool?.name
+						})
+						expect(toolNames).to.not.include("focus_chain")
+						expect(JSON.stringify(tools)).to.not.include('"focus_chain"')
 						const snapshotName = `${providerId}_${family.replace(/[^a-zA-Z0-9]/g, "_")}.tools.snap`
 						await assertSnapshot(snapshotName, JSON.stringify(tools, null, 2))
 					})
@@ -250,6 +258,13 @@ describe("Prompt System Integration Tests", () => {
 						await runPromptTest(this, context, modelId, async ({ systemPrompt, tools }) => {
 							if (enableNativeToolCalls) {
 								expect(tools).to.be.an("array").that.is.not.empty
+								const toolNames = (tools as any[]).map((tool) => {
+									if (tool?.type === "function") {
+										return tool.function?.name
+									}
+									return tool?.name
+								})
+								expect(toolNames).to.not.include("focus_chain")
 							} else {
 								expect(tools).to.be.undefined
 							}

--- a/src/core/prompts/system-prompt/registry/ClineToolSet.ts
+++ b/src/core/prompts/system-prompt/registry/ClineToolSet.ts
@@ -131,7 +131,7 @@ export class ClineToolSet {
 		// via the "use_native_tools" label set to 1
 		// This avoids exposing tools to models that don't support them
 		// or variants that aren't designed for tool use
-		if (variant.labels["use_native_tools"] !== 1 || !context.enableNativeToolCalls) {
+		if (variant.labels.use_native_tools !== 1 || !context.enableNativeToolCalls) {
 			return undefined
 		}
 
@@ -143,7 +143,9 @@ export class ClineToolSet {
 		const mcpServers = context.mcpHub?.getServers()?.filter((s) => s.disabled !== true) || []
 		const mcpTools = mcpServers?.flatMap((server) => mcpToolToClineToolSpec(variant.family, server))
 
-		const enabledTools = [...toolConfigs, ...mcpTools]
+		const enabledTools = [...toolConfigs, ...mcpTools].filter(
+			(tool) => typeof tool.description === "string" && tool.description.trim().length > 0,
+		)
 		const converter = ClineToolSet.getNativeConverter(context.providerInfo.providerId, context.providerInfo.model.id)
 
 		return enabledTools.map((tool) => converter(tool, context))


### PR DESCRIPTION
<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- For feature requests: Created a discussion in our Feature Requests discussions board https://github.com/cline/cline/discussions/categories/feature-requests and received approval from core maintainers before implementation
- For all changes: Link the associated issue/discussion in the "Related Issue" section below

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly without prior discussion.

Why this requirement?
We deeply appreciate all community contributions - they are essential to Cline's success! To ensure the best use of everyone's time and maintain project direction, we use our Feature Requests discussions board to gauge community interest and validate feature ideas before implementation begins. This helps us focus development efforts on features that will benefit the most users.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:**  https://github.com/cline/cline/issues/7696

### Description

<!-- 
Help reviewers understand your changes by making this PR readable and well-organized:

- What problem does this PR solve?
- Why were these changes introduced and what purpose do they serve?
- For larger changes, provide context about your approach and reasoning

Small PRs may need minimal description, but larger changes benefit from explaining where you're coming from. Much of this context can be in the linked issue above, so feel free to reference it rather than repeating everything here.
-->

This commit ensures that internal placeholder tools, specifically `focus_chain`, are filtered out from the final list of native tools exposed to the LLM.

- Added a test case in `PromptRegistry.test.ts` to verify `focus_chain` is excluded from native tools output.
- Updated snapshot files for various models (OpenAI GPT-5, Vertex Gemini 3, etc.) to reflect the removal of the `focus_chain` tool definition.

### Test Procedure

<!-- 
Please walk us through your testing approach and thought process. This helps reviewers understand that you've thoroughly considered the impact of your changes:

- How did you test this change?
- What could potentially break and how did you verify it doesn't?
- What existing functionality might be affected and how did you check it still works?
- Why are you confident this is ready for merge?

We're not looking for exhaustive documentation - just evidence that you've thought through the implications of your changes and tested accordingly.
-->

- Green CI - unit tests have been updated to ensure focus_chain is not listed as one of the tool in native tools format.
- Verify the issue reported has been fixed

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes bug by removing `focus_chain` from the final list of native tools and updates tests and snapshots accordingly.
> 
>   - **Behavior**:
>     - Filters out `focus_chain` from native tools in `ClineToolSet.ts`.
>     - Ensures only tools with valid descriptions are included.
>   - **Tests**:
>     - Adds test in `PromptRegistry.test.ts` to verify `focus_chain` exclusion.
>     - Updates snapshots in `cline_native_next_gen.tools.snap`, `openai_gpt_5_1_native.tools.snap`, `openai_gpt_5_native.tools.snap`, and `vertex_gemini3.tools.snap` to reflect changes.
>     - Modifies `integration.test.ts` to check for `focus_chain` exclusion in various contexts.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for c1131718a0b536789ecb51854d5f32932ce5ad3a. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->