### PR TITLE
Do not show hardcoded new items

### DIFF
--- a/src/test/e2e/auth.test.ts
+++ b/src/test/e2e/auth.test.ts
@@ -55,15 +55,7 @@ e2e("Views - can set up API keys and navigate to Settings from Chat", async ({ s
 		// Kanban modal did not appear during this run.
 	}
 
-	// Verify the "What's New" modal is visible for new installs and can be closed.
-	const dialog = sidebar.getByRole("heading", {
-		name: /^🎉 New in v\d/,
-	})
-	await expect(dialog).toBeVisible({ timeout: 10_000 })
-	await sidebar.getByRole("button", { name: "Close" }).click()
-	await expect(dialog).not.toBeVisible()
-
-	// Verify you are now in the chat page after setup was completed and the dialog was closed.
+	// Verify you are now in the chat page after setup was completed.
 	// cline logo container
 	const clineLogo = sidebar.locator(".size-20")
 	await expect(clineLogo).toBeVisible()

--- a/webview-ui/src/components/chat/chat-view/components/layout/WelcomeSection.tsx
+++ b/webview-ui/src/components/chat/chat-view/components/layout/WelcomeSection.tsx
@@ -75,7 +75,7 @@ export const WelcomeSection: React.FC<WelcomeSectionProps> = ({
 			setShowWhatsNewModal(true)
 			setHasShownWhatsNewModal(true)
 		}
-	}, [welcomeBanners])
+	}, [welcomeBanners, showAnnouncement, hasShownWhatsNewModal])
 
 	const handleCloseWhatsNewModal = useCallback(() => {
 		setShowWhatsNewModal(false)

--- a/webview-ui/src/components/chat/chat-view/components/layout/WelcomeSection.tsx
+++ b/webview-ui/src/components/chat/chat-view/components/layout/WelcomeSection.tsx
@@ -3,7 +3,7 @@ import { EmptyRequest } from "@shared/proto/cline/common"
 import type { Worktree } from "@shared/proto/cline/worktree"
 import { TrackWorktreeViewOpenedRequest } from "@shared/proto/cline/worktree"
 import { GitBranch } from "lucide-react"
-import React, { useCallback, useEffect, useMemo, useRef, useState } from "react"
+import React, { useCallback, useEffect, useMemo, useState } from "react"
 import BannerCarousel from "@/components/common/BannerCarousel"
 import WhatsNewModal from "@/components/common/WhatsNewModal"
 import HistoryPreview from "@/components/history/HistoryPreview"
@@ -37,7 +37,6 @@ export const WelcomeSection: React.FC<WelcomeSectionProps> = ({
 	// Track if we've shown the "What's New" modal this session
 	const [hasShownWhatsNewModal, setHasShownWhatsNewModal] = useState(false)
 	const [showWhatsNewModal, setShowWhatsNewModal] = useState(false)
-	const bannerWaitTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
 	// Quick launch worktree modal
 	const [showCreateWorktreeModal, setShowCreateWorktreeModal] = useState(false)
@@ -70,33 +69,9 @@ export const WelcomeSection: React.FC<WelcomeSectionProps> = ({
 	} = useExtensionState()
 	const { handleFieldsChange } = useApiConfigurationHandlers()
 
-	// Show modal when there's a new announcement and we haven't shown it this session.
-	// We delay opening slightly to wait for welcome banners from the backend API,
-	// which are fetched asynchronously and may not be available on the first state push.
-	// The modal opens immediately if banners arrive, or after a 3s timeout as fallback.
+	// Open modal once we have welcome banners
 	useEffect(() => {
-		if (showAnnouncement && !hasShownWhatsNewModal && !bannerWaitTimeoutRef.current) {
-			bannerWaitTimeoutRef.current = setTimeout(() => {
-				bannerWaitTimeoutRef.current = null
-				setShowWhatsNewModal(true)
-				setHasShownWhatsNewModal(true)
-			}, 3000)
-		}
-		return () => {
-			if (bannerWaitTimeoutRef.current) {
-				clearTimeout(bannerWaitTimeoutRef.current)
-				bannerWaitTimeoutRef.current = null
-			}
-		}
-	}, [showAnnouncement, hasShownWhatsNewModal])
-
-	// Open modal early if welcome banners arrive before the timeout
-	useEffect(() => {
-		if (bannerWaitTimeoutRef.current && welcomeBanners && welcomeBanners.length > 0) {
-			if (bannerWaitTimeoutRef.current) {
-				clearTimeout(bannerWaitTimeoutRef.current)
-				bannerWaitTimeoutRef.current = null
-			}
+		if (showAnnouncement && !hasShownWhatsNewModal && welcomeBanners && welcomeBanners.length > 0) {
 			setShowWhatsNewModal(true)
 			setHasShownWhatsNewModal(true)
 		}

--- a/webview-ui/src/components/common/WhatsNewItems.tsx
+++ b/webview-ui/src/components/common/WhatsNewItems.tsx
@@ -7,31 +7,14 @@ interface WhatsNewItemsProps {
 	onBannerAction?: (action: BannerAction) => void
 	onClose: () => void
 	inlineCodeStyle: React.CSSProperties
-	onNavigateToModelPicker: (initialModelTab: "recommended" | "free", modelId?: string) => void
 }
 
-type InlineModelLinkProps = { pickerTab: "recommended" | "free"; modelId: string; label: string }
-
-export const WhatsNewItems: React.FC<WhatsNewItemsProps> = ({
-	welcomeBanners,
-	onBannerAction,
-	onClose,
-	inlineCodeStyle,
-	onNavigateToModelPicker,
-}) => {
-	const InlineModelLink: React.FC<InlineModelLinkProps> = ({ pickerTab, modelId, label }) => (
-		<span
-			onClick={() => onNavigateToModelPicker(pickerTab, modelId)}
-			style={{ color: "var(--vscode-textLink-foreground)", cursor: "pointer" }}>
-			{label}
-		</span>
-	)
-
+export const WhatsNewItems: React.FC<WhatsNewItemsProps> = ({ welcomeBanners, onBannerAction, onClose, inlineCodeStyle }) => {
 	const hasWelcomeBanners = welcomeBanners && welcomeBanners.length > 0
 
 	return (
 		<ul className="text-sm pl-3 list-disc" style={{ color: "var(--vscode-descriptionForeground)" }}>
-			{hasWelcomeBanners ? (
+			{hasWelcomeBanners &&
 				welcomeBanners.map((banner) => (
 					<li className="mb-2" key={banner.id}>
 						{banner.title && <strong>{banner.title}</strong>}{" "}
@@ -74,27 +57,7 @@ export const WhatsNewItems: React.FC<WhatsNewItemsProps> = ({
 							</span>
 						)}
 					</li>
-				))
-			) : (
-				<>
-					{/* Hardcoded fallback items shown when remote welcome banners feature flag is off */}
-					<li className="mb-2">
-						<strong>Try Codex 5.3:</strong> OpenAI's latest coding model, now available in Cline!{" "}
-						<InlineModelLink label="Try now" modelId="openai/gpt-5.3-codex" pickerTab="recommended" />
-					</li>
-					<li className="mb-2">
-						<strong>Try latest SOTA coding model:</strong> Claude Sonnet 4.6 and Gemini 3.1 pro within Cline!{" "}
-						<InlineModelLink label="Try now" modelId="anthropic/claude-sonnet-4.6" pickerTab="recommended" />
-					</li>
-					<li className="mb-2">
-						<strong>Try Cline CLI 2.0:</strong> with /mcp functionality added in CLI{" "}
-						<code style={inlineCodeStyle}>npm install -g cline</code>
-					</li>
-					<li className="mb-2">
-						<strong>Minimax M2.5 and Z.ai GLM 5:</strong> no longer free starting Feb 23, 2026
-					</li>
-				</>
-			)}
+				))}
 		</ul>
 	)
 }

--- a/webview-ui/src/components/common/WhatsNewModal.tsx
+++ b/webview-ui/src/components/common/WhatsNewModal.tsx
@@ -1,5 +1,5 @@
 import { BannerAction, BannerCardData } from "@shared/cline/banner"
-import React, { useCallback } from "react"
+import React from "react"
 import { useMount } from "react-use"
 import DiscordIcon from "@/assets/DiscordIcon"
 import GitHubIcon from "@/assets/GitHubIcon"
@@ -9,7 +9,6 @@ import XIcon from "@/assets/XIcon"
 import WhatsNewItems from "@/components/common/WhatsNewItems"
 import { Dialog, DialogContent } from "@/components/ui/dialog"
 import { useExtensionState } from "@/context/ExtensionStateContext"
-import { useApiConfigurationHandlers } from "../settings/utils/useApiConfigurationHandlers"
 
 interface WhatsNewModalProps {
 	open: boolean
@@ -20,32 +19,10 @@ interface WhatsNewModalProps {
 }
 
 export const WhatsNewModal: React.FC<WhatsNewModalProps> = ({ open, onClose, version, welcomeBanners, onBannerAction }) => {
-	const { openRouterModels, refreshOpenRouterModels, navigateToSettingsModelPicker } = useExtensionState()
-	const { handleFieldsChange } = useApiConfigurationHandlers()
+	const { refreshOpenRouterModels } = useExtensionState()
 
 	// Get latest model list in case user hits shortcut button to set model
 	useMount(refreshOpenRouterModels)
-
-	const navigateToModelPicker = useCallback(
-		(initialModelTab: "recommended" | "free", modelId?: string) => {
-			// Switch to Cline provider first so the model picker tab works
-			// Optionally also set the model if provided
-			const updates: Record<string, any> = {
-				planModeApiProvider: "cline",
-				actModeApiProvider: "cline",
-			}
-			if (modelId) {
-				updates.planModeOpenRouterModelId = modelId
-				updates.actModeOpenRouterModelId = modelId
-				updates.planModeOpenRouterModelInfo = openRouterModels[modelId]
-				updates.actModeOpenRouterModelInfo = openRouterModels[modelId]
-			}
-			handleFieldsChange(updates)
-			onClose()
-			navigateToSettingsModelPicker({ targetSection: "api-config", initialModelTab })
-		},
-		[handleFieldsChange, navigateToSettingsModelPicker, onClose, openRouterModels],
-	)
 
 	const inlineCodeStyle: React.CSSProperties = {
 		backgroundColor: "var(--vscode-textCodeBlock-background)",
@@ -73,7 +50,6 @@ export const WhatsNewModal: React.FC<WhatsNewModalProps> = ({ open, onClose, ver
 						inlineCodeStyle={inlineCodeStyle}
 						onBannerAction={onBannerAction}
 						onClose={onClose}
-						onNavigateToModelPicker={navigateToModelPicker}
 						welcomeBanners={welcomeBanners}
 					/>
 


### PR DESCRIPTION
### Description

The hardcoded new items are old. Now that the banners have been working for a while, we can get rid of them and the logic to show them.

### Test Procedure

Tested locally

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)