### PR TITLE
fix: pin protobufjs to 7.5.5 to address CVE-2026-41242

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5596,8 +5596,7 @@
 			"optional": true,
 			"os": [
 				"android"
-			],
-			"peer": true
+			]
 		},
 		"node_modules/@rollup/rollup-android-arm64": {
 			"version": "4.60.0",
@@ -5610,8 +5609,7 @@
 			"optional": true,
 			"os": [
 				"android"
-			],
-			"peer": true
+			]
 		},
 		"node_modules/@rollup/rollup-darwin-arm64": {
 			"version": "4.60.0",
@@ -5624,8 +5622,7 @@
 			"optional": true,
 			"os": [
 				"darwin"
-			],
-			"peer": true
+			]
 		},
 		"node_modules/@rollup/rollup-darwin-x64": {
 			"version": "4.60.0",
@@ -5638,8 +5635,7 @@
 			"optional": true,
 			"os": [
 				"darwin"
-			],
-			"peer": true
+			]
 		},
 		"node_modules/@rollup/rollup-freebsd-arm64": {
 			"version": "4.60.0",
@@ -5652,8 +5648,7 @@
 			"optional": true,
 			"os": [
 				"freebsd"
-			],
-			"peer": true
+			]
 		},
 		"node_modules/@rollup/rollup-freebsd-x64": {
 			"version": "4.60.0",
@@ -5666,8 +5661,7 @@
 			"optional": true,
 			"os": [
 				"freebsd"
-			],
-			"peer": true
+			]
 		},
 		"node_modules/@rollup/rollup-linux-arm-gnueabihf": {
 			"version": "4.60.0",
@@ -5680,8 +5674,7 @@
 			"optional": true,
 			"os": [
 				"linux"
-			],
-			"peer": true
+			]
 		},
 		"node_modules/@rollup/rollup-linux-arm-musleabihf": {
 			"version": "4.60.0",
@@ -5694,8 +5687,7 @@
 			"optional": true,
 			"os": [
 				"linux"
-			],
-			"peer": true
+			]
 		},
 		"node_modules/@rollup/rollup-linux-arm64-gnu": {
 			"version": "4.60.0",
@@ -5708,8 +5700,7 @@
 			"optional": true,
 			"os": [
 				"linux"
-			],
-			"peer": true
+			]
 		},
 		"node_modules/@rollup/rollup-linux-arm64-musl": {
 			"version": "4.60.0",
@@ -5722,8 +5713,7 @@
 			"optional": true,
 			"os": [
 				"linux"
-			],
-			"peer": true
+			]
 		},
 		"node_modules/@rollup/rollup-linux-loong64-gnu": {
 			"version": "4.60.0",
@@ -5736,8 +5726,7 @@
 			"optional": true,
 			"os": [
 				"linux"
-			],
-			"peer": true
+			]
 		},
 		"node_modules/@rollup/rollup-linux-loong64-musl": {
 			"version": "4.60.0",
@@ -5750,8 +5739,7 @@
 			"optional": true,
 			"os": [
 				"linux"
-			],
-			"peer": true
+			]
 		},
 		"node_modules/@rollup/rollup-linux-ppc64-gnu": {
 			"version": "4.60.0",
@@ -5764,8 +5752,7 @@
 			"optional": true,
 			"os": [
 				"linux"
-			],
-			"peer": true
+			]
 		},
 		"node_modules/@rollup/rollup-linux-ppc64-musl": {
 			"version": "4.60.0",
@@ -5778,8 +5765,7 @@
 			"optional": true,
 			"os": [
 				"linux"
-			],
-			"peer": true
+			]
 		},
 		"node_modules/@rollup/rollup-linux-riscv64-gnu": {
 			"version": "4.60.0",
@@ -5792,8 +5778,7 @@
 			"optional": true,
 			"os": [
 				"linux"
-			],
-			"peer": true
+			]
 		},
 		"node_modules/@rollup/rollup-linux-riscv64-musl": {
 			"version": "4.60.0",
@@ -5806,8 +5791,7 @@
 			"optional": true,
 			"os": [
 				"linux"
-			],
-			"peer": true
+			]
 		},
 		"node_modules/@rollup/rollup-linux-s390x-gnu": {
 			"version": "4.60.0",
@@ -5820,8 +5804,7 @@
 			"optional": true,
 			"os": [
 				"linux"
-			],
-			"peer": true
+			]
 		},
 		"node_modules/@rollup/rollup-linux-x64-gnu": {
 			"version": "4.60.0",
@@ -5834,8 +5817,7 @@
 			"optional": true,
 			"os": [
 				"linux"
-			],
-			"peer": true
+			]
 		},
 		"node_modules/@rollup/rollup-linux-x64-musl": {
 			"version": "4.60.0",
@@ -5848,8 +5830,7 @@
 			"optional": true,
 			"os": [
 				"linux"
-			],
-			"peer": true
+			]
 		},
 		"node_modules/@rollup/rollup-openbsd-x64": {
 			"version": "4.60.0",
@@ -5862,8 +5843,7 @@
 			"optional": true,
 			"os": [
 				"openbsd"
-			],
-			"peer": true
+			]
 		},
 		"node_modules/@rollup/rollup-openharmony-arm64": {
 			"version": "4.60.0",
@@ -5876,8 +5856,7 @@
 			"optional": true,
 			"os": [
 				"openharmony"
-			],
-			"peer": true
+			]
 		},
 		"node_modules/@rollup/rollup-win32-arm64-msvc": {
 			"version": "4.60.0",
@@ -5890,8 +5869,7 @@
 			"optional": true,
 			"os": [
 				"win32"
-			],
-			"peer": true
+			]
 		},
 		"node_modules/@rollup/rollup-win32-ia32-msvc": {
 			"version": "4.60.0",
@@ -5904,8 +5882,7 @@
 			"optional": true,
 			"os": [
 				"win32"
-			],
-			"peer": true
+			]
 		},
 		"node_modules/@rollup/rollup-win32-x64-gnu": {
 			"version": "4.60.0",
@@ -5918,8 +5895,7 @@
 			"optional": true,
 			"os": [
 				"win32"
-			],
-			"peer": true
+			]
 		},
 		"node_modules/@rollup/rollup-win32-x64-msvc": {
 			"version": "4.60.0",
@@ -5932,8 +5908,7 @@
 			"optional": true,
 			"os": [
 				"win32"
-			],
-			"peer": true
+			]
 		},
 		"node_modules/@sap-ai-sdk/ai-api": {
 			"version": "2.7.0",
@@ -18873,9 +18848,9 @@
 			"license": "ISC"
 		},
 		"node_modules/protobufjs": {
-			"version": "7.5.4",
-			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
-			"integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
+			"version": "7.5.5",
+			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.5.tgz",
+			"integrity": "sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==",
 			"hasInstallScript": true,
 			"license": "BSD-3-Clause",
 			"dependencies": {
@@ -22231,7 +22206,6 @@
 			"os": [
 				"aix"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -22248,7 +22222,6 @@
 			"os": [
 				"android"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -22265,7 +22238,6 @@
 			"os": [
 				"android"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -22282,7 +22254,6 @@
 			"os": [
 				"android"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -22299,7 +22270,6 @@
 			"os": [
 				"darwin"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -22316,7 +22286,6 @@
 			"os": [
 				"darwin"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -22333,7 +22302,6 @@
 			"os": [
 				"freebsd"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -22350,7 +22318,6 @@
 			"os": [
 				"freebsd"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -22367,7 +22334,6 @@
 			"os": [
 				"linux"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -22384,7 +22350,6 @@
 			"os": [
 				"linux"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -22401,7 +22366,6 @@
 			"os": [
 				"linux"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -22418,7 +22382,6 @@
 			"os": [
 				"linux"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -22435,7 +22398,6 @@
 			"os": [
 				"linux"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -22452,7 +22414,6 @@
 			"os": [
 				"linux"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -22469,7 +22430,6 @@
 			"os": [
 				"linux"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -22486,7 +22446,6 @@
 			"os": [
 				"linux"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -22503,7 +22462,6 @@
 			"os": [
 				"linux"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -22520,7 +22478,6 @@
 			"os": [
 				"netbsd"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -22537,7 +22494,6 @@
 			"os": [
 				"netbsd"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -22554,7 +22510,6 @@
 			"os": [
 				"openbsd"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -22571,7 +22526,6 @@
 			"os": [
 				"openbsd"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -22588,7 +22542,6 @@
 			"os": [
 				"openharmony"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -22605,7 +22558,6 @@
 			"os": [
 				"sunos"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -22622,7 +22574,6 @@
 			"os": [
 				"win32"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -22639,7 +22590,6 @@
 			"os": [
 				"win32"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -22656,7 +22606,6 @@
 			"os": [
 				"win32"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -22712,7 +22661,6 @@
 			"os": [
 				"darwin"
 			],
-			"peer": true,
 			"engines": {
 				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
 			}

--- a/package.json
+++ b/package.json
@@ -597,6 +597,7 @@
 		"vite": "^7.1.11",
 		"js-yaml": "^4.1.1",
 		"serialize-javascript": ">=7.0.3",
+		"protobufjs": "7.5.5",
 		"mocha": {
 			"diff": ">=8.0.3"
 		}

--- a/standalone/runtime-files/package-lock.json
+++ b/standalone/runtime-files/package-lock.json
@@ -21,7 +21,6 @@
 			"resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.13.3.tgz",
 			"integrity": "sha512-FTXHdOoPbZrBjlVLHuKbDZnsTxXv2BlHF57xw6LuThXacXvtkahEPED0CKMk6obZDf65Hv4k3z62eyPNpvinIg==",
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
 				"@grpc/proto-loader": "^0.7.13",
 				"@js-sdsl/ordered-map": "^4.4.2"
@@ -668,9 +667,9 @@
 			}
 		},
 		"node_modules/protobufjs": {
-			"version": "7.5.2",
-			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.2.tgz",
-			"integrity": "sha512-f2ls6rpO6G153Cy+o2XQ+Y0sARLOZ17+OGVLHrc3VUKcLHYKEKWbkSujdBWQXM7gKn5NTfp0XnRPZn1MIu8n9w==",
+			"version": "7.5.5",
+			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.5.tgz",
+			"integrity": "sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==",
 			"hasInstallScript": true,
 			"license": "BSD-3-Clause",
 			"dependencies": {

--- a/standalone/runtime-files/package.json
+++ b/standalone/runtime-files/package.json
@@ -11,6 +11,7 @@
 		"vscode-uri": "^3.1.0"
 	},
 	"overrides": {
-		"tar-fs": "^3.1.1"
+		"tar-fs": "^3.1.1",
+		"protobufjs": "7.5.5"
 	}
 }

--- a/webview-ui/package-lock.json
+++ b/webview-ui/package-lock.json
@@ -11925,7 +11925,9 @@
 			}
 		},
 		"node_modules/protobufjs": {
-			"version": "7.5.4",
+			"version": "7.5.5",
+			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.5.tgz",
+			"integrity": "sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==",
 			"hasInstallScript": true,
 			"license": "BSD-3-Clause",
 			"dependencies": {

--- a/webview-ui/package.json
+++ b/webview-ui/package.json
@@ -86,6 +86,9 @@
 		"vite": "^7.1.11",
 		"vitest": "^3.0.5"
 	},
+	"overrides": {
+		"protobufjs": "7.5.5"
+	},
 	"optionalDependencies": {
 		"@rollup/rollup-linux-arm64-gnu": "^4.40.0",
 		"@rollup/rollup-linux-x64-gnu": "^4.40.0",


### PR DESCRIPTION
### Description

Pins `protobufjs` to version `7.5.5` across all package workspaces to remediate __CVE-2026-41242__.

`protobufjs` is a transitive dependency (pulled in by `@grpc/proto-loader`) and was previously resolving to `7.5.4` in the root and webview workspaces, and `7.5.2` in the standalone runtime. None of these versions are directly declared in any `package.json` — the pin is enforced via npm's `overrides` field.

__CVE-2026-41242__ is a critical arbitrary code execution vulnerability (CVSS 4.0: Critical, AV:N) in `protobufjs` ≤ 7.5.4. Attackers can inject arbitrary JavaScript into the `type` fields of a protobuf definition, which executes during object decoding. The fix is available in `7.5.5`.

While Cline's practical exposure is low (proto definitions are loaded from build-time artifacts and trusted npm packages, not user-supplied input), the vulnerable version was present in the dependency tree and flagged by security scanners. Pinning to the patched version eliminates the finding and adds defense-in-depth.
 
### Test Procedure
Both unit test and webview test passed. 

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)
