### PR TITLE
fix(core): avoid duplicating aggregate session usage

### DIFF
--- a/sdk/packages/core/src/services/session-data.test.ts
+++ b/sdk/packages/core/src/services/session-data.test.ts
@@ -2,6 +2,7 @@ import type { MessageWithMetadata } from "@cline/llms";
 import type { AgentResult } from "@cline/shared";
 import { describe, expect, it } from "vitest";
 import { withLatestAssistantTurnMetadata } from "./session-data";
+import { summarizeUsageFromMessages } from "./usage";
 
 type LegacyStoredMessage = MessageWithMetadata & {
 	providerId?: string;
@@ -217,6 +218,69 @@ describe("withLatestAssistantTurnMetadata", () => {
 				cacheWriteTokens: 8,
 				cost: 0.09,
 			},
+		});
+	});
+
+	it("does not attach aggregate usage to an empty terminal assistant when per-turn metrics already exist", () => {
+		const persisted = withLatestAssistantTurnMetadata(
+			[
+				{ role: "user", content: "do something" },
+				{
+					role: "assistant",
+					content: [{ type: "tool_use", id: "1", name: "bash", input: {} }],
+					metrics: {
+						inputTokens: 10,
+						outputTokens: 3,
+						cacheReadTokens: 2,
+						cacheWriteTokens: 1,
+						cost: 1,
+					},
+				},
+				{
+					role: "user",
+					content: [{ type: "tool_result", tool_use_id: "1", content: "done" }],
+				},
+				{
+					role: "assistant",
+					content: [{ type: "text", text: "partial answer" }],
+					metrics: {
+						inputTokens: 20,
+						outputTokens: 7,
+						cacheReadTokens: 4,
+						cacheWriteTokens: 2,
+						cost: 2,
+					},
+				},
+				{ role: "assistant", content: [] },
+			] as MessageWithMetadata[],
+			createResult({
+				usage: {
+					inputTokens: 30,
+					outputTokens: 10,
+					cacheReadTokens: 6,
+					cacheWriteTokens: 3,
+					totalCost: 3,
+				},
+			}),
+			[],
+		);
+
+		expect(persisted[4]).toMatchObject({
+			role: "assistant",
+			content: [],
+			modelInfo: {
+				id: "claude-sonnet-4-6",
+				provider: "anthropic",
+				family: "claude-sonnet-4",
+			},
+		});
+		expect(persisted[4]).not.toHaveProperty("metrics");
+		expect(summarizeUsageFromMessages(persisted)).toEqual({
+			inputTokens: 30,
+			outputTokens: 10,
+			cacheReadTokens: 6,
+			cacheWriteTokens: 3,
+			totalCost: 3,
 		});
 	});
 });

--- a/sdk/packages/core/src/services/session-data.ts
+++ b/sdk/packages/core/src/services/session-data.ts
@@ -154,14 +154,21 @@ export function withLatestAssistantTurnMetadata(
 	}
 
 	const lastAssistantIndex = assistantIndexes[assistantIndexes.length - 1];
