### PR TITLE
fix: use per-server timeout for MCP tool/resource/prompt requests

### DIFF
--- a/src/services/mcp/McpHub.ts
+++ b/src/services/mcp/McpHub.ts
@@ -43,7 +43,6 @@ import { Logger } from "@/shared/services/Logger"
 import { expandEnvironmentVariables } from "@/utils/envExpansion"
 import { getServerAuthHash } from "@/utils/mcpAuth"
 import { TelemetryService } from "../telemetry/TelemetryService"
-import { DEFAULT_REQUEST_TIMEOUT_MS } from "./constants"
 import { McpOAuthManager } from "./McpOAuthManager"
 import { StreamableHttpReconnectHandler } from "./StreamableHttpReconnectHandler"
 import { BaseConfigSchema, McpSettingsSchema, ServerConfigSchema } from "./schemas"
@@ -674,6 +673,18 @@ export class McpHub {
 		connection.server.error = newError //.slice(0, 800)
 	}
 
+	private getServerTimeoutMs(connection: McpConnection): number {
+		let timeout = secondsToMs(DEFAULT_MCP_TIMEOUT_SECONDS)
+		try {
+			const config = JSON.parse(connection.server.config)
+			const parsedConfig = ServerConfigSchema.parse(config)
+			timeout = secondsToMs(parsedConfig.timeout)
+		} catch (error) {
+			Logger.error(`Failed to parse timeout configuration for server ${connection.server.name}: ${error}`)
+		}
+		return timeout
+	}
+
 	private async fetchToolsList(serverName: string): Promise<McpTool[]> {
 		try {
 			const connection = this.connections.find((conn) => conn.server.name === serverName)
@@ -688,7 +699,7 @@ export class McpHub {
 			}
 
 			const response = await connection.client.request({ method: "tools/list" }, ListToolsResultSchema, {
-				timeout: DEFAULT_REQUEST_TIMEOUT_MS,
+				timeout: this.getServerTimeoutMs(connection),
 			})
 
 			// Get autoApprove settings
@@ -720,7 +731,7 @@ export class McpHub {
 			}
 
 			const response = await connection.client.request({ method: "resources/list" }, ListResourcesResultSchema, {
-				timeout: DEFAULT_REQUEST_TIMEOUT_MS,
+				timeout: this.getServerTimeoutMs(connection),
 			})
 			return response?.resources || []
 		} catch (_error) {
@@ -742,7 +753,7 @@ export class McpHub {
 				{ method: "resources/templates/list" },
 				ListResourceTemplatesResultSchema,
 				{
-					timeout: DEFAULT_REQUEST_TIMEOUT_MS,
+					timeout: this.getServerTimeoutMs(connection),
 				},
 			)
 
@@ -763,7 +774,7 @@ export class McpHub {
 			}
 
 			const response = await connection.client.request({ method: "prompts/list" }, ListPromptsResultSchema, {
-				timeout: DEFAULT_REQUEST_TIMEOUT_MS,
+				timeout: this.getServerTimeoutMs(connection),
 			})
 
 			return (response?.prompts || []).map((prompt) => ({
@@ -1188,6 +1199,9 @@ export class McpHub {
 				},
 			},
 			ReadResourceResultSchema,
+			{
+				timeout: this.getServerTimeoutMs(connection),
+			},
 		)
 	}
 
@@ -1217,7 +1231,7 @@ export class McpHub {
 			},
 			GetPromptResultSchema,
 			{
-				timeout: DEFAULT_REQUEST_TIMEOUT_MS,
+				timeout: this.getServerTimeoutMs(connection),
 			},
 		)
 
@@ -1247,15 +1261,7 @@ export class McpHub {
 			throw new Error(`Server "${serverName}" is disabled and cannot be used`)
 		}
 
-		let timeout = secondsToMs(DEFAULT_MCP_TIMEOUT_SECONDS) // sdk expects ms
-
-		try {
-			const config = JSON.parse(connection.server.config)
-			const parsedConfig = ServerConfigSchema.parse(config)
-			timeout = secondsToMs(parsedConfig.timeout)
-		} catch (error) {
-			Logger.error(`Failed to parse timeout configuration for server ${serverName}: ${error}`)
-		}
+		const timeout = this.getServerTimeoutMs(connection)
 
 		this.telemetryService.captureMcpToolCall(
 			ulid,


### PR DESCRIPTION
## Problem

MCP request methods (`fetchToolsList`, `fetchResourcesList`, `fetchResourceTemplatesList`, `fetchPromptsList`, `getPrompt`, `readResource`) use a hardcoded 5-second timeout (`DEFAULT_REQUEST_TIMEOUT_MS = 5000`) instead of the user-configured per-server `timeout` setting (default 60s).

This causes tools/resources/prompts listing to time out prematurely on slow MCP servers, while `callTool()` correctly honors the per-server timeout.

## Solution

Extract the timeout-parsing pattern from `callTool` into a shared `getServerTimeoutMs(connection)` helper and apply it consistently across all 7 affected methods:

- **`fetchToolsList`** — was 5s, now uses per-server timeout
- **`fetchResourcesList`** — was 5s, now uses per-server timeout
- **`fetchResourceTemplatesList`** — was 5s, now uses per-server timeout
- **`fetchPromptsList`** — was 5s, now uses per-server timeout
- **`getPrompt`** — was 5s, now uses per-server timeout
- **`readResource`** — had **no timeout at all**, now uses per-server timeout
- **`callTool`** — refactored to use the shared helper (no behavior change)

## Changes

| File | Change |
|------|--------|
| `src/services/mcp/McpHub.ts` | Add `getServerTimeoutMs()` helper, update 7 methods, remove unused import |

**1 file changed, +21/-15 lines**

## Testing

- TypeScript: 0 new errors (verified against main baseline)
- Biome lint: pass
- Biome format: pass
- lint-staged: pass (ran on commit)

Fixes #7635