### PR TITLE
fix(cli): ignore api_req_failed history on resume

### DIFF
--- a/cli/src/utils/plain-text-task.ts
+++ b/cli/src/utils/plain-text-task.ts
@@ -102,7 +102,9 @@ export async function runPlainTextTask(options: PlainTextTaskOptions): Promise<b
 				completionResolve()
 			}
 		} else if (message.say === "error" || message.ask === "api_req_failed") {
-			completionReject(message.text ?? "message.say error || message.ask api_req_failed")
+			if (isViewTaskOnly || ts > completionCutoffTs) {
+				completionReject(message.text ?? "message.say error || message.ask api_req_failed")
+			}
 		}
 	}
 

--- a/src/core/task/index.ts
+++ b/src/core/task/index.ts
@@ -1183,7 +1183,7 @@ export class Task {
 			// Optionally, inform the user or handle the error appropriately
 		}
 
-		const savedClineMessages = await getSavedClineMessages(this.taskId)
+		let savedClineMessages = await getSavedClineMessages(this.taskId)
 
 		// Remove any resume messages that may have been added before
 
@@ -1194,6 +1194,9 @@ export class Task {
 		if (lastRelevantMessageIndex !== -1) {
 			savedClineMessages.splice(lastRelevantMessageIndex + 1)
 		}
+
+		// Remove any stale api_req_failed asks so resume doesn't immediately crash
+		savedClineMessages = savedClineMessages.filter((message) => message.ask !== "api_req_failed")
 
 		// since we don't use api_req_finished anymore, we need to check if the last api_req_started has a cost value, if it doesn't and no cancellation reason to present, then we remove it since it indicates an api request without any partial content streamed
 		const lastApiReqStartedIndex = findLastIndex(savedClineMessages, (m) => m.type === "say" && m.say === "api_req_started")


### PR DESCRIPTION
### Related Issue

**Issue:** #9948

### Description

Stale `api_req_failed` asks can linger in `ui_messages.json` and cause an immediate failure when resuming. This drops those stale asks during resume so tasks can continue normally.

### Test Procedure

Not run (logic-only change).

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A

### Additional Notes

Mirrors the manual workaround from the issue (`jq 'map(select(.ask != "api_req_failed"))'`).
