### PR TITLE
Update: Deepseek reasoner check to include v4-pro

### DIFF
--- a/src/core/api/providers/deepseek.ts
+++ b/src/core/api/providers/deepseek.ts
@@ -81,7 +81,7 @@ export class DeepSeekHandler implements ApiHandler {
 		const client = this.ensureClient()
 		const model = this.getModel()
 
-		const isDeepseekReasoner = model.id.includes("deepseek-reasoner")
+		const isDeepseekReasoner = model.id.includes("deepseek-reasoner") || model.id.includes("deepseek-v4-pro")
 
 		const convertedMessages = convertToOpenAiMessages(messages)
 		const openAiMessages: OpenAI.Chat.ChatCompletionMessageParam[] = isDeepseekReasoner
@@ -95,7 +95,7 @@ export class DeepSeekHandler implements ApiHandler {
 			stream: true,
 			stream_options: { include_usage: true },
 			// Only set temperature for non-reasoner models
-			...(model.id === "deepseek-reasoner" ? {} : { temperature: 0 }),
+			...(isDeepseekReasoner ? {} : { temperature: 0 })
 			...getOpenAIToolParams(tools),
 		})
 


### PR DESCRIPTION
Description
This PR adds support for the new DeepSeek V4 models (deepseek-v4-flash and deepseek-v4-pro) to the Cline API integration.

Changes made:

Model definitions (deepseekModels):

Added deepseek-v4-flash and deepseek-v4-pro with their correct context window (1_000_000 for both), maximum output tokens (384_000), and official pricing (including the 75% promotional discount valid until 2026-05-05).

Set deepseek-v4-flash as the new default model.

Handler logic (DeepSeekHandler.ts):

Updated the reasoning model detection to recognize both deepseek-reasoner (legacy) and deepseek-v4-pro.

deepseek-v4-pro receives the same special treatment as the legacy reasoner: messages are formatted with addReasoningContent, and temperature is omitted.

deepseek-v4-flash is treated as a standard chat model (standard message formatting, temperature 0).

All models continue to emit usage and reasoning stream chunks correctly.

Backward compatibility:

The legacy deepseek-chat and deepseek-reasoner model IDs remain fully functional until their official deprecation date (July 24, 2026).

No breaking changes for existing users who are still using the old model names.

Why: DeepSeek recently released their V4 series with improved performance and pricing. Adding them allows Cline users to take advantage of these new capabilities (1M context, lower costs) while maintaining a smooth migration path from the legacy models.