### PR TITLE
fix: prevent input bounce in debounced text fields

### DIFF
--- a/webview-ui/src/components/settings/utils/useDebouncedInput.ts
+++ b/webview-ui/src/components/settings/utils/useDebouncedInput.ts
@@ -10,24 +10,29 @@ import { useDebounceEffect } from "@/utils/useDebounceEffect"
  * @param debounceMs - Debounce delay in milliseconds (default: 500ms)
  * @returns A tuple of [currentValue, setValue] similar to useState
  */
-export function useDebouncedInput<T>(
-	initialValue: T,
-	onChange: (value: T) => void,
-	debounceMs: number = 100,
-): [T, (value: T) => void] {
+export function useDebouncedInput<T>(initialValue: T, onChange: (value: T) => void, debounceMs = 100): [T, (value: T) => void] {
 	// Local state to prevent jumpy input - initialize once
 	const [localValue, setLocalValue] = useState(initialValue)
 
 	// Track previous initialValue to detect external changes
 	const prevInitialValueRef = useRef<T>(initialValue)
+	const localValueRef = useRef<T>(initialValue)
 
 	// Sync local state when initialValue changes externally (e.g., when switching Plan/Act tabs)
 	useEffect(() => {
 		if (prevInitialValueRef.current !== initialValue) {
-			setLocalValue(initialValue)
+			// Only overwrite if the user hasn't modified the value (prevents input bounce)
+			if (localValueRef.current === prevInitialValueRef.current) {
+				setLocalValue(initialValue)
+			}
 			prevInitialValueRef.current = initialValue
 		}
 	}, [initialValue])
+
+	// Track localValue changes so the sync effect can check if user has edited
+	useEffect(() => {
+		localValueRef.current = localValue
+	}, [localValue])
 
 	// Debounced backend save - saves after user stops changing value
 	useDebounceEffect(

--- a/webview-ui/src/components/settings/utils/useDebouncedInput.ts
+++ b/webview-ui/src/components/settings/utils/useDebouncedInput.ts
@@ -7,7 +7,7 @@ import { useDebounceEffect } from "@/utils/useDebounceEffect"
  *
  * @param initialValue - The initial value for the input
  * @param onChange - Callback function to save the value (e.g., to backend)
- * @param debounceMs - Debounce delay in milliseconds (default: 500ms)
+ * @param debounceMs - Debounce delay in milliseconds (default: 100ms)
  * @returns A tuple of [currentValue, setValue] similar to useState
  */
 export function useDebouncedInput<T>(initialValue: T, onChange: (value: T) => void, debounceMs = 100): [T, (value: T) => void] {

--- a/webview-ui/src/components/settings/utils/useDebouncedInput.ts
+++ b/webview-ui/src/components/settings/utils/useDebouncedInput.ts
@@ -21,11 +21,13 @@ export function useDebouncedInput<T>(initialValue: T, onChange: (value: T) => vo
 	// Sync local state when initialValue changes externally (e.g., when switching Plan/Act tabs)
 	useEffect(() => {
 		if (prevInitialValueRef.current !== initialValue) {
-			// Only overwrite if the user hasn't modified the value (prevents input bounce)
 			if (localValueRef.current === prevInitialValueRef.current) {
 				setLocalValue(initialValue)
+				prevInitialValueRef.current = initialValue
+			} else {
+				// User is editing — keep ref aligned so future external changes can still sync
+				prevInitialValueRef.current = localValueRef.current
 			}
-			prevInitialValueRef.current = initialValue
 		}
 	}, [initialValue])
 


### PR DESCRIPTION
<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- For feature requests: Created a discussion in our Feature Requests discussions board https://github.com/cline/cline/discussions/categories/feature-requests and received approval from core maintainers before implementation
- For all changes: Link the associated issue/discussion in the "Related Issue" section below

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly without prior discussion.

Why this requirement?
We deeply appreciate all community contributions - they are essential to Cline's success! To ensure the best use of everyone's time and maintain project direction, we use our Feature Requests discussions board to gauge community interest and validate feature ideas before implementation begins. This helps us focus development efforts on features that will benefit the most users.
-->

### Related Issue
#10510 
debounced input fields bounce during fast typing

### Description

Fix text input bounce/jump in all debounced input fields (model ID, max tokens, context window, base URL, etc. — any field using `DebouncedTextField`).

**Root cause**: `useDebouncedInput` unconditionally syncs external `initialValue` changes to `localValue`. When a gRPC response updates the context while the user is actively typing, the effect overwrites the user's input, causing the cursor to jump and text to bounce.

**Fix**: Only overwrite `localValue` with external `initialValue` when the user has not modified the value (i.e., external sync from tab switch or remote config push). User edits are preserved during active typing.

**Scope**: 1 file — `webview-ui/src/components/settings/utils/useDebouncedInput.ts`. Impact is system-wide; all providers benefit.

### Test Procedure

1. Open Settings → Anthropic provider → check "Use custom model ID"
2. Rapidly type in Model ID, Max Tokens, Context Window, or any price field
3. Verify no cursor jump or text bounce during fast typing
4. Verify debounced value saves correctly to backend after stopping
5. Switch between Plan/Act tabs — verify values sync correctly
6. Repeat for other providers that use `DebouncedTextField`

### Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ♻️ Refactor Changes
- [ ] 💅 Cosmetic Changes
- [ ] 📚 Documentation update
- [ ] 🏃 Workflow Changes

### Pre-flight Checklist

- [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
- [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
- [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A — no UI changes, internal hook logic only.

### Additional Notes

N/A