### PR TITLE
Route GLM thinking via provider metadata ENG-2019

### DIFF
--- a/sdk/packages/llms/AGENTS.md
+++ b/sdk/packages/llms/AGENTS.md
@@ -15,6 +15,11 @@ alwaysApply: true
   quirks, default behavior, or wire-format details.
 - Stable, reliable known-model facts belong in typed `ModelInfo.metadata`
   helpers or `src/providers/model-facts.ts`.
+- Stable provider routing facts belong in `GatewayProviderMetadata.routing`
+  and the relevant builtin provider manifest. For example, if a native
+  provider uses a known reasoning wire format for a model route, add a typed
+  `GatewayReasoningFormat` value and route metadata instead of matching that
+  provider id directly in a rule predicate.
 - Provider wire-format encoding belongs in `PROVIDER_OPTION_RULES` and codec
   helpers under `src/providers/routing`.
 - Local or dynamic provider fallbacks, such as Ollama or routed model-id

--- a/sdk/packages/llms/CHANGELOG.md
+++ b/sdk/packages/llms/CHANGELOG.md
@@ -3,3 +3,4 @@
 ## Next Release
 
 - Supports Bedrock bearer API keys, direct IAM credentials, AWS profiles, and the default AWS SDK credential chain
+- Routes Z.AI GLM thinking through provider metadata while preserving generic thinking suppression for non-GLM Z.AI custom models

--- a/sdk/packages/llms/src/providers/builtins.test.ts
+++ b/sdk/packages/llms/src/providers/builtins.test.ts
@@ -103,4 +103,24 @@ describe("built-in provider metadata", () => {
 			}),
 		);
 	});
+
+	it("routes native Z.AI providers through GLM thinking metadata", async () => {
+		for (const providerId of ["zai", "zai-coding-plan"] as const) {
+			await expect(getProvider(providerId)).resolves.toMatchObject({
+				metadata: {
+					routing: {
+						reasoning: {
+							format: "glm-thinking",
+						},
+					},
+				},
+			});
+
+			const models = Object.values(await getModelsForProvider(providerId));
+			expect(models.length).toBeGreaterThan(0);
+			for (const model of models) {
+				expect(model.family?.startsWith("glm")).toBe(true);
+			}
+		}
+	});
 });

--- a/sdk/packages/llms/src/providers/builtins.ts
+++ b/sdk/packages/llms/src/providers/builtins.ts
@@ -21,6 +21,7 @@ import {
 	ANTHROPIC_ROUTING_METADATA,
 	QWEN_CACHE_ROUTING_METADATA,
 } from "./routing/anthropic-compatible";
+import { GLM_THINKING_ROUTING_METADATA } from "./routing/glm-thinking";
 
 export const DEFAULT_INTERNAL_OCA_BASE_URL =
 	"https://code-internal.aiservice.us-chicago-1.oci.oraclecloud.com/20250206/app/litellm";
