### PR TITLE
feat(sapaicore): add Claude 4.6 Opus model support

### DIFF
--- a/.changeset/fix-sapaicore-add-claude-4.6-opus.md
+++ b/.changeset/fix-sapaicore-add-claude-4.6-opus.md
@@ -1,5 +1,5 @@
 ---
-"cline": patch
+"cline": minor
 ---
 
 feat(sapaicore): add Claude 4.6 Opus model support

--- a/.changeset/fix-sapaicore-add-claude-4.6-opus.md
+++ b/.changeset/fix-sapaicore-add-claude-4.6-opus.md
@@ -1,0 +1,13 @@
+---
+"cline": patch
+---
+
+feat(sapaicore): add Claude 4.6 Opus model support
+
+Added `anthropic--claude-4.6-opus` to the SAP AI Core provider:
+- Model definition in `api.ts` (128K max tokens, 200K context, images + caching)
+- Added to `anthropicModels` array in `sapaicore.ts`
+- Added to converse-stream endpoint filter (uses caching-enabled API path)
+- Added to stream completion handler (uses Sonnet 3.7+ streaming format)
+
+Fixes #9644

--- a/src/core/api/providers/sapaicore.ts
+++ b/src/core/api/providers/sapaicore.ts
@@ -609,6 +609,7 @@ export class SapAiCoreHandler implements ApiHandler {
 
 		const anthropicModels = [
 			"anthropic--claude-4.5-haiku",
+			"anthropic--claude-4.6-opus",
 			"anthropic--claude-4.5-opus",
 			"anthropic--claude-4.6-sonnet",
 			"anthropic--claude-4.5-sonnet",
@@ -659,6 +660,7 @@ export class SapAiCoreHandler implements ApiHandler {
 			const secondLastMsgUserIndex = userMsgIndices[userMsgIndices.length - 2] ?? -1
 
 			if (
+				model.id === "anthropic--claude-4.6-opus" ||
 				model.id === "anthropic--claude-4.5-opus" ||
 				model.id === "anthropic--claude-4.6-sonnet" ||
 				model.id === "anthropic--claude-4.5-sonnet" ||
@@ -792,6 +794,7 @@ export class SapAiCoreHandler implements ApiHandler {
 			} else if (openAIModels.includes(model.id) || perplexityModels.includes(model.id)) {
 				yield* this.streamCompletionGPT(response.data, model)
 			} else if (
+				model.id === "anthropic--claude-4.6-opus" ||
 				model.id === "anthropic--claude-4.5-opus" ||
 				model.id === "anthropic--claude-4.6-sonnet" ||
 				model.id === "anthropic--claude-4.5-sonnet" ||

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -3785,6 +3785,13 @@ export const sapAiCoreModels = {
 		supportsPromptCache: true,
 		description: sapAiCoreModelDescription,
 	},
+	"anthropic--claude-4.6-opus": {
+		maxTokens: 128_000,
+		contextWindow: 200_000,
+		supportsImages: true,
+		supportsPromptCache: true,
+		description: sapAiCoreModelDescription,
+	},
 	"anthropic--claude-4.5-opus": {
 		maxTokens: 64_000,
 		contextWindow: 200_000,


### PR DESCRIPTION
## Summary

Adds `anthropic--claude-4.6-opus` to the SAP AI Core provider. Fixes #9644.

## Changes

**`src/shared/api.ts`:**
- Added `anthropic--claude-4.6-opus` model definition (128K max tokens, 200K context window, images + prompt caching)

**`src/core/api/providers/sapaicore.ts`** (3 locations):
1. **`anthropicModels` array** — Added to the list of recognized Anthropic model IDs
2. **Converse-stream endpoint filter** — Routes opus 4.6 through the caching-enabled `converse-stream` API path (same as sonnet 4.6, opus 4.5, etc.)
3. **Stream completion handler** — Routes opus 4.6 through the `streamCompletionSonnet37` handler (same as other modern Anthropic models)

## Notes

- The reporter also requested 1M context support via `additionalModelRequestFields: { "anthropic_beta": ["context-1m-2025-08-07"] }`. This is tracked separately as it requires either a new model variant or a settings toggle, and none of the existing SAP AI Core Anthropic models currently support 1M context configuration.
- The model definition follows the same pattern as `anthropic--claude-4.5-opus` but with `maxTokens: 128_000` matching the Anthropic `claude-opus-4-6` spec.

Fixes #9644
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds support for the Claude 4.6 Opus model to SAP AI Core, updating model definitions and routing logic in `api.ts` and `sapaicore.ts`.
> 
>   - **Behavior**:
>     - Adds `anthropic--claude-4.6-opus` model to `sapAiCoreModels` in `api.ts` with 128K max tokens, 200K context window, supports images and prompt caching.
>     - Updates `sapaicore.ts` to include `anthropic--claude-4.6-opus` in `anthropicModels` array.
>     - Routes `anthropic--claude-4.6-opus` through `converse-stream` endpoint and `streamCompletionSonnet37` handler in `sapaicore.ts`.
>   - **Misc**:
>     - Fixes #9644.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for 632c4a11c0e9d74a0309f50041fdd57130472b27. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->