### PR TITLE
feat(zai): add GLM-5.1 model support

### DIFF
--- a/docs/api/models.mdx
+++ b/docs/api/models.mdx
@@ -44,8 +44,8 @@ These models are available at no cost. They are a good starting point for experi
 |----------|----------|---------------|
 | `minimax/minimax-m2.5` | MiniMax | 1M |
 | `kwaipilot/kat-coder-pro` | Kwaipilot | 32K |
-| `z-ai/glm-5.1` | Z-AI | 128K |
-| `z-ai/glm-5` | Z-AI | 128K |
+| `z-ai/glm-5.1` | Z-AI | 200K |
+| `z-ai/glm-5` | Z-AI | 200K |
 
 Free models have the same API interface as paid models. Just use their model ID:
 

--- a/docs/api/models.mdx
+++ b/docs/api/models.mdx
@@ -44,6 +44,7 @@ These models are available at no cost. They are a good starting point for experi
 |----------|----------|---------------|
 | `minimax/minimax-m2.5` | MiniMax | 1M |
 | `kwaipilot/kat-coder-pro` | Kwaipilot | 32K |
+| `z-ai/glm-5.1` | Z-AI | 128K |
 | `z-ai/glm-5` | Z-AI | 128K |
 
 Free models have the same API interface as paid models. Just use their model ID:

--- a/docs/api/reference.mdx
+++ b/docs/api/reference.mdx
@@ -153,6 +153,7 @@ The following models are available at no cost:
 |----------|----------|
 | `minimax/minimax-m2.5` | MiniMax |
 | `kwaipilot/kat-coder-pro` | Kwaipilot |
+| `z-ai/glm-5.1` | Z-AI |
 | `z-ai/glm-5` | Z-AI |
 
 <Note>

--- a/docs/provider-config/zai.mdx
+++ b/docs/provider-config/zai.mdx
@@ -25,8 +25,11 @@ Z AI (formerly Zhipu AI) offers the GLM model series, featuring hybrid reasoning
 
 Z AI provides different model catalogs based on your selected region. Both regions share the same model lineup:
 
-#### GLM-5 (Latest)
--   `glm-5` (Default) - Latest flagship model with 200K context window and prompt caching ($1.00/$3.20 per 1M tokens)
+#### GLM-5.1 (Latest)
+-   `glm-5.1` - Latest flagship model with 200K context window and prompt caching ($1.40/$4.40 per 1M tokens)
+
+#### GLM-5
+-   `glm-5` (Default) - Previous flagship model with 200K context window and prompt caching ($1.00/$3.20 per 1M tokens)
 
 #### GLM-4.7
 -   `glm-4.7` - High-performance model with 200K context and prompt caching ($0.60/$2.20 per 1M tokens)

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -4436,6 +4436,15 @@ export const basetenDefaultModelId = "zai-org/GLM-4.6" satisfies BasetenModelId
 export type internationalZAiModelId = keyof typeof internationalZAiModels
 export const internationalZAiDefaultModelId: internationalZAiModelId = "glm-5"
 export const internationalZAiModels = {
+	"glm-5.1": {
+		maxTokens: 128_000,
+		contextWindow: 200_000,
+		supportsImages: false,
+		supportsPromptCache: true,
+		cacheReadsPrice: 0.26,
+		inputPrice: 1.4,
+		outputPrice: 4.4,
+	},
 	"glm-5": {
 		maxTokens: 128_000,
 		contextWindow: 200_000,
@@ -4492,6 +4501,15 @@ export const internationalZAiModels = {
 export type mainlandZAiModelId = keyof typeof mainlandZAiModels
 export const mainlandZAiDefaultModelId: mainlandZAiModelId = "glm-5"
 export const mainlandZAiModels = {
+	"glm-5.1": {
+		maxTokens: 128_000,
+		contextWindow: 200_000,
+		supportsImages: false,
+		supportsPromptCache: true,
+		cacheReadsPrice: 0.26,
+		inputPrice: 1.4,
+		outputPrice: 4.4,
+	},
 	"glm-5": {
 		maxTokens: 128_000,
 		contextWindow: 200_000,


### PR DESCRIPTION
## Description
Added GLM-5.1 as a supported model. Updated pricing, max output, and capabilities based on Zhipu AI documentation. Context window 200k, output 128k, pricing $1.4 input / $4.4 output.

## Test Procedure
Ran the Extension Development Host and tested the model with the Z.AI provider to verify it works correctly.