### PR TITLE
fix(skills): give actionable errors for invalid SKILL.md files

### DIFF
--- a/src/core/context/instructions/user-instructions/__tests__/skills.test.ts
+++ b/src/core/context/instructions/user-instructions/__tests__/skills.test.ts
@@ -12,7 +12,7 @@ import * as sinon from "sinon"
 import * as disk from "@/core/storage/disk"
 import { Logger } from "@/shared/services/Logger"
 import * as fsUtils from "@/utils/fs"
-import { discoverSkills, getAvailableSkills, getSkillContent, parseRemoteSkillEntries } from "../skills"
+import { discoverSkills, getAvailableSkills, getSkillContent, parseRemoteSkillEntries, validateSkillFrontmatter } from "../skills"
 
 describe("Skills Utility Functions", () => {
 	let sandbox: sinon.SinonSandbox
@@ -384,6 +384,7 @@ Content`)
 			const skills = await discoverSkills(TEST_CWD)
 
 			expect(skills).to.have.lengthOf(0)
+			sinon.assert.calledWithMatch(Logger.warn as sinon.SinonStub, /malformed YAML frontmatter/)
 		})
 
 		it("should handle file without frontmatter", async () => {
@@ -400,6 +401,42 @@ Content`)
 			const skills = await discoverSkills(TEST_CWD)
 
 			expect(skills).to.have.lengthOf(0)
+			sinon.assert.calledWithMatch(Logger.warn as sinon.SinonStub, /missing YAML frontmatter/)
+		})
+
+		it("should reject empty SKILL.md file with actionable error", async () => {
+			const skillDir = path.join(GLOBAL_SKILLS_DIR, "empty-skill")
+			const skillMdPath = path.join(skillDir, "SKILL.md")
+
+			fileExistsStub.withArgs(GLOBAL_SKILLS_DIR).resolves(true)
+			fileExistsStub.withArgs(skillMdPath).resolves(true)
+			isDirectoryStub.withArgs(GLOBAL_SKILLS_DIR).resolves(true)
+			readdirStub.withArgs(GLOBAL_SKILLS_DIR).resolves(["empty-skill"])
+			statStub.withArgs(skillDir).resolves({ isDirectory: () => true })
+			readFileStub.withArgs(skillMdPath, "utf-8").resolves("")
+
+			const skills = await discoverSkills(TEST_CWD)
+
+			expect(skills).to.have.lengthOf(0)
+			sinon.assert.calledWithMatch(Logger.warn as sinon.SinonStub, /SKILL\.md.*is empty/)
+			sinon.assert.calledWithMatch(Logger.warn as sinon.SinonStub, /name: empty-skill/)
+		})
+
+		it("should reject whitespace-only SKILL.md file as empty", async () => {
+			const skillDir = path.join(GLOBAL_SKILLS_DIR, "blank-skill")
+			const skillMdPath = path.join(skillDir, "SKILL.md")
+
+			fileExistsStub.withArgs(GLOBAL_SKILLS_DIR).resolves(true)
+			fileExistsStub.withArgs(skillMdPath).resolves(true)
+			isDirectoryStub.withArgs(GLOBAL_SKILLS_DIR).resolves(true)
+			readdirStub.withArgs(GLOBAL_SKILLS_DIR).resolves(["blank-skill"])
+			statStub.withArgs(skillDir).resolves({ isDirectory: () => true })
+			readFileStub.withArgs(skillMdPath, "utf-8").resolves("   \n\n\t\n  ")
+
+			const skills = await discoverSkills(TEST_CWD)
+
+			expect(skills).to.have.lengthOf(0)
+			sinon.assert.calledWithMatch(Logger.warn as sinon.SinonStub, /SKILL\.md.*is empty/)
 		})
 	})
 
@@ -653,6 +690,62 @@ description: Test
 				await getSkillContent("Remote Only", [skill], entries)
 				sinon.assert.notCalled(readFileStub)
 			})
