### PR TITLE
Add --auto-condense CLI flag for AI-powered context compaction

### DIFF
--- a/cli/src/index.test.ts
+++ b/cli/src/index.test.ts
@@ -34,6 +34,8 @@ describe("CLI Commands", () => {
 			.option("--thinking [tokens]", "Enable extended thinking")
 			.option("--reasoning-effort <effort>", "Reasoning effort")
 			.option("--max-consecutive-mistakes <count>", "Maximum consecutive mistakes")
+			.option("--double-check-completion", "Reject first completion attempt to force re-verification")
+			.option("--auto-condense", "Enable AI-powered context compaction instead of mechanical truncation")
 			.option("--hooks-dir <path>", "Additional hooks directory")
 			.action(() => {})
 
@@ -74,6 +76,8 @@ describe("CLI Commands", () => {
 			.option("--thinking [tokens]", "Enable extended thinking")
 			.option("--reasoning-effort <effort>", "Reasoning effort")
 			.option("--max-consecutive-mistakes <count>", "Maximum consecutive mistakes")
+			.option("--double-check-completion", "Reject first completion attempt to force re-verification")
+			.option("--auto-condense", "Enable AI-powered context compaction instead of mechanical truncation")
 			.option("--hooks-dir <path>", "Additional hooks directory")
 			.option("--auto-approve-all", "Enable auto-approve all")
 			.action(() => {})
@@ -187,6 +191,20 @@ describe("CLI Commands", () => {
 			const args = ["test prompt", "--hooks-dir", "/tmp/hooks"]
 			taskCmd.parse(args, { from: "user" })
 			expect(taskCmd.opts().hooksDir).toBe("/tmp/hooks")
+		})
+
+		it("should parse --double-check-completion flag", () => {
+			const taskCmd = program.commands.find((c) => c.name() === "task")!
+			const args = ["test prompt", "--double-check-completion"]
+			taskCmd.parse(args, { from: "user" })
+			expect(taskCmd.opts().doubleCheckCompletion).toBe(true)
+		})
+
+		it("should parse --auto-condense flag", () => {
+			const taskCmd = program.commands.find((c) => c.name() === "task")!
+			const args = ["test prompt", "--auto-condense"]
+			taskCmd.parse(args, { from: "user" })
+			expect(taskCmd.opts().autoCondense).toBe(true)
 		})
 
 		it("should parse short flags", () => {

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -64,6 +64,7 @@ interface TaskOptions {
 	yolo?: boolean
 	autoApproveAll?: boolean
 	doubleCheckCompletion?: boolean
+	autoCondense?: boolean
 	timeout?: string
 	json?: boolean
 	stdinWasPiped?: boolean
@@ -212,6 +213,10 @@ function applyTaskOptions(options: TaskOptions): void {
 	if (options.doubleCheckCompletion) {
 		StateManager.get().setGlobalState("doubleCheckCompletionEnabled", true)
 		telemetryService.captureHostEvent("double_check_completion_flag", "true")
+	}
+
+	if (options.autoCondense) {
+		StateManager.get().setGlobalState("useAutoCondense", true)
 	}
 }
 
@@ -751,6 +756,7 @@ program
 	.option("--max-consecutive-mistakes <count>", "Maximum consecutive mistakes before halting in yolo mode")
 	.option("--json", "Output messages as JSON instead of styled text")
 	.option("--double-check-completion", "Reject first completion attempt to force re-verification")
+	.option("--auto-condense", "Enable AI-powered context compaction instead of mechanical truncation")
 	.option("--hooks-dir <path>", "Path to additional hooks directory for runtime hook injection")
 	.option("-T, --taskId <id>", "Resume an existing task by ID")
 	.action((prompt, options) => {
@@ -920,6 +926,7 @@ program
 	.option("--max-consecutive-mistakes <count>", "Maximum consecutive mistakes before halting in yolo mode")
 	.option("--json", "Output messages as JSON instead of styled text")
 	.option("--double-check-completion", "Reject first completion attempt to force re-verification")
+	.option("--auto-condense", "Enable AI-powered context compaction instead of mechanical truncation")
 	.option("--hooks-dir <path>", "Path to additional hooks directory for runtime hook injection")
 	.option("--acp", "Run in ACP (Agent Client Protocol) mode for editor integration")
 	.option("-T, --taskId <id>", "Resume an existing task by ID")


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

### Description

Adds `--auto-condense` as a CLI flag so eval harnesses (e.g. Harbor/SWE-bench) can enable AI-powered context compaction without going through the VS Code settings UI.

The underlying `useAutoCondense` state key and `ContextManager` logic already exist — this just exposes the toggle. Follows the exact same pattern as `--double-check-completion`.

### Test Procedure

- Added unit tests for parsing `--auto-condense` (and `--double-check-completion` which was missing) in `cli/src/index.test.ts`
- All 358 CLI tests pass (`cd cli && npm test`)
- No snapshot updates needed — no system prompt changes

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A — CLI-only change, no UI impact.

### Additional Notes

The Harbor `cline.py` counterpart (kwarg parsing, run flag, metadata) is not included here as it lives in a separate repo.
