### PR TITLE
Restrict /test-jetbrains trigger to authorized users (SEC-29)

### DIFF
--- a/.github/workflows/trigger-jetbrains-tests.yml
+++ b/.github/workflows/trigger-jetbrains-tests.yml
@@ -20,7 +20,8 @@ jobs:
       github.event_name == 'pull_request_target' ||
       (github.event_name == 'issue_comment' &&
        github.event.issue.pull_request &&
-       contains(github.event.comment.body, '/test-jetbrains'))
+       contains(github.event.comment.body, '/test-jetbrains') &&
+       contains(fromJSON('["MEMBER","OWNER","COLLABORATOR"]'), github.event.comment.author_association))
     steps:
       - name: Generate GitHub App Token
         id: app-token


### PR DESCRIPTION
## Summary
- Adds `author_association` check to the `/test-jetbrains` issue comment workflow trigger, restricting it to `MEMBER`, `OWNER`, and `COLLABORATOR` users only
- Previously any GitHub user could trigger the workflow by commenting `/test-jetbrains` on any open PR, allowing unauthorized use of the GitHub App token and draining Actions minutes
- Fixes GHSA-5fq9-fh5x-w83r (SEC-29)

## Test plan
- [ ] Verify an org member commenting `/test-jetbrains` still triggers the workflow
- [ ] Verify an external user commenting `/test-jetbrains` does **not** trigger the workflow
- [ ] Verify `pull_request_target` (PR open/reopen) still triggers normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Restricts `/test-jetbrains` trigger to authorized users by adding `author_association` check in `trigger-jetbrains-tests.yml`.
> 
>   - **Security**:
>     - Adds `author_association` check in `trigger-jetbrains-tests.yml` to restrict `/test-jetbrains` trigger to `MEMBER`, `OWNER`, and `COLLABORATOR` users.
>     - Prevents unauthorized users from triggering the workflow, addressing GHSA-5fq9-fh5x-w83r (SEC-29).
>   - **Behavior**:
>     - Workflow still triggers on `pull_request_target` events (open/reopen) and authorized `/test-jetbrains` comments.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cline%2Fcline&utm_source=github&utm_medium=referral)<sup> for e853d9bae444a19aff1f56d404a984506ccb91bf. You can [customize](https://app.ellipsis.dev/cline/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->