### PR TITLE
fix(sdk): support Vertex ADC tool-use inference

### DIFF
--- a/sdk/packages/core/src/runtime/config/agent-message-codec.test.ts
+++ b/sdk/packages/core/src/runtime/config/agent-message-codec.test.ts
@@ -107,8 +107,47 @@ describe("agent message codec", () => {
 			toolName: "editor",
 			metadata: {
 				signature: "sig_4",
-				thoughtSignature: "sig_4",
 			},
 		});
+	});
+
+	it("restores legacy tool result names from prior tool calls", () => {
+		const messages = messagesToAgentMessages([
+			{
+				id: "assistant_1",
+				role: "assistant",
+				ts: 1,
+				content: [
+					{
+						type: "tool_use",
+						id: "toolu_5",
+						name: "editor",
+						input: { path: "/tmp/out.txt" },
+					},
+				],
+			},
+			{
+				id: "tool_result_1",
+				role: "user",
+				ts: 2,
+				content: [
+					{
+						type: "tool_result",
+						tool_use_id: "toolu_5",
+						content: "ok",
+					} as never,
+				],
+			},
+		]);
+
+		expect(messages[1]?.content).toEqual([
+			{
+				type: "tool-result",
+				toolCallId: "toolu_5",
+				toolName: "editor",
+				output: "ok",
+				isError: undefined,
+			},
+		]);
 	});
 });

--- a/sdk/packages/core/src/runtime/config/agent-message-codec.test.ts
+++ b/sdk/packages/core/src/runtime/config/agent-message-codec.test.ts
@@ -110,44 +110,4 @@ describe("agent message codec", () => {
 			},
 		});
 	});
-
-	it("restores legacy tool result names from prior tool calls", () => {
-		const messages = messagesToAgentMessages([
-			{
-				id: "assistant_1",
-				role: "assistant",
-				ts: 1,
-				content: [
-					{
-						type: "tool_use",
-						id: "toolu_5",
-						name: "editor",
-						input: { path: "/tmp/out.txt" },
-					},
-				],
-			},
-			{
-				id: "tool_result_1",
-				role: "user",
-				ts: 2,
-				content: [
-					{
-						type: "tool_result",
-						tool_use_id: "toolu_5",
-						content: "ok",
-					} as never,
-				],
-			},
-		]);
-
-		expect(messages[1]?.content).toEqual([
-			{
-				type: "tool-result",
-				toolCallId: "toolu_5",
-				toolName: "editor",
-				output: "ok",
-				isError: undefined,
-			},
-		]);
-	});
 });

--- a/sdk/packages/core/src/runtime/config/agent-message-codec.test.ts
+++ b/sdk/packages/core/src/runtime/config/agent-message-codec.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { messageToAgentMessages } from "./agent-message-codec";
+import {
+	agentMessageToMessageWithMetadata,
+	messageToAgentMessages,
+	messagesToAgentMessages,
+} from "./agent-message-codec";
 
 describe("agent message codec", () => {
 	it("preserves mixed tool result and user text order", () => {
@@ -67,5 +71,44 @@ describe("agent message codec", () => {
 				toolName: "read_files",
 			}),
 		]);
+	});
+
+	it("round-trips Gemini tool call thought signatures", () => {
+		const persisted = agentMessageToMessageWithMetadata({
+			id: "msg_tool_call",
+			role: "assistant",
+			createdAt: 1,
+			content: [
+				{
+					type: "tool-call",
+					toolCallId: "toolu_4",
+					toolName: "editor",
+					input: { path: "/tmp/out.txt" },
+					metadata: {
+						thoughtSignature: "sig_4",
+					},
+				},
+			],
+		});
+
+		expect(persisted.content).toEqual([
+			expect.objectContaining({
+				type: "tool_use",
+				id: "toolu_4",
+				name: "editor",
+				signature: "sig_4",
+			}),
+		]);
+
+		const [restored] = messagesToAgentMessages([persisted]);
+		expect(restored?.content[0]).toMatchObject({
+			type: "tool-call",
+			toolCallId: "toolu_4",
+			toolName: "editor",
+			metadata: {
+				signature: "sig_4",
+				thoughtSignature: "sig_4",
+			},
+		});
 	});
 });

--- a/sdk/packages/core/src/runtime/config/agent-message-codec.ts
+++ b/sdk/packages/core/src/runtime/config/agent-message-codec.ts
@@ -171,7 +171,12 @@ function contentBlockToAgentPart(block: ContentBlock): AgentMessagePart {
 				toolCallId: block.id,
 				toolName: block.name,
 				input: block.input,
-				metadata: block.signature ? { signature: block.signature } : undefined,
+				metadata: block.signature
+					? {
+							signature: block.signature,
+							thoughtSignature: block.signature,
+						}
+					: undefined,
 			};
 		case "tool_result":
 			return toolResultContentToAgentPart(block);
@@ -229,15 +234,21 @@ function agentPartToContentBlock(
 				path: part.path,
 				content: part.content,
 			} satisfies FileContent;
