### PR TITLE
Add pure compaction budget projection engine

### DIFF
--- a/sdk/packages/core/src/extensions/context/budget-projection/index.ts
+++ b/sdk/packages/core/src/extensions/context/budget-projection/index.ts
@@ -1,3 +1,7 @@
+export {
+	buildBudgetProjection,
+	findLatestTypedUserMessageIndex,
+} from "./project";
 export type {
 	BlockBudgetClass,
 	BudgetAction,
@@ -11,4 +15,3 @@ export type {
 	ContentBlockBudgetClassification,
 	LiveTailHandling,
 } from "./types";
-

--- a/sdk/packages/core/src/extensions/context/budget-projection/project.test.ts
+++ b/sdk/packages/core/src/extensions/context/budget-projection/project.test.ts
@@ -213,7 +213,7 @@ describe("buildBudgetProjection", () => {
 		expect(result.actions).toEqual(
 			expect.arrayContaining([
 				expect.objectContaining({
-					kind: "dropped_message",
+					kind: "preserved",
 					path: expect.objectContaining({ messageIndex: 1 }),
 				}),
 				expect.objectContaining({
@@ -280,6 +280,84 @@ describe("buildBudgetProjection", () => {
 		);
 	});
 
+	it("drops completed tool pairs after the latest typed prompt", () => {
+		const result = buildBudgetProjection({
+			messages: [
+				{ role: "user", content: "old task " + "x".repeat(500) },
+				{ role: "user", content: "latest typed prompt" },
+				{
+					role: "assistant",
+					content: [
+						{ type: "tool_use", id: "tool_after", name: "read", input: {} },
+					],
+				},
+				{
+					role: "user",
+					content: [
+						{
+							type: "tool_result",
+							tool_use_id: "tool_after",
+							name: "read",
+							content: "huge result " + "y".repeat(2_000),
+						},
+					],
+				},
+			],
+			targetTokens: 140,
+			policyIntent: "agentic_summary",
+			estimateMessageTokens: estimateChars,
+		});
+
+		const serialized = JSON.stringify(result.messages);
+		expect(serialized).toContain("latest typed prompt");
+		expect(serialized).not.toContain("tool_after");
+		expect(result.actions).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					kind: "dropped_message",
+					reason: "tool_pair_boundary",
+					path: expect.objectContaining({ messageIndex: 2 }),
+				}),
+				expect.objectContaining({
+					kind: "dropped_message",
+					reason: "tool_pair_boundary",
+					path: expect.objectContaining({ messageIndex: 3 }),
+				}),
+			]),
+		);
+	});
+
+	it("preserves unresolved tool use after the latest typed prompt", () => {
+		const result = buildBudgetProjection({
+			messages: [
+				{ role: "user", content: "old task " + "x".repeat(500) },
+				{ role: "user", content: "latest typed prompt" },
+				{
+					role: "assistant",
+					content: [
+						{
+							type: "tool_use",
+							id: "tool_live",
+							name: "run_command",
+							input: { command: "sleep 1" },
+						},
+					],
+				},
+			],
+			targetTokens: 80,
+			policyIntent: "agentic_summary",
+			estimateMessageTokens: estimateChars,
+		});
+
+		const serialized = JSON.stringify(result.messages);
+		expect(serialized).toContain("latest typed prompt");
+		expect(serialized).toContain("tool_live");
+		expect(result.status).toBe("failed");
+		expect(result.warnings[0]?.code).toBe(
+			"budget_unachievable_with_protections",
+		);
+	});
+
 	it("does not preserve later text or file blocks after tool-result budget is exhausted", () => {
 		const result = buildBudgetProjection({
 			messages: [
@@ -335,7 +413,7 @@ describe("buildBudgetProjection", () => {
 					],
 				},
 			],
-			targetTokens: 190,
+			targetTokens: 900,
 			policyIntent: "agentic_summary",
 			estimateMessageTokens: estimateChars,
 		});

--- a/sdk/packages/core/src/extensions/context/budget-projection/project.test.ts
+++ b/sdk/packages/core/src/extensions/context/budget-projection/project.test.ts
@@ -121,6 +121,36 @@ describe("buildBudgetProjection", () => {
 		);
 	});
 
+	it("protects latest typed user after thinking-only messages are pruned", () => {
+		const result = buildBudgetProjection({
+			messages: [
+				{ role: "user", content: "old task" },
+				{
+					role: "assistant",
+					content: [{ type: "thinking", thinking: "discard me" }],
+				},
+				{
+					role: "user",
+					content: [
+						{ type: "text", text: "what is in this image?" },
+						{
+							type: "image",
+							data: "live-image",
+							mediaType: "image/png",
+						},
+					],
+				},
+			],
+			targetTokens: 1_000,
+			policyIntent: "agentic_summary",
+			estimateMessageTokens: estimateChars,
+		});
+
+		const serialized = JSON.stringify(result.messages);
+		expect(serialized).toContain("live-image");
+		expect(serialized).not.toContain("discard me");
+	});
+
 	it("keeps tool-use and tool-result pairs coherent when dropping history", () => {
 		const result = buildBudgetProjection({
 			messages: [

--- a/sdk/packages/core/src/extensions/context/budget-projection/project.test.ts
+++ b/sdk/packages/core/src/extensions/context/budget-projection/project.test.ts
@@ -169,11 +169,12 @@ describe("buildBudgetProjection", () => {
 				{
 					role: "user",
 					content: [
-						{
-							type: "tool_result",
-							tool_use_id: "tool_1",
-							content: "x".repeat(1000),
-						},
+							{
+								type: "tool_result",
+								tool_use_id: "tool_1",
+								name: "read_files",
+								content: "x".repeat(1000),
+							},
 					],
 				},
 				{ role: "user", content: "latest task" },
@@ -236,11 +237,12 @@ describe("buildBudgetProjection", () => {
 			{
 				role: "user",
 				content: [
-					{
-						type: "tool_result",
-						tool_use_id: "tool_1",
-						content: "result",
-					},
+						{
+							type: "tool_result",
+							tool_use_id: "tool_1",
+							name: "read",
+							content: "result",
+						},
 				],
 			},
 		];
@@ -259,6 +261,7 @@ describe("buildBudgetProjection", () => {
 						{
 							type: "tool_result",
 							tool_use_id: "tool_1",
+							name: "read",
 							content: "result " + "y".repeat(500),
 						},
 					],
@@ -293,6 +296,7 @@ describe("buildBudgetProjection", () => {
 						{
 							type: "tool_result",
 							tool_use_id: "tool_live",
+							name: "read",
 							content: [
 								{ type: "text", text: "a".repeat(200) },
 								{ type: "file", path: "/tmp/huge.txt", content: "b".repeat(1_000) },
@@ -360,6 +364,7 @@ describe("buildBudgetProjection", () => {
 						{
 							type: "tool_result",
 							tool_use_id: "tool_old",
+							name: "read",
 							content: [
 								{ type: "text", text: "old output" },
 								{

--- a/sdk/packages/core/src/extensions/context/budget-projection/project.test.ts
+++ b/sdk/packages/core/src/extensions/context/budget-projection/project.test.ts
@@ -114,12 +114,9 @@ describe("buildBudgetProjection", () => {
 		});
 
 		expect(JSON.stringify(result.messages)).toContain("live-image");
-		expect(result.actions).toEqual(
+		expect(result.actions).not.toEqual(
 			expect.arrayContaining([
-				expect.objectContaining({
-					kind: "preserved",
-					reason: "protected_live_tail",
-				}),
+				expect.objectContaining({ kind: "dropped_block" }),
 			]),
 		);
 	});
@@ -292,7 +289,7 @@ describe("buildBudgetProjection", () => {
 		);
 	});
 
-	it("clears thinking blocks after the message text budget is exhausted", () => {
+	it("drops thinking blocks instead of mutating provider-native reasoning", () => {
 		const result = buildBudgetProjection({
 			messages: [
 				{ role: "user", content: "latest typed prompt" },
@@ -313,6 +310,54 @@ describe("buildBudgetProjection", () => {
 			(message) => message.role === "assistant",
 		);
 		expect(JSON.stringify(assistant)).not.toContain("b".repeat(100));
+		expect(JSON.stringify(assistant)).not.toContain("\"thinking\"");
+		expect(result.actions).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					kind: "dropped_block",
+					reason: "unsafe_to_truncate",
+				}),
+			]),
+		);
 	});
 
+	it("drops nested unsafe tool-result blocks outside the protected tail", () => {
+		const result = buildBudgetProjection({
+			messages: [
+				{
+					role: "user",
+					content: [
+						{
+							type: "tool_result",
+							tool_use_id: "tool_old",
+							content: [
+								{ type: "text", text: "old output" },
+								{
+									type: "image",
+									data: "old-image-data",
+									mediaType: "image/png",
+								},
+							],
+						},
+					],
+				},
+				{ role: "user", content: "latest typed prompt" },
+			],
+			targetTokens: 1_000,
+			policyIntent: "agentic_summary",
+			estimateMessageTokens: estimateChars,
+		});
+
+		const serialized = JSON.stringify(result.messages);
+		expect(serialized).toContain("old output");
+		expect(serialized).not.toContain("old-image-data");
+		expect(result.actions).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					kind: "dropped_block",
+					reason: "unsafe_to_truncate",
+				}),
+			]),
+		);
+	});
 });

--- a/sdk/packages/core/src/extensions/context/budget-projection/project.test.ts
+++ b/sdk/packages/core/src/extensions/context/budget-projection/project.test.ts
@@ -169,12 +169,12 @@ describe("buildBudgetProjection", () => {
 				{
 					role: "user",
 					content: [
-							{
-								type: "tool_result",
-								tool_use_id: "tool_1",
-								name: "read_files",
-								content: "x".repeat(1000),
-							},
+						{
+							type: "tool_result",
+							tool_use_id: "tool_1",
+							name: "read_files",
+							content: "x".repeat(1000),
+						},
 					],
 				},
 				{ role: "user", content: "latest task" },
@@ -237,12 +237,12 @@ describe("buildBudgetProjection", () => {
 			{
 				role: "user",
 				content: [
-						{
-							type: "tool_result",
-							tool_use_id: "tool_1",
-							name: "read",
-							content: "result",
-						},
+					{
+						type: "tool_result",
+						tool_use_id: "tool_1",
+						name: "read",
+						content: "result",
+					},
 				],
 			},
 		];

--- a/sdk/packages/core/src/extensions/context/budget-projection/project.test.ts
+++ b/sdk/packages/core/src/extensions/context/budget-projection/project.test.ts
@@ -1,0 +1,294 @@
+import type { MessageWithMetadata } from "@cline/shared";
+import { describe, expect, it } from "vitest";
+import {
+	buildBudgetProjection,
+	findLatestTypedUserMessageIndex,
+} from "./project";
+
+const estimateChars = (message: MessageWithMetadata) =>
+	JSON.stringify(message).length;
+
+describe("buildBudgetProjection", () => {
+	it("fails explicitly for impossible budgets", () => {
+		const result = buildBudgetProjection({
+			messages: [{ role: "user", content: "keep me" }],
+			targetTokens: 0,
+			policyIntent: "agentic_summary",
+			estimateMessageTokens: estimateChars,
+		});
+
+		expect(result.status).toBe("failed");
+		expect(result.messages).toHaveLength(1);
+		expect(result.warnings[0]?.code).toBe("budget_impossible");
+	});
+
+	it("drops unsafe image and redacted thinking blocks instead of truncating them", () => {
+		const result = buildBudgetProjection({
+			messages: [
+				{
+					role: "assistant",
+					content: [
+						{ type: "text", text: "old context" },
+						{
+							type: "redacted_thinking",
+							data: "x".repeat(500),
+						},
+					],
+				},
+				{
+					role: "assistant",
+					content: [
+						{
+							type: "image",
+							data: "y".repeat(500),
+							mediaType: "image/png",
+						},
+					],
+				},
+				{ role: "user", content: "latest task" },
+			],
+			targetTokens: 150,
+			policyIntent: "agentic_summary",
+			estimateMessageTokens: estimateChars,
+		});
+
+		const serialized = JSON.stringify(result.messages);
+		expect(serialized).not.toContain("redacted_thinking");
+		expect(serialized).not.toContain("image/png");
+		expect(result.actions).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					kind: "dropped_block",
+					reason: "unsafe_to_truncate",
+				}),
+			]),
+		);
+		expect(result.liveTailHandling).toBe("included_degraded");
+	});
+
+	it("keeps unsafe blocks when input is already under budget", () => {
+		const result = buildBudgetProjection({
+			messages: [
+				{
+					role: "user",
+					content: [
+						{ type: "text", text: "look at this" },
+						{
+							type: "image",
+							data: "small-image",
+							mediaType: "image/png",
+						},
+					],
+				},
+			],
+			targetTokens: 1_000,
+			policyIntent: "agentic_summary",
+			estimateMessageTokens: estimateChars,
+		});
+
+		expect(result.status).toBe("ok");
+		expect(result.actions).toEqual([]);
+		expect(result.liveTailHandling).toBe("included_verbatim");
+		expect(JSON.stringify(result.messages)).toContain("small-image");
+	});
+
+	it("preserves unsafe blocks in the latest typed user message", () => {
+		const result = buildBudgetProjection({
+			messages: [
+				{ role: "user", content: "old task " + "x".repeat(500) },
+				{
+					role: "user",
+					content: [
+						{ type: "text", text: "what is in this image?" },
+						{
+							type: "image",
+							data: "live-image",
+							mediaType: "image/png",
+						},
+					],
+				},
+			],
+			targetTokens: 120,
+			policyIntent: "basic_compaction_projection",
+			estimateMessageTokens: estimateChars,
+		});
+
+		expect(JSON.stringify(result.messages)).toContain("live-image");
+		expect(result.actions).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					kind: "preserved",
+					reason: "protected_live_tail",
+				}),
+			]),
+		);
+	});
+
+	it("keeps tool-use and tool-result pairs coherent when dropping history", () => {
+		const result = buildBudgetProjection({
+			messages: [
+				{ role: "user", content: "original task" },
+				{
+					role: "assistant",
+					content: [
+						{
+							type: "tool_use",
+							id: "tool_1",
+							name: "read_files",
+							input: { file_paths: ["/tmp/a.ts"] },
+						},
+					],
+				},
+				{
+					role: "user",
+					content: [
+						{
+							type: "tool_result",
+							tool_use_id: "tool_1",
+							content: "x".repeat(1000),
+						},
+					],
+				},
+				{ role: "user", content: "latest task" },
+			],
+			targetTokens: 140,
+			policyIntent: "basic_compaction_projection",
+			estimateMessageTokens: estimateChars,
+		});
+
+		const serialized = JSON.stringify(result.messages);
+		expect(serialized).not.toContain("tool_1");
+		expect(serialized).toContain("latest task");
+		expect(result.actions).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ reason: "tool_pair_boundary" }),
+			]),
+		);
+	});
+
+	it("records budget action paths against original message indexes", () => {
+		const result = buildBudgetProjection({
+			messages: [
+				{
+					role: "assistant",
+					content: [{ type: "image", data: "x", mediaType: "image/png" }],
+				},
+				{ role: "user", content: "old task " + "x".repeat(500) },
+				{ role: "assistant", content: "old answer " + "y".repeat(500) },
+				{ role: "user", content: "latest task" },
+			],
+			targetTokens: 80,
+			policyIntent: "basic_compaction_projection",
+			estimateMessageTokens: estimateChars,
+		});
+
+		expect(result.actions).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					kind: "dropped_message",
+					path: expect.objectContaining({ messageIndex: 1 }),
+				}),
+				expect.objectContaining({
+					kind: "dropped_message",
+					path: expect.objectContaining({ messageIndex: 2 }),
+				}),
+			]),
+		);
+	});
+
+	it("detects the latest typed user message when tool results follow it", () => {
+		const messages: MessageWithMetadata[] = [
+			{ role: "user", content: "old task" },
+			{ role: "user", content: "latest typed prompt" },
+			{
+				role: "assistant",
+				content: [
+					{ type: "tool_use", id: "tool_1", name: "read", input: {} },
+				],
+			},
+			{
+				role: "user",
+				content: [
+					{
+						type: "tool_result",
+						tool_use_id: "tool_1",
+						content: "result",
+					},
+				],
+			},
+		];
+
+		expect(findLatestTypedUserMessageIndex(messages)).toBe(1);
+	});
+
+	it("preserves the latest typed prompt under pressure", () => {
+		const result = buildBudgetProjection({
+			messages: [
+				{ role: "user", content: "old task " + "x".repeat(500) },
+				{ role: "user", content: "latest typed prompt" },
+				{
+					role: "user",
+					content: [
+						{
+							type: "tool_result",
+							tool_use_id: "tool_1",
+							content: "result " + "y".repeat(500),
+						},
+					],
+				},
+			],
+			targetTokens: 120,
+			policyIntent: "agentic_summary",
+			estimateMessageTokens: estimateChars,
+		});
+
+		expect(JSON.stringify(result.messages)).toContain("latest typed prompt");
+		expect(result.actions).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ reason: "protected_live_tail" }),
+			]),
+		);
+	});
+
+	it("does not preserve later text or file blocks after tool-result budget is exhausted", () => {
+		const result = buildBudgetProjection({
+			messages: [
+				{ role: "user", content: "latest typed prompt" },
+				{
+					role: "assistant",
+					content: [
+						{ type: "tool_use", id: "tool_live", name: "read", input: {} },
+					],
+				},
+				{
+					role: "user",
+					content: [
+						{
+							type: "tool_result",
+							tool_use_id: "tool_live",
+							content: [
+								{ type: "text", text: "a".repeat(200) },
+								{ type: "file", path: "/tmp/huge.txt", content: "b".repeat(1_000) },
+							],
+						},
+					],
+				},
+			],
+			targetTokens: 260,
+			policyIntent: "agentic_summary",
+			estimateMessageTokens: estimateChars,
+		});
+
+		const serialized = JSON.stringify(result.messages);
+		expect(serialized).toContain("latest typed prompt");
+		expect(serialized).not.toContain("b".repeat(100));
+		expect(result.actions).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					kind: "truncated_text",
+					reason: "over_budget",
+				}),
+			]),
+		);
+	});
+});

