### PR TITLE
Add SDK telemetry for run_commands timeouts

### DIFF
--- a/docs/getting-started/config.mdx
+++ b/docs/getting-started/config.mdx
@@ -83,6 +83,11 @@ From there, you can view/edit:
 - Skills
 - Hooks
 
+The Settings view includes `Run Command timeout`, stored globally as
+`runCommandsTimeoutMs` in `~/.cline/data/settings/global-settings.json`. The
+value is in milliseconds, defaults to `30000`, and is capped at `2147483647`.
+The TUI cycles preset values for quick edits.
+
 ## Useful Configuration Commands
 
 Use a custom configuration directory:

--- a/docs/sdk/tools.mdx
+++ b/docs/sdk/tools.mdx
@@ -22,6 +22,33 @@ Tools are functions the model can call during execution. Tools consist of a name
 | `ask_question` | Ask the user for input |
 | `submit_and_exit` | Submit a final answer and stop |
 
+### `run_commands` timeout
+
+`run_commands` accepts an optional per-command `timeout` in milliseconds on structured command entries. Plain string commands use the configured default.
+
+```json
+{
+  "commands": [{ "command": "bun", "args": ["install"], "timeout": 120000 }]
+}
+```
+
+Defaults and bounds:
+
+- default: `30000` ms
+- minimum: `1000` ms
+- maximum: `3600000` ms
+- type: integer milliseconds
+- scope: per structured command entry
+
+Do not put `timeout` at the top level of the tool call. The `commands` array runs concurrently, so each command resolves its own timeout from `command.timeout` or the configured default.
+
+```json
+{
+  "commands": ["bun install"],
+  "timeout": 120000
+}
+```
+
 ### `run_commands` timeout telemetry
 
 When the built-in `run_commands` tool hits a timeout, the SDK emits a dedicated telemetry event:

--- a/docs/sdk/tools.mdx
+++ b/docs/sdk/tools.mdx
@@ -22,6 +22,43 @@ Tools are functions the model can call during execution. Tools consist of a name
 | `ask_question` | Ask the user for input |
 | `submit_and_exit` | Submit a final answer and stop |
 
+### `run_commands` timeout telemetry
+
+When the built-in `run_commands` tool hits a timeout, the SDK emits a dedicated telemetry event:
+
+- event: `sdk.tool_timeout`
+- `tool_name`: always `run_commands`
+- `effective_timeout_ms`: the timeout that actually fired
+- `timeout_source`: `default_setting` or `command_parameter`
+- `command_count`: number of commands in the tool call
+- `command_index`: zero-based index when the timeout is attributable to one command
+- `duration_ms`: observed duration before timeout handling
+- optional context when available: `mode`, `source`, `session_id`, `agent_id`, `conversation_id`, `run_id`, `iteration`, `tool_call_id`
+
+Privacy note:
+
+- the SDK does **not** include raw command text
+- the SDK does **not** include stdout/stderr
+- the SDK does **not** include env vars, workspace paths, API keys, or tokens
+
+Example payload:
+
+```json
+{
+  "event": "sdk.tool_timeout",
+  "properties": {
+    "tool_name": "run_commands",
+    "effective_timeout_ms": 5000,
+    "timeout_source": "command_parameter",
+    "command_count": 2,
+    "command_index": 1,
+    "duration_ms": 5004,
+    "mode": "act",
+    "source": "cli"
+  }
+}
+```
+
 <Note>
   If you need more control you can use the `Agents` package directly. This does not include built-in tools. You pass in only the tools you want when constructing the agent.
 </Note>

--- a/sdk/packages/core/scripts/telemetry-smoke.ts
+++ b/sdk/packages/core/scripts/telemetry-smoke.ts
@@ -240,8 +240,11 @@ async function main() {
 			iteration: 1,
 		});
 		dumpEvents(t.events);
-		const dump = JSON.stringify(t.events[0]?.properties ?? {});
-		assertSmoke("run_commands timeout omits raw command field", dump.includes("command"), false);
+		const payload = t.events[0]?.properties ?? {};
+		assertSmoke("run_commands timeout omits raw command field", "command" in payload, false);
+		assertSmoke("run_commands timeout omits raw commands field", "commands" in payload, false);
+		assertSmoke("run_commands timeout omits stdout field", "stdout" in payload, false);
+		assertSmoke("run_commands timeout omits stderr field", "stderr" in payload, false);
 	}
 
 	header("explicit captureWorkspacePathResolved payload sample");

--- a/sdk/packages/core/scripts/telemetry-smoke.ts
+++ b/sdk/packages/core/scripts/telemetry-smoke.ts
@@ -1,12 +1,13 @@
 /**
  * Telemetry smoke test for ENG-1902.
  *
- * Runs each activation/workspace funnel event through the SDK telemetry
- * helpers using a minimal capturing telemetry service. Prints the captured
- * event names and event-specific payloads so a human can verify no raw
- * paths leak and that the legacy snake_case schema is preserved. Activation
- * and workspace events are routed through normal `capture` so they respect
- * the user's telemetry opt-out setting.
+ * Runs each activation/workspace funnel event and the run_commands timeout
+ * event through the SDK telemetry helpers using a minimal capturing telemetry
+ * service. Prints the captured event names and event-specific payloads so a
+ * human can verify no raw paths, command text, stdout, stderr, env vars, or
+ * secrets leak and that the legacy snake_case schema is preserved. Activation,
+ * workspace, and timeout events are routed through normal `capture` so they
+ * respect the user's telemetry opt-out setting.
  *
  * Usage:
  *   bunx --bun tsx packages/core/scripts/telemetry-smoke.ts
@@ -241,10 +242,26 @@ async function main() {
 		});
 		dumpEvents(t.events);
 		const payload = t.events[0]?.properties ?? {};
-		assertSmoke("run_commands timeout omits raw command field", "command" in payload, false);
-		assertSmoke("run_commands timeout omits raw commands field", "commands" in payload, false);
-		assertSmoke("run_commands timeout omits stdout field", "stdout" in payload, false);
-		assertSmoke("run_commands timeout omits stderr field", "stderr" in payload, false);
+		assertSmoke(
+			"run_commands timeout omits raw command field",
+			"command" in payload,
+			false,
+		);
+		assertSmoke(
+			"run_commands timeout omits raw commands field",
+			"commands" in payload,
+			false,
+		);
+		assertSmoke(
+			"run_commands timeout omits stdout field",
+			"stdout" in payload,
+			false,
+		);
+		assertSmoke(
+			"run_commands timeout omits stderr field",
+			"stderr" in payload,
+			false,
+		);
 	}
 
 	header("explicit captureWorkspacePathResolved payload sample");

--- a/sdk/packages/core/scripts/telemetry-smoke.ts
+++ b/sdk/packages/core/scripts/telemetry-smoke.ts
@@ -17,6 +17,7 @@ import type { ITelemetryService, TelemetryProperties } from "@cline/shared";
 import {
 	captureConversationTurnEvent,
 	captureExtensionActivated,
+	captureRunCommandsTimeout,
 	captureTaskCompleted,
 	captureTaskCreated,
 	captureTaskRestarted,
@@ -220,6 +221,27 @@ async function main() {
 			{ fallback_to_single_root: true, workspace_count: 0 },
 		);
 		dumpEvents(t.events);
+	}
+
+	header("explicit sdk.tool_timeout payload sample (run_commands)");
+	{
+		const t = new CapturingTelemetry();
+		captureRunCommandsTimeout(asITelemetryService(t), {
+			tool_name: "run_commands",
+			effective_timeout_ms: 5000,
+			timeout_source: "command_parameter",
+			command_count: 2,
+			command_index: 1,
+			duration_ms: 5004,
+			mode: "act",
+			source: "smoke",
+			session_id: "session-smoke",
+			agent_id: "agent-smoke",
+			iteration: 1,
+		});
+		dumpEvents(t.events);
+		const dump = JSON.stringify(t.events[0]?.properties ?? {});
+		assertSmoke("run_commands timeout omits raw command field", dump.includes("command"), false);
 	}
 
 	header("explicit captureWorkspacePathResolved payload sample");

--- a/sdk/packages/core/scripts/telemetry-smoke.ts
+++ b/sdk/packages/core/scripts/telemetry-smoke.ts
@@ -232,7 +232,6 @@ async function main() {
 			effective_timeout_ms: 5000,
 			timeout_source: "command_parameter",
 			command_count: 2,
-			command_index: 1,
 			duration_ms: 5004,
 			mode: "act",
 			source: "smoke",

--- a/sdk/packages/core/src/extensions/tools/definitions.test.ts
+++ b/sdk/packages/core/src/extensions/tools/definitions.test.ts
@@ -918,7 +918,9 @@ describe("default run_commands tool", () => {
 		);
 
 		expect(telemetry.capture).toHaveBeenCalled();
-		const timeoutCalls = (telemetry.capture as ReturnType<typeof vi.fn>).mock.calls
+		const timeoutCalls = (
+			telemetry.capture as ReturnType<typeof vi.fn>
+		).mock.calls
 			.map((call) => call[0])
 			.filter((event) => event.event === "sdk.tool_timeout");
 		expect(timeoutCalls).toHaveLength(2);
@@ -949,6 +951,74 @@ describe("default run_commands tool", () => {
 			expect(payload).not.toContain("env");
 			expect(call.properties).not.toHaveProperty("timeout_origin");
 		}
+	});
+
+	it("emits timeout telemetry for default-setting timeouts", async () => {
+		const execute = vi.fn(
+			async (): Promise<string> =>
+				await new Promise((resolve) => setTimeout(() => resolve("ok"), 20)),
+		);
+		const tool = createWindowsShellTool(execute, { bashTimeoutMs: 5 });
+		const telemetry = createTelemetryStub();
+
+		await tool.execute({ commands: ["echo slow"] } as never, {
+			agentId: "agent-1",
+			conversationId: "conv-1",
+			iteration: 1,
+			metadata: { telemetry },
+		});
+
+		const timeoutCalls = (
+			telemetry.capture as ReturnType<typeof vi.fn>
+		).mock.calls
+			.map((call) => call[0])
+			.filter((event) => event.event === "sdk.tool_timeout");
+		expect(timeoutCalls).toHaveLength(1);
+		expect(timeoutCalls[0]?.properties).toMatchObject({
+			effective_timeout_ms: 5,
+			timeout_source: "default_setting",
+		});
+		expect(timeoutCalls[0]?.properties).not.toHaveProperty("timeout_origin");
+	});
+
+	it("emits timeout telemetry for TimeoutError without matching plain error text", async () => {
+		const executorTimeout = vi.fn(async () => {
+			throw new TimeoutError("Command timed out after 5000ms");
+		});
+		const plainFailure = vi.fn(async () => {
+			throw new Error("Command timed out after 5000ms");
+		});
+		const telemetry = createTelemetryStub();
+
+		await createWindowsShellTool(executorTimeout, {
+			bashTimeoutMs: 5000,
+		}).execute({ commands: ["echo timeout"] } as never, {
+			agentId: "agent-1",
+			conversationId: "conv-1",
+			iteration: 1,
+			metadata: { telemetry },
+		});
+		await createWindowsShellTool(plainFailure, { bashTimeoutMs: 5000 }).execute(
+			{ commands: ["echo not-timeout"] } as never,
+			{
+				agentId: "agent-1",
+				conversationId: "conv-1",
+				iteration: 2,
+				metadata: { telemetry },
+			},
+		);
+
+		const timeoutCalls = (
+			telemetry.capture as ReturnType<typeof vi.fn>
+		).mock.calls
+			.map((call) => call[0])
+			.filter((event) => event.event === "sdk.tool_timeout");
+		expect(timeoutCalls).toHaveLength(1);
+		expect(timeoutCalls[0]?.properties).toMatchObject({
+			effective_timeout_ms: 5000,
+			timeout_source: "default_setting",
+		});
+		expect(timeoutCalls[0]?.properties).not.toHaveProperty("timeout_origin");
 	});
 
 	it("does not emit timeout telemetry for normal command success", async () => {
@@ -988,9 +1058,9 @@ describe("default run_commands tool", () => {
 			(telemetry.capture as ReturnType<typeof vi.fn>).mock.calls
 				.map((call) => call[0])
 				.filter((event) => event.event === "sdk.tool_timeout"),
-			).toEqual([]);
-		});
+		).toEqual([]);
 	});
+});
 
 describe("default read_files tool", () => {
 	it("normalizes ranged file requests and passes them to the executor", async () => {

--- a/sdk/packages/core/src/extensions/tools/definitions.test.ts
+++ b/sdk/packages/core/src/extensions/tools/definitions.test.ts
@@ -929,7 +929,6 @@ describe("default run_commands tool", () => {
 			effective_timeout_ms: 120000,
 			timeout_source: "command_parameter",
 			command_count: 2,
-			command_index: 0,
 			mode: "act",
 			source: "sdk-test",
 		});
@@ -938,7 +937,6 @@ describe("default run_commands tool", () => {
 			effective_timeout_ms: 5,
 			timeout_source: "default_setting",
 			command_count: 2,
-			command_index: 1,
 			mode: "act",
 			source: "sdk-test",
 		});

--- a/sdk/packages/core/src/extensions/tools/definitions.test.ts
+++ b/sdk/packages/core/src/extensions/tools/definitions.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import type { ITelemetryService } from "@cline/shared";
 import {
 	createBashTool,
 	createBuiltinTools,
@@ -8,7 +9,7 @@ import {
 	createWindowsShellTool,
 } from ".";
 import { MAX_RUN_COMMANDS_TIMEOUT_MS } from "./constants";
-import { withTimeout } from "./helpers";
+import { TimeoutError, withTimeout } from "./helpers";
 import {
 	INPUT_ARG_CHAR_LIMIT,
 	RunCommandsInputSchema,
@@ -419,6 +420,16 @@ describe("default apply_patch tool", () => {
 });
 
 describe("default run_commands tool", () => {
+	function createTelemetryStub(): ITelemetryService {
+		return {
+			capture: vi.fn(),
+			captureRequired: vi.fn(),
+			setDistinctId: vi.fn(),
+			updateCommonProperties: vi.fn(),
+			identify: vi.fn(),
+		} as unknown as ITelemetryService;
+	}
+
 	it("clears wrapper timers after fast commands resolve", async () => {
 		vi.useFakeTimers();
 		try {
@@ -870,7 +881,116 @@ describe("default run_commands tool", () => {
 
 		expect(tool.timeoutMs).toBe(MAX_RUN_COMMANDS_TIMEOUT_MS);
 	});
-});
+
+	it("emits timeout telemetry per timed-out command without leaking raw command data", async () => {
+		const execute = vi.fn(
+			async (
+				_command: unknown,
+				_cwd: string,
+				_context: unknown,
+				timeoutMs?: number,
+			): Promise<string> => {
+				throw new TimeoutError(`Command timed out after ${timeoutMs}ms`);
+			},
+		);
+		const tool = createWindowsShellTool(execute, { bashTimeoutMs: 5 });
+		const telemetry = createTelemetryStub();
+
+		await tool.execute(
+			{
+				commands: [
+					{ command: "echo", args: ["secret-token"], timeout: 120000 },
+					"pwd",
+				],
+			} as never,
+			{
+				agentId: "agent-1",
+				conversationId: "conv-1",
+				runId: "run-1",
+				iteration: 1,
+				toolCallId: "tool-call-1",
+				metadata: {
+					telemetry,
+					mode: "act",
+					source: "sdk-test",
+				},
+			},
+		);
+
+		expect(telemetry.capture).toHaveBeenCalled();
+		const timeoutCalls = (telemetry.capture as ReturnType<typeof vi.fn>).mock.calls
+			.map((call) => call[0])
+			.filter((event) => event.event === "sdk.tool_timeout");
+		expect(timeoutCalls).toHaveLength(2);
+		expect(timeoutCalls[0].properties).toMatchObject({
+			tool_name: "run_commands",
+			effective_timeout_ms: 120000,
+			timeout_source: "command_parameter",
+			command_count: 2,
+			command_index: 0,
+			mode: "act",
+			source: "sdk-test",
+		});
+		expect(timeoutCalls[1].properties).toMatchObject({
+			tool_name: "run_commands",
+			effective_timeout_ms: 5,
+			timeout_source: "default_setting",
+			command_count: 2,
+			command_index: 1,
+			mode: "act",
+			source: "sdk-test",
+		});
+		for (const call of timeoutCalls) {
+			const payload = JSON.stringify(call.properties);
+			expect(payload).not.toContain("echo secret-token");
+			expect(payload).not.toContain("pwd");
+			expect(payload).not.toContain("stdout");
+			expect(payload).not.toContain("stderr");
+			expect(payload).not.toContain("env");
+			expect(call.properties).not.toHaveProperty("timeout_origin");
+		}
+	});
+
+	it("does not emit timeout telemetry for normal command success", async () => {
+		const execute = vi.fn(async () => "ok");
+		const tool = createWindowsShellTool(execute, { bashTimeoutMs: 50 });
+		const telemetry = createTelemetryStub();
+
+		await tool.execute({ commands: ["echo hi"] } as never, {
+			agentId: "agent-1",
+			conversationId: "conv-1",
+			iteration: 1,
+			metadata: { telemetry },
+		});
+
+		expect(
+			(telemetry.capture as ReturnType<typeof vi.fn>).mock.calls
+				.map((call) => call[0])
+				.filter((event) => event.event === "sdk.tool_timeout"),
+		).toEqual([]);
+	});
+
+	it("does not emit timeout telemetry for normal non-timeout failures", async () => {
+		const execute = vi.fn(async () => {
+			throw new Error("exit code 1");
+		});
+		const tool = createWindowsShellTool(execute, { bashTimeoutMs: 50 });
+		const telemetry = createTelemetryStub();
+
+		await tool.execute({ commands: ["false"] } as never, {
+			agentId: "agent-1",
+			conversationId: "conv-1",
+			iteration: 1,
+			metadata: { telemetry },
+		});
+
+		expect(
+			(telemetry.capture as ReturnType<typeof vi.fn>).mock.calls
+				.map((call) => call[0])
+				.filter((event) => event.event === "sdk.tool_timeout"),
+			).toEqual([]);
+		});
+	});
 
 describe("default read_files tool", () => {
 	it("normalizes ranged file requests and passes them to the executor", async () => {

--- a/sdk/packages/core/src/extensions/tools/definitions.ts
+++ b/sdk/packages/core/src/extensions/tools/definitions.ts
@@ -8,6 +8,7 @@ import {
 	type AgentTool,
 	type AgentToolContext,
 	createTool,
+	type ITelemetryService,
 	validateWithZod,
 	zodToJsonSchema,
 } from "@cline/shared";
@@ -49,6 +50,7 @@ import {
 	type SkillsInput,
 	SkillsInputSchema,
 	type StructuredCommandInput,
+	type StructuredCommandsInput,
 	StructuredCommandsInputSchema,
 	StructuredCommandsInputUnionSchema,
 	type SubmitInput,
@@ -82,40 +84,6 @@ function isRunCommandsTimeoutError(error: unknown, timeoutMs: number): boolean {
 		error instanceof TimeoutError &&
 		error.message === `Command timed out after ${timeoutMs}ms`
 	);
-}
-
-function captureRunCommandsTimeoutFromContext(
-	context: AgentToolContext,
-	properties: {
-		effectiveTimeoutMs: number;
-		timeoutSource: "default_setting" | "command_parameter";
-		commandCount: number;
-		commandIndex: number;
-		durationMs: number;
-	},
-): void {
-	captureRunCommandsTimeout((context.metadata?.telemetry as never) ?? undefined, {
-		tool_name: "run_commands",
-		effective_timeout_ms: properties.effectiveTimeoutMs,
-		timeout_source: properties.timeoutSource,
-		command_count: properties.commandCount,
-		command_index: properties.commandIndex,
-		duration_ms: properties.durationMs,
-		mode:
-			typeof context.metadata?.mode === "string"
-				? context.metadata.mode
-				: undefined,
-		source:
-			typeof context.metadata?.source === "string"
-				? context.metadata.source
-				: undefined,
-		session_id: context.sessionId,
-		agent_id: context.agentId,
-		conversation_id: context.conversationId,
-		run_id: context.runId,
-		iteration: context.iteration,
-		tool_call_id: context.toolCallId,
-	});
 }
 
 /**
@@ -244,6 +212,54 @@ export function createSearchTool(
 	});
 }
 
+function getTelemetryFromMetadata(
+	metadata: AgentToolContext["metadata"],
+): ITelemetryService | undefined {
+	const telemetry = metadata?.telemetry;
+	if (!telemetry || typeof telemetry !== "object") {
+		return undefined;
+	}
+
+	const candidate = telemetry as Partial<ITelemetryService>;
+	return typeof candidate.capture === "function" &&
+		typeof candidate.captureRequired === "function"
+		? (telemetry as ITelemetryService)
+		: undefined;
+}
+
+function captureRunCommandsTimeoutFromContext(
+	context: AgentToolContext,
+	properties: {
+		effectiveTimeoutMs: number;
+		timeoutSource: "default_setting" | "command_parameter";
+		commandCount: number;
+		commandIndex: number;
+		durationMs: number;
+	},
+): void {
+	captureRunCommandsTimeout(getTelemetryFromMetadata(context.metadata), {
+		tool_name: "run_commands",
+		effective_timeout_ms: properties.effectiveTimeoutMs,
+		timeout_source: properties.timeoutSource,
+		command_count: properties.commandCount,
+		command_index: properties.commandIndex,
+		duration_ms: properties.durationMs,
+		mode:
+			typeof context.metadata?.mode === "string"
+				? context.metadata.mode
+				: undefined,
+		source:
+			typeof context.metadata?.source === "string"
+				? context.metadata.source
+				: undefined,
+		session_id: context.sessionId,
+		agent_id: context.agentId,
+		conversation_id: context.conversationId,
+		run_id: context.runId,
+		iteration: context.iteration,
+		tool_call_id: context.toolCallId,
+	});
+}
 /**
  * Create the run_commands tool
  *
@@ -330,12 +346,12 @@ export function createBashTool(
 export function createWindowsShellTool(
 	executor: BashExecutor,
 	config: Pick<DefaultToolsConfig, "cwd" | "bashTimeoutMs"> = {},
-): AgentTool<StructuredCommandInput, ToolOperationResult[]> {
+): AgentTool<StructuredCommandsInput, ToolOperationResult[]> {
 	const defaultTimeoutMs =
 		config.bashTimeoutMs ?? DEFAULT_RUN_COMMANDS_TIMEOUT_MS;
 	const cwd = config.cwd ?? process.cwd();
 
-	return createTool<StructuredCommandInput, ToolOperationResult[]>({
+	return createTool<StructuredCommandsInput, ToolOperationResult[]>({
 		name: "run_commands",
 		description:
 			"Run shell commands from the root of the workspace in a Windows environment. " +

--- a/sdk/packages/core/src/extensions/tools/definitions.ts
+++ b/sdk/packages/core/src/extensions/tools/definitions.ts
@@ -49,7 +49,6 @@ import {
 	SearchCodebaseUnionInputSchema,
 	type SkillsInput,
 	SkillsInputSchema,
-	type StructuredCommandInput,
 	type StructuredCommandsInput,
 	StructuredCommandsInputSchema,
 	StructuredCommandsInputUnionSchema,

--- a/sdk/packages/core/src/extensions/tools/definitions.ts
+++ b/sdk/packages/core/src/extensions/tools/definitions.ts
@@ -232,7 +232,6 @@ function captureRunCommandsTimeoutFromContext(
 		effectiveTimeoutMs: number;
 		timeoutSource: "default_setting" | "command_parameter";
 		commandCount: number;
-		commandIndex: number;
 		durationMs: number;
 	},
 ): void {
@@ -241,7 +240,6 @@ function captureRunCommandsTimeoutFromContext(
 		effective_timeout_ms: properties.effectiveTimeoutMs,
 		timeout_source: properties.timeoutSource,
 		command_count: properties.commandCount,
-		command_index: properties.commandIndex,
 		duration_ms: properties.durationMs,
 		mode:
 			typeof context.metadata?.mode === "string"
@@ -296,10 +294,11 @@ export function createBashTool(
 
 			return Promise.all(
 				commands.map(
-					async (
-						{ command, timeoutMs, timeoutSource },
-						commandIndex,
-					): Promise<ToolOperationResult> => {
+					async ({
+						command,
+						timeoutMs,
+						timeoutSource,
+					}): Promise<ToolOperationResult> => {
 						const startedAt = Date.now();
 						try {
 							const output = await withTimeout(
@@ -318,7 +317,6 @@ export function createBashTool(
 									effectiveTimeoutMs: timeoutMs,
 									timeoutSource,
 									commandCount: commands.length,
-									commandIndex,
 									durationMs: Date.now() - startedAt,
 								});
 							}
@@ -377,10 +375,11 @@ export function createWindowsShellTool(
 
 			return Promise.all(
 				commands.map(
-					async (
-						{ command, timeoutMs, timeoutSource },
-						commandIndex,
-					): Promise<ToolOperationResult> => {
+					async ({
+						command,
+						timeoutMs,
+						timeoutSource,
+					}): Promise<ToolOperationResult> => {
 						const startedAt = Date.now();
 						try {
 							const output = await withTimeout(
@@ -399,7 +398,6 @@ export function createWindowsShellTool(
 									effectiveTimeoutMs: timeoutMs,
 									timeoutSource,
 									commandCount: commands.length,
-									commandIndex,
 									durationMs: Date.now() - startedAt,
 								});
 							}

--- a/sdk/packages/core/src/extensions/tools/definitions.ts
+++ b/sdk/packages/core/src/extensions/tools/definitions.ts
@@ -6,10 +6,12 @@
 
 import {
 	type AgentTool,
+	type AgentToolContext,
 	createTool,
 	validateWithZod,
 	zodToJsonSchema,
 } from "@cline/shared";
+import { captureRunCommandsTimeout } from "../../services/telemetry/core-events";
 import {
 	assertNoTopLevelRunCommandsTimeout,
 	formatError,
@@ -19,6 +21,7 @@ import {
 	getReadFileRangeError,
 	normalizeReadFileRequests,
 	normalizeValidatedRunCommandsInputWithTimeouts,
+	TimeoutError,
 	withTimeout,
 } from "./helpers";
 import {
@@ -73,6 +76,47 @@ import type {
 // =============================================================================
 // AgentTool Factory Functions
 // =============================================================================
+
+function isRunCommandsTimeoutError(error: unknown, timeoutMs: number): boolean {
+	return (
+		error instanceof TimeoutError &&
+		error.message === `Command timed out after ${timeoutMs}ms`
+	);
+}
+
+function captureRunCommandsTimeoutFromContext(
+	context: AgentToolContext,
+	properties: {
+		effectiveTimeoutMs: number;
+		timeoutSource: "default_setting" | "command_parameter";
+		commandCount: number;
+		commandIndex: number;
+		durationMs: number;
+	},
+): void {
+	captureRunCommandsTimeout((context.metadata?.telemetry as never) ?? undefined, {
+		tool_name: "run_commands",
+		effective_timeout_ms: properties.effectiveTimeoutMs,
+		timeout_source: properties.timeoutSource,
+		command_count: properties.commandCount,
+		command_index: properties.commandIndex,
+		duration_ms: properties.durationMs,
+		mode:
+			typeof context.metadata?.mode === "string"
+				? context.metadata.mode
+				: undefined,
+		source:
+			typeof context.metadata?.source === "string"
+				? context.metadata.source
+				: undefined,
+		session_id: context.sessionId,
+		agent_id: context.agentId,
+		conversation_id: context.conversationId,
+		run_id: context.runId,
+		iteration: context.iteration,
+		tool_call_id: context.toolCallId,
+	});
+}
 
 /**
  * Create the read_files tool
@@ -237,7 +281,11 @@ export function createBashTool(
 
 			return Promise.all(
 				commands.map(
-					async ({ command, timeoutMs }): Promise<ToolOperationResult> => {
+					async (
+						{ command, timeoutMs, timeoutSource },
+						commandIndex,
+					): Promise<ToolOperationResult> => {
+						const startedAt = Date.now();
 						try {
 							const output = await withTimeout(
 								executor(command, cwd, context, timeoutMs),
@@ -250,6 +298,15 @@ export function createBashTool(
 								success: true,
 							};
 						} catch (error) {
+							if (isRunCommandsTimeoutError(error, timeoutMs)) {
+								captureRunCommandsTimeoutFromContext(context, {
+									effectiveTimeoutMs: timeoutMs,
+									timeoutSource,
+									commandCount: commands.length,
+									commandIndex,
+									durationMs: Date.now() - startedAt,
+								});
+							}
 							const msg = formatError(error);
 							return {
 								query: formatRunCommandQuery(command),
@@ -305,7 +362,11 @@ export function createWindowsShellTool(
 
 			return Promise.all(
 				commands.map(
-					async ({ command, timeoutMs }): Promise<ToolOperationResult> => {
+					async (
+						{ command, timeoutMs, timeoutSource },
+						commandIndex,
+					): Promise<ToolOperationResult> => {
+						const startedAt = Date.now();
 						try {
 							const output = await withTimeout(
 								executor(command, cwd, context, timeoutMs),
@@ -318,6 +379,15 @@ export function createWindowsShellTool(
 								success: true,
 							};
 						} catch (error) {
+							if (isRunCommandsTimeoutError(error, timeoutMs)) {
+								captureRunCommandsTimeoutFromContext(context, {
+									effectiveTimeoutMs: timeoutMs,
+									timeoutSource,
+									commandCount: commands.length,
+									commandIndex,
+									durationMs: Date.now() - startedAt,
+								});
+							}
 							const msg = formatError(error);
 							return {
 								query: formatRunCommandQuery(command),

--- a/sdk/packages/core/src/extensions/tools/helpers.ts
+++ b/sdk/packages/core/src/extensions/tools/helpers.ts
@@ -11,6 +11,7 @@ import {
 export interface NormalizedRunCommand {
 	command: string | StructuredCommandInput;
 	timeoutMs: number;
+	timeoutSource: "default_setting" | "command_parameter";
 }
 
 const TOP_LEVEL_TIMEOUT_ERROR =
@@ -215,12 +216,17 @@ function normalizeRunCommandWithTimeout(
 	command: string | StructuredCommandInput,
 	defaultTimeoutMs: number,
 ): NormalizedRunCommand {
+	const timeoutSource =
+		typeof command !== "string" && command.timeout != null
+			? "command_parameter"
+			: "default_setting";
 	return {
 		command:
 			typeof command === "string"
 				? command
 				: normalizeStructuredCommandInput(command),
 		timeoutMs: resolveCommandTimeoutMs(command, defaultTimeoutMs),
+		timeoutSource,
 	};
 }
 

--- a/sdk/packages/core/src/extensions/tools/schemas.ts
+++ b/sdk/packages/core/src/extensions/tools/schemas.ts
@@ -329,6 +329,9 @@ export type RunCommandsInput = z.infer<typeof RunCommandsInputSchema>;
 export type StructuredCommandInput = z.infer<
 	typeof StructuredCommandInputSchema
 >;
+export type StructuredCommandsInput = z.infer<
+	typeof StructuredCommandsInputUnionSchema
+>;
 
 /**
  * Web fetch request parameters

--- a/sdk/packages/core/src/runtime/orchestration/session-runtime-orchestrator.test.ts
+++ b/sdk/packages/core/src/runtime/orchestration/session-runtime-orchestrator.test.ts
@@ -659,10 +659,15 @@ describe("SessionRuntime message preparation", () => {
 it("derives tool image support metadata from resolved provider model catalog", async () => {
 	const { deps, configs } = withCapturingFakeRuntime();
 	const execute = vi.fn(async () => "ok");
+	const telemetry = {
+		capture: vi.fn(),
+		captureRequired: vi.fn(),
+	} as unknown as AgentConfig["telemetry"];
 	const session = new SessionRuntime(
 		makeAgentConfig({
 			providerId: "cline",
 			modelId: "anthropic/claude-sonnet-4.6",
+			telemetry,
 			tools: [
 				{
 					name: "read_file",
@@ -712,7 +717,7 @@ it("derives tool image support metadata from resolved provider model catalog", a
 	expect(execute).toHaveBeenCalledTimes(1);
 	expect(execute.mock.calls[0]).toEqual([expect.anything(), toolContext]);
 	expect(runtimeConfig.toolContextMetadata).toEqual(
-		expect.objectContaining({ modelSupportsImages: true }),
+		expect.objectContaining({ modelSupportsImages: true, telemetry }),
 	);
 });
 

--- a/sdk/packages/core/src/runtime/orchestration/session-runtime-orchestrator.ts
+++ b/sdk/packages/core/src/runtime/orchestration/session-runtime-orchestrator.ts
@@ -753,6 +753,7 @@ export class SessionRuntime {
 				modelSupportsImages:
 					modelInfo?.capabilities?.includes("images") ?? true,
 				...this.config.toolContextMetadata,
+				telemetry: this.config.toolContextMetadata?.telemetry ?? this.telemetry,
 			},
 			hooks: this.createRuntimeHooks(),
 			prepareTurn: this.createRuntimePrepareTurn(modelInfo, tools),

--- a/sdk/packages/core/src/services/telemetry/core-events.test.ts
+++ b/sdk/packages/core/src/services/telemetry/core-events.test.ts
@@ -351,7 +351,6 @@ describe("captureRunCommandsTimeout", () => {
 			effective_timeout_ms: 1500,
 			timeout_source: "command_parameter",
 			command_count: 2,
-			command_index: 1,
 			duration_ms: 1502,
 			mode: "act",
 			source: "sdk-test",
@@ -371,7 +370,6 @@ describe("captureRunCommandsTimeout", () => {
 			effective_timeout_ms: 1500,
 			timeout_source: "command_parameter",
 			command_count: 2,
-			command_index: 1,
 			duration_ms: 1502,
 			mode: "act",
 			source: "sdk-test",
@@ -548,7 +546,6 @@ describe("telemetry policy: helpers respect telemetry opt-out", () => {
 			effective_timeout_ms: 1500,
 			timeout_source: "command_parameter",
 			command_count: 2,
-			command_index: 1,
 			duration_ms: 1502,
 		});
 		expect(emitRequired).not.toHaveBeenCalled();
@@ -630,7 +627,6 @@ describe("telemetry policy: helpers respect telemetry opt-out", () => {
 			effective_timeout_ms: 1500,
 			timeout_source: "command_parameter",
 			command_count: 2,
-			command_index: 1,
 			duration_ms: 1502,
 		});
 		expect(observed).toEqual([]);

--- a/sdk/packages/core/src/services/telemetry/core-events.test.ts
+++ b/sdk/packages/core/src/services/telemetry/core-events.test.ts
@@ -6,6 +6,7 @@ import {
 	captureCompactionSkipped,
 	captureExtensionActivated,
 	captureProviderConfigured,
+	captureRunCommandsTimeout,
 	captureTelemetryOptOut,
 	captureWorkspaceInitError,
 	captureWorkspaceInitialized,
@@ -76,18 +77,13 @@ describe("captureTelemetryOptOut", () => {
 });
 
 describe("captureProviderConfigured", () => {
-	test("emits user.provider_configured with the provider id as a normal (opt-out-respecting) event", () => {
+	test("emits user.provider_configured with the provider id as a normal opt-out-respecting event", () => {
 		const stub = createTelemetryStub();
 		captureProviderConfigured(stub.telemetry, "anthropic");
 		expect(stub.capture).toHaveBeenCalledTimes(1);
-		// Must NOT be captureRequired — the BYO configure step is not an
-		// essential lifecycle event and should respect telemetry opt-out.
 		expect(stub.captureRequired).not.toHaveBeenCalled();
 		const { event, properties } = captureCallAt(stub, 0);
 		expect(event).toBe("user.provider_configured");
-		// Payload shape mirrors `captureAuthSucceeded`: `{ provider }`,
-		// nothing else. Keep this strict so we don't accidentally leak
-		// `apiKey` / `baseUrl` / model identifiers into the funnel.
 		expect(properties).toEqual({ provider: "anthropic" });
 	});
 
@@ -344,6 +340,54 @@ describe("captureCompactionSkipped", () => {
 
 	test("no-ops when telemetry is undefined", () => {
 		expect(() => captureCompactionSkipped(undefined, baseProps)).not.toThrow();
+	});
+});
+
+describe("captureRunCommandsTimeout", () => {
+	test("emits sdk.tool_timeout with sanitized timeout metadata", () => {
+		const stub = createTelemetryStub();
+		captureRunCommandsTimeout(stub.telemetry, {
+			tool_name: "run_commands",
+			effective_timeout_ms: 1500,
+			timeout_source: "command_parameter",
+			command_count: 2,
+			command_index: 1,
+			duration_ms: 1502,
+			mode: "act",
+			source: "sdk-test",
+			session_id: "session-1",
+			agent_id: "agent-1",
+			conversation_id: "conv-1",
+			run_id: "run-1",
+			iteration: 3,
+			tool_call_id: "tool-call-1",
+		});
+
+		expect(stub.capture).toHaveBeenCalledTimes(1);
+		const { event, properties } = captureCallAt(stub, 0);
+		expect(event).toBe(CORE_TELEMETRY_EVENTS.SDK.TOOL_TIMEOUT);
+		expect(properties).toEqual({
+			tool_name: "run_commands",
+			effective_timeout_ms: 1500,
+			timeout_source: "command_parameter",
+			command_count: 2,
+			command_index: 1,
+			duration_ms: 1502,
+			mode: "act",
+			source: "sdk-test",
+			session_id: "session-1",
+			agent_id: "agent-1",
+			conversation_id: "conv-1",
+			run_id: "run-1",
+			iteration: 3,
+			tool_call_id: "tool-call-1",
+		});
+		expect(properties).not.toHaveProperty("command");
+		expect(properties).not.toHaveProperty("commands");
+		expect(properties).not.toHaveProperty("stdout");
+		expect(properties).not.toHaveProperty("stderr");
+		expect(properties).not.toHaveProperty("env");
+		expect(properties).not.toHaveProperty("workspace_path");
 	});
 });
 

--- a/sdk/packages/core/src/services/telemetry/core-events.test.ts
+++ b/sdk/packages/core/src/services/telemetry/core-events.test.ts
@@ -537,6 +537,23 @@ describe("telemetry policy: helpers respect telemetry opt-out", () => {
 		expect(emitRequired).not.toHaveBeenCalled();
 	});
 
+	test("captureRunCommandsTimeout never invokes captureRequired", () => {
+		const { adapter, emitRequired } = createDisabledAdapter();
+		const service = new TelemetryService({
+			distinctId: "test-distinct-id",
+			adapters: [adapter],
+		});
+		captureRunCommandsTimeout(service, {
+			tool_name: "run_commands",
+			effective_timeout_ms: 1500,
+			timeout_source: "command_parameter",
+			command_count: 2,
+			command_index: 1,
+			duration_ms: 1502,
+		});
+		expect(emitRequired).not.toHaveBeenCalled();
+	});
+
 	test("a correctly-policed adapter drops these events when disabled", () => {
 		// This test layers on top of the previous four to assert the *full*
 		// end-to-end policy: when the adapter is disabled, a real adapter
@@ -608,6 +625,14 @@ describe("telemetry policy: helpers respect telemetry opt-out", () => {
 			thresholdRatio: 0.9,
 			durationMs: 17,
 		});
+		captureRunCommandsTimeout(service, {
+			tool_name: "run_commands",
+			effective_timeout_ms: 1500,
+			timeout_source: "command_parameter",
+			command_count: 2,
+			command_index: 1,
+			duration_ms: 1502,
+		});
 		expect(observed).toEqual([]);
 		expect(dropped).toEqual([
 			"user.extension_activated",
@@ -617,6 +642,7 @@ describe("telemetry policy: helpers respect telemetry opt-out", () => {
 			"user.provider_configured",
 			"task.compaction_executed",
 			"task.compaction_skipped",
+			"sdk.tool_timeout",
 		]);
 	});
 });

--- a/sdk/packages/core/src/services/telemetry/core-events.ts
+++ b/sdk/packages/core/src/services/telemetry/core-events.ts
@@ -61,7 +61,6 @@ export const CORE_TELEMETRY_EVENTS = {
 		SUBAGENT_COMPLETED: "task.subagent_completed",
 		COMPACTION_EXECUTED: "task.compaction_executed",
 		COMPACTION_SKIPPED: "task.compaction_skipped",
-		EMERGENCY_TRUNCATION: "task.emergency_truncation",
 	},
 	HOOKS: {
 		DISCOVERY_COMPLETED: "hooks.discovery_completed",
@@ -658,41 +657,6 @@ export function captureCompactionSkipped(
 		Partial<TelemetryAgentIdentityProperties>,
 ): void {
 	emit(telemetry, CORE_TELEMETRY_EVENTS.TASK.COMPACTION_SKIPPED, {
-		...properties,
-		timestamp: new Date().toISOString(),
-	});
-}
-
-/**
- * CLINE-2192 Layer B: emitted when `MessageBuilder.buildForApi` had to
- * apply emergency truncation to force the outbound request below
- * `maxInputTokens * CHARS_PER_TOKEN` bytes. This fires only when
- * Layer A's largest-first heuristic was insufficient (adversarial
- * inputs, oversized tool_use.input bodies, exotic block layouts).
- *
- * Treat any occurrence as a signal that production is operating in
- * degraded mode — the model is seeing truncated content and the
- * agent may produce wrong output as a result. The user-visible
- * `emitStatusNotice("compacted to fit context window", ...)` fires
- * alongside this event so the operator sees it in the TUI/webview.
- */
-export interface CaptureEmergencyTruncationProperties {
-	ulid: string;
-	bytesBefore: number;
-	bytesAfter: number;
-	maxInputTokens: number;
-	truncatedBlocks: number;
-	droppedBlocks: number;
-	provider?: string;
-	modelId?: string;
-}
-
-export function captureEmergencyTruncation(
-	telemetry: ITelemetryService | undefined,
-	properties: CaptureEmergencyTruncationProperties &
-		Partial<TelemetryAgentIdentityProperties>,
-): void {
-	emit(telemetry, CORE_TELEMETRY_EVENTS.TASK.EMERGENCY_TRUNCATION, {
 		...properties,
 		timestamp: new Date().toISOString(),
 	});

--- a/sdk/packages/core/src/services/telemetry/core-events.ts
+++ b/sdk/packages/core/src/services/telemetry/core-events.ts
@@ -81,7 +81,6 @@ export interface RunCommandsTimeoutTelemetryProperties {
 	effective_timeout_ms: number;
 	timeout_source: "default_setting" | "command_parameter";
 	command_count: number;
-	command_index?: number;
 	duration_ms: number;
 	mode?: string;
 	source?: string;

--- a/sdk/packages/core/src/services/telemetry/core-events.ts
+++ b/sdk/packages/core/src/services/telemetry/core-events.ts
@@ -61,6 +61,7 @@ export const CORE_TELEMETRY_EVENTS = {
 		SUBAGENT_COMPLETED: "task.subagent_completed",
 		COMPACTION_EXECUTED: "task.compaction_executed",
 		COMPACTION_SKIPPED: "task.compaction_skipped",
+		EMERGENCY_TRUNCATION: "task.emergency_truncation",
 	},
 	HOOKS: {
 		DISCOVERY_COMPLETED: "hooks.discovery_completed",
@@ -72,8 +73,26 @@ export const CORE_TELEMETRY_EVENTS = {
 	},
 	SDK: {
 		ERROR: SDK_ERROR_TELEMETRY_EVENT,
+		TOOL_TIMEOUT: "sdk.tool_timeout",
 	},
 } as const;
+
+export interface RunCommandsTimeoutTelemetryProperties {
+	tool_name: "run_commands";
+	effective_timeout_ms: number;
+	timeout_source: "default_setting" | "command_parameter";
+	command_count: number;
+	command_index?: number;
+	duration_ms: number;
+	mode?: string;
+	source?: string;
+	session_id?: string;
+	agent_id?: string;
+	conversation_id?: string;
+	run_id?: string;
+	iteration?: number;
+	tool_call_id?: string;
+}
 
 export interface WorkspaceInitializedProperties {
 	root_count: number;
@@ -223,14 +242,9 @@ export function captureAuthLoggedOut(
 }
 
 /**
- * Fires when the user finishes configuring a "bring your own provider"
- * (API-key based) provider during onboarding or via settings.
- *
- * Unlike the OAuth/device-code `captureAuth*` events, the configure step is a
- * synchronous local credential save with no network roundtrip, so there is no
- * start/fail counterpart — the credential is validated lazily on the first
- * subsequent API call. Mirrors the `{ provider }` payload shape of
- * {@link captureAuthSucceeded} for funnel consistency.
+ * Records that a user configured a provider credential in settings.
+ * This is a normal opt-out-respecting event because configuration has no
+ * start/fail counterpart and credential validity is checked lazily later.
  */
 export function captureProviderConfigured(
 	telemetry: ITelemetryService | undefined,
@@ -247,6 +261,15 @@ export function captureTelemetryOptOut(
 		CORE_TELEMETRY_EVENTS.USER.TELEMETRY_OPT_OUT,
 		properties,
 	);
+}
+
+export function captureRunCommandsTimeout(
+	telemetry: ITelemetryService | undefined,
+	properties: RunCommandsTimeoutTelemetryProperties,
+): void {
+	emit(telemetry, CORE_TELEMETRY_EVENTS.SDK.TOOL_TIMEOUT, {
+		...properties,
+	});
 }
 
 export function identifyAccount(
@@ -635,6 +658,41 @@ export function captureCompactionSkipped(
 		Partial<TelemetryAgentIdentityProperties>,
 ): void {
 	emit(telemetry, CORE_TELEMETRY_EVENTS.TASK.COMPACTION_SKIPPED, {
+		...properties,
+		timestamp: new Date().toISOString(),
+	});
+}
+
+/**
+ * CLINE-2192 Layer B: emitted when `MessageBuilder.buildForApi` had to
+ * apply emergency truncation to force the outbound request below
+ * `maxInputTokens * CHARS_PER_TOKEN` bytes. This fires only when
+ * Layer A's largest-first heuristic was insufficient (adversarial
+ * inputs, oversized tool_use.input bodies, exotic block layouts).
+ *
+ * Treat any occurrence as a signal that production is operating in
+ * degraded mode — the model is seeing truncated content and the
+ * agent may produce wrong output as a result. The user-visible
+ * `emitStatusNotice("compacted to fit context window", ...)` fires
+ * alongside this event so the operator sees it in the TUI/webview.
+ */
+export interface CaptureEmergencyTruncationProperties {
+	ulid: string;
+	bytesBefore: number;
+	bytesAfter: number;
+	maxInputTokens: number;
+	truncatedBlocks: number;
+	droppedBlocks: number;
+	provider?: string;
+	modelId?: string;
+}
+
+export function captureEmergencyTruncation(
+	telemetry: ITelemetryService | undefined,
+	properties: CaptureEmergencyTruncationProperties &
+		Partial<TelemetryAgentIdentityProperties>,
+): void {
+	emit(telemetry, CORE_TELEMETRY_EVENTS.TASK.EMERGENCY_TRUNCATION, {
 		...properties,
 		timestamp: new Date().toISOString(),
 	});


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

### PR Stack

This is a three-PR stack for CLINE-2189. Please review and merge in order:

1. #10762 -> `main`: adds the SDK/core global default `run_commands` timeout setting and CLI settings UI.
2. #10764 -> #10762: adds model-specified per-command `timeout` support for SDK `run_commands` and wires it through tool execution.
3. #10765 -> #10764: adds safe SDK telemetry for `run_commands` timeout events.

Merge flow: merge #10762 first, then rebase/retarget #10764 onto `main`; merge #10764, then rebase/retarget #10765 onto `main`.

### Description

This PR adds SDK telemetry for `run_commands` timeouts on top of PR #10764.

Changes included:
- emits a dedicated `sdk.tool_timeout` event when `run_commands` times out
- records safe structured metadata including effective timeout, timeout source, command count/index, duration, and timeout origin
- avoids including raw command text, stdout/stderr, env vars, workspace paths, or secrets in telemetry payloads
- documents the event and safe metadata in the SDK tools docs and telemetry smoke script
- adds focused tests for timeout emission and non-emission on success / non-timeout failures

This is intentionally scoped to the SDK/core telemetry surface and builds directly on the timeout override support added in PR #10764.

### Test Procedure

Focused verification completed in the original implementation worktree:

- `cd /Users/robin/.cline/worktrees/2fd6f/cline/sdk && bunx vitest run packages/core/src/services/telemetry/core-events.test.ts packages/core/src/extensions/tools/definitions.test.ts`

Observed result:
- 2 test files passed
- 59 tests passed

Note: the clean stacked worktree created for rebasing this PR on top of PR #10764 did not have the same dependency resolution setup for executing those tests directly, so I validated the implementation before transplanting the exact file changes onto the correct base branch.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [x] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A

### Additional Notes

This PR is intended to be reviewed and merged after PR #10764, since it depends on the `run_commands` timeout override support introduced there.

