### PR TITLE
feat(read_file): add chunked reading with start_line/end_line

### DIFF
--- a/src/core/assistant-message/index.ts
+++ b/src/core/assistant-message/index.ts
@@ -54,6 +54,8 @@ export const toolParamNames = [
 	"prompt_3",
 	"prompt_4",
 	"prompt_5",
+	"start_line",
+	"end_line",
 ] as const
 
 export type ToolParamName = (typeof toolParamNames)[number]

--- a/src/core/prompts/system-prompt/__tests__/__snapshots__/anthropic_claude_sonnet_4-basic.snap
+++ b/src/core/prompts/system-prompt/__tests__/__snapshots__/anthropic_claude_sonnet_4-basic.snap
@@ -39,13 +39,17 @@ Usage:
 </execute_command>
 
 ## read_file
-Description: Request to read the contents of a file at the specified path. Use this when you need to examine the contents of an existing file you do not know the contents of, for example to analyze code, review text files, or extract information from configuration files. Returned text lines are prefixed with line labels in the format `L<number>:`. Treat these labels as metadata and not part of the underlying file text. Automatically extracts raw text from PDF and DOCX files. May not be suitable for other types of binary files, as it returns the raw content as a string. Do NOT use this tool to list the contents of a directory. Only use this tool on files.
+Description: Request to read the contents of a file at the specified path. Use this when you need to examine the contents of an existing file you do not know the contents of, for example to analyze code, review text files, or extract information from configuration files. Returned text lines are prefixed with line labels (e.g. `L1:`, `L2:`). These labels are metadata, not part of the file content. For large files, output is automatically limited to 1000 lines. Use start_line and end_line to read specific sections. Automatically extracts raw text from PDF and DOCX files. May not be suitable for other types of binary files, as it returns the raw content as a string.
 Parameters:
 - path: (required) The path of the file to read (relative to the current working directory /test/project)
+- start_line: (optional) The 1-based line number to start reading from (inclusive). Defaults to 1.
+- end_line: (optional) The 1-based line number to stop reading at (inclusive). Defaults to start_line + 1000. Use with start_line to read specific sections of large files.
 - task_progress: (optional) A checklist showing task progress after this tool use is completed. The task_progress parameter must be included as a separate parameter inside of the parent tool call, it must be separate from other parameters such as content, arguments, etc. (See 'UPDATING TASK PROGRESS' section for more details)
 Usage:
 <read_file>
 <path>File path here</path>
+<start_line>1</start_line>
+<end_line>1000</end_line>
 <task_progress>Checklist here (optional)</task_progress>
 </read_file>
 

--- a/src/core/prompts/system-prompt/__tests__/__snapshots__/anthropic_claude_sonnet_4-no-browser.snap
+++ b/src/core/prompts/system-prompt/__tests__/__snapshots__/anthropic_claude_sonnet_4-no-browser.snap
@@ -39,13 +39,17 @@ Usage:
 </execute_command>
 
 ## read_file
-Description: Request to read the contents of a file at the specified path. Use this when you need to examine the contents of an existing file you do not know the contents of, for example to analyze code, review text files, or extract information from configuration files. Returned text lines are prefixed with line labels in the format `L<number>:`. Treat these labels as metadata and not part of the underlying file text. Automatically extracts raw text from PDF and DOCX files. May not be suitable for other types of binary files, as it returns the raw content as a string. Do NOT use this tool to list the contents of a directory. Only use this tool on files.
+Description: Request to read the contents of a file at the specified path. Use this when you need to examine the contents of an existing file you do not know the contents of, for example to analyze code, review text files, or extract information from configuration files. Returned text lines are prefixed with line labels (e.g. `L1:`, `L2:`). These labels are metadata, not part of the file content. For large files, output is automatically limited to 1000 lines. Use start_line and end_line to read specific sections. Automatically extracts raw text from PDF and DOCX files. May not be suitable for other types of binary files, as it returns the raw content as a string.
 Parameters:
 - path: (required) The path of the file to read (relative to the current working directory /test/project)
+- start_line: (optional) The 1-based line number to start reading from (inclusive). Defaults to 1.
+- end_line: (optional) The 1-based line number to stop reading at (inclusive). Defaults to start_line + 1000. Use with start_line to read specific sections of large files.
 - task_progress: (optional) A checklist showing task progress after this tool use is completed. The task_progress parameter must be included as a separate parameter inside of the parent tool call, it must be separate from other parameters such as content, arguments, etc. (See 'UPDATING TASK PROGRESS' section for more details)
 Usage:
 <read_file>
 <path>File path here</path>
+<start_line>1</start_line>
+<end_line>1000</end_line>
 <task_progress>Checklist here (optional)</task_progress>
 </read_file>
 

--- a/src/core/prompts/system-prompt/__tests__/__snapshots__/anthropic_claude_sonnet_4-no-focus-chain.snap
+++ b/src/core/prompts/system-prompt/__tests__/__snapshots__/anthropic_claude_sonnet_4-no-focus-chain.snap
@@ -36,12 +36,16 @@ Usage:
 </execute_command>
 
 ## read_file
-Description: Request to read the contents of a file at the specified path. Use this when you need to examine the contents of an existing file you do not know the contents of, for example to analyze code, review text files, or extract information from configuration files. Returned text lines are prefixed with line labels in the format `L<number>:`. Treat these labels as metadata and not part of the underlying file text. Automatically extracts raw text from PDF and DOCX files. May not be suitable for other types of binary files, as it returns the raw content as a string. Do NOT use this tool to list the contents of a directory. Only use this tool on files.
+Description: Request to read the contents of a file at the specified path. Use this when you need to examine the contents of an existing file you do not know the contents of, for example to analyze code, review text files, or extract information from configuration files. Returned text lines are prefixed with line labels (e.g. `L1:`, `L2:`). These labels are metadata, not part of the file content. For large files, output is automatically limited to 1000 lines. Use start_line and end_line to read specific sections. Automatically extracts raw text from PDF and DOCX files. May not be suitable for other types of binary files, as it returns the raw content as a string.
 Parameters:
 - path: (required) The path of the file to read (relative to the current working directory /test/project)
+- start_line: (optional) The 1-based line number to start reading from (inclusive). Defaults to 1.
+- end_line: (optional) The 1-based line number to stop reading at (inclusive). Defaults to start_line + 1000. Use with start_line to read specific sections of large files.
 Usage:
 <read_file>
 <path>File path here</path>
+<start_line>1</start_line>
+<end_line>1000</end_line>
 </read_file>
 
 ## write_to_file

--- a/src/core/prompts/system-prompt/__tests__/__snapshots__/anthropic_claude_sonnet_4-no-mcp.snap
+++ b/src/core/prompts/system-prompt/__tests__/__snapshots__/anthropic_claude_sonnet_4-no-mcp.snap
@@ -39,13 +39,17 @@ Usage:
 </execute_command>
 
 ## read_file
-Description: Request to read the contents of a file at the specified path. Use this when you need to examine the contents of an existing file you do not know the contents of, for example to analyze code, review text files, or extract information from configuration files. Returned text lines are prefixed with line labels in the format `L<number>:`. Treat these labels as metadata and not part of the underlying file text. Automatically extracts raw text from PDF and DOCX files. May not be suitable for other types of binary files, as it returns the raw content as a string. Do NOT use this tool to list the contents of a directory. Only use this tool on files.
+Description: Request to read the contents of a file at the specified path. Use this when you need to examine the contents of an existing file you do not know the contents of, for example to analyze code, review text files, or extract information from configuration files. Returned text lines are prefixed with line labels (e.g. `L1:`, `L2:`). These labels are metadata, not part of the file content. For large files, output is automatically limited to 1000 lines. Use start_line and end_line to read specific sections. Automatically extracts raw text from PDF and DOCX files. May not be suitable for other types of binary files, as it returns the raw content as a string.
 Parameters:
 - path: (required) The path of the file to read (relative to the current working directory /test/project)
