### PR TITLE
fix: handle map<> types in proto field regex

### DIFF
--- a/scripts/generate-state-proto.mjs
+++ b/scripts/generate-state-proto.mjs
@@ -248,7 +248,8 @@ function parseProtoMessageFieldNumbers(protoContent, messageName) {
 	const messageBody = match[1]
 
 	// Match field definitions: optional/required/repeated type name = number;
-	const fieldRegex = /(?:optional|required|repeated)?\s*\w+\s+(\w+)\s*=\s*(\d+)\s*;/g
+	// Type can be a simple word (e.g. string) or a generic type (e.g. map<string, string>)
+	const fieldRegex = /(?:optional|required|repeated)?\s*\w+(?:<[^>]+>)?\s+(\w+)\s*=\s*(\d+)\s*;/g
 	const matches = messageBody.matchAll(fieldRegex)
 
 	for (const fieldMatch of matches) {


### PR DESCRIPTION
## Related Issue

Closes #9593

## Description

The `fieldRegex` in `parseProtoMessageFieldNumbers()` (line 251 of `scripts/generate-state-proto.mjs`) uses `\w+` to match proto field types. This fails to match parameterized types like `map<string, string>`, causing their existing field numbers to be lost during proto regeneration. The lost fields are then reassigned new (incorrect) field numbers, breaking backward compatibility.

**Before (bug):** Running the script moves `map<string, string> open_ai_headers` from field number 177 to 182 because the regex cannot parse the existing field definition.

**After (fix):** Updated the regex to `\w+(?:<[^>]+>)?` which correctly matches both simple types (`string`, `bool`, `int64`) and generic/map types (`map<string, string>`). The field number 177 is now preserved.

## Test Procedure

1. Before this fix, run `node scripts/generate-state-proto.mjs` and check the diff — `open_ai_headers` field number changes from 177 to 182
2. After this fix, run the same script — `open_ai_headers` stays at field number 177

Regex unit test:
```js
const fieldRegex = /(?:optional|required|repeated)?\s*\w+(?:<[^>]+>)?\s+(\w+)\s*=\s*(\d+)\s*;/g;
// ✅ "map<string, string> open_ai_headers = 177;" -> name: open_ai_headers, number: 177
// ✅ "optional string api_key = 1;" -> name: api_key, number: 1
// ✅ "repeated string tags = 3;" -> name: tags, number: 3
```

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Pre-flight Checklist

- [x] I have read the [contributing guidelines](../CONTRIBUTING.md)
- [x] My changes follow the project's coding style
- [x] I have tested my changes
- [x] My changes do not generate any new warnings

## Additional Notes

This is a one-line regex change. The only modification is adding `(?:<[^>]+>)?` after `\w+` in the type-matching portion of the regex, enabling it to handle proto map/generic types while maintaining backward compatibility with simple types.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes regex in `scripts/generate-state-proto.mjs` to correctly handle `map<>` types, preserving field numbers during proto regeneration.
> 
>   - **Behavior**:
>     - Fixes regex in `parseProtoMessageFieldNumbers()` in `scripts/generate-state-proto.mjs` to handle `map<>` types, preserving field numbers during proto regeneration.
>     - Before fix: `map<string, string>` fields were reassigned new numbers, breaking compatibility.
>     - After fix: Field numbers for `map<string, string>` are preserved.
>   - **Regex**:
>     - Updated regex to `\w+(?:<[^>]+>)?` to match both simple and generic/map types.
>   - **Testing**:
>     - Verified by running `node scripts/generate-state-proto.mjs` before and after the fix to ensure field numbers remain consistent.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for caf8d6e0be99c15d8762bcd8964e5719dfece962. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->