### PR TITLE
fix: treat streamed usage as request snapshots

### DIFF
--- a/sdk/apps/cli/src/tui/views/config-view.tsx
+++ b/sdk/apps/cli/src/tui/views/config-view.tsx
@@ -237,6 +237,7 @@ function appendToolRows(
 
 export function ConfigPanelContent(props: ConfigPanelProps) {
 	const { resolve, dismiss, dialogId, config } = props;
+	const { loadConfigData } = props;
 	const { height } = useTerminalDimensions();
 
 	const [mode, setMode] = useState(props.currentMode);
@@ -267,7 +268,7 @@ export function ConfigPanelContent(props: ConfigPanelProps) {
 			activeTab !== "tools" ||
 			pluginToolsLoaded ||
 			pluginToolsError ||
-			!props.loadConfigData
+			!loadConfigData
 		) {
 			return;
 		}
@@ -275,8 +276,7 @@ export function ConfigPanelContent(props: ConfigPanelProps) {
 		let cancelled = false;
 		setPluginToolsLoading(true);
 		setPluginToolsError(undefined);
-		props
-			.loadConfigData({ includePluginTools: true })
+		loadConfigData({ includePluginTools: true })
 			.then((nextData) => {
 				if (cancelled) {
 					return;
@@ -300,7 +300,7 @@ export function ConfigPanelContent(props: ConfigPanelProps) {
 		return () => {
 			cancelled = true;
 		};
-	}, [activeTab, pluginToolsError, pluginToolsLoaded, props.loadConfigData]);
+	}, [activeTab, loadConfigData, pluginToolsError, pluginToolsLoaded]);
 
 	const rows = useMemo(() => {
 		const r: ConfigRow[] = [];

--- a/src/core/task/__tests__/usage-snapshot.test.ts
+++ b/src/core/task/__tests__/usage-snapshot.test.ts
@@ -1,0 +1,53 @@
+import { strict as assert } from "node:assert"
+import { describe, it } from "mocha"
+import { type ApiRequestUsageMetrics, applyUsageSnapshot } from "../usage"
+
+describe("applyUsageSnapshot", () => {
+	it("keeps the latest per-request usage snapshot instead of accumulating repeated chunks", () => {
+		const metrics: ApiRequestUsageMetrics = {
+			inputTokens: 0,
+			outputTokens: 0,
+			cacheWriteTokens: 0,
+			cacheReadTokens: 0,
+			totalCost: undefined,
+		}
+
+		const firstDelta = applyUsageSnapshot(metrics, {
+			inputTokens: 13_856,
+			outputTokens: 133,
+			cacheWriteTokens: 0,
+			cacheReadTokens: 0,
+			totalCost: 0.1,
+		})
+		const secondDelta = applyUsageSnapshot(metrics, {
+			inputTokens: 13_856,
+			outputTokens: 134,
+			cacheWriteTokens: 0,
+			cacheReadTokens: 0,
+			totalCost: 0.11,
+		})
+
+		assert.deepEqual(metrics, {
+			inputTokens: 13_856,
+			outputTokens: 134,
+			cacheWriteTokens: 0,
+			cacheReadTokens: 0,
+			totalCost: 0.11,
+		})
+		assert.deepEqual(firstDelta, {
+			inputTokens: 13_856,
+			outputTokens: 133,
+			cacheWriteTokens: 0,
+			cacheReadTokens: 0,
+			totalCost: 0.1,
+		})
+		const { totalCost: secondDeltaCost, ...secondDeltaTokens } = secondDelta
+		assert.deepEqual(secondDeltaTokens, {
+			inputTokens: 0,
+			outputTokens: 1,
+			cacheWriteTokens: 0,
+			cacheReadTokens: 0,
+		})
+		assert.equal(Number(secondDeltaCost?.toFixed(2)), 0.01)
+	})
+})

--- a/src/core/task/index.ts
+++ b/src/core/task/index.ts
@@ -128,6 +128,7 @@ import { StreamResponseHandler } from "./StreamResponseHandler"
 import { TaskPresentationScheduler } from "./TaskPresentationScheduler"
 import { TaskState } from "./TaskState"
 import { ToolExecutor } from "./ToolExecutor"
+import { applyUsageSnapshot } from "./usage"
 import { detectAvailableCliTools, extractProviderDomainFromUrl, updateApiReqMsg } from "./utils"
 import { buildUserFeedbackContent } from "./utils/buildUserFeedbackContent"
 
@@ -2840,15 +2841,11 @@ export class Task {
 					onUsageChunk: (chunk) => {
 						this.streamHandler.setRequestId(chunk.id)
 						didReceiveUsageChunk = true
-						taskMetrics.inputTokens += chunk.inputTokens
-						taskMetrics.outputTokens += chunk.outputTokens
-						taskMetrics.cacheWriteTokens += chunk.cacheWriteTokens ?? 0
-						taskMetrics.cacheReadTokens += chunk.cacheReadTokens ?? 0
-						taskMetrics.totalCost = chunk.totalCost ?? taskMetrics.totalCost
-						queueUsageChunkSideEffects(chunk.inputTokens, chunk.outputTokens, {
-							cacheWriteTokens: chunk.cacheWriteTokens,
-							cacheReadTokens: chunk.cacheReadTokens,
-							totalCost: chunk.totalCost,
+						const usageDelta = applyUsageSnapshot(taskMetrics, chunk)
+						queueUsageChunkSideEffects(usageDelta.inputTokens, usageDelta.outputTokens, {
+							cacheWriteTokens: usageDelta.cacheWriteTokens,
+							cacheReadTokens: usageDelta.cacheReadTokens,
+							totalCost: usageDelta.totalCost,
 						})
 					},
 				})
@@ -3072,15 +3069,11 @@ export class Task {
 			if (!didReceiveUsageChunk) {
 				const apiStreamUsage = await this.api.getApiStreamUsage?.()
 				if (apiStreamUsage) {
-					taskMetrics.inputTokens += apiStreamUsage.inputTokens
-					taskMetrics.outputTokens += apiStreamUsage.outputTokens
-					taskMetrics.cacheWriteTokens += apiStreamUsage.cacheWriteTokens ?? 0
-					taskMetrics.cacheReadTokens += apiStreamUsage.cacheReadTokens ?? 0
-					taskMetrics.totalCost = apiStreamUsage.totalCost ?? taskMetrics.totalCost
-					queueUsageChunkSideEffects(apiStreamUsage.inputTokens, apiStreamUsage.outputTokens, {
-						cacheWriteTokens: apiStreamUsage.cacheWriteTokens,
-						cacheReadTokens: apiStreamUsage.cacheReadTokens,
-						totalCost: apiStreamUsage.totalCost,
+					const usageDelta = applyUsageSnapshot(taskMetrics, apiStreamUsage)
+					queueUsageChunkSideEffects(usageDelta.inputTokens, usageDelta.outputTokens, {
+						cacheWriteTokens: usageDelta.cacheWriteTokens,
+						cacheReadTokens: usageDelta.cacheReadTokens,
+						totalCost: usageDelta.totalCost,
 					})
 				}
 			}

--- a/src/core/task/tools/subagent/SubagentRunner.ts
+++ b/src/core/task/tools/subagent/SubagentRunner.ts
@@ -516,7 +516,9 @@ export class SubagentRunner {
 					requestUsage.outputTokens +
 					requestUsage.cacheWriteTokens +
 					requestUsage.cacheReadTokens
-				stats.totalCost += calculatedRequestCost || 0
+				if (requestUsage.totalCost === undefined) {
+					stats.totalCost += calculatedRequestCost || 0
+				}
 				usageState.lastRequest = { ...requestUsage }
 
 				const nativeFinalizedToolCalls = toolUseHandler.getAllFinalizedToolUses().map((toolCall, index) => ({

--- a/src/core/task/tools/subagent/SubagentRunner.ts
+++ b/src/core/task/tools/subagent/SubagentRunner.ts
@@ -19,6 +19,7 @@ import { ApiFormat } from "@/shared/proto/cline/models"
 import { calculateApiCostAnthropic } from "@/utils/cost"
 import { isNextGenModelFamily } from "@/utils/model-utils"
 import { TaskState } from "../../TaskState"
+import { applyUsageSnapshot } from "../../usage"
 import { ToolExecutorCoordinator } from "../ToolExecutorCoordinator"
 import { ToolValidator } from "../ToolValidator"
 import type { TaskConfig } from "../types/TaskConfig"
@@ -454,20 +455,17 @@ export class SubagentRunner {
 					switch (chunk.type) {
 						case "usage":
 							requestId = requestId ?? chunk.id
-							stats.inputTokens += chunk.inputTokens || 0
-							stats.outputTokens += chunk.outputTokens || 0
-							stats.cacheWriteTokens += chunk.cacheWriteTokens || 0
-							stats.cacheReadTokens += chunk.cacheReadTokens || 0
-							requestUsage.inputTokens += chunk.inputTokens || 0
-							requestUsage.outputTokens += chunk.outputTokens || 0
-							requestUsage.cacheWriteTokens += chunk.cacheWriteTokens || 0
-							requestUsage.cacheReadTokens += chunk.cacheReadTokens || 0
+							const usageDelta = applyUsageSnapshot(requestUsage, chunk)
+							stats.inputTokens += usageDelta.inputTokens
+							stats.outputTokens += usageDelta.outputTokens
+							stats.cacheWriteTokens += usageDelta.cacheWriteTokens
+							stats.cacheReadTokens += usageDelta.cacheReadTokens
 							requestUsage.totalTokens =
 								requestUsage.inputTokens +
 								requestUsage.outputTokens +
 								requestUsage.cacheWriteTokens +
 								requestUsage.cacheReadTokens
-							requestUsage.totalCost = chunk.totalCost ?? requestUsage.totalCost
+							stats.totalCost += usageDelta.totalCost ?? 0
 							stats.contextTokens = requestUsage.totalTokens
 							stats.contextUsagePercentage =
 								stats.contextWindow > 0 ? (stats.contextTokens / stats.contextWindow) * 100 : 0

--- a/src/core/task/usage.ts
+++ b/src/core/task/usage.ts
@@ -1,0 +1,39 @@
+export type ApiRequestUsageMetrics = {
+	inputTokens: number
+	outputTokens: number
+	cacheWriteTokens: number
+	cacheReadTokens: number
+	totalCost?: number
+}
+
+export type ApiRequestUsageSnapshot = {
+	inputTokens?: number
+	outputTokens?: number
+	cacheWriteTokens?: number
+	cacheReadTokens?: number
+	totalCost?: number
+}
+
+export function applyUsageSnapshot(metrics: ApiRequestUsageMetrics, usage: ApiRequestUsageSnapshot) {
+	const previous = {
+		inputTokens: metrics.inputTokens,
+		outputTokens: metrics.outputTokens,
+		cacheWriteTokens: metrics.cacheWriteTokens,
+		cacheReadTokens: metrics.cacheReadTokens,
+		totalCost: metrics.totalCost,
+	}
+
+	metrics.inputTokens = usage.inputTokens ?? metrics.inputTokens
+	metrics.outputTokens = usage.outputTokens ?? metrics.outputTokens
+	metrics.cacheWriteTokens = usage.cacheWriteTokens ?? metrics.cacheWriteTokens
+	metrics.cacheReadTokens = usage.cacheReadTokens ?? metrics.cacheReadTokens
+	metrics.totalCost = usage.totalCost ?? metrics.totalCost
+
+	return {
+		inputTokens: Math.max(0, metrics.inputTokens - previous.inputTokens),
+		outputTokens: Math.max(0, metrics.outputTokens - previous.outputTokens),
+		cacheWriteTokens: Math.max(0, metrics.cacheWriteTokens - previous.cacheWriteTokens),
+		cacheReadTokens: Math.max(0, metrics.cacheReadTokens - previous.cacheReadTokens),
+		totalCost: metrics.totalCost === undefined ? undefined : Math.max(0, metrics.totalCost - (previous.totalCost ?? 0)),
+	}
+}


### PR DESCRIPTION
## Summary
- Treat streamed usage chunks as the latest per-request snapshot instead of accumulating every chunk.
- Emit only positive usage deltas for live telemetry updates, while keeping the request total aligned to the newest snapshot.
- Apply the same snapshot handling to subagent runs and add a regression test for repeated streaming usage snapshots.

Fixes #10148

## Testing
- npm run check-types
- npx biome lint src/core/task/usage.ts src/core/task/utils.ts src/core/task/index.ts src/core/task/tools/subagent/SubagentRunner.ts src/core/task/__tests__/usage-snapshot.test.ts --no-errors-on-unmatched --files-ignore-unknown=true --diagnostic-level=error
- TS_NODE_PROJECT=./tsconfig.unit-test.json node -r ts-node/register -e "const assert=require('node:assert').strict; const {applyUsageSnapshot}=require('./src/core/task/usage.ts'); const metrics={inputTokens:0,outputTokens:0,cacheWriteTokens:0,cacheReadTokens:0}; applyUsageSnapshot(metrics,{inputTokens:13856,outputTokens:133,cacheWriteTokens:0,cacheReadTokens:0,totalCost:0.1}); const delta=applyUsageSnapshot(metrics,{inputTokens:13856,outputTokens:134,cacheWriteTokens:0,cacheReadTokens:0,totalCost:0.11}); assert.equal(metrics.inputTokens,13856); assert.equal(metrics.outputTokens,134); assert.equal(delta.inputTokens,0); assert.equal(delta.outputTokens,1);"
- git diff --check
