### PR TITLE
fix: update stale maxTokens values for Claude 3.7+ models across Anthropic, Bedrock, Vertex, and SAP AI Core

### DIFF
--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -774,7 +774,7 @@ export const openRouterClaudeSonnet451mModelId = `anthropic/claude-sonnet-4.5${C
 export const openRouterClaudeSonnet461mModelId = `anthropic/claude-sonnet-4.6${CLAUDE_SONNET_1M_SUFFIX}`
 export const openRouterClaudeOpus461mModelId = `anthropic/claude-opus-4.6${CLAUDE_SONNET_1M_SUFFIX}`
 export const openRouterDefaultModelInfo: ModelInfo = {
-	maxTokens: 8192,
+	maxTokens: 64_000,
 	contextWindow: 200_000,
 	supportsImages: true,
 	supportsPromptCache: true,


### PR DESCRIPTION
### Related Issue

**Issue:** #7998

### Description

The static `maxTokens` values for Claude models in `src/shared/api.ts` have been stuck at `8192` since the Claude 3.5 era. Anthropic has since increased output limits significantly for every model from Claude 3.7 Sonnet onward, but these definitions were never updated.

This matters because `maxTokens` is sent as `max_tokens` to the API — it's the ceiling on how many output tokens the model can generate per response. When a model tries to write a large file via `write_to_file` and the content exceeds 8192 tokens, the response gets silently truncated. The tool call JSON is incomplete, the `content` parameter is lost, and the user sees:

```
Cline tried to use write_to_file without value for required parameter 'content'. Retrying...
```

The retry also fails (same ceiling), and the agent dies after 3-4 API calls.

#### Which providers are affected?

These static definitions are the source of truth for providers that don't fetch model info dynamically:

| Provider | Uses `api.ts` static values? | Affected? |
|----------|------------------------------|-----------|
| **Anthropic direct** | Yes (`anthropicModels`) | **Yes — fixed in this PR** |
| **AWS Bedrock** | Yes (`bedrockModels`) | **Yes — fixed in this PR** |
| **Google Vertex AI** | Yes (`vertexModels`) | **Yes — fixed in this PR** |
| **SAP AI Core** | Yes (`sapAiCoreModels`) | **Yes — fixed in this PR** |
| OpenRouter | No — fetches dynamically | Not affected (fixed in #9544) |
| Vercel AI Gateway | No — fetches dynamically | Not affected (API reports correct values) |
| Cline provider | No — uses OpenRouter stream | Not affected (fixed in #9544) |

#### What changed?

Updated 41 `maxTokens` entries across four model definition sections:

| Model | Old Value | New Value | Source |
|-------|-----------|-----------|--------|
| Claude Opus 4.6 | 8,192 | **128,000** | [Anthropic docs](https://docs.anthropic.com/en/docs/about-claude/models/overview) |
| Claude 3.7 Sonnet | 8,192 | **128,000** | [AWS Bedrock docs](https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-anthropic-claude-37.html) |
| Claude Sonnet 4.6 | 8,192 | **64,000** | [Anthropic docs](https://docs.anthropic.com/en/docs/about-claude/models/overview) |
| Claude Sonnet 4.5 | 8,192 | **64,000** | [Anthropic docs](https://docs.anthropic.com/en/docs/about-claude/models/overview) |
| Claude Sonnet 4 | 8,192 | **64,000** | [Google Vertex AI docs](https://docs.cloud.google.com/vertex-ai/generative-ai/docs/partner-models/claude/sonnet-4) |
| Claude Haiku 4.5 | 8,192 | **64,000** | [Anthropic docs](https://docs.anthropic.com/en/docs/about-claude/models/overview) |
| Claude Opus 4.5 | 8,192 | **64,000** | [Google Vertex AI docs](https://docs.cloud.google.com/vertex-ai/generative-ai/docs/partner-models/claude/opus-4-5) |
| Claude Opus 4.1 | 8,192 | **32,000** | [Google Vertex AI docs](https://cloud.google.com/vertex-ai/generative-ai/docs/partner-models/claude/opus-4-1) |
| Claude Opus 4 | 8,192 | **32,000** | [model.wiki](https://model.wiki/providers/anthropic/models/claude-opus-4-20250514/) |

Claude 3.5 Sonnet and Claude 3.5 Haiku remain at 8,192 (correct).

All `:1m` variants, Bedrock `v1:0` variants, and Vertex `@date` variants are updated to match their base model.

#### Important nuance: `max_tokens` semantics differ by API

- **Anthropic native API** (used by Anthropic direct, Bedrock, Vertex): `max_tokens` is the **total** budget for thinking + output when extended thinking is enabled. E.g. `max_tokens: 64000` with `budget_tokens: 10000` leaves 54,000 for output.
- **OpenAI-compatible APIs** (OpenRouter, Vercel): `max_tokens` is output only; thinking budget is separate via `reasoning.max_tokens`.

This means the values in this PR serve double duty — they're both the output ceiling for non-thinking requests and the total budget for thinking requests. The values match what Anthropic documents as the max for each model.

### Test Procedure

- Verified values against Anthropic's official documentation, AWS Bedrock docs, Google Vertex AI docs, and the Vercel AI Gateway API (`https://ai-gateway.vercel.sh/v1/models`).
- Cross-referenced with OpenRouter's dynamic model info (which already reports the correct values).
- `npm run compile` passes cleanly — no type errors.
- The companion PR #9544 was tested with runtime instrumentation on OpenRouter, proving that the old 8192 ceiling caused truncation (`finish_reason: "length"`, `completion_tokens: 8192`) and that raising the limit resolved it (`finish_reason: "tool_calls"`, `completion_tokens: 9824`). The same truncation mechanism applies to all providers using these static definitions.

**What could break:** The model will now be allowed to generate longer outputs, which could increase latency and cost for very long responses. However, the model only generates what it needs — `max_tokens` is a ceiling, not a target. The old 8192 value was artificially preventing the model from completing valid tool calls.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A — data-only change to model definitions. No UI changes.

### Additional Notes

- Companion to #9544, which fixes the same issue for OpenRouter by removing a hardcoded switch that overrode the (correct) dynamic value.
- Vercel AI Gateway was independently verified to report correct values via its public API, so it does not need a fix.
- A reference document with all sources is available at `docs/claude-max-output-tokens-reference-2026-02-24.md` in the repo.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Updated `maxTokens` values for Claude 3.7+ models in `src/shared/api.ts` to handle larger outputs across multiple providers.
> 
>   - **Behavior**:
>     - Updated `maxTokens` values for Claude models in `src/shared/api.ts` to reflect increased limits from Claude 3.7+ models.
>     - Affects `anthropicModels`, `bedrockModels`, `vertexModels`, and `sapAiCoreModels`.
>     - Ensures models can handle larger outputs without truncation.
>   - **Models**:
>     - `maxTokens` for `claude-opus-4-6` updated to 128,000.
>     - `maxTokens` for `claude-sonnet-4-6` and `claude-sonnet-4-5` updated to 64,000.
>     - `maxTokens` for `claude-opus-4-1` and `claude-opus-4` updated to 32,000.
>   - **Misc**:
>     - Verified against official documentation and dynamic model info from OpenRouter.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 6ffe11fdd9d496e52e61f10691727657b49bc8eb. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->