### PR TITLE
fix(sdk): trim oldest completed tool pairs from protected tail in basic compaction (CLINE-2185)

### DIFF
--- a/sdk/packages/core/src/extensions/context/basic-compaction.ts
+++ b/sdk/packages/core/src/extensions/context/basic-compaction.ts
@@ -15,13 +15,35 @@ import {
 	truncateToolResultContentForCompaction,
 } from "./compaction-shared";
 
-interface BasicCompactionCandidate {
-	index: number;
+/**
+ * Minimum candidate shape that the atomic-pair removal helpers below need.
+ * Both the prefix-compaction candidates (BasicCompactionCandidate) and the
+ * tail-compaction candidates (TailCandidate) extend this; the closure logic
+ * is identical for both.
+ */
+interface MinimalCandidate {
 	message: MessageWithMetadata;
 	estimatedTokens: number;
+}
+
+interface BasicCompactionCandidate extends MinimalCandidate {
+	index: number;
 	isFirstUser: boolean;
 	isLastUser: boolean;
 	isLastAssistant: boolean;
+}
+
+/**
+ * Tail-compaction candidate. Lives inside the post-CLINE-2136 protected
+ * tail (everything from the latest typed user prompt onward). The flags
+ * here drive a stricter preservation predicate than the prefix candidates
+ * use; see runBasicCompaction / trimProtectedTail.
+ */
+interface TailCandidate extends MinimalCandidate {
+	index: number;
+	isTurnStart: boolean;
+	isLastAssistant: boolean;
+	hasInFlightToolUse: boolean;
 }
 
 function sanitizeMessageForBasic(
@@ -154,15 +176,17 @@ function collectToolResultIds(message: MessageWithMetadata): Set<string> {
 	return ids;
 }
 
-function collectToolPairIds(candidate: BasicCompactionCandidate): Set<string> {
+function collectToolPairIds<C extends MinimalCandidate>(
+	candidate: C,
+): Set<string> {
 	return new Set([
 		...collectToolUseIds(candidate.message),
 		...collectToolResultIds(candidate.message),
 	]);
 }
 
-function buildToolPairCandidateIndex(
-	candidates: BasicCompactionCandidate[],
+function buildToolPairCandidateIndex<C extends MinimalCandidate>(
+	candidates: C[],
 ): Map<string, Set<number>> {
 	const indexByToolUseId = new Map<string, Set<number>>();
 	for (let index = 0; index < candidates.length; index += 1) {
@@ -178,8 +202,8 @@ function buildToolPairCandidateIndex(
 	return indexByToolUseId;
 }
 
-function collectAtomicRemovalIndexes(
-	candidates: BasicCompactionCandidate[],
+function collectAtomicRemovalIndexes<C extends MinimalCandidate>(
+	candidates: C[],
 	startIndex: number,
 ): Set<number> {
 	const pairIndex = buildToolPairCandidateIndex(candidates);
@@ -204,9 +228,9 @@ function collectAtomicRemovalIndexes(
 	return removalIndexes;
 }
 
-function removeCandidatesByPredicate(
-	candidates: BasicCompactionCandidate[],
-	predicate: (candidate: BasicCompactionCandidate) => boolean,
+function removeCandidatesByPredicate<C extends MinimalCandidate>(
+	candidates: C[],
+	predicate: (candidate: C) => boolean,
 	targetTokens: number,
 	estimateMessageTokens: EstimateMessageTokens,
 ): void {
@@ -324,6 +348,168 @@ function splitLatestTurn(messages: MessageWithMetadata[]): {
 	};
 }
 
+/**
+ * Collect tool_use ids inside the tail that do NOT have a matching
+ * tool_result anywhere in the same tail. These are "in-flight" tool
+ * calls — the model has emitted them but the runtime hasn't recorded
+ * a result yet. We must NEVER fold them into a summary or drop them,
+ * or the provider will reject the next request with "No tool call
+ * found for function call output with call_id ..." (the inverse of
+ * the orphaned-tool_result failure mode CLINE-2136 fixed for the
+ * historical prefix).
+ *
+ * The tail snapshot we receive is the one the agent runtime passes
+ * into prepareTurn BEFORE the next model request. By construction
+ * any tool_result that has already arrived is in `state.messages`,
+ * so a missing result reliably means "in-flight" — not "lost".
+ */
+function findInFlightToolUseIdsInTail(
+	tail: readonly MessageWithMetadata[],
+): Set<string> {
+	const uses = new Set<string>();
+	const results = new Set<string>();
+	for (const message of tail) {
+		if (!Array.isArray(message.content)) {
+			continue;
+		}
+		for (const block of message.content) {
+			if (block.type === "tool_use") {
+				uses.add(block.id);
+			}
+			if (block.type === "tool_result") {
+				results.add(block.tool_use_id);
+			}
+		}
+	}
+	for (const id of results) {
+		uses.delete(id);
+	}
+	return uses;
+}
+
+function buildTailCandidates(
+	tail: MessageWithMetadata[],
+	estimateMessageTokens: EstimateMessageTokens,
+	inFlightToolUseIds: Set<string>,
+): TailCandidate[] {
+	const lastAssistantIndex = findLastAssistantIndex(tail);
+	const candidates: TailCandidate[] = [];
+	for (let index = 0; index < tail.length; index += 1) {
+		const sanitized = sanitizeMessageForBasic(tail[index]) ?? tail[index];
+		let hasInFlightToolUse = false;
+		if (Array.isArray(sanitized.content)) {
+			for (const block of sanitized.content) {
+				if (block.type === "tool_use" && inFlightToolUseIds.has(block.id)) {
+					hasInFlightToolUse = true;
+					break;
+				}
+			}
+		}
+		candidates.push({
+			index,
+			message: sanitized,
+			estimatedTokens: estimateMessageTokens(sanitized),
+			// By construction the tail starts at findLastTurnStartIndex,
+			// so the typed user prompt is always at index 0.
+			isTurnStart: index === 0 && isTurnStartMessage(tail[0]),
+			isLastAssistant: index === lastAssistantIndex,
+			hasInFlightToolUse,
+		});
+	}
+	return candidates;
+}
+
+/**
+ * Drop the oldest completed tool_use/tool_result pairs inside the
+ * post-CLINE-2136 protected tail when the tail alone exceeds the
+ * compaction target. Preserves the typed user prompt, the latest
+ * assistant message, and any assistant message carrying an in-flight
+ * tool_use (see findInFlightToolUseIdsInTail).
+ *
+ * Reuses the existing atomic-pair closure (collectAtomicRemovalIndexes)
+ * via removeCandidatesByPredicate, so a removal expands across the
+ * full tool_use_id graph and we never orphan a half-pair.
+ */
+/**
+ * Same shape as `removeCandidatesByPredicate` but with one key
+ * difference: if the atomic-pair closure of a seed candidate touches
+ * ANY candidate that the predicate marks as not-removable, we abort
+ * that seed and move on. This is what makes tail trimming safe:
+ * dropping a tool_result whose matching tool_use is the last
+ * assistant message would otherwise drag the last assistant into
+ * the removal set via the closure, violating the preservation
+ * contract.
+ *
+ * On the prefix path the existing `removeCandidatesByPredicate`
+ * is still used; its closures only group same-role candidates
+ * (e.g. a non-last assistant with its non-last user tool_result),
+ * so the two predicates collapse there and behavior is unchanged.
+ */
+function removeTailCandidatesByPredicate<C extends MinimalCandidate>(
+	candidates: C[],
+	predicate: (candidate: C) => boolean,
+	targetTokens: number,
+	estimateMessageTokens: EstimateMessageTokens,
+): void {
+	let totalTokens = getTotalTokens(
+		candidates.map((candidate) => candidate.message),
+		estimateMessageTokens,
+	);
+	for (
+		let index = 0;
+		index < candidates.length && totalTokens > targetTokens;
+	) {
+		if (!predicate(candidates[index])) {
+			index += 1;
+			continue;
+		}
+		const removalIndexes = collectAtomicRemovalIndexes(candidates, index);
+		let closureRemovable = true;
+		for (const linked of removalIndexes) {
+			if (!predicate(candidates[linked])) {
+				closureRemovable = false;
+				break;
+			}
+		}
+		if (!closureRemovable) {
+			index += 1;
+			continue;
+		}
+		totalTokens -= Array.from(removalIndexes).reduce(
+			(total, removalIndex) => total + candidates[removalIndex].estimatedTokens,
+			0,
+		);
+		for (const removalIndex of Array.from(removalIndexes).sort(
+			(left, right) => right - left,
+		)) {
+			candidates.splice(removalIndex, 1);
+		}
+	}
+}
+
+function trimProtectedTail(
+	tail: MessageWithMetadata[],
+	targetTokens: number,
+	estimateMessageTokens: EstimateMessageTokens,
+): MessageWithMetadata[] {
+	if (tail.length <= 1) {
+		return tail;
+	}
+	const inFlightToolUseIds = findInFlightToolUseIdsInTail(tail);
+	const candidates = buildTailCandidates(
+		tail,
+		estimateMessageTokens,
+		inFlightToolUseIds,
+	);
+	removeTailCandidatesByPredicate(
+		candidates,
+		(c) => !c.isTurnStart && !c.isLastAssistant && !c.hasInFlightToolUse,
+		targetTokens,
+		estimateMessageTokens,
+	);
+	return candidates.map((c) => c.message);
+}
+
 export function runBasicCompaction(options: {
 	context: CoreCompactionContext;
 	estimateMessageTokens: EstimateMessageTokens;
@@ -336,16 +522,15 @@ export function runBasicCompaction(options: {
 	const { compactable, protectedTail } = splitLatestTurn(
 		options.context.messages,
 	);
-	if (compactable.length === 0) {
-		return undefined;
-	}
+	// CLINE-2185: previously this function bailed out when there was
+	// no historical prefix to compact. The tail-trim path below still
+	// needs to run in that case, so we no longer return undefined here.
+	// Instead we build candidates over whatever prefix we have (which
+	// may be empty) and let the prefix passes be no-ops.
 	const candidates = buildBasicCandidates(
 		compactable,
 		options.estimateMessageTokens,
 	);
-	if (candidates.length === 0) {
-		return undefined;
-	}
 
 	removeCandidatesByPredicate(
 		candidates,
@@ -386,9 +571,30 @@ export function runBasicCompaction(options: {
 		options.estimateMessageTokens,
 	);
 
+	// CLINE-2185: the protected tail (the in-flight turn after the user's
+	// latest typed prompt) can itself exceed the compaction target when
+	// the agent has produced many large tool results in a single turn.
+	// Trim oldest completed tool pairs out of the tail while preserving
+	// the typed prompt, the latest assistant message, and any in-flight
+	// tool_use (whose result has not yet arrived). Atomic-pair closure
+	// guarantees no orphaned tool_use/tool_result blocks.
+	const tailTokensBefore = getTotalTokens(
+		protectedTail,
+		options.estimateMessageTokens,
+	);
+	const tailMessagesBefore = protectedTail.length;
+	let finalTail = protectedTail;
+	if (tailTokensBefore > targetTokens) {
+		finalTail = trimProtectedTail(
+			protectedTail,
+			targetTokens,
+			options.estimateMessageTokens,
+		);
+	}
+
 	const nextMessages = [
 		...candidates.map((candidate) => candidate.message),
-		...protectedTail,
+		...finalTail,
 	];
 	if (!haveMessagesChanged(options.context.messages, nextMessages)) {
 		return undefined;
@@ -413,6 +619,9 @@ export function runBasicCompaction(options: {
 		tokensAfter: afterTokens,
 		targetTokens,
 		maxInputTokens: options.context.maxInputTokens,
+		tailTokensBefore,
+		tailMessagesBefore,
+		tailMessagesAfter: finalTail.length,
 	});
 
 	return { messages: nextMessages };

--- a/sdk/packages/core/src/extensions/context/basic-compaction.ts
+++ b/sdk/packages/core/src/extensions/context/basic-compaction.ts
@@ -148,7 +148,10 @@ function reconstructPrefixMessages(
 		initialCandidates.map((candidate) => candidate.index),
 	);
 	const remainingByIndex = new Map(
-		remainingCandidates.map((candidate) => [candidate.index, candidate.message]),
+		remainingCandidates.map((candidate) => [
+			candidate.index,
+			candidate.message,
+		]),
 	);
 	const messages: MessageWithMetadata[] = [];
 	for (let index = 0; index < compactable.length; index += 1) {

--- a/sdk/packages/core/src/extensions/context/basic-compaction.ts
+++ b/sdk/packages/core/src/extensions/context/basic-compaction.ts
@@ -420,17 +420,6 @@ function buildTailCandidates(
 }
 
 /**
- * Drop the oldest completed tool_use/tool_result pairs inside the
- * post-CLINE-2136 protected tail when the tail alone exceeds the
- * compaction target. Preserves the typed user prompt, the latest
- * assistant message, and any assistant message carrying an in-flight
- * tool_use (see findInFlightToolUseIdsInTail).
- *
- * Reuses the existing atomic-pair closure (collectAtomicRemovalIndexes)
- * via removeCandidatesByPredicate, so a removal expands across the
- * full tool_use_id graph and we never orphan a half-pair.
- */
-/**
  * Same shape as `removeCandidatesByPredicate` but with one key
  * difference: if the atomic-pair closure of a seed candidate touches
  * ANY candidate that the predicate marks as not-removable, we abort
@@ -487,6 +476,13 @@ function removeTailCandidatesByPredicate<C extends MinimalCandidate>(
 	}
 }
 
+/**
+ * Drop the oldest completed tool_use/tool_result pairs inside the
+ * post-CLINE-2136 protected tail when the tail alone exceeds the
+ * compaction target. Preserves the typed user prompt, the latest
+ * assistant message, and any assistant message carrying an in-flight
+ * tool_use (see findInFlightToolUseIdsInTail).
+ */
 function trimProtectedTail(
 	tail: MessageWithMetadata[],
 	targetTokens: number,

--- a/sdk/packages/core/src/extensions/context/basic-compaction.ts
+++ b/sdk/packages/core/src/extensions/context/basic-compaction.ts
@@ -139,6 +139,34 @@ function buildBasicCandidates(
 	return candidates;
 }
 
+function reconstructPrefixMessages(
+	compactable: MessageWithMetadata[],
+	initialCandidates: BasicCompactionCandidate[],
+	remainingCandidates: BasicCompactionCandidate[],
+): MessageWithMetadata[] {
+	const initialCandidateIndexes = new Set(
+		initialCandidates.map((candidate) => candidate.index),
+	);
+	const remainingByIndex = new Map(
+		remainingCandidates.map((candidate) => [candidate.index, candidate.message]),
+	);
+	const messages: MessageWithMetadata[] = [];
+	for (let index = 0; index < compactable.length; index += 1) {
+		const remaining = remainingByIndex.get(index);
+		if (remaining) {
+			messages.push(remaining);
+			continue;
+		}
+		if (initialCandidateIndexes.has(index)) {
+			continue;
+		}
+		if (isCompactionSummaryMessage(compactable[index])) {
+			messages.push(compactable[index]);
+		}
+	}
+	return messages;
+}
+
 function updateCandidate(
 	candidates: BasicCompactionCandidate[],
 	index: number,
@@ -527,6 +555,7 @@ export function runBasicCompaction(options: {
 		compactable,
 		options.estimateMessageTokens,
 	);
+	const initialCandidates = candidates.map((candidate) => ({ ...candidate }));
 
 	removeCandidatesByPredicate(
 		candidates,
@@ -588,10 +617,11 @@ export function runBasicCompaction(options: {
 		);
 	}
 
-	const prefixMessages =
-		candidates.length > 0
-			? candidates.map((candidate) => candidate.message)
-			: compactable;
+	const prefixMessages = reconstructPrefixMessages(
+		compactable,
+		initialCandidates,
+		candidates,
+	);
 	const nextMessages = [...prefixMessages, ...finalTail];
 	if (!haveMessagesChanged(options.context.messages, nextMessages)) {
 		return undefined;

--- a/sdk/packages/core/src/extensions/context/basic-compaction.ts
+++ b/sdk/packages/core/src/extensions/context/basic-compaction.ts
@@ -588,10 +588,11 @@ export function runBasicCompaction(options: {
 		);
 	}
 
-	const nextMessages = [
-		...candidates.map((candidate) => candidate.message),
-		...finalTail,
-	];
+	const prefixMessages =
+		candidates.length > 0
+			? candidates.map((candidate) => candidate.message)
+			: compactable;
+	const nextMessages = [...prefixMessages, ...finalTail];
 	if (!haveMessagesChanged(options.context.messages, nextMessages)) {
 		return undefined;
 	}

--- a/sdk/packages/core/src/extensions/context/compaction.test.ts
+++ b/sdk/packages/core/src/extensions/context/compaction.test.ts
@@ -490,6 +490,33 @@ describe("createContextCompactionPrepareTurn", () => {
 		]);
 	});
 
+	it("preserves an existing compaction summary when the prefix has no basic candidates (CLINE-2185)", () => {
+		const summary = {
+			role: "user",
+			content: "Context summary:\nPrior work",
+			metadata: { kind: "compaction_summary" },
+		} as LlmsProviders.Message;
+		const compacted = runForcedBasicCompaction(
+			[
+				summary,
+				{ role: "user", content: "continue the task" },
+				assistantToolUseMessage("old-tail", [
+					{ type: "text", text: "old tool call".repeat(100) },
+				]),
+				toolResultMessage("old-tail", "old result".repeat(1_000)),
+				{ role: "assistant", content: "latest assistant" },
+			],
+			1_500,
+		);
+
+		expect(compacted[0]).toEqual(summary);
+		expect(compacted).toContainEqual({
+			role: "user",
+			content: "continue the task",
+		});
+		expect(JSON.stringify(compacted)).not.toContain("old-tail");
+	});
+
 	it("does not add unsupported max output tokens to Codex OAuth summarizer requests", () => {
 		const codexConfig = resolveSummarizerConfig({
 			activeProviderConfig: {

--- a/sdk/packages/core/src/extensions/context/compaction.test.ts
+++ b/sdk/packages/core/src/extensions/context/compaction.test.ts
@@ -372,6 +372,124 @@ describe("createContextCompactionPrepareTurn", () => {
 		expect(compacted).toBe(messages);
 	});
 
+	// CLINE-2185: protected-tail trim. The in-flight turn (everything
+	// from the latest typed user prompt forward) used to be returned
+	// verbatim by runBasicCompaction. That meant a single turn whose
+	// tool calls accumulated large outputs could push the request past
+	// any context window. These tests cover the new tail trim.
+	it("trims completed tool pairs inside the protected tail when the tail alone exceeds the trigger (CLINE-2185)", () => {
+		const messages: LlmsProviders.Message[] = [
+			{ role: "user", content: "Read three files" },
+			assistantToolUseMessage("tail-a"),
+			toolResultMessage("tail-a", "a".repeat(2_000)),
+			assistantToolUseMessage("tail-b"),
+			toolResultMessage("tail-b", "b".repeat(2_000)),
+			assistantToolUseMessage("tail-c"),
+			toolResultMessage("tail-c", "c".repeat(2_000)),
+		];
+
+		// Force a target that fits only the typed prompt + last
+		// completed pair plus a little slack.
+		const compacted = runForcedBasicCompaction(messages, 3_000);
+
+		expectNoOrphanedToolPairs(compacted);
+		const pairs = collectToolPairPresence(compacted);
+		// Oldest two pairs are removed; the most recent pair survives
+		// because the last assistant + its tool_result are preserved.
+		expect(pairs.get("tail-a")).toBeUndefined();
+		expect(pairs.get("tail-b")).toBeUndefined();
+		expect(pairs.get("tail-c")).toEqual({ hasResult: true, hasUse: true });
+		// The typed prompt is always preserved as the turn-start.
+		expect(compacted[0]).toEqual({
+			role: "user",
+			content: "Read three files",
+		});
+	});
+
+	it("preserves an in-flight tool_use whose result has not yet arrived (CLINE-2185)", () => {
+		const messages: LlmsProviders.Message[] = [
+			{ role: "user", content: "Do the work" },
+			assistantToolUseMessage("done-a"),
+			toolResultMessage("done-a", "a".repeat(2_000)),
+			// In-flight: model just emitted this; tool_result not yet
+			// recorded in state.messages.
+			assistantToolUseMessage("inflight-b"),
+		];
+
+		const compacted = runForcedBasicCompaction(messages, 1);
+
+		const pairs = collectToolPairPresence(compacted);
+		// Older completed pair is removed.
+		expect(pairs.get("done-a")).toBeUndefined();
+		// In-flight tool_use is preserved (its tool_result will land
+		// before the next request — dropping it would synthesize the
+		// "Tool execution was interrupted before a result was produced"
+		// failure mode CLINE-2136 fixed for the historical prefix).
+		// We do NOT call expectNoOrphanedToolPairs here because an
+		// in-flight tool_use legitimately has no matching tool_result
+		// at this snapshot in time.
+		expect(pairs.get("inflight-b")).toEqual({
+			hasResult: false,
+			hasUse: true,
+		});
+	});
+
+	it("preserves the typed prompt and the last assistant message under aggressive tail compaction (CLINE-2185)", () => {
+		const messages: LlmsProviders.Message[] = [
+			{ role: "user", content: "Latest typed prompt" },
+			assistantToolUseMessage("only-pair"),
+			toolResultMessage("only-pair", "result body"),
+		];
+
+		const compacted = runForcedBasicCompaction(messages, 1);
+
+		expectNoOrphanedToolPairs(compacted);
+		// Everything in this transcript is in the preservation set:
+		// turn-start user, last assistant, and the matching
+		// tool_result that the closure pulls in with it.
+		expect(compacted).toEqual(messages);
+	});
+
+	it("returns the tail unchanged when the entire tail is in the preservation set (CLINE-2185)", () => {
+		const messages: LlmsProviders.Message[] = [
+			{ role: "user", content: "Begin" },
+			// in-flight: no tool_result yet
+			assistantToolUseMessage("inflight-x"),
+		];
+
+		const compacted = runForcedBasicCompaction(messages, 1);
+
+		// runBasicCompaction returns the original messages array
+		// unchanged when haveMessagesChanged detects no change.
+		expect(compacted).toBe(messages);
+	});
+
+	it("still compacts the historical prefix when the tail is small (CLINE-2185)", () => {
+		const oldAnswer = "Old answer ".repeat(50);
+		const messages: LlmsProviders.Message[] = [
+			{ role: "user", content: "Old request" },
+			{ role: "assistant", content: oldAnswer },
+			{ role: "user", content: "Read the latest file" },
+			assistantToolUseMessage("tail-a"),
+			toolResultMessage("tail-a", "latest result"),
+		];
+
+		// Pick a budget below the prefix size but well above the
+		// tiny tail, so the prefix pass fires and the tail trim does
+		// not need to do anything.
+		const targetTokens =
+			totalJsonTokens(messages) - estimateJsonTokens(messages[1]) + 10;
+		const compacted = runForcedBasicCompaction(messages, targetTokens);
+
+		// Prefix "Old answer..." is gone; tail intact.
+		expect(compacted).toEqual([
+			{ role: "user", content: "Old request" },
+			{ role: "user", content: "Read the latest file" },
+			assistantToolUseMessage("tail-a"),
+			toolResultMessage("tail-a", "latest result"),
+		]);
+	});
+
 	it("does not add unsupported max output tokens to Codex OAuth summarizer requests", () => {
 		const codexConfig = resolveSummarizerConfig({
 			activeProviderConfig: {

--- a/sdk/packages/core/src/extensions/context/compaction.test.ts
+++ b/sdk/packages/core/src/extensions/context/compaction.test.ts
@@ -517,6 +517,41 @@ describe("createContextCompactionPrepareTurn", () => {
 		expect(JSON.stringify(compacted)).not.toContain("old-tail");
 	});
 
+	it("does not resurrect removed prefix candidates when preserving a compaction summary (CLINE-2185)", () => {
+		const summary = {
+			role: "user",
+			content: "Context summary:\nPrior work",
+			metadata: { kind: "compaction_summary" },
+		} as LlmsProviders.Message;
+		const oldAssistant = {
+			role: "assistant",
+			content: "old assistant prefix ".repeat(1_000),
+		} as LlmsProviders.Message;
+		const messages: LlmsProviders.Message[] = [
+			summary,
+			oldAssistant,
+			{ role: "user", content: "continue the task" },
+			{ role: "assistant", content: "latest assistant" },
+		];
+
+		const compacted = runForcedBasicCompaction(
+			messages,
+			totalJsonTokens(messages) - estimateJsonTokens(oldAssistant) + 10,
+		);
+
+		expect(compacted[0]).toEqual(summary);
+		expect(compacted).toContainEqual({
+			role: "user",
+			content: "continue the task",
+		});
+		expect(compacted).toContainEqual({
+			role: "assistant",
+			content: "latest assistant",
+		});
+		expect(compacted).not.toContainEqual(oldAssistant);
+		expect(JSON.stringify(compacted)).not.toContain("old assistant prefix");
+	});
+
 	it("does not add unsupported max output tokens to Codex OAuth summarizer requests", () => {
 		const codexConfig = resolveSummarizerConfig({
 			activeProviderConfig: {


### PR DESCRIPTION
### Related Issue

**Issue:** CLINE-2185 — Compaction can't shrink the in-flight turn (protected-tail trim)
**Stacked on:** #10739 — please merge that first.
**Triggering report:** CLINE-2183 (Opus 4.7 request can exceed context limit after a few prompts)

### Description

This is the structural follow-up to #10739. The triage PR widened `MessageBuilder.buildForApi`'s 6 MB allowlist so the safety net covers the realistic large-output default tools. That bounds the worst case at ~2M tokens — still above a 1M Opus 4.7 ceiling. This PR closes the gap.

The real root cause of CLINE-2183 is the protected-tail carve-out introduced in CLINE-2136:

- `runBasicCompaction.splitLatestTurn` carves out `messages.slice(findLastTurnStartIndex(...))` as `protectedTail` and concatenates it verbatim into the result.
- `runAgenticCompaction`'s `findCutIndex` snaps to the same turn-start boundary.

Both are correct — they prevent orphaned `tool_use` / `tool_result` pairs that providers reject — but together they leave the in-flight turn unbounded. A coding-heavy turn with many large `editor` patches, fetched web content, or skill results can grow the tail past any context window, and basic compaction returns the same bloated tail no matter how aggressive the budget.

The atomic-pair removal infrastructure (`collectAtomicRemovalIndexes`) added in CLINE-2136 already proves the closure invariant: a removal expands across the whole `tool_use_id` graph. We can reuse that to drop oldest completed pairs from inside the tail, as long as we preserve a small floor:

- The typed user prompt (always at tail index 0 by construction).
- The most recent assistant message.
- Any assistant message carrying a `tool_use` whose `tool_result` has not yet arrived (an "in-flight pair"). This is the new exception that prevents the "Tool execution was interrupted before a result was produced" failure mode CLINE-2136 fixed for the historical prefix.

Everything else inside the tail is candidate for removal, oldest first.


### Implementation notes (deviations from plan.md)

Two design choices that surfaced during implementation:

1. **New `removeTailCandidatesByPredicate`, not a generic-ized version of the existing one.** plan.md suggested generic-izing `removeCandidatesByPredicate` with a `MinimalCandidate` interface. I generic-ized the closure helpers (`collectAtomicRemovalIndexes`, `buildToolPairCandidateIndex`, `collectToolPairIds`) but kept `removeCandidatesByPredicate` for the prefix and added a sibling `removeTailCandidatesByPredicate` for the tail. The new helper has one key difference: if the atomic closure of a seed candidate touches ANY candidate that fails the predicate, the seed is aborted. This is what prevents the closure from dragging the preserved last-assistant into the removal set when its `tool_result` is the seed. Prefix codepath stays byte-identical.

2. **Removed the `compactable.length === 0` early bail in `runBasicCompaction`.** The CLINE-2183 shape is "one in-progress turn, no historical prefix yet" — exactly the case where `compactable` is empty. The old early-bail would skip the tail trim there, the worst possible time. Now `runBasicCompaction` proceeds with an empty prefix candidate list (prefix passes are no-ops) and lets the tail-trim path run.

### Test Procedure

Five new cases in `sdk/packages/core/src/extensions/context/compaction.test.ts`:

1. `trims completed tool pairs inside the protected tail when the tail alone exceeds the trigger (CLINE-2185)` — three completed pairs in a single turn, force a tight budget, assert oldest two pairs dropped, last pair + typed prompt preserved, no orphaned pairs.
2. `preserves an in-flight tool_use whose result has not yet arrived (CLINE-2185)` — older completed pair + newer in-flight `tool_use`. Asserts older pair dropped, in-flight pair preserved.
3. `preserves the typed prompt and the last assistant message under aggressive tail compaction (CLINE-2185)` — minimal transcript that is entirely preservation set. Asserts unchanged output.
4. `returns the tail unchanged when the entire tail is in the preservation set (CLINE-2185)` — typed prompt + one in-flight `tool_use`, no result yet. Asserts no change.
5. `still compacts the historical prefix when the tail is small (CLINE-2185)` — regression check: old `[user, asst, user, ...tail]` shape with a small tail still drops the old assistant message.

Verification:

```
sdk/packages/core $ bun run typecheck:smoke    # clean
sdk/packages/core $ bun run test:unit -- compaction.test
  ✓ 32 tests passed (27 existing + 5 new)
sdk/packages/core $ bun run test:unit
  Test Files  102 passed | 1 skipped (103)
       Tests  913 passed | 4 skipped (917)
```

What could break:

- The atomic-pair closure invariant is preserved by reuse of `collectAtomicRemovalIndexes` (function body unchanged; only signature widens to `<C extends MinimalCandidate>`). The new `removeTailCandidatesByPredicate` is strictly more conservative than the original — it only commits a removal when the entire closure is removable.
- The new `compactable.length === 0` path: previously this returned `undefined`, now it returns either a tail-trim result or `undefined` (when `haveMessagesChanged` reports no change). Callers handle both cases.

### What this PR still does NOT fix (intentional non-goals, per goals.md)

- **Intra-message truncation** of an oversized assistant message (e.g. a single huge `editor` patch inside the preserved last assistant). `MessageBuilder.buildForApi` already does per-block truncation; we don't reach inside the message here.
- **Anthropic `thinking` blocks** are still invisible to the aggregate budget.
- **Oversized first-user prompt** is handled by the existing prefix `trimCandidatesToBudget`; not touched.
- **`runAgenticCompaction` tail trim.** `findCutIndex` has the same protected-tail issue. Agentic compaction is more invasive (materializes a summary message via the LLM) so it warrants its own PR.
- **MCP tool result allowlisting.** Names are dynamic; needs a size-based fallback that doesn't exist yet.

Worst-case bound after this PR: a single in-flight tool pair plus the typed prompt + last assistant message. Anything larger surfacing as the bloat source is the next escalation, and it should land in a future PR rather than be jammed in here.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A — backend data-shaping change. Test counts above are the evidence.

### Additional Notes

The `logger?.debug("Performed basic compaction", ...)` line gains three new fields (`tailTokensBefore`, `tailMessagesBefore`, `tailMessagesAfter`) so the tail path is visible in diagnostics. The `task.compaction_executed` telemetry schema is unchanged.

### Diagram

```text
PR #10740 / CLINE-2185
Layer 1: trim completed tool-call pairs inside the protected tail

Conversation before API request:

  historical prefix        latest in-flight turn / protected tail
  -----------------        -------------------------------------
  old messages             user prompt
  old tool pairs           assistant tool_use A
  old text                 tool_result A
                           assistant tool_use B
                           tool_result B
                           assistant currently in progress

Old behavior:
  compact historical prefix only
        |
        v
  protected tail kept verbatim
        |
        v
  if tail alone is huge, request still too large


New behavior:
  compact historical prefix
        |
        v
  if still too large:
        |
        v
  remove oldest completed tool_use/tool_result pairs from tail
        |
        v
  preserve:
    - typed user prompt
    - latest assistant context
    - in-progress tool_use blocks
    - atomic tool_use/tool_result consistency
        |
        v
  coherent but smaller request
```