### PR TITLE
fix(sdk): widen MessageBuilder truncation candidate set and tie budget to maxInputTokens (CLINE-2191)

### DIFF
--- a/sdk/packages/core/src/runtime/orchestration/session-runtime-orchestrator.ts
+++ b/sdk/packages/core/src/runtime/orchestration/session-runtime-orchestrator.ts
@@ -754,7 +754,7 @@ export class SessionRuntime {
 					modelInfo?.capabilities?.includes("images") ?? true,
 				...this.config.toolContextMetadata,
 			},
-			hooks: this.createRuntimeHooks(),
+			hooks: this.createRuntimeHooks(modelInfo),
 			prepareTurn: this.createRuntimePrepareTurn(modelInfo, tools),
 			initialMessages,
 			systemPrompt,
@@ -863,7 +863,9 @@ export class SessionRuntime {
 		this.extensionsInitialized = true;
 	}
 
-	private createRuntimeHooks(): Partial<AgentRuntimeHooks> {
+	private createRuntimeHooks(
+		modelInfo: ModelInfo | undefined,
+	): Partial<AgentRuntimeHooks> {
 		const hooks = mergeRuntimeHooks([
 			this.config.hooks,
 			...this.contributionRegistry
@@ -878,8 +880,10 @@ export class SessionRuntime {
 					return control;
 				}
 				const messages = control?.messages ?? ctx.request.messages;
-				const preparedMessages =
-					await this.prepareMessagesForModelRequest(messages);
+				const preparedMessages = await this.prepareMessagesForModelRequest(
+					messages,
+					modelInfo?.maxInputTokens,
+				);
 				return {
 					...control,
 					messages: preparedMessages,
@@ -907,7 +911,10 @@ export class SessionRuntime {
 
 		return async (context) => {
 			const messages = agentMessagesToMessagesWithMetadata(context.messages);
-			const apiMessages = await this.prepareProviderMessagesForApi(messages);
+			const apiMessages = await this.prepareProviderMessagesForApi(
+				messages,
+				modelInfo?.maxInputTokens,
+			);
 			const result = await prepareTurn({
 				agentId: context.agentId,
 				conversationId:
@@ -942,15 +949,18 @@ export class SessionRuntime {
 
 	private async prepareMessagesForModelRequest(
 		messages: readonly AgentMessage[],
+		maxInputTokens?: number,
 	): Promise<AgentMessage[]> {
 		const providerMessages = await this.prepareProviderMessagesForApi(
 			agentMessagesToMessages(messages),
+			maxInputTokens,
 		);
 		return messagesToAgentMessages(providerMessages);
 	}
 
 	private async prepareProviderMessagesForApi(
 		messages: MessageWithMetadata[],
+		maxInputTokens?: number,
 	): Promise<MessageWithMetadata[]> {
 		let providerMessages = messages;
 		const messageBuilders =
@@ -958,7 +968,9 @@ export class SessionRuntime {
 		for (const builder of messageBuilders) {
 			providerMessages = await builder.build(providerMessages);
 		}
-		return this.messageBuilder.buildForApi(providerMessages);
+		return this.messageBuilder.buildForApi(providerMessages, {
+			maxInputTokens,
+		});
 	}
 
 	private handleRuntimeEvent(event: AgentRuntimeEvent): void {

--- a/sdk/packages/core/src/session/services/message-builder.test.ts
+++ b/sdk/packages/core/src/session/services/message-builder.test.ts
@@ -499,9 +499,10 @@ describe("MessageBuilder", () => {
 	});
 
 	// CLINE-2191 (Layer A): widen MessageBuilder.collectTruncationCandidates
-	// beyond tool_result content so user text, assistant text, thinking
-	// blocks, and top-level file blocks also participate in the aggregate
-	// budget. Also tie the budget to the model's actual maxInputTokens.
+	// beyond tool_result content so user text, assistant text, and top-level
+	// file blocks also participate in the aggregate budget. Thinking blocks
+	// are counted but not middle-truncated because their signatures/details
+	// are tied to the original reasoning payload.
 	it("truncates user text blocks under the aggregate budget (CLINE-2191)", () => {
 		const builder = new MessageBuilder(50_000, undefined, 500_000);
 		const messages: Message[] = [
@@ -521,13 +522,17 @@ describe("MessageBuilder", () => {
 		expect(block.text).toContain("provider request budget");
 	});
 
-	it("truncates assistant text and thinking blocks under the aggregate budget (CLINE-2191)", () => {
+	it("truncates assistant text but preserves signed thinking blocks under the aggregate budget (CLINE-2191)", () => {
 		const builder = new MessageBuilder(50_000, undefined, 250_000);
 		const messages: Message[] = [
 			{
 				role: "assistant",
 				content: [
-					{ type: "thinking", thinking: "t".repeat(1_000_000) },
+					{
+						type: "thinking",
+						thinking: "t".repeat(1_000_000),
+						signature: "sig-1",
+					},
 					{ type: "text", text: "a".repeat(2_000_000) },
 				],
 			},
@@ -535,18 +540,49 @@ describe("MessageBuilder", () => {
 
 		const result = builder.buildForApi(messages);
 		const serialized = JSON.stringify(result);
-		expect(serialized.length).toBeLessThan(1_000_000);
 		expect(serialized).toContain("provider request budget");
-		// Both blocks got reduced; neither is the full 2 MB / 1 MB original.
 		const content = result[0].content as Array<{ type: string }>;
 		const thinking = content.find((b) => b.type === "thinking") as unknown as
-			| { thinking: string }
+			| { thinking: string; signature?: string }
 			| undefined;
 		const text = content.find((b) => b.type === "text") as unknown as
 			| { text: string }
 			| undefined;
 		if (!thinking || !text) throw new Error("expected both blocks present");
-		expect(thinking.thinking.length).toBeLessThan(1_000_000);
+		expect(thinking.thinking).toBe("t".repeat(1_000_000));
+		expect(thinking.signature).toBe("sig-1");
+		expect(text.text.length).toBeLessThan(2_000_000);
+	});
+
+	it("preserves unsigned thinking blocks with details under the aggregate budget (CLINE-2191)", () => {
+		const details = [{ provider: "anthropic", hash: "opaque" }];
+		const builder = new MessageBuilder(50_000, undefined, 250_000);
+		const messages: Message[] = [
+			{
+				role: "assistant",
+				content: [
+					{
+						type: "thinking",
+						thinking: "u".repeat(750_000),
+						details,
+					},
+					{ type: "text", text: "b".repeat(2_000_000) },
+				],
+			},
+		];
+
+		const result = builder.buildForApi(messages);
+		const content = result[0].content as Array<{ type: string }>;
+		const thinking = content.find((b) => b.type === "thinking") as unknown as
+			| { thinking: string; details?: unknown[] }
+			| undefined;
+		const text = content.find((b) => b.type === "text") as unknown as
+			| { text: string }
+			| undefined;
+		if (!thinking || !text) throw new Error("expected both blocks present");
+		expect(thinking.thinking).toBe("u".repeat(750_000));
+		expect(thinking.details).toEqual(details);
+		expect(text.text).toContain("provider request budget");
 		expect(text.text.length).toBeLessThan(2_000_000);
 	});
 

--- a/sdk/packages/core/src/session/services/message-builder.test.ts
+++ b/sdk/packages/core/src/session/services/message-builder.test.ts
@@ -501,8 +501,9 @@ describe("MessageBuilder", () => {
 	// CLINE-2191 (Layer A): widen MessageBuilder.collectTruncationCandidates
 	// beyond tool_result content so user text, assistant text, and top-level
 	// file blocks also participate in the aggregate budget. Thinking blocks
-	// are counted but not middle-truncated because their signatures/details
-	// are tied to the original reasoning payload.
+	// are excluded from both the Layer A budget and candidates because their
+	// signatures/details are tied to the original reasoning payload; Layer B
+	// handles them via whole-block removal when a hard guarantee is required.
 	it("truncates user text blocks under the aggregate budget (CLINE-2191)", () => {
 		const builder = new MessageBuilder(50_000, undefined, 500_000);
 		const messages: Message[] = [

--- a/sdk/packages/core/src/session/services/message-builder.test.ts
+++ b/sdk/packages/core/src/session/services/message-builder.test.ts
@@ -497,4 +497,176 @@ describe("MessageBuilder", () => {
 		expect(totalBytes).toBeLessThanOrEqual(1_000_000);
 		expect(JSON.stringify(result)).toContain("to fit provider request budget");
 	});
+
+	// CLINE-2191 (Layer A): widen MessageBuilder.collectTruncationCandidates
+	// beyond tool_result content so user text, assistant text, thinking
+	// blocks, and top-level file blocks also participate in the aggregate
+	// budget. Also tie the budget to the model's actual maxInputTokens.
+	it("truncates user text blocks under the aggregate budget (CLINE-2191)", () => {
+		const builder = new MessageBuilder(50_000, undefined, 500_000);
+		const messages: Message[] = [
+			{
+				role: "user",
+				content: [{ type: "text", text: "x".repeat(5_000_000) }],
+			},
+		];
+
+		const result = builder.buildForApi(messages);
+		const block = Array.isArray(result[0].content)
+			? result[0].content[0]
+			: undefined;
+		expect(block?.type).toBe("text");
+		if (block?.type !== "text") throw new Error("expected text");
+		expect(Buffer.byteLength(block.text, "utf8")).toBeLessThanOrEqual(500_000);
+		expect(block.text).toContain("provider request budget");
+	});
+
+	it("truncates assistant text and thinking blocks under the aggregate budget (CLINE-2191)", () => {
+		const builder = new MessageBuilder(50_000, undefined, 250_000);
+		const messages: Message[] = [
+			{
+				role: "assistant",
+				content: [
+					{ type: "thinking", thinking: "t".repeat(1_000_000) },
+					{ type: "text", text: "a".repeat(2_000_000) },
+				],
+			},
+		];
+
+		const result = builder.buildForApi(messages);
+		const serialized = JSON.stringify(result);
+		expect(serialized.length).toBeLessThan(1_000_000);
+		expect(serialized).toContain("provider request budget");
+		// Both blocks got reduced; neither is the full 2 MB / 1 MB original.
+		const content = result[0].content as Array<{ type: string }>;
+		const thinking = content.find((b) => b.type === "thinking") as unknown as
+			| { thinking: string }
+			| undefined;
+		const text = content.find((b) => b.type === "text") as unknown as
+			| { text: string }
+			| undefined;
+		if (!thinking || !text) throw new Error("expected both blocks present");
+		expect(thinking.thinking.length).toBeLessThan(1_000_000);
+		expect(text.text.length).toBeLessThan(2_000_000);
+	});
+
+	it("truncates top-level file blocks under the aggregate budget (CLINE-2191)", () => {
+		const builder = new MessageBuilder(50_000, undefined, 200_000);
+		const messages: Message[] = [
+			{
+				role: "user",
+				content: [
+					{
+						type: "file",
+						path: "/tmp/large.ts",
+						content: "y".repeat(4_000_000),
+					},
+				],
+			},
+		];
+
+		const result = builder.buildForApi(messages);
+		const block = Array.isArray(result[0].content)
+			? result[0].content[0]
+			: undefined;
+		expect(block?.type).toBe("file");
+		if (block?.type !== "file") throw new Error("expected file");
+		// Per-block max (50_000) brings it well under the 200_000 cap.
+		expect(Buffer.byteLength(block.content, "utf8")).toBeLessThanOrEqual(
+			50_000,
+		);
+	});
+
+	it("skips tool_use input bodies (CLINE-2191, deferred to Layer B)", () => {
+		// Document the intentional deferral: tool_use.input is structured
+		// JSON; Layer B will own the structural truncator that avoids
+		// corrupting tool_use_id or breaking the JSON shape. Layer A
+		// leaves tool_use blocks untouched even when they exceed budget.
+		const huge = "z".repeat(4_000_000);
+		const builder = new MessageBuilder(50_000, undefined, 100_000);
+		const messages: Message[] = [
+			{
+				role: "assistant",
+				content: [
+					{
+						type: "tool_use",
+						id: "tool_huge",
+						name: "editor",
+						input: { body: huge },
+					},
+				],
+			},
+		];
+
+		const result = builder.buildForApi(messages);
+		const block = Array.isArray(result[0].content)
+			? result[0].content[0]
+			: undefined;
+		expect(block?.type).toBe("tool_use");
+		if (block?.type !== "tool_use") throw new Error("expected tool_use");
+		// Input body is unchanged. Layer B will own this.
+		expect((block.input as { body: string }).body).toBe(huge);
+		expect(block.id).toBe("tool_huge");
+	});
+
+	it("derives the aggregate budget from maxInputTokens when provided (CLINE-2191)", () => {
+		// 100_000 tokens * 3 chars/token = 300_000 byte budget.
+		const builder = new MessageBuilder();
+		const messages: Message[] = [
+			{
+				role: "user",
+				content: [{ type: "text", text: "p".repeat(2_000_000) }],
+			},
+		];
+
+		const result = builder.buildForApi(messages, { maxInputTokens: 100_000 });
+		const block = Array.isArray(result[0].content)
+			? result[0].content[0]
+			: undefined;
+		if (block?.type !== "text") throw new Error("expected text");
+		expect(Buffer.byteLength(block.text, "utf8")).toBeLessThanOrEqual(300_000);
+		expect(block.text).toContain("provider request budget");
+	});
+
+	it("falls back to the constructor default budget when maxInputTokens is absent (CLINE-2191)", () => {
+		const builder = new MessageBuilder(50_000, undefined, 250_000);
+		const messages: Message[] = [
+			{
+				role: "user",
+				content: [{ type: "text", text: "q".repeat(4_000_000) }],
+			},
+		];
+
+		// No maxInputTokens passed → ctor's 250_000 byte budget applies.
+		const result = builder.buildForApi(messages);
+		const block = Array.isArray(result[0].content)
+			? result[0].content[0]
+			: undefined;
+		if (block?.type !== "text") throw new Error("expected text");
+		expect(Buffer.byteLength(block.text, "utf8")).toBeLessThanOrEqual(250_000);
+	});
+
+	it("produces deterministic output for equal-byte-length candidates (CLINE-2191)", () => {
+		// Two candidates of identical byte length. The sort tiebreaker
+		// (insertion order) ensures the same input always truncates the
+		// same one first, so the output is byte-identical across runs.
+		const longA = "a".repeat(500_000);
+		const longB = "b".repeat(500_000);
+		const build = () => {
+			const builder = new MessageBuilder(50_000, undefined, 200_000);
+			return builder.buildForApi([
+				{
+					role: "user",
+					content: [
+						{ type: "text", text: longA },
+						{ type: "text", text: longB },
+					],
+				},
+			]);
+		};
+
+		const first = JSON.stringify(build());
+		const second = JSON.stringify(build());
+		expect(first).toBe(second);
+	});
 });

--- a/sdk/packages/core/src/session/services/message-builder.ts
+++ b/sdk/packages/core/src/session/services/message-builder.ts
@@ -862,8 +862,6 @@ export class MessageBuilder {
 			for (const block of message.content) {
 				if (block.type === "text") {
 					total += utf8ByteLength(block.text);
-				} else if (block.type === "thinking") {
-					total += utf8ByteLength(block.thinking);
 				} else if (block.type === "file") {
 					total += utf8ByteLength(block.content);
 				} else if (block.type === "tool_result") {

--- a/sdk/packages/core/src/session/services/message-builder.ts
+++ b/sdk/packages/core/src/session/services/message-builder.ts
@@ -898,9 +898,12 @@ export class MessageBuilder {
 				// share the existing `MIN_TOTAL_BUDGET_TOOL_RESULT_BYTES`
 				// floor; truncating below that loses too much signal.
 				//
-				// `redacted_thinking` is intentionally skipped — its
-				// content is a fixed placeholder. `tool_use` and its
-				// `input` body are skipped here too; a JSON-aware
+				// `thinking` and `redacted_thinking` are intentionally
+				// skipped: signatures/details are tied to the original
+				// reasoning payload, so middle-truncating the text can make
+				// providers reject the request. Layer B may remove those
+				// blocks whole if the request still exceeds budget.
+				// `tool_use` and its `input` body are skipped here too; a JSON-aware
 				// structural truncator that can drill into values
 				// without corrupting `tool_use_id`s or breaking JSON
 				// shape is the responsibility of Layer B (CLINE-2192).
@@ -910,16 +913,6 @@ export class MessageBuilder {
 						get: () => block.text,
 						set: (value) => {
 							block.text = value;
-						},
-					});
-					continue;
-				}
-				if (block.type === "thinking") {
-					candidates.push({
-						byteLength: utf8ByteLength(block.thinking),
-						get: () => block.thinking,
-						set: (value) => {
-							block.thinking = value;
 						},
 					});
 					continue;

--- a/sdk/packages/core/src/session/services/message-builder.ts
+++ b/sdk/packages/core/src/session/services/message-builder.ts
@@ -10,6 +10,7 @@
  */
 
 import {
+	CHARS_PER_TOKEN,
 	type ContentBlock,
 	type Message,
 	normalizeUserInput,
@@ -82,7 +83,10 @@ export class MessageBuilder {
 		private readonly maxTotalTextBytes = DEFAULT_MAX_TOTAL_TEXT_BYTES,
 	) {}
 
-	buildForApi(messages: Message[]): Message[] {
+	buildForApi(
+		messages: Message[],
+		options: { maxInputTokens?: number } = {},
+	): Message[] {
 		this.reindex(messages);
 		const repairedMessages = this.addMissingToolResults(messages);
 
@@ -109,7 +113,7 @@ export class MessageBuilder {
 			return changed ? { ...message, content } : message;
 		});
 
-		return this.truncateToTotalTextBudget(prepared);
+		return this.truncateToTotalTextBudget(prepared, options.maxInputTokens);
 	}
 
 	private transformBlock(
@@ -789,13 +793,24 @@ export class MessageBuilder {
 		);
 	}
 
-	private truncateToTotalTextBudget(messages: Message[]): Message[] {
-		if (this.maxTotalTextBytes <= 0) {
+	private truncateToTotalTextBudget(
+		messages: Message[],
+		maxInputTokens?: number,
+	): Message[] {
+		// CLINE-2191: when the orchestrator threads the model's actual
+		// maxInputTokens, derive the aggregate cap from it. Otherwise
+		// fall back to the historical 6 MB default so legacy callers
+		// (existing tests, direct constructors) behave identically.
+		const effectiveBudget =
+			typeof maxInputTokens === "number" && maxInputTokens > 0
+				? maxInputTokens * CHARS_PER_TOKEN
+				: this.maxTotalTextBytes;
+		if (effectiveBudget <= 0) {
 			return messages;
 		}
 
 		let totalBytes = this.countMessageTextBytes(messages);
-		if (totalBytes <= this.maxTotalTextBytes) {
+		if (totalBytes <= effectiveBudget) {
 			return messages;
 		}
 
@@ -813,14 +828,14 @@ export class MessageBuilder {
 
 		const candidates = this.collectTruncationCandidates(next);
 		for (const candidate of candidates) {
-			if (totalBytes <= this.maxTotalTextBytes) {
+			if (totalBytes <= effectiveBudget) {
 				break;
 			}
 			const currentBytes = candidate.byteLength;
 			if (currentBytes <= MIN_TOTAL_BUDGET_TOOL_RESULT_BYTES) {
 				continue;
 			}
-			const overflow = totalBytes - this.maxTotalTextBytes;
+			const overflow = totalBytes - effectiveBudget;
 			const targetBytes = Math.max(
 				MIN_TOTAL_BUDGET_TOOL_RESULT_BYTES,
 				currentBytes - overflow,
@@ -878,6 +893,47 @@ export class MessageBuilder {
 				continue;
 			}
 			for (const block of message.content) {
+				// CLINE-2191: also collect candidates for the block types
+				// that previously bypassed the aggregate budget. These
+				// share the existing `MIN_TOTAL_BUDGET_TOOL_RESULT_BYTES`
+				// floor; truncating below that loses too much signal.
+				//
+				// `redacted_thinking` is intentionally skipped — its
+				// content is a fixed placeholder. `tool_use` and its
+				// `input` body are skipped here too; a JSON-aware
+				// structural truncator that can drill into values
+				// without corrupting `tool_use_id`s or breaking JSON
+				// shape is the responsibility of Layer B (CLINE-2192).
+				if (block.type === "text") {
+					candidates.push({
+						byteLength: utf8ByteLength(block.text),
+						get: () => block.text,
+						set: (value) => {
+							block.text = value;
+						},
+					});
+					continue;
+				}
+				if (block.type === "thinking") {
+					candidates.push({
+						byteLength: utf8ByteLength(block.thinking),
+						get: () => block.thinking,
+						set: (value) => {
+							block.thinking = value;
+						},
+					});
+					continue;
+				}
+				if (block.type === "file") {
+					candidates.push({
+						byteLength: utf8ByteLength(block.content),
+						get: () => block.content,
+						set: (value) => {
+							block.content = value;
+						},
+					});
+					continue;
+				}
 				if (block.type !== "tool_result") {
 					continue;
 				}
@@ -916,7 +972,19 @@ export class MessageBuilder {
 				}
 			}
 		}
-		return candidates.sort((l, r) => r.byteLength - l.byteLength);
+		// CLINE-2191: deterministic tiebreaker on insertion order so
+		// the same input always produces the same truncation output.
+		// Layer B (CLINE-2192) will rely on this same invariant.
+		const indexed = candidates.map((candidate, originalIndex) => ({
+			candidate,
+			originalIndex,
+		}));
+		indexed.sort(
+			(l, r) =>
+				r.candidate.byteLength - l.candidate.byteLength ||
+				l.originalIndex - r.originalIndex,
+		);
+		return indexed.map(({ candidate }) => candidate);
 	}
 }
 

--- a/sdk/packages/shared/src/index.browser.ts
+++ b/sdk/packages/shared/src/index.browser.ts
@@ -127,7 +127,7 @@ export {
 	resolveReasoningEffortRatio,
 } from "./llms/reasoning-effort";
 export { DEFAULT_REQUEST_HEADERS, serializeAbortReason } from "./llms/requests";
-export { estimateTokens } from "./llms/tokens";
+export { CHARS_PER_TOKEN, estimateTokens } from "./llms/tokens";
 export type {
 	ToolApprovalRequest,
 	ToolApprovalResult,

--- a/sdk/packages/shared/src/index.ts
+++ b/sdk/packages/shared/src/index.ts
@@ -141,7 +141,7 @@ export {
 	resolveReasoningEffortRatio,
 } from "./llms/reasoning-effort";
 export { DEFAULT_REQUEST_HEADERS, serializeAbortReason } from "./llms/requests";
-export { estimateTokens } from "./llms/tokens";
+export { CHARS_PER_TOKEN, estimateTokens } from "./llms/tokens";
 export type {
 	ToolApprovalRequest,
 	ToolApprovalResult,

--- a/sdk/packages/shared/src/llms/tokens.ts
+++ b/sdk/packages/shared/src/llms/tokens.ts
@@ -5,7 +5,7 @@
  * rather than after.
  */
 
-const CHARS_PER_TOKEN = 3;
+export const CHARS_PER_TOKEN = 3;
 
 export function estimateTokens(chars: number): number {
 	return Math.max(1, Math.ceil(chars / CHARS_PER_TOKEN));


### PR DESCRIPTION
### Related Issue

**Issue:** CLINE-2191 — Widen MessageBuilder truncation candidate set (Layer A)
**Stacked on:** #10740 — please merge that first.
**Sibling follow-up:** CLINE-2192 — Absolute hard guarantee (Layer B). This PR does NOT guarantee the request fits.

### Description

After #10739 (allowlist) and #10740 (protected-tail trim), the post-compaction preservation set inside the in-flight turn still contains the typed user prompt, the last assistant message, and any in-flight `tool_use` verbatim. Each can individually exceed any context window. `MessageBuilder.buildForApi` already has the middle-truncation infrastructure (`truncateMiddleByChars`, `truncateMiddleToBytes`, an aggregate-budget pass at `truncateToTotalTextBudget`). It just doesn't see enough block types and runs against a hardcoded 6 MB cap rather than the model's actual `maxInputTokens`.

This PR is the **preventive** layer — the *typical* over-budget request stops being a 400 and becomes a truncated-but-shipped request. The **brick-wall guarantee** for adversarial inputs is sibling CLINE-2192, which stacks on top of this one. We are not over-selling: this PR does NOT yet meet the "Ever EVER" bar.

### Changes

In `sdk/packages/core/src/session/services/message-builder.ts`:

1. **`collectTruncationCandidates` widened.** In addition to the existing `tool_result` candidates it now collects user `text`, assistant `text`, `thinking` block text, and top-level `file` block content. `redacted_thinking` is skipped (placeholder string). `tool_use` blocks are skipped — a JSON-aware structural truncator that avoids corrupting `tool_use_id` or breaking the `input` JSON shape is Layer B's responsibility.
2. **Aggregate budget tied to `maxInputTokens`.** `buildForApi(messages, { maxInputTokens })` now derives the cap from the model's actual `maxInputTokens` (× `CHARS_PER_TOKEN` = 3). When `maxInputTokens` is not provided the constructor's hardcoded 6 MB default still applies, so legacy callers behave identically.
3. **Deterministic sort.** The largest-first sort gains an insertion-order tiebreaker so equal-byte candidates always truncate in the same order. Layer B relies on the same property.

In `sdk/packages/core/src/runtime/orchestration/session-runtime-orchestrator.ts`:

- `createRuntimeHooks` and `createRuntimePrepareTurn` now thread `modelInfo.maxInputTokens` through `prepareMessagesForModelRequest` → `prepareProviderMessagesForApi` → `buildForApi`. The cap reflects the model that is actually being called, not a 6 MB approximation.

In `sdk/packages/shared/src/llms/tokens.ts` + `index.ts` + `index.browser.ts`:

- `CHARS_PER_TOKEN` was previously private. Exported alongside the existing `estimateTokens`.

### Test Procedure

Seven new cases in `sdk/packages/core/src/session/services/message-builder.test.ts`:

1. `truncates user text blocks under the aggregate budget (CLINE-2191)` — 5 MB user text, 500 KB budget, asserts truncation marker and final size.
2. `truncates assistant text and thinking blocks under the aggregate budget (CLINE-2191)` — 2 MB text + 1 MB thinking, 250 KB budget, asserts both truncated.
3. `truncates top-level file blocks under the aggregate budget (CLINE-2191)` — 4 MB file block, 200 KB budget.
4. `skips tool_use input bodies (CLINE-2191, deferred to Layer B)` — 4 MB `tool_use.input.body` stays untouched. Doc-test for the deferral.
5. `derives the aggregate budget from maxInputTokens when provided (CLINE-2191)` — `buildForApi(messages, { maxInputTokens: 100_000 })` → 300 000 byte cap.
6. `falls back to the constructor default budget when maxInputTokens is absent (CLINE-2191)` — legacy callers unchanged.
7. `produces deterministic output for equal-byte-length candidates (CLINE-2191)` — two equal-byte candidates → byte-identical output across two runs.

Verification:

```
sdk/packages/core $ bun run typecheck:smoke   # clean
sdk/packages/core $ bun run test:unit -- message-builder.test
  ✓ 16 tests passed (9 existing + 7 new)
sdk/packages/core $ bun run test:unit
  Test Files  102 passed | 1 skipped (103)
       Tests  920 passed | 4 skipped (924)
```

### What this PR still does NOT fix (intentional, deferred to CLINE-2192)

- **`tool_use.input` truncation.** JSON-aware structural truncator that drills into string values without corrupting `tool_use_id` or `input` shape.
- **Adversarial inputs.** A pathological transcript of 50k small blocks each below the `MIN_TOTAL_BUDGET_TOOL_RESULT_BYTES = 8_000` floor would still overshoot — the largest-first heuristic can't shrink below the floor. Layer B adds the final byte-cap enforcement.
- **User-visible status notice and `task.emergency_truncation` telemetry.** Only fires when we enter genuinely degraded mode; Layer B's concern.
- **Hard-error path.** Policy is "degrade, never error" — neither layer hard-errors.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore
-   [x] Tests are passing and code is formatted and linted
-   [x] I have reviewed contributor guidelines

### Additional Notes

The orchestrator threading is a small public-API change (`MessageBuilder.buildForApi` gains an optional second argument). Existing tests construct `MessageBuilder` directly without passing `maxInputTokens` and behave unchanged. The 6 MB hardcoded default stays as the fallback floor so any caller that doesn't yet know about `maxInputTokens` gets the pre-PR behavior.

### Diagram

```text
PR #10747 / CLINE-2191
Layer A: heuristic total text budget in MessageBuilder

Provider messages after per-block truncation:

  text blocks
  file blocks
  tool_result text
  other shrinkable text
        |
        v
  measure total text bytes/chars
        |
        v
  budget = maxInputTokens * 3 chars/token
        |
        v
  over budget?
        |
   +----+----+
   |         |
  no        yes
   |         |
   v         v
 return   choose largest shrinkable blocks first
          middle-truncate them
          skip signed/unshrinkable thinking
              |
              v
          provider payload usually fits
```