### PR TITLE
docs(sdk): reframe runtime page as ClineCore, remove tier choice from overview

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -204,7 +204,7 @@
 							"sdk/guides/scheduled-agents",
 							"sdk/events",
 							"sdk/model-providers",
-							"sdk/session-management"
+							"sdk/clinecore"
 						]
 					},
 					{
@@ -790,11 +790,11 @@
 		},
 		{
 			"source": "/cline-sdk/agents",
-			"destination": "/sdk/session-management"
+			"destination": "/sdk/clinecore"
 		},
 		{
 			"source": "/cline-sdk/sessions",
-			"destination": "/sdk/session-management"
+			"destination": "/sdk/clinecore"
 		},
 		{
 			"source": "/cline-sdk/tools",
@@ -922,11 +922,11 @@
 		},
 		{
 			"source": "/sdk/agents",
-			"destination": "/sdk/session-management"
+			"destination": "/sdk/clinecore"
 		},
 		{
 			"source": "/sdk/sessions",
-			"destination": "/sdk/session-management"
+			"destination": "/sdk/clinecore"
 		},
 		{
 			"source": "/sdk/streaming-and-events",

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -204,7 +204,7 @@
 							"sdk/guides/scheduled-agents",
 							"sdk/events",
 							"sdk/model-providers",
-							"sdk/runtime"
+							"sdk/session-management"
 						]
 					},
 					{
@@ -790,11 +790,11 @@
 		},
 		{
 			"source": "/cline-sdk/agents",
-			"destination": "/sdk/runtime"
+			"destination": "/sdk/session-management"
 		},
 		{
 			"source": "/cline-sdk/sessions",
-			"destination": "/sdk/runtime"
+			"destination": "/sdk/session-management"
 		},
 		{
 			"source": "/cline-sdk/tools",
@@ -922,11 +922,11 @@
 		},
 		{
 			"source": "/sdk/agents",
-			"destination": "/sdk/runtime"
+			"destination": "/sdk/session-management"
 		},
 		{
 			"source": "/sdk/sessions",
-			"destination": "/sdk/runtime"
+			"destination": "/sdk/session-management"
 		},
 		{
 			"source": "/sdk/streaming-and-events",

--- a/docs/sdk/clinecore.mdx
+++ b/docs/sdk/clinecore.mdx
@@ -1,16 +1,12 @@
 ---
-title: "Session Management"
-sidebarTitle: "Session Management"
-description: "How the SDK handles sessions, persistence, and state across agent runs."
+title: "ClineCore"
+sidebarTitle: "ClineCore"
+description: "The full Cline harness: built-in tools, sessions, approvals, scheduling, and hub support."
 ---
 
-The SDK lets you choose how much session management you want it to handle.
+`ClineCore` is the full Cline harness as a programmable runtime. It gives you everything Cline ships out of the box: built-in tools for files, shell, search, and web; session persistence and message history; tool approval callbacks; local, hub, and remote backends; scheduling and automation APIs; and plugin support.
 
-`ClineCore` manages everything: session persistence, message history, built-in tools, approvals, scheduling, and hub support. Use it when you want a fully managed agent runtime.
-
-`Agent` (also exported as `AgentRuntime`) is the stateless primitive underneath. You bring your own tools and manage your own state. Use it when you want direct control, lightweight embedding, or browser compatibility.
-
-`Agent` is an alias for `AgentRuntime`. Use `Agent` when constructing from provider/model IDs. Use `AgentRuntime` when supplying a pre-built `AgentModel`.
+Under the hood, `ClineCore` uses the `Agent` class from `@cline/agents`. You can use `Agent` directly if you want to skip the harness and wire everything yourself: your own tools, your own persistence, your own lifecycle.
 
 ## When to use which
 
@@ -24,63 +20,6 @@ The SDK lets you choose how much session management you want it to handle.
 | Browser-compatible or lightweight in-process agent | `Agent` |
 | Custom tools only, no built-ins | `Agent` |
 | Full control over persistence and lifecycle | `Agent` |
-
-## Agent / AgentRuntime
-
-`Agent` runs the core loop:
-
-```txt
-run() or continue()
-  -> model request
-  -> tool calls, if any
-  -> tool results
-  -> repeat until complete
-```
-
-```typescript
-import { Agent } from "@cline/sdk"
-
-const agent = new Agent({
-  providerId: "anthropic",
-  modelId: "claude-sonnet-4-6",
-  apiKey: process.env.ANTHROPIC_API_KEY,
-  systemPrompt: "You are a helpful coding assistant.",
-  tools: [myTool],
-})
-
-agent.subscribe((event) => {
-  if (event.type === "assistant-text-delta") {
-    process.stdout.write(event.text ?? "")
-  }
-})
-
-const result = await agent.run("Review this diff")
-console.log(result.outputText)
-```
-
-### Methods
-
-| Method | Purpose |
-|--------|---------|
-| `run(input)` | Start a run with user input |
-| `continue(input?)` | Continue with optional new input |
-| `abort(reason?)` | Abort the active run |
-| `subscribe(listener)` | Listen to `AgentRuntimeEvent` events |
-| `restore(messages)` | Replace conversation history |
-| `snapshot()` | Read runtime state |
-
-See [Agent reference](/sdk/reference/agent) for exact signatures.
-
-## Multi-Turn Conversations
-
-`AgentRuntime` keeps message state internally. Use `continue()` after the first run:
-
-```typescript
-await agent.run("What does this project do?")
-await agent.continue("Now identify risky files")
-```
-
-If you persist messages externally, restore them with `restore(messages)` before continuing.
 
 ## ClineCore
 
@@ -203,3 +142,64 @@ const cline = await ClineCore.create({
 ```
 
 For tool behavior and policies, see [Tools](/sdk/tools).
+
+## Using Agent directly
+
+`Agent` (also exported as `AgentRuntime`) is the stateless primitive that `ClineCore` builds on. Use it directly when you want full control or don't need the harness.
+
+`Agent` is an alias for `AgentRuntime`. Use `Agent` when constructing from provider/model IDs. Use `AgentRuntime` when supplying a pre-built `AgentModel`.
+
+`Agent` runs the core loop:
+
+```txt
+run() or continue()
+  -> model request
+  -> tool calls, if any
+  -> tool results
+  -> repeat until complete
+```
+
+```typescript
+import { Agent } from "@cline/sdk"
+
+const agent = new Agent({
+  providerId: "anthropic",
+  modelId: "claude-sonnet-4-6",
+  apiKey: process.env.ANTHROPIC_API_KEY,
+  systemPrompt: "You are a helpful coding assistant.",
+  tools: [myTool],
+})
+
+agent.subscribe((event) => {
+  if (event.type === "assistant-text-delta") {
+    process.stdout.write(event.text ?? "")
+  }
+})
+
+const result = await agent.run("Review this diff")
+console.log(result.outputText)
+```
+
+### Agent Methods
+
+| Method | Purpose |
+|--------|---------|
+| `run(input)` | Start a run with user input |
+| `continue(input?)` | Continue with optional new input |
+| `abort(reason?)` | Abort the active run |
+| `subscribe(listener)` | Listen to `AgentRuntimeEvent` events |
+| `restore(messages)` | Replace conversation history |
+| `snapshot()` | Read runtime state |
+
+See [Agent reference](/sdk/reference/agent) for exact signatures.
+
+### Multi-Turn Conversations
+
+`AgentRuntime` keeps message state internally. Use `continue()` after the first run:
+
+```typescript
+await agent.run("What does this project do?")
+await agent.continue("Now identify risky files")
+```
+
+If you persist messages externally, restore them with `restore(messages)` before continuing.

--- a/docs/sdk/overview.mdx
+++ b/docs/sdk/overview.mdx
@@ -65,16 +65,6 @@ const result = await agent.run("Explain what an SDK is in two sentences.")
 
 See [Packages](/sdk/architecture/overview) for package boundaries and exports.
 
-## Runtime Choices
-
-| Runtime | Use when |
-|---------|----------|
-| `ClineCore` | The fully featured Cline agent that you can customize and build upon. Includes session management, built-in tools, approvals, config discovery, channels, and scheduling |
-| `Agent` / `AgentRuntime` | A stateless in-process loop that offers even more control. ClineCore depends on the Agents package. Build with Agents directly if you want to control tools, session persistence, and configuration directly |
-
-
-See [Agent vs ClineCore](/sdk/runtime).
-
 ## Next Steps
 
 <CardGroup cols={2}>

--- a/docs/sdk/session-management.mdx
+++ b/docs/sdk/session-management.mdx
@@ -1,28 +1,29 @@
 ---
-title: "Agent vs ClineCore"
-sidebarTitle: "Agent vs ClineCore"
-description: "Choose between the stateless AgentRuntime loop and the full ClineCore runtime."
+title: "Session Management"
+sidebarTitle: "Session Management"
+description: "How the SDK handles sessions, persistence, and state across agent runs."
 ---
 
-The SDK has two main runtime entry points:
+The SDK lets you choose how much session management you want it to handle.
 
-- `ClineCore` from `@cline/core`: Node runtime with sessions, persistence, built-in tools, approvals, automation, and hub support.
-- `Agent` / `AgentRuntime` from `@cline/agents`: browser-compatible, stateless, in-process execution. You provide tools, persistence, and lifecycle management.
+`ClineCore` manages everything: session persistence, message history, built-in tools, approvals, scheduling, and hub support. Use it when you want a fully managed agent runtime.
+
+`Agent` (also exported as `AgentRuntime`) is the stateless primitive underneath. You bring your own tools and manage your own state. Use it when you want direct control, lightweight embedding, or browser compatibility.
 
 `Agent` is an alias for `AgentRuntime`. Use `Agent` when constructing from provider/model IDs. Use `AgentRuntime` when supplying a pre-built `AgentModel`.
 
-## Which Runtime to Use
+## When to use which
 
 | Need | Use |
 |------|-----|
-| Browser-compatible or lightweight in-process agent | `Agent` / `AgentRuntime` |
-| Custom tools only | `Agent` / `AgentRuntime` |
-| Manual control over persistence | `Agent` / `AgentRuntime` |
+| Sessions, persistence, message history | `ClineCore` |
 | Built-in tools for files, shell, search, web fetch | `ClineCore` |
-| Session persistence | `ClineCore` |
 | Hub/remote runtime | `ClineCore` |
 | Scheduling or event automation | `ClineCore` |
 | Multi-agent teams | `ClineCore` |
+| Browser-compatible or lightweight in-process agent | `Agent` |
+| Custom tools only, no built-ins | `Agent` |
+| Full control over persistence and lifecycle | `Agent` |
 
 ## Agent / AgentRuntime
 


### PR DESCRIPTION
The SDK overview page had a "Runtime Choices" section with an "Agent vs ClineCore" comparison table sitting right in the middle of the page. For a new user landing on the SDK docs for the first time, this is a confusing fork-in-the-road -- they don't know what either of those classes are yet, and asking them to choose between two things they've never heard of is a bounce risk.

Two changes:

1. Removed the "Runtime Choices" section from `docs/sdk/overview.mdx`. The overview now flows cleanly: intro, install, minimal Agent snippet, packages table, next steps cards. No decision points blocking the reader.

2. Renamed `docs/sdk/runtime.mdx` to `docs/sdk/clinecore.mdx` and reframed it. The old framing was "Agent vs ClineCore" -- two classes competing for your attention. The new framing is "ClineCore" -- this is the full Cline harness, here's what it gives you (built-in tools, sessions, approvals, scheduling, hub, plugins). Agent is explained at the bottom as the stateless primitive underneath that you use when you want to skip the harness and wire everything yourself. All original content (code examples, methods tables, backend modes, session artifacts, tool approval, "when to use which" table) is preserved, just reordered so ClineCore leads.

Nav entries and redirects in `docs.json` updated to point at the new `/sdk/clinecore` path.
