### PR TITLE
fix: preserve Korean and other non-Latin filenames in @ context menu

### DIFF
--- a/webview-ui/src/components/common/CodeAccordian.test.ts
+++ b/webview-ui/src/components/common/CodeAccordian.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest"
+import { cleanPathPrefix } from "./CodeAccordian"
+
+describe("cleanPathPrefix", () => {
+	it("removes leading non-letter, non-digit characters from Latin paths", () => {
+		expect(cleanPathPrefix("/test.md")).toBe("test.md")
+		expect(cleanPathPrefix("./src/index.ts")).toBe("src/index.ts")
+	})
+
+	it("preserves Korean (Hangul) characters", () => {
+		expect(cleanPathPrefix("/한글_test.md")).toBe("한글_test.md")
+	})
+
+	it("preserves Japanese characters", () => {
+		expect(cleanPathPrefix("/テスト.md")).toBe("テスト.md")
+		expect(cleanPathPrefix("/日本語.md")).toBe("日本語.md")
+	})
+
+	it("preserves Chinese characters", () => {
+		expect(cleanPathPrefix("/中文.md")).toBe("中文.md")
+	})
+
+	it("preserves Arabic characters", () => {
+		expect(cleanPathPrefix("/ملف.md")).toBe("ملف.md")
+	})
+
+	it("preserves Thai characters", () => {
+		expect(cleanPathPrefix("/ไฟล์.md")).toBe("ไฟล์.md")
+	})
+
+	it("handles mixed scripts with leading symbols", () => {
+		expect(cleanPathPrefix("/._한글test.md")).toBe("한글test.md")
+	})
+
+	it("returns the string unchanged if it starts with a letter or digit", () => {
+		expect(cleanPathPrefix("test.md")).toBe("test.md")
+		expect(cleanPathPrefix("123.md")).toBe("123.md")
+	})
+})

--- a/webview-ui/src/components/common/CodeAccordian.tsx
+++ b/webview-ui/src/components/common/CodeAccordian.tsx
@@ -20,10 +20,11 @@ interface CodeAccordianProps {
 /*
 We need to remove leading non-alphanumeric characters from the path in order for our leading ellipses trick to work.
 ^: Anchors the match to the start of the string.
-[^a-zA-Z0-9]+: Matches one or more characters that are not alphanumeric.
-The replace method removes these matched characters, effectively trimming the string up to the first alphanumeric character.
+[^\p{L}0-9]+: Matches one or more characters that are not Unicode letters or digits.
+The replace method removes these matched characters, effectively trimming the string up to the first letter or digit.
+The `u` flag enables Unicode-aware matching so \p{L} covers all scripts (Latin, CJK, Korean, Japanese, Arabic, etc.).
 */
-export const cleanPathPrefix = (path: string): string => path.replace(/^[^\u4e00-\u9fa5a-zA-Z0-9]+/, "")
+export const cleanPathPrefix = (path: string): string => path.replace(/^[^\p{L}0-9]+/u, "")
 
 const CodeAccordian = ({
 	code,


### PR DESCRIPTION
## Summary
- Fix `cleanPathPrefix` regex in `CodeAccordian.tsx` to use `\p{L}` (Unicode Letter property) instead of hardcoded Chinese character range + Latin letters
- This preserves filenames in Korean, Japanese, Thai, Arabic, and all other Unicode scripts when displaying `@` context mentions
- Add tests covering Korean, Japanese, Chinese, Arabic, Thai, mixed-script, and Latin filenames

Closes #5137

## Test plan
- [x] All 157 existing webview tests pass
- [x] 8 new tests for `cleanPathPrefix` covering multiple scripts

🤖 Generated with [Claude Code](https://claude.com/claude-code)