+		})
+	})
+
+	describe("validateSkillFrontmatter", () => {
+		const SKILL_PATH = path.join("/skills", "my-skill", "SKILL.md")
+
+		it("returns frontmatter on a valid file", () => {
+			const result = validateSkillFrontmatter(
+				`---\nname: my-skill\ndescription: Does a thing\n---\nBody`,
+				SKILL_PATH,
+				"my-skill",
+			)
+			expect(result).to.deep.equal({ name: "my-skill", description: "Does a thing" })
+		})
+
+		it("rejects empty content with a specific message", () => {
+			expect(validateSkillFrontmatter("", SKILL_PATH, "my-skill")).to.be.null
+			sinon.assert.calledWithMatch(Logger.warn as sinon.SinonStub, /SKILL\.md.*is empty/)
+		})
+
+		it("rejects whitespace-only content as empty", () => {
+			expect(validateSkillFrontmatter("\n\t  \n", SKILL_PATH, "my-skill")).to.be.null
+			sinon.assert.calledWithMatch(Logger.warn as sinon.SinonStub, /SKILL\.md.*is empty/)
+		})
+
+		it("rejects content without frontmatter with a specific message", () => {
+			expect(validateSkillFrontmatter("Just a body, no frontmatter\n", SKILL_PATH, "my-skill")).to.be.null
+			sinon.assert.calledWithMatch(Logger.warn as sinon.SinonStub, /missing YAML frontmatter/)
+		})
+
+		it("rejects malformed YAML frontmatter with a specific message", () => {
+			const result = validateSkillFrontmatter(`---\nname: [bad yaml\n---\nBody`, SKILL_PATH, "my-skill")
+			expect(result).to.be.null
+			sinon.assert.calledWithMatch(Logger.warn as sinon.SinonStub, /malformed YAML frontmatter/)
+		})
+
+		it("rejects missing 'name' field", () => {
+			const result = validateSkillFrontmatter(`---\ndescription: No name\n---\nBody`, SKILL_PATH, "my-skill")
+			expect(result).to.be.null
+			sinon.assert.calledWithMatch(Logger.warn as sinon.SinonStub, /missing required 'name' field/)
+		})
+
+		it("rejects missing 'description' field", () => {
+			const result = validateSkillFrontmatter(`---\nname: my-skill\n---\nBody`, SKILL_PATH, "my-skill")
+			expect(result).to.be.null
+			sinon.assert.calledWithMatch(Logger.warn as sinon.SinonStub, /missing required 'description' field/)
+		})
+
+		it("rejects name/directory mismatch", () => {
+			const result = validateSkillFrontmatter(
+				`---\nname: other-name\ndescription: Mismatch\n---\nBody`,
+				SKILL_PATH,
+				"my-skill",
+			)
+			expect(result).to.be.null
+			sinon.assert.calledWithMatch(Logger.warn as sinon.SinonStub, /doesn't match directory/)
 		})
 	})
 })

--- a/src/core/context/instructions/user-instructions/skills.ts
+++ b/src/core/context/instructions/user-instructions/skills.ts
@@ -98,6 +98,57 @@ async function scanSkillsDirectory(dirPath: string, source: "global" | "project"
 	return skills
 }
 
+/** Validate a SKILL.md file and return its frontmatter, or null after logging an actionable warning. */
+export function validateSkillFrontmatter(
+	fileContent: string,
+	skillMdPath: string,
+	expectedName: string,
+): { name: string; description: string } | null {
+	if (fileContent.trim().length === 0) {
+		Logger.warn(
+			`Invalid skill: SKILL.md at ${skillMdPath} is empty. ` +
+				`Add YAML frontmatter with 'name' and 'description', e.g.:\n` +
+				`---\nname: ${expectedName}\ndescription: <one-line summary>\n---\n<instructions>`,
+		)
+		return null
+	}
+
+	const result = parseYamlFrontmatter(fileContent)
+
+	if (result.parseError) {
+		Logger.warn(`Invalid skill: SKILL.md at ${skillMdPath} has malformed YAML frontmatter: ${result.parseError}`)
+		return null
+	}
+
+	if (!result.hadFrontmatter) {
+		Logger.warn(
+			`Invalid skill: SKILL.md at ${skillMdPath} is missing YAML frontmatter. ` +
+				`Add a '---' delimited block with 'name' and 'description' at the top of the file.`,
+		)
+		return null
+	}
+
+	const frontmatter = result.data
+
+	if (!frontmatter.name || typeof frontmatter.name !== "string") {
+		Logger.warn(`Invalid skill at ${skillMdPath}: missing required 'name' field in frontmatter.`)
+		return null
+	}
+	if (!frontmatter.description || typeof frontmatter.description !== "string") {
+		Logger.warn(`Invalid skill at ${skillMdPath}: missing required 'description' field in frontmatter.`)
+		return null
+	}
+
+	if (frontmatter.name !== expectedName) {
+		Logger.warn(
+			`Invalid skill at ${skillMdPath}: frontmatter name "${frontmatter.name}" doesn't match directory name "${expectedName}".`,
+		)
+		return null
+	}
+
+	return { name: frontmatter.name, description: frontmatter.description }
+}
+
 /**
  * Load skill metadata from a skill directory.
  */
