### PR TITLE
fix: replace flaky setTimeout waits with deterministic drainForTesting() in BannerService tests

### DIFF
--- a/apps/vscode/src/services/banner/__tests__/BannerService.test.ts
+++ b/apps/vscode/src/services/banner/__tests__/BannerService.test.ts
@@ -162,7 +162,7 @@ describe("BannerService", () => {
 				bannerService.getActiveBanners() // Triggers background fetch
 
 				// Wait for background fetch to complete
-				await new Promise((resolve) => setTimeout(resolve, 10))
+				await bannerService.drainForTesting()
 
 				expect(mockFetch.calledOnce).to.be.true
 				const banners = bannerService.getActiveBanners() // Get banners after fetch completes
@@ -181,7 +181,7 @@ describe("BannerService", () => {
 				const banners = bannerService.getActiveBanners()
 
 				// Wait for background fetch to complete
-				await new Promise((resolve) => setTimeout(resolve, 10))
+				await bannerService.drainForTesting()
 
 				expect(banners).to.have.lengthOf(0)
 			})
@@ -318,7 +318,7 @@ describe("BannerService", () => {
 				bannerService.getActiveBanners()
 
 				// Wait for background fetch to complete
-				await new Promise((resolve) => setTimeout(resolve, 10))
+				await bannerService.drainForTesting()
 
 				const banners = bannerService.getActiveBanners()
 				expect(banners).to.have.lengthOf(1)
@@ -352,7 +352,7 @@ describe("BannerService", () => {
 				bannerService.getActiveBanners()
 
 				// Wait for background fetch to complete
-				await new Promise((resolve) => setTimeout(resolve, 10))
+				await bannerService.drainForTesting()
 
 				const banners = bannerService.getActiveBanners()
 				expect(banners).to.have.lengthOf(1)
@@ -386,7 +386,7 @@ describe("BannerService", () => {
 				bannerService.getActiveBanners()
 
 				// Wait for background fetch to complete
-				await new Promise((resolve) => setTimeout(resolve, 10))
+				await bannerService.drainForTesting()
 
 				const banners = bannerService.getActiveBanners()
 				expect(banners).to.have.lengthOf(0)
@@ -419,7 +419,7 @@ describe("BannerService", () => {
 				bannerService.getActiveBanners()
 
 				// Wait for background fetch to complete
-				await new Promise((resolve) => setTimeout(resolve, 10))
+				await bannerService.drainForTesting()
 
 				const banners = bannerService.getActiveBanners()
 				expect(banners).to.have.lengthOf(1)
@@ -453,7 +453,7 @@ describe("BannerService", () => {
 				bannerService.getActiveBanners()
 
 				// Wait for background fetch to complete
-				await new Promise((resolve) => setTimeout(resolve, 10))
+				await bannerService.drainForTesting()
 
 				const banners = bannerService.getActiveBanners()
 				expect(banners).to.have.lengthOf(0)
@@ -485,7 +485,7 @@ describe("BannerService", () => {
 				bannerService.getActiveBanners()
 
 				// Wait for background fetch to complete
-				await new Promise((resolve) => setTimeout(resolve, 10))
+				await bannerService.drainForTesting()
 
 				const banners = bannerService.getActiveBanners()
 				expect(banners).to.have.lengthOf(1)
@@ -515,7 +515,7 @@ describe("BannerService", () => {
 				bannerService.getActiveBanners()
 
 				// Wait for background fetch to complete
-				await new Promise((resolve) => setTimeout(resolve, 10))
+				await bannerService.drainForTesting()
 
 				const banners = bannerService.getActiveBanners()
 				expect(banners).to.have.lengthOf(1)
@@ -548,14 +548,14 @@ describe("BannerService", () => {
 				bannerService.getActiveBanners()
 
 				// Wait for background fetch to complete
-				await new Promise((resolve) => setTimeout(resolve, 10))
+				await bannerService.drainForTesting()
 				expect(mockFetch.calledOnce).to.be.true
 
 				bannerService.clearCache()
 
 				bannerService.getActiveBanners()
 				// Wait for background fetch to complete
-				await new Promise((resolve) => setTimeout(resolve, 10))
+				await bannerService.drainForTesting()
 				expect(mockFetch.calledTwice).to.be.true
 			})
 		})
@@ -585,7 +585,7 @@ describe("BannerService", () => {
 				bannerService.getActiveBanners()
 
 				// Wait for background fetch to complete
-				await new Promise((resolve) => setTimeout(resolve, 10))
+				await bannerService.drainForTesting()
 
 				expect(mockFetch.calledOnce).to.be.true
 				const call = mockFetch.getCall(0)
@@ -624,7 +624,7 @@ describe("BannerService", () => {
 				bannerService.getActiveBanners()
 
 				// Wait for background fetch to complete
-				await new Promise((resolve) => setTimeout(resolve, 10))
+				await bannerService.drainForTesting()
 
 				const banners = bannerService.getActiveBanners()
 				expect(banners).to.have.lengthOf(1)
@@ -665,7 +665,7 @@ describe("BannerService", () => {
 				bannerService.getActiveBanners()
 
 				// Wait for background fetch to complete
-				await new Promise((resolve) => setTimeout(resolve, 10))
+				await bannerService.drainForTesting()
 
 				const banners = bannerService.getActiveBanners()
 				expect(banners).to.have.lengthOf(0)
@@ -713,7 +713,7 @@ describe("BannerService", () => {
 				bannerService.getActiveBanners()
 
 				// Wait for background fetch to complete
-				await new Promise((resolve) => setTimeout(resolve, 10))
+				await bannerService.drainForTesting()
 
 				const banners = bannerService.getActiveBanners()
 				expect(banners).to.have.lengthOf(2)
@@ -745,7 +745,7 @@ describe("BannerService", () => {
 				bannerService.getActiveBanners()
 
 				// Wait for background fetch to complete
-				await new Promise((resolve) => setTimeout(resolve, 10))
+				await bannerService.drainForTesting()
 
 				const banners = bannerService.getActiveBanners()
 				expect(banners).to.have.lengthOf(1)
@@ -778,7 +778,7 @@ describe("BannerService", () => {
 				bannerService.getActiveBanners()
 
 				// Wait for background fetch to complete
-				await new Promise((resolve) => setTimeout(resolve, 10))
+				await bannerService.drainForTesting()
 
 				const banners = bannerService.getActiveBanners()
 				expect(banners).to.have.lengthOf(1)
@@ -811,7 +811,7 @@ describe("BannerService", () => {
 				bannerService.getActiveBanners()
 
 				// Wait for background fetch to complete
-				await new Promise((resolve) => setTimeout(resolve, 10))
+				await bannerService.drainForTesting()
 
 				const banners = bannerService.getActiveBanners()
 				expect(banners).to.have.lengthOf(0)
@@ -854,7 +854,7 @@ describe("BannerService", () => {
 				bannerService.getActiveBanners()
 
 				// Wait for background fetch to complete
-				await new Promise((resolve) => setTimeout(resolve, 10))
+				await bannerService.drainForTesting()
 
 				const banners = bannerService.getActiveBanners()
 				expect(mockedPostStateToWebview.called).to.be.true
@@ -892,7 +892,7 @@ describe("BannerService", () => {
 			await mockFetchForTesting(mockFetch, async () => {
 				const bannerService = BannerService.initialize(mockController)
 				bannerService.getActiveBanners()
-				await new Promise((resolve) => setTimeout(resolve, 10))
+				await bannerService.drainForTesting()
 
 				expect(await getIdeParam(mockFetch)).to.equal("vscode")
 			})
@@ -905,7 +905,7 @@ describe("BannerService", () => {
 			await mockFetchForTesting(mockFetch, async () => {
 				const bannerService = BannerService.initialize(mockController)
 				bannerService.getActiveBanners()
-				await new Promise((resolve) => setTimeout(resolve, 10))
+				await bannerService.drainForTesting()
 
 				expect(await getIdeParam(mockFetch)).to.equal("vscode")
 			})
@@ -918,7 +918,7 @@ describe("BannerService", () => {
 			await mockFetchForTesting(mockFetch, async () => {
 				const bannerService = BannerService.initialize(mockController)
 				bannerService.getActiveBanners()
-				await new Promise((resolve) => setTimeout(resolve, 10))
+				await bannerService.drainForTesting()
 
 				expect(await getIdeParam(mockFetch)).to.equal("jetbrains")
 			})
@@ -931,7 +931,7 @@ describe("BannerService", () => {
 			await mockFetchForTesting(mockFetch, async () => {
 				const bannerService = BannerService.initialize(mockController)
 				bannerService.getActiveBanners()
-				await new Promise((resolve) => setTimeout(resolve, 10))
+				await bannerService.drainForTesting()
 
 				expect(await getIdeParam(mockFetch)).to.equal("jetbrains")
 			})
@@ -944,7 +944,7 @@ describe("BannerService", () => {
 			await mockFetchForTesting(mockFetch, async () => {
 				const bannerService = BannerService.initialize(mockController)
 				bannerService.getActiveBanners()
-				await new Promise((resolve) => setTimeout(resolve, 10))
+				await bannerService.drainForTesting()
 
 				expect(await getIdeParam(mockFetch)).to.equal("cli")
 			})
@@ -957,7 +957,7 @@ describe("BannerService", () => {
 			await mockFetchForTesting(mockFetch, async () => {
 				const bannerService = BannerService.initialize(mockController)
 				bannerService.getActiveBanners()
-				await new Promise((resolve) => setTimeout(resolve, 10))
+				await bannerService.drainForTesting()
 
 				expect(await getIdeParam(mockFetch)).to.equal("vscode")
 			})
@@ -970,7 +970,7 @@ describe("BannerService", () => {
 			await mockFetchForTesting(mockFetch, async () => {
 				const bannerService = BannerService.initialize(mockController)
 				bannerService.getActiveBanners()
-				await new Promise((resolve) => setTimeout(resolve, 10))
+				await bannerService.drainForTesting()
 
 				expect(await getIdeParam(mockFetch)).to.equal("vscode")
 			})
@@ -983,7 +983,7 @@ describe("BannerService", () => {
 			await mockFetchForTesting(mockFetch, async () => {
 				const bannerService = BannerService.initialize(mockController)
 				bannerService.getActiveBanners()
-				await new Promise((resolve) => setTimeout(resolve, 10))
+				await bannerService.drainForTesting()
 
 				expect(await getIdeParam(mockFetch)).to.equal("unknown")
 			})
@@ -996,7 +996,7 @@ describe("BannerService", () => {
 			await mockFetchForTesting(mockFetch, async () => {
 				const bannerService = BannerService.initialize(mockController)
 				bannerService.getActiveBanners()
-				await new Promise((resolve) => setTimeout(resolve, 10))
+				await bannerService.drainForTesting()
 
 				expect(await getIdeParam(mockFetch)).to.equal("unknown")
 			})
@@ -1009,7 +1009,7 @@ describe("BannerService", () => {
 			await mockFetchForTesting(mockFetch, async () => {
 				const bannerService = BannerService.initialize(mockController)
 				bannerService.getActiveBanners()
-				await new Promise((resolve) => setTimeout(resolve, 10))
+				await bannerService.drainForTesting()
 
 				expect(await getIdeParam(mockFetch)).to.equal("jetbrains")
 			})


### PR DESCRIPTION
## Problem

BannerService tests flake on Windows CI with `Error: Timeout of 2000ms exceeded`. This is a known intermittent failure on the `test (windows-latest)` job.

## Root Cause

29 tests use `await new Promise(resolve => setTimeout(resolve, 10))` to wait for background fetch completion. This 10ms sleep is a race condition — on Windows CI runners under load, the microtask/promise queue may not drain within 10ms, causing the test to hang until mocha's 2000ms default timeout expires.

## Fix

`BannerService` already exposes a `drainForTesting()` method that deterministically awaits the in-flight fetch promise:

```ts
public async drainForTesting(): Promise<void> {
    await this.fetchPromise
}
```

Some tests already use this (via the `flushBannerServiceWork` helper for fake-timer tests), but 29 tests used the 10ms sleep hack instead.

This PR replaces all 29 instances of `setTimeout(resolve, 10)` with `bannerService.drainForTesting()`, making the tests deterministic regardless of CI runner speed.

## Changes

- `src/services/banner/__tests__/BannerService.test.ts` — Replace `await new Promise(resolve => setTimeout(resolve, 10))` with `await bannerService.drainForTesting()` (29 occurrences)

## Testing

All 1422 unit tests pass locally, including all 35 BannerService tests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only synchronization change; no runtime banner or API logic modified.
> 
> **Overview**
> **BannerService** unit tests no longer use a fixed **10ms `setTimeout`** to wait for background banner fetches. Those waits are replaced with **`await bannerService.drainForTesting()`**, which awaits the service’s in-flight **`fetchPromise`**.
> 
> This aligns the affected cases with tests that already used **`flushBannerServiceWork`** / **`drainForTesting`**, and is meant to stop intermittent **Windows CI** timeouts when the microtask queue doesn’t settle within 10ms under load. **Production `BannerService` behavior is unchanged**—only **`BannerService.test.ts`** is updated (~29 call sites).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 195c9178dd59c28ce79b2b7bd1b3ead1a2702b2f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->