### PR TITLE
call telemetry service after initializeCli

### DIFF
--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -333,10 +333,19 @@ async function drainStdout(): Promise<void> {
 
 export async function captureUnhandledException(reason: Error, context: string) {
 	try {
-		const errorService = ErrorService.get()
-		await errorService.captureException(reason, { context })
-		// dispose flushes any pending error captures to ensure they're sent before the process exits
-		return errorService.dispose()
+		// ErrorService may not be initialized yet (e.g., error occurred before initializeCli())
+		// so we guard with a try/get pattern rather than letting ErrorService.get() throw
+		let errorService: ErrorService | null = null
+		try {
+			errorService = ErrorService.get()
+		} catch {
+			// ErrorService not yet initialized; skip capture
+		}
+		if (errorService) {
+			await errorService.captureException(reason, { context })
+			// dispose flushes any pending error captures to ensure they're sent before the process exits
+			return errorService.dispose()
+		}
 	} catch {
 		// Ignore errors during shutdown to avoid an infinite loop
 		Logger.info("Error capturing unhandled exception. Proceeding with shutdown.")
@@ -395,7 +404,11 @@ function setupSignalHandlers() {
 				} catch {
 					// StateManager may not be initialized yet
 				}
-				await ErrorService.get().dispose()
+				try {
+					await ErrorService.get().dispose()
+				} catch {
+					// ErrorService may not be initialized yet
+				}
 				await disposeTelemetryServices()
 			}
 		} catch {
@@ -552,6 +565,11 @@ async function runTask(prompt: string, options: TaskOptions & { images?: string[
 
 	// Task without prompt starts in interactive mode
 	telemetryService.captureHostEvent("task_command", prompt ? "task" : "interactive")
+
+	// Capture piped stdin telemetry now that HostProvider is initialized
+	if (options.stdinWasPiped) {
+		telemetryService.captureHostEvent("piped", "detached")
+	}
 
 	// Apply shared task options (mode, model, thinking, yolo)
 	applyTaskOptions(options)
@@ -874,6 +892,11 @@ async function resumeTask(taskId: string, options: TaskOptions & { initialPrompt
 
 	telemetryService.captureHostEvent("resume_task_command", options.initialPrompt ? "with_prompt" : "interactive")
 
+	// Capture piped stdin telemetry now that HostProvider is initialized
+	if (options.stdinWasPiped) {
+		telemetryService.captureHostEvent("piped", "detached")
+	}
+
 	// Apply shared task options (mode, model, thinking, yolo)
 	applyTaskOptions(options)
 	await StateManager.get().flushPendingState()
@@ -1041,8 +1064,6 @@ program
 			} else {
 				effectivePrompt = stdinInput
 			}
-
-			telemetryService.captureHostEvent("piped", "detached")
 
 			// Debug: show that we received piped input
 			if (options.verbose) {


### PR DESCRIPTION
- calling telemetry service before initializeCli call causes a "hostprovider not initialized error", which invokes errorservice, which causes another "hostprovider not initialized error", which was breaking this cline use case: `echo "say hello" | cline`

<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- For feature requests: Created a discussion in our Feature Requests discussions board https://github.com/cline/cline/discussions/categories/feature-requests and received approval from core maintainers before implementation
- For all changes: Link the associated issue/discussion in the "Related Issue" section below

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly without prior discussion.

Why this requirement?
We deeply appreciate all community contributions - they are essential to Cline's success! To ensure the best use of everyone's time and maintain project direction, we use our Feature Requests discussions board to gauge community interest and validate feature ideas before implementation begins. This helps us focus development efforts on features that will benefit the most users.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** N/A

### Description

- calling telemetry service before initializeCli call causes a "hostprovider not initialized error", which invokes errorservice, which causes another "hostprovider not initialized error", which was breaking this cline use case: `echo "say hello" | cline`

<!-- 
Help reviewers understand your changes by making this PR readable and well-organized:

- What problem does this PR solve?
- Why were these changes introduced and what purpose do they serve?
- For larger changes, provide context about your approach and reasoning

Small PRs may need minimal description, but larger changes benefit from explaining where you're coming from. Much of this context can be in the linked issue above, so feel free to reference it rather than repeating everything here.
-->

### Test Procedure

`echo "say hello" | cline` works now

<!-- 
Please walk us through your testing approach and thought process. This helps reviewers understand that you've thoroughly considered the impact of your changes:

- How did you test this change?
- What could potentially break and how did you verify it doesn't?
- What existing functionality might be affected and how did you check it still works?
- Why are you confident this is ready for merge?

We're not looking for exhaustive documentation - just evidence that you've thought through the implications of your changes and tested accordingly.
-->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->
