### PR TITLE
fix: Claude Sonnet 4.5 Thinking is on a single line

### DIFF
--- a/webview-ui/src/components/chat/ThinkingRow.tsx
+++ b/webview-ui/src/components/chat/ThinkingRow.tsx
@@ -107,7 +107,7 @@ export const ThinkingRow = memo(
 								)}
 								onScroll={checkScrollable}
 								ref={scrollRef}>
-								<span className="pb-2 block text-sm">{reasoningContent}</span>
+								<span className="pb-2 block text-sm whitespace-pre-wrap">{reasoningContent}</span>
 							</div>
 							{canScrollUp && (
 								<div className="absolute top-0 left-0 right-0 h-6 pointer-events-none bg-gradient-to-b from-background to-transparent" />


### PR DESCRIPTION
Fixes #7876

Thinking/reasoning block content rendered on a single line because the `<span>` in `ThinkingRow.tsx` did not preserve whitespace. Adds `whitespace-pre-wrap` to the span so newlines in `reasoningContent` are rendered correctly.