### PR TITLE
fix: use model.info.maxTokens for OpenRouter instead of hardcoded 8192

### DIFF
--- a/src/core/api/transform/openrouter-stream.ts
+++ b/src/core/api/transform/openrouter-stream.ts
@@ -116,37 +116,7 @@ export async function createOpenRouterStream(
 			break
 	}
 
-	// Not sure how openrouter defaults max tokens when no value is provided, but the anthropic api requires this value and since they offer both 4096 and 8192 variants, we should ensure 8192.
-	// (models usually default to max tokens allowed)
-	let maxTokens: number | undefined
-	switch (model.id) {
-		case "anthropic/claude-opus-4.6":
-		case "anthropic/claude-haiku-4.5":
-		case "anthropic/claude-4.5-haiku":
-		case "anthropic/claude-sonnet-4.6":
-		case "anthropic/claude-4.6-sonnet":
-		case "anthropic/claude-sonnet-4.5":
-		case "anthropic/claude-4.5-sonnet":
-		case "anthropic/claude-sonnet-4":
-		case "anthropic/claude-opus-4.5":
-		case "anthropic/claude-opus-4.1":
-		case "anthropic/claude-opus-4":
-		case "anthropic/claude-3.7-sonnet":
-		case "anthropic/claude-3.7-sonnet:beta":
-		case "anthropic/claude-3.7-sonnet:thinking":
-		case "anthropic/claude-3-7-sonnet":
-		case "anthropic/claude-3-7-sonnet:beta":
-		case "anthropic/claude-3.5-sonnet":
-		case "anthropic/claude-3.5-sonnet:beta":
-		case "anthropic/claude-3.5-sonnet-20240620":
-		case "anthropic/claude-3.5-sonnet-20240620:beta":
-		case "anthropic/claude-3-5-haiku":
-		case "anthropic/claude-3-5-haiku:beta":
-		case "anthropic/claude-3-5-haiku-20241022":
-		case "anthropic/claude-3-5-haiku-20241022:beta":
-			maxTokens = 8_192
-			break
-	}
+	const maxTokens = model.info.maxTokens || undefined
 
 	let temperature: number | undefined = 0
 	let topP: number | undefined


### PR DESCRIPTION
### Related Issue

**Issue:** #7998

### Description

`write_to_file` fails with `missing required parameter 'content'` on OpenRouter (and the Cline provider, which shares the same code path) when the model tries to write a large file. The root cause is a hardcoded `max_tokens = 8192` in the OpenRouter stream transform that silently overrides the correct dynamic value from `model.info.maxTokens`.

**What happens:**
1. Model generates a `write_to_file` tool call with large `content` (e.g. a 500-line file)
2. Output hits the 8192-token ceiling → provider returns `finish_reason: "length"`
3. `StreamResponseHandler` tries to finalize the incomplete tool call JSON
4. `JSON.parse` fails → regex fallback extracts `path` (short, complete) but not `content` (truncated mid-string)
5. `WriteToFileToolHandler` rejects: `missing required parameter 'content'`
6. Retry hits the same ceiling → agent dies after 3-4 API calls

**Why this exists:** The switch statement was written when 8192 was the actual max output for Claude models. Modern Claude models support much higher limits (128K for Opus 4.6, 64K for Sonnet 4.6/4.5). OpenRouter's API already reports the correct value via `top_provider.max_completion_tokens`, and `model.info.maxTokens` reflects this — but the hardcoded switch was overriding it.

**The fix:** Replace the 30-line hardcoded switch with `const maxTokens = model.info.maxTokens || undefined` — matching what the Vercel AI Gateway transform already does.

### Test Procedure

Debugged with runtime instrumentation. Before/after comparison:

**Before fix** (hardcoded `max_tokens: 8192`):
- `max_tokens` sent to OpenRouter: **8192**
- `completion_tokens` returned: **8192** (hit ceiling exactly)
- `finish_reason`: **"length"** (truncated)
- `write_to_file` result: **missing content parameter** ❌

**After fix** (`max_tokens: 128000` from `model.info`):
- `max_tokens` sent to OpenRouter: **128000**
- `completion_tokens` returned: **9824** (model needed ~20% more than old ceiling allowed)
- `finish_reason`: **"tool_calls"** (completed normally)
- `write_to_file` result: **succeeded**, 35,070 chars written ✅

Tested by prompting Cline with OpenRouter + Claude Sonnet 4.6 to write a large single-file Python implementation (~600 lines). Previously failed deterministically; now succeeds.

**What could break:** Models not in the switch statement previously got `maxTokens = undefined`, which let OpenRouter use its own default. After this change, they get `model.info.maxTokens`, which should be equivalent or better since model info is populated from OpenRouter's API response. For models where `model.info.maxTokens` is 0 or undefined, the `|| undefined` fallback preserves the old behavior.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A — backend-only change. No UI changes.

### Additional Notes

- The Cline provider (`src/core/api/providers/cline.ts`) also benefits from this fix since it calls `createOpenRouterStream` internally.
- The Vercel AI Gateway transform already uses `model.info?.maxTokens || undefined` and does not have this bug.
- A separate follow-up may be needed to update the static `maxTokens: 8192` values in `src/shared/api.ts` for `anthropicModels`, `bedrockModels`, and `vertexModels`, which affect the Anthropic direct, Bedrock, and Vertex providers.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes token limit issue in `createOpenRouterStream` by using `model.info.maxTokens` instead of a hardcoded value.
> 
>   - **Behavior**:
>     - Replaces hardcoded `maxTokens = 8192` with `model.info.maxTokens || undefined` in `createOpenRouterStream` in `openrouter-stream.ts`.
>     - Fixes issue where large `write_to_file` calls failed due to token limit being exceeded.
>   - **Impact**:
>     - Affects OpenRouter and Cline providers using `createOpenRouterStream`.
>     - Ensures models use correct token limits from `model.info`.
>   - **Misc**:
>     - Removes 30-line switch statement for `maxTokens` in `openrouter-stream.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for edb3e068eff0a06d03f83708459f0ddeda26fa41. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->