### PR TITLE
feat(hooks): add PostAssistantTurn hook

### DIFF
--- a/proto/cline/hooks.proto
+++ b/proto/cline/hooks.proto
@@ -25,6 +25,7 @@ message HookInput {
     TaskCompleteData task_complete = 16;
     PreCompactData pre_compact = 17;
     NotificationData notification = 18;
+    PostAssistantTurnData post_assistant_turn = 19;
   }
 }
 
@@ -95,6 +96,18 @@ message TaskCancelData {
 // Data for TaskComplete hook
 message TaskCompleteData {
   map<string, string> task_metadata = 1;
+}
+
+// Data for PostAssistantTurn hook
+message PostAssistantTurnData {
+  // Plain text of the assistant's response (no tool XML)
+  string assistant_text = 1;
+  // Names of tools invoked during this turn (empty if none)
+  repeated string tool_names = 2;
+  // Turn number within the current task (1-based)
+  int64 turn_number = 3;
+  // Task metadata (taskId, ulid)
+  map<string, string> task_metadata = 4;
 }
 
 // Data for PreCompact hook

--- a/src/core/hooks/__tests__/fixtures/hooks/postassistantturn/error/PostAssistantTurn
+++ b/src/core/hooks/__tests__/fixtures/hooks/postassistantturn/error/PostAssistantTurn
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+console.error("Hook execution error");
+process.exit(1);

--- a/src/core/hooks/__tests__/fixtures/hooks/postassistantturn/logging/PostAssistantTurn
+++ b/src/core/hooks/__tests__/fixtures/hooks/postassistantturn/logging/PostAssistantTurn
@@ -1,8 +1,9 @@
 #!/usr/bin/env node
 const input = JSON.parse(require('fs').readFileSync(0, 'utf-8'));
 const turn = input.postAssistantTurn;
+const toolNames = turn.toolNames || [];
 console.log(JSON.stringify({
   cancel: false,
-  contextModification: "turn=" + turn.turnNumber + " tools=" + turn.toolNames.length + " len=" + turn.assistantText.length,
+  contextModification: "turn=" + turn.turnNumber + " tools=" + toolNames.length + " len=" + turn.assistantText.length,
   errorMessage: ""
 }));

--- a/src/core/hooks/__tests__/fixtures/hooks/postassistantturn/logging/PostAssistantTurn
+++ b/src/core/hooks/__tests__/fixtures/hooks/postassistantturn/logging/PostAssistantTurn
@@ -1,0 +1,8 @@
+#!/usr/bin/env node
+const input = JSON.parse(require('fs').readFileSync(0, 'utf-8'));
+const turn = input.postAssistantTurn;
+console.log(JSON.stringify({
+  cancel: false,
+  contextModification: "turn=" + turn.turnNumber + " tools=" + turn.toolNames.length + " len=" + turn.assistantText.length,
+  errorMessage: ""
+}));

--- a/src/core/hooks/__tests__/fixtures/hooks/postassistantturn/success/PostAssistantTurn
+++ b/src/core/hooks/__tests__/fixtures/hooks/postassistantturn/success/PostAssistantTurn
@@ -1,0 +1,6 @@
+#!/usr/bin/env node
+console.log(JSON.stringify({
+  cancel: false,
+  contextModification: "PostAssistantTurn hook executed successfully",
+  errorMessage: ""
+}));

--- a/src/core/hooks/__tests__/post-assistant-turn.test.ts
+++ b/src/core/hooks/__tests__/post-assistant-turn.test.ts
@@ -1,0 +1,367 @@
+import { afterEach, beforeEach, describe, it } from "mocha"
+import "should"
+import fs from "fs/promises"
+import path from "path"
+import sinon from "sinon"
+import { HookOutput } from "../../../shared/proto/cline/hooks"
+import { HookFactory } from "../hook-factory"
+import { createHookTestEnv, HookTestEnv, stubHookDirs, withFixtureRunner, writeHookScriptForPlatform } from "./test-utils"
+
+describe("PostAssistantTurn Hook", () => {
+	let tempDir: string
+	let sandbox: sinon.SinonSandbox
+	let hookTestEnv: HookTestEnv
+	const WINDOWS_HOOK_TEST_TIMEOUT_MS = 15000
+
+	type FixtureScenario = {
+		fixtureName: string
+		assistantText: string
+		toolNames: string[]
+		turnNumber: number
+		assert: (result: HookOutput) => void
+	}
+
+	const getErrorMessage = (error: unknown): string => (error instanceof Error ? error.message : String(error))
+
+	const writeHookScript = async (hookPath: string, nodeScript: string): Promise<void> => {
+		await writeHookScriptForPlatform(hookPath, nodeScript)
+	}
+
+	const defaultInput = () => ({
+		taskId: "test-task",
+		postAssistantTurn: {
+			assistantText: "Here is the result.",
+			toolNames: [],
+			turnNumber: 1,
+			taskMetadata: { taskId: "test-task", ulid: "test-ulid" },
+		},
+	})
+
+	beforeEach(async () => {
+		hookTestEnv = await createHookTestEnv()
+		tempDir = hookTestEnv.tempDir
+		sandbox = hookTestEnv.sandbox
+	})
+
+	afterEach(async () => {
+		await hookTestEnv.cleanup()
+	})
+
+	describe("Hook Input Format", () => {
+		it("should receive assistantText from the turn", async () => {
+			const hookPath = path.join(tempDir, ".clinerules", "hooks", "PostAssistantTurn")
+			const hookScript = `#!/usr/bin/env node
+const input = JSON.parse(require('fs').readFileSync(0, 'utf-8'));
+const hasText = input.postAssistantTurn && typeof input.postAssistantTurn.assistantText === 'string';
+console.log(JSON.stringify({
+  cancel: false,
+  contextModification: hasText ? "Received text" : "Missing text"
+}))`
+
+			await writeHookScript(hookPath, hookScript)
+
+			const factory = new HookFactory()
+			const runner = await factory.create("PostAssistantTurn")
+
+			const result = await runner.run(defaultInput())
+
+			result.cancel.should.be.false()
+			result.contextModification?.should.equal("Received text")
+		})
+
+		it("should receive toolNames array", async () => {
+			const hookPath = path.join(tempDir, ".clinerules", "hooks", "PostAssistantTurn")
+			const hookScript = `#!/usr/bin/env node
+const input = JSON.parse(require('fs').readFileSync(0, 'utf-8'));
+const tools = input.postAssistantTurn.toolNames;
+console.log(JSON.stringify({
+  cancel: false,
+  contextModification: "tools=" + tools.join(",")
+}))`
+
+			await writeHookScript(hookPath, hookScript)
+
+			const factory = new HookFactory()
+			const runner = await factory.create("PostAssistantTurn")
+
+			const result = await runner.run({
+				taskId: "test-task",
+				postAssistantTurn: {
+					assistantText: "Done.",
+					toolNames: ["read_file", "write_to_file"],
+					turnNumber: 2,
+					taskMetadata: { taskId: "test-task", ulid: "test-ulid" },
+				},
+			})
+
+			result.contextModification?.should.equal("tools=read_file,write_to_file")
+		})
+
+		it("should receive turnNumber", async () => {
+			const hookPath = path.join(tempDir, ".clinerules", "hooks", "PostAssistantTurn")
+			const hookScript = `#!/usr/bin/env node
+const input = JSON.parse(require('fs').readFileSync(0, 'utf-8'));
+console.log(JSON.stringify({
+  cancel: false,
+  contextModification: "turn=" + input.postAssistantTurn.turnNumber
+}))`
+
+			await writeHookScript(hookPath, hookScript)
+
+			const factory = new HookFactory()
+			const runner = await factory.create("PostAssistantTurn")
+
+			const result = await runner.run({
+				taskId: "test-task",
+				postAssistantTurn: {
+					assistantText: "Done.",
+					toolNames: [],
+					turnNumber: 5,
+					taskMetadata: { taskId: "test-task", ulid: "test-ulid" },
+				},
+			})
+
+			result.contextModification?.should.equal("turn=5")
+		})
+
+		it("should receive taskMetadata with taskId and ulid", async () => {
+			const hookPath = path.join(tempDir, ".clinerules", "hooks", "PostAssistantTurn")
+			const hookScript = `#!/usr/bin/env node
+const input = JSON.parse(require('fs').readFileSync(0, 'utf-8'));
+const meta = input.postAssistantTurn.taskMetadata;
+const hasIds = meta.taskId && meta.ulid;
+console.log(JSON.stringify({
+  cancel: false,
+  contextModification: hasIds ? "IDs present" : "IDs missing"
+}))`
+
+			await writeHookScript(hookPath, hookScript)
+
+			const factory = new HookFactory()
+			const runner = await factory.create("PostAssistantTurn")
+
+			const result = await runner.run(defaultInput())
+
+			result.contextModification?.should.equal("IDs present")
+		})
+
+		it("should receive all common hook input fields", async () => {
+			const hookPath = path.join(tempDir, ".clinerules", "hooks", "PostAssistantTurn")
+			const hookScript = `#!/usr/bin/env node
+const input = JSON.parse(require('fs').readFileSync(0, 'utf-8'));
+const hasAllFields = input.clineVersion && input.hookName === 'PostAssistantTurn' &&
+                     input.timestamp && input.taskId && input.workspaceRoots !== undefined &&
+                     input.model && input.model.provider && input.model.slug;
+console.log(JSON.stringify({
+  cancel: false,
+  contextModification: hasAllFields ? "All fields present" : "Missing fields"
+}))`
+
+			await writeHookScript(hookPath, hookScript)
+
+			const factory = new HookFactory()
+			const runner = await factory.create("PostAssistantTurn")
+
+			const result = await runner.run(defaultInput())
+
+			result.contextModification?.should.equal("All fields present")
+		})
+	})
+
+	describe("Observation-Only Semantics", () => {
+		it("should return hook output even when cancel is true (caller ignores it)", async () => {
+			const hookPath = path.join(tempDir, ".clinerules", "hooks", "PostAssistantTurn")
+			const hookScript = `#!/usr/bin/env node
+console.log(JSON.stringify({
+  cancel: true,
+  errorMessage: "Hook tried to cancel"
+}))`
+
+			await writeHookScript(hookPath, hookScript)
+
+			const factory = new HookFactory()
+			const runner = await factory.create("PostAssistantTurn")
+
+			// The runner still returns the hook output — it's the caller's responsibility to ignore cancel
+			const result = await runner.run(defaultInput())
+			result.cancel.should.be.true()
+			result.errorMessage?.should.equal("Hook tried to cancel")
+		})
+
+		it("should handle turn with no tool calls", async () => {
+			const hookPath = path.join(tempDir, ".clinerules", "hooks", "PostAssistantTurn")
+			const hookScript = `#!/usr/bin/env node
+const input = JSON.parse(require('fs').readFileSync(0, 'utf-8'));
+const toolCount = input.postAssistantTurn.toolNames.length;
+console.log(JSON.stringify({
+  cancel: false,
+  contextModification: "tool_count=" + toolCount
+}))`
+
+			await writeHookScript(hookPath, hookScript)
+
+			const factory = new HookFactory()
+			const runner = await factory.create("PostAssistantTurn")
+
+			const result = await runner.run({
+				taskId: "test-task",
+				postAssistantTurn: {
+					assistantText: "No tools were needed.",
+					toolNames: [],
+					turnNumber: 1,
+					taskMetadata: { taskId: "test-task", ulid: "test-ulid" },
+				},
+			})
+
+			result.contextModification?.should.equal("tool_count=0")
+		})
+	})
+
+	describe("Error Handling", () => {
+		it("should handle malformed JSON output from hook", async () => {
+			const hookPath = path.join(tempDir, ".clinerules", "hooks", "PostAssistantTurn")
+			const hookScript = `#!/usr/bin/env node
+console.log("not valid json")`
+
+			await writeHookScript(hookPath, hookScript)
+
+			const factory = new HookFactory()
+			const runner = await factory.create("PostAssistantTurn")
+
+			const result = await runner.run(defaultInput())
+
+			result.cancel.should.be.false()
+			;(result.contextModification === undefined || result.contextModification === "").should.be.true()
+		})
+
+		it("should handle hook script errors", async () => {
+			const hookPath = path.join(tempDir, ".clinerules", "hooks", "PostAssistantTurn")
+			const hookScript = `#!/usr/bin/env node
+process.exit(1)`
+
+			await writeHookScript(hookPath, hookScript)
+
+			const factory = new HookFactory()
+			const runner = await factory.create("PostAssistantTurn")
+
+			try {
+				await runner.run(defaultInput())
+				throw new Error("Should have thrown")
+			} catch (error: unknown) {
+				getErrorMessage(error).should.match(/exited with code 1/)
+			}
+		})
+	})
+
+	describe("Global and Workspace Hooks", () => {
+		let globalHooksDir: string
+		let workspaceHooksDir: string
+
+		beforeEach(async () => {
+			globalHooksDir = path.join(tempDir, "global-hooks")
+			await fs.mkdir(globalHooksDir, { recursive: true })
+			workspaceHooksDir = path.join(tempDir, ".clinerules", "hooks")
+
+			stubHookDirs(sandbox, [globalHooksDir, workspaceHooksDir])
+		})
+
+		it("should execute both global and workspace PostAssistantTurn hooks", async () => {
+			const globalHookPath = path.join(globalHooksDir, "PostAssistantTurn")
+			const globalHookScript = `#!/usr/bin/env node
+console.log(JSON.stringify({
+  cancel: false,
+  contextModification: "GLOBAL: turn observed"
+}))`
+			await writeHookScript(globalHookPath, globalHookScript)
+
+			const workspaceHookPath = path.join(tempDir, ".clinerules", "hooks", "PostAssistantTurn")
+			const workspaceHookScript = `#!/usr/bin/env node
+console.log(JSON.stringify({
+  cancel: false,
+  contextModification: "WORKSPACE: turn observed"
+}))`
+			await writeHookScript(workspaceHookPath, workspaceHookScript)
+
+			const factory = new HookFactory()
+			const runner = await factory.create("PostAssistantTurn")
+
+			const result = await runner.run(defaultInput())
+
+			result.cancel.should.be.false()
+			result.contextModification?.should.match(/GLOBAL: turn observed/)
+			result.contextModification?.should.match(/WORKSPACE: turn observed/)
+		})
+	})
+
+	describe("No Hook Behavior", () => {
+		it("should succeed when no hook exists", async () => {
+			const factory = new HookFactory()
+			const runner = await factory.create("PostAssistantTurn")
+
+			const result = await runner.run(defaultInput())
+
+			result.cancel.should.be.false()
+		})
+	})
+
+	describe("Fixture-Based Tests", () => {
+		it("should validate representative fixtures end-to-end", async function () {
+			this.timeout(WINDOWS_HOOK_TEST_TIMEOUT_MS)
+
+			const scenarios: FixtureScenario[] = [
+				{
+					fixtureName: "success",
+					assistantText: "Here is the result.",
+					toolNames: [],
+					turnNumber: 1,
+					assert: (result: HookOutput) => {
+						result.cancel.should.be.false()
+						result.contextModification?.should.equal("PostAssistantTurn hook executed successfully")
+					},
+				},
+				{
+					fixtureName: "logging",
+					assistantText: "Done.",
+					toolNames: ["read_file"],
+					turnNumber: 3,
+					assert: (result: HookOutput) => {
+						result.cancel.should.be.false()
+						result.contextModification?.should.equal("turn=3 tools=1 len=5")
+					},
+				},
+			]
+
+			for (const scenario of scenarios) {
+				await withFixtureRunner(
+					"PostAssistantTurn",
+					`hooks/postassistantturn/${scenario.fixtureName}`,
+					hookTestEnv,
+					async (runner) => {
+						const result = await runner.run({
+							taskId: "test-task",
+							postAssistantTurn: {
+								assistantText: scenario.assistantText,
+								toolNames: scenario.toolNames,
+								turnNumber: scenario.turnNumber,
+								taskMetadata: { taskId: "test-task", ulid: "test-ulid" },
+							},
+						})
+
+						scenario.assert(result)
+					},
+				)
+			}
+		})
+
+		it("should cover failing fixture path", async () => {
+			await withFixtureRunner("PostAssistantTurn", "hooks/postassistantturn/error", hookTestEnv, async (runner) => {
+				try {
+					await runner.run(defaultInput())
+					throw new Error("Should have thrown")
+				} catch (error: unknown) {
+					getErrorMessage(error).should.match(/PostAssistantTurn.*exited with code 1/)
+				}
+			})
+		})
+	})
+})

--- a/src/core/hooks/__tests__/post-assistant-turn.test.ts
+++ b/src/core/hooks/__tests__/post-assistant-turn.test.ts
@@ -192,7 +192,8 @@ console.log(JSON.stringify({
 			const hookPath = path.join(tempDir, ".clinerules", "hooks", "PostAssistantTurn")
 			const hookScript = `#!/usr/bin/env node
 const input = JSON.parse(require('fs').readFileSync(0, 'utf-8'));
-const toolCount = input.postAssistantTurn.toolNames.length;
+const toolNames = input.postAssistantTurn.toolNames || [];
+const toolCount = toolNames.length;
 console.log(JSON.stringify({
   cancel: false,
   contextModification: "tool_count=" + toolCount

--- a/src/core/hooks/hook-factory.ts
+++ b/src/core/hooks/hook-factory.ts
@@ -9,6 +9,7 @@ import {
 	HookModelContext,
 	HookOutput,
 	NotificationData,
+	PostAssistantTurnData,
 	PostToolUseData,
 	PreCompactData,
 	PreToolUseData,
@@ -126,6 +127,9 @@ export interface Hooks {
 	}
 	PreCompact: {
 		preCompact: PreCompactData
+	}
+	PostAssistantTurn: {
+		postAssistantTurn: PostAssistantTurnData
 	}
 }
 

--- a/src/core/hooks/templates.ts
+++ b/src/core/hooks/templates.ts
@@ -19,6 +19,7 @@ export function getHookTemplate(hookName: string): string {
 		UserPromptSubmit: getUserPromptSubmitTemplate(),
 		Notification: getNotificationTemplate(),
 		PreCompact: getPreCompactTemplate(),
+		PostAssistantTurn: getPostAssistantTurnTemplate(),
 	}
 
 	return templates[hookName] || getDefaultTemplate(hookName)
@@ -463,6 +464,51 @@ fi
 echo "[PreCompact] About to compact conversation (contextSize: $CONTEXT_SIZE, strategy: $STRATEGY, tokensIn: $TOKENS_IN, tokensOut: $TOKENS_OUT)" >&2
 
 # Return result
+echo '{"cancel":false,"contextModification":"","errorMessage":""}'
+`
+}
+
+function getPostAssistantTurnTemplate(): string {
+	return `#!/bin/bash
+#
+# PostAssistantTurn Hook
+#
+# Executes after each complete assistant turn (text + all tool calls finished).
+# Observation-only: cancel and contextModification are ignored by the caller.
+#
+# Input: {
+#   taskId,
+#   postAssistantTurn: {
+#     assistantText: string,     # plain text of the assistant response
+#     toolNames: string[],       # tools invoked this turn (may be empty)
+#     turnNumber: number,        # 1-based turn index within the task
+#     taskMetadata: { taskId: string, ulid: string }
+#   },
+#   clineVersion, timestamp, ...
+# }
+# Output: { cancel: boolean, contextModification?: string, errorMessage?: string }
+#
+# Use cases:
+# - Log every AI exchange for reproducibility (e.g. repro-mcp log_exchange)
+# - Audit assistant responses
+# - Trigger external notifications after each turn
+
+INPUT=$(cat)
+
+if command -v jq &> /dev/null; then
+  TASK_ID=$(echo "$INPUT" | jq -r '.taskId')
+  TURN=$(echo "$INPUT" | jq -r '.postAssistantTurn.turnNumber')
+  TOOLS=$(echo "$INPUT" | jq -r '.postAssistantTurn.toolNames | join(", ")')
+  TEXT_LEN=$(echo "$INPUT" | jq -r '.postAssistantTurn.assistantText | length')
+else
+  TASK_ID="<taskId>"
+  TURN="?"
+  TOOLS=""
+  TEXT_LEN="?"
+fi
+
+echo "[PostAssistantTurn] Task=$TASK_ID turn=$TURN tools=[$TOOLS] response_length=$TEXT_LEN" >&2
+
 echo '{"cancel":false,"contextModification":"","errorMessage":""}'
 `
 }

--- a/src/core/hooks/templates.ts
+++ b/src/core/hooks/templates.ts
@@ -498,7 +498,8 @@ INPUT=$(cat)
 if command -v jq &> /dev/null; then
   TASK_ID=$(echo "$INPUT" | jq -r '.taskId')
   TURN=$(echo "$INPUT" | jq -r '.postAssistantTurn.turnNumber')
-  TOOLS=$(echo "$INPUT" | jq -r '.postAssistantTurn.toolNames | join(", ")')
+  # toolNames may be absent when empty (proto3 omits default values) — default to []
+  TOOLS=$(echo "$INPUT" | jq -r '(.postAssistantTurn.toolNames // []) | join(", ")')
   TEXT_LEN=$(echo "$INPUT" | jq -r '.postAssistantTurn.assistantText | length')
 else
   TASK_ID="<taskId>"

--- a/src/core/task/index.ts
+++ b/src/core/task/index.ts
@@ -3204,6 +3204,31 @@ export class Task {
 				// Save checkpoint after all tools in this response have finished executing
 				await this.checkpointManager?.saveCheckpoint()
 
+				// Fire PostAssistantTurn hook — observation-only, fires after every complete turn
+				if (getHooksEnabledSafe(this.stateManager.getGlobalSettingsKey("hooksEnabled"))) {
+					const toolNames = this.taskState.assistantMessageContent
+						.filter((block) => block.type === "tool_use")
+						.map((block) => (block as { type: "tool_use"; name: string }).name)
+					const turnNumber = Math.ceil(this.messageStateHandler.getApiConversationHistory().length / 2)
+					await executeHook({
+						hookName: "PostAssistantTurn",
+						hookInput: {
+							postAssistantTurn: {
+								assistantText: assistantTextOnly,
+								toolNames,
+								turnNumber,
+								taskMetadata: { taskId: this.taskId, ulid: this.ulid },
+							},
+						},
+						isCancellable: false,
+						say: this.say.bind(this),
+						messageStateHandler: this.messageStateHandler,
+						taskId: this.taskId,
+						hooksEnabled: true,
+						model: getHookModelContext(this.api, this.stateManager),
+					})
+				}
+
 				// if the model did not tool use, then we need to tell it to either use a tool or attempt_completion
 				const didToolUse = this.taskState.assistantMessageContent.some((block) => block.type === "tool_use")
 

--- a/src/core/task/index.ts
+++ b/src/core/task/index.ts
@@ -3224,7 +3224,7 @@ export class Task {
 						say: this.say.bind(this),
 						messageStateHandler: this.messageStateHandler,
 						taskId: this.taskId,
-						hooksEnabled: true,
+						hooksEnabled: getHooksEnabledSafe(this.stateManager.getGlobalSettingsKey("hooksEnabled")),
 						model: getHookModelContext(this.api, this.stateManager),
 					})
 				}


### PR DESCRIPTION
Related Issue
Issue: #10752

-- UPDATE 21st May 2026: code review addressed, waiting on companion JetBrains plugin update from team member --


Description
This PR adds a PostAssistantTurn hook that fires after each complete assistant turn — once all tool calls in that turn have finished executing and the checkpoint has been saved. It is observation-only: cancel and contextModification are ignored by the caller.

Why this hook is needed:

PostToolUse fires per tool call and TaskComplete fires at task end, but there is no hook that fires once per complete assistant turn (text response + all its tools as a unit). This gap prevents external tools from building turn-level logs without polling or reconstructing state from individual tool events.

Motivation — scientific computing reproducibility:

The primary motivation is [repro-mcp](https://github.com/ABindoff/repro-mcp), an MCP server that logs every AI exchange to human-readable markdown files for scientific audit trails. Researchers working locally under privacy or funding constraints need a complete record of AI interactions — not just what code changed, but why. PostAssistantTurn makes that logging automatic and transparent without requiring the AI to remember to call a logging tool each turn.

Changes (4 files, 88 lines):

proto/cline/hooks.proto — adds PostAssistantTurnData message (assistantText, toolNames, turnNumber, taskMetadata) and wires it into HookInput's oneof
src/core/hooks/hook-factory.ts — adds PostAssistantTurn to the Hooks interface
src/core/hooks/templates.ts — adds a bash template with jq-based parsing example
src/core/task/index.ts — fires the hook after pWaitFor(userMessageContentReady) + saveCheckpoint(), before the next recursivelyMakeClineRequests call
Test Procedure
Verified TypeScript compiles clean (npm run compile) with no errors
Manually confirmed the hook fires by placing a PostAssistantTurn script in .clinerules/hooks/ and observing it execute after each assistant turn, including turns with multiple tool calls
Verified it does not fire on turns where the stream is aborted early (the pWaitFor gate ensures this)
Verified existing hooks (PostToolUse, TaskComplete, TaskStart) are unaffected — their call sites are unchanged
The observation-only behaviour (ignoring cancel/contextModification) matches the existing pattern used by Notification and TaskComplete
Type of Change
done
✨ New feature (non-breaking change which adds functionality)
Pre-flight Checklist
done
Changes are limited to a single feature (adding PostAssistantTurn hook)
done
Code is formatted and linted (npm run compile passes, biome pre-commit hook ran clean)
done
I have reviewed contributor guidelines
Screenshots
No UI changes. The hook fires and is handled identically to other observation-only hooks (PostToolUse, Notification). Terminal output from a test run showing the hook script executing after each turn is available on request.

Additional Notes
The proto/cline/hooks.proto change uses field number 19 for PostAssistantTurnData in the oneof data block, continuing the existing sequence. npm run protos was run after the proto change to regenerate types (generated files are gitignored per project convention).

