### PR TITLE
feat: wire up remote globalSkills with enterprise UI and architectural fixes [ENG-1774]

### DIFF
--- a/proto/cline/file.proto
+++ b/proto/cline/file.proto
@@ -295,8 +295,9 @@ message DeleteHookResponse {
 message SkillInfo {
   string name = 1; // Name of the skill (matches directory name)
   string description = 2; // Description from SKILL.md frontmatter
-  string path = 3; // Full path to SKILL.md file
+  string path = 3; // Full path to SKILL.md file (or "remote:<name>" for remote skills)
   bool enabled = 4; // Whether the skill is enabled
+  bool always_enabled = 5; // Whether the skill is always enabled (remote only, user cannot toggle off)
 }
 
 // Response for refreshSkills operation

--- a/proto/cline/file.proto
+++ b/proto/cline/file.proto
@@ -310,6 +310,7 @@ message RefreshedSkills {
 message SkillsToggles {
   map<string, bool> global_skills_toggles = 1;
   map<string, bool> local_skills_toggles = 2;
+  map<string, bool> remote_skills_toggles = 3;
 }
 
 // Request to toggle a skill

--- a/src/core/context/instructions/user-instructions/__tests__/skills.test.ts
+++ b/src/core/context/instructions/user-instructions/__tests__/skills.test.ts
@@ -12,7 +12,7 @@ import * as sinon from "sinon"
 import * as disk from "@/core/storage/disk"
 import { Logger } from "@/shared/services/Logger"
 import * as fsUtils from "@/utils/fs"
-import { discoverSkills, getAvailableSkills, getSkillContent } from "../skills"
+import { discoverSkills, getAvailableSkills, getSkillContent, parseRemoteSkillEntries } from "../skills"
 
 describe("Skills Utility Functions", () => {
 	let sandbox: sinon.SinonSandbox
@@ -469,10 +469,69 @@ description: Test
 	})
 
 	describe("Remote Skills", () => {
+		// entry.name must match frontmatter name (enforced by parseRemoteSkillEntries)
 		const makeEntry = (name: string, desc: string, body = "Instructions", alwaysEnabled = false) => ({
-			name: "entry-key",
+			name,
 			alwaysEnabled,
 			contents: `---\nname: ${name}\ndescription: ${desc}\n---\n${body}`,
+		})
+
+		describe("parseRemoteSkillEntries", () => {
+			it("should return validated entries when entry.name matches frontmatter.name", () => {
+				const entries = [
+					{ name: "Deploy", alwaysEnabled: true, contents: `---\nname: Deploy\ndescription: CI/CD\n---\nBody` },
+				]
+				const result = parseRemoteSkillEntries(entries)
+				expect(result).to.have.lengthOf(1)
+				expect(result[0].name).to.equal("Deploy")
+				expect(result[0].description).to.equal("CI/CD")
+				expect(result[0].alwaysEnabled).to.equal(true)
+			})
+
+			it("should reject entries where entry.name does not match frontmatter.name", () => {
+				const entries = [
+					{
+						name: "entry-key",
+						alwaysEnabled: false,
+						contents: `---\nname: Different Name\ndescription: Desc\n---\nBody`,
+					},
+				]
+				const result = parseRemoteSkillEntries(entries)
+				expect(result).to.have.lengthOf(0)
+				sinon.assert.calledWithMatch(Logger.warn as sinon.SinonStub, /does not match frontmatter\.name/)
+			})
+
+			it("should skip entries with missing frontmatter name", () => {
+				const entries = [{ name: "bad", alwaysEnabled: false, contents: `---\ndescription: No name\n---\nContent` }]
+				const result = parseRemoteSkillEntries(entries)
+				expect(result).to.have.lengthOf(0)
+			})
+
+			it("should skip entries with missing frontmatter description", () => {
+				const entries = [{ name: "No Desc", alwaysEnabled: false, contents: `---\nname: No Desc\n---\nContent` }]
+				const result = parseRemoteSkillEntries(entries)
+				expect(result).to.have.lengthOf(0)
+			})
+
+			it("should handle empty array", () => {
+				expect(parseRemoteSkillEntries([])).to.have.lengthOf(0)
+			})
+
+			it("should filter mixed valid and invalid entries", () => {
+				const entries = [
+					{ name: "Good", alwaysEnabled: false, contents: `---\nname: Good\ndescription: Valid\n---\nBody` },
+					{ name: "drift", alwaysEnabled: false, contents: `---\nname: Different\ndescription: Drifted\n---\nBody` },
+					{
+						name: "Also Good",
+						alwaysEnabled: true,
+						contents: `---\nname: Also Good\ndescription: Valid too\n---\nBody`,
+					},
+				]
+				const result = parseRemoteSkillEntries(entries)
+				expect(result).to.have.lengthOf(2)
+				expect(result[0].name).to.equal("Good")
+				expect(result[1].name).to.equal("Also Good")
+			})
 		})
 
 		describe("discoverSkills - remote skill discovery", () => {
@@ -487,12 +546,12 @@ description: Test
 				expect(remoteSkill!.description).to.equal("Handles CI/CD deployment")
 			})
 
-			it("should use frontmatter.name as identity (not entry.name)", async () => {
-				const entries = [makeEntry("My Actual Skill", "The real name")]
+			it("should reject entries where entry.name drifts from frontmatter.name", async () => {
+				const entries = [
+					{ name: "entry-key", alwaysEnabled: false, contents: `---\nname: Actual Name\ndescription: Desc\n---\nBody` },
+				]
 				const skills = await discoverSkills(TEST_CWD, entries)
-
-				expect(skills.find((s) => s.name === "My Actual Skill")).to.not.be.undefined
-				expect(skills.find((s) => s.name === "entry-key")).to.be.undefined
+				expect(skills.find((s) => s.path?.startsWith("remote:"))).to.be.undefined
 			})
 
 			it("should skip remote skills with missing frontmatter name", async () => {
@@ -502,7 +561,7 @@ description: Test
 			})
 
 			it("should skip remote skills with missing frontmatter description", async () => {
-				const entries = [{ name: "bad", alwaysEnabled: false, contents: `---\nname: No Desc\n---\nContent` }]
+				const entries = [{ name: "No Desc", alwaysEnabled: false, contents: `---\nname: No Desc\n---\nContent` }]
 				const skills = await discoverSkills(TEST_CWD, entries)
 				expect(skills.find((s) => s.path?.startsWith("remote:"))).to.be.undefined
 			})
@@ -525,7 +584,9 @@ description: Test
 				isDirectoryStub.withArgs(GLOBAL_SKILLS_DIR).resolves(true)
 				readdirStub.withArgs(GLOBAL_SKILLS_DIR).resolves(["coding"])
 				statStub.withArgs(diskGlobalDir).resolves({ isDirectory: () => true })
-				readFileStub.withArgs(diskGlobalMd, "utf-8").resolves(`---\nname: coding\ndescription: Disk global coding\n---\nDisk`)
+				readFileStub
+					.withArgs(diskGlobalMd, "utf-8")
+					.resolves(`---\nname: coding\ndescription: Disk global coding\n---\nDisk`)
 
 				const available = getAvailableSkills(await discoverSkills(TEST_CWD, entries))
 				expect(available).to.have.lengthOf(1)
@@ -555,7 +616,12 @@ description: Test
 		describe("getSkillContent - remote skill content loading", () => {
 			it("should load content from provided entries for remote skills", async () => {
 				const entries = [makeEntry("Deploy Pipeline", "Deployment skill", "These are the deployment instructions.")]
-				const skill = { name: "Deploy Pipeline", description: "Deployment skill", path: "remote:Deploy Pipeline", source: "global" as const }
+				const skill = {
+					name: "Deploy Pipeline",
+					description: "Deployment skill",
+					path: "remote:Deploy Pipeline",
+					source: "global" as const,
+				}
 				const content = await getSkillContent("Deploy Pipeline", [skill], entries)
 
 				expect(content).to.not.be.null

--- a/src/core/context/instructions/user-instructions/__tests__/skills.test.ts
+++ b/src/core/context/instructions/user-instructions/__tests__/skills.test.ts
@@ -467,4 +467,121 @@ description: Test
 			expect(content!.instructions).to.equal("Instructions with whitespace")
 		})
 	})
+
+	describe("Remote Skills", () => {
+		const makeEntry = (name: string, desc: string, body = "Instructions", alwaysEnabled = false) => ({
+			name: "entry-key",
+			alwaysEnabled,
+			contents: `---\nname: ${name}\ndescription: ${desc}\n---\n${body}`,
+		})
+
+		describe("discoverSkills - remote skill discovery", () => {
+			it("should include remote skills from remote config", async () => {
+				const entries = [makeEntry("Deploy Pipeline", "Handles CI/CD deployment", "Deploy instructions")]
+				const skills = await discoverSkills(TEST_CWD, entries)
+
+				const remoteSkill = skills.find((s) => s.name === "Deploy Pipeline")
+				expect(remoteSkill).to.not.be.undefined
+				expect(remoteSkill!.path).to.equal("remote:Deploy Pipeline")
+				expect(remoteSkill!.source).to.equal("global")
+				expect(remoteSkill!.description).to.equal("Handles CI/CD deployment")
+			})
+
+			it("should use frontmatter.name as identity (not entry.name)", async () => {
+				const entries = [makeEntry("My Actual Skill", "The real name")]
+				const skills = await discoverSkills(TEST_CWD, entries)
+
+				expect(skills.find((s) => s.name === "My Actual Skill")).to.not.be.undefined
+				expect(skills.find((s) => s.name === "entry-key")).to.be.undefined
+			})
+
+			it("should skip remote skills with missing frontmatter name", async () => {
+				const entries = [{ name: "bad", alwaysEnabled: false, contents: `---\ndescription: No name\n---\nContent` }]
+				const skills = await discoverSkills(TEST_CWD, entries)
+				expect(skills.find((s) => s.path?.startsWith("remote:"))).to.be.undefined
+			})
+
+			it("should skip remote skills with missing frontmatter description", async () => {
+				const entries = [{ name: "bad", alwaysEnabled: false, contents: `---\nname: No Desc\n---\nContent` }]
+				const skills = await discoverSkills(TEST_CWD, entries)
+				expect(skills.find((s) => s.path?.startsWith("remote:"))).to.be.undefined
+			})
+
+			it("should handle empty and undefined entries gracefully", async () => {
+				for (const val of [[], undefined]) {
+					const skills = await discoverSkills(TEST_CWD, val)
+					expect(skills.filter((s) => s.path?.startsWith("remote:"))).to.have.lengthOf(0)
+				}
+			})
+		})
+
+		describe("Override resolution (remote > disk-global > project)", () => {
+			it("remote overrides disk-global skill of same name", async () => {
+				const entries = [makeEntry("coding", "Remote coding")]
+				const diskGlobalDir = path.join(GLOBAL_SKILLS_DIR, "coding")
+				const diskGlobalMd = path.join(diskGlobalDir, "SKILL.md")
+				fileExistsStub.withArgs(GLOBAL_SKILLS_DIR).resolves(true)
+				fileExistsStub.withArgs(diskGlobalMd).resolves(true)
+				isDirectoryStub.withArgs(GLOBAL_SKILLS_DIR).resolves(true)
+				readdirStub.withArgs(GLOBAL_SKILLS_DIR).resolves(["coding"])
+				statStub.withArgs(diskGlobalDir).resolves({ isDirectory: () => true })
+				readFileStub.withArgs(diskGlobalMd, "utf-8").resolves(`---\nname: coding\ndescription: Disk global coding\n---\nDisk`)
+
+				const available = getAvailableSkills(await discoverSkills(TEST_CWD, entries))
+				expect(available).to.have.lengthOf(1)
+				expect(available[0].description).to.equal("Remote coding")
+				expect(available[0].path).to.equal("remote:coding")
+			})
+
+			it("remote overrides project skill of same name", async () => {
+				const entries = [makeEntry("coding", "Remote coding")]
+				const projDir = path.join(TEST_CWD, ".clinerules", "skills")
+				const projSkillDir = path.join(projDir, "coding")
+				const projMd = path.join(projSkillDir, "SKILL.md")
+				fileExistsStub.withArgs(projDir).resolves(true)
+				fileExistsStub.withArgs(projMd).resolves(true)
+				isDirectoryStub.withArgs(projDir).resolves(true)
+				readdirStub.withArgs(projDir).resolves(["coding"])
+				statStub.withArgs(projSkillDir).resolves({ isDirectory: () => true })
+				readFileStub.withArgs(projMd, "utf-8").resolves(`---\nname: coding\ndescription: Project coding\n---\nProject`)
+
+				const available = getAvailableSkills(await discoverSkills(TEST_CWD, entries))
+				expect(available).to.have.lengthOf(1)
+				expect(available[0].description).to.equal("Remote coding")
+				expect(available[0].path).to.equal("remote:coding")
+			})
+		})
+
+		describe("getSkillContent - remote skill content loading", () => {
+			it("should load content from provided entries for remote skills", async () => {
+				const entries = [makeEntry("Deploy Pipeline", "Deployment skill", "These are the deployment instructions.")]
+				const skill = { name: "Deploy Pipeline", description: "Deployment skill", path: "remote:Deploy Pipeline", source: "global" as const }
+				const content = await getSkillContent("Deploy Pipeline", [skill], entries)
+
+				expect(content).to.not.be.null
+				expect(content!.name).to.equal("Deploy Pipeline")
+				expect(content!.instructions).to.equal("These are the deployment instructions.")
+			})
+
+			it("should trim whitespace from remote skill instructions", async () => {
+				const entries = [makeEntry("Trim Skill", "Test", "\n   Instructions with whitespace   \n\n")]
+				const skill = { name: "Trim Skill", description: "Test", path: "remote:Trim Skill", source: "global" as const }
+				const content = await getSkillContent("Trim Skill", [skill], entries)
+				expect(content!.instructions).to.equal("Instructions with whitespace")
+			})
+
+			it("should return null if remote skill entry not found in entries", async () => {
+				const skill = { name: "Gone", description: "Removed", path: "remote:Gone", source: "global" as const }
+				const content = await getSkillContent("Gone", [skill], [])
+				expect(content).to.be.null
+			})
+
+			it("should not attempt disk read for remote skills", async () => {
+				const entries = [makeEntry("Remote Only", "Test", "Remote content")]
+				const skill = { name: "Remote Only", description: "Test", path: "remote:Remote Only", source: "global" as const }
+				await getSkillContent("Remote Only", [skill], entries)
+				sinon.assert.notCalled(readFileStub)
+			})
+		})
+	})
 })

--- a/src/core/context/instructions/user-instructions/__tests__/skills.test.ts
+++ b/src/core/context/instructions/user-instructions/__tests__/skills.test.ts
@@ -488,7 +488,7 @@ description: Test
 				expect(result[0].alwaysEnabled).to.equal(true)
 			})
 
-			it("should reject entries where entry.name does not match frontmatter.name", () => {
+			it("should warn but still include entries where entry.name drifts from frontmatter.name", () => {
 				const entries = [
 					{
 						name: "entry-key",
@@ -497,7 +497,8 @@ description: Test
 					},
 				]
 				const result = parseRemoteSkillEntries(entries)
-				expect(result).to.have.lengthOf(0)
+				expect(result).to.have.lengthOf(1)
+				expect(result[0].name).to.equal("Different Name")
 				sinon.assert.calledWithMatch(Logger.warn as sinon.SinonStub, /does not match frontmatter\.name/)
 			})
 
@@ -517,7 +518,7 @@ description: Test
 				expect(parseRemoteSkillEntries([])).to.have.lengthOf(0)
 			})
 
-			it("should filter mixed valid and invalid entries", () => {
+			it("should include all entries with valid frontmatter even with drift", () => {
 				const entries = [
 					{ name: "Good", alwaysEnabled: false, contents: `---\nname: Good\ndescription: Valid\n---\nBody` },
 					{ name: "drift", alwaysEnabled: false, contents: `---\nname: Different\ndescription: Drifted\n---\nBody` },
@@ -528,9 +529,10 @@ description: Test
 					},
 				]
 				const result = parseRemoteSkillEntries(entries)
-				expect(result).to.have.lengthOf(2)
+				expect(result).to.have.lengthOf(3)
 				expect(result[0].name).to.equal("Good")
-				expect(result[1].name).to.equal("Also Good")
+				expect(result[1].name).to.equal("Different")
+				expect(result[2].name).to.equal("Also Good")
 			})
 		})
 
@@ -546,12 +548,15 @@ description: Test
 				expect(remoteSkill!.description).to.equal("Handles CI/CD deployment")
 			})
 
