### PR TITLE
fix(sdk): fix ChatGPT OAuth model catalog

### DIFF
--- a/sdk/packages/core/src/services/llms/provider-defaults.test.ts
+++ b/sdk/packages/core/src/services/llms/provider-defaults.test.ts
@@ -48,6 +48,66 @@ describe("resolveProviderConfig", () => {
 		);
 	});
 
+	it("uses the live OpenAI catalog for ChatGPT subscription models", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async () => {
+				return new Response(
+					JSON.stringify({
+						openai: {
+							models: {
+								"gpt-5.6-live": {
+									name: "GPT-5.6 Live",
+									tool_call: true,
+									reasoning: true,
+									family: "gpt",
+									release_date: "2027-01-01",
+								},
+								"gpt-5.4-live": {
+									name: "GPT-5.4 Live",
+									tool_call: true,
+									reasoning: true,
+									family: "gpt",
+									release_date: "2027-01-02",
+								},
+								"gpt-5.4-nano": {
+									name: "GPT-5.4 nano",
+									tool_call: true,
+									reasoning: true,
+									family: "gpt-nano",
+									release_date: "2027-01-03",
+								},
+								"o-live": {
+									name: "o live",
+									tool_call: true,
+									reasoning: true,
+									family: "o",
+									release_date: "2027-01-04",
+								},
+							},
+						},
+					}),
+					{
+						status: 200,
+						headers: { "content-type": "application/json" },
+					},
+				);
+			}),
+		);
+
+		const resolved = await resolveProviderConfig("openai-codex", {
+			loadLatestOnInit: true,
+			failOnError: false,
+			cacheTtlMs: 0,
+			url: "https://models.test/api.json",
+		});
+
+		expect(resolved?.knownModels?.["gpt-5.6-live"]?.name).toBe("GPT-5.6 Live");
+		expect(resolved?.knownModels?.["gpt-5.4-live"]).toBeUndefined();
+		expect(resolved?.knownModels?.["gpt-5.4-nano"]).toBeUndefined();
+		expect(resolved?.knownModels?.["o-live"]).toBeUndefined();
+	});
+
 	it("uses built-in modelsSourceUrl for keyless local provider models", async () => {
 		const fetchMock = vi.fn(async () => {
 			return new Response(
@@ -77,30 +137,34 @@ describe("resolveProviderConfig", () => {
 		expect(Object.keys(resolved?.knownModels ?? {})).toEqual(["local-llama"]);
 	});
 
-	it("does not expose generic OpenAI models for OpenAI Codex OAuth fallback", async () => {
+	it("derives ChatGPT subscription models from the generated OpenAI catalog", async () => {
 		const resolved = await resolveProviderConfig("openai-codex");
+		const openAiResolved = await resolveProviderConfig("openai-native");
 		const modelIds = Object.keys(resolved?.knownModels ?? {});
-		const additionalOAuthModelIds = new Set([
-			"gpt-5.2",
-			"gpt-5.4",
-			"gpt-5.4-mini",
-		]);
 
 		expect(modelIds).toEqual(
 			expect.arrayContaining([
-				"gpt-5.1-codex-max",
+				"gpt-5.5",
+				"gpt-5.5-pro",
+				"gpt-5.2",
 				"gpt-5.3-codex",
+				"gpt-5.3-codex-spark",
 				"gpt-5.4",
 				"gpt-5.4-mini",
 			]),
 		);
-		expect(
-			modelIds.every(
-				(id) => id.includes("codex") || additionalOAuthModelIds.has(id),
-			),
-		).toBe(true);
+		expect(modelIds).not.toContain("gpt-5.1-codex-max");
+		expect(modelIds).not.toContain("gpt-5.2-codex");
+		expect(modelIds).not.toContain("gpt-5.4-nano");
+		expect(modelIds).not.toContain("o3");
 		expect(resolved?.knownModels?.["gpt-5.4"]).toBeDefined();
-		expect(resolved?.knownModels?.["gpt-5.4-nano"]).toBeUndefined();
+		expect(resolved?.knownModels?.["gpt-5.5"]).toEqual(
+			expect.objectContaining({
+				...openAiResolved?.knownModels?.["gpt-5.5"],
+				maxInputTokens: 272_000,
+				contextWindow: 400_000,
+			}),
+		);
 	});
 
 	it("does not spawn Codex app-server while resolving ChatGPT OAuth models", async () => {
@@ -122,11 +186,12 @@ describe("resolveProviderConfig", () => {
 		expect(listModels).not.toHaveBeenCalled();
 		expect(Object.keys(resolved?.knownModels ?? {})).toEqual(
 			expect.arrayContaining([
-				"gpt-5.1-codex-max",
 				"gpt-5.2",
 				"gpt-5.3-codex",
+				"gpt-5.3-codex-spark",
 				"gpt-5.4",
 				"gpt-5.4-mini",
+				"gpt-5.5",
 			]),
 		);
 		expect(resolved?.knownModels?.["gpt-5.4-mini"]).toEqual(

--- a/sdk/packages/core/src/services/llms/provider-defaults.ts
+++ b/sdk/packages/core/src/services/llms/provider-defaults.ts
@@ -174,7 +174,7 @@ async function mergeKnownModels(
 	if (providerId === "openai-codex") {
 		return Llms.sortModelsByReleaseDate({
 			...defaultKnownModels,
-			...liveModels,
+			...Llms.filterOpenAICodexModels(liveModels),
 			...publicModels,
 			...userKnownModels,
 		});
@@ -633,7 +633,7 @@ async function getPrivateProviderModels(
 async function fetchLiveModelsCatalog(
 	url: string,
 ): Promise<Record<string, Record<string, ModelInfo>>> {
-	return Llms.fetchModelsDevProviderModels(url);
+	return Llms.fetchModelsDevProviderModels(url, globalThis.fetch);
 }
 
 export async function getLiveModelsCatalog(

--- a/sdk/packages/llms/src/index.browser.ts
+++ b/sdk/packages/llms/src/index.browser.ts
@@ -6,6 +6,7 @@ export type {
 	ProviderInfo,
 } from "./models";
 export {
+	filterOpenAICodexModels,
 	getAllProviders,
 	getGeneratedModelsForProvider,
 	getModelsForProvider,

--- a/sdk/packages/llms/src/index.ts
+++ b/sdk/packages/llms/src/index.ts
@@ -9,6 +9,7 @@ export type {
 } from "./models";
 export {
 	fetchModelsDevProviderModels,
+	filterOpenAICodexModels,
 	getAllProviders,
 	getGeneratedModelsForProvider,
 	getGeneratedProviderModels,

--- a/sdk/packages/llms/src/models.ts
+++ b/sdk/packages/llms/src/models.ts
@@ -28,3 +28,4 @@ export {
 	resetRegistry,
 	unregisterProvider,
 } from "./providers/model-registry";
+export { filterOpenAICodexModels } from "./providers/openai-codex-models";

--- a/sdk/packages/llms/src/providers/builtins.test.ts
+++ b/sdk/packages/llms/src/providers/builtins.test.ts
@@ -61,47 +61,46 @@ describe("built-in provider metadata", () => {
 		});
 	});
 
-	it("enriches OpenAI Codex fallback models from the generated OpenAI catalog", async () => {
-		const models = await getModelsForProvider("openai-codex");
-		const modelIds = Object.keys(models);
-		const additionalOAuthModelIds = new Set([
-			"gpt-5.2",
-			"gpt-5.4",
-			"gpt-5.4-mini",
-		]);
+	it("derives ChatGPT subscription models from the generated OpenAI catalog", async () => {
+		const chatGptModels = await getModelsForProvider("openai-codex");
+		const openAiModels = await getModelsForProvider("openai-native");
+		const modelIds = Object.keys(chatGptModels);
 
 		expect(modelIds).toEqual(
 			expect.arrayContaining([
-				"gpt-5.1-codex-max",
+				"gpt-5.5",
+				"gpt-5.5-pro",
+				"gpt-5.2",
 				"gpt-5.3-codex",
+				"gpt-5.3-codex-spark",
 				"gpt-5.4",
 				"gpt-5.4-mini",
 			]),
 		);
-		expect(
-			modelIds.every(
-				(id) => id.includes("codex") || additionalOAuthModelIds.has(id),
-			),
-		).toBe(true);
-		expect(modelIds.filter((id) => !id.includes("codex")).sort()).toEqual([
-			"gpt-5.2",
-			"gpt-5.4",
-			"gpt-5.4-mini",
-		]);
-		expect(models["gpt-5.4"]).toEqual(
+		expect(modelIds).not.toContain("gpt-5.1-codex-max");
+		expect(modelIds).not.toContain("gpt-5.2-codex");
+		expect(modelIds).not.toContain("gpt-5.4-nano");
+		expect(modelIds).not.toContain("o3");
+		expect(chatGptModels["gpt-5.5"]).toEqual(
+			expect.objectContaining({
+				...openAiModels["gpt-5.5"],
+				maxInputTokens: 272_000,
+				contextWindow: 400_000,
+			}),
+		);
+		expect(chatGptModels["gpt-5.4"]).toEqual(
 			expect.objectContaining({
 				name: "GPT-5.4",
 				maxInputTokens: expect.any(Number),
 				contextWindow: expect.any(Number),
 			}),
 		);
-		expect(models["gpt-5.3-codex"]).toEqual(
+		expect(chatGptModels["gpt-5.3-codex"]).toEqual(
 			expect.objectContaining({
 				name: "GPT-5.3 Codex",
 				maxInputTokens: expect.any(Number),
 				contextWindow: expect.any(Number),
 			}),
 		);
-		expect(models["gpt-5.4-nano"]).toBeUndefined();
 	});
 });

--- a/sdk/packages/llms/src/providers/builtins.ts
+++ b/sdk/packages/llms/src/providers/builtins.ts
@@ -15,6 +15,7 @@ import type {
 	ProviderClient,
 	ProviderProtocol,
 } from "../catalog/types";
+import { filterOpenAICodexModels } from "./openai-codex-models";
 import {
 	ANTHROPIC_AND_QWEN_CACHE_ROUTING_METADATA,
 	ANTHROPIC_ROUTING_METADATA,
@@ -25,6 +26,7 @@ export const DEFAULT_INTERNAL_OCA_BASE_URL =
 	"https://code-internal.aiservice.us-chicago-1.oci.oraclecloud.com/20250206/app/litellm";
 export const DEFAULT_EXTERNAL_OCA_BASE_URL =
 	"https://code.aiservice.us-chicago-1.oci.oraclecloud.com/20250206/app/litellm";
+const OPENAI_CODEX_DEFAULT_MODEL_ID = "gpt-5.4";
 
 export type ProviderFamily =
 	| "openai"
@@ -131,24 +133,7 @@ function buildClaudeCodeModels(): Record<string, ModelInfo> {
 }
 
 function buildOpenAICodexModels(): Record<string, ModelInfo> {
-	const openaiModels = generatedModels("openai-native");
-	const additionalOAuthModelIds = ["gpt-5.2", "gpt-5.4", "gpt-5.4-mini"];
-	const fallbackIds = Array.from(
-		new Set([
-			...Object.keys(openaiModels).filter((id) => id.includes("codex")),
-			...additionalOAuthModelIds,
-		]),
-	);
-	return Object.fromEntries(
-		fallbackIds.map((id) => [
-			id,
-			openaiModels[id] ?? {
-				id,
-				name: id,
-				capabilities: ["tools", "reasoning", "streaming"],
-			},
-		]),
-	);
+	return filterOpenAICodexModels(generatedModels("openai-native"));
 }
 
 function fallbackModelInfo(id: string, spec?: BuiltinSpec): ModelInfo {
@@ -674,7 +659,7 @@ export const BUILTIN_SPECS: BuiltinSpec[] = [
 		family: "openai",
 		popular: 2,
 		capabilities: ["reasoning", "oauth"],
-		defaultModelId: "gpt-5.4",
+		defaultModelId: OPENAI_CODEX_DEFAULT_MODEL_ID,
 		modelsFactory: buildOpenAICodexModels,
 		defaults: { baseUrl: "https://chatgpt.com/backend-api/codex" },
 		metadata: { usageCostDisplay: "hide" },

--- a/sdk/packages/llms/src/providers/openai-codex-models.ts
+++ b/sdk/packages/llms/src/providers/openai-codex-models.ts
@@ -1,0 +1,38 @@
+import type { ModelInfo } from "../catalog/types";
+
+const OPENAI_CODEX_ALLOWED_MODELS = new Set([
+	"gpt-5.5",
+	"gpt-5.2",
+	"gpt-5.3-codex",
+	"gpt-5.3-codex-spark",
+	"gpt-5.4",
+	"gpt-5.4-mini",
+]);
+
+function isOpenAICodexAllowedModel(id: string): boolean {
+	if (OPENAI_CODEX_ALLOWED_MODELS.has(id)) return true;
+	const match = id.match(/^gpt-(\d+\.\d+)/);
+	return match ? Number.parseFloat(match[1]) > 5.4 : false;
+}
+
+function toOpenAICodexModel(id: string, model: ModelInfo): ModelInfo {
+	if (!id.includes("gpt-5.5")) {
+		return model;
+	}
+	return {
+		...model,
+		contextWindow: 400_000,
+		maxInputTokens: 272_000,
+		maxTokens: 128_000,
+	};
+}
+
+export function filterOpenAICodexModels(
+	models: Record<string, ModelInfo>,
+): Record<string, ModelInfo> {
+	return Object.fromEntries(
+		Object.entries(models)
+			.filter(([id]) => isOpenAICodexAllowedModel(id))
+			.map(([id, model]) => [id, toOpenAICodexModel(id, model)]),
+	);
+}

--- a/sdk/packages/llms/src/providers/provider-keys.ts
+++ b/sdk/packages/llms/src/providers/provider-keys.ts
@@ -14,6 +14,11 @@ const PROVIDER_IDS_MAP: ReadonlyArray<{
 		generatedProviderId: "openai-native",
 		runtimeProviderId: "openai-codex-cli",
 	},
+	{
+		modelsDevKey: "openai",
+		generatedProviderId: "openai-native",
+		runtimeProviderId: "openai-codex",
+	},
 	{ modelsDevKey: "anthropic", generatedProviderId: "anthropic" },
 	{
 		modelsDevKey: "anthropic",


### PR DESCRIPTION
### Related Issue

Issue: #XXXX

### Description

The ChatGPT subscription provider (`openai-codex`) was still using a stale curated model fallback. That meant SDK/CLI model pickers could lag behind what ChatGPT OAuth actually supports, including newer models such as `gpt-5.5`.

I pulled latest OpenCode and checked how they handle this path. OpenCode still uses models.dev/OpenAI as the source catalog, but it layers a ChatGPT OAuth compatibility filter on top of the OpenAI provider when OAuth auth is active. Their current Codex plugin allows the current ChatGPT/Codex model ids and also has a forward-compatible rule for future `gpt-X.Y` versions newer than `gpt-5.4`.

This PR aligns Cline with that approach while keeping our provider architecture intact:

- Adds a shared `filterOpenAICodexModels` helper in `@cline/llms`.
- Keeps models.dev as the source of model metadata.
- Filters `openai-codex` bundled models through the OpenCode-style compatibility rule.
- Applies the same filter to live models.dev refreshes, so startup refresh and bundled fallback do not drift.
- Maps `openai-codex` to the OpenAI native generated catalog key for live catalog resolution.
- Preserves the ChatGPT backend token limits OpenCode applies for `gpt-5.5` models.

This avoids spawning Codex CLI, avoids querying private app-server model endpoints during provider resolution, and avoids showing the full OpenAI API key model surface for ChatGPT OAuth.

### Test Procedure

I tested the change at the SDK package boundary and the core provider-defaults boundary:

```bash
bun test src/providers/builtins.test.ts src/catalog/catalog-live.test.ts
bun -F @cline/core test:unit src/services/llms/provider-defaults.test.ts
bun -F @cline/llms typecheck
bun -F @cline/core typecheck
sleep 1 && git diff --check
```

The pre-commit hook also ran successfully during commit and completed the repo type checks plus Biome checks for the staged files.

The tests cover both bundled catalog behavior and live models.dev refresh behavior. They verify that ChatGPT OAuth includes the OpenCode-aligned models such as `gpt-5.5`, `gpt-5.5-pro`, `gpt-5.2`, `gpt-5.3-codex`, `gpt-5.3-codex-spark`, `gpt-5.4`, and `gpt-5.4-mini`, while excluding models outside the ChatGPT OAuth compatibility rule such as `gpt-5.4-nano` and `o3`.

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Not applicable. This is an SDK/provider catalog change with no direct UI rendering changes.

### Additional Notes

The OpenCode reference point is their latest `packages/opencode/src/plugin/codex.ts` behavior after pulling `origin/dev`: OAuth auth uses an OpenAI provider model hook that keeps a known compatible model set plus future `gpt-X.Y` models above `5.4`, and adjusts `gpt-5.5` limits for the ChatGPT backend.
