### PR TITLE
fix(task): latch double-check completion until next edit

### DIFF
--- a/src/core/task/TaskState.ts
+++ b/src/core/task/TaskState.ts
@@ -49,6 +49,7 @@ export class TaskState {
 	consecutiveMistakeCount = 0
 	doubleCheckCompletionPending = false
 	doubleCheckCompletionLatched = false
+	doubleCheckCompletionRejectionCount = 0
 	didAutomaticallyRetryFailedApiRequest = false
 	checkpointManagerErrorMessage?: string
 

--- a/src/core/task/TaskState.ts
+++ b/src/core/task/TaskState.ts
@@ -48,6 +48,7 @@ export class TaskState {
 	// Error tracking
 	consecutiveMistakeCount = 0
 	doubleCheckCompletionPending = false
+	doubleCheckCompletionLatched = false
 	didAutomaticallyRetryFailedApiRequest = false
 	checkpointManagerErrorMessage?: string
 

--- a/src/core/task/tools/handlers/ApplyPatchHandler.ts
+++ b/src/core/task/tools/handlers/ApplyPatchHandler.ts
@@ -344,10 +344,15 @@ export class ApplyPatchHandler implements IFullyManagedTool {
 
 			// Build response with file contents and diagnostics
 			const responseLines = ["Successfully applied patch to the following files:"]
+			const hasAppliedChanges = Object.keys(applyResults).length > 0
+			if (hasAppliedChanges) {
+				config.taskState.didEditFile = true
+				config.taskState.doubleCheckCompletionPending = false
+				config.taskState.doubleCheckCompletionLatched = false
+			}
 
 			for (const [path, result] of Object.entries(applyResults)) {
 				if (result.deleted) {
-					config.taskState.didEditFile = true
 					responseLines.push(`\n${path}: [deleted]`)
 				} else {
 					// Format response similar to WriteToFileToolHandler

--- a/src/core/task/tools/handlers/ApplyPatchHandler.ts
+++ b/src/core/task/tools/handlers/ApplyPatchHandler.ts
@@ -349,6 +349,7 @@ export class ApplyPatchHandler implements IFullyManagedTool {
 				config.taskState.didEditFile = true
 				config.taskState.doubleCheckCompletionPending = false
 				config.taskState.doubleCheckCompletionLatched = false
+				config.taskState.doubleCheckCompletionRejectionCount = 0
 			}
 
 			for (const [path, result] of Object.entries(applyResults)) {

--- a/src/core/task/tools/handlers/AttemptCompletionHandler.ts
+++ b/src/core/task/tools/handlers/AttemptCompletionHandler.ts
@@ -65,29 +65,36 @@ export class AttemptCompletionHandler implements IToolHandler, IPartialBlockHand
 
 		config.taskState.consecutiveMistakeCount = 0
 
-		// Double-check completion: reject attempt_completion calls that haven't been re-verified
-		if (config.doubleCheckCompletionEnabled && !config.taskState.doubleCheckCompletionPending) {
-			config.taskState.doubleCheckCompletionPending = true
-			// Remove the partial completion_result message that was shown during streaming
-			await config.callbacks.removeLastPartialMessageIfExistsWithType("say", "completion_result")
+		// Double-check completion with a latch:
+		// - First completion attempt after edits is rejected with guidance.
+		// - Immediate follow-up attempt is accepted and latched.
+		// - Latch remains until invalidated by a later edit.
+		if (config.doubleCheckCompletionEnabled && !config.taskState.doubleCheckCompletionLatched) {
+			if (!config.taskState.doubleCheckCompletionPending) {
+				config.taskState.doubleCheckCompletionPending = true
+				// Remove the partial completion_result message that was shown during streaming
+				await config.callbacks.removeLastPartialMessageIfExistsWithType("say", "completion_result")
 
-			const taskPreview = getInitialTaskPreview(config)
-			const taskSection = taskPreview ? `\n\n<initial_task>\n${taskPreview}\n</initial_task>` : ""
+				const taskPreview = getInitialTaskPreview(config)
+				const taskSection = taskPreview ? `\n\n<initial_task>\n${taskPreview}\n</initial_task>` : ""
 
-			return formatResponse.toolError(
-				"Before completing, re-verify your work against the original task requirements. Check that:\n" +
-					"1. All requested changes have been made\n" +
-					"2. No steps were skipped or partially completed\n" +
-					"3. Edge cases and error handling are addressed\n" +
-					"4. The solution matches what was asked for, not just what was convenient\n" +
-					"5. Output files contain exactly what was specified--no extra columns, fields, debug output, or commentary\n" +
-					"6. If the task specifies numerical thresholds or accuracy targets, verify your result meets the criteria. If close but not passing, iterate rather than declaring completion" +
-					taskSection +
-					"\n\nIf everything checks out, call attempt_completion again with your final result.",
-			)
+				return formatResponse.toolError(
+					"Before completing, re-verify your work against the original task requirements. Check that:\n" +
+						"1. All requested changes have been made\n" +
+						"2. No steps were skipped or partially completed\n" +
+						"3. Edge cases and error handling are addressed\n" +
+						"4. The solution matches what was asked for, not just what was convenient\n" +
+						"5. Output files contain exactly what was specified--no extra columns, fields, debug output, or commentary\n" +
+						"6. If the task specifies numerical thresholds or accuracy targets, verify your result meets the criteria. If close but not passing, iterate rather than declaring completion" +
+						taskSection +
+						"\n\nIf everything checks out, call attempt_completion again with your final result.",
+				)
+			}
+
+			// Follow-up completion attempt passes and sets the latch.
+			config.taskState.doubleCheckCompletionPending = false
+			config.taskState.doubleCheckCompletionLatched = true
 		}
-		// Reset so the next attempt_completion pair triggers double-check again
-		config.taskState.doubleCheckCompletionPending = false
 
 		// Run PreToolUse hook before execution
 		try {

--- a/src/core/task/tools/handlers/AttemptCompletionHandler.ts
+++ b/src/core/task/tools/handlers/AttemptCompletionHandler.ts
@@ -20,6 +20,65 @@ import { getTaskCompletionTelemetry } from "../utils"
 import { ToolResultUtils } from "../utils/ToolResultUtils"
 
 const TASK_PREVIEW_MAX_CHARS = 8000
+export const DOUBLE_CHECK_MAX_GATE_REJECTIONS = 3
+export const DOUBLE_CHECK_FINALIZATION_RESERVE_SEC = 90
+const DOUBLE_CHECK_TASK_TIMEOUT_ENV_KEY = "CLINE_TASK_TIMEOUT_SECONDS"
+
+export type DoubleCheckGateBypassReason = "max_gate_rejections" | "finalization_reserve"
+
+export function resolveDoubleCheckTaskTimeoutSeconds(env: NodeJS.ProcessEnv = process.env): number | undefined {
+	const rawValue = env[DOUBLE_CHECK_TASK_TIMEOUT_ENV_KEY]
+	if (!rawValue) {
+		return undefined
+	}
+
+	const parsed = Number.parseInt(rawValue, 10)
+	return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined
+}
+
+export function evaluateDoubleCheckGateFuse(args: {
+	rejectionCount: number
+	taskStartTimeMs: number
+	taskTimeoutSeconds?: number
+	maxGateRejections?: number
+	finalizationReserveSec?: number
+	nowMs?: number
+}): {
+	shouldBypass: boolean
+	reason?: DoubleCheckGateBypassReason
+	remainingSeconds?: number
+} {
+	const maxGateRejections = args.maxGateRejections ?? DOUBLE_CHECK_MAX_GATE_REJECTIONS
+	if (args.rejectionCount >= maxGateRejections) {
+		return {
+			shouldBypass: true,
+			reason: "max_gate_rejections",
+		}
+	}
+
+	if (args.taskTimeoutSeconds === undefined) {
+		return {
+			shouldBypass: false,
+		}
+	}
+
+	const nowMs = args.nowMs ?? Date.now()
+	const elapsedSeconds = Math.max(0, (nowMs - args.taskStartTimeMs) / 1000)
+	const remainingSeconds = args.taskTimeoutSeconds - elapsedSeconds
+	const finalizationReserveSec = args.finalizationReserveSec ?? DOUBLE_CHECK_FINALIZATION_RESERVE_SEC
+	if (remainingSeconds <= finalizationReserveSec) {
+		return {
+			shouldBypass: true,
+			reason: "finalization_reserve",
+			remainingSeconds,
+		}
+	}
+
+	return {
+		shouldBypass: false,
+		remainingSeconds,
+	}
+}
 
 function getInitialTaskPreview(config: TaskConfig): string | undefined {
 	const firstTaskMessage = config.messageState
@@ -71,29 +130,55 @@ export class AttemptCompletionHandler implements IToolHandler, IPartialBlockHand
 		// - Latch remains until invalidated by a later edit.
 		if (config.doubleCheckCompletionEnabled && !config.taskState.doubleCheckCompletionLatched) {
 			if (!config.taskState.doubleCheckCompletionPending) {
-				config.taskState.doubleCheckCompletionPending = true
-				// Remove the partial completion_result message that was shown during streaming
-				await config.callbacks.removeLastPartialMessageIfExistsWithType("say", "completion_result")
+				const nextRejectionCount = config.taskState.doubleCheckCompletionRejectionCount + 1
+				config.taskState.doubleCheckCompletionRejectionCount = nextRejectionCount
 
-				const taskPreview = getInitialTaskPreview(config)
-				const taskSection = taskPreview ? `\n\n<initial_task>\n${taskPreview}\n</initial_task>` : ""
+				const fuseDecision = evaluateDoubleCheckGateFuse({
+					rejectionCount: nextRejectionCount,
+					taskStartTimeMs: config.taskState.taskStartTimeMs,
+					taskTimeoutSeconds: resolveDoubleCheckTaskTimeoutSeconds(),
+				})
 
-				return formatResponse.toolError(
-					"Before completing, re-verify your work against the original task requirements. Check that:\n" +
-						"1. All requested changes have been made\n" +
-						"2. No steps were skipped or partially completed\n" +
-						"3. Edge cases and error handling are addressed\n" +
-						"4. The solution matches what was asked for, not just what was convenient\n" +
-						"5. Output files contain exactly what was specified--no extra columns, fields, debug output, or commentary\n" +
-						"6. If the task specifies numerical thresholds or accuracy targets, verify your result meets the criteria. If close but not passing, iterate rather than declaring completion" +
-						taskSection +
-						"\n\nIf everything checks out, call attempt_completion again with your final result.",
-				)
+				if (!fuseDecision.shouldBypass) {
+					config.taskState.doubleCheckCompletionPending = true
+					// Remove the partial completion_result message that was shown during streaming
+					await config.callbacks.removeLastPartialMessageIfExistsWithType("say", "completion_result")
+
+					const taskPreview = getInitialTaskPreview(config)
+					const taskSection = taskPreview ? `\n\n<initial_task>\n${taskPreview}\n</initial_task>` : ""
+
+					return formatResponse.toolError(
+						"Before completing, re-verify your work against the original task requirements. Check that:\n" +
+							"1. All requested changes have been made\n" +
+							"2. No steps were skipped or partially completed\n" +
+							"3. Edge cases and error handling are addressed\n" +
+							"4. The solution matches what was asked for, not just what was convenient\n" +
+							"5. Output files contain exactly what was specified--no extra columns, fields, debug output, or commentary\n" +
+							"6. If the task specifies numerical thresholds or accuracy targets, verify your result meets the criteria. If close but not passing, iterate rather than declaring completion" +
+							taskSection +
+							"\n\nIf everything checks out, call attempt_completion again with your final result.",
+					)
+				}
+
+				config.taskState.doubleCheckCompletionPending = false
+				config.taskState.doubleCheckCompletionLatched = true
+
+				const reasonText =
+					fuseDecision.reason === "finalization_reserve"
+						? `Bypassing completion re-check: remaining task budget (${Math.max(
+								0,
+								Math.floor(fuseDecision.remainingSeconds ?? 0),
+							)}s) is within finalization reserve (${DOUBLE_CHECK_FINALIZATION_RESERVE_SEC}s).`
+						: `Bypassing completion re-check after ${nextRejectionCount} gate rejections to avoid retry loops.`
+
+				Logger.warn(`[AttemptCompletionHandler] ${reasonText}`)
+				await config.callbacks.say("info", reasonText)
 			}
 
 			// Follow-up completion attempt passes and sets the latch.
 			config.taskState.doubleCheckCompletionPending = false
 			config.taskState.doubleCheckCompletionLatched = true
+			config.taskState.doubleCheckCompletionRejectionCount = 0
 		}
 
 		// Run PreToolUse hook before execution

--- a/src/core/task/tools/handlers/WriteToFileToolHandler.ts
+++ b/src/core/task/tools/handlers/WriteToFileToolHandler.ts
@@ -362,6 +362,7 @@ export class WriteToFileToolHandler implements IFullyManagedTool {
 			config.taskState.didEditFile = true // used to determine if we should wait for busy terminal to update before sending api request
 			config.taskState.doubleCheckCompletionPending = false
 			config.taskState.doubleCheckCompletionLatched = false
+			config.taskState.doubleCheckCompletionRejectionCount = 0
 
 			// Track file edit operation
 			await config.services.fileContextTracker.trackFileContext(relPath, "cline_edited")

--- a/src/core/task/tools/handlers/WriteToFileToolHandler.ts
+++ b/src/core/task/tools/handlers/WriteToFileToolHandler.ts
@@ -360,6 +360,8 @@ export class WriteToFileToolHandler implements IFullyManagedTool {
 			config.taskState.consecutiveMistakeCount = 0
 
 			config.taskState.didEditFile = true // used to determine if we should wait for busy terminal to update before sending api request
+			config.taskState.doubleCheckCompletionPending = false
+			config.taskState.doubleCheckCompletionLatched = false
 
 			// Track file edit operation
 			await config.services.fileContextTracker.trackFileContext(relPath, "cline_edited")

--- a/src/core/task/tools/handlers/__tests__/AttemptCompletionHandler.doubleCheck.test.ts
+++ b/src/core/task/tools/handlers/__tests__/AttemptCompletionHandler.doubleCheck.test.ts
@@ -7,9 +7,8 @@ import { TaskState } from "../../../TaskState"
  * Tests for the double-check completion feature in AttemptCompletionHandler.
  *
  * When doubleCheckCompletionEnabled is true, each attempt_completion call
- * is rejected the first time (setting pending=true), then accepted on the
- * immediate follow-up (resetting pending=false). This means every completion
- * attempt gets double-checked, not just the first one in a task.
+ * is rejected once, then accepted on the immediate follow-up and latched.
+ * The latch remains until invalidated by an edit.
  */
 describe("AttemptCompletionHandler double-check completion", () => {
 	let taskState: TaskState
@@ -42,7 +41,7 @@ describe("AttemptCompletionHandler double-check completion", () => {
 			taskState.doubleCheckCompletionPending = true
 		})
 
-		it("should accept the second completion attempt and reset pending", () => {
+		it("should accept the second completion attempt and latch completion gate", () => {
 			const enabled = true
 
 			// Simulate first call rejected
@@ -52,38 +51,36 @@ describe("AttemptCompletionHandler double-check completion", () => {
 			const shouldReject = enabled && !taskState.doubleCheckCompletionPending
 			shouldReject.should.be.false()
 
-			// Handler resets pending after acceptance
+			// Handler resets pending and latches after acceptance
 			taskState.doubleCheckCompletionPending = false
+			taskState.doubleCheckCompletionLatched = true
 			taskState.doubleCheckCompletionPending.should.be.false()
+			taskState.doubleCheckCompletionLatched.should.be.true()
 		})
 
-		it("should reject again after the pending flag is reset (third call)", () => {
+		it("should not reject subsequent attempts while latched", () => {
 			const enabled = true
 
-			// After a full reject/accept cycle, pending is back to false
+			// After a full reject/accept cycle, pending is false and latch is true
 			taskState.doubleCheckCompletionPending = false
+			taskState.doubleCheckCompletionLatched = true
 
-			const shouldReject = enabled && !taskState.doubleCheckCompletionPending
-			shouldReject.should.be.true()
+			const shouldReject = enabled && !taskState.doubleCheckCompletionLatched && !taskState.doubleCheckCompletionPending
+			shouldReject.should.be.false()
 		})
 
-		it("should double-check every completion attempt across a full task lifecycle", () => {
-			const shouldReject = () => !taskState.doubleCheckCompletionPending
-
-			// Cycle 1: reject, then accept
-			shouldReject().should.be.true()
-			taskState.doubleCheckCompletionPending = true
-			shouldReject().should.be.false()
+		it("should require re-check again after edit invalidates latch", () => {
+			// Simulate a previously latched state
+			taskState.doubleCheckCompletionLatched = true
 			taskState.doubleCheckCompletionPending = false
 
-			// Cycle 2: reject, then accept
-			shouldReject().should.be.true()
-			taskState.doubleCheckCompletionPending = true
-			shouldReject().should.be.false()
+			// Edit invalidates latch
+			taskState.doubleCheckCompletionLatched = false
 			taskState.doubleCheckCompletionPending = false
 
-			// Cycle 3: still triggers
-			shouldReject().should.be.true()
+			// First completion attempt after invalidation should be rejected again
+			const shouldReject = !taskState.doubleCheckCompletionLatched && !taskState.doubleCheckCompletionPending
+			shouldReject.should.be.true()
 		})
 	})
 
@@ -99,12 +96,15 @@ describe("AttemptCompletionHandler double-check completion", () => {
 	describe("initialization and lifecycle", () => {
 		it("should start as false", () => {
 			taskState.doubleCheckCompletionPending.should.be.false()
+			taskState.doubleCheckCompletionLatched.should.be.false()
 		})
 
 		it("should reset with new TaskState (new task)", () => {
 			taskState.doubleCheckCompletionPending = true
+			taskState.doubleCheckCompletionLatched = true
 			const newTaskState = new TaskState()
 			newTaskState.doubleCheckCompletionPending.should.be.false()
+			newTaskState.doubleCheckCompletionLatched.should.be.false()
 		})
 	})
 })

--- a/src/core/task/tools/handlers/__tests__/AttemptCompletionHandler.doubleCheck.test.ts
+++ b/src/core/task/tools/handlers/__tests__/AttemptCompletionHandler.doubleCheck.test.ts
@@ -97,14 +97,17 @@ describe("AttemptCompletionHandler double-check completion", () => {
 		it("should start as false", () => {
 			taskState.doubleCheckCompletionPending.should.be.false()
 			taskState.doubleCheckCompletionLatched.should.be.false()
+			taskState.doubleCheckCompletionRejectionCount.should.equal(0)
 		})
 
 		it("should reset with new TaskState (new task)", () => {
 			taskState.doubleCheckCompletionPending = true
 			taskState.doubleCheckCompletionLatched = true
+			taskState.doubleCheckCompletionRejectionCount = 3
 			const newTaskState = new TaskState()
 			newTaskState.doubleCheckCompletionPending.should.be.false()
 			newTaskState.doubleCheckCompletionLatched.should.be.false()
+			newTaskState.doubleCheckCompletionRejectionCount.should.equal(0)
 		})
 	})
 })

--- a/src/core/task/tools/handlers/__tests__/AttemptCompletionHandler.gateFuse.test.ts
+++ b/src/core/task/tools/handlers/__tests__/AttemptCompletionHandler.gateFuse.test.ts
@@ -1,0 +1,70 @@
+import assert from "node:assert/strict"
+import { describe, it } from "mocha"
+import {
+	DOUBLE_CHECK_FINALIZATION_RESERVE_SEC,
+	DOUBLE_CHECK_MAX_GATE_REJECTIONS,
+	evaluateDoubleCheckGateFuse,
+	resolveDoubleCheckTaskTimeoutSeconds,
+} from "../AttemptCompletionHandler"
+
+describe("AttemptCompletionHandler gate fuse policy", () => {
+	it("bypasses when max gate rejections is reached", () => {
+		const decision = evaluateDoubleCheckGateFuse({
+			rejectionCount: DOUBLE_CHECK_MAX_GATE_REJECTIONS,
+			taskStartTimeMs: 0,
+		})
+
+		assert.equal(decision.shouldBypass, true)
+		assert.equal(decision.reason, "max_gate_rejections")
+	})
+
+	it("does not bypass when below max rejections and no timeout is configured", () => {
+		const decision = evaluateDoubleCheckGateFuse({
+			rejectionCount: DOUBLE_CHECK_MAX_GATE_REJECTIONS - 1,
+			taskStartTimeMs: 0,
+		})
+
+		assert.equal(decision.shouldBypass, false)
+		assert.equal(decision.reason, undefined)
+	})
+
+	it("bypasses when remaining budget is within finalization reserve", () => {
+		const decision = evaluateDoubleCheckGateFuse({
+			rejectionCount: 1,
+			taskStartTimeMs: 0,
+			taskTimeoutSeconds: 100,
+			finalizationReserveSec: DOUBLE_CHECK_FINALIZATION_RESERVE_SEC,
+			nowMs: (100 - DOUBLE_CHECK_FINALIZATION_RESERVE_SEC + 1) * 1000,
+		})
+
+		assert.equal(decision.shouldBypass, true)
+		assert.equal(decision.reason, "finalization_reserve")
+	})
+
+	it("does not bypass when budget remains outside finalization reserve", () => {
+		const decision = evaluateDoubleCheckGateFuse({
+			rejectionCount: 1,
+			taskStartTimeMs: 0,
+			taskTimeoutSeconds: 300,
+			finalizationReserveSec: 60,
+			nowMs: 100_000,
+		})
+
+		assert.equal(decision.shouldBypass, false)
+		assert.equal(decision.reason, undefined)
+	})
+
+	it("parses timeout seconds from environment when valid", () => {
+		const timeout = resolveDoubleCheckTaskTimeoutSeconds({
+			CLINE_TASK_TIMEOUT_SECONDS: "1200",
+		})
+
+		assert.equal(timeout, 1200)
+	})
+
+	it("ignores missing or invalid timeout environment values", () => {
+		assert.equal(resolveDoubleCheckTaskTimeoutSeconds({}), undefined)
+		assert.equal(resolveDoubleCheckTaskTimeoutSeconds({ CLINE_TASK_TIMEOUT_SECONDS: "abc" }), undefined)
+		assert.equal(resolveDoubleCheckTaskTimeoutSeconds({ CLINE_TASK_TIMEOUT_SECONDS: "0" }), undefined)
+	})
+})


### PR DESCRIPTION
## Summary
- Add a minimal double-check latch to avoid repeated completion rejections after verification
- Invalidate the latch on successful file edits (`write_to_file` and `apply_patch`)
- Update double-check unit tests to reflect latch behavior

## Changes
- `TaskState`: add `doubleCheckCompletionLatched`
- `AttemptCompletionHandler`: first completion attempt is rejected, second attempt latches and proceeds
- `WriteToFileToolHandler` + `ApplyPatchHandler`: reset latch/pending when edits are applied
- `AttemptCompletionHandler.doubleCheck.test.ts`: update expectations for latched flow

## Validation
- `npm run test:unit -- src/core/task/tools/handlers/__tests__/AttemptCompletionHandler.doubleCheck.test.ts`
- Result: `1262 passing, 4 pending`
