### PR TITLE
fix(api): stop retrying long retry-after 429s

### DIFF
--- a/src/core/api/retry.test.ts
+++ b/src/core/api/retry.test.ts
@@ -145,6 +145,34 @@ describe("Retry Decorator", () => {
 			result.should.deepEqual(["success after retry"])
 		})
 
+		it("should not retry when retry-after exceeds the stop threshold", async () => {
+			const setTimeoutSpy = sinon.spy(global, "setTimeout")
+			let callCount = 0
+
+			class TestClass {
+				@withRetry({ maxRetries: 2, baseDelay: 10 })
+				async *failMethod() {
+					callCount++
+					const error: any = new Error("Rate limit exceeded")
+					error.status = 429
+					error.headers = { "retry-after": "3600" }
+					throw error
+				}
+			}
+
+			const test = new TestClass()
+			try {
+				for await (const _ of test.failMethod()) {
+					// Should not reach here
+				}
+				throw new Error("Should have thrown")
+			} catch (error: any) {
+				error.message.should.equal("Rate limit exceeded")
+				callCount.should.equal(1)
+				setTimeoutSpy.called.should.be.false
+			}
+		})
+
 		it("should use exponential backoff when no retry-after header", async () => {
 			const setTimeoutSpy = sinon.spy(global, "setTimeout")
 			let callCount = 0

--- a/src/core/api/retry.test.ts
+++ b/src/core/api/retry.test.ts
@@ -113,7 +113,8 @@ describe("Retry Decorator", () => {
 			const setTimeoutSpy = sinon.spy(global, "setTimeout")
 			let callCount = 0
 			const fixedDate = new Date("2010-01-01T00:00:00.000Z")
-			const retryTimestamp = Math.floor(fixedDate.getTime() / 1000) + 0.01 // 10ms in the future
+			const clock = sinon.useFakeTimers({ now: fixedDate })
+			const retryTimestamp = Math.floor(fixedDate.getTime() / 1000) + 1 // 1s in the future
 			const baseDelay = 1000
 
 			class TestClass {
@@ -140,9 +141,10 @@ describe("Retry Decorator", () => {
 
 			setTimeoutSpy.calledOnce.should.be.true
 			const [_, delay] = setTimeoutSpy.getCall(0).args
-			delay?.should.equal(fixedDate.getTime())
+			delay?.should.equal(1000)
 
 			result.should.deepEqual(["success after retry"])
+			clock.restore()
 		})
 
 		it("should not retry when retry-after exceeds the stop threshold", async () => {

--- a/src/core/api/retry.ts
+++ b/src/core/api/retry.ts
@@ -14,6 +14,8 @@ const DEFAULT_OPTIONS: Required<RetryOptions> = {
 	retryAllErrors: false,
 }
 
+const STOP_THRESHOLD_MS = 5 * 60 * 1000
+
 export class RetriableError extends Error {
 	status: number = 429
 	retryAfter?: number
@@ -63,6 +65,10 @@ export function withRetry(options: RetryOptions = {}) {
 						} else {
 							// Delta seconds
 							delay = retryValue * 1000
+						}
+
+						if (delay > STOP_THRESHOLD_MS) {
+							throw error
 						}
 					} else {
 						// Use exponential backoff if no header


### PR DESCRIPTION
### Related Issue

**Issue:** #10139

### Description

Add a stop threshold for long retry-after values so quota exhaustion surfaces immediately instead of consuming retry attempts. Also adds a regression test for the long retry-after case.

### Test Procedure

- Not run (unit test added in src/core/api/retry.test.ts).

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (
> claude-dev@3.77.0 pretest
> npm run compile && npm run compile-tests && npm run compile-standalone && npm run lint


> claude-dev@3.77.0 compile
> npm run check-types && npm run lint && node esbuild.mjs


> claude-dev@3.77.0 check-types
> npm run protos && npx tsc --noEmit && cd webview-ui && npx tsc --noEmit && cd ../cli && npx tsc --noEmit


> claude-dev@3.77.0 protos
> node scripts/build-proto.mjs) and code is formatted and linted (
> claude-dev@3.77.0 format
> biome format --changed --no-errors-on-unmatched --files-ignore-unknown=true --diagnostic-level=error)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A

### Additional Notes

N/A
