### PR TITLE
feat: user-level remote-config discovery with inline value reuse

### DIFF
--- a/src/core/storage/__tests__/fetchRemoteConfig.test.ts
+++ b/src/core/storage/__tests__/fetchRemoteConfig.test.ts
@@ -1,0 +1,317 @@
+import * as diskStorage from "@core/storage/disk"
+import * as remoteConfigFetch from "@core/storage/remote-config/fetch"
+import * as remoteConfigUtils from "@core/storage/remote-config/utils"
+import * as assert from "assert"
+import { afterEach, beforeEach, describe, it } from "mocha"
+import sinon from "sinon"
+import { ClineAccountService } from "@/services/account/ClineAccountService"
+import { AuthService } from "@/services/auth/AuthService"
+
+describe("fetchRemoteConfig", () => {
+	let sandbox: sinon.SinonSandbox
+	let accountService: ClineAccountService
+	let authServiceStub: Partial<AuthService>
+	let fetchUserRemoteConfigStub: sinon.SinonStub
+	let isRemoteConfigEnabledStub: sinon.SinonStub
+
+	beforeEach(() => {
+		sandbox = sinon.createSandbox()
+		authServiceStub = {}
+		sandbox.stub(AuthService, "getInstance").returns(authServiceStub as AuthService)
+		accountService = new ClineAccountService()
+		sandbox.stub(ClineAccountService, "getInstance").returns(accountService)
+		fetchUserRemoteConfigStub = sandbox.stub(accountService, "fetchUserRemoteConfig")
+		isRemoteConfigEnabledStub = sandbox.stub(remoteConfigUtils, "isRemoteConfigEnabled").returns(true)
+		sandbox.stub(remoteConfigUtils, "applyRemoteConfig").resolves()
+		sandbox.stub(remoteConfigUtils, "clearRemoteConfig")
+		sandbox.stub(diskStorage, "writeRemoteConfigToCache").resolves()
+		sandbox.stub(diskStorage, "readRemoteConfigFromCache").resolves({ version: "v1" })
+		sandbox.stub(diskStorage, "deleteRemoteConfigFromCache").resolves()
+	})
+
+	afterEach(() => {
+		sandbox.restore()
+	})
+
+	it("switches org when not in the chosen org", async () => {
+		Object.assign(authServiceStub, {
+			getActiveOrganizationId: () => "org-current",
+		})
+
+		fetchUserRemoteConfigStub.resolves({
+			organizationId: "org-target",
+			value: '{"version":"v1"}',
+			organizations: [{ organizationId: "org-target", name: "Target Org" }],
+		})
+
+		const controller = {
+			accountService: { switchAccount: sandbox.stub().resolves() },
+			stateManager: { setSecret: sandbox.stub() },
+			mcpHub: {},
+			postStateToWebview: sandbox.stub(),
+		}
+
+		await remoteConfigFetch.fetchRemoteConfig(controller as any)
+
+		assert.strictEqual(controller.accountService.switchAccount.callCount, 1)
+		assert.strictEqual(controller.accountService.switchAccount.firstCall.args[0], "org-target")
+		assert.ok((remoteConfigUtils.applyRemoteConfig as sinon.SinonStub).calledOnce)
+	})
+
+	it("skips switchAccount when already in the chosen org", async () => {
+		Object.assign(authServiceStub, {
+			getActiveOrganizationId: () => "org-target",
+		})
+
+		fetchUserRemoteConfigStub.resolves({
+			organizationId: "org-target",
+			value: '{"version":"v1"}',
+			organizations: [{ organizationId: "org-target", name: "Target Org" }],
+		})
+
+		const controller = {
+			accountService: { switchAccount: sandbox.stub() },
+			stateManager: { setSecret: sandbox.stub() },
+			mcpHub: {},
+			postStateToWebview: sandbox.stub(),
+		}
+
+		await remoteConfigFetch.fetchRemoteConfig(controller as any)
+
+		assert.strictEqual(controller.accountService.switchAccount.callCount, 0)
+		assert.ok((remoteConfigUtils.applyRemoteConfig as sinon.SinonStub).calledOnce)
+	})
+
+	it("uses discoveredValue inline and skips org-level config fetch", async () => {
+		Object.assign(authServiceStub, {
+			getActiveOrganizationId: () => "org-target",
+			getAuthToken: () => Promise.resolve("token"),
+		})
+
+		fetchUserRemoteConfigStub.resolves({
+			organizationId: "org-target",
+			value: '{"version":"v1"}',
+			organizations: [{ organizationId: "org-target", name: "Target Org" }],
+		})
+
+		const controller = {
+			accountService: { switchAccount: sandbox.stub() },
+			stateManager: { setSecret: sandbox.stub() },
+			mcpHub: {},
+			postStateToWebview: sandbox.stub(),
+		}
+
+		await remoteConfigFetch.fetchRemoteConfig(controller as any)
+
+		assert.ok((remoteConfigUtils.applyRemoteConfig as sinon.SinonStub).calledOnce)
+		// writeRemoteConfigToCache is called with the parsed config, proving inline parse succeeded.
+		// If it had fallen through to fetchRemoteConfigForOrganization, it would need getAuthToken
+		// and make an HTTP call — but no axios stub is set up, so the test would fail.
+		assert.ok((diskStorage.writeRemoteConfigToCache as sinon.SinonStub).calledOnce)
+	})
+
+	it("falls back to org-level fetch when discoveredValue fails to parse", async () => {
+		Object.assign(authServiceStub, {
+			getActiveOrganizationId: () => "org-target",
+			getAuthToken: () => Promise.resolve(null),
+		})
+
+		fetchUserRemoteConfigStub.resolves({
+			organizationId: "org-target",
+			value: "not valid json{{{",
+			organizations: [{ organizationId: "org-target", name: "Target Org" }],
+		})
+
+		const controller = {
+			accountService: { switchAccount: sandbox.stub() },
+			stateManager: { setSecret: sandbox.stub() },
+			mcpHub: {},
+			postStateToWebview: sandbox.stub(),
+		}
+
+		await remoteConfigFetch.fetchRemoteConfig(controller as any)
+
+		// Parse failed → fetchRemoteConfigForOrganization → no auth → cache fallback
+		assert.ok((diskStorage.readRemoteConfigFromCache as sinon.SinonStub).called)
+		assert.ok((remoteConfigUtils.applyRemoteConfig as sinon.SinonStub).calledOnce)
+	})
+
+	it("does not switch org when resolve fails", async () => {
+		Object.assign(authServiceStub, {
+			getActiveOrganizationId: () => "org-current",
+			getAuthToken: () => Promise.resolve(null),
+		})
+
+		fetchUserRemoteConfigStub.resolves({
+			organizationId: "org-target",
+			value: "not valid json{{{",
+			organizations: [{ organizationId: "org-target", name: "Target Org" }],
+		})
+
+		// Both inline parse and org-level fetch fail (no auth → no fetch), cache is empty
+		;(diskStorage.readRemoteConfigFromCache as sinon.SinonStub).resolves(undefined)
+
+		const controller = {
+			accountService: { switchAccount: sandbox.stub() },
+			stateManager: { setSecret: sandbox.stub() },
+			mcpHub: {},
+			postStateToWebview: sandbox.stub(),
+		}
+
+		await remoteConfigFetch.fetchRemoteConfig(controller as any)
+
+		// Config resolution failed — user should stay in their current org
+		assert.strictEqual(controller.accountService.switchAccount.callCount, 0)
+		assert.ok((remoteConfigUtils.clearRemoteConfig as sinon.SinonStub).called)
+		assert.strictEqual((remoteConfigUtils.applyRemoteConfig as sinon.SinonStub).callCount, 0)
+	})
+
+	it("falls back to next locally-allowed org when backend org is opted-out", async () => {
+		Object.assign(authServiceStub, {
+			getActiveOrganizationId: () => "org-3",
+			getAuthToken: () => Promise.resolve("token"),
+		})
+
+		fetchUserRemoteConfigStub.resolves({
+			organizationId: "org-1",
+			value: '{"version":"v1"}',
+			organizations: [
+				{ organizationId: "org-1", name: "Org 1" },
+				{ organizationId: "org-2", name: "Org 2" },
+				{ organizationId: "org-3", name: "Org 3" },
+			],
+		})
+		isRemoteConfigEnabledStub.reset()
+		isRemoteConfigEnabledStub.withArgs("org-1").returns(false)
+		isRemoteConfigEnabledStub.withArgs("org-2").returns(false)
+		isRemoteConfigEnabledStub.withArgs("org-3").returns(true)
+		// Fallback org has no discoveredValue, so it will go through fetchRemoteConfigForOrganization
+		// which needs auth → will fall back to cache
+		;(diskStorage.readRemoteConfigFromCache as sinon.SinonStub).resolves({ version: "v1" })
+
+		const controller = {
+			accountService: { switchAccount: sandbox.stub().resolves() },
+			stateManager: { setSecret: sandbox.stub() },
+			mcpHub: {},
+			postStateToWebview: sandbox.stub(),
+		}
+
+		await remoteConfigFetch.fetchRemoteConfig(controller as any)
+
+		assert.ok((remoteConfigUtils.applyRemoteConfig as sinon.SinonStub).calledOnce)
+	})
+
+	it("clears remote config when all orgs are locally opted-out", async () => {
+		fetchUserRemoteConfigStub.resolves({
+			organizationId: "org-1",
+			value: '{"version":"v1"}',
+			organizations: [
+				{ organizationId: "org-1", name: "Org 1" },
+				{ organizationId: "org-2", name: "Org 2" },
+			],
+		})
+		isRemoteConfigEnabledStub.reset()
+		isRemoteConfigEnabledStub.returns(false)
+
+		const controller = {
+			accountService: { switchAccount: sandbox.stub() },
+			stateManager: { setSecret: sandbox.stub() },
+			mcpHub: {},
+			postStateToWebview: sandbox.stub(),
+		}
+
+		await remoteConfigFetch.fetchRemoteConfig(controller as any)
+
+		assert.ok((remoteConfigUtils.clearRemoteConfig as sinon.SinonStub).called)
+		assert.strictEqual(controller.accountService.switchAccount.callCount, 0)
+		assert.strictEqual((remoteConfigUtils.applyRemoteConfig as sinon.SinonStub).callCount, 0)
+	})
+
+	it("calls clearRemoteConfig when discovery returns no qualifying org", async () => {
+		fetchUserRemoteConfigStub.resolves(undefined)
+
+		const controller = {
+			accountService: { switchAccount: sandbox.stub() },
+			stateManager: { setSecret: sandbox.stub() },
+			mcpHub: {},
+			postStateToWebview: sandbox.stub(),
+		}
+
+		await remoteConfigFetch.fetchRemoteConfig(controller as any)
+
+		assert.ok((remoteConfigUtils.clearRemoteConfig as sinon.SinonStub).called)
+		assert.strictEqual(controller.accountService.switchAccount.callCount, 0)
+		assert.strictEqual((remoteConfigUtils.applyRemoteConfig as sinon.SinonStub).callCount, 0)
+	})
+
+	it("clears remote config when isRemoteConfigEnabled toggled off mid-flight", async () => {
+		Object.assign(authServiceStub, {
+			getActiveOrganizationId: () => "org-target",
+		})
+
+		fetchUserRemoteConfigStub.resolves({
+			organizationId: "org-target",
+			value: '{"version":"v1"}',
+			organizations: [{ organizationId: "org-target", name: "Target Org" }],
+		})
+
+		isRemoteConfigEnabledStub.reset()
+		isRemoteConfigEnabledStub.onFirstCall().returns(true)
+		isRemoteConfigEnabledStub.onSecondCall().returns(false)
+
+		const controller = {
+			accountService: { switchAccount: sandbox.stub() },
+			stateManager: { setSecret: sandbox.stub() },
+			mcpHub: {},
+			postStateToWebview: sandbox.stub(),
+		}
+
+		await remoteConfigFetch.fetchRemoteConfig(controller as any)
+
+		assert.ok((diskStorage.writeRemoteConfigToCache as sinon.SinonStub).calledOnce)
+		assert.ok((remoteConfigUtils.clearRemoteConfig as sinon.SinonStub).called)
+		assert.strictEqual((remoteConfigUtils.applyRemoteConfig as sinon.SinonStub).callCount, 0)
+	})
+
+	it("preserves existing config on unexpected network error", async () => {
+		fetchUserRemoteConfigStub.rejects(new Error("network failure"))
+
+		const controller = {
+			accountService: { switchAccount: sandbox.stub() },
+			stateManager: { setSecret: sandbox.stub() },
+			mcpHub: {},
+			postStateToWebview: sandbox.stub(),
+		}
+
+		await remoteConfigFetch.fetchRemoteConfig(controller as any)
+
+		// Transient errors should NOT clear existing remote config
+		assert.strictEqual((remoteConfigUtils.clearRemoteConfig as sinon.SinonStub).callCount, 0)
+		assert.strictEqual(controller.postStateToWebview.callCount, 0)
+	})
+
+	it("preserves existing config when switchAccount rejects", async () => {
+		Object.assign(authServiceStub, {
+			getActiveOrganizationId: () => "org-current",
+		})
+
+		fetchUserRemoteConfigStub.resolves({
+			organizationId: "org-target",
+			value: '{"version":"v1"}',
+			organizations: [{ organizationId: "org-target", name: "Target Org" }],
+		})
+
+		const controller = {
+			accountService: { switchAccount: sandbox.stub().rejects(new Error("switch failed")) },
+			stateManager: { setSecret: sandbox.stub() },
+			mcpHub: {},
+			postStateToWebview: sandbox.stub(),
+		}
+
+		await remoteConfigFetch.fetchRemoteConfig(controller as any)
+
+		// switchAccount failure should NOT clear existing remote config
+		assert.strictEqual((remoteConfigUtils.clearRemoteConfig as sinon.SinonStub).callCount, 0)
+		assert.strictEqual((remoteConfigUtils.applyRemoteConfig as sinon.SinonStub).callCount, 0)
+	})
+})

