### PR TITLE
feat(terminal): detect WSL without remote extension and show targeted guidance

### DIFF
--- a/src/integrations/terminal/CommandExecutor.ts
+++ b/src/integrations/terminal/CommandExecutor.ts
@@ -15,6 +15,7 @@
 
 import { findLastIndex } from "@shared/array"
 import { ClineToolResponseContent } from "@shared/messages"
+import { isWslWithoutRemoteExtension } from "@utils/shell"
 import { Logger } from "@/shared/services/Logger"
 import { orchestrateCommandExecution } from "./CommandOrchestrator"
 import { StandaloneTerminalManager } from "./standalone/StandaloneTerminalManager"
@@ -141,6 +142,7 @@ export class CommandExecutor {
 					}
 				: undefined,
 			showShellIntegrationSuggestion: this.shouldShowBackgroundTerminalSuggestion(),
+			isWslWithoutRemoteExtension: isWslWithoutRemoteExtension(),
 			terminalType: useStandalone ? "standalone" : "vscode",
 		})
 

--- a/src/integrations/terminal/CommandExecutor.ts
+++ b/src/integrations/terminal/CommandExecutor.ts
@@ -142,7 +142,7 @@ export class CommandExecutor {
 					}
 				: undefined,
 			showShellIntegrationSuggestion: this.shouldShowBackgroundTerminalSuggestion(),
-			isWslWithoutRemoteExtension: isWslWithoutRemoteExtension(),
+			isWslWithoutRemoteExtension,
 			terminalType: useStandalone ? "standalone" : "vscode",
 		})
 

