### PR TITLE
fix: remove tmp and temp from default ignore directories

### DIFF
--- a/src/services/glob/list-files.ts
+++ b/src/services/glob/list-files.ts
@@ -17,8 +17,6 @@ const DEFAULT_IGNORE_DIRECTORIES = [
 	"out",
 	"bundle",
 	"vendor",
-	"tmp",
-	"temp",
 	"deps",
 	"Pods",
 ]


### PR DESCRIPTION
## Related Issue

#6142

## Description

Removes `tmp` and `temp` from `DEFAULT_IGNORE_DIRECTORIES` in `src/services/glob/list-files.ts`. These entries cause file autocomplete and `@file` mentions to silently skip files in temporary directories within the user's workspace, which is unexpected behavior.

Fixes #6142

## Test Procedure

1. Create a directory named `temp` or `tmp` inside your project workspace
2. Add files to it
3. Type `@` in the Cline chat and start typing the file name
4. Verify the files in `temp`/`tmp` directories now appear in autocomplete suggestions

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (code change that neither fixes a bug nor adds a feature)
- [ ] Cosmetic (whitespace, formatting, etc.)
- [ ] Documentation update
- [ ] Workflow/CI change

## Pre-flight Checklist

- [x] I have read the [Contributing Guide](CONTRIBUTING.md)
- [x] My changes follow the code style of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

## Additional Notes

This is a minimal 2-line change that removes the overly broad exclusion of `tmp` and `temp` directories. These are common names for directories that users may intentionally create in their project (e.g., for temporary build artifacts, test fixtures, etc.) and should be discoverable through file autocomplete.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Removes `tmp` and `temp` from `DEFAULT_IGNORE_DIRECTORIES` in `list-files.ts` to include files in these directories in autocomplete suggestions.
> 
>   - **Behavior**:
>     - Removes `tmp` and `temp` from `DEFAULT_IGNORE_DIRECTORIES` in `list-files.ts`, allowing files in these directories to appear in autocomplete suggestions.
>   - **Test Procedure**:
>     - Create `temp` or `tmp` directories, add files, and verify they appear in autocomplete.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 21887b5be3606d0e4b5ca861c4b0095b4309f210. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->