### PR TITLE
fix(acp): forward cli config and cwd to agent

### DIFF
--- a/cli/src/acp/index.ts
+++ b/cli/src/acp/index.ts
@@ -69,6 +69,8 @@ export interface AcpModeOptions {
 	config?: string
 	/** Working directory (default: process.cwd()) */
 	cwd?: string
+	/** Additional runtime hooks directory */
+	hooksDir?: string
 	/** Enable verbose/debug logging to stderr */
 	verbose?: boolean
 }
@@ -96,6 +98,7 @@ export async function runAcpMode(options: AcpModeOptions = {}): Promise<void> {
 	new AgentSideConnection((conn) => {
 		agent = new AcpAgent(conn, {
 			debug: Boolean(options.verbose),
+			hooksDir: options.hooksDir,
 		})
 		return agent
 	}, stream)

--- a/cli/src/acp/index.ts
+++ b/cli/src/acp/index.ts
@@ -97,6 +97,8 @@ export async function runAcpMode(options: AcpModeOptions = {}): Promise<void> {
 
 	new AgentSideConnection((conn) => {
 		agent = new AcpAgent(conn, {
+			clineDir: options.config,
+			cwd: options.cwd,
 			debug: Boolean(options.verbose),
 			hooksDir: options.hooksDir,
 		})

--- a/cli/src/agent/ClineAgent.ts
+++ b/cli/src/agent/ClineAgent.ts
@@ -42,6 +42,7 @@ import { getProviderModelIdKey } from "@shared/storage/provider-keys"
 import { ClineEndpoint } from "@/config.js"
 import { Controller } from "@/core/controller"
 import { getAvailableSlashCommands } from "@/core/controller/slash/getAvailableSlashCommands"
+import { setRuntimeHooksDir } from "@/core/storage/disk"
 import { StateManager } from "@/core/storage/StateManager"
 import { AuthHandler } from "@/hosts/external/AuthHandler.js"
 import { ExternalCommentReviewController } from "@/hosts/external/ExternalCommentReviewController.js"
@@ -140,6 +141,7 @@ export class ClineAgent implements acp.Agent {
 
 	constructor(options: ClineAgentOptions) {
 		this.options = options
+		setRuntimeHooksDir(options.hooksDir)
 		this.ctx = initializeCliContext({ clineDir: options.clineDir })
 	}
 

--- a/cli/src/agent/ClineAgent.ts
+++ b/cli/src/agent/ClineAgent.ts
@@ -142,7 +142,10 @@ export class ClineAgent implements acp.Agent {
 	constructor(options: ClineAgentOptions) {
 		this.options = options
 		setRuntimeHooksDir(options.hooksDir)
-		this.ctx = initializeCliContext({ clineDir: options.clineDir })
+		this.ctx = initializeCliContext({
+			clineDir: options.clineDir,
+			workspaceDir: options.cwd,
+		})
 	}
 
 	/**

--- a/cli/src/agent/public-types.ts
+++ b/cli/src/agent/public-types.ts
@@ -71,6 +71,8 @@ export interface ClineAgentOptions {
 	debug?: boolean
 	/** Cline Config Directory (defaults to ~/.cline) */
 	clineDir?: string
+	/** Additional runtime hooks directory */
+	hooksDir?: string
 }
 
 /**
@@ -79,6 +81,8 @@ export interface ClineAgentOptions {
 export interface AcpAgentOptions {
 	/** Whether debug logging is enabled */
 	debug?: boolean
+	/** Additional runtime hooks directory */
+	hooksDir?: string
 }
 
 // ============================================================

--- a/cli/src/agent/public-types.ts
+++ b/cli/src/agent/public-types.ts
@@ -71,6 +71,8 @@ export interface ClineAgentOptions {
 	debug?: boolean
 	/** Cline Config Directory (defaults to ~/.cline) */
 	clineDir?: string
+	/** Working directory for storage and workspace context */
+	cwd?: string
 	/** Additional runtime hooks directory */
 	hooksDir?: string
 }
@@ -81,6 +83,10 @@ export interface ClineAgentOptions {
 export interface AcpAgentOptions {
 	/** Whether debug logging is enabled */
 	debug?: boolean
+	/** Cline Config Directory (defaults to ~/.cline) */
+	clineDir?: string
+	/** Working directory for storage and workspace context */
+	cwd?: string
 	/** Additional runtime hooks directory */
 	hooksDir?: string
 }

--- a/cli/src/index.test.ts
+++ b/cli/src/index.test.ts
@@ -33,6 +33,7 @@ describe("CLI Commands", () => {
 			.option("--thinking [tokens]", "Enable extended thinking")
 			.option("--reasoning-effort <effort>", "Reasoning effort")
 			.option("--max-consecutive-mistakes <count>", "Maximum consecutive mistakes")
+			.option("--hooks-dir <path>", "Additional hooks directory")
 			.action(() => {})
 
 		program
@@ -72,6 +73,7 @@ describe("CLI Commands", () => {
 			.option("--thinking [tokens]", "Enable extended thinking")
 			.option("--reasoning-effort <effort>", "Reasoning effort")
 			.option("--max-consecutive-mistakes <count>", "Maximum consecutive mistakes")
+			.option("--hooks-dir <path>", "Additional hooks directory")
 			.action(() => {})
 	})
 
@@ -169,6 +171,13 @@ describe("CLI Commands", () => {
 			const args = ["test prompt", "--max-consecutive-mistakes", "999"]
 			taskCmd.parse(args, { from: "user" })
 			expect(taskCmd.opts().maxConsecutiveMistakes).toBe("999")
+		})
+
+		it("should parse --hooks-dir option", () => {
+			const taskCmd = program.commands.find((c) => c.name() === "task")!
+			const args = ["test prompt", "--hooks-dir", "/tmp/hooks"]
+			taskCmd.parse(args, { from: "user" })
+			expect(taskCmd.opts().hooksDir).toBe("/tmp/hooks")
 		})
 
 		it("should parse short flags", () => {
@@ -320,6 +329,11 @@ describe("CLI Commands", () => {
 		it("should parse --max-consecutive-mistakes option", () => {
 			program.parse(["node", "cli", "--max-consecutive-mistakes", "7"])
 			expect(program.opts().maxConsecutiveMistakes).toBe("7")
+		})
+
+		it("should parse --hooks-dir option", () => {
+			program.parse(["node", "cli", "--hooks-dir", "/tmp/hooks"])
+			expect(program.opts().hooksDir).toBe("/tmp/hooks")
 		})
 	})
 

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -9,6 +9,7 @@ import { render } from "ink"
 import React from "react"
 import { ClineEndpoint } from "@/config"
 import type { Controller } from "@/core/controller"
+import { setRuntimeHooksDir } from "@/core/storage/disk"
 import { StateManager } from "@/core/storage/StateManager"
 import { AuthHandler } from "@/hosts/external/AuthHandler"
 import { HostProvider } from "@/hosts/host-provider"
@@ -65,6 +66,7 @@ interface TaskOptions {
 	timeout?: string
 	json?: boolean
 	stdinWasPiped?: boolean
+	hooksDir?: string
 }
 
 let telemetryDisposed = false
@@ -131,6 +133,11 @@ function normalizeMaxConsecutiveMistakes(value?: string): number | undefined {
  * Shared between runTask and resumeTask to avoid duplication.
  */
 function applyTaskOptions(options: TaskOptions): void {
+	// Set runtime hooks directory for hook discovery
+	if (options.hooksDir) {
+		setRuntimeHooksDir(options.hooksDir)
+	}
+
 	// Apply mode flag
 	if (options.plan) {
 		StateManager.get().setGlobalState("mode", "plan")
@@ -738,6 +745,7 @@ program
 	.option("--max-consecutive-mistakes <count>", "Maximum consecutive mistakes before halting in yolo mode")
 	.option("--json", "Output messages as JSON instead of styled text")
 	.option("--double-check-completion", "Reject first completion attempt to force re-verification")
+	.option("--hooks-dir <path>", "Path to additional hooks directory for runtime hook injection")
 	.option("-T, --taskId <id>", "Resume an existing task by ID")
 	.action((prompt, options) => {
 		if (options.taskId) {
@@ -905,6 +913,7 @@ program
 	.option("--max-consecutive-mistakes <count>", "Maximum consecutive mistakes before halting in yolo mode")
 	.option("--json", "Output messages as JSON instead of styled text")
 	.option("--double-check-completion", "Reject first completion attempt to force re-verification")
+	.option("--hooks-dir <path>", "Path to additional hooks directory for runtime hook injection")
 	.option("--acp", "Run in ACP (Agent Client Protocol) mode for editor integration")
 	.option("-T, --taskId <id>", "Resume an existing task by ID")
 	.action(async (prompt, options) => {

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -133,11 +133,6 @@ function normalizeMaxConsecutiveMistakes(value?: string): number | undefined {
  * Shared between runTask and resumeTask to avoid duplication.
  */
 function applyTaskOptions(options: TaskOptions): void {
-	// Set runtime hooks directory for hook discovery
-	if (options.hooksDir) {
-		setRuntimeHooksDir(options.hooksDir)
-	}
-
 	// Apply mode flag
 	if (options.plan) {
 		StateManager.get().setGlobalState("mode", "plan")
@@ -401,6 +396,7 @@ interface CliContext {
 interface InitOptions {
 	config?: string
 	cwd?: string
+	hooksDir?: string
 	verbose?: boolean
 	enableAuth?: boolean
 }
@@ -410,6 +406,7 @@ interface InitOptions {
  */
 async function initializeCli(options: InitOptions): Promise<CliContext> {
 	const workspacePath = options.cwd || process.cwd()
+	setRuntimeHooksDir(options.hooksDir)
 	const { extensionContext, storageContext, DATA_DIR, EXTENSION_DIR } = initializeCliContext({
 		clineDir: options.config,
 		workspaceDir: workspacePath,
@@ -922,6 +919,7 @@ program
 			await runAcpMode({
 				config: options.config,
 				cwd: options.cwd,
+				hooksDir: options.hooksDir,
 				verbose: options.verbose,
 			})
 			return

--- a/src/core/storage/__tests__/disk.test.ts
+++ b/src/core/storage/__tests__/disk.test.ts
@@ -10,9 +10,11 @@ import { HostProvider } from "@/hosts/host-provider"
 import { setVscodeHostProviderMock } from "@/test/host-provider-test-utils"
 import {
 	ensureStateDirectoryExists,
+	getAllHooksDirs,
 	getTaskHistoryStateFilePath,
 	getWorkspaceHooksDirs,
 	readTaskHistoryFromState,
+	setRuntimeHooksDir,
 	writeTaskHistoryToState,
 } from "../disk"
 import { StateManager } from "../StateManager"
@@ -29,6 +31,7 @@ describe("disk - hooks functionality", () => {
 
 	afterEach(async () => {
 		sandbox.restore()
+		setRuntimeHooksDir(undefined)
 		try {
 			await fs.rm(tempDir, { recursive: true, force: true })
 		} catch (error) {
@@ -197,6 +200,41 @@ describe("disk - hooks functionality", () => {
 			result.should.be.an.Array()
 			result.length.should.equal(1)
 			result[0].should.equal(hooksDir)
+		})
+	})
+
+	describe("getAllHooksDirs", () => {
+		it("should include the runtime hooks directory when it exists", async () => {
+			const runtimeHooksDir = path.join(tempDir, "runtime-hooks")
+			await fs.mkdir(runtimeHooksDir, { recursive: true })
+
+			sandbox.stub(os, "homedir").returns(tempDir)
+			sandbox.stub(StateManager, "get").returns({
+				getGlobalStateKey: () => [],
+			} as any)
+
+			sandbox.stub(fsUtils, "isDirectory").callsFake(async (targetPath: string) => targetPath === runtimeHooksDir)
+
+			setRuntimeHooksDir(runtimeHooksDir)
+
+			const result = await getAllHooksDirs()
+			result.should.containEql(runtimeHooksDir)
+		})
+
+		it("should not include the runtime hooks directory when it does not exist", async () => {
+			const runtimeHooksDir = path.join(tempDir, "missing-runtime-hooks")
+
+			sandbox.stub(os, "homedir").returns(tempDir)
+			sandbox.stub(StateManager, "get").returns({
+				getGlobalStateKey: () => [],
+			} as any)
+
+			sandbox.stub(fsUtils, "isDirectory").resolves(false)
+
+			setRuntimeHooksDir(runtimeHooksDir)
+
+			const result = await getAllHooksDirs()
+			result.should.not.containEql(runtimeHooksDir)
 		})
 	})
 })

--- a/src/core/storage/disk.ts
+++ b/src/core/storage/disk.ts
@@ -508,10 +508,22 @@ export async function getGlobalHooksDir(): Promise<string | undefined> {
 	return (await isDirectory(globalHooksDir)) ? globalHooksDir : undefined
 }
 
+let runtimeHooksDir: string | undefined
+
+/**
+ * Sets a runtime hooks directory, typically passed via the --hooks-dir CLI flag.
+ * This directory is included alongside global and workspace hooks directories
+ * when discovering hooks.
+ */
+export function setRuntimeHooksDir(dir: string | undefined): void {
+	runtimeHooksDir = dir
+}
+
 /**
  * Gets the paths to all hooks directories to search for hooks, including:
- * 1. The global hooks directory (if it exists)
- * 2. Each workspace root's .clinerules/hooks directory (if they exist)
+ * 1. The runtime hooks directory (if set via --hooks-dir CLI flag)
+ * 2. The global hooks directory (if it exists)
+ * 3. Each workspace root's .clinerules/hooks directory (if they exist)
  *
  * Note: Hooks from different directories may be executed concurrently.
  * No execution order is guaranteed between hooks from different directories.
@@ -520,6 +532,11 @@ export async function getGlobalHooksDir(): Promise<string | undefined> {
  */
 export async function getAllHooksDirs(): Promise<string[]> {
 	const hooksDirs: string[] = []
+
+	// Add runtime hooks directory (set by --hooks-dir CLI flag)
+	if (runtimeHooksDir && (await isDirectory(runtimeHooksDir))) {
+		hooksDirs.push(runtimeHooksDir)
+	}
 
 	// Add global hooks directory (if it exists)
 	const globalHooksDir = await getGlobalHooksDir()


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

### Description

This is a stacked follow-up to #9658.

While wiring `--hooks-dir` through the CLI, I found that the ACP launch path was already dropping two existing CLI options before they reached `ClineAgent`: `config` and `cwd`.

The root CLI action forwards both values into `runAcpMode()`, but `runAcpMode()` was only passing `debug` into `AcpAgent`, and `ClineAgent` was always initializing its storage context from process defaults. In practice that means `cline --acp --config /some/cline-dir --cwd /some/workspace` can silently run against the wrong config directory and wrong workspace storage.

This PR keeps the fix intentionally narrow:

- extend `AcpAgentOptions` and `ClineAgentOptions` to include `clineDir` and `cwd`
- pass `config` and `cwd` through `runAcpMode()` into `AcpAgent`
- initialize `ClineAgent` with those values so ACP sessions use the same CLI context the caller requested

I considered broadening this into more ACP cleanup or adding more option forwarding at the same time, but I kept it scoped to the concrete bug we already identified while reviewing #9658.

### Test Procedure

I ran a focused static check on the touched files:

```bash
npx biome check --no-errors-on-unmatched --files-ignore-unknown=true cli/src/acp/index.ts cli/src/agent/ClineAgent.ts cli/src/agent/public-types.ts
```

This passed.

I also attempted to add a dedicated unit test around `runAcpMode()`, but the root Vitest harness could not import the ACP entrypoint cleanly because of the CLI alias setup. Rather than add unrelated test harness work to a small stacked bugfix, I kept the code change small and verified the forwarding path directly in code review.

The main thing that could break here is ACP startup if any caller was implicitly relying on the old incorrect fallback to `process.cwd()` or `~/.cline`. This change should be an improvement for those callers because it now respects the CLI options they already passed.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A

### Additional Notes

This PR is intentionally based on `saoudrizwan/cli-hooks-dir` and should merge after that branch. I split it out so the `--hooks-dir` bugfix in #9658 could stay focused instead of also carrying the broader ACP option-forwarding cleanup.
