### PR TITLE
Fix: add idle timeout watchdog for streaming 

### DIFF
--- a/src/core/task/StreamChunkCoordinator.ts
+++ b/src/core/task/StreamChunkCoordinator.ts
@@ -16,8 +16,22 @@ Without this split, usage updates can be delayed behind awaited UI/tool work.
 */
 export type NonUsageApiStreamChunk = Exclude<ApiStreamChunk, { type: "usage" }>
 
+/**
+ * Thrown by the pump when no chunk is received from the underlying stream
+ * within `idleTimeoutMs`. Treated as a generic recoverable error so it flows
+ * through the existing retry path in `attemptApiRequest()` (3x exponential
+ * backoff) rather than being classified as an auth/balance/quota failure.
+ */
+export class StreamIdleTimeoutError extends Error {
+	constructor(idleMs: number) {
+		super(`Stream idle timeout: no data received for ${idleMs}ms`)
+		this.name = "StreamIdleTimeoutError"
+	}
+}
+
 type StreamChunkCoordinatorOptions = {
 	onUsageChunk: (chunk: ApiStreamUsageChunk) => void
+	idleTimeoutMs?: number
 }
 
 export class StreamChunkCoordinator {
@@ -64,11 +78,40 @@ export class StreamChunkCoordinator {
 		}
 	}
 
