### PR TITLE
fix(wandb): honor explicit model IDs outside static catalog

### DIFF
--- a/src/core/api/providers/__tests__/wandb.test.ts
+++ b/src/core/api/providers/__tests__/wandb.test.ts
@@ -1,0 +1,42 @@
+import "should"
+import { openAiModelInfoSaneDefaults, wandbDefaultModelId, wandbModels } from "@shared/api"
+import { WandbHandler } from "../wandb"
+
+describe("WandbHandler", () => {
+	it("returns known catalog model metadata when model id is recognized", () => {
+		const modelId = "meta-llama/Llama-3.3-70B-Instruct"
+		const handler = new WandbHandler({
+			wandbApiKey: "test-api-key",
+			apiModelId: modelId,
+		})
+
+		const model = handler.getModel()
+
+		model.id.should.equal(modelId)
+		model.info.should.deepEqual(wandbModels[modelId])
+	})
+
+	it("passes through an explicit unknown model id instead of silently falling back", () => {
+		const unknownModelId = "moonshotai/Kimi-K2.5"
+		const handler = new WandbHandler({
+			wandbApiKey: "test-api-key",
+			apiModelId: unknownModelId,
+		})
+
+		const model = handler.getModel()
+
+		model.id.should.equal(unknownModelId)
+		model.info.should.deepEqual(openAiModelInfoSaneDefaults)
+	})
+
+	it("uses the default W&B model when no model id is configured", () => {
+		const handler = new WandbHandler({
+			wandbApiKey: "test-api-key",
+		})
+
+		const model = handler.getModel()
+
+		model.id.should.equal(wandbDefaultModelId)
+		model.info.should.deepEqual(wandbModels[wandbDefaultModelId])
+	})
+})

--- a/src/core/api/providers/wandb.ts
+++ b/src/core/api/providers/wandb.ts
@@ -1,4 +1,4 @@
-import { type ModelInfo, type WandbModelId, wandbDefaultModelId, wandbModels } from "@shared/api"
+import { openAiModelInfoSaneDefaults, type ModelInfo, type WandbModelId, wandbDefaultModelId, wandbModels } from "@shared/api"
 import OpenAI from "openai"
 import type { ChatCompletionTool as OpenAITool } from "openai/resources/chat/completions"
 import { ClineStorageMessage } from "@/shared/messages/content"
@@ -87,11 +87,16 @@ export class WandbHandler implements ApiHandler {
 	}
 
 	getModel(): { id: string; info: ModelInfo } {
-		const modelId = this.options.apiModelId
+		const modelId = this.options.apiModelId?.trim()
 
-		if (modelId !== undefined && modelId in wandbModels) {
+		if (modelId && modelId in wandbModels) {
 			return { id: modelId, info: wandbModels[modelId as WandbModelId] }
 		}
+
+		if (modelId) {
+			return { id: modelId, info: openAiModelInfoSaneDefaults }
+		}
+
 		return { id: wandbDefaultModelId, info: wandbModels[wandbDefaultModelId] }
 	}
 }


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

### Description

This PR fixes a W&B provider model resolution bug where explicitly configured model IDs outside the static `wandbModels` catalog were silently replaced by the default model.

Before this change:
- `WandbHandler.getModel()` fell back to `meta-llama/Llama-3.3-70B-Instruct` when `apiModelId` was not in the static list.
- Example impact: `cline auth -p wandb -m moonshotai/Kimi-K2.5` did not actually use `moonshotai/Kimi-K2.5`.

After this change:
- Known catalog IDs still use their catalog metadata.
- Unknown but explicitly configured IDs now pass through as-is.
- Omitted model IDs still fall back to the existing W&B default.
- Added unit tests for known, unknown, and unset model-id paths.

### Test Procedure

- Ran proto generation:
  - `npm run protos`
- Ran unit tests for this area:
  - `TS_NODE_PROJECT=./tsconfig.unit-test.json ./node_modules/.bin/mocha src/core/api/providers/__tests__/wandb.test.ts`
  - Result: passing (the repo's mocha config executed the unit suite; 1263 passing).
- Manual validation done before and after patch:
  - Reproduced that unknown W&B model IDs previously fell back to the default model.
  - Confirmed explicit unknown IDs now resolve to the configured model ID.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A (backend/provider logic only).

### Additional Notes

This intentionally removes a silent fallback path for explicit unknown W&B model IDs so configuration matches runtime behavior.
