### PR TITLE
feat(sdk): emit telemetry for compaction lifecycle events

### DIFF
--- a/sdk/apps/cli/src/main.ts
+++ b/sdk/apps/cli/src/main.ts
@@ -38,7 +38,7 @@ import {
 	normalizeProviderId,
 } from "./utils/provider-auth";
 import { rewriteTeamPrompt, TEAM_COMMAND_USAGE } from "./utils/team-command";
-import { captureCliExtensionActivated } from "./utils/telemetry";
+import { captureCliExtensionActivated, getCliTelemetryService } from "./utils/telemetry";
 import type { Config } from "./utils/types";
 import { runConnectWizard } from "./wizards/connect";
 import { runMcpWizard } from "./wizards/mcp";
@@ -856,6 +856,7 @@ export async function runCli(): Promise<void> {
 			mode: args.mode,
 			logger: loggerAdapter.core,
 			loggerConfig: loggerAdapter.runtimeConfig,
+			telemetry: getCliTelemetryService(loggerAdapter.core),
 			defaultToolAutoApprove,
 			toolPolicies,
 			enableSpawnAgent: !isYoloMode,

--- a/sdk/apps/cli/src/runtime/interactive/compaction.ts
+++ b/sdk/apps/cli/src/runtime/interactive/compaction.ts
@@ -72,6 +72,11 @@ export async function compactInteractiveMessages(input: {
 				enabled: true,
 			},
 			logger: input.config.logger,
+			// Forward telemetry + sessionId so manual compactions emit
+			// `task.compaction_executed` / `task.compaction_skipped` events
+			// alongside auto compactions.
+			telemetry: input.config.telemetry,
+			sessionId: input.sessionId,
 		},
 		{ mode: "manual" },
 	);

--- a/sdk/packages/core/src/extensions/context/compaction.test.ts
+++ b/sdk/packages/core/src/extensions/context/compaction.test.ts
@@ -1403,4 +1403,313 @@ describe("createContextCompactionPrepareTurn", () => {
 		expect(createHandlerMock).not.toHaveBeenCalled();
 		expect(result).toBeUndefined();
 	});
