### PR TITLE
ci: add path filters, concurrency control, and draft PR skip

### DIFF
--- a/.github/workflows/ext-vscode-test-e2e.yml
+++ b/.github/workflows/ext-vscode-test-e2e.yml
@@ -69,11 +69,15 @@ jobs:
         steps:
             - id: set-matrix
               run: |
-                  echo 'matrix=[{"runner":"ubuntu"},{"runner":"windows"},{"runner":"macos"}]' >> $GITHUB_OUTPUT
+                  if [ "${{ github.event_name }}" = "push" ] || [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+                    echo 'matrix=[{"runner":"ubuntu"},{"runner":"windows"},{"runner":"macos"}]' >> $GITHUB_OUTPUT
+                  else
+                    echo 'matrix=[{"runner":"ubuntu"},{"runner":"windows"}]' >> $GITHUB_OUTPUT
+                  fi
 
     e2e:
         needs: [detect-changes, matrix_prep]
-        if: needs.detect-changes.outputs.e2e == 'true'
+        if: needs.detect-changes.outputs.e2e == 'true' && (github.event_name != 'pull_request' || !github.event.pull_request.draft)
         strategy:
             fail-fast: false
             matrix:

--- a/.github/workflows/ext-vscode-test.yml
+++ b/.github/workflows/ext-vscode-test.yml
@@ -15,6 +15,10 @@ permissions:
     contents: read # Needed to check out code
     pull-requests: read # Needed for changed-file detection on pull requests
 
+concurrency:
+    group: ${{ github.workflow }}-${{ github.event.pull_request.number || format('{0}-{1}', github.event_name, github.ref) }}
+    cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
     detect-changes:
         runs-on: ubuntu-latest
@@ -79,7 +83,7 @@ jobs:
 
     quality-checks:
         needs: detect-changes
-        if: needs.detect-changes.outputs.vscode == 'true' || needs.detect-changes.outputs.testing_platform == 'true'
+        if: (github.event_name != 'pull_request' || !github.event.pull_request.draft) && (needs.detect-changes.outputs.vscode == 'true' || needs.detect-changes.outputs.testing_platform == 'true')
         runs-on: ubuntu-latest
         name: Quality Checks
         defaults:

--- a/.github/workflows/ext-vscode-test.yml
+++ b/.github/workflows/ext-vscode-test.yml
@@ -8,6 +8,9 @@ on:
     pull_request:
         branches:
             - main
+        # ready_for_review re-runs after draft skip so required checks are not
+        # left green from a draft-only pass that never executed vscode-test.
+        types: [opened, reopened, synchronize, ready_for_review]
     workflow_call:
 
 # Set default permissions for all jobs

--- a/.github/workflows/ext-vscode-test.yml
+++ b/.github/workflows/ext-vscode-test.yml
@@ -349,6 +349,7 @@ jobs:
                   TESTING_PLATFORM_CHANGED: ${{ needs.detect-changes.outputs.testing_platform }}
                   VSCODE_TEST_RESULT: ${{ needs.vscode-test.result }}
                   TEST_PLATFORM_RESULT: ${{ needs.test-platform-integration.result }}
+                  IS_DRAFT: ${{ github.event.pull_request.draft }}
               run: |
                   if [ "$DETECT_CHANGES_RESULT" != "success" ]; then
                     echo "detect-changes did not succeed: $DETECT_CHANGES_RESULT"
@@ -357,6 +358,14 @@ jobs:
 
                   if [ "$VSCODE_CHANGED" != "true" ] && [ "$TESTING_PLATFORM_CHANGED" != "true" ]; then
                     echo "No root test paths changed; skipping root test requirements."
+                    exit 0
+                  fi
+
+                  # Draft PRs intentionally skip quality-checks (and thus downstream
+                  # test jobs). The required aggregate "test" check must stay green so
+                  # draft status does not fail the workflow while CI is deferred.
+                  if [ "$IS_DRAFT" = "true" ] && [ "$QUALITY_CHECKS_RESULT" = "skipped" ]; then
+                    echo "Draft PR: quality-checks skipped intentionally; deferring CI until ready for review."
                     exit 0
                   fi
 


### PR DESCRIPTION
## Summary

Quick CI pipeline optimizations that reduce wasted runner time without changing any test logic.

## Changes

### 1. Path filters on test.yml, e2e.yml, cli-tui-tests.yml
Skip the full test suite when only non-code files change:
- `docs/**`, `locales/**`, `**/*.md`, `assets/**`, `.github/ISSUE_TEMPLATE/**`, `walkthrough/**`

Previously, a docs-only PR triggered:
- Full unit + integration tests on 2 OSes
- E2E tests on 3 OSes  
- CLI TUI tests

Now these are skipped. `workflow_dispatch` and `workflow_call` still run unconditionally.

### 2. Concurrency control on test.yml
Added `concurrency` group with `cancel-in-progress` for PRs. When a developer pushes multiple commits quickly, stale runs are cancelled instead of piling up.

Only cancels on `pull_request` events — pushes to `main` always run to completion.

### 3. Draft PR skip
Added `if: github.event_name != 'pull_request' || !github.event.pull_request.draft` to the first job in each workflow:
- `quality-checks` in test.yml (gates all downstream jobs)
- `e2e` in e2e.yml
- `cli-tui-tests` in cli-tui-tests.yml

Draft PRs no longer consume CI resources.

### 4. macOS E2E only on push to main
The E2E matrix now includes macOS only on `push` to `main` and `workflow_dispatch`. PRs run ubuntu + windows only.

macOS runners cost ~10x Linux runners. Full 3-OS E2E coverage is maintained on the main branch.

## Impact
- **Docs-only PRs**: Skip ~30 min of total CI compute across all workflows
- **Rapid PR pushes**: Cancel stale test.yml runs instead of queueing them
- **Draft PRs**: Zero CI consumption until marked ready for review
- **PR E2E**: Save ~$0.80/run by skipping macOS (still runs on main)

## Risk
- Low: only changes workflow triggers and conditions, no test logic modified
- `workflow_call` callers (publish workflows) are unaffected — they don't pass path filters
- `workflow_dispatch` always runs the full suite

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow conditions and runner matrix only; no application or test logic changes.
> 
> **Overview**
> **Defers VS Code CI on draft PRs** while keeping required checks green. `quality-checks` and E2E no longer run when `pull_request.draft` is true; the aggregate `test` job exits successfully if quality-checks was skipped intentionally on a draft. `pull_request` now includes `ready_for_review` so marking a draft ready re-triggers the suite instead of leaving a stale green gate.
> 
> **`ext-vscode-test`** adds **concurrency** keyed by PR number (or ref for non-PR events) with `cancel-in-progress` only on pull requests, so rapid pushes cancel older runs without affecting `main` pushes.
> 
> **E2E matrix** runs **macOS only on `push` and `workflow_dispatch`**; pull requests run Ubuntu and Windows only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d16fb51139438c731d386bac41645f89afc9d99. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->