### PR TITLE
fix(cli): avoid ChatGPT model refresh on startup

### DIFF
--- a/sdk/packages/core/src/services/llms/provider-defaults.test.ts
+++ b/sdk/packages/core/src/services/llms/provider-defaults.test.ts
@@ -103,15 +103,10 @@ describe("resolveProviderConfig", () => {
 		expect(resolved?.knownModels?.["gpt-5.4-nano"]).toBeUndefined();
 	});
 
-	it("merges OpenAI Codex account models into the ChatGPT OAuth fallback list", async () => {
+	it("does not spawn Codex app-server while resolving ChatGPT OAuth models", async () => {
 		const listModels = vi
 			.spyOn(Llms, "listOpenAICodexModels")
-			.mockResolvedValue([
-				{ id: "gpt-5.3-codex", name: "GPT-5.3 Codex" },
-				{ id: "gpt-5.4", name: "GPT-5.4" },
-				{ id: "gpt-5.4-mini", name: "gpt-5.4-mini" },
-				{ id: "account-only-codex", name: "Account Only Codex" },
-			]);
+			.mockRejectedValue(new Error("should not be called"));
 
 		const resolved = await resolveProviderConfig(
 			"openai-codex",
@@ -124,15 +119,9 @@ describe("resolveProviderConfig", () => {
 			},
 		);
 
-		expect(listModels).toHaveBeenCalledWith(
-			expect.objectContaining({
-				accessToken: "oauth-token",
-				accountId: "acct_123",
-			}),
-		);
+		expect(listModels).not.toHaveBeenCalled();
 		expect(Object.keys(resolved?.knownModels ?? {})).toEqual(
 			expect.arrayContaining([
-				"account-only-codex",
 				"gpt-5.1-codex-max",
 				"gpt-5.2",
 				"gpt-5.3-codex",
@@ -142,7 +131,7 @@ describe("resolveProviderConfig", () => {
 		);
 		expect(resolved?.knownModels?.["gpt-5.4-mini"]).toEqual(
 			expect.objectContaining({
-				name: "gpt-5.4-mini",
+				name: "GPT-5.4 mini",
 				maxInputTokens: 272_000,
 				contextWindow: 400_000,
 			}),

--- a/sdk/packages/core/src/services/llms/provider-defaults.ts
+++ b/sdk/packages/core/src/services/llms/provider-defaults.ts
@@ -175,7 +175,6 @@ async function mergeKnownModels(
 		return Llms.sortModelsByReleaseDate({
 			...defaultKnownModels,
 			...liveModels,
-			...privateModels,
 			...publicModels,
 			...userKnownModels,
 		});

--- a/sdk/packages/core/src/services/llms/provider-defaults.ts
+++ b/sdk/packages/core/src/services/llms/provider-defaults.ts
@@ -1,7 +1,6 @@
 /** biome-ignore-all lint/style/noNonNullAssertion: static */
 
 import * as Llms from "@cline/llms";
-import { decodeJwtPayload } from "../../auth/utils";
 import {
 	fetchModelIdsFromSource,
 	resolveModelsSourceUrl,
@@ -234,34 +233,6 @@ function resolvePrivateCacheKey(
 	return `${providerId}:${normalizeBaseUrl(config.baseUrl)}:${fingerprint(resolveAuthToken(config) ?? "")}`;
 }
 
-function deriveOpenAICodexAccountId(
-	accessToken: string | undefined,
-): string | undefined {
-	const trimmed = accessToken?.trim();
-	if (!trimmed) {
-		return undefined;
-	}
-	const payload = decodeJwtPayload(trimmed) as {
-		"https://api.openai.com/auth"?: { chatgpt_account_id?: string };
-		organizations?: Array<{ id?: string }>;
-		chatgpt_account_id?: string;
-	} | null;
-	const authAccountId =
-		payload?.["https://api.openai.com/auth"]?.chatgpt_account_id;
-	if (typeof authAccountId === "string" && authAccountId.length > 0) {
-		return authAccountId;
-	}
-	const orgAccountId = payload?.organizations?.[0]?.id;
-	if (typeof orgAccountId === "string" && orgAccountId.length > 0) {
-		return orgAccountId;
-	}
-	const rootAccountId = payload?.chatgpt_account_id;
-	if (typeof rootAccountId === "string" && rootAccountId.length > 0) {
-		return rootAccountId;
-	}
-	return undefined;
-}
-
 async function fetchWithTimeout(
 	input: string,
 	init: RequestInit,
@@ -327,23 +298,6 @@ function buildModelFromPrivateSource(
 		releaseDate: input.releaseDate,
 		status: "active",
 	};
-}
-
-function buildOpenAICodexPrivateModelInfo(
-	model: Llms.OpenAICodexListedModel,
-): ModelInfo {
-	const generated =
-		Llms.getGeneratedModelsForProvider("openai-native")[model.id];
-	if (generated) {
-		return {
-			...generated,
-			id: model.id,
-			name: model.name ?? generated.name ?? model.id,
-		};
-	}
-	return buildModelFromPrivateSource(model.id, {
-		name: model.name ?? model.id,
-	});
 }
 
 interface BasetenModelResponse {
@@ -522,33 +476,6 @@ async function fetchLiteLlmPrivateModels(
 	return models;
 }
 
-async function fetchOpenAICodexPrivateModels(
-	config: ProviderConfig,
-	token: string,
-): Promise<Record<string, ModelInfo>> {
-	const models = await Llms.listOpenAICodexModels({
-		accessToken: token,
-		accountId: config.accountId ?? deriveOpenAICodexAccountId(token),
-		cwd:
-			typeof config.codex?.defaultSettings?.cwd === "string"
-				? config.codex.defaultSettings.cwd
-				: undefined,
-		codexPath:
-			typeof config.codex?.defaultSettings?.codexPath === "string"
-				? config.codex.defaultSettings.codexPath
-				: undefined,
-		env:
-			config.codex?.defaultSettings?.env &&
-			typeof config.codex.defaultSettings.env === "object" &&
-			!Array.isArray(config.codex.defaultSettings.env)
-				? (config.codex.defaultSettings.env as Record<string, string>)
-				: undefined,
-	});
-	return Object.fromEntries(
-		models.map((model) => [model.id, buildOpenAICodexPrivateModelInfo(model)]),
-	);
-}
-
 type PrivateProviderModelFetcher = (
 	config: ProviderConfig,
 	token: string,
@@ -561,7 +488,6 @@ const PRIVATE_PROVIDER_MODEL_FETCHERS: Record<
 	baseten: fetchBasetenPrivateModels,
 	hicap: fetchHicapPrivateModels,
 	litellm: fetchLiteLlmPrivateModels,
-	"openai-codex": fetchOpenAICodexPrivateModels,
 };
 
 const PUBLIC_MODELS_CACHE = new Map<


### PR DESCRIPTION
### Related Issue

Issue: #XXXX

### Description

This is a stability hotfix for users who updated to the latest CLI and saw Cline immediately exit with `zsh: killed cline`.

The likely failure mode is tied to ChatGPT subscription as the last-used provider. On interactive startup, the CLI resolves provider config so the model picker and session config are ready. For OAuth-backed ChatGPT subscription, that resolution path was also attempting a private account model refresh. That refresh uses `ai-sdk-provider-codex-cli`, which starts a Codex app-server process under the hood.

That means simply launching `cline` could spawn a native Codex child process before the user gets into the TUI. If that native path is killed by macOS, quarantine, memory pressure, security tooling, or any other environment-specific condition, the top-level npm wrapper mirrors the signal and the shell reports `zsh: killed cline`.

We do not need that private refresh on startup anymore. PR #10836 already changed the ChatGPT subscription provider to have a filtered fallback model list built from the generated `openai-native` models.dev catalog. That fallback gives users the expected ChatGPT/Codex model picker without needing to ask the account-specific Codex app-server at launch.

This PR removes `openai-codex` from the private model fetcher registry. The result:

- Resolving ChatGPT subscription provider config no longer spawns Codex app-server.
- CLI startup with ChatGPT as last-used provider uses the filtered bundled catalog.
- The model picker still excludes generic OpenAI API-only models like `gpt-5.4-nano`.
- Actual ChatGPT subscription requests are unchanged.

Tradeoff:

We lose account-specific model discovery during config resolution. If OpenAI quietly grants a model to one account before it lands in our generated catalog, Cline will not auto-discover it through startup refresh. If an account lacks a model from our filtered catalog, selecting it may fail at request time instead of being hidden. For a production crash where users cannot launch Cline at all, avoiding native process spawn during startup is the safer behavior.

### Test Procedure

Focused tests:

```sh
cd sdk/packages/core
bun vitest run src/services/llms/provider-defaults.test.ts --config vitest.config.ts
bun run typecheck
```

Related provider tests:

```sh
cd sdk/packages/llms
bun vitest run src/providers/builtins.test.ts src/providers/vendors/community.test.ts --config vitest.config.ts
```

I also installed and launched the published `cline@3.0.6` Linux package locally with a fake persisted `openai-codex` last-used provider config. That did not reproduce the macOS `SIGKILL`, but it confirmed the production package can reach the TUI with ChatGPT as the last provider. This PR removes the remaining startup path that can spawn the native Codex app-server during that config resolution.

Pre-commit also ran `bun run types` and biome on the staged files.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Not applicable. This is startup and provider-resolution behavior with no UI change.

### Additional Notes

Recommended release smoke before publishing:

- Install the built package on macOS.
- Use a config where `openai-codex` is the last-used provider with saved OAuth settings.
- Run `cline` with no arguments and confirm it reaches the TUI instead of being killed.
