### PR TITLE
feat: add editSymlinkedFiles auto-approval setting

### DIFF
--- a/src/core/task/tools/autoApprove.ts
+++ b/src/core/task/tools/autoApprove.ts
@@ -1,3 +1,5 @@
+import fs from "fs/promises"
+import * as path from "path"
 import { resolveWorkspacePath } from "@core/workspace"
 import { isMultiRootEnabled } from "@core/workspace/multi-root-utils"
 import { ClineDefaultTool } from "@shared/tools"
@@ -116,6 +118,46 @@ export class AutoApprove {
 		return false
 	}
 
+	/**
+	 * Check if a path is accessed via a symlink that exists within the workspace.
+	 * This walks up the path tree to find any symlinks and verifies they are in the workspace.
+	 */
+	private async isPathViaWorkspaceSymlink(filePath: string): Promise<boolean> {
+		try {
+			const { workspacePaths } = await this.getWorkspaceInfo()
+
+			// Normalize the path
+			const normalizedPath = path.normalize(filePath)
+			const parts = normalizedPath.split(path.sep)
+
+			// Check each directory in the path (from root to leaf)
+			let currentPath = ""
+			for (const part of parts) {
+				currentPath = currentPath ? path.join(currentPath, part) : part
+				if (!currentPath || currentPath === path.sep) continue
+
+				try {
+					const stats = await fs.lstat(currentPath)
+					if (stats.isSymbolicLink()) {
+						// Found a symlink - check if it's in any workspace
+						for (const wsPath of workspacePaths.paths) {
+							if (currentPath.startsWith(wsPath + path.sep) || currentPath === wsPath) {
+								// The symlink is within a workspace folder - allow it
+								return true
+							}
+						}
+					}
+				} catch {
+					// Path component doesn't exist or can't be accessed, skip
+					continue
+				}
+			}
+			return false
+		} catch {
+			return false
+		}
+	}
+
 	// Check if the tool should be auto-approved based on the settings
 	// and the path of the action. Returns true if the tool should be auto-approved
 	// based on the user's settings and the path of the action.
@@ -130,14 +172,14 @@ export class AutoApprove {
 			return true
 		}
 
-		let isLocalRead = false
+		let isLocalPath = false
 		if (autoApproveActionpath) {
 			// Use cached workspace info instead of fetching every time
 			const { isMultiRootScenario } = await this.getWorkspaceInfo()
 
 			if (isMultiRootScenario) {
 				// Multi-root: check if file is in ANY workspace
-				isLocalRead = await isLocatedInWorkspace(autoApproveActionpath)
+				isLocalPath = await isLocatedInWorkspace(autoApproveActionpath)
 			} else {
 				// Single-root: use existing logic
 				const cwd = await getCwd(getDesktopDir())
@@ -147,11 +189,20 @@ export class AutoApprove {
 					autoApproveActionpath,
 					"AutoApprove.shouldAutoApproveToolWithPath",
 				) as string
-				isLocalRead = isLocatedInPath(cwd, absolutePath)
+				isLocalPath = isLocatedInPath(cwd, absolutePath)
+			}
+
+			// If not local, check if accessed via a workspace symlink and setting is enabled
+			const autoApprovalSettings = this.stateManager.getGlobalSettingsKey("autoApprovalSettings")
+			if (!isLocalPath && autoApprovalSettings.actions.editSymlinkedFiles) {
+				const isViaSymlink = await this.isPathViaWorkspaceSymlink(autoApproveActionpath)
+				if (isViaSymlink) {
+					isLocalPath = true
+				}
 			}
 		} else {
 			// If we do not get a path for some reason, default to a (safer) false return
-			isLocalRead = false
+			isLocalPath = false
 		}
 
 		// Get auto-approve settings for local and external edits
