### PR TITLE
fix(hooks): Use shell escapes on JSON literals in hooks templates

### DIFF
--- a/docs/customization/hooks.mdx
+++ b/docs/customization/hooks.mdx
@@ -129,7 +129,7 @@ Create a file called `file-logger` in your hooks directory with this content:
 # Logs all file operations to ~/cline-activity.log
 
 INPUT=$(cat)
-TOOL=$(echo "$INPUT" | jq -r '.preToolUse.tool')
+TOOL=$(echo "$INPUT" | jq -r '.preToolUse.toolName')
 FILE_PATH=$(echo "$INPUT" | jq -r '.preToolUse.parameters.path // "N/A"')
 
 # Log to file
@@ -221,7 +221,11 @@ Every hook receives a JSON object with common fields plus hook-specific data:
   
   // Hook-specific field (name matches hook type in camelCase)
   "taskStart": {
-    "task": "Add authentication to the API"
+    "taskMetadata": {
+      "taskId": "abc123",
+      "ulid": "01J...",
+      "initialTask": "Add authentication to the API"
+    }
   }
 }
 ```
@@ -238,11 +242,11 @@ If your scripts previously read `.workspacePath`, switch to `.workspaceRoots[0]`
 </Note>
 
 The hook-specific field name matches the hook type:
-- `taskStart`, `taskResume`, `taskCancel`, `taskComplete` contain `{ task: string }`
-- `preToolUse` contains `{ tool: string, parameters: object }`
-- `postToolUse` contains `{ tool: string, parameters: object, result: string, success: boolean, durationMs: number }`
-- `userPromptSubmit` contains `{ prompt: string }`
-- `preCompact` contains `{ conversationLength: number, estimatedTokens: number }`
+- `taskStart`, `taskResume`, `taskCancel`, `taskComplete` contain `{ taskMetadata: { taskId, ulid, ... } }`
+- `preToolUse` contains `{ toolName: string, parameters: object }`
+- `postToolUse` contains `{ toolName: string, parameters: object, result: string, success: boolean, executionTimeMs: number }`
+- `userPromptSubmit` contains `{ prompt: string, attachments: string[] }`
+- `preCompact` contains `{ taskId, ulid, contextSize, compactionStrategy, tokensIn, tokensOut, ... }`
 
 ### Output Structure
 
@@ -287,7 +291,7 @@ Runs when you start a new task. Use it to:
 ```bash
 #!/bin/bash
 INPUT=$(cat)
