### PR TITLE
Fix SDK Qwen prompt cache routing

### DIFF
--- a/sdk/packages/core/src/services/llms/handler-factory.test.ts
+++ b/sdk/packages/core/src/services/llms/handler-factory.test.ts
@@ -1,5 +1,5 @@
-import type { AgentModel, ITelemetryService } from "@cline/shared";
-import { describe, expect, it, vi } from "vitest";
+import type { AgentConfig, AgentModel, ITelemetryService } from "@cline/shared";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const gatewayMock = vi.hoisted(() => {
 	const createAgentModel = vi.fn();
@@ -15,6 +15,14 @@ vi.mock("@cline/llms", () => ({
 }));
 
 describe("createAgentModelFromConfig", () => {
+	beforeEach(() => {
+		gatewayMock.createAgentModel.mockReset();
+		gatewayMock.createGateway.mockClear();
+		gatewayMock.createGateway.mockImplementation(() => ({
+			createAgentModel: gatewayMock.createAgentModel,
+		}));
+	});
+
 	it("forwards effective telemetry into the gateway", async () => {
 		const { createAgentModelFromConfig } = await import("./handler-factory");
 		const logger = {
@@ -72,5 +80,80 @@ describe("createAgentModelFromConfig", () => {
 				telemetry,
 			}),
 		);
+	});
+
+	it("preserves model capabilities and metadata when configuring gateway models", async () => {
+		const { createAgentModelFromConfig } = await import("./handler-factory");
+
+		createAgentModelFromConfig(
+			{
+				providerId: "openrouter",
+				modelId: "qwen/qwen3.6-plus",
+				apiKey: "test-key",
+				systemPrompt: "",
+				tools: [],
+				knownModels: {
+					"qwen/qwen3.6-plus": {
+						id: "qwen/qwen3.6-plus",
+						name: "Qwen3.6 Plus",
+						contextWindow: 1_000_000,
+						maxInputTokens: 1_000_000,
+						maxTokens: 65_536,
+						capabilities: [
+							"tools",
+							"reasoning",
+							"structured_output",
+							"prompt-cache",
+						],
+						pricing: {
+							input: 0.325,
+							output: 1.95,
+							cacheRead: 0.0325,
+							cacheWrite: 0.40625,
+						},
+						releaseDate: "2026-04-02",
+						family: "qwen",
+					},
+				},
+			} satisfies AgentConfig,
+			undefined,
+		);
+
+		const gatewayConfig = (
+			gatewayMock.createGateway.mock.calls as unknown as Array<
+				[
+					{
+						providerConfigs: Array<{
+							models: Array<Record<string, unknown>>;
+						}>;
+					},
+				]
+			>
+		)[0][0];
+		const model = gatewayConfig.providerConfigs[0].models[0];
+		expect(model).toMatchObject({
+			id: "qwen/qwen3.6-plus",
+			name: "Qwen3.6 Plus",
+			contextWindow: 1_000_000,
+			maxInputTokens: 1_000_000,
+			maxOutputTokens: 65_536,
+			capabilities: expect.arrayContaining([
+				"text",
+				"tools",
+				"reasoning",
+				"structured-output",
+				"prompt-cache",
+			]),
+			metadata: {
+				family: "qwen",
+				pricing: {
+					input: 0.325,
+					output: 1.95,
+					cacheRead: 0.0325,
+					cacheWrite: 0.40625,
+				},
+				releaseDate: "2026-04-02",
+			},
+		});
 	});
 });

--- a/sdk/packages/core/src/services/llms/handler-factory.ts
+++ b/sdk/packages/core/src/services/llms/handler-factory.ts
@@ -3,6 +3,7 @@ import type {
 	AgentConfig,
 	AgentModel,
 	BasicLogger,
+	GatewayModelDefinition,
 	ITelemetryService,
 	ModelInfo,
 } from "@cline/shared";
@@ -21,6 +22,57 @@ export function resolveKnownModelsFromConfig(
 	return (
 		MODEL_COLLECTIONS_BY_PROVIDER_ID[config.providerId]?.models ?? undefined
 	);
+}
+
+function toGatewayCapabilities(
+	capabilities: ModelInfo["capabilities"],
+): GatewayModelDefinition["capabilities"] {
+	if (!capabilities?.length) {
+		return undefined;
+	}
+
+	const mapped = new Set<
+		NonNullable<GatewayModelDefinition["capabilities"]>[number]
+	>();
+	for (const capability of capabilities) {
+		switch (capability) {
+			case "tools":
+			case "reasoning":
+			case "prompt-cache":
+			case "images":
+				mapped.add(capability);
+				break;
+			case "structured_output":
+				mapped.add("structured-output");
+				break;
+			default:
+				mapped.add("text");
+		}
+	}
+
+	mapped.add("text");
+	return [...mapped];
+}
+
+function toGatewayConfiguredModel(
+	id: string,
+	model: ModelInfo,
+): Omit<GatewayModelDefinition, "providerId"> {
+	return {
+		id,
+		name: model.name ?? id,
+		description: model.description,
+		contextWindow: model.contextWindow,
+		maxInputTokens: model.maxInputTokens,
+		maxOutputTokens: model.maxTokens,
+		capabilities: toGatewayCapabilities(model.capabilities),
+		metadata: {
+			family: model.family,
+			pricing: model.pricing,
+			status: model.status,
+			releaseDate: model.releaseDate,
+		},
+	};
 }
 
 export function createAgentModelFromConfig(
@@ -55,14 +107,7 @@ export function createAgentModelFromConfig(
 				headers: normalizedProviderConfig.headers,
 				models: normalizedProviderConfig.knownModels
 					? Object.entries(normalizedProviderConfig.knownModels).map(
-							([id, model]) => ({
-								id,
-								name: model.name ?? id,
-								description: model.description,
-								contextWindow: model.contextWindow,
-								maxInputTokens: model.maxInputTokens,
-								maxOutputTokens: model.maxTokens,
-							}),
+							([id, model]) => toGatewayConfiguredModel(id, model),
 						)
 					: undefined,
 			},

--- a/sdk/packages/llms/src/providers/ai-sdk.test.ts
+++ b/sdk/packages/llms/src/providers/ai-sdk.test.ts
@@ -267,6 +267,44 @@ describe("ai-sdk usage normalization", () => {
 			expect(flattened).toBeDefined();
 		});
 
+		it("extracts Qwen cache writes from OpenRouter prompt token details", () => {
+			const normalized = normalizeUsage({
+				prompt_tokens: 10126,
+				completion_tokens: 13,
+				prompt_tokens_details: {
+					cached_tokens: 0,
+					cache_write_tokens: 10106,
+				},
+			});
+
+			expect(normalized).toEqual(
+				expect.objectContaining({
+					inputTokens: 10126,
+					outputTokens: 13,
+					cacheReadTokens: 0,
+					cacheWriteTokens: 10106,
+				}),
+			);
+		});
+
+		it("extracts Qwen cache reads from raw prompt token details", () => {
+			const normalized = normalizeUsage({
+				raw: {
+					prompt_tokens_details: {
+						cached_tokens: 8885,
+						cache_write_tokens: 10106,
+					},
+				},
+			});
+
+			expect(normalized).toEqual(
+				expect.objectContaining({
+					cacheReadTokens: 8885,
+					cacheWriteTokens: 10106,
+				}),
+			);
+		});
+
 		it("handles Anthropic's cache_creation metadata", () => {
 			const anthropicRaw = (
 				(fixtures as Record<string, unknown>).anthropic_stream_usage as Record<

--- a/sdk/packages/llms/src/providers/ai-sdk.ts
+++ b/sdk/packages/llms/src/providers/ai-sdk.ts
@@ -22,7 +22,7 @@ import {
 	applyPromptCacheToLastTextPart,
 	isAnthropicCompatibleModel,
 	resolveModelFamily,
-	shouldUseAnthropicPromptCache,
+	shouldApplyPromptCache,
 } from "./routing/anthropic-compatible";
 import {
 	type AiSdkProviderOptionsTarget,
@@ -492,8 +492,8 @@ export function normalizeUsage(
 				"cache_read_input_tokens",
 			) ||
 			getNestedUsageValue(usage, "prompt_tokens_details", "cached_tokens") ||
-			getUsageValue(rawUsage, "cachedContentTokenCount") ||
 			getNestedUsageValue(rawUsage, "prompt_tokens_details", "cached_tokens") ||
+			getUsageValue(rawUsage, "cachedContentTokenCount") ||
 			getUsageValue(
 				providerUsage ?? {},
 				"cachedInputTokens",
@@ -504,14 +504,13 @@ export function normalizeUsage(
 		cacheWriteTokens:
 			getNestedUsageValue(usage, "inputTokens", "cacheWrite") ||
 			getNestedUsageValue(usage, "inputTokenDetails", "cacheWriteTokens") ||
-			getUsageValue(
+			getNestedUsageValue(
 				usage,
-				"cacheWriteTokens",
+				"prompt_tokens_details",
 				"cache_write_tokens",
-				"cache_creation_input_tokens",
 			) ||
 			getUsageValue(
-				rawUsage,
+				usage,
 				"cacheWriteTokens",
 				"cache_write_tokens",
 				"cache_creation_input_tokens",
@@ -520,6 +519,12 @@ export function normalizeUsage(
 				rawUsage,
 				"prompt_tokens_details",
 				"cache_write_tokens",
+			) ||
+			getUsageValue(
+				rawUsage,
+				"cacheWriteTokens",
+				"cache_write_tokens",
+				"cache_creation_input_tokens",
 			) ||
 			getUsageValue(
 				providerUsage ?? {},
@@ -875,7 +880,7 @@ function createAiSdkProvider(kind: ProviderModuleKind): GatewayProviderFactory {
 				const messagesSystemPrompt = useSystemOption ? undefined : systemPrompt;
 				stream = streamText({
 					model: provider.model(context.model.id) as never,
-					messages: (shouldUseAnthropicPromptCache(request, context)
+					messages: (shouldApplyPromptCache(request, context)
 						? buildCachedAiSdkMessages(request, context, messagesSystemPrompt)
 						: toAiSdkMessages(request.messages, messagesSystemPrompt)) as never,
 					...(useSystemOption ? { system: systemPrompt } : {}),

--- a/sdk/packages/llms/src/providers/builtins.ts
+++ b/sdk/packages/llms/src/providers/builtins.ts
@@ -15,6 +15,11 @@ import type {
 	ProviderClient,
 	ProviderProtocol,
 } from "../catalog/types";
+import {
+	ANTHROPIC_AND_QWEN_CACHE_ROUTING_METADATA,
+	ANTHROPIC_ROUTING_METADATA,
+	QWEN_CACHE_ROUTING_METADATA,
+} from "./routing/anthropic-compatible";
 
 export const DEFAULT_INTERNAL_OCA_BASE_URL =
 	"https://code-internal.aiservice.us-chicago-1.oci.oraclecloud.com/20250206/app/litellm";
@@ -140,6 +145,18 @@ function buildOpenAICodexModels(): Record<string, ModelInfo> {
 	);
 }
 
+function fallbackModelInfo(id: string, spec?: BuiltinSpec): ModelInfo {
+	const info: ModelInfo = {
+		id,
+		name: id,
+	};
+	if (spec?.id === "qwen" || spec?.id === "qwen-code") {
+		info.family = "qwen";
+		info.capabilities = ["prompt-cache"];
+	}
+	return info;
+}
+
 function modelInfoToGateway(
 	providerId: string,
 	info: ModelInfo,
@@ -152,6 +169,9 @@ function modelInfoToGateway(
 				break;
 			case "reasoning":
 				capabilities.add("reasoning");
+				break;
+			case "prompt-cache":
+				capabilities.add("prompt-cache");
 				break;
 			case "images":
 				capabilities.add("images");
@@ -247,7 +267,7 @@ const OPENAI_COMPATIBLE_SPECS: BuiltinSpec[] = [
 				return `${getClineEnvironmentConfig().apiBaseUrl}/api/v1`;
 			},
 		},
-		metadata: { promptCacheStrategy: "anthropic-automatic" },
+		metadata: ANTHROPIC_AND_QWEN_CACHE_ROUTING_METADATA,
 	},
 	{
 		id: "deepseek",
@@ -377,7 +397,7 @@ const OPENAI_COMPATIBLE_SPECS: BuiltinSpec[] = [
 		apiKeyEnv: ["AI_GATEWAY_API_KEY"],
 		modelsProviderId: "vercel-ai-gateway",
 		defaults: { baseUrl: "https://ai-gateway.vercel.sh/v1" },
-		metadata: { promptCacheStrategy: "anthropic-automatic" },
+		metadata: ANTHROPIC_AND_QWEN_CACHE_ROUTING_METADATA,
 	},
 	{
 		id: "v0",
@@ -401,7 +421,7 @@ const OPENAI_COMPATIBLE_SPECS: BuiltinSpec[] = [
 		apiKeyEnv: ["AIHUBMIX_API_KEY"],
 		modelsProviderId: "aihubmix",
 		defaults: { baseUrl: "https://api.aihubmix.com/v1" },
-		metadata: { promptCacheStrategy: "anthropic-automatic" },
+		metadata: ANTHROPIC_ROUTING_METADATA,
 	},
 	{
 		id: "hicap",
@@ -443,7 +463,7 @@ const OPENAI_COMPATIBLE_SPECS: BuiltinSpec[] = [
 		apiKeyEnv: ["QWEN_API_KEY"],
 		modelsProviderId: "qwen",
 		defaults: { baseUrl: "https://dashscope.aliyuncs.com/compatible-mode/v1" },
-		metadata: { promptCacheStrategy: "anthropic-automatic" },
+		metadata: QWEN_CACHE_ROUTING_METADATA,
 	},
 	{
 		id: "qwen-code",
@@ -454,7 +474,7 @@ const OPENAI_COMPATIBLE_SPECS: BuiltinSpec[] = [
 		defaultModelId: "qwen3-coder-plus",
 		modelsProviderId: "qwen-code",
 		defaults: { baseUrl: "https://dashscope.aliyuncs.com/compatible-mode/v1" },
-		metadata: { promptCacheStrategy: "anthropic-automatic" },
+		metadata: QWEN_CACHE_ROUTING_METADATA,
 	},
 	{
 		id: "doubao",
@@ -547,7 +567,7 @@ const OPENAI_COMPATIBLE_SPECS: BuiltinSpec[] = [
 		modelsProviderId: "openrouter",
 		docsUrl: "https://openrouter.ai/models",
 		defaults: { baseUrl: "https://openrouter.ai/api/v1" },
-		metadata: { promptCacheStrategy: "anthropic-automatic" },
+		metadata: ANTHROPIC_AND_QWEN_CACHE_ROUTING_METADATA,
 	},
 	{
 		id: "ollama",
@@ -581,7 +601,7 @@ const OPENAI_COMPATIBLE_SPECS: BuiltinSpec[] = [
 		apiKeyEnv: ["OCA_API_KEY"],
 		modelsProviderId: "oca",
 		defaults: { baseUrl: DEFAULT_EXTERNAL_OCA_BASE_URL },
-		metadata: { promptCacheStrategy: "anthropic-automatic" },
+		metadata: ANTHROPIC_ROUTING_METADATA,
 	},
 	{
 		id: "asksage",
@@ -605,7 +625,7 @@ const OPENAI_COMPATIBLE_SPECS: BuiltinSpec[] = [
 		defaultModelId: "anthropic--claude-3.5-sonnet",
 		apiKeyEnv: ["AICORE_SERVICE_KEY", "VCAP_SERVICES"],
 		modelsProviderId: "sapaicore",
-		metadata: { promptCacheStrategy: "anthropic-automatic" },
+		metadata: ANTHROPIC_ROUTING_METADATA,
 	},
 ];
 
@@ -656,7 +676,7 @@ export const BUILTIN_SPECS: BuiltinSpec[] = [
 		apiKeyEnv: ["ANTHROPIC_API_KEY"],
 		modelsProviderId: "anthropic",
 		defaults: { baseUrl: "https://api.anthropic.com/v1" },
-		metadata: { promptCacheStrategy: "anthropic-automatic" },
+		metadata: ANTHROPIC_ROUTING_METADATA,
 	},
 	{
 		id: "claude-code",
@@ -695,7 +715,7 @@ export const BUILTIN_SPECS: BuiltinSpec[] = [
 			"GOOGLE_API_KEY",
 		],
 		modelsProviderId: "vertex",
-		metadata: { promptCacheStrategy: "anthropic-automatic" },
+		metadata: ANTHROPIC_ROUTING_METADATA,
 	},
 	{
 		id: "bedrock",
@@ -712,7 +732,7 @@ export const BUILTIN_SPECS: BuiltinSpec[] = [
 			"AWS_SESSION_TOKEN",
 		],
 		modelsProviderId: "bedrock",
-		metadata: { promptCacheStrategy: "anthropic-automatic" },
+		metadata: ANTHROPIC_ROUTING_METADATA,
 	},
 	{
 		id: "mistral",
@@ -735,7 +755,7 @@ export const BUILTIN_SPECS: BuiltinSpec[] = [
 		apiKeyEnv: ["MINIMAX_API_KEY"],
 		modelsProviderId: "minimax",
 		defaults: { baseUrl: "https://api.minimax.io/anthropic" },
-		metadata: { promptCacheStrategy: "anthropic-automatic" },
+		metadata: ANTHROPIC_ROUTING_METADATA,
 	},
 	{
 		id: "opencode",
@@ -778,10 +798,7 @@ function toModelCollection(spec: BuiltinSpec): ModelCollection {
 			? sourceModels
 			: spec.defaultModelId
 				? {
-						[spec.defaultModelId]: {
-							id: spec.defaultModelId,
-							name: spec.defaultModelId,
-						},
+						[spec.defaultModelId]: fallbackModelInfo(spec.defaultModelId, spec),
 					}
 				: {};
 	const modelIds = Object.keys(models);

--- a/sdk/packages/llms/src/providers/compat.ts
+++ b/sdk/packages/llms/src/providers/compat.ts
@@ -63,6 +63,7 @@ function toGatewayCapabilities(
 		switch (capability) {
 			case "tools":
 			case "reasoning":
+			case "prompt-cache":
 			case "images":
 			case "audio":
 				mapped.add(capability);
@@ -70,7 +71,6 @@ function toGatewayCapabilities(
 			case "files":
 			case "streaming":
 			case "temperature":
-			case "prompt-cache":
 			case "reasoning-effort":
 			case "computer-use":
 			case "global-endpoint":

--- a/sdk/packages/llms/src/providers/gateway.test.ts
+++ b/sdk/packages/llms/src/providers/gateway.test.ts
@@ -193,17 +193,30 @@ describe("sdk-gateway", () => {
 			.listProviders()
 			.find((provider) => provider.id === "aihubmix");
 		expect(aihubmix?.metadata).toMatchObject({
-			promptCacheStrategy: "anthropic-automatic",
+			routing: {
+				promptCache: {
+					format: "anthropic-cache-control",
+				},
+				reasoning: {
+					format: "anthropic-thinking",
+					routes: [
+						{
+							matcher: "anthropic-compatible",
+						},
+					],
+				},
+			},
 		});
 	});
 
-	it("keeps anthropic-automatic prompt cache strategy on the expected remapped provider set", () => {
+	it("keeps Anthropic cache-control routing on the expected provider set", () => {
 		const gateway = createGateway();
 		const strategyProviders = gateway
 			.listProviders()
 			.filter(
 				(provider) =>
-					provider.metadata?.promptCacheStrategy === "anthropic-automatic",
+					provider.metadata?.routing?.promptCache?.format ===
+					"anthropic-cache-control",
 			)
 			.map((provider) => provider.id)
 			.sort();
@@ -222,6 +235,80 @@ describe("sdk-gateway", () => {
 			"vercel-ai-gateway",
 			"vertex",
 		]);
+	});
+
+	it("routes Qwen cache controls by model family instead of exact model ids", () => {
+		const gateway = createGateway();
+		const openrouter = gateway
+			.listProviders()
+			.find((provider) => provider.id === "openrouter");
+		const promptCacheRoutes =
+			openrouter?.metadata?.routing?.promptCache?.routes ?? [];
+
+		expect(promptCacheRoutes).toEqual([
+			{ matcher: "anthropic-compatible" },
+			{
+				matcher: "model-family",
+				family: "qwen",
+				requiredCapability: "prompt-cache",
+			},
+		]);
+		expect(promptCacheRoutes).not.toContainEqual(
+			expect.objectContaining({ matcher: "model-id" }),
+		);
+
+		const openrouterQwen = gateway
+			.listModels("openrouter")
+			.find((model) => model.id === "qwen/qwen3.6-plus");
+		expect(openrouterQwen?.metadata?.family).toBe("qwen");
+		expect(openrouterQwen?.capabilities).toContain("prompt-cache");
+
+		const directQwen = gateway
+			.listModels("qwen")
+			.find((model) => model.id === "qwen-plus-latest");
+		expect(directQwen).toBeDefined();
+		expect(directQwen?.metadata?.family).toBe("qwen");
+		expect(directQwen?.capabilities).toContain("prompt-cache");
+
+		const directQwenCode = gateway
+			.listModels("qwen-code")
+			.find((model) => model.id === "qwen3-coder-plus");
+		expect(directQwenCode).toBeDefined();
+		expect(directQwenCode?.metadata?.family).toBe("qwen");
+		expect(directQwenCode?.capabilities).toContain("prompt-cache");
+	});
+
+	it("deep-merges provider config routing metadata overrides", () => {
+		const gateway = createGateway({
+			providerConfigs: [
+				{
+					providerId: "openrouter",
+					metadata: {
+						routing: {
+							promptCache: {
+								format: "anthropic-cache-control",
+								routes: [{ matcher: "model-id", modelId: "custom/qwen" }],
+							},
+						},
+					},
+				},
+			],
+		});
+
+		const openrouter = gateway
+			.listProviders()
+			.find((provider) => provider.id === "openrouter");
+
+		expect(openrouter?.metadata?.routing).toMatchObject({
+			promptCache: {
+				format: "anthropic-cache-control",
+				routes: [{ matcher: "model-id", modelId: "custom/qwen" }],
+			},
+			reasoning: {
+				format: "anthropic-thinking",
+				routes: [{ matcher: "anthropic-compatible" }],
+			},
+		});
 	});
 
 	it("adapts OpenAI Responses streams through the native AI SDK provider", async () => {
@@ -1735,6 +1822,7 @@ describe("sdk-gateway", () => {
 						{
 							id: "alibaba/qwen3.6-plus",
 							name: "Qwen 3.6 Plus",
+							capabilities: ["prompt-cache"],
 							metadata: {
 								family: "qwen",
 							},
@@ -1772,6 +1860,7 @@ describe("sdk-gateway", () => {
 					}),
 				}),
 			}),
+			{ type: "text", text: " " },
 		]);
 		expect(userMessage?.content).not.toBe("Hello");
 	});
@@ -2074,7 +2163,14 @@ describe("sdk-gateway", () => {
 				{
 					providerId: "deepseek",
 					apiKey: "deepseek-key",
-					metadata: { promptCacheStrategy: "anthropic-automatic" },
+					metadata: {
+						routing: {
+							promptCache: {
+								format: "anthropic-cache-control",
+								routes: [{ matcher: "anthropic-compatible" }],
+							},
+						},
+					},
 					models: [
 						{
 							id: "deepseek-claude-alias",
@@ -2127,6 +2223,289 @@ describe("sdk-gateway", () => {
 				}),
 			}),
 		);
+	});
+
+	it("preserves legacy promptCacheStrategy for custom Qwen provider configs", async () => {
+		streamTextSpy.mockReturnValue({
+			fullStream: makeStreamParts([
+				{ type: "finish", usage: { inputTokens: 1, outputTokens: 1 } },
+			]),
+		});
+
+		const gateway = createGateway({
+			providerConfigs: [
+				{
+					providerId: "deepseek",
+					apiKey: "deepseek-key",
+					metadata: {
+						promptCacheStrategy: "anthropic-automatic",
+					},
+				},
+			],
+		});
+
+		await collect(
+			await gateway.stream({
+				providerId: "deepseek",
+				modelId: "qwen/qwen3.6-plus",
+				messages: baseMessages,
+			}),
+		);
+
+		expect(streamTextSpy).toHaveBeenCalledWith(
+			expect.objectContaining({
+				messages: [
+					expect.objectContaining({
+						role: "user",
+						content: [
+							expect.objectContaining({
+								type: "text",
+								text: "Hello",
+								providerOptions: expect.objectContaining({
+									openaiCompatible: expect.objectContaining({
+										cache_control: { type: "ephemeral" },
+									}),
+									deepseek: expect.objectContaining({
+										cache_control: { type: "ephemeral" },
+									}),
+								}),
+							}),
+							{ type: "text", text: " " },
+						],
+					}),
+				],
+				providerOptions: expect.objectContaining({
+					openaiCompatible: expect.objectContaining({
+						cache_control: { type: "ephemeral" },
+					}),
+					deepseek: expect.objectContaining({
+						cache_control: { type: "ephemeral" },
+					}),
+				}),
+			}),
+		);
+		const qwenCall = streamTextSpy.mock.calls.at(-1)?.[0] as {
+			providerOptions?: Record<string, Record<string, unknown> | undefined>;
+		};
+		expect(qwenCall.providerOptions?.anthropic).not.toEqual(
+			expect.objectContaining({
+				cache_control: { type: "ephemeral" },
+			}),
+		);
+	});
+
+	it("forwards Anthropic-style prompt cache controls for Qwen on OpenRouter", async () => {
+		streamTextSpy.mockReturnValue({
+			fullStream: makeStreamParts([
+				{
+					type: "finish",
+					usage: {
+						prompt_tokens: 10126,
+						completion_tokens: 13,
+						prompt_tokens_details: {
+							cached_tokens: 0,
+							cache_write_tokens: 10106,
+						},
+					},
+				},
+			]),
+		});
+
+		const gateway = createGateway({
+			providerConfigs: [
+				{
+					providerId: "openrouter",
+					apiKey: "openrouter-key",
+				},
+			],
+		});
+
+		const events = await collect(
+			await gateway.stream({
+				providerId: "openrouter",
+				modelId: "qwen/qwen3.6-plus",
+				messages: baseMessages,
+			}),
+		);
+
+		expect(streamTextSpy).toHaveBeenCalledWith(
+			expect.objectContaining({
+				messages: expect.arrayContaining([
+					expect.objectContaining({
+						role: "user",
+						content: [
+							expect.objectContaining({
+								type: "text",
+								providerOptions: expect.objectContaining({
+									openaiCompatible: expect.objectContaining({
+										cache_control: { type: "ephemeral" },
+									}),
+									openrouter: expect.objectContaining({
+										cache_control: { type: "ephemeral" },
+									}),
+								}),
+							}),
+							{ type: "text", text: " " },
+						],
+					}),
+				]),
+				providerOptions: expect.objectContaining({
+					openaiCompatible: expect.objectContaining({
+						cache_control: { type: "ephemeral" },
+					}),
+					openrouter: expect.objectContaining({
+						cache_control: { type: "ephemeral" },
+					}),
+				}),
+			}),
+		);
+		const qwenCall = streamTextSpy.mock.calls.at(-1)?.[0] as {
+			providerOptions?: Record<string, Record<string, unknown> | undefined>;
+		};
+		expect(qwenCall.providerOptions?.anthropic).not.toEqual(
+			expect.objectContaining({
+				cache_control: { type: "ephemeral" },
+			}),
+		);
+		expect(events).toContainEqual({
+			type: "usage",
+			usage: expect.objectContaining({
+				cacheReadTokens: 0,
+				cacheWriteTokens: 10106,
+			}),
+		});
+	});
+
+	it.each([
+		{
+			providerId: "cline",
+			modelId: "qwen/qwen3.6-plus",
+			providerOptionsKey: "cline",
+			aliasKey: undefined,
+		},
+		{
+			providerId: "vercel-ai-gateway",
+			modelId: "alibaba/qwen3.6-plus",
+			providerOptionsKey: "vercel-ai-gateway",
+			aliasKey: "vercelAiGateway",
+		},
+	])("forwards Qwen prompt cache controls without Anthropic reasoning for $providerId", async ({
+		providerId,
+		modelId,
+		providerOptionsKey,
+		aliasKey,
+	}) => {
+		streamTextSpy.mockReturnValue({
+			fullStream: makeStreamParts([
+				{ type: "finish", usage: { inputTokens: 1, outputTokens: 1 } },
+			]),
+		});
+
+		const gateway = createGateway({
+			providerConfigs: [
+				{
+					providerId,
+					apiKey: "provider-key",
+				},
+			],
+		});
+
+		await collect(
+			await gateway.stream({
+				providerId,
+				modelId,
+				messages: baseMessages,
+				reasoning: { enabled: true, effort: "high" },
+			}),
+		);
+
+		const qwenCall = streamTextSpy.mock.calls.at(-1)?.[0] as {
+			messages?: Array<{
+				role: string;
+				content: Array<{
+					type: string;
+					providerOptions?: Record<string, Record<string, unknown>>;
+				}>;
+			}>;
+			providerOptions?: Record<string, Record<string, unknown> | undefined>;
+		};
+		const expectedCacheControl = {
+			cache_control: { type: "ephemeral" },
+		};
+
+		expect(qwenCall.messages).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					role: "user",
+					content: [
+						expect.objectContaining({
+							type: "text",
+							providerOptions: expect.objectContaining({
+								openaiCompatible: expect.objectContaining(expectedCacheControl),
+								[providerOptionsKey]:
+									expect.objectContaining(expectedCacheControl),
+							}),
+						}),
+						{ type: "text", text: " " },
+					],
+				}),
+			]),
+		);
+		expect(qwenCall.providerOptions).toEqual(
+			expect.objectContaining({
+				openaiCompatible: expect.objectContaining(expectedCacheControl),
+				[providerOptionsKey]: expect.objectContaining(expectedCacheControl),
+			}),
+		);
+		if (aliasKey) {
+			expect(qwenCall.providerOptions?.[aliasKey]).toEqual(
+				expect.objectContaining(expectedCacheControl),
+			);
+		}
+		expect(qwenCall.providerOptions?.[providerOptionsKey]).not.toEqual(
+			expect.objectContaining({
+				reasoning: expect.anything(),
+			}),
+		);
+		expect(qwenCall.providerOptions?.anthropic).not.toEqual(
+			expect.objectContaining(expectedCacheControl),
+		);
+	});
+
+	it.each([
+		{
+			providerId: "openrouter",
+			modelId: "qwen/qwen-future-cache-model",
+		},
+		{
+			providerId: "vercel-ai-gateway",
+			modelId: "alibaba/qwen-future-cache-model",
+		},
+	])("does not prompt-cache unregistered $providerId Qwen ids without capability metadata", async ({
+		providerId,
+		modelId,
+	}) => {
+		streamTextSpy.mockReturnValue({
+			fullStream: makeStreamParts([
+				{ type: "finish", usage: { inputTokens: 1, outputTokens: 1 } },
+			]),
+		});
+
+		const gateway = createGateway({
+			providerConfigs: [{ providerId, apiKey: "test-key" }],
+		});
+
+		await collect(
+			await gateway.stream({
+				providerId,
+				modelId,
+				messages: baseMessages,
+			}),
+		);
+
+		expect(openaiCompatibleSpy).toHaveBeenCalledWith(modelId);
+		const call = streamTextSpy.mock.calls.at(-1)?.[0];
+		expect(JSON.stringify(call)).not.toContain("cache_control");
 	});
 
 	it("does not rewrite non-anthropic messages with prompt cache provider options", async () => {

--- a/sdk/packages/llms/src/providers/registry.ts
+++ b/sdk/packages/llms/src/providers/registry.ts
@@ -4,6 +4,7 @@ import type {
 	GatewayProviderConfig,
 	GatewayProviderFactory,
 	GatewayProviderManifest,
+	GatewayProviderMetadata,
 	GatewayProviderRegistration,
 	GatewayResolvedModel,
 	GatewayResolvedProviderConfig,
@@ -57,6 +58,29 @@ function mergeModels(
 	}
 
 	return Array.from(merged.values());
+}
+
+function mergeProviderMetadata(
+	base: GatewayProviderMetadata | undefined,
+	override: GatewayProviderMetadata | undefined,
+): GatewayProviderMetadata | undefined {
+	// Routing metadata merges at the promptCache/reasoning branch boundary:
+	// omitted branches inherit, provided branches replace in full. Route arrays
+	// are intentionally not concatenated so overrides remain explicit.
+	const routing =
+		base?.routing || override?.routing
+			? {
+					...(base?.routing ?? {}),
+					...(override?.routing ?? {}),
+				}
+			: undefined;
+	const metadata: GatewayProviderMetadata = {
+		...(base ?? {}),
+		...(override ?? {}),
+		...(routing ? { routing } : {}),
+	};
+
+	return Object.keys(metadata).length > 0 ? metadata : undefined;
 }
 
 function createUnregisteredModel(
@@ -173,13 +197,10 @@ export class GatewayRegistry {
 			...cloneManifest(record.manifest),
 			defaultModelId,
 			models,
-			metadata:
-				config?.metadata || record.manifest.metadata
-					? {
-							...(record.manifest.metadata ?? {}),
-							...(config?.metadata ?? {}),
-						}
-					: undefined,
+			metadata: mergeProviderMetadata(
+				record.manifest.metadata,
+				config?.metadata,
+			),
 		};
 	}
 
@@ -226,12 +247,10 @@ export class GatewayRegistry {
 		}
 
 		const config = this.providerConfigs.get(providerId);
-		const mergedMetadata = {
-			...(record.defaults?.metadata ?? {}),
-			...(config?.metadata ?? {}),
-		};
-		const metadata =
-			Object.keys(mergedMetadata).length > 0 ? mergedMetadata : undefined;
+		const metadata = mergeProviderMetadata(
+			record.defaults?.metadata,
+			config?.metadata,
+		);
 
 		return {
 			manifest,

--- a/sdk/packages/llms/src/providers/routing/anthropic-compatible.test.ts
+++ b/sdk/packages/llms/src/providers/routing/anthropic-compatible.test.ts
@@ -1,4 +1,5 @@
 import type {
+	GatewayModelRoute,
 	GatewayProviderContext,
 	GatewayProviderManifest,
 } from "@cline/shared";
@@ -6,10 +7,10 @@ import { describe, expect, it } from "vitest";
 import {
 	isAnthropicCompatibleModel,
 	isAnthropicCompatibleModelId,
-	isAnthropicPromptCacheCompatibleModel,
-	isAnthropicPromptCacheCompatibleModelId,
-	resolvePromptCacheStrategy,
-	shouldUseAnthropicPromptCache,
+	isQwenModel,
+	resolveAnthropicReasoningRequestPolicy,
+	resolvePromptCacheRoute,
+	shouldApplyPromptCache,
 } from "./anthropic-compatible";
 
 function makeProvider(
@@ -34,6 +35,7 @@ function makeProvider(
 function makeContext(
 	family?: string,
 	metadata?: GatewayProviderManifest["metadata"],
+	capabilities?: GatewayProviderContext["model"]["capabilities"],
 ): GatewayProviderContext {
 	return {
 		provider: makeProvider(metadata),
@@ -41,10 +43,37 @@ function makeContext(
 			id: "model-id",
 			name: "Model",
 			providerId: "test-provider",
+			capabilities,
 			metadata: family ? { family } : undefined,
 		},
 		config: {
 			providerId: "test-provider",
+		},
+	};
+}
+
+function metadataWithRouting(options: {
+	promptCacheRoutes?: GatewayModelRoute[];
+	reasoningRoutes?: GatewayModelRoute[];
+}): GatewayProviderManifest["metadata"] {
+	return {
+		routing: {
+			...(options.promptCacheRoutes
+				? {
+						promptCache: {
+							format: "anthropic-cache-control",
+							routes: options.promptCacheRoutes,
+						},
+					}
+				: {}),
+			...(options.reasoningRoutes
+				? {
+						reasoning: {
+							format: "anthropic-thinking",
+							routes: options.reasoningRoutes,
+						},
+					}
+				: {}),
 		},
 	};
 }
@@ -86,82 +115,279 @@ describe("anthropic-compatible routing helpers", () => {
 		);
 	});
 
-	it("keeps Qwen out of Anthropic reasoning compatibility", () => {
-		expect(isAnthropicCompatibleModel({ family: "qwen" })).toBe(false);
-		expect(isAnthropicCompatibleModelId("qwen/qwen3-coder-plus")).toBe(false);
-	});
-
-	it("matches Qwen for Anthropic-style prompt cache compatibility", () => {
-		expect(isAnthropicPromptCacheCompatibleModel({ family: "qwen" })).toBe(
-			true,
-		);
-		expect(isAnthropicPromptCacheCompatibleModel({ family: "qwen3.6" })).toBe(
-			true,
-		);
+	it("keeps Qwen outside Anthropic compatibility and routes cache by provider metadata", () => {
+		expect(isAnthropicCompatibleModelId("qwen/qwen3.6-plus")).toBe(false);
+		expect(isQwenModel({ modelId: "qwen/qwen3.6-plus" })).toBe(true);
+		expect(isQwenModel({ modelId: "alibaba/qwen3.6-plus" })).toBe(true);
+		expect(isQwenModel({ family: "qwen" })).toBe(true);
+		expect(isQwenModel({ modelId: "anthropic/claude-sonnet-4.6" })).toBe(false);
 		expect(
-			isAnthropicPromptCacheCompatibleModelId("qwen/qwen3-coder-plus"),
-		).toBe(true);
-	});
-
-	it("resolves only the supported prompt cache strategy", () => {
-		expect(
-			resolvePromptCacheStrategy(
-				makeProvider({ promptCacheStrategy: "anthropic-automatic" }),
-			),
-		).toBe("anthropic-automatic");
-		expect(
-			resolvePromptCacheStrategy(
-				makeProvider({ promptCacheStrategy: "invalid" as never }),
+			resolvePromptCacheRoute(
+				{
+					providerId: "test-provider",
+					modelId: "qwen/qwen3.6-plus",
+					messages: [],
+				},
+				makeContext(),
 			),
 		).toBeUndefined();
-		expect(resolvePromptCacheStrategy(makeProvider())).toBeUndefined();
-	});
-
-	it("requires both anthropic compatibility and strategy for prompt cache", () => {
 		expect(
-			shouldUseAnthropicPromptCache(
-				{
-					providerId: "test-provider",
-					modelId: "anthropic.claude-sonnet-4-6",
-					messages: [],
-				},
-				makeContext(undefined, { promptCacheStrategy: "anthropic-automatic" }),
-			),
-		).toBe(true);
-
-		expect(
-			shouldUseAnthropicPromptCache(
-				{
-					providerId: "test-provider",
-					modelId: "anthropic.claude-sonnet-4-6",
-					messages: [],
-				},
-				makeContext(undefined),
-			),
-		).toBe(false);
-
-		expect(
-			shouldUseAnthropicPromptCache(
-				{
-					providerId: "test-provider",
-					modelId: "openai/gpt-5.4",
-					messages: [],
-				},
-				makeContext(undefined, { promptCacheStrategy: "anthropic-automatic" }),
-			),
-		).toBe(false);
-	});
-
-	it("uses prompt cache for Qwen family metadata when the provider opts in", () => {
-		expect(
-			shouldUseAnthropicPromptCache(
+			resolvePromptCacheRoute(
 				{
 					providerId: "test-provider",
 					modelId: "alibaba/qwen3.6-plus",
 					messages: [],
 				},
-				makeContext("qwen", { promptCacheStrategy: "anthropic-automatic" }),
+				makeContext(
+					"qwen",
+					metadataWithRouting({
+						promptCacheRoutes: [
+							{
+								matcher: "model-family",
+								family: "qwen",
+								requiredCapability: "prompt-cache",
+							},
+						],
+					}),
+					["text", "prompt-cache"],
+				),
+			),
+		).toEqual({
+			matcher: "model-family",
+			family: "qwen",
+			requiredCapability: "prompt-cache",
+		});
+		expect(
+			resolvePromptCacheRoute(
+				{
+					providerId: "test-provider",
+					modelId: "alibaba/qwen3.6-plus",
+					messages: [],
+				},
+				makeContext(
+					"qwen",
+					metadataWithRouting({
+						promptCacheRoutes: [
+							{
+								matcher: "model-family",
+								family: "qwen",
+								requiredCapability: "prompt-cache",
+							},
+						],
+					}),
+					["text"],
+				),
+			),
+		).toBeUndefined();
+		expect(
+			resolvePromptCacheRoute(
+				{
+					providerId: "test-provider",
+					modelId: "qwen/qwen3.6-plus",
+					messages: [],
+				},
+				makeContext(
+					undefined,
+					metadataWithRouting({
+						promptCacheRoutes: [
+							{ matcher: "model-id", modelId: "qwen/qwen3.6-plus" },
+						],
+					}),
+				),
+			),
+		).toEqual({ matcher: "model-id", modelId: "qwen/qwen3.6-plus" });
+	});
+
+	it("requires an explicit prompt-cache route", () => {
+		expect(
+			shouldApplyPromptCache(
+				{
+					providerId: "test-provider",
+					modelId: "anthropic.claude-sonnet-4-5",
+					messages: [],
+				},
+				makeContext(
+					undefined,
+					metadataWithRouting({
+						promptCacheRoutes: [{ matcher: "anthropic-compatible" }],
+					}),
+				),
 			),
 		).toBe(true);
+
+		expect(
+			shouldApplyPromptCache(
+				{
+					providerId: "test-provider",
+					modelId: "anthropic.claude-sonnet-4-5",
+					messages: [],
+				},
+				makeContext(),
+			),
+		).toBe(false);
+
+		expect(
+			shouldApplyPromptCache(
+				{
+					providerId: "test-provider",
+					modelId: "openai/gpt-5.4",
+					messages: [],
+				},
+				makeContext(
+					undefined,
+					metadataWithRouting({
+						promptCacheRoutes: [{ matcher: "anthropic-compatible" }],
+					}),
+				),
+			),
+		).toBe(false);
+	});
+
+	it("honors legacy promptCacheStrategy when routing metadata is absent", () => {
+		const request = {
+			providerId: "test-provider",
+			modelId: "anthropic/claude-3.5-sonnet",
+			messages: [],
+		};
+		const context = makeContext(undefined, {
+			promptCacheStrategy: "anthropic-automatic",
+		});
+
+		expect(resolvePromptCacheRoute(request, context)).toEqual({
+			matcher: "anthropic-compatible",
+		});
+		expect(shouldApplyPromptCache(request, context)).toBe(true);
+		expect(
+			shouldApplyPromptCache(
+				{
+					providerId: "test-provider",
+					modelId: "openai/gpt-5.4",
+					messages: [],
+				},
+				context,
+			),
+		).toBe(false);
+	});
+
+	it("preserves legacy promptCacheStrategy for custom Qwen providers", () => {
+		const request = {
+			providerId: "test-provider",
+			modelId: "qwen/qwen3.6-plus",
+			messages: [],
+		};
+		const context = makeContext(undefined, {
+			promptCacheStrategy: "anthropic-automatic",
+		});
+
+		expect(resolvePromptCacheRoute(request, context)).toEqual({
+			matcher: "model-id",
+			modelId: "qwen/qwen3.6-plus",
+		});
+		expect(shouldApplyPromptCache(request, context)).toBe(true);
+	});
+
+	it("preserves legacy Anthropic reasoning for custom Claude providers", () => {
+		const request = {
+			providerId: "test-provider",
+			modelId: "anthropic/claude-sonnet-4-5",
+			messages: [],
+		};
+		const context = makeContext("claude-sonnet", {
+			promptCacheStrategy: "anthropic-automatic",
+		});
+
+		expect(resolveAnthropicReasoningRequestPolicy(request, context)).toEqual({
+			kind: "anthropic-manual",
+		});
+	});
+
+	it("does not preserve legacy Anthropic reasoning for custom Qwen providers", () => {
+		const request = {
+			providerId: "test-provider",
+			modelId: "qwen/qwen3.6-plus",
+			messages: [],
+		};
+		const context = makeContext("qwen", {
+			promptCacheStrategy: "anthropic-automatic",
+		});
+
+		expect(resolveAnthropicReasoningRequestPolicy(request, context)).toEqual({
+			kind: "none",
+		});
+	});
+
+	it("keeps prompt-cache routes separate from reasoning routes", () => {
+		expect(
+			resolveAnthropicReasoningRequestPolicy(
+				{
+					providerId: "test-provider",
+					modelId: "anthropic.claude-sonnet-4-5",
+					messages: [],
+				},
+				makeContext(
+					"claude-sonnet",
+					metadataWithRouting({
+						promptCacheRoutes: [{ matcher: "anthropic-compatible" }],
+					}),
+				),
+			),
+		).toEqual({ kind: "none" });
+
+		expect(
+			resolveAnthropicReasoningRequestPolicy(
+				{
+					providerId: "test-provider",
+					modelId: "anthropic.claude-sonnet-4-5",
+					messages: [],
+				},
+				makeContext(
+					"claude-sonnet",
+					metadataWithRouting({
+						reasoningRoutes: [
+							{
+								matcher: "anthropic-compatible",
+							},
+						],
+					}),
+				),
+			),
+		).toEqual({ kind: "anthropic-manual" });
+	});
+
+	it("enables Anthropic-style prompt cache for Qwen when the provider opts in", () => {
+		expect(
+			shouldApplyPromptCache(
+				{
+					providerId: "test-provider",
+					modelId: "qwen/qwen3.6-plus",
+					messages: [],
+				},
+				makeContext(
+					undefined,
+					metadataWithRouting({
+						promptCacheRoutes: [
+							{ matcher: "model-id", modelId: "qwen/qwen3.6-plus" },
+						],
+					}),
+				),
+			),
+		).toBe(true);
+		expect(
+			resolveAnthropicReasoningRequestPolicy(
+				{
+					providerId: "test-provider",
+					modelId: "qwen/qwen3.6-plus",
+					messages: [],
+				},
+				makeContext(
+					undefined,
+					metadataWithRouting({
+						promptCacheRoutes: [
+							{ matcher: "model-id", modelId: "qwen/qwen3.6-plus" },
+						],
+					}),
+				),
+			),
+		).toEqual({ kind: "none" });
 	});
 });

--- a/sdk/packages/llms/src/providers/routing/anthropic-compatible.test.ts
+++ b/sdk/packages/llms/src/providers/routing/anthropic-compatible.test.ts
@@ -86,6 +86,11 @@ describe("anthropic-compatible routing helpers", () => {
 				family: "Claude-Sonnet",
 			}),
 		).toBe(true);
+		expect(
+			isAnthropicCompatibleModel({
+				family: "Anthropic",
+			}),
+		).toBe(true);
 	});
 
 	it("falls back to model id when family is whitespace-only", () => {
@@ -107,6 +112,7 @@ describe("anthropic-compatible routing helpers", () => {
 		expect(isAnthropicCompatibleModelId("anthropic--claude-3.5-sonnet")).toBe(
 			true,
 		);
+		expect(isAnthropicCompatibleModelId("custom/anthropic-alias")).toBe(true);
 	});
 
 	it("does not match unrelated model ids", () => {

--- a/sdk/packages/llms/src/providers/routing/anthropic-compatible.test.ts
+++ b/sdk/packages/llms/src/providers/routing/anthropic-compatible.test.ts
@@ -5,6 +5,7 @@ import type {
 } from "@cline/shared";
 import { describe, expect, it } from "vitest";
 import {
+	applyPromptCacheToLastTextPart,
 	isAnthropicCompatibleModel,
 	isAnthropicCompatibleModelId,
 	isQwenModel,
@@ -120,6 +121,7 @@ describe("anthropic-compatible routing helpers", () => {
 		expect(isQwenModel({ modelId: "qwen/qwen3.6-plus" })).toBe(true);
 		expect(isQwenModel({ modelId: "alibaba/qwen3.6-plus" })).toBe(true);
 		expect(isQwenModel({ family: "qwen" })).toBe(true);
+		expect(isQwenModel({ family: "qwen3.6" })).toBe(true);
 		expect(isQwenModel({ modelId: "anthropic/claude-sonnet-4.6" })).toBe(false);
 		expect(
 			resolvePromptCacheRoute(
@@ -131,6 +133,32 @@ describe("anthropic-compatible routing helpers", () => {
 				makeContext(),
 			),
 		).toBeUndefined();
+		expect(
+			resolvePromptCacheRoute(
+				{
+					providerId: "test-provider",
+					modelId: "alibaba/qwen3.6-plus",
+					messages: [],
+				},
+				makeContext(
+					"qwen3.6",
+					metadataWithRouting({
+						promptCacheRoutes: [
+							{
+								matcher: "model-family",
+								family: "qwen",
+								requiredCapability: "prompt-cache",
+							},
+						],
+					}),
+					["text", "prompt-cache"],
+				),
+			),
+		).toEqual({
+			matcher: "model-family",
+			family: "qwen",
+			requiredCapability: "prompt-cache",
+		});
 		expect(
 			resolvePromptCacheRoute(
 				{
@@ -301,6 +329,20 @@ describe("anthropic-compatible routing helpers", () => {
 		});
 	});
 
+	it("preserves unrouted Anthropic reasoning for custom Claude providers", () => {
+		const request = {
+			providerId: "test-provider",
+			modelId: "anthropic/claude-3.5-sonnet",
+			messages: [],
+		};
+
+		expect(
+			resolveAnthropicReasoningRequestPolicy(request, makeContext()),
+		).toEqual({
+			kind: "anthropic-manual",
+		});
+	});
+
 	it("does not preserve legacy Anthropic reasoning for custom Qwen providers", () => {
 		const request = {
 			providerId: "test-provider",
@@ -389,5 +431,49 @@ describe("anthropic-compatible routing helpers", () => {
 				),
 			),
 		).toEqual({ kind: "none" });
+	});
+
+	it("adds the non-Anthropic filler when only one text part is present", () => {
+		const message = {
+			content: [
+				{ type: "image_url", image_url: { url: "https://example.test/a.png" } },
+				{ type: "text", text: "Hello" },
+			],
+		};
+
+		applyPromptCacheToLastTextPart(message, "openrouter", false);
+
+		expect(message.content).toHaveLength(3);
+		expect(message.content[1]).toMatchObject({
+			type: "text",
+			text: "Hello",
+			providerOptions: {
+				openaiCompatible: { cache_control: { type: "ephemeral" } },
+				openrouter: { cache_control: { type: "ephemeral" } },
+			},
+		});
+		expect(message.content[2]).toEqual({ type: "text", text: " " });
+	});
+
+	it("does not add the non-Anthropic filler when multiple text parts are present", () => {
+		const message = {
+			content: [
+				{ type: "image_url", image_url: { url: "https://example.test/a.png" } },
+				{ type: "text", text: "Hello" },
+				{ type: "text", text: "World" },
+			],
+		};
+
+		applyPromptCacheToLastTextPart(message, "openrouter", false);
+
+		expect(message.content).toHaveLength(3);
+		expect(message.content[2]).toMatchObject({
+			type: "text",
+			text: "World",
+			providerOptions: {
+				openaiCompatible: { cache_control: { type: "ephemeral" } },
+				openrouter: { cache_control: { type: "ephemeral" } },
+			},
+		});
 	});
 });

--- a/sdk/packages/llms/src/providers/routing/anthropic-compatible.ts
+++ b/sdk/packages/llms/src/providers/routing/anthropic-compatible.ts
@@ -94,10 +94,9 @@ export function isAnthropicCompatibleModel(options: {
 	modelId?: string;
 	family?: string;
 }): boolean {
-	const family =
-		typeof options.family === "string" ? options.family.trim() : "";
+	const family = normalizeRoutingValue(options.family);
 	if (family) {
-		return family.toLowerCase().includes("claude");
+		return isAnthropicLineageValue(family);
 	}
 
 	return isAnthropicCompatibleModelId(options.modelId);
@@ -110,11 +109,7 @@ export function isAnthropicCompatibleModelId(
 		return false;
 	}
 
-	const normalized = modelId.toLowerCase();
-	const hasAnthropicVendor = normalized.includes("anthropic");
-	const hasClaudeLineage = normalized.includes("claude");
-
-	return hasAnthropicVendor || hasClaudeLineage;
+	return isAnthropicLineageValue(modelId);
 }
 
 export function isQwenModel(options: {
@@ -133,6 +128,13 @@ export function isQwenModel(options: {
 function normalizeRoutingValue(value: string | undefined) {
 	const normalized = value?.trim().toLowerCase();
 	return normalized ? normalized : undefined;
+}
+
+function isAnthropicLineageValue(value: string | undefined): boolean {
+	const normalized = normalizeRoutingValue(value);
+	return normalized
+		? normalized.includes("anthropic") || normalized.includes("claude")
+		: false;
 }
 
 function isQwenLineageValue(value: string | undefined): boolean {

--- a/sdk/packages/llms/src/providers/routing/anthropic-compatible.ts
+++ b/sdk/packages/llms/src/providers/routing/anthropic-compatible.ts
@@ -1,7 +1,9 @@
 import type {
+	GatewayModelRoute,
 	GatewayPromptCacheStrategy,
 	GatewayProviderContext,
 	GatewayProviderManifest,
+	GatewayProviderMetadata,
 	GatewayStreamRequest,
 } from "@cline/shared";
 import { createEphemeralCacheControl, toProviderOptionsKey } from "./utils";
@@ -20,14 +22,66 @@ export type AnthropicReasoningRequestPolicy =
 	| { kind: "anthropic-adaptive" };
 
 /**
- * Anthropic-compatible routing precedence:
- * 1) `context.model.metadata.family` (contains "claude")
- * 2) `request.modelId` fallback heuristics
- *
- * Prompt-cache shaping is stricter: it only applies when the resolved model is
- * Anthropic-compatible AND provider metadata opts into
- * `promptCacheStrategy = "anthropic-automatic"`.
+ * Provider metadata owns behavior routing. `anthropic-compatible` is one route
+ * matcher for Claude/Anthropic lineage; prompt-cache and reasoning decide
+ * independently whether they use it.
  */
+
+const ANTHROPIC_COMPATIBLE_ROUTE: GatewayModelRoute = {
+	matcher: "anthropic-compatible",
+};
+
+// Qwen cache support is model-specific; direct Dashscope/OpenRouter catalogs
+// only match this route once their model metadata includes prompt-cache support.
+const QWEN_PROMPT_CACHE_ROUTE: GatewayModelRoute = {
+	matcher: "model-family",
+	family: "qwen",
+	requiredCapability: "prompt-cache",
+};
+
+function createAnthropicRoutingMetadata(options?: {
+	promptCacheRoutes?: GatewayModelRoute[];
+	reasoningRoutes?: GatewayModelRoute[];
+}): GatewayProviderMetadata {
+	const promptCacheRoutes: GatewayModelRoute[] = options?.promptCacheRoutes ?? [
+		ANTHROPIC_COMPATIBLE_ROUTE,
+	];
+	const reasoningRoutes: GatewayModelRoute[] = options?.reasoningRoutes ?? [
+		ANTHROPIC_COMPATIBLE_ROUTE,
+	];
+	return {
+		routing: {
+			...(promptCacheRoutes.length > 0
+				? {
+						promptCache: {
+							format: "anthropic-cache-control",
+							routes: promptCacheRoutes.map((route) => ({ ...route })),
+						},
+					}
+				: {}),
+			...(reasoningRoutes.length > 0
+				? {
+						reasoning: {
+							format: "anthropic-thinking",
+							routes: reasoningRoutes.map((route) => ({ ...route })),
+						},
+					}
+				: {}),
+		},
+	};
+}
+
+export const ANTHROPIC_ROUTING_METADATA = createAnthropicRoutingMetadata();
+
+export const QWEN_CACHE_ROUTING_METADATA = createAnthropicRoutingMetadata({
+	promptCacheRoutes: [QWEN_PROMPT_CACHE_ROUTE],
+	reasoningRoutes: [],
+});
+
+export const ANTHROPIC_AND_QWEN_CACHE_ROUTING_METADATA =
+	createAnthropicRoutingMetadata({
+		promptCacheRoutes: [ANTHROPIC_COMPATIBLE_ROUTE, QWEN_PROMPT_CACHE_ROUTE],
+	});
 
 export function resolveModelFamily(
 	context: GatewayProviderContext,
@@ -43,7 +97,7 @@ export function isAnthropicCompatibleModel(options: {
 	const family =
 		typeof options.family === "string" ? options.family.trim() : "";
 	if (family) {
-		return hasAnthropicLineage(family);
+		return family.toLowerCase().includes("claude");
 	}
 
 	return isAnthropicCompatibleModelId(options.modelId);
@@ -56,39 +110,61 @@ export function isAnthropicCompatibleModelId(
 		return false;
 	}
 
-	return hasAnthropicLineage(modelId);
+	const normalized = modelId.toLowerCase();
+	const hasAnthropicVendor = normalized.includes("anthropic");
+	const hasClaudeLineage = normalized.includes("claude");
+
+	return hasAnthropicVendor || hasClaudeLineage;
 }
 
-export function isAnthropicPromptCacheCompatibleModel(options: {
+export function isQwenModel(options: {
 	modelId?: string;
 	family?: string;
 }): boolean {
-	const family =
-		typeof options.family === "string" ? options.family.trim() : "";
-	if (family) {
-		return hasAnthropicLineage(family) || hasQwenLineage(family);
+	const family = normalizeRoutingValue(options.family);
+	if (family === "qwen") {
+		return true;
 	}
 
-	return isAnthropicPromptCacheCompatibleModelId(options.modelId);
+	const modelId = normalizeRoutingValue(options.modelId);
+	return modelId ? /(^|[/:._-])qwen(?:$|[/:._-]|\d)/.test(modelId) : false;
 }
 
-export function isAnthropicPromptCacheCompatibleModelId(
-	modelId: string | undefined,
+function normalizeRoutingValue(value: string | undefined) {
+	const normalized = value?.trim().toLowerCase();
+	return normalized ? normalized : undefined;
+}
+
+function routeMatches(
+	route: GatewayModelRoute,
+	options: {
+		modelId?: string;
+		family?: string;
+		capabilities?: readonly string[];
+	},
 ): boolean {
-	if (!modelId) {
+	if (
+		"requiredCapability" in route &&
+		route.requiredCapability &&
+		!options.capabilities?.includes(route.requiredCapability)
+	) {
 		return false;
 	}
 
-	return hasAnthropicLineage(modelId) || hasQwenLineage(modelId);
-}
-
-function hasAnthropicLineage(value: string): boolean {
-	const normalized = value.toLowerCase();
-	return normalized.includes("anthropic") || normalized.includes("claude");
-}
-
-function hasQwenLineage(value: string): boolean {
-	return value.toLowerCase().includes("qwen");
+	switch (route.matcher) {
+		case "anthropic-compatible":
+			return isAnthropicCompatibleModel(options);
+		case "model-family":
+			return (
+				normalizeRoutingValue(options.family) ===
+				normalizeRoutingValue(route.family)
+			);
+		case "model-id":
+			return (
+				normalizeRoutingValue(options.modelId) ===
+				normalizeRoutingValue(route.modelId)
+			);
+	}
 }
 
 export function createPromptCacheProviderOptions(
@@ -122,7 +198,7 @@ export function applyPromptCacheToLastTextPart(
 
 	const content = message.content;
 	if (typeof content === "string") {
-		message.content = [
+		const cachedContent: Record<string, unknown>[] = [
 			{
 				type: "text",
 				text: content,
@@ -132,6 +208,13 @@ export function applyPromptCacheToLastTextPart(
 				),
 			},
 		];
+		if (!includeAnthropic) {
+			// Keep non-Anthropic OpenAI-compatible requests multipart so
+			// cache_control remains on the content part instead of being collapsed
+			// to message metadata. Anthropic rejects whitespace-only text blocks.
+			cachedContent.push({ type: "text", text: " " });
+		}
+		message.content = cachedContent;
 		return;
 	}
 
@@ -146,6 +229,7 @@ export function applyPromptCacheToLastTextPart(
 			typeof part === "object" &&
 			(part as { type?: unknown }).type === "text"
 		) {
+			const needsFiller = content.length === 1 && !includeAnthropic;
 			content[i] = {
 				...(part as Record<string, unknown>),
 				providerOptions: createPromptCacheProviderOptions(
@@ -153,20 +237,131 @@ export function applyPromptCacheToLastTextPart(
 					includeAnthropic,
 				),
 			};
+			if (needsFiller) {
+				content.push({ type: "text", text: " " });
+			}
 			return;
 		}
 	}
 }
 
-export function shouldUseAnthropicPromptCache(
+export function shouldApplyPromptCache(
+	request: GatewayStreamRequest,
+	context: GatewayProviderContext,
+): boolean {
+	return resolvePromptCacheRoute(request, context) !== undefined;
+}
+
+function shouldApplyAnthropicCacheBucket(
 	request: GatewayStreamRequest,
 	context: GatewayProviderContext,
 ): boolean {
 	return (
-		isAnthropicPromptCacheCompatibleModel({
+		resolvePromptCacheRoute(request, context)?.matcher ===
+		"anthropic-compatible"
+	);
+}
+
+function resolveLegacyPromptCacheStrategy(
+	provider: GatewayProviderManifest,
+): GatewayPromptCacheStrategy | undefined {
+	return provider.metadata?.promptCacheStrategy === "anthropic-automatic"
+		? "anthropic-automatic"
+		: undefined;
+}
+
+function resolveLegacyPromptCacheRoute(
+	request: GatewayStreamRequest,
+	context: GatewayProviderContext,
+): GatewayModelRoute | undefined {
+	if (
+		resolveLegacyPromptCacheStrategy(context.provider) !== "anthropic-automatic"
+	) {
+		return undefined;
+	}
+
+	const family = resolveModelFamily(context);
+	if (
+		isAnthropicCompatibleModel({
+			modelId: request.modelId,
+			family,
+		})
+	) {
+		return { matcher: "anthropic-compatible" };
+	}
+
+	// `promptCacheStrategy` predates explicit routing and historically treated
+	// Qwen ids as Anthropic-compatible. Preserve that opt-in custom-provider
+	// behavior, but keep the returned route non-Anthropic so Qwen still gets the
+	// OpenAI-compatible cache_control shape used by the new routing path.
+	if (isQwenModel({ modelId: request.modelId, family })) {
+		return family
+			? { matcher: "model-family", family }
+			: { matcher: "model-id", modelId: request.modelId };
+	}
+
+	return undefined;
+}
+
+function resolveLegacyReasoningRoute(
+	request: GatewayStreamRequest,
+	context: GatewayProviderContext,
+): GatewayModelRoute | undefined {
+	if (
+		resolveLegacyPromptCacheStrategy(context.provider) !== "anthropic-automatic"
+	) {
+		return undefined;
+	}
+
+	const family = resolveModelFamily(context);
+	return isAnthropicCompatibleModel({
+		modelId: request.modelId,
+		family,
+	})
+		? { matcher: "anthropic-compatible" }
+		: undefined;
+}
+
+export function resolvePromptCacheRoute(
+	request: GatewayStreamRequest,
+	context: GatewayProviderContext,
+): GatewayModelRoute | undefined {
+	const promptCache = context.provider.metadata?.routing?.promptCache;
+	if (promptCache) {
+		if (promptCache.format !== "anthropic-cache-control") {
+			return undefined;
+		}
+
+		return promptCache.routes.find((route) =>
+			routeMatches(route, {
+				modelId: request.modelId,
+				family: resolveModelFamily(context),
+				capabilities: context.model.capabilities,
+			}),
+		);
+	}
+
+	return resolveLegacyPromptCacheRoute(request, context);
+}
+
+export function resolveReasoningRoute(
+	request: GatewayStreamRequest,
+	context: GatewayProviderContext,
+): GatewayModelRoute | undefined {
+	const reasoning = context.provider.metadata?.routing?.reasoning;
+	if (!reasoning) {
+		return resolveLegacyReasoningRoute(request, context);
+	}
+	if (reasoning.format !== "anthropic-thinking") {
+		return undefined;
+	}
+
+	return reasoning.routes.find((route) =>
+		routeMatches(route, {
 			modelId: request.modelId,
 			family: resolveModelFamily(context),
-		}) && resolvePromptCacheStrategy(context.provider) === "anthropic-automatic"
+			capabilities: context.model.capabilities,
+		}),
 	);
 }
 
@@ -248,7 +443,7 @@ export function resolveAnthropicReasoningRequestPolicy(
 ): AnthropicReasoningRequestPolicy {
 	const family = resolveModelFamily(context);
 	if (
-		!isAnthropicCompatibleModel({ modelId: request.modelId, family }) ||
+		!resolveReasoningRoute(request, context) ||
 		!shouldEmitAnthropicReasoning(context)
 	) {
 		return { kind: "none" };
@@ -260,13 +455,6 @@ export function resolveAnthropicReasoningRequestPolicy(
 	})
 		? { kind: "anthropic-adaptive" }
 		: { kind: "anthropic-manual" };
-}
-
-export function resolvePromptCacheStrategy(
-	provider: GatewayProviderManifest,
-): GatewayPromptCacheStrategy | undefined {
-	const strategy = provider.metadata?.promptCacheStrategy;
-	return strategy === "anthropic-automatic" ? strategy : undefined;
 }
 
 export function buildAnthropicProviderOptions(
@@ -302,7 +490,7 @@ export function buildAnthropicProviderOptions(
 			? { effort: request.reasoning.effort }
 			: {}),
 		...(thinking ? { thinking } : {}),
-		...(shouldUseAnthropicPromptCache(request, context)
+		...(shouldApplyAnthropicCacheBucket(request, context)
 			? createEphemeralCacheControl()
 			: {}),
 	};
@@ -411,12 +599,25 @@ export function buildGatewayReasoningOptions(
 	}
 
 	const policy = resolveAnthropicReasoningRequestPolicy(request, context);
-	if (
+	const reasoningRoute = resolveReasoningRoute(request, context);
+	const family = resolveModelFamily(context);
+	const shouldSuppressUnsupportedRoutedReasoning =
+		policy.kind === "none" && reasoningRoute !== undefined;
+	const shouldSuppressUnroutedAnthropicLikeReasoning =
 		policy.kind === "none" &&
-		isAnthropicCompatibleModel({
-			modelId: request.modelId,
-			family: resolveModelFamily(context),
-		})
+		reasoningRoute === undefined &&
+		(shouldApplyPromptCache(request, context) ||
+			isQwenModel({
+				modelId: request.modelId,
+				family,
+			}) ||
+			isAnthropicCompatibleModel({
+				modelId: request.modelId,
+				family,
+			}));
+	if (
+		shouldSuppressUnsupportedRoutedReasoning ||
+		shouldSuppressUnroutedAnthropicLikeReasoning
 	) {
 		return undefined;
 	}
@@ -425,7 +626,7 @@ export function buildGatewayReasoningOptions(
 		policy.kind === "anthropic-manual"
 			? resolveAnthropicCompatibleReasoningBudget({
 					modelId: request.modelId,
-					family: resolveModelFamily(context),
+					family,
 					effort: request.reasoning?.effort,
 					maxTokens: request.maxTokens,
 					explicitBudgetTokens: request.reasoning?.budgetTokens,

--- a/sdk/packages/llms/src/providers/routing/anthropic-compatible.ts
+++ b/sdk/packages/llms/src/providers/routing/anthropic-compatible.ts
@@ -122,17 +122,38 @@ export function isQwenModel(options: {
 	family?: string;
 }): boolean {
 	const family = normalizeRoutingValue(options.family);
-	if (family === "qwen") {
+	if (isQwenLineageValue(family)) {
 		return true;
 	}
 
 	const modelId = normalizeRoutingValue(options.modelId);
-	return modelId ? /(^|[/:._-])qwen(?:$|[/:._-]|\d)/.test(modelId) : false;
+	return isQwenLineageValue(modelId);
 }
 
 function normalizeRoutingValue(value: string | undefined) {
 	const normalized = value?.trim().toLowerCase();
 	return normalized ? normalized : undefined;
+}
+
+function isQwenLineageValue(value: string | undefined): boolean {
+	return value ? /(^|[/:._-])qwen(?:$|[/:._-]|\d)/.test(value) : false;
+}
+
+function modelFamilyMatches(
+	family: string | undefined,
+	routeFamily: string | undefined,
+): boolean {
+	const normalizedFamily = normalizeRoutingValue(family);
+	const normalizedRouteFamily = normalizeRoutingValue(routeFamily);
+	if (!normalizedFamily || !normalizedRouteFamily) {
+		return false;
+	}
+	if (normalizedFamily === normalizedRouteFamily) {
+		return true;
+	}
+	return normalizedRouteFamily === "qwen"
+		? isQwenLineageValue(normalizedFamily)
+		: false;
 }
 
 function routeMatches(
@@ -155,10 +176,7 @@ function routeMatches(
 		case "anthropic-compatible":
 			return isAnthropicCompatibleModel(options);
 		case "model-family":
-			return (
-				normalizeRoutingValue(options.family) ===
-				normalizeRoutingValue(route.family)
-			);
+			return modelFamilyMatches(options.family, route.family);
 		case "model-id":
 			return (
 				normalizeRoutingValue(options.modelId) ===
@@ -222,6 +240,13 @@ export function applyPromptCacheToLastTextPart(
 		return;
 	}
 
+	const textPartCount = content.filter(
+		(part) =>
+			part &&
+			typeof part === "object" &&
+			(part as { type?: unknown }).type === "text",
+	).length;
+
 	for (let i = content.length - 1; i >= 0; i--) {
 		const part = content[i];
 		if (
@@ -229,7 +254,7 @@ export function applyPromptCacheToLastTextPart(
 			typeof part === "object" &&
 			(part as { type?: unknown }).type === "text"
 		) {
-			const needsFiller = content.length === 1 && !includeAnthropic;
+			const needsFiller = textPartCount === 1 && !includeAnthropic;
 			content[i] = {
 				...(part as Record<string, unknown>),
 				providerOptions: createPromptCacheProviderOptions(
@@ -322,6 +347,23 @@ function resolveLegacyReasoningRoute(
 		: undefined;
 }
 
+function resolveUnroutedAnthropicReasoningRoute(
+	request: GatewayStreamRequest,
+	context: GatewayProviderContext,
+): GatewayModelRoute | undefined {
+	if (context.provider.metadata?.routing) {
+		return undefined;
+	}
+
+	const family = resolveModelFamily(context);
+	return isAnthropicCompatibleModel({
+		modelId: request.modelId,
+		family,
+	})
+		? { matcher: "anthropic-compatible" }
+		: undefined;
+}
+
 export function resolvePromptCacheRoute(
 	request: GatewayStreamRequest,
 	context: GatewayProviderContext,
@@ -350,7 +392,10 @@ export function resolveReasoningRoute(
 ): GatewayModelRoute | undefined {
 	const reasoning = context.provider.metadata?.routing?.reasoning;
 	if (!reasoning) {
-		return resolveLegacyReasoningRoute(request, context);
+		return (
+			resolveLegacyReasoningRoute(request, context) ??
+			resolveUnroutedAnthropicReasoningRoute(request, context)
+		);
 	}
 	if (reasoning.format !== "anthropic-thinking") {
 		return undefined;

--- a/sdk/packages/llms/src/providers/routing/generic-compatible.ts
+++ b/sdk/packages/llms/src/providers/routing/generic-compatible.ts
@@ -5,9 +5,11 @@ import type {
 import {
 	buildAnthropicCompatibleReasoningOptions,
 	isAnthropicCompatibleModel,
+	isQwenModel,
 	resolveAnthropicReasoningRequestPolicy,
 	resolveModelFamily,
-	shouldUseAnthropicPromptCache,
+	resolveReasoningRoute,
+	shouldApplyPromptCache,
 } from "./anthropic-compatible";
 import type {
 	AiSdkProviderOptionsTarget,
@@ -37,14 +39,32 @@ function buildCompatibleThinkingOptions(options: {
 		return {};
 	}
 
+	const family = resolveModelFamily(context);
+	const anthropicPolicy = resolveAnthropicReasoningRequestPolicy(
+		request,
+		context,
+	);
+	const hasAnthropicReasoningRoute =
+		resolveReasoningRoute(request, context) !== undefined;
+	const hasPromptCacheRoute = shouldApplyPromptCache(request, context);
 	const isAnthropicCompatible = isAnthropicCompatibleModel({
 		modelId: request.modelId,
-		family: resolveModelFamily(context),
+		family,
 	});
-	const anthropicPolicy = isAnthropicCompatible
-		? resolveAnthropicReasoningRequestPolicy(request, context)
-		: undefined;
-	if (anthropicPolicy && anthropicPolicy.kind !== "anthropic-adaptive") {
+	const isQwen = isQwenModel({
+		modelId: request.modelId,
+		family,
+	});
+	if (
+		!hasAnthropicReasoningRoute &&
+		(hasPromptCacheRoute || isQwen || isAnthropicCompatible)
+	) {
+		return {};
+	}
+	if (
+		hasAnthropicReasoningRoute &&
+		anthropicPolicy.kind !== "anthropic-adaptive"
+	) {
 		return {};
 	}
 	return { thinking: { type: "adaptive" } };
@@ -52,7 +72,8 @@ function buildCompatibleThinkingOptions(options: {
 
 function buildCompatibleEffortOptions(options: {
 	reasoning: GatewayStreamRequest["reasoning"];
-	isAnthropicCompatibleModelId: boolean;
+	usesAnthropicReasoningRoute: boolean;
+	suppressEffortOptions: boolean;
 	suppressions: ProviderOptionSuppression;
 	anthropicReasoningPolicyKind?: ReturnType<
 		typeof resolveAnthropicReasoningRequestPolicy
@@ -62,12 +83,13 @@ function buildCompatibleEffortOptions(options: {
 	if (
 		options.suppressions.genericEffort ||
 		!effort ||
-		options.reasoning?.enabled === false
+		options.reasoning?.enabled === false ||
+		options.suppressEffortOptions
 	) {
 		return {};
 	}
 	const allowEffort =
-		!options.isAnthropicCompatibleModelId ||
+		!options.usesAnthropicReasoningRoute ||
 		options.anthropicReasoningPolicyKind === "anthropic-adaptive";
 	if (!allowEffort) {
 		return {};
@@ -75,7 +97,7 @@ function buildCompatibleEffortOptions(options: {
 	return {
 		effort,
 		reasoningEffort: effort,
-		...(options.isAnthropicCompatibleModelId
+		...(options.usesAnthropicReasoningRoute
 			? {}
 			: { reasoningSummary: "auto" }),
 	};
@@ -84,33 +106,41 @@ function buildCompatibleEffortOptions(options: {
 export function buildCompatibleProviderOptions(options: {
 	request: GatewayStreamRequest;
 	context: GatewayProviderContext;
-	isAnthropicCompatibleModelId: boolean;
 	target: AiSdkProviderOptionsTarget;
 	suppressions: ProviderOptionSuppression;
 }): Record<string, unknown> {
-	const {
+	const { request, context, target, suppressions } = options;
+	const family = resolveModelFamily(context);
+	const anthropicReasoningPolicy = resolveAnthropicReasoningRequestPolicy(
 		request,
 		context,
-		isAnthropicCompatibleModelId,
-		target,
-		suppressions,
-	} = options;
-	const anthropicReasoningPolicy = isAnthropicCompatibleModelId
-		? resolveAnthropicReasoningRequestPolicy(request, context)
-		: undefined;
+	);
+	const usesAnthropicReasoningRoute =
+		resolveReasoningRoute(request, context) !== undefined;
+	const hasPromptCacheRoute = shouldApplyPromptCache(request, context);
+	const isAnthropicCompatible = isAnthropicCompatibleModel({
+		modelId: request.modelId,
+		family,
+	});
+	const isQwen = isQwenModel({
+		modelId: request.modelId,
+		family,
+	});
+	const suppressCompatibleReasoningOptions =
+		!usesAnthropicReasoningRoute &&
+		(hasPromptCacheRoute || isQwen || isAnthropicCompatible);
 	const reasoning = buildAnthropicCompatibleReasoningOptions(request, context);
-	const promptCache = shouldUseAnthropicPromptCache(request, context)
-		? createEphemeralCacheControl()
-		: {};
+	const promptCache = hasPromptCacheRoute ? createEphemeralCacheControl() : {};
 
 	return {
 		...(target === "openai-compatible" ? { strictJsonSchema: false } : {}),
 		...buildCompatibleThinkingOptions({ request, context, suppressions }),
 		...buildCompatibleEffortOptions({
 			reasoning: request.reasoning,
-			isAnthropicCompatibleModelId,
+			usesAnthropicReasoningRoute,
+			suppressEffortOptions: suppressCompatibleReasoningOptions,
 			suppressions,
-			anthropicReasoningPolicyKind: anthropicReasoningPolicy?.kind,
+			anthropicReasoningPolicyKind: anthropicReasoningPolicy.kind,
 		}),
 		...(reasoning ? { reasoning } : {}),
 		...promptCache,

--- a/sdk/packages/llms/src/providers/routing/provider-options.test.ts
+++ b/sdk/packages/llms/src/providers/routing/provider-options.test.ts
@@ -537,6 +537,29 @@ describe("composeAiSdkProviderOptions: Anthropic thinking precedence", () => {
 				},
 			],
 		},
+		{
+			name: "unrouted custom Claude -> Anthropic reasoning",
+			request: {
+				providerId: "custom-provider",
+				modelId: "anthropic/claude-3.5-sonnet",
+				reasoning: { enabled: true, effort: "high" },
+			},
+			context: {
+				disableAutoAnthropicRouting: true,
+			},
+			expect: [
+				{
+					bucket: "custom-provider",
+					has: { reasoning: { enabled: true, max_tokens: 1024 } },
+					lacks: ["thinking", "effort", "reasoningEffort", "reasoningSummary"],
+				},
+				{
+					bucket: "openaiCompatible",
+					has: { reasoning: { enabled: true, max_tokens: 1024 } },
+					lacks: ["thinking", "effort", "reasoningEffort", "reasoningSummary"],
+				},
+			],
+		},
 	]);
 });
 

--- a/sdk/packages/llms/src/providers/routing/provider-options.test.ts
+++ b/sdk/packages/llms/src/providers/routing/provider-options.test.ts
@@ -19,21 +19,58 @@ type ContextOverrides = {
 	modelId?: string;
 	family?: string;
 	capabilities?: GatewayProviderContext["model"]["capabilities"];
-	providerMetadata?: GatewayProviderContext["provider"]["metadata"];
+	metadata?: GatewayProviderContext["provider"]["metadata"];
+	disableAutoAnthropicRouting?: boolean;
 };
 
 function makeContext(options?: ContextOverrides): GatewayProviderContext {
 	const providerId = options?.providerId ?? "test-provider";
 	const modelId = options?.modelId ?? "model-id";
+	const normalizedFamily = options?.family?.toLowerCase() ?? "";
+	const normalizedModelId = modelId.toLowerCase();
+	const useAnthropicReasoningRoute =
+		options?.disableAutoAnthropicRouting !== true &&
+		(normalizedFamily.includes("claude") ||
+			normalizedModelId.includes("claude") ||
+			normalizedModelId.includes("anthropic"));
+	const anthropicReasoningMetadata: GatewayProviderContext["provider"]["metadata"] =
+		useAnthropicReasoningRoute
+			? {
+					routing: {
+						reasoning: {
+							format: "anthropic-thinking",
+							routes: [
+								{
+									matcher: "anthropic-compatible",
+								},
+							],
+						},
+					},
+				}
+			: undefined;
+	const metadata =
+		anthropicReasoningMetadata || options?.metadata
+			? {
+					...(anthropicReasoningMetadata ?? {}),
+					...(options?.metadata ?? {}),
+					routing:
+						anthropicReasoningMetadata?.routing || options?.metadata?.routing
+							? {
+									...(anthropicReasoningMetadata?.routing ?? {}),
+									...(options?.metadata?.routing ?? {}),
+								}
+							: undefined,
+				}
+			: undefined;
 	return {
 		provider: {
 			id: providerId,
 			name: providerId,
 			defaultModelId: modelId,
-			metadata: options?.providerMetadata,
 			models: [
 				{ id: modelId, name: modelId, providerId, capabilities: ["text"] },
 			],
+			metadata,
 		},
 		model: {
 			id: modelId,
@@ -476,6 +513,30 @@ describe("composeAiSdkProviderOptions: Anthropic thinking precedence", () => {
 				},
 			],
 		},
+		{
+			name: "legacy custom Claude with promptCacheStrategy -> Anthropic reasoning",
+			request: {
+				providerId: "custom-provider",
+				modelId: "anthropic/claude-sonnet-4-5",
+				reasoning: { enabled: true, effort: "high" },
+			},
+			context: {
+				disableAutoAnthropicRouting: true,
+				metadata: { promptCacheStrategy: "anthropic-automatic" },
+			},
+			expect: [
+				{
+					bucket: "custom-provider",
+					has: { reasoning: { enabled: true, max_tokens: 1024 } },
+					lacks: ["thinking", "effort", "reasoningEffort", "reasoningSummary"],
+				},
+				{
+					bucket: "openaiCompatible",
+					has: { reasoning: { enabled: true, max_tokens: 1024 } },
+					lacks: ["thinking", "effort", "reasoningEffort", "reasoningSummary"],
+				},
+			],
+		},
 	]);
 });
 
@@ -527,7 +588,7 @@ describe("composeAiSdkProviderOptions: family/provider thinking patches", () => 
 			},
 			context: {
 				family: "qwen",
-				providerMetadata: { promptCacheStrategy: "anthropic-automatic" },
+				metadata: { promptCacheStrategy: "anthropic-automatic" },
 			},
 			expect: [
 				{
@@ -815,6 +876,171 @@ describe("composeAiSdkProviderOptions: family/provider thinking patches", () => 
 			context: { family: "kimi-k2.6" },
 			expect: [
 				{ bucket: "openaiCompatible", has: { thinking: { type: "enabled" } } },
+			],
+		},
+		{
+			name: "qwen prompt-cache-only route reasoning.enabled=true -> cache control, no thinking",
+			request: {
+				providerId: "qwen",
+				modelId: "qwen-plus",
+				reasoning: { enabled: true, effort: "high" },
+			},
+			context: {
+				family: "qwen",
+				capabilities: ["text", "prompt-cache"],
+				metadata: {
+					routing: {
+						promptCache: {
+							format: "anthropic-cache-control",
+							routes: [
+								{
+									matcher: "model-family",
+									family: "qwen",
+									requiredCapability: "prompt-cache",
+								},
+							],
+						},
+					},
+				},
+			},
+			expect: [
+				{
+					bucket: "qwen",
+					has: { cache_control: { type: "ephemeral" } },
+					lacks: ["thinking", "effort", "reasoningEffort", "reasoningSummary"],
+				},
+				{
+					bucket: "openaiCompatible",
+					has: { cache_control: { type: "ephemeral" } },
+					lacks: ["thinking", "effort", "reasoningEffort", "reasoningSummary"],
+				},
+			],
+		},
+		{
+			name: "qwen prompt-cache route without capability reasoning.enabled=true -> no generic thinking",
+			request: {
+				providerId: "qwen",
+				modelId: "qwen-plus",
+				reasoning: { enabled: true, effort: "high" },
+			},
+			context: {
+				family: "qwen",
+				capabilities: ["text"],
+				metadata: {
+					routing: {
+						promptCache: {
+							format: "anthropic-cache-control",
+							routes: [
+								{
+									matcher: "model-family",
+									family: "qwen",
+									requiredCapability: "prompt-cache",
+								},
+							],
+						},
+					},
+				},
+			},
+			expect: [
+				{
+					bucket: "qwen",
+					lacks: [
+						"cache_control",
+						"thinking",
+						"effort",
+						"reasoningEffort",
+						"reasoningSummary",
+					],
+				},
+				{
+					bucket: "openaiCompatible",
+					lacks: [
+						"cache_control",
+						"thinking",
+						"effort",
+						"reasoningEffort",
+						"reasoningSummary",
+					],
+				},
+			],
+		},
+		{
+			name: "cline qwen prompt-cache-only route reasoning.enabled=true -> cache control, no gateway reasoning",
+			request: {
+				providerId: "cline",
+				modelId: "qwen/qwen3.6-plus",
+				reasoning: { enabled: true, effort: "high" },
+			},
+			context: {
+				family: "qwen",
+				capabilities: ["text", "prompt-cache"],
+				metadata: {
+					routing: {
+						promptCache: {
+							format: "anthropic-cache-control",
+							routes: [
+								{
+									matcher: "model-family",
+									family: "qwen",
+									requiredCapability: "prompt-cache",
+								},
+							],
+						},
+					},
+				},
+			},
+			expect: [
+				{
+					bucket: "cline",
+					has: { cache_control: { type: "ephemeral" } },
+					lacks: [
+						"reasoning",
+						"thinking",
+						"effort",
+						"reasoningEffort",
+						"reasoningSummary",
+					],
+				},
+			],
+		},
+		{
+			name: "cline unregistered qwen reasoning.enabled=true -> no gateway reasoning",
+			request: {
+				providerId: "cline",
+				modelId: "qwen/qwen3.7-plus",
+				reasoning: { enabled: true, effort: "high" },
+			},
+			context: {
+				metadata: {
+					routing: {
+						promptCache: {
+							format: "anthropic-cache-control",
+							routes: [
+								{
+									matcher: "model-family",
+									family: "qwen",
+									requiredCapability: "prompt-cache",
+								},
+							],
+						},
+					},
+				},
+			},
+			expect: [
+				{
+					bucket: "cline",
+					lacks: [
+						"reasoning",
+						"thinking",
+						"effort",
+						"reasoningEffort",
+						"reasoningSummary",
+					],
+				},
+				{
+					bucket: "openaiCompatible",
+					lacks: ["thinking", "effort", "reasoningEffort", "reasoningSummary"],
+				},
 			],
 		},
 		{

--- a/sdk/packages/llms/src/providers/routing/provider-options.ts
+++ b/sdk/packages/llms/src/providers/routing/provider-options.ts
@@ -90,7 +90,6 @@ export function composeAiSdkProviderOptions(
 	const compatibleOptions = buildCompatibleProviderOptions({
 		request,
 		context,
-		isAnthropicCompatibleModelId,
 		target,
 		suppressions,
 	});

--- a/sdk/packages/llms/src/tests/live-providers.example.json
+++ b/sdk/packages/llms/src/tests/live-providers.example.json
@@ -157,6 +157,44 @@
 				"provider": "openrouter",
 				"model": "qwen/qwen3.6-plus"
 			},
+			"runs": 3,
+			"expectations": {
+				"requireUsage": true,
+				"requireCacheReadTokens": true
+			}
+		},
+		"qwen-direct-cache": {
+			"settings": {
+				"provider": "qwen",
+				"model": "qwen-plus",
+				"apiKeyEnv": "DASHSCOPE_API_KEY",
+				"baseUrl": "https://dashscope-intl.aliyuncs.com/compatible-mode/v1"
+			},
+			"runs": 3,
+			"expectations": {
+				"requireUsage": true,
+				"requireCacheReadTokens": true
+			}
+		},
+		"qwen-code-direct-cache": {
+			"settings": {
+				"provider": "qwen-code",
+				"model": "qwen3-coder-plus",
+				"apiKeyEnv": "DASHSCOPE_API_KEY",
+				"baseUrl": "https://dashscope-intl.aliyuncs.com/compatible-mode/v1"
+			},
+			"runs": 3,
+			"expectations": {
+				"requireUsage": true,
+				"requireCacheReadTokens": true
+			}
+		},
+		"cline-qwen": {
+			"settings": {
+				"provider": "cline",
+				"model": "qwen/qwen3.6-plus"
+			},
+			"runs": 3,
 			"expectations": {
 				"requireUsage": true
 			}
@@ -206,8 +244,10 @@
 				"provider": "vercel-ai-gateway",
 				"model": "alibaba/qwen3.6-plus"
 			},
+			"runs": 3,
 			"expectations": {
-				"requireUsage": true
+				"requireUsage": true,
+				"requireCacheReadTokens": true
 			}
 		}
 	}

--- a/sdk/packages/llms/src/tests/live-providers.tools.example.json
+++ b/sdk/packages/llms/src/tests/live-providers.tools.example.json
@@ -91,6 +91,30 @@
 				"requireToolCall": true
 			}
 		},
+		"qwen-tools": {
+			"settings": {
+				"provider": "qwen",
+				"model": "qwen-plus",
+				"apiKeyEnv": "DASHSCOPE_API_KEY",
+				"baseUrl": "https://dashscope-intl.aliyuncs.com/compatible-mode/v1"
+			},
+			"expectations": {
+				"requireUsage": true,
+				"requireToolCall": true
+			}
+		},
+		"qwen-code-tools": {
+			"settings": {
+				"provider": "qwen-code",
+				"model": "qwen3-coder-plus",
+				"apiKeyEnv": "DASHSCOPE_API_KEY",
+				"baseUrl": "https://dashscope-intl.aliyuncs.com/compatible-mode/v1"
+			},
+			"expectations": {
+				"requireUsage": true,
+				"requireToolCall": true
+			}
+		},
 		"cline-tools": {
 			"settings": {
 				"provider": "cline",

--- a/sdk/packages/shared/src/llms/gateway.ts
+++ b/sdk/packages/shared/src/llms/gateway.ts
@@ -27,17 +27,43 @@ export type GatewayModelCapability =
 	| "text"
 	| "tools"
 	| "reasoning"
+	| "prompt-cache"
 	| "images"
 	| "audio"
 	| "structured-output";
 
 export type GatewayPromptCacheStrategy = "anthropic-automatic";
 export type GatewayUsageCostDisplay = "show" | "hide";
+export type GatewayPromptCacheFormat = "anthropic-cache-control";
+export type GatewayReasoningFormat = "anthropic-thinking";
+export type GatewayModelRoute =
+	| { matcher: "anthropic-compatible" }
+	| {
+			matcher: "model-family";
+			family: string;
+			requiredCapability?: GatewayModelCapability;
+	  }
+	| {
+			matcher: "model-id";
+			modelId: string;
+			requiredCapability?: GatewayModelCapability;
+	  };
+export interface GatewayProviderRouting {
+	promptCache?: {
+		format: GatewayPromptCacheFormat;
+		routes: GatewayModelRoute[];
+	};
+	reasoning?: {
+		format: GatewayReasoningFormat;
+		routes: GatewayModelRoute[];
+	};
+}
 
 export interface GatewayProviderMetadata {
 	promptCacheStrategy?: GatewayPromptCacheStrategy;
 	usageCostDisplay?: GatewayUsageCostDisplay;
-	[key: string]: JsonValue | undefined;
+	routing?: GatewayProviderRouting;
+	[key: string]: JsonValue | GatewayProviderRouting | undefined;
 }
 
 export interface GatewayModelDefinition {


### PR DESCRIPTION
## Summary

Ports the SDK Qwen/OpenRouter prompt-cache routing fix into the embedded `sdk/` tree in `cline/cline`.

- replaces the old Qwen-as-Anthropic prompt-cache heuristic with explicit provider routing metadata
- gates Qwen prompt-cache markers on model family plus `prompt-cache` capability
- keeps Anthropic reasoning behavior separate from prompt-cache marker behavior
- preserves model family/capability/pricing metadata when core turns known models into gateway models
- adds regression coverage for Qwen/OpenRouter, Vercel AI Gateway, Anthropic reasoning separation, custom-provider routing, and live-provider examples

## Why

The previous routing path could send or suppress behavior based on broad Anthropic-compatible string matching. Qwen needs the Anthropic-style `cache_control` marker shape, but it should not inherit Anthropic reasoning/provider-option behavior. This keeps the boundary explicit: model metadata says whether prompt caching is supported, and provider routing says which wire-format marker to emit.

## Validation

From `sdk/`:

- `bun run build:sdk`
- `bun run types`
- `bun run test:unit`
- `git diff --check origin/main...HEAD`
- `bun biome check --diagnostic-level=error` on the changed SDK files

Live SDK inference using `/Users/ara2/Desktop/sdk/.env` and `/Users/ara2/Desktop/cline/.env`:

| Case | Result |
| --- | --- |
| OpenRouter `qwen/qwen3.6-plus` | cache reads worked across repeated calls; max `cacheReadTokens=9640` |
| Vercel AI Gateway `alibaba/qwen3.6-plus` | cache reads worked; first call wrote cache, later calls read cache; max `cacheReadTokens=9640` |
| Anthropic `claude-sonnet-4-6` | cache reads worked; max `cacheReadTokens=9639` |
| Cline `anthropic/claude-sonnet-4.6` | cache reads worked; max `cacheReadTokens=9639` |
| Cline `qwen/qwen3.6-plus` | request succeeded, but reported cache read/write usage stayed `0`; this matches the known Cline backend/reporting gap and is not an SDK request-shaping failure |
| Anthropic/OpenRouter/Vercel Claude reasoning | reasoning chunks streamed successfully |
| OpenRouter Qwen with reasoning enabled | request succeeded and streamed reasoning without Anthropic provider-option leakage |

Live CLI inference using the same `.env` files and isolated `--data-dir` sessions, checked in stdout usage, session metadata, and `messages.json`:

| Case | Result |
| --- | --- |
| OpenRouter `qwen/qwen3.6-plus` | cache hit persisted; max metadata `cacheReadTokens=117154`, `messages.json` had nonzero cache reads |
| Vercel AI Gateway `alibaba/qwen3.6-plus` | cache hit persisted; max metadata `cacheReadTokens=43565`, `messages.json` had nonzero cache reads |
| Anthropic `claude-sonnet-4-6` | cache hit persisted; max metadata `cacheReadTokens=32942`, `messages.json` had nonzero cache reads |
| Cline `anthropic/claude-sonnet-4.6` | cache hit persisted; max metadata `cacheReadTokens=34548`, `messages.json` had nonzero cache reads |
| Cline `qwen/qwen3.6-plus` | request succeeded, but metadata and `messages.json` both reported `0` cache read/write tokens; same known Cline Qwen backend/reporting gap |
| CLI Anthropic/OpenRouter/Vercel Claude reasoning | reasoning events streamed and reasoning parts were persisted in `messages.json` |
| CLI OpenRouter Qwen with reasoning enabled | request succeeded and reasoning events streamed/persisted |

Note: a full `bun biome check --diagnostic-level=error` still reports pre-existing formatting issues in SDK example files outside this PR.
