### PR TITLE
fix(litellm): respect user-configured context window in getModel()

### DIFF
--- a/src/core/api/providers/__tests__/litellm.test.ts
+++ b/src/core/api/providers/__tests__/litellm.test.ts
@@ -1,7 +1,9 @@
 import { LiteLlmHandler, type LiteLlmModelInfoResponse } from "@core/api/providers/litellm"
 import { convertToOpenAiMessages } from "@core/api/transform/openai-format"
+import { liteLlmModelInfoSaneDefaults } from "@shared/api" // used in getModel tests
 import { expect } from "chai"
 import sinon from "sinon"
+import { StateManager } from "@/core/storage/StateManager" // used in getModel tests
 import { ClineStorageMessage } from "@/shared/messages/content"
 import { mockFetchForTesting } from "@/shared/net"
 
@@ -244,6 +246,81 @@ describe("LiteLlmHandler", () => {
 				expect(callArgs.stream).to.equal(true)
 				expect(callArgs.stream_options).to.deep.equal({ include_usage: true })
 			})
+		})
+	})
+
+	describe("getModel", () => {
+		let stateManagerStub: sinon.SinonStub
+
+		beforeEach(() => {
+			stateManagerStub = sinon.stub(StateManager, "get").returns({
+				getModelInfo: () => null,
+			} as any)
+		})
+
+		afterEach(() => {
+			stateManagerStub.restore()
+		})
+
+		it("returns sane defaults when no liteLlmModelInfo option is provided", () => {
+			const h = new LiteLlmHandler({
+				liteLlmApiKey: "test",
+				liteLlmModelId: "some-model",
+			})
+			const model = h.getModel()
+			expect(model.id).to.equal("some-model")
+			expect(model.info.contextWindow).to.equal(liteLlmModelInfoSaneDefaults.contextWindow)
+		})
+
+		it("returns user-configured model info when liteLlmModelInfo is provided and no cache exists", () => {
+			const h = new LiteLlmHandler({
+				liteLlmApiKey: "test",
+				liteLlmModelId: "claude-sonnet-4-6",
+				liteLlmModelInfo: {
+					contextWindow: 1_000_000,
+					maxTokens: 8192,
+					supportsImages: true,
+					supportsPromptCache: true,
+					inputPrice: 3,
+					outputPrice: 15,
+					cacheWritesPrice: 3.75,
+					cacheReadsPrice: 0.3,
+				},
+			})
+			const model = h.getModel()
+			expect(model.id).to.equal("claude-sonnet-4-6")
+			expect(model.info.contextWindow).to.equal(1_000_000)
+		})
+
+		it("prefers StateManager cached model info over user-configured liteLlmModelInfo", () => {
+			const cachedInfo = {
+				contextWindow: 200_000,
+				maxTokens: 4096,
+				supportsImages: true,
+				supportsPromptCache: true,
+				inputPrice: 0,
+				outputPrice: 0,
+			}
+			stateManagerStub.returns({
+				getModelInfo: () => cachedInfo,
+			} as any)
+
+			const h = new LiteLlmHandler({
+				liteLlmApiKey: "test",
+				liteLlmModelId: "claude-sonnet-4-6",
+				liteLlmModelInfo: {
+					contextWindow: 1_000_000,
+					maxTokens: 8192,
+					supportsImages: true,
+					supportsPromptCache: true,
+					inputPrice: 3,
+					outputPrice: 15,
+					cacheWritesPrice: 3.75,
+					cacheReadsPrice: 0.3,
+				},
+			})
+			const model = h.getModel()
+			expect(model.info.contextWindow).to.equal(200_000)
 		})
 	})
 })

--- a/src/core/api/providers/litellm.ts
+++ b/src/core/api/providers/litellm.ts
@@ -72,26 +72,24 @@ export async function fetchLiteLlmModelsInfo(baseUrl: string, apiKey: string): P
 		if (response.ok) {
 			const data: LiteLlmModelInfoResponse = await response.json()
 			return data
-		} else {
-			Logger.error("Failed to fetch LiteLLM model info:", response.statusText)
-			// Try with Authorization header instead
-			const retryResponse = await fetch(url, {
-				method: "GET",
-				headers: {
-					accept: "application/json",
-					Authorization: `Bearer ${apiKey}`,
-					...buildExternalBasicHeaders(),
-				},
-			})
-
-			if (retryResponse.ok) {
-				const data: LiteLlmModelInfoResponse = await retryResponse.json()
-				return data
-			} else {
-				Logger.error("Failed to fetch LiteLLM model info with Authorization header:", retryResponse.statusText)
-				throw new Error(`Failed to fetch LiteLLM model info: ${retryResponse.statusText}`)
-			}
 		}
