### PR TITLE
fix: quote file mention paths containing spaces

### DIFF
--- a/src/core/mentions/index.test.ts
+++ b/src/core/mentions/index.test.ts
@@ -9,7 +9,7 @@ import * as path from "path"
 import * as sinon from "sinon"
 import { HostProvider } from "@/hosts/host-provider"
 import { setVscodeHostProviderMock } from "@/test/host-provider-test-utils"
-import { parseMentions } from "."
+import { getFileMentionFromPath, parseMentions } from "."
 
 describe("parseMentions", () => {
 	let sandbox: sinon.SinonSandbox
@@ -56,6 +56,30 @@ describe("parseMentions", () => {
 	})
 
 	describe("File mentions", () => {
+		it("should format relative file mentions without spaces", async () => {
+			sandbox.stub(HostProvider.workspace, "getWorkspacePaths").resolves({ paths: [cwd] })
+
+			const result = await getFileMentionFromPath("/test/project/src/index.ts")
+
+			expect(result).to.equal("@/src/index.ts")
+		})
+
+		it("should format relative file mentions with spaces using quoted mention syntax", async () => {
+			sandbox.stub(HostProvider.workspace, "getWorkspacePaths").resolves({ paths: [cwd] })
+
+			const result = await getFileMentionFromPath("/test/project/path with spaces/file.txt")
+
+			expect(result).to.equal('@"/path with spaces/file.txt"')
+		})
+
+		it("should format absolute file mentions with spaces when no cwd is available", async () => {
+			sandbox.stub(HostProvider.workspace, "getWorkspacePaths").resolves({ paths: [] })
+
+			const result = await getFileMentionFromPath("/tmp/path with spaces/file.txt")
+
+			expect(result).to.equal('@"/tmp/path with spaces/file.txt"')
+		})
+
 		it("should handle simple file mention", async () => {
 			const text = "Check @/src/index.ts for details"
 

--- a/src/core/mentions/index.ts
+++ b/src/core/mentions/index.ts
@@ -47,13 +47,17 @@ export async function openMention(mention?: string): Promise<void> {
 export async function getFileMentionFromPath(filePath: string) {
 	const cwd = await getCwd()
 	if (!cwd) {
-		const pathStr = filePath.includes(" ") ? `"${filePath}"` : filePath
-		return "@/" + pathStr
+		return formatFileMention(filePath)
 	}
 	const relativePath = path.relative(cwd, filePath)
-	// Quote paths containing spaces so the LLM parses the full path (#7789)
-	const pathStr = relativePath.includes(" ") ? `"${relativePath}"` : relativePath
-	return "@/" + pathStr
+	return formatFileMention(relativePath)
+}
+
+function formatFileMention(filePath: string): string {
+	const normalizedPath = filePath.replace(/\\/g, "/")
+	const mentionPath = normalizedPath.startsWith("/") ? normalizedPath : `/${normalizedPath}`
+	// Quoted mention syntax expects the slash to be inside the quotes: @"/path with spaces"
+	return mentionPath.includes(" ") ? `@"${mentionPath}"` : `@${mentionPath}`
 }
 
 export async function parseMentions(

--- a/src/core/mentions/index.ts
+++ b/src/core/mentions/index.ts
@@ -47,10 +47,13 @@ export async function openMention(mention?: string): Promise<void> {
 export async function getFileMentionFromPath(filePath: string) {
 	const cwd = await getCwd()
 	if (!cwd) {
-		return "@/" + filePath
+		const pathStr = filePath.includes(" ") ? `"${filePath}"` : filePath
+		return "@/" + pathStr
 	}
 	const relativePath = path.relative(cwd, filePath)
-	return "@/" + relativePath
+	// Quote paths containing spaces so the LLM parses the full path (#7789)
+	const pathStr = relativePath.includes(" ") ? `"${relativePath}"` : relativePath
+	return "@/" + pathStr
 }
 
 export async function parseMentions(


### PR DESCRIPTION
## Summary

- Fixes #7789 — "Add to Cline" inserts unquoted file paths, so files with spaces get truncated by the LLM
- `getFileMentionFromPath()` now wraps paths containing spaces in quotes
- Upstream already added parsing support for quoted mentions (commit 0d933e8) but never fixed the generation side — this is the missing piece

## Test Procedure

1. Right-click a file with spaces in its path (e.g. `My Documents/config file.json`)
2. Select "Add to Cline"
3. Verify the mention appears as `@/"My Documents/config file.json"` (quoted)
4. Verify the LLM can read the full file path

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Pre-flight Checklist

- [x] Changes are limited to a single feature/bugfix
- [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

Replaces #8888 (rebased on current upstream).

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>