### PR TITLE
fix: preserve configured context window

### DIFF
--- a/sdk/apps/cli/src/tui/views/config-view.tsx
+++ b/sdk/apps/cli/src/tui/views/config-view.tsx
@@ -261,13 +261,14 @@ export function ConfigPanelContent(props: ConfigPanelProps) {
 	const [navPos, setNavPos] = useState(0);
 
 	const displayName = resolveModelDisplayName(config);
+	const { loadConfigData } = props;
 
 	useEffect(() => {
 		if (
 			activeTab !== "tools" ||
 			pluginToolsLoaded ||
 			pluginToolsError ||
-			!props.loadConfigData
+			!loadConfigData
 		) {
 			return;
 		}
@@ -275,8 +276,7 @@ export function ConfigPanelContent(props: ConfigPanelProps) {
 		let cancelled = false;
 		setPluginToolsLoading(true);
 		setPluginToolsError(undefined);
-		props
-			.loadConfigData({ includePluginTools: true })
+		loadConfigData({ includePluginTools: true })
 			.then((nextData) => {
 				if (cancelled) {
 					return;
@@ -300,7 +300,7 @@ export function ConfigPanelContent(props: ConfigPanelProps) {
 		return () => {
 			cancelled = true;
 		};
-	}, [activeTab, pluginToolsError, pluginToolsLoaded, props.loadConfigData]);
+	}, [activeTab, loadConfigData, pluginToolsError, pluginToolsLoaded]);
 
 	const rows = useMemo(() => {
 		const r: ConfigRow[] = [];

--- a/src/core/context/context-management/__tests__/context-window-utils.test.ts
+++ b/src/core/context/context-management/__tests__/context-window-utils.test.ts
@@ -1,0 +1,24 @@
+import { expect } from "chai"
+import { getContextWindowInfo } from "../context-window-utils"
+
+function createMockApi(modelId: string, contextWindow?: number) {
+	return {
+		getModel: () => ({ id: modelId, info: { contextWindow } }),
+	} as any
+}
+
+describe("getContextWindowInfo", () => {
+	it("preserves configured context window for OpenAI-compatible DeepSeek models", () => {
+		const result = getContextWindowInfo(createMockApi("deepseek/deepseek-v4-pro", 1_000_000))
+
+		expect(result.contextWindow).to.equal(1_000_000)
+		expect(result.maxAllowedSize).to.equal(960_000)
+	})
+
+	it("uses the default context window when a model omits one", () => {
+		const result = getContextWindowInfo(createMockApi("custom-model"))
+
+		expect(result.contextWindow).to.equal(128_000)
+		expect(result.maxAllowedSize).to.equal(98_000)
+	})
+})

--- a/src/core/context/context-management/context-window-utils.ts
+++ b/src/core/context/context-management/context-window-utils.ts
@@ -1,5 +1,4 @@
 import { ApiHandler } from "@core/api"
-import { OpenAiHandler } from "@core/api/providers/openai"
 
 /**
  * Gets context window information for the given API handler
@@ -8,13 +7,7 @@ import { OpenAiHandler } from "@core/api/providers/openai"
  * @returns An object containing the raw context window size and the effective max allowed size
  */
 export function getContextWindowInfo(api: ApiHandler) {
-	let contextWindow = api.getModel().info.contextWindow || 128_000
-	// FIXME: hack to get anyone using openai compatible with deepseek to have the proper context window instead of the default 128k. We need a way for the user to specify the context window for models they input through openai compatible
-
-	// Handle special cases like DeepSeek
-	if (api instanceof OpenAiHandler && api.getModel().id.toLowerCase().includes("deepseek")) {
-		contextWindow = 128_000
-	}
+	const contextWindow = api.getModel().info.contextWindow || 128_000
 
 	let maxAllowedSize: number
 	switch (contextWindow) {

--- a/src/core/hooks/__tests__/hook-factory.test.ts
+++ b/src/core/hooks/__tests__/hook-factory.test.ts
@@ -472,7 +472,11 @@ console.log(JSON.stringify({
 			stubHookDirs(sandbox, [globalHooksDir, workspaceHooksDir])
 		})
 
-		it("should execute both global and workspace hooks", async () => {
+		it("should execute both global and workspace hooks", async function () {
+			if (process.platform === "win32") {
+				this.timeout(WINDOWS_HOOK_TEST_TIMEOUT_MS)
+			}
+
 			// Create global hook
 			const globalHookPath = path.join(globalHooksDir, "PreToolUse")
 			const globalHookScript = `#!/usr/bin/env node


### PR DESCRIPTION
## Summary

- Preserve configured model context windows instead of forcing OpenAI-compatible DeepSeek models back to 128k
- Keep the existing 128k fallback when a model does not provide a context window
- Add regression coverage for configured large-context models and the default fallback

Fixes #10637

## Test plan

- `npx cross-env TS_NODE_PROJECT=./tsconfig.unit-test.json mocha --no-config --require ts-node/register --require tsconfig-paths/register --require source-map-support/register --require ./src/test/requires.ts src/core/context/context-management/__tests__/context-window-utils.test.ts`
- `npm run check-types`
- `npx biome lint src/core/context/context-management/context-window-utils.ts src/core/context/context-management/__tests__/context-window-utils.test.ts --no-errors-on-unmatched --files-ignore-unknown=true --diagnostic-level=error`
- `git diff --check`

Note: full `npm run lint` currently reports an existing hook dependency issue in `sdk/apps/cli/src/tui/views/config-view.tsx`, outside this change.
