### PR TITLE
Adding cline quota exceeded cap error message

### DIFF
--- a/src/core/task/index.ts
+++ b/src/core/task/index.ts
@@ -2084,6 +2084,7 @@ export class Task {
 
 				const isAuthError = clineError.isErrorType(ClineErrorType.Auth)
 				const isSpendLimitError = clineError.isErrorType(ClineErrorType.SpendLimit)
+				const quotaExceeded = clineError.isErrorType(ClineErrorType.QuotaExceeded)
 
 				// Check if this is a Cline provider insufficient credits error - don't auto-retry these
 				const isClineProviderInsufficientCredits = (() => {
@@ -2100,12 +2101,13 @@ export class Task {
 
 				let response: ClineAskResponse
 				// Skip auto-retry for Cline provider insufficient credits, auth errors, or spend limit errors
-				if (
+				const shouldRetry =
 					!isClineProviderInsufficientCredits &&
 					!isAuthError &&
 					!isSpendLimitError &&
+					!quotaExceeded &&
 					this.taskState.autoRetryAttempts < 3
-				) {
+				if (shouldRetry) {
 					// Auto-retry enabled with max 3 attempts: automatically approve the retry
 					this.taskState.autoRetryAttempts++
 
@@ -2156,7 +2158,8 @@ export class Task {
 					await setTimeoutPromise(delay)
 				} else {
 					// Show error_retry with failed flag to indicate all retries exhausted (but not for insufficient credits or spend limit)
-					if (!isClineProviderInsufficientCredits && !isAuthError && !isSpendLimitError) {
+					const showRetry = !isClineProviderInsufficientCredits && !isAuthError && !isSpendLimitError && !quotaExceeded
+					if (showRetry) {
 						await this.say(
 							"error_retry",
 							JSON.stringify({

--- a/src/services/error/ClineError.ts
+++ b/src/services/error/ClineError.ts
@@ -7,6 +7,7 @@ export enum ClineErrorType {
 	RateLimit = "rateLimit",
 	Balance = "balance",
 	SpendLimit = "spendLimit",
+	QuotaExceeded = "quotaExceeded",
 }
 
 interface ErrorDetails {
@@ -155,6 +156,10 @@ export class ClineError extends Error {
 		const isAuthStatus = status !== undefined && status > 400 && status < 429
 		if (code === "ERR_BAD_REQUEST" || err instanceof AuthInvalidTokenError || isAuthStatus) {
 			return ClineErrorType.Auth
+		}
+
+		if (code === "INFERENCE_CAP_ERROR") {
+			return ClineErrorType.QuotaExceeded
 		}
 
 		if (message) {

--- a/src/services/error/__tests__/ClineError.test.ts
+++ b/src/services/error/__tests__/ClineError.test.ts
@@ -1,0 +1,12 @@
+import { describe, it } from "mocha"
+import "should"
+import { ClineError, ClineErrorType } from "../ClineError"
+
+describe("ClineError", () => {
+	describe("getErrorType", () => {
+		it("should return QuotaExceeded when code is INFERENCE_CAP_ERROR", () => {
+			const err = new ClineError({ message: "Inference cap reached", code: "INFERENCE_CAP_ERROR" })
+			ClineError.getErrorType(err)!.should.equal(ClineErrorType.QuotaExceeded)
+		})
+	})
+})

--- a/webview-ui/src/components/chat/ErrorRow.test.tsx
+++ b/webview-ui/src/components/chat/ErrorRow.test.tsx
@@ -117,14 +117,15 @@ describe("ErrorRow", () => {
 
 		it("renders quota exceeded error", async () => {
 			const mockClineError = {
+				message: "Inference cap reached",
 				isErrorType: vi.fn((type) => type === "quotaexceeded"),
 			}
 
 			const { ClineError } = await import("../../../../src/services/error/ClineError")
 			vi.mocked(ClineError.parse).mockReturnValue(mockClineError as any)
 
-			render(<ErrorRow apiRequestFailedMessage="Quota exceeded" errorType="error" message="" />)
-			expect(screen.getByText("Quota exceeded")).toBeInTheDocument()
+			render(<ErrorRow apiRequestFailedMessage="The message" errorType="error" message="" />)
+			expect(screen.getByText("Inference cap reached")).toBeInTheDocument()
 		})
 
 		it("renders friendly logged-out message and sign in button when user is not signed in", async () => {

--- a/webview-ui/src/components/chat/ErrorRow.test.tsx
+++ b/webview-ui/src/components/chat/ErrorRow.test.tsx
@@ -115,6 +115,18 @@ describe("ErrorRow", () => {
 			expect(screen.getByText("Request ID: req_123456")).toBeInTheDocument()
 		})
 
+		it("renders quota exceeded error", async () => {
+			const mockClineError = {
+				isErrorType: vi.fn((type) => type === "quotaexceeded"),
+			}
+
+			const { ClineError } = await import("../../../../src/services/error/ClineError")
+			vi.mocked(ClineError.parse).mockReturnValue(mockClineError as any)
+
+			render(<ErrorRow apiRequestFailedMessage="Quota exceeded" errorType="error" message="" />)
+			expect(screen.getByText("Quota exceeded")).toBeInTheDocument()
+		})
+
 		it("renders friendly logged-out message and sign in button when user is not signed in", async () => {
 			const mockClineError = {
 				message: "Authentication failed",

--- a/webview-ui/src/components/chat/ErrorRow.tsx
+++ b/webview-ui/src/components/chat/ErrorRow.tsx
@@ -70,6 +70,10 @@ const ErrorRow = memo(({ message, errorType, apiRequestFailedMessage, apiReqStre
 						)
 					}
 
+					if (clineError?.isErrorType(ClineErrorType.QuotaExceeded)) {
+						return <p className="m-0 whitespace-pre-wrap text-error wrap-anywhere">{errorMessage}</p>
+					}
+
 					if (clineError?.isErrorType(ClineErrorType.Auth) && isClineProvider) {
 						return !clineUser ? (
 							// User is using Cline provider and is not logged in


### PR DESCRIPTION
### Description

Added a simple VS Code extension error message to handle the specific error code `INFERENCE_CAP_ERROR`, which occurs when the cap quota is exceeded from the Cline provider. This error returns an HTTP 429 status code and is currently treated as a standard 429 response.

Note: The current VS Code extension behavior retries all 429 responses indiscriminately, regardless of their cause. Addressing this behavior is out of scope for this PR.

Note_2: I will not add specific fields(e.g. request_id) within api responses, message will contain all the necessary, unless special formatting is needed.

### Test Procedure

Tested locally while debugging the extension and confirmed that the message appears as expected.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [x] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<img width="376" height="273" alt="image" src="https://github.com/user-attachments/assets/d9b10635-3d7b-4396-bb78-5a56d0f40591" />


### Additional Notes

n/a
