### PR TITLE
fix: reject directory paths in replace_in_file / write_to_file

### DIFF
--- a/src/core/task/tools/handlers/WriteToFileToolHandler.ts
+++ b/src/core/task/tools/handlers/WriteToFileToolHandler.ts
@@ -7,7 +7,7 @@ import { getWorkspaceBasename, resolveWorkspacePath } from "@core/workspace"
 import { processFilesIntoText } from "@integrations/misc/extract-text"
 import { ClineSayTool } from "@shared/ExtensionMessage"
 import { getLastApiReqTotalTokens } from "@shared/getApiMetrics"
-import { fileExistsAtPath } from "@utils/fs"
+import { fileExistsAtPath, isDirectory } from "@utils/fs"
 import { arePathsEqual, getReadablePath, isLocatedInWorkspace } from "@utils/path"
 import { applyPatch } from "diff"
 import { telemetryService } from "@/services/telemetry"
@@ -22,6 +22,10 @@ import { captureAccepted, captureRejected, getModelInfo } from "../utils/AiOutpu
 import { applyModelContentFixes } from "../utils/ModelContentProcessor"
 import { ToolDisplayUtils } from "../utils/ToolDisplayUtils"
 import { ToolResultUtils } from "../utils/ToolResultUtils"
+
+/** Returned to the model when replace_in_file / write_to_file target a directory (avoids EISDIR and unclear retries). */
+const DIRECTORY_PATH_TOOL_ERROR =
+	"The provided path is a directory, not a file. Please specify the exact file within this directory that you wish to edit."
 
 export class WriteToFileToolHandler implements IFullyManagedTool {
 	readonly name = ClineDefaultTool.FILE_NEW // This handler supports write_to_file, replace_in_file, and new_rule
@@ -464,6 +468,26 @@ export class WriteToFileToolHandler implements IFullyManagedTool {
 				config.taskState.didAlreadyUseTool = true
 			}
 
+			return
+		}
+
+		// Reject directories before any read/open — fileExistsAtPath uses fs.access, which is true for dirs, then readFile throws EISDIR.
+		if (await isDirectory(absolutePath)) {
+			config.taskState.consecutiveMistakeCount++
+			const errorResponse = formatResponse.toolError(DIRECTORY_PATH_TOOL_ERROR)
+			ToolResultUtils.pushToolResult(
+				errorResponse,
+				block,
+				config.taskState.userMessageContent,
+				ToolDisplayUtils.getToolDescription,
+				config.coordinator,
+				config.taskState.toolUseIdMap,
+			)
+			if (!config.enableParallelToolCalling) {
+				config.taskState.didAlreadyUseTool = true
+			}
+			await config.callbacks.say("error", DIRECTORY_PATH_TOOL_ERROR)
+			await config.services.diffViewProvider.reset()
 			return
 		}
 

