### PR TITLE
fix(sdk): hide teammate sessions from history by default CLINE-2173

### DIFF
--- a/sdk/apps/cli/src/session/session.test.ts
+++ b/sdk/apps/cli/src/session/session.test.ts
@@ -241,6 +241,7 @@ describe("createCliCore", () => {
 				limit: 25,
 				includeManifestFallback: true,
 				hydrate: false,
+				includeSubagents: false,
 			},
 		);
 		expect(createCore).not.toHaveBeenCalled();
@@ -271,6 +272,7 @@ describe("createCliCore", () => {
 				limit: 25,
 				includeManifestFallback: true,
 				hydrate: false,
+				includeSubagents: false,
 			},
 		);
 		expect(rows).toEqual([

--- a/sdk/apps/cli/src/session/session.ts
+++ b/sdk/apps/cli/src/session/session.ts
@@ -100,6 +100,7 @@ export async function listSessions(
 		limit,
 		includeManifestFallback: true,
 		hydrate: options?.hydrate ?? false,
+		includeSubagents: false,
 	});
 }
 

--- a/sdk/packages/core/src/ClineCore.test.ts
+++ b/sdk/packages/core/src/ClineCore.test.ts
@@ -1,7 +1,6 @@
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import type { AgentResult } from "@cline/shared";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ClineCoreStartInput } from "./cline-core/types";
 import type {
@@ -17,6 +16,7 @@ vi.mock("./runtime/host/host", () => ({
 	createRuntimeHost: createRuntimeHostMock,
 }));
 
+import type { AgentResult } from "@cline/shared";
 import { ClineCore } from "./ClineCore";
 
 function createStartInput(): ClineCoreStartInput {
@@ -389,7 +389,7 @@ describe("ClineCore", () => {
 		const core = await ClineCore.create();
 		const [row] = await core.list(10);
 
-		expect(host.listSessions).toHaveBeenCalledWith(10);
+		expect(host.listSessions).toHaveBeenCalledWith(20);
 		expect(host.readSessionMessages).toHaveBeenCalledWith("session-3");
 		expect(row).toMatchObject({
 			sessionId: "session-3",
@@ -444,9 +444,10 @@ describe("ClineCore", () => {
 		const core = await ClineCore.create();
 		const [row] = await core.list(10, { hydrate: false });
 
-		// Hydration options are consumed by ClineCore/listSessionHistory; the host
-		// list contract only receives the numeric limit.
-		expect(host.listSessions.mock.calls).toEqual([[10]]);
+		// Hydration and default root-session filtering are consumed by
+		// ClineCore/listSessionHistory; the host list contract only receives the
+		// numeric scan limit.
+		expect(host.listSessions.mock.calls).toEqual([[20]]);
 		expect(host.readSessionMessages).not.toHaveBeenCalled();
 		expect(row).toMatchObject({
 			sessionId: "session-lightweight",

--- a/sdk/packages/core/src/runtime/host/history.test.ts
+++ b/sdk/packages/core/src/runtime/host/history.test.ts
@@ -262,7 +262,7 @@ describe("session history", () => {
 			{ limit: 10, hydrate: false },
 		);
 
-		expect(list).toHaveBeenCalledWith(10);
+		expect(list).toHaveBeenCalledWith(20);
 		expect(readSessionMessages).not.toHaveBeenCalled();
 		expect(rows).toEqual([
 			expect.objectContaining({
@@ -271,6 +271,62 @@ describe("session history", () => {
 				model: "anthropic/claude-sonnet-4.6",
 				metadata: expect.objectContaining({ title: "stored title" }),
 			}),
+		]);
+	});
+
+	it("filters child sessions from history by default", async () => {
+		const listSessions = vi.fn().mockResolvedValue([
+			createBackendRow({
+				sessionId: "root-session__teamtask__java-haiku-agent__abc123",
+				parentSessionId: "root-session",
+				parentAgentId: "lead",
+				agentId: "java-haiku-agent",
+				isSubagent: true,
+			}),
+			createBackendRow({
+				sessionId: "root-session__plain-worker",
+				parentSessionId: "root-session",
+				parentAgentId: "lead",
+				agentId: "plain-worker",
+				isSubagent: true,
+			}),
+			createBackendRow({
+				sessionId: "root-session",
+			}),
+		]);
+
+		const rows = await listSessionHistoryFromBackend(
+			{ listSessions },
+			{ limit: 10, hydrate: false },
+		);
+
+		expect(listSessions).toHaveBeenCalledWith(20);
+		expect(rows.map((row) => row.sessionId)).toEqual(["root-session"]);
+	});
+
+	it("can include child sessions when explicitly requested", async () => {
+		const listSessions = vi.fn().mockResolvedValue([
+			createBackendRow({
+				sessionId: "root-session__teamtask__java-haiku-agent__abc123",
+				parentSessionId: "root-session",
+				parentAgentId: "lead",
+				agentId: "java-haiku-agent",
+				isSubagent: true,
+			}),
+			createBackendRow({
+				sessionId: "root-session",
+			}),
+		]);
+
+		const rows = await listSessionHistoryFromBackend(
+			{ listSessions },
+			{ limit: 10, hydrate: false, includeSubagents: true },
+		);
+
+		expect(listSessions).toHaveBeenCalledWith(10);
+		expect(rows.map((row) => row.sessionId)).toEqual([
+			"root-session__teamtask__java-haiku-agent__abc123",
+			"root-session",
 		]);
 	});
 
@@ -295,6 +351,7 @@ describe("session history", () => {
 			{ limit: 10, hydrate: false },
 		);
 
+		expect(listSessions).toHaveBeenCalledWith(20);
 		expect(rows.map((row) => row.sessionId)).toEqual([
 			"sess_full",
 			"sess_empty",
@@ -324,7 +381,7 @@ describe("session history", () => {
 			{ limit: 5, hydrate: false },
 		);
 
-		expect(listSessions).toHaveBeenCalledWith(5);
+		expect(listSessions).toHaveBeenCalledWith(20);
 		expect(rows).toEqual([
 			expect.objectContaining({
 				sessionId: "sess_backend_direct",

--- a/sdk/packages/core/src/runtime/host/history.ts
+++ b/sdk/packages/core/src/runtime/host/history.ts
@@ -20,6 +20,7 @@ export interface SessionHistoryListOptions {
 	limit?: number;
 	includeManifestFallback?: boolean;
 	hydrate?: boolean;
+	includeSubagents?: boolean;
 }
 
 type StoredSessionMessage = LlmsProviders.Message & {
@@ -69,6 +70,21 @@ function asHistoryMetadata(value: unknown): SessionHistoryMetadata | undefined {
 function normalizeHistoryLimit(limit: number | undefined): number {
 	const value = limit ?? 200;
 	return Number.isFinite(value) ? Math.max(0, Math.floor(value)) : 200;
+}
+
+function normalizeHistoryScanLimit(limit: number): number {
+	if (limit === 0) {
+		return 0;
+	}
+	return Math.min(Math.max(limit * 2, 20), 2000);
+}
+
+function isRootSessionRecord(
+	row: Pick<SessionRecord, "isSubagent"> & {
+		parentSessionId?: string;
+	},
+): boolean {
+	return row.isSubagent !== true && !asTrimmedString(row.parentSessionId);
 }
 
 function extractSessionRecencyToken(sessionId: string): number {
@@ -170,13 +186,21 @@ async function listManifestHistoryRows(
 async function listHostSessionRows(
 	host: Pick<RuntimeHost, "listSessions" | "readSessionMessages">,
 	limit: number,
+	options: { includeSubagents: boolean },
 ): Promise<SessionRecord[]> {
 	const requestedLimit = normalizeHistoryLimit(limit);
 	if (requestedLimit === 0) {
 		await host.listSessions(0);
 		return [];
 	}
-	return (await host.listSessions(requestedLimit)).slice(0, requestedLimit);
+	const scanLimit = options.includeSubagents
+		? requestedLimit
+		: normalizeHistoryScanLimit(requestedLimit);
+	const rows = await host.listSessions(scanLimit);
+	const filtered = options.includeSubagents
+		? rows
+		: rows.filter(isRootSessionRecord);
+	return filtered.slice(0, requestedLimit);
 }
 
 function extractTextFromContent(
@@ -369,7 +393,10 @@ export async function listSessionHistory(
 	options: SessionHistoryListOptions = {},
 ): Promise<SessionHistoryRecord[]> {
 	const limit = normalizeHistoryLimit(options.limit);
-	const backendRows = await listHostSessionRows(host, limit);
+	const includeSubagents = options.includeSubagents === true;
+	const backendRows = await listHostSessionRows(host, limit, {
+		includeSubagents,
+	});
 	const manifestRows =
 		options.includeManifestFallback === true && backendRows.length < limit
 			? await listManifestHistoryRows(Math.min(Math.max(limit * 2, 100), 500))


### PR DESCRIPTION


<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- For feature requests: Created a discussion in our Feature Requests discussions board https://github.com/cline/cline/discussions/categories/feature-requests and received approval from core maintainers before implementation
- For all changes: Link the associated issue/discussion in the "Related Issue" section below

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly without prior discussion.

Why this requirement?
We deeply appreciate all community contributions - they are essential to Cline's success! To ensure the best use of everyone's time and maintain project direction, we use our Feature Requests discussions board to gauge community interest and validate feature ideas before implementation begins. This helps us focus development efforts on features that will benefit the most users.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** #XXXX

### Description

<!-- 
Help reviewers understand your changes by making this PR readable and well-organized:

- What problem does this PR solve?
- Why were these changes introduced and what purpose do they serve?
- For larger changes, provide context about your approach and reasoning

Small PRs may need minimal description, but larger changes benefit from explaining where you're coming from. Much of this context can be in the linked issue above, so feel free to reference it rather than repeating everything here.
-->


Filter teammate/subagent sessions out of session history unless explicitly requested. Increase the backend scan limit to compensate for filtered rows so root session listings can still satisfy the requested limit.

### Test Procedure

<!-- 
Please walk us through your testing approach and thought process. This helps reviewers understand that you've thoroughly considered the impact of your changes:

- How did you test this change?
- What could potentially break and how did you verify it doesn't?
- What existing functionality might be affected and how did you check it still works?
- Why are you confident this is ready for merge?

We're not looking for exhaustive documentation - just evidence that you've thought through the implications of your changes and tested accordingly.
-->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

#### After

<img width="1088" height="315" alt="image" src="https://github.com/user-attachments/assets/5064ba16-4f24-47cd-a570-94347f444771" />


### Additional Notes

<!-- Add any additional notes for reviewers -->
