### PR TITLE
fix: expose Plan/Act mode as an accessible radio group

### DIFF
--- a/webview-ui/src/components/chat/ChatTextArea.tsx
+++ b/webview-ui/src/components/chat/ChatTextArea.tsx
@@ -990,28 +990,64 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 			[updateCursorPosition],
 		)
 
-		const onModeToggle = useCallback(() => {
-			void (async () => {
-				const convertedProtoMode = mode === "plan" ? PlanActMode.ACT : PlanActMode.PLAN
-				const response = await StateServiceClient.togglePlanActModeProto(
-					TogglePlanActModeRequest.create({
-						mode: convertedProtoMode,
-						chatContent: {
-							message: inputValue.trim() ? inputValue : undefined,
-							images: selectedImages,
-							files: selectedFiles,
-						},
-					}),
-				)
-				// Focus the textarea after mode toggle with slight delay
-				setTimeout(() => {
-					if (response.value) {
-						setInputValue("")
-					}
+		const onModeSelect = useCallback(
+			(targetMode: Mode) => {
+				if (mode === targetMode) {
 					textAreaRef.current?.focus()
-				}, 100)
-			})()
-		}, [mode, inputValue, selectedImages, selectedFiles, setInputValue])
+					return
+				}
+
+				void (async () => {
+					const convertedProtoMode = targetMode === "plan" ? PlanActMode.PLAN : PlanActMode.ACT
+					const response = await StateServiceClient.togglePlanActModeProto(
+						TogglePlanActModeRequest.create({
+							mode: convertedProtoMode,
+							chatContent: {
+								message: inputValue.trim() ? inputValue : undefined,
+								images: selectedImages,
+								files: selectedFiles,
+							},
+						}),
+					)
+					// Focus the textarea after mode toggle with slight delay
+					setTimeout(() => {
+						if (response.value) {
+							setInputValue("")
+						}
+						textAreaRef.current?.focus()
+					}, 100)
+				})()
+			},
+			[mode, inputValue, selectedImages, selectedFiles, setInputValue],
+		)
+
+		const onModeToggle = useCallback(() => {
+			const nextMode = mode === "plan" ? "act" : "plan"
+			onModeSelect(nextMode)
+		}, [mode, onModeSelect])
+
+		const handleModeOptionKeyDown = useCallback(
+			(event: React.KeyboardEvent<HTMLButtonElement>, targetMode: Mode) => {
+				switch (event.key) {
+					case " ":
+					case "Enter":
+						event.preventDefault()
+						onModeSelect(targetMode)
+						break
+					case "ArrowLeft":
+					case "ArrowUp":
+						event.preventDefault()
+						onModeSelect("plan")
+						break
+					case "ArrowRight":
+					case "ArrowDown":
+						event.preventDefault()
+						onModeSelect("act")
+						break
+				}
+			},
+			[onModeSelect],
+		)
 
 		useShortcut(usePlatform().togglePlanActKeys, onModeToggle, { disableTextInputs: false }) // important that we don't disable the text input here
 
@@ -1595,20 +1631,31 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 							</p>
 						</TooltipContent>
 						<TooltipTrigger>
-							<SwitchContainer data-testid="mode-switch" disabled={false} onClick={onModeToggle}>
+							<SwitchContainer
+								aria-label="Plan or Act mode"
+								data-testid="mode-switch"
+								disabled={false}
+								role="radiogroup">
 								<Slider isAct={mode === "act"} isPlan={mode === "plan"} />
 								{["Plan", "Act"].map((m) => (
-									<div
+									<button
 										aria-checked={mode === m.toLowerCase()}
 										className={cn(
-											"pt-0.5 pb-px px-2 z-10 text-xs w-1/2 text-center bg-transparent",
+											"pt-0.5 pb-px px-2 z-10 text-xs w-1/2 text-center bg-transparent border-0",
 											mode === m.toLowerCase() ? "text-white" : "text-input-foreground",
 										)}
+										key={m}
+										onBlur={() => setShownTooltipMode(null)}
+										onClick={() => onModeSelect(m.toLowerCase() as Mode)}
+										onFocus={() => setShownTooltipMode(m.toLowerCase() as Mode)}
+										onKeyDown={(event) => handleModeOptionKeyDown(event, m.toLowerCase() as Mode)}
 										onMouseLeave={() => setShownTooltipMode(null)}
 										onMouseOver={() => setShownTooltipMode(m.toLowerCase() === "plan" ? "plan" : "act")}
-										role="switch">
+										role="radio"
+										tabIndex={mode === m.toLowerCase() ? 0 : -1}
+										type="button">
 										{m}
-									</div>
+									</button>
 								))}
 							</SwitchContainer>
 						</TooltipTrigger>

