### PR TITLE
Fix task_progress parameter causing infinite loop in MCP tool calls

### DIFF
--- a/src/core/task/tools/handlers/UseMcpToolHandler.ts
+++ b/src/core/task/tools/handlers/UseMcpToolHandler.ts
@@ -74,6 +74,15 @@ export class UseMcpToolHandler implements IFullyManagedTool {
 				await config.callbacks.say("error", `Cline tried to use ${tool_name} with an invalid JSON argument. Retrying...`)
 				return formatResponse.toolError(formatResponse.invalidMcpToolArgumentError(server_name, tool_name))
 			}
+
+			// Strip task_progress from arguments before sending to MCP server.
+			// The model may include task_progress inside the arguments JSON because
+			// the system prompt instructs it to include task_progress with every tool
+			// call. MCP servers don't expect this parameter and will reject it,
+			// causing an infinite retry loop. (See #9684)
+			if (parsedArguments && "task_progress" in parsedArguments) {
+				delete parsedArguments.task_progress
+			}
 		}
 
 		config.taskState.consecutiveMistakeCount = 0


### PR DESCRIPTION
## Summary

Fixes #9684

- Strip `task_progress` from MCP tool call arguments before sending them to MCP servers
- The system prompt instructs the model to include `task_progress` with every tool call for progress tracking, but MCP servers don't recognize this parameter and reject it as unexpected
- This rejection causes the model to retry with the same parameter, creating an infinite loop

## Root Cause

Cline's focus chain system adds `task_progress` as an optional parameter to all tool specs, including `use_mcp_tool`. The system prompt tells the model to include it with every tool call. When the model includes `task_progress` inside the `arguments` JSON of an MCP tool call, it gets parsed and passed directly to the MCP server via `McpHub.callTool()`. The MCP server rejects the unexpected parameter, the model retries with the same parameter, and an infinite loop results.

## Fix

In `UseMcpToolHandler.execute()`, after parsing the `arguments` JSON string into `parsedArguments`, delete `task_progress` from the object before passing it to `McpHub.callTool()`. This is a minimal, targeted fix that:

1. Preserves `task_progress` at the block level (`block.params.task_progress`) for focus chain tracking
2. Only strips it from the MCP server-bound arguments
3. Has no effect when `task_progress` is not present in the arguments

## Test plan

- [ ] Verify MCP tool calls no longer include `task_progress` in arguments sent to MCP servers
- [ ] Verify focus chain / task progress tracking still works (task_progress is still extracted from `block.params`)
- [ ] Verify MCP tool calls with valid arguments still work correctly
- [ ] Test with focus chain enabled and disabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)