### PR TITLE
fix: preserve content block order in MCP tool responses

### DIFF
--- a/src/core/task/tools/handlers/UseMcpToolHandler.ts
+++ b/src/core/task/tools/handlers/UseMcpToolHandler.ts
@@ -4,6 +4,7 @@ import { ClineAsk, ClineAskUseMcpServer } from "@shared/ExtensionMessage"
 import { telemetryService } from "@/services/telemetry"
 import { truncateContent } from "@/shared/content-limits"
 import { ClineDefaultTool } from "@/shared/tools"
+import type Anthropic from "@anthropic-ai/sdk"
 import type { ToolResponse } from "../../index"
 import { showNotificationForApproval } from "../../utils"
 import type { IFullyManagedTool } from "../ToolExecutorCoordinator"
@@ -173,7 +174,7 @@ export class UseMcpToolHandler implements IFullyManagedTool {
 				await config.callbacks.say("mcp_notification", `[${notification.serverName}] ${notification.message}`)
 			}
 
-			// Process tool result
+			// Process tool result — collect images and text separately for display
 			const toolResultImages =
 				toolResult?.content
 					.filter((item: any) => item.type === "image")
@@ -208,8 +209,41 @@ export class UseMcpToolHandler implements IFullyManagedTool {
 			// Truncate response if it exceeds 400KB to prevent context overflow
 			toolResultText = truncateContent(toolResultText)
 
-			// Return formatted result (only pass images if model supports them)
-			return formatResponse.toolResult(toolResultText, supportsImages ? toolResultImages : undefined)
+			// Build content blocks preserving original order from MCP response
+			if (supportsImages && toolResultImages.length > 0) {
+				const orderedBlocks: Array<Anthropic.TextBlockParam | Anthropic.ImageBlockParam> = []
+				let pendingText = toolResult?.isError ? "Error:\n" : ""
+				for (const item of toolResult?.content || []) {
+					if (item.type === "text") {
+						pendingText += (pendingText ? "\n\n" : "") + item.text
+					} else if (item.type === "resource") {
+						const { blob: _blob, ...rest } = item.resource
+						pendingText += (pendingText ? "\n\n" : "") + JSON.stringify(rest, null, 2)
+					} else if (item.type === "image") {
+						if (pendingText) {
+							orderedBlocks.push({ type: "text", text: truncateContent(pendingText) })
+							pendingText = ""
+						}
+						const dataUrl = `data:${item.mimeType};base64,${item.data}`
+						const [rest, base64] = dataUrl.split(",")
+						const mimeType = rest.split(":")[1].split(";")[0]
+						orderedBlocks.push({
+							type: "image",
+							source: { type: "base64", media_type: mimeType, data: base64 },
+						} as Anthropic.ImageBlockParam)
+					}
+				}
+				if (pendingText) {
+					orderedBlocks.push({ type: "text", text: truncateContent(pendingText) })
+				}
+				if (orderedBlocks.length === 0) {
+					return "(No response)"
+				}
+				return orderedBlocks
+			}
+
+			// Return text-only result (no images or model doesn't support them)
+			return toolResultText
 		} catch (error) {
 			return `Error executing MCP tool: ${(error as Error)?.message}`
 		}


### PR DESCRIPTION
## Related Issue

Fixes #9540

## Description

When an MCP tool returns interleaved text and image content blocks (e.g., `text → image → text → image`), the handler separates all images from text and groups them at the end. This breaks the spatial relationship between text and images, causing context loss for multimodal tasks like reading Markdown files with inline images.

### Root Cause

In `UseMcpToolHandler.ts`, the tool result processing:
1. Filters all image blocks into a separate array (line 177-180)
2. Maps all text/resource blocks into a single concatenated string (line 182-196)
3. Passes them to `formatResponse.toolResult(text, images)` which always puts text first, then images

This means `text → image → text → image` becomes `text text → image image`.

### Fix

When the model supports images and images are present, build an ordered array of `Anthropic.TextBlockParam | Anthropic.ImageBlockParam` blocks that preserves the original sequence from the MCP response:
- Accumulate text between image blocks
- Flush accumulated text as a `TextBlockParam` before each image
- Return the ordered array directly as the tool result

The webview display (`toolResultToDisplay`) and non-image model fallback are unchanged.

## Test Procedure

1. Set up an MCP tool that returns interleaved text and image content blocks
2. Call the tool through Cline with a multimodal model (e.g., GPT-4o, Claude Sonnet)
3. Verify the model reports images appearing in their correct positions relative to text
4. Test with a non-multimodal model — verify fallback text-only behavior still works

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Pre-flight Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/cline/cline/blob/main/CONTRIBUTING.md) doc
- [x] I've used conventional commit format for my commit message
- [x] My changes don't introduce any new warnings or errors
- [x] I've tested the changes locally

## Additional Notes

Only 1 file changed (`UseMcpToolHandler.ts`). The webview display behavior is unchanged — images are still appended at the end for UI rendering. Only the content sent to the AI model is reordered to match the MCP tool's original output.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes `UseMcpToolHandler.ts` to preserve original order of text and image blocks in MCP tool responses, maintaining spatial relationships.
> 
>   - **Behavior**:
>     - Fixes issue in `UseMcpToolHandler.ts` where text and image blocks from MCP tool responses were separated, disrupting their original order.
>     - Preserves original order by creating an ordered array of `Anthropic.TextBlockParam` and `Anthropic.ImageBlockParam`.
>     - Accumulates text between image blocks and flushes it as a `TextBlockParam` before each image.
>     - Returns ordered array directly as tool result if model supports images.
>   - **Fallback**:
>     - If model does not support images, returns text-only result.
>   - **Misc**:
>     - Webview display behavior remains unchanged; images are appended at the end for UI rendering.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 53902a62d0748be0d99f982ae4ff70b00a7879c4. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->