### PR TITLE
fix(deps): align isbinaryfile declared floor with lockfile (^5.0.7)

### DIFF
--- a/apps/vscode/package-lock.json
+++ b/apps/vscode/package-lock.json
@@ -69,7 +69,7 @@
 				"iconv-lite": "^0.6.3",
 				"ignore": "^7.0.3",
 				"image-size": "^2.0.2",
-				"isbinaryfile": "^5.0.2",
+				"isbinaryfile": "^5.0.7",
 				"jschardet": "^3.1.4",
 				"json5": "^2.2.3",
 				"mammoth": "^1.11.0",

--- a/apps/vscode/package.json
+++ b/apps/vscode/package.json
@@ -546,7 +546,7 @@
 		"iconv-lite": "^0.6.3",
 		"ignore": "^7.0.3",
 		"image-size": "^2.0.2",
-		"isbinaryfile": "^5.0.2",
+		"isbinaryfile": "^5.0.7",
 		"jschardet": "^3.1.4",
 		"json5": "^2.2.3",
 		"mammoth": "^1.11.0",


### PR DESCRIPTION
### Related Issue

**Issue:** N/A — small dependency-floor alignment per the template's "Limited exceptions" clause.

> Fork chain: **Cline → Roo-Code → Zoo-Code**. Full background, stack trace, and fix verification: **[Zoo-Code-Org/Zoo-Code#88](https://github.com/Zoo-Code-Org/Zoo-Code/pull/88)**. This PR upstreams the declared-floor alignment to Cline.

### Description

[`package.json`](package.json:553) declared `"isbinaryfile": "^5.0.2"`, but [`package-lock.json`](package-lock.json:1) already resolves to `5.0.7` (auto-upgraded in #9127). This PR aligns the declared SemVer floor so a future lockfile regeneration cannot land back on the buggy `5.0.2` / `5.0.4` (which crash with `RangeError: Invalid array length` on UTF-8 files at the 512-byte boundary).

```diff
- "isbinaryfile": "^5.0.2",
+ "isbinaryfile": "^5.0.7",
```

```diff
# package-lock.json  (root packages."" mirror; the resolved entry was already 5.0.7)
- "isbinaryfile": "^5.0.2",
+ "isbinaryfile": "^5.0.7",
```

### Test Procedure

**No runtime testing required** — this PR is a no-op for anyone whose lockfile is already at `5.0.7` (i.e. current `main`). It only tightens the declared floor.

Static verification: `npm ci --dry-run --ignore-scripts` passes (lockfile and `package.json` are internally consistent).

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A — see [Zoo-Code#88](https://github.com/Zoo-Code-Org/Zoo-Code/pull/88) for runtime crash reproduction on the descendant fork.

### Additional Notes

None.
