### PR TITLE
fix: update broken Getting Started link (for-new-coders → quick-start)

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ English | <a href="https://github.com/cline/cline/blob/main/locales/es/README.md
 <a href="https://github.com/cline/cline/discussions/categories/feature-requests?discussions_q=is%3Aopen+category%3A%22Feature+Requests%22+sort%3Atop" target="_blank"><strong>Feature Requests</strong></a>
 </td>
 <td align="center">
-<a href="https://docs.cline.bot/getting-started/for-new-coders" target="_blank"><strong>Getting Started</strong></a>
+<a href="https://docs.cline.bot/getting-started/quick-start" target="_blank"><strong>Getting Started</strong></a>
 </td>
 </tbody>
 </table>

--- a/cli/README.md
+++ b/cli/README.md
@@ -20,7 +20,7 @@
 <a href="https://github.com/cline/cline/discussions/categories/feature-requests?discussions_q=is%3Aopen+category%3A%22Feature+Requests%22+sort%3Atop" target="_blank"><strong>Feature Requests</strong></a>
 </td>
 <td align="center">
-<a href="https://docs.cline.bot/getting-started/for-new-coders" target="_blank"><strong>Getting Started</strong></a>
+<a href="https://docs.cline.bot/getting-started/quick-start" target="_blank"><strong>Getting Started</strong></a>
 </td>
 </tbody>
 </table>

--- a/locales/zh-cn/README.md
+++ b/locales/zh-cn/README.md
@@ -20,7 +20,7 @@
 <a href="https://github.com/cline/cline/discussions/categories/feature-requests?discussions_q=is%3Aopen+category%3A%22Feature+Requests%22+sort%3Atop" target="_blank"><strong>功能请求</strong></a>
 </td>
 <td align="center">
-<a href="https://docs.cline.bot/getting-started/for-new-coders" target="_blank"><strong>新手上路</strong></a>
+<a href="https://docs.cline.bot/getting-started/quick-start" target="_blank"><strong>新手上路</strong></a>
 </td>
 </tbody>
 </table>


### PR DESCRIPTION
The `/getting-started/for-new-coders` docs page no longer exists (returns 404). Updated all README files to point to `/getting-started/quick-start`.\n\nFiles changed:\n- `README.md`\n- `cli/README.md`\n- `locales/zh-cn/README.md`\n\nFixes #9888