### PR TITLE
fix: load cline rules for commit message generation

### DIFF
--- a/src/hosts/vscode/commit-message-generator.ts
+++ b/src/hosts/vscode/commit-message-generator.ts
@@ -2,6 +2,12 @@ import { buildApiHandler } from "@core/api"
 import * as path from "path"
 import * as vscode from "vscode"
 import { Controller } from "@/core/controller"
+import {
+	getGlobalClineRules,
+	getLocalClineRules,
+	refreshClineRulesToggles,
+} from "@/core/context/instructions/user-instructions/cline-rules"
+import { ensureRulesDirectoryExists } from "@/core/storage/disk"
 import { HostProvider } from "@/hosts/host-provider"
 import { ShowMessageType } from "@/shared/proto/host/window"
 import { Logger } from "@/shared/services/Logger"
@@ -162,15 +168,31 @@ async function generateCommitMsgForRepository(controller: Controller, repository
 			title: `Generating commit message for ${repoPath.split(path.sep).pop() || "repository"}...`,
 			cancellable: true,
 		},
-		() => performCommitMsgGeneration(controller, gitDiff, inputBox),
+		() => performCommitMsgGeneration(controller, gitDiff, inputBox, repoPath),
 	)
 }
 
-async function performCommitMsgGeneration(controller: Controller, gitDiff: string, inputBox: any) {
+async function performCommitMsgGeneration(controller: Controller, gitDiff: string, inputBox: any, repoPath: string) {
 	try {
 		vscode.commands.executeCommand("setContext", "cline.isGeneratingCommit", true)
 
 		const prompts = [PROMPT.instruction]
+
+		// Load cline rules (global + local) so commit messages follow user's custom instructions
+		try {
+			const { globalToggles, localToggles } = await refreshClineRulesToggles(controller, repoPath)
+			const globalClineRulesFilePath = await ensureRulesDirectoryExists()
+			const globalRules = await getGlobalClineRules(globalClineRulesFilePath, globalToggles)
+			const localRules = await getLocalClineRules(repoPath, localToggles)
+
+			const ruleInstructions = [globalRules.instructions, localRules.instructions].filter(Boolean).join("\n\n")
+
+			if (ruleInstructions) {
+				prompts.push(`# User's Custom Instructions\n${ruleInstructions}`)
+			}
+		} catch (error) {
+			Logger.error("Failed to load cline rules for commit message generation:", error)
+		}
 
 		const workspaceManager = await controller.ensureWorkspaceManager()
 		if (workspaceManager) {


### PR DESCRIPTION
## Related Issue

Fixes #9410

## Description

The commit message generator uses a hardcoded system prompt and does not load user's custom instructions from `.clinerules` files. This means any commit message formatting rules (e.g., conventional commit format, language preferences, project-specific conventions) defined in `.clinerules` are completely ignored during commit message generation.

### Root Cause

`performCommitMsgGeneration()` in `commit-message-generator.ts` constructs its prompt using only the hardcoded `PROMPT` constant and workspace configuration, without ever calling the rule-loading functions that the main task system uses.

### Fix

- Import `getGlobalClineRules`, `getLocalClineRules`, `refreshClineRulesToggles`, and `ensureRulesDirectoryExists`
- Pass `repoPath` to `performCommitMsgGeneration()` so it knows the working directory
- Load global and local cline rules using the same functions the main task system uses
- Include the rules in the prompt, after the base instruction and before workspace config/diff

The rules are loaded with a try/catch so failures don't break commit generation — they just fall back to the existing behavior.

## Test Procedure

1. Create a `.clinerules` file in a project root with commit message rules (e.g., `Always write commit messages in Chinese` or `Use gitmoji format`)
2. Stage some changes
3. Click the Cline commit message generation button
4. Verify the generated commit message follows the custom rules
5. Remove the `.clinerules` file and generate again — should use default format

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Pre-flight Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/cline/cline/blob/main/CONTRIBUTING.md) doc
- [x] I've used conventional commit format for my commit message
- [x] My changes don't introduce any new warnings or errors
- [x] I've tested the changes locally

## Additional Notes

Only one file changed (`commit-message-generator.ts`). Uses the same rule-loading functions that the main task system uses, ensuring consistent behavior. Backward compatible — if no rules are defined, behavior is identical to before.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes commit message generator to load user-defined rules from `.clinerules` files in `commit-message-generator.ts`.
> 
>   - **Behavior**:
>     - `performCommitMsgGeneration()` in `commit-message-generator.ts` now loads user-defined rules from `.clinerules` files.
>     - Imports `getGlobalClineRules`, `getLocalClineRules`, `refreshClineRulesToggles`, and `ensureRulesDirectoryExists` to load rules.
>     - Includes rules in the prompt after base instruction and before workspace config/diff.
>     - Uses try/catch to handle rule-loading failures, falling back to default behavior.
>   - **Misc**:
>     - Passes `repoPath` to `performCommitMsgGeneration()` to identify the working directory.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 38785c050c504cd5220fc0d823cfd6a1958dd398. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->