### PR TITLE
fix(cli): show reasoning in TUI when -v is set

### DIFF
--- a/cli/src/components/App.tsx
+++ b/cli/src/components/App.tsx
@@ -270,6 +270,7 @@ const InternalApp: React.FC<AppProps> = ({
 							onError={onError}
 							onExit={onWelcomeExit}
 							taskId={selectedTaskId}
+							verbose={verbose}
 						/>
 					)}
 				</TaskContextProvider>

--- a/cli/src/components/ChatMessage.test.tsx
+++ b/cli/src/components/ChatMessage.test.tsx
@@ -104,3 +104,33 @@ describe("ChatMessage subagent rendering", () => {
 		expect(frame).toContain("5 tool uses · 28.9k tokens · $0.00")
 	})
 })
+
+describe("ChatMessage reasoning rendering (verbose flag)", () => {
+	const reasoningMessage: ClineMessage = {
+		ts: Date.now(),
+		type: "say",
+		say: "reasoning",
+		text: "The user just said hi, so I should greet them back politely.",
+	}
+
+	it("hides reasoning messages by default", () => {
+		const { lastFrame } = render(React.createElement(ChatMessage, { message: reasoningMessage, mode: "act" }))
+		expect(lastFrame() ?? "").not.toContain("greet them back")
+	})
+
+	it("hides reasoning messages when verbose is explicitly false", () => {
+		const { lastFrame } = render(React.createElement(ChatMessage, { message: reasoningMessage, mode: "act", verbose: false }))
+		expect(lastFrame() ?? "").not.toContain("greet them back")
+	})
+
+	it("renders reasoning messages when verbose is true", () => {
+		const { lastFrame } = render(React.createElement(ChatMessage, { message: reasoningMessage, mode: "act", verbose: true }))
+		expect(lastFrame() ?? "").toContain("greet them back")
+	})
+
+	it("hides empty/whitespace-only reasoning even when verbose is true", () => {
+		const blank: ClineMessage = { ts: Date.now(), type: "say", say: "reasoning", text: "   \n\n  " }
+		const { lastFrame } = render(React.createElement(ChatMessage, { message: blank, mode: "act", verbose: true }))
+		expect(lastFrame() ?? "").toBe("")
+	})
+})

--- a/cli/src/components/ChatMessage.tsx
+++ b/cli/src/components/ChatMessage.tsx
@@ -191,6 +191,7 @@ interface ChatMessageProps {
 	message: ClineMessage
 	isStreaming?: boolean
 	mode?: "act" | "plan"
+	verbose?: boolean
 }
 
 /**
@@ -307,7 +308,7 @@ function formatToolResult(result: string, maxLines = 5): string[] {
 	return displayLines
 }
 
-export const ChatMessage: React.FC<ChatMessageProps> = ({ message, mode, isStreaming }) => {
+export const ChatMessage: React.FC<ChatMessageProps> = ({ message, mode, isStreaming, verbose }) => {
 	const { type, ask, say, text, partial } = message
 	const toolColor = mode === "plan" ? "yellow" : COLORS.primaryBlue
 	const { columns: terminalWidth } = useTerminalSize()
@@ -337,9 +338,15 @@ export const ChatMessage: React.FC<ChatMessageProps> = ({ message, mode, isStrea
 		)
 	}
 
-	// Assistant text response (hide reasoning traces - they're verbose and clutter the UI)
 	if (say === "reasoning") {
-		return null
+		if (!verbose || !text?.trim()) return null
+		return (
+			<Box flexDirection="column" marginBottom={1} width="100%">
+				<DotRow color="gray">
+					<Text color="gray">{text}</Text>
+				</DotRow>
+			</Box>
+		)
 	}
 	if (say === "text") {
 		if (!text?.trim()) return null

--- a/cli/src/components/ChatView.tsx
+++ b/cli/src/components/ChatView.tsx
@@ -186,6 +186,7 @@ interface ChatViewProps {
 	initialPrompt?: string
 	initialImages?: string[]
 	taskId?: string
+	verbose?: boolean
 }
 
 const SEARCH_DEBOUNCE_MS = 150
@@ -352,6 +353,7 @@ export const ChatView: React.FC<ChatViewProps> = ({
 	initialPrompt,
 	initialImages,
 	taskId,
+	verbose,
 }) => {
 	// Get Ink app instance for graceful exit
 	const { exit: inkExit } = useApp()
@@ -1505,7 +1507,7 @@ export const ChatView: React.FC<ChatViewProps> = ({
 					// Completed message
 					return (
 						<Box key={item.message.ts} paddingX={1} width="100%">
-							<ChatMessage message={item.message} mode={mode} />
+							<ChatMessage message={item.message} mode={mode} verbose={verbose} />
 						</Box>
 					)
 				}}
@@ -1527,7 +1529,7 @@ export const ChatView: React.FC<ChatViewProps> = ({
 				{/* Current streaming message */}
 				{currentMessage && (
 					<Box paddingX={1} width="100%">
-						<ChatMessage isStreaming message={currentMessage} mode={mode} />
+						<ChatMessage isStreaming message={currentMessage} mode={mode} verbose={verbose} />
 					</Box>
 				)}
 


### PR DESCRIPTION
### Related Issue

**Issue:** #10197

### Description

The `-v`/`--verbose` flag had no effect on reasoning messages in interactive TUI mode — they were unconditionally dropped at `ChatMessage.tsx:341` regardless of the flag, while pipe mode (`echo prompt | cline -v`) correctly emitted them on stderr. The CLI docs at `cli/DEVELOPMENT.md:71` advertised `-v` as showing reasoning, so this was a docs-vs-behavior gap.

The `verbose` prop existed on `App` but was only forwarded to `TaskJsonView`, never to `ChatView` / `ChatMessage`. This PR threads it through and renders reasoning in gray when verbose is set.

### Test Procedure

- New tests in `ChatMessage.test.tsx` cover all four cases: hidden by default, hidden when `verbose: false`, shown when `verbose: true`, and empty/whitespace-only reasoning still hidden in verbose mode.
- Full CLI test suite passes (417/417), `tsc --noEmit` clean, biome lint clean.
- Built `dist/cli.mjs` confirmed to contain the new conditional and `cline --help` still lists `-v, --verbose`.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)

### Pre-flight Checklist

-   [x] Changes are limited to a single bugfix
-   [x] Tests are passing and code is linted
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)
