### PR TITLE
fix(llms): avoid double-counting OpenRouter usage cost

### DIFF
--- a/sdk/packages/llms/src/providers/ai-sdk.test.ts
+++ b/sdk/packages/llms/src/providers/ai-sdk.test.ts
@@ -36,7 +36,7 @@ const testCases = [
 			outputTokens: 77,
 			cacheReadTokens: 9090,
 			cacheWriteTokens: 0,
-			totalCost: 0.0068249999999999995, // 0.000325 (cost) + 0.0065 (upstream)
+			totalCost: 0.0068249999999999995, // BYOK fee + upstream provider cost
 		},
 	},
 	{
@@ -183,12 +183,51 @@ describe("ai-sdk usage normalization", () => {
 			expect(normalized.totalCost).toBe(0.000641);
 		});
 
-		it("sums base + upstream costs when both present (OpenRouter)", () => {
+		it("sums BYOK fee + upstream provider cost when OpenRouter marks the request as BYOK", () => {
 			const openrouterUsage = (fixtures as Record<string, unknown>)
 				.openrouter_stream_usage as Record<string, unknown>;
 			const normalized = normalizeUsage(openrouterUsage);
-			// 0.000325 (cost) + 0.0065 (upstream_inference_cost) = 0.0068250
 			expect(normalized.totalCost).toBeCloseTo(0.006825, 5);
+		});
+
+		it("does not double-count OpenRouter credit-billed usage when upstream mirrors cost", () => {
+			const normalized = normalizeUsage({
+				prompt_tokens: 15,
+				completion_tokens: 5,
+				cost: 0.0000301,
+				is_byok: false,
+				cost_details: {
+					upstream_inference_cost: 0.0000301,
+				},
+			});
+
+			expect(normalized.totalCost).toBe(0.0000301);
+		});
+
+		it("uses upstream inference cost when OpenRouter reports no account charge for BYOK", () => {
+			const normalized = normalizeUsage({
+				prompt_tokens: 10,
+				completion_tokens: 5,
+				cost: 0,
+				is_byok: true,
+				cost_details: {
+					upstream_inference_cost: 0.000036,
+				},
+			});
+
+			expect(normalized.totalCost).toBe(0.000036);
+		});
+
+		it("falls back to upstream inference cost when it is the only explicit cost", () => {
+			const normalized = normalizeUsage({
+				prompt_tokens: 10,
+				completion_tokens: 5,
+				cost_details: {
+					upstream_inference_cost: 0.000036,
+				},
+			});
+
+			expect(normalized.totalCost).toBe(0.000036);
 		});
 
 		it("calculates cost from pricing when no explicit cost in response", () => {

--- a/sdk/packages/llms/src/providers/ai-sdk.ts
+++ b/sdk/packages/llms/src/providers/ai-sdk.ts
@@ -404,14 +404,6 @@ function calculateUsageCostFromPricing(
 
 /**
  * Normalizes usage from various provider formats into a standard structure.
- * Handles multiple naming conventions (e.g., inputTokens vs input_tokens),
- * extracts costs from market_cost/cost/upstream_inference_cost fields,
- * and falls back to pricing-based calculation if no explicit cost is found.
- * For providers that charge both gateway and model costs (e.g., OpenRouter),
- * sums baseCost + upstreamInferenceCost when both are present.
- */
-/**
- * Normalizes usage from various provider formats into a standard structure.
  * Accepts both AI SDK's normalized shapes (AiSdkStreamTotalUsage, AiSdkStreamUsage)
  * and raw provider responses. Handles multiple naming conventions (camelCase vs snake_case),
  * extracts costs from provider-specific fields, and falls back to pricing-based calculation.
@@ -462,11 +454,22 @@ export function normalizeUsage(
 		marketCost !== undefined ||
 		baseCost !== undefined ||
 		upstreamInferenceCost !== undefined;
+	const isByokUsage =
+		rawUsage.is_byok === true ||
+		rawUsage.isByok === true ||
+		gatewayMetadata.is_byok === true ||
+		gatewayMetadata.isByok === true;
+	const shouldAddUpstreamCost =
+		isByokUsage &&
+		baseCost !== undefined &&
+		upstreamInferenceCost !== undefined;
+	const costOrUpstream =
+		baseCost !== undefined && baseCost > 0
+			? baseCost
+			: (upstreamInferenceCost ?? baseCost);
 	const totalCost =
 		marketCost ??
-		(baseCost !== undefined && upstreamInferenceCost !== undefined
-			? baseCost + upstreamInferenceCost
-			: (baseCost ?? upstreamInferenceCost));
+		(shouldAddUpstreamCost ? baseCost + upstreamInferenceCost : costOrUpstream);
 	const normalizedUsage = {
 		inputTokens:
 			getNestedUsageValue(usage, "inputTokens", "total") ||

--- a/sdk/packages/llms/src/providers/gateway.test.ts
+++ b/sdk/packages/llms/src/providers/gateway.test.ts
@@ -894,7 +894,7 @@ describe("sdk-gateway", () => {
 		});
 	});
 
-	it("uses provider-specific openrouter billed total from nested raw usage", async () => {
+	it("adds OpenRouter BYOK account fee and upstream provider cost from nested raw usage", async () => {
 		streamTextSpy.mockReturnValue({
 			fullStream: makeStreamParts([
 				{
@@ -904,6 +904,7 @@ describe("sdk-gateway", () => {
 						completion_tokens: 31,
 						raw: {
 							cost: 0.000618625,
+							is_byok: true,
 							cost_details: {
 								upstream_inference_cost: 0.0123725,
 							},
@@ -945,6 +946,60 @@ describe("sdk-gateway", () => {
 				event.type === "usage",
 		);
 		expect(usageEvent?.usage.totalCost).toBeCloseTo(0.012991125, 12);
+	});
+
+	it("does not double-count OpenRouter credit-billed upstream cost from nested raw usage", async () => {
+		streamTextSpy.mockReturnValue({
+			fullStream: makeStreamParts([
+				{
+					type: "finish",
+					usage: {
+						prompt_tokens: 15,
+						completion_tokens: 5,
+						raw: {
+							cost: 0.0000301,
+							is_byok: false,
+							cost_details: {
+								upstream_inference_cost: 0.0000301,
+							},
+						},
+					},
+				},
+			]),
+		});
+
+		const gateway = createGateway({
+			providerConfigs: [
+				{
+					providerId: "openrouter",
+					apiKey: "openrouter-key",
+					defaultModelId: "z-ai/glm-5.1",
+					models: [
+						{
+							id: "z-ai/glm-5.1",
+							name: "GLM 5.1",
+							metadata: {
+								pricing: { input: 0.98, output: 3.08 },
+							},
+						},
+					],
+				},
+			],
+		});
+
+		const events = await collect(
+			await gateway.stream({
+				providerId: "openrouter",
+				modelId: "z-ai/glm-5.1",
+				messages: baseMessages,
+			}),
+		);
+
+		const usageEvent = events.find(
+			(event): event is Extract<AgentModelEvent, { type: "usage" }> =>
+				event.type === "usage",
+		);
+		expect(usageEvent?.usage.totalCost).toBe(0.0000301);
 	});
 
 	it("applies provider-specific usage normalization to stream usage promises", async () => {


### PR DESCRIPTION
<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- For feature requests: Created a discussion in our Feature Requests discussions board https://github.com/cline/cline/discussions/categories/feature-requests and received approval from core maintainers before implementation
- For all changes: Link the associated issue/discussion in the "Related Issue" section below

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly without prior discussion.

Why this requirement?
We deeply appreciate all community contributions - they are essential to Cline's success! To ensure the best use of everyone's time and maintain project direction, we use our Feature Requests discussions board to gauge community interest and validate feature ideas before implementation begins. This helps us focus development efforts on features that will benefit the most users.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** #XXXX

### Description

Fixes OpenRouter usage normalization so credit-billed responses are not reported at 2x cost when OpenRouter includes both `usage.cost` and `usage.cost_details.upstream_inference_cost`.

OpenRouter documents `usage.cost` as the total amount charged to the OpenRouter account, while `cost_details.upstream_inference_cost` is the upstream provider cost. Current OpenRouter responses often include both fields for non-BYOK calls with the same value. The previous SDK logic always added them together, which doubled reported cost for those responses.

This change keeps the existing BYOK behavior when OpenRouter explicitly marks usage as BYOK: `cost` can represent the OpenRouter BYOK fee while `upstream_inference_cost` represents the provider-side bill, so those remain additive. For normal credit-billed responses, positive `cost` is treated as authoritative and upstream is only used as a fallback when cost is missing or zero.

Live verification before the fix, using OpenRouter GLM 5.1 forced to GMICloud:

```json
{
  "is_byok": false,
  "cost": 0.0000301,
  "upstream_inference_cost": 0.0000301,
  "sdk_total_cost_before": 0.0000602
}
```

Live verification after the fix:

```json
{
  "is_byok": false,
  "cost": 0.0000301,
  "upstream_inference_cost": 0.0000301,
  "sdk_total_cost_after": 0.0000301
}
```

### Test Procedure

- Ran focused llms tests:
  - `bun -F @cline/llms test src/providers/ai-sdk.test.ts src/providers/gateway.test.ts`
- Ran SDK build:
  - `bun run build:sdk`
- Ran full SDK unit suite:
  - `bun run test:unit`
- Ran Biome check for touched files:
  - `bun biome check packages/llms/src/providers/ai-sdk.ts packages/llms/src/providers/ai-sdk.test.ts packages/llms/src/providers/gateway.test.ts --diagnostic-level=error`
- Manually verified the fixed code path with a real OpenRouter inference using a redacted API key, forcing `z-ai/glm-5.1` to `GMICloud` and capturing raw usage before SDK normalization.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A - SDK usage normalization only.

### Additional Notes

OpenRouter docs referenced while validating this fix:

- https://openrouter.ai/docs/cookbook/administration/usage-accounting
- https://openrouter.ai/docs/api/reference/overview/
- https://openrouter.ai/docs/faq
