### PR TITLE
fix(cli): restore initialism @search matching

### DIFF
--- a/src/services/search/file-search.ts
+++ b/src/services/search/file-search.ts
@@ -163,14 +163,18 @@ const GRPC_STATUS_UNIMPLEMENTED = 12
  * doesn't implement the RPC / the index is unavailable. Returning `[]` is
  * authoritative — caller does not fall back to ripgrep.
  */
-async function executeHostIndexForFiles(
+export async function executeHostIndexForFiles(
 	query: string,
 	workspacePath: string,
 	selectedType?: "file" | "folder",
 ): Promise<{ path: string; type: "file" | "folder"; label?: string }[] | null> {
 	try {
+		// Preserve core-side fuzzy matching semantics (including initialism input like
+		// "M-A-C-D" -> MyAmazingClassDefinition) by asking the host for a broad seed set
+		// and letting fzf rank locally. Native host indexes generally do literal/prefix
+		// matching, so forwarding the raw query can prematurely exclude valid fuzzy hits.
 		const req = SearchWorkspaceItemsRequest.create({
-			query,
+			query: query.trim() ? "" : query,
 			workspacePath,
 			limit: HOST_INDEX_CANDIDATE_LIMIT,
 			selectedType:

--- a/src/test/services/search/file-search.test.ts
+++ b/src/test/services/search/file-search.test.ts
@@ -247,6 +247,22 @@ describe("File Search", () => {
 				label: "important.js",
 			})
 		})
+
+		it("should request an unfiltered host candidate set for fuzzy initialism queries", async () => {
+			const hostResponse = SearchWorkspaceItemsResponse.create({
+				items: [{ path: "src/MyAmazingClassDefinition.js", type: SearchWorkspaceItemsRequest_SearchItemType.FILE }],
+			})
+			const searchItemsStub = sandbox.stub(HostProvider.workspace, "searchWorkspaceItems").resolves(hostResponse)
+
+			const result = await fileSearch.executeHostIndexForFiles("M-A-C-D", "/workspace")
+
+			should(searchItemsStub.calledOnce).be.true()
+			searchItemsStub.firstCall.args[0].query.should.equal("")
+			should(result).deepEqual([
+				{ path: "src/MyAmazingClassDefinition.js", type: "file", label: "MyAmazingClassDefinition.js" },
+				{ path: "src", type: "folder", label: "src" },
+			])
+		})
 	})
 
 	describe("OrderbyMatchScore", () => {


### PR DESCRIPTION
## Summary
Fixes #10798

Restore TUI @search initialism matching by asking host indexes for an unfiltered candidate seed set and keeping fuzzy ranking in core.

## Changes
- stop forwarding non-empty mention queries to host-native workspace search
- add a regression test covering initialism-style host index requests