--- a/src/integrations/terminal/CommandOrchestrator.ts
+++ b/src/integrations/terminal/CommandOrchestrator.ts
@@ -464,7 +464,9 @@ export async function orchestrateCommandExecution(
 	})
 
 	process.once("no_shell_integration", async () => {
-		if (showShellIntegrationSuggestion) {
+		if (options.isWslWithoutRemoteExtension) {
+			await say("shell_integration_warning_wsl")
+		} else if (showShellIntegrationSuggestion) {
 			await say("shell_integration_warning_with_suggestion")
 		} else {
 			await say("shell_integration_warning")

--- a/src/integrations/terminal/CommandOrchestrator.ts
+++ b/src/integrations/terminal/CommandOrchestrator.ts
@@ -464,7 +464,7 @@ export async function orchestrateCommandExecution(
 	})
 
 	process.once("no_shell_integration", async () => {
-		if (options.isWslWithoutRemoteExtension) {
+		if (options.isWslWithoutRemoteExtension?.()) {
 			await say("shell_integration_warning_wsl")
 		} else if (showShellIntegrationSuggestion) {
 			await say("shell_integration_warning_with_suggestion")

--- a/src/integrations/terminal/types.ts
+++ b/src/integrations/terminal/types.ts
@@ -394,8 +394,8 @@ export interface OrchestrationOptions {
 	onOutputLine?: (line: string) => void
 	/** Whether to show shell integration warning with suggestion */
 	showShellIntegrationSuggestion?: boolean
-	/** Whether the user is on Windows with a WSL profile but without the VS Code WSL extension */
-	isWslWithoutRemoteExtension?: boolean
+	/** Lazily checks whether the user is on Windows with a WSL profile but without the VS Code WSL extension */
+	isWslWithoutRemoteExtension?: () => boolean
 	/**
 	 * Callback invoked when user clicks "Proceed While Running".
 	 * Used to start background command tracking in the terminal manager.

--- a/src/integrations/terminal/types.ts
+++ b/src/integrations/terminal/types.ts
@@ -394,6 +394,8 @@ export interface OrchestrationOptions {
 	onOutputLine?: (line: string) => void
 	/** Whether to show shell integration warning with suggestion */
 	showShellIntegrationSuggestion?: boolean
+	/** Whether the user is on Windows with a WSL profile but without the VS Code WSL extension */
+	isWslWithoutRemoteExtension?: boolean
 	/**
 	 * Callback invoked when user clicks "Proceed While Running".
 	 * Used to start background command tracking in the terminal manager.

--- a/src/shared/ExtensionMessage.ts
+++ b/src/shared/ExtensionMessage.ts
@@ -171,6 +171,7 @@ export type ClineSay =
 	| "tool"
 	| "shell_integration_warning"
 	| "shell_integration_warning_with_suggestion"
+	| "shell_integration_warning_wsl"
 	| "browser_action_launch"
 	| "browser_action"
 	| "browser_action_result"

--- a/src/shared/proto-conversions/cline-message.ts
+++ b/src/shared/proto-conversions/cline-message.ts
@@ -86,6 +86,7 @@ function convertClineSayToProtoEnum(say: AppClineSay | undefined): ClineSay | un
 		tool: ClineSay.TOOL_SAY,
 		shell_integration_warning: ClineSay.SHELL_INTEGRATION_WARNING,
 		shell_integration_warning_with_suggestion: ClineSay.SHELL_INTEGRATION_WARNING,
+		shell_integration_warning_wsl: ClineSay.SHELL_INTEGRATION_WARNING,
 		browser_action_launch: ClineSay.BROWSER_ACTION_LAUNCH_SAY,
 		browser_action: ClineSay.BROWSER_ACTION,
 		browser_action_result: ClineSay.BROWSER_ACTION_RESULT,

--- a/src/test/shell.test.ts
+++ b/src/test/shell.test.ts
@@ -250,6 +250,15 @@ describe("Shell Detection Tests", () => {
 			expect(isWslWithoutRemoteExtension()).to.equal(false)
 		})
 
+		it("returns false for profile names that contain 'wsl' as a substring but not a word", () => {
+			Object.defineProperty(process, "platform", { value: "win32" })
+			;(vscode.env as any).remoteName = undefined
+			mockVsCodeConfig("windows", "awslify", {
+				awslify: {},
+			})
+			expect(isWslWithoutRemoteExtension()).to.equal(false)
+		})
+
 		it("returns false on Windows with no default profile set", () => {
 			Object.defineProperty(process, "platform", { value: "win32" })
 			;(vscode.env as any).remoteName = undefined

--- a/src/test/shell.test.ts
+++ b/src/test/shell.test.ts
@@ -202,12 +202,12 @@ describe("Shell Detection Tests", () => {
 		})
 
 		afterEach(() => {
-			Object.defineProperty(vscode.env, "remoteName", { value: originalRemoteName, configurable: true })
+			Object.defineProperty(vscode.env, "remoteName", { value: originalRemoteName, configurable: true, writable: true })
 		})
 
 		it("returns true on Windows with WSL source profile and no remote extension", () => {
 			Object.defineProperty(process, "platform", { value: "win32" })
-			Object.defineProperty(vscode.env, "remoteName", { value: undefined, configurable: true })
+			Object.defineProperty(vscode.env, "remoteName", { value: undefined, configurable: true, writable: true })
 			mockVsCodeConfig("windows", "WSL", {
 				WSL: { source: "WSL" },
 			})
@@ -216,7 +216,7 @@ describe("Shell Detection Tests", () => {
 
 		it("returns true on Windows when profile name includes 'wsl'", () => {
 			Object.defineProperty(process, "platform", { value: "win32" })
-			Object.defineProperty(vscode.env, "remoteName", { value: undefined, configurable: true })
+			Object.defineProperty(vscode.env, "remoteName", { value: undefined, configurable: true, writable: true })
 			mockVsCodeConfig("windows", "Ubuntu WSL", {
 				"Ubuntu WSL": {},
 			})
@@ -225,7 +225,7 @@ describe("Shell Detection Tests", () => {
 
 		it("returns false when remoteName is 'wsl' (extension is active)", () => {
 			Object.defineProperty(process, "platform", { value: "win32" })
-			Object.defineProperty(vscode.env, "remoteName", { value: "wsl", configurable: true })
+			Object.defineProperty(vscode.env, "remoteName", { value: "wsl", configurable: true, writable: true })
 			mockVsCodeConfig("windows", "WSL", {
 				WSL: { source: "WSL" },
 			})
@@ -234,7 +234,7 @@ describe("Shell Detection Tests", () => {
 
 		it("returns false on non-Windows platforms", () => {
 			Object.defineProperty(process, "platform", { value: "linux" })
-			Object.defineProperty(vscode.env, "remoteName", { value: undefined, configurable: true })
+			Object.defineProperty(vscode.env, "remoteName", { value: undefined, configurable: true, writable: true })
 			mockVsCodeConfig("linux", "bash", {
 				bash: { path: "/bin/bash" },
 			})
@@ -243,7 +243,7 @@ describe("Shell Detection Tests", () => {
 
 		it("returns false on Windows with non-WSL profile", () => {
 			Object.defineProperty(process, "platform", { value: "win32" })
-			Object.defineProperty(vscode.env, "remoteName", { value: undefined, configurable: true })
+			Object.defineProperty(vscode.env, "remoteName", { value: undefined, configurable: true, writable: true })
 			mockVsCodeConfig("windows", "PowerShell", {
 				PowerShell: { source: "PowerShell" },
 			})
@@ -252,7 +252,7 @@ describe("Shell Detection Tests", () => {
 
 		it("returns false for profile names that contain 'wsl' as a substring but not a word", () => {
 			Object.defineProperty(process, "platform", { value: "win32" })
-			Object.defineProperty(vscode.env, "remoteName", { value: undefined, configurable: true })
+			Object.defineProperty(vscode.env, "remoteName", { value: undefined, configurable: true, writable: true })
 			mockVsCodeConfig("windows", "awslify", {
 				awslify: {},
 			})
@@ -261,7 +261,7 @@ describe("Shell Detection Tests", () => {
 
 		it("returns false on Windows with no default profile set", () => {
 			Object.defineProperty(process, "platform", { value: "win32" })
-			Object.defineProperty(vscode.env, "remoteName", { value: undefined, configurable: true })
+			Object.defineProperty(vscode.env, "remoteName", { value: undefined, configurable: true, writable: true })
 			mockVsCodeConfig("windows", null, {})
 			expect(isWslWithoutRemoteExtension()).to.equal(false)
 		})

--- a/src/test/shell.test.ts
+++ b/src/test/shell.test.ts
@@ -202,12 +202,12 @@ describe("Shell Detection Tests", () => {
 		})
 
 		afterEach(() => {
-			;(vscode.env as any).remoteName = originalRemoteName
+			Object.defineProperty(vscode.env, "remoteName", { value: originalRemoteName, configurable: true })
 		})
 
 		it("returns true on Windows with WSL source profile and no remote extension", () => {
 			Object.defineProperty(process, "platform", { value: "win32" })
-			;(vscode.env as any).remoteName = undefined
+			Object.defineProperty(vscode.env, "remoteName", { value: undefined, configurable: true })
 			mockVsCodeConfig("windows", "WSL", {
 				WSL: { source: "WSL" },
 			})
@@ -216,7 +216,7 @@ describe("Shell Detection Tests", () => {
 
 		it("returns true on Windows when profile name includes 'wsl'", () => {
 			Object.defineProperty(process, "platform", { value: "win32" })
-			;(vscode.env as any).remoteName = undefined
+			Object.defineProperty(vscode.env, "remoteName", { value: undefined, configurable: true })
 			mockVsCodeConfig("windows", "Ubuntu WSL", {
 				"Ubuntu WSL": {},
 			})
@@ -225,7 +225,7 @@ describe("Shell Detection Tests", () => {
 
 		it("returns false when remoteName is 'wsl' (extension is active)", () => {
 			Object.defineProperty(process, "platform", { value: "win32" })
-			;(vscode.env as any).remoteName = "wsl"
+			Object.defineProperty(vscode.env, "remoteName", { value: "wsl", configurable: true })
 			mockVsCodeConfig("windows", "WSL", {
 				WSL: { source: "WSL" },
 			})
@@ -234,7 +234,7 @@ describe("Shell Detection Tests", () => {
 
 		it("returns false on non-Windows platforms", () => {
 			Object.defineProperty(process, "platform", { value: "linux" })
-			;(vscode.env as any).remoteName = undefined
+			Object.defineProperty(vscode.env, "remoteName", { value: undefined, configurable: true })
 			mockVsCodeConfig("linux", "bash", {
 				bash: { path: "/bin/bash" },
 			})
@@ -243,7 +243,7 @@ describe("Shell Detection Tests", () => {
 
 		it("returns false on Windows with non-WSL profile", () => {
 			Object.defineProperty(process, "platform", { value: "win32" })
-			;(vscode.env as any).remoteName = undefined
+			Object.defineProperty(vscode.env, "remoteName", { value: undefined, configurable: true })
 			mockVsCodeConfig("windows", "PowerShell", {
 				PowerShell: { source: "PowerShell" },
 			})
@@ -252,7 +252,7 @@ describe("Shell Detection Tests", () => {
 
 		it("returns false for profile names that contain 'wsl' as a substring but not a word", () => {
 			Object.defineProperty(process, "platform", { value: "win32" })
-			;(vscode.env as any).remoteName = undefined
+			Object.defineProperty(vscode.env, "remoteName", { value: undefined, configurable: true })
 			mockVsCodeConfig("windows", "awslify", {
 				awslify: {},
 			})
@@ -261,7 +261,7 @@ describe("Shell Detection Tests", () => {
 
 		it("returns false on Windows with no default profile set", () => {
 			Object.defineProperty(process, "platform", { value: "win32" })
-			;(vscode.env as any).remoteName = undefined
+			Object.defineProperty(vscode.env, "remoteName", { value: undefined, configurable: true })
 			mockVsCodeConfig("windows", null, {})
 			expect(isWslWithoutRemoteExtension()).to.equal(false)
 		})

--- a/src/test/shell.test.ts
+++ b/src/test/shell.test.ts
@@ -1,4 +1,4 @@
-import { getShell } from "@utils/shell"
+import { getShell, isWslWithoutRemoteExtension } from "@utils/shell"
 import { expect } from "chai"
 import { afterEach, beforeEach, describe, it } from "mocha"
 import { userInfo } from "os"
@@ -188,6 +188,73 @@ describe("Shell Detection Tests", () => {
 			vscode.workspace.getConfiguration = () => ({ get: () => undefined }) as any
 			// userInfo => null, SHELL => undefined
 			expect(getShell()).to.equal("/bin/bash")
+		})
+	})
+
+	// --------------------------------------------------------------------------
+	// WSL Without Remote Extension Detection
+	// --------------------------------------------------------------------------
+	describe("WSL Without Remote Extension Detection", () => {
+		let originalRemoteName: string | undefined
+
+		beforeEach(() => {
+			originalRemoteName = vscode.env.remoteName
+		})
+
+		afterEach(() => {
+			;(vscode.env as any).remoteName = originalRemoteName
+		})
+
+		it("returns true on Windows with WSL source profile and no remote extension", () => {
+			Object.defineProperty(process, "platform", { value: "win32" })
+			;(vscode.env as any).remoteName = undefined
+			mockVsCodeConfig("windows", "WSL", {
+				WSL: { source: "WSL" },
+			})
+			expect(isWslWithoutRemoteExtension()).to.equal(true)
+		})
+
+		it("returns true on Windows when profile name includes 'wsl'", () => {
+			Object.defineProperty(process, "platform", { value: "win32" })
+			;(vscode.env as any).remoteName = undefined
+			mockVsCodeConfig("windows", "Ubuntu WSL", {
+				"Ubuntu WSL": {},
+			})
+			expect(isWslWithoutRemoteExtension()).to.equal(true)
+		})
+
+		it("returns false when remoteName is 'wsl' (extension is active)", () => {
+			Object.defineProperty(process, "platform", { value: "win32" })
+			;(vscode.env as any).remoteName = "wsl"
+			mockVsCodeConfig("windows", "WSL", {
+				WSL: { source: "WSL" },
+			})
+			expect(isWslWithoutRemoteExtension()).to.equal(false)
+		})
+
+		it("returns false on non-Windows platforms", () => {
+			Object.defineProperty(process, "platform", { value: "linux" })
+			;(vscode.env as any).remoteName = undefined
+			mockVsCodeConfig("linux", "bash", {
+				bash: { path: "/bin/bash" },
+			})
+			expect(isWslWithoutRemoteExtension()).to.equal(false)
+		})
+
+		it("returns false on Windows with non-WSL profile", () => {
+			Object.defineProperty(process, "platform", { value: "win32" })
+			;(vscode.env as any).remoteName = undefined
+			mockVsCodeConfig("windows", "PowerShell", {
+				PowerShell: { source: "PowerShell" },
+			})
+			expect(isWslWithoutRemoteExtension()).to.equal(false)
+		})
+
+		it("returns false on Windows with no default profile set", () => {
+			Object.defineProperty(process, "platform", { value: "win32" })
+			;(vscode.env as any).remoteName = undefined
+			mockVsCodeConfig("windows", null, {})
+			expect(isWslWithoutRemoteExtension()).to.equal(false)
 		})
 	})
 

--- a/src/utils/shell.ts
+++ b/src/utils/shell.ts
@@ -28,7 +28,7 @@ export function isWslWithoutRemoteExtension(): boolean {
 	}
 
 	const profile = profiles[defaultProfileName]
-	return profile?.source === "WSL" || defaultProfileName.toLowerCase().includes("wsl")
+	return profile?.source === "WSL" || /\bwsl\b/i.test(defaultProfileName)
 }
 
 const SHELL_PATHS = {

--- a/src/utils/shell.ts
+++ b/src/utils/shell.ts
@@ -4,6 +4,33 @@ import * as vscode from "vscode"
 export const WINDOWS_POWERSHELL_7_PATH = "C:\\Program Files\\PowerShell\\7\\pwsh.exe"
 export const WINDOWS_POWERSHELL_LEGACY_PATH = "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe"
 
+/**
+ * Detects when a Windows user has selected a WSL terminal profile but is NOT
+ * connected via the VS Code WSL extension (ms-vscode-remote.remote-wsl).
+ *
+ * This configuration causes shell integration failures because VS Code runs
+ * on Windows and bridges into WSL for terminal commands, rather than running
+ * natively inside WSL via the extension's remote server.
+ */
+export function isWslWithoutRemoteExtension(): boolean {
+	if (process.platform !== "win32") {
+		return false
+	}
+
+	// If remoteName is "wsl", the user is connected via the WSL extension — no problem
+	if (vscode.env.remoteName === "wsl") {
+		return false
+	}
+
+	const { defaultProfileName, profiles } = getWindowsTerminalConfig()
+	if (!defaultProfileName) {
+		return false
+	}
+
+	const profile = profiles[defaultProfileName]
+	return profile?.source === "WSL" || defaultProfileName.toLowerCase().includes("wsl")
+}
+
 const SHELL_PATHS = {
 	// Windows paths
 	POWERSHELL_7: WINDOWS_POWERSHELL_7_PATH,
@@ -100,7 +127,8 @@ function getWindowsShellFromVSCode(): string | null {
 		if (profile?.path) {
 			// If there's an explicit PowerShell path, return that
 			return profile.path
-		} else if (profile?.source === "PowerShell") {
+		}
+		if (profile?.source === "PowerShell") {
 			// If the profile is sourced from PowerShell, assume the newest
 			return SHELL_PATHS.POWERSHELL_7
 		}

--- a/webview-ui/src/App.stories.tsx
+++ b/webview-ui/src/App.stories.tsx
@@ -842,6 +842,26 @@ export const ShellIntegrationWarning: Story = {
 	},
 }
 
+export const ShellIntegrationWarningWsl: Story = {
+	decorators: [
+		createStoryDecorator({
+			clineMessages: [
+				createMessage(5, "say", "task", "Run a command"),
+				createMessage(4.7, "say", "text", "I'll run the command for you."),
+				createMessage(4.5, "say", "shell_integration_warning_wsl", ""),
+			],
+			vscodeTerminalExecutionMode: "integrated",
+		}),
+	],
+	parameters: {
+		docs: {
+			description: {
+				story: "Shows WSL-specific shell integration warning recommending the VS Code WSL extension.",
+			},
+		},
+	},
+}
+
 export const ErrorRetryInProgress: Story = {
 	decorators: [
 		createStoryDecorator({

--- a/webview-ui/src/components/chat/ChatRow.tsx
+++ b/webview-ui/src/components/chat/ChatRow.tsx
@@ -1057,6 +1057,54 @@ export const ChatRowContent = memo(
 								</div>
 							</div>
 						)
+					case "shell_integration_warning_wsl": {
+						const isBackgroundModeEnabledWsl = vscodeTerminalExecutionMode === "backgroundExec"
+						return (
+							<div className="p-2 bg-warning/20 border border-warning rounded-xs">
+								<div className="flex items-center mb-1">
+									<TriangleAlertIcon className="mr-2 size-2 stroke-3 text-warning" />
+									<span className="font-medium text-foreground">WSL Configuration Issue</span>
+								</div>
+								<div className="text-foreground opacity-90 mb-2">
+									You're using a WSL terminal profile from Windows without the VS Code WSL extension. This
+									causes shell integration failures. To fix:
+								</div>
+								<ol className="text-foreground opacity-80 m-0 pl-5 mb-2 list-decimal text-[12px] leading-relaxed">
+									<li>
+										Install the{" "}
+										<a href="https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-wsl">
+											WSL extension
+										</a>{" "}
+										from Microsoft
+									</li>
+									<li>
+										Open your project from inside WSL by running <code>code .</code> in your WSL terminal
+									</li>
+								</ol>
+								<div className="text-foreground opacity-70 text-[11px] mb-2">
+									Or use Background Terminal mode as a quick workaround:
+								</div>
+								<button
+									className={cn(
+										"bg-button-background text-button-foreground border-0 rounded-xs py-1.5 px-3 text-[12px] flex items-center gap-1.5 cursor-pointer hover:bg-button-hover",
+										{
+											"cursor-default opacity-80 bg-success": isBackgroundModeEnabledWsl,
+										},
+									)}
+									disabled={isBackgroundModeEnabledWsl}
+									onClick={async () => {
+										try {
+											await UiServiceClient.setTerminalExecutionMode(BooleanRequest.create({ value: true }))
+										} catch (error) {
+											console.error("Failed to enable background terminal:", error)
+										}
+									}}>
+									<SettingsIcon className="size-2" />
+									{isBackgroundModeEnabledWsl ? "Background Terminal Enabled" : "Enable Background Terminal"}
+								</button>
+							</div>
+						)
+					}
 					case "error_retry":
 						try {
 							const retryInfo = JSON.parse(message.text || "{}")


### PR DESCRIPTION
## Summary

When a Windows user selects a WSL terminal profile but is **not** connected via the VS Code WSL extension (`ms-vscode-remote.remote-wsl`), shell integration consistently fails. The current generic "Shell Integration Unavailable" warning does not help these users understand the root cause or how to fix it.

This PR adds detection for this specific misconfiguration and shows a targeted WSL-specific warning.

### Problem

Users on Windows with a WSL terminal profile selected (e.g. "WSL Bash", "Ubuntu WSL") but without the VS Code WSL extension experience persistent shell integration failures. This manifests as:

- `[Command is running but producing no output]`
- Commands completing but Cline thinking they are still running
- Repeated "Shell Integration Unavailable" warnings with no actionable WSL-specific guidance

This is a well-documented scenario in #4356 — see reports from @dayglo ("cline 3.26.5 on windows 10 with WSL Ubuntu") and @yousecjoe ("Why do we need to use GitBash in Windows when we are already using Bash in Linux with WSL?").

**Root cause:** Without the WSL extension, VS Code runs on Windows and bridges into WSL for terminal commands. Shell integration sequences do not work reliably across this bridge. When the WSL extension is active, VS Code Server runs natively inside Linux, and shell integration works correctly.

### Solution

**Detection logic** (`src/utils/shell.ts`): New `isWslWithoutRemoteExtension()` function checks three conditions:
1. `process.platform === "win32"` (Windows host)
2. Terminal profile is WSL (via existing `profile.source === "WSL"` or name containing "wsl")
3. `vscode.env.remoteName !== "wsl"` (WSL extension is NOT active)

**Warning flow** (`CommandOrchestrator.ts`): When `no_shell_integration` fires and the WSL mismatch is detected, emits `shell_integration_warning_wsl` instead of the generic warning.

**Targeted UI** (`ChatRow.tsx`): Shows a WSL-specific warning that:
- Explains the WSL extension is needed
- Links to install it from the [VS Code marketplace](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-wsl)
- Recommends opening the project from inside WSL via `code .`
- Offers "Enable Background Terminal" as a quick workaround button

### Changes

| File | Change |
|------|--------|
| `src/utils/shell.ts` | New `isWslWithoutRemoteExtension()` detection function |
| `src/integrations/terminal/types.ts` | Added `isWslWithoutRemoteExtension` to `OrchestrationOptions` |
| `src/integrations/terminal/CommandExecutor.ts` | Passes WSL detection result to orchestrator |
| `src/integrations/terminal/CommandOrchestrator.ts` | Prioritizes WSL warning over generic warnings |
| `src/shared/ExtensionMessage.ts` | Added `shell_integration_warning_wsl` say type |
| `src/shared/proto-conversions/cline-message.ts` | Maps new type to existing `SHELL_INTEGRATION_WARNING` proto enum |
| `webview-ui/src/components/chat/ChatRow.tsx` | WSL-specific warning UI component |
| `webview-ui/src/App.stories.tsx` | Storybook entry for the new warning |
| `src/test/shell.test.ts` | 6 tests covering all WSL detection scenarios |

### Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ♻️ Refactor Changes
- [ ] 💅 Cosmetic Changes
- [ ] 📚 Documentation update
- [ ] 🏃 Workflow Changes

### Pre-flight Checklist

- [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
- [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
- [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

Addresses #4356