### PR TITLE
Add Padding to Retry Message

### DIFF
--- a/webview-ui/src/components/chat/ChatRow.tsx
+++ b/webview-ui/src/components/chat/ChatRow.tsx
@@ -1055,7 +1055,7 @@ export const ChatRowContent = memo(
 									{errorMessage && (
 										<p className="m-0 whitespace-pre-wrap text-error wrap-anywhere text-xs">{errorMessage}</p>
 									)}
-									<div className="flex flex-col bg-quote p-0 rounded-[3px] text-[12px] p-4">
+									<div className="flex flex-col bg-quote p-0 rounded-[3px] text-[12px] p-3">
 										<div className="flex items-center mb-1">
 											{isFailed && !isRequestInProgress ? (
 												<TriangleAlertIcon className="mr-2 size-2" />


### PR DESCRIPTION
### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** NA

### Description
Adds padding around auto retry message in the extension

### Test Procedure
- Trigger the auto retry message (you can do this by selecting a provider without adding any credentials)
- **Expect** to see some padding around the container


### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [x] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots
**Before**
<img width="667" height="434" alt="Screenshot 2026-03-02 at 10 37 40 AM" src="https://github.com/user-attachments/assets/3e9eae3e-941e-42df-8813-15b50d4cc71a" />

**After**
<img width="537" height="434" alt="Screenshot 2026-03-02 at 10 50 03 AM" src="https://github.com/user-attachments/assets/136246f6-a508-4bdd-a598-61aab806d164" />
<img width="537" height="434" alt="Screenshot 2026-03-02 at 10 50 20 AM" src="https://github.com/user-attachments/assets/0f26114c-0028-462b-ada2-a987026882e8" />



### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds padding to the auto-retry message container in `ChatRow.tsx` for improved visual spacing.
> 
>   - **UI Update**:
>     - Adds padding to the auto-retry message container in `ChatRow.tsx` to improve visual spacing.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for e47863206b6cf6d24a2e9f22c9417eb2d2dd6371. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->