### PR TITLE
fix: respect supportsImages toggle for paste and drag-drop

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://unpkg.com/@changesets/config@3.0.0/schema.json",
+  "changelog": "@changesets/cli/changelog",
+  "commit": false,
+  "fixed": [],
+  "linked": [],
+  "access": "restricted",
+  "baseBranch": "main",
+  "updateInternalDependencies": "patch"
+}

--- a/.changeset/fix-image-paste-toggle.md
+++ b/.changeset/fix-image-paste-toggle.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+fix: respect supportsImages toggle for paste and drag-drop operations

--- a/webview-ui/src/components/chat/ChatTextArea.tsx
+++ b/webview-ui/src/components/chat/ChatTextArea.tsx
@@ -80,6 +80,7 @@ interface ChatTextAreaProps {
 	onSend: () => void
 	onSelectFilesAndImages: () => void
 	shouldDisableFilesAndImages: boolean
+	imagesSupported: boolean
 	onHeightChange?: (height: number) => void
 	onFocusChange?: (isFocused: boolean) => void
 }
@@ -207,6 +208,7 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 			onSend,
 			onSelectFilesAndImages,
 			shouldDisableFilesAndImages,
+			imagesSupported,
 			onHeightChange,
 			onFocusChange,
 		},
@@ -856,7 +858,7 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 					const [type, subtype] = item.type.split("/")
 					return type === "image" && acceptedTypes.includes(subtype)
 				})
-				if (!shouldDisableFilesAndImages && imageItems.length > 0) {
+				if (!shouldDisableFilesAndImages && imagesSupported && imageItems.length > 0) {
 					e.preventDefault()
 					const imagePromises = imageItems.map((item) => {
 						return new Promise<string | null>((resolve) => {
@@ -1264,7 +1266,7 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 				return type === "image" && acceptedTypes.includes(subtype)
 			})
 
-			if (shouldDisableFilesAndImages || imageFiles.length === 0) {
+			if (shouldDisableFilesAndImages || !imagesSupported || imageFiles.length === 0) {
 				return
 			}
 

--- a/webview-ui/src/components/chat/ChatView.tsx
+++ b/webview-ui/src/components/chat/ChatView.tsx
@@ -390,6 +390,7 @@ const ChatView = ({ isHidden, showAnnouncement, hideAnnouncement, showHistoryVie
 					scrollBehavior={scrollBehavior}
 					selectFilesAndImages={selectFilesAndImages}
 					shouldDisableFilesAndImages={shouldDisableFilesAndImages}
+						imagesSupported={selectedModelInfo.supportsImages || false}
 				/>
 			</footer>
 		</ChatLayout>

--- a/webview-ui/src/components/chat/chat-view/components/layout/InputSection.tsx
+++ b/webview-ui/src/components/chat/chat-view/components/layout/InputSection.tsx
@@ -9,6 +9,7 @@ interface InputSectionProps {
 	scrollBehavior: ScrollBehavior
 	placeholderText: string
 	shouldDisableFilesAndImages: boolean
+	imagesSupported: boolean
 	selectFilesAndImages: () => Promise<void>
 }
 
@@ -21,6 +22,7 @@ export const InputSection: React.FC<InputSectionProps> = ({
 	scrollBehavior,
 	placeholderText,
 	shouldDisableFilesAndImages,
+	imagesSupported,
 	selectFilesAndImages,
 }) => {
 	const {
@@ -72,6 +74,7 @@ export const InputSection: React.FC<InputSectionProps> = ({
 				setSelectedFiles={setSelectedFiles}
 				setSelectedImages={setSelectedImages}
 				shouldDisableFilesAndImages={shouldDisableFilesAndImages}
+				imagesSupported={imagesSupported}
 			/>
 		</>
 	)


### PR DESCRIPTION
## Problem

The "Supports images" toggle in model configuration is correctly respected for the **file picker dialog** (which filters out image extensions when disabled), but is **not checked for paste and drag-and-drop operations**. This means users can paste/drop images into chat for models with image support disabled, leading to failed API requests after retries.

As noted in the [bot analysis](https://github.com/cline/cline/issues/8635#issuecomment-3754023374):

- `shouldDisableFilesAndImages` only checks if the max file/image limit is reached
- It does **not** check `selectedModelInfo.supportsImages`
- The file picker correctly filters images via `supportsImages`, but paste/drop bypass this

## Fix

Add an `imagesSupported` prop to `ChatTextArea` (threaded through `InputSection`) and check it in both the paste handler and drop handler:

- **Paste**: `if (!shouldDisableFilesAndImages && imagesSupported && ...)`
- **Drop**: `if (shouldDisableFilesAndImages || !imagesSupported || ...)`

This ensures that when a model's image support is toggled off, images are silently ignored on paste/drop — consistent with the file picker behavior.

## Changes

- **`ChatTextArea.tsx`**: Added `imagesSupported` prop; checked in paste handler (line ~861) and drop handler (line ~1269)
- **`InputSection.tsx`**: Added `imagesSupported` to interface and prop threading
- **`ChatView.tsx`**: Pass `imagesSupported={selectedModelInfo.supportsImages || false}`

Fixes #8635