### PR TITLE
fix(api): stop retrying on long retry-after

### DIFF
--- a/src/core/api/retry.ts
+++ b/src/core/api/retry.ts
@@ -14,6 +14,8 @@ const DEFAULT_OPTIONS: Required<RetryOptions> = {
 	retryAllErrors: false,
 }
 
+const STOP_THRESHOLD_MS = 5 * 60 * 1000
+
 export class RetriableError extends Error {
 	status: number = 429
 	retryAfter?: number
@@ -63,6 +65,10 @@ export function withRetry(options: RetryOptions = {}) {
 						} else {
 							// Delta seconds
 							delay = retryValue * 1000
+						}
+
+						if (delay > STOP_THRESHOLD_MS) {
+							throw error
 						}
 					} else {
 						// Use exponential backoff if no header


### PR DESCRIPTION
### Related Issue

**Issue:** #10139

### Description

Stops retrying 429s when a retry-after header indicates a long wait (over 5 minutes), so quota-exhaustion errors surface immediately instead of burning retry attempts.

### Test Procedure

Not run (not available in this environment).

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (
> claude-dev@3.77.0 pretest
> npm run compile && npm run compile-tests && npm run compile-standalone && npm run lint


> claude-dev@3.77.0 compile
> npm run check-types && npm run lint && node esbuild.mjs


> claude-dev@3.77.0 check-types
> npm run protos && npx tsc --noEmit && cd webview-ui && npx tsc --noEmit && cd ../cli && npx tsc --noEmit


> claude-dev@3.77.0 protos
> node scripts/build-proto.mjs) and code is formatted and linted (
> claude-dev@3.77.0 format
> biome format --changed --no-errors-on-unmatched --files-ignore-unknown=true --diagnostic-level=error)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A

### Additional Notes

None.