### PR TITLE
fix: strip task_progress from MCP tool call arguments

### DIFF
--- a/src/core/task/tools/handlers/UseMcpToolHandler.ts
+++ b/src/core/task/tools/handlers/UseMcpToolHandler.ts
@@ -74,6 +74,15 @@ export class UseMcpToolHandler implements IFullyManagedTool {
 				await config.callbacks.say("error", `Cline tried to use ${tool_name} with an invalid JSON argument. Retrying...`)
 				return formatResponse.toolError(formatResponse.invalidMcpToolArgumentError(server_name, tool_name))
 			}
+
+			// Strip task_progress from arguments before sending to MCP server.
+			// The model includes task_progress with every tool call per system prompt,
+			// but MCP servers don't expect it and reject it, causing an infinite retry
+			// loop. We preserve task_progress at the block level for focus chain tracking.
+			// See #9684
+			if (parsedArguments && "task_progress" in parsedArguments) {
+				delete parsedArguments.task_progress
+			}
 		}
 
 		config.taskState.consecutiveMistakeCount = 0
@@ -128,18 +137,17 @@ export class UseMcpToolHandler implements IFullyManagedTool {
 					block.isNativeToolCall,
 				)
 				return formatResponse.toolDenied()
-			} else {
-				telemetryService.captureToolUsage(
-					config.ulid,
-					block.name,
-					config.api.getModel().id,
-					provider,
-					false,
-					true,
-					undefined,
-					block.isNativeToolCall,
-				)
 			}
+			telemetryService.captureToolUsage(
+				config.ulid,
+				block.name,
+				config.api.getModel().id,
+				provider,
+				false,
+				true,
+				undefined,
+				block.isNativeToolCall,
+			)
 		}
 
 		// Run PreToolUse hook after approval but before execution


### PR DESCRIPTION
## Summary

Fixes #9684 (also reported in #9919)

Strip the internal `task_progress` parameter from MCP tool call arguments before forwarding them to MCP servers.

## Root Cause

The system prompt instructs the model to include `task_progress` with every tool call for focus chain tracking. When the model calls an MCP tool, `task_progress` ends up inside the `arguments` JSON. MCP servers with strict schema validation reject the unexpected parameter, the model retries with the same parameter, and an infinite loop results.

## Fix

In `UseMcpToolHandler.execute()`, after parsing the `arguments` JSON string, delete `task_progress` from the object before passing it to `McpHub.callTool()`. This:

1. Preserves `task_progress` at the block level (`block.params.task_progress`) for focus chain tracking
2. Only strips it from the MCP server-bound arguments
3. No-ops when `task_progress` is not present in the arguments

## Test plan

- [ ] MCP tool calls no longer include `task_progress` in arguments sent to servers
- [ ] Focus chain / task progress tracking still works
- [ ] MCP tool calls with valid arguments work correctly
- [ ] Works with focus chain enabled and disabled