### PR TITLE
fix(cli): improve light theme TUI colors

### DIFF
--- a/sdk/apps/cli/src/tui/components/chat-entry.tsx
+++ b/sdk/apps/cli/src/tui/components/chat-entry.tsx
@@ -2,10 +2,14 @@ import { useTerminalDimensions } from "@opentui/react";
 import type React from "react";
 import { useState } from "react";
 import "opentui-spinner/react";
-import { useTerminalBackground } from "../hooks/use-terminal-background";
+import {
+	useTerminalBackground,
+	useTerminalForeground,
+} from "../hooks/use-terminal-background";
 import {
 	getDefaultForeground,
 	getModeInputBackground,
+	getTerminalTheme,
 	palette,
 } from "../palette";
 import type { ChatEntry } from "../types";
@@ -254,6 +258,8 @@ function ToolCallView(props: {
 export function ChatEntryView(props: { entry: ChatEntry; accent?: string }) {
 	const { entry, accent = palette.act } = props;
 	const terminalBg = useTerminalBackground();
+	const terminalFg = useTerminalForeground();
+	const terminalTheme = getTerminalTheme(terminalBg, terminalFg);
 	const defaultFg = getDefaultForeground(terminalBg);
 	const userMsgBg = getModeInputBackground(
 		accent === palette.plan ? "plan" : "act",
@@ -316,7 +322,7 @@ export function ChatEntryView(props: { entry: ChatEntry; accent?: string }) {
 					<box flexGrow={1}>
 						<markdown
 							content={content}
-							syntaxStyle={getSyntaxStyle()}
+							syntaxStyle={getSyntaxStyle(terminalTheme)}
 							streaming={entry.streaming}
 							fg={defaultFg}
 						/>

--- a/sdk/apps/cli/src/tui/components/chat-entry.tsx
+++ b/sdk/apps/cli/src/tui/components/chat-entry.tsx
@@ -2,15 +2,12 @@ import { useTerminalDimensions } from "@opentui/react";
 import type React from "react";
 import { useState } from "react";
 import "opentui-spinner/react";
-import {
-	useTerminalBackground,
-	useTerminalForeground,
-} from "../hooks/use-terminal-background";
+import { useTerminalBackground } from "../hooks/use-terminal-background";
 import {
 	getDefaultForeground,
 	getModeInputBackground,
-	getTerminalTheme,
 	palette,
+	type TerminalTheme,
 } from "../palette";
 import type { ChatEntry } from "../types";
 import { getSyntaxStyle } from "../utils/syntax-style";
@@ -255,11 +252,13 @@ function ToolCallView(props: {
 	);
 }
 
-export function ChatEntryView(props: { entry: ChatEntry; accent?: string }) {
-	const { entry, accent = palette.act } = props;
+export function ChatEntryView(props: {
+	entry: ChatEntry;
+	accent?: string;
+	terminalTheme: TerminalTheme;
+}) {
+	const { entry, accent = palette.act, terminalTheme } = props;
 	const terminalBg = useTerminalBackground();
-	const terminalFg = useTerminalForeground();
-	const terminalTheme = getTerminalTheme(terminalBg, terminalFg);
 	const defaultFg = getDefaultForeground(terminalBg);
 	const userMsgBg = getModeInputBackground(
 		accent === palette.plan ? "plan" : "act",

--- a/sdk/apps/cli/src/tui/components/chat-message-list.tsx
+++ b/sdk/apps/cli/src/tui/components/chat-message-list.tsx
@@ -9,11 +9,8 @@ import {
 	useRef,
 } from "react";
 import type { TranscriptCommand } from "../hooks/transcript-keybinds";
-import {
-	useTerminalBackground,
-	useTerminalForeground,
-} from "../hooks/use-terminal-background";
-import { getModeAccent, getTerminalTheme } from "../palette";
+import { useTerminalTheme } from "../hooks/use-terminal-background";
+import { getModeAccent } from "../palette";
 import type { ChatEntry } from "../types";
 import { ChatEntryView } from "./chat-entry";
 
@@ -33,9 +30,7 @@ export const ChatMessageList = forwardRef<
 >(function ChatMessageList(props, ref) {
 	const scrollboxRef = useRef<ScrollBoxRenderable | null>(null);
 	const lastEntry = props.entries.at(-1);
-	const terminalBg = useTerminalBackground();
-	const terminalFg = useTerminalForeground();
-	const terminalTheme = getTerminalTheme(terminalBg, terminalFg);
+	const terminalTheme = useTerminalTheme();
 	const accent = getModeAccent(props.uiMode ?? "act", terminalTheme);
 	const userSubmissionScrollKey =
 		lastEntry?.kind === "user_submitted" ? props.entries.length : 0;
@@ -100,7 +95,14 @@ export const ChatMessageList = forwardRef<
 			<box flexDirection="column" paddingX={1} paddingY={1} gap={1}>
 				{props.entries.map((entry, i) => {
 					const key = `${i}:${entry.kind}`;
-					return <ChatEntryView key={key} entry={entry} accent={accent} />;
+					return (
+						<ChatEntryView
+							key={key}
+							entry={entry}
+							accent={accent}
+							terminalTheme={terminalTheme}
+						/>
+					);
 				})}
 				{props.isStreaming && (
 					<box flexDirection="row" gap={1}>

--- a/sdk/apps/cli/src/tui/components/chat-message-list.tsx
+++ b/sdk/apps/cli/src/tui/components/chat-message-list.tsx
@@ -9,7 +9,11 @@ import {
 	useRef,
 } from "react";
 import type { TranscriptCommand } from "../hooks/transcript-keybinds";
-import { getModeAccent } from "../palette";
+import {
+	useTerminalBackground,
+	useTerminalForeground,
+} from "../hooks/use-terminal-background";
+import { getModeAccent, getTerminalTheme } from "../palette";
 import type { ChatEntry } from "../types";
 import { ChatEntryView } from "./chat-entry";
 
@@ -29,6 +33,10 @@ export const ChatMessageList = forwardRef<
 >(function ChatMessageList(props, ref) {
 	const scrollboxRef = useRef<ScrollBoxRenderable | null>(null);
 	const lastEntry = props.entries.at(-1);
+	const terminalBg = useTerminalBackground();
+	const terminalFg = useTerminalForeground();
+	const terminalTheme = getTerminalTheme(terminalBg, terminalFg);
+	const accent = getModeAccent(props.uiMode ?? "act", terminalTheme);
 	const userSubmissionScrollKey =
 		lastEntry?.kind === "user_submitted" ? props.entries.length : 0;
 
@@ -92,17 +100,11 @@ export const ChatMessageList = forwardRef<
 			<box flexDirection="column" paddingX={1} paddingY={1} gap={1}>
 				{props.entries.map((entry, i) => {
 					const key = `${i}:${entry.kind}`;
-					return (
-						<ChatEntryView
-							key={key}
-							entry={entry}
-							accent={getModeAccent(props.uiMode ?? "act")}
-						/>
-					);
+					return <ChatEntryView key={key} entry={entry} accent={accent} />;
 				})}
 				{props.isStreaming && (
 					<box flexDirection="row" gap={1}>
-						<spinner name="dots" color={getModeAccent(props.uiMode ?? "act")} />
+						<spinner name="dots" color={accent} />
 						<text fg="gray">Thinking... (esc to cancel)</text>
 					</box>
 				)}

--- a/sdk/apps/cli/src/tui/components/status-bar.tsx
+++ b/sdk/apps/cli/src/tui/components/status-bar.tsx
@@ -1,8 +1,16 @@
 import type { AgentMode } from "@cline/core";
 import { useTerminalDimensions } from "@opentui/react";
 import { shouldShowCliUsageCost } from "../../utils/usage-cost-display";
-import { useTerminalBackground } from "../hooks/use-terminal-background";
-import { getDefaultForeground, palette } from "../palette";
+import {
+	useTerminalBackground,
+	useTerminalForeground,
+} from "../hooks/use-terminal-background";
+import {
+	getDefaultForeground,
+	getModeAccent,
+	getSuccessColor,
+	getTerminalTheme,
+} from "../palette";
 import { HOME_VIEW_MAX_WIDTH } from "../types";
 
 export function createContextBar(
@@ -132,8 +140,13 @@ export function StatusBar(props: StatusBarProps) {
 
 	const { width } = useTerminalDimensions();
 	const terminalBg = useTerminalBackground();
+	const terminalFg = useTerminalForeground();
+	const terminalTheme = getTerminalTheme(terminalBg, terminalFg);
 	const defaultFg = getDefaultForeground(terminalBg);
 	const contextBarFilledFg = resolveContextBarFilledForeground(defaultFg);
+	const actAccent = getModeAccent("act", terminalTheme);
+	const planAccent = getModeAccent("plan", terminalTheme);
+	const successColor = getSuccessColor(terminalTheme);
 	const hasMaxInputTokens =
 		typeof maxInputTokens === "number" &&
 		Number.isFinite(maxInputTokens) &&
@@ -212,10 +225,10 @@ export function StatusBar(props: StatusBarProps) {
 					flexShrink={0}
 					onMouseDown={onToggleMode}
 				>
-					<text fg={uiMode === "plan" ? palette.plan : "gray"}>
+					<text fg={uiMode === "plan" ? planAccent : "gray"}>
 						{uiMode === "plan" ? "●" : "○"} Plan
 					</text>
-					<text fg={uiMode === "act" ? palette.act : "gray"}>
+					<text fg={uiMode === "act" ? actAccent : "gray"}>
 						{uiMode === "act" ? "●" : "○"} Act
 					</text>
 					<text fg="gray">(Tab)</text>
@@ -231,7 +244,7 @@ export function StatusBar(props: StatusBarProps) {
 						{" | "}
 						{gitDiffStats.files} file
 						{gitDiffStats.files !== 1 ? "s" : ""}{" "}
-						<span fg={palette.success}>+{gitDiffStats.additions}</span>{" "}
+						<span fg={successColor}>+{gitDiffStats.additions}</span>{" "}
 						<span fg="red">-{gitDiffStats.deletions}</span>
 					</span>
 				)}
@@ -239,7 +252,7 @@ export function StatusBar(props: StatusBarProps) {
 
 			{autoApproveAll ? (
 				<text fg={defaultFg}>
-					<span fg={palette.success}>
+					<span fg={successColor}>
 						{"\u23f5\u23f5"} Auto-approve all enabled
 					</span>
 					<span fg="gray"> (Shift+Tab)</span>

--- a/sdk/apps/cli/src/tui/components/status-bar.tsx
+++ b/sdk/apps/cli/src/tui/components/status-bar.tsx
@@ -3,13 +3,12 @@ import { useTerminalDimensions } from "@opentui/react";
 import { shouldShowCliUsageCost } from "../../utils/usage-cost-display";
 import {
 	useTerminalBackground,
-	useTerminalForeground,
+	useTerminalTheme,
 } from "../hooks/use-terminal-background";
 import {
 	getDefaultForeground,
 	getModeAccent,
 	getSuccessColor,
-	getTerminalTheme,
 } from "../palette";
 import { HOME_VIEW_MAX_WIDTH } from "../types";
 
@@ -140,8 +139,7 @@ export function StatusBar(props: StatusBarProps) {
 
 	const { width } = useTerminalDimensions();
 	const terminalBg = useTerminalBackground();
-	const terminalFg = useTerminalForeground();
-	const terminalTheme = getTerminalTheme(terminalBg, terminalFg);
+	const terminalTheme = useTerminalTheme();
 	const defaultFg = getDefaultForeground(terminalBg);
 	const contextBarFilledFg = resolveContextBarFilledForeground(defaultFg);
 	const actAccent = getModeAccent("act", terminalTheme);

--- a/sdk/apps/cli/src/tui/components/tool-output.tsx
+++ b/sdk/apps/cli/src/tui/components/tool-output.tsx
@@ -1,5 +1,14 @@
 import { useState } from "react";
-import { palette } from "../palette";
+import {
+	useTerminalBackground,
+	useTerminalForeground,
+} from "../hooks/use-terminal-background";
+import {
+	diffPalettes,
+	getTerminalTheme,
+	palette,
+	type TerminalTheme,
+} from "../palette";
 import { makeUnifiedDiff } from "../utils/diff";
 import { getSyntaxStyle } from "../utils/syntax-style";
 import {
@@ -43,7 +52,7 @@ function isEditTool(toolName: string): boolean {
 	);
 }
 
-function BashOutput(props: { fullText: string }) {
+function BashOutput(props: { fullText: string; theme: TerminalTheme }) {
 	const [expanded, setExpanded] = useState(false);
 	const { fullText } = props;
 	const trimmed = fullText.trimEnd();
@@ -83,7 +92,7 @@ function BashOutput(props: { fullText: string }) {
 				<code
 					content={fullText}
 					filetype="bash"
-					syntaxStyle={getSyntaxStyle()}
+					syntaxStyle={getSyntaxStyle(props.theme)}
 					selectable
 				/>
 			</box>
@@ -131,7 +140,11 @@ function DiffStats(props: {
 	);
 }
 
-function EditOutput(props: { rawInput?: unknown; outputSummary: string }) {
+function EditOutput(props: {
+	rawInput?: unknown;
+	outputSummary: string;
+	theme: TerminalTheme;
+}) {
 	const [expanded, setExpanded] = useState(true);
 	const editorInfo = parseEditorInput(props.rawInput);
 
@@ -150,6 +163,7 @@ function EditOutput(props: { rawInput?: unknown; outputSummary: string }) {
 	const language = detectLanguage(editorInfo.path);
 	const addedLines = newText.split("\n").length;
 	const removedLines = oldText ? oldText.split("\n").length : 0;
+	const diffPalette = diffPalettes[props.theme];
 
 	return (
 		<box
@@ -168,9 +182,15 @@ function EditOutput(props: { rawInput?: unknown; outputSummary: string }) {
 						diff={makeUnifiedDiff(oldText, newText, editorInfo.path)}
 						view="unified"
 						filetype={language ?? "text"}
+						syntaxStyle={getSyntaxStyle(props.theme)}
 						showLineNumbers
-						addedLineNumberBg="#1a4d1a"
-						removedLineNumberBg="#4d1a1a"
+						addedBg={diffPalette.addedBg}
+						removedBg={diffPalette.removedBg}
+						addedLineNumberBg={diffPalette.addedLineNumberBg}
+						removedLineNumberBg={diffPalette.removedLineNumberBg}
+						addedSignColor={diffPalette.addedSignColor}
+						removedSignColor={diffPalette.removedSignColor}
+						lineNumberFg={diffPalette.lineNumberFg}
 					/>
 				</box>
 			)}
@@ -181,6 +201,7 @@ function EditOutput(props: { rawInput?: unknown; outputSummary: string }) {
 function ApplyPatchOutput(props: {
 	rawInput?: unknown;
 	outputSummary: string;
+	theme: TerminalTheme;
 }) {
 	const [expanded, setExpanded] = useState(true);
 	const info = parseApplyPatchInput(props.rawInput);
@@ -197,6 +218,7 @@ function ApplyPatchOutput(props: {
 
 	const fileLabel = info.files.map((f) => shortenPath(f, 40)).join(", ");
 	const language = detectLanguage(info.files[0] ?? "");
+	const diffPalette = diffPalettes[props.theme];
 
 	return (
 		<box
@@ -215,9 +237,15 @@ function ApplyPatchOutput(props: {
 						diff={info.diff}
 						view="unified"
 						filetype={language ?? "text"}
+						syntaxStyle={getSyntaxStyle(props.theme)}
 						showLineNumbers
-						addedLineNumberBg="#1a4d1a"
-						removedLineNumberBg="#4d1a1a"
+						addedBg={diffPalette.addedBg}
+						removedBg={diffPalette.removedBg}
+						addedLineNumberBg={diffPalette.addedLineNumberBg}
+						removedLineNumberBg={diffPalette.removedLineNumberBg}
+						addedSignColor={diffPalette.addedSignColor}
+						removedSignColor={diffPalette.removedSignColor}
+						lineNumberFg={diffPalette.lineNumberFg}
 					/>
 				</box>
 			)}
@@ -271,6 +299,9 @@ function GenericOutput(props: { outputSummary: string; fullText?: string }) {
 
 export function ToolOutput(props: ToolOutputProps) {
 	const { toolName, outputSummary, rawOutput, rawInput, error } = props;
+	const terminalBg = useTerminalBackground();
+	const terminalFg = useTerminalForeground();
+	const terminalTheme = getTerminalTheme(terminalBg, terminalFg);
 
 	if (error) {
 		return (
@@ -300,7 +331,9 @@ export function ToolOutput(props: ToolOutputProps) {
 	}
 
 	if (isBashTool(toolName)) {
-		return <BashOutput fullText={fullText || outputSummary} />;
+		return (
+			<BashOutput fullText={fullText || outputSummary} theme={terminalTheme} />
+		);
 	}
 
 	if (isReadTool(toolName)) {
@@ -311,12 +344,22 @@ export function ToolOutput(props: ToolOutputProps) {
 
 	if (toolName === "apply_patch") {
 		return (
-			<ApplyPatchOutput rawInput={rawInput} outputSummary={outputSummary} />
+			<ApplyPatchOutput
+				rawInput={rawInput}
+				outputSummary={outputSummary}
+				theme={terminalTheme}
+			/>
 		);
 	}
 
 	if (isEditTool(toolName)) {
-		return <EditOutput rawInput={rawInput} outputSummary={outputSummary} />;
+		return (
+			<EditOutput
+				rawInput={rawInput}
+				outputSummary={outputSummary}
+				theme={terminalTheme}
+			/>
+		);
 	}
 
 	return <GenericOutput outputSummary={outputSummary} fullText={fullText} />;

--- a/sdk/apps/cli/src/tui/components/tool-output.tsx
+++ b/sdk/apps/cli/src/tui/components/tool-output.tsx
@@ -1,14 +1,6 @@
 import { useState } from "react";
-import {
-	useTerminalBackground,
-	useTerminalForeground,
-} from "../hooks/use-terminal-background";
-import {
-	diffPalettes,
-	getTerminalTheme,
-	palette,
-	type TerminalTheme,
-} from "../palette";
+import { useTerminalTheme } from "../hooks/use-terminal-background";
+import { diffPalettes, palette, type TerminalTheme } from "../palette";
 import { makeUnifiedDiff } from "../utils/diff";
 import { getSyntaxStyle } from "../utils/syntax-style";
 import {
@@ -299,9 +291,7 @@ function GenericOutput(props: { outputSummary: string; fullText?: string }) {
 
 export function ToolOutput(props: ToolOutputProps) {
 	const { toolName, outputSummary, rawOutput, rawInput, error } = props;
-	const terminalBg = useTerminalBackground();
-	const terminalFg = useTerminalForeground();
-	const terminalTheme = getTerminalTheme(terminalBg, terminalFg);
+	const terminalTheme = useTerminalTheme();
 
 	if (error) {
 		return (

--- a/sdk/apps/cli/src/tui/hooks/use-terminal-background.ts
+++ b/sdk/apps/cli/src/tui/hooks/use-terminal-background.ts
@@ -1,4 +1,5 @@
 import { createContext, useContext } from "react";
+import { getTerminalTheme, type TerminalTheme } from "../palette";
 
 export interface TerminalColors {
 	background: string | null;
@@ -16,4 +17,9 @@ export function useTerminalBackground(): string | null {
 
 export function useTerminalForeground(): string | null {
 	return useContext(TerminalColorsContext).foreground;
+}
+
+export function useTerminalTheme(): TerminalTheme {
+	const { background, foreground } = useContext(TerminalColorsContext);
+	return getTerminalTheme(background, foreground);
 }

--- a/sdk/apps/cli/src/tui/palette.test.ts
+++ b/sdk/apps/cli/src/tui/palette.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { getModeAccent, getSuccessColor, getTerminalTheme } from "./palette";
+
+describe("getTerminalTheme", () => {
+	it("detects light terminals from the default background", () => {
+		expect(getTerminalTheme("#ffffff")).toBe("light");
+		expect(getTerminalTheme("#fdf6e3")).toBe("light");
+	});
+
+	it("detects dark terminals from the default background", () => {
+		expect(getTerminalTheme("#000000")).toBe("dark");
+		expect(getTerminalTheme("#002b36")).toBe("dark");
+	});
+
+	it("uses the foreground as a fallback when background is unavailable", () => {
+		expect(getTerminalTheme(null, "#1a1a1a")).toBe("light");
+		expect(getTerminalTheme(null, "#f0f0f0")).toBe("dark");
+	});
+
+	it("defaults to the existing dark theme when detection is unavailable", () => {
+		expect(getTerminalTheme(null, null)).toBe("dark");
+	});
+});
+
+describe("theme-aware palette helpers", () => {
+	it("preserves the existing named ANSI colors for dark terminals", () => {
+		expect(getModeAccent("act", "dark")).toBe("cyan");
+		expect(getModeAccent("plan", "dark")).toBe("yellow");
+		expect(getSuccessColor("dark")).toBe("brightGreen");
+	});
+
+	it("uses darker accents on light terminals", () => {
+		expect(getModeAccent("act", "light")).toBe("#0969da");
+		expect(getModeAccent("plan", "light")).toBe("#9a6700");
+		expect(getSuccessColor("light")).toBe("#116329");
+	});
+});

--- a/sdk/apps/cli/src/tui/palette.ts
+++ b/sdk/apps/cli/src/tui/palette.ts
@@ -8,8 +8,51 @@ export const palette = {
 	textOnSelection: "black",
 } as const;
 
-export function getModeAccent(mode: string): string {
-	return mode === "plan" ? palette.plan : palette.act;
+export type TerminalTheme = "dark" | "light";
+
+export const themePalette = {
+	dark: {
+		act: palette.act,
+		plan: palette.plan,
+		success: palette.success,
+	},
+	light: {
+		act: "#0969da",
+		plan: "#9a6700",
+		success: "#116329",
+	},
+} as const;
+
+export const diffPalettes = {
+	dark: {
+		addedBg: "#1a4d1a",
+		removedBg: "#4d1a1a",
+		addedLineNumberBg: "#1a4d1a",
+		removedLineNumberBg: "#4d1a1a",
+		addedSignColor: "#22c55e",
+		removedSignColor: "#ef4444",
+		lineNumberFg: "#888888",
+	},
+	light: {
+		addedBg: "#e6ffed",
+		removedBg: "#ffebe9",
+		addedLineNumberBg: "#ccf0d2",
+		removedLineNumberBg: "#ffd7d5",
+		addedSignColor: "#116329",
+		removedSignColor: "#b42318",
+		lineNumberFg: "#57606a",
+	},
+} as const;
+
+export function getModeAccent(
+	mode: string,
+	theme: TerminalTheme = "dark",
+): string {
+	return mode === "plan" ? themePalette[theme].plan : themePalette[theme].act;
+}
+
+export function getSuccessColor(theme: TerminalTheme = "dark"): string {
+	return themePalette[theme].success;
 }
 
 // Input field adaptive color system
@@ -64,6 +107,23 @@ function isLightTheme(terminalBg: string | null): boolean {
 	return hexToOklab(hex).L > LIGHT_THEME_THRESHOLD;
 }
 
+export function getTerminalTheme(
+	terminalBg: string | null,
+	terminalFg?: string | null,
+): TerminalTheme {
+	const bg = normalizeHex(terminalBg);
+	if (bg) {
+		return hexToOklab(bg).L > LIGHT_THEME_THRESHOLD ? "light" : "dark";
+	}
+
+	const fg = normalizeHex(terminalFg ?? null);
+	if (fg) {
+		return hexToOklab(fg).L <= LIGHT_THEME_THRESHOLD ? "light" : "dark";
+	}
+
+	return "dark";
+}
+
 export function getDefaultForeground(
 	terminalBg: string | null,
 ): string | undefined {
@@ -116,11 +176,11 @@ export function getModeInputPlaceholder(
 }
 
 function srgbToLinear(c: number): number {
-	return c <= 0.04045 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4;
+	return c <= 0.04045 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4);
 }
 
 function linearToSrgb(c: number): number {
-	const v = c <= 0.0031308 ? c * 12.92 : 1.055 * c ** (1 / 2.4) - 0.055;
+	const v = c <= 0.0031308 ? c * 12.92 : 1.055 * Math.pow(c, 1 / 2.4) - 0.055;
 	return Math.max(0, Math.min(1, v));
 }
 

--- a/sdk/apps/cli/src/tui/utils/syntax-style.test.ts
+++ b/sdk/apps/cli/src/tui/utils/syntax-style.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it, vi } from "vitest";
+import { getSyntaxStyle } from "./syntax-style";
+
+const { MockRGBA, MockSyntaxStyle } = vi.hoisted(() => {
+	class MockRGBA {
+		private constructor(private readonly hex: string) {}
+
+		static fromHex(hex: string): MockRGBA {
+			return new MockRGBA(hex.toLowerCase());
+		}
+
+		toInts(): [number, number, number, number] {
+			return [
+				Number.parseInt(this.hex.slice(1, 3), 16),
+				Number.parseInt(this.hex.slice(3, 5), 16),
+				Number.parseInt(this.hex.slice(5, 7), 16),
+				255,
+			];
+		}
+	}
+
+	class MockSyntaxStyle {
+		private constructor(private readonly styles: Map<string, unknown>) {}
+
+		static fromStyles(styles: Record<string, unknown>): MockSyntaxStyle {
+			return new MockSyntaxStyle(new Map(Object.entries(styles)));
+		}
+
+		getStyle(name: string): unknown {
+			return this.styles.get(name);
+		}
+	}
+
+	return { MockRGBA, MockSyntaxStyle };
+});
+
+vi.mock("@opentui/core", () => ({
+	RGBA: MockRGBA,
+	SyntaxStyle: MockSyntaxStyle,
+}));
+
+describe("getSyntaxStyle", () => {
+	it("keeps dark markdown prose on the terminal default foreground", () => {
+		expect(getSyntaxStyle("dark").getStyle("default")).toBeUndefined();
+	});
+
+	it("uses a dark default foreground for light markdown content", () => {
+		const style = getSyntaxStyle("light").getStyle("default");
+
+		expect(style?.fg?.toInts()).toEqual([26, 26, 26, 255]);
+	});
+});

--- a/sdk/apps/cli/src/tui/utils/syntax-style.ts
+++ b/sdk/apps/cli/src/tui/utils/syntax-style.ts
@@ -1,36 +1,130 @@
-import { RGBA, SyntaxStyle } from "@opentui/core";
+import { RGBA, type StyleDefinition, SyntaxStyle } from "@opentui/core";
+import type { TerminalTheme } from "../palette";
 
-let _instance: SyntaxStyle | null = null;
+const instances: Record<TerminalTheme, SyntaxStyle | null> = {
+	dark: null,
+	light: null,
+};
 
-export function getSyntaxStyle(): SyntaxStyle {
-	if (_instance) return _instance;
-	const markdownCode = RGBA.fromHex("#98c379");
-	const markdownHeading = RGBA.fromHex("#56b6c2");
-	const markdownMuted = RGBA.fromHex("#808080");
-	const markdownLink = RGBA.fromHex("#56b6c2");
+interface SyntaxColors {
+	keyword: string;
+	operator: string;
+	type: string;
+	functionName: string;
+	variable: string;
+	string: string;
+	number: string;
+	comment: string;
+	punctuation: string;
+	property: string;
+	constant: string;
+	tag: string;
+	attribute: string;
+	escape: string;
+	markdownCode: string;
+	markdownHeading: string;
+	markdownMuted: string;
+	markdownLink: string;
+	markdownItalic: string;
+	markdownDefault?: string;
+}
 
-	_instance = SyntaxStyle.fromStyles({
-		keyword: { fg: RGBA.fromHex("#c678dd"), bold: true },
-		"keyword.control": { fg: RGBA.fromHex("#c678dd"), bold: true },
-		"keyword.operator": { fg: RGBA.fromHex("#56b6c2") },
-		type: { fg: RGBA.fromHex("#e5c07b") },
-		"type.builtin": { fg: RGBA.fromHex("#e5c07b") },
-		function: { fg: RGBA.fromHex("#61afef") },
-		"function.method": { fg: RGBA.fromHex("#61afef") },
-		variable: { fg: RGBA.fromHex("#e06c75") },
-		"variable.parameter": { fg: RGBA.fromHex("#e06c75") },
-		"variable.builtin": { fg: RGBA.fromHex("#e5c07b") },
-		string: { fg: RGBA.fromHex("#98c379") },
-		"string.special": { fg: RGBA.fromHex("#98c379") },
-		number: { fg: RGBA.fromHex("#d19a66") },
-		comment: { fg: RGBA.fromHex("#5c6370"), italic: true },
-		operator: { fg: RGBA.fromHex("#56b6c2") },
-		punctuation: { fg: RGBA.fromHex("#abb2bf") },
-		property: { fg: RGBA.fromHex("#e06c75") },
-		constant: { fg: RGBA.fromHex("#d19a66") },
-		tag: { fg: RGBA.fromHex("#e06c75") },
-		attribute: { fg: RGBA.fromHex("#d19a66") },
-		escape: { fg: RGBA.fromHex("#56b6c2") },
+const syntaxColors: Record<TerminalTheme, SyntaxColors> = {
+	dark: {
+		keyword: "#c678dd",
+		operator: "#56b6c2",
+		type: "#e5c07b",
+		functionName: "#61afef",
+		variable: "#e06c75",
+		string: "#98c379",
+		number: "#d19a66",
+		comment: "#5c6370",
+		punctuation: "#abb2bf",
+		property: "#e06c75",
+		constant: "#d19a66",
+		tag: "#e06c75",
+		attribute: "#d19a66",
+		escape: "#56b6c2",
+		markdownCode: "#98c379",
+		markdownHeading: "#56b6c2",
+		markdownMuted: "#808080",
+		markdownLink: "#56b6c2",
+		markdownItalic: "#e5c07b",
+	},
+	light: {
+		keyword: "#cf222e",
+		operator: "#0550ae",
+		type: "#953800",
+		functionName: "#8250df",
+		variable: "#953800",
+		string: "#0a3069",
+		number: "#0550ae",
+		comment: "#6e7781",
+		punctuation: "#57606a",
+		property: "#0550ae",
+		constant: "#0550ae",
+		tag: "#116329",
+		attribute: "#0550ae",
+		escape: "#0550ae",
+		markdownCode: "#116329",
+		markdownHeading: "#0969da",
+		markdownMuted: "#6e7781",
+		markdownLink: "#0969da",
+		markdownItalic: "#8250df",
+		markdownDefault: "#1a1a1a",
+	},
+};
+
+function color(hex: string): RGBA {
+	return RGBA.fromHex(hex);
+}
+
+function fg(hex: string): StyleDefinition {
+	return { fg: color(hex) };
+}
+
+function bold(hex: string): StyleDefinition {
+	return { fg: color(hex), bold: true };
+}
+
+function italic(hex: string): StyleDefinition {
+	return { fg: color(hex), italic: true };
+}
+
+function underline(hex: string): StyleDefinition {
+	return { fg: color(hex), underline: true };
+}
+
+function buildSyntaxStyle(theme: TerminalTheme): SyntaxStyle {
+	const colors = syntaxColors[theme];
+	const markdownHeading = color(colors.markdownHeading);
+	const markdownCode = color(colors.markdownCode);
+	const markdownMuted = color(colors.markdownMuted);
+	const markdownLink = color(colors.markdownLink);
+
+	return SyntaxStyle.fromStyles({
+		...(colors.markdownDefault ? { default: fg(colors.markdownDefault) } : {}),
+		keyword: bold(colors.keyword),
+		"keyword.control": bold(colors.keyword),
+		"keyword.operator": fg(colors.operator),
+		type: fg(colors.type),
+		"type.builtin": fg(colors.type),
+		function: fg(colors.functionName),
+		"function.method": fg(colors.functionName),
+		variable: fg(colors.variable),
+		"variable.parameter": fg(colors.variable),
+		"variable.builtin": fg(colors.type),
+		string: fg(colors.string),
+		"string.special": fg(colors.string),
+		number: fg(colors.number),
+		comment: italic(colors.comment),
+		operator: fg(colors.operator),
+		punctuation: fg(colors.punctuation),
+		property: fg(colors.property),
+		constant: fg(colors.constant),
+		tag: fg(colors.tag),
+		attribute: fg(colors.attribute),
+		escape: fg(colors.escape),
 		"markup.heading": { fg: markdownHeading, bold: true },
 		"markup.heading.1": { fg: markdownHeading, bold: true },
 		"markup.heading.2": { fg: markdownHeading, bold: true },
@@ -43,7 +137,7 @@ export function getSyntaxStyle(): SyntaxStyle {
 		"markup.raw.block": { fg: markdownCode },
 		"markup.strong": { fg: markdownHeading, bold: true },
 		"markup.bold": { fg: markdownHeading, bold: true },
-		"markup.italic": { fg: RGBA.fromHex("#e5c07b"), italic: true },
+		"markup.italic": italic(colors.markdownItalic),
 		"markup.quote": { fg: markdownMuted, italic: true },
 		"markup.list": { fg: markdownHeading },
 		"markup.link": { fg: markdownLink, underline: true },
@@ -51,7 +145,11 @@ export function getSyntaxStyle(): SyntaxStyle {
 		"markup.link.url": { fg: markdownLink, underline: true },
 		label: { fg: markdownLink },
 		conceal: { fg: markdownMuted },
-		"string.special.url": { fg: markdownLink, underline: true },
+		"string.special.url": underline(colors.markdownLink),
 	});
-	return _instance;
+}
+
+export function getSyntaxStyle(theme: TerminalTheme = "dark"): SyntaxStyle {
+	instances[theme] ??= buildSyntaxStyle(theme);
+	return instances[theme];
 }

--- a/sdk/apps/cli/src/tui/utils/syntax-style.ts
+++ b/sdk/apps/cli/src/tui/utils/syntax-style.ts
@@ -150,6 +150,5 @@ function buildSyntaxStyle(theme: TerminalTheme): SyntaxStyle {
 }
 
 export function getSyntaxStyle(theme: TerminalTheme = "dark"): SyntaxStyle {
-	instances[theme] ??= buildSyntaxStyle(theme);
-	return instances[theme];
+	return (instances[theme] ??= buildSyntaxStyle(theme));
 }

--- a/sdk/apps/cli/src/tui/views/chat-view.tsx
+++ b/sdk/apps/cli/src/tui/views/chat-view.tsx
@@ -14,12 +14,16 @@ import {
 	StatusBar,
 } from "../components/status-bar";
 import { useSession } from "../contexts/session-context";
-import { useTerminalBackground } from "../hooks/use-terminal-background";
+import {
+	useTerminalBackground,
+	useTerminalForeground,
+} from "../hooks/use-terminal-background";
 import {
 	getModeAccent,
 	getModeInputBackground,
 	getModeInputForeground,
 	getModeInputPlaceholder,
+	getTerminalTheme,
 } from "../palette";
 import type { QueuedPromptItem, TuiProps } from "../types";
 
@@ -61,7 +65,9 @@ export function ChatView(props: {
 	} = props;
 	const session = useSession();
 	const terminalBg = useTerminalBackground();
-	const accent = getModeAccent(session.uiMode);
+	const terminalFg = useTerminalForeground();
+	const terminalTheme = getTerminalTheme(terminalBg, terminalFg);
+	const accent = getModeAccent(session.uiMode, terminalTheme);
 	const inputBackground = getModeInputBackground(session.uiMode, terminalBg);
 	const inputForeground = getModeInputForeground(session.uiMode, terminalBg);
 	const inputPlaceholder = getModeInputPlaceholder(session.uiMode, terminalBg);

--- a/sdk/apps/cli/src/tui/views/chat-view.tsx
+++ b/sdk/apps/cli/src/tui/views/chat-view.tsx
@@ -16,14 +16,13 @@ import {
 import { useSession } from "../contexts/session-context";
 import {
 	useTerminalBackground,
-	useTerminalForeground,
+	useTerminalTheme,
 } from "../hooks/use-terminal-background";
 import {
 	getModeAccent,
 	getModeInputBackground,
 	getModeInputForeground,
 	getModeInputPlaceholder,
-	getTerminalTheme,
 } from "../palette";
 import type { QueuedPromptItem, TuiProps } from "../types";
 
@@ -65,8 +64,7 @@ export function ChatView(props: {
 	} = props;
 	const session = useSession();
 	const terminalBg = useTerminalBackground();
-	const terminalFg = useTerminalForeground();
-	const terminalTheme = getTerminalTheme(terminalBg, terminalFg);
+	const terminalTheme = useTerminalTheme();
 	const accent = getModeAccent(session.uiMode, terminalTheme);
 	const inputBackground = getModeInputBackground(session.uiMode, terminalBg);
 	const inputForeground = getModeInputForeground(session.uiMode, terminalBg);

--- a/sdk/apps/cli/src/tui/views/home-view.tsx
+++ b/sdk/apps/cli/src/tui/views/home-view.tsx
@@ -13,13 +13,17 @@ import {
 } from "../components/status-bar";
 import { TrackedRobot, useMouseTracker } from "../components/tracked-robot";
 import { useSession } from "../contexts/session-context";
-import { useTerminalBackground } from "../hooks/use-terminal-background";
+import {
+	useTerminalBackground,
+	useTerminalForeground,
+} from "../hooks/use-terminal-background";
 import {
 	getDefaultForeground,
 	getModeAccent,
 	getModeInputBackground,
 	getModeInputForeground,
 	getModeInputPlaceholder,
+	getTerminalTheme,
 } from "../palette";
 import { HOME_VIEW_MAX_WIDTH, type TuiProps } from "../types";
 
@@ -63,8 +67,10 @@ export function HomeView(props: {
 	} | null>(null);
 
 	const terminalBg = useTerminalBackground();
+	const terminalFg = useTerminalForeground();
+	const terminalTheme = getTerminalTheme(terminalBg, terminalFg);
 	const defaultFg = getDefaultForeground(terminalBg);
-	const accent = getModeAccent(session.uiMode);
+	const accent = getModeAccent(session.uiMode, terminalTheme);
 	const inputBackground = getModeInputBackground(session.uiMode, terminalBg);
 	const inputForeground = getModeInputForeground(session.uiMode, terminalBg);
 	const inputPlaceholder = getModeInputPlaceholder(session.uiMode, terminalBg);

--- a/sdk/apps/cli/src/tui/views/home-view.tsx
+++ b/sdk/apps/cli/src/tui/views/home-view.tsx
@@ -15,7 +15,7 @@ import { TrackedRobot, useMouseTracker } from "../components/tracked-robot";
 import { useSession } from "../contexts/session-context";
 import {
 	useTerminalBackground,
-	useTerminalForeground,
+	useTerminalTheme,
 } from "../hooks/use-terminal-background";
 import {
 	getDefaultForeground,
@@ -23,7 +23,6 @@ import {
 	getModeInputBackground,
 	getModeInputForeground,
 	getModeInputPlaceholder,
-	getTerminalTheme,
 } from "../palette";
 import { HOME_VIEW_MAX_WIDTH, type TuiProps } from "../types";
 
@@ -67,8 +66,7 @@ export function HomeView(props: {
 	} | null>(null);
 
 	const terminalBg = useTerminalBackground();
-	const terminalFg = useTerminalForeground();
-	const terminalTheme = getTerminalTheme(terminalBg, terminalFg);
+	const terminalTheme = useTerminalTheme();
 	const defaultFg = getDefaultForeground(terminalBg);
 	const accent = getModeAccent(session.uiMode, terminalTheme);
 	const inputBackground = getModeInputBackground(session.uiMode, terminalBg);


### PR DESCRIPTION
This PR improves the CLI TUI on light-themed terminals. The existing color choices were built around dark backgrounds, which made several areas hard to read on white or near-white terminal backgrounds.

<img width="1677" height="683" alt="image" src="https://github.com/user-attachments/assets/f095d279-4e70-4450-aa8f-ef5489bf53bf" />


The change starts by detecting whether the terminal is effectively light or dark from the detected default background, with a foreground-based fallback when the background is unavailable. Dark terminals keep the existing named ANSI colors for plan, act, success, and normal markdown prose. Light terminals get darker explicit colors for plan, act, success, markdown syntax, diffs, and default markdown foregrounds.

The implementation also applies the detected terminal theme to the chat accent, status bar mode labels, auto-approve-all success text, syntax highlighting, and diff renderables. Diff backgrounds and line number colors now have light-theme variants instead of reusing dark green and dark red backgrounds on white terminals.
