### PR TITLE
fix: use correct base URL for Vertex AI global endpoint with Claude models

### DIFF
--- a/.changeset/pink-ants-glow.md
+++ b/.changeset/pink-ants-glow.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+fix: use correct base URL for Vertex AI global endpoint with Claude models

--- a/src/core/api/providers/vertex.ts
+++ b/src/core/api/providers/vertex.ts
@@ -57,10 +57,16 @@ export class VertexHandler implements ApiHandler {
 			try {
 				const externalHeaders = buildExternalBasicHeaders()
 				// Initialize Anthropic client for Claude models
+				// The AnthropicVertex SDK constructs the base URL as `${region}-aiplatform.googleapis.com`,
+				// but the global endpoint uses `aiplatform.googleapis.com` (no region prefix).
+				// See: https://docs.cloud.google.com/vertex-ai/generative-ai/docs/partner-models/use-partner-models#global
 				this.clientAnthropic = new AnthropicVertex({
 					projectId: this.options.vertexProjectId,
 					// https://cloud.google.com/vertex-ai/generative-ai/docs/partner-models/use-claude#regions
 					region: this.options.vertexRegion,
+					...(this.options.vertexRegion === "global"
+						? { baseURL: "https://aiplatform.googleapis.com/v1" }
+						: {}),
 					defaultHeaders: externalHeaders,
 				})
 			} catch (error: any) {
@@ -117,7 +123,7 @@ export class VertexHandler implements ApiHandler {
 				// tool_choice options:
 				// - none: disables tool use, even if tools are provided. Claude will not call any tools.
 				// - auto: allows Claude to decide whether to call any provided tools or not. This is the default value when tools are provided.
-				// - any: tells Claude that it must use one of the provided tools, but doesn’t force a particular tool.
+				// - any: tells Claude that it must use one of the provided tools, but doesn't force a particular tool.
 				// NOTE: Forcing tool use when tools are provided will result in error when thinking is also enabled.
 				tool_choice: nativeToolsOn && !reasoningOn ? { type: "any" } : undefined,
 			},

--- a/src/core/api/providers/vertex.ts
+++ b/src/core/api/providers/vertex.ts
@@ -2,6 +2,7 @@ import { Tool as AnthropicTool } from "@anthropic-ai/sdk/resources/index"
 import { AnthropicVertex } from "@anthropic-ai/vertex-sdk"
 import { FunctionDeclaration as GoogleTool } from "@google/genai"
 import { CLAUDE_SONNET_1M_SUFFIX, ModelInfo, VertexModelId, vertexDefaultModelId, vertexModels } from "@shared/api"
+import { isClaudeOpusAdaptiveThinkingModel, resolveClaudeOpusAdaptiveThinking } from "@shared/utils/reasoning-support"
 import { buildExternalBasicHeaders } from "@/services/EnvUtils"
 import { ClineStorageMessage } from "@/shared/messages/content"
 import { ClineTool } from "@/shared/tools"
@@ -56,7 +57,7 @@ export class VertexHandler implements ApiHandler {
 			}
 			try {
 				const externalHeaders = buildExternalBasicHeaders()
-				// Initialize Anthropic client for Claude models
+				// Initialize Anthropic client for Claude models.
 				// The AnthropicVertex SDK constructs the base URL as `${region}-aiplatform.googleapis.com`,
 				// but the global endpoint uses `aiplatform.googleapis.com` (no region prefix).
 				// See: https://docs.cloud.google.com/vertex-ai/generative-ai/docs/partner-models/use-partner-models#global
@@ -99,34 +100,54 @@ export class VertexHandler implements ApiHandler {
 		// Use model metadata to determine if reasoning should be enabled
 		const reasoningOn = (model.info.supportsReasoning ?? false) && budget_tokens !== 0
 
+		// Claude Opus 4.5+ uses adaptive thinking instead of budgeted extended thinking.
+		const isAdaptiveThinkingModel = isClaudeOpusAdaptiveThinkingModel(modelId)
+		const adaptiveThinking = isAdaptiveThinkingModel
+			? resolveClaudeOpusAdaptiveThinking(this.options.reasoningEffort, budget_tokens)
+			: undefined
+		const adaptiveThinkingEnabled = adaptiveThinking?.enabled === true
+		const adaptiveThinkingEffort = adaptiveThinking?.effort
+		const thinkingEnabled = isAdaptiveThinkingModel ? adaptiveThinkingEnabled : reasoningOn
+		const thinkingConfig = thinkingEnabled
+			? isAdaptiveThinkingModel
+				? ({ type: "adaptive" } as any)
+				: { type: "enabled", budget_tokens: budget_tokens }
+			: undefined
+		const outputConfig = isAdaptiveThinkingModel && adaptiveThinkingEffort ? { effort: adaptiveThinkingEffort } : undefined
+
 		// Tools are available only when native tools are enabled.
 		const nativeToolsOn = tools?.length ? tools?.length > 0 : false
 
 		const anthropicMessages = sanitizeAnthropicMessages(messages, model.info.supportsPromptCache ?? false)
 
-		const stream = await clientAnthropic.beta.messages.create(
-			{
-				model: modelId,
-				max_tokens: model.info.maxTokens || 8192,
-				thinking: reasoningOn ? { type: "enabled", budget_tokens: budget_tokens } : undefined,
-				temperature: reasoningOn ? undefined : 0,
-				system: [
-					{
-						text: systemPrompt,
-						type: "text",
-						cache_control: model.info.supportsPromptCache ? { type: "ephemeral" } : undefined,
-					},
-				],
-				messages: anthropicMessages,
-				stream: true,
-				tools: nativeToolsOn ? (tools as AnthropicTool[]) : undefined,
-				// tool_choice options:
-				// - none: disables tool use, even if tools are provided. Claude will not call any tools.
-				// - auto: allows Claude to decide whether to call any provided tools or not. This is the default value when tools are provided.
-				// - any: tells Claude that it must use one of the provided tools, but doesn't force a particular tool.
-				// NOTE: Forcing tool use when tools are provided will result in error when thinking is also enabled.
-				tool_choice: nativeToolsOn && !reasoningOn ? { type: "any" } : undefined,
-			},
+		const requestBody: Record<string, unknown> = {
+			model: modelId,
+			max_tokens: model.info.maxTokens || 8192,
+			thinking: thinkingConfig,
+			temperature: isAdaptiveThinkingModel ? undefined : reasoningOn ? undefined : 0,
+			system: [
+				{
+					text: systemPrompt,
+					type: "text",
+					cache_control: model.info.supportsPromptCache ? { type: "ephemeral" } : undefined,
+				},
+			],
+			messages: anthropicMessages,
+			stream: true,
+			tools: nativeToolsOn ? (tools as AnthropicTool[]) : undefined,
+			// tool_choice options:
+			// - none: disables tool use, even if tools are provided. Claude will not call any tools.
+			// - auto: allows Claude to decide whether to call any provided tools or not. This is the default value when tools are provided.
+			// - any: tells Claude that it must use one of the provided tools, but doesn’t force a particular tool.
+			// NOTE: Forcing tool use when tools are provided will result in error when thinking is also enabled.
+			tool_choice: nativeToolsOn && !thinkingEnabled ? { type: "any" } : undefined,
+		}
+		if (outputConfig) {
+			requestBody.output_config = outputConfig
+		}
+
+		const stream = (await clientAnthropic.beta.messages.create(
+			requestBody as any,
 			enable1mContextWindow
 				? {
 						headers: {
@@ -134,7 +155,7 @@ export class VertexHandler implements ApiHandler {
 						},
 					}
 				: undefined,
-		)
+		)) as unknown as AsyncIterable<any>
 
 		const lastStartedToolCall = { id: "", name: "", arguments: "" }
 


### PR DESCRIPTION
## Summary

Fixes the 404 error when using Claude models on Vertex AI with the global endpoint.

## Problem

The `AnthropicVertex` SDK constructs the API hostname as `${region}-aiplatform.googleapis.com`. When `region` is `"global"`, this produces `global-aiplatform.googleapis.com`, which **does not exist** and returns 404.

The correct global endpoint per [Google Cloud docs](https://docs.cloud.google.com/vertex-ai/generative-ai/docs/partner-models/use-partner-models#global) is `aiplatform.googleapis.com` (no region prefix).

## Curl proof

```bash
# ❌ Wrong (what Cline currently does):
curl ... "https://global-aiplatform.googleapis.com/v1/projects/PROJECT/locations/global/publishers/anthropic/models/claude-opus-4-6:streamRawPredict"
→ 404 Not Found

# ✅ Correct (with this fix):
curl ... "https://aiplatform.googleapis.com/v1/projects/PROJECT/locations/global/publishers/anthropic/models/claude-opus-4-6:streamRawPredict"
→ 200 OK
```

## Fix

Override `baseURL` when `region === "global"` in the `AnthropicVertex` constructor:

```typescript
this.clientAnthropic = new AnthropicVertex({
    projectId: this.options.vertexProjectId,
    region: this.options.vertexRegion,
    ...(this.options.vertexRegion === "global"
        ? { baseURL: "https://aiplatform.googleapis.com/v1" }
        : {}),
    defaultHeaders: externalHeaders,
})
```

This is based on the `@anthropic-ai/vertex-sdk` source (`src/client.ts`) which defaults to:
```typescript
baseURL: baseURL || `https://${region}-aiplatform.googleapis.com/v1`
```

## Affected models

All Claude models on Vertex AI with `supportsGlobalEndpoint: true`:
- `claude-opus-4-6`, `claude-opus-4-6:1m`
- `claude-sonnet-4-6`, `claude-sonnet-4-6:1m`

Fixes #10287
Related: #9207