### PR TITLE
Route Ollama default-on reasoning disable ENG-2019

### DIFF
--- a/sdk/packages/llms/src/providers/model-facts.ts
+++ b/sdk/packages/llms/src/providers/model-facts.ts
@@ -160,3 +160,25 @@ export function getReasoningDefaultOnMetadata(
 	const value = context.model.metadata?.reasoningDefaultOn;
 	return typeof value === "boolean" ? value : undefined;
 }
+
+export function isOllamaQwen3ModelIdFallback(
+	request: Pick<GatewayStreamRequest, "providerId" | "modelId">,
+): boolean {
+	// Local Ollama models are discovered from /api/tags and often only provide
+	// names such as "qwen3-coder:30b". This fallback is used by
+	// modelReasoningDefaultsOn when no catalog metadata is present.
+	return (
+		request.providerId === "ollama" &&
+		normalizedModelId(request).includes("qwen3")
+	);
+}
+
+export function modelReasoningDefaultsOn(options: {
+	request: Pick<GatewayStreamRequest, "providerId" | "modelId">;
+	context: GatewayProviderContext;
+}): boolean {
+	return (
+		getReasoningDefaultOnMetadata(options.context) ??
+		isOllamaQwen3ModelIdFallback(options.request)
+	);
+}

--- a/sdk/packages/llms/src/providers/routing/provider-option-rules.ts
+++ b/sdk/packages/llms/src/providers/routing/provider-option-rules.ts
@@ -9,6 +9,7 @@ import {
 	isGlmModel,
 	isKimiK26Family as isKimiK26FamilyFact,
 	isMoonshotKimiModelIdFallback,
+	modelReasoningDefaultsOn,
 } from "../model-facts";
 import type {
 	MatchedProviderOptionRule,
@@ -37,6 +38,19 @@ function isDeepSeekModelOrProviderDefault(
 ): boolean {
 	return (
 		isDeepSeekFamily(input.context) || input.request.providerId === "deepseek"
+	);
+}
+
+function isOllamaReasoningDefaultOnDisable(
+	input: ProviderOptionMatchInput,
+): boolean {
+	return (
+		input.request.providerId === "ollama" &&
+		input.request.reasoning?.enabled === false &&
+		modelReasoningDefaultsOn({
+			request: input.request,
+			context: input.context,
+		})
 	);
 }
 
@@ -234,7 +248,8 @@ const deepSeekThinkingRule: ProviderOptionRule = {
 		"DeepSeek models use thinking.type only for explicit reasoning enabled/disabled.",
 	applies: (input) =>
 		input.request.providerId !== "openrouter" &&
-		isDeepSeekModelOrProviderDefault(input),
+		isDeepSeekModelOrProviderDefault(input) &&
+		!isOllamaReasoningDefaultOnDisable(input),
 	suppresses: { genericThinking: true },
 	build: (input) => {
 		const thinkingType = resolveFamilyThinkingType(input, undefined);
@@ -245,6 +260,28 @@ const deepSeekThinkingRule: ProviderOptionRule = {
 					thinkingType,
 				})
 			: undefined;
+	},
+};
+
+const ollamaReasoningDefaultOnDisableRule: ProviderOptionRule = {
+	id: "provider.ollama.reasoning-default-on.disable-none",
+	phase: "provider-reasoning",
+	description:
+		"Ollama models whose reasoning defaults on need reasoningEffort=none when request reasoning is disabled.",
+	applies: isOllamaReasoningDefaultOnDisable,
+	build: (input) => {
+		const bucketOptions = {
+			reasoningEffort: "none",
+			reasoning: { effort: "none" },
+		};
+		return {
+			...buildProviderAndAliasPatch({
+				providerId: input.request.providerId,
+				providerOptionsKey: input.providerOptionsKey,
+				bucketOptions,
+			}),
+			openaiCompatible: bucketOptions,
+		};
 	},
 };
 
