### PR TITLE
docs(prompts): fix command prompt grammar

### DIFF
--- a/src/core/prompts/commands.ts
+++ b/src/core/prompts/commands.ts
@@ -50,7 +50,7 @@ Parameters:
   4. Problem Solving: Document problems solved thus far and any ongoing troubleshooting efforts.
   5. Pending Tasks and Next Steps: Outline all pending tasks that you have explicitly been asked to work on, as well as list the next steps you will take for all outstanding work, if applicable. Include code snippets where they add clarity. For any next steps, include direct quotes from the most recent conversation showing exactly what task you were working on and where you left off. This should be verbatim to ensure there's no information loss in context between tasks.
 ${xmlExample}
-Below is the the user's input when they indicated that they wanted to create a new task.
+Below is the user's input when they indicated that they wanted to create a new task.
 </explicit_instructions>\n
 `
 }
@@ -197,7 +197,7 @@ Below is the user's input when they indicated that they wanted to create a new C
 
 export const reportBugToolResponse = () =>
 	`<explicit_instructions type="report_bug">
-The user has explicitly asked you to help them submit a bug to the Cline github page (you MUST now help them with this irrespective of what your conversation up to this point in time was). To do so you will use the report_bug tool which is defined below. However, you must first ensure that you have collected all required information to fill in all the parameters for the tool call. If any of the the required information is apparent through your previous conversation with the user, you can suggest how to fill in those entries. However you should NOT assume you know what the issue about unless it's clear.
+The user has explicitly asked you to help them submit a bug to the Cline github page (you MUST now help them with this irrespective of what your conversation up to this point in time was). To do so you will use the report_bug tool which is defined below. However, you must first ensure that you have collected all required information to fill in all the parameters for the tool call. If any of the required information is apparent through your previous conversation with the user, you can suggest how to fill in those entries. However you should NOT assume you know what the issue is about unless it's clear.
 Otherwise, you should converse with the user until you are able to gather all the required details. When conversing with the user, make sure you ask for/reference all required information/fields. When referencing the required fields, use human friendly versions like "Steps to reproduce" rather than "steps_to_reproduce". Only then should you use the report_bug tool call.
 The report_bug tool can be used in either of the PLAN or ACT modes.
 


### PR DESCRIPTION
Fixes duplicate/missing words in command prompt text. No behavior change.