### PR TITLE
workflow: add default auto-tag flow for Publish Release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -57,10 +57,11 @@ jobs:
                     exit 1
                   fi
 
-                  if [[ ! "$TAG" =~ ^v[0-9] ]]; then
-                    echo "Error: tag must start with 'v' and look like vX.Y.Z"
+                  if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z.]+)?$ ]]; then
+                    echo "Error: tag must match vX.Y.Z (optionally with -suffix or .suffix)"
                     exit 1
                   fi
+                  TAG_REF="refs/tags/$TAG"
 
                   git fetch origin main --tags
 
@@ -76,8 +77,8 @@ jobs:
                       exit 1
                     fi
 
-                    if git rev-parse "$TAG" >/dev/null 2>&1; then
-                      TAG_SHA=$(git rev-list -n 1 "$TAG")
+                    if git show-ref --verify --quiet "$TAG_REF"; then
+                      TAG_SHA=$(git rev-list -n 1 "$TAG_REF^{commit}")
                       if [[ "$TAG_SHA" != "$TESTED_SHA" ]]; then
                         echo "Error: tag '$TAG' already exists at $TAG_SHA, not at tested SHA ($TESTED_SHA)"
                         exit 1
@@ -87,18 +88,18 @@ jobs:
                       git config user.name "github-actions[bot]"
                       git config user.email "github-actions[bot]@users.noreply.github.com"
                       git tag "$TAG" "$TESTED_SHA"
-                      git push origin "$TAG"
+                      git push origin "$TAG_REF"
                       echo "Created and pushed tag '$TAG' from tested SHA $TESTED_SHA."
                     fi
                   else
-                    if ! git rev-parse "$TAG" >/dev/null 2>&1; then
+                    if ! git show-ref --verify --quiet "$TAG_REF"; then
                       echo "Error: tag '$TAG' does not exist in the repository"
                       exit 1
                     fi
                     echo "Using existing tag '$TAG'."
                   fi
 
-                  git checkout --detach "$TAG"
+                  git checkout --detach "$TAG_REF^{commit}"
                   echo "tag=$TAG" >> $GITHUB_OUTPUT
                   echo "resolved_sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

### Description

This PR simplifies the extension release flow while preserving the existing hotfix path.

- Adds a new `workflow_dispatch` option: `auto_create_tag_from_main` (default: `true`)
- In default mode, the workflow creates and pushes the provided tag from latest `origin/main`
- In manual mode (`false`), the workflow uses an already-existing tag (for hotfix/manual releases)
- Resolves and checks out the release tag before install/build/publish so release artifacts are built from the exact tagged commit
- Adds a guard to verify the tag matches `package.json` version (`v<version>`)

Scope is intentionally small for easy review: one workflow file only.

### Test Procedure

- Validated YAML parsing for `.github/workflows/publish.yml`
- Verified PR diff is limited to `.github/workflows/publish.yml`
- Reviewed both release paths in script logic:
  - auto-create from latest `origin/main`
  - existing tag validation path for hotfixes

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [x] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A (workflow-only change)

### Additional Notes

Default release behavior is now the low-friction path (no local tag push required). Existing-tag behavior remains available for hotfix/advanced cases.

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds automated tag creation from `origin/main` to `publish.yml`, ensuring tag matches package version.
> 
>   - **Workflow Changes**:
>     - Adds `auto_create_tag_from_main` option to `.github/workflows/publish.yml` (default: `true`).
>     - Automates tag creation from `origin/main` if `auto_create_tag_from_main` is `true`.
>     - Validates existing tag for manual releases if `auto_create_tag_from_main` is `false`.
>   - **Tag Validation**:
>     - Ensures release tag matches `package.json` version (`v<version>`).
>     - Checks out the release tag before build and publish steps.
>   - **Misc**:
>     - Updates `publish.yml` to handle both auto-created and existing tags for releases.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for c5e82cae07f424dfdea5c6580b46f0d85d378859. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->