### PR TITLE
fix(prompts): add use_skill docs and guard hardcoded TOOL_USE drift

### DIFF
--- a/src/core/prompts/system-prompt/__tests__/__snapshots__/test_hermes_4-basic.snap
+++ b/src/core/prompts/system-prompt/__tests__/__snapshots__/test_hermes_4-basic.snap
@@ -91,6 +91,13 @@ Param: context (Current Work; Key Concepts; Relevant Files/Code; Problem Solving
 <context>context to preload new task with</context>
 </new_task>
 
+**use_skill** — Load and activate a skill by exact name. Use this once when the request matches one of the listed skills.
+Params: skill_name.
+*Example:*
+<use_skill>
+<skill_name>skill name here</skill_name>
+</use_skill>
+
 **plan_mode_respond** — PLAN-only reply.
 Params: response, needs_more_exploration (optional).
 Include options/trade-offs when helpful, ask if plan matches, then add the exact mode-switch line.

--- a/src/core/prompts/system-prompt/__tests__/__snapshots__/test_hermes_4-no-browser.snap
+++ b/src/core/prompts/system-prompt/__tests__/__snapshots__/test_hermes_4-no-browser.snap
@@ -91,6 +91,13 @@ Param: context (Current Work; Key Concepts; Relevant Files/Code; Problem Solving
 <context>context to preload new task with</context>
 </new_task>
 
+**use_skill** — Load and activate a skill by exact name. Use this once when the request matches one of the listed skills.
+Params: skill_name.
+*Example:*
+<use_skill>
+<skill_name>skill name here</skill_name>
+</use_skill>
+
 **plan_mode_respond** — PLAN-only reply.
 Params: response, needs_more_exploration (optional).
 Include options/trade-offs when helpful, ask if plan matches, then add the exact mode-switch line.

--- a/src/core/prompts/system-prompt/__tests__/__snapshots__/test_hermes_4-no-focus-chain.snap
+++ b/src/core/prompts/system-prompt/__tests__/__snapshots__/test_hermes_4-no-focus-chain.snap
@@ -91,6 +91,13 @@ Param: context (Current Work; Key Concepts; Relevant Files/Code; Problem Solving
 <context>context to preload new task with</context>
 </new_task>
 
+**use_skill** — Load and activate a skill by exact name. Use this once when the request matches one of the listed skills.
+Params: skill_name.
+*Example:*
+<use_skill>
+<skill_name>skill name here</skill_name>
+</use_skill>
+
 **plan_mode_respond** — PLAN-only reply.
 Params: response, needs_more_exploration (optional).
 Include options/trade-offs when helpful, ask if plan matches, then add the exact mode-switch line.

--- a/src/core/prompts/system-prompt/__tests__/__snapshots__/test_hermes_4-no-mcp.snap
+++ b/src/core/prompts/system-prompt/__tests__/__snapshots__/test_hermes_4-no-mcp.snap
@@ -91,6 +91,13 @@ Param: context (Current Work; Key Concepts; Relevant Files/Code; Problem Solving
 <context>context to preload new task with</context>
 </new_task>
 
+**use_skill** — Load and activate a skill by exact name. Use this once when the request matches one of the listed skills.
+Params: skill_name.
+*Example:*
+<use_skill>
+<skill_name>skill name here</skill_name>
+</use_skill>
+
 **plan_mode_respond** — PLAN-only reply.
 Params: response, needs_more_exploration (optional).
 Include options/trade-offs when helpful, ask if plan matches, then add the exact mode-switch line.

--- a/src/core/prompts/system-prompt/__tests__/__snapshots__/zai_glm_4_6-basic.snap
+++ b/src/core/prompts/system-prompt/__tests__/__snapshots__/zai_glm_4_6-basic.snap
@@ -118,6 +118,13 @@ Param: context (Current Work; Key Concepts; Relevant Files/Code; Problem Solving
 <context>context to preload new task with</context>
 </new_task>
 
+**use_skill** — Load and activate a skill by exact name. Use this once when the request matches one of the listed skills.
+Params: skill_name.
+*Example:*
+<use_skill>
+<skill_name>skill name here</skill_name>
+</use_skill>
+
 **plan_mode_respond** — PLAN-only reply.
 Params: response, needs_more_exploration (optional).
 Include options/trade-offs when helpful, ask if plan matches, then add the exact mode-switch line.

--- a/src/core/prompts/system-prompt/__tests__/__snapshots__/zai_glm_4_6-no-browser.snap
+++ b/src/core/prompts/system-prompt/__tests__/__snapshots__/zai_glm_4_6-no-browser.snap
@@ -118,6 +118,13 @@ Param: context (Current Work; Key Concepts; Relevant Files/Code; Problem Solving
 <context>context to preload new task with</context>
 </new_task>
 
+**use_skill** — Load and activate a skill by exact name. Use this once when the request matches one of the listed skills.
+Params: skill_name.
+*Example:*
+<use_skill>
+<skill_name>skill name here</skill_name>
+</use_skill>
+
 **plan_mode_respond** — PLAN-only reply.
 Params: response, needs_more_exploration (optional).
 Include options/trade-offs when helpful, ask if plan matches, then add the exact mode-switch line.

--- a/src/core/prompts/system-prompt/__tests__/__snapshots__/zai_glm_4_6-no-focus-chain.snap
+++ b/src/core/prompts/system-prompt/__tests__/__snapshots__/zai_glm_4_6-no-focus-chain.snap
@@ -118,6 +118,13 @@ Param: context (Current Work; Key Concepts; Relevant Files/Code; Problem Solving
 <context>context to preload new task with</context>
 </new_task>
 
+**use_skill** — Load and activate a skill by exact name. Use this once when the request matches one of the listed skills.
+Params: skill_name.
+*Example:*
+<use_skill>
+<skill_name>skill name here</skill_name>
+</use_skill>
+
 **plan_mode_respond** — PLAN-only reply.
 Params: response, needs_more_exploration (optional).
 Include options/trade-offs when helpful, ask if plan matches, then add the exact mode-switch line.

--- a/src/core/prompts/system-prompt/__tests__/__snapshots__/zai_glm_4_6-no-mcp.snap
+++ b/src/core/prompts/system-prompt/__tests__/__snapshots__/zai_glm_4_6-no-mcp.snap
@@ -90,6 +90,13 @@ Param: context (Current Work; Key Concepts; Relevant Files/Code; Problem Solving
 <context>context to preload new task with</context>
 </new_task>
 
+**use_skill** — Load and activate a skill by exact name. Use this once when the request matches one of the listed skills.
+Params: skill_name.
+*Example:*
+<use_skill>
+<skill_name>skill name here</skill_name>
+</use_skill>
+
 **plan_mode_respond** — PLAN-only reply.
 Params: response, needs_more_exploration (optional).
 Include options/trade-offs when helpful, ask if plan matches, then add the exact mode-switch line.

--- a/src/core/prompts/system-prompt/__tests__/integration.test.ts
+++ b/src/core/prompts/system-prompt/__tests__/integration.test.ts
@@ -23,7 +23,10 @@ import * as path from "node:path"
 import { expect } from "chai"
 import type { McpHub } from "@/services/mcp/McpHub"
 import { ModelFamily } from "@/shared/prompts"
+import { ClineDefaultTool } from "@/shared/tools"
 import { getSystemPrompt } from "../index"
+import { PromptRegistry } from "../registry/PromptRegistry"
+import { SystemPromptSection } from "../templates/placeholders"
 import type { SystemPromptContext } from "../types"
 
 // ============================================================================
@@ -299,6 +302,50 @@ describe("Prompt System Integration Tests", () => {
 						const snapshotName = `${providerId}_${modelId.replace(/[^a-zA-Z0-9]/g, "_")}-parallel-tools.snap`
 						await assertSnapshot(snapshotName, systemPrompt)
 					})
+				})
+			}
+		})
+
+		describe("Hardcoded TOOL_USE drift guard", () => {
+			const toolNameByKey: Partial<Record<ClineDefaultTool, string>> = {
+				[ClineDefaultTool.USE_SUBAGENTS]: "use_subagents",
+				[ClineDefaultTool.USE_SKILL]: "use_skill",
+			}
+
+			const driftGuardCases = [
+				{ modelId: "glm-4.6", providerId: "zai" },
+				{ modelId: "hermes-4", providerId: "test" },
+				{ modelId: "qwen3_coder", providerId: "lmstudio" },
+			]
+
+			for (const { modelId, providerId } of driftGuardCases) {
+				it(`should include key tool docs in rendered prompt for ${providerId}/${modelId}`, async () => {
+					const context: SystemPromptContext = {
+						...baseContext,
+						providerInfo: makeProviderInfo(modelId, providerId),
+						enableNativeToolCalls: false,
+					}
+					const registry = PromptRegistry.getInstance()
+					const variant = registry.getVariant(context)
+					const toolUseTemplate = variant.componentOverrides[SystemPromptSection.TOOL_USE]?.template
+
+					expect(toolUseTemplate).to.exist
+
+					const renderedToolUse = typeof toolUseTemplate === "function" ? toolUseTemplate(context) : toolUseTemplate
+					expect(renderedToolUse).to.be.a("string")
+					expect(renderedToolUse).to.not.include("{{TOOLS_SECTION}}")
+
+					const configuredKeyTools = (variant.tools ?? []).filter(
+						(tool) => tool === ClineDefaultTool.USE_SUBAGENTS || tool === ClineDefaultTool.USE_SKILL,
+					)
+					expect(configuredKeyTools.length).to.be.greaterThan(0)
+
+					const { systemPrompt } = await getSystemPrompt(context)
+					for (const keyTool of configuredKeyTools) {
+						const toolName = toolNameByKey[keyTool]
+						expect(toolName).to.be.a("string")
+						expect(systemPrompt).to.include(`**${toolName}**`)
+					}
 				})
 			}
 		})

--- a/src/core/prompts/system-prompt/variants/glm/overrides.ts
+++ b/src/core/prompts/system-prompt/variants/glm/overrides.ts
@@ -129,6 +129,13 @@ Param: context (Current Work; Key Concepts; Relevant Files/Code; Problem Solving
 <context>context to preload new task with</context>
 </new_task>
 
+**use_skill** — Load and activate a skill by exact name. Use this once when the request matches one of the listed skills.
+Params: skill_name.
+*Example:*
+<use_skill>
+<skill_name>skill name here</skill_name>
+</use_skill>
+
 **plan_mode_respond** — PLAN-only reply.
 Params: response, needs_more_exploration (optional).
 Include options/trade-offs when helpful, ask if plan matches, then add the exact mode-switch line.

--- a/src/core/prompts/system-prompt/variants/hermes/overrides.ts
+++ b/src/core/prompts/system-prompt/variants/hermes/overrides.ts
@@ -101,6 +101,13 @@ Param: context (Current Work; Key Concepts; Relevant Files/Code; Problem Solving
 <context>context to preload new task with</context>
 </new_task>
 
+**use_skill** — Load and activate a skill by exact name. Use this once when the request matches one of the listed skills.
+Params: skill_name.
+*Example:*
+<use_skill>
+<skill_name>skill name here</skill_name>
+</use_skill>
+
 **plan_mode_respond** — PLAN-only reply.
 Params: response, needs_more_exploration (optional).
 Include options/trade-offs when helpful, ask if plan matches, then add the exact mode-switch line.


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

### Description

This PR addresses prompt drift in hardcoded `TOOL_USE` overrides by:

- adding `**use_skill**` tool documentation to the hardcoded GLM and Hermes `TOOL_USE` templates (both variants enable `ClineDefaultTool.USE_SKILL`)
- adding a regression guard in `integration.test.ts` that checks rendered prompts for hardcoded `TOOL_USE` variants and fails if key configured tools are omitted
- updating prompt snapshots for GLM, Hermes, and XS

Note: because `main` currently does not yet include the `use_subagents` hardcoded prompt updates from PR #10200, this branch also includes `use_subagents` text in GLM/Hermes/XS so the new drift guard can enforce both keys (`use_subagents`, `use_skill`) on top of current `main`.

### Test Procedure

- Ran targeted prompt/unit suite with maintainer-recommended grep mode:
  - `npm run test:unit -- --gre "system-prompt|Prompt|snapshot" --update-snapshots`
  - `npm run test:unit -- --gre "system-prompt|Prompt|snapshot"`
- Verified new drift-guard tests pass:
  - `Prompt System Integration Tests > Snapshot Testing > Hardcoded TOOL_USE drift guard`

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A (prompt text and test-only changes)

### Additional Notes

The new guard intentionally targets hardcoded `TOOL_USE` variants to prevent future config/template drift for key tools.
