### PR TITLE
fix: show text content before attempt_completion instead of swallowing it

### DIFF
--- a/src/core/task/index.ts
+++ b/src/core/task/index.ts
@@ -2101,9 +2101,19 @@ export class Task {
 		const block = cloneDeep(this.taskState.assistantMessageContent[this.taskState.currentStreamingContentIndex]) // need to create copy bc while stream is updating the array, it could be updating the reference block properties too
 		switch (block.type) {
 			case "text": {
-				// Skip text rendering if tool was rejected, or if a tool was already used and parallel calling is disabled
-				if (this.taskState.didRejectTool || (!this.isParallelToolCallingEnabled() && this.taskState.didAlreadyUseTool)) {
+				// Skip text rendering if tool was rejected, or if a tool was already used and parallel calling is disabled.
+				// Exception: don't skip text that immediately precedes attempt_completion, since that content
+				// is typically the substantive output the user requested (e.g., a code review or analysis).
+				if (this.taskState.didRejectTool) {
 					break
+				}
+				if (!this.isParallelToolCallingEnabled() && this.taskState.didAlreadyUseTool) {
+					const nextBlock = this.taskState.assistantMessageContent[this.taskState.currentStreamingContentIndex + 1]
+					const nextBlockIsCompletion =
+						nextBlock && nextBlock.type === "tool_use" && nextBlock.name === "attempt_completion"
+					if (!nextBlockIsCompletion) {
+						break
+					}
 				}
 				let content = block.content
 				if (content) {


### PR DESCRIPTION
## Summary
- Fixes #9719 — when parallel tool calling is disabled 和 a tool has already been used, text blocks were unconditionally skipped. This caused substantive content (code reviews, analyses, summaries) written before `attempt_completion` to be silently discarded in the UI.
- The fix peeks at the next content block when deciding whether to skip text. If the next block is `attempt_completion`, the text is rendered instead of skipped.
- This preserves the existing optimization of hiding model "chatter" between regular tool calls.

## Test plan
- [ ] With parallel tool calling disabled, have the model write a detailed analysis followed by `attempt_completion` — verify the analysis text appears in the chat above the completion box
- [ ] Verify normal tool call sequences still skip intermediate text (e.g., text between `read_file` and `write_to_file`)
- [ ] Verify rejected tool flows still skip text as before
- [ ] Test with parallel tool calling enabled — behavior should be unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)