### PR TITLE
feat(uri): add /lg-task webhook integration for LG dashboard flow

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -53,7 +53,7 @@ import { ExtensionRegistryInfo } from "./registry"
 import { AuthService } from "./services/auth/AuthService"
 import { LogoutReason } from "./services/auth/types"
 import { telemetryService } from "./services/telemetry"
-import { SharedUriHandler, TASK_URI_PATH } from "./services/uri/SharedUriHandler"
+import { LG_TASK_URI_PATH, SharedUriHandler, TASK_URI_PATH } from "./services/uri/SharedUriHandler"
 import { ShowMessageType } from "./shared/proto/host/window"
 import { fileExistsAtPath } from "./utils/fs"
 
@@ -160,7 +160,8 @@ export async function activate(context: vscode.ExtensionContext) {
 
 	const handleUri = async (uri: vscode.Uri) => {
 		const url = decodeURIComponent(uri.toString())
-		const isTaskUri = getUriPath(url) === TASK_URI_PATH
+		const uriPath = getUriPath(url)
+		const isTaskUri = uriPath === TASK_URI_PATH || uriPath === LG_TASK_URI_PATH
 
 		if (isTaskUri) {
 			await openClineSidebarForTaskUri()

--- a/src/services/lg-cns-integration/webhook-hooks.ts
+++ b/src/services/lg-cns-integration/webhook-hooks.ts
@@ -1,10 +1,48 @@
-export type LgHookScript = {
+import fs from "fs/promises"
+import path from "path"
+import { ensureHooksDirectoryExists, getDocumentsPath } from "@/core/storage/disk"
+
+type LgHookScript = {
 	fileName: string
 	content: string
 	mode?: number
 }
 
-export function getLgWebhookHookScripts(): LgHookScript[] {
+export async function writeLgWebhookConfig(webhookUrl: string, webhookToken: string): Promise<void> {
+	const documentsPath = await getDocumentsPath()
+	const clineDir = path.join(documentsPath, "Cline")
+	const configPath = path.join(clineDir, "webhook_config.json")
+
+	await fs.mkdir(clineDir, { recursive: true })
+	await fs.writeFile(
+		configPath,
+		JSON.stringify(
+			{
+				webhook_url: webhookUrl,
+				webhook_token: webhookToken,
+				created_at: new Date().toISOString(),
+			},
+			null,
+			2,
+		),
+		"utf-8",
+	)
+}
+
+export async function writeLgWebhookHooks(): Promise<void> {
+	const hooksDir = await ensureHooksDirectoryExists()
+	const hooks = getLgWebhookHookScripts()
+
+	for (const hook of hooks) {
+		const hookPath = path.join(hooksDir, hook.fileName)
+		await fs.writeFile(hookPath, hook.content, "utf-8")
+		if (hook.mode !== undefined) {
+			await fs.chmod(hookPath, hook.mode)
+		}
+	}
+}
+
+function getLgWebhookHookScripts(): LgHookScript[] {
 	if (process.platform === "win32") {
 		return [
 			{ fileName: "TaskStart.ps1", content: TASK_START_POWERSHELL },

--- a/src/services/uri/SharedUriHandler.test.ts
+++ b/src/services/uri/SharedUriHandler.test.ts
@@ -4,11 +4,10 @@ import { afterEach, beforeEach, describe, it } from "mocha"
 import os from "os"
 import path from "path"
 import * as sinon from "sinon"
-import * as disk from "@/core/storage/disk"
 import { WebviewProvider } from "@/core/webview"
+import * as webhookHooks from "@/services/lg-cns-integration/webhook-hooks"
 import { Logger } from "@/shared/services/Logger"
 import { ErrorService } from "../error"
-import * as lgWebhookHooks from "./lgWebhookHooks"
 import { SharedUriHandler } from "./SharedUriHandler"
 
 describe("SharedUriHandler", () => {
@@ -120,18 +119,10 @@ describe("SharedUriHandler", () => {
 				const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "lg-task-uri-"))
 				try {
 					const promptFilePath = path.join(tempDir, "lg-spec.md")
-					const documentsPath = path.join(tempDir, "Documents")
-					const hooksDir = path.join(documentsPath, "Cline", "Hooks")
-					await fs.mkdir(hooksDir, { recursive: true })
 					await fs.writeFile(promptFilePath, "Implement user registration flow", "utf-8")
 
-					sandbox.stub(disk, "getDocumentsPath").resolves(documentsPath)
-					sandbox.stub(disk, "ensureHooksDirectoryExists").resolves(hooksDir)
-					sandbox.stub(lgWebhookHooks, "getLgWebhookHookScripts").returns([
-						{ fileName: "TaskStart", content: "taskstart", mode: 0o755 },
-						{ fileName: "PostToolUse", content: "posttooluse" },
-						{ fileName: "TaskComplete", content: "taskcomplete" },
-					])
+					const writeConfigStub = sandbox.stub(webhookHooks, "writeLgWebhookConfig").resolves()
+					const writeHooksStub = sandbox.stub(webhookHooks, "writeLgWebhookHooks").resolves()
 
 					const result = await SharedUriHandler.handleUri(
 						`vscode://cline.cline/lg-task?prompt-file=${encodeURIComponent(
@@ -145,32 +136,24 @@ describe("SharedUriHandler", () => {
 					expect(taskPrompt).to.contain(promptFilePath)
 					expect(taskPrompt).to.contain("Implement user registration flow")
 					expect(taskPrompt).to.contain("re-read")
-
-					const configJson = JSON.parse(
-						await fs.readFile(path.join(documentsPath, "Cline", "webhook_config.json"), "utf-8"),
-					)
-					expect(configJson.webhook_url).to.equal(webhookUrl)
-					expect(configJson.webhook_token).to.equal(webhookToken)
-					expect(configJson.created_at).to.be.a("string")
-
-					expect(await fs.readFile(path.join(hooksDir, "TaskStart"), "utf-8")).to.equal("taskstart")
-					expect(await fs.readFile(path.join(hooksDir, "PostToolUse"), "utf-8")).to.equal("posttooluse")
-					expect(await fs.readFile(path.join(hooksDir, "TaskComplete"), "utf-8")).to.equal("taskcomplete")
-
-					const taskStartStats = await fs.stat(path.join(hooksDir, "TaskStart"))
-					expect(taskStartStats.mode & 0o111).to.not.equal(0)
+					sinon.assert.calledOnceWithExactly(writeConfigStub, webhookUrl, webhookToken)
+					sinon.assert.calledOnce(writeHooksStub)
 				} finally {
 					await fs.rm(tempDir, { recursive: true, force: true })
 				}
 			})
 
 			it("should return false when LG task parameters are missing", async () => {
+				const writeConfigStub = sandbox.stub(webhookHooks, "writeLgWebhookConfig").resolves()
+				const writeHooksStub = sandbox.stub(webhookHooks, "writeLgWebhookHooks").resolves()
 				const result = await SharedUriHandler.handleUri(
 					"vscode://cline.cline/lg-task?prompt-file=%2Ftmp%2Fspec.md&webhook-url=https%3A%2F%2Fexample.com",
 				)
 
 				expect(result).to.be.false
 				expect(handleTaskCreationStub.called).to.be.false
+				expect(writeConfigStub.called).to.be.false
+				expect(writeHooksStub.called).to.be.false
 			})
 		})
 

--- a/src/services/uri/SharedUriHandler.test.ts
+++ b/src/services/uri/SharedUriHandler.test.ts
@@ -1,15 +1,21 @@
 import { expect } from "chai"
+import * as fs from "fs/promises"
 import { afterEach, beforeEach, describe, it } from "mocha"
+import os from "os"
+import path from "path"
 import * as sinon from "sinon"
+import * as disk from "@/core/storage/disk"
 import { WebviewProvider } from "@/core/webview"
 import { Logger } from "@/shared/services/Logger"
 import { ErrorService } from "../error"
+import * as lgWebhookHooks from "./lgWebhookHooks"
 import { SharedUriHandler } from "./SharedUriHandler"
 
 describe("SharedUriHandler", () => {
 	let sandbox: sinon.SinonSandbox
 	let handleOpenRouterCallbackStub: sinon.SinonStub
 	let handleAuthCallbackStub: sinon.SinonStub
+	let handleTaskCreationStub: sinon.SinonStub
 
 	beforeEach(async () => {
 		sandbox = sinon.createSandbox()
@@ -34,10 +40,12 @@ describe("SharedUriHandler", () => {
 
 		handleOpenRouterCallbackStub = sandbox.stub().resolves()
 		handleAuthCallbackStub = sandbox.stub().resolves()
+		handleTaskCreationStub = sandbox.stub().resolves()
 		const mockWebviewProvider = {
 			controller: {
 				handleOpenRouterCallback: handleOpenRouterCallbackStub,
 				handleAuthCallback: handleAuthCallbackStub,
+				handleTaskCreation: handleTaskCreationStub,
 			},
 		} as any
 		sandbox.stub(WebviewProvider, "getVisibleInstance").returns(mockWebviewProvider)
@@ -102,6 +110,63 @@ describe("SharedUriHandler", () => {
 				expect(result).to.be.false
 				expect(handleAuthCallbackStub.called).to.be.false
 				expect(handleOpenRouterCallbackStub.called).to.be.false
+			})
+		})
+
+		describe("LG task URI handling", () => {
+			it("should setup webhook files and create task from prompt-file", async () => {
+				const webhookUrl = "https://example.com/api/updates"
+				const webhookToken = "token-123"
+				const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "lg-task-uri-"))
+				try {
+					const promptFilePath = path.join(tempDir, "lg-spec.md")
+					const documentsPath = path.join(tempDir, "Documents")
+					const hooksDir = path.join(documentsPath, "Cline", "Hooks")
+					await fs.mkdir(hooksDir, { recursive: true })
+					await fs.writeFile(promptFilePath, "Implement user registration flow", "utf-8")
+
+					sandbox.stub(disk, "getDocumentsPath").resolves(documentsPath)
+					sandbox.stub(disk, "ensureHooksDirectoryExists").resolves(hooksDir)
+					sandbox.stub(lgWebhookHooks, "getLgWebhookHookScripts").returns([
+						{ fileName: "TaskStart", content: "taskstart", mode: 0o755 },
+						{ fileName: "PostToolUse", content: "posttooluse" },
+						{ fileName: "TaskComplete", content: "taskcomplete" },
+					])
+
+					const result = await SharedUriHandler.handleUri(
+						`vscode://cline.cline/lg-task?prompt-file=${encodeURIComponent(
+							promptFilePath,
+						)}&webhook-url=${encodeURIComponent(webhookUrl)}&webhook-token=${encodeURIComponent(webhookToken)}`,
+					)
+
+					expect(result).to.be.true
+					sinon.assert.calledOnceWithExactly(handleTaskCreationStub, "Implement user registration flow")
+
+					const configJson = JSON.parse(
+						await fs.readFile(path.join(documentsPath, "Cline", "webhook_config.json"), "utf-8"),
+					)
+					expect(configJson.webhook_url).to.equal(webhookUrl)
+					expect(configJson.webhook_token).to.equal(webhookToken)
+					expect(configJson.created_at).to.be.a("string")
+
+					expect(await fs.readFile(path.join(hooksDir, "TaskStart"), "utf-8")).to.equal("taskstart")
+					expect(await fs.readFile(path.join(hooksDir, "PostToolUse"), "utf-8")).to.equal("posttooluse")
+					expect(await fs.readFile(path.join(hooksDir, "TaskComplete"), "utf-8")).to.equal("taskcomplete")
+
+					const taskStartStats = await fs.stat(path.join(hooksDir, "TaskStart"))
+					expect(taskStartStats.mode & 0o111).to.not.equal(0)
+				} finally {
+					await fs.rm(tempDir, { recursive: true, force: true })
+				}
+			})
+
+			it("should return false when LG task parameters are missing", async () => {
+				const result = await SharedUriHandler.handleUri(
+					"vscode://cline.cline/lg-task?prompt-file=%2Ftmp%2Fspec.md&webhook-url=https%3A%2F%2Fexample.com",
+				)
+
+				expect(result).to.be.false
+				expect(handleTaskCreationStub.called).to.be.false
 			})
 		})
 

--- a/src/services/uri/SharedUriHandler.test.ts
+++ b/src/services/uri/SharedUriHandler.test.ts
@@ -140,7 +140,11 @@ describe("SharedUriHandler", () => {
 					)
 
 					expect(result).to.be.true
-					sinon.assert.calledOnceWithExactly(handleTaskCreationStub, "Implement user registration flow")
+					sinon.assert.calledOnce(handleTaskCreationStub)
+					const taskPrompt = handleTaskCreationStub.firstCall.args[0] as string
+					expect(taskPrompt).to.contain(promptFilePath)
+					expect(taskPrompt).to.contain("Implement user registration flow")
+					expect(taskPrompt).to.contain("re-read")
 
 					const configJson = JSON.parse(
 						await fs.readFile(path.join(documentsPath, "Cline", "webhook_config.json"), "utf-8"),

--- a/src/services/uri/SharedUriHandler.ts
+++ b/src/services/uri/SharedUriHandler.ts
@@ -107,7 +107,16 @@ export class SharedUriHandler {
 						return false
 					}
 
-					const prompt = await fs.readFile(promptFile, "utf-8")
+					const specContents = await fs.readFile(promptFile, "utf-8")
+					const prompt = [
+						`The following file contains the development specification you must implement: ${promptFile}`,
+						"",
+						"Start by reading that file from disk. If context compaction happens later, re-read the same file path so you can continue tracking progress against the original requirements.",
+						"",
+						"For convenience, here is the current file content:",
+						"",
+						specContents,
+					].join("\n")
 					await SharedUriHandler.writeLgWebhookConfig(webhookUrl, webhookToken)
 					await SharedUriHandler.writeLgWebhookHooks()
 					await visibleWebview.controller.handleTaskCreation(prompt)

--- a/src/services/uri/SharedUriHandler.ts
+++ b/src/services/uri/SharedUriHandler.ts
@@ -1,7 +1,12 @@
+import fs from "fs/promises"
+import path from "path"
+import { ensureHooksDirectoryExists, getDocumentsPath } from "@/core/storage/disk"
 import { WebviewProvider } from "@/core/webview"
 import { Logger } from "@/shared/services/Logger"
+import { getLgWebhookHookScripts } from "./lgWebhookHooks"
 
 export const TASK_URI_PATH = "/task"
+export const LG_TASK_URI_PATH = "/lg-task"
 
 /**
  * Shared URI handler that processes both VSCode URI events and HTTP server callbacks
@@ -92,6 +97,22 @@ export class SharedUriHandler {
 					Logger.warn("SharedUriHandler: Missing prompt parameter for task creation")
 					return false
 				}
+				case LG_TASK_URI_PATH: {
+					const promptFile = query.get("prompt-file")
+					const webhookUrl = query.get("webhook-url")
+					const webhookToken = query.get("webhook-token")
+
+					if (!promptFile || !webhookUrl || !webhookToken) {
+						Logger.warn("SharedUriHandler: Missing required parameters for LG task creation")
+						return false
+					}
+
+					const prompt = await fs.readFile(promptFile, "utf-8")
+					await SharedUriHandler.writeLgWebhookConfig(webhookUrl, webhookToken)
+					await SharedUriHandler.writeLgWebhookHooks()
+					await visibleWebview.controller.handleTaskCreation(prompt)
+					return true
+				}
 				// Match /mcp-auth/callback/{hash}
 				case path.match(/^\/mcp-auth\/callback\/[^/]+$/)?.input: {
 					const serverHash = path.split("/").pop()
@@ -122,6 +143,40 @@ export class SharedUriHandler {
 		} catch (error) {
 			Logger.error("SharedUriHandler: Error processing URI:", error)
 			return false
+		}
+	}
+
+	private static async writeLgWebhookConfig(webhookUrl: string, webhookToken: string): Promise<void> {
+		const documentsPath = await getDocumentsPath()
+		const clineDir = path.join(documentsPath, "Cline")
+		const configPath = path.join(clineDir, "webhook_config.json")
+
+		await fs.mkdir(clineDir, { recursive: true })
+		await fs.writeFile(
+			configPath,
+			JSON.stringify(
+				{
+					webhook_url: webhookUrl,
+					webhook_token: webhookToken,
+					created_at: new Date().toISOString(),
+				},
+				null,
+				2,
+			),
+			"utf-8",
+		)
+	}
+
+	private static async writeLgWebhookHooks(): Promise<void> {
+		const hooksDir = await ensureHooksDirectoryExists()
+		const hooks = getLgWebhookHookScripts()
+
+		for (const hook of hooks) {
+			const hookPath = path.join(hooksDir, hook.fileName)
+			await fs.writeFile(hookPath, hook.content, "utf-8")
+			if (hook.mode !== undefined) {
+				await fs.chmod(hookPath, hook.mode)
+			}
 		}
 	}
 }

--- a/src/services/uri/SharedUriHandler.ts
+++ b/src/services/uri/SharedUriHandler.ts
@@ -1,9 +1,7 @@
 import fs from "fs/promises"
-import path from "path"
-import { ensureHooksDirectoryExists, getDocumentsPath } from "@/core/storage/disk"
 import { WebviewProvider } from "@/core/webview"
+import { writeLgWebhookConfig, writeLgWebhookHooks } from "@/services/lg-cns-integration/webhook-hooks"
 import { Logger } from "@/shared/services/Logger"
-import { getLgWebhookHookScripts } from "./lgWebhookHooks"
 
 export const TASK_URI_PATH = "/task"
 export const LG_TASK_URI_PATH = "/lg-task"
@@ -117,8 +115,8 @@ export class SharedUriHandler {
 						"",
 						specContents,
 					].join("\n")
-					await SharedUriHandler.writeLgWebhookConfig(webhookUrl, webhookToken)
-					await SharedUriHandler.writeLgWebhookHooks()
+					await writeLgWebhookConfig(webhookUrl, webhookToken)
+					await writeLgWebhookHooks()
 					await visibleWebview.controller.handleTaskCreation(prompt)
 					return true
 				}
@@ -152,40 +150,6 @@ export class SharedUriHandler {
 		} catch (error) {
 			Logger.error("SharedUriHandler: Error processing URI:", error)
 			return false
-		}
-	}
-
-	private static async writeLgWebhookConfig(webhookUrl: string, webhookToken: string): Promise<void> {
-		const documentsPath = await getDocumentsPath()
-		const clineDir = path.join(documentsPath, "Cline")
-		const configPath = path.join(clineDir, "webhook_config.json")
-
-		await fs.mkdir(clineDir, { recursive: true })
-		await fs.writeFile(
-			configPath,
-			JSON.stringify(
-				{
-					webhook_url: webhookUrl,
-					webhook_token: webhookToken,
-					created_at: new Date().toISOString(),
-				},
-				null,
-				2,
-			),
-			"utf-8",
-		)
-	}
-
-	private static async writeLgWebhookHooks(): Promise<void> {
-		const hooksDir = await ensureHooksDirectoryExists()
-		const hooks = getLgWebhookHookScripts()
-
-		for (const hook of hooks) {
-			const hookPath = path.join(hooksDir, hook.fileName)
-			await fs.writeFile(hookPath, hook.content, "utf-8")
-			if (hook.mode !== undefined) {
-				await fs.chmod(hookPath, hook.mode)
-			}
 		}
 	}
 }

--- a/src/services/uri/lgWebhookHooks.ts
+++ b/src/services/uri/lgWebhookHooks.ts
@@ -1,0 +1,284 @@
+export type LgHookScript = {
+	fileName: string
+	content: string
+	mode?: number
+}
+
+export function getLgWebhookHookScripts(): LgHookScript[] {
+	if (process.platform === "win32") {
+		return [
+			{ fileName: "TaskStart.ps1", content: TASK_START_POWERSHELL },
+			{ fileName: "PostToolUse.ps1", content: POST_TOOL_USE_POWERSHELL },
+			{ fileName: "TaskComplete.ps1", content: TASK_COMPLETE_POWERSHELL },
+		]
+	}
+
+	return [
+		{ fileName: "TaskStart", content: TASK_START_NODE, mode: 0o755 },
+		{ fileName: "PostToolUse", content: POST_TOOL_USE_NODE, mode: 0o755 },
+		{ fileName: "TaskComplete", content: TASK_COMPLETE_NODE, mode: 0o755 },
+	]
+}
+
+const TASK_START_POWERSHELL = `try {
+    $rawInput = [Console]::In.ReadToEnd()
+    $inputData = $null
+    if ($rawInput) {
+        $inputData = $rawInput | ConvertFrom-Json -Depth 100
+    }
+} catch {
+    $inputData = $null
+}
+
+try {
+    $documentsPath = [System.Environment]::GetFolderPath([System.Environment+SpecialFolder]::MyDocuments)
+    if (-not $documentsPath) {
+        $documentsPath = Join-Path $HOME "Documents"
+    }
+
+    $configPath = Join-Path (Join-Path $documentsPath "Cline") "webhook_config.json"
+    if (-not (Test-Path $configPath)) {
+        @{ cancel = $false } | ConvertTo-Json -Compress
+        exit 0
+    }
+
+    $config = Get-Content $configPath -Raw | ConvertFrom-Json -Depth 100
+    if (-not $config.webhook_url -or -not $config.webhook_token) {
+        @{ cancel = $false } | ConvertTo-Json -Compress
+        exit 0
+    }
+
+    $workspaceRoots = @()
+    if ($inputData -and $null -ne $inputData.workspaceRoots) {
+        $workspaceRoots = $inputData.workspaceRoots
+    }
+
+    $taskMetadata = @{}
+    if ($inputData -and $inputData.taskStart -and $null -ne $inputData.taskStart.taskMetadata) {
+        $taskMetadata = $inputData.taskStart.taskMetadata
+    }
+
+    $payload = @{
+        event = "task_started"
+        timestamp = (Get-Date).ToUniversalTime().ToString("o")
+        data = @{
+            task_id = if ($inputData) { $inputData.taskId } else { $null }
+            cline_version = if ($inputData) { $inputData.clineVersion } else { $null }
+            workspace_roots = $workspaceRoots
+            task_metadata = $taskMetadata
+        }
+    }
+
+    $headers = @{
+        Authorization = "Bearer $($config.webhook_token)"
+        "Content-Type" = "application/json"
+    }
+
+    Invoke-RestMethod -Method Post -Uri $config.webhook_url -Headers $headers -Body ($payload | ConvertTo-Json -Depth 100) -ContentType "application/json" -TimeoutSec 5 | Out-Null
+} catch {}
+
+@{ cancel = $false } | ConvertTo-Json -Compress
+`
+
+const POST_TOOL_USE_POWERSHELL = `try {
+    $rawInput = [Console]::In.ReadToEnd()
+    $inputData = $null
+    if ($rawInput) {
+        $inputData = $rawInput | ConvertFrom-Json -Depth 100
+    }
+} catch {
+    $inputData = $null
+}
+
+try {
+    $documentsPath = [System.Environment]::GetFolderPath([System.Environment+SpecialFolder]::MyDocuments)
+    if (-not $documentsPath) {
+        $documentsPath = Join-Path $HOME "Documents"
+    }
+
+    $configPath = Join-Path (Join-Path $documentsPath "Cline") "webhook_config.json"
+    if (-not (Test-Path $configPath)) {
+        @{ cancel = $false } | ConvertTo-Json -Compress
+        exit 0
+    }
+
+    $config = Get-Content $configPath -Raw | ConvertFrom-Json -Depth 100
+    if (-not $config.webhook_url -or -not $config.webhook_token) {
+        @{ cancel = $false } | ConvertTo-Json -Compress
+        exit 0
+    }
+
+    $toolData = $null
+    if ($inputData -and $inputData.postToolUse) {
+        $toolData = $inputData.postToolUse
+    }
+
+    $payload = @{
+        event = "tool_executed"
+        timestamp = (Get-Date).ToUniversalTime().ToString("o")
+        data = @{
+            task_id = if ($inputData) { $inputData.taskId } else { $null }
+            tool_name = if ($toolData) { $toolData.toolName } else { $null }
+            parameters = if ($toolData -and $null -ne $toolData.parameters) { $toolData.parameters } else { @{} }
+            success = if ($toolData) { [bool]$toolData.success } else { $false }
+            execution_time_ms = if ($toolData) { $toolData.executionTimeMs } else { $null }
+        }
+    }
+
+    $headers = @{
+        Authorization = "Bearer $($config.webhook_token)"
+        "Content-Type" = "application/json"
+    }
+
+    Invoke-RestMethod -Method Post -Uri $config.webhook_url -Headers $headers -Body ($payload | ConvertTo-Json -Depth 100) -ContentType "application/json" -TimeoutSec 5 | Out-Null
+} catch {}
+
+@{ cancel = $false } | ConvertTo-Json -Compress
+`
+
+const TASK_COMPLETE_POWERSHELL = `try {
+    $rawInput = [Console]::In.ReadToEnd()
+    $inputData = $null
+    if ($rawInput) {
+        $inputData = $rawInput | ConvertFrom-Json -Depth 100
+    }
+} catch {
+    $inputData = $null
+}
+
+try {
+    $documentsPath = [System.Environment]::GetFolderPath([System.Environment+SpecialFolder]::MyDocuments)
+    if (-not $documentsPath) {
+        $documentsPath = Join-Path $HOME "Documents"
+    }
+
+    $configPath = Join-Path (Join-Path $documentsPath "Cline") "webhook_config.json"
+    if (-not (Test-Path $configPath)) {
+        @{ cancel = $false } | ConvertTo-Json -Compress
+        exit 0
+    }
+
+    $config = Get-Content $configPath -Raw | ConvertFrom-Json -Depth 100
+    if (-not $config.webhook_url -or -not $config.webhook_token) {
+        @{ cancel = $false } | ConvertTo-Json -Compress
+        exit 0
+    }
+
+    $taskMetadata = @{}
+    if ($inputData -and $inputData.taskComplete -and $null -ne $inputData.taskComplete.taskMetadata) {
+        $taskMetadata = $inputData.taskComplete.taskMetadata
+    }
+
+    $payload = @{
+        event = "task_completed"
+        timestamp = (Get-Date).ToUniversalTime().ToString("o")
+        data = @{
+            task_id = if ($inputData) { $inputData.taskId } else { $null }
+            task_metadata = $taskMetadata
+        }
+    }
+
+    $headers = @{
+        Authorization = "Bearer $($config.webhook_token)"
+        "Content-Type" = "application/json"
+    }
+
+    Invoke-RestMethod -Method Post -Uri $config.webhook_url -Headers $headers -Body ($payload | ConvertTo-Json -Depth 100) -ContentType "application/json" -TimeoutSec 5 | Out-Null
+} catch {}
+
+@{ cancel = $false } | ConvertTo-Json -Compress
+`
+
+const NODE_HOOK_SHARED = `#!/usr/bin/env node
+const fs = require("fs/promises")
+const os = require("os")
+const path = require("path")
+
+async function readConfig() {
+  const configPath = path.join(os.homedir(), "Documents", "Cline", "webhook_config.json")
+  try {
+    const rawConfig = await fs.readFile(configPath, "utf-8")
+    const config = JSON.parse(rawConfig)
+    if (!config.webhook_url || !config.webhook_token) {
+      return null
+    }
+    return config
+  } catch {
+    return null
+  }
+}
+
+async function postEvent(config, payload) {
+  let timeout
+  try {
+    const controller = new AbortController()
+    timeout = setTimeout(() => controller.abort(), 5000)
+    await fetch(config.webhook_url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: \`Bearer \${config.webhook_token}\`,
+      },
+      body: JSON.stringify(payload),
+      signal: controller.signal,
+    })
+  } catch {} finally {
+    if (timeout) {
+      clearTimeout(timeout)
+    }
+  }
+}
+
+async function main(buildPayload) {
+  let input = {}
+  try {
+    const rawInput = await fs.readFile(0, "utf-8")
+    input = rawInput ? JSON.parse(rawInput) : {}
+  } catch {}
+
+  const config = await readConfig()
+  if (config) {
+    await postEvent(config, buildPayload(input))
+  }
+
+  process.stdout.write(JSON.stringify({ cancel: false }))
+}
+`
+
+const TASK_START_NODE = `${NODE_HOOK_SHARED}
+main((input) => ({
+  event: "task_started",
+  timestamp: new Date().toISOString(),
+  data: {
+    task_id: input.taskId ?? null,
+    cline_version: input.clineVersion ?? null,
+    workspace_roots: input.workspaceRoots ?? [],
+    task_metadata: input.taskStart?.taskMetadata ?? {},
+  },
+}))
+`
+
+const POST_TOOL_USE_NODE = `${NODE_HOOK_SHARED}
+main((input) => ({
+  event: "tool_executed",
+  timestamp: new Date().toISOString(),
+  data: {
+    task_id: input.taskId ?? null,
+    tool_name: input.postToolUse?.toolName ?? null,
+    parameters: input.postToolUse?.parameters ?? {},
+    success: Boolean(input.postToolUse?.success),
+    execution_time_ms: input.postToolUse?.executionTimeMs ?? null,
+  },
+}))
+`
+
+const TASK_COMPLETE_NODE = `${NODE_HOOK_SHARED}
+main((input) => ({
+  event: "task_completed",
+  timestamp: new Date().toISOString(),
+  data: {
+    task_id: input.taskId ?? null,
+    task_metadata: input.taskComplete?.taskMetadata ?? {},
+  },
+}))
+`


### PR DESCRIPTION
### Related Issue

Issue: N/A

### Description

This PR adds a dedicated `/lg-task` URI path so the LG dashboard can launch Cline with a spec file and webhook configuration instead of embedding large prompts directly in the URI.

The new flow in `SharedUriHandler` now:

- Validates required query params: `prompt-file`, `webhook-url`, `webhook-token`
- Reads the spec from the provided file path
- Writes `~/Documents/Cline/webhook_config.json` with webhook URL, token, and timestamp
- Installs/overwrites `TaskStart`, `PostToolUse`, and `TaskComplete` hook scripts under `~/Documents/Cline/Hooks`
- Starts task creation with the loaded spec content

To keep the hook payload logic maintainable, I added a new `lgWebhookHooks.ts` module that centralizes script content and platform-specific file selection:

- Windows: `.ps1` hooks using `Invoke-RestMethod` with 5 second timeout
- Non-Windows: executable Node hook files using `fetch` with 5 second timeout

I also updated URI bootstrap behavior in `extension.ts` so `/lg-task` gets the same sidebar open + retry handling currently used for `/task`, which avoids startup race conditions.

### Test Procedure

I tested behavior at both unit and validation levels.

1. Unit tests for new URI behavior

```bash
npm run test:unit -- src/services/uri/SharedUriHandler.test.ts
```

Coverage includes:

- Success case for `/lg-task` with prompt file loading, config writing, hook writing, and task creation
- Failure case when required LG params are missing

2. Type checks

```bash
npm run check-types
```

3. Lint

```bash
npm run lint
```

All commands passed locally.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor Changes
- [ ] Cosmetic Changes
- [ ] Documentation update
- [ ] Workflow Changes

### Pre-flight Checklist

- [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
- [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
- [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A

### Additional Notes

One subtle implementation detail is that URI query parsing already preserves plus signs in values inside `SharedUriHandler`. This is important for some token formats and remains intact for the new LG params.
