### PR TITLE
chore(cli): prepare 3.0.1 release

### DIFF
--- a/sdk/apps/cli/CHANGELOG.md
+++ b/sdk/apps/cli/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Cline CLI Changelog
 
+## 3.0.1
+
+- Fix CLI release cleanup scripts so they work correctly on Windows.
+- Fix the kanban migration notice wording in the TUI.
+
 ## 3.0.0
 
 Introducing our new Cline CLI built on our new SDK and comes with a snappy new TUI.

--- a/sdk/apps/cli/package.json
+++ b/sdk/apps/cli/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@cline/cli",
 	"displayName": "cline",
-	"version": "3.0.0",
+	"version": "3.0.1",
 	"description": "Autonomous coding agent CLI - capable of creating/editing files, running commands, using the browser, and more",
 	"type": "module",
 	"publishConfig": {

--- a/sdk/bun.lock
+++ b/sdk/bun.lock
@@ -19,7 +19,7 @@
     },
     "apps/cli": {
       "name": "@cline/cli",
-      "version": "3.0.0",
+      "version": "3.0.1",
       "bin": {
         "cline": "src/index.ts",
       },


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

### Description

Prepare the Cline CLI 3.0.1 release by bumping `sdk/apps/cli/package.json`, refreshing the `sdk/bun.lock` workspace version, and adding the 3.0.1 changelog entry.

After this merges, the release tag should be cut as `cli-v3.0.1` from the merged commit before running the `Publish CLI to NPM` workflow with `publish_target=main`.

### Test Procedure

- Ran `bun install --lockfile-only` from `sdk`.
- Ran `bun -F @cline/cli typecheck` from `sdk`.
- Ran `bun run build:sdk` from `sdk`.
- Ran `bun -F @cline/cli test:unit` from `sdk` after building SDK packages.

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [x] 📚 Documentation update
-   [x] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A

### Additional Notes

No npm release is performed by this PR. The publish step should happen after merge by creating/pushing `cli-v3.0.1`, then running `publish-cli.yaml` with `confirm_publish=publish`.