--- a/src/core/storage/remote-config/fetch.ts
+++ b/src/core/storage/remote-config/fetch.ts
@@ -1,5 +1,6 @@
 import axios, { AxiosRequestConfig, AxiosResponse } from "axios"
 import { Controller } from "@/core/controller"
+import { ClineAccountService } from "@/services/account/ClineAccountService"
 import { buildBasicClineHeaders } from "@/services/EnvUtils"
 import { getAxiosSettings } from "@/shared/net"
 import { Logger } from "@/shared/services/Logger"
@@ -156,33 +157,27 @@ async function fetchApiKeysForOrganization(organizationId: string): Promise<APIK
 	}
 }
 
-/**
- * Scans all user organizations to find the first one with an enabled remote configuration.
- *
- * @returns Object containing the organization ID and config, or undefined if none found
- */
-async function findOrganizationWithRemoteConfig(): Promise<{ organizationId: string; config: RemoteConfig } | undefined> {
-	const authService = AuthService.getInstance()
+async function discoverRemoteConfigOrg(): Promise<
+	{ organizationId: string; discoveredValue?: string } | undefined
+> {
+	const accountService = ClineAccountService.getInstance()
 
-	// Get all user organizations from cached auth info
-	const userOrganizations = authService.getUserOrganizations()
-
-	if (!userOrganizations || userOrganizations.length === 0) {
+	const discovery = await accountService.fetchUserRemoteConfig()
+	if (!discovery) {
 		return undefined
 	}
 
-	// Scan each organization for remote config
-	for (const org of userOrganizations) {
-		if (!isRemoteConfigEnabled(org.organizationId)) {
-			continue
-		}
+	if (isRemoteConfigEnabled(discovery.organizationId)) {
+		return { organizationId: discovery.organizationId, discoveredValue: discovery.value }
+	}
 
-		const remoteConfig = await fetchRemoteConfigForOrganization(org.organizationId)
-
-		if (remoteConfig) {
-			return {
-				organizationId: org.organizationId,
-				config: remoteConfig,
+	if (discovery.organizations) {
+		for (const org of discovery.organizations) {
+			if (org.organizationId === discovery.organizationId) {
+				continue
+			}
+			if (isRemoteConfigEnabled(org.organizationId)) {
+				return { organizationId: org.organizationId }
 			}
 		}
 	}
@@ -190,78 +185,97 @@ async function findOrganizationWithRemoteConfig(): Promise<{ organizationId: str
 	return undefined
 }
 
+function parseDiscoveredConfig(value: string, organizationId: string): RemoteConfig | undefined {
+	try {
+		return RemoteConfigSchema.parse(JSON.parse(value))
+	} catch (error) {
+		Logger.warn(`Failed to parse discovered config for org ${organizationId}, will re-fetch`, error)
+		return undefined
+	}
+}
+
+async function resolveRemoteConfig(
+	organizationId: string,
+	discoveredValue?: string,
+): Promise<RemoteConfig | undefined> {
+	if (discoveredValue) {
+		const config = parseDiscoveredConfig(discoveredValue, organizationId)
+		if (config) {
+			return config
+		}
+	}
+	return fetchRemoteConfigForOrganization(organizationId)
+}
+
 /**
- * Ensures the user is in the correct organization with remote configuration enabled.
- * Automatically switches to the organization if needed and applies the remote config.
+ * Discovers the target org, resolves its remote config, switches org if needed,
+ * fetches API keys, and applies the config. Clears remote config when no
+ * qualifying org is found or config resolution returns nothing.
  *
  * @param controller The controller instance
  * @returns RemoteConfig if found and applied, undefined otherwise
  */
 async function ensureUserInOrgWithRemoteConfig(controller: Controller): Promise<RemoteConfig | undefined> {
 	const authService = AuthService.getInstance()
+	const discovered = await discoverRemoteConfigOrg()
 
-	try {
-		// Find an organization with remote config
-		const result = await findOrganizationWithRemoteConfig()
+	if (!discovered) {
+		clearRemoteConfig()
+		controller.postStateToWebview()
+		return undefined
+	}
 
-		if (!result) {
-			clearRemoteConfig()
-			controller.postStateToWebview()
-			return undefined
-		}
+	const { organizationId, discoveredValue } = discovered
 
-		const { organizationId, config } = result
+	const remoteConfig = await resolveRemoteConfig(organizationId, discoveredValue)
 
-		// Check if we need to switch organizations
-		const currentActiveOrgId = authService.getActiveOrganizationId()
-		if (currentActiveOrgId !== organizationId) {
-			await controller.accountService.switchAccount(organizationId)
-		}
+	if (!remoteConfig) {
+		clearRemoteConfig()
+		controller.postStateToWebview()
+		return undefined
+	}
 
-		const configuredApiKeys: ConfiguredAPIKeys = {}
-		// Fetch and store API keys for configured providers
-		const hasConfiguredProviders = config.providerSettings && Object.keys(config.providerSettings).length > 0
-		if (hasConfiguredProviders) {
-			const apiKeys = await fetchApiKeysForOrganization(organizationId)
-			if (config.providerSettings?.LiteLLM) {
-				if (apiKeys.litellm) {
-					configuredApiKeys["litellm"] = true
-					controller.stateManager.setSecret("remoteLiteLlmApiKey", apiKeys.litellm)
-				} else {
-					controller.stateManager.setSecret("remoteLiteLlmApiKey", undefined)
-				}
+	// Switch org only after we know we have a valid config to apply.
+	if (authService.getActiveOrganizationId() !== organizationId) {
+		await controller.accountService.switchAccount(organizationId)
+	}
+
+	const configuredApiKeys: ConfiguredAPIKeys = {}
+	const hasConfiguredProviders = remoteConfig.providerSettings && Object.keys(remoteConfig.providerSettings).length > 0
+	if (hasConfiguredProviders) {
+		const apiKeys = await fetchApiKeysForOrganization(organizationId)
+		if (remoteConfig.providerSettings?.LiteLLM) {
+			if (apiKeys.litellm) {
+				configuredApiKeys["litellm"] = true
+				controller.stateManager.setSecret("remoteLiteLlmApiKey", apiKeys.litellm)
 			} else {
 				controller.stateManager.setSecret("remoteLiteLlmApiKey", undefined)
 			}
 		} else {
 			controller.stateManager.setSecret("remoteLiteLlmApiKey", undefined)
 		}
-
-		// Cache and apply the remote config
-		await writeRemoteConfigToCache(organizationId, config)
-		if (isRemoteConfigEnabled(organizationId)) {
-			await applyRemoteConfig(config, configuredApiKeys, controller.mcpHub)
-		} else {
-			clearRemoteConfig()
-		}
-		controller.postStateToWebview()
-
-		return config
-	} catch (error) {
-		Logger.error("Failed to ensure user in organization with remote config:", error)
-		return undefined
+	} else {
+		controller.stateManager.setSecret("remoteLiteLlmApiKey", undefined)
 	}
+
+	await writeRemoteConfigToCache(organizationId, remoteConfig)
+	if (isRemoteConfigEnabled(organizationId)) {
+		await applyRemoteConfig(remoteConfig, configuredApiKeys, controller.mcpHub)
+	} else {
+		clearRemoteConfig()
+	}
+	controller.postStateToWebview()
+
+	return remoteConfig
 }
 
 /**
  * Main entry point for fetching remote configuration.
- * Scans all user organizations, switches to the one with remote config if found,
- * and applies the configuration.
+ * Called periodically to ensure users stay in organizations with remote
+ * configuration enabled.
  *
- * It catches any exceptions, logs them and does not propagate them to the caller.
- *
- * This function is called periodically to ensure users stay in
- * organizations with remote configuration enabled.
+ * Catches all exceptions and logs them without clearing existing config,
+ * so transient failures do not drop remote-config-enforced settings.
  *
  * @param controller The controller instance
  */

--- a/src/services/account/ClineAccountService.ts
+++ b/src/services/account/ClineAccountService.ts
@@ -5,6 +5,7 @@ import type {
 	OrganizationUsageTransaction,
 	PaymentTransaction,
 	UsageTransaction,
+	UserRemoteConfigDiscoveryResponse,
 	UserResponse,
 } from "@shared/ClineAccount"
 import axios, { AxiosRequestConfig, AxiosResponse } from "axios"
@@ -46,13 +47,20 @@ export class ClineAccountService {
 	 * Helper function to make authenticated requests to the Cline API
 	 * @param endpoint The API endpoint to call (without the base URL)
 	 * @param config Additional axios request configuration
+	 * @param options.allowNullData When true, allows response.data.data to be null without throwing.
+	 *   Callers must include `| null` in T and handle null themselves.
+	 *   Used by endpoints like /users/me/remote-config that return 200 with data: null.
 	 * @returns The API response data
 	 * @throws Error if the API key is not found or the request fails
 	 */
-	private async authenticatedRequest<T>(endpoint: string, config: AxiosRequestConfig = {}): Promise<T> {
+	private async authenticatedRequest<T>(
+		endpoint: string,
+		config: AxiosRequestConfig = {},
+		options?: { allowNullData?: boolean; authToken?: string },
+	): Promise<T> {
 		const url = new URL(endpoint, this.baseUrl).toString() // Validate URL
 		// IMPORTANT: Prefixed with 'workos:' so backend can route verification to WorkOS provider
-		const clineAccountAuthToken = await this._authService.getAuthToken()
+		const clineAccountAuthToken = options?.authToken ?? (await this._authService.getAuthToken())
 		if (!clineAccountAuthToken) {
 			throw new Error("No Cline account auth token found")
 		}
@@ -66,7 +74,7 @@ export class ClineAccountService {
 			},
 			...getAxiosSettings(),
 		}
-		const response: AxiosResponse<{ data?: T; error: string; success: boolean }> = await axios.request({
+		const response: AxiosResponse<{ data?: T | null; error: string; success: boolean }> = await axios.request({
 			url,
 			method: "GET",
 			...requestConfig,
@@ -75,16 +83,22 @@ export class ClineAccountService {
 		if (status < 200 || status >= 300) {
 			throw new Error(`Request to ${endpoint} failed with status ${status}`)
 		}
-		if (response.statusText !== "No Content" && (!response.data || !response.data.data)) {
-			throw new Error(`Invalid response from ${endpoint} API`)
-		}
 		if (typeof response.data === "object" && !response.data.success) {
 			throw new Error(`API error: ${response.data.error}`)
 		}
 		if (response.statusText === "No Content") {
-			return {} as T // Return empty object if no content
+			return {} as T
 		}
-		return response.data.data as T
+
+		const payload = response.data?.data
+		if (!response.data || typeof payload === "undefined") {
+			throw new Error(`Invalid response from ${endpoint} API`)
+		}
+		if (payload === null && !options?.allowNullData) {
+			throw new Error(`Invalid response from ${endpoint} API`)
+		}
+
+		return payload as T
 	}
 
 	/**
@@ -232,6 +246,21 @@ export class ClineAccountService {
 			Logger.error("Failed to fetch active organization transactions (RPC):", error)
 			return undefined
 		}
+	}
+
+	async fetchUserRemoteConfig(): Promise<UserRemoteConfigDiscoveryResponse | undefined> {
+		const token = await this._authService.getAuthToken()
+		if (!token) {
+			return undefined
+		}
+
+		const data = await this.authenticatedRequest<UserRemoteConfigDiscoveryResponse | null>(
+			CLINE_API_ENDPOINT.USER_REMOTE_CONFIG,
+			{},
+			{ allowNullData: true, authToken: token },
+		)
+		// Backend returns 200 with data: null when no org has remote config
+		return data ?? undefined
 	}
 
 	/**

--- a/src/shared/ClineAccount.ts
+++ b/src/shared/ClineAccount.ts
@@ -83,5 +83,16 @@ export interface OrganizationUsageTransaction {
 	userId: string
 }
 
+export interface UserRemoteConfigOrganization {
+	organizationId: string
+	name: string
+}
+
+export interface UserRemoteConfigDiscoveryResponse {
+	organizationId: string
+	value: string
+	organizations?: UserRemoteConfigOrganization[]
+}
+
 // Used in cline.ts provider and in webview-ui/src/components/chat/ChatRow.tsx to display the login button
 export const CLINE_ACCOUNT_AUTH_ERROR_MESSAGE = "Unauthorized: Please sign in to Cline before trying again."

--- a/src/shared/cline/api.ts
+++ b/src/shared/cline/api.ts
@@ -8,6 +8,7 @@ enum CLINE_API_ENDPOINT_V1 {
 	USER_INFO = "/api/v1/users/me",
 	FEATUREBASE_TOKEN = "/api/v1/users/me/featurebase-token",
 	ACTIVE_ACCOUNT = "/api/v1/users/active-account",
+	USER_REMOTE_CONFIG = "/api/v1/users/me/remote-config",
 	REMOTE_CONFIG = "/api/v1/organizations/{id}/remote-config",
 	API_KEYS = "/api/v1/organizations/{id}/api-keys",
 }

--- a/src/test/services/ClineAccountService.test.ts
+++ b/src/test/services/ClineAccountService.test.ts
@@ -4,6 +4,83 @@ import sinon from "sinon"
 import { ClineAccountService } from "@/services/account/ClineAccountService"
 import { AuthService } from "@/services/auth/AuthService"
 
+describe("ClineAccountService.fetchUserRemoteConfig", () => {
+	let service: ClineAccountService
+	let sandbox: sinon.SinonSandbox
+	let authStub: { getAuthToken: sinon.SinonStub }
+
+	beforeEach(() => {
+		sandbox = sinon.createSandbox()
+		authStub = { getAuthToken: sandbox.stub().resolves("token") }
+		sandbox.stub(AuthService, "getInstance").returns(authStub as unknown as AuthService)
+		service = new ClineAccountService()
+	})
+
+	afterEach(() => {
+		sandbox.restore()
+	})
+
+	it("returns discovery response on a successful authenticated request", async () => {
+		const mockResponse = {
+			organizationId: "org-123",
+			value: '{"version":"v1"}',
+			organizations: [
+				{ organizationId: "org-123", name: "Test Org" },
+				{ organizationId: "org-456", name: "Another Org" },
+			],
+		}
+		sandbox.stub(service as unknown as { authenticatedRequest: () => unknown }, "authenticatedRequest").resolves(mockResponse)
+
+		const result = await service.fetchUserRemoteConfig()
+
+		assert.ok(result !== undefined, "result should not be undefined")
+		assert.strictEqual(result?.organizationId, "org-123")
+		assert.strictEqual(result?.organizations?.length, 2)
+		assert.strictEqual(result?.organizations?.[0].name, "Test Org")
+	})
+
+	it("re-throws when the request throws a network error", async () => {
+		sandbox
+			.stub(service as unknown as { authenticatedRequest: () => unknown }, "authenticatedRequest")
+			.rejects(new Error("Network error"))
+
+		await assert.rejects(() => service.fetchUserRemoteConfig(), { message: "Network error" })
+	})
+
+	it("returns undefined when there is no auth token", async () => {
+		authStub.getAuthToken.resolves(null)
+
+		const result = await service.fetchUserRemoteConfig()
+
+		assert.strictEqual(result, undefined)
+	})
+
+	it("returns undefined when backend returns data: null (no org has remote config)", async () => {
+		// When allowNullData is true and backend returns { success: true, data: null },
+		// authenticatedRequest returns null. fetchUserRemoteConfig should coalesce to undefined.
+		sandbox.stub(service as unknown as { authenticatedRequest: () => unknown }, "authenticatedRequest").resolves(null)
+
+		const result = await service.fetchUserRemoteConfig()
+
+		assert.strictEqual(result, undefined)
+	})
+
+	it("returns response when backend selects fallback org", async () => {
+		const mockResponse = {
+			organizationId: "org-fallback",
+			value: '{"version":"v1"}',
+			organizations: [{ organizationId: "org-fallback", name: "Fallback Org" }],
+		}
+		sandbox.stub(service as unknown as { authenticatedRequest: () => unknown }, "authenticatedRequest").resolves(mockResponse)
+
+		const result = await service.fetchUserRemoteConfig()
+
+		assert.ok(result !== undefined)
+		assert.strictEqual(result?.organizationId, "org-fallback")
+		assert.strictEqual(result?.organizations?.length, 1)
+	})
+})
+
 describe("ClineAccountService.fetchFeaturebaseToken", () => {
 	let service: ClineAccountService
 	let sandbox: sinon.SinonSandbox


### PR DESCRIPTION
## Summary

Replace the old client-side per-org scan for remote config with a single discovery call to `GET /api/v1/users/me/remote-config`, reuse the inline config value when possible, and switch accounts if needed.

This API was introduced in https://github.com/cline/core-platform/pull/2265 (in PROD now).

## Client Flow

1. Call `GET /api/v1/users/me/remote-config`.
2. If the backend-selected org is locally allowed, use it (with the inline `value`). If opted out, scan the returned `organizations` list for the first locally allowed org.
3. Resolve config: parse the inline `discoveredValue` if available (backend-selected org), otherwise fetch via the org-level endpoint.
4. If the chosen org differs from the current active org, switch accounts (only after config is successfully resolved).
5. Fetch API keys only for the chosen org.
6. Cache and apply the config (with a re-check for mid-flight opt-out toggles).
7. Clear remote config if no returned org is locally allowed, or if config resolution returns nothing. Transient errors (network failures, 5xx) are logged without clearing existing config.

## What Changed

| File | Change |
|------|--------|
| `src/shared/cline/api.ts` | Added `USER_REMOTE_CONFIG` endpoint constant |
| `src/shared/ClineAccount.ts` | Added discovery response types |
| `src/services/account/ClineAccountService.ts` | Added `fetchUserRemoteConfig()` with auth precheck; tightened `authenticatedRequest()` null vs undefined validation; added optional `authToken` pass-through |
| `src/core/storage/remote-config/fetch.ts` | Replaced per-org probing with single discovery call, inline value reuse, and linear discover → resolve → switch → apply flow |
| `src/core/storage/__tests__/fetchRemoteConfig.test.ts` | 11 tests covering org switching, inline value reuse, parse failure fallback, local opt-out, transient error preservation, resolve-before-switch safety |
| `src/test/services/ClineAccountService.test.ts` | 5 tests for the new account service method (success, network re-throw, no auth, null data, fallback org) |

## Behavior Notes

- Reduces discovery from N org-level requests to 1 user-level request.
- Skips the org-level config fetch entirely when the backend-selected org is chosen (inline value reuse).
- Preserves local opt-out checks on the client.
- Org switch only happens after config resolution succeeds — avoids stranding the user in a different org on resolve failure.
- Transient discovery/network errors preserve existing remote config instead of clearing it.
- `authenticatedRequest()` now distinguishes `null` from `undefined` in response payloads (strict null check via `allowNullData`).