### PR TITLE
fix(e2e): harden VS Code teardown

### DIFF
--- a/src/test/e2e/chat.test.ts
+++ b/src/test/e2e/chat.test.ts
@@ -1,7 +1,7 @@
 import { expect } from "@playwright/test"
 import { e2e } from "./utils/helpers"
 
-e2e("Chat - can send messages and switch between modes", async ({ helper, sidebar, page }) => {
+e2e("Chat - can send messages and switch between modes", async ({ helper, sidebar }) => {
 	// Sign in
 	await helper.signin(sidebar)
 
@@ -59,6 +59,4 @@ e2e("Chat - can send messages and switch between modes", async ({ helper, sideba
 	// Add following text to verify it works correctly
 	await inputbox.pressSequentially("following text should be preserved")
 	await expect(inputbox).toHaveValue("@problems following text should be preserved")
-
-	await page.close()
 })

--- a/src/test/e2e/diff.test.ts
+++ b/src/test/e2e/diff.test.ts
@@ -38,8 +38,6 @@ e2e.describe("Diff Editor", () => {
 			)
 			await diffEditor.click()
 			await expect(diffEditor).toBeVisible()
-
-			await page.close()
 		})
 	})
 })

--- a/src/test/e2e/utils/helpers.ts
+++ b/src/test/e2e/utils/helpers.ts
@@ -1,4 +1,5 @@
-import { mkdtempSync, type PathLike, type RmOptions, rmSync } from "node:fs"
+import type { ChildProcess } from "node:child_process"
+import { mkdtempSync, type PathLike, type RmOptions, readdirSync, rmSync } from "node:fs"
 import * as os from "node:os"
 import * as path from "node:path"
 import { type ElectronApplication, expect, type Frame, type Page, test } from "@playwright/test"
@@ -22,6 +23,9 @@ export class E2ETestHelper {
 	// Constants
 	public static readonly CODEBASE_ROOT_DIR = path.resolve(__dirname, "..", "..", "..", "..")
 	public static readonly E2E_TESTS_DIR = path.join(E2ETestHelper.CODEBASE_ROOT_DIR, "src", "test", "e2e")
+	private static readonly TEARDOWN_TIMEOUT_MS = 10_000
+	private static readonly WINDOW_DIAGNOSTIC_TIMEOUT_MS = 1_000
+	private static readonly PROCESS_EXIT_TIMEOUT_MS = 2_000
 
 	// Instance properties for caching
 	private cachedFrame: Frame | null = null
@@ -115,6 +119,138 @@ export class E2ETestHelper {
 				}
 				await new Promise((resolve) => setTimeout(resolve, 50 * attempt)) // Progressive delay
 			}
