### PR TITLE
fix: replace buf with npx buf in proto-lint.sh

### DIFF
--- a/scripts/proto-lint.sh
+++ b/scripts/proto-lint.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 set -u
 
-buf lint
+npx buf lint
 
-if ! buf format -w --exit-code; then
+if ! npx buf format -w --exit-code; then
   echo Proto files were formatted
 fi
 
@@ -12,4 +12,3 @@ if grep -rn "rpc .*[A-Z][A-Z].*[(]" --include="*.proto"; then
   echo Error: Proto RPC names cannot contain repeated capital letters
   exit 1
 fi
-

--- a/src/core/controller/file/searchFiles.ts
+++ b/src/core/controller/file/searchFiles.ts
@@ -60,11 +60,7 @@ export async function searchFiles(controller: Controller, request: FileSearchReq
 
 			if (!workspacePath) {
 				Logger.error("Error in searchFiles: No workspace path available")
-				telemetryService.captureMentionFailed(
-					"folder",
-					"workspace_unavailable",
-					"No workspace path available",
-				)
+				telemetryService.captureMentionFailed("folder", "workspace_unavailable", "No workspace path available")
 				return {
 					results: [],
 					mentionsRequestId: request.mentionsRequestId,


### PR DESCRIPTION
<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- For feature requests: Created a discussion in our Feature Requests discussions board https://github.com/cline/cline/discussions/categories/feature-requests and received approval from core maintainers before implementation
- For all changes: Link the associated issue/discussion in the "Related Issue" section below

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly without prior discussion.

Why this requirement?
We deeply appreciate all community contributions - they are essential to Cline's success! To ensure the best use of everyone's time and maintain project direction, we use our Feature Requests discussions board to gauge community interest and validate feature ideas before implementation begins. This helps us focus development efforts on features that will benefit the most users.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** N/A (build tooling fix)

### Description

<!-- 
Help reviewers understand your changes by making this PR readable and well-organized:

- What problem does this PR solve?
- Why were these changes introduced and what purpose do they serve?
- For larger changes, provide context about your approach and reasoning

Small PRs may need minimal description, but larger changes benefit from explaining where you're coming from. Much of this context can be in the linked issue above, so feel free to reference it rather than repeating everything here.
-->

The `buf` command in `node_modules/.bin/buf` is a Node.js script with a `#!/usr/bin/env node` shebang, but `node` is not available on PATH when it runs in a Linux environment (e.g., WSL on Windows). This causes the error:

```
node_modules/.bin/buf: 15: exec: node: not found
```

**Fix**: Replace `buf` with `npx buf` in `proto-lint.sh`. `npx` resolves and runs the locally installed `buf` package correctly regardless of PATH.

### Test Procedure

<!-- 
Please walk us through your testing approach and thought process. This helps reviewers understand that you've thoroughly considered the impact of your changes:

- How did you test this change?
- What could potentially break and how did you verify it doesn't?
- What existing functionality might be affected and how did you check it still works?
- Why are you confident this is ready for merge?

We're not looking for exhaustive documentation - just evidence that you've thought through the implications of your changes and tested accordingly.
-->

1. Run `npm run lint:proto` on Windows
2. Verify no `buf: command not found` or `node: not found` error
3. Verify `buf lint` executes and passes
4. Run `vsce package` — verify the full build pipeline completes without proto-lint errors

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

N/A — no UI changes.

### Additional Notes

<!-- Add any additional notes for reviewers -->

N/A