### PR TITLE
fix(cli): clean up connector plugin command sandboxes

### DIFF
--- a/sdk/apps/cli/src/connectors/adapters/discord.ts
+++ b/sdk/apps/cli/src/connectors/adapters/discord.ts
@@ -530,10 +530,11 @@ class DiscordConnector extends ConnectorBase<
 		});
 		await userInstructionService.start().catch(() => undefined);
 		const commandCwd = startRequest.cwd || process.cwd();
-		const { host: chatCommandHost } = await createWorkspaceChatCommandHost({
-			cwd: commandCwd,
-			workspaceRoot: startRequest.workspaceRoot || commandCwd,
-		});
+		const { host: chatCommandHost, shutdown: shutdownPluginChatCommands } =
+			await createWorkspaceChatCommandHost({
+				cwd: commandCwd,
+				workspaceRoot: startRequest.workspaceRoot || commandCwd,
+			});
 		const { url: rpcAddress, authToken: rpcAuthToken } =
 			await ensureCliHubServer(
 				startRequest.workspaceRoot || startRequest.cwd || process.cwd(),
@@ -795,6 +796,7 @@ class DiscordConnector extends ConnectorBase<
 		);
 		if (!gatewayStartResponse.ok) {
 			stopTaskUpdateStream();
+			await shutdownPluginChatCommands().catch(() => undefined);
 			userInstructionService.stop();
 			client.close();
 			this.removeStateFile(statePath);
@@ -887,6 +889,7 @@ class DiscordConnector extends ConnectorBase<
 		stopEventStream();
 		await gatewayTask?.catch(() => undefined);
 		await server.close();
+		await shutdownPluginChatCommands().catch(() => undefined);
 		userInstructionService.stop();
 		client.close();
 		this.removeStateFile(statePath);

--- a/sdk/apps/cli/src/connectors/adapters/gchat.ts
+++ b/sdk/apps/cli/src/connectors/adapters/gchat.ts
@@ -536,10 +536,11 @@ class GoogleChatConnector extends ConnectorBase<
 		});
 		await userInstructionService.start().catch(() => undefined);
 		const commandCwd = startRequest.cwd || process.cwd();
-		const { host: chatCommandHost } = await createWorkspaceChatCommandHost({
-			cwd: commandCwd,
-			workspaceRoot: startRequest.workspaceRoot || commandCwd,
-		});
+		const { host: chatCommandHost, shutdown: shutdownPluginChatCommands } =
+			await createWorkspaceChatCommandHost({
+				cwd: commandCwd,
+				workspaceRoot: startRequest.workspaceRoot || commandCwd,
+			});
 		const { url: rpcAddress, authToken: rpcAuthToken } =
 			await ensureCliHubServer(
 				startRequest.workspaceRoot || startRequest.cwd || process.cwd(),
@@ -816,6 +817,7 @@ class GoogleChatConnector extends ConnectorBase<
 		stopTaskUpdateStream();
 		stopEventStream();
 		await server.close();
+		await shutdownPluginChatCommands().catch(() => undefined);
 		userInstructionService.stop();
 		client.close();
 		this.removeStateFile(statePath);

--- a/sdk/apps/cli/src/connectors/adapters/linear.ts
+++ b/sdk/apps/cli/src/connectors/adapters/linear.ts
@@ -571,10 +571,11 @@ class LinearConnector extends ConnectorBase<
 		});
 		await userInstructionService.start().catch(() => undefined);
 		const commandCwd = startRequest.cwd || process.cwd();
-		const { host: chatCommandHost } = await createWorkspaceChatCommandHost({
-			cwd: commandCwd,
-			workspaceRoot: startRequest.workspaceRoot || commandCwd,
-		});
+		const { host: chatCommandHost, shutdown: shutdownPluginChatCommands } =
+			await createWorkspaceChatCommandHost({
+				cwd: commandCwd,
+				workspaceRoot: startRequest.workspaceRoot || commandCwd,
+			});
 		const { url: rpcAddress, authToken: rpcAuthToken } =
 			await ensureCliHubServer(
 				startRequest.workspaceRoot || startRequest.cwd || process.cwd(),
@@ -854,6 +855,7 @@ class LinearConnector extends ConnectorBase<
 		stopEventStream();
 		await server.close();
 		userInstructionService.stop();
+		await shutdownPluginChatCommands().catch(() => undefined);
 		await bot.shutdown().catch(() => undefined);
 		client.close();
 		this.removeStateFile(statePath);

--- a/sdk/apps/cli/src/connectors/adapters/slack.ts
+++ b/sdk/apps/cli/src/connectors/adapters/slack.ts
@@ -664,10 +664,11 @@ class SlackConnector extends ConnectorBase<
 		});
 		await userInstructionService.start().catch(() => undefined);
 		const commandCwd = startRequest.cwd || process.cwd();
