### PR TITLE
Changelog and version bump for release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## [3.72.0]
+
+### Added
+
+- Added Anthropic Opus 4.6 fast mode variants
+
+### Fixed
+
+- Resolved native tool placeholder interpolation in prompts
+- Gemini: capped Flash output tokens to 8192 across providers
+- Fixed Windows unit test path normalization
+- Fixed flaky hooks tests on Windows
+- Bedrock: handle thinking and redacted_thinking blocks correctly in message conversion and streaming
+- Prevent crash when `list_files` or `list_code_definition_names` receives a file path
+
+### Changed
+
+- Updated Jupyter Notebook GIFs
+- Markdown image loading now requires user consent
+- Added `.github/copilot-instructions.md` for coding agents
+- Hooks: reintroduced feature toggle
+
 ## [3.71.0]
 
 ### Added

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,5 +1,26 @@
 # cline
 
+## [2.7.0]
+
+### Added
+
+- Added MCP add shortcuts for stdio and HTTP servers
+- Added `--continue` for the current directory
+- Added `--auto-condense` flag for AI-powered context compaction
+- Added `--hooks-dir` flag for runtime hook injection
+- Enabled error autocapture
+- Prompt rules now include test verification guidance and make `CLI_RULES` language-agnostic
+
+### Fixed
+
+- Fixed remount behavior so TUI remounts only on width resize
+- Fixed startup prompt replay on resize remount
+- Fixed task flags so they are applied before the welcome TUI mounts
+
+### Changed
+
+- Hooks: reintroduced feature toggle
+
 ## [2.6.1]
 
 ### Added

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cline",
-	"version": "2.6.1",
+	"version": "2.7.0",
 	"description": "Autonomous coding agent CLI - capable of creating/editing files, running commands, using the browser, and more",
 	"main": "dist/lib.mjs",
 	"types": "dist/lib.d.ts",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "claude-dev",
-	"version": "3.71.0",
+	"version": "3.72.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "claude-dev",
-			"version": "3.71.0",
+			"version": "3.72.0",
 			"license": "Apache-2.0",
 			"workspaces": [
 				".",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "claude-dev",
 	"displayName": "Cline",
 	"description": "Autonomous coding agent right in your IDE, capable of creating/editing files, running commands, using the browser, and more with your permission every step of the way.",
-	"version": "3.71.0",
+	"version": "3.72.0",
 	"icon": "assets/icons/icon.png",
 	"workspaces": [
 		".",


### PR DESCRIPTION
VSCode version: `3.72.0`
CLI version: `2.7.0`