### PR TITLE
fix(claude-code): handle CLI v2.1+ result chunks and error_max_turns

### DIFF
--- a/.mocharc.json
+++ b/.mocharc.json
@@ -7,8 +7,8 @@
 		"src/test/services/**/*.test.ts"
 	],
 	"require": [
-		"ts-node/register",
-		"source-map-support/register",
+		"tsx/cjs",
+		"tsconfig-paths/register",
 		"./src/test/requires.ts"
 	],
 	"recursive": true,

--- a/.mocharc.json
+++ b/.mocharc.json
@@ -4,7 +4,8 @@
 	],
 	"spec": [
 		"src/**/__tests__/*.ts",
-		"src/test/services/**/*.test.ts"
+		"src/test/services/**/*.test.ts",
+		"src/integrations/claude-code/run.test.ts"
 	],
 	"require": [
 		"tsx/cjs",

--- a/package-lock.json
+++ b/package-lock.json
@@ -154,6 +154,7 @@
 				"ts-node": "^10.9.2",
 				"ts-proto": "^2.6.1",
 				"tsconfig-paths": "^4.2.0",
+				"tsx": "4.21.0",
 				"typescript": "^5.4.5"
 			},
 			"engines": {
@@ -13031,6 +13032,19 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/get-tsconfig": {
+			"version": "4.14.0",
+			"resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+			"integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
+			"devOptional": true,
+			"license": "MIT",
+			"dependencies": {
+				"resolve-pkg-maps": "^1.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+			}
+		},
 		"node_modules/get-uri": {
 			"version": "6.0.5",
 			"resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.5.tgz",
@@ -19409,6 +19423,16 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/resolve-pkg-maps": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+			"integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+			"devOptional": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+			}
+		},
 		"node_modules/restore-cursor": {
 			"version": "5.1.0",
 			"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
@@ -21636,6 +21660,498 @@
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
 			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
 			"license": "0BSD"
+		},
+		"node_modules/tsx": {
+			"version": "4.21.0",
+			"resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+			"integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+			"devOptional": true,
+			"license": "MIT",
+			"dependencies": {
+				"esbuild": "~0.27.0",
+				"get-tsconfig": "^4.7.5"
+			},
+			"bin": {
+				"tsx": "dist/cli.mjs"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			},
+			"optionalDependencies": {
+				"fsevents": "~2.3.3"
+			}
+		},
+		"node_modules/tsx/node_modules/@esbuild/aix-ppc64": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+			"integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+			"cpu": [
+				"ppc64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"aix"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/tsx/node_modules/@esbuild/android-arm": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+			"integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+			"cpu": [
+				"arm"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/tsx/node_modules/@esbuild/android-arm64": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+			"integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/tsx/node_modules/@esbuild/android-x64": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+			"integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/tsx/node_modules/@esbuild/darwin-arm64": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+			"integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/tsx/node_modules/@esbuild/darwin-x64": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+			"integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/tsx/node_modules/@esbuild/freebsd-arm64": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+			"integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/tsx/node_modules/@esbuild/freebsd-x64": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+			"integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/tsx/node_modules/@esbuild/linux-arm": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+			"integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+			"cpu": [
+				"arm"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/tsx/node_modules/@esbuild/linux-arm64": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+			"integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/tsx/node_modules/@esbuild/linux-ia32": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+			"integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+			"cpu": [
+				"ia32"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/tsx/node_modules/@esbuild/linux-loong64": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+			"integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+			"cpu": [
+				"loong64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/tsx/node_modules/@esbuild/linux-mips64el": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+			"integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+			"cpu": [
+				"mips64el"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/tsx/node_modules/@esbuild/linux-ppc64": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+			"integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+			"cpu": [
+				"ppc64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/tsx/node_modules/@esbuild/linux-riscv64": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+			"integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+			"cpu": [
+				"riscv64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/tsx/node_modules/@esbuild/linux-s390x": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+			"integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+			"cpu": [
+				"s390x"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/tsx/node_modules/@esbuild/linux-x64": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+			"integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/tsx/node_modules/@esbuild/netbsd-arm64": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+			"integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"netbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/tsx/node_modules/@esbuild/netbsd-x64": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+			"integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"netbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/tsx/node_modules/@esbuild/openbsd-arm64": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+			"integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/tsx/node_modules/@esbuild/openbsd-x64": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+			"integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/tsx/node_modules/@esbuild/openharmony-arm64": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+			"integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openharmony"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/tsx/node_modules/@esbuild/sunos-x64": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+			"integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"sunos"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/tsx/node_modules/@esbuild/win32-arm64": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+			"integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/tsx/node_modules/@esbuild/win32-ia32": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+			"integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+			"cpu": [
+				"ia32"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/tsx/node_modules/@esbuild/win32-x64": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+			"integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/tsx/node_modules/esbuild": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+			"integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+			"devOptional": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"bin": {
+				"esbuild": "bin/esbuild"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"optionalDependencies": {
+				"@esbuild/aix-ppc64": "0.27.7",
+				"@esbuild/android-arm": "0.27.7",
+				"@esbuild/android-arm64": "0.27.7",
+				"@esbuild/android-x64": "0.27.7",
+				"@esbuild/darwin-arm64": "0.27.7",
+				"@esbuild/darwin-x64": "0.27.7",
+				"@esbuild/freebsd-arm64": "0.27.7",
+				"@esbuild/freebsd-x64": "0.27.7",
+				"@esbuild/linux-arm": "0.27.7",
+				"@esbuild/linux-arm64": "0.27.7",
+				"@esbuild/linux-ia32": "0.27.7",
+				"@esbuild/linux-loong64": "0.27.7",
+				"@esbuild/linux-mips64el": "0.27.7",
+				"@esbuild/linux-ppc64": "0.27.7",
+				"@esbuild/linux-riscv64": "0.27.7",
+				"@esbuild/linux-s390x": "0.27.7",
+				"@esbuild/linux-x64": "0.27.7",
+				"@esbuild/netbsd-arm64": "0.27.7",
+				"@esbuild/netbsd-x64": "0.27.7",
+				"@esbuild/openbsd-arm64": "0.27.7",
+				"@esbuild/openbsd-x64": "0.27.7",
+				"@esbuild/openharmony-arm64": "0.27.7",
+				"@esbuild/sunos-x64": "0.27.7",
+				"@esbuild/win32-arm64": "0.27.7",
+				"@esbuild/win32-ia32": "0.27.7",
+				"@esbuild/win32-x64": "0.27.7"
+			}
+		},
+		"node_modules/tsx/node_modules/fsevents": {
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+			"integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+			"hasInstallScript": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+			}
 		},
 		"node_modules/tunnel": {
 			"version": "0.0.6",

--- a/package.json
+++ b/package.json
@@ -492,6 +492,7 @@
 		"ts-node": "^10.9.2",
 		"ts-proto": "^2.6.1",
 		"tsconfig-paths": "^4.2.0",
+		"tsx": "4.21.0",
 		"typescript": "^5.4.5"
 	},
 	"dependencies": {

--- a/src/core/api/providers/__tests__/claude-code.test.ts
+++ b/src/core/api/providers/__tests__/claude-code.test.ts
@@ -1,35 +1,22 @@
-import { afterEach, beforeEach, describe, it } from "mocha"
-import sinon from "sinon"
+import { describe, it } from "mocha"
 import "should"
 import { ClaudeCodeHandler } from "@core/api/providers/claude-code"
 import { ClineStorageMessage } from "@/shared/messages/content"
 
+function makeHandler(mockGen: () => AsyncGenerator<any>) {
+	return new ClaudeCodeHandler({
+		claudeCodePath: "/mock/path",
+		apiModelId: "claude-opus-4-1-20250805",
+		_runClaudeCode: mockGen as any,
+	})
+}
+
 describe("ClaudeCodeHandler", () => {
-	let handler: ClaudeCodeHandler
-	let sandbox: sinon.SinonSandbox
-
-	beforeEach(() => {
-		sandbox = sinon.createSandbox()
-		handler = new ClaudeCodeHandler({
-			claudeCodePath: "/mock/path",
-			apiModelId: "claude-opus-4-1-20250805",
-		})
-	})
-
-	afterEach(() => {
-		sandbox.restore()
-	})
-
 	describe("token counting", () => {
 		it("should correctly handle token usage from assistant messages", async () => {
 			// The 'input_tokens' field represents the TOTAL number of input tokens used.
 			// See https://docs.anthropic.com/en/api/messages#usage-object
 
-			// Mock the runClaudeCode function
-			const runClaudeCodeModule = await import("@/integrations/claude-code/run")
-			const runClaudeCodeStub = sandbox.stub(runClaudeCodeModule, "runClaudeCode")
-
-			// Create a proper async generator mock for the Claude Code response
 			async function* mockGenerator() {
 				// First yield the system init
 				yield {
@@ -68,8 +55,7 @@ describe("ClaudeCodeHandler", () => {
 				}
 			}
 
-			runClaudeCodeStub.returns(mockGenerator() as any)
-
+			const handler = makeHandler(mockGenerator)
 			const systemPrompt = "You are a helpful assistant."
 			const messages: ClineStorageMessage[] = [{ role: "user", content: "Hello" }]
 
@@ -106,11 +92,6 @@ describe("ClaudeCodeHandler", () => {
 		})
 
 		it("should handle missing usage fields with nullish coalescing", async () => {
-			// Mock the runClaudeCode function
-			const runClaudeCodeModule = await import("@/integrations/claude-code/run")
-			const runClaudeCodeStub = sandbox.stub(runClaudeCodeModule, "runClaudeCode")
-
-			// Create a proper async generator mock with missing/undefined usage fields
 			async function* mockGenerator() {
 				yield {
 					type: "assistant",
@@ -137,8 +118,7 @@ describe("ClaudeCodeHandler", () => {
 				}
 			}
 
-			runClaudeCodeStub.returns(mockGenerator() as any)
-
+			const handler = makeHandler(mockGenerator)
 			const systemPrompt = "You are a helpful assistant."
 			const messages: ClineStorageMessage[] = [{ role: "user", content: "Hello" }]
 
@@ -167,11 +147,6 @@ describe("ClaudeCodeHandler", () => {
 		})
 
 		it("should handle completely missing usage object", async () => {
-			// Mock the runClaudeCode function
-			const runClaudeCodeModule = await import("@/integrations/claude-code/run")
-			const runClaudeCodeStub = sandbox.stub(runClaudeCodeModule, "runClaudeCode")
-
-			// Create a proper async generator mock with missing usage object
 			async function* mockGenerator() {
 				yield {
 					type: "assistant",
@@ -196,8 +171,7 @@ describe("ClaudeCodeHandler", () => {
 				}
 			}
 
-			runClaudeCodeStub.returns(mockGenerator() as any)
-
+			const handler = makeHandler(mockGenerator)
 			const systemPrompt = "You are a helpful assistant."
 			const messages: ClineStorageMessage[] = [{ role: "user", content: "Hello" }]
 
@@ -228,9 +202,6 @@ describe("ClaudeCodeHandler", () => {
 
 	describe("error handling", () => {
 		it("should not crash when assistant message has empty content array", async () => {
-			const runClaudeCodeModule = await import("@/integrations/claude-code/run")
-			const runClaudeCodeStub = sandbox.stub(runClaudeCodeModule, "runClaudeCode")
-
 			async function* mockGenerator() {
 				yield {
 					type: "assistant",
@@ -251,8 +222,7 @@ describe("ClaudeCodeHandler", () => {
 				}
 			}
 
-			runClaudeCodeStub.returns(mockGenerator() as any)
-
+			const handler = makeHandler(mockGenerator)
 			const chunks: any[] = []
 			// Should not throw
 			for await (const chunk of handler.createMessage("system", [{ role: "user", content: "hi" }])) {
@@ -264,10 +234,82 @@ describe("ClaudeCodeHandler", () => {
 			usageChunk.inputTokens.should.equal(10)
 		})
 
-		it("should throw when result has is_error=true (e.g. rate limit with no assistant message)", async () => {
-			const runClaudeCodeModule = await import("@/integrations/claude-code/run")
-			const runClaudeCodeStub = sandbox.stub(runClaudeCodeModule, "runClaudeCode")
+		it("should yield usage when result chunk has no 'result' property (CLI v2.1+ success format)", async () => {
+			async function* mockGenerator() {
+				yield {
+					type: "assistant",
+					message: {
+						content: [{ type: "text", text: "Hello" }],
+						usage: { input_tokens: 10, output_tokens: 5 },
+						stop_reason: "end_turn",
+					},
+				}
 
+				// CLI v2.1+ omits the 'result' string property on success
+				yield {
+					type: "result",
+					subtype: "success",
+					is_error: false,
+					total_cost_usd: 0.001,
+					duration_ms: 1000,
+					duration_api_ms: 900,
+					num_turns: 1,
+					session_id: "test",
+				}
+			}
+
+			const handler = makeHandler(mockGenerator)
+			const chunks: any[] = []
+			for await (const chunk of handler.createMessage("system", [{ role: "user", content: "hi" }])) {
+				chunks.push(chunk)
+			}
+
+			const usageChunk = chunks.find((c) => c.type === "usage")
+			usageChunk.should.be.ok()
+			usageChunk.totalCost.should.equal(0.001)
+		})
+
+		it("should not throw on error_max_turns and should yield usage (normal --max-turns 1 behaviour)", async () => {
+			async function* mockGenerator() {
+				yield {
+					type: "assistant",
+					message: {
+						content: [{ type: "tool_use", id: "t1", name: "write_to_file", input: {} }],
+						usage: { input_tokens: 20, output_tokens: 10 },
+						stop_reason: "tool_use",
+					},
+				}
+
+				yield {
+					type: "result",
+					subtype: "error_max_turns",
+					is_error: true,
+					total_cost_usd: 0.002,
+					duration_ms: 2000,
+					duration_api_ms: 1800,
+					num_turns: 2,
+					session_id: "test",
+				}
+			}
+
+			const handler = makeHandler(mockGenerator)
+			let thrownError: Error | undefined
+			const chunks: any[] = []
+			try {
+				for await (const chunk of handler.createMessage("system", [{ role: "user", content: "hi" }])) {
+					chunks.push(chunk)
+				}
+			} catch (err) {
+				thrownError = err as Error
+			}
+
+			;(thrownError === undefined).should.be.true()
+			const usageChunk = chunks.find((c) => c.type === "usage")
+			usageChunk.should.be.ok()
+			usageChunk.totalCost.should.equal(0.002)
+		})
+
+		it("should throw when result has is_error=true (e.g. rate limit with no assistant message)", async () => {
 			async function* mockGenerator() {
 				yield {
 					type: "system",
@@ -296,8 +338,7 @@ describe("ClaudeCodeHandler", () => {
 				}
 			}
 
-			runClaudeCodeStub.returns(mockGenerator() as any)
-
+			const handler = makeHandler(mockGenerator)
 			let thrownError: Error | undefined
 			try {
 				for await (const _ of handler.createMessage("system", [{ role: "user", content: "hi" }])) {
@@ -311,9 +352,6 @@ describe("ClaudeCodeHandler", () => {
 		})
 
 		it("should ignore rate_limit_event system messages without throwing", async () => {
-			const runClaudeCodeModule = await import("@/integrations/claude-code/run")
-			const runClaudeCodeStub = sandbox.stub(runClaudeCodeModule, "runClaudeCode")
-
 			async function* mockGenerator() {
 				yield {
 					type: "system",
@@ -345,8 +383,7 @@ describe("ClaudeCodeHandler", () => {
 				}
 			}
 
-			runClaudeCodeStub.returns(mockGenerator() as any)
-
+			const handler = makeHandler(mockGenerator)
 			const textChunks: string[] = []
 			for await (const chunk of handler.createMessage("system", [{ role: "user", content: "hi" }])) {
 				if (chunk.type === "text") textChunks.push(chunk.text)

--- a/src/core/api/providers/claude-code.ts
+++ b/src/core/api/providers/claude-code.ts
@@ -11,6 +11,8 @@ interface ClaudeCodeHandlerOptions extends CommonApiHandlerOptions {
 	claudeCodePath?: string
 	apiModelId?: string
 	thinkingBudgetTokens?: number
+	/** For testing only: inject a custom runClaudeCode implementation */
+	_runClaudeCode?: (...args: Parameters<typeof runClaudeCode>) => ReturnType<typeof runClaudeCode>
 }
 
 export class ClaudeCodeHandler implements ApiHandler {
@@ -29,7 +31,8 @@ export class ClaudeCodeHandler implements ApiHandler {
 		// Filter out image blocks since Claude Code doesn't support them
 		const filteredMessages = filterMessagesForClaudeCode(messages)
 
-		const claudeProcess = runClaudeCode({
+		const runFn = this.options._runClaudeCode ?? runClaudeCode
+		const claudeProcess = runFn({
 			systemPrompt,
 			messages: filteredMessages,
 			path: this.options.claudeCodePath,
@@ -184,9 +187,9 @@ export class ClaudeCodeHandler implements ApiHandler {
 				continue
 			}
 
-			if (chunk.type === "result" && "result" in chunk) {
-				if (chunk.is_error) {
-					throw new Error(`Claude Code returned an error: ${chunk.result}`)
+			if (chunk.type === "result") {
+				if (chunk.is_error && chunk.subtype !== "error_max_turns") {
+					throw new Error(`Claude Code returned an error: ${chunk.result ?? JSON.stringify(chunk)}`)
 				}
 
 				usage.totalCost = isPaidUsage ? chunk.total_cost_usd : 0

--- a/src/core/workspace/WorkspaceRootManager.ts
+++ b/src/core/workspace/WorkspaceRootManager.ts
@@ -4,7 +4,6 @@
  */
 
 import { VcsType, WorkspaceRoot } from "@shared/multi-root/types"
-import { execa } from "execa"
 import * as path from "path"
 import { getGitRemoteUrls, getLatestGitCommitHash } from "../../utils/git"
 
@@ -16,9 +15,9 @@ export interface WorkspaceContext {
 
 export class WorkspaceRootManager {
 	private roots: WorkspaceRoot[] = []
-	private primaryIndex: number = 0
+	private primaryIndex = 0
 
-	constructor(roots: WorkspaceRoot[] = [], primaryIndex: number = 0) {
+	constructor(roots: WorkspaceRoot[] = [], primaryIndex = 0) {
 		this.roots = roots
 		this.primaryIndex = Math.min(primaryIndex, Math.max(0, roots.length - 1))
 	}
@@ -45,6 +44,7 @@ export class WorkspaceRootManager {
 	 * Detect version control system for a directory
 	 */
 	private static async detectVcs(dirPath: string): Promise<VcsType> {
+		const { execa } = await import("execa")
 		try {
 			// Check for Git
 			await execa("git", ["rev-parse", "--git-dir"], { cwd: dirPath })

--- a/src/integrations/claude-code/run.test.ts
+++ b/src/integrations/claude-code/run.test.ts
@@ -4,41 +4,31 @@ import proxyquire from "proxyquire"
 import sinon from "sinon"
 
 // Build a mock execa process. exitCode controls what the "close" event emits
-// and what `await cProcess` resolves to.
+// and what `await cProcess` resolves/rejects to.
+// For non-zero exit codes, the promise rejects — matching execa's default reject:true.
 const createMockProcess = (exitCode = 0) => {
-	const mockProcess = {
-		stdin: {
-			write: sinon.fake(),
-			end: sinon.fake(),
-		},
-		stdout: {
-			on: sinon.fake(),
-			resume: sinon.fake(),
-		},
-		stderr: {
-			on: sinon.fake(() => {}),
-		},
-		on: sinon.fake((event, callback) => {
+	// Simulate execa: reject on non-zero exit, resolve on zero.
+	const awaitResult: Promise<{ exitCode: number }> =
+		exitCode !== 0
+			? Promise.reject(Object.assign(new Error(`Command failed with exit code ${exitCode}: claude`), { exitCode }))
+			: Promise.resolve({ exitCode })
+
+	return {
+		stdin: { write: sinon.fake(), end: sinon.fake() },
+		stdout: { on: sinon.fake(), resume: sinon.fake() },
+		stderr: { on: sinon.fake(() => {}) },
+		on: sinon.fake((event: string, callback: (code: number) => void) => {
 			if (event === "close") {
 				setImmediate(() => callback(exitCode))
-			}
-			if (event === "error") {
 			}
 		}),
 		killed: false,
 		kill: sinon.fake(),
 		exitCode,
-		then: (onResolve: (value: any) => void) => {
-			setImmediate(() => onResolve({ exitCode }))
-			return Promise.resolve({ exitCode })
-		},
-		catch: () => Promise.resolve({ exitCode }),
-		finally: (callback: () => void) => {
-			setImmediate(callback)
-			return Promise.resolve({ exitCode })
-		},
+		then: (onResolve: any, onReject?: any) => awaitResult.then(onResolve, onReject),
+		catch: (fn: any) => awaitResult.catch(fn),
+		finally: (fn: any) => awaitResult.finally(fn),
 	}
-	return mockProcess
 }
 
 const createMockReadlineInterface = (lines: string[] = []) => ({
@@ -224,7 +214,8 @@ describe("Claude Code Integration", () => {
 			}
 
 			expect(thrownError).to.not.be.undefined
-			expect(thrownError!.message).to.include("exited with code 1")
+			// execa rejects with "Command failed with exit code 1: ..." which catch re-wraps
+			expect(thrownError!.message).to.include("exit code 1")
 		})
 	})
 })

--- a/src/integrations/claude-code/run.test.ts
+++ b/src/integrations/claude-code/run.test.ts
@@ -3,7 +3,9 @@ import path from "path"
 import proxyquire from "proxyquire"
 import sinon from "sinon"
 
-const createMockProcess = () => {
+// Build a mock execa process. exitCode controls what the "close" event emits
+// and what `await cProcess` resolves to.
+const createMockProcess = (exitCode = 0) => {
 	const mockProcess = {
 		stdin: {
 			write: sinon.fake(),
@@ -18,44 +20,42 @@ const createMockProcess = () => {
 		},
 		on: sinon.fake((event, callback) => {
 			if (event === "close") {
-				setImmediate(() => callback(0))
+				setImmediate(() => callback(exitCode))
 			}
 			if (event === "error") {
 			}
 		}),
 		killed: false,
 		kill: sinon.fake(),
-		exitCode: 0,
+		exitCode,
 		then: (onResolve: (value: any) => void) => {
-			setImmediate(() => onResolve({ exitCode: 0 }))
-			return Promise.resolve({ exitCode: 0 })
+			setImmediate(() => onResolve({ exitCode }))
+			return Promise.resolve({ exitCode })
 		},
-		catch: () => Promise.resolve({ exitCode: 0 }),
+		catch: () => Promise.resolve({ exitCode }),
 		finally: (callback: () => void) => {
 			setImmediate(callback)
-			return Promise.resolve({ exitCode: 0 })
+			return Promise.resolve({ exitCode })
 		},
 	}
 	return mockProcess
 }
 
-const createMockReadlineInterface = () => {
-	const mockInterface = {
-		async *[Symbol.asyncIterator]() {
-			// Simulate Claude CLI JSON output - yield a few chunks then end
-			yield '{"type":"text","text":"Hello"}'
-			yield '{"type":"text","text":" world"}'
-			// Iterator ends naturally when function returns
-			return
-		},
-		close: sinon.fake(),
-	}
-	return mockInterface
-}
-
-const mockExeca = sinon.fake((..._args) => {
-	return createMockProcess()
+const createMockReadlineInterface = (lines: string[] = []) => ({
+	async *[Symbol.asyncIterator]() {
+		for (const line of lines) {
+			yield line
+		}
+	},
+	close: sinon.fake(),
 })
+
+const DEFAULT_LINES = ['{"type":"text","text":"Hello"}', '{"type":"text","text":" world"}']
+
+// mockExeca is called synchronously by runProcess; we reset it per-test via sinon.restore
+let mockExeca = sinon.fake((..._args: any[]) => createMockProcess())
+let mockReadlineLines: string[] = DEFAULT_LINES
+let mockProcessExitCode = 0
 
 let os = "darwin"
 
@@ -66,29 +66,36 @@ const { MAX_SYSTEM_PROMPT_LENGTH, runClaudeCode } = proxyquire("./run", {
 	"node:os": {
 		platform: () => os,
 	},
-	execa: {
-		execa: mockExeca,
-	},
 	readline: {
-		createInterface: createMockReadlineInterface,
+		createInterface: () => createMockReadlineInterface(mockReadlineLines),
 	},
 })
 
-describe("Claude Code Integration", () => {
-	const scriptPath = "echo"
+// Helper: build an options object that injects mockExeca directly,
+// bypassing the dynamic import("execa") that proxyquire cannot intercept.
+const makeOptions = (overrides: Record<string, unknown> = {}) => ({
+	systemPrompt: "system",
+	messages: [],
+	modelId: "test",
+	path: "echo",
+	_execa: (...args: any[]) => {
+		mockExeca(...args)
+		return createMockProcess(mockProcessExitCode)
+	},
+	...overrides,
+})
 
+describe("Claude Code Integration", () => {
 	afterEach(() => {
 		sinon.restore()
+		mockExeca = sinon.fake((..._args: any[]) => createMockProcess())
+		mockReadlineLines = DEFAULT_LINES
+		mockProcessExitCode = 0
 	})
 
 	const itCallsTheScriptWithAFile = (systemPrompt: string) => {
 		it("calls the script using with a file", async () => {
-			const cProcess = runClaudeCode({
-				systemPrompt,
-				messages: [],
-				modelId: "test",
-				path: scriptPath,
-			})
+			const cProcess = runClaudeCode(makeOptions({ systemPrompt }))
 
 			const chunks: string[] = []
 			for await (const chunk of cProcess) {
@@ -98,6 +105,7 @@ describe("Claude Code Integration", () => {
 			expect(chunks).to.have.length(2)
 
 			const lastExecaCall = mockExeca.lastCall
+			expect(lastExecaCall).to.not.be.null
 			const params = lastExecaCall.args[1]
 			expect(params).to.not.be.null
 			expect(params.includes("--system-prompt-file")).to.be.true
@@ -112,13 +120,11 @@ describe("Claude Code Integration", () => {
 
 		describe("when the system prompt is longer than the MAX_SYSTEM_PROMPT_LENGTH", () => {
 			const SYSTEM_PROMPT = "a".repeat(MAX_SYSTEM_PROMPT_LENGTH * 1.2)
-
 			itCallsTheScriptWithAFile(SYSTEM_PROMPT)
 		})
 
 		describe("when the system prompt is shorter than the MAX_SYSTEM_PROMPT_LENGTH", () => {
 			const SYSTEM_PROMPT = "a".repeat(MAX_SYSTEM_PROMPT_LENGTH / 2)
-
 			itCallsTheScriptWithAFile(SYSTEM_PROMPT)
 		})
 	})
@@ -130,7 +136,6 @@ describe("Claude Code Integration", () => {
 
 		describe("when the system prompt is longer than the MAX_SYSTEM_PROMPT_LENGTH", () => {
 			const SYSTEM_PROMPT = "a".repeat(MAX_SYSTEM_PROMPT_LENGTH * 1.2)
-
 			itCallsTheScriptWithAFile(SYSTEM_PROMPT)
 		})
 
@@ -138,12 +143,7 @@ describe("Claude Code Integration", () => {
 			const SYSTEM_PROMPT = "a".repeat(MAX_SYSTEM_PROMPT_LENGTH / 2)
 
 			it("calls the script without a file", async () => {
-				const cProcess = runClaudeCode({
-					systemPrompt: SYSTEM_PROMPT,
-					messages: [],
-					modelId: "test",
-					path: scriptPath,
-				})
+				const cProcess = runClaudeCode(makeOptions({ systemPrompt: SYSTEM_PROMPT }))
 
 				const chunks: string[] = []
 				for await (const chunk of cProcess) {
@@ -153,11 +153,78 @@ describe("Claude Code Integration", () => {
 				expect(chunks).to.have.length(2)
 
 				const lastExecaCall = mockExeca.lastCall
+				expect(lastExecaCall).to.not.be.null
 				const params = lastExecaCall.args[1]
 				expect(params).to.not.be.null
 				expect(params.includes("--system-prompt-file")).to.be.false
 				expect(params.includes("--system-prompt")).to.be.true
 			})
+		})
+	})
+
+	describe("seenMaxTurns / exit-code handling", () => {
+		it("should not throw when process exits code 1 after error_max_turns result", async () => {
+			// CLI exits with code 1 on --max-turns exhaustion. Without seenMaxTurns
+			// tracking this would throw "Claude Code process exited with code 1".
+			mockReadlineLines = [
+				JSON.stringify({
+					type: "assistant",
+					message: {
+						content: [{ type: "tool_use", id: "t1", name: "write_to_file", input: {} }],
+						usage: { input_tokens: 10, output_tokens: 5 },
+						stop_reason: "tool_use",
+					},
+				}),
+				JSON.stringify({
+					type: "result",
+					subtype: "error_max_turns",
+					is_error: true,
+					total_cost_usd: 0.001,
+					duration_ms: 1000,
+					duration_api_ms: 900,
+					num_turns: 1,
+					session_id: "test",
+				}),
+			]
+			mockProcessExitCode = 1
+
+			let threw = false
+			try {
+				for await (const _ of runClaudeCode(makeOptions())) {
+					// consume
+				}
+			} catch {
+				threw = true
+			}
+
+			expect(threw).to.be.false
+		})
+
+		it("should throw when process exits code 1 without error_max_turns", async () => {
+			// A genuine non-zero exit (not max-turns) should still propagate as an error.
+			mockReadlineLines = [
+				JSON.stringify({
+					type: "assistant",
+					message: {
+						content: [{ type: "text", text: "Hello" }],
+						usage: { input_tokens: 10, output_tokens: 5 },
+						stop_reason: "end_turn",
+					},
+				}),
+			]
+			mockProcessExitCode = 1
+
+			let thrownError: Error | undefined
+			try {
+				for await (const _ of runClaudeCode(makeOptions())) {
+					// consume
+				}
+			} catch (err) {
+				thrownError = err as Error
+			}
+
+			expect(thrownError).to.not.be.undefined
+			expect(thrownError!.message).to.include("exited with code 1")
 		})
 	})
 })

--- a/src/integrations/claude-code/run.ts
+++ b/src/integrations/claude-code/run.ts
@@ -3,7 +3,6 @@ import fs from "node:fs/promises"
 import os from "node:os"
 import path from "node:path"
 import type Anthropic from "@anthropic-ai/sdk"
-import { execa } from "execa"
 import readline from "readline"
 import { Logger } from "@/shared/services/Logger"
 import { getCwd } from "@/utils/path"
@@ -23,6 +22,7 @@ type ProcessState = {
 	error: Error | null
 	stderrLogs: string
 	exitCode: number | null
+	seenMaxTurns: boolean
 }
 
 // The maximum argument length is longer than this,
@@ -42,7 +42,7 @@ export async function* runClaudeCode(options: ClaudeCodeOptions): AsyncGenerator
 		options.shouldUseFile = true
 	}
 
-	const cProcess = runProcess(options, await getCwd())
+	const cProcess = await runProcess(options, await getCwd())
 
 	const rl = readline.createInterface({
 		input: cProcess.stdout,
@@ -53,6 +53,7 @@ export async function* runClaudeCode(options: ClaudeCodeOptions): AsyncGenerator
 		stderrLogs: "",
 		exitCode: null,
 		partialData: null,
+		seenMaxTurns: false,
 	}
 
 	try {
@@ -80,6 +81,10 @@ export async function* runClaudeCode(options: ClaudeCodeOptions): AsyncGenerator
 					continue
 				}
 
+				if (chunk.type === "result" && chunk.subtype === "error_max_turns") {
+					processState.seenMaxTurns = true
+				}
+
 				yield chunk
 			}
 		}
@@ -91,7 +96,7 @@ export async function* runClaudeCode(options: ClaudeCodeOptions): AsyncGenerator
 		}
 
 		const { exitCode } = await cProcess
-		if (exitCode !== null && exitCode !== 0) {
+		if (exitCode !== null && exitCode !== 0 && !processState.seenMaxTurns) {
 			const errorOutput = processState.error?.message || processState.stderrLogs?.trim()
 			throw new Error(
 				`Claude Code process exited with code ${exitCode}.${errorOutput ? ` Error output: ${errorOutput}` : ""}`,
@@ -194,10 +199,11 @@ const BUFFER_SIZE = 20_000_000 // 20 MB
 // This is the limit imposed by the CLI
 const CLAUDE_CODE_MAX_OUTPUT_TOKENS = "32000"
 
-function runProcess(
+async function runProcess(
 	{ systemPrompt, messages, path, modelId, thinkingBudgetTokens, shouldUseFile }: ClaudeCodeOptions,
 	cwd: string,
 ) {
+	const { execa } = await import("execa")
 	const claudePath = path?.trim() || "claude"
 
 	const args = [

--- a/src/integrations/claude-code/run.ts
+++ b/src/integrations/claude-code/run.ts
@@ -106,6 +106,11 @@ export async function* runClaudeCode(options: ClaudeCodeOptions): AsyncGenerator
 			)
 		}
 	} catch (err) {
+		// Normal completion: CLI hit --max-turns 1 and exited with code 1.
+		// execa's default reject:true throws before the exit-code check above can run.
+		if (processState.seenMaxTurns) {
+			return
+		}
 		Logger.error(`Error during Claude Code execution:`, err)
 
 		if (processState.stderrLogs.includes("unknown option '--system-prompt-file'")) {

--- a/src/integrations/claude-code/run.ts
+++ b/src/integrations/claude-code/run.ts
@@ -15,6 +15,8 @@ type ClaudeCodeOptions = {
 	modelId: string
 	thinkingBudgetTokens?: number
 	shouldUseFile?: boolean
+	/** For testing only: inject a custom execa implementation */
+	_execa?: Awaited<typeof import("execa")>["execa"]
 }
 
 type ProcessState = {
@@ -42,7 +44,8 @@ export async function* runClaudeCode(options: ClaudeCodeOptions): AsyncGenerator
 		options.shouldUseFile = true
 	}
 
-	const cProcess = await runProcess(options, await getCwd())
+	const execa = options._execa ?? (await import("execa")).execa
+	const cProcess = runProcess(options, await getCwd(), execa)
 
 	const rl = readline.createInterface({
 		input: cProcess.stdout,
@@ -199,11 +202,11 @@ const BUFFER_SIZE = 20_000_000 // 20 MB
 // This is the limit imposed by the CLI
 const CLAUDE_CODE_MAX_OUTPUT_TOKENS = "32000"
 
-async function runProcess(
+function runProcess(
 	{ systemPrompt, messages, path, modelId, thinkingBudgetTokens, shouldUseFile }: ClaudeCodeOptions,
 	cwd: string,
+	execa: Awaited<typeof import("execa")>["execa"],
 ) {
-	const { execa } = await import("execa")
 	const claudePath = path?.trim() || "claude"
 
 	const args = [

--- a/src/integrations/claude-code/types.ts
+++ b/src/integrations/claude-code/types.ts
@@ -57,7 +57,7 @@ type ResultMessage = {
 	duration_ms: number
 	duration_api_ms: number
 	num_turns: number
-	result: string
+	result?: string
 	session_id: string
 }
 

--- a/src/test/requires.ts
+++ b/src/test/requires.ts
@@ -16,6 +16,16 @@ Module.prototype.require = function (path: string) {
 	if (path === "@integrations/checkpoints/MultiRootCheckpointManager") {
 		return { MultiRootCheckpointManager: class {} }
 	}
+	// unicorn-magic is a pure-ESM package with no CJS exports. tsx/cjs converts
+	// ESM node_modules to CJS, so require('unicorn-magic') fails with ERR_PACKAGE_PATH_NOT_EXPORTED.
+	// Provide a stub so the execa dependency chain doesn't break in tests.
+	if (path === "unicorn-magic") {
+		return {
+			toPath: (input: unknown) => (typeof input === "string" ? input : String(input)),
+			traversePathUp: (_path: string) => [],
+			delay: (_duration: unknown) => Promise.resolve(),
+		}
+	}
 
 	return originalRequire.call(this, path)
 }


### PR DESCRIPTION
## Summary

- **Root cause:** `createMessage` checked `chunk.type === "result" && "result" in chunk` before handling the final result chunk. Claude Code CLI v2.1+ omits the `result` string property on success (it only includes metadata like `total_cost_usd`), so `"result" in chunk` evaluated `false`, the handler was skipped, and the code fell through to `Logger.warn("Unrecognized Claude Code chunk type: result")` — causing every task to fail silently.
- **`error_max_turns` crash:** After removing the guard, `is_error: true` on `error_max_turns` chunks still threw. Added `chunk.subtype !== "error_max_turns"` exception so hitting `--max-turns 1` is treated as a normal completion, not an error.
- **Exit-code throw:** The CLI exits with code 1 on max-turns; a second throw fired. Fixed by tracking `seenMaxTurns` in `ProcessState` and skipping the exit-code check when set.

## Changes

- `src/integrations/claude-code/types.ts` — make `ResultMessage.result` optional (CLI v2.1+ omits it on success)
- `src/core/api/providers/claude-code.ts` — remove `"result" in chunk` guard; add `error_max_turns` exception; improve error message fallback; add `_runClaudeCode` DI option for testing
- `src/integrations/claude-code/run.ts` — track `seenMaxTurns`; suppress exit-code throw for `error_max_turns`; lazy-import `execa` to fix CJS loading in tests
- `src/core/workspace/WorkspaceRootManager.ts` — lazy-import `execa` (same CJS chain fix)
- `src/test/requires.ts` — stub `unicorn-magic` for `tsx/cjs` test runner (pure-ESM package with no CJS exports)
- `.mocharc.json` — switch from `ts-node/register` to `tsx/cjs` + `tsconfig-paths/register` (Node 22 compatibility)
- `src/core/api/providers/__tests__/claude-code.test.ts` — rewrite tests using dependency injection instead of sinon module stubs (esbuild CJS exports are non-configurable); add two new tests covering the bug fixes

## Test plan

- [x] All 17 `ClaudeCodeHandler` unit tests pass (`npm run test:unit`)
- [x] New test: "should yield usage when result chunk has no 'result' property (CLI v2.1+ success format)"
- [x] New test: "should not throw on error_max_turns and should yield usage (normal --max-turns 1 behaviour)"
- [x] Verified against Claude Code CLI v2.1.119 — tasks now complete successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)