### PR TITLE
Show read_file line ranges in chat UI

### DIFF
--- a/src/core/task/tools/handlers/ReadFileToolHandler.ts
+++ b/src/core/task/tools/handlers/ReadFileToolHandler.ts
@@ -18,16 +18,19 @@ import { ToolResultUtils } from "../utils/ToolResultUtils"
 export const DEFAULT_MAX_LINES = 1000
 const FILE_TRUNCATED_MARKER = "\n\n---\n\n[FILE TRUNCATED:"
 
-/**
- * Slice file content to the requested line range, add one-based `N |` line labels,
- * and append a continuation hint when the file has more lines to read.
- */
-export function formatFileContentWithLineNumbers(content: string, startLine?: number, endLine?: number): string {
+type DisplayedLineSlice = {
+	start: number
+	end: number
+	totalLines: number
+	lines: string[]
+	truncationSuffix: string
+}
+
+function getDisplayedLineSlice(content: string, startLine?: number, endLine?: number): DisplayedLineSlice | null {
 	if (!content) {
-		return content
+		return null
 	}
 
-	// Separate any byte-truncation notice appended by content-limits.ts
 	let body = content
 	let truncationSuffix = ""
 	const truncationIndex = content.indexOf(FILE_TRUNCATED_MARKER)
@@ -48,6 +51,42 @@ export function formatFileContentWithLineNumbers(content: string, startLine?: nu
 	const start = shouldSwapBounds ? requestedEnd : requestedStart
 	const end = Math.min(totalLines, shouldSwapBounds ? requestedStart : requestedEnd)
 
+	return { start, end, totalLines, lines, truncationSuffix }
+}
+
+/**
+ * Line range shown for a read_file result (matches formatFileContentWithLineNumbers). Omits image reads and empty files.
+ */
+export function getReadToolDisplayedLineRange(
+	block: ToolUse,
+	fileContent: FileContentResult,
+): { start: number; end: number } | undefined {
+	if (fileContent.imageBlock) {
+		return undefined
+	}
+	const { startLine, endLine } = parseRequestedLineRange(block)
+	const slice = getDisplayedLineSlice(fileContent.text, startLine, endLine)
+	if (!slice || slice.totalLines === 0) {
+		return undefined
+	}
+	return { start: slice.start, end: slice.end }
+}
+
+/**
+ * Slice file content to the requested line range, add one-based `N |` line labels,
+ * and append a continuation hint when the file has more lines to read.
+ */
+export function formatFileContentWithLineNumbers(content: string, startLine?: number, endLine?: number): string {
+	if (!content) {
+		return content
+	}
+
+	const meta = getDisplayedLineSlice(content, startLine, endLine)
+	if (!meta) {
+		return content
+	}
+
+	const { start, end, totalLines, lines, truncationSuffix } = meta
 	const slice = lines.slice(start - 1, end)
 	const labeled = slice.map((line, i) => `${start + i} | ${line}`).join("\n")
 
@@ -80,6 +119,24 @@ function buildReadResponse(block: ToolUse, fileContent: FileContentResult, prefi
 		: formatFileContentWithLineNumbers(fileContent.text, startLine, endLine)
 
 	return prefix ? `${prefix}\n${text}` : text
+}
+
+async function emitReadFileToolUiComplete(
+	config: TaskConfig,
+	sharedMessageProps: ClineSayTool,
+	block: ToolUse,
+	fileContent: FileContentResult,
+): Promise<void> {
+	if (config.isSubagentExecution) {
+		return
+	}
+	const range = getReadToolDisplayedLineRange(block, fileContent)
+	const payload: ClineSayTool = { ...sharedMessageProps }
+	if (range) {
+		payload.readLineStart = range.start
+		payload.readLineEnd = range.end
+	}
+	await config.callbacks.say("tool", JSON.stringify(payload), undefined, undefined, false)
 }
 
 export class ReadFileToolHandler implements IFullyManagedTool {
@@ -170,10 +227,9 @@ export class ReadFileToolHandler implements IFullyManagedTool {
 		const shouldAutoApprove =
 			config.isSubagentExecution || (await config.callbacks.shouldAutoApproveToolWithPath(block.name, relPath))
 		if (shouldAutoApprove) {
-			// Auto-approval flow
+			// Auto-approval flow (completed read is announced after extractFileContent so line range is known)
 			if (!config.isSubagentExecution) {
 				await config.callbacks.removeLastPartialMessageIfExistsWithType("ask", "tool")
-				await config.callbacks.say("tool", completeMessage, undefined, undefined, false)
 			}
 
 			// Capture telemetry
@@ -283,6 +339,7 @@ export class ReadFileToolHandler implements IFullyManagedTool {
 			}
 
 			if (validCached.readCount >= 3) {
+				await emitReadFileToolUiComplete(config, sharedMessageProps, block, fileContent)
 				return buildReadResponse(
 					block,
 					fileContent,
@@ -290,6 +347,7 @@ export class ReadFileToolHandler implements IFullyManagedTool {
 				)
 			}
 
+			await emitReadFileToolUiComplete(config, sharedMessageProps, block, fileContent)
 			return buildReadResponse(
 				block,
 				fileContent,
@@ -338,9 +396,11 @@ export class ReadFileToolHandler implements IFullyManagedTool {
 		// Handle image blocks separately - they need to be pushed to userMessageContent
 		if (fileContent.imageBlock) {
 			config.taskState.userMessageContent.push(fileContent.imageBlock)
+			await emitReadFileToolUiComplete(config, sharedMessageProps, block, fileContent)
 			return buildReadResponse(block, fileContent)
 		}
 
+		await emitReadFileToolUiComplete(config, sharedMessageProps, block, fileContent)
 		return buildReadResponse(block, fileContent)
 	}
 }

--- a/src/core/task/tools/handlers/__tests__/ReadFileToolHandler.lineNumbers.test.ts
+++ b/src/core/task/tools/handlers/__tests__/ReadFileToolHandler.lineNumbers.test.ts
@@ -1,6 +1,34 @@
 import assert from "node:assert/strict"
+import { ClineDefaultTool } from "@shared/tools"
 import { describe, it } from "mocha"
-import { DEFAULT_MAX_LINES, formatFileContentWithLineNumbers } from "../ReadFileToolHandler"
+import { DEFAULT_MAX_LINES, formatFileContentWithLineNumbers, getReadToolDisplayedLineRange } from "../ReadFileToolHandler"
+
+describe("getReadToolDisplayedLineRange", () => {
+	const block = (start?: string, end?: string) => ({
+		type: "tool_use" as const,
+		name: ClineDefaultTool.FILE_READ,
+		params: {
+			path: "f.txt",
+			...(start !== undefined ? { start_line: start } : {}),
+			...(end !== undefined ? { end_line: end } : {}),
+		},
+		partial: false,
+	})
+
+	it("matches the slice shown for explicit start/end", () => {
+		const text = Array.from({ length: 10 }, (_, i) => `L${i + 1}`).join("\n")
+		const r = getReadToolDisplayedLineRange(block("3", "5"), { text })
+		assert.deepEqual(r, { start: 3, end: 5 })
+	})
+
+	it("returns undefined for image reads", () => {
+		const r = getReadToolDisplayedLineRange(block(), {
+			text: "ok",
+			imageBlock: { type: "image", source: { type: "url", url: "x" } } as any,
+		})
+		assert.equal(r, undefined)
+	})
+})
 
 describe("formatFileContentWithLineNumbers", () => {
 	describe("line labels", () => {

--- a/src/shared/ExtensionMessage.ts
+++ b/src/shared/ExtensionMessage.ts
@@ -216,6 +216,9 @@ export interface ClineSayTool {
 	operationIsLocatedInWorkspace?: boolean
 	/** Starting line numbers in the original file where each SEARCH block matched */
 	startLineNumbers?: number[]
+	/** Inclusive line range actually returned by read_file (for UI summaries). */
+	readLineStart?: number
+	readLineEnd?: number
 }
 
 export interface ClineSayHook {

--- a/webview-ui/src/components/chat/ChatRow.tsx
+++ b/webview-ui/src/components/chat/ChatRow.tsx
@@ -527,6 +527,12 @@ export const ChatRowContent = memo(
 									{tool.path && !tool.path.startsWith(".") && <span>/</span>}
 									<span className="ph-no-capture whitespace-nowrap overflow-hidden text-ellipsis mr-2 text-left [direction: rtl]">
 										{cleanPathPrefix(tool.path ?? "") + "\u200E"}
+										{tool.readLineStart != null && tool.readLineEnd != null ? (
+											<span className="opacity-80">
+												{" "}
+												({tool.readLineStart}-{tool.readLineEnd})
+											</span>
+										) : null}
 									</span>
 									<div className="grow" />
 									{!isImage && <SquareArrowOutUpRightIcon className="size-2" />}

--- a/webview-ui/src/components/chat/chat-view/components/messages/ToolGroupRenderer.test.ts
+++ b/webview-ui/src/components/chat/chat-view/components/messages/ToolGroupRenderer.test.ts
@@ -1,0 +1,59 @@
+import type { ClineMessage } from "@shared/ExtensionMessage"
+import { describe, expect, it } from "vitest"
+import { buildToolsWithReasoning, getToolGroupSummaryFromParsedTools } from "./ToolGroupRenderer"
+
+const readToolMessage = (
+	ts: number,
+	type: "ask" | "say",
+	path: string,
+	range?: { start: number; end: number },
+): ClineMessage => ({
+	ts,
+	type,
+	...(type === "ask" ? { ask: "tool" as const } : { say: "tool" as const }),
+	text: JSON.stringify({
+		tool: "readFile",
+		path,
+		...(range ? { readLineStart: range.start, readLineEnd: range.end } : {}),
+	}),
+})
+
+describe("buildToolsWithReasoning", () => {
+	it("replaces an immediately-following read approval ask with the completed read", () => {
+		const tools = buildToolsWithReasoning([
+			readToolMessage(1, "ask", "src/a.ts"),
+			readToolMessage(2, "say", "src/a.ts", { start: 1, end: 20 }),
+		])
+
+		expect(tools).toHaveLength(1)
+		expect(tools[0].tool.say).toBe("tool")
+		expect(tools[0].parsedTool.readLineStart).toBe(1)
+		expect(tools[0].parsedTool.readLineEnd).toBe(20)
+	})
+
+	it("keeps separate reads of the same file when they are distinct operations", () => {
+		const tools = buildToolsWithReasoning([
+			readToolMessage(1, "ask", "src/a.ts"),
+			readToolMessage(2, "say", "src/a.ts", { start: 1, end: 20 }),
+			readToolMessage(3, "ask", "src/a.ts"),
+			readToolMessage(4, "say", "src/a.ts", { start: 40, end: 60 }),
+		])
+
+		expect(tools).toHaveLength(2)
+		expect(tools.map((tool) => [tool.parsedTool.readLineStart, tool.parsedTool.readLineEnd])).toEqual([
+			[1, 20],
+			[40, 60],
+		])
+	})
+})
+
+describe("getToolGroupSummaryFromParsedTools", () => {
+	it("counts rendered read tools once after ask/say collapse", () => {
+		const tools = buildToolsWithReasoning([
+			readToolMessage(1, "ask", "src/a.ts"),
+			readToolMessage(2, "say", "src/a.ts", { start: 1, end: 20 }),
+		])
+
+		expect(getToolGroupSummaryFromParsedTools(tools.map((tool) => tool.parsedTool))).toBe("Cline read 1 file")
+	})
+})

--- a/webview-ui/src/components/chat/chat-view/components/messages/ToolGroupRenderer.tsx
+++ b/webview-ui/src/components/chat/chat-view/components/messages/ToolGroupRenderer.tsx
@@ -40,8 +40,14 @@ const getActivityText = (tool: ClineSayTool): string | null => {
 	}
 
 	switch (tool.tool) {
-		case "readFile":
-			return tool.path ? `Reading ${cleanedPath}...` : null
+		case "readFile": {
+			if (!tool.path) {
+				return null
+			}
+			const lineHint =
+				tool.readLineStart != null && tool.readLineEnd != null ? ` (lines ${tool.readLineStart}-${tool.readLineEnd})` : ""
+			return `Reading ${cleanedPath}${lineHint}...`
+		}
 		case "listFilesTopLevel":
 		case "listFilesRecursive":
 			return tool.path ? `Exploring ${cleanedPath}/...` : null
@@ -144,7 +150,7 @@ export const ToolGroupRenderer = memo(({ messages, allMessages, isLastGroup }: T
 		return [...dedupedCompleted, ...activeTools]
 	}, [completedTools, activeTools])
 
-	const summary = getToolGroupSummary(filteredMessages)
+	const summary = getToolGroupSummaryFromParsedTools(completedTools.map((item) => item.parsedTool))
 
 	const handleOpenFile = useCallback((filePath: string) => {
 		FileServiceClient.openFileRelativePath(StringRequest.create({ value: filePath })).catch((err) =>
@@ -234,7 +240,7 @@ export const ToolGroupRenderer = memo(({ messages, allMessages, isLastGroup }: T
  * Build tool items WITHOUT reasoning.
  * Reasoning should not be displayed in file lists - only file/folder content.
  */
-function buildToolsWithReasoning(messages: ClineMessage[]): ToolWithReasoning[] {
+export function buildToolsWithReasoning(messages: ClineMessage[]): ToolWithReasoning[] {
 	const result: ToolWithReasoning[] = []
 
 	for (const msg of messages) {
@@ -245,6 +251,23 @@ function buildToolsWithReasoning(messages: ClineMessage[]): ToolWithReasoning[] 
 
 		if (isLowStakesTool(msg)) {
 			const parsedTool = parseToolSafe(msg.text)
+			const previous = result.at(-1)
+			const supersedesPreviousReadAsk =
+				parsedTool.tool === "readFile" &&
+				parsedTool.path &&
+				msg.say === "tool" &&
+				previous?.tool.ask === "tool" &&
+				previous.parsedTool.tool === "readFile" &&
+				previous.parsedTool.path === parsedTool.path
+
+			if (supersedesPreviousReadAsk) {
+				result[result.length - 1] = {
+					tool: msg,
+					parsedTool,
+					reasoning: undefined,
+				}
+				continue
+			}
 			result.push({
 				tool: msg,
 				parsedTool,
@@ -276,8 +299,16 @@ function getToolDisplayInfo(tool: ClineSayTool) {
 	const folderPath = filePath + "/"
 
 	switch (tool.tool) {
-		case "readFile":
-			return { icon, path: filePath, label: "read" }
+		case "readFile": {
+			const lineNote =
+				tool.readLineStart != null && tool.readLineEnd != null ? `lines ${tool.readLineStart}-${tool.readLineEnd}` : null
+			return {
+				icon,
+				path: filePath,
+				label: "read",
+				displayText: lineNote ? `${cleanPathPrefix(filePath)} · ${lineNote}` : undefined,
+			}
+		}
 		case "listFilesTopLevel":
 			return { icon, path: folderPath, label: "listed" }
 		case "listFilesRecursive":
@@ -319,15 +350,10 @@ function formatSearchDisplay(regex: string, path: string, filePattern?: string):
 /**
  * Get summary label for a tool group - shows what's been added to context.
  */
-function getToolGroupSummary(messages: ClineMessage[]): string {
+export function getToolGroupSummaryFromParsedTools(tools: ClineSayTool[]): string {
 	const counts = { read: 0, list: 0, search: 0, def: 0 }
 
-	for (const msg of messages) {
-		if (!isLowStakesTool(msg)) {
-			continue
-		}
-
-		const tool = parseToolSafe(msg.text)
+	for (const tool of tools) {
 		switch (tool.tool) {
 			case "readFile":
 				counts.read++


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

### Description

This updates the read-file chat UI so it shows the actual line range added to context instead of only the file path.
It also keeps the grouped tool summary accurate for manual approvals and repeated reads of the same file.

### Test Procedure

- Ran `npm run compile`
- Ran `npm run test:unit -- --grep "formatFileContentWithLineNumbers|ReadFileToolHandler"`
- Ran `npm run test:unit -- --grep "getReadToolDisplayedLineRange"`
- Ran `npm test -- ToolGroupRenderer.test.ts` in `webview-ui`
- Verified the grouped tool UI now reports line ranges and does not double-count manual approval rows

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<img width="414" height="335" alt="Screenshot 2026-04-01 at 3 28 56 PM" src="https://github.com/user-attachments/assets/cfe7aa98-57e0-4823-b8ea-7ebfa8293efa" />

### Additional Notes


