### PR TITLE
fix: emit mistake_limit_reached in SDK path after consecutive tool failures

### DIFF
--- a/src/sdk/message-translator.ts
+++ b/src/sdk/message-translator.ts
@@ -46,6 +46,10 @@ export interface TranslationResult {
 	sessionEnded: boolean
 	/** Whether the agent turn is complete */
 	turnComplete: boolean
+	/** Whether a tool call ended with an error (content_end with event.error) */
+	toolError?: boolean
+	/** Whether a tool call ended successfully (content_end without error) */
+	toolSuccess?: boolean
 	/** Usage info if available */
 	usage?: {
 		tokensIn: number
@@ -1025,6 +1029,17 @@ export function translateSessionEvent(event: CoreSessionEvent, state: MessageTra
 			}
 			if (event.payload.event.type === "error") {
 				result.turnComplete = true
+			}
+
+			// Track tool success/error for consecutive mistake counting.
+			// A content_end event with contentType "tool" signals a completed
+			// tool call — if event.error is set, the tool failed.
+			if (event.payload.event.type === "content_end" && event.payload.event.contentType === "tool") {
+				if (event.payload.event.error) {
+					result.toolError = true
+				} else {
+					result.toolSuccess = true
+				}
 			}
 
 			// Extract usage from usage events

--- a/src/sdk/sdk-session-event-coordinator.ts
+++ b/src/sdk/sdk-session-event-coordinator.ts
@@ -2,7 +2,7 @@ import type { CoreSessionEvent } from "@clinebot/core"
 import { refreshClineRecommendedModels } from "@/core/controller/models/refreshClineRecommendedModels"
 import type { StateManager } from "@/core/storage/StateManager"
 import { CLINE_RECOMMENDED_MODELS_FALLBACK } from "@/shared/cline/recommended-models"
-import type { ClineApiReqInfo } from "@/shared/ExtensionMessage"
+import type { ClineApiReqInfo, ClineMessage } from "@/shared/ExtensionMessage"
 import { Logger } from "@/shared/services/Logger"
 import type { MessageTranslatorState, TranslationResult } from "./message-translator"
 import { translateSessionEvent } from "./message-translator"
@@ -34,8 +34,16 @@ export interface SdkSessionEventCoordinatorOptions {
 export class SdkSessionEventCoordinator {
 	private readonly translateSessionEvent: (event: CoreSessionEvent, state: MessageTranslatorState) => TranslationResult
 
+	/** Tracks consecutive tool errors for mistake_limit_reached detection */
+	private consecutiveToolErrorCount = 0
+
 	constructor(private readonly options: SdkSessionEventCoordinatorOptions) {
 		this.translateSessionEvent = options.translateSessionEvent ?? translateSessionEvent
+	}
+
+	/** Reset the consecutive tool error counter (e.g. when a new task starts or user responds) */
+	resetConsecutiveToolErrorCount(): void {
+		this.consecutiveToolErrorCount = 0
 	}
 
 	async handleSessionEvent(event: CoreSessionEvent): Promise<void> {
@@ -53,6 +61,11 @@ export class SdkSessionEventCoordinator {
 				(m) => !(m.type === "ask" && (m.ask === "completion_result" || m.ask === "resume_completed_task")),
 			)
 		}
+
+		// Track consecutive tool errors and emit mistake_limit_reached when threshold is met.
+		// This mirrors the classic Task.recursivelyMakeClineRequests() behavior where
+		// consecutiveMistakeCount is checked against maxConsecutiveMistakes.
+		this.trackToolErrors(result)
 
 		if (result.messages.length > 0) {
 			this.options.messages.appendAndEmit(result.messages, event)
@@ -82,6 +95,51 @@ export class SdkSessionEventCoordinator {
 			this.options.postStateToWebview().catch((err) => {
 				Logger.error("[SdkController] Failed to post state after event:", err)
 			})
+		}
+	}
+
+	/**
+	 * Track consecutive tool errors. When the count reaches maxConsecutiveMistakes,
+	 * append an ask="mistake_limit_reached" message so the webview shows
+	 * "Proceed Anyways" / "Start New Task" buttons instead of tool approval buttons.
+	 */
+	private trackToolErrors(result: TranslationResult): void {
+		if (result.toolSuccess) {
+			// A tool succeeded — reset the consecutive error counter
+			this.consecutiveToolErrorCount = 0
+		}
+
+		if (result.toolError) {
+			this.consecutiveToolErrorCount++
+
+			const stateManager = this.options.stateManager
+			const maxConsecutiveMistakes = stateManager ? stateManager.getGlobalSettingsKey("maxConsecutiveMistakes") : 3 // default fallback
+
+			if (this.consecutiveToolErrorCount >= maxConsecutiveMistakes) {
+				Logger.log(
+					`[SdkController] Consecutive tool error count (${this.consecutiveToolErrorCount}) reached limit (${maxConsecutiveMistakes}), emitting mistake_limit_reached`,
+				)
+
+				// Determine the model-specific guidance message (mirrors classic Task behavior)
+				const modelId = this.getCurrentClineModelId() ?? ""
+				const guidanceMessage = modelId.includes("claude")
+					? `This may indicate a failure in Cline's thought process or inability to use a tool properly, which can be mitigated with some user guidance (e.g. "Try breaking down the task into smaller steps").`
+					: "Cline uses complex prompts and iterative task execution that may be challenging for less capable models. For best results, it's recommended to use Claude 4.5 Sonnet for its advanced agentic coding capabilities."
+
+				// Emit ask="mistake_limit_reached" message so the webview updates buttons
+				const mistakeLimitMessage: ClineMessage = {
+					ts: this.options.messageTranslatorState.nextTs(),
+					type: "ask",
+					ask: "mistake_limit_reached",
+					text: guidanceMessage,
+					partial: false,
+				}
+
+				result.messages.push(mistakeLimitMessage)
+
+				// Reset the counter after emitting so it can trigger again if the user continues
+				this.consecutiveToolErrorCount = 0
+			}
 		}
 	}
 


### PR DESCRIPTION
### Related Issue

**Issue:** [ENG-1874](https://linear.app/cline-bot/issue/ENG-1874/after-6-tool-failures-we-dont-update-ui-buttons-to-retry)

### Description

Fixes the bug where after reaching the consecutive tool failure limit (`maxConsecutiveMistakes`, default 3), the UI buttons do NOT update from **Approve/Reject** to **Proceed Anyways/Start New Task**.

#### Root Cause

The SDK execution path was missing consecutive tool error tracking that the classic Task class provides. In the classic extension:

1. Tool handlers (e.g., `WriteToFileToolHandler`) increment `consecutiveMistakeCount` on `TaskState` when tools fail
2. At the top of `recursivelyMakeClineRequests()`, if `consecutiveMistakeCount >= maxConsecutiveMistakes`, it calls `ask("mistake_limit_reached", ...)`
3. This adds a `ClineMessage` of type `ask` with `ask="mistake_limit_reached"` to the message list
4. The webview picks this up and shows "Proceed Anyways" / "Start New Task" buttons

In the SDK path, **none of this existed**:
- The SDK agent handles tool execution internally
- Tool errors show up as `content_end` events with `event.error` set
- The `message-translator.ts` translated these to `say="error"` messages
- But there was **NO tracking of consecutive mistakes** and **NO emission of `ask="mistake_limit_reached"`**

#### Changes

**`src/sdk/message-translator.ts`**
- Added `toolError` and `toolSuccess` boolean fields to `TranslationResult` interface
- In `translateSessionEvent()`, detects `content_end` events for tools and sets `toolError=true` when `event.error` is present, or `toolSuccess=true` when the tool succeeds

**`src/sdk/sdk-session-event-coordinator.ts`**
- Added `consecutiveToolErrorCount` private field to track consecutive tool errors
- Added `resetConsecutiveToolErrorCount()` public method for counter reset
- Added `trackToolErrors()` private method that:
  - Resets counter on tool success
  - Increments counter on tool error
  - When count reaches `maxConsecutiveMistakes` (from settings, default 3), emits an `ask="mistake_limit_reached"` ClineMessage with model-specific guidance text (mirrors classic Task behavior)
  - Resets the counter after emitting so it can re-trigger if the user continues

**Frontend (no changes needed)**
The webview already handles `mistake_limit_reached` correctly:
- `buttonConfig.ts` has the correct config (`primaryText: "Proceed Anyways"`, `secondaryText: "Start New Task"`)
- `getButtonConfig()` has the case for `mistake_limit_reached`
- `errorTypes` array includes it, ensuring it's not blocked by the streaming check

### Test Procedure

- TypeScript compilation (`npx tsc --noEmit`) passes cleanly with zero errors
- Verified that the `mistake_limit_reached` button config is already correct in the webview (`buttonConfig.ts` line 42-49)
- Verified that `getButtonConfig()` properly routes `mistake_limit_reached` to the correct button config (line 242-243)
- Verified that the `errorTypes` array includes `mistake_limit_reached`, ensuring it bypasses the streaming check (line 210)
- The fix replicates the same behavior as the classic `Task.recursivelyMakeClineRequests()` method (lines 2357-2415 in `src/core/task/index.ts`)

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Additional Notes

This PR targets the `dpc/sdk-migration-simpler-login` branch since the bug is specific to the SDK execution path.
