### PR TITLE
fix: preserve unsent input text on Plan/Act mode switch

### DIFF
--- a/webview-ui/src/components/chat/ChatTextArea.tsx
+++ b/webview-ui/src/components/chat/ChatTextArea.tsx
@@ -1017,13 +1017,10 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 				)
 				// Focus the textarea after mode toggle with slight delay
 				setTimeout(() => {
-					if (response.value) {
-						setInputValue("")
-					}
 					textAreaRef.current?.focus()
 				}, 100)
 			})()
-		}, [mode, inputValue, selectedImages, selectedFiles, setInputValue])
+		}, [mode, inputValue, selectedImages, selectedFiles])
 
 		useShortcut(usePlatform().togglePlanActKeys, onModeToggle, { disableTextInputs: false }) // important that we don't disable the text input here
 


### PR DESCRIPTION
## Summary
- Fixes data loss when switching from Plan to Act mode while text is typed in the chat input
- Removes the `setInputValue("")` call in the `onModeToggle` callback in `ChatTextArea.tsx` so unsent text is preserved across mode switches
- The mode toggle still sends input text to the backend and refocuses the textarea — it just no longer wipes the input

## Test plan
- [ ] Open Cline in Plan mode
- [ ] Type a message in the chat input (do not send)
- [ ] Switch to Act mode — verify text is preserved
- [ ] Switch back to Plan mode — verify text is still there
- [ ] Verify normal message sending still works in both modes

Closes #9453
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes data loss in `ChatTextArea.tsx` by preserving unsent input text during Plan/Act mode switches.
> 
>   - **Behavior**:
>     - Fixes data loss when switching from Plan to Act mode in `ChatTextArea.tsx` by preserving unsent input text.
>     - Removes `setInputValue("")` in `onModeToggle` to keep text intact during mode switches.
>     - Mode toggle still sends input text to backend and refocuses textarea without clearing input.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 135431e5931ee957b1a739fc371b4c6be6ae06e0. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->