### PR TITLE
feat: add toggle to disable feature tips in chat

### DIFF
--- a/cli/src/components/FeatureTip.tsx
+++ b/cli/src/components/FeatureTip.tsx
@@ -63,6 +63,9 @@ const FEATURE_TIPS: FeatureTipItem[] = [
 	{
 		text: "Use /skills to browse and attach reusable skill files that guide Cline's behavior.",
 	},
+	{
+		text: 'You can disable these tips in /settings → Features → "Feature tips".',
+	},
 ]
 
 const SHOW_DELAY_MS = 2000

--- a/cli/src/components/SettingsPanelContent.tsx
+++ b/cli/src/components/SettingsPanelContent.tsx
@@ -129,6 +129,12 @@ const FEATURE_SETTINGS = {
 		label: "Double-check completion",
 		description: "Reject first completion attempt and require re-verification",
 	},
+	showFeatureTips: {
+		stateKey: "showFeatureTips",
+		default: true,
+		label: "Feature tips",
+		description: "Show tips during thinking phases",
+	},
 } as const
 
 type FeatureKey = keyof typeof FEATURE_SETTINGS

--- a/cli/src/components/ThinkingIndicator.tsx
+++ b/cli/src/components/ThinkingIndicator.tsx
@@ -4,6 +4,7 @@
 
 import { Box, Text, useInput } from "ink"
 import React, { useEffect, useMemo, useState } from "react"
+import { StateManager } from "@/core/storage/StateManager"
 import { COLORS } from "../constants/colors"
 import { FeatureTip } from "./FeatureTip"
 