+	const hasAssistantTurnMetrics = assistantIndexes.some(
+		(index) => next[index]?.metrics,
+	);
 	for (const targetIndex of assistantIndexes) {
 		const target = next[targetIndex];
 		// Use per-turn metrics already stamped on the message if available.
 		// Only fall back to result.usage (total run usage) for the terminal
-		// assistant message when no per-turn metrics are present, to avoid
-		// attaching session totals to intermediate turn messages.
+		// assistant message when this run has no per-turn metrics, to avoid
+		// attaching session totals to terminal bookkeeping messages.
 		let metrics = target.metrics;
-		if (!metrics && targetIndex === lastAssistantIndex) {
+		if (
+			!metrics &&
+			targetIndex === lastAssistantIndex &&
+			!hasAssistantTurnMetrics
+		) {
 			const usage = result.usage;
 			metrics = {
 				inputTokens: usage.inputTokens,


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

### Description

This PR fixes a session persistence bug where aggregate run usage can be stored as if it were usage for another assistant/model turn.

There are two different usage shapes involved:

- `message.metrics`: usage for one persisted assistant message / model turn.
- `result.usage`: aggregate usage for the whole run returned by the agent.

`withLatestAssistantTurnMetadata()` had a fallback that copied `result.usage` onto the terminal assistant message whenever that terminal message had no metrics. That fallback is still useful for legacy/non-agent-loop paths where no assistant message has per-turn metrics.

The broken shape happens on failed/interrupted runs where the agent loop has already stamped correct per-turn `message.metrics` onto real assistant messages, then the run ends with a terminal empty assistant message:

```txt
assistant turn 1 metrics: cost A
assistant turn 2 metrics: cost B
empty terminal assistant: no metrics
result.usage.totalCost: A + B
```

Before this PR, persistence copied `result.usage` onto the empty terminal assistant, producing:

```txt
assistant turn 1 metrics: cost A
assistant turn 2 metrics: cost B
empty terminal assistant metrics: cost A + B
```

Any consumer that sums `message.metrics.cost` then gets:

```txt
A + B + (A + B) = 2x the real run cost
```

This PR changes the fallback condition so aggregate `result.usage` is only copied to the terminal assistant message when the current run has no assistant per-turn metrics at all. If any assistant message in the current run already has metrics, the terminal bookkeeping message does not receive aggregate usage.

The legacy fallback remains intact for paths where no per-turn metrics exist.

### Test Procedure

#### Targeted regression test

Added a test for the failed-run persistence shape:

```txt
assistant A metrics: cost 1
assistant B metrics: cost 2
final empty assistant: no metrics
result.usage.totalCost: 3
```

Expected patched behavior:

```txt
final empty assistant metrics: none
summed message usage: 3, not 6
```

The existing legacy fallback test still verifies that `result.usage` is attached once when no assistant messages have per-turn metrics.

#### Direct old-code versus patched-code live verification

I verified the old behavior by checking out the PR base commit, `origin/main` at `0e1a41133`, building the SDK, running real OpenRouter inference, and passing the resulting messages through the old `withLatestAssistantTurnMetadata()` and `summarizeUsageFromMessages()`.

Then I switched back to this PR branch and fed the same saved live turn data through the patched persistence helper.

Commands used for the old-code check included:

```txt
git switch --detach origin/main
bun run build:sdk
# run real OpenRouter inference and old persistence helper
```

Then for the patched check:

```txt
git switch arafatkatze/fix-session-aggregate-metrics
# feed the same saved live turn data through patched persistence helper
```

Actual results:

| Model | Turn Costs | Aggregate Cost | Actual Old Persisted Sum | Actual New Persisted Sum |
|---|---:|---:|---:|---:|
| `anthropic/claude-sonnet-4.5` | `0.000108`, `0.000966` | `0.001074` | `0.002148` | `0.001074` |
| `openai/gpt-4o-mini` | `0.0000042`, `0.00003075` | `0.00003495` | `0.0000699` | `0.00003495` |
| `google/gemini-2.5-flash-lite` | `0.0000015`, `0.0000162` | `0.0000177` | `0.0000354` | `0.0000177` |
| `meta-llama/llama-3.3-70b-instruct` | `0.000004175`, `0.00002488` | `0.000029055` | `0.00005811` | `0.000029055` |
| `deepseek/deepseek-chat-v3.1` | `0.00000995`, `0.00003475` | `0.0000447` | `0.0000894` | `0.0000447` |

For Sonnet 4.5 on the old code, the final empty assistant actually received aggregate metrics:

```json
{
  "inputTokens": 68,
  "outputTokens": 58,
  "cacheReadTokens": 0,
  "cacheWriteTokens": 0,
  "cost": 0.0010739999999999999
}
```

That made the old message-level sum exactly double:

```txt
0.000108 + 0.000966 + 0.001074 = 0.002148
```

On this PR branch, with the same saved live turn data, the final empty assistant metrics were:

```txt
null
```

and the message-level sum stayed equal to the aggregate:

```txt
0.000108 + 0.000966 = 0.001074
```

#### Validation commands

- `bun -F @cline/core test:unit src/services/session-data.test.ts src/services/usage.test.ts`
- `bun -F @cline/core typecheck`
- `bun run build:sdk`
- `bun -F @cline/core test:unit`
- `bun biome check packages/core/src/services/session-data.ts packages/core/src/services/session-data.test.ts --diagnostic-level=error`
- `bun run test:unit`
- `git diff --check`

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A. Backend/session persistence change only.

### Additional Notes

This is intentionally separate from the OpenRouter cost-normalization PR. That PR fixes provider usage normalization in `@cline/llms`; this PR fixes core session persistence so aggregate run usage is not stored as another assistant turn metric.