@@ -111,27 +162,12 @@ async function loadSkillMetadata(
 
 	try {
 		const fileContent = await fs.readFile(skillMdPath, "utf-8")
-		const { data: frontmatter } = parseFrontmatter(fileContent)
-
-		// Validate required fields
-		if (!frontmatter.name || typeof frontmatter.name !== "string") {
-			Logger.warn(`Skill at ${skillDir} missing required 'name' field`)
-			return null
-		}
-		if (!frontmatter.description || typeof frontmatter.description !== "string") {
-			Logger.warn(`Skill at ${skillDir} missing required 'description' field`)
-			return null
-		}
-
-		// Name must match directory name per spec
-		if (frontmatter.name !== skillName) {
-			Logger.warn(`Skill name "${frontmatter.name}" doesn't match directory "${skillName}"`)
-			return null
-		}
+		const validated = validateSkillFrontmatter(fileContent, skillMdPath, skillName)
+		if (!validated) return null
 
 		return {
 			name: skillName,
-			description: frontmatter.description,
+			description: validated.description,
 			path: skillMdPath,
 			source,
 		}

--- a/src/core/controller/file/refreshSkills.ts
+++ b/src/core/controller/file/refreshSkills.ts
@@ -1,8 +1,7 @@
-import { parseRemoteSkillEntries } from "@core/context/instructions/user-instructions/skills"
+import { parseRemoteSkillEntries, validateSkillFrontmatter } from "@core/context/instructions/user-instructions/skills"
 import { RefreshedSkills, SkillInfo } from "@shared/proto/cline/file"
 import fs from "fs/promises"
 import path from "path"
-import { parseYamlFrontmatter } from "@/core/context/instructions/user-instructions/frontmatter"
 import { getSkillsDirectoriesForScan } from "@/core/storage/disk"
 import { HostProvider } from "@/hosts/host-provider"
 import { Logger } from "@/shared/services/Logger"
@@ -32,27 +31,19 @@ async function scanSkillsDirectory(dirPath: string): Promise<SkillInfo[]> {
 
 			try {
 				const fileContent = await fs.readFile(skillMdPath, "utf-8")
-				const result = parseYamlFrontmatter(fileContent)
-				if (result.parseError) {
-					Logger.warn("Failed to parse YAML frontmatter:", result.parseError)
-				}
-				const frontmatter = result.data
-
-				// Validate required fields
-				if (!frontmatter.name || typeof frontmatter.name !== "string") continue
-				if (!frontmatter.description || typeof frontmatter.description !== "string") continue
-				if (frontmatter.name !== entryName) continue
+				const validated = validateSkillFrontmatter(fileContent, skillMdPath, entryName)
+				if (!validated) continue
 
 				skills.push(
 					SkillInfo.create({
 						name: entryName,
-						description: frontmatter.description,
+						description: validated.description,
 						path: skillMdPath,
 						enabled: true, // Will be updated with toggle state
 					}),
 				)
-			} catch {
-				// Skip invalid skills
+			} catch (error) {
+				Logger.warn(`Failed to load skill at ${entryPath}:`, error)
 			}
 		}
 	} catch {


### PR DESCRIPTION
### Related Issue

**Issue:** #10341

### Description

Skill loading collapsed several distinct failure modes (empty file, missing frontmatter, malformed YAML, missing fields, name mismatch) into the same misleading `"missing required 'name' field"` warning, and `refreshSkills.scanSkillsDirectory` swallowed errors with `try { ... } catch {}` so users never saw anything from the UI refresh path.

A new shared `validateSkillFrontmatter` helper emits a specific warning per failure mode. Empty-file message suggests a copy-paste template using the directory name. Both `loadSkillMetadata` and `refreshSkills` now use it.

### Test Procedure

- New tests in `skills.test.ts`: 8 direct unit tests for `validateSkillFrontmatter` + 2 integration tests for empty and whitespace-only files.
- Existing 35 tests preserved (substrings like `missing required 'name' field` are kept in the new messages).
- `npm run test:unit` passes (1434 passing), `tsc --noEmit` clean, biome lint clean.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)

### Pre-flight Checklist

-   [x] Changes are limited to a single bugfix
-   [x] Tests are passing and code is linted
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)