--- a/src/core/task/tools/handlers/WriteToFileToolHandler.ts
+++ b/src/core/task/tools/handlers/WriteToFileToolHandler.ts
@@ -473,6 +473,10 @@ export class WriteToFileToolHandler implements IFullyManagedTool {
 
 		// Reject directories before any read/open — fileExistsAtPath uses fs.access, which is true for dirs, then readFile throws EISDIR.
 		if (await isDirectory(absolutePath)) {
+			// During streaming, the path is complete before the full diff/content; skip error side effects until the final block (matches diff-error path).
+			if (block.partial) {
+				return
+			}
 			config.taskState.consecutiveMistakeCount++
 			const errorResponse = formatResponse.toolError(DIRECTORY_PATH_TOOL_ERROR)
 			ToolResultUtils.pushToolResult(

--- a/src/core/task/tools/handlers/__tests__/WriteToFileToolHandler.directoryPath.test.ts
+++ b/src/core/task/tools/handlers/__tests__/WriteToFileToolHandler.directoryPath.test.ts
@@ -76,13 +76,25 @@ function createConfig() {
 	return { config, callbacks, taskState, validator }
 }
 
-function makeReplaceInFileBlock(relPath: string): ToolUse {
+function makeReplaceInFileBlock(relPath: string, partial = false): ToolUse {
 	return {
 		type: "tool_use",
 		name: ClineDefaultTool.FILE_EDIT,
 		params: {
 			path: relPath,
 			diff: "------- SEARCH\nnope\n=======\nstill no\n+++++++ REPLACE\n",
+		},
+		partial,
+	}
+}
+
+function makeWriteToFileBlock(relPath: string): ToolUse {
+	return {
+		type: "tool_use",
+		name: ClineDefaultTool.FILE_NEW,
+		params: {
+			path: relPath,
+			content: "// new file body",
 		},
 		partial: false,
 	}
@@ -149,5 +161,56 @@ describe("WriteToFileToolHandler.validateAndPrepareFileOperation – directory p
 		await handler.validateAndPrepareFileOperation(config, block, "dir2", block.params.diff as string, undefined)
 
 		assert.equal(taskState.didAlreadyUseTool, true)
+	})
+
+	it("does not push errors on partial blocks when path is a directory (streaming)", async () => {
+		const subDir = path.join(tmpDir, "partial_dir")
+		await fs.mkdir(subDir, { recursive: true })
+
+		const { config, callbacks, taskState, validator } = createConfig()
+		const handler = new WriteToFileToolHandler(validator)
+		const block = makeReplaceInFileBlock("partial_dir", true)
+
+		const result = await handler.validateAndPrepareFileOperation(
+			config,
+			block,
+			"partial_dir",
+			block.params.diff as string,
+			undefined,
+		)
+
+		assert.equal(result, undefined)
+		assert.equal(taskState.consecutiveMistakeCount, 0)
+		assert.ok(pushToolResultStub.notCalled)
+		assert.ok((callbacks.say as sinon.SinonStub).notCalled)
+		assert.ok((config.services.diffViewProvider.reset as sinon.SinonStub).notCalled)
+	})
+
+	it("returns early with a tool error when write_to_file targets a directory", async () => {
+		const subDir = path.join(tmpDir, "write_to_dir")
+		await fs.mkdir(subDir, { recursive: true })
+
+		const { config, callbacks, taskState, validator } = createConfig()
+		const handler = new WriteToFileToolHandler(validator)
+		const block = makeWriteToFileBlock("write_to_dir")
+
+		const result = await handler.validateAndPrepareFileOperation(
+			config,
+			block,
+			"write_to_dir",
+			undefined,
+			block.params.content as string,
+		)
+
+		assert.equal(result, undefined)
+		assert.equal(taskState.consecutiveMistakeCount, 1)
+		assert.ok(
+			(callbacks.say as sinon.SinonStub).calledWith("error", EXPECTED_DIRECTORY_ERROR),
+			"expected say('error', directory message)",
+		)
+		assert.ok(pushToolResultStub.calledOnce)
+		const pushed = pushToolResultStub.firstCall.args[0] as string
+		assert.ok(pushed.includes(EXPECTED_DIRECTORY_ERROR))
+		assert.ok((config.services.diffViewProvider.open as sinon.SinonStub).notCalled)
 	})
 })

--- a/src/core/task/tools/handlers/__tests__/WriteToFileToolHandler.directoryPath.test.ts
+++ b/src/core/task/tools/handlers/__tests__/WriteToFileToolHandler.directoryPath.test.ts
@@ -1,0 +1,153 @@
+import { strict as assert } from "node:assert"
+import fs from "node:fs/promises"
+import os from "node:os"
+import path from "node:path"
+import type { ToolUse } from "@core/assistant-message"
+import { afterEach, beforeEach, describe, it } from "mocha"
+import sinon from "sinon"
+import { ClineDefaultTool } from "@shared/tools"
+import { TaskState } from "../../../TaskState"
+import { ToolValidator } from "../../ToolValidator"
+import type { TaskConfig } from "../../types/TaskConfig"
+import { ToolResultUtils } from "../../utils/ToolResultUtils"
+import { WriteToFileToolHandler } from "../WriteToFileToolHandler"
+
+const EXPECTED_DIRECTORY_ERROR =
+	"The provided path is a directory, not a file. Please specify the exact file within this directory that you wish to edit."
+
+let tmpDir: string
+
+function createConfig() {
+	const taskState = new TaskState()
+
+	const callbacks = {
+		say: sinon.stub().resolves(undefined),
+		ask: sinon.stub().resolves({ response: "yesButtonClicked" }),
+		sayAndCreateMissingParamError: sinon.stub().resolves("missing"),
+		removeLastPartialMessageIfExistsWithType: sinon.stub().resolves(),
+		shouldAutoApproveToolWithPath: sinon.stub().resolves(true),
+	}
+
+	const config = {
+		taskId: "task-1",
+		ulid: "ulid-1",
+		cwd: tmpDir,
+		mode: "act",
+		isMultiRootEnabled: false,
+		enableParallelToolCalling: true,
+		taskState,
+		messageState: {} as TaskConfig["messageState"],
+		api: {
+			getModel: () => ({ id: "test-model", info: {} }),
+		},
+		autoApprovalSettings: { enableNotifications: false, actions: {} },
+		autoApprover: { shouldAutoApproveTool: sinon.stub().returns([true, true]) },
+		browserSettings: {},
+		focusChainSettings: {},
+		callbacks,
+		coordinator: { getHandler: sinon.stub().returns(null) },
+		services: {
+			diffViewProvider: {
+				editType: undefined as "create" | "modify" | undefined,
+				isEditing: false,
+				reset: sinon.stub().resolves(undefined),
+				open: sinon.stub().rejects(new Error("diffViewProvider.open should not run for a directory path")),
+				update: sinon.stub().resolves(undefined),
+				revertChanges: sinon.stub().resolves(undefined),
+				originalContent: "",
+				getOriginalContentForLLM: sinon.stub().returns(""),
+			},
+			stateManager: {
+				getGlobalSettingsKey: sinon.stub().returns("act"),
+				getApiConfiguration: sinon.stub().returns({ planModeApiProvider: "x", actModeApiProvider: "x" }),
+			},
+			fileContextTracker: { trackFileContext: sinon.stub().resolves() },
+			mcpHub: {},
+			browserSession: {},
+			urlContentFetcher: {},
+			clineIgnoreController: { validateAccess: () => true },
+			commandPermissionController: {},
+			contextManager: {},
+		},
+	} as unknown as TaskConfig
+
+	const validator = new ToolValidator({ validateAccess: () => true } as any)
+
+	return { config, callbacks, taskState, validator }
+}
+
+function makeReplaceInFileBlock(relPath: string): ToolUse {
+	return {
+		type: "tool_use",
+		name: ClineDefaultTool.FILE_EDIT,
+		params: {
+			path: relPath,
+			diff: "------- SEARCH\nnope\n=======\nstill no\n+++++++ REPLACE\n",
+		},
+		partial: false,
+	}
+}
+
+describe("WriteToFileToolHandler.validateAndPrepareFileOperation – directory path", () => {
+	let sandbox: sinon.SinonSandbox
+	let pushToolResultStub: sinon.SinonStub
+
+	beforeEach(async () => {
+		sandbox = sinon.createSandbox()
+		pushToolResultStub = sandbox.stub(ToolResultUtils, "pushToolResult")
+		tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "cline-w2f-dir-test-"))
+	})
+
+	afterEach(async () => {
+		sandbox.restore()
+		await fs.rm(tmpDir, { recursive: true, force: true }).catch(() => {})
+	})
+
+	it("returns early with a tool error when replace_in_file targets a directory (no open/read)", async () => {
+		const subDir = path.join(tmpDir, "only_a_directory")
+		await fs.mkdir(subDir, { recursive: true })
+
+		const { config, callbacks, taskState, validator } = createConfig()
+		const handler = new WriteToFileToolHandler(validator)
+		const block = makeReplaceInFileBlock("only_a_directory")
+
+		const result = await handler.validateAndPrepareFileOperation(
+			config,
+			block,
+			"only_a_directory",
+			block.params.diff as string,
+			undefined,
+		)
+
+		assert.equal(result, undefined)
+		assert.equal(taskState.consecutiveMistakeCount, 1)
+		assert.ok(
+			(callbacks.say as sinon.SinonStub).calledWith("error", EXPECTED_DIRECTORY_ERROR),
+			"expected say('error', directory message)",
+		)
+		assert.ok((config.services.diffViewProvider.reset as sinon.SinonStub).calledOnce)
+		assert.ok(pushToolResultStub.calledOnce, "tool result should be pushed for the LLM")
+		const pushed = pushToolResultStub.firstCall.args[0] as string
+		assert.ok(pushed.includes(EXPECTED_DIRECTORY_ERROR), `expected tool result to include directory hint, got: ${pushed}`)
+		assert.ok(
+			(config.services.diffViewProvider.open as sinon.SinonStub).notCalled,
+			"must not read/open a directory as a file",
+		)
+	})
+
+	it("sets didAlreadyUseTool when parallel tool calling is disabled", async () => {
+		const subDir = path.join(tmpDir, "dir2")
+		await fs.mkdir(subDir, { recursive: true })
+
+		const { config, taskState, validator } = createConfig()
+		config.enableParallelToolCalling = false
+		taskState.didAlreadyUseTool = false
+
+		const handler = new WriteToFileToolHandler(validator)
+		const block = makeReplaceInFileBlock("dir2")
+
+		await handler.validateAndPrepareFileOperation(config, block, "dir2", block.params.diff as string, undefined)
+
+		assert.equal(taskState.didAlreadyUseTool, true)
+	})
+})


