### PR TITLE
fix: add tool-specific error messages for replace_in_file and execute_command

### DIFF
--- a/src/core/prompts/__tests__/toolSpecificMissingParamErrors.test.ts
+++ b/src/core/prompts/__tests__/toolSpecificMissingParamErrors.test.ts
@@ -1,0 +1,67 @@
+import { describe, it } from "mocha"
+import "should"
+import { formatResponse } from "../responses"
+
+describe("formatResponse.replaceInFileMissingDiffError", () => {
+	it("should include the file path in the error message", () => {
+		const result = formatResponse.replaceInFileMissingDiffError("src/index.ts")
+		result.should.containEql("src/index.ts")
+	})
+
+	it("should mention that the diff parameter was empty", () => {
+		const result = formatResponse.replaceInFileMissingDiffError("src/index.ts")
+		result.should.containEql("'diff' parameter was empty")
+	})
+
+	it("should include the SEARCH/REPLACE block format", () => {
+		const result = formatResponse.replaceInFileMissingDiffError("src/index.ts")
+		result.should.containEql("<<<<<<< SEARCH")
+		result.should.containEql("=======")
+		result.should.containEql(">>>>>>> REPLACE")
+	})
+
+	it("should include rules about exact matching", () => {
+		const result = formatResponse.replaceInFileMissingDiffError("src/index.ts")
+		result.should.containEql("match existing file content exactly")
+	})
+
+	it("should suggest using read_file if unsure", () => {
+		const result = formatResponse.replaceInFileMissingDiffError("src/index.ts")
+		result.should.containEql("read_file")
+	})
+
+	it("should NOT include the generic toolUseInstructionsReminder", () => {
+		const result = formatResponse.replaceInFileMissingDiffError("src/index.ts")
+		result.should.not.containEql("Reminder: Instructions for Tool Use")
+	})
+
+	it("should work with different file paths", () => {
+		const result = formatResponse.replaceInFileMissingDiffError("components/App.tsx")
+		result.should.containEql("components/App.tsx")
+	})
+})
+
+describe("formatResponse.executeCommandMissingCommandError", () => {
+	it("should mention that the command parameter was empty", () => {
+		const result = formatResponse.executeCommandMissingCommandError()
+		result.should.containEql("'command' parameter was empty")
+	})
+
+	it("should include a concrete XML example", () => {
+		const result = formatResponse.executeCommandMissingCommandError()
+		result.should.containEql("<execute_command>")
+		result.should.containEql("<command>")
+		result.should.containEql("</command>")
+		result.should.containEql("</execute_command>")
+	})
+
+	it("should include requires_approval in the example", () => {
+		const result = formatResponse.executeCommandMissingCommandError()
+		result.should.containEql("<requires_approval>")
+	})
+
+	it("should NOT include the generic toolUseInstructionsReminder", () => {
+		const result = formatResponse.executeCommandMissingCommandError()
+		result.should.not.containEql("Reminder: Instructions for Tool Use")
+	})
+})

--- a/src/core/prompts/responses.ts
+++ b/src/core/prompts/responses.ts
@@ -96,6 +96,33 @@ Otherwise, if you have not completed the task and do not need additional informa
 		)
 	},
 
+	replaceInFileMissingDiffError: (relPath: string): string => {
+		return (
+			`Failed to edit '${relPath}': The 'diff' parameter was empty.\n\n` +
+			`The diff parameter must contain SEARCH/REPLACE blocks in this format:\n` +
+			"<<<<<<< SEARCH\n" +
+			"exact lines to find\n" +
+			"=======\n" +
+			"replacement lines\n" +
+			">>>>>>> REPLACE\n\n" +
+			`Rules:\n` +
+			`- The SEARCH block must match existing file content exactly (including whitespace and indentation)\n` +
+			`- You can include multiple SEARCH/REPLACE blocks in a single diff parameter\n` +
+			`- If you're unsure of the exact content, use read_file first to see the current file`
+		)
+	},
+
+	executeCommandMissingCommandError: (): string => {
+		return (
+			"The 'command' parameter was empty. Provide the shell command to execute.\n\n" +
+			"Example:\n" +
+			"<execute_command>\n" +
+			"<command>cd /path && python -m pytest tests/</command>\n" +
+			"<requires_approval>false</requires_approval>\n" +
+			"</execute_command>"
+		)
+	},
+
 	invalidMcpToolArgumentError: (serverName: string, toolName: string) =>
 		`Invalid JSON argument used with ${serverName} for ${toolName}. Please retry with a properly formatted JSON argument.`,
 

--- a/src/core/task/tools/handlers/ExecuteCommandToolHandler.ts
+++ b/src/core/task/tools/handlers/ExecuteCommandToolHandler.ts
@@ -100,7 +100,11 @@ export class ExecuteCommandToolHandler implements IFullyManagedTool {
 		// Validate required parameters
 		if (!command) {
 			config.taskState.consecutiveMistakeCount++
-			return await config.callbacks.sayAndCreateMissingParamError(this.name, "command")
+			await config.callbacks.say(
+				"error",
+				"Cline tried to use execute_command without value for required parameter 'command'. Retrying...",
+			)
+			return formatResponse.toolError(formatResponse.executeCommandMissingCommandError())
 		}
 
 		if (!requiresApprovalRaw) {

--- a/src/core/task/tools/handlers/WriteToFileToolHandler.ts
+++ b/src/core/task/tools/handlers/WriteToFileToolHandler.ts
@@ -114,7 +114,12 @@ export class WriteToFileToolHandler implements IFullyManagedTool {
 		if (block.name === "replace_in_file" && !rawDiff) {
 			config.taskState.consecutiveMistakeCount++
 			await config.services.diffViewProvider.reset()
-			return await config.callbacks.sayAndCreateMissingParamError(block.name, "diff")
+			const relPath = rawRelPath || "unknown"
+			await config.callbacks.say(
+				"error",
+				`Cline tried to use replace_in_file for '${relPath}' without value for required parameter 'diff'. Retrying...`,
+			)
+			return formatResponse.toolError(formatResponse.replaceInFileMissingDiffError(relPath))
 		}
 
 		if (block.name === "write_to_file" && !rawContent) {


### PR DESCRIPTION
### Related Issue

Reopened from #9685 (closed in error).

### Description

When the model sends `replace_in_file` without `diff` or `execute_command` without `command`, it gets a generic ~30-line error about XML formatting that doesn't help recovery. In SWE-bench evaluation, 11/182 failures (6%) were caused by the model getting stuck in loops of malformed tool calls that never recover.

This PR adds tool-specific error messages for these two tools (following the existing `writeToFileMissingContentError` pattern):
- **`replace_in_file`** missing `diff` — shows the exact SEARCH/REPLACE block format
- **`execute_command`** missing `command` — shows a concrete XML example

The new messages skip the generic `toolUseInstructionsReminder` boilerplate since the model knows the format but dropped a parameter.

### Test Procedure

- Added 11 unit tests verifying both error messages contain the expected tool-specific guidance and do NOT include the generic boilerplate
- Ran `npm run test:unit` — all new tests pass, no regressions

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore
-   [x] Tests are passing (`npm test`) and code is formatted and linted
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)


Made with [Cursor](https://cursor.com)