### PR TITLE
fix(cli): avoid duplicate skill picker row keys

### DIFF
--- a/sdk/apps/cli/src/tui/components/searchable-list.test.ts
+++ b/sdk/apps/cli/src/tui/components/searchable-list.test.ts
@@ -73,4 +73,23 @@ describe("searchable list sections", () => {
 			label: "Popular",
 		});
 	});
+
+	it("keeps render keys unique when items share the same backing path", () => {
+		const duplicatedPath =
+			"/Users/jaygohil/.agents/skills/find-skills/SKILL.md";
+
+		const rows = buildSearchableListRows([
+			{ key: duplicatedPath, label: "find-skills", section: "Global Skills" },
+			{
+				key: duplicatedPath,
+				label: "find-skills",
+				section: "Workspace Skills",
+			},
+		]);
+
+		expect(new Set(rows.map((row) => row.key)).size).toBe(rows.length);
+		expect(
+			rows.filter((row) => row.kind === "item").map((row) => row.item.key),
+		).toEqual([duplicatedPath, duplicatedPath]);
+	});
 });

--- a/sdk/apps/cli/src/tui/components/searchable-list.tsx
+++ b/sdk/apps/cli/src/tui/components/searchable-list.tsx
@@ -89,7 +89,12 @@ export function buildSearchableListRows(
 				label: item.section,
 			});
 		}
-		rows.push({ kind: "item", key: item.key, item, itemIndex });
+		rows.push({
+			kind: "item",
+			key: `item-${itemIndex}-${item.key}`,
+			item,
+			itemIndex,
+		});
 		previousSection = item.section;
 	}
 	return rows;

--- a/sdk/apps/cli/src/tui/components/searchable-list.tsx
+++ b/sdk/apps/cli/src/tui/components/searchable-list.tsx
@@ -289,7 +289,7 @@ export function SearchableList(props: {
 						const isSel = row.itemIndex === safeSelected;
 						return (
 							<box
-								key={item.key}
+								key={row.key}
 								paddingX={1}
 								flexDirection="row"
 								gap={1}


### PR DESCRIPTION
## Summary
- keep searchable list render keys unique even when two rows share the same backing skill path
- preserve the original item key so selection and item metadata keep using the source path
- add regression coverage for duplicate skill paths from separate sections

Fixes #9784

## Tests
- bunx vitest run --config vitest.config.ts src/tui/components/searchable-list.test.ts
- bun biome lint apps/cli/src/tui/components/searchable-list.tsx apps/cli/src/tui/components/searchable-list.test.ts --files-ignore-unknown=true --diagnostic-level=error
- git diff --check