### PR TITLE
fix: DiffViewProvider — await scroll, accurate line count, BOM preservation

### DIFF
--- a/cli/src/acp/ACPDiffViewProvider.ts
+++ b/cli/src/acp/ACPDiffViewProvider.ts
@@ -211,7 +211,7 @@ export class ACPDiffViewProvider extends FileEditProvider {
 	 * content via the ACP connection. Otherwise, it falls back to the
 	 * FileEditProvider's local fs implementation.
 	 */
-	protected override async saveDocument(): Promise<Boolean> {
+	protected override async saveDocument(): Promise<boolean> {
 		// If we can't write files via ACP, fall back to FileEditProvider
 		if (!this.canWriteFile()) {
 			Logger.debug("[ACPDiffViewProvider] Client does not support fs.writeTextFile, falling back to local fs")

--- a/src/hosts/external/ExternalDiffviewProvider.ts
+++ b/src/hosts/external/ExternalDiffviewProvider.ts
@@ -55,7 +55,7 @@ export class ExternalDiffViewProvider extends DiffViewProvider {
 		return lines.length
 	}
 
-	protected async saveDocument(): Promise<Boolean> {
+	protected async saveDocument(): Promise<boolean> {
 		if (!this.activeDiffEditorId) {
 			return false
 		}
@@ -68,9 +68,8 @@ export class ExternalDiffViewProvider extends DiffViewProvider {
 				// consider it a real error.
 				Logger.log("Diff not found:", this.activeDiffEditorId)
 				return false
-			} else {
-				throw err
 			}
+			throw err
 		}
 	}
 

--- a/src/hosts/vscode/VscodeDiffViewProvider.ts
+++ b/src/hosts/vscode/VscodeDiffViewProvider.ts
@@ -190,7 +190,7 @@ export class VscodeDiffViewProvider extends DiffViewProvider {
 		return this.activeDiffEditor.document.getText()
 	}
 
-	protected override async saveDocument(): Promise<Boolean> {
+	protected override async saveDocument(): Promise<boolean> {
 		if (!this.activeDiffEditor) {
 			return false
 		}

--- a/src/integrations/editor/DiffViewProvider.ts
+++ b/src/integrations/editor/DiffViewProvider.ts
@@ -22,8 +22,8 @@ export abstract class DiffViewProvider {
 	private preDiagnostics: FileDiagnostics[] = []
 	protected relPath?: string
 	protected absolutePath?: string
-	protected fileEncoding: string = "utf8"
-	private originalHadBom = false
+	protected fileEncoding = "utf8"
+	protected originalHadBom = false
 	private streamedLines: string[] = []
 	private newContent?: string
 
@@ -161,7 +161,7 @@ export abstract class DiffViewProvider {
 	 *
 	 * @returns true if the file was saved.
 	 */
-	protected abstract saveDocument(): Promise<Boolean>
+	protected abstract saveDocument(): Promise<boolean>
 
 	/**
 	 * Closes all open diff views.
@@ -355,12 +355,6 @@ export abstract class DiffViewProvider {
 			}
 		}
 
-		// Re-add BOM if the original file had one — update() strips it to prevent
-		// duplication during streaming, but we need to preserve it in the final save.
-		if (this.originalHadBom && !this.newContent.startsWith("\ufeff")) {
-			this.newContent = "\ufeff" + this.newContent
-		}
-
 		await this.saveDocument()
 		// get text after save in case there is any auto-formatting done by the editor
 		const postSaveContent = (await this.getDocumentText()) || ""
@@ -372,12 +366,27 @@ export abstract class DiffViewProvider {
 		const newProblemsMessage =
 			newProblems.length > 0 ? `\n\nNew problems detected after saving the file:\n${newProblems}` : ""
 
+		// Strip any leading BOM so the comparison below isn't thrown off by it:
+		// update() strips the BOM from incoming content before populating the document,
+		// while the host editor may re-add it (or not) on save. Comparing BOM-stripped
+		// strings avoids false "user edited Cline's output" reports on BOM files.
+		const stripBom = (s: string) => (s.startsWith("\ufeff") ? s.slice(1) : s)
+
 		// If the edited content has different EOL characters, we don't want to show a diff with all the EOL differences.
 		const newContentEOL = this.newContent.includes("\r\n") ? "\r\n" : "\n"
-		const normalizedPreSaveContent = preSaveContent.replace(/\r\n|\n/g, newContentEOL).trimEnd() + newContentEOL // trimEnd to fix issue where editor adds in extra new line automatically
-		const normalizedPostSaveContent = postSaveContent.replace(/\r\n|\n/g, newContentEOL).trimEnd() + newContentEOL // this is the final content we return to the model to use as the new baseline for future edits
+		const normalizedPreSaveContent =
+			stripBom(preSaveContent)
+				.replace(/\r\n|\n/g, newContentEOL)
+				.trimEnd() + newContentEOL // trimEnd to fix issue where editor adds in extra new line automatically
+		const normalizedPostSaveContent =
+			stripBom(postSaveContent)
+				.replace(/\r\n|\n/g, newContentEOL)
+				.trimEnd() + newContentEOL // this is the final content we return to the model to use as the new baseline for future edits
 		// just in case the new content has a mix of varying EOL characters
-		const normalizedNewContent = this.newContent.replace(/\r\n|\n/g, newContentEOL).trimEnd() + newContentEOL
+		const normalizedNewContent =
+			stripBom(this.newContent)
+				.replace(/\r\n|\n/g, newContentEOL)
+				.trimEnd() + newContentEOL
 
 		let userEdits: string | undefined
 		if (normalizedPreSaveContent !== normalizedNewContent) {

--- a/src/integrations/editor/DiffViewProvider.ts
+++ b/src/integrations/editor/DiffViewProvider.ts
@@ -23,6 +23,7 @@ export abstract class DiffViewProvider {
 	protected relPath?: string
 	protected absolutePath?: string
 	protected fileEncoding: string = "utf8"
+	private originalHadBom = false
 	private streamedLines: string[] = []
 	private newContent?: string
 
@@ -45,9 +46,11 @@ export abstract class DiffViewProvider {
 			const fileBuffer = await fs.readFile(this.absolutePath)
 			this.fileEncoding = await detectEncoding(fileBuffer)
 			this.originalContent = iconv.decode(fileBuffer, this.fileEncoding)
+			this.originalHadBom = this.originalContent.startsWith("\ufeff")
 		} else {
 			this.originalContent = ""
 			this.fileEncoding = "utf8"
+			this.originalHadBom = false
 		}
 		// for new files, create any necessary directories and keep track of new directories to delete if the user denies the operation
 		this.createdDirs = await createDirectoriesForFile(this.absolutePath)
@@ -352,6 +355,12 @@ export abstract class DiffViewProvider {
 			}
 		}
 
+		// Re-add BOM if the original file had one — update() strips it to prevent
+		// duplication during streaming, but we need to preserve it in the final save.
+		if (this.originalHadBom && !this.newContent.startsWith("\ufeff")) {
+			this.newContent = "\ufeff" + this.newContent
+		}
+
 		await this.saveDocument()
 		// get text after save in case there is any auto-formatting done by the editor
 		const postSaveContent = (await this.getDocumentText()) || ""
@@ -430,8 +439,7 @@ export abstract class DiffViewProvider {
 			// revert document
 			// Apply the edit and save, since contents shouldn't have changed this won't show in local history unless of
 			// course the user made changes and saved during the edit.
-			const contents = (await this.getDocumentText()) || ""
-			const lineCount = (contents.match(/\n/g) || []).length + 1
+			const lineCount = await this.getDocumentLineCount()
 			await this.replaceText(this.originalContent ?? "", { startLine: 0, endLine: lineCount }, undefined)
 
 			await this.saveDocument()
@@ -456,7 +464,7 @@ export abstract class DiffViewProvider {
 		for (const part of diffs) {
 			if (part.added || part.removed) {
 				// Found the first diff, scroll to it
-				this.scrollEditorToLine(lineCount)
+				await this.scrollEditorToLine(lineCount)
 				return
 			}
 			if (!part.removed) {
@@ -495,6 +503,7 @@ export abstract class DiffViewProvider {
 		this.preDiagnostics = []
 
 		this.originalContent = undefined
+		this.originalHadBom = false
 		this.fileEncoding = "utf8"
 		this.documentWasOpen = false
 

--- a/src/integrations/editor/FileEditProvider.ts
+++ b/src/integrations/editor/FileEditProvider.ts
@@ -104,7 +104,7 @@ export class FileEditProvider extends DiffViewProvider {
 		return this.getDocumentText()
 	}
 
-	protected async saveDocument(): Promise<Boolean> {
+	protected async saveDocument(): Promise<boolean> {
 		if (!this.absolutePath || !this.documentContent) {
 			return false
 		}
@@ -113,7 +113,13 @@ export class FileEditProvider extends DiffViewProvider {
 			// Always use UTF-8 for writing - it's the modern standard and handles all characters
 			// including emojis. The detected fileEncoding was used for reading to preserve
 			// compatibility, but writing as UTF-8 ensures no character corruption.
-			await fs.writeFile(this.absolutePath, this.documentContent, { encoding: "utf8" })
+			// Re-add the BOM if the original file had one (update() strips it to avoid
+			// duplication during streaming).
+			const contentToWrite =
+				this.originalHadBom && !this.documentContent.startsWith("\ufeff")
+					? "\ufeff" + this.documentContent
+					: this.documentContent
+			await fs.writeFile(this.absolutePath, contentToWrite, { encoding: "utf8" })
 			return true
 		} catch (error) {
 			Logger.error(`Failed to save document to ${this.absolutePath}:`, error)

--- a/src/integrations/editor/__tests__/DiffViewProvider.test.ts
+++ b/src/integrations/editor/__tests__/DiffViewProvider.test.ts
@@ -3,7 +3,7 @@ import { describe, it } from "mocha"
 import { DiffViewProvider } from "../DiffViewProvider"
 
 class TestBoundaryDiffViewProvider extends DiffViewProvider {
-	public documentText: string = ""
+	public documentText = ""
 	public truncatedAt: number | undefined
 
 	async openDiffEditor(): Promise<void> {}
@@ -26,7 +26,7 @@ class TestBoundaryDiffViewProvider extends DiffViewProvider {
 		return this.documentText
 	}
 
-	async saveDocument(): Promise<Boolean> {
+	async saveDocument(): Promise<boolean> {
 		return true
 	}
 	async closeAllDiffViews(): Promise<void> {}
@@ -199,7 +199,7 @@ describe("DiffViewProvider Update Throttling", () => {
 	// Only the final line (without trailing newline) is deferred until isFinal=true.
 
 	class ThrottleTestDiffViewProvider extends DiffViewProvider {
-		public documentText: string = ""
+		public documentText = ""
 		public replaceTextCallCount = 0
 
 		async openDiffEditor(): Promise<void> {}
@@ -215,7 +215,7 @@ describe("DiffViewProvider Update Throttling", () => {
 			return this.documentText
 		}
 
-		async saveDocument(): Promise<Boolean> {
+		async saveDocument(): Promise<boolean> {
 			return true
 		}
 		async closeAllDiffViews(): Promise<void> {}


### PR DESCRIPTION
## Summary

Three small fixes to `DiffViewProvider`:

1. **scrollToFirstDiff()**: add missing `await` on `scrollEditorToLine()` — currently fire-and-forget, so the scroll may not complete before subsequent operations
2. **revertChanges()**: use `getDocumentLineCount()` instead of regex `(contents.match(/\n/g) || []).length + 1` — the regex can be off-by-one with mixed line endings (CRLF vs LF)
3. **BOM preservation**: track whether the original file had a UTF-8 BOM. `update()` correctly strips BOM during streaming to prevent duplication, but `saveChanges()` never re-adds it — files that originally had a BOM silently lose it after editing

## Test Procedure

**Scroll fix (#8885):**
1. Open a large file, make an edit near the middle
2. Verify the diff view scrolls to the first change reliably

**Line count fix (#8884):**
1. Open a file with CRLF line endings
2. Revert changes
3. Verify the full content is restored correctly (no extra/missing lines)

**BOM fix (#8883):**
1. Create a UTF-8 file with BOM (e.g. via Notepad with "UTF-8 with BOM" encoding)
2. Let Cline edit the file
3. Approve the edit
4. Verify the saved file still has the BOM (check with `xxd` or hex editor — should start with `EF BB BF`)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Pre-flight Checklist

- [x] Changes are limited to a single feature/bugfix
- [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

Replaces #8885, #8884, #8883 (rebased on current upstream, combined into one PR since all touch DiffViewProvider).

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>