### PR TITLE
Fix SDK examples README and VS Code clean build

### DIFF
--- a/sdk/apps/examples/README.md
+++ b/sdk/apps/examples/README.md
@@ -2,15 +2,6 @@
 
 Learn how to build with the Cline SDK through working examples, ordered from simple to complex.
 
-## SDK Skill
-If you use a coding agent (Claude Code, Codex, Cline, etc.), install the [Cline SDK skill](https://github.com/cline/sdk-skill) to give your agent context on the SDK's APIs and best practices to help you build with the Cline SDK.
-
-```bash
-npx skills add cline/sdk-skill
-```
-
-Prompt it to scaffold agents, create custom tools, wire up plugins, configure providers, and more.
-
 ## Getting started
 
 All examples live in this directory. Each is a standalone project with its own `package.json` and README. To run any example:

--- a/sdk/apps/examples/vscode/package.json
+++ b/sdk/apps/examples/vscode/package.json
@@ -43,9 +43,10 @@
 	},
 	"scripts": {
 		"build:webview": "cd ./src/webview && bun run build",
-		"build": "bun run build:webview && bun build ./src/extension.ts ./src/hub-daemon.ts --outdir ./dist --target=node --format=cjs --external=vscode --minify",
+		"build": "rm -rf dist && bun run build:webview && bun build ./src/extension.ts ./src/hub-daemon.ts --outdir ./dist --target=node --format=cjs --external=vscode --minify",
 		"watch": "bun build ./src/extension.ts ./src/hub-daemon.ts --outdir ./dist --target=node --format=cjs --external=vscode --minify --watch",
 		"typecheck": "tsc --noEmit",
+		"clean": "rm -rf dist",
 		"dev": "bun run watch"
 	},
 	"dependencies": {


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

### Description

Removes the outdated SDK skill callout from the SDK examples README and makes the VS Code SDK example build start from a clean `dist` directory.

This keeps the examples landing page focused on the examples themselves and prevents stale output from surviving repeated VS Code example builds.

### Test Procedure

- Ran `git diff --check`
- Ran `bun run typecheck` from `sdk/apps/examples/vscode`

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [x] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A - documentation and package script cleanup only.

### Additional Notes

This is split out from the larger SDK example demo work so it can be reviewed independently.