@@ -315,6 +352,7 @@ export const PROVIDER_OPTION_RULES: ReadonlyArray<ProviderOptionRule> = [
 	clineReasoningDisabledThinkingRule,
 	kimiK26ThinkingRule,
 	deepSeekThinkingRule,
+	ollamaReasoningDefaultOnDisableRule,
 	nativeZaiNonGlmSuppressionRule,
 	nativeZaiGlmThinkingRule,
 	routedGlmReasoningRule,

--- a/sdk/packages/llms/src/providers/routing/provider-options.test.ts
+++ b/sdk/packages/llms/src/providers/routing/provider-options.test.ts
@@ -18,8 +18,10 @@ type ContextOverrides = {
 	providerId?: string;
 	modelId?: string;
 	family?: string;
+	modelMetadata?: NonNullable<GatewayProviderContext["model"]["metadata"]>;
 	capabilities?: GatewayProviderContext["model"]["capabilities"];
 	metadata?: GatewayProviderContext["provider"]["metadata"];
+	/** Test helper escape hatch for Claude-like models that should not get an auto-injected Anthropic reasoning route. */
 	disableAutoAnthropicRouting?: boolean;
 };
 
@@ -62,6 +64,13 @@ function makeContext(options?: ContextOverrides): GatewayProviderContext {
 							: undefined,
 				}
 			: undefined;
+	const modelMetadata =
+		options?.family || options?.modelMetadata
+			? {
+					...options.modelMetadata,
+					...(options.family ? { family: options.family } : {}),
+				}
+			: undefined;
 	return {
 		provider: {
 			id: providerId,
@@ -77,7 +86,7 @@ function makeContext(options?: ContextOverrides): GatewayProviderContext {
 			name: modelId,
 			providerId,
 			capabilities: options?.capabilities,
-			metadata: options?.family ? { family: options.family } : undefined,
+			metadata: modelMetadata,
 		},
 		config: { providerId },
 	};
@@ -1201,6 +1210,146 @@ describe("composeAiSdkProviderOptions: family/provider thinking patches", () => 
 			expect: [
 				{ bucket: "openai-compatible", lacks: ["thinking"] },
 				{ bucket: "openaiCompatible", lacks: ["thinking"] },
+			],
+		},
+		// Ollama Qwen3: model behavior fact first, documented dynamic fallback second.
+		{
+			name: "ollama metadata reasoningDefaultOn disabled -> reasoningEffort none",
+			request: {
+				providerId: "ollama",
+				modelId: "local-known-reasoner:latest",
+				reasoning: { enabled: false },
+			},
+			context: { modelMetadata: { reasoningDefaultOn: true } },
+			expect: [
+				{
+					bucket: "ollama",
+					has: {
+						reasoningEffort: "none",
+						reasoning: { effort: "none" },
+					},
+				},
+				{
+					bucket: "openaiCompatible",
+					has: {
+						reasoningEffort: "none",
+						reasoning: { effort: "none" },
+					},
+				},
+			],
+		},
+		{
+			name: "ollama qwen3 fallback reasoning disabled -> reasoningEffort none",
+			request: {
+				providerId: "ollama",
+				modelId: "qwen3-coder:30b",
+				reasoning: { enabled: false },
+			},
+			expect: [
+				{
+					bucket: "ollama",
+					has: {
+						reasoningEffort: "none",
+						reasoning: { effort: "none" },
+					},
+				},
+				{
+					bucket: "openaiCompatible",
+					has: {
+						reasoningEffort: "none",
+						reasoning: { effort: "none" },
+					},
+				},
+			],
+		},
+		{
+			name: "ollama qwen3 fallback reasoning enabled -> no disable patch",
+			request: {
+				providerId: "ollama",
+				modelId: "qwen3-coder:30b",
+				reasoning: { enabled: true },
+			},
+			expect: [
+				{ bucket: "ollama", lacks: ["reasoningEffort", "reasoning"] },
+				{ bucket: "openaiCompatible", lacks: ["reasoningEffort", "reasoning"] },
+			],
+		},
+		{
+			name: "ollama qwen3 fallback with unset reasoning -> no disable patch",
+			request: {
+				providerId: "ollama",
+				modelId: "qwen3-coder:30b",
+			},
+			expect: [
+				{ bucket: "ollama", lacks: ["reasoningEffort", "reasoning"] },
+				{ bucket: "openaiCompatible", lacks: ["reasoningEffort", "reasoning"] },
+			],
+		},
+		{
+			name: "ollama metadata reasoningDefaultOn with unset reasoning -> no disable patch",
+			request: {
+				providerId: "ollama",
+				modelId: "local-known-reasoner:latest",
+			},
+			context: { modelMetadata: { reasoningDefaultOn: true } },
+			expect: [
+				{ bucket: "ollama", lacks: ["reasoningEffort", "reasoning"] },
+				{ bucket: "openaiCompatible", lacks: ["reasoningEffort", "reasoning"] },
+			],
+		},
+		{
+			name: "ollama metadata reasoningDefaultOn beats deepseek family thinking disable",
+			request: {
+				providerId: "ollama",
+				modelId: "deepseek-r1:latest",
+				reasoning: { enabled: false },
+			},
+			context: {
+				family: "deepseek",
+				modelMetadata: { reasoningDefaultOn: true },
+			},
+			expect: [
+				{
+					bucket: "ollama",
+					has: {
+						reasoningEffort: "none",
+						reasoning: { effort: "none" },
+					},
+					lacks: ["thinking"],
+				},
+				{
+					bucket: "openaiCompatible",
+					has: {
+						reasoningEffort: "none",
+						reasoning: { effort: "none" },
+					},
+					lacks: ["thinking"],
+				},
+			],
+		},
+		{
+			name: "ollama metadata reasoningDefaultOn false prevents qwen3 fallback",
+			request: {
+				providerId: "ollama",
+				modelId: "qwen3-coder:30b",
+				reasoning: { enabled: false },
+			},
+			context: { modelMetadata: { reasoningDefaultOn: false } },
+			expect: [
+				{ bucket: "ollama", lacks: ["reasoningEffort", "reasoning"] },
+				{ bucket: "openaiCompatible", lacks: ["reasoningEffort", "reasoning"] },
+			],
+		},
+		{
+			name: "ollama non-default reasoning disabled -> no special disable patch",
+			request: {
+				providerId: "ollama",
+				modelId: "llama3.1:8b",
+				reasoning: { enabled: false },
+			},
+			expect: [
+				{ bucket: "ollama", lacks: ["reasoningEffort", "reasoning"] },
+				{ bucket: "openaiCompatible", lacks: ["reasoningEffort", "reasoning"] },
 			],
 		},
 	]);