+- start_line: (optional) The 1-based line number to start reading from (inclusive). Defaults to 1.
+- end_line: (optional) The 1-based line number to stop reading at (inclusive). Defaults to start_line + 1000. Use with start_line to read specific sections of large files.
 - task_progress: (optional) A checklist showing task progress after this tool use is completed. The task_progress parameter must be included as a separate parameter inside of the parent tool call, it must be separate from other parameters such as content, arguments, etc. (See 'UPDATING TASK PROGRESS' section for more details)
 Usage:
 <read_file>
 <path>File path here</path>
+<start_line>1</start_line>
+<end_line>1000</end_line>
 <task_progress>Checklist here (optional)</task_progress>
 </read_file>
 

--- a/src/core/prompts/system-prompt/__tests__/__snapshots__/cline_devstral-basic.snap
+++ b/src/core/prompts/system-prompt/__tests__/__snapshots__/cline_devstral-basic.snap
@@ -39,13 +39,17 @@ Usage:
 </execute_command>
 
 ## read_file
-Description: Request to read the contents of a file at the specified path. Use this when you need to examine the contents of an existing file you do not know the contents of, for example to analyze code, review text files, or extract information from configuration files. Returned text lines are prefixed with line labels in the format `L<number>:`. Treat these labels as metadata and not part of the underlying file text. Automatically extracts raw text from PDF and DOCX files. May not be suitable for other types of binary files, as it returns the raw content as a string. Do NOT use this tool to list the contents of a directory. Only use this tool on files.
+Description: Request to read the contents of a file at the specified path. Use this when you need to examine the contents of an existing file you do not know the contents of, for example to analyze code, review text files, or extract information from configuration files. Returned text lines are prefixed with line labels (e.g. `L1:`, `L2:`). These labels are metadata, not part of the file content. For large files, output is automatically limited to 1000 lines. Use start_line and end_line to read specific sections. Automatically extracts raw text from PDF and DOCX files. May not be suitable for other types of binary files, as it returns the raw content as a string.
 Parameters:
 - path: (required) The path of the file to read (relative to the current working directory /test/project)
+- start_line: (optional) The 1-based line number to start reading from (inclusive). Defaults to 1.
+- end_line: (optional) The 1-based line number to stop reading at (inclusive). Defaults to start_line + 1000. Use with start_line to read specific sections of large files.
 - task_progress: (optional) A checklist showing task progress after this tool use is completed. The task_progress parameter must be included as a separate parameter inside of the parent tool call, it must be separate from other parameters such as content, arguments, etc. (See 'UPDATING TASK PROGRESS' section for more details)
 Usage:
 <read_file>
 <path>File path here</path>
+<start_line>1</start_line>
+<end_line>1000</end_line>
 <task_progress>Checklist here (optional)</task_progress>
 </read_file>
 

--- a/src/core/prompts/system-prompt/__tests__/__snapshots__/cline_devstral-no-browser.snap
+++ b/src/core/prompts/system-prompt/__tests__/__snapshots__/cline_devstral-no-browser.snap
@@ -39,13 +39,17 @@ Usage:
 </execute_command>
 
 ## read_file
-Description: Request to read the contents of a file at the specified path. Use this when you need to examine the contents of an existing file you do not know the contents of, for example to analyze code, review text files, or extract information from configuration files. Returned text lines are prefixed with line labels in the format `L<number>:`. Treat these labels as metadata and not part of the underlying file text. Automatically extracts raw text from PDF and DOCX files. May not be suitable for other types of binary files, as it returns the raw content as a string. Do NOT use this tool to list the contents of a directory. Only use this tool on files.
+Description: Request to read the contents of a file at the specified path. Use this when you need to examine the contents of an existing file you do not know the contents of, for example to analyze code, review text files, or extract information from configuration files. Returned text lines are prefixed with line labels (e.g. `L1:`, `L2:`). These labels are metadata, not part of the file content. For large files, output is automatically limited to 1000 lines. Use start_line and end_line to read specific sections. Automatically extracts raw text from PDF and DOCX files. May not be suitable for other types of binary files, as it returns the raw content as a string.
 Parameters:
 - path: (required) The path of the file to read (relative to the current working directory /test/project)
+- start_line: (optional) The 1-based line number to start reading from (inclusive). Defaults to 1.
+- end_line: (optional) The 1-based line number to stop reading at (inclusive). Defaults to start_line + 1000. Use with start_line to read specific sections of large files.
 - task_progress: (optional) A checklist showing task progress after this tool use is completed. The task_progress parameter must be included as a separate parameter inside of the parent tool call, it must be separate from other parameters such as content, arguments, etc. (See 'UPDATING TASK PROGRESS' section for more details)
 Usage:
 <read_file>
 <path>File path here</path>
+<start_line>1</start_line>
+<end_line>1000</end_line>
 <task_progress>Checklist here (optional)</task_progress>
 </read_file>
 

--- a/src/core/prompts/system-prompt/__tests__/__snapshots__/cline_devstral-no-focus-chain.snap
+++ b/src/core/prompts/system-prompt/__tests__/__snapshots__/cline_devstral-no-focus-chain.snap
@@ -36,12 +36,16 @@ Usage:
 </execute_command>
 
 ## read_file
-Description: Request to read the contents of a file at the specified path. Use this when you need to examine the contents of an existing file you do not know the contents of, for example to analyze code, review text files, or extract information from configuration files. Returned text lines are prefixed with line labels in the format `L<number>:`. Treat these labels as metadata and not part of the underlying file text. Automatically extracts raw text from PDF and DOCX files. May not be suitable for other types of binary files, as it returns the raw content as a string. Do NOT use this tool to list the contents of a directory. Only use this tool on files.
+Description: Request to read the contents of a file at the specified path. Use this when you need to examine the contents of an existing file you do not know the contents of, for example to analyze code, review text files, or extract information from configuration files. Returned text lines are prefixed with line labels (e.g. `L1:`, `L2:`). These labels are metadata, not part of the file content. For large files, output is automatically limited to 1000 lines. Use start_line and end_line to read specific sections. Automatically extracts raw text from PDF and DOCX files. May not be suitable for other types of binary files, as it returns the raw content as a string.
 Parameters:
 - path: (required) The path of the file to read (relative to the current working directory /test/project)
+- start_line: (optional) The 1-based line number to start reading from (inclusive). Defaults to 1.
+- end_line: (optional) The 1-based line number to stop reading at (inclusive). Defaults to start_line + 1000. Use with start_line to read specific sections of large files.
 Usage:
 <read_file>
 <path>File path here</path>
+<start_line>1</start_line>
+<end_line>1000</end_line>
 </read_file>
 
 ## write_to_file

--- a/src/core/prompts/system-prompt/__tests__/__snapshots__/cline_devstral-no-mcp.snap
+++ b/src/core/prompts/system-prompt/__tests__/__snapshots__/cline_devstral-no-mcp.snap
@@ -39,13 +39,17 @@ Usage:
 </execute_command>
 
 ## read_file
-Description: Request to read the contents of a file at the specified path. Use this when you need to examine the contents of an existing file you do not know the contents of, for example to analyze code, review text files, or extract information from configuration files. Returned text lines are prefixed with line labels in the format `L<number>:`. Treat these labels as metadata and not part of the underlying file text. Automatically extracts raw text from PDF and DOCX files. May not be suitable for other types of binary files, as it returns the raw content as a string. Do NOT use this tool to list the contents of a directory. Only use this tool on files.
+Description: Request to read the contents of a file at the specified path. Use this when you need to examine the contents of an existing file you do not know the contents of, for example to analyze code, review text files, or extract information from configuration files. Returned text lines are prefixed with line labels (e.g. `L1:`, `L2:`). These labels are metadata, not part of the file content. For large files, output is automatically limited to 1000 lines. Use start_line and end_line to read specific sections. Automatically extracts raw text from PDF and DOCX files. May not be suitable for other types of binary files, as it returns the raw content as a string.
 Parameters:
 - path: (required) The path of the file to read (relative to the current working directory /test/project)
