### PR TITLE
test: rebaseline vertex_gemini3.tools.snap

### DIFF
--- a/src/core/prompts/system-prompt/__tests__/__snapshots__/vertex_gemini3.tools.snap
+++ b/src/core/prompts/system-prompt/__tests__/__snapshots__/vertex_gemini3.tools.snap
@@ -151,7 +151,7 @@
       "properties": {
         "path": {
           "type": "STRING",
-          "description": "The path of the directory (relative to the current working directory {{CWD}}){{MULTI_ROOT_HINT}} to list top level source code definitions for."
+          "description": "The path of a directory (not a file) relative to the current working directory {{CWD}}{{MULTI_ROOT_HINT}}. Lists definitions across all source files in that directory. To inspect a single file, use read_file instead."
         },
         "task_progress": {
           "type": "STRING",


### PR DESCRIPTION
Commit 55569efb7 (`fix(tools): prevent crash when list_files/list_code_definition_names receives a file path`) changed the `list_code_definition_names` path parameter description but did not update the snapshot baseline, causing `vertex_gemini3.tools.snap` to fail on every PR.

```
npm run test:unit -- --update-snapshots
```