### PR TITLE
test(cli): cover streaming token display update

### DIFF
--- a/sdk/apps/cli/src/tui/contexts/session-context.test.ts
+++ b/sdk/apps/cli/src/tui/contexts/session-context.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { nextUsageTokenDisplay } from "./session-context";
+
+describe("nextUsageTokenDisplay", () => {
+	it("uses streaming input tokens as an absolute context size", () => {
+		let displayedTokens = 0;
+
+		displayedTokens = nextUsageTokenDisplay(displayedTokens, {
+			inputTokens: 633_000,
+			outputTokens: 31_000,
+		});
+		displayedTokens = nextUsageTokenDisplay(displayedTokens, {
+			inputTokens: 934_000,
+			outputTokens: 266_000,
+		});
+
+		expect(displayedTokens).toBe(934_000);
+	});
+
+	it("ignores output-only usage events for the context size display", () => {
+		expect(
+			nextUsageTokenDisplay(633_000, {
+				outputTokens: 31_000,
+			}),
+		).toBe(633_000);
+	});
+});

--- a/sdk/apps/cli/src/tui/contexts/session-context.tsx
+++ b/sdk/apps/cli/src/tui/contexts/session-context.tsx
@@ -37,11 +37,7 @@ interface SessionContextValue {
 	setHasSubmitted: (v: boolean) => void;
 	setLastTotalTokens: (v: number) => void;
 	setLastTotalCost: (v: number) => void;
-	addUsageDelta: (usage: {
-		inputTokens?: number;
-		outputTokens?: number;
-		cost?: number;
-	}) => void;
+	addUsageDelta: (usage: UsageDelta) => void;
 	setUiMode: (mode: AgentMode) => void;
 	toggleMode: () => void;
 	toggleAutoApprove: () => void;
@@ -51,12 +47,26 @@ interface SessionContextValue {
 	replaceEntries: (entries: ChatEntry[]) => void;
 }
 
+type UsageDelta = {
+	inputTokens?: number;
+	outputTokens?: number;
+	cost?: number;
+};
+
 const SessionContext = createContext<SessionContextValue | null>(null);
 
 export function useSession(): SessionContextValue {
 	const ctx = useContext(SessionContext);
 	if (!ctx) throw new Error("useSession must be within SessionProvider");
 	return ctx;
+}
+
+export function nextUsageTokenDisplay(
+	previousTotalTokens: number,
+	usage: UsageDelta,
+): number {
+	const inputTokens = Math.max(0, usage.inputTokens ?? 0);
+	return inputTokens > 0 ? inputTokens : previousTotalTokens;
 }
 
 export function SessionProvider(props: {
@@ -209,10 +219,10 @@ export function SessionProvider(props: {
 	}, []);
 
 	const addUsageDelta = useCallback(
-		(usage: { inputTokens?: number; outputTokens?: number; cost?: number }) => {
-			const inputTokens = Math.max(0, usage.inputTokens ?? 0);
-			if (inputTokens > 0) {
-				setLastTotalTokens(inputTokens);
+		(usage: UsageDelta) => {
+			const nextTotalTokens = nextUsageTokenDisplay(0, usage);
+			if (nextTotalTokens > 0) {
+				setLastTotalTokens((prev) => nextUsageTokenDisplay(prev, usage));
 			}
 			const costDelta = usage.cost;
 			if (


### PR DESCRIPTION
### Related Issue

**Issue:** #10725

### Description

Adds focused regression coverage for the CLI TUI streaming token-count display fixed in #10725.

The test verifies that streaming usage input tokens are treated as the latest absolute context size for the status bar instead of being accumulated across usage events. It also verifies output-only usage events do not inflate the displayed context size.

### Test Procedure

Ran the focused CLI unit test:

```sh
bun -F @cline/cli test:unit -- src/tui/contexts/session-context.test.ts
```

Ran the CLI TypeScript check:

```sh
bun -F @cline/cli typecheck
```

Checked the final diff for whitespace errors:

```sh
git diff --check origin/main...HEAD
```

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Not applicable. This is a unit test coverage change for CLI TUI token-count state.

### Additional Notes

This intentionally keeps runtime behavior aligned with #10725 while adding a direct guard for the non-additive token display invariant.
