### PR TITLE
docs: add WaveSpeed provider setup guide

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -206,7 +206,8 @@
 									"provider-config/requesty",
 									"provider-config/sap-aicore",
 									"provider-config/vercel-ai-gateway",
-									"provider-config/vscode-language-model-api"
+									"provider-config/vscode-language-model-api",
+									"provider-config/wavespeed"
 								]
 							}
 						]

--- a/docs/enterprise-solutions/configuration/remote-configuration/overview.mdx
+++ b/docs/enterprise-solutions/configuration/remote-configuration/overview.mdx
@@ -107,6 +107,8 @@ Select your provider below to begin the configuration process:
   </Card>
 
   <Card title="Anthropic" icon="robot" href="/enterprise-solutions/configuration/remote-configuration/anthropic/admin-configuration">
+    Anthropic models with managed API key configuration for your team.
+  </Card>
 
   <Card title="LiteLLM" icon="layer-group" href="/enterprise-solutions/configuration/remote-configuration/litellm/admin-configuration">
     Unified proxy for accessing 100+ AI models through a single interface.

--- a/docs/provider-config/wavespeed.mdx
+++ b/docs/provider-config/wavespeed.mdx
@@ -1,0 +1,50 @@
+---
+title: "WaveSpeed"
+description: "Learn how to configure and use WaveSpeed LLM with Cline through an OpenAI-compatible endpoint."
+---
+
+WaveSpeed LLM provides access to language models from multiple vendors through an OpenAI-compatible API. Use it in Cline by selecting the OpenAI Compatible provider and pointing it at the WaveSpeed LLM base URL.
+
+**Website:** [https://wavespeed.ai/llm](https://wavespeed.ai/llm)
+
+### Getting an API Key
+
+1.  **Sign Up/Sign In:** Go to [WaveSpeed](https://wavespeed.ai/). Create an account or sign in.
+2.  **Navigate to API Keys:** Open the [API keys page](https://wavespeed.ai/accesskey).
+3.  **Create a Key:** Generate a new API key.
+4.  **Copy the Key:** Copy the API key immediately and store it securely.
+
+### Configuration in Cline
+
+1.  **Open Cline Settings:** Click the settings icon (⚙️) in the Cline panel.
+2.  **Select Provider:** Choose "OpenAI Compatible" from the "API Provider" dropdown.
+3.  **Enter Base URL:** Set the base URL to `https://llm.wavespeed.ai/v1`.
+4.  **Enter API Key:** Paste your WaveSpeed API key.
+5.  **Enter Model ID:** Specify a model using the `vendor/model` format from the WaveSpeed catalog, such as `anthropic/claude-opus-4.6`.
+6.  **Configure Settings:** Optionally adjust context window size, max output tokens, image support, and tool use based on the selected model's capabilities.
+7.  **Verify:** Click "Verify" to confirm the connection.
+
+### Supported Models
+
+WaveSpeed hosts models from multiple vendors. Model IDs use a `vendor/model` format. Examples:
+
+-   `anthropic/claude-opus-4.6`
+-   `openai/gpt-5.2-pro`
+-   `google/gemini-3-flash-preview`
+-   `deepseek/deepseek-v4-pro`
+
+Refer to the [WaveSpeed LLM catalog](https://wavespeed.ai/llm) for the complete and up-to-date list.
+
+### Tips and Notes
+
+-   **OpenAI Compatible:** Use the "OpenAI Compatible" provider in Cline, not the "OpenAI" provider.
+-   **Model IDs Are Case-Sensitive:** Copy model IDs exactly from the WaveSpeed catalog, including the vendor prefix.
+-   **Model Capabilities Vary:** Check whether the selected model supports image input or tool use before enabling those options in Cline.
+-   **Quick Start Guide:** See the [WaveSpeed LLM quick start](https://wavespeed.ai/docs/llm-service-quick-start) for additional setup details.
+
+### Troubleshooting
+
+-   **"401 Unauthorized":** Confirm you pasted a WaveSpeed API key, not a key from another provider.
+-   **"404 Model Not Found":** Use the full `vendor/model` ID from the WaveSpeed catalog.
+-   **Connection Errors:** Check that the base URL is exactly `https://llm.wavespeed.ai/v1`, including the `llm.` subdomain and `/v1` path.
+-   **Unexpected Tool or Vision Behavior:** Verify that the selected model supports the capability you enabled in Cline.


### PR DESCRIPTION
### Related Issue

This is a documentation-only addition. No prior issue required per [CONTRIBUTING.md](https://github.com/cline/cline/blob/main/CONTRIBUTING.md):

> Limited exceptions: Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly without prior discussion.

### Description

Adds a provider setup guide for [WaveSpeed LLM](https://wavespeed.ai/llm) under the Advanced Configuration section. WaveSpeed provides an OpenAI-compatible endpoint (`https://llm.wavespeed.ai/v1`) that gives access to 290+ models from multiple vendors through a single API key.

This PR does **not** add a native provider or touch any source code. It only adds documentation showing how to use WaveSpeed through the existing OpenAI Compatible provider in Cline.

### Changes

- `docs/provider-config/wavespeed.mdx` — new provider setup guide covering API key, base URL, model ID format, configuration steps, and troubleshooting
- `docs/docs.json` — adds `provider-config/wavespeed` to the Advanced Configuration navigation group
- `docs/enterprise-solutions/configuration/remote-configuration/overview.mdx` — fixes a pre-existing MDX syntax error (Anthropic card missing content and closing tag) that blocked `npm run check`

### Validation

- `docs.json` JSON parse: **OK**
- `wavespeed.mdx` MDX compile: **OK**
- `npm run check` (mintlify broken-links): 60 broken links in 23 files — **all pre-existing**, none related to WaveSpeed or the new navigation entry
- All external links verified reachable (200):
  - https://wavespeed.ai/llm
  - https://wavespeed.ai/accesskey
  - https://wavespeed.ai/docs/llm-service-quick-start
  - https://llm.wavespeed.ai/v1/models (API endpoint)
- All 4 example model IDs confirmed present in live `/v1/models` response
- Document style matches existing provider docs (openai-compatible, together, aihubmix, requesty)

### Type of Change

- [x] 📚 Documentation update

### Pre-flight Checklist

- [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
- [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`) — N/A for docs-only change
- [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Additional Notes

The second commit fixes a pre-existing MDX syntax error in the enterprise remote configuration overview page. This fix was necessary to unblock `npm run check` validation for the new WaveSpeed page. The fix is minimal (adds missing card content and closing tag for the Anthropic card).