### PR TITLE
fix(cli): fix plugin tools in production build

### DIFF
--- a/sdk/apps/cli/script/publish-npm.ts
+++ b/sdk/apps/cli/script/publish-npm.ts
@@ -41,6 +41,14 @@ const expectedPlatformPackages = [
 	"@cline/cli-windows-x64",
 ] as const;
 
+const hostSdkPackages = [
+	{ name: "@cline/sdk", directory: "sdk" },
+	{ name: "@cline/core", directory: "core" },
+	{ name: "@cline/agents", directory: "agents" },
+	{ name: "@cline/llms", directory: "llms" },
+	{ name: "@cline/shared", directory: "shared" },
+] as const;
+
 interface PlatformPackageManifest {
 	name: string;
 	version: string;
@@ -66,6 +74,26 @@ function isPlatformPackageManifest(
 		typeof value.version === "string" &&
 		isStringArray(value.os)
 	);
+}
+
+function readPackageVersion(name: string, packageJsonPath: string): string {
+	const pkg: unknown = JSON.parse(readFileSync(packageJsonPath, "utf-8"));
+	if (!isRecord(pkg) || pkg.name !== name || typeof pkg.version !== "string") {
+		console.error(`Invalid package manifest for ${name}: ${packageJsonPath}`);
+		process.exit(1);
+	}
+	return pkg.version;
+}
+
+function buildHostSdkDependencies(): Record<string, string> {
+	const dependencies: Record<string, string> = {};
+	for (const pkg of hostSdkPackages) {
+		dependencies[pkg.name] = readPackageVersion(
+			pkg.name,
+			join(cliDir, "../../packages", pkg.directory, "package.json"),
+		);
+	}
+	return dependencies;
 }
 
 function removePackedTarballs(dir: string): void {
@@ -175,6 +203,7 @@ if (sourceVersion !== version) {
 }
 const sourceRepository =
 	"repository" in sourcePkgRecord ? sourcePkgRecord.repository : undefined;
+const hostSdkDependencies = buildHostSdkDependencies();
 
 console.log(`Publishing ${wrapperPackageName} v${version}`);
 console.log(`  Tag: ${npmTag}`);
@@ -270,6 +299,7 @@ const wrapperPackageJson = {
 	scripts: {
 		postinstall: "node ./postinstall.mjs || true",
 	},
+	dependencies: hostSdkDependencies,
 	optionalDependencies: binaries,
 };
 

--- a/sdk/apps/cli/script/publish-npm.ts
+++ b/sdk/apps/cli/script/publish-npm.ts
@@ -119,6 +119,28 @@ async function npmPackageVersionExists(
 	return result.exitCode === 0;
 }
 
+async function verifyPublishedDependencies(
+	dependencies: Record<string, string>,
+): Promise<void> {
+	const missingDependencies: string[] = [];
+	for (const [name, version] of Object.entries(dependencies).sort()) {
+		if (!(await npmPackageVersionExists(name, version))) {
+			missingDependencies.push(`${name}@${version}`);
+		}
+	}
+
+	if (missingDependencies.length === 0) {
+		return;
+	}
+
+	console.error("Wrapper package dependencies are not published:");
+	for (const dependency of missingDependencies) {
+		console.error(`  ${dependency}`);
+	}
+	console.error("Publish the SDK packages before publishing the CLI wrapper.");
+	process.exit(1);
+}
+
 async function publishPackage(input: {
 	name: string;
 	version: string;
@@ -211,6 +233,10 @@ console.log(`  Dry run: ${dryRun}`);
 console.log(`  Platform packages: ${Object.keys(binaries).length}`);
 for (const name of Object.keys(binaries)) {
 	console.log(`    ${name}`);
+}
+
+if (!dryRun) {
+	await verifyPublishedDependencies(hostSdkDependencies);
 }
 
 // Step 1: Publish platform-specific packages (in parallel)

--- a/sdk/bun.lock
+++ b/sdk/bun.lock
@@ -19,7 +19,7 @@
     },
     "apps/cli": {
       "name": "@cline/cli",
-      "version": "3.0.1",
+      "version": "3.0.3",
       "bin": {
         "cline": "src/index.ts",
       },
@@ -313,7 +313,7 @@
         "@opentelemetry/sdk-trace-base": "^2.6.1",
         "@opentelemetry/sdk-trace-node": "^2.6.1",
         "@opentelemetry/semantic-conventions": "^1.40.0",
-        "jiti": "^1.21.7",
+        "jiti": "^2.7.0",
         "nanoid": "^5.1.7",
         "node-machine-id": "^1.1.12",
         "simple-git": "3.36.0",
@@ -2271,7 +2271,7 @@
 
     "jimp": ["jimp@1.6.0", "", { "dependencies": { "@jimp/core": "1.6.0", "@jimp/diff": "1.6.0", "@jimp/js-bmp": "1.6.0", "@jimp/js-gif": "1.6.0", "@jimp/js-jpeg": "1.6.0", "@jimp/js-png": "1.6.0", "@jimp/js-tiff": "1.6.0", "@jimp/plugin-blit": "1.6.0", "@jimp/plugin-blur": "1.6.0", "@jimp/plugin-circle": "1.6.0", "@jimp/plugin-color": "1.6.0", "@jimp/plugin-contain": "1.6.0", "@jimp/plugin-cover": "1.6.0", "@jimp/plugin-crop": "1.6.0", "@jimp/plugin-displace": "1.6.0", "@jimp/plugin-dither": "1.6.0", "@jimp/plugin-fisheye": "1.6.0", "@jimp/plugin-flip": "1.6.0", "@jimp/plugin-hash": "1.6.0", "@jimp/plugin-mask": "1.6.0", "@jimp/plugin-print": "1.6.0", "@jimp/plugin-quantize": "1.6.0", "@jimp/plugin-resize": "1.6.0", "@jimp/plugin-rotate": "1.6.0", "@jimp/plugin-threshold": "1.6.0", "@jimp/types": "1.6.0", "@jimp/utils": "1.6.0" } }, "sha512-YcwCHw1kiqEeI5xRpDlPPBGL2EOpBKLwO4yIBJcXWHPj5PnA5urGq0jbyhM5KoNpypQ6VboSoxc9D8HyfvngSg=="],
 
-    "jiti": ["jiti@1.21.7", "", { "bin": { "jiti": "bin/jiti.js" } }, "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A=="],
+    "jiti": ["jiti@2.7.0", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ=="],
 
     "jose": ["jose@6.2.3", "", {}, "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw=="],
 
@@ -3284,8 +3284,6 @@
     "@slack/web-api/retry": ["retry@0.13.1", "", {}, "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg=="],
 
     "@streamdown/code/shiki": ["shiki@3.23.0", "", { "dependencies": { "@shikijs/core": "3.23.0", "@shikijs/engine-javascript": "3.23.0", "@shikijs/engine-oniguruma": "3.23.0", "@shikijs/langs": "3.23.0", "@shikijs/themes": "3.23.0", "@shikijs/types": "3.23.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-55Dj73uq9ZXL5zyeRPzHQsK7Nbyt6Y10k5s7OjuFZGMhpp4r/rsLBH0o/0fstIzX1Lep9VxefWljK/SKCzygIA=="],
-
-    "@tailwindcss/node/jiti": ["jiti@2.7.0", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ=="],
 
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.10.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" }, "bundled": true }, "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw=="],
 

--- a/sdk/packages/core/package.json
+++ b/sdk/packages/core/package.json
@@ -59,7 +59,7 @@
 		"@opentelemetry/sdk-trace-base": "^2.6.1",
 		"@opentelemetry/sdk-trace-node": "^2.6.1",
 		"@opentelemetry/semantic-conventions": "^1.40.0",
-		"jiti": "^1.21.7",
+		"jiti": "^2.7.0",
 		"node-machine-id": "^1.1.12",
 		"nanoid": "^5.1.7",
 		"simple-git": "3.36.0",

--- a/sdk/packages/core/src/extensions/plugin/plugin-loader.test.ts
+++ b/sdk/packages/core/src/extensions/plugin/plugin-loader.test.ts
@@ -30,10 +30,9 @@ describe("plugin-loader", () => {
 		await writeFile(
 			join(dir, "plugin-top-level-await.mjs"),
 			[
-				"import { createTool } from '@cline/core';",
 				"const name = await Promise.resolve('plugin-top-level-await');",
 				"export default {",
-				"  name: typeof createTool === 'function' ? name : 'invalid',",
+				"  name,",
 				"  manifest: { capabilities: ['tools'] },",
 				"};",
 			].join("\n"),

--- a/sdk/packages/core/src/extensions/plugin/plugin-loader.test.ts
+++ b/sdk/packages/core/src/extensions/plugin/plugin-loader.test.ts
@@ -28,6 +28,18 @@ describe("plugin-loader", () => {
 			"utf8",
 		);
 		await writeFile(
+			join(dir, "plugin-top-level-await.mjs"),
+			[
+				"import { createTool } from '@cline/core';",
+				"const name = await Promise.resolve('plugin-top-level-await');",
+				"export default {",
+				"  name: typeof createTool === 'function' ? name : 'invalid',",
+				"  manifest: { capabilities: ['tools'] },",
+				"};",
+			].join("\n"),
+			"utf8",
+		);
+		await writeFile(
 			join(dir, "plugin-named.mjs"),
 			[
 				"export const plugin = {",
@@ -257,6 +269,13 @@ describe("plugin-loader", () => {
 		);
 		expect(plugin.name).toBe("from-default");
 		expect(plugin.manifest.capabilities).toContain("hooks");
+	});
+
+	it("loads ESM plugin with top-level await from path", async () => {
+		const plugin = await loadAgentPluginFromPath(
+			join(dir, "plugin-top-level-await.mjs"),
+		);
+		expect(plugin.name).toBe("plugin-top-level-await");
 	});
 
 	it("loads named plugin export from path", async () => {

--- a/sdk/packages/core/src/extensions/plugin/plugin-loader.test.ts
+++ b/sdk/packages/core/src/extensions/plugin/plugin-loader.test.ts
@@ -312,6 +312,54 @@ describe("plugin-loader", () => {
 		expect(plugin.name).toMatch(/ok: true/i);
 	});
 
+	it("resolves standalone plugin dependencies from the npm wrapper path", async () => {
+		const previousWrapperPath = process.env.CLINE_WRAPPER_PATH;
+		const wrapperRoot = join(dir, "wrapper-root");
+		const wrapperBinDir = join(wrapperRoot, "bin");
+		const depDir = join(wrapperRoot, "node_modules", "wrapper-host-dep");
+		const pluginPath = join(dir, "plugin-with-wrapper-dep.ts");
+		await mkdir(wrapperBinDir, { recursive: true });
+		await mkdir(depDir, { recursive: true });
+		await writeFile(join(wrapperBinDir, "cline"), "#!/usr/bin/env node\n");
+		await writeFile(
+			join(depDir, "package.json"),
+			JSON.stringify({
+				name: "wrapper-host-dep",
+				type: "module",
+				exports: "./index.js",
+			}),
+			"utf8",
+		);
+		await writeFile(
+			join(depDir, "index.js"),
+			"export const depName = 'wrapper-host-dep';\n",
+			"utf8",
+		);
+		await writeFile(
+			pluginPath,
+			[
+				"import { depName } from 'wrapper-host-dep';",
+				"export default {",
+				"  name: depName,",
+				"  manifest: { capabilities: ['tools'] },",
+				"};",
+			].join("\n"),
+			"utf8",
+		);
+
+		try {
+			process.env.CLINE_WRAPPER_PATH = join(wrapperBinDir, "cline");
+			const plugin = await loadAgentPluginFromPath(pluginPath);
+			expect(plugin.name).toBe("wrapper-host-dep");
+		} finally {
+			if (previousWrapperPath === undefined) {
+				delete process.env.CLINE_WRAPPER_PATH;
+			} else {
+				process.env.CLINE_WRAPPER_PATH = previousWrapperPath;
+			}
+		}
+	});
+
 	it("requires package-based plugins to provide their own non-SDK dependencies", async () => {
 		await expect(
 			loadAgentPluginFromPath(join(copyDir, "packaged-plugin", "index.ts"), {

--- a/sdk/packages/core/src/extensions/plugin/plugin-module-import.ts
+++ b/sdk/packages/core/src/extensions/plugin/plugin-module-import.ts
@@ -45,6 +45,7 @@ export interface ImportPluginModuleOptions {
 function collectWorkspaceAliases(root: string): Record<string, string> {
 	const aliases: Record<string, string> = {};
 	const candidates: Record<string, string> = {
+		"@cline/sdk": resolve(root, "packages/sdk/src/index.ts"),
 		"@cline/agents": resolve(root, "packages/agents/src/index.ts"),
 		"@cline/core": resolve(root, "packages/core/src/index.ts"),
 		"@cline/llms": resolve(root, "packages/llms/src/index.ts"),
@@ -289,8 +290,24 @@ function resolveHostPackageExport(specifier: string): string | null {
 	}
 }
 
-function findHostPackageRoot(packageName: string): string | null {
-	let current = MODULE_DIR;
+function getHostPackageSearchRoots(): string[] {
+	const roots = [MODULE_DIR];
+	const wrapperPath = process.env.CLINE_WRAPPER_PATH?.trim();
+	if (wrapperPath) {
+		roots.push(dirname(dirname(wrapperPath)));
+	}
+	const execPath = process.execPath?.trim();
+	if (execPath) {
+		roots.push(dirname(execPath));
+	}
+	return [...new Set(roots.map((root) => resolve(root)))];
+}
+
+function findHostPackageRootFrom(
+	startDir: string,
+	packageName: string,
+): string | null {
+	let current = startDir;
 	while (true) {
 		const packageJsonPath = resolve(current, "package.json");
 		if (existsSync(packageJsonPath)) {
@@ -320,6 +337,16 @@ function findHostPackageRoot(packageName: string): string | null {
 		}
 		current = parent;
 	}
+}
+
+function findHostPackageRoot(packageName: string): string | null {
+	for (const root of getHostPackageSearchRoots()) {
+		const packageRoot = findHostPackageRootFrom(root, packageName);
+		if (packageRoot) {
+			return packageRoot;
+		}
+	}
+	return null;
 }
 
 function isPackageBasedPlugin(pluginFilePath: string): boolean {
@@ -538,6 +565,86 @@ function collectPluginImportAliases(
 	return aliases;
 }
 
+type JitiTransform = (opts: {
+	source: string;
+	filename?: string;
+	ts?: boolean;
+	async?: boolean;
+	jsx?: unknown;
+	[key: string]: unknown;
+}) => { code: string; error?: unknown };
+
+let cachedJitiTransform: JitiTransform | null | undefined;
+
+function loadJitiBabelTransform(): JitiTransform | null {
+	if (cachedJitiTransform !== undefined) {
+		return cachedJitiTransform;
+	}
+	// jiti's default lazyTransform path is
+	//   createRequire(import.meta.url)("../dist/babel.cjs")
+	// which fails in a `bun build --compile` binary: `import.meta.url` is
+	// `bunfs:/root/chunk-XXXX.js`, so the relative resolve has nothing to
+	// walk through. The wrapper install layout still has the real file at
+	// <wrapper>/node_modules/jiti/dist/babel.cjs, so locate it on disk via
+	// our host-package resolver and createRequire from an actual on-disk
+	// path. Returning null falls back to jiti's own loader (works in dev).
+	const jitiRoot = findHostPackageRoot("jiti");
+	if (!jitiRoot) {
+		cachedJitiTransform = null;
+		return null;
+	}
+	const babelPath = resolve(jitiRoot, "dist", "babel.cjs");
+	if (!existsSync(babelPath)) {
+		cachedJitiTransform = null;
+		return null;
+	}
+	try {
+		const requireFromBabel = createRequire(babelPath);
+		const transform = requireFromBabel(babelPath) as unknown;
+		cachedJitiTransform =
+			typeof transform === "function" ? (transform as JitiTransform) : null;
+	} catch {
+		cachedJitiTransform = null;
+	}
+	return cachedJitiTransform;
+}
+
+let cachedHostVirtualModules: Record<string, unknown> | undefined;
+
+function tryRequireFromPath(fromPath: string, specifier: string): unknown {
+	try {
+		return createRequire(fromPath)(specifier);
+	} catch {
+		return undefined;
+	}
+}
+
+function requireHostModule(specifier: string): unknown {
+	const wrapperPath = process.env.CLINE_WRAPPER_PATH?.trim();
+	if (wrapperPath) {
+		const module = tryRequireFromPath(wrapperPath, specifier);
+		if (module) {
+			return module;
+		}
+	}
+	return tryRequireFromPath(import.meta.url, specifier);
+}
+
+function collectHostVirtualModules(): Record<string, unknown> {
+	if (cachedHostVirtualModules) {
+		return cachedHostVirtualModules;
+	}
+	const modules: Record<string, unknown> = {};
+	for (const specifier of HOST_PROVIDED_SDK_SPECIFIERS) {
+		const value = requireHostModule(specifier);
+		if (value && Object.keys(value).length > 0) {
+			modules[specifier] = value;
+		}
+	}
+	cachedHostVirtualModules = modules;
+	return modules;
+}
+
 export async function importPluginModule(
 	pluginPath: string,
 	options: ImportPluginModuleOptions = {},
@@ -559,14 +666,83 @@ export async function importPluginModule(
 	if (!createJiti) {
 		throw new Error("Unable to load jiti");
 	}
+	// The host packages (@cline/core, @cline/shared, etc.) are already loaded
+	// inside this process; the cline binary bundles them. Hand jiti those live
+	// module instances as virtual modules so a plugin's `import "@cline/core"`
+	// resolves to an object lookup instead of jiti walking + transforming the
+	// entire shipped package tree on every load (8s -> ~300ms for `cline config
+	// tools` in packaged installs). `virtualModules` lookup keys on the bare
+	// specifier before alias rewriting, so we strip any alias entry we'll
+	// satisfy virtually. Otherwise the alias rewrites the specifier to an
+	// absolute path and we pay the full file-load cost anyway.
+	//
+	// A plugin that ships its own installed copy of a host package (e.g. a
+	// pinned `@cline/shared` in its node_modules) must still see that copy, not
+	// our bundled one. `collectPluginImportAliases` already drops workspace
+	// aliases for plugin-installed deps; mirror that here so virtualModules
+	// behaves the same way.
+	const pluginRequire = createRequire(pluginPath);
+	const virtualModules: Record<string, unknown> = {};
+	for (const [specifier, value] of Object.entries(
+		collectHostVirtualModules(),
+	)) {
+		try {
+			pluginRequire.resolve(specifier);
+			continue;
+		} catch {
+			// Plugin doesn't ship its own copy; the bundled host module is
+			// what jiti should hand back for this specifier.
+		}
+		virtualModules[specifier] = value;
+	}
+	const jitiAliases: Record<string, string> = {};
+	for (const [specifier, target] of Object.entries(sortedAliases)) {
+		if (!Object.hasOwn(virtualModules, specifier)) {
+			jitiAliases[specifier] = target;
+		}
+	}
+	// jiti's lazyTransform uses `createRequire(import.meta.url)("../dist/babel.cjs")`
+	// to load its babel transformer on demand. In a `bun build --compile`
+	// binary that fails because `import.meta.url` points inside the bunfs
+	// bundle; the wrapper install still has the file on real disk though, so
+	// we locate it via our host-package resolver and inject the transform.
+	//
+	// jiti threads its top-level `interopDefault` into babel via the transform
+	// call's options (babel uses `noInterop: !interopDefault`). We want babel
+	// to emit the CJS interop wrapper so `import YAML from "yaml"` works for
+	// CJS deps, but we do not want jiti's runtime to wrap returned modules
+	// in a default-synthesizing Proxy (that proxy makes `moduleExports.default`
+	// truthy even for namespace-only modules, which breaks named-export
+	// plugins). Pin `interopDefault: true` going into babel by overriding it
+	// in the transform call, while keeping `interopDefault: false` on the jiti
+	// instance so the loader sees raw exports.
+	const baseBabelTransform = loadJitiBabelTransform();
+	const babelTransform: JitiTransform | undefined = baseBabelTransform
+		? (opts) => baseBabelTransform({ ...opts, interopDefault: true })
+		: undefined;
 	const jiti = createJiti(pluginPath, {
-		alias: sortedAliases,
+		alias: jitiAliases,
 		cache: options.useCache,
 		requireCache: options.useCache,
 		esmResolve: true,
 		interopDefault: false,
 		nativeModules: [...BUILTIN_MODULES],
-		transformModules: Object.keys(sortedAliases),
+		transformModules: Object.keys(jitiAliases),
+		virtualModules,
+		// On Bun (the packaged binary), tryNative defaults to true, which makes
+		// jiti hand the plugin path straight to Bun's `import()`. Bun then owns
+		// every nested import in the plugin, sees `import "@cline/core"` with no
+		// node_modules adjacent to the drop-in plugin, and throws ResolveMessage.
+		// Forcing tryNative off keeps jiti in charge so bare specifiers route
+		// through `virtualModules` first.
+		tryNative: false,
+		...(babelTransform ? { transform: babelTransform } : {}),
 	});
-	return (await jiti.import(pluginPath, {})) as Record<string, unknown>;
+	// Use the synchronous jiti(path) call rather than `jiti.import(path)`.
+	// The async path emits ESM, which `vm.runInThisContext` can't compile, so
+	// jiti falls back to `nativeImport(data:URL)`, and that Bun-side import
+	// has no way to consult our virtualModules map. The sync path emits CJS,
+	// wraps it in a function with jiti's own `require` injected, and routes
+	// every `require("@cline/core")` back through jitiRequire -> virtualModules.
+	return jiti(pluginPath) as Record<string, unknown>;
 }

--- a/sdk/packages/core/src/extensions/plugin/plugin-module-import.ts
+++ b/sdk/packages/core/src/extensions/plugin/plugin-module-import.ts
@@ -565,6 +565,16 @@ function collectPluginImportAliases(
 	return aliases;
 }
 
+function shouldTransformAliasTarget(target: string): boolean {
+	const extension = extname(target);
+	return (
+		extension === ".ts" ||
+		extension === ".tsx" ||
+		extension === ".mts" ||
+		extension === ".cts"
+	);
+}
+
 type JitiTransform = (opts: {
 	source: string;
 	filename?: string;
@@ -609,42 +619,6 @@ function loadJitiBabelTransform(): JitiTransform | null {
 	return cachedJitiTransform;
 }
 
-let cachedHostVirtualModules: Record<string, unknown> | undefined;
-
-function tryRequireFromPath(fromPath: string, specifier: string): unknown {
-	try {
-		return createRequire(fromPath)(specifier);
-	} catch {
-		return undefined;
-	}
-}
-
-function requireHostModule(specifier: string): unknown {
-	const wrapperPath = process.env.CLINE_WRAPPER_PATH?.trim();
-	if (wrapperPath) {
-		const module = tryRequireFromPath(wrapperPath, specifier);
-		if (module) {
-			return module;
-		}
-	}
-	return tryRequireFromPath(import.meta.url, specifier);
-}
-
-function collectHostVirtualModules(): Record<string, unknown> {
-	if (cachedHostVirtualModules) {
-		return cachedHostVirtualModules;
-	}
-	const modules: Record<string, unknown> = {};
-	for (const specifier of HOST_PROVIDED_SDK_SPECIFIERS) {
-		const value = requireHostModule(specifier);
-		if (value && Object.keys(value).length > 0) {
-			modules[specifier] = value;
-		}
-	}
-	cachedHostVirtualModules = modules;
-	return modules;
-}
-
 export async function importPluginModule(
 	pluginPath: string,
 	options: ImportPluginModuleOptions = {},
@@ -666,41 +640,9 @@ export async function importPluginModule(
 	if (!createJiti) {
 		throw new Error("Unable to load jiti");
 	}
-	// The host packages (@cline/core, @cline/shared, etc.) are already loaded
-	// inside this process; the cline binary bundles them. Hand jiti those live
-	// module instances as virtual modules so a plugin's `import "@cline/core"`
-	// resolves to an object lookup instead of jiti walking + transforming the
-	// entire shipped package tree on every load (8s -> ~300ms for `cline config
-	// tools` in packaged installs). `virtualModules` lookup keys on the bare
-	// specifier before alias rewriting, so we strip any alias entry we'll
-	// satisfy virtually. Otherwise the alias rewrites the specifier to an
-	// absolute path and we pay the full file-load cost anyway.
-	//
-	// A plugin that ships its own installed copy of a host package (e.g. a
-	// pinned `@cline/shared` in its node_modules) must still see that copy, not
-	// our bundled one. `collectPluginImportAliases` already drops workspace
-	// aliases for plugin-installed deps; mirror that here so virtualModules
-	// behaves the same way.
-	const pluginRequire = createRequire(pluginPath);
-	const virtualModules: Record<string, unknown> = {};
-	for (const [specifier, value] of Object.entries(
-		collectHostVirtualModules(),
-	)) {
-		try {
-			pluginRequire.resolve(specifier);
-			continue;
-		} catch {
-			// Plugin doesn't ship its own copy; the bundled host module is
-			// what jiti should hand back for this specifier.
-		}
-		virtualModules[specifier] = value;
-	}
-	const jitiAliases: Record<string, string> = {};
-	for (const [specifier, target] of Object.entries(sortedAliases)) {
-		if (!Object.hasOwn(virtualModules, specifier)) {
-			jitiAliases[specifier] = target;
-		}
-	}
+	const transformModules = Object.entries(sortedAliases)
+		.filter(([, target]) => shouldTransformAliasTarget(target))
+		.map(([specifier]) => specifier);
 	// jiti's lazyTransform uses `createRequire(import.meta.url)("../dist/babel.cjs")`
 	// to load its babel transformer on demand. In a `bun build --compile`
 	// binary that fails because `import.meta.url` points inside the bunfs
@@ -721,28 +663,20 @@ export async function importPluginModule(
 		? (opts) => baseBabelTransform({ ...opts, interopDefault: true })
 		: undefined;
 	const jiti = createJiti(pluginPath, {
-		alias: jitiAliases,
+		alias: sortedAliases,
 		cache: options.useCache,
 		requireCache: options.useCache,
 		esmResolve: true,
 		interopDefault: false,
 		nativeModules: [...BUILTIN_MODULES],
-		transformModules: Object.keys(jitiAliases),
-		virtualModules,
+		transformModules,
 		// On Bun (the packaged binary), tryNative defaults to true, which makes
 		// jiti hand the plugin path straight to Bun's `import()`. Bun then owns
 		// every nested import in the plugin, sees `import "@cline/core"` with no
-		// node_modules adjacent to the drop-in plugin, and throws ResolveMessage.
-		// Forcing tryNative off keeps jiti in charge so bare specifiers route
-		// through `virtualModules` first.
+		// node_modules adjacent to the drop-in plugin. Forcing tryNative off keeps
+		// jiti in charge so bare specifiers can be rewritten through aliases first.
 		tryNative: false,
 		...(babelTransform ? { transform: babelTransform } : {}),
 	});
-	// Use the synchronous jiti(path) call rather than `jiti.import(path)`.
-	// The async path emits ESM, which `vm.runInThisContext` can't compile, so
-	// jiti falls back to `nativeImport(data:URL)`, and that Bun-side import
-	// has no way to consult our virtualModules map. The sync path emits CJS,
-	// wraps it in a function with jiti's own `require` injected, and routes
-	// every `require("@cline/core")` back through jitiRequire -> virtualModules.
-	return jiti(pluginPath) as Record<string, unknown>;
+	return (await jiti.import(pluginPath, {})) as Record<string, unknown>;
 }

--- a/sdk/packages/core/src/extensions/plugin/plugin-module-import.ts
+++ b/sdk/packages/core/src/extensions/plugin/plugin-module-import.ts
@@ -11,6 +11,7 @@ const HOST_REQUIRE = createRequire(import.meta.url);
 const WORKSPACE_ROOT = resolve(MODULE_DIR, "..", "..", "..", "..", "..");
 const WORKSPACE_ALIASES = collectWorkspaceAliases(WORKSPACE_ROOT);
 const HOST_PROVIDED_SDK_SPECIFIERS = [
+	"@cline/sdk",
 	"@cline/agents",
 	"@cline/core",
 	"@cline/core/hub",

--- a/sdk/packages/core/src/extensions/plugin/plugin-sandbox.test.ts
+++ b/sdk/packages/core/src/extensions/plugin/plugin-sandbox.test.ts
@@ -8,7 +8,15 @@ import type {
 	AgentToolContext,
 	Message,
 } from "@cline/shared";
-import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import {
+	afterAll,
+	beforeAll,
+	beforeEach,
+	describe,
+	expect,
+	it,
+	vi,
+} from "vitest";
 import { loadSandboxedPlugins } from "./plugin-sandbox";
 
 function createApiCapture() {
@@ -424,6 +432,100 @@ describe("plugin-sandbox", () => {
 				payload: { value: "hello" },
 			},
 		]);
+	});
+
+	it("resolves sandbox bootstrap from the npm wrapper platform package", async () => {
+		const previousWrapperPath = process.env.CLINE_WRAPPER_PATH;
+		const wrapperRoot = await mkdtemp(
+			join(tmpdir(), "core-plugin-sandbox-wrapper-"),
+		);
+		const platform =
+			process.platform === "win32" ? "windows" : process.platform;
+		const packageRoot = join(
+			wrapperRoot,
+			"node_modules",
+			"@cline",
+			`cli-${platform}-${process.arch}`,
+		);
+		const wrapperBinDir = join(wrapperRoot, "bin");
+		const bootstrapPath = join(
+			packageRoot,
+			"extensions",
+			"plugin-sandbox-bootstrap.js",
+		);
+		const wrapperPath = join(wrapperBinDir, "cline");
+		const events: Array<{ name: string; payload?: unknown }> = [];
+
+		try {
+			await mkdir(join(packageRoot, "extensions"), { recursive: true });
+			await mkdir(wrapperBinDir, { recursive: true });
+			await writeFile(wrapperPath, "#!/usr/bin/env node\n", "utf8");
+			await writeFile(
+				join(packageRoot, "package.json"),
+				JSON.stringify({
+					name: `@cline/cli-${platform}-${process.arch}`,
+					version: "0.0.0-test",
+					type: "module",
+				}),
+				"utf8",
+			);
+			await writeFile(
+				bootstrapPath,
+				[
+					"process.on('message', (message) => {",
+					"  if (!message || message.type !== 'call') return;",
+					"  if (message.method !== 'initialize') throw new Error('Unexpected method: ' + message.method);",
+					"  process.send?.({ type: 'event', name: 'wrapper_bootstrap_selected', payload: { ok: true } });",
+					"  process.send?.({",
+					"    type: 'response',",
+					"    id: message.id,",
+					"    ok: true,",
+					"    result: {",
+					"      plugins: [{",
+					"        pluginId: 'plugin_1',",
+					"        pluginPath: 'wrapper-bootstrap',",
+					"        name: 'wrapper-bootstrap',",
+					"        manifest: { capabilities: ['tools'] },",
+					"        contributions: { tools: [], commands: [], messageBuilders: [], providers: [], automationEventTypes: [] },",
+					"      }],",
+					"      failures: [],",
+					"      warnings: [],",
+					"    },",
+					"  });",
+					"});",
+				].join("\n"),
+				"utf8",
+			);
+
+			process.env.CLINE_WRAPPER_PATH = wrapperPath;
+			vi.resetModules();
+			const { loadSandboxedPlugins: loadSandboxedPluginsFromWrapper } =
+				await import("./plugin-sandbox");
+			const sandboxed = await loadSandboxedPluginsFromWrapper({
+				pluginPaths: [join(wrapperRoot, "unused-plugin.mjs")],
+				onEvent: (event) => events.push(event),
+			});
+
+			try {
+				expect(
+					sandboxed.extensions?.map((extension) => extension.name),
+				).toEqual(["wrapper-bootstrap"]);
+				expect(events).toContainEqual({
+					name: "wrapper_bootstrap_selected",
+					payload: { ok: true },
+				});
+			} finally {
+				await sandboxed.shutdown();
+			}
+		} finally {
+			if (previousWrapperPath === undefined) {
+				delete process.env.CLINE_WRAPPER_PATH;
+			} else {
+				process.env.CLINE_WRAPPER_PATH = previousWrapperPath;
+			}
+			vi.resetModules();
+			await rm(wrapperRoot, { recursive: true, force: true });
+		}
 	});
 
 	it("registers automation event types and forwards sandbox automation events", async () => {

--- a/sdk/packages/core/src/extensions/plugin/plugin-sandbox.ts
+++ b/sdk/packages/core/src/extensions/plugin/plugin-sandbox.ts
@@ -108,6 +108,45 @@ function isUnknownPluginIdError(error: unknown): boolean {
 	return message.includes("Unknown sandbox plugin id:");
 }
 
+function getPlatformPackageName(): string {
+	const platform = process.platform === "win32" ? "windows" : process.platform;
+	return `@cline/cli-${platform}-${process.arch}`;
+}
+
+function resolveBootstrapFromWrapper(): string | undefined {
+	const wrapperPath = process.env.CLINE_WRAPPER_PATH?.trim();
+	if (!wrapperPath) {
+		return undefined;
+	}
+	try {
+		const requireFromWrapper = createRequire(wrapperPath);
+		const packageJsonPath = requireFromWrapper.resolve(
+			`${getPlatformPackageName()}/package.json`,
+		);
+		const candidate = join(
+			dirname(packageJsonPath),
+			"extensions",
+			"plugin-sandbox-bootstrap.js",
+		);
+		return existsSync(candidate) ? candidate : undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+function resolveBootstrapFromExecutable(): string | undefined {
+	const execPath = process.execPath?.trim();
+	if (!execPath) {
+		return undefined;
+	}
+	const candidate = join(
+		dirname(dirname(execPath)),
+		"extensions",
+		"plugin-sandbox-bootstrap.js",
+	);
+	return existsSync(candidate) ? candidate : undefined;
+}
+
 /**
  * Resolve the bootstrap for the sandbox subprocess.
  *
@@ -127,8 +166,12 @@ function resolveBootstrap(): { file: string } | { script: string } {
 		join(dir, "plugin-sandbox-bootstrap.js"),
 		join(dir, "extensions", "plugin-sandbox-bootstrap.js"),
 		join(dir, "agents", "plugin-sandbox-bootstrap.js"),
+		resolveBootstrapFromWrapper(),
+		resolveBootstrapFromExecutable(),
 	];
-	for (const candidate of candidates) {
+	for (const candidate of candidates.filter(
+		(candidate): candidate is string => typeof candidate === "string",
+	)) {
 		if (existsSync(candidate)) return { file: candidate };
 	}
 	const tsPath = join(dir, "plugin-sandbox-bootstrap.ts");


### PR DESCRIPTION
This fixes npm-installed Cline plugin tools not loading for production users.

The bug was easy to miss because local dev worked. When running from the monorepo with `bun run dev`, plugin examples that import `@cline/core`, `@cline/sdk`, or `@cline/shared` can resolve those packages from the workspace. In the published npm install path, the `cline` package is a Node wrapper that launches an OS-specific compiled Bun binary. Drop-in plugins under `~/.cline/plugins` are just user files, so they do not bring their own `node_modules`. That meant plugins could appear in the plugin list through filesystem discovery, while their tools failed to load because the plugin module import path could not reliably satisfy SDK imports in the packaged runtime.

There were three related problems:

1. The npm wrapper package did not ship the SDK packages that plugin authors import from.
2. Once the SDK packages were resolvable, jiti was still asked to transform every alias target, including already-compiled SDK package files from the wrapper install.
3. Runtime agent tools load through the plugin sandbox, so the packaged binary also needed to find `plugin-sandbox-bootstrap.js` from the installed platform package layout.

The fix keeps the public plugin authoring model intact: example plugins and user plugins can keep importing from `@cline/core`, `@cline/sdk`, `@cline/shared`, and the other host SDK packages. The npm wrapper now ships those packages as dependencies, and the plugin loader resolves those SDK package specifiers from packaged runtime search roots such as `CLINE_WRAPPER_PATH`.

Concretely, this PR:

- Adds `@cline/sdk`, `@cline/core`, `@cline/agents`, `@cline/llms`, and `@cline/shared` as dependencies of the generated `cline` npm wrapper package.
- Adds `@cline/sdk` to the host-provided plugin SDK specifier set so `@cline/sdk` works as the public plugin entrypoint, not only `@cline/core`.
- Updates `@cline/core` to jiti 2.7.
- Resolves host packages from runtime search roots that exist in packaged installs, including the npm wrapper path and executable-relative layout.
- Keeps plugin imports inside jiti with `tryNative: false`, so Bun native import does not try to resolve `@cline/core` from a drop-in plugin directory with no adjacent `node_modules`.
- Leaves `jiti.import()` on the async path so ESM plugins with top-level await continue to work.
- Only passes TS alias targets to jiti `transformModules`; compiled JS targets from wrapper dependencies are resolved as compiled JS instead of being re-transformed.
- Locates jiti's babel transform from real disk when available, avoiding lazy transform lookup problems inside `bun build --compile`.
- Adds packaged-layout sandbox bootstrap resolution so runtime plugin tools load in the agent path, not only in settings or `config tools`.
- Adds regression coverage for a standalone plugin resolving SDK dependencies from the npm wrapper path and for an ESM plugin using top-level await.

The important architecture detail is that the wrapper SDK packages and jiti aliasing are complementary:

```text
wrapper SDK dependencies
  make @cline/core, @cline/sdk, @cline/shared, etc. exist on disk next to the npm wrapper

jiti aliases
  let drop-in plugin imports resolve to host-provided SDK package files

transformModules filtering
  keeps TS workspace aliases transformable in dev, but avoids transforming compiled wrapper dependencies in packaged installs

sandbox bootstrap packaged-path lookup
  lets runtime plugin execution find plugin-sandbox-bootstrap.js from npm wrapper and platform binary layouts
```

Why not just rely on the compiled binary containing the code?

Bun's compiled binary contains the Cline code internally, but it does not expose a Node package namespace that a user plugin can import as `@cline/core`. A no-SDK wrapper experiment confirmed this: `cline config plugins` could still discover plugin files, but `cline config tools` only showed built-in tools because the plugin SDK imports could not be satisfied.

Why filtering `transformModules` matters after adding wrapper SDK dependencies:

Making `@cline/core` resolvable fixes correctness, but by itself it made `cline config tools` slow in packaged smoke tests. The old importer used:

```ts
transformModules: Object.keys(sortedAliases)
```

In local dev, that is reasonable because workspace aliases point at TypeScript source. In npm installs, those same alias keys can point at compiled `dist` files under wrapper `node_modules`. Asking jiti to transform that compiled package tree was the source of the 7 to 9 second `cline config tools` path.

The cleaned-up importer now computes:

```ts
const transformModules = Object.entries(sortedAliases)
  .filter(([, target]) => shouldTransformAliasTarget(target))
  .map(([specifier]) => specifier);
```

That preserves local dev behavior for TS workspace aliases and keeps packaged installs fast by not transforming compiled SDK packages.

There is also a settings versus runtime distinction that matters for this bug. Settings tool listing imports plugins in-process through `listPluginTools()`. Runtime agent tools load through the sandbox path and need `plugin-sandbox-bootstrap.js` to be found from the packaged layout. We saw states where tools could appear in settings but not reach the agent, so this PR fixes both the in-process import side and the sandbox bootstrap lookup side.

Debugging journey and gotchas:

- Plugin file discovery and plugin tool loading are different paths. The Plugins screen can show plugin files without importing them. Tool loading must import the plugin and run setup.
- Local dev worked because workspace packages were present and aliases resolved to source files.
- Packaged installs initially failed because the wrapper did not provide the SDK packages plugin authors import.
- After wrapper SDK packages were added, packaged tool listing became slow because jiti was transforming compiled host SDK dependencies.
- A virtual module experiment made the hot path fast, but it was the wrong long-term shape: it depended on `require()` for host modules, was brittle for ESM-only exports, and pushed toward sync jiti loading that could regress top-level await plugins.
- The agent path had one more requirement beyond settings: the plugin sandbox bootstrap had to be found from the platform package layout.
- During local testing, the wrapper cache at `bin/.cline` can hide stale binaries. The wrapper checks `bin/.cline` before resolving the platform package, so rebuilding the workspace binary is not enough unless the wrapper install and postinstall cache are refreshed.

Alternatives considered during debugging:

- Loading settings tools through the plugin sandbox. This worked functionally but made opening settings and toggling tools feel slow because it spawned sandbox work for UI listing.
- Caching plugin tool summaries. This would hide the import cost and add invalidation risk without fixing the underlying module resolution and transform issue.
- Static host SDK imports inside `plugin-module-import.ts`. This made the sandbox bootstrap bundle pull in too much core code and caused packaged sandbox failures.
- jiti virtual modules for host SDK packages. This was fast but too brittle for package export semantics and ESM compatibility.
- Removing wrapper SDK dependencies after adding aliasing. Tested and rejected because the compiled binary does not expose importable Node package namespaces to user plugins.
- Deferring unrelated slash command plugin loading. Useful as a later performance follow-up, but not the fire fix for production plugin tools.

This PR is intentionally scoped to making the existing plugin system work for npm-installed users without changing the plugin authoring API.
