### PR TITLE
Add SDK nightly publish workflow

### DIFF
--- a/.github/workflows/publish-nightly-sdk.yml
+++ b/.github/workflows/publish-nightly-sdk.yml
@@ -67,4 +67,4 @@ jobs:
                   OTEL_EXPORTER_OTLP_PROTOCOL: ${{ secrets.OTEL_EXPORTER_OTLP_PROTOCOL }}
                   OTEL_EXPORTER_OTLP_ENDPOINT: ${{ secrets.OTEL_EXPORTER_OTLP_ENDPOINT }}
                   OTEL_EXPORTER_OTLP_HEADERS: ${{ secrets.OTEL_EXPORTER_OTLP_HEADERS }}
-              run: npm run publish:marketplace:nightly
+              run: npm run publish:marketplace:nightly -- --pre-release

--- a/.github/workflows/publish-nightly-sdk.yml
+++ b/.github/workflows/publish-nightly-sdk.yml
@@ -1,0 +1,70 @@
+name: "Publish SDK Nightly Release"
+
+on:
+    workflow_dispatch:
+
+permissions:
+    contents: read
+    packages: write
+    checks: write
+    pull-requests: write
+
+env:
+    # Keep the publish source pinned to one reviewed branch instead of accepting arbitrary refs.
+    SDK_NIGHTLY_REF: dpc/sdk-migration-simpler-login
+
+jobs:
+    publish:
+        name: Publish Cline (Nightly SDK) Extension
+        if: github.repository == 'cline/cline' && github.ref == 'refs/heads/main'
+        runs-on: ubuntu-latest
+        environment: PublishNightly
+
+        steps:
+            - name: Checkout trusted SDK nightly branch
+              uses: actions/checkout@v4
+              with:
+                  ref: ${{ env.SDK_NIGHTLY_REF }}
+                  lfs: true
+                  persist-credentials: false
+
+            - name: Setup Node.js
+              uses: actions/setup-node@v4
+              with:
+                  # Keep publish environment aligned with test workflow/tooling lockfile expectations.
+                  # Newer LTS (Node 24 / npm 11) can make `npm list` fail with ELSPROBLEMS during vsce packaging.
+                  node-version: 22
+
+            - name: Install root dependencies
+              run: npm ci --include=optional
+
+            - name: Install webview-ui dependencies
+              run: cd webview-ui && npm ci --include=optional
+
+            - name: Install Publishing Tools
+              run: npm install -g @vscode/vsce ovsx
+
+            - name: Verify LFS media assets are resolved
+              run: |
+                  for FILE in webview-ui/src/assets/cline_kanban_demo.mp4 webview-ui/src/assets/cline_kanban_demo.webm; do
+                    if grep -q "git-lfs.github.com/spec/v1" "$FILE"; then
+                      echo "Error: $FILE is still a Git LFS pointer in CI checkout"
+                      exit 1
+                    fi
+                  done
+
+            - name: Publish SDK nightly extension as pre-release
+              env:
+                  VSCE_PAT: ${{ secrets.VSCE_PAT }}
+                  OVSX_PAT: ${{ secrets.OVSX_PAT }}
+                  TELEMETRY_SERVICE_API_KEY: ${{ secrets.TELEMETRY_SERVICE_API_KEY }}
+                  ERROR_SERVICE_API_KEY: ${{ secrets.ERROR_SERVICE_API_KEY }}
+                  CLINE_ENVIRONMENT: production
+                  # OpenTelemetry production defaults (can be overridden at runtime)
+                  OTEL_TELEMETRY_ENABLED: ${{ secrets.OTEL_TELEMETRY_ENABLED }}
+                  OTEL_LOGS_EXPORTER: otlp
+                  OTEL_METRICS_EXPORTER: otlp
+                  OTEL_EXPORTER_OTLP_PROTOCOL: ${{ secrets.OTEL_EXPORTER_OTLP_PROTOCOL }}
+                  OTEL_EXPORTER_OTLP_ENDPOINT: ${{ secrets.OTEL_EXPORTER_OTLP_ENDPOINT }}
+                  OTEL_EXPORTER_OTLP_HEADERS: ${{ secrets.OTEL_EXPORTER_OTLP_HEADERS }}
+              run: npm run publish:marketplace:nightly


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

### Description

Adds a separate manual GitHub Actions workflow for SDK nightly publishing. The new workflow stays behind the protected nightly environment, only runs when dispatched from `main`, and checks out a single trusted SDK branch before running the existing nightly publish script with the current Marketplace/OpenVSX secrets.

This keeps the PAT-gated nightly publish path available for SDK validation without allowing arbitrary branch refs to run with publish credentials.

### Test Procedure

- Parsed `.github/workflows/publish-nightly-sdk.yml` with Ruby's YAML parser to confirm the workflow syntax is valid.
- Reviewed the workflow to ensure it hardcodes `dpc/sdk-migration-simpler-login` via `SDK_NIGHTLY_REF` and reuses `environment: PublishNightly`.
- Did not run the GitHub Actions workflow itself.

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [x] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A

### Additional Notes

The trusted SDK source branch is currently pinned to `dpc/sdk-migration-simpler-login` in the workflow env block. If the team wants a longer-lived branch for SDK nightly publishing, that value can be updated without changing the publish logic.
