### PR TITLE
fix: show platform-specific keyboard shortcut for Plan/Act toggle

### DIFF
--- a/webview-ui/src/components/common/MarkdownBlock.tsx
+++ b/webview-ui/src/components/common/MarkdownBlock.tsx
@@ -21,7 +21,7 @@ import { WithCopyButton } from "./CopyButton"
  * Returns the platform-specific keyboard shortcut for toggling Plan/Act mode.
  * Mac: ⌘⇧A, Windows: Win+Shift+A, Linux: Alt+Shift+A
  */
-function getPlanActShortcut(): string {
+export function getPlanActShortcut(): string {
 	const platform = getCurrentPlatform()
 	switch (platform) {
 		case "mac":

--- a/webview-ui/src/components/common/MarkdownBlock.tsx
+++ b/webview-ui/src/components/common/MarkdownBlock.tsx
@@ -14,7 +14,24 @@ import { Button } from "@/components/ui/button"
 import { useExtensionState } from "@/context/ExtensionStateContext"
 import { cn } from "@/lib/utils"
 import { FileServiceClient, StateServiceClient } from "@/services/grpc-client"
+import { getCurrentPlatform } from "@/utils/platformUtils"
 import { WithCopyButton } from "./CopyButton"
+
+/**
+ * Returns the platform-specific keyboard shortcut for toggling Plan/Act mode.
+ * Mac: ⌘⇧A, Windows: Win+Shift+A, Linux: Alt+Shift+A
+ */
+function getPlanActShortcut(): string {
+	const platform = getCurrentPlatform()
+	switch (platform) {
+		case "mac":
+			return "⌘⇧A"
+		case "windows":
+			return "Win+Shift+A"
+		default:
+			return "Alt+Shift+A"
+	}
+}
 
 function parseMarkdownIntoBlocks(markdown: string): string[] {
 	try {
@@ -64,10 +81,11 @@ const MemoizedMarkdownBlock = memo(
 							})
 							.join("")
 
-						// Case-insensitive check for "Act Mode (⌘⇧A)" pattern
+						// Case-insensitive check for "Act Mode (<shortcut>)" pattern
 						// This ensures we only style the exact "Act Mode" mentions with keyboard shortcut
 						// Using case-insensitive flag to catch all capitalization variations
-						if (/^act mode\s*\(⌘⇧A\)$/i.test(childrenText)) {
+						const shortcutPattern = getPlanActShortcut().replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+						if (new RegExp(`^act mode\\s*\\(${shortcutPattern}\\)$`, "i").test(childrenText)) {
 							return <ActModeHighlight />
 						}
 
@@ -138,7 +156,7 @@ const ActModeHighlight: React.FC = () => {
 			<div className="p-1 rounded-md bg-code flex items-center justify-end w-7 border border-input-border">
 				<div className="rounded-full bg-link w-2 h-2" />
 			</div>
-			Act Mode (⌘⇧A)
+			Act Mode ({getPlanActShortcut()})
 		</span>
 	)
 }
@@ -202,7 +220,8 @@ const remarkHighlightActMode = () => {
 			// Case-insensitive regex to match "to Act Mode" in various capitalizations
 			// Using word boundaries to avoid matching within words
 			// Added negative lookahead to avoid matching if already followed by the shortcut
-			const actModeRegex = /\bto\s+Act\s+Mode\b(?!\s*\(⌘⇧A\))/i
+			const shortcut = getPlanActShortcut().replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+			const actModeRegex = new RegExp(`\\bto\\s+Act\\s+Mode\\b(?!\\s*\\(${shortcut}\\))`, "i")
 
 			if (!node.value.match(actModeRegex)) {
 				return
@@ -240,14 +259,14 @@ const remarkHighlightActMode = () => {
 						const actModePart = matchText.substring(actModeIndex)
 						children.push({
 							type: "strong",
-							children: [{ type: "text", value: `${actModePart} (⌘⇧A)` }],
+							children: [{ type: "text", value: `${actModePart} (${getPlanActShortcut()})` }],
 						})
 					} else {
 						// Fallback if we can't parse it correctly
 						children.push({ type: "text", value: matchText + " " })
 						children.push({
 							type: "strong",
-							children: [{ type: "text", value: `(⌘⇧A)` }],
+							children: [{ type: "text", value: `(${getPlanActShortcut()})` }],
 						})
 					}
 				}

--- a/webview-ui/src/components/common/__tests__/MarkdownBlock.spec.ts
+++ b/webview-ui/src/components/common/__tests__/MarkdownBlock.spec.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it, vi } from "vitest"
+
+vi.mock("@/utils/platformUtils", () => ({
+	getCurrentPlatform: vi.fn(),
+}))
+
+import { getCurrentPlatform } from "@/utils/platformUtils"
+import { getPlanActShortcut } from "../MarkdownBlock"
+
+const mockedGetCurrentPlatform = vi.mocked(getCurrentPlatform)
+
+describe("getPlanActShortcut", () => {
+	it("should return Mac shortcut on macOS", () => {
+		mockedGetCurrentPlatform.mockReturnValue("mac")
+		expect(getPlanActShortcut()).toBe("⌘⇧A")
+	})
+
+	it("should return Windows shortcut on Windows", () => {
+		mockedGetCurrentPlatform.mockReturnValue("windows")
+		expect(getPlanActShortcut()).toBe("Win+Shift+A")
+	})
+
+	it("should return Linux shortcut on Linux", () => {
+		mockedGetCurrentPlatform.mockReturnValue("linux")
+		expect(getPlanActShortcut()).toBe("Alt+Shift+A")
+	})
+})


### PR DESCRIPTION
## Summary
- Fixes Mac-only keyboard shortcut symbol (⌘⇧A) being shown on all platforms in the Act Mode highlight in chat messages
- Adds a `getPlanActShortcut()` helper that uses `getCurrentPlatform()` to return the correct shortcut:
  - **Mac**: ⌘⇧A
  - **Windows**: Win+Shift+A
  - **Linux**: Alt+Shift+A
- Replaces all 4 hardcoded `⌘⇧A` references in `MarkdownBlock.tsx` (ActModeHighlight component, strong element regex, and remarkHighlightActMode plugin)

## Test plan
- [ ] On macOS: verify "Act Mode (⌘⇧A)" appears in chat markdown
- [ ] On Windows: verify "Act Mode (Win+Shift+A)" appears instead of ⌘⇧A
- [ ] On Linux: verify "Act Mode (Alt+Shift+A)" appears
- [ ] Verify clicking the Act Mode highlight still toggles to Act mode
- [ ] Verify the remark plugin still correctly detects and highlights "to Act Mode" text

Closes #3770
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes platform-specific keyboard shortcut display for Act Mode toggle in `MarkdownBlock.tsx`.
> 
>   - **Behavior**:
>     - Fixes Mac-only shortcut symbol (⌘⇧A) shown on all platforms in Act Mode highlight.
>     - Adds `getPlanActShortcut()` to return platform-specific shortcuts using `getCurrentPlatform()`.
>     - Replaces hardcoded `⌘⇧A` with dynamic shortcut in `MarkdownBlock.tsx` (ActModeHighlight component, strong element regex, and remarkHighlightActMode plugin).
>   - **Test Plan**:
>     - Verify correct shortcut display on macOS, Windows, and Linux.
>     - Ensure Act Mode toggle and highlight detection function correctly.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for f87378c3f680acaf3c468e96f1dc48a3dd5cd780. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->