+
+	// ------------------------------------------------------------------
+	// Telemetry coverage — task.compaction_executed / task.compaction_skipped
+	// ------------------------------------------------------------------
+
+	it("emits task.compaction_executed telemetry after a successful basic compaction", async () => {
+		const captureCalls: Array<{
+			event: string;
+			properties?: Record<string, unknown>;
+		}> = [];
+		const telemetry = {
+			capture: (call: {
+				event: string;
+				properties?: Record<string, unknown>;
+			}) => captureCalls.push(call),
+			captureRequired: () => {},
+			setDistinctId: () => {},
+			updateCommonProperties: () => {},
+			identify: () => {},
+		} as unknown as Parameters<
+			typeof createContextCompactionPrepareTurn
+		>[0]["telemetry"];
+
+		const prepareTurn = createContextCompactionPrepareTurn({
+			providerId: "anthropic",
+			modelId: "mock-model",
+			providerConfig: {
+				providerId: "anthropic",
+				modelId: "mock-model",
+			} as LlmsProviders.ProviderConfig,
+			compaction: {
+				enabled: true,
+				strategy: "basic",
+				reserveTokens: 1,
+			},
+			telemetry,
+			sessionId: "ulid-test-1",
+		});
+
+		const filler = "x".repeat(200);
+		const messages: LlmsProviders.Message[] = [
+			{ role: "user", content: "Original task" },
+			{ role: "assistant", content: `Old answer ${filler}` },
+			{ role: "user", content: `Older user followup ${filler}` },
+			{ role: "assistant", content: `Older assistant ${filler}` },
+			{ role: "user", content: "Latest user question" },
+		];
+
+		const result = await prepareTurn?.({
+			agentId: "agent-1",
+			conversationId: "conv-1",
+			parentAgentId: null,
+			iteration: 1,
+			abortSignal: new AbortController().signal,
+			systemPrompt: "",
+			tools: [],
+			messages,
+			apiMessages: messages,
+			model: {
+				id: "mock-model",
+				provider: "anthropic",
+				info: { id: "mock-model", maxInputTokens: 100 },
+			},
+		});
+
+		expect(result?.messages).toBeDefined();
+		const executed = captureCalls.find(
+			(call) => call.event === "task.compaction_executed",
+		);
+		expect(executed).toBeDefined();
+		const props = executed?.properties as Record<string, unknown>;
+		expect(props.strategy).toBe("basic");
+		expect(props.mode).toBe("auto");
+		expect(props.ulid).toBe("ulid-test-1");
+		expect(props.provider).toBe("anthropic");
+		expect(props.modelId).toBe("mock-model");
+		expect(props.agentId).toBe("agent-1");
+		expect(props.conversationId).toBe("conv-1");
+		expect(typeof props.durationMs).toBe("number");
+		expect(typeof props.tokensBefore).toBe("number");
+		expect(typeof props.tokensAfter).toBe("number");
+		expect(props.messagesBefore).toBe(messages.length);
+		expect(typeof props.messagesAfter).toBe("number");
+		expect(props.tokensSaved).toBe(
+			(props.tokensBefore as number) - (props.tokensAfter as number),
+		);
+	});
+
+	it("marks strategy as 'custom' when a user-supplied compact callback is used", async () => {
+		const captureCalls: Array<{
+			event: string;
+			properties?: Record<string, unknown>;
+		}> = [];
+		const telemetry = {
+			capture: (call: {
+				event: string;
+				properties?: Record<string, unknown>;
+			}) => captureCalls.push(call),
+			captureRequired: () => {},
+			setDistinctId: () => {},
+			updateCommonProperties: () => {},
+			identify: () => {},
+		} as unknown as Parameters<
+			typeof createContextCompactionPrepareTurn
+		>[0]["telemetry"];
+
+		const customCompact = vi.fn(async () => ({
+			messages: [
+				{ role: "user", content: "trimmed" },
+			] as LlmsProviders.Message[],
+		}));
+
+		const prepareTurn = createContextCompactionPrepareTurn({
+			providerId: "anthropic",
+			modelId: "mock-model",
+			providerConfig: {
+				providerId: "anthropic",
+				modelId: "mock-model",
+			} as LlmsProviders.ProviderConfig,
+			compaction: {
+				enabled: true,
+				strategy: "basic", // ignored when `compact` is provided
+				reserveTokens: 1,
+				compact: customCompact,
+			},
+			telemetry,
+		});
+
+		const messages: LlmsProviders.Message[] = [
+			{ role: "user", content: "Original task" },
+			{ role: "assistant", content: "x".repeat(500) },
+			{ role: "user", content: "Latest" },
+		];
+
+		await prepareTurn?.({
+			agentId: "agent-1",
+			conversationId: "conv-1",
+			parentAgentId: null,
+			iteration: 2,
+			abortSignal: new AbortController().signal,
+			systemPrompt: "",
+			tools: [],
+			messages,
+			apiMessages: messages,
+			model: {
+				id: "mock-model",
+				provider: "anthropic",
+				info: { id: "mock-model", maxInputTokens: 100 },
+			},
+		});
+
+		expect(customCompact).toHaveBeenCalledTimes(1);
+		const executed = captureCalls.find(
+			(call) => call.event === "task.compaction_executed",
+		);
+		expect(executed).toBeDefined();
+		expect((executed?.properties as Record<string, unknown>).strategy).toBe(
+			"custom",
+		);
+	});
+
+	it("emits task.compaction_skipped when the strategy returns undefined", async () => {
+		const captureCalls: Array<{
+			event: string;
+			properties?: Record<string, unknown>;
+		}> = [];
+		const telemetry = {
+			capture: (call: {
+				event: string;
+				properties?: Record<string, unknown>;
+			}) => captureCalls.push(call),
+			captureRequired: () => {},
+			setDistinctId: () => {},
+			updateCommonProperties: () => {},
+			identify: () => {},
+		} as unknown as Parameters<
+			typeof createContextCompactionPrepareTurn
+		>[0]["telemetry"];
+
+		// Force the trigger to fire (small budget vs large transcript) but
+		// supply a `compact` callback that intentionally returns undefined
+		// so the wrapper records a skip.
+		const prepareTurn = createContextCompactionPrepareTurn({
+			providerId: "anthropic",
+			modelId: "mock-model",
+			providerConfig: {
+				providerId: "anthropic",
+				modelId: "mock-model",
+			} as LlmsProviders.ProviderConfig,
+			compaction: {
+				enabled: true,
+				strategy: "basic",
+				reserveTokens: 1,
+				compact: async () => undefined,
+			},
+			telemetry,
+			sessionId: "ulid-test-skip",
+		});
+
+		const messages: LlmsProviders.Message[] = [
+			{ role: "user", content: "Original task" },
+			{ role: "assistant", content: "x".repeat(500) },
+			{ role: "user", content: "Latest" },
+		];
+
+		const result = await prepareTurn?.({
+			agentId: "agent-1",
+			conversationId: "conv-1",
+			parentAgentId: null,
+			iteration: 3,
+			abortSignal: new AbortController().signal,
+			systemPrompt: "",
+			tools: [],
+			messages,
+			apiMessages: messages,
+			model: {
+				id: "mock-model",
+				provider: "anthropic",
+				info: { id: "mock-model", maxInputTokens: 100 },
+			},
+		});
+
+		expect(result).toBeUndefined();
+		const skipped = captureCalls.find(
+			(call) => call.event === "task.compaction_skipped",
+		);
+		expect(skipped).toBeDefined();
+		const props = skipped?.properties as Record<string, unknown>;
+		expect(props.strategy).toBe("custom");
+		expect(props.mode).toBe("auto");
+		expect(props.reason).toBe("no_result");
+		expect(props.ulid).toBe("ulid-test-skip");
+		expect(typeof props.durationMs).toBe("number");
+		expect(
+			captureCalls.find((call) => call.event === "task.compaction_executed"),
+		).toBeUndefined();
+	});
+
+	it("tags telemetry mode as 'manual' when prepareTurn is run with mode: manual", async () => {
+		const captureCalls: Array<{
+			event: string;
+			properties?: Record<string, unknown>;
+		}> = [];
+		const telemetry = {
+			capture: (call: {
+				event: string;
+				properties?: Record<string, unknown>;
+			}) => captureCalls.push(call),
+			captureRequired: () => {},
+			setDistinctId: () => {},
+			updateCommonProperties: () => {},
+			identify: () => {},
+		} as unknown as Parameters<
+			typeof createContextCompactionPrepareTurn
+		>[0]["telemetry"];
+
+		const prepareTurn = createContextCompactionPrepareTurn(
+			{
+				providerId: "anthropic",
+				modelId: "mock-model",
+				providerConfig: {
+					providerId: "anthropic",
+					modelId: "mock-model",
+				} as LlmsProviders.ProviderConfig,
+				compaction: {
+					enabled: true,
+					strategy: "basic",
+					reserveTokens: 1,
+				},
+				telemetry,
+			},
+			{ mode: "manual" },
+		);
+
+		const messages: LlmsProviders.Message[] = [
+			{ role: "user", content: "Original task" },
+			{ role: "assistant", content: "x".repeat(500) },
+			{ role: "user", content: "Older followup" },
+			{ role: "assistant", content: "x".repeat(500) },
+			{ role: "user", content: "Latest" },
+		];
+
+		await prepareTurn?.({
+			agentId: "agent-1",
+			conversationId: "conv-1",
+			parentAgentId: null,
+			iteration: 4,
+			abortSignal: new AbortController().signal,
+			systemPrompt: "",
+			tools: [],
+			messages,
+			apiMessages: messages,
+			model: {
+				id: "mock-model",
+				provider: "anthropic",
+				info: { id: "mock-model", maxInputTokens: 100_000 },
+			},
+		});
+
+		const compactionEvent = captureCalls.find(
+			(call) =>
+				call.event === "task.compaction_executed" ||
+				call.event === "task.compaction_skipped",
+		);
+		expect(compactionEvent).toBeDefined();
+		expect((compactionEvent?.properties as Record<string, unknown>).mode).toBe(
+			"manual",
+		);
+	});
 });

