### PR TITLE
docs: capitalize GitHub in report bug copy

### DIFF
--- a/cli/src/components/ChatMessage.tsx
+++ b/cli/src/components/ChatMessage.tsx
@@ -850,7 +850,7 @@ export const ChatMessage: React.FC<ChatMessageProps> = ({ message, mode, isStrea
 			<Box flexDirection="column" marginBottom={1} width="100%">
 				<DotRow color={COLORS.primaryBlue} flashing={partial === true && isStreaming}>
 					<Text bold color={COLORS.primaryBlue}>
-						Cline wants to create a Github issue:
+						Cline wants to create a GitHub issue:
 					</Text>
 				</DotRow>
 				<Box flexDirection="column" paddingLeft={2}>

--- a/webview-ui/src/components/chat/ChatRow.tsx
+++ b/webview-ui/src/components/chat/ChatRow.tsx
@@ -1264,7 +1264,7 @@ export const ChatRowContent = memo(
 							<div>
 								<div className={HEADER_CLASSNAMES}>
 									<FilePlus2Icon className="size-2" />
-									<span className="text-foreground font-bold">Cline wants to create a Github issue:</span>
+									<span className="text-foreground font-bold">Cline wants to create a GitHub issue:</span>
 								</div>
 								<ReportBugPreview data={message.text || ""} />
 							</div>


### PR DESCRIPTION
Updates two report-bug UI strings to use the official GitHub capitalization. No behavior changes.