-		const { host: chatCommandHost } = await createWorkspaceChatCommandHost({
-			cwd: commandCwd,
-			workspaceRoot: startRequest.workspaceRoot || commandCwd,
-		});
+		const { host: chatCommandHost, shutdown: shutdownPluginChatCommands } =
+			await createWorkspaceChatCommandHost({
+				cwd: commandCwd,
+				workspaceRoot: startRequest.workspaceRoot || commandCwd,
+			});
 		const { url: rpcAddress, authToken: rpcAuthToken } =
 			await ensureCliHubServer(
 				startRequest.workspaceRoot || startRequest.cwd || process.cwd(),
@@ -1056,6 +1057,7 @@ class SlackConnector extends ConnectorBase<
 		stopTaskUpdateStream();
 		stopEventStream();
 		await server.close();
+		await shutdownPluginChatCommands().catch(() => undefined);
 		userInstructionService.stop();
 		client.close();
 		this.removeStateFile(statePath);

--- a/sdk/apps/cli/src/connectors/adapters/telegram.ts
+++ b/sdk/apps/cli/src/connectors/adapters/telegram.ts
@@ -547,10 +547,11 @@ class TelegramConnector extends ConnectorBase<
 		});
 		await userInstructionService.start().catch(() => undefined);
 		const commandCwd = startRequest.cwd || process.cwd();
-		const { host: chatCommandHost } = await createWorkspaceChatCommandHost({
-			cwd: commandCwd,
-			workspaceRoot: startRequest.workspaceRoot || commandCwd,
-		});
+		const { host: chatCommandHost, shutdown: shutdownPluginChatCommands } =
+			await createWorkspaceChatCommandHost({
+				cwd: commandCwd,
+				workspaceRoot: startRequest.workspaceRoot || commandCwd,
+			});
 		const { url: rpcAddress, authToken: rpcAuthToken } =
 			await ensureCliHubServer(
 				startRequest.workspaceRoot || startRequest.cwd || process.cwd(),
@@ -942,6 +943,7 @@ class TelegramConnector extends ConnectorBase<
 			loggerAdapter,
 		);
 		await telegram.stopPolling().catch(() => undefined);
+		await shutdownPluginChatCommands().catch(() => undefined);
 		await bot.shutdown().catch(() => undefined);
 		client.close();
 		this.removeStateFile(statePath);

--- a/sdk/apps/cli/src/connectors/adapters/whatsapp.ts
+++ b/sdk/apps/cli/src/connectors/adapters/whatsapp.ts
@@ -538,10 +538,11 @@ class WhatsAppConnector extends ConnectorBase<
 		});
 		await userInstructionService.start().catch(() => undefined);
 		const commandCwd = startRequest.cwd || process.cwd();
