### PR TITLE
fix: unblock stuck command_output ask when terminal command ends

### DIFF
--- a/src/core/task/index.ts
+++ b/src/core/task/index.ts
@@ -542,6 +542,9 @@ export class Task {
 					files: result.files,
 				}
 			},
+			resolvePendingAsk: (response) => {
+				void this.handleWebviewAskResponse(response as ClineAskResponse)
+			},
 			updateBackgroundCommandState: (isRunning: boolean) =>
 				this.controller.updateBackgroundCommandState(isRunning, this.taskId),
 			updateClineMessage: async (index: number, updates: { commandCompleted?: boolean; text?: string }) => {

--- a/src/integrations/terminal/CommandOrchestrator.ts
+++ b/src/integrations/terminal/CommandOrchestrator.ts
@@ -124,6 +124,25 @@ export async function orchestrateCommandExecution(
 
 	// Track if buffer gets stuck
 	let bufferStuckTimer: NodeJS.Timeout | null = null
+	let commandOutputAskSequence = 0
+	let pendingCommandOutputAskId: number | null = null
+	let releasePendingCommandOutputAsk: (() => void) | null = null
+
+	const clearPendingCommandOutputAsk = () => {
+		pendingCommandOutputAskId = null
+		releasePendingCommandOutputAsk = null
+	}
+
+	const releaseAnyPendingCommandOutputAsk = () => {
+		const release = releasePendingCommandOutputAsk
+		if (release) {
+			callbacks.resolvePendingAsk?.("messageResponse")
+		}
+		if (!release) {
+			return
+		}
+		release()
+	}
 
 	/**
 	 * Flush buffered output to the UI using ask() which waits for user response.
@@ -148,7 +167,36 @@ export async function orchestrateCommandExecution(
 			try {
 				// Use ask() to present output and wait for user response
 				// This enables "Proceed While Running" button functionality
-				const interaction = await ask("command_output", chunk)
+				const interaction = await new Promise<Awaited<ReturnType<CommandExecutorCallbacks["ask"]>> | undefined>(
+					(resolve, reject) => {
+						const currentAskId = ++commandOutputAskSequence
+						pendingCommandOutputAskId = currentAskId
+
+						releasePendingCommandOutputAsk = () => {
+							if (pendingCommandOutputAskId !== currentAskId) {
+								return
+							}
+							clearPendingCommandOutputAsk()
+							resolve(undefined)
+						}
+
+						ask("command_output", chunk)
+							.then((result) => {
+								if (pendingCommandOutputAskId !== currentAskId) {
+									return
+								}
+								clearPendingCommandOutputAsk()
+								resolve(result)
+							})
+							.catch((error) => {
+								if (pendingCommandOutputAskId !== currentAskId) {
+									return
+								}
+								clearPendingCommandOutputAsk()
+								reject(error)
+							})
+					},
+				)
 				if (!interaction) {
 					return
 				}
@@ -397,6 +445,8 @@ export async function orchestrateCommandExecution(
 	process.once("completed", async (details?: TerminalCompletionDetails) => {
 		completed = true
 		completionDetails = details
+		// If command completed while command_output ask was pending, release it.
+		releaseAnyPendingCommandOutputAsk()
 		// Clear the completion timer
 		if (completionTimer) {
 			clearTimeout(completionTimer)
@@ -410,6 +460,9 @@ export async function orchestrateCommandExecution(
 			}
 			await flushBuffer(true)
 		}
+	})
+	process.once("error", () => {
+		releaseAnyPendingCommandOutputAsk()
 	})
 
 	process.once("no_shell_integration", async () => {
@@ -435,6 +488,8 @@ export async function orchestrateCommandExecution(
 				if (error.message === "COMMAND_TIMEOUT") {
 					// Timeout triggers "Proceed While Running" behavior
 					didContinue = true
+					// Release any pending command_output ask before transitioning state.
+					releaseAnyPendingCommandOutputAsk()
 
 					// Clear all our timers first
 					if (chunkTimer) {

--- a/src/integrations/terminal/CommandOrchestrator.ts
+++ b/src/integrations/terminal/CommandOrchestrator.ts
@@ -135,12 +135,10 @@ export async function orchestrateCommandExecution(
 
 	const releaseAnyPendingCommandOutputAsk = () => {
 		const release = releasePendingCommandOutputAsk
-		if (release) {
-			callbacks.resolvePendingAsk?.("messageResponse")
-		}
 		if (!release) {
 			return
 		}
+		callbacks.resolvePendingAsk?.("messageResponse")
 		release()
 	}
 

--- a/src/integrations/terminal/__tests__/CommandOrchestrator.commandOutputAsk.test.ts
+++ b/src/integrations/terminal/__tests__/CommandOrchestrator.commandOutputAsk.test.ts
@@ -1,0 +1,170 @@
+import assert from "node:assert/strict"
+import { EventEmitter } from "events"
+import { describe, it } from "mocha"
+import { orchestrateCommandExecution } from "../CommandOrchestrator"
+import { CHUNK_DEBOUNCE_MS } from "../constants"
+import type {
+	CommandExecutorCallbacks,
+	ITerminalManager,
+	ITerminalProcess,
+	TerminalCompletionDetails,
+	TerminalProcessEvents,
+	TerminalProcessResultPromise,
+} from "../types"
+
+class FakeTerminalProcess extends EventEmitter<TerminalProcessEvents> implements ITerminalProcess {
+	isHot = false
+	waitForShellIntegration = false
+	private readonly promise: Promise<void>
+	private resolvePromise!: () => void
+	private rejectPromise!: (error: Error) => void
+
+	constructor() {
+		super()
+		this.promise = new Promise<void>((resolve, reject) => {
+			this.resolvePromise = resolve
+			this.rejectPromise = reject
+		})
+	}
+
+	continue(): void {
+		this.emit("continue")
+		this.resolvePromise()
+	}
+
+	getUnretrievedOutput(): string {
+		return ""
+	}
+
+	getCompletionDetails(): TerminalCompletionDetails {
+		return {}
+	}
+
+	complete(details?: TerminalCompletionDetails): void {
+		this.emit("completed", details)
+		this.emit("continue")
+		this.resolvePromise()
+	}
+
+	fail(error: Error): void {
+		this.emit("error", error)
+		this.rejectPromise(error)
+	}
+
+	asResultPromise(): TerminalProcessResultPromise {
+		const processWithPromise = this as unknown as FakeTerminalProcess & Partial<TerminalProcessResultPromise>
+		processWithPromise.then = this.promise.then.bind(this.promise)
+		processWithPromise.catch = this.promise.catch.bind(this.promise)
+		processWithPromise.finally = this.promise.finally.bind(this.promise)
+		return processWithPromise as TerminalProcessResultPromise
+	}
+}
+
+function createCallbacks(): CommandExecutorCallbacks {
+	return {
+		say: async () => undefined,
+		ask: async () => ({ response: "messageResponse" }),
+		updateBackgroundCommandState: () => {},
+		updateClineMessage: async () => {},
+		getClineMessages: () => [],
+		addToUserMessageContent: () => {},
+	}
+}
+
+function createTerminalManager(): ITerminalManager {
+	return {
+		processOutput: (outputLines: string[]) => outputLines.join("\n"),
+	} as ITerminalManager
+}
+
+async function waitFor(predicate: () => boolean, timeoutMs = 300): Promise<void> {
+	const start = Date.now()
+	while (!predicate()) {
+		if (Date.now() - start > timeoutMs) {
+			throw new Error("Condition not met before timeout")
+		}
+		await new Promise((resolve) => setTimeout(resolve, 10))
+	}
+}
+
+describe("CommandOrchestrator command_output ask lifecycle", () => {
+	it("settles a pending command_output ask when the process completes", async () => {
+		const process = new FakeTerminalProcess()
+		let askCalls = 0
+		let askSettled = false
+		let resolvePendingAsk: ((value: { response: "messageResponse" }) => void) | null = null
+
+		const callbacks = createCallbacks()
+		callbacks.ask = async () => {
+			askCalls++
+			return new Promise<{ response: "messageResponse" }>((resolve) => {
+				resolvePendingAsk = resolve
+			}).finally(() => {
+				askSettled = true
+			})
+		}
+		callbacks.resolvePendingAsk = () => {
+			resolvePendingAsk?.({ response: "messageResponse" })
+		}
+
+		const orchestrationPromise = orchestrateCommandExecution(process.asResultPromise(), createTerminalManager(), callbacks, {
+			command: "echo test",
+		})
+
+		process.emit("line", "line one")
+		await new Promise((resolve) => setTimeout(resolve, CHUNK_DEBOUNCE_MS + 40))
+		assert.equal(askCalls, 1, "expected command_output ask after buffered output flush")
+
+		process.complete({ exitCode: 0, signal: null })
+		await orchestrationPromise
+
+		try {
+			await waitFor(() => askSettled, 500)
+			assert.equal(askSettled, true, "pending command_output ask should settle after process completion")
+		} finally {
+			;(resolvePendingAsk as ((value: { response: "messageResponse" }) => void) | null)?.({
+				response: "messageResponse",
+			})
+		}
+	})
+
+	it("settles a pending command_output ask when the process errors", async () => {
+		const process = new FakeTerminalProcess()
+		let askCalls = 0
+		let askSettled = false
+		let resolvePendingAsk: ((value: { response: "messageResponse" }) => void) | null = null
+
+		const callbacks = createCallbacks()
+		callbacks.ask = async () => {
+			askCalls++
+			return new Promise<{ response: "messageResponse" }>((resolve) => {
+				resolvePendingAsk = resolve
+			}).finally(() => {
+				askSettled = true
+			})
+		}
+		callbacks.resolvePendingAsk = () => {
+			resolvePendingAsk?.({ response: "messageResponse" })
+		}
+
+		const orchestrationPromise = orchestrateCommandExecution(process.asResultPromise(), createTerminalManager(), callbacks, {
+			command: "echo test",
+		})
+
+		process.emit("line", "line one")
+		await new Promise((resolve) => setTimeout(resolve, CHUNK_DEBOUNCE_MS + 40))
+		assert.equal(askCalls, 1, "expected command_output ask after buffered output flush")
+
+		process.fail(new Error("process failed"))
+		await assert.rejects(orchestrationPromise, /process failed/)
+
+		try {
+			await waitFor(() => askSettled, 500)
+			assert.equal(askSettled, true, "pending command_output ask should settle after process error")
+		} finally {
+			;(resolvePendingAsk as ((value: { response: "messageResponse" }) => void) | null)?.({
+				response: "messageResponse",
+			})
+		}
+	})
+})

--- a/src/integrations/terminal/__tests__/CommandOrchestrator.commandOutputAsk.test.ts
+++ b/src/integrations/terminal/__tests__/CommandOrchestrator.commandOutputAsk.test.ts
@@ -167,4 +167,78 @@ describe("CommandOrchestrator command_output ask lifecycle", () => {
 			})
 		}
 	})
+
+	it("settles a pending command_output ask when execution transitions on timeout", async () => {
+		const process = new FakeTerminalProcess()
+		let askCalls = 0
+		let askSettled = false
+		let resolvePendingAsk: ((value: { response: "messageResponse" }) => void) | null = null
+
+		const callbacks = createCallbacks()
+		callbacks.ask = async () => {
+			askCalls++
+			return new Promise<{ response: "messageResponse" }>((resolve) => {
+				resolvePendingAsk = resolve
+			}).finally(() => {
+				askSettled = true
+			})
+		}
+		callbacks.resolvePendingAsk = () => {
+			resolvePendingAsk?.({ response: "messageResponse" })
+		}
+
+		const orchestrationPromise = orchestrateCommandExecution(process.asResultPromise(), createTerminalManager(), callbacks, {
+			command: "sleep 10",
+			timeoutSeconds: 0.3,
+		})
+
+		process.emit("line", "line one")
+		await new Promise((resolve) => setTimeout(resolve, CHUNK_DEBOUNCE_MS + 40))
+		assert.equal(askCalls, 1, "expected command_output ask after buffered output flush")
+		const result = await orchestrationPromise
+
+		try {
+			await waitFor(() => askSettled, 500)
+			assert.equal(askSettled, true, "pending command_output ask should settle after timeout transition")
+			assert.equal(result.completed, false)
+			assert.match(result.result as string, /Command execution timed out/)
+		} finally {
+			;(resolvePendingAsk as ((value: { response: "messageResponse" }) => void) | null)?.({
+				response: "messageResponse",
+			})
+		}
+	})
+
+	it("does not attempt to resolve the same pending ask twice across lifecycle events", async () => {
+		const process = new FakeTerminalProcess()
+		let askCalls = 0
+		let resolvePendingAsk: ((value: { response: "messageResponse" }) => void) | null = null
+		let resolvePendingAskCalls = 0
+
+		const callbacks = createCallbacks()
+		callbacks.ask = async () => {
+			askCalls++
+			return new Promise<{ response: "messageResponse" }>((resolve) => {
+				resolvePendingAsk = resolve
+			})
+		}
+		callbacks.resolvePendingAsk = () => {
+			resolvePendingAskCalls++
+			resolvePendingAsk?.({ response: "messageResponse" })
+		}
+
+		const orchestrationPromise = orchestrateCommandExecution(process.asResultPromise(), createTerminalManager(), callbacks, {
+			command: "echo test",
+		})
+
+		process.emit("line", "line one")
+		await new Promise((resolve) => setTimeout(resolve, CHUNK_DEBOUNCE_MS + 40))
+		assert.equal(askCalls, 1, "expected command_output ask after buffered output flush")
+
+		process.complete({ exitCode: 0, signal: null })
+		await orchestrationPromise
+
+		process.emit("error", new Error("late error event"))
+		assert.equal(resolvePendingAskCalls, 1, "pending ask should be released at most once")
+	})
 })

--- a/src/integrations/terminal/types.ts
+++ b/src/integrations/terminal/types.ts
@@ -328,6 +328,8 @@ export interface CommandExecutorCallbacks {
 	 * This is used for "Proceed While Running" flow where we need to wait for user input
 	 */
 	ask: (type: string, text?: string, partial?: boolean) => Promise<AskResponse>
+	/** Resolve the currently pending ask (if any). Used to release command_output waits on terminal lifecycle transitions. */
+	resolvePendingAsk?: (response: AskResponse["response"]) => void
 	/** Update the background command running state in the controller */
 	updateBackgroundCommandState: (running: boolean) => void
 	/**


### PR DESCRIPTION
### Related Issue

**Issue:** #10235

### Description

This fixes a command orchestration deadlock where `ask("command_output", ...)` could remain pending after the terminal process already completed or errored.

The fix adds an explicit release path for pending `command_output` asks during terminal lifecycle transitions (`completed`, `error`, and timeout transition), and wires a targeted callback from `Task` so the underlying pending ask state is resolved.

It also adds regression tests to verify pending `command_output` asks are settled on both completion and error paths.

### Test Procedure

Ran focused terminal-related unit coverage:

- `npm run test:unit -- --grep "CommandOrchestrator|VscodeTerminalProcess|ExecuteCommandToolHandler.timeout"`

Verified:

- Existing ExecuteCommand timeout policy tests pass
- New command_output ask lifecycle tests pass for both completion and error scenarios

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A (no UI change)

### Additional Notes

This patch intentionally keeps `Task.ask()` semantics unchanged globally and scopes behavior to terminal orchestration via callback release.
