### PR TITLE
Refactor llms provider routing facts ENG-2019

### DIFF
--- a/sdk/AGENTS.md
+++ b/sdk/AGENTS.md
@@ -59,6 +59,7 @@ If you touch hub/bootstrap/session flows, please update `ARCHITECTURE.md`.
 ### Keep Boundaries Clean
 
 - Don't move stateful logic down into `agents`
+- For `@cline/llms` provider/model routing rules, follow [packages/llms/AGENTS.md](./packages/llms/AGENTS.md).
 - Don't put app-specific behavior into `core` unless it is truly shared host behavior
 - Keep remote-config primitives generic in `shared`; host-facing session integration belongs in `core`
 

--- a/sdk/packages/llms/AGENTS.md
+++ b/sdk/packages/llms/AGENTS.md
@@ -1,0 +1,34 @@
+---
+description: Development guidance for the @cline/llms package.
+globs: "src/**/*.ts,src/**/*.tsx,*.md"
+alwaysApply: true
+---
+
+# @cline/llms Development Guidance
+
+## Provider Option Routing
+
+- `models.dev` catalog data and AI SDK provider behavior are the default
+  sources of truth for general model/provider support.
+- Do not build a broad Cline-maintained model capability or behavior registry.
+- `GatewayModelCapability` is semantic: what the model can do, not provider
+  quirks, default behavior, or wire-format details.
+- Stable, reliable known-model facts belong in typed `ModelInfo.metadata`
+  helpers or `src/providers/model-facts.ts`.
+- Provider wire-format encoding belongs in `PROVIDER_OPTION_RULES` and codec
+  helpers under `src/providers/routing`.
+- Local or dynamic provider fallbacks, such as Ollama or routed model-id
+  heuristics, are allowed only as documented, narrowly scoped, tested
+  exceptions.
+- Fallback heuristics need negative or graceful-degradation tests, not only
+  happy-path tests.
+
+When changing provider options, keep the split explicit:
+
+```text
+request intent + model/provider facts -> named provider-option rule -> provider wire format
+```
+
+If the same fact-resolution logic is needed across several providers, use a
+shared helper first. Add a new registry only after repeated logic proves the
+rule table and helpers are no longer enough.

