### PR TITLE
Add SDK checkpoint support

### DIFF
--- a/src/core/controller/worktree/deleteWorktree.ts
+++ b/src/core/controller/worktree/deleteWorktree.ts
@@ -34,14 +34,27 @@ export async function deleteWorktree(_controller: Controller, request: DeleteWor
 			})
 		}
 
-		// Clean up checkpoint data (shadow git repo) for the deleted worktree
+		// Clean up checkpoint data for the deleted worktree:
+		// 1. Legacy shadow git cleanup (for tasks created before ref-based checkpoints)
 		try {
 			const cwdHash = hashWorkingDir(request.path)
 			const checkpointDir = path.join(HostProvider.get().globalStorageFsPath, "checkpoints", cwdHash)
 			await rm(checkpointDir, { recursive: true, force: true })
 		} catch (error) {
-			// Log but don't fail - checkpoint cleanup is best-effort
-			Logger.log(`Failed to cleanup checkpoints for deleted worktree: ${error}`)
+			Logger.log(`Failed to cleanup legacy checkpoints for deleted worktree: ${error}`)
+		}
+
+		// 2. Ref-based checkpoint cleanup (delete refs/cline/checkpoints/* in the worktree's repo)
+		try {
+			const { RefCheckpointTracker } = await import("@/integrations/checkpoints/RefCheckpointTracker")
+			// Get all task IDs that had checkpoints in this worktree
+			const git = simpleGit(cwd)
+			const refs = await git.raw(["for-each-ref", "--format=%(refname)", "refs/cline/checkpoints/"])
+			for (const ref of refs.split("\n").filter(Boolean)) {
+				await git.raw(["update-ref", "-d", ref]).catch(() => {})
+			}
+		} catch (error) {
+			Logger.log(`Failed to cleanup ref-based checkpoints for deleted worktree: ${error}`)
 		}
 
 		// Delete the branch if requested