### PR DESCRIPTION
### Related Issue

**Issue:** https://github.com/cline/cline/issues/9912

### Description

When the model passed a **directory** path to `replace_in_file` (or `write_to_file`), `fileExistsAtPath` treated it as existing (via `fs.access`), so the diff flow tried to `readFile` the path and hit **EISDIR**. That surfaced as a generic failure and often caused retry loops and confusing “search does not match” style errors.

This PR adds an early check with `isDirectory()` from `@utils/fs` after clineignore validation and before any read/open. If the path is a directory, the handler returns a clear tool error for the model and resets the diff view, without attempting to read the path as a file.

### Test Procedure

- Added `WriteToFileToolHandler.directoryPath.test.ts` covering `validateAndPrepareFileOperation` for a directory path (tool result pushed, `say('error', …)`, `reset`, `open` not called, and `didAlreadyUseTool` when parallel tool calling is off).
- Run only this file (avoids `.mocharc` running the full suite when a single path is passed):

```bash
npx cross-env TS_NODE_PROJECT=./tsconfig.unit-test.json npx mocha --no-config \
  --require ts-node/register \
  --require source-map-support/register \
  --require ./src/test/requires.ts \
  --extension ts \
  src/core/task/tools/handlers/__tests__/WriteToFileToolHandler.directoryPath.test.ts
```

Ensure `npm run protos` has been run if generated proto files are missing.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A (no UI changes)

### Additional Notes

N/A