### PR TITLE
fix: normalize cache write/read telemetry for OpenRouter-compatible providers

### DIFF
--- a/src/core/api/providers/__tests__/cline.test.ts
+++ b/src/core/api/providers/__tests__/cline.test.ts
@@ -1,5 +1,6 @@
 import "should"
 import { openRouterDefaultModelInfo } from "@shared/api"
+import axios from "axios"
 import sinon from "sinon"
 import { ClineAccountService } from "@/services/account/ClineAccountService"
 import { AuthService } from "@/services/auth/AuthService"
@@ -64,6 +65,52 @@ describe("ClineHandler", () => {
 		])
 	})
 
+	it("should read cache write tokens from cache_creation_input_tokens", async () => {
+		const handler = createHandler({})
+		const fakeClient = {
+			chat: {
+				completions: {
+					create: sinon.stub().resolves(
+						createAsyncIterable([
+							{
+								choices: [{}],
+								usage: {
+									prompt_tokens: 200,
+									completion_tokens: 11,
+									cache_creation_input_tokens: 40,
+									prompt_tokens_details: {
+										cached_tokens: 150,
+									},
+								},
+							},
+						]),
+					),
+				},
+			},
+		}
+		sinon.stub(handler as any, "ensureClient").resolves(fakeClient as any)
+		sinon.stub(handler, "getModel").returns({
+			id: "anthropic/claude-sonnet-4.6",
+			info: openRouterDefaultModelInfo,
+		})
+
+		const chunks: any[] = []
+		for await (const chunk of handler.createMessage("system", [{ role: "user", content: "hi" }])) {
+			chunks.push(chunk)
+		}
+
+		chunks.should.deepEqual([
+			{
+				type: "usage",
+				cacheWriteTokens: 40,
+				cacheReadTokens: 150,
+				inputTokens: 10,
+				outputTokens: 11,
+				totalCost: 0,
+			},
+		])
+	})
+
 	it("should forward enableParallelToolCalling to OpenRouter payload", async () => {
 		const handler = createHandler({ enableParallelToolCalling: true })
 		const createStub = sinon.stub().resolves(createAsyncIterable([]))
@@ -89,5 +136,40 @@ describe("ClineHandler", () => {
 
 		const payload = createStub.firstCall.args[0]
 		payload.parallel_tool_calls.should.equal(true)
+	})
+
+	it("should subtract cache read and cache write tokens in generation fallback", async () => {
+		const handler = createHandler({})
+		handler.lastGenerationId = "gen-123"
+
+		;(handler as any)._authService = { getAuthToken: async () => "test-token" }
+		;(handler as any).clineAccountService = { baseUrl: "https://api.cline.bot" }
+
+		sinon.stub(handler, "getModel").returns({
+			id: "anthropic/claude-sonnet-4.6",
+			info: openRouterDefaultModelInfo,
+		})
+
+		sinon.stub(axios, "get").resolves({
+			data: {
+				native_tokens_prompt: 1000,
+				native_tokens_cached: 500,
+				native_tokens_cache_write: 300,
+				native_tokens_completion: 200,
+				total_cost: 1.23,
+			},
+		} as any)
+
+		const usage = await handler.getApiStreamUsage(new Set())
+
+		should.exist(usage)
+		usage!.should.deepEqual({
+			type: "usage",
+			cacheWriteTokens: 300,
+			cacheReadTokens: 500,
+			inputTokens: 200,
+			outputTokens: 200,
+			totalCost: 1.23,
+		})
 	})
 })

