### PR TITLE
fix: truncate byte-heavy terminal output summaries

### DIFF
--- a/src/integrations/terminal/CommandOrchestrator.test.ts
+++ b/src/integrations/terminal/CommandOrchestrator.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict"
 import { EventEmitter } from "events"
 import { describe, it } from "mocha"
 import { orchestrateCommandExecution } from "./CommandOrchestrator"
+import { MAX_BYTES_BEFORE_FILE } from "./constants"
 import type {
 	CommandExecutorCallbacks,
 	ITerminalManager,
@@ -110,5 +111,27 @@ describe("CommandOrchestrator exit status messaging", () => {
 		assert.equal(result.completed, true)
 		assert.equal(result.exitCode, 0)
 		assert.match(result.result as string, /^Command executed successfully \(exit code 0\)\./)
+	})
+
+	it("truncates huge single-line summaries when file logging is triggered by bytes", async () => {
+		const process = new FakeTerminalProcess()
+		const orchestrationPromise = orchestrateCommandExecution(
+			process.asResultPromise(),
+			createTerminalManager(),
+			createCallbacks(),
+			{ command: "echo huge" },
+		)
+
+		const hugeLine = `START-${"x".repeat(MAX_BYTES_BEFORE_FILE + 32 * 1024)}-END`
+		process.emit("line", hugeLine)
+		await new Promise((resolve) => setTimeout(resolve, 0))
+		process.complete({ exitCode: 0, signal: null })
+		const result: OrchestrationResult = await orchestrationPromise
+		const resultText = result.result as string
+
+		assert.equal(result.completed, true)
+		assert.match(resultText, /output truncated by size/)
+		assert.match(resultText, /Full output saved to:/)
+		assert.equal(resultText.includes(hugeLine), false)
 	})
 })

--- a/src/integrations/terminal/CommandOrchestrator.ts
+++ b/src/integrations/terminal/CommandOrchestrator.ts
@@ -29,6 +29,7 @@ import {
 	COMPLETION_TIMEOUT_MS,
 	MAX_BYTES_BEFORE_FILE,
 	MAX_LINES_BEFORE_FILE,
+	SUMMARY_BYTES_TO_KEEP,
 	SUMMARY_LINES_TO_KEEP,
 } from "./constants"
 import type {
@@ -529,10 +530,19 @@ export async function orchestrateCommandExecution(
 	let resultOutputLines: string[]
 
 	if (isWritingToFile) {
-		// Build summary from first and last lines
-		const skippedLines = totalLineCount - firstLines.length - lastLines.length
-		const summaryLines = [...firstLines, `\n... (${skippedLines} lines written to ${largeOutputLogPath}) ...\n`, ...lastLines]
-		result = terminalManager.processOutput(summaryLines)
+		// Build summary from first and last lines, avoiding overlap when output is small.
+		const overlappingLines = Math.max(0, firstLines.length + lastLines.length - totalLineCount)
+		const nonOverlappingLastLines = overlappingLines > 0 ? lastLines.slice(overlappingLines) : lastLines
+		const skippedLines = Math.max(0, totalLineCount - firstLines.length - nonOverlappingLastLines.length)
+		const summaryLines =
+			skippedLines > 0
+				? [
+						...firstLines,
+						`\n... (${skippedLines} lines written to ${largeOutputLogPath ?? "output log file"}) ...\n`,
+						...nonOverlappingLastLines,
+					]
+				: [...firstLines, ...nonOverlappingLastLines]
+		result = truncateSummaryByBytes(terminalManager.processOutput(summaryLines), SUMMARY_BYTES_TO_KEEP)
 		resultOutputLines = summaryLines
 	} else {
 		result = terminalManager.processOutput(outputLines)
@@ -625,4 +635,26 @@ export function findLastIndex<T>(array: T[], predicate: (item: T) => boolean): n
 		}
 	}
 	return -1
+}
+
+function truncateSummaryByBytes(output: string, maxBytes: number): string {
+	if (Buffer.byteLength(output, "utf8") <= maxBytes) {
+		return output
+	}
+
+	const marker = "\n... (output truncated by size) ...\n"
+	const markerBytes = Buffer.byteLength(marker, "utf8")
+
+	if (maxBytes <= markerBytes) {
+		return marker.trim()
+	}
+
+	const bytesForContent = maxBytes - markerBytes
+	const startBytes = Math.ceil(bytesForContent / 2)
+	const endBytes = Math.floor(bytesForContent / 2)
+	const buffer = Buffer.from(output, "utf8")
+	const start = buffer.subarray(0, startBytes).toString("utf8").replace(/\uFFFD+$/u, "")
+	const end = buffer.subarray(buffer.length - endBytes).toString("utf8").replace(/^\uFFFD+/u, "")
+
+	return `${start}${marker}${end}`.trim()
 }

--- a/src/integrations/terminal/constants.ts
+++ b/src/integrations/terminal/constants.ts
@@ -51,6 +51,9 @@ export const MAX_BYTES_BEFORE_FILE = 512 * 1024 // 512KB
 /** Lines to keep at start/end for summary when truncating */
 export const SUMMARY_LINES_TO_KEEP = 100
 
+/** Maximum bytes to keep in large-output summaries returned to AI */
+export const SUMMARY_BYTES_TO_KEEP = 64 * 1024 // 64KB
+
 /** Maximum size for fullOutput storage (memory protection) */
 export const MAX_FULL_OUTPUT_SIZE = 1024 * 1024 // 1MB
 


### PR DESCRIPTION
### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** #XXXX

### Description

Fixes a terminal output summarization edge case where large output correctly switched to file logging by byte size, but a very long single line could still be inserted into context because summary truncation was line-only.

Changes included:
- Add `SUMMARY_BYTES_TO_KEEP` (64KB) for large-output summaries.
- Truncate summary text by byte size with a clear marker (`... (output truncated by size) ...`).
- Prevent overlap between `firstLines` and `lastLines` when building file-mode summaries, which also avoids negative skipped-line counts.
- Add a regression test covering byte-triggered file logging with a huge single output line.

### Test Procedure

- Ran:
  - `npx cross-env TS_NODE_PROJECT=./tsconfig.unit-test.json mocha src/integrations/terminal/CommandOrchestrator.test.ts`
- Result:
  - `1249 passing`
- Verified the new regression asserts that the full huge line is not embedded in the returned context summary and that truncation marker text is present.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A (non-UI change)

### Additional Notes

Base branch set per request: `arafatkatze/update-fireworks-serverless-models`.