+	/**
+	 * Races `promise` against a per-call idle timeout. Used by the pump to
+	 * detect TCP "half-open" situations where the connection is still alive
+	 * but no data is being delivered (e.g. upstream LLM service freezes).
+	 *
+	 * Implementation notes:
+	 * - Uses `Promise.race` to avoid wrapping the iterator itself; the timer is
+	 *   armed fresh for every chunk so a slow-but-steady stream never trips it.
+	 * - `clearTimeout` runs in `finally` so that both success and failure paths
+	 *   release the pending timer immediately, preventing node event-loop leaks
+	 *   and keeping `stop()` able to return promptly.
+	 */
+	private async withIdleTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
+		let timeoutId: ReturnType<typeof setTimeout> | undefined
+		const timeoutPromise = new Promise<never>((_, reject) => {
+			timeoutId = setTimeout(() => reject(new StreamIdleTimeoutError(timeoutMs)), timeoutMs)
+		})
+		try {
+			return await Promise.race([promise, timeoutPromise])
+		} finally {
+			if (timeoutId !== undefined) {
+				clearTimeout(timeoutId)
+			}
+		}
+	}
+
 	private startPump(): Promise<void> {
 		return (async () => {
 			try {
 				while (!this.stopRequested) {
-					const { value: chunk, done } = await this.iterator.next()
+					const nextResult = this.options.idleTimeoutMs
+						? await this.withIdleTimeout(this.iterator.next(), this.options.idleTimeoutMs)
+						: await this.iterator.next()
+					const { value: chunk, done } = nextResult
 					if (done || !chunk) {
 						break
 					}

--- a/src/core/task/__tests__/StreamChunkCoordinator.test.ts
+++ b/src/core/task/__tests__/StreamChunkCoordinator.test.ts
@@ -1,0 +1,337 @@
+import type { ApiStream, ApiStreamChunk, ApiStreamUsageChunk } from "@core/api/transform/stream"
+import { describe, it } from "mocha"
+import "should"
+import sinon from "sinon"
+
+import { StreamChunkCoordinator, StreamIdleTimeoutError } from "../StreamChunkCoordinator"
+
+type DeferredNext = {
+	resolve: (result: IteratorResult<ApiStreamChunk>) => void
+	reject: (err: unknown) => void
+}
+
+interface ControllableStream {
+	stream: ApiStream
+	pushChunk: (chunk: ApiStreamChunk) => void
+	complete: () => void
+	fail: (err: unknown) => void
+	returnCalled: () => boolean
+}
+
+/**
+ * Builds a minimal async iterator that lets the test decide exactly when each
+ * iterator.next() call resolves/rejects. This mirrors how a real Provider
+ * stream behaves: the coordinator awaits iterator.next() and we control the
+ * timing of each chunk delivery.
+ */
+function createControllableStream(): ControllableStream {
+	const buffered: IteratorResult<ApiStreamChunk>[] = []
+	let bufferedError: { err: unknown } | undefined
+	let pending: DeferredNext | undefined
+	let returned = false
+
+	const iter: AsyncGenerator<ApiStreamChunk> = {
+		next(): Promise<IteratorResult<ApiStreamChunk>> {
+			if (bufferedError) {
+				const { err } = bufferedError
+				bufferedError = undefined
+				return Promise.reject(err)
+			}
+			if (buffered.length > 0) {
+				return Promise.resolve(buffered.shift()!)
+			}
+			return new Promise<IteratorResult<ApiStreamChunk>>((resolve, reject) => {
+				pending = { resolve, reject }
+			})
+		},
+		return(value?: unknown): Promise<IteratorResult<ApiStreamChunk>> {
+			returned = true
+			if (pending) {
+				const p = pending
+				pending = undefined
+				p.resolve({ value: undefined as unknown as ApiStreamChunk, done: true })
+			}
+			return Promise.resolve({ value: value as ApiStreamChunk, done: true })
+		},
+		throw(err: unknown): Promise<IteratorResult<ApiStreamChunk>> {
+			if (pending) {
+				const p = pending
+				pending = undefined
+				p.reject(err)
+			}
+			return Promise.reject(err)
+		},
+		[Symbol.asyncIterator]() {
+			return this
+		},
+	}
+
+	return {
+		stream: iter as ApiStream,
+		pushChunk: (chunk) => {
+			if (pending) {
+				const p = pending
+				pending = undefined
+				p.resolve({ value: chunk, done: false })
+				return
+			}
+			buffered.push({ value: chunk, done: false })
+		},
+		complete: () => {
+			if (pending) {
+				const p = pending
+				pending = undefined
+				p.resolve({ value: undefined as unknown as ApiStreamChunk, done: true })
+				return
+			}
+			buffered.push({ value: undefined as unknown as ApiStreamChunk, done: true })
+		},
+		fail: (err) => {
+			if (pending) {
+				const p = pending
+				pending = undefined
+				p.reject(err)
+				return
+			}
+			bufferedError = { err }
+		},
+		returnCalled: () => returned,
+	}
+}
+
+describe("StreamChunkCoordinator", () => {
+	it("forwards non-usage chunks in FIFO order when no idle timeout is configured", async () => {
+		const ctrl = createControllableStream()
+		const onUsageChunk = sinon.spy()
+		const coordinator = new StreamChunkCoordinator(ctrl.stream, { onUsageChunk })
+
+		ctrl.pushChunk({ type: "text", text: "hello" })
+		ctrl.pushChunk({ type: "text", text: "world" })
+		ctrl.complete()
+
+		const first = await coordinator.nextChunk()
+		first!.type.should.equal("text")
+		;(first as { type: "text"; text: string }).text.should.equal("hello")
+
+		const second = await coordinator.nextChunk()
+		;(second as { type: "text"; text: string }).text.should.equal("world")
+
+		const end = await coordinator.nextChunk()
+		;(end === undefined).should.equal(true)
+
+		onUsageChunk.callCount.should.equal(0)
+		await coordinator.waitForCompletion()
+	})
+
+	it("routes usage chunks to onUsageChunk without enqueueing them for consumers", async () => {
+		const ctrl = createControllableStream()
+		const onUsageChunk = sinon.spy()
+		const coordinator = new StreamChunkCoordinator(ctrl.stream, { onUsageChunk })
+
+		const usage: ApiStreamUsageChunk = {
+			type: "usage",
+			inputTokens: 10,
+			outputTokens: 20,
+			cacheReadTokens: 1,
+			cacheWriteTokens: 2,
+			totalCost: 0.0001,
+		}
+		ctrl.pushChunk(usage)
+		ctrl.pushChunk({ type: "text", text: "done" })
+		ctrl.complete()
+
+		const chunk = await coordinator.nextChunk()
+		;(chunk as { type: "text"; text: string }).text.should.equal("done")
+		;((await coordinator.nextChunk()) === undefined).should.equal(true)
+
+		onUsageChunk.calledOnce.should.equal(true)
+		onUsageChunk.firstCall.args[0].should.deepEqual(usage)
+	})
+
+	it("propagates iterator errors via nextChunk()", async () => {
+		const ctrl = createControllableStream()
+		const coordinator = new StreamChunkCoordinator(ctrl.stream, { onUsageChunk: sinon.spy() })
+
+		ctrl.fail(new Error("upstream failure"))
+
+		let caught: unknown
+		try {
+			await coordinator.nextChunk()
+		} catch (e) {
+			caught = e
+		}
+		;(caught as Error).message.should.equal("upstream failure")
+	})
+
+	it("throws StreamIdleTimeoutError when no chunk arrives within idleTimeoutMs", async () => {
+		const clock = sinon.useFakeTimers()
+		try {
+			const ctrl = createControllableStream()
+			const coordinator = new StreamChunkCoordinator(ctrl.stream, {
+				onUsageChunk: sinon.spy(),
+				idleTimeoutMs: 1000,
+			})
+
+			const pendingChunk = coordinator.nextChunk().then(
+				(value) => ({ ok: true as const, value }),
+				(error: unknown) => ({ ok: false as const, error }),
+			)
+			// Let the pump register its timeout before we advance time.
+			await clock.tickAsync(0)
+			await clock.tickAsync(1000)
+
+			const outcome = await pendingChunk
+			outcome.ok.should.equal(false)
+			;((outcome as { ok: false; error: unknown }).error instanceof StreamIdleTimeoutError).should.equal(true)
+			;(outcome as { ok: false; error: Error }).error.message.should.match(/1000ms/)
+
+			// Further nextChunk() calls should keep surfacing the same error instead of hanging.
+			const secondOutcome = await coordinator.nextChunk().then(
+				() => ({ ok: true as const }),
+				(error: unknown) => ({ ok: false as const, error }),
+			)
+			secondOutcome.ok.should.equal(false)
+			;((secondOutcome as { ok: false; error: unknown }).error instanceof StreamIdleTimeoutError).should.equal(true)
+		} finally {
+			clock.restore()
+		}
+	})
+
+	it("resets the idle window for each chunk so slow but steady streams succeed", async () => {
+		const clock = sinon.useFakeTimers()
+		try {
+			const ctrl = createControllableStream()
+			const coordinator = new StreamChunkCoordinator(ctrl.stream, {
+				onUsageChunk: sinon.spy(),
+				idleTimeoutMs: 1000,
+			})
+
+			// Arm the pump's first timeout.
+			await clock.tickAsync(0)
+			// Chunk arrives just before the idle window elapses.
+			await clock.tickAsync(900)
+			ctrl.pushChunk({ type: "text", text: "a" })
+			const first = await coordinator.nextChunk()
+			;(first as { type: "text"; text: string }).text.should.equal("a")
+
+			// Another 900ms — under the per-chunk budget — still counts as "alive".
+			await clock.tickAsync(900)
+			ctrl.pushChunk({ type: "text", text: "b" })
+			const second = await coordinator.nextChunk()
+			;(second as { type: "text"; text: string }).text.should.equal("b")
+
+			ctrl.complete()
+			;((await coordinator.nextChunk()) === undefined).should.equal(true)
+		} finally {
+			clock.restore()
+		}
+	})
+
+	it("resets the idle window after usage chunks so they do not starve content chunks", async () => {
+		const clock = sinon.useFakeTimers()
+		try {
+			const ctrl = createControllableStream()
+			const onUsageChunk = sinon.spy()
+			const coordinator = new StreamChunkCoordinator(ctrl.stream, {
+				onUsageChunk,
+				idleTimeoutMs: 1000,
+			})
+
+			await clock.tickAsync(0)
+			await clock.tickAsync(500)
+			ctrl.pushChunk({
+				type: "usage",
+				inputTokens: 1,
+				outputTokens: 1,
+			})
+			// Yield so the pump can process the usage chunk and re-arm its timer.
+			await clock.tickAsync(0)
+			await clock.tickAsync(900)
+			ctrl.pushChunk({ type: "text", text: "after-usage" })
+
+			const chunk = await coordinator.nextChunk()
+			;(chunk as { type: "text"; text: string }).text.should.equal("after-usage")
+			onUsageChunk.callCount.should.equal(1)
+
+			ctrl.complete()
+			;((await coordinator.nextChunk()) === undefined).should.equal(true)
+		} finally {
+			clock.restore()
+		}
+	})
+
+	it("stop() unblocks cleanly after an idle timeout and closes the iterator", async () => {
+		const clock = sinon.useFakeTimers()
+		try {
+			const ctrl = createControllableStream()
+			const coordinator = new StreamChunkCoordinator(ctrl.stream, {
+				onUsageChunk: sinon.spy(),
+				idleTimeoutMs: 500,
+			})
+
+			const pendingChunk = coordinator.nextChunk().then(
+				() => ({ ok: true as const }),
+				(error: unknown) => ({ ok: false as const, error }),
+			)
+			await clock.tickAsync(0)
+			await clock.tickAsync(500)
+
+			const outcome = await pendingChunk
+			outcome.ok.should.equal(false)
+			;((outcome as { ok: false; error: unknown }).error instanceof StreamIdleTimeoutError).should.equal(true)
+
+			const stopPromise = coordinator.stop()
+			await clock.tickAsync(0)
+			await stopPromise
+
+			ctrl.returnCalled().should.equal(true)
+		} finally {
+			clock.restore()
+		}
+	})
+
+	it("does not leak timers after stop() when idle timeout is configured", async () => {
+		const clock = sinon.useFakeTimers()
+		try {
+			const ctrl = createControllableStream()
+			const coordinator = new StreamChunkCoordinator(ctrl.stream, {
+				onUsageChunk: sinon.spy(),
+				idleTimeoutMs: 5_000,
+			})
+
+			// Let the pump enter its first await and arm the idle timer.
+			await clock.tickAsync(0)
+			clock.countTimers().should.be.greaterThan(0)
+
+			await coordinator.stop()
+			await clock.tickAsync(0)
+			clock.countTimers().should.equal(0)
+		} finally {
+			clock.restore()
+		}
+	})
+
+	it("does not register any timer when idleTimeoutMs is not provided", async () => {
+		const clock = sinon.useFakeTimers()
+		try {
+			const ctrl = createControllableStream()
+			const coordinator = new StreamChunkCoordinator(ctrl.stream, { onUsageChunk: sinon.spy() })
+
+			await clock.tickAsync(0)
+			clock.countTimers().should.equal(0)
+
+			// Advancing well past any reasonable idle threshold must not trigger anything.
+			await clock.tickAsync(10 * 60_000)
+			clock.countTimers().should.equal(0)
+
+			ctrl.pushChunk({ type: "text", text: "late" })
+			const chunk = await coordinator.nextChunk()
+			;(chunk as { type: "text"; text: string }).text.should.equal("late")
+
+			ctrl.complete()
+			await coordinator.waitForCompletion()
+		} finally {
+			clock.restore()
+		}
+	})
+})

--- a/src/core/task/index.ts
+++ b/src/core/task/index.ts
@@ -2851,6 +2851,13 @@ export class Task {
 							totalCost: chunk.totalCost,
 						})
 					},
+					// Abort the request if no chunk arrives within 60s. This covers TCP
+					// half-open / upstream stalls that would otherwise hang indefinitely.
+					// A StreamIdleTimeoutError is surfaced as a generic retryable error and
+					// flows through the existing 3x exponential-backoff retry path. The
+					// value is intentionally loose enough to tolerate long reasoning pauses
+					// (Claude/DeepSeek) while remaining far shorter than OS keepalive.
+					idleTimeoutMs: 60_000,
 				})
 
 				let shouldInterruptStream = false


### PR DESCRIPTION
### Related Issue

**Issue:** #10631

### Description

`StreamChunkCoordinator.startPump()` awaits `this.iterator.next()` with no timeout. When network instability puts the TCP connection into a half-open state — the socket is still alive but the upstream LLM provider stops emitting chunks — the pump stays parked on that `await` forever. The task never surfaces an error, the existing 3x exponential-backoff retry path in `attemptApiRequest()` is never triggered, and the user is left with a silently stalled request that can only be recovered by clicking Cancel manually.

### Test Procedure
The specific thorough tests can be found in the src/core/task/__tests__/StreamChunkCoordinator.test.ts file.
<img width="390" alt="image" src="https://github.com/user-attachments/assets/5f033d1c-e26b-487f-bbc7-77c4ca0eecf4" />


### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