--- a/src/core/api/providers/__tests__/openai.test.ts
+++ b/src/core/api/providers/__tests__/openai.test.ts
@@ -1,0 +1,92 @@
+import "should"
+import sinon from "sinon"
+import { OpenAiHandler } from "../openai"
+
+describe("OpenAiHandler", () => {
+	afterEach(() => {
+		sinon.restore()
+	})
+
+	const createAsyncIterable = (data: any[] = []) => ({
+		[Symbol.asyncIterator]: async function* () {
+			yield* data
+		},
+	})
+
+	it("should read cache write tokens from cache_creation_input_tokens", async () => {
+		const handler = new OpenAiHandler({
+			openAiApiKey: "test-api-key",
+			openAiBaseUrl: "https://ai-gateway.vercel.sh/v1",
+			openAiModelId: "anthropic/claude-sonnet-4.6",
+		})
+		const fakeClient = {
+			chat: {
+				completions: {
+					create: sinon.stub().resolves(
+						createAsyncIterable([
+							{
+								choices: [{}],
+								usage: {
+									prompt_tokens: 90,
+									completion_tokens: 6,
+									cache_creation_input_tokens: 20,
+									prompt_tokens_details: {
+										cached_tokens: 60,
+									},
+								},
+							},
+						]),
+					),
+				},
+			},
+		}
+		sinon.stub(handler as any, "ensureClient").returns(fakeClient as any)
+
+		const chunks: any[] = []
+		for await (const chunk of handler.createMessage("system", [{ role: "user", content: "hi" }])) {
+			chunks.push(chunk)
+		}
+
+		chunks.should.deepEqual([
+			{
+				type: "usage",
+				cacheWriteTokens: 20,
+				cacheReadTokens: 60,
+				inputTokens: 10,
+				outputTokens: 6,
+			},
+		])
+	})
+
+	it("should add cache_control blocks for anthropic models on openrouter base URL", async () => {
+		const createStub = sinon.stub().resolves(createAsyncIterable([]))
+		const handler = new OpenAiHandler({
+			openAiApiKey: "test-api-key",
+			openAiBaseUrl: "https://openrouter.ai/api/v1",
+			openAiModelId: "anthropic/claude-sonnet-4.6",
+		})
+		const fakeClient = {
+			chat: {
+				completions: {
+					create: createStub,
+				},
+			},
+		}
+		sinon.stub(handler as any, "ensureClient").returns(fakeClient as any)
+
+		for await (const _chunk of handler.createMessage("system", [{ role: "user", content: "hi" }])) {
+			// drain stream
+		}
+
+		const payload = createStub.firstCall.args[0]
+		const systemMessage = payload.messages[0]
+		const userMessage = payload.messages.find((msg: any) => msg.role === "user")
+
+		Array.isArray(systemMessage.content).should.equal(true)
+		systemMessage.content[0].cache_control.should.deepEqual({ type: "ephemeral" })
+
+		Array.isArray(userMessage.content).should.equal(true)
+		const userLastTextPart = userMessage.content.filter((part: any) => part.type === "text").pop()
+		userLastTextPart.cache_control.should.deepEqual({ type: "ephemeral" })
+	})
+})

--- a/src/core/api/providers/__tests__/openrouter.test.ts
+++ b/src/core/api/providers/__tests__/openrouter.test.ts
@@ -108,6 +108,85 @@ describe("OpenRouterHandler", () => {
 		])
 	})
 
