### PR TITLE
fix(vscode-terminal): unblock run() when shell integration stream never yields

### DIFF
--- a/src/hosts/vscode/terminal/VscodeTerminalProcess.ts
+++ b/src/hosts/vscode/terminal/VscodeTerminalProcess.ts
@@ -66,26 +66,52 @@ export class VscodeTerminalProcess extends EventEmitter<TerminalProcessEvents> i
 			let didOutputNonCommand = false
 			let didEmitEmptyLine = false
 
-			for await (let data of stream) {
-				// Parse shell integration completion markers when present.
-				// Sequence format: ]633;D;<exitCode>
-				const completionMatches = [...data.matchAll(/\]633;D(?:;(-?\d+))?/g)]
-				const latestCompletionMatch = completionMatches[completionMatches.length - 1]
-				if (latestCompletionMatch?.[1] !== undefined) {
-					const parsedExitCode = Number.parseInt(latestCompletionMatch[1], 10)
-					if (Number.isInteger(parsedExitCode)) {
-						this.exitCode = parsedExitCode
-					}
+			// Fallback end signal: if the shell rejects a command at parse time, the stream
+			// yields nothing and never closes. VS Code still fires end-of-execution for the
+			// terminal's shell integration, so race the stream against that event and exit
+			// the loop if it fires. The event's `execution` property is not reference-equal
+			// to the one returned by executeCommand(); match on `shellIntegration` instead.
+			const END_SENTINEL: unique symbol = Symbol("end-of-execution")
+			let resolveEndOfExecution: () => void = () => {}
+			const endOfExecutionPromise = new Promise<typeof END_SENTINEL>((resolve) => {
+				resolveEndOfExecution = () => resolve(END_SENTINEL)
+			})
+			const endOfExecutionDisposable = (vscode.window as any).onDidEndTerminalShellExecution?.((e: any) => {
+				if (e?.shellIntegration === terminal.shellIntegration) {
+					resolveEndOfExecution()
 				}
+			})
 
-				// 1. Process chunk and remove artifacts
-				if (isFirstChunk) {
-					/*
+			const iterator = stream[Symbol.asyncIterator]()
+			try {
+				while (true) {
+					const next = await Promise.race([iterator.next(), endOfExecutionPromise])
+					if (next === END_SENTINEL) {
+						break
+					}
+					if (next.done) {
+						break
+					}
+					let data = next.value
+					// Parse shell integration completion markers when present.
+					// Sequence format: ]633;D;<exitCode>
+					const completionMatches = [...data.matchAll(/\]633;D(?:;(-?\d+))?/g)]
+					const latestCompletionMatch = completionMatches[completionMatches.length - 1]
+					if (latestCompletionMatch?.[1] !== undefined) {
+						const parsedExitCode = Number.parseInt(latestCompletionMatch[1], 10)
+						if (Number.isInteger(parsedExitCode)) {
+							this.exitCode = parsedExitCode
+						}
+					}
+
+					// 1. Process chunk and remove artifacts
+					if (isFirstChunk) {
+						/*
 					The first chunk we get from this stream needs to be processed to be more human readable, ie remove vscode's custom escape sequences and identifiers, removing duplicate first char bug, etc.
 					*/
 
-					// bug where sometimes the command output makes its way into vscode shell integration metadata
-					/*
+						// bug where sometimes the command output makes its way into vscode shell integration metadata
+						/*
 					]633 is a custom sequence number used by VSCode shell integration:
 					- OSC 633 ; A ST - Mark prompt start
 					- OSC 633 ; B ST - Mark prompt end
@@ -93,119 +119,122 @@ export class VscodeTerminalProcess extends EventEmitter<TerminalProcessEvents> i
 					- OSC 633 ; D [; <exitcode>] ST - Mark execution finished with optional exit code
 					- OSC 633 ; E ; <commandline> [; <nonce>] ST - Explicitly set command line with optional nonce
 					*/
-					// if you print this data you might see something like "eecho hello worldo hello world;5ba85d14-e92a-40c4-b2fd-71525581eeb0]633;C" but this is actually just a bunch of escape sequences, ignore up to the first ;C
-					/* ddateb15026-6a64-40db-b21f-2a621a9830f0]633;CTue Sep 17 06:37:04 EDT 2024 % ]633;D;0]633;P;Cwd=/Users/saoud/Repositories/test */
-					// Gets output between ]633;C (command start) and ]633;D (command end)
-					const outputBetweenSequences = this.removeLastLineArtifacts(
-						data.match(/\]633;C([\s\S]*?)\]633;D/)?.[1] || "",
-					).trim()
+						// if you print this data you might see something like "eecho hello worldo hello world;5ba85d14-e92a-40c4-b2fd-71525581eeb0]633;C" but this is actually just a bunch of escape sequences, ignore up to the first ;C
+						/* ddateb15026-6a64-40db-b21f-2a621a9830f0]633;CTue Sep 17 06:37:04 EDT 2024 % ]633;D;0]633;P;Cwd=/Users/saoud/Repositories/test */
+						// Gets output between ]633;C (command start) and ]633;D (command end)
+						const outputBetweenSequences = this.removeLastLineArtifacts(
+							data.match(/\]633;C([\s\S]*?)\]633;D/)?.[1] || "",
+						).trim()
 
