### PR TITLE
Add concurrency to SDK live provider tests

### DIFF
--- a/sdk/packages/llms/README.md
+++ b/sdk/packages/llms/README.md
@@ -123,6 +123,7 @@ Optional:
 
 - `LLMS_LIVE_PROVIDER_TIMEOUT_MS=120000` to increase per-provider timeout.
 - `LLMS_LIVE_PROVIDER_RETRIES=2` to retry transient upstream/provider failures per provider (total attempts = retries + 1).
+- `LLMS_LIVE_PROVIDER_CONCURRENCY=3` to run multiple provider entries in parallel. Defaults to `3`; lower it if you need stricter provider rate-limit behavior.
 - Point `LLMS_LIVE_PROVIDERS_PATH` to a custom file if you want a narrower provider set.
 - Point `LLMS_LIVE_REASONING_PROVIDERS_PATH` to a custom file for reasoning-enabled suites.
 - Point `LLMS_LIVE_TOOL_PROVIDERS_PATH` to a custom file for tool-use suites.

--- a/sdk/packages/llms/src/tests/provider-live-reasoning.test.ts
+++ b/sdk/packages/llms/src/tests/provider-live-reasoning.test.ts
@@ -3,6 +3,10 @@ import path from "node:path";
 import { describe, it } from "vitest";
 import * as LlmsProviders from "../providers";
 import { toLiveProviderConfig } from "./provider-live-config";
+import {
+	LIVE_PROVIDER_CONCURRENCY,
+	runLiveProviderTargets,
+} from "./provider-live-runner";
 
 type ProviderConfig = import("../providers").ProviderConfig;
 
