### PR TITLE
v3.79.0 Release Notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## [3.79.0]
+
+### Added
+
+- Add Claude Opus 4.7 model support
+- Add Azure Blob Storage as a storage provider
+- Add GPT-5.2 model support
+- Add `globalSkills` to remote config
+- Inline value reuse in user-level remote-config discovery
+
+### Fixed
+
+- Fix cache reflection for Cline and Vercel API handlers
+- Fix stuck `command_output` ask when terminal command ends unexpectedly
+- Add `use_subagents` to system prompt for GLM, Hermes, and XS models
+- Fix action injection security risk
+
+### Changed
+
+- Remove deprecated evals tool
+
 ## [3.78.0]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@
 
 - Add Claude Opus 4.7 model support
 - Add Azure Blob Storage as a storage provider
-- Add GPT-5.2 model support
 - Add `globalSkills` to remote config
 - Inline value reuse in user-level remote-config discovery
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- Add Claude Opus 4.7 and GPT-5.2 model support
+- Add Claude Opus 4.7 model support
 - Inline value reuse in user-level remote-config discovery
 - Add `globalSkills` to remote config
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,5 +1,17 @@
 # cline
 
+## [2.15.0]
+
+### Added
+
+- Add Claude Opus 4.7 and GPT-5.2 model support
+- Inline value reuse in user-level remote-config discovery
+- Add `globalSkills` to remote config
+
+### Fixed
+
+- Stabilize Windows CI test path handling
+
 ## [2.14.0]
 
 ### Added

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cline",
-	"version": "2.14.0",
+	"version": "2.15.0",
 	"description": "Autonomous coding agent CLI - capable of creating/editing files, running commands, using the browser, and more",
 	"main": "dist/lib.mjs",
 	"types": "dist/lib.d.ts",

--- a/package-lock.json
+++ b/package-lock.json
@@ -162,7 +162,7 @@
 		},
 		"cli": {
 			"name": "cline",
-			"version": "2.14.0",
+			"version": "2.15.0",
 			"cpu": [
 				"x64",
 				"arm64"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "claude-dev",
-	"version": "3.78.0",
+	"version": "3.79.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "claude-dev",
-			"version": "3.78.0",
+			"version": "3.79.0",
 			"license": "Apache-2.0",
 			"workspaces": [
 				".",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "claude-dev",
 	"displayName": "Cline",
 	"description": "Autonomous coding agent right in your IDE, capable of creating/editing files, running commands, using the browser, and more with your permission every step of the way.",
-	"version": "3.78.0",
+	"version": "3.79.0",
 	"icon": "assets/icons/icon.png",
 	"workspaces": [
 		".",


### PR DESCRIPTION
## Summary

- Bump version from `3.78.0` → `3.79.0`
- Update `CHANGELOG.md` with curated release notes for `3.79.0`

## What's in this release

### Added
- Claude Opus 4.7 model support
- Azure Blob Storage as a storage provider
- GPT-5.2 model support
- `globalSkills` to remote config
- Inline value reuse in user-level remote-config discovery

### Fixed
- Fix cache reflection for Cline and Vercel API handlers
- Fix stuck `command_output` ask when terminal command ends unexpectedly
- Add `use_subagents` to system prompt for GLM, Hermes, and XS models
- Fix action injection security risk

### Changed
- Remove deprecated evals tool

## Test plan
- [ ] Verify `package.json` version reads `3.79.0`
- [ ] Verify `CHANGELOG.md` header is `## [3.79.0]`
- [ ] After merge: tag `v3.79.0` and trigger publish workflow at https://github.com/cline/cline/actions/workflows/publish.yml

🤖 Generated with [Claude Code](https://claude.ai/claude-code)