+		Logger.error("Failed to fetch LiteLLM model info:", response.statusText)
+		// Try with Authorization header instead
+		const retryResponse = await fetch(url, {
+			method: "GET",
+			headers: {
+				accept: "application/json",
+				Authorization: `Bearer ${apiKey}`,
+				...buildExternalBasicHeaders(),
+			},
+		})
+
+		if (retryResponse.ok) {
+			const data: LiteLlmModelInfoResponse = await retryResponse.json()
+			return data
+		}
+		Logger.error("Failed to fetch LiteLLM model info with Authorization header:", retryResponse.statusText)
+		throw new Error(`Failed to fetch LiteLLM model info: ${retryResponse.statusText}`)
 	} catch (error) {
 		Logger.error("Error fetching LiteLLM model info:", error)
 		throw error
@@ -102,7 +100,7 @@ export class LiteLlmHandler implements ApiHandler {
 	private options: LiteLlmHandlerOptions
 	private client: OpenAI | undefined
 	private modelInfoCache: LiteLlmModelInfoResponse | undefined
-	private modelInfoCacheTimestamp: number = 0
+	private modelInfoCacheTimestamp = 0
 	private readonly modelInfoCacheTTL = 5 * 60 * 1000 // 5 minutes
 
 	constructor(options: LiteLlmHandlerOptions) {
@@ -274,7 +272,8 @@ export class LiteLlmHandler implements ApiHandler {
 								},
 							] as any,
 						}
-					} else if (Array.isArray(message.content)) {
+					}
+					if (Array.isArray(message.content)) {
 						// Apply cache control to the last content item in the array
 						return {
 							...message,
@@ -377,7 +376,7 @@ export class LiteLlmHandler implements ApiHandler {
 		const cachedModelInfo = StateManager.get().getModelInfo("liteLlm", modelId)
 
 		// Fall back to provided model info or defaults if not in cache
-		const modelInfo = cachedModelInfo || liteLlmModelInfoSaneDefaults
+		const modelInfo = cachedModelInfo || this.options.liteLlmModelInfo || liteLlmModelInfoSaneDefaults
 
 		return {
 			id: modelId,


### PR DESCRIPTION
### Related Issue

**Issue:** #9748

### Description

`LiteLlmHandler.getModel()` silently ignores the user-configured model info (`this.options.liteLlmModelInfo`) when building the model info object. The fallback chain was:

```typescript
// Before
const modelInfo = cachedModelInfo || liteLlmModelInfoSaneDefaults
```

`this.options.liteLlmModelInfo` is populated from the stored `planModeLiteLlmModelInfo`/`actModeLiteLlmModelInfo` settings — this is where users set custom context windows (e.g. 1M tokens). The StateManager cache (`cachedModelInfo`) is never populated for LiteLLM models in practice (no `setModelInfo("liteLlm", ...)` call exists in the codebase), so every call always fell through to `liteLlmModelInfoSaneDefaults` which has `contextWindow: 128_000`.

**Effect:** The `ContextManager` reads context window size from `getModel()`. Users who configured 1M context window saw 88% auto-condense trigger at ~112K tokens (88% of 128K) instead of ~880K tokens (88% of 1M). The UI displayed the correct 1M value but the compaction logic used 128K.

**Fix:** One line — add `this.options.liteLlmModelInfo` to the fallback chain:

```typescript
// After
const modelInfo = cachedModelInfo || this.options.liteLlmModelInfo || liteLlmModelInfoSaneDefaults
```

The priority is: StateManager cache (from LiteLLM server) → user-configured model info → hardcoded defaults.

### Test Procedure

Added three new unit tests to `litellm.test.ts` covering `getModel()`:

1. **Returns sane defaults** when no `liteLlmModelInfo` option is provided (existing behavior preserved)
2. **Returns user-configured model info** when `liteLlmModelInfo` is provided and no StateManager cache exists (the bug fix)
3. **Prefers StateManager cache** over user-configured `liteLlmModelInfo` (cache still wins)

All 3 new tests pass. Full test suite: 1255 passing, 0 failures, 4 pending (run with `TS_NODE_TRANSPILE_ONLY=true` to bypass unrelated WANDB proto type error on current main).

No existing tests were broken. The change only affects the fallback order — if StateManager cache is populated (future scenario), it still takes precedence.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

No UI changes. The fix is in provider logic.

**Root cause trace:**
- `LiteLlmHandler.getModel()` → returns `liteLlmModelInfoSaneDefaults` (128K) instead of user config
- `getContextWindowInfo(api)` → reads `api.getModel().info.contextWindow` → gets 128K
- `ContextManager` compaction threshold → `128K * 0.88 = 112K` (triggers around ~100K tokens)
- **After fix:** `getModel()` returns `this.options.liteLlmModelInfo` → gets 1M → threshold = 880K ✓

### Additional Notes

The comment above the fixed line already described the intended behavior: *"Fall back to provided model info or defaults if not in cache"* — but the implementation only fell back to defaults, not provided model info. This was a simple oversight.

This same bug may affect the OCA provider (`oca.ts`) which has a similar pattern (`this.options.ocaModelInfo || liteLlmModelInfoSaneDefaults` — already correct there).
