### PR TITLE
fix(sdk): truncate large context-management tool results

### DIFF
--- a/sdk/packages/core/src/session/services/message-builder.test.ts
+++ b/sdk/packages/core/src/session/services/message-builder.test.ts
@@ -363,4 +363,127 @@ describe("MessageBuilder", () => {
 			}),
 		]);
 	});
+
+	// CLINE-2183: editor / apply_patch / fetch_web_content were not
+	// in the original TARGET_TOOL_NAMES allowlist, so their tool_results
+	// bypassed both per-block truncation and the aggregate text budget.
+	// A coding-heavy turn could push the outbound request past a model's
+	// context window even with compaction enabled.
+	it("truncates editor tool results above the per-block limit (CLINE-2183)", () => {
+		const builder = new MessageBuilder(100);
+		const messages: Message[] = [
+			{
+				role: "assistant",
+				content: [
+					{
+						type: "tool_use",
+						id: "tool_1",
+						name: "editor",
+						input: { path: "/tmp/example.ts", new_text: "x" },
+					},
+				],
+			},
+			{
+				role: "user",
+				content: [
+					{
+						type: "tool_result",
+						tool_use_id: "tool_1",
+						content: "z".repeat(250),
+					},
+				],
+			},
+		];
+
+		const result = builder.buildForApi(messages);
+		const content = result[1].content;
+		expect(Array.isArray(content)).toBe(true);
+		const block = Array.isArray(content) ? content[0] : undefined;
+		expect(block?.type).toBe("tool_result");
+		if (block?.type !== "tool_result") {
+			throw new Error("expected tool_result");
+		}
+		expect(
+			typeof block.content === "string" ? block.content.length : 0,
+		).toBeLessThanOrEqual(100);
+		expect(block.content).toContain("...[truncated");
+	});
+
+	it("applies the aggregate text budget across editor / apply_patch / fetch_web_content tool results (CLINE-2183)", () => {
+		// 1 MB total budget against ~4.5 MB of input across the three newly
+		// covered tools. Use the default TARGET_TOOL_NAMES (omit the
+		// second constructor arg) to exercise the constant change itself.
+		// maxToolResultChars is set above each block size so the per-block
+		// truncator does not fire and the aggregate budget is the active limiter.
+		const builder = new MessageBuilder(2_000_000, undefined, 1_000_000);
+		const messages: Message[] = [
+			{
+				role: "assistant",
+				content: [
+					{
+						type: "tool_use",
+						id: "tool_editor",
+						name: "editor",
+						input: { path: "/tmp/a.ts" },
+					},
+					{
+						type: "tool_use",
+						id: "tool_patch",
+						name: "apply_patch",
+						input: { input: "*** Begin Patch" },
+					},
+					{
+						type: "tool_use",
+						id: "tool_fetch",
+						name: "fetch_web_content",
+						input: { requests: [] },
+					},
+				],
+			},
+			{
+				role: "user",
+				content: [
+					{
+						type: "tool_result",
+						tool_use_id: "tool_editor",
+						content: "e".repeat(1_500_000),
+					},
+					{
+						type: "tool_result",
+						tool_use_id: "tool_patch",
+						content: "p".repeat(1_500_000),
+					},
+					{
+						type: "tool_result",
+						tool_use_id: "tool_fetch",
+						content: "f".repeat(1_500_000),
+					},
+				],
+			},
+		];
+
+		const result = builder.buildForApi(messages);
+		const totalBytes = result.reduce((sum, message) => {
+			if (typeof message.content === "string") {
+				return sum + Buffer.byteLength(message.content, "utf8");
+			}
+			return (
+				sum +
+				message.content.reduce((inner, block) => {
+					if (block.type !== "tool_result") {
+						return inner;
+					}
+					return (
+						inner +
+						(typeof block.content === "string"
+							? Buffer.byteLength(block.content, "utf8")
+							: 0)
+					);
+				}, 0)
+			);
+		}, 0);
+
+		expect(totalBytes).toBeLessThanOrEqual(1_000_000);
+		expect(JSON.stringify(result)).toContain("to fit provider request budget");
+	});
 });

--- a/sdk/packages/core/src/session/services/message-builder.ts
+++ b/sdk/packages/core/src/session/services/message-builder.ts
@@ -20,6 +20,11 @@ import {
 const DEFAULT_MAX_TOOL_RESULT_CHARS = 50_000;
 const DEFAULT_MAX_TOTAL_TEXT_BYTES = 6_000_000;
 const MIN_TOTAL_BUDGET_TOOL_RESULT_BYTES = 8_000;
+// Tools whose results are large enough to need provider-payload truncation
+// (per-block at maxToolResultChars and in aggregate at maxTotalTextBytes).
+// Bounded-output tools (ask_question, submit_and_exit) are intentionally
+// excluded. MCP tool names are dynamic and not covered here; see
+// the broader compaction hardening follow-up.
 const TARGET_TOOL_NAMES = new Set([
 	"read",
 	"read_files",
@@ -27,6 +32,9 @@ const TARGET_TOOL_NAMES = new Set([
 	"search_codebase",
 	"bash",
 	"run_commands",
+	"editor",
+	"apply_patch",
+	"fetch_web_content",
 ]);
 const READ_TOOL_NAMES = new Set(["read", "read_files"]);
 const OUTDATED_FILE_CONTENT = "[outdated - see the latest file content]";


### PR DESCRIPTION
### Description

This PR is a small provider-payload safety net, separate from the larger ENG-1967 compaction architecture work.

`MessageBuilder.buildForApi` already applies the existing tool-result truncation path to known large tools such as `read`, `read_files`, `search`, `search_codebase`, `bash`, and `run_commands`. Three other built-in tools can also produce large text payloads but were not in that allowlist:

- `editor`
- `apply_patch`
- `fetch_web_content`

That meant a large webpage, patch output, or editor result could bypass both the per-block tool-result cap and the aggregate text-budget truncation candidates in `MessageBuilder`.

This PR adds those three tools to `TARGET_TOOL_NAMES` so they use the same existing truncation behavior.

`skills` is intentionally left out for now. Skill output may legitimately be a long generated artifact or report, and today there is no per-tool cap or per-call escape hatch. If skill outputs become a real context-bloat source, we should add a specific per-tool limit rather than silently applying the shared 50k cap.

### Tradeoff

This is not a compaction strategy and it is not a hard provider-size guarantee. It is a narrow context-management guard at provider message construction time.

The larger compaction work is handled separately by ENG-1967 and the newer compaction budget projection stack. This PR only prevents a few known heavy tool results from bypassing `MessageBuilder`'s existing safety net.

### Test Procedure

Focused verification:

```sh
cd sdk
bun -F @cline/core test:unit -- src/session/services/message-builder.test.ts
bun --filter @cline/core typecheck
cd ..
git diff --check
```

Result: passing.

Added coverage for:

- `editor` per-block truncation.
- aggregate text-budget truncation across `editor`, `apply_patch`, and `fetch_web_content` tool results.

### Diagram

```text
Before
------
fetch_web_content result: huge webpage
        |
        v
not in TARGET_TOOL_NAMES
        |
        v
bypasses MessageBuilder tool-result truncation
        |
        v
can inflate provider payload

After
-----
fetch_web_content / editor / apply_patch result
        |
        v
existing MessageBuilder tool-result truncation path
        |
        v
per-block cap + aggregate text-budget candidate
        |
        v
smaller provider payload
```
