### PR TITLE
fix(plan-mode): prevent repeated restricted-tool error rows during streaming

### DIFF
--- a/src/core/task/ToolExecutor.ts
+++ b/src/core/task/ToolExecutor.ts
@@ -348,7 +348,7 @@ export class ToolExecutor {
 			) {
 				const errorMessage = `Tool '${block.name}' is not available in PLAN MODE. This tool is restricted to ACT MODE for file modifications. Only use tools available for PLAN MODE when in that mode.`
 				await this.removeLastPartialMessageIfExistsWithType("say", "error")
-				await this.say("error", errorMessage)
+				await this.say("error", errorMessage, undefined, undefined, block.partial)
 				// Only push the final error message when the streaming is done.
 				if (!block.partial) {
 					this.pushToolResult(formatResponse.toolError(errorMessage), block)


### PR DESCRIPTION
### Related Issue

Issue: N/A

### Description

This PR fixes noisy repeated error messages in plan mode when a restricted file-modification tool is emitted as a streaming native tool call.

What was happening:
- In strict plan mode, restricted tools like `apply_patch` are blocked in `ToolExecutor`.
- During streaming, partial tool chunks repeatedly hit the same restriction branch.
- The branch emitted `say("error", ...)` as a non-partial message each time, so the UI showed many duplicate error rows.

What changed:
- The plan-mode restriction error now mirrors the tool block streaming state by passing `block.partial` into `say`.
- Partial chunks now update a single partial error message, and the final non-partial chunk finalizes it once.
- Final tool-result behavior is unchanged: it is still pushed only on the non-partial block.

Why this approach:
- It is the smallest possible behavioral fix for the spammy UX.
- It does not change tool gating logic, mode restrictions, or result semantics.

### Test Procedure

I validated this change with:
- `npm run test:unit -- src/core/task/__tests__/ToolExecutor.test.ts`
- `npx biome lint --diagnostic-level=error src/core/task/ToolExecutor.ts`
- `npm run check-types`

Risk review:
- Verified the change path only affects plan-mode restricted-tool error rendering.
- Verified no additional files or settings changed.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor Changes
- [ ] Cosmetic Changes
- [ ] Documentation update
- [ ] Workflow Changes

### Pre-flight Checklist

- [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
- [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
- [x] I have reviewed contributor guidelines

### Screenshots

N/A

### Additional Notes

This intentionally addresses only the UI spam behavior. It does not yet hide mode-incompatible tools from the plan-mode tool list.
