### PR TITLE
fix(openrouter): stop sending max_tokens in stream requests

### DIFF
--- a/src/core/api/transform/openrouter-stream.ts
+++ b/src/core/api/transform/openrouter-stream.ts
@@ -116,8 +116,6 @@ export async function createOpenRouterStream(
 			break
 	}
 
-	const maxTokens = model.info.maxTokens || undefined
-
 	let temperature: number | undefined = 0
 	let topP: number | undefined
 	if (
@@ -185,7 +183,6 @@ export async function createOpenRouterStream(
 
 	const requestPayload: Record<string, unknown> = {
 		model: model.id,
-		max_tokens: maxTokens,
 		temperature: temperature,
 		top_p: topP,
 		messages: openAiMessages,


### PR DESCRIPTION
### Related Issue

Issue: #9592

### Description

This PR removes `max_tokens` from the OpenRouter streaming request payload in `openrouter-stream.ts`.

Why this change:
- In v3.68.0 we started passing `model.info.maxTokens` directly for OpenRouter requests.
- For some models, OpenRouter reports very large `max_completion_tokens` values (for example `131072`).
- Sending that value on every request can make `input_tokens + requested_output_tokens` exceed the model context window and trigger 400 context length errors.
- It also inflates perceived context usage because the request advertises a huge output budget even when the user does not need it.

By omitting `max_tokens`, we let OpenRouter/Vercel apply their provider-side defaults and constraints based on the model/context window, which avoids over-allocating output budget by default.

Technical approach:
- Removed the local `maxTokens` variable derived from `model.info.maxTokens`.
- Removed `max_tokens` from the `requestPayload` passed to `client.chat.completions.create(...)` for OpenRouter stream requests.
- Left the rest of the request shaping intact (reasoning, provider preferences, prompt caching, tools).

### Test Procedure

I validated this as a focused behavior change:

1. Ran targeted unit tests for OpenRouter/Cline provider streaming paths:

```bash
npm run test:unit -- src/core/api/providers/__tests__/openrouter.test.ts src/core/api/providers/__tests__/cline.test.ts
```

2. Result:
- Test run passed (`1093 passing`, `4 pending` in this workspace run).
- No failures introduced in OpenRouter/Cline streaming provider tests.

3. Sanity check:
- Verified the diff is scoped to one file and only removes `max_tokens` wiring from OpenRouter stream payload construction.

Potential impact considered:
- This intentionally defers output-token limits to provider defaults for OpenRouter streaming.
- If a strict caller-side cap is needed in the future, it should be computed with context-aware budgeting rather than copying raw `max_completion_tokens` from model metadata.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Not applicable (backend/request payload change).

### Additional Notes

Follow-up idea:
- If we want explicit output caps later, implement dynamic budgeting from `context_window - estimated_input_tokens - buffer` instead of directly using model-reported max completion tokens.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Removes `max_tokens` from OpenRouter streaming requests in `openrouter-stream.ts` to prevent context length errors.
> 
>   - **Behavior**:
>     - Removes `max_tokens` from `requestPayload` in `createOpenRouterStream()` in `openrouter-stream.ts`.
>     - Prevents context length errors by deferring to provider-side defaults for token limits.
>   - **Technical Changes**:
>     - Eliminates `maxTokens` variable derived from `model.info.maxTokens` in `openrouter-stream.ts`.
>   - **Testing**:
>     - Validated with unit tests for OpenRouter/Cline streaming paths, ensuring no new test failures.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 013c9b40010c0d8332c7c2238e8ed30d1df547aa. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->