### PR TITLE
docs: add Explain Changes feature documentation page

### DIFF
--- a/docs/core-workflows/using-commands.mdx
+++ b/docs/core-workflows/using-commands.mdx
@@ -60,7 +60,7 @@ This command is only available in VS Code.
 
 `/explain-changes` generates AI-powered explanations for any git diff. You can explain the last commit, uncommitted work, staged changes, specific commits, branches, PRs, or any range of changes.
 
-Use `/explain-changes` when reviewing code, onboarding to a new codebase, or understanding what changed. For the full list of use cases and examples, see [Explain Changes Command](#explain-changes).
+Use `/explain-changes` when reviewing code, onboarding to a new codebase, or understanding what changed. For the full list of use cases and examples, see [Explain Changes](/features/explain-changes).
 
 ### /reportbug
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -132,6 +132,7 @@
 							"features/background-edit",
 							"features/jupyter-notebooks",
 							"features/deep-planning",
+							"features/explain-changes",
 							"features/web-tools",
 							"features/worktrees"
 						]
@@ -643,7 +644,7 @@
 		},
 		{
 			"source": "/features/slash-commands/explain-changes",
-			"destination": "/core-workflows/using-commands#explain-changes"
+			"destination": "/features/explain-changes"
 		},
 		{
 			"source": "/features/slash-commands/new-rule",

--- a/docs/features/explain-changes.mdx
+++ b/docs/features/explain-changes.mdx
@@ -1,0 +1,91 @@
+---
+title: "Explain Changes"
+sidebarTitle: "Explain Changes"
+description: "Generate AI-powered inline explanations for any git diff, right inside a multi-file diff view."
+---
+
+`/explain-changes` lets you point Cline at any set of git changes — a commit, a branch comparison, a PR, uncommitted work — and get AI-generated inline comments explaining what changed and why. The comments appear directly in a side-by-side diff view inside VS Code.
+
+<Note>
+This feature is only available in VS Code. It is not supported in the CLI or JetBrains environments.
+</Note>
+
+## How to Use It
+
+Type `/explain-changes` in the Cline chat input, optionally followed by a description of what you want explained:
+
+```
+/explain-changes Explain the last commit
+```
+
+```
+/explain-changes What changed between main and feature/auth?
+```
+
+```
+/explain-changes Walk me through PR #42
+```
+
+If you don't provide any details, Cline defaults to analyzing uncommitted changes in your working directory.
+
+### What Happens Next
+
+1. **Cline gathers context** — It runs git or gh CLI commands to retrieve the diff, reads relevant files, and builds an understanding of the changes.
+2. **Cline calls `generate_explanation`** — This opens a multi-file diff view and streams AI-generated inline comments explaining each change.
+
+You'll see Cline working through these steps in the chat before the diff view opens.
+
+## Git Reference Formats
+
+Cline understands all standard git references. Here are common examples:
+
+| What You Want | How to Ask |
+|---|---|
+| Last commit | `Explain the last commit` |
+| Specific commit | `Explain commit abc1234` |
+| Commit range | `Explain changes from abc1234 to def5678` |
+| Branch comparison | `What changed between main and feature/auth?` |
+| Pull request | `Explain PR #42` |
+| Uncommitted changes | `Explain my current changes` |
+| Staged changes | `Explain what I've staged` |
+| Tag comparison | `What changed between v1.0 and v2.0?` |
+
+Under the hood, this translates to git refs like commit hashes, branch names, tags, and relative references (`HEAD~1`, `HEAD^`, `origin/main`, etc.).
+
+## Understanding the Output
+
+### Multi-File Diff View
+
+Cline opens a side-by-side diff view in VS Code showing the before and after state of each changed file. Inline comments are attached to the specific lines they explain.
+
+### Streaming Comments
+
+Comments appear in real-time as the AI generates them. For smaller diffs (1–2 files), the diff view opens immediately and comments stream in. For larger diffs (3+ files), Cline cycles through each file individually to show comments as they arrive, then opens the combined multi-file diff view at the end.
+
+### Interactive Replies
+
+Each comment thread is interactive — you can reply to ask follow-up questions about a specific change. Cline will respond with additional context about that code section. If you need Cline to actually modify code based on the discussion, each comment thread has an **"Add to Cline Chat"** button that sends the conversation to the main Cline agent.
+
+## Checkpoint-Based Explanations
+
+Beyond the slash command, you can also trigger Explain Changes from **checkpoint messages** within a task. When Cline creates checkpoints during a task, each checkpoint message has an option to explain the changes made since the previous checkpoint. This uses the same diff view and inline comments but compares checkpoint hashes rather than git refs.
+
+## Use Cases
+
+- **Code review** — Understand what a PR or commit does before approving it
+- **Onboarding** — Explore unfamiliar codebases by explaining recent changes
+- **Learning** — See explanations of how specific patterns or features were implemented
+- **Debugging** — Understand what changed between a working and broken state
+- **Documentation** — Generate explanations you can reference later when maintaining code
+
+## Tips
+
+- **Provide context in your prompt.** The more specific you are ("Explain the auth changes in PR #42"), the more focused Cline's investigation will be.
+- **Use `@` mentions.** Point Cline at specific files to give it additional context before generating explanations.
+- **Reply to comments.** The interactive threads let you dig deeper into any change you don't fully understand.
+
+## Related
+
+- [Using Commands](/core-workflows/using-commands) — All available slash commands
+- [Checkpoints](/core-workflows/checkpoints) — Git-based snapshots of your project during tasks
+- [Plan & Act Mode](/core-workflows/plan-and-act) — Cline's dual-mode system for structured development


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

### Description

Adds a dedicated documentation page for the **Explain Changes** feature (`/explain-changes` slash command), which previously had no dedicated docs page despite being a fully shipped, user-facing capability.

**Changes:**
- **New page** `docs/features/explain-changes.mdx` covering:
  - How to use the `/explain-changes` slash command with examples
  - Supported git reference formats (commits, branches, tags, PRs, relative refs)
  - Understanding the output (multi-file diff view, streaming inline comments, interactive reply threads)
  - Checkpoint-based explanations (explaining changes within a task)
  - Use cases and tips
- **Updated** `docs/docs.json`:
  - Added `features/explain-changes` to the Features navigation group
  - Updated the existing redirect from `/features/slash-commands/explain-changes` to point to the new dedicated page instead of `using-commands#explain-changes`
- **Updated** `docs/core-workflows/using-commands.mdx`:
  - Fixed the `/explain-changes` section link to point to the new page instead of a broken self-referencing anchor

All technical details were cross-referenced against source code: `explainChanges.ts`, `explainChangesShared.ts`, `generate_explanation.ts`, `commands.ts`, and `src/core/slash-commands/index.ts`.

### Test Procedure

- Verified all YAML frontmatter fields (`title`, `sidebarTitle`, `description`) are present
- Verified internal links reference existing pages (`/core-workflows/using-commands`, `/core-workflows/checkpoints`, `/core-workflows/plan-and-act`)
- Verified `docs.json` navigation entry and redirect are correctly structured
- Page can be validated locally with `cd docs && npx mintlify dev`

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [x] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A — documentation-only change.

### Additional Notes

This is PR 5 of 6 from a documentation gap analysis identifying high-impact features with little to no documentation. The page follows the established Mintlify `.mdx` format consistent with other feature pages like `deep-planning.mdx`.
