### PR TITLE
fix: coerce MCP tool argument types

### DIFF
--- a/src/services/mcp/McpHub.ts
+++ b/src/services/mcp/McpHub.ts
@@ -190,13 +190,22 @@ function coerceStringWithSchema(value: string, schema: JsonSchema): unknown {
 		return undefined
 	}
 	if (types.has("boolean")) {
-		return coerceStringToBoolean(value)
+		const coerced = coerceStringToBoolean(value)
+		if (coerced !== undefined) {
+			return coerced
+		}
 	}
 	if (types.has("integer")) {
-		return coerceStringToNumber(value, true)
+		const coerced = coerceStringToNumber(value, true)
+		if (coerced !== undefined) {
+			return coerced
+		}
 	}
 	if (types.has("number")) {
-		return coerceStringToNumber(value, false)
+		const coerced = coerceStringToNumber(value, false)
+		if (coerced !== undefined) {
+			return coerced
+		}
 	}
 
 	return coerceStringToComposedSchema(value, schema)

--- a/src/services/mcp/McpHub.ts
+++ b/src/services/mcp/McpHub.ts
@@ -48,6 +48,191 @@ import { McpOAuthManager } from "./McpOAuthManager"
 import { StreamableHttpReconnectHandler } from "./StreamableHttpReconnectHandler"
 import { BaseConfigSchema, McpSettingsSchema, ServerConfigSchema } from "./schemas"
 import { McpConnection, McpServerConfig, Transport } from "./types"
