### PR TITLE
fix: read cache_creation_input_tokens for cache write tokens in providers

### DIFF
--- a/src/core/api/providers/cline.ts
+++ b/src/core/api/providers/cline.ts
@@ -15,6 +15,7 @@ import type { ApiHandler, CommonApiHandlerOptions } from "../"
 import { withRetry } from "../retry"
 import { createOpenRouterStream } from "../transform/openrouter-stream"
 import type { ApiStream, ApiStreamUsageChunk } from "../transform/stream"
+import { parseOpenAIStreamingUsage } from "../transform/stream"
 import { ToolCallProcessor } from "../transform/tool-call-processor"
 import type { OpenRouterErrorResponse } from "./types"
 
@@ -214,10 +215,7 @@ export class ClineHandler implements ApiHandler {
 
 					yield {
 						type: "usage",
-						cacheWriteTokens: 0,
-						cacheReadTokens: chunk.usage.prompt_tokens_details?.cached_tokens || 0,
-						inputTokens: (chunk.usage.prompt_tokens || 0) - (chunk.usage.prompt_tokens_details?.cached_tokens || 0),
-						outputTokens: chunk.usage.completion_tokens || 0,
+						...parseOpenAIStreamingUsage(chunk.usage as Parameters<typeof parseOpenAIStreamingUsage>[0]),
 						totalCost,
 					}
 					didOutputUsage = true

--- a/src/core/api/providers/openrouter.ts
+++ b/src/core/api/providers/openrouter.ts
@@ -11,7 +11,7 @@ import { Logger } from "@/shared/services/Logger"
 import { ApiHandler, CommonApiHandlerOptions } from "../"
 import { withRetry } from "../retry"
 import { createOpenRouterStream } from "../transform/openrouter-stream"
-import { ApiStream, ApiStreamUsageChunk, parseOpenAIStreamingUsage } from "../transform/stream"
+import { ApiStream, ApiStreamUsageChunk } from "../transform/stream"
 import { ToolCallProcessor } from "../transform/tool-call-processor"
 import { OpenRouterErrorResponse } from "./types"
 
@@ -154,7 +154,10 @@ export class OpenRouterHandler implements ApiHandler {
 			if (!didOutputUsage && chunk.usage) {
 				yield {
 					type: "usage",
-					...parseOpenAIStreamingUsage(chunk.usage as Parameters<typeof parseOpenAIStreamingUsage>[0]),
+					cacheWriteTokens: 0,
+					cacheReadTokens: chunk.usage.prompt_tokens_details?.cached_tokens || 0,
+					inputTokens: (chunk.usage.prompt_tokens || 0) - (chunk.usage.prompt_tokens_details?.cached_tokens || 0),
+					outputTokens: chunk.usage.completion_tokens || 0,
 					// @ts-expect-error-next-line
 					totalCost: (chunk.usage.cost || 0) + (chunk.usage.cost_details?.upstream_inference_cost || 0),
 				}

--- a/src/core/api/providers/openrouter.ts
+++ b/src/core/api/providers/openrouter.ts
@@ -11,7 +11,7 @@ import { Logger } from "@/shared/services/Logger"
 import { ApiHandler, CommonApiHandlerOptions } from "../"
 import { withRetry } from "../retry"
 import { createOpenRouterStream } from "../transform/openrouter-stream"
-import { ApiStream, ApiStreamUsageChunk } from "../transform/stream"
+import { ApiStream, ApiStreamUsageChunk, parseOpenAIStreamingUsage } from "../transform/stream"
 import { ToolCallProcessor } from "../transform/tool-call-processor"
 import { OpenRouterErrorResponse } from "./types"
 
@@ -154,10 +154,7 @@ export class OpenRouterHandler implements ApiHandler {
 			if (!didOutputUsage && chunk.usage) {
 				yield {
 					type: "usage",
-					cacheWriteTokens: 0,
-					cacheReadTokens: chunk.usage.prompt_tokens_details?.cached_tokens || 0,
-					inputTokens: (chunk.usage.prompt_tokens || 0) - (chunk.usage.prompt_tokens_details?.cached_tokens || 0),
-					outputTokens: chunk.usage.completion_tokens || 0,
+					...parseOpenAIStreamingUsage(chunk.usage as Parameters<typeof parseOpenAIStreamingUsage>[0]),
 					// @ts-expect-error-next-line
 					totalCost: (chunk.usage.cost || 0) + (chunk.usage.cost_details?.upstream_inference_cost || 0),
 				}

--- a/src/core/api/providers/vercel-ai-gateway.ts
+++ b/src/core/api/providers/vercel-ai-gateway.ts
@@ -7,7 +7,7 @@ import { createOpenAIClient } from "@/shared/net"
 import { Logger } from "@/shared/services/Logger"
 import { ApiHandler, CommonApiHandlerOptions } from "../index"
 import { withRetry } from "../retry"
-import { ApiStream } from "../transform/stream"
+import { ApiStream, parseOpenAIStreamingUsage } from "../transform/stream"
 import { ToolCallProcessor } from "../transform/tool-call-processor"
 import { createVercelAIGatewayStream } from "../transform/vercel-ai-gateway-stream"
 
@@ -113,15 +113,12 @@ export class VercelAIGatewayHandler implements ApiHandler {
 				}
 
 				if (!didOutputUsage && chunk.usage) {
-					// @ts-expect-error - Vercel AI Gateway extends OpenAI types
+					// @ts-expect-error - Vercel AI Gateway extends OpenAI types with Anthropic/provider-specific fields
 					const totalCost = (chunk.usage.cost || 0) + (chunk.usage.cost_details?.upstream_inference_cost || 0)
 
 					yield {
 						type: "usage",
-						cacheWriteTokens: 0,
-						cacheReadTokens: chunk.usage.prompt_tokens_details?.cached_tokens || 0,
-						inputTokens: (chunk.usage.prompt_tokens || 0) - (chunk.usage.prompt_tokens_details?.cached_tokens || 0),
-						outputTokens: chunk.usage.completion_tokens || 0,
+						...parseOpenAIStreamingUsage(chunk.usage as Parameters<typeof parseOpenAIStreamingUsage>[0]),
 						totalCost,
 					}
 					didOutputUsage = true

--- a/src/core/api/transform/stream.ts
+++ b/src/core/api/transform/stream.ts
@@ -118,7 +118,7 @@ export function parseOpenAIStreamingUsage(usage: {
 	return {
 		cacheWriteTokens,
 		cacheReadTokens,
-		inputTokens: (usage.prompt_tokens || 0) - cacheReadTokens - cacheWriteTokens,
+		inputTokens: Math.max(0, (usage.prompt_tokens || 0) - cacheReadTokens - cacheWriteTokens),
 		outputTokens: usage.completion_tokens || 0,
 	}
 }

--- a/src/core/api/transform/stream.ts
+++ b/src/core/api/transform/stream.ts
@@ -96,3 +96,29 @@ export interface ApiStreamThinkingChunk {
 	 */
 	id?: string
 }
+
+/**
+ * Parses cache token fields from an OpenAI-compatible streaming usage object.
+ *
+ * OpenAI's `CompletionUsage` type doesn't include Anthropic-specific fields like
+ * `cache_creation_input_tokens`, but providers (OpenRouter, Cline, Vercel AI Gateway)
+ * pass them through for Anthropic models. This helper extracts those fields and
+ * computes the non-cached input token count.
+ */
+export function parseOpenAIStreamingUsage(usage: {
+	prompt_tokens?: number
+	completion_tokens?: number
+	prompt_tokens_details?: { cached_tokens?: number }
+	// Anthropic-specific field for cache writes, not in OpenAI types
+	cache_creation_input_tokens?: number
+}): Pick<ApiStreamUsageChunk, "cacheWriteTokens" | "cacheReadTokens" | "inputTokens" | "outputTokens"> {
+	const cacheWriteTokens = usage.cache_creation_input_tokens || 0
+	const cacheReadTokens = usage.prompt_tokens_details?.cached_tokens || 0
+
+	return {
+		cacheWriteTokens,
+		cacheReadTokens,
+		inputTokens: (usage.prompt_tokens || 0) - cacheReadTokens - cacheWriteTokens,
+		outputTokens: usage.completion_tokens || 0,
+	}
+}


### PR DESCRIPTION
### Related Issue

**Issue:** ENG-1607

### Description

Three OpenAI-compatible providers (`cline.ts`, `openrouter.ts`, `vercel-ai-gateway.ts`) were hardcoding `cacheWriteTokens: 0` and not reading `cache_creation_input_tokens` from the Anthropic-specific usage response fields. This caused cache write tokens to be misreported as regular input tokens in telemetry and the UI.

**Changes:**
- **`src/core/api/transform/stream.ts`**: Added `parseOpenAIStreamingUsage()` — a shared helper that reads `cache_creation_input_tokens` (Anthropic cache writes), `prompt_tokens_details.cached_tokens` (cache reads), and computes non-cached `inputTokens = prompt_tokens - cacheReadTokens - cacheWriteTokens`
- **3 providers**: Replaced duplicated inline cache parsing with `...parseOpenAIStreamingUsage(chunk.usage)`. Each provider still handles its own `totalCost` calculation since that varies.

### Test Procedure

- Verified against Vercel AI Gateway dashboard: `tokensIn=3` matches "Input: 3", `cacheWriteTokens=649` matches "Cache Write: 649", `cacheReadTokens=53429` matches "Cache Read: 53K"
- Unit tests pass: `npm run test:unit -- --grep "TelemetryService|VercelAIGateway|OpenRouter"` (19 passing)
- `npm run compile` succeeds with no errors

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [x] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A — backend-only change.

### Additional Notes

The `parseOpenAIStreamingUsage()` helper is intentionally scoped to just these three providers. Other providers (Anthropic, Vertex, LiteLLM, etc.) use provider-specific SDK types and different field names (`prompt_cache_miss_tokens` for DeepSeek, etc.), so they handle usage inline per the existing convention.
