### PR TITLE
fix(sdk): enforce hard provider request byte budget (CLINE-2192)

### DIFF
--- a/docs/enterprise-solutions/monitoring/opentelemetry-events.mdx
+++ b/docs/enterprise-solutions/monitoring/opentelemetry-events.mdx
@@ -179,6 +179,8 @@ Core events tracking task lifecycle, conversation turns, tool usage, and executi
 |-------|-------------|----------------|
 | `task.summarize_task` | Auto-compaction/summarize triggered for context pressure | conversation_length, estimated_tokens |
 | `task.auto_condense_toggled` | Auto-condense setting toggled | enabled |
+| `task.emergency_truncation` | Provider request payload was aggressively truncated to fit the context-window budget | ulid, bytesBefore, bytesAfter, maxInputTokens, truncatedBlocks, droppedBlocks, provider, modelId |
+| `task.request_overhead_exceeds_budget` | Non-message provider request overhead already exceeded the derived byte budget before messages could be included | ulid, requestBytes, budgetBytes, maxInputTokens, systemPromptBytes, toolsBytes, optionsBytes, provider, modelId |
 
 ### Settings & Features
 

--- a/sdk/packages/core/src/extensions/context/basic-compaction.ts
+++ b/sdk/packages/core/src/extensions/context/basic-compaction.ts
@@ -262,13 +262,13 @@ function collectAtomicRemovalIndexes<C extends MinimalCandidate>(
 // Unlike removeTailCandidatesByPredicate, this function does NOT check
 // whether every member of an atomic closure satisfies the predicate before
 // removing. That is safe on the prefix path because the four successive
-// predicate calls are role-monotone: each call's predicate either accepts
-// ALL members of any possible closure (because closures only span
-// same-role candidates on the prefix) or accepts NONE. A tool_use in an
-// assistant message is always paired with a tool_result in a user message;
-// the first pass removes only assistant non-last messages and the second
-// removes only non-last-non-first user messages, so a closure can never
-// straddle a protected and an unprotected candidate on the prefix path.
+// predicate calls protect only typed turn-start user messages. Prefix
+// tool_result messages are tool-result-only, so they are never first/last
+// typed users; if a removable assistant tool_use closure pulls in its
+// matching user tool_result, that user message is also removable on the
+// prefix path. The stricter closure-safety check is still required for
+// protected-tail trimming, where the last assistant message may share a
+// closure with an otherwise removable tool_result.
 function removeCandidatesByPredicate<C extends MinimalCandidate>(
 	candidates: C[],
 	predicate: (candidate: C) => boolean,
@@ -363,6 +363,47 @@ function trimCandidatesToBudget(
 			estimateMessageTokens,
 		);
 	}
+}
+
+function compactBasicCandidatesToBudget(
+	candidates: BasicCompactionCandidate[],
+	targetTokens: number,
+	estimateMessageTokens: EstimateMessageTokens,
+): void {
+	removeCandidatesByPredicate(
+		candidates,
+		(candidate) =>
+			candidate.message.role === "assistant" && !candidate.isLastAssistant,
+		targetTokens,
+		estimateMessageTokens,
+	);
+	removeCandidatesByPredicate(
+		candidates,
+		(candidate) =>
+			candidate.message.role === "user" &&
+			!candidate.isFirstUser &&
+			!candidate.isLastUser,
+		targetTokens,
+		estimateMessageTokens,
+	);
+	removeCandidatesByPredicate(
+		candidates,
+		(candidate) =>
+			candidate.message.role === "assistant" && candidate.isLastAssistant,
+		targetTokens,
+		estimateMessageTokens,
+	);
+	removeCandidatesByPredicate(
+		candidates,
+		(candidate) =>
+			candidate.message.role === "user" &&
+			candidate.isLastUser &&
+			!candidate.isFirstUser,
+		targetTokens,
+		estimateMessageTokens,
+	);
+
+	trimCandidatesToBudget(candidates, targetTokens, estimateMessageTokens);
 }
 
 function haveMessagesChanged(
@@ -472,9 +513,9 @@ function buildTailCandidates(
  * contract.
  *
  * On the prefix path the existing `removeCandidatesByPredicate`
- * is still used; its closures only group same-role candidates
- * (e.g. a non-last assistant with its non-last user tool_result),
- * so the two predicates collapse there and behavior is unchanged.
+ * is still used because a closure can only pull in user tool_result
+ * messages that are not typed turn starts. The tail has stronger
+ * preservation rules, so it needs this explicit closure check.
  */
 function removeTailCandidatesByPredicate<C extends MinimalCandidate>(
 	candidates: C[],
@@ -571,45 +612,6 @@ export function runBasicCompaction(options: {
 	);
 	const initialCandidates = candidates.map((candidate) => ({ ...candidate }));
 
-	removeCandidatesByPredicate(
-		candidates,
-		(candidate) =>
-			candidate.message.role === "assistant" && !candidate.isLastAssistant,
-		targetTokens,
-		options.estimateMessageTokens,
-	);
-	removeCandidatesByPredicate(
-		candidates,
-		(candidate) =>
-			candidate.message.role === "user" &&
-			!candidate.isFirstUser &&
-			!candidate.isLastUser,
-		targetTokens,
-		options.estimateMessageTokens,
-	);
-	removeCandidatesByPredicate(
-		candidates,
-		(candidate) =>
-			candidate.message.role === "assistant" && candidate.isLastAssistant,
-		targetTokens,
-		options.estimateMessageTokens,
-	);
-	removeCandidatesByPredicate(
-		candidates,
-		(candidate) =>
-			candidate.message.role === "user" &&
-			candidate.isLastUser &&
-			!candidate.isFirstUser,
-		targetTokens,
-		options.estimateMessageTokens,
-	);
-
-	trimCandidatesToBudget(
-		candidates,
-		targetTokens,
-		options.estimateMessageTokens,
-	);
-
 	// CLINE-2185: the protected tail (the in-flight turn after the user's
 	// latest typed prompt) can itself exceed the compaction target when
 	// the agent has produced many large tool results in a single turn.
@@ -627,6 +629,41 @@ export function runBasicCompaction(options: {
 		finalTail = trimProtectedTail(
 			protectedTail,
 			targetTokens,
+			options.estimateMessageTokens,
+		);
+	}
+	const finalTailTokens = getTotalTokens(
+		finalTail,
+		options.estimateMessageTokens,
+	);
+	const prefixTargetTokens = Math.max(1, targetTokens - finalTailTokens);
+	// The final transcript is prefix + protected tail. Budgeting each half
+	// independently can still return an over-target result, so compact the
+	// historical prefix against the remaining budget after tail preservation.
+	compactBasicCandidatesToBudget(
+		candidates,
+		prefixTargetTokens,
+		options.estimateMessageTokens,
+	);
+	for (let attempt = 0; attempt < 4; attempt += 1) {
+		const totalAfter = getTotalTokens(
+			[...candidates.map((candidate) => candidate.message), ...finalTail],
+			options.estimateMessageTokens,
+		);
+		if (totalAfter <= targetTokens || candidates.length === 0) {
+			break;
+		}
+		const prefixTokens = getTotalTokens(
+			candidates.map((candidate) => candidate.message),
+			options.estimateMessageTokens,
+		);
+		const adjustedPrefixTarget = Math.max(
+			1,
+			prefixTokens - (totalAfter - targetTokens) - 1,
+		);
+		compactBasicCandidatesToBudget(
+			candidates,
+			adjustedPrefixTarget,
 			options.estimateMessageTokens,
 		);
 	}

--- a/sdk/packages/core/src/extensions/context/basic-compaction.ts
+++ b/sdk/packages/core/src/extensions/context/basic-compaction.ts
@@ -259,6 +259,16 @@ function collectAtomicRemovalIndexes<C extends MinimalCandidate>(
 	return removalIndexes;
 }
 
+// Unlike removeTailCandidatesByPredicate, this function does NOT check
+// whether every member of an atomic closure satisfies the predicate before
+// removing. That is safe on the prefix path because the four successive
+// predicate calls are role-monotone: each call's predicate either accepts
+// ALL members of any possible closure (because closures only span
+// same-role candidates on the prefix) or accepts NONE. A tool_use in an
+// assistant message is always paired with a tool_result in a user message;
+// the first pass removes only assistant non-last messages and the second
+// removes only non-last-non-first user messages, so a closure can never
+// straddle a protected and an unprotected candidate on the prefix path.
 function removeCandidatesByPredicate<C extends MinimalCandidate>(
 	candidates: C[],
 	predicate: (candidate: C) => boolean,
@@ -367,10 +377,11 @@ function splitLatestTurn(messages: MessageWithMetadata[]): {
 	protectedTail: MessageWithMetadata[];
 } {
 	const lastTurnStartIndex = findLastTurnStartIndex(messages);
-	if (
-		lastTurnStartIndex < 0 ||
-		(lastTurnStartIndex === 0 && !isTurnStartMessage(messages[0]))
-	) {
+	// findLastTurnStartIndex returns 0 as its "not found" sentinel (never -1),
+	// so we detect the sentinel by checking whether messages[0] is actually a
+	// turn-start message. When it is not, there is no typed user prompt in
+	// history and we treat the entire array as compactable with no tail.
+	if (lastTurnStartIndex === 0 && !isTurnStartMessage(messages[0])) {
 		return { compactable: messages, protectedTail: [] };
 	}
 	return {

--- a/sdk/packages/core/src/extensions/context/compaction.test.ts
+++ b/sdk/packages/core/src/extensions/context/compaction.test.ts
@@ -34,6 +34,16 @@ function totalJsonTokens(messages: LlmsProviders.Message[]): number {
 	);
 }
 
+function totalEstimatedTokens(
+	messages: LlmsProviders.Message[],
+	estimateMessageTokens: (message: LlmsProviders.Message) => number,
+): number {
+	return messages.reduce(
+		(total, message) => total + estimateMessageTokens(message),
+		0,
+	);
+}
+
 function runForcedBasicCompaction(
 	messages: LlmsProviders.Message[],
 	targetTokens: number,
@@ -550,6 +560,49 @@ describe("createContextCompactionPrepareTurn", () => {
 		});
 		expect(compacted).not.toContainEqual(oldAssistant);
 		expect(JSON.stringify(compacted)).not.toContain("old assistant prefix");
+	});
+
+	it("budgets the historical prefix against the preserved tail during basic compaction", () => {
+		const messages: LlmsProviders.Message[] = [
+			{ role: "user", content: "Initial task " + "i".repeat(4_000) },
+			{ role: "user", content: "Latest request " + "u".repeat(200) },
+			{
+				role: "assistant",
+				content: "Latest assistant state " + "a".repeat(900),
+			},
+		];
+		const targetTokens = 520;
+		const estimateMessageTokens = createTokenEstimator();
+		const result = runBasicCompaction({
+			context: {
+				agentId: "agent-1",
+				conversationId: "conv-1",
+				parentAgentId: null,
+				iteration: 1,
+				messages,
+				model: {
+					id: "mock-model",
+					provider: "anthropic",
+					info: { id: "mock-model", maxInputTokens: targetTokens },
+				},
+				maxInputTokens: targetTokens,
+				triggerTokens: targetTokens,
+				thresholdRatio: 1,
+				utilizationRatio: 2,
+			},
+			estimateMessageTokens,
+		});
+
+		expect(result?.messages).toBeDefined();
+		const compacted = result?.messages ?? [];
+		expect(compacted.at(-2)).toEqual(messages[1]);
+		expect(compacted.at(-1)).toEqual(messages[2]);
+		const prefix = compacted[0];
+		expect(typeof prefix?.content).toBe("string");
+		expect((prefix?.content as string).length).toBeLessThan(1_200);
+		expect(totalEstimatedTokens(compacted, estimateMessageTokens)).toBeLessThan(
+			totalEstimatedTokens(messages, estimateMessageTokens),
+		);
 	});
 
 	it("does not add unsupported max output tokens to Codex OAuth summarizer requests", () => {

--- a/sdk/packages/core/src/runtime/orchestration/session-runtime-orchestrator.test.ts
+++ b/sdk/packages/core/src/runtime/orchestration/session-runtime-orchestrator.test.ts
@@ -523,6 +523,154 @@ describe("SessionRuntime message preparation", () => {
 		expect(textParts).toEqual(["original", "builder-added"]);
 	});
 
+	it("budgets API-safe messages against full model request overhead", async () => {
+		const { deps, configs } = makeRecordingRuntimeFactory();
+		const maxInputTokens = 10_000;
+		const session = new SessionRuntime(
+			makeAgentConfig({
+				knownModels: {
+					"claude-3-5-sonnet": {
+						id: "claude-3-5-sonnet",
+						maxInputTokens,
+					},
+				},
+			}),
+			deps,
+		);
+
+		await session.run("go");
+		const beforeModel = configs[0]?.hooks?.beforeModel;
+		expect(beforeModel).toBeDefined();
+
+		const request = {
+			systemPrompt: "system ".repeat(1_600),
+			messages: [
+				{
+					id: "m1",
+					role: "user" as const,
+					content: [
+						{
+							type: "text" as const,
+							text: "x".repeat(100_000),
+						},
+					],
+					createdAt: 1,
+				},
+			],
+			tools: [
+				{
+					name: "wide_tool",
+					description: "tool description ".repeat(350),
+					inputSchema: {
+						type: "object",
+						properties: {
+							body: {
+								type: "string",
+								description: "body description ".repeat(250),
+							},
+						},
+					},
+				},
+			],
+			options: { reasoningEffort: "high" },
+		};
+
+		const result = await beforeModel?.({
+			snapshot: makeSnapshot(),
+			request,
+		});
+
+		const fullRequestBytes = Buffer.byteLength(
+			JSON.stringify({
+				systemPrompt: request.systemPrompt,
+				messages: result?.messages,
+				tools: request.tools,
+				options: request.options,
+			}),
+			"utf8",
+		);
+		expect(fullRequestBytes).toBeLessThanOrEqual(maxInputTokens * 3);
+		const textPart = result?.messages?.[0]?.content[0];
+		expect(textPart?.type).toBe("text");
+		if (textPart?.type === "text") {
+			expect(textPart.text.length).toBeLessThan(100_000);
+		}
+	});
+
+	it("emits request-overhead telemetry when non-message payload alone exceeds the budget", async () => {
+		const { deps, configs } = makeRecordingRuntimeFactory();
+		const capture = vi.fn();
+		const telemetry = {
+			capture,
+			captureRequired: vi.fn(),
+			setDistinctId: vi.fn(),
+			setMetadata: vi.fn(),
+			updateMetadata: vi.fn(),
+			setCommonProperties: vi.fn(),
+			updateCommonProperties: vi.fn(),
+			isEnabled: () => true,
+			recordCounter: vi.fn(),
+			recordHistogram: vi.fn(),
+			recordGauge: vi.fn(),
+			flush: vi.fn(async () => {}),
+			dispose: vi.fn(async () => {}),
+		};
+		const session = new SessionRuntime(
+			makeAgentConfig({
+				knownModels: {
+					"claude-3-5-sonnet": {
+						id: "claude-3-5-sonnet",
+						maxInputTokens: 1_000,
+					},
+				},
+			}),
+			{ ...deps, telemetry: telemetry as never },
+		);
+		const notices: AgentEvent[] = [];
+		session.subscribeEvents((event) => {
+			notices.push(event);
+		});
+
+		await session.run("go");
+		const beforeModel = configs[0]?.hooks?.beforeModel;
+		const result = await beforeModel?.({
+			snapshot: makeSnapshot(),
+			request: {
+				systemPrompt: "s".repeat(10_000),
+				messages: [
+					{
+						id: "m1",
+						role: "user",
+						content: [{ type: "text", text: "x".repeat(10_000) }],
+						createdAt: 1,
+					},
+				],
+				tools: [],
+			},
+		});
+
+		expect(result?.messages).toEqual([]);
+		expect(capture).toHaveBeenCalledWith(
+			expect.objectContaining({
+				event: "task.request_overhead_exceeds_budget",
+				properties: expect.objectContaining({
+					requestBytes: expect.any(Number),
+					budgetBytes: 3_000,
+					maxInputTokens: 1_000,
+					systemPromptBytes: 10_000,
+					toolsBytes: expect.any(Number),
+					optionsBytes: expect.any(Number),
+				}),
+			}),
+		);
+		const requestSizeNotices = notices.filter(
+			(event) =>
+				event.type === "notice" &&
+				event.message === "request size exceeds model context window",
+		);
+		expect(requestSizeNotices).toHaveLength(1);
+	});
+
 	it("adapts prepareTurn with API-safe messages for runtime compaction", async () => {
 		const prepareTurn = vi.fn(() => ({
 			messages: [

--- a/sdk/packages/core/src/runtime/orchestration/session-runtime-orchestrator.test.ts
+++ b/sdk/packages/core/src/runtime/orchestration/session-runtime-orchestrator.test.ts
@@ -597,6 +597,106 @@ describe("SessionRuntime message preparation", () => {
 		}
 	});
 
+	it("does not emit stale emergency truncation telemetry from a failed retry attempt", async () => {
+		const { deps, configs } = makeRecordingRuntimeFactory();
+		const capture = vi.fn();
+		const telemetry = {
+			capture,
+			captureRequired: vi.fn(),
+			setDistinctId: vi.fn(),
+			setMetadata: vi.fn(),
+			updateMetadata: vi.fn(),
+			setCommonProperties: vi.fn(),
+			updateCommonProperties: vi.fn(),
+			isEnabled: () => true,
+			recordCounter: vi.fn(),
+			recordHistogram: vi.fn(),
+			recordGauge: vi.fn(),
+			flush: vi.fn(async () => {}),
+			dispose: vi.fn(async () => {}),
+		};
+		const session = new SessionRuntime(
+			makeAgentConfig({
+				knownModels: {
+					"claude-3-5-sonnet": {
+						id: "claude-3-5-sonnet",
+						maxInputTokens: 1_000,
+					},
+				},
+			}),
+			{ ...deps, telemetry: telemetry as never },
+		);
+		const notices: AgentEvent[] = [];
+		session.subscribeEvents((event) => {
+			notices.push(event);
+		});
+
+		await session.run("go");
+		// Deliberately replace the private builder here: this regression targets
+		// the orchestrator retry buffer, independent of MessageBuilder internals.
+		const buildForApi = vi
+			.fn()
+			.mockImplementationOnce((_messages, options) => {
+				options.emitStatusNotice?.("compacted to fit context window", {
+					kind: "emergency_truncation",
+				});
+				options.telemetry?.capture({
+					event: "task.emergency_truncation",
+					properties: { bytesBefore: 10_000 },
+				});
+				return [
+					{
+						role: "user",
+						content: [{ type: "text", text: "x".repeat(10_000) }],
+					},
+				];
+			})
+			.mockImplementationOnce(() => [
+				{
+					role: "user",
+					content: [{ type: "text", text: "ok" }],
+				},
+			]);
+		(
+			session as unknown as {
+				messageBuilder: { buildForApi: typeof buildForApi };
+			}
+		).messageBuilder.buildForApi = buildForApi;
+
+		const beforeModel = configs[0]?.hooks?.beforeModel;
+		const result = await beforeModel?.({
+			snapshot: makeSnapshot(),
+			request: {
+				systemPrompt: "system",
+				messages: [
+					{
+						id: "m1",
+						role: "user",
+						content: [{ type: "text", text: "original" }],
+						createdAt: 1,
+					},
+				],
+				tools: [],
+			},
+		});
+
+		expect(buildForApi).toHaveBeenCalledTimes(2);
+		expect(result?.messages?.[0]?.content[0]).toMatchObject({
+			type: "text",
+			text: "ok",
+		});
+		expect(capture).not.toHaveBeenCalledWith(
+			expect.objectContaining({ event: "task.emergency_truncation" }),
+		);
+		expect(
+			notices.filter(
+				(event) =>
+					event.type === "notice" &&
+					event.message === "compacted to fit context window",
+			),
+		).toHaveLength(0);
+	});
+
 	it("emits request-overhead telemetry when non-message payload alone exceeds the budget", async () => {
 		const { deps, configs } = makeRecordingRuntimeFactory();
 		const capture = vi.fn();

--- a/sdk/packages/core/src/runtime/orchestration/session-runtime-orchestrator.ts
+++ b/sdk/packages/core/src/runtime/orchestration/session-runtime-orchestrator.ts
@@ -880,9 +880,41 @@ export class SessionRuntime {
 					return control;
 				}
 				const messages = control?.messages ?? ctx.request.messages;
+				// Build the same full options that createRuntimePrepareTurn
+				// uses so Layer B observability (status notice + telemetry)
+				// fires on the main hot path, not only when the SDK consumer
+				// supplies a prepareTurn callback.
+				const buildForApiOptions: Parameters<
+					typeof this.messageBuilder.buildForApi
+				>[1] = {
+					maxInputTokens: modelInfo?.maxInputTokens,
+					emitStatusNotice: (message, metadata) => {
+						this.emitLegacyEvent({
+							type: "notice",
+							noticeType: "status",
+							displayRole: "status",
+							message,
+							metadata,
+							agentId: ctx.snapshot.agentId,
+							conversationId: ctx.snapshot.conversationId ?? undefined,
+							parentAgentId: ctx.snapshot.parentAgentId ?? undefined,
+						});
+					},
+					telemetry: this.telemetry,
+					sessionId: this.config.sessionId,
+					provider: this.config.providerId,
+					modelId: this.config.modelId,
+					agentIdentity: {
+						agentId: ctx.snapshot.agentId,
+						conversationId:
+							ctx.snapshot.conversationId ??
+							this.conversation.getConversationId(),
+						parentAgentId: ctx.snapshot.parentAgentId ?? undefined,
+					},
+				};
 				const preparedMessages = await this.prepareMessagesForModelRequest(
 					messages,
-					modelInfo?.maxInputTokens,
+					buildForApiOptions,
 				);
 				return {
 					...control,
@@ -965,11 +997,11 @@ export class SessionRuntime {
 
 	private async prepareMessagesForModelRequest(
 		messages: readonly AgentMessage[],
-		maxInputTokens?: number,
+		options: Parameters<typeof this.messageBuilder.buildForApi>[1] = {},
 	): Promise<AgentMessage[]> {
 		const providerMessages = await this.prepareProviderMessagesForApi(
 			agentMessagesToMessages(messages),
-			{ maxInputTokens },
+			options,
 		);
 		return messagesToAgentMessages(providerMessages);
 	}

--- a/sdk/packages/core/src/runtime/orchestration/session-runtime-orchestrator.ts
+++ b/sdk/packages/core/src/runtime/orchestration/session-runtime-orchestrator.ts
@@ -1148,6 +1148,10 @@ export class SessionRuntime {
 		// monotonically non-increasing as the message payload shrinks. The third
 		// attempt is a guard for unexpected formatter drift.
 		for (let attempt = 0; attempt < REQUEST_BUDGET_MAX_ATTEMPTS; attempt += 1) {
+			// Keep only the final attempt's signal; a clean retry must not flush
+			// stale emergency-truncation telemetry from an earlier failed attempt.
+			bufferedNotice = undefined;
+			bufferedTelemetry = undefined;
 			apiMessages = this.messageBuilder.buildForApi(providerMessages, {
 				...bufferingOptions,
 				requestOverheadBytes,

--- a/sdk/packages/core/src/runtime/orchestration/session-runtime-orchestrator.ts
+++ b/sdk/packages/core/src/runtime/orchestration/session-runtime-orchestrator.ts
@@ -911,9 +911,25 @@ export class SessionRuntime {
 
 		return async (context) => {
 			const messages = agentMessagesToMessagesWithMetadata(context.messages);
+			const buildForApiOptions: Parameters<
+				typeof this.messageBuilder.buildForApi
+			>[1] = {
+				maxInputTokens: modelInfo?.maxInputTokens,
+				emitStatusNotice: context.emitStatusNotice,
+				telemetry: this.telemetry,
+				sessionId: this.config.sessionId,
+				provider: this.config.providerId,
+				modelId: this.config.modelId,
+				agentIdentity: {
+					agentId: context.agentId,
+					conversationId:
+						context.conversationId ?? this.conversation.getConversationId(),
+					parentAgentId: context.parentAgentId ?? undefined,
+				},
+			};
 			const apiMessages = await this.prepareProviderMessagesForApi(
 				messages,
-				modelInfo?.maxInputTokens,
+				buildForApiOptions,
 			);
 			const result = await prepareTurn({
 				agentId: context.agentId,
@@ -953,14 +969,14 @@ export class SessionRuntime {
 	): Promise<AgentMessage[]> {
 		const providerMessages = await this.prepareProviderMessagesForApi(
 			agentMessagesToMessages(messages),
-			maxInputTokens,
+			{ maxInputTokens },
 		);
 		return messagesToAgentMessages(providerMessages);
 	}
 
 	private async prepareProviderMessagesForApi(
 		messages: MessageWithMetadata[],
-		maxInputTokens?: number,
+		options: Parameters<typeof this.messageBuilder.buildForApi>[1] = {},
 	): Promise<MessageWithMetadata[]> {
 		let providerMessages = messages;
 		const messageBuilders =
@@ -968,9 +984,7 @@ export class SessionRuntime {
 		for (const builder of messageBuilders) {
 			providerMessages = await builder.build(providerMessages);
 		}
-		return this.messageBuilder.buildForApi(providerMessages, {
-			maxInputTokens,
-		});
+		return this.messageBuilder.buildForApi(providerMessages, options);
 	}
 
 	private handleRuntimeEvent(event: AgentRuntimeEvent): void {

--- a/sdk/packages/core/src/runtime/orchestration/session-runtime-orchestrator.ts
+++ b/sdk/packages/core/src/runtime/orchestration/session-runtime-orchestrator.ts
@@ -29,6 +29,7 @@ import {
 	type AgentExtensionRule,
 	type AgentFinishReason,
 	type AgentMessage,
+	type AgentModelRequest,
 	type AgentResult,
 	type AgentRunResult,
 	type AgentRuntimeEvent,
@@ -50,7 +51,11 @@ import {
 	createAgentModelFromConfig,
 	resolveKnownModelsFromConfig,
 } from "../../services/llms/handler-factory";
-import { MessageBuilder } from "../../session/services/message-builder";
+import { captureRequestOverheadExceedsBudget } from "../../services/telemetry/core-events";
+import {
+	MESSAGE_BUILDER_CHARS_PER_TOKEN,
+	MessageBuilder,
+} from "../../session/services/message-builder";
 import { ConversationStore } from "../../session/stores/conversation-store";
 import {
 	agentMessagesToMessages,
@@ -73,6 +78,57 @@ function formatToolResultError(output: unknown): string {
 		return JSON.stringify(output);
 	} catch {
 		return String(output);
+	}
+}
+
+const REQUEST_BUDGET_SAFETY_MARGIN_BYTES = 256;
+const REQUEST_BUDGET_MAX_ATTEMPTS = 3;
+type MessageBuilderOptions = NonNullable<
+	Parameters<MessageBuilder["buildForApi"]>[1]
+>;
+type RequestBudgetContext = Pick<
+	AgentModelRequest,
+	"systemPrompt" | "tools" | "options"
+>;
+
+function utf8ByteLength(text: string): number {
+	return Buffer.byteLength(text, "utf8");
+}
+
+function countModelRequestBytes(
+	request: Pick<
+		AgentModelRequest,
+		"systemPrompt" | "messages" | "tools" | "options"
+	>,
+): number {
+	try {
+		return utf8ByteLength(
+			JSON.stringify({
+				systemPrompt: request.systemPrompt,
+				messages: request.messages,
+				tools: request.tools,
+				options: request.options,
+			}),
+		);
+	} catch {
+		return Number.POSITIVE_INFINITY;
+	}
+}
+
+function countProviderMessageBytes(messages: MessageWithMetadata[]): number {
+	try {
+		return utf8ByteLength(JSON.stringify(messages));
+	} catch {
+		return Number.POSITIVE_INFINITY;
+	}
+}
+
+function countJsonBytes(value: unknown): number {
+	try {
+		const serialized = JSON.stringify(value);
+		return typeof serialized === "string" ? utf8ByteLength(serialized) : 0;
+	} catch {
+		return Number.POSITIVE_INFINITY;
 	}
 }
 
@@ -880,13 +936,15 @@ export class SessionRuntime {
 					return control;
 				}
 				const messages = control?.messages ?? ctx.request.messages;
+				const tools = control?.tools ?? ctx.request.tools;
+				const options = control?.options
+					? { ...(ctx.request.options ?? {}), ...control.options }
+					: ctx.request.options;
 				// Build the same full options that createRuntimePrepareTurn
 				// uses so Layer B observability (status notice + telemetry)
 				// fires on the main hot path, not only when the SDK consumer
 				// supplies a prepareTurn callback.
-				const buildForApiOptions: Parameters<
-					typeof this.messageBuilder.buildForApi
-				>[1] = {
+				const buildForApiOptions: MessageBuilderOptions = {
 					maxInputTokens: modelInfo?.maxInputTokens,
 					emitStatusNotice: (message, metadata) => {
 						this.emitLegacyEvent({
@@ -915,6 +973,11 @@ export class SessionRuntime {
 				const preparedMessages = await this.prepareMessagesForModelRequest(
 					messages,
 					buildForApiOptions,
+					{
+						systemPrompt: ctx.request.systemPrompt,
+						tools,
+						options,
+					},
 				);
 				return {
 					...control,
@@ -943,10 +1006,14 @@ export class SessionRuntime {
 
 		return async (context) => {
 			const messages = agentMessagesToMessagesWithMetadata(context.messages);
-			const buildForApiOptions: Parameters<
-				typeof this.messageBuilder.buildForApi
-			>[1] = {
+			const buildForApiOptions: MessageBuilderOptions = {
 				maxInputTokens: modelInfo?.maxInputTokens,
+				requestOverheadBytes: countModelRequestBytes({
+					systemPrompt: context.systemPrompt,
+					messages: [],
+					tools: context.tools,
+					options: undefined,
+				}),
 				emitStatusNotice: context.emitStatusNotice,
 				telemetry: this.telemetry,
 				sessionId: this.config.sessionId,
@@ -959,9 +1026,16 @@ export class SessionRuntime {
 					parentAgentId: context.parentAgentId ?? undefined,
 				},
 			};
-			const apiMessages = await this.prepareProviderMessagesForApi(
-				messages,
+			const providerMessages =
+				await this.applyRegisteredMessageBuilders(messages);
+			const apiMessages = this.buildApiMessagesForRequestBudget(
+				providerMessages,
 				buildForApiOptions,
+				{
+					systemPrompt: context.systemPrompt,
+					tools: context.tools,
+					options: undefined,
+				},
 			);
 			const result = await prepareTurn({
 				agentId: context.agentId,
@@ -997,18 +1071,140 @@ export class SessionRuntime {
 
 	private async prepareMessagesForModelRequest(
 		messages: readonly AgentMessage[],
-		options: Parameters<typeof this.messageBuilder.buildForApi>[1] = {},
+		options: MessageBuilderOptions = {},
+		requestBudgetContext?: RequestBudgetContext,
 	): Promise<AgentMessage[]> {
-		const providerMessages = await this.prepareProviderMessagesForApi(
+		const providerMessages = await this.applyRegisteredMessageBuilders(
 			agentMessagesToMessages(messages),
-			options,
 		);
-		return messagesToAgentMessages(providerMessages);
+		return messagesToAgentMessages(
+			this.buildApiMessagesForRequestBudget(
+				providerMessages,
+				options,
+				requestBudgetContext,
+			),
+		);
 	}
 
-	private async prepareProviderMessagesForApi(
+	private buildApiMessagesForRequestBudget(
+		providerMessages: MessageWithMetadata[],
+		options: MessageBuilderOptions,
+		requestBudgetContext: RequestBudgetContext | undefined,
+	): MessageWithMetadata[] {
+		if (
+			requestBudgetContext === undefined ||
+			typeof options.maxInputTokens !== "number" ||
+			!Number.isFinite(options.maxInputTokens) ||
+			options.maxInputTokens <= 0
+		) {
+			return this.messageBuilder.buildForApi(providerMessages, options);
+		}
+
+		const maxRequestBytes =
+			options.maxInputTokens * MESSAGE_BUILDER_CHARS_PER_TOKEN;
+		let requestOverheadBytes = Math.max(
+			0,
+			options.requestOverheadBytes ??
+				countModelRequestBytes({
+					...requestBudgetContext,
+					messages: [],
+				}),
+		);
+		let bufferedNotice:
+			| { message: string; metadata?: Record<string, unknown> }
+			| undefined;
+		let bufferedTelemetry:
+			| Parameters<NonNullable<ITelemetryService>["capture"]>[0]
+			| undefined;
+		const bufferingOptions: MessageBuilderOptions = {
+			...options,
+			emitStatusNotice: (message, metadata) => {
+				bufferedNotice = { message, metadata };
+			},
+			telemetry: options.telemetry
+				? ({
+						capture: (
+							input: Parameters<NonNullable<ITelemetryService>["capture"]>[0],
+						) => {
+							bufferedTelemetry = input;
+						},
+						captureRequired: () => {},
+					} as unknown as ITelemetryService)
+				: undefined,
+		};
+		const flushBufferedEmergencyTruncation = () => {
+			if (bufferedNotice) {
+				options.emitStatusNotice?.(
+					bufferedNotice.message,
+					bufferedNotice.metadata,
+				);
+			}
+			if (bufferedTelemetry) {
+				options.telemetry?.capture(bufferedTelemetry);
+			}
+		};
+		let apiMessages: MessageWithMetadata[] = providerMessages;
+		// Two attempts are sufficient because measured codec/framing delta is
+		// monotonically non-increasing as the message payload shrinks. The third
+		// attempt is a guard for unexpected formatter drift.
+		for (let attempt = 0; attempt < REQUEST_BUDGET_MAX_ATTEMPTS; attempt += 1) {
+			apiMessages = this.messageBuilder.buildForApi(providerMessages, {
+				...bufferingOptions,
+				requestOverheadBytes,
+			});
+			const agentMessages = messagesToAgentMessages(apiMessages);
+			const requestBytes = countModelRequestBytes({
+				...requestBudgetContext,
+				messages: agentMessages,
+			});
+			if (requestBytes <= maxRequestBytes) {
+				flushBufferedEmergencyTruncation();
+				return apiMessages;
+			}
+			const messageBytes = countProviderMessageBytes(apiMessages);
+			if (!Number.isFinite(messageBytes)) {
+				break;
+			}
+			requestOverheadBytes = Math.max(
+				0,
+				requestBytes - messageBytes + REQUEST_BUDGET_SAFETY_MARGIN_BYTES,
+			);
+		}
+
+		const requestBytes = countModelRequestBytes({
+			...requestBudgetContext,
+			messages: messagesToAgentMessages(apiMessages),
+		});
+		flushBufferedEmergencyTruncation();
+		if (requestBytes > maxRequestBytes) {
+			options.emitStatusNotice?.("request size exceeds model context window", {
+				kind: "request_overhead_exceeds_budget",
+				maxInputTokens: options.maxInputTokens,
+				requestBytes,
+				budgetBytes: maxRequestBytes,
+			});
+			captureRequestOverheadExceedsBudget(options.telemetry, {
+				ulid: options.sessionId ?? options.agentIdentity?.conversationId ?? "",
+				requestBytes,
+				budgetBytes: maxRequestBytes,
+				maxInputTokens: options.maxInputTokens,
+				systemPromptBytes:
+					typeof requestBudgetContext.systemPrompt === "string"
+						? utf8ByteLength(requestBudgetContext.systemPrompt)
+						: 0,
+				toolsBytes: countJsonBytes(requestBudgetContext.tools),
+				optionsBytes: countJsonBytes(requestBudgetContext.options),
+				provider: options.provider,
+				modelId: options.modelId,
+				...options.agentIdentity,
+			});
+		}
+
+		return apiMessages;
+	}
+
+	private async applyRegisteredMessageBuilders(
 		messages: MessageWithMetadata[],
-		options: Parameters<typeof this.messageBuilder.buildForApi>[1] = {},
 	): Promise<MessageWithMetadata[]> {
 		let providerMessages = messages;
 		const messageBuilders =
@@ -1016,7 +1212,7 @@ export class SessionRuntime {
 		for (const builder of messageBuilders) {
 			providerMessages = await builder.build(providerMessages);
 		}
-		return this.messageBuilder.buildForApi(providerMessages, options);
+		return providerMessages;
 	}
 
 	private handleRuntimeEvent(event: AgentRuntimeEvent): void {

--- a/sdk/packages/core/src/services/telemetry/core-events.test.ts
+++ b/sdk/packages/core/src/services/telemetry/core-events.test.ts
@@ -549,6 +549,24 @@ describe("telemetry policy: helpers respect telemetry opt-out", () => {
 		expect(emitRequired).not.toHaveBeenCalled();
 	});
 
+	test("captureRequestOverheadExceedsBudget never invokes captureRequired", () => {
+		const { adapter, emitRequired } = createDisabledAdapter();
+		const service = new TelemetryService({
+			distinctId: "test-distinct-id",
+			adapters: [adapter],
+		});
+		captureRequestOverheadExceedsBudget(service, {
+			ulid: "ulid-1",
+			requestBytes: 80_000,
+			budgetBytes: 60_000,
+			maxInputTokens: 20_000,
+			systemPromptBytes: 50_000,
+			toolsBytes: 25_000,
+			optionsBytes: 500,
+		});
+		expect(emitRequired).not.toHaveBeenCalled();
+	});
+
 	test("a correctly-policed adapter drops these events when disabled", () => {
 		// This test layers on top of the previous four to assert the *full*
 		// end-to-end policy: when the adapter is disabled, a real adapter
@@ -627,6 +645,15 @@ describe("telemetry policy: helpers respect telemetry opt-out", () => {
 			truncatedBlocks: 4,
 			droppedBlocks: 1,
 		});
+		captureRequestOverheadExceedsBudget(service, {
+			ulid: "ulid-1",
+			requestBytes: 80_000,
+			budgetBytes: 60_000,
+			maxInputTokens: 20_000,
+			systemPromptBytes: 50_000,
+			toolsBytes: 25_000,
+			optionsBytes: 500,
+		});
 		expect(observed).toEqual([]);
 		expect(dropped).toEqual([
 			"user.extension_activated",
@@ -636,6 +663,7 @@ describe("telemetry policy: helpers respect telemetry opt-out", () => {
 			"task.compaction_executed",
 			"task.compaction_skipped",
 			"task.emergency_truncation",
+			"task.request_overhead_exceeds_budget",
 		]);
 	});
 });

--- a/sdk/packages/core/src/services/telemetry/core-events.test.ts
+++ b/sdk/packages/core/src/services/telemetry/core-events.test.ts
@@ -4,6 +4,7 @@ import {
 	CORE_TELEMETRY_EVENTS,
 	captureCompactionExecuted,
 	captureCompactionSkipped,
+	captureEmergencyTruncation,
 	captureExtensionActivated,
 	captureRequestOverheadExceedsBudget,
 	captureTelemetryOptOut,
@@ -316,6 +317,39 @@ describe("captureCompactionSkipped", () => {
 	});
 });
 
+describe("captureEmergencyTruncation", () => {
+	const baseProps = {
+		ulid: "ulid-1",
+		bytesBefore: 120_000,
+		bytesAfter: 55_000,
+		maxInputTokens: 20_000,
+		truncatedBlocks: 4,
+		droppedBlocks: 1,
+		provider: "anthropic",
+		modelId: "claude-sonnet-4",
+	};
+
+	test("emits task.emergency_truncation with all properties and a timestamp", () => {
+		const stub = createTelemetryStub();
+		captureEmergencyTruncation(stub.telemetry, baseProps);
+		expect(stub.capture).toHaveBeenCalledTimes(1);
+		expect(stub.captureRequired).not.toHaveBeenCalled();
+		const { event, properties } = captureCallAt(stub, 0);
+		expect(event).toBe(CORE_TELEMETRY_EVENTS.TASK.EMERGENCY_TRUNCATION);
+		expect(event).toBe("task.emergency_truncation");
+		expect(properties).toMatchObject(baseProps);
+		expect(typeof (properties as Record<string, unknown>).timestamp).toBe(
+			"string",
+		);
+	});
+
+	test("no-ops when telemetry is undefined", () => {
+		expect(() =>
+			captureEmergencyTruncation(undefined, baseProps),
+		).not.toThrow();
+	});
+});
+
 describe("captureRequestOverheadExceedsBudget", () => {
 	const baseProps = {
 		ulid: "ulid-1",
@@ -498,6 +532,23 @@ describe("telemetry policy: helpers respect telemetry opt-out", () => {
 		expect(emitRequired).not.toHaveBeenCalled();
 	});
 
+	test("captureEmergencyTruncation never invokes captureRequired", () => {
+		const { adapter, emitRequired } = createDisabledAdapter();
+		const service = new TelemetryService({
+			distinctId: "test-distinct-id",
+			adapters: [adapter],
+		});
+		captureEmergencyTruncation(service, {
+			ulid: "ulid-1",
+			bytesBefore: 120_000,
+			bytesAfter: 55_000,
+			maxInputTokens: 20_000,
+			truncatedBlocks: 4,
+			droppedBlocks: 1,
+		});
+		expect(emitRequired).not.toHaveBeenCalled();
+	});
+
 	test("a correctly-policed adapter drops these events when disabled", () => {
 		// This test layers on top of the previous four to assert the *full*
 		// end-to-end policy: when the adapter is disabled, a real adapter
@@ -568,6 +619,14 @@ describe("telemetry policy: helpers respect telemetry opt-out", () => {
 			thresholdRatio: 0.9,
 			durationMs: 17,
 		});
+		captureEmergencyTruncation(service, {
+			ulid: "ulid-1",
+			bytesBefore: 120_000,
+			bytesAfter: 55_000,
+			maxInputTokens: 20_000,
+			truncatedBlocks: 4,
+			droppedBlocks: 1,
+		});
 		expect(observed).toEqual([]);
 		expect(dropped).toEqual([
 			"user.extension_activated",
@@ -576,6 +635,7 @@ describe("telemetry policy: helpers respect telemetry opt-out", () => {
 			"workspace.path_resolved",
 			"task.compaction_executed",
 			"task.compaction_skipped",
+			"task.emergency_truncation",
 		]);
 	});
 });

--- a/sdk/packages/core/src/services/telemetry/core-events.test.ts
+++ b/sdk/packages/core/src/services/telemetry/core-events.test.ts
@@ -5,6 +5,7 @@ import {
 	captureCompactionExecuted,
 	captureCompactionSkipped,
 	captureExtensionActivated,
+	captureRequestOverheadExceedsBudget,
 	captureTelemetryOptOut,
 	captureWorkspaceInitError,
 	captureWorkspaceInitialized,
@@ -312,6 +313,42 @@ describe("captureCompactionSkipped", () => {
 
 	test("no-ops when telemetry is undefined", () => {
 		expect(() => captureCompactionSkipped(undefined, baseProps)).not.toThrow();
+	});
+});
+
+describe("captureRequestOverheadExceedsBudget", () => {
+	const baseProps = {
+		ulid: "ulid-1",
+		requestBytes: 80_000,
+		budgetBytes: 60_000,
+		maxInputTokens: 20_000,
+		systemPromptBytes: 50_000,
+		toolsBytes: 25_000,
+		optionsBytes: 500,
+		provider: "anthropic",
+		modelId: "claude-sonnet-4",
+	};
+
+	test("emits task.request_overhead_exceeds_budget with all properties and a timestamp", () => {
+		const stub = createTelemetryStub();
+		captureRequestOverheadExceedsBudget(stub.telemetry, baseProps);
+		expect(stub.capture).toHaveBeenCalledTimes(1);
+		expect(stub.captureRequired).not.toHaveBeenCalled();
+		const { event, properties } = captureCallAt(stub, 0);
+		expect(event).toBe(
+			CORE_TELEMETRY_EVENTS.TASK.REQUEST_OVERHEAD_EXCEEDS_BUDGET,
+		);
+		expect(event).toBe("task.request_overhead_exceeds_budget");
+		expect(properties).toMatchObject(baseProps);
+		expect(typeof (properties as Record<string, unknown>).timestamp).toBe(
+			"string",
+		);
+	});
+
+	test("no-ops when telemetry is undefined", () => {
+		expect(() =>
+			captureRequestOverheadExceedsBudget(undefined, baseProps),
+		).not.toThrow();
 	});
 });
 

--- a/sdk/packages/core/src/services/telemetry/core-events.ts
+++ b/sdk/packages/core/src/services/telemetry/core-events.ts
@@ -61,6 +61,7 @@ export const CORE_TELEMETRY_EVENTS = {
 		COMPACTION_EXECUTED: "task.compaction_executed",
 		COMPACTION_SKIPPED: "task.compaction_skipped",
 		EMERGENCY_TRUNCATION: "task.emergency_truncation",
+		REQUEST_OVERHEAD_EXCEEDS_BUDGET: "task.request_overhead_exceeds_budget",
 	},
 	HOOKS: {
 		DISCOVERY_COMPLETED: "hooks.discovery_completed",
@@ -653,6 +654,29 @@ export function captureEmergencyTruncation(
 		Partial<TelemetryAgentIdentityProperties>,
 ): void {
 	emit(telemetry, CORE_TELEMETRY_EVENTS.TASK.EMERGENCY_TRUNCATION, {
+		...properties,
+		timestamp: new Date().toISOString(),
+	});
+}
+
+export interface CaptureRequestOverheadExceedsBudgetProperties {
+	ulid: string;
+	requestBytes: number;
+	budgetBytes: number;
+	maxInputTokens: number;
+	systemPromptBytes: number;
+	toolsBytes: number;
+	optionsBytes: number;
+	provider?: string;
+	modelId?: string;
+}
+
+export function captureRequestOverheadExceedsBudget(
+	telemetry: ITelemetryService | undefined,
+	properties: CaptureRequestOverheadExceedsBudgetProperties &
+		Partial<TelemetryAgentIdentityProperties>,
+): void {
+	emit(telemetry, CORE_TELEMETRY_EVENTS.TASK.REQUEST_OVERHEAD_EXCEEDS_BUDGET, {
 		...properties,
 		timestamp: new Date().toISOString(),
 	});

--- a/sdk/packages/core/src/services/telemetry/core-events.ts
+++ b/sdk/packages/core/src/services/telemetry/core-events.ts
@@ -60,6 +60,7 @@ export const CORE_TELEMETRY_EVENTS = {
 		SUBAGENT_COMPLETED: "task.subagent_completed",
 		COMPACTION_EXECUTED: "task.compaction_executed",
 		COMPACTION_SKIPPED: "task.compaction_skipped",
+		EMERGENCY_TRUNCATION: "task.emergency_truncation",
 	},
 	HOOKS: {
 		DISCOVERY_COMPLETED: "hooks.discovery_completed",
@@ -617,6 +618,41 @@ export function captureCompactionSkipped(
 		Partial<TelemetryAgentIdentityProperties>,
 ): void {
 	emit(telemetry, CORE_TELEMETRY_EVENTS.TASK.COMPACTION_SKIPPED, {
+		...properties,
+		timestamp: new Date().toISOString(),
+	});
+}
+
+/**
+ * CLINE-2192 Layer B: emitted when `MessageBuilder.buildForApi` had to
+ * apply emergency truncation to force the outbound request below
+ * `maxInputTokens * CHARS_PER_TOKEN` bytes. This fires only when
+ * Layer A's largest-first heuristic was insufficient (adversarial
+ * inputs, oversized tool_use.input bodies, exotic block layouts).
+ *
+ * Treat any occurrence as a signal that production is operating in
+ * degraded mode — the model is seeing truncated content and the
+ * agent may produce wrong output as a result. The user-visible
+ * `emitStatusNotice("compacted to fit context window", ...)` fires
+ * alongside this event so the operator sees it in the TUI/webview.
+ */
+export interface CaptureEmergencyTruncationProperties {
+	ulid: string;
+	bytesBefore: number;
+	bytesAfter: number;
+	maxInputTokens: number;
+	truncatedBlocks: number;
+	droppedBlocks: number;
+	provider?: string;
+	modelId?: string;
+}
+
+export function captureEmergencyTruncation(
+	telemetry: ITelemetryService | undefined,
+	properties: CaptureEmergencyTruncationProperties &
+		Partial<TelemetryAgentIdentityProperties>,
+): void {
+	emit(telemetry, CORE_TELEMETRY_EVENTS.TASK.EMERGENCY_TRUNCATION, {
 		...properties,
 		timestamp: new Date().toISOString(),
 	});

--- a/sdk/packages/core/src/session/services/message-builder.test.ts
+++ b/sdk/packages/core/src/session/services/message-builder.test.ts
@@ -783,6 +783,60 @@ describe("MessageBuilder", () => {
 		);
 	});
 
+	it("reserves request overhead when enforcing the hard byte budget (CLINE-2192)", () => {
+		const builder = new MessageBuilder();
+		const messages: Message[] = [
+			{
+				role: "user",
+				content: [{ type: "text", text: "x".repeat(100_000) }],
+			},
+		];
+		const maxInputTokens = 10_000;
+		const requestOverheadBytes = 20_000;
+
+		const result = builder.buildForApi(messages, {
+			maxInputTokens,
+			requestOverheadBytes,
+		});
+
+		expect(
+			Buffer.byteLength(JSON.stringify(result), "utf8") + requestOverheadBytes,
+		).toBeLessThanOrEqual(maxInputTokens * 3);
+	});
+
+	it("is idempotent for repeated calls with identical input and budget options (CLINE-2192)", () => {
+		const builder = new MessageBuilder();
+		const messages: Message[] = [
+			{
+				role: "assistant",
+				content: [
+					{
+						type: "tool_use",
+						id: "tool_1",
+						name: "editor",
+						input: {
+							body: "x".repeat(120_000),
+							notes: ["a".repeat(20_000), "b".repeat(20_000)],
+						},
+					},
+				],
+			},
+			{
+				role: "user",
+				content: Array.from({ length: 30 }, (_, index) => ({
+					type: "text" as const,
+					text: `${index}:` + "y".repeat(1_000),
+				})),
+			},
+		];
+		const options = { maxInputTokens: 5_000, requestOverheadBytes: 10_000 };
+
+		const first = builder.buildForApi(messages, options);
+		const second = builder.buildForApi(messages, options);
+
+		expect(second).toEqual(first);
+	});
+
 	it("enforces the hard byte budget when Layer A's floor would otherwise keep too many small blocks (CLINE-2192)", () => {
 		const builder = new MessageBuilder();
 		const content = Array.from({ length: 200 }, (_, i) => ({

--- a/sdk/packages/core/src/session/services/message-builder.test.ts
+++ b/sdk/packages/core/src/session/services/message-builder.test.ts
@@ -939,6 +939,71 @@ describe("MessageBuilder", () => {
 		).toBeLessThanOrEqual(3_000);
 	});
 
+	it("preserves thinking content and signature during Layer B string truncation (CLINE-2192)", () => {
+		const thinkingText = "reasoning".repeat(2_000);
+		const builder = new MessageBuilder();
+		const messages: Message[] = [
+			{
+				role: "assistant",
+				content: [
+					{
+						type: "thinking",
+						thinking: thinkingText,
+						signature: "sig-1",
+					},
+					{
+						type: "text",
+						text: "x".repeat(500_000),
+					},
+				],
+			},
+		];
+
+		const result = builder.buildForApi(messages, { maxInputTokens: 10_000 });
+		const content = Array.isArray(result[0].content) ? result[0].content : [];
+		const thinking = content.find((b) => b.type === "thinking") as
+			| { thinking: string; signature?: string }
+			| undefined;
+		const text = content.find((b) => b.type === "text") as
+			| { text: string }
+			| undefined;
+
+		expect(thinking?.thinking).toBe(thinkingText);
+		expect(thinking?.signature).toBe("sig-1");
+		expect(text?.text).toContain("context window");
+		expect(
+			Buffer.byteLength(JSON.stringify(result), "utf8"),
+		).toBeLessThanOrEqual(30_000);
+	});
+
+	it("removes oversized thinking blocks whole instead of truncating signed content (CLINE-2192)", () => {
+		const thinkingText = "reasoning".repeat(50_000);
+		const builder = new MessageBuilder();
+		const messages: Message[] = [
+			{
+				role: "assistant",
+				content: [
+					{
+						type: "thinking",
+						thinking: thinkingText,
+						signature: "sig-oversized",
+					},
+				],
+			},
+			{
+				role: "user",
+				content: [{ type: "text", text: "keep going" }],
+			},
+		];
+
+		const result = builder.buildForApi(messages, { maxInputTokens: 1_000 });
+		const serialized = JSON.stringify(result);
+
+		expect(serialized).not.toContain("sig-oversized");
+		expect(serialized).not.toContain("reasoningreasoning");
+		expect(Buffer.byteLength(serialized, "utf8")).toBeLessThanOrEqual(3_000);
+	});
+
 	it("preserves image.data intact and removes the block under extreme budget (CLINE-2192)", () => {
 		// image.data is raw base64. Middle-truncating it produces invalid base64.
 		// Layer B must exclude it from string truncation.

--- a/sdk/packages/core/src/session/services/message-builder.test.ts
+++ b/sdk/packages/core/src/session/services/message-builder.test.ts
@@ -924,7 +924,8 @@ describe("MessageBuilder", () => {
 		];
 
 		const result = builder.buildForApi(messages, { maxInputTokens: 1_000 });
-		const content = Array.isArray(result[0].content) ? result[0].content : [];
+		const content =
+			result[0] && Array.isArray(result[0].content) ? result[0].content : [];
 		const rThink = content.find((b) => b.type === "redacted_thinking") as
 			| { type: string; data: string }
 			| undefined;
@@ -1004,6 +1005,169 @@ describe("MessageBuilder", () => {
 		expect(Buffer.byteLength(serialized, "utf8")).toBeLessThanOrEqual(3_000);
 	});
 
+	it("removes older whole blocks before blanking the latest user prompt in emergency truncation (CLINE-2192)", () => {
+		const builder = new MessageBuilder();
+		const messages: Message[] = [
+			{
+				role: "user",
+				content: "old user context ".repeat(20_000),
+			},
+			{
+				role: "assistant",
+				content: [
+					{
+						type: "thinking",
+						thinking: "old signed reasoning".repeat(40_000),
+						signature: "sig-remove-before-latest-user",
+					},
+				],
+			},
+			{
+				role: "user",
+				content: [{ type: "text", text: "latest user prompt must survive" }],
+			},
+		];
+
+		const result = builder.buildForApi(messages, { maxInputTokens: 1_000 });
+		const serialized = JSON.stringify(result);
+
+		expect(serialized).not.toContain("sig-remove-before-latest-user");
+		expect(serialized).not.toContain("old signed reasoning");
+		expect(serialized).toContain("latest user prompt must survive");
+		expect(Buffer.byteLength(serialized, "utf8")).toBeLessThanOrEqual(3_000);
+	});
+
+	it("exhausts zeroable and non-zeroable last-assistant blocks before latest-user emergency work (CLINE-2192)", () => {
+		const builder = new MessageBuilder();
+		const messages: Message[] = [
+			{
+				role: "assistant",
+				content: [
+					{
+						type: "text",
+						text: "old assistant text".repeat(20_000),
+					},
+					{
+						type: "thinking",
+						thinking: "old signed reasoning".repeat(40_000),
+						signature: "sig-mixed-priority",
+					},
+				],
+			},
+			{
+				role: "user",
+				content: [{ type: "text", text: "latest user stays after mixed old" }],
+			},
+		];
+
+		const result = builder.buildForApi(messages, { maxInputTokens: 1_000 });
+		const serialized = JSON.stringify(result);
+
+		expect(serialized).not.toContain("old assistant text");
+		expect(serialized).not.toContain("sig-mixed-priority");
+		expect(serialized).not.toContain("old signed reasoning");
+		expect(serialized).toContain("latest user stays after mixed old");
+		expect(Buffer.byteLength(serialized, "utf8")).toBeLessThanOrEqual(3_000);
+	});
+
+	it("can still blank and remove the latest user prompt as the final emergency resort (CLINE-2192)", () => {
+		const notice = vi.fn();
+		const telemetry = { capture: vi.fn() };
+		const builder = new MessageBuilder();
+		const messages: Message[] = [
+			{
+				role: "user",
+				content: [{ type: "text", text: "latest only ".repeat(10_000) }],
+			},
+		];
+
+		const result = builder.buildForApi(messages, {
+			maxRequestBytes: 2,
+			emitStatusNotice: notice,
+			telemetry: telemetry as never,
+			sessionId: "session-1",
+			provider: "anthropic",
+			modelId: "claude-test",
+		});
+
+		expect(result).toEqual([]);
+		expect(notice).toHaveBeenCalledWith(
+			"compacted to fit context window",
+			expect.objectContaining({ kind: "emergency_truncation" }),
+		);
+		expect(telemetry.capture).toHaveBeenCalledWith(
+			expect.objectContaining({
+				event: "task.emergency_truncation",
+				properties: expect.objectContaining({
+					droppedBlocks: expect.any(Number),
+					truncatedBlocks: expect.any(Number),
+				}),
+			}),
+		);
+	});
+
+	it("prunes empty string messages created by emergency zeroing (CLINE-2192)", () => {
+		const builder = new MessageBuilder();
+		const messages: Message[] = [
+			{
+				role: "user",
+				content: "old oversized prompt ".repeat(10_000),
+			},
+			{
+				role: "user",
+				content: [{ type: "text", text: "latest prompt survives" }],
+			},
+		];
+
+		const result = builder.buildForApi(messages, { maxRequestBytes: 500 });
+		const serialized = JSON.stringify(result);
+
+		expect(serialized).not.toContain('"content":""');
+		expect(serialized).not.toContain('"text":""');
+		expect(serialized).toContain("latest prompt survives");
+		expect(Buffer.byteLength(serialized, "utf8")).toBeLessThanOrEqual(500);
+	});
+
+	it("removes empty tool results atomically after emergency zeroing (CLINE-2192)", () => {
+		const builder = new MessageBuilder();
+		const messages: Message[] = [
+			{
+				role: "assistant",
+				content: [
+					{
+						type: "tool_use",
+						id: "tool-empty-result",
+						name: "editor",
+						input: {},
+					},
+				],
+			},
+			{
+				role: "user",
+				content: [
+					{
+						type: "tool_result",
+						tool_use_id: "tool-empty-result",
+						content: "oversized result ".repeat(20_000),
+					},
+				],
+			},
+			{
+				role: "user",
+				content: [{ type: "text", text: "latest prompt survives" }],
+			},
+		];
+
+		const result = builder.buildForApi(messages, { maxRequestBytes: 500 });
+		const serialized = JSON.stringify(result);
+
+		expect(serialized).not.toContain("tool-empty-result");
+		expect(serialized).not.toContain('"content":""');
+		expect(serialized).not.toContain('"text":""');
+		expect(serialized).toContain("latest prompt survives");
+		expect(Buffer.byteLength(serialized, "utf8")).toBeLessThanOrEqual(500);
+	});
+
 	it("drops the last assistant before the latest user prompt in the final block-removal pass (CLINE-2192)", () => {
 		const builder = new MessageBuilder();
 		const messages: Message[] = [
@@ -1048,6 +1212,61 @@ describe("MessageBuilder", () => {
 		expect(Buffer.byteLength(serialized, "utf8")).toBeLessThanOrEqual(3_000);
 	});
 
+	it("protects the latest typed prompt when later user messages are tool results (CLINE-2192)", () => {
+		const builder = new MessageBuilder();
+		const messages: Message[] = [
+			{
+				role: "user",
+				content: "original task ".repeat(12_000),
+			},
+			{
+				role: "user",
+				content: [{ type: "text", text: "latest typed prompt survives" }],
+			},
+			{
+				role: "assistant",
+				content: [
+					{
+						type: "thinking",
+						thinking: "signed reasoning".repeat(25_000),
+						signature: "sig-tool-turn",
+					},
+					{
+						type: "tool_use",
+						id: "tool-with-image",
+						name: "fetch_web_content",
+						input: {},
+					},
+				],
+			},
+			{
+				role: "user",
+				content: [
+					{
+						type: "tool_result",
+						tool_use_id: "tool-with-image",
+						content: [
+							{
+								type: "image",
+								data: "SGVsbG8gV29ybGQ=".repeat(1_000),
+								mediaType: "image/png",
+							},
+						],
+					},
+				],
+			},
+		];
+
+		const result = builder.buildForApi(messages, { maxRequestBytes: 200 });
+		const serialized = JSON.stringify(result);
+
+		expect(serialized).toContain("latest typed prompt survives");
+		expect(serialized).not.toContain("sig-tool-turn");
+		expect(serialized).not.toContain("tool-with-image");
+		expect(serialized).not.toContain("original task");
+		expect(Buffer.byteLength(serialized, "utf8")).toBeLessThanOrEqual(200);
+	});
+
 	it("preserves image.data intact and removes the block under extreme budget (CLINE-2192)", () => {
 		// image.data is raw base64. Middle-truncating it produces invalid base64.
 		// Layer B must exclude it from string truncation.
@@ -1071,7 +1290,8 @@ describe("MessageBuilder", () => {
 		];
 
 		const result = builder.buildForApi(messages, { maxInputTokens: 1_000 });
-		const content = Array.isArray(result[0].content) ? result[0].content : [];
+		const content =
+			result[0] && Array.isArray(result[0].content) ? result[0].content : [];
 		const img = content.find((b) => b.type === "image") as
 			| { data: string }
 			| undefined;

--- a/sdk/packages/core/src/session/services/message-builder.test.ts
+++ b/sdk/packages/core/src/session/services/message-builder.test.ts
@@ -845,4 +845,124 @@ describe("MessageBuilder", () => {
 		expect(notice).not.toHaveBeenCalled();
 		expect(telemetry.capture).not.toHaveBeenCalled();
 	});
+
+	it("preserves redacted_thinking.data intact and removes the block under extreme budget (CLINE-2192)", () => {
+		// redacted_thinking.data is an Anthropic-encrypted blob. Middle-
+		// truncating it would produce invalid data that the provider rejects.
+		// Layer B must exclude it from string-leaf truncation and instead
+		// handle it only via whole-block removal.
+		const encryptedBlob = "encrypted_blob_data".repeat(1_000);
+		const builder = new MessageBuilder();
+		const messages: Message[] = [
+			{
+				role: "assistant",
+				content: [
+					{
+						type: "redacted_thinking",
+						data: encryptedBlob,
+					},
+					{
+						type: "text",
+						text: "x".repeat(500_000),
+					},
+				],
+			},
+		];
+
+		const result = builder.buildForApi(messages, { maxInputTokens: 1_000 });
+		const content = Array.isArray(result[0].content) ? result[0].content : [];
+		const rThink = content.find((b) => b.type === "redacted_thinking") as
+			| { type: string; data: string }
+			| undefined;
+
+		if (rThink !== undefined) {
+			// If the block survived, its data must be intact (not truncated).
+			expect(rThink.data).toBe(encryptedBlob);
+		}
+		// Either way, the serialized result must be within budget.
+		expect(
+			Buffer.byteLength(JSON.stringify(result), "utf8"),
+		).toBeLessThanOrEqual(3_000);
+	});
+
+	it("preserves image.data intact and removes the block under extreme budget (CLINE-2192)", () => {
+		// image.data is raw base64. Middle-truncating it produces invalid base64.
+		// Layer B must exclude it from string truncation.
+		const base64Data = "SGVsbG8gV29ybGQ=".repeat(2_000); // valid-looking base64
+		const builder = new MessageBuilder();
+		const messages: Message[] = [
+			{
+				role: "user",
+				content: [
+					{
+						type: "image",
+						data: base64Data,
+						mediaType: "image/png",
+					},
+					{
+						type: "text",
+						text: "x".repeat(500_000),
+					},
+				],
+			},
+		];
+
+		const result = builder.buildForApi(messages, { maxInputTokens: 1_000 });
+		const content = Array.isArray(result[0].content) ? result[0].content : [];
+		const img = content.find((b) => b.type === "image") as
+			| { data: string }
+			| undefined;
+
+		if (img) {
+			// If the image survived, its base64 data must be intact.
+			expect(img.data).toBe(base64Data);
+		}
+		expect(
+			Buffer.byteLength(JSON.stringify(result), "utf8"),
+		).toBeLessThanOrEqual(3_000);
+	});
+
+	it("removes empty messages left after block removal (CLINE-2192)", () => {
+		// Block-removal can leave content: [] which providers reject.
+		// enforceHardByteBudget must prune these before returning.
+		const builder = new MessageBuilder();
+		const messages: Message[] = [
+			{
+				role: "assistant",
+				content: [
+					{
+						type: "tool_use",
+						id: "t1",
+						name: "editor",
+						input: { body: "x".repeat(500_000) },
+					},
+				],
+			},
+		];
+
+		const result = builder.buildForApi(messages, { maxInputTokens: 100 });
+		for (const message of result) {
+			if (Array.isArray(message.content)) {
+				expect(message.content.length).toBeGreaterThan(0);
+			}
+		}
+	});
+
+	it("never throws on adversarial or circular-like inputs (CLINE-2192)", () => {
+		// Layer B must degrade gracefully and never throw, even for unusual inputs.
+		const builder = new MessageBuilder();
+		expect(() =>
+			builder.buildForApi(
+				[
+					{ role: "user", content: [] },
+					{ role: "assistant", content: [] },
+					{
+						role: "user",
+						content: [{ type: "text", text: "x".repeat(10_000_000) }],
+					},
+				],
+				{ maxInputTokens: 10 },
+			),
+		).not.toThrow();
+	});
 });

--- a/sdk/packages/core/src/session/services/message-builder.test.ts
+++ b/sdk/packages/core/src/session/services/message-builder.test.ts
@@ -1004,6 +1004,50 @@ describe("MessageBuilder", () => {
 		expect(Buffer.byteLength(serialized, "utf8")).toBeLessThanOrEqual(3_000);
 	});
 
+	it("drops the last assistant before the latest user prompt in the final block-removal pass (CLINE-2192)", () => {
+		const builder = new MessageBuilder();
+		const messages: Message[] = [
+			{
+				role: "assistant",
+				content: [
+					{
+						type: "thinking",
+						thinking: "old reasoning".repeat(20_000),
+						signature: "sig-old",
+					},
+				],
+			},
+			{
+				role: "user",
+				content: [
+					{
+						type: "image",
+						data: "SGVsbG8gV29ybGQ=".repeat(40),
+						mediaType: "image/png",
+					},
+				],
+			},
+			{
+				role: "assistant",
+				content: [
+					{
+						type: "thinking",
+						thinking: "last reasoning".repeat(20_000),
+						signature: "sig-last-assistant",
+					},
+				],
+			},
+		];
+
+		const result = builder.buildForApi(messages, { maxInputTokens: 1_000 });
+		const serialized = JSON.stringify(result);
+
+		expect(serialized).toContain("SGVsbG8gV29ybGQ=");
+		expect(serialized).not.toContain("sig-old");
+		expect(serialized).not.toContain("sig-last-assistant");
+		expect(Buffer.byteLength(serialized, "utf8")).toBeLessThanOrEqual(3_000);
+	});
+
 	it("preserves image.data intact and removes the block under extreme budget (CLINE-2192)", () => {
 		// image.data is raw base64. Middle-truncating it produces invalid base64.
 		// Layer B must exclude it from string truncation.

--- a/sdk/packages/core/src/session/services/message-builder.test.ts
+++ b/sdk/packages/core/src/session/services/message-builder.test.ts
@@ -1,5 +1,5 @@
 import type { Message } from "@cline/shared";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { MessageBuilder } from "./message-builder";
 
 describe("MessageBuilder", () => {
@@ -662,7 +662,7 @@ describe("MessageBuilder", () => {
 			: undefined;
 		if (block?.type !== "text") throw new Error("expected text");
 		expect(Buffer.byteLength(block.text, "utf8")).toBeLessThanOrEqual(300_000);
-		expect(block.text).toContain("provider request budget");
+		expect(block.text).toContain("...[truncated");
 	});
 
 	it("falls back to the constructor default budget when maxInputTokens is absent (CLINE-2191)", () => {
@@ -705,5 +705,122 @@ describe("MessageBuilder", () => {
 		const first = JSON.stringify(build());
 		const second = JSON.stringify(build());
 		expect(first).toBe(second);
+	});
+
+	// CLINE-2192 (Layer B): absolute hard guarantee. These tests use
+	// maxInputTokens so MessageBuilder must enforce maxInputTokens * 3
+	// bytes after Layer A.
+	it("truncates tool_use.input string values without corrupting JSON or tool_use_id (CLINE-2192)", () => {
+		const notice = vi.fn();
+		const telemetry = { capture: vi.fn() };
+		const builder = new MessageBuilder();
+		const messages: Message[] = [
+			{
+				role: "assistant",
+				content: [
+					{
+						type: "tool_use",
+						id: "tool_1",
+						name: "editor",
+						input: { body: "x".repeat(1_000_000), nested: { keep: true } },
+					},
+				],
+			},
+		];
+
+		const result = builder.buildForApi(messages, {
+			maxInputTokens: 50_000,
+			emitStatusNotice: notice,
+			telemetry: telemetry as never,
+			sessionId: "session-1",
+			provider: "openrouter",
+			modelId: "anthropic/claude-opus-4.7",
+		});
+		const block = Array.isArray(result[0].content)
+			? result[0].content[0]
+			: undefined;
+		if (block?.type !== "tool_use") throw new Error("expected tool_use");
+
+		expect(block.id).toBe("tool_1");
+		expect(block.name).toBe("editor");
+		expect((block.input.nested as { keep: boolean }).keep).toBe(true);
+		expect((block.input.body as string).length).toBeLessThan(1_000_000);
+		expect(
+			Buffer.byteLength(JSON.stringify(result), "utf8"),
+		).toBeLessThanOrEqual(150_000);
+		expect(JSON.parse(JSON.stringify(block.input))).toEqual(block.input);
+		expect(notice).toHaveBeenCalledWith(
+			"compacted to fit context window",
+			expect.objectContaining({ kind: "emergency_truncation" }),
+		);
+		expect(telemetry.capture).toHaveBeenCalledWith(
+			expect.objectContaining({
+				event: "task.emergency_truncation",
+				properties: expect.objectContaining({ ulid: "session-1" }),
+			}),
+		);
+	});
+
+	it("enforces the hard byte budget when Layer A's floor would otherwise keep too many small blocks (CLINE-2192)", () => {
+		const builder = new MessageBuilder();
+		const content = Array.from({ length: 200 }, (_, i) => ({
+			type: "text" as const,
+			text: `${i}:` + "x".repeat(300),
+		}));
+
+		const result = builder.buildForApi(
+			[{ role: "user", content }],
+			{ maxInputTokens: 2_000 }, // 6 KB budget
+		);
+		const serializedBytes = Buffer.byteLength(JSON.stringify(result), "utf8");
+		const payloadBytes = (result[0].content as typeof content).reduce(
+			(total, block) => total + Buffer.byteLength(block.text, "utf8"),
+			0,
+		);
+		expect(serializedBytes).toBeLessThanOrEqual(6_000);
+		expect(payloadBytes).toBeLessThanOrEqual(6_000);
+	});
+
+	it("produces deterministic Layer B output for adversarial inputs (CLINE-2192)", () => {
+		const make = () =>
+			new MessageBuilder().buildForApi(
+				[
+					{
+						role: "assistant",
+						content: [
+							{
+								type: "tool_use",
+								id: "deterministic",
+								name: "editor",
+								input: { a: "a".repeat(100_000), b: "b".repeat(100_000) },
+							},
+						],
+					},
+				],
+				{ maxInputTokens: 5_000 },
+			);
+
+		expect(JSON.stringify(make())).toBe(JSON.stringify(make()));
+	});
+
+	it("does not emit emergency_truncation when Layer A alone suffices (CLINE-2192)", () => {
+		const notice = vi.fn();
+		const telemetry = { capture: vi.fn() };
+		new MessageBuilder().buildForApi(
+			[
+				{
+					role: "user",
+					content: [{ type: "text", text: "x".repeat(20_000) }],
+				},
+			],
+			{
+				maxInputTokens: 10_000,
+				emitStatusNotice: notice,
+				telemetry: telemetry as never,
+			},
+		);
+
+		expect(notice).not.toHaveBeenCalled();
+		expect(telemetry.capture).not.toHaveBeenCalled();
 	});
 });

--- a/sdk/packages/core/src/session/services/message-builder.test.ts
+++ b/sdk/packages/core/src/session/services/message-builder.test.ts
@@ -707,6 +707,28 @@ describe("MessageBuilder", () => {
 		expect(first).toBe(second);
 	});
 
+	it("truncates the current typed-prompt user text when the aggregate budget is tight (CLINE-2191)", () => {
+		// Layer A is unconditional — even the most-recent user message (the
+		// typed prompt) participates in the aggregate budget. This is intentional:
+		// the guarantee is that the request fits, not that any particular block
+		// is preserved. A gigantic typed prompt is unusual but possible.
+		const builder = new MessageBuilder(50_000, undefined, 100_000);
+		const messages: Message[] = [
+			{
+				role: "user",
+				content: [{ type: "text", text: "u".repeat(4_000_000) }],
+			},
+		];
+
+		const result = builder.buildForApi(messages);
+		const block = Array.isArray(result[0].content)
+			? result[0].content[0]
+			: undefined;
+		if (block?.type !== "text") throw new Error("expected text");
+		expect(Buffer.byteLength(block.text, "utf8")).toBeLessThanOrEqual(100_000);
+		expect(block.text).toContain("provider request budget");
+	});
+
 	// CLINE-2192 (Layer B): absolute hard guarantee. These tests use
 	// maxInputTokens so MessageBuilder must enforce maxInputTokens * 3
 	// bytes after Layer A.

--- a/sdk/packages/core/src/session/services/message-builder.ts
+++ b/sdk/packages/core/src/session/services/message-builder.ts
@@ -25,7 +25,7 @@ import {
 const DEFAULT_MAX_TOOL_RESULT_CHARS = 50_000;
 const DEFAULT_MAX_TOTAL_TEXT_BYTES = 6_000_000;
 const MIN_TOTAL_BUDGET_TOOL_RESULT_BYTES = 8_000;
-const MESSAGE_BUILDER_CHARS_PER_TOKEN = 3;
+export const MESSAGE_BUILDER_CHARS_PER_TOKEN = 3;
 // CLINE-2192 Layer B: when Layer A can't bring the request under the
 // budget (adversarial inputs, oversized tool_use.input bodies, etc.)
 // we drop the floor to this much smaller value and aggressively
@@ -80,6 +80,18 @@ interface TruncationCandidate {
  */
 export interface BuildForApiOptions {
 	maxInputTokens?: number;
+	/**
+	 * Explicit byte budget for the serialized Message[] payload. Callers that
+	 * know the full provider request overhead can pass the remaining
+	 * message-list budget here; it overrides the maxInputTokens-derived budget.
+	 */
+	maxRequestBytes?: number;
+	/**
+	 * Bytes reserved by the caller for non-message request payload. Used with
+	 * maxInputTokens to derive the message-list budget:
+	 * maxInputTokens * MESSAGE_BUILDER_CHARS_PER_TOKEN - requestOverheadBytes.
+	 */
+	requestOverheadBytes?: number;
 	/**
 	 * Per-turn status-notice channel. When Layer B's emergency
 	 * truncation fires we emit `"compacted to fit context window"`
@@ -151,9 +163,10 @@ export class MessageBuilder {
 			return changed ? { ...message, content } : message;
 		});
 
+		const messageBudgetBytes = this.resolveMessageBudgetBytes(options);
 		const afterLayerA = this.truncateToTotalTextBudget(
 			prepared,
-			options.maxInputTokens,
+			messageBudgetBytes,
 		);
 		// CLINE-2192 Layer B: hard guarantee. If Layer A's largest-first
 		// candidate-set heuristic couldn't bring the request under the
@@ -161,13 +174,42 @@ export class MessageBuilder {
 		// many small blocks below Layer A's floor), drop to the
 		// emergency floor and brick-wall the bytes. Always degrades,
 		// never throws.
-		if (
-			typeof options.maxInputTokens === "number" &&
-			options.maxInputTokens > 0
-		) {
-			return this.enforceHardByteBudget(afterLayerA, options);
+		if (messageBudgetBytes !== undefined && messageBudgetBytes >= 0) {
+			return this.enforceHardByteBudget(
+				afterLayerA,
+				options,
+				messageBudgetBytes,
+			);
 		}
 		return afterLayerA;
+	}
+
+	private resolveMessageBudgetBytes(
+		options: BuildForApiOptions,
+	): number | undefined {
+		if (
+			typeof options.maxRequestBytes === "number" &&
+			Number.isFinite(options.maxRequestBytes)
+		) {
+			return Math.max(0, options.maxRequestBytes);
+		}
+		if (
+			typeof options.maxInputTokens !== "number" ||
+			!Number.isFinite(options.maxInputTokens) ||
+			options.maxInputTokens <= 0
+		) {
+			return undefined;
+		}
+		const requestOverheadBytes =
+			typeof options.requestOverheadBytes === "number" &&
+			Number.isFinite(options.requestOverheadBytes)
+				? Math.max(0, options.requestOverheadBytes)
+				: 0;
+		return Math.max(
+			0,
+			options.maxInputTokens * MESSAGE_BUILDER_CHARS_PER_TOKEN -
+				requestOverheadBytes,
+		);
 	}
 
 	private transformBlock(
@@ -849,16 +891,13 @@ export class MessageBuilder {
 
 	private truncateToTotalTextBudget(
 		messages: Message[],
-		maxInputTokens?: number,
+		messageBudgetBytes?: number,
 	): Message[] {
 		// CLINE-2191: when the orchestrator threads the model's actual
 		// maxInputTokens, derive the aggregate cap from it. Otherwise
 		// fall back to the historical 6 MB default so legacy callers
 		// (existing tests, direct constructors) behave identically.
-		const effectiveBudget =
-			typeof maxInputTokens === "number" && maxInputTokens > 0
-				? maxInputTokens * MESSAGE_BUILDER_CHARS_PER_TOKEN
-				: this.maxTotalTextBytes;
+		const effectiveBudget = messageBudgetBytes ?? this.maxTotalTextBytes;
 		if (effectiveBudget <= 0) {
 			return messages;
 		}
@@ -1062,10 +1101,9 @@ export class MessageBuilder {
 	private enforceHardByteBudget(
 		messages: Message[],
 		options: BuildForApiOptions,
+		budgetBytes: number,
 	): Message[] {
-		const budgetBytes =
-			(options.maxInputTokens ?? 0) * MESSAGE_BUILDER_CHARS_PER_TOKEN;
-		if (budgetBytes <= 0) {
+		if (budgetBytes < 0) {
 			return messages;
 		}
 		const bytesBefore = countProviderRequestBytes(messages);

--- a/sdk/packages/core/src/session/services/message-builder.ts
+++ b/sdk/packages/core/src/session/services/message-builder.ts
@@ -60,6 +60,7 @@ const TRUNCATE_MARKER_DEFAULT = (n: number) =>
 	`\n\n...[truncated ${n} chars]...\n\n`;
 const TRUNCATE_MARKER_BUDGET = (n: number) =>
 	`\n\n...[truncated ${n} chars to fit provider request budget]...\n\n`;
+const LATEST_USER_DROP_PRIORITY = 4;
 
 interface ReadLocator {
 	path: string;
@@ -71,6 +72,10 @@ interface TruncationCandidate {
 	byteLength: number;
 	get(): string;
 	set(value: string): void;
+}
+
+interface EmergencyTruncationCandidate extends TruncationCandidate {
+	priority: number;
 }
 
 /**
@@ -1083,16 +1088,19 @@ export class MessageBuilder {
 	 *
 	 * If still over budget, two passes:
 	 *
-	 *  1. Aggressive middle-truncation of EVERY string-bearing block
+	 *  1. Aggressive middle-truncation of string-bearing blocks
 	 *     (including `tool_use.input` string leaves), dropping the
-	 *     per-block floor to `EMERGENCY_FLOOR_BYTES`. `tool_use_id`,
-	 *     `id`, `call_id`, `name` strings are excluded.
+	 *     per-block floor to `EMERGENCY_FLOOR_BYTES`. This sweeps by
+	 *     preservation priority: shrink zeroable strings at a priority,
+	 *     then remove whole blocks at that same priority, before touching
+	 *     more-protected messages. `tool_use_id`, `id`, `call_id`, `name`
+	 *     strings are excluded.
 	 *  2. If pass 1 didn't fit (extremely unlikely, but possible if
 	 *     the preservation set itself exceeds the budget), drop
 	 *     non-essential blocks (oldest assistant text/thinking
-	 *     blocks first, then oldest tool pairs atomically). The
-	 *     typed prompt (turn-start user) and the last assistant are
-	 *     last in the drop order.
+	 *     blocks first, then oldest tool pairs atomically). Drop
+	 *     order: 0 older assistants, 1 middle users, 2 last assistant,
+	 *     3 first user, 4 typed prompt (last resort).
 	 *
 	 * On any non-zero work performed: emits `task.emergency_truncation`
 	 * telemetry and a status notice so the operator sees the degraded
@@ -1125,43 +1133,80 @@ export class MessageBuilder {
 		});
 
 		// Pass 1: aggressive middle-truncation, EMERGENCY_FLOOR_BYTES floor.
-		const candidates = collectEmergencyCandidates(next);
 		let totalBytes = countProviderRequestBytes(next);
 		let truncatedBlocks = 0;
-		for (const candidate of candidates) {
+		let droppedBlocks = 0;
+		for (
+			let priority = 0;
+			priority <= LATEST_USER_DROP_PRIORITY;
+			priority += 1
+		) {
 			if (totalBytes <= budgetBytes) {
 				break;
 			}
-			const currentBytes = candidate.byteLength;
-			if (currentBytes <= EMERGENCY_FLOOR_BYTES) {
-				continue;
+			if (priority === LATEST_USER_DROP_PRIORITY) {
+				for (
+					let lowerPriority = 0;
+					lowerPriority < LATEST_USER_DROP_PRIORITY;
+					lowerPriority += 1
+				) {
+					droppedBlocks += exhaustPriorityUntilFits(
+						next,
+						budgetBytes,
+						lowerPriority,
+					);
+					totalBytes = countProviderRequestBytes(next);
+					if (totalBytes <= budgetBytes) {
+						break;
+					}
+				}
+				if (totalBytes <= budgetBytes) {
+					break;
+				}
 			}
-			const overflow = totalBytes - budgetBytes;
-			const targetBytes = Math.max(
-				EMERGENCY_FLOOR_BYTES,
-				currentBytes - overflow,
+			const candidates = collectEmergencyCandidates(next).filter(
+				(candidate) => candidate.priority === priority,
 			);
-			const truncated = truncateMiddleToBytes(
-				candidate.get(),
-				targetBytes,
-				TRUNCATE_MARKER_EMERGENCY,
-			);
-			candidate.set(truncated);
-			totalBytes = countProviderRequestBytes(next);
-			truncatedBlocks += 1;
+			for (const candidate of candidates) {
+				if (totalBytes <= budgetBytes) {
+					break;
+				}
+				let didTruncateCandidate = false;
+				while (totalBytes > budgetBytes) {
+					const currentBytes = utf8ByteLength(candidate.get());
+					if (currentBytes <= EMERGENCY_FLOOR_BYTES) {
+						break;
+					}
+					const overflow = totalBytes - budgetBytes;
+					const targetBytes = Math.max(
+						EMERGENCY_FLOOR_BYTES,
+						currentBytes - overflow - 1_024,
+					);
+					if (targetBytes >= currentBytes) {
+						break;
+					}
+					const truncated = truncateMiddleToBytes(
+						candidate.get(),
+						targetBytes,
+						TRUNCATE_MARKER_EMERGENCY,
+					);
+					candidate.set(truncated);
+					totalBytes = countProviderRequestBytes(next);
+					didTruncateCandidate = true;
+				}
+				if (didTruncateCandidate) {
+					truncatedBlocks += 1;
+				}
+			}
 		}
 
 		// Pass 2: if even floor-truncation didn't fit, drop blocks.
-		const droppedBlocks = dropOldestUntilFits(next, budgetBytes);
+		droppedBlocks += dropOldestUntilFits(next, budgetBytes);
 
-		// Block removal can leave messages with content: []. Providers
-		// reject empty content arrays, so prune those messages out.
-		for (let i = next.length - 1; i >= 0; i -= 1) {
-			const m = next[i];
-			if (Array.isArray(m.content) && m.content.length === 0) {
-				next.splice(i, 1);
-			}
-		}
+		// Block removal and string zeroing can leave empty content. Providers
+		// reject empty text blocks, empty string messages, and empty arrays, so
+		// prune them before returning.
+		pruneEmptyTextContent(next);
 
 		const bytesAfter = countProviderRequestBytes(next);
 
@@ -1289,6 +1334,98 @@ function countProviderRequestBytes(messages: Message[]): number {
 		);
 	}
 }
+
+function pruneEmptyTextContent(messages: Message[]): void {
+	let changed = true;
+	while (changed) {
+		changed = false;
+		for (
+			let messageIndex = messages.length - 1;
+			messageIndex >= 0;
+			messageIndex -= 1
+		) {
+			const message = messages[messageIndex];
+			if (typeof message.content === "string") {
+				if (message.content.length === 0) {
+					messages.splice(messageIndex, 1);
+					changed = true;
+				}
+				continue;
+			}
+			if (!Array.isArray(message.content)) {
+				continue;
+			}
+			for (
+				let blockIndex = message.content.length - 1;
+				blockIndex >= 0;
+				blockIndex -= 1
+			) {
+				const block = message.content[blockIndex];
+				if (block.type === "tool_result") {
+					pruneEmptyToolResultEntries(block);
+					if (isEmptyToolResult(block)) {
+						removeEmptyToolResultAtomically(messages, messageIndex, blockIndex);
+						changed = true;
+						break;
+					}
+				}
+				if (
+					(block.type === "text" && block.text.length === 0) ||
+					(block.type === "file" && block.content.length === 0)
+				) {
+					message.content.splice(blockIndex, 1);
+					changed = true;
+				}
+			}
+			if (Array.isArray(message.content) && message.content.length === 0) {
+				messages.splice(messageIndex, 1);
+				changed = true;
+			}
+		}
+	}
+}
+
+function pruneEmptyToolResultEntries(
+	block: Extract<ContentBlock, { type: "tool_result" }>,
+): void {
+	if (typeof block.content === "string") {
+		return;
+	}
+	for (let index = block.content.length - 1; index >= 0; index -= 1) {
+		const entry = block.content[index];
+		if (
+			(entry.type === "text" && entry.text.length === 0) ||
+			(entry.type === "file" && entry.content.length === 0)
+		) {
+			block.content.splice(index, 1);
+		}
+	}
+}
+
+function isEmptyToolResult(
+	block: Extract<ContentBlock, { type: "tool_result" }>,
+): boolean {
+	return typeof block.content === "string"
+		? block.content.length === 0
+		: block.content.length === 0;
+}
+
+function removeEmptyToolResultAtomically(
+	messages: Message[],
+	messageIndex: number,
+	blockIndex: number,
+): void {
+	const candidate = collectBlockRemovalCandidates(messages).find((entry) =>
+		entry.blocks.some(
+			(block) =>
+				block.messageIndex === messageIndex && block.blockIndex === blockIndex,
+		),
+	);
+	if (candidate) {
+		removeBlocks(messages, candidate.blocks);
+	}
+}
+
 /**
  * CLINE-2192 Layer B: collect every string-bearing block location the
  * brick-wall byte-budget pass may middle-truncate. Strictly wider
@@ -1310,18 +1447,30 @@ function countProviderRequestBytes(messages: Message[]): number {
  *   safe because `collectStringLeaves` only traverses `block.input`,
  *   never the block itself.
  *
- * Order is deterministic: walk message-by-message, block-by-block;
- * within each `tool_use.input`, walk the JSON tree depth-first with
- * lexicographic key order. The final sort is largest-first with
- * insertion-order tiebreaker (same property Layer A uses).
+ * Order is deterministic: lower preservation priority first, then largest
+ * first within that priority, with an insertion-order tiebreaker.
  */
 function collectEmergencyCandidates(
 	messages: Message[],
-): TruncationCandidate[] {
-	const candidates: TruncationCandidate[] = [];
-	for (const message of messages) {
+): EmergencyTruncationCandidate[] {
+	const candidates: EmergencyTruncationCandidate[] = [];
+	const lastAssistantIndex = findLastAssistantMessageIndex(messages);
+	const latestTypedUserIndex = findLatestTypedUserMessageIndex(messages);
+	for (
+		let messageIndex = 0;
+		messageIndex < messages.length;
+		messageIndex += 1
+	) {
+		const message = messages[messageIndex];
+		const priority = getDropPriority(
+			message,
+			messageIndex,
+			lastAssistantIndex,
+			latestTypedUserIndex,
+		);
 		if (typeof message.content === "string") {
 			candidates.push({
+				priority,
 				byteLength: utf8ByteLength(message.content),
 				get: () => message.content as string,
 				set: (value) => {
@@ -1336,6 +1485,7 @@ function collectEmergencyCandidates(
 		for (const block of message.content) {
 			if (block.type === "text") {
 				candidates.push({
+					priority,
 					byteLength: utf8ByteLength(block.text),
 					get: () => block.text,
 					set: (value) => {
@@ -1354,6 +1504,7 @@ function collectEmergencyCandidates(
 			}
 			if (block.type === "file") {
 				candidates.push({
+					priority,
 					byteLength: utf8ByteLength(block.content),
 					get: () => block.content,
 					set: (value) => {
@@ -1372,6 +1523,7 @@ function collectEmergencyCandidates(
 			if (block.type === "tool_result") {
 				if (typeof block.content === "string") {
 					candidates.push({
+						priority,
 						byteLength: utf8ByteLength(block.content),
 						get: () => block.content as string,
 						set: (value) => {
@@ -1382,6 +1534,7 @@ function collectEmergencyCandidates(
 					for (const entry of block.content) {
 						if (entry.type === "text") {
 							candidates.push({
+								priority,
 								byteLength: utf8ByteLength(entry.text),
 								get: () => entry.text,
 								set: (value) => {
@@ -1390,6 +1543,7 @@ function collectEmergencyCandidates(
 							});
 						} else if (entry.type === "file") {
 							candidates.push({
+								priority,
 								byteLength: utf8ByteLength(entry.content),
 								get: () => entry.content,
 								set: (value) => {
@@ -1408,6 +1562,7 @@ function collectEmergencyCandidates(
 			if (block.type === "tool_use") {
 				collectStringLeaves(block.input, (get, set) => {
 					candidates.push({
+						priority,
 						byteLength: utf8ByteLength(get()),
 						get,
 						set,
@@ -1421,6 +1576,7 @@ function collectEmergencyCandidates(
 		.map((candidate, originalIndex) => ({ candidate, originalIndex }))
 		.sort(
 			(l, r) =>
+				l.candidate.priority - r.candidate.priority ||
 				r.candidate.byteLength - l.candidate.byteLength ||
 				l.originalIndex - r.originalIndex,
 		)
@@ -1489,10 +1645,32 @@ function dropOldestUntilFits(messages: Message[], budgetBytes: number): number {
 	let droppedBlocks = 0;
 
 	// Sub-pass 1: zero out string payloads (cheaper than block removal and
-	// preserves JSON shape so the provider can still parse the request).
-	// Candidates are snapshot at entry; set("") mutates in place so later
-	// candidates with get().length === 0 are naturally skipped.
-	const stringCandidates = collectEmergencyCandidates(messages);
+	// preserves JSON shape so the provider can still parse the request). Sweep
+	// by preservation priority so older whole blocks are removed before the
+	// latest user prompt is blanked.
+	for (let priority = 0; priority <= LATEST_USER_DROP_PRIORITY; priority += 1) {
+		droppedBlocks += exhaustPriorityUntilFits(messages, budgetBytes, priority);
+	}
+
+	if (countProviderRequestBytes(messages) <= budgetBytes) {
+		return droppedBlocks;
+	}
+
+	// Sub-pass 2: remove entire blocks.
+	droppedBlocks += removeBlocksUntilFits(messages, budgetBytes);
+
+	return droppedBlocks;
+}
+
+function exhaustPriorityUntilFits(
+	messages: Message[],
+	budgetBytes: number,
+	priority: number,
+): number {
+	let droppedBlocks = 0;
+	const stringCandidates = collectEmergencyCandidates(messages).filter(
+		(candidate) => candidate.priority === priority,
+	);
 	for (const candidate of stringCandidates) {
 		if (countProviderRequestBytes(messages) <= budgetBytes) {
 			break;
@@ -1503,26 +1681,55 @@ function dropOldestUntilFits(messages: Message[], budgetBytes: number): number {
 		candidate.set("");
 		droppedBlocks += 1;
 	}
+	droppedBlocks += removeBlocksAtPriorityUntilFits(
+		messages,
+		budgetBytes,
+		priority,
+	);
+	return droppedBlocks;
+}
 
-	if (countProviderRequestBytes(messages) <= budgetBytes) {
-		return droppedBlocks;
-	}
-
-	// Sub-pass 2: remove entire blocks. Recompute collectBlockRemovalCandidates
-	// after each removal to avoid stale messageIndex/blockIndex references —
-	// splice shifts indices within a message and a frozen candidate list would
-	// silently miss or wrong-remove subsequent blocks.
+function removeBlocksAtPriorityUntilFits(
+	messages: Message[],
+	budgetBytes: number,
+	priority: number,
+): number {
+	let droppedBlocks = 0;
+	// Recompute collectBlockRemovalCandidates after each removal to avoid stale
+	// messageIndex/blockIndex references — splice shifts indices within a message
+	// and a frozen candidate list would silently miss or wrong-remove subsequent
+	// blocks.
 	while (countProviderRequestBytes(messages) > budgetBytes) {
 		const blockCandidates = collectBlockRemovalCandidates(messages);
-		if (blockCandidates.length === 0) {
+		const candidate = blockCandidates.find(
+			(blockCandidate) => blockCandidate.priority === priority,
+		);
+		if (!candidate) {
 			break;
 		}
-		if (!removeBlocks(messages, blockCandidates[0].blocks)) {
+		if (!removeBlocks(messages, candidate.blocks)) {
 			break; // No progress; avoid an infinite loop.
 		}
-		droppedBlocks += blockCandidates[0].blocks.length;
+		droppedBlocks += candidate.blocks.length;
 	}
+	return droppedBlocks;
+}
 
+function removeBlocksUntilFits(
+	messages: Message[],
+	budgetBytes: number,
+): number {
+	let droppedBlocks = 0;
+	for (let priority = 0; priority <= LATEST_USER_DROP_PRIORITY; priority += 1) {
+		droppedBlocks += removeBlocksAtPriorityUntilFits(
+			messages,
+			budgetBytes,
+			priority,
+		);
+		if (countProviderRequestBytes(messages) <= budgetBytes) {
+			break;
+		}
+	}
 	return droppedBlocks;
 }
 
@@ -1544,7 +1751,7 @@ function collectBlockRemovalCandidates(
 	const toolRefs = new Map<string, BlockRef[]>();
 	const candidates: BlockRemovalCandidate[] = [];
 	const lastAssistantIndex = findLastAssistantMessageIndex(messages);
-	const lastUserIndex = findLastUserMessageIndex(messages);
+	const latestTypedUserIndex = findLatestTypedUserMessageIndex(messages);
 
 	for (
 		let messageIndex = 0;
@@ -1592,7 +1799,7 @@ function collectBlockRemovalCandidates(
 				message,
 				messageIndex,
 				lastAssistantIndex,
-				lastUserIndex,
+				latestTypedUserIndex,
 			);
 			if (block.type === "tool_use") {
 				candidates.push({
@@ -1635,7 +1842,7 @@ function getDropPriority(
 	message: Message,
 	messageIndex: number,
 	lastAssistantIndex: number,
-	lastUserIndex: number,
+	latestTypedUserIndex: number,
 ): number {
 	// Lower values are dropped first:
 	// 0 older assistants, 1 middle users, 2 last assistant, 3 first user,
@@ -1646,15 +1853,15 @@ function getDropPriority(
 	if (
 		message.role === "user" &&
 		messageIndex !== 0 &&
-		messageIndex !== lastUserIndex
+		messageIndex !== latestTypedUserIndex
 	) {
 		return 1;
 	}
 	if (message.role === "assistant") {
 		return 2;
 	}
-	if (message.role === "user" && messageIndex === lastUserIndex) {
-		return 4;
+	if (message.role === "user" && messageIndex === latestTypedUserIndex) {
+		return LATEST_USER_DROP_PRIORITY;
 	}
 	return 3;
 }
@@ -1668,13 +1875,30 @@ function findLastAssistantMessageIndex(messages: Message[]): number {
 	return -1;
 }
 
-function findLastUserMessageIndex(messages: Message[]): number {
+function findLatestTypedUserMessageIndex(messages: Message[]): number {
 	for (let index = messages.length - 1; index >= 0; index -= 1) {
-		if (messages[index].role === "user") {
+		if (isTypedUserMessage(messages[index])) {
 			return index;
 		}
 	}
 	return -1;
+}
+
+// Tool results are provider-shaped as role:"user" messages, but they are not
+// typed prompts. The latest typed prompt is the user-authored message we
+// preserve as the final emergency-truncation resort.
+function isTypedUserMessage(message: Message): boolean {
+	if (message.role !== "user") {
+		return false;
+	}
+	if (typeof message.content === "string") {
+		return true;
+	}
+	return (
+		Array.isArray(message.content) &&
+		message.content.length > 0 &&
+		message.content.some((block) => block.type !== "tool_result")
+	);
 }
 
 function removeBlocks(messages: Message[], refs: BlockRef[]): boolean {

--- a/sdk/packages/core/src/session/services/message-builder.ts
+++ b/sdk/packages/core/src/session/services/message-builder.ts
@@ -970,6 +970,11 @@ export class MessageBuilder {
 					continue;
 				}
 				if (block.type === "file") {
+					// Note: transformBlock already applied per-block
+					// truncation to file content (via truncateMiddle at
+					// maxToolResultChars). The candidate here allows Layer A
+					// to apply a second, tighter cut when the aggregate
+					// budget is still exceeded after per-block truncation.
 					candidates.push({
 						byteLength: utf8ByteLength(block.content),
 						get: () => block.content,

--- a/sdk/packages/core/src/session/services/message-builder.ts
+++ b/sdk/packages/core/src/session/services/message-builder.ts
@@ -1115,6 +1115,16 @@ export class MessageBuilder {
 
 		// Pass 2: if even floor-truncation didn't fit, drop blocks.
 		const droppedBlocks = dropOldestUntilFits(next, budgetBytes);
+
+		// Block removal can leave messages with content: []. Providers
+		// reject empty content arrays, so prune those messages out.
+		for (let i = next.length - 1; i >= 0; i -= 1) {
+			const m = next[i];
+			if (Array.isArray(m.content) && m.content.length === 0) {
+				next.splice(i, 1);
+			}
+		}
+
 		const bytesAfter = countProviderRequestBytes(next);
 
 		if (truncatedBlocks > 0 || droppedBlocks > 0) {
@@ -1245,9 +1255,20 @@ function countProviderRequestBytes(messages: Message[]): number {
  * CLINE-2192 Layer B: collect every string-bearing block location the
  * brick-wall byte-budget pass may middle-truncate. Strictly wider
  * than Layer A's set — it also includes the string leaves inside
- * `tool_use.input`. Keys, numbers, booleans, null, and the reserved
- * identifier fields (`id`, `tool_use_id`, `call_id`, `name`) are
- * excluded.
+ * `tool_use.input`.
+ *
+ * What IS excluded from string truncation:
+ * - `redacted_thinking.data` — Anthropic-encrypted opaque blob; truncation
+ *   produces invalid data. Handled by block removal in pass 2.
+ * - `image.data` and tool-result image entries — raw base64; truncation
+ *   produces invalid base64. Handled by block removal in pass 2.
+ *
+ * What is NOT excluded (intentional in emergency territory):
+ * - String-valued input parameters named `id`, `name`, etc. within
+ *   `tool_use.input`. These are parameter values, not provider-level
+ *   identifiers. The actual block-level `block.id` and `block.name` are
+ *   safe because `collectStringLeaves` only traverses `block.input`,
+ *   never the block itself.
  *
  * Order is deterministic: walk message-by-message, block-by-block;
  * within each `tool_use.input`, walk the JSON tree depth-first with
@@ -1294,13 +1315,10 @@ function collectEmergencyCandidates(
 				continue;
 			}
 			if (block.type === "redacted_thinking") {
-				candidates.push({
-					byteLength: utf8ByteLength(block.data),
-					get: () => block.data,
-					set: (value) => {
-						block.data = value;
-					},
-				});
+				// `data` is an Anthropic-encrypted opaque blob. Middle-
+				// truncating it produces binary garbage that the provider
+				// rejects with a 400. Exclude from string truncation;
+				// collectBlockRemovalCandidates handles whole-block removal.
 				continue;
 			}
 			if (block.type === "file") {
@@ -1314,13 +1332,10 @@ function collectEmergencyCandidates(
 				continue;
 			}
 			if (block.type === "image") {
-				candidates.push({
-					byteLength: utf8ByteLength(block.data),
-					get: () => block.data,
-					set: (value) => {
-						block.data = value;
-					},
-				});
+				// `data` is raw base64. Middle-truncating it produces
+				// invalid base64 that the provider rejects with a 400.
+				// Exclude from string truncation; whole-block removal
+				// is handled by collectBlockRemovalCandidates.
 				continue;
 			}
 			if (block.type === "tool_result") {
@@ -1351,13 +1366,9 @@ function collectEmergencyCandidates(
 								},
 							});
 						} else if (entry.type === "image") {
-							candidates.push({
-								byteLength: utf8ByteLength(entry.data),
-								get: () => entry.data,
-								set: (value) => {
-									entry.data = value;
-								},
-							});
+							// base64 data — same as top-level image blocks,
+							// middle-truncation produces invalid base64. Skip;
+							// whole-block removal is the right lever here.
 						}
 					}
 				}
@@ -1386,11 +1397,15 @@ function collectEmergencyCandidates(
 }
 
 /**
- * Walks `tool_use.input` depth-first with lexicographic key order
- * and invokes the visitor for every string leaf with a `get`/`set`
- * pair that reads/writes the leaf in place. Non-string leaves
- * (numbers, booleans, null) are not visited. Arrays-of-strings ARE
- * visited per-index.
+ * Walks a value (typically `tool_use.input`) depth-first with
+ * lexicographic key order and invokes the visitor for every string
+ * leaf with a `get`/`set` pair that reads/writes the leaf in place.
+ * Non-string leaves (numbers, booleans, null) are not visited.
+ * Arrays-of-strings ARE visited per-index.
+ *
+ * This function is called with `block.input`, never with the block
+ * itself, so block-level fields like `block.id` and `block.name` are
+ * always outside the traversal scope.
  */
 function collectStringLeaves(
 	node: unknown,
@@ -1441,8 +1456,13 @@ function collectStringLeaves(
  */
 function dropOldestUntilFits(messages: Message[], budgetBytes: number): number {
 	let droppedBlocks = 0;
-	const candidates = collectEmergencyCandidates(messages);
-	for (const candidate of candidates) {
+
+	// Sub-pass 1: zero out string payloads (cheaper than block removal and
+	// preserves JSON shape so the provider can still parse the request).
+	// Candidates are snapshot at entry; set("") mutates in place so later
+	// candidates with get().length === 0 are naturally skipped.
+	const stringCandidates = collectEmergencyCandidates(messages);
+	for (const candidate of stringCandidates) {
 		if (countProviderRequestBytes(messages) <= budgetBytes) {
 			break;
 		}
@@ -1457,14 +1477,21 @@ function dropOldestUntilFits(messages: Message[], budgetBytes: number): number {
 		return droppedBlocks;
 	}
 
-	for (const removal of collectBlockRemovalCandidates(messages)) {
-		if (countProviderRequestBytes(messages) <= budgetBytes) {
+	// Sub-pass 2: remove entire blocks. Recompute collectBlockRemovalCandidates
+	// after each removal to avoid stale messageIndex/blockIndex references —
+	// splice shifts indices within a message and a frozen candidate list would
+	// silently miss or wrong-remove subsequent blocks.
+	while (countProviderRequestBytes(messages) > budgetBytes) {
+		const blockCandidates = collectBlockRemovalCandidates(messages);
+		if (blockCandidates.length === 0) {
 			break;
 		}
-		if (removeBlocks(messages, removal.blocks)) {
-			droppedBlocks += removal.blocks.length;
+		if (!removeBlocks(messages, blockCandidates[0].blocks)) {
+			break; // No progress; avoid an infinite loop.
 		}
+		droppedBlocks += blockCandidates[0].blocks.length;
 	}
+
 	return droppedBlocks;
 }
 

--- a/sdk/packages/core/src/session/services/message-builder.ts
+++ b/sdk/packages/core/src/session/services/message-builder.ts
@@ -10,17 +10,31 @@
  */
 
 import {
-	CHARS_PER_TOKEN,
 	type ContentBlock,
+	type ITelemetryService,
 	type Message,
 	normalizeUserInput,
 	type TextContent,
 	type ToolResultContent,
 } from "@cline/shared";
+import {
+	captureEmergencyTruncation,
+	type TelemetryAgentIdentityProperties,
+} from "../../services/telemetry/core-events";
 
 const DEFAULT_MAX_TOOL_RESULT_CHARS = 50_000;
 const DEFAULT_MAX_TOTAL_TEXT_BYTES = 6_000_000;
 const MIN_TOTAL_BUDGET_TOOL_RESULT_BYTES = 8_000;
+const MESSAGE_BUILDER_CHARS_PER_TOKEN = 3;
+// CLINE-2192 Layer B: when Layer A can't bring the request under the
+// budget (adversarial inputs, oversized tool_use.input bodies, etc.)
+// we drop the floor to this much smaller value and aggressively
+// middle-truncate every string-bearing block until we fit. Small
+// enough to free real budget; large enough that the block still
+// carries some signal.
+const EMERGENCY_FLOOR_BYTES = 256;
+const TRUNCATE_MARKER_EMERGENCY = (n: number) =>
+	`\n\n...[truncated ${n} chars to fit context window]...\n\n`;
 // Tools whose results are large enough to need provider-payload truncation
 // (per-block at maxToolResultChars and in aggregate at maxTotalTextBytes).
 // Bounded-output tools (ask_question, submit_and_exit) are intentionally
@@ -60,6 +74,30 @@ interface TruncationCandidate {
 }
 
 /**
+ * Options for `MessageBuilder.buildForApi`. The Layer A budget knob
+ * (`maxInputTokens`) plus the Layer B observability surface for the
+ * brick-wall byte-budget guarantee (CLINE-2192).
+ */
+export interface BuildForApiOptions {
+	maxInputTokens?: number;
+	/**
+	 * Per-turn status-notice channel. When Layer B's emergency
+	 * truncation fires we emit `"compacted to fit context window"`
+	 * so the TUI/webview surfaces a visible signal to the user.
+	 */
+	emitStatusNotice?: (
+		message: string,
+		metadata?: Record<string, unknown>,
+	) => void;
+	/** Per-session telemetry sink for `task.emergency_truncation`. */
+	telemetry?: ITelemetryService;
+	sessionId?: string;
+	provider?: string;
+	modelId?: string;
+	agentIdentity?: Partial<TelemetryAgentIdentityProperties>;
+}
+
+/**
  * Builds an API-safe message copy without mutating original conversation history.
  */
 export class MessageBuilder {
@@ -85,7 +123,7 @@ export class MessageBuilder {
 
 	buildForApi(
 		messages: Message[],
-		options: { maxInputTokens?: number } = {},
+		options: BuildForApiOptions = {},
 	): Message[] {
 		this.reindex(messages);
 		const repairedMessages = this.addMissingToolResults(messages);
@@ -113,7 +151,23 @@ export class MessageBuilder {
 			return changed ? { ...message, content } : message;
 		});
 
-		return this.truncateToTotalTextBudget(prepared, options.maxInputTokens);
+		const afterLayerA = this.truncateToTotalTextBudget(
+			prepared,
+			options.maxInputTokens,
+		);
+		// CLINE-2192 Layer B: hard guarantee. If Layer A's largest-first
+		// candidate-set heuristic couldn't bring the request under the
+		// budget (adversarial inputs, oversized tool_use.input bodies,
+		// many small blocks below Layer A's floor), drop to the
+		// emergency floor and brick-wall the bytes. Always degrades,
+		// never throws.
+		if (
+			typeof options.maxInputTokens === "number" &&
+			options.maxInputTokens > 0
+		) {
+			return this.enforceHardByteBudget(afterLayerA, options);
+		}
+		return afterLayerA;
 	}
 
 	private transformBlock(
@@ -803,7 +857,7 @@ export class MessageBuilder {
 		// (existing tests, direct constructors) behave identically.
 		const effectiveBudget =
 			typeof maxInputTokens === "number" && maxInputTokens > 0
-				? maxInputTokens * CHARS_PER_TOKEN
+				? maxInputTokens * MESSAGE_BUILDER_CHARS_PER_TOKEN
 				: this.maxTotalTextBytes;
 		if (effectiveBudget <= 0) {
 			return messages;
@@ -977,6 +1031,111 @@ export class MessageBuilder {
 		);
 		return indexed.map(({ candidate }) => candidate);
 	}
+
+	/**
+	 * CLINE-2192 Layer B: the brick-wall byte-budget pass. Runs after
+	 * Layer A. If the input is already under budget this is a no-op
+	 * and the input array is returned unchanged.
+	 *
+	 * If still over budget, two passes:
+	 *
+	 *  1. Aggressive middle-truncation of EVERY string-bearing block
+	 *     (including `tool_use.input` string leaves), dropping the
+	 *     per-block floor to `EMERGENCY_FLOOR_BYTES`. `tool_use_id`,
+	 *     `id`, `call_id`, `name` strings are excluded.
+	 *  2. If pass 1 didn't fit (extremely unlikely, but possible if
+	 *     the preservation set itself exceeds the budget), drop
+	 *     non-essential blocks (oldest assistant text/thinking
+	 *     blocks first, then oldest tool pairs atomically). The
+	 *     typed prompt (turn-start user) and the last assistant are
+	 *     last in the drop order.
+	 *
+	 * On any non-zero work performed: emits `task.emergency_truncation`
+	 * telemetry and a status notice so the operator sees the degraded
+	 * state in the TUI/webview.
+	 */
+	private enforceHardByteBudget(
+		messages: Message[],
+		options: BuildForApiOptions,
+	): Message[] {
+		const budgetBytes =
+			(options.maxInputTokens ?? 0) * MESSAGE_BUILDER_CHARS_PER_TOKEN;
+		if (budgetBytes <= 0) {
+			return messages;
+		}
+		const bytesBefore = countProviderRequestBytes(messages);
+		if (bytesBefore <= budgetBytes) {
+			return messages;
+		}
+
+		// Deep-clone so we don't mutate the input.
+		const next = messages.map((message) => {
+			if (!Array.isArray(message.content)) {
+				return { ...message };
+			}
+			return {
+				...message,
+				content: message.content.map((block) =>
+					cloneContentBlockForMutation(block),
+				),
+			};
+		});
+
+		// Pass 1: aggressive middle-truncation, EMERGENCY_FLOOR_BYTES floor.
+		const candidates = collectEmergencyCandidates(next);
+		let totalBytes = countProviderRequestBytes(next);
+		let truncatedBlocks = 0;
+		for (const candidate of candidates) {
+			if (totalBytes <= budgetBytes) {
+				break;
+			}
+			const currentBytes = candidate.byteLength;
+			if (currentBytes <= EMERGENCY_FLOOR_BYTES) {
+				continue;
+			}
+			const overflow = totalBytes - budgetBytes;
+			const targetBytes = Math.max(
+				EMERGENCY_FLOOR_BYTES,
+				currentBytes - overflow,
+			);
+			const truncated = truncateMiddleToBytes(
+				candidate.get(),
+				targetBytes,
+				TRUNCATE_MARKER_EMERGENCY,
+			);
+			candidate.set(truncated);
+			totalBytes = countProviderRequestBytes(next);
+			truncatedBlocks += 1;
+		}
+
+		// Pass 2: if even floor-truncation didn't fit, drop blocks.
+		const droppedBlocks = dropOldestUntilFits(next, budgetBytes);
+		const bytesAfter = countProviderRequestBytes(next);
+
+		if (truncatedBlocks > 0 || droppedBlocks > 0) {
+			options.emitStatusNotice?.("compacted to fit context window", {
+				kind: "emergency_truncation",
+				maxInputTokens: options.maxInputTokens,
+				bytesBefore,
+				bytesAfter,
+				truncatedBlocks,
+				droppedBlocks,
+			});
+			captureEmergencyTruncation(options.telemetry, {
+				ulid: options.sessionId ?? options.agentIdentity?.conversationId ?? "",
+				bytesBefore,
+				bytesAfter,
+				maxInputTokens: options.maxInputTokens ?? 0,
+				truncatedBlocks,
+				droppedBlocks,
+				provider: options.provider,
+				modelId: options.modelId,
+				...options.agentIdentity,
+			});
+		}
+
+		return next;
+	}
 }
 
 function utf8ByteLength(text: string): number {
@@ -1033,6 +1192,12 @@ function truncateMiddleToBytes(
 }
 
 function cloneContentBlockForMutation(block: ContentBlock): ContentBlock {
+	if (block.type === "tool_use") {
+		return {
+			...block,
+			input: cloneJsonLike(block.input) as Record<string, unknown>,
+		};
+	}
 	if (block.type !== "tool_result" || typeof block.content === "string") {
 		return { ...block };
 	}
@@ -1040,4 +1205,412 @@ function cloneContentBlockForMutation(block: ContentBlock): ContentBlock {
 		...block,
 		content: block.content.map((entry) => ({ ...entry })),
 	};
+}
+
+function cloneJsonLike(value: unknown): unknown {
+	if (Array.isArray(value)) {
+		return value.map((entry) => cloneJsonLike(entry));
+	}
+	if (value && typeof value === "object") {
+		const result: Record<string, unknown> = {};
+		for (const [key, entry] of Object.entries(value)) {
+			result[key] = cloneJsonLike(entry);
+		}
+		return result;
+	}
+	return value;
+}
+
+function countProviderRequestBytes(messages: Message[]): number {
+	// CLINE-2192: provider payloads include JSON framing, tool names,
+	// tool ids, object keys and scalar arguments — not just string
+	// leaf contents. Counting the JSON-serialized message list is a
+	// conservative byte-budget proxy and is the metric Layer B must
+	// force under `maxInputTokens * MESSAGE_BUILDER_CHARS_PER_TOKEN`.
+	try {
+		return utf8ByteLength(JSON.stringify(messages));
+	} catch {
+		return messages.reduce(
+			(total, message) => total + utf8ByteLength(String(message)),
+			0,
+		);
+	}
+}
+/**
+ * CLINE-2192 Layer B: collect every string-bearing block location the
+ * brick-wall byte-budget pass may middle-truncate. Strictly wider
+ * than Layer A's set — it also includes the string leaves inside
+ * `tool_use.input`. Keys, numbers, booleans, null, and the reserved
+ * identifier fields (`id`, `tool_use_id`, `call_id`, `name`) are
+ * excluded.
+ *
+ * Order is deterministic: walk message-by-message, block-by-block;
+ * within each `tool_use.input`, walk the JSON tree depth-first with
+ * lexicographic key order. The final sort is largest-first with
+ * insertion-order tiebreaker (same property Layer A uses).
+ */
+function collectEmergencyCandidates(
+	messages: Message[],
+): TruncationCandidate[] {
+	const candidates: TruncationCandidate[] = [];
+	for (const message of messages) {
+		if (typeof message.content === "string") {
+			candidates.push({
+				byteLength: utf8ByteLength(message.content),
+				get: () => message.content as string,
+				set: (value) => {
+					message.content = value;
+				},
+			});
+			continue;
+		}
+		if (!Array.isArray(message.content)) {
+			continue;
+		}
+		for (const block of message.content) {
+			if (block.type === "text") {
+				candidates.push({
+					byteLength: utf8ByteLength(block.text),
+					get: () => block.text,
+					set: (value) => {
+						block.text = value;
+					},
+				});
+				continue;
+			}
+			if (block.type === "thinking") {
+				candidates.push({
+					byteLength: utf8ByteLength(block.thinking),
+					get: () => block.thinking,
+					set: (value) => {
+						block.thinking = value;
+					},
+				});
+				continue;
+			}
+			if (block.type === "redacted_thinking") {
+				candidates.push({
+					byteLength: utf8ByteLength(block.data),
+					get: () => block.data,
+					set: (value) => {
+						block.data = value;
+					},
+				});
+				continue;
+			}
+			if (block.type === "file") {
+				candidates.push({
+					byteLength: utf8ByteLength(block.content),
+					get: () => block.content,
+					set: (value) => {
+						block.content = value;
+					},
+				});
+				continue;
+			}
+			if (block.type === "image") {
+				candidates.push({
+					byteLength: utf8ByteLength(block.data),
+					get: () => block.data,
+					set: (value) => {
+						block.data = value;
+					},
+				});
+				continue;
+			}
+			if (block.type === "tool_result") {
+				if (typeof block.content === "string") {
+					candidates.push({
+						byteLength: utf8ByteLength(block.content),
+						get: () => block.content as string,
+						set: (value) => {
+							block.content = value;
+						},
+					});
+				} else {
+					for (const entry of block.content) {
+						if (entry.type === "text") {
+							candidates.push({
+								byteLength: utf8ByteLength(entry.text),
+								get: () => entry.text,
+								set: (value) => {
+									entry.text = value;
+								},
+							});
+						} else if (entry.type === "file") {
+							candidates.push({
+								byteLength: utf8ByteLength(entry.content),
+								get: () => entry.content,
+								set: (value) => {
+									entry.content = value;
+								},
+							});
+						} else if (entry.type === "image") {
+							candidates.push({
+								byteLength: utf8ByteLength(entry.data),
+								get: () => entry.data,
+								set: (value) => {
+									entry.data = value;
+								},
+							});
+						}
+					}
+				}
+				continue;
+			}
+			if (block.type === "tool_use") {
+				collectStringLeaves(block.input, (get, set) => {
+					candidates.push({
+						byteLength: utf8ByteLength(get()),
+						get,
+						set,
+					});
+				});
+				continue;
+			}
+		}
+	}
+	return candidates
+		.map((candidate, originalIndex) => ({ candidate, originalIndex }))
+		.sort(
+			(l, r) =>
+				r.candidate.byteLength - l.candidate.byteLength ||
+				l.originalIndex - r.originalIndex,
+		)
+		.map(({ candidate }) => candidate);
+}
+
+/**
+ * Walks `tool_use.input` depth-first with lexicographic key order
+ * and invokes the visitor for every string leaf with a `get`/`set`
+ * pair that reads/writes the leaf in place. Non-string leaves
+ * (numbers, booleans, null) are not visited. Arrays-of-strings ARE
+ * visited per-index.
+ */
+function collectStringLeaves(
+	node: unknown,
+	visit: (get: () => string, set: (value: string) => void) => void,
+): void {
+	if (Array.isArray(node)) {
+		for (let i = 0; i < node.length; i += 1) {
+			const value = node[i];
+			if (typeof value === "string") {
+				visit(
+					() => node[i] as string,
+					(next) => {
+						node[i] = next;
+					},
+				);
+			} else {
+				collectStringLeaves(value, visit);
+			}
+		}
+		return;
+	}
+	if (node && typeof node === "object") {
+		const obj = node as Record<string, unknown>;
+		for (const key of Object.keys(obj).sort()) {
+			const value = obj[key];
+			if (typeof value === "string") {
+				visit(
+					() => obj[key] as string,
+					(next) => {
+						obj[key] = next;
+					},
+				);
+			} else {
+				collectStringLeaves(value, visit);
+			}
+		}
+	}
+}
+
+/**
+ * CLINE-2192 Layer B pass 2: when even floor-truncating every
+ * string leaf still leaves the request over budget, blank out
+ * remaining string-bearing payloads until it fits. This is intentionally
+ * brutal but structured: ids, tool names, object keys, booleans,
+ * numbers, nulls, arrays and object shapes are preserved. A tool call
+ * may fail because an argument string became empty, but the provider
+ * request will fit and the agent can recover in the next turn.
+ */
+function dropOldestUntilFits(messages: Message[], budgetBytes: number): number {
+	let droppedBlocks = 0;
+	const candidates = collectEmergencyCandidates(messages);
+	for (const candidate of candidates) {
+		if (countProviderRequestBytes(messages) <= budgetBytes) {
+			break;
+		}
+		if (candidate.get().length === 0) {
+			continue;
+		}
+		candidate.set("");
+		droppedBlocks += 1;
+	}
+
+	if (countProviderRequestBytes(messages) <= budgetBytes) {
+		return droppedBlocks;
+	}
+
+	for (const removal of collectBlockRemovalCandidates(messages)) {
+		if (countProviderRequestBytes(messages) <= budgetBytes) {
+			break;
+		}
+		if (removeBlocks(messages, removal.blocks)) {
+			droppedBlocks += removal.blocks.length;
+		}
+	}
+	return droppedBlocks;
+}
+
+interface BlockRef {
+	messageIndex: number;
+	blockIndex: number;
+}
+
+interface BlockRemovalCandidate {
+	priority: number;
+	messageIndex: number;
+	blockIndex: number;
+	blocks: BlockRef[];
+}
+
+function collectBlockRemovalCandidates(
+	messages: Message[],
+): BlockRemovalCandidate[] {
+	const toolRefs = new Map<string, BlockRef[]>();
+	const candidates: BlockRemovalCandidate[] = [];
+	const lastAssistantIndex = findLastAssistantMessageIndex(messages);
+
+	for (
+		let messageIndex = 0;
+		messageIndex < messages.length;
+		messageIndex += 1
+	) {
+		const message = messages[messageIndex];
+		if (!Array.isArray(message.content)) {
+			continue;
+		}
+		for (
+			let blockIndex = 0;
+			blockIndex < message.content.length;
+			blockIndex += 1
+		) {
+			const block = message.content[blockIndex];
+			if (block.type === "tool_use") {
+				const refs = toolRefs.get(block.id) ?? [];
+				refs.push({ messageIndex, blockIndex });
+				toolRefs.set(block.id, refs);
+			} else if (block.type === "tool_result") {
+				const refs = toolRefs.get(block.tool_use_id) ?? [];
+				refs.push({ messageIndex, blockIndex });
+				toolRefs.set(block.tool_use_id, refs);
+			}
+		}
+	}
+
+	for (
+		let messageIndex = 0;
+		messageIndex < messages.length;
+		messageIndex += 1
+	) {
+		const message = messages[messageIndex];
+		if (!Array.isArray(message.content)) {
+			continue;
+		}
+		for (
+			let blockIndex = 0;
+			blockIndex < message.content.length;
+			blockIndex += 1
+		) {
+			const block = message.content[blockIndex];
+			const priority = getDropPriority(
+				message,
+				messageIndex,
+				lastAssistantIndex,
+			);
+			if (block.type === "tool_use") {
+				candidates.push({
+					priority,
+					messageIndex,
+					blockIndex,
+					blocks: toolRefs.get(block.id) ?? [{ messageIndex, blockIndex }],
+				});
+				continue;
+			}
+			if (block.type === "tool_result") {
+				candidates.push({
+					priority,
+					messageIndex,
+					blockIndex,
+					blocks: toolRefs.get(block.tool_use_id) ?? [
+						{ messageIndex, blockIndex },
+					],
+				});
+				continue;
+			}
+			candidates.push({
+				priority,
+				messageIndex,
+				blockIndex,
+				blocks: [{ messageIndex, blockIndex }],
+			});
+		}
+	}
+
+	return candidates.sort(
+		(a, b) =>
+			a.priority - b.priority ||
+			a.messageIndex - b.messageIndex ||
+			a.blockIndex - b.blockIndex,
+	);
+}
+
+function getDropPriority(
+	message: Message,
+	messageIndex: number,
+	lastAssistantIndex: number,
+): number {
+	if (message.role === "assistant" && messageIndex !== lastAssistantIndex) {
+		return 0;
+	}
+	if (message.role === "user" && messageIndex !== 0) {
+		return 1;
+	}
+	if (message.role === "assistant") {
+		return 2;
+	}
+	return 3;
+}
+
+function findLastAssistantMessageIndex(messages: Message[]): number {
+	for (let index = messages.length - 1; index >= 0; index -= 1) {
+		if (messages[index].role === "assistant") {
+			return index;
+		}
+	}
+	return -1;
+}
+
+function removeBlocks(messages: Message[], refs: BlockRef[]): boolean {
+	let didRemove = false;
+	const refsByMessage = new Map<number, number[]>();
+	for (const ref of refs) {
+		const indexes = refsByMessage.get(ref.messageIndex) ?? [];
+		indexes.push(ref.blockIndex);
+		refsByMessage.set(ref.messageIndex, indexes);
+	}
+	for (const [messageIndex, blockIndexes] of refsByMessage) {
+		const message = messages[messageIndex];
+		if (!message || !Array.isArray(message.content)) {
+			continue;
+		}
+		for (const blockIndex of [...new Set(blockIndexes)].sort((a, b) => b - a)) {
+			if (blockIndex >= 0 && blockIndex < message.content.length) {
+				message.content.splice(blockIndex, 1);
+				didRemove = true;
+			}
+		}
+	}
+	return didRemove;
 }

--- a/sdk/packages/core/src/session/services/message-builder.ts
+++ b/sdk/packages/core/src/session/services/message-builder.ts
@@ -1544,6 +1544,7 @@ function collectBlockRemovalCandidates(
 	const toolRefs = new Map<string, BlockRef[]>();
 	const candidates: BlockRemovalCandidate[] = [];
 	const lastAssistantIndex = findLastAssistantMessageIndex(messages);
+	const lastUserIndex = findLastUserMessageIndex(messages);
 
 	for (
 		let messageIndex = 0;
@@ -1591,6 +1592,7 @@ function collectBlockRemovalCandidates(
 				message,
 				messageIndex,
 				lastAssistantIndex,
+				lastUserIndex,
 			);
 			if (block.type === "tool_use") {
 				candidates.push({
@@ -1633,15 +1635,26 @@ function getDropPriority(
 	message: Message,
 	messageIndex: number,
 	lastAssistantIndex: number,
+	lastUserIndex: number,
 ): number {
+	// Lower values are dropped first:
+	// 0 older assistants, 1 middle users, 2 last assistant, 3 first user,
+	// 4 latest user (the typed prompt for the current turn).
 	if (message.role === "assistant" && messageIndex !== lastAssistantIndex) {
 		return 0;
 	}
-	if (message.role === "user" && messageIndex !== 0) {
+	if (
+		message.role === "user" &&
+		messageIndex !== 0 &&
+		messageIndex !== lastUserIndex
+	) {
 		return 1;
 	}
 	if (message.role === "assistant") {
 		return 2;
+	}
+	if (message.role === "user" && messageIndex === lastUserIndex) {
+		return 4;
 	}
 	return 3;
 }
@@ -1649,6 +1662,15 @@ function getDropPriority(
 function findLastAssistantMessageIndex(messages: Message[]): number {
 	for (let index = messages.length - 1; index >= 0; index -= 1) {
 		if (messages[index].role === "assistant") {
+			return index;
+		}
+	}
+	return -1;
+}
+
+function findLastUserMessageIndex(messages: Message[]): number {
+	for (let index = messages.length - 1; index >= 0; index -= 1) {
+		if (messages[index].role === "user") {
 			return index;
 		}
 	}

--- a/sdk/packages/core/src/session/services/message-builder.ts
+++ b/sdk/packages/core/src/session/services/message-builder.ts
@@ -1296,6 +1296,8 @@ function countProviderRequestBytes(messages: Message[]): number {
  * `tool_use.input`.
  *
  * What IS excluded from string truncation:
+ * - `thinking.thinking` — signatures/details are tied to the original
+ *   reasoning payload. Handled by block removal in pass 2.
  * - `redacted_thinking.data` — Anthropic-encrypted opaque blob; truncation
  *   produces invalid data. Handled by block removal in pass 2.
  * - `image.data` and tool-result image entries — raw base64; truncation
@@ -1342,21 +1344,12 @@ function collectEmergencyCandidates(
 				});
 				continue;
 			}
-			if (block.type === "thinking") {
-				candidates.push({
-					byteLength: utf8ByteLength(block.thinking),
-					get: () => block.thinking,
-					set: (value) => {
-						block.thinking = value;
-					},
-				});
-				continue;
-			}
-			if (block.type === "redacted_thinking") {
-				// `data` is an Anthropic-encrypted opaque blob. Middle-
-				// truncating it produces binary garbage that the provider
-				// rejects with a 400. Exclude from string truncation;
-				// collectBlockRemovalCandidates handles whole-block removal.
+			if (block.type === "thinking" || block.type === "redacted_thinking") {
+				// `thinking` signatures/details and `redacted_thinking.data`
+				// are paired with the original payload. Middle-truncating
+				// either can make the provider reject the request. Exclude
+				// from string truncation; collectBlockRemovalCandidates
+				// handles whole-block removal.
 				continue;
 			}
 			if (block.type === "file") {


### PR DESCRIPTION
### Related Issue

**Issue:** CLINE-2192 — Absolute hard guarantee: provider request can never exceed maxInputTokens (Layer B)

Stacked on: #10747 → #10740 → #10739

### Description

Adds the Layer B hard byte-budget guarantee for provider requests. After Layer 0/#10739, Layer 1/#10740, and Layer A/#10747 handle common context-bloat cases, this PR adds the final emergency pass that runs after Layer A and forces the serialized provider request under the model-derived byte budget.

Current implementation includes:

- `BuildForApiOptions` support for status notices, telemetry, session/provider/model identity, and request-overhead-aware budgeting.
- `task.emergency_truncation` telemetry via `captureEmergencyTruncation`.
- `task.request_overhead_exceeds_budget` telemetry for the rare case where non-message request payload alone exceeds the budget.
- Emergency truncation of string-bearing blocks, including structured truncation of `tool_use.input` string leaves while preserving provider-level identifiers, keys, booleans, numbers, nulls, arrays, and object shape.
- Explicit exclusion of `thinking`, `redacted_thinking`, and image data from string-leaf truncation; those are handled only by whole-block removal to avoid provider 400s from corrupted signatures, encrypted blobs, or base64.
- Deterministic block-removal fallback that preserves atomic tool-use/tool-result pairs, prefers dropping older content first, and keeps the latest user prompt after the last assistant in the final drop order.
- Full-request byte accounting in `SessionRuntime` with a bounded retry loop that measures the actual serialized `AgentModelRequest` including `systemPrompt`, `tools`, `options`, and codec/framing overhead.
- Buffered emergency notices/telemetry in the retry loop so only the final returned attempt can emit a user-visible notice or telemetry event.

### Test Procedure

Verified locally:

```sh
bun test sdk/packages/core/src/session/services/message-builder.test.ts sdk/packages/core/src/runtime/orchestration/session-runtime-orchestrator.test.ts sdk/packages/core/src/services/telemetry/core-events.test.ts sdk/packages/core/src/extensions/context/compaction.test.ts
cd sdk && bun --filter @cline/core typecheck
git diff --check
```

Results:

- Focused compaction/message-builder/orchestrator/telemetry suite: 144 passed.
- `@cline/core` typecheck passed.
- `git diff --check` passed.
- Commit hooks also passed `bun run types` and Biome checks on staged files.
- Claude consultation accepted the final architecture and follow-up fixes.
- Greptile feedback has been addressed and re-triggered across the stack.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing and code is formatted/linted for the touched SDK files
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A — backend data-shaping change.

### Additional Notes

Policy decision from the user: degrade, never hard-error. If emergency truncation fires, the user receives a visible status notice (`compacted to fit context window`) and telemetry records `task.emergency_truncation`.

### Diagram

```text
PR #10759 / CLINE-2192
Layer B: hard serialized-byte guarantee

Full provider request:
  {
    model,
    system,
    tools,
    messages,
    ...
  }
        |
        v
  JSON.stringify request
        |
        v
  actual byte size <= maxInputTokens * 3 ?
        |
   +----+----+
   |         |
  yes       no
   |         |
   v         v
 return   emergency pass 1
          middle-truncate remaining safe string leaves
          skip:
            - thinking
            - redacted_thinking.data
            - image.data
              |
              v
          remeasure serialized request
              |
              v
          still too large?
              |
          +---+---+
          |       |
         no      yes
          |       |
          v       v
        return  emergency pass 2
                drop whole blocks/messages by priority:
                  1. oldest tool results / older assistant blocks
                  2. older middle user blocks
                  3. last assistant if necessary
                  4. first user
                  5. latest user only as final resort
                    |
                    v
                prune empty messages
                    |
                    v
                return payload under hard byte budget
```