### PR TITLE
fix: update KanbanMigrationView test to match component text

### DIFF
--- a/cli/src/components/KanbanMigrationView.test.tsx
+++ b/cli/src/components/KanbanMigrationView.test.tsx
@@ -8,11 +8,11 @@ describe("KanbanMigrationView", () => {
 		const onSelect = vi.fn()
 		const { lastFrame } = render(createElement(KanbanMigrationView, { isRawModeSupported: true, onSelect }))
 
-		expect(lastFrame()).toContain("Cline is moving out of the terminal. Introducing Cline Kanban.")
+		expect(lastFrame()).toContain("Introducing Cline Kanban!")
 		expect(lastFrame()).toContain("Open the new experience")
 		expect(lastFrame()).toContain("Launch Cline Kanban and start there by default.")
 		expect(lastFrame()).toContain("cline --tui")
-		expect(lastFrame()).toContain("Close and rerun with cline --tui if you want the old CLI.")
+		expect(lastFrame()).toContain("You can always run cline --tui for the terminal experience.")
 		expect(lastFrame()).toContain("Exit")
 	})
 


### PR DESCRIPTION
## Summary

`#10161` updated the KanbanMigrationView component copy but missed updating the test assertions. This breaks CI on `main` and any branch based on it.

## Changes

- `cli/src/components/KanbanMigrationView.test.tsx`: Updated test assertions to match the current component text:
  - `"Cline is moving out of the terminal. Introducing Cline Kanban."` → `"Introducing Cline Kanban!"`
  - `"Close and rerun with cline --tui if you want the old CLI."` → `"You can always run cline --tui for the terminal experience."`

## Evidence

Latest Tests run on `main` (run 24055422662) fails:
```
FAIL src/components/KanbanMigrationView.test.tsx > KanbanMigrationView > renders the migration options
AssertionError: expected '...' to contain 'Cline is moving out of the terminal. ...'
```