### PR TITLE
fix(cli): update kanban migration copy to not imply TUI deprecation

### DIFF
--- a/cli/src/components/KanbanMigrationView.tsx
+++ b/cli/src/components/KanbanMigrationView.tsx
@@ -30,7 +30,7 @@ const InternalKanbanMigrationView: React.FC<Pick<KanbanMigrationViewProps, "onSe
 			},
 			{
 				label: "Exit",
-				description: "Close and rerun with cline --tui if you want the old CLI.",
+				description: "You can always run cline --tui for the terminal experience.",
 				value: "exit",
 			},
 		],
@@ -60,7 +60,7 @@ const InternalKanbanMigrationView: React.FC<Pick<KanbanMigrationViewProps, "onSe
 			<StaticRobotFrame />
 			<Text> </Text>
 			<Text bold color="white">
-				Cline is moving out of the terminal. Introducing Cline Kanban.
+				Introducing Cline Kanban!
 			</Text>
 			<Text color="gray">A board for orchestrating coding agents across worktrees, right from your browser.</Text>
 			<Text> </Text>


### PR DESCRIPTION
### Related Issue

N/A - internal copy fix

### Description

The kanban migration view shown to existing CLI users had copy that implied the terminal TUI was being deprecated:

- "Cline is moving out of the terminal. Introducing Cline Kanban." → "Introducing Cline Kanban!"
- "Close and rerun with cline --tui if you want the old CLI." → "You can always run cline --tui for the terminal experience."

The word "old" and "moving out of the terminal" framing made it sound like TUI was going away, which it isn't. The new copy positions Kanban as the new default while making clear the TUI remains a first-class option.

### Test Procedure

- Run `cline` as an existing user who hasn't seen the migration view yet
- Verify the updated copy reads naturally and doesn't imply TUI deprecation
- Verify "Open the new experience" launches Kanban and "Exit" exits cleanly

### Type of Change

-   [x] 💅 Cosmetic Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)