-TASK=$(echo "$INPUT" | jq -r '.taskStart.task')
+TASK=$(echo "$INPUT" | jq -r '.taskStart.taskMetadata.initialTask')
 echo "[TaskStart] Starting: $TASK" >&2
 echo '{"cancel":false,"contextModification":"","errorMessage":""}'
 ```
@@ -329,7 +333,7 @@ The input includes the tool name and its parameters:
 ```json
 {
   "preToolUse": {
-    "tool": "write_to_file",
+    "toolName": "write_to_file",
     "parameters": {
       "path": "src/config.ts",
       "content": "..."
@@ -343,7 +347,7 @@ Example that blocks `.js` files in a TypeScript project:
 ```bash
 #!/bin/bash
 INPUT=$(cat)
-TOOL=$(echo "$INPUT" | jq -r '.preToolUse.tool')
+TOOL=$(echo "$INPUT" | jq -r '.preToolUse.toolName')
 FILE_PATH=$(echo "$INPUT" | jq -r '.preToolUse.parameters.path // empty')
 
 if [[ "$TOOL" == "write_to_file" && "$FILE_PATH" == *.js ]]; then
@@ -367,11 +371,11 @@ The input includes execution results:
 ```json
 {
   "postToolUse": {
-    "tool": "execute_command",
+    "toolName": "execute_command",
     "parameters": { "command": "npm test" },
     "result": "All tests passed",
     "success": true,
-    "durationMs": 3450
+    "executionTimeMs": 3450
   }
 }
 ```
@@ -401,8 +405,14 @@ The input includes context metrics:
 ```json
 {
   "preCompact": {
-    "conversationLength": 45,
-    "estimatedTokens": 125000
+    "taskId": "abc123",
+    "ulid": "01J...",
+    "contextSize": 45,
+    "compactionStrategy": "auto-condense",
+    "tokensIn": 125000,
+    "tokensOut": 8500,
+    "tokensInCache": 0,
+    "tokensOutCache": 0
   }
 }
 ```
@@ -418,7 +428,7 @@ Block creation of `.js` files in a TypeScript project:
 # PreToolUse hook
 
 INPUT=$(cat)
-TOOL=$(echo "$INPUT" | jq -r '.preToolUse.tool')
+TOOL=$(echo "$INPUT" | jq -r '.preToolUse.toolName')
 FILE_PATH=$(echo "$INPUT" | jq -r '.preToolUse.parameters.path // empty')
 
 if [[ "$TOOL" == "write_to_file" && "$FILE_PATH" == *.js ]]; then
@@ -438,9 +448,9 @@ Log all tool executions to a file:
 # PostToolUse hook
 
 INPUT=$(cat)
-TOOL=$(echo "$INPUT" | jq -r '.postToolUse.tool')
+TOOL=$(echo "$INPUT" | jq -r '.postToolUse.toolName')
 SUCCESS=$(echo "$INPUT" | jq -r '.postToolUse.success')
-DURATION=$(echo "$INPUT" | jq -r '.postToolUse.durationMs')
+DURATION=$(echo "$INPUT" | jq -r '.postToolUse.executionTimeMs')
 
 echo "$(date -Iseconds) | $TOOL | success=$SUCCESS | ${DURATION}ms" >> ~/.cline-tool-log.txt
 

--- a/src/core/hooks/__tests__/taskresume.test.ts
+++ b/src/core/hooks/__tests__/taskresume.test.ts
@@ -553,9 +553,9 @@ console.log(JSON.stringify({
 
 	describe("Fixture-Based Tests", () => {
 		it("should validate representative fixtures end-to-end", async function () {
-			if (process.platform === "win32") {
-				this.timeout(WINDOWS_HOOK_TEST_TIMEOUT_MS)
-			}
+			// Multiple fixture scenarios spawn child processes sequentially,
+			// which can easily exceed the default 2 s Mocha timeout.
+			this.timeout(WINDOWS_HOOK_TEST_TIMEOUT_MS)
 
 			const scenarios: FixtureScenario[] = [
 				{

--- a/src/core/hooks/__tests__/user-prompt-submit.test.ts
+++ b/src/core/hooks/__tests__/user-prompt-submit.test.ts
@@ -371,9 +371,9 @@ console.log(JSON.stringify({
 		const isWindows = process.platform === "win32"
 
 		it("should validate representative fixtures end-to-end", async function () {
-			if (isWindows) {
-				this.timeout(WINDOWS_HOOK_TEST_TIMEOUT_MS)
-			}
+			// Multiple fixture scenarios spawn child processes sequentially,
+			// which can easily exceed the default 2 s Mocha timeout.
+			this.timeout(WINDOWS_HOOK_TEST_TIMEOUT_MS)
 
 			const scenarios: FixtureScenario[] = [
 				{

--- a/src/core/hooks/templates.ts
+++ b/src/core/hooks/templates.ts
@@ -52,7 +52,13 @@ function getTaskStartTemplate(): string {
 # 
 # Executes when a new task begins.
 # 
-# Input: { taskId, taskStart: { task: string }, clineVersion, timestamp, ... }
+# Input: { 
+#   taskId, 
+#   taskStart: { 
+#     taskMetadata: { taskId: string, ulid: string, initialTask: string } 
+#   }, 
+#   clineVersion, timestamp, ... 
+# }
 # Output: { cancel: boolean, contextModification?: string, errorMessage?: string }
 # 
 # Use cases:
@@ -66,7 +72,7 @@ INPUT=$(cat)
 
 # Parse input using jq (or fallback to basic parsing)
 if command -v jq &> /dev/null; then
-  TASK=$(echo "$INPUT" | jq -r '.taskStart.task')
+  TASK=$(echo "$INPUT" | jq -r '.taskStart.taskMetadata.initialTask')
   TASK_ID=$(echo "$INPUT" | jq -r '.taskId')
   TIMESTAMP=$(echo "$INPUT" | jq -r '.timestamp')
 else
@@ -101,7 +107,14 @@ function getTaskResumeTemplate(): string {
 # 
 # Executes when a task is resumed after being interrupted.
 # 
-# Input: { taskId, taskResume: { task: string }, clineVersion, timestamp, ... }
+# Input: { 
+#   taskId, 
+#   taskResume: { 
+#     taskMetadata: { taskId: string, ulid: string },
+#     previousState: { lastMessageTs: string, messageCount: string, conversationHistoryDeleted: string }
+#   }, 
+#   clineVersion, timestamp, ... 
+# }
 # Output: { cancel: boolean, contextModification?: string, errorMessage?: string }
 # 
 # Use cases:
@@ -114,12 +127,14 @@ INPUT=$(cat)
 
 # Parse input using jq (or fallback to basic parsing)
 if command -v jq &> /dev/null; then
-  TASK=$(echo "$INPUT" | jq -r '.taskResume.task')
+  TASK_ID=$(echo "$INPUT" | jq -r '.taskResume.taskMetadata.taskId')
+  MSG_COUNT=$(echo "$INPUT" | jq -r '.taskResume.previousState.messageCount')
 else
-  TASK="<task>"
+  TASK_ID="<taskId>"
+  MSG_COUNT="0"
 fi
 
-echo "[TaskResume] Resuming task: $TASK" >&2
+echo "[TaskResume] Resuming task: $TASK_ID (previous messages: $MSG_COUNT)" >&2
 
 # Return result
 echo '{"cancel":false,"contextModification":"","errorMessage":""}'
@@ -133,7 +148,13 @@ function getTaskCancelTemplate(): string {
 # 
 # Executes when a task is cancelled by the user.
 # 
-# Input: { taskId, taskCancel: { task: string }, clineVersion, timestamp, ... }
+# Input: { 
+#   taskId, 
+#   taskCancel: { 
+#     taskMetadata: { taskId: string, ulid: string, completionStatus: string } 
+#   }, 
+#   clineVersion, timestamp, ... 
+# }
 # Output: { cancel: boolean, contextModification?: string, errorMessage?: string }
 # 
 # Use cases:
@@ -146,12 +167,14 @@ INPUT=$(cat)
 
 # Parse input using jq (or fallback to basic parsing)
 if command -v jq &> /dev/null; then
-  TASK=$(echo "$INPUT" | jq -r '.taskCancel.task')
+  TASK_ID=$(echo "$INPUT" | jq -r '.taskCancel.taskMetadata.taskId')
+  STATUS=$(echo "$INPUT" | jq -r '.taskCancel.taskMetadata.completionStatus')
 else
-  TASK="<task>"
+  TASK_ID="<taskId>"
+  STATUS="cancelled"
 fi
 
-echo "[TaskCancel] Task cancelled: $TASK" >&2
+echo "[TaskCancel] Task cancelled: $TASK_ID (status: $STATUS)" >&2
 
 # Return result
 echo '{"cancel":false,"contextModification":"","errorMessage":""}'
@@ -165,7 +188,13 @@ function getTaskCompleteTemplate(): string {
 # 
 # Executes when a task completes successfully.
 # 
-# Input: { taskId, taskComplete: { task: string }, clineVersion, timestamp, ... }
+# Input: { 
+#   taskId, 
+#   taskComplete: { 
+#     taskMetadata: { taskId: string, ulid: string, result: string, command: string } 
+#   }, 
+#   clineVersion, timestamp, ... 
+# }
 # Output: { cancel: boolean, contextModification?: string, errorMessage?: string }
 # 
 # Use cases:
@@ -179,12 +208,14 @@ INPUT=$(cat)
 
 # Parse input using jq (or fallback to basic parsing)
 if command -v jq &> /dev/null; then
-  TASK=$(echo "$INPUT" | jq -r '.taskComplete.task')
+  TASK_ID=$(echo "$INPUT" | jq -r '.taskComplete.taskMetadata.taskId')
+  RESULT=$(echo "$INPUT" | jq -r '.taskComplete.taskMetadata.result')
 else
-  TASK="<task>"
+  TASK_ID="<taskId>"
+  RESULT="<result>"
 fi
 
-echo "[TaskComplete] Task completed: $TASK" >&2
+echo "[TaskComplete] Task completed: $TASK_ID (result: $RESULT)" >&2
 
 # Return result
 echo '{"cancel":false,"contextModification":"","errorMessage":""}'
@@ -198,7 +229,7 @@ function getPreToolUseTemplate(): string {
 # 
 # Executes before any tool is used (read_file, write_to_file, execute_command, etc.)
 # 
-# Input: { taskId, preToolUse: { tool: string, parameters: object }, ... }
+# Input: { taskId, preToolUse: { toolName: string, parameters: object }, ... }
 # Output: { cancel: boolean, contextModification?: string, errorMessage?: string }
 # 
 # Use cases:
@@ -212,7 +243,7 @@ INPUT=$(cat)
 
 # Parse input using jq (or fallback to basic parsing)
 if command -v jq &> /dev/null; then
-  TOOL=$(echo "$INPUT" | jq -r '.preToolUse.tool')
+  TOOL=$(echo "$INPUT" | jq -r '.preToolUse.toolName')
   COMMAND=$(echo "$INPUT" | jq -r '.preToolUse.parameters.command // empty')
 else
   TOOL="<tool>"
@@ -243,11 +274,11 @@ function getPostToolUseTemplate(): string {
 # Input: { 
 #   taskId, 
 #   postToolUse: { 
-#     tool: string, 
+#     toolName: string, 
 #     parameters: object,
 #     result: string,
 #     success: boolean,
-#     durationMs: number
+#     executionTimeMs: number
 #   }, 
 #   ... 
 # }
@@ -264,9 +295,9 @@ INPUT=$(cat)
 
 # Parse input using jq (or fallback to basic parsing)
 if command -v jq &> /dev/null; then
-  TOOL=$(echo "$INPUT" | jq -r '.postToolUse.tool')
+  TOOL=$(echo "$INPUT" | jq -r '.postToolUse.toolName')
   SUCCESS=$(echo "$INPUT" | jq -r '.postToolUse.success')
-  DURATION=$(echo "$INPUT" | jq -r '.postToolUse.durationMs')
+  DURATION=$(echo "$INPUT" | jq -r '.postToolUse.executionTimeMs')
 else
   TOOL="<tool>"
   SUCCESS="true"
@@ -290,7 +321,7 @@ function getUserPromptSubmitTemplate(): string {
 # 
 # Executes when the user submits a prompt to Cline.
 # 
-# Input: { taskId, userPromptSubmit: { prompt: string }, clineVersion, timestamp, ... }
+# Input: { taskId, userPromptSubmit: { prompt: string, attachments: string[] }, clineVersion, timestamp, ... }
 # Output: { cancel: boolean, contextModification?: string, errorMessage?: string }
 # 
 # Use cases:
@@ -390,8 +421,19 @@ function getPreCompactTemplate(): string {
 # Input: { 
 #   taskId, 
 #   preCompact: { 
-#     conversationLength: number,
-#     estimatedTokens: number 
+#     taskId: string,
+#     ulid: string,
+#     contextSize: number,
+#     compactionStrategy: string,
+#     previousApiReqIndex: number,
+#     tokensIn: number,
+#     tokensOut: number,
+#     tokensInCache: number,
+#     tokensOutCache: number,
+#     deletedRangeStart: number,
+#     deletedRangeEnd: number,
+#     contextJsonPath: string,
+#     contextRawPath: string
 #   }, 
 #   ... 
 # }
@@ -407,14 +449,18 @@ INPUT=$(cat)
 
 # Parse input using jq (or fallback to basic parsing)
 if command -v jq &> /dev/null; then
-  CONV_LENGTH=$(echo "$INPUT" | jq -r '.preCompact.conversationLength')
-  EST_TOKENS=$(echo "$INPUT" | jq -r '.preCompact.estimatedTokens')
+  CONTEXT_SIZE=$(echo "$INPUT" | jq -r '.preCompact.contextSize')
+  STRATEGY=$(echo "$INPUT" | jq -r '.preCompact.compactionStrategy')
+  TOKENS_IN=$(echo "$INPUT" | jq -r '.preCompact.tokensIn')
+  TOKENS_OUT=$(echo "$INPUT" | jq -r '.preCompact.tokensOut')
 else
-  CONV_LENGTH="<length>"
-  EST_TOKENS="<tokens>"
+  CONTEXT_SIZE="<size>"
+  STRATEGY="<strategy>"
+  TOKENS_IN="<tokens>"
+  TOKENS_OUT="<tokens>"
 fi
 
-echo "[PreCompact] About to compact conversation (messages: $CONV_LENGTH, tokens: $EST_TOKENS)" >&2
+echo "[PreCompact] About to compact conversation (contextSize: $CONTEXT_SIZE, strategy: $STRATEGY, tokensIn: $TOKENS_IN, tokensOut: $TOKENS_OUT)" >&2
 
 # Return result
 echo '{"cancel":false,"contextModification":"","errorMessage":""}'

--- a/src/core/hooks/templates.ts
+++ b/src/core/hooks/templates.ts
@@ -1,4 +1,3 @@
-// biome-ignore-all lint/suspicious/noUselessEscapeInString: keep shell JSON echo pattern aligned with existing templates
 /**
  * Hook script templates for all supported hook types.
  * On Unix, templates are Bash scripts with comprehensive examples.
@@ -86,7 +85,7 @@ TIMESTAMP_ISO=$(date -u -d @"$((TIMESTAMP/1000))" +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/n
 CONTEXT_MOD="Note: Task started at $TIMESTAMP_ISO"
 
 # Return result as JSON
-echo "{\"cancel\":false,\"contextModification\":\"$CONTEXT_MOD\",\"errorMessage\":\"\"}"
+echo "{\\"cancel\\":false,\\"contextModification\\":\\"$CONTEXT_MOD\\",\\"errorMessage\\":\\"\\"}"
 `
 }
 
@@ -118,7 +117,7 @@ fi
 echo "[TaskResume] Resuming task: $TASK" >&2
 
 # Return result
-echo "{\"cancel\":false,\"contextModification\":\"\",\"errorMessage\":\"\"}"
+echo '{"cancel":false,"contextModification":"","errorMessage":""}'
 `
 }
 
@@ -150,7 +149,7 @@ fi
 echo "[TaskCancel] Task cancelled: $TASK" >&2
 
 # Return result
-echo "{\"cancel\":false,\"contextModification\":\"\",\"errorMessage\":\"\"}"
+echo '{"cancel":false,"contextModification":"","errorMessage":""}'
 `
 }
 
@@ -183,7 +182,7 @@ fi
 echo "[TaskComplete] Task completed: $TASK" >&2
 
 # Return result
-echo "{\"cancel\":false,\"contextModification\":\"\",\"errorMessage\":\"\"}"
+echo '{"cancel":false,"contextModification":"","errorMessage":""}'
 `
 }
 
@@ -217,7 +216,7 @@ fi
 
 # Example: Block dangerous operations
 if [[ "$TOOL" == "execute_command" ]] && [[ "$COMMAND" == *"rm -rf /"* ]]; then
-  echo "{\"cancel\":true,\"errorMessage\":\"Dangerous command blocked by PreToolUse hook\"}"
+  echo '{"cancel":true,"errorMessage":"Dangerous command blocked by PreToolUse hook"}'
   exit 0
 fi
 
@@ -225,7 +224,7 @@ fi
 echo "[PreToolUse] Tool about to execute: $TOOL" >&2
 
 # Allow execution
-echo "{\"cancel\":false,\"contextModification\":\"\",\"errorMessage\":\"\"}"
+echo '{"cancel":false,"contextModification":"","errorMessage":""}'
 `
 }
 
