### PR TITLE
fix(gemini): split mixed signed/unsigned thoughtSignature parts to prevent 400 error

### DIFF
--- a/src/core/api/providers/aihubmix.ts
+++ b/src/core/api/providers/aihubmix.ts
@@ -285,7 +285,10 @@ export class AIhubmixHandler implements ApiHandler {
 		const client = this.ensureGeminiClient()
 		const modelId = this.options.modelId || "gemini-2.0-flash-exp"
 
-		const contents = messages.map(convertAnthropicMessageToGemini)
+		const contents = messages.flatMap((m) => {
+			const result = convertAnthropicMessageToGemini(m)
+			return Array.isArray(result) ? result : [result]
+		})
 
 		const requestConfig: GenerateContentConfig = {
 			systemInstruction: systemPrompt,

--- a/src/core/api/providers/gemini.ts
+++ b/src/core/api/providers/gemini.ts
@@ -148,7 +148,10 @@ export class GeminiHandler implements ApiHandler {
 	async *createMessage(systemPrompt: string, messages: ClineStorageMessage[], tools?: GoogleTool[]): ApiStream {
 		const client = this.ensureClient()
 		const { id: modelId, info } = this.getModel()
-		const contents = messages.map(convertAnthropicMessageToGemini)
+		const contents = messages.flatMap((m) => {
+			const result = convertAnthropicMessageToGemini(m)
+			return Array.isArray(result) ? result : [result]
+		})
 		// Gemini may emit multiple function calls under the same responseId and without functionCall.id.
 		// Track a local sequence so each emitted tool call has a stable unique ID.
 		const responseToolCallCount = new Map<string, number>()

--- a/src/core/api/transform/gemini-format.ts
+++ b/src/core/api/transform/gemini-format.ts
@@ -60,11 +60,36 @@ export function convertAnthropicContentToGemini(content: string | ClineStorageMe
 		.filter((part): part is Part => part !== undefined) // Filter out unsupported blocks
 }
 
-export function convertAnthropicMessageToGemini(message: Anthropic.Messages.MessageParam): Content {
-	return {
-		role: message.role === "assistant" ? "model" : "user",
-		parts: convertAnthropicContentToGemini(message.content),
+/**
+ * Convert an Anthropic message to one or more Gemini Content objects.
+ *
+ * Gemini requires that parts WITH thoughtSignature and parts WITHOUT are NOT
+ * mixed in the same Content message. When an assistant message contains both
+ * (e.g. text without signature + functionCall with signature), we split them
+ * into separate Content objects.
+ *
+ * Reference: https://ai.google.dev/gemini-api/docs/thought-signatures
+ * "Don't merge one part with a signature with another part without a signature"
+ */
+export function convertAnthropicMessageToGemini(message: Anthropic.Messages.MessageParam): Content | Content[] {
+	const role = message.role === "assistant" ? "model" : "user"
+	const parts = convertAnthropicContentToGemini(message.content)
+
+	// Only split model messages — user messages don't have thoughtSignature
+	if (role === "model" && parts.length > 1) {
+		const signed = parts.filter((p) => "thoughtSignature" in p && (p as any).thoughtSignature)
+		const unsigned = parts.filter((p) => !("thoughtSignature" in p && (p as any).thoughtSignature))
+
+		if (signed.length > 0 && unsigned.length > 0) {
+			// Split: unsigned parts first, then signed parts
+			return [
+				{ role, parts: unsigned },
+				{ role, parts: signed },
+			]
+		}
 	}
+
+	return { role, parts }
 }
 
 /*


### PR DESCRIPTION
## Problem

When Gemini thinking mode is enabled, assistant messages can contain both:
- Text parts **without** `thoughtSignature` (plain text responses)
- `functionCall` parts **with** `thoughtSignature` (tool invocations)

Gemini API rejects requests where signed and unsigned parts coexist in the same `Content` message, returning a 400 error.

From [Gemini thought signature docs](https://ai.google.dev/gemini-api/docs/thought-signatures):
> "Don't merge one part with a signature with another part without a signature"

## Fix

`convertAnthropicMessageToGemini()` now detects mixed signed/unsigned parts in model messages and splits them into two consecutive `Content` objects:

1. First: unsigned parts (text)
2. Second: signed parts (functionCall + thoughtSignature)

Return type changes from `Content` to `Content | Content[]`. Callers updated to `flatMap`.

## Changes

- `src/core/api/transform/gemini-format.ts` — split logic in `convertAnthropicMessageToGemini()`
- `src/core/api/providers/gemini.ts` — `.map()` → `.flatMap()` 
- `src/core/api/providers/aihubmix.ts` — same

## Context

This is the same bug as [LiteLLM #17949](https://github.com/BerriAI/litellm/issues/17949) (open 3+ months). I've submitted fixes there too ([PR #23809](https://github.com/BerriAI/litellm/pull/23809)) and documented the full solution in [gemini-claude-bridge](https://github.com/weijiafu14/gemini-claude-bridge).