### PR TITLE
Parse `CLINE_OTEL_EXPORTER_OTLP_HEADERS` when building the OTEL config

### DIFF
--- a/src/services/telemetry/providers/opentelemetry/OpenTelemetryClientProvider.ts
+++ b/src/services/telemetry/providers/opentelemetry/OpenTelemetryClientProvider.ts
@@ -48,14 +48,8 @@ export class OpenTelemetryClientProvider {
 			Logger.log(`[OTEL DEBUG]   - Metric Export Interval: ${this.config.metricExportInterval || 60000}ms`)
 		}
 
-		// Check for headers configuration
-		// This is only used for printing, only the config value should be passed down
-		// so that the library can read and parse the env variable correclty if the config value is undefined
-		const headers = config?.otlpHeaders || process.env.OTEL_EXPORTER_OTLP_HEADERS
-		if (isDebugMode && headers) {
-			const headerCount = config?.otlpHeaders
-				? Object.keys(config.otlpHeaders).length
-				: process.env.OTEL_EXPORTER_OTLP_HEADERS?.length
+		if (isDebugMode && config.otlpHeaders) {
+			const headerCount = Object.keys(config.otlpHeaders).length
 			// In debug mode, show that headers are configured and their total length
 			Logger.log(`[OTEL DEBUG]   - OTLP Headers: ${headerCount} headers configured`)
 			Logger.log("[OTEL DEBUG] ================================================")

--- a/src/shared/services/config/otel-config.ts
+++ b/src/shared/services/config/otel-config.ts
@@ -1,3 +1,4 @@
+import { parseKeyPairsIntoRecord } from "@opentelemetry/core"
 import { BUILD_CONSTANTS } from "@/shared/constants"
 import { RemoteConfigFields } from "@/shared/storage/state-keys"
 
@@ -128,7 +129,10 @@ function getOtelConfig(): OpenTelemetryClientConfig {
 		otlpProtocol: BUILD_CONSTANTS.OTEL_EXPORTER_OTLP_PROTOCOL,
 		otlpEndpoint: BUILD_CONSTANTS.OTEL_EXPORTER_OTLP_ENDPOINT,
 		metricExportInterval: BUILD_CONSTANTS.OTEL_METRIC_EXPORT_INTERVAL
-			? parseInt(BUILD_CONSTANTS.OTEL_METRIC_EXPORT_INTERVAL, 10)
+			? Number.parseInt(BUILD_CONSTANTS.OTEL_METRIC_EXPORT_INTERVAL, 10)
+			: undefined,
+		otlpHeaders: BUILD_CONSTANTS.OTEL_EXPORTER_OTLP_HEADERS
+			? parseKeyPairsIntoRecord(BUILD_CONSTANTS.OTEL_EXPORTER_OTLP_HEADERS)
 			: undefined,
 	}
 }
@@ -148,6 +152,7 @@ function getOtelConfig(): OpenTelemetryClientConfig {
  * - CLINE_OTEL_LOGS_EXPORTER: Comma-separated list: "console", "otlp"
  * - CLINE_OTEL_EXPORTER_OTLP_PROTOCOL: "grpc", "http/json", or "http/protobuf"
  * - CLINE_OTEL_EXPORTER_OTLP_ENDPOINT: OTLP collector endpoint (if not using specific endpoints)
+ * - CLINE_OTEL_EXPORTER_OTLP_HEADERS: Comma-separated key-value pairs (e.g., "key1=value1,key2=value2")
  * - CLINE_OTEL_EXPORTER_OTLP_METRICS_PROTOCOL: Metrics-specific protocol override
  * - CLINE_OTEL_EXPORTER_OTLP_METRICS_ENDPOINT: Metrics-specific endpoint override
  * - CLINE_OTEL_EXPORTER_OTLP_LOGS_PROTOCOL: Logs-specific protocol override
@@ -174,17 +179,20 @@ function getRuntimeOtelConfig(): OpenTelemetryClientConfig {
 		otlpLogsProtocol: process.env.CLINE_OTEL_EXPORTER_OTLP_LOGS_PROTOCOL,
 		otlpLogsEndpoint: process.env.CLINE_OTEL_EXPORTER_OTLP_LOGS_ENDPOINT,
 		metricExportInterval: process.env.CLINE_OTEL_METRIC_EXPORT_INTERVAL
-			? parseInt(process.env.CLINE_OTEL_METRIC_EXPORT_INTERVAL, 10)
+			? Number.parseInt(process.env.CLINE_OTEL_METRIC_EXPORT_INTERVAL, 10)
 			: undefined,
 		otlpInsecure: process.env.CLINE_OTEL_EXPORTER_OTLP_INSECURE === "true",
 		logBatchSize: process.env.CLINE_OTEL_LOG_BATCH_SIZE
-			? Math.max(1, parseInt(process.env.CLINE_OTEL_LOG_BATCH_SIZE, 10))
+			? Math.max(1, Number.parseInt(process.env.CLINE_OTEL_LOG_BATCH_SIZE, 10))
 			: undefined,
 		logBatchTimeout: process.env.CLINE_OTEL_LOG_BATCH_TIMEOUT
-			? Math.max(1, parseInt(process.env.CLINE_OTEL_LOG_BATCH_TIMEOUT, 10))
+			? Math.max(1, Number.parseInt(process.env.CLINE_OTEL_LOG_BATCH_TIMEOUT, 10))
 			: undefined,
 		logMaxQueueSize: process.env.CLINE_OTEL_LOG_MAX_QUEUE_SIZE
-			? Math.max(1, parseInt(process.env.CLINE_OTEL_LOG_MAX_QUEUE_SIZE, 10))
+			? Math.max(1, Number.parseInt(process.env.CLINE_OTEL_LOG_MAX_QUEUE_SIZE, 10))
+			: undefined,
+		otlpHeaders: process.env.CLINE_OTEL_EXPORTER_OTLP_HEADERS
+			? parseKeyPairsIntoRecord(process.env.CLINE_OTEL_EXPORTER_OTLP_HEADERS)
 			: undefined,
 	}
 }


### PR DESCRIPTION
### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** #8348

### Description

We aren't parsing runtime headers. This PR fixes that.

### Test Procedure

Tested locally.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Parse `CLINE_OTEL_EXPORTER_OTLP_HEADERS` in OpenTelemetry configuration and log header count in debug mode.
> 
>   - **Behavior**:
>     - Parses `CLINE_OTEL_EXPORTER_OTLP_HEADERS` in `getOtelConfig()` and `getRuntimeOtelConfig()` in `otel-config.ts` using `parseKeyPairsIntoRecord`.
>     - Logs the number of OTLP headers in debug mode in `OpenTelemetryClientProvider` constructor.
>   - **Functions**:
>     - Adds `getHeaders()` in `OpenTelemetryClientProvider.ts` to retrieve headers from config.
>   - **Misc**:
>     - Replaces `parseInt` with `Number.parseInt` in `otel-config.ts` for consistency.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 2b2e422eb586e95ae638d8526654a0a51f5958fe. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->