@@ -275,7 +274,7 @@ STATUS="success"
 echo "[PostToolUse] Tool completed: $TOOL ($STATUS) in \${DURATION}ms" >&2
 
 # Return result
-echo "{\"cancel\":false,\"contextModification\":\"\",\"errorMessage\":\"\"}"
+echo '{"cancel":false,"contextModification":"","errorMessage":""}'
 `
 }
 
@@ -309,7 +308,7 @@ fi
 echo "[UserPromptSubmit] User submitted prompt (length: $PROMPT_LENGTH)" >&2
 
 # Return result
-echo "{\"cancel\":false,\"contextModification\":\"\",\"errorMessage\":\"\"}"
+echo '{"cancel":false,"contextModification":"","errorMessage":""}'
 `
 }
 
@@ -372,7 +371,7 @@ fi
 
 echo "[Notification] event=$EVENT source=$SOURCE sourceType=$SOURCE_TYPE waitingForUserInput=$WAITING requiresUserAction=$REQUIRES_ACTION severity=$SEVERITY eventVersion=$EVENT_VERSION" >&2
 
-echo "{\"cancel\":false,\"contextModification\":\"\",\"errorMessage\":\"\"}"
+echo '{"cancel":false,"contextModification":"","errorMessage":""}'
 `
 }
 
@@ -413,7 +412,7 @@ fi
 echo "[PreCompact] About to compact conversation (messages: $CONV_LENGTH, tokens: $EST_TOKENS)" >&2
 
 # Return result
-echo "{\"cancel\":false,\"contextModification\":\"\",\"errorMessage\":\"\"}"
+echo '{"cancel":false,"contextModification":"","errorMessage":""}'
 `
 }
 
