### PR TITLE
docs(sdk): add SDK skill section to overview and README

### DIFF
--- a/docs/sdk/overview.mdx
+++ b/docs/sdk/overview.mdx
@@ -4,7 +4,7 @@ sidebarTitle: "Overview"
 description: "TypeScript packages for embedding Cline's agent runtime in your own applications."
 ---
 
-The Cline SDK is an open source framework for building agentic applications, and is the same harness used in the Cline IDE extensions and CLI. It uses a plugin architecture that makes it easy to customize and comes with all the features you expect from agents like checkpoints, web fetch, MCPs, cron jobs, agent teams, and more.
+The Cline SDK is an open source framework for building agentic applications, and is the same harness used in the Cline IDE extensions and CLI. It uses a plugin architecture that makes it easy to customize and comes with all the features you expect from agents like checkpoints, web fetch, MCPs, cron jobs, subagents, and more.
 
 Use the Cline SDK to run agents from CI/CD pipelines, create automations for end-to-end workflows, or embed agents directly inside your products.
 

--- a/docs/sdk/overview.mdx
+++ b/docs/sdk/overview.mdx
@@ -1,19 +1,12 @@
 ---
 title: "Cline SDK"
 sidebarTitle: "Overview"
-description: "TypeScript packages for embedding Cline agents, tools, providers, and sessions."
+description: "TypeScript packages for embedding Cline's agent runtime in your own applications."
 ---
 
-The Cline SDK is a set of TypeScript packages for embedding Cline's agent runtime in your own applications.
+The Cline SDK is an open source framework for building agentic applications, and is the same harness used in the Cline IDE extensions and CLI. It uses a plugin architecture that makes it easy to customize and comes with all the features you expect from agents like checkpoints, web fetch, MCPs, cron jobs, agent teams, and more.
 
-Use it to build:
-
-- in-process agents with custom tools
-- coding agents with file, shell, search, and web tools
-- persistent sessions
-- chat connectors
-- scheduled automations
-- multi-agent workflows
+Use the Cline SDK to run agents from CI/CD pipelines, create automations for end-to-end workflows, or embed agents directly inside your products.
 
 ## Install
 
@@ -21,11 +14,21 @@ Use it to build:
 npm install @cline/sdk
 ```
 
-`@cline/sdk` re-exports everything from `@cline/core`. You only need `@cline/agents` or `@cline/llms` if you want lower-level control over the agent runtime or model gateway directly.
+`@cline/sdk` exports all SDK packages: `@cline/core` for the full agent harness, `@cline/agents` for the stateless agent loop, `@cline/llms` for control over the model gateway, and `@cline/shared` for common utilities.
 
 Requires Node.js 22 or later.
 
-## Minimal Agent
+## SDK Skill
+
+If you use a coding agent (Claude Code, Codex, Cline, etc.), install the [Cline SDK skill](https://github.com/cline/sdk-skill) to give your agent context on the SDK's APIs and best practices to help you build with the Cline SDK.
+
+```bash
+npx skills add cline/sdk-skill
+```
+
+Prompt it to scaffold agents, create custom tools, wire up plugins, configure providers, and more.
+
+## Your First Agent
 
 ```typescript
 import { Agent } from "@cline/sdk"
@@ -59,7 +62,6 @@ const result = await agent.run("Explain what an SDK is in two sentences.")
 | `@cline/agents` | Browser-compatible stateless agent execution loop |
 | `@cline/llms` | Provider gateway and model catalogs |
 | `@cline/shared` | Types, schemas, tool helpers, hooks, storage helpers |
-
 
 
 

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -42,6 +42,16 @@ That's it. The agent streams its response, calls tools if you give it any, and r
 npm install @cline/sdk
 ```
 
+## SDK Skill
+
+If you use a coding agent (Claude Code, Codex, Cline, etc.), install the [Cline SDK skill](https://github.com/cline/sdk-skill) to give your agent context on the SDK's APIs and best practices to help you build with the Cline SDK.
+
+```bash
+npx skills add cline/sdk-skill
+```
+
+Prompt it to scaffold agents, create custom tools, wire up plugins, configure providers, and more.
+
 ## What You Can Build
 
 Coding agents, Slack bots, scheduled automations, code review pipelines, multi-agent teams, IDE integrations -- anything that benefits from an LLM that can take actions, not just generate text.


### PR DESCRIPTION
### Related Issue

N/A -- documentation addition for the new [cline/sdk-skill](https://github.com/cline/sdk-skill) repo.

### Description

We just shipped a [Cline SDK skill](https://github.com/cline/sdk-skill) that coding agents can install via `npx skills add cline/sdk-skill` to get deep context on the SDK's APIs, patterns, and best practices. This PR adds a short "SDK Skill" section to two places so developers discover it:

1. `docs/sdk/overview.mdx` -- the docs site overview page. Also rewrote the intro paragraph to better position the SDK (same engine as the IDE extensions/CLI, plugin architecture, feature highlights) and reframed the install section to explain what each sub-package does.

2. `sdk/README.md` -- the GitHub-facing README. Added the same skill section right after Install so it's visible to anyone landing on the repo.

Both use the same concise copy:

> If you use a coding agent (Claude Code, Codex, Cline, etc.), install the Cline SDK skill to give your agent context on the SDK's APIs and best practices to help you build with the Cline SDK.

### Test Procedure

Documentation-only change. Verified the markdown renders correctly and links point to the right repo.

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [x] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)