@@ -160,7 +211,7 @@ export class AutoApprove {
 			? autoApproveResult
 			: [autoApproveResult, false]
 
-		if ((isLocalRead && autoApproveLocal) || (!isLocalRead && autoApproveLocal && autoApproveExternal)) {
+		if ((isLocalPath && autoApproveLocal) || (!isLocalPath && autoApproveLocal && autoApproveExternal)) {
 			return true
 		}
 		return false

--- a/src/shared/AutoApprovalSettings.ts
+++ b/src/shared/AutoApprovalSettings.ts
@@ -16,6 +16,7 @@ export interface AutoApprovalSettings {
 		readFilesExternally?: boolean // Read files and directories outside of the working directory
 		editFiles: boolean // Edit files in the working directory
 		editFilesExternally?: boolean // Edit files outside of the working directory
+		editSymlinkedFiles?: boolean // Edit files accessed via symlinks within the workspace
 		executeSafeCommands?: boolean // Execute safe commands
 		executeAllCommands?: boolean // Execute all commands
 		useBrowser: boolean // Use browser
@@ -35,6 +36,7 @@ export const DEFAULT_AUTO_APPROVAL_SETTINGS: AutoApprovalSettings = {
 		readFilesExternally: false,
 		editFiles: false,
 		editFilesExternally: false,
+		editSymlinkedFiles: false,
 		executeSafeCommands: true,
 		executeAllCommands: false,
 		useBrowser: false,

--- a/webview-ui/src/components/chat/auto-approve-menu/AutoApproveMenuItem.tsx
+++ b/webview-ui/src/components/chat/auto-approve-menu/AutoApproveMenuItem.tsx
@@ -54,6 +54,11 @@ const AutoApproveMenuItem = ({ action, isChecked, onToggle, showIcon = true, dis
 					<AutoApproveMenuItem action={action.subAction} isChecked={isChecked} onToggle={onToggle} />
 				</SubOptionAnimateIn>
 			)}
+			{action.additionalSubAction && (
+				<SubOptionAnimateIn inert={!checked ? "" : undefined} show={checked}>
+					<AutoApproveMenuItem action={action.additionalSubAction} isChecked={isChecked} onToggle={onToggle} />
+				</SubOptionAnimateIn>
+			)}
 		</div>
 	)
 

--- a/webview-ui/src/components/chat/auto-approve-menu/constants.ts
+++ b/webview-ui/src/components/chat/auto-approve-menu/constants.ts
@@ -26,6 +26,13 @@ export const ACTION_METADATA: ActionMetadata[] = [
 			icon: "codicon-files",
 			parentActionId: "editFiles",
 		},
+		additionalSubAction: {
+			id: "editSymlinkedFiles",
+			label: "Edit symlinked files",
+			shortName: "Symlinks",
+			icon: "codicon-link",
+			parentActionId: "editFiles",
+		},
 	},
 	{
 		id: "executeSafeCommands",

--- a/webview-ui/src/components/chat/auto-approve-menu/types.ts
+++ b/webview-ui/src/components/chat/auto-approve-menu/types.ts
@@ -6,6 +6,7 @@ export interface ActionMetadata {
 	shortName: string
 	icon: string
 	subAction?: ActionMetadata
+	additionalSubAction?: ActionMetadata
 	sub?: boolean
 	parentActionId?: string
 }


### PR DESCRIPTION
## Summary
Adds a new auto-approval setting that allows files accessed via symlinks within the workspace to be auto-approved for editing. This enables workflows where symlinked directories point to files outside the workspace root.

## Changes
- Add `editSymlinkedFiles` to `AutoApprovalSettings` interface and defaults
- Add `isPathViaWorkspaceSymlink()` method to check if a path traverses a symlink that exists within a workspace folder
- Add UI support with `additionalSubAction` pattern for nested sub-options
- Rename `isLocalRead` to `isLocalPath` for clarity (used for both read/write operations)

## Testing
- Manual testing with symlinked directories in workspace
- Existing tests pass (no existing tests for similar settings)

Feature Request -> https://github.com/cline/cline/discussions/10579