### PR TITLE
fix: Serve H.264/MP4 for VSCode *and* VP9/WebM for JetBrains

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,6 @@
 demo.gif filter=lfs diff=lfs merge=lfs -text
 assets/docs/demo.gif filter=lfs diff=lfs merge=lfs -text
+webview-ui/src/assets/cline_kanban_demo.mp4 filter=lfs diff=lfs merge=lfs -text
 webview-ui/src/assets/cline_kanban_demo.webm filter=lfs diff=lfs merge=lfs -text
 
 * text=auto eol=lf

--- a/.github/workflows/publish-nightly.yml
+++ b/.github/workflows/publish-nightly.yml
@@ -53,11 +53,12 @@ jobs:
 
             - name: Verify LFS media assets are resolved
               run: |
-                  FILE="webview-ui/src/assets/cline_kanban_demo.webm"
-                  if grep -q "git-lfs.github.com/spec/v1" "$FILE"; then
-                    echo "Error: $FILE is still a Git LFS pointer in CI checkout"
-                    exit 1
-                  fi
+                  for FILE in webview-ui/src/assets/cline_kanban_demo.mp4 webview-ui/src/assets/cline_kanban_demo.webm; do
+                    if grep -q "git-lfs.github.com/spec/v1" "$FILE"; then
+                      echo "Error: $FILE is still a Git LFS pointer in CI checkout"
+                      exit 1
+                    fi
+                  done
 
             - name: Publish Extension as Pre-release
               env:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -136,11 +136,12 @@ jobs:
 
             - name: Verify LFS media assets are resolved
               run: |
-                  FILE="webview-ui/src/assets/cline_kanban_demo.webm"
-                  if grep -q "git-lfs.github.com/spec/v1" "$FILE"; then
-                    echo "Error: $FILE is still a Git LFS pointer in CI checkout"
-                    exit 1
-                  fi
+                  for FILE in webview-ui/src/assets/cline_kanban_demo.mp4 webview-ui/src/assets/cline_kanban_demo.webm; do
+                    if grep -q "git-lfs.github.com/spec/v1" "$FILE"; then
+                      echo "Error: $FILE is still a Git LFS pointer in CI checkout"
+                      exit 1
+                    fi
+                  done
 
             - name: Package and Publish Extension
               env:

--- a/webview-ui/src/assets/cline_kanban_demo.mp4
+++ b/webview-ui/src/assets/cline_kanban_demo.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fa7c90bf657f317e63dee745e010898ca0cb13ee82e9dbe341ac16199170399a
+size 3738635

--- a/webview-ui/src/components/common/ClineKanbanLaunchModal.tsx
+++ b/webview-ui/src/components/common/ClineKanbanLaunchModal.tsx
@@ -1,16 +1,17 @@
 import { StringRequest } from "@shared/proto/cline/common"
 import { VSCodeButton, VSCodeCheckbox } from "@vscode/webview-ui-toolkit/react"
 import React, { useEffect, useMemo, useState } from "react"
-import kanbanDemoVideo from "@/assets/cline_kanban_demo.webm"
+import kanbanDemoVideoMp4 from "@/assets/cline_kanban_demo.mp4"
+import kanbanDemoVideoWebm from "@/assets/cline_kanban_demo.webm"
 import { Dialog, DialogContent } from "@/components/ui/dialog"
 import { PLATFORM_CONFIG, PlatformType } from "@/config/platform.config"
 import { FileServiceClient, StateServiceClient } from "@/services/grpc-client"
 
 const INSTALL_COMMAND = "npm install -g cline"
 const COPIED_TIMEOUT = 1500
-const kanbanDemoVideoSrc = kanbanDemoVideo.startsWith("/src/")
-	? new URL(kanbanDemoVideo, import.meta.url).toString()
-	: kanbanDemoVideo
+const resolveAssetSrc = (src: string) => (src.startsWith("/src/") ? new URL(src, import.meta.url).toString() : src)
+const kanbanDemoMp4Src = resolveAssetSrc(kanbanDemoVideoMp4)
+const kanbanDemoWebmSrc = resolveAssetSrc(kanbanDemoVideoWebm)
 
 export const CLINE_KANBAN_MODAL_DISMISS_ID = "cline-kanban-launch-modal-v1"
 
@@ -76,9 +77,10 @@ export const ClineKanbanLaunchModal: React.FC<ClineKanbanLaunchModalProps> = ({ 
 						className="w-full rounded-md border border-[var(--vscode-editorGroup-border)]"
 						loop
 						muted
-						playsInline
-						src={kanbanDemoVideoSrc}
-					/>
+						playsInline>
+						<source src={kanbanDemoMp4Src} type="video/mp4" />
+						<source src={kanbanDemoWebmSrc} type="video/webm" />
+					</video>
 
 					<p className="text-sm" style={{ color: "var(--vscode-descriptionForeground)" }}>
 						A replacement for your IDE better suited for running many agents in parallel and reviewing diffs. Enable


### PR DESCRIPTION
#9997 fixed the Kanban sizzle reel for JetBrains, but broke it in VSCode. This adds the H.264 MP4 back and lets the browser decide which one it wants.

### Related Issue

**Issue:** #9997

### Test Procedure

Manual test:

1. Run vscode (from VSCode, "Run Extension (production)" launch config)
2. In the JetBrains plugin, pull in this change and run `./gradlew :runIde`
3. In both IDEs, check that the video displays properly

### Type of Change

-   [X] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [X] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [X] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [X] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

VSCode:

<img width="562" height="542" alt="Screenshot 2026-03-27 at 17 44 59" src="https://github.com/user-attachments/assets/909a6fc8-7a11-46a8-b0ad-091613447f67" />

JetBrains:

<img width="452" height="730" alt="Screenshot 2026-03-27 at 17 40 17" src="https://github.com/user-attachments/assets/8131d77b-a301-46a6-a457-37089f2852bc" />

