### PR TITLE
feat(sdk): add auth and provider-configured telemetry to SDK TUI onboarding

### DIFF
--- a/sdk/apps/cli/src/tui/views/onboarding/auth.test.ts
+++ b/sdk/apps/cli/src/tui/views/onboarding/auth.test.ts
@@ -1,0 +1,150 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const hoisted = vi.hoisted(() => ({
+	loginLocalProvider: vi.fn(),
+	startClineDeviceAuth: vi.fn(),
+	completeClineDeviceAuth: vi.fn(),
+	saveLocalProviderOAuthCredentials: vi.fn(),
+	openMock: vi.fn(() => Promise.resolve()),
+}));
+
+vi.mock("@cline/core", () => ({
+	loginLocalProvider: hoisted.loginLocalProvider,
+	startClineDeviceAuth: hoisted.startClineDeviceAuth,
+	completeClineDeviceAuth: hoisted.completeClineDeviceAuth,
+	saveLocalProviderOAuthCredentials: hoisted.saveLocalProviderOAuthCredentials,
+	ProviderSettingsManager: class {},
+}));
+
+vi.mock("@cline/shared", () => ({
+	getClineEnvironmentConfig: () => ({ apiBaseUrl: "https://api.example" }),
+}));
+
+vi.mock("open", () => ({ default: hoisted.openMock }));
+
+import { runDeviceCodeAuthFlow, runOAuthAuthFlow } from "./auth";
+
+// Minimal stand-in for a telemetry service. The auth helpers must forward this
+// reference verbatim into core; we only need referential equality, so the
+// concrete shape doesn't matter for these tests.
+const fakeTelemetry = { __id: "fake-telemetry" } as unknown as Parameters<
+	typeof runOAuthAuthFlow
+>[0]["telemetry"];
+
+function makeManager() {
+	return {
+		getProviderSettings: vi.fn(() => undefined),
+	} as unknown as Parameters<
+		typeof runOAuthAuthFlow
+	>[0]["providerSettingsManager"];
+}
+
+describe("onboarding auth telemetry forwarding", () => {
+	beforeEach(() => {
+		hoisted.loginLocalProvider.mockReset();
+		hoisted.startClineDeviceAuth.mockReset();
+		hoisted.completeClineDeviceAuth.mockReset();
+		hoisted.saveLocalProviderOAuthCredentials.mockReset();
+		hoisted.openMock.mockReset();
+		hoisted.openMock.mockResolvedValue(undefined);
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("forwards the CLI telemetry service into loginLocalProvider", async () => {
+		// Resolve the credentials promise so the onComplete branch fires, but the
+		// test's assertion is on the telemetry argument passed to core.
+		hoisted.loginLocalProvider.mockResolvedValueOnce({
+			access: "a",
+			refresh: "r",
+			expires: 0,
+		});
+
+		const onComplete = vi.fn();
+		runOAuthAuthFlow({
+			providerId: "openai-codex",
+			providerSettingsManager: makeManager(),
+			isAborted: () => false,
+			setStatus: vi.fn(),
+			setAuthUrl: vi.fn(),
+			setError: vi.fn(),
+			onComplete,
+			telemetry: fakeTelemetry,
+		});
+
+		// Flush the .then chain so we can assert on the post-login callbacks too.
+		await Promise.resolve();
+		await Promise.resolve();
+
+		expect(hoisted.loginLocalProvider).toHaveBeenCalledTimes(1);
+		const [providerArg, , , telemetryArg] =
+			hoisted.loginLocalProvider.mock.calls[0];
+		expect(providerArg).toBe("openai-codex");
+		// Identity, not deep-equal — we are validating the exact reference flows
+		// through so opt-out / common metadata stays consistent.
+		expect(telemetryArg).toBe(fakeTelemetry);
+	});
+
+	it("does not pass telemetry when none is provided (back-compat)", () => {
+		hoisted.loginLocalProvider.mockResolvedValueOnce({
+			access: "a",
+			refresh: "r",
+			expires: 0,
+		});
+
+		runOAuthAuthFlow({
+			providerId: "openai-codex",
+			providerSettingsManager: makeManager(),
+			isAborted: () => false,
+			setStatus: vi.fn(),
+			setAuthUrl: vi.fn(),
+			setError: vi.fn(),
+			onComplete: vi.fn(),
+		});
+
+		const [, , , telemetryArg] = hoisted.loginLocalProvider.mock.calls[0];
+		expect(telemetryArg).toBeUndefined();
+	});
+
+	it("forwards telemetry into completeClineDeviceAuth for the device-code flow", async () => {
+		hoisted.startClineDeviceAuth.mockResolvedValueOnce({
+			deviceCode: "dc",
+			userCode: "uc",
+			verificationUri: "https://verify",
+			verificationUriComplete: "https://verify?user_code=uc",
+			expiresInSeconds: 600,
+			pollIntervalSeconds: 5,
+		});
+		hoisted.completeClineDeviceAuth.mockResolvedValueOnce({
+			access: "a",
+			refresh: "r",
+			expires: 0,
+		});
+
+		runDeviceCodeAuthFlow({
+			providerId: "cline",
+			providerSettingsManager: makeManager(),
+			isAborted: () => false,
+			setUserCode: vi.fn(),
+			setVerifyUrl: vi.fn(),
+			setStatus: vi.fn(),
+			setError: vi.fn(),
+			onComplete: vi.fn(),
+			telemetry: fakeTelemetry,
+		});
+
+		await Promise.resolve();
+		await Promise.resolve();
+		await Promise.resolve();
+
+		expect(hoisted.completeClineDeviceAuth).toHaveBeenCalledTimes(1);
+		const [opts] = hoisted.completeClineDeviceAuth.mock.calls[0];
+		expect(opts.telemetry).toBe(fakeTelemetry);
+		// We do NOT forward telemetry to startClineDeviceAuth — auth_started is
+		// emitted by completeClineDeviceAuth, so passing telemetry to the start
+		// helper would double-emit the event.
+		expect(hoisted.startClineDeviceAuth).toHaveBeenCalledWith();
+	});
+});

--- a/sdk/apps/cli/src/tui/views/onboarding/auth.ts
+++ b/sdk/apps/cli/src/tui/views/onboarding/auth.ts
@@ -1,5 +1,6 @@
 import {
 	completeClineDeviceAuth,
+	type ITelemetryService,
 	loginLocalProvider,
 	type ProviderSettingsManager,
 	saveLocalProviderOAuthCredentials,
@@ -28,22 +29,28 @@ export function runOAuthAuthFlow(input: {
 	setAuthUrl: (url: string) => void;
 	setError: (error: string) => void;
 	onComplete: (providerId: OnboardingOAuthProviderId) => void;
+	telemetry?: ITelemetryService;
 }): void {
 	const existing = input.providerSettingsManager.getProviderSettings(
 		input.providerId,
 	);
 
-	loginLocalProvider(input.providerId, existing, (url: string) => {
-		input.setAuthUrl(url);
-		input.setStatus("Waiting for sign-in...");
-		try {
-			void open(url, { wait: false }).catch(() => {
+	loginLocalProvider(
+		input.providerId,
+		existing,
+		(url: string) => {
+			input.setAuthUrl(url);
+			input.setStatus("Waiting for sign-in...");
+			try {
+				void open(url, { wait: false }).catch(() => {
+					input.setStatus("Could not open browser. Visit the URL below.");
+				});
+			} catch {
 				input.setStatus("Could not open browser. Visit the URL below.");
-			});
-		} catch {
-			input.setStatus("Could not open browser. Visit the URL below.");
-		}
-	})
+			}
+		},
+		input.telemetry,
+	)
 		.then((credentials) => {
 			if (input.isAborted()) return;
 			saveLocalProviderOAuthCredentials(
@@ -70,6 +77,7 @@ export function runDeviceCodeAuthFlow(input: {
 	setStatus: (status: string) => void;
 	setError: (error: string) => void;
 	onComplete: (providerId: OnboardingOAuthProviderId) => void;
+	telemetry?: ITelemetryService;
 }): void {
 	const existing = input.providerSettingsManager.getProviderSettings(
 		input.providerId,
@@ -77,6 +85,10 @@ export function runDeviceCodeAuthFlow(input: {
 	const apiBaseUrl =
 		existing?.baseUrl?.trim() || getClineEnvironmentConfig().apiBaseUrl;
 
+	// `startClineDeviceAuth` only requests the user/device code pair; the
+	// `auth_started` telemetry event is emitted by `completeClineDeviceAuth`
+	// (which owns the actual login lifecycle), so we intentionally do NOT
+	// pass telemetry into `startClineDeviceAuth` here.
 	startClineDeviceAuth()
 		.then((result) => {
 			if (input.isAborted()) return;
@@ -92,6 +104,7 @@ export function runDeviceCodeAuthFlow(input: {
 				pollIntervalSeconds: result.pollIntervalSeconds,
 				apiBaseUrl,
 				provider: input.providerId,
+				telemetry: input.telemetry,
 			})
 				.then((credentials) => {
 					if (input.isAborted()) return;

--- a/sdk/apps/cli/src/tui/views/onboarding/controller.ts
+++ b/sdk/apps/cli/src/tui/views/onboarding/controller.ts
@@ -1,4 +1,5 @@
 import {
+	captureProviderConfigured,
 	getLocalProviderModels,
 	getProviderConfigFields,
 	listLocalProviders,
@@ -15,6 +16,7 @@ import {
 	isOpenAICodexCliProvider,
 } from "../../../utils/codex-cli";
 import { getPersistedProviderApiKey } from "../../../utils/provider-auth";
+import { getCliTelemetryService } from "../../../utils/telemetry";
 import {
 	buildClineModelEntries,
 	type ClineModelPickerEntry,
@@ -282,6 +284,7 @@ export function useOnboardingController(props: OnboardingControllerProps) {
 				setStatus: setDeviceStatus,
 				setError: setDeviceError,
 				onComplete: transitionToModelPicker,
+				telemetry: getCliTelemetryService(),
 			});
 		},
 		[providerSettingsManager, transitionToModelPicker],
@@ -307,6 +310,7 @@ export function useOnboardingController(props: OnboardingControllerProps) {
 				setAuthUrl,
 				setError: setAuthError,
 				onComplete: transitionToModelPicker,
+				telemetry: getCliTelemetryService(),
 			});
 		},
 		[
@@ -393,6 +397,12 @@ export function useOnboardingController(props: OnboardingControllerProps) {
 			apiKey: byoFields.apiKey ? byoApiKey.trim() : undefined,
 			baseUrl: byoFields.baseUrl ? byoBaseUrl.trim() : undefined,
 		});
+		// Emit a single `user.provider_configured` event mirroring the
+		// `{ provider }` payload shape used by the auth funnel. The save above
+		// is synchronous and infallible, so there's no start/fail counterpart;
+		// invalid credentials surface later as `task.provider_api_error` on
+		// the first real API call.
+		captureProviderConfigured(getCliTelemetryService(), activeProviderId);
 		transitionToModelPicker(activeProviderId);
 	}, [
 		byoApiKey,

--- a/sdk/packages/core/src/index.ts
+++ b/sdk/packages/core/src/index.ts
@@ -490,6 +490,7 @@ export {
 	captureMentionUsed,
 	captureModeSwitch,
 	captureProviderApiError,
+	captureProviderConfigured,
 	captureSkillUsed,
 	captureSubagentExecution,
 	captureTaskCompleted,

--- a/sdk/packages/core/src/services/providers/local-provider-service.ts
+++ b/sdk/packages/core/src/services/providers/local-provider-service.ts
@@ -2,6 +2,7 @@ import * as LlmsModels from "@cline/llms";
 import {
 	type AddProviderActionRequest,
 	getClineEnvironmentConfig,
+	type ITelemetryService,
 	isOAuthProviderId,
 	type OAuthProviderId,
 	type ProviderCapability,
@@ -729,6 +730,7 @@ export async function loginLocalProvider(
 	providerId: OAuthProviderId,
 	existing: ProviderSettings | undefined,
 	openUrl: (url: string) => void,
+	telemetry?: ITelemetryService,
 ): Promise<{
 	access: string;
 	refresh: string;
@@ -749,11 +751,18 @@ export async function loginLocalProvider(
 				existing?.baseUrl?.trim() || getClineEnvironmentConfig().apiBaseUrl,
 			useWorkOSDeviceAuth: true,
 			callbacks,
+			telemetry,
 		});
 	}
 	if (providerId === "oca")
-		return loginOcaOAuth({ mode: existing?.oca?.mode, callbacks });
-	return loginOpenAICodex(callbacks);
+		return loginOcaOAuth({ mode: existing?.oca?.mode, callbacks, telemetry });
+	return loginOpenAICodex({
+		onAuth: callbacks.onAuth,
+		onPrompt: callbacks.onPrompt,
+		onProgress: callbacks.onProgress,
+		onManualCodeInput: callbacks.onManualCodeInput,
+		telemetry,
+	});
 }
 
 export function saveLocalProviderOAuthCredentials(

--- a/sdk/packages/core/src/services/telemetry/core-events.test.ts
+++ b/sdk/packages/core/src/services/telemetry/core-events.test.ts
@@ -5,6 +5,7 @@ import {
 	captureCompactionExecuted,
 	captureCompactionSkipped,
 	captureExtensionActivated,
+	captureProviderConfigured,
 	captureTelemetryOptOut,
 	captureWorkspaceInitError,
 	captureWorkspaceInitialized,
@@ -71,6 +72,37 @@ describe("captureTelemetryOptOut", () => {
 			"user.opt_out",
 			undefined,
 		);
+	});
+});
+
+describe("captureProviderConfigured", () => {
+	test("emits user.provider_configured with the provider id as a normal (opt-out-respecting) event", () => {
+		const stub = createTelemetryStub();
+		captureProviderConfigured(stub.telemetry, "anthropic");
+		expect(stub.capture).toHaveBeenCalledTimes(1);
+		// Must NOT be captureRequired — the BYO configure step is not an
+		// essential lifecycle event and should respect telemetry opt-out.
+		expect(stub.captureRequired).not.toHaveBeenCalled();
+		const { event, properties } = captureCallAt(stub, 0);
+		expect(event).toBe("user.provider_configured");
+		// Payload shape mirrors `captureAuthSucceeded`: `{ provider }`,
+		// nothing else. Keep this strict so we don't accidentally leak
+		// `apiKey` / `baseUrl` / model identifiers into the funnel.
+		expect(properties).toEqual({ provider: "anthropic" });
+	});
+
+	test("emits with provider=undefined when none is supplied", () => {
+		const stub = createTelemetryStub();
+		captureProviderConfigured(stub.telemetry);
+		const { event, properties } = captureCallAt(stub, 0);
+		expect(event).toBe("user.provider_configured");
+		expect(properties).toEqual({ provider: undefined });
+	});
+
+	test("no-ops when telemetry is undefined", () => {
+		expect(() =>
+			captureProviderConfigured(undefined, "openrouter"),
+		).not.toThrow();
 	});
 });
 

--- a/sdk/packages/core/src/services/telemetry/core-events.test.ts
+++ b/sdk/packages/core/src/services/telemetry/core-events.test.ts
@@ -537,6 +537,7 @@ describe("telemetry policy: helpers respect telemetry opt-out", () => {
 			context: "search_codebase",
 			resolution_type: "fallback_to_primary",
 		});
+		captureProviderConfigured(service, "test-provider");
 		captureCompactionExecuted(service, {
 			ulid: "ulid-1",
 			strategy: "basic",

--- a/sdk/packages/core/src/services/telemetry/core-events.test.ts
+++ b/sdk/packages/core/src/services/telemetry/core-events.test.ts
@@ -569,6 +569,7 @@ describe("telemetry policy: helpers respect telemetry opt-out", () => {
 			"workspace.initialized",
 			"workspace.init_error",
 			"workspace.path_resolved",
+			"user.provider_configured",
 			"task.compaction_executed",
 			"task.compaction_skipped",
 		]);

--- a/sdk/packages/core/src/services/telemetry/core-events.ts
+++ b/sdk/packages/core/src/services/telemetry/core-events.ts
@@ -38,6 +38,7 @@ export const CORE_TELEMETRY_EVENTS = {
 		AUTH_SUCCEEDED: "user.auth_succeeded",
 		AUTH_FAILED: "user.auth_failed",
 		AUTH_LOGGED_OUT: "user.auth_logged_out",
+		PROVIDER_CONFIGURED: "user.provider_configured",
 		TELEMETRY_OPT_OUT: "user.opt_out",
 	},
 	TASK: {
@@ -219,6 +220,23 @@ export function captureAuthLoggedOut(
 		provider,
 		reason,
 	});
+}
+
+/**
+ * Fires when the user finishes configuring a "bring your own provider"
+ * (API-key based) provider during onboarding or via settings.
+ *
+ * Unlike the OAuth/device-code `captureAuth*` events, the configure step is a
+ * synchronous local credential save with no network roundtrip, so there is no
+ * start/fail counterpart — the credential is validated lazily on the first
+ * subsequent API call. Mirrors the `{ provider }` payload shape of
+ * {@link captureAuthSucceeded} for funnel consistency.
+ */
+export function captureProviderConfigured(
+	telemetry: ITelemetryService | undefined,
+	provider?: string,
+): void {
+	emit(telemetry, CORE_TELEMETRY_EVENTS.USER.PROVIDER_CONFIGURED, { provider });
 }
 
 export function captureTelemetryOptOut(


### PR DESCRIPTION
### Related Issue

**Issue:** ENG-2018

### Description

The SDK TUI onboarding login page (at `sdk/apps/cli/src/tui/views/onboarding/`) was not emitting any telemetry for login events. This PR wires the existing standardized auth events (`user.auth_started`, `user.auth_succeeded`, `user.auth_failed`) and a new `user.provider_configured` event into the SDK TUI onboarding flows.

**OAuth / device-code login (Cline, OpenAI Codex, OCA):**
- `runOAuthAuthFlow()` and `runDeviceCodeAuthFlow()` now accept an optional telemetry service.
- `useOnboardingController()` passes `getCliTelemetryService()` into these helpers so events use existing CLI metadata and respect the user's telemetry opt-out setting.
- Auth events are fired from the underlying `loginLocalProvider` core helpers — no new event names, no UI changes.

**BYO API key (OpenAI, Anthropic, OpenRouter, etc.):**
- Adds a new `user.provider_configured` core event emitted when `saveByoConfig()` successfully persists an API key. This is a one-shot "save succeeded" signal; invalid keys surface later as the existing `task.provider_api_error`.

**Debug tooling:**
- Adds `CLINE_TELEMETRY_DEBUG_LOG=/path/to/file` env var support to the CLI telemetry service. When set, every captured event is appended to the file via the existing `TelemetryLoggerSink` adapter — independent of Ink's stdout rendering so events are visible while the TUI is live. Off by default, no production behavior change.

**No changes to the legacy `cli/` React Ink CLI.**

### Test Procedure

1. **Unit tests** — new focused tests confirm:
   - `user.provider_configured` payload shape, `provider=undefined` fallback, and `telemetry=undefined` no-op.
   - SDK TUI auth path passes the telemetry service through to `loginLocalProvider`.

2. **Interactive verification** — ran the SDK TUI in dev mode with the debug file logger and confirmed events appear on screen:
   ```bash
   cd sdk/apps/cli
   CLINE_FORCE_ONBOARDING=1 CLINE_TELEMETRY_DEBUG_LOG=/tmp/tel.log bun run dev
   tail -f /tmp/tel.log
   ```
   - OAuth flow (Cline): `user.auth_started` → `user.auth_succeeded`/`user.auth_failed`
   - BYO API key save: `user.provider_configured { "provider": "..." }`

3. **Typecheck** — `tsc --noEmit` passes clean on both `@cline/core` and `apps/cli`.

4. **Existing behavior** — telemetry opt-out not affected (events route through `capture()`, not `captureRequired()`); Esc/cancel does not synthesize spurious failure events.

### Type of Change

-   [x] ✨ New feature (non-breaking change which adds functionality)

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Terminal output from interactive test run:

```
2026-05-12T23:41:02.115Z [log] Telemetry event: user.auth_started {"provider":"cline"}
2026-05-12T23:41:08.832Z [log] Telemetry event: user.auth_succeeded {"provider":"cline"}
2026-05-12T23:44:11.201Z [log] Telemetry event: user.provider_configured {"provider":"openai"}
```

### Additional Notes

`user.provider_configured` is SDK-TUI-only. The VSCode extension uses `user.onboarding_progress { completed: true }` for the equivalent BYO flow — pre-existing inconsistency across surfaces, not introduced here.
