### PR TITLE
Remove stale free model fallback

### DIFF
--- a/cli/src/constants/featured-models.test.ts
+++ b/cli/src/constants/featured-models.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest"
-import { getAllFeaturedModels, mapRecommendedModelsToFeaturedModels } from "./featured-models"
+import { getAllFeaturedModels, mapRecommendedModelsToFeaturedModels, withFeaturedModelFallback } from "./featured-models"
 
 describe("featured models", () => {
 	it("includes display names for all featured models", () => {
@@ -10,14 +10,33 @@ describe("featured models", () => {
 		}
 	})
 
-	it("fills free model metadata from fallback when upstream payload is sparse", () => {
+	it("does not add fallback free models when upstream free models are empty", () => {
+		const models = mapRecommendedModelsToFeaturedModels({
+			recommended: [],
+			free: [],
+		})
+
+		expect(models.free).toEqual([])
+	})
+
+	it("only falls back recommended models", () => {
+		const models = withFeaturedModelFallback({
+			recommended: [],
+			free: [],
+		})
+
+		expect(models.recommended.length).toBeGreaterThan(0)
+		expect(models.free).toEqual([])
+	})
+
+	it("adds the free label to upstream free models when tags are omitted", () => {
 		const models = mapRecommendedModelsToFeaturedModels({
 			recommended: [],
 			free: [{ id: "trinity-large-preview:free", name: "trinity-large-preview:free", description: "", tags: [] }],
 		})
 
-		expect(models.free[0]?.name).toBe("Arcee AI Trinity Large Preview")
-		expect(models.free[0]?.description).toBe("Arcee AI's advanced large preview model in the Trinity series")
+		expect(models.free[0]?.name).toBe("trinity-large-preview:free")
+		expect(models.free[0]?.description).toBe("")
 		expect(models.free[0]?.labels).toContain("FREE")
 	})
 })

--- a/cli/src/constants/featured-models.ts
+++ b/cli/src/constants/featured-models.ts
@@ -86,6 +86,5 @@ export function mapRecommendedModelsToFeaturedModels(data: RecommendedModelsByTi
 
 export function withFeaturedModelFallback(modelsByTier: FeaturedModelsByTier): FeaturedModelsByTier {
 	const recommended = modelsByTier.recommended.length > 0 ? modelsByTier.recommended : FEATURED_MODELS.recommended
-	const free = modelsByTier.free.length > 0 ? modelsByTier.free : FEATURED_MODELS.free
-	return { recommended, free }
+	return { recommended, free: modelsByTier.free }
 }

--- a/src/core/api/providers/__tests__/cline.test.ts
+++ b/src/core/api/providers/__tests__/cline.test.ts
@@ -1,12 +1,14 @@
 import "should"
 import { openRouterDefaultModelInfo } from "@shared/api"
 import sinon from "sinon"
+import { resetClineRecommendedModelsCacheForTests } from "@/core/controller/models/refreshClineRecommendedModels"
 import { ClineAccountService } from "@/services/account/ClineAccountService"
 import { AuthService } from "@/services/auth/AuthService"
 import { ClineHandler } from "../cline"
 
 describe("ClineHandler", () => {
 	afterEach(() => {
+		resetClineRecommendedModelsCacheForTests()
 		sinon.restore()
 	})
 
@@ -60,6 +62,49 @@ describe("ClineHandler", () => {
 				inputTokens: 17,
 				outputTokens: 9,
 				totalCost: 0,
+			},
+		])
+	})
+
+	it("should not zero usage cost for removed free fallback models", async () => {
+		const handler = createHandler({})
+		const fakeClient = {
+			chat: {
+				completions: {
+					create: sinon.stub().resolves(
+						createAsyncIterable([
+							{
+								choices: [{}],
+								usage: {
+									prompt_tokens: 17,
+									completion_tokens: 9,
+									cost: 0.02,
+								},
+							},
+						]),
+					),
+				},
+			},
+		}
+		sinon.stub(handler as any, "ensureClient").resolves(fakeClient as any)
+		sinon.stub(handler, "getModel").returns({
+			id: "kwaipilot/kat-coder-pro",
+			info: openRouterDefaultModelInfo,
+		})
+
+		const chunks: any[] = []
+		for await (const chunk of handler.createMessage("system", [{ role: "user", content: "hi" }])) {
+			chunks.push(chunk)
+		}
+
+		chunks.should.deepEqual([
+			{
+				type: "usage",
+				cacheWriteTokens: 0,
+				cacheReadTokens: 0,
+				inputTokens: 17,
+				outputTokens: 9,
+				totalCost: 0.02,
 			},
 		])
 	})

--- a/src/core/api/providers/cline.ts
+++ b/src/core/api/providers/cline.ts
@@ -9,7 +9,6 @@ import { ClineAccountService } from "@/services/account/ClineAccountService"
 import { AuthService } from "@/services/auth/AuthService"
 import { buildClineExtraHeaders } from "@/services/EnvUtils"
 import { CLINE_ACCOUNT_AUTH_ERROR_MESSAGE } from "@/shared/ClineAccount"
-import { CLINE_RECOMMENDED_MODELS_FALLBACK } from "@/shared/cline/recommended-models"
 import type { ClineStorageMessage } from "@/shared/messages/content"
 import { fetch, getAxiosSettings } from "@/shared/net"
 import { Logger } from "@/shared/services/Logger"
@@ -36,8 +35,6 @@ interface ClineHandlerOptions extends CommonApiHandlerOptions {
 function normalizeModelId(modelId: string): string {
 	return modelId.trim().toLowerCase()
 }
-
-const CLINE_FREE_MODEL_IDS = new Set(CLINE_RECOMMENDED_MODELS_FALLBACK.free.map((model) => normalizeModelId(model.id)))
 
 function getCacheReadTokens(usage: any): number {
 	return usage?.prompt_tokens_details?.cached_tokens || usage?.cache_read_input_tokens || 0
@@ -68,14 +65,12 @@ export class ClineHandler implements ApiHandler {
 		try {
 			const models = await refreshClineRecommendedModels()
 			const freeModelIds = models.free.map((model) => normalizeModelId(model.id)).filter((modelId) => modelId.length > 0)
-			if (freeModelIds.length > 0) {
-				return new Set(freeModelIds)
-			}
+			return new Set(freeModelIds)
 		} catch (error) {
 			Logger.error("Error resolving Cline free model IDs from recommended models:", error)
 		}
 
-		return CLINE_FREE_MODEL_IDS
+		return new Set<string>()
 	}
 
 	private async ensureClient(): Promise<OpenAI> {

--- a/src/shared/cline/recommended-models.ts
+++ b/src/shared/cline/recommended-models.ts
@@ -40,18 +40,5 @@ export const CLINE_RECOMMENDED_MODELS_FALLBACK: ClineRecommendedModelsData = {
 			tags: ["NEW"],
 		},
 	],
-	free: [
-		{
-			id: "kwaipilot/kat-coder-pro",
-			name: "KwaiKAT Kat Coder Pro",
-			description: "KwaiKAT's most advanced agentic coding model in the KAT-Coder series",
-			tags: ["FREE"],
-		},
-		{
-			id: "arcee-ai/trinity-large-preview:free",
-			name: "Arcee AI Trinity Large Preview",
-			description: "Arcee AI's advanced large preview model in the Trinity series",
-			tags: ["FREE"],
-		},
-	],
+	free: [],
 }

--- a/webview-ui/src/components/settings/ClineModelPicker.tsx
+++ b/webview-ui/src/components/settings/ClineModelPicker.tsx
@@ -88,10 +88,6 @@ const RECOMMENDED_MODELS_FALLBACK: FeaturedModelCardEntry[] = CLINE_RECOMMENDED_
 	.map((model) => toFeaturedModelCardEntry(model, "RECOMMENDED"))
 	.filter((model): model is FeaturedModelCardEntry => model !== null)
 
-const FREE_MODELS_FALLBACK: FeaturedModelCardEntry[] = CLINE_RECOMMENDED_MODELS_FALLBACK.free
-	.map((model) => toFeaturedModelCardEntry(model, "FREE"))
-	.filter((model): model is FeaturedModelCardEntry => model !== null)
-
 const ClineModelPicker: React.FC<ClineModelPickerProps> = ({ isPopup, currentMode, showProviderRouting, initialTab }) => {
 	const { handleModeFieldsChange, handleFieldChange } = useApiConfigurationHandlers()
 	const { apiConfiguration, favoritedModelIds, clineModels, refreshClineModels } = useExtensionState()
@@ -102,9 +98,7 @@ const ClineModelPicker: React.FC<ClineModelPickerProps> = ({ isPopup, currentMod
 	const [clineRecommendedModels, setClineRecommendedModels] = useState<FeaturedModelCardEntry[]>([])
 	const [clineFreeModels, setClineFreeModels] = useState<FeaturedModelCardEntry[]>([])
 	const freeClineModelIds = useMemo(() => {
-		const freeModelIds =
-			clineFreeModels.length > 0 ? clineFreeModels.map((model) => model.id) : FREE_MODELS_FALLBACK.map((model) => model.id)
-		return [...new Set(freeModelIds)]
+		return [...new Set(clineFreeModels.map((model) => model.id))]
 	}, [clineFreeModels])
 	const freeClineModelIdSet = useMemo(
 		() => new Set(freeClineModelIds.map((modelId) => normalizeModelId(modelId))),
@@ -115,7 +109,8 @@ const ClineModelPicker: React.FC<ClineModelPickerProps> = ({ isPopup, currentMod
 		() => (clineRecommendedModels.length > 0 ? clineRecommendedModels : RECOMMENDED_MODELS_FALLBACK),
 		[clineRecommendedModels],
 	)
-	const freeModels = useMemo(() => (clineFreeModels.length > 0 ? clineFreeModels : FREE_MODELS_FALLBACK), [clineFreeModels])
+	const freeModels = clineFreeModels
+	const hasFreeModels = freeModels.length > 0
 	const hasSuccessfulClineRecommendedModelsFetchRef = useRef(false)
 	const isFetchingClineRecommendedModelsRef = useRef(false)
 	const clineRecommendedModelsRetryTimeoutRef = useRef<number | null>(null)
@@ -179,10 +174,14 @@ const ClineModelPicker: React.FC<ClineModelPickerProps> = ({ isPopup, currentMod
 	}, [clearClineRecommendedModelsRetryTimeout])
 
 	useEffect(() => {
-		if (initialTab) {
-			setActiveTab(initialTab)
+		if (initialTab === "free") {
+			setActiveTab(hasFreeModels ? "free" : "recommended")
+			return
 		}
-	}, [initialTab])
+		if (initialTab === "recommended") {
+			setActiveTab("recommended")
+		}
+	}, [hasFreeModels, initialTab])
 
 	useEffect(() => {
 		if (initialTab) {
@@ -400,9 +399,11 @@ const ClineModelPicker: React.FC<ClineModelPickerProps> = ({ isPopup, currentMod
 						<Tab active={activeTab === "recommended"} onClick={() => setActiveTab("recommended")}>
 							Recommended
 						</Tab>
-						<Tab active={activeTab === "free"} onClick={() => setActiveTab("free")}>
-							Free
-						</Tab>
+						{hasFreeModels && (
+							<Tab active={activeTab === "free"} onClick={() => setActiveTab("free")}>
+								Free
+							</Tab>
+						)}
 					</TabsContainer>
 
 					{/* Model Cards */}


### PR DESCRIPTION
<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- For feature requests: Created a discussion in our Feature Requests discussions board https://github.com/cline/cline/discussions/categories/feature-requests and received approval from core maintainers before implementation
- For all changes: Link the associated issue/discussion in the "Related Issue" section below

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly without prior discussion.

Why this requirement?
We deeply appreciate all community contributions - they are essential to Cline's success! To ensure the best use of everyone's time and maintain project direction, we use our Feature Requests discussions board to gauge community interest and validate feature ideas before implementation begins. This helps us focus development efforts on features that will benefit the most users.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** #XXXX

### Description

Removes the hardcoded fallback free-model list so a successful upstream response with no free models is respected throughout the app.

This updates the settings picker, CLI featured model fallback handling, and Cline provider usage-cost detection so stale fallback IDs are not displayed or treated as free after the backend removes them. The Free tab is now hidden when no free models are available.

### Test Procedure

- `npm run test:run -- featured-models.test.ts`
- `TS_NODE_PROJECT=./tsconfig.unit-test.json npx mocha --no-config --require ts-node/register --require source-map-support/register --require ./src/test/requires.ts --extension ts src/core/api/providers/__tests__/cline.test.ts src/core/controller/models/__tests__/refreshClineRecommendedModels.test.ts --exit`
- `npm run check-types`

Verified that empty upstream free model data stays empty in CLI mapping, removed fallback free IDs no longer zero usage cost, the settings picker hides Free when the upstream list is empty, and TypeScript still passes across extension, webview, and CLI projects.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A

### Additional Notes

The primary checkout previously had unrelated local changes outside this PR; those were stashed before checking out this branch locally for testing.