+	it("should fall back to cache_creation_input_tokens when cache_write_tokens is missing", async () => {
+		const handler = new OpenRouterHandler({
+			openRouterApiKey: "test-api-key",
+		})
+		const fakeClient = {
+			chat: {
+				completions: {
+					create: sinon.stub().resolves(
+						createAsyncIterable([
+							{
+								choices: [{}],
+								usage: {
+									prompt_tokens: 1000,
+									completion_tokens: 200,
+									cache_creation_input_tokens: 300,
+									prompt_tokens_details: {
+										cached_tokens: 500,
+									},
+								},
+							},
+						]),
+					),
+				},
+			},
+		}
+		sinon.stub(handler as any, "ensureClient").returns(fakeClient as any)
+		sinon.stub(handler, "getModel").returns({
+			id: "anthropic/claude-sonnet-4.6",
+			info: openRouterDefaultModelInfo,
+		})
+
+		const chunks: any[] = []
+		for await (const chunk of handler.createMessage("system", [{ role: "user", content: "hi" }])) {
+			chunks.push(chunk)
+		}
+
+		chunks.should.deepEqual([
+			{
+				type: "usage",
+				cacheWriteTokens: 300,
+				cacheReadTokens: 500,
+				inputTokens: 200,
+				outputTokens: 200,
+				totalCost: 0,
+			},
+		])
+	})
+
+	it("should subtract cache read and cache write tokens in generation fallback", async () => {
+		const handler = new OpenRouterHandler({
+			openRouterApiKey: "test-api-key",
+		})
+		handler.lastGenerationId = "gen-123"
+
+		sinon.stub(handler, "fetchGenerationDetails").returns(
+			(async function* () {
+				yield {
+					native_tokens_prompt: 1000,
+					native_tokens_cached: 500,
+					native_tokens_cache_write: 300,
+					native_tokens_completion: 200,
+					total_cost: 1.23,
+				}
+			})() as any,
+		)
+
+		const usage = await handler.getApiStreamUsage()
+
+		should.exist(usage)
+		usage!.should.deepEqual({
+			type: "usage",
+			cacheWriteTokens: 300,
+			cacheReadTokens: 500,
+			inputTokens: 200,
+			outputTokens: 200,
+			totalCost: 1.23,
+		})
+	})
+
 	type ParallelToolCallsTestCase = {
 		modelId: string
 		enableParallelToolCalling: boolean

--- a/src/core/api/providers/__tests__/vercel-ai-gateway.test.ts
+++ b/src/core/api/providers/__tests__/vercel-ai-gateway.test.ts
@@ -90,5 +90,49 @@ describe("VercelAIGatewayHandler", () => {
 				},
 			])
 		})
+
+		it("should read cache write tokens from cache_creation_input_tokens", async () => {
+			const handler = new VercelAIGatewayHandler({
+				vercelAiGatewayApiKey: "test-api-key",
+			})
+			const fakeClient = {
+				chat: {
+					completions: {
+						create: sinon.stub().resolves(
+							createAsyncIterable([
+								{
+									choices: [{}],
+									usage: {
+										prompt_tokens: 90,
+										completion_tokens: 6,
+										cache_creation_input_tokens: 20,
+										prompt_tokens_details: {
+											cached_tokens: 60,
+										},
+									},
+								},
+							]),
+						),
+					},
+				},
+			}
+			sinon.stub(handler as any, "ensureClient").returns(fakeClient as any)
+
+			const chunks: any[] = []
+			for await (const chunk of handler.createMessage("system", [{ role: "user", content: "hi" }])) {
+				chunks.push(chunk)
+			}
+
+			chunks.should.deepEqual([
+				{
+					type: "usage",
+					cacheWriteTokens: 20,
+					cacheReadTokens: 60,
+					inputTokens: 10,
+					outputTokens: 6,
+					totalCost: 0,
+				},
+			])
+		})
 	})
 })

--- a/src/core/api/providers/cache-usage.ts
+++ b/src/core/api/providers/cache-usage.ts
@@ -1,0 +1,42 @@
+export interface OpenAiCompatibleCacheUsage {
+	prompt_tokens_details?: {
+		cached_tokens?: number
+		cache_write_tokens?: number
+	}
+	cache_creation_input_tokens?: number
+	cache_read_input_tokens?: number
+	prompt_cache_miss_tokens?: number
+	prompt_cache_hit_tokens?: number
+}
+
+function asNumber(value: unknown): number | undefined {
+	return typeof value === "number" ? value : undefined
+}
+
+export function extractCacheTokenUsage(usage?: OpenAiCompatibleCacheUsage): {
+	cacheReadTokens: number
+	cacheWriteTokens: number
+} {
+	if (!usage) {
+		return {
+			cacheReadTokens: 0,
+			cacheWriteTokens: 0,
+		}
+	}
+
+	const cacheReadTokens =
+		asNumber(usage.prompt_tokens_details?.cached_tokens) ??
+		asNumber(usage.cache_read_input_tokens) ??
+		asNumber(usage.prompt_cache_hit_tokens) ??
+		0
+	const cacheWriteTokens =
+		asNumber(usage.prompt_tokens_details?.cache_write_tokens) ??
+		asNumber(usage.cache_creation_input_tokens) ??
+		asNumber(usage.prompt_cache_miss_tokens) ??
+		0
+
+	return {
+		cacheReadTokens,
+		cacheWriteTokens,
+	}
+}

