### PR TITLE
feat: add /lg-task URI handler for LG CNS dashboard integration

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -53,7 +53,7 @@ import { ExtensionRegistryInfo } from "./registry"
 import { AuthService } from "./services/auth/AuthService"
 import { LogoutReason } from "./services/auth/types"
 import { telemetryService } from "./services/telemetry"
-import { SharedUriHandler, TASK_URI_PATH } from "./services/uri/SharedUriHandler"
+import { LG_TASK_URI_PATH, SharedUriHandler, TASK_URI_PATH } from "./services/uri/SharedUriHandler"
 import { ShowMessageType } from "./shared/proto/host/window"
 import { fileExistsAtPath } from "./utils/fs"
 
@@ -160,7 +160,8 @@ export async function activate(context: vscode.ExtensionContext) {
 
 	const handleUri = async (uri: vscode.Uri) => {
 		const url = decodeURIComponent(uri.toString())
-		const isTaskUri = getUriPath(url) === TASK_URI_PATH
+		const uriPath = getUriPath(url)
+		const isTaskUri = uriPath === TASK_URI_PATH || uriPath === LG_TASK_URI_PATH
 
 		if (isTaskUri) {
 			await openClineSidebarForTaskUri()

--- a/src/services/lg-cns-integration/webhook-hooks.ts
+++ b/src/services/lg-cns-integration/webhook-hooks.ts
@@ -1,0 +1,185 @@
+import fs from "fs/promises"
+import path from "path"
+import { ensureHooksDirectoryExists, getDocumentsPath } from "@/core/storage/disk"
+import { Logger } from "@/shared/services/Logger"
+
+/**
+ * Sets up webhook hooks for LG CNS dashboard integration.
+ *
+ * Writes a webhook config file and installs PowerShell hook scripts
+ * to ~/Documents/Cline/Hooks/ that POST progress events back to
+ * the LG web dashboard.
+ */
+export async function setupLgWebhooks(webhookUrl: string, webhookToken: string): Promise<void> {
+	const documentsPath = await getDocumentsPath()
+	const clineDir = path.join(documentsPath, "Cline")
+
+	// Ensure Cline directory exists
+	await fs.mkdir(clineDir, { recursive: true })
+
+	// Write webhook config
+	const config = {
+		webhook_url: webhookUrl,
+		webhook_token: webhookToken,
+		created_at: new Date().toISOString(),
+	}
+	await fs.writeFile(path.join(clineDir, "webhook_config.json"), JSON.stringify(config, null, 2), "utf-8")
+
+	// Write hook scripts
+	const hooksDir = await ensureHooksDirectoryExists()
+
+	await Promise.all([
+		fs.writeFile(path.join(hooksDir, "TaskStart"), TASK_START_HOOK, "utf-8"),
+		fs.writeFile(path.join(hooksDir, "PostToolUse"), POST_TOOL_USE_HOOK, "utf-8"),
+		fs.writeFile(path.join(hooksDir, "TaskComplete"), TASK_COMPLETE_HOOK, "utf-8"),
+	])
+
+	Logger.info(`LG webhooks configured: ${webhookUrl}`)
+}
+
+// -- Hook script contents (PowerShell) --
+
+const TASK_START_HOOK = `#!/usr/bin/env pwsh
+# Cline Hook: TaskStart
+# Fires when Cline begins a new task.
+# Reads webhook config and POSTs a task_started event to the dashboard.
+
+$ErrorActionPreference = "SilentlyContinue"
+
+# Read hook input from stdin (Cline sends JSON)
+$hookInput = $input | Out-String | ConvertFrom-Json
+
+# Load webhook config
+$configPath = Join-Path $HOME "Documents" "Cline" "webhook_config.json"
+if (-not (Test-Path $configPath)) {
+    # No webhook configured, output empty response and exit
+    Write-Output '{"cancel": false}'
+    exit 0
+}
+$config = Get-Content $configPath -Raw | ConvertFrom-Json
+
+# Extract useful info from hook input
+$taskMetadata = @{}
+if ($hookInput.taskStart -and $hookInput.taskStart.taskMetadata) {
+    $taskMetadata = $hookInput.taskStart.taskMetadata
+}
+
+$payload = @{
+    event = "task_started"
+    timestamp = (Get-Date).ToUniversalTime().ToString("o")
+    data = @{
+        task_id = if ($hookInput.taskId) { $hookInput.taskId } else { "" }
+        cline_version = if ($hookInput.clineVersion) { $hookInput.clineVersion } else { "" }
+        workspace_roots = if ($hookInput.workspaceRoots) { $hookInput.workspaceRoots } else { @() }
+        task_metadata = $taskMetadata
+    }
+} | ConvertTo-Json -Depth 5 -Compress
+
+# POST to webhook (fire-and-forget, 5 second timeout)
+try {
+    $headers = @{
+        "Content-Type" = "application/json"
+        "Authorization" = "Bearer $($config.webhook_token)"
+    }
+    Invoke-RestMethod -Uri $config.webhook_url -Method Post -Body $payload -Headers $headers -TimeoutSec 5 | Out-Null
+} catch {
+    # Fire-and-forget: don't block Cline if the webhook is unreachable
+}
+
+# Output valid hook response (don't cancel, no context modification)
+Write-Output '{"cancel": false}'
+`
+
+const POST_TOOL_USE_HOOK = `#!/usr/bin/env pwsh
+# Cline Hook: PostToolUse
+# Fires after each tool execution (file writes, commands, etc.).
+# Reads webhook config and POSTs a tool_executed event to the dashboard.
+
+$ErrorActionPreference = "SilentlyContinue"
+
+# Read hook input from stdin (Cline sends JSON)
+$hookInput = $input | Out-String | ConvertFrom-Json
+
+# Load webhook config
+$configPath = Join-Path $HOME "Documents" "Cline" "webhook_config.json"
+if (-not (Test-Path $configPath)) {
+    Write-Output '{"cancel": false}'
+    exit 0
+}
+$config = Get-Content $configPath -Raw | ConvertFrom-Json
+
+# Extract tool execution data
+$toolData = if ($hookInput.postToolUse) { $hookInput.postToolUse } else { @{} }
+
+$payload = @{
+    event = "tool_executed"
+    timestamp = (Get-Date).ToUniversalTime().ToString("o")
+    data = @{
+        task_id = if ($hookInput.taskId) { $hookInput.taskId } else { "" }
+        tool_name = if ($toolData.toolName) { $toolData.toolName } else { "" }
+        parameters = if ($toolData.parameters) { $toolData.parameters } else { @{} }
+        success = if ($null -ne $toolData.success) { $toolData.success } else { $false }
+        execution_time_ms = if ($toolData.executionTimeMs) { $toolData.executionTimeMs } else { 0 }
+    }
+} | ConvertTo-Json -Depth 5 -Compress
+
+# POST to webhook (fire-and-forget, 5 second timeout)
+try {
+    $headers = @{
+        "Content-Type" = "application/json"
+        "Authorization" = "Bearer $($config.webhook_token)"
+    }
+    Invoke-RestMethod -Uri $config.webhook_url -Method Post -Body $payload -Headers $headers -TimeoutSec 5 | Out-Null
+} catch {
+    # Fire-and-forget: don't block Cline if the webhook is unreachable
+}
+
+# Output valid hook response
+Write-Output '{"cancel": false}'
+`
+
+const TASK_COMPLETE_HOOK = `#!/usr/bin/env pwsh
+# Cline Hook: TaskComplete
+# Fires when Cline finishes a task successfully.
+# Reads webhook config and POSTs a task_completed event to the dashboard.
+
+$ErrorActionPreference = "SilentlyContinue"
+
+# Read hook input from stdin (Cline sends JSON)
+$hookInput = $input | Out-String | ConvertFrom-Json
+
+# Load webhook config
+$configPath = Join-Path $HOME "Documents" "Cline" "webhook_config.json"
+if (-not (Test-Path $configPath)) {
+    Write-Output '{"cancel": false}'
+    exit 0
+}
+$config = Get-Content $configPath -Raw | ConvertFrom-Json
+
+# Extract task completion data
+$taskData = if ($hookInput.taskComplete) { $hookInput.taskComplete } else { @{} }
+$taskMetadata = if ($taskData.taskMetadata) { $taskData.taskMetadata } else { @{} }
+
+$payload = @{
+    event = "task_completed"
+    timestamp = (Get-Date).ToUniversalTime().ToString("o")
+    data = @{
+        task_id = if ($hookInput.taskId) { $hookInput.taskId } else { "" }
+        task_metadata = $taskMetadata
+    }
+} | ConvertTo-Json -Depth 5 -Compress
+
+# POST to webhook (fire-and-forget, 5 second timeout)
+try {
+    $headers = @{
+        "Content-Type" = "application/json"
+        "Authorization" = "Bearer $($config.webhook_token)"
+    }
+    Invoke-RestMethod -Uri $config.webhook_url -Method Post -Body $payload -Headers $headers -TimeoutSec 5 | Out-Null
+} catch {
+    # Fire-and-forget: don't block Cline if the webhook is unreachable
+}
+
+# Output valid hook response
+Write-Output '{"cancel": false}'
+`

--- a/src/services/lg-cns-integration/webhook-hooks.ts
+++ b/src/services/lg-cns-integration/webhook-hooks.ts
@@ -1,6 +1,6 @@
 import fs from "fs/promises"
 import path from "path"
-import { ensureHooksDirectoryExists, getClineHomePath } from "@/core/storage/disk"
+import { ensureHooksDirectoryExists, getDocumentsPath } from "@/core/storage/disk"
 import { Logger } from "@/shared/services/Logger"
 
 /**
@@ -11,26 +11,36 @@ import { Logger } from "@/shared/services/Logger"
  * the LG web dashboard.
  */
 export async function setupLgWebhooks(webhookUrl: string, webhookToken: string): Promise<void> {
-	// Write webhook config to ~/.cline/ (stable, platform-independent path).
-	// We avoid ~/Documents/Cline/ because the Documents folder can be in a
-	// non-standard location (e.g., OneDrive, different drive) on Windows.
-	const clineHome = getClineHomePath()
-	await fs.mkdir(clineHome, { recursive: true })
+	const documentsPath = await getDocumentsPath()
+	const clineDir = path.join(documentsPath, "Cline")
 
+	await fs.mkdir(clineDir, { recursive: true })
+
+	// Write webhook config next to hooks in ~/Documents/Cline/
+	const configPath = path.join(clineDir, "webhook_config.json")
 	const config = {
 		webhook_url: webhookUrl,
 		webhook_token: webhookToken,
 		created_at: new Date().toISOString(),
 	}
-	await fs.writeFile(path.join(clineHome, "webhook_config.json"), JSON.stringify(config, null, 2), "utf-8")
+	await fs.writeFile(configPath, JSON.stringify(config, null, 2), "utf-8")
 
-	// Write hook scripts
+	// Write hook scripts with the resolved config path baked in,
+	// so hooks don't need to guess the Documents folder location at runtime
 	const hooksDir = await ensureHooksDirectoryExists()
 
 	await Promise.all([
-		fs.writeFile(path.join(hooksDir, "TaskStart"), makeHookScript("task_started", TASK_START_DATA), "utf-8"),
-		fs.writeFile(path.join(hooksDir, "PostToolUse"), makeHookScript("tool_executed", POST_TOOL_USE_DATA), "utf-8"),
-		fs.writeFile(path.join(hooksDir, "TaskComplete"), makeHookScript("task_completed", TASK_COMPLETE_DATA), "utf-8"),
+		fs.writeFile(path.join(hooksDir, "TaskStart"), makeHookScript("task_started", TASK_START_DATA, configPath), "utf-8"),
+		fs.writeFile(
+			path.join(hooksDir, "PostToolUse"),
+			makeHookScript("tool_executed", POST_TOOL_USE_DATA, configPath),
+			"utf-8",
+		),
+		fs.writeFile(
+			path.join(hooksDir, "TaskComplete"),
+			makeHookScript("task_completed", TASK_COMPLETE_DATA, configPath),
+			"utf-8",
+		),
 	])
 
 	Logger.info(`LG webhooks configured: ${webhookUrl}`)
@@ -42,18 +52,22 @@ export async function setupLgWebhooks(webhookUrl: string, webhookToken: string):
  * Generates a PowerShell hook script that reads stdin JSON from Cline,
  * extracts event-specific data, and POSTs a webhook event.
  *
- * @param eventName - The webhook event name (e.g., "task_started")
- * @param dataExtraction - PowerShell code that sets $eventData from $hookInput
+ * The config path is resolved at generation time and embedded in the script,
+ * so hooks work correctly even if the Documents folder is in a non-standard
+ * location (e.g., OneDrive, different drive on Windows).
  */
-function makeHookScript(eventName: string, dataExtraction: string): string {
+function makeHookScript(eventName: string, dataExtraction: string, configPath: string): string {
+	// Escape backslashes for embedding in the PowerShell string
+	const escapedConfigPath = configPath.replace(/\\/g, "\\\\")
+
 	return `#!/usr/bin/env pwsh
 $ErrorActionPreference = "SilentlyContinue"
 
 # Read hook input from stdin (Cline sends JSON)
 $hookInput = $input | Out-String | ConvertFrom-Json
 
-# Load webhook config from ~/.cline/ (stable path across platforms)
-$configPath = Join-Path $HOME ".cline" "webhook_config.json"
+# Load webhook config (path resolved at install time by the Cline extension)
+$configPath = "${escapedConfigPath}"
 if (-not (Test-Path $configPath)) {
     Write-Output '{"cancel": false}'
     exit 0

--- a/src/services/lg-cns-integration/webhook-hooks.ts
+++ b/src/services/lg-cns-integration/webhook-hooks.ts
@@ -1,6 +1,6 @@
 import fs from "fs/promises"
 import path from "path"
-import { ensureHooksDirectoryExists, getDocumentsPath } from "@/core/storage/disk"
+import { ensureHooksDirectoryExists, getClineHomePath } from "@/core/storage/disk"
 import { Logger } from "@/shared/services/Logger"
 
 /**
@@ -11,19 +11,18 @@ import { Logger } from "@/shared/services/Logger"
  * the LG web dashboard.
  */
 export async function setupLgWebhooks(webhookUrl: string, webhookToken: string): Promise<void> {
-	const documentsPath = await getDocumentsPath()
-	const clineDir = path.join(documentsPath, "Cline")
+	// Write webhook config to ~/.cline/ (stable, platform-independent path).
+	// We avoid ~/Documents/Cline/ because the Documents folder can be in a
+	// non-standard location (e.g., OneDrive, different drive) on Windows.
+	const clineHome = getClineHomePath()
+	await fs.mkdir(clineHome, { recursive: true })
 
-	// Ensure Cline directory exists
-	await fs.mkdir(clineDir, { recursive: true })
-
-	// Write webhook config
 	const config = {
 		webhook_url: webhookUrl,
 		webhook_token: webhookToken,
 		created_at: new Date().toISOString(),
 	}
-	await fs.writeFile(path.join(clineDir, "webhook_config.json"), JSON.stringify(config, null, 2), "utf-8")
+	await fs.writeFile(path.join(clineHome, "webhook_config.json"), JSON.stringify(config, null, 2), "utf-8")
 
 	// Write hook scripts
 	const hooksDir = await ensureHooksDirectoryExists()
@@ -53,8 +52,8 @@ $ErrorActionPreference = "SilentlyContinue"
 # Read hook input from stdin (Cline sends JSON)
 $hookInput = $input | Out-String | ConvertFrom-Json
 
-# Load webhook config
-$configPath = Join-Path $HOME "Documents" "Cline" "webhook_config.json"
+# Load webhook config from ~/.cline/ (stable path across platforms)
+$configPath = Join-Path $HOME ".cline" "webhook_config.json"
 if (-not (Test-Path $configPath)) {
     Write-Output '{"cancel": false}'
     exit 0

--- a/src/services/lg-cns-integration/webhook-hooks.ts
+++ b/src/services/lg-cns-integration/webhook-hooks.ts
@@ -29,21 +29,25 @@ export async function setupLgWebhooks(webhookUrl: string, webhookToken: string):
 	const hooksDir = await ensureHooksDirectoryExists()
 
 	await Promise.all([
-		fs.writeFile(path.join(hooksDir, "TaskStart"), TASK_START_HOOK, "utf-8"),
-		fs.writeFile(path.join(hooksDir, "PostToolUse"), POST_TOOL_USE_HOOK, "utf-8"),
-		fs.writeFile(path.join(hooksDir, "TaskComplete"), TASK_COMPLETE_HOOK, "utf-8"),
+		fs.writeFile(path.join(hooksDir, "TaskStart"), makeHookScript("task_started", TASK_START_DATA), "utf-8"),
+		fs.writeFile(path.join(hooksDir, "PostToolUse"), makeHookScript("tool_executed", POST_TOOL_USE_DATA), "utf-8"),
+		fs.writeFile(path.join(hooksDir, "TaskComplete"), makeHookScript("task_completed", TASK_COMPLETE_DATA), "utf-8"),
 	])
 
 	Logger.info(`LG webhooks configured: ${webhookUrl}`)
 }
 
-// -- Hook script contents (PowerShell) --
+// -- Hook script generation --
 
-const TASK_START_HOOK = `#!/usr/bin/env pwsh
-# Cline Hook: TaskStart
-# Fires when Cline begins a new task.
-# Reads webhook config and POSTs a task_started event to the dashboard.
-
+/**
+ * Generates a PowerShell hook script that reads stdin JSON from Cline,
+ * extracts event-specific data, and POSTs a webhook event.
+ *
+ * @param eventName - The webhook event name (e.g., "task_started")
+ * @param dataExtraction - PowerShell code that sets $eventData from $hookInput
+ */
+function makeHookScript(eventName: string, dataExtraction: string): string {
+	return `#!/usr/bin/env pwsh
 $ErrorActionPreference = "SilentlyContinue"
 
 # Read hook input from stdin (Cline sends JSON)
@@ -52,134 +56,58 @@ $hookInput = $input | Out-String | ConvertFrom-Json
 # Load webhook config
 $configPath = Join-Path $HOME "Documents" "Cline" "webhook_config.json"
 if (-not (Test-Path $configPath)) {
-    # No webhook configured, output empty response and exit
     Write-Output '{"cancel": false}'
     exit 0
 }
 $config = Get-Content $configPath -Raw | ConvertFrom-Json
 
-# Extract useful info from hook input
-$taskMetadata = @{}
+# Extract event-specific data
+${dataExtraction}
+
+$payload = @{
+    event = "${eventName}"
+    timestamp = (Get-Date).ToUniversalTime().ToString("o")
+    data = $eventData
+} | ConvertTo-Json -Depth 5 -Compress
+
+# POST to webhook (fire-and-forget, 5 second timeout)
+try {
+    $headers = @{
+        "Content-Type" = "application/json"
+        "Authorization" = "Bearer $($config.webhook_token)"
+    }
+    Invoke-RestMethod -Uri $config.webhook_url -Method Post -Body $payload -Headers $headers -TimeoutSec 5 | Out-Null
+} catch {}
+
+Write-Output '{"cancel": false}'
+`
+}
+
+// Each extraction block sets $eventData from $hookInput
+
+const TASK_START_DATA = `$taskMetadata = @{}
 if ($hookInput.taskStart -and $hookInput.taskStart.taskMetadata) {
     $taskMetadata = $hookInput.taskStart.taskMetadata
 }
+$eventData = @{
+    task_id = if ($hookInput.taskId) { $hookInput.taskId } else { "" }
+    cline_version = if ($hookInput.clineVersion) { $hookInput.clineVersion } else { "" }
+    workspace_roots = if ($hookInput.workspaceRoots) { $hookInput.workspaceRoots } else { @() }
+    task_metadata = $taskMetadata
+}`
 
-$payload = @{
-    event = "task_started"
-    timestamp = (Get-Date).ToUniversalTime().ToString("o")
-    data = @{
-        task_id = if ($hookInput.taskId) { $hookInput.taskId } else { "" }
-        cline_version = if ($hookInput.clineVersion) { $hookInput.clineVersion } else { "" }
-        workspace_roots = if ($hookInput.workspaceRoots) { $hookInput.workspaceRoots } else { @() }
-        task_metadata = $taskMetadata
-    }
-} | ConvertTo-Json -Depth 5 -Compress
+const POST_TOOL_USE_DATA = `$toolData = if ($hookInput.postToolUse) { $hookInput.postToolUse } else { @{} }
+$eventData = @{
+    task_id = if ($hookInput.taskId) { $hookInput.taskId } else { "" }
+    tool_name = if ($toolData.toolName) { $toolData.toolName } else { "" }
+    parameters = if ($toolData.parameters) { $toolData.parameters } else { @{} }
+    success = if ($null -ne $toolData.success) { $toolData.success } else { $false }
+    execution_time_ms = if ($toolData.executionTimeMs) { $toolData.executionTimeMs } else { 0 }
+}`
 
-# POST to webhook (fire-and-forget, 5 second timeout)
-try {
-    $headers = @{
-        "Content-Type" = "application/json"
-        "Authorization" = "Bearer $($config.webhook_token)"
-    }
-    Invoke-RestMethod -Uri $config.webhook_url -Method Post -Body $payload -Headers $headers -TimeoutSec 5 | Out-Null
-} catch {
-    # Fire-and-forget: don't block Cline if the webhook is unreachable
-}
-
-# Output valid hook response (don't cancel, no context modification)
-Write-Output '{"cancel": false}'
-`
-
-const POST_TOOL_USE_HOOK = `#!/usr/bin/env pwsh
-# Cline Hook: PostToolUse
-# Fires after each tool execution (file writes, commands, etc.).
-# Reads webhook config and POSTs a tool_executed event to the dashboard.
-
-$ErrorActionPreference = "SilentlyContinue"
-
-# Read hook input from stdin (Cline sends JSON)
-$hookInput = $input | Out-String | ConvertFrom-Json
-
-# Load webhook config
-$configPath = Join-Path $HOME "Documents" "Cline" "webhook_config.json"
-if (-not (Test-Path $configPath)) {
-    Write-Output '{"cancel": false}'
-    exit 0
-}
-$config = Get-Content $configPath -Raw | ConvertFrom-Json
-
-# Extract tool execution data
-$toolData = if ($hookInput.postToolUse) { $hookInput.postToolUse } else { @{} }
-
-$payload = @{
-    event = "tool_executed"
-    timestamp = (Get-Date).ToUniversalTime().ToString("o")
-    data = @{
-        task_id = if ($hookInput.taskId) { $hookInput.taskId } else { "" }
-        tool_name = if ($toolData.toolName) { $toolData.toolName } else { "" }
-        parameters = if ($toolData.parameters) { $toolData.parameters } else { @{} }
-        success = if ($null -ne $toolData.success) { $toolData.success } else { $false }
-        execution_time_ms = if ($toolData.executionTimeMs) { $toolData.executionTimeMs } else { 0 }
-    }
-} | ConvertTo-Json -Depth 5 -Compress
-
-# POST to webhook (fire-and-forget, 5 second timeout)
-try {
-    $headers = @{
-        "Content-Type" = "application/json"
-        "Authorization" = "Bearer $($config.webhook_token)"
-    }
-    Invoke-RestMethod -Uri $config.webhook_url -Method Post -Body $payload -Headers $headers -TimeoutSec 5 | Out-Null
-} catch {
-    # Fire-and-forget: don't block Cline if the webhook is unreachable
-}
-
-# Output valid hook response
-Write-Output '{"cancel": false}'
-`
-
-const TASK_COMPLETE_HOOK = `#!/usr/bin/env pwsh
-# Cline Hook: TaskComplete
-# Fires when Cline finishes a task successfully.
-# Reads webhook config and POSTs a task_completed event to the dashboard.
-
-$ErrorActionPreference = "SilentlyContinue"
-
-# Read hook input from stdin (Cline sends JSON)
-$hookInput = $input | Out-String | ConvertFrom-Json
-
-# Load webhook config
-$configPath = Join-Path $HOME "Documents" "Cline" "webhook_config.json"
-if (-not (Test-Path $configPath)) {
-    Write-Output '{"cancel": false}'
-    exit 0
-}
-$config = Get-Content $configPath -Raw | ConvertFrom-Json
-
-# Extract task completion data
-$taskData = if ($hookInput.taskComplete) { $hookInput.taskComplete } else { @{} }
+const TASK_COMPLETE_DATA = `$taskData = if ($hookInput.taskComplete) { $hookInput.taskComplete } else { @{} }
 $taskMetadata = if ($taskData.taskMetadata) { $taskData.taskMetadata } else { @{} }
-
-$payload = @{
-    event = "task_completed"
-    timestamp = (Get-Date).ToUniversalTime().ToString("o")
-    data = @{
-        task_id = if ($hookInput.taskId) { $hookInput.taskId } else { "" }
-        task_metadata = $taskMetadata
-    }
-} | ConvertTo-Json -Depth 5 -Compress
-
-# POST to webhook (fire-and-forget, 5 second timeout)
-try {
-    $headers = @{
-        "Content-Type" = "application/json"
-        "Authorization" = "Bearer $($config.webhook_token)"
-    }
-    Invoke-RestMethod -Uri $config.webhook_url -Method Post -Body $payload -Headers $headers -TimeoutSec 5 | Out-Null
-} catch {
-    # Fire-and-forget: don't block Cline if the webhook is unreachable
-}
-
-# Output valid hook response
-Write-Output '{"cancel": false}'
-`
+$eventData = @{
+    task_id = if ($hookInput.taskId) { $hookInput.taskId } else { "" }
+    task_metadata = $taskMetadata
+}`

--- a/src/services/uri/SharedUriHandler.ts
+++ b/src/services/uri/SharedUriHandler.ts
@@ -1,4 +1,3 @@
-import fs from "fs/promises"
 import { WebviewProvider } from "@/core/webview"
 import { setupLgWebhooks } from "@/services/lg-cns-integration/webhook-hooks"
 import { Logger } from "@/shared/services/Logger"
@@ -102,15 +101,19 @@ export class SharedUriHandler {
 						return false
 					}
 
-					const specContents = await fs.readFile(promptFile, "utf-8")
-
 					const webhookUrl = query.get("webhook-url")
 					const webhookToken = query.get("webhook-token")
 					if (webhookUrl && webhookToken) {
 						await setupLgWebhooks(webhookUrl, webhookToken)
 					}
 
-					await visibleWebview.controller.handleTaskCreation(specContents)
+					const prompt =
+						`The following file contains a development specification for you to implement: ${promptFile}\n\n` +
+						`Start by reading this file. As you work through the task, re-read the file whenever its contents ` +
+						`are lost during context compaction (when the context window limit is reached), so you can keep ` +
+						`track of your progress against the spec requirements.`
+
+					await visibleWebview.controller.handleTaskCreation(prompt)
 					return true
 				}
 				// Match /mcp-auth/callback/{hash}

--- a/src/services/uri/SharedUriHandler.ts
+++ b/src/services/uri/SharedUriHandler.ts
@@ -1,7 +1,10 @@
+import fs from "fs/promises"
 import { WebviewProvider } from "@/core/webview"
+import { setupLgWebhooks } from "@/services/lg-cns-integration/webhook-hooks"
 import { Logger } from "@/shared/services/Logger"
 
 export const TASK_URI_PATH = "/task"
+export const LG_TASK_URI_PATH = "/lg-task"
 
 /**
  * Shared URI handler that processes both VSCode URI events and HTTP server callbacks
@@ -91,6 +94,24 @@ export class SharedUriHandler {
 					}
 					Logger.warn("SharedUriHandler: Missing prompt parameter for task creation")
 					return false
+				}
+				case LG_TASK_URI_PATH: {
+					const promptFile = query.get("prompt-file")
+					if (!promptFile) {
+						Logger.warn("SharedUriHandler: Missing prompt-file parameter for LG task creation")
+						return false
+					}
+
+					const specContents = await fs.readFile(promptFile, "utf-8")
+
+					const webhookUrl = query.get("webhook-url")
+					const webhookToken = query.get("webhook-token")
+					if (webhookUrl && webhookToken) {
+						await setupLgWebhooks(webhookUrl, webhookToken)
+					}
+
+					await visibleWebview.controller.handleTaskCreation(specContents)
+					return true
 				}
 				// Match /mcp-auth/callback/{hash}
 				case path.match(/^\/mcp-auth\/callback\/[^/]+$/)?.input: {


### PR DESCRIPTION
## Summary

Adds a new `/lg-task` URI path that enables the LG CNS web dashboard to launch Cline tasks directly from the browser on their Windows VM. The dashboard can't execute scripts on the OS, but it can open URI schemes, so everything flows through the URI handler.

When the dashboard opens `vscode://saoudrizwan.claude-dev/lg-task?prompt-file=<path>&webhook-url=<url>&webhook-token=<token>`, the extension:

1. Writes `~/Documents/Cline/webhook_config.json` with the webhook credentials
2. Installs PowerShell hook scripts (TaskStart, PostToolUse, TaskComplete) to `~/Documents/Cline/Hooks/` that POST progress events back to the dashboard
3. Starts a new task with a prompt that points the agent to the spec file path, instructing it to read the file and re-read it after context compaction so it can track progress against the spec

The agent receives the file path rather than the file contents inline. This way the spec survives context compaction -- the agent can always go back and re-read the file.

The hooks fire at each lifecycle event and POST `task_started`, `tool_executed`, and `task_completed` events to the webhook URL. All webhook calls are fire-and-forget with a 5-second timeout so they never block Cline.

All LG-specific code lives in `src/services/lg-cns-integration/` for clear separation.

## Changes

- `src/services/lg-cns-integration/webhook-hooks.ts` (new): `setupLgWebhooks()` function that writes webhook config and installs PowerShell hook scripts. Hook scripts are generated from a shared `makeHookScript()` template to avoid duplication -- each hook only defines its event name and data extraction logic.
- `src/services/uri/SharedUriHandler.ts`: New `LG_TASK_URI_PATH` constant and `/lg-task` case that extracts query params, sets up webhooks, and starts a task with the spec file path
- `src/extension.ts`: Extended task URI detection so `/lg-task` gets the same sidebar initialization and retry logic as `/task`

## Test plan

- [ ] `npm run compile` passes (verified locally, only pre-existing CLI errors)
- [ ] Open `vscode://saoudrizwan.claude-dev/lg-task?prompt-file=/tmp/test.md&webhook-url=http://localhost:8080&webhook-token=test` and verify task starts with prompt referencing the file path
- [ ] Verify `~/Documents/Cline/webhook_config.json` is written with correct URL and token
- [ ] Verify hook scripts are written to `~/Documents/Cline/Hooks/`
- [ ] Verify webhook events are POSTed when hooks fire
- [ ] Verify missing `prompt-file` param returns false and logs warning
- [ ] Verify webhook params are optional (task still starts without them)