+
+type JsonSchema = {
+	type?: unknown
+	properties?: Record<string, JsonSchema>
+	items?: JsonSchema | JsonSchema[]
+	const?: unknown
+	enum?: unknown
+	anyOf?: unknown
+	oneOf?: unknown
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+function coerceStringToBoolean(value: string): boolean | undefined {
+	if (value === "true") {
+		return true
+	}
+	if (value === "false") {
+		return false
+	}
+	return undefined
+}
+
+function coerceStringToNumber(value: string, requireInteger: boolean): number | undefined {
+	if (!/^-?(?:0|[1-9]\d*)(?:\.\d+)?(?:[eE][+-]?\d+)?$/.test(value)) {
+		return undefined
+	}
+
+	const numberValue = Number(value)
+	if (!Number.isFinite(numberValue)) {
+		return undefined
+	}
+
+	if (requireInteger && !Number.isInteger(numberValue)) {
+		return undefined
+	}
+
+	return numberValue
+}
+
+function coerceStringToLiteral(value: string, literal: unknown): unknown {
+	if (typeof literal === "boolean") {
+		return coerceStringToBoolean(value) === literal ? literal : undefined
+	}
+
+	if (typeof literal === "number") {
+		const coerced = coerceStringToNumber(value, Number.isInteger(literal))
+		return coerced === literal ? literal : undefined
+	}
+
+	return undefined
+}
+
+function coerceStringToEnum(value: string, enumValues: unknown[]): unknown {
+	const matchingValues = enumValues.filter((enumValue) => {
+		if (typeof enumValue === "string") {
+			return enumValue === value
+		}
+
+		return coerceStringToLiteral(value, enumValue) !== undefined
+	})
+
+	if (matchingValues.length !== 1 || typeof matchingValues[0] === "string") {
+		return undefined
+	}
+
+	return matchingValues[0]
+}
+
+function getSchemaBranches(branches: unknown): JsonSchema[] {
+	return Array.isArray(branches) ? branches.filter(isRecord) : []
+}
+
+function getSchemaTypes(schema: JsonSchema): Set<string> {
+	if (typeof schema.type === "string") {
+		return new Set([schema.type])
+	}
+
+	if (Array.isArray(schema.type)) {
+		return new Set(schema.type.filter((type): type is string => typeof type === "string"))
+	}
+
+	return new Set()
+}
+
+function schemaAllowsStringValue(value: string, schema: JsonSchema): boolean {
+	if (Object.hasOwn(schema, "const") && schema.const === value) {
+		return true
+	}
+
+	if (Array.isArray(schema.enum) && schema.enum.some((enumValue) => enumValue === value)) {
+		return true
+	}
+
+	return getSchemaTypes(schema).has("string")
+}
+
+function coerceStringToComposedSchema(value: string, schema: JsonSchema): unknown {
+	const matchingValues: unknown[] = []
+	let acceptsOriginalString = false
+
+	for (const branch of [...getSchemaBranches(schema.anyOf), ...getSchemaBranches(schema.oneOf)]) {
+		if (schemaAllowsStringValue(value, branch)) {
+			acceptsOriginalString = true
+			continue
+		}
+
+		const coerced = coerceStringWithSchema(value, branch)
+		if (coerced !== undefined && typeof coerced !== "string") {
+			matchingValues.push(coerced)
+		}
+	}
+
+	if (acceptsOriginalString || matchingValues.length !== 1) {
+		return undefined
+	}
+
+	return matchingValues[0]
+}
+
+function coerceStringWithSchema(value: string, schema: JsonSchema): unknown {
+	if (Object.hasOwn(schema, "const")) {
+		const coerced = coerceStringToLiteral(value, schema.const)
+		if (coerced !== undefined) {
+			return coerced
+		}
+	}
+
+	if (Array.isArray(schema.enum)) {
+		const coerced = coerceStringToEnum(value, schema.enum)
+		if (coerced !== undefined) {
+			return coerced
+		}
+	}
+
+	const types = getSchemaTypes(schema)
+	if (types.has("string")) {
+		return undefined
+	}
+	if (types.has("boolean")) {
+		return coerceStringToBoolean(value)
+	}
+	if (types.has("integer")) {
+		return coerceStringToNumber(value, true)
+	}
+	if (types.has("number")) {
+		return coerceStringToNumber(value, false)
+	}
+
+	return coerceStringToComposedSchema(value, schema)
+}
+
+function coerceValueForSchema(value: unknown, schema: JsonSchema): unknown {
+	if (typeof value === "string") {
+		return coerceStringWithSchema(value, schema) ?? value
+	}
+
+	if (Array.isArray(value) && schema.items && !Array.isArray(schema.items)) {
+		return value.map((item) => coerceValueForSchema(item, schema.items as JsonSchema))
+	}
+
+	if (isRecord(value) && schema.properties) {
+		return coerceMcpToolArguments(value, schema)
+	}
+
+	return value
+}
+
+function coerceMcpToolArguments(toolArguments: Record<string, unknown>, inputSchema: unknown): Record<string, unknown> {
+	if (!isRecord(inputSchema) || !isRecord(inputSchema.properties)) {
+		return toolArguments
+	}
+
+	const coercedArguments = { ...toolArguments }
+	for (const [name, propertySchema] of Object.entries(inputSchema.properties)) {
+		if (Object.hasOwn(coercedArguments, name) && isRecord(propertySchema)) {
+			coercedArguments[name] = coerceValueForSchema(coercedArguments[name], propertySchema)
+		}
+	}
+
+	return coercedArguments
+}
+
 export class McpHub {
 	getMcpServersPath: () => Promise<string>
 	private getSettingsDirectoryPath: () => Promise<string>
@@ -1257,13 +1442,16 @@ export class McpHub {
 			Logger.error(`Failed to parse timeout configuration for server ${serverName}: ${error}`)
 		}
 
+		const inputSchema = connection.server.tools?.find((tool) => tool.name === toolName)?.inputSchema
+		const requestArguments = toolArguments ? coerceMcpToolArguments(toolArguments, inputSchema) : undefined
+
 		this.telemetryService.captureMcpToolCall(
 			ulid,
 			serverName,
 			toolName,
 			"started",
 			undefined,
-			toolArguments ? Object.keys(toolArguments) : undefined,
+			requestArguments ? Object.keys(requestArguments) : undefined,
 		)
 
 		try {
@@ -1272,7 +1460,7 @@ export class McpHub {
 					method: "tools/call",
 					params: {
 						name: toolName,
-						arguments: toolArguments,
+						arguments: requestArguments,
 					},
 				},
 				CallToolResultSchema,
@@ -1287,7 +1475,7 @@ export class McpHub {
 				toolName,
 				"success",
 				undefined,
-				toolArguments ? Object.keys(toolArguments) : undefined,
+				requestArguments ? Object.keys(requestArguments) : undefined,
 			)
 
 			return {
@@ -1301,7 +1489,7 @@ export class McpHub {
 				toolName,
 				"error",
 				error instanceof Error ? error.message : String(error),
-				toolArguments ? Object.keys(toolArguments) : undefined,
+				requestArguments ? Object.keys(requestArguments) : undefined,
 			)
 			throw error
 		}

--- a/src/services/mcp/__tests__/McpHub.callTool.test.ts
+++ b/src/services/mcp/__tests__/McpHub.callTool.test.ts
@@ -1,0 +1,117 @@
+import { strict as assert } from "node:assert"
+import { describe, it } from "mocha"
+import sinon from "sinon"
+import { McpHub } from "../McpHub"
+
+function createHub(inputSchema: object) {
+	const request = sinon.stub().resolves({ content: [{ type: "text", text: "ok" }] })
+	const telemetry = {
+		captureMcpToolCall: sinon.stub(),
+	}
+	const hub = {
+		connections: [
+			{
+				server: {
+					name: "builder",
+					disabled: false,
+					config: JSON.stringify({ type: "sse", url: "http://localhost:3000", timeout: 5 }),
+					tools: [{ name: "edit", inputSchema }],
+				},
+				client: { request },
+			},
+		],
+		telemetryService: telemetry,
+	} as unknown as McpHub
+
+	return { hub, request }
+}
+
+describe("McpHub.callTool argument coercion", () => {
+	it("coerces JSON string values to schema-required number and boolean arguments", async () => {
+		const { hub, request } = createHub({
+			type: "object",
+			properties: {
+				location: { type: "integer" },
+				analyzeStructure: { type: "boolean" },
+				title: { type: "string" },
+				exactLocation: { const: 8 },
+				mode: { enum: [1, 2] },
+				literalLocation: { anyOf: [{ const: 0 }, { const: 1 }, { const: 8 }] },
+				literalFlag: { oneOf: [{ const: true }, { const: false }] },
+			},
+		})
+
+		await McpHub.prototype.callTool.call(
+			hub,
+			"builder",
+			"edit",
+			{
+				location: "8",
+				analyzeStructure: "true",
+				title: "8",
+				exactLocation: "8",
+				mode: "2",
+				literalLocation: "8",
+				literalFlag: "true",
+			},
+			"ulid-1",
+		)
+
+		assert.deepEqual(request.firstCall.args[0].params.arguments, {
+			location: 8,
+			analyzeStructure: true,
+			title: "8",
+			exactLocation: 8,
+			mode: 2,
+			literalLocation: 8,
+			literalFlag: true,
+		})
+	})
+
+	it("leaves invalid or ambiguous string values unchanged", async () => {
+		const { hub, request } = createHub({
+			type: "object",
+			properties: {
+				count: { type: "integer" },
+				flag: { type: "boolean" },
+				ambiguous: { enum: ["1", 1] },
+				malformedEnum: { enum: 1 },
+				stringOrInteger: { anyOf: [{ type: "string" }, { type: "integer" }] },
+				nested: {
+					type: "object",
+					properties: {
+						enabled: { type: "boolean" },
+					},
+				},
+			},
+		})
+
+		await McpHub.prototype.callTool.call(
+			hub,
+			"builder",
+			"edit",
+			{
+				count: "08",
+				flag: "TRUE",
+				ambiguous: "1",
+				malformedEnum: "1",
+				stringOrInteger: "8",
+				nested: {
+					enabled: "false",
+				},
+			},
+			"ulid-1",
+		)
+
+		assert.deepEqual(request.firstCall.args[0].params.arguments, {
+			count: "08",
+			flag: "TRUE",
+			ambiguous: "1",
+			malformedEnum: "1",
+			stringOrInteger: "8",
+			nested: {
+				enabled: false,
+			},
+		})
+	})
+})

--- a/src/services/mcp/__tests__/McpHub.callTool.test.ts
+++ b/src/services/mcp/__tests__/McpHub.callTool.test.ts
@@ -38,6 +38,7 @@ describe("McpHub.callTool argument coercion", () => {
 				mode: { enum: [1, 2] },
 				literalLocation: { anyOf: [{ const: 0 }, { const: 1 }, { const: 8 }] },
 				literalFlag: { oneOf: [{ const: true }, { const: false }] },
+				unionType: { type: ["boolean", "integer"] },
 			},
 		})
 
@@ -53,6 +54,7 @@ describe("McpHub.callTool argument coercion", () => {
 				mode: "2",
 				literalLocation: "8",
 				literalFlag: "true",
+				unionType: "1",
 			},
 			"ulid-1",
 		)
@@ -65,10 +67,11 @@ describe("McpHub.callTool argument coercion", () => {
 			mode: 2,
 			literalLocation: 8,
 			literalFlag: true,
+			unionType: 1,
 		})
 	})
 
