### PR TITLE
fix: preserve multiline thinking blocks

### DIFF
--- a/webview-ui/src/components/chat/ThinkingRow.test.tsx
+++ b/webview-ui/src/components/chat/ThinkingRow.test.tsx
@@ -21,6 +21,17 @@ describe("ThinkingRow", () => {
 		expect(screen.getByText("Inspecting files...")).toBeInTheDocument()
 	})
 
+	it("allows expanded thinking content to preserve multiline formatting", () => {
+		render(<ThinkingRow isExpanded={true} isVisible={true} reasoningContent={"Step 1\nStep 2"} showTitle={true} />)
+
+		const reasoningContent = screen.getByText(/Step 1/, { selector: "span" })
+		expect(reasoningContent).toBeInTheDocument()
+		expect(reasoningContent.textContent).toBe("Step 1\nStep 2")
+		expect(reasoningContent.closest("div")).toHaveClass("whitespace-pre-wrap")
+		expect(reasoningContent.closest("button")).toHaveClass("whitespace-normal")
+		expect(reasoningContent.closest("button")).not.toHaveClass("whitespace-nowrap")
+	})
+
 	it("calls onToggle when header is clicked", () => {
 		const onToggle = vi.fn()
 

--- a/webview-ui/src/components/chat/ThinkingRow.tsx
+++ b/webview-ui/src/components/chat/ThinkingRow.tsx
@@ -89,7 +89,7 @@ export const ThinkingRow = memo(
 				{isExpanded && (
 					<Button
 						className={cn(
-							"flex gap-0 overflow-hidden w-full min-w-0 max-h-0 opacity-0 items-baseline justify-baseline text-left !p-0 !pl-0",
+							"flex gap-0 overflow-hidden whitespace-normal w-full min-w-0 max-h-0 opacity-0 items-baseline justify-baseline text-left !p-0 !pl-0",
 							"disabled:cursor-text disabled:opacity-100",
 							{
 								"max-h-[200px] opacity-100": isVisible,


### PR DESCRIPTION
### Related Issue

**Issue:** #7876

### Description

This keeps expanded thinking content from inheriting the shared button wrapper's `whitespace-nowrap` style.

- adds `whitespace-normal` to the expanded `ThinkingRow` wrapper so Claude Sonnet 4.5 reasoning content can wrap across lines again
- adds a regression test that checks the multiline content keeps its newline text and no longer sits inside a `whitespace-nowrap` button

### Test Procedure

- `cd webview-ui && npm test -- --run src/components/chat/ThinkingRow.test.tsx`
- `cd webview-ui && npx tsc -p tsconfig.json --noEmit`
- `cd webview-ui && npx @biomejs/biome check src/components/chat/ThinkingRow.tsx src/components/chat/ThinkingRow.test.tsx`

`biome check` still reports the existing informational `useExhaustiveDependencies` note on `ThinkingRow.tsx`, but there were no formatter or lint errors introduced by this change.

### Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ♻️ Refactor Changes
- [ ] 💅 Cosmetic Changes
- [ ] 📚 Documentation update
- [ ] 🏃 Workflow Changes

### Pre-flight Checklist

- [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
- [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
- [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Not included because this is a narrow style fix for existing thinking blocks, and the linked issue already shows the broken rendering.

### Additional Notes

I limited local verification to the affected webview component so this can stay small and low risk.
