### PR TITLE
refactor(webview-ui): filter per-file diff content in individual "cline wants to edit this file" views

### DIFF
--- a/webview-ui/src/components/chat/PlannedEdits.tsx
+++ b/webview-ui/src/components/chat/PlannedEdits.tsx
@@ -1,0 +1,27 @@
+import React from "react"
+import { DiffViewer } from "./DiffViewer"
+
+interface PlannedEditsProps {
+	diff: string
+	files: Array<{ path: string }>
+}
+
+export const PlannedEdits = ({ diff, files }: PlannedEditsProps) => {
+	const getFileDiff = (filePath: string): string => {
+		if (!diff || !filePath) return diff
+		const escaped = filePath.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+		const match = diff.match(new RegExp(`(diff --git a/.*${escaped}[\s\S]*?)(?=\ndiff --git a/|$)`))
+		return match ? match[1] : diff
+	}
+
+	return (
+		<div>
+			{files.map((file) => (
+				<div key={file.path}>
+					<div>Cline wants to edit this file: {file.path}</div>
+					<DiffViewer diff={getFileDiff(file.path)} />
+				</div>
+			))}
+		</div>
+	)
+}


### PR DESCRIPTION
## Code Quality

### Problem
The component rendering the list of planned file edits (the collapsible "Cline wants to edit this file:" sections) currently passes the full multi-file diff to every DiffViewer instance. This causes the diff view for any individual file to display changes from all edited files. We must compute and pass only the relevant diff hunk for the current file path.

**Severity**: `high`
**File**: `webview-ui/src/components/chat/PlannedEdits.tsx`

### Solution
The component rendering the list of planned file edits (the collapsible "Cline wants to edit this file:" sections) currently passes the full multi-file diff to every DiffViewer instance. This causes the diff view for any individual file to display changes from all edited files. We must compute and pass only the relevant diff hunk for the current file path.

### Changes
- `webview-ui/src/components/chat/PlannedEdits.tsx` (modified)



### Related Issue


**Issue:** #XXXX

### Description



### Test Procedure



### Type of Change



-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist



-   [ ] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots



### Additional Notes


Contributed by Lê Thành Chỉnh
Code is a tool. Mindset is the real value.

Closes #9904