### PR TITLE
ci(cli): wire CHANGELOG into GitHub release, add npm README, prep first cline/cline CLI release

### DIFF
--- a/.github/workflows/publish-cli.yaml
+++ b/.github/workflows/publish-cli.yaml
@@ -177,17 +177,32 @@ jobs:
         run: bun script/publish-npm.ts --tag latest
         working-directory: sdk/apps/cli
 
-      - name: Create GitHub release
-        env:
-          GH_TOKEN: ${{ github.token }}
+      - name: Get Previous CLI Tag
+        id: prev_tag
         run: |
-          TAG="${{ steps.version.outputs.tag }}"
-          VERSION="${{ steps.version.outputs.version }}"
+          CURRENT_TAG="${{ steps.version.outputs.tag }}"
+          PREV_TAG=$(git describe --tags --abbrev=0 --match 'cli-v*' "$CURRENT_TAG^" 2>/dev/null || echo "")
+          echo "prev_tag=$PREV_TAG" >> $GITHUB_OUTPUT
 
-          gh release create "$TAG" \
-            --verify-tag \
-            --title "CLI v${VERSION}" \
-            --notes "Published cline@${VERSION} to npm."
+      - name: Get Changelog Entry
+        id: changelog
+        run: |
+          # Grab content between the first "## " header and the next one in apps/cli/CHANGELOG.md
+          CONTENT=$(awk '/^## [0-9]/{if(found) exit; found=1; next} found{print}' apps/cli/CHANGELOG.md)
+          echo "content<<EOF" >> $GITHUB_OUTPUT
+          echo "$CONTENT" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ steps.version.outputs.tag }}
+          name: "CLI v${{ steps.version.outputs.version }}"
+          body: |
+            ${{ steps.changelog.outputs.content }}
+            ${{ steps.prev_tag.outputs.prev_tag != '' && format('Full Changelog: https://github.com/{0}/compare/{1}...{2}', github.repository, steps.prev_tag.outputs.prev_tag, steps.version.outputs.tag) || '' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Summary
         run: |
@@ -202,16 +217,20 @@ jobs:
           token: ${{ secrets.SLACK_RELEASE_BOT_TOKEN }}
           payload: |
             channel: "C0APVKGGZFC"
-            text: "Cline SDK CLI v${{ steps.version.outputs.version }}"
+            text: "Cline CLI v${{ steps.version.outputs.version }}"
             blocks:
               - type: "section"
                 text:
                   type: "mrkdwn"
-                  text: "Cline SDK CLI v${{ steps.version.outputs.version }}"
+                  text: "Cline CLI v${{ steps.version.outputs.version }}"
+              - type: "section"
+                text:
+                  type: "mrkdwn"
+                  text: ${{ toJSON(steps.changelog.outputs.content) }}
               - type: "context"
                 elements:
                   - type: "mrkdwn"
-                    text: "<https://www.npmjs.com/package/cline/v/${{ steps.version.outputs.version }}|View on npm>"
+                    text: "<https://www.npmjs.com/package/cline/v/${{ steps.version.outputs.version }}|View on npm>${{ steps.prev_tag.outputs.prev_tag != '' && format(' | Full Changelog: https://github.com/{0}/compare/{1}...{2}', github.repository, steps.prev_tag.outputs.prev_tag, steps.version.outputs.tag) || '' }}"
 
   publish-nightly:
     name: Publish cline nightly

--- a/sdk/apps/cli/.cline/skills/publish-cli/SKILL.md
+++ b/sdk/apps/cli/.cline/skills/publish-cli/SKILL.md
@@ -67,7 +67,7 @@ Ask whether this should be patch, minor, major, or an explicit version. Do not g
 
 Update `apps/cli/package.json` to the approved version.
 
-Prepend a section to `apps/cli/CHANGELOG.md` for the approved version using the approved release notes.
+Prepend a section to `apps/cli/CHANGELOG.md` for the approved version using the approved release notes. Use the header format `## X.Y.Z` with no date. The publish workflow extracts the top section of the changelog by matching `^## [0-9]` and pastes it verbatim into the GitHub release body and the Slack release announcement, so the section content is the release notes that get shipped.
 
 6. Verify before committing.
 

--- a/sdk/apps/cli/CHANGELOG.md
+++ b/sdk/apps/cli/CHANGELOG.md
@@ -1,17 +1,30 @@
 # Cline CLI Changelog
 
-## 3.0.0 (2026-05-11)
+## 3.0.0
 
-- Publish the SDK CLI as `cline` for the public package handoff
-- Keep platform-specific binaries under `@cline/cli-*` and resolve them from the `cline` wrapper package
+First Cline CLI release published from the `cline/cline` monorepo. The CLI source previously lived in `cline/sdk` and is now developed alongside the VS Code extension, with releases cut from the same repository.
 
-## 0.0.13 (2026-05-07)
+The Cline CLI is a terminal-native coding agent. It runs in your shell with a TUI built on OpenTUI, and shares its agent core with the Cline VS Code extension, including plan/act modes, MCP servers, checkpoints, rules, skills, and provider configuration.
+
+Install:
+
+```sh
+npm install -g cline
+```
+
+For nightly builds:
+
+```sh
+npm install -g cline@nightly
+```
+
+## 0.0.13
 
 - Detect prompt-cache support from cache write pricing so providers with write-only caching are represented correctly in the model catalog
 - Dual-publish `@clinebot/cli` mirror wrapper so existing users who installed via `npm i -g @clinebot/cli` continue receiving updates
 - Fix response truncation for OpenAI Codex model responses
 
-## 0.0.12 (2026-05-06)
+## 0.0.12
 
 - Fix markdown rendering in the published binary: headers, inline code, blockquotes, bold, italic, and lists now render with proper syntax highlighting (tables were the only element working before)
 - Add keyboard shortcuts for scrolling through the chat transcript (Page Up/Down, Home/End)
@@ -22,7 +35,7 @@
 - Hide ChatGPT subscription provider usage costs
 - Handle file index prewarm timeouts gracefully instead of hanging
 
-## 0.0.11 (2026-05-06)
+## 0.0.11
 
 - Add `/skills` slash command for browsing and toggling available skills interactively
 - System prompts from AI SDK are now passed via the dedicated `system` option instead of being embedded in message history
@@ -35,7 +48,7 @@
 - Fix stray log output appearing over the TUI when the log file fallback wrote directly to the stderr file descriptor, bypassing the TUI's stdio capture
 - Refresh the built-in model catalog with the latest available models and pricing
 
-## 0.0.10 (2026-05-04)
+## 0.0.10
 
 - Improve local provider onboarding: setting up Ollama, LM Studio, or other local providers now prompts for the endpoint URL directly, supports typing a model ID manually when the provider returns no models, and correctly discovers models from your saved endpoint
 - Ctrl+C no longer cancels a running turn -- it now clears the input field or exits the CLI, matching standard terminal behavior. Use Escape to cancel a running turn instead
@@ -52,12 +65,12 @@
 - Login now uses device auth exclusively
 - Fix chat input and chat view text losing its indent on wrapped lines
 
-## 0.0.9 (2026-05-03)
+## 0.0.9
 
 - Fix stray text appearing over the TUI when background operations (like hub restart messages) write directly to stdout/stderr during interactive sessions
 - Fix hub connection recovery: when a newer CLI instance restarts the shared hub daemon, already-running CLI sessions now automatically reconnect to the new hub endpoint instead of failing with transport errors
 
-## 0.0.8 (2026-05-03)
+## 0.0.8
 
 - Fix crash when pressing Escape to cancel a running turn
 - Add plugin and SDK tool toggles to the settings panel
@@ -73,7 +86,7 @@
 - Clean up CLI program description and compact slash command descriptions
 - Clean up CLI flags
 
-## 0.0.7 (2026-04-30)
+## 0.0.7
 
 - Fix graceful recovery when the model returns malformed tool call inputs, preventing crashes mid-conversation
 - Add settings toggles for core skills (enable/disable individual skills from the settings panel)
@@ -90,13 +103,13 @@
 - Fix hub tool capabilities being routed to the wrong session
 - Revert loading extension-created sessions from history (was causing issues)
 
-## 0.0.6 (2026-04-29)
+## 0.0.6
 
 - Add checkpoint restore: press Esc twice or type `/undo` to rewind to a previous checkpoint, with options to restore chat only or chat + workspace
 - Fix clipboard: fall back to system clipboard (pbcopy, PowerShell, wl-copy, xclip) when OSC 52 fails, fixing copy for longer text selections
 - Fix prompt focus: restore focus to the prompt input after dialogs close, preventing the input from becoming unresponsive after using `/settings`
 
-## 0.0.5 (2026-04-28)
+## 0.0.5
 
 - The input field has been completely redesigned -- the old bordered box is replaced with a clean chevron-prompt style that adapts its background color to any terminal theme using perceptual OKLAB color math. Light terminals are fully supported now.
 - Pasting 5+ lines into the input shows a compact preview marker instead of flooding the textarea. The full content is still submitted.
@@ -110,11 +123,11 @@
 - `providers.json` (which stores API keys and OAuth tokens) is now written with 0600 permissions, preventing other processes on the machine from reading it.
 - Models that emit `command` or `cmd` instead of `commands` (or `paths` instead of `path`) no longer fail. Common aliases are normalized before execution.
 
-## 0.0.4 (2026-04-28)
+## 0.0.4
 
 - Fix compiled binary spawning infinite hub daemon recursion loop
 
-## 0.0.3 (2026-04-28)
+## 0.0.3
 
 - Rewritten TUI from Ink to OpenTUI with streaming markdown, syntax-highlighted diffs, scrollable chat, and mouse support
 - Dialog system for model picker, tool approval, settings browser, session history, and onboarding

--- a/sdk/apps/cli/DEVELOPMENT.md
+++ b/sdk/apps/cli/DEVELOPMENT.md
@@ -413,3 +413,64 @@ Then attach VS Code or Chrome DevTools to `ws://127.0.0.1:6499`.
   - `@opentui/react` - React reconciler (`createRoot`, hooks)
   - `@opentui-ui/dialog` - Dialog/modal system
   - `opentui-spinner` - Spinner component
+
+## Publishing
+
+The CLI is published as the `cline` wrapper package on npm with platform-specific binaries under `@cline/cli-*`. The release flow lives in the `publish-cli` skill (`sdk/apps/cli/.cline/skills/publish-cli/SKILL.md`).
+
+From the `apps/cli` workspace:
+
+```bash
+# Dry run for checking package size and build output
+bun publish --dry-run
+
+# Publish to npm (version bump required first)
+bun run release
+```
+
+See [DISTRIBUTION.md](./DISTRIBUTION.md) for details on how the CLI is packaged.
+
+## Runtime ownership
+
+- CLI renders runtime events and handles terminal UX.
+- Core owns agent creation, runtime composition, and session message persistence.
+- CLI does not directly instantiate `Agent` for chat/task execution.
+- CLI does not perform direct file/db message persistence in run/interactive paths.
+- CLI owns the user-instruction watcher (rules/workflows/skills) because prompt assembly uses rule context before session start; the watcher is disposed on all exit paths.
+- RPC runtime uses the same prompt resolver and accepts optional `rules` in runtime config (or `systemPrompt` when fully prebuilt by the caller).
+
+### Connector runtime behavior
+
+- Telegram final assistant replies are sent through Telegram entity payloads with raw-text fallback; Google Chat and WhatsApp use the shared connector runtime formatting path.
+- Assistant text streams incrementally into chat surfaces that use the shared runtime streaming path; Telegram sends final assistant replies after the turn completes.
+- Tool activity is summarized as compact start/error messages with short argument previews.
+- Required tool approvals are posted back into the chat thread and accept `Y` / `N` replies.
+- Google Chat serves its webhook at `/api/webhooks/gchat`; configure the Google Chat App URL as `<base-url>/api/webhooks/gchat`.
+- Webhook-based connectors are hosted through a shared CLI `node:http` server helper rather than `Bun.serve`.
+- WhatsApp serves its webhook at `/api/webhooks/whatsapp`; configure the Meta callback URL as `<base-url>/api/webhooks/whatsapp`.
+
+## Logging adapter
+
+`cline` uses a `pino`-backed adapter that targets the core `BasicLogger` contract:
+
+- CLI runtime passes `logger` directly into local `@cline/core` sessions.
+- Hub-backed sessions include a serialized logger payload in `ChatStartSessionRequest.logger`; the runtime reconstructs the same `pino` settings and injects them into core.
+- Hosts can attach stable runtime logger bindings (for example `clientId`, `clientType`, `clientApp`) through `RuntimeLoggerConfig.bindings`.
+
+After login, OAuth credentials are persisted with `auth.expiresAt`, and `@cline/core` refreshes these tokens automatically during session turns. Provider auth and model settings should be changed through `cline auth`, the interactive config UI, or core provider-settings APIs rather than editing provider settings files directly.
+
+On startup, `cline` also attempts a legacy settings import:
+
+- Source files: `<CLINE_DATA_DIR>/globalState.json` and `<CLINE_DATA_DIR>/secrets.json`
+- Target file: `<CLINE_DATA_DIR>/settings/providers.json` (or `CLINE_PROVIDER_SETTINGS_PATH`)
+- Existing providers in `providers.json` are never overwritten
+- Missing providers discovered in legacy files are merged into `providers.json`
+- Migrated provider entries are annotated with `tokenSource: "migration"`
+
+Custom provider registry notes:
+
+- Provider runtime settings continue to persist in `<CLINE_DATA_DIR>/settings/providers.json`.
+- Providers in `providers.json` can opt into the OpenAI Responses API with `"protocol": "openai-responses"`; this routes the runtime through the OpenAI client while keeping the user-defined provider ID, base URL, and model catalog.
+- User-added OpenAI-compatible provider model catalogs are persisted in `<CLINE_DATA_DIR>/settings/models.json` (or alongside `CLINE_PROVIDER_SETTINGS_PATH`).
+- `models.json` stores model lists by provider ID and is loaded by the runtime provider actions.
+- Entries with only `models` extend an existing provider; entries with `provider` metadata register or override a custom provider.

--- a/sdk/apps/cli/README.md
+++ b/sdk/apps/cli/README.md
@@ -1,216 +1,200 @@
 # Cline CLI
 
-Cline CLI built with Cline SDK.
+<p align="center">
+  <img src="https://github.com/user-attachments/assets/7123f9d1-afeb-48d5-93fa-e750dec0ebba" width="70%" />
+</p>
 
-Streams output in real time and includes built-in tools, sub-agent spawning, and team runtime support by default.
+<div align="center">
+<table>
+<tbody>
+<td align="center">
+<a href="https://www.npmjs.com/package/cline" target="_blank">NPM</a>
+</td>
+<td align="center">
+<a href="https://marketplace.visualstudio.com/items?itemName=saoudrizwan.claude-dev" target="_blank">VS Code Extension</a>
+</td>
+<td align="center">
+<a href="https://discord.gg/cline" target="_blank">Discord</a>
+</td>
+<td align="center">
+<a href="https://www.reddit.com/r/cline/" target="_blank">r/cline</a>
+</td>
+<td align="center">
+<a href="https://github.com/cline/cline/discussions/categories/feature-requests?discussions_q=is%3Aopen+category%3A%22Feature+Requests%22+sort%3Atop" target="_blank">Feature Requests</a>
+</td>
+<td align="center">
+<a href="https://docs.cline.bot" target="_blank">Docs</a>
+</td>
+</tbody>
+</table>
+</div>
 
-Detailed CLI command/feature reference is centralized in [`DOC.md`](./DOC.md).
+Run Cline in your terminal. Interactive chat for paired sessions, or fully headless for CI/CD and scripting. The CLI shares its agent core with the [Cline VS Code extension](https://marketplace.visualstudio.com/items?itemName=saoudrizwan.claude-dev), JetBrains plugin, and SDK, so plan/act modes, MCP servers, checkpoints, rules, skills, and provider configuration all behave the same across surfaces.
 
+## Install
 
-## Requirements
-
-- [Bun](https://bun.com/docs/installation) (for development, build, and running `cline`)
-
-## Installation
-
-```bash
-npm i -g cline
-# or
-bun i -g cline
+```sh
+npm install -g cline
 ```
 
-## Development
+For nightly builds:
 
-Quick Start:
-
-```bash
-# From Root of the repository
-bun install
-bun run build
-
-bun run cli # Run Dev script for the CLI package 
-# or
-bun run -F @cline/cli dev "your prompt" # Run the CLI from the package workspace
-# or
-bun link # Link the package globally for easy access from anywhere
-# Run from the linked binary
-cline auth
-
-# Run built CLI with Bun
-bun cli/dist/index.js "your prompt"
+```sh
+npm install -g cline@nightly
 ```
 
-Dev runtime note:
+Platform binaries are published for macOS, Linux, and Windows on `arm64` and `x64`. The `cline` package resolves the correct binary for your platform via optional dependencies, so no Node, Bun, or Zig runtime is required at install time.
 
-- Distinct host ID resolution is handled by `@cline/core` `createRuntimeHost(...)`.
-- When no explicit `distinctId` is provided, core uses `node-machine-id` first and only persists a generated fallback at `<session-data-dir>/machine-id` if machine ID lookup is unavailable.
+## Quick start
 
-## Publishing
+Run interactively:
 
-From the @cline/cli package workspace:
-
-```bash
-# Package the latest model list from models.dev
-bun run build:models
-
-# Dry run for checking package size and build output
-bun publish --dry-run
-# Example Output: Total files: 3 / Unpacked size: 2.28MB
-
-# Publish to npm with Bun (version bump required)
-bun run release
+```sh
+cline
 ```
 
-## Testing
+Run a single prompt:
 
-```bash
-
-# Run CLI unit tests
-bun -F @cline/cli test:unit
-
-# Run CLI e2e tests
-bun -F @cline/cli test:e2e
-bun -F @cline/cli test:e2e:interactive
+```sh
+cline "Audit this package and propose fixes"
 ```
+
+Pipe input:
+
+```sh
+cat file.txt | cline "Summarize this"
+```
+
+See `cline --help` for the full flag reference.
+
+## Use any provider
+
+Cline supports the same providers as the VS Code extension. You can sign in to Cline directly, use your ChatGPT Subscription through `openai-codex`, or bring an API key from Anthropic, OpenAI, Google Gemini, OpenRouter, AWS Bedrock, GCP Vertex, Cerebras, Groq, and any OpenAI-compatible endpoint.
+
+```sh
+cline auth                              # interactive sign-in
+cline auth cline                        # OAuth sign-in
+cline auth --provider anthropic --apikey sk-... --modelid claude-sonnet-4-6
+```
+
+`cline auth` without a provider opens the interactive auth setup TUI with the same options as the old CLI flow (Sign in with Cline, Sign in with ChatGPT Subscription, Sign in with OCA, or use your own API key).
+
+OAuth-supported providers (`cline`, `openai-codex`, `oca`) do not auto-launch a browser on normal startup. Authenticate explicitly first with `cline auth <provider>`. For non-interactive runs, if an OAuth provider is selected and no saved credentials are available, `cline` fails fast with an authentication message instead of launching a hidden browser flow.
+
+## Modes
+
+Cline CLI runs in a few different shapes depending on what you need:
+
+- Interactive TUI: `cline` or `cline -i` opens a full terminal UI with plan/act toggle, slash commands, file mentions, and live tool approvals
+- One-shot: `cline "your prompt"` runs a single turn and exits
+- JSON: `cline --json "..."` streams NDJSON events for piping into other tools
+- Yolo: `cline --yolo "..."` skips approval prompts and exits when the turn finishes
+- Zen: `cline --zen "..."` fires the task to the background hub daemon and exits immediately (see below)
+
+## Headless mode for CI/CD
+
+Run Cline with zero interaction for scripting and automation. Pipe input, get JSON output, chain commands, integrate into CI/CD pipelines.
+
+```sh
+# One-shot prompt, auto-approve all tools
+cline --yolo "Run tests and fix any failures"
+
+# Pipe a diff in for review
+git diff origin/main | cline "Review these changes for issues"
+
+# NDJSON output for downstream tooling
+cline --json "List all TODO comments" | jq -r 'select(.type == "agent_event" and .event.text) | .event.text'
+```
+
+## Features
+
+- Streaming TUI built on [OpenTUI](https://github.com/sst/opentui) with markdown rendering, syntax-highlighted diffs, scrollable chat, and mouse support
+- Plan/Act mode toggle for switching between planning and execution
+- Native MCP support for connecting custom tools
+- Checkpoints with `/undo` to rewind workspace state
+- Sub-agent spawning and agent teams for parallel work
+- OAuth login for Cline, ChatGPT Subscription (`openai-codex`), and OCA
+- Configurable thinking budgets per run
+- Cron and event-driven schedules for recurring agent work
+- Chat connectors for Telegram, Google Chat, and WhatsApp
 
 ## Usage
 
-```bash
+```sh
 # Start Cline CLI without a prompt to enter interactive mode
 cline
 
-# Single prompt / One-shot - includes tools + spawn + teams
+# Single prompt (one-shot) - includes tools, spawn, and teams
 cline "Audit this package and propose fixes"
-# NOTE: Single-prompt runs are non-interactive and exit when the turn finishes
 
-# Interactive mode
-cline -i
-# With custom system prompt
+# Interactive mode with a starting prompt
+cline -i "Let's work on this together. First, analyze the current state."
+
+# With a custom system prompt
 cline -i -s "You are a pirate" "Tell me about the sea"
-cline -i "Let's work on this together. First, analyze the current state and suggest next steps."
 
 # Require approval before each tool call
 cline --auto-approve false "Inspect and modify this repository"
-# Explicitly enable auto-approval for all tools
-cline --auto-approve true "Refactor src/index.ts for readability"
 
-# Pipe input
-cat file.txt | cline "Summarize this"
+# Explicit yolo: enables submit_and_exit and disables spawn/team tools by default
+cline --yolo --retries 5 "Refactor this package"
+
+# Override consecutive internal mistake (retry) limit (default: 3)
+cline --retries 5 "Fix failing tests"
 
 # Team workflow with persistent name
 cline --team-name my-team "Plan, implement, and verify release checklist"
 cline --team-name my-team "Continue yesterday's team workflow"
 
-# Show verbose run stats (includes elapsed time, tokens, and estimated cost when available)
+# Show verbose run stats (elapsed time, tokens, estimated cost when available)
 cline -v "Explain quantum computing"
 
-# Override consecutive internal mistake (retry) limit for this run (default: 3)
-cline --retries 5 "Fix failing tests"
-# Common with auto-approve/yolo-style runs
-cline --auto-approve true --retries 5 "Refactor this package"
+# Use a specific provider, model, and access token for a single prompt
+cline -P openrouter -m google/gemini-3-pro -k sk-... "Set up a storybook"
 
-# Explicit yolo also enables submit_and_exit and disables spawn/team tools by default
-cline --yolo --retries 5 "Refactor this package"
-
-# Zen mode: fire-and-forget a task to the background hub and exit the CLI immediately
-# The hub keeps running the task; the menubar app (if installed) will notify you on
-# completion. Otherwise check `cline history` later to see the result.
-cline --zen "Refactor the authentication module"
+# Use a different model with the last used provider
+cline -m anthropic/claude-opus-4-6 "Explain string theory"
 
 # Stream structured NDJSON output
 cline --json "Summarize this repository"
 
-# Use a specific provider, model, and access token for a single prompt/task
-cline -P openrouter -m google/gemini-3-pro -k sk-your-google-gemini-api-key "Set up a storybook for the frontend react ui components"
-# Use a different model with the last used provider
-cline -m anthropic/claude-opus-4-6 "Explain string theory"
-
-# Quick setup with API key/model
+# Quick provider setup
 cline auth --provider anthropic --apikey sk-... --modelid claude-sonnet-4-6
 cline auth --provider openai-native --apikey sk-... --modelid gpt-5 --baseurl https://api.example.com/v1
+```
 
-# Authenticate OAuth providers explicitly
-cline auth <cline|openai-codex|oca>
+### Connectors
 
-# Bridge a Telegram Bot API bot into RPC-backed chat sessions (polling mode)
-# Create the bot with @BotFather, copy the username without @ and the token,
-# then keep this connector process running while you want Telegram access.
+Bridge a chat surface into RPC-backed Cline sessions. Each conversation thread maps to a session with full context. Supported platforms: Telegram, Slack, Google Chat, WhatsApp, and Linear.
+
+```sh
+# Telegram (polling mode)
 cline connect telegram -m my_bot -k 123456:ABCDEF...
-# Foreground mode for local debugging / logs in the active terminal
-cline connect telegram -i -m my_bot -k 123456:ABCDEF...
-# Tools are enabled by default for Telegram. Use --no-tools when the chat surface is not trusted.
-cline connect telegram -m my_bot -k 123456:ABCDEF... --no-tools
-# Provider/model default to the CLI's last-used provider settings. Override them if needed.
-cline connect telegram -m my_bot -k 123456:ABCDEF... --provider cline --model openai/gpt-5.3-codex
-# Dispatch connector lifecycle/message events to an external hook command
-cline connect telegram -m my_bot -k 123456:ABCDEF... --hook-command '/Users/me/bin/on-connector-event'
-# In Telegram chats, use /help, /start, /new, /clear, /whereami, /tools,
-# /yolo, /cwd <path>, /schedule, /abort, and /exit.
-# In groups, bot-addressed commands like /help@my_bot are recognized only for this bot.
-# Final assistant replies use Telegram entity payloads with raw-text fallback.
-# Detailed Telegram connector docs: apps/cli/src/connectors/adapters/telegram.md
 
-# Bridge a Google Chat app into RPC-backed chat sessions (webhook mode)
+# Slack (webhook mode)
+cline connect slack --bot-token $SLACK_BOT_TOKEN --signing-secret $SLACK_SIGNING_SECRET --base-url https://your-domain.com
+
+# Google Chat (webhook mode)
 cline connect gchat --base-url https://your-domain.com
-# Foreground mode for local debugging / logs in the active terminal
-cline connect gchat -i --base-url https://your-domain.com --port 8787
-# Receive all-space messages through Workspace Events / Pub/Sub
-cline connect gchat --base-url https://your-domain.com --pubsub-topic projects/my-project/topics/chat-events --impersonate-user admin@example.com
-# Enable tools explicitly only if you trust the Google Chat surface
-cline connect gchat --base-url https://your-domain.com --enable-tools
 
-# Bridge a WhatsApp Business webhook into RPC-backed chat sessions
+# WhatsApp (webhook mode)
 cline connect whatsapp --base-url https://your-domain.com
-# Foreground mode for local debugging / logs in the active terminal
-cline connect whatsapp -i --base-url https://your-domain.com --port 8787
-# Override Meta credentials directly instead of relying on environment variables
-cline connect whatsapp --base-url https://your-domain.com --phone-number-id 1234567890 --access-token token --app-secret secret --verify-token verify
-# Enable tools explicitly only if you trust the WhatsApp surface
-cline connect whatsapp --base-url https://your-domain.com --enable-tools
+
+# Linear (webhook mode)
+cline connect linear --api-key $LINEAR_API_KEY --base-url https://your-domain.com
 
 # Stop connector bridges and delete their sessions
 cline connect --stop
 cline connect --stop telegram
-cline connect --stop gchat
-cline connect --stop whatsapp
+```
 
-# Connector implementation notes
-# - adapter files keep transport-specific setup and schedule-delivery rules
-# - shared logic for flags/process helpers, thread bindings, session bootstrap,
-#   and turn/approval handling lives under apps/cli/src/connectors/
+In chat surfaces, connector slash commands include `/help`, `/start`, `/new`, `/clear`, `/whereami`, `/tools`, `/yolo`, `/cwd <path>`, `/schedule`, `/abort`, and `/exit`. Run `cline connect <adapter> --help` to see the full flag list for any adapter.
 
-# Open the CLI runtime log file
-cline doctor log
+### Schedules
 
-# Inspect local CLI/RPC process health
-cline doctor
-# Include historical spawn records from the shared CLI log
-cline doctor --verbose
-# Kill stale local RPC listeners and old CLI processes
-cline doctor fix
+Schedule agents on cron-like intervals or external events.
 
-# Open interactive config view directly
-cline config
-# Running `cline` with no prompt also enters interactive mode.
-# Interactive mode is rendered with the OpenTUI TUI.
-# The initial screen uses a WelcomeView-style layout before the first prompt.
-# Inline composer supports completion menus:
-# - `@` opens workspace file mention search (arrow keys to move, Enter/Tab to insert)
-# - `/` opens workflow slash command search (arrow keys to move, Enter/Tab to insert)
-# - Ctrl+P opens the command palette for common CLI actions
-# - `/config` (or `/settings`) opens the interactive config browser
-#   with general settings plus tabs for workflows, rules, skills, hooks, and agents
-# - Settings > General includes a Compaction row for switching agentic compaction,
-#   basic compaction, or disabling compaction
-# Footer rows mirror the legacy CLI layout:
-# 1) command/file hint + Plan/Act badges (Tab)
-# 2) provider/model + context bar + token/cost
-# 3) repo/branch + git diff stats
-# 4) auto-approve state (Shift+Tab toggles)
-# For one-shot auto-exit behavior, pass a prompt argument.
-# Exit interactive mode with Ctrl+D (or Ctrl+C when idle).
-
-# Schedule agents on cron-like intervals
+```sh
 cline schedule create "Daily code review" \
   --cron "0 9 * * MON-FRI" \
   --prompt "Review PRs opened yesterday and summarize issues." \
@@ -220,56 +204,15 @@ cline schedule create "Daily code review" \
   --timeout 3600 \
   --tags automation,review
 
-# Route a scheduled result back to a Telegram thread handled by the connector
-# First, send /whereami to your bot in Telegram to get the thread id
-# Keep the Telegram connector running when the scheduled result is delivered
-cline schedule create "Daily summary" \
-  --cron "0 9 * * *" \
-  --prompt "Summarize yesterday's activity in this workspace." \
-  --workspace /path/to/repo \
-  --delivery-adapter telegram \
-  --delivery-bot my_bot \
-  --delivery-thread telegram:123456789
 cline schedule list
 cline schedule get <schedule-id>
 cline schedule trigger <schedule-id>
 cline schedule history <schedule-id> --limit 20
-cline schedule stats <schedule-id>
-cline schedule active
-cline schedule upcoming --limit 10
 cline schedule export <schedule-id> > daily-review.yaml
 cline schedule import ./daily-review.yaml
 ```
 
-Telegram connector details live next to the adapter implementation: [`src/connectors/adapters/telegram.md`](./src/connectors/adapters/telegram.md).
-
-## OAuth Authentication
-
-`cline` supports OAuth login for:
-
-- `cline`
-- `openai-codex`
-- `oca`
-
-`cline` does not auto-start OAuth during normal command startup. Authenticate explicitly first with `cline auth <provider>`.
-
-For non-interactive runs, if one of these providers is selected and no saved credentials are available, `cline` fails fast with an authentication message instead of launching a hidden browser flow.
-
-During OAuth login, `cline` tries to open the authorization URL in your default browser automatically and still prints the URL for manual fallback.
-
-OAuth refresh is handled by `@cline/core` during session turns. If refresh cannot recover credentials, the run fails with a re-authentication message; clients are not sent a separate auth-request event that can mutate provider config on their behalf.
-
-`cline auth` (without a provider) opens the interactive auth TUI with the same auth options as the old CLI flow:
-
-- Sign in with Cline
-- Sign in with ChatGPT Subscription (`openai-codex`)
-- Sign in with OCA
-- Use your own API key (provider + model + optional base URL)
-
-Runtime note:
-
-- Hook dispatch now runs in-process against the active runtime session instead of spinning up a separate `cline hook-worker` service.
-- Hook commands are adapters over the SDK runtime hook bag; hook payload `taskId` uses the stable conversation id when available, not the per-run id.
+Schedules can route results back to chat surfaces with `--delivery-adapter`, `--delivery-bot`, and `--delivery-thread`.
 
 ## Options
 
@@ -279,14 +222,14 @@ Runtime note:
 | `-P, --provider <id>` | Provider id (default: `cline`) |
 | `-m, --model <id>` | Model id (default: `anthropic/claude-sonnet-4.6`) |
 | `-k, --key <api-key>` | API key override for this run |
-| `-p, --plan` | Run in plan mode. Default to act mode. |
+| `-p, --plan` | Run in plan mode (default is act mode) |
 | `-i, --tui` | Interactive TUI multi-turn mode |
 | `-t, --timeout <seconds>` | Optional run timeout in seconds |
 | `-c, --cwd <path>` | Working directory for tools |
 | `--config <path>` | Configuration directory (used for CLI home resolution) |
 | `--hooks-dir <path>` | Additional hooks directory hint for runtime hook injection |
 | `--acp` | ACP (Agent Client Protocol) mode |
-| `--thinking [none\|low\|medium\|high\|xhigh]` | Set model thinking level when supported. Defaults to `medium` when the flag is provided without a level; thinking is off when the flag is omitted. |
+| `--thinking [none\|low\|medium\|high\|xhigh]` | Model thinking level when supported. Defaults to `medium` when the flag is provided without a level; thinking is off when the flag is omitted. |
 | `--compaction <agentic\|basic\|off>` | Context compaction mode. Defaults to `basic`; use `agentic` for LLM compaction or `off` to disable. |
 | `--retries <count>` | Maximum consecutive mistakes (retries) before halting (default: `3`) |
 | `--json` | Output NDJSON instead of styled text |
@@ -294,15 +237,15 @@ Runtime note:
 | `--auto-approve [true\|false]` | Set tool auto-approval for all tools |
 | `--kanban` | Run the external `kanban` app |
 | `-y, --yolo` | Skip tool approval prompts, enable `submit_and_exit`, and disable spawn/team tools by default |
-| `-z, --zen` | Dispatch the task to the background hub and exit the CLI immediately (see "Zen mode" below) |
+| `-z, --zen` | Dispatch the task to the background hub and exit the CLI immediately |
 | `--team-name <name>` | Override the runtime team state name |
-| `-h, --help` | Show help (exits immediately) |
+| `-h, --help` | Show help and exit |
 | `-v, --verbose` | Show verbose runtime diagnostics |
-| `-V, --version` | Show version (exits immediately) |
+| `-V, --version` | Show version and exit |
 
-`--json` is non-interactive and requires either a prompt argument or piped stdin.
+`--json` is non-interactive and requires either a prompt argument or piped stdin. `--key` takes precedence over environment variables.
 
-Top-level commands:
+## Top-level commands
 
 - `cline config` - Open the interactive config view
 - `cline history|h [options]` - List session history or manage saved sessions
@@ -319,40 +262,11 @@ Top-level commands:
 - `cline hub` - Manage the local hub daemon
 - `cline kanban` - Run the external `kanban` app, installing it first when needed
 
-Connector shortcuts:
-
-- `cline connect telegram -m <bot> -k <token>` - Start the Telegram bridge
-- `cline connect gchat --base-url <url>` - Start the Google Chat webhook bridge
-- `cline connect whatsapp --base-url <url>` - Start the WhatsApp webhook bridge
-- `cline connect <adapter> --help` - Show adapter-specific options and examples
-- `--hook-command <command>` - Run a shell command for connector events
-
-Schedule shortcuts:
-
-- `cline schedule create <name> --cron "<expr>" --prompt "<text>" --workspace <path>` - Create a scheduled run
-- `cline schedule <create|list|get|update|pause|resume|delete|trigger|history|stats|active|upcoming|import|export>` - Manage schedules and execution history
-
-Behavior notes:
-
-- `cline auth` without a provider opens the interactive auth setup TUI.
-- Connector slash commands are shared across connector chat surfaces: `/help`, `/start`, `/new`, `/clear`, `/whereami`, `/tools`, `/yolo`, `/cwd <path>`, `/schedule`, `/abort`, `/exit`.
-- Telegram group commands addressed to the bot, such as `/help@my_bot`, are normalized only when the suffix matches the configured bot username.
-- Interactive CLI can use the shared slash-command parser when `CLINE_ENABLE_CHAT_COMMANDS=1`.
-- `/team <task>` is handled directly by the CLI in both interactive and non-interactive runs, even when chat commands are otherwise disabled.
-
-Auth quick-setup flags:
-
-- `-P, --provider <id>`
-- `-k, --apikey <key>`
-- `-m, --modelid <id>`
-- `-b, --baseurl <url>` (OpenAI/OpenAI-compatible quick setup)
-
-## Zen Mode
+## Zen mode
 
 `--zen` (alias `-z`) runs a task in the background hub daemon and exits the CLI immediately. It is intended for long-running tasks you want to fire off and walk away from.
 
-```bash
-# Fire off a task and return to your shell right away
+```sh
 cline --zen "Refactor the authentication module and add unit tests"
 ```
 
@@ -364,16 +278,12 @@ Behavior:
 - If the menubar app is not running, there is no live UI for the task. Use `cline history` later to find the session and inspect the result.
 - `--zen` is incompatible with `--data-dir` (the implicit sandbox requires a local backend that exits with the CLI) and with `--tui` (there is no terminal UI to render into).
 
-## Tool Approval
+## Tool approval
 
 Tool calls are auto-approved by default. Use `--auto-approve false` to require review before tool execution.
 
-```bash
-# Require approval for all tools
+```sh
 cline --auto-approve false "Inspect and modify this repository"
-
-# Explicitly keep approvals disabled for this run
-cline --auto-approve true "Audit the current workspace"
 ```
 
 When approval is required, the CLI prompts in TTY mode:
@@ -386,111 +296,36 @@ Approve tool "<tool_name>" with input <preview>? [y/N]
 - Enter anything else (or press Enter) to reject.
 - If stdin/stdout is not a TTY, required-approval calls are denied in terminal mode.
 
-Desktop-integrated approval mode is also supported via env wiring:
+Desktop-integrated approval mode is also supported via env wiring (`CLINE_TOOL_APPROVAL_MODE=desktop` and `CLINE_TOOL_APPROVAL_DIR=<path>`). In desktop mode, CLI writes a request JSON file and waits for a matching decision JSON file.
 
-- `CLINE_TOOL_APPROVAL_MODE=desktop`
-- `CLINE_TOOL_APPROVAL_DIR=<path>`
-
-In desktop mode, CLI writes a request JSON file and waits for a matching decision JSON file.
-
-## Environment Variables
+## Environment variables
 
 - `ANTHROPIC_API_KEY` - API key for Anthropic
 - `CLINE_API_KEY` - API key for Cline (when using `-P cline`)
+- `OPENAI_API_KEY` - API key for OpenAI (when using `-P openai`)
+- `OPENROUTER_API_KEY` - API key for OpenRouter (when using `-P openrouter`)
+- `AI_GATEWAY_API_KEY` - API key for Vercel AI Gateway (when using `-P vercel-ai-gateway`)
+- `V0_API_KEY` - API key for v0 (when using `-P v0`)
 - `CLINE_DATA_DIR` - Base data directory for sessions/settings/teams/hooks
 - `CLINE_SANDBOX` - Set to `1` to force sandbox mode
 - `CLINE_SANDBOX_DATA_DIR` - Override sandbox state directory
 - `CLINE_TEAM_DATA_DIR` - Override team persistence directory
-- `CLINE_BUILD_ENV` - Runtime build mode for SDK-owned subprocess launches (`development` adds `node|bun --inspect=127.0.0.1:0 --enable-source-maps` by default; falls back to `NODE_ENV` or `--conditions=development`)
-- `CLINE_DEBUG_HOST` - Override the host used for development inspector listeners (default `127.0.0.1`)
-- `CLINE_DEBUG_PORT_BASE` - Override the base inspector port for development child processes; when unset, child processes use ephemeral inspector ports
+- `CLINE_BUILD_ENV` - Runtime build mode for SDK-owned subprocess launches
+- `CLINE_DEBUG_HOST` - Host for development inspector listeners (default `127.0.0.1`)
+- `CLINE_DEBUG_PORT_BASE` - Base inspector port for development child processes
 - `CLINE_TOOL_APPROVAL_MODE` - Approval mode (`desktop` uses file IPC; unset uses terminal prompt)
 - `CLINE_TOOL_APPROVAL_DIR` - Directory for desktop approval request/decision files
 - `CLINE_LOG_ENABLED` - Set to `0`/`false` to disable runtime file logging
 - `CLINE_LOG_LEVEL` - Runtime log level (`trace|debug|info|warn|error|fatal|silent`, default `info`)
 - `CLINE_LOG_PATH` - Runtime log file path (default `<CLINE_DATA_DIR>/logs/cline.log`)
 - `CLINE_LOG_NAME` - Logger name embedded in runtime log records
-- `OPENAI_API_KEY` - API key for OpenAI (when using `-p openai`)
-- `OPENROUTER_API_KEY` - API key for OpenRouter (when using `-P openrouter`)
-- `AI_GATEWAY_API_KEY` - API key for Vercel AI Gateway (when using `-p vercel-ai-gateway`)
-- `V0_API_KEY` - API key for v0 (when using `-P v0`)
 
 `--key` takes precedence over environment variables.
 
-For OAuth providers (`cline`, `openai-codex`, `oca`), authenticate explicitly with `cline auth <provider>`. Normal command startup does not auto-launch OAuth.
+## Contributing
 
-## Debugging
+See [DEVELOPMENT.md](./DEVELOPMENT.md) for local development setup, monorepo structure, and TUI architecture. See [DISTRIBUTION.md](./DISTRIBUTION.md) for how the CLI is packaged and distributed.
 
-- `CLINE_BUILD_ENV=development` enables debugger ports for SDK-owned spawned Node/Bun subprocesses.
-- By default, child processes use ephemeral inspector ports to avoid collisions.
-- Set `CLINE_DEBUG_PORT_BASE=9230` if you want deterministic role-based ports such as hook worker `9231`, plugin sandbox `9232`, connector child `9233`.
-- Those ports do not apply to the top-level CLI when it is running under Bun. To debug the Bun CLI process itself, launch the real CLI entrypoint under Bun with an inspector port such as:
+## License
 
-```bash
-cd apps/cli
-CLINE_BUILD_ENV=development bun --conditions=development --inspect-brk=6499 ./src/index.ts "hey"
-```
-
-- The workspace includes [.vscode/launch.json](./.vscode/launch.json) with a single `Launch CLI Debugger` compound entry for VS Code. It launches `apps/cli/src/index.ts` directly under Bun in development mode and attaches the common SDK child-process debuggers.
-- The launch config uses `"type": "bun"` (requires the [`oven.bun-vscode`](https://marketplace.visualstudio.com/items?itemName=oven.bun-vscode) extension). Using `type: node` will not work because breakpoints in the CLI and workspace packages like `packages/core` will be silently ignored.
-- Attach configs use `"url": "ws://127.0.0.1:<port>"` with `localRoot`/`remoteRoot` both set to `${workspaceFolder}`. This lets the Bun debug adapter resolve source maps for files loaded through workspace symlinks (for example `node_modules/@cline/core` to `packages/core/src/...`), so breakpoints set in `packages/core` hit correctly.
-
-## Logging Adapter
-
-`cline` uses a `pino`-backed adapter that targets the core `BasicLogger` contract:
-
-- CLI runtime passes `logger` directly into local `@cline/core` sessions.
-- Hub-backed sessions include a serialized logger payload in `ChatStartSessionRequest.logger`; the runtime reconstructs the same `pino` settings and injects them into core.
-- Hosts can attach stable runtime logger bindings (for example `clientId`, `clientType`, `clientApp`) through `RuntimeLoggerConfig.bindings`.
-
-After login, OAuth credentials are persisted with `auth.expiresAt`, and `@cline/core` refreshes these tokens automatically during session turns. Provider auth and model settings should be changed through `cline auth`, the interactive config UI, or core provider-settings APIs rather than editing provider settings files directly.
-
-On startup, `cline` also attempts a legacy settings import:
-
-- Source files: `<CLINE_DATA_DIR>/globalState.json` and `<CLINE_DATA_DIR>/secrets.json`
-- Target file: `<CLINE_DATA_DIR>/settings/providers.json` (or `CLINE_PROVIDER_SETTINGS_PATH`)
-- Existing providers in `providers.json` are never overwritten
-- Missing providers discovered in legacy files are merged into `providers.json`
-- Migrated provider entries are annotated with `tokenSource: "migration"`
-
-Custom provider registry notes:
-
-- Provider runtime settings continue to persist in `<CLINE_DATA_DIR>/settings/providers.json`.
-- Providers in `providers.json` can opt into the OpenAI Responses API with `"protocol": "openai-responses"`; this routes the runtime through the OpenAI client while keeping the user-defined provider ID, base URL, and model catalog.
-- User-added OpenAI-compatible provider model catalogs are persisted in `<CLINE_DATA_DIR>/settings/models.json` (or alongside `CLINE_PROVIDER_SETTINGS_PATH`).
-- `models.json` stores model lists by provider ID and is loaded by the runtime provider actions.
-- Entries with only `models` extend an existing provider; entries with `provider` metadata register or override a custom provider.
-
-## Features
-
-- Streaming output - Responses stream in real-time
-- Stable stream rendering - Prefers structured agent events and avoids duplicate text/tool output when chunk mirrors are also emitted
-- Sub-agent spawning - `spawn_agent` is available by default unless disabled
-- Recursive delegation - Sub-agents spawned via `spawn_agent` also receive `spawn_agent` when spawn is enabled
-- Agent teams runtime - Team tools (tasks/mailbox/mission log) are available by default unless disabled
-- Team tools keep related operations grouped where that improves usability (for example `team_task` uses an `action` field, while teammate/runs/mailbox/outcome tools stay separate)
-- Pipe support - Accepts piped input for processing files
-- Interactive mode - Multi-turn conversations
-- JSON output mode - NDJSON records for run lifecycle, agent/team events, and final result (`--json`)
-- Minimal dependencies - Fast startup time
-- Multiple providers - Works with Anthropic, OpenAI, and more
-- Configurable reasoning effort - Adjust model reasoning depth per run
-
-## Runtime Ownership
-
-- CLI renders runtime events and handles terminal UX.
-- Core owns agent creation, runtime composition, and session message persistence.
-- CLI does not directly instantiate `Agent` for chat/task execution.
-- CLI does not perform direct file/db message persistence in run/interactive paths.
-- CLI owns the user-instruction watcher (rules/workflows/skills) because prompt assembly uses rule context before session start; the watcher is disposed on all exit paths.
-- RPC runtime uses the same prompt resolver and accepts optional `rules` in runtime config (or `systemPrompt` when fully prebuilt by the caller).
-
-### Connector runtime behavior
-
-- Telegram final assistant replies are sent through Telegram entity payloads with raw-text fallback; Google Chat and WhatsApp use the shared connector runtime formatting path.
-- Assistant text streams incrementally into chat surfaces that use the shared runtime streaming path; Telegram sends final assistant replies after the turn completes.
-- Tool activity is summarized as compact start/error messages with short argument previews.
-- Required tool approvals are posted back into the chat thread and accept `Y` / `N` replies.
-- Google Chat serves its webhook at `/api/webhooks/gchat`; configure the Google Chat App URL as `<base-url>/api/webhooks/gchat`.
-- Webhook-based connectors are hosted through a shared CLI `node:http` server helper rather than `Bun.serve`.
-- WhatsApp serves its webhook at `/api/webhooks/whatsapp`; configure the Meta callback URL as `<base-url>/api/webhooks/whatsapp`.
+[Apache 2.0 © Cline Bot Inc.](https://github.com/cline/cline/blob/main/LICENSE)

--- a/sdk/apps/cli/package.json
+++ b/sdk/apps/cli/package.json
@@ -2,7 +2,7 @@
 	"name": "@cline/cli",
 	"displayName": "cline",
 	"version": "3.0.0",
-	"description": "[EXPERIMENTAL] A lightweight Cline CLI built with the Cline SDKs",
+	"description": "Autonomous coding agent CLI - capable of creating/editing files, running commands, using the browser, and more",
 	"type": "module",
 	"publishConfig": {
 		"access": "public"
@@ -11,6 +11,29 @@
 		"type": "git",
 		"url": "git+https://github.com/cline/cline.git",
 		"directory": "sdk/apps/cli"
+	},
+	"keywords": [
+		"cline",
+		"claude",
+		"dev",
+		"mcp",
+		"openrouter",
+		"coding",
+		"agent",
+		"autonomous",
+		"chatgpt",
+		"sonnet",
+		"ai",
+		"llama",
+		"cli"
+	],
+	"author": {
+		"name": "Cline Bot Inc."
+	},
+	"license": "Apache-2.0",
+	"homepage": "https://cline.bot",
+	"bugs": {
+		"url": "https://github.com/cline/cline/issues"
 	},
 	"bin": {
 		"cline": "src/index.ts"
@@ -69,7 +92,6 @@
 		"yaml": "^2.8.2",
 		"zod": "^4.1.11"
 	},
-	"license": "Apache-2.0",
 	"devDependencies": {
 		"@cline/core": "workspace:*",
 		"@cline/shared": "workspace:*",

--- a/sdk/apps/cli/script/publish-npm.ts
+++ b/sdk/apps/cli/script/publish-npm.ts
@@ -217,6 +217,20 @@ if (existsSync(licenseFrom)) {
 	await $`cp ${licenseFrom} ${join(mainPkgDir, "LICENSE")}`;
 }
 
+// Copy README.md so the npm registry listing has the same landing page
+// as the repo. The published wrapper package is generated fresh in
+// dist/cli/ each release, so the source README is not picked up
+// automatically.
+const readmeFrom = join(cliDir, "README.md");
+if (existsSync(readmeFrom)) {
+	await $`cp ${readmeFrom} ${join(mainPkgDir, "README.md")}`;
+} else {
+	console.error(
+		`Missing ${readmeFrom}. The CLI README must exist before publishing.`,
+	);
+	process.exit(1);
+}
+
 const mainPkg: unknown = JSON.parse(
 	readFileSync(join(cliDir, "package.json"), "utf-8"),
 );
@@ -230,11 +244,25 @@ const license =
 	"license" in mainPkgRecord && typeof mainPkgRecord.license === "string"
 		? mainPkgRecord.license
 		: undefined;
+const keywords =
+	"keywords" in mainPkgRecord && isStringArray(mainPkgRecord.keywords)
+		? mainPkgRecord.keywords
+		: undefined;
+const author = "author" in mainPkgRecord ? mainPkgRecord.author : undefined;
+const homepage =
+	"homepage" in mainPkgRecord && typeof mainPkgRecord.homepage === "string"
+		? mainPkgRecord.homepage
+		: undefined;
+const bugs = "bugs" in mainPkgRecord ? mainPkgRecord.bugs : undefined;
 const wrapperPackageJson = {
 	name: wrapperPackageName,
 	version,
 	description: description || "Cline CLI",
 	license: license || "Apache-2.0",
+	...(keywords ? { keywords } : {}),
+	...(author ? { author } : {}),
+	...(homepage ? { homepage } : {}),
+	...(bugs ? { bugs } : {}),
 	...(sourceRepository ? { repository: sourceRepository } : {}),
 	bin: {
 		cline: "./bin/cline",


### PR DESCRIPTION
### Related Issue

N/A. Internal release-tooling cleanup. No issue number.

### Description

The CLI's official release flow has been bare since the SDK moved into this monorepo. Specifically, when we ran the publish workflow:

- The GitHub release body was hardcoded to ``Published cline@\${VERSION} to npm.`` (no changelog content)
- The Slack release announcement was hardcoded to ``Cline SDK CLI v\${VERSION}`` (no changelog, no compare link)
- The published ``cline`` npm package shipped with no README at all (the wrapper package is generated fresh in ``dist/cli/`` containing only ``bin/``, ``postinstall.mjs``, ``LICENSE``, and a stamped ``package.json``; ``apps/cli/README.md`` was never copied in)
- The wrapper ``package.json`` carried ``[EXPERIMENTAL]`` in the description and was missing ``keywords``, ``author``, ``homepage``, and ``bugs`` metadata

This PR closes those gaps and prepares ``cli-v3.0.0`` as the first proper CLI release cut from ``cline/cline``.

#### Workflow changes (``.github/workflows/publish-cli.yaml``)

Mirrors the VS Code extension's ``publish.yml`` flow, with monorepo-specific adjustments:

1. ``Get Previous CLI Tag`` step uses ``git describe --match 'cli-v*'`` so the prev-tag lookup doesn't pick up the extension's ``v*`` tags now that both products ship from the same repo.
2. ``Get Changelog Entry`` step extracts the top section of ``sdk/apps/cli/CHANGELOG.md`` via ``awk '/^## [0-9]/...'``. The workflow already runs with ``defaults.run.working-directory: sdk``, so the awk path is ``apps/cli/CHANGELOG.md``.
3. Switched from ``gh release create`` to ``softprops/action-gh-release@v1`` to match the extension and handle multi-line release bodies cleanly.
4. Slack payload now includes the changelog body via ``\${{ toJSON(steps.changelog.outputs.content) }}`` plus a compare link, mirroring the extension's pattern. Channel ID (``C0APVKGGZFC``) is unchanged.
5. The compare link in both the GitHub release body and the Slack context block is guarded on ``prev_tag != ''``. This will be the first ``cli-v*`` tag in the repo, so ``git describe`` will return empty and the compare line is omitted. From the second cli release onward the compare link will populate normally.

Dropped bold formatting (``**Full Changelog**``, ``*Cline ${tag}*``) from the release body and Slack header to comply with the repo's no-bold rule.

I verified the awk extraction locally against the new CHANGELOG and validated the YAML with ``js-yaml``.

#### Changelog format (``sdk/apps/cli/CHANGELOG.md``)

Stripped publication dates from all entries (e.g. ``## 0.0.13 (2026-05-07)`` → ``## 0.0.13``) so the awk regex is just ``^## [0-9]``, matching the extension's pattern. Replaced the bare ``## 3.0.0`` placeholder entry (which was never actually published) with a proper ``## 3.0.0`` section framing this as the first release from the ``cline/cline`` monorepo and giving a high-level description of what the CLI is.

#### Package metadata (``sdk/apps/cli/package.json``)

- Removed ``[EXPERIMENTAL]`` from the description and aligned the wording with the VS Code extension
- Added ``keywords``, ``author``, ``homepage``, and ``bugs`` so the npm registry listing carries the same metadata as the marketplace listing
- Version stays at ``3.0.0`` (was briefly bumped to ``3.0.1`` during this PR; reverted after confirming ``3.0.0`` was never actually published to npm)

#### Wrapper package generation (``sdk/apps/cli/script/publish-npm.ts``)

The publish script hand-builds a ``package.json`` for the ``cline`` wrapper in ``dist/cli/``. It previously only forwarded ``name``, ``version``, ``description``, ``license``, ``repository``, ``bin``, ``scripts``, and ``optionalDependencies`` from the source ``package.json``. Caught by Greptile review — extended forwarding to include ``keywords``, ``author``, ``homepage``, and ``bugs`` so the new metadata fields actually show up on the npm registry.

Also added a step to copy ``apps/cli/README.md`` into the wrapper as ``dist/cli/README.md`` so the npm registry listing has the same landing page as the repo.

#### npm README (``sdk/apps/cli/README.md``, ``sdk/apps/cli/DEVELOPMENT.md``)

- Rewrote ``apps/cli/README.md`` as a user-facing landing page (install, quick start, providers, modes, usage examples, options table, top-level commands, zen mode, tool approval, env vars)
- Added the header image and the links table (NPM, VS Code Extension, Discord, r/cline, Feature Requests, Docs) carried over from the old ``cli/README.md`` so the npm page has the same top-of-page presence as the old repo README
- Moved the dev-only sections (Publishing, Runtime Ownership, Connector runtime behavior, Logging Adapter) into ``DEVELOPMENT.md``, which already covers local setup, monorepo structure, tech stack, and TUI architecture

#### Skill doc (``sdk/apps/cli/.cline/skills/publish-cli/SKILL.md``)

Updated the release-prep instructions to use the no-date header format and to note that the publish workflow extracts the top changelog section verbatim into the GitHub release body and the Slack release announcement.

### Test Procedure

Couldn't run the workflow end-to-end since publishing to npm + GitHub releases + Slack is one-shot. Instead, validated each part in isolation:

- ``awk '/^## [0-9]/{if(found) exit; found=1; next} found{print}' sdk/apps/cli/CHANGELOG.md`` outputs the full 3.0.0 entry content and stops at the 0.0.13 header. Verified locally.
- Workflow YAML validates with ``js-yaml``.
- Verified ``cli-v*`` tags do not currently exist in the repo (confirmed via ``git ls-remote --tags origin 'cli-v*'``), which is why the compare-link guard is needed on this first release.
- Compared the resulting workflow against the VS Code extension's ``publish.yml``. The pattern matches (prev tag lookup → changelog extract → action-gh-release with body containing changelog + compare link → Slack with toJSON'd body + compare link), with the monorepo adjustments noted above.
- For the package.json updates, ran ``node -p`` to confirm all new fields parse and resolve correctly.
- Typechecked ``@cline/cli`` after each round of edits to ``publish-npm.ts``.

### After this PR merges

1. ``git tag -a cli-v3.0.0 -m \"CLI v3.0.0\"`` on the merge commit
2. ``git push origin refs/tags/cli-v3.0.0``
3. ``gh workflow run publish-cli.yaml -f publish_target=main -f git_tag=cli-v3.0.0 -f confirm_publish=publish``

The first release will skip the compare-link footer since there is no prior cli-v* tag. From ``cli-v3.0.1`` onward, the compare link will populate normally using ``cli-v3.0.0`` as the prev tag.

### Type of Change

-   [x] 🏃 Workflow Changes
-   [x] 📚 Documentation update
-   [x] 💅 Cosmetic Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (release tooling cleanup)
-   [x] I have reviewed contributor guidelines

### Additional Notes

The VS Code extension's ``publish.yml`` still uses bold (``**Full Changelog**``) and Slack-asterisk (``*Cline ${tag}*``) formatting in its release body and Slack message. Not fixed in this PR since the scope here is CLI-only. Worth a follow-up.

For future CLI releases, the publish-cli skill describes a normal release-prep flow: bump ``apps/cli/package.json``, prepend a ``## X.Y.Z`` section to ``apps/cli/CHANGELOG.md`` (no date), commit, tag ``cli-vX.Y.Z``, push tag, run the workflow.