+		}
+	}
+
+	private static async withTimeout<T>(
+		promise: Promise<T>,
+		timeoutMs: number,
+	): Promise<{ timedOut: false; value: T } | { timedOut: true }> {
+		let timeout: ReturnType<typeof setTimeout> | undefined
+		let timedOut = false
+
+		try {
+			const value = await Promise.race([
+				promise.then((value) => ({ timedOut: false as const, value })),
+				new Promise<{ timedOut: true }>((resolve) => {
+					timeout = setTimeout(() => {
+						timedOut = true
+						resolve({ timedOut: true })
+					}, timeoutMs)
+				}),
+			])
+
+			return value
+		} finally {
+			if (timeout) {
+				clearTimeout(timeout)
+			}
+			if (timedOut) {
+				void promise.catch(() => undefined)
+			}
+		}
+	}
+
+	private static async getWindowDiagnostics(app: ElectronApplication): Promise<string> {
+		const windows = app.windows()
+		const titles = await Promise.all(
+			windows.map(async (window, index) => {
+				if (window.isClosed()) {
+					return `#${index}: closed`
+				}
+
+				const title = await E2ETestHelper.withTimeout(window.title(), E2ETestHelper.WINDOW_DIAGNOSTIC_TIMEOUT_MS)
+				return title.timedOut ? `#${index}: title timed out` : `#${index}: ${title.value || "<untitled>"}`
+			}),
+		)
+
+		return titles.length > 0 ? titles.join(", ") : "no windows"
+	}
+
+	private static async waitForProcessExit(process: ChildProcess, timeoutMs: number): Promise<boolean> {
+		if (process.exitCode !== null || process.signalCode !== null) {
+			return true
+		}
+
+		return new Promise((resolve) => {
+			const onExit = () => {
+				clearTimeout(timeout)
+				resolve(true)
+			}
+			const timeout = setTimeout(() => {
+				process.off("exit", onExit)
+				resolve(process.exitCode !== null || process.signalCode !== null)
+			}, timeoutMs)
+
+			process.once("exit", onExit)
+		})
+	}
+
+	public static async closePageForTeardown(page: Page): Promise<void> {
+		if (page.isClosed()) {
+			return
+		}
+
+		const result = await E2ETestHelper.withTimeout(page.close(), E2ETestHelper.TEARDOWN_TIMEOUT_MS).catch((error) => {
+			console.warn(`[e2e teardown] page.close() failed: ${error}`)
+			return { timedOut: false as const, value: undefined }
+		})
+		if (result.timedOut) {
+			console.warn(`[e2e teardown] page.close() exceeded ${E2ETestHelper.TEARDOWN_TIMEOUT_MS}ms; continuing to app cleanup`)
+		}
+	}
+
+	public static async closeAppForTeardown(app: ElectronApplication): Promise<void> {
+		const process = app.process()
+		const getProcessSummary = () =>
+			process
+				? `pid=${process.pid ?? "unknown"} exitCode=${process.exitCode ?? "null"} signalCode=${process.signalCode ?? "null"} killed=${process.killed}`
+				: "process unavailable"
+
+		const closeResult = await E2ETestHelper.withTimeout(app.close(), E2ETestHelper.TEARDOWN_TIMEOUT_MS).catch((error) => {
+			console.warn(`[e2e teardown] app.close() failed: ${error}`)
+			return { timedOut: true as const }
+		})
+		if (!closeResult.timedOut) {
+			return
+		}
+
+		const windowDiagnostics = await E2ETestHelper.getWindowDiagnostics(app).catch(
+			(error) => `window diagnostics failed: ${error}`,
+		)
+		console.warn(
+			`[e2e teardown] app.close() exceeded ${E2ETestHelper.TEARDOWN_TIMEOUT_MS}ms; forcing VS Code/Electron shutdown (${getProcessSummary()}; windows: ${windowDiagnostics})`,
+		)
+
+		if (!process || process.killed || process.exitCode !== null) {
+			return
+		}
+
+		try {
+			if (process.kill("SIGKILL")) {
+				const exited = await E2ETestHelper.waitForProcessExit(process, E2ETestHelper.PROCESS_EXIT_TIMEOUT_MS)
+				if (!exited) {
+					console.warn(
+						`[e2e teardown] VS Code/Electron process did not report exit within ${E2ETestHelper.PROCESS_EXIT_TIMEOUT_MS}ms after SIGKILL (${getProcessSummary()})`,
+					)
+				}
+				return
+			}
+
+			console.warn(
+				`[e2e teardown] SIGKILL returned false for VS Code/Electron process; skipping SIGTERM (${getProcessSummary()})`,
+			)
+			return
+		} catch (error) {
+			console.warn(`[e2e teardown] SIGKILL failed for VS Code/Electron process: ${error}`)
+		}
+
+		try {
+			if (process.exitCode === null && process.signalCode === null && process.kill("SIGTERM")) {
+				await E2ETestHelper.waitForProcessExit(process, E2ETestHelper.PROCESS_EXIT_TIMEOUT_MS)
+			}
+		} catch (error) {
+			console.warn(`[e2e teardown] SIGTERM failed for VS Code/Electron process: ${error}`)
 		}
 	}
 
