### PR TITLE
ci: post release changelogs to #releases Slack channel

### DIFF
--- a/.github/workflows/npm-main.yaml
+++ b/.github/workflows/npm-main.yaml
@@ -91,3 +91,21 @@ jobs:
           echo ""
           echo "📦 Install with: npm install -g cline"
           echo "🔗 NPM: https://www.npmjs.com/package/cline/v/${{ steps.version.outputs.version }}"
+
+      - name: Post release to Slack
+        uses: slackapi/slack-github-action@v3.0.1
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_RELEASE_BOT_TOKEN }}
+          payload: |
+            channel: "C0APVKGGZFC"
+            text: "Cline CLI v${{ steps.version.outputs.version }}"
+            blocks:
+              - type: "section"
+                text:
+                  type: "mrkdwn"
+                  text: "*Cline CLI v${{ steps.version.outputs.version }}*"
+              - type: "context"
+                elements:
+                  - type: "mrkdwn"
+                    text: "<https://www.npmjs.com/package/cline/v/${{ steps.version.outputs.version }}|View on npm>"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -197,3 +197,25 @@ jobs:
                   prerelease: ${{ github.event.inputs.release-type == 'pre-release' }}
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+            - name: Post release to Slack
+              uses: slackapi/slack-github-action@v3.0.1
+              with:
+                  method: chat.postMessage
+                  token: ${{ secrets.SLACK_RELEASE_BOT_TOKEN }}
+                  payload: |
+                    channel: "C0APVKGGZFC"
+                    text: "Cline ${{ steps.resolve_tag.outputs.tag }}"
+                    blocks:
+                      - type: "section"
+                        text:
+                          type: "mrkdwn"
+                          text: "*Cline ${{ steps.resolve_tag.outputs.tag }}*"
+                      - type: "section"
+                        text:
+                          type: "mrkdwn"
+                          text: ${{ toJSON(steps.changelog.outputs.content) }}
+                      - type: "context"
+                        elements:
+                          - type: "mrkdwn"
+                            text: "Full Changelog: https://github.com/${{ github.repository }}/compare/${{ steps.prev_tag.outputs.prev_tag }}...${{ steps.resolve_tag.outputs.tag }}"


### PR DESCRIPTION
### Related Issue

N/A - internal CI improvement

### Description

Adds Slack notifications to both the extension publish and CLI publish workflows. After a successful release, a message is posted to the #releases Slack channel (C0APVKGGZFC) with:

- Extension releases: version tag, changelog content, and a link to the full changelog diff on GitHub
- CLI releases: version number and a link to the npm package page

Uses the official `slackapi/slack-github-action@v3.0.1` action with a `SLACK_RELEASE_BOT_TOKEN` secret for auth.

### Test Procedure

- CI workflow changes -- will be validated on next release
- Reviewed the Slack GitHub Action docs to confirm payload format is correct
- Channel ID `C0APVKGGZFC` corresponds to #releases

### Type of Change

- [x] 🏃 Workflow Changes

### Pre-flight Checklist

- [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
- [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
- [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)