### PR TITLE
Increase timeout of flaky test

### DIFF
--- a/cli/src/lib-import.test.ts
+++ b/cli/src/lib-import.test.ts
@@ -5,5 +5,5 @@ describe("library import side effects", () => {
 		const originalConsoleLog = console.log
 		await import("./exports")
 		expect(console.log).toBe(originalConsoleLog)
-	}, 10000)
+	}, 30000)
 })


### PR DESCRIPTION
### Related Issue

**Issue:** n/a

### Description

We're currently seeing a flaky test in CI on PRs where the CLI tests on Windows fail intermittently due to taking longer than 10 seconds to do a large import.  This PR increases the timeout to 30 seconds, which is a quick fix, but it's not the scalable, longer term solution (we can ask Cline for the more robust solution in the future).


### Test Procedure

n/a

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

n/a

### Additional Notes

n/a
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Increase test timeout in `cli/src/lib-import.test.ts` from 10 to 30 seconds to fix flaky test on Windows CI.
> 
>   - **Test Timeout Increase**:
>     - In `cli/src/lib-import.test.ts`, increase timeout for the test "importing library exports must not mutate console.log" from 10 seconds to 30 seconds to address intermittent failures on Windows CI.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for f9e0d937b36802f2468bfa80d44667f94d296eda. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->