### PR TITLE
Fix cache reflection for Cline and Vercel handlers

### DIFF
--- a/src/core/api/providers/__tests__/cline.test.ts
+++ b/src/core/api/providers/__tests__/cline.test.ts
@@ -64,6 +64,52 @@ describe("ClineHandler", () => {
 		])
 	})
 
+	it("should read Anthropic-style cache creation and read tokens from usage chunks", async () => {
+		const handler = createHandler({})
+		const fakeClient = {
+			chat: {
+				completions: {
+					create: sinon.stub().resolves(
+						createAsyncIterable([
+							{
+								choices: [{}],
+								usage: {
+									prompt_tokens: 1000,
+									completion_tokens: 200,
+									prompt_tokens_details: {
+										cached_tokens: 500,
+									},
+									cache_creation_input_tokens: 300,
+								},
+							},
+						]),
+					),
+				},
+			},
+		}
+		sinon.stub(handler as any, "ensureClient").resolves(fakeClient as any)
+		sinon.stub(handler, "getModel").returns({
+			id: "anthropic/claude-sonnet-4.6",
+			info: openRouterDefaultModelInfo,
+		})
+
+		const chunks: any[] = []
+		for await (const chunk of handler.createMessage("system", [{ role: "user", content: "hi" }])) {
+			chunks.push(chunk)
+		}
+
+		chunks.should.deepEqual([
+			{
+				type: "usage",
+				cacheWriteTokens: 300,
+				cacheReadTokens: 500,
+				inputTokens: 200,
+				outputTokens: 200,
+				totalCost: 0,
+			},
+		])
+	})
+
 	it("should forward enableParallelToolCalling to OpenRouter payload", async () => {
 		const handler = createHandler({ enableParallelToolCalling: true })
 		const createStub = sinon.stub().resolves(createAsyncIterable([]))

--- a/src/core/api/providers/__tests__/vercel-ai-gateway.test.ts
+++ b/src/core/api/providers/__tests__/vercel-ai-gateway.test.ts
@@ -90,5 +90,49 @@ describe("VercelAIGatewayHandler", () => {
 				},
 			])
 		})
+
+		it("should read Anthropic-style cache creation and read tokens from usage chunks", async () => {
+			const handler = new VercelAIGatewayHandler({
+				vercelAiGatewayApiKey: "test-api-key",
+			})
+			const fakeClient = {
+				chat: {
+					completions: {
+						create: sinon.stub().resolves(
+							createAsyncIterable([
+								{
+									choices: [{}],
+									usage: {
+										prompt_tokens: 1000,
+										completion_tokens: 200,
+										prompt_tokens_details: {
+											cached_tokens: 500,
+										},
+										cache_creation_input_tokens: 300,
+									},
+								},
+							]),
+						),
+					},
+				},
+			}
+			sinon.stub(handler as any, "ensureClient").returns(fakeClient as any)
+
+			const chunks: any[] = []
+			for await (const chunk of handler.createMessage("system", [{ role: "user", content: "hi" }])) {
+				chunks.push(chunk)
+			}
+
+			chunks.should.deepEqual([
+				{
+					type: "usage",
+					cacheWriteTokens: 300,
+					cacheReadTokens: 500,
+					inputTokens: 200,
+					outputTokens: 200,
+					totalCost: 0,
+				},
+			])
+		})
 	})
 })

