### PR TITLE
fix: rephrase plan-to-act toggle text to avoid Azure content filter

### DIFF
--- a/src/core/task/tools/handlers/PlanModeRespondHandler.ts
+++ b/src/core/task/tools/handlers/PlanModeRespondHandler.ts
@@ -83,7 +83,9 @@ export class PlanModeRespondHandler implements IToolHandler, IPartialBlockHandle
 				}
 
 				// we dont need to process any text, options, files or other content here
-				return formatResponse.toolResult(`[The user has switched to ACT MODE, so you may now proceed with the task.]`)
+				return formatResponse.toolResult(
+					`[The user has approved your plan and wants you to proceed with implementation. All tools are now available.]`,
+				)
 			}
 			Logger.warn("YOLO MODE: Failed to switch to ACT MODE, continuing with normal plan mode")
 		}
@@ -137,9 +139,9 @@ export class PlanModeRespondHandler implements IToolHandler, IPartialBlockHandle
 		// Handle mode switching response
 		if (config.taskState.didRespondToPlanAskBySwitchingMode) {
 			const result = formatResponse.toolResult(
-				`[The user has switched to ACT MODE, so you may now proceed with the task.]` +
+				`[The user has approved your plan and wants you to proceed with implementation. All tools are now available.]` +
 					(text
-						? `\n\nThe user also provided the following message when switching to ACT MODE:\n<user_message>\n${text}\n</user_message>`
+						? `\n\nThe user provided the following additional instructions:\n<user_message>\n${text}\n</user_message>`
 						: ""),
 				images,
 				fileContentString,


### PR DESCRIPTION
## Related Issue

Fixes #8860

## Description

When switching between Plan and Act modes, the tool result message sent to the API contains the text `[The user has switched to ACT MODE, so you may now proceed with the task.]`. Azure OpenAI's content filter misclassifies this "mode switching" language as a jailbreak policy violation, returning a 400 error with `ResponsibleAIPolicyViolation` / `jailbreak: { filtered: true, detected: true }`.

### Root Cause

The phrasing "switched to ACT MODE, so you may now proceed" matches Azure's pattern-based jailbreak detection — it resembles common jailbreak prompts that claim to switch the model into an unrestricted mode.

### Fix

Rephrase the two instances of mode-switch text in `PlanModeRespondHandler.ts` to use neutral language:
- Before: `The user has switched to ACT MODE, so you may now proceed with the task.`
- After: `The user has approved your plan and wants you to proceed with implementation. All tools are now available.`

Also changed `The user also provided the following message when switching to ACT MODE` → `The user provided the following additional instructions`

The semantics are identical — the model still knows it can proceed with implementation and that all tools are available — but the phrasing no longer resembles a jailbreak pattern.

## Test Procedure

1. Configure Cline with Azure OpenAI (e.g., gpt-4.1 or gpt-5.1)
2. Start a conversation in Plan mode
3. Switch to Act mode (or vice versa)
4. Verify the request succeeds without a 400 jailbreak error

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Pre-flight Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/cline/cline/blob/main/CONTRIBUTING.md) doc
- [x] I've used conventional commit format for my commit message
- [x] My changes don't introduce any new warnings or errors
- [x] I've tested the changes locally

## Additional Notes

Only 1 file changed (`PlanModeRespondHandler.ts`), 3 string literals replaced. No behavioral change — the model receives the same semantic instruction, just without jailbreak-triggering language.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Rephrased mode-switch text in `PlanModeRespondHandler.ts` to avoid Azure content filter issues by using neutral language.
> 
>   - **Behavior**:
>     - Rephrased mode-switch text in `PlanModeRespondHandler.ts` to avoid Azure content filter issues.
>     - Before: `The user has switched to ACT MODE, so you may now proceed with the task.`
>     - After: `The user has approved your plan and wants you to proceed with implementation. All tools are now available.`
>     - Changed `The user also provided the following message when switching to ACT MODE` to `The user provided the following additional instructions`.
>   - **Testing**:
>     - Verified request success without 400 error when switching modes using Azure OpenAI.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 9161db67740cedac78451580deea23c57f5558f0. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->