### PR TITLE
docs(readme): tidy Repo Map table

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,8 +112,8 @@ Cline ships across multiple surfaces. When you are reading about a feature below
 |---------|------------|--------------|
 | **SDK** | Node.js programmatic agent API and extension exports. | [`./sdk/`](https://github.com/cline/cline/tree/main/sdk) |
 | **CLI** | Terminal UI, headless mode, shell commands, and CLI-specific flows. | [`./sdk/apps/cli/`](https://github.com/cline/cline/tree/main/sdk/apps/cli) |
-| **VS Code Extension** | The Marketplace extension and extension host integration. | [`./`](https://github.com/cline/cline/tree/main) (WIP migrating) |
-| **JetBrains Plugin** | JetBrains-hosted client that talks to the shared agent core. | Currently we are not open-sourcing JetBrains plugins |
+| **VS Code Extension** | The Marketplace extension and extension host integration. | [`./`](https://github.com/cline/cline/tree/main) |
+| **JetBrains Plugin** | JetBrains-hosted client that talks to the shared agent core. | Closed source. [JetBrains Marketplace](https://plugins.jetbrains.com/plugin/28247-cline). |
 | **Kanban** | Web-based multi-agent task board. | Kanban app code lives in [`cline/kanban`](https://github.com/cline/kanban). |
 | **Docs site** | Public documentation pages. | `docs/` |
 


### PR DESCRIPTION
Two small cleanups in the Repository Map table:

1. VS Code Extension row: drop the `(WIP migrating)` qualifier. The extension code still lives at the repo root after the SDK monorepo merge; the qualifier reads as half-finished for a launch front door.
2. JetBrains Plugin row: replace the prose pointer (`Currently we are not open-sourcing JetBrains plugins`) with a link to the JetBrains Marketplace listing. Closed-source status preserved as a short prefix so readers still know not to hunt for code in-repo.