### PR TITLE
use setSessionOverride instead of setGlobalState

### DIFF
--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -140,46 +140,43 @@ function normalizeMaxConsecutiveMistakes(value?: string): number | undefined {
 function applyTaskOptions(options: TaskOptions): void {
 	// Apply mode flag
 	if (options.plan) {
-		StateManager.get().setGlobalState("mode", "plan")
+		StateManager.get().setSessionOverride("mode", "plan")
 		telemetryService.captureHostEvent("mode_flag", "plan")
 	} else if (options.act) {
-		StateManager.get().setGlobalState("mode", "act")
+		StateManager.get().setSessionOverride("mode", "act")
 		telemetryService.captureHostEvent("mode_flag", "act")
 	}
 
 	// Apply model override if specified
 	if (options.model) {
-		const selectedMode = (StateManager.get().getGlobalSettingsKey("mode") || "act") as "act" | "plan"
+		const selectedMode = (StateManager.get().getGlobalSettingsKey("mode") ?? "act") as "act" | "plan"
 		const providerKey = selectedMode === "act" ? "actModeApiProvider" : "planModeApiProvider"
 		const currentProvider = StateManager.get().getGlobalSettingsKey(providerKey) as ApiProvider
 		const modelKey = getProviderModelIdKey(currentProvider, selectedMode)
 		if (modelKey) {
-			StateManager.get().setGlobalState(modelKey, options.model)
+			StateManager.get().setSessionOverride(modelKey, options.model)
 		}
 		telemetryService.captureHostEvent("model_flag", options.model)
 	}
 
+	const currentMode = (StateManager.get().getGlobalSettingsKey("mode") || "act") as "act" | "plan"
+
 	// Set thinking budget based on --thinking flag (boolean or number)
-	let thinkingBudget = 0
-	if (options.thinking) {
+	if (options.thinking !== undefined) {
+		let thinkingBudget = 1024
 		if (typeof options.thinking === "string") {
 			const parsed = Number.parseInt(options.thinking, 10)
 			if (Number.isNaN(parsed) || parsed < 0) {
 				printWarning(`Invalid --thinking value '${options.thinking}'. Using default 1024.`)
-				thinkingBudget = 1024
 			} else {
 				thinkingBudget = parsed
 			}
-		} else {
-			thinkingBudget = 1024
 		}
-	}
-	const currentMode = (StateManager.get().getGlobalSettingsKey("mode") || "act") as "act" | "plan"
-	setModeScopedState(currentMode, (mode) => {
-		const thinkingKey = mode === "act" ? "actModeThinkingBudgetTokens" : "planModeThinkingBudgetTokens"
-		StateManager.get().setGlobalState(thinkingKey, thinkingBudget)
-	})
-	if (options.thinking) {
+
+		setModeScopedState(currentMode, (mode) => {
+			const thinkingKey = mode === "act" ? "actModeThinkingBudgetTokens" : "planModeThinkingBudgetTokens"
+			StateManager.get().setSessionOverride(thinkingKey, thinkingBudget)
+		})
 		telemetryService.captureHostEvent("thinking_flag", "true")
 	}
 
@@ -187,14 +184,14 @@ function applyTaskOptions(options: TaskOptions): void {
 	if (reasoningEffort !== undefined) {
 		setModeScopedState(currentMode, (mode) => {
 			const reasoningKey = mode === "act" ? "actModeReasoningEffort" : "planModeReasoningEffort"
-			StateManager.get().setGlobalState(reasoningKey, reasoningEffort)
+			StateManager.get().setSessionOverride(reasoningKey, reasoningEffort)
 		})
 		telemetryService.captureHostEvent("reasoning_effort_flag", reasoningEffort)
 	}
 
 	const maxConsecutiveMistakes = normalizeMaxConsecutiveMistakes(options.maxConsecutiveMistakes)
 	if (maxConsecutiveMistakes !== undefined) {
-		StateManager.get().setGlobalState("maxConsecutiveMistakes", maxConsecutiveMistakes)
+		StateManager.get().setSessionOverride("maxConsecutiveMistakes", maxConsecutiveMistakes)
 		telemetryService.captureHostEvent("max_consecutive_mistakes_flag", String(maxConsecutiveMistakes))
 	}
 
@@ -214,12 +211,12 @@ function applyTaskOptions(options: TaskOptions): void {
 
 	// Set double-check completion based on flag
 	if (options.doubleCheckCompletion) {
-		StateManager.get().setGlobalState("doubleCheckCompletionEnabled", true)
+		StateManager.get().setSessionOverride("doubleCheckCompletionEnabled", true)
 		telemetryService.captureHostEvent("double_check_completion_flag", "true")
 	}
 
 	if (options.autoCondense) {
-		StateManager.get().setGlobalState("useAutoCondense", true)
+		StateManager.get().setSessionOverride("useAutoCondense", true)
 	}
 }
 

--- a/src/core/storage/StateManager.ts
+++ b/src/core/storage/StateManager.ts
@@ -881,12 +881,15 @@ export class StateManager {
 
 	/**
 	 * Helper to get a setting value with override support
-	 * Precedence: remote config > task settings > global settings
+	 * Precedence: remote config > session override > task settings > global settings
 	 */
 	private getSettingWithOverride<K extends keyof Settings>(key: K): Settings[K] {
 		const remoteValue = this.remoteConfigCache[key]
 		if (remoteValue !== undefined) {
 			return remoteValue
+		}
+		if (this.sessionOverrideCache[key] !== undefined) {
+			return this.sessionOverrideCache[key]
 		}
 		const taskValue = this.taskStateCache[key]
 		if (taskValue !== undefined) {


### PR DESCRIPTION
- cli was storing fields to persistent state when it shouldn't be. The
value of these flags should only live for the duration of the CLI
session

<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- For feature requests: Created a discussion in our Feature Requests discussions board https://github.com/cline/cline/discussions/categories/feature-requests and received approval from core maintainers before implementation
- For all changes: Link the associated issue/discussion in the "Related Issue" section below

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly without prior discussion.

Why this requirement?
We deeply appreciate all community contributions - they are essential to Cline's success! To ensure the best use of everyone's time and maintain project direction, we use our Feature Requests discussions board to gauge community interest and validate feature ideas before implementation begins. This helps us focus development efforts on features that will benefit the most users.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** N/A

### Description

CLI flags were storing some values to persistent state when they shouldn't be. This changes uses the StateManager setSessionOverride function to store transient values while the CLI process is alive.

<!-- 
Help reviewers understand your changes by making this PR readable and well-organized:

- What problem does this PR solve?
- Why were these changes introduced and what purpose do they serve?
- For larger changes, provide context about your approach and reasoning

Small PRs may need minimal description, but larger changes benefit from explaining where you're coming from. Much of this context can be in the linked issue above, so feel free to reference it rather than repeating everything here.
-->

### Test Procedure

1. `cline --config ~/.my-test-dir` -- creates a globalState.json file here
1. `cline --config ~/.my-test-dir --thinking 1337 -y "just say hello"` -- verify the `actModeThinkingBudgetTokens` value is unchanged in the globalState.json
1. `cline --config ~/.my-test-dir -m anthropic/sonnet-4.5 -y "just say hello"` -- verify the model value does not change in the globalState.json

<!-- 
Please walk us through your testing approach and thought process. This helps reviewers understand that you've thoroughly considered the impact of your changes:

- How did you test this change?
- What could potentially break and how did you verify it doesn't?
- What existing functionality might be affected and how did you check it still works?
- Why are you confident this is ready for merge?

We're not looking for exhaustive documentation - just evidence that you've thought through the implications of your changes and tested accordingly.
-->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->
