### PR TITLE
fix: avoid wasting number of processed files in `SummarizeTaskHandler`

### DIFF
--- a/src/core/task/tools/handlers/SummarizeTaskHandler.ts
+++ b/src/core/task/tools/handlers/SummarizeTaskHandler.ts
@@ -144,6 +144,12 @@ export class SummarizeTaskHandler implements IToolHandler, IPartialBlockHandler 
 				// Read each file only if auto-approved
 				// We consider the list of files still good context for task continuation even if user doesn't have auto approval on
 				for (const relPath of filePaths) {
+					// Check .clineignore first and skip ignored files
+					const accessValidation = this.validator.checkClineIgnorePath(relPath)
+					if (!accessValidation.ok) {
+						continue
+					}
+
 					// Validate that we have not loaded this file previously
 					const normalizedPath = relPath.toLowerCase()
 					if (loadedFiles.has(normalizedPath)) {
@@ -154,12 +160,6 @@ export class SummarizeTaskHandler implements IToolHandler, IPartialBlockHandler 
 					filesProcessed++
 					if (filesProcessed > MAX_FILES_PROCESSED) {
 						break
-					}
-
-					// Check .clineignore first and skip ignored files
-					const accessValidation = this.validator.checkClineIgnorePath(relPath)
-					if (!accessValidation.ok) {
-						continue
 					}
 
 					// Only process if auto-approved (respects workspace/outside-workspace settings)


### PR DESCRIPTION
<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- For feature requests: Created a discussion in our Feature Requests discussions board https://github.com/cline/cline/discussions/categories/feature-requests and received approval from core maintainers before implementation
- For all changes: Link the associated issue/discussion in the "Related Issue" section below

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly without prior discussion.

Why this requirement?
We deeply appreciate all community contributions - they are essential to Cline's success! To ensure the best use of everyone's time and maintain project direction, we use our Feature Requests discussions board to gauge community interest and validate feature ideas before implementation begins. This helps us focus development efforts on features that will benefit the most users.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** NA

### Description

<!-- 
Help reviewers understand your changes by making this PR readable and well-organized:

- What problem does this PR solve?
- Why were these changes introduced and what purpose do they serve?
- For larger changes, provide context about your approach and reasoning

Small PRs may need minimal description, but larger changes benefit from explaining where you're coming from. Much of this context can be in the linked issue above, so feel free to reference it rather than repeating everything here.
-->

Files under "cline ignore path" can consume number of processed files incorrectly. So check "cline ignore path" first before increasing number of processed files. Otherwise, loading files can't be done due to MAX_FILES_PROCESSED(10).

### Test Procedure

<!-- 
Please walk us through your testing approach and thought process. This helps reviewers understand that you've thoroughly considered the impact of your changes:

- How did you test this change?
- What could potentially break and how did you verify it doesn't?
- What existing functionality might be affected and how did you check it still works?
- Why are you confident this is ready for merge?

We're not looking for exhaustive documentation - just evidence that you've thought through the implications of your changes and tested accordingly.
-->

I think this is logical issue, so I ran `npm test`.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->