-		const { host: chatCommandHost } = await createWorkspaceChatCommandHost({
-			cwd: commandCwd,
-			workspaceRoot: startRequest.workspaceRoot || commandCwd,
-		});
+		const { host: chatCommandHost, shutdown: shutdownPluginChatCommands } =
+			await createWorkspaceChatCommandHost({
+				cwd: commandCwd,
+				workspaceRoot: startRequest.workspaceRoot || commandCwd,
+			});
 		const { url: rpcAddress, authToken: rpcAuthToken } =
 			await ensureCliHubServer(
 				startRequest.workspaceRoot || startRequest.cwd || process.cwd(),
@@ -842,6 +843,7 @@ class WhatsAppConnector extends ConnectorBase<
 		stopTaskUpdateStream();
 		stopEventStream();
 		await server.close();
+		await shutdownPluginChatCommands().catch(() => undefined);
 		userInstructionService.stop();
 		client.close();
 		this.removeStateFile(statePath);

--- a/sdk/apps/cli/src/utils/plugin-chat-commands.test.ts
+++ b/sdk/apps/cli/src/utils/plugin-chat-commands.test.ts
@@ -6,17 +6,60 @@ import { createWorkspaceChatCommandHost } from "./plugin-chat-commands";
 
 describe("plugin chat commands", () => {
 	const tempRoots: string[] = [];
+	const envSnapshot = {
+		CLINE_DIR: process.env.CLINE_DIR,
+		CLINE_GLOBAL_SETTINGS_PATH: process.env.CLINE_GLOBAL_SETTINGS_PATH,
+	};
 
 	afterEach(async () => {
+		restoreEnv("CLINE_DIR", envSnapshot.CLINE_DIR);
+		restoreEnv(
+			"CLINE_GLOBAL_SETTINGS_PATH",
+			envSnapshot.CLINE_GLOBAL_SETTINGS_PATH,
+		);
 		await Promise.all(
 			tempRoots.map((dir) => rm(dir, { recursive: true, force: true })),
 		);
 		tempRoots.length = 0;
 	});
 
+	function restoreEnv(name: string, value: string | undefined): void {
+		if (value === undefined) {
+			delete process.env[name];
+			return;
+		}
+		process.env[name] = value;
+	}
+
+	function isolateGlobalPlugins(tempRoot: string): void {
+		process.env.CLINE_DIR = join(tempRoot, ".cline-global");
+		process.env.CLINE_GLOBAL_SETTINGS_PATH = join(
+			tempRoot,
+			"global-settings.json",
+		);
+	}
+
+	it("returns a callable shutdown when no plugin commands are loaded", async () => {
+		const tempRoot = await mkdtemp(
+			join(tmpdir(), "cli-plugin-commands-empty-"),
+		);
+		tempRoots.push(tempRoot);
+		isolateGlobalPlugins(tempRoot);
+
+		const { pluginSlashCommands, shutdown } =
+			await createWorkspaceChatCommandHost({
+				cwd: tempRoot,
+				workspaceRoot: tempRoot,
+			});
+
+		expect(pluginSlashCommands).toEqual([]);
+		await expect(shutdown()).resolves.toBeUndefined();
+	});
+
 	it("bridges plugin extension commands onto the chat command host", async () => {
 		const tempRoot = await mkdtemp(join(tmpdir(), "cli-plugin-commands-"));
 		tempRoots.push(tempRoot);
+		isolateGlobalPlugins(tempRoot);
 		const pluginsDir = join(tempRoot, ".cline", "plugins");
 		await mkdir(pluginsDir, { recursive: true });
 		await writeFile(
@@ -63,6 +106,6 @@ describe("plugin chat commands", () => {
 
 		expect(handled).toBe(true);
 		expect(reply).toHaveBeenCalledWith("echo:hello plugin");
-		await shutdown?.();
+		await shutdown();
 	});
 });

--- a/sdk/apps/cli/src/utils/plugin-chat-commands.ts
+++ b/sdk/apps/cli/src/utils/plugin-chat-commands.ts
@@ -20,8 +20,10 @@ export interface WorkspaceChatCommandHostResult {
 	host: ChatCommandHost;
 	// Plugin-registered commands surfaced as slash commands for TUI autocomplete.
 	pluginSlashCommands: PluginSlashCommand[];
-	shutdown?: () => Promise<void>;
+	shutdown: () => Promise<void>;
 }
+
+const noopShutdown = async (): Promise<void> => undefined;
 
 function normalizeCommandName(name: string): string {
 	const trimmed = name.trim();
@@ -69,13 +71,21 @@ export async function createWorkspaceChatCommandHost(input: {
 		input.logger?.log(
 			`plugin command loading failed; continuing without plugin commands (${message})`,
 		);
-		return { host: chatCommandHost, pluginSlashCommands: [] };
+		return {
+			host: chatCommandHost,
+			pluginSlashCommands: [],
+			shutdown: noopShutdown,
+		};
 	}
 	if (!loaded.extensions.length) {
 		await loaded.shutdown?.().catch(() => {
 			// Best effort cleanup when no command-capable plugins were loaded.
 		});
-		return { host: chatCommandHost, pluginSlashCommands: [] };
+		return {
+			host: chatCommandHost,
+			pluginSlashCommands: [],
+			shutdown: noopShutdown,
+		};
 	}
 
 	const registry = createContributionRegistry<
@@ -95,7 +105,11 @@ export async function createWorkspaceChatCommandHost(input: {
 		await loaded.shutdown?.().catch(() => {
 			// Best effort cleanup after failed command discovery.
 		});
-		return { host: chatCommandHost, pluginSlashCommands: [] };
+		return {
+			host: chatCommandHost,
+			pluginSlashCommands: [],
+			shutdown: noopShutdown,
+		};
 	}
 
 	const host = chatCommandHost.clone();
@@ -114,5 +128,9 @@ export async function createWorkspaceChatCommandHost(input: {
 			});
 		}
 	}
-	return { host, pluginSlashCommands, shutdown: loaded.shutdown };
+	return {
+		host,
+		pluginSlashCommands,
+		shutdown: loaded.shutdown ?? noopShutdown,
+	};
 }


### PR DESCRIPTION
This PR follows up on the plugin discovery work from PR #10819. That PR moved plugin slash command discovery onto the sandbox backed plugin loader so interactive CLI command discovery uses the same production loading model as the agent runtime.

That change also meant createWorkspaceChatCommandHost can now return command handlers that proxy into a live plugin sandbox process. The interactive runtime already keeps the returned shutdown callback and calls it during cleanup, but the connector adapters were still using the older call pattern where they only kept the chat command host.

The important distinction is that plugin command discovery is not just static metadata. The host registers executable command handlers, and sandbox backed command handlers need the sandbox process to remain alive until the host is no longer used. If a long-lived connector starts with plugin slash commands and then stops, it needs to close that sandbox just like it closes its server, streams, bot runtime, and hub client.

This PR makes that lifecycle explicit by changing createWorkspaceChatCommandHost so shutdown is always a callable function. Successful sandbox backed command hosts return the real sandbox shutdown callback. Empty, failed, or already cleaned up paths return a no-op shutdown. This removes the optional lifecycle footgun and gives every caller the same simple contract.

The connector adapters for Slack, Discord, Google Chat, Linear, Telegram, and WhatsApp now capture shutdownPluginChatCommands and call it from their existing shutdown paths. Discord also has an early gateway startup failure path after the command host has been created, so that path now shuts down plugin commands before returning.

The implementation intentionally avoids a larger abstraction. Each adapter already has one clear cleanup sequence, so the smallest reliable fix is to wire this new resource into those sequences. This keeps sandbox backed command loading as the default while making the ownership explicit for the long-lived connector processes.