@@ -439,6 +438,6 @@ fi
 echo "[${hookName}] Executed for task $TASK_ID" >&2
 
 # Return result
-echo "{\"cancel\":false,\"contextModification\":\"\",\"errorMessage\":\"\"}"
+echo '{"cancel":false,"contextModification":"","errorMessage":""}'
 `
 }

--- a/src/core/hooks/templates.ts
+++ b/src/core/hooks/templates.ts
@@ -84,8 +84,13 @@ echo "[TaskStart] Task ID: $TASK_ID" >&2
 TIMESTAMP_ISO=$(date -u -d @"$((TIMESTAMP/1000))" +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || date -u +"%Y-%m-%dT%H:%M:%SZ")
 CONTEXT_MOD="Note: Task started at $TIMESTAMP_ISO"
 
-# Return result as JSON
-echo "{\\"cancel\\":false,\\"contextModification\\":\\"$CONTEXT_MOD\\",\\"errorMessage\\":\\"\\"}"
+# Return result as JSON (use jq to safely encode the variable, with a simple fallback)
+if command -v jq &> /dev/null; then
+  jq -n --arg ctx "$CONTEXT_MOD" '{"cancel":false,"contextModification":$ctx,"errorMessage":""}'
+else
+  ESCAPED_MOD=$(printf '%s' "$CONTEXT_MOD" | sed 's/\\\\/\\\\\\\\/g; s/"/\\\\"/g')
+  echo '{"cancel":false,"contextModification":"'"$ESCAPED_MOD"'","errorMessage":""}'
+fi
 `
 }
 