--- a/src/integrations/checkpoints/RefCheckpointTracker.ts
+++ b/src/integrations/checkpoints/RefCheckpointTracker.ts
@@ -1,0 +1,356 @@
+/**
+ * RefCheckpointTracker — Git plumbing-based checkpoint tracker for the SDK migration.
+ *
+ * Uses the user's workspace .git repo directly (no shadow git) with synthetic
+ * commits stored under custom refs: refs/cline/checkpoints/<taskId>/turn/<seq>
+ *
+ * Checkpoints form their own commit chain — each checkpoint's parent is the
+ * previous checkpoint commit for that task. The first checkpoint's parent is
+ * HEAD at task-start time.
+ */
+
+import { execFile } from "node:child_process"
+import * as fs from "node:fs/promises"
+import * as os from "node:os"
+import * as path from "node:path"
+import { promisify } from "node:util"
+import { isBinaryFile } from "isbinaryfile"
+import { Logger } from "@/shared/services/Logger"
+
+const execFileAsync = promisify(execFile)
+
+const GIT_AUTHOR_NAME = "Cline Checkpoints"
+const GIT_AUTHOR_EMAIL = "checkpoints@cline.bot"
+const MAX_BUFFER = 10 * 1024 * 1024
+
+export class RefCheckpointTracker {
+	private readonly taskId: string
+	private readonly repoRoot: string
+	private sequenceNumber = 0
+	private previousCheckpointCommit: string | undefined
+
+	private constructor(taskId: string, repoRoot: string) {
+		this.taskId = taskId
+		this.repoRoot = repoRoot
+	}
+
+	public static async create(
+		taskId: string,
+		enableCheckpoints: boolean,
+		workspaceRoot: string,
+	): Promise<RefCheckpointTracker | undefined> {
+		if (!enableCheckpoints) {
+			Logger.info(`[RefCheckpointTracker] Checkpoints disabled for task ${taskId}`)
+			return undefined
+		}
+
+		try {
+			await execFileAsync("git", ["--version"], { timeout: 5000 })
+		} catch {
+			Logger.warn("[RefCheckpointTracker] Git not available — checkpoints disabled")
+			return undefined
+		}
+
+		let repoRoot: string
+		try {
+			const { stdout } = await execFileAsync("git", ["rev-parse", "--show-toplevel"], {
+				cwd: workspaceRoot,
+				timeout: 5000,
+			})
+			repoRoot = stdout.trim()
+		} catch {
+			Logger.info(`[RefCheckpointTracker] Not a git repo: ${workspaceRoot} — skipping`)
+			return undefined
+		}
+
+		Logger.info(`[RefCheckpointTracker] Created for task ${taskId} in ${repoRoot}`)
+		return new RefCheckpointTracker(taskId, repoRoot)
+	}
+
+	/**
+	 * Create a checkpoint commit capturing the current workspace state.
+	 * Uses a temp index file so the user's real index is never modified.
+	 */
+	public async commit(): Promise<string | undefined> {
+		let tempDir: string | undefined
+
+		try {
+			const startTime = performance.now()
+			tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "cline-cp-"))
+			const tempIndex = path.join(tempDir, "index")
+
+			const gitEnv: Record<string, string> = {
+				...process.env,
+				GIT_INDEX_FILE: tempIndex,
+				GIT_AUTHOR_NAME,
+				GIT_AUTHOR_EMAIL,
+				GIT_COMMITTER_NAME: GIT_AUTHOR_NAME,
+				GIT_COMMITTER_EMAIL: GIT_AUTHOR_EMAIL,
+			} as Record<string, string>
+
+			// Read source tree into temp index (previous checkpoint or HEAD)
+			const readTreeSource = this.previousCheckpointCommit ?? (await this.getHeadCommit())
+			if (readTreeSource) {
+				await execFileAsync("git", ["read-tree", readTreeSource], {
+					cwd: this.repoRoot,
+					env: gitEnv,
+					maxBuffer: MAX_BUFFER,
+				})
+			}
+
+			// Stage all working tree files into temp index
+			await execFileAsync("git", ["add", "-A", "--", "."], {
+				cwd: this.repoRoot,
+				env: gitEnv,
+				maxBuffer: MAX_BUFFER,
+			})
+
+			// Write tree object from temp index
+			const { stdout: treeHash } = await execFileAsync("git", ["write-tree"], {
+				cwd: this.repoRoot,
+				env: gitEnv,
+			})
+			const tree = treeHash.trim()
+
+			// Create commit-tree with parent
+			this.sequenceNumber++
+			const message = `checkpoint ${this.taskId} turn ${this.sequenceNumber}`
+			const commitArgs = ["commit-tree", tree, "-m", message]
+
+			const parent = this.previousCheckpointCommit ?? (await this.getHeadCommit())
+			if (parent) {
+				commitArgs.push("-p", parent)
+			}
+
+			const { stdout: commitOut } = await execFileAsync("git", commitArgs, {
+				cwd: this.repoRoot,
+				env: gitEnv,
+			})
+			const commit = commitOut.trim()
+
+			// Update ref
+			const refName = `refs/cline/checkpoints/${this.taskId}/turn/${this.sequenceNumber}`
+			await execFileAsync("git", ["update-ref", refName, commit], {
+				cwd: this.repoRoot,
+			})
+
+			this.previousCheckpointCommit = commit
+
+			const durationMs = Math.round(performance.now() - startTime)
+			Logger.info(`[RefCheckpointTracker] Checkpoint #${this.sequenceNumber}: ${commit} (${durationMs}ms)`)
+			return commit
+		} catch (error) {
+			Logger.error("[RefCheckpointTracker] Failed to create checkpoint:", error)
+			return undefined
+		} finally {
+			if (tempDir) {
+				await fs.rm(tempDir, { recursive: true, force: true }).catch(() => {})
+			}
+		}
+	}
+
+	/**
+	 * Restore the workspace to a checkpoint's state.
+	 * Deletes files created after the checkpoint, then restores all checkpoint files.
+	 */
+	public async restore(commitHash: string): Promise<void> {
+		try {
+			const startTime = performance.now()
+			const hash = this.cleanCommitHash(commitHash)
+			Logger.info(`[RefCheckpointTracker] Restoring to checkpoint: ${hash}`)
+
+			// Find untracked files that wouldn't show in git diff
+			const { stdout: untrackedFiles } = await execFileAsync("git", ["ls-files", "--others", "--exclude-standard"], {
+				cwd: this.repoRoot,
+				maxBuffer: MAX_BUFFER,
+			}).catch(() => ({ stdout: "" }))
+
+			// Delete untracked files that don't exist in the checkpoint
+			for (const file of untrackedFiles.split("\n").filter(Boolean)) {
+				try {
+					await execFileAsync("git", ["cat-file", "-e", `${hash}:${file}`], { cwd: this.repoRoot })
+				} catch {
+					await fs.rm(path.join(this.repoRoot, file), { force: true }).catch(() => {})
+				}
+			}
+
+			// Restore all checkpoint files to the working tree
+			await execFileAsync("git", ["restore", `--source=${hash}`, "--worktree", "--", "."], {
+				cwd: this.repoRoot,
+				maxBuffer: MAX_BUFFER,
+			})
+
+			const durationMs = Math.round(performance.now() - startTime)
+			Logger.info(`[RefCheckpointTracker] Restored to ${hash} (${durationMs}ms)`)
+		} catch (error) {
+			Logger.error("[RefCheckpointTracker] Failed to restore checkpoint:", error)
+			throw error
+		}
+	}
+
+	/** Get changed files between two commits, or between a commit and working dir. */
+	public async getDiffSet(
+		lhsHash: string,
+		rhsHash?: string,
+	): Promise<Array<{ relativePath: string; absolutePath: string; before: string; after: string }>> {
+		try {
+			const cleanLhs = this.cleanCommitHash(lhsHash)
+			const cleanRhs = rhsHash ? this.cleanCommitHash(rhsHash) : undefined
+
+			const diffArgs = ["diff", "--name-status"]
+			if (cleanRhs) {
+				diffArgs.push(`${cleanLhs}..${cleanRhs}`)
+			} else {
+				diffArgs.push(cleanLhs)
+			}
+
+			const { stdout } = await execFileAsync("git", diffArgs, {
+				cwd: this.repoRoot,
+				maxBuffer: MAX_BUFFER,
+			})
+
+			const result: Array<{ relativePath: string; absolutePath: string; before: string; after: string }> = []
+
+			for (const line of stdout.split("\n").filter(Boolean)) {
+				const [_status, ...pathParts] = line.split("\t")
+				const filePath = pathParts.join("\t")
+				if (!filePath) continue
+
+				const absolutePath = path.join(this.repoRoot, filePath)
+
+				// Skip binary files for extensionless/dotfiles
+				const lastDot = filePath.lastIndexOf(".")
+				const lastSlash = Math.max(filePath.lastIndexOf("/"), filePath.lastIndexOf("\\"))
+				const ext = lastDot > lastSlash ? filePath.substring(lastDot).toLowerCase() : ""
+				const isDotfile = lastDot !== -1 && lastDot === lastSlash + 1
+				if (!ext || isDotfile) {
+					try {
+						if (await isBinaryFile(absolutePath).catch(() => false)) continue
+					} catch {
+						continue
+					}
+				}
+
+				let before = ""
+				try {
+					const { stdout: c } = await execFileAsync("git", ["show", `${cleanLhs}:${filePath}`], {
+						cwd: this.repoRoot,
+						maxBuffer: MAX_BUFFER,
+					})
+					before = c
+				} catch {
+					/* file didn't exist */
+				}
+
+				let after = ""
+				if (cleanRhs) {
+					try {
+						const { stdout: c } = await execFileAsync("git", ["show", `${cleanRhs}:${filePath}`], {
+							cwd: this.repoRoot,
+							maxBuffer: MAX_BUFFER,
+						})
+						after = c
+					} catch {
+						/* file doesn't exist */
+					}
+				} else {
+					try {
+						after = await fs.readFile(absolutePath, "utf8")
+					} catch {
+						/* deleted */
+					}
+				}
+
+				result.push({ relativePath: filePath, absolutePath, before, after })
+			}
+
+			return result
+		} catch (error) {
+			Logger.error("[RefCheckpointTracker] getDiffSet failed:", error)
+			return []
+		}
+	}
+
+	/** Get count of changed files between two commits. */
+	public async getDiffCount(lhsHash: string, rhsHash?: string): Promise<number> {
+		try {
+			const cleanLhs = this.cleanCommitHash(lhsHash)
+			const cleanRhs = rhsHash ? this.cleanCommitHash(rhsHash) : undefined
+			const diffArgs = ["diff", "--name-only"]
+			if (cleanRhs) {
+				diffArgs.push(`${cleanLhs}..${cleanRhs}`)
+			} else {
+				diffArgs.push(cleanLhs)
+			}
+			const { stdout } = await execFileAsync("git", diffArgs, {
+				cwd: this.repoRoot,
+				maxBuffer: MAX_BUFFER,
+			})
+			return stdout.split("\n").filter(Boolean).length
+		} catch (error) {
+			Logger.error("[RefCheckpointTracker] getDiffCount failed:", error)
+			return 0
+		}
+	}
+
+	/** Delete all refs for this task. Git gc handles unreferenced objects. */
+	public async cleanupRefs(): Promise<void> {
+		try {
+			const { stdout } = await execFileAsync(
+				"git",
+				["for-each-ref", "--format=%(refname)", `refs/cline/checkpoints/${this.taskId}/`],
+				{ cwd: this.repoRoot },
+			)
+			const refs = stdout.split("\n").filter(Boolean)
+			for (const ref of refs) {
+				await execFileAsync("git", ["update-ref", "-d", ref], { cwd: this.repoRoot }).catch(() => {})
+			}
+			Logger.info(`[RefCheckpointTracker] Cleaned up ${refs.length} refs for task ${this.taskId}`)
+		} catch (error) {
+			Logger.error("[RefCheckpointTracker] cleanupRefs failed:", error)
+		}
+	}
+
+	/** Static cleanup for when the tracker instance is unavailable. */
+	public static async cleanupRefsForTask(taskId: string, workspaceRoot: string): Promise<void> {
+		try {
+			let repoRoot: string
+			try {
+				const { stdout } = await execFileAsync("git", ["rev-parse", "--show-toplevel"], {
+					cwd: workspaceRoot,
+					timeout: 5000,
+				})
+				repoRoot = stdout.trim()
+			} catch {
+				return // Not a git repo
+			}
+			const { stdout } = await execFileAsync(
+				"git",
+				["for-each-ref", "--format=%(refname)", `refs/cline/checkpoints/${taskId}/`],
+				{ cwd: repoRoot },
+			)
+			const refs = stdout.split("\n").filter(Boolean)
+			for (const ref of refs) {
+				await execFileAsync("git", ["update-ref", "-d", ref], { cwd: repoRoot }).catch(() => {})
+			}
+			if (refs.length > 0) {
+				Logger.info(`[RefCheckpointTracker] Cleaned up ${refs.length} refs for task ${taskId}`)
+			}
+		} catch (error) {
+			Logger.warn("[RefCheckpointTracker] Static cleanup failed (non-fatal):", error)
+		}
+	}
+
+	private async getHeadCommit(): Promise<string | undefined> {
+		try {
+			const { stdout } = await execFileAsync("git", ["rev-parse", "HEAD"], { cwd: this.repoRoot })
+			return stdout.trim() || undefined
+		} catch {
+			return undefined
+		}
+	}
+
+	private cleanCommitHash(hash: string): string {
+		return hash.startsWith("HEAD ") ? hash.slice(5) : hash
+	}
+}

