### PR TITLE
Add globalSkills to remote config

### DIFF
--- a/src/shared/remote-config/__tests__/schema.test.ts
+++ b/src/shared/remote-config/__tests__/schema.test.ts
@@ -679,6 +679,13 @@ describe("Remote Config Schema", () => {
 						contents: "# Deployment Workflow\n\n1. Run tests\n2. Build\n3. Deploy",
 					},
 				],
+				globalSkills: [
+					{
+						alwaysEnabled: true,
+						name: "company-standards.md",
+						contents: "# Company Standards\n\nAll code must follow these standards...",
+					},
+				],
 				providerSettings: {
 					OpenAiCompatible: {
 						models: [
@@ -840,6 +847,11 @@ describe("Remote Config Schema", () => {
 			expect(result.globalWorkflows?.[0].alwaysEnabled).to.equal(true)
 			expect(result.globalWorkflows?.[0].name).to.equal("deployment-workflow.md")
 			expect(result.globalWorkflows?.[0].contents).to.include("Deployment Workflow")
+
+			expect(result.globalSkills).to.have.lengthOf(1)
+			expect(result.globalSkills?.[0].alwaysEnabled).to.equal(true)
+			expect(result.globalSkills?.[0].name).to.equal("company-standards.md")
+			expect(result.globalSkills?.[0].contents).to.include("Company Standards")
 
 			expect(result.enterpriseTelemetry?.promptUploading?.enabled).to.equal(true)
 			expect(result.enterpriseTelemetry?.promptUploading?.type).to.equal("s3_access_keys")

--- a/src/shared/remote-config/schema.ts
+++ b/src/shared/remote-config/schema.ts
@@ -224,6 +224,7 @@ export const RemoteConfigSchema = z.object({
 	// Rules & Workflows
 	globalRules: z.array(GlobalInstructionsFileSchema).optional(),
 	globalWorkflows: z.array(GlobalInstructionsFileSchema).optional(),
+	globalSkills: z.array(GlobalInstructionsFileSchema).optional(),
 })
 
 export const APIKeySchema = z.record(z.string(), z.string())


### PR DESCRIPTION
### Description

We want to introduce global skills through Remote Config. This PR does the first step of updating the schema.

### Test Procedure

Added tests

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)