### PR TITLE
fix(cli): satisfy useExhaustiveDependencies in ConfigPanelContent

### DIFF
--- a/sdk/apps/cli/src/tui/views/config-view.tsx
+++ b/sdk/apps/cli/src/tui/views/config-view.tsx
@@ -236,7 +236,7 @@ function appendToolRows(
 }
 
 export function ConfigPanelContent(props: ConfigPanelProps) {
-	const { resolve, dismiss, dialogId, config } = props;
+	const { resolve, dismiss, dialogId, config, loadConfigData } = props;
 	const { height } = useTerminalDimensions();
 
 	const [mode, setMode] = useState(props.currentMode);
@@ -267,7 +267,7 @@ export function ConfigPanelContent(props: ConfigPanelProps) {
 			activeTab !== "tools" ||
 			pluginToolsLoaded ||
 			pluginToolsError ||
-			!props.loadConfigData
+			!loadConfigData
 		) {
 			return;
 		}
@@ -275,8 +275,7 @@ export function ConfigPanelContent(props: ConfigPanelProps) {
 		let cancelled = false;
 		setPluginToolsLoading(true);
 		setPluginToolsError(undefined);
-		props
-			.loadConfigData({ includePluginTools: true })
+		loadConfigData({ includePluginTools: true })
 			.then((nextData) => {
 				if (cancelled) {
 					return;
@@ -300,7 +299,7 @@ export function ConfigPanelContent(props: ConfigPanelProps) {
 		return () => {
 			cancelled = true;
 		};
-	}, [activeTab, pluginToolsError, pluginToolsLoaded, props.loadConfigData]);
+	}, [activeTab, pluginToolsError, pluginToolsLoaded, loadConfigData]);
 
 	const rows = useMemo(() => {
 		const r: ConfigRow[] = [];


### PR DESCRIPTION
## What

Fix two Biome `lint/correctness/useExhaustiveDependencies` errors in
`sdk/apps/cli/src/tui/views/config-view.tsx` introduced by #10819:

```
sdk/apps/cli/src/tui/views/config-view.tsx:265:2
  × This hook specifies a dependency more specific than its captures: props.loadConfigData
  × This hook does not specify its dependency on props.
```

`loadConfigData` is now destructured from `props` at the top of
`ConfigPanelContent` (next to `resolve`, `dismiss`, `dialogId`, `config`)
and used as a local binding inside the effect body and dep array.

## Why this matters

- `npm run lint` is currently red on `cline/cline` `main` (see the Quality
  Checks job on `5cd72e58…` / `b4d1b83b…`).
- The same lint runs inside the JetBrains-plugin integration workflow against
  the merged tree, so every downstream `cline/intellij-plugin` submodule-bump
  PR is failing on this — e.g. cline/intellij-plugin#935.

## Verification

- `npx biome lint --diagnostic-level=error sdk/apps/cli/src/tui/views/config-view.tsx` — exit 0.
- Full-repo `biome lint` — 2537 files, no errors.
- No behavior change: the effect still refires only when `loadConfigData`
  identity changes, matching the original intent.

Full rationale (why this shape rather than adding `props` to the deps) is in
the commit description.