-			it("should reject entries where entry.name drifts from frontmatter.name", async () => {
+			it("should use frontmatter.name as identity even when entry.name drifts", async () => {
 				const entries = [
 					{ name: "entry-key", alwaysEnabled: false, contents: `---\nname: Actual Name\ndescription: Desc\n---\nBody` },
 				]
 				const skills = await discoverSkills(TEST_CWD, entries)
-				expect(skills.find((s) => s.path?.startsWith("remote:"))).to.be.undefined
+				const remoteSkill = skills.find((s) => s.path?.startsWith("remote:"))
+				expect(remoteSkill).to.not.be.undefined
+				expect(remoteSkill!.name).to.equal("Actual Name")
+				expect(remoteSkill!.path).to.equal("remote:Actual Name")
 			})
 
 			it("should skip remote skills with missing frontmatter name", async () => {

--- a/src/core/context/instructions/user-instructions/skills.ts
+++ b/src/core/context/instructions/user-instructions/skills.ts
@@ -18,6 +18,13 @@ export interface ValidatedRemoteSkill {
 	contents: string
 }
 
+export interface SkillToggleState {
+	globalSkillsToggles?: Record<string, boolean>
+	localSkillsToggles?: Record<string, boolean>
+	remoteSkillsToggles?: Record<string, boolean>
+	remoteSkillEntries?: GlobalInstructionsFile[]
+}
+
 /**
  * Parse and validate remote skill entries from GlobalInstructionsFile[].
  *
@@ -161,7 +168,7 @@ export async function discoverSkills(cwd: string, remoteSkillEntries?: GlobalIns
 		}
 	}
 
-	// Remote skills: validated via parseRemoteSkillEntries (entry.name must match frontmatter.name)
+	// Remote skills: validated via parseRemoteSkillEntries and keyed by frontmatter.name.
 	const remoteSkills: SkillMetadata[] = parseRemoteSkillEntries(remoteSkillEntries || []).map((entry) => ({
 		name: entry.name,
 		description: entry.description,
@@ -193,6 +200,34 @@ export function getAvailableSkills(skills: SkillMetadata[]): SkillMetadata[] {
 	}
 
 	return result
+}
+
+export function filterEnabledSkills(skills: SkillMetadata[], toggleState: SkillToggleState = {}): SkillMetadata[] {
+	const globalSkillsToggles = toggleState.globalSkillsToggles ?? {}
+	const localSkillsToggles = toggleState.localSkillsToggles ?? {}
+	const remoteSkillsToggles = toggleState.remoteSkillsToggles ?? {}
+	const remoteSkillMap = new Map(
+		parseRemoteSkillEntries(toggleState.remoteSkillEntries || []).map((entry) => [entry.name, entry]),
+	)
+
+	return skills.filter((skill) => {
+		if (skill.path.startsWith("remote:")) {
+			const name = skill.path.replace("remote:", "")
+			const entry = remoteSkillMap.get(name)
+			if (entry?.alwaysEnabled) {
+				return true
+			}
+			return remoteSkillsToggles[name] !== false
+		}
+
+		const toggles = skill.source === "global" ? globalSkillsToggles : localSkillsToggles
+		return toggles[skill.path] !== false
+	})
+}
+
+export async function discoverAvailableSkills(cwd: string, toggleState: SkillToggleState = {}): Promise<SkillMetadata[]> {
+	const allSkills = await discoverSkills(cwd, toggleState.remoteSkillEntries)
+	return filterEnabledSkills(getAvailableSkills(allSkills), toggleState)
 }
 
 /**

--- a/src/core/context/instructions/user-instructions/skills.ts
+++ b/src/core/context/instructions/user-instructions/skills.ts
@@ -1,4 +1,5 @@
 import { getSkillsDirectoriesForScan } from "@core/storage/disk"
+import type { GlobalInstructionsFile } from "@shared/remote-config/schema"
 import type { SkillContent, SkillMetadata } from "@shared/skills"
 import { fileExistsAtPath, isDirectory } from "@utils/fs"
 import * as fs from "fs/promises"
@@ -91,19 +92,49 @@ async function loadSkillMetadata(
 }
 
 /**
- * Discover all skills from global (~/.cline/skills) and project directories.
- * Returns skills in order: project skills first, then global skills.
- * Global skills take precedence over project skills with the same name.
+ * Discover all skills from global (~/.cline/skills), remote config, and project directories.
+ *
+ * Precedence (highest wins on name collision via getAvailableSkills):
+ *   remote (enterprise) > disk-global (user personal) > project (workspace)
+ *
+ * This is achieved by the array order + getAvailableSkills iterating in reverse (last wins):
+ *   [project..., disk-global..., remote...]
  */
-export async function discoverSkills(cwd: string): Promise<SkillMetadata[]> {
+export async function discoverSkills(cwd: string, remoteSkillEntries?: GlobalInstructionsFile[]): Promise<SkillMetadata[]> {
 	const skills: SkillMetadata[] = []
 
 	const scanDirs = getSkillsDirectoriesForScan(cwd)
 
+	// Collect project and disk-global skills separately so we can insert remote between them
+	const projectSkills: SkillMetadata[] = []
+	const diskGlobalSkills: SkillMetadata[] = []
+
 	for (const dir of scanDirs) {
 		const dirSkills = await scanSkillsDirectory(dir.path, dir.source)
-		skills.push(...dirSkills)
+		if (dir.source === "project") {
+			projectSkills.push(...dirSkills)
+		} else {
+			diskGlobalSkills.push(...dirSkills)
+		}
 	}
+
+	// Remote skills: identity is frontmatter.name (not entry.name)
+	const remoteSkills: SkillMetadata[] = []
+	for (const entry of remoteSkillEntries || []) {
+		const { data: frontmatter } = parseYamlFrontmatter(entry.contents)
+		if (!frontmatter.name || typeof frontmatter.name !== "string") continue
+		if (!frontmatter.description || typeof frontmatter.description !== "string") continue
+		remoteSkills.push({
+			name: frontmatter.name,
+			description: frontmatter.description,
+			path: `remote:${frontmatter.name}`,
+			source: "global",
+		})
+	}
+
+	// Insert in order: project → disk-global → remote
+	// getAvailableSkills iterates backwards so remote (last) wins, then disk-global, then project
+	skills.push(...projectSkills, ...diskGlobalSkills, ...remoteSkills)
 
 	return skills
 }
@@ -129,10 +160,29 @@ export function getAvailableSkills(skills: SkillMetadata[]): SkillMetadata[] {
 
 /**
  * Get full skill content including instructions.
+ * For remote skills, pass remoteSkillEntries so content can be loaded without disk I/O.
  */
-export async function getSkillContent(skillName: string, availableSkills: SkillMetadata[]): Promise<SkillContent | null> {
+export async function getSkillContent(
+	skillName: string,
+	availableSkills: SkillMetadata[],
+	remoteSkillEntries?: GlobalInstructionsFile[],
+): Promise<SkillContent | null> {
 	const skill = availableSkills.find((s) => s.name === skillName)
 	if (!skill) return null
+
+	// Remote skills have no file on disk — retrieve content from the provided entries
+	if (skill.path.startsWith("remote:")) {
+		const entry = (remoteSkillEntries || []).find((e) => {
+			const { data } = parseYamlFrontmatter(e.contents)
+			return typeof data.name === "string" && data.name === skillName
+		})
+		if (!entry) return null
+		const { body } = parseYamlFrontmatter(entry.contents)
+		return {
+			...skill,
+			instructions: body.trim(),
+		}
+	}
 
 	try {
 		const fileContent = await fs.readFile(skill.path, "utf-8")

--- a/src/core/context/instructions/user-instructions/skills.ts
+++ b/src/core/context/instructions/user-instructions/skills.ts
@@ -7,6 +7,49 @@ import * as path from "path"
 import { Logger } from "@/shared/services/Logger"
 import { parseYamlFrontmatter } from "./frontmatter"
 
+/**
+ * A remote skill entry after frontmatter validation.
+ * entry.name must match frontmatter.name to prevent drift between dashboard and SKILL.md content.
+ */
+export interface ValidatedRemoteSkill {
+	name: string
+	description: string
+	alwaysEnabled: boolean
+	contents: string
+}
+
+/**
+ * Parse and validate remote skill entries from GlobalInstructionsFile[].
+ *
+ * Validates:
+ *  - frontmatter.name and frontmatter.description are present strings
+ *  - entry.name matches frontmatter.name (rejects on drift)
+ *
+ * Returns only valid entries. Callers share this single validation point
+ * instead of duplicating frontmatter parsing.
+ */
+export function parseRemoteSkillEntries(entries: GlobalInstructionsFile[]): ValidatedRemoteSkill[] {
+	return entries
+		.map((entry) => {
+			const { data: frontmatter } = parseYamlFrontmatter(entry.contents)
+			if (!frontmatter.name || typeof frontmatter.name !== "string") return null
+			if (!frontmatter.description || typeof frontmatter.description !== "string") return null
+			if (entry.name !== frontmatter.name) {
+				Logger.warn(
+					`Remote skill entry.name "${entry.name}" does not match frontmatter.name "${frontmatter.name}", skipping`,
+				)
+				return null
+			}
+			return {
+				name: entry.name,
+				description: frontmatter.description as string,
+				alwaysEnabled: entry.alwaysEnabled,
+				contents: entry.contents,
+			}
+		})
+		.filter((e): e is NonNullable<typeof e> => e !== null)
+}
+
 /** Parse YAML frontmatter from markdown content (shared helper). */
 function parseFrontmatter(fileContent: string): { data: Record<string, unknown>; content: string } {
 	const result = parseYamlFrontmatter(fileContent)
@@ -118,19 +161,13 @@ export async function discoverSkills(cwd: string, remoteSkillEntries?: GlobalIns
 		}
 	}
 
-	// Remote skills: identity is frontmatter.name (not entry.name)
-	const remoteSkills: SkillMetadata[] = []
-	for (const entry of remoteSkillEntries || []) {
-		const { data: frontmatter } = parseYamlFrontmatter(entry.contents)
-		if (!frontmatter.name || typeof frontmatter.name !== "string") continue
-		if (!frontmatter.description || typeof frontmatter.description !== "string") continue
-		remoteSkills.push({
-			name: frontmatter.name,
-			description: frontmatter.description,
-			path: `remote:${frontmatter.name}`,
-			source: "global",
-		})
-	}
+	// Remote skills: validated via parseRemoteSkillEntries (entry.name must match frontmatter.name)
+	const remoteSkills: SkillMetadata[] = parseRemoteSkillEntries(remoteSkillEntries || []).map((entry) => ({
+		name: entry.name,
+		description: entry.description,
+		path: `remote:${entry.name}`,
+		source: "global" as const,
+	}))
 
 	// Insert in order: project → disk-global → remote
 	// getAvailableSkills iterates backwards so remote (last) wins, then disk-global, then project
@@ -170,12 +207,10 @@ export async function getSkillContent(
 	const skill = availableSkills.find((s) => s.name === skillName)
 	if (!skill) return null
 
-	// Remote skills have no file on disk — retrieve content from the provided entries
+	// Remote skills have no file on disk — retrieve content from the provided entries.
+	// Lookup by entry.name is safe because parseRemoteSkillEntries validated entry.name === frontmatter.name.
 	if (skill.path.startsWith("remote:")) {
-		const entry = (remoteSkillEntries || []).find((e) => {
-			const { data } = parseYamlFrontmatter(e.contents)
-			return typeof data.name === "string" && data.name === skillName
-		})
+		const entry = (remoteSkillEntries || []).find((e) => e.name === skillName)
 		if (!entry) return null
 		const { body } = parseYamlFrontmatter(entry.contents)
 		return {

--- a/src/core/context/instructions/user-instructions/skills.ts
+++ b/src/core/context/instructions/user-instructions/skills.ts
@@ -9,7 +9,7 @@ import { parseYamlFrontmatter } from "./frontmatter"
 
 /**
  * A remote skill entry after frontmatter validation.
- * entry.name must match frontmatter.name to prevent drift between dashboard and SKILL.md content.
+ * name is always frontmatter.name (canonical). A warning is logged if entry.name drifts.
  */
 export interface ValidatedRemoteSkill {
 	name: string
@@ -23,7 +23,7 @@ export interface ValidatedRemoteSkill {
  *
  * Validates:
  *  - frontmatter.name and frontmatter.description are present strings
- *  - entry.name matches frontmatter.name (rejects on drift)
+ *  - Warns if entry.name does not match frontmatter.name (drift)
  *
  * Returns only valid entries. Callers share this single validation point
  * instead of duplicating frontmatter parsing.
@@ -34,14 +34,14 @@ export function parseRemoteSkillEntries(entries: GlobalInstructionsFile[]): Vali
 			const { data: frontmatter } = parseYamlFrontmatter(entry.contents)
 			if (!frontmatter.name || typeof frontmatter.name !== "string") return null
 			if (!frontmatter.description || typeof frontmatter.description !== "string") return null
+			// Warn on drift but use frontmatter.name as the canonical identity.
+			// The dashboard should keep entry.name in sync, but we don't reject on mismatch
+			// since that would silently hide org-configured skills from users.
 			if (entry.name !== frontmatter.name) {
-				Logger.warn(
-					`Remote skill entry.name "${entry.name}" does not match frontmatter.name "${frontmatter.name}", skipping`,
-				)
-				return null
+				Logger.warn(`Remote skill entry.name "${entry.name}" does not match frontmatter.name "${frontmatter.name}"`)
 			}
 			return {
-				name: entry.name,
+				name: frontmatter.name,
 				description: frontmatter.description as string,
 				alwaysEnabled: entry.alwaysEnabled,
 				contents: entry.contents,
@@ -208,9 +208,15 @@ export async function getSkillContent(
 	if (!skill) return null
 
 	// Remote skills have no file on disk — retrieve content from the provided entries.
-	// Lookup by entry.name is safe because parseRemoteSkillEntries validated entry.name === frontmatter.name.
+	// Try entry.name first (fast path when dashboard is in sync), fall back to frontmatter match.
 	if (skill.path.startsWith("remote:")) {
-		const entry = (remoteSkillEntries || []).find((e) => e.name === skillName)
+		let entry = (remoteSkillEntries || []).find((e) => e.name === skillName)
+		if (!entry) {
+			entry = (remoteSkillEntries || []).find((e) => {
+				const { data } = parseYamlFrontmatter(e.contents)
+				return typeof data.name === "string" && data.name === skillName
+			})
+		}
 		if (!entry) return null
 		const { body } = parseYamlFrontmatter(entry.contents)
 		return {

--- a/src/core/controller/file/openFile.ts
+++ b/src/core/controller/file/openFile.ts
@@ -11,9 +11,10 @@ import { Controller } from ".."
  * Opens a file in the editor
  * @param controller The controller instance
  * @param request The request message containing the file path in the 'value' field.
- *                Supports special URI format for remote rules/workflows:
+ *                Supports special URI format for remote rules/workflows/skills:
  *                - remote://rule/{ruleName}
  *                - remote://workflow/{workflowName}
+ *                - remote://skill/{skillName}
  * @returns Empty response
  */
 export async function openFile(_controller: Controller, request: StringRequest): Promise<Empty> {
@@ -29,12 +30,12 @@ export async function openFile(_controller: Controller, request: StringRequest):
 }
 
 /**
- * Opens a remote rule or workflow file by creating a temp file with its contents
- * @param uri The remote URI in format: remote://rule/{name} or remote://workflow/{name}
+ * Opens a remote rule, workflow, or skill file by creating a temp file with its contents
+ * @param uri The remote URI in format: remote://rule/{name}, remote://workflow/{name}, or remote://skill/{name}
  */
 async function openRemoteFile(uri: string): Promise<void> {
-	// Parse: remote://rule/{name} or remote://workflow/{name}
-	const match = uri.match(/^remote:\/\/(rule|workflow)\/(.+)$/)
+	// Parse: remote://rule/{name}, remote://workflow/{name}, or remote://skill/{name}
+	const match = uri.match(/^remote:\/\/(rule|workflow|skill)\/(.+)$/)
 	if (!match) {
 		throw new Error(`Invalid remote file URI: ${uri}`)
 	}
@@ -43,7 +44,14 @@ async function openRemoteFile(uri: string): Promise<void> {
 	const remoteConfig = StateManager.get().getRemoteConfigSettings()
 
 	// Look up content based on type
-	const items = type === "rule" ? remoteConfig.remoteGlobalRules : remoteConfig.remoteGlobalWorkflows
+	let items
+	if (type === "rule") {
+		items = remoteConfig.remoteGlobalRules
+	} else if (type === "workflow") {
+		items = remoteConfig.remoteGlobalWorkflows
+	} else {
+		items = remoteConfig.remoteGlobalSkills
+	}
 	const item = items?.find((r) => r.name === name)
 
 	if (!item?.contents) {
@@ -51,8 +59,7 @@ async function openRemoteFile(uri: string): Promise<void> {
 	}
 
 	// Create temp file with read-only header comment
-	const typeLabel = type === "rule" ? "rule" : "workflow"
-	const header = `# ⚠️ READ-ONLY: This ${typeLabel} is managed by your organization.\n# Changes made here will not be saved.\n\n`
+	const header = `# ⚠️ READ-ONLY: This ${type} is managed by your organization.\n# Changes made here will not be saved.\n\n`
 	const content = header + item.contents
 
 	// Sanitize the name for use in filename (replace invalid characters)

--- a/src/core/controller/file/openFile.ts
+++ b/src/core/controller/file/openFile.ts
@@ -1,7 +1,9 @@
+import { parseYamlFrontmatter } from "@core/context/instructions/user-instructions/frontmatter"
 import { StateManager } from "@core/storage/StateManager"
 import { openFile as openFileIntegration } from "@integrations/misc/open-file"
 import { Empty, StringRequest } from "@shared/proto/cline/common"
 import { REMOTE_URI_SCHEME } from "@shared/remote-config/constants"
+import type { GlobalInstructionsFile } from "@shared/remote-config/schema"
 import { writeFile } from "@utils/fs"
 import * as os from "os"
 import * as path from "path"
@@ -44,7 +46,7 @@ async function openRemoteFile(uri: string): Promise<void> {
 	const remoteConfig = StateManager.get().getRemoteConfigSettings()
 
 	// Look up content based on type
-	let items
+	let items: GlobalInstructionsFile[] | undefined
 	if (type === "rule") {
 		items = remoteConfig.remoteGlobalRules
 	} else if (type === "workflow") {
@@ -52,7 +54,15 @@ async function openRemoteFile(uri: string): Promise<void> {
 	} else {
 		items = remoteConfig.remoteGlobalSkills
 	}
-	const item = items?.find((r) => r.name === name)
+	// Try entry.name first (fast path), fall back to frontmatter.name for skills
+	// in case entry.name drifts from the frontmatter
+	let item = items?.find((r) => r.name === name)
+	if (!item && type === "skill") {
+		item = items?.find((r) => {
+			const { data } = parseYamlFrontmatter(r.contents)
+			return typeof data.name === "string" && data.name === name
+		})
+	}
 
 	if (!item?.contents) {
 		throw new Error(`Remote ${type} not found: ${name}`)

--- a/src/core/controller/file/refreshSkills.ts
+++ b/src/core/controller/file/refreshSkills.ts
@@ -97,6 +97,33 @@ export async function refreshSkills(controller: Controller): Promise<RefreshedSk
 		skill.enabled = globalToggles[skill.path] !== false
 	}
 
+	// Add remote skills from remote config.
+	// Precedence: remote (enterprise) > disk-global (user) > project (workspace).
+	// Remote entries are appended to globalSkills[] and rendered under "Global Skills" in the UI.
+	// The toggle store distinguishes them by the "remote:" path prefix.
+	const remoteConfigSettings = controller.stateManager.getRemoteConfigSettings()
+	const remoteSkillEntries = remoteConfigSettings.remoteGlobalSkills || []
+	const remoteSkillsToggles = controller.stateManager.getGlobalStateKey("remoteSkillsToggles") || {}
+
+	for (const entry of remoteSkillEntries) {
+		const { data: frontmatter } = parseYamlFrontmatter(entry.contents)
+		if (!frontmatter.name || typeof frontmatter.name !== "string") continue
+		if (!frontmatter.description || typeof frontmatter.description !== "string") continue
+
+		const name = frontmatter.name
+		const enabled = entry.alwaysEnabled || remoteSkillsToggles[name] !== false
+
+		globalSkills.push(
+			SkillInfo.create({
+				name,
+				description: frontmatter.description,
+				path: `remote:${name}`,
+				enabled,
+				alwaysEnabled: entry.alwaysEnabled,
+			}),
+		)
+	}
+
 	// Get local toggles and apply them
 	const localToggles = controller.stateManager.getWorkspaceStateKey("localSkillsToggles") || {}
 	for (const skill of localSkills) {

--- a/src/core/controller/file/refreshSkills.ts
+++ b/src/core/controller/file/refreshSkills.ts
@@ -100,8 +100,8 @@ export async function refreshSkills(controller: Controller): Promise<RefreshedSk
 
 	// Add remote skills from remote config.
 	// Precedence: remote (enterprise) > disk-global (user) > project (workspace).
-	// Remote entries are appended to globalSkills[] and rendered under "Global Skills" in the UI.
-	// The toggle store distinguishes them by the "remote:" path prefix.
+	// Remote entries are appended to globalSkills[] and split into the dedicated "Enterprise Skills"
+	// section by the UI. The toggle store distinguishes them by the "remote:" path prefix.
 	const remoteConfigSettings = controller.stateManager.getRemoteConfigSettings()
 	const remoteSkillsToggles = controller.stateManager.getGlobalStateKey("remoteSkillsToggles") || {}
 	const validatedRemoteSkills = parseRemoteSkillEntries(remoteConfigSettings.remoteGlobalSkills || [])

--- a/src/core/controller/file/refreshSkills.ts
+++ b/src/core/controller/file/refreshSkills.ts
@@ -1,3 +1,4 @@
+import { parseRemoteSkillEntries } from "@core/context/instructions/user-instructions/skills"
 import { RefreshedSkills, SkillInfo } from "@shared/proto/cline/file"
 import fs from "fs/promises"
 import path from "path"
@@ -102,22 +103,17 @@ export async function refreshSkills(controller: Controller): Promise<RefreshedSk
 	// Remote entries are appended to globalSkills[] and rendered under "Global Skills" in the UI.
 	// The toggle store distinguishes them by the "remote:" path prefix.
 	const remoteConfigSettings = controller.stateManager.getRemoteConfigSettings()
-	const remoteSkillEntries = remoteConfigSettings.remoteGlobalSkills || []
 	const remoteSkillsToggles = controller.stateManager.getGlobalStateKey("remoteSkillsToggles") || {}
+	const validatedRemoteSkills = parseRemoteSkillEntries(remoteConfigSettings.remoteGlobalSkills || [])
 
-	for (const entry of remoteSkillEntries) {
-		const { data: frontmatter } = parseYamlFrontmatter(entry.contents)
-		if (!frontmatter.name || typeof frontmatter.name !== "string") continue
-		if (!frontmatter.description || typeof frontmatter.description !== "string") continue
-
-		const name = frontmatter.name
-		const enabled = entry.alwaysEnabled || remoteSkillsToggles[name] !== false
+	for (const entry of validatedRemoteSkills) {
+		const enabled = entry.alwaysEnabled || remoteSkillsToggles[entry.name] !== false
 
 		globalSkills.push(
 			SkillInfo.create({
-				name,
-				description: frontmatter.description,
-				path: `remote:${name}`,
+				name: entry.name,
+				description: entry.description,
+				path: `remote:${entry.name}`,
 				enabled,
 				alwaysEnabled: entry.alwaysEnabled,
 			}),

--- a/src/core/controller/file/toggleSkill.ts
+++ b/src/core/controller/file/toggleSkill.ts
@@ -23,11 +23,13 @@ export async function toggleSkill(controller: Controller, request: ToggleSkillRe
 	let globalToggles = controller.stateManager.getGlobalSettingsKey("globalSkillsToggles") || {}
 	let localToggles = controller.stateManager.getWorkspaceStateKey("localSkillsToggles") || {}
 
+	let remoteToggles = controller.stateManager.getGlobalStateKey("remoteSkillsToggles") || {}
+
 	// Remote skills are identified by a "remote:" path prefix. They use a separate toggle store
-	// keyed by frontmatter name (the part after "remote:") rather than the file path.
+	// keyed by skill name (the part after "remote:") rather than the file path.
 	if (skillPath.startsWith("remote:")) {
 		const name = skillPath.replace("remote:", "")
-		const remoteToggles = { ...(controller.stateManager.getGlobalStateKey("remoteSkillsToggles") || {}), [name]: enabled }
+		remoteToggles = { ...remoteToggles, [name]: enabled }
 		controller.stateManager.setGlobalState("remoteSkillsToggles", remoteToggles)
 	} else if (isGlobal) {
 		globalToggles = { ...globalToggles, [skillPath]: enabled }
@@ -42,5 +44,6 @@ export async function toggleSkill(controller: Controller, request: ToggleSkillRe
 	return SkillsToggles.create({
 		globalSkillsToggles: globalToggles,
 		localSkillsToggles: localToggles,
+		remoteSkillsToggles: remoteToggles,
 	})
 }

--- a/src/core/controller/file/toggleSkill.ts
+++ b/src/core/controller/file/toggleSkill.ts
@@ -23,7 +23,13 @@ export async function toggleSkill(controller: Controller, request: ToggleSkillRe
 	let globalToggles = controller.stateManager.getGlobalSettingsKey("globalSkillsToggles") || {}
 	let localToggles = controller.stateManager.getWorkspaceStateKey("localSkillsToggles") || {}
 
-	if (isGlobal) {
+	// Remote skills are identified by a "remote:" path prefix. They use a separate toggle store
+	// keyed by frontmatter name (the part after "remote:") rather than the file path.
+	if (skillPath.startsWith("remote:")) {
+		const name = skillPath.replace("remote:", "")
+		const remoteToggles = { ...(controller.stateManager.getGlobalStateKey("remoteSkillsToggles") || {}), [name]: enabled }
+		controller.stateManager.setGlobalState("remoteSkillsToggles", remoteToggles)
+	} else if (isGlobal) {
 		globalToggles = { ...globalToggles, [skillPath]: enabled }
 		controller.stateManager.setGlobalState("globalSkillsToggles", globalToggles)
 	} else {

--- a/src/core/storage/StateManager.ts
+++ b/src/core/storage/StateManager.ts
@@ -438,6 +438,19 @@ export class StateManager {
 	}
 
 	/**
+	 * Atomically replace the entire remote config cache.
+	 * Use this instead of clearRemoteConfig() + setRemoteConfigField() loops
+	 * to avoid a window where the cache is empty and concurrent readers get stale data.
+	 */
+	replaceRemoteConfig(newCache: Partial<RemoteConfigFields>): void {
+		if (!this.isInitialized) {
+			throw new Error(STATE_MANAGER_NOT_INITIALIZED)
+		}
+
+		this.remoteConfigCache = { ...newCache }
+	}
+
+	/**
 	 * Set models cache for a specific provider (in-memory only, not persisted)
 	 */
 	setModelsCache(

--- a/src/core/storage/__tests__/remote-config-skills.test.ts
+++ b/src/core/storage/__tests__/remote-config-skills.test.ts
@@ -5,9 +5,9 @@
 
 import { expect } from "chai"
 import { describe, it } from "mocha"
-import { transformRemoteConfigToStateShape } from "@/core/storage/remote-config/utils"
 import { synchronizeRemoteRuleToggles } from "@/core/context/instructions/user-instructions/rule-helpers"
-import { parseYamlFrontmatter } from "@/core/context/instructions/user-instructions/frontmatter"
+import { parseRemoteSkillEntries } from "@/core/context/instructions/user-instructions/skills"
+import { transformRemoteConfigToStateShape } from "@/core/storage/remote-config/utils"
 import type { RemoteConfig } from "@/shared/remote-config/schema"
 
 function makeConfig(globalSkills: RemoteConfig["globalSkills"]): RemoteConfig {
@@ -20,7 +20,7 @@ function makeSKILLMd(name: string, description: string, body = "Instructions her
 
 describe("transformRemoteConfigToStateShape - globalSkills", () => {
 	it("maps globalSkills to remoteGlobalSkills", () => {
-		const entries = [{ name: "s1", alwaysEnabled: false, contents: makeSKILLMd("My Skill", "Desc") }]
+		const entries = [{ name: "My Skill", alwaysEnabled: false, contents: makeSKILLMd("My Skill", "Desc") }]
 		const result = transformRemoteConfigToStateShape(makeConfig(entries))
 		expect(result.remoteGlobalSkills).to.deep.equal(entries)
 	})
@@ -37,8 +37,8 @@ describe("transformRemoteConfigToStateShape - globalSkills", () => {
 
 	it("preserves alwaysEnabled flag", () => {
 		const entries = [
-			{ name: "locked", alwaysEnabled: true, contents: makeSKILLMd("Locked", "Desc") },
-			{ name: "unlocked", alwaysEnabled: false, contents: makeSKILLMd("Free", "Desc") },
+			{ name: "Locked", alwaysEnabled: true, contents: makeSKILLMd("Locked", "Desc") },
+			{ name: "Free", alwaysEnabled: false, contents: makeSKILLMd("Free", "Desc") },
 		]
 		const result = transformRemoteConfigToStateShape(makeConfig(entries))
 		expect(result.remoteGlobalSkills![0].alwaysEnabled).to.equal(true)
@@ -58,7 +58,10 @@ describe("synchronizeRemoteRuleToggles - remote skill toggle sync", () => {
 	})
 
 	it("removes stale toggle entries", () => {
-		const result = synchronizeRemoteRuleToggles([{ name: "New", alwaysEnabled: false, contents: "" }], { Old: true, New: false })
+		const result = synchronizeRemoteRuleToggles([{ name: "New", alwaysEnabled: false, contents: "" }], {
+			Old: true,
+			New: false,
+		})
 		expect(result["Old"]).to.be.undefined
 		expect(result["New"]).to.equal(false)
 	})
@@ -80,63 +83,58 @@ describe("synchronizeRemoteRuleToggles - remote skill toggle sync", () => {
 	})
 })
 
-describe("applyRemoteConfig skill frontmatter parsing pattern", () => {
-	const parse = (entries: { name: string; alwaysEnabled: boolean; contents: string }[]) =>
-		entries
-			.map((entry) => {
-				const { data } = parseYamlFrontmatter(entry.contents)
-				return typeof data.name === "string" ? { ...entry, name: data.name } : null
-			})
-			.filter((e): e is NonNullable<typeof e> => e !== null)
+describe("applyRemoteConfig uses parseRemoteSkillEntries", () => {
+	it("validates entry.name matches frontmatter.name", () => {
+		const validated = parseRemoteSkillEntries([
+			{ name: "Deploy", alwaysEnabled: false, contents: makeSKILLMd("Deploy", "Desc") },
+		])
+		expect(validated).to.have.lengthOf(1)
+		expect(validated[0].name).to.equal("Deploy")
+	})
 
-	it("uses frontmatter.name not entry.name as identity", () => {
-		const parsed = parse([{ name: "entry-key", alwaysEnabled: false, contents: makeSKILLMd("Actual Name", "Desc") }])
-		expect(parsed).to.have.lengthOf(1)
-		expect(parsed[0].name).to.equal("Actual Name")
+	it("rejects entries where entry.name drifts from frontmatter.name", () => {
+		const validated = parseRemoteSkillEntries([
+			{ name: "entry-key", alwaysEnabled: false, contents: makeSKILLMd("Actual Name", "Desc") },
+		])
+		expect(validated).to.have.lengthOf(0)
 	})
 
 	it("filters entries with missing frontmatter name", () => {
-		const parsed = parse([
+		const validated = parseRemoteSkillEntries([
 			{ name: "x", alwaysEnabled: false, contents: `---\ndescription: No name\n---\nBody` },
 			{ name: "y", alwaysEnabled: false, contents: "No frontmatter" },
 		])
-		expect(parsed).to.have.lengthOf(0)
+		expect(validated).to.have.lengthOf(0)
 	})
 
 	it("filters entries where frontmatter.name is not a string", () => {
-		const parsed = parse([{ name: "x", alwaysEnabled: false, contents: `---\nname: 123\ndescription: Desc\n---\nBody` }])
-		expect(parsed).to.have.lengthOf(0)
+		const validated = parseRemoteSkillEntries([
+			{ name: "x", alwaysEnabled: false, contents: `---\nname: 123\ndescription: Desc\n---\nBody` },
+		])
+		expect(validated).to.have.lengthOf(0)
 	})
 
 	it("passes through multiple valid entries", () => {
-		const parsed = parse([
-			{ name: "a", alwaysEnabled: true, contents: makeSKILLMd("Skill One", "Desc") },
-			{ name: "b", alwaysEnabled: false, contents: makeSKILLMd("Skill Two", "Desc") },
+		const validated = parseRemoteSkillEntries([
+			{ name: "Skill One", alwaysEnabled: true, contents: makeSKILLMd("Skill One", "Desc") },
+			{ name: "Skill Two", alwaysEnabled: false, contents: makeSKILLMd("Skill Two", "Desc") },
 		])
-		expect(parsed).to.have.lengthOf(2)
-		expect(parsed[0].name).to.equal("Skill One")
-		expect(parsed[1].name).to.equal("Skill Two")
+		expect(validated).to.have.lengthOf(2)
+		expect(validated[0].name).to.equal("Skill One")
+		expect(validated[1].name).to.equal("Skill Two")
 	})
 })
 
 describe("alwaysEnabled enforcement in toggle sync", () => {
-	const { parseYamlFrontmatter } = require("@/core/context/instructions/user-instructions/frontmatter")
-
 	function syncWithAlwaysEnabled(
 		entries: { name: string; alwaysEnabled: boolean; contents: string }[],
 		currentToggles: Record<string, boolean>,
 	) {
-		const parsedEntries = entries
-			.map((entry) => {
-				const { data } = parseYamlFrontmatter(entry.contents)
-				return typeof data.name === "string" ? { ...entry, name: data.name } : null
-			})
-			.filter((e): e is NonNullable<typeof e> => e !== null)
-
-		const synced = synchronizeRemoteRuleToggles(parsedEntries, currentToggles)
+		const validated = parseRemoteSkillEntries(entries)
+		const synced = synchronizeRemoteRuleToggles(validated, currentToggles)
 
 		// Enforce alwaysEnabled (mirrors applyRemoteConfig logic)
-		for (const entry of parsedEntries) {
+		for (const entry of validated) {
 			if (entry.alwaysEnabled && synced[entry.name] === false) {
 				synced[entry.name] = true
 			}
@@ -145,30 +143,26 @@ describe("alwaysEnabled enforcement in toggle sync", () => {
 		return synced
 	}
 
-	function makeSKILLMd(name: string, desc: string): string {
-		return `---\nname: ${name}\ndescription: ${desc}\n---\nBody`
-	}
-
 	it("overrides stale false toggle when admin sets alwaysEnabled", () => {
-		const entries = [{ name: "x", alwaysEnabled: true, contents: makeSKILLMd("Deploy", "Desc") }]
+		const entries = [{ name: "Deploy", alwaysEnabled: true, contents: makeSKILLMd("Deploy", "Desc") }]
 		const result = syncWithAlwaysEnabled(entries, { Deploy: false })
 		expect(result["Deploy"]).to.equal(true)
 	})
 
 	it("does not override false toggle when alwaysEnabled is false", () => {
-		const entries = [{ name: "x", alwaysEnabled: false, contents: makeSKILLMd("Deploy", "Desc") }]
+		const entries = [{ name: "Deploy", alwaysEnabled: false, contents: makeSKILLMd("Deploy", "Desc") }]
 		const result = syncWithAlwaysEnabled(entries, { Deploy: false })
 		expect(result["Deploy"]).to.equal(false)
 	})
 
 	it("keeps true toggle unchanged when alwaysEnabled is true", () => {
-		const entries = [{ name: "x", alwaysEnabled: true, contents: makeSKILLMd("Deploy", "Desc") }]
+		const entries = [{ name: "Deploy", alwaysEnabled: true, contents: makeSKILLMd("Deploy", "Desc") }]
 		const result = syncWithAlwaysEnabled(entries, { Deploy: true })
 		expect(result["Deploy"]).to.equal(true)
 	})
 
 	it("new alwaysEnabled skill defaults to true", () => {
-		const entries = [{ name: "x", alwaysEnabled: true, contents: makeSKILLMd("New Skill", "Desc") }]
+		const entries = [{ name: "New Skill", alwaysEnabled: true, contents: makeSKILLMd("New Skill", "Desc") }]
 		const result = syncWithAlwaysEnabled(entries, {})
 		expect(result["New Skill"]).to.equal(true)
 	})

--- a/src/core/storage/__tests__/remote-config-skills.test.ts
+++ b/src/core/storage/__tests__/remote-config-skills.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Unit tests for remote skill handling in remote-config/utils.ts
+ * Covers: transformRemoteConfigToStateShape and toggle synchronisation logic.
+ */
+
+import { expect } from "chai"
+import { describe, it } from "mocha"
+import { transformRemoteConfigToStateShape } from "@/core/storage/remote-config/utils"
+import { synchronizeRemoteRuleToggles } from "@/core/context/instructions/user-instructions/rule-helpers"
+import { parseYamlFrontmatter } from "@/core/context/instructions/user-instructions/frontmatter"
+import type { RemoteConfig } from "@/shared/remote-config/schema"
+
+function makeConfig(globalSkills: RemoteConfig["globalSkills"]): RemoteConfig {
+	return { version: "v1", globalSkills }
+}
+
+function makeSKILLMd(name: string, description: string, body = "Instructions here."): string {
+	return `---\nname: ${name}\ndescription: ${description}\n---\n${body}`
+}
+
+describe("transformRemoteConfigToStateShape - globalSkills", () => {
+	it("maps globalSkills to remoteGlobalSkills", () => {
+		const entries = [{ name: "s1", alwaysEnabled: false, contents: makeSKILLMd("My Skill", "Desc") }]
+		const result = transformRemoteConfigToStateShape(makeConfig(entries))
+		expect(result.remoteGlobalSkills).to.deep.equal(entries)
+	})
+
+	it("does not set remoteGlobalSkills when globalSkills is undefined", () => {
+		const result = transformRemoteConfigToStateShape({ version: "v1" })
+		expect(result.remoteGlobalSkills).to.be.undefined
+	})
+
+	it("sets remoteGlobalSkills to [] when globalSkills is []", () => {
+		const result = transformRemoteConfigToStateShape(makeConfig([]))
+		expect(result.remoteGlobalSkills).to.deep.equal([])
+	})
+
+	it("preserves alwaysEnabled flag", () => {
+		const entries = [
+			{ name: "locked", alwaysEnabled: true, contents: makeSKILLMd("Locked", "Desc") },
+			{ name: "unlocked", alwaysEnabled: false, contents: makeSKILLMd("Free", "Desc") },
+		]
+		const result = transformRemoteConfigToStateShape(makeConfig(entries))
+		expect(result.remoteGlobalSkills![0].alwaysEnabled).to.equal(true)
+		expect(result.remoteGlobalSkills![1].alwaysEnabled).to.equal(false)
+	})
+})
+
+describe("synchronizeRemoteRuleToggles - remote skill toggle sync", () => {
+	it("adds new toggle entries defaulting to true", () => {
+		const result = synchronizeRemoteRuleToggles([{ name: "Deploy", alwaysEnabled: false, contents: "" }], {})
+		expect(result["Deploy"]).to.equal(true)
+	})
+
+	it("preserves existing toggle values", () => {
+		const result = synchronizeRemoteRuleToggles([{ name: "Deploy", alwaysEnabled: false, contents: "" }], { Deploy: false })
+		expect(result["Deploy"]).to.equal(false)
+	})
+
+	it("removes stale toggle entries", () => {
+		const result = synchronizeRemoteRuleToggles([{ name: "New", alwaysEnabled: false, contents: "" }], { Old: true, New: false })
+		expect(result["Old"]).to.be.undefined
+		expect(result["New"]).to.equal(false)
+	})
+
+	it("returns empty object when no skills", () => {
+		const result = synchronizeRemoteRuleToggles([], { Ghost: true })
+		expect(result).to.deep.equal({})
+	})
+
+	it("handles multiple skills", () => {
+		const entries = [
+			{ name: "A", alwaysEnabled: true, contents: "" },
+			{ name: "B", alwaysEnabled: false, contents: "" },
+		]
+		const result = synchronizeRemoteRuleToggles(entries, { A: false, D: true })
+		expect(result["A"]).to.equal(false)
+		expect(result["B"]).to.equal(true)
+		expect(result["D"]).to.be.undefined
+	})
+})
+
+describe("applyRemoteConfig skill frontmatter parsing pattern", () => {
+	const parse = (entries: { name: string; alwaysEnabled: boolean; contents: string }[]) =>
+		entries
+			.map((entry) => {
+				const { data } = parseYamlFrontmatter(entry.contents)
+				return typeof data.name === "string" ? { ...entry, name: data.name } : null
+			})
+			.filter((e): e is NonNullable<typeof e> => e !== null)
+
+	it("uses frontmatter.name not entry.name as identity", () => {
+		const parsed = parse([{ name: "entry-key", alwaysEnabled: false, contents: makeSKILLMd("Actual Name", "Desc") }])
+		expect(parsed).to.have.lengthOf(1)
+		expect(parsed[0].name).to.equal("Actual Name")
+	})
+
+	it("filters entries with missing frontmatter name", () => {
+		const parsed = parse([
+			{ name: "x", alwaysEnabled: false, contents: `---\ndescription: No name\n---\nBody` },
+			{ name: "y", alwaysEnabled: false, contents: "No frontmatter" },
+		])
+		expect(parsed).to.have.lengthOf(0)
+	})
+
+	it("filters entries where frontmatter.name is not a string", () => {
+		const parsed = parse([{ name: "x", alwaysEnabled: false, contents: `---\nname: 123\ndescription: Desc\n---\nBody` }])
+		expect(parsed).to.have.lengthOf(0)
+	})
+
+	it("passes through multiple valid entries", () => {
+		const parsed = parse([
+			{ name: "a", alwaysEnabled: true, contents: makeSKILLMd("Skill One", "Desc") },
+			{ name: "b", alwaysEnabled: false, contents: makeSKILLMd("Skill Two", "Desc") },
+		])
+		expect(parsed).to.have.lengthOf(2)
+		expect(parsed[0].name).to.equal("Skill One")
+		expect(parsed[1].name).to.equal("Skill Two")
+	})
+})

--- a/src/core/storage/__tests__/remote-config-skills.test.ts
+++ b/src/core/storage/__tests__/remote-config-skills.test.ts
@@ -118,3 +118,58 @@ describe("applyRemoteConfig skill frontmatter parsing pattern", () => {
 		expect(parsed[1].name).to.equal("Skill Two")
 	})
 })
+
+describe("alwaysEnabled enforcement in toggle sync", () => {
+	const { parseYamlFrontmatter } = require("@/core/context/instructions/user-instructions/frontmatter")
+
+	function syncWithAlwaysEnabled(
+		entries: { name: string; alwaysEnabled: boolean; contents: string }[],
+		currentToggles: Record<string, boolean>,
+	) {
+		const parsedEntries = entries
+			.map((entry) => {
+				const { data } = parseYamlFrontmatter(entry.contents)
+				return typeof data.name === "string" ? { ...entry, name: data.name } : null
+			})
+			.filter((e): e is NonNullable<typeof e> => e !== null)
+
+		const synced = synchronizeRemoteRuleToggles(parsedEntries, currentToggles)
+
+		// Enforce alwaysEnabled (mirrors applyRemoteConfig logic)
+		for (const entry of parsedEntries) {
+			if (entry.alwaysEnabled && synced[entry.name] === false) {
+				synced[entry.name] = true
+			}
+		}
+
+		return synced
+	}
+
+	function makeSKILLMd(name: string, desc: string): string {
+		return `---\nname: ${name}\ndescription: ${desc}\n---\nBody`
+	}
+
+	it("overrides stale false toggle when admin sets alwaysEnabled", () => {
+		const entries = [{ name: "x", alwaysEnabled: true, contents: makeSKILLMd("Deploy", "Desc") }]
+		const result = syncWithAlwaysEnabled(entries, { Deploy: false })
+		expect(result["Deploy"]).to.equal(true)
+	})
+
+	it("does not override false toggle when alwaysEnabled is false", () => {
+		const entries = [{ name: "x", alwaysEnabled: false, contents: makeSKILLMd("Deploy", "Desc") }]
+		const result = syncWithAlwaysEnabled(entries, { Deploy: false })
+		expect(result["Deploy"]).to.equal(false)
+	})
+
+	it("keeps true toggle unchanged when alwaysEnabled is true", () => {
+		const entries = [{ name: "x", alwaysEnabled: true, contents: makeSKILLMd("Deploy", "Desc") }]
+		const result = syncWithAlwaysEnabled(entries, { Deploy: true })
+		expect(result["Deploy"]).to.equal(true)
+	})
+
+	it("new alwaysEnabled skill defaults to true", () => {
+		const entries = [{ name: "x", alwaysEnabled: true, contents: makeSKILLMd("New Skill", "Desc") }]
+		const result = syncWithAlwaysEnabled(entries, {})
+		expect(result["New Skill"]).to.equal(true)
+	})
+})

--- a/src/core/storage/__tests__/remote-config-skills.test.ts
+++ b/src/core/storage/__tests__/remote-config-skills.test.ts
@@ -92,11 +92,12 @@ describe("applyRemoteConfig uses parseRemoteSkillEntries", () => {
 		expect(validated[0].name).to.equal("Deploy")
 	})
 
-	it("rejects entries where entry.name drifts from frontmatter.name", () => {
+	it("warns but includes entries where entry.name drifts from frontmatter.name", () => {
 		const validated = parseRemoteSkillEntries([
 			{ name: "entry-key", alwaysEnabled: false, contents: makeSKILLMd("Actual Name", "Desc") },
 		])
-		expect(validated).to.have.lengthOf(0)
+		expect(validated).to.have.lengthOf(1)
+		expect(validated[0].name).to.equal("Actual Name")
 	})
 
 	it("filters entries with missing frontmatter name", () => {

--- a/src/core/storage/remote-config/utils.ts
+++ b/src/core/storage/remote-config/utils.ts
@@ -344,8 +344,6 @@ export async function applyRemoteConfig(
 	stateManager.setGlobalState("remoteWorkflowToggles", syncedWorkflowToggles)
 	stateManager.setGlobalState("remoteSkillsToggles", syncedSkillToggles)
 
-	// Clear existing remote config cache
-	stateManager.clearRemoteConfig()
 	telemetryService.removeProvider(REMOTE_CONFIG_OTEL_PROVIDER_ID)
 
 	// If the existing configured provider is valid, don't update it
@@ -357,16 +355,13 @@ export async function applyRemoteConfig(
 		transformed.planModeApiProvider = apiConfiguration.planModeApiProvider
 	}
 
-	// Populate remote config cache with transformed values
-	for (const [key, value] of Object.entries(transformed)) {
-		stateManager.setRemoteConfigField(key as keyof RemoteConfigFields, value)
-	}
-	stateManager.setRemoteConfigField("configuredApiKeys", configuredKeys)
-
-	// Restore previousRemoteMCPServers across cache clears
+	// Build the full new cache and swap atomically to avoid a window where
+	// concurrent readers (e.g., UseSkillToolHandler) see an empty cache.
+	const newCache: Partial<RemoteConfigFields> = { ...transformed, configuredApiKeys: configuredKeys }
 	if (previousRemoteMCPServers !== undefined) {
-		stateManager.setRemoteConfigField("previousRemoteMCPServers", previousRemoteMCPServers)
+		newCache.previousRemoteMCPServers = previousRemoteMCPServers
 	}
+	stateManager.replaceRemoteConfig(newCache)
 
 	applyRemoteSyncQueueConfig(transformed)
 

--- a/src/core/storage/remote-config/utils.ts
+++ b/src/core/storage/remote-config/utils.ts
@@ -1,5 +1,5 @@
 import { synchronizeRemoteRuleToggles } from "@core/context/instructions/user-instructions/rule-helpers"
-import { parseYamlFrontmatter } from "@core/context/instructions/user-instructions/frontmatter"
+import { parseRemoteSkillEntries } from "@core/context/instructions/user-instructions/skills"
 import type { RemoteConfig, S3AccessKeySettings } from "@shared/remote-config/schema"
 import { ConfiguredAPIKeys, GlobalStateAndSettings, RemoteConfigFields } from "@shared/storage/state-keys"
 import { AuthService } from "@/services/auth/AuthService"
@@ -327,19 +327,14 @@ export async function applyRemoteConfig(
 	const syncedRuleToggles = synchronizeRemoteRuleToggles(remoteConfig.globalRules || [], currentRuleToggles)
 	const syncedWorkflowToggles = synchronizeRemoteRuleToggles(remoteConfig.globalWorkflows || [], currentWorkflowToggles)
 
-	// For remote skills, identity is frontmatter.name (not entry.name). Parse and filter valid entries.
+	// Remote skills use shared validation (entry.name must match frontmatter.name)
 	const currentSkillToggles = stateManager.getGlobalStateKey("remoteSkillsToggles") || {}
-	const parsedSkillEntries = (remoteConfig.globalSkills || [])
-		.map((entry) => {
-			const { data } = parseYamlFrontmatter(entry.contents)
-			return typeof data.name === "string" ? { ...entry, name: data.name } : null
-		})
-		.filter((e): e is NonNullable<typeof e> => e !== null)
-	const syncedSkillToggles = synchronizeRemoteRuleToggles(parsedSkillEntries, currentSkillToggles)
+	const validatedSkillEntries = parseRemoteSkillEntries(remoteConfig.globalSkills || [])
+	const syncedSkillToggles = synchronizeRemoteRuleToggles(validatedSkillEntries, currentSkillToggles)
 
 	// Enforce alwaysEnabled: override any stale false toggles for skills the admin has locked on.
 	// This ensures the toggle store is the single source of truth — both the UI and handler agree.
-	for (const entry of parsedSkillEntries) {
+	for (const entry of validatedSkillEntries) {
 		if (entry.alwaysEnabled && syncedSkillToggles[entry.name] === false) {
 			syncedSkillToggles[entry.name] = true
 		}

--- a/src/core/storage/remote-config/utils.ts
+++ b/src/core/storage/remote-config/utils.ts
@@ -337,6 +337,14 @@ export async function applyRemoteConfig(
 		.filter((e): e is NonNullable<typeof e> => e !== null)
 	const syncedSkillToggles = synchronizeRemoteRuleToggles(parsedSkillEntries, currentSkillToggles)
 
+	// Enforce alwaysEnabled: override any stale false toggles for skills the admin has locked on.
+	// This ensures the toggle store is the single source of truth — both the UI and handler agree.
+	for (const entry of parsedSkillEntries) {
+		if (entry.alwaysEnabled && syncedSkillToggles[entry.name] === false) {
+			syncedSkillToggles[entry.name] = true
+		}
+	}
+
 	stateManager.setGlobalState("remoteRulesToggles", syncedRuleToggles)
 	stateManager.setGlobalState("remoteWorkflowToggles", syncedWorkflowToggles)
 	stateManager.setGlobalState("remoteSkillsToggles", syncedSkillToggles)

--- a/src/core/storage/remote-config/utils.ts
+++ b/src/core/storage/remote-config/utils.ts
@@ -1,4 +1,5 @@
 import { synchronizeRemoteRuleToggles } from "@core/context/instructions/user-instructions/rule-helpers"
+import { parseYamlFrontmatter } from "@core/context/instructions/user-instructions/frontmatter"
 import type { RemoteConfig, S3AccessKeySettings } from "@shared/remote-config/schema"
 import { ConfiguredAPIKeys, GlobalStateAndSettings, RemoteConfigFields } from "@shared/storage/state-keys"
 import { AuthService } from "@/services/auth/AuthService"
@@ -217,12 +218,15 @@ export function transformRemoteConfigToStateShape(remoteConfig: RemoteConfig): P
 		transformed.remoteConfiguredProviders = providers
 	}
 
-	// Map global rules and workflows
+	// Map global rules, workflows, and skills
 	if (remoteConfig.globalRules !== undefined) {
 		transformed.remoteGlobalRules = remoteConfig.globalRules
 	}
 	if (remoteConfig.globalWorkflows !== undefined) {
 		transformed.remoteGlobalWorkflows = remoteConfig.globalWorkflows
+	}
+	if (remoteConfig.globalSkills !== undefined) {
+		transformed.remoteGlobalSkills = remoteConfig.globalSkills
 	}
 
 	if (remoteConfig.enterpriseTelemetry?.promptUploading) {
@@ -282,6 +286,7 @@ export function clearRemoteConfig() {
 		// the remote config cline rules toggle state is stored in global state
 		stateManager.setGlobalState("remoteRulesToggles", {})
 		stateManager.setGlobalState("remoteWorkflowToggles", {})
+		stateManager.setGlobalState("remoteSkillsToggles", {})
 
 		// clear secrets
 		stateManager.setSecret("remoteLiteLlmApiKey", undefined)
@@ -322,8 +327,19 @@ export async function applyRemoteConfig(
 	const syncedRuleToggles = synchronizeRemoteRuleToggles(remoteConfig.globalRules || [], currentRuleToggles)
 	const syncedWorkflowToggles = synchronizeRemoteRuleToggles(remoteConfig.globalWorkflows || [], currentWorkflowToggles)
 
+	// For remote skills, identity is frontmatter.name (not entry.name). Parse and filter valid entries.
+	const currentSkillToggles = stateManager.getGlobalStateKey("remoteSkillsToggles") || {}
+	const parsedSkillEntries = (remoteConfig.globalSkills || [])
+		.map((entry) => {
+			const { data } = parseYamlFrontmatter(entry.contents)
+			return typeof data.name === "string" ? { ...entry, name: data.name } : null
+		})
+		.filter((e): e is NonNullable<typeof e> => e !== null)
+	const syncedSkillToggles = synchronizeRemoteRuleToggles(parsedSkillEntries, currentSkillToggles)
+
 	stateManager.setGlobalState("remoteRulesToggles", syncedRuleToggles)
 	stateManager.setGlobalState("remoteWorkflowToggles", syncedWorkflowToggles)
+	stateManager.setGlobalState("remoteSkillsToggles", syncedSkillToggles)
 
 	// Clear existing remote config cache
 	stateManager.clearRemoteConfig()

--- a/src/core/task/index.ts
+++ b/src/core/task/index.ts
@@ -1940,15 +1940,22 @@ export class Task {
 		}
 
 		// Discover and filter available skills
-		const allSkills = await discoverSkills(this.cwd)
+		const remoteSkillEntries = this.stateManager.getRemoteConfigSettings().remoteGlobalSkills || []
+		const allSkills = await discoverSkills(this.cwd, remoteSkillEntries)
 		const resolvedSkills = getAvailableSkills(allSkills)
 
 		// Filter skills by toggle state (enabled by default)
 		const globalSkillsToggles = this.stateManager.getGlobalSettingsKey("globalSkillsToggles") ?? {}
 		const localSkillsToggles = this.stateManager.getWorkspaceStateKey("localSkillsToggles") ?? {}
+		const remoteSkillsToggles = this.stateManager.getGlobalStateKey("remoteSkillsToggles") ?? {}
 		const availableSkills = resolvedSkills.filter((skill) => {
+			if (skill.path.startsWith("remote:")) {
+				const name = skill.path.replace("remote:", "")
+				const entry = remoteSkillEntries.find((e) => e.name === name)
+				if (entry?.alwaysEnabled) return true
+				return remoteSkillsToggles[name] !== false
+			}
 			const toggles = skill.source === "global" ? globalSkillsToggles : localSkillsToggles
-			// If toggle exists, use it; otherwise default to enabled (true)
 			return toggles[skill.path] !== false
 		})
 

--- a/src/core/task/index.ts
+++ b/src/core/task/index.ts
@@ -109,7 +109,7 @@ import { Logger } from "@/shared/services/Logger"
 import { Session } from "@/shared/services/Session"
 import { RuleContextBuilder } from "../context/instructions/user-instructions/RuleContextBuilder"
 import { ensureLocalClineDirExists } from "../context/instructions/user-instructions/rule-helpers"
-import { discoverSkills, getAvailableSkills } from "../context/instructions/user-instructions/skills"
+import { discoverAvailableSkills } from "../context/instructions/user-instructions/skills"
 import { refreshWorkflowToggles } from "../context/instructions/user-instructions/workflows"
 import { Controller } from "../controller"
 import { executeHook } from "../hooks/hook-executor"
@@ -1941,22 +1941,11 @@ export class Task {
 
 		// Discover and filter available skills
 		const remoteSkillEntries = this.stateManager.getRemoteConfigSettings().remoteGlobalSkills || []
-		const allSkills = await discoverSkills(this.cwd, remoteSkillEntries)
-		const resolvedSkills = getAvailableSkills(allSkills)
-
-		// Filter skills by toggle state (enabled by default)
-		const globalSkillsToggles = this.stateManager.getGlobalSettingsKey("globalSkillsToggles") ?? {}
-		const localSkillsToggles = this.stateManager.getWorkspaceStateKey("localSkillsToggles") ?? {}
-		const remoteSkillsToggles = this.stateManager.getGlobalStateKey("remoteSkillsToggles") ?? {}
-		const availableSkills = resolvedSkills.filter((skill) => {
-			if (skill.path.startsWith("remote:")) {
-				const name = skill.path.replace("remote:", "")
-				const entry = remoteSkillEntries.find((e) => e.name === name)
-				if (entry?.alwaysEnabled) return true
-				return remoteSkillsToggles[name] !== false
-			}
-			const toggles = skill.source === "global" ? globalSkillsToggles : localSkillsToggles
-			return toggles[skill.path] !== false
+		const availableSkills = await discoverAvailableSkills(this.cwd, {
+			remoteSkillEntries,
+			globalSkillsToggles: this.stateManager.getGlobalSettingsKey("globalSkillsToggles") ?? {},
+			localSkillsToggles: this.stateManager.getWorkspaceStateKey("localSkillsToggles") ?? {},
+			remoteSkillsToggles: this.stateManager.getGlobalStateKey("remoteSkillsToggles") ?? {},
 		})
 
 		// Snapshot editor tabs so prompt tools can decide whether to include

--- a/src/core/task/tools/handlers/UseSkillToolHandler.ts
+++ b/src/core/task/tools/handlers/UseSkillToolHandler.ts
@@ -48,6 +48,8 @@ export class UseSkillToolHandler implements IToolHandler, IPartialBlockHandler {
 		const availableSkills = resolvedSkills.filter((skill) => {
 			if (skill.path.startsWith("remote:")) {
 				const name = skill.path.replace("remote:", "")
+				const entry = remoteSkillEntries.find((e) => e.name === name)
+				if (entry?.alwaysEnabled) return true
 				return remoteSkillsToggles[name] !== false
 			}
 			const toggles = skill.source === "global" ? globalSkillsToggles : localSkillsToggles

--- a/src/core/task/tools/handlers/UseSkillToolHandler.ts
+++ b/src/core/task/tools/handlers/UseSkillToolHandler.ts
@@ -1,5 +1,5 @@
 import type { ToolUse } from "@core/assistant-message"
-import { discoverSkills, getAvailableSkills, getSkillContent } from "@core/context/instructions/user-instructions/skills"
+import { discoverAvailableSkills, getSkillContent } from "@core/context/instructions/user-instructions/skills"
 import type { SkillMetadata } from "@shared/skills"
 import { telemetryService } from "@/services/telemetry"
 import { ClineDefaultTool } from "@/shared/tools"
@@ -37,23 +37,12 @@ export class UseSkillToolHandler implements IToolHandler, IPartialBlockHandler {
 
 		// Discover skills on-demand (lazy loading)
 		const remoteSkillEntries = config.services.stateManager.getRemoteConfigSettings().remoteGlobalSkills || []
-		const allSkills = await discoverSkills(config.cwd, remoteSkillEntries)
-		const resolvedSkills = getAvailableSkills(allSkills)
-
-		// Filter by toggle state
 		const stateManager = config.services.stateManager
-		const globalSkillsToggles = stateManager.getGlobalSettingsKey("globalSkillsToggles") ?? {}
-		const localSkillsToggles = stateManager.getWorkspaceStateKey("localSkillsToggles") ?? {}
-		const remoteSkillsToggles = stateManager.getGlobalStateKey("remoteSkillsToggles") ?? {}
-		const availableSkills = resolvedSkills.filter((skill) => {
-			if (skill.path.startsWith("remote:")) {
-				const name = skill.path.replace("remote:", "")
-				const entry = remoteSkillEntries.find((e) => e.name === name)
-				if (entry?.alwaysEnabled) return true
-				return remoteSkillsToggles[name] !== false
-			}
-			const toggles = skill.source === "global" ? globalSkillsToggles : localSkillsToggles
-			return toggles[skill.path] !== false
+		const availableSkills = await discoverAvailableSkills(config.cwd, {
+			remoteSkillEntries,
+			globalSkillsToggles: stateManager.getGlobalSettingsKey("globalSkillsToggles") ?? {},
+			localSkillsToggles: stateManager.getWorkspaceStateKey("localSkillsToggles") ?? {},
+			remoteSkillsToggles: stateManager.getGlobalStateKey("remoteSkillsToggles") ?? {},
 		})
 
 		if (availableSkills.length === 0) {

--- a/src/core/task/tools/handlers/UseSkillToolHandler.ts
+++ b/src/core/task/tools/handlers/UseSkillToolHandler.ts
@@ -36,14 +36,20 @@ export class UseSkillToolHandler implements IToolHandler, IPartialBlockHandler {
 		}
 
 		// Discover skills on-demand (lazy loading)
-		const allSkills = await discoverSkills(config.cwd)
+		const remoteSkillEntries = config.services.stateManager.getRemoteConfigSettings().remoteGlobalSkills || []
+		const allSkills = await discoverSkills(config.cwd, remoteSkillEntries)
 		const resolvedSkills = getAvailableSkills(allSkills)
 
 		// Filter by toggle state
 		const stateManager = config.services.stateManager
 		const globalSkillsToggles = stateManager.getGlobalSettingsKey("globalSkillsToggles") ?? {}
 		const localSkillsToggles = stateManager.getWorkspaceStateKey("localSkillsToggles") ?? {}
+		const remoteSkillsToggles = stateManager.getGlobalStateKey("remoteSkillsToggles") ?? {}
 		const availableSkills = resolvedSkills.filter((skill) => {
+			if (skill.path.startsWith("remote:")) {
+				const name = skill.path.replace("remote:", "")
+				return remoteSkillsToggles[name] !== false
+			}
 			const toggles = skill.source === "global" ? globalSkillsToggles : localSkillsToggles
 			return toggles[skill.path] !== false
 		})
@@ -68,7 +74,7 @@ export class UseSkillToolHandler implements IToolHandler, IPartialBlockHandler {
 		config.taskState.consecutiveMistakeCount = 0
 
 		try {
-			const skillContent = await getSkillContent(skillName, availableSkills)
+			const skillContent = await getSkillContent(skillName, availableSkills, remoteSkillEntries)
 
 			if (!skillContent) {
 				const availableNames = availableSkills.map((s: SkillMetadata) => s.name).join(", ")
@@ -89,12 +95,16 @@ export class UseSkillToolHandler implements IToolHandler, IPartialBlockHandler {
 				"UseSkillToolHandler.execute",
 			)
 
+			const skillDirNote = skillContent.path.startsWith("remote:")
+				? ""
+				: ` You may access other files in the skill directory at: ${skillContent.path.replace(/SKILL\.md$/, "")}`
+
 			return `# Skill "${skillContent.name}" is now active
 
 ${skillContent.instructions}
 
 ---
-IMPORTANT: The skill is now loaded. Do NOT call use_skill again for this task. Simply follow the instructions above to complete the user's request. You may access other files in the skill directory at: ${skillContent.path.replace(/SKILL\.md$/, "")}`
+IMPORTANT: The skill is now loaded. Do NOT call use_skill again for this task. Simply follow the instructions above to complete the user's request.${skillDirNote}`
 		} catch (error) {
 			return `Error loading skill "${skillName}": ${(error as Error)?.message}`
 		}

--- a/src/core/task/tools/subagent/SubagentRunner.ts
+++ b/src/core/task/tools/subagent/SubagentRunner.ts
@@ -2,7 +2,7 @@ import * as path from "node:path"
 import { setTimeout as delay } from "node:timers/promises"
 import type { ApiHandler, buildApiHandler } from "@core/api"
 import { parseAssistantMessageV2, ToolUse } from "@core/assistant-message"
-import { discoverSkills, getAvailableSkills } from "@core/context/instructions/user-instructions/skills"
+import { discoverAvailableSkills } from "@core/context/instructions/user-instructions/skills"
 import { formatResponse } from "@core/prompts/responses"
 import { PromptRegistry } from "@core/prompts/system-prompt"
 import type { SystemPromptContext } from "@core/prompts/system-prompt/types"
@@ -336,8 +336,13 @@ export class SubagentRunner {
 				!!this.baseConfig.services.stateManager.getGlobalStateKey("nativeToolCallEnabled")
 
 			const host = HostRegistryInfo.get()
-			const discoveredSkills = await discoverSkills(this.baseConfig.cwd)
-			const availableSkills = getAvailableSkills(discoveredSkills)
+			const remoteSkillEntries = this.baseConfig.services.stateManager.getRemoteConfigSettings().remoteGlobalSkills || []
+			const availableSkills = await discoverAvailableSkills(this.baseConfig.cwd, {
+				remoteSkillEntries,
+				globalSkillsToggles: this.baseConfig.services.stateManager.getGlobalSettingsKey("globalSkillsToggles") ?? {},
+				localSkillsToggles: this.baseConfig.services.stateManager.getWorkspaceStateKey("localSkillsToggles") ?? {},
+				remoteSkillsToggles: this.baseConfig.services.stateManager.getGlobalStateKey("remoteSkillsToggles") ?? {},
+			})
 			const configuredSkillNames = this.agent.getConfiguredSkills()
 			const skills =
 				configuredSkillNames !== undefined

--- a/src/core/task/tools/subagent/__tests__/SubagentRunner.test.ts
+++ b/src/core/task/tools/subagent/__tests__/SubagentRunner.test.ts
@@ -3,6 +3,7 @@ import * as coreApi from "@core/api"
 import * as skills from "@core/context/instructions/user-instructions/skills"
 import { PromptRegistry } from "@core/prompts/system-prompt"
 import type { TaskConfig } from "@core/task/tools/types/TaskConfig"
+import type { GlobalInstructionsFile } from "@shared/remote-config/schema"
 import { afterEach, describe, it } from "mocha"
 import sinon from "sinon"
 import { HostProvider } from "@/hosts/host-provider"
@@ -36,7 +37,31 @@ function initializeHostProvider() {
 	)
 }
 
-function createTaskConfig(nativeToolCallEnabled: boolean): TaskConfig {
+function createRemoteSkillEntry(
+	name: string,
+	description: string,
+	options: { alwaysEnabled?: boolean } = {},
+): GlobalInstructionsFile {
+	return {
+		name,
+		alwaysEnabled: options.alwaysEnabled ?? false,
+		contents: `---
+name: ${name}
+description: ${description}
+---
+Instructions for ${name}.`,
+	}
+}
+
+function createTaskConfig(
+	nativeToolCallEnabled: boolean,
+	options: {
+		globalSkillsToggles?: Record<string, boolean>
+		localSkillsToggles?: Record<string, boolean>
+		remoteSkillsToggles?: Record<string, boolean>
+		remoteGlobalSkills?: GlobalInstructionsFile[]
+	} = {},
+): TaskConfig {
 	return {
 		taskId: "task-1",
 		ulid: "ulid-1",
@@ -71,9 +96,29 @@ function createTaskConfig(nativeToolCallEnabled: boolean): TaskConfig {
 					if (key === "customPrompt") {
 						return undefined
 					}
+					if (key === "globalSkillsToggles") {
+						return options.globalSkillsToggles
+					}
 					return undefined
 				},
-				getGlobalStateKey: (key: string) => (key === "nativeToolCallEnabled" ? nativeToolCallEnabled : undefined),
+				getGlobalStateKey: (key: string) => {
+					if (key === "nativeToolCallEnabled") {
+						return nativeToolCallEnabled
+					}
+					if (key === "remoteSkillsToggles") {
+						return options.remoteSkillsToggles
+					}
+					return undefined
+				},
+				getWorkspaceStateKey: (key: string) => {
+					if (key === "localSkillsToggles") {
+						return options.localSkillsToggles
+					}
+					return undefined
+				},
+				getRemoteConfigSettings: () => ({
+					remoteGlobalSkills: options.remoteGlobalSkills ?? [],
+				}),
 				getApiConfiguration: () => ({
 					actModeApiProvider: "anthropic",
 					planModeApiProvider: "anthropic",
@@ -376,7 +421,9 @@ describe("SubagentRunner", () => {
 		assert.equal(createMessage.callCount, 2)
 	})
 
-	it("retries initial stream failures before failing", async () => {
+	it("retries initial stream failures before failing", async function () {
+		this.timeout(8_000)
+
 		const createMessage = sinon.stub()
 		createMessage.onFirstCall().callsFake(async function* () {
 			yield* []
@@ -407,12 +454,8 @@ describe("SubagentRunner", () => {
 		stubApiHandler(createMessage)
 		initializeHostProvider()
 
-		const clock = sinon.useFakeTimers()
 		const runner = new SubagentRunner(createTaskConfig(false))
-		const runPromise = runner.run("List files", () => {})
-		await clock.runAllAsync()
-		const result = await runPromise
-		clock.restore()
+		const result = await runner.run("List files", () => {})
 
 		assert.equal(result.status, "failed")
 		assert.equal(createMessage.callCount, 3)
@@ -503,15 +546,17 @@ describe("SubagentRunner", () => {
 			return "system prompt"
 		})
 		sinon.stub(SubagentBuilder.prototype, "getConfiguredSkills").returns(["allowed-skill"])
-		sinon.stub(skills, "discoverSkills").resolves([])
-		sinon.stub(skills, "getAvailableSkills").returns([
-			{ name: "allowed-skill", description: "Allowed", path: "/skills/allowed/SKILL.md", source: "project" },
-			{ name: "other-skill", description: "Other", path: "/skills/other/SKILL.md", source: "project" },
-		])
 		stubApiHandler(createMessage)
 		initializeHostProvider()
 
-		const runner = new SubagentRunner(createTaskConfig(false))
+		const runner = new SubagentRunner(
+			createTaskConfig(false, {
+				remoteGlobalSkills: [
+					createRemoteSkillEntry("allowed-skill", "Allowed"),
+					createRemoteSkillEntry("other-skill", "Other"),
+				],
+			}),
+		)
 		const result = await runner.run("Run task", () => {})
 
 		assert.equal(result.status, "completed")
@@ -543,10 +588,9 @@ describe("SubagentRunner", () => {
 			return "system prompt"
 		})
 		sinon.stub(SubagentBuilder.prototype, "getConfiguredSkills").returns(undefined)
-		sinon.stub(skills, "discoverSkills").resolves([])
-		sinon.stub(skills, "getAvailableSkills").returns([
-			{ name: "alpha-skill", description: "Alpha", path: "/skills/alpha/SKILL.md", source: "project" },
-			{ name: "beta-skill", description: "Beta", path: "/skills/beta/SKILL.md", source: "project" },
+		sinon.stub(skills, "discoverAvailableSkills").resolves([
+			{ name: "alpha-skill", description: "Alpha", path: "remote:alpha-skill", source: "global" },
+			{ name: "beta-skill", description: "Beta", path: "remote:beta-skill", source: "global" },
 		])
 		stubApiHandler(createMessage)
 		initializeHostProvider()
@@ -584,19 +628,89 @@ describe("SubagentRunner", () => {
 			return "system prompt"
 		})
 		sinon.stub(SubagentBuilder.prototype, "getConfiguredSkills").returns(["present-skill", "missing-skill"])
-		sinon.stub(skills, "discoverSkills").resolves([])
-		sinon
-			.stub(skills, "getAvailableSkills")
-			.returns([{ name: "present-skill", description: "Present", path: "/skills/present/SKILL.md", source: "project" }])
 		stubApiHandler(createMessage)
 		initializeHostProvider()
 
-		const runner = new SubagentRunner(createTaskConfig(false))
+		const runner = new SubagentRunner(
+			createTaskConfig(false, {
+				remoteGlobalSkills: [createRemoteSkillEntry("present-skill", "Present")],
+			}),
+		)
 		const result = await runner.run("Run task", () => {})
 
 		assert.equal(result.status, "completed")
 		assert.equal(createMessage.callCount, 1)
 		sinon.assert.calledWith(warnStub, "[SubagentRunner] Configured skill 'missing-skill' not found for subagent run.")
+	})
+
+	it("includes enabled remote skills in subagent context and preserves configured remote names", async () => {
+		const createMessage = sinon.stub().callsFake(async function* () {
+			yield {
+				type: "tool_calls",
+				tool_call: {
+					function: {
+						id: "toolu_subagent_remote_skills_1",
+						name: ClineDefaultTool.ATTEMPT,
+						arguments: JSON.stringify({ result: "done" }),
+					},
+				},
+			}
+		})
+
+		const remoteGlobalSkills = [
+			createRemoteSkillEntry("remote-enabled", "Enabled remote skill"),
+			createRemoteSkillEntry("remote-disabled", "Disabled remote skill"),
+			createRemoteSkillEntry("remote-locked", "Always enabled remote skill", { alwaysEnabled: true }),
+		]
+
+		const promptRegistry = PromptRegistry.getInstance()
+		sinon.stub(promptRegistry, "get").callsFake(async (context) => {
+			assert.ok(context.skills)
+			assert.deepEqual(
+				context.skills.map((skill) => skill.name),
+				["remote-enabled", "remote-locked"],
+			)
+			promptRegistry.nativeTools = undefined
+			return "system prompt"
+		})
+		sinon
+			.stub(SubagentBuilder.prototype, "getConfiguredSkills")
+			.returns(["remote-enabled", "remote-disabled", "remote-locked"])
+		sinon.stub(skills, "discoverSkills").callsFake(async (_cwd, remoteEntries) => {
+			assert.deepEqual(remoteEntries, remoteGlobalSkills)
+			return [
+				{ name: "remote-enabled", description: "Enabled remote skill", path: "remote:remote-enabled", source: "global" },
+				{
+					name: "remote-disabled",
+					description: "Disabled remote skill",
+					path: "remote:remote-disabled",
+					source: "global",
+				},
+				{
+					name: "remote-locked",
+					description: "Always enabled remote skill",
+					path: "remote:remote-locked",
+					source: "global",
+				},
+			]
+		})
+		sinon.stub(skills, "getAvailableSkills").callsFake((availableSkills) => availableSkills)
+		stubApiHandler(createMessage)
+		initializeHostProvider()
+
+		const runner = new SubagentRunner(
+			createTaskConfig(false, {
+				remoteGlobalSkills,
+				remoteSkillsToggles: {
+					"remote-disabled": false,
+					"remote-locked": false,
+				},
+			}),
+		)
+		const result = await runner.run("Run task", () => {})
+
+		assert.equal(result.status, "completed")
+		assert.equal(createMessage.callCount, 1)
 	})
 
 	it("includes workspace metadata only in the initial user message", async () => {

--- a/src/shared/storage/state-keys.ts
+++ b/src/shared/storage/state-keys.ts
@@ -55,6 +55,7 @@ const REMOTE_CONFIG_EXTRA_FIELDS = {
 	previousRemoteMCPServers: { default: undefined as Array<{ name: string; url: string }> | undefined },
 	remoteGlobalRules: { default: undefined as GlobalInstructionsFile[] | undefined },
 	remoteGlobalWorkflows: { default: undefined as GlobalInstructionsFile[] | undefined },
+	remoteGlobalSkills: { default: undefined as GlobalInstructionsFile[] | undefined },
 	blockPersonalRemoteMCPServers: { default: false as boolean },
 	openTelemetryOtlpHeaders: { default: undefined as Record<string, string> | undefined },
 	otlpMetricsHeaders: { default: undefined as Record<string, string> | undefined },
@@ -89,6 +90,7 @@ const GLOBAL_STATE_FIELDS = {
 	nativeToolCallEnabled: { default: true as boolean },
 	remoteRulesToggles: { default: {} as ClineRulesToggles },
 	remoteWorkflowToggles: { default: {} as ClineRulesToggles },
+	remoteSkillsToggles: { default: {} as ClineRulesToggles },
 	dismissedBanners: { default: [] as Array<{ bannerId: string; dismissedAt: number }> },
 	// Path to worktree that should auto-open Cline sidebar when launched
 	worktreeAutoOpenPath: { default: undefined as string | undefined },

--- a/webview-ui/src/components/cline-rules/ClineRulesToggleModal.tsx
+++ b/webview-ui/src/components/cline-rules/ClineRulesToggleModal.tsx
@@ -403,7 +403,9 @@ const ClineRulesToggleModal: React.FC = () => {
 					setLocalSkillsToggles(response.localSkillsToggles)
 				}
 				// Update local skills state
-				if (isGlobal) {
+				if (skillPath.startsWith("remote:")) {
+					setGlobalSkills((prev) => prev.map((s) => (s.path === skillPath ? { ...s, enabled } : s)))
+				} else if (isGlobal) {
 					setGlobalSkills((prev) => prev.map((s) => (s.path === skillPath ? { ...s, enabled } : s)))
 				} else {
 					setLocalSkills((prev) => prev.map((s) => (s.path === skillPath ? { ...s, enabled } : s)))
@@ -780,27 +782,47 @@ const ClineRulesToggleModal: React.FC = () => {
 							</>
 						) : currentView === "skills" ? (
 							<>
+								{/* Enterprise Skills Section (remote) */}
+								{globalSkills.some((s) => s.path.startsWith("remote:")) && (
+									<div className="mb-3">
+										<div className="text-sm font-normal mb-2">Enterprise Skills</div>
+										<div className="flex flex-col gap-0">
+											{globalSkills
+												.filter((s) => s.path.startsWith("remote:"))
+												.sort((a, b) => a.name.localeCompare(b.name))
+												.map((skill) => (
+													<RuleRow
+														alwaysEnabled={skill.alwaysEnabled}
+														enabled={skill.enabled}
+														isGlobal={true}
+														isRemote={true}
+														key={skill.path}
+														rulePath={skill.name}
+														ruleType="skill"
+														toggleRule={(_path, enabled) => toggleSkill(true, skill.path, enabled)}
+													/>
+												))}
+										</div>
+									</div>
+								)}
+
 								{/* Global Skills Section */}
 								<div className="mb-3">
 									<div className="text-sm font-normal mb-2">Global Skills</div>
 									<div className="flex flex-col gap-0">
 										{globalSkills
+											.filter((s) => !s.path.startsWith("remote:"))
 											.sort((a, b) => a.name.localeCompare(b.name))
-											.map((skill) => {
-												const isRemote = skill.path.startsWith("remote:")
-												return (
-													<RuleRow
-														enabled={skill.enabled}
-														isGlobal={true}
-														isRemote={isRemote}
-														alwaysEnabled={isRemote ? skill.alwaysEnabled : undefined}
-														key={skill.path}
-														rulePath={isRemote ? skill.name : skill.path}
-														ruleType="skill"
-														toggleRule={(_path, enabled) => toggleSkill(true, skill.path, enabled)}
-													/>
-												)
-											})}
+											.map((skill) => (
+												<RuleRow
+													enabled={skill.enabled}
+													isGlobal={true}
+													key={skill.path}
+													rulePath={skill.path}
+													ruleType="skill"
+													toggleRule={(_path, enabled) => toggleSkill(true, skill.path, enabled)}
+												/>
+											))}
 										<NewRuleRow isGlobal={true} ruleType="skill" />
 									</div>
 								</div>

--- a/webview-ui/src/components/cline-rules/ClineRulesToggleModal.tsx
+++ b/webview-ui/src/components/cline-rules/ClineRulesToggleModal.tsx
@@ -786,16 +786,21 @@ const ClineRulesToggleModal: React.FC = () => {
 									<div className="flex flex-col gap-0">
 										{globalSkills
 											.sort((a, b) => a.name.localeCompare(b.name))
-											.map((skill) => (
-												<RuleRow
-													enabled={skill.enabled}
-													isGlobal={true}
-													key={skill.path}
-													rulePath={skill.path}
-													ruleType="skill"
-													toggleRule={(path, enabled) => toggleSkill(true, path, enabled)}
-												/>
-											))}
+											.map((skill) => {
+												const isRemote = skill.path.startsWith("remote:")
+												return (
+													<RuleRow
+														enabled={skill.enabled}
+														isGlobal={true}
+														isRemote={isRemote}
+														alwaysEnabled={isRemote ? skill.alwaysEnabled : undefined}
+														key={skill.path}
+														rulePath={isRemote ? skill.name : skill.path}
+														ruleType="skill"
+														toggleRule={(_path, enabled) => toggleSkill(true, skill.path, enabled)}
+													/>
+												)
+											})}
 										<NewRuleRow isGlobal={true} ruleType="skill" />
 									</div>
 								</div>

--- a/webview-ui/src/components/cline-rules/RuleRow.tsx
+++ b/webview-ui/src/components/cline-rules/RuleRow.tsx
@@ -100,9 +100,15 @@ const RuleRow: React.FC<{
 		}
 	}
 
+	const getRemoteUriType = () => {
+		if (ruleType === "workflow") return "workflow"
+		if (ruleType === "skill") return "skill"
+		return "rule"
+	}
+
 	const handleEditClick = () => {
-		// For remote rules, use the special remote:// URI format
-		const filePath = isRemote ? `${REMOTE_URI_SCHEME}${ruleType === "workflow" ? "workflow" : "rule"}/${rulePath}` : rulePath
+		// For remote rules/workflows/skills, use the special remote:// URI format
+		const filePath = isRemote ? `${REMOTE_URI_SCHEME}${getRemoteUriType()}/${rulePath}` : rulePath
 		FileServiceClient.openFile(StringRequest.create({ value: filePath })).catch((err) =>
 			console.error("Failed to open file:", err),
 		)
@@ -158,19 +164,19 @@ const RuleRow: React.FC<{
 						title={isDisabled ? "This rule is required and cannot be disabled" : undefined}
 					/>
 					<Button
-						aria-label={isRemote ? "View rule file" : "Edit rule file"}
+						aria-label={isRemote ? `View ${ruleType} file` : `Edit ${ruleType} file`}
 						onClick={handleEditClick}
 						size="xs"
-						title={isRemote ? "View rule file (read-only)" : "Edit rule file"}
+						title={isRemote ? `View ${ruleType} file (read-only)` : `Edit ${ruleType} file`}
 						variant="icon">
 						{isRemote ? <EyeIcon /> : <PenIcon />}
 					</Button>
 					<Button
-						aria-label="Delete rule file"
+						aria-label={`Delete ${ruleType} file`}
 						disabled={isRemote}
 						onClick={handleDeleteClick}
 						size="xs"
-						title="Delete rule file"
+						title={`Delete ${ruleType} file`}
 						variant="icon">
 						<Trash2Icon />
 					</Button>


### PR DESCRIPTION
### Related Issue

**Issue:** #10236

### Description

The remote config schema already includes `globalSkills: GlobalInstructionsFile[]` (merged in #10236). The core-platform dashboard can save skills to the remote config. This PR wires up the extension to read, display, and use them end-to-end.

**Key design decisions:**
- **`frontmatter.name` is the canonical identity** for remote skills. A warning is logged if `entry.name` drifts from `frontmatter.name`, but the skill is still included (not rejected) to avoid silently hiding org-configured skills.
- **`remote:` path prefix** distinguishes remote from disk-based skills in toggle stores, content loading, and UI rendering.
- **`parseRemoteSkillEntries`** is the single shared validation point — eliminates duplicated frontmatter parsing across `skills.ts`, `refreshSkills.ts`, and `remote-config/utils.ts`.
- **`skills.ts` remains a pure utility module** with zero `StateManager` coupling. Remote entries are injected as optional parameters by callers that have state access.
- **Precedence: remote (enterprise) > disk-global (user) > project (workspace)**. Enterprise-pushed skills override user personal globals, which override workspace skills. `alwaysEnabled` skills cannot be toggled off.

### Changes

| Layer | File | Change |
|---|---|---|
| State | `state-keys.ts` | Add `remoteGlobalSkills` + `remoteSkillsToggles` |
| Remote config | `remote-config/utils.ts` | Transform, sync toggles via shared utility; atomic `replaceRemoteConfig` to fix race condition |
| StateManager | `StateManager.ts` | Add `replaceRemoteConfig()` for atomic cache swap |
| Shared utility | `skills.ts` | `parseRemoteSkillEntries` shared validator; `discoverSkills` + `getSkillContent` accept remote entries with drift-tolerant lookup |
| UI refresh | `refreshSkills.ts` | Uses shared utility for remote skill parsing |
| System prompt | `task/index.ts` | Pass `remoteSkillEntries` to `discoverSkills` + remote toggle/alwaysEnabled filtering |
| Tool handler | `UseSkillToolHandler.ts` | Remote toggle filter with `alwaysEnabled` enforcement |
| Toggle | `toggleSkill.ts` | Route `remote:` paths to `remoteSkillsToggles`; return all 3 toggle maps |
| View file | `openFile.ts` | Handle `remote://skill/{name}` URIs with frontmatter fallback |
| Proto | `file.proto` | Add `always_enabled` to `SkillInfo`; add `remote_skills_toggles` to `SkillsToggles` |
| UI modal | `ClineRulesToggleModal.tsx` | Dedicated "Enterprise Skills" section; correct toggle response handling |
| UI row | `RuleRow.tsx` | Correct `remote://skill/` URI construction; contextual tooltip text |

### Bugs fixed beyond the original feature

1. **System prompt didn't include remote skills** — `discoverSkills()` was called without remote entries during prompt generation, so the model never knew remote skills existed
2. **Race condition in `applyRemoteConfig`** — `clearRemoteConfig()` + field-by-field repopulation created a window where concurrent readers saw an empty cache. Replaced with atomic `replaceRemoteConfig()`
3. **`alwaysEnabled` not enforced in handler** — toggle filter could hide admin-locked skills
4. **View button didn't work for skills** — `openRemoteFile` only handled `rule|workflow`, not `skill`
5. **Tooltip said "View rule file" for all types** — now contextual ("View skill file", etc.)

### Test Procedure

- **53 unit tests** covering all layers:
  - `parseRemoteSkillEntries`: validation, drift warning (not reject), missing fields, mixed entries
  - Remote skill discovery: inclusion, drift tolerance, missing frontmatter, empty/undefined
  - Precedence resolution: remote > disk-global, remote > project
  - Remote content loading: content from entries, trimming, missing entry, no disk read
  - Remote config transform: mapping, undefined, empty, alwaysEnabled preservation
  - Toggle sync: new defaults, preservation, stale removal, empty, multiple
  - alwaysEnabled enforcement: override stale false, respect false when not locked, defaults
- All pre-existing disk-based skill tests continue to pass unchanged
- 1392 total tests passing, 0 failures

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Additional Notes

- Enterprise skills with `alwaysEnabled: true` cannot be toggled off by the user — both in the UI (toggle is disabled with tooltip) and at execution time (handler + system prompt both respect the flag).
- The `remote:` path convention is consistent across toggle storage, content loading, UI rendering, system prompt, and the tool handler. It is never written to disk.
- The `replaceRemoteConfig` race fix benefits rules and workflows too, not just skills.

## Screenshots

<img width="434" height="231" alt="Screenshot 2026-04-16 at 8 45 27 AM" src="https://github.com/user-attachments/assets/3b063391-56fb-4510-acd6-89914ebd5112" />

<img width="442" height="466" alt="Screenshot 2026-04-16 at 9 34 51 AM" src="https://github.com/user-attachments/assets/7d6bb032-912b-4ed0-9fff-eb91236d1eb1" />
<img width="652" height="306" alt="Screenshot 2026-04-16 at 8 50 52 AM" src="https://github.com/user-attachments/assets/dc5e1d53-2f40-43f1-a4df-b54854a70a63" />
