### PR TITLE
fix: Transcode kanban video to VP9/WebM for JetBrains

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,5 @@
 demo.gif filter=lfs diff=lfs merge=lfs -text
 assets/docs/demo.gif filter=lfs diff=lfs merge=lfs -text
-webview-ui/src/assets/cline_kanban_demo.mp4 filter=lfs diff=lfs merge=lfs -text
+webview-ui/src/assets/cline_kanban_demo.webm filter=lfs diff=lfs merge=lfs -text
 
 * text=auto eol=lf

--- a/.github/workflows/publish-nightly.yml
+++ b/.github/workflows/publish-nightly.yml
@@ -53,7 +53,7 @@ jobs:
 
             - name: Verify LFS media assets are resolved
               run: |
-                  FILE="webview-ui/src/assets/cline_kanban_demo.mp4"
+                  FILE="webview-ui/src/assets/cline_kanban_demo.webm"
                   if grep -q "git-lfs.github.com/spec/v1" "$FILE"; then
                     echo "Error: $FILE is still a Git LFS pointer in CI checkout"
                     exit 1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -136,7 +136,7 @@ jobs:
 
             - name: Verify LFS media assets are resolved
               run: |
-                  FILE="webview-ui/src/assets/cline_kanban_demo.mp4"
+                  FILE="webview-ui/src/assets/cline_kanban_demo.webm"
                   if grep -q "git-lfs.github.com/spec/v1" "$FILE"; then
                     echo "Error: $FILE is still a Git LFS pointer in CI checkout"
                     exit 1

--- a/webview-ui/src/assets/cline_kanban_demo.mp4
+++ b/webview-ui/src/assets/cline_kanban_demo.mp4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:fa7c90bf657f317e63dee745e010898ca0cb13ee82e9dbe341ac16199170399a
-size 3738635

--- a/webview-ui/src/assets/cline_kanban_demo.webm
+++ b/webview-ui/src/assets/cline_kanban_demo.webm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d8c44f299b676775874c508c7bbd76a91e084c4d5ae790e3af5d83179db3e4e3
+size 916270

--- a/webview-ui/src/components/common/ClineKanbanLaunchModal.tsx
+++ b/webview-ui/src/components/common/ClineKanbanLaunchModal.tsx
@@ -1,7 +1,7 @@
 import { StringRequest } from "@shared/proto/cline/common"
 import { VSCodeButton, VSCodeCheckbox } from "@vscode/webview-ui-toolkit/react"
 import React, { useEffect, useMemo, useState } from "react"
-import kanbanDemoVideo from "@/assets/cline_kanban_demo.mp4"
+import kanbanDemoVideo from "@/assets/cline_kanban_demo.webm"
 import { Dialog, DialogContent } from "@/components/ui/dialog"
 import { PLATFORM_CONFIG, PlatformType } from "@/config/platform.config"
 import { FileServiceClient, StateServiceClient } from "@/services/grpc-client"


### PR DESCRIPTION
## Problem

The kanban demo video is encoded with H.264. JetBrains IDEs use JCEF (Chromium Embedded Framework) for their webviews, and Chromium builds often do **not** include H.264 decoding due to licensing restrictions. This causes the kanban demo video to fail to play in JetBrains-based editors.

Transcode the video to **VP9/WebM**, which is a royalty-free codec with universal support across all Chromium derivatives (Chrome, Edge, JCEF, Electron, etc.).

Bonus: File size reduced from **3.6 MB → 895 KB** (~75% smaller) at the same resolution 1156×720, 30fps.

## Test Plan

```
./gradlew :runIde
```

Check the kanban sizzle video plays.