### PR TITLE
Add typed model metadata facts ENG-2019

### DIFF
--- a/sdk/packages/llms/src/catalog/types.ts
+++ b/sdk/packages/llms/src/catalog/types.ts
@@ -15,6 +15,8 @@ export {
 	ModelCapabilitySchema,
 	type ModelInfo,
 	ModelInfoSchema,
+	type ModelMetadata,
+	ModelMetadataSchema,
 	type ModelPricing,
 	ModelPricingSchema,
 	type ModelStatus,

--- a/sdk/packages/llms/src/providers/builtins.ts
+++ b/sdk/packages/llms/src/providers/builtins.ts
@@ -194,6 +194,9 @@ function modelInfoToGateway(
 	if (info.releaseDate) {
 		metadata.releaseDate = info.releaseDate;
 	}
+	if (typeof info.metadata?.reasoningDefaultOn === "boolean") {
+		metadata.reasoningDefaultOn = info.metadata.reasoningDefaultOn;
+	}
 	return {
 		id: info.id,
 		name: info.name ?? info.id,

--- a/sdk/packages/llms/src/providers/model-facts.ts
+++ b/sdk/packages/llms/src/providers/model-facts.ts
@@ -153,3 +153,10 @@ export function isMoonshotKimiModelIdFallback(
 export function isDeepSeekFamily(context: GatewayProviderContext): boolean {
 	return normalizedFamily(context).includes("deepseek");
 }
+
+export function getReasoningDefaultOnMetadata(
+	context: GatewayProviderContext,
+): boolean | undefined {
+	const value = context.model.metadata?.reasoningDefaultOn;
+	return typeof value === "boolean" ? value : undefined;
+}

--- a/sdk/packages/shared/src/index.browser.ts
+++ b/sdk/packages/shared/src/index.browser.ts
@@ -112,6 +112,8 @@ export {
 	ModelCapabilitySchema,
 	type ModelInfo,
 	ModelInfoSchema,
+	type ModelMetadata,
+	ModelMetadataSchema,
 	type ModelPricing,
 	ModelPricingSchema,
 	type ModelStatus,

--- a/sdk/packages/shared/src/index.ts
+++ b/sdk/packages/shared/src/index.ts
@@ -126,6 +126,8 @@ export {
 	ModelCapabilitySchema,
 	type ModelInfo,
 	ModelInfoSchema,
+	type ModelMetadata,
+	ModelMetadataSchema,
 	type ModelPricing,
 	ModelPricingSchema,
 	type ModelStatus,

--- a/sdk/packages/shared/src/llms/model-info.ts
+++ b/sdk/packages/shared/src/llms/model-info.ts
@@ -60,6 +60,15 @@ export const ThinkingConfigSchema = z.object({
 
 export type ThinkingConfig = z.infer<typeof ThinkingConfigSchema>;
 
+export const ModelMetadataSchema = z
+	// Keep metadata open for catalog-defined facts while typing routing fields.
+	.object({
+		reasoningDefaultOn: z.boolean().optional(),
+	})
+	.catchall(z.unknown());
+
+export type ModelMetadata = z.infer<typeof ModelMetadataSchema>;
+
 export const ModelInfoSchema = z.object({
 	id: z.string(),
 	name: z.string().optional(),
@@ -79,6 +88,7 @@ export const ModelInfoSchema = z.object({
 	releaseDate: z.string().optional(),
 	deprecationDate: z.string().optional(),
 	family: z.string().optional(),
+	metadata: ModelMetadataSchema.optional(),
 });
 
 export type ModelInfo = z.infer<typeof ModelInfoSchema>;


### PR DESCRIPTION
### Related Issue

**Issue:** ENG-2019

### Description

Adds a typed model metadata channel for stable model behavior facts.

This PR introduces `ModelMetadataSchema` / `ModelMetadata` with `metadata.reasoningDefaultOn?: boolean`, exports that schema/type through the shared and catalog surfaces, and copies the catalog metadata fact into gateway model metadata when available.

This keeps `GatewayModelCapability` semantic: capabilities describe what a model can do. A stable behavior fact like “reasoning defaults on” is not a capability, so it belongs in typed metadata when the model is catalog-known.

This is intentionally narrow:

- It does not add broad Cline-owned model capability maintenance.
- It does not replace `models.dev` or AI SDK as the default/general source of truth.
- It does not add the Ollama routing behavior; that is in the next stacked PR.

Stacked PRs:

1. https://github.com/cline/cline/pull/10676: fact extraction and routing architecture guidance.
2. https://github.com/cline/cline/pull/10677: typed model metadata facts.
3. https://github.com/cline/cline/pull/10678: Ollama default-on reasoning disable routing.

### Test Procedure

Ran the focused routing tests after this split:

```sh
bun test sdk/packages/llms/src/providers/routing/provider-options.test.ts sdk/packages/llms/src/providers/routing/anthropic-compatible.test.ts
```

Result: 82 passing tests.

Ran Biome on the touched files for this PR:

```sh
bunx biome check sdk/packages/llms/src/catalog/types.ts sdk/packages/llms/src/providers/builtins.ts sdk/packages/llms/src/providers/model-facts.ts sdk/packages/shared/src/index.browser.ts sdk/packages/shared/src/index.ts sdk/packages/shared/src/llms/model-info.ts
```

Result: pass.

The main compatibility risk is schema/export surface area. The metadata schema is intentionally open via `.catchall(z.unknown())` so catalog-defined facts can pass through while the fields used by routing remain typed.

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A - SDK metadata/schema plumbing only.

### Additional Notes

This is PR 2 of 3 in the ENG-2019 stack. Review order is #10676 -> #10677 -> #10678.


