### PR TITLE
Add compaction budget projection contract

### DIFF
--- a/sdk/packages/core/src/extensions/context/budget-projection/index.ts
+++ b/sdk/packages/core/src/extensions/context/budget-projection/index.ts
@@ -1,0 +1,14 @@
+export type {
+	BlockBudgetClass,
+	BudgetAction,
+	BudgetActionKind,
+	BudgetActionReason,
+	BudgetPath,
+	BudgetPolicyIntent,
+	BudgetProjectionOptions,
+	BudgetProjectionResult,
+	BudgetProjectionWarning,
+	ContentBlockBudgetClassification,
+	LiveTailHandling,
+} from "./types";
+

--- a/sdk/packages/core/src/extensions/context/budget-projection/types.ts
+++ b/sdk/packages/core/src/extensions/context/budget-projection/types.ts
@@ -1,0 +1,88 @@
+import type { ContentBlock, MessageWithMetadata } from "@cline/shared";
+
+export type BudgetPolicyIntent =
+	| "agentic_summary"
+	| "basic_compaction_projection"
+	| "normal_provider_request";
+
+export type BudgetActionKind =
+	| "truncated_text"
+	| "dropped_block"
+	| "dropped_message"
+	| "preserved";
+
+export type BudgetActionReason =
+	| "over_budget"
+	| "unsafe_to_truncate"
+	| "tool_pair_boundary"
+	| "protected_live_tail";
+
+export type LiveTailHandling =
+	| "included_verbatim"
+	| "included_degraded"
+	| "summarized_as_context"
+	| "omitted_with_warning"
+	| "preserved_out_of_band";
+
+export type BlockBudgetClass =
+	| "text"
+	| "thinking"
+	| "tool_use"
+	| "tool_result"
+	| "unsafe_binary"
+	| "unsafe_encrypted"
+	| "opaque";
+
+export interface BudgetPath {
+	messageIndex: number;
+	blockIndex?: number;
+}
+
+interface BaseBudgetAction {
+	path: BudgetPath;
+	originalSize: number;
+	finalSize: number;
+}
+
+export interface BudgetMutationAction extends BaseBudgetAction {
+	kind: Exclude<BudgetActionKind, "preserved">;
+	reason: BudgetActionReason;
+}
+
+export interface BudgetPreservedAction extends BaseBudgetAction {
+	kind: "preserved";
+	reason: Extract<
+		BudgetActionReason,
+		"protected_live_tail" | "tool_pair_boundary"
+	>;
+}
+
+export type BudgetAction = BudgetMutationAction | BudgetPreservedAction;
+
+export interface BudgetProjectionWarning {
+	code: string;
+	message: string;
+	path?: BudgetPath;
+}
+
+export interface BudgetProjectionOptions {
+	messages: MessageWithMetadata[];
+	targetTokens: number;
+	policyIntent: BudgetPolicyIntent;
+	estimateMessageTokens: (message: MessageWithMetadata) => number;
+}
+
+export interface BudgetProjectionResult {
+	messages: MessageWithMetadata[];
+	actions: BudgetAction[];
+	liveTailHandling: LiveTailHandling;
+	estimatedTokens: number;
+	warnings: BudgetProjectionWarning[];
+}
+
+export interface ContentBlockBudgetClassification {
+	block: ContentBlock;
+	budgetClass: BlockBudgetClass;
+	canStringTruncate: boolean;
+	canDropWholeBlock: boolean;
+}

--- a/sdk/packages/core/src/extensions/context/budget-projection/types.ts
+++ b/sdk/packages/core/src/extensions/context/budget-projection/types.ts
@@ -44,10 +44,15 @@ interface BaseBudgetAction {
 	finalSize: number;
 }
 
-export interface BudgetMutationAction extends BaseBudgetAction {
-	kind: Exclude<BudgetActionKind, "preserved">;
-	reason: BudgetActionReason;
-}
+export type BudgetMutationAction =
+	| (BaseBudgetAction & {
+			kind: "truncated_text";
+			reason: Extract<BudgetActionReason, "over_budget">;
+	  })
+	| (BaseBudgetAction & {
+			kind: "dropped_block" | "dropped_message";
+			reason: Exclude<BudgetActionReason, "protected_live_tail">;
+	  });
 
 export interface BudgetPreservedAction extends BaseBudgetAction {
 	kind: "preserved";
@@ -59,8 +64,12 @@ export interface BudgetPreservedAction extends BaseBudgetAction {
 
 export type BudgetAction = BudgetMutationAction | BudgetPreservedAction;
 
+export type BudgetProjectionWarningCode =
+	| "budget_impossible"
+	| "budget_unachievable_with_protections";
+
 export interface BudgetProjectionWarning {
-	code: string;
+	code: BudgetProjectionWarningCode;
 	message: string;
 	path?: BudgetPath;
 }

--- a/sdk/packages/core/src/extensions/context/budget-projection/types.ts
+++ b/sdk/packages/core/src/extensions/context/budget-projection/types.ts
@@ -50,7 +50,12 @@ export type BudgetMutationAction =
 			reason: Extract<BudgetActionReason, "over_budget">;
 	  })
 	| (BaseBudgetAction & {
-			kind: "dropped_block" | "dropped_message";
+			kind: "dropped_block";
+			path: Required<BudgetPath>;
+			reason: Exclude<BudgetActionReason, "protected_live_tail">;
+	  })
+	| (BaseBudgetAction & {
+			kind: "dropped_message";
 			reason: Exclude<BudgetActionReason, "protected_live_tail">;
 	  });
 


### PR DESCRIPTION
### Related Issue

**Issue:** ENG-1967

### Description

Adds the shared compaction budget projection contract used by the follow-up compaction hardening PRs.

This PR is intentionally groundwork-only: it defines policy intent, budget actions, warnings, live-tail handling, block classifications, and the projection result shape without adding callers yet.

### Test Procedure

Validated at the stack tip with:

- `cd sdk && bun -F @cline/core test:unit -- src/extensions/context/compaction.test.ts src/extensions/context/budget-projection/project.test.ts src/services/telemetry/core-events.test.ts`
- `cd sdk && bun --filter @cline/core typecheck`
- `git diff --check`

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality not to work as expected)
-   [x] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A

### Additional Notes

Stack base: #10651 (`robin/eng-1967-preserve-canonical-session-history`).

### Diagram

Whole live stack tracked by ENG-1967:

```text
canonical history sidecar (#10651)
        |
        v
#10786 budget contract
        |
        v
#10800 pure budget projection engine
        |
        v
#10801 agentic summary input uses projection
        |
        v
#10802 basic compaction output uses projection
        |
        v
#10803 telemetry/status for budget emergency
        |
        v
MessageBuilder hard byte wall remains final provider guard
```

This PR:

```text
compaction caller
        |
        v
BudgetProjectionOptions
        |
        v
BudgetProjectionResult
        |
        +--> messages safe to continue with
        +--> actions for what changed
        +--> warnings for degraded/impossible budgets
        +--> liveTailHandling for reviewer/telemetry context
```