--- a/src/integrations/checkpoints/SDK_CHECKPOINT_PLAN.md
+++ b/src/integrations/checkpoints/SDK_CHECKPOINT_PLAN.md
@@ -1,0 +1,91 @@
+# SDK Checkpoint System — Implementation Plan
+
+Ref-based checkpoint system for the SDK-migrated Cline extension. Uses synthetic Git commits under custom refs in the user's workspace repo, replacing the old shadow-git approach.
+
+## Design Decisions
+
+1. Use the user's workspace `.git` repo — no shadow git repos, no `~/.cline/data/checkpoints/` directory. Non-git workspaces do NOT get checkpoint support (gracefully skip/disable).
+2. Ref naming: `refs/cline/checkpoints/<taskId>/turn/<sequenceNumber>`
+3. Checkpoints form their own commit chain — each checkpoint's parent is the previous checkpoint commit for that task. The first checkpoint's parent is HEAD at task-start time.
+4. Metadata stays on ClineMessage — `lastCheckpointHash` on ClineMessage objects is the source of truth for mapping messages to checkpoint commits. The webview already reads this field.
+5. No workspace mutation lock — disable restore UI buttons while agent is running. Keep the existing cancel-before-restore pattern.
+6. Checkpoints are created when a **user submits a follow-up message** (not on every tool execution). Only user messages have the "restore to checkpoint" option.
+
+## Implementation Checklist
+
+### New Files
+
+- [x] `src/integrations/checkpoints/RefCheckpointTracker.ts` — Git plumbing-based tracker
+  - Uses `child_process.execFile` with `GIT_INDEX_FILE` env overrides
+  - `create()` — validates git repo, gracefully skips non-git workspaces
+  - `commit()` — temp index → `git add -A` → `git write-tree` → `git commit-tree` → `git update-ref`
+  - `restore()` — deletes untracked files not in checkpoint, then `git restore --source=<hash> --worktree -- .`
+  - `getDiffSet()` / `getDiffCount()` — `git diff --name-status` / `--name-only`
+  - `cleanupRefs()` / `cleanupRefsForTask()` — `git for-each-ref` + `git update-ref -d`
+
+- [x] `src/integrations/checkpoints/SdkCheckpointManager.ts` — Lean manager implementing `ICheckpointManager`
+  - Lazy-inits `RefCheckpointTracker` on first use (promise-based dedup)
+  - `commit()` — creates checkpoint, writes `lastCheckpointHash` onto latest `checkpoint_created` ClineMessage
+  - `saveCheckpoint()` — delegates to `commit()`, handles completion messages
+  - `restoreCheckpoint()` — uses tracker's `restore()` for workspace restores, supports offset-based message lookup
+  - `doesLatestTaskCompletionHaveNewChanges()` — checks diff count between previous and current completion
+
+### Modified Files
+
+- [x] `src/sdk/task-proxy.ts` — Wire `checkpointManager` property + message truncation
+  - Changed from `any` stub returning `undefined` to `ICheckpointManager | undefined` with getter/setter
+  - Added `currentCheckpointManager` mutable state
+  - Added `setMessages()` to `MessageStateHandler` for checkpoint restore truncation
+
+- [x] `src/sdk/SdkController.ts` — Initialize checkpoint manager on task creation
+  - Added `initCheckpointManager(task)` private method
+  - Wired into `taskControl.setTask` callback (fires when task proxy is created)
+  - Reads `enableCheckpointsSetting` from StateManager
+
+- [x] `src/sdk/sdk-followup-coordinator.ts` — Checkpoint save on user message
+  - Added `saveCheckpointOnUserMessage()` private method
+  - Called in `askResponse()` **before** `emitUserFeedback()` so `checkpoint_created` appears before `user_feedback` in the message array (the UserMessage "edit & restore" UI sends `offset: 1` which subtracts from the user_feedback index)
+  - Emits `checkpoint_created` ClineMessage, then fire-and-forget `saveCheckpoint()`
+
+- [x] `webview-ui/src/components/common/CheckmarkControl.tsx` — Disable restore while running
+  - Added `isAgentRunning?: boolean` prop
+  - "Restore" button disabled with `not-allowed` cursor and tooltip when agent is running
+
+- [x] `webview-ui/src/components/chat/UserMessage.tsx` — Disable restore while running
+  - Added `isAgentRunning?: boolean` prop and `disabled?: boolean` on `RestoreButtonProps`
+  - "Restore All" and "Restore Chat" buttons disabled when agent is running
+
+- [x] `webview-ui/src/components/chat/ChatRow.tsx` — Pass running state to checkpoint UI
+  - Passes `isAgentRunning={isRequestInProgress}` to `CheckmarkControl` and `UserMessage`
+
+- [x] `src/core/controller/worktree/deleteWorktree.ts` — Cleanup refs on worktree deletion
+  - Added ref-based checkpoint cleanup (`refs/cline/checkpoints/*`) alongside legacy shadow-git cleanup
+
+### Not Modified (by design)
+
+- [ ] `src/integrations/checkpoints/types.ts` — `ICheckpointManager` interface unchanged
+- [ ] `src/core/controller/checkpoints/checkpointRestore.ts` — works unchanged via `controller.task?.checkpointManager?.restoreCheckpoint(...)`
+
+### Bug Fixes
+
+- [x] `src/integrations/checkpoints/SdkCheckpointManager.ts` — Session invalidation on restore
+  - Added `onSessionInvalidated` callback option
+  - On "task" or "taskAndWorkspace" restore: saves truncated messages to disk, then tears down the active SDK session via the callback
+  - Without this, the LLM's conversation history still contained deleted messages after restore (assistant "remembered" things from after the checkpoint)
+
+- [x] `src/sdk/SdkController.ts` — Wire `onSessionInvalidated` in `initCheckpointManager`
+  - Clears the active session reference, unsubscribes, stops, and disposes the session manager
+  - The next `askResponse()` sees `!activeSession` and goes through `tryResumeSessionFromTask` which loads the truncated history from disk
+
+- [x] `src/sdk/sdk-followup-coordinator.ts` — Fix session resume condition
+  - Changed `(!activeSession || !activeSession.isRunning) && task` → `!activeSession && task`
+  - After a turn completes, `isRunning` is `false` but the session is still alive. The old check incorrectly tore down and recreated the session on every follow-up, bypassing checkpoints and wasting resources.
+  - Now only resumes when the session is truly gone (disposed after MCP reload, mode switch, etc.)
+
+### Not Yet Implemented
+
+- [ ] Checkpoint save on initial task creation (blocked: checkpoint manager init is async, not ready in time)
+- [ ] `presentMultifileDiff` support in `SdkCheckpointManager` (optional method on `ICheckpointManager`)
+- [ ] Persist checkpoint messages to disk after commit hash writeback (currently in-memory only until next message save)
+- [ ] Telemetry for checkpoint operations (commit duration, restore duration, etc.)
+- [ ] Unit tests for `RefCheckpointTracker` and `SdkCheckpointManager`

