### PR TITLE
fix(gemini): cap Flash output tokens at 8192 across providers

### DIFF
--- a/src/core/api/providers/__tests__/gemini.test.ts
+++ b/src/core/api/providers/__tests__/gemini.test.ts
@@ -1,0 +1,77 @@
+import "should"
+import sinon from "sinon"
+import { GeminiHandler } from "../gemini"
+
+describe("GeminiHandler", () => {
+	afterEach(() => {
+		sinon.restore()
+	})
+
+	const createAsyncIterable = (data: any[] = []) => ({
+		[Symbol.asyncIterator]: async function* () {
+			yield* data
+		},
+	})
+
+	it("caps maxOutputTokens to 8192 for Flash models", async () => {
+		const handler = new GeminiHandler({
+			geminiApiKey: "test-api-key",
+			apiModelId: "gemini-2.5-flash",
+		})
+
+		const generateContentStream = sinon.stub().resolves(
+			createAsyncIterable([
+				{
+					responseId: "resp-1",
+					usageMetadata: {
+						promptTokenCount: 10,
+						candidatesTokenCount: 20,
+						cachedContentTokenCount: 0,
+						thoughtsTokenCount: 0,
+					},
+				},
+			]),
+		)
+		sinon.stub(handler as any, "ensureClient").returns({
+			models: { generateContentStream },
+		} as any)
+
+		for await (const _chunk of handler.createMessage("system", [{ role: "user", content: "hi" }] as any)) {
+			// Consume stream to trigger request execution.
+		}
+
+		const requestArgs = generateContentStream.firstCall.args[0] as Record<string, any>
+		requestArgs.config.should.have.property("maxOutputTokens", 8_192)
+	})
+
+	it("does not set maxOutputTokens for non-Flash models", async () => {
+		const handler = new GeminiHandler({
+			geminiApiKey: "test-api-key",
+			apiModelId: "gemini-2.5-pro",
+		})
+
+		const generateContentStream = sinon.stub().resolves(
+			createAsyncIterable([
+				{
+					responseId: "resp-2",
+					usageMetadata: {
+						promptTokenCount: 10,
+						candidatesTokenCount: 20,
+						cachedContentTokenCount: 0,
+						thoughtsTokenCount: 0,
+					},
+				},
+			]),
+		)
+		sinon.stub(handler as any, "ensureClient").returns({
+			models: { generateContentStream },
+		} as any)
+
+		for await (const _chunk of handler.createMessage("system", [{ role: "user", content: "hi" }] as any)) {
+			// Consume stream to trigger request execution.
+		}
+
+		const requestArgs = generateContentStream.firstCall.args[0] as Record<string, any>
+		requestArgs.config.should.not.have.property("maxOutputTokens")
+	})
+})

--- a/src/core/api/providers/gemini.ts
+++ b/src/core/api/providers/gemini.ts
@@ -9,6 +9,7 @@ import {
 	ThinkingLevel,
 } from "@google/genai"
 import { GeminiModelId, geminiDefaultModelId, geminiModels, ModelInfo } from "@shared/api"
+import { GEMINI_FLASH_MAX_OUTPUT_TOKENS, isGeminiFlashModel } from "@utils/model-utils"
 import { buildExternalBasicHeaders } from "@/services/EnvUtils"
 import { telemetryService } from "@/services/telemetry"
 import { ClineStorageMessage } from "@/shared/messages/content"
@@ -43,6 +44,18 @@ function mapReasoningEffortToGeminiThinkingLevel(effort: string): ThinkingLevel 
 		default:
 			return ThinkingLevel.LOW
 	}