-		case "tool-call":
+		case "tool-call": {
+			const metadata = part.metadata as
+				| {
+						signature?: string;
+						thoughtSignature?: string;
+				  }
+				| undefined;
 			return {
 				type: "tool_use",
 				id: part.toolCallId,
 				name: part.toolName,
 				input: (part.input as Record<string, unknown>) ?? {},
-				signature: (part.metadata as { signature?: string } | undefined)
-					?.signature,
+				signature: metadata?.thoughtSignature ?? metadata?.signature,
 			} satisfies ToolUseContent;
+		}
 		case "tool-result": {
 			const output = part.output;
 			const content =

--- a/sdk/packages/core/src/runtime/config/agent-message-codec.ts
+++ b/sdk/packages/core/src/runtime/config/agent-message-codec.ts
@@ -16,6 +16,7 @@ import type {
 
 export function messageToAgentMessages(
 	message: MessageWithMetadata,
+	toolNameById: Map<string, string> = new Map(),
 ): AgentMessage[] {
 	const blocks = normalizeContentBlocks(message.content);
 	const out: AgentMessage[] = [];
@@ -58,6 +59,9 @@ export function messageToAgentMessages(
 	}
 
 	for (const block of blocks) {
+		if (block.type === "tool_use") {
+			rememberToolName(toolNameById, block);
+		}
 		if (block.type !== "tool_result") {
 			nonToolBlocks.push(block);
 			continue;
@@ -66,7 +70,7 @@ export function messageToAgentMessages(
 		out.push({
 			id: `${baseId}_tool_${block.tool_use_id}`,
 			role: "tool",
-			content: [toolResultContentToAgentPart(block)],
+			content: [toolResultContentToAgentPart(block, toolNameById)],
 			createdAt: message.ts ?? Date.now(),
 			metadata: message.metadata,
 		});
@@ -79,7 +83,10 @@ export function messageToAgentMessages(
 export function messagesToAgentMessages(
 	messages: readonly MessageWithMetadata[],
 ): AgentMessage[] {
-	return messages.flatMap(messageToAgentMessages);
+	const toolNameById = new Map<string, string>();
+	return messages.flatMap((message) =>
+		messageToAgentMessages(message, toolNameById),
+	);
 }
 
 export function agentMessageToMessageWithMetadata(
@@ -174,7 +181,6 @@ function contentBlockToAgentPart(block: ContentBlock): AgentMessagePart {
 				metadata: block.signature
 					? {
 							signature: block.signature,
-							thoughtSignature: block.signature,
 						}
 					: undefined,
 			};
@@ -185,14 +191,26 @@ function contentBlockToAgentPart(block: ContentBlock): AgentMessagePart {
 
 function toolResultContentToAgentPart(
 	block: ToolResultContent,
+	toolNameById: Map<string, string> = new Map(),
 ): AgentMessagePart {
+	const legacyBlock = block as ToolResultContent & { name?: string };
 	return {
 		type: "tool-result",
 		toolCallId: block.tool_use_id,
-		toolName: block.name,
+		toolName: legacyBlock.name ?? toolNameById.get(block.tool_use_id) ?? "tool",
 		output: block.content,
 		isError: block.is_error,
 	};
+}
+
+function rememberToolName(
+	toolNameById: Map<string, string>,
+	block: ToolUseContent,
+): void {
+	toolNameById.set(block.id, block.name);
+	if (typeof block.call_id === "string") {
+		toolNameById.set(block.call_id, block.name);
+	}
 }
 
 function agentPartToContentBlock(

--- a/sdk/packages/core/src/runtime/config/agent-message-codec.ts
+++ b/sdk/packages/core/src/runtime/config/agent-message-codec.ts
@@ -16,7 +16,6 @@ import type {
 
 export function messageToAgentMessages(
 	message: MessageWithMetadata,
-	toolNameById: Map<string, string> = new Map(),
 ): AgentMessage[] {
 	const blocks = normalizeContentBlocks(message.content);
 	const out: AgentMessage[] = [];
@@ -59,9 +58,6 @@ export function messageToAgentMessages(
 	}
 
 	for (const block of blocks) {
-		if (block.type === "tool_use") {
-			rememberToolName(toolNameById, block);
-		}
 		if (block.type !== "tool_result") {
 			nonToolBlocks.push(block);
 			continue;
@@ -70,7 +66,7 @@ export function messageToAgentMessages(
 		out.push({
 			id: `${baseId}_tool_${block.tool_use_id}`,
 			role: "tool",
-			content: [toolResultContentToAgentPart(block, toolNameById)],
+			content: [toolResultContentToAgentPart(block)],
 			createdAt: message.ts ?? Date.now(),
 			metadata: message.metadata,
 		});
@@ -83,10 +79,7 @@ export function messageToAgentMessages(
 export function messagesToAgentMessages(
 	messages: readonly MessageWithMetadata[],
 ): AgentMessage[] {
-	const toolNameById = new Map<string, string>();
-	return messages.flatMap((message) =>
-		messageToAgentMessages(message, toolNameById),
-	);
+	return messages.flatMap(messageToAgentMessages);
 }
 
 export function agentMessageToMessageWithMetadata(
@@ -191,26 +184,14 @@ function contentBlockToAgentPart(block: ContentBlock): AgentMessagePart {
 
 function toolResultContentToAgentPart(
 	block: ToolResultContent,
-	toolNameById: Map<string, string> = new Map(),
 ): AgentMessagePart {
-	const legacyBlock = block as ToolResultContent & { name?: string };
 	return {
 		type: "tool-result",
 		toolCallId: block.tool_use_id,
-		toolName: legacyBlock.name ?? toolNameById.get(block.tool_use_id) ?? "tool",
+		toolName: block.name,
 		output: block.content,
 		isError: block.is_error,
 	};
-}
-
-function rememberToolName(
-	toolNameById: Map<string, string>,
-	block: ToolUseContent,
-): void {
-	toolNameById.set(block.id, block.name);
-	if (typeof block.call_id === "string") {
-		toolNameById.set(block.call_id, block.name);
-	}
 }
 
 function agentPartToContentBlock(

--- a/sdk/packages/llms/src/providers/ai-sdk.ts
+++ b/sdk/packages/llms/src/providers/ai-sdk.ts
@@ -140,7 +140,9 @@ function toAiSdkMessages(
 			if (part.type === "tool-call") {
 				const metadata = part.metadata as Record<string, unknown> | undefined;
 				const thoughtSignature =
-					metadata?.thoughtSignature ?? metadata?.thought_signature;
+					metadata?.thoughtSignature ??
+					metadata?.signature ??
+					metadata?.thought_signature;
 				content.push({
 					type: "tool-call",
 					toolCallId: part.toolCallId,
@@ -604,12 +606,19 @@ function extractGoogleThoughtMetadata(
 		providerMetadata?.google && typeof providerMetadata.google === "object"
 			? (providerMetadata.google as Record<string, unknown>)
 			: undefined;
+	const vertexMetadata =
+		providerMetadata?.vertex && typeof providerMetadata.vertex === "object"
+			? (providerMetadata.vertex as Record<string, unknown>)
+			: undefined;
 
 	if (
 		typeof metadata.thoughtSignature !== "string" &&
-		typeof googleMetadata?.thoughtSignature === "string"
+		typeof (
+			googleMetadata?.thoughtSignature ?? vertexMetadata?.thoughtSignature
+		) === "string"
 	) {
-		metadata.thoughtSignature = googleMetadata.thoughtSignature;
+		metadata.thoughtSignature =
+			googleMetadata?.thoughtSignature ?? vertexMetadata?.thoughtSignature;
 	}
 	if (
 		typeof metadata.thought_signature !== "string" &&

--- a/sdk/packages/llms/src/providers/ai-sdk.ts
+++ b/sdk/packages/llms/src/providers/ai-sdk.ts
@@ -140,7 +140,9 @@ function toAiSdkMessages(
 			if (part.type === "tool-call") {
 				const metadata = part.metadata as Record<string, unknown> | undefined;
 				const thoughtSignature =
-					metadata?.thoughtSignature ?? metadata?.signature;
+					metadata?.thoughtSignature ??
+					metadata?.signature ??
+					metadata?.thought_signature;
 				content.push({
 					type: "tool-call",
 					toolCallId: part.toolCallId,
@@ -592,6 +594,9 @@ function extractGoogleThoughtMetadata(
 	if (typeof part.thoughtSignature === "string") {
 		metadata.thoughtSignature = part.thoughtSignature;
 	}
+	if (typeof part.thought_signature === "string") {
+		metadata.thought_signature = part.thought_signature;
+	}
 
 	const providerMetadata =
 		part.providerMetadata && typeof part.providerMetadata === "object"
@@ -614,6 +619,12 @@ function extractGoogleThoughtMetadata(
 	) {
 		metadata.thoughtSignature =
 			googleMetadata?.thoughtSignature ?? vertexMetadata?.thoughtSignature;
+	}
+	if (
+		typeof metadata.thought_signature !== "string" &&
+		typeof googleMetadata?.thought_signature === "string"
+	) {
+		metadata.thought_signature = googleMetadata.thought_signature;
 	}
 
 	return Object.keys(metadata).length > 0 ? metadata : undefined;

--- a/sdk/packages/llms/src/providers/ai-sdk.ts
+++ b/sdk/packages/llms/src/providers/ai-sdk.ts
@@ -140,9 +140,7 @@ function toAiSdkMessages(
 			if (part.type === "tool-call") {
 				const metadata = part.metadata as Record<string, unknown> | undefined;
 				const thoughtSignature =
-					metadata?.thoughtSignature ??
-					metadata?.signature ??
-					metadata?.thought_signature;
+					metadata?.thoughtSignature ?? metadata?.signature;
 				content.push({
 					type: "tool-call",
 					toolCallId: part.toolCallId,
@@ -594,9 +592,6 @@ function extractGoogleThoughtMetadata(
 	if (typeof part.thoughtSignature === "string") {
 		metadata.thoughtSignature = part.thoughtSignature;
 	}
-	if (typeof part.thought_signature === "string") {
-		metadata.thought_signature = part.thought_signature;
-	}
 
 	const providerMetadata =
 		part.providerMetadata && typeof part.providerMetadata === "object"
@@ -619,12 +614,6 @@ function extractGoogleThoughtMetadata(
 	) {
 		metadata.thoughtSignature =
 			googleMetadata?.thoughtSignature ?? vertexMetadata?.thoughtSignature;
-	}
-	if (
-		typeof metadata.thought_signature !== "string" &&
-		typeof googleMetadata?.thought_signature === "string"
-	) {
-		metadata.thought_signature = googleMetadata.thought_signature;
 	}
 
 	return Object.keys(metadata).length > 0 ? metadata : undefined;

--- a/sdk/packages/llms/src/providers/gateway.test.ts
+++ b/sdk/packages/llms/src/providers/gateway.test.ts
@@ -1718,6 +1718,135 @@ describe("sdk-gateway", () => {
 		}
 	});
 
+	it("preserves legacy Google snake_case thought signatures", async () => {
+		streamTextSpy.mockReturnValueOnce({
+			fullStream: makeStreamParts([
+				{
+					type: "tool-call",
+					toolCallId: "call_legacy",
+					toolName: "editor",
+					input: { path: "/tmp/out.txt" },
+					providerMetadata: {
+						google: {
+							thought_signature: "sig_legacy",
+						},
+					},
+				},
+				{ type: "finish", usage: { inputTokens: 1, outputTokens: 1 } },
+			]),
+		});
+
+		const gateway = createGateway({
+			providerConfigs: [
+				{
+					providerId: "gemini",
+					apiKey: "google-key",
+				},
+			],
+		});
+
+		const events = await collect(
+			await gateway.stream({
+				providerId: "gemini",
+				modelId: "gemini-2.5-flash",
+				messages: baseMessages,
+				tools: [
+					{
+						name: "editor",
+						description: "Edits files",
+						inputSchema: { type: "object" },
+					},
+				],
+			}),
+		);
+
+		expect(events).toContainEqual(
+			expect.objectContaining({
+				type: "tool-call-delta",
+				toolCallId: "call_legacy",
+				toolName: "editor",
+				metadata: expect.objectContaining({
+					thought_signature: "sig_legacy",
+				}),
+			}),
+		);
+
+		streamTextSpy.mockReset();
+		streamTextSpy.mockReturnValueOnce({
+			fullStream: makeStreamParts([
+				{ type: "text-delta", textDelta: "done" },
+				{ type: "finish", usage: { inputTokens: 1, outputTokens: 1 } },
+			]),
+		});
+
+		await collect(
+			await gateway.stream({
+				providerId: "gemini",
+				modelId: "gemini-2.5-flash",
+				messages: [
+					{
+						id: "assistant_legacy",
+						role: "assistant",
+						content: [
+							{
+								type: "tool-call",
+								toolCallId: "call_legacy",
+								toolName: "editor",
+								input: { path: "/tmp/out.txt" },
+								metadata: {
+									thought_signature: "sig_legacy",
+								},
+							},
+						],
+						createdAt: Date.now(),
+					},
+					{
+						id: "tool_legacy",
+						role: "tool",
+						content: [
+							{
+								type: "tool-result",
+								toolCallId: "call_legacy",
+								toolName: "editor",
+								output: { ok: true },
+							},
+						],
+						createdAt: Date.now(),
+					},
+				],
+				tools: [
+					{
+						name: "editor",
+						description: "Edits files",
+						inputSchema: { type: "object" },
+					},
+				],
+			}),
+		);
+
+		expect(streamTextSpy).toHaveBeenCalledWith(
+			expect.objectContaining({
+				messages: expect.arrayContaining([
+					expect.objectContaining({
+						role: "assistant",
+						content: [
+							expect.objectContaining({
+								type: "tool-call",
+								toolCallId: "call_legacy",
+								toolName: "editor",
+								providerOptions: {
+									google: {
+										thoughtSignature: "sig_legacy",
+									},
+								},
+							}),
+						],
+					}),
+				]),
+			}),
+		);
+	});
+
 	it("does not pass extra tools to providers that disable external tool execution", async () => {
 		streamTextSpy.mockReturnValue({
 			fullStream: makeStreamParts([

--- a/sdk/packages/llms/src/providers/gateway.test.ts
+++ b/sdk/packages/llms/src/providers/gateway.test.ts
@@ -1623,80 +1623,99 @@ describe("sdk-gateway", () => {
 			}),
 		);
 
+		const toolCallEvent = events.find(
+			(event): event is Extract<AgentModelEvent, { type: "tool-call-delta" }> =>
+				event.type === "tool-call-delta",
+		);
+		expect(toolCallEvent).toBeDefined();
+
 		streamTextSpy.mockReset();
-		streamTextSpy.mockReturnValueOnce({
-			fullStream: makeStreamParts([
-				{ type: "text-delta", textDelta: "done" },
-				{ type: "finish", usage: { inputTokens: 1, outputTokens: 1 } },
-			]),
-		});
 
-		await collect(
-			await gateway.stream({
-				providerId: "vertex",
-				modelId: "gemini-3-flash-preview",
-				messages: [
-					{
-						id: "assistant_1",
-						role: "assistant",
-						content: [
-							{
-								type: "tool-call",
-								toolCallId: "call_1",
-								toolName: "editor",
-								input: { path: "/tmp/out.txt" },
-								metadata: {
-									signature: "sig_1",
-								},
-							},
-						],
-						createdAt: Date.now(),
-					},
-					{
-						id: "tool_1",
-						role: "tool",
-						content: [
-							{
-								type: "tool-result",
-								toolCallId: "call_1",
-								toolName: "editor",
-								output: { ok: true },
-							},
-						],
-						createdAt: Date.now(),
-					},
-				],
-				tools: [
-					{
-						name: "editor",
-						description: "Edits files",
-						inputSchema: { type: "object" },
-					},
-				],
-			}),
-		);
+		const replayCases = [
+			{
+				name: "fresh event metadata",
+				metadata: toolCallEvent?.metadata,
+			},
+			{
+				name: "persisted history metadata",
+				metadata: { signature: "sig_1" },
+			},
+		];
 
-		expect(streamTextSpy).toHaveBeenCalledWith(
-			expect.objectContaining({
-				messages: expect.arrayContaining([
-					expect.objectContaining({
-						role: "assistant",
-						content: [
-							expect.objectContaining({
-								type: "tool-call",
-								toolCallId: "call_1",
-								toolName: "editor",
-								providerOptions: {
-									google: {
-										thoughtSignature: "sig_1",
-									},
-								},
-							}),
-						],
-					}),
+		for (const replayCase of replayCases) {
+			streamTextSpy.mockReset();
+			streamTextSpy.mockReturnValueOnce({
+				fullStream: makeStreamParts([
+					{ type: "text-delta", textDelta: `done ${replayCase.name}` },
+					{ type: "finish", usage: { inputTokens: 1, outputTokens: 1 } },
 				]),
-			}),
-		);
+			});
+
+			await collect(
+				await gateway.stream({
+					providerId: "vertex",
+					modelId: "gemini-3-flash-preview",
+					messages: [
+						{
+							id: `assistant_${replayCase.name}`,
+							role: "assistant",
+							content: [
+								{
+									type: "tool-call",
+									toolCallId: "call_1",
+									toolName: "editor",
+									input: { path: "/tmp/out.txt" },
+									metadata: replayCase.metadata,
+								},
+							],
+							createdAt: Date.now(),
+						},
+						{
+							id: `tool_${replayCase.name}`,
+							role: "tool",
+							content: [
+								{
+									type: "tool-result",
+									toolCallId: "call_1",
+									toolName: "editor",
+									output: { ok: true },
+								},
+							],
+							createdAt: Date.now(),
+						},
+					],
+					tools: [
+						{
+							name: "editor",
+							description: "Edits files",
+							inputSchema: { type: "object" },
+						},
+					],
+				}),
+			);
+
+			expect(streamTextSpy).toHaveBeenCalledWith(
+				expect.objectContaining({
+					messages: expect.arrayContaining([
+						expect.objectContaining({
+							role: "assistant",
+							content: [
+								expect.objectContaining({
+									type: "tool-call",
+									toolCallId: "call_1",
+									toolName: "editor",
+									providerOptions: {
+										google: {
+											thoughtSignature: "sig_1",
+										},
+									},
+								}),
+							],
+						}),
+					]),
+				}),
+			);
+		}
 	});
 
 	it("does not pass extra tools to providers that disable external tool execution", async () => {

--- a/sdk/packages/llms/src/providers/gateway.test.ts
+++ b/sdk/packages/llms/src/providers/gateway.test.ts
@@ -1567,6 +1567,138 @@ describe("sdk-gateway", () => {
 		);
 	});
 
+	it("preserves Vertex thought signatures on tool calls and replays them", async () => {
+		streamTextSpy.mockReturnValueOnce({
+			fullStream: makeStreamParts([
+				{
+					type: "tool-call",
+					toolCallId: "call_1",
+					toolName: "editor",
+					input: { path: "/tmp/out.txt" },
+					providerMetadata: {
+						vertex: {
+							thoughtSignature: "sig_1",
+						},
+					},
+				},
+				{ type: "finish", usage: { inputTokens: 1, outputTokens: 1 } },
+			]),
+		});
+
+		const gateway = createGateway({
+			providerConfigs: [
+				{
+					providerId: "vertex",
+					options: {
+						project: "test-project",
+						location: "global",
+					},
+				},
+			],
+		});
+
+		const events = await collect(
+			await gateway.stream({
+				providerId: "vertex",
+				modelId: "gemini-3-flash-preview",
+				messages: baseMessages,
+				tools: [
+					{
+						name: "editor",
+						description: "Edits files",
+						inputSchema: { type: "object" },
+					},
+				],
+			}),
+		);
+
+		expect(events).toContainEqual(
+			expect.objectContaining({
+				type: "tool-call-delta",
+				toolCallId: "call_1",
+				toolName: "editor",
+				metadata: expect.objectContaining({
+					thoughtSignature: "sig_1",
+				}),
+			}),
+		);
+
+		streamTextSpy.mockReset();
+		streamTextSpy.mockReturnValueOnce({
+			fullStream: makeStreamParts([
+				{ type: "text-delta", textDelta: "done" },
+				{ type: "finish", usage: { inputTokens: 1, outputTokens: 1 } },
+			]),
+		});
+
+		await collect(
+			await gateway.stream({
+				providerId: "vertex",
+				modelId: "gemini-3-flash-preview",
+				messages: [
+					{
+						id: "assistant_1",
+						role: "assistant",
+						content: [
+							{
+								type: "tool-call",
+								toolCallId: "call_1",
+								toolName: "editor",
+								input: { path: "/tmp/out.txt" },
+								metadata: {
+									signature: "sig_1",
+								},
+							},
+						],
+						createdAt: Date.now(),
+					},
+					{
+						id: "tool_1",
+						role: "tool",
+						content: [
+							{
+								type: "tool-result",
+								toolCallId: "call_1",
+								toolName: "editor",
+								output: { ok: true },
+							},
+						],
+						createdAt: Date.now(),
+					},
+				],
+				tools: [
+					{
+						name: "editor",
+						description: "Edits files",
+						inputSchema: { type: "object" },
+					},
+				],
+			}),
+		);
+
+		expect(streamTextSpy).toHaveBeenCalledWith(
+			expect.objectContaining({
+				messages: expect.arrayContaining([
+					expect.objectContaining({
+						role: "assistant",
+						content: [
+							expect.objectContaining({
+								type: "tool-call",
+								toolCallId: "call_1",
+								toolName: "editor",
+								providerOptions: {
+									google: {
+										thoughtSignature: "sig_1",
+									},
+								},
+							}),
+						],
+					}),
+				]),
+			}),
+		);
+	});
+
 	it("does not pass extra tools to providers that disable external tool execution", async () => {
 		streamTextSpy.mockReturnValue({
 			fullStream: makeStreamParts([

--- a/sdk/packages/llms/src/providers/model-facts.ts
+++ b/sdk/packages/llms/src/providers/model-facts.ts
@@ -27,6 +27,21 @@ function normalizedModelId(
 	return normalizeRoutingValue(request.modelId) ?? "";
 }
 
+function geminiModelDescriptor(input: {
+	request: Pick<GatewayStreamRequest, "modelId">;
+	context: GatewayProviderContext;
+}): string {
+	return [
+		input.request.modelId,
+		input.context.model.id,
+		input.context.model.name,
+		input.context.model.metadata?.family,
+	]
+		.filter(Boolean)
+		.join(" ")
+		.toLowerCase();
+}
+
 function isAnthropicLineageValue(value: string | undefined): boolean {
 	const normalized = normalizeRoutingValue(value);
 	return normalized
@@ -85,6 +100,46 @@ export function isQwenModel(options: {
 	}
 
 	return isQwenLineageValue(options.modelId);
+}
+
+export function isGemini3Model(input: {
+	request: Pick<GatewayStreamRequest, "modelId">;
+	context: GatewayProviderContext;
+}): boolean {
+	return /(^|[/\s])gemini-3([.-]|$)/.test(geminiModelDescriptor(input));
+}
+
+export function isGeminiProModel(input: {
+	request: Pick<GatewayStreamRequest, "modelId">;
+	context: GatewayProviderContext;
+}): boolean {
+	return /(^|[/\s])gemini-2\.5-pro([-\s]|$)/.test(
+		geminiModelDescriptor(input),
+	);
+}
+
+export function isGeminiFlashModel(input: {
+	request: Pick<GatewayStreamRequest, "modelId">;
+	context: GatewayProviderContext;
+}): boolean {
+	const descriptor = geminiModelDescriptor(input);
+	return (
+		/(^|[/\s])gemini-(?:\d(?:\.\d)?-)?flash(?:-lite|-image)?([-\s]|$)/.test(
+			descriptor,
+		) || descriptor.includes("gemini-flash")
+	);
+}
+
+export function supportsGeminiThinking(input: {
+	request: Pick<GatewayStreamRequest, "modelId">;
+	context: GatewayProviderContext;
+}): boolean {
+	const descriptor = geminiModelDescriptor(input);
+	return (
+		isGemini3Model(input) ||
+		/(^|[/\s])gemini-2\.5([-\s]|$)/.test(descriptor) ||
+		descriptor.includes("gemini-flash-latest")
+	);
 }
 
 function modelFamilyMatches(

--- a/sdk/packages/llms/src/providers/routing/provider-option-rules.ts
+++ b/sdk/packages/llms/src/providers/routing/provider-option-rules.ts
@@ -135,24 +135,20 @@ function isGeminiFlashModel(input: ProviderOptionMatchInput): boolean {
 	return (
 		/(^|[/\s])gemini-(?:\d(?:\.\d)?-)?flash(?:-lite|-image)?([-\s]|$)/.test(
 			descriptor,
-		) ||
-		descriptor.includes("gemini-flash") ||
-		descriptor.includes("gemini-flash-latest")
+		) || descriptor.includes("gemini-flash")
 	);
 }
 
 function supportsGeminiThinking(input: ProviderOptionMatchInput): boolean {
+	const descriptor = getGeminiModelDescriptor(input);
 	return (
-		input.context.model.capabilities?.includes("reasoning") === true ||
 		isGemini3Model(input) ||
-		/(^|[/\s])gemini-2\.5([-\s]|$)/.test(getGeminiModelDescriptor(input)) ||
-		getGeminiModelDescriptor(input).includes("gemini-flash-latest")
+		/(^|[/\s])gemini-2\.5([-\s]|$)/.test(descriptor) ||
+		descriptor.includes("gemini-flash-latest")
 	);
 }
 
-function buildGeminiThinkingConfig(
-	input: ProviderOptionBuildInput,
-):
+function buildGeminiThinkingConfig(input: ProviderOptionBuildInput):
 	| {
 			thinkingLevel?: "minimal" | "low" | "medium" | "high";
 			thinkingBudget?: number;

--- a/sdk/packages/llms/src/providers/routing/provider-option-rules.ts
+++ b/sdk/packages/llms/src/providers/routing/provider-option-rules.ts
@@ -102,6 +102,108 @@ function buildReasoningPatchForProvider(
 	});
 }
 
+const GEMINI_25_THINKING_BUDGET_BY_EFFORT = {
+	low: 1_024,
+	medium: 8_192,
+	high: 24_576,
+} as const;
+
+function getGeminiModelDescriptor(input: ProviderOptionMatchInput): string {
+	return [
+		input.request.modelId,
+		input.context.model.id,
+		input.context.model.name,
+		input.context.model.metadata?.family,
+	]
+		.filter(Boolean)
+		.join(" ")
+		.toLowerCase();
+}
+
+function isGemini3Model(input: ProviderOptionMatchInput): boolean {
+	return /(^|[/\s])gemini-3([.-]|$)/.test(getGeminiModelDescriptor(input));
+}
+
+function isGeminiProModel(input: ProviderOptionMatchInput): boolean {
+	return /(^|[/\s])gemini-2\.5-pro([-\s]|$)/.test(
+		getGeminiModelDescriptor(input),
+	);
+}
+
+function isGeminiFlashModel(input: ProviderOptionMatchInput): boolean {
+	const descriptor = getGeminiModelDescriptor(input);
+	return (
+		/(^|[/\s])gemini-(?:\d(?:\.\d)?-)?flash(?:-lite|-image)?([-\s]|$)/.test(
+			descriptor,
+		) ||
+		descriptor.includes("gemini-flash") ||
+		descriptor.includes("gemini-flash-latest")
+	);
+}
+
+function supportsGeminiThinking(input: ProviderOptionMatchInput): boolean {
+	return (
+		input.context.model.capabilities?.includes("reasoning") === true ||
+		isGemini3Model(input) ||
+		/(^|[/\s])gemini-2\.5([-\s]|$)/.test(getGeminiModelDescriptor(input)) ||
+		getGeminiModelDescriptor(input).includes("gemini-flash-latest")
+	);
+}
+
+function buildGeminiThinkingConfig(
+	input: ProviderOptionBuildInput,
+):
+	| {
+			thinkingLevel?: "minimal" | "low" | "medium" | "high";
+			thinkingBudget?: number;
+			includeThoughts: boolean;
+	  }
+	| undefined {
+	const reasoning = input.request.reasoning;
+	if (!reasoning) {
+		return undefined;
+	}
+
+	if (isGemini3Model(input)) {
+		if (reasoning.enabled === false) {
+			return {
+				thinkingLevel: isGeminiFlashModel(input) ? "minimal" : "low",
+				includeThoughts: false,
+			};
+		}
+		if (!reasoning.effort) {
+			return undefined;
+		}
+		return {
+			thinkingLevel: reasoning.effort,
+			includeThoughts: true,
+		};
+	}
+
+	if (reasoning.enabled === false) {
+		return {
+			thinkingBudget: isGeminiProModel(input) ? 128 : 0,
+			includeThoughts: false,
+		};
+	}
+
+	if (typeof reasoning.budgetTokens === "number") {
+		return {
+			thinkingBudget: reasoning.budgetTokens,
+			includeThoughts: true,
+		};
+	}
+
+	if (!reasoning.effort) {
+		return undefined;
+	}
+
+	return {
+		thinkingBudget: GEMINI_25_THINKING_BUDGET_BY_EFFORT[reasoning.effort],
+		includeThoughts: true,
+	};
+}
+
 const directAnthropicProviderRule: ProviderOptionRule = {
 	id: "provider.anthropic.direct",
 	phase: "provider",
@@ -209,22 +311,22 @@ const geminiThinkingRule: ProviderOptionRule = {
 	id: "provider.google-gemini.thinking-config",
 	phase: "provider",
 	description: "Google/Gemini/Vertex maps reasoning to thinkingConfig.",
+	suppresses: { genericThinking: true, genericEffort: true },
 	applies: (input) =>
 		(input.request.providerId === "google" ||
 			input.request.providerId === "gemini" ||
 			input.request.providerId === "vertex") &&
+		supportsGeminiThinking(input) &&
 		(!!input.request.reasoning?.effort ||
+			typeof input.request.reasoning?.budgetTokens === "number" ||
 			input.request.reasoning?.enabled === false),
 	build: (input) => {
 		const providerOptionsName =
 			input.request.providerId === "vertex" ? "vertex" : "google";
-		const thinkingConfig =
-			input.request.reasoning?.enabled === false
-				? { thinkingLevel: "minimal", includeThoughts: false }
-				: {
-						thinkingLevel: input.request.reasoning?.effort,
-						includeThoughts: true,
-					};
+		const thinkingConfig = buildGeminiThinkingConfig(input);
+		if (!thinkingConfig) {
+			return undefined;
+		}
 		return {
 			[providerOptionsName]: {
 				thinkingConfig,

--- a/sdk/packages/llms/src/providers/routing/provider-option-rules.ts
+++ b/sdk/packages/llms/src/providers/routing/provider-option-rules.ts
@@ -1,10 +1,14 @@
 import {
 	isDeepSeekFamily,
+	isGemini3Model,
+	isGeminiFlashModel,
+	isGeminiProModel,
 	isGlmModel,
 	isKimiK26Family as isKimiK26FamilyFact,
 	isMoonshotKimiModelIdFallback,
 	modelReasoningDefaultsOn,
 	providerReasoningRouteMatches,
+	supportsGeminiThinking,
 } from "../model-facts";
 import { buildGatewayReasoningOptions } from "./anthropic-compatible";
 import { buildOpenAINativeProviderOptions } from "./generic-compatible";
@@ -107,46 +111,6 @@ const GEMINI_25_THINKING_BUDGET_BY_EFFORT = {
 	medium: 8_192,
 	high: 24_576,
 } as const;
-
-function getGeminiModelDescriptor(input: ProviderOptionMatchInput): string {
-	return [
-		input.request.modelId,
-		input.context.model.id,
-		input.context.model.name,
-		input.context.model.metadata?.family,
-	]
-		.filter(Boolean)
-		.join(" ")
-		.toLowerCase();
-}
-
-function isGemini3Model(input: ProviderOptionMatchInput): boolean {
-	return /(^|[/\s])gemini-3([.-]|$)/.test(getGeminiModelDescriptor(input));
-}
-
-function isGeminiProModel(input: ProviderOptionMatchInput): boolean {
-	return /(^|[/\s])gemini-2\.5-pro([-\s]|$)/.test(
-		getGeminiModelDescriptor(input),
-	);
-}
-
-function isGeminiFlashModel(input: ProviderOptionMatchInput): boolean {
-	const descriptor = getGeminiModelDescriptor(input);
-	return (
-		/(^|[/\s])gemini-(?:\d(?:\.\d)?-)?flash(?:-lite|-image)?([-\s]|$)/.test(
-			descriptor,
-		) || descriptor.includes("gemini-flash")
-	);
-}
-
-function supportsGeminiThinking(input: ProviderOptionMatchInput): boolean {
-	const descriptor = getGeminiModelDescriptor(input);
-	return (
-		isGemini3Model(input) ||
-		/(^|[/\s])gemini-2\.5([-\s]|$)/.test(descriptor) ||
-		descriptor.includes("gemini-flash-latest")
-	);
-}
 
 function buildGeminiThinkingConfig(input: ProviderOptionBuildInput):
 	| {

--- a/sdk/packages/llms/src/providers/routing/provider-option-rules.ts
+++ b/sdk/packages/llms/src/providers/routing/provider-option-rules.ts
@@ -208,19 +208,29 @@ const openRouterReasoningRule: ProviderOptionRule = {
 const geminiThinkingRule: ProviderOptionRule = {
 	id: "provider.google-gemini.thinking-config",
 	phase: "provider",
-	description: "Google/Gemini maps reasoning effort to google.thinkingConfig.",
+	description: "Google/Gemini/Vertex maps reasoning to thinkingConfig.",
 	applies: (input) =>
 		(input.request.providerId === "google" ||
-			input.request.providerId === "gemini") &&
-		!!input.request.reasoning?.effort,
-	build: (input) => ({
-		google: {
-			thinkingConfig: {
-				thinkingLevel: input.request.reasoning?.effort,
-				includeThoughts: true,
+			input.request.providerId === "gemini" ||
+			input.request.providerId === "vertex") &&
+		(!!input.request.reasoning?.effort ||
+			input.request.reasoning?.enabled === false),
+	build: (input) => {
+		const providerOptionsName =
+			input.request.providerId === "vertex" ? "vertex" : "google";
+		const thinkingConfig =
+			input.request.reasoning?.enabled === false
+				? { thinkingLevel: "minimal", includeThoughts: false }
+				: {
+						thinkingLevel: input.request.reasoning?.effort,
+						includeThoughts: true,
+					};
+		return {
+			[providerOptionsName]: {
+				thinkingConfig,
 			},
-		},
-	}),
+		};
+	},
 };
 
 const clineReasoningDisabledThinkingRule: ProviderOptionRule = {

--- a/sdk/packages/llms/src/providers/routing/provider-options.test.ts
+++ b/sdk/packages/llms/src/providers/routing/provider-options.test.ts
@@ -1416,7 +1416,7 @@ describe("composeAiSdkProviderOptions: provider-specific overlays", () => {
 		expect(result.openaiCodex).not.toHaveProperty("truncation");
 	});
 
-	it("emits the gemini google.thinkingConfig only when reasoning effort is set", () => {
+	it("emits Gemini 2.5 google.thinkingConfig budget only when reasoning effort is set", () => {
 		const withEffort = composeAiSdkProviderOptions(
 			makeRequest({
 				providerId: "gemini",
@@ -1426,7 +1426,7 @@ describe("composeAiSdkProviderOptions: provider-specific overlays", () => {
 			makeContext({ providerId: "gemini", modelId: "gemini-2.5-flash" }),
 		);
 		expect(withEffort.google).toEqual({
-			thinkingConfig: { thinkingLevel: "medium", includeThoughts: true },
+			thinkingConfig: { thinkingBudget: 8192, includeThoughts: true },
 		});
 
 		const withoutEffort = composeAiSdkProviderOptions(
@@ -1447,7 +1447,7 @@ describe("composeAiSdkProviderOptions: provider-specific overlays", () => {
 		);
 
 		expect(result.google).toEqual({
-			thinkingConfig: { thinkingLevel: "high", includeThoughts: true },
+			thinkingConfig: { thinkingBudget: 24576, includeThoughts: true },
 		});
 		expect(result.google).not.toHaveProperty("thinking");
 		expect(result.google).not.toHaveProperty("effort");
@@ -1473,6 +1473,10 @@ describe("composeAiSdkProviderOptions: provider-specific overlays", () => {
 				thinkingConfig: { thinkingLevel: "high", includeThoughts: true },
 			}),
 		);
+		expect(result.vertex).not.toHaveProperty("thinking");
+		expect(result.vertex).not.toHaveProperty("effort");
+		expect(result.vertex).not.toHaveProperty("reasoningEffort");
+		expect(result.vertex).not.toHaveProperty("reasoningSummary");
 		expect(result.google).toBeUndefined();
 	});
 
@@ -1494,6 +1498,91 @@ describe("composeAiSdkProviderOptions: provider-specific overlays", () => {
 				thinkingConfig: { thinkingLevel: "minimal", includeThoughts: false },
 			}),
 		);
+		expect(result.vertex).not.toHaveProperty("thinking");
+		expect(result.vertex).not.toHaveProperty("effort");
+		expect(result.vertex).not.toHaveProperty("reasoningEffort");
+		expect(result.vertex).not.toHaveProperty("reasoningSummary");
+		expect(result.google).toBeUndefined();
+	});
+
+	it("maps Vertex Gemini Flash Latest disabled thinking to a zero thinking budget", () => {
+		const result = composeAiSdkProviderOptions(
+			makeRequest({
+				providerId: "vertex",
+				modelId: "gemini-flash-latest",
+				reasoning: { enabled: false },
+			}),
+			makeContext({
+				providerId: "vertex",
+				modelId: "gemini-flash-latest",
+				family: "gemini-flash",
+				capabilities: ["reasoning"],
+			}),
+		);
+
+		expect(result.vertex).toEqual(
+			expect.objectContaining({
+				thinkingConfig: { thinkingBudget: 0, includeThoughts: false },
+			}),
+		);
+		expect(result.vertex).not.toHaveProperty("thinking");
+		expect(result.vertex).not.toHaveProperty("effort");
+		expect(result.vertex).not.toHaveProperty("reasoningEffort");
+		expect(result.vertex).not.toHaveProperty("reasoningSummary");
+		expect(result.google).toBeUndefined();
+	});
+
+	it("maps Vertex Gemini Flash Latest effort to a Gemini 2.5 thinking budget", () => {
+		const result = composeAiSdkProviderOptions(
+			makeRequest({
+				providerId: "vertex",
+				modelId: "gemini-flash-latest",
+				reasoning: { enabled: true, effort: "high" },
+			}),
+			makeContext({
+				providerId: "vertex",
+				modelId: "gemini-flash-latest",
+				family: "gemini-flash",
+				capabilities: ["reasoning"],
+			}),
+		);
+
+		expect(result.vertex).toEqual(
+			expect.objectContaining({
+				thinkingConfig: { thinkingBudget: 24576, includeThoughts: true },
+			}),
+		);
+		expect(result.vertex).not.toHaveProperty("thinking");
+		expect(result.vertex).not.toHaveProperty("effort");
+		expect(result.vertex).not.toHaveProperty("reasoningEffort");
+		expect(result.vertex).not.toHaveProperty("reasoningSummary");
+		expect(result.google).toBeUndefined();
+	});
+
+	it("keeps disabled Vertex Gemini 2.5 Pro on a valid minimum thinking budget", () => {
+		const result = composeAiSdkProviderOptions(
+			makeRequest({
+				providerId: "vertex",
+				modelId: "gemini-2.5-pro",
+				reasoning: { enabled: false },
+			}),
+			makeContext({
+				providerId: "vertex",
+				modelId: "gemini-2.5-pro",
+				family: "gemini-pro",
+				capabilities: ["reasoning"],
+			}),
+		);
+
+		expect(result.vertex).toEqual(
+			expect.objectContaining({
+				thinkingConfig: { thinkingBudget: 128, includeThoughts: false },
+			}),
+		);
+		expect(result.vertex).not.toHaveProperty("thinking");
+		expect(result.vertex).not.toHaveProperty("effort");
+		expect(result.vertex).not.toHaveProperty("reasoningEffort");
+		expect(result.vertex).not.toHaveProperty("reasoningSummary");
 		expect(result.google).toBeUndefined();
 	});
 });

--- a/sdk/packages/llms/src/providers/routing/provider-options.test.ts
+++ b/sdk/packages/llms/src/providers/routing/provider-options.test.ts
@@ -1480,6 +1480,32 @@ describe("composeAiSdkProviderOptions: provider-specific overlays", () => {
 		expect(result.google).toBeUndefined();
 	});
 
+	it("keeps Vertex Claude reasoning on the Anthropic-compatible route", () => {
+		const result = composeAiSdkProviderOptions(
+			makeRequest({
+				providerId: "vertex",
+				modelId: "claude-sonnet-4-5",
+				reasoning: { enabled: true, effort: "high" },
+			}),
+			makeContext({
+				providerId: "vertex",
+				modelId: "claude-sonnet-4-5",
+				family: "claude-sonnet",
+				capabilities: ["text", "reasoning"],
+			}),
+		);
+
+		expect(result.vertex).toEqual(
+			expect.objectContaining({
+				reasoning: { enabled: true, max_tokens: 1024 },
+			}),
+		);
+		expect(result.vertex).not.toHaveProperty("thinkingConfig");
+		expect(result.vertex).not.toHaveProperty("effort");
+		expect(result.vertex).not.toHaveProperty("reasoningEffort");
+		expect(result.vertex).not.toHaveProperty("reasoningSummary");
+	});
+
 	it("maps disabled Vertex thinking to minimal thinkingConfig", () => {
 		const result = composeAiSdkProviderOptions(
 			makeRequest({

--- a/sdk/packages/llms/src/providers/routing/provider-options.test.ts
+++ b/sdk/packages/llms/src/providers/routing/provider-options.test.ts
@@ -1454,4 +1454,46 @@ describe("composeAiSdkProviderOptions: provider-specific overlays", () => {
 		expect(result.google).not.toHaveProperty("reasoningEffort");
 		expect(result.google).not.toHaveProperty("reasoningSummary");
 	});
+
+	it("emits Gemini thinkingConfig in the vertex bucket for Vertex providers", () => {
+		const result = composeAiSdkProviderOptions(
+			makeRequest({
+				providerId: "vertex",
+				modelId: "gemini-3-flash-preview",
+				reasoning: { enabled: true, effort: "high" },
+			}),
+			makeContext({
+				providerId: "vertex",
+				modelId: "gemini-3-flash-preview",
+			}),
+		);
+
+		expect(result.vertex).toEqual(
+			expect.objectContaining({
+				thinkingConfig: { thinkingLevel: "high", includeThoughts: true },
+			}),
+		);
+		expect(result.google).toBeUndefined();
+	});
+
+	it("maps disabled Vertex thinking to minimal thinkingConfig", () => {
+		const result = composeAiSdkProviderOptions(
+			makeRequest({
+				providerId: "vertex",
+				modelId: "gemini-3-flash-preview",
+				reasoning: { enabled: false },
+			}),
+			makeContext({
+				providerId: "vertex",
+				modelId: "gemini-3-flash-preview",
+			}),
+		);
+
+		expect(result.vertex).toEqual(
+			expect.objectContaining({
+				thinkingConfig: { thinkingLevel: "minimal", includeThoughts: false },
+			}),
+		);
+		expect(result.google).toBeUndefined();
+	});
 });


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

### Description

Fixes the SDK CLI Vertex path for Gemini models that use ADC and tool calls.

This PR fixes several issues hit when running Cline CLI against Vertex-hosted Gemini models, including `gemini-3-flash-preview` and `gemini-flash-early-exp`:

- Preserve Vertex ADC auth by avoiding API-key fallback from GCP environment variables.
- Forward cloud provider options such as Vertex project and location into the gateway provider config.
- Restore tool names for persisted legacy `tool_result` blocks before replaying them to AI SDK.
- Preserve and replay Gemini/Vertex thought signatures across tool-call turns.

### Test Procedure

Tested with focused unit/type checks and real SDK CLI inference through Vertex using local ADC.

- `cd sdk && bun -F @cline/core test:unit -- src/runtime/config/agent-message-codec.test.ts src/services/llms/handler-factory.test.ts`
- `cd sdk && bun -F @cline/llms test -- src/providers/vendors/vertex.test.ts src/providers/gateway.test.ts`
- `cd sdk && bun -F @cline/core typecheck`
- `cd sdk && bun -F @cline/llms typecheck`
- Real inference smoke with `vertex/gemini-3-flash-preview`: created a file, ran `cat`, completed with `SDK_VERTEX_GEMINI_RERUN_OK`.
- Real inference smoke with `vertex/gemini-flash-early-exp`: created a file, ran `cat`, completed with `SDK_VERTEX_AJAX_OK`.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A. Backend/SDK CLI fix.

### Additional Notes

This was verified against latest `main` with the SDK CLI under `sdk/apps/cli` using local Application Default Credentials.
