### PR TITLE
feat: add Kanban launch banner

### DIFF
--- a/src/shared/cline/banner.ts
+++ b/src/shared/cline/banner.ts
@@ -87,6 +87,22 @@ export interface BannerAction {
  */
 
 export const BANNER_DATA: BannerCardData[] = [
+	// Kanban launch banner
+	{
+		id: "kanban-launch-2026-mar-16",
+		icon: "layout-dashboard",
+		title: "Introducing Kanban",
+		description:
+			"Run many CLI agents in parallel with isolated worktrees and real-time diffs. Install with `npm i -g kanban`.",
+		actions: [
+			{
+				title: "View on GitHub",
+				action: BannerActionType.Link,
+				arg: "https://github.com/cline/kanban",
+			},
+		],
+	},
+
 	// Sonnet 4.6 banner
 	{
 		// Bump this version string when copy/CTA changes and you want the banner to reappear.

--- a/webview-ui/src/components/common/WhatsNewItems.tsx
+++ b/webview-ui/src/components/common/WhatsNewItems.tsx
@@ -31,6 +31,17 @@ export const WhatsNewItems: React.FC<WhatsNewItemsProps> = ({
 
 	return (
 		<ul className="text-sm pl-3 list-disc" style={{ color: "var(--vscode-descriptionForeground)" }}>
+			<li className="mb-2">
+				<strong>Introducing Kanban:</strong> Run many CLI agents in parallel with worktrees and real-time diffs. Install
+				with <code style={inlineCodeStyle}>npm i -g kanban</code> or <code style={inlineCodeStyle}>npx kanban</code>.{" "}
+				<a
+					href="https://github.com/cline/kanban"
+					rel="noopener noreferrer"
+					style={{ color: "var(--vscode-textLink-foreground)" }}
+					target="_blank">
+					View on GitHub
+				</a>
+			</li>
 			{hasWelcomeBanners ? (
 				welcomeBanners.map((banner) => (
 					<li className="mb-2" key={banner.id}>


### PR DESCRIPTION
### Related Issue

N/A -- internal feature promotion

### Description

Adds a banner and What's New entry to promote the new [Kanban](https://github.com/cline/kanban) tool, which lets users run many CLI agents in parallel with isolated worktrees and real-time diffs.

Two surfaces updated:
- Banner carousel (`src/shared/cline/banner.ts`): new card at the top of `BANNER_DATA` with a "View on GitHub" link
- What's New list (`webview-ui/src/components/common/WhatsNewItems.tsx`): pinned list item with install instructions (`npm i -g kanban` / `npx kanban`) and a GitHub link

### Test Procedure

- Open the extension, verify the Kanban banner appears in the welcome carousel
- Click "View on GitHub" and confirm it opens `https://github.com/cline/kanban`
- Open the What's New panel and verify the Kanban entry appears at the top with working links

### Type of Change

-   [x] ✨ New feature (non-breaking change which adds functionality)

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)