-					// Once we've retrieved any potential output between sequences, we can remove everything up to end of the last sequence
-					// https://code.visualstudio.com/docs/terminal/shell-integration#_vs-code-custom-sequences-osc-633-st
-					const vscodeSequenceRegex = /\x1b\]633;.[^\x07]*\x07/g
-					const lastMatch = [...data.matchAll(vscodeSequenceRegex)].pop()
-					if (lastMatch && lastMatch.index !== undefined) {
-						data = data.slice(lastMatch.index + lastMatch[0].length)
+						// Once we've retrieved any potential output between sequences, we can remove everything up to end of the last sequence
+						// https://code.visualstudio.com/docs/terminal/shell-integration#_vs-code-custom-sequences-osc-633-st
+						const vscodeSequenceRegex = /\x1b\]633;.[^\x07]*\x07/g
+						const lastMatch = [...data.matchAll(vscodeSequenceRegex)].pop()
+						if (lastMatch && lastMatch.index !== undefined) {
+							data = data.slice(lastMatch.index + lastMatch[0].length)
+						}
+						// Place output back after removing vscode sequences
+						if (outputBetweenSequences) {
+							data = outputBetweenSequences + "\n" + data
+						}
+						// remove ansi
+						data = stripAnsi(data)
+						// Split data by newlines
+						const lines = data ? data.split("\n") : []
+						// Remove non-human readable characters from the first line
+						if (lines.length > 0) {
+							lines[0] = lines[0].replace(/[^\x20-\x7E]/g, "")
+						}
+						// Check for duplicated first character that might be a terminal artifact
+						// But skip this check for known syntax characters like {, [, ", etc.
+						if (
+							lines.length > 0 &&
+							lines[0].length >= 2 &&
+							lines[0][0] === lines[0][1] &&
+							!["[", "{", '"', "'", "<", "("].includes(lines[0][0])
+						) {
+							lines[0] = lines[0].slice(1)
+						}
+						// Only remove specific terminal artifacts from line beginnings while preserving JSON syntax
+						if (lines.length > 0) {
+							// This regex only removes common terminal artifacts (%, $, >, #) and invisible control chars
+							// but preserves important syntax chars like {, [, ", etc.
+							lines[0] = lines[0].replace(/^[\x00-\x1F%$>#\s]*/, "")
+						}
+						if (lines.length > 1) {
+							lines[1] = lines[1].replace(/^[\x00-\x1F%$>#\s]*/, "")
+						}
+						// Join lines back
+						data = lines.join("\n")
+						isFirstChunk = false
+					} else {
+						data = stripAnsi(data)
 					}
-					// Place output back after removing vscode sequences
-					if (outputBetweenSequences) {
-						data = outputBetweenSequences + "\n" + data
-					}
-					// remove ansi
-					data = stripAnsi(data)
-					// Split data by newlines
-					const lines = data ? data.split("\n") : []
-					// Remove non-human readable characters from the first line
-					if (lines.length > 0) {
-						lines[0] = lines[0].replace(/[^\x20-\x7E]/g, "")
-					}
-					// Check for duplicated first character that might be a terminal artifact
-					// But skip this check for known syntax characters like {, [, ", etc.
-					if (
-						lines.length > 0 &&
-						lines[0].length >= 2 &&
-						lines[0][0] === lines[0][1] &&
-						!["[", "{", '"', "'", "<", "("].includes(lines[0][0])
-					) {
-						lines[0] = lines[0].slice(1)
-					}
-					// Only remove specific terminal artifacts from line beginnings while preserving JSON syntax
-					if (lines.length > 0) {
-						// This regex only removes common terminal artifacts (%, $, >, #) and invisible control chars
-						// but preserves important syntax chars like {, [, ", etc.
-						lines[0] = lines[0].replace(/^[\x00-\x1F%$>#\s]*/, "")
-					}
-					if (lines.length > 1) {
-						lines[1] = lines[1].replace(/^[\x00-\x1F%$>#\s]*/, "")
-					}
-					// Join lines back
-					data = lines.join("\n")
-					isFirstChunk = false
-				} else {
-					data = stripAnsi(data)
-				}
 
-				// Ctrl+C detection: if user presses Ctrl+C, treat as command terminated
-				if (data.includes("^C") || data.includes("\u0003")) {
+					// Ctrl+C detection: if user presses Ctrl+C, treat as command terminated
+					if (data.includes("^C") || data.includes("\u0003")) {
+						if (this.hotTimer) {
+							clearTimeout(this.hotTimer)
+						}
+						this.isHot = false
+						break
+					}
+
+					// first few chunks could be the command being echoed back, so we must ignore
+					// note this means that 'echo' commands won't work
+					if (!didOutputNonCommand) {
+						const lines = data.split("\n")
+						for (let i = 0; i < lines.length; i++) {
+							if (command.includes(lines[i].trim())) {
+								lines.splice(i, 1)
+								i-- // Adjust index after removal
+							} else {
+								didOutputNonCommand = true
+								break
+							}
+						}
+						data = lines.join("\n")
+					}
+
+					// 2. Set isHot depending on the command
+					// Set to hot to stall API requests until terminal is cool again
+					this.isHot = true
 					if (this.hotTimer) {
 						clearTimeout(this.hotTimer)
 					}
-					this.isHot = false
-					break
-				}
+					// these markers indicate the command is some kind of local dev server recompiling the app, which we want to wait for output of before sending request to cline
+					const isCompiling = isCompilingOutput(data)
+					this.hotTimer = setTimeout(
+						() => {
+							this.isHot = false
+						},
+						isCompiling ? PROCESS_HOT_TIMEOUT_COMPILING : PROCESS_HOT_TIMEOUT_NORMAL,
+					)
 
-				// first few chunks could be the command being echoed back, so we must ignore
-				// note this means that 'echo' commands won't work
-				if (!didOutputNonCommand) {
-					const lines = data.split("\n")
-					for (let i = 0; i < lines.length; i++) {
-						if (command.includes(lines[i].trim())) {
-							lines.splice(i, 1)
-							i-- // Adjust index after removal
-						} else {
-							didOutputNonCommand = true
-							break
-						}
+					// For non-immediately returning commands we want to show loading spinner right away but this wouldn't happen until it emits a line break, so as soon as we get any output we emit "" to let webview know to show spinner
+					// This is only done for the sake of unblocking the UI, in case there may be some time before the command emits a full line
+					if (!didEmitEmptyLine && !this.fullOutput && data) {
+						this.emit("line", "") // empty line to indicate start of command output stream
+						didEmitEmptyLine = true
 					}
-					data = lines.join("\n")
-				}
 
-				// 2. Set isHot depending on the command
-				// Set to hot to stall API requests until terminal is cool again
-				this.isHot = true
-				if (this.hotTimer) {
-					clearTimeout(this.hotTimer)
-				}
-				// these markers indicate the command is some kind of local dev server recompiling the app, which we want to wait for output of before sending request to cline
-				const isCompiling = isCompilingOutput(data)
-				this.hotTimer = setTimeout(
-					() => {
-						this.isHot = false
-					},
-					isCompiling ? PROCESS_HOT_TIMEOUT_COMPILING : PROCESS_HOT_TIMEOUT_NORMAL,
-				)
+					this.fullOutput += data
 
-				// For non-immediately returning commands we want to show loading spinner right away but this wouldn't happen until it emits a line break, so as soon as we get any output we emit "" to let webview know to show spinner
-				// This is only done for the sake of unblocking the UI, in case there may be some time before the command emits a full line
-				if (!didEmitEmptyLine && !this.fullOutput && data) {
-					this.emit("line", "") // empty line to indicate start of command output stream
-					didEmitEmptyLine = true
-				}
+					// Cap fullOutput at MAX_FULL_OUTPUT_SIZE to prevent memory exhaustion
+					if (this.fullOutput.length > MAX_FULL_OUTPUT_SIZE) {
+						// Keep last half of max size
+						this.fullOutput = this.fullOutput.slice(-MAX_FULL_OUTPUT_SIZE / 2)
+						// Reset lastRetrievedIndex since we truncated the beginning
+						this.lastRetrievedIndex = 0
+					}
 
-				this.fullOutput += data
-
-				// Cap fullOutput at MAX_FULL_OUTPUT_SIZE to prevent memory exhaustion
-				if (this.fullOutput.length > MAX_FULL_OUTPUT_SIZE) {
-					// Keep last half of max size
-					this.fullOutput = this.fullOutput.slice(-MAX_FULL_OUTPUT_SIZE / 2)
-					// Reset lastRetrievedIndex since we truncated the beginning
-					this.lastRetrievedIndex = 0
+					if (this.isListening) {
+						this.emitIfEol(data)
+						this.lastRetrievedIndex = this.fullOutput.length - this.buffer.length
+					}
 				}
-
-				if (this.isListening) {
-					this.emitIfEol(data)
-					this.lastRetrievedIndex = this.fullOutput.length - this.buffer.length
-				}
+			} finally {
+				endOfExecutionDisposable?.dispose?.()
 			}
 
 			this.emitRemainingBufferIfListening()

--- a/src/hosts/vscode/terminal/VscodeTerminalProcess.ts
+++ b/src/hosts/vscode/terminal/VscodeTerminalProcess.ts
@@ -78,6 +78,11 @@ export class VscodeTerminalProcess extends EventEmitter<TerminalProcessEvents> i
 			})
 			const endOfExecutionDisposable = (vscode.window as any).onDidEndTerminalShellExecution?.((e: any) => {
 				if (e?.shellIntegration === terminal.shellIntegration) {
+					// Capture exit code from the event when the stream never yields its own ]633;D marker
+					// (e.g. parse-rejected commands). Available on VS Code 1.93+.
+					if (this.exitCode === undefined && typeof e?.exitCode === "number") {
+						this.exitCode = e.exitCode
+					}
 					resolveEndOfExecution()
 				}
 			})
@@ -235,6 +240,9 @@ export class VscodeTerminalProcess extends EventEmitter<TerminalProcessEvents> i
 				}
 			} finally {
 				endOfExecutionDisposable?.dispose?.()
+				// Signal the async iterator to clean up on early exit. `for await` does this
+				// automatically on `break`; we're using a manual while loop so call it explicitly.
+				await iterator.return?.()
 			}
 
 			this.emitRemainingBufferIfListening()


### PR DESCRIPTION
Many thanks to Taeksu Kim @ Samsung for the deep investigation here

### Related Issue

**Issue:** #XXXX

<!-- No tracking issue; fix flagged in internal Slack thread following the 3.79 RC by Taeksu Kim after PR #10269 shipped. -->

### Description

When the user's shell rejects a command at parse time (e.g. zsh's `parse error near '|'` for `tail -10 /var/www/html/index.html 2>1& | echo -`), VS Code's shell-integration read stream yields zero chunks and never closes. `VscodeTerminalProcess.run()`'s `for await (let data of stream)` hangs forever, `run()` never resolves, and `CommandOrchestrator` sits on `await process` indefinitely. In the UI this shows as a command that "Skipped" and a task spinning on "Thinking..." with no way to recover.

**Why PR #10269 didn't already cover this:** #10269 added a release path for a blocked `Task.ask("command_output", ...)` whenever the process emits `completed`, `error`, or `COMMAND_TIMEOUT`. That works correctly, but the hang here happens *earlier*: `run()` never returns, so none of those lifecycle signals ever fire, so #10269's release paths are never reached.

**Fix.** Race each iterator `.next()` call against a promise resolved by VS Code's `window.onDidEndTerminalShellExecution` (which *does* fire for this case). When the end-of-execution event matches the current terminal's `shellIntegration`, break out of the loop. The existing post-loop `returnCurrentTerminalContents()` fallback captures whatever was rendered in the terminal, `run()` resolves, and `completed` fires downstream as normal.

Matching notes: VS Code re-wraps the `TerminalShellExecution` inside the end event, so `e.execution === execution` does **not** hold. `e.shellIntegration === terminal.shellIntegration` does, and `shellIntegration` is part of the public `TerminalShellExecutionEndEvent` API, so that's the identity used here.

Type note: `@types/vscode` is pinned at 1.84.0 in this repo, which predates the stabilized `onDidEndTerminalShellExecution` event (added in VS Code 1.93). The API exists and works at runtime in every supported VS Code version; this change uses a localized `as any` cast to sidestep the stale type without bumping the types package. A follow-up to bump `@types/vscode` is worth doing separately.

### Test Procedure

**Reproducer** (zsh; bash behaves the same for commands rejected at parse time):

1. Ensure `terminal.integrated.shellIntegration.enabled = true` and Cline is configured to use the VS Code terminal.
2. Ask Cline to run this exact command:
   ```
   tail -10 /var/www/html/index.html 2>1& | echo -
   ```
   The `2>1&` terminates the command with `&` (background), leaving `|` with nothing to pipe from. Both zsh and bash reject this at parse time.
3. Before the fix: Cline gets stuck on "Thinking..." indefinitely. After the fix: the command resolves within ~700ms and the task continues.

**Instrumented verification** (run end-to-end during development):

Pre-fix, buggy command:
```
[t+418ms] run() enter, hasShellIntegration:true
[t+466ms] onDidEndTerminalShellExecution fired
[t+30s+]  silence, no chunks, no loop exit, no lifecycle events
```

Post-fix, same buggy command:
```
[t+36ms]  end-of-execution listener fired (shellIntegration match)
[t+37ms]  broke loop on end-of-execution, totalChunks: 0
[t+678ms] 'completed' listener fired, process awaited and resolved
```

Regression check with a valid command (`tail -10 /var/www/html/index.html 2>&1 | echo -`):
```
[t+75ms]  stream yielded chunk (chunkIndex: 1, dataLength: 368)
[t+76ms]  stream loop exited, endOfExecutionTriggered: false
[t+533ms] 'completed' listener fired
```

`endOfExecutionTriggered: false` confirms the fallback was not exercised for healthy commands and the stream closed naturally via its `]633;D` marker, so there is no behavior change on the healthy path.

**What could break / how verified:**
- Healthy commands where the stream closes normally: iterator `.next()` resolves first, loop exits via `next.done`, identical behavior to the old `for await`. Verified by regression log above.
- Concurrent commands on other terminals: listener filters on `e.shellIntegration === terminal.shellIntegration`, so end events from other terminals are ignored.
- Event listener leaks: subscription is scoped per `run()` and disposed in a `finally` block.

### Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ♻️ Refactor Changes
- [ ] 💅 Cosmetic Changes
- [ ] 📚 Documentation update
- [ ] 🏃 Workflow Changes

### Pre-flight Checklist

- [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
- [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
- [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A (backend fix). Log evidence in "Test Procedure" above.

### Additional Notes

- Root cause isolation (the critical observation that `timeoutSeconds = undefined` and that neither `pWaitFor` in `Task` is entered during the hang) belongs to Taeksu Kim.
- PR #10269's release logic is untouched and continues to work for `completed` / `error` / `COMMAND_TIMEOUT`. This fix addresses the upstream case where `run()` itself never resolves, which is why #10269's paths weren't reached.
- Out of scope: dangling `Task` instances after a new session starts (separate lifecycle concern), and v1 VS Code extension maintenance plan discussions.