--- a/webview-ui/src/components/chat/__tests__/ChatTextArea.spec.tsx
+++ b/webview-ui/src/components/chat/__tests__/ChatTextArea.spec.tsx
@@ -1,0 +1,121 @@
+import { fireEvent, render, screen } from "@testing-library/react"
+import type React from "react"
+import { describe, expect, it, vi } from "vitest"
+
+const mockTogglePlanActModeProto = vi.fn().mockResolvedValue({ value: false })
+
+vi.mock("@vscode/webview-ui-toolkit/react", () => ({
+	VSCodeButton: (props: React.ComponentProps<"button">) => <button {...props} />,
+}))
+
+vi.mock("@/context/ExtensionStateContext", () => ({
+	useExtensionState: () => ({
+		mode: "plan",
+		apiConfiguration: undefined,
+		openRouterModels: {},
+		platform: "macos",
+		localWorkflowToggles: [],
+		globalWorkflowToggles: [],
+		remoteWorkflowToggles: [],
+		remoteConfigSettings: undefined,
+		navigateToSettingsModelPicker: vi.fn(),
+		mcpServers: [],
+	}),
+}))
+
+vi.mock("@/context/PlatformContext", () => ({
+	usePlatform: () => ({
+		togglePlanActKeys: "Tab",
+	}),
+}))
+
+vi.mock("@/services/grpc-client", () => ({
+	FileServiceClient: {
+		searchCommits: vi.fn().mockResolvedValue({ commits: [] }),
+		searchFiles: vi.fn().mockResolvedValue({ files: [] }),
+		getRelativePaths: vi.fn().mockResolvedValue({ paths: [] }),
+	},
+	StateServiceClient: {
+		togglePlanActModeProto: (...args: unknown[]) => mockTogglePlanActModeProto(...args),
+	},
+}))
+
+vi.mock("@/utils/hooks", () => ({
+	useMetaKeyDetection: () => [false, "Cmd"],
+	useShortcut: vi.fn(),
+}))
+
+vi.mock("@/components/ui/tooltip", () => ({
+	Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+	TooltipContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+	TooltipTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}))
+
+vi.mock("../ContextMenu", () => ({
+	default: () => null,
+}))
+
+vi.mock("../SlashCommandMenu", () => ({
+	default: () => null,
+}))
+
+vi.mock("@/components/common/Thumbnails", () => ({
+	default: () => null,
+}))
+
+vi.mock("../ServersToggleModal", () => ({
+	default: () => null,
+}))
+
+vi.mock("../../cline-rules/ClineRulesToggleModal", () => ({
+	default: () => null,
+}))
+
+import ChatTextArea from "../ChatTextArea"
+
+describe("ChatTextArea mode switch", () => {
+	it("renders the plan/act picker as an accessible radio group", () => {
+		render(
+			<ChatTextArea
+				inputValue=""
+				onSelectFilesAndImages={vi.fn()}
+				onSend={vi.fn()}
+				placeholderText="Ask Cline"
+				selectedFiles={[]}
+				selectedImages={[]}
+				sendingDisabled={false}
+				setInputValue={vi.fn()}
+				setSelectedFiles={vi.fn()}
+				setSelectedImages={vi.fn()}
+				shouldDisableFilesAndImages={false}
+			/>,
+		)
+
+		expect(screen.getByRole("radiogroup", { name: "Plan or Act mode" })).toBeTruthy()
+		expect(screen.getByRole("radio", { name: "Plan" }).getAttribute("aria-checked")).toBe("true")
+		expect(screen.getByRole("radio", { name: "Act" }).getAttribute("aria-checked")).toBe("false")
+	})
+
+	it("selects act mode when the act radio is clicked", () => {
+		render(
+			<ChatTextArea
+				inputValue=""
+				onSelectFilesAndImages={vi.fn()}
+				onSend={vi.fn()}
+				placeholderText="Ask Cline"
+				selectedFiles={[]}
+				selectedImages={[]}
+				sendingDisabled={false}
+				setInputValue={vi.fn()}
+				setSelectedFiles={vi.fn()}
+				setSelectedImages={vi.fn()}
+				shouldDisableFilesAndImages={false}
+			/>,
+		)
+
+		fireEvent.click(screen.getByRole("radio", { name: "Act" }))
+
+		expect(mockTogglePlanActModeProto).toHaveBeenCalledTimes(1)
+		expect(mockTogglePlanActModeProto.mock.calls[0][0].mode).toBe(1)
+	})
+})


### PR DESCRIPTION
## Summary

Fixes #4932.

This updates the Plan/Act mode picker in the chat composer so assistive technologies see it as a proper radio group instead of generic clickable controls.

## What changed

- refactored the mode-switch handler to support selecting an explicit target mode
- rendered Plan and Act as `role="radio"` options inside a `radiogroup`
- added keyboard support for Enter/Space and arrow-key selection
- added a focused webview test covering accessibility roles and selecting Act mode

## Validation

- `cd webview-ui && npm test -- ChatTextArea.spec.tsx`
- `cd webview-ui && npx tsc --noEmit`
- `npx biome check webview-ui/src/components/chat/ChatTextArea.tsx webview-ui/src/components/chat/__tests__/ChatTextArea.spec.tsx --diagnostic-level=error`

## Notes

I only ran targeted validation for the affected webview surface. The repo's full proto generation flow currently requires Rosetta on Apple Silicon, so I avoided claiming a full-project build/test pass that I did not run.
