### PR TITLE
fix: include .clinerules in commit message generation

### DIFF
--- a/src/hosts/vscode/commit-message-generator.ts
+++ b/src/hosts/vscode/commit-message-generator.ts
@@ -1,7 +1,13 @@
 import { buildApiHandler } from "@core/api"
 import * as path from "path"
 import * as vscode from "vscode"
+import {
+	getGlobalClineRules,
+	getLocalClineRules,
+	refreshClineRulesToggles,
+} from "@/core/context/instructions/user-instructions/cline-rules"
 import { Controller } from "@/core/controller"
+import { ensureRulesDirectoryExists } from "@/core/storage/disk"
 import { HostProvider } from "@/hosts/host-provider"
 import { ShowMessageType } from "@/shared/proto/host/window"
 import { Logger } from "@/shared/services/Logger"
@@ -150,11 +156,11 @@ async function generateCommitMsgForRepository(controller: Controller, repository
 			title: `Generating commit message for ${repoPath.split(path.sep).pop() || "repository"}...`,
 			cancellable: true,
 		},
-		() => performCommitMsgGeneration(controller, gitDiff, inputBox),
+		() => performCommitMsgGeneration(controller, gitDiff, inputBox, repoPath),
 	)
 }
 
-async function performCommitMsgGeneration(controller: Controller, gitDiff: string, inputBox: any) {
+async function performCommitMsgGeneration(controller: Controller, gitDiff: string, inputBox: any, repoPath: string) {
 	try {
 		vscode.commands.executeCommand("setContext", "cline.isGeneratingCommit", true)
 
@@ -166,6 +172,23 @@ async function performCommitMsgGeneration(controller: Controller, gitDiff: strin
 			if (workspacesJson) {
 				prompts.push(`# Workspace Configuration\n${workspacesJson}`)
 			}
+		}
+
+		// Load .clinerules (global and local) to inform commit message style
+		try {
+			const { globalToggles, localToggles } = await refreshClineRulesToggles(controller, repoPath)
+			const globalClineRulesFilePath = await ensureRulesDirectoryExists()
+			const globalRules = await getGlobalClineRules(globalClineRulesFilePath, globalToggles)
+			const localRules = await getLocalClineRules(repoPath, localToggles)
+
+			if (globalRules.instructions) {
+				prompts.push(globalRules.instructions)
+			}
+			if (localRules.instructions) {
+				prompts.push(localRules.instructions)
+			}
+		} catch {
+			// Rules loading is best-effort; don't block commit message generation
 		}
 
 		const currentInput = inputBox.value?.trim() || ""


### PR DESCRIPTION
## Summary
- The "Generate Commit Message" feature previously used a hardcoded prompt that ignored `.clinerules` and any user-defined commit conventions
- Now loads both global and local `.clinerules` (respecting toggles) and includes them in the prompt so the AI follows project-specific commit message guidelines
- Rules loading is best-effort — failures don't block commit message generation

Closes #4868

## Test plan
- [ ] Configure a `.clinerules` file with custom commit message conventions (e.g., "always use emoji prefix")
- [ ] Stage changes and use "Generate Commit Message" feature
- [ ] Verify the generated commit message follows the custom conventions from `.clinerules`
- [ ] Verify commit message generation still works when no `.clinerules` exist
- [ ] Verify commit message generation still works when `.clinerules` loading fails
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Enhances commit message generation by incorporating `.clinerules` for user-defined conventions in `commit-message-generator.ts`.
> 
>   - **Behavior**:
>     - `performCommitMsgGeneration()` in `commit-message-generator.ts` now loads global and local `.clinerules` to include in commit message prompts.
>     - Rules loading is best-effort; failures don't block commit message generation.
>   - **Imports**:
>     - Adds imports for `getGlobalClineRules`, `getLocalClineRules`, `refreshClineRulesToggles`, and `ensureRulesDirectoryExists` in `commit-message-generator.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for d701409485d5fe5f511e0cff7b55fdcf24f9c58b. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->