### PR TITLE
ci(cli): align release changelog formatting

### DIFF
--- a/.github/workflows/cli-publish.yml
+++ b/.github/workflows/cli-publish.yml
@@ -200,7 +200,8 @@ jobs:
           name: "CLI v${{ steps.version.outputs.version }}"
           body: |
             ${{ steps.changelog.outputs.content }}
-            ${{ steps.prev_tag.outputs.prev_tag != '' && format('Full Changelog: https://github.com/{0}/compare/{1}...{2}', github.repository, steps.prev_tag.outputs.prev_tag, steps.version.outputs.tag) || '' }}
+
+            ${{ steps.prev_tag.outputs.prev_tag != '' && format('**Full Changelog**: https://github.com/{0}/compare/{1}...{2}', github.repository, steps.prev_tag.outputs.prev_tag, steps.version.outputs.tag) || '' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
### Related Issue

Issue: #XXXX

### Description

The CLI publish workflow was already extracting the latest CLI changelog entry, but the GitHub release body did not format the full changelog link the same way as the VS Code extension release workflow. The CLI release body put the compare link directly after the changelog content and rendered the label as plain text.

This change updates the CLI GitHub release body so it follows the same spacing and markdown label style as the VS Code release workflow: changelog content first, a blank line, then the `**Full Changelog**:` compare link. The CLI workflow still keeps its existing guard so the compare link is omitted when there is no previous `cli-v*` tag.

The main gotcha was keeping the CLI-specific previous-tag behavior intact while matching the VS Code release body markup. I also rebased the branch onto the current `origin/main` before opening this PR because the task worktree started from a local main commit that was missing one upstream commit, which initially made the comparison include unrelated SDK files.

### Test Procedure

Parsed `.github/workflows/cli-publish.yml` with the repository's installed `yaml` package:

```sh
node -e "const fs = require('fs'); const YAML = require('yaml'); YAML.parse(fs.readFileSync('.github/workflows/cli-publish.yml', 'utf8')); console.log('yaml ok')"
```

The command printed `yaml ok`.

I also checked the final branch diff against `origin/main` and confirmed it only changes `.github/workflows/cli-publish.yml`.

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [x] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Not applicable. This is a GitHub Actions workflow formatting change.

### Additional Notes

No full test suite was run because this only changes the markdown body passed to `softprops/action-gh-release`.
