### PR TITLE
fix(ci): prevent smoke test timeout cancellation

### DIFF
--- a/evals/analysis/src/__tests__/metrics.test.ts
+++ b/evals/analysis/src/__tests__/metrics.test.ts
@@ -233,6 +233,27 @@ describe("MetricsCalculator", () => {
 			expect(metrics.passAt3).toBe(0)
 			expect(metrics.passCaret3).toBe(0)
 		})
+
+		it("does not set passAt3 when first success is after trial 3", () => {
+			// Fail fail fail pass, then early-exit with trialsRequested > 4
+			const observed = [false, false, false, true]
+			const base = calc.calculateTaskMetrics(observed)
+			const metrics = calc.applyEarlyExitPassAtK(base, 4, 5, true)
+
+			expect(metrics.passAt1).toBe(base.passAt1)
+			expect(metrics.passAt3).toBe(base.passAt3)
+			expect(metrics.passAt3).not.toBe(1.0)
+			expect(metrics.passCaret3).toBe(base.passCaret3)
+		})
+
+		it("sets passAt3 when first success is on trial 2 of 5", () => {
+			const observed = [false, true]
+			const metrics = calc.applyEarlyExitPassAtK(calc.calculateTaskMetrics(observed), 2, 5, true)
+
+			expect(metrics.passAt1).toBe(1.0)
+			expect(metrics.passAt3).toBe(1.0)
+			expect(metrics.passCaret3).toBe(0)
+		})
 	})
 
 	describe("getTaskStatus", () => {

--- a/evals/analysis/src/__tests__/metrics.test.ts
+++ b/evals/analysis/src/__tests__/metrics.test.ts
@@ -191,6 +191,50 @@ describe("MetricsCalculator", () => {
 		})
 	})
 
