### PR TITLE
fix: enable parallel tool calling for Gemini 3 on OpenRouter

### DIFF
--- a/cli/src/components/SettingsPanelContent.tsx
+++ b/cli/src/components/SettingsPanelContent.tsx
@@ -119,7 +119,7 @@ const FEATURE_SETTINGS = {
 	},
 	parallelToolCalling: {
 		stateKey: "enableParallelToolCalling",
-		default: false,
+		default: true,
 		label: "Parallel tool calling",
 		description: "Allow multiple tools in a single response",
 	},

--- a/src/core/api/transform/openrouter-stream.ts
+++ b/src/core/api/transform/openrouter-stream.ts
@@ -193,7 +193,7 @@ export async function createOpenRouterStream(
 		...(openRouterProviderSorting && !providerPreferences ? { provider: { sort: openRouterProviderSorting } } : {}),
 		...(providerPreferences ? { provider: providerPreferences } : {}),
 		...(isClaude1m ? { provider: { order: ["anthropic", "google-vertex/global"], allow_fallbacks: false } } : {}),
-		...getOpenAIToolParams(tools),
+		...getOpenAIToolParams(tools, model.id.startsWith("google/gemini-3")),
 	}
 
 	// @ts-expect-error-next-line


### PR DESCRIPTION
### Related Issue

Gemini 3 Flash never uses parallel tool calls when routed through OpenRouter, despite the model being capable of it.

### Description

Two bugs prevented parallel tool calling for Gemini 3 on OpenRouter:

1. **API flag bug** (`openrouter-stream.ts`): `getOpenAIToolParams(tools)` was called without the `enableParallelToolCalls` argument, defaulting `parallel_tool_calls` to `false` in every OpenRouter request. Fixed by passing `true` for `google/gemini-3*` models.

2. **CLI prompt language bug** (`SettingsPanelContent.tsx`): The CLI set `enableParallelToolCalling` default to `false` (vs `true` in the extension's `state-keys.ts`). This caused the system prompt to say *"You should use a single tool at a time and wait for the result"* instead of the parallel-encouraging variant. Fixed by matching the extension default.

### Evidence

**Before fix**: Across 12,227 assistant turns in SWE-bench runs, only 0.44% had any real parallel tool calls. The model was explicitly told to go serial by both the API flag and the prompt.

**After fix** (local test): Gemini 3 Flash via OpenRouter emits multiple `readFile` calls in a single turn:
```
turn 0: ['listFilesTopLevel']
turn 2: ['readFile']
turn 3: ['readFile', 'readFile'] <<< PARALLEL
```

**API-level proof**: Direct OpenRouter API calls with `parallel_tool_calls: true` and Gemini 3 Flash return 3 parallel tool calls regardless of the flag value — the model is capable, it just wasn't being asked.

### Test Procedure

```bash
cd /tmp/test && mkdir -p src
echo 'def auth(): pass' > src/auth.py
echo 'class User: pass' > src/models.py  
echo 'def routes(): pass' > src/routes.py

npm run compile && npm run cli:link
cline auth --provider openrouter --apikey "$KEY" --modelid "google/gemini-3-flash-preview"
cline -y --verbose --json -- 'Read all 3 files in src/ in parallel'
# Observe multiple readFile calls in same conversationHistoryIndex
```

### Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

### Pre-flight Checklist

- [x] Changes are limited to a single feature, bugfix or chore
- [ ] Tests are passing (`npm test`)
- [ ] I have created a changeset using `npm run changeset`
- [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Additional Notes

- This is a minimal, targeted fix — only 2 lines changed across 2 files
- The extension UI already defaults `enableParallelToolCalling` to `true`; this PR aligns the CLI
- Whether Gemini actually *uses* parallel calls in complex SWE-bench scenarios (21 tools, long context) is still being validated — but at minimum, the API and prompt should not actively prevent it