### PR TITLE
chore: Collect telemetry on state update message sizes

### DIFF
--- a/src/core/controller/state/subscribeToState.ts
+++ b/src/core/controller/state/subscribeToState.ts
@@ -1,5 +1,6 @@
 import { EmptyRequest } from "@shared/proto/cline/common"
 import { State } from "@shared/proto/cline/state"
+import { telemetryService } from "@/services/telemetry"
 import { ExtensionState } from "@/shared/ExtensionMessage"
 import { Logger } from "@/shared/services/Logger"
 import { getRequestRegistry, StreamingResponseHandler } from "../grpc-handler"
@@ -38,6 +39,8 @@ export async function subscribeToState(
 	const initialState = await controller.getStateToPostToWebview()
 	const initialStateJson = JSON.stringify(initialState)
 
+	recordStateSizeTelemetry(Buffer.byteLength(initialStateJson, "utf8"))
+
 	try {
 		await responseStream(
 			{
@@ -56,10 +59,18 @@ export async function subscribeToState(
  * @param state The state to send
  */
 export async function sendStateUpdate(state: ExtensionState): Promise<void> {
-	// Send the state to all active subscribers
+	let stateJson: string
+	try {
+		stateJson = JSON.stringify(state)
+	} catch (error) {
+		Logger.error("Error serializing state update:", error)
+		return
+	}
+
+	recordStateSizeTelemetry(Buffer.byteLength(stateJson, "utf8"))
+
 	const promises = Array.from(activeStateSubscriptions).map(async (responseStream) => {
 		try {
-			const stateJson = JSON.stringify(state)
 			await responseStream(
 				{
 					stateJson,
@@ -68,10 +79,13 @@ export async function sendStateUpdate(state: ExtensionState): Promise<void> {
 			)
 		} catch (error) {
 			Logger.error("Error sending state update:", error)
-			// Remove the subscription if there was an error
 			activeStateSubscriptions.delete(responseStream)
 		}
 	})
 
 	await Promise.all(promises)
+}
+
+function recordStateSizeTelemetry(sizeBytes: number): void {
+	telemetryService.captureGrpcResponseSize(sizeBytes, "cline.StateService", "subscribeToState")
 }

--- a/src/services/telemetry/TelemetryService.ts
+++ b/src/services/telemetry/TelemetryService.ts
@@ -162,6 +162,9 @@ export class TelemetryService {
 			CONTEXT_MODIFICATIONS_TOTAL: "cline.hooks.context_modifications.total",
 			CACHE_ACCESSES_TOTAL: "cline.hooks.cache.accesses.total",
 		},
+		GRPC: {
+			RESPONSE_SIZE_BYTES: "cline.grpc.response.size_bytes",
+		},
 	}
 	// Event constants for tracking user interactions and system events
 	private static readonly EVENTS = {
@@ -2182,6 +2185,35 @@ export class TelemetryService {
 				content,
 			},
 		})
+	}
+
+	/**
+	 * Records the size of a gRPC response message for observability.
+	 *
+	 * @param sizeUtf8Bytes Size in UTF-8 bytes (use `Buffer.byteLength`, not `string.length`)
+	 * @param service The gRPC service name
+	 * @param method The gRPC method name
+	 * @param requestId Optional request ID for correlation
+	 */
+	public captureGrpcResponseSize(sizeUtf8Bytes: number, service: string, method: string, requestId?: string): void {
+		this.recordHistogram(
+			TelemetryService.METRICS.GRPC.RESPONSE_SIZE_BYTES,
+			sizeUtf8Bytes,
+			{
+				service,
+				method,
+				...(requestId && { request_id: requestId }),
+			},
+			"Size of gRPC response messages in bytes",
+		)
+
+		if (sizeUtf8Bytes > 4 * 1024 * 1024) {
+			Logger.warn(
+				`[TelemetryService] Large gRPC response: ${service}.${method} ` +
+					`size=${(sizeUtf8Bytes / (1024 * 1024)).toFixed(1)}MB` +
+					(requestId ? ` request_id=${requestId}` : ""),
+			)
+		}
 	}
 
 	/**

--- a/src/services/telemetry/__tests__/TelemetryService.metrics.test.ts
+++ b/src/services/telemetry/__tests__/TelemetryService.metrics.test.ts
@@ -235,4 +235,43 @@ describe("TelemetryService metrics", () => {
 		assert.strictEqual(durationMetric?.value, 2.1)
 		assert.strictEqual(durationMetric?.attributes.scope, "task")
 	})
+
+	it("captureGrpcResponseSize records histogram with correct name, value, and attributes", () => {
+		const provider = new FakeProvider()
+		const service = createTelemetryService(provider)
+
+		service.captureGrpcResponseSize(123456, "cline.StateService", "subscribeToState")
+
+		assert.strictEqual(provider.histograms.length, 1)
+		const entry = provider.histograms[0]
+		assert.strictEqual(entry.name, TelemetryService.METRICS.GRPC.RESPONSE_SIZE_BYTES)
+		assert.strictEqual(entry.value, 123456)
+		assert.strictEqual(entry.attributes.service, "cline.StateService")
+		assert.strictEqual(entry.attributes.method, "subscribeToState")
+		assert.strictEqual(entry.description, "Size of gRPC response messages in bytes")
+		// Should not have request_id when not provided
+		assert.strictEqual(entry.attributes.request_id, undefined)
+	})
+
+	it("captureGrpcResponseSize includes request_id when provided", () => {
+		const provider = new FakeProvider()
+		const service = createTelemetryService(provider)
+
+		service.captureGrpcResponseSize(5000, "cline.StateService", "subscribeToState", "req-42")
+
+		assert.strictEqual(provider.histograms.length, 1)
+		const entry = provider.histograms[0]
+		assert.strictEqual(entry.attributes.request_id, "req-42")
+	})
+
+	it("captureGrpcResponseSize includes standard metadata attributes", () => {
+		const provider = new FakeProvider()
+		const service = createTelemetryService(provider)
+
+		service.captureGrpcResponseSize(1000, "cline.StateService", "subscribeToState")
+
+		const entry = provider.histograms[0]
+		assert.strictEqual(entry.attributes.extension_version, "test")
+		assert.strictEqual(entry.attributes.platform, "test-platform")
+	})
 })


### PR DESCRIPTION
### Related Issue

**Issue:** #6696 

### Description

When task size exceeds a fixed buffer size in the IntelliJ plugin, the webview stops getting updates. This adds telemetry to monitor the size of state update messages.

### Test Procedure

Manual test:

1. Patch this into the cline directory of the IntelliJ plugin.
2. `OTEL_TELEMETRY_ENABLED=true OTEL_METRICS_EXPORTER=console ./gradlew :runIde`
3. Chat the night away
4. Examine ~/.cline/cline-core-service.log for messages such as these:

```
{
  descriptor: {
    name: 'cline.grpc.response.size_bytes',
    type: 'HISTOGRAM',
    description: 'Size of gRPC response messages in bytes',
    unit: '',
    valueType: 1,
    advice: {}
  },
  dataPointType: 0,
  dataPoints: [
    {
      attributes: {
        extension_version: '3.68.0',
        platform: 'IntelliJ IDEA Community',
        platform_version: '2024.2.5',
        cline_type: 'Cline for JetBrains',
...
        service: 'cline.StateService',
        method: 'subscribeToState'
      },
      startTime: [ 1772447902, 648000000 ],
      endTime: [ 1772448261, 629000000 ],
      value: {
        min: 76695,
        max: 10120584,
        sum: 125121255,
        buckets: {
          boundaries: [
               0,    5,    10,   25,
              50,   75,   100,  250,
             500,  750,  1000, 2500,
            5000, 7500, 10000
          ],
          counts: [
            0, 0, 0,  0, 0, 0,
            0, 0, 0,  0, 0, 0,
            0, 0, 0, 54
          ]
        },
        count: 54
      }
    }
  ]
}
```

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [X] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Additional Notes

This issue will be fixed in the IntelliJ plugin, but we need to monitor growth in message sizes.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add telemetry to monitor state update message sizes in IntelliJ plugin to track gRPC response size growth.
> 
>   - **Telemetry**:
>     - Add `recordStateSizeTelemetry()` in `subscribeToState.ts` to log state update message sizes.
>     - Use `TelemetryService.captureGrpcResponseSize()` in `TelemetryService.ts` to record gRPC response sizes.
>   - **Behavior**:
>     - Track message size growth to detect when approaching gRPC transport limits (default 4MB, 256MB on JetBrains).
>     - Log warnings for messages exceeding 10MB in `TelemetryService.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 542c95d574bff7eb7eb64ffe19b29c3559f2b9c7. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->