### PR TITLE
feat: collect and output agent system prompt and IO log on task compl…

### DIFF
--- a/src/core/storage/disk.ts
+++ b/src/core/storage/disk.ts
@@ -45,6 +45,8 @@ export const GlobalFileNames = {
 	apiConversationHistory: "api_conversation_history.json",
 	contextHistory: "context_history.json",
 	uiMessages: "ui_messages.json",
+	agentPromptInfo: "agent_prompt_info.json",
+	agentIoLog: "agent_io_log.json",
 	clineRecommendedModels: "cline_recommended_models.json",
 	clineModels: "cline_models.json",
 	openRouterModels: "openrouter_models.json",

--- a/src/core/task/index.ts
+++ b/src/core/task/index.ts
@@ -242,6 +242,22 @@ export class Task {
 	private modelContextTracker: ModelContextTracker
 	private environmentContextTracker: EnvironmentContextTracker
 
+	// Agent prompt & IO collection
+	private collectedSystemPrompt: string = ""
+	private collectedThinkingMode: "fast" | "slow" = "fast"
+	private collectedIoLog: Array<{
+		request_number: number
+		timestamp: string
+		provider: string
+		model: string
+		mode: string
+		system_prompt: string
+		messages: unknown[]
+		tools: unknown[]
+		response: unknown | null
+	}> = []
+	private currentRequestIoEntry: (typeof this.collectedIoLog)[number] | null = null
+
 	// Focus Chain
 	private FocusChainManager?: FocusChainManager
 
@@ -1624,6 +1640,9 @@ export class Task {
 				Logger.error("Failed to post state after setting abort flag", error)
 			}
 
+			// PHASE 5.5: Write agent output files (system prompt + IO log)
+			await this.writeAgentOutputFiles()
+
 			// PHASE 6: Check for incomplete progress
 			if (this.FocusChainManager) {
 				// Extract current model and provider for telemetry
@@ -1784,6 +1803,51 @@ export class Task {
 			])
 		} catch (error) {
 			Logger.error("Failed to write prompt metadata artifacts:", error)
+		}
+	}
+
+	/**
+	 * Write two JSON files to the task directory when the task completes:
+	 * 1. agent_prompt_info.json - system prompt and thinking mode
+	 * 2. agent_io_log.json - all request/response data from the task
+	 */
+	private async writeAgentOutputFiles(): Promise<void> {
+		try {
+			const taskDir = await ensureTaskDirectoryExists(this.taskId)
+
+			// If we have an in-flight request entry that didn't get a response (e.g. aborted mid-stream),
+			// still include it in the log
+			if (this.currentRequestIoEntry) {
+				this.collectedIoLog.push(this.currentRequestIoEntry)
+				this.currentRequestIoEntry = null
+			}
+
+			const promptInfo = {
+				coding_agent_system_prompt: this.collectedSystemPrompt,
+				thinking_mode: this.collectedThinkingMode,
+			}
+
+			const ioLog = {
+				task_id: this.taskId,
+				total_requests: this.collectedIoLog.length,
+				requests: this.collectedIoLog,
+			}
+
+			await Promise.all([
+				fs.writeFile(
+					path.join(taskDir, GlobalFileNames.agentPromptInfo),
+					JSON.stringify(promptInfo, null, 2),
+					"utf8",
+				),
+				fs.writeFile(
+					path.join(taskDir, GlobalFileNames.agentIoLog),
+					JSON.stringify(ioLog, null, 2),
+					"utf8",
+				),
+			])
+			Logger.info(`[Task ${this.taskId}] Agent output files written to ${taskDir}`)
+		} catch (error) {
+			Logger.error(`[Task ${this.taskId}] Failed to write agent output files:`, error)
 		}
 	}
 
