### PR TITLE
fix(cli): restore file initials search

### DIFF
--- a/sdk/apps/cli/src/tui/components/searchable-list.test.ts
+++ b/sdk/apps/cli/src/tui/components/searchable-list.test.ts
@@ -3,6 +3,7 @@ import {
 	buildSearchableListRows,
 	getSearchableListRowsWindow,
 	type SearchableItem,
+	scoreItem,
 } from "./searchable-list";
 
 function rowLabels(items: SearchableItem[]): string[] {
@@ -72,5 +73,23 @@ describe("searchable list sections", () => {
 			kind: "header",
 			label: "Popular",
 		});
+	});
+});
+
+describe("searchable list scoring", () => {
+	it("prioritizes camel-case filename initials", () => {
+		const target: SearchableItem = {
+			key: "src/classes/MyAmazingClassDefinition.js",
+			label: "MyAmazingClassDefinition.js",
+		};
+		const fuzzyOnly: SearchableItem = {
+			key: "src/classes/MainClientDashboard.js",
+			label: "MainClientDashboard.js",
+		};
+
+		expect(scoreItem(target, "M-A-C-D")).toBeGreaterThan(
+			scoreItem(fuzzyOnly, "M-A-C-D"),
+		);
+		expect(scoreItem(target, "M-A-C-D")).toBe(95);
 	});
 });

--- a/sdk/apps/cli/src/tui/components/searchable-list.tsx
+++ b/sdk/apps/cli/src/tui/components/searchable-list.tsx
@@ -32,7 +32,21 @@ export type CreateSearchableItem = (
 ) => SearchableItem | undefined;
 
 function normalize(s: string): string {
-	return s.replace(/[^a-z0-9.]/g, "");
+	return s.toLowerCase().replace(/[^a-z0-9.]/g, "");
+}
+
+function filenameStem(path: string): string {
+	const filename = path.split(/[\\/]/).pop() ?? path;
+	return filename.replace(/\.[^.]*$/, "");
+}
+
+function initials(s: string): string {
+	return (
+		s
+			.match(/[A-Z]+(?=[A-Z][a-z]|\b)|[A-Z]?[a-z0-9]+/g)
+			?.map((word) => word[0])
+			.join("") ?? ""
+	).toLowerCase();
 }
 
 function fuzzyMatch(text: string, query: string): boolean {
@@ -43,12 +57,8 @@ function fuzzyMatch(text: string, query: string): boolean {
 	return qi === query.length;
 }
 
-function scoreItem(item: SearchableItem, query: string): number {
-	const targets = [
-		item.label.toLowerCase(),
-		item.key.toLowerCase(),
-		item.searchText?.toLowerCase() ?? "",
-	];
+export function scoreItem(item: SearchableItem, query: string): number {
+	const targets = [item.label, item.key, item.searchText ?? ""];
 	const nQuery = normalize(query);
 
 	let best = 0;
@@ -58,7 +68,14 @@ function scoreItem(item: SearchableItem, query: string): number {
 		if (t === nQuery) return 100;
 		if (t.startsWith(nQuery)) best = Math.max(best, 90);
 		else if (t.includes(nQuery)) best = Math.max(best, 70);
-		else if (fuzzyMatch(t, nQuery)) best = Math.max(best, 30);
+
+		for (const acronym of [initials(raw), initials(filenameStem(raw))]) {
+			if (!acronym) continue;
+			if (acronym === nQuery) best = Math.max(best, 95);
+			else if (acronym.startsWith(nQuery)) best = Math.max(best, 80);
+		}
+
+		if (fuzzyMatch(t, nQuery)) best = Math.max(best, 30);
 	}
 	return best;
 }


### PR DESCRIPTION
### Related Issue

**Issue:** Fixes #10798

### Description

Restores CLI TUI file search matching by filename initials/acronyms. A query such as `M-A-C-D` now scores `MyAmazingClassDefinition.js` highly by matching the camel-case filename stem initials, while preserving exact, prefix, substring, and fuzzy matching behavior.

### Test Procedure

- `cd sdk && bun biome check apps/cli/src/tui/components/searchable-list.tsx apps/cli/src/tui/components/searchable-list.test.ts --diagnostic-level=error`
- `cd sdk && bun -F @cline/cli test:unit -- src/tui/components/searchable-list.test.ts`
- `cd sdk && bun -F @cline/cli typecheck`

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A (CLI search scoring change covered by unit test).

### Additional Notes

This PR is intentionally scoped to the shared searchable-list scoring used by the CLI TUI.