### PR TITLE
ENG-2011: Disable Ollama Qwen thinking when reasoning is off

### DIFF
--- a/sdk/packages/llms/src/providers/routing/provider-option-rules.ts
+++ b/sdk/packages/llms/src/providers/routing/provider-option-rules.ts
@@ -38,12 +38,9 @@ function isDeepSeekFamily(input: ProviderOptionMatchInput): boolean {
 	return !!input.modelFamily?.trim().toLowerCase().includes("deepseek");
 }
 
-function isQwen3Family(input: ProviderOptionMatchInput): boolean {
-	const normalizedFamily = input.modelFamily?.trim().toLowerCase() ?? "";
+function isQwen3ModelId(input: ProviderOptionMatchInput): boolean {
 	const normalizedModelId = input.request.modelId.toLowerCase();
-	return (
-		normalizedModelId.includes("qwen3")
-	);
+	return normalizedModelId.includes("qwen3");
 }
 
 function resolveFamilyThinkingType(
@@ -177,14 +174,14 @@ const openRouterReasoningRule: ProviderOptionRule = {
 		),
 };
 
-const ollamaReasoningDisabledRule: ProviderOptionRule = {
-	id: "provider.ollama.disable-reasoning",
+const ollamaQwen3ReasoningDisabledRule: ProviderOptionRule = {
+	id: "provider.ollama.qwen3.disable-reasoning",
 	phase: "provider-reasoning",
 	description:
 		"Ollama OpenAI-compatible Qwen3 models need reasoning_effort=none to disable default thinking.",
 	applies: (input) =>
 		input.request.providerId === "ollama" &&
-		isQwen3Family(input) &&
+		isQwen3ModelId(input) &&
 		input.request.reasoning?.enabled === false,
 	suppresses: { genericThinking: true },
 	build: (input) => {
@@ -338,7 +335,7 @@ export const PROVIDER_OPTION_RULES: ReadonlyArray<ProviderOptionRule> = [
 	genericProviderFanoutRule,
 	clineGatewayReasoningRule,
 	openRouterReasoningRule,
-	ollamaReasoningDisabledRule,
+	ollamaQwen3ReasoningDisabledRule,
 	geminiThinkingRule,
 	clineReasoningDisabledThinkingRule,
 	kimiK26ThinkingRule,

--- a/sdk/packages/llms/src/providers/routing/provider-option-rules.ts
+++ b/sdk/packages/llms/src/providers/routing/provider-option-rules.ts
@@ -42,7 +42,7 @@ function isQwen3Family(input: ProviderOptionMatchInput): boolean {
 	const normalizedFamily = input.modelFamily?.trim().toLowerCase() ?? "";
 	const normalizedModelId = input.request.modelId.toLowerCase();
 	return (
-		normalizedFamily.startsWith("qwen3") || normalizedModelId.includes("qwen3")
+		normalizedModelId.includes("qwen3")
 	);
 }
 

--- a/sdk/packages/llms/src/providers/routing/provider-option-rules.ts
+++ b/sdk/packages/llms/src/providers/routing/provider-option-rules.ts
@@ -38,6 +38,14 @@ function isDeepSeekFamily(input: ProviderOptionMatchInput): boolean {
 	return !!input.modelFamily?.trim().toLowerCase().includes("deepseek");
 }
 
+function isQwen3Family(input: ProviderOptionMatchInput): boolean {
+	const normalizedFamily = input.modelFamily?.trim().toLowerCase() ?? "";
+	const normalizedModelId = input.request.modelId.toLowerCase();
+	return (
+		normalizedFamily.startsWith("qwen3") || normalizedModelId.includes("qwen3")
+	);
+}
+
 function resolveFamilyThinkingType(
 	input: ProviderOptionMatchInput,
 	defaultWhenUnset: "enabled" | "disabled" | undefined,
@@ -167,6 +175,32 @@ const openRouterReasoningRule: ProviderOptionRule = {
 			input,
 			buildOpenRouterReasoningOptions(input.request),
 		),
+};
+
+const ollamaReasoningDisabledRule: ProviderOptionRule = {
+	id: "provider.ollama.disable-reasoning",
+	phase: "provider-reasoning",
+	description:
+		"Ollama OpenAI-compatible Qwen3 models need reasoning_effort=none to disable default thinking.",
+	applies: (input) =>
+		input.request.providerId === "ollama" &&
+		isQwen3Family(input) &&
+		input.request.reasoning?.enabled === false,
+	suppresses: { genericThinking: true },
+	build: (input) => {
+		const bucketOptions = {
+			reasoningEffort: "none",
+			reasoning: { effort: "none" },
+		};
+		return {
+			...buildProviderAndAliasPatch({
+				providerId: input.request.providerId,
+				providerOptionsKey: input.providerOptionsKey,
+				bucketOptions,
+			}),
+			openaiCompatible: bucketOptions,
+		};
+	},
 };
 
 const geminiThinkingRule: ProviderOptionRule = {
@@ -304,6 +338,7 @@ export const PROVIDER_OPTION_RULES: ReadonlyArray<ProviderOptionRule> = [
 	genericProviderFanoutRule,
 	clineGatewayReasoningRule,
 	openRouterReasoningRule,
+	ollamaReasoningDisabledRule,
 	geminiThinkingRule,
 	clineReasoningDisabledThinkingRule,
 	kimiK26ThinkingRule,

--- a/sdk/packages/llms/src/providers/routing/provider-options.test.ts
+++ b/sdk/packages/llms/src/providers/routing/provider-options.test.ts
@@ -736,13 +736,13 @@ describe("composeAiSdkProviderOptions: family/provider thinking patches", () => 
 			],
 		},
 		{
-			name: "ollama Qwen3 reasoning.enabled=false -> OpenAI-compatible reasoning disabled",
+			name: "ollama Qwen3 modelId reasoning.enabled=false -> effort none in provider buckets",
 			request: {
 				providerId: "ollama",
 				modelId: "qwen3-coder:30b",
 				reasoning: { enabled: false },
 			},
-			context: { family: "qwen3" },
+			context: { family: "qwen" },
 			expect: [
 				{
 					bucket: "ollama",
@@ -763,7 +763,7 @@ describe("composeAiSdkProviderOptions: family/provider thinking patches", () => 
 			],
 		},
 		{
-			name: "ollama non-Qwen3 reasoning.enabled=false -> no Qwen3 reasoning override",
+			name: "ollama non-Qwen3 modelId reasoning.enabled=false -> no effort-none override",
 			request: {
 				providerId: "ollama",
 				modelId: "llama3.1",

--- a/sdk/packages/llms/src/providers/routing/provider-options.test.ts
+++ b/sdk/packages/llms/src/providers/routing/provider-options.test.ts
@@ -736,6 +736,52 @@ describe("composeAiSdkProviderOptions: family/provider thinking patches", () => 
 			],
 		},
 		{
+			name: "ollama Qwen3 reasoning.enabled=false -> OpenAI-compatible reasoning disabled",
+			request: {
+				providerId: "ollama",
+				modelId: "qwen3-coder:30b",
+				reasoning: { enabled: false },
+			},
+			context: { family: "qwen3" },
+			expect: [
+				{
+					bucket: "ollama",
+					has: {
+						reasoningEffort: "none",
+						reasoning: { effort: "none" },
+					},
+					lacks: ["thinking"],
+				},
+				{
+					bucket: "openaiCompatible",
+					has: {
+						reasoningEffort: "none",
+						reasoning: { effort: "none" },
+					},
+					lacks: ["thinking"],
+				},
+			],
+		},
+		{
+			name: "ollama non-Qwen3 reasoning.enabled=false -> no Qwen3 reasoning override",
+			request: {
+				providerId: "ollama",
+				modelId: "llama3.1",
+				reasoning: { enabled: false },
+			},
+			context: { family: "llama" },
+			expect: [
+				{
+					bucket: "ollama",
+					lacks: ["reasoningEffort", "reasoning", "thinking"],
+				},
+				{
+					bucket: "openaiCompatible",
+					lacks: ["reasoningEffort", "reasoning", "thinking"],
+				},
+			],
+		},
+		{
 			name: "cline non-K2.6 Moonshot Kimi reasoning.enabled=false -> thinking.type=disabled",
 			request: {
 				providerId: "cline",


### PR DESCRIPTION
### Related Issue

**Issue:** ENG-2011

### Description

Ports the SDK fix from `cline/sdk` branch `robin/eng-2011-ollama-qwen-slow` into the embedded SDK in `cline/cline`.

When Ollama is used with Qwen3 models and reasoning is explicitly disabled, add provider options that send `reasoningEffort: "none"` and `reasoning: { effort: "none" }` to both the Ollama provider bucket and the OpenAI-compatible bucket. This suppresses the generic thinking patch so Qwen3 does not keep default thinking enabled.

### Test Procedure

- Ran `bun -F @cline/llms test -- src/providers/routing/provider-options.test.ts` from `sdk/`: 60 tests passed.
- Ran `bunx --bun @biomejs/biome check --config-path ./biome.json packages/llms/src/providers/routing/provider-option-rules.ts packages/llms/src/providers/routing/provider-options.test.ts` from `sdk/`: 2 files checked, no fixes applied.
- Ran `git diff --check`: no whitespace errors.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A - provider routing logic only.

### Additional Notes

Source SDK commit: `d17f5b7ddae8270c3e4538bba0d8cb143439fc39`.
