### PR TITLE
fix: prevent VS Code LM model name truncation for BYOK providers

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://unpkg.com/@changesets/config@3.0.0/schema.json",
+  "changelog": "@changesets/cli/changelog",
+  "commit": false,
+  "fixed": [],
+  "linked": [],
+  "access": "restricted",
+  "baseBranch": "main",
+  "updateInternalDependencies": "patch"
+}

--- a/.changeset/fix-model-name-truncation.md
+++ b/.changeset/fix-model-name-truncation.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+fix: prevent VS Code LM model name truncation for BYOK providers

--- a/webview-ui/src/components/settings/providers/VSCodeLmProvider.tsx
+++ b/webview-ui/src/components/settings/providers/VSCodeLmProvider.tsx
@@ -54,7 +54,11 @@ export const VSCodeLmProvider = ({ currentMode }: VSCodeLmProviderProps) => {
 							if (!value) {
 								return
 							}
-							const [vendor, family] = value.split("/")
+							// Split on first "/" only — family may contain slashes
+						// (e.g., BYOK providers: "copilot/openai/gpt-4o")
+						const separatorIndex = value.indexOf("/")
+						const vendor = value.substring(0, separatorIndex)
+						const family = value.substring(separatorIndex + 1)
 
 							handleModeFieldChange(
 								{ plan: "planModeVsCodeLmModelSelector", act: "actModeVsCodeLmModelSelector" },


### PR DESCRIPTION
## Problem

When using the VS Code Language Model API with a BYOK (Bring Your Own Key) provider like OpenRouter via GitHub Copilot, the model name gets truncated in the dropdown selector.

For example, a model with `vendor: 'copilot'` and `family: 'openai/gpt-4o'` produces the dropdown value `copilot/openai/gpt-4o`. The existing code splits this on `/` using array destructuring:

```typescript
const [vendor, family] = value.split('/')
// vendor = 'copilot', family = 'openai'  ← 'gpt-4o' is lost!
```

This causes the model selector to store a truncated family name, and the selected model no longer matches any available model.

## Fix

Split only on the **first** `/` to preserve the full family name:

```typescript
const separatorIndex = value.indexOf('/')
const vendor = value.substring(0, separatorIndex)
const family = value.substring(separatorIndex + 1)
// vendor = 'copilot', family = 'openai/gpt-4o'  ✓
```

## Changes

- **`webview-ui/src/components/settings/providers/VSCodeLmProvider.tsx`**: Replaced `value.split('/')` destructuring with `indexOf` + `substring` to split on first `/` only.

Fixes #6293