### PR TITLE
fix(vscode): open settings before account setup

### DIFF
--- a/sdk/apps/cli/src/tui/views/config-view.tsx
+++ b/sdk/apps/cli/src/tui/views/config-view.tsx
@@ -236,7 +236,7 @@ function appendToolRows(
 }
 
 export function ConfigPanelContent(props: ConfigPanelProps) {
-	const { resolve, dismiss, dialogId, config } = props;
+	const { resolve, dismiss, dialogId, config, loadConfigData } = props;
 	const { height } = useTerminalDimensions();
 
 	const [mode, setMode] = useState(props.currentMode);
@@ -267,7 +267,7 @@ export function ConfigPanelContent(props: ConfigPanelProps) {
 			activeTab !== "tools" ||
 			pluginToolsLoaded ||
 			pluginToolsError ||
-			!props.loadConfigData
+			!loadConfigData
 		) {
 			return;
 		}
@@ -275,8 +275,7 @@ export function ConfigPanelContent(props: ConfigPanelProps) {
 		let cancelled = false;
 		setPluginToolsLoading(true);
 		setPluginToolsError(undefined);
-		props
-			.loadConfigData({ includePluginTools: true })
+		loadConfigData({ includePluginTools: true })
 			.then((nextData) => {
 				if (cancelled) {
 					return;
@@ -300,7 +299,7 @@ export function ConfigPanelContent(props: ConfigPanelProps) {
 		return () => {
 			cancelled = true;
 		};
-	}, [activeTab, pluginToolsError, pluginToolsLoaded, props.loadConfigData]);
+	}, [activeTab, loadConfigData, pluginToolsError, pluginToolsLoaded]);
 
 	const rows = useMemo(() => {
 		const r: ConfigRow[] = [];

--- a/webview-ui/src/App.tsx
+++ b/webview-ui/src/App.tsx
@@ -97,6 +97,10 @@ const AppContent = () => {
 		return null
 	}
 
+	if (showWelcome && showSettings) {
+		return <SettingsView onDone={hideSettings} targetSection={settingsTargetSection} />
+	}
+
 	if (showWelcome) {
 		return <OnboardingView />
 	}


### PR DESCRIPTION
### Related Issue

**Issue:** #10636

### Description

This fixes the settings gear path for first-run users who have not completed account setup. When the welcome/onboarding view is active, a settings navigation event can now render `SettingsView` instead of being hidden behind the welcome view. Closing settings returns to onboarding as before.

The PR also includes the current `config-view` hook dependency cleanup needed for the repo lint gate on this branch.

### Test Procedure

- `npm run lint -- webview-ui/src/App.tsx sdk/apps/cli/src/tui/views/config-view.tsx`
- `npm run check-types`
- `git diff --check origin/main...HEAD`

The main risk is accidentally bypassing onboarding. This keeps onboarding as the default view and only shows settings when the settings state is explicitly active.

### Type of Change

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Refactor Changes
-   [ ] Cosmetic Changes
-   [ ] Documentation update
-   [ ] Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Not included; this is a small render-state fix.

### Additional Notes

None.