### PR TITLE
ci: add automatic retries for smoke test jobs

### DIFF
--- a/.changeset/smoke-test-retries.md
+++ b/.changeset/smoke-test-retries.md
@@ -1,0 +1,5 @@
+---
+"cline": patch
+---
+
+Add automatic retries (up to 3 attempts) for smoke test CI jobs to reduce flaky failures

--- a/.github/workflows/cline-evals-regression.yml
+++ b/.github/workflows/cline-evals-regression.yml
@@ -55,7 +55,22 @@ jobs:
           CLINE_API_KEY: ${{ secrets.CLINE_API_KEY }}
         run: |
           cline auth -p cline -k "$CLINE_API_KEY" -m "anthropic/claude-sonnet-4.5"
-          npx tsx evals/smoke-tests/run-smoke-tests.ts --trials 1 --parallel
+          max_attempts=3
+          for attempt in $(seq 1 $max_attempts); do
+            echo "::group::Attempt $attempt of $max_attempts"
+            if npx tsx evals/smoke-tests/run-smoke-tests.ts --trials 1 --parallel; then
+              echo "::endgroup::"
+              echo "Smoke tests passed on attempt $attempt"
+              exit 0
+            fi
+            echo "::endgroup::"
+            if [ $attempt -lt $max_attempts ]; then
+              echo "::warning::Smoke tests failed on attempt $attempt, retrying..."
+              sleep 10
+            fi
+          done
+          echo "::error::Smoke tests failed after $max_attempts attempts"
+          exit 1
 
       - name: Generate summary
         if: always()


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

### Description

Smoke tests can fail intermittently due to flaky API calls or transient infrastructure issues. This adds automatic retry logic (up to 3 attempts with a 10-second delay between retries) to the smoke test step in the CI workflow, reducing false negatives that block PRs.

### Test Procedure

This is a CI workflow change. The retry logic will be exercised the next time smoke tests run on a PR that touches the relevant paths. The bash retry loop was verified for correctness by inspection.

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [x] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A — CI workflow change only.

### Additional Notes

The retry wraps only the test execution step. Auth is performed once before the retry loop. Each attempt is grouped in GitHub Actions logs for readability, with `::warning::` annotations on retry and `::error::` if all 3 attempts fail.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds retry logic to smoke test CI jobs to handle flaky failures by retrying up to 3 times.
> 
>   - **CI Workflow**:
>     - Adds retry logic to `cline-evals-regression.yml` for smoke tests, retrying up to 3 times with a 10-second delay.
>     - Logs each attempt with `::group::` and `::endgroup::` for readability in GitHub Actions.
>     - Uses `::warning::` for retries and `::error::` if all attempts fail.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 961fba9e366f0f7fd35ee9a382417df333607376. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->