### PR TITLE
feat: add beta version checkbox to bug report issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -26,6 +26,12 @@ body:
       placeholder: 'e.g., 1.2.3'
     validations:
       required: true
+  - type: checkboxes
+    id: beta
+    attributes:
+      label: Beta version
+      options:
+        - label: I am using a beta version of Cline
   - type: textarea
     id: what-happened
     attributes:

--- a/.github/workflows/label-jetbrains-issues.yml
+++ b/.github/workflows/label-jetbrains-issues.yml
@@ -51,3 +51,15 @@ jobs:
                 });
               }
             }
+
+            // Check if beta version checkbox is checked
+            if (body.includes('- [X] I am using a beta version of Cline') || body.includes('- [x] I am using a beta version of Cline')) {
+              if (!labels.includes('beta')) {
+                await github.rest.issues.addLabels({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: context.issue.number,
+                  labels: ['beta']
+                });
+              }
+            }


### PR DESCRIPTION
### Related Issue

N/A -- internal improvement

### Description

Adds a "Beta version" checkbox to the bug report issue template so users can self-identify when they're filing a bug on a beta build. Since users can't add labels to their own issues, the existing auto-label workflow (`label-jetbrains-issues.yml`) is extended to detect the checked checkbox in the issue body and automatically apply a `beta` label. This lets us filter and triage beta-specific bugs easily.

The checkbox sits right after the "Cline Version" input field, before the "What happened?" textarea. It's optional so it doesn't add friction for users on stable.

The workflow handles both `[X]` and `[x]` checkbox formats that GitHub renders.

### Test Procedure

- Verified the YAML is valid for GitHub Issue Forms
- The auto-label logic matches the exact checkbox text rendered by GitHub when a user checks the box
- Follows the same pattern as the existing JetBrains/VSCode/CLI auto-labeling in the same workflow file

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [x] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A -- issue template and workflow changes only

### Additional Notes

Make sure a `beta` label exists in the repo (Settings > Labels) before this merges, or GitHub will auto-create it on first use.