### PR TITLE
fix: Model metadata fails to update when change model (#10248)

### DIFF
--- a/webview-ui/src/components/settings/ClineModelPicker.tsx
+++ b/webview-ui/src/components/settings/ClineModelPicker.tsx
@@ -198,6 +198,7 @@ const ClineModelPicker: React.FC<ClineModelPickerProps> = ({ isPopup, currentMod
 	const handleModelChange = (newModelId: string) => {
 		setSearchTerm(newModelId)
 
+		const modelInfo = clineModels?.[newModelId]
 		handleModeFieldsChange(
 			{
 				clineModelId: { plan: "planModeClineModelId", act: "actModeClineModelId" },
@@ -205,28 +206,62 @@ const ClineModelPicker: React.FC<ClineModelPickerProps> = ({ isPopup, currentMod
 			},
 			{
 				clineModelId: newModelId,
-				clineModelInfo: clineModels?.[newModelId],
+				// Only write modelInfo when clineModels has data for this model.
+				// Writing undefined would overwrite any existing valid modelInfo
+				// in the persisted config, causing stale/incorrect prices until
+				// the next page reload.
+				...(modelInfo != null ? { clineModelInfo: modelInfo } : {}),
 			},
 			currentMode,
 		)
 	}
 
-	const { selectedModelId, selectedModelInfo } = useMemo(() => {
+	const { selectedModelId, selectedModelInfo, isModelInfoLoading } = useMemo(() => {
 		const selected = normalizeApiConfiguration(apiConfiguration, currentMode)
-		if (freeClineModelIdSet.has(normalizeModelId(selected.selectedModelId))) {
+		const configModelId = selected.selectedModelId
+
+		// When a user clicks a model card/dropdown item, searchTerm updates immediately
+		// but apiConfiguration lags behind (waiting for gRPC round-trip). Use searchTerm
+		// as the effective model ID when it differs from the config value, so the price
+		// display updates instantly instead of showing stale data from the old model.
+		// Unlike checking clineModels for existence, this comparison covers the case where
+		// a model appears in the recommended list but not yet in clineModels (e.g. newly
+		// launched models).
+		const isPendingGrpcUpdate = !!searchTerm && searchTerm !== configModelId
+		const effectiveModelId = isPendingGrpcUpdate ? searchTerm : configModelId
+
+		// Prefer fresh model info from clineModels over the config-stored copy,
+		// which may be stale or undefined after a model switch.
+		const modelInfoFromClineModels = clineModels?.[effectiveModelId]
+		const effectiveModelInfo = modelInfoFromClineModels ?? selected.selectedModelInfo
+
+		// When the model is not in clineModels and gRPC hasn't confirmed the selection yet,
+		// we can't trust any price data. Signal the loading state so ModelInfoView can
+		// display "Loading..." instead of showing potentially incorrect prices (e.g. showing
+		// "Free" for a paid model based on stale data from a previously selected free model).
+		const isModelInfoLoading = isPendingGrpcUpdate && !modelInfoFromClineModels
+
+		if (freeClineModelIdSet.has(normalizeModelId(effectiveModelId))) {
 			return {
 				...selected,
+				selectedModelId: effectiveModelId,
 				selectedModelInfo: {
-					...selected.selectedModelInfo,
+					...effectiveModelInfo,
 					inputPrice: 0,
 					outputPrice: 0,
 					cacheReadsPrice: 0,
 					cacheWritesPrice: 0,
 				},
+				isModelInfoLoading: false,
 			}
 		}
-		return selected
-	}, [apiConfiguration, currentMode, freeClineModelIdSet])
+		return {
+			...selected,
+			selectedModelId: effectiveModelId,
+			selectedModelInfo: effectiveModelInfo,
+			isModelInfoLoading,
+		}
+	}, [apiConfiguration, currentMode, freeClineModelIdSet, clineModels, searchTerm])
 
 	useMount(() => {
 		refreshClineModels()
@@ -573,6 +608,7 @@ const ClineModelPicker: React.FC<ClineModelPickerProps> = ({ isPopup, currentMod
 					)}
 
 					<ModelInfoView
+						isLoading={isModelInfoLoading}
 						isPopup={isPopup}
 						modelInfo={selectedModelInfo}
 						onProviderSortingChange={(value) => handleFieldChange("openRouterProviderSorting", value)}

--- a/webview-ui/src/components/settings/common/ModelInfoView.tsx
+++ b/webview-ui/src/components/settings/common/ModelInfoView.tsx
@@ -170,6 +170,8 @@ interface ModelInfoViewProps {
 	selectedModelId: string
 	modelInfo: ModelInfo
 	isPopup?: boolean
+	/** When true, pricing fields show "Loading..." instead of stale/incorrect values */
+	isLoading?: boolean
 	// Provider routing props (optional - only shown for Cline provider)
 	providerSorting?: string
 	onProviderSortingChange?: (value: string) => void
@@ -182,6 +184,7 @@ export const ModelInfoView = ({
 	selectedModelId,
 	modelInfo,
 	isPopup,
+	isLoading,
 	providerSorting,
 	onProviderSortingChange,
 	showProviderRouting,
@@ -215,19 +218,21 @@ export const ModelInfoView = ({
 						<InfoValue>{formatCompactContext(modelInfo.contextWindow)}</InfoValue>
 					</InfoItem>
 				)}
-				{modelInfo.inputPrice !== undefined && (
+				{(modelInfo.inputPrice !== undefined || isLoading) && (
 					<InfoItem>
 						<InfoLabel>Input: </InfoLabel>
-						<InfoValue>{formatCompactPrice(modelInfo.inputPrice)}</InfoValue>
+						<InfoValue>{isLoading ? "Loading..." : formatCompactPrice(modelInfo.inputPrice)}</InfoValue>
 					</InfoItem>
 				)}
-				{modelInfo.outputPrice !== undefined && (
+				{(modelInfo.outputPrice !== undefined || isLoading) && (
 					<InfoItem>
 						<InfoLabel>Output: </InfoLabel>
 						<InfoValue>
-							{hasThinkingConfig && modelInfo.thinkingConfig?.outputPrice !== undefined
-								? formatCompactPrice(modelInfo.thinkingConfig.outputPrice)
-								: formatCompactPrice(modelInfo.outputPrice)}
+							{isLoading
+								? "Loading..."
+								: hasThinkingConfig && modelInfo.thinkingConfig?.outputPrice !== undefined
+									? formatCompactPrice(modelInfo.thinkingConfig.outputPrice)
+									: formatCompactPrice(modelInfo.outputPrice)}
 						</InfoValue>
 					</InfoItem>
 				)}


### PR DESCRIPTION
### Related Issue

**Issue:** #10248

### Description

When selecting a model through the "Recommended" list or "NEW" announcement chips in the Settings UI, the cost metadata (Input/Output price) does not update — it retains stale pricing from the previously selected model, often showing "Free" for a paid model.

This UI state desync led to users making decisions based on incorrect pricing information, resulting in unintended expenditures.

### Root Cause

The `selectedModelInfo` useMemo depends on `apiConfiguration`, which only updates after a gRPC round-trip. When a user clicks a model card, `searchTerm` updates immediately (synchronous), but `apiConfiguration` lags behind (async). The previous fix only resolved the price when `searchTerm` existed in `clineModels`, but models from the recommended list may not yet be in `clineModels` (e.g. newly launched models served from a different API endpoint), leaving the bug unpatched in exactly the most impactful scenario.

Additionally, `handleModelChange` wrote `undefined` as `clineModelInfo` when the model wasn't in `clineModels`, overwriting any previously valid persisted model info and causing stale prices until page reload.

### Solution

**1. Optimistic update with loading fallback in useMemo**

Replace the `clineModels` existence check (`!!clineModels?.[searchTerm]`) with a simpler pending-state comparison (`searchTerm !== configModelId`). This covers the case where a model appears in the recommended list but not yet in `clineModels`.

- When `searchTerm` differs from `configModelId` and `clineModels` has data for the model → display correct price immediately (optimistic update, no flicker)
- When `searchTerm` differs from `configModelId` but `clineModels` lacks the model → signal `isModelInfoLoading = true` to show "Loading..." instead of stale/incorrect prices
- When `searchTerm` matches `configModelId` → use config data as before

**2. Guard against undefined modelInfo in handleModelChange**

Only write `clineModelInfo` to the persisted config when `clineModels` actually has data for the selected model. Writing `undefined` would overwrite any existing valid model info, causing incorrect prices until the next page reload.

**3. Add `isLoading` prop to ModelInfoView**

When `isLoading` is true, Input/Output price fields display "Loading..." instead of stale values. This prop is optional and defaults to `false`, so all other provider ModelPickers are unaffected.

### Test Procedure

All tests has passed.


### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots
<img width="455" height="982" alt="image" src="https://github.com/user-attachments/assets/8d2e9191-89dd-4a91-8647-2622b144084d" />

<img width="1030" height="1518" alt="image" src="https://github.com/user-attachments/assets/81041b93-1ac8-44ef-a346-95a2c193a38b" />
