### PR TITLE
fix: respect user-defined timeout in MCP server requests

### DIFF
--- a/.changeset/fix-mcp-timeout.md
+++ b/.changeset/fix-mcp-timeout.md
@@ -1,0 +1,1 @@
+---\n'cline': patch\n---\n\nfix: respect user-defined timeout in MCP server requests

--- a/src/services/mcp/McpHub.ts
+++ b/src/services/mcp/McpHub.ts
@@ -69,7 +69,7 @@ export class McpHub {
 	 *
 	 * Timeline:
 	 *   0ms:    flag = true, write file
-	 *   ~100ms: file watcher fires "change" â†’ sees flag=true â†’ skips
+	 *   ~100ms: file watcher fires "change" -> sees flag=true -> skips
 	 *   300ms:  flag = false (ready for external file changes)
 	 */
 	private isUpdatingClineSettings = false


### PR DESCRIPTION
### Description
MCP server requests for tools, resources, and prompts were previously hardcoded to a 5-second timeout (\DEFAULT_REQUEST_TIMEOUT_MS\), which caused connection failures for slower MCP servers (like remote proxies or AWS-hosted ones) even when a higher timeout was explicitly configured in settings.

This PR introduces a \getTimeout\ helper in \McpHub\ that:
1.  Reads the per-server \	imeout\ configuration from \mcpSettings.json\.
2.  Converts it to milliseconds.
3.  Falls back to the default 5s if no custom timeout is set.

All internal requests (\	ools/list\, \esources/list\, \prompts/list\, etc.) now use this dynamic timeout.

### Related Issues
Fixes #7635

### Checklist
- [x] I have tested these changes locally.
- [x] I have followed the project's code style guidelines.
- [x] All tests pass (run \
pm run compile\).
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Introduces dynamic timeout handling for MCP server requests in `McpHub`, respecting user-defined settings and fixing hardcoded timeout issue.
> 
>   - **Behavior**:
>     - Introduces `getTimeout()` in `McpHub` to dynamically determine request timeouts based on `mcpSettings.json`.
>     - Applies dynamic timeout to `fetchToolsList()`, `fetchResourcesList()`, `fetchResourceTemplatesList()`, `fetchPromptsList()`, and `getPrompt()`.
>     - Falls back to `DEFAULT_REQUEST_TIMEOUT_MS` if no custom timeout is set.
>   - **Error Handling**:
>     - Logs error if timeout configuration parsing fails in `getTimeout()`.
>   - **Misc**:
>     - Fixes hardcoded timeout issue in MCP server requests, addressing issue #7635.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for e70487dddcb64f47a8847a323dd7c61947494d14. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->