### PR TITLE
docs: remove demo video from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,6 @@ English | <a href="https://github.com/cline/cline/blob/main/locales/es/README.md
 </sub></div>
 
 # Cline
-
-<p align="center">
-  <img src="https://media.githubusercontent.com/media/cline/cline/main/assets/docs/demo.gif" width="100%" />
-</p>
-
 <div align="center">
 <table>
 <tbody>


### PR DESCRIPTION
Removes the demo gif/video from the top of the README. The large animated gif was adding unnecessary weight to the page load and isn't needed as the primary introduction to the project -- the links table and description that follow are sufficient.