--- a/sdk/packages/core/src/extensions/context/compaction.ts
+++ b/sdk/packages/core/src/extensions/context/compaction.ts
@@ -1,3 +1,8 @@
+import {
+	captureCompactionExecuted,
+	captureCompactionSkipped,
+	type TelemetryCompactionStrategy,
+} from "../../services/telemetry/core-events";
 import type {
 	CoreCompactionConfig,
 	CoreCompactionContext,
@@ -204,10 +209,30 @@ function resolveManualTargetState(input: {
 	};
 }
 
+/**
+ * Build the `prepareTurn` callback used by the agent runtime to compact the
+ * transcript before each model request.
+ *
+ * Telemetry: emits `task.compaction_executed` on a successful compaction and
+ * `task.compaction_skipped` when the configured strategy returns `undefined`.
+ * Telemetry is keyed by `config.sessionId` (falling back to the per-turn
+ * `conversationId`) and tagged with `provider` / `modelId`.
+ *
+ * Known gap: compactions performed via plugin `registerMessageBuilder()` or
+ * via the `beforeModel` runtime hook bypass this wrapper entirely, so they
+ * do not emit compaction telemetry. If we want coverage there too, the
+ * plugin/hook pipelines must be instrumented separately.
+ */
 export function createContextCompactionPrepareTurn(
 	config: Pick<
 		CoreSessionConfig,
-		"providerConfig" | "providerId" | "modelId" | "compaction" | "logger"
+		| "providerConfig"
+		| "providerId"
+		| "modelId"
+		| "compaction"
+		| "logger"
+		| "telemetry"
+		| "sessionId"
 	>,
 	options: ContextCompactionPrepareTurnOptions = {},
 ):
@@ -230,6 +255,9 @@ export function createContextCompactionPrepareTurn(
 	const strategy = userCompaction?.strategy ?? "basic";
 	const runBuiltinStrategy = BUILTIN_COMPACTION_STRATEGIES[strategy];
 	const mode = options.mode ?? "auto";
+	const telemetryStrategy: TelemetryCompactionStrategy = userCompaction?.compact
+		? "custom"
+		: strategy;
 
 	return async (context) => {
 		const inputTokens = context.apiMessages.reduce(
@@ -313,6 +341,7 @@ export function createContextCompactionPrepareTurn(
 		);
 
 		const beforeMessageCount = context.messages.length;
+		const startedAt = Date.now();
 
 		const result = userCompaction?.compact
 			? await userCompaction.compact(compactionContext)
@@ -327,6 +356,18 @@ export function createContextCompactionPrepareTurn(
 					estimateMessageTokens,
 					logger: config.logger,
 				});
+
+		const durationMs = Date.now() - startedAt;
+		// Telemetry identity: surface the agent/conversation passed into the
+		// prepareTurn so multi-agent runs can attribute compactions correctly.
+		// `sessionId` is the host-owned session id (ulid). We fall back to the
+		// conversation id when no sessionId is supplied (e.g. ad-hoc callers).
+		const telemetryUlid = config.sessionId ?? context.conversationId;
+		const telemetryIdentity = {
+			agentId: context.agentId,
+			conversationId: context.conversationId,
+			parentAgentId: context.parentAgentId ?? undefined,
+		};
 
 		if (result?.messages) {
 			const afterTokens = result.messages.reduce(
@@ -347,6 +388,41 @@ export function createContextCompactionPrepareTurn(
 				messagesAfter: result.messages.length,
 				messagesRemoved: beforeMessageCount - result.messages.length,
 			} as Record<string, unknown>);
+			captureCompactionExecuted(config.telemetry, {
+				ulid: telemetryUlid,
+				strategy: telemetryStrategy,
+				mode,
+				messagesBefore: beforeMessageCount,
+				messagesAfter: result.messages.length,
+				messagesRemoved: beforeMessageCount - result.messages.length,
+				tokensBefore: inputTokens,
+				tokensAfter: afterTokens,
+				tokensSaved: inputTokens - afterTokens,
+				triggerTokens: targetState.triggerTokens,
+				maxInputTokens,
+				thresholdRatio: targetState.thresholdRatio,
+				durationMs,
+				// Matches the field name used by other TASK telemetry helpers
+				// (e.g. captureTaskCompleted, captureToolUsage).
+				provider: config.providerId,
+				modelId: config.modelId,
+				...telemetryIdentity,
+			});
+		} else {
+			captureCompactionSkipped(config.telemetry, {
+				ulid: telemetryUlid,
+				strategy: telemetryStrategy,
+				mode,
+				reason: "no_result",
+				tokensBefore: inputTokens,
+				triggerTokens: targetState.triggerTokens,
+				maxInputTokens,
+				thresholdRatio: targetState.thresholdRatio,
+				durationMs,
+				provider: config.providerId,
+				modelId: config.modelId,
+				...telemetryIdentity,
+			});
 		}
 
 		return result;

--- a/sdk/packages/core/src/index.ts
+++ b/sdk/packages/core/src/index.ts
@@ -461,8 +461,12 @@ export {
 	type SqliteTeamStoreOptions,
 } from "./services/storage/team-store";
 export type {
+	CaptureCompactionExecutedProperties,
+	CaptureCompactionSkippedProperties,
 	TelemetryAgentIdentityProperties,
 	TelemetryAgentKind,
+	TelemetryCompactionMode,
+	TelemetryCompactionStrategy,
 	WorkspaceInitErrorProperties,
 	WorkspaceInitializedProperties,
 	WorkspacePathResolvedProperties,
@@ -475,6 +479,8 @@ export {
 	captureAuthLoggedOut,
 	captureAuthStarted,
 	captureAuthSucceeded,
+	captureCompactionExecuted,
+	captureCompactionSkipped,
 	captureConversationTurnEvent,
 	captureDiffEditFailure,
 	captureExtensionActivated,

--- a/sdk/packages/core/src/services/telemetry/core-events.test.ts
+++ b/sdk/packages/core/src/services/telemetry/core-events.test.ts
@@ -417,6 +417,50 @@ describe("telemetry policy: helpers respect telemetry opt-out", () => {
 		expect(emitRequired).not.toHaveBeenCalled();
 	});
 
+	test("captureCompactionExecuted never invokes captureRequired", () => {
+		const { adapter, emitRequired } = createDisabledAdapter();
+		const service = new TelemetryService({
+			distinctId: "test-distinct-id",
+			adapters: [adapter],
+		});
+		captureCompactionExecuted(service, {
+			ulid: "ulid-1",
+			strategy: "basic",
+			mode: "auto",
+			messagesBefore: 12,
+			messagesAfter: 6,
+			messagesRemoved: 6,
+			tokensBefore: 100_000,
+			tokensAfter: 50_000,
+			tokensSaved: 50_000,
+			triggerTokens: 180_000,
+			maxInputTokens: 200_000,
+			thresholdRatio: 0.9,
+			durationMs: 42,
+		});
+		expect(emitRequired).not.toHaveBeenCalled();
+	});
+
+	test("captureCompactionSkipped never invokes captureRequired", () => {
+		const { adapter, emitRequired } = createDisabledAdapter();
+		const service = new TelemetryService({
+			distinctId: "test-distinct-id",
+			adapters: [adapter],
+		});
+		captureCompactionSkipped(service, {
+			ulid: "ulid-1",
+			strategy: "basic",
+			mode: "auto",
+			reason: "no_result",
+			tokensBefore: 100_000,
+			triggerTokens: 180_000,
+			maxInputTokens: 200_000,
+			thresholdRatio: 0.9,
+			durationMs: 17,
+		});
+		expect(emitRequired).not.toHaveBeenCalled();
+	});
+
 	test("a correctly-policed adapter drops these events when disabled", () => {
 		// This test layers on top of the previous four to assert the *full*
 		// end-to-end policy: when the adapter is disabled, a real adapter
@@ -461,12 +505,40 @@ describe("telemetry policy: helpers respect telemetry opt-out", () => {
 			context: "search_codebase",
 			resolution_type: "fallback_to_primary",
 		});
+		captureCompactionExecuted(service, {
+			ulid: "ulid-1",
+			strategy: "basic",
+			mode: "auto",
+			messagesBefore: 12,
+			messagesAfter: 6,
+			messagesRemoved: 6,
+			tokensBefore: 100_000,
+			tokensAfter: 50_000,
+			tokensSaved: 50_000,
+			triggerTokens: 180_000,
+			maxInputTokens: 200_000,
+			thresholdRatio: 0.9,
+			durationMs: 42,
+		});
+		captureCompactionSkipped(service, {
+			ulid: "ulid-1",
+			strategy: "basic",
+			mode: "auto",
+			reason: "no_result",
+			tokensBefore: 100_000,
+			triggerTokens: 180_000,
+			maxInputTokens: 200_000,
+			thresholdRatio: 0.9,
+			durationMs: 17,
+		});
 		expect(observed).toEqual([]);
 		expect(dropped).toEqual([
 			"user.extension_activated",
 			"workspace.initialized",
 			"workspace.init_error",
 			"workspace.path_resolved",
+			"task.compaction_executed",
+			"task.compaction_skipped",
 		]);
 	});
 });

--- a/sdk/packages/core/src/services/telemetry/core-events.test.ts
+++ b/sdk/packages/core/src/services/telemetry/core-events.test.ts
@@ -1,6 +1,9 @@
 import type { ITelemetryService } from "@cline/shared";
 import { describe, expect, test, vi } from "vitest";
 import {
+	CORE_TELEMETRY_EVENTS,
+	captureCompactionExecuted,
+	captureCompactionSkipped,
 	captureExtensionActivated,
 	captureTelemetryOptOut,
 	captureWorkspaceInitError,
@@ -219,6 +222,96 @@ describe("captureWorkspacePathResolved", () => {
 				resolution_type: "fallback_to_primary",
 			}),
 		).not.toThrow();
+	});
+});
+describe("captureCompactionExecuted", () => {
+	const baseProps = {
+		ulid: "ulid-1",
+		strategy: "basic" as const,
+		mode: "auto" as const,
+		messagesBefore: 12,
+		messagesAfter: 6,
+		messagesRemoved: 6,
+		tokensBefore: 100_000,
+		tokensAfter: 50_000,
+		tokensSaved: 50_000,
+		triggerTokens: 180_000,
+		maxInputTokens: 200_000,
+		thresholdRatio: 0.9,
+		durationMs: 42,
+		provider: "anthropic",
+		modelId: "claude-sonnet-4",
+	};
+
+	test("emits task.compaction_executed with all properties and a timestamp", () => {
+		const stub = createTelemetryStub();
+		captureCompactionExecuted(stub.telemetry, baseProps);
+		expect(stub.capture).toHaveBeenCalledTimes(1);
+		expect(stub.captureRequired).not.toHaveBeenCalled();
+		const { event, properties } = captureCallAt(stub, 0);
+		expect(event).toBe(CORE_TELEMETRY_EVENTS.TASK.COMPACTION_EXECUTED);
+		expect(event).toBe("task.compaction_executed");
+		expect(properties).toMatchObject(baseProps);
+		expect(typeof (properties as Record<string, unknown>).timestamp).toBe(
+			"string",
+		);
+	});
+
+	test("preserves optional agent identity fields when supplied", () => {
+		const stub = createTelemetryStub();
+		captureCompactionExecuted(stub.telemetry, {
+			...baseProps,
+			agentId: "agent-7",
+			agentKind: "subagent",
+			conversationId: "conv-1",
+			parentAgentId: "agent-root",
+			isSubagent: true,
+		});
+		const { properties } = captureCallAt(stub, 0);
+		const props = properties as Record<string, unknown>;
+		expect(props.agentId).toBe("agent-7");
+		expect(props.agentKind).toBe("subagent");
+		expect(props.conversationId).toBe("conv-1");
+		expect(props.parentAgentId).toBe("agent-root");
+		expect(props.isSubagent).toBe(true);
+	});
+
+	test("no-ops when telemetry is undefined", () => {
+		expect(() => captureCompactionExecuted(undefined, baseProps)).not.toThrow();
+	});
+});
+
+describe("captureCompactionSkipped", () => {
+	const baseProps = {
+		ulid: "ulid-1",
+		strategy: "agentic" as const,
+		mode: "auto" as const,
+		reason: "no_result",
+		tokensBefore: 100_000,
+		triggerTokens: 180_000,
+		maxInputTokens: 200_000,
+		thresholdRatio: 0.9,
+		durationMs: 17,
+		provider: "anthropic",
+		modelId: "claude-sonnet-4",
+	};
+
+	test("emits task.compaction_skipped with all properties and a timestamp", () => {
+		const stub = createTelemetryStub();
+		captureCompactionSkipped(stub.telemetry, baseProps);
+		expect(stub.capture).toHaveBeenCalledTimes(1);
+		expect(stub.captureRequired).not.toHaveBeenCalled();
+		const { event, properties } = captureCallAt(stub, 0);
+		expect(event).toBe(CORE_TELEMETRY_EVENTS.TASK.COMPACTION_SKIPPED);
+		expect(event).toBe("task.compaction_skipped");
+		expect(properties).toMatchObject(baseProps);
+		expect(typeof (properties as Record<string, unknown>).timestamp).toBe(
+			"string",
+		);
+	});
+
+	test("no-ops when telemetry is undefined", () => {
+		expect(() => captureCompactionSkipped(undefined, baseProps)).not.toThrow();
 	});
 });
 

