### PR TITLE
Soften rejected tool call display in CLI TUI

### DIFF
--- a/sdk/apps/cli/src/tui/components/chat-entry.tsx
+++ b/sdk/apps/cli/src/tui/components/chat-entry.tsx
@@ -11,6 +11,7 @@ import {
 } from "../palette";
 import type { ChatEntry } from "../types";
 import { getSyntaxStyle } from "../utils/syntax-style";
+import { isWarningToolError } from "../utils/tool-errors";
 import {
 	parseApplyPatchInput,
 	parseAskQuestionInput,
@@ -212,6 +213,7 @@ function ToolCallView(props: {
 		defaultFg,
 	} = props;
 	const failed = result?.error != null;
+	const warningFailure = isWarningToolError(result?.error);
 	const params = formatToolParams(toolName, props.rawInput, inputSummary);
 
 	return (
@@ -220,6 +222,8 @@ function ToolCallView(props: {
 				<box width={2}>
 					{streaming ? (
 						<spinner name="dots" color="gray" />
+					) : warningFailure ? (
+						<text fg="yellow">!</text>
 					) : failed ? (
 						<text fg="red">x</text>
 					) : (

--- a/sdk/apps/cli/src/tui/components/tool-output.tsx
+++ b/sdk/apps/cli/src/tui/components/tool-output.tsx
@@ -3,6 +3,7 @@ import { useTerminalTheme } from "../hooks/use-terminal-background";
 import { diffPalettes, palette, type TerminalTheme } from "../palette";
 import { makeUnifiedDiff } from "../utils/diff";
 import { getSyntaxStyle } from "../utils/syntax-style";
+import { getToolErrorPresentation } from "../utils/tool-errors";
 import {
 	detectLanguage,
 	extractFullOutputText,
@@ -292,13 +293,29 @@ function GenericOutput(props: { outputSummary: string; fullText?: string }) {
 export function ToolOutput(props: ToolOutputProps) {
 	const { toolName, outputSummary, rawOutput, rawInput, error } = props;
 	const terminalTheme = useTerminalTheme();
+	const [errorExpanded, setErrorExpanded] = useState(false);
 
 	if (error) {
+		const presentation = getToolErrorPresentation(error);
+		const isWarning = presentation.severity === "warning";
+		const showDetail =
+			errorExpanded && presentation.detail !== presentation.summary.trim();
 		return (
-			<box paddingLeft={2}>
-				<text fg="red" selectable>
-					{"  "} Error: {error}
+			<box
+				flexDirection="column"
+				paddingLeft={2}
+				onMouseDown={() => setErrorExpanded(!errorExpanded)}
+			>
+				<text fg={isWarning ? "yellow" : "red"} selectable>
+					{"  "} {isWarning ? "!" : "Error:"} {presentation.summary}
 				</text>
+				{showDetail && (
+					<box paddingLeft={3}>
+						<text fg="gray" selectable>
+							{presentation.detail}
+						</text>
+					</box>
+				)}
 			</box>
 		);
 	}

--- a/sdk/apps/cli/src/tui/utils/tool-errors.test.ts
+++ b/sdk/apps/cli/src/tui/utils/tool-errors.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+import {
+	getToolErrorPresentation,
+	isWarningToolError,
+	unwrapToolError,
+} from "./tool-errors";
+
+describe("tool error presentation", () => {
+	it("unwraps JSON-encoded tool errors", () => {
+		const raw = JSON.stringify({
+			error: "Tool call run_commands was rejected before execution: nope",
+		});
+
+		expect(unwrapToolError(raw)).toBe(
+			"Tool call run_commands was rejected before execution: nope",
+		);
+	});
+
+	it("summarizes invalid tool input as a warning", () => {
+		const raw = JSON.stringify({
+			error:
+				'Tool call run_commands was rejected before execution: Invalid input for tool run_commands: Type validation failed: Value: {"commands":[{"command":"cat file"}]}.\nError message: []',
+		});
+
+		expect(getToolErrorPresentation(raw)).toMatchObject({
+			severity: "warning",
+			summary: "Invalid run_commands input; tool call skipped.",
+		});
+		expect(isWarningToolError(raw)).toBe(true);
+	});
+
+	it("summarizes generic pre-execution rejections as warnings", () => {
+		expect(
+			getToolErrorPresentation(
+				"Tool call editor was rejected before execution: approval request failed",
+			),
+		).toMatchObject({
+			severity: "warning",
+			summary: "editor call was skipped before execution.",
+		});
+	});
+
+	it("keeps non-rejection failures as errors", () => {
+		const presentation = getToolErrorPresentation("command failed with exit 1");
+
+		expect(presentation).toEqual({
+			severity: "error",
+			summary: "command failed with exit 1",
+			detail: "command failed with exit 1",
+		});
+	});
+
+	it("summarizes JSON-wrapped hard errors without dumping stacks", () => {
+		const raw = JSON.stringify({
+			error:
+				"Error: command failed with exit 1\n    at runTool (/tmp/tool.ts:10:1)\n    at async main (/tmp/main.ts:5:1)",
+		});
+
+		expect(getToolErrorPresentation(raw)).toEqual({
+			severity: "error",
+			summary: "command failed with exit 1",
+			detail:
+				"Error: command failed with exit 1\n    at runTool (/tmp/tool.ts:10:1)\n    at async main (/tmp/main.ts:5:1)",
+		});
+	});
+
+	it("collapses long one-line hard errors", () => {
+		const detail = `Validation failed: ${"x".repeat(180)}`;
+		const presentation = getToolErrorPresentation(detail);
+
+		expect(presentation.severity).toBe("error");
+		expect(presentation.detail).toBe(detail);
+		expect(presentation.summary.length).toBeLessThanOrEqual(140);
+		expect(presentation.summary.endsWith("...")).toBe(true);
+	});
+
+	it("uses a generic summary when no string error can be extracted", () => {
+		const presentation = getToolErrorPresentation(
+			JSON.stringify({ code: "E_TOOL", data: { value: 1 } }),
+		);
+
+		expect(presentation).toEqual({
+			severity: "error",
+			summary: "Tool returned a structured error.",
+			detail: JSON.stringify({ code: "E_TOOL", data: { value: 1 } }),
+		});
+	});
+});

--- a/sdk/apps/cli/src/tui/utils/tool-errors.ts
+++ b/sdk/apps/cli/src/tui/utils/tool-errors.ts
@@ -1,0 +1,118 @@
+export interface ToolErrorPresentation {
+	severity: "warning" | "error";
+	summary: string;
+	detail: string;
+}
+
+const MAX_ERROR_SUMMARY_LENGTH = 140;
+
+function extractStringError(value: unknown): string | undefined {
+	if (typeof value === "string") {
+		return value.trim() || undefined;
+	}
+	if (!value || typeof value !== "object" || Array.isArray(value)) {
+		return undefined;
+	}
+	const record = value as Record<string, unknown>;
+	return (
+		extractStringError(record.error) ??
+		extractStringError(record.message) ??
+		undefined
+	);
+}
+
+export function unwrapToolError(error: string): string {
+	let current = error.trim();
+	for (let i = 0; i < 3; i += 1) {
+		if (!current.startsWith("{") && !current.startsWith("[")) break;
+		try {
+			const parsed = JSON.parse(current) as unknown;
+			const next = extractStringError(parsed);
+			if (!next || next === current) break;
+			current = next.trim();
+		} catch {
+			break;
+		}
+	}
+	return current;
+}
+
+function summarizeInvalidInput(message: string): string | undefined {
+	const rejected = message.match(
+		/^Tool call\s+([A-Za-z0-9_-]+)\s+was rejected before execution:\s+Invalid input for tool\s+([A-Za-z0-9_-]+):\s*([^.\n]+)(?:\.|\n|$)/,
+	);
+	if (rejected) {
+		return `Invalid ${rejected[2]} input; tool call skipped.`;
+	}
+
+	const invalid = message.match(
+		/^Invalid input for tool\s+([A-Za-z0-9_-]+):\s*([^.\n]+)(?:\.|\n|$)/,
+	);
+	if (invalid) {
+		return `Invalid ${invalid[1]} input; tool call skipped.`;
+	}
+
+	return undefined;
+}
+
+function truncateSummary(text: string): string {
+	const trimmed = text.trim();
+	if (trimmed.length <= MAX_ERROR_SUMMARY_LENGTH) {
+		return trimmed;
+	}
+	return `${trimmed.slice(0, MAX_ERROR_SUMMARY_LENGTH - 3).trimEnd()}...`;
+}
+
+function summarizeErrorDetail(detail: string): string {
+	const trimmed = detail.trim();
+	if (!trimmed) {
+		return "Tool failed.";
+	}
+
+	if (trimmed.startsWith("{") || trimmed.startsWith("[")) {
+		return "Tool returned a structured error.";
+	}
+
+	const firstLine =
+		trimmed
+			.replace(/\r\n/g, "\n")
+			.split("\n")
+			.map((line) => line.trim())
+			.find(Boolean) ?? "Tool failed.";
+	const withoutGenericPrefix = firstLine.replace(/^Error:\s+/i, "");
+
+	return truncateSummary(withoutGenericPrefix.replace(/\s+/g, " "));
+}
+
+export function getToolErrorPresentation(error: string): ToolErrorPresentation {
+	const detail = unwrapToolError(error);
+	const inputSummary = summarizeInvalidInput(detail);
+	if (inputSummary) {
+		return {
+			severity: "warning",
+			summary: inputSummary,
+			detail,
+		};
+	}
+
+	const rejected = detail.match(
+		/^Tool call\s+([A-Za-z0-9_-]+)\s+was rejected before execution:/,
+	);
+	if (rejected) {
+		return {
+			severity: "warning",
+			summary: `${rejected[1]} call was skipped before execution.`,
+			detail,
+		};
+	}
+
+	return {
+		severity: "error",
+		summary: summarizeErrorDetail(detail),
+		detail,
+	};
+}
+
+export function isWarningToolError(error: string | undefined): boolean {
+	return error ? getToolErrorPresentation(error).severity === "warning" : false;
+}


### PR DESCRIPTION
### Related Issue

**Issue:** #XXXX

### Description

Makes rejected tool-call input failures less visually alarming in the CLI TUI. Provider/runtime validation errors such as DeepSeek emitting malformed tool arguments are now shown as a compact yellow warning instead of a red failure block, while preserving the full diagnostic detail behind expansion.

This keeps actual tool execution failures red, but treats pre-execution input rejection as a recoverable warning state.

### Test Procedure

Reproduced the DeepSeek V4 Pro rejected-tool-call path locally with the SDK CLI and root `.env` loaded. The model emitted malformed `run_commands` input, and the runtime rejected it before execution.

Verified the formatting helper and CLI package after the change:

- `bunx vitest run src/tui/utils/tool-errors.test.ts --config vitest.config.ts`
- `bun -F @cline/cli typecheck`
- pre-commit hook ran `bun run types` and Biome for staged files

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [x] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

N/A. This changes terminal text rendering for rejected tool-call rows; the focused tests cover the DeepSeek-style JSON-wrapped error formatting.

### Additional Notes

No linked issue was provided; this is a small CLI TUI bug/cosmetic fix.
