### PR TITLE
fix: use deterministic keys for MCP server tool routing

### DIFF
--- a/src/services/mcp/McpHub.ts
+++ b/src/services/mcp/McpHub.ts
@@ -46,7 +46,7 @@ import { DEFAULT_REQUEST_TIMEOUT_MS } from "./constants"
 import { McpOAuthManager } from "./McpOAuthManager"
 import { StreamableHttpReconnectHandler } from "./StreamableHttpReconnectHandler"
 import { BaseConfigSchema, McpSettingsSchema, ServerConfigSchema } from "./schemas"
-import { buildServerKey, hashServerName } from "./server-key"
+import { buildServerKey } from "./server-key"
 import { McpConnection, McpServerConfig, Transport } from "./types"
 export class McpHub {
 	getMcpServersPath: () => Promise<string>
@@ -140,15 +140,16 @@ export class McpHub {
 		// Generate a deterministic 6-character ID from the server name.
 		// "c" prefix ensures it starts with a letter (for Gemini compatibility).
 		const uid = buildServerKey(server)
+		const existing = McpHub.mcpServerKeys.get(uid)
+		if (existing && existing !== server) {
+			Logger.warn(
+				`MCP server key collision: "${server}" and "${existing}" both hash to "${uid}". ` +
+					`"${existing}" will be overwritten. Consider renaming one of the servers.`,
+			)
+		}
 		McpHub.mcpServerKeys.set(uid, server)
 		return uid
 	}
-
-	/**
-	 * Expose hashServerName for backward compatibility and direct access.
-	 * @see {@link hashServerName} in ./server-key.ts
-	 */
-	static hashServerName = hashServerName
 
 	/**
 	 * Gets the path to the MCP settings file

--- a/src/services/mcp/McpHub.ts
+++ b/src/services/mcp/McpHub.ts
@@ -33,7 +33,6 @@ import { secondsToMs } from "@utils/time"
 import chokidar, { FSWatcher } from "chokidar"
 import deepEqual from "fast-deep-equal"
 import * as fs from "fs/promises"
-import { nanoid } from "nanoid"
 import ReconnectingEventSource from "reconnecting-eventsource"
 import { z } from "zod"
 import { HostProvider } from "@/hosts/host-provider"
@@ -47,6 +46,7 @@ import { DEFAULT_REQUEST_TIMEOUT_MS } from "./constants"
 import { McpOAuthManager } from "./McpOAuthManager"
 import { StreamableHttpReconnectHandler } from "./StreamableHttpReconnectHandler"
 import { BaseConfigSchema, McpSettingsSchema, ServerConfigSchema } from "./schemas"
+import { buildServerKey, hashServerName } from "./server-key"
 import { McpConnection, McpServerConfig, Transport } from "./types"
 export class McpHub {
 	getMcpServersPath: () => Promise<string>
@@ -124,8 +124,11 @@ export class McpHub {
 	}
 
 	/**
-	 * Create a unique key for an MCP server based on its name.
-	 * This avoids making a tool name too long while still ensuring uniqueness.
+	 * Create a stable, deterministic key for an MCP server based on its name.
+	 * Uses a hash of the server name instead of a random nanoid so the same
+	 * server always gets the same key across extension restarts / reconnects.
+	 * This prevents tool routing failures when the model has cached tool names
+	 * from a previous session (see #8087).
 	 */
 	private getMcpServerKey(server: string): string {
 		// Reuse existing key if server is already registered
@@ -134,13 +137,18 @@ export class McpHub {
 				return existingKey
 			}
 		}
-		// Generate a short 6-character unique ID for the server
-		// Add c prefix to ensure it starts with a letter (for compatibility with Gemini)
-		// Only use the first 5 characters of nanoid to keep it short
-		const uid = "c" + nanoid(5)
+		// Generate a deterministic 6-character ID from the server name.
+		// "c" prefix ensures it starts with a letter (for Gemini compatibility).
+		const uid = buildServerKey(server)
 		McpHub.mcpServerKeys.set(uid, server)
 		return uid
 	}