--- a/src/core/api/providers/cline.ts
+++ b/src/core/api/providers/cline.ts
@@ -18,6 +18,7 @@ import { withRetry } from "../retry"
 import { createOpenRouterStream } from "../transform/openrouter-stream"
 import type { ApiStream, ApiStreamUsageChunk } from "../transform/stream"
 import { ToolCallProcessor } from "../transform/tool-call-processor"
+import { extractCacheTokenUsage, OpenAiCompatibleCacheUsage } from "./cache-usage"
 import type { OpenRouterErrorResponse } from "./types"
 
 interface ClineHandlerOptions extends CommonApiHandlerOptions {
@@ -230,6 +231,9 @@ export class ClineHandler implements ApiHandler {
 					let totalCost = (chunk.usage.cost || 0) + (chunk.usage.cost_details?.upstream_inference_cost || 0)
 					const modelId = this.getModel().id
 					const isFreeModel = freeModelIds.has(normalizeModelId(modelId))
+					const { cacheReadTokens, cacheWriteTokens } = extractCacheTokenUsage(
+						chunk.usage as OpenAiCompatibleCacheUsage,
+					)
 
 					if (isFreeModel) {
 						totalCost = 0
@@ -237,9 +241,9 @@ export class ClineHandler implements ApiHandler {
 
 					yield {
 						type: "usage",
-						cacheWriteTokens: 0,
-						cacheReadTokens: chunk.usage.prompt_tokens_details?.cached_tokens || 0,
-						inputTokens: (chunk.usage.prompt_tokens || 0) - (chunk.usage.prompt_tokens_details?.cached_tokens || 0),
+						cacheWriteTokens,
+						cacheReadTokens,
+						inputTokens: (chunk.usage.prompt_tokens || 0) - cacheReadTokens - cacheWriteTokens,
 						outputTokens: chunk.usage.completion_tokens || 0,
 						totalCost,
 					}
@@ -282,6 +286,11 @@ export class ClineHandler implements ApiHandler {
 				})
 
 				const generation = response.data
+				const { cacheReadTokens: usageCacheReadTokens, cacheWriteTokens: usageCacheWriteTokens } = extractCacheTokenUsage(
+					generation as OpenAiCompatibleCacheUsage,
+				)
+				const cacheWriteTokens = generation?.native_tokens_cache_write ?? usageCacheWriteTokens
+				const cacheReadTokens = generation?.native_tokens_cached ?? usageCacheReadTokens
 				let totalCost = generation?.total_cost || 0
 				const modelId = this.getModel().id
 				const isFreeModel = resolvedFreeModelIds.has(normalizeModelId(modelId))
@@ -292,10 +301,10 @@ export class ClineHandler implements ApiHandler {
 
 				return {
 					type: "usage",
-					cacheWriteTokens: 0,
-					cacheReadTokens: generation?.native_tokens_cached || 0,
+					cacheWriteTokens,
+					cacheReadTokens,
 					// openrouter generation endpoint fails often
-					inputTokens: (generation?.native_tokens_prompt || 0) - (generation?.native_tokens_cached || 0),
+					inputTokens: (generation?.native_tokens_prompt || 0) - cacheReadTokens - cacheWriteTokens,
 					outputTokens: generation?.native_tokens_completion || 0,
 					totalCost,
 				}

--- a/src/core/api/providers/openai.ts
+++ b/src/core/api/providers/openai.ts
@@ -12,6 +12,7 @@ import { convertToOpenAiMessages } from "../transform/openai-format"
 import { convertToR1Format } from "../transform/r1-format"
 import { ApiStream } from "../transform/stream"
 import { getOpenAIToolParams, ToolCallProcessor } from "../transform/tool-call-processor"
+import { extractCacheTokenUsage, OpenAiCompatibleCacheUsage } from "./cache-usage"
 
 interface OpenAiHandlerOptions extends CommonApiHandlerOptions {
 	openAiApiKey?: string
@@ -133,6 +134,39 @@ export class OpenAiHandler implements ApiHandler {
 			reasoningEffort = requestedEffort === "none" ? undefined : (requestedEffort as ChatCompletionReasoningEffort)
 		}
 
+		// OpenRouter Anthropic and MiniMax models require explicit cache_control blocks
+		// when accessed through the OpenAI-compatible endpoint.
+		const isOpenRouterBaseUrl = this.options.openAiBaseUrl?.toLowerCase().includes("openrouter.ai")
+		const needsCacheControl = isOpenRouterBaseUrl && (modelId.startsWith("anthropic/") || modelId.startsWith("minimax/"))
+		if (needsCacheControl && openAiMessages.length > 0) {
+			const firstMessage = openAiMessages[0] as any
+			if (typeof firstMessage.content === "string") {
+				firstMessage.content = [{ type: "text", text: firstMessage.content, cache_control: { type: "ephemeral" } }]
+			} else if (Array.isArray(firstMessage.content)) {
+				let firstMessageLastTextPart = firstMessage.content.filter((part: any) => part.type === "text").pop()
+				if (!firstMessageLastTextPart) {
+					firstMessageLastTextPart = { type: "text", text: "..." }
+					firstMessage.content.push(firstMessageLastTextPart)
+				}
+				firstMessageLastTextPart.cache_control = { type: "ephemeral" }
+			}
+
+			const lastTwoUserMessages = openAiMessages.filter((msg) => msg.role === "user").slice(-2) as any[]
+			lastTwoUserMessages.forEach((msg) => {
+				if (typeof msg.content === "string") {
+					msg.content = [{ type: "text", text: msg.content }]
+				}
+				if (Array.isArray(msg.content)) {
+					let lastTextPart = msg.content.filter((part: any) => part.type === "text").pop()
+					if (!lastTextPart) {
+						lastTextPart = { type: "text", text: "..." }
+						msg.content.push(lastTextPart)
+					}
+					lastTextPart.cache_control = { type: "ephemeral" }
+				}
+			})
+		}
+
 		const stream = await client.chat.completions.create({
 			model: modelId,
 			messages: openAiMessages,
@@ -167,13 +201,13 @@ export class OpenAiHandler implements ApiHandler {
 			}
 
 			if (chunk.usage) {
+				const { cacheReadTokens, cacheWriteTokens } = extractCacheTokenUsage(chunk.usage as OpenAiCompatibleCacheUsage)
 				yield {
 					type: "usage",
-					inputTokens: chunk.usage.prompt_tokens || 0,
+					inputTokens: (chunk.usage.prompt_tokens || 0) - cacheReadTokens - cacheWriteTokens,
 					outputTokens: chunk.usage.completion_tokens || 0,
-					cacheReadTokens: chunk.usage.prompt_tokens_details?.cached_tokens || 0,
-					// @ts-expect-error-next-line
-					cacheWriteTokens: chunk.usage.prompt_cache_miss_tokens || 0,
+					cacheReadTokens,
+					cacheWriteTokens,
 				}
 			}
 		}

--- a/src/core/api/providers/openrouter.ts
+++ b/src/core/api/providers/openrouter.ts
@@ -13,6 +13,7 @@ import { withRetry } from "../retry"
 import { createOpenRouterStream } from "../transform/openrouter-stream"
 import { ApiStream, ApiStreamUsageChunk } from "../transform/stream"
 import { ToolCallProcessor } from "../transform/tool-call-processor"
+import { extractCacheTokenUsage, OpenAiCompatibleCacheUsage } from "./cache-usage"
 import { OpenRouterErrorResponse } from "./types"
 
 interface OpenRouterHandlerOptions extends CommonApiHandlerOptions {
@@ -154,16 +155,12 @@ export class OpenRouterHandler implements ApiHandler {
 			}
 
 			if (!didOutputUsage && chunk.usage) {
-				// @ts-expect-error-next-line -- OpenRouter returns cache_write_tokens for Anthropic models
-				const cacheWriteTokens = chunk.usage.prompt_tokens_details?.cache_write_tokens || 0
+				const { cacheReadTokens, cacheWriteTokens } = extractCacheTokenUsage(chunk.usage as OpenAiCompatibleCacheUsage)
 				yield {
 					type: "usage",
 					cacheWriteTokens,
-					cacheReadTokens: chunk.usage.prompt_tokens_details?.cached_tokens || 0,
-					inputTokens:
-						(chunk.usage.prompt_tokens || 0) -
-						(chunk.usage.prompt_tokens_details?.cached_tokens || 0) -
-						(cacheWriteTokens || 0),
+					cacheReadTokens,
+					inputTokens: (chunk.usage.prompt_tokens || 0) - cacheReadTokens - cacheWriteTokens,
 					outputTokens: chunk.usage.completion_tokens || 0,
 					// @ts-expect-error-next-line
 					totalCost: (chunk.usage.cost || 0) + (chunk.usage.cost_details?.upstream_inference_cost || 0),
@@ -187,13 +184,18 @@ export class OpenRouterHandler implements ApiHandler {
 			try {
 				const generationIterator = this.fetchGenerationDetails(this.lastGenerationId)
 				const generation = (await generationIterator.next()).value
+				const { cacheReadTokens: usageCacheReadTokens, cacheWriteTokens: usageCacheWriteTokens } = extractCacheTokenUsage(
+					generation as OpenAiCompatibleCacheUsage,
+				)
+				const cacheWriteTokens = generation?.native_tokens_cache_write ?? usageCacheWriteTokens
+				const cacheReadTokens = generation?.native_tokens_cached ?? usageCacheReadTokens
 				// Logger.log("OpenRouter generation details:", generation)
 				return {
 					type: "usage",
-					cacheWriteTokens: generation?.native_tokens_cache_write || 0,
-					cacheReadTokens: generation?.native_tokens_cached || 0,
+					cacheWriteTokens,
+					cacheReadTokens,
 					// openrouter generation endpoint fails often
-					inputTokens: (generation?.native_tokens_prompt || 0) - (generation?.native_tokens_cached || 0),
+					inputTokens: (generation?.native_tokens_prompt || 0) - cacheReadTokens - cacheWriteTokens,
 					outputTokens: generation?.native_tokens_completion || 0,
 					totalCost: generation?.total_cost || 0,
 				}

--- a/src/core/api/providers/vercel-ai-gateway.ts
+++ b/src/core/api/providers/vercel-ai-gateway.ts
@@ -10,6 +10,7 @@ import { withRetry } from "../retry"
 import { ApiStream } from "../transform/stream"
 import { ToolCallProcessor } from "../transform/tool-call-processor"
 import { createVercelAIGatewayStream } from "../transform/vercel-ai-gateway-stream"
+import { extractCacheTokenUsage, OpenAiCompatibleCacheUsage } from "./cache-usage"
 
 interface VercelAIGatewayHandlerOptions extends CommonApiHandlerOptions {
 	vercelAiGatewayApiKey?: string
@@ -113,14 +114,17 @@ export class VercelAIGatewayHandler implements ApiHandler {
 				}
 
 				if (!didOutputUsage && chunk.usage) {
+					const { cacheReadTokens, cacheWriteTokens } = extractCacheTokenUsage(
+						chunk.usage as OpenAiCompatibleCacheUsage,
+					)
 					// @ts-expect-error - Vercel AI Gateway extends OpenAI types
 					const totalCost = (chunk.usage.cost || 0) + (chunk.usage.cost_details?.upstream_inference_cost || 0)
 
 					yield {
 						type: "usage",
-						cacheWriteTokens: 0,
-						cacheReadTokens: chunk.usage.prompt_tokens_details?.cached_tokens || 0,
-						inputTokens: (chunk.usage.prompt_tokens || 0) - (chunk.usage.prompt_tokens_details?.cached_tokens || 0),
+						cacheWriteTokens,
+						cacheReadTokens,
+						inputTokens: (chunk.usage.prompt_tokens || 0) - cacheReadTokens - cacheWriteTokens,
 						outputTokens: chunk.usage.completion_tokens || 0,
 						totalCost,
 					}


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

### Description

This fixes cache token telemetry inconsistencies for OpenRouter-compatible providers (OpenRouter, Vercel AI Gateway, and Cline proxy paths).

What was happening:
- OpenRouter reported cache writes via `prompt_tokens_details.cache_write_tokens` and we handled that in `OpenRouterHandler`.
- Vercel AI Gateway commonly reports cache writes via `cache_creation_input_tokens` instead, so `cacheWriteTokens` stayed at `0`.
- Cline handler had the same issue in streaming usage parsing.

What changed:
- Added a shared parser: `extractCacheTokenUsage()` in `src/core/api/providers/cache-usage.ts`.
- It normalizes cache usage fields from multiple response shapes:
  - `prompt_tokens_details.cached_tokens`
  - `prompt_tokens_details.cache_write_tokens`
  - `cache_read_input_tokens`
  - `cache_creation_input_tokens`
  - `prompt_cache_hit_tokens`
  - `prompt_cache_miss_tokens`
- Wired the parser into:
  - `OpenRouterHandler`
  - `VercelAIGatewayHandler`
  - `ClineHandler`
- Updated non-cached input token calculation to consistently compute:
  - `prompt_tokens - cacheReadTokens - cacheWriteTokens`

### Test Procedure

1. Unit tests (provider-focused and full unit suite invocation path):
- `npx cross-env TS_NODE_PROJECT=./tsconfig.unit-test.json mocha --no-config -r ts-node/register -r source-map-support/register -r ./src/test/requires.ts src/core/api/providers/__tests__/openrouter.test.ts src/core/api/providers/__tests__/cline.test.ts src/core/api/providers/__tests__/vercel-ai-gateway.test.ts`
- `npm run test:unit -- src/core/api/providers/__tests__/openrouter.test.ts src/core/api/providers/__tests__/cline.test.ts src/core/api/providers/__tests__/vercel-ai-gateway.test.ts src/core/api/providers/__tests__/fireworks.test.ts`

2. Added unit coverage for fallback field shapes:
- OpenRouter: falls back to `cache_creation_input_tokens` when `cache_write_tokens` is absent
- Vercel: reads `cache_creation_input_tokens`
- Cline: reads `cache_creation_input_tokens`

3. Live API verification with `.env` credentials (Anthropic Claude + explicit `cache_control`) for 3 providers:
- OpenRouter: first request showed non-zero write tokens, second showed non-zero read tokens
- Vercel AI Gateway: first request showed non-zero `cache_creation_input_tokens`, second showed non-zero cached reads
- Anthropic: first request showed non-zero `cache_creation_input_tokens`, second showed non-zero `cache_read_input_tokens`

4. CLI build:
- `npm run cli:build`

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ♻️ Refactor Changes
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A (backend/provider telemetry mapping changes only).

### Additional Notes

Context: tracked under internal/linear issue OPS-271 (`Explore caching in OpenRouter for Anthropic model family`).
