### PR TITLE
fix: Mermaid node text labels clipped when zooming/exporting to PNG

### DIFF
--- a/webview-ui/src/components/common/MermaidBlock.tsx
+++ b/webview-ui/src/components/common/MermaidBlock.tsx
@@ -129,7 +129,7 @@ export default function MermaidBlock({ code }: MermaidBlockProps) {
 		if (!containerRef.current) {
 			return
 		}
-		const svgEl = containerRef.current.querySelector("svg")
+		const svgEl = containerRef.current.querySelector<SVGSVGElement>("svg")
 		if (!svgEl) {
 			return
 		}
@@ -157,7 +157,7 @@ export default function MermaidBlock({ code }: MermaidBlockProps) {
 			{isLoading && <LoadingMessage>Generating mermaid diagram...</LoadingMessage>}
 			<ButtonContainer>
 				<StyledVSCodeButton aria-label="Copy Code" onClick={handleCopyCode} title="Copy Code">
-					<span className="codicon codicon-copy"></span>
+					<span className="codicon codicon-copy" />
 				</StyledVSCodeButton>
 			</ButtonContainer>
 			<SvgContainer $isLoading={isLoading} onClick={handleClick} ref={containerRef} />
@@ -165,7 +165,7 @@ export default function MermaidBlock({ code }: MermaidBlockProps) {
 	)
 }
 
-async function svgToPng(svgEl: SVGElement): Promise<string> {
+async function svgToPng(svgEl: SVGSVGElement): Promise<string> {
 	console.log("svgToPng function called")
 	// Clone the SVG to avoid modifying the original
 	const svgClone = svgEl.cloneNode(true) as SVGElement

--- a/webview-ui/src/components/common/MermaidBlock.tsx
+++ b/webview-ui/src/components/common/MermaidBlock.tsx
@@ -170,19 +170,33 @@ async function svgToPng(svgEl: SVGElement): Promise<string> {
 	// Clone the SVG to avoid modifying the original
 	const svgClone = svgEl.cloneNode(true) as SVGElement
 
-	// Get the original viewBox
+	// Use getBBox() to measure the actual rendered content bounds, which includes
+	// text labels that overflow beyond the viewBox. This fixes #7398 where node
+	// text labels are clipped in the PNG export.
+	const bbox = svgEl.getBBox()
 	const viewBox = svgClone.getAttribute("viewBox")?.split(" ").map(Number) || []
-	const originalWidth = viewBox[2] || svgClone.clientWidth
-	const originalHeight = viewBox[3] || svgClone.clientHeight
+
+	// Add padding to ensure nothing is clipped at edges
+	const padding = 20
+	const contentX = Math.min(bbox.x, viewBox[0] ?? bbox.x) - padding
+	const contentY = Math.min(bbox.y, viewBox[1] ?? bbox.y) - padding
+	const contentWidth = Math.max(bbox.width + bbox.x - contentX, (viewBox[2] ?? 0) + (viewBox[0] ?? 0) - contentX) + padding
+	const contentHeight = Math.max(bbox.height + bbox.y - contentY, (viewBox[3] ?? 0) + (viewBox[1] ?? 0) - contentY) + padding
+
+	// Update the viewBox to encompass all rendered content
+	svgClone.setAttribute("viewBox", `${contentX} ${contentY} ${contentWidth} ${contentHeight}`)
+
+	// Ensure SVG and text elements handle overflow correctly
+	svgClone.style.overflow = "visible"
+	svgClone.querySelectorAll("text").forEach((textEl) => {
+		textEl.style.overflow = "visible"
+	})
 
 	// Calculate the scale factor to fit editor width while maintaining aspect ratio
-
-	// Unless we can find a way to get the actual editor window dimensions through the VS Code API (which might be possible but would require changes to the extension side),
-	// the fixed width seems like a reliable approach.
 	const editorWidth = 3_600
 
-	const scale = editorWidth / originalWidth
-	const scaledHeight = originalHeight * scale
+	const scale = editorWidth / contentWidth
+	const scaledHeight = contentHeight * scale
 
 	// Update SVG dimensions
 	svgClone.setAttribute("width", `${editorWidth}`)
@@ -258,6 +272,12 @@ const SvgContainer = styled.div<SvgContainerProps>`
 	cursor: pointer;
 	display: flex;
 	justify-content: center;
+	overflow: visible;
+	padding: 20px;
+
+	svg {
+		overflow: visible !important;
+	}
 `
 
 const StyledVSCodeButton = styled(VSCodeButton)`


### PR DESCRIPTION
## Summary

- Fixes #7398 — Mermaid diagram text labels clipped/missing when clicking to zoom or exporting to PNG
- The CSS-only approach (PR #8050) fixes the **inline** view but not the **PNG export** — `svgToPng()` sizes the canvas from the SVG `viewBox`, so any text overflowing the viewBox gets cut off
- Uses `getBBox()` to measure actual rendered content bounds (including overflowing text labels), expands the viewBox to encompass everything with padding, and sets `overflow: visible` on SVG/text elements in the serialized clone
- Also adds `overflow: visible` CSS to `SvgContainer` for the inline view

## Related

- Issue: #7398
- Builds on the approach from PR #8050 by @YifanDevs (CSS-only fix), which a maintainer confirmed still showed clipping locally

## Test Procedure

1. Generate a Mermaid diagram (flowchart with long text labels in nodes)
2. Verify text is fully visible in the inline chat view (CSS fix)
3. Click the diagram to open the zoomed PNG view
4. Verify text labels inside nodes are fully visible and not clipped at edges (getBBox fix)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Pre-flight Checklist

- [x] Changes are limited to a single feature/bugfix
- [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>