--- a/sdk/packages/core/src/services/telemetry/core-events.ts
+++ b/sdk/packages/core/src/services/telemetry/core-events.ts
@@ -58,6 +58,8 @@ export const CORE_TELEMETRY_EVENTS = {
 		AGENT_TEAM_CREATED: "task.agent_team_created",
 		SUBAGENT_STARTED: "task.subagent_started",
 		SUBAGENT_COMPLETED: "task.subagent_completed",
+		COMPACTION_EXECUTED: "task.compaction_executed",
+		COMPACTION_SKIPPED: "task.compaction_skipped",
 	},
 	HOOKS: {
 		DISCOVERY_COMPLETED: "hooks.discovery_completed",
@@ -528,6 +530,94 @@ export function captureHookDiscovery(
 		globalCount,
 		workspaceCount,
 		totalCount: globalCount + workspaceCount,
+		timestamp: new Date().toISOString(),
+	});
+}
+
+/**
+ * Identifies which compaction implementation produced a
+ * `task.compaction_executed` / `task.compaction_skipped` event.
+ *
+ * - `basic`   — built-in token-budget truncation
+ *   (see `extensions/context/basic-compaction.ts`).
+ * - `agentic` — built-in LLM-powered summarization
+ *   (see `extensions/context/agentic-compaction.ts`).
+ * - `custom`  — user-supplied `compaction.compact()` callback on
+ *   `CoreSessionConfig`.
+ */
+export type TelemetryCompactionStrategy = "basic" | "agentic" | "custom";
+
+/**
+ * Trigger mode for a compaction attempt.
+ *
+ * - `auto`   — fired automatically by `createContextCompactionPrepareTurn`
+ *   when input tokens exceed the configured threshold.
+ * - `manual` — user-initiated (e.g. CLI `/compact`).
+ */
+export type TelemetryCompactionMode = "auto" | "manual";
+
+export interface CaptureCompactionExecutedProperties {
+	ulid: string;
+	strategy: TelemetryCompactionStrategy;
+	mode: TelemetryCompactionMode;
+	messagesBefore: number;
+	messagesAfter: number;
+	messagesRemoved: number;
+	tokensBefore: number;
+	tokensAfter: number;
+	tokensSaved: number;
+	triggerTokens: number;
+	maxInputTokens: number;
+	thresholdRatio: number;
+	durationMs: number;
+	// Name matches the rest of the TASK-namespace capture functions
+	// (`captureTaskCompleted`, `captureToolUsage`, etc.) — using `provider`,
+	// not `providerId`, keeps downstream PostHog joins consistent.
+	provider?: string;
+	modelId?: string;
+}
+
+export function captureCompactionExecuted(
+	telemetry: ITelemetryService | undefined,
+	properties: CaptureCompactionExecutedProperties &
+		Partial<TelemetryAgentIdentityProperties>,
+): void {
+	emit(telemetry, CORE_TELEMETRY_EVENTS.TASK.COMPACTION_EXECUTED, {
+		...properties,
+		timestamp: new Date().toISOString(),
+	});
+}
+
+export interface CaptureCompactionSkippedProperties {
+	ulid: string;
+	strategy: TelemetryCompactionStrategy;
+	mode: TelemetryCompactionMode;
+	/**
+	 * Why the strategy decided not to compact. Currently only one value is
+	 * emitted by the wrapper:
+	 * - `no_result` — strategy returned `undefined` (e.g. there was nothing
+	 *   safe to remove). Strategy *exceptions* propagate up instead of
+	 *   firing telemetry, so no `strategy_error` value is emitted today.
+	 * The field is kept loosely typed (`string`) so additional reasons can
+	 * be introduced without changing the schema.
+	 */
+	reason: string;
+	tokensBefore: number;
+	triggerTokens: number;
+	maxInputTokens: number;
+	thresholdRatio: number;
+	durationMs: number;
+	provider?: string;
+	modelId?: string;
+}
+
+export function captureCompactionSkipped(
+	telemetry: ITelemetryService | undefined,
+	properties: CaptureCompactionSkippedProperties &
+		Partial<TelemetryAgentIdentityProperties>,
+): void {
+	emit(telemetry, CORE_TELEMETRY_EVENTS.TASK.COMPACTION_SKIPPED, {
+		...properties,
 		timestamp: new Date().toISOString(),
 	});
 }