--- a/src/integrations/checkpoints/SdkCheckpointManager.ts
+++ b/src/integrations/checkpoints/SdkCheckpointManager.ts
@@ -1,0 +1,207 @@
+/**
+ * SdkCheckpointManager — Lean checkpoint manager for SDK-migrated tasks.
+ *
+ * Implements ICheckpointManager using RefCheckpointTracker (git plumbing
+ * with custom refs in the user's workspace repo).
+ */
+
+import { findLast, findLastIndex } from "@shared/array"
+import type { ClineMessage } from "@shared/ExtensionMessage"
+import { Logger } from "@shared/services/Logger"
+import { RefCheckpointTracker } from "./RefCheckpointTracker"
+import type { ICheckpointManager } from "./types"
+
+/** Minimal interface for reading/writing ClineMessages. */
+export interface SdkCheckpointMessageAccess {
+	getClineMessages(): ClineMessage[]
+	setMessages(messages: ClineMessage[]): void
+}
+
+export interface SdkCheckpointManagerOptions {
+	taskId: string
+	workspaceRoot: string
+	enableCheckpoints: boolean
+	messageAccess: SdkCheckpointMessageAccess
+	/**
+	 * Called after a "task" or "taskAndWorkspace" restore to tear down the
+	 * active SDK session. The next user message will create a fresh session
+	 * loaded from the (now-truncated) saved messages, ensuring the LLM's
+	 * conversation history matches the truncated ClineMessages.
+	 */
+	onSessionInvalidated?: () => Promise<void>
+}
+
+export class SdkCheckpointManager implements ICheckpointManager {
+	private readonly taskId: string
+	private readonly workspaceRoot: string
+	private readonly enableCheckpoints: boolean
+	private readonly messageAccess: SdkCheckpointMessageAccess
+	private readonly onSessionInvalidated?: () => Promise<void>
+
+	private tracker: RefCheckpointTracker | undefined
+	private trackerInitPromise: Promise<RefCheckpointTracker | undefined> | undefined
+	private initFailed = false
+
+	constructor(options: SdkCheckpointManagerOptions) {
+		this.taskId = options.taskId
+		this.workspaceRoot = options.workspaceRoot
+		this.enableCheckpoints = options.enableCheckpoints
+		this.messageAccess = options.messageAccess
+		this.onSessionInvalidated = options.onSessionInvalidated
+	}
+
+	private async ensureTracker(): Promise<RefCheckpointTracker | undefined> {
+		if (this.tracker) return this.tracker
+		if (this.initFailed) return undefined
+		if (this.trackerInitPromise) return this.trackerInitPromise
+
+		this.trackerInitPromise = RefCheckpointTracker.create(this.taskId, this.enableCheckpoints, this.workspaceRoot)
+			.then((t) => {
+				this.tracker = t
+				if (!t) this.initFailed = true
+				return t
+			})
+			.catch((err) => {
+				Logger.error("[SdkCheckpointManager] Tracker init failed:", err)
+				this.initFailed = true
+				return undefined
+			})
+			.finally(() => {
+				this.trackerInitPromise = undefined
+			})
+
+		return this.trackerInitPromise
+	}
+
+	async commit(): Promise<string | undefined> {
+		if (!this.enableCheckpoints) return undefined
+		const tracker = await this.ensureTracker()
+		if (!tracker) return undefined
+
+		try {
+			const commitHash = await tracker.commit()
+			if (!commitHash) return undefined
+
+			// Write hash onto the most recent checkpoint_created message without a hash
+			const messages = this.messageAccess.getClineMessages()
+			const targetMsg = findLast(messages, (m) => m.say === "checkpoint_created" && !m.lastCheckpointHash)
+			if (targetMsg) {
+				targetMsg.lastCheckpointHash = commitHash
+			} else {
+				const last = messages[messages.length - 1]
+				if (last) last.lastCheckpointHash = commitHash
+			}
+			return commitHash
+		} catch (error) {
+			Logger.error("[SdkCheckpointManager] commit failed:", error)
+			return undefined
+		}
+	}
+
+	async saveCheckpoint(isAttemptCompletionMessage?: boolean, completionMessageTs?: number): Promise<void> {
+		if (!this.enableCheckpoints) return
+		const commitHash = await this.commit()
+		if (!commitHash) return
+
+		if (isAttemptCompletionMessage) {
+			const messages = this.messageAccess.getClineMessages()
+			const completionMsg = completionMessageTs
+				? messages.find((m) => m.ts === completionMessageTs)
+				: findLast(messages, (m) => m.say === "completion_result")
+			if (completionMsg) {
+				completionMsg.lastCheckpointHash = commitHash
+			}
+		}
+	}
+
+	async restoreCheckpoint(messageTs: number, restoreType: any, offset?: number): Promise<any> {
+		const messages = this.messageAccess.getClineMessages()
+		const messageIndex = messages.findIndex((m) => m.ts === messageTs) - (offset || 0)
+		const message = messages[messageIndex]
+
+		if (!message) {
+			Logger.error(`[SdkCheckpointManager] Message not found for ts=${messageTs}`)
+			return
+		}
+
+		if (restoreType === "workspace" || restoreType === "taskAndWorkspace") {
+			const hash = message.lastCheckpointHash
+			if (hash) {
+				const tracker = await this.ensureTracker()
+				if (tracker) {
+					try {
+						await tracker.restore(hash)
+					} catch (error) {
+						Logger.error("[SdkCheckpointManager] Workspace restore failed:", error)
+					}
+				}
+			} else {
+				const prevIdx = findLastIndex(messages.slice(0, messageIndex), (m) => m.lastCheckpointHash !== undefined)
+				const prevMsg = messages[prevIdx]
+				if (prevMsg?.lastCheckpointHash) {
+					const tracker = await this.ensureTracker()
+					if (tracker) {
+						try {
+							await tracker.restore(prevMsg.lastCheckpointHash)
+						} catch (error) {
+							Logger.error("[SdkCheckpointManager] Workspace restore (fallback) failed:", error)
+						}
+					}
+				}
+			}
+		}
+
+		if (restoreType === "task" || restoreType === "taskAndWorkspace") {
+			// Truncate messages to the checkpoint point (remove everything after)
+			const truncated = messages.slice(0, messageIndex + 1)
+			this.messageAccess.setMessages(truncated)
+			Logger.info(
+				`[SdkCheckpointManager] Task restore: truncated to ${truncated.length} messages (from ${messages.length})`,
+			)
+
+			// Save the truncated messages to disk so that when the session is
+			// restarted it loads the truncated history (not the full history).
+			try {
+				const { saveClineMessages } = await import("@core/storage/disk")
+				await saveClineMessages(this.taskId, truncated)
+			} catch (err) {
+				Logger.error("[SdkCheckpointManager] Failed to save truncated messages:", err)
+			}
+
+			// Invalidate the active SDK session so the next user message creates
+			// a fresh session loaded from the truncated saved messages. Without
+			// this, the LLM's conversation history would still contain the
+			// deleted messages and the assistant would "remember" them.
+			if (this.onSessionInvalidated) {
+				try {
+					await this.onSessionInvalidated()
+				} catch (err) {
+					Logger.error("[SdkCheckpointManager] Failed to invalidate session:", err)
+				}
+			}
+		}
+	}
+
+	async doesLatestTaskCompletionHaveNewChanges(): Promise<boolean> {
+		if (!this.enableCheckpoints) return false
+		try {
+			const messages = this.messageAccess.getClineMessages()
+			const idx = findLastIndex(messages, (m) => m.say === "completion_result")
+			const msg = messages[idx]
+			if (!msg?.lastCheckpointHash) return false
+
+			const tracker = await this.ensureTracker()
+			if (!tracker) return false
+
+			const prevCompletion = findLast(messages.slice(0, idx), (m) => m.say === "completion_result")
+			const firstCp = messages.find((m) => m.say === "checkpoint_created")
+			const prevHash = prevCompletion?.lastCheckpointHash ?? firstCp?.lastCheckpointHash
+			if (!prevHash) return false
+
+			return (await tracker.getDiffCount(prevHash, msg.lastCheckpointHash)) > 0
+		} catch (error) {
+			Logger.error("[SdkCheckpointManager] doesLatestTaskCompletionHaveNewChanges failed:", error)
+			return false
+		}
+	}
+}

