### PR TITLE
docs: update auto-approve menu with notification toggle location

### DIFF
--- a/docs/features/auto-approve.mdx
+++ b/docs/features/auto-approve.mdx
@@ -26,7 +26,7 @@ A few details matter:
 
 - **Workspace vs outside workspace**: "Read all files" and "Edit all files" only extend the base toggle. If the base toggle is off, the "all files" option does nothing.
 - **Terminal commands**: Cline treats commands as either safe or requiring approval. "Execute safe commands" covers safe commands. "Execute all commands" extends to commands flagged as requiring approval.
-- **Notifications**: If enabled, Cline sends OS-level notifications when approval is required, and when an auto-approved terminal command has been running for 30 seconds.
+- **Notifications**: The "Enable notifications" toggle is located at the bottom of the Auto Approve menu, below a separator line. When enabled, Cline sends OS-level notifications when approval is required, and when an auto-approved terminal command has been running for 30 seconds.
 
 ## Permissions
 
@@ -40,7 +40,7 @@ A few details matter:
 | Execute all commands | Run commands requiring approval (requires base toggle) |
 | Use the browser | Browser tool for web fetching and searching |
 | Use MCP servers | MCP tools and resources |
-| Enable notifications | Notifies you about long-running commands |
+| Enable notifications | Notifies you about long-running commands (toggle at bottom of Auto Approve menu) |
 
 <Warning>
 "Read all files" and "Edit all files" only matter if their base toggle is enabled. They extend access outside your workspace.


### PR DESCRIPTION
Fixes #7810

Updates `docs/features/auto-approve.mdx` to reflect that the "Enable notifications" toggle has been moved from General Settings into the Auto Approve menu itself.

## Changes

- Updated the **Notifications** bullet in "How It Works" to note the toggle is at the bottom of the Auto Approve menu, below a separator line
- Updated the **Enable notifications** row in the permissions table to clarify the toggle location

## Context

The notification toggle was moved inline into the auto-approve menu in PR #7812 for better discoverability. A previous docs PR (#8445) addressed this, but the changes were overwritten by a later commit (#10057) that regenerated the docs directory. This PR re-applies the documentation update.