### PR TITLE
Fix failing `listFiles` unit test on Windows

### DIFF
--- a/src/services/glob/__tests__/list-files.test.ts
+++ b/src/services/glob/__tests__/list-files.test.ts
@@ -5,6 +5,10 @@ import * as path from "path"
 import "should"
 import { listFiles } from "../list-files"
 
+function normalizeForComparison(value: string): string {
+	return path.normalize(value)
+}
+
 describe("listFiles", () => {
 	const tmpDir = path.join(os.tmpdir(), `cline-list-files-test-${Math.random().toString(36).slice(2)}`)
 
@@ -30,6 +34,6 @@ describe("listFiles", () => {
 
 		const [files] = await listFiles(tmpDir, false, 200)
 
-		files.should.containEql(nestedFile)
+		files.map(normalizeForComparison).should.containEql(normalizeForComparison(nestedFile))
 	})
 })


### PR DESCRIPTION
### Related Issue

**Issue:** n/a

### Description

This PR fixes a failing unit test on Windows:
```
  1181 passing (50s)
  5 pending
  1 failing

  1) listFiles
       still lists files when cwd points to a directory:
     AssertionError: expected Array [
  'C:/Users/RUNNER~1/AppData/Local/Temp/cline-list-files-test-ntbrk5kwb1/index.ts',
  'C:/Users/RUNNER~1/AppData/Local/Temp/cline-list-files-test-ntbrk5kwb1/single-file.ts'
] to contain 'C:\\Users\\RUNNER~1\\AppData\\Local\\Temp\\cline-list-files-test-ntbrk5kwb1\\index.ts'
      at Assertion.fail (node_modules\should\cjs\should.js:275:17)
      at Assertion.value [as containEql] (node_modules\should\cjs\should.js:356:19)
      at Context.<anonymous> (src\services\glob\__tests__\list-files.test.ts:33:16)
```


### Test Procedure

Run the tests in a Windows environment.  I'm doing so in Windows 11 on my mac via Parallels.  This will also get run in CI on Windows hosts.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

n/a

### Additional Notes

n/a