@@ -53,6 +54,7 @@ const ShimmerText: React.FC<{ text: string; color: string; shimmerPos: number }>
 }
 
 export const ThinkingIndicator: React.FC<ThinkingIndicatorProps> = ({ mode = "act", startTime, onCancel }) => {
+	const showFeatureTips = StateManager.get().getGlobalSettingsKey("showFeatureTips") ?? true
 	const message = mode === "plan" ? "Planning" : "Acting"
 	const color = mode === "plan" ? "yellow" : COLORS.primaryBlue
 
@@ -124,7 +126,7 @@ export const ThinkingIndicator: React.FC<ThinkingIndicatorProps> = ({ mode = "ac
 				<ShimmerText color={color} shimmerPos={shimmerPos} text={fullText} />
 				{elapsedStr && <Text color="gray"> ({elapsedStr} · esc to interrupt)</Text>}
 			</Box>
-			<FeatureTip />
+			{showFeatureTips && <FeatureTip />}
 		</Box>
 	)
 }

--- a/proto/cline/state.proto
+++ b/proto/cline/state.proto
@@ -285,6 +285,7 @@ message Settings {
   optional OpenRouterModelInfo plan_mode_cline_model_info = 179;
   optional string act_mode_cline_model_id = 180;
   optional OpenRouterModelInfo act_mode_cline_model_info = 181;
+  optional bool show_feature_tips = 182;
 }
 
 message State {
@@ -426,6 +427,7 @@ message UpdateSettingsRequest {
   optional bool opt_out_of_remote_config = 39;
   optional bool worktrees_enabled = 40;
   optional bool double_check_completion_enabled = 41;
+  optional bool show_feature_tips = 42;
 }
 
 message UpdateTerminalConnectionTimeoutRequest {

--- a/src/core/controller/index.ts
+++ b/src/core/controller/index.ts
@@ -887,6 +887,7 @@ export class Controller {
 		const lastDismissedCliBannerVersion = this.stateManager.getGlobalStateKey("lastDismissedCliBannerVersion") || 0
 		const dismissedBanners = this.stateManager.getGlobalStateKey("dismissedBanners")
 		const doubleCheckCompletionEnabled = this.stateManager.getGlobalSettingsKey("doubleCheckCompletionEnabled")
+		const showFeatureTips = this.stateManager.getGlobalSettingsKey("showFeatureTips")
 
 		const localClineRulesToggles = this.stateManager.getWorkspaceStateKey("localClineRulesToggles")
 		const localWindsurfRulesToggles = this.stateManager.getWorkspaceStateKey("localWindsurfRulesToggles")
@@ -997,6 +998,7 @@ export class Controller {
 			backgroundEditEnabled: this.stateManager.getGlobalSettingsKey("backgroundEditEnabled"),
 			optOutOfRemoteConfig: this.stateManager.getGlobalSettingsKey("optOutOfRemoteConfig"),
 			doubleCheckCompletionEnabled,
+			showFeatureTips,
 			banners,
 			welcomeBanners,
 			openAiCodexIsAuthenticated,

--- a/src/core/controller/state/updateSettings.ts
+++ b/src/core/controller/state/updateSettings.ts
@@ -344,6 +344,10 @@ export async function updateSettings(controller: Controller, request: UpdateSett
 			controller.stateManager.setGlobalState("doubleCheckCompletionEnabled", request.doubleCheckCompletionEnabled)
 		}
 
+		if (request.showFeatureTips !== undefined) {
+			controller.stateManager.setGlobalState("showFeatureTips", request.showFeatureTips)
+		}
+
 		// Post updated state to webview
 		await controller.postStateToWebview()
 

--- a/src/shared/ExtensionMessage.ts
+++ b/src/shared/ExtensionMessage.ts
@@ -108,6 +108,7 @@ export interface ExtensionState {
 	backgroundEditEnabled?: boolean
 	optOutOfRemoteConfig?: boolean
 	doubleCheckCompletionEnabled?: boolean
+	showFeatureTips?: boolean
 	banners?: BannerCardData[]
 	welcomeBanners?: BannerCardData[]
 	openAiCodexIsAuthenticated?: boolean

--- a/src/shared/storage/state-keys.ts
+++ b/src/shared/storage/state-keys.ts
@@ -273,6 +273,7 @@ const USER_SETTINGS_FIELDS = {
 	backgroundEditEnabled: { default: false as boolean },
 	optOutOfRemoteConfig: { default: false as boolean },
 	doubleCheckCompletionEnabled: { default: false as boolean },
+	showFeatureTips: { default: true as boolean },
 
 	// OpenTelemetry configuration
 	openTelemetryEnabled: { default: true as boolean },

--- a/webview-ui/src/components/chat/ChatRow.tsx
+++ b/webview-ui/src/components/chat/ChatRow.tsx
@@ -155,6 +155,7 @@ export const ChatRowContent = memo(
 			onRelinquishControl,
 			vscodeTerminalExecutionMode,
 			clineMessages,
+			showFeatureTips,
 		} = useExtensionState()
 		const [seeNewChangesDisabled, setSeeNewChangesDisabled] = useState(false)
 		const [explainChangesDisabled, setExplainChangesDisabled] = useState(false)
@@ -903,7 +904,7 @@ export const ChatRowContent = memo(
 									showTitle={true}
 									title={isReasoningStreaming ? "Thinking..." : "Thinking"}
 								/>
-						{isReasoningStreaming && <FeatureTip />}
+								{isReasoningStreaming && showFeatureTips !== false && <FeatureTip />}
 							</div>
 						)
 					}

--- a/webview-ui/src/components/chat/FeatureTip.tsx
+++ b/webview-ui/src/components/chat/FeatureTip.tsx
@@ -43,6 +43,9 @@ const FEATURE_TIPS: FeatureTipItem[] = [
 	{
 		text: "Use /reportbug to quickly file a GitHub issue with diagnostic context included.",
 	},
+	{
+		text: 'You can disable these tips in Settings → Features → "Feature Tips".',
+	},
 ]
 
 const SHOW_DELAY_MS = 2000

--- a/webview-ui/src/components/settings/sections/FeatureSettingsSection.tsx
+++ b/webview-ui/src/components/settings/sections/FeatureSettingsSection.tsx
@@ -80,6 +80,13 @@ const agentFeatures: FeatureToggle[] = [
 
 const editorFeatures: FeatureToggle[] = [
 	{
+		id: "show-feature-tips",
+		label: "Feature Tips",
+		description: "Show rotating tips during the thinking phase to help you discover Cline features.",
+		stateKey: "showFeatureTips",
+		settingKey: "showFeatureTips",
+	},
+	{
 		id: "background-edit",
 		label: "Background Edit",
 		description: "Allow edits without stealing editor focus",
@@ -211,6 +218,7 @@ const FeatureSettingsSection = ({ renderSectionHeader }: FeatureSettingsSectionP
 		enableParallelToolCalling,
 		backgroundEditEnabled,
 		doubleCheckCompletionEnabled,
+		showFeatureTips,
 	} = useExtensionState()
 
 	const handleFocusChainIntervalChange = useCallback(
@@ -224,6 +232,7 @@ const FeatureSettingsSection = ({ renderSectionHeader }: FeatureSettingsSectionP
 
 	// State lookup for mapped features
 	const featureState: Record<string, boolean | undefined> = {
+		showFeatureTips,
 		enableCheckpointsSetting,
 		strictPlanModeEnabled,
 		hooksEnabled,

--- a/webview-ui/src/context/ExtensionStateContext.tsx
+++ b/webview-ui/src/context/ExtensionStateContext.tsx
@@ -277,6 +277,7 @@ export const ExtensionStateContextProvider: React.FC<{
 		lastDismissedCliBannerVersion: 0,
 		backgroundEditEnabled: false,
 		doubleCheckCompletionEnabled: false,
+		showFeatureTips: true,
 		globalSkillsToggles: {},
 		localSkillsToggles: {},
 


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

### Description

Addresses user feedback requesting the ability to disable feature tips shown in the chat conversation pane during the thinking/reasoning phase. Users found the tips appearing in the conversation pane unsettling, especially when Cline wasn't actively running a task.

This PR adds a **"Feature Tips"** toggle in Settings → Features → Editor that allows users to turn tips on or off. The setting defaults to **on** for new users and persists across sessions via global state.

Changes span both the VSCode extension and CLI:
- New `showFeatureTips` global state key with full proto plumbing
- Toggle in webview `FeatureSettingsSection` (Editor group)
- Conditional rendering of `<FeatureTip />` in `ChatRow` (webview) and `ThinkingIndicator` (CLI)
- Toggle in CLI `SettingsPanelContent` Features tab
- Added a self-referential tip telling users how to disable tips

### Test Procedure

- Verified the toggle appears in Settings → Features → Editor section in the webview
- Toggled off: confirmed tips no longer appear during thinking phase in ChatRow
- Toggled on: confirmed tips reappear as before
- Verified the setting persists across webview reloads via global state round-trip
- Confirmed CLI SettingsPanelContent shows the Feature Tips checkbox and writes state correctly
- Checked that the proto field `show_feature_tips` (field 42) in `UpdateSettingsRequest` compiles and the setting flows through `updateSettings.ts`

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A — Settings toggle is a standard checkbox in the existing Feature Settings section. No new UI paradigms introduced.

### Additional Notes

The 12 files changed touch the full settings plumbing chain: state-keys → proto → updateSettings handler → Controller state posting → ExtensionState → webview context → UI toggle → conditional rendering in both ChatRow (webview) and ThinkingIndicator (CLI).