### PR DESCRIPTION
### Related Issue

**Issue:** CLINE-2174

### Description

Adds two new SDK telemetry events so we can see what's happening in the compaction pipeline.

**The problem.** The SDK had no dedicated compaction telemetry. The only existing coverage was a generic `agent.status-notice` pass-through that fired *before* the strategy ran, carrying just the trigger thresholds — no result data, no strategy attribution, no duration. The legacy `src/` code has `captureSummarizeTask` (called from `SummarizeTaskHandler.ts`) but the SDK had no equivalent.

**The fix.**

- `task.compaction_executed` fires after a successful compaction. Properties: `strategy` (`"basic" | "agentic" | "custom"`), `mode` (`"auto" | "manual"`), `messagesBefore/After/Removed`, `tokensBefore/After/Saved`, `triggerTokens`, `maxInputTokens`, `thresholdRatio`, `durationMs`, `provider`, `modelId`, agent identity, `ulid`.
- `task.compaction_skipped` fires when the configured strategy returns `undefined` (reason: `"no_result"` — the threshold was crossed but the strategy decided there was nothing safe to remove). Strategy *exceptions* still propagate up rather than firing telemetry; the JSDoc explicitly documents this.

`createContextCompactionPrepareTurn` was extended to accept `telemetry` and `sessionId` from `CoreSessionConfig` (both already plumbed by `local-runtime-host.ts`). The CLI manual `/compact` path forwards both so manual compactions emit events alongside auto.