### PR DESCRIPTION
Fixes #7672 

When hooks were created, some examples where checked in with incorrect field names. These got carried into documentation and templates.

This fixes the documentation and templates to match the field names we are *actually* sending.

In addition, the templates contained strings with two levels of escaping: TypeScript string literals, and shell string interpolation. The escaping was wrong so the template hooks didn't work.

This also adds proper escaping for an interpolated string in hook output. The string was benign in this case, but since we expect users to modify these templates, we should escape the string properly so their hook works if they send a more complex string.

### Description

The default hooks templates include these lines:

```
# Return result as JSON
echo "{"cancel":false,"contextModification":"$CONTEXT_MOD","errorMessage":""}"
```

The " escaping is wrong and as a result the hook doesn't work. In particular, a line like:

```
echo "{"cancel":false,"contextModification":"$CONTEXT_MOD","errorMessage":""}
```

Produces a line which is not valid JavaScript, let alone JSON:

```
{cancel:false,contextModification:,errorMessage:}
```

### Test Procedure

1. Create a hook, for example `UserPromptSubmit` and add a context modification.
2. Trigger the hook, for example, send a message.
3. Verify that the hook did modify the context.
4. Create a `PostToolUse` hook.
5. Trigger the hook by asking the agent to list `/tmp`.
6. Verify that the hook actually outputs some values for execution time and tool name.

### Type of Change

-   [X] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshot

<img width="461" height="837" alt="Screenshot 2026-04-24 at 17 46 06" src="https://github.com/user-attachments/assets/028ae459-0be0-43ae-8e7b-b92effd507c7" />
