### PR TITLE
improve: fetch models list for hicap in CLI, update endpoint to fetch models list

### DIFF
--- a/.changeset/great-phones-visit.md
+++ b/.changeset/great-phones-visit.md
@@ -1,0 +1,5 @@
+---
+"@fake-scope/fake-pkg": patch
+---
+
+improve: fetch models list for hicap in CLI, update endpoint to fetch models list

--- a/cli/src/components/ModelPicker.tsx
+++ b/cli/src/components/ModelPicker.tsx
@@ -6,6 +6,7 @@
 import { Box, Text } from "ink"
 import Spinner from "ink-spinner"
 import React, { useEffect, useMemo, useState } from "react"
+import { refreshHicapModels } from "@/core/controller/models/refreshHicapModels"
 import { refreshOcaModels } from "@/core/controller/models/refreshOcaModels"
 import { refreshOpenRouterModels } from "@/core/controller/models/refreshOpenRouterModels"
 import {
@@ -110,7 +111,7 @@ export function hasStaticModels(provider: string): boolean {
 }
 
 export function hasModelPicker(provider: string): boolean {
-	return hasStaticModels(provider) || usesOpenRouterModels(provider) || provider === "oca"
+	return hasStaticModels(provider) || usesOpenRouterModels(provider) || provider === "oca" || provider === "hicap"
 }
 
 export function getDefaultModelId(provider: string): string {
@@ -137,7 +138,7 @@ export const ModelPicker: React.FC<ModelPickerProps> = ({ provider, controller, 
 	const [isLoading, setIsLoading] = useState(false)
 	const [asyncModels, setAsyncModels] = useState<string[]>([])
 
-	// Fetch async models (OpenRouter or OCA) when needed
+	// Fetch async models (OpenRouter, OCA, or Hicap) when needed
 	useEffect(() => {
 		if (usesOpenRouterModels(provider)) {
 			setIsLoading(true)
@@ -162,11 +163,23 @@ export const ModelPicker: React.FC<ModelPickerProps> = ({ provider, controller, 
 				.finally(() => {
 					setIsLoading(false)
 				})
+		} else if (provider === "hicap") {
+			setIsLoading(true)
+			refreshHicapModels(controller, StringRequest.create({ value: "" }))
+				.then((result) => {
+					if (result.models) {
+						const modelIds = Object.keys(result.models).sort((a, b) => a.localeCompare(b))
+						setAsyncModels(modelIds)
+					}
+				})
+				.finally(() => {
+					setIsLoading(false)
+				})
 		}
 	}, [provider, controller])
 
 	const modelList = useMemo(() => {
-		if (usesOpenRouterModels(provider) || provider === "oca") {
+		if (usesOpenRouterModels(provider) || provider === "oca" || provider === "hicap") {
 			return asyncModels
 		}
 		return getModelList(provider)
@@ -208,7 +221,7 @@ export const ModelPicker: React.FC<ModelPickerProps> = ({ provider, controller, 
 	}
 
 	// If async fetch returned no models, render nothing
-	if ((usesOpenRouterModels(provider) || provider === "oca") && modelList.length === 0) {
+	if ((usesOpenRouterModels(provider) || provider === "oca" || provider === "hicap") && modelList.length === 0) {
 		return null
 	}
 

--- a/cli/src/components/ModelPicker.tsx
+++ b/cli/src/components/ModelPicker.tsx
@@ -66,7 +66,7 @@ import {
 	xaiDefaultModelId,
 	xaiModels,
 } from "@/shared/api"
-import { StringRequest } from "@/shared/proto/cline/common"
+import { EmptyRequest, StringRequest } from "@/shared/proto/cline/common"
 import { filterOpenRouterModelIds } from "@/shared/utils/model-filters"
 import { COLORS } from "../constants/colors"
 import { getOpenRouterDefaultModelId, usesOpenRouterModels } from "../utils/openrouter-models"
@@ -165,7 +165,7 @@ export const ModelPicker: React.FC<ModelPickerProps> = ({ provider, controller, 
 				})
 		} else if (provider === "hicap") {
 			setIsLoading(true)
-			refreshHicapModels(controller, StringRequest.create({ value: "" }))
+			refreshHicapModels(controller, EmptyRequest.create({}))
 				.then((result) => {
 					if (result.models) {
 						const modelIds = Object.keys(result.models).sort((a, b) => a.localeCompare(b))

--- a/src/core/controller/models/refreshHicapModels.ts
+++ b/src/core/controller/models/refreshHicapModels.ts
@@ -27,15 +27,7 @@ export async function refreshHicapModels(controller: Controller, _request: Empty
 
 	const models: Record<string, OpenRouterModelInfo> = {}
 	try {
-		// Get the Hicap API key from the controller's state
-		const hicapApiKey = controller.stateManager.getSecretKey("hicapApiKey")
-
-		const response = await axios.get("https://api.hicap.ai/v2/openai/models", {
-			headers: {
-				"api-key": hicapApiKey,
-			},
-			...getAxiosSettings(),
-		})
+		const response = await axios.get("https://api.hicap.ai/v1/models/all", { ...getAxiosSettings() })
 
 		if (response.data?.data) {
 			const rawModels = response.data.data


### PR DESCRIPTION
### Description

* This PR improve the provider Hicap option in CLI, instead enter manually the model name to use, now is fetching a models list available on hicap.
* We update the endpoint to fetch the available models list, now is a public endpoint, an api key is not longer required

### Test Procedure

* Tested request/response cycle to ensure proper communication with Hicap dashboard website
* Ran  `npm test` to confirm all existing tests pass.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [X] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<img width="872" height="228" alt="Captura de pantalla 2026-03-11 a la(s) 10 39 09 a m" src="https://github.com/user-attachments/assets/66e0e994-1262-4659-baef-80efdcc995f7" />


<img width="852" height="266" alt="Captura de pantalla 2026-03-11 a la(s) 10 39 44 a m" src="https://github.com/user-attachments/assets/d6f9eb2c-191c-48ec-bd47-6eb6fdfd5780" />

