### PR TITLE
docs: Add FuturMix provider setup guide

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1,682 +1,1112 @@
 {
-	"$schema": "https://mintlify.com/docs.json",
-	"theme": "mint",
-	"name": "Cline",
-	"description": "AI-powered coding agent for complex work",
-	"colors": {
-		"primary": "#9D4EDD",
-		"light": "#F0E6FF",
-		"dark": "#000000"
-	},
-	"logo": {
-		"light": "/assets/Cline_Logo-complete_black.png",
-		"dark": "/assets/Cline_Logo-complete_white.png"
-	},
-	"favicon": {
-		"light": "/assets/robot_panel_light.png",
-		"dark": "/assets/robot_panel_dark.png"
-	},
-	"background": {
-		"color": {
-			"light": "#fafaf9",
-			"dark": "#0f0f0f"
-		}
-	},
-	"styling": {
-		"eyebrows": "breadcrumbs",
-		"codeblocks": "system",
-		"css": "styles.css"
-	},
-	"appearance": {
-		"default": "system",
-		"strict": false
-	},
-	"fonts": {
-		"family": "Geist Sans"
-	},
-	"navbar": {
-		"links": [
-			{
-				"label": "GitHub",
-				"icon": "github",
-				"href": "https://github.com/cline/cline"
-			},
-			{
-				"label": "Discord",
-				"icon": "discord",
-				"href": "https://discord.gg/cline"
-			}
-		],
-		"primary": {
-			"type": "button",
-			"label": "Install Cline",
-			"href": "https://cline.bot/install?utm_source=website&utm_medium=header"
-		}
-	},
-	"navigation": {
-		"tabs": [
-			{
-				"tab": "Docs",
-				"icon": "square-terminal",
-				"groups": [
-					{
-						"group": "Home",
-						"pages": [
-							"home",
-							"getting-started/quick-start"
-						]
-					},
-					{
-						"group": "Getting Started",
-						"pages": [
-							"getting-started/what-is-cline",
-							"getting-started/installing-cline",
-							"getting-started/authorizing-with-cline",
-							"getting-started/your-first-project"
-						]
-					},
-					{
-						"group": "Core Workflows",
-						"pages": [
-							"core-workflows/task-management",
-							"core-workflows/plan-and-act",
-							"core-workflows/working-with-files",
-							"core-workflows/using-commands",
-							"core-workflows/checkpoints"
-						]
-					},
-					{
-						"group": "Customization",
-						"pages": [
-							"customization/overview",
-							"customization/cline-rules",
-							"customization/skills",
-							"customization/workflows",
-							"customization/hooks",
-							"customization/clineignore"
-						]
-					},
-					{
-						"group": "Cline CLI",
-						"pages": [
-							"cline-cli/overview",
-							"cline-cli/installation",
-							"cline-sdk/overview",
-							"cline-cli/interactive-mode",
-							{
-								"group": "Headless Mode",
-								"pages": [
-									"cline-cli/three-core-flows",
-									"cline-cli/samples/overview",
-									"cline-cli/samples/github-issue-rca",
-									"cline-cli/samples/github-integration",
-									"cline-cli/samples/github-pr-review",
-									"cline-cli/samples/model-orchestration",
-									"cline-cli/samples/worktree-workflows"
-								]
-							},
-							"cline-cli/configuration",
-							"cline-cli/acp-editor-integrations",
-							"cline-cli/cli-reference"
-						]
-					},
-					{
-						"group": "Features",
-						"pages": [
-							"features/memory-bank",
-							"features/focus-chain",
-							"features/auto-approve",
-							"features/auto-compact",
-							"features/multiroot-workspace",
-							"features/subagents",
-							"features/background-edit",
-							"features/jupyter-notebooks",
-							"features/deep-planning",
-							"features/web-tools",
-							"features/worktrees"
-						]
-					},
-					{
-						"group": "Models & Providers",
-						"pages": [
-							{
-								"group": "Choosing & Configuring Models",
-								"pages": [
-									"core-features/model-selection-guide",
-									"model-config/context-windows"
-								]
-							},
-							{
-								"group": "Running Models Locally",
-								"pages": [
-									"running-models-locally/overview",
-									"running-models-locally/ollama",
-									"running-models-locally/lm-studio"
-								]
-							},
-							{
-								"group": "Cloud Providers",
-								"pages": [
-									"provider-config/qwen",
-									"provider-config/anthropic",
-									"provider-config/asksage",
-									"provider-config/baseten",
-									"provider-config/cerebras",
-									"provider-config/claude-code",
-									"provider-config/deepseek",
-									"provider-config/doubao",
-									"provider-config/fireworks",
-									"provider-config/gcp-vertex-ai",
-									"provider-config/google-gemini",
-									"provider-config/groq",
-									"provider-config/huawei-cloud-maas",
-									"provider-config/huggingface",
-									"provider-config/minimax",
-									"provider-config/mistral-ai",
-									"provider-config/moonshot",
-									"provider-config/nebius",
-									"provider-config/nousresearch",
-									"provider-config/openai",
-									"provider-config/openai-codex",
-									"provider-config/openrouter",
-									"provider-config/oracle-code-assist",
-									"provider-config/qwen-code",
-									"provider-config/sambanova",
-									"provider-config/together",
-									"provider-config/xai-grok",
-									"provider-config/zai",
-									{
-										"group": "AWS Bedrock",
-										"pages": [
-											"provider-config/aws-bedrock/api-key",
-											"provider-config/aws-bedrock/iam-credentials",
-											"provider-config/aws-bedrock/cli-profile"
-										]
-									}
-								]
-							},
-							{
-								"group": "Advanced Configuration",
-								"pages": [
-									"provider-config/aihubmix",
-									"provider-config/dify",
-									"provider-config/hicap",
-									"provider-config/litellm-and-cline-using-codestral",
-									"provider-config/openai-compatible",
-									"provider-config/requesty",
-									"provider-config/sap-aicore",
-									"provider-config/vercel-ai-gateway",
-									"provider-config/vscode-language-model-api"
-								]
-							}
-						]
-					},
-					{
-						"group": "MCP (Extending Cline)",
-						"pages": [
-							"mcp/mcp-overview",
-							"mcp/mcp-marketplace",
-							"mcp/adding-and-configuring-servers",
-							"mcp/mcp-server-development-protocol",
-							"mcp/connecting-to-a-remote-server",
-							"mcp/mcp-transport-mechanisms"
-						]
-					},
-					{
-						"group": "Tools Reference",
-						"pages": [
-							"tools-reference/all-cline-tools",
-							"tools-reference/browser-automation"
-						]
-					},
-					{
-						"group": "Troubleshooting",
-						"pages": [
-							"troubleshooting/terminal-quick-fixes",
-							"troubleshooting/networking-and-proxies",
-							"troubleshooting/task-history-recovery"
-						]
-					},
-					{
-						"group": "Contributing",
-						"pages": [
-							"contributing/documentation-guide",
-							"contributing/doc-templates"
-						]
-					}
-				]
-			},
-			{
-				"tab": "Enterprise",
-				"icon": "building",
-				"groups": [
-					{
-						"group": "Enterprise Solutions",
-						"pages": [
-							"enterprise-solutions/overview",
-							"enterprise-solutions/onboarding",
-							"enterprise-solutions/sso-setup",
-							"enterprise-solutions/team-management/managing-members",
-							{
-								"group": "Remote Provider Configuration",
-								"pages": [
-									"enterprise-solutions/configuration/remote-configuration/overview",
-									{
-										"group": "AWS Bedrock",
-										"pages": [
-											"enterprise-solutions/configuration/remote-configuration/aws-bedrock/admin-configuration",
-											"enterprise-solutions/configuration/remote-configuration/aws-bedrock/member-configuration"
-										]
-									},
-									{
-										"group": "Google Vertex AI",
-										"pages": [
-											"enterprise-solutions/configuration/remote-configuration/google-vertex/admin-configuration",
-											"enterprise-solutions/configuration/remote-configuration/google-vertex/member-configuration"
-										]
-									},
-									{
-										"group": "OpenAI Compatible",
-										"pages": [
-											"enterprise-solutions/configuration/remote-configuration/openai-compatible/admin-configuration",
-											"enterprise-solutions/configuration/remote-configuration/openai-compatible/member-configuration"
-										]
-									},
-									{
-										"group": "Anthropic",
-										"pages": [
-											"enterprise-solutions/configuration/remote-configuration/anthropic/admin-configuration",
-											"enterprise-solutions/configuration/remote-configuration/anthropic/member-configuration"
-										]
-									},
-									{
-										"group": "LiteLLM",
-										"pages": [
-											"enterprise-solutions/configuration/remote-configuration/litellm/admin-configuration",
-											"enterprise-solutions/configuration/remote-configuration/litellm/member-configuration"
-										]
-									}
-								]
-							},
-							{
-								"group": "Control Other Cline Features",
-								"pages": [
-									"enterprise-solutions/configuration/infrastructure-configuration/control-other-cline-features/yolo-mode",
-									"enterprise-solutions/configuration/infrastructure-configuration/control-other-cline-features/mcp-marketplace"
-								]
-							},
-							{
-								"group": "Monitoring",
-								"pages": [
-									"enterprise-solutions/monitoring/overview",
-									"enterprise-solutions/monitoring/telemetry",
-									"enterprise-solutions/monitoring/prompt-storage",
-									"enterprise-solutions/monitoring/opentelemetry",
-									"enterprise-solutions/monitoring/opentelemetry-events",
-									"enterprise-solutions/monitoring/opentelemetry_override"
-								]
-							},
-							"enterprise-solutions/api-reference"
-						]
-					}
-				]
-			},
-			{
-				"tab": "API",
-				"icon": "code",
-				"groups": [
-					{
-						"group": "Cline API",
-						"pages": [
-							"api/overview",
-							"api/getting-started",
-							"api/authentication"
-						]
-					},
-					{
-						"group": "Endpoints",
-						"pages": [
-							"api/chat-completions"
-						]
-					},
-					{
-						"group": "Reference",
-						"pages": [
-							"api/models",
-							"api/errors",
-							"api/sdk-examples"
-						]
-					}
-				]
-			},
-			{
-				"tab": "Kanban",
-				"icon": "table-columns",
-				"groups": [
-					{
-						"group": "Cline Kanban",
-						"pages": [
-							"kanban/overview",
-							"kanban/getting-started",
-							"kanban/core-workflow",
-							"kanban/features",
-							"kanban/remote-access"
-						]
-					}
-				]
-			},
-			{
-				"tab": "Learn",
-				"icon": "graduation-cap",
-				"href": "https://cline.bot/learn"
-			}
-		]
-	},
-	"footer": {
-		"socials": {
-			"x": "https://x.com/cline",
-			"github": "https://github.com/cline/cline",
-			"discord": "https://discord.gg/cline"
-		}
-	},
-	"anchors": [
-		{
-			"name": "Overview",
-			"icon": "house",
-			"url": "getting-started/what-is-cline"
-		}
-	],
-	"redirects": [
-		{
-			"source": "/getting-started/installing-cline-jetbrains",
-			"destination": "/getting-started/installing-cline"
-		},
-		{
-			"source": "/getting-started/overview",
-			"destination": "/getting-started/what-is-cline"
-		},
-		{
-			"source": "/introduction",
-			"destination": "/getting-started/what-is-cline"
-		},
-		{
-			"source": "/introduction/welcome",
-			"destination": "/getting-started/what-is-cline"
-		},
-		{
-			"source": "/introduction/overview",
-			"destination": "/getting-started/what-is-cline"
-		},
-		{
-			"source": "/getting-started/model-selection-guide",
-			"destination": "/core-features/model-selection-guide"
-		},
-		{
-			"source": "/provider-config/ollama",
-			"destination": "/running-models-locally/ollama"
-		},
-		{
-			"source": "/running-models-locally/read-me-first",
-			"destination": "/running-models-locally/overview"
-		},
-		{
-			"source": "/getting-started/understanding-context-management",
-			"destination": "/model-config/context-windows"
-		},
-		{
-			"source": "/best-practices/understanding-context-management",
-			"destination": "/model-config/context-windows"
-		},
-		{
-			"source": "/prompting/understanding-context-management",
-			"destination": "/model-config/context-windows"
-		},
-		{
-			"source": "/prompting/prompt-engineering-guide",
-			"destination": "/customization/cline-rules"
-		},
-		{
-			"source": "/prompting/cline-memory-bank",
-			"destination": "/features/memory-bank"
-		},
-		{
-			"source": "/customization/memory-bank",
-			"destination": "/features/memory-bank"
-		},
-		{
-			"source": "/customization/focus-chain",
-			"destination": "/features/focus-chain"
-		},
-		{
-			"source": "/customization/auto-approve",
-			"destination": "/features/auto-approve"
-		},
-		{
-			"source": "/customization/auto-compact",
-			"destination": "/features/auto-compact"
-		},
-		{
-			"source": "/getting-started/your-first-task",
-			"destination": "/getting-started/your-first-project"
-		},
-		{
-			"source": "/cline-cli/samples",
-			"destination": "/cline-cli/samples/overview"
-		},
-		{
-			"source": "/cline-cli/overview",
-			"destination": "/cline-cli/getting-started"
-		},
-		{
-			"source": "/features/hooks/real-world-examples",
-			"destination": "/customization/hooks"
-		},
-		{
-			"source": "/features/hooks/index",
-			"destination": "/customization/hooks"
-		},
-		{
-			"source": "/features/hooks/hook-reference",
-			"destination": "/customization/hooks"
-		},
-		{
-			"source": "/features/hooks/samples",
-			"destination": "/customization/hooks"
-		},
-		{
-			"source": "/features/plan-and-act",
-			"destination": "/core-workflows/plan-and-act"
-		},
-		{
-			"source": "/features/checkpoints",
-			"destination": "/core-workflows/checkpoints"
-		},
-		{
-			"source": "/features/tasks/understanding-tasks",
-			"destination": "/core-workflows/task-management"
-		},
-		{
-			"source": "/features/tasks/task-management",
-			"destination": "/core-workflows/task-management"
-		},
-		{
-			"source": "/features/at-mentions/overview",
-			"destination": "/core-workflows/working-with-files"
-		},
-		{
-			"source": "/features/at-mentions/file-mentions",
-			"destination": "/core-workflows/working-with-files"
-		},
-		{
-			"source": "/features/at-mentions/folder-mentions",
-			"destination": "/core-workflows/working-with-files"
-		},
-		{
-			"source": "/features/at-mentions/terminal-mentions",
-			"destination": "/core-workflows/working-with-files"
-		},
-		{
-			"source": "/features/at-mentions/problem-mentions",
-			"destination": "/core-workflows/working-with-files"
-		},
-		{
-			"source": "/features/at-mentions/git-mentions",
-			"destination": "/core-workflows/working-with-files"
-		},
-		{
-			"source": "/features/at-mentions/url-mentions",
-			"destination": "/core-workflows/working-with-files"
-		},
-		{
-			"source": "/features/drag-and-drop",
-			"destination": "/core-workflows/working-with-files"
-		},
-		{
-			"source": "/features/yolo-mode",
-			"destination": "/features/auto-approve"
-		},
-		{
-			"source": "/features/cline-rules",
-			"destination": "/customization/cline-rules"
-		},
-		{
-			"source": "/features/cline-rules/overview",
-			"destination": "/customization/cline-rules"
-		},
-		{
-			"source": "/features/cline-rules/conditional-rules",
-			"destination": "/customization/cline-rules"
-		},
-		{
-			"source": "/features/commands-and-shortcuts/overview",
-			"destination": "/core-workflows/using-commands"
-		},
-		{
-			"source": "/features/commands-and-shortcuts/code-commands",
-			"destination": "/core-workflows/using-commands"
-		},
-		{
-			"source": "/features/commands-and-shortcuts/terminal-integration",
-			"destination": "/core-workflows/using-commands"
-		},
-		{
-			"source": "/features/commands-and-shortcuts/git-integration",
-			"destination": "/core-workflows/using-commands"
-		},
-		{
-			"source": "/features/commands-and-shortcuts/keyboard-shortcuts",
-			"destination": "/core-workflows/using-commands"
-		},
-		{
-			"source": "/features/slash-commands/new-task",
-			"destination": "/core-workflows/using-commands"
-		},
-		{
-			"source": "/features/slash-commands/workflows/index",
-			"destination": "/customization/workflows"
-		},
-		{
-			"source": "/features/slash-commands/workflows/quickstart",
-			"destination": "/customization/workflows"
-		},
-		{
-			"source": "/features/slash-commands/workflows/best-practices",
-			"destination": "/customization/workflows"
-		},
-		{
-			"source": "/exploring-clines-tools/cline-tools-guide",
-			"destination": "/tools-reference/all-cline-tools"
-		},
-		{
-			"source": "/exploring-clines-tools/new-task-tool",
-			"destination": "/tools-reference/all-cline-tools"
-		},
-		{
-			"source": "/exploring-clines-tools/remote-browser-support",
-			"destination": "/tools-reference/browser-automation"
-		},
-		{
-			"source": "/mcp/adding-mcp-servers-from-github",
-			"destination": "/mcp/adding-and-configuring-servers"
-		},
-		{
-			"source": "/mcp/configuring-mcp-servers",
-			"destination": "/mcp/adding-and-configuring-servers"
-		},
-		{
-			"source": "/more-info/telemetry",
-			"destination": "/enterprise-solutions/monitoring/telemetry"
-		},
-		{
-			"source": "/enterprise-solutions/configure-AWS-Bedrock-Admin",
-			"destination": "/enterprise-solutions/configuration/remote-configuration/aws-bedrock/admin-configuration"
-		},
-		{
-			"source": "/enterprise-solutions/configure-AWS-Bedrock-Member",
-			"destination": "/enterprise-solutions/configuration/remote-configuration/aws-bedrock/member-configuration"
-		},
-		{
-			"source": "/enterprise-solutions/configure-workOS-authkit",
-			"destination": "/enterprise-solutions/onboarding"
-		},
-		{
-			"source": "/enterprise-solutions/Onboarding your Organization",
-			"destination": "/enterprise-solutions/onboarding"
-		},
-		{
-			"source": "/enterprise-solutions/team-management/overview",
-			"destination": "/enterprise-solutions/team-management/managing-members"
-		},
-		{
-			"source": "/enterprise-solutions/team-management/roles-and-permissions",
-			"destination": "/enterprise-solutions/team-management/managing-members"
-		},
-		{
-			"source": "/features/customization/opening-cline-in-sidebar",
-			"destination": "/getting-started/installing-cline"
-		},
-		{
-			"source": "/prompting/prompt-engineering-guide/clineignore-file-guide",
-			"destination": "/customization/clineignore"
-		},
-		{
-			"source": "/getting-started/selecting-your-model",
-			"destination": "/getting-started/authorizing-with-cline"
-		},
-		{
-			"source": "/model-config/model-comparison",
-			"destination": "/core-features/model-selection-guide"
-		},
-		{
-			"source": "/troubleshooting/terminal-integration-guide",
-			"destination": "/troubleshooting/terminal-quick-fixes"
-		},
-		{
-			"source": "/features/slash-commands/deep-planning",
-			"destination": "/features/deep-planning"
-		},
-		{
-			"source": "/features/slash-commands/smol",
-			"destination": "/core-workflows/using-commands#smol"
-		},
-		{
-			"source": "/features/slash-commands/explain-changes",
-			"destination": "/core-workflows/using-commands#explain-changes"
-		},
-		{
-			"source": "/features/slash-commands/new-rule",
-			"destination": "/core-workflows/using-commands#newrule"
-		},
-		{
-			"source": "/features/skills",
-			"destination": "/customization/skills"
-		},
-		{
-			"source": "/api/reference",
-			"destination": "/api/overview"
-		}
-	],
-	"search": {
-		"prompt": "Search Cline documentation..."
-	}
+  "$schema": "https://mintlify.com/docs.json",
+  "theme": "mint",
+  "name": "Cline",
+  "description": "AI-powered coding agent for complex work",
+  "colors": {
+    "primary": "#9D4EDD",
+    "light": "#F0E6FF",
+    "dark": "#000000"
+  },
+  "logo": {
+    "light": "/assets/Cline_Logo-complete_black.png",
+    "dark": "/assets/Cline_Logo-complete_white.png"
+  },
+  "favicon": {
+    "light": "/assets/robot_panel_light.png",
+    "dark": "/assets/robot_panel_dark.png"
+  },
+  "background": {
+    "color": {
+      "light": "#fafaf9",
+      "dark": "#0f0f0f"
+    }
+  },
+  "styling": {
+    "eyebrows": "breadcrumbs",
+    "codeblocks": "system",
+    "css": "styles.css"
+  },
+  "appearance": {
+    "default": "system",
+    "strict": false
+  },
+  "fonts": {
+    "family": "Geist Sans"
+  },
+  "navbar": {
+    "links": [
+      {
+        "label": "GitHub",
+        "icon": "github",
+        "href": "https://github.com/cline/cline"
+      },
+      {
+        "label": "Discord",
+        "icon": "discord",
+        "href": "https://discord.gg/cline"
+      }
+    ],
+    "primary": {
+      "type": "button",
+      "label": "Install Cline",
+      "href": "https://cline.bot/install?utm_source=website&utm_medium=header"
+    }
+  },
+  "navigation": {
+    "tabs": [
+      {
+        "tab": "Cline",
+        "icon": "robot",
+        "groups": [
+          {
+            "group": "Getting Started",
+            "pages": [
+              "cline-overview",
+              "getting-started/installing-cline",
+              {
+                "group": "Models & Providers",
+                "pages": [
+                  "getting-started/authorizing-with-cline",
+                  "getting-started/cline-provider",
+                  "running-models-locally/overview",
+                  {
+                    "group": "Cloud Providers",
+                    "pages": [
+                      "provider-config/qwen",
+                      "provider-config/anthropic",
+                      {
+                        "group": "AWS Bedrock",
+                        "pages": [
+                          "provider-config/aws-bedrock/api-key",
+                          "provider-config/aws-bedrock/iam-credentials",
+                          "provider-config/aws-bedrock/cli-profile"
+                        ]
+                      },
+                      "provider-config/deepseek",
+                      "provider-config/futurmix",
+                      "provider-config/google-gemini",
+                      "provider-config/minimax",
+                      "provider-config/openai",
+                      "provider-config/openai-compatible",
+                      "provider-config/openrouter",
+                      "provider-config/zai",
+                      "provider-config/other-30-plus-providers"
+                    ]
+                  }
+                ]
+              },
+              "getting-started/config"
+            ]
+          },
+          {
+            "group": "Usage",
+            "pages": [
+              "usage/ide",
+              "usage/tui",
+              {
+                "group": "CLI",
+                "pages": [
+                  "usage/cli-overview",
+                  "cli/cli-reference",
+                  {
+                    "group": "Examples",
+                    "pages": [
+                      "cli/samples/github-issue-rca",
+                      "cli/samples/github-integration",
+                      "cli/samples/github-pr-review",
+                      "cli/samples/model-orchestration"
+                    ]
+                  },
+                  "cli/acp-editor-integrations"
+                ]
+              },
+              {
+                "group": "Kanban",
+                "pages": [
+                  "usage/kanban",
+                  "kanban/core-workflow",
+                  "kanban/remote-access"
+                ]
+              }
+            ]
+          },
+          {
+            "group": "Configurations",
+            "pages": [
+              "tools-reference/all-cline-tools",
+              "customization/cline-rules",
+              "customization/skills",
+              "customization/plugins",
+              "mcp/mcp-overview",
+              "customization/hooks",
+              "cli/scheduling",
+              "cli/connectors",
+              "customization/clineignore"
+            ]
+          },
+          {
+            "group": "Features",
+            "pages": [
+              "core-workflows/plan-and-act",
+              "core-workflows/working-with-files",
+              "core-workflows/using-commands",
+              "core-workflows/checkpoints",
+              "cli/agent-teams",
+              "features/subagents"
+            ]
+          },
+          {
+            "group": "IDE Specific Features",
+            "pages": [
+              "features/auto-approve",
+              "features/jupyter-notebooks",
+              "features/multiroot-workspace"
+            ]
+          },
+          {
+            "group": "Troubleshooting",
+            "pages": [
+              "troubleshooting/networking-and-proxies"
+            ]
+          }
+        ]
+      },
+      {
+        "tab": "SDK",
+        "icon": "cube",
+        "groups": [
+          {
+            "group": "Start",
+            "pages": [
+              "sdk/overview",
+              "sdk/examples"
+            ]
+          },
+          {
+            "group": "Concepts",
+            "pages": [
+              {
+                "group": "Plugins",
+                "pages": [
+                  "sdk/plugins",
+                  "sdk/plugin-install",
+                  "sdk/guides/writing-plugins",
+                  "sdk/plugin-examples"
+                ]
+              },
+              {
+                "group": "Tools",
+                "pages": [
+                  "sdk/tools",
+                  "sdk/guides/creating-custom-tools"
+                ]
+              },
+              "sdk/guides/scheduled-agents",
+              "sdk/events",
+              "sdk/model-providers",
+              "sdk/clinecore"
+            ]
+          },
+          {
+            "group": "Architecture",
+            "pages": [
+              "sdk/architecture/overview",
+              "sdk/architecture/hub-spoke"
+            ]
+          },
+          {
+            "group": "Guides",
+            "pages": [
+              "sdk/guides/building-an-agent",
+              "sdk/guides/permission-handling",
+              "sdk/guides/multi-agent-teams",
+              "sdk/guides/going-to-production"
+            ]
+          },
+          {
+            "group": "API Reference",
+            "pages": [
+              "sdk/reference/cline-core",
+              "sdk/reference/agent",
+              "sdk/reference/gateway",
+              "sdk/reference/tools-api",
+              "sdk/reference/events",
+              "sdk/reference/types"
+            ]
+          }
+        ]
+      },
+      {
+        "tab": "Enterprise",
+        "icon": "building",
+        "groups": [
+          {
+            "group": "Enterprise Solutions",
+            "pages": [
+              "enterprise-solutions/overview",
+              "enterprise-solutions/onboarding",
+              "enterprise-solutions/sso-setup",
+              "enterprise-solutions/team-management/managing-members",
+              {
+                "group": "Remote Provider Configuration",
+                "pages": [
+                  "enterprise-solutions/configuration/remote-configuration/overview",
+                  {
+                    "group": "AWS Bedrock",
+                    "pages": [
+                      "enterprise-solutions/configuration/remote-configuration/aws-bedrock/admin-configuration",
+                      "enterprise-solutions/configuration/remote-configuration/aws-bedrock/member-configuration"
+                    ]
+                  },
+                  {
+                    "group": "Google Vertex AI",
+                    "pages": [
+                      "enterprise-solutions/configuration/remote-configuration/google-vertex/admin-configuration",
+                      "enterprise-solutions/configuration/remote-configuration/google-vertex/member-configuration"
+                    ]
+                  },
+                  {
+                    "group": "OpenAI Compatible",
+                    "pages": [
+                      "enterprise-solutions/configuration/remote-configuration/openai-compatible/admin-configuration",
+                      "enterprise-solutions/configuration/remote-configuration/openai-compatible/member-configuration"
+                    ]
+                  },
+                  {
+                    "group": "Anthropic",
+                    "pages": [
+                      "enterprise-solutions/configuration/remote-configuration/anthropic/admin-configuration",
+                      "enterprise-solutions/configuration/remote-configuration/anthropic/member-configuration"
+                    ]
+                  },
+                  {
+                    "group": "LiteLLM",
+                    "pages": [
+                      "enterprise-solutions/configuration/remote-configuration/litellm/admin-configuration",
+                      "enterprise-solutions/configuration/remote-configuration/litellm/member-configuration"
+                    ]
+                  }
+                ]
+              },
+              {
+                "group": "Control Other Cline Features",
+                "pages": [
+                  "enterprise-solutions/configuration/infrastructure-configuration/control-other-cline-features/yolo-mode",
+                  "enterprise-solutions/configuration/infrastructure-configuration/control-other-cline-features/mcp-marketplace"
+                ]
+              },
+              {
+                "group": "Monitoring",
+                "pages": [
+                  "enterprise-solutions/monitoring/overview",
+                  "enterprise-solutions/monitoring/telemetry",
+                  "enterprise-solutions/monitoring/prompt-storage",
+                  "enterprise-solutions/monitoring/opentelemetry",
+                  "enterprise-solutions/monitoring/opentelemetry-events",
+                  "enterprise-solutions/monitoring/opentelemetry_override"
+                ]
+              },
+              "enterprise-solutions/api-reference"
+            ]
+          }
+        ]
+      },
+      {
+        "tab": "API",
+        "icon": "code",
+        "groups": [
+          {
+            "group": "Cline API",
+            "pages": [
+              "api/overview",
+              "api/getting-started",
+              "api/authentication"
+            ]
+          },
+          {
+            "group": "Endpoints",
+            "pages": [
+              "api/chat-completions"
+            ]
+          },
+          {
+            "group": "Reference",
+            "pages": [
+              "api/models",
+              "api/errors",
+              "api/sdk-examples"
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "footer": {
+    "socials": {
+      "x": "https://x.com/cline",
+      "github": "https://github.com/cline/cline",
+      "discord": "https://discord.gg/cline"
+    }
+  },
+  "anchors": [
+    {
+      "name": "Overview",
+      "icon": "house",
+      "url": "cline-overview"
+    }
+  ],
+  "redirects": [
+    {
+      "source": "/usage/cli",
+      "destination": "/usage/cli-overview"
+    },
+    {
+      "source": "/getting-started/installing-cline-jetbrains",
+      "destination": "/getting-started/installing-cline"
+    },
+    {
+      "source": "/getting-started/overview",
+      "destination": "/cline-overview"
+    },
+    {
+      "source": "/getting-started/your-first-project",
+      "destination": "/usage/ide"
+    },
+    {
+      "source": "/introduction",
+      "destination": "/cline-overview"
+    },
+    {
+      "source": "/introduction/welcome",
+      "destination": "/cline-overview"
+    },
+    {
+      "source": "/introduction/overview",
+      "destination": "/cline-overview"
+    },
+    {
+      "source": "/getting-started/model-selection-guide",
+      "destination": "/getting-started/cline-provider"
+    },
+    {
+      "source": "/provider-config/ollama",
+      "destination": "/running-models-locally/overview#runtime-options"
+    },
+    {
+      "source": "/running-models-locally/read-me-first",
+      "destination": "/running-models-locally/overview"
+    },
+    {
+      "source": "/running-models-locally/ollama",
+      "destination": "/running-models-locally/overview#runtime-options"
+    },
+    {
+      "source": "/running-models-locally/lm-studio",
+      "destination": "/running-models-locally/overview#runtime-options"
+    },
+    {
+      "source": "/getting-started/understanding-context-management",
+      "destination": "/getting-started/cline-provider"
+    },
+    {
+      "source": "/best-practices/understanding-context-management",
+      "destination": "/getting-started/cline-provider"
+    },
+    {
+      "source": "/prompting/understanding-context-management",
+      "destination": "/getting-started/cline-provider"
+    },
+    {
+      "source": "/model-config/context-windows",
+      "destination": "/getting-started/cline-provider"
+    },
+    {
+      "source": "/core-features/model-selection-guide",
+      "destination": "/getting-started/cline-provider"
+    },
+    {
+      "source": "/prompting/prompt-engineering-guide",
+      "destination": "/customization/cline-rules"
+    },
+    {
+      "source": "/prompting/cline-memory-bank",
+      "destination": "/core-workflows/task-management"
+    },
+    {
+      "source": "/customization/memory-bank",
+      "destination": "/core-workflows/task-management"
+    },
+    {
+      "source": "/customization/overview",
+      "destination": "/getting-started/config"
+    },
+    {
+      "source": "/customization/focus-chain",
+      "destination": "/core-workflows/using-commands#deep-planning"
+    },
+    {
+      "source": "/features/deep-planning",
+      "destination": "/core-workflows/using-commands#deep-planning"
+    },
+    {
+      "source": "/customization/auto-approve",
+      "destination": "/features/auto-approve"
+    },
+    {
+      "source": "/customization/auto-compact",
+      "destination": "/features/auto-compact"
+    },
+    {
+      "source": "/getting-started/your-first-task",
+      "destination": "/usage/ide"
+    },
+    {
+      "source": "/features/hooks/real-world-examples",
+      "destination": "/customization/hooks"
+    },
+    {
+      "source": "/features/hooks/index",
+      "destination": "/customization/hooks"
+    },
+    {
+      "source": "/features/hooks/hook-reference",
+      "destination": "/customization/hooks"
+    },
+    {
+      "source": "/features/hooks/samples",
+      "destination": "/customization/hooks"
+    },
+    {
+      "source": "/features/plan-and-act",
+      "destination": "/core-workflows/plan-and-act"
+    },
+    {
+      "source": "/features/checkpoints",
+      "destination": "/core-workflows/checkpoints"
+    },
+    {
+      "source": "/features/tasks/understanding-tasks",
+      "destination": "/core-workflows/task-management"
+    },
+    {
+      "source": "/features/tasks/task-management",
+      "destination": "/core-workflows/task-management"
+    },
+    {
+      "source": "/features/at-mentions/overview",
+      "destination": "/core-workflows/working-with-files"
+    },
+    {
+      "source": "/features/at-mentions/file-mentions",
+      "destination": "/core-workflows/working-with-files"
+    },
+    {
+      "source": "/features/at-mentions/folder-mentions",
+      "destination": "/core-workflows/working-with-files"
+    },
+    {
+      "source": "/features/at-mentions/terminal-mentions",
+      "destination": "/core-workflows/working-with-files"
+    },
+    {
+      "source": "/features/at-mentions/problem-mentions",
+      "destination": "/core-workflows/working-with-files"
+    },
+    {
+      "source": "/features/at-mentions/git-mentions",
+      "destination": "/core-workflows/working-with-files"
+    },
+    {
+      "source": "/features/at-mentions/url-mentions",
+      "destination": "/core-workflows/working-with-files"
+    },
+    {
+      "source": "/features/drag-and-drop",
+      "destination": "/core-workflows/working-with-files"
+    },
+    {
+      "source": "/features/yolo-mode",
+      "destination": "/features/auto-approve"
+    },
+    {
+      "source": "/features/cline-rules",
+      "destination": "/customization/cline-rules"
+    },
+    {
+      "source": "/features/cline-rules/overview",
+      "destination": "/customization/cline-rules"
+    },
+    {
+      "source": "/features/cline-rules/conditional-rules",
+      "destination": "/customization/cline-rules"
+    },
+    {
+      "source": "/features/commands-and-shortcuts/overview",
+      "destination": "/core-workflows/using-commands"
+    },
+    {
+      "source": "/features/commands-and-shortcuts/code-commands",
+      "destination": "/core-workflows/using-commands"
+    },
+    {
+      "source": "/features/commands-and-shortcuts/terminal-integration",
+      "destination": "/core-workflows/using-commands"
+    },
+    {
+      "source": "/features/commands-and-shortcuts/git-integration",
+      "destination": "/core-workflows/using-commands"
+    },
+    {
+      "source": "/features/commands-and-shortcuts/keyboard-shortcuts",
+      "destination": "/core-workflows/using-commands"
+    },
+    {
+      "source": "/features/slash-commands/new-task",
+      "destination": "/core-workflows/using-commands"
+    },
+    {
+      "source": "/exploring-clines-tools/cline-tools-guide",
+      "destination": "/tools-reference/all-cline-tools"
+    },
+    {
+      "source": "/exploring-clines-tools/new-task-tool",
+      "destination": "/tools-reference/all-cline-tools"
+    },
+    {
+      "source": "/exploring-clines-tools/remote-browser-support",
+      "destination": "/tools-reference/all-cline-tools"
+    },
+    {
+      "source": "/mcp/adding-mcp-servers-from-github",
+      "destination": "/mcp/mcp-overview"
+    },
+    {
+      "source": "/mcp/configuring-mcp-servers",
+      "destination": "/mcp/mcp-overview"
+    },
+    {
+      "source": "/more-info/telemetry",
+      "destination": "/enterprise-solutions/monitoring/telemetry"
+    },
+    {
+      "source": "/enterprise-solutions/configure-AWS-Bedrock-Admin",
+      "destination": "/enterprise-solutions/configuration/remote-configuration/aws-bedrock/admin-configuration"
+    },
+    {
+      "source": "/enterprise-solutions/configure-AWS-Bedrock-Member",
+      "destination": "/enterprise-solutions/configuration/remote-configuration/aws-bedrock/member-configuration"
+    },
+    {
+      "source": "/enterprise-solutions/configure-workOS-authkit",
+      "destination": "/enterprise-solutions/onboarding"
+    },
+    {
+      "source": "/enterprise-solutions/Onboarding your Organization",
+      "destination": "/enterprise-solutions/onboarding"
+    },
+    {
+      "source": "/enterprise-solutions/team-management/overview",
+      "destination": "/enterprise-solutions/team-management/managing-members"
+    },
+    {
+      "source": "/enterprise-solutions/team-management/roles-and-permissions",
+      "destination": "/enterprise-solutions/team-management/managing-members"
+    },
+    {
+      "source": "/features/customization/opening-cline-in-sidebar",
+      "destination": "/getting-started/installing-cline"
+    },
+    {
+      "source": "/prompting/prompt-engineering-guide/clineignore-file-guide",
+      "destination": "/customization/clineignore"
+    },
+    {
+      "source": "/getting-started/selecting-your-model",
+      "destination": "/getting-started/authorizing-with-cline"
+    },
+    {
+      "source": "/model-config/model-comparison",
+      "destination": "/getting-started/cline-provider"
+    },
+    {
+      "source": "/troubleshooting/terminal-integration-guide",
+      "destination": "/core-workflows/using-commands"
+    },
+    {
+      "source": "/features/slash-commands/deep-planning",
+      "destination": "/core-workflows/using-commands#deep-planning"
+    },
+    {
+      "source": "/features/slash-commands/smol",
+      "destination": "/core-workflows/using-commands#smol"
+    },
+    {
+      "source": "/features/slash-commands/explain-changes",
+      "destination": "/core-workflows/using-commands#explain-changes"
+    },
+    {
+      "source": "/features/slash-commands/new-rule",
+      "destination": "/core-workflows/using-commands#newrule"
+    },
+    {
+      "source": "/features/memory-bank",
+      "destination": "/core-workflows/task-management"
+    },
+    {
+      "source": "/features/focus-chain",
+      "destination": "/core-workflows/using-commands#deep-planning"
+    },
+    {
+      "source": "/features/skills",
+      "destination": "/customization/skills"
+    },
+    {
+      "source": "/api/reference",
+      "destination": "/api/overview"
+    },
+    {
+      "source": "/cli/overview",
+      "destination": "/usage/cli-overview"
+    },
+    {
+      "source": "/kanban/overview",
+      "destination": "/usage/kanban"
+    },
+    {
+      "source": "/kanban/getting-started",
+      "destination": "/usage/kanban"
+    },
+    {
+      "source": "/kanban/features",
+      "destination": "/usage/kanban"
+    },
+    {
+      "source": "/features/background-edit",
+      "destination": "/features/auto-approve"
+    },
+    {
+      "source": "/features/worktrees",
+      "destination": "/usage/ide"
+    },
+    {
+      "source": "/cli/getting-started",
+      "destination": "/usage/cli-overview"
+    },
+    {
+      "source": "/cli/installation",
+      "destination": "/getting-started/installing-cline"
+    },
+    {
+      "source": "/cli/three-core-flows",
+      "destination": "/usage/cli-overview#headless-mode"
+    },
+    {
+      "source": "/cline-cli/getting-started",
+      "destination": "/usage/cli-overview"
+    },
+    {
+      "source": "/cline-cli/installation",
+      "destination": "/getting-started/installing-cline"
+    },
+    {
+      "source": "/cline-cli/three-core-flows",
+      "destination": "/usage/cli-overview#headless-mode"
+    },
+    {
+      "source": "/cline-cli/connectors",
+      "destination": "/cli/connectors"
+    },
+    {
+      "source": "/cline-cli/scheduling",
+      "destination": "/cli/scheduling"
+    },
+    {
+      "source": "/cline-cli/mcp-servers",
+      "destination": "/mcp/mcp-overview"
+    },
+    {
+      "source": "/cli/mcp-servers",
+      "destination": "/mcp/mcp-overview"
+    },
+    {
+      "source": "/cline-cli/agent-teams",
+      "destination": "/cli/agent-teams"
+    },
+    {
+      "source": "/cline-cli/cli-reference",
+      "destination": "/cli/cli-reference"
+    },
+    {
+      "source": "/cline-cli/configuration",
+      "destination": "/getting-started/config"
+    },
+    {
+      "source": "/provider-config/claude-code",
+      "destination": "/provider-config/anthropic"
+    },
+    {
+      "source": "/provider-config/openai-codex",
+      "destination": "/provider-config/openai"
+    },
+    {
+      "source": "/cli/configuration",
+      "destination": "/getting-started/config"
+    },
+    {
+      "source": "/cline-cli/acp-editor-integrations",
+      "destination": "/cli/acp-editor-integrations"
+    },
+    {
+      "source": "/cline-cli/samples/github-issue-rca",
+      "destination": "/cli/samples/github-issue-rca"
+    },
+    {
+      "source": "/cline-cli/samples/github-integration",
+      "destination": "/cli/samples/github-integration"
+    },
+    {
+      "source": "/cline-cli/samples/github-pr-review",
+      "destination": "/cli/samples/github-pr-review"
+    },
+    {
+      "source": "/cline-cli/samples/model-orchestration",
+      "destination": "/cli/samples/model-orchestration"
+    },
+    {
+      "source": "/cline-sdk/overview",
+      "destination": "/sdk/overview"
+    },
+    {
+      "source": "/cline-sdk/quickstart",
+      "destination": "/sdk/guides/building-an-agent"
+    },
+    {
+      "source": "/sdk/quickstart",
+      "destination": "/sdk/guides/building-an-agent"
+    },
+    {
+      "source": "/cline-sdk/examples",
+      "destination": "/sdk/guides/building-an-agent"
+    },
+    {
+      "source": "/cline-sdk/agents",
+      "destination": "/sdk/clinecore"
+    },
+    {
+      "source": "/cline-sdk/sessions",
+      "destination": "/sdk/clinecore"
+    },
+    {
+      "source": "/cline-sdk/tools",
+      "destination": "/sdk/tools"
+    },
+    {
+      "source": "/cline-sdk/streaming-and-events",
+      "destination": "/sdk/events"
+    },
+    {
+      "source": "/cline-sdk/plugins",
+      "destination": "/sdk/plugins"
+    },
+    {
+      "source": "/cline-sdk/hooks",
+      "destination": "/sdk/plugins"
+    },
+    {
+      "source": "/cline-sdk/model-providers",
+      "destination": "/sdk/model-providers"
+    },
+    {
+      "source": "/cline-sdk/guides/building-an-agent",
+      "destination": "/sdk/guides/building-an-agent"
+    },
+    {
+      "source": "/cline-sdk/guides/creating-custom-tools",
+      "destination": "/sdk/guides/creating-custom-tools"
+    },
+    {
+      "source": "/cline-sdk/guides/writing-plugins",
+      "destination": "/sdk/guides/writing-plugins"
+    },
+    {
+      "source": "/cline-sdk/guides/permission-handling",
+      "destination": "/sdk/guides/permission-handling"
+    },
+    {
+      "source": "/cline-sdk/guides/scheduled-agents",
+      "destination": "/sdk/guides/scheduled-agents"
+    },
+    {
+      "source": "/cline-sdk/guides/multi-agent-teams",
+      "destination": "/sdk/guides/multi-agent-teams"
+    },
+    {
+      "source": "/cline-sdk/guides/connectors",
+      "destination": "/cli/connectors"
+    },
+    {
+      "source": "/sdk/guides/connectors",
+      "destination": "/cli/connectors"
+    },
+    {
+      "source": "/cline-sdk/guides/going-to-production",
+      "destination": "/sdk/guides/going-to-production"
+    },
+    {
+      "source": "/cline-sdk/architecture/overview",
+      "destination": "/sdk/architecture/overview"
+    },
+    {
+      "source": "/cline-sdk/architecture/hub-spoke",
+      "destination": "/sdk/architecture/hub-spoke"
+    },
+    {
+      "source": "/cline-sdk/architecture/packages",
+      "destination": "/sdk/architecture/overview"
+    },
+    {
+      "source": "/cline-sdk/reference/cline-core",
+      "destination": "/sdk/reference/cline-core"
+    },
+    {
+      "source": "/cline-sdk/reference/agent",
+      "destination": "/sdk/reference/agent"
+    },
+    {
+      "source": "/cline-sdk/reference/gateway",
+      "destination": "/sdk/reference/gateway"
+    },
+    {
+      "source": "/cline-sdk/reference/tools-api",
+      "destination": "/sdk/reference/tools-api"
+    },
+    {
+      "source": "/cline-sdk/reference/events",
+      "destination": "/sdk/reference/events"
+    },
+    {
+      "source": "/cline-sdk/reference/types",
+      "destination": "/sdk/reference/types"
+    },
+    {
+      "source": "/cline-sdk/extensions",
+      "destination": "/sdk/plugins"
+    },
+    {
+      "source": "/sdk/guides/writing-extensions",
+      "destination": "/sdk/guides/writing-plugins"
+    },
+    {
+      "source": "/cline-sdk/guides/writing-extensions",
+      "destination": "/sdk/guides/writing-plugins"
+    },
+    {
+      "source": "/mcp/mcp-marketplace",
+      "destination": "/mcp/mcp-overview"
+    },
+    {
+      "source": "/mcp/adding-and-configuring-servers",
+      "destination": "/mcp/mcp-overview"
+    },
+    {
+      "source": "/mcp/mcp-server-development-protocol",
+      "destination": "/mcp/mcp-overview"
+    },
+    {
+      "source": "/mcp/connecting-to-a-remote-server",
+      "destination": "/mcp/mcp-overview"
+    },
+    {
+      "source": "/mcp/mcp-transport-mechanisms",
+      "destination": "/mcp/mcp-overview"
+    },
+    {
+      "source": "/sdk/agents",
+      "destination": "/sdk/clinecore"
+    },
+    {
+      "source": "/sdk/sessions",
+      "destination": "/sdk/clinecore"
+    },
+    {
+      "source": "/sdk/streaming-and-events",
+      "destination": "/sdk/events"
+    },
+    {
+      "source": "/sdk/hooks",
+      "destination": "/sdk/plugins"
+    },
+    {
+      "source": "/sdk/extensions",
+      "destination": "/sdk/plugins"
+    },
+    {
+      "source": "/sdk/examples",
+      "destination": "/sdk/guides/building-an-agent"
+    },
+    {
+      "source": "/cline-cli/interactive-mode",
+      "destination": "/usage/cli-overview"
+    },
+    {
+      "source": "/cline-cli/overview",
+      "destination": "/usage/cli-overview"
+    },
+    {
+      "source": "/cline-cli/samples/overview",
+      "destination": "/usage/cli-overview"
+    },
+    {
+      "source": "/cline-cli/samples/worktree-workflows",
+      "destination": "/usage/cli-overview"
+    },
+    {
+      "source": "/contributing/doc-templates",
+      "destination": "/cline-overview"
+    },
+    {
+      "source": "/contributing/documentation-guide",
+      "destination": "/cline-overview"
+    },
+    {
+      "source": "/customization/workflows",
+      "destination": "/customization/cline-rules"
+    },
+    {
+      "source": "/features/web-tools",
+      "destination": "/tools-reference/all-cline-tools"
+    },
+    {
+      "source": "/getting-started/quick-start",
+      "destination": "/cline-overview"
+    },
+    {
+      "source": "/getting-started/what-is-cline",
+      "destination": "/cline-overview"
+    },
+    {
+      "source": "/home",
+      "destination": "/cline-overview"
+    },
+    {
+      "source": "/provider-config/aihubmix",
+      "destination": "/provider-config/other-30-plus-providers#aihubmix"
+    },
+    {
+      "source": "/provider-config/asksage",
+      "destination": "/provider-config/other-30-plus-providers#asksage"
+    },
+    {
+      "source": "/provider-config/baseten",
+      "destination": "/provider-config/other-30-plus-providers#baseten"
+    },
+    {
+      "source": "/provider-config/cerebras",
+      "destination": "/provider-config/other-30-plus-providers#cerebras"
+    },
+    {
+      "source": "/provider-config/dify",
+      "destination": "/provider-config/other-30-plus-providers#difyai"
+    },
+    {
+      "source": "/provider-config/doubao",
+      "destination": "/provider-config/other-30-plus-providers#doubao"
+    },
+    {
+      "source": "/provider-config/fireworks",
+      "destination": "/provider-config/other-30-plus-providers#fireworks-ai"
+    },
+    {
+      "source": "/provider-config/gcp-vertex-ai",
+      "destination": "/provider-config/other-30-plus-providers#gcp-vertex-ai"
+    },
+    {
+      "source": "/provider-config/groq",
+      "destination": "/provider-config/other-30-plus-providers#groq"
+    },
+    {
+      "source": "/provider-config/hicap",
+      "destination": "/provider-config/other-30-plus-providers#hicap"
+    },
+    {
+      "source": "/provider-config/huawei-cloud-maas",
+      "destination": "/provider-config/other-30-plus-providers#huawei-cloud-maas"
+    },
+    {
+      "source": "/provider-config/huggingface",
+      "destination": "/provider-config/other-30-plus-providers#hugging-face"
+    },
+    {
+      "source": "/provider-config/litellm-and-cline-using-codestral",
+      "destination": "/provider-config/openai-compatible"
+    },
+    {
+      "source": "/provider-config/mistral-ai",
+      "destination": "/provider-config/other-30-plus-providers#mistral"
+    },
+    {
+      "source": "/provider-config/moonshot",
+      "destination": "/provider-config/other-30-plus-providers#moonshot"
+    },
+    {
+      "source": "/provider-config/nebius",
+      "destination": "/provider-config/other-30-plus-providers#nebius-ai-studio"
+    },
+    {
+      "source": "/provider-config/nousresearch",
+      "destination": "/provider-config/other-30-plus-providers#nous-research"
+    },
+    {
+      "source": "/provider-config/oracle-code-assist",
+      "destination": "/provider-config/other-30-plus-providers#oracle-code-assist"
+    },
+    {
+      "source": "/provider-config/qwen-code",
+      "destination": "/provider-config/other-30-plus-providers#qwen-code"
+    },
+    {
+      "source": "/provider-config/requesty",
+      "destination": "/provider-config/other-30-plus-providers#requesty"
+    },
+    {
+      "source": "/provider-config/sambanova",
+      "destination": "/provider-config/other-30-plus-providers#sambanova"
+    },
+    {
+      "source": "/provider-config/sap-aicore",
+      "destination": "/provider-config/other-30-plus-providers#sap-ai-core"
+    },
+    {
+      "source": "/provider-config/together",
+      "destination": "/provider-config/other-30-plus-providers#together"
+    },
+    {
+      "source": "/provider-config/vercel-ai-gateway",
+      "destination": "/provider-config/other-30-plus-providers#vercel-ai-gateway"
+    },
+    {
+      "source": "/provider-config/vscode-language-model-api",
+      "destination": "/provider-config/other-30-plus-providers#vs-code-language-model-api"
+    },
+    {
+      "source": "/provider-config/xai-grok",
+      "destination": "/provider-config/other-30-plus-providers#xai-grok"
+    },
+    {
+      "source": "/tools-reference/browser-automation",
+      "destination": "/tools-reference/all-cline-tools"
+    },
+    {
+      "source": "/troubleshooting/task-history-recovery",
+      "destination": "/core-workflows/task-management"
+    },
+    {
+      "source": "/troubleshooting/terminal-quick-fixes",
+      "destination": "/core-workflows/using-commands"
+    }
+  ],
+  "search": {
+    "prompt": "Search Cline documentation..."
+  }
 }

--- a/docs/provider-config/futurmix.mdx
+++ b/docs/provider-config/futurmix.mdx
@@ -1,0 +1,40 @@
+---
+title: "FuturMix"
+description: "Learn how to configure and use FuturMix with Cline. Access AI models from multiple providers through a unified OpenAI-compatible gateway."
+---
+
+FuturMix is a unified AI gateway that provides access to AI models from multiple providers through a single OpenAI-compatible API.
+
+**Website:** [https://futurmix.ai/](https://futurmix.ai/)
+
+### Getting an API Key
+
+1.  **Sign Up/Sign In:** Go to [FuturMix](https://futurmix.ai/). Create an account or sign in.
+2.  **Navigate to API Keys:** Access the API key section in your dashboard.
+3.  **Create a Key:** Generate a new API key.
+4.  **Copy the Key:** Copy the API key immediately and store it securely.
+
+### Supported Models
+
+FuturMix provides access to models from multiple providers including:
+
+-   **Anthropic:** Claude Sonnet 4.5, Claude Opus 4.6, Claude Haiku 4.5
+-   **OpenAI:** GPT-5.4, GPT-5.4 Mini, GPT-image-2
+-   **Google:** Gemini 2.5 Pro, Gemini 2.5 Flash, Gemini 3 Flash Preview
+-   **And more:** Check the [FuturMix website](https://futurmix.ai) for the complete and up-to-date model list.
+
+### Configuration in Cline
+
+1.  **Open Cline Settings:** Click the settings icon in the Cline panel.
+2.  **Select Provider:** Choose "OpenAI Compatible" from the "API Provider" dropdown.
+3.  **Enter Base URL:** Set the base URL to `https://futurmix.ai/v1`
+4.  **Enter API Key:** Paste your FuturMix API key.
+5.  **Enter Model ID:** Specify the model you want to use (e.g., `claude-sonnet-4-5-20250929`, `gpt-5.4`, `gemini-2.5-flash`).
+6.  **Configure Settings:** Optionally set context window size and max output tokens based on your selected model.
+
+### Tips and Notes
+
+-   **OpenAI Compatible:** FuturMix uses an OpenAI-compatible API format, making it a drop-in replacement for OpenAI endpoints.
+-   **Multi-Provider Access:** Access models from Anthropic, OpenAI, Google, and more through a single API key.
+-   **Custom Model IDs:** You can specify any model ID available on the FuturMix platform.
+-   **Pricing:** Check the [FuturMix website](https://futurmix.ai) for current rates.


### PR DESCRIPTION
Adds FuturMix as a Cloud Provider option in Cline's documentation, following the same structure as other provider docs (OpenRouter, Together, AIhubmix).

## Changes
- **New file**: `docs/provider-config/futurmix.mdx` — FuturMix provider configuration page
- **Modified**: `docs/docs.json` — Added FuturMix to Cloud Providers navigation (alphabetically between DeepSeek and Google Gemini)

## What is FuturMix?
FuturMix provides an OpenAI-compatible API endpoint supporting 22+ models (Claude, GPT, Gemini, DeepSeek) through a single base URL. Users configure it like any OpenAI-compatible provider.

## Testing
- Verified docs.json structure matches current upstream format
- MDX page follows existing provider doc patterns
- No code changes, docs only

Supersedes #10406 (closed due to merge conflict from upstream restructuring).