### PR TITLE
fix(ollama): strip data URI prefix from images for Ollama API compati…

### DIFF
--- a/src/core/api/transform/ollama-format.ts
+++ b/src/core/api/transform/ollama-format.ts
@@ -37,6 +37,7 @@ export function convertToOllamaMessages(anthropicMessages: Omit<ClineStorageMess
 				const toolResultImages: string[] = []
 				toolMessages.forEach((toolMessage) => {
 					// The Anthropic SDK allows tool results to be a string or an array of text and image blocks, enabling rich and structured content. In contrast, the Ollama SDK only supports tool results as a single string, so we map the Anthropic tool result parts into one concatenated string to maintain compatibility.
+					// Note: Ollama SDK expects raw base64 data without data URI prefix for the `images` field
 					let content: string
 
 					if (typeof toolMessage.content === "string") {
@@ -46,7 +47,11 @@ export function convertToOllamaMessages(anthropicMessages: Omit<ClineStorageMess
 							toolMessage.content
 								?.map((part) => {
 									if (part.type === "image") {
-										toolResultImages.push(`data:${part.source.media_type};base64,${part.source.data}`)
+										// Strip data URI prefix if present (e.g., "data:image/png;base64,")
+										const base64Data = part.source.data
+											.replace(/^data:image\/\w+;base64,/, "")
+											.replace(/^data:[^;]+;base64,/, "")
+										toolResultImages.push(base64Data)
 										return "(see following user message for image)"
 									}
 									return part.text
@@ -61,17 +66,26 @@ export function convertToOllamaMessages(anthropicMessages: Omit<ClineStorageMess
 				})
 
 				// Process non-tool messages
+				const nonToolImages: string[] = []
 				if (nonToolMessages.length > 0) {
+					const nonToolContent: string = nonToolMessages
+						.map((part) => {
+							if (part.type === "image") {
+								// Strip data URI prefix if present (e.g., "data:image/png;base64,")
+								const base64Data = part.source.data
+									.replace(/^data:image\/\w+;base64,/, "")
+									.replace(/^data:[^;]+;base64,/, "")
+								nonToolImages.push(base64Data)
+								return "(see following user message for image)"
+							}
+							return part.text
+						})
+						.join("\n")
+
 					ollamaMessages.push({
 						role: "user",
-						content: nonToolMessages
-							.map((part) => {
-								if (part.type === "image") {
-									return `data:${part.source.media_type};base64,${part.source.data}`
-								}
-								return part.text
-							})
-							.join("\n"),
+						content: nonToolContent,
+						images: nonToolImages.length > 0 ? nonToolImages : undefined,
 					})
 				}
 			} else if (anthropicMessage.role === "assistant") {
@@ -91,7 +105,7 @@ export function convertToOllamaMessages(anthropicMessages: Omit<ClineStorageMess
 				)
 
 				// Process non-tool messages
-				let content: string = ""
+				let content = ""
 				if (nonToolMessages.length > 0) {
 					content = nonToolMessages
 						.map((part) => {

--- a/src/core/api/transform/ollama-format.ts
+++ b/src/core/api/transform/ollama-format.ts
@@ -48,9 +48,7 @@ export function convertToOllamaMessages(anthropicMessages: Omit<ClineStorageMess
 								?.map((part) => {
 									if (part.type === "image") {
 										// Strip data URI prefix if present (e.g., "data:image/png;base64,")
-										const base64Data = part.source.data
-											.replace(/^data:image\/\w+;base64,/, "")
-											.replace(/^data:[^;]+;base64,/, "")
+										const base64Data = part.source.data.replace(/^data:[^;]+;base64,/, "")
 										toolResultImages.push(base64Data)
 										return "(see following user message for image)"
 									}
@@ -72,9 +70,7 @@ export function convertToOllamaMessages(anthropicMessages: Omit<ClineStorageMess
 						.map((part) => {
 							if (part.type === "image") {
 								// Strip data URI prefix if present (e.g., "data:image/png;base64,")
-								const base64Data = part.source.data
-									.replace(/^data:image\/\w+;base64,/, "")
-									.replace(/^data:[^;]+;base64,/, "")
+								const base64Data = part.source.data.replace(/^data:[^;]+;base64,/, "")
 								nonToolImages.push(base64Data)
 								return "(see following user message for image)"
 							}


### PR DESCRIPTION
## 🐛 Problem
When using Ollama with vision-capable models (e.g., `qwen3-vl`, `llava`), the model fails to process uploaded images. The chat proceeds, but the model ignores the image content or returns an error because it receives malformed base64 data.

## 🔍 Root Cause
The Ollama API expects the `images` field in the request payload to contain an array of **raw base64 strings** (without the `data:image/...;base64,` prefix). 
Previously, Cline was passing images with the Data URI prefix included (standard for web/browser usage), which caused Ollama to reject or ignore the image data.

## 🛠️ Solution
This PR updates `src/core/api/transform/ollama-format.ts` to:
1. Extract image data from both regular user messages and tool results.
2. Strip the `data:image/...;base64,` prefix from the base64 string using regex.
3. Pass the clean base64 strings in the dedicated `images` array field for Ollama messages, as required by the Ollama API specification.

## 🧪 How to Test
1. Configure Cline to use an **Ollama** provider.
2. Select a vision-capable model (e.g., `qwen3-vl:8b` or `llava:latest`).
3. Upload an image in the chat interface.
4. Ask the model: "What is in this image?"
5. **Expected Result:** The model correctly describes the image content.
6. **Before Fix:** The model would likely say it cannot see the image or ignore it entirely.

## 📌 Related Issue
Closes #10368