**Known gap (documented inline):** plugin `registerMessageBuilder()` and runtime hook `beforeModel` compactions bypass `createContextCompactionPrepareTurn` entirely, so they emit no telemetry today. Called out in the JSDoc block on `createContextCompactionPrepareTurn`.

**Schema consistency.** Field names match the existing `TASK.*` capture-function convention (`provider`, `modelId`, `ulid`, `Partial<TelemetryAgentIdentityProperties>`) so downstream PostHog joins remain consistent with `captureTaskCompleted`, `captureToolUsage`, `captureSkillUsed`, etc. This was caught during peer review — the first revision used `providerId` and would have broken those joins.

### Test Procedure

**New tests (9 added):**

- `sdk/packages/core/src/services/telemetry/core-events.test.ts` — 5 tests covering both helpers: event name matches enum, properties pass through unchanged, ISO `timestamp` is added, optional `TelemetryAgentIdentityProperties` fields propagate, no-op when telemetry is `undefined`.
- `sdk/packages/core/src/extensions/context/compaction.test.ts` — 4 integration tests against the prepareTurn wrapper:
    1. Successful basic compaction emits `task.compaction_executed` with all expected props; asserts `tokensSaved === tokensBefore - tokensAfter`.
    2. A user-supplied `compact()` callback is tagged `strategy: "custom"`.
    3. A strategy returning `undefined` emits `task.compaction_skipped` with `reason: "no_result"` and no `task.compaction_executed`.
    4. `mode: "manual"` round-trips through the wrapper into the event.

