### PR TITLE
fix: cap retry-after delay to prevent silent multi-hour hangs

### DIFF
--- a/apps/vscode/src/core/api/retry.test.ts
+++ b/apps/vscode/src/core/api/retry.test.ts
@@ -112,12 +112,13 @@ describe("Retry Decorator", () => {
 		it("should respect retry-after header with Unix timestamp", async () => {
 			const setTimeoutSpy = sinon.spy(global, "setTimeout")
 			let callCount = 0
-			const fixedDate = new Date("2010-01-01T00:00:00.000Z")
-			const retryTimestamp = Math.floor(fixedDate.getTime() / 1000) + 0.01 // 10ms in the future
-			const baseDelay = 1000
+			const fakeNow = 1700000000000
+			sinon.stub(Date, "now").returns(fakeNow)
+			const retryTimestamp = fakeNow / 1000 + 1 // 1 second in the future
+			const baseDelay = 10000
 
 			class TestClass {
-				@withRetry({ maxRetries: 2, baseDelay, maxRetryAfter: Number.POSITIVE_INFINITY }) // Use large baseDelay to ensure header takes precedence
+				@withRetry({ maxRetries: 2, baseDelay }) // Use large baseDelay to ensure header takes precedence
 				async *failMethod() {
 					callCount++
 					if (callCount === 1) {
@@ -140,7 +141,7 @@ describe("Retry Decorator", () => {
 
 			setTimeoutSpy.calledOnce.should.be.true
 			const [_, delay] = setTimeoutSpy.getCall(0).args
-			delay?.should.equal(fixedDate.getTime())
+			delay?.should.equal(1000) // (fakeNow/1000 + 1) * 1000 - fakeNow = 1000ms
 
 			result.should.deepEqual(["success after retry"])
 		})

--- a/apps/vscode/src/core/api/retry.test.ts
+++ b/apps/vscode/src/core/api/retry.test.ts
@@ -117,7 +117,7 @@ describe("Retry Decorator", () => {
 			const baseDelay = 1000
 
 			class TestClass {
-				@withRetry({ maxRetries: 2, baseDelay }) // Use large baseDelay to ensure header takes precedence
+				@withRetry({ maxRetries: 2, baseDelay, maxRetryAfter: Number.POSITIVE_INFINITY }) // Use large baseDelay to ensure header takes precedence
 				async *failMethod() {
 					callCount++
 					if (callCount === 1) {
@@ -174,6 +174,60 @@ describe("Retry Decorator", () => {
 			const [_, delay] = setTimeoutSpy.getCall(0).args
 			delay?.should.equal(baseDelay)
 
+			result.should.deepEqual(["success after retry"])
+		})
+
+		it("should throw immediately when retry-after exceeds maxRetryAfter", async () => {
+			let callCount = 0
+			class TestClass {
+				@withRetry({ maxRetries: 3, baseDelay: 10, maxRetryAfter: 60_000 })
+				async *failMethod() {
+					callCount++
+					if (callCount === 1) {
+						const error: any = new Error("Rate limit exceeded")
+						error.status = 429
+						error.headers = { "retry-after": "10800" } // 3 hours
+						throw error
+					}
+					yield "should not reach"
+				}
+			}
+
+			const test = new TestClass()
+			try {
+				for await (const _ of test.failMethod()) {
+					// Should not reach here
+				}
+				throw new Error("Should have thrown")
+			} catch (error: any) {
+				error.message.should.equal("Rate limit exceeded")
+				callCount.should.equal(1)
+			}
+		})
+
+		it("should still retry when retry-after is within maxRetryAfter", async () => {
+			let callCount = 0
+			class TestClass {
+				@withRetry({ maxRetries: 2, baseDelay: 10, maxRetryAfter: 60_000 })
+				async *failMethod() {
+					callCount++
+					if (callCount === 1) {
+						const error: any = new Error("Rate limit exceeded")
+						error.status = 429
+						error.headers = { "retry-after": "0.01" } // 10ms, well within limit
+						throw error
+					}
+					yield "success after retry"
+				}
+			}
+
+			const test = new TestClass()
+			const result = []
+			for await (const value of test.failMethod()) {
+				result.push(value)
+			}
+
+			callCount.should.equal(2)
 			result.should.deepEqual(["success after retry"])
 		})
 

--- a/apps/vscode/src/core/api/retry.ts
+++ b/apps/vscode/src/core/api/retry.ts
@@ -4,6 +4,7 @@ interface RetryOptions {
 	maxRetries?: number
 	baseDelay?: number
 	maxDelay?: number
+	maxRetryAfter?: number
 	retryAllErrors?: boolean
 }
 
@@ -11,11 +12,12 @@ const DEFAULT_OPTIONS: Required<RetryOptions> = {
 	maxRetries: 3,
 	baseDelay: 1_000,
 	maxDelay: 10_000,
+	maxRetryAfter: 60_000,
 	retryAllErrors: false,
 }
 
 export class RetriableError extends Error {
-	status: number = 429
+	status = 429
 	retryAfter?: number
 
 	constructor(message: string, retryAfter?: number, options?: ErrorOptions) {
@@ -27,7 +29,7 @@ export class RetriableError extends Error {
 }
 
 export function withRetry(options: RetryOptions = {}) {
-	const { maxRetries, baseDelay, maxDelay, retryAllErrors } = { ...DEFAULT_OPTIONS, ...options }
+	const { maxRetries, baseDelay, maxDelay, maxRetryAfter, retryAllErrors } = { ...DEFAULT_OPTIONS, ...options }
 
 	return (_target: any, _propertyKey: string, descriptor: PropertyDescriptor) => {
 		const originalMethod = descriptor.value
@@ -56,13 +58,17 @@ export function withRetry(options: RetryOptions = {}) {
 					let delay: number
 					if (retryAfter) {
 						// Handle both delta-seconds and Unix timestamp formats
-						const retryValue = parseInt(retryAfter, 10)
+						const retryValue = Number.parseInt(retryAfter, 10)
 						if (retryValue > Date.now() / 1000) {
 							// Unix timestamp
 							delay = retryValue * 1000 - Date.now()
 						} else {
 							// Delta seconds
 							delay = retryValue * 1000
+						}
+
+						if (delay > maxRetryAfter) {
+							throw error
 						}
 					} else {
 						// Use exponential backoff if no header


### PR DESCRIPTION
## Summary

When a server returns a large `retry-after` header value (e.g., 3 hours from Gemini quota exhaustion), the `withRetry` decorator silently waits for the full duration instead of surfacing the error. This causes multi-hour hangs with no user feedback.

This PR adds a `maxRetryAfter` option (default: 60 seconds) to the retry decorator. When the computed retry delay from a `retry-after` header exceeds this cap, the error is thrown immediately instead of waiting, letting callers surface it to the user.

Fixes #10139

## Changes

- **`src/core/api/retry.ts`**: Added `maxRetryAfter` to `RetryOptions` interface and defaults (60s). After computing delay from `retry-after` header, throws immediately if `delay > maxRetryAfter`.
- **`src/core/api/retry.test.ts`**: Added two test cases:
  - Verifies immediate throw when retry-after (3 hours) exceeds the cap
  - Verifies normal retry when retry-after (10ms) is within the cap
  - Updated existing Unix timestamp test to pass `maxRetryAfter: Infinity` since its synthetic timestamp produces a delay that exceeds the default cap

## Test plan

- [x] All 10 retry decorator tests pass (`npx mocha --no-config src/core/api/retry.test.ts`)
- [x] Pre-commit hooks (biome lint) pass
- [ ] Existing behavior preserved: exponential backoff, maxDelay, maxRetries, non-429 errors all unchanged
- [ ] New guard only activates when retry-after header produces a delay > maxRetryAfter