@@ -1993,6 +2057,21 @@ export class Task {
 		this.useNativeToolCalls = !!tools?.length
 		await this.writePromptMetadataArtifacts({ systemPrompt, providerInfo })
 
+		// Collect system prompt (always keep the latest)
+		this.collectedSystemPrompt = systemPrompt
+
+		// Determine thinking mode: "slow" if extended thinking budget is set, "fast" otherwise
+		{
+			const apiConfig = this.stateManager.getApiConfiguration()
+			const currentMode = this.stateManager.getGlobalSettingsKey("mode")
+			const thinkingBudget =
+				currentMode === "plan" ? apiConfig.planModeThinkingBudgetTokens : apiConfig.actModeThinkingBudgetTokens
+			const modelId = providerInfo.model.id
+			const hasThinkingBudget = thinkingBudget !== undefined && thinkingBudget > 0
+			const isFastModel = modelId.includes(":fast")
+			this.collectedThinkingMode = hasThinkingBudget && !isFastModel ? "slow" : "fast"
+		}
+
 		const contextManagementMetadata = await this.contextManager.getNewContextMessagesAndMetadata(
 			this.messageStateHandler.getApiConversationHistory(),
 			this.messageStateHandler.getClineMessages(),
@@ -2007,6 +2086,19 @@ export class Task {
 			this.taskState.conversationHistoryDeletedRange = contextManagementMetadata.conversationHistoryDeletedRange
 			await this.messageStateHandler.saveClineMessagesAndUpdateHistory()
 			// saves task history item which we use to keep track of conversation history deleted range
+		}
+
+		// Collect IO log entry for this request (response will be filled after streaming)
+		this.currentRequestIoEntry = {
+			request_number: this.taskState.apiRequestCount,
+			timestamp: new Date().toISOString(),
+			provider: providerInfo.providerId,
+			model: providerInfo.model.id,
+			mode: providerInfo.mode,
+			system_prompt: systemPrompt,
+			messages: contextManagementMetadata.truncatedConversationHistory,
+			tools: tools || [],
+			response: null,
 		}
 
 		// Response API requires native tool calls to be enabled
@@ -3153,6 +3245,26 @@ export class Task {
 						},
 						ts: Date.now(),
 					})
+				}
+
+				// Capture response into IO log entry
+				if (this.currentRequestIoEntry) {
+					this.currentRequestIoEntry.response = {
+						role: "assistant",
+						content: assistantContent,
+						modelInfo,
+						id: requestId,
+						metrics: {
+							tokens: {
+								prompt: taskMetrics.inputTokens,
+								completion: taskMetrics.outputTokens,
+								cached: (taskMetrics.cacheWriteTokens ?? 0) + (taskMetrics.cacheReadTokens ?? 0),
+							},
+							cost: taskMetrics.totalCost,
+						},
+					}
+					this.collectedIoLog.push(this.currentRequestIoEntry)
+					this.currentRequestIoEntry = null
 				}
 			}
 


### PR DESCRIPTION
…etion

Adds two JSON files written to the task directory when a task completes:
- agent_prompt_info.json: contains coding_agent_system_prompt and thinking_mode (fast/slow)
- agent_io_log.json: contains all request/response data from the entire task session

Files are output to the default task storage path, which in containers maps to ~/.vscode-server/data/User/globalStorage/saoudrizwan.claude-dev/tasks/{taskId}/

<!--
Thank you for contributing to Cline!

⚠️ Important: Before submitting this PR, please ensure you have:
- For feature requests: Created a discussion in our Feature Requests discussions board https://github.com/cline/cline/discussions/categories/feature-requests and received approval from core maintainers before implementation
- For all changes: Link the associated issue/discussion in the "Related Issue" section below

Limited exceptions:
Small bug fixes, typo corrections, minor wording improvements, or simple type fixes that don't change functionality may be submitted directly without prior discussion.

Why this requirement?
We deeply appreciate all community contributions - they are essential to Cline's success! To ensure the best use of everyone's time and maintain project direction, we use our Feature Requests discussions board to gauge community interest and validate feature ideas before implementation begins. This helps us focus development efforts on features that will benefit the most users.
-->

### Related Issue

<!-- Replace XXXX with the issue number that this PR addresses -->
**Issue:** #XXXX

### Description

<!-- 
Help reviewers understand your changes by making this PR readable and well-organized:

- What problem does this PR solve?
- Why were these changes introduced and what purpose do they serve?
- For larger changes, provide context about your approach and reasoning

Small PRs may need minimal description, but larger changes benefit from explaining where you're coming from. Much of this context can be in the linked issue above, so feel free to reference it rather than repeating everything here.
-->

### Test Procedure

<!-- 
Please walk us through your testing approach and thought process. This helps reviewers understand that you've thoroughly considered the impact of your changes:

- How did you test this change?
- What could potentially break and how did you verify it doesn't?
- What existing functionality might be affected and how did you check it still works?
- Why are you confident this is ready for merge?

We're not looking for exhaustive documentation - just evidence that you've thought through the implications of your changes and tested accordingly.
-->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [ ] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- 
Help reviewers quickly understand your changes:

- **UI Changes**: Please include screenshots showing before/after states
- **Complex Workflows**: Consider uploading a screen recording (video) if your changes involve multiple steps or state transitions
- **Backend Changes**: Not required, but feel free to include terminal output or other evidence that demonstrates functionality

This helps reviewers see what you've built without having to pull down and test your branch first.
-->

### Additional Notes

<!-- Add any additional notes for reviewers -->
