### PR TITLE
fix(prompts): add use_subagents to GLM, Hermes, and XS TOOL_USE_SECTI…

### DIFF
--- a/src/core/prompts/system-prompt/__tests__/__snapshots__/lmstudio_qwen3_coder-basic.snap
+++ b/src/core/prompts/system-prompt/__tests__/__snapshots__/lmstudio_qwen3_coder-basic.snap
@@ -86,8 +86,16 @@ Key: Never include an option to toggle modes.
 
 **new_task** — Create a new task with context. Param: context (Current Work; Key Concepts; Relevant Files/Code; Problem Solving; Pending & Next).
 
-**plan_mode_respond** — PLAN-only reply. Params: response, needs_more_exploration (optional).  
+**plan_mode_respond** — PLAN-only reply. Params: response, needs_more_exploration (optional).
 Include options/trade-offs when helpful, ask if plan matches, then add the exact mode-switch line.
+
+**use_subagents** — Run up to 5 focused in-process subagents in parallel for broad exploration. Each subagent gets its own prompt and returns a comprehensive research result. Use this when reading many files would consume the main agent's context window. Using a single subagent is also valid for light discovery work.
+Params: prompt_1 (required), prompt_2, prompt_3, prompt_4, prompt_5 (all optional).
+*Example:*
+<use_subagents>
+<prompt_1>First subagent task description here.</prompt_1>
+<prompt_2>Optional second subagent task here.</prompt_2>
+</use_subagents>
 
 ## EXECUTION FLOW
 - Understand request → PLAN explore (read-only) → propose collaborative plan with options/risks/tests → ask if it matches → output: **Switch me to ACT MODE to implement.**

--- a/src/core/prompts/system-prompt/__tests__/__snapshots__/lmstudio_qwen3_coder-no-browser.snap
+++ b/src/core/prompts/system-prompt/__tests__/__snapshots__/lmstudio_qwen3_coder-no-browser.snap
@@ -86,8 +86,16 @@ Key: Never include an option to toggle modes.
 
 **new_task** — Create a new task with context. Param: context (Current Work; Key Concepts; Relevant Files/Code; Problem Solving; Pending & Next).
 
-**plan_mode_respond** — PLAN-only reply. Params: response, needs_more_exploration (optional).  
+**plan_mode_respond** — PLAN-only reply. Params: response, needs_more_exploration (optional).
 Include options/trade-offs when helpful, ask if plan matches, then add the exact mode-switch line.
+
+**use_subagents** — Run up to 5 focused in-process subagents in parallel for broad exploration. Each subagent gets its own prompt and returns a comprehensive research result. Use this when reading many files would consume the main agent's context window. Using a single subagent is also valid for light discovery work.
+Params: prompt_1 (required), prompt_2, prompt_3, prompt_4, prompt_5 (all optional).
+*Example:*
+<use_subagents>
+<prompt_1>First subagent task description here.</prompt_1>
+<prompt_2>Optional second subagent task here.</prompt_2>
+</use_subagents>
 
 ## EXECUTION FLOW
 - Understand request → PLAN explore (read-only) → propose collaborative plan with options/risks/tests → ask if it matches → output: **Switch me to ACT MODE to implement.**

--- a/src/core/prompts/system-prompt/__tests__/__snapshots__/lmstudio_qwen3_coder-no-focus-chain.snap
+++ b/src/core/prompts/system-prompt/__tests__/__snapshots__/lmstudio_qwen3_coder-no-focus-chain.snap
@@ -86,8 +86,16 @@ Key: Never include an option to toggle modes.
 
 **new_task** — Create a new task with context. Param: context (Current Work; Key Concepts; Relevant Files/Code; Problem Solving; Pending & Next).
 
-**plan_mode_respond** — PLAN-only reply. Params: response, needs_more_exploration (optional).  
+**plan_mode_respond** — PLAN-only reply. Params: response, needs_more_exploration (optional).
 Include options/trade-offs when helpful, ask if plan matches, then add the exact mode-switch line.
