### PR TITLE
Use details instead of caught error message

### DIFF
--- a/webview-ui/src/components/chat/ErrorRow.tsx
+++ b/webview-ui/src/components/chat/ErrorRow.tsx
@@ -71,7 +71,8 @@ const ErrorRow = memo(({ message, errorType, apiRequestFailedMessage, apiReqStre
 					}
 
 					if (clineError?.isErrorType(ClineErrorType.QuotaExceeded)) {
-						return <p className="m-0 whitespace-pre-wrap text-error wrap-anywhere">{errorMessage}</p>
+						const detailMessage = clineError?._error?.details?.message || errorMessage
+						return <p className="m-0 whitespace-pre-wrap text-error wrap-anywhere">{detailMessage}</p>
 					}
 
 					if (clineError?.isErrorType(ClineErrorType.Auth) && isClineProvider) {


### PR DESCRIPTION
### Description

For quota exceeded error, instead of using caught error message, I will use error detail message instead. To give us more freedom of changing the error from the API with the exact formatting.

### Test Procedure

- Local debugging + verified proper error message

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [x] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<img width="309" height="256" alt="image" src="https://github.com/user-attachments/assets/79d27370-6956-4ea4-b8f4-360de28c953b" />

### Additional Notes