### PR TITLE
fix: map Meta shortcut to Ctrl on Linux and Windows

### DIFF
--- a/webview-ui/src/utils/__tests__/hooks.spec.ts
+++ b/webview-ui/src/utils/__tests__/hooks.spec.ts
@@ -7,7 +7,8 @@ describe("useShortcut", () => {
 		const callback = vi.fn()
 		renderHook(() => useShortcut("Meta+Shift+a", callback))
 
-		const event = new KeyboardEvent("keydown", { key: "a", metaKey: true, shiftKey: true })
+		// On non-Mac platforms, Meta maps to ctrlKey, so we include both to work cross-platform
+		const event = new KeyboardEvent("keydown", { key: "a", metaKey: true, ctrlKey: true, shiftKey: true })
 		window.dispatchEvent(event)
 
 		expect(callback).toHaveBeenCalled()
@@ -31,7 +32,8 @@ describe("useShortcut", () => {
 		document.body.appendChild(input)
 		input.focus()
 
-		const event = new KeyboardEvent("keydown", { key: "a", metaKey: true, shiftKey: true })
+		// On non-Mac platforms, Meta maps to ctrlKey, so we include both to work cross-platform
+		const event = new KeyboardEvent("keydown", { key: "a", metaKey: true, ctrlKey: true, shiftKey: true })
 		input.dispatchEvent(event)
 
 		expect(callback).not.toHaveBeenCalled()

--- a/webview-ui/src/utils/__tests__/hooks.spec.ts
+++ b/webview-ui/src/utils/__tests__/hooks.spec.ts
@@ -45,7 +45,7 @@ describe("useMetaKeyDetection", () => {
 		// mock the detect functions
 		const { result } = renderHook(() => useMetaKeyDetection("win32"))
 		expect(result.current[0]).toBe("windows")
-		expect(result.current[1]).toBe("Win")
+		expect(result.current[1]).toBe("Ctrl")
 	})
 
 	it("should detect Mac OS and metaKey from platform", () => {
@@ -59,6 +59,6 @@ describe("useMetaKeyDetection", () => {
 		// mock the detect functions
 		const { result } = renderHook(() => useMetaKeyDetection("linux"))
 		expect(result.current[0]).toBe("linux")
-		expect(result.current[1]).toBe("Alt")
+		expect(result.current[1]).toBe("Ctrl")
 	})
 })

--- a/webview-ui/src/utils/__tests__/platformUtils.spec.ts
+++ b/webview-ui/src/utils/__tests__/platformUtils.spec.ts
@@ -7,18 +7,18 @@ describe("detectMetaKeyChar", () => {
 		expect(result).toBe("CMD")
 	})
 
-	it("should return ⊞ Win for win32 platform", () => {
+	it("should return Ctrl for win32 platform", () => {
 		const result = detectMetaKeyChar("win32")
-		expect(result).toBe("Win")
+		expect(result).toBe("Ctrl")
 	})
 
-	it("should return Alt for linux platform", () => {
+	it("should return Ctrl for linux platform", () => {
 		const result = detectMetaKeyChar("linux")
-		expect(result).toBe("Alt")
+		expect(result).toBe("Ctrl")
 	})
 
-	it("should return generic CMD for unknown platform", () => {
+	it("should return Ctrl for unknown platform", () => {
 		const result = detectMetaKeyChar("somethingelse")
-		expect(result).toBe("CMD")
+		expect(result).toBe("Ctrl")
 	})
 })

--- a/webview-ui/src/utils/hooks.ts
+++ b/webview-ui/src/utils/hooks.ts
@@ -18,6 +18,7 @@ export const useMetaKeyDetection = (platform: string) => {
 export const useShortcut = (shortcut: string, callback: (...args: unknown[]) => void, options = { disableTextInputs: true }) => {
 	const callbackRef = useRef(callback)
 	const [keyCombo, setKeyCombo] = useState<string[]>([])
+	const isMac = /mac|darwin/i.test(navigator?.platform || "")
 
 	useLayoutEffect(() => {
 		callbackRef.current = callback
@@ -33,7 +34,7 @@ export const useShortcut = (shortcut: string, callback: (...args: unknown[]) => 
 			const modifierMap: { [key: string]: boolean } = {
 				Control: event.ctrlKey,
 				Alt: event.altKey,
-				Meta: event.metaKey, // alias for Command
+				Meta: isMac ? event.metaKey : event.ctrlKey,
 				Shift: event.shiftKey,
 			}
 

--- a/webview-ui/src/utils/platformUtils.ts
+++ b/webview-ui/src/utils/platformUtils.ts
@@ -26,12 +26,8 @@ export const detectOS = (platform: string) => {
 export const detectMetaKeyChar = (platform: string) => {
 	if (platform.match(platforms.mac)) {
 		return "CMD"
-	} else if (platform.match(platforms.windows)) {
-		return "Win"
-	} else if (platform.match(platforms.linux)) {
-		return "Alt"
 	} else {
-		return "CMD"
+		return "Ctrl"
 	}
 }
 


### PR DESCRIPTION
## Related Issue

Fixes #8974

## Description

On Linux and Windows, the `Meta` key maps to the Super/Windows key, which is intercepted by the desktop environment. This makes keyboard shortcuts like Plan/Act toggle (`Meta+Shift+A`) non-functional on these platforms.

This PR maps `Meta` to `Ctrl` on non-Mac platforms in the `useShortcut` hook, following the standard VS Code convention where Cmd on macOS corresponds to Ctrl on Linux/Windows. The display label is also updated to show "Ctrl" instead of "Alt"/"Win" to match the actual keybinding.

### Changes

1. **`webview-ui/src/utils/hooks.ts`** — In `useShortcut`, detect platform via `navigator.platform` and map `Meta` to `event.ctrlKey` on non-Mac platforms (keeping `event.metaKey` on macOS).
2. **`webview-ui/src/utils/platformUtils.ts`** — Simplify `detectMetaKeyChar` to return "Ctrl" for all non-Mac platforms, ensuring the displayed shortcut label matches the actual keybinding.
3. **`webview-ui/src/utils/__tests__/hooks.spec.ts`** — Update test expectations for Windows ("Ctrl" instead of "Win") and Linux ("Ctrl" instead of "Alt").

## Test Procedure

1. On Linux: Open Cline, verify the Plan/Act toggle tooltip shows "Ctrl+Shift+A"
2. Press Ctrl+Shift+A — should toggle between Plan and Act modes
3. On macOS: Verify CMD+Shift+A still works as before
4. On Windows: Verify Ctrl+Shift+A works (previously showed "Win+Shift+A" which was non-functional)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Pre-flight Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/cline/cline/blob/main/CONTRIBUTING.md) doc
- [x] I've used conventional commit format for my commit message
- [x] My changes don't introduce any new warnings or errors
- [x] I've tested the changes locally

## Additional Notes

This follows the standard VS Code convention: macOS uses Cmd as the primary modifier, while Linux and Windows use Ctrl. The previous mapping (Super/Win key) was intercepted at the OS level, making shortcuts unusable on non-Mac platforms.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remap `Meta` to `Ctrl` on Linux/Windows in `useShortcut` and update tests to ensure correct shortcut functionality and labeling.
> 
>   - **Behavior**:
>     - In `useShortcut` in `hooks.ts`, map `Meta` to `Ctrl` on non-Mac platforms using `navigator.platform`.
>     - Update `detectMetaKeyChar` in `platformUtils.ts` to return "Ctrl" for non-Mac platforms.
>   - **Tests**:
>     - Update `hooks.spec.ts` to expect "Ctrl" instead of "Win" or "Alt" for Windows and Linux.
>   - **Misc**:
>     - Ensure shortcut labels match actual keybindings across platforms.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 2dd62986b295a3b9aa4cc949dd7d2a16faa8d6e5. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->