### PR TITLE
fix: show Cline logo in system notifications on Windows and Linux

### DIFF
--- a/src/integrations/notifications/__tests__/notifications.test.ts
+++ b/src/integrations/notifications/__tests__/notifications.test.ts
@@ -26,8 +26,29 @@ describe("notifications", () => {
 
 		expect(script).to.contain("$message = '$(Start-Process calc)'")
 		expect(script).to.contain("$textNodes.Item(1).InnerText = $message")
+		expect(script).to.contain('template="ToastGeneric"')
 		expect(script).to.not.contain('<text id="2">$(Start-Process calc)</text>')
 		expect(script).to.not.contain('$template = @"')
+	})
+
+	it("includes AppLogoOverride image in Windows toast when iconPath is provided", () => {
+		const script = notificationsModule.buildWindowsToastNotificationScript({
+			subtitle: "Test",
+			message: "Hello",
+			iconPath: "C:\\extensions\\cline\\assets\\icons\\icon.png",
+		})
+
+		expect(script).to.contain('placement="appLogoOverride"')
+		expect(script).to.contain("C:\\extensions\\cline\\assets\\icons\\icon.png")
+	})
+
+	it("omits AppLogoOverride image in Windows toast when no iconPath", () => {
+		const script = notificationsModule.buildWindowsToastNotificationScript({
+			subtitle: "Test",
+			message: "Hello",
+		})
+
+		expect(script).to.not.contain("appLogoOverride")
 	})
 
 	it("escapes single quotes for PowerShell single-quoted strings", () => {
@@ -83,6 +104,28 @@ describe("notifications", () => {
 		sinon.assert.calledOnce(execaStub)
 		expect(execaStub.firstCall.args[0]).to.equal("notify-send")
 		expect(execaStub.firstCall.args[1]).to.deep.equal(["Cline", "Approval Required\ntest"])
+	})
+
+	it("passes --icon flag to notify-send on Linux when iconPath is provided", async () => {
+		const execaStub = createResolvedExecaStub()
+		notificationsModule.setNotificationExecaForTesting(
+			execaStub as unknown as Parameters<typeof notificationsModule.setNotificationExecaForTesting>[0],
+		)
+		const platformStub = sinon.stub().returns("linux")
+		notificationsModule.setNotificationPlatformForTesting(
+			platformStub as unknown as Parameters<typeof notificationsModule.setNotificationPlatformForTesting>[0],
+		)
+
+		await notificationsModule.showSystemNotification({
+			title: "Cline",
+			subtitle: "Test",
+			message: "hello",
+			iconPath: "/ext/assets/icons/icon.png",
+		})
+
+		sinon.assert.calledOnce(execaStub)
+		expect(execaStub.firstCall.args[0]).to.equal("notify-send")
+		expect(execaStub.firstCall.args[1]).to.deep.equal(["--icon=/ext/assets/icons/icon.png", "Cline", "Test\nhello"])
 	})
 
 	it("creates explicit approval marker only when required", () => {

--- a/src/integrations/notifications/index.ts
+++ b/src/integrations/notifications/index.ts
@@ -1,11 +1,14 @@
+import path from "node:path"
 import { execa } from "execa"
 import { platform } from "os"
+import { HostProvider } from "@/hosts/host-provider"
 import { Logger } from "@/shared/services/Logger"
 
 interface NotificationOptions {
 	title?: string
 	subtitle?: string
 	message: string
+	iconPath?: string
 }
 
 export interface ApprovalNotificationOptions {
@@ -58,13 +61,19 @@ export function createApprovalNotificationMessage(options: ApprovalNotificationO
 }
 
 /**
- * Note: `title` is not rendered on Windows because the ToastText02 template only exposes
- * two text slots, which we use for subtitle (id=1) and message (id=2).
+ * Note: `title` is not rendered on Windows because the ToastGeneric template uses
+ * two text slots for subtitle (id=1) and message (id=2). When iconPath is provided,
+ * the Cline logo is shown via AppLogoOverride.
  */
 export function buildWindowsToastNotificationScript(options: NotificationOptions): string {
-	const { subtitle = "", message } = options
+	const { subtitle = "", message, iconPath } = options
 	const safeSubtitle = escapePowerShellSingleQuotedString(subtitle)
 	const safeMessage = escapePowerShellSingleQuotedString(message)
+
+	// Use ToastGeneric binding to support AppLogoOverride for the Cline icon
+	const imageElement = iconPath
+		? `<image placement="appLogoOverride" src="${escapePowerShellSingleQuotedString(iconPath)}" />`
+		: ""
 
 	return `
     [Windows.UI.Notifications.ToastNotificationManager, Windows.UI.Notifications, ContentType = WindowsRuntime] | Out-Null
@@ -74,7 +83,7 @@ export function buildWindowsToastNotificationScript(options: NotificationOptions
     $message = '${safeMessage}'
 
     $xml = New-Object Windows.Data.Xml.Dom.XmlDocument
-    $xml.LoadXml('<toast><visual><binding template="ToastText02"><text id="1"></text><text id="2"></text></binding></visual></toast>')
+    $xml.LoadXml('<toast><visual><binding template="ToastGeneric"><text id="1"></text><text id="2"></text>${imageElement}</binding></visual></toast>')
 
     $textNodes = $xml.GetElementsByTagName('text')
     $textNodes.Item(0).InnerText = $subtitle
@@ -109,16 +118,30 @@ async function showWindowsNotification(options: NotificationOptions): Promise<vo
 }
 
 async function showLinuxNotification(options: NotificationOptions): Promise<void> {
-	const { title = "", subtitle = "", message } = options
+	const { title = "", subtitle = "", message, iconPath } = options
 
 	// Combine subtitle and message if subtitle exists
 	const fullMessage = subtitle ? `${subtitle}\n${message}` : message
 
+	const args = iconPath ? [`--icon=${iconPath}`, title, fullMessage] : [title, fullMessage]
+
 	try {
-		await execaImpl("notify-send", [title, fullMessage])
+		await execaImpl("notify-send", args)
 	} catch (error) {
 		throw new Error(`Failed to show Linux notification: ${error}`)
 	}
+}
+
+function resolveIconPath(): string | undefined {
+	try {
+		const extensionFsPath = HostProvider.get().extensionFsPath
+		if (extensionFsPath) {
+			return path.join(extensionFsPath, "assets", "icons", "icon.png")
+		}
+	} catch {
+		// HostProvider may not be initialized (e.g., in tests)
+	}
+	return undefined
 }
 
 export async function showSystemNotification(options: NotificationOptions): Promise<void> {
@@ -133,6 +156,7 @@ export async function showSystemNotification(options: NotificationOptions): Prom
 			...options,
 			title,
 			subtitle: options.subtitle || "",
+			iconPath: options.iconPath ?? resolveIconPath(),
 		}
 
 		switch (platformImpl()) {


### PR DESCRIPTION
## Summary
- **Windows**: Switch from `ToastText02` to `ToastGeneric` template with `AppLogoOverride` image element, displaying the Cline icon (`assets/icons/icon.png`) in toast notifications
- **Linux**: Pass `--icon=<path>` flag to `notify-send` to show the Cline icon
- **macOS**: No change needed — `display notification` uses the host app icon automatically
- Icon path is resolved at runtime from `HostProvider.extensionFsPath` with a safe fallback when unavailable (e.g., in tests)

Closes #6082

## Test plan
- [x] All 14 notification tests pass (3 new: Windows icon, Windows no-icon, Linux icon)
- [x] `npm run compile` succeeds
- [ ] Manual: Enable notifications in Cline settings, trigger a task on Windows → Cline logo should appear in the toast notification
- [ ] Manual: Same test on Linux with a desktop environment supporting `notify-send`

🤖 Generated with [Claude Code](https://claude.com/claude-code)