### PR TITLE
fix(mcp): skip write and add grace period to prevent self-triggered reconnect

### DIFF
--- a/src/core/storage/remote-config/syncRemoteMcpServers.ts
+++ b/src/core/storage/remote-config/syncRemoteMcpServers.ts
@@ -4,6 +4,8 @@ import * as fs from "fs/promises"
 import type { McpHub } from "@/services/mcp/McpHub"
 import { Logger } from "@/shared/services/Logger"
 
+const REMOTE_CONFIG_WATCHER_GRACE_MS = 300
+
 /**
  * Synchronizes remote MCP servers from remote config to the local MCP settings file
  * This allows admins to centrally configure MCP servers that are automatically deployed to users
@@ -33,6 +35,7 @@ export async function syncRemoteMcpServersToSettings(
 		// Read current settings
 		const content = await fs.readFile(settingsPath, "utf-8")
 		const config = JSON.parse(content)
+		const initialSerializedConfig = JSON.stringify(config)
 
 		// Ensure mcpServers object exists
 		if (!config.mcpServers || typeof config.mcpServers !== "object") {
@@ -81,9 +84,18 @@ export async function syncRemoteMcpServersToSettings(
 		}
 
 		try {
+			const nextSerializedConfig = JSON.stringify(config)
+			if (initialSerializedConfig === nextSerializedConfig) {
+				return
+			}
+
 			// Write back to file
 			await fs.writeFile(settingsPath, JSON.stringify(config, null, 2))
 		} finally {
+			// Keep the flag set briefly to outlive chokidar's awaitWriteFinish delay.
+			// Otherwise the watcher may process our own remote-config write and reconnect servers.
+			await new Promise((resolve) => setTimeout(resolve, REMOTE_CONFIG_WATCHER_GRACE_MS))
+
 			// Always clear flag, even if write fails
 			if (mcpHub) {
 				mcpHub.setIsUpdatingFromRemoteConfig(false)


### PR DESCRIPTION

<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- For feature requests: Created a discussion in our Feature Requests discussions board https://github.com/cline/cline/discussions/categories/feature-requests and received approval from core maintainers before implementation
- For all changes: Link the associated issue/discussion in the "Related Issue" section below

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly without prior discussion.

Why this requirement?
We deeply appreciate all community contributions - they are essential to Cline's success! To ensure the best use of everyone's time and maintain project direction, we use our Feature Requests discussions board to gauge community interest and validate feature ideas before implementation begins. This helps us focus development efforts on features that will benefit the most users.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** #XXXX

### Description

<!-- 
Help reviewers understand your changes by making this PR readable and well-organized:

- What problem does this PR solve?
- Why were these changes introduced and what purpose do they serve?
- For larger changes, provide context about your approach and reasoning

Small PRs may need minimal description, but larger changes benefit from explaining where you're coming from. Much of this context can be in the linked issue above, so feel free to reference it rather than repeating everything here.
-->

- Skip writing MCP settings file when config is unchanged to avoid unnecessary file system writes and watcher triggers
- Add 300ms grace period after write before clearing the `isUpdatingFromRemoteConfig` flag to outlive chokidar's `awaitWriteFinish` delay, preventing the file watcher from processing our own remote-config write and reconnecting servers

### Test Procedure

<!-- 
Please walk us through your testing approach and thought process. This helps reviewers understand that you've thoroughly considered the impact of your changes:

- How did you test this change?
- What could potentially break and how did you verify it doesn't?
- What existing functionality might be affected and how did you check it still works?
- Why are you confident this is ready for merge?

We're not looking for exhaustive documentation - just evidence that you've thought through the implications of your changes and tested accordingly.
-->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Optimize `syncRemoteMcpServersToSettings()` by skipping unchanged writes and adding a grace period to prevent self-triggered reconnects.
> 
>   - **Behavior**:
>     - Skip writing MCP settings file if configuration is unchanged in `syncRemoteMcpServersToSettings()`.
>     - Add 300ms grace period after writing to settings file before clearing `isUpdatingFromRemoteConfig` flag in `syncRemoteMcpServersToSettings()` to prevent self-triggered reconnects.
>   - **Constants**:
>     - Introduce `REMOTE_CONFIG_WATCHER_GRACE_MS` constant for grace period duration in `syncRemoteMcpServers.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for e2417a41d03cf80df1f9c33ea92a371fe89c4ede. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->