### PR TITLE
docs(readme): reframe hero copy for SDK + CLI v3 launch

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <h1 align="center">Cline</h1>
 
 <p align="center">
-  Autonomous AI coding agents for your IDE, terminal, and applications.
+  Open source AI coding agents for your IDE, terminal, and applications.
 </p>
 
 <div align="center">
@@ -13,6 +13,10 @@
 [Discord](https://discord.gg/cline) | [Documentation](https://docs.cline.bot) | [Reddit](https://www.reddit.com/r/cline/) | [Feature Requests](https://github.com/cline/cline/discussions/categories/feature-requests?discussions_q=is%3Aopen+category%3A%22Feature+Requests%22+sort%3Atop) | [Careers](https://cline.bot/join-us)
 
 </div>
+
+<p align="center">
+  <em>New:</em> Cline SDK and CLI v3 are live. <code>npm i -g cline</code> for the CLI, or <a href="#sdk">install the SDK</a>.
+</p>
 
 <br>
 


### PR DESCRIPTION
Two small hero-area edits to make the SDK + CLI v3 launch land on the repo's front door.

1. Tagline: `Autonomous AI coding agents for your IDE, terminal, and applications.` becomes `Open source AI coding agents for your IDE, terminal, and applications.` The previous tagline does not name a real differentiator. Open source is one of the most meaningful claims Cline can make versus closed-source incumbents, and it fits the same slot.

2. Launch callout: a single centered line below the existing links row:

   > New: Cline SDK and CLI v3 are live. `npm i -g cline` for the CLI, or install the SDK.

   Subtle enough to not dominate the hero, visible enough that a reader arriving from the announcement immediately sees what is new. The `#sdk` anchor resolves to the existing SDK heading further down.

Both edits are independently revertable if the team prefers to keep the original framing.