### PR TITLE
Move PR skill to .agents/skills

### DIFF
--- a/.agents/skills/create-pull-request/SKILL.md
+++ b/.agents/skills/create-pull-request/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: create-pull-request
-description: Create a GitHub pull request following project conventions. Use when the user asks to create a PR, submit changes for review, or open a pull request. Handles commit analysis, branch management, and PR creation using the gh CLI tool.
+description: Create a GitHub pull request following project conventions. Use when the user asks to create a PR, submit changes for review, or open a pull request. Handles commit analysis, branch management, PR template usage, and PR creation using the gh CLI tool.
 ---
 
 # Create Pull Request
@@ -170,25 +170,6 @@ gh pr create --title "PR_TITLE" --body-file /tmp/pr-body.md --base main --draft
 ```
 
 **Why use a file?** Passing complex markdown with newlines, special characters, and checkboxes directly via `--body` is error-prone. The `--body-file` flag handles all content reliably.
-
-## Changesets
-
-When in doubt, create a changeset. Any change that could be noticed by a user should have one.
-
-To create a changeset, write a markdown file to `.changeset/` with a short kebab-case name describing the change:
-
-**File: `.changeset/your-change-name.md`**
-```markdown
----
-"claude-dev": patch
----
-
-Short description of what changed, written for end users.
-```
-
-**Always use `patch`.** Never use `minor` or `major`.
-
-Only skip changesets for purely internal changes like refactors, CI tweaks, or documentation updates that have zero user-facing impact.
 
 ## Post-Creation
 


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

### Description

Moves the `create-pull-request` skill from `.cline/skills/` to `.agents/skills/` and removes changeset guidance (changesets are being removed from the project).

### Test Procedure

Skill files are configuration/documentation only. Verified the file content is correct and the rename was detected properly by git.

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [x] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A - skill file changes only.

### Additional Notes

No changeset needed - this is an internal workflow change with no user-facing impact.
