### PR TITLE
fix: use isLocatedInPath() instead of string.includes() for path containment

### DIFF
--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -92,16 +92,14 @@ export function getReadablePath(cwd: string, relPath?: string): string {
 	if (arePathsEqual(path.normalize(absolutePath), path.normalize(cwd))) {
 		const basenameResult = workspaceResolver.getBasename(absolutePath, "Utils.path.getReadablePath")
 		return basenameResult.toPosix()
-	} else {
-		// show the relative path to the cwd
-		const normalizedRelPath = path.relative(cwd, absolutePath)
-		if (absolutePath.includes(cwd)) {
-			return normalizedRelPath.toPosix()
-		} else {
-			// we are outside the cwd, so show the absolute path (useful for when cline passes in '../../' for example)
-			return absolutePath.toPosix()
-		}
 	}
+	// show the relative path to the cwd
+	const normalizedRelPath = path.relative(cwd, absolutePath)
+	if (isLocatedInPath(cwd, absolutePath)) {
+		return normalizedRelPath.toPosix()
+	}
+	// we are outside the cwd, so show the absolute path (useful for when cline passes in '../../' for example)
+	return absolutePath.toPosix()
 }
 
 // Returns the path of the first workspace directory, or the defaultCwdPath if there is no workspace open.
@@ -132,7 +130,7 @@ export async function getWorkspacePath(defaultCwd = ""): Promise<string> {
 	return await getCwd(defaultCwd)
 }
 
-export async function isLocatedInWorkspace(pathToCheck: string = ""): Promise<boolean> {
+export async function isLocatedInWorkspace(pathToCheck = ""): Promise<boolean> {
 	const workspacePaths = (await HostProvider.workspace.getWorkspacePaths({})).paths
 	for (const workspacePath of workspacePaths) {
 		const resolvedPathResult = workspaceResolver.resolveWorkspacePath(


### PR DESCRIPTION
## Summary
- Fixes false positives in `getReadablePath()` when directories share a prefix (e.g., `/home/user/project` incorrectly matching `/home/user/project-backup`)
- Replaces `absolutePath.includes(cwd)` with the existing `isLocatedInPath()` function which correctly handles path boundaries using `path.relative()`

## Test plan
- [x] Existing unit tests pass (`npm run test:unit -- --grep "Path"` — 120 passing)
- [ ] Verify with two directories sharing a prefix (e.g., `project` and `project-backup`) that files are correctly identified

Closes #8761
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes path containment issue in `getReadablePath()` by using `isLocatedInPath()` instead of string includes.
> 
>   - **Behavior**:
>     - Fixes false positives in `getReadablePath()` when directories share a prefix by replacing `absolutePath.includes(cwd)` with `isLocatedInPath()`.
>     - `isLocatedInPath()` uses `path.relative()` to correctly handle path boundaries.
>   - **Testing**:
>     - Existing unit tests pass (120 tests related to "Path").
>     - Manual verification needed for directories with shared prefixes (e.g., `project` and `project-backup`).
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 7ca71e9a545c2f5349390cb69aac03e7f0ae04b5. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->