+}
+
+function getGeminiMaxOutputTokens(modelId: string, modelMaxTokens?: number): number | undefined {
+	if (!isGeminiFlashModel(modelId)) {
+		return undefined
+	}
+
+	if (modelMaxTokens && modelMaxTokens > 0) {
+		return Math.min(modelMaxTokens, GEMINI_FLASH_MAX_OUTPUT_TOKENS)
+	}
+
+	return GEMINI_FLASH_MAX_OUTPUT_TOKENS
 }
 
 /**
@@ -152,6 +165,7 @@ export class GeminiHandler implements ApiHandler {
 		}
 
 		// Set up base generation config
+		const maxOutputTokens = getGeminiMaxOutputTokens(modelId, info.maxTokens)
 		const requestConfig: GenerateContentConfig = {
 			// Add base URL if configured
 			httpOptions: this.options.geminiBaseUrl ? { baseUrl: this.options.geminiBaseUrl } : undefined,
@@ -159,6 +173,7 @@ export class GeminiHandler implements ApiHandler {
 			// Set temperature (default to 0)
 			// Gemini 3 recommends 1.0
 			temperature: info.temperature ?? 1,
+			...(maxOutputTokens !== undefined ? { maxOutputTokens } : {}),
 		}
 
 		// Add thinking config only if the model supports it

--- a/src/core/api/transform/__tests__/openrouter-stream.test.ts
+++ b/src/core/api/transform/__tests__/openrouter-stream.test.ts
@@ -1,0 +1,80 @@
+import { describe, it } from "mocha"
+import "should"
+import type { ModelInfo } from "@shared/api"
+import sinon from "sinon"
+import { createOpenRouterStream } from "../openrouter-stream"
+
+describe("createOpenRouterStream", () => {
+	const createAsyncIterable = () => ({
+		async *[Symbol.asyncIterator]() {},
+	})
+
+	const createClient = () => {
+		const create = sinon.stub().resolves(createAsyncIterable())
+		return {
+			client: {
+				chat: {
+					completions: {
+						create,
+					},
+				},
+			},
+			create,
+		}
+	}
+
+	const createModelInfo = (maxTokens: number): ModelInfo => ({
+		maxTokens,
+		contextWindow: 1_048_576,
+		supportsImages: true,
+		supportsPromptCache: false,
+	})
+
+	it("caps Gemini Flash OpenRouter requests to 8192 max_tokens", async () => {
+		const { client, create } = createClient()
+
+		await createOpenRouterStream(client as any, "system prompt", [{ role: "user", content: "hello" }] as any, {
+			id: "google/gemini-2.5-flash",
+			info: createModelInfo(65_536),
+		})
+
+		const payload = create.firstCall.args[0] as Record<string, unknown>
+		payload.should.have.property("max_tokens", 8_192)
+	})
+
+	it("keeps lower Gemini Flash max_tokens values when already below 8192", async () => {
+		const { client, create } = createClient()
+
+		await createOpenRouterStream(client as any, "system prompt", [{ role: "user", content: "hello" }] as any, {
+			id: "google/gemini-2.5-flash",
+			info: createModelInfo(4_096),
+		})
+
+		const payload = create.firstCall.args[0] as Record<string, unknown>
+		payload.should.have.property("max_tokens", 4_096)
+	})
+
+	it("does not send max_tokens for non-Gemini models", async () => {
+		const { client, create } = createClient()
+
+		await createOpenRouterStream(client as any, "system prompt", [{ role: "user", content: "hello" }] as any, {
+			id: "anthropic/claude-sonnet-4.5",
+			info: createModelInfo(64_000),
+		})
+
+		const payload = create.firstCall.args[0] as Record<string, unknown>
+		payload.should.not.have.property("max_tokens")
+	})
+
+	it("does not send max_tokens for non-Flash Gemini models", async () => {
+		const { client, create } = createClient()
+
+		await createOpenRouterStream(client as any, "system prompt", [{ role: "user", content: "hello" }] as any, {
+			id: "google/gemini-2.5-pro",
+			info: createModelInfo(65_536),
+		})
+
+		const payload = create.firstCall.args[0] as Record<string, unknown>
+		payload.should.not.have.property("max_tokens")
+	})
+})

--- a/src/core/api/transform/openrouter-stream.ts
+++ b/src/core/api/transform/openrouter-stream.ts
@@ -9,7 +9,12 @@ import {
 	openRouterClaudeSonnet461mModelId,
 } from "@shared/api"
 import { normalizeOpenaiReasoningEffort } from "@shared/storage/types"
-import { shouldSkipReasoningForModel, supportsReasoningEffortForModel } from "@utils/model-utils"
+import {
+	GEMINI_FLASH_MAX_OUTPUT_TOKENS,
+	isGeminiFlashModel,
+	shouldSkipReasoningForModel,
+	supportsReasoningEffortForModel,
+} from "@utils/model-utils"
 import OpenAI from "openai"
 import { ChatCompletionTool } from "openai/resources/chat/completions"
 import { convertToOpenAiMessages, sanitizeGeminiMessages } from "./openai-format"
@@ -180,9 +185,13 @@ export async function createOpenRouterStream(
 	const includeReasoning = !shouldSkipReasoningForModel(model.id) && reasoningEffortValue !== "none"
 	const reasoningPayload =
 		reasoning ?? (reasoningEffortValue && reasoningEffortValue !== "none" ? { effort: reasoningEffortValue } : undefined)
+	const maxTokens = isGeminiFlashModel(model.id)
+		? Math.min(model.info.maxTokens || GEMINI_FLASH_MAX_OUTPUT_TOKENS, GEMINI_FLASH_MAX_OUTPUT_TOKENS)
+		: undefined
 
 	const requestPayload: Record<string, unknown> = {
 		model: model.id,
+		...(maxTokens ? { max_tokens: maxTokens } : {}),
 		temperature: temperature,
 		top_p: topP,
 		messages: openAiMessages,

--- a/src/core/controller/models/refreshClineModels.ts
+++ b/src/core/controller/models/refreshClineModels.ts
@@ -1,6 +1,7 @@
 import { ensureCacheDirectoryExists, GlobalFileNames } from "@core/storage/disk"
 import type { ModelInfo } from "@shared/api"
 import { fileExistsAtPath } from "@utils/fs"
+import { GEMINI_FLASH_MAX_OUTPUT_TOKENS, isGeminiFlashModel } from "@utils/model-utils"
 import axios from "axios"
 import cloneDeep from "clone-deep"
 import fs from "fs/promises"
@@ -238,6 +239,13 @@ async function fetchAndCacheClineModels(): Promise<Record<string, ModelInfo>> {
 						}
 					}
 					break
+			}
+
+			if (isGeminiFlashModel(rawModel.id)) {
+				modelInfo.maxTokens = Math.min(
+					modelInfo.maxTokens || GEMINI_FLASH_MAX_OUTPUT_TOKENS,
+					GEMINI_FLASH_MAX_OUTPUT_TOKENS,
+				)
 			}
 
 			models[rawModel.id] = modelInfo

--- a/src/core/controller/models/refreshOpenRouterModels.ts
+++ b/src/core/controller/models/refreshOpenRouterModels.ts
@@ -1,5 +1,6 @@
 import { ensureCacheDirectoryExists, GlobalFileNames } from "@core/storage/disk"
 import type { ModelInfo } from "@shared/api"
+import { GEMINI_FLASH_MAX_OUTPUT_TOKENS, isGeminiFlashModel } from "@utils/model-utils"
 import axios from "axios"
 import cloneDeep from "clone-deep"
 import fs from "fs/promises"
@@ -262,6 +263,13 @@ async function fetchAndCacheModels(controller: Controller): Promise<Record<strin
 							}
 						}
 						break
+				}
+
+				if (isGeminiFlashModel(rawModel.id)) {
+					modelInfo.maxTokens = Math.min(
+						modelInfo.maxTokens || GEMINI_FLASH_MAX_OUTPUT_TOKENS,
+						GEMINI_FLASH_MAX_OUTPUT_TOKENS,
+					)
 				}
 
 				models[rawModel.id] = modelInfo

--- a/src/utils/__tests__/model-utils.test.ts
+++ b/src/utils/__tests__/model-utils.test.ts
@@ -1,6 +1,13 @@
 import { describe, it } from "mocha"
 import "should"
-import { isClaude4PlusModelFamily, isGptOssModelFamily, isGPT5ModelFamily, shouldSkipReasoningForModel } from "../model-utils"
+import {
+	GEMINI_FLASH_MAX_OUTPUT_TOKENS,
+	isClaude4PlusModelFamily,
+	isGeminiFlashModel,
+	isGPT5ModelFamily,
+	isGptOssModelFamily,
+	shouldSkipReasoningForModel,
+} from "../model-utils"
 
 describe("shouldSkipReasoningForModel", () => {
 	it("should return true for grok-4 models", () => {
@@ -100,5 +107,38 @@ describe("isGptOssModelFamily", () => {
 		isGptOssModelFamily("gpt-5").should.equal(false)
 		isGptOssModelFamily("gpt-4o").should.equal(false)
 		isGptOssModelFamily("claude-sonnet-4").should.equal(false)
+	})
+})
+
+describe("isGeminiFlashModel", () => {
+	it("should return true for Gemini Flash model IDs", () => {
+		isGeminiFlashModel("google/gemini-2.5-flash").should.equal(true)
+		isGeminiFlashModel("google/gemini-3-flash-preview").should.equal(true)
+		isGeminiFlashModel("google/gemini-2.5-flash-lite").should.equal(true)
+	})
+
+	it("should return false for non-Flash Gemini model IDs", () => {
+		isGeminiFlashModel("google/gemini-2.5-pro").should.equal(false)
+		isGeminiFlashModel("google/gemini-3-pro-preview").should.equal(false)
+	})
+
+	it("should return true for direct Gemini provider IDs", () => {
+		isGeminiFlashModel("gemini-2.5-flash").should.equal(true)
+		isGeminiFlashModel("gemini-3-flash-preview").should.equal(true)
+	})
+
+	it("should return false for non-matching IDs", () => {
+		isGeminiFlashModel("openrouter/google/gemini-2.5-flash").should.equal(false)
+		isGeminiFlashModel("google/gemini-2.5-pro").should.equal(false)
+	})
+
+	it("should be case insensitive", () => {
+		isGeminiFlashModel("GOOGLE/GEMINI-2.5-FLASH").should.equal(true)
+	})
+})
+
+describe("GEMINI_FLASH_MAX_OUTPUT_TOKENS", () => {
+	it("should be set to 8192", () => {
+		GEMINI_FLASH_MAX_OUTPUT_TOKENS.should.equal(8_192)
 	})
 })

--- a/src/utils/model-utils.ts
+++ b/src/utils/model-utils.ts
@@ -4,6 +4,7 @@ import { AnthropicModelId, anthropicModels } from "@/shared/api"
 export { supportsReasoningEffortForModel } from "@shared/utils/reasoning-support"
 
 const CLAUDE_VERSION_MATCH_REGEX = /[-_ ]([\d](?:\.[05])?)[-_ ]?/
+export const GEMINI_FLASH_MAX_OUTPUT_TOKENS = 8_192
 
 export function isNextGenModelProvider(providerInfo: ApiProviderInfo): boolean {
 	const providerId = normalize(providerInfo.providerId)
@@ -150,6 +151,13 @@ export function isTrinityModelFamily(id: string): boolean {
 export function isGemini3ModelFamily(id: string): boolean {
 	const modelId = normalize(id)
 	return modelId.includes("gemini3") || modelId.includes("gemini-3")
+}
+
+export function isGeminiFlashModel(id: string): boolean {
+	const modelId = normalize(id)
+	const isGooglePrefixedGemini = modelId.startsWith("google/gemini")
+	const isDirectGemini = modelId.startsWith("gemini-")
+	return (isGooglePrefixedGemini || isDirectGemini) && modelId.includes("flash")
 }
 
 function isDeepSeek32ModelFamily(id: string): boolean {


### PR DESCRIPTION


### Description

The purpose of this PR is to stop spiraling of Gemini flash models because with no limits on output tokens the model just keeps outputting forever. This PR adds a consistent output-token cap for Gemini Flash models to prevent overly large completions and keep behavior predictable across providers.

Changes included:
- Cap Gemini Flash output tokens to `8192` in direct Gemini requests by setting `maxOutputTokens` in the Gemini provider.
- Cap OpenRouter Gemini Flash requests to `8192` by sending `max_tokens` for Gemini Flash model IDs.
- Clamp dynamic OpenRouter/Cline model metadata for Gemini Flash to `8192` so runtime and model info stay aligned.
- Add unit tests for OpenRouter stream payload behavior.

### Test Procedure

I validated the change with:

- `npm run protos`
- `npm run test:unit -- src/core/api/transform/__tests__/openrouter-stream.test.ts src/core/api/providers/__tests__/openrouter.test.ts`
- `npm run test:unit -- src/core/api/transform/__tests__/openrouter-stream.test.ts`
- `npx tsc --noEmit --pretty false --project tsconfig.unit-test.json`
- `npx biome check src/core/api/providers/gemini.ts src/core/api/transform/openrouter-stream.ts src/core/controller/models/refreshClineModels.ts src/core/controller/models/refreshOpenRouterModels.ts src/core/api/transform/__tests__/openrouter-stream.test.ts`

What I specifically checked:
- OpenRouter includes `max_tokens=8192` for Gemini Flash.
- OpenRouter preserves lower max token values when model metadata is below `8192`.
- OpenRouter does not send `max_tokens` for non-Gemini models.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A (no UI changes)

### Additional Notes

I used `8192` as the cap (instead of `8092`/`8196`) to align with existing token-limit conventions in this codebase.