-	it("leaves invalid or ambiguous string values unchanged", async () => {
+	it("leaves invalid or ambiguous values unchanged while coercing nested properties", async () => {
 		const { hub, request } = createHub({
 			type: "object",
 			properties: {


### PR DESCRIPTION
### Related Issue

**Issue:** #10203

### Description

Cline forwards MCP tool arguments to `tools/call` after parsing the model-provided input. For tools whose MCP input schema requires numeric or boolean values, strict servers can reject string values such as `"8"` or `"true"` before running the tool.

This change coerces only unambiguous string arguments at the MCP call boundary using the connected tool input schema. It covers numeric/boolean `type`, numeric/boolean `const`, numeric/boolean `enum`, and literal `anyOf`/`oneOf` branches. Values stay unchanged when the schema accepts strings or the match is ambiguous, invalid, or malformed.

### Test Procedure

- Added a focused `McpHub.callTool` regression test for numeric, boolean, `const`, `enum`, `anyOf`/`oneOf`, ambiguous, invalid, malformed enum, and nested-object cases.
- Ran `npm test` (pretest compile/check-types/lint/standalone build, unit tests, and VS Code integration tests all passed).
- Ran `npm run format`.
- Ran `npm run lint`.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A; backend MCP call payload fix.

### Additional Notes

None.
