### PR TITLE
fix: exclude new_task tool from system prompt in yolo/headless mode

### DIFF
--- a/src/core/prompts/system-prompt/__tests__/new-task-yolo-filter.test.ts
+++ b/src/core/prompts/system-prompt/__tests__/new-task-yolo-filter.test.ts
@@ -1,0 +1,65 @@
+import { expect } from "chai"
+import { before, describe, it } from "mocha"
+import { ModelFamily } from "@/shared/prompts"
+import { ClineDefaultTool } from "@/shared/tools"
+import { ClineToolSet } from "../registry/ClineToolSet"
+import { PromptRegistry } from "../registry/PromptRegistry"
+import { new_task_variants } from "../tools/new_task"
+import type { SystemPromptContext } from "../types"
+import { mockProviderInfo } from "./integration.test"
+
+const baseContext: SystemPromptContext = {
+	cwd: "/test/project",
+	ide: "TestIde",
+	supportsBrowserUse: true,
+	providerInfo: mockProviderInfo,
+	isTesting: true,
+}
+
+describe("new_task tool contextRequirements", () => {
+	before(() => {
+		// Ensure tools are registered via PromptRegistry initialization
+		PromptRegistry.getInstance()
+	})
+
+	const genericVariant = new_task_variants.find((v) => v.variant === ModelFamily.GENERIC)
+
+	it("should have a contextRequirements function defined", () => {
+		expect(genericVariant).to.exist
+		expect(genericVariant!.contextRequirements).to.be.a("function")
+	})
+
+	it("should be enabled when yoloModeToggled is false", () => {
+		const context: SystemPromptContext = { ...baseContext, yoloModeToggled: false }
+		expect(genericVariant!.contextRequirements!(context)).to.be.true
+	})
+
+	it("should be enabled when yoloModeToggled is undefined", () => {
+		const context: SystemPromptContext = { ...baseContext, yoloModeToggled: undefined }
+		expect(genericVariant!.contextRequirements!(context)).to.be.true
+	})
+
+	it("should be disabled when yoloModeToggled is true", () => {
+		const context: SystemPromptContext = { ...baseContext, yoloModeToggled: true }
+		expect(genericVariant!.contextRequirements!(context)).to.be.false
+	})
+
+	it("should follow the same pattern as ask_followup_question", () => {
+		const newTaskTool = ClineToolSet.getToolByNameWithFallback(ClineDefaultTool.NEW_TASK, ModelFamily.GENERIC)
+		const askTool = ClineToolSet.getToolByNameWithFallback(ClineDefaultTool.ASK, ModelFamily.GENERIC)
+
+		expect(newTaskTool).to.exist
+		expect(askTool).to.exist
+		expect(newTaskTool!.config.contextRequirements).to.be.a("function")
+		expect(askTool!.config.contextRequirements).to.be.a("function")
+
+		const yoloContext: SystemPromptContext = { ...baseContext, yoloModeToggled: true }
+		const normalContext: SystemPromptContext = { ...baseContext, yoloModeToggled: false }
+
+		expect(newTaskTool!.config.contextRequirements!(yoloContext)).to.be.false
+		expect(askTool!.config.contextRequirements!(yoloContext)).to.be.false
+
+		expect(newTaskTool!.config.contextRequirements!(normalContext)).to.be.true
+		expect(askTool!.config.contextRequirements!(normalContext)).to.be.true
+	})
+})

--- a/src/core/prompts/system-prompt/tools/new_task.ts
+++ b/src/core/prompts/system-prompt/tools/new_task.ts
@@ -27,6 +27,7 @@ const generic: ClineToolSpec = {
 	name: "new_task",
 	description: `Request to create a new task with preloaded context covering the conversation with the user up to this point and key information for continuing with the new task. With this tool, you will create a detailed summary of the conversation so far, paying close attention to the user's explicit requests and your previous actions, with a focus on the most relevant information required for the new task.
 Among other important areas of focus, this summary should be thorough in capturing technical details, code patterns, and architectural decisions that would be essential for continuing with the new task. The user will be presented with a preview of your generated context and can choose to create a new task or keep chatting in the current conversation. The user may choose to start a new task at any point.`,
+	contextRequirements: (context) => !context.yoloModeToggled,
 	parameters: [
 		{
 			name: "context",


### PR DESCRIPTION
### Related Issue

**Issue:** N/A (bug discovered during CLI headless mode investigation)

### Description

The `new_task` tool requires interactive user input — it creates an `ask` message of type `"new_task"` and blocks waiting for a response. In headless CLI mode (`-y`/`--yolo`, piped, `--json`) and ACP agent mode, no component responds to this ask, causing the task to **hang indefinitely**.

This PR adds a `contextRequirements` filter to exclude `new_task` from the system prompt when `yoloModeToggled` is true, matching the existing pattern used by `ask_followup_question`.
**Known limitations:**
- This only covers `-y`/`--yolo` headless mode. Piped mode without `-y` is not covered, though that scenario already hangs at every approval prompt so `-y` is effectively required for headless operation.
- ACP agent mode only benefits if the agent's auto-approval settings result in `yoloModeToggled` being set. If not, the tool still appears in the prompt (though the agent cannot respond to it).
- A more complete fix would require a dedicated `isHeadlessMode`/`isNonInteractive` context flag that precisely targets non-interactive runtimes regardless of approval settings.

### Test Procedure

- Added 5 unit tests in `new-task-yolo-filter.test.ts` verifying:
  - `contextRequirements` is defined on the tool spec
  - Tool is enabled when `yoloModeToggled` is `false` or `undefined`
  - Tool is disabled when `yoloModeToggled` is `true`
  - `new_task` and `ask_followup_question` follow the identical filtering pattern through the `ClineToolSet` registry
- All 61 existing snapshot tests pass unchanged
- All 122 prompt-related unit tests pass
### Type of Change

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Refactor Changes
-   [ ] Cosmetic Changes
-   [ ] Documentation update
-   [ ] Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing and code is formatted and linted
-   [x] I have reviewed contributor guidelines

### Screenshots

N/A - backend-only change with no UI impact.

### Additional Notes

The code change is a single line addition to `src/core/prompts/system-prompt/tools/new_task.ts`, following the exact same `contextRequirements` pattern already used by `ask_followup_question`, `browser_action`, `access_mcp_resource`, and other context-gated tools.