@@ -247,29 +251,33 @@ describe("live provider reasoning smoke test", () => {
 				throw new Error(`No providers found in ${filePath}.`);
 			}
 
-			const failures: string[] = [];
-			for (const target of targets) {
-				let success = false;
-				let lastError: unknown;
-				for (let attempt = 1; attempt <= PROVIDER_ATTEMPTS; attempt++) {
-					try {
-						await withTimeout(
-							runReasoningPrompt(target),
-							PROVIDER_TIMEOUT_MS,
-							target.label,
-						);
-						success = true;
-						break;
-					} catch (error) {
-						lastError = error;
+			const failures = await runLiveProviderTargets({
+				targets,
+				concurrency: LIVE_PROVIDER_CONCURRENCY,
+				runTarget: async (target) => {
+					let success = false;
+					let lastError: unknown;
+					for (let attempt = 1; attempt <= PROVIDER_ATTEMPTS; attempt++) {
+						try {
+							await withTimeout(
+								runReasoningPrompt(target),
+								PROVIDER_TIMEOUT_MS,
+								target.label,
+							);
+							success = true;
+							break;
+						} catch (error) {
+							lastError = error;
+						}
 					}
-				}
-				if (!success) {
+					if (success) {
+						return undefined;
+					}
 					const message =
 						lastError instanceof Error ? lastError.message : String(lastError);
-					failures.push(`${target.label}: ${message}`);
-				}
-			}
+					return `${target.label}: ${message}`;
+				},
+			});
 
 			if (failures.length > 0) {
 				throw new Error(

--- a/sdk/packages/llms/src/tests/provider-live-runner.ts
+++ b/sdk/packages/llms/src/tests/provider-live-runner.ts
@@ -1,0 +1,51 @@
+const DEFAULT_PROVIDER_CONCURRENCY = 3;
+
+export const LIVE_PROVIDER_CONCURRENCY = parseLiveProviderConcurrency(
+	process.env.LLMS_LIVE_PROVIDER_CONCURRENCY,
+);
+
+function parseLiveProviderConcurrency(value: string | undefined): number {
+	if (!value) {
+		return DEFAULT_PROVIDER_CONCURRENCY;
+	}
+	const parsed = Number(value);
+	if (!Number.isFinite(parsed)) {
+		return DEFAULT_PROVIDER_CONCURRENCY;
+	}
+	return Math.max(1, Math.floor(parsed));
+}
+
+export async function runLiveProviderTargets<Target>(options: {
+	targets: readonly Target[];
+	concurrency?: number;
+	runTarget(target: Target): Promise<string | undefined>;
+}): Promise<string[]> {
+	const concurrency = Math.max(
+		1,
+		Math.floor(options.concurrency ?? LIVE_PROVIDER_CONCURRENCY),
+	);
+	const failures: string[] = [];
+	let nextIndex = 0;
+
+	async function worker(): Promise<void> {
+		while (true) {
+			const target = options.targets[nextIndex];
+			nextIndex += 1;
+			if (!target) {
+				return;
+			}
+			const failure = await options.runTarget(target);
+			if (failure) {
+				failures.push(failure);
+			}
+		}
+	}
+
+	const workerCount = Math.min(concurrency, options.targets.length);
+	await Promise.all(
+		Array.from({ length: workerCount }, async () => {
+			await worker();
+		}),
+	);
+	return failures;
+}

--- a/sdk/packages/llms/src/tests/provider-live-runner.ts
+++ b/sdk/packages/llms/src/tests/provider-live-runner.ts
@@ -31,7 +31,7 @@ export async function runLiveProviderTargets<Target>(options: {
 		while (true) {
 			const target = options.targets[nextIndex];
 			nextIndex += 1;
-			if (!target) {
+			if (target === undefined) {
 				return;
 			}
 			const failure = await options.runTarget(target);
@@ -42,10 +42,6 @@ export async function runLiveProviderTargets<Target>(options: {
 	}
 
 	const workerCount = Math.min(concurrency, options.targets.length);
-	await Promise.all(
-		Array.from({ length: workerCount }, async () => {
-			await worker();
-		}),
-	);
+	await Promise.all(Array.from({ length: workerCount }, () => worker()));
 	return failures;
 }

--- a/sdk/packages/llms/src/tests/provider-live-tools.test.ts
+++ b/sdk/packages/llms/src/tests/provider-live-tools.test.ts
@@ -3,6 +3,10 @@ import path from "node:path";
 import { describe, it } from "vitest";
 import * as LlmsProviders from "../providers";
 import { toLiveProviderConfig } from "./provider-live-config";
+import {
+	LIVE_PROVIDER_CONCURRENCY,
+	runLiveProviderTargets,
+} from "./provider-live-runner";
 
 type ProviderConfig = import("../providers").ProviderConfig;
 
@@ -222,29 +226,33 @@ describe("live provider tool-use smoke test", () => {
 				throw new Error(`No providers found in ${filePath}.`);
 			}
 
-			const failures: string[] = [];
-			for (const target of targets) {
-				let success = false;
-				let lastError: unknown;
-				for (let attempt = 1; attempt <= PROVIDER_ATTEMPTS; attempt++) {
-					try {
-						await withTimeout(
-							runToolUsePrompt(target),
-							PROVIDER_TIMEOUT_MS,
-							target.label,
-						);
-						success = true;
-						break;
-					} catch (error) {
-						lastError = error;
+			const failures = await runLiveProviderTargets({
+				targets,
+				concurrency: LIVE_PROVIDER_CONCURRENCY,
+				runTarget: async (target) => {
+					let success = false;
+					let lastError: unknown;
+					for (let attempt = 1; attempt <= PROVIDER_ATTEMPTS; attempt++) {
+						try {
+							await withTimeout(
+								runToolUsePrompt(target),
+								PROVIDER_TIMEOUT_MS,
+								target.label,
+							);
+							success = true;
+							break;
+						} catch (error) {
+							lastError = error;
+						}
 					}
-				}
-				if (!success) {
+					if (success) {
+						return undefined;
+					}
 					const message =
 						lastError instanceof Error ? lastError.message : String(lastError);
-					failures.push(`${target.label}: ${message}`);
-				}
-			}
+					return `${target.label}: ${message}`;
+				},
+			});
 
 			if (failures.length > 0) {
 				throw new Error(

--- a/sdk/packages/llms/src/tests/provider-live.test.ts
+++ b/sdk/packages/llms/src/tests/provider-live.test.ts
@@ -3,6 +3,10 @@ import path from "node:path";
 import { describe, it } from "vitest";
 import * as LlmsProviders from "../providers";
 import { toLiveProviderConfig } from "./provider-live-config";
+import {
+	LIVE_PROVIDER_CONCURRENCY,
+	runLiveProviderTargets,
+} from "./provider-live-runner";
 
 type ProviderConfig = import("../providers").ProviderConfig;
 
@@ -307,30 +311,33 @@ describe("live provider smoke test", () => {
 				throw new Error(`No providers found in ${filePath}.`);
 			}
 
-			const failures: string[] = [];
-
-			for (const target of targets) {
-				let success = false;
-				let lastError: unknown;
-				for (let attempt = 1; attempt <= PROVIDER_ATTEMPTS; attempt++) {
-					try {
-						await withTimeout(
-							runPrompt(target),
-							PROVIDER_TIMEOUT_MS,
-							target.label,
-						);
-						success = true;
-						break;
-					} catch (error) {
-						lastError = error;
+			const failures = await runLiveProviderTargets({
+				targets,
+				concurrency: LIVE_PROVIDER_CONCURRENCY,
+				runTarget: async (target) => {
+					let success = false;
+					let lastError: unknown;
+					for (let attempt = 1; attempt <= PROVIDER_ATTEMPTS; attempt++) {
+						try {
+							await withTimeout(
+								runPrompt(target),
+								PROVIDER_TIMEOUT_MS,
+								target.label,
+							);
+							success = true;
+							break;
+						} catch (error) {
+							lastError = error;
+						}
 					}
-				}
-				if (!success) {
+					if (success) {
+						return undefined;
+					}
 					const message =
 						lastError instanceof Error ? lastError.message : String(lastError);
-					failures.push(`${target.label}: ${message}`);
-				}
-			}
+					return `${target.label}: ${message}`;
+				},
+			});
 
 			if (failures.length > 0) {
 				throw new Error(


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

### Description

Adds bounded concurrency to the SDK live provider test harness so configured provider entries can run in parallel instead of strictly sequentially.

The new `LLMS_LIVE_PROVIDER_CONCURRENCY` environment variable controls the limit and defaults to `3`. The existing retry and timeout behavior remains per provider.

### Test Procedure

- `bunx biome check sdk/packages/llms/src/tests/provider-live-runner.ts sdk/packages/llms/src/tests/provider-live.test.ts sdk/packages/llms/src/tests/provider-live-reasoning.test.ts sdk/packages/llms/src/tests/provider-live-tools.test.ts sdk/packages/llms/README.md --diagnostic-level=error`
- `git diff --check -- sdk/packages/llms/README.md sdk/packages/llms/src/tests/provider-live-runner.ts sdk/packages/llms/src/tests/provider-live.test.ts sdk/packages/llms/src/tests/provider-live-reasoning.test.ts sdk/packages/llms/src/tests/provider-live-tools.test.ts`
- `LLMS_LIVE_REASONING_TESTS=1 LLMS_LIVE_REASONING_PROVIDERS_PATH=sdk/packages/llms/src/tests/live-providers.reasoning-disabled.example.json LLMS_LIVE_PROVIDER_TIMEOUT_MS=120000 LLMS_LIVE_PROVIDER_RETRIES=0 bun run --filter @cline/llms test:live -- src/tests/provider-live-reasoning.test.ts`

Also verified during development with `LLMS_LIVE_PROVIDER_CONCURRENCY=3` across reasoning-enabled, reasoning-disabled, general smoke, and tool-use live suites. Full smoke/tool configs are blocked only by missing `MISTRAL_API_KEY`; no-Mistral variants passed.

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [x] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A

### Additional Notes

The default concurrency is intentionally modest (`3`) to improve runtime while limiting rate-limit pressure on live provider accounts.
