### PR TITLE
fix(sdk): restore ChatGPT subscription models

### DIFF
--- a/sdk/packages/core/src/services/llms/provider-defaults.test.ts
+++ b/sdk/packages/core/src/services/llms/provider-defaults.test.ts
@@ -79,19 +79,26 @@ describe("resolveProviderConfig", () => {
 
 	it("does not expose generic OpenAI models for OpenAI Codex OAuth fallback", async () => {
 		const resolved = await resolveProviderConfig("openai-codex");
-
-		expect(Object.keys(resolved?.knownModels ?? {}).sort()).toEqual([
-			"gpt-5-codex",
-			"gpt-5.1-codex",
-			"gpt-5.1-codex-max",
-			"gpt-5.1-codex-mini",
+		const modelIds = Object.keys(resolved?.knownModels ?? {});
+		const additionalOAuthModelIds = new Set([
 			"gpt-5.2",
-			"gpt-5.2-codex",
-			"gpt-5.3-codex",
-			"gpt-5.3-codex-spark",
 			"gpt-5.4",
 			"gpt-5.4-mini",
 		]);
+
+		expect(modelIds).toEqual(
+			expect.arrayContaining([
+				"gpt-5.1-codex-max",
+				"gpt-5.3-codex",
+				"gpt-5.4",
+				"gpt-5.4-mini",
+			]),
+		);
+		expect(
+			modelIds.every(
+				(id) => id.includes("codex") || additionalOAuthModelIds.has(id),
+			),
+		).toBe(true);
 		expect(resolved?.knownModels?.["gpt-5.4"]).toBeDefined();
 		expect(resolved?.knownModels?.["gpt-5.4-nano"]).toBeUndefined();
 	});
@@ -123,19 +130,16 @@ describe("resolveProviderConfig", () => {
 				accountId: "acct_123",
 			}),
 		);
-		expect(Object.keys(resolved?.knownModels ?? {}).sort()).toEqual([
-			"account-only-codex",
-			"gpt-5-codex",
-			"gpt-5.1-codex",
-			"gpt-5.1-codex-max",
-			"gpt-5.1-codex-mini",
-			"gpt-5.2",
-			"gpt-5.2-codex",
-			"gpt-5.3-codex",
-			"gpt-5.3-codex-spark",
-			"gpt-5.4",
-			"gpt-5.4-mini",
-		]);
+		expect(Object.keys(resolved?.knownModels ?? {})).toEqual(
+			expect.arrayContaining([
+				"account-only-codex",
+				"gpt-5.1-codex-max",
+				"gpt-5.2",
+				"gpt-5.3-codex",
+				"gpt-5.4",
+				"gpt-5.4-mini",
+			]),
+		);
 		expect(resolved?.knownModels?.["gpt-5.4-mini"]).toEqual(
 			expect.objectContaining({
 				name: "gpt-5.4-mini",

--- a/sdk/packages/core/src/services/llms/provider-defaults.test.ts
+++ b/sdk/packages/core/src/services/llms/provider-defaults.test.ts
@@ -80,17 +80,30 @@ describe("resolveProviderConfig", () => {
 	it("does not expose generic OpenAI models for OpenAI Codex OAuth fallback", async () => {
 		const resolved = await resolveProviderConfig("openai-codex");
 
+		expect(Object.keys(resolved?.knownModels ?? {}).sort()).toEqual([
+			"gpt-5-codex",
+			"gpt-5.1-codex",
+			"gpt-5.1-codex-max",
+			"gpt-5.1-codex-mini",
+			"gpt-5.2",
+			"gpt-5.2-codex",
+			"gpt-5.3-codex",
+			"gpt-5.3-codex-spark",
+			"gpt-5.4",
+			"gpt-5.4-mini",
+		]);
 		expect(resolved?.knownModels?.["gpt-5.4"]).toBeDefined();
 		expect(resolved?.knownModels?.["gpt-5.4-nano"]).toBeUndefined();
 	});
 
-	it("uses OpenAI Codex account models as the authoritative authenticated list", async () => {
+	it("merges OpenAI Codex account models into the ChatGPT OAuth fallback list", async () => {
 		const listModels = vi
 			.spyOn(Llms, "listOpenAICodexModels")
 			.mockResolvedValue([
 				{ id: "gpt-5.3-codex", name: "GPT-5.3 Codex" },
 				{ id: "gpt-5.4", name: "GPT-5.4" },
 				{ id: "gpt-5.4-mini", name: "gpt-5.4-mini" },
+				{ id: "account-only-codex", name: "Account Only Codex" },
 			]);
 
 		const resolved = await resolveProviderConfig(
@@ -111,7 +124,15 @@ describe("resolveProviderConfig", () => {
 			}),
 		);
 		expect(Object.keys(resolved?.knownModels ?? {}).sort()).toEqual([
+			"account-only-codex",
+			"gpt-5-codex",
+			"gpt-5.1-codex",
+			"gpt-5.1-codex-max",
+			"gpt-5.1-codex-mini",
+			"gpt-5.2",
+			"gpt-5.2-codex",
 			"gpt-5.3-codex",
+			"gpt-5.3-codex-spark",
 			"gpt-5.4",
 			"gpt-5.4-mini",
 		]);

--- a/sdk/packages/core/src/services/llms/provider-defaults.ts
+++ b/sdk/packages/core/src/services/llms/provider-defaults.ts
@@ -172,10 +172,12 @@ async function mergeKnownModels(
 			...userKnownModels,
 		});
 	}
-	const privateHasResults = Object.keys(privateModels).length > 0;
-	if (providerId === "openai-codex" && privateHasResults) {
+	if (providerId === "openai-codex") {
 		return Llms.sortModelsByReleaseDate({
+			...defaultKnownModels,
+			...liveModels,
 			...privateModels,
+			...publicModels,
 			...userKnownModels,
 		});
 	}

--- a/sdk/packages/llms/src/providers/builtins.test.ts
+++ b/sdk/packages/llms/src/providers/builtins.test.ts
@@ -64,6 +64,18 @@ describe("built-in provider metadata", () => {
 	it("enriches OpenAI Codex fallback models from the generated OpenAI catalog", async () => {
 		const models = await getModelsForProvider("openai-codex");
 
+		expect(Object.keys(models).sort()).toEqual([
+			"gpt-5-codex",
+			"gpt-5.1-codex",
+			"gpt-5.1-codex-max",
+			"gpt-5.1-codex-mini",
+			"gpt-5.2",
+			"gpt-5.2-codex",
+			"gpt-5.3-codex",
+			"gpt-5.3-codex-spark",
+			"gpt-5.4",
+			"gpt-5.4-mini",
+		]);
 		expect(models["gpt-5.4"]).toEqual(
 			expect.objectContaining({
 				name: "GPT-5.4",
@@ -78,5 +90,6 @@ describe("built-in provider metadata", () => {
 				contextWindow: expect.any(Number),
 			}),
 		);
+		expect(models["gpt-5.4-nano"]).toBeUndefined();
 	});
 });

--- a/sdk/packages/llms/src/providers/builtins.test.ts
+++ b/sdk/packages/llms/src/providers/builtins.test.ts
@@ -63,16 +63,28 @@ describe("built-in provider metadata", () => {
 
 	it("enriches OpenAI Codex fallback models from the generated OpenAI catalog", async () => {
 		const models = await getModelsForProvider("openai-codex");
-
-		expect(Object.keys(models).sort()).toEqual([
-			"gpt-5-codex",
-			"gpt-5.1-codex",
-			"gpt-5.1-codex-max",
-			"gpt-5.1-codex-mini",
+		const modelIds = Object.keys(models);
+		const additionalOAuthModelIds = new Set([
 			"gpt-5.2",
-			"gpt-5.2-codex",
-			"gpt-5.3-codex",
-			"gpt-5.3-codex-spark",
+			"gpt-5.4",
+			"gpt-5.4-mini",
+		]);
+
+		expect(modelIds).toEqual(
+			expect.arrayContaining([
+				"gpt-5.1-codex-max",
+				"gpt-5.3-codex",
+				"gpt-5.4",
+				"gpt-5.4-mini",
+			]),
+		);
+		expect(
+			modelIds.every(
+				(id) => id.includes("codex") || additionalOAuthModelIds.has(id),
+			),
+		).toBe(true);
+		expect(modelIds.filter((id) => !id.includes("codex")).sort()).toEqual([
+			"gpt-5.2",
 			"gpt-5.4",
 			"gpt-5.4-mini",
 		]);

--- a/sdk/packages/llms/src/providers/builtins.ts
+++ b/sdk/packages/llms/src/providers/builtins.ts
@@ -132,7 +132,13 @@ function buildClaudeCodeModels(): Record<string, ModelInfo> {
 
 function buildOpenAICodexModels(): Record<string, ModelInfo> {
 	const openaiModels = generatedModels("openai-native");
-	const fallbackIds = ["gpt-5.4", "gpt-5.3-codex"];
+	const additionalOAuthModelIds = ["gpt-5.2", "gpt-5.4", "gpt-5.4-mini"];
+	const fallbackIds = Array.from(
+		new Set([
+			...Object.keys(openaiModels).filter((id) => id.includes("codex")),
+			...additionalOAuthModelIds,
+		]),
+	);
 	return Object.fromEntries(
 		fallbackIds.map((id) => [
 			id,

--- a/sdk/packages/llms/src/providers/vendors/community.test.ts
+++ b/sdk/packages/llms/src/providers/vendors/community.test.ts
@@ -22,13 +22,13 @@ describe("listOpenAICodexModels", () => {
 		closeSpy.mockResolvedValue(undefined);
 	});
 
-	it("uses the codex executable on PATH by default", async () => {
+	it("lets the provider resolve its bundled Codex CLI by default", async () => {
 		await listOpenAICodexModels();
 
 		expect(createCodexAppServerSpy).toHaveBeenCalledWith(
 			expect.objectContaining({
-				defaultSettings: expect.objectContaining({
-					codexPath: "codex",
+				defaultSettings: expect.not.objectContaining({
+					codexPath: expect.anything(),
 				}),
 			}),
 		);

--- a/sdk/packages/llms/src/providers/vendors/community.test.ts
+++ b/sdk/packages/llms/src/providers/vendors/community.test.ts
@@ -25,12 +25,12 @@ describe("listOpenAICodexModels", () => {
 	it("lets the provider resolve its bundled Codex CLI by default", async () => {
 		await listOpenAICodexModels();
 
-		expect(createCodexAppServerSpy).toHaveBeenCalledWith(
-			expect.objectContaining({
-				defaultSettings: expect.not.objectContaining({
-					codexPath: expect.anything(),
-				}),
-			}),
+		const options = createCodexAppServerSpy.mock.calls[0]?.[0] as
+			| { defaultSettings?: Record<string, unknown> }
+			| undefined;
+		expect(options?.defaultSettings).toBeDefined();
+		expect(Object.hasOwn(options?.defaultSettings ?? {}, "codexPath")).toBe(
+			false,
 		);
 		expect(listModelsSpy).toHaveBeenCalledWith(["openai"]);
 		expect(closeSpy).toHaveBeenCalled();

--- a/sdk/packages/llms/src/providers/vendors/community.ts
+++ b/sdk/packages/llms/src/providers/vendors/community.ts
@@ -63,7 +63,9 @@ export async function listOpenAICodexModels(
 			: undefined;
 	const provider = createCodexAppServer({
 		defaultSettings: {
-			codexPath: options.codexPath,
+			...(options.codexPath !== undefined
+				? { codexPath: options.codexPath }
+				: {}),
 			cwd: options.cwd,
 			env: options.env,
 			logger: false,

--- a/sdk/packages/llms/src/providers/vendors/community.ts
+++ b/sdk/packages/llms/src/providers/vendors/community.ts
@@ -63,7 +63,7 @@ export async function listOpenAICodexModels(
 			: undefined;
 	const provider = createCodexAppServer({
 		defaultSettings: {
-			codexPath: options.codexPath ?? "codex",
+			codexPath: options.codexPath,
 			cwd: options.cwd,
 			env: options.env,
 			logger: false,


### PR DESCRIPTION
This fixes a ChatGPT subscription provider regression in the SDK where users could sign in successfully but then hit failures while the provider refreshed models, or see an unexpectedly small model picker after changing models.

What users saw:

- Sign-in could crash during the ChatGPT subscription model refresh path on machines without a global `codex` executable.
- The ChatGPT subscription provider could show only a few models instead of the expected ChatGPT and Codex model set.

Why it happened:

- The ChatGPT subscription provider uses the Codex app-server provider internally to ask the ChatGPT backend which models are available. We were forcing `codexPath` to `"codex"` even though `ai-sdk-provider-codex-cli` can resolve its bundled Codex CLI when that option is omitted. That made the refresh path depend on a global binary that end users may not have.
- The SDK recently moved the OpenAI catalog identity from `openai` to `openai-native`, while models.dev still exposes the provider as `openai`. Some call sites were fixed, but the ChatGPT subscription provider ended up with a tiny custom fallback list instead of a filtered OpenAI catalog. Authenticated model refresh could then replace that fallback with an even smaller account response.

What changed:

- Let the Codex app-server provider resolve its bundled Codex CLI by default instead of forcing `codexPath: "codex"`.
- Build the ChatGPT subscription fallback models from the generated `openai-native` catalog, filtered to Codex model ids plus the non-Codex ChatGPT OAuth ids that should be visible.
- Merge authenticated ChatGPT account models into the fallback list instead of treating the account response as the complete model picker list.
- Add regression coverage for the filtered ChatGPT fallback list, the authenticated merge behavior, and the bundled CLI resolution path.

Models.dev provides the base OpenAI catalog, and the ChatGPT OAuth provider filters that catalog rather than exposing every generic OpenAI API model.
