### PR TITLE
fix(cli): route LiteLLM through chat completions

### DIFF
--- a/sdk/packages/core/src/runtime/orchestration/runtime-builder.test.ts
+++ b/sdk/packages/core/src/runtime/orchestration/runtime-builder.test.ts
@@ -312,7 +312,8 @@ describe("DefaultRuntimeBuilder", () => {
 			serverPath,
 			`let buffer = "";
 function write(payload) {
-  process.stdout.write(JSON.stringify(payload) + "\\n");
+  const body = JSON.stringify(payload);
+  process.stdout.write("Content-Length: " + Buffer.byteLength(body, "utf8") + "\\r\\n\\r\\n" + body);
 }
 function handle(message) {
   if (message.method === "initialize") {
@@ -330,12 +331,18 @@ function handle(message) {
 process.stdin.on("data", (chunk) => {
   buffer += chunk.toString("utf8");
   while (true) {
-    const separator = buffer.indexOf("\\n");
+    const separator = buffer.indexOf("\\r\\n\\r\\n");
     if (separator < 0) break;
-    const line = buffer.slice(0, separator).trim();
-    buffer = buffer.slice(separator + 1);
-    if (!line) continue;
-    const message = JSON.parse(line);
+    const header = buffer.slice(0, separator);
+    const match = header.match(/Content-Length:\\s*(\\d+)/i);
+    if (!match) throw new Error("missing content length");
+    const length = Number(match[1]);
+    const start = separator + 4;
+    const end = start + length;
+    if (buffer.length < end) break;
+    const body = buffer.slice(start, end);
+    buffer = buffer.slice(end);
+    const message = JSON.parse(body);
     if (message.method === "notifications/initialized") continue;
     handle(message);
   }
@@ -360,13 +367,16 @@ process.stdin.on("data", (chunk) => {
 		);
 
 		process.env.CLINE_MCP_SETTINGS_PATH = settingsPath;
+		let runtime:
+			| Awaited<ReturnType<DefaultRuntimeBuilder["build"]>>
+			| undefined;
 		try {
-			const runtime = await new DefaultRuntimeBuilder().build({
+			runtime = await new DefaultRuntimeBuilder().build({
 				config: makeBaseConfig(),
 			});
 			expect(runtime.tools.map((tool) => tool.name)).toContain("mock__echo");
-			await runtime.shutdown("test");
 		} finally {
+			await runtime?.shutdown("test");
 			process.env.CLINE_MCP_SETTINGS_PATH = previousSettingsPath;
 		}
 	});

--- a/sdk/packages/llms/src/providers/builtins.ts
+++ b/sdk/packages/llms/src/providers/builtins.ts
@@ -389,7 +389,6 @@ const OPENAI_COMPATIBLE_SPECS: BuiltinSpec[] = [
 		name: "LiteLLM",
 		description: "Self-hosted LLM proxy",
 		family: "openai-compatible",
-		protocol: "openai-responses",
 		popular: 8,
 		capabilities: ["prompt-cache"],
 		defaultModelId: "gpt-5.4",

--- a/sdk/packages/llms/src/providers/ids.test.ts
+++ b/sdk/packages/llms/src/providers/ids.test.ts
@@ -82,7 +82,7 @@ describe("provider-ids", () => {
 	});
 
 	it("routes Responses API built-ins through the OpenAI provider factory", async () => {
-		for (const providerId of ["litellm", "v0"]) {
+		for (const providerId of ["v0"]) {
 			const provider = await getProvider(providerId);
 			expect(provider).toMatchObject({
 				id: providerId,
@@ -97,5 +97,20 @@ describe("provider-ids", () => {
 				createProvider: createOpenAIProvider,
 			});
 		}
+	});
+
+	it("routes LiteLLM through OpenAI-compatible chat completions", async () => {
+		await expect(getProvider("litellm")).resolves.toMatchObject({
+			id: "litellm",
+			protocol: "openai-chat",
+			client: "openai-compatible",
+		});
+
+		const registration = BUILTIN_PROVIDER_REGISTRATIONS.find(
+			(item) => item.manifest.id === "litellm",
+		);
+		await expect(registration?.loadProvider?.()).resolves.toMatchObject({
+			createProvider: createOpenAICompatibleProvider,
+		});
 	});
 });


### PR DESCRIPTION
## Summary

Fixes #10781.

LiteLLM is an OpenAI-compatible proxy and many deployments only expose `/v1/chat/completions`. The built-in provider was explicitly opting into the OpenAI Responses API, which routes requests to `/v1/responses` and breaks those proxies.

This removes the LiteLLM Responses API override so it follows the default `openai-compatible` chat-completions path, while keeping `v0` on the Responses API path.

## Tests

- `cd sdk/packages/llms && bun test src/providers/ids.test.ts`
- `cd sdk/packages/llms && bun run typecheck`
- `cd sdk && bunx --bun @biomejs/biome check packages/llms/src/providers/builtins.ts packages/llms/src/providers/ids.test.ts`
- `git diff --check`