### PR TITLE
fix: add directory validation to prevent EISDIR error in file tools

### DIFF
--- a/src/core/task/tools/handlers/WriteToFileToolHandler.ts
+++ b/src/core/task/tools/handlers/WriteToFileToolHandler.ts
@@ -486,7 +486,7 @@ export class WriteToFileToolHandler implements IFullyManagedTool {
 				)
 
 				const errorResponse = formatResponse.toolError(
-					`The path '${resolvedPath}' is a directory, not a file. You must provide a file path, not a directory path. For example, use '${resolvedPath}/index.ts' instead of '${resolvedPath}'.`,
+					`The path '${resolvedPath}' is a directory, not a file. You must provide a file path, not a directory path. For example, use a specific file inside '${resolvedPath}' such as '${resolvedPath}/index.ts' or another file within that directory.`,
 				)
 				ToolResultUtils.pushToolResult(
 					errorResponse,
@@ -502,8 +502,12 @@ export class WriteToFileToolHandler implements IFullyManagedTool {
 
 				return
 			}
-		} catch {
-			// Path doesn't exist yet (new file) — that's fine, continue
+		} catch (err: unknown) {
+			// Path doesn't exist yet (new file) — that's fine, continue.
+			// Re-throw any unexpected errors so they surface properly.
+			if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
+				throw err
+			}
 		}
 
 		// Check if file exists to determine the correct UI message

--- a/src/core/task/tools/handlers/WriteToFileToolHandler.ts
+++ b/src/core/task/tools/handlers/WriteToFileToolHandler.ts
@@ -1,3 +1,4 @@
+import fs from "node:fs/promises"
 import path from "node:path"
 import { setTimeout as setTimeoutPromise } from "node:timers/promises"
 import type { ToolUse } from "@core/assistant-message"
@@ -470,6 +471,39 @@ export class WriteToFileToolHandler implements IFullyManagedTool {
 			}
 
 			return
+		}
+
+		// Reject directory paths early — the model sometimes passes a directory
+		// instead of a file path, causing an EISDIR error on read. Return a clear
+		// error so the model can self-correct. See #9912
+		try {
+			const stat = await fs.stat(absolutePath)
+			if (stat.isDirectory()) {
+				config.taskState.consecutiveMistakeCount++
+				await config.callbacks.say(
+					"error",
+					`Cline tried to use ${block.name} on '${resolvedPath}', but that path is a directory, not a file. Retrying...`,
+				)
+
+				const errorResponse = formatResponse.toolError(
+					`The path '${resolvedPath}' is a directory, not a file. You must provide a file path, not a directory path. For example, use '${resolvedPath}/index.ts' instead of '${resolvedPath}'.`,
+				)
+				ToolResultUtils.pushToolResult(
+					errorResponse,
+					block,
+					config.taskState.userMessageContent,
+					ToolDisplayUtils.getToolDescription,
+					config.coordinator,
+					config.taskState.toolUseIdMap,
+				)
+				if (!config.enableParallelToolCalling) {
+					config.taskState.didAlreadyUseTool = true
+				}
+
+				return
+			}
+		} catch {
+			// Path doesn't exist yet (new file) — that's fine, continue
 		}
 
 		// Check if file exists to determine the correct UI message


### PR DESCRIPTION
## Summary

Fixes #9912

Add an early directory check in `validateAndPrepareFileOperation()` to detect when the model passes a directory path instead of a file path to `write_to_file` or `replace_in_file`.

## Root Cause

When a model passes a directory path (e.g., `src/components`) instead of a file path to file editing tools, the handler attempts `fs.readFile()` on a directory, which throws an `EISDIR: illegal operation on a directory` error. The error message is cryptic and the model can't recover from it.

## Fix

In `WriteToFileToolHandler.validateAndPrepareFileOperation()`, after validating clineignore access and before checking file existence, call `fs.stat()` and check `isDirectory()`. If the path is a directory, return a clear error message like:

> The path 'src/components' is a directory, not a file. You must provide a file path, not a directory path. For example, use 'src/components/index.ts' instead of 'src/components'.

This allows the model to self-correct on the next attempt.

## Test plan

- [ ] `replace_in_file` on a directory path returns a clear error instead of EISDIR
- [ ] `write_to_file` on a directory path returns a clear error instead of EISDIR
- [ ] Normal file operations (existing + new files) still work correctly
- [ ] `consecutiveMistakeCount` increments on directory path errors