### PR TITLE
fix(cli): satisfy config view hook dependencies

### DIFF
--- a/sdk/apps/cli/src/tui/views/config-view.tsx
+++ b/sdk/apps/cli/src/tui/views/config-view.tsx
@@ -261,13 +261,14 @@ export function ConfigPanelContent(props: ConfigPanelProps) {
 	const [navPos, setNavPos] = useState(0);
 
 	const displayName = resolveModelDisplayName(config);
+	const { loadConfigData } = props;
 
 	useEffect(() => {
 		if (
 			activeTab !== "tools" ||
 			pluginToolsLoaded ||
 			pluginToolsError ||
-			!props.loadConfigData
+			!loadConfigData
 		) {
 			return;
 		}
@@ -275,8 +276,7 @@ export function ConfigPanelContent(props: ConfigPanelProps) {
 		let cancelled = false;
 		setPluginToolsLoading(true);
 		setPluginToolsError(undefined);
-		props
-			.loadConfigData({ includePluginTools: true })
+		loadConfigData({ includePluginTools: true })
 			.then((nextData) => {
 				if (cancelled) {
 					return;
@@ -300,7 +300,7 @@ export function ConfigPanelContent(props: ConfigPanelProps) {
 		return () => {
 			cancelled = true;
 		};
-	}, [activeTab, pluginToolsError, pluginToolsLoaded, props.loadConfigData]);
+	}, [activeTab, pluginToolsError, pluginToolsLoaded, loadConfigData]);
 
 	const rows = useMemo(() => {
 		const r: ConfigRow[] = [];


### PR DESCRIPTION
## Summary

- Fixes the config view effect dependency shape that Biome reports in CI.
- Destructures `loadConfigData` before the effect and uses that stable capture in both the effect body and dependency list.

## Validation

- `../cline-10776/node_modules/.bin/biome lint sdk/apps/cli/src/tui/views/config-view.tsx --files-ignore-unknown=true --diagnostic-level=error`
- `../cline-10776/node_modules/.bin/biome format sdk/apps/cli/src/tui/views/config-view.tsx --files-ignore-unknown=true --diagnostic-level=error`
