### PR TITLE
docs(readme): add Quick Start block above the surface grid

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,18 @@
 
 <br>
 
+## Quick Start
+
+Get a running agent in under a minute:
+
+```bash
+npm i -g cline
+cline auth
+cline "what does this repo do?"
+```
+
+For other surfaces, see the [VS Code extension](https://marketplace.visualstudio.com/items?itemName=saoudrizwan.claude-dev), [JetBrains plugin](https://plugins.jetbrains.com/plugin/28247-cline), [SDK](#sdk), or [Kanban](https://github.com/cline/kanban).
+
 <div align="center">
 <table>
 <tr>


### PR DESCRIPTION
Insert a `## Quick Start` section between the hero and the surface grid so a reader can install and run cline in under a minute without scrolling through the surface descriptions first.

```bash
npm i -g cline
cline auth
cline "what does this repo do?"
```

Plus a one-liner pointing to the other surfaces (VS Code, JetBrains, SDK, Kanban) for readers who want a non-CLI on-ramp. Mirrors the pattern already in use in `sdk/apps/cli/README.md`.