### PR TITLE
Fix SDK app examples

### DIFF
--- a/sdk/apps/examples/README.md
+++ b/sdk/apps/examples/README.md
@@ -39,7 +39,6 @@ Requires Node.js 22+.
 | [desktop-app](./desktop-app) | Full Tauri + Next.js desktop app for running and inspecting chat sessions. | Sidecar runtime, websocket transport, session persistence |
 | [menubar](./menubar) | macOS menu bar app with Tauri. | Native app integration, compact UI |
 | [vscode](./vscode) | VS Code extension with chat panel. | Extension API, webview, workspace context |
-| [slack-bot](./slack-bot) | Slack bot integration. | Event-driven, external service integration |
 
 ## SDK packages
 

--- a/sdk/apps/examples/cli-agent/src/index.ts
+++ b/sdk/apps/examples/cli-agent/src/index.ts
@@ -4,7 +4,7 @@ import { z } from "zod";
 
 const agent = new Agent({
 	providerId: "cline",
-	modelId: "anthropic/claude-sonnet-4-6",
+	modelId: "anthropic/claude-sonnet-4.6",
 	apiKey: process.env.CLINE_API_KEY,
 	systemPrompt: "You are a helpful assistant in a terminal chat. Be concise.",
 	maxIterations: 10,
@@ -35,13 +35,22 @@ agent.subscribe((event) => {
 			process.stdout.write(event.text);
 			break;
 		case "tool-started":
-			console.log(`\n[tool] ${event.toolCall.toolName}(${JSON.stringify(event.toolCall.input)})`);
+			console.log(
+				`\n[tool] ${event.toolCall.toolName}(${JSON.stringify(event.toolCall.input)})`,
+			);
 			break;
 		case "tool-finished": {
-			const result = event.message.content.find((p) => p.type === "tool-result");
+			const result = event.message.content.find(
+				(p) => p.type === "tool-result",
+			);
 			if (result && result.type === "tool-result") {
-				const output = typeof result.output === "string" ? result.output : JSON.stringify(result.output, null, 2);
-				console.log(`[result] ${output.slice(0, 200)}${output.length > 200 ? "..." : ""}`);
+				const output =
+					typeof result.output === "string"
+						? result.output
+						: JSON.stringify(result.output, null, 2);
+				console.log(
+					`[result] ${output.slice(0, 200)}${output.length > 200 ? "..." : ""}`,
+				);
 			}
 			break;
 		}

--- a/sdk/apps/examples/code-review-bot/src/index.ts
+++ b/sdk/apps/examples/code-review-bot/src/index.ts
@@ -1,4 +1,6 @@
-import { execSync } from "node:child_process";
+import { execFileSync } from "node:child_process";
+import { readFileSync, realpathSync, statSync } from "node:fs";
+import path from "node:path";
 import { Agent, createTool } from "@cline/sdk";
 import { z } from "zod";
 
@@ -11,9 +13,22 @@ const ReviewCommentSchema = z.object({
 
 const reviews: z.infer<typeof ReviewCommentSchema>[] = [];
 
+const repoRoot = (() => {
+	try {
+		return execFileSync("git", ["rev-parse", "--show-toplevel"], {
+			encoding: "utf-8",
+		}).trim();
+	} catch {
+		console.error("Error: must be run from within a git repository.");
+		process.exit(1);
+	}
+})();
+
+const realRepoRoot = realpathSync(repoRoot);
+
 const agent = new Agent({
 	providerId: "cline",
-	modelId: "anthropic/claude-sonnet-4-6",
+	modelId: "anthropic/claude-sonnet-4.6",
 	apiKey: process.env.CLINE_API_KEY,
 	systemPrompt: `You are a senior code reviewer. Analyze the git diff provided and leave review comments using the add_review_comment tool. Focus on:
 - Bugs and logic errors (critical)
@@ -22,18 +37,38 @@ const agent = new Agent({
 - Style and readability improvements (suggestion)
 
 When you are done reviewing, call submit_review with a brief summary.`,
-	maxIterations: 5,
+	maxIterations: 20,
 	tools: [
 		createTool({
 			name: "get_file_context",
-			description: "Read the full contents of a file to understand context around a diff hunk.",
+			description:
+				"Read the full contents of a file to understand context around a diff hunk.",
 			inputSchema: z.object({
 				path: z.string().describe("File path relative to the repo root"),
 			}),
 			async execute(input) {
 				try {
-					const content = execSync(`cat "${input.path}"`, { encoding: "utf-8", maxBuffer: 1024 * 1024 });
-					return content;
+					if (path.isAbsolute(input.path)) {
+						return `Error: absolute paths are not allowed: ${input.path}`;
+					}
+					const resolvedPath = path.resolve(repoRoot, input.path);
+					const realPath = realpathSync(resolvedPath);
+					const relativePath = path.relative(realRepoRoot, realPath);
+					if (
+						!relativePath ||
+						relativePath.startsWith("..") ||
+						path.isAbsolute(relativePath)
+					) {
+						return `Error: path is outside repo root: ${input.path}`;
+					}
+					const stats = statSync(realPath);
+					if (!stats.isFile()) {
+						return `Error: path is not a file: ${input.path}`;
+					}
+					if (stats.size > 1024 * 1024) {
+						return `Error: file is too large to read: ${input.path}`;
+					}
+					return readFileSync(realPath, { encoding: "utf-8" });
 				} catch {
 					return `Error: could not read file ${input.path}`;
 				}
@@ -57,7 +92,11 @@ When you are done reviewing, call submit_review with a brief summary.`,
 			}),
 			lifecycle: { completesRun: true },
 			async execute(input) {
-				return JSON.stringify({ summary: input.summary, approve: input.approve, commentCount: reviews.length });
+				return JSON.stringify({
+					summary: input.summary,
+					approve: input.approve,
+					commentCount: reviews.length,
+				});
 			},
 		}),
 	],
@@ -70,9 +109,18 @@ agent.subscribe((event) => {
 			break;
 		case "tool-started":
 			if (event.toolCall.toolName === "add_review_comment") {
-				const input = event.toolCall.input as z.infer<typeof ReviewCommentSchema>;
-				const icon = input.severity === "critical" ? "X" : input.severity === "warning" ? "!" : "~";
-				console.log(`  [${icon}] ${input.file}:${input.line} - ${input.comment}`);
+				const input = event.toolCall.input as z.infer<
+					typeof ReviewCommentSchema
+				>;
+				const icon =
+					input.severity === "critical"
+						? "X"
+						: input.severity === "warning"
+							? "!"
+							: "~";
+				console.log(
+					`  [${icon}] ${input.file}:${input.line} - ${input.comment}`,
+				);
 			}
 			break;
 	}
@@ -80,9 +128,17 @@ agent.subscribe((event) => {
 
 // Get the diff to review
 const ref = process.argv[2] || "HEAD~1";
+if (ref.startsWith("-")) {
+	console.error(`Invalid ref: ${ref}`);
+	process.exit(1);
+}
+
 let diff: string;
 try {
-	diff = execSync(`git diff ${ref}`, { encoding: "utf-8", maxBuffer: 5 * 1024 * 1024 });
+	diff = execFileSync("git", ["diff", ref], {
+		encoding: "utf-8",
+		maxBuffer: 5 * 1024 * 1024,
+	});
 } catch {
 	console.error(`Failed to get diff for ref: ${ref}`);
 	console.error("Usage: bun dev [git-ref]");
@@ -96,9 +152,13 @@ if (!diff.trim()) {
 	process.exit(0);
 }
 
-console.log(`Reviewing diff against ${ref} (${diff.split("\n").length} lines)...\n`);
+console.log(
+	`Reviewing diff against ${ref} (${diff.split("\n").length} lines)...\n`,
+);
 
-const result = await agent.run(`Review this git diff:\n\n\`\`\`diff\n${diff}\n\`\`\``);
+const result = await agent.run(
+	`Review this git diff:\n\n\`\`\`diff\n${diff}\n\`\`\``,
+);
 
 console.log("\n\n--- Review Complete ---\n");
 
@@ -129,4 +189,6 @@ if (reviews.length === 0) {
 	}
 }
 
-console.log(`\nStatus: ${result.status} | Iterations: ${result.iterations} | Tokens: ${result.usage.outputTokens} output`);
+console.log(
+	`\nStatus: ${result.status} | Iterations: ${result.iterations} | Tokens: ${result.usage.outputTokens} output`,
+);

--- a/sdk/apps/examples/multi-agent/src/index.ts
+++ b/sdk/apps/examples/multi-agent/src/index.ts
@@ -134,7 +134,7 @@ const AGENT_ROLES = [
 function createAgentConfig() {
 	return {
 		providerId: "cline",
-		modelId: "anthropic/claude-sonnet-4-6",
+		modelId: "anthropic/claude-sonnet-4.6",
 		apiKey: process.env.CLINE_API_KEY,
 		maxIterations: 1,
 	};
@@ -222,7 +222,11 @@ async function runAgents(
 			status: result.status,
 		});
 
-		return { role: spec.role, output: result.outputText, status: result.status };
+		return {
+			role: spec.role,
+			output: result.outputText,
+			status: result.status,
+		};
 	});
 
 	return Promise.all(promises);

--- a/sdk/apps/examples/quickstart/src/index.ts
+++ b/sdk/apps/examples/quickstart/src/index.ts
@@ -2,7 +2,7 @@ import { Agent } from "@cline/sdk";
 
 const agent = new Agent({
 	providerId: "cline",
-	modelId: "anthropic/claude-sonnet-4-6",
+	modelId: "anthropic/claude-sonnet-4.6",
 	apiKey: process.env.CLINE_API_KEY,
 	maxIterations: 1,
 });
@@ -14,4 +14,6 @@ agent.subscribe((event) => {
 });
 
 const result = await agent.run("Explain what an SDK is in two sentences.");
-console.log(`\n\nDone (${result.iterations} iteration, ${result.usage.outputTokens} output tokens)`);
+console.log(
+	`\n\nDone (${result.iterations} iteration, ${result.usage.outputTokens} output tokens)`,
+);

--- a/sdk/apps/examples/vscode/README.md
+++ b/sdk/apps/examples/vscode/README.md
@@ -4,7 +4,7 @@ VS Code extension that opens a chat webview and runs Cline sessions over the RPC
 
 ## What it does
 
-- Opens a webview panel via `Cline: Open Chat`.
+- Opens a webview panel via `Cline: Open Chat in Editor`.
 - Ensures a compatible owner-scoped RPC sidecar by running `cline rpc ensure --json`.
 - Starts/sends/aborts chat turns using RPC runtime methods (`StartRuntimeSession`, `SendRuntimeSession`, `AbortRuntimeSession`).
 - Streams runtime events into the webview for incremental assistant output.
@@ -29,4 +29,4 @@ To run locally in VS Code:
 1. Build the extension: `bun -F @cline/vscode build`.
 2. Open `apps/examples/vscode` in VS Code.
 3. Press `F5` to launch the Extension Development Host.
-4. Run command `Cline: Open RPC Chat`.
+4. Run command `Cline: Open Chat in Editor`.


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

### Description

Fixes several SDK app example issues found while building and manually running the examples:

- Updates direct SDK examples to use the current Cline model id, `anthropic/claude-sonnet-4.6`.
- Fixes `code-review-bot` file context reads so paths from git diffs resolve from the repository root.
- Hardens `code-review-bot` git/file handling by avoiding shell-constructed git commands, rejecting option-like refs, constraining file reads to the repo, and enforcing a file size cap.
- Removes the nonexistent `slack-bot` entry from the examples README.
- Updates the VS Code example README to use its actual contributed command, `Cline: Open Chat in Editor`.

### Test Procedure

- Ran `bun install` and `bun run build:sdk` from `sdk/`.
- Ran `bun run build` for:
  - `sdk/apps/examples/quickstart`
  - `sdk/apps/examples/cli-agent`
  - `sdk/apps/examples/code-review-bot`
  - `sdk/apps/examples/multi-agent`
- Loaded a local `.env` with `CLINE_API_KEY` and manually verified:
  - `quickstart` streams a real model response.
  - `cli-agent` returns a live response in an interactive terminal and exits cleanly.
  - `code-review-bot` completes a live review run with `Status: completed`.
  - `multi-agent` renders in the browser, all three agent cards reach `done`, and the synthesized answer appears.
- Verified `sdk/apps/examples` no longer contains stale `slack-bot`, `Open RPC Chat`, or direct SDK `anthropic/claude-sonnet-4-6` references.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality not to work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [x] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A. These changes are SDK example fixes and documentation corrections.

### Additional Notes

No associated issue was found; this is a small bug fix and documentation cleanup.