**Verification commands run:**

```sh
bun -F @cline/core typecheck      # clean
bun -F @cline/cli typecheck       # clean
bun run types                     # all packages clean
bun -F @cline/core test:unit      # 50/50 relevant tests pass (23 telemetry + 27 compaction)
bun -F @cline/cli test:unit       # 505/505 tests pass
bun biome check                   # clean
```

The 6 pre-existing `src/hub/daemon/index.test.ts` failures are unrelated — they reproduce on plain `origin/main`.

**What could break.** The Pick<>-widening on `createContextCompactionPrepareTurn`'s config parameter is purely additive (both new fields are already declared optional on `CoreSessionConfig`), and the wrapper short-circuits when `telemetry` is `undefined`, so existing callers that don't pass telemetry are unaffected. The CLI manual `/compact` change is also additive.

**Why I'm confident this is ready.** Peer-reviewed with Claude Code (`claude -p` session) before submission. Round 1 caught a real `providerId`/`provider` field-name inconsistency vs. the rest of the `TASK.*` capture functions — fixed and confirmed in round 2 with an explicit `ACCEPTED` verdict.

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing and code is formatted and linted
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Backend-only change. Event schema:

```
task.compaction_executed
  ulid, agentId, conversationId, parentAgentId
  strategy: "basic" | "agentic" | "custom"
  mode: "auto" | "manual"
  messagesBefore, messagesAfter, messagesRemoved
  tokensBefore, tokensAfter, tokensSaved
  triggerTokens, maxInputTokens, thresholdRatio
  durationMs
  provider, modelId
  timestamp

task.compaction_skipped
  (same identity / provider / timing fields)
  reason: "no_result"
  tokensBefore, triggerTokens, maxInputTokens, thresholdRatio
```

### Additional Notes

- Scoped to the SDK at `sdk/`. The legacy VSCode extension at `src/` already has its one compaction event (`captureSummarizeTask`) and is not touched here.
- No changelog entry — per repo guidelines, maintainers handle changelog curation during the release process.
- Field naming on `provider` (not `providerId`) is a deliberate choice for downstream-query consistency; an inline comment in `core-events.ts` documents why.
