### PR TITLE
fix: Add Linux ARM64 (aarch64) support for JetBrains plugin

### DIFF
--- a/scripts/download-ripgrep.mjs
+++ b/scripts/download-ripgrep.mjs
@@ -44,7 +44,7 @@ const PLATFORMS = [
 		isZip: false,
 	},
 	{
-		name: "linux-arm64",
+		name: "linux-aarch64",
 		archiveName: `ripgrep-${RIPGREP_VERSION}-aarch64-unknown-linux-gnu.tar.gz`,
 		url: `https://github.com/BurntSushi/ripgrep/releases/download/${RIPGREP_VERSION}/ripgrep-${RIPGREP_VERSION}-aarch64-unknown-linux-gnu.tar.gz`,
 		binaryPath: "rg",

--- a/scripts/package-standalone.mjs
+++ b/scripts/package-standalone.mjs
@@ -22,6 +22,7 @@ const TARGET_PLATFORMS = [
 	{ platform: "darwin", arch: "x64", targetDir: "darwin-x64" },
 	{ platform: "darwin", arch: "arm64", targetDir: "darwin-arm64" },
 	{ platform: "linux", arch: "x64", targetDir: "linux-x64" },
+	{ platform: "linux", arch: "arm64", targetDir: "linux-aarch64" },
 ]
 const SUPPORTED_BINARY_MODULES = ["better-sqlite3"]
 


### PR DESCRIPTION
Add Linux ARM64 (aarch64) as a supported platform for the JetBrains plugin standalone packaging.

This requires a JetBrains-side change to actually make it go end-to-end. That is in a separate PR.

## Test Plan

See a related change in the JetBrains plugin.