### PR TITLE
fix: run file read optimization every turn

### DIFF
--- a/src/core/context/context-management/ContextManager.ts
+++ b/src/core/context/context-management/ContextManager.ts
@@ -245,18 +245,18 @@ export class ContextManager {
 					const totalTokens = (tokensIn || 0) + (tokensOut || 0) + (cacheWrites || 0) + (cacheReads || 0)
 					const { maxAllowedSize } = getContextWindowInfo(api)
 
+					// Attempt file read optimization on every turn to reduce repeated context load.
+					let { anyContextUpdates, needToTruncate } = this.attemptFileReadOptimizationCore(
+						apiConversationHistory,
+						conversationHistoryDeletedRange,
+						timestamp,
+					)
+
 					// This is the most reliable way to know when we're close to hitting the context window.
 					if (totalTokens >= maxAllowedSize) {
 						// Since the user may switch between models with different context windows, truncating half may not be enough (ie if switching from claude 200k to deepseek 64k, half truncation will only remove 100k tokens, but we need to remove much more)
 						// So if totalTokens/2 is greater than maxAllowedSize, we truncate 3/4 instead of 1/2
 						const keep = totalTokens / 2 > maxAllowedSize ? "quarter" : "half"
-
-						// Attempt file read optimization and check if we need to truncate
-						let { anyContextUpdates, needToTruncate } = this.attemptFileReadOptimizationCore(
-							apiConversationHistory,
-							conversationHistoryDeletedRange,
-							timestamp,
-						)
 
 						if (needToTruncate) {
 							// go ahead with truncation
@@ -271,11 +271,11 @@ export class ContextManager {
 
 							updatedConversationHistoryDeletedRange = true
 						}
+					}
 
-						// if we alter the context history, save the updated version to disk
-						if (anyContextUpdates) {
-							await this.saveContextHistory(taskDirectory)
-						}
+					// if we alter the context history, save the updated version to disk
+					if (anyContextUpdates) {
+						await this.saveContextHistory(taskDirectory)
 					}
 				}
 			}


### PR DESCRIPTION
### Related Issue

**Issue:** #10077

### Description

Runs file read optimization on every turn so repeated reads are deduped earlier, while keeping truncation only when the context window is actually near the limit.

### Test Procedure

Not run (no automated tests available for this path).

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (
> claude-dev@3.76.0 pretest
> npm run compile && npm run compile-tests && npm run compile-standalone && npm run lint


> claude-dev@3.76.0 compile
> npm run check-types && npm run lint && node esbuild.mjs


> claude-dev@3.76.0 check-types
> npm run protos && npx tsc --noEmit && cd webview-ui && npx tsc --noEmit && cd ../cli && npx tsc --noEmit


> claude-dev@3.76.0 protos
> node scripts/build-proto.mjs) and code is formatted and linted (
> claude-dev@3.76.0 format
> biome format --changed --no-errors-on-unmatched --files-ignore-unknown=true --diagnostic-level=error)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A

### Additional Notes

N/A