### PR TITLE
fix: honor rejected command approvals

### DIFF
--- a/sdk/apps/cli/src/tui/views/config-view.tsx
+++ b/sdk/apps/cli/src/tui/views/config-view.tsx
@@ -261,13 +261,14 @@ export function ConfigPanelContent(props: ConfigPanelProps) {
 	const [navPos, setNavPos] = useState(0);
 
 	const displayName = resolveModelDisplayName(config);
+	const { loadConfigData } = props;
 
 	useEffect(() => {
 		if (
 			activeTab !== "tools" ||
 			pluginToolsLoaded ||
 			pluginToolsError ||
-			!props.loadConfigData
+			!loadConfigData
 		) {
 			return;
 		}
@@ -275,8 +276,7 @@ export function ConfigPanelContent(props: ConfigPanelProps) {
 		let cancelled = false;
 		setPluginToolsLoading(true);
 		setPluginToolsError(undefined);
-		props
-			.loadConfigData({ includePluginTools: true })
+		loadConfigData({ includePluginTools: true })
 			.then((nextData) => {
 				if (cancelled) {
 					return;
@@ -300,7 +300,7 @@ export function ConfigPanelContent(props: ConfigPanelProps) {
 		return () => {
 			cancelled = true;
 		};
-	}, [activeTab, pluginToolsError, pluginToolsLoaded, props.loadConfigData]);
+	}, [activeTab, loadConfigData, pluginToolsError, pluginToolsLoaded]);
 
 	const rows = useMemo(() => {
 		const r: ConfigRow[] = [];

--- a/src/core/task/TaskState.ts
+++ b/src/core/task/TaskState.ts
@@ -41,6 +41,7 @@ export class TaskState {
 
 	// Tool execution flags
 	didRejectTool = false
+	rejectedCommands: Set<string> = new Set()
 	didAlreadyUseTool = false
 	didEditFile = false
 	lastToolName = "" // Track last tool used for consecutive call detection

--- a/src/core/task/tools/handlers/ExecuteCommandToolHandler.ts
+++ b/src/core/task/tools/handlers/ExecuteCommandToolHandler.ts
@@ -55,6 +55,10 @@ export function resolveCommandTimeoutSeconds(
 	return isLikelyLongRunningCommand(command) ? LONG_RUNNING_COMMAND_TIMEOUT_SECONDS : DEFAULT_COMMAND_TIMEOUT_SECONDS
 }
 
+export function commandRejectionKey(command: string): string {
+	return command.trim().replace(/\s+/g, " ")
+}
+
 export class ExecuteCommandToolHandler implements IFullyManagedTool {
 	readonly name = ClineDefaultTool.BASH
 
@@ -158,6 +162,14 @@ export class ExecuteCommandToolHandler implements IFullyManagedTool {
 			// If no hint, use primary workspace (cwd)
 		}
 
+		const key = commandRejectionKey(actualCommand)
+		if (config.taskState.rejectedCommands.has(key)) {
+			config.taskState.didRejectTool = true
+			return formatResponse.toolError(
+				`The user already rejected this command in the current task: ${actualCommand}. Ask the user for confirmation or choose a different approach before trying it again.`,
+			)
+		}
+
 		// Check command permission validation (CLINE_COMMAND_PERMISSIONS env var)
 		const permissionResult = config.services.commandPermissionController.validateCommand(actualCommand)
 		if (!permissionResult.allowed) {
@@ -254,6 +266,7 @@ export class ExecuteCommandToolHandler implements IFullyManagedTool {
 				config,
 			)
 			if (!didApprove) {
+				config.taskState.rejectedCommands.add(key)
 				telemetryService.captureToolUsage(
 					config.ulid,
 					block.name,
@@ -328,6 +341,7 @@ export class ExecuteCommandToolHandler implements IFullyManagedTool {
 
 		if (userRejected) {
 			config.taskState.didRejectTool = true
+			config.taskState.rejectedCommands.add(key)
 		}
 
 		return result

--- a/src/core/task/tools/handlers/ExecuteCommandToolHandler.ts
+++ b/src/core/task/tools/handlers/ExecuteCommandToolHandler.ts
@@ -34,7 +34,7 @@ const LONG_RUNNING_COMMAND_PATTERNS: RegExp[] = [
 ]
 
 export function isLikelyLongRunningCommand(command: string): boolean {
-	const normalized = command.trim().replace(/\s+/g, " ")
+	const normalized = commandRejectionKey(command)
 	return LONG_RUNNING_COMMAND_PATTERNS.some((pattern) => pattern.test(normalized))
 }
 
@@ -162,11 +162,12 @@ export class ExecuteCommandToolHandler implements IFullyManagedTool {
 			// If no hint, use primary workspace (cwd)
 		}
 
-		const key = commandRejectionKey(actualCommand)
+		const rejectedCommandLabel = workspaceHint ? `@${workspaceHint}:${actualCommand}` : actualCommand
+		const key = commandRejectionKey(rejectedCommandLabel)
 		if (config.taskState.rejectedCommands.has(key)) {
 			config.taskState.didRejectTool = true
 			return formatResponse.toolError(
-				`The user already rejected this command in the current task: ${actualCommand}. Ask the user for confirmation or choose a different approach before trying it again.`,
+				`The user already rejected this command in the current task: ${rejectedCommandLabel}. Ask the user for confirmation or choose a different approach before trying it again.`,
 			)
 		}
 

--- a/src/core/task/tools/handlers/__tests__/ExecuteCommandToolHandler.timeout.test.ts
+++ b/src/core/task/tools/handlers/__tests__/ExecuteCommandToolHandler.timeout.test.ts
@@ -166,6 +166,8 @@ describe("ExecuteCommandToolHandler timeout policy", () => {
 
 		assert.equal(allowed, "executed")
 		assert.equal(setup.callbacks.executeCommandTool.calledOnce, true)
-		assert.equal(setup.callbacks.executeCommandTool.firstCall.args[0], 'cd "/tmp/frontend" && npm install')
+		const executedCommand = setup.callbacks.executeCommandTool.firstCall.args[0]
+		assert.match(executedCommand, /^cd ".*frontend" && npm install$/)
+		assert.equal(executedCommand.includes("backend"), false)
 	})
 })

--- a/src/core/task/tools/handlers/__tests__/ExecuteCommandToolHandler.timeout.test.ts
+++ b/src/core/task/tools/handlers/__tests__/ExecuteCommandToolHandler.timeout.test.ts
@@ -72,7 +72,7 @@ function config(options?: { response?: "yesButtonClicked" | "noButtonClicked"; a
 			api: { getModel: () => ({ id: "test-model" }) },
 			services: {
 				stateManager: {
-					getGlobalSettingsKey: (key: string) => (key === "mode" ? "act" : undefined),
+					getGlobalSettingsKey: (key: string) => (key === "mode" ? "act" : key === "hooksEnabled" ? false : undefined),
 					getApiConfiguration: () => ({
 						actModeApiProvider: "test-provider",
 						planModeApiProvider: "test-provider",
@@ -139,5 +139,33 @@ describe("ExecuteCommandToolHandler timeout policy", () => {
 		assert.equal(setup.callbacks.ask.called, false)
 		assert.equal(setup.callbacks.executeCommandTool.called, false)
 		assert.equal(setup.state.didRejectTool, true)
+	})
+
+	it("scopes rejected commands by workspace hint", async () => {
+		const handler = new ExecuteCommandToolHandler({} as never)
+		const setup = config({ response: "noButtonClicked" })
+		Object.assign(setup.config, {
+			isMultiRootEnabled: true,
+			workspaceManager: {
+				getRootByName: (name: string) => ({ name, path: `/tmp/${name}` }),
+				getRoots: () => [
+					{ name: "backend", path: "/tmp/backend" },
+					{ name: "frontend", path: "/tmp/frontend" },
+				],
+				getPrimaryRoot: () => ({ name: "backend", path: "/tmp/backend" }),
+				resolvePathToRoot: () => undefined,
+			},
+		})
+
+		const rejected = await handler.execute(setup.config, block("@backend:npm install"))
+		assert.equal(rejected, "The user denied this operation.")
+		assert.equal(setup.state.rejectedCommands.has(commandRejectionKey("@backend:npm install")), true)
+
+		setup.config.autoApprover.shouldAutoApproveTool = sinon.stub().returns([true, true])
+		const allowed = await handler.execute(setup.config, block("@frontend:npm install"))
+
+		assert.equal(allowed, "executed")
+		assert.equal(setup.callbacks.executeCommandTool.calledOnce, true)
+		assert.equal(setup.callbacks.executeCommandTool.firstCall.args[0], 'cd "/tmp/frontend" && npm install')
 	})
 })

--- a/src/core/task/tools/handlers/__tests__/ExecuteCommandToolHandler.timeout.test.ts
+++ b/src/core/task/tools/handlers/__tests__/ExecuteCommandToolHandler.timeout.test.ts
@@ -1,6 +1,95 @@
 import assert from "node:assert/strict"
 import { describe, it } from "mocha"
-import { isLikelyLongRunningCommand, resolveCommandTimeoutSeconds } from "../ExecuteCommandToolHandler"
+import sinon from "sinon"
+import type { ToolUse } from "../../../../assistant-message"
+import type { TaskConfig } from "../../types/TaskConfig"
+import {
+	commandRejectionKey,
+	ExecuteCommandToolHandler,
+	isLikelyLongRunningCommand,
+	resolveCommandTimeoutSeconds,
+} from "../ExecuteCommandToolHandler"
+
+function block(command: string): ToolUse {
+	return {
+		type: "tool_use",
+		name: "execute_command",
+		params: { command, requires_approval: "true" },
+		partial: false,
+	} as ToolUse
+}
+
+function config(options?: { response?: "yesButtonClicked" | "noButtonClicked"; auto?: [boolean, boolean] }) {
+	const state = {
+		didRejectTool: false,
+		rejectedCommands: new Set<string>(),
+		fileReadCache: new Map(),
+	} as {
+		didRejectTool: boolean
+		rejectedCommands: Set<string>
+		fileReadCache: Map<string, unknown>
+	}
+	const callbacks = {
+		say: sinon.stub().resolves(undefined),
+		ask: sinon.stub().resolves({ response: options?.response ?? "yesButtonClicked" }),
+		saveCheckpoint: sinon.stub().resolves(),
+		sayAndCreateMissingParamError: sinon.stub().resolves("missing"),
+		removeLastPartialMessageIfExistsWithType: sinon.stub().resolves(),
+		executeCommandTool: sinon.stub().resolves([false, "executed"]),
+		cancelRunningCommandTool: sinon.stub().resolves(false),
+		doesLatestTaskCompletionHaveNewChanges: sinon.stub().resolves(false),
+		updateFCListFromToolResponse: sinon.stub().resolves(),
+		shouldAutoApproveTool: sinon.stub().returns(false),
+		shouldAutoApproveToolWithPath: sinon.stub().resolves(false),
+		postStateToWebview: sinon.stub().resolves(),
+		reinitExistingTaskFromId: sinon.stub().resolves(),
+		cancelTask: sinon.stub().resolves(),
+		updateTaskHistory: sinon.stub().resolves([]),
+		applyLatestBrowserSettings: sinon.stub().resolves(undefined),
+		switchToActMode: sinon.stub().resolves(false),
+		setActiveHookExecution: sinon.stub().resolves(),
+		clearActiveHookExecution: sinon.stub().resolves(),
+		getActiveHookExecution: sinon.stub().resolves(undefined),
+		runUserPromptSubmitHook: sinon.stub().resolves({}),
+	}
+
+	return {
+		callbacks,
+		state,
+		config: {
+			taskId: "task-1",
+			ulid: "ulid-1",
+			cwd: "/tmp",
+			mode: "act",
+			strictPlanModeEnabled: false,
+			yoloModeToggled: false,
+			doubleCheckCompletionEnabled: false,
+			vscodeTerminalExecutionMode: "vscodeTerminal",
+			enableParallelToolCalling: true,
+			isSubagentExecution: false,
+			taskState: state,
+			messageState: {},
+			api: { getModel: () => ({ id: "test-model" }) },
+			services: {
+				stateManager: {
+					getGlobalSettingsKey: (key: string) => (key === "mode" ? "act" : undefined),
+					getApiConfiguration: () => ({
+						actModeApiProvider: "test-provider",
+						planModeApiProvider: "test-provider",
+					}),
+				},
+				commandPermissionController: { validateCommand: sinon.stub().returns({ allowed: true }) },
+				clineIgnoreController: { validateCommand: sinon.stub().returns(undefined) },
+			},
+			autoApprovalSettings: { enableNotifications: false },
+			autoApprover: { shouldAutoApproveTool: sinon.stub().returns(options?.auto ?? [false, false]) },
+			browserSettings: {},
+			focusChainSettings: {},
+			callbacks,
+			coordinator: {},
+		} as unknown as TaskConfig,
+	}
+}
 
 describe("ExecuteCommandToolHandler timeout policy", () => {
 	it("returns undefined when managed timeout is disabled", () => {
@@ -27,5 +116,28 @@ describe("ExecuteCommandToolHandler timeout policy", () => {
 		assert.equal(isLikelyLongRunningCommand("cargo build --release"), true)
 		assert.equal(isLikelyLongRunningCommand("docker build ."), true)
 		assert.equal(isLikelyLongRunningCommand("pytest -q"), true)
+	})
+
+	it("normalizes command rejection keys", () => {
+		assert.equal(commandRejectionKey("  npm   run   build  "), "npm run build")
+	})
+
+	it("blocks a command after the user rejects it once", async () => {
+		const handler = new ExecuteCommandToolHandler({} as never)
+		const setup = config({ response: "noButtonClicked" })
+
+		const rejected = await handler.execute(setup.config, block("npm run build"))
+		assert.equal(rejected, "The user denied this operation.")
+		assert.equal(setup.callbacks.executeCommandTool.called, false)
+		assert.equal(setup.state.rejectedCommands.has(commandRejectionKey("npm run build")), true)
+
+		setup.config.autoApprover.shouldAutoApproveTool = sinon.stub().returns([true, true])
+		setup.callbacks.ask.resetHistory()
+
+		const retry = await handler.execute(setup.config, block(" npm   run   build "))
+		assert.match(String(retry), /already rejected this command/)
+		assert.equal(setup.callbacks.ask.called, false)
+		assert.equal(setup.callbacks.executeCommandTool.called, false)
+		assert.equal(setup.state.didRejectTool, true)
 	})
 })


### PR DESCRIPTION
## Summary

Fixes #10783.

- Track commands rejected by the user for the lifetime of the current task.
- Block an exact retry before it can enter the approval or execution path again.
- Add coverage for rejection-key normalization and the rejected-command retry guard.

## Tests

- npm run test:unit -- src/core/task/tools/handlers/__tests__/ExecuteCommandToolHandler.timeout.test.ts
- npm run check-types
- npx biome lint src/core/task/TaskState.ts src/core/task/tools/handlers/ExecuteCommandToolHandler.ts src/core/task/tools/handlers/__tests__/ExecuteCommandToolHandler.timeout.test.ts --no-errors-on-unmatched --files-ignore-unknown=true --diagnostic-level=error
- git diff --check
