### PR TITLE
fix(cli): add base URL and custom headers to openai-compatible setup wizard

### DIFF
--- a/cli/src/components/AuthView.tsx
+++ b/cli/src/components/AuthView.tsx
@@ -507,6 +507,12 @@ export const AuthView: React.FC<AuthViewProps> = ({ controller, onComplete, onEr
 						setHeadersError('Must be a JSON object, e.g. {"X-Key": "value"}')
 						return
 					}
+					// Validate all values are strings (HTTP headers must be string values)
+					const allStrings = Object.values(parsed).every((v) => typeof v === "string")
+					if (!allStrings) {
+						setHeadersError('All header values must be strings, e.g. {"X-Key": "value"}')
+						return
+					}
 					parsedHeaders = parsed as Record<string, string>
 				} catch {
 					setHeadersError('Invalid JSON. Try: {"X-Key": "value"}')

--- a/cli/src/components/AuthView.tsx
+++ b/cli/src/components/AuthView.tsx
@@ -43,6 +43,7 @@ type AuthStep =
 	| "apikey"
 	| "modelid"
 	| "baseurl"
+	| "headers"
 	| "saving"
 	| "success"
 	| "error"
@@ -177,6 +178,8 @@ export const AuthView: React.FC<AuthViewProps> = ({ controller, onComplete, onEr
 	const [importSources, setImportSources] = useState<DetectedSources>({ codex: false, opencode: false })
 	const [importSource, setImportSource] = useState<ImportSource | null>(null)
 	const [bedrockConfig, setBedrockConfig] = useState<BedrockConfig | null>(null)
+	const [headersJson, setHeadersJson] = useState("")
+	const [headersError, setHeadersError] = useState("")
 
 	// OCA auth hook - enabled when step is oca_auth
 	const handleOcaAuthSuccess = useCallback(async () => {
@@ -426,7 +429,7 @@ export const AuthView: React.FC<AuthViewProps> = ({ controller, onComplete, onEr
 	)
 
 	const saveConfiguration = useCallback(
-		async (model: string, base: string) => {
+		async (model: string, base: string, headers?: Record<string, string>) => {
 			try {
 				if (selectedProvider === "bedrock" && bedrockConfig) {
 					await applyBedrockConfig({
@@ -440,6 +443,7 @@ export const AuthView: React.FC<AuthViewProps> = ({ controller, onComplete, onEr
 						apiKey,
 						modelId: model,
 						baseUrl: base,
+						headers,
 						controller,
 					})
 				}
@@ -469,7 +473,7 @@ export const AuthView: React.FC<AuthViewProps> = ({ controller, onComplete, onEr
 				setModelId(value)
 			}
 			// Only show baseurl step for OpenAI-like providers
-			if (["openai", "openai-native"].includes(selectedProvider)) {
+			if (["openai", "openai-native", "openai-compatible"].includes(selectedProvider)) {
 				setStep("baseurl")
 			} else {
 				setStep("saving")
@@ -482,10 +486,38 @@ export const AuthView: React.FC<AuthViewProps> = ({ controller, onComplete, onEr
 	const handleBaseUrlSubmit = useCallback(
 		(value: string) => {
 			setBaseUrl(value)
-			setStep("saving")
-			saveConfiguration(modelId, value)
+			// openai-compatible gets a headers step; other providers save immediately
+			if (selectedProvider === "openai-compatible") {
+				setStep("headers")
+			} else {
+				setStep("saving")
+				saveConfiguration(modelId, value)
+			}
 		},
-		[modelId, saveConfiguration],
+		[modelId, selectedProvider, saveConfiguration],
+	)
+
+	const handleHeadersSubmit = useCallback(
+		(value: string) => {
+			let parsedHeaders: Record<string, string> | undefined
+			if (value.trim()) {
+				try {
+					const parsed = JSON.parse(value.trim())
+					if (typeof parsed !== "object" || Array.isArray(parsed) || parsed === null) {
+						setHeadersError('Must be a JSON object, e.g. {"X-Key": "value"}')
+						return
+					}
+					parsedHeaders = parsed as Record<string, string>
+				} catch {
+					setHeadersError('Invalid JSON. Try: {"X-Key": "value"}')
+					return
+				}
+			}
+			setHeadersError("")
+			setStep("saving")
+			saveConfiguration(modelId, baseUrl, parsedHeaders)
+		},
+		[modelId, baseUrl, saveConfiguration],
 	)
 
 	const handleClineModelSelect = useCallback(
@@ -582,6 +614,11 @@ export const AuthView: React.FC<AuthViewProps> = ({ controller, onComplete, onEr
 			case "baseurl":
 				setBaseUrl("")
 				setStep("modelid")
+				break
+			case "headers":
+				setHeadersJson("")
+				setHeadersError("")
+				setStep("baseurl")
 				break
 			case "oca_employee_check":
 				setStep("provider")
@@ -717,6 +754,29 @@ export const AuthView: React.FC<AuthViewProps> = ({ controller, onComplete, onEr
 					</Box>
 				)
 
+			case "headers":
+				return (
+					<Box flexDirection="column">
+						<Text color="white">Custom headers (optional)</Text>
+						<Text> </Text>
+						<Text color="gray">For providers that need extra HTTP headers</Text>
+						<Text color="gray">{'e.g. {"X-API-Key": "your-key"}'}</Text>
+						<Text> </Text>
+						<TextInput
+							onChange={setHeadersJson}
+							onSubmit={handleHeadersSubmit}
+							placeholder="{}"
+							value={headersJson}
+						/>
+						<Text> </Text>
+						{headersError ? (
+							<Text color="red">{headersError}</Text>
+						) : (
+							<Text color="gray">Leave blank to skip, Enter to continue, Esc to go back</Text>
+						)}
+					</Box>
+				)
+
 			case "saving":
 				return (
 					<Box>
@@ -832,6 +892,7 @@ export const AuthView: React.FC<AuthViewProps> = ({ controller, onComplete, onEr
 		"provider",
 		"modelid",
 		"baseurl",
+		"headers",
 		"cline_auth",
 		"oca_auth",
 		"cline_model",

--- a/cli/src/utils/provider-config.ts
+++ b/cli/src/utils/provider-config.ts
@@ -18,6 +18,7 @@ export interface ApplyProviderConfigOptions {
 	apiKey?: string
 	modelId?: string // Override default model
 	baseUrl?: string // For OpenAI-compatible providers
+	headers?: Record<string, string> // Custom HTTP headers for OpenAI-compatible providers
 	controller?: Controller
 }
 
@@ -25,7 +26,7 @@ export interface ApplyProviderConfigOptions {
  * Apply provider configuration to state and rebuild API handler if needed
  */
 export async function applyProviderConfig(options: ApplyProviderConfigOptions): Promise<void> {
-	const { providerId, apiKey, modelId, baseUrl, controller } = options
+	const { providerId, apiKey, modelId, baseUrl, headers, controller } = options
 	const stateManager = StateManager.get()
 
 	const config: Record<string, string> = {
@@ -77,6 +78,12 @@ export async function applyProviderConfig(options: ApplyProviderConfigOptions): 
 
 	// Save via StateManager
 	stateManager.setApiConfiguration(config)
+
+	// Save custom headers separately - it's a nested object, not a flat string value
+	if (headers && Object.keys(headers).length > 0) {
+		stateManager.setGlobalState("openAiHeaders", headers)
+	}
+
 	await stateManager.flushPendingState()
 
 	// Rebuild API handler on active task if one exists

--- a/docs/provider-config/openai-compatible.mdx
+++ b/docs/provider-config/openai-compatible.mdx
@@ -37,14 +37,7 @@ Headers are key-value pairs. Common uses:
 -   `X-Organization-ID: your-org-id` (for multi-tenant endpoints)
 -   `X-API-Key: your-key` (API key passed via header instead of Bearer token)
 
-**CLI users:** The `cline auth` wizard does not currently have a UI for custom headers. Set them manually in `~/.cline/data/globalState.json`:
-
-```json
-"openAiHeaders": {
-  "X-Custom-Header": "value",
-  "Another-Header": "another-value"
-}
-```
+**CLI users:** The `cline auth` wizard now prompts for custom headers as the last step of the `openai-compatible` setup flow. Enter headers as a JSON object, e.g. `{"X-API-Key": "your-key"}`, or press Enter to skip.
 
 ### Model Configuration
 

--- a/docs/provider-config/openai-compatible.mdx
+++ b/docs/provider-config/openai-compatible.mdx
@@ -15,24 +15,50 @@ This document focuses on setting up providers _other than_ the official OpenAI A
 
 The key to using an OpenAI-compatible provider with Cline is to configure these main settings:
 
-1.  **Base URL:** This is the API endpoint specific to the provider. It will _not_ be `https://api.openai.com/v1` (that URL is for the official OpenAI API).
-2.  **API Key:** This is the secret key you obtain from your chosen provider. (or **Use Azure Identity Authentication**)
-3.  **Model ID:** This is the specific name or identifier for the model you wish to use.
+1.  **Base URL:** The API endpoint for your provider. This will _not_ be `https://api.openai.com/v1` (that URL is for the official OpenAI API).
+2.  **API Key:** The secret key from your provider. (or **Use Azure Identity Authentication**)
+3.  **Model ID:** The specific model name or identifier.
 
 You'll find these settings in the Cline settings panel (click the ⚙️ icon):
 
 -   **API Provider:** Select "OpenAI Compatible".
--   **Base URL:** Enter the base URL provided by your chosen provider. **This is a crucial step.**
+-   **Base URL:** Enter the base URL provided by your chosen provider. **This is required** - without it, requests will fail.
 -   **API Key:** Enter your API key from the provider.
 -   **Model:** Choose or enter the model ID.
--   **Use Azure Identity Authentication:** Check the box to authenticate with your Azure managed identity (Note that this will not trigger the authentication, it will use the existing one (e.g., "az login"))
--   **Model Configuration:** This section allows you to customize advanced parameters for the model, such as:
-    -   Max Output Tokens
-    -   Context Window size
-    -   Image Support capabilities
-    -   Computer Use (e.g., for models with tool/function calling)
-    -   Input Price (per token/million tokens)
-    -   Output Price (per token/million tokens)
+-   **Use Azure Identity Authentication:** Check the box to authenticate with your Azure managed identity (this uses an existing auth session, e.g. from `az login`).
+
+### Custom Headers
+
+Some providers require additional HTTP headers for authentication or routing - for example, `X-API-Key`, organization identifiers, or proxy routing headers. You can add these in the VS Code extension settings panel under **Custom Headers**.
+
+Headers are key-value pairs. Common uses:
+
+-   `Authorization: Bearer <token>` (alternative auth schemes)
+-   `X-Organization-ID: your-org-id` (for multi-tenant endpoints)
+-   `X-API-Key: your-key` (API key passed via header instead of Bearer token)
+
+**CLI users:** The `cline auth` wizard does not currently have a UI for custom headers. Set them manually in `~/.cline/data/globalState.json`:
+
+```json
+"openAiHeaders": {
+  "X-Custom-Header": "value",
+  "Another-Header": "another-value"
+}
+```
+
+### Model Configuration
+
+This section lets you override the model's reported capabilities. Useful when the provider doesn't return accurate model info or you need to set pricing for cost tracking:
+
+-   **Max Output Tokens:** Maximum tokens the model can generate per response.
+-   **Context Window:** Total token limit (input + output).
+-   **Image Support:** Enable if the model accepts image inputs.
+-   **R1 Format:** Enable for DeepSeek R1-style reasoning models.
+-   **Input Price:** Cost per million input tokens (for usage tracking).
+-   **Output Price:** Cost per million output tokens (for usage tracking).
+-   **Temperature:** Default sampling temperature for the model.
+
+**CLI users:** Model configuration overrides are not available through `cline auth`. You can set them via `cline config` (Settings tab) or directly in `~/.cline/data/globalState.json` using the `openAiModelInfo` key.
 
 ### Supported Models (for OpenAI Native Endpoint)
 
@@ -68,5 +94,6 @@ While the "OpenAI Compatible" provider type allows connecting to various endpoin
 -   **"Model Not Found":** Ensure you're using a valid model ID for your chosen provider and that it's available at the specified Base URL.
 -   **Connection Errors:** Verify the Base URL is correct, that your provider's API is accessible from your machine, and that there are no firewall or network issues.
 -   **Unexpected Results:** If you're getting unexpected outputs, try a different model or double-check all configuration parameters.
+-   **CLI - missing base URL prompt:** If you're using the CLI and the setup wizard didn't ask for a base URL, update to CLI v2.8.0 or later. Earlier versions skipped that step for openai-compatible.
 
 By using an OpenAI-compatible provider, you can leverage the flexibility of Cline with a wider array of AI models. Remember to always consult your provider's documentation for the most accurate and up-to-date information.


### PR DESCRIPTION
### Related Issue

**Issue:** #9847

### Description

The CLI setup wizard (`cline auth`) was broken for `openai-compatible` providers in two ways:

1. **Base URL was never collected.** The wizard only showed the base URL step for `openai` and `openai-native`. When a user picked `openai-compatible`, it skipped straight to saving - meaning `openAiBaseUrl` was never set. The provider is useless without a base URL.

2. **No way to set custom headers.** Some providers require custom HTTP headers (e.g. `X-API-Key`, organization routing headers). The VS Code extension has a full UI for this; the CLI had nothing.

**What this PR does:**

- Adds `openai-compatible` to the provider check so the base URL step shows up
- Adds an optional `headers` step after base URL, specific to `openai-compatible` - accepts JSON input like `{"X-API-Key": "value"}`, validates it, and saves to `openAiHeaders` in state
- Both steps can be skipped with Enter (they're optional - not every provider needs them)
- Wires `headers` through `saveConfiguration` → `applyProviderConfig` → `StateManager.setGlobalState("openAiHeaders")`
- Updates `docs/provider-config/openai-compatible.mdx` with a Custom Headers section, Model Configuration overrides reference, and CLI manual workaround notes

**New wizard flow for `openai-compatible`:**
```
provider → apikey → modelid → baseurl (optional) → headers (optional) → saving
```

### Test Procedure

- TypeScript compiles clean: `npx tsc --noEmit` in `cli/` passes with no errors
- Biome lint passed on commit (via pre-commit hook)
- Manually verified the flow:
  - Selecting `openai-compatible` now progresses through base URL and headers steps
  - Pressing Enter on both optional steps skips them and saves successfully
  - Entering invalid JSON on the headers step shows an inline error and stays on the step
  - Valid JSON headers are parsed and saved to state
  - Esc on the headers step goes back to base URL; Esc on base URL goes back to model ID
  - Other providers (`openai`, `openai-native`, `anthropic`, etc.) are unaffected - their flow is unchanged

**What could break:** None of the changes touch other provider flows. The `saveConfiguration` signature change is backwards-compatible (`headers` is optional). The `applyProviderConfig` change only writes to state if headers are present.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [x] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

**Base URL step (now shown for `openai-compatible`):**
```
╭─────────────────────────────────────────────────╮
│ Base URL (optional)                             │
│                                                 │
│ For self-hosted or proxy endpoints              │
│                                                 │
│ e.g. https://api.example.com/v1 |               │
│                                                 │
│ Enter to skip or continue, Esc to go back       │
╰─────────────────────────────────────────────────╯
```

**New custom headers step:**
```
╭─────────────────────────────────────────────────╮
│ Custom headers (optional)                       │
│                                                 │
│ For providers that need extra HTTP headers      │
│ e.g. {"X-API-Key": "your-key"}                  │
│                                                 │
│ |                                               │
│                                                 │
│ Leave blank to skip, Enter to continue, Esc     │
╰─────────────────────────────────────────────────╯
```

### Additional Notes

The `openAiHeaders` field is typed as `Record<string, string>` in state — it's a nested object, not a flat string — so it's saved separately via `stateManager.setGlobalState("openAiHeaders", headers)` rather than through the flat `setApiConfiguration` config batch. This matches how other nested state (like model info objects) is handled in the codebase.
