### PR TITLE
fix(cli): prevent startup prompt replay on resize remount

### DIFF
--- a/cli/src/components/App.resize-initial-prompt.test.tsx
+++ b/cli/src/components/App.resize-initial-prompt.test.tsx
@@ -1,0 +1,79 @@
+import { Text } from "ink"
+import { render } from "ink-testing-library"
+import React from "react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { App } from "./App"
+
+vi.mock("./ChatView", () => ({
+	ChatView: ({ controller, initialPrompt, initialImages }: any) => {
+		React.useEffect(() => {
+			if (initialPrompt || (initialImages && initialImages.length > 0)) {
+				controller?.initTask(initialPrompt || "", initialImages)
+			}
+		}, [])
+
+		return React.createElement(Text, null, "ChatView")
+	},
+}))
+
+vi.mock("./TaskJsonView", () => ({
+	TaskJsonView: () => React.createElement(Text, null, "TaskJsonView"),
+}))
+
+vi.mock("./HistoryView", () => ({
+	HistoryView: () => React.createElement(Text, null, "HistoryView"),
+}))
+
+vi.mock("./ConfigView", () => ({
+	ConfigView: () => React.createElement(Text, null, "ConfigView"),
+}))
+
+vi.mock("./AuthView", () => ({
+	AuthView: () => React.createElement(Text, null, "AuthView"),
+}))
+
+vi.mock("../context/TaskContext", () => ({
+	TaskContextProvider: ({ children }: any) => children,
+}))
+
+vi.mock("../context/StdinContext", () => ({
+	StdinProvider: ({ children }: any) => children,
+}))
+
+describe("App startup prompt resize behavior", () => {
+	beforeEach(() => {
+		vi.useFakeTimers()
+	})
+
+	afterEach(() => {
+		vi.useRealTimers()
+		vi.restoreAllMocks()
+	})
+
+	it("does not replay initialPrompt after a real terminal resize event", async () => {
+		const initTask = vi.fn()
+		const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(((...args: any[]) => {
+			const callback = args.find((arg) => typeof arg === "function")
+			if (callback) {
+				callback()
+			}
+			return true
+		}) as any)
+
+		const { unmount } = render(
+			<App controller={{ initTask }} initialPrompt="hello" isRawModeSupported={true} view="welcome" />,
+		)
+
+		await vi.advanceTimersByTimeAsync(0)
+		expect(initTask).toHaveBeenCalledTimes(1)
+
+		process.stdout.emit("resize")
+		await vi.advanceTimersByTimeAsync(350)
+		await vi.advanceTimersByTimeAsync(0)
+
+		expect(initTask).toHaveBeenCalledTimes(1)
+		expect(writeSpy).toHaveBeenCalled()
+
+		unmount()
+	})
+})

--- a/cli/src/components/App.tsx
+++ b/cli/src/components/App.tsx
@@ -4,7 +4,7 @@
  */
 
 import { Box, useApp } from "ink"
-import React, { ReactNode, useCallback, useState } from "react"
+import React, { ReactNode, useCallback, useEffect, useState } from "react"
 import { StdinProvider } from "../context/StdinContext"
 import { TaskContextProvider } from "../context/TaskContext"
 import { useTerminalSize } from "../hooks/useTerminalSize"
@@ -146,6 +146,17 @@ const InternalApp: React.FC<AppProps> = ({
 	const { resizeKey } = useTerminalSize()
 	const [currentView, setCurrentView] = useState<ViewType>(initialView)
 	const [selectedTaskId, setSelectedTaskId] = useState<string | undefined>(taskId)
+	const [pendingInitialPrompt, setPendingInitialPrompt] = useState<string | undefined>(initialPrompt)
+	const [pendingInitialImages, setPendingInitialImages] = useState<string[] | undefined>(initialImages)
+
+	useEffect(() => {
+		if (!pendingInitialPrompt && (!pendingInitialImages || pendingInitialImages.length === 0)) {
+			return
+		}
+
+		setPendingInitialPrompt(undefined)
+		setPendingInitialImages(undefined)
+	}, [pendingInitialPrompt, pendingInitialImages])
 
 	const handleSelectTask = useCallback((taskId: string) => {
 		setSelectedTaskId(taskId)
@@ -253,8 +264,8 @@ const InternalApp: React.FC<AppProps> = ({
 					) : (
 						<ChatView
 							controller={controller}
-							initialImages={initialImages}
-							initialPrompt={initialPrompt}
+							initialImages={pendingInitialImages}
+							initialPrompt={pendingInitialPrompt}
 							onComplete={onComplete}
 							onError={onError}
 							onExit={onWelcomeExit}


### PR DESCRIPTION
### Related Issue

Issue: N/A

### Description

This fixes a CLI TUI regression where `cline \"prompt\"` restarted the task after terminal resize.

Root cause:
- `useTerminalSize` increments `resizeKey` after a real `process.stdout` resize event.
- `App` remounts keyed content on resize.
- `ChatView` runs mount-only startup auto-submit effect.
- `initialPrompt` and `initialImages` were still being passed on remount, so `controller.initTask(...)` replayed.

Why interactive typed prompts did not restart:
- typed prompts are not persistent startup props after first submit.
- only CLI startup props were being re-sent on remount.

Fix approach:
- make startup prompt and images one-shot in `App` via local pending state.
- clear pending startup values after first mount so later resize remounts do not replay.

Added regression coverage:
- new test `App.resize-initial-prompt.test.tsx` emits a real `process.stdout` `resize` event.
- verifies startup `initTask` runs once and is not called again after resize debounce/remount.

### Test Procedure

Ran:
- `npm -C cli run typecheck`
- `npm -C cli run test:run -- src/components/App.test.tsx src/components/App.resize-initial-prompt.test.tsx`
- `npx --yes biome check --diagnostic-level=error --files-ignore-unknown=true cli/src/components/App.tsx cli/src/components/App.resize-initial-prompt.test.tsx`

Manual behavior validation target for reviewers:
1. run `cline \"hello\"`
2. let task start
3. resize terminal
4. confirm UI reflows only and task does not restart

### Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ♻️ Refactor Changes
- [ ] 💅 Cosmetic Changes
- [ ] 📚 Documentation update
- [ ] 🏃 Workflow Changes

### Pre-flight Checklist

- [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
- [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
- [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A

### Additional Notes

The previous attempted fix focused on remount behavior in `ChatView`, but this patch fixes the source of replay by consuming startup inputs one time at the `App` boundary where props are threaded into `ChatView`.