### PR TITLE
feat: include active rules in task metadata

### DIFF
--- a/src/core/context/context-tracking/ContextTrackerTypes.ts
+++ b/src/core/context/context-tracking/ContextTrackerTypes.ts
@@ -29,6 +29,9 @@ export interface ActiveRulesMetadataEntry {
 	ts: number
 	global: string[]
 	local: string[]
+	cursor: string[]
+	windsurf: string[]
+	agents: string[]
 	activated_conditional_rules: Array<{
 		name: string
 		matched_conditions: Record<string, string[]>

--- a/src/core/context/context-tracking/ContextTrackerTypes.ts
+++ b/src/core/context/context-tracking/ContextTrackerTypes.ts
@@ -25,8 +25,19 @@ export interface EnvironmentMetadataEntry {
 	cline_version: string
 }
 
+export interface ActiveRulesMetadataEntry {
+	ts: number
+	global: string[]
+	local: string[]
+	activated_conditional_rules: Array<{
+		name: string
+		matched_conditions: Record<string, string[]>
+	}>
+}
+
 export interface TaskMetadata {
 	files_in_context: FileMetadataEntry[]
 	model_usage: ModelMetadataEntry[]
 	environment_history: EnvironmentMetadataEntry[]
+	active_rules?: ActiveRulesMetadataEntry
 }

--- a/src/core/context/context-tracking/__tests__/ActiveRulesMetadata.test.ts
+++ b/src/core/context/context-tracking/__tests__/ActiveRulesMetadata.test.ts
@@ -1,0 +1,191 @@
+import * as diskModule from "@core/storage/disk"
+import { expect } from "chai"
+import { afterEach, beforeEach, describe, it } from "mocha"
+import * as sinon from "sinon"
+import type { ActiveRulesMetadataEntry, TaskMetadata } from "../ContextTrackerTypes"
+
+describe("ActiveRulesMetadata", () => {
+	const taskId = "test-task-id"
+	let sandbox: sinon.SinonSandbox
+	let mockTaskMetadata: TaskMetadata
+	let getTaskMetadataStub: sinon.SinonStub
+	let saveTaskMetadataStub: sinon.SinonStub
+
+	beforeEach(() => {
+		sandbox = sinon.createSandbox()
+
+		mockTaskMetadata = { files_in_context: [], model_usage: [], environment_history: [] }
+		getTaskMetadataStub = sandbox.stub(diskModule, "getTaskMetadata").resolves(mockTaskMetadata)
+		saveTaskMetadataStub = sandbox.stub(diskModule, "saveTaskMetadata").resolves()
+	})
+
+	afterEach(() => {
+		sandbox.restore()
+	})
+
+	it("should save active rules snapshot to task metadata", async () => {
+		const fakeNow = 1717293940000
+		const clock = sandbox.useFakeTimers(fakeNow)
+
+		try {
+			// Simulate the toggle data available during system prompt building
+			const globalToggles: Record<string, boolean> = {
+				"/home/user/.cline/rules/style.md": true,
+				"/home/user/.cline/rules/testing.md": false,
+				"/home/user/.cline/rules/security.md": true,
+			}
+			const localToggles: Record<string, boolean> = {
+				".clinerules/db-rules.md": true,
+				".clinerules/disabled-rule.md": false,
+			}
+			const activatedConditionalRules = [
+				{
+					name: "workspace:.clinerules/db-rules.md",
+					matchedConditions: { paths: ["**/*.sql"] },
+				},
+			]
+
+			// Replicate the logic from index.ts
+			const metadata = await diskModule.getTaskMetadata(taskId)
+			metadata.active_rules = {
+				ts: Date.now(),
+				global: Object.entries(globalToggles)
+					.filter(([, enabled]) => enabled !== false)
+					.map(([filePath]) => filePath),
+				local: Object.entries(localToggles)
+					.filter(([, enabled]) => enabled !== false)
+					.map(([filePath]) => filePath),
+				activated_conditional_rules: activatedConditionalRules.map((rule) => ({
+					name: rule.name,
+					matched_conditions: rule.matchedConditions,
+				})),
+			}
+			await diskModule.saveTaskMetadata(taskId, metadata)
+
+			// Verify getTaskMetadata was called
+			expect(getTaskMetadataStub.calledOnce).to.be.true
+			expect(getTaskMetadataStub.firstCall.args[0]).to.equal(taskId)
+
+			// Verify saveTaskMetadata was called
+			expect(saveTaskMetadataStub.calledOnce).to.be.true
+			const savedMetadata: TaskMetadata = saveTaskMetadataStub.firstCall.args[1]
+
+			// Verify active_rules is present
+			expect(savedMetadata.active_rules).to.exist
+
+			const activeRules = savedMetadata.active_rules as ActiveRulesMetadataEntry
+			expect(activeRules.ts).to.equal(fakeNow)
+
+			// Only enabled rules should be included
+			expect(activeRules.global).to.deep.equal(["/home/user/.cline/rules/style.md", "/home/user/.cline/rules/security.md"])
+			expect(activeRules.local).to.deep.equal([".clinerules/db-rules.md"])
+
+			// Conditional rules should be mapped correctly
+			expect(activeRules.activated_conditional_rules).to.deep.equal([
+				{
+					name: "workspace:.clinerules/db-rules.md",
+					matched_conditions: { paths: ["**/*.sql"] },
+				},
+			])
+		} finally {
+			clock.restore()
+		}
+	})
+
+	it("should preserve existing metadata fields when saving active rules", async () => {
+		// Pre-populate existing metadata
+		mockTaskMetadata.model_usage = [
+			{ ts: 1617200000000, model_id: "claude-3-opus", model_provider_id: "anthropic", mode: "act" },
+		]
+		mockTaskMetadata.files_in_context = [
+			{
+				path: "src/index.ts",
+				record_state: "active",
+				record_source: "read_tool",
+				cline_read_date: 1617200000000,
+				cline_edit_date: null,
+			},
+		]
+
+		const globalToggles: Record<string, boolean> = { "rule1.md": true }
+		const localToggles: Record<string, boolean> = {}
+
+		const metadata = await diskModule.getTaskMetadata(taskId)
+		metadata.active_rules = {
+			ts: Date.now(),
+			global: Object.entries(globalToggles)
+				.filter(([, enabled]) => enabled !== false)
+				.map(([filePath]) => filePath),
+			local: Object.entries(localToggles)
+				.filter(([, enabled]) => enabled !== false)
+				.map(([filePath]) => filePath),
+			activated_conditional_rules: [],
+		}
+		await diskModule.saveTaskMetadata(taskId, metadata)
+
+		const savedMetadata: TaskMetadata = saveTaskMetadataStub.firstCall.args[1]
+
+		// Existing fields should be preserved
+		expect(savedMetadata.model_usage).to.have.length(1)
+		expect(savedMetadata.model_usage[0].model_id).to.equal("claude-3-opus")
+		expect(savedMetadata.files_in_context).to.have.length(1)
+		expect(savedMetadata.files_in_context[0].path).to.equal("src/index.ts")
+
+		// active_rules should also be present
+		expect(savedMetadata.active_rules).to.exist
+		expect(savedMetadata.active_rules!.global).to.deep.equal(["rule1.md"])
+	})
+
+	it("should handle empty toggles gracefully", async () => {
+		const globalToggles: Record<string, boolean> = {}
+		const localToggles: Record<string, boolean> = {}
+
+		const metadata = await diskModule.getTaskMetadata(taskId)
+		metadata.active_rules = {
+			ts: Date.now(),
+			global: Object.entries(globalToggles)
+				.filter(([, enabled]) => enabled !== false)
+				.map(([filePath]) => filePath),
+			local: Object.entries(localToggles)
+				.filter(([, enabled]) => enabled !== false)
+				.map(([filePath]) => filePath),
+			activated_conditional_rules: [],
+		}
+		await diskModule.saveTaskMetadata(taskId, metadata)
+
+		const savedMetadata: TaskMetadata = saveTaskMetadataStub.firstCall.args[1]
+		expect(savedMetadata.active_rules!.global).to.deep.equal([])
+		expect(savedMetadata.active_rules!.local).to.deep.equal([])
+		expect(savedMetadata.active_rules!.activated_conditional_rules).to.deep.equal([])
+	})
+
+	it("should filter out disabled rules (value === false)", async () => {
+		const globalToggles: Record<string, boolean> = {
+			"enabled.md": true,
+			"disabled.md": false,
+			"also-enabled.md": true,
+			"also-disabled.md": false,
+		}
+		const localToggles: Record<string, boolean> = {
+			"local-on.md": true,
+			"local-off.md": false,
+		}
+
+		const metadata = await diskModule.getTaskMetadata(taskId)
+		metadata.active_rules = {
+			ts: Date.now(),
+			global: Object.entries(globalToggles)
+				.filter(([, enabled]) => enabled !== false)
+				.map(([filePath]) => filePath),
+			local: Object.entries(localToggles)
+				.filter(([, enabled]) => enabled !== false)
+				.map(([filePath]) => filePath),
+			activated_conditional_rules: [],
+		}
+		await diskModule.saveTaskMetadata(taskId, metadata)
+
+		const savedMetadata: TaskMetadata = saveTaskMetadataStub.firstCall.args[1]
+		expect(savedMetadata.active_rules!.global).to.deep.equal(["enabled.md", "also-enabled.md"])
+		expect(savedMetadata.active_rules!.local).to.deep.equal(["local-on.md"])
+	})
+})

--- a/src/core/context/context-tracking/__tests__/ActiveRulesMetadata.test.ts
+++ b/src/core/context/context-tracking/__tests__/ActiveRulesMetadata.test.ts
@@ -2,86 +2,53 @@ import * as diskModule from "@core/storage/disk"
 import { expect } from "chai"
 import { afterEach, beforeEach, describe, it } from "mocha"
 import * as sinon from "sinon"
-import type { ActiveRulesMetadataEntry, TaskMetadata } from "../ContextTrackerTypes"
+import { buildActiveRulesMetadata } from "../buildActiveRulesMetadata"
+import type { TaskMetadata } from "../ContextTrackerTypes"
 
-describe("ActiveRulesMetadata", () => {
-	const taskId = "test-task-id"
+describe("buildActiveRulesMetadata", () => {
 	let sandbox: sinon.SinonSandbox
-	let mockTaskMetadata: TaskMetadata
-	let getTaskMetadataStub: sinon.SinonStub
-	let saveTaskMetadataStub: sinon.SinonStub
 
 	beforeEach(() => {
 		sandbox = sinon.createSandbox()
-
-		mockTaskMetadata = { files_in_context: [], model_usage: [], environment_history: [] }
-		getTaskMetadataStub = sandbox.stub(diskModule, "getTaskMetadata").resolves(mockTaskMetadata)
-		saveTaskMetadataStub = sandbox.stub(diskModule, "saveTaskMetadata").resolves()
 	})
 
 	afterEach(() => {
 		sandbox.restore()
 	})
 
-	it("should save active rules snapshot to task metadata", async () => {
+	it("should include only enabled rules and map conditional rules correctly", () => {
 		const fakeNow = 1717293940000
 		const clock = sandbox.useFakeTimers(fakeNow)
 
 		try {
-			// Simulate the toggle data available during system prompt building
-			const globalToggles: Record<string, boolean> = {
-				"/home/user/.cline/rules/style.md": true,
-				"/home/user/.cline/rules/testing.md": false,
-				"/home/user/.cline/rules/security.md": true,
-			}
-			const localToggles: Record<string, boolean> = {
-				".clinerules/db-rules.md": true,
-				".clinerules/disabled-rule.md": false,
-			}
-			const activatedConditionalRules = [
-				{
-					name: "workspace:.clinerules/db-rules.md",
-					matchedConditions: { paths: ["**/*.sql"] },
+			const result = buildActiveRulesMetadata({
+				globalToggles: {
+					"/home/user/.cline/rules/style.md": true,
+					"/home/user/.cline/rules/testing.md": false,
+					"/home/user/.cline/rules/security.md": true,
 				},
-			]
+				localToggles: {
+					".clinerules/db-rules.md": true,
+					".clinerules/disabled-rule.md": false,
+				},
+				cursorLocalToggles: { ".cursorrules": true },
+				windsurfLocalToggles: { ".windsurfrules": false },
+				agentsLocalToggles: { "AGENTS.md": true },
+				activatedConditionalRules: [
+					{
+						name: "workspace:.clinerules/db-rules.md",
+						matchedConditions: { paths: ["**/*.sql"] },
+					},
+				],
+			})
 
-			// Replicate the logic from index.ts
-			const metadata = await diskModule.getTaskMetadata(taskId)
-			metadata.active_rules = {
-				ts: Date.now(),
-				global: Object.entries(globalToggles)
-					.filter(([, enabled]) => enabled !== false)
-					.map(([filePath]) => filePath),
-				local: Object.entries(localToggles)
-					.filter(([, enabled]) => enabled !== false)
-					.map(([filePath]) => filePath),
-				activated_conditional_rules: activatedConditionalRules.map((rule) => ({
-					name: rule.name,
-					matched_conditions: rule.matchedConditions,
-				})),
-			}
-			await diskModule.saveTaskMetadata(taskId, metadata)
-
-			// Verify getTaskMetadata was called
-			expect(getTaskMetadataStub.calledOnce).to.be.true
-			expect(getTaskMetadataStub.firstCall.args[0]).to.equal(taskId)
-
-			// Verify saveTaskMetadata was called
-			expect(saveTaskMetadataStub.calledOnce).to.be.true
-			const savedMetadata: TaskMetadata = saveTaskMetadataStub.firstCall.args[1]
-
-			// Verify active_rules is present
-			expect(savedMetadata.active_rules).to.exist
-
-			const activeRules = savedMetadata.active_rules as ActiveRulesMetadataEntry
-			expect(activeRules.ts).to.equal(fakeNow)
-
-			// Only enabled rules should be included
-			expect(activeRules.global).to.deep.equal(["/home/user/.cline/rules/style.md", "/home/user/.cline/rules/security.md"])
-			expect(activeRules.local).to.deep.equal([".clinerules/db-rules.md"])
-
-			// Conditional rules should be mapped correctly
-			expect(activeRules.activated_conditional_rules).to.deep.equal([
+			expect(result.ts).to.equal(fakeNow)
+			expect(result.global).to.deep.equal(["/home/user/.cline/rules/style.md", "/home/user/.cline/rules/security.md"])
+			expect(result.local).to.deep.equal([".clinerules/db-rules.md"])
+			expect(result.cursor).to.deep.equal([".cursorrules"])
+			expect(result.windsurf).to.deep.equal([])
+			expect(result.agents).to.deep.equal(["AGENTS.md"])
+			expect(result.activated_conditional_rules).to.deep.equal([
 				{
 					name: "workspace:.clinerules/db-rules.md",
 					matched_conditions: { paths: ["**/*.sql"] },
@@ -92,100 +59,117 @@ describe("ActiveRulesMetadata", () => {
 		}
 	})
 
-	it("should preserve existing metadata fields when saving active rules", async () => {
-		// Pre-populate existing metadata
+	it("should handle empty toggles gracefully", () => {
+		const result = buildActiveRulesMetadata({
+			globalToggles: {},
+			localToggles: {},
+			cursorLocalToggles: {},
+			windsurfLocalToggles: {},
+			agentsLocalToggles: {},
+			activatedConditionalRules: [],
+		})
+
+		expect(result.global).to.deep.equal([])
+		expect(result.local).to.deep.equal([])
+		expect(result.cursor).to.deep.equal([])
+		expect(result.windsurf).to.deep.equal([])
+		expect(result.agents).to.deep.equal([])
+		expect(result.activated_conditional_rules).to.deep.equal([])
+	})
+
+	it("should filter out all disabled rules", () => {
+		const result = buildActiveRulesMetadata({
+			globalToggles: {
+				"enabled.md": true,
+				"disabled.md": false,
+				"also-enabled.md": true,
+				"also-disabled.md": false,
+			},
+			localToggles: {
+				"local-on.md": true,
+				"local-off.md": false,
+			},
+			cursorLocalToggles: {},
+			windsurfLocalToggles: {},
+			agentsLocalToggles: {},
+			activatedConditionalRules: [],
+		})
+
+		expect(result.global).to.deep.equal(["enabled.md", "also-enabled.md"])
+		expect(result.local).to.deep.equal(["local-on.md"])
+	})
+})
+
+describe("ActiveRulesMetadata integration", () => {
+	const taskId = "test-task-id"
+	let sandbox: sinon.SinonSandbox
+	let mockTaskMetadata: TaskMetadata
+	let getTaskMetadataStub: sinon.SinonStub
+	let saveTaskMetadataStub: sinon.SinonStub
+
+	beforeEach(() => {
+		sandbox = sinon.createSandbox()
+		mockTaskMetadata = { files_in_context: [], model_usage: [], environment_history: [] }
+		getTaskMetadataStub = sandbox.stub(diskModule, "getTaskMetadata").resolves(mockTaskMetadata)
+		saveTaskMetadataStub = sandbox.stub(diskModule, "saveTaskMetadata").resolves()
+	})
+
+	afterEach(() => {
+		sandbox.restore()
+	})
+
+	it("should save active rules and preserve existing metadata fields", async () => {
 		mockTaskMetadata.model_usage = [
 			{ ts: 1617200000000, model_id: "claude-3-opus", model_provider_id: "anthropic", mode: "act" },
 		]
-		mockTaskMetadata.files_in_context = [
-			{
-				path: "src/index.ts",
-				record_state: "active",
-				record_source: "read_tool",
-				cline_read_date: 1617200000000,
-				cline_edit_date: null,
-			},
-		]
-
-		const globalToggles: Record<string, boolean> = { "rule1.md": true }
-		const localToggles: Record<string, boolean> = {}
 
 		const metadata = await diskModule.getTaskMetadata(taskId)
-		metadata.active_rules = {
-			ts: Date.now(),
-			global: Object.entries(globalToggles)
-				.filter(([, enabled]) => enabled !== false)
-				.map(([filePath]) => filePath),
-			local: Object.entries(localToggles)
-				.filter(([, enabled]) => enabled !== false)
-				.map(([filePath]) => filePath),
-			activated_conditional_rules: [],
-		}
+		metadata.active_rules = buildActiveRulesMetadata({
+			globalToggles: { "rule1.md": true },
+			localToggles: {},
+			cursorLocalToggles: {},
+			windsurfLocalToggles: {},
+			agentsLocalToggles: {},
+			activatedConditionalRules: [],
+		})
 		await diskModule.saveTaskMetadata(taskId, metadata)
 
 		const savedMetadata: TaskMetadata = saveTaskMetadataStub.firstCall.args[1]
-
-		// Existing fields should be preserved
 		expect(savedMetadata.model_usage).to.have.length(1)
-		expect(savedMetadata.model_usage[0].model_id).to.equal("claude-3-opus")
-		expect(savedMetadata.files_in_context).to.have.length(1)
-		expect(savedMetadata.files_in_context[0].path).to.equal("src/index.ts")
-
-		// active_rules should also be present
 		expect(savedMetadata.active_rules).to.exist
 		expect(savedMetadata.active_rules!.global).to.deep.equal(["rule1.md"])
 	})
 
-	it("should handle empty toggles gracefully", async () => {
-		const globalToggles: Record<string, boolean> = {}
-		const localToggles: Record<string, boolean> = {}
-
-		const metadata = await diskModule.getTaskMetadata(taskId)
-		metadata.active_rules = {
-			ts: Date.now(),
-			global: Object.entries(globalToggles)
-				.filter(([, enabled]) => enabled !== false)
-				.map(([filePath]) => filePath),
-			local: Object.entries(localToggles)
-				.filter(([, enabled]) => enabled !== false)
-				.map(([filePath]) => filePath),
+	it("should not overwrite active_rules if already present (first-turn guard)", async () => {
+		// Simulate metadata already having active_rules from first turn
+		mockTaskMetadata.active_rules = {
+			ts: 1617200000000,
+			global: ["original-rule.md"],
+			local: [],
+			cursor: [],
+			windsurf: [],
+			agents: [],
 			activated_conditional_rules: [],
-		}
-		await diskModule.saveTaskMetadata(taskId, metadata)
-
-		const savedMetadata: TaskMetadata = saveTaskMetadataStub.firstCall.args[1]
-		expect(savedMetadata.active_rules!.global).to.deep.equal([])
-		expect(savedMetadata.active_rules!.local).to.deep.equal([])
-		expect(savedMetadata.active_rules!.activated_conditional_rules).to.deep.equal([])
-	})
-
-	it("should filter out disabled rules (value === false)", async () => {
-		const globalToggles: Record<string, boolean> = {
-			"enabled.md": true,
-			"disabled.md": false,
-			"also-enabled.md": true,
-			"also-disabled.md": false,
-		}
-		const localToggles: Record<string, boolean> = {
-			"local-on.md": true,
-			"local-off.md": false,
 		}
 
 		const metadata = await diskModule.getTaskMetadata(taskId)
-		metadata.active_rules = {
-			ts: Date.now(),
-			global: Object.entries(globalToggles)
-				.filter(([, enabled]) => enabled !== false)
-				.map(([filePath]) => filePath),
-			local: Object.entries(localToggles)
-				.filter(([, enabled]) => enabled !== false)
-				.map(([filePath]) => filePath),
-			activated_conditional_rules: [],
-		}
-		await diskModule.saveTaskMetadata(taskId, metadata)
 
-		const savedMetadata: TaskMetadata = saveTaskMetadataStub.firstCall.args[1]
-		expect(savedMetadata.active_rules!.global).to.deep.equal(["enabled.md", "also-enabled.md"])
-		expect(savedMetadata.active_rules!.local).to.deep.equal(["local-on.md"])
+		// Replicate the guard from index.ts
+		if (!metadata.active_rules) {
+			metadata.active_rules = buildActiveRulesMetadata({
+				globalToggles: { "new-rule.md": true },
+				localToggles: {},
+				cursorLocalToggles: {},
+				windsurfLocalToggles: {},
+				agentsLocalToggles: {},
+				activatedConditionalRules: [],
+			})
+			await diskModule.saveTaskMetadata(taskId, metadata)
+		}
+
+		// saveTaskMetadata should NOT have been called
+		expect(saveTaskMetadataStub.called).to.be.false
+		// Original active_rules should be preserved
+		expect(metadata.active_rules.global).to.deep.equal(["original-rule.md"])
 	})
 })

--- a/src/core/context/context-tracking/buildActiveRulesMetadata.ts
+++ b/src/core/context/context-tracking/buildActiveRulesMetadata.ts
@@ -1,0 +1,41 @@
+import type { ActiveRulesMetadataEntry } from "./ContextTrackerTypes"
+
+interface ActivatedConditionalRule {
+	name: string
+	matchedConditions: Record<string, string[]>
+}
+
+/**
+ * Filter enabled rule paths from a toggles map.
+ * Rules default to enabled — only entries explicitly set to false are excluded.
+ */
+function getEnabledRulePaths(toggles: Record<string, boolean>): string[] {
+	return Object.entries(toggles)
+		.filter(([, enabled]) => enabled !== false)
+		.map(([filePath]) => filePath)
+}
+
+/**
+ * Build an ActiveRulesMetadataEntry from the current rule toggles and activated conditional rules.
+ */
+export function buildActiveRulesMetadata(params: {
+	globalToggles: Record<string, boolean>
+	localToggles: Record<string, boolean>
+	cursorLocalToggles: Record<string, boolean>
+	windsurfLocalToggles: Record<string, boolean>
+	agentsLocalToggles: Record<string, boolean>
+	activatedConditionalRules: ActivatedConditionalRule[]
+}): ActiveRulesMetadataEntry {
+	return {
+		ts: Date.now(),
+		global: getEnabledRulePaths(params.globalToggles),
+		local: getEnabledRulePaths(params.localToggles),
+		cursor: getEnabledRulePaths(params.cursorLocalToggles),
+		windsurf: getEnabledRulePaths(params.windsurfLocalToggles),
+		agents: getEnabledRulePaths(params.agentsLocalToggles),
+		activated_conditional_rules: params.activatedConditionalRules.map((rule) => ({
+			name: rule.name,
+			matched_conditions: rule.matchedConditions,
+		})),
+	}
+}

--- a/src/core/task/index.ts
+++ b/src/core/task/index.ts
@@ -5,6 +5,7 @@ import { AssistantMessageContent, parseAssistantMessageV2, ToolUse } from "@core
 import { ContextManager } from "@core/context/context-management/ContextManager"
 import { checkContextWindowExceededError } from "@core/context/context-management/context-error-handling"
 import { getContextWindowInfo } from "@core/context/context-management/context-window-utils"
+import { buildActiveRulesMetadata } from "@core/context/context-tracking/buildActiveRulesMetadata"
 import { EnvironmentContextTracker } from "@core/context/context-tracking/EnvironmentContextTracker"
 import { FileContextTracker } from "@core/context/context-tracking/FileContextTracker"
 import { ModelContextTracker } from "@core/context/context-tracking/ModelContextTracker"
@@ -1991,22 +1992,19 @@ export class Task {
 			await this.say("conditional_rules_applied", JSON.stringify({ rules: activatedConditionalRules }))
 		}
 
-		// Save active rules snapshot to task metadata (see #5710)
+		// Save active rules snapshot on first turn only (see #5710)
 		const metadata = await getTaskMetadata(this.taskId)
-		metadata.active_rules = {
-			ts: Date.now(),
-			global: Object.entries(globalToggles)
-				.filter(([, enabled]) => enabled !== false)
-				.map(([filePath]) => filePath),
-			local: Object.entries(localToggles)
-				.filter(([, enabled]) => enabled !== false)
-				.map(([filePath]) => filePath),
-			activated_conditional_rules: activatedConditionalRules.map((rule) => ({
-				name: rule.name,
-				matched_conditions: rule.matchedConditions,
-			})),
+		if (!metadata.active_rules) {
+			metadata.active_rules = buildActiveRulesMetadata({
+				globalToggles,
+				localToggles,
+				cursorLocalToggles,
+				windsurfLocalToggles,
+				agentsLocalToggles,
+				activatedConditionalRules,
+			})
+			await saveTaskMetadata(this.taskId, metadata)
 		}
-		await saveTaskMetadata(this.taskId, metadata)
 
 		const { systemPrompt, tools } = await getSystemPrompt(promptContext)
 		this.useNativeToolCalls = !!tools?.length

--- a/src/core/task/index.ts
+++ b/src/core/task/index.ts
@@ -36,6 +36,8 @@ import {
 	GlobalFileNames,
 	getSavedApiConversationHistory,
 	getSavedClineMessages,
+	getTaskMetadata,
+	saveTaskMetadata,
 } from "@core/storage/disk"
 import { releaseTaskLock } from "@core/task/TaskLockUtils"
 import { isMultiRootEnabled } from "@core/workspace/multi-root-utils"
@@ -1988,6 +1990,23 @@ export class Task {
 		if (activatedConditionalRules.length > 0) {
 			await this.say("conditional_rules_applied", JSON.stringify({ rules: activatedConditionalRules }))
 		}
+
+		// Save active rules snapshot to task metadata (see #5710)
+		const metadata = await getTaskMetadata(this.taskId)
+		metadata.active_rules = {
+			ts: Date.now(),
+			global: Object.entries(globalToggles)
+				.filter(([, enabled]) => enabled !== false)
+				.map(([filePath]) => filePath),
+			local: Object.entries(localToggles)
+				.filter(([, enabled]) => enabled !== false)
+				.map(([filePath]) => filePath),
+			activated_conditional_rules: activatedConditionalRules.map((rule) => ({
+				name: rule.name,
+				matched_conditions: rule.matchedConditions,
+			})),
+		}
+		await saveTaskMetadata(this.taskId, metadata)
 
 		const { systemPrompt, tools } = await getSystemPrompt(promptContext)
 		this.useNativeToolCalls = !!tools?.length


### PR DESCRIPTION
### Related Issue

  **Issue:** #5710

  ### Description

  When exporting a task, `task_metadata.json` includes `files_in_context`,
  `model_usage`, and `environment_history`, but no information about which rules were
  active. Since rules can be toggled on/off, knowing which rules were active during a
  task is valuable for reviewing and debugging.

  This PR saves an `active_rules` snapshot to `task_metadata.json` when building the
  system prompt, including enabled global/local rule paths and activated conditional
  rules.

  ### Test Procedure

  - Added 4 unit tests covering: normal save, field preservation, empty toggles,
  disabled rule filtering
  - All 1342 existing unit tests pass
  - Manually tested in Extension Development Host:
    - **main branch**: `task_metadata.json` has no `active_rules` field
    - **fix branch**: `active_rules` appears with correct data after starting a new
  task

  ### Type of Change

  -   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
  -   [x] ✨ New feature (non-breaking change which adds functionality)
  -   [ ] 💥 Breaking change (fix or feature that would cause existing functionality
  to not work as expected)
  -   [ ] ♻️ Refactor Changes
  -   [ ] 💅 Cosmetic Changes
  -   [ ] 📚 Documentation update
  -   [ ] 🏃 Workflow Changes

  ### Pre-flight Checklist

  -   [x] Changes are limited to a single feature, bugfix or chore (split larger
  changes into separate PRs)
  -   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run
  format && npm run lint`)
  -   [x] I have reviewed [contributor
  guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

  ### Screenshots

  N/A - no UI changes. Example `task_metadata.json` output after fix:

  ```json
  {
    "active_rules": {
      "ts": 1774834903165,
      "global": ["/Users/user/.cline/rules/style.md"],
      "local": [".clinerules/general.md"],
      "activated_conditional_rules": []
    }
  }

  Additional Notes

  The active_rules field is optional to maintain backward compatibility with existing
  task metadata files.