### PR DESCRIPTION
### Related Issue

**Issue:** ENG-2019

### Description

Adds the Ollama provider-option routing rule for models whose reasoning/thinking defaults on.

When the request explicitly disables reasoning:

```ts
reasoning: { enabled: false }
```

and the model is known to default reasoning on, the routing layer emits the Ollama/OpenAI-compatible disable shape:

```ts
{
  reasoningEffort: "none",
  reasoning: { effort: "none" }
}
```

The rule uses a metadata-first decision flow:

- Prefer typed catalog/gateway metadata: `metadata.reasoningDefaultOn === true`.
- For local/dynamic Ollama models where metadata is often unavailable, use the documented fallback: Ollama model IDs containing `qwen3`.
- Explicit `metadata.reasoningDefaultOn === false` prevents the fallback.

This keeps the provider-option rule table as the codec/policy registry: it decides how abstract request intent maps to provider wire format. It avoids pushing this behavior into capabilities or scattered provider code.

Stacked PRs:

1. https://github.com/cline/cline/pull/10676: fact extraction and routing architecture guidance.
2. https://github.com/cline/cline/pull/10677: typed model metadata facts.
3. https://github.com/cline/cline/pull/10678: Ollama default-on reasoning disable routing.

### Test Procedure

Ran the focused routing tests after this split:

```sh
bun test sdk/packages/llms/src/providers/routing/provider-options.test.ts sdk/packages/llms/src/providers/routing/anthropic-compatible.test.ts
```

Result: 90 passing tests.

Ran Biome on the touched files for this PR:

```sh
bunx biome check sdk/packages/llms/src/providers/model-facts.ts sdk/packages/llms/src/providers/routing/provider-option-rules.ts sdk/packages/llms/src/providers/routing/provider-options.test.ts
```

Result: pass.

Also ran:

```sh
git diff --check
```

Result: pass.

The test matrix covers:

- metadata-driven Ollama disable
- Qwen3 fallback disable
- `reasoning.enabled: true` does not trigger disable
- Qwen3 fallback with unset `reasoning` does not trigger disable
- metadata-driven unset `reasoning` does not trigger disable
- metadata `false` prevents fallback
- non-default Ollama models do not get the patch
- Ollama default-on disable owns the codec instead of also emitting DeepSeek `thinking.type`

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A - SDK/provider-option routing behavior only.

### Additional Notes

This is PR 3 of 3 in the ENG-2019 stack. Review order is #10676 -> #10677 -> #10678.


