### PR TITLE
docs: fix broken Oracle Code Assist website link

### DIFF
--- a/docs/provider-config/oracle-code-assist.mdx
+++ b/docs/provider-config/oracle-code-assist.mdx
@@ -5,7 +5,7 @@ description: "Learn how to configure and use Oracle Code Assist with Cline. Acce
 
 Oracle Code Assist provides AI-powered coding assistance through Oracle Cloud Infrastructure (OCI) Generative AI service.
 
-**Website:** [https://www.oracle.com/artificial-intelligence/code-assist/](https://www.oracle.com/artificial-intelligence/code-assist/)
+**Website:** [https://www.oracle.com/application-development/code-assist/](https://www.oracle.com/application-development/code-assist/)
 
 ### Getting Started
 


### PR DESCRIPTION
The Oracle Code Assist URL moved from `/artificial-intelligence/code-assist/` to `/application-development/code-assist/`. The old URL returns a 404.