+	describe("applyEarlyExitPassAtK", () => {
+		it("sets pass@k without padding unrun trials for reliability metrics", () => {
+			// Early-exit after first pass when 3 trials were requested
+			const observed = [true]
+			const metrics = calc.applyEarlyExitPassAtK(calc.calculateTaskMetrics(observed), 1, 3, true)
+
+			expect(metrics.passAt1).toBe(1.0)
+			expect(metrics.passAt3).toBe(1.0)
+			// Must not claim all-k reliability or invent flakiness from unrun trials
+			expect(metrics.passCaret3).toBe(0)
+			expect(metrics.flakinessScore).toBe(0)
+		})
+
+		it("does not invent pass^3 via true-padding (anti-regression)", () => {
+			const observed = [true]
+			const padded = [true, true, true]
+			const honest = calc.applyEarlyExitPassAtK(calc.calculateTaskMetrics(observed), 1, 3, true)
+			const falsified = calc.calculateTaskMetrics(padded)
+
+			expect(honest.passAt3).toBe(1.0)
+			expect(honest.passCaret3).toBe(0)
+			expect(falsified.passCaret3).toBe(1.0)
+			expect(honest.passCaret3).not.toBe(falsified.passCaret3)
+		})
+
+		it("is a no-op when all requested trials ran", () => {
+			const trials = [true, false, true]
+			const base = calc.calculateTaskMetrics(trials)
+			const metrics = calc.applyEarlyExitPassAtK({ ...base }, 3, 3, true)
+
+			expect(metrics).toEqual(base)
+		})
+
+		it("is a no-op when the last trial failed (no early-exit pass)", () => {
+			const trials = [false]
+			const base = calc.calculateTaskMetrics(trials)
+			const metrics = calc.applyEarlyExitPassAtK({ ...base }, 1, 3, false)
+
+			expect(metrics.passAt1).toBe(0)
+			expect(metrics.passAt3).toBe(0)
+			expect(metrics.passCaret3).toBe(0)
+		})
+	})
+
 	describe("getTaskStatus", () => {
 		it("returns 'pass' when all trials pass", () => {
 			expect(calc.getTaskStatus([true, true, true])).toBe("pass")

--- a/evals/analysis/src/__tests__/metrics.test.ts
+++ b/evals/analysis/src/__tests__/metrics.test.ts
@@ -238,7 +238,8 @@ describe("MetricsCalculator", () => {
 			// Fail fail fail pass, then early-exit with trialsRequested > 4
 			const observed = [false, false, false, true]
 			const base = calc.calculateTaskMetrics(observed)
-			const metrics = calc.applyEarlyExitPassAtK(base, 4, 5, true)
+			// Copy before call: applyEarlyExitPassAtK mutates its metrics argument.
+			const metrics = calc.applyEarlyExitPassAtK({ ...base }, 4, 5, true)
 
 			expect(metrics.passAt1).toBe(base.passAt1)
 			expect(metrics.passAt3).toBe(base.passAt3)

--- a/evals/analysis/src/metrics.ts
+++ b/evals/analysis/src/metrics.ts
@@ -183,4 +183,37 @@ export class MetricsCalculator {
 		}
 		return "flaky"
 	}
+
+	/**
+	 * After early-exit on a passing trial, set pass@k to 1 without inventing
+	 * unobserved successes for pass^k or flakiness.
+	 *
+	 * pass@k means "found a solution within k trials". If we stop after the
+	 * first pass, that probability is 1 for any requested k. pass^k and
+	 * flakinessScore must still reflect only trials that actually ran.
+	 */
+	applyEarlyExitPassAtK(
+		metrics: {
+			passAt1: number
+			passAt3: number
+			passCaret3: number
+			flakinessScore: number
+		},
+		trialsRan: number,
+		trialsRequested: number,
+		lastTrialPassed: boolean,
+	): {
+		passAt1: number
+		passAt3: number
+		passCaret3: number
+		flakinessScore: number
+	} {
+		if (trialsRan < trialsRequested && lastTrialPassed) {
+			metrics.passAt1 = 1
+			if (trialsRequested >= 3) {
+				metrics.passAt3 = 1
+			}
+		}
+		return metrics
+	}
 }

--- a/evals/analysis/src/metrics.ts
+++ b/evals/analysis/src/metrics.ts
@@ -185,12 +185,13 @@ export class MetricsCalculator {
 	}
 
 	/**
-	 * After early-exit on a passing trial, set pass@k to 1 without inventing
-	 * unobserved successes for pass^k or flakiness.
+	 * After early-exit on a passing trial, set pass@k to 1 only when the first
+	 * success occurred within k attempts, without inventing unobserved
+	 * successes for pass^k or flakiness.
 	 *
-	 * pass@k means "found a solution within k trials". If we stop after the
-	 * first pass, that probability is 1 for any requested k. pass^k and
-	 * flakinessScore must still reflect only trials that actually ran.
+	 * pass@k means "found a solution within k trials". `trialsRan` is the
+	 * 1-based trial index of the first pass when early-exit stops after that
+	 * pass. pass^k and flakinessScore still reflect only trials that ran.
 	 */
 	applyEarlyExitPassAtK(
 		metrics: {
@@ -209,8 +210,11 @@ export class MetricsCalculator {
 		flakinessScore: number
 	} {
 		if (trialsRan < trialsRequested && lastTrialPassed) {
-			metrics.passAt1 = 1
-			if (trialsRequested >= 3) {
+			// First success was on attempt `trialsRan` (early-exit after pass).
+			if (trialsRan <= 1) {
+				metrics.passAt1 = 1
+			}
+			if (trialsRequested >= 3 && trialsRan <= 3) {
 				metrics.passAt3 = 1
 			}
 		}

--- a/evals/smoke-tests/run-smoke-tests.ts
+++ b/evals/smoke-tests/run-smoke-tests.ts
@@ -550,6 +550,9 @@ async function main() {
 			trialWorkdirs.push(trialWorkdir)
 			const result = await runTrial(scenario, modelId, trialWorkdir)
 			trialResults.push(result)
+			if (result.passed && trials > 1) {
+				break
+			}
 		}
 
 		trialResults.forEach((result, t) => {
@@ -565,6 +568,9 @@ async function main() {
 		})
 
 		const trialBools = trialResults.map((t) => t.passed)
+		if (trialResults.length < trials && trialResults[trialResults.length - 1]?.passed) {
+			trialBools.push(...Array(trials - trialResults.length).fill(true))
+		}
 		const metrics = metricsCalc.calculateTaskMetrics(trialBools)
 		const status = metricsCalc.getTaskStatus(trialBools)
 

--- a/evals/smoke-tests/run-smoke-tests.ts
+++ b/evals/smoke-tests/run-smoke-tests.ts
@@ -567,11 +567,16 @@ async function main() {
 			fs.writeFileSync(path.join(logDir, `trial-${trialNum}.log`), logContent)
 		})
 
+		// Use only trials that actually ran for reliability metrics (pass^k,
+		// flakiness). Padding unrun trials with `true` after early-exit would
+		// inflate passCaret3 to 1.0 and force flakinessScore to 0.
 		const trialBools = trialResults.map((t) => t.passed)
-		if (trialResults.length < trials && trialResults[trialResults.length - 1]?.passed) {
-			trialBools.push(...Array(trials - trialResults.length).fill(true))
-		}
-		const metrics = metricsCalc.calculateTaskMetrics(trialBools)
+		const metrics = metricsCalc.applyEarlyExitPassAtK(
+			metricsCalc.calculateTaskMetrics(trialBools),
+			trialResults.length,
+			trials,
+			Boolean(trialResults[trialResults.length - 1]?.passed),
+		)
 		const status = metricsCalc.getTaskStatus(trialBools)
 
 		return {


### PR DESCRIPTION
## Problem

The Smoke Tests workflow has a 15-minute job timeout that is too tight. Build steps take ~80s, and the shell retry loop (`max_attempts=3`) reruns **all 8 scenarios** from scratch on any failure. With each parallel run taking ~6 minutes, three full-suite retries total ~18 minutes of test time, exceeding the 15-minute budget.

This causes the job to be cancelled with "The operation was canceled" — not because of a test failure, but because the timeout kills it mid-run. This was observed on PR #10525 and other recent PRs.

**Timeline from PR #10525 (commit `13facd7c`):**
- Build steps: ~80s
- Smoke test step: ran for 13 min 51 sec → **cancelled by 15-min job timeout**

## Changes

### 1. Increase timeout (15 → 30 minutes)
Provides adequate headroom for build + retries, even in worst-case scenarios.

### 2. Replace shell retry with runner's built-in `--trials 3`
The old approach ran `--trials 1` inside a `max_attempts=3` shell loop that retried **all scenarios** on any failure. The new approach uses `--trials 3 --parallel`, which gives each scenario 3 independent chances (same flaky tolerance as before).

| | Old (shell retry) | New (--trials 3) |
|---|---|---|
| Retry scope | Entire suite (all 8 scenarios) | Per-scenario |
| Passing scenarios re-run? | Yes, on every retry | No (early exit) |
| Worst case (all fail) | 3 × 8 scenarios = 24 runs | 8 × 3 trials = 24 runs |
| Best case (all pass) | 8 runs | 8 runs |
| Typical (1 flaky) | 8 + 8 + 8 = 24 runs | 7 + 3 = 10 runs |

### 3. Early-exit optimization in runner
When a trial passes, skip remaining trials for that scenario. This means passing scenarios run exactly once, and only failures use all 3 trials.

## Before vs After

**Before:** `~80s build + up to 18 min tests = ~19 min` → exceeds 15 min timeout → CANCELLED  
**After:** `~80s build + ~6-8 min tests = ~8 min` → well within 30 min timeout

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to eval/smoke-test execution and metrics reporting, with no production runtime or auth impact.
> 
> **Overview**
> Adds **per-scenario early exit** in the smoke test runner: when `trials > 1`, it stops after the first passing trial instead of running the full retry budget.
> 
> Introduces **`MetricsCalculator.applyEarlyExitPassAtK`** so reporting still treats pass@k as “found a solution within k attempts” when fewer than the requested trials ran. **pass^k** and **flakiness** stay based only on trials that actually executed—avoiding padded `true` values that would falsely show perfect reliability.
> 
> Unit tests cover early-exit edge cases (no-op when all trials run or last trial fails, pass@3 only when success is within three attempts, anti-regression vs true-padding).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6cd03e91192dc34b291da70f077d45c7e4ca257. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->