### PR TITLE
fix: return to chat after CLI account login

### DIFF
--- a/sdk/apps/cli/src/tui/views/config-view.tsx
+++ b/sdk/apps/cli/src/tui/views/config-view.tsx
@@ -236,7 +236,7 @@ function appendToolRows(
 }
 
 export function ConfigPanelContent(props: ConfigPanelProps) {
-	const { resolve, dismiss, dialogId, config } = props;
+	const { resolve, dismiss, dialogId, config, loadConfigData } = props;
 	const { height } = useTerminalDimensions();
 
 	const [mode, setMode] = useState(props.currentMode);
@@ -267,7 +267,7 @@ export function ConfigPanelContent(props: ConfigPanelProps) {
 			activeTab !== "tools" ||
 			pluginToolsLoaded ||
 			pluginToolsError ||
-			!props.loadConfigData
+			!loadConfigData
 		) {
 			return;
 		}
@@ -275,8 +275,7 @@ export function ConfigPanelContent(props: ConfigPanelProps) {
 		let cancelled = false;
 		setPluginToolsLoading(true);
 		setPluginToolsError(undefined);
-		props
-			.loadConfigData({ includePluginTools: true })
+		loadConfigData({ includePluginTools: true })
 			.then((nextData) => {
 				if (cancelled) {
 					return;
@@ -300,7 +299,7 @@ export function ConfigPanelContent(props: ConfigPanelProps) {
 		return () => {
 			cancelled = true;
 		};
-	}, [activeTab, pluginToolsError, pluginToolsLoaded, props.loadConfigData]);
+	}, [activeTab, loadConfigData, pluginToolsError, pluginToolsLoaded]);
 
 	const rows = useMemo(() => {
 		const r: ConfigRow[] = [];

--- a/webview-ui/src/App.tsx
+++ b/webview-ui/src/App.tsx
@@ -1,5 +1,5 @@
 import type { Boolean, EmptyRequest } from "@shared/proto/cline/common"
-import { useCallback, useEffect, useState } from "react"
+import { useCallback, useEffect, useRef, useState } from "react"
 import AccountView from "./components/account/AccountView"
 import ChatView from "./components/chat/ChatView"
 import ClineKanbanLaunchModal, { CLINE_KANBAN_MODAL_DISMISS_ID } from "./components/common/ClineKanbanLaunchModal"
@@ -39,8 +39,10 @@ const AppContent = () => {
 	} = useExtensionState()
 	const [showKanbanModal, setShowKanbanModal] = useState(false)
 	const [hasShownKanbanModal, setHasShownKanbanModal] = useState(false)
+	const previousAccountUidRef = useRef<string | undefined>(undefined)
 
 	const { clineUser, organizations, activeOrganization } = useClineAuth()
+	const clineUserUid = clineUser?.uid
 
 	const showUpdateAnnouncementModal = useCallback(() => {
 		setShowAnnouncement(true)
@@ -84,12 +86,21 @@ const AppContent = () => {
 		showUpdateAnnouncementModal,
 	])
 
+	useEffect(() => {
+		const previousUid = previousAccountUidRef.current
+		previousAccountUidRef.current = clineUserUid
+
+		if (showAccount && !previousUid && clineUserUid) {
+			hideAccount()
+		}
+	}, [clineUserUid, hideAccount, showAccount])
+
 	const handleCloseKanbanModal = useCallback((doNotShowAgain: boolean) => {
 		setShowKanbanModal(false)
 		if (doNotShowAgain) {
-			StateServiceClient.dismissBanner({ value: CLINE_KANBAN_MODAL_DISMISS_ID }).catch((error) =>
-				console.error("Failed to persist Cline Kanban modal dismissal:", error),
-			)
+			StateServiceClient.dismissBanner({
+				value: CLINE_KANBAN_MODAL_DISMISS_ID,
+			}).catch((error) => console.error("Failed to persist Cline Kanban modal dismissal:", error))
 		}
 	}, [])
 

--- a/webview-ui/src/App.tsx
+++ b/webview-ui/src/App.tsx
@@ -39,10 +39,10 @@ const AppContent = () => {
 	} = useExtensionState()
 	const [showKanbanModal, setShowKanbanModal] = useState(false)
 	const [hasShownKanbanModal, setHasShownKanbanModal] = useState(false)
-	const previousAccountUidRef = useRef<string | undefined>(undefined)
 
 	const { clineUser, organizations, activeOrganization } = useClineAuth()
 	const clineUserUid = clineUser?.uid
+	const previousAccountUidRef = useRef<string | undefined>(clineUserUid)
 
 	const showUpdateAnnouncementModal = useCallback(() => {
 		setShowAnnouncement(true)


### PR DESCRIPTION
## Summary
- close the account overlay after a previously signed-out CLI session completes login
- reveal the existing chat/task surface again so the user can retry the task immediately
- keep already-authenticated account navigation unchanged

Fixes #9647

## Test plan
- npm run check-types
- npx biome lint webview-ui/src/App.tsx --no-errors-on-unmatched --files-ignore-unknown=true --diagnostic-level=error
- git diff --check