### PR TITLE
fix(browser): skip WebP screenshots for GLM and Devstral models (llama.cpp STB doesn't support WebP)

### DIFF
--- a/src/utils/__tests__/model-utils.test.ts
+++ b/src/utils/__tests__/model-utils.test.ts
@@ -1,13 +1,19 @@
 import { describe, it } from "mocha"
 import "should"
+import type { ApiHandlerModel } from "@core/api"
 import {
 	GEMINI_FLASH_MAX_OUTPUT_TOKENS,
 	isClaude4PlusModelFamily,
 	isGeminiFlashModel,
+	isGLMModelFamily,
 	isGPT5ModelFamily,
 	isGptOssModelFamily,
+	modelDoesntSupportWebp,
 	shouldSkipReasoningForModel,
 } from "../model-utils"
+
+// Minimal helper — modelDoesntSupportWebp only reads apiHandlerModel.id
+const m = (id: string): ApiHandlerModel => ({ id, info: {} as any })
 
 describe("shouldSkipReasoningForModel", () => {
 	it("should return true for grok-4 models", () => {
@@ -140,5 +146,61 @@ describe("isGeminiFlashModel", () => {
 describe("GEMINI_FLASH_MAX_OUTPUT_TOKENS", () => {
 	it("should be set to 8192", () => {
 		GEMINI_FLASH_MAX_OUTPUT_TOKENS.should.equal(8_192)
+	})
+})
+
+describe("isGLMModelFamily", () => {
+	it("should match hyphen-separated GLM model IDs", () => {
+		isGLMModelFamily("glm-4.6").should.equal(true)
+		isGLMModelFamily("glm-4.5").should.equal(true)
+		isGLMModelFamily("glm-4.7").should.equal(true)
+		isGLMModelFamily("glm-5").should.equal(true)
+		isGLMModelFamily("z-ai/glm-4.6").should.equal(true)
+		isGLMModelFamily("zai-org/glm-4.5").should.equal(true)
+	})
+
+	it("should match space-separated GLM model IDs used with openai-compatible local servers", () => {
+		// "GLM 4.6V" is the model ID reported in issue #8203
+		isGLMModelFamily("GLM 4.6V").should.equal(true)
+		isGLMModelFamily("glm 4.6v").should.equal(true)
+		isGLMModelFamily("GLM 4.5").should.equal(true)
+	})
+
+	it("should return false for non-GLM models", () => {
+		isGLMModelFamily("gpt-4").should.equal(false)
+		isGLMModelFamily("claude-sonnet-4").should.equal(false)
+		isGLMModelFamily("gemini-2.5-flash").should.equal(false)
+	})
+})
+
+describe("modelDoesntSupportWebp", () => {
+	it("should return true for Grok models", () => {
+		modelDoesntSupportWebp(m("grok-3")).should.equal(true)
+		modelDoesntSupportWebp(m("x-ai/grok-3-mini")).should.equal(true)
+	})
+
+	it("should return true for GLM models (hyphen-separated)", () => {
+		modelDoesntSupportWebp(m("glm-4.6")).should.equal(true)
+		modelDoesntSupportWebp(m("glm-4.5")).should.equal(true)
+		modelDoesntSupportWebp(m("z-ai/glm-4.6")).should.equal(true)
+	})
+
+	it("should return true for GLM models with space-separated IDs (issue #8203)", () => {
+		modelDoesntSupportWebp(m("GLM 4.6V")).should.equal(true)
+		modelDoesntSupportWebp(m("glm 4.5")).should.equal(true)
+	})
+
+	it("should return true for Devstral models running through llama.cpp", () => {
+		modelDoesntSupportWebp(m("devstral-small")).should.equal(true)
+		modelDoesntSupportWebp(m("unsloth/devstral-small-2512")).should.equal(true)
+		modelDoesntSupportWebp(m("Devstral-Small-2-24B-Instruct")).should.equal(true)
+	})
+
+	it("should return false for models that support WebP", () => {
+		modelDoesntSupportWebp(m("claude-sonnet-4")).should.equal(false)
+		modelDoesntSupportWebp(m("gpt-5")).should.equal(false)
+		modelDoesntSupportWebp(m("gemini-2.5-flash")).should.equal(false)
+		modelDoesntSupportWebp(m("qwen2.5-vl-72b")).should.equal(false)
+		modelDoesntSupportWebp(m("llama-3.1-8b")).should.equal(false)
 	})
 })

--- a/src/utils/model-utils.ts
+++ b/src/utils/model-utils.ts
@@ -29,7 +29,10 @@ export function isNextGenModelProvider(providerInfo: ApiProviderInfo): boolean {
 
 export function modelDoesntSupportWebp(apiHandlerModel: ApiHandlerModel): boolean {
 	const modelId = apiHandlerModel.id.toLowerCase()
-	return modelId.includes("grok")
+	// Grok doesn't support WebP via its API.
+	// GLM and Devstral models running through llama.cpp fail with WebP because
+	// llama.cpp's STB image library doesn't support the WebP format.
+	return modelId.includes("grok") || isGLMModelFamily(modelId) || isDevstralModelFamily(modelId)
 }
 
 /**
@@ -108,6 +111,8 @@ export function isGLMModelFamily(id: string): boolean {
 		modelId.includes("glm-4.7") ||
 		modelId.includes("glm-4.6") ||
 		modelId.includes("glm-4.5") ||
+		// Space-separated variants like "GLM 4.6V" used with openai-compatible local servers
+		modelId.includes("glm 4.") ||
 		modelId.includes("z-ai/glm") ||
 		modelId.includes("zai-org/glm")
 	)


### PR DESCRIPTION
## Summary

`modelDoesntSupportWebp()` only skipped WebP screenshots for Grok models. Users running **GLM** and **Devstral** vision models through a local llama.cpp server hit a 400 error whenever Cline used the browser tool, because llama.cpp's STB image library doesn't support the WebP format.

Closes #8203

## Root cause

```typescript
// Before — only Grok
export function modelDoesntSupportWebp(apiHandlerModel: ApiHandlerModel): boolean {
    const modelId = apiHandlerModel.id.toLowerCase()
    return modelId.includes("grok")
}
```

Browser screenshots default to WebP. llama.cpp decodes images using STB, which has no WebP support. Any vision model running through llama.cpp server (openai-compatible endpoint) will return `400 Failed to load image or audio file` unless we downgrade to PNG.

## Changes

**`src/utils/model-utils.ts`**
- Extend `modelDoesntSupportWebp()` to also return `true` for GLM and Devstral model families, using the existing `isGLMModelFamily()` and `isDevstralModelFamily()` detection functions.
- Update `isGLMModelFamily()` to handle space-separated model IDs like `"GLM 4.6V"` (the format llama.cpp server reports for this model, which previously wasn't matched by the hyphen-based checks).

**`src/utils/__tests__/model-utils.test.ts`**
- Add `describe("isGLMModelFamily")` tests covering both hyphen-separated and space-separated variants.
- Add `describe("modelDoesntSupportWebp")` tests covering Grok, GLM (both formats), Devstral, and WebP-capable models that should not be affected.

## Testing

```
1263 passing (44s), 0 failing
```

All new test cases pass, including the exact model ID from the bug report (`"GLM 4.6V"`).

## What this doesn't fix

This is a targeted fix for the reported model families. A proper long-term solution would add a `supportsWebP` flag to model configuration with a UI checkbox, so any local model user can opt out of WebP regardless of model name. That's tracked as a follow-up (PR 2).

## Models covered

| Model | Reported by | Previously broken |
|---|---|---|
| GLM 4.6V (via llama.cpp) | @ramblingcoder | ✅ |
| GLM 4.5 / GLM-4.6 (via llama.cpp) | @AbirFaisal | ✅ |
| Devstral-Small (via llama.cpp) | @AbirFaisal, @Incongruent | ✅ |