--- a/sdk/packages/core/src/extensions/context/budget-projection/project.test.ts
+++ b/sdk/packages/core/src/extensions/context/budget-projection/project.test.ts
@@ -291,4 +291,28 @@ describe("buildBudgetProjection", () => {
 			]),
 		);
 	});
+
+	it("clears thinking blocks after the message text budget is exhausted", () => {
+		const result = buildBudgetProjection({
+			messages: [
+				{ role: "user", content: "latest typed prompt" },
+				{
+					role: "assistant",
+					content: [
+						{ type: "text", text: "a".repeat(1_000) },
+						{ type: "thinking", thinking: "b".repeat(1_000) },
+					],
+				},
+			],
+			targetTokens: 190,
+			policyIntent: "agentic_summary",
+			estimateMessageTokens: estimateChars,
+		});
+
+		const assistant = result.messages.find(
+			(message) => message.role === "assistant",
+		);
+		expect(JSON.stringify(assistant)).not.toContain("b".repeat(100));
+	});
+
 });

--- a/sdk/packages/core/src/extensions/context/budget-projection/project.ts
+++ b/sdk/packages/core/src/extensions/context/budget-projection/project.ts
@@ -91,6 +91,18 @@ export function findLatestTypedUserMessageIndex(
 	return -1;
 }
 
