### PR TITLE
fix(cli): handle openExternal failures when browser open fails

### DIFF
--- a/cli/src/controllers/index.ts
+++ b/cli/src/controllers/index.ts
@@ -149,9 +149,14 @@ export class CliEnvServiceClient implements EnvServiceClientInterface {
 		const url = request.value || ""
 		if (url) {
 			printInfo(`🌐 Opening: ${url}`)
-			// Dynamically import 'open' to open URL in default browser
-			const { default: open } = await import("open")
-			await open(url)
+			try {
+				// Dynamically import 'open' to open URL in default browser
+				const { default: open } = await import("open")
+				await open(url)
+			} catch (error) {
+				const message = error instanceof Error ? error.message : String(error)
+				printWarning(`Unable to open browser automatically (${message}). Please open this URL manually: ${url}`)
+			}
 		}
 		return proto.cline.Empty.create()
 	}


### PR DESCRIPTION
### Related Issue

**Issue:** #9991

### Description

Handles failures from the browser opener in CLI mode so missing `xdg-open` (or similar) doesn’t crash the process. Now we warn and print the URL for manual opening.

### Test Procedure

Not run (error handling change only).

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A

### Additional Notes

N/A
