### PR TITLE
fix: detect and abort in-generation text loops during streaming

### DIFF
--- a/src/core/task/InGenerationLoopDetector.ts
+++ b/src/core/task/InGenerationLoopDetector.ts
@@ -26,6 +26,11 @@ export class InGenerationLoopDetector {
 		this.textLengthSinceLastTool = 0
 	}
 
+	/** Reset the timer without clearing the char count — reasoning tokens aren't text, but shouldn't count toward elapsed time. */
+	onReasoningActivity(): void {
+		this.lastToolActivityTime = this.now()
+	}
+
 	onTextChunk(chunkLength: number): void {
 		this.textLengthSinceLastTool += chunkLength
 	}

--- a/src/core/task/__tests__/InGenerationLoopDetector.test.ts
+++ b/src/core/task/__tests__/InGenerationLoopDetector.test.ts
@@ -88,6 +88,24 @@ describe("InGenerationLoopDetector", () => {
 		detector.isLooping().should.be.true()
 	})
 
+	it("should reset timer on reasoning activity without clearing char count", () => {
+		const { detector, advance } = createDetector()
+		detector.onTextChunk(16_000)
+		advance(90_000) // 90s of reasoning
+		detector.onReasoningActivity() // resets timer but keeps 16K chars
+		advance(30_000) // only 30s since reasoning reset
+		detector.isLooping().should.be.false()
+	})
+
+	it("should trigger after reasoning if text continues long enough", () => {
+		const { detector, advance } = createDetector()
+		advance(90_000) // 90s of reasoning
+		detector.onReasoningActivity()
+		detector.onTextChunk(16_000)
+		advance(61_000) // 61s since reasoning ended
+		detector.isLooping().should.be.true()
+	})
+
 	it("should not trigger at exact boundary values", () => {
 		const { detector, advance } = createDetector({
 			charThreshold: 100,

--- a/src/core/task/index.ts
+++ b/src/core/task/index.ts
@@ -2725,6 +2725,8 @@ export class Task {
 								redacted_data: chunk.redacted_data,
 							})
 
+							loopDetector.onReasoningActivity()
+
 							// fixes bug where cancelling task > aborts task > for loop may be in middle of streaming reasoning > say function throws error before we get a chance to properly clean up and cancel the task.
 							if (!this.taskState.abort) {
 								const thinkingBlock = reasonsHandler.getCurrentReasoning()


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

### Description

Detects and aborts in-generation text loops where a model produces excessive text within a single streaming API response without ever emitting a tool call.

**The problem:** Some models (especially Gemini Flash) enter degenerate loops where they generate thousands of repetitive text lines (e.g., 2,455x "Actually, I'll use read_file") within a single API response. The existing `consecutiveMistakeCount` mechanism can't detect this because it only fires *between* API responses — a single-turn thought spiral never completes, so the harness never gets a chance to intervene.

**The fix:** A new `InGenerationLoopDetector` that monitors the streaming response in real time. It tracks two signals:

1. **Characters of text since the last tool-related activity** (default threshold: 15,000 chars)
2. **Elapsed wall-clock time since the last tool activity** (default threshold: 60 seconds)

The detector only triggers when **both** thresholds are exceeded simultaneously, avoiding false positives on legitimate long text outputs (which are either fast or short, but not both slow and long without tool calls).

When triggered, the stream is aborted, the response is truncated to 500 chars with a `[Response interrupted]` marker, and the task continues normally (the model gets the truncated output and can recover).

**Cross-agent comparison:**

| Agent | In-generation loop detection? |
|-------|-------------------------------|
| Gemini CLI | `LoopDetectionService` (framework-level) |
| LangChain | `LoopDetectionMiddleware` (per-file edit tracking) |
| Cline (before) | None — only `consecutiveMistakeCount` between turns |
| Cline (after) | `InGenerationLoopDetector` (streaming) |

### Test Procedure

- All 1171 unit tests passing
- 10 unit tests for `InGenerationLoopDetector` covering:
  - Under both thresholds (no trigger)
  - Only char threshold exceeded (no trigger)
  - Only time threshold exceeded (no trigger)
  - Both thresholds exceeded (triggers)
  - Accumulation across multiple chunks
  - Reset on tool activity
  - Re-accumulation after reset
  - Trigger after tool activity with new text
  - Custom thresholds
  - Exact boundary values (no trigger)

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A — backend-only streaming fix with no UI changes.

### Additional Notes

- The dual-threshold design (chars AND time) is intentional. A model might legitimately produce a large amount of text quickly (e.g., writing a file), or spend a long time on a small amount of reasoning text. Only when both signals are present is it a degenerate loop.
- The 15K char / 60s defaults are conservative. In observed failures, loops produced 40K+ chars over 8+ minutes. These thresholds can be tuned based on production data.
- The detector integrates into both the XML tool parsing path and the native tool calling path in `index.ts`.