--- a/src/core/api/providers/cline.ts
+++ b/src/core/api/providers/cline.ts
@@ -39,6 +39,14 @@ function normalizeModelId(modelId: string): string {
 
 const CLINE_FREE_MODEL_IDS = new Set(CLINE_RECOMMENDED_MODELS_FALLBACK.free.map((model) => normalizeModelId(model.id)))
 
+function getCacheReadTokens(usage: any): number {
+	return usage?.prompt_tokens_details?.cached_tokens || usage?.cache_read_input_tokens || 0
+}
+
+function getCacheWriteTokens(usage: any): number {
+	return usage?.prompt_tokens_details?.cache_write_tokens || usage?.cache_creation_input_tokens || 0
+}
+
 export class ClineHandler implements ApiHandler {
 	private options: ClineHandlerOptions
 	private clineAccountService = ClineAccountService.getInstance()
@@ -230,6 +238,8 @@ export class ClineHandler implements ApiHandler {
 					let totalCost = (chunk.usage.cost || 0) + (chunk.usage.cost_details?.upstream_inference_cost || 0)
 					const modelId = this.getModel().id
 					const isFreeModel = freeModelIds.has(normalizeModelId(modelId))
+					const cacheReadTokens = getCacheReadTokens(chunk.usage)
+					const cacheWriteTokens = getCacheWriteTokens(chunk.usage)
 
 					if (isFreeModel) {
 						totalCost = 0
@@ -237,9 +247,9 @@ export class ClineHandler implements ApiHandler {
 
 					yield {
 						type: "usage",
-						cacheWriteTokens: 0,
-						cacheReadTokens: chunk.usage.prompt_tokens_details?.cached_tokens || 0,
-						inputTokens: (chunk.usage.prompt_tokens || 0) - (chunk.usage.prompt_tokens_details?.cached_tokens || 0),
+						cacheWriteTokens,
+						cacheReadTokens,
+						inputTokens: Math.max(0, (chunk.usage.prompt_tokens || 0) - cacheReadTokens - cacheWriteTokens),
 						outputTokens: chunk.usage.completion_tokens || 0,
 						totalCost,
 					}
@@ -292,10 +302,15 @@ export class ClineHandler implements ApiHandler {
 
 				return {
 					type: "usage",
-					cacheWriteTokens: 0,
+					cacheWriteTokens: generation?.native_tokens_cache_write || 0,
 					cacheReadTokens: generation?.native_tokens_cached || 0,
 					// openrouter generation endpoint fails often
-					inputTokens: (generation?.native_tokens_prompt || 0) - (generation?.native_tokens_cached || 0),
+					inputTokens: Math.max(
+						0,
+						(generation?.native_tokens_prompt || 0) -
+							(generation?.native_tokens_cached || 0) -
+							(generation?.native_tokens_cache_write || 0),
+					),
 					outputTokens: generation?.native_tokens_completion || 0,
 					totalCost,
 				}

--- a/src/core/api/providers/vercel-ai-gateway.ts
+++ b/src/core/api/providers/vercel-ai-gateway.ts
@@ -19,6 +19,14 @@ interface VercelAIGatewayHandlerOptions extends CommonApiHandlerOptions {
 	thinkingBudgetTokens?: number
 }
 
+function getCacheReadTokens(usage: any): number {
+	return usage?.prompt_tokens_details?.cached_tokens || usage?.cache_read_input_tokens || 0
+}
+
+function getCacheWriteTokens(usage: any): number {
+	return usage?.prompt_tokens_details?.cache_write_tokens || usage?.cache_creation_input_tokens || 0
+}
+
 export class VercelAIGatewayHandler implements ApiHandler {
 	private options: VercelAIGatewayHandlerOptions
 	private client: OpenAI | undefined
@@ -115,12 +123,14 @@ export class VercelAIGatewayHandler implements ApiHandler {
 				if (!didOutputUsage && chunk.usage) {
 					// @ts-expect-error - Vercel AI Gateway extends OpenAI types
 					const totalCost = (chunk.usage.cost || 0) + (chunk.usage.cost_details?.upstream_inference_cost || 0)
+					const cacheReadTokens = getCacheReadTokens(chunk.usage)
+					const cacheWriteTokens = getCacheWriteTokens(chunk.usage)
 
 					yield {
 						type: "usage",
-						cacheWriteTokens: 0,
-						cacheReadTokens: chunk.usage.prompt_tokens_details?.cached_tokens || 0,
-						inputTokens: (chunk.usage.prompt_tokens || 0) - (chunk.usage.prompt_tokens_details?.cached_tokens || 0),
+						cacheWriteTokens,
+						cacheReadTokens,
+						inputTokens: Math.max(0, (chunk.usage.prompt_tokens || 0) - cacheReadTokens - cacheWriteTokens),
 						outputTokens: chunk.usage.completion_tokens || 0,
 						totalCost,
 					}


### PR DESCRIPTION
## Summary
- reflect Anthropic-style cache creation tokens in the `cline` and `vercel-ai-gateway` provider handlers
- subtract cache writes from reflected non-cached input token counts
- add regression coverage for usage chunks that expose `cache_creation_input_tokens`

## Why
`openrouter` already reflected cache writes from `prompt_tokens_details.cache_write_tokens`, but `cline` and `vercel-ai-gateway` were hardcoding `cacheWriteTokens: 0` even when the provider usage chunk exposed Anthropic-style cache writes via `cache_creation_input_tokens`. That made cache accounting and reflected `inputTokens` wrong for multi-turn Claude caching, and it could misstate other providers if they expose the same field shape.

## Validation
- `npm run cli:build`
- `npm run test:unit -- --grep "ClineHandler|VercelAIGatewayHandler|OpenRouterHandler"`
- `npm run check-types`
- live 3-turn matrix with fresh cache seeds across:
  - providers: `cline`, `openrouter`, `vercel-ai-gateway`
  - models: `openai/gpt-5.4`, `google/gemini-3-flash-preview`, `anthropic/claude-sonnet-4.6`

In the live matrix, reflected usage matched the raw provider usage fields for all 27 runs after the patch. Provider-side caching behavior still differs by provider/model, but the repo now reflects the raw cache read/write fields correctly wherever they are exposed.
