### PR TITLE
docs(readme): repoint SDK link to in-repo README

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Build your own AI agents and integrations powered by the same engine that runs t
 npm install @cline/sdk
 ```
 
-<a href="https://docs.cline.bot/cline-sdk/overview">Documentation</a>
+<a href="./sdk/README.md">Learn more</a>
 <br><br>
 
 </td>


### PR DESCRIPTION
The "Documentation" link in the SDK cell points at `https://docs.cline.bot/cline-sdk/overview`, which today renders the old ACP-based `ClineAgent` page from March. That predates the new `@cline/sdk` package, so a launch-day reader who clicks through sees an SDK that doesn't match the README.

Repoint to `./sdk/README.md` (in-repo), matching the pattern the CLI cell already uses (`./sdk/apps/cli/README.md`). Link text changes from "Documentation" to "Learn more" for consistency.

Once the new SDK docs tab on docs.cline.bot ships, a one-line follow-up can repoint to it.