+
+**use_subagents** — Run up to 5 focused in-process subagents in parallel for broad exploration. Each subagent gets its own prompt and returns a comprehensive research result. Use this when reading many files would consume the main agent's context window. Using a single subagent is also valid for light discovery work.
+Params: prompt_1 (required), prompt_2, prompt_3, prompt_4, prompt_5 (all optional).
+*Example:*
+<use_subagents>
+<prompt_1>First subagent task description here.</prompt_1>
+<prompt_2>Optional second subagent task here.</prompt_2>
+</use_subagents>
 
 ## EXECUTION FLOW
 - Understand request → PLAN explore (read-only) → propose collaborative plan with options/risks/tests → ask if it matches → output: **Switch me to ACT MODE to implement.**

--- a/src/core/prompts/system-prompt/__tests__/__snapshots__/lmstudio_qwen3_coder-no-mcp.snap
+++ b/src/core/prompts/system-prompt/__tests__/__snapshots__/lmstudio_qwen3_coder-no-mcp.snap
@@ -86,8 +86,16 @@ Key: Never include an option to toggle modes.
 
 **new_task** — Create a new task with context. Param: context (Current Work; Key Concepts; Relevant Files/Code; Problem Solving; Pending & Next).
 
-**plan_mode_respond** — PLAN-only reply. Params: response, needs_more_exploration (optional).  
+**plan_mode_respond** — PLAN-only reply. Params: response, needs_more_exploration (optional).
 Include options/trade-offs when helpful, ask if plan matches, then add the exact mode-switch line.
+
+**use_subagents** — Run up to 5 focused in-process subagents in parallel for broad exploration. Each subagent gets its own prompt and returns a comprehensive research result. Use this when reading many files would consume the main agent's context window. Using a single subagent is also valid for light discovery work.
+Params: prompt_1 (required), prompt_2, prompt_3, prompt_4, prompt_5 (all optional).
+*Example:*
+<use_subagents>
+<prompt_1>First subagent task description here.</prompt_1>
+<prompt_2>Optional second subagent task here.</prompt_2>
+</use_subagents>
 
 ## EXECUTION FLOW
 - Understand request → PLAN explore (read-only) → propose collaborative plan with options/risks/tests → ask if it matches → output: **Switch me to ACT MODE to implement.**