+function findFirstTypedUserMessageIndex(
+	messages: MessageWithMetadata[],
+): number {
+	for (let index = 0; index < messages.length; index += 1) {
+		const message = messages[index];
+		if (message.role === "user" && !isToolResultOnlyUserMessage(message)) {
+			return index;
+		}
+	}
+	return -1;
+}
+
 function collectToolIds(message: MessageWithMetadata): Set<string> {
 	const ids = new Set<string>();
 	if (!Array.isArray(message.content)) {
@@ -121,6 +133,35 @@ function buildToolPairIndex(
 		}
 	}
 	return index;
+}
+
+function findProtectedTailStartIndex(messages: MessageWithMetadata[]): number {
+	const resolvedToolUseIds = new Set<string>();
+	for (const message of messages) {
+		if (!Array.isArray(message.content)) {
+			continue;
+		}
+		for (const block of message.content) {
+			if (block.type === "tool_result") {
+				resolvedToolUseIds.add(block.tool_use_id);
+			}
+		}
+	}
+	for (let index = messages.length - 1; index >= 0; index -= 1) {
+		const message = messages[index];
+		if (!Array.isArray(message.content)) {
+			continue;
+		}
+		if (
+			message.content.some(
+				(block) =>
+					block.type === "tool_use" && !resolvedToolUseIds.has(block.id),
+			)
+		) {
+			return index;
+		}
+	}
+	return messages.length;
 }
 
 function collectMessageClosure(
@@ -197,7 +238,8 @@ function dropUnsafeBlocks(
 	messages: MessageWithMetadata[],
 	originalIndexes: number[],
 	actions: BudgetAction[],
-	protectedStartIndex: number,
+	latestTypedUserIndex: number,
+	protectedTailStartIndex: number,
 	policy: ProjectionPolicy,
 ): MessageWithMetadata[] {
 	return messages.map((message, messageIndex) => {
@@ -206,7 +248,8 @@ function dropUnsafeBlocks(
 		}
 		let changed = false;
 		const protectedBlock =
-			protectedStartIndex >= 0 && messageIndex >= protectedStartIndex;
+			messageIndex === latestTypedUserIndex ||
+			messageIndex >= protectedTailStartIndex;
 		const content = message.content.flatMap((block, blockIndex) => {
 			if (shouldDropWholeBlock(block, policy, protectedBlock)) {
 				changed = true;
@@ -242,12 +285,6 @@ function dropUnsafeBlocks(
 					});
 					return [nextBlock];
 				}
-			}
-			if (!isUnsafeBlock(block)) {
-				return [block];
-			}
-			if (protectedBlock) {
-				return [block];
 			}
 			return [block];
 		});
@@ -425,6 +462,13 @@ function closureTouchesProtectedTail(
 	return false;
 }
 
+function closureTouchesPinnedMessage(
+	closure: Set<number>,
+	pinnedIndex: number,
+): boolean {
+	return pinnedIndex >= 0 && closure.has(pinnedIndex);
+}
+
 export function buildBudgetProjection(
 	options: BudgetProjectionOptions,
 ): BudgetProjectionResult {
@@ -461,16 +505,20 @@ export function buildBudgetProjection(
 		messages = prunedThinking.messages;
 		originalIndexes = prunedThinking.originalIndexes;
 	}
-	const protectedStartIndex = policy.protectLatestTypedUser
+	const latestTypedUserIndex = policy.protectLatestTypedUser
 		? findLatestTypedUserMessageIndex(messages)
 		: -1;
+	const protectedTailStartIndex = policy.protectLiveTailFromDrop
+		? findProtectedTailStartIndex(messages)
+		: messages.length;
 	if (policy.dropUnsafeOutsideLiveTail) {
 		const prunedUnsafe = pruneEmptyMessages(
 			dropUnsafeBlocks(
 				messages,
 				originalIndexes,
 				actions,
-				protectedStartIndex,
+				latestTypedUserIndex,
+				protectedTailStartIndex,
 				policy,
 			),
 			originalIndexes,
@@ -499,6 +547,12 @@ export function buildBudgetProjection(
 	) {
 		const latestTypedUserIndex = findLatestTypedUserMessageIndex(messages);
 		if (index === latestTypedUserIndex) {
+			continue;
+		}
+		if (
+			policy.protectLiveTailFromDrop &&
+			index >= findProtectedTailStartIndex(messages)
+		) {
 			continue;
 		}
 		if (!hasTruncatableText(messages[index])) {
@@ -532,11 +586,12 @@ export function buildBudgetProjection(
 		let index = 0;
 		index < messages.length && estimatedTokens > options.targetTokens;
 	) {
+		const firstTypedUserIndex = findFirstTypedUserMessageIndex(messages);
 		const latestTypedUserIndex = findLatestTypedUserMessageIndex(messages);
 		const protectedStartIndex = policy.protectLiveTailFromDrop
-			? latestTypedUserIndex
-			: -1;
-		if (index === latestTypedUserIndex) {
+			? findProtectedTailStartIndex(messages)
+			: messages.length;
+		if (index === firstTypedUserIndex || index === latestTypedUserIndex) {
 			actions.push({
 				kind: "preserved",
 				path: { messageIndex: originalIndexes[index] },
@@ -548,6 +603,14 @@ export function buildBudgetProjection(
 			continue;
 		}
 		const closure = collectMessageClosure(messages, index);
+		if (closureTouchesPinnedMessage(closure, firstTypedUserIndex)) {
+			index += 1;
+			continue;
+		}
+		if (closureTouchesPinnedMessage(closure, latestTypedUserIndex)) {
+			index += 1;
+			continue;
+		}
 		if (closureTouchesProtectedTail(closure, protectedStartIndex)) {
 			index += 1;
 			continue;

--- a/sdk/packages/core/src/extensions/context/budget-projection/project.ts
+++ b/sdk/packages/core/src/extensions/context/budget-projection/project.ts
@@ -1,0 +1,518 @@
+import type {
+	ContentBlock,
+	MessageWithMetadata,
+	ToolResultContent,
+} from "@cline/shared";
+import type {
+	BudgetAction,
+	BudgetProjectionOptions,
+	BudgetProjectionResult,
+	BudgetProjectionWarning,
+	BudgetPolicyIntent,
+} from "./types";
+
+type EstimateMessageTokens = (message: MessageWithMetadata) => number;
+
+interface ProjectionPolicy {
+	protectLatestTypedUser: boolean;
+	protectLiveTailFromDrop: boolean;
+	dropUnsafeOutsideLiveTail: boolean;
+}
+
+function resolveProjectionPolicy(
+	intent: BudgetPolicyIntent,
+): ProjectionPolicy {
+	switch (intent) {
+		case "agentic_summary":
+		case "basic_compaction_projection":
+			return {
+				protectLatestTypedUser: true,
+				protectLiveTailFromDrop: true,
+				dropUnsafeOutsideLiveTail: true,
+			};
+		case "normal_provider_request":
+			return {
+				protectLatestTypedUser: true,
+				protectLiveTailFromDrop: true,
+				dropUnsafeOutsideLiveTail: false,
+			};
+	}
+}
+
+function cloneMessages(messages: MessageWithMetadata[]): MessageWithMetadata[] {
+	return messages.map((message) => ({
+		...message,
+		content: Array.isArray(message.content)
+			? message.content.map((block) => ({ ...block }) as ContentBlock)
+			: message.content,
+		...(message.metadata ? { metadata: { ...message.metadata } } : {}),
+	}));
+}
+
+function safeJsonSize(value: unknown): number {
+	try {
+		return JSON.stringify(value).length;
+	} catch {
+		return String(value).length;
+	}
+}
+
+function totalTokens(
+	messages: MessageWithMetadata[],
+	estimateMessageTokens: EstimateMessageTokens,
+): number {
+	return messages.reduce(
+		(total, message) => total + estimateMessageTokens(message),
+		0,
+	);
+}
+
+function isToolResultOnlyUserMessage(message: MessageWithMetadata): boolean {
+	return (
+		message.role === "user" &&
+		Array.isArray(message.content) &&
+		message.content.length > 0 &&
+		message.content.every((block) => block.type === "tool_result")
+	);
+}
+
+export function findLatestTypedUserMessageIndex(
+	messages: MessageWithMetadata[],
+): number {
+	for (let index = messages.length - 1; index >= 0; index -= 1) {
+		const message = messages[index];
+		if (message.role === "user" && !isToolResultOnlyUserMessage(message)) {
+			return index;
+		}
+	}
+	return -1;
+}
+
+function collectToolIds(message: MessageWithMetadata): Set<string> {
+	const ids = new Set<string>();
+	if (!Array.isArray(message.content)) {
+		return ids;
+	}
+	for (const block of message.content) {
+		if (block.type === "tool_use") {
+			ids.add(block.id);
+		} else if (block.type === "tool_result") {
+			ids.add(block.tool_use_id);
+		}
+	}
+	return ids;
+}
+
+function buildToolPairIndex(
+	messages: MessageWithMetadata[],
+): Map<string, Set<number>> {
+	const index = new Map<string, Set<number>>();
+	for (let messageIndex = 0; messageIndex < messages.length; messageIndex += 1) {
+		for (const id of collectToolIds(messages[messageIndex])) {
+			const existing = index.get(id);
+			if (existing) {
+				existing.add(messageIndex);
+			} else {
+				index.set(id, new Set([messageIndex]));
+			}
+		}
+	}
+	return index;
+}
+
+function collectMessageClosure(
+	messages: MessageWithMetadata[],
+	startIndex: number,
+): Set<number> {
+	const pairIndex = buildToolPairIndex(messages);
+	const removal = new Set<number>();
+	const queue = [startIndex];
+	while (queue.length > 0) {
+		const index = queue.shift();
+		if (index === undefined || removal.has(index)) {
+			continue;
+		}
+		removal.add(index);
+		for (const id of collectToolIds(messages[index])) {
+			for (const linked of pairIndex.get(id) ?? []) {
+				if (!removal.has(linked)) {
+					queue.push(linked);
+				}
+			}
+		}
+	}
+	return removal;
+}
+
+function isUnsafeBlock(block: ContentBlock): boolean {
+	return block.type === "image" || block.type === "redacted_thinking";
+}
+
+function pruneEmptyMessages(
+	messages: MessageWithMetadata[],
+	originalIndexes: number[],
+	actions: BudgetAction[],
+): { messages: MessageWithMetadata[]; originalIndexes: number[] } {
+	const next: MessageWithMetadata[] = [];
+	const nextOriginalIndexes: number[] = [];
+	for (let index = 0; index < messages.length; index += 1) {
+		const message = messages[index];
+		if (Array.isArray(message.content) && message.content.length === 0) {
+			actions.push({
+				kind: "dropped_message",
+				path: { messageIndex: originalIndexes[index] },
+				reason: "over_budget",
+				originalSize: safeJsonSize(message),
+				finalSize: 0,
+			});
+			continue;
+		}
+		next.push(message);
+		nextOriginalIndexes.push(originalIndexes[index]);
+	}
+	return { messages: next, originalIndexes: nextOriginalIndexes };
+}
+
+function dropUnsafeBlocks(
+	messages: MessageWithMetadata[],
+	originalIndexes: number[],
+	actions: BudgetAction[],
+	protectedStartIndex: number,
+): MessageWithMetadata[] {
+	return messages.map((message, messageIndex) => {
+		if (!Array.isArray(message.content)) {
+			return message;
+		}
+		let changed = false;
+		const content = message.content.filter((block, blockIndex) => {
+			if (!isUnsafeBlock(block)) {
+				return true;
+			}
+			if (protectedStartIndex >= 0 && messageIndex >= protectedStartIndex) {
+				actions.push({
+					kind: "preserved",
+					path: { messageIndex: originalIndexes[messageIndex], blockIndex },
+					reason: "protected_live_tail",
+					originalSize: safeJsonSize(block),
+					finalSize: safeJsonSize(block),
+				});
+				return true;
+			}
+			changed = true;
+			actions.push({
+				kind: "dropped_block",
+				path: { messageIndex: originalIndexes[messageIndex], blockIndex },
+				reason: "unsafe_to_truncate",
+				originalSize: safeJsonSize(block),
+				finalSize: 0,
+			});
+			return false;
+		});
+		return changed ? { ...message, content } : message;
+	});
+}
+
+function truncateText(text: string, maxChars: number): string {
+	if (maxChars <= 0) {
+		return "";
+	}
+	if (text.length <= maxChars) {
+		return text;
+	}
+	if (maxChars <= 16) {
+		return text.slice(0, Math.max(1, maxChars));
+	}
+	const estimateMarker = `\n...[truncated ${text.length - maxChars} chars]`;
+	const keep = Math.max(1, maxChars - estimateMarker.length);
+	const marker = `\n...[truncated ${text.length - keep} chars]`;
+	return `${text.slice(0, keep)}${marker}`;
+}
+
+function truncateToolResultContent(
+	content: ToolResultContent["content"],
+	maxChars: number,
+): ToolResultContent["content"] {
+	if (typeof content === "string") {
+		return truncateText(content, maxChars);
+	}
+	let remaining = maxChars;
+	return content.map((block) => {
+		if (remaining <= 0) {
+			if (block.type === "text") {
+				return { ...block, text: "" };
+			}
+			if (block.type === "file") {
+				return { ...block, content: "" };
+			}
+			return block;
+		}
+		if (block.type === "text") {
+			const text = truncateText(block.text, remaining);
+			remaining -= text.length;
+			return { ...block, text };
+		}
+		if (block.type === "file") {
+			const content = truncateText(block.content, remaining);
+			remaining -= content.length;
+			return { ...block, content };
+		}
+		return block;
+	});
+}
+
+function truncateMessageText(
+	message: MessageWithMetadata,
+	maxChars: number,
+): MessageWithMetadata {
+	if (typeof message.content === "string") {
+		return { ...message, content: truncateText(message.content, maxChars) };
+	}
+	let remaining = maxChars;
+	return {
+			...message,
+			content: message.content.map((block) => {
+				if (remaining <= 0) {
+					if (block.type === "text") {
+						return { ...block, text: "" };
+					}
+					if (block.type === "file") {
+						return { ...block, content: "" };
+					}
+					return block;
+				}
+			if (block.type === "text") {
+				const text = truncateText(block.text, remaining);
+				remaining -= text.length;
+				return { ...block, text };
+			}
+			if (block.type === "file") {
+				const content = truncateText(block.content, remaining);
+				remaining -= content.length;
+				return { ...block, content };
+			}
+			if (block.type === "thinking") {
+				const thinking = truncateText(block.thinking, remaining);
+				remaining -= thinking.length;
+				return { ...block, thinking };
+			}
+			if (block.type === "tool_result") {
+				const content = truncateToolResultContent(block.content, remaining);
+				remaining -= safeJsonSize(content);
+				return { ...block, content };
+			}
+			return block;
+		}),
+	};
+}
+
+function hasTruncatableText(message: MessageWithMetadata): boolean {
+	if (typeof message.content === "string") {
+		return message.content.length > 0;
+	}
+	return message.content.some(
+		(block) =>
+			block.type === "text" ||
+			block.type === "file" ||
+			block.type === "thinking" ||
+			block.type === "tool_result",
+	);
+}
+
+function removeMessagesAt(
+	messages: MessageWithMetadata[],
+	originalIndexes: number[],
+	removal: Set<number>,
+): { messages: MessageWithMetadata[]; originalIndexes: number[] } {
+	return {
+		messages: messages.filter((_, index) => !removal.has(index)),
+		originalIndexes: originalIndexes.filter((_, index) => !removal.has(index)),
+	};
+}
+
+function closureTouchesProtectedTail(
+	closure: Set<number>,
+	protectedStartIndex: number,
+): boolean {
+	if (protectedStartIndex < 0) {
+		return false;
+	}
+	for (const removalIndex of closure) {
+		if (removalIndex >= protectedStartIndex) {
+			return true;
+		}
+	}
+	return false;
+}
+
+export function buildBudgetProjection(
+	options: BudgetProjectionOptions,
+): BudgetProjectionResult {
+	const actions: BudgetAction[] = [];
+	const warnings: BudgetProjectionWarning[] = [];
+	const policy = resolveProjectionPolicy(options.policyIntent);
+	if (options.targetTokens <= 0) {
+		return {
+			status: "failed",
+			messages: cloneMessages(options.messages),
+			actions,
+			liveTailHandling: "preserved_out_of_band",
+			estimatedTokens: totalTokens(
+				options.messages,
+				options.estimateMessageTokens,
+			),
+			warnings: [
+				{
+					code: "budget_impossible",
+					message: "Target budget must be greater than zero.",
+				},
+			],
+		};
+	}
+
+	let messages = cloneMessages(options.messages);
+	let originalIndexes = messages.map((_, index) => index);
+	let estimatedTokens = totalTokens(messages, options.estimateMessageTokens);
+	if (estimatedTokens <= options.targetTokens) {
+		return {
+			status: "ok",
+			messages,
+			actions,
+			liveTailHandling: "included_verbatim",
+			estimatedTokens,
+			warnings,
+		};
+	}
+
+	const protectedStartIndex = policy.protectLatestTypedUser
+		? findLatestTypedUserMessageIndex(messages)
+		: -1;
+	const pruned = pruneEmptyMessages(
+		policy.dropUnsafeOutsideLiveTail
+			? dropUnsafeBlocks(
+					messages,
+					originalIndexes,
+					actions,
+					protectedStartIndex,
+				)
+			: messages,
+		originalIndexes,
+		actions,
+	);
+	messages = pruned.messages;
+	originalIndexes = pruned.originalIndexes;
+	estimatedTokens = totalTokens(messages, options.estimateMessageTokens);
+	if (estimatedTokens <= options.targetTokens) {
+		return {
+			status: "ok",
+			messages,
+			actions,
+			liveTailHandling: "included_degraded",
+			estimatedTokens,
+			warnings,
+		};
+	}
+
+	for (
+		let index = messages.length - 1;
+		index >= 0 && estimatedTokens > options.targetTokens;
+		index -= 1
+	) {
+		const latestTypedUserIndex = findLatestTypedUserMessageIndex(messages);
+		if (index === latestTypedUserIndex) {
+			continue;
+		}
+		if (!hasTruncatableText(messages[index])) {
+			continue;
+		}
+		const originalSize = safeJsonSize(messages[index]);
+		const charsPerToken = Math.max(
+			1,
+			originalSize /
+				Math.max(1, options.estimateMessageTokens(messages[index])),
+		);
+		const targetChars = Math.max(
+			16,
+			Math.floor(
+				(options.targetTokens * charsPerToken) /
+					Math.max(1, messages.length),
+			),
+		);
+		messages[index] = truncateMessageText(messages[index], targetChars);
+		actions.push({
+			kind: "truncated_text",
+			path: { messageIndex: originalIndexes[index] },
+			reason: "over_budget",
+			originalSize,
+			finalSize: safeJsonSize(messages[index]),
+		});
+		estimatedTokens = totalTokens(messages, options.estimateMessageTokens);
+	}
+
+	for (
+		let index = 0;
+		index < messages.length && estimatedTokens > options.targetTokens;
+	) {
+		const latestTypedUserIndex = findLatestTypedUserMessageIndex(messages);
+		const protectedStartIndex = policy.protectLiveTailFromDrop
+			? latestTypedUserIndex
+			: -1;
+		if (index === latestTypedUserIndex) {
+			actions.push({
+				kind: "preserved",
+				path: { messageIndex: originalIndexes[index] },
+				reason: "protected_live_tail",
+				originalSize: safeJsonSize(messages[index]),
+				finalSize: safeJsonSize(messages[index]),
+			});
+			index += 1;
+			continue;
+		}
+		const closure = collectMessageClosure(messages, index);
+		if (closureTouchesProtectedTail(closure, protectedStartIndex)) {
+			index += 1;
+			continue;
+		}
+		for (const removalIndex of closure) {
+			actions.push({
+				kind: "dropped_message",
+				path: { messageIndex: originalIndexes[removalIndex] },
+				reason:
+					closure.size > 1 || collectToolIds(messages[removalIndex]).size > 0
+						? "tool_pair_boundary"
+						: "over_budget",
+				originalSize: safeJsonSize(messages[removalIndex]),
+				finalSize: 0,
+			});
+		}
+		const removed = removeMessagesAt(messages, originalIndexes, closure);
+		messages = removed.messages;
+		originalIndexes = removed.originalIndexes;
+		estimatedTokens = totalTokens(messages, options.estimateMessageTokens);
+	}
+
+	if (estimatedTokens > options.targetTokens) {
+		warnings.push({
+			code: "budget_unachievable_with_protections",
+			message:
+				"Projection could not reach budget without violating protected content.",
+		});
+		return {
+			status: "failed",
+			messages,
+			actions,
+			liveTailHandling: "included_degraded",
+			estimatedTokens,
+			warnings,
+		};
+	}
+
+	return {
+		status: "ok",
+		messages,
+		actions,
+		liveTailHandling:
+			actions.length > 0 ? "included_degraded" : "included_verbatim",
+		estimatedTokens,
+		warnings,
+	};
+}

--- a/sdk/packages/core/src/extensions/context/budget-projection/project.ts
+++ b/sdk/packages/core/src/extensions/context/budget-projection/project.ts
@@ -260,6 +260,21 @@ function truncateToolResultContent(
 	});
 }
 
+function toolResultTextLength(content: ToolResultContent["content"]): number {
+	if (typeof content === "string") {
+		return content.length;
+	}
+	return content.reduce((total, block) => {
+		if (block.type === "text") {
+			return total + block.text.length;
+		}
+		if (block.type === "file") {
+			return total + block.content.length;
+		}
+		return total;
+	}, 0);
+}
+
 function truncateMessageText(
 	message: MessageWithMetadata,
 	maxChars: number,
@@ -269,17 +284,20 @@ function truncateMessageText(
 	}
 	let remaining = maxChars;
 	return {
-			...message,
-			content: message.content.map((block) => {
-				if (remaining <= 0) {
-					if (block.type === "text") {
-						return { ...block, text: "" };
-					}
-					if (block.type === "file") {
-						return { ...block, content: "" };
-					}
-					return block;
+		...message,
+		content: message.content.map((block) => {
+			if (remaining <= 0) {
+				if (block.type === "text") {
+					return { ...block, text: "" };
 				}
+				if (block.type === "file") {
+					return { ...block, content: "" };
+				}
+				if (block.type === "thinking") {
+					return { ...block, thinking: "" };
+				}
+				return block;
+			}
 			if (block.type === "text") {
 				const text = truncateText(block.text, remaining);
 				remaining -= text.length;
@@ -297,7 +315,7 @@ function truncateMessageText(
 			}
 			if (block.type === "tool_result") {
 				const content = truncateToolResultContent(block.content, remaining);
-				remaining -= safeJsonSize(content);
+				remaining -= toolResultTextLength(content);
 				return { ...block, content };
 			}
 			return block;

--- a/sdk/packages/core/src/extensions/context/budget-projection/project.ts
+++ b/sdk/packages/core/src/extensions/context/budget-projection/project.ts
@@ -452,9 +452,6 @@ export function buildBudgetProjection(
 
 	let messages = cloneMessages(options.messages);
 	let originalIndexes = messages.map((_, index) => index);
-	const protectedStartIndex = policy.protectLatestTypedUser
-		? findLatestTypedUserMessageIndex(messages)
-		: -1;
 	if (policy.dropThinkingBlocks) {
 		const prunedThinking = pruneEmptyMessages(
 			dropThinkingBlocks(messages, originalIndexes, actions),
@@ -464,6 +461,9 @@ export function buildBudgetProjection(
 		messages = prunedThinking.messages;
 		originalIndexes = prunedThinking.originalIndexes;
 	}
+	const protectedStartIndex = policy.protectLatestTypedUser
+		? findLatestTypedUserMessageIndex(messages)
+		: -1;
 	if (policy.dropUnsafeOutsideLiveTail) {
 		const prunedUnsafe = pruneEmptyMessages(
 			dropUnsafeBlocks(

--- a/sdk/packages/core/src/extensions/context/budget-projection/project.ts
+++ b/sdk/packages/core/src/extensions/context/budget-projection/project.ts
@@ -17,6 +17,7 @@ interface ProjectionPolicy {
 	protectLatestTypedUser: boolean;
 	protectLiveTailFromDrop: boolean;
 	dropUnsafeOutsideLiveTail: boolean;
+	dropThinkingBlocks: boolean;
 }
 
 function resolveProjectionPolicy(
@@ -29,12 +30,14 @@ function resolveProjectionPolicy(
 				protectLatestTypedUser: true,
 				protectLiveTailFromDrop: true,
 				dropUnsafeOutsideLiveTail: true,
+				dropThinkingBlocks: true,
 			};
 		case "normal_provider_request":
 			return {
 				protectLatestTypedUser: true,
 				protectLiveTailFromDrop: true,
 				dropUnsafeOutsideLiveTail: false,
+				dropThinkingBlocks: false,
 			};
 	}
 }
@@ -148,6 +151,23 @@ function isUnsafeBlock(block: ContentBlock): boolean {
 	return block.type === "image" || block.type === "redacted_thinking";
 }
 
+function isNestedUnsafeToolResultBlock(
+	block: Extract<ToolResultContent["content"], unknown[]>[number],
+): boolean {
+	return block.type === "image";
+}
+
+function shouldDropWholeBlock(
+	block: ContentBlock,
+	policy: ProjectionPolicy,
+	isProtected: boolean,
+): boolean {
+	if (policy.dropThinkingBlocks && block.type === "thinking") {
+		return true;
+	}
+	return policy.dropUnsafeOutsideLiveTail && !isProtected && isUnsafeBlock(block);
+}
+
 function pruneEmptyMessages(
 	messages: MessageWithMetadata[],
 	originalIndexes: number[],
@@ -178,6 +198,67 @@ function dropUnsafeBlocks(
 	originalIndexes: number[],
 	actions: BudgetAction[],
 	protectedStartIndex: number,
+	policy: ProjectionPolicy,
+): MessageWithMetadata[] {
+	return messages.map((message, messageIndex) => {
+		if (!Array.isArray(message.content)) {
+			return message;
+		}
+		let changed = false;
+		const protectedBlock =
+			protectedStartIndex >= 0 && messageIndex >= protectedStartIndex;
+		const content = message.content.flatMap((block, blockIndex) => {
+			if (shouldDropWholeBlock(block, policy, protectedBlock)) {
+				changed = true;
+				actions.push({
+					kind: "dropped_block",
+					path: { messageIndex: originalIndexes[messageIndex], blockIndex },
+					reason: "unsafe_to_truncate",
+					originalSize: safeJsonSize(block),
+					finalSize: 0,
+				});
+				return [];
+			}
+			if (block.type === "tool_result" && Array.isArray(block.content)) {
+				const nestedContent = block.content.filter((nestedBlock) => {
+					if (
+						policy.dropUnsafeOutsideLiveTail &&
+						!protectedBlock &&
+						isNestedUnsafeToolResultBlock(nestedBlock)
+					) {
+						return false;
+					}
+					return true;
+				});
+				if (nestedContent.length !== block.content.length) {
+					changed = true;
+					const nextBlock = { ...block, content: nestedContent };
+					actions.push({
+						kind: "dropped_block",
+						path: { messageIndex: originalIndexes[messageIndex], blockIndex },
+						reason: "unsafe_to_truncate",
+						originalSize: safeJsonSize(block),
+						finalSize: safeJsonSize(nextBlock),
+					});
+					return [nextBlock];
+				}
+			}
+			if (!isUnsafeBlock(block)) {
+				return [block];
+			}
+			if (protectedBlock) {
+				return [block];
+			}
+			return [block];
+		});
+		return changed ? { ...message, content } : message;
+	});
+}
+
+function dropThinkingBlocks(
+	messages: MessageWithMetadata[],
+	originalIndexes: number[],
+	actions: BudgetAction[],
 ): MessageWithMetadata[] {
 	return messages.map((message, messageIndex) => {
 		if (!Array.isArray(message.content)) {
@@ -185,17 +266,7 @@ function dropUnsafeBlocks(
 		}
 		let changed = false;
 		const content = message.content.filter((block, blockIndex) => {
-			if (!isUnsafeBlock(block)) {
-				return true;
-			}
-			if (protectedStartIndex >= 0 && messageIndex >= protectedStartIndex) {
-				actions.push({
-					kind: "preserved",
-					path: { messageIndex: originalIndexes[messageIndex], blockIndex },
-					reason: "protected_live_tail",
-					originalSize: safeJsonSize(block),
-					finalSize: safeJsonSize(block),
-				});
+			if (block.type !== "thinking") {
 				return true;
 			}
 			changed = true;
@@ -211,6 +282,7 @@ function dropUnsafeBlocks(
 		return changed ? { ...message, content } : message;
 	});
 }
+
 
 function truncateText(text: string, maxChars: number): string {
 	if (maxChars <= 0) {
@@ -293,9 +365,6 @@ function truncateMessageText(
 				if (block.type === "file") {
 					return { ...block, content: "" };
 				}
-				if (block.type === "thinking") {
-					return { ...block, thinking: "" };
-				}
 				return block;
 			}
 			if (block.type === "text") {
@@ -307,11 +376,6 @@ function truncateMessageText(
 				const content = truncateText(block.content, remaining);
 				remaining -= content.length;
 				return { ...block, content };
-			}
-			if (block.type === "thinking") {
-				const thinking = truncateText(block.thinking, remaining);
-				remaining -= thinking.length;
-				return { ...block, thinking };
 			}
 			if (block.type === "tool_result") {
 				const content = truncateToolResultContent(block.content, remaining);
@@ -331,7 +395,6 @@ function hasTruncatableText(message: MessageWithMetadata): boolean {
 		(block) =>
 			block.type === "text" ||
 			block.type === "file" ||
-			block.type === "thinking" ||
 			block.type === "tool_result",
 	);
 }
@@ -389,42 +452,41 @@ export function buildBudgetProjection(
 
 	let messages = cloneMessages(options.messages);
 	let originalIndexes = messages.map((_, index) => index);
+	const protectedStartIndex = policy.protectLatestTypedUser
+		? findLatestTypedUserMessageIndex(messages)
+		: -1;
+	if (policy.dropThinkingBlocks) {
+		const prunedThinking = pruneEmptyMessages(
+			dropThinkingBlocks(messages, originalIndexes, actions),
+			originalIndexes,
+			actions,
+		);
+		messages = prunedThinking.messages;
+		originalIndexes = prunedThinking.originalIndexes;
+	}
+	if (policy.dropUnsafeOutsideLiveTail) {
+		const prunedUnsafe = pruneEmptyMessages(
+			dropUnsafeBlocks(
+				messages,
+				originalIndexes,
+				actions,
+				protectedStartIndex,
+				policy,
+			),
+			originalIndexes,
+			actions,
+		);
+		messages = prunedUnsafe.messages;
+		originalIndexes = prunedUnsafe.originalIndexes;
+	}
 	let estimatedTokens = totalTokens(messages, options.estimateMessageTokens);
 	if (estimatedTokens <= options.targetTokens) {
 		return {
 			status: "ok",
 			messages,
 			actions,
-			liveTailHandling: "included_verbatim",
-			estimatedTokens,
-			warnings,
-		};
-	}
-
-	const protectedStartIndex = policy.protectLatestTypedUser
-		? findLatestTypedUserMessageIndex(messages)
-		: -1;
-	const pruned = pruneEmptyMessages(
-		policy.dropUnsafeOutsideLiveTail
-			? dropUnsafeBlocks(
-					messages,
-					originalIndexes,
-					actions,
-					protectedStartIndex,
-				)
-			: messages,
-		originalIndexes,
-		actions,
-	);
-	messages = pruned.messages;
-	originalIndexes = pruned.originalIndexes;
-	estimatedTokens = totalTokens(messages, options.estimateMessageTokens);
-	if (estimatedTokens <= options.targetTokens) {
-		return {
-			status: "ok",
-			messages,
-			actions,
-			liveTailHandling: "included_degraded",
+			liveTailHandling:
+				actions.length > 0 ? "included_degraded" : "included_verbatim",
 			estimatedTokens,
 			warnings,
 		};

--- a/sdk/packages/core/src/extensions/context/budget-projection/project.ts
+++ b/sdk/packages/core/src/extensions/context/budget-projection/project.ts
@@ -5,6 +5,7 @@ import type {
 } from "@cline/shared";
 import type {
 	BudgetAction,
+	BudgetMutationAction,
 	BudgetProjectionOptions,
 	BudgetProjectionResult,
 	BudgetProjectionWarning,
@@ -213,19 +214,20 @@ function pruneEmptyMessages(
 	messages: MessageWithMetadata[],
 	originalIndexes: number[],
 	actions: BudgetAction[],
+	reason: BudgetMutationAction["reason"] = "over_budget",
 ): { messages: MessageWithMetadata[]; originalIndexes: number[] } {
 	const next: MessageWithMetadata[] = [];
 	const nextOriginalIndexes: number[] = [];
 	for (let index = 0; index < messages.length; index += 1) {
 		const message = messages[index];
 		if (Array.isArray(message.content) && message.content.length === 0) {
-			actions.push({
-				kind: "dropped_message",
-				path: { messageIndex: originalIndexes[index] },
-				reason: "over_budget",
-				originalSize: safeJsonSize(message),
-				finalSize: 0,
-			});
+				actions.push({
+					kind: "dropped_message",
+					path: { messageIndex: originalIndexes[index] },
+					reason,
+					originalSize: safeJsonSize(message),
+					finalSize: 0,
+				});
 			continue;
 		}
 		next.push(message);
@@ -402,6 +404,12 @@ function truncateMessageText(
 				if (block.type === "file") {
 					return { ...block, content: "" };
 				}
+				if (block.type === "tool_result") {
+					return {
+						...block,
+						content: truncateToolResultContent(block.content, 0),
+					};
+				}
 				return block;
 			}
 			if (block.type === "text") {
@@ -501,6 +509,7 @@ export function buildBudgetProjection(
 			dropThinkingBlocks(messages, originalIndexes, actions),
 			originalIndexes,
 			actions,
+			"unsafe_to_truncate",
 		);
 		messages = prunedThinking.messages;
 		originalIndexes = prunedThinking.originalIndexes;

--- a/sdk/packages/core/src/extensions/context/budget-projection/types.ts
+++ b/sdk/packages/core/src/extensions/context/budget-projection/types.ts
@@ -87,6 +87,7 @@ export interface BudgetProjectionOptions {
 }
 
 export interface BudgetProjectionResult {
+	status: "ok" | "failed";
 	messages: MessageWithMetadata[];
 	actions: BudgetAction[];
 	liveTailHandling: LiveTailHandling;


### PR DESCRIPTION
### Related Issue

**Issue:** ENG-1967

### Description

Adds the pure budget projection engine behind the contract from #10786.

This is the deterministic choke point used by later compaction layers. It projects messages to fit a configured budget, records actions/warnings, protects only the content that must survive, and avoids mutating canonical session history.

Latest update: the protected-tail policy now separates semantic prompt protection from structural tool-state protection. The first typed user prompt is protected from whole-message drop but remains truncatable, the latest typed user prompt is pinned individually, and only unresolved tool_use tail state is protected as live structure. Completed tool_use/tool_result pairs after the latest typed prompt are budget candidates and are dropped atomically.

This fixes the Harbor repro where multi-MB completed tool results after the latest typed prompt were effectively untouchable.

### Stack

- #10651 sidecar foundation
- #10786 budget projection contract
- #10800 pure budget projection engine
- #10801 agentic summary input budgeting
- #10802 basic compaction output budgeting
- #10803 emergency telemetry/status

### Test Procedure

Validated at the stack tip with:

- `cd sdk && bun -F @cline/core test:unit -- src/extensions/context/budget-projection/project.test.ts src/extensions/context/compaction.test.ts src/services/telemetry/core-events.test.ts`
- `cd sdk && bun --filter @cline/core typecheck`
- `cd sdk && git diff --check`
- Harbor repro fixture: 15,752,815 chars -> 1,907 chars, status ok, 34 completed tool-pair message drops, no warnings, huge tool results absent
- CLI sidecar proof: compaction fired, sidecar written, canonical transcript bytes unchanged, latest prompt retained