### PR TITLE
publish-nightly improvements

### DIFF
--- a/.github/workflows/publish-nightly.yml
+++ b/.github/workflows/publish-nightly.yml
@@ -5,6 +5,14 @@ on:
 
 run-name: "Publish Nightly from ${{ github.ref_name }} @ ${{ github.sha }}"
 
+# Prevent concurrent publish runs on the same branch. The nightly publish script
+# generates the extension version from a seconds-resolution timestamp, so parallel
+# runs on the same ref can collide on the same version and cause publish failures
+# or inconsistent tagging. Runs on different branches proceed independently.
+concurrency:
+  group: publish-nightly-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions:
   contents: write
   checks: write

--- a/.github/workflows/publish-nightly.yml
+++ b/.github/workflows/publish-nightly.yml
@@ -3,73 +3,95 @@ name: "Publish Nightly Release"
 on:
   workflow_dispatch:
 
+run-name: "Publish Nightly from ${{ github.ref_name }} @ ${{ github.sha }}"
+
 permissions:
-    contents: write
-    packages: write
-    checks: write
-    pull-requests: write
+  contents: write
+  packages: write
+  checks: write
+  pull-requests: write
 
 jobs:
-    test:
-        uses: ./.github/workflows/test.yml
+  test:
+    if: github.repository == 'cline/cline' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dpc/sdk-migration-simpler-login')
+    uses: ./.github/workflows/test.yml
 
-    publish:
-        needs: test
-        name: Publish Cline (Nightly) Extension
-        if: github.repository == 'cline/cline'
-        runs-on: ubuntu-latest
-        environment: PublishNightly
+  publish:
+    needs: test
+    name: Publish Cline (Nightly) Extension
+    if: github.repository == 'cline/cline' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dpc/sdk-migration-simpler-login')
+    runs-on: ubuntu-latest
+    environment: PublishNightly
 
-        steps:
-            - uses: actions/checkout@v4
-              with:
-                  lfs: true
+    steps:
+      - name: Checkout selected branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.sha }}
+          lfs: true
+          persist-credentials: false
 
-            - name: Check for recent commits
-              run: |
-                if [ $(git rev-list --count HEAD --since="24 hours ago") -eq 0 ]; then
-                  echo "No commits in last 24 hours, exiting"
-                  exit 0
-                fi
-                echo "Found recent commits, proceeding with build"
-                
-            - name: Setup Node.js
-              uses: actions/setup-node@v4
-              with:
-                  # Keep publish environment aligned with test workflow/tooling lockfile expectations.
-                  # Newer LTS (Node 24 / npm 11) can make `npm list` fail with ELSPROBLEMS during vsce packaging.
-                  node-version: 22
+      - name: Show build source
+        run: |
+          echo "Building ref: $GITHUB_REF"
+          echo "Building sha: $GITHUB_SHA"
+          git --no-pager log -1 --oneline
 
-            - name: Install root dependencies
-              run: npm ci --include=optional
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          # Keep publish environment aligned with test workflow/tooling lockfile expectations.
+          # Newer LTS (Node 24 / npm 11) can make `npm list` fail with ELSPROBLEMS during vsce packaging.
+          node-version: 22
 
-            - name: Install webview-ui dependencies
-              run: cd webview-ui && npm ci --include=optional
+      - name: Install root dependencies
+        run: npm ci --include=optional
 
-            - name: Install Publishing Tools
-              run: npm install -g @vscode/vsce ovsx
+      - name: Install webview-ui dependencies
+        run: cd webview-ui && npm ci --include=optional
 
-            - name: Verify LFS media assets are resolved
-              run: |
-                  for FILE in webview-ui/src/assets/cline_kanban_demo.mp4 webview-ui/src/assets/cline_kanban_demo.webm; do
-                    if grep -q "git-lfs.github.com/spec/v1" "$FILE"; then
-                      echo "Error: $FILE is still a Git LFS pointer in CI checkout"
-                      exit 1
-                    fi
-                  done
+      - name: Install Publishing Tools
+        run: npm install -g @vscode/vsce ovsx
 
