### PR TITLE
docs(readme): add positioning sentence below the surface grid

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,10 @@ npm install @cline/sdk
 </table>
 </div>
 
+<p align="center">
+  Open source. Runs in your IDE, terminal, or as a library. Works with every major model. Extensible through MCP servers and plugins.
+</p>
+
 ---
 
 ## Repository Map


### PR DESCRIPTION
A reader scrolling through today's README has to infer Cline's differentiation from the cumulative feature list. The hero tagline names what Cline is, the surface grid names where it runs, but nothing says what is distinct.

Add a single centered line between the surface grid and the Repository Map:

> Open source. Runs in your IDE, terminal, or as a library. Works with every major model. Extensible through MCP servers and plugins.

22 words. No comparison table, no marketing copy. Each clause is verifiable from elsewhere in the README:

- Open source: Apache 2.0 in LICENSE.
- Runs in your IDE, terminal, or as a library: the four surface cells above.
- Works with every major model: the model table further down.
- Extensible through MCP servers and plugins: the Extend section further down.

Placed below the surface grid rather than in the hero so the hero stays uncluttered.