### PR TITLE
fix: prevent path traversal in ClineIgnoreController.validateAccess

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5596,7 +5596,8 @@
 			"optional": true,
 			"os": [
 				"android"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-android-arm64": {
 			"version": "4.60.0",
@@ -5609,7 +5610,8 @@
 			"optional": true,
 			"os": [
 				"android"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-darwin-arm64": {
 			"version": "4.60.0",
@@ -5622,7 +5624,8 @@
 			"optional": true,
 			"os": [
 				"darwin"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-darwin-x64": {
 			"version": "4.60.0",
@@ -5635,7 +5638,8 @@
 			"optional": true,
 			"os": [
 				"darwin"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-freebsd-arm64": {
 			"version": "4.60.0",
@@ -5648,7 +5652,8 @@
 			"optional": true,
 			"os": [
 				"freebsd"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-freebsd-x64": {
 			"version": "4.60.0",
@@ -5661,7 +5666,8 @@
 			"optional": true,
 			"os": [
 				"freebsd"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-linux-arm-gnueabihf": {
 			"version": "4.60.0",
@@ -5674,7 +5680,8 @@
 			"optional": true,
 			"os": [
 				"linux"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-linux-arm-musleabihf": {
 			"version": "4.60.0",
@@ -5687,7 +5694,8 @@
 			"optional": true,
 			"os": [
 				"linux"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-linux-arm64-gnu": {
 			"version": "4.60.0",
@@ -5700,7 +5708,8 @@
 			"optional": true,
 			"os": [
 				"linux"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-linux-arm64-musl": {
 			"version": "4.60.0",
@@ -5713,7 +5722,8 @@
 			"optional": true,
 			"os": [
 				"linux"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-linux-loong64-gnu": {
 			"version": "4.60.0",
@@ -5726,7 +5736,8 @@
 			"optional": true,
 			"os": [
 				"linux"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-linux-loong64-musl": {
 			"version": "4.60.0",
@@ -5739,7 +5750,8 @@
 			"optional": true,
 			"os": [
 				"linux"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-linux-ppc64-gnu": {
 			"version": "4.60.0",
@@ -5752,7 +5764,8 @@
 			"optional": true,
 			"os": [
 				"linux"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-linux-ppc64-musl": {
 			"version": "4.60.0",
@@ -5765,7 +5778,8 @@
 			"optional": true,
 			"os": [
 				"linux"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-linux-riscv64-gnu": {
 			"version": "4.60.0",
@@ -5778,7 +5792,8 @@
 			"optional": true,
 			"os": [
 				"linux"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-linux-riscv64-musl": {
 			"version": "4.60.0",
@@ -5791,7 +5806,8 @@
 			"optional": true,
 			"os": [
 				"linux"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-linux-s390x-gnu": {
 			"version": "4.60.0",
@@ -5804,7 +5820,8 @@
 			"optional": true,
 			"os": [
 				"linux"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-linux-x64-gnu": {
 			"version": "4.60.0",
@@ -5817,7 +5834,8 @@
 			"optional": true,
 			"os": [
 				"linux"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-linux-x64-musl": {
 			"version": "4.60.0",
@@ -5830,7 +5848,8 @@
 			"optional": true,
 			"os": [
 				"linux"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-openbsd-x64": {
 			"version": "4.60.0",
@@ -5843,7 +5862,8 @@
 			"optional": true,
 			"os": [
 				"openbsd"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-openharmony-arm64": {
 			"version": "4.60.0",
@@ -5856,7 +5876,8 @@
 			"optional": true,
 			"os": [
 				"openharmony"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-win32-arm64-msvc": {
 			"version": "4.60.0",
@@ -5869,7 +5890,8 @@
 			"optional": true,
 			"os": [
 				"win32"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-win32-ia32-msvc": {
 			"version": "4.60.0",
@@ -5882,7 +5904,8 @@
 			"optional": true,
 			"os": [
 				"win32"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-win32-x64-gnu": {
 			"version": "4.60.0",
@@ -5895,7 +5918,8 @@
 			"optional": true,
 			"os": [
 				"win32"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-win32-x64-msvc": {
 			"version": "4.60.0",
@@ -5908,7 +5932,8 @@
 			"optional": true,
 			"os": [
 				"win32"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@sap-ai-sdk/ai-api": {
 			"version": "2.7.0",
@@ -22206,6 +22231,7 @@
 			"os": [
 				"aix"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -22222,6 +22248,7 @@
 			"os": [
 				"android"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -22238,6 +22265,7 @@
 			"os": [
 				"android"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -22254,6 +22282,7 @@
 			"os": [
 				"android"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -22270,6 +22299,7 @@
 			"os": [
 				"darwin"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -22286,6 +22316,7 @@
 			"os": [
 				"darwin"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -22302,6 +22333,7 @@
 			"os": [
 				"freebsd"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -22318,6 +22350,7 @@
 			"os": [
 				"freebsd"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -22334,6 +22367,7 @@
 			"os": [
 				"linux"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -22350,6 +22384,7 @@
 			"os": [
 				"linux"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -22366,6 +22401,7 @@
 			"os": [
 				"linux"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -22382,6 +22418,7 @@
 			"os": [
 				"linux"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -22398,6 +22435,7 @@
 			"os": [
 				"linux"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -22414,6 +22452,7 @@
 			"os": [
 				"linux"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -22430,6 +22469,7 @@
 			"os": [
 				"linux"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -22446,6 +22486,7 @@
 			"os": [
 				"linux"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -22462,6 +22503,7 @@
 			"os": [
 				"linux"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -22478,6 +22520,7 @@
 			"os": [
 				"netbsd"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -22494,6 +22537,7 @@
 			"os": [
 				"netbsd"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -22510,6 +22554,7 @@
 			"os": [
 				"openbsd"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -22526,6 +22571,7 @@
 			"os": [
 				"openbsd"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -22542,6 +22588,7 @@
 			"os": [
 				"openharmony"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -22558,6 +22605,7 @@
 			"os": [
 				"sunos"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -22574,6 +22622,7 @@
 			"os": [
 				"win32"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -22590,6 +22639,7 @@
 			"os": [
 				"win32"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -22606,6 +22656,7 @@
 			"os": [
 				"win32"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -22661,6 +22712,7 @@
 			"os": [
 				"darwin"
 			],
+			"peer": true,
 			"engines": {
 				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
 			}

--- a/src/core/ignore/ClineIgnoreController.test.ts
+++ b/src/core/ignore/ClineIgnoreController.test.ts
@@ -290,4 +290,35 @@ describe("ClineIgnoreController", () => {
 			controller.validateAccess("file.log").should.be.true()
 		})
 	})
+
+	describe("Path Traversal Protection", () => {
+		it("should block paths that escape the workspace via ..", async () => {
+			controller.validateAccess("../../etc/passwd").should.be.false()
+			controller.validateAccess("../../../home/user/.bashrc").should.be.false()
+			controller.validateAccess("../outside-workspace/file.txt").should.be.false()
+		})
+
+		it("should block absolute paths outside workspace", async () => {
+			controller.validateAccess("/etc/passwd").should.be.false()
+			controller.validateAccess("/home/user/.ssh/id_rsa").should.be.false()
+		})
+
+		it("should still allow paths within workspace", async () => {
+			controller.validateAccess("src/index.ts").should.be.true()
+			controller.validateAccess("README.md").should.be.true()
+		})
+
+		it("should block traversal when .clineignore does not exist", async () => {
+			const emptyDir = path.join(os.tmpdir(), `llm-test-no-ignore-${Date.now()}`)
+			await fs.mkdir(emptyDir)
+			try {
+				const noIgnoreController = new ClineIgnoreController(emptyDir)
+				await noIgnoreController.initialize()
+				noIgnoreController.validateAccess("../../etc/passwd").should.be.false()
+				noIgnoreController.validateAccess("src/index.ts").should.be.true()
+			} finally {
+				await fs.rm(emptyDir, { recursive: true, force: true })
+			}
+		})
+	})
 })

--- a/src/core/ignore/ClineIgnoreController.test.ts
+++ b/src/core/ignore/ClineIgnoreController.test.ts
@@ -291,6 +291,42 @@ describe("ClineIgnoreController", () => {
 		})
 	})
 
+	describe("Include Directive Path Traversal Protection", () => {
+		it("should block !include directives that escape workspace via ..", async () => {
+			await fs.writeFile(path.join(tempDir, ".clineignore"), ["!include ../../etc/passwd", "*.log"].join("\n"))
+
+			controller = new ClineIgnoreController(tempDir)
+			await controller.initialize()
+
+			// Only *.log pattern should be active (traversal include blocked)
+			controller.validateAccess("server.log").should.be.false()
+			controller.validateAccess("regular-file.txt").should.be.true()
+		})
+
+		it("should block !include with absolute paths", async () => {
+			await fs.writeFile(path.join(tempDir, ".clineignore"), ["!include /etc/shadow", "*.tmp"].join("\n"))
+
+			controller = new ClineIgnoreController(tempDir)
+			await controller.initialize()
+
+			controller.validateAccess("file.tmp").should.be.false()
+			controller.validateAccess("regular.txt").should.be.true()
+		})
+
+		it("should allow !include with paths within workspace", async () => {
+			await fs.writeFile(path.join(tempDir, "extra-ignore.txt"), ["*.log", "debug/"].join("\n"))
+			await fs.writeFile(path.join(tempDir, ".clineignore"), ["!include extra-ignore.txt", "secret.txt"].join("\n"))
+
+			controller = new ClineIgnoreController(tempDir)
+			await controller.initialize()
+
+			controller.validateAccess("server.log").should.be.false()
+			controller.validateAccess("debug/app.js").should.be.false()
+			controller.validateAccess("secret.txt").should.be.false()
+			controller.validateAccess("app.js").should.be.true()
+		})
+	})
+
 	describe("Path Traversal Protection", () => {
 		it("should block paths that escape the workspace via ..", async () => {
 			controller.validateAccess("../../etc/passwd").should.be.false()

--- a/src/core/ignore/ClineIgnoreController.ts
+++ b/src/core/ignore/ClineIgnoreController.ts
@@ -153,21 +153,26 @@ export class ClineIgnoreController {
 	 * @returns true if file is accessible, false if ignored
 	 */
 	validateAccess(filePath: string): boolean {
-		// Always allow access if .clineignore does not exist
-		if (!this.clineIgnoreContent) {
-			return true
-		}
 		try {
 			// Normalize path to be relative to cwd and use forward slashes
 			const absolutePath = path.resolve(this.cwd, filePath)
-			const relativePath = path.relative(this.cwd, absolutePath).toPosix()
+			const relativePath = path.relative(this.cwd, absolutePath)
+
+			// Block paths that resolve outside the workspace (path traversal)
+			if (relativePath.startsWith("..") || path.isAbsolute(relativePath)) {
+				return false
+			}
+
+			// Always allow access if .clineignore does not exist
+			if (!this.clineIgnoreContent) {
+				return true
+			}
 
 			// Ignore expects paths to be path.relative()'d
-			return !this.ignoreInstance.ignores(relativePath)
+			return !this.ignoreInstance.ignores(relativePath.toPosix())
 		} catch (_error) {
-			// Logger.error(`Error validating access for ${filePath}:`, error)
-			// Ignore is designed to work with relative file paths, so will throw error for paths outside cwd. We are allowing access to all files outside cwd.
-			return true
+			// Deny by default on errors (e.g., invalid paths)
+			return false
 		}
 	}
 

--- a/src/core/ignore/ClineIgnoreController.ts
+++ b/src/core/ignore/ClineIgnoreController.ts
@@ -137,7 +137,14 @@ export class ClineIgnoreController {
 	 */
 	private async readIncludedFile(includeLine: string): Promise<string | null> {
 		const includePath = includeLine.substring("!include ".length).trim()
-		const resolvedIncludePath = path.join(this.cwd, includePath)
+		const resolvedIncludePath = path.resolve(this.cwd, includePath)
+
+		// Block paths that resolve outside the workspace (path traversal)
+		const relativePath = path.relative(this.cwd, resolvedIncludePath)
+		if (relativePath.startsWith("..") || path.isAbsolute(relativePath)) {
+			Logger.debug(`[ClineIgnore] Included file path escapes workspace: ${includePath}`)
+			return null
+		}
 
 		if (!(await fileExistsAtPath(resolvedIncludePath))) {
 			Logger.debug(`[ClineIgnore] Included file not found: ${resolvedIncludePath}`)


### PR DESCRIPTION
## Summary

The `ClineIgnoreController.validateAccess()` method allowed access to **all paths outside the workspace** by default, enabling path traversal attacks via `../` sequences or absolute paths.

This was exploitable through `write_to_file`, `read_file`, and `apply_patch` tools when the AI agent was instructed (via `.clinerules`, MCP responses, or prompt injection) to access files like `../../etc/passwd` or `~/.ssh/authorized_keys`.

## Root Cause

Two issues in `validateAccess()`:

1. **Error handler allowed external paths**: When `path.relative()` failed or returned a `..`-prefixed path, the `catch` block returned `true` (allow access) with the explicit comment: _"We are allowing access to all files outside cwd."_

2. **No boundary check without .clineignore**: When no `.clineignore` file existed (the default for most projects), **all paths were allowed** — including traversal paths like `../../etc/shadow`.

## Fix

Added workspace boundary enforcement **before** the `.clineignore` check:

```typescript
const relativePath = path.relative(this.cwd, absolutePath)

// Block paths that resolve outside the workspace (path traversal)
if (relativePath.startsWith("..") || path.isAbsolute(relativePath)) {
    return false
}
```

Also changed the error handler to **deny by default** instead of allowing access.

## Testing

- Added 4 new test cases covering traversal with and without `.clineignore`
- Verified logic with standalone test: all 11 cases pass
- Existing tests unaffected (null-byte edge case still works — it resolves in-workspace)

## Impact

- **Low risk**: Only affects paths that escape the workspace — legitimate in-workspace paths are unaffected
- **No breaking changes for normal usage**: Files within the project directory continue to work identically
- **Fixes YOLO mode exploit chain**: In auto-approve/YOLO modes, this was a complete filesystem read/write primitive