### PR TITLE
Add block-no-verify PreToolUse hook to prevent agents from bypassing git hooks

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,11 @@
 {
 	"hooks": {
+		"PreToolUse": [
+			{
+				"matcher": "Bash",
+				"hooks": [{ "type": "command", "command": "npx block-no-verify@1.1.2" }]
+			}
+		],
 		"SessionStart": [
 			{
 				"hooks": [


### PR DESCRIPTION
## Summary

Adds `block-no-verify@1.1.2` as a `PreToolUse` Bash hook in `.claude/settings.json`, alongside the existing `SessionStart` hook.

## Details

When Claude Code runs `git commit` or `git push` with the hook-bypass flag, it silently skips pre-commit hooks, commit-msg validation, and pre-push test suites. `block-no-verify` reads `tool_input.command` from the PreToolUse stdin payload, detects the hook-bypass flag across all git subcommands, and exits 2 to block. No custom scripts needed.

The existing `SessionStart` hook is preserved unchanged.

Closes #9889

---

_Disclosure: I am the author and maintainer of `block-no-verify`._
