### PR TITLE
fix: preserve completed task resume state after hooks

### DIFF
--- a/sdk/apps/cli/src/tui/views/config-view.tsx
+++ b/sdk/apps/cli/src/tui/views/config-view.tsx
@@ -261,13 +261,14 @@ export function ConfigPanelContent(props: ConfigPanelProps) {
 	const [navPos, setNavPos] = useState(0);
 
 	const displayName = resolveModelDisplayName(config);
+	const { loadConfigData } = props;
 
 	useEffect(() => {
 		if (
 			activeTab !== "tools" ||
 			pluginToolsLoaded ||
 			pluginToolsError ||
-			!props.loadConfigData
+			!loadConfigData
 		) {
 			return;
 		}
@@ -275,8 +276,7 @@ export function ConfigPanelContent(props: ConfigPanelProps) {
 		let cancelled = false;
 		setPluginToolsLoading(true);
 		setPluginToolsError(undefined);
-		props
-			.loadConfigData({ includePluginTools: true })
+		loadConfigData({ includePluginTools: true })
 			.then((nextData) => {
 				if (cancelled) {
 					return;
@@ -300,7 +300,7 @@ export function ConfigPanelContent(props: ConfigPanelProps) {
 		return () => {
 			cancelled = true;
 		};
-	}, [activeTab, pluginToolsError, pluginToolsLoaded, props.loadConfigData]);
+	}, [activeTab, pluginToolsError, pluginToolsLoaded, loadConfigData]);
 
 	const rows = useMemo(() => {
 		const r: ConfigRow[] = [];

--- a/src/core/task/__tests__/resume-state.test.ts
+++ b/src/core/task/__tests__/resume-state.test.ts
@@ -1,0 +1,32 @@
+import { strict as assert } from "node:assert"
+import { getLastNonHookMessage, getResumeAskType } from "@core/task/resume-state"
+import type { ClineMessage } from "@shared/ExtensionMessage"
+import { describe, it } from "mocha"
+
+function ask(ask: ClineMessage["ask"], ts: number): ClineMessage {
+	return { type: "ask", ask, ts }
+}
+
+function say(say: ClineMessage["say"], ts: number): ClineMessage {
+	return { type: "say", say, ts }
+}
+
+describe("resume-state", () => {
+	it("keeps completed tasks completed when hook messages trail the result", () => {
+		const messages = [ask("completion_result", 1), say("hook_status", 2), say("hook_output_stream", 3), ask("resume_task", 4)]
+
+		assert.equal(getResumeAskType(messages), "resume_completed_task")
+	})
+
+	it("keeps active tasks resumable when hook messages trail work", () => {
+		const messages = [say("text", 1), say("hook_status", 2)]
+
+		assert.equal(getResumeAskType(messages), "resume_task")
+	})
+
+	it("ignores trailing hook messages for button-only state checks", () => {
+		const messages = [ask("completion_result", 1), say("hook_status", 2)]
+
+		assert.equal(getLastNonHookMessage(messages)?.ask, "completion_result")
+	})
+})

--- a/src/core/task/index.ts
+++ b/src/core/task/index.ts
@@ -1223,7 +1223,7 @@ export class Task {
 		await this.contextManager.initializeContextHistory(await ensureTaskDirectoryExists(this.taskId))
 
 		const lastClineMessage = getLastTaskStateMessage(this.messageStateHandler.getClineMessages())
-		const askType = getResumeAskType(this.messageStateHandler.getClineMessages())
+		const askType: ClineAsk = lastClineMessage?.ask === "completion_result" ? "resume_completed_task" : "resume_task"
 
 		this.taskState.isInitialized = true
 		this.taskState.abort = false // Reset abort flag when resuming task

--- a/src/core/task/index.ts
+++ b/src/core/task/index.ts
@@ -37,6 +37,7 @@ import {
 	getSavedApiConversationHistory,
 	getSavedClineMessages,
 } from "@core/storage/disk"
+import { getLastNonHookMessage, getLastTaskStateMessage, getResumeAskType } from "@core/task/resume-state"
 import { releaseTaskLock } from "@core/task/TaskLockUtils"
 import { isMultiRootEnabled } from "@core/workspace/multi-root-utils"
 import { WorkspaceRootManager } from "@core/workspace/WorkspaceRootManager"
@@ -1221,18 +1222,8 @@ export class Task {
 		await ensureTaskDirectoryExists(this.taskId)
 		await this.contextManager.initializeContextHistory(await ensureTaskDirectoryExists(this.taskId))
 
-		const lastClineMessage = this.messageStateHandler
-			.getClineMessages()
-			.slice()
-			.reverse()
-			.find((m) => !(m.ask === "resume_task" || m.ask === "resume_completed_task")) // could be multiple resume tasks
-
-		let askType: ClineAsk
-		if (lastClineMessage?.ask === "completion_result") {
-			askType = "resume_completed_task"
-		} else {
-			askType = "resume_task"
-		}
+		const lastClineMessage = getLastTaskStateMessage(this.messageStateHandler.getClineMessages())
+		const askType = getResumeAskType(this.messageStateHandler.getClineMessages())
 
 		this.taskState.isInitialized = true
 		this.taskState.abort = false // Reset abort flag when resuming task
@@ -1509,7 +1500,7 @@ export class Task {
 
 		// Check if we're at a button-only state (no active work, just waiting for user action)
 		const clineMessages = this.messageStateHandler.getClineMessages()
-		const lastMessage = clineMessages.at(-1)
+		const lastMessage = getLastNonHookMessage(clineMessages)
 		const isAtButtonOnlyState =
 			lastMessage?.type === "ask" &&
 			(lastMessage.ask === "resume_task" ||
@@ -1593,18 +1584,7 @@ export class Task {
 
 					// TaskCancel completed successfully
 					// Present resume button after successful TaskCancel hook
-					const lastClineMessage = this.messageStateHandler
-						.getClineMessages()
-						.slice()
-						.reverse()
-						.find((m) => !(m.ask === "resume_task" || m.ask === "resume_completed_task"))
-
-					let askType: ClineAsk
-					if (lastClineMessage?.ask === "completion_result") {
-						askType = "resume_completed_task"
-					} else {
-						askType = "resume_task"
-					}
+					const askType = getResumeAskType(this.messageStateHandler.getClineMessages())
 
 					// Present the resume ask - this will show the resume button in the UI
 					// We don't await this because we want to set the abort flag immediately

--- a/src/core/task/resume-state.ts
+++ b/src/core/task/resume-state.ts
@@ -1,0 +1,31 @@
+import type { ClineAsk, ClineMessage } from "@shared/ExtensionMessage"
+
+const RESUME_ASKS = new Set<ClineAsk>(["resume_task", "resume_completed_task"])
+const HOOK_SAYS = new Set(["hook_status", "hook_output_stream"])
+
+function isResumeAsk(message: ClineMessage): boolean {
+	return message.type === "ask" && message.ask !== undefined && RESUME_ASKS.has(message.ask)
+}
+
+function isHookMessage(message: ClineMessage): boolean {
+	return message.type === "say" && message.say !== undefined && HOOK_SAYS.has(message.say)
+}
+
+export function getLastNonHookMessage(messages: ClineMessage[]): ClineMessage | undefined {
+	return messages
+		.slice()
+		.reverse()
+		.find((message) => !isHookMessage(message))
+}
+
+export function getLastTaskStateMessage(messages: ClineMessage[]): ClineMessage | undefined {
+	return messages
+		.slice()
+		.reverse()
+		.find((message) => !isResumeAsk(message) && !isHookMessage(message))
+}
+
+export function getResumeAskType(messages: ClineMessage[]): ClineAsk {
+	const lastTaskStateMessage = getLastTaskStateMessage(messages)
+	return lastTaskStateMessage?.ask === "completion_result" ? "resume_completed_task" : "resume_task"
+}

--- a/src/core/task/resume-state.ts
+++ b/src/core/task/resume-state.ts
@@ -1,7 +1,7 @@
-import type { ClineAsk, ClineMessage } from "@shared/ExtensionMessage"
+import type { ClineAsk, ClineMessage, ClineSay } from "@shared/ExtensionMessage"
 
 const RESUME_ASKS = new Set<ClineAsk>(["resume_task", "resume_completed_task"])
-const HOOK_SAYS = new Set(["hook_status", "hook_output_stream"])
+const HOOK_SAYS = new Set<ClineSay>(["hook_status", "hook_output_stream"])
 
 function isResumeAsk(message: ClineMessage): boolean {
 	return message.type === "ask" && message.ask !== undefined && RESUME_ASKS.has(message.ask)


### PR DESCRIPTION
### Related Issue

**Issue:** Fixes #10379

### Description

Completed tasks can have hook status/output messages appended after the `completion_result`. The resume-state check was reading those trailing hook messages as the latest task state, so reopening a completed task with hooks enabled could show the active "Resume Task" action instead of "Start New Task".

This change centralizes resume-state message selection so hook status/output rows are ignored for resume decisions while preserving the existing resume ask cleanup behavior.

### Test Procedure

- `npx cross-env TS_NODE_PROJECT=./tsconfig.unit-test.json mocha --no-config --extension ts --require ts-node/register --require tsconfig-paths/register --require source-map-support/register --require ./src/test/requires.ts src/core/task/__tests__/resume-state.test.ts`
- `npm run check-types`
- `npm run format`
- `npx biome lint --changed --no-errors-on-unmatched --files-ignore-unknown=true --diagnostic-level=error`
- `git diff --check`

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Not applicable; this is covered by a resume-state regression test.

### Additional Notes

Full `npm test` was not run locally; the targeted regression test, typecheck, changed-file lint, format check, and diff whitespace check passed.