+- start_line: (optional) The 1-based line number to start reading from (inclusive). Defaults to 1.
+- end_line: (optional) The 1-based line number to stop reading at (inclusive). Defaults to start_line + 1000. Use with start_line to read specific sections of large files.
 - task_progress: (optional) A checklist showing task progress after this tool use is completed. The task_progress parameter must be included as a separate parameter inside of the parent tool call, it must be separate from other parameters such as content, arguments, etc. (See 'UPDATING TASK PROGRESS' section for more details)
 Usage:
 <read_file>
 <path>File path here</path>
+<start_line>1</start_line>
+<end_line>1000</end_line>
 <task_progress>Checklist here (optional)</task_progress>
 </read_file>
 

--- a/src/core/prompts/system-prompt/__tests__/__snapshots__/cline_native_next_gen.tools.snap
+++ b/src/core/prompts/system-prompt/__tests__/__snapshots__/cline_native_next_gen.tools.snap
@@ -59,7 +59,7 @@
     "type": "function",
     "function": {
       "name": "read_file",
-      "description": "Request to read the contents of a file at the specified path. Use this when you need to examine the contents of an existing file you do not know the contents of, for example to analyze code, review text files, or extract information from configuration files. Returned text lines are prefixed with line labels in the format `L<number>:`. Treat these labels as metadata and not part of the underlying file text. Automatically extracts raw text from PDF and DOCX files. May not be suitable for other types of binary files, as it returns the raw content as a string. Do NOT use this tool to list the contents of a directory. Only use this tool on files.",
+      "description": "Request to read the contents of a file at the specified path. Use this when you need to examine the contents of an existing file you do not know the contents of, for example to analyze code, review text files, or extract information from configuration files. Returned text lines are prefixed with line labels (e.g. `L1:`, `L2:`). These labels are metadata, not part of the file content. For large files, output is automatically limited to 1000 lines. Use start_line and end_line to read specific sections. Automatically extracts raw text from PDF and DOCX files. May not be suitable for other types of binary files, as it returns the raw content as a string.",
       "strict": false,
       "parameters": {
         "type": "object",
@@ -67,6 +67,14 @@
           "path": {
             "type": "string",
             "description": "The path of the file to read (relative to the current working directory {{CWD}}){{MULTI_ROOT_HINT}}"
+          },
+          "start_line": {
+            "type": "integer",
+            "description": "The 1-based line number to start reading from (inclusive). Defaults to 1."
+          },
+          "end_line": {
+            "type": "integer",
+            "description": "The 1-based line number to stop reading at (inclusive). Defaults to start_line + 1000. Use with start_line to read specific sections of large files."
           },
           "task_progress": {
             "type": "string",

--- a/src/core/prompts/system-prompt/__tests__/__snapshots__/openai_gpt_3-basic.snap
+++ b/src/core/prompts/system-prompt/__tests__/__snapshots__/openai_gpt_3-basic.snap
@@ -39,13 +39,17 @@ Usage:
 </execute_command>
 
 ## read_file
-Description: Request to read the contents of a file at the specified path. Use this when you need to examine the contents of an existing file you do not know the contents of, for example to analyze code, review text files, or extract information from configuration files. Returned text lines are prefixed with line labels in the format `L<number>:`. Treat these labels as metadata and not part of the underlying file text. Automatically extracts raw text from PDF and DOCX files. May not be suitable for other types of binary files, as it returns the raw content as a string. Do NOT use this tool to list the contents of a directory. Only use this tool on files.
+Description: Request to read the contents of a file at the specified path. Use this when you need to examine the contents of an existing file you do not know the contents of, for example to analyze code, review text files, or extract information from configuration files. Returned text lines are prefixed with line labels (e.g. `L1:`, `L2:`). These labels are metadata, not part of the file content. For large files, output is automatically limited to 1000 lines. Use start_line and end_line to read specific sections. Automatically extracts raw text from PDF and DOCX files. May not be suitable for other types of binary files, as it returns the raw content as a string.
 Parameters:
 - path: (required) The path of the file to read (relative to the current working directory /test/project)
+- start_line: (optional) The 1-based line number to start reading from (inclusive). Defaults to 1.
+- end_line: (optional) The 1-based line number to stop reading at (inclusive). Defaults to start_line + 1000. Use with start_line to read specific sections of large files.
 - task_progress: (optional) A checklist showing task progress after this tool use is completed. The task_progress parameter must be included as a separate parameter inside of the parent tool call, it must be separate from other parameters such as content, arguments, etc. (See 'UPDATING TASK PROGRESS' section for more details)
 Usage:
 <read_file>
 <path>File path here</path>
+<start_line>1</start_line>
+<end_line>1000</end_line>
 <task_progress>Checklist here (optional)</task_progress>
 </read_file>
 

--- a/src/core/prompts/system-prompt/__tests__/__snapshots__/openai_gpt_3-no-browser.snap
+++ b/src/core/prompts/system-prompt/__tests__/__snapshots__/openai_gpt_3-no-browser.snap
@@ -39,13 +39,17 @@ Usage:
 </execute_command>
 
 ## read_file
-Description: Request to read the contents of a file at the specified path. Use this when you need to examine the contents of an existing file you do not know the contents of, for example to analyze code, review text files, or extract information from configuration files. Returned text lines are prefixed with line labels in the format `L<number>:`. Treat these labels as metadata and not part of the underlying file text. Automatically extracts raw text from PDF and DOCX files. May not be suitable for other types of binary files, as it returns the raw content as a string. Do NOT use this tool to list the contents of a directory. Only use this tool on files.
+Description: Request to read the contents of a file at the specified path. Use this when you need to examine the contents of an existing file you do not know the contents of, for example to analyze code, review text files, or extract information from configuration files. Returned text lines are prefixed with line labels (e.g. `L1:`, `L2:`). These labels are metadata, not part of the file content. For large files, output is automatically limited to 1000 lines. Use start_line and end_line to read specific sections. Automatically extracts raw text from PDF and DOCX files. May not be suitable for other types of binary files, as it returns the raw content as a string.
 Parameters:
 - path: (required) The path of the file to read (relative to the current working directory /test/project)
+- start_line: (optional) The 1-based line number to start reading from (inclusive). Defaults to 1.
+- end_line: (optional) The 1-based line number to stop reading at (inclusive). Defaults to start_line + 1000. Use with start_line to read specific sections of large files.
 - task_progress: (optional) A checklist showing task progress after this tool use is completed. The task_progress parameter must be included as a separate parameter inside of the parent tool call, it must be separate from other parameters such as content, arguments, etc. (See 'UPDATING TASK PROGRESS' section for more details)
 Usage:
 <read_file>
 <path>File path here</path>
+<start_line>1</start_line>
+<end_line>1000</end_line>
 <task_progress>Checklist here (optional)</task_progress>
 </read_file>
 

--- a/src/core/prompts/system-prompt/__tests__/__snapshots__/openai_gpt_3-no-focus-chain.snap
+++ b/src/core/prompts/system-prompt/__tests__/__snapshots__/openai_gpt_3-no-focus-chain.snap
@@ -36,12 +36,16 @@ Usage:
 </execute_command>
 
 ## read_file
-Description: Request to read the contents of a file at the specified path. Use this when you need to examine the contents of an existing file you do not know the contents of, for example to analyze code, review text files, or extract information from configuration files. Returned text lines are prefixed with line labels in the format `L<number>:`. Treat these labels as metadata and not part of the underlying file text. Automatically extracts raw text from PDF and DOCX files. May not be suitable for other types of binary files, as it returns the raw content as a string. Do NOT use this tool to list the contents of a directory. Only use this tool on files.
+Description: Request to read the contents of a file at the specified path. Use this when you need to examine the contents of an existing file you do not know the contents of, for example to analyze code, review text files, or extract information from configuration files. Returned text lines are prefixed with line labels (e.g. `L1:`, `L2:`). These labels are metadata, not part of the file content. For large files, output is automatically limited to 1000 lines. Use start_line and end_line to read specific sections. Automatically extracts raw text from PDF and DOCX files. May not be suitable for other types of binary files, as it returns the raw content as a string.
 Parameters:
 - path: (required) The path of the file to read (relative to the current working directory /test/project)
+- start_line: (optional) The 1-based line number to start reading from (inclusive). Defaults to 1.
+- end_line: (optional) The 1-based line number to stop reading at (inclusive). Defaults to start_line + 1000. Use with start_line to read specific sections of large files.
 Usage:
 <read_file>
 <path>File path here</path>
+<start_line>1</start_line>
+<end_line>1000</end_line>
 </read_file>
 
 ## write_to_file

--- a/src/core/prompts/system-prompt/__tests__/__snapshots__/openai_gpt_3-no-mcp.snap
+++ b/src/core/prompts/system-prompt/__tests__/__snapshots__/openai_gpt_3-no-mcp.snap
@@ -39,13 +39,17 @@ Usage:
 </execute_command>
 
 ## read_file
-Description: Request to read the contents of a file at the specified path. Use this when you need to examine the contents of an existing file you do not know the contents of, for example to analyze code, review text files, or extract information from configuration files. Returned text lines are prefixed with line labels in the format `L<number>:`. Treat these labels as metadata and not part of the underlying file text. Automatically extracts raw text from PDF and DOCX files. May not be suitable for other types of binary files, as it returns the raw content as a string. Do NOT use this tool to list the contents of a directory. Only use this tool on files.
+Description: Request to read the contents of a file at the specified path. Use this when you need to examine the contents of an existing file you do not know the contents of, for example to analyze code, review text files, or extract information from configuration files. Returned text lines are prefixed with line labels (e.g. `L1:`, `L2:`). These labels are metadata, not part of the file content. For large files, output is automatically limited to 1000 lines. Use start_line and end_line to read specific sections. Automatically extracts raw text from PDF and DOCX files. May not be suitable for other types of binary files, as it returns the raw content as a string.
 Parameters:
 - path: (required) The path of the file to read (relative to the current working directory /test/project)
+- start_line: (optional) The 1-based line number to start reading from (inclusive). Defaults to 1.
+- end_line: (optional) The 1-based line number to stop reading at (inclusive). Defaults to start_line + 1000. Use with start_line to read specific sections of large files.
 - task_progress: (optional) A checklist showing task progress after this tool use is completed. The task_progress parameter must be included as a separate parameter inside of the parent tool call, it must be separate from other parameters such as content, arguments, etc. (See 'UPDATING TASK PROGRESS' section for more details)
 Usage:
 <read_file>
 <path>File path here</path>
+<start_line>1</start_line>
+<end_line>1000</end_line>
 <task_progress>Checklist here (optional)</task_progress>
 </read_file>
 

--- a/src/core/prompts/system-prompt/__tests__/__snapshots__/openai_gpt_5-basic.snap
+++ b/src/core/prompts/system-prompt/__tests__/__snapshots__/openai_gpt_5-basic.snap
@@ -39,13 +39,17 @@ Usage:
 </execute_command>
 
 ## read_file
-Description: Request to read the contents of a file at the specified path. Use this when you need to examine the contents of an existing file you do not know the contents of, for example to analyze code, review text files, or extract information from configuration files. Returned text lines are prefixed with line labels in the format `L<number>:`. Treat these labels as metadata and not part of the underlying file text. Automatically extracts raw text from PDF and DOCX files. May not be suitable for other types of binary files, as it returns the raw content as a string. Do NOT use this tool to list the contents of a directory. Only use this tool on files.
+Description: Request to read the contents of a file at the specified path. Use this when you need to examine the contents of an existing file you do not know the contents of, for example to analyze code, review text files, or extract information from configuration files. Returned text lines are prefixed with line labels (e.g. `L1:`, `L2:`). These labels are metadata, not part of the file content. For large files, output is automatically limited to 1000 lines. Use start_line and end_line to read specific sections. Automatically extracts raw text from PDF and DOCX files. May not be suitable for other types of binary files, as it returns the raw content as a string.
 Parameters:
 - path: (required) The path of the file to read (relative to the current working directory /test/project)
+- start_line: (optional) The 1-based line number to start reading from (inclusive). Defaults to 1.
+- end_line: (optional) The 1-based line number to stop reading at (inclusive). Defaults to start_line + 1000. Use with start_line to read specific sections of large files.
 - task_progress: (optional) A checklist showing task progress after this tool use is completed. The task_progress parameter must be included as a separate parameter inside of the parent tool call, it must be separate from other parameters such as content, arguments, etc. (See 'UPDATING TASK PROGRESS' section for more details)
 Usage:
 <read_file>
 <path>File path here</path>
+<start_line>1</start_line>
+<end_line>1000</end_line>
 <task_progress>Checklist here (optional)</task_progress>
 </read_file>
 

--- a/src/core/prompts/system-prompt/__tests__/__snapshots__/openai_gpt_5-no-browser.snap
+++ b/src/core/prompts/system-prompt/__tests__/__snapshots__/openai_gpt_5-no-browser.snap
@@ -39,13 +39,17 @@ Usage:
 </execute_command>
 
 ## read_file
-Description: Request to read the contents of a file at the specified path. Use this when you need to examine the contents of an existing file you do not know the contents of, for example to analyze code, review text files, or extract information from configuration files. Returned text lines are prefixed with line labels in the format `L<number>:`. Treat these labels as metadata and not part of the underlying file text. Automatically extracts raw text from PDF and DOCX files. May not be suitable for other types of binary files, as it returns the raw content as a string. Do NOT use this tool to list the contents of a directory. Only use this tool on files.
+Description: Request to read the contents of a file at the specified path. Use this when you need to examine the contents of an existing file you do not know the contents of, for example to analyze code, review text files, or extract information from configuration files. Returned text lines are prefixed with line labels (e.g. `L1:`, `L2:`). These labels are metadata, not part of the file content. For large files, output is automatically limited to 1000 lines. Use start_line and end_line to read specific sections. Automatically extracts raw text from PDF and DOCX files. May not be suitable for other types of binary files, as it returns the raw content as a string.
 Parameters:
 - path: (required) The path of the file to read (relative to the current working directory /test/project)
+- start_line: (optional) The 1-based line number to start reading from (inclusive). Defaults to 1.
+- end_line: (optional) The 1-based line number to stop reading at (inclusive). Defaults to start_line + 1000. Use with start_line to read specific sections of large files.
 - task_progress: (optional) A checklist showing task progress after this tool use is completed. The task_progress parameter must be included as a separate parameter inside of the parent tool call, it must be separate from other parameters such as content, arguments, etc. (See 'UPDATING TASK PROGRESS' section for more details)
 Usage:
 <read_file>
 <path>File path here</path>
+<start_line>1</start_line>
+<end_line>1000</end_line>
 <task_progress>Checklist here (optional)</task_progress>
 </read_file>
 

--- a/src/core/prompts/system-prompt/__tests__/__snapshots__/openai_gpt_5-no-focus-chain.snap
+++ b/src/core/prompts/system-prompt/__tests__/__snapshots__/openai_gpt_5-no-focus-chain.snap
@@ -36,12 +36,16 @@ Usage:
 </execute_command>
 
 ## read_file
-Description: Request to read the contents of a file at the specified path. Use this when you need to examine the contents of an existing file you do not know the contents of, for example to analyze code, review text files, or extract information from configuration files. Returned text lines are prefixed with line labels in the format `L<number>:`. Treat these labels as metadata and not part of the underlying file text. Automatically extracts raw text from PDF and DOCX files. May not be suitable for other types of binary files, as it returns the raw content as a string. Do NOT use this tool to list the contents of a directory. Only use this tool on files.
+Description: Request to read the contents of a file at the specified path. Use this when you need to examine the contents of an existing file you do not know the contents of, for example to analyze code, review text files, or extract information from configuration files. Returned text lines are prefixed with line labels (e.g. `L1:`, `L2:`). These labels are metadata, not part of the file content. For large files, output is automatically limited to 1000 lines. Use start_line and end_line to read specific sections. Automatically extracts raw text from PDF and DOCX files. May not be suitable for other types of binary files, as it returns the raw content as a string.
 Parameters:
 - path: (required) The path of the file to read (relative to the current working directory /test/project)
+- start_line: (optional) The 1-based line number to start reading from (inclusive). Defaults to 1.
+- end_line: (optional) The 1-based line number to stop reading at (inclusive). Defaults to start_line + 1000. Use with start_line to read specific sections of large files.
 Usage:
 <read_file>
 <path>File path here</path>
+<start_line>1</start_line>
+<end_line>1000</end_line>
 </read_file>
 
 ## write_to_file

--- a/src/core/prompts/system-prompt/__tests__/__snapshots__/openai_gpt_5-no-mcp.snap
+++ b/src/core/prompts/system-prompt/__tests__/__snapshots__/openai_gpt_5-no-mcp.snap
@@ -39,13 +39,17 @@ Usage:
 </execute_command>
 
 ## read_file
-Description: Request to read the contents of a file at the specified path. Use this when you need to examine the contents of an existing file you do not know the contents of, for example to analyze code, review text files, or extract information from configuration files. Returned text lines are prefixed with line labels in the format `L<number>:`. Treat these labels as metadata and not part of the underlying file text. Automatically extracts raw text from PDF and DOCX files. May not be suitable for other types of binary files, as it returns the raw content as a string. Do NOT use this tool to list the contents of a directory. Only use this tool on files.
+Description: Request to read the contents of a file at the specified path. Use this when you need to examine the contents of an existing file you do not know the contents of, for example to analyze code, review text files, or extract information from configuration files. Returned text lines are prefixed with line labels (e.g. `L1:`, `L2:`). These labels are metadata, not part of the file content. For large files, output is automatically limited to 1000 lines. Use start_line and end_line to read specific sections. Automatically extracts raw text from PDF and DOCX files. May not be suitable for other types of binary files, as it returns the raw content as a string.
 Parameters:
 - path: (required) The path of the file to read (relative to the current working directory /test/project)
+- start_line: (optional) The 1-based line number to start reading from (inclusive). Defaults to 1.
+- end_line: (optional) The 1-based line number to stop reading at (inclusive). Defaults to start_line + 1000. Use with start_line to read specific sections of large files.
 - task_progress: (optional) A checklist showing task progress after this tool use is completed. The task_progress parameter must be included as a separate parameter inside of the parent tool call, it must be separate from other parameters such as content, arguments, etc. (See 'UPDATING TASK PROGRESS' section for more details)
 Usage:
 <read_file>
 <path>File path here</path>
+<start_line>1</start_line>
+<end_line>1000</end_line>
 <task_progress>Checklist here (optional)</task_progress>
 </read_file>
 

--- a/src/core/prompts/system-prompt/__tests__/__snapshots__/openai_gpt_5_1_native.tools.snap
+++ b/src/core/prompts/system-prompt/__tests__/__snapshots__/openai_gpt_5_1_native.tools.snap
@@ -29,7 +29,7 @@
     "type": "function",
     "function": {
       "name": "read_file",
-      "description": "Request to read the contents of a file at the specified path. Use this when you need to examine the contents of an existing file you do not know the contents of, for example to analyze code, review text files, or extract information from configuration files. Returned text lines are prefixed with line labels in the format `L<number>:`. Treat these labels as metadata and not part of the underlying file text. Automatically extracts raw text from PDF and DOCX files. May not be suitable for other types of binary files, as it returns the raw content as a string. Do NOT use this tool to list the contents of a directory. Only use this tool on files.",
+      "description": "Request to read the contents of a file at the specified path. Use this when you need to examine the contents of an existing file you do not know the contents of, for example to analyze code, review text files, or extract information from configuration files. Returned text lines are prefixed with line labels (e.g. `L1:`, `L2:`). These labels are metadata, not part of the file content. For large files, output is automatically limited to 1000 lines. Use start_line and end_line to read specific sections. Automatically extracts raw text from PDF and DOCX files. May not be suitable for other types of binary files, as it returns the raw content as a string.",
       "strict": false,
       "parameters": {
         "type": "object",
@@ -37,6 +37,14 @@
           "path": {
             "type": "string",
             "description": "The path of the file to read (relative to the current working directory {{CWD}}){{MULTI_ROOT_HINT}}"
+          },
+          "start_line": {
+            "type": "integer",
+            "description": "The 1-based line number to start reading from (inclusive). Defaults to 1."
+          },
+          "end_line": {
+            "type": "integer",
+            "description": "The 1-based line number to stop reading at (inclusive). Defaults to start_line + 1000. Use with start_line to read specific sections of large files."
           },
           "task_progress": {
             "type": "string",

--- a/src/core/prompts/system-prompt/__tests__/__snapshots__/openai_gpt_5_native.tools.snap
+++ b/src/core/prompts/system-prompt/__tests__/__snapshots__/openai_gpt_5_native.tools.snap
@@ -29,7 +29,7 @@
     "type": "function",
     "function": {
       "name": "read_file",
-      "description": "Request to read the contents of a file at the specified path. Use this when you need to examine the contents of an existing file you do not know the contents of, for example to analyze code, review text files, or extract information from configuration files. Returned text lines are prefixed with line labels in the format `L<number>:`. Treat these labels as metadata and not part of the underlying file text. Automatically extracts raw text from PDF and DOCX files. May not be suitable for other types of binary files, as it returns the raw content as a string. Do NOT use this tool to list the contents of a directory. Only use this tool on files.",
+      "description": "Request to read the contents of a file at the specified path. Use this when you need to examine the contents of an existing file you do not know the contents of, for example to analyze code, review text files, or extract information from configuration files. Returned text lines are prefixed with line labels (e.g. `L1:`, `L2:`). These labels are metadata, not part of the file content. For large files, output is automatically limited to 1000 lines. Use start_line and end_line to read specific sections. Automatically extracts raw text from PDF and DOCX files. May not be suitable for other types of binary files, as it returns the raw content as a string.",
       "strict": false,
       "parameters": {
         "type": "object",
@@ -37,6 +37,14 @@
           "path": {
             "type": "string",
             "description": "The path of the file to read (relative to the current working directory {{CWD}}){{MULTI_ROOT_HINT}}"
+          },
+          "start_line": {
+            "type": "integer",
+            "description": "The 1-based line number to start reading from (inclusive). Defaults to 1."
+          },
+          "end_line": {
+            "type": "integer",
+            "description": "The 1-based line number to stop reading at (inclusive). Defaults to start_line + 1000. Use with start_line to read specific sections of large files."
           },
           "task_progress": {
             "type": "string",

--- a/src/core/prompts/system-prompt/__tests__/__snapshots__/openrouter_arcee_ai_trinity_large_preview-basic.snap
+++ b/src/core/prompts/system-prompt/__tests__/__snapshots__/openrouter_arcee_ai_trinity_large_preview-basic.snap
@@ -48,13 +48,17 @@ Usage:
 </execute_command>
 
 ## read_file
-Description: Request to read the contents of a file at the specified path. Use this when you need to examine the contents of an existing file you do not know the contents of, for example to analyze code, review text files, or extract information from configuration files. Returned text lines are prefixed with line labels in the format `L<number>:`. Treat these labels as metadata and not part of the underlying file text. Automatically extracts raw text from PDF and DOCX files. May not be suitable for other types of binary files, as it returns the raw content as a string. Do NOT use this tool to list the contents of a directory. Only use this tool on files.
+Description: Request to read the contents of a file at the specified path. Use this when you need to examine the contents of an existing file you do not know the contents of, for example to analyze code, review text files, or extract information from configuration files. Returned text lines are prefixed with line labels (e.g. `L1:`, `L2:`). These labels are metadata, not part of the file content. For large files, output is automatically limited to 1000 lines. Use start_line and end_line to read specific sections. Automatically extracts raw text from PDF and DOCX files. May not be suitable for other types of binary files, as it returns the raw content as a string.
 Parameters:
 - path: (required) The path of the file to read (relative to the current working directory /test/project)
+- start_line: (optional) The 1-based line number to start reading from (inclusive). Defaults to 1.
+- end_line: (optional) The 1-based line number to stop reading at (inclusive). Defaults to start_line + 1000. Use with start_line to read specific sections of large files.
 - task_progress: (optional) A checklist showing task progress after this tool use is completed. The task_progress parameter must be included as a separate parameter inside of the parent tool call, it must be separate from other parameters such as content, arguments, etc. (See 'UPDATING TASK PROGRESS' section for more details)
 Usage:
 <read_file>
 <path>File path here</path>
+<start_line>1</start_line>
+<end_line>1000</end_line>
 <task_progress>Checklist here (optional)</task_progress>
 </read_file>
 

--- a/src/core/prompts/system-prompt/__tests__/__snapshots__/openrouter_arcee_ai_trinity_large_preview-no-browser.snap
+++ b/src/core/prompts/system-prompt/__tests__/__snapshots__/openrouter_arcee_ai_trinity_large_preview-no-browser.snap
@@ -48,13 +48,17 @@ Usage:
 </execute_command>
 
 ## read_file
-Description: Request to read the contents of a file at the specified path. Use this when you need to examine the contents of an existing file you do not know the contents of, for example to analyze code, review text files, or extract information from configuration files. Returned text lines are prefixed with line labels in the format `L<number>:`. Treat these labels as metadata and not part of the underlying file text. Automatically extracts raw text from PDF and DOCX files. May not be suitable for other types of binary files, as it returns the raw content as a string. Do NOT use this tool to list the contents of a directory. Only use this tool on files.
+Description: Request to read the contents of a file at the specified path. Use this when you need to examine the contents of an existing file you do not know the contents of, for example to analyze code, review text files, or extract information from configuration files. Returned text lines are prefixed with line labels (e.g. `L1:`, `L2:`). These labels are metadata, not part of the file content. For large files, output is automatically limited to 1000 lines. Use start_line and end_line to read specific sections. Automatically extracts raw text from PDF and DOCX files. May not be suitable for other types of binary files, as it returns the raw content as a string.
 Parameters:
 - path: (required) The path of the file to read (relative to the current working directory /test/project)
+- start_line: (optional) The 1-based line number to start reading from (inclusive). Defaults to 1.
+- end_line: (optional) The 1-based line number to stop reading at (inclusive). Defaults to start_line + 1000. Use with start_line to read specific sections of large files.
 - task_progress: (optional) A checklist showing task progress after this tool use is completed. The task_progress parameter must be included as a separate parameter inside of the parent tool call, it must be separate from other parameters such as content, arguments, etc. (See 'UPDATING TASK PROGRESS' section for more details)
 Usage:
 <read_file>
 <path>File path here</path>
+<start_line>1</start_line>
+<end_line>1000</end_line>
 <task_progress>Checklist here (optional)</task_progress>
 </read_file>
 

--- a/src/core/prompts/system-prompt/__tests__/__snapshots__/openrouter_arcee_ai_trinity_large_preview-no-focus-chain.snap
+++ b/src/core/prompts/system-prompt/__tests__/__snapshots__/openrouter_arcee_ai_trinity_large_preview-no-focus-chain.snap
@@ -45,12 +45,16 @@ Usage:
 </execute_command>
 
 ## read_file
-Description: Request to read the contents of a file at the specified path. Use this when you need to examine the contents of an existing file you do not know the contents of, for example to analyze code, review text files, or extract information from configuration files. Returned text lines are prefixed with line labels in the format `L<number>:`. Treat these labels as metadata and not part of the underlying file text. Automatically extracts raw text from PDF and DOCX files. May not be suitable for other types of binary files, as it returns the raw content as a string. Do NOT use this tool to list the contents of a directory. Only use this tool on files.
+Description: Request to read the contents of a file at the specified path. Use this when you need to examine the contents of an existing file you do not know the contents of, for example to analyze code, review text files, or extract information from configuration files. Returned text lines are prefixed with line labels (e.g. `L1:`, `L2:`). These labels are metadata, not part of the file content. For large files, output is automatically limited to 1000 lines. Use start_line and end_line to read specific sections. Automatically extracts raw text from PDF and DOCX files. May not be suitable for other types of binary files, as it returns the raw content as a string.
 Parameters:
 - path: (required) The path of the file to read (relative to the current working directory /test/project)
+- start_line: (optional) The 1-based line number to start reading from (inclusive). Defaults to 1.
+- end_line: (optional) The 1-based line number to stop reading at (inclusive). Defaults to start_line + 1000. Use with start_line to read specific sections of large files.
 Usage:
 <read_file>
 <path>File path here</path>
+<start_line>1</start_line>
+<end_line>1000</end_line>
 </read_file>
 
 ## write_to_file

--- a/src/core/prompts/system-prompt/__tests__/__snapshots__/openrouter_arcee_ai_trinity_large_preview-no-mcp.snap
+++ b/src/core/prompts/system-prompt/__tests__/__snapshots__/openrouter_arcee_ai_trinity_large_preview-no-mcp.snap
@@ -48,13 +48,17 @@ Usage:
 </execute_command>
 
 ## read_file
-Description: Request to read the contents of a file at the specified path. Use this when you need to examine the contents of an existing file you do not know the contents of, for example to analyze code, review text files, or extract information from configuration files. Returned text lines are prefixed with line labels in the format `L<number>:`. Treat these labels as metadata and not part of the underlying file text. Automatically extracts raw text from PDF and DOCX files. May not be suitable for other types of binary files, as it returns the raw content as a string. Do NOT use this tool to list the contents of a directory. Only use this tool on files.
+Description: Request to read the contents of a file at the specified path. Use this when you need to examine the contents of an existing file you do not know the contents of, for example to analyze code, review text files, or extract information from configuration files. Returned text lines are prefixed with line labels (e.g. `L1:`, `L2:`). These labels are metadata, not part of the file content. For large files, output is automatically limited to 1000 lines. Use start_line and end_line to read specific sections. Automatically extracts raw text from PDF and DOCX files. May not be suitable for other types of binary files, as it returns the raw content as a string.
 Parameters:
 - path: (required) The path of the file to read (relative to the current working directory /test/project)
+- start_line: (optional) The 1-based line number to start reading from (inclusive). Defaults to 1.
+- end_line: (optional) The 1-based line number to stop reading at (inclusive). Defaults to start_line + 1000. Use with start_line to read specific sections of large files.
 - task_progress: (optional) A checklist showing task progress after this tool use is completed. The task_progress parameter must be included as a separate parameter inside of the parent tool call, it must be separate from other parameters such as content, arguments, etc. (See 'UPDATING TASK PROGRESS' section for more details)
 Usage:
 <read_file>
 <path>File path here</path>
+<start_line>1</start_line>
+<end_line>1000</end_line>
 <task_progress>Checklist here (optional)</task_progress>
 </read_file>
 

--- a/src/core/prompts/system-prompt/__tests__/__snapshots__/vertex_gemini3.tools.snap
+++ b/src/core/prompts/system-prompt/__tests__/__snapshots__/vertex_gemini3.tools.snap
@@ -20,12 +20,18 @@
   },
   {
     "name": "read_file",
-    "description": "Request to read the contents of a file at the specified path. Use this when you need to examine the contents of an existing file you do not know the contents of, for example to analyze code, review text files, or extract information from configuration files. Returned text lines are prefixed with line labels in the format `L<number>:`. Treat these labels as metadata and not part of the underlying file text. Automatically extracts raw text from PDF and DOCX files. May not be suitable for other types of binary files, as it returns the raw content as a string. Do NOT use this tool to list the contents of a directory. Only use this tool on files.",
+    "description": "Request to read the contents of a file at the specified path. Use this when you need to examine the contents of an existing file you do not know the contents of, for example to analyze code, review text files, or extract information from configuration files. Returned text lines are prefixed with line labels (e.g. `L1:`, `L2:`). These labels are metadata, not part of the file content. For large files, output is automatically limited to 1000 lines. Use start_line and end_line to read specific sections. Automatically extracts raw text from PDF and DOCX files. May not be suitable for other types of binary files, as it returns the raw content as a string.",
     "parameters": {
       "type": "OBJECT",
       "properties": {
         "path": {
           "type": "STRING"
+        },
+        "start_line": {
+          "type": "NUMBER"
+        },
+        "end_line": {
+          "type": "NUMBER"
         },
         "task_progress": {
           "type": "STRING"

--- a/src/core/prompts/system-prompt/tools/read_file.ts
+++ b/src/core/prompts/system-prompt/tools/read_file.ts
@@ -5,38 +5,48 @@ import { TASK_PROGRESS_PARAMETER } from "../types"
 
 const id = ClineDefaultTool.FILE_READ
 
+const READ_FILE_DESCRIPTION =
+	"Request to read the contents of a file at the specified path. Use this when you need to examine the contents of an existing file you do not know the contents of, for example to analyze code, review text files, or extract information from configuration files. Returned text lines are prefixed with line labels (e.g. `L1:`, `L2:`). These labels are metadata, not part of the file content. For large files, output is automatically limited to 1000 lines. Use start_line and end_line to read specific sections. Automatically extracts raw text from PDF and DOCX files. May not be suitable for other types of binary files, as it returns the raw content as a string."
+
+const READ_FILE_PARAMETERS: ClineToolSpec["parameters"] = [
+	{
+		name: "path",
+		required: true,
+		instruction: `The path of the file to read (relative to the current working directory {{CWD}}){{MULTI_ROOT_HINT}}`,
+		usage: "File path here",
+	},
+	{
+		name: "start_line",
+		required: false,
+		type: "integer",
+		instruction: "The 1-based line number to start reading from (inclusive). Defaults to 1.",
+		usage: "1",
+	},
+	{
+		name: "end_line",
+		required: false,
+		type: "integer",
+		instruction:
+			"The 1-based line number to stop reading at (inclusive). Defaults to start_line + 1000. Use with start_line to read specific sections of large files.",
+		usage: "1000",
+	},
+	TASK_PROGRESS_PARAMETER,
+]
+
 const generic: ClineToolSpec = {
 	variant: ModelFamily.GENERIC,
 	id,
 	name: "read_file",
-	description:
-		"Request to read the contents of a file at the specified path. Use this when you need to examine the contents of an existing file you do not know the contents of, for example to analyze code, review text files, or extract information from configuration files. Returned text lines are prefixed with line labels in the format `L<number>:`. Treat these labels as metadata and not part of the underlying file text. Automatically extracts raw text from PDF and DOCX files. May not be suitable for other types of binary files, as it returns the raw content as a string. Do NOT use this tool to list the contents of a directory. Only use this tool on files.",
-	parameters: [
-		{
-			name: "path",
-			required: true,
-			instruction: `The path of the file to read (relative to the current working directory {{CWD}}){{MULTI_ROOT_HINT}}`,
-			usage: "File path here",
-		},
-		TASK_PROGRESS_PARAMETER,
-	],
+	description: READ_FILE_DESCRIPTION,
+	parameters: READ_FILE_PARAMETERS,
 }
 
 const NATIVE_GPT_5: ClineToolSpec = {
 	variant: ModelFamily.NATIVE_GPT_5,
 	id,
 	name: "read_file",
-	description:
-		"Request to read the contents of a file at the specified path. Use this when you need to examine the contents of an existing file you do not know the contents of, for example to analyze code, review text files, or extract information from configuration files. Returned text lines are prefixed with line labels in the format `L<number>:`. Treat these labels as metadata and not part of the underlying file text. Automatically extracts raw text from PDF and DOCX files. May not be suitable for other types of binary files, as it returns the raw content as a string. Do NOT use this tool to list the contents of a directory. Only use this tool on files.",
-	parameters: [
-		{
-			name: "path",
-			required: true,
-			instruction: `The path of the file to read (relative to the current working directory {{CWD}}){{MULTI_ROOT_HINT}}`,
-			usage: "File path here",
-		},
-		TASK_PROGRESS_PARAMETER,
-	],
+	description: READ_FILE_DESCRIPTION,
+	parameters: READ_FILE_PARAMETERS,
 }
 
 const NATIVE_NEXT_GEN: ClineToolSpec = {

--- a/src/core/task/tools/handlers/ReadFileToolHandler.ts
+++ b/src/core/task/tools/handlers/ReadFileToolHandler.ts
@@ -15,21 +15,21 @@ import type { TaskConfig } from "../types/TaskConfig"
 import type { StronglyTypedUIHelpers } from "../types/UIHelpers"
 import { ToolResultUtils } from "../utils/ToolResultUtils"
 
+export const DEFAULT_MAX_LINES = 1000
 const FILE_TRUNCATED_MARKER = "\n\n---\n\n[FILE TRUNCATED:"
 
 /**
- * Prefix each visible file line with a 1-indexed label (e.g., L42: ...).
- * In truncated reads, only number the actual file-content section and leave the
- * truncation notice untouched.
+ * Slice file content to the requested line range, add L-prefixed line labels,
+ * and append a continuation hint when the file has more lines to read.
  */
-export function addLineNumbersToReadFileContent(content: string): string {
+export function formatFileContentWithLineNumbers(content: string, startLine?: number, endLine?: number): string {
 	if (!content) {
 		return content
 	}
 
+	// Separate any byte-truncation notice appended by content-limits.ts
 	let body = content
 	let truncationSuffix = ""
-
 	const truncationIndex = content.indexOf(FILE_TRUNCATED_MARKER)
 	if (truncationIndex !== -1) {
 		body = content.slice(0, truncationIndex)
@@ -38,12 +38,26 @@ export function addLineNumbersToReadFileContent(content: string): string {
 
 	const lines = body.split(/\r?\n/)
 	if (body.endsWith("\n") && lines.length > 0) {
-		// Avoid creating an extra numbered line for trailing newline terminators.
 		lines.pop()
 	}
+	const totalLines = lines.length
 
-	const numberedBody = lines.map((line, index) => `L${index + 1}: ${line}`).join("\n")
-	return truncationSuffix ? `${numberedBody}${truncationSuffix}` : numberedBody
+	const start = Math.max(1, startLine ?? 1)
+	const end = Math.min(totalLines, endLine ?? start + DEFAULT_MAX_LINES - 1)
+
+	const slice = lines.slice(start - 1, end)
+	const labeled = slice.map((line, i) => `L${start + i}: ${line}`).join("\n")
+
+	let suffix = truncationSuffix
+	if (!truncationSuffix) {
+		if (end < totalLines) {
+			suffix = `\n\n(Showing lines ${start}-${end} of ${totalLines} total. Use start_line=${end + 1} to continue reading.)`
+		} else {
+			suffix = `\n\n(File has ${totalLines} lines total.)`
+		}
+	}
+
+	return labeled + suffix
 }
 
 export class ReadFileToolHandler implements IFullyManagedTool {
@@ -210,13 +224,12 @@ export class ReadFileToolHandler implements IFullyManagedTool {
 		// Handle image blocks separately - they need to be pushed to userMessageContent
 		if (fileContent.imageBlock) {
 			config.taskState.userMessageContent.push(fileContent.imageBlock)
+			return fileContent.text
 		}
 
-		// Add stable line labels so line-number reasoning is deterministic in both PLAN and ACT flows.
-		if (!fileContent.imageBlock) {
-			return addLineNumbersToReadFileContent(fileContent.text)
-		}
+		const startLine = block.params.start_line ? Number.parseInt(block.params.start_line, 10) : undefined
+		const endLine = block.params.end_line ? Number.parseInt(block.params.end_line, 10) : undefined
 
-		return fileContent.text
+		return formatFileContentWithLineNumbers(fileContent.text, startLine, endLine)
 	}
 }

--- a/src/core/task/tools/handlers/__tests__/ReadFileToolHandler.lineNumbers.test.ts
+++ b/src/core/task/tools/handlers/__tests__/ReadFileToolHandler.lineNumbers.test.ts
@@ -1,31 +1,111 @@
 import assert from "node:assert/strict"
 import { describe, it } from "mocha"
-import { addLineNumbersToReadFileContent } from "../ReadFileToolHandler"
+import { DEFAULT_MAX_LINES, formatFileContentWithLineNumbers } from "../ReadFileToolHandler"
 
-describe("ReadFileToolHandler line numbering", () => {
-	it("adds codex-style 1-indexed line prefixes", () => {
-		const result = addLineNumbersToReadFileContent("alpha\nbeta")
-		assert.equal(result, "L1: alpha\nL2: beta")
+describe("formatFileContentWithLineNumbers", () => {
+	describe("line labels", () => {
+		it("adds 1-indexed line prefixes", () => {
+			const result = formatFileContentWithLineNumbers("alpha\nbeta")
+			assert.ok(result.startsWith("L1: alpha\nL2: beta"))
+		})
+
+		it("does not add an extra numbered line for trailing newline", () => {
+			const result = formatFileContentWithLineNumbers("alpha\nbeta\n")
+			assert.ok(result.startsWith("L1: alpha\nL2: beta"))
+			assert.ok(!result.includes("L3:"))
+		})
+
+		it("returns empty content unchanged", () => {
+			const result = formatFileContentWithLineNumbers("")
+			assert.equal(result, "")
+		})
 	})
 
-	it("does not add an extra numbered line for trailing newline", () => {
-		const result = addLineNumbersToReadFileContent("alpha\nbeta\n")
-		assert.equal(result, "L1: alpha\nL2: beta")
+	describe("chunked reads", () => {
+		const tenLines = Array.from({ length: 10 }, (_, i) => `line${i + 1}`).join("\n")
+
+		it("defaults to reading from line 1", () => {
+			const result = formatFileContentWithLineNumbers(tenLines)
+			assert.ok(result.startsWith("L1: line1\n"))
+		})
+
+		it("respects start_line parameter", () => {
+			const result = formatFileContentWithLineNumbers(tenLines, 5)
+			assert.ok(result.startsWith("L5: line5\n"))
+			assert.ok(!result.includes("L4:"))
+		})
+
+		it("respects start_line and end_line parameters", () => {
+			const result = formatFileContentWithLineNumbers(tenLines, 3, 5)
+			assert.ok(result.startsWith("L3: line3\n"))
+			assert.ok(result.includes("L4: line4\n"))
+			assert.ok(result.includes("L5: line5"))
+			assert.ok(!result.includes("L2:"))
+			assert.ok(!result.includes("L6:"))
+		})
+
+		it("clamps start_line to 1 if below", () => {
+			const result = formatFileContentWithLineNumbers(tenLines, -5, 3)
+			assert.ok(result.startsWith("L1: line1\n"))
+		})
+
+		it("clamps end_line to total lines if beyond", () => {
+			const result = formatFileContentWithLineNumbers(tenLines, 8, 999)
+			assert.ok(result.includes("L10: line10"))
+			assert.ok(!result.includes("L11:"))
+		})
 	})
 
-	it("preserves truncation notice without numbering it", () => {
-		const input =
-			"alpha\nbeta\n\n---\n\n[FILE TRUNCATED: This content is 1.0 MB but only the first 400 KB is shown (600 KB truncated).]"
-		const result = addLineNumbersToReadFileContent(input)
+	describe("continuation hints", () => {
+		const tenLines = Array.from({ length: 10 }, (_, i) => `line${i + 1}`).join("\n")
 
-		assert.equal(
-			result,
-			"L1: alpha\nL2: beta\n\n---\n\n[FILE TRUNCATED: This content is 1.0 MB but only the first 400 KB is shown (600 KB truncated).]",
-		)
+		it("shows continuation hint when more lines remain", () => {
+			const result = formatFileContentWithLineNumbers(tenLines, 1, 5)
+			assert.ok(result.includes("Showing lines 1-5 of 10 total"))
+			assert.ok(result.includes("start_line=6"))
+		})
+
+		it("shows total-lines footer when entire file is returned", () => {
+			const result = formatFileContentWithLineNumbers(tenLines, 1, 10)
+			assert.ok(result.includes("File has 10 lines total"))
+		})
+
+		it("shows total-lines footer when file fits within default limit", () => {
+			const result = formatFileContentWithLineNumbers(tenLines)
+			assert.ok(result.includes("File has 10 lines total"))
+		})
 	})
 
-	it("returns empty content unchanged", () => {
-		const result = addLineNumbersToReadFileContent("")
-		assert.equal(result, "")
+	describe("default max lines", () => {
+		const bigContent = Array.from({ length: DEFAULT_MAX_LINES + 500 }, (_, i) => `row${i + 1}`).join("\n")
+
+		it("limits output to DEFAULT_MAX_LINES when no end_line given", () => {
+			const result = formatFileContentWithLineNumbers(bigContent)
+			assert.ok(result.includes(`L1: row1`))
+			assert.ok(result.includes(`L${DEFAULT_MAX_LINES}: row${DEFAULT_MAX_LINES}`))
+			assert.ok(!result.includes(`L${DEFAULT_MAX_LINES + 1}:`))
+			assert.ok(result.includes(`start_line=${DEFAULT_MAX_LINES + 1}`))
+		})
+
+		it("allows reading beyond default limit with explicit end_line", () => {
+			const endLine = DEFAULT_MAX_LINES + 200
+			const result = formatFileContentWithLineNumbers(bigContent, 1, endLine)
+			assert.ok(result.includes(`L${endLine}: row${endLine}`))
+		})
+	})
+
+	describe("byte truncation interaction", () => {
+		it("preserves truncation notice without numbering it", () => {
+			const input =
+				"alpha\nbeta\n\n---\n\n[FILE TRUNCATED: This content is 1.0 MB but only the first 400 KB is shown (600 KB truncated).]"
+			const result = formatFileContentWithLineNumbers(input)
+			assert.ok(result.startsWith("L1: alpha\nL2: beta"))
+			assert.ok(
+				result.includes(
+					"[FILE TRUNCATED: This content is 1.0 MB but only the first 400 KB is shown (600 KB truncated).]",
+				),
+			)
+			assert.ok(!result.includes("L3:"))
+		})
 	})
 })


### PR DESCRIPTION
### Related Issue

**Issue:** #8659

### Description

Builds on #9371 (line labels) to add chunked file reading to `read_file`. Instead of dumping entire files into context, the tool now:

- Returns at most 1000 lines per call (configurable via `start_line`/`end_line`)
- Appends a continuation hint when truncated: `(Showing lines 1-1000 of 6750 total. Use start_line=1001 to continue reading.)`
- Lets the model paginate to specific sections on follow-up calls

This matches the chunked reading pattern used by Codex, OpenCode, and Gemini CLI. The model drives pagination — it calls `read_file` with just `path` on the first read, gets the first 1000 lines + hint, then uses `start_line`/`end_line` to read more if the task requires it.

**Changes:**
- `src/core/assistant-message/index.ts` — Add `start_line`/`end_line` to `toolParamNames`
- `src/core/prompts/system-prompt/tools/read_file.ts` — Add optional `start_line` (integer) and `end_line` (integer) parameters to tool spec for all variants
- `src/core/task/tools/handlers/ReadFileToolHandler.ts` — Replace `addLineNumbersToReadFileContent` with `formatFileContentWithLineNumbers` that slices to the requested range, adds line labels, and appends continuation hints
- Snapshot updates across all model families

### Test Procedure

- `npm run test:unit` — 1110 passing, 4 pending
- 10 new test cases covering: line labels, chunked reads with `start_line`/`end_line`, clamping of out-of-range values, continuation hints, default max lines enforcement, and byte-truncation interaction
- Manual testing: ran Cline from the worktree, confirmed a 6750-line file was chunked to 1000 lines with correct `L1:`-`L1000:` labels and continuation hint

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A — backend-only change. See test procedure for verification.

### Additional Notes

- Stacked on #9371 (line labels PR). Only the chunked-read delta is in this PR.
- Works with both XML tool calling and native tool calling (integer params in JSON schema).
- The 400KB byte truncation in `content-limits.ts` is preserved as a safety net — line chunking operates on the (potentially already byte-truncated) text.
