### PR TITLE
fix: preserve proto field numbers for hyphenated keys and map types

### DIFF
--- a/scripts/generate-state-proto.mjs
+++ b/scripts/generate-state-proto.mjs
@@ -224,15 +224,16 @@ function parseFieldDefinitions(sourceFile, variableName) {
 }
 
 /**
- * Convert snake_case to camelCase for mapping proto fields back to TS keys
- */
-function snakeToCamel(str) {
-	return str.replace(/_([a-z])/g, (_, letter) => letter.toUpperCase())
-}
-
-/**
  * Parse field numbers from an existing proto message definition
- * Returns a map of camelCase field names to their field numbers
+ * Returns a map of snake_case proto field names to their field numbers.
+ *
+ * We key by the proto field name (snake_case) rather than converting back
+ * to camelCase, because the reverse conversion via snakeToCamel() cannot
+ * reconstruct the original key when it contains hyphens (e.g.,
+ * "openai-codex-oauth-credentials" -> proto "openai_codex_oauth_credentials"
+ * -> snakeToCamel gives "openaiCodexOauthCredentials", which doesn't match
+ * the original hyphenated key). Using the proto field name avoids this
+ * ambiguity since toProtoFieldName() is the canonical forward conversion.
  */
 function parseProtoMessageFieldNumbers(protoContent, messageName) {
 	const fieldNumbers = {}
@@ -248,14 +249,15 @@ function parseProtoMessageFieldNumbers(protoContent, messageName) {
 	const messageBody = match[1]
 
 	// Match field definitions: optional/required/repeated type name = number;
-	const fieldRegex = /(?:optional|required|repeated)?\s*\w+\s+(\w+)\s*=\s*(\d+)\s*;/g
+	// Use \w+(?:<[^>]+>)? for the type to handle map<K, V> parameterized types
+	const fieldRegex = /(?:optional|required|repeated)?\s*\w+(?:<[^>]+>)?\s+(\w+)\s*=\s*(\d+)\s*;/g
 	const matches = messageBody.matchAll(fieldRegex)
 
 	for (const fieldMatch of matches) {
 		const snakeName = fieldMatch[1]
 		const fieldNum = Number.parseInt(fieldMatch[2], 10)
-		const camelName = snakeToCamel(snakeName)
-		fieldNumbers[camelName] = fieldNum
+		// Store by proto field name (snake_case) for unambiguous lookup
+		fieldNumbers[snakeName] = fieldNum
 	}
 
 	return fieldNumbers
@@ -281,7 +283,12 @@ async function loadFieldNumbersFromProto() {
 }
 
 /**
- * Assign field numbers, preserving existing assignments and adding new ones
+ * Assign field numbers, preserving existing assignments and adding new ones.
+ *
+ * existingNumbers is keyed by proto field name (snake_case), so we convert
+ * each field's name to its proto field name via toProtoFieldName() for lookup.
+ * This correctly handles keys with hyphens (e.g., "openai-codex-oauth-credentials")
+ * that become "openai_codex_oauth_credentials" in the proto file.
  */
 function assignFieldNumbers(fields, existingNumbers, startNumber = 1) {
 	const result = {}
@@ -296,8 +303,9 @@ function assignFieldNumbers(fields, existingNumbers, startNumber = 1) {
 
 	// Preserve existing assignments
 	for (const field of fields) {
-		if (existingNumbers[field.name] !== undefined) {
-			result[field.name] = existingNumbers[field.name]
+		const protoName = toProtoFieldName(field.name)
+		if (existingNumbers[protoName] !== undefined) {
+			result[field.name] = existingNumbers[protoName]
 		}
 	}
 


### PR DESCRIPTION
## Related Issue

Fixes #9593

## Summary

The `generate-state-proto.mjs` script was silently reassigning proto field numbers on every run for two categories of fields, breaking proto backward compatibility:

1. **Hyphenated keys** (e.g., `openai-codex-oauth-credentials`): The script converted proto snake_case names back to camelCase via `snakeToCamel()`, producing `openaiCodexOauthCredentials` — which doesn't match the original hyphenated key `openai-codex-oauth-credentials`. The field was treated as new each run.

2. **Map types** (e.g., `map<string, string> open_ai_headers`): The field regex used `\w+` for the type, which can't match parameterized types. The field was silently skipped when reading existing numbers.

**Before (bug):** Running the script always changed `openai_codex_oauth_credentials` from field 48 → 49 and `open_ai_headers` from 177 → 182.

**After (fix):** Both field numbers are correctly preserved. The script is idempotent.

## Changes

- Key the existing field number map by proto field name (snake_case) instead of attempting a lossy reverse conversion to camelCase
- Use `toProtoFieldName()` as the canonical forward conversion for lookups in `assignFieldNumbers()`
- Update the field regex to `\w+(?:<[^>]+>)?` to handle `map<K, V>` parameterized types
- Remove unused `snakeToCamel()` function

## Test Procedure

```bash
# Before fix: proto file changes every run
node scripts/generate-state-proto.mjs
git diff proto/cline/state.proto  # shows field number changes

# After fix: proto file is unchanged
node scripts/generate-state-proto.mjs
git diff proto/cline/state.proto  # no changes

# Run again to verify idempotency
node scripts/generate-state-proto.mjs
git diff proto/cline/state.proto  # still no changes
```

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Disclosure

This PR was autonomously authored by an AI (Claude Opus 4.6, Anthropic) as part of a transparent initiative to demonstrate AI contributions to open-source projects. No human is being impersonated. See https://github.com/anthropics/claude-code for details.