### PR TITLE
docs: fix Getting Started README links

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ English | <a href="https://github.com/cline/cline/blob/main/locales/es/README.md
 <a href="https://github.com/cline/cline/discussions/categories/feature-requests?discussions_q=is%3Aopen+category%3A%22Feature+Requests%22+sort%3Atop" target="_blank"><strong>Feature Requests</strong></a>
 </td>
 <td align="center">
-<a href="https://docs.cline.bot/getting-started/for-new-coders" target="_blank"><strong>Getting Started</strong></a>
+<a href="https://docs.cline.bot/getting-started" target="_blank"><strong>Getting Started</strong></a>
 </td>
 </tbody>
 </table>

--- a/cli/README.md
+++ b/cli/README.md
@@ -20,7 +20,7 @@
 <a href="https://github.com/cline/cline/discussions/categories/feature-requests?discussions_q=is%3Aopen+category%3A%22Feature+Requests%22+sort%3Atop" target="_blank"><strong>Feature Requests</strong></a>
 </td>
 <td align="center">
-<a href="https://docs.cline.bot/getting-started/for-new-coders" target="_blank"><strong>Getting Started</strong></a>
+<a href="https://docs.cline.bot/getting-started" target="_blank"><strong>Getting Started</strong></a>
 </td>
 </tbody>
 </table>

--- a/locales/ar-sa/README.md
+++ b/locales/ar-sa/README.md
@@ -24,7 +24,7 @@
 <a href="https://github.com/cline/cline/discussions/categories/feature-requests?discussions_q=is%3Aopen+category%3A%22Feature+Requests%22+sort%3Atop" target="_blank"><strong>طلبات الميزات</strong></a>
 </td>
 <td align="center">
-<a href="https://docs.cline.bot/getting-started/getting-started-new-coders" target="_blank"><strong>البدء</strong></a>
+<a href="https://docs.cline.bot/getting-started" target="_blank"><strong>البدء</strong></a>
 </td>
 </tbody>
 </table>

--- a/locales/zh-cn/README.md
+++ b/locales/zh-cn/README.md
@@ -20,7 +20,7 @@
 <a href="https://github.com/cline/cline/discussions/categories/feature-requests?discussions_q=is%3Aopen+category%3A%22Feature+Requests%22+sort%3Atop" target="_blank"><strong>功能请求</strong></a>
 </td>
 <td align="center">
-<a href="https://docs.cline.bot/getting-started/for-new-coders" target="_blank"><strong>新手上路</strong></a>
+<a href="https://docs.cline.bot/getting-started" target="_blank"><strong>新手上路</strong></a>
 </td>
 </tbody>
 </table>

--- a/locales/zh-tw/README.md
+++ b/locales/zh-tw/README.md
@@ -24,7 +24,7 @@
 <a href="https://github.com/cline/cline/discussions/categories/feature-requests?discussions_q=is%3Aopen+category%3A%22Feature+Requests%22+sort%3Atop" target="_blank"><strong>功能建議</strong></a>
 </td>
 <td align="center">
-<a href="https://docs.cline.bot/getting-started/getting-started-new-coders" target="_blank"><strong>新手上路</strong></a>
+<a href="https://docs.cline.bot/getting-started" target="_blank"><strong>新手上路</strong></a>
 </td>
 </tbody>
 </table>


### PR DESCRIPTION
### Related Issue

**Issue:** PRD-254

### Description

Fixes stale "Getting Started" documentation links in the root README, CLI README, and localized README headers.

The previous links pointed to outdated docs routes that 404. They now point to the canonical Getting Started page:

https://docs.cline.bot/getting-started

### Test Procedure

- Verified the edited README links point to `https://docs.cline.bot/getting-started`.
- Searched README files and locales for the stale routes (`for-new-coders` and `getting-started-new-coders`) and confirmed no matches remain.
- Fetched `https://docs.cline.bot/getting-started` and confirmed it resolves to the Cline Quick Start documentation page.

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [x] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A — documentation link-only change.

### Additional Notes

This is a small documentation-only fix; no code paths are affected.
