### PR TITLE
fix(cli): apply task options in no-prompt welcome startup

### DIFF
--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -9,8 +9,8 @@ import { render } from "ink"
 import React from "react"
 import { ClineEndpoint } from "@/config"
 import type { Controller } from "@/core/controller"
-import { setRuntimeHooksDir } from "@/core/storage/disk"
 import { getHooksEnabledSafe } from "@/core/hooks/hooks-utils"
+import { setRuntimeHooksDir } from "@/core/storage/disk"
 import { StateManager } from "@/core/storage/StateManager"
 import { AuthHandler } from "@/hosts/external/AuthHandler"
 import { HostProvider } from "@/hosts/host-provider"
@@ -907,11 +907,16 @@ async function resumeTask(taskId: string, options: TaskOptions & { initialPrompt
  * Show welcome prompt and wait for user input
  * If auth is not configured, show auth flow first
  */
-async function showWelcome(options: { verbose?: boolean; cwd?: string; config?: string; thinking?: boolean }) {
+async function showWelcome(options: TaskOptions) {
 	const ctx = await initializeCli({ ...options, enableAuth: true })
 
 	// Check if auth is configured
 	const hasAuth = await isAuthConfigured()
+
+	// Apply CLI task options in interactive startup too, so flags like
+	// --auto-approve-all and --yolo affect the initial TUI state.
+	applyTaskOptions(options)
+	await StateManager.get().flushPendingState()
 
 	let hadError = false
 


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

### Description

This PR fixes a bug where CLI flags defined in `TaskOptions` were not consistently applied across interactive startup paths.

The immediate symptom was:

- `cline --auto-approve-all` (no prompt) launched the TUI with auto-approve-all still set to the previously persisted value.

The root cause was path-specific option application:

- Prompted paths (`runTask`, `resumeTask`) call `applyTaskOptions(options)` before rendering.
- No-prompt interactive startup (`showWelcome`) did not call `applyTaskOptions(options)`.

That made `--auto-approve-all` appear flaky, but the issue is broader than a single flag. Any startup-only CLI option routed through `applyTaskOptions` could be skipped in this path, creating inconsistent behavior based only on whether the user passed an initial prompt.

What this changes:

- `showWelcome` now accepts `TaskOptions`.
- `showWelcome` now calls:
  - `applyTaskOptions(options)`
  - `StateManager.get().flushPendingState()`

Why this is a larger correctness fix:

- It restores behavioral parity between all interactive startup entry points.
- It centralizes option application semantics so future flags added to `applyTaskOptions` are not silently ignored in no-prompt startup.
- It prevents state/UI mismatch at mount time where the welcome TUI could render stale values.

Debugging journey and findings:

- Reproduced with `cline --auto-approve-all` and observed welcome footer state did not reflect flag intent.
- Traced startup flow in `cli/src/index.ts`:
  - default command with prompt -> `runTask` -> `applyTaskOptions` (works)
  - default command without prompt -> `showWelcome` (missing call)
- Verified that the flag wiring itself was correct (`setSessionOverride("autoApproveAllToggled", true)`), but unreachable on the no-prompt path.
- Chose the minimal, maintainable fix: call shared option application inside `showWelcome` so behavior remains unified.

Non-obvious gotcha:

- Because the option set is split between session-scoped overrides and persisted globals, missing the shared option-application function can fail silently and only in specific entry paths. This can look like a UI bug but is actually initialization ordering.

Alternatives considered:

- Applying only `autoApproveAllToggled` directly inside `showWelcome`.
  - Rejected because it fixes one symptom and leaves the structural startup inconsistency in place.
- Applying options in the default command action before calling `showWelcome`.
  - Viable, but less robust than handling it in `showWelcome` itself, where the invariant belongs.

### Test Procedure

Local validation performed:

1. Type safety
   - `cd cli && npm run typecheck`
   - Passed.

2. CLI component regression safety
   - `cd cli && npm run test:run -- src/components/ChatView.test.tsx`
   - Passed.

Manual behavior validation target:

1. Start with persisted auto-approve-all disabled.
2. Run `cline --auto-approve-all`.
3. Confirm TUI launches with auto-approve-all enabled immediately.
4. Run plain `cline` after restarting and confirm persisted setting behavior is unchanged (session override is not persisted).

Risk assessment:

- Low risk. Change is constrained to startup option application in one path.
- No model/tool/runtime logic changes.
- Existing prompted paths remain unchanged.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Not applicable. CLI startup behavior fix with no UI layout changes.

### Additional Notes

This is a focused follow-up to the recently merged `--auto-approve-all` work, and it addresses the no-prompt startup path that could skip task-option initialization.
