### PR TITLE
fix: reset mistake count on user turn

### DIFF
--- a/sdk/packages/core/src/runtime/orchestration/session-runtime-orchestrator.test.ts
+++ b/sdk/packages/core/src/runtime/orchestration/session-runtime-orchestrator.test.ts
@@ -2129,7 +2129,7 @@ function failedStructuredToolTurnEvents(): AgentRuntimeEvent[] {
 }
 
 describe("SessionRuntime.run — tracker wiring (P1 #3)", () => {
-	it("aborts after maxConsecutiveMistakes failed-tool turns", async () => {
+	it("aborts after maxConsecutiveMistakes failed-tool turns without a new user turn", async () => {
 		const { deps, abortCalls } = makeScriptedRuntime({
 			events: failedToolTurnEvents(),
 		});
@@ -2140,9 +2140,23 @@ describe("SessionRuntime.run — tracker wiring (P1 #3)", () => {
 		await session.run("one");
 		// First failed turn — counter 1 < 2, no abort yet.
 		expect(abortCalls).toHaveLength(0);
-		await session.continue("two");
+		await session.continue();
 		// Second failed turn — counter reaches 2, tracker calls abort.
 		expect(abortCalls.length).toBeGreaterThanOrEqual(1);
+	});
+
+	it("resets mistake tracking when continue() carries a new user turn", async () => {
+		const { deps, abortCalls } = makeScriptedRuntime({
+			events: failedToolTurnEvents(),
+		});
+		const session = new SessionRuntime(
+			makeAgentConfig({ execution: { maxConsecutiveMistakes: 2 } }),
+			deps,
+		);
+		await session.run("one");
+		expect(abortCalls).toHaveLength(0);
+		await session.continue("two");
+		expect(abortCalls).toHaveLength(0);
 	});
 
 	it("serializes structured tool errors in mistake details", async () => {

--- a/sdk/packages/core/src/runtime/orchestration/session-runtime-orchestrator.ts
+++ b/sdk/packages/core/src/runtime/orchestration/session-runtime-orchestrator.ts
@@ -644,6 +644,9 @@ export class SessionRuntime {
 		userImages?: string[],
 		userFiles?: string[],
 	): Promise<AgentResult> {
+		if (userMessage !== undefined) {
+			this.resetConversationBoundaryTrackers();
+		}
 		return this.executeRun({
 			userMessage,
 			userImages,


### PR DESCRIPTION
### Related Issue

**Issue:** #10358

### Description

This fixes premature consecutive-mistake aborts when `continue()` is called with a new user message.

The change resets the conversation-boundary trackers before a continued run only when `continue()` carries a new user turn. Plain `continue()` still preserves the existing mistake count, so repeated failed tool turns without a new user turn continue to abort at the configured threshold.

Updated files:

- `sdk/packages/core/src/runtime/orchestration/session-runtime-orchestrator.ts`
- `sdk/packages/core/src/runtime/orchestration/session-runtime-orchestrator.test.ts`

### Test Procedure

Regression coverage now checks both paths:

- `continue()` without a new user turn keeps mistake tracking and still aborts after the configured limit.
- `continue("two")` with a new user turn resets mistake tracking and avoids aborting from the previous turn's failed tool call.

Validation on the current PR commit:

- `sdk-test / Quality Checks`: passed
- `sdk-test / Test (ubuntu-latest, Node 24.x)`: passed
- `sdk-test / Test (windows-latest, Node 24.x)`: passed
- `ext-vscode-test / Quality Checks`: passed
- `ext-vscode-test / vscode test`: passed
- `ext-vscode-test / vscode test (windows-latest)`: passed
- `ext-vscode-test-e2e / e2e (ubuntu)`: passed
- `ext-vscode-test-e2e / e2e (windows)`: passed
- `ext-vscode-test-e2e / e2e (macos)`: passed

### Type of Change

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Refactor Changes
-   [ ] Cosmetic Changes
-   [ ] Documentation update
-   [ ] Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing and code is formatted/linted
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

No UI change.

### Additional Notes

The earlier conflict and JetBrains-plugin failure comments are stale against the current PR head. Current core, VS Code, and cross-platform e2e checks are passing on the updated SDK-based implementation.