@@ -507,6 +508,7 @@ const OPENAI_COMPATIBLE_SPECS: BuiltinSpec[] = [
 		apiKeyEnv: ["ZHIPU_API_KEY"],
 		modelsProviderId: "zai",
 		defaults: { baseUrl: "https://api.z.ai/api/paas/v4" },
+		metadata: GLM_THINKING_ROUTING_METADATA,
 	},
 	{
 		id: "zai-coding-plan",
@@ -518,6 +520,7 @@ const OPENAI_COMPATIBLE_SPECS: BuiltinSpec[] = [
 		apiKeyEnv: ["ZHIPU_API_KEY"],
 		modelsProviderId: "zai-coding-plan",
 		defaults: { baseUrl: "https://api.z.ai/api/coding/paas/v4" },
+		metadata: GLM_THINKING_ROUTING_METADATA,
 	},
 	{
 		id: "moonshot",

--- a/sdk/packages/llms/src/providers/gateway.test.ts
+++ b/sdk/packages/llms/src/providers/gateway.test.ts
@@ -2712,56 +2712,6 @@ describe("sdk-gateway", () => {
 		);
 	});
 
-	it("does not apply Z.AI GLM thinking controls to non-GLM native Z.AI models", async () => {
-		streamTextSpy.mockReturnValue({
-			fullStream: makeStreamParts([
-				{ type: "finish", usage: { inputTokens: 1, outputTokens: 1 } },
-			]),
-		});
-
-		const gateway = createGateway({
-			providerConfigs: [
-				{
-					providerId: "zai",
-					apiKey: "zai-key",
-					models: [
-						{
-							id: "zai-other-model",
-							name: "Non GLM Model",
-							metadata: {
-								family: "other",
-							},
-						},
-					],
-				},
-			],
-		});
-
-		await collect(
-			await gateway.stream({
-				providerId: "zai",
-				modelId: "zai-other-model",
-				messages: baseMessages,
-				reasoning: {
-					enabled: true,
-				},
-			}),
-		);
-
-		expect(streamTextSpy).toHaveBeenCalledWith(
-			expect.objectContaining({
-				providerOptions: expect.objectContaining({
-					zai: expect.not.objectContaining({
-						thinking: expect.anything(),
-					}),
-					openaiCompatible: expect.not.objectContaining({
-						thinking: expect.anything(),
-					}),
-				}),
-			}),
-		);
-	});
-
 	it("passes routed GLM reasoning include/exclude provider options", async () => {
 		streamTextSpy.mockReturnValue({
 			fullStream: makeStreamParts([

--- a/sdk/packages/llms/src/providers/gateway.test.ts
+++ b/sdk/packages/llms/src/providers/gateway.test.ts
@@ -2712,6 +2712,56 @@ describe("sdk-gateway", () => {
 		);
 	});
 
+	it("does not apply generic thinking to non-GLM native Z.AI custom models", async () => {
+		streamTextSpy.mockReturnValue({
+			fullStream: makeStreamParts([
+				{ type: "finish", usage: { inputTokens: 1, outputTokens: 1 } },
+			]),
+		});
+
+		const gateway = createGateway({
+			providerConfigs: [
+				{
+					providerId: "zai",
+					apiKey: "zai-key",
+					models: [
+						{
+							id: "zai-other-model",
+							name: "Non GLM Model",
+							metadata: {
+								family: "other",
+							},
+						},
+					],
+				},
+			],
+		});
+
+		await collect(
+			await gateway.stream({
+				providerId: "zai",
+				modelId: "zai-other-model",
+				messages: baseMessages,
+				reasoning: {
+					enabled: true,
+				},
+			}),
+		);
+
+		expect(streamTextSpy).toHaveBeenCalledWith(
+			expect.objectContaining({
+				providerOptions: expect.objectContaining({
+					zai: expect.not.objectContaining({
+						thinking: expect.anything(),
+					}),
+					openaiCompatible: expect.not.objectContaining({
+						thinking: expect.anything(),
+					}),
+				}),
+			}),
+		);
+	});
+
 	it("passes routed GLM reasoning include/exclude provider options", async () => {
 		streamTextSpy.mockReturnValue({
 			fullStream: makeStreamParts([

--- a/sdk/packages/llms/src/providers/model-facts.ts
+++ b/sdk/packages/llms/src/providers/model-facts.ts
@@ -1,5 +1,6 @@
 import type {
 	GatewayModelRoute,
+	GatewayReasoningFormat,
 	GatewayProviderContext,
 	GatewayStreamRequest,
 } from "@cline/shared";
@@ -126,6 +127,25 @@ export function modelRouteMatches(
 				normalizeRoutingValue(route.modelId)
 			);
 	}
+}
+
+export function providerReasoningRouteMatches(
+	format: GatewayReasoningFormat,
+	request: Pick<GatewayStreamRequest, "modelId">,
+	context: GatewayProviderContext,
+): boolean {
+	const reasoning = context.provider.metadata?.routing?.reasoning;
+	if (reasoning?.format !== format) {
+		return false;
+	}
+
+	return reasoning.routes.some((route) =>
+		modelRouteMatches(route, {
+			modelId: request.modelId,
+			family: resolveModelFamily(context),
+			capabilities: context.model.capabilities,
+		}),
+	);
 }
 
 export function isGlmModel(

--- a/sdk/packages/llms/src/providers/routing/glm-thinking.ts
+++ b/sdk/packages/llms/src/providers/routing/glm-thinking.ts
@@ -1,5 +1,6 @@
 import type {
 	GatewayProviderContext,
+	GatewayProviderMetadata,
 	GatewayStreamRequest,
 } from "@cline/shared";
 import { isGlmModel } from "../model-facts";
@@ -14,9 +15,18 @@ import type { ProviderOptionsPatch } from "./utils";
  * composer can rely on merge order instead of out-of-band flags.
  */
 
-export function isNativeZaiProvider(providerId: string): boolean {
-	return providerId === "zai" || providerId === "zai-coding-plan";
-}
+export const GLM_THINKING_ROUTING_METADATA: GatewayProviderMetadata = {
+	routing: {
+		reasoning: {
+			format: "glm-thinking",
+			routes: [
+				{ matcher: "model-family", family: "glm" },
+				{ matcher: "model-family", family: "glm-air" },
+				{ matcher: "model-family", family: "glm-flash" },
+			],
+		},
+	},
+};
 
 function buildNativeZaiThinkingOptions(request: GatewayStreamRequest) {
 	if (request.reasoning?.enabled === undefined) {
@@ -47,28 +57,28 @@ function buildRoutedGlmReasoningOptions(request: GatewayStreamRequest) {
 	return undefined;
 }
 
-export function buildGlmThinkingProviderOptionsPatch(
+export function buildNativeGlmThinkingProviderOptionsPatch(
+	request: GatewayStreamRequest,
+	providerOptionsKey: string,
+): ProviderOptionsPatch | undefined {
+	const nativeThinking = buildNativeZaiThinkingOptions(request);
+	return nativeThinking
+		? {
+				openaiCompatible: nativeThinking,
+				[request.providerId]: nativeThinking,
+				...(providerOptionsKey !== request.providerId
+					? { [providerOptionsKey]: nativeThinking }
+					: {}),
+			}
+		: undefined;
+}
+
+export function buildRoutedGlmReasoningProviderOptionsPatch(
 	request: GatewayStreamRequest,
 	context: GatewayProviderContext,
 	providerOptionsKey: string,
 	options?: { includeProviderBuckets?: boolean },
 ): ProviderOptionsPatch | undefined {
-	if (isNativeZaiProvider(request.providerId)) {
-		if (!isGlmModel(request, context)) {
-			return undefined;
-		}
-		const nativeThinking = buildNativeZaiThinkingOptions(request);
-		return nativeThinking
-			? {
-					openaiCompatible: nativeThinking,
-					[request.providerId]: nativeThinking,
-					...(providerOptionsKey !== request.providerId
-						? { [providerOptionsKey]: nativeThinking }
-						: {}),
-				}
-			: undefined;
-	}
-
 	if (!isGlmModel(request, context)) {
 		return undefined;
 	}

--- a/sdk/packages/llms/src/providers/routing/glm-thinking.ts
+++ b/sdk/packages/llms/src/providers/routing/glm-thinking.ts
@@ -61,6 +61,8 @@ export function buildNativeGlmThinkingProviderOptionsPatch(
 	request: GatewayStreamRequest,
 	providerOptionsKey: string,
 ): ProviderOptionsPatch | undefined {
+	// Native Z.AI GLM endpoints expect `thinking.type`; they do not accept the
+	// routed `reasoning.enabled` / `reasoning.exclude` shape.
 	const nativeThinking = buildNativeZaiThinkingOptions(request);
 	return nativeThinking
 		? {
@@ -79,6 +81,8 @@ export function buildRoutedGlmReasoningProviderOptionsPatch(
 	providerOptionsKey: string,
 	options?: { includeProviderBuckets?: boolean },
 ): ProviderOptionsPatch | undefined {
+	// Routed GLM endpoints stay OpenAI-compatible and use the generic
+	// `reasoning` include/exclude shape instead of native Z.AI `thinking.type`.
 	if (!isGlmModel(request, context)) {
 		return undefined;
 	}

--- a/sdk/packages/llms/src/providers/routing/provider-option-rules.ts
+++ b/sdk/packages/llms/src/providers/routing/provider-option-rules.ts
@@ -1,8 +1,8 @@
 import { buildGatewayReasoningOptions } from "./anthropic-compatible";
 import { buildOpenAINativeProviderOptions } from "./generic-compatible";
 import {
-	buildGlmThinkingProviderOptionsPatch,
-	isNativeZaiProvider,
+	buildNativeGlmThinkingProviderOptionsPatch,
+	buildRoutedGlmReasoningProviderOptionsPatch,
 } from "./glm-thinking";
 import {
 	isDeepSeekFamily,
@@ -10,6 +10,7 @@ import {
 	isKimiK26Family as isKimiK26FamilyFact,
 	isMoonshotKimiModelIdFallback,
 	modelReasoningDefaultsOn,
+	providerReasoningRouteMatches,
 } from "../model-facts";
 import type {
 	MatchedProviderOptionRule,
@@ -51,6 +52,14 @@ function isOllamaReasoningDefaultOnDisable(
 			request: input.request,
 			context: input.context,
 		})
+	);
+}
+
+function usesGlmThinkingProviderRouting(input: ProviderOptionMatchInput): boolean {
+	return providerReasoningRouteMatches(
+		"glm-thinking",
+		input.request,
+		input.context,
 	);
 }
 
@@ -285,31 +294,16 @@ const ollamaReasoningDefaultOnDisableRule: ProviderOptionRule = {
 	},
 };
 
-const nativeZaiNonGlmSuppressionRule: ProviderOptionRule = {
-	id: "provider.zai.non-glm.suppress-generic-thinking",
-	phase: "provider",
-	description:
-		"Native Z.AI non-GLM models should not inherit adaptive OpenAI-compatible thinking.",
-	applies: (input) =>
-		isNativeZaiProvider(input.request.providerId) &&
-		input.request.reasoning?.enabled !== undefined &&
-		!isGlmModel(input.request, input.context),
-	suppresses: { genericThinking: true },
-	build: () => undefined,
-};
-
 const nativeZaiGlmThinkingRule: ProviderOptionRule = {
-	id: "family.glm.native-zai-thinking",
+	id: "provider.routing.glm-thinking",
 	phase: "model-overlay",
-	description: "Native Z.AI GLM models use thinking.type.",
-	applies: (input) =>
-		isNativeZaiProvider(input.request.providerId) &&
-		isGlmModel(input.request, input.context),
+	description:
+		"Providers routed to the GLM thinking format use thinking.type.",
+	applies: usesGlmThinkingProviderRouting,
 	suppresses: { genericThinking: true },
 	build: (input) =>
-		buildGlmThinkingProviderOptionsPatch(
+		buildNativeGlmThinkingProviderOptionsPatch(
 			input.request,
-			input.context,
 			input.providerOptionsKey,
 		),
 };
@@ -320,11 +314,11 @@ const routedGlmReasoningRule: ProviderOptionRule = {
 	description:
 		"Routed GLM models use the generic reasoning include/exclude shape, not thinking.type.",
 	applies: (input) =>
-		!isNativeZaiProvider(input.request.providerId) &&
+		!usesGlmThinkingProviderRouting(input) &&
 		isGlmModel(input.request, input.context),
 	suppresses: { genericThinking: true },
 	build: (input) =>
-		buildGlmThinkingProviderOptionsPatch(
+		buildRoutedGlmReasoningProviderOptionsPatch(
 			input.request,
 			input.context,
 			input.providerOptionsKey,
@@ -353,7 +347,6 @@ export const PROVIDER_OPTION_RULES: ReadonlyArray<ProviderOptionRule> = [
 	kimiK26ThinkingRule,
 	deepSeekThinkingRule,
 	ollamaReasoningDefaultOnDisableRule,
-	nativeZaiNonGlmSuppressionRule,
 	nativeZaiGlmThinkingRule,
 	routedGlmReasoningRule,
 ];

--- a/sdk/packages/llms/src/providers/routing/provider-option-rules.ts
+++ b/sdk/packages/llms/src/providers/routing/provider-option-rules.ts
@@ -1,9 +1,3 @@
-import { buildGatewayReasoningOptions } from "./anthropic-compatible";
-import { buildOpenAINativeProviderOptions } from "./generic-compatible";
-import {
-	buildNativeGlmThinkingProviderOptionsPatch,
-	buildRoutedGlmReasoningProviderOptionsPatch,
-} from "./glm-thinking";
 import {
 	isDeepSeekFamily,
 	isGlmModel,
@@ -12,6 +6,12 @@ import {
 	modelReasoningDefaultsOn,
 	providerReasoningRouteMatches,
 } from "../model-facts";
+import { buildGatewayReasoningOptions } from "./anthropic-compatible";
+import { buildOpenAINativeProviderOptions } from "./generic-compatible";
+import {
+	buildNativeGlmThinkingProviderOptionsPatch,
+	buildRoutedGlmReasoningProviderOptionsPatch,
+} from "./glm-thinking";
 import type {
 	MatchedProviderOptionRule,
 	ProviderOptionBuildInput,
@@ -55,11 +55,22 @@ function isOllamaReasoningDefaultOnDisable(
 	);
 }
 
-function usesGlmThinkingProviderRouting(input: ProviderOptionMatchInput): boolean {
+function usesGlmThinkingProviderRouting(
+	input: ProviderOptionMatchInput,
+): boolean {
 	return providerReasoningRouteMatches(
 		"glm-thinking",
 		input.request,
 		input.context,
+	);
+}
+
+function hasGlmThinkingProviderRouting(
+	input: ProviderOptionMatchInput,
+): boolean {
+	return (
+		input.context.provider.metadata?.routing?.reasoning?.format ===
+		"glm-thinking"
 	);
 }
 
@@ -294,11 +305,23 @@ const ollamaReasoningDefaultOnDisableRule: ProviderOptionRule = {
 	},
 };
 
+const nonGlmProviderRoutingSuppressionRule: ProviderOptionRule = {
+	id: "provider.routing.glm-thinking.non-glm.suppress-generic-thinking",
+	phase: "provider",
+	description:
+		"Providers with GLM thinking routing should not apply generic adaptive thinking to non-GLM models.",
+	applies: (input) =>
+		hasGlmThinkingProviderRouting(input) &&
+		input.request.reasoning?.enabled !== undefined &&
+		!usesGlmThinkingProviderRouting(input),
+	suppresses: { genericThinking: true },
+	build: () => undefined,
+};
+
 const nativeZaiGlmThinkingRule: ProviderOptionRule = {
 	id: "provider.routing.glm-thinking",
 	phase: "model-overlay",
-	description:
-		"Providers routed to the GLM thinking format use thinking.type.",
+	description: "Providers routed to the GLM thinking format use thinking.type.",
 	applies: usesGlmThinkingProviderRouting,
 	suppresses: { genericThinking: true },
 	build: (input) =>
@@ -347,6 +370,7 @@ export const PROVIDER_OPTION_RULES: ReadonlyArray<ProviderOptionRule> = [
 	kimiK26ThinkingRule,
 	deepSeekThinkingRule,
 	ollamaReasoningDefaultOnDisableRule,
+	nonGlmProviderRoutingSuppressionRule,
 	nativeZaiGlmThinkingRule,
 	routedGlmReasoningRule,
 ];

--- a/sdk/packages/llms/src/providers/routing/provider-options.test.ts
+++ b/sdk/packages/llms/src/providers/routing/provider-options.test.ts
@@ -8,6 +8,7 @@ import {
 	mergeProviderOptionPatches,
 	type ProviderOptionsPatch,
 } from "./provider-options";
+import { GLM_THINKING_ROUTING_METADATA } from "./glm-thinking";
 
 type RequestOverrides = Partial<GatewayStreamRequest> & {
 	providerId: string;
@@ -770,6 +771,7 @@ describe("composeAiSdkProviderOptions: family/provider thinking patches", () => 
 				modelId: "glm-4.7",
 				reasoning: { enabled: true },
 			},
+			context: { family: "glm", metadata: GLM_THINKING_ROUTING_METADATA },
 			expect: [
 				{ bucket: "zai", has: { thinking: { type: "enabled" } } },
 				{

--- a/sdk/packages/llms/src/providers/routing/provider-options.test.ts
+++ b/sdk/packages/llms/src/providers/routing/provider-options.test.ts
@@ -3,12 +3,12 @@ import type {
 	GatewayStreamRequest,
 } from "@cline/shared";
 import { describe, expect, it } from "vitest";
+import { GLM_THINKING_ROUTING_METADATA } from "./glm-thinking";
 import {
 	composeAiSdkProviderOptions,
 	mergeProviderOptionPatches,
 	type ProviderOptionsPatch,
 } from "./provider-options";
-import { GLM_THINKING_ROUTING_METADATA } from "./glm-thinking";
 
 type RequestOverrides = Partial<GatewayStreamRequest> & {
 	providerId: string;
@@ -779,6 +779,19 @@ describe("composeAiSdkProviderOptions: family/provider thinking patches", () => 
 					has: { thinking: { type: "enabled" } },
 					lacks: ["reasoning"],
 				},
+			],
+		},
+		{
+			name: "native zai custom non-GLM -> no generic adaptive thinking",
+			request: {
+				providerId: "zai",
+				modelId: "zai-other-model",
+				reasoning: { enabled: true },
+			},
+			context: { family: "other", metadata: GLM_THINKING_ROUTING_METADATA },
+			expect: [
+				{ bucket: "zai", lacks: ["thinking", "reasoning"] },
+				{ bucket: "openaiCompatible", lacks: ["thinking", "reasoning"] },
 			],
 		},
 		// Kimi K2.6 family: explicit enabled/disabled and unset defaults to enabled

--- a/sdk/packages/shared/src/llms/gateway.ts
+++ b/sdk/packages/shared/src/llms/gateway.ts
@@ -35,7 +35,7 @@ export type GatewayModelCapability =
 export type GatewayPromptCacheStrategy = "anthropic-automatic";
 export type GatewayUsageCostDisplay = "show" | "hide";
 export type GatewayPromptCacheFormat = "anthropic-cache-control";
-export type GatewayReasoningFormat = "anthropic-thinking";
+export type GatewayReasoningFormat = "anthropic-thinking" | "glm-thinking";
 export type GatewayModelRoute =
 	| { matcher: "anthropic-compatible" }
 	| {


### PR DESCRIPTION
### Related Issue

**Issue:** ENG-2019

### Description

This is the fourth PR in the stacked provider-option routing architecture work:

- #10676 refactors shared model/provider fact helpers.
- #10677 adds typed model metadata facts.
- #10678 routes Ollama default-on reasoning disable behavior.
- This PR moves native Z.AI GLM thinking format selection into typed provider routing metadata.

The architectural point is the one discussed on ENG-2019: stable provider routing facts should live with provider metadata, while `PROVIDER_OPTION_RULES` remains the auditable codec/policy table that turns request intent plus facts into AI SDK `providerOptions`.

Concretely, this PR:

- Adds `glm-thinking` as a typed `GatewayReasoningFormat`.
- Adds GLM thinking routing metadata to the native `zai` and `zai-coding-plan` builtins.
- Changes the native GLM thinking rule to match provider metadata instead of checking Z.AI provider ids directly.
- Removes the old defensive non-GLM Z.AI suppression rule; native Z.AI has no non-GLM catalog models.
- Replaces the artificial non-GLM Z.AI gateway test with a builtin-provider metadata/catalog invariant test for the real Z.AI surface.
- Documents in `sdk/packages/llms/AGENTS.md` when future routing behavior should be defined in `GatewayProviderMetadata.routing` and builtins instead of hard-coded in rule predicates.

This keeps the larger tradeoff explicit: the rule table may grow, but it should grow as one auditable routing matrix. Stable provider/model facts should feed that matrix from typed metadata rather than leaking into ad hoc predicates.

### Test Procedure

Ran:

- `bun test sdk/packages/llms/src/providers/builtins.test.ts`
- `bun test sdk/packages/llms/src/providers/routing/provider-options.test.ts`
- `bun test sdk/packages/llms/src/providers/gateway.test.ts -t "Z.AI|GLM|thinking"`
- `bun run typecheck` from `sdk/packages/llms`
- `git diff --check`

I also ran the full `bun test sdk/packages/llms/src/providers/gateway.test.ts`. The Z.AI/GLM routing tests passed, but three existing tool-call tests fail independently when run by themselves:

- `does not pass extra tools to providers that disable external tool execution`
- `tags tool call events with provider metadata for providers that disable external tool execution`
- `keeps AI SDK tool-error parts recoverable`

Those failures are outside the provider-option routing surface changed here.

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [x] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [x] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A

### Additional Notes

Base branch is `robin/llms-routing-ollama` so this stays stacked on top of #10678.