@@ -272,23 +408,13 @@ export const e2e = test
 		app: async ({ openVSCode, userDataDir, extensionsDir, workspaceType, workspaceDir, multiRootWorkspaceDir }, use) => {
 			const workspacePath = workspaceType === "single" ? workspaceDir : multiRootWorkspaceDir
 
-			// Track the clineTestDir created in openVSCode
-			let clineTestDir: string | undefined
-			const originalOpenVSCode = openVSCode
-			const wrappedOpenVSCode = async (wp: string) => {
-				const app = await originalOpenVSCode(wp)
-				// Extract CLINE_DIR from the launched app's environment
-				// We'll need to pass it through the fixture chain
-				return app
-			}
-
 			const app = await openVSCode(workspacePath)
 
 			try {
 				await use(app)
 			} finally {
-				await app.close()
-				// Cleanup in parallel - include clineTestDir if it was created
+				await E2ETestHelper.closeAppForTeardown(app)
+				// Cleanup in parallel after the app process has been asked to exit.
 				const cleanupTasks = [
 					E2ETestHelper.rmForRetries(userDataDir, { recursive: true }),
 					E2ETestHelper.rmForRetries(extensionsDir, { recursive: true }),
@@ -298,7 +424,7 @@ export const e2e = test
 				// Find all temp directories matching our pattern
 				const tmpDir = os.tmpdir()
 				try {
-					const entries = require("node:fs").readdirSync(tmpDir)
+					const entries = readdirSync(tmpDir)
 					for (const entry of entries) {
 						if (entry.startsWith("cline-e2e-")) {
 							cleanupTasks.push(E2ETestHelper.rmForRetries(path.join(tmpDir, entry), { recursive: true }))
@@ -328,11 +454,7 @@ export const e2e = test
 			try {
 				await use(page)
 			} finally {
-				// Ensure proper cleanup: Close the page if it's still open and not already closed by app.close()
-				// This provides a common teardown mechanism for all e2e tests without requiring explicit page.close() calls
-				if (!page.isClosed()) {
-					await page.close()
-				}
+				await E2ETestHelper.closePageForTeardown(page)
 			}
 		},
 	})


### PR DESCRIPTION
### Related Issue

**Issue:** Linear [ENG-2064](https://linear.app/cline-bot/issue/ENG-2064/investigate-and-harden-flaky-vs-code-e2e-teardown-failures)

### Description

This PR hardens the shared VS Code e2e teardown path after recent GitHub Actions flakes showed Playwright workers timing out while closing the Electron app.

The dominant failure signature was teardown-related rather than an assertion failure:

```text
Worker teardown timeout of 60000ms exceeded.
Tearing down "app" exceeded the test timeout of 60000ms.
```

Representative failing runs from the investigation:

- https://github.com/cline/cline/actions/runs/25937344590
- https://github.com/cline/cline/actions/runs/25937328005
- https://github.com/cline/cline/actions/runs/25937322597
- https://github.com/cline/cline/actions/runs/25937495646

Changes made:

- Add bounded teardown helpers for Playwright pages and the VS Code/Electron application.
- Log process/window diagnostics when `app.close()` exceeds the teardown budget.
- Force-kill the Electron process after the bounded close attempt so one stuck shutdown does not fail the worker.
- Remove explicit `page.close()` calls from specs so the shared fixture owns lifecycle cleanup consistently.

### Test Procedure

Ran formatting and type checks:

```bash
npx tsc --noEmit --pretty false
npx biome check src/test/e2e/utils/helpers.ts src/test/e2e/chat.test.ts src/test/e2e/diff.test.ts --files-ignore-unknown=true --diagnostic-level=error
```

Ran the affected e2e specs locally:

```bash
npx playwright test -c playwright.config.ts src/test/e2e/editor.test.ts src/test/e2e/diff.test.ts src/test/e2e/chat.test.ts
```

Result: 6/6 passed.

The local Playwright run reproduced the teardown hang three times. Each time the new diagnostics logged `app.close() exceeded 10000ms`, force-killed the VS Code/Electron process, and allowed the test worker to continue passing instead of failing on teardown.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [x] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A. Test infrastructure change only.

### Additional Notes

This does not hide product/test assertion failures. It only bounds fixture cleanup when VS Code/Electron refuses to exit cleanly and emits diagnostics for future investigation.
