### PR TITLE
fix: detect plain context overflow errors

### DIFF
--- a/sdk/apps/cli/src/tui/views/config-view.tsx
+++ b/sdk/apps/cli/src/tui/views/config-view.tsx
@@ -261,13 +261,14 @@ export function ConfigPanelContent(props: ConfigPanelProps) {
 	const [navPos, setNavPos] = useState(0);
 
 	const displayName = resolveModelDisplayName(config);
+	const { loadConfigData } = props;
 
 	useEffect(() => {
 		if (
 			activeTab !== "tools" ||
 			pluginToolsLoaded ||
 			pluginToolsError ||
-			!props.loadConfigData
+			!loadConfigData
 		) {
 			return;
 		}
@@ -275,8 +276,7 @@ export function ConfigPanelContent(props: ConfigPanelProps) {
 		let cancelled = false;
 		setPluginToolsLoading(true);
 		setPluginToolsError(undefined);
-		props
-			.loadConfigData({ includePluginTools: true })
+		loadConfigData({ includePluginTools: true })
 			.then((nextData) => {
 				if (cancelled) {
 					return;
@@ -300,7 +300,7 @@ export function ConfigPanelContent(props: ConfigPanelProps) {
 		return () => {
 			cancelled = true;
 		};
-	}, [activeTab, pluginToolsError, pluginToolsLoaded, props.loadConfigData]);
+	}, [activeTab, loadConfigData, pluginToolsError, pluginToolsLoaded]);
 
 	const rows = useMemo(() => {
 		const r: ConfigRow[] = [];

--- a/src/core/context/context-management/__tests__/context-error-handling.test.ts
+++ b/src/core/context/context-management/__tests__/context-error-handling.test.ts
@@ -27,6 +27,12 @@ describe("checkContextWindowExceededError", () => {
 		expect(checkContextWindowExceededError(error)).to.equal(true)
 	})
 
+	it("does not classify unrelated long input validation errors", () => {
+		const error = new Error("input is too long for this field")
+
+		expect(checkContextWindowExceededError(error)).to.equal(false)
+	})
+
 	it("does not classify unrelated 400 errors as context window failures", () => {
 		const error = new Error("OpenRouter API Error 400: Invalid API key")
 

--- a/src/core/context/context-management/__tests__/context-error-handling.test.ts
+++ b/src/core/context/context-management/__tests__/context-error-handling.test.ts
@@ -4,9 +4,7 @@ import { checkContextWindowExceededError } from "../context-error-handling"
 describe("checkContextWindowExceededError", () => {
 	it("detects OpenRouter context errors using structured status", () => {
 		const error = Object.assign(
-			new Error(
-				"This endpoint's maximum context length is 204800 tokens. However, you requested about 244027 tokens.",
-			),
+			new Error("This endpoint's maximum context length is 204800 tokens. However, you requested about 244027 tokens."),
 			{
 				status: 400,
 			},
@@ -19,6 +17,12 @@ describe("checkContextWindowExceededError", () => {
 		const error = new Error(
 			'OpenRouter Mid-Stream Error: {"status":400,"message":"This endpoint\'s maximum context length is 200000 tokens"}',
 		)
+
+		expect(checkContextWindowExceededError(error)).to.equal(true)
+	})
+
+	it("detects plain context overflow messages without structured status", () => {
+		const error = new Error("prompt is too long: 228307 tokens > 200000 maximum [failed to stream chunk]")
 
 		expect(checkContextWindowExceededError(error)).to.equal(true)
 	})

--- a/src/core/context/context-management/context-error-handling.ts
+++ b/src/core/context/context-management/context-error-handling.ts
@@ -34,7 +34,7 @@ function checkIsGenericContextWindowError(error: any): boolean {
 			/prompt is too long.*tokens?\s*>\s*\d+\s*maximum/i,
 			/input token count exceeds.*maximum.*tokens? allowed/i,
 			/requested input length.*exceeds.*maximum input length/i,
-			/input is too long/i,
+			/input is too long.*tokens?/i,
 		] as const
 
 		return messages.some((message) => CONTEXT_ERROR_PATTERNS.some((pattern) => pattern.test(String(message))))

--- a/src/core/context/context-management/context-error-handling.ts
+++ b/src/core/context/context-management/context-error-handling.ts
@@ -2,6 +2,7 @@ import LengthFinishReasonError, { APIError } from "openai"
 
 export function checkContextWindowExceededError(error: unknown): boolean {
 	return (
+		checkIsGenericContextWindowError(error) ||
 		checkIsOpenAIContextWindowError(error) ||
 		checkIsOpenRouterContextWindowError(error) ||
 		checkIsAnthropicContextWindowError(error) ||
@@ -9,6 +10,37 @@ export function checkContextWindowExceededError(error: unknown): boolean {
 		checkIsBedrockContextWindowError(error) ||
 		checkIsVercelContextWindowError(error)
 	)
+}
+
+function getErrorMessages(error: any): string[] {
+	return [
+		error?.message,
+		error?.error?.message,
+		error?.error?.param?.message,
+		error?.error?.param?.error,
+		error?.error?.error?.message,
+		error?.error?.value?.error_message,
+	].filter((message) => message != null)
+}
+
+function checkIsGenericContextWindowError(error: any): boolean {
+	try {
+		const messages = getErrorMessages(error)
+		if (messages.length === 0) {
+			return false
+		}
+
+		const CONTEXT_ERROR_PATTERNS = [
+			/prompt is too long.*tokens?\s*>\s*\d+\s*maximum/i,
+			/input token count exceeds.*maximum.*tokens? allowed/i,
+			/requested input length.*exceeds.*maximum input length/i,
+			/input is too long/i,
+		] as const
+
+		return messages.some((message) => CONTEXT_ERROR_PATTERNS.some((pattern) => pattern.test(String(message))))
+	} catch {
+		return false
+	}
 }
 
 function checkIsOpenRouterContextWindowError(error: any): boolean {
@@ -129,14 +161,7 @@ export function checkIsVercelContextWindowError(error: any): boolean {
 			return true
 		}
 
-		const messages: string[] = [
-			error?.message,
-			error?.error?.message,
-			error?.error?.param?.message,
-			error?.error?.param?.error,
-			error?.error?.error?.message,
-			error?.error?.value?.error_message, // Alibaba Qwen validation errors
-		].filter((msg) => msg != null)
+		const messages = getErrorMessages(error)
 
 		if (messages.length === 0) {
 			return false


### PR DESCRIPTION
Fixes #9660.
Detects plain context overflow messages so failed first chunks enter the existing compaction retry path instead of generic retry handling.