+
+	/**
+	 * Expose hashServerName for backward compatibility and direct access.
+	 * @see {@link hashServerName} in ./server-key.ts
+	 */
+	static hashServerName = hashServerName
 
 	/**
 	 * Gets the path to the MCP settings file

--- a/src/services/mcp/__tests__/McpHub.serverKeys.test.ts
+++ b/src/services/mcp/__tests__/McpHub.serverKeys.test.ts
@@ -1,0 +1,66 @@
+import { describe, it } from "mocha"
+import "should"
+import { buildServerKey, hashServerName } from "../server-key"
+
+describe("hashServerName", () => {
+	it("should produce a 5-character alphanumeric string", () => {
+		const hash = hashServerName("my-server")
+		hash.length.should.equal(5)
+		;/^[a-z0-9]{5}$/.test(hash).should.be.true()
+	})
+
+	it("should be deterministic — same input always yields same output", () => {
+		const first = hashServerName("test-server")
+		const second = hashServerName("test-server")
+		first.should.equal(second)
+	})
+
+	it("should produce different hashes for different server names", () => {
+		const a = hashServerName("server-alpha")
+		const b = hashServerName("server-beta")
+		a.should.not.equal(b)
+	})
+
+	it("should handle empty strings", () => {
+		const hash = hashServerName("")
+		hash.length.should.equal(5)
+		;/^[a-z0-9]{5}$/.test(hash).should.be.true()
+	})
+
+	it("should handle special characters in server names", () => {
+		const hash = hashServerName("my-server/v2@latest!")
+		hash.length.should.equal(5)
+		;/^[a-z0-9]{5}$/.test(hash).should.be.true()
+	})
+
+	it("should handle very long server names", () => {
+		const hash = hashServerName("a".repeat(1000))
+		hash.length.should.equal(5)
+		;/^[a-z0-9]{5}$/.test(hash).should.be.true()
+	})
+})
+
+describe("buildServerKey", () => {
+	it("should produce a 6-character key starting with 'c'", () => {
+		const key = buildServerKey("my-server")
+		key.length.should.equal(6)
+		key[0].should.equal("c")
+	})
+
+	it("should be deterministic across calls", () => {
+		const first = buildServerKey("my-mcp-server")
+		const second = buildServerKey("my-mcp-server")
+		first.should.equal(second)
+	})
+
+	it("should match 'c' + hashServerName", () => {
+		const key = buildServerKey("test-server")
+		const hash = hashServerName("test-server")
+		key.should.equal(`c${hash}`)
+	})
+
+	it("should only contain alphanumeric characters safe for function names", () => {
+		const key = buildServerKey("a server with spaces & symbols!")
+		;/^c[a-z0-9]{5}$/.test(key).should.be.true()
+	})
+})

--- a/src/services/mcp/server-key.ts
+++ b/src/services/mcp/server-key.ts
@@ -1,0 +1,34 @@
+/**
+ * Generate a deterministic, short key from an MCP server name.
+ *
+ * The key is used to build native tool-call names:
+ *   `{key}0mcp0{tool_name}`
+ *
+ * Requirements:
+ *  - Starts with a letter (Gemini rejects function names starting with digits)
+ *  - 6 characters total (c + 5 alphanumeric) to stay under the 64-char tool-name limit
+ *  - **Deterministic** — the same server name always produces the same key,
+ *    even across extension restarts / reconnects (fixes #8087)
+ *  - Low collision probability for typical numbers of MCP servers (< 100)
+ */
+
+/**
+ * Produce a deterministic 5-character alphanumeric hash from a server name.
+ * Uses djb2 which gives good distribution for short strings;
+ * base-36 output (0-9a-z) is safe for function-name identifiers.
+ */
+export function hashServerName(name: string): string {
+	let hash = 5381
+	for (let i = 0; i < name.length; i++) {
+		hash = (hash * 33) ^ name.charCodeAt(i)
+	}
+	// Convert to unsigned 32-bit, then to base-36 (0-9a-z), take first 5 chars
+	return (hash >>> 0).toString(36).padStart(5, "0").slice(0, 5)
+}
+
+/**
+ * Build the full 6-character server key: "c" prefix + 5-char hash.
+ */
+export function buildServerKey(serverName: string): string {
+	return `c${hashServerName(serverName)}`
+}


### PR DESCRIPTION
### Related Issue

**Issue:** #8087

### Description

MCP tool function names embed a server key (e.g. `cg9IjN0mcp0health_check`). Today this key is generated with `nanoid(5)` — random and ephemeral. After an extension restart or MCP reconnect the key changes, but the model may still have old tool names cached in its context. This causes "No connection found for server" routing failures.

This PR replaces the random nanoid with a **deterministic djb2 hash** of the server name. The same server always gets the same key, so cached tool names remain valid across restarts.

**Changes:**
- Extract `hashServerName()` / `buildServerKey()` into a standalone `server-key.ts` utility (zero dependencies, easy to test)
- Replace `nanoid(5)` call in `McpHub.getMcpServerKey()` with `buildServerKey()`
- Remove unused `nanoid` import from `McpHub.ts`
- Add 10 unit tests covering determinism, output format, edge cases

**Key design decisions:**
- **djb2 hash** — fast, good distribution for short strings, well-established
- **base-36 output** — only `[a-z0-9]`, safe for function-name identifiers across all providers
- **`c` prefix preserved** — Gemini requires function names to start with a letter
- **Same 6-char length** (`c` + 5 chars) — no change to tool name format or length budgets
- **In-memory Map retained** — still used for O(1) reverse lookup in `getMcpServerByKey()`

### Test Procedure

1. Configure 2+ MCP servers with native tool calls enabled
2. Start Cline, list tools — observe stable tool name keys
3. Reload window / restart extension host
4. List tools again — keys should be identical to step 2
5. Attempt MCP tool call — should route correctly (previously failed)

**Unit tests:**
```bash
TS_NODE_PROJECT=./tsconfig.unit-test.json npx mocha \
  --require ts-node/register --require source-map-support/register \
  --spec "src/services/mcp/__tests__/McpHub.serverKeys.test.ts" --no-config
```
All 10 passing.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

### Pre-flight Checklist

- [x] Changes are limited to a single feature/bugfix
- [x] Tests are passing
- [x] Code is formatted and linted (biome)
- [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>