### PR TITLE
fix: queue addToInput text when panel has no active subscribers

### DIFF
--- a/src/core/controller/ui/subscribeToAddToInput.ts
+++ b/src/core/controller/ui/subscribeToAddToInput.ts
@@ -6,6 +6,9 @@ import type { Controller } from "../index"
 // Keep track of active addToInput subscriptions
 const activeAddToInputSubscriptions = new Set<StreamingResponseHandler<ProtoString>>()
 
+// Pending text to send when a subscriber connects
+let pendingAddToInputText: string | null = null
+
 /**
  * Subscribe to addToInput events
  * @param controller The controller instance
@@ -22,6 +25,13 @@ export async function subscribeToAddToInput(
 	// Add this subscription to the active subscriptions
 	activeAddToInputSubscriptions.add(responseStream)
 
+	// If there was pending text waiting for a subscriber, send it now
+	if (pendingAddToInputText !== null) {
+		const text = pendingAddToInputText
+		pendingAddToInputText = null
+		await sendAddToInputEvent(text)
+	}
+
 	// Register cleanup when the connection is closed
 	const cleanup = () => {
 		activeAddToInputSubscriptions.delete(responseStream)
@@ -34,10 +44,17 @@ export async function subscribeToAddToInput(
 }
 
 /**
- * Send an addToInput event to all active subscribers
+ * Send an addToInput event to all active subscribers.
+ * If no subscribers are active (e.g. panel not yet initialized), the text is
+ * queued and will be delivered when the first subscriber connects.
  * @param text The text to add to the input
  */
 export async function sendAddToInputEvent(text: string): Promise<void> {
+	if (activeAddToInputSubscriptions.size === 0) {
+		pendingAddToInputText = text
+		return
+	}
+
 	// Send the event to all active subscribers
 	const promises = Array.from(activeAddToInputSubscriptions).map(async (responseStream) => {
 		try {


### PR DESCRIPTION
## Related Issue

Fixes #7351

## Description

When the Cline panel is closed or not yet initialized, `sendAddToInputEvent` iterates over an empty subscriber set and silently discards the text. This causes the "Add to Cline" context menu action to fail without any feedback.

### Root Cause

The `activeAddToInputSubscriptions` set is only populated when the webview registers its gRPC subscription via `subscribeToAddToInput`. If the panel hasn't been opened yet (or was disposed), there are no active subscribers and the event is lost.

### Fix

Add a `pendingAddToInputText` variable to `subscribeToAddToInput.ts`:
- In `sendAddToInputEvent`: if no subscribers are active, store the text as pending instead of discarding it
- In `subscribeToAddToInput`: when a new subscriber connects, check for pending text and deliver it immediately

This ensures that `showWebview()` (already called by `getContextForCommand`) has time to initialize the panel and register the subscription, at which point the queued text is sent.

## Test Procedure

1. Close the Cline panel completely (not just hide it)
2. Select code in the editor
3. Right-click → "Add to Cline"
4. Verify the Cline panel opens and the selected code appears in the chat input
5. Repeat with the panel already open — should work as before

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Pre-flight Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/cline/cline/blob/main/CONTRIBUTING.md) doc
- [x] I've used conventional commit format for my commit message
- [x] My changes don't introduce any new warnings or errors
- [x] I've tested the changes locally

## Additional Notes

Only one file changed (`subscribeToAddToInput.ts`). The fix is backward-compatible — when subscribers are active, behavior is identical to before. The pending queue only holds one text at a time (latest wins), matching the expected usage pattern.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes text discard issue in `subscribeToAddToInput.ts` by queuing text when no subscribers are active and sending it when a subscriber connects.
> 
>   - **Behavior**:
>     - In `sendAddToInputEvent`, if no subscribers are active, text is stored in `pendingAddToInputText` instead of being discarded.
>     - In `subscribeToAddToInput`, when a new subscriber connects, pending text is sent immediately.
>   - **Implementation**:
>     - Adds `pendingAddToInputText` variable to `subscribeToAddToInput.ts` to queue text.
>     - Updates `sendAddToInputEvent` and `subscribeToAddToInput` functions to handle pending text logic.
>   - **Testing**:
>     - Verified that text is correctly queued and sent when the panel is opened after being closed.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 81a9128a3b5755ea8fa4641f9ec848345daccd28. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->