### PR TITLE
fix(openrouter): enable cache control for Qwen models

### DIFF
--- a/src/core/api/transform/__tests__/openrouter-stream.test.ts
+++ b/src/core/api/transform/__tests__/openrouter-stream.test.ts
@@ -78,6 +78,19 @@ describe("createOpenRouterStream", () => {
 		payload.should.not.have.property("max_tokens")
 	})
 
+	it("adds cache_control blocks for Qwen models that require explicit OpenRouter caching", async () => {
+		const { client, create } = createClient()
+
+		await createOpenRouterStream(client as any, "system prompt", [{ role: "user", content: "hello" }] as any, {
+			id: "qwen/qwen3.6-plus",
+			info: createModelInfo(65_536),
+		})
+
+		const payload = create.firstCall.args[0] as any
+		payload.messages[0].content[0].cache_control.should.deepEqual({ type: "ephemeral" })
+		payload.messages[1].content[0].cache_control.should.deepEqual({ type: "ephemeral" })
+	})
+
 	it("uses adaptive reasoning with verbosity for Claude Opus adaptive models", async () => {
 		const { client, create } = createClient()
 

--- a/src/core/api/transform/openrouter-stream.ts
+++ b/src/core/api/transform/openrouter-stream.ts
@@ -23,6 +23,21 @@ import { convertToOpenAiMessages, sanitizeGeminiMessages } from "./openai-format
 import { convertToR1Format } from "./r1-format"
 import { getOpenAIToolParams } from "./tool-call-processor"
 
+const openRouterExplicitCacheControlModelIds = new Set([
+	"deepseek/deepseek-v3.2",
+	"qwen/qwen-plus",
+	"qwen/qwen3-max",
+	"qwen/qwen3.6-plus",
+	"qwen/qwen3-coder-plus",
+	"qwen/qwen3-coder-flash",
+])
+
+function needsExplicitCacheControl(modelId: string): boolean {
+	return (
+		modelId.startsWith("anthropic/") || modelId.startsWith("minimax/") || openRouterExplicitCacheControlModelIds.has(modelId)
+	)
+}
+
 export async function createOpenRouterStream(
 	client: OpenAI,
 	systemPrompt: string,
@@ -55,9 +70,9 @@ export async function createOpenRouterStream(
 	openAiMessages = sanitizeGeminiMessages(openAiMessages, model.id)
 
 	// prompt caching: https://openrouter.ai/docs/prompt-caching
-	// Anthropic and MiniMax models require explicit cache_control blocks to enable prompt caching on OpenRouter.
+	// Some OpenRouter models require cache_control blocks instead of automatic provider caching.
 	// Other providers (OpenAI, Google) handle caching automatically without cache_control blocks.
-	const needsCacheControl = model.id.startsWith("anthropic/") || model.id.startsWith("minimax/")
+	const needsCacheControl = needsExplicitCacheControl(model.id)
 
 	if (needsCacheControl) {
 		openAiMessages[0] = {


### PR DESCRIPTION
<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- For feature requests: Created a discussion in our Feature Requests discussions board https://github.com/cline/cline/discussions/categories/feature-requests and received approval from core maintainers before implementation
- For all changes: Link the associated issue/discussion in the "Related Issue" section below

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly without prior discussion.

Why this requirement?
We deeply appreciate all community contributions - they are essential to Cline's success! To ensure the best use of everyone's time and maintain project direction, we use our Feature Requests discussions board to gauge community interest and validate feature ideas before implementation begins. This helps us focus development efforts on features that will benefit the most users.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** #XXXX

### Description

OpenRouter's prompt caching docs list several explicit-cache models that require `cache_control` blocks rather than relying on automatic provider caching. Cline already added those breakpoints for Anthropic and MiniMax models, but Qwen models such as `qwen/qwen3.6-plus` were sent without cache control, resulting in zero cache reads across repeated turns.

This adds the documented explicit-cache model ids to the OpenRouter transform so those requests receive the same system and recent-user-message cache breakpoints. It also adds a regression test for `qwen/qwen3.6-plus`.

### Test Procedure

Validated against OpenRouter with `qwen/qwen3.6-plus` using a 5-turn repeated-prefix harness:

- Current Cline request shape before this change: `0%` cache reads across 5 turns.
- Explicit `cache_control` request shape: first turn wrote `18,242` cache tokens; turns 2-5 each read `18,242` cached tokens; post-warmup hit rate was `99.28%`.

Local verification:

- `npm run cli:build`
- `npx cross-env TS_NODE_PROJECT=./tsconfig.unit-test.json mocha src/core/api/transform/__tests__/openrouter-stream.test.ts` (repo config expanded this to the broader unit suite: `1427 passing`)

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A - provider request formatting change only.

### Additional Notes

The explicit-cache list mirrors OpenRouter's documented Alibaba model list at the time of testing. Gemini has separate cache-control behavior and is intentionally not changed here.
