### PR TITLE
fix: bypass git hooks on checkpoint initial commit

### DIFF
--- a/.changeset/fix-checkpoint-initial-commit-no-verify.md
+++ b/.changeset/fix-checkpoint-initial-commit-no-verify.md
@@ -1,0 +1,15 @@
+---
+"cline": patch
+---
+
+fix: bypass git hooks on checkpoint initial commit
+
+The initial checkpoint commit in `CheckpointGitOperations.ts` was missing
+the `--no-verify` flag, causing Cline to fail to initialize when users
+have global git pre-commit hooks (e.g., conventional commits enforcement).
+
+Subsequent checkpoint commits already used `--no-verify` (in
+`CheckpointTracker.ts`), but the initial empty commit did not, creating
+an inconsistency.
+
+Fixes #9672

--- a/src/integrations/checkpoints/CheckpointGitOperations.ts
+++ b/src/integrations/checkpoints/CheckpointGitOperations.ts
@@ -104,7 +104,7 @@ export class GitOperations {
 		}
 
 		// Initial commit only on first repo creation
-		await git.commit("initial commit", { "--allow-empty": null })
+		await git.commit("initial commit", { "--allow-empty": null, "--no-verify": null })
 
 		const durationMs = Math.round(performance.now() - startTime)
 		telemetryService.captureCheckpointUsage(taskId, "shadow_git_initialized", durationMs)


### PR DESCRIPTION
## Summary

Fixes #9672 — Cline fails to initialize when users have global git pre-commit hooks (e.g., conventional commits enforcement).

## Root Cause

The initial checkpoint commit in `CheckpointGitOperations.ts` (line 107) was missing `--no-verify`:

```typescript
// Before:
await git.commit("initial commit", { "--allow-empty": null })

// After:
await git.commit("initial commit", { "--allow-empty": null, "--no-verify": null })
```

Subsequent checkpoint commits in `CheckpointTracker.ts` (line 253) already used `--no-verify`, but the initial empty commit did not. When users have global pre-commit hooks that enforce commit message formats, the initial commit gets rejected and Cline fails to start.

## Changes

One line in `src/integrations/checkpoints/CheckpointGitOperations.ts` — added `"--no-verify": null` to the initial commit options.

Fixes #9672