### PR TITLE
docs: clarify plugin SDK peer dependency

### DIFF
--- a/docs/customization/plugins.mdx
+++ b/docs/customization/plugins.mdx
@@ -100,15 +100,15 @@ If no `cline.plugins` field is present, the installer falls back to auto-discove
 
 ### Host-Provided Dependencies
 
-Dependencies under the `@cline/` scope (like `@cline/core`, `@cline/shared`) are provided by the host runtime. The installer automatically strips these from the plugin's dependency list before running `npm install`, so you should declare them as `peerDependencies`:
+Dependencies under the `@cline/` scope are provided by the host runtime. The installer automatically strips these from the plugin's dependency list before running `npm install`, so declare any `@cline/*` package your plugin imports as an optional peer dependency. The host currently provides `@cline/sdk`, `@cline/core`, `@cline/agents`, `@cline/llms`, and `@cline/shared`.
 
 ```json
 {
   "peerDependencies": {
-    "@cline/core": "*"
+    "@cline/sdk": "*"
   },
   "peerDependenciesMeta": {
-    "@cline/core": {
+    "@cline/sdk": {
       "optional": true
     }
   }

--- a/docs/sdk/guides/writing-plugins.mdx
+++ b/docs/sdk/guides/writing-plugins.mdx
@@ -251,15 +251,21 @@ await cline.start({
 
 ## Distributing via CLI Install
 
-To make your plugin installable with `cline plugin install`, add a `cline` field to your `package.json` that declares entry points and list `@cline/` imports as peer dependencies (the host runtime provides them):
+To make your plugin installable with `cline plugin install`, add a `cline` field to your `package.json` that declares entry points. Dependencies under the `@cline/` scope are provided by the host runtime. The installer automatically strips these from the plugin's dependency list before running `npm install`, so declare any `@cline/*` package your plugin imports as an optional peer dependency:
 
 ```json
 {
   "cline": {
     "plugins": [{ "paths": ["./github-plugin.ts"], "capabilities": ["tools", "hooks"] }]
   },
-  "peerDependencies": { "@cline/core": "*" },
-  "peerDependenciesMeta": { "@cline/core": { "optional": true } }
+  "peerDependencies": {
+    "@cline/sdk": "*"
+  },
+  "peerDependenciesMeta": {
+    "@cline/sdk": {
+      "optional": true
+    }
+  }
 }
 ```
 


### PR DESCRIPTION
### Related Issue

Issue: #XXXX

Follow-up from https://github.com/cline/cline/pull/10809#issuecomment-4466200288

### Description

This updates the plugin docs to align the package examples with the SDK imports used in the examples.

The writing guide imports plugin APIs from `@cline/sdk`, but the installable package snippet previously showed `@cline/core` as the peer dependency. That made the guidance internally inconsistent and could lead plugin authors to declare the wrong host SDK package.

The docs now keep the existing host-runtime guidance: `@cline/*` packages are provided by the host runtime, and the installer strips those packages from plugin dependencies before `npm install`. The examples now declare only `@cline/sdk` as an optional peer dependency because that is the package shown in the sample imports. The customization page also names the current host-provided package set so authors know the broader rule applies to any `@cline/*` package they actually import.

### Test Procedure

Checked the docs diff directly to verify:

- The writing guide and customization page both preserve the host runtime and installer stripping guidance.
- The package snippets declare `@cline/sdk` as an optional peer dependency.
- No runtime code changed.

Validation run locally:

- `git diff --check`
- `bunx --bun @biomejs/biome check --no-errors-on-unmatched --files-ignore-unknown=true docs/sdk/guides/writing-plugins.mdx docs/customization/plugins.mdx`

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [x] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Not applicable. This is a docs-only change.

### Additional Notes

This intentionally keeps the snippets minimal by declaring only `@cline/sdk`, while the prose documents the broader rule for the other host-provided `@cline/*` packages.