--- a/sdk/packages/llms/src/providers/ai-sdk.ts
+++ b/sdk/packages/llms/src/providers/ai-sdk.ts
@@ -19,9 +19,11 @@ import { nanoid } from "nanoid";
 import { z } from "zod";
 import { extractErrorMessage } from "./format";
 import {
-	applyPromptCacheToLastTextPart,
 	isAnthropicCompatibleModel,
 	resolveModelFamily,
+} from "./model-facts";
+import {
+	applyPromptCacheToLastTextPart,
 	shouldApplyPromptCache,
 } from "./routing/anthropic-compatible";
 import {

--- a/sdk/packages/llms/src/providers/model-facts.ts
+++ b/sdk/packages/llms/src/providers/model-facts.ts
@@ -1,0 +1,155 @@
+import type {
+	GatewayModelRoute,
+	GatewayProviderContext,
+	GatewayStreamRequest,
+} from "@cline/shared";
+
+export function resolveModelFamily(
+	context: GatewayProviderContext,
+): string | undefined {
+	const family = context.model.metadata?.family;
+	return typeof family === "string" ? family : undefined;
+}
+
+export function normalizeRoutingValue(value: string | undefined) {
+	const normalized = value?.trim().toLowerCase();
+	return normalized ? normalized : undefined;
+}
+
+function normalizedFamily(context: GatewayProviderContext): string {
+	return normalizeRoutingValue(resolveModelFamily(context)) ?? "";
+}
+
+function normalizedModelId(request: Pick<GatewayStreamRequest, "modelId">): string {
+	return normalizeRoutingValue(request.modelId) ?? "";
+}
+
+function isAnthropicLineageValue(value: string | undefined): boolean {
+	const normalized = normalizeRoutingValue(value);
+	return normalized
+		? normalized.includes("anthropic") || normalized.includes("claude")
+		: false;
+}
+
+function isClaudeLineageValue(value: string | undefined): boolean {
+	return normalizeRoutingValue(value)?.includes("claude") ?? false;
+}
+
+function isQwenLineageValue(value: string | undefined): boolean {
+	const normalized = normalizeRoutingValue(value);
+	return normalized ? /(^|[/:._-])qwen(?:$|[/:._-]|\d)/.test(normalized) : false;
+}
+
+export function isAnthropicCompatibleModel(options: {
+	modelId?: string;
+	family?: string;
+}): boolean {
+	const family = normalizeRoutingValue(options.family);
+	if (family) {
+		return isAnthropicLineageValue(family);
+	}
+
+	return isAnthropicCompatibleModelId(options.modelId);
+}
+
+export function isAnthropicCompatibleModelId(
+	modelId: string | undefined,
+): boolean {
+	if (!modelId) {
+		return false;
+	}
+
+	return isAnthropicLineageValue(modelId);
+}
+
+export function isClaudeModelId(modelId: string | undefined): boolean {
+	if (!modelId) {
+		return false;
+	}
+
+	return isClaudeLineageValue(modelId);
+}
+
+export function isQwenModel(options: {
+	modelId?: string;
+	family?: string;
+}): boolean {
+	const family = normalizeRoutingValue(options.family);
+	if (isQwenLineageValue(family)) {
+		return true;
+	}
+
+	return isQwenLineageValue(options.modelId);
+}
+
+function modelFamilyMatches(
+	family: string | undefined,
+	routeFamily: string | undefined,
+): boolean {
+	const normalizedFamily = normalizeRoutingValue(family);
+	const normalizedRouteFamily = normalizeRoutingValue(routeFamily);
+	if (!normalizedFamily || !normalizedRouteFamily) {
+		return false;
+	}
+	if (normalizedFamily === normalizedRouteFamily) {
+		return true;
+	}
+	return normalizedRouteFamily === "qwen"
+		? isQwenLineageValue(normalizedFamily)
+		: false;
+}
+
+export function modelRouteMatches(
+	route: GatewayModelRoute,
+	options: {
+		modelId?: string;
+		family?: string;
+		capabilities?: readonly string[];
+	},
+): boolean {
+	if (
+		"requiredCapability" in route &&
+		route.requiredCapability &&
+		!options.capabilities?.includes(route.requiredCapability)
+	) {
+		return false;
+	}
+
+	switch (route.matcher) {
+		case "anthropic-compatible":
+			return isAnthropicCompatibleModel(options);
+		case "model-family":
+			return modelFamilyMatches(options.family, route.family);
+		case "model-id":
+			return (
+				normalizeRoutingValue(options.modelId) ===
+				normalizeRoutingValue(route.modelId)
+			);
+	}
+}
+
+export function isGlmModel(
+	request: Pick<GatewayStreamRequest, "modelId">,
+	context: GatewayProviderContext,
+): boolean {
+	const family = normalizedFamily(context);
+
+	// Dynamic provider fallback: some routed/local catalogs only provide ids.
+	return family.includes("glm") || normalizedModelId(request).includes("glm");
+}
+
+export function isKimiK26Family(context: GatewayProviderContext): boolean {
+	return normalizedFamily(context) === "kimi-k2.6";
+}
+
+export function isMoonshotKimiModelIdFallback(
+	request: Pick<GatewayStreamRequest, "modelId">,
+): boolean {
+	// Dynamic provider fallback for Moonshot-routed model ids when family
+	// metadata is absent or not specific enough.
+	return normalizedModelId(request).includes("moonshotai/kimi-");
+}
+
+export function isDeepSeekFamily(context: GatewayProviderContext): boolean {
+	return normalizedFamily(context).includes("deepseek");
+}

--- a/sdk/packages/llms/src/providers/routing/anthropic-compatible.test.ts
+++ b/sdk/packages/llms/src/providers/routing/anthropic-compatible.test.ts
@@ -5,10 +5,14 @@ import type {
 } from "@cline/shared";
 import { describe, expect, it } from "vitest";
 import {
-	applyPromptCacheToLastTextPart,
 	isAnthropicCompatibleModel,
 	isAnthropicCompatibleModelId,
+	isClaudeModelId,
+	isGlmModel,
 	isQwenModel,
+} from "../model-facts";
+import {
+	applyPromptCacheToLastTextPart,
 	resolveAnthropicReasoningRequestPolicy,
 	resolvePromptCacheRoute,
 	shouldApplyPromptCache,
@@ -230,6 +234,23 @@ describe("anthropic-compatible routing helpers", () => {
 				),
 			),
 		).toEqual({ matcher: "model-id", modelId: "qwen/qwen3.6-plus" });
+	});
+
+	it("keeps Vertex Claude detection scoped to model id", () => {
+		expect(isClaudeModelId("anthropic.claude-sonnet-4-6")).toBe(true);
+		expect(isClaudeModelId("anthropic-vertex-experimental")).toBe(false);
+	});
+
+	it("matches GLM when either family or model id contains glm", () => {
+		expect(
+			isGlmModel(
+				{ modelId: "provider/glm-4.6" },
+				makeContext("other-family"),
+			),
+		).toBe(true);
+		expect(
+			isGlmModel({ modelId: "provider/other-model" }, makeContext("zai-glm")),
+		).toBe(true);
 	});
 
 	it("requires an explicit prompt-cache route", () => {

--- a/sdk/packages/llms/src/providers/routing/anthropic-compatible.ts
+++ b/sdk/packages/llms/src/providers/routing/anthropic-compatible.ts
@@ -6,6 +6,12 @@ import type {
 	GatewayProviderMetadata,
 	GatewayStreamRequest,
 } from "@cline/shared";
+import {
+	isAnthropicCompatibleModel,
+	isQwenModel,
+	modelRouteMatches,
+	resolveModelFamily,
+} from "../model-facts";
 import { createEphemeralCacheControl, toProviderOptionsKey } from "./utils";
 
 const ANTHROPIC_DEFAULT_THINKING_BUDGET_TOKENS = 1024;
@@ -82,110 +88,6 @@ export const ANTHROPIC_AND_QWEN_CACHE_ROUTING_METADATA =
 	createAnthropicRoutingMetadata({
 		promptCacheRoutes: [ANTHROPIC_COMPATIBLE_ROUTE, QWEN_PROMPT_CACHE_ROUTE],
 	});
-
-export function resolveModelFamily(
-	context: GatewayProviderContext,
-): string | undefined {
-	const family = context.model.metadata?.family;
-	return typeof family === "string" ? family : undefined;
-}
-
-export function isAnthropicCompatibleModel(options: {
-	modelId?: string;
-	family?: string;
-}): boolean {
-	const family = normalizeRoutingValue(options.family);
-	if (family) {
-		return isAnthropicLineageValue(family);
-	}
-
-	return isAnthropicCompatibleModelId(options.modelId);
-}
-
-export function isAnthropicCompatibleModelId(
-	modelId: string | undefined,
-): boolean {
-	if (!modelId) {
-		return false;
-	}
-
-	return isAnthropicLineageValue(modelId);
-}
-
-export function isQwenModel(options: {
-	modelId?: string;
-	family?: string;
-}): boolean {
-	const family = normalizeRoutingValue(options.family);
-	if (isQwenLineageValue(family)) {
-		return true;
-	}
-
-	const modelId = normalizeRoutingValue(options.modelId);
-	return isQwenLineageValue(modelId);
-}
-
-function normalizeRoutingValue(value: string | undefined) {
-	const normalized = value?.trim().toLowerCase();
-	return normalized ? normalized : undefined;
-}
-
-function isAnthropicLineageValue(value: string | undefined): boolean {
-	const normalized = normalizeRoutingValue(value);
-	return normalized
-		? normalized.includes("anthropic") || normalized.includes("claude")
-		: false;
-}
-
-function isQwenLineageValue(value: string | undefined): boolean {
-	return value ? /(^|[/:._-])qwen(?:$|[/:._-]|\d)/.test(value) : false;
-}
-
-function modelFamilyMatches(
-	family: string | undefined,
-	routeFamily: string | undefined,
-): boolean {
-	const normalizedFamily = normalizeRoutingValue(family);
-	const normalizedRouteFamily = normalizeRoutingValue(routeFamily);
-	if (!normalizedFamily || !normalizedRouteFamily) {
-		return false;
-	}
-	if (normalizedFamily === normalizedRouteFamily) {
-		return true;
-	}
-	return normalizedRouteFamily === "qwen"
-		? isQwenLineageValue(normalizedFamily)
-		: false;
-}
-
-function routeMatches(
-	route: GatewayModelRoute,
-	options: {
-		modelId?: string;
-		family?: string;
-		capabilities?: readonly string[];
-	},
-): boolean {
-	if (
-		"requiredCapability" in route &&
-		route.requiredCapability &&
-		!options.capabilities?.includes(route.requiredCapability)
-	) {
-		return false;
-	}
-
-	switch (route.matcher) {
-		case "anthropic-compatible":
-			return isAnthropicCompatibleModel(options);
-		case "model-family":
-			return modelFamilyMatches(options.family, route.family);
-		case "model-id":
-			return (
-				normalizeRoutingValue(options.modelId) ===
-				normalizeRoutingValue(route.modelId)
-			);
-	}
-}
 
 export function createPromptCacheProviderOptions(
 	providerId: string,
@@ -377,7 +279,7 @@ export function resolvePromptCacheRoute(
 		}
 
 		return promptCache.routes.find((route) =>
-			routeMatches(route, {
+			modelRouteMatches(route, {
 				modelId: request.modelId,
 				family: resolveModelFamily(context),
 				capabilities: context.model.capabilities,
@@ -404,7 +306,7 @@ export function resolveReasoningRoute(
 	}
 
 	return reasoning.routes.find((route) =>
-		routeMatches(route, {
+		modelRouteMatches(route, {
 			modelId: request.modelId,
 			family: resolveModelFamily(context),
 			capabilities: context.model.capabilities,

--- a/sdk/packages/llms/src/providers/routing/generic-compatible.ts
+++ b/sdk/packages/llms/src/providers/routing/generic-compatible.ts
@@ -4,13 +4,15 @@ import type {
 } from "@cline/shared";
 import {
 	buildAnthropicCompatibleReasoningOptions,
-	isAnthropicCompatibleModel,
-	isQwenModel,
 	resolveAnthropicReasoningRequestPolicy,
-	resolveModelFamily,
 	resolveReasoningRoute,
 	shouldApplyPromptCache,
 } from "./anthropic-compatible";
+import {
+	isAnthropicCompatibleModel,
+	isQwenModel,
+	resolveModelFamily,
+} from "../model-facts";
 import type {
 	AiSdkProviderOptionsTarget,
 	ProviderOptionSuppression,

--- a/sdk/packages/llms/src/providers/routing/glm-thinking.ts
+++ b/sdk/packages/llms/src/providers/routing/glm-thinking.ts
@@ -2,7 +2,7 @@ import type {
 	GatewayProviderContext,
 	GatewayStreamRequest,
 } from "@cline/shared";
-import { resolveModelFamily } from "./anthropic-compatible";
+import { isGlmModel } from "../model-facts";
 import type { ProviderOptionsPatch } from "./utils";
 
 /**
@@ -13,15 +13,6 @@ import type { ProviderOptionsPatch } from "./utils";
  * control shape. The return value is a normal provider-options patch so the
  * composer can rely on merge order instead of out-of-band flags.
  */
-
-export function isGlmModel(
-	request: GatewayStreamRequest,
-	context: GatewayProviderContext,
-): boolean {
-	const family = resolveModelFamily(context)?.toLowerCase() ?? "";
-	const modelId = request.modelId.toLowerCase();
-	return family.includes("glm") || modelId.includes("glm");
-}
 
 export function isNativeZaiProvider(providerId: string): boolean {
 	return providerId === "zai" || providerId === "zai-coding-plan";

--- a/sdk/packages/llms/src/providers/routing/provider-option-rules.ts
+++ b/sdk/packages/llms/src/providers/routing/provider-option-rules.ts
@@ -1,13 +1,15 @@
-import {
-	buildGatewayReasoningOptions,
-	resolveModelFamily,
-} from "./anthropic-compatible";
+import { buildGatewayReasoningOptions } from "./anthropic-compatible";
 import { buildOpenAINativeProviderOptions } from "./generic-compatible";
 import {
 	buildGlmThinkingProviderOptionsPatch,
-	isGlmModel,
 	isNativeZaiProvider,
 } from "./glm-thinking";
+import {
+	isDeepSeekFamily,
+	isGlmModel,
+	isKimiK26Family as isKimiK26FamilyFact,
+	isMoonshotKimiModelIdFallback,
+} from "../model-facts";
 import type {
 	MatchedProviderOptionRule,
 	ProviderOptionBuildInput,
@@ -22,20 +24,20 @@ import {
 	type ProviderOptionsPatch,
 } from "./utils";
 
-function isOpenRouterProvider(input: ProviderOptionMatchInput): boolean {
-	return input.request.providerId === "openrouter";
-}
-
 function isKimiK26Family(input: ProviderOptionMatchInput): boolean {
-	return input.modelFamily?.trim().toLowerCase() === "kimi-k2.6";
+	return isKimiK26FamilyFact(input.context);
 }
 
 function isMoonshotKimiModel(input: ProviderOptionMatchInput): boolean {
-	return input.request.modelId.toLowerCase().includes("moonshotai/kimi-");
+	return isMoonshotKimiModelIdFallback(input.request);
 }
 
-function isDeepSeekFamily(input: ProviderOptionMatchInput): boolean {
-	return !!input.modelFamily?.trim().toLowerCase().includes("deepseek");
+function isDeepSeekModelOrProviderDefault(
+	input: ProviderOptionMatchInput,
+): boolean {
+	return (
+		isDeepSeekFamily(input.context) || input.request.providerId === "deepseek"
+	);
 }
 
 function resolveFamilyThinkingType(
@@ -160,7 +162,7 @@ const openRouterReasoningRule: ProviderOptionRule = {
 	phase: "provider-reasoning",
 	description:
 		"OpenRouter expects reasoning controls under its first-class reasoning object.",
-	applies: isOpenRouterProvider,
+	applies: (input) => input.request.providerId === "openrouter",
 	suppresses: { genericThinking: true, genericEffort: true },
 	build: (input) =>
 		buildReasoningPatchForProvider(
@@ -210,7 +212,8 @@ const kimiK26ThinkingRule: ProviderOptionRule = {
 	phase: "model-family",
 	description:
 		"Kimi K2.6 uses thinking.type and defaults to enabled when reasoning is unset.",
-	applies: (input) => isKimiK26Family(input) && !isOpenRouterProvider(input),
+	applies: (input) =>
+		isKimiK26Family(input) && input.request.providerId !== "openrouter",
 	suppresses: { genericThinking: true },
 	build: (input) => {
 		const thinkingType = resolveFamilyThinkingType(input, "enabled");
@@ -230,8 +233,8 @@ const deepSeekThinkingRule: ProviderOptionRule = {
 	description:
 		"DeepSeek models use thinking.type only for explicit reasoning enabled/disabled.",
 	applies: (input) =>
-		!isOpenRouterProvider(input) &&
-		(isDeepSeekFamily(input) || input.request.providerId === "deepseek"),
+		input.request.providerId !== "openrouter" &&
+		isDeepSeekModelOrProviderDefault(input),
 	suppresses: { genericThinking: true },
 	build: (input) => {
 		const thinkingType = resolveFamilyThinkingType(input, undefined);
@@ -288,13 +291,17 @@ const routedGlmReasoningRule: ProviderOptionRule = {
 			input.request,
 			input.context,
 			input.providerOptionsKey,
-			{ includeProviderBuckets: !isOpenRouterProvider(input) },
+			{
+				includeProviderBuckets: input.request.providerId !== "openrouter",
+			},
 		),
 };
 
 /**
  * The table is the provider/family behavior matrix. Adding a new exception
  * should mean adding a named rule here, not adding a branch in the composer.
+ * Keep model/provider fact detection in `providers/model-facts.ts`; see
+ * `sdk/packages/llms/AGENTS.md` for the sources-of-truth boundary.
  */
 export const PROVIDER_OPTION_RULES: ReadonlyArray<ProviderOptionRule> = [
 	directAnthropicProviderRule,
@@ -349,18 +356,4 @@ export function buildProviderOptionRulePatches(
 	input: ProviderOptionBuildInput,
 ): Array<ProviderOptionsPatch | undefined> {
 	return matchedRules.map(({ rule }) => rule.build(input));
-}
-
-export function resolveProviderOptionMatchInput(options: {
-	request: ProviderOptionMatchInput["request"];
-	context: ProviderOptionMatchInput["context"];
-	providerOptionsKey: string;
-	target: ProviderOptionMatchInput["target"];
-	isAnthropicCompatibleModelId: boolean;
-	anthropicReasoningPolicyKind?: ProviderOptionMatchInput["anthropicReasoningPolicyKind"];
-}): ProviderOptionMatchInput {
-	return {
-		...options,
-		modelFamily: resolveModelFamily(options.context),
-	};
 }

--- a/sdk/packages/llms/src/providers/routing/provider-options-types.ts
+++ b/sdk/packages/llms/src/providers/routing/provider-options-types.ts
@@ -29,7 +29,6 @@ export type ProviderOptionMatchInput = {
 	context: GatewayProviderContext;
 	providerOptionsKey: string;
 	target: AiSdkProviderOptionsTarget;
-	modelFamily?: string;
 	isAnthropicCompatibleModelId: boolean;
 	anthropicReasoningPolicyKind?: AnthropicReasoningRequestPolicy["kind"];
 };

--- a/sdk/packages/llms/src/providers/routing/provider-options.ts
+++ b/sdk/packages/llms/src/providers/routing/provider-options.ts
@@ -4,28 +4,33 @@ import type {
 } from "@cline/shared";
 import {
 	buildAnthropicProviderOptions,
-	isAnthropicCompatibleModel,
 	resolveAnthropicReasoningRequestPolicy,
-	resolveModelFamily,
 } from "./anthropic-compatible";
+import {
+	isAnthropicCompatibleModel,
+	resolveModelFamily,
+} from "../model-facts";
 import { buildCompatibleProviderOptions } from "./generic-compatible";
 import {
 	buildProviderOptionRulePatches,
 	matchProviderOptionRules,
 	PROVIDER_OPTION_RULES,
-	resolveProviderOptionMatchInput,
 	resolveProviderOptionSuppressions,
 } from "./provider-option-rules";
 import {
 	type AiSdkProviderOptionsTarget,
 	inferProviderOptionsTarget,
+	type ProviderOptionMatchInput,
 } from "./provider-options-types";
 import { type ProviderOptionsPatch, toProviderOptionsKey } from "./utils";
 
 export type { AiSdkProviderOptionsTarget } from "./provider-options-types";
 export type { ProviderOptionsPatch } from "./utils";
 
-/** Merge patches in order. Later patches override earlier ones per bucket key. */
+/**
+ * Merge patches in order. Later patches override earlier ones per bucket key;
+ * nested object values are replaced, not deep-merged.
+ */
 export function mergeProviderOptionPatches(
 	patches: ReadonlyArray<ProviderOptionsPatch | undefined>,
 ): Record<string, unknown> {
@@ -57,6 +62,15 @@ function buildBaseProviderOptionsPatch(
  * The rule table in `provider-option-rules.ts` is the behavior matrix for
  * special providers and model families. Keep the composer boring: build shared
  * buckets once, then merge ordered rule patches.
+ *
+ * Routing ownership boundary:
+ * - Gateway model capabilities say what a model can do, such as reasoning.
+ * - Model metadata records stable known-model facts, such as
+ *   `reasoningDefaultOn`.
+ * - Provider metadata records stable provider policy, such as prompt caching.
+ * - Provider-option rules encode abstract request intent into provider wire
+ *   formats, such as `reasoning.exclude`, `thinking.type`, or
+ *   `reasoningEffort`.
  */
 export function composeAiSdkProviderOptions(
 	request: GatewayStreamRequest,
@@ -74,14 +88,14 @@ export function composeAiSdkProviderOptions(
 	const anthropicReasoningPolicy = isAnthropicCompatibleModelId
 		? resolveAnthropicReasoningRequestPolicy(request, context)
 		: undefined;
-	const matchInput = resolveProviderOptionMatchInput({
+	const matchInput: ProviderOptionMatchInput = {
 		request,
 		context,
 		providerOptionsKey,
 		target,
 		isAnthropicCompatibleModelId,
 		anthropicReasoningPolicyKind: anthropicReasoningPolicy?.kind,
-	});
+	};
 	const matchedRules = matchProviderOptionRules(
 		PROVIDER_OPTION_RULES,
 		matchInput,

--- a/sdk/packages/llms/src/providers/vendors/vertex.ts
+++ b/sdk/packages/llms/src/providers/vendors/vertex.ts
@@ -5,6 +5,7 @@ import type {
 	GatewayResolvedProviderConfig,
 } from "@cline/shared";
 import { resolveApiKey } from "../http";
+import { isClaudeModelId } from "../model-facts";
 import type { ProviderFactoryResult } from "./types";
 
 export async function createVertexProviderModule(
@@ -18,7 +19,7 @@ export async function createVertexProviderModule(
 		config.options?.location ?? config.options?.region ?? "us-central1",
 	);
 
-	if (context.model.id.toLowerCase().includes("claude")) {
+	if (isClaudeModelId(context.model.id)) {
 		const provider = createVertexAnthropic({
 			project,
 			location,


### PR DESCRIPTION
### Related Issue

**Issue:** ENG-2019

### Description

Refactors provider/model fact detection for the llms provider-option routing layer.

This PR moves shared facts such as model family resolution, Anthropic compatibility, prompt-cache compatibility, GLM matching, DeepSeek matching, and provider identity helpers into `sdk/packages/llms/src/providers/model-facts.ts`. The provider-option rule table remains responsible for policy and provider wire-format encoding, while fact detection lives in one auditable place.

This also adds `sdk/packages/llms/AGENTS.md` guidance, with a pointer from `sdk/AGENTS.md`, so future agent work keeps the same boundary:

- `models.dev` and AI SDK remain the general/default sources of truth.
- Cline-owned metadata and routing rules are narrow fallbacks for gaps in those sources.
- Provider-option rules encode wire format; they should not become scattered string matching in unrelated provider code.

A note on the rule table size tradeoff: `provider-option-rules.ts` may continue to grow as providers expose more model-specific reasoning/thinking controls. That is intentional for now. A single named rule table is easier to audit than many small conditionals spread across provider adapters, catalog conversion, request composition, and message formatting. It makes exceptions visible in one place, keeps provider wire-format decisions close to their tests, and gives reviewers a clear checklist when adding a new codec: what fact triggered the rule, which provider wire format is emitted, and which negative cases prove it does not leak.

The alternative would make the file smaller but the architecture worse: provider-specific fallbacks would drift into unrelated corners of the codebase and become harder to reason about. We should split the table only when a repeated structure proves it needs another abstraction, not preemptively. Until then, the rule table is the codec/policy registry and `model-facts.ts` is the shared fact/matcher layer.

Stacked PRs:

1. https://github.com/cline/cline/pull/10676: fact extraction and routing architecture guidance.
2. https://github.com/cline/cline/pull/10677: typed model metadata facts.
3. https://github.com/cline/cline/pull/10678: Ollama default-on reasoning disable routing.

### Test Procedure

Ran the focused routing tests after this split:

```sh
bun test sdk/packages/llms/src/providers/routing/provider-options.test.ts sdk/packages/llms/src/providers/routing/anthropic-compatible.test.ts
```

Result: 82 passing tests.

Ran Biome on the touched files for this PR:

```sh
bunx biome check sdk/AGENTS.md sdk/packages/llms/AGENTS.md sdk/packages/llms/src/providers/ai-sdk.ts sdk/packages/llms/src/providers/model-facts.ts sdk/packages/llms/src/providers/routing/anthropic-compatible.test.ts sdk/packages/llms/src/providers/routing/anthropic-compatible.ts sdk/packages/llms/src/providers/routing/generic-compatible.ts sdk/packages/llms/src/providers/routing/glm-thinking.ts sdk/packages/llms/src/providers/routing/provider-option-rules.ts sdk/packages/llms/src/providers/routing/provider-options-types.ts sdk/packages/llms/src/providers/routing/provider-options.ts sdk/packages/llms/src/providers/vendors/vertex.ts
```

Result: pass.

This PR rebases on #10659 and preserves its explicit provider routing metadata behavior, including Qwen prompt-cache routes. It should not introduce new provider behavior beyond moving reusable model/route fact matching into the shared helper layer.

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [x] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [x] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A - SDK/provider routing refactor only.

### Additional Notes

This is PR 1 of 3 in the ENG-2019 stack. Review order is #10676 -> #10677 -> #10678.