-            - name: Publish Nightly Extension
-              env:
-                  VSCE_PAT: ${{ secrets.VSCE_PAT }}
-                  OVSX_PAT: ${{ secrets.OVSX_PAT }}
-                  TELEMETRY_SERVICE_API_KEY: ${{ secrets.TELEMETRY_SERVICE_API_KEY }}
-                  ERROR_SERVICE_API_KEY: ${{ secrets.ERROR_SERVICE_API_KEY }}
-                  CLINE_ENVIRONMENT: production
-                  # OpenTelemetry production defaults (can be overridden at runtime)
-                  OTEL_TELEMETRY_ENABLED: ${{ secrets.OTEL_TELEMETRY_ENABLED }}
-                  OTEL_LOGS_EXPORTER: otlp
-                  OTEL_METRICS_EXPORTER: otlp
-                  OTEL_EXPORTER_OTLP_PROTOCOL: ${{ secrets.OTEL_EXPORTER_OTLP_PROTOCOL }}
-                  OTEL_EXPORTER_OTLP_ENDPOINT: ${{ secrets.OTEL_EXPORTER_OTLP_ENDPOINT }}
-                  OTEL_EXPORTER_OTLP_HEADERS: ${{ secrets.OTEL_EXPORTER_OTLP_HEADERS }}
-              run: npm run publish:marketplace:nightly
+      - name: Verify LFS media assets are resolved
+        run: |
+          for FILE in webview-ui/src/assets/cline_kanban_demo.mp4 webview-ui/src/assets/cline_kanban_demo.webm; do
+            if grep -q "git-lfs.github.com/spec/v1" "$FILE"; then
+              echo "Error: $FILE is still a Git LFS pointer in CI checkout"
+              exit 1
+            fi
+          done
+
+      - name: Publish Nightly Extension
+        env:
+          VSCE_PAT: ${{ secrets.VSCE_PAT }}
+          OVSX_PAT: ${{ secrets.OVSX_PAT }}
+          TELEMETRY_SERVICE_API_KEY: ${{ secrets.TELEMETRY_SERVICE_API_KEY }}
+          ERROR_SERVICE_API_KEY: ${{ secrets.ERROR_SERVICE_API_KEY }}
+          CLINE_ENVIRONMENT: production
+          # OpenTelemetry production defaults (can be overridden at runtime)
+          OTEL_TELEMETRY_ENABLED: ${{ secrets.OTEL_TELEMETRY_ENABLED }}
+          OTEL_LOGS_EXPORTER: otlp
+          OTEL_METRICS_EXPORTER: otlp
+          OTEL_EXPORTER_OTLP_PROTOCOL: ${{ secrets.OTEL_EXPORTER_OTLP_PROTOCOL }}
+          OTEL_EXPORTER_OTLP_ENDPOINT: ${{ secrets.OTEL_EXPORTER_OTLP_ENDPOINT }}
+          OTEL_EXPORTER_OTLP_HEADERS: ${{ secrets.OTEL_EXPORTER_OTLP_HEADERS }}
+        run: npm run publish:marketplace:nightly
+
+      - name: Tag published commit
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          SAFE_REF=$(echo "$GITHUB_REF_NAME" | tr '/[:upper:]' '-[:lower:]' | tr -cd 'a-z0-9._-')
+          SHORT_SHA=$(git rev-parse --short=12 HEAD)
+          TIMESTAMP=$(date -u +"%Y%m%d%H%M%S")
+          TAG="nightly-${SAFE_REF}-${TIMESTAMP}-${SHORT_SHA}"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -a "$TAG" -m "Cline Nightly published from ${GITHUB_REF_NAME} at ${GITHUB_SHA}"
+          # use token auth to push tag since we set persist-credentials: false on checkout for security hardening,
+          # so the default GITHUB_TOKEN auth won't be available in this step
+          git push "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "refs/tags/${TAG}"
+
+          echo "Tagged published commit: $TAG"

--- a/.github/workflows/publish-nightly.yml
+++ b/.github/workflows/publish-nightly.yml
@@ -7,9 +7,7 @@ run-name: "Publish Nightly from ${{ github.ref_name }} @ ${{ github.sha }}"
 
 permissions:
   contents: write
-  packages: write
   checks: write
-  pull-requests: write
 
 jobs:
   test:
@@ -90,8 +88,8 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git tag -a "$TAG" -m "Cline Nightly published from ${GITHUB_REF_NAME} at ${GITHUB_SHA}"
-          # use token auth to push tag since we set persist-credentials: false on checkout for security hardening,
-          # so the default GITHUB_TOKEN auth won't be available in this step
+          # Use an explicit HTTPS remote with GH_TOKEN because checkout was run with
+          # persist-credentials: false, so actions/checkout did not persist a git credential helper.
           git push "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "refs/tags/${TAG}"
 
           echo "Tagged published commit: $TAG"


### PR DESCRIPTION
   ## Summary

   This consolidates nightly publishing into `.github/workflows/publish-nightly.yml` and removes the separate SDK nightly workflow.

   The nightly publisher is now manual-only and publishes the exact branch/SHA selected when dispatching the workflow. It is guarded to only run in `cline/cline` for:

   - `main`
   - `dpc/sdk-migration-simpler-login`

   It also logs the source ref/SHA and tags the published commit after a successful publish, so bug reports can be mapped back to the exact shipped source.

   ## Security / GitHub settings required before merge

   Before merging, we should update GitHub repo settings so the trusted branches and publishing environment are protected:

   1. Protect `dpc/sdk-migration-simpler-login`
      - Restrict direct pushes/updates to trusted maintainers or teams

   2. Confirm `main` has these protections (they should already be there)
      - No unrestricted direct pushes
      - PR review required
      - Force pushes blocked

   3. Lock down the `PublishNightly` environment
      - Restrict deployment branches/tags to:
        - `main`
        - `dpc/sdk-migration-simpler-login`

   4. Confirm workflow/manual-dispatch permissions
      - Only trusted repo members can manually run Actions in `cline/cline`
      - Forks cannot publish because the job is guarded to `github.repository == 'cline/cline'` and forks do not have our secrets

   ## Notes

   This intentionally trades the previous cross-branch checkout pattern for clearer release provenance: the workflow run, checked-out code, published artifact, and tag all correspond to the selected branch/SHA.