--- a/src/sdk/SdkController.ts
+++ b/src/sdk/SdkController.ts
@@ -27,6 +27,7 @@ import { clearRemoteConfig } from "@/core/storage/remote-config/utils"
 import { StateManager } from "@/core/storage/StateManager"
 import { type WorkspaceRootManager } from "@/core/workspace/WorkspaceRootManager"
 import { HostProvider } from "@/hosts/host-provider"
+import { SdkCheckpointManager } from "@/integrations/checkpoints/SdkCheckpointManager"
 import { ExtensionRegistryInfo } from "@/registry"
 import { UrlContentFetcher } from "@/services/browser/UrlContentFetcher"
 import { ClineError } from "@/services/error/ClineError"
@@ -256,6 +257,9 @@ export class Controller {
 			getTask: () => this.task,
 			setTask: (task) => {
 				this.task = task
+				if (task) {
+					this.initCheckpointManager(task)
+				}
 			},
 			onAskResponse: (text, images, files) => this.askResponse(text, images, files),
 			resetMessageTranslator: () => this.messageTranslatorState.reset(),
@@ -272,6 +276,9 @@ export class Controller {
 			clearTask: () => this.clearTask(),
 			setTask: (task) => {
 				this.task = task
+				if (task) {
+					this.initCheckpointManager(task)
+				}
 			},
 			onAskResponse: (text, images, files) => this.askResponse(text, images, files),
 			onCancelTask: () => this.cancelTask(),
@@ -404,6 +411,41 @@ export class Controller {
 	 * The classic extension used `vscode.workspace.workspaceFolders[0].uri.fsPath`
 	 * directly; using HostProvider keeps this host-agnostic.
 	 */
+	/**
+	 * Initialize the SdkCheckpointManager for a task proxy.
+	 * Fire-and-forget: async init happens in the background.
+	 */
+	private initCheckpointManager(task: TaskProxy): void {
+		const enableCheckpoints = this.stateManager.getGlobalSettingsKey("enableCheckpointsSetting") ?? true
+		if (!enableCheckpoints) return
+
+		this.getWorkspaceRoot()
+			.then((workspaceRoot) => {
+				const manager = new SdkCheckpointManager({
+					taskId: task.taskId,
+					workspaceRoot,
+					enableCheckpoints,
+					messageAccess: task.messageStateHandler,
+					onSessionInvalidated: async () => {
+						// Tear down the active SDK session so the next askResponse()
+						// creates a fresh session with the truncated conversation history.
+						const activeSession = this.sessions.clearActiveSessionReference()
+						if (activeSession) {
+							const { sessionManager, unsubscribe, sessionId } = activeSession
+							unsubscribe()
+							sessionManager.stop(sessionId).catch(() => {})
+							sessionManager.dispose("checkpointRestore").catch(() => {})
+						}
+					},
+				})
+				task.checkpointManager = manager
+				Logger.info(`[SdkController] Checkpoint manager initialized for task ${task.taskId}`)
+			})
+			.catch((err) => {
+				Logger.error("[SdkController] Failed to init checkpoint manager:", err)
+			})
+	}
+
 	private async getWorkspaceRoot(): Promise<string> {
 		try {
 			const { paths } = await HostProvider.workspace.getWorkspacePaths({})

--- a/src/sdk/sdk-followup-coordinator.ts
+++ b/src/sdk/sdk-followup-coordinator.ts
@@ -52,7 +52,13 @@ export class SdkFollowupCoordinator {
 
 		const activeSession = this.options.sessions.getActiveSession()
 		const task = this.options.getTask()
-		if ((!activeSession || !activeSession.isRunning) && task) {
+		if (!activeSession && task) {
+			// No active session but task exists — the session was disposed (e.g., after
+			// MCP tool reload or mode switch). Resume by creating a new session with
+			// the task's history. Note: we intentionally do NOT check isRunning here.
+			// After a turn completes the session is still alive (activeSession exists)
+			// but isRunning is false — that's the normal between-turns state, not a
+			// reason to tear down and recreate the session.
 			Logger.log(`[SdkController] askResponse: No active session but task exists (${task.taskId}), resuming...`)
 			await this.tryResumeSessionFromTask(task.taskId, prompt, images, files)
 			return
@@ -72,6 +78,14 @@ export class SdkFollowupCoordinator {
 		}
 
 		this.options.sessions.setRunning(true)
+
+		// Save a checkpoint before the user feedback message so that
+		// checkpoint_created appears right before user_feedback in the
+		// message array. The UserMessage "edit & restore" UI sends
+		// offset: 1 which subtracts from the user_feedback index,
+		// expecting to land on the checkpoint_created message.
+		this.saveCheckpointOnUserMessage()
+
 		this.emitUserFeedback(sessionId, prompt, images, files)
 
 		if (!wasAlreadyRunning) {
@@ -165,6 +179,30 @@ export class SdkFollowupCoordinator {
 
 		const resolvedPrompt = await this.options.resolveContextMentions(effectivePrompt)
 		this.options.sessions.fireAndForgetSend(sessionManager, startResult.sessionId, resolvedPrompt, images, files)
+	}
+
+	/**
+	 * Save a checkpoint when the user submits a message.
+	 * Emits a checkpoint_created message and commits the workspace state.
+	 * Fire-and-forget to avoid blocking the message send.
+	 */
+	private saveCheckpointOnUserMessage(): void {
+		const task = this.options.getTask()
+		if (!task?.checkpointManager) return
+
+		// Emit checkpoint_created message
+		const checkpointMessage: ClineMessage = {
+			ts: Date.now(),
+			type: "say",
+			say: "checkpoint_created",
+			partial: false,
+		}
+		this.options.messages.appendMessages([checkpointMessage])
+
+		// Commit checkpoint asynchronously (fire-and-forget)
+		task.checkpointManager.saveCheckpoint().catch((err) => {
+			Logger.error("[SdkFollowupCoordinator] Failed to save checkpoint:", err)
+		})
 	}
 
 	private emitUserFeedback(sessionId: string, prompt?: string, images?: string[], files?: string[]): void {

--- a/src/sdk/task-proxy.ts
+++ b/src/sdk/task-proxy.ts
@@ -9,6 +9,7 @@
 // and return safe defaults.
 
 import { EventEmitter } from "node:events"
+import type { ICheckpointManager } from "@integrations/checkpoints/types"
 import type { ClineMessage } from "@shared/ExtensionMessage"
 import { Logger } from "@shared/services/Logger"
 import type { ClineAskResponse } from "@shared/WebviewMessage"
@@ -30,9 +31,8 @@ export interface TaskProxy {
 	/** Browser session — stubbed (browser automation removed in this migration) */
 	// biome-ignore lint/suspicious/noExplicitAny: typed as any for handler compatibility; browser automation removed
 	browserSession: any
-	/** Checkpoint manager — stubbed (shadow git removed in this migration) */
-	// biome-ignore lint/suspicious/noExplicitAny: typed as any for handler compatibility; checkpoints removed
-	checkpointManager: any
+	/** Checkpoint manager — wired to SdkCheckpointManager for ref-based checkpoints */
+	checkpointManager: ICheckpointManager | undefined
 	/** Terminal manager — stub that safely no-ops for settings compatibility */
 	terminalManager: TaskProxyTerminalManager
 	/** Task state for tracking */
@@ -103,6 +103,12 @@ export class MessageStateHandler extends EventEmitter<MessageStateHandlerEvents>
 	/** Get all accumulated messages (returns a copy) */
 	getClineMessages(): ClineMessage[] {
 		return [...this.messages]
+	}
+
+	/** Replace the entire message array (e.g., on checkpoint restore truncation) */
+	setMessages(messages: ClineMessage[]): void {
+		this.messages = [...messages]
+		this.emit("clineMessagesChanged", { type: "set", messages: this.messages })
 	}
 
 	/** Clear all messages (e.g., on task clear) */
@@ -179,6 +185,9 @@ export function createTaskProxy(
 	// Mutable session ID — updated when the session is restarted (e.g., MCP tool reload)
 	let currentSessionId = sessionId
 
+	// Mutable checkpoint manager — set after creation by the coordinator
+	let currentCheckpointManager: ICheckpointManager | undefined
+
 	// Mutable API handler — updateSettings() replaces it when switching models
 	let currentApi: TaskProxyApi = {
 		getModel: () => ({ id: "unknown" }),
@@ -250,9 +259,11 @@ export function createTaskProxy(
 			return undefined
 		},
 
-		get checkpointManager() {
-			// Shadow git checkpoints removed — see ARCHITECTURE.md
-			return undefined
+		get checkpointManager(): ICheckpointManager | undefined {
+			return currentCheckpointManager
+		},
+		set checkpointManager(manager: ICheckpointManager | undefined) {
+			currentCheckpointManager = manager
 		},
 
 		get terminalManager(): TaskProxyTerminalManager {

--- a/webview-ui/src/components/chat/ChatRow.tsx
+++ b/webview-ui/src/components/chat/ChatRow.tsx
@@ -911,6 +911,7 @@ export const ChatRowContent = memo(
 							<UserMessage
 								files={message.files}
 								images={message.images}
+								isAgentRunning={isRequestInProgress}
 								messageTs={message.ts}
 								sendMessageFromChatRow={sendMessageFromChatRow}
 								text={message.text}
@@ -935,7 +936,13 @@ export const ChatRowContent = memo(
 					case "clineignore_error":
 						return <ErrorRow errorType="clineignore_error" message={message} />
 					case "checkpoint_created":
-						return <CheckmarkControl isCheckpointCheckedOut={message.isCheckpointCheckedOut} messageTs={message.ts} />
+						return (
+							<CheckmarkControl
+								isAgentRunning={isRequestInProgress}
+								isCheckpointCheckedOut={message.isCheckpointCheckedOut}
+								messageTs={message.ts}
+							/>
+						)
 					case "load_mcp_documentation":
 						return (
 							<div className="text-foreground flex items-center opacity-70 text-[12px] py-1 px-0">

--- a/webview-ui/src/components/chat/UserMessage.tsx
+++ b/webview-ui/src/components/chat/UserMessage.tsx
@@ -13,9 +13,10 @@ interface UserMessageProps {
 	images?: string[]
 	messageTs?: number // Timestamp for the message, needed for checkpoint restore
 	sendMessageFromChatRow?: (text: string, images: string[], files: string[]) => void
+	isAgentRunning?: boolean
 }
 
-const UserMessage: React.FC<UserMessageProps> = ({ text, images, files, messageTs, sendMessageFromChatRow }) => {
+const UserMessage: React.FC<UserMessageProps> = ({ text, images, files, messageTs, sendMessageFromChatRow, isAgentRunning }) => {
 	const [isEditing, setIsEditing] = useState(false)
 	const [editedText, setEditedText] = useState(text || "")
 	const textAreaRef = useRef<HTMLTextAreaElement>(null)
@@ -126,20 +127,30 @@ const UserMessage: React.FC<UserMessageProps> = ({ text, images, files, messageT
 					<div style={{ display: "flex", gap: "8px", marginTop: "8px", justifyContent: "flex-end" }}>
 						{!checkpointManagerErrorMessage && (
 							<RestoreButton
+								disabled={isAgentRunning}
 								isPrimary={false}
 								label="Restore All"
 								onClick={handleRestoreWorkspace}
 								ref={restoreAllButtonRef}
-								title="Restore both the chat and workspace files to this checkpoint and send your edited message"
+								title={
+									isAgentRunning
+										? "Cancel the task before restoring"
+										: "Restore both the chat and workspace files to this checkpoint and send your edited message"
+								}
 								type="taskAndWorkspace"
 							/>
 						)}
 						<RestoreButton
+							disabled={isAgentRunning}
 							isPrimary={true}
 							label="Restore Chat"
 							onClick={handleRestoreWorkspace}
 							ref={restoreChatButtonRef}
-							title="Restore just the chat to this checkpoint and send your edited message"
+							title={
+								isAgentRunning
+									? "Cancel the task before restoring"
+									: "Restore just the chat to this checkpoint and send your edited message"
+							}
 							type="task"
 						/>
 					</div>
@@ -163,35 +174,38 @@ interface RestoreButtonProps {
 	isPrimary: boolean
 	onClick: (type: ClineCheckpointRestore) => void
 	title?: string
+	disabled?: boolean
 }
 
-const RestoreButton = forwardRef<HTMLButtonElement, RestoreButtonProps>(({ type, label, isPrimary, onClick, title }, ref) => {
-	const handleClick = (e: React.MouseEvent<HTMLButtonElement>) => {
-		e.stopPropagation()
-		onClick(type)
-	}
+const RestoreButton = forwardRef<HTMLButtonElement, RestoreButtonProps>(
+	({ type, label, isPrimary, onClick, title, disabled }, ref) => {
+		const handleClick = (e: React.MouseEvent<HTMLButtonElement>) => {
+			e.stopPropagation()
+			if (!disabled) onClick(type)
+		}
 
-	return (
-		<button
-			onClick={handleClick}
-			ref={ref}
-			style={{
-				backgroundColor: isPrimary
-					? "var(--vscode-button-background)"
-					: "var(--vscode-button-secondaryBackground, var(--vscode-descriptionForeground))",
-				color: isPrimary
-					? "var(--vscode-button-foreground)"
-					: "var(--vscode-button-secondaryForeground, var(--vscode-foreground))",
-				border: "none",
-				padding: "4px 8px",
-				borderRadius: "2px",
-				fontSize: "9px",
-				cursor: "pointer",
-			}}
-			title={title}>
-			{label}
-		</button>
-	)
-})
+		return (
+			<button
+				onClick={handleClick}
+				ref={ref}
+				style={{
+					backgroundColor: isPrimary
+						? "var(--vscode-button-background)"
+						: "var(--vscode-button-secondaryBackground, var(--vscode-descriptionForeground))",
+					color: isPrimary
+						? "var(--vscode-button-foreground)"
+						: "var(--vscode-button-secondaryForeground, var(--vscode-foreground))",
+					border: "none",
+					padding: "4px 8px",
+					borderRadius: "2px",
+					fontSize: "9px",
+					cursor: "pointer",
+				}}
+				title={title}>
+				{label}
+			</button>
+		)
+	},
+)
 
 export default UserMessage

--- a/webview-ui/src/components/common/CheckmarkControl.tsx
+++ b/webview-ui/src/components/common/CheckmarkControl.tsx
@@ -15,9 +15,10 @@ import { CheckpointsServiceClient } from "@/services/grpc-client"
 interface CheckmarkControlProps {
 	messageTs?: number
 	isCheckpointCheckedOut?: boolean
+	isAgentRunning?: boolean
 }
 
-export const CheckmarkControl = ({ messageTs, isCheckpointCheckedOut }: CheckmarkControlProps) => {
+export const CheckmarkControl = ({ messageTs, isCheckpointCheckedOut, isAgentRunning }: CheckmarkControlProps) => {
 	const [compareDisabled, setCompareDisabled] = useState(false)
 	const [restoreTaskDisabled, setRestoreTaskDisabled] = useState(false)
 	const [restoreWorkspaceDisabled, setRestoreWorkspaceDisabled] = useState(false)
@@ -211,8 +212,11 @@ export const CheckmarkControl = ({ messageTs, isCheckpointCheckedOut }: Checkmar
 					<div ref={refs.setReference} style={{ position: "relative", marginTop: -2 }}>
 						<CustomButton
 							$isCheckedOut={isCheckpointCheckedOut}
+							disabled={isAgentRunning}
 							isActive={showRestoreConfirm}
-							onClick={() => setShowRestoreConfirm(true)}>
+							onClick={() => !isAgentRunning && setShowRestoreConfirm(true)}
+							style={{ cursor: isAgentRunning ? "not-allowed" : undefined }}
+							title={isAgentRunning ? "Cancel the task before restoring" : undefined}>
 							Restore
 						</CustomButton>
 						{showRestoreConfirm &&


### PR DESCRIPTION
## Summary

Adds SDK-migrated checkpoint support using Git refs in the user's workspace repository instead of the legacy shadow-git checkpoint store.

Key changes:
- Adds `RefCheckpointTracker`, which creates synthetic checkpoint commits with a temporary Git index and stores them under `refs/cline/checkpoints/<taskId>/turn/<n>`.
- Adds `SdkCheckpointManager`, implementing the existing checkpoint manager interface for SDK tasks, including checkpoint save, restore, diff counting, message truncation, and session invalidation after restore.
- Wires SDK `TaskProxy`/`SdkController`/follow-up handling so checkpoints are initialized for tasks and saved before user follow-up messages.
- Disables checkpoint restore controls while the agent is running, preserving the cancel-before-restore workflow.
- Cleans up ref-based checkpoints when deleting worktrees, alongside legacy checkpoint cleanup.

## Reviewer visualization

```mermaid
sequenceDiagram
    participant User
    participant Webview
    participant Followup as SdkFollowupCoordinator
    participant Manager as SdkCheckpointManager
    participant Tracker as RefCheckpointTracker
    participant Git as Workspace .git refs
    participant Session as SDK Session

    User->>Webview: Send follow-up message
    Webview->>Followup: askResponse(...)
    Followup->>Webview: append checkpoint_created
    Followup->>Manager: saveCheckpoint() fire-and-forget
    Manager->>Tracker: commit()
    Tracker->>Git: temp index + write-tree + commit-tree
    Tracker->>Git: update-ref refs/cline/checkpoints/<task>/turn/<n>
    Manager->>Webview: attach lastCheckpointHash to message
    Followup->>Session: emit user_feedback

    User->>Webview: Restore checkpoint
    Webview->>Manager: restoreCheckpoint(ts, type, offset)
    Manager->>Tracker: restore(commitHash)
    Tracker->>Git: git restore --source=<hash> --worktree -- .
    Manager->>Manager: truncate ClineMessages
    Manager->>Session: invalidate active SDK session
    Note over Session: next user message resumes from truncated history
```

## Notes for review

- Checkpoints are skipped gracefully when Git is unavailable or the workspace is not a Git repo.
- `GIT_INDEX_FILE` is used for checkpoint commits so the user's real index is not mutated.
- Restore buttons are disabled while requests are in progress instead of adding a workspace mutation lock.
- The active SDK session is torn down after task/task+workspace restore so LLM history matches the truncated Cline message history.

## Testing

- Tested with a few tasks on my local. 
