### PR TITLE
Changelog and version bump for release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [3.77.0]
+
+### Added
+
+- Add "Lazy Teammate Mode" experimental toggle
+- `read_file` tool now supports chunked reading for targeted file access
+
+### Fixed
+
+- Exclude `new_task` tool from system prompt in yolo/headless mode
+- Fix Kanban demo video formatting
+
+### Changed
+
+- Polish `Notification` hook functionality
+
 ## [3.76.0]
 
 ### Added

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,5 +1,19 @@
 # cline
 
+## [2.12.0]
+
+### Added
+
+- `read_file` tool now supports chunked reading for targeted file access
+
+### Fixed
+
+- Exclude `new_task` tool from system prompt in yolo/headless mode
+
+### Changed
+
+- Polish `Notification` hook functionality
+
 ## [2.9.0]
 
 ### Added

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cline",
-	"version": "2.11.0",
+	"version": "2.12.0",
 	"description": "Autonomous coding agent CLI - capable of creating/editing files, running commands, using the browser, and more",
 	"main": "dist/lib.mjs",
 	"types": "dist/lib.d.ts",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "claude-dev",
-	"version": "3.76.0",
+	"version": "3.77.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "claude-dev",
-			"version": "3.76.0",
+			"version": "3.77.0",
 			"license": "Apache-2.0",
 			"workspaces": [
 				".",
@@ -162,7 +162,7 @@
 		},
 		"cli": {
 			"name": "cline",
-			"version": "2.11.0",
+			"version": "2.12.0",
 			"cpu": [
 				"x64",
 				"arm64"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "claude-dev",
 	"displayName": "Cline",
 	"description": "Autonomous coding agent right in your IDE, capable of creating/editing files, running commands, using the browser, and more with your permission every step of the way.",
-	"version": "3.76.0",
+	"version": "3.77.0",
 	"icon": "assets/icons/icon.png",
 	"workspaces": [
 		".",


### PR DESCRIPTION
Release for today.

* VSCode extension: `v3.77.0`
* CLI: `v2.12.0`