### PR TITLE
fix(cli): forward provider options to gateway

### DIFF
--- a/sdk/packages/core/src/services/llms/handler-factory.test.ts
+++ b/sdk/packages/core/src/services/llms/handler-factory.test.ts
@@ -82,6 +82,52 @@ describe("createAgentModelFromConfig", () => {
 		);
 	});
 
+	it("forwards provider-specific options into the gateway config", async () => {
+		const { createAgentModelFromConfig } = await import("./handler-factory");
+
+		createAgentModelFromConfig(
+			{
+				providerId: "bedrock",
+				modelId: "anthropic.claude-opus-4-7",
+				systemPrompt: "",
+				tools: [],
+				providerConfig: {
+					providerId: "bedrock",
+					modelId: "anthropic.claude-opus-4-7",
+					region: "us-east-1",
+					aws: {
+						authentication: "profile",
+						profile: "default",
+						accessKey: "access-key",
+						secretKey: "secret-key",
+						sessionToken: "session-token",
+						endpoint: "https://bedrock-runtime.us-east-1.amazonaws.com",
+					},
+				},
+			} satisfies AgentConfig,
+			undefined,
+		);
+
+		expect(gatewayMock.createGateway).toHaveBeenLastCalledWith(
+			expect.objectContaining({
+				providerConfigs: [
+					expect.objectContaining({
+						providerId: "bedrock",
+						options: {
+							region: "us-east-1",
+							authentication: "profile",
+							profile: "default",
+							accessKeyId: "access-key",
+							secretAccessKey: "secret-key",
+							sessionToken: "session-token",
+							endpoint: "https://bedrock-runtime.us-east-1.amazonaws.com",
+						},
+					}),
+				],
+			}),
+		);
+	});
+
 	it("preserves model capabilities and metadata when configuring gateway models", async () => {
 		const { createAgentModelFromConfig } = await import("./handler-factory");
 

--- a/sdk/packages/core/src/services/llms/handler-factory.ts
+++ b/sdk/packages/core/src/services/llms/handler-factory.ts
@@ -75,6 +75,34 @@ function toGatewayConfiguredModel(
 	};
 }
 
+function compactOptions(options: Record<string, unknown>) {
+	const entries = Object.entries(options).filter(
+		([, value]) => value !== undefined,
+	);
+	return entries.length ? Object.fromEntries(entries) : undefined;
+}
+
+function toGatewayProviderOptions(
+	config: ProviderConfig,
+): Record<string, unknown> | undefined {
+	return compactOptions({
+		region: config.region,
+		authentication: config.aws?.authentication,
+		profile: config.aws?.profile,
+		accessKeyId: config.aws?.accessKey,
+		secretAccessKey: config.aws?.secretKey,
+		sessionToken: config.aws?.sessionToken,
+		endpoint: config.aws?.endpoint,
+		usePromptCache: config.aws?.usePromptCache,
+		useCrossRegionInference: config.useCrossRegionInference,
+		useGlobalInference: config.useGlobalInference,
+		customModelBaseId: config.aws?.customModelBaseId,
+		projectId: config.gcp?.projectId,
+		apiVersion: config.azure?.apiVersion,
+		useIdentity: config.azure?.useIdentity,
+	});
+}
+
 export function createAgentModelFromConfig(
 	config: AgentConfig,
 	logger: BasicLogger | undefined,
@@ -105,6 +133,7 @@ export function createAgentModelFromConfig(
 				apiKey: normalizedProviderConfig.apiKey,
 				baseUrl: normalizedProviderConfig.baseUrl,
 				headers: normalizedProviderConfig.headers,
+				options: toGatewayProviderOptions(normalizedProviderConfig),
 				models: normalizedProviderConfig.knownModels
 					? Object.entries(normalizedProviderConfig.knownModels).map(
 							([id, model]) => toGatewayConfiguredModel(id, model),

--- a/sdk/packages/core/src/services/llms/handler-factory.ts
+++ b/sdk/packages/core/src/services/llms/handler-factory.ts
@@ -82,9 +82,13 @@ function compactOptions(options: Record<string, unknown>) {
 	return entries.length ? Object.fromEntries(entries) : undefined;
 }
 
-function toGatewayProviderOptions(
+function toGatewayBedrockOptions(
 	config: ProviderConfig,
 ): Record<string, unknown> | undefined {
+	if (config.providerId !== "bedrock") {
+		return undefined;
+	}
+
 	return compactOptions({
 		region: config.region,
 		authentication: config.aws?.authentication,
@@ -93,13 +97,6 @@ function toGatewayProviderOptions(
 		secretAccessKey: config.aws?.secretKey,
 		sessionToken: config.aws?.sessionToken,
 		endpoint: config.aws?.endpoint,
-		usePromptCache: config.aws?.usePromptCache,
-		useCrossRegionInference: config.useCrossRegionInference,
-		useGlobalInference: config.useGlobalInference,
-		customModelBaseId: config.aws?.customModelBaseId,
-		projectId: config.gcp?.projectId,
-		apiVersion: config.azure?.apiVersion,
-		useIdentity: config.azure?.useIdentity,
 	});
 }
 
@@ -133,7 +130,7 @@ export function createAgentModelFromConfig(
 				apiKey: normalizedProviderConfig.apiKey,
 				baseUrl: normalizedProviderConfig.baseUrl,
 				headers: normalizedProviderConfig.headers,
-				options: toGatewayProviderOptions(normalizedProviderConfig),
+				options: toGatewayBedrockOptions(normalizedProviderConfig),
 				models: normalizedProviderConfig.knownModels
 					? Object.entries(normalizedProviderConfig.knownModels).map(
 							([id, model]) => toGatewayConfiguredModel(id, model),


### PR DESCRIPTION
## Summary
- forward provider-specific settings from the CLI-normalized config into gateway provider configs
- include AWS Bedrock region/profile/credential options so the Bedrock provider can resolve profile auth in the CLI path
- cover the config handoff with a handler-factory unit test

Fixes #10770

## Test plan
- git diff --check
- Not run: package tests, because this sparse checkout has no installed dependencies and I avoided a local install/build for this small pass.