### PR TITLE
fix(cli): hydrate plugin tools and commands in settings

### DIFF
--- a/sdk/apps/cli/src/runtime/interactive/config-data.test.ts
+++ b/sdk/apps/cli/src/runtime/interactive/config-data.test.ts
@@ -45,6 +45,30 @@ describe("interactive config data loader", () => {
 		tempRoots.length = 0;
 	});
 
+	async function writeSettingsPlugin(tempRoot: string): Promise<string> {
+		const pluginsDir = join(tempRoot, ".cline", "plugins");
+		await mkdir(pluginsDir, { recursive: true });
+		const pluginPath = join(pluginsDir, "settings-plugin.js");
+		await writeFile(
+			pluginPath,
+			[
+				"export default {",
+				"  name: 'settings-plugin',",
+				"  manifest: { capabilities: ['tools'] },",
+				"  setup(api) {",
+				"    api.registerTool({",
+				"      name: 'settings_plugin_tool',",
+				"      description: 'Settings plugin tool',",
+				"      inputSchema: { type: 'object', properties: {} },",
+				"      execute: async () => 'ok',",
+				"    });",
+				"  },",
+				"};",
+			].join("\n"),
+		);
+		return pluginPath;
+	}
+
 	it("toggles a skill item to the opposite enabled state and refreshes before reload", async () => {
 		const tempRoot = await mkdtemp(join(tmpdir(), "cli-config-data-"));
 		tempRoots.push(tempRoot);
@@ -139,6 +163,49 @@ Use this skill.`,
 		expect(data).toBeDefined();
 	});
 
+	it("can skip plugin tool imports for fast settings open", async () => {
+		const tempRoot = await mkdtemp(join(tmpdir(), "cli-config-data-"));
+		tempRoots.push(tempRoot);
+		process.env.CLINE_GLOBAL_SETTINGS_PATH = join(
+			tempRoot,
+			"global-settings.json",
+		);
+		const pluginPath = await writeSettingsPlugin(tempRoot);
+		const loader = createInteractiveConfigDataLoader({
+			config: createConfig(tempRoot),
+		});
+
+		const data = await loader.loadConfigData({ includePluginTools: false });
+
+		expect(data.plugins.some((item) => item.path === pluginPath)).toBe(true);
+		expect(
+			data.tools.some((item) => item.pluginName === "settings-plugin"),
+		).toBe(false);
+	});
+
+	it("loads plugin tools when requested", async () => {
+		const tempRoot = await mkdtemp(join(tmpdir(), "cli-config-data-"));
+		tempRoots.push(tempRoot);
+		process.env.CLINE_GLOBAL_SETTINGS_PATH = join(
+			tempRoot,
+			"global-settings.json",
+		);
+		await writeSettingsPlugin(tempRoot);
+		const loader = createInteractiveConfigDataLoader({
+			config: createConfig(tempRoot),
+		});
+
+		const data = await loader.loadConfigData({ includePluginTools: true });
+
+		expect(
+			data.tools.some(
+				(item) =>
+					item.pluginName === "settings-plugin" &&
+					item.name === "settings_plugin_tool",
+			),
+		).toBe(true);
+	});
+
 	it("toggles every SDK tool name for a displayed built-in tool", async () => {
 		const tempRoot = await mkdtemp(join(tmpdir(), "cli-config-data-"));
 		tempRoots.push(tempRoot);
@@ -190,8 +257,11 @@ Use this skill.`,
 		const data = await loader.loadConfigData();
 		const plugin = data.plugins.find((item) => item.path === pluginPath);
 		expect(plugin?.enabled).toBe(false);
+		if (!plugin) {
+			throw new Error("Expected workspace plugin to be listed");
+		}
 
-		const nextData = await loader.onToggleConfigItem(plugin!);
+		const nextData = await loader.onToggleConfigItem(plugin);
 		const settings = JSON.parse(
 			await readFile(process.env.CLINE_GLOBAL_SETTINGS_PATH, "utf8"),
 		) as { disabledPlugins?: string[] };

--- a/sdk/apps/cli/src/runtime/interactive/config-data.ts
+++ b/sdk/apps/cli/src/runtime/interactive/config-data.ts
@@ -6,6 +6,7 @@ import {
 import {
 	type InteractiveConfigData,
 	type InteractiveConfigItem,
+	type LoadInteractiveConfigDataOptions,
 	loadInteractiveConfigData,
 } from "../../tui/interactive-config";
 import type { Config } from "../../utils/types";
@@ -23,16 +24,20 @@ export function createInteractiveConfigDataLoader(input: {
 		enableSpawnAgent: input.config.enableSpawnAgent,
 		enableAgentTeams: input.config.enableAgentTeams,
 	});
-	const loadConfigData = async (): Promise<InteractiveConfigData> =>
+	const loadConfigData = async (
+		options: LoadInteractiveConfigDataOptions = {},
+	): Promise<InteractiveConfigData> =>
 		await loadInteractiveConfigData({
 			userInstructionService: input.userInstructionService,
 			cwd: input.config.cwd,
 			workspaceRoot: workspaceRoot(),
 			availabilityContext: availabilityContext(),
+			includePluginTools: options.includePluginTools,
 		});
 
 	const onToggleConfigItem = async (
 		item: InteractiveConfigItem,
+		options: LoadInteractiveConfigDataOptions = {},
 	): Promise<InteractiveConfigData | undefined> => {
 		const settings = createCoreSettingsService();
 		if (item.kind === "skill" && typeof item.enabled === "boolean") {
@@ -47,12 +52,12 @@ export function createInteractiveConfigDataLoader(input: {
 				userInstructionService: input.userInstructionService,
 				availabilityContext: availabilityContext(),
 			});
-			return await loadConfigData();
+			return await loadConfigData(options);
 		}
 
 		if (item.kind === "plugin" && typeof item.enabled === "boolean") {
 			setDisabledPlugin(item.path, item.enabled);
-			return await loadConfigData();
+			return await loadConfigData(options);
 		}
 
 		if (item.kind === "mcp" && typeof item.enabled === "boolean") {
@@ -66,7 +71,7 @@ export function createInteractiveConfigDataLoader(input: {
 				workspaceRoot: workspaceRoot(),
 				availabilityContext: availabilityContext(),
 			});
-			return await loadConfigData();
+			return await loadConfigData(options);
 		}
 
 		if (
@@ -93,7 +98,7 @@ export function createInteractiveConfigDataLoader(input: {
 				availabilityContext: availabilityContext(),
 			});
 		}
-		return await loadConfigData();
+		return await loadConfigData(options);
 	};
 
 	return {

--- a/sdk/apps/cli/src/runtime/run-interactive.ts
+++ b/sdk/apps/cli/src/runtime/run-interactive.ts
@@ -68,24 +68,48 @@ export async function runInteractive(
 		userInstructionService,
 	);
 	let interactiveChatCommandHost = chatCommandHost;
+	let pluginChatCommandHostLoaded = false;
+	let pluginChatSlashCommands: InteractiveSlashCommand[] = [];
+	let pluginChatCommandHostShutdown: (() => Promise<void>) | undefined;
+	let pluginChatCommandHostPromise:
+		| Promise<InteractiveSlashCommand[]>
+		| undefined;
 	const configDataLoader = createInteractiveConfigDataLoader({
 		config,
 		userInstructionService,
 	});
-	const loadAdditionalSlashCommands = async (): Promise<
+	const ensurePluginChatCommandHost = async (): Promise<
 		InteractiveSlashCommand[]
 	> => {
-		const { host, pluginSlashCommands } = await createWorkspaceChatCommandHost({
+		if (pluginChatCommandHostLoaded) {
+			return pluginChatSlashCommands;
+		}
+		pluginChatCommandHostPromise ??= createWorkspaceChatCommandHost({
 			cwd: config.cwd,
 			workspaceRoot: config.workspaceRoot,
 			logger: config.logger,
-		});
-		interactiveChatCommandHost = host;
-		return pluginSlashCommands.map((cmd) => ({
-			name: cmd.name,
-			instructions: "",
-			description: cmd.description ?? "Plugin command",
-		}));
+		})
+			.then(({ host, pluginSlashCommands, shutdown }) => {
+				interactiveChatCommandHost = host;
+				pluginChatCommandHostShutdown = shutdown;
+				pluginChatSlashCommands = pluginSlashCommands.map((cmd) => ({
+					name: cmd.name,
+					instructions: "",
+					description: cmd.description ?? "Plugin command",
+				}));
+				return pluginChatSlashCommands;
+			})
+			.finally(() => {
+				pluginChatCommandHostLoaded = true;
+				pluginChatCommandHostPromise = undefined;
+			});
+		return await pluginChatCommandHostPromise;
+	};
+	const loadAdditionalSlashCommands = async (): Promise<
+		InteractiveSlashCommand[]
+	> => await ensurePluginChatCommandHost();
+	const shouldTryPluginChatCommands = (prompt: string): boolean => {
+		return prompt.trimStart().startsWith("/");
 	};
 
 	const enableChatCommands = true;
@@ -220,9 +244,18 @@ export async function runInteractive(
 		cleanupPromise = (async () => {
 			process.off("SIGINT", handleSigint);
 			process.off("SIGTERM", handleSigterm);
-			const exitSummary = await sessionRuntime.cleanup();
-			setActiveRuntimeAbort(undefined);
-			setActiveRuntimeCleanup(undefined);
+			let exitSummary: InteractiveExitSummary | undefined;
+			try {
+				exitSummary = await sessionRuntime.cleanup();
+			} finally {
+				await pluginChatCommandHostPromise?.catch(() => []);
+				await pluginChatCommandHostShutdown?.().catch(() => {
+					// Best effort cleanup for plugin command discovery sandbox.
+				});
+				pluginChatCommandHostShutdown = undefined;
+				setActiveRuntimeAbort(undefined);
+				setActiveRuntimeCleanup(undefined);
+			}
 			return exitSummary;
 		})();
 		return await cleanupPromise;
@@ -386,7 +419,7 @@ export async function runInteractive(
 					isRunning = true;
 				}
 
-				const chatCommandResult = await runInteractiveChatCommand({
+				let chatCommandResult = await runInteractiveChatCommand({
 					prompt: input,
 					enabled: enableChatCommands,
 					config,
@@ -399,6 +432,26 @@ export async function runInteractive(
 				});
 				if (chatCommandResult.handled) {
 					return chatCommandResult.turnResult;
+				}
+				if (
+					shouldTryPluginChatCommands(input) &&
+					!pluginChatCommandHostLoaded
+				) {
+					await ensurePluginChatCommandHost();
+					chatCommandResult = await runInteractiveChatCommand({
+						prompt: input,
+						enabled: enableChatCommands,
+						config,
+						host: interactiveChatCommandHost,
+						chatCommandState,
+						autoApproveAllRef,
+						setInteractiveAutoApprove,
+						sessionRuntime,
+						stop: () => tuiApp?.destroy(),
+					});
+					if (chatCommandResult.handled) {
+						return chatCommandResult.turnResult;
+					}
 				}
 				input = chatCommandResult.input;
 				const {

--- a/sdk/apps/cli/src/runtime/run-interactive.ts
+++ b/sdk/apps/cli/src/runtime/run-interactive.ts
@@ -10,7 +10,10 @@ import {
 	loadClineAccountSnapshot,
 	switchClineAccount,
 } from "../tui/cline-account";
-import type { InteractiveConfigItem } from "../tui/interactive-config";
+import type {
+	InteractiveConfigItem,
+	LoadInteractiveConfigDataOptions,
+} from "../tui/interactive-config";
 import {
 	type InteractiveSlashCommand,
 	listInteractiveSlashCommands,
@@ -309,10 +312,11 @@ export async function runInteractive(
 
 	const onToggleConfigItem = async (
 		item: InteractiveConfigItem,
+		options: LoadInteractiveConfigDataOptions = {},
 	): Promise<
 		Awaited<ReturnType<typeof configDataLoader.onToggleConfigItem>>
 	> => {
-		const data = await configDataLoader.onToggleConfigItem(item);
+		const data = await configDataLoader.onToggleConfigItem(item, options);
 		if (data && shouldRefreshInteractiveSessionForConfigItem(item)) {
 			await refreshInteractiveSessionPolicies();
 		}

--- a/sdk/apps/cli/src/tui/components/dialogs/config-dialogs.tsx
+++ b/sdk/apps/cli/src/tui/components/dialogs/config-dialogs.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import type {
 	InteractiveConfigData,
 	InteractiveConfigItem,
+	LoadInteractiveConfigDataOptions,
 } from "../../interactive-config";
 import { palette } from "../../palette";
 import {
@@ -18,6 +19,7 @@ export function ExtDetailContent(
 		item: InteractiveConfigItem;
 		onToggleConfigItem?: (
 			item: InteractiveConfigItem,
+			options?: LoadInteractiveConfigDataOptions,
 		) => Promise<InteractiveConfigData | undefined>;
 	},
 ) {
@@ -33,7 +35,9 @@ export function ExtDetailContent(
 		}
 		setToggleError(undefined);
 		try {
-			const nextData = await props.onToggleConfigItem(item);
+			const nextData = await props.onToggleConfigItem(item, {
+				includePluginTools: false,
+			});
 			const nextItem = [
 				...(nextData?.workflows ?? []),
 				...(nextData?.rules ?? []),

--- a/sdk/apps/cli/src/tui/hooks/use-config-panel.tsx
+++ b/sdk/apps/cli/src/tui/hooks/use-config-panel.tsx
@@ -5,6 +5,7 @@ import { useCallback, useMemo } from "react";
 import type {
 	InteractiveConfigData,
 	InteractiveConfigItem,
+	LoadInteractiveConfigDataOptions,
 } from "../../tui/interactive-config";
 import type { CliCompactionMode, Config } from "../../utils/types";
 import { ExtDetailContent } from "../components/dialogs/config-dialogs";
@@ -21,9 +22,12 @@ export function useConfigPanel(opts: {
 	toggleAutoApprove: () => void;
 	setCompactionMode: (mode: CliCompactionMode) => void;
 	termHeight: number;
-	loadConfigData: () => Promise<InteractiveConfigData>;
+	loadConfigData: (
+		options?: LoadInteractiveConfigDataOptions,
+	) => Promise<InteractiveConfigData>;
 	onToggleConfigItem?: (
 		item: InteractiveConfigItem,
+		options?: LoadInteractiveConfigDataOptions,
 	) => Promise<InteractiveConfigData | undefined>;
 	openModelSelector: (options?: OpenModelSelectorOptions) => Promise<void>;
 	openMcpManager: (options?: { refocus?: boolean }) => Promise<boolean>;
@@ -47,7 +51,9 @@ export function useConfigPanel(opts: {
 		let keepOpen = true;
 		while (keepOpen) {
 			const [data, providerInfo] = await Promise.all([
-				opts.loadConfigData().catch(() => emptyConfigData),
+				opts
+					.loadConfigData({ includePluginTools: false })
+					.catch(() => emptyConfigData),
 				Llms.getProvider(opts.config.providerId).catch(() => undefined),
 			]);
 			const providerDisplayName = providerInfo?.name ?? opts.config.providerId;
@@ -60,6 +66,7 @@ export function useConfigPanel(opts: {
 						{...ctx}
 						config={opts.config}
 						configData={data}
+						loadConfigData={opts.loadConfigData}
 						providerDisplayName={providerDisplayName}
 						currentMode={opts.sessionUiMode}
 						currentCompactionMode={opts.compactionMode}

--- a/sdk/apps/cli/src/tui/interactive-config.ts
+++ b/sdk/apps/cli/src/tui/interactive-config.ts
@@ -69,6 +69,10 @@ export interface InteractiveConfigData {
 	tools: InteractiveConfigItem[];
 }
 
+export interface LoadInteractiveConfigDataOptions {
+	includePluginTools?: boolean;
+}
+
 export function isToggleableInteractiveConfigItem(
 	item: Pick<InteractiveConfigItem, "kind" | "source">,
 ): boolean {
@@ -217,6 +221,7 @@ export async function loadInteractiveConfigData(input: {
 	cwd: string;
 	workspaceRoot: string;
 	availabilityContext?: BuiltinToolAvailabilityContext;
+	includePluginTools?: boolean;
 }): Promise<InteractiveConfigData> {
 	const workflows: InteractiveConfigItem[] = [];
 	const rules: InteractiveConfigItem[] = [];
@@ -349,29 +354,31 @@ export async function loadInteractiveConfigData(input: {
 			description: tool.description,
 		})),
 	);
-	try {
-		for (const pluginTool of await listPluginTools({
-			workspacePath: input.workspaceRoot,
-			cwd: input.cwd,
-			providerId: input.availabilityContext?.providerId,
-			modelId: input.availabilityContext?.modelId,
-		})) {
-			tools.push({
-				id: `${pluginTool.pluginName}:${pluginTool.name}:${pluginTool.path}`,
-				name: pluginTool.name,
-				path: pluginTool.path,
-				enabled: pluginTool.enabled,
-				enabledState: pluginTool.enabled ? "enabled" : "disabled",
-				kind: "tool" as const,
-				toolNames: [pluginTool.name],
-				configKind: "tool",
-				pluginName: pluginTool.pluginName,
-				source: pluginTool.source,
-				description: pluginTool.description,
-			});
+	if (input.includePluginTools !== false) {
+		try {
+			for (const pluginTool of await listPluginTools({
+				workspacePath: input.workspaceRoot,
+				cwd: input.cwd,
+				providerId: input.availabilityContext?.providerId,
+				modelId: input.availabilityContext?.modelId,
+			})) {
+				tools.push({
+					id: `${pluginTool.pluginName}:${pluginTool.name}:${pluginTool.path}`,
+					name: pluginTool.name,
+					path: pluginTool.path,
+					enabled: pluginTool.enabled,
+					enabledState: pluginTool.enabled ? "enabled" : "disabled",
+					kind: "tool" as const,
+					toolNames: [pluginTool.name],
+					configKind: "tool",
+					pluginName: pluginTool.pluginName,
+					source: pluginTool.source,
+					description: pluginTool.description,
+				});
+			}
+		} catch {
+			// Best effort: built-in tools and instruction config should still render.
 		}
-	} catch {
-		// Best effort: built-in tools and instruction config should still render.
 	}
 
 	return {

--- a/sdk/apps/cli/src/tui/types.ts
+++ b/sdk/apps/cli/src/tui/types.ts
@@ -20,6 +20,7 @@ import type { ClineAccountSnapshot } from "./cline-account";
 import type {
 	InteractiveConfigData,
 	InteractiveConfigItem,
+	LoadInteractiveConfigDataOptions,
 } from "./interactive-config";
 import type { InteractiveSlashCommand } from "./interactive-welcome";
 
@@ -116,9 +117,12 @@ export interface TuiProps {
 	loadWelcomeLine?: () => Promise<string | undefined>;
 	loadClineAccount: () => Promise<ClineAccountSnapshot>;
 	switchClineAccount: (organizationId?: string | null) => Promise<void>;
-	loadConfigData: () => Promise<InteractiveConfigData>;
+	loadConfigData: (
+		options?: LoadInteractiveConfigDataOptions,
+	) => Promise<InteractiveConfigData>;
 	onToggleConfigItem?: (
 		item: InteractiveConfigItem,
+		options?: LoadInteractiveConfigDataOptions,
 	) => Promise<InteractiveConfigData | undefined>;
 	subscribeToEvents: (handlers: {
 		onAgentEvent: (event: AgentEvent) => void;

--- a/sdk/apps/cli/src/tui/views/config-view.tsx
+++ b/sdk/apps/cli/src/tui/views/config-view.tsx
@@ -266,7 +266,6 @@ export function ConfigPanelContent(props: ConfigPanelProps) {
 		if (
 			activeTab !== "tools" ||
 			pluginToolsLoaded ||
-			pluginToolsLoading ||
 			pluginToolsError ||
 			!props.loadConfigData
 		) {
@@ -301,13 +300,7 @@ export function ConfigPanelContent(props: ConfigPanelProps) {
 		return () => {
 			cancelled = true;
 		};
-	}, [
-		activeTab,
-		pluginToolsError,
-		pluginToolsLoaded,
-		pluginToolsLoading,
-		props.loadConfigData,
-	]);
+	}, [activeTab, pluginToolsError, pluginToolsLoaded, props.loadConfigData]);
 
 	const rows = useMemo(() => {
 		const r: ConfigRow[] = [];

--- a/sdk/apps/cli/src/tui/views/config-view.tsx
+++ b/sdk/apps/cli/src/tui/views/config-view.tsx
@@ -382,13 +382,11 @@ export function ConfigPanelContent(props: ConfigPanelProps) {
 		setToggleError(undefined);
 		try {
 			const nextData = await props.onToggleConfigItem(item, {
-				includePluginTools: activeTab === "tools" && pluginToolsLoaded,
+				includePluginTools: pluginToolsLoaded,
 			});
 			if (nextData) {
 				setConfigData(nextData);
-				setPluginToolsLoaded(
-					pluginToolsLoaded || nextData.tools.some((tool) => tool.pluginName),
-				);
+				setPluginToolsLoaded(nextData.tools.some((tool) => tool.pluginName));
 			}
 		} catch (error) {
 			const message = error instanceof Error ? error.message : String(error);

--- a/sdk/apps/cli/src/tui/views/config-view.tsx
+++ b/sdk/apps/cli/src/tui/views/config-view.tsx
@@ -1,11 +1,12 @@
 import { useTerminalDimensions } from "@opentui/react";
 import type { ChoiceContext } from "@opentui-ui/dialog";
 import { useDialogKeyboard } from "@opentui-ui/dialog/react";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import type {
 	InteractiveConfigData,
 	InteractiveConfigItem,
 	InteractiveConfigTab,
+	LoadInteractiveConfigDataOptions,
 } from "../../tui/interactive-config";
 import {
 	formatCliCompactionMode,
@@ -117,11 +118,15 @@ const COMPACTION_MODE_COLORS: Record<CliCompactionMode, string> = {
 export interface ConfigPanelProps extends ChoiceContext<ConfigAction> {
 	config: Config;
 	configData: InteractiveConfigData;
+	loadConfigData?: (
+		options?: LoadInteractiveConfigDataOptions,
+	) => Promise<InteractiveConfigData>;
 	providerDisplayName: string;
 	currentMode: string;
 	currentCompactionMode: CliCompactionMode;
 	onToggleConfigItem?: (
 		item: InteractiveConfigItem,
+		options?: LoadInteractiveConfigDataOptions,
 	) => Promise<InteractiveConfigData | undefined>;
 	onToggleMode: () => void;
 	onToggleAutoApprove: () => void;
@@ -244,11 +249,65 @@ export function ConfigPanelContent(props: ConfigPanelProps) {
 	);
 	const [activeTab, setActiveTab] = useState<InteractiveConfigTab>("general");
 	const [configData, setConfigData] = useState(props.configData);
+	const [pluginToolsLoaded, setPluginToolsLoaded] = useState(
+		props.configData.tools.some((item) => item.pluginName),
+	);
+	const [pluginToolsLoading, setPluginToolsLoading] = useState(false);
+	const [pluginToolsError, setPluginToolsError] = useState<
+		string | undefined
+	>();
 	const [togglingItemId, setTogglingItemId] = useState<string | null>(null);
 	const [toggleError, setToggleError] = useState<string | undefined>();
 	const [navPos, setNavPos] = useState(0);
 
 	const displayName = resolveModelDisplayName(config);
+
+	useEffect(() => {
+		if (
+			activeTab !== "tools" ||
+			pluginToolsLoaded ||
+			pluginToolsLoading ||
+			pluginToolsError ||
+			!props.loadConfigData
+		) {
+			return;
+		}
+
+		let cancelled = false;
+		setPluginToolsLoading(true);
+		setPluginToolsError(undefined);
+		props
+			.loadConfigData({ includePluginTools: true })
+			.then((nextData) => {
+				if (cancelled) {
+					return;
+				}
+				setConfigData(nextData);
+				setPluginToolsLoaded(true);
+			})
+			.catch((error) => {
+				if (cancelled) {
+					return;
+				}
+				const message = error instanceof Error ? error.message : String(error);
+				setPluginToolsError(`Failed to load plugin tools: ${message}`);
+			})
+			.finally(() => {
+				if (!cancelled) {
+					setPluginToolsLoading(false);
+				}
+			});
+
+		return () => {
+			cancelled = true;
+		};
+	}, [
+		activeTab,
+		pluginToolsError,
+		pluginToolsLoaded,
+		pluginToolsLoading,
+		props.loadConfigData,
+	]);
 
 	const rows = useMemo(() => {
 		const r: ConfigRow[] = [];
@@ -271,13 +330,25 @@ export function ConfigPanelContent(props: ConfigPanelProps) {
 				label: `${toTabLabel(activeTab)} (${activeItems.length})`,
 			});
 
-			if (activeItems.length === 0) {
+			if (activeItems.length === 0 && !pluginToolsLoading) {
 				r.push({
 					kind: "detail",
 					text: `No ${toTabLabel(activeTab).toLowerCase()} found.`,
 				});
 			} else if (activeTab === "tools") {
 				appendToolRows(r, activeItems);
+				if (pluginToolsLoading) {
+					r.push({
+						kind: "detail",
+						text: "Loading plugin tools...",
+					});
+				}
+				if (pluginToolsError) {
+					r.push({
+						kind: "detail",
+						text: pluginToolsError,
+					});
+				}
 			} else {
 				for (const item of activeItems) {
 					r.push({
@@ -298,7 +369,7 @@ export function ConfigPanelContent(props: ConfigPanelProps) {
 		}
 
 		return r;
-	}, [activeTab, configData]);
+	}, [activeTab, configData, pluginToolsError, pluginToolsLoading]);
 
 	const navIndices = useMemo(
 		() => rows.map((r, i) => (isNavigable(r) ? i : -1)).filter((i) => i >= 0),
@@ -317,9 +388,14 @@ export function ConfigPanelContent(props: ConfigPanelProps) {
 		setTogglingItemId(item.id);
 		setToggleError(undefined);
 		try {
-			const nextData = await props.onToggleConfigItem(item);
+			const nextData = await props.onToggleConfigItem(item, {
+				includePluginTools: activeTab === "tools" && pluginToolsLoaded,
+			});
 			if (nextData) {
 				setConfigData(nextData);
+				setPluginToolsLoaded(
+					pluginToolsLoaded || nextData.tools.some((tool) => tool.pluginName),
+				);
 			}
 		} catch (error) {
 			const message = error instanceof Error ? error.message : String(error);

--- a/sdk/apps/cli/src/utils/plugin-chat-commands.test.ts
+++ b/sdk/apps/cli/src/utils/plugin-chat-commands.test.ts
@@ -36,10 +36,11 @@ describe("plugin chat commands", () => {
 			].join("\n"),
 		);
 
-		const { host, pluginSlashCommands } = await createWorkspaceChatCommandHost({
-			cwd: tempRoot,
-			workspaceRoot: tempRoot,
-		});
+		const { host, pluginSlashCommands, shutdown } =
+			await createWorkspaceChatCommandHost({
+				cwd: tempRoot,
+				workspaceRoot: tempRoot,
+			});
 		const reply = vi.fn(async () => undefined);
 
 		// Filter to only our test plugin to ignore any discovered system plugins
@@ -62,5 +63,6 @@ describe("plugin chat commands", () => {
 
 		expect(handled).toBe(true);
 		expect(reply).toHaveBeenCalledWith("echo:hello plugin");
+		await shutdown?.();
 	});
 });

--- a/sdk/apps/cli/src/utils/plugin-chat-commands.ts
+++ b/sdk/apps/cli/src/utils/plugin-chat-commands.ts
@@ -18,8 +18,9 @@ export interface PluginSlashCommand {
 
 export interface WorkspaceChatCommandHostResult {
 	host: ChatCommandHost;
-	/** Plugin-registered commands surfaced as slash commands for TUI autocomplete. */
+	// Plugin-registered commands surfaced as slash commands for TUI autocomplete.
 	pluginSlashCommands: PluginSlashCommand[];
+	shutdown?: () => Promise<void>;
 }
 
 function normalizeCommandName(name: string): string {
@@ -62,7 +63,6 @@ export async function createWorkspaceChatCommandHost(input: {
 		loaded = await resolveAndLoadAgentPlugins({
 			cwd: input.cwd,
 			workspacePath: workspaceRoot,
-			mode: "in_process",
 		});
 	} catch (error) {
 		const message = error instanceof Error ? error.message : String(error);
@@ -72,6 +72,9 @@ export async function createWorkspaceChatCommandHost(input: {
 		return { host: chatCommandHost, pluginSlashCommands: [] };
 	}
 	if (!loaded.extensions.length) {
+		await loaded.shutdown?.().catch(() => {
+			// Best effort cleanup when no command-capable plugins were loaded.
+		});
 		return { host: chatCommandHost, pluginSlashCommands: [] };
 	}
 
@@ -89,6 +92,9 @@ export async function createWorkspaceChatCommandHost(input: {
 		input.logger?.log(
 			`plugin command registry initialization failed; continuing without plugin commands (${message})`,
 		);
+		await loaded.shutdown?.().catch(() => {
+			// Best effort cleanup after failed command discovery.
+		});
 		return { host: chatCommandHost, pluginSlashCommands: [] };
 	}
 
@@ -108,5 +114,5 @@ export async function createWorkspaceChatCommandHost(input: {
 			});
 		}
 	}
-	return { host, pluginSlashCommands };
+	return { host, pluginSlashCommands, shutdown: loaded.shutdown };
 }

--- a/sdk/packages/core/src/services/plugin-tools.ts
+++ b/sdk/packages/core/src/services/plugin-tools.ts
@@ -1,6 +1,6 @@
 import type { AgentConfig, AgentTool } from "@cline/shared";
 import { resolveAgentPluginPaths } from "../extensions/plugin/plugin-config-loader";
-import { loadAgentPluginsFromPathsWithDiagnostics } from "../extensions/plugin/plugin-loader";
+import { loadSandboxedPlugins } from "../extensions/plugin/plugin-sandbox";
 import { resolveDisabledToolNames } from "./global-settings";
 
 type AgentExtension = NonNullable<AgentConfig["extensions"]>[number];
@@ -51,29 +51,38 @@ export async function listPluginTools(input: {
 	const summaries: PluginToolSummary[] = [];
 
 	for (const pluginPath of pluginPaths) {
-		const report = await loadAgentPluginsFromPathsWithDiagnostics(
-			[pluginPath],
-			{
+		let sandboxed: Awaited<ReturnType<typeof loadSandboxedPlugins>> | undefined;
+		try {
+			sandboxed = await loadSandboxedPlugins({
+				pluginPaths: [pluginPath],
 				cwd: input.cwd,
 				providerId: input.providerId,
 				modelId: input.modelId,
-			},
-		);
-		for (const extension of report.plugins) {
-			for (const tool of collectRegisteredTools(extension, {
-				rootPath: input.workspacePath,
-			})) {
-				summaries.push({
-					name: tool.name,
-					pluginName: extension.name,
-					path: pluginPath,
-					source: pluginPath.startsWith(input.workspacePath)
-						? "workspace-plugin"
-						: "global-plugin",
-					enabled: !disabled.has(tool.name),
-					description: tool.description?.trim() || undefined,
-				});
+				workspaceInfo: { rootPath: input.workspacePath },
+			});
+			for (const extension of sandboxed.extensions ?? []) {
+				for (const tool of collectRegisteredTools(extension, {
+					rootPath: input.workspacePath,
+				})) {
+					summaries.push({
+						name: tool.name,
+						pluginName: extension.name,
+						path: pluginPath,
+						source: pluginPath.startsWith(input.workspacePath)
+							? "workspace-plugin"
+							: "global-plugin",
+						enabled: !disabled.has(tool.name),
+						description: tool.description?.trim() || undefined,
+					});
+				}
 			}
+		} catch {
+			// Tool listing is best effort so settings can still render built-in tools
+			// if one plugin fails to initialize.
+		} finally {
+			await sandboxed?.shutdown().catch(() => {
+				// Best effort cleanup after contribution discovery.
+			});
 		}
 	}
 


### PR DESCRIPTION
This PR fixes the production plugin discovery split that showed up after the CLI production plugin loading fix landed in v3.0.4.

The symptom was confusing because the agent runtime could see and use plugin tools, but the Settings Tools tab and `cline config tools` did not show those same plugin tools. That made it look like plugins were partially loaded: asking the agent what tools it had showed `background-terminal` tools, while opening Settings or running `cline config tools` omitted them.

The root cause was that we had two different plugin discovery paths:

1. The agent runtime loads plugins through the sandbox. This is the path that actually gives the model plugin tools.
2. Settings and `cline config tools` listed plugin tools with a separate in-process fake load. That path diverged from the runtime path and did not behave like production plugin execution.

This PR makes Settings and `cline config tools` use sandbox-backed plugin discovery too. That means the UI and CLI config command now list plugin tools from the same loading model the agent runtime uses.

There was a second TUI issue while making plugin discovery visible in Settings. The Tools tab intentionally lazy-loads plugin tools so opening `/settings` does not block on plugin discovery. The loading row could get stuck forever because the effect included `pluginToolsLoading` in its dependency list, then set `pluginToolsLoading` to true. React reran the cleanup for the in-flight request, marked it cancelled, and the resolved plugin list was ignored. This PR removes that self-cancelling dependency so the loading indicator resolves and updates the Tools tab.

Finally, plugin slash commands needed a cleaner treatment. The TUI dropdown should still show plugin slash commands, but loading them on startup must not freeze the input. Previously `createWorkspaceChatCommandHost()` loaded plugins in-process just to discover `registerCommand()` contributions. That is expensive in production because plugin module loading can involve JITI and host package resolution, and doing it in the TUI process blocks interactivity.

This PR changes plugin slash command discovery to use the sandbox-backed plugin loader instead of forcing `mode: "in_process"`. The TUI still passes an async `loadAdditionalSlashCommands` function to the slash command registry, so built-in and workflow slash commands appear immediately, while plugin commands hydrate into the dropdown after the sandbox finishes. The sandbox remains alive so plugin command handlers can run, and it is shut down during interactive cleanup.

The important design decision here is that plugin tools and plugin command metadata should not be discovered through a third, special in-process path. For this bugfix we keep the existing public API and UI shape, but align the discovery path with runtime sandbox loading so production users see the same plugin surfaces the agent can actually use.

Debugging context that motivated this shape:

- Production `cline@3.0.4` could load plugin tools into the agent runtime.
- The same install did not show those plugin tools in Settings or `cline config tools`.
- `cline config plugins` did show the plugin file, so plugin file discovery was not the issue.
- `cline config tools` started listing plugin tools when tool listing moved to sandbox discovery.
- Opening `/settings` stayed responsive after plugin tools were skipped during initial settings load.
- The Tools tab loader then got stuck because of the effect dependency bug described above.
- Plugin slash command loading on startup caused a noticeable TUI freeze because it was an independent in-process plugin load.
- Moving plugin slash command discovery to sandbox-backed async loading preserves dropdown hydration without blocking the TUI process.