### PR TITLE
fix(agents): reset usage at start of each execute() call

### DIFF
--- a/sdk/packages/agents/src/agent-runtime.test.ts
+++ b/sdk/packages/agents/src/agent-runtime.test.ts
@@ -1388,4 +1388,40 @@ describe("AgentRuntime", () => {
 			true,
 		);
 	});
+
+	it("resets usage between consecutive run/continue calls", async () => {
+		const model = new ScriptedModel([
+			() => [
+				{
+					type: "usage",
+					usage: { inputTokens: 100, outputTokens: 20, totalCost: 0.5 },
+				},
+				{ type: "text-delta", text: "first" },
+				{ type: "finish", reason: "stop" },
+			],
+			() => [
+				{
+					type: "usage",
+					usage: { inputTokens: 200, outputTokens: 40, totalCost: 1.0 },
+				},
+				{ type: "text-delta", text: "second" },
+				{ type: "finish", reason: "stop" },
+			],
+		]);
+		const runtime = new AgentRuntime({ model });
+
+		const first = await runtime.run("Turn 1");
+		expect(first.usage).toMatchObject({
+			inputTokens: 100,
+			outputTokens: 20,
+			totalCost: 0.5,
+		});
+
+		const second = await runtime.continue("Turn 2");
+		expect(second.usage).toMatchObject({
+			inputTokens: 200,
+			outputTokens: 40,
+			totalCost: 1.0,
+		});
+	});
 });

--- a/sdk/packages/agents/src/agent-runtime.ts
+++ b/sdk/packages/agents/src/agent-runtime.ts
@@ -537,6 +537,7 @@ export class AgentRuntime {
 		this.state.iteration = 0;
 		this.state.pendingToolCalls = [];
 		this.state.lastError = undefined;
+		this.state.usage = cloneUsage(DEFAULT_USAGE);
 
 		try {
 			await this.callBeforeRunHooks();


### PR DESCRIPTION
### Related Issue

N/A -- found during debugging inflated token counts in SDK CLI interactive sessions.

### Description

`AgentRuntime.execute()` (which backs both `run()` and `continue()`) was resetting per-run state like `iteration`, `pendingToolCalls`, and `lastError` at the start of each call, but it was not resetting `this.state.usage`. This was introduced in #219 (`64c8ddbcc`, April 23) when the execute method was refactored.

Because usage was never zeroed between calls, `result.usage` after turn N contained the cumulative sum of all N turns. The host layer in `local-runtime-host.ts` then treated this as a per-turn value and added it on top of `usageBaseline` (which already contained prior turns' totals via `accumulateUsageTotals`). The result was that every prior turn's tokens got double-counted on each new turn.

Concrete example of the inflation pattern with ~25k input tokens per turn:
- After turn 1: reported 25k (correct)
- After turn 2: reported 75k instead of 50k (25k baseline + 50k cumulative)
- After turn 3: reported 150k instead of 75k (75k baseline + 75k cumulative)

The fix is a single line: reset `this.state.usage` to defaults at the start of `execute()`, just like the other per-run fields. This way `result.usage` reflects only the current execution, which is what `local-runtime-host.ts` expects when it accumulates onto the baseline.

This is related to but distinct from #10689 (`7b48ead59`), which fixed a separate double-counting path in `withLatestAssistantTurnMetadata` where aggregate session totals were stamped onto terminal assistant messages even when per-turn metrics already existed. That fix was necessary but insufficient -- even with correct message-level metrics, the host-layer accumulation was still inflating the session totals reported to the CLI.

### Test Procedure

Added a test `"resets usage between consecutive run/continue calls"` that creates an `AgentRuntime`, calls `run()` then `continue()` with distinct usage values, and asserts that each result contains only its own turn's usage (not cumulative). Before the fix this test fails because the second result includes turn 1's tokens on top of turn 2's.

Also ran the full SDK test suite -- all 207 service/agent tests pass. The 14 failing test files in CI are all CLI e2e/integration tests that fail due to sandbox environment constraints (missing `script` command), unrelated to this change.

### Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

### Pre-flight Checklist

- [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
- [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
- [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)