### PR TITLE
fix: hide context window bar when token usage is unavailable

### DIFF
--- a/webview-ui/src/components/chat/task-header/ContextWindow.tsx
+++ b/webview-ui/src/components/chat/task-header/ContextWindow.tsx
@@ -92,7 +92,7 @@ const ContextWindow: React.FC<ContextWindowProgressProps> = ({
 	}, [])
 
 	const tokenData = useMemo(() => {
-		if (!contextWindow) {
+		if (!contextWindow || lastApiReqTotalTokens == null) {
 			return null
 		}
 		return {


### PR DESCRIPTION
## Related Issue

Closes #9433

## Description

When an API provider returns `"usage": null` in responses, `lastApiReqTotalTokens` is `undefined`. The context window bar calculates `(undefined / contextWindow) * 100` which evaluates to `NaN`, displayed as **0%** in the progress bar.

**Fix:** Add a null check for `lastApiReqTotalTokens` alongside the existing `contextWindow` check. When either value is unavailable, `tokenData` returns `null` and the component is not rendered, avoiding the misleading 0% display.

```typescript
// Before:
if (!contextWindow) {
    return null
}

// After:
if (!contextWindow || lastApiReqTotalTokens == null) {
    return null
}
```

## Test Procedure

1. Configure Cline with an OpenAI-compatible provider that returns `"usage": null`
2. Start a task and observe the context window area — it should not show a 0% bar
3. Switch to a provider that returns proper usage data — the context window bar should appear with correct percentages

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Pre-flight Checklist

- [x] I have read the [contributing guidelines](../CONTRIBUTING.md)
- [x] My changes follow the project's coding style
- [x] I have tested my changes
- [x] My changes do not generate any new warnings

## Additional Notes

Uses loose equality (`== null`) to catch both `null` and `undefined`, which is the idiomatic TypeScript pattern for nullish checks.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds null check in `ContextWindow.tsx` to prevent rendering progress bar when token usage is unavailable, avoiding misleading 0% display.
> 
>   - **Behavior**:
>     - Adds null check for `lastApiReqTotalTokens` in `ContextWindow.tsx` to prevent rendering when token usage is unavailable.
>     - Avoids displaying misleading 0% in progress bar when API returns `"usage": null`.
>   - **Code**:
>     - Updates `useMemo` in `ContextWindow` to return `null` if `lastApiReqTotalTokens` is `null` or `undefined`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 58f96543b5cfa84bb754647db67b5ef2f90ce207. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->