### PR TITLE
fix(cli): remount TUI only on width resize

### DIFF
--- a/cli/src/components/App.resize-initial-prompt.test.tsx
+++ b/cli/src/components/App.resize-initial-prompt.test.tsx
@@ -4,6 +4,26 @@ import React from "react"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import { App } from "./App"
 
+const CLEAR_SEQUENCE = "\x1b[2J\x1b[3J\x1b[H"
+
+function setTerminalSize(columns: number, rows: number) {
+	Object.defineProperty(process.stdout, "columns", {
+		configurable: true,
+		writable: true,
+		value: columns,
+	})
+
+	Object.defineProperty(process.stdout, "rows", {
+		configurable: true,
+		writable: true,
+		value: rows,
+	})
+}
+
+function hasClearSequenceCall(calls: unknown[][]): boolean {
+	return calls.some((call) => call[0] === CLEAR_SEQUENCE)
+}
+
 vi.mock("./ChatView", () => ({
 	ChatView: ({ controller, initialPrompt, initialImages }: any) => {
 		React.useEffect(() => {
@@ -48,10 +68,14 @@ describe("App startup prompt resize behavior", () => {
 	afterEach(() => {
 		vi.useRealTimers()
 		vi.restoreAllMocks()
+		delete (process.stdout as any).columns
+		delete (process.stdout as any).rows
 	})
 
-	it("does not replay initialPrompt after a real terminal resize event", async () => {
+	it("does not replay initialPrompt after a width resize", async () => {
 		const initTask = vi.fn()
+		setTerminalSize(120, 40)
+
 		const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(((...args: any[]) => {
 			const callback = args.find((arg) => typeof arg === "function")
 			if (callback) {
@@ -66,13 +90,46 @@ describe("App startup prompt resize behavior", () => {
 
 		await vi.advanceTimersByTimeAsync(0)
 		expect(initTask).toHaveBeenCalledTimes(1)
+		writeSpy.mockClear()
 
+		setTerminalSize(121, 40)
 		process.stdout.emit("resize")
 		await vi.advanceTimersByTimeAsync(350)
 		await vi.advanceTimersByTimeAsync(0)
 
 		expect(initTask).toHaveBeenCalledTimes(1)
-		expect(writeSpy).toHaveBeenCalled()
+		expect(hasClearSequenceCall(writeSpy.mock.calls as unknown[][])).toBe(true)
+
+		unmount()
+	})
+
+	it("does not remount on height-only resize", async () => {
+		const initTask = vi.fn()
+		setTerminalSize(120, 40)
+
+		const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(((...args: any[]) => {
+			const callback = args.find((arg) => typeof arg === "function")
+			if (callback) {
+				callback()
+			}
+			return true
+		}) as any)
+
+		const { unmount } = render(
+			<App controller={{ initTask }} initialPrompt="hello" isRawModeSupported={true} view="welcome" />,
+		)
+
+		await vi.advanceTimersByTimeAsync(0)
+		expect(initTask).toHaveBeenCalledTimes(1)
+		writeSpy.mockClear()
+
+		setTerminalSize(120, 45)
+		process.stdout.emit("resize")
+		await vi.advanceTimersByTimeAsync(350)
+		await vi.advanceTimersByTimeAsync(0)
+
+		expect(initTask).toHaveBeenCalledTimes(1)
+		expect(hasClearSequenceCall(writeSpy.mock.calls as unknown[][])).toBe(false)
 
 		unmount()
 	})

--- a/cli/src/hooks/useTerminalSize.ts
+++ b/cli/src/hooks/useTerminalSize.ts
@@ -26,6 +26,9 @@ import { useCallback, useEffect, useRef, useState } from "react"
  *    to unmount and remount everything from scratch. This resets Ink's internal tracking
  *    AND re-renders Static content since the components are brand new instances.
  *
+ * We only run this full recovery when terminal width changes. Height-only resizes do not
+ * affect wrapping in the same way and should not restart the task view.
+ *
  * Gemini CLI does the same thing in AppContainer.tsx: debounce 300ms, then
  * stdout.write(ansiEscapes.clearTerminal) + setHistoryRemountKey(prev => prev + 1).
  *
@@ -41,6 +44,8 @@ export function useTerminalSize() {
 	})
 	const [resizeKey, setResizeKey] = useState(0)
 	const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+	const previousColumnsRef = useRef(process.stdout.columns || 80)
+	const pendingWidthRefreshRef = useRef(false)
 
 	const refreshAfterResize = useCallback(() => {
 		// Clear terminal + scrollback to wipe stale content from old width
@@ -56,17 +61,33 @@ export function useTerminalSize() {
 
 	useEffect(() => {
 		function updateSize() {
+			const nextColumns = process.stdout.columns || 80
+			const nextRows = process.stdout.rows || 24
+			const didWidthChange = nextColumns !== previousColumnsRef.current
+			previousColumnsRef.current = nextColumns
+
 			setSize({
-				columns: process.stdout.columns || 80,
-				rows: process.stdout.rows || 24,
+				columns: nextColumns,
+				rows: nextRows,
 			})
+
+			if (didWidthChange) {
+				pendingWidthRefreshRef.current = true
+			}
+
+			if (!pendingWidthRefreshRef.current) {
+				return
+			}
 
 			// Debounce: wait 300ms after last resize event to do full recovery
 			if (debounceRef.current) {
 				clearTimeout(debounceRef.current)
 			}
 			debounceRef.current = setTimeout(() => {
-				refreshAfterResize()
+				if (pendingWidthRefreshRef.current) {
+					refreshAfterResize()
+					pendingWidthRefreshRef.current = false
+				}
 				debounceRef.current = null
 			}, 300)
 		}
@@ -76,6 +97,7 @@ export function useTerminalSize() {
 			if (debounceRef.current) {
 				clearTimeout(debounceRef.current)
 			}
+			pendingWidthRefreshRef.current = false
 		}
 	}, [refreshAfterResize])
 


### PR DESCRIPTION
### Related Issue

Issue: N/A

### Description

This fixes a follow-up CLI TUI behavior issue after the startup-prompt replay fix.

Current behavior before this change:
- Any terminal resize event triggered the full recovery path in `useTerminalSize`
- The recovery path clears the terminal and forces a remount via `resizeKey`
- This was needed for width changes, but it also ran on height-only changes

Problem with that behavior:
- Width changes alter wrapping, so Ink's tracked output height can go stale and the remount is useful
- Height-only changes do not change wrapping width, so forcing a remount is unnecessary and causes visible task restart-like churn

What this PR changes:
- `useTerminalSize` now tracks previous `columns`
- It sets a pending recovery flag only when width actually changes
- Height-only resize events still update `rows` reactively, but do not trigger clear + remount
- Debounce behavior remains the same for width changes

I also expanded the regression test to reflect runtime behavior more accurately:
- Added helpers to control `process.stdout.columns` and `rows` in tests
- Updated the existing resize test to explicitly verify width change triggers the clear sequence
- Added a new test that verifies height-only resize does not trigger the clear sequence or remount path

### Test Procedure

Ran:
- `npm -C cli run test:run -- src/components/App.resize-initial-prompt.test.tsx`
- `npm -C cli run typecheck`
- `npx --yes biome check --diagnostic-level=error --files-ignore-unknown=true cli/src/hooks/useTerminalSize.ts cli/src/components/App.resize-initial-prompt.test.tsx`

Manual check:
1. Start `cline "prompt"`
2. Resize terminal height only
3. Confirm no full reload/remount behavior
4. Resize terminal width
5. Confirm recovery path still runs and rendering remains correct

### Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ♻️ Refactor Changes
- [ ] 💅 Cosmetic Changes
- [ ] 📚 Documentation update
- [ ] 🏃 Workflow Changes

### Pre-flight Checklist

- [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
- [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
- [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A

### Additional Notes

This keeps the width-resize protection that addresses Ink rendering artifacts while removing unnecessary remounts on height-only resizes.