--- a/src/core/prompts/system-prompt/__tests__/__snapshots__/test_hermes_4-basic.snap
+++ b/src/core/prompts/system-prompt/__tests__/__snapshots__/test_hermes_4-basic.snap
@@ -92,7 +92,7 @@ Param: context (Current Work; Key Concepts; Relevant Files/Code; Problem Solving
 </new_task>
 
 **plan_mode_respond** — PLAN-only reply.
-Params: response, needs_more_exploration (optional).  
+Params: response, needs_more_exploration (optional).
 Include options/trade-offs when helpful, ask if plan matches, then add the exact mode-switch line.
 *Example:*
 <plan_mode_respond>
@@ -100,6 +100,14 @@ Include options/trade-offs when helpful, ask if plan matches, then add the exact
 <needs_more_exploration>true or false (optional, but you MUST set to true if in <response> you need to read files or use other exploration tools)</needs_more_exploration>
 <task_progress>Checklist here (If you have presented the user with concrete steps or requirements, you can optionally include a todo list outlining these steps.)</task_progress>
 </plan_mode_respond>
+
+**use_subagents** — Run up to 5 focused in-process subagents in parallel for broad exploration. Each subagent gets its own prompt and returns a comprehensive research result. Use this when reading many files would consume the main agent's context window. Using a single subagent is also valid for light discovery work.
+Params: prompt_1 (required), prompt_2, prompt_3, prompt_4, prompt_5 (all optional).
+*Example:*
+<use_subagents>
+<prompt_1>First subagent task description here.</prompt_1>
+<prompt_2>Optional second subagent task here.</prompt_2>
+</use_subagents>
 
 ## RULES
 

--- a/src/core/prompts/system-prompt/__tests__/__snapshots__/test_hermes_4-no-browser.snap
+++ b/src/core/prompts/system-prompt/__tests__/__snapshots__/test_hermes_4-no-browser.snap
@@ -92,7 +92,7 @@ Param: context (Current Work; Key Concepts; Relevant Files/Code; Problem Solving
 </new_task>
 
 **plan_mode_respond** — PLAN-only reply.
-Params: response, needs_more_exploration (optional).  
+Params: response, needs_more_exploration (optional).
 Include options/trade-offs when helpful, ask if plan matches, then add the exact mode-switch line.
 *Example:*
 <plan_mode_respond>
@@ -100,6 +100,14 @@ Include options/trade-offs when helpful, ask if plan matches, then add the exact
 <needs_more_exploration>true or false (optional, but you MUST set to true if in <response> you need to read files or use other exploration tools)</needs_more_exploration>
 <task_progress>Checklist here (If you have presented the user with concrete steps or requirements, you can optionally include a todo list outlining these steps.)</task_progress>
 </plan_mode_respond>
+
+**use_subagents** — Run up to 5 focused in-process subagents in parallel for broad exploration. Each subagent gets its own prompt and returns a comprehensive research result. Use this when reading many files would consume the main agent's context window. Using a single subagent is also valid for light discovery work.
+Params: prompt_1 (required), prompt_2, prompt_3, prompt_4, prompt_5 (all optional).
+*Example:*
+<use_subagents>
+<prompt_1>First subagent task description here.</prompt_1>
+<prompt_2>Optional second subagent task here.</prompt_2>
+</use_subagents>
 
 ## RULES
 

--- a/src/core/prompts/system-prompt/__tests__/__snapshots__/test_hermes_4-no-focus-chain.snap
+++ b/src/core/prompts/system-prompt/__tests__/__snapshots__/test_hermes_4-no-focus-chain.snap
@@ -92,7 +92,7 @@ Param: context (Current Work; Key Concepts; Relevant Files/Code; Problem Solving
 </new_task>
 
 **plan_mode_respond** — PLAN-only reply.
-Params: response, needs_more_exploration (optional).  
+Params: response, needs_more_exploration (optional).
 Include options/trade-offs when helpful, ask if plan matches, then add the exact mode-switch line.
 *Example:*
 <plan_mode_respond>
@@ -100,6 +100,14 @@ Include options/trade-offs when helpful, ask if plan matches, then add the exact
 <needs_more_exploration>true or false (optional, but you MUST set to true if in <response> you need to read files or use other exploration tools)</needs_more_exploration>
 <task_progress>Checklist here (If you have presented the user with concrete steps or requirements, you can optionally include a todo list outlining these steps.)</task_progress>
 </plan_mode_respond>
+
+**use_subagents** — Run up to 5 focused in-process subagents in parallel for broad exploration. Each subagent gets its own prompt and returns a comprehensive research result. Use this when reading many files would consume the main agent's context window. Using a single subagent is also valid for light discovery work.
+Params: prompt_1 (required), prompt_2, prompt_3, prompt_4, prompt_5 (all optional).
+*Example:*
+<use_subagents>
+<prompt_1>First subagent task description here.</prompt_1>
+<prompt_2>Optional second subagent task here.</prompt_2>
+</use_subagents>
 
 ## RULES
 

--- a/src/core/prompts/system-prompt/__tests__/__snapshots__/test_hermes_4-no-mcp.snap
+++ b/src/core/prompts/system-prompt/__tests__/__snapshots__/test_hermes_4-no-mcp.snap
@@ -92,7 +92,7 @@ Param: context (Current Work; Key Concepts; Relevant Files/Code; Problem Solving
 </new_task>
 
 **plan_mode_respond** — PLAN-only reply.
-Params: response, needs_more_exploration (optional).  
+Params: response, needs_more_exploration (optional).
 Include options/trade-offs when helpful, ask if plan matches, then add the exact mode-switch line.
 *Example:*
 <plan_mode_respond>
@@ -100,6 +100,14 @@ Include options/trade-offs when helpful, ask if plan matches, then add the exact
 <needs_more_exploration>true or false (optional, but you MUST set to true if in <response> you need to read files or use other exploration tools)</needs_more_exploration>
 <task_progress>Checklist here (If you have presented the user with concrete steps or requirements, you can optionally include a todo list outlining these steps.)</task_progress>
 </plan_mode_respond>
+
+**use_subagents** — Run up to 5 focused in-process subagents in parallel for broad exploration. Each subagent gets its own prompt and returns a comprehensive research result. Use this when reading many files would consume the main agent's context window. Using a single subagent is also valid for light discovery work.
+Params: prompt_1 (required), prompt_2, prompt_3, prompt_4, prompt_5 (all optional).
+*Example:*
+<use_subagents>
+<prompt_1>First subagent task description here.</prompt_1>
+<prompt_2>Optional second subagent task here.</prompt_2>
+</use_subagents>
 
 ## RULES
 

--- a/src/core/prompts/system-prompt/__tests__/__snapshots__/zai_glm_4_6-basic.snap
+++ b/src/core/prompts/system-prompt/__tests__/__snapshots__/zai_glm_4_6-basic.snap
@@ -119,7 +119,7 @@ Param: context (Current Work; Key Concepts; Relevant Files/Code; Problem Solving
 </new_task>
 
 **plan_mode_respond** — PLAN-only reply.
-Params: response, needs_more_exploration (optional).  
+Params: response, needs_more_exploration (optional).
 Include options/trade-offs when helpful, ask if plan matches, then add the exact mode-switch line.
 *Example:*
 <plan_mode_respond>
@@ -127,6 +127,14 @@ Include options/trade-offs when helpful, ask if plan matches, then add the exact
 <needs_more_exploration>true or false (optional, but you MUST set to true if in <response> you need to read files or use other exploration tools)</needs_more_exploration>
 <task_progress>Checklist here (If you have presented the user with concrete steps or requirements, you can optionally include a todo list outlining these steps.)</task_progress>
 </plan_mode_respond>
+
+**use_subagents** — Run up to 5 focused in-process subagents in parallel for broad exploration. Each subagent gets its own prompt and returns a comprehensive research result. Use this when reading many files would consume the main agent's context window. Using a single subagent is also valid for light discovery work.
+Params: prompt_1 (required), prompt_2, prompt_3, prompt_4, prompt_5 (all optional).
+*Example:*
+<use_subagents>
+<prompt_1>First subagent task description here.</prompt_1>
+<prompt_2>Optional second subagent task here.</prompt_2>
+</use_subagents>
 
 ## UPDATING TASK PROGRESS
 

--- a/src/core/prompts/system-prompt/__tests__/__snapshots__/zai_glm_4_6-no-browser.snap
+++ b/src/core/prompts/system-prompt/__tests__/__snapshots__/zai_glm_4_6-no-browser.snap
@@ -119,7 +119,7 @@ Param: context (Current Work; Key Concepts; Relevant Files/Code; Problem Solving
 </new_task>
 
 **plan_mode_respond** — PLAN-only reply.
-Params: response, needs_more_exploration (optional).  
+Params: response, needs_more_exploration (optional).
 Include options/trade-offs when helpful, ask if plan matches, then add the exact mode-switch line.
 *Example:*
 <plan_mode_respond>
@@ -127,6 +127,14 @@ Include options/trade-offs when helpful, ask if plan matches, then add the exact
 <needs_more_exploration>true or false (optional, but you MUST set to true if in <response> you need to read files or use other exploration tools)</needs_more_exploration>
 <task_progress>Checklist here (If you have presented the user with concrete steps or requirements, you can optionally include a todo list outlining these steps.)</task_progress>
 </plan_mode_respond>
+
+**use_subagents** — Run up to 5 focused in-process subagents in parallel for broad exploration. Each subagent gets its own prompt and returns a comprehensive research result. Use this when reading many files would consume the main agent's context window. Using a single subagent is also valid for light discovery work.
+Params: prompt_1 (required), prompt_2, prompt_3, prompt_4, prompt_5 (all optional).
+*Example:*
+<use_subagents>
+<prompt_1>First subagent task description here.</prompt_1>
+<prompt_2>Optional second subagent task here.</prompt_2>
+</use_subagents>
 
 ## UPDATING TASK PROGRESS
 

--- a/src/core/prompts/system-prompt/__tests__/__snapshots__/zai_glm_4_6-no-focus-chain.snap
+++ b/src/core/prompts/system-prompt/__tests__/__snapshots__/zai_glm_4_6-no-focus-chain.snap
@@ -119,7 +119,7 @@ Param: context (Current Work; Key Concepts; Relevant Files/Code; Problem Solving
 </new_task>
 
 **plan_mode_respond** — PLAN-only reply.
-Params: response, needs_more_exploration (optional).  
+Params: response, needs_more_exploration (optional).
 Include options/trade-offs when helpful, ask if plan matches, then add the exact mode-switch line.
 *Example:*
 <plan_mode_respond>
@@ -127,6 +127,14 @@ Include options/trade-offs when helpful, ask if plan matches, then add the exact
 <needs_more_exploration>true or false (optional, but you MUST set to true if in <response> you need to read files or use other exploration tools)</needs_more_exploration>
 <task_progress>Checklist here (If you have presented the user with concrete steps or requirements, you can optionally include a todo list outlining these steps.)</task_progress>
 </plan_mode_respond>
+
+**use_subagents** — Run up to 5 focused in-process subagents in parallel for broad exploration. Each subagent gets its own prompt and returns a comprehensive research result. Use this when reading many files would consume the main agent's context window. Using a single subagent is also valid for light discovery work.
+Params: prompt_1 (required), prompt_2, prompt_3, prompt_4, prompt_5 (all optional).
+*Example:*
+<use_subagents>
+<prompt_1>First subagent task description here.</prompt_1>
+<prompt_2>Optional second subagent task here.</prompt_2>
+</use_subagents>
 
 ## RULES
 

--- a/src/core/prompts/system-prompt/__tests__/__snapshots__/zai_glm_4_6-no-mcp.snap
+++ b/src/core/prompts/system-prompt/__tests__/__snapshots__/zai_glm_4_6-no-mcp.snap
@@ -91,7 +91,7 @@ Param: context (Current Work; Key Concepts; Relevant Files/Code; Problem Solving
 </new_task>
 
 **plan_mode_respond** — PLAN-only reply.
-Params: response, needs_more_exploration (optional).  
+Params: response, needs_more_exploration (optional).
 Include options/trade-offs when helpful, ask if plan matches, then add the exact mode-switch line.
 *Example:*
 <plan_mode_respond>
@@ -99,6 +99,14 @@ Include options/trade-offs when helpful, ask if plan matches, then add the exact
 <needs_more_exploration>true or false (optional, but you MUST set to true if in <response> you need to read files or use other exploration tools)</needs_more_exploration>
 <task_progress>Checklist here (If you have presented the user with concrete steps or requirements, you can optionally include a todo list outlining these steps.)</task_progress>
 </plan_mode_respond>
+
+**use_subagents** — Run up to 5 focused in-process subagents in parallel for broad exploration. Each subagent gets its own prompt and returns a comprehensive research result. Use this when reading many files would consume the main agent's context window. Using a single subagent is also valid for light discovery work.
+Params: prompt_1 (required), prompt_2, prompt_3, prompt_4, prompt_5 (all optional).
+*Example:*
+<use_subagents>
+<prompt_1>First subagent task description here.</prompt_1>
+<prompt_2>Optional second subagent task here.</prompt_2>
+</use_subagents>
 
 ## UPDATING TASK PROGRESS
 

--- a/src/core/prompts/system-prompt/variants/glm/overrides.ts
+++ b/src/core/prompts/system-prompt/variants/glm/overrides.ts
@@ -130,14 +130,22 @@ Param: context (Current Work; Key Concepts; Relevant Files/Code; Problem Solving
 </new_task>
 
 **plan_mode_respond** — PLAN-only reply.
-Params: response, needs_more_exploration (optional).  
+Params: response, needs_more_exploration (optional).
 Include options/trade-offs when helpful, ask if plan matches, then add the exact mode-switch line.
 *Example:*
 <plan_mode_respond>
 <response>Your response here</response>
 <needs_more_exploration>true or false (optional, but you MUST set to true if in <response> you need to read files or use other exploration tools)</needs_more_exploration>
 <task_progress>Checklist here (If you have presented the user with concrete steps or requirements, you can optionally include a todo list outlining these steps.)</task_progress>
-</plan_mode_respond>`
+</plan_mode_respond>
+
+**use_subagents** — Run up to 5 focused in-process subagents in parallel for broad exploration. Each subagent gets its own prompt and returns a comprehensive research result. Use this when reading many files would consume the main agent's context window. Using a single subagent is also valid for light discovery work.
+Params: prompt_1 (required), prompt_2, prompt_3, prompt_4, prompt_5 (all optional).
+*Example:*
+<use_subagents>
+<prompt_1>First subagent task description here.</prompt_1>
+<prompt_2>Optional second subagent task here.</prompt_2>
+</use_subagents>`
 }
 
 const GLM_OBJECTIVE_TEMPLATE = `OBJECTIVE

--- a/src/core/prompts/system-prompt/variants/glm/overrides.ts
+++ b/src/core/prompts/system-prompt/variants/glm/overrides.ts
@@ -137,7 +137,9 @@ Include options/trade-offs when helpful, ask if plan matches, then add the exact
 <response>Your response here</response>
 <needs_more_exploration>true or false (optional, but you MUST set to true if in <response> you need to read files or use other exploration tools)</needs_more_exploration>
 <task_progress>Checklist here (If you have presented the user with concrete steps or requirements, you can optionally include a todo list outlining these steps.)</task_progress>
-</plan_mode_respond>
+</plan_mode_respond>${
+		context.subagentsEnabled && !context.isSubagentRun
+			? `
 
 **use_subagents** — Run up to 5 focused in-process subagents in parallel for broad exploration. Each subagent gets its own prompt and returns a comprehensive research result. Use this when reading many files would consume the main agent's context window. Using a single subagent is also valid for light discovery work.
 Params: prompt_1 (required), prompt_2, prompt_3, prompt_4, prompt_5 (all optional).
@@ -146,6 +148,8 @@ Params: prompt_1 (required), prompt_2, prompt_3, prompt_4, prompt_5 (all optiona
 <prompt_1>First subagent task description here.</prompt_1>
 <prompt_2>Optional second subagent task here.</prompt_2>
 </use_subagents>`
+			: ""
+	}`
 }
 
 const GLM_OBJECTIVE_TEMPLATE = `OBJECTIVE

--- a/src/core/prompts/system-prompt/variants/glm/overrides.ts
+++ b/src/core/prompts/system-prompt/variants/glm/overrides.ts
@@ -138,7 +138,7 @@ Include options/trade-offs when helpful, ask if plan matches, then add the exact
 <needs_more_exploration>true or false (optional, but you MUST set to true if in <response> you need to read files or use other exploration tools)</needs_more_exploration>
 <task_progress>Checklist here (If you have presented the user with concrete steps or requirements, you can optionally include a todo list outlining these steps.)</task_progress>
 </plan_mode_respond>${
-		context.subagentsEnabled && !context.isSubagentRun
+		context.subagentsEnabled === true && !context.isSubagentRun
 			? `
 
 **use_subagents** — Run up to 5 focused in-process subagents in parallel for broad exploration. Each subagent gets its own prompt and returns a comprehensive research result. Use this when reading many files would consume the main agent's context window. Using a single subagent is also valid for light discovery work.

--- a/src/core/prompts/system-prompt/variants/hermes/overrides.ts
+++ b/src/core/prompts/system-prompt/variants/hermes/overrides.ts
@@ -100,14 +100,22 @@ Param: context (Current Work; Key Concepts; Relevant Files/Code; Problem Solving
 </new_task>
 
 **plan_mode_respond** — PLAN-only reply.
-Params: response, needs_more_exploration (optional).  
+Params: response, needs_more_exploration (optional).
 Include options/trade-offs when helpful, ask if plan matches, then add the exact mode-switch line.
 *Example:*
 <plan_mode_respond>
 <response>Your response here</response>
 <needs_more_exploration>true or false (optional, but you MUST set to true if in <response> you need to read files or use other exploration tools)</needs_more_exploration>
 <task_progress>Checklist here (If you have presented the user with concrete steps or requirements, you can optionally include a todo list outlining these steps.)</task_progress>
-</plan_mode_respond>`
+</plan_mode_respond>
+
+**use_subagents** — Run up to 5 focused in-process subagents in parallel for broad exploration. Each subagent gets its own prompt and returns a comprehensive research result. Use this when reading many files would consume the main agent's context window. Using a single subagent is also valid for light discovery work.
+Params: prompt_1 (required), prompt_2, prompt_3, prompt_4, prompt_5 (all optional).
+*Example:*
+<use_subagents>
+<prompt_1>First subagent task description here.</prompt_1>
+<prompt_2>Optional second subagent task here.</prompt_2>
+</use_subagents>`
 
 const HERMES_OBJECTIVE_TEMPLATE = `OBJECTIVE
 

--- a/src/core/prompts/system-prompt/variants/hermes/overrides.ts
+++ b/src/core/prompts/system-prompt/variants/hermes/overrides.ts
@@ -9,7 +9,9 @@ const HERMES_AGENT_ROLE_TEMPLATE = [
 	"with extensive knowledge in many programming languages, frameworks, design patterns, and best practices. ",
 ].join("")
 
-const HERMES_TOOL_USE_TEMPLATE = `Begin every task by exploring the codebase (e.g., list_files, search_files, read_file) and outlining the required changes. Do not implement until exploration yields enough context to state objectives, approach, affected files, and risks. Briefly summarize the plan, then proceed with implementation.
+const HERMES_TOOL_USE_TEMPLATE = (
+	context: SystemPromptContext,
+) => `Begin every task by exploring the codebase (e.g., list_files, search_files, read_file) and outlining the required changes. Do not implement until exploration yields enough context to state objectives, approach, affected files, and risks. Briefly summarize the plan, then proceed with implementation.
 
 Tool invocation policy: Invoke tools only in assistant messages; they will not execute if placed inside reasoning blocks. Use reasoning blocks solely for analysis/option-weighing; place all tool XML blocks in assistant messages to execute them.
 
@@ -107,7 +109,9 @@ Include options/trade-offs when helpful, ask if plan matches, then add the exact
 <response>Your response here</response>
 <needs_more_exploration>true or false (optional, but you MUST set to true if in <response> you need to read files or use other exploration tools)</needs_more_exploration>
 <task_progress>Checklist here (If you have presented the user with concrete steps or requirements, you can optionally include a todo list outlining these steps.)</task_progress>
-</plan_mode_respond>
+</plan_mode_respond>${
+	context.subagentsEnabled && !context.isSubagentRun
+		? `
 
 **use_subagents** — Run up to 5 focused in-process subagents in parallel for broad exploration. Each subagent gets its own prompt and returns a comprehensive research result. Use this when reading many files would consume the main agent's context window. Using a single subagent is also valid for light discovery work.
 Params: prompt_1 (required), prompt_2, prompt_3, prompt_4, prompt_5 (all optional).
@@ -116,6 +120,8 @@ Params: prompt_1 (required), prompt_2, prompt_3, prompt_4, prompt_5 (all optiona
 <prompt_1>First subagent task description here.</prompt_1>
 <prompt_2>Optional second subagent task here.</prompt_2>
 </use_subagents>`
+		: ""
+}`
 
 const HERMES_OBJECTIVE_TEMPLATE = `OBJECTIVE
 

--- a/src/core/prompts/system-prompt/variants/hermes/overrides.ts
+++ b/src/core/prompts/system-prompt/variants/hermes/overrides.ts
@@ -110,7 +110,7 @@ Include options/trade-offs when helpful, ask if plan matches, then add the exact
 <needs_more_exploration>true or false (optional, but you MUST set to true if in <response> you need to read files or use other exploration tools)</needs_more_exploration>
 <task_progress>Checklist here (If you have presented the user with concrete steps or requirements, you can optionally include a todo list outlining these steps.)</task_progress>
 </plan_mode_respond>${
-	context.subagentsEnabled && !context.isSubagentRun
+	context.subagentsEnabled === true && !context.isSubagentRun
 		? `
 
 **use_subagents** — Run up to 5 focused in-process subagents in parallel for broad exploration. Each subagent gets its own prompt and returns a comprehensive research result. Use this when reading many files would consume the main agent's context window. Using a single subagent is also valid for light discovery work.

--- a/src/core/prompts/system-prompt/variants/xs/overrides.ts
+++ b/src/core/prompts/system-prompt/variants/xs/overrides.ts
@@ -96,8 +96,16 @@ Key: Never include an option to toggle modes.
 
 **new_task** — Create a new task with context. Param: context (Current Work; Key Concepts; Relevant Files/Code; Problem Solving; Pending & Next).
 
-**plan_mode_respond** — PLAN-only reply. Params: response, needs_more_exploration (optional).  
-Include options/trade-offs when helpful, ask if plan matches, then add the exact mode-switch line.`
+**plan_mode_respond** — PLAN-only reply. Params: response, needs_more_exploration (optional).
+Include options/trade-offs when helpful, ask if plan matches, then add the exact mode-switch line.
+
+**use_subagents** — Run up to 5 focused in-process subagents in parallel for broad exploration. Each subagent gets its own prompt and returns a comprehensive research result. Use this when reading many files would consume the main agent's context window. Using a single subagent is also valid for light discovery work.
+Params: prompt_1 (required), prompt_2, prompt_3, prompt_4, prompt_5 (all optional).
+*Example:*
+<use_subagents>
+<prompt_1>First subagent task description here.</prompt_1>
+<prompt_2>Optional second subagent task here.</prompt_2>
+</use_subagents>`
 
 export const xsComponentOverrides = {
 	AGENT_ROLE:

--- a/src/core/prompts/system-prompt/variants/xs/overrides.ts
+++ b/src/core/prompts/system-prompt/variants/xs/overrides.ts
@@ -98,7 +98,7 @@ Key: Never include an option to toggle modes.
 
 **plan_mode_respond** — PLAN-only reply. Params: response, needs_more_exploration (optional).
 Include options/trade-offs when helpful, ask if plan matches, then add the exact mode-switch line.${
-				context.subagentsEnabled && !context.isSubagentRun
+				context.subagentsEnabled === true && !context.isSubagentRun
 					? `
 
 **use_subagents** — Run up to 5 focused in-process subagents in parallel for broad exploration. Each subagent gets its own prompt and returns a comprehensive research result. Use this when reading many files would consume the main agent's context window. Using a single subagent is also valid for light discovery work.

--- a/src/core/prompts/system-prompt/variants/xs/overrides.ts
+++ b/src/core/prompts/system-prompt/variants/xs/overrides.ts
@@ -97,7 +97,9 @@ Key: Never include an option to toggle modes.
 **new_task** — Create a new task with context. Param: context (Current Work; Key Concepts; Relevant Files/Code; Problem Solving; Pending & Next).
 
 **plan_mode_respond** — PLAN-only reply. Params: response, needs_more_exploration (optional).
-Include options/trade-offs when helpful, ask if plan matches, then add the exact mode-switch line.
+Include options/trade-offs when helpful, ask if plan matches, then add the exact mode-switch line.${
+				context.subagentsEnabled && !context.isSubagentRun
+					? `
 
 **use_subagents** — Run up to 5 focused in-process subagents in parallel for broad exploration. Each subagent gets its own prompt and returns a comprehensive research result. Use this when reading many files would consume the main agent's context window. Using a single subagent is also valid for light discovery work.
 Params: prompt_1 (required), prompt_2, prompt_3, prompt_4, prompt_5 (all optional).
@@ -106,6 +108,8 @@ Params: prompt_1 (required), prompt_2, prompt_3, prompt_4, prompt_5 (all optiona
 <prompt_1>First subagent task description here.</prompt_1>
 <prompt_2>Optional second subagent task here.</prompt_2>
 </use_subagents>`
+					: ""
+			}`
 
 export const xsComponentOverrides = {
 	AGENT_ROLE:


### PR DESCRIPTION
### Related Issue

**Issue:** #10179

### Description

GLM-5, Hermes, and XS variants use hardcoded `TOOL_USE_SECTION` override templates via `.overrideComponent()`, which bypass the auto-generated tool descriptions. When `use_subagents` was added as a new tool, it was correctly registered in each variant's `.tools()` config, but was **never added to the hardcoded override templates**.

Since these variants use prompt-based tool calling (no `use_native_tools` label), models only know about tools that are explicitly described in the system prompt text. As a result, models like GLM-5 had no knowledge of `use_subagents` and fell back to calling `list_files`/`read_file` repeatedly instead.

Root cause confirmed by manually patching the `use_subagents` block into the GLM override template — GLM-5 immediately started invoking sub-agents correctly.

### Test Procedure

- Reproduced the bug: GLM-5 with sub-agents enabled never called `use_subagents`, falling back to repeated `list_files`/`read_file` calls
- Applied the fix and verified GLM-5 correctly invokes `use_subagents`
- Ran full unit test suite: `UPDATE_SNAPSHOTS=true npm run test:unit` → **1353 passing**
- Updated snapshots for all affected variants (GLM × 4, Hermes × 4, XS/lmstudio × 4)

### Type of Change

- [x]  Bug fix (non-breaking change which fixes an issue)

### Pre-flight Checklist

- [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
- [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
- [x] I have reviewed [[contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Additional Notes

The same pattern applies to any future tools added to these variants — the hardcoded override templates must be manually updated whenever a new tool is introduced. Generic/native variants are not affected as they use auto-generated tool descriptions.