### PR TITLE
fix: exclude agent tooling from VSIX package

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -2,6 +2,10 @@
 .vscode/**
 .vscode-test/**
 .worktrees/**
+# Agent tooling, never shipped in the VSIX
+.agents/**
+.claude/**
+.codex/**
 CLAUDE.local.md
 out/
 dist-standalone/


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

### Description

Excludes agent-only hidden tooling directories from the VSIX package:

- `.agents/**`
- `.claude/**`
- `.codex/**`

The current `main` E2E workflow fails before Playwright starts during `vsce package --allow-package-secrets sendgrid --out dist/e2e.vsix`. VSCE includes `.claude/skills/cline-sdk`, which is a symlink to the `.agents/skills/cline-sdk` directory, and secret scanning fails while processing packaged files. These directories are repository tooling for agents and should not be shipped in the extension VSIX.

### Test Procedure

- Ran `npx vsce ls --tree --no-dependencies | rg -n "\\.agents|\\.claude|\\.codex" || true` and confirmed no agent tooling directories are included.
- Ran `npx vsce package --allow-package-secrets sendgrid --out /tmp/cline-main-vsix-agent-ignore.vsix` successfully on a branch based on current `origin/main`.
- Confirmed the generated VSIX file list no longer includes `.agents`, `.claude`, or `.codex`.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A

### Additional Notes

This is intended to unblock E2E checks on `main` and downstream PRs. The packaging command exercises the same VSCE secret scanning step that was failing in CI.
