### PR TITLE
fix(cli): ignore pre-resume api failures in plain text

### DIFF
--- a/cli/src/utils/plain-text-task.ts
+++ b/cli/src/utils/plain-text-task.ts
@@ -102,7 +102,9 @@ export async function runPlainTextTask(options: PlainTextTaskOptions): Promise<b
 				completionResolve()
 			}
 		} else if (message.say === "error" || message.ask === "api_req_failed") {
-			completionReject(message.text ?? "message.say error || message.ask api_req_failed")
+			if (isViewTaskOnly || ts > completionCutoffTs) {
+				completionReject(message.text ?? "message.say error || message.ask api_req_failed")
+			}
 		}
 	}
 

--- a/cli/src/utils/plain-text-task.ts
+++ b/cli/src/utils/plain-text-task.ts
@@ -59,9 +59,11 @@ export async function runPlainTextTask(options: PlainTextTaskOptions): Promise<b
 
 	const isViewTaskOnly = Boolean(options.taskId) && !prompt
 
-	// When resuming a task, we need to ignore completion_result messages that existed
-	// before we sent our new prompt. This timestamp marks the cutoff - only completion
-	// results AFTER this time should trigger task completion.
+	// When resuming a task, ignore completion/error messages that already existed
+	// before we sent a new prompt.
+	const shouldIgnoreHistory = Boolean(options.taskId && prompt)
+	let initialHistoryTs: Set<number> | null = shouldIgnoreHistory ? null : null
+	// Fallback cutoff for non-resume flows (used when not ignoring history)
 	const completionCutoffTs = Date.now()
 
 	const emitTaskStarted = () => {
@@ -95,15 +97,20 @@ export async function runPlainTextTask(options: PlainTextTaskOptions): Promise<b
 		processedMessages.set(ts, message.text ?? "")
 
 		// Check for completion (only on non-partial messages)
-		// When resuming a task, only consider completion_result messages that appeared
-		// AFTER we sent our resume message (ts > completionCutoffTs)
-		if (message.say === "completion_result" || message.ask === "completion_result") {
-			if (isViewTaskOnly || ts > completionCutoffTs) {
-				completionResolve()
-			}
-		} else if (message.say === "error" || message.ask === "api_req_failed") {
-			if (isViewTaskOnly || ts > completionCutoffTs) {
-				completionReject(message.text ?? "message.say error || message.ask api_req_failed")
+		// When resuming a task, only consider completion/error messages that are NOT
+		// part of the pre-resume history.
+		const isHistorical = shouldIgnoreHistory && initialHistoryTs ? initialHistoryTs.has(ts) : false
+		const shouldEvaluateCompletion =
+			!shouldIgnoreHistory || (initialHistoryTs ? !isHistorical : false)
+		if (shouldEvaluateCompletion) {
+			if (message.say === "completion_result" || message.ask === "completion_result") {
+				if (isViewTaskOnly || ts > completionCutoffTs) {
+					completionResolve()
+				}
+			} else if (message.say === "error" || message.ask === "api_req_failed") {
+				if (isViewTaskOnly || ts > completionCutoffTs) {
+					completionReject(message.text ?? "message.say error || message.ask api_req_failed")
+				}
 			}
 		}
 	}
@@ -138,6 +145,11 @@ export async function runPlainTextTask(options: PlainTextTaskOptions): Promise<b
 			// Load the existing task
 			await showTaskWithId(controller, StringRequest.create({ value: options.taskId }))
 			emitTaskStarted()
+
+			if (shouldIgnoreHistory && controller.task) {
+				const existingMessages = controller.task.messageStateHandler.getClineMessages()
+				initialHistoryTs = new Set(existingMessages.map((message) => message.ts || 0))
+			}
 
 			// If a prompt was provided, send it as a message to the resumed task
 			if (prompt && controller.task) {

--- a/src/core/task/index.ts
+++ b/src/core/task/index.ts
@@ -1183,7 +1183,7 @@ export class Task {
 			// Optionally, inform the user or handle the error appropriately
 		}
 
-		const savedClineMessages = await getSavedClineMessages(this.taskId)
+		let savedClineMessages = await getSavedClineMessages(this.taskId)
 
 		// Remove any resume messages that may have been added before
 
@@ -1194,6 +1194,9 @@ export class Task {
 		if (lastRelevantMessageIndex !== -1) {
 			savedClineMessages.splice(lastRelevantMessageIndex + 1)
 		}
+
+		// Remove any stale api_req_failed asks so resume doesn't immediately crash
+		savedClineMessages = savedClineMessages.filter((message) => message.ask !== "api_req_failed")
 
 		// since we don't use api_req_finished anymore, we need to check if the last api_req_started has a cost value, if it doesn't and no cancellation reason to present, then we remove it since it indicates an api request without any partial content streamed
 		const lastApiReqStartedIndex = findLastIndex(savedClineMessages, (m) => m.type === "say" && m.say === "api_req_started")


### PR DESCRIPTION
### Related Issue

**Issue:** #9948

### Description

Plain-text resume mode was treating historical `api_req_failed` asks as fresh errors. When resuming, that could immediately abort the run even though the error occurred before the new prompt. This change records the initial message history after loading a task and ignores completion/error checks for those historical messages.

### Test Procedure

Not run (logic-only change in plain-text task runner).

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A

### Additional Notes

N/A