### PR TITLE
fix(cli): prevent inflated TUI token count

### DIFF
--- a/sdk/apps/cli/src/tui/contexts/session-context.tsx
+++ b/sdk/apps/cli/src/tui/contexts/session-context.tsx
@@ -210,11 +210,9 @@ export function SessionProvider(props: {
 
 	const addUsageDelta = useCallback(
 		(usage: { inputTokens?: number; outputTokens?: number; cost?: number }) => {
-			const tokenDelta =
-				Math.max(0, usage.inputTokens ?? 0) +
-				Math.max(0, usage.outputTokens ?? 0);
-			if (tokenDelta > 0) {
-				setLastTotalTokens((prev) => prev + tokenDelta);
+			const inputTokens = Math.max(0, usage.inputTokens ?? 0);
+			if (inputTokens > 0) {
+				setLastTotalTokens(inputTokens);
 			}
 			const costDelta = usage.cost;
 			if (


### PR DESCRIPTION
### Related Issue

Issue: #XXXX

### Description

The CLI TUI status bar token count could briefly jump to an inflated value during streaming and then snap back to the correct count when the turn finished.

The status bar value is used as the current context size for both the displayed token number and the context window progress bar. During streaming, `addUsageDelta` was treating usage events as additive token deltas and adding `inputTokens + outputTokens` onto the previous displayed value. That is not the same thing as current context size. For each model call, `inputTokens` already represents the prompt/context size for that call, while `outputTokens` is generated output and should not be added to the context gauge.

This PR changes the live status bar update to set the token display to the latest positive `inputTokens` value. Cost handling remains additive because spend really does accumulate across streaming usage events.

### Test Procedure

Validated the focused TUI status bar tests:

```sh
npx vitest run sdk/apps/cli/src/tui/components/status-bar.test.ts
```

Validated the CLI TypeScript project:

```sh
cd /workspace/cline/sdk && npx tsc --noEmit -p apps/cli/tsconfig.json
```

Checked the final patch for whitespace issues:

```sh
sleep 1 && git diff --check
```

The main behavior risk is cost display regression, so I left the existing cost accumulation path unchanged. The token display now matches the same current-context-size semantics used when the turn completes via `result.currentContextSize`.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Not included. This is a small status bar accounting fix and was validated with focused tests and typecheck.

### Additional Notes

This is intentionally scoped to the CLI TUI display layer